### PR TITLE
feat(client): claude-code-tui handler core (tmux + transcript tail)

### DIFF
--- a/packages/client/src/__tests__/agent-bootstrap.test.ts
+++ b/packages/client/src/__tests__/agent-bootstrap.test.ts
@@ -1,0 +1,116 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// In-memory pin state shared with the bootstrap.js mock. Hoisted so it's
+// available inside the (hoisted) vi.mock factory.
+const state = vi.hoisted(() => ({ cachedTreeHead: null as string | null, cachedCli: null as string | null }));
+
+vi.mock("../runtime/bootstrap.js", () => ({
+  bootstrapWorkspace: vi.fn(),
+  installCoreSkills: vi.fn(),
+  installFirstTreeIntegration: vi.fn(),
+  deepEqualIdentity: vi.fn(() => false),
+  readContextTreeHead: vi.fn(() => "head1"),
+  readCachedContextTreeHead: vi.fn(() => state.cachedTreeHead),
+  resolveBundledCliVersion: vi.fn(() => "1.0.0"),
+  readCachedBundledCliVersion: vi.fn(() => state.cachedCli),
+  writeContextTreeHead: vi.fn((_w: string, h: string | null) => {
+    state.cachedTreeHead = h;
+  }),
+  writeBundledCliVersion: vi.fn((_w: string, v: string | null) => {
+    state.cachedCli = v;
+  }),
+}));
+
+import { ensureAgentBootstrap } from "../runtime/agent-bootstrap.js";
+import { installFirstTreeIntegration } from "../runtime/bootstrap.js";
+import type { SessionContext } from "../runtime/handler.js";
+import { INIT_COMPLETE_SENTINEL_REL } from "../runtime/workspace.js";
+
+function fakeSessionCtx(): SessionContext {
+  return {
+    agent: {
+      agentId: "agent-1",
+      inboxId: "inbox-1",
+      displayName: "Agent One",
+      type: "agent",
+      visibility: "organization",
+      delegateMention: null,
+      metadata: {},
+    },
+    sdk: { serverUrl: "https://hub.test" },
+    log: () => {},
+  } as unknown as SessionContext;
+}
+
+/**
+ * Regression for the integration-failure retry gate (PR #712 review round 2):
+ * a tree-bound agent whose first `installFirstTreeIntegration` fails must NOT
+ * be frozen behind the init-complete sentinel — the next ensureAgentBootstrap
+ * has to retry, and only stop retrying once integration succeeds (CLI pin set).
+ */
+describe("ensureAgentBootstrap — integration retry gate", () => {
+  let workspace: string;
+
+  beforeEach(() => {
+    workspace = mkdtempSync(join(tmpdir(), "ft-agent-bootstrap-"));
+    // Simulate "already bootstrapped once" — the sentinel is present, which is
+    // exactly the state that previously let a failed integration coast on the
+    // fast path forever.
+    const sentinel = join(workspace, INIT_COMPLETE_SENTINEL_REL);
+    mkdirSync(dirname(sentinel), { recursive: true });
+    mkdirSync(join(workspace, ".agent"), { recursive: true });
+    writeFileSync(sentinel, "1", "utf-8");
+
+    state.cachedTreeHead = null;
+    state.cachedCli = null;
+    vi.mocked(installFirstTreeIntegration).mockReset();
+  });
+
+  afterEach(() => {
+    rmSync(workspace, { recursive: true, force: true });
+    vi.clearAllMocks();
+  });
+
+  it("retries integration after a first failure, then settles once it succeeds", () => {
+    // First integration attempt fails, second succeeds.
+    vi.mocked(installFirstTreeIntegration).mockReturnValueOnce(false).mockReturnValueOnce(true);
+
+    const params = {
+      workspace,
+      sessionCtx: fakeSessionCtx(),
+      contextTreePath: "/tree",
+      contextTreeRepoUrl: null,
+      agentName: "agent-1",
+    };
+
+    // Call 1: integration fails → CLI version NOT pinned.
+    ensureAgentBootstrap(params);
+    expect(installFirstTreeIntegration).toHaveBeenCalledTimes(1);
+    expect(state.cachedCli).toBeNull();
+
+    // Call 2: CLI pin still missing → slow path retries integration (succeeds).
+    ensureAgentBootstrap(params);
+    expect(installFirstTreeIntegration).toHaveBeenCalledTimes(2);
+    expect(state.cachedCli).toBe("1.0.0");
+
+    // Call 3: integration succeeded (CLI pinned), no drift → fast path, no retry.
+    ensureAgentBootstrap(params);
+    expect(installFirstTreeIntegration).toHaveBeenCalledTimes(2);
+  });
+
+  it("non-tree agents take the fast path on the sentinel (no integration gate)", () => {
+    const params = {
+      workspace,
+      sessionCtx: fakeSessionCtx(),
+      contextTreePath: null,
+      contextTreeRepoUrl: null,
+      agentName: "agent-1",
+    };
+    ensureAgentBootstrap(params);
+    // No Context Tree → installFirstTreeIntegration is never called regardless.
+    expect(installFirstTreeIntegration).not.toHaveBeenCalled();
+  });
+});

--- a/packages/client/src/__tests__/builtin-handlers.test.ts
+++ b/packages/client/src/__tests__/builtin-handlers.test.ts
@@ -28,6 +28,27 @@ describe("Built-in Handlers", () => {
     expect(typeof handler.shutdown).toBe("function");
   });
 
+  it("registers claude-code-tui handler", () => {
+    registerBuiltinHandlers();
+
+    const factory = getHandlerFactory("claude-code-tui");
+    expect(factory).toBeDefined();
+    expect(typeof factory).toBe("function");
+  });
+
+  it("claude-code-tui factory returns a valid session-oriented handler", () => {
+    registerBuiltinHandlers();
+
+    const factory = getHandlerFactory("claude-code-tui");
+    const handler = factory({ workspaceRoot: "/tmp/test" });
+    expect(handler).toBeDefined();
+    expect(typeof handler.start).toBe("function");
+    expect(typeof handler.resume).toBe("function");
+    expect(typeof handler.inject).toBe("function");
+    expect(typeof handler.suspend).toBe("function");
+    expect(typeof handler.shutdown).toBe("function");
+  });
+
   it("registers codex handler", () => {
     registerBuiltinHandlers();
 

--- a/packages/client/src/__tests__/tui-ask-user-degrader.test.ts
+++ b/packages/client/src/__tests__/tui-ask-user-degrader.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { formatQuestionsAsText } from "../handlers/claude-code-tui/ask-user-degrader.js";
+
+describe("formatQuestionsAsText", () => {
+  it("renders a single question with options as readable markdown", () => {
+    const text = formatQuestionsAsText({
+      questions: [
+        {
+          question: "Pick a fruit",
+          header: "Fruit",
+          multiSelect: false,
+          options: [
+            { label: "Apple", description: "Red and round" },
+            { label: "Banana" },
+            { label: "Cherry", description: "Small and tart" },
+          ],
+        },
+      ],
+    });
+
+    expect(text).toContain("Claude has a question for you");
+    expect(text).toContain("**Pick a fruit**");
+    expect(text).toContain("_Fruit_");
+    expect(text).toContain("**Apple** — Red and round");
+    expect(text).toContain("**Banana**"); // no description -> no em-dash trailer
+    expect(text).not.toContain("**Banana** — ");
+    expect(text).toContain("**Cherry** — Small and tart");
+    expect(text).toContain("_Options:_");
+    expect(text).toContain("Reply with your answer in plain text.");
+  });
+
+  it("numbers each question when multiple are present", () => {
+    const text = formatQuestionsAsText({
+      questions: [
+        { question: "First?", options: [{ label: "Yes" }] },
+        { question: "Second?", options: [{ label: "No" }] },
+      ],
+    });
+
+    expect(text).toMatch(/1\. \*\*First\?\*\*/);
+    expect(text).toMatch(/2\. \*\*Second\?\*\*/);
+  });
+
+  it("annotates multi-select questions in the options heading", () => {
+    const text = formatQuestionsAsText({
+      questions: [
+        {
+          question: "Pick all that apply",
+          multiSelect: true,
+          options: [{ label: "A" }, { label: "B" }],
+        },
+      ],
+    });
+
+    expect(text).toContain("_Options (multi-select):_");
+  });
+
+  it("falls back gracefully when input is empty or malformed", () => {
+    expect(formatQuestionsAsText(undefined)).toContain("payload was empty");
+    expect(formatQuestionsAsText({})).toContain("payload was empty");
+    expect(formatQuestionsAsText({ questions: [] })).toContain("payload was empty");
+    expect(formatQuestionsAsText({ questions: "not an array" })).toContain("payload was empty");
+  });
+
+  it("tolerates missing question text and option labels", () => {
+    const text = formatQuestionsAsText({
+      questions: [
+        {
+          // no `question` field
+          options: [
+            {
+              /* no label */
+            },
+            { label: "Real" },
+          ],
+        },
+      ],
+    });
+    expect(text).toContain("(no question text)");
+    expect(text).toContain("(option)");
+    expect(text).toContain("**Real**");
+  });
+});

--- a/packages/client/src/__tests__/tui-tmux-session.test.ts
+++ b/packages/client/src/__tests__/tui-tmux-session.test.ts
@@ -29,15 +29,26 @@ describe("deriveSessionName", () => {
     expect(a).not.toBe(b);
   });
 
-  it("strips disallowed tmux characters (. and :)", () => {
+  it("produces a tmux-safe name (hex digest, no . or :) even from dirty ids", () => {
     const name = deriveSessionName(CID, "agent.with.dots", "chat:with:colons");
     expect(name).not.toMatch(/[.:]/);
   });
 
-  it("caps the agent and chat parts at 8 chars", () => {
+  it("does NOT alias uuidv7 agents that share a timestamp prefix", () => {
+    // uuidv7 leading chars are a ms timestamp — agents created in the same
+    // window share the first 8+ chars. A prefix-truncating name would collide
+    // (and startClaude would kill the peer's live session); the hash must not.
+    const a = "019250a1-0000-7000-8000-000000000001";
+    const b = "019250a1-0000-7000-8000-000000000002";
+    expect(a.slice(0, 8)).toBe(b.slice(0, 8)); // guards the premise
+    expect(deriveSessionName(CID, a, "chat-1")).not.toBe(deriveSessionName(CID, b, "chat-1"));
+  });
+
+  it("keeps the name short and within the owner prefix", () => {
     const name = deriveSessionName(CID, "a".repeat(40), "b".repeat(40));
-    // "ftth-" (5) + clientTag (8) + "-" + agent8 + "-" + chat8 = 31
-    expect(name.length).toBe(31);
+    // "ftth-" (5) + clientTag (8) + "-" (1) + 12-hex digest = 26
+    expect(name.length).toBe(26);
+    expect(name.startsWith(ownedSessionPrefix(CID))).toBe(true);
   });
 });
 

--- a/packages/client/src/__tests__/tui-tmux-session.test.ts
+++ b/packages/client/src/__tests__/tui-tmux-session.test.ts
@@ -1,33 +1,56 @@
 import { describe, expect, it } from "vitest";
-import { deriveSessionName } from "../handlers/claude-code-tui/tmux-session.js";
+import { deriveSessionName, ownedSessionPrefix } from "../handlers/claude-code-tui/tmux-session.js";
+
+const CID = "client_abcd1234";
 
 describe("deriveSessionName", () => {
-  it("starts with the ftth- prefix so the orphan sweep can match", () => {
-    const name = deriveSessionName("agent-abc", "chat-xyz");
+  it("starts with the client-scoped ftth- prefix so the orphan sweep can match", () => {
+    const name = deriveSessionName(CID, "agent-abc", "chat-xyz");
     expect(name.startsWith("ftth-")).toBe(true);
+    expect(name.startsWith(ownedSessionPrefix(CID))).toBe(true);
   });
 
-  it("is deterministic for the same (agentId, chatId)", () => {
-    expect(deriveSessionName("agent-1", "chat-1")).toBe(deriveSessionName("agent-1", "chat-1"));
+  it("is deterministic for the same (clientId, agentId, chatId)", () => {
+    expect(deriveSessionName(CID, "agent-1", "chat-1")).toBe(deriveSessionName(CID, "agent-1", "chat-1"));
   });
 
   it("differs across different (agentId, chatId) pairs", () => {
-    const a = deriveSessionName("agent-1", "chat-1");
-    const b = deriveSessionName("agent-1", "chat-2");
-    const c = deriveSessionName("agent-2", "chat-1");
+    const a = deriveSessionName(CID, "agent-1", "chat-1");
+    const b = deriveSessionName(CID, "agent-1", "chat-2");
+    const c = deriveSessionName(CID, "agent-2", "chat-1");
     expect(a).not.toBe(b);
     expect(a).not.toBe(c);
     expect(b).not.toBe(c);
   });
 
+  it("differs across clients so one client's sweep can't match another's sessions", () => {
+    const a = deriveSessionName("client_aaaa1111", "agent-1", "chat-1");
+    const b = deriveSessionName("client_bbbb2222", "agent-1", "chat-1");
+    expect(a).not.toBe(b);
+  });
+
   it("strips disallowed tmux characters (. and :)", () => {
-    const name = deriveSessionName("agent.with.dots", "chat:with:colons");
+    const name = deriveSessionName(CID, "agent.with.dots", "chat:with:colons");
     expect(name).not.toMatch(/[.:]/);
   });
 
-  it("caps each part at 8 chars so the full name stays short", () => {
-    const name = deriveSessionName("a".repeat(40), "b".repeat(40));
-    // prefix "ftth-" + 8 + "-" + 8 = 22 chars
-    expect(name.length).toBe(22);
+  it("caps the agent and chat parts at 8 chars", () => {
+    const name = deriveSessionName(CID, "a".repeat(40), "b".repeat(40));
+    // "ftth-" (5) + clientTag (8) + "-" + agent8 + "-" + chat8 = 31
+    expect(name.length).toBe(31);
+  });
+});
+
+describe("ownedSessionPrefix", () => {
+  it("is the per-client scope the orphan sweep filters on (trailing client-id hex)", () => {
+    expect(ownedSessionPrefix(CID)).toBe("ftth-abcd1234-");
+  });
+
+  it("differs per client so a sweep only ever matches its own sessions", () => {
+    expect(ownedSessionPrefix("client_aaaa1111")).not.toBe(ownedSessionPrefix("client_bbbb2222"));
+  });
+
+  it("falls back to a placeholder tag when clientId is empty", () => {
+    expect(ownedSessionPrefix("")).toBe("ftth-nocid-");
   });
 });

--- a/packages/client/src/__tests__/tui-tmux-session.test.ts
+++ b/packages/client/src/__tests__/tui-tmux-session.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { deriveSessionName } from "../handlers/claude-code-tui/tmux-session.js";
+
+describe("deriveSessionName", () => {
+  it("starts with the ftth- prefix so the orphan sweep can match", () => {
+    const name = deriveSessionName("agent-abc", "chat-xyz");
+    expect(name.startsWith("ftth-")).toBe(true);
+  });
+
+  it("is deterministic for the same (agentId, chatId)", () => {
+    expect(deriveSessionName("agent-1", "chat-1")).toBe(deriveSessionName("agent-1", "chat-1"));
+  });
+
+  it("differs across different (agentId, chatId) pairs", () => {
+    const a = deriveSessionName("agent-1", "chat-1");
+    const b = deriveSessionName("agent-1", "chat-2");
+    const c = deriveSessionName("agent-2", "chat-1");
+    expect(a).not.toBe(b);
+    expect(a).not.toBe(c);
+    expect(b).not.toBe(c);
+  });
+
+  it("strips disallowed tmux characters (. and :)", () => {
+    const name = deriveSessionName("agent.with.dots", "chat:with:colons");
+    expect(name).not.toMatch(/[.:]/);
+  });
+
+  it("caps each part at 8 chars so the full name stays short", () => {
+    const name = deriveSessionName("a".repeat(40), "b".repeat(40));
+    // prefix "ftth-" + 8 + "-" + 8 = 22 chars
+    expect(name.length).toBe(22);
+  });
+});

--- a/packages/client/src/__tests__/tui-transcript-tail.test.ts
+++ b/packages/client/src/__tests__/tui-transcript-tail.test.ts
@@ -1,0 +1,138 @@
+import { appendFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  TranscriptTailer,
+  transcriptEntryToEvents,
+  transcriptPathFor,
+} from "../handlers/claude-code-tui/transcript-tail.js";
+
+describe("transcriptPathFor", () => {
+  it("replaces forward-slashes and dots with dashes and prefixes with dash", () => {
+    const path = transcriptPathFor("/Users/alice/work.cd", "abc-123");
+    expect(path.endsWith("/.claude/projects/-Users-alice-work-cd/abc-123.jsonl")).toBe(true);
+  });
+
+  it("normalises to an absolute path before encoding", () => {
+    const abs = transcriptPathFor("./relative", "id");
+    // resolve() applied: starts from process.cwd() so the encoding includes more dashes
+    expect(abs).toMatch(/\/\.claude\/projects\/-.+\/id\.jsonl$/);
+  });
+});
+
+describe("transcriptEntryToEvents", () => {
+  it("maps user string content to user_text", () => {
+    const events = transcriptEntryToEvents({ type: "user", message: { content: "hi" }, timestamp: "t0" });
+    expect(events).toEqual([{ kind: "user_text", text: "hi", ts: "t0" }]);
+  });
+
+  it("maps user array content with tool_result block", () => {
+    const events = transcriptEntryToEvents({
+      type: "user",
+      message: {
+        content: [{ type: "tool_result", tool_use_id: "u1", is_error: false, content: "done" }],
+      },
+      timestamp: "t1",
+    });
+    expect(events).toEqual([{ kind: "tool_result", toolUseId: "u1", isError: false, content: "done", ts: "t1" }]);
+  });
+
+  it("maps assistant content with mixed block types", () => {
+    const events = transcriptEntryToEvents({
+      type: "assistant",
+      message: {
+        content: [
+          { type: "text", text: "Reasoning..." },
+          { type: "tool_use", id: "u2", name: "Bash", input: { command: "ls" } },
+          { type: "thinking", thinking: "internal monologue" },
+        ],
+      },
+      timestamp: "t2",
+    });
+    expect(events).toEqual([
+      { kind: "assistant_text", text: "Reasoning...", ts: "t2" },
+      { kind: "tool_use", toolUseId: "u2", name: "Bash", input: { command: "ls" }, ts: "t2" },
+      { kind: "thinking", text: "internal monologue", ts: "t2" },
+    ]);
+  });
+
+  it("ignores entries the runtime doesn't care about", () => {
+    expect(transcriptEntryToEvents({ type: "permission-mode" })).toEqual([]);
+    expect(transcriptEntryToEvents({ type: "file-history-snapshot" })).toEqual([]);
+    expect(transcriptEntryToEvents({ type: "system" })).toEqual([]);
+    expect(transcriptEntryToEvents({})).toEqual([]);
+  });
+});
+
+describe("TranscriptTailer", () => {
+  let testDir: string;
+  let filePath: string;
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), "tui-tail-"));
+    filePath = join(testDir, "session.jsonl");
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it("returns empty when the file does not exist yet", () => {
+    const tailer = new TranscriptTailer(filePath);
+    expect(tailer.drainEntries()).toEqual([]);
+  });
+
+  it("returns only new entries on each drain", () => {
+    mkdirSync(testDir, { recursive: true });
+    writeFileSync(filePath, "");
+    const tailer = new TranscriptTailer(filePath);
+
+    appendFileSync(filePath, `${JSON.stringify({ type: "user", message: { content: "first" } })}\n`);
+    const first = tailer.drainEntries();
+    expect(first).toHaveLength(1);
+    expect(first[0]).toMatchObject({ type: "user" });
+
+    appendFileSync(filePath, `${JSON.stringify({ type: "assistant", message: { content: [] } })}\n`);
+    const second = tailer.drainEntries();
+    expect(second).toHaveLength(1);
+    expect(second[0]).toMatchObject({ type: "assistant" });
+
+    expect(tailer.drainEntries()).toEqual([]);
+  });
+
+  it("buffers partial lines across reads", () => {
+    writeFileSync(filePath, "");
+    const tailer = new TranscriptTailer(filePath);
+
+    const piece1 = '{"type":"user","message":{"content":"half';
+    const piece2 = ' message"}}\n';
+    appendFileSync(filePath, piece1);
+    expect(tailer.drainEntries()).toEqual([]);
+
+    appendFileSync(filePath, piece2);
+    const entries = tailer.drainEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ type: "user", message: { content: "half message" } });
+  });
+
+  it("tolerates malformed lines without failing the drain", () => {
+    writeFileSync(filePath, "");
+    const tailer = new TranscriptTailer(filePath);
+
+    appendFileSync(filePath, "this is not json\n");
+    appendFileSync(filePath, `${JSON.stringify({ type: "user", message: { content: "ok" } })}\n`);
+
+    const entries = tailer.drainEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ type: "user" });
+  });
+
+  it("drainEvents is the mapped convenience over drainEntries", () => {
+    writeFileSync(filePath, "");
+    const tailer = new TranscriptTailer(filePath);
+    appendFileSync(filePath, `${JSON.stringify({ type: "user", message: { content: "x" } })}\n`);
+    const events = tailer.drainEvents();
+    expect(events).toEqual([{ kind: "user_text", text: "x", ts: undefined }]);
+  });
+});

--- a/packages/client/src/__tests__/tui-turn-disposition.test.ts
+++ b/packages/client/src/__tests__/tui-turn-disposition.test.ts
@@ -4,29 +4,39 @@ import { resolveTurnDisposition } from "../handlers/claude-code-tui/turn-disposi
 const CLEAN = { aborted: false, timedOut: false, turnFailed: false, forwardFailed: false };
 
 describe("resolveTurnDisposition", () => {
-  it("a clean turn reports success, acks, and goes idle", () => {
-    expect(resolveTurnDisposition(CLEAN)).toEqual({ status: "success", ack: true, runtimeState: "idle" });
+  it("a clean turn reports success, acks, forwards, and goes idle", () => {
+    expect(resolveTurnDisposition(CLEAN)).toEqual({
+      status: "success",
+      ack: true,
+      forward: true,
+      runtimeState: "idle",
+    });
   });
 
   /**
-   * Regression for PR #712 review round 3: a turn that hit TURN_TIMEOUT_MS was
-   * being reported as `success` and acked, silently consuming the user's
-   * message with no replay path. A timeout must report error, must NOT ack
-   * (so the inbox entries are redelivered for a real retry), and must surface
-   * an error runtime state.
+   * Regression for PR #712 review round 3 + 4: a turn that hit TURN_TIMEOUT_MS
+   * was reported as `success` and acked, silently consuming the user's message
+   * with no replay path (round 3). Round 4: even after that fix, a timed-out
+   * turn that had drained partial finalText still forwarded it to chat before
+   * the no-ack decision — so the chat got a partial message while the entry
+   * stayed un-acked and re-ran on reconnect, double-posting. A timeout must
+   * report error, must NOT ack AND must NOT forward (so the redelivered retry
+   * is the single source of output), and must surface an error runtime state.
    */
-  it("a timed-out turn reports error, does NOT ack, and surfaces error state", () => {
+  it("a timed-out turn reports error, does NOT ack, does NOT forward, and surfaces error state", () => {
     expect(resolveTurnDisposition({ ...CLEAN, timedOut: true })).toEqual({
       status: "error",
       ack: false,
+      forward: false,
       runtimeState: "error",
     });
   });
 
-  it("a body failure reports error, acks (clean close, avoid storm), and surfaces error state", () => {
+  it("a body failure reports error, acks + forwards (clean close, avoid storm), and surfaces error state", () => {
     expect(resolveTurnDisposition({ ...CLEAN, turnFailed: true })).toEqual({
       status: "error",
       ack: true,
+      forward: true,
       runtimeState: "error",
     });
   });
@@ -35,23 +45,39 @@ describe("resolveTurnDisposition", () => {
     expect(resolveTurnDisposition({ ...CLEAN, forwardFailed: true })).toEqual({
       status: "error",
       ack: true,
+      forward: true,
       runtimeState: "idle",
     });
   });
 
-  it("an aborted (suspended) turn does NOT ack so it re-runs on resume, and is not flagged failed", () => {
+  it("an aborted (suspended) turn does NOT ack or forward so it re-runs cleanly on resume", () => {
     expect(resolveTurnDisposition({ ...CLEAN, aborted: true })).toEqual({
       status: "success",
       ack: false,
+      forward: false,
       runtimeState: "idle",
     });
   });
 
-  it("timeout dominates: a timed-out turn that also failed to forward still withholds the ack", () => {
+  it("timeout dominates: a timed-out turn that also failed to forward still withholds ack + forward", () => {
     expect(resolveTurnDisposition({ ...CLEAN, timedOut: true, forwardFailed: true })).toEqual({
       status: "error",
       ack: false,
+      forward: false,
       runtimeState: "error",
     });
+  });
+
+  it("ack and forward always agree (we never consume a turn we won't deliver, or vice versa)", () => {
+    for (const aborted of [false, true]) {
+      for (const timedOut of [false, true]) {
+        for (const turnFailed of [false, true]) {
+          for (const forwardFailed of [false, true]) {
+            const d = resolveTurnDisposition({ aborted, timedOut, turnFailed, forwardFailed });
+            expect(d.ack).toBe(d.forward);
+          }
+        }
+      }
+    }
   });
 });

--- a/packages/client/src/__tests__/tui-turn-disposition.test.ts
+++ b/packages/client/src/__tests__/tui-turn-disposition.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { resolveTurnDisposition } from "../handlers/claude-code-tui/turn-disposition.js";
+
+const CLEAN = { aborted: false, timedOut: false, turnFailed: false, forwardFailed: false };
+
+describe("resolveTurnDisposition", () => {
+  it("a clean turn reports success, acks, and goes idle", () => {
+    expect(resolveTurnDisposition(CLEAN)).toEqual({ status: "success", ack: true, runtimeState: "idle" });
+  });
+
+  /**
+   * Regression for PR #712 review round 3: a turn that hit TURN_TIMEOUT_MS was
+   * being reported as `success` and acked, silently consuming the user's
+   * message with no replay path. A timeout must report error, must NOT ack
+   * (so the inbox entries are redelivered for a real retry), and must surface
+   * an error runtime state.
+   */
+  it("a timed-out turn reports error, does NOT ack, and surfaces error state", () => {
+    expect(resolveTurnDisposition({ ...CLEAN, timedOut: true })).toEqual({
+      status: "error",
+      ack: false,
+      runtimeState: "error",
+    });
+  });
+
+  it("a body failure reports error, acks (clean close, avoid storm), and surfaces error state", () => {
+    expect(resolveTurnDisposition({ ...CLEAN, turnFailed: true })).toEqual({
+      status: "error",
+      ack: true,
+      runtimeState: "error",
+    });
+  });
+
+  it("a forward-only failure reports error and acks but keeps the session idle", () => {
+    expect(resolveTurnDisposition({ ...CLEAN, forwardFailed: true })).toEqual({
+      status: "error",
+      ack: true,
+      runtimeState: "idle",
+    });
+  });
+
+  it("an aborted (suspended) turn does NOT ack so it re-runs on resume, and is not flagged failed", () => {
+    expect(resolveTurnDisposition({ ...CLEAN, aborted: true })).toEqual({
+      status: "success",
+      ack: false,
+      runtimeState: "idle",
+    });
+  });
+
+  it("timeout dominates: a timed-out turn that also failed to forward still withholds the ack", () => {
+    expect(resolveTurnDisposition({ ...CLEAN, timedOut: true, forwardFailed: true })).toEqual({
+      status: "error",
+      ack: false,
+      runtimeState: "error",
+    });
+  });
+});

--- a/packages/client/src/handlers/claude-code-tui/ask-user-degrader.ts
+++ b/packages/client/src/handlers/claude-code-tui/ask-user-degrader.ts
@@ -1,0 +1,86 @@
+/**
+ * AskUserQuestion is the only tool whose default behaviour requires the user
+ * to interact with claude's TUI selection menu — which the tmux runtime
+ * cannot do. We keep the tool enabled (claude is free to invoke it whenever
+ * it judges useful) and gracefully degrade each invocation to a plain-text
+ * round-trip:
+ *
+ *   1. Detect the selection menu via the `Enter to select` pane footer.
+ *   2. Send Escape to cancel — claude flushes the cancelled `tool_use(input)`
+ *      to the transcript (verified end-to-end in the PoC).
+ *   3. The handler picks up the cancelled `tool_use` from the transcript
+ *      tail and formats `input.questions` as markdown.
+ *   4. That text is forwarded to the chat. The next user reply is injected
+ *      as a normal user turn; claude sees its own cancelled tool call and
+ *      continues naturally.
+ *
+ * This module owns step (4)'s formatting only — menu detection lives in
+ * `index.ts`'s turn loop where it has the capture-pane handle.
+ */
+
+type AskUserOption = {
+  label?: unknown;
+  description?: unknown;
+};
+
+type AskUserQuestionItem = {
+  question?: unknown;
+  header?: unknown;
+  multiSelect?: unknown;
+  options?: unknown;
+};
+
+type AskUserInput = {
+  questions?: unknown;
+};
+
+/**
+ * Render the AskUserQuestion `input.questions` payload as markdown the user
+ * can answer in free text. Defensive against missing / malformed fields so
+ * we never throw on a transcript entry — the format is whatever claude
+ * decided to send, and we'd rather degrade than drop the message.
+ */
+export function formatQuestionsAsText(input: unknown): string {
+  const questions = extractQuestionList(input);
+  if (questions.length === 0) {
+    return "Claude wanted to ask you something, but the question payload was empty. Please reply with what you'd like it to do next.";
+  }
+
+  const lines: string[] = ["Claude has a question for you:", ""];
+  questions.forEach((q, idx) => {
+    const heading = questions.length > 1 ? `${idx + 1}. ` : "";
+    const questionText = typeof q.question === "string" ? q.question : "(no question text)";
+    lines.push(`${heading}**${questionText}**`);
+    if (typeof q.header === "string" && q.header.trim().length > 0) {
+      lines.push(`   _${q.header}_`);
+    }
+
+    const options = extractOptionList(q.options);
+    if (options.length > 0) {
+      const multi = q.multiSelect === true;
+      lines.push(`   _Options${multi ? " (multi-select)" : ""}:_`);
+      for (const opt of options) {
+        const label = typeof opt.label === "string" ? opt.label : "(option)";
+        const description = typeof opt.description === "string" ? opt.description.trim() : "";
+        lines.push(description ? `   - **${label}** — ${description}` : `   - **${label}**`);
+      }
+    }
+    lines.push("");
+  });
+
+  lines.push("Reply with your answer in plain text.");
+  return lines.join("\n");
+}
+
+function extractQuestionList(input: unknown): AskUserQuestionItem[] {
+  if (input && typeof input === "object" && !Array.isArray(input)) {
+    const questions = (input as AskUserInput).questions;
+    if (Array.isArray(questions)) return questions as AskUserQuestionItem[];
+  }
+  return [];
+}
+
+function extractOptionList(options: unknown): AskUserOption[] {
+  if (!Array.isArray(options)) return [];
+  return options as AskUserOption[];
+}

--- a/packages/client/src/handlers/claude-code-tui/index.ts
+++ b/packages/client/src/handlers/claude-code-tui/index.ts
@@ -27,6 +27,7 @@ import {
 } from "./tmux-session.js";
 import { type RawTranscriptEntry, TranscriptTailer, transcriptPathFor } from "./transcript-tail.js";
 import { ASKUSER_MENU_FOOTER, ASKUSER_TOOL_NAME, WORKING_MARKER } from "./tui-markers.js";
+import { resolveTurnDisposition } from "./turn-disposition.js";
 
 const TURN_TIMEOUT_MS = 10 * 60 * 1000;
 const TURN_POLL_MS = 250;
@@ -338,6 +339,7 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
 
     const state: TurnState = { finalTexts: [], askUserTexts: [], seenToolUseIds: new Set() };
     let turnFailed = false;
+    let timedOut = false;
     let everSawWorking = false;
     let askUserEscapeArmed = false;
     let brokeOnIdle = false;
@@ -404,13 +406,26 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
 
       // Loop hit the TURN_TIMEOUT ceiling (not a clean idle break, not an
       // explicit abort): claude may still be working. Interrupt it so its
-      // output doesn't bleed into the next turn's pane/transcript.
+      // output doesn't bleed into the next turn's pane/transcript, and flag the
+      // turn as timed out — it is NOT a success. A timed-out turn reports
+      // `turn_end: error`, stays un-acked (so the inbox entries are redelivered
+      // for a real retry instead of being silently consumed), and settles the
+      // runtime into `error` (see resolveTurnDisposition).
       if (!brokeOnIdle && !turnAborted) {
+        timedOut = true;
+        sessionCtx.log(`tui turn exceeded ${TURN_TIMEOUT_MS}ms without completing; interrupting claude`);
         try {
           await sendKey(tmuxSessionName, "Escape");
         } catch {
           /* best-effort */
         }
+        sessionCtx.emitEvent({
+          kind: "error",
+          payload: {
+            source: "runtime",
+            message: `Turn timed out after ${Math.round(TURN_TIMEOUT_MS / 1000)}s; claude was interrupted before finishing`,
+          },
+        });
       }
     } catch (err) {
       turnFailed = true;
@@ -446,23 +461,19 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
       }
     }
 
-    sessionCtx.emitEvent({
-      kind: "turn_end",
-      payload: { status: !turnFailed && !forwardFailed ? "success" : "error" },
-    });
-    // The runtime never auto-acks on turn_end (see SessionContext in
-    // handler.ts) — without this the triggering inbox entries stay in-flight
-    // and the server redelivers them (re-running the turn) on reconnect /
-    // restart. Ack on a clean close even when forwardResult failed (mirroring
-    // the SDK handler's ackTurnClose) to avoid redelivery storms; but NOT when
-    // the turn was aborted by suspend(), so the message is re-run on resume.
-    if (!turnAborted) {
+    // Resolve status / ack / runtime-state from how the turn ended. The
+    // runtime never auto-acks on turn_end (see SessionContext in handler.ts):
+    // when `ack` is false the triggering inbox entries stay in-flight and the
+    // server redelivers them (re-running the turn) on reconnect / restart.
+    // A clean close acks even on a forward-only failure (mirrors the SDK
+    // handler's ackTurnClose, avoiding redelivery storms); an abort (suspend)
+    // or a timeout withholds the ack so the message gets a real retry.
+    const disposition = resolveTurnDisposition({ aborted: turnAborted, timedOut, turnFailed, forwardFailed });
+    sessionCtx.emitEvent({ kind: "turn_end", payload: { status: disposition.status } });
+    if (disposition.ack) {
       sessionCtx.markCompleted(ackCount);
     }
-    // A failed turn loop (e.g. the tmux session died) leaves a broken session —
-    // surface it as `error` rather than advertising `idle`. A forward-only
-    // failure keeps the session healthy, so it stays idle.
-    sessionCtx.setRuntimeState(turnFailed ? "error" : "idle");
+    sessionCtx.setRuntimeState(disposition.runtimeState);
     resetProcessor();
   }
 

--- a/packages/client/src/handlers/claude-code-tui/index.ts
+++ b/packages/client/src/handlers/claude-code-tui/index.ts
@@ -1,23 +1,15 @@
 import { randomUUID } from "node:crypto";
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import {
-  type AgentRuntimeConfigPayload,
-  DEFAULT_CLAUDE_CODE_TUI_RUNTIME_CONFIG_PAYLOAD,
-  deriveRepoLocalPath,
-} from "@first-tree/shared";
+import { type AgentRuntimeConfigPayload, DEFAULT_CLAUDE_CODE_TUI_RUNTIME_CONFIG_PAYLOAD } from "@first-tree/shared";
+import { ensureAgentBootstrap } from "../../runtime/agent-bootstrap.js";
 import type { AgentConfigCache } from "../../runtime/agent-config-cache.js";
-import {
-  bootstrapWorkspace,
-  buildChatSystemPrompt,
-  installFirstTreeIntegration,
-  type PredeclaredSourceRepo,
-} from "../../runtime/bootstrap.js";
+import { buildChatSystemPrompt, type PredeclaredSourceRepo } from "../../runtime/bootstrap.js";
 import { type ChatContext, fetchChatContext } from "../../runtime/chat-context.js";
-import { resolveGitRepoTargetPath } from "../../runtime/git-local-path.js";
 import type { GitMirrorManager } from "../../runtime/git-mirror-manager.js";
 import type { AgentHandler, HandlerFactory, SessionContext, SessionMessage } from "../../runtime/handler.js";
-import { acquireAgentHome, INIT_COMPLETE_SENTINEL_REL, markWorkspaceInitComplete } from "../../runtime/workspace.js";
+import { prepareSourceRepos } from "../../runtime/source-repos.js";
+import { acquireAgentHome, markWorkspaceInitComplete } from "../../runtime/workspace.js";
 import { createToolCallProcessor, mapMcpServers } from "../claude-code.js";
 import { resolveClaudeCodeExecutable } from "../claude-executable.js";
 import { formatQuestionsAsText } from "./ask-user-degrader.js";
@@ -162,74 +154,6 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
     } catch (err) {
       sessionCtx.log(`fetchChatContext failed: ${err instanceof Error ? err.message : String(err)}`);
       return undefined;
-    }
-  }
-
-  function ensureFirstTreeBinding(workspace: string, sessionCtx: SessionContext): void {
-    if (!contextTreePath) return;
-    installFirstTreeIntegration({
-      workspacePath: workspace,
-      contextTreePath,
-      workspaceId: agentName ?? sessionCtx.chatId,
-      treeRepoUrl: contextTreeRepoUrl ?? undefined,
-      log: (msg) => sessionCtx.log(msg),
-    });
-  }
-
-  /**
-   * Materialise predeclared source repos at the top level of the agent
-   * home and update `sourceReposForPrompt` so they show up in the per-chat
-   * system-prompt block. Mirrors claude-code.ts's `refreshSourceRepos` —
-   * sessionKey is the agent name (not chatId), so two chats reuse the
-   * same checkout instead of forking branches per-chat.
-   *
-   * Cleanup tracking is omitted: predeclared source repos are agent-scoped
-   * persistent resources that survive shutdown.
-   */
-  async function prepareGitWorktrees(
-    payload: AgentRuntimeConfigPayload,
-    workspaceCwd: string,
-    sessionCtx: SessionContext,
-  ): Promise<void> {
-    sourceReposForPrompt = [];
-    if (!gitMirrorManager) return;
-    const branchAgentKey = agentName ?? sessionCtx.agent.agentId;
-    for (const repo of payload.gitRepos) {
-      const localPath = repo.localPath ?? deriveRepoLocalPath(repo.url);
-      if (!localPath) continue;
-      const targetPath = resolveGitRepoTargetPath(workspaceCwd, localPath);
-      try {
-        await gitMirrorManager.ensureMirror(repo.url);
-        await gitMirrorManager.fetchMirror(repo.url);
-        let branchName: string;
-        if (existsSync(targetPath)) {
-          // Reuse path; nothing more to do — buildChatSystemPrompt still
-          // wants the metadata so the agent knows where the checkout is.
-          branchName = repo.ref ?? "main";
-        } else {
-          const result = await gitMirrorManager.createWorktree({
-            url: repo.url,
-            ref: repo.ref,
-            targetPath,
-            sessionKey: branchAgentKey,
-            agentName: branchAgentKey,
-          });
-          branchName = result.branchName;
-          // Source repos are agent-scoped persistent resources (per
-          // proposals/agent-session-cwd-redesign §⑤) — they survive
-          // shutdown so the next chat finds them ready. Intentionally
-          // NOT tracked in ownedWorktrees.
-        }
-        sourceReposForPrompt.push({
-          absolutePath: targetPath,
-          url: repo.url,
-          ...(repo.ref ? { ref: repo.ref } : {}),
-          branch: branchName,
-        });
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        sessionCtx.log(`tui git materialisation skipped (${repo.url}): ${msg}`);
-      }
     }
   }
 
@@ -625,18 +549,19 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
 
         const payload = (await loadPayload(sessionCtx)) ?? defaultPayload();
 
-        // Per-chat material flows through the system-prompt-append channel
-        // built in `buildPromptAppend` — bootstrapWorkspace itself only writes
-        // agent-stable files now (per-agent-home redesign, proposals/2026-05-19).
+        // Per-chat material flows through the system-prompt-append channel built
+        // in `buildPromptAppend`. The stable agent-home bootstrap (CLAUDE.md
+        // briefing, core skills, Context-Tree/CLI drift pins) is the SAME shared
+        // contract the SDK handler uses — see runtime/agent-bootstrap.ts.
         chatContextForPrompt = await fetchChatContextOrLog(sessionCtx);
-        bootstrapWorkspace({
-          workspacePath: cwd,
-          identity: sessionCtx.agent,
-          contextTreePath,
-          serverUrl: sessionCtx.sdk.serverUrl,
+        ensureAgentBootstrap({ workspace: cwd, sessionCtx, contextTreePath, contextTreeRepoUrl, agentName });
+        sourceReposForPrompt = await prepareSourceRepos({
+          workspace: cwd,
+          payload,
+          sessionCtx,
+          gitMirrorManager,
+          agentName,
         });
-        ensureFirstTreeBinding(cwd, sessionCtx);
-        await prepareGitWorktrees(payload, cwd, sessionCtx);
         markWorkspaceInitComplete(cwd);
 
         const sessionId = await startClaude({ sessionCtx, resumeSessionId: null });
@@ -666,16 +591,17 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
         const payload = (await loadPayload(sessionCtx)) ?? defaultPayload();
 
         chatContextForPrompt = await fetchChatContextOrLog(sessionCtx);
-        bootstrapWorkspace({
-          workspacePath: cwd,
-          identity: sessionCtx.agent,
-          contextTreePath,
-          serverUrl: sessionCtx.sdk.serverUrl,
+        // Same shared bootstrap as start(): ensureAgentBootstrap handles the
+        // sentinel + Context-Tree/CLI drift internally, so a stale or failed
+        // integration is re-run on resume instead of being skipped.
+        ensureAgentBootstrap({ workspace: cwd, sessionCtx, contextTreePath, contextTreeRepoUrl, agentName });
+        sourceReposForPrompt = await prepareSourceRepos({
+          workspace: cwd,
+          payload,
+          sessionCtx,
+          gitMirrorManager,
+          agentName,
         });
-        if (!existsSync(join(cwd, INIT_COMPLETE_SENTINEL_REL))) {
-          ensureFirstTreeBinding(cwd, sessionCtx);
-        }
-        await prepareGitWorktrees(payload, cwd, sessionCtx);
         markWorkspaceInitComplete(cwd);
 
         const restartedId = await startClaude({ sessionCtx, resumeSessionId: sessionId });

--- a/packages/client/src/handlers/claude-code-tui/index.ts
+++ b/packages/client/src/handlers/claude-code-tui/index.ts
@@ -94,9 +94,14 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
   let transcriptTailer: TranscriptTailer | null = null;
   let currentTurnPromise: Promise<void> | null = null;
   let turnAborted = false;
+  // True for the whole span a turn is being prepared/run — start/resume
+  // bootstrap through turn completion, or a queued-message turn. This is the
+  // single synchronous gate that serialises turn execution: `pump()` starts a
+  // queued turn only when this is false, so concurrent injects can never run
+  // two turns against one tmux pane.
+  let turnRunning = false;
   let ctx: SessionContext | null = null;
   let configTempDir: string | null = null;
-  let drainScheduled = false;
   const queuedMessages: SessionMessage[] = [];
   const ownedWorktrees: Worktree[] = [];
   // Per-chat state captured at session start — surfaced into the
@@ -310,9 +315,18 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
       command,
       env: buildEnv(sessionCtx, payload),
     });
-    await waitForReady({ name: sessionName, timeoutMs: READY_TIMEOUT_MS });
-
+    // Track the session name immediately so a waitForReady failure still has a
+    // teardown path — otherwise the detached tmux session (and its claude
+    // process) leaks until the next process restart's orphan sweep.
     tmuxSessionName = sessionName;
+    try {
+      await waitForReady({ name: sessionName, timeoutMs: READY_TIMEOUT_MS });
+    } catch (err) {
+      await killSession(sessionName).catch(() => {});
+      tmuxSessionName = null;
+      throw err;
+    }
+
     transcriptTailer = new TranscriptTailer(transcriptPathFor(cwd, sessionId));
     return sessionId;
   }
@@ -381,7 +395,7 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
     }
   }
 
-  async function runTurn(text: string, sessionCtx: SessionContext): Promise<void> {
+  async function runTurn(text: string, sessionCtx: SessionContext, ackCount = 1): Promise<void> {
     if (!tmuxSessionName || !transcriptTailer) {
       throw new Error("runTurn called before session was prepared");
     }
@@ -391,6 +405,8 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
     const state: TurnState = { finalTexts: [], askUserTexts: [], seenToolUseIds: new Set() };
     let turnFailed = false;
     let everSawWorking = false;
+    let askUserEscapeArmed = false;
+    let brokeOnIdle = false;
 
     try {
       // Pre-flush whatever's already in the transcript (the prior turn's
@@ -410,18 +426,30 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
         const pane = await capturePane(tmuxSessionName);
         const working = pane.includes(WORKING_MARKER);
         if (working) everSawWorking = true;
+        // A turn that finishes between two polls may never paint the working
+        // marker; treat any produced output as evidence the turn ran so a fast
+        // reply doesn't block until TURN_TIMEOUT.
+        const producedOutput = state.finalTexts.length > 0 || state.askUserTexts.length > 0;
+        const sawActivity = everSawWorking || producedOutput;
 
         if (pane.includes(ASKUSER_MENU_FOOTER)) {
-          // Cancel the TUI selection menu — claude will flush the cancelled
-          // tool_use to the transcript on the next tick.
-          try {
-            await sendKey(tmuxSessionName, "Escape");
-          } catch (err) {
-            sessionCtx.log(`tui Escape failed: ${err instanceof Error ? err.message : String(err)}`);
+          // Cancel the TUI selection menu once per appearance. The footer stays
+          // painted for several polls after Escape, so re-sending it every tick
+          // would land stray Escapes after the menu closes — where Escape
+          // interrupts the very turn that was meant to continue.
+          if (!askUserEscapeArmed) {
+            askUserEscapeArmed = true;
+            try {
+              await sendKey(tmuxSessionName, "Escape");
+            } catch (err) {
+              sessionCtx.log(`tui Escape failed: ${err instanceof Error ? err.message : String(err)}`);
+            }
           }
+        } else {
+          askUserEscapeArmed = false;
         }
 
-        if (everSawWorking && !working) {
+        if (sawActivity && !working) {
           // Final flush grace period — claude writes the closing
           // assistant_text block to the transcript after the working
           // marker disappears.
@@ -430,6 +458,7 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
             await drainAndConsume(sessionCtx, state);
             await sleep(150);
           }
+          brokeOnIdle = true;
           break;
         }
 
@@ -438,6 +467,17 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
 
       // One last pass in case the timeout-or-break left entries behind.
       await drainAndConsume(sessionCtx, state);
+
+      // Loop hit the TURN_TIMEOUT ceiling (not a clean idle break, not an
+      // explicit abort): claude may still be working. Interrupt it so its
+      // output doesn't bleed into the next turn's pane/transcript.
+      if (!brokeOnIdle && !turnAborted) {
+        try {
+          await sendKey(tmuxSessionName, "Escape");
+        } catch {
+          /* best-effort */
+        }
+      }
     } catch (err) {
       turnFailed = true;
       sessionCtx.emitEvent({
@@ -476,37 +516,60 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
       kind: "turn_end",
       payload: { status: !turnFailed && !forwardFailed ? "success" : "error" },
     });
-    sessionCtx.setRuntimeState("idle");
-    resetProcessor();
-
-    if (queuedMessages.length > 0 && !drainScheduled) {
-      drainScheduled = true;
-      setImmediate(() => {
-        drainScheduled = false;
-        const drained = queuedMessages.splice(0);
-        if (drained.length === 0 || !ctx) return;
-        void mergeAndRun(drained, ctx);
-      });
+    // The runtime never auto-acks on turn_end (see SessionContext in
+    // handler.ts) — without this the triggering inbox entries stay in-flight
+    // and the server redelivers them (re-running the turn) on reconnect /
+    // restart. Ack on a clean close even when forwardResult failed (mirroring
+    // the SDK handler's ackTurnClose) to avoid redelivery storms; but NOT when
+    // the turn was aborted by suspend(), so the message is re-run on resume.
+    if (!turnAborted) {
+      sessionCtx.markCompleted(ackCount);
     }
+    // A failed turn loop (e.g. the tmux session died) leaves a broken session —
+    // surface it as `error` rather than advertising `idle`. A forward-only
+    // failure keeps the session healthy, so it stays idle.
+    sessionCtx.setRuntimeState(turnFailed ? "error" : "idle");
+    resetProcessor();
   }
 
-  async function mergeAndRun(drained: SessionMessage[], sessionCtx: SessionContext): Promise<void> {
-    const inputs: string[] = [];
-    for (const m of drained) {
-      try {
-        inputs.push(await sessionCtx.formatInboundContent(m));
-      } catch (err) {
-        sessionCtx.log(`tui inject formatInboundContent failed: ${err instanceof Error ? err.message : String(err)}`);
+  /**
+   * Start a turn for any queued messages, if the session is live and no turn is
+   * already running. The single serialisation point for turn execution:
+   * `inject()` only ever enqueues + calls `pump()`, and `turnRunning` (a plain
+   * synchronous boolean) guarantees at most one turn runs against the tmux pane
+   * at a time. `currentTurnPromise` is assigned synchronously before any await
+   * so a concurrent `suspend()` awaits the turn instead of tearing it down.
+   */
+  function pump(): void {
+    if (turnRunning || queuedMessages.length === 0) return;
+    const sessionCtx = ctx;
+    if (!sessionCtx || !tmuxSessionName) return;
+    const drained = queuedMessages.splice(0);
+    turnRunning = true;
+    const promise = (async () => {
+      const inputs: string[] = [];
+      for (const m of drained) {
+        try {
+          inputs.push(await sessionCtx.formatInboundContent(m));
+        } catch (err) {
+          sessionCtx.log(`tui inject formatInboundContent failed: ${err instanceof Error ? err.message : String(err)}`);
+        }
       }
-    }
-    if (inputs.length === 0) return;
-    const promise = runTurn(inputs.join("\n\n"), sessionCtx);
+      if (inputs.length === 0) return;
+      await runTurn(inputs.join("\n\n"), sessionCtx, drained.length);
+    })();
     currentTurnPromise = promise;
-    try {
-      await promise;
-    } finally {
-      currentTurnPromise = null;
-    }
+    void promise
+      .catch((err) => {
+        sessionCtx.log(`tui queued turn failed: ${err instanceof Error ? err.message : String(err)}`);
+      })
+      .finally(() => {
+        turnRunning = false;
+        currentTurnPromise = null;
+        // Drain anything injected while this turn ran. setImmediate keeps the
+        // recursion off the stack and lets the just-cleared flags settle.
+        setImmediate(pump);
+      });
   }
 
   function sleep(ms: number): Promise<void> {
@@ -541,95 +604,95 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
 
   return {
     async start(message, sessionCtx) {
-      await orphanSweep();
-      ctx = sessionCtx;
-      cwd = acquireAgentHome(workspaceRoot);
-
-      const payload = (await loadPayload(sessionCtx)) ?? defaultPayload();
-
-      // Per-chat material flows through the system-prompt-append channel
-      // built in `buildPromptAppend` — bootstrapWorkspace itself only writes
-      // agent-stable files now (per-agent-home redesign, proposals/2026-05-19).
-      chatContextForPrompt = await fetchChatContextOrLog(sessionCtx);
-      bootstrapWorkspace({
-        workspacePath: cwd,
-        identity: sessionCtx.agent,
-        contextTreePath,
-        serverUrl: sessionCtx.sdk.serverUrl,
-      });
-      ensureFirstTreeBinding(cwd, sessionCtx);
-      await prepareGitWorktrees(payload, cwd, sessionCtx);
-      markWorkspaceInitComplete(cwd);
-
-      const sessionId = await startClaude({ sessionCtx, resumeSessionId: null });
-
-      const inputText = await sessionCtx.formatInboundContent(message);
-      const promise = runTurn(inputText, sessionCtx);
-      currentTurnPromise = promise;
+      // Hold turnRunning across the whole bootstrap so an inject arriving while
+      // the session is still being prepared queues instead of racing pump()
+      // into a second turn the instant startClaude sets tmuxSessionName.
+      turnRunning = true;
       try {
-        await promise;
-      } finally {
-        currentTurnPromise = null;
-      }
-      return sessionId;
-    },
+        await orphanSweep();
+        ctx = sessionCtx;
+        cwd = acquireAgentHome(workspaceRoot);
 
-    async resume(message, sessionId, sessionCtx) {
-      await orphanSweep();
-      ctx = sessionCtx;
-      cwd = acquireAgentHome(workspaceRoot);
+        const payload = (await loadPayload(sessionCtx)) ?? defaultPayload();
 
-      const payload = (await loadPayload(sessionCtx)) ?? defaultPayload();
-
-      chatContextForPrompt = await fetchChatContextOrLog(sessionCtx);
-      bootstrapWorkspace({
-        workspacePath: cwd,
-        identity: sessionCtx.agent,
-        contextTreePath,
-        serverUrl: sessionCtx.sdk.serverUrl,
-      });
-      if (!existsSync(join(cwd, INIT_COMPLETE_SENTINEL_REL))) {
+        // Per-chat material flows through the system-prompt-append channel
+        // built in `buildPromptAppend` — bootstrapWorkspace itself only writes
+        // agent-stable files now (per-agent-home redesign, proposals/2026-05-19).
+        chatContextForPrompt = await fetchChatContextOrLog(sessionCtx);
+        bootstrapWorkspace({
+          workspacePath: cwd,
+          identity: sessionCtx.agent,
+          contextTreePath,
+          serverUrl: sessionCtx.sdk.serverUrl,
+        });
         ensureFirstTreeBinding(cwd, sessionCtx);
-      }
-      await prepareGitWorktrees(payload, cwd, sessionCtx);
-      markWorkspaceInitComplete(cwd);
+        await prepareGitWorktrees(payload, cwd, sessionCtx);
+        markWorkspaceInitComplete(cwd);
 
-      const restartedId = await startClaude({ sessionCtx, resumeSessionId: sessionId });
+        const sessionId = await startClaude({ sessionCtx, resumeSessionId: null });
 
-      if (message) {
         const inputText = await sessionCtx.formatInboundContent(message);
-        const promise = runTurn(inputText, sessionCtx);
-        currentTurnPromise = promise;
+        currentTurnPromise = runTurn(inputText, sessionCtx, 1);
         try {
-          await promise;
+          await currentTurnPromise;
         } finally {
           currentTurnPromise = null;
         }
+        return sessionId;
+      } finally {
+        turnRunning = false;
+        // Drain any messages injected during bootstrap / the first turn.
+        setImmediate(pump);
       }
-      return restartedId;
     },
 
-    inject(message) {
-      if (currentTurnPromise) {
-        queuedMessages.push(message);
-        return;
-      }
-      const sessionCtx = ctx;
-      if (!sessionCtx || !tmuxSessionName) return;
-      void (async () => {
-        try {
-          const text = await sessionCtx.formatInboundContent(message);
-          const promise = runTurn(text, sessionCtx);
-          currentTurnPromise = promise;
+    async resume(message, sessionId, sessionCtx) {
+      turnRunning = true;
+      try {
+        await orphanSweep();
+        ctx = sessionCtx;
+        cwd = acquireAgentHome(workspaceRoot);
+
+        const payload = (await loadPayload(sessionCtx)) ?? defaultPayload();
+
+        chatContextForPrompt = await fetchChatContextOrLog(sessionCtx);
+        bootstrapWorkspace({
+          workspacePath: cwd,
+          identity: sessionCtx.agent,
+          contextTreePath,
+          serverUrl: sessionCtx.sdk.serverUrl,
+        });
+        if (!existsSync(join(cwd, INIT_COMPLETE_SENTINEL_REL))) {
+          ensureFirstTreeBinding(cwd, sessionCtx);
+        }
+        await prepareGitWorktrees(payload, cwd, sessionCtx);
+        markWorkspaceInitComplete(cwd);
+
+        const restartedId = await startClaude({ sessionCtx, resumeSessionId: sessionId });
+
+        if (message) {
+          const inputText = await sessionCtx.formatInboundContent(message);
+          currentTurnPromise = runTurn(inputText, sessionCtx, 1);
           try {
-            await promise;
+            await currentTurnPromise;
           } finally {
             currentTurnPromise = null;
           }
-        } catch (err) {
-          sessionCtx.log(`tui inject failed: ${err instanceof Error ? err.message : String(err)}`);
         }
-      })();
+        return restartedId;
+      } finally {
+        turnRunning = false;
+        setImmediate(pump);
+      }
+    },
+
+    inject(message) {
+      // Always enqueue, then let the single serialised pump() decide when to
+      // run. This removes the prior races where an inject arriving in the
+      // narrow window around turn completion / startup could either start a
+      // second concurrent turn or be stranded with no drain scheduled.
+      queuedMessages.push(message);
+      pump();
     },
 
     async suspend() {

--- a/packages/client/src/handlers/claude-code-tui/index.ts
+++ b/packages/client/src/handlers/claude-code-tui/index.ts
@@ -27,6 +27,7 @@ import {
   killSession,
   listOwnedSessions,
   newSession,
+  ownedSessionPrefix,
   pasteText,
   sendKey,
   sessionExists,
@@ -44,17 +45,21 @@ const SHORT_PROMPT_INLINE_THRESHOLD = 200;
 type Worktree = { url: string; path: string; branchName: string };
 
 /**
- * Module-level lazy sweep: on first handler instantiation in this process,
- * kill all `ftth-*` tmux sessions left over from prior runs. We can be
- * aggressive because Hub Client is the only thing that creates them — anything
- * the registry doesn't know about is orphaned.
+ * Module-level lazy sweep: on first handler instantiation in this process, kill
+ * tmux sessions left over from a prior crashed run of THIS client.
+ *
+ * Scoped by the client-owner prefix (`ftth-<clientTag>-`), never the bare
+ * `ftth-` prefix: multiple client processes (prod / staging / dev) and parallel
+ * QA slots share one tmux server, so a blanket sweep would kill sessions a
+ * concurrent live process is actively driving. The client tag is stable across
+ * restarts of the same client, so we still reclaim our own orphans.
  */
 let orphanSweepDone = false;
-async function orphanSweep(): Promise<void> {
+async function orphanSweep(clientId: string): Promise<void> {
   if (orphanSweepDone) return;
   orphanSweepDone = true;
   try {
-    const owned = await listOwnedSessions();
+    const owned = await listOwnedSessions(ownedSessionPrefix(clientId));
     for (const name of owned) {
       try {
         await killSession(name);
@@ -86,6 +91,11 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
   const contextTreePath = (config.contextTreePath as string | undefined) ?? null;
   const contextTreeRepoUrl = (config.contextTreeRepoUrl as string | undefined) ?? null;
   const agentName = (config.agentName as string | undefined) ?? null;
+  // Identifies this client process; scopes tmux session ownership so the orphan
+  // sweep and session names never collide with another live client / QA slot
+  // on the shared tmux server. Empty string is tolerated (falls back to a
+  // placeholder tag) but the daemon always supplies a real client id.
+  const clientId = (config.clientId as string | undefined) ?? "";
   const claudeCodeExecutable =
     (config.claudeCodeExecutable as string | undefined) ?? resolveClaudeCodeExecutable().path ?? "claude";
 
@@ -296,7 +306,7 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
     const payload = (await loadPayload(sessionCtx)) ?? defaultPayload();
 
     const sessionId = resumeSessionId ?? randomUUID();
-    const sessionName = deriveSessionName(sessionCtx.agent.agentId, sessionCtx.chatId);
+    const sessionName = deriveSessionName(clientId, sessionCtx.agent.agentId, sessionCtx.chatId);
     if (await sessionExists(sessionName)) {
       await killSession(sessionName);
     }
@@ -609,7 +619,7 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
       // into a second turn the instant startClaude sets tmuxSessionName.
       turnRunning = true;
       try {
-        await orphanSweep();
+        await orphanSweep(clientId);
         ctx = sessionCtx;
         cwd = acquireAgentHome(workspaceRoot);
 
@@ -649,7 +659,7 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
     async resume(message, sessionId, sessionCtx) {
       turnRunning = true;
       try {
-        await orphanSweep();
+        await orphanSweep(clientId);
         ctx = sessionCtx;
         cwd = acquireAgentHome(workspaceRoot);
 

--- a/packages/client/src/handlers/claude-code-tui/index.ts
+++ b/packages/client/src/handlers/claude-code-tui/index.ts
@@ -1,0 +1,691 @@
+import { randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  type AgentRuntimeConfigPayload,
+  DEFAULT_CLAUDE_CODE_TUI_RUNTIME_CONFIG_PAYLOAD,
+  deriveRepoLocalPath,
+} from "@first-tree/shared";
+import type { AgentConfigCache } from "../../runtime/agent-config-cache.js";
+import {
+  bootstrapWorkspace,
+  buildChatSystemPrompt,
+  installFirstTreeIntegration,
+  type PredeclaredSourceRepo,
+} from "../../runtime/bootstrap.js";
+import { type ChatContext, fetchChatContext } from "../../runtime/chat-context.js";
+import { resolveGitRepoTargetPath } from "../../runtime/git-local-path.js";
+import type { GitMirrorManager } from "../../runtime/git-mirror-manager.js";
+import type { AgentHandler, HandlerFactory, SessionContext, SessionMessage } from "../../runtime/handler.js";
+import { acquireAgentHome, INIT_COMPLETE_SENTINEL_REL, markWorkspaceInitComplete } from "../../runtime/workspace.js";
+import { createToolCallProcessor, mapMcpServers } from "../claude-code.js";
+import { resolveClaudeCodeExecutable } from "../claude-executable.js";
+import { formatQuestionsAsText } from "./ask-user-degrader.js";
+import {
+  capturePane,
+  deriveSessionName,
+  killSession,
+  listOwnedSessions,
+  newSession,
+  pasteText,
+  sendKey,
+  sessionExists,
+  waitForReady,
+} from "./tmux-session.js";
+import { type RawTranscriptEntry, TranscriptTailer, transcriptPathFor } from "./transcript-tail.js";
+import { ASKUSER_MENU_FOOTER, ASKUSER_TOOL_NAME, WORKING_MARKER } from "./tui-markers.js";
+
+const TURN_TIMEOUT_MS = 10 * 60 * 1000;
+const TURN_POLL_MS = 250;
+const TURN_GRACE_MS = 1500;
+const READY_TIMEOUT_MS = 30_000;
+const SHORT_PROMPT_INLINE_THRESHOLD = 200;
+
+type Worktree = { url: string; path: string; branchName: string };
+
+/**
+ * Module-level lazy sweep: on first handler instantiation in this process,
+ * kill all `ftth-*` tmux sessions left over from prior runs. We can be
+ * aggressive because Hub Client is the only thing that creates them — anything
+ * the registry doesn't know about is orphaned.
+ */
+let orphanSweepDone = false;
+async function orphanSweep(): Promise<void> {
+  if (orphanSweepDone) return;
+  orphanSweepDone = true;
+  try {
+    const owned = await listOwnedSessions();
+    for (const name of owned) {
+      try {
+        await killSession(name);
+      } catch {
+        /* best-effort */
+      }
+    }
+  } catch {
+    /* best-effort */
+  }
+}
+
+/**
+ * Claude Code TUI Handler — drives `claude` (interactive TUI) through tmux.
+ *
+ * Replaces the SDK-based `claude-code` handler with a tmux-driven equivalent
+ * for the post-SDK-sunset world. Input is injected via `paste-buffer`;
+ * events stream from `~/.claude/projects/<encoded-cwd>/<session-id>.jsonl`
+ * (claude's per-session transcript). AskUserQuestion is gracefully degraded
+ * to a plain-text round-trip via Escape-cancel — the tool stays enabled.
+ *
+ * See `experiments/tmux-claude-runtime/FINDINGS.md` for the design rationale
+ * and PoC verification matrix.
+ */
+export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
+  const workspaceRoot = config.workspaceRoot as string;
+  const agentConfigCache = (config.agentConfigCache as AgentConfigCache | undefined) ?? null;
+  const gitMirrorManager = (config.gitMirrorManager as GitMirrorManager | undefined) ?? null;
+  const contextTreePath = (config.contextTreePath as string | undefined) ?? null;
+  const contextTreeRepoUrl = (config.contextTreeRepoUrl as string | undefined) ?? null;
+  const agentName = (config.agentName as string | undefined) ?? null;
+  const claudeCodeExecutable =
+    (config.claudeCodeExecutable as string | undefined) ?? resolveClaudeCodeExecutable().path ?? "claude";
+
+  let cwd: string | null = null;
+  let tmuxSessionName: string | null = null;
+  let transcriptTailer: TranscriptTailer | null = null;
+  let currentTurnPromise: Promise<void> | null = null;
+  let turnAborted = false;
+  let ctx: SessionContext | null = null;
+  let configTempDir: string | null = null;
+  let drainScheduled = false;
+  const queuedMessages: SessionMessage[] = [];
+  const ownedWorktrees: Worktree[] = [];
+  // Per-chat state captured at session start — surfaced into the
+  // --append-system-prompt block via buildChatSystemPrompt. Unlike the SDK
+  // path the TUI handler can't update the prompt between turns (claude is a
+  // persistent process), so we snapshot once per startClaude().
+  let chatContextForPrompt: ChatContext | undefined;
+  let sourceReposForPrompt: PredeclaredSourceRepo[] = [];
+
+  function buildEnv(sessionCtx: SessionContext, payload: AgentRuntimeConfigPayload): Record<string, string> {
+    const env: Record<string, string> = {};
+    for (const [k, v] of Object.entries(process.env)) {
+      if (typeof v === "string") env[k] = v;
+    }
+    for (const e of payload.env) env[e.key] = e.value;
+    const merged = sessionCtx.buildAgentEnv(env);
+    const out: Record<string, string> = {};
+    for (const [k, v] of Object.entries(merged)) {
+      if (typeof v === "string") out[k] = v;
+    }
+    return out;
+  }
+
+  /**
+   * Compose the `--append-system-prompt` content: agent-config-managed
+   * append (from payload.prompt.append) + the per-chat block built via
+   * `buildChatSystemPrompt` (working-dir convention, source repos,
+   * worktree-on-demand, chat context). Mirrors the claude-code SDK
+   * handler's `combinedAppend` — both providers feed claude through the
+   * same prompt-append channel; we just deliver it via a CLI flag instead
+   * of a Query option.
+   */
+  function buildPromptAppend(payload: AgentRuntimeConfigPayload, workspaceCwd: string | null): string {
+    const agentConfigAppend = payload.prompt.append?.trim() ?? "";
+    const perChatAppend = workspaceCwd
+      ? buildChatSystemPrompt({
+          agentHome: workspaceCwd,
+          chatContext: chatContextForPrompt,
+          sourceRepos: sourceReposForPrompt,
+        }).trim()
+      : "";
+    return [agentConfigAppend, perChatAppend].filter((s) => s.length > 0).join("\n\n");
+  }
+
+  async function fetchChatContextOrLog(sessionCtx: SessionContext): Promise<ChatContext | undefined> {
+    try {
+      return await fetchChatContext(sessionCtx.sdk, sessionCtx.chatId, sessionCtx.agent);
+    } catch (err) {
+      sessionCtx.log(`fetchChatContext failed: ${err instanceof Error ? err.message : String(err)}`);
+      return undefined;
+    }
+  }
+
+  function ensureFirstTreeBinding(workspace: string, sessionCtx: SessionContext): void {
+    if (!contextTreePath) return;
+    installFirstTreeIntegration({
+      workspacePath: workspace,
+      contextTreePath,
+      workspaceId: agentName ?? sessionCtx.chatId,
+      treeRepoUrl: contextTreeRepoUrl ?? undefined,
+      log: (msg) => sessionCtx.log(msg),
+    });
+  }
+
+  /**
+   * Materialise predeclared source repos at the top level of the agent
+   * home and update `sourceReposForPrompt` so they show up in the per-chat
+   * system-prompt block. Mirrors claude-code.ts's `refreshSourceRepos` —
+   * sessionKey is the agent name (not chatId), so two chats reuse the
+   * same checkout instead of forking branches per-chat.
+   *
+   * Cleanup tracking is omitted: predeclared source repos are agent-scoped
+   * persistent resources that survive shutdown.
+   */
+  async function prepareGitWorktrees(
+    payload: AgentRuntimeConfigPayload,
+    workspaceCwd: string,
+    sessionCtx: SessionContext,
+  ): Promise<void> {
+    sourceReposForPrompt = [];
+    if (!gitMirrorManager) return;
+    const branchAgentKey = agentName ?? sessionCtx.agent.agentId;
+    for (const repo of payload.gitRepos) {
+      const localPath = repo.localPath ?? deriveRepoLocalPath(repo.url);
+      if (!localPath) continue;
+      const targetPath = resolveGitRepoTargetPath(workspaceCwd, localPath);
+      try {
+        await gitMirrorManager.ensureMirror(repo.url);
+        await gitMirrorManager.fetchMirror(repo.url);
+        let branchName: string;
+        if (existsSync(targetPath)) {
+          // Reuse path; nothing more to do — buildChatSystemPrompt still
+          // wants the metadata so the agent knows where the checkout is.
+          branchName = repo.ref ?? "main";
+        } else {
+          const result = await gitMirrorManager.createWorktree({
+            url: repo.url,
+            ref: repo.ref,
+            targetPath,
+            sessionKey: branchAgentKey,
+            agentName: branchAgentKey,
+          });
+          branchName = result.branchName;
+          // Source repos are agent-scoped persistent resources (per
+          // proposals/agent-session-cwd-redesign §⑤) — they survive
+          // shutdown so the next chat finds them ready. Intentionally
+          // NOT tracked in ownedWorktrees.
+        }
+        sourceReposForPrompt.push({
+          absolutePath: targetPath,
+          url: repo.url,
+          ...(repo.ref ? { ref: repo.ref } : {}),
+          branch: branchName,
+        });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        sessionCtx.log(`tui git materialisation skipped (${repo.url}): ${msg}`);
+      }
+    }
+  }
+
+  function ensureConfigTempDir(workspaceCwd: string, sessionId: string): string {
+    const dir = join(workspaceCwd, ".claude-code-tui", sessionId);
+    mkdirSync(dir, { recursive: true });
+    return dir;
+  }
+
+  /**
+   * Build claude CLI args. Returns the joined command string ready for tmux
+   * (tmux runs through the user's $SHELL, which handles quoting reasonably).
+   * Inputs that contain spaces are shell-quoted defensively.
+   */
+  function buildClaudeCommand(input: {
+    sessionId: string;
+    resumeSessionId: string | null;
+    payload: AgentRuntimeConfigPayload;
+    workspaceCwd: string;
+    claudeBin: string;
+  }): string {
+    const { sessionId, resumeSessionId, payload, workspaceCwd, claudeBin } = input;
+    const args: string[] = [
+      shellQuote(claudeBin),
+      "--dangerously-skip-permissions",
+      "--session-id",
+      shellQuote(sessionId),
+    ];
+    if (resumeSessionId) {
+      args.push("--resume", shellQuote(resumeSessionId));
+    }
+    if (payload.model) {
+      args.push("--model", shellQuote(payload.model));
+    }
+
+    const tempDir = ensureConfigTempDir(workspaceCwd, sessionId);
+    configTempDir = tempDir;
+
+    const promptAppend = buildPromptAppend(payload, workspaceCwd).trim();
+    if (promptAppend.length > 0) {
+      if (promptAppend.length <= SHORT_PROMPT_INLINE_THRESHOLD && !promptAppend.includes("\n")) {
+        args.push("--append-system-prompt", shellQuote(promptAppend));
+      } else {
+        const path = join(tempDir, "system-prompt-append.txt");
+        writeFileSync(path, promptAppend, "utf-8");
+        args.push("--append-system-prompt-file", shellQuote(path));
+      }
+    }
+
+    if (payload.mcpServers.length > 0) {
+      const mcpConfigPath = join(tempDir, "mcp-config.json");
+      writeFileSync(mcpConfigPath, JSON.stringify({ mcpServers: mapMcpServers(payload) }, null, 2), "utf-8");
+      args.push("--mcp-config", shellQuote(mcpConfigPath));
+      args.push("--strict-mcp-config");
+    }
+
+    args.push("--setting-sources", "user,project");
+
+    return args.join(" ");
+  }
+
+  async function loadPayload(sessionCtx: SessionContext): Promise<AgentRuntimeConfigPayload | null> {
+    if (!agentConfigCache) return null;
+    const cached = agentConfigCache.get(sessionCtx.agent.agentId);
+    if (cached) return cached.payload;
+    const refreshed = await agentConfigCache.refresh(sessionCtx.agent.agentId);
+    return refreshed.payload;
+  }
+
+  async function startClaude(input: { sessionCtx: SessionContext; resumeSessionId: string | null }): Promise<string> {
+    const { sessionCtx, resumeSessionId } = input;
+    if (!cwd) throw new Error("startClaude called before cwd was acquired");
+
+    const payload = (await loadPayload(sessionCtx)) ?? defaultPayload();
+
+    const sessionId = resumeSessionId ?? randomUUID();
+    const sessionName = deriveSessionName(sessionCtx.agent.agentId, sessionCtx.chatId);
+    if (await sessionExists(sessionName)) {
+      await killSession(sessionName);
+    }
+
+    const command = buildClaudeCommand({
+      sessionId,
+      resumeSessionId,
+      payload,
+      workspaceCwd: cwd,
+      claudeBin: claudeCodeExecutable,
+    });
+
+    await newSession({
+      name: sessionName,
+      cwd,
+      command,
+      env: buildEnv(sessionCtx, payload),
+    });
+    await waitForReady({ name: sessionName, timeoutMs: READY_TIMEOUT_MS });
+
+    tmuxSessionName = sessionName;
+    transcriptTailer = new TranscriptTailer(transcriptPathFor(cwd, sessionId));
+    return sessionId;
+  }
+
+  function defaultPayload(): AgentRuntimeConfigPayload {
+    // Reuse the shared default so this stays in sync with the schema (e.g. the
+    // `reasoningEffort` field) instead of hand-maintaining the literal here.
+    return { ...DEFAULT_CLAUDE_CODE_TUI_RUNTIME_CONFIG_PAYLOAD };
+  }
+
+  /**
+   * Process raw transcript entries: feed them to the shared tool-call
+   * processor (which emits assistant_text / thinking / tool_call events),
+   * and pull out two side channels we need locally:
+   *   - assistant text → accumulated for `forwardResult`
+   *   - AskUserQuestion tool_use → degraded to plain text
+   */
+  type TurnState = {
+    finalTexts: string[];
+    askUserTexts: string[];
+    seenToolUseIds: Set<string>;
+  };
+
+  function consumeEntry(entry: RawTranscriptEntry, sessionCtx: SessionContext, state: TurnState): void {
+    // Feed the shared processor — it emits all the session events we'd
+    // otherwise have to reimplement (assistant_text / thinking / tool_call
+    // pending / tool_call final, plus context_tree_usage when bound).
+    processor(sessionCtx).onMessage(entry);
+
+    if (entry?.type !== "assistant") return;
+    const content = entry.message?.content;
+    if (!Array.isArray(content)) return;
+    for (const blk of content as Array<Record<string, unknown>>) {
+      if (blk.type === "text" && typeof blk.text === "string") {
+        const text = blk.text.trim();
+        if (text.length > 0) state.finalTexts.push(blk.text);
+      } else if (blk.type === "tool_use" && typeof blk.id === "string" && blk.name === ASKUSER_TOOL_NAME) {
+        if (state.seenToolUseIds.has(blk.id)) continue;
+        state.seenToolUseIds.add(blk.id);
+        state.askUserTexts.push(formatQuestionsAsText(blk.input));
+      }
+    }
+  }
+
+  // Single processor instance per turn (constructed lazily because we need
+  // the session ctx). Reset between turns to free its `pending` map.
+  let turnProcessor: ReturnType<typeof createToolCallProcessor> | null = null;
+  function processor(sessionCtx: SessionContext): ReturnType<typeof createToolCallProcessor> {
+    if (!turnProcessor) {
+      turnProcessor = createToolCallProcessor(
+        (event) => sessionCtx.emitEvent(event),
+        contextTreePath ? { path: contextTreePath, repoUrl: contextTreeRepoUrl } : undefined,
+      );
+    }
+    return turnProcessor;
+  }
+  function resetProcessor(): void {
+    turnProcessor?.flush();
+    turnProcessor = null;
+  }
+
+  async function drainAndConsume(sessionCtx: SessionContext, state: TurnState): Promise<void> {
+    if (!transcriptTailer) return;
+    for (const entry of transcriptTailer.drainEntries()) {
+      consumeEntry(entry, sessionCtx, state);
+    }
+  }
+
+  async function runTurn(text: string, sessionCtx: SessionContext): Promise<void> {
+    if (!tmuxSessionName || !transcriptTailer) {
+      throw new Error("runTurn called before session was prepared");
+    }
+    sessionCtx.setRuntimeState("working");
+    turnAborted = false;
+
+    const state: TurnState = { finalTexts: [], askUserTexts: [], seenToolUseIds: new Set() };
+    let turnFailed = false;
+    let everSawWorking = false;
+
+    try {
+      // Pre-flush whatever's already in the transcript (the prior turn's
+      // tail end) so it doesn't pollute this turn's text accumulation.
+      transcriptTailer.drainEntries();
+
+      await pasteText(tmuxSessionName, text);
+      sessionCtx.touch();
+
+      const startTs = Date.now();
+      while (Date.now() - startTs < TURN_TIMEOUT_MS) {
+        if (turnAborted) break;
+        sessionCtx.touch();
+
+        await drainAndConsume(sessionCtx, state);
+
+        const pane = await capturePane(tmuxSessionName);
+        const working = pane.includes(WORKING_MARKER);
+        if (working) everSawWorking = true;
+
+        if (pane.includes(ASKUSER_MENU_FOOTER)) {
+          // Cancel the TUI selection menu — claude will flush the cancelled
+          // tool_use to the transcript on the next tick.
+          try {
+            await sendKey(tmuxSessionName, "Escape");
+          } catch (err) {
+            sessionCtx.log(`tui Escape failed: ${err instanceof Error ? err.message : String(err)}`);
+          }
+        }
+
+        if (everSawWorking && !working) {
+          // Final flush grace period — claude writes the closing
+          // assistant_text block to the transcript after the working
+          // marker disappears.
+          const graceUntil = Date.now() + TURN_GRACE_MS;
+          while (Date.now() < graceUntil) {
+            await drainAndConsume(sessionCtx, state);
+            await sleep(150);
+          }
+          break;
+        }
+
+        await sleep(TURN_POLL_MS);
+      }
+
+      // One last pass in case the timeout-or-break left entries behind.
+      await drainAndConsume(sessionCtx, state);
+    } catch (err) {
+      turnFailed = true;
+      sessionCtx.emitEvent({
+        kind: "error",
+        payload: { source: "runtime", message: err instanceof Error ? err.message : String(err) },
+      });
+    }
+
+    // Compose the final user-facing text. AskUserQuestion text takes priority
+    // — when claude tried to ask a structured question, that question (not
+    // any preceding assistant text) is the meaningful payload for the user.
+    let finalText = "";
+    if (state.askUserTexts.length > 0) {
+      finalText = state.askUserTexts.join("\n\n");
+    } else {
+      finalText = state.finalTexts.join("\n\n").trim();
+    }
+
+    let forwardFailed = false;
+    if (finalText.trim()) {
+      try {
+        await sessionCtx.forwardResult(finalText);
+      } catch (err) {
+        forwardFailed = true;
+        sessionCtx.emitEvent({
+          kind: "error",
+          payload: {
+            source: "runtime",
+            message: `forwardResult failed: ${err instanceof Error ? err.message : String(err)}`,
+          },
+        });
+      }
+    }
+
+    sessionCtx.emitEvent({
+      kind: "turn_end",
+      payload: { status: !turnFailed && !forwardFailed ? "success" : "error" },
+    });
+    sessionCtx.setRuntimeState("idle");
+    resetProcessor();
+
+    if (queuedMessages.length > 0 && !drainScheduled) {
+      drainScheduled = true;
+      setImmediate(() => {
+        drainScheduled = false;
+        const drained = queuedMessages.splice(0);
+        if (drained.length === 0 || !ctx) return;
+        void mergeAndRun(drained, ctx);
+      });
+    }
+  }
+
+  async function mergeAndRun(drained: SessionMessage[], sessionCtx: SessionContext): Promise<void> {
+    const inputs: string[] = [];
+    for (const m of drained) {
+      try {
+        inputs.push(await sessionCtx.formatInboundContent(m));
+      } catch (err) {
+        sessionCtx.log(`tui inject formatInboundContent failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+    if (inputs.length === 0) return;
+    const promise = runTurn(inputs.join("\n\n"), sessionCtx);
+    currentTurnPromise = promise;
+    try {
+      await promise;
+    } finally {
+      currentTurnPromise = null;
+    }
+  }
+
+  function sleep(ms: number): Promise<void> {
+    return new Promise((r) => setTimeout(r, ms));
+  }
+
+  function shellQuote(value: string): string {
+    if (!value) return "''";
+    if (/^[A-Za-z0-9_@%+=:,./-]+$/.test(value)) return value;
+    return `'${value.replace(/'/g, "'\\''")}'`;
+  }
+
+  async function teardownTmux(): Promise<void> {
+    if (tmuxSessionName) {
+      try {
+        await killSession(tmuxSessionName);
+      } catch {
+        /* best-effort */
+      }
+    }
+    tmuxSessionName = null;
+    transcriptTailer = null;
+    if (configTempDir && existsSync(configTempDir)) {
+      try {
+        rmSync(configTempDir, { recursive: true, force: true });
+      } catch {
+        /* best-effort */
+      }
+    }
+    configTempDir = null;
+  }
+
+  return {
+    async start(message, sessionCtx) {
+      await orphanSweep();
+      ctx = sessionCtx;
+      cwd = acquireAgentHome(workspaceRoot);
+
+      const payload = (await loadPayload(sessionCtx)) ?? defaultPayload();
+
+      // Per-chat material flows through the system-prompt-append channel
+      // built in `buildPromptAppend` — bootstrapWorkspace itself only writes
+      // agent-stable files now (per-agent-home redesign, proposals/2026-05-19).
+      chatContextForPrompt = await fetchChatContextOrLog(sessionCtx);
+      bootstrapWorkspace({
+        workspacePath: cwd,
+        identity: sessionCtx.agent,
+        contextTreePath,
+        serverUrl: sessionCtx.sdk.serverUrl,
+      });
+      ensureFirstTreeBinding(cwd, sessionCtx);
+      await prepareGitWorktrees(payload, cwd, sessionCtx);
+      markWorkspaceInitComplete(cwd);
+
+      const sessionId = await startClaude({ sessionCtx, resumeSessionId: null });
+
+      const inputText = await sessionCtx.formatInboundContent(message);
+      const promise = runTurn(inputText, sessionCtx);
+      currentTurnPromise = promise;
+      try {
+        await promise;
+      } finally {
+        currentTurnPromise = null;
+      }
+      return sessionId;
+    },
+
+    async resume(message, sessionId, sessionCtx) {
+      await orphanSweep();
+      ctx = sessionCtx;
+      cwd = acquireAgentHome(workspaceRoot);
+
+      const payload = (await loadPayload(sessionCtx)) ?? defaultPayload();
+
+      chatContextForPrompt = await fetchChatContextOrLog(sessionCtx);
+      bootstrapWorkspace({
+        workspacePath: cwd,
+        identity: sessionCtx.agent,
+        contextTreePath,
+        serverUrl: sessionCtx.sdk.serverUrl,
+      });
+      if (!existsSync(join(cwd, INIT_COMPLETE_SENTINEL_REL))) {
+        ensureFirstTreeBinding(cwd, sessionCtx);
+      }
+      await prepareGitWorktrees(payload, cwd, sessionCtx);
+      markWorkspaceInitComplete(cwd);
+
+      const restartedId = await startClaude({ sessionCtx, resumeSessionId: sessionId });
+
+      if (message) {
+        const inputText = await sessionCtx.formatInboundContent(message);
+        const promise = runTurn(inputText, sessionCtx);
+        currentTurnPromise = promise;
+        try {
+          await promise;
+        } finally {
+          currentTurnPromise = null;
+        }
+      }
+      return restartedId;
+    },
+
+    inject(message) {
+      if (currentTurnPromise) {
+        queuedMessages.push(message);
+        return;
+      }
+      const sessionCtx = ctx;
+      if (!sessionCtx || !tmuxSessionName) return;
+      void (async () => {
+        try {
+          const text = await sessionCtx.formatInboundContent(message);
+          const promise = runTurn(text, sessionCtx);
+          currentTurnPromise = promise;
+          try {
+            await promise;
+          } finally {
+            currentTurnPromise = null;
+          }
+        } catch (err) {
+          sessionCtx.log(`tui inject failed: ${err instanceof Error ? err.message : String(err)}`);
+        }
+      })();
+    },
+
+    async suspend() {
+      turnAborted = true;
+      if (tmuxSessionName) {
+        try {
+          await sendKey(tmuxSessionName, "Escape");
+        } catch {
+          /* best-effort */
+        }
+      }
+      try {
+        await currentTurnPromise;
+      } catch {
+        /* swallow */
+      }
+      currentTurnPromise = null;
+      await teardownTmux();
+    },
+
+    async shutdown() {
+      turnAborted = true;
+      if (tmuxSessionName) {
+        try {
+          await sendKey(tmuxSessionName, "Escape");
+        } catch {
+          /* best-effort */
+        }
+      }
+      try {
+        await currentTurnPromise;
+      } catch {
+        /* swallow */
+      }
+      currentTurnPromise = null;
+      await teardownTmux();
+
+      // Per agent-session-cwd-redesign: cwd is the per-agent home — shared
+      // by every chat. shutdown() must NOT remove it; that would wipe
+      // persistent state and source-repo checkouts other chats may resume
+      // against. Source repos are also intentionally left in place
+      // (proposals/agent-session-cwd-redesign §⑤). On-demand worktrees the
+      // agent created under `<cwd>/worktrees/<name>/` belong to the agent.
+      if (gitMirrorManager) {
+        for (const wt of ownedWorktrees) {
+          try {
+            await gitMirrorManager.removeWorktree({ url: wt.url, path: wt.path, branchName: wt.branchName });
+          } catch (err) {
+            ctx?.log(`tui worktree cleanup failed (${wt.path}): ${err instanceof Error ? err.message : String(err)}`);
+          }
+        }
+        ownedWorktrees.length = 0;
+      }
+      cwd = null;
+      ctx = null;
+      queuedMessages.length = 0;
+    },
+  } satisfies AgentHandler;
+};

--- a/packages/client/src/handlers/claude-code-tui/index.ts
+++ b/packages/client/src/handlers/claude-code-tui/index.ts
@@ -445,8 +445,15 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
       finalText = state.finalTexts.join("\n\n").trim();
     }
 
+    // Decide delivery + ack/state from how the turn ended. The `forward` /
+    // `ack` flags are independent of forwardResult's own success, so compute
+    // them first and use `forward` to gate delivery: on a timeout or a
+    // suspend-abort the inbox entry stays un-acked and the message re-runs on
+    // reconnect/resume, so forwarding partial output here would double-post
+    // (and risk inconsistent output) once the replay produces the real answer.
     let forwardFailed = false;
-    if (finalText.trim()) {
+    const willForward = resolveTurnDisposition({ aborted: turnAborted, timedOut, turnFailed, forwardFailed: false });
+    if (willForward.forward && finalText.trim()) {
       try {
         await sessionCtx.forwardResult(finalText);
       } catch (err) {
@@ -461,13 +468,13 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
       }
     }
 
-    // Resolve status / ack / runtime-state from how the turn ended. The
-    // runtime never auto-acks on turn_end (see SessionContext in handler.ts):
-    // when `ack` is false the triggering inbox entries stay in-flight and the
-    // server redelivers them (re-running the turn) on reconnect / restart.
-    // A clean close acks even on a forward-only failure (mirrors the SDK
-    // handler's ackTurnClose, avoiding redelivery storms); an abort (suspend)
-    // or a timeout withholds the ack so the message gets a real retry.
+    // Re-resolve with the real forwardFailed folded in (it only affects
+    // `status`). The runtime never auto-acks on turn_end (see SessionContext in
+    // handler.ts): when `ack` is false the triggering inbox entries stay
+    // in-flight and the server redelivers them on reconnect / restart. A clean
+    // close acks even on a forward-only failure (mirrors the SDK handler's
+    // ackTurnClose, avoiding redelivery storms); an abort or a timeout
+    // withholds the ack so the message gets a real retry.
     const disposition = resolveTurnDisposition({ aborted: turnAborted, timedOut, turnFailed, forwardFailed });
     sessionCtx.emitEvent({ kind: "turn_end", payload: { status: disposition.status } });
     if (disposition.ack) {

--- a/packages/client/src/handlers/claude-code-tui/tmux-session.ts
+++ b/packages/client/src/handlers/claude-code-tui/tmux-session.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { mkdtempSync, unlinkSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { READY_MARKER, TMUX_SESSION_PREFIX, USER_RE } from "./tui-markers.js";
@@ -90,6 +90,12 @@ export async function newSession(input: NewSessionInput): Promise<void> {
  * -p` uses bracketed paste so multi-line content and shell metacharacters
  * (\ ` $ etc.) are delivered without interpretation. A small delay before
  * Enter avoids races where claude's reader misses the trailing newline.
+ *
+ * Cleanup matters for confidentiality: the tmux buffer lives on the shared
+ * tmux *server*, not in our session, so even after our session is killed the
+ * message text stays readable via `tmux show-buffer` from any other surviving
+ * session. We delete the buffer (`paste-buffer -d` plus a finally backstop) and
+ * remove the whole temp directory, not just the file.
  */
 export async function pasteText(sessionName: string, text: string): Promise<void> {
   const dir = mkdtempSync(join(tmpdir(), "ftth-tui-"));
@@ -98,12 +104,16 @@ export async function pasteText(sessionName: string, text: string): Promise<void
   const bufferName = `${sessionName}-msg`;
   try {
     await tmuxOrThrow(["load-buffer", "-b", bufferName, file]);
-    await tmuxOrThrow(["paste-buffer", "-b", bufferName, "-t", sessionName, "-p"]);
+    // `-d` deletes the buffer once pasted, so the text doesn't linger server-side.
+    await tmuxOrThrow(["paste-buffer", "-b", bufferName, "-t", sessionName, "-p", "-d"]);
     await new Promise((r) => setTimeout(r, 150));
     await tmuxOrThrow(["send-keys", "-t", sessionName, "Enter"]);
   } finally {
+    // Backstop: if paste failed before `-d` could delete the buffer, drop it
+    // explicitly. Best-effort (no throw if already gone).
+    await runTmux(["delete-buffer", "-b", bufferName]);
     try {
-      unlinkSync(file);
+      rmSync(dir, { recursive: true, force: true });
     } catch {
       /* ignore */
     }
@@ -143,10 +153,15 @@ export async function listSessions(): Promise<string[]> {
     .filter((s) => s.length > 0);
 }
 
-/** List ftth-prefixed sessions only. */
-export async function listOwnedSessions(): Promise<string[]> {
+/**
+ * List sessions whose name starts with `prefix`. The orphan sweep passes the
+ * client-scoped prefix from `ownedSessionPrefix(clientId)` so it only ever
+ * matches sessions THIS client created — never another live client process or
+ * a parallel QA slot, which carry a different client tag.
+ */
+export async function listOwnedSessions(prefix: string): Promise<string[]> {
   const all = await listSessions();
-  return all.filter((name) => name.startsWith(TMUX_SESSION_PREFIX));
+  return all.filter((name) => name.startsWith(prefix));
 }
 
 export type WaitForReadyInput = {
@@ -174,14 +189,32 @@ export async function waitForReady(input: WaitForReadyInput): Promise<void> {
 }
 
 /**
- * Derive a deterministic, tmux-safe session name from `(agentId, chatId)`.
- * tmux disallows `:` and `.` in session names — strip them out and cap at
- * 32 chars so the name comfortably fits inside any tmux client display.
+ * Per-client tag embedded in every session name so each client process owns a
+ * disjoint slice of the `ftth-` namespace. Derived from the trailing chars of
+ * the client id (the unique hex in `client_<hex>`); stable across restarts of
+ * the same client (so the sweep finds its own crashed-run leftovers) but
+ * distinct from any other client / QA process.
  */
-export function deriveSessionName(agentId: string, chatId: string): string {
+function clientTag(clientId: string): string {
+  const s = sanitise(clientId);
+  return s.length >= 4 ? s.slice(-8) : "nocid";
+}
+
+/** Prefix matching exactly the sessions a given client owns: `ftth-<clientTag>-`. */
+export function ownedSessionPrefix(clientId: string): string {
+  return `${TMUX_SESSION_PREFIX}${clientTag(clientId)}-`;
+}
+
+/**
+ * Derive a deterministic, tmux-safe session name from `(clientId, agentId,
+ * chatId)`. tmux disallows `:` and `.` in session names — strip them out. The
+ * client tag scopes ownership so the orphan sweep never touches another
+ * process's sessions; agent/chat are capped at 8 chars to keep the name short.
+ */
+export function deriveSessionName(clientId: string, agentId: string, chatId: string): string {
   const a = sanitise(agentId).slice(0, 8);
   const c = sanitise(chatId).slice(0, 8);
-  return `${TMUX_SESSION_PREFIX}${a}-${c}`;
+  return `${ownedSessionPrefix(clientId)}${a}-${c}`;
 }
 
 function sanitise(input: string): string {

--- a/packages/client/src/handlers/claude-code-tui/tmux-session.ts
+++ b/packages/client/src/handlers/claude-code-tui/tmux-session.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -206,15 +207,22 @@ export function ownedSessionPrefix(clientId: string): string {
 }
 
 /**
- * Derive a deterministic, tmux-safe session name from `(clientId, agentId,
- * chatId)`. tmux disallows `:` and `.` in session names — strip them out. The
- * client tag scopes ownership so the orphan sweep never touches another
- * process's sessions; agent/chat are capped at 8 chars to keep the name short.
+ * Derive a deterministic, tmux-safe, collision-resistant session name from
+ * `(clientId, agentId, chatId)`.
+ *
+ * The agent/chat component is a hash, not a truncated prefix: server agent ids
+ * are uuidv7, whose leading chars are a millisecond timestamp, so two agents
+ * created close together share the first 8 chars. Truncating would alias two
+ * distinct peer agents in the same chat to one session name — and `startClaude`
+ * kills any pre-existing session with that name, so one agent would tear down a
+ * peer's live pane. A 12-hex (48-bit) SHA-256 slice gives uniform entropy
+ * regardless of uuid structure; collisions are negligible. The output is hex
+ * only, so it is inherently tmux-safe (no `:`/`.`). The client-owner prefix is
+ * kept so the orphan sweep's prefix filter still matches.
  */
 export function deriveSessionName(clientId: string, agentId: string, chatId: string): string {
-  const a = sanitise(agentId).slice(0, 8);
-  const c = sanitise(chatId).slice(0, 8);
-  return `${ownedSessionPrefix(clientId)}${a}-${c}`;
+  const digest = createHash("sha256").update(`${agentId} ${chatId}`).digest("hex").slice(0, 12);
+  return `${ownedSessionPrefix(clientId)}${digest}`;
 }
 
 function sanitise(input: string): string {

--- a/packages/client/src/handlers/claude-code-tui/tmux-session.ts
+++ b/packages/client/src/handlers/claude-code-tui/tmux-session.ts
@@ -1,0 +1,189 @@
+import { spawn } from "node:child_process";
+import { mkdtempSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { READY_MARKER, TMUX_SESSION_PREFIX, USER_RE } from "./tui-markers.js";
+
+const DEFAULT_TMUX_TIMEOUT_MS = 5000;
+
+type TmuxResult = { ok: boolean; stdout: string; stderr: string; code: number | null };
+
+function runTmux(args: string[], timeoutMs = DEFAULT_TMUX_TIMEOUT_MS): Promise<TmuxResult> {
+  return new Promise((resolve) => {
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    const child = spawn("tmux", args, { stdio: ["ignore", "pipe", "pipe"] });
+    const timer = setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        child.kill("SIGKILL");
+        resolve({ ok: false, stdout, stderr: stderr + "\n[timeout]", code: null });
+      }
+    }, timeoutMs);
+    child.stdout.on("data", (b: Buffer) => {
+      stdout += b.toString("utf-8");
+    });
+    child.stderr.on("data", (b: Buffer) => {
+      stderr += b.toString("utf-8");
+    });
+    child.on("error", (err) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({ ok: false, stdout, stderr: stderr + (stderr ? "\n" : "") + err.message, code: null });
+    });
+    child.on("close", (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({ ok: code === 0, stdout, stderr, code });
+    });
+  });
+}
+
+async function tmuxOrThrow(args: string[], timeoutMs?: number): Promise<string> {
+  const result = await runTmux(args, timeoutMs);
+  if (!result.ok) {
+    throw new Error(`tmux ${args.join(" ")} failed (code=${result.code ?? "n/a"}): ${result.stderr.trim()}`);
+  }
+  return result.stdout;
+}
+
+export type NewSessionInput = {
+  name: string;
+  cwd: string;
+  command: string;
+  env?: Record<string, string>;
+  width?: number;
+  height?: number;
+};
+
+/**
+ * Spawn a detached tmux session running `command`. Returns once tmux reports
+ * the session started (note: the inner process may still be initialising).
+ */
+export async function newSession(input: NewSessionInput): Promise<void> {
+  const args = [
+    "new-session",
+    "-d",
+    "-s",
+    input.name,
+    "-x",
+    String(input.width ?? 220),
+    "-y",
+    String(input.height ?? 60),
+    "-c",
+    input.cwd,
+  ];
+  for (const [k, v] of Object.entries(input.env ?? {})) {
+    args.push("-e", `${k}=${v}`);
+  }
+  args.push(input.command);
+  await tmuxOrThrow(args);
+}
+
+/**
+ * Inject text into the session pane via bracketed paste, then send Enter.
+ *
+ * `load-buffer` writes the verbatim text into a tmux buffer; `paste-buffer
+ * -p` uses bracketed paste so multi-line content and shell metacharacters
+ * (\ ` $ etc.) are delivered without interpretation. A small delay before
+ * Enter avoids races where claude's reader misses the trailing newline.
+ */
+export async function pasteText(sessionName: string, text: string): Promise<void> {
+  const dir = mkdtempSync(join(tmpdir(), "ftth-tui-"));
+  const file = join(dir, "msg.txt");
+  writeFileSync(file, text, "utf-8");
+  const bufferName = `${sessionName}-msg`;
+  try {
+    await tmuxOrThrow(["load-buffer", "-b", bufferName, file]);
+    await tmuxOrThrow(["paste-buffer", "-b", bufferName, "-t", sessionName, "-p"]);
+    await new Promise((r) => setTimeout(r, 150));
+    await tmuxOrThrow(["send-keys", "-t", sessionName, "Enter"]);
+  } finally {
+    try {
+      unlinkSync(file);
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+/** Send a single key (e.g. `Escape`, `C-c`) to the session. */
+export async function sendKey(sessionName: string, key: string): Promise<void> {
+  await tmuxOrThrow(["send-keys", "-t", sessionName, key]);
+}
+
+/** Snapshot the visible pane (or full scrollback when `fullScrollback`). */
+export async function capturePane(sessionName: string, fullScrollback = false): Promise<string> {
+  const args = ["capture-pane", "-t", sessionName, "-p"];
+  if (fullScrollback) args.push("-S", "-");
+  return tmuxOrThrow(args);
+}
+
+/** True iff a tmux session with the given name exists. */
+export async function sessionExists(sessionName: string): Promise<boolean> {
+  const result = await runTmux(["has-session", "-t", sessionName]);
+  return result.ok;
+}
+
+/** Force-kill the tmux session; best-effort (no throw if already gone). */
+export async function killSession(sessionName: string): Promise<void> {
+  await runTmux(["kill-session", "-t", sessionName]);
+}
+
+/** List names of all tmux sessions on the local server. Returns [] if no server is running. */
+export async function listSessions(): Promise<string[]> {
+  const result = await runTmux(["list-sessions", "-F", "#{session_name}"]);
+  if (!result.ok) return [];
+  return result.stdout
+    .split("\n")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+/** List ftth-prefixed sessions only. */
+export async function listOwnedSessions(): Promise<string[]> {
+  const all = await listSessions();
+  return all.filter((name) => name.startsWith(TMUX_SESSION_PREFIX));
+}
+
+export type WaitForReadyInput = {
+  name: string;
+  timeoutMs?: number;
+  pollIntervalMs?: number;
+};
+
+/**
+ * Poll capture-pane until both the bypass-permissions marker and a `❯`
+ * input prompt line are visible. Resolves on success, throws on timeout.
+ */
+export async function waitForReady(input: WaitForReadyInput): Promise<void> {
+  const timeoutMs = input.timeoutMs ?? 30_000;
+  const pollIntervalMs = input.pollIntervalMs ?? 250;
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    const pane = await capturePane(input.name);
+    if (pane.includes(READY_MARKER) && pane.split("\n").some((line) => USER_RE.test(line))) {
+      return;
+    }
+    await new Promise((r) => setTimeout(r, pollIntervalMs));
+  }
+  throw new Error(`claude TUI did not become ready within ${timeoutMs}ms (session=${input.name})`);
+}
+
+/**
+ * Derive a deterministic, tmux-safe session name from `(agentId, chatId)`.
+ * tmux disallows `:` and `.` in session names — strip them out and cap at
+ * 32 chars so the name comfortably fits inside any tmux client display.
+ */
+export function deriveSessionName(agentId: string, chatId: string): string {
+  const a = sanitise(agentId).slice(0, 8);
+  const c = sanitise(chatId).slice(0, 8);
+  return `${TMUX_SESSION_PREFIX}${a}-${c}`;
+}
+
+function sanitise(input: string): string {
+  return input.replace(/[^A-Za-z0-9_-]/g, "").toLowerCase();
+}

--- a/packages/client/src/handlers/claude-code-tui/transcript-tail.ts
+++ b/packages/client/src/handlers/claude-code-tui/transcript-tail.ts
@@ -1,0 +1,178 @@
+import { closeSync, existsSync, openSync, readSync, realpathSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+
+/**
+ * Resolve Claude Code's per-session transcript path.
+ *
+ * Encoding: cwd's `/` and `.` are replaced by `-`, prefixed with `-`. So
+ * `/Users/alice/work.cd` becomes `-Users-alice-work-cd`. Verified empirically
+ * on macOS during the PoC; if claude changes this rule, this is the single
+ * point of update.
+ *
+ * Symlink note: claude derives the encoding from `process.cwd()` inside the
+ * spawned binary, which the kernel returns with symlinks resolved (e.g. on
+ * macOS `/var/folders/...` surfaces as `/private/var/folders/...`). Apply
+ * `realpath` here so the tailer points at the same file claude writes,
+ * even when the caller's `cwd` argument still contains an unresolved
+ * symlink component. Falls back to the input on realpath errors so the
+ * tailer can still operate against not-yet-created workspaces (the
+ * existsSync guard inside drainEntries handles the missing-file window).
+ *
+ * The file is created lazily by claude on first message flush, so consumers
+ * must tolerate `existsSync(path) === false` for a brief window after
+ * session start.
+ */
+export function transcriptPathFor(cwd: string, sessionId: string): string {
+  const absCwd = resolve(cwd);
+  let realCwd = absCwd;
+  try {
+    realCwd = realpathSync(absCwd);
+  } catch {
+    // realpath fails if the dir doesn't exist yet — fall back to the
+    // unresolved path; the caller may be racing dir creation.
+  }
+  const encoded = `-${realCwd.replace(/^\//, "").replace(/[/.]/g, "-")}`;
+  return join(homedir(), ".claude", "projects", encoded, `${sessionId}.jsonl`);
+}
+
+/** Raw transcript entry — the JSON object claude wrote, in Anthropic message-stream shape. */
+export type RawTranscriptEntry = {
+  type?: string;
+  message?: { content?: unknown };
+  timestamp?: string;
+  [key: string]: unknown;
+};
+
+/** Mapped event used by tests and for the askuser/text-accumulation paths in the handler. */
+export type TranscriptEvent =
+  | { kind: "user_text"; text: string; ts?: string }
+  | { kind: "assistant_text"; text: string; ts?: string }
+  | { kind: "tool_use"; toolUseId: string; name: string; input: unknown; ts?: string }
+  | { kind: "tool_result"; toolUseId: string; isError: boolean; content: unknown; ts?: string }
+  | { kind: "thinking"; text: string; ts?: string };
+
+type AnthropicBlock = {
+  type?: string;
+  text?: string;
+  id?: string;
+  name?: string;
+  input?: unknown;
+  tool_use_id?: string;
+  is_error?: boolean;
+  content?: unknown;
+  thinking?: string;
+};
+
+/**
+ * Convert one transcript entry into zero or more TranscriptEvents. Mostly
+ * used in tests; the live handler also uses it to pick out assistant text
+ * (for forwardResult) and AskUser tool_use blocks (for the text-degrade path).
+ */
+export function transcriptEntryToEvents(entry: RawTranscriptEntry): TranscriptEvent[] {
+  if (entry?.type === "user") {
+    const content = entry.message?.content;
+    if (Array.isArray(content)) {
+      const out: TranscriptEvent[] = [];
+      for (const blk of content as AnthropicBlock[]) {
+        if (blk.type === "tool_result") {
+          out.push({
+            kind: "tool_result",
+            toolUseId: blk.tool_use_id ?? "",
+            isError: blk.is_error === true,
+            content: blk.content,
+            ts: entry.timestamp,
+          });
+        }
+      }
+      return out;
+    }
+    if (typeof content === "string") {
+      return [{ kind: "user_text", text: content, ts: entry.timestamp }];
+    }
+    return [];
+  }
+  if (entry?.type === "assistant") {
+    const content = entry.message?.content;
+    if (!Array.isArray(content)) return [];
+    const out: TranscriptEvent[] = [];
+    for (const blk of content as AnthropicBlock[]) {
+      if (blk.type === "text" && typeof blk.text === "string") {
+        out.push({ kind: "assistant_text", text: blk.text, ts: entry.timestamp });
+      } else if (blk.type === "tool_use") {
+        out.push({
+          kind: "tool_use",
+          toolUseId: blk.id ?? "",
+          name: blk.name ?? "",
+          input: blk.input,
+          ts: entry.timestamp,
+        });
+      } else if (blk.type === "thinking" && typeof blk.thinking === "string") {
+        out.push({ kind: "thinking", text: blk.thinking, ts: entry.timestamp });
+      }
+    }
+    return out;
+  }
+  return [];
+}
+
+/**
+ * Tail an append-only JSONL transcript. Each `drainEntries()` returns raw
+ * entries appended since the last call. Tolerates the file not yet existing
+ * (returns empty), partial lines across reads, and malformed JSON (single
+ * bad line is skipped, not fatal).
+ *
+ * NOT thread-safe across instances — each session should own one tailer.
+ */
+export class TranscriptTailer {
+  private readonly path: string;
+  private offset = 0;
+  private partial = "";
+
+  constructor(path: string) {
+    this.path = path;
+  }
+
+  /** Read raw JSONL entries appended since the last call. Best-effort. */
+  drainEntries(): RawTranscriptEntry[] {
+    if (!existsSync(this.path)) return [];
+    const stat = statSync(this.path);
+    if (stat.size <= this.offset) return [];
+
+    const fd = openSync(this.path, "r");
+    let chunk = "";
+    try {
+      const buf = Buffer.allocUnsafe(stat.size - this.offset);
+      const read = readSync(fd, buf, 0, buf.length, this.offset);
+      this.offset += read;
+      chunk = this.partial + buf.subarray(0, read).toString("utf-8");
+    } finally {
+      closeSync(fd);
+    }
+
+    const parts = chunk.split("\n");
+    this.partial = parts.pop() ?? "";
+
+    const entries: RawTranscriptEntry[] = [];
+    for (const raw of parts) {
+      if (!raw.trim()) continue;
+      try {
+        entries.push(JSON.parse(raw) as RawTranscriptEntry);
+      } catch {
+        // skip malformed line
+      }
+    }
+    return entries;
+  }
+
+  /** Convenience wrapper: read entries and immediately map them to events. */
+  drainEvents(): TranscriptEvent[] {
+    const out: TranscriptEvent[] = [];
+    for (const entry of this.drainEntries()) {
+      for (const ev of transcriptEntryToEvents(entry)) {
+        out.push(ev);
+      }
+    }
+    return out;
+  }
+}

--- a/packages/client/src/handlers/claude-code-tui/tui-markers.ts
+++ b/packages/client/src/handlers/claude-code-tui/tui-markers.ts
@@ -1,0 +1,42 @@
+/**
+ * Magic strings the Claude Code TUI prints, centralised so future cosmetic
+ * drift in the TUI is a single-point change. Each glyph (`❯`, `⏺`, `⎿`, `✻`)
+ * is followed by a U+00A0 NBSP rather than ASCII space, so regexes use
+ * `[\s ]` to match either.
+ *
+ * Verified against the claude binary observed during the tmux-runtime PoC
+ * (see `experiments/tmux-claude-runtime/FINDINGS.md`).
+ */
+
+/** Pane shows this while a turn is in flight. Disappearance signals turn-end candidacy. */
+export const WORKING_MARKER = "esc to interrupt";
+
+/** Pane shows this while the AskUserQuestion selection menu is open. */
+export const ASKUSER_MENU_FOOTER = "Enter to select";
+
+/** Pane shows this after a successful `claude --dangerously-skip-permissions` start. */
+export const READY_MARKER = "bypass permissions on";
+
+/** Lines the user (or paste-buffer injection) put on screen. */
+export const USER_RE = /^❯[\s ]/;
+
+/** Lines the assistant emitted as visible reply text. */
+export const ASSISTANT_RE = /^⏺[\s ]/;
+
+/** Footer line claude prints below the latest assistant text — `✻ Churned for Ns`. */
+export const FOOTER_RE = /^✻[\s ]/;
+
+/** Tool-call box header inside the visible reply, e.g. `⏺ Bash(date +%s)`. */
+export const TOOL_BOX_HEADER_RE = /^⏺[\s ]+[A-Za-z][A-Za-z0-9_-]*\([^)]*\)\s*$/;
+
+/** Continuation line inside a tool-call box, e.g. `  ⎿ Result text`. */
+export const TOOL_BOX_CONT_RE = /^\s+⎿\s/;
+
+/** Tool name claude renders for the AskUser tool. */
+export const ASKUSER_TOOL_NAME = "AskUserQuestion";
+
+/** All tmux sessions we own start with this prefix; orphan sweep filters by it. */
+export const TMUX_SESSION_PREFIX = "ftth-";
+
+/** Sentinel claude writes to the transcript when a tool_use was cancelled via Escape. */
+export const TOOL_INTERRUPT_SENTINEL = "[Request interrupted by user for tool use]";

--- a/packages/client/src/handlers/claude-code-tui/turn-disposition.ts
+++ b/packages/client/src/handlers/claude-code-tui/turn-disposition.ts
@@ -1,0 +1,63 @@
+/**
+ * How a single TUI turn ended. The boolean flags are mutually compatible
+ * (e.g. a turn can both time out and have a forward failure); the disposition
+ * resolves them into the three observable outcomes the runtime cares about.
+ */
+export type TurnOutcome = {
+  /** suspend()/shutdown() aborted the turn — it must re-run on resume. */
+  aborted: boolean;
+  /**
+   * The poll loop hit TURN_TIMEOUT_MS without claude reaching idle and without
+   * an explicit abort — claude was interrupted mid-flight, so the turn's
+   * outcome is unknown.
+   */
+  timedOut: boolean;
+  /** The runTurn body threw (e.g. the tmux session died). */
+  turnFailed: boolean;
+  /** forwardResult threw while delivering the assistant text. */
+  forwardFailed: boolean;
+};
+
+export type TurnDisposition = {
+  /** Status reported on the `turn_end` event. */
+  status: "success" | "error";
+  /**
+   * Whether to `markCompleted` (ack the triggering inbox entries). The runtime
+   * never auto-acks on turn_end, so a false here leaves the entries in-flight
+   * for at-least-once redelivery.
+   */
+  ack: boolean;
+  /** Runtime state to settle into after the turn. */
+  runtimeState: "idle" | "error";
+};
+
+/**
+ * Resolve how a finished turn is reported and acked.
+ *
+ * The reliability-critical rule (PR #712 review round 3): a **timed-out** turn
+ * is NOT a success. claude was interrupted before reaching idle, so we cannot
+ * confirm the work completed. Acking it would silently consume the user's
+ * message with no replay path — exactly the bug this function guards. So a
+ * timeout reports `turn_end: error`, leaves the inbox entries un-acked (the
+ * server redelivers them on reconnect/restart for a genuine retry), and surfaces
+ * an `error` runtime state.
+ *
+ * Ack policy otherwise mirrors the SDK handler's `ackTurnClose`: a clean close
+ * acks even on a plain forward failure (claude finished; re-running yields the
+ * same result, so acking avoids a redelivery storm). Only `aborted` (suspend)
+ * and `timedOut` withhold the ack.
+ *
+ * `aborted` keeps the pre-existing semantics: it is a deliberate suspend, not a
+ * failure, so it does not flip the status to error on its own — it only
+ * withholds the ack so the message re-runs on resume.
+ */
+export function resolveTurnDisposition(outcome: TurnOutcome): TurnDisposition {
+  const { aborted, timedOut, turnFailed, forwardFailed } = outcome;
+  return {
+    status: turnFailed || forwardFailed || timedOut ? "error" : "success",
+    ack: !aborted && !timedOut,
+    // A broken (turnFailed) or interrupted (timedOut) session is advertised as
+    // error; a forward-only failure leaves the session healthy, so it stays idle.
+    runtimeState: turnFailed || timedOut ? "error" : "idle",
+  };
+}

--- a/packages/client/src/handlers/claude-code-tui/turn-disposition.ts
+++ b/packages/client/src/handlers/claude-code-tui/turn-disposition.ts
@@ -27,6 +27,13 @@ export type TurnDisposition = {
    * for at-least-once redelivery.
    */
   ack: boolean;
+  /**
+   * Whether to deliver the assistant text to chat (`forwardResult`). Tracks
+   * `ack`: we only post output for a turn we are consuming. A turn that will
+   * re-run (abort/timeout) must NOT forward partial output, or the chat
+   * double-posts once the replay produces the real answer.
+   */
+  forward: boolean;
   /** Runtime state to settle into after the turn. */
   runtimeState: "idle" | "error";
 };
@@ -53,9 +60,14 @@ export type TurnDisposition = {
  */
 export function resolveTurnDisposition(outcome: TurnOutcome): TurnDisposition {
   const { aborted, timedOut, turnFailed, forwardFailed } = outcome;
+  // Consume the turn (ack + deliver its output) only when it is NOT going to
+  // re-run. abort (suspend) and timeout both leave the entries un-acked for a
+  // replay, so neither acks nor forwards — otherwise the replay double-posts.
+  const consume = !aborted && !timedOut;
   return {
     status: turnFailed || forwardFailed || timedOut ? "error" : "success",
-    ack: !aborted && !timedOut,
+    ack: consume,
+    forward: consume,
     // A broken (turnFailed) or interrupted (timedOut) session is advertised as
     // error; a forward-only failure leaves the session healthy, so it stays idle.
     runtimeState: turnFailed || timedOut ? "error" : "idle",

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
@@ -15,43 +15,22 @@ import type {
 import { query as claudeQuery } from "@anthropic-ai/claude-agent-sdk";
 import type { AgentRuntimeConfigPayload, SessionEvent, SupportedImageMime } from "@first-tree/shared";
 import {
-  deriveRepoLocalPath,
   isImageBatchRefContent,
   isImageRefContent,
   SUPPORTED_IMAGE_MIMES as SHARED_SUPPORTED_IMAGE_MIMES,
 } from "@first-tree/shared";
+import { ensureAgentBootstrap as ensureAgentBootstrapShared } from "../runtime/agent-bootstrap.js";
 import type { AgentConfigCache } from "../runtime/agent-config-cache.js";
-import {
-  bootstrapWorkspace,
-  buildChatSystemPrompt,
-  deepEqualIdentity,
-  installCoreSkills,
-  installFirstTreeIntegration,
-  isHubWorktreeMarker,
-  type PredeclaredSourceRepo,
-  readCachedBundledCliVersion,
-  readCachedContextTreeHead,
-  readContextTreeHead,
-  resolveBundledCliVersion,
-  writeBundledCliVersion,
-  writeContextTreeHead,
-} from "../runtime/bootstrap.js";
+import { buildChatSystemPrompt, type PredeclaredSourceRepo } from "../runtime/bootstrap.js";
 import { type ChatContext, fetchChatContext } from "../runtime/chat-context.js";
 import { getCliBinding } from "../runtime/cli-binding.js";
 import { classify } from "../runtime/error-taxonomy.js";
-import { resolveGitRepoTargetPath } from "../runtime/git-local-path.js";
-import { deriveSessionBranchName, type GitMirrorManager } from "../runtime/git-mirror-manager.js";
-import type {
-  AgentHandler,
-  AgentIdentity,
-  HandlerFactory,
-  SessionContext,
-  SessionMessage,
-} from "../runtime/handler.js";
+import type { GitMirrorManager } from "../runtime/git-mirror-manager.js";
+import type { AgentHandler, HandlerFactory, SessionContext, SessionMessage } from "../runtime/handler.js";
 import { findImagePath } from "../runtime/image-store.js";
 import { InputController } from "../runtime/input-controller.js";
-import { acquireAgentHome, INIT_COMPLETE_SENTINEL_REL, markWorkspaceInitComplete } from "../runtime/workspace.js";
-import { withWorktreePathLock } from "../runtime/worktree-mutex.js";
+import { prepareSourceRepos as prepareSourceReposShared } from "../runtime/source-repos.js";
+import { acquireAgentHome, markWorkspaceInitComplete } from "../runtime/workspace.js";
 import { formatAuthHint, isClaudeAuthError } from "./auth-error-hint.js";
 import { resolveClaudeCodeExecutable } from "./claude-executable.js";
 
@@ -1352,82 +1331,16 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
     payload: AgentRuntimeConfigPayload | undefined,
     sessionCtx: SessionContext,
   ): Promise<void> {
-    // Reset the prompt-facing list. If `gitRepos` is empty (or the manager
-    // isn't wired up), the agent simply gets no source-repos section.
-    sourceReposForPrompt = [];
-
-    if (!gitMirrorManager || !payload?.gitRepos?.length) return;
-
-    for (const repo of payload.gitRepos) {
-      const localPath = repo.localPath ?? deriveRepoLocalPath(repo.url);
-      // Source repos live at the TOP LEVEL of the agent home — no
-      // `worktrees/` prefix. The `worktrees/` subdir is reserved for the
-      // agent's on-demand worktrees.
-      const targetPath = resolveGitRepoTargetPath(workspace, localPath);
-      sessionCtx.log(`Git: preparing source repo ${repo.url} → ${localPath}${repo.ref ? ` @ ${repo.ref}` : ""}`);
-
-      // D14: ensureMirror is idempotent — clone once, fast return thereafter.
-      const mirror = await gitMirrorManager.ensureMirror(repo.url);
-      if (mirror.cloned) {
-        sessionCtx.log(`Git: cloned ${repo.url} in ${mirror.elapsedMs}ms`);
-      }
-
-      // D10: fresh fetch on every new dialog. Failure aborts session creation.
-      await gitMirrorManager.fetchMirror(repo.url);
-
-      const branchAgentKey = agentName ?? sessionCtx.agent.agentId;
-
-      // Serialise per absolute path so two concurrent sessions for the same
-      // agent can't both try to create the same checkout.
-      const { branchName } = await withWorktreePathLock(targetPath, async () => {
-        if (existsSync(targetPath)) {
-          if (isHubWorktreeMarker(targetPath)) {
-            sessionCtx.log(`Git: reusing existing source repo at ${localPath}`);
-            // Reuse path: branchName is deterministic for cleanup. With the
-            // per-agent shared-checkout model, sessionKey is the agentName
-            // (not chatId) so a checkout created by chat A is reused by
-            // chat B without forking branches.
-            return {
-              branchName: deriveSessionBranchName(branchAgentKey, branchAgentKey, repo.url),
-              headCommit: null as string | null,
-            };
-          }
-          // Path occupied by a non-First Tree directory (operator placed it, leftover
-          // from an old layout, etc). Log it explicitly — `createWorktree`
-          // below will likely fail with a generic "path exists" error, and
-          // without this line the operator has no way to know why. PR #506
-          // review S1.
-          sessionCtx.log(
-            `Git: source-repo target ${localPath} occupied by a non-First Tree directory; ` +
-              "createWorktree will likely fail — move or remove the directory and re-run",
-          );
-        }
-        const created = await gitMirrorManager.createWorktree({
-          url: repo.url,
-          ref: repo.ref,
-          targetPath,
-          // sessionKey identifies the branch *owner*. In the per-agent-home
-          // model the owner is the agent, not the chat.
-          sessionKey: branchAgentKey,
-          agentName: branchAgentKey,
-        });
-        return { branchName: created.branchName, headCommit: created.headCommit as string | null };
-      });
-
-      // Per agent-session-cwd-redesign: predeclared source repos are agent-
-      // scoped persistent resources. They survive shutdown so the next chat
-      // finds them ready. We therefore do NOT track them in `ownedWorktrees`
-      // (the legacy shutdown-cleanup list).
-
-      sourceReposForPrompt.push({
-        absolutePath: targetPath,
-        url: repo.url,
-        ...(repo.ref ? { ref: repo.ref } : {}),
-        branch: branchName,
-      });
-
-      sessionCtx.log(`Git: source repo at ${localPath} on ${branchName}`);
-    }
+    // Delegates to the shared helper (runtime/source-repos.ts) so the SDK and
+    // TUI handlers share one worktree-lock / Hub-marker implementation rather
+    // than each carrying its own source-repo invariant.
+    sourceReposForPrompt = await prepareSourceReposShared({
+      workspace,
+      payload,
+      sessionCtx,
+      gitMirrorManager,
+      agentName,
+    });
   }
 
   /** Tear down all worktrees this session owns; best-effort. */
@@ -1498,47 +1411,6 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
   }
 
   /**
-   * Hash-check the existing identity.json against the current agent metadata
-   * and rewrite it (plus the rest of the .agent/ stable section) only when
-   * something changed. Cheap to run on every session start — the typical
-   * path is a single readFileSync + JSON.parse + memcmp.
-   *
-   * R5 in the proposal: agent rename / inboxId change / metadata edits must
-   * still propagate even after the sentinel is set, so this runs OUT of the
-   * sentinel gate.
-   */
-  function ensureStableIdentity(workspace: string, sessionCtx: SessionContext): void {
-    const identityPath = join(workspace, ".agent", "identity.json");
-    const desired = {
-      agentId: sessionCtx.agent.agentId,
-      displayName: sessionCtx.agent.displayName,
-      type: sessionCtx.agent.type,
-      delegateMention: sessionCtx.agent.delegateMention,
-      metadata: sessionCtx.agent.metadata,
-      serverUrl: sessionCtx.sdk.serverUrl,
-      contextTreePath,
-    };
-    if (existsSync(identityPath)) {
-      try {
-        const current = JSON.parse(readFileSync(identityPath, "utf-8"));
-        if (deepEqualIdentity(current, desired)) return;
-      } catch {
-        // Corrupt JSON — fall through to rewrite via bootstrapWorkspace.
-      }
-    }
-    // Mismatch (or missing / corrupt) — re-run the full stable bootstrap so
-    // context/, tools.md, the boundary marker, and identity.json all line up
-    // with the current agent metadata. Cheap relative to integrate / git.
-    bootstrapWorkspace({
-      workspacePath: workspace,
-      identity: sessionCtx.agent,
-      contextTreePath,
-      serverUrl: sessionCtx.sdk.serverUrl,
-    });
-    generateStableClaudeMd(workspace, sessionCtx.agent, contextTreePath);
-  }
-
-  /**
    * Run the expensive first-time bootstrap (full stable layout + `first-tree
    * tree integrate` shell-out). Gated by the stage-2 sentinel + Context-Tree
    * HEAD drift detection (proposals/agent-session-cwd-redesign §⑤.3):
@@ -1552,87 +1424,10 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
    * directory is per-agent, so the skill identity stays stable across chats.
    */
   function ensureAgentBootstrap(workspace: string, sessionCtx: SessionContext): void {
-    const sentinelPresent = existsSync(join(workspace, INIT_COMPLETE_SENTINEL_REL));
-    const currentTreeHead = readContextTreeHead(contextTreePath);
-    const cachedTreeHead = readCachedContextTreeHead(workspace);
-    // Only treat as drift when we know both values AND they differ — `null`
-    // on either side means "we don't know", in which case we fall back to
-    // the sentinel-only decision (fail open). Warn when the asymmetry shows
-    // up so a transient `git rev-parse` failure doesn't silently disable
-    // drift detection (PR #506 review Q1).
-    if (cachedTreeHead !== null && currentTreeHead === null) {
-      sessionCtx.log(
-        `Context Tree HEAD probe returned null while cached value is ` +
-          `${cachedTreeHead.slice(0, 7)}; drift detection bypassed for this start`,
-      );
-    }
-    const treeDrifted = currentTreeHead !== null && cachedTreeHead !== null && currentTreeHead !== cachedTreeHead;
-
-    // CLI-version drift forces a fresh `installFirstTreeIntegration` so the
-    // shipped `.agents/skills/*` payload tracks `first-tree upgrade` even
-    // when the Context Tree HEAD is unchanged. Same "fail open" rule as
-    // tree drift: a null on either side means "unknown" and we do not
-    // force re-bootstrap.
-    const currentCliVersion = resolveBundledCliVersion();
-    const cachedCliVersion = readCachedBundledCliVersion(workspace);
-    const cliDrifted =
-      currentCliVersion !== null && cachedCliVersion !== null && currentCliVersion !== cachedCliVersion;
-
-    if (sentinelPresent && !treeDrifted && !cliDrifted) {
-      ensureStableIdentity(workspace, sessionCtx);
-      return;
-    }
-
-    if (sentinelPresent && treeDrifted) {
-      sessionCtx.log(
-        `Context Tree HEAD changed (${cachedTreeHead?.slice(0, 7)} → ${currentTreeHead?.slice(0, 7)}); re-running bootstrap`,
-      );
-    }
-    if (sentinelPresent && cliDrifted) {
-      sessionCtx.log(
-        `Bundled CLI version changed (${cachedCliVersion} → ${currentCliVersion}); re-running bootstrap to refresh skills`,
-      );
-    }
-
-    bootstrapWorkspace({
-      workspacePath: workspace,
-      identity: sessionCtx.agent,
-      contextTreePath,
-      serverUrl: sessionCtx.sdk.serverUrl,
-    });
-    generateStableClaudeMd(workspace, sessionCtx.agent, contextTreePath);
-
-    // Core skills (`attention`) ship with every agent, with or without a
-    // Context Tree. The slimmed `tools.md` injected by bootstrap only
-    // carries a pointer at `attention/SKILL.md`, so the on-disk payload
-    // has to exist before the agent's first turn — degrade gracefully
-    // when the CLI is unavailable; the integration install below will
-    // also install attention as part of `tree integrate` for tree-bound
-    // agents, so we have a backup path.
-    installCoreSkills({
-      workspacePath: workspace,
-      log: (msg) => sessionCtx.log(msg),
-    });
-
-    let integrationOk = true;
-    if (contextTreePath) {
-      integrationOk = installFirstTreeIntegration({
-        workspacePath: workspace,
-        contextTreePath,
-        workspaceId: agentName ?? sessionCtx.agent.agentId,
-        treeRepoUrl: contextTreeRepoUrl ?? undefined,
-        log: (msg) => sessionCtx.log(msg),
-      });
-    }
-
-    // Pin the current HEAD so the next start can detect drift.
-    writeContextTreeHead(workspace, currentTreeHead);
-    // Only pin the CLI version when integrate actually succeeded — pinning
-    // on a failed run would silently mask the gap and the next start would
-    // skip the retry that this drift trigger exists to perform.
-    if (integrationOk) {
-      writeBundledCliVersion(workspace, currentCliVersion);
-    }
+    // Delegates to the shared helper (runtime/agent-bootstrap.ts) so the SDK
+    // and TUI handlers share one briefing / core-skill / drift-pin contract
+    // rather than each maintaining a partial copy.
+    ensureAgentBootstrapShared({ workspace, sessionCtx, contextTreePath, contextTreeRepoUrl, agentName });
   }
 
   const handler: AgentHandler = {
@@ -1854,77 +1649,3 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
 
   return handler;
 };
-
-/**
- * Generate a CLAUDE.md file from .agent/ bootstrap data.
- *
- * Layer 1 (always): Agent identity (from First Tree)
- * Layer 2 (if Context Tree configured): Operating instructions + domain map
- * Layer 3 (if Context Tree configured): Context Tree location for on-demand reading
- *
- * Per PRD D7 the agent's behavior instructions live in server-managed
- * `agent_configs.payload.prompt.append` and are passed to the Claude SDK via
- * `systemPrompt.append` — not through this file.
- */
-/**
- * Generate the **stable** CLAUDE.md materialised at the agent home root.
- *
- * Per agent-session-cwd-redesign: this file contains only agent-level
- * content (identity, org domain map, Context Tree pointer, SDK tools). Per-
- * chat content — Current Chat Context, participants — is injected per turn
- * via the SDK's `appendSystemPrompt` so two concurrent chats sharing this
- * cwd never see each other's data on disk.
- *
- * Per PRD D7 the agent's behavior instructions live in server-managed
- * `agent_configs.payload.prompt.append` and are passed to the Claude SDK via
- * `systemPrompt.append` — not through this file.
- */
-function generateStableClaudeMd(workspacePath: string, identity: AgentIdentity, contextTreePath: string | null): void {
-  const sections: string[] = [];
-  const contextDir = join(workspacePath, ".agent", "context");
-
-  // --- Identity ---
-  // Post-type-merge (migration 0051): pre-merge `personal_assistant` and
-  // `autonomous_agent` collapsed into a single `agent` row. The "personal
-  // assistant" vs. "autonomous bot" framing is now carried by
-  // `agents.visibility` (private → personal assistant, organization →
-  // autonomous bot). Do NOT infer from `delegateMention` — only `human`
-  // rows can hold a delegate, so every `agent` row's `delegateMention`
-  // is null and that signal is useless for this distinction.
-  const name = identity.displayName ?? identity.agentId;
-  if (identity.visibility === "private") {
-    sections.push(`# Agent Identity\n\nYou are ${name}, a personal assistant agent.\n`);
-  } else {
-    sections.push(`# Agent Identity\n\nYou are ${name}, an autonomous agent.\n`);
-  }
-
-  // --- Context Tree operating instructions (AGENT.md) ---
-  const agentInstructionsPath = join(contextDir, "agent-instructions.md");
-  if (existsSync(agentInstructionsPath)) {
-    const instructions = readFileSync(agentInstructionsPath, "utf-8");
-    sections.push(`## Operating Instructions\n\n${instructions}\n`);
-  }
-
-  // --- Organization domain map (root NODE.md) ---
-  const domainMapPath = join(contextDir, "domain-map.md");
-  if (existsSync(domainMapPath)) {
-    const domainMap = readFileSync(domainMapPath, "utf-8");
-    sections.push(`## Organization Domain Map\n\n${domainMap}\n`);
-  }
-
-  // --- Context Tree location for on-demand reading ---
-  if (contextTreePath) {
-    sections.push(
-      `## Context Tree Location\n\nThe full Context Tree is available at: \`${contextTreePath}\`\n\nRead specific domain nodes as needed following the operating instructions above.\n`,
-    );
-  }
-
-  // --- SDK tools reference ---
-  const toolsPath = join(workspacePath, ".agent", "tools.md");
-  if (existsSync(toolsPath)) {
-    const toolsContent = readFileSync(toolsPath, "utf-8");
-    sections.push(toolsContent);
-  }
-
-  writeFileSync(join(workspacePath, "CLAUDE.md"), sections.join("\n"), "utf-8");
-}

--- a/packages/client/src/handlers/index.ts
+++ b/packages/client/src/handlers/index.ts
@@ -1,5 +1,6 @@
 import { registerHandler } from "../runtime/handler.js";
 import { createClaudeCodeHandler } from "./claude-code.js";
+import { createClaudeCodeTuiHandler } from "./claude-code-tui/index.js";
 import { resolveClaudeCodeExecutable } from "./claude-executable.js";
 import { createCodexHandler } from "./codex.js";
 
@@ -15,6 +16,13 @@ export function registerBuiltinHandlers(): void {
   }
   registerHandler("claude-code", (config) =>
     createClaudeCodeHandler({ ...config, claudeCodeExecutable: resolution.path }),
+  );
+  // claude-code-tui: drives the Claude Code TUI through tmux. Replaces the
+  // SDK-based handler for the post-SDK-sunset world. Requires `tmux` >= 3.0
+  // and `claude` resolvable on PATH (capability probe in
+  // `runtime/capabilities/claude-code-tui.ts` enforces both).
+  registerHandler("claude-code-tui", (config) =>
+    createClaudeCodeTuiHandler({ ...config, claudeCodeExecutable: resolution.path }),
   );
   // Codex SDK bundles the codex CLI binary inside the npm package — no PATH
   // resolution needed. The handler factory consumes the same HandlerConfig

--- a/packages/client/src/runtime/agent-bootstrap.ts
+++ b/packages/client/src/runtime/agent-bootstrap.ts
@@ -158,7 +158,16 @@ export function ensureAgentBootstrap(params: AgentBootstrapParams): void {
   const cachedCliVersion = readCachedBundledCliVersion(workspace);
   const cliDrifted = currentCliVersion !== null && cachedCliVersion !== null && currentCliVersion !== cachedCliVersion;
 
-  if (sentinelPresent && !treeDrifted && !cliDrifted) {
+  // A tree-bound agent only pins its CLI version after `installFirstTreeIntegration`
+  // SUCCEEDS (see the integrationOk gate below). So a missing CLI pin on a
+  // tree-bound agent means integration has never succeeded — force the slow
+  // path to retry it rather than freezing behind the sentinel without skills /
+  // briefing. Guard on `currentCliVersion !== null`: when the CLI version is
+  // unknown we can't pin one anyway, so fall back to the sentinel-only decision
+  // (no perpetual re-integration in version-less environments).
+  const integrationNeverPinned = contextTreePath !== null && currentCliVersion !== null && cachedCliVersion === null;
+
+  if (sentinelPresent && !treeDrifted && !cliDrifted && !integrationNeverPinned) {
     ensureStableIdentity(workspace, sessionCtx, contextTreePath);
     return;
   }

--- a/packages/client/src/runtime/agent-bootstrap.ts
+++ b/packages/client/src/runtime/agent-bootstrap.ts
@@ -1,0 +1,211 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  bootstrapWorkspace,
+  deepEqualIdentity,
+  installCoreSkills,
+  installFirstTreeIntegration,
+  readCachedBundledCliVersion,
+  readCachedContextTreeHead,
+  readContextTreeHead,
+  resolveBundledCliVersion,
+  writeBundledCliVersion,
+  writeContextTreeHead,
+} from "./bootstrap.js";
+import type { AgentIdentity, SessionContext } from "./handler.js";
+import { INIT_COMPLETE_SENTINEL_REL } from "./workspace.js";
+
+export type AgentBootstrapParams = {
+  workspace: string;
+  sessionCtx: SessionContext;
+  contextTreePath: string | null;
+  contextTreeRepoUrl: string | null;
+  /** Stable workspace id for the integrate shell-out; falls back to agent id. */
+  agentName: string | null;
+};
+
+/**
+ * Generate the **stable** CLAUDE.md materialised at the agent home root.
+ *
+ * Per agent-session-cwd-redesign: this file contains only agent-level content
+ * (identity, org domain map, Context Tree pointer, tools reference). Per-chat
+ * content is injected per turn (via the SDK `appendSystemPrompt` or the TUI
+ * `--append-system-prompt`) so two concurrent chats sharing this cwd never see
+ * each other's data on disk.
+ *
+ * Per PRD D7 the agent's behavior instructions live in server-managed
+ * `agent_configs.payload.prompt.append`, not in this file.
+ */
+export function generateStableClaudeMd(
+  workspacePath: string,
+  identity: AgentIdentity,
+  contextTreePath: string | null,
+): void {
+  const sections: string[] = [];
+  const contextDir = join(workspacePath, ".agent", "context");
+
+  // --- Identity ---
+  // Post-type-merge (migration 0051): the "personal assistant" vs "autonomous
+  // bot" framing is carried by `agents.visibility`, not `delegateMention`.
+  const name = identity.displayName ?? identity.agentId;
+  if (identity.visibility === "private") {
+    sections.push(`# Agent Identity\n\nYou are ${name}, a personal assistant agent.\n`);
+  } else {
+    sections.push(`# Agent Identity\n\nYou are ${name}, an autonomous agent.\n`);
+  }
+
+  // --- Context Tree operating instructions (AGENT.md) ---
+  const agentInstructionsPath = join(contextDir, "agent-instructions.md");
+  if (existsSync(agentInstructionsPath)) {
+    const instructions = readFileSync(agentInstructionsPath, "utf-8");
+    sections.push(`## Operating Instructions\n\n${instructions}\n`);
+  }
+
+  // --- Organization domain map (root NODE.md) ---
+  const domainMapPath = join(contextDir, "domain-map.md");
+  if (existsSync(domainMapPath)) {
+    const domainMap = readFileSync(domainMapPath, "utf-8");
+    sections.push(`## Organization Domain Map\n\n${domainMap}\n`);
+  }
+
+  // --- Context Tree location for on-demand reading ---
+  if (contextTreePath) {
+    sections.push(
+      `## Context Tree Location\n\nThe full Context Tree is available at: \`${contextTreePath}\`\n\nRead specific domain nodes as needed following the operating instructions above.\n`,
+    );
+  }
+
+  // --- Tools reference ---
+  const toolsPath = join(workspacePath, ".agent", "tools.md");
+  if (existsSync(toolsPath)) {
+    const toolsContent = readFileSync(toolsPath, "utf-8");
+    sections.push(toolsContent);
+  }
+
+  writeFileSync(join(workspacePath, "CLAUDE.md"), sections.join("\n"), "utf-8");
+}
+
+/**
+ * Hash-check the existing identity.json against current agent metadata and
+ * rewrite the stable `.agent/` section + CLAUDE.md only when something changed.
+ * Runs OUT of the sentinel gate so agent rename / inboxId / metadata edits
+ * still propagate after first bootstrap (proposal R5).
+ */
+function ensureStableIdentity(workspace: string, sessionCtx: SessionContext, contextTreePath: string | null): void {
+  const identityPath = join(workspace, ".agent", "identity.json");
+  const desired = {
+    agentId: sessionCtx.agent.agentId,
+    displayName: sessionCtx.agent.displayName,
+    type: sessionCtx.agent.type,
+    delegateMention: sessionCtx.agent.delegateMention,
+    metadata: sessionCtx.agent.metadata,
+    serverUrl: sessionCtx.sdk.serverUrl,
+    contextTreePath,
+  };
+  if (existsSync(identityPath)) {
+    try {
+      const current = JSON.parse(readFileSync(identityPath, "utf-8"));
+      if (deepEqualIdentity(current, desired)) return;
+    } catch {
+      // Corrupt JSON — fall through to rewrite via bootstrapWorkspace.
+    }
+  }
+  // Mismatch (or missing / corrupt) — re-run the stable bootstrap so context/,
+  // tools.md, the boundary marker, and identity.json line up with the current
+  // agent metadata. Cheap relative to integrate / git.
+  bootstrapWorkspace({
+    workspacePath: workspace,
+    identity: sessionCtx.agent,
+    contextTreePath,
+    serverUrl: sessionCtx.sdk.serverUrl,
+  });
+  generateStableClaudeMd(workspace, sessionCtx.agent, contextTreePath);
+}
+
+/**
+ * Run the agent-home bootstrap that every Claude-driven handler shares: stable
+ * `.agent/` layout + CLAUDE.md briefing, core-skill install, and (for
+ * Context-Tree-bound agents) `first-tree tree integrate`. Gated by the stage-2
+ * sentinel + Context-Tree-HEAD / CLI-version drift detection so a changed tree
+ * or a `first-tree upgrade` forces a refresh, while the steady-state path is a
+ * cheap identity check.
+ *
+ * Extracted from the claude-code SDK handler so the claude-code-tui handler
+ * gets the identical briefing/skill/drift contract instead of a partial copy.
+ */
+export function ensureAgentBootstrap(params: AgentBootstrapParams): void {
+  const { workspace, sessionCtx, contextTreePath, contextTreeRepoUrl, agentName } = params;
+
+  const sentinelPresent = existsSync(join(workspace, INIT_COMPLETE_SENTINEL_REL));
+  const currentTreeHead = readContextTreeHead(contextTreePath);
+  const cachedTreeHead = readCachedContextTreeHead(workspace);
+  // Only treat as drift when both values are known AND differ — `null` on
+  // either side means "unknown", so we fall back to the sentinel-only decision
+  // (fail open). Warn on the asymmetry so a transient `git rev-parse` failure
+  // doesn't silently disable drift detection.
+  if (cachedTreeHead !== null && currentTreeHead === null) {
+    sessionCtx.log(
+      `Context Tree HEAD probe returned null while cached value is ` +
+        `${cachedTreeHead.slice(0, 7)}; drift detection bypassed for this start`,
+    );
+  }
+  const treeDrifted = currentTreeHead !== null && cachedTreeHead !== null && currentTreeHead !== cachedTreeHead;
+
+  // CLI-version drift forces a fresh `installFirstTreeIntegration` so the
+  // shipped skills payload tracks `first-tree upgrade` even when the Context
+  // Tree HEAD is unchanged. Same fail-open rule as tree drift.
+  const currentCliVersion = resolveBundledCliVersion();
+  const cachedCliVersion = readCachedBundledCliVersion(workspace);
+  const cliDrifted = currentCliVersion !== null && cachedCliVersion !== null && currentCliVersion !== cachedCliVersion;
+
+  if (sentinelPresent && !treeDrifted && !cliDrifted) {
+    ensureStableIdentity(workspace, sessionCtx, contextTreePath);
+    return;
+  }
+
+  if (sentinelPresent && treeDrifted) {
+    sessionCtx.log(
+      `Context Tree HEAD changed (${cachedTreeHead?.slice(0, 7)} → ${currentTreeHead?.slice(0, 7)}); re-running bootstrap`,
+    );
+  }
+  if (sentinelPresent && cliDrifted) {
+    sessionCtx.log(
+      `Bundled CLI version changed (${cachedCliVersion} → ${currentCliVersion}); re-running bootstrap to refresh skills`,
+    );
+  }
+
+  bootstrapWorkspace({
+    workspacePath: workspace,
+    identity: sessionCtx.agent,
+    contextTreePath,
+    serverUrl: sessionCtx.sdk.serverUrl,
+  });
+  generateStableClaudeMd(workspace, sessionCtx.agent, contextTreePath);
+
+  // Core skills (`attention`) ship with every agent, tree or not — the slimmed
+  // tools.md only carries a pointer, so the payload must exist before the first
+  // turn. Degrade gracefully when the CLI is unavailable.
+  installCoreSkills({
+    workspacePath: workspace,
+    log: (msg) => sessionCtx.log(msg),
+  });
+
+  let integrationOk = true;
+  if (contextTreePath) {
+    integrationOk = installFirstTreeIntegration({
+      workspacePath: workspace,
+      contextTreePath,
+      workspaceId: agentName ?? sessionCtx.agent.agentId,
+      treeRepoUrl: contextTreeRepoUrl ?? undefined,
+      log: (msg) => sessionCtx.log(msg),
+    });
+  }
+
+  // Pin the current HEAD so the next start can detect drift.
+  writeContextTreeHead(workspace, currentTreeHead);
+  // Only pin the CLI version when integrate actually succeeded — pinning on a
+  // failed run would mask the gap and skip the retry this trigger exists for.
+  if (integrationOk) {
+    writeBundledCliVersion(workspace, currentCliVersion);
+  }
+}

--- a/packages/client/src/runtime/agent-slot.ts
+++ b/packages/client/src/runtime/agent-slot.ts
@@ -212,6 +212,11 @@ export class AgentSlot {
           contextTreePath: contextTreeBinding?.path,
           contextTreeRepoUrl: contextTreeBinding?.repoUrl,
           gitMirrorManager,
+          // Identifies the owning client process. The claude-code-tui handler
+          // uses it to scope tmux session ownership (orphan sweep / names) so
+          // it never touches another live client's sessions. Other handlers
+          // ignore it.
+          clientId: this.clientConnection.clientId,
         },
         agentIdentity: {
           agentId: agent.agentId,

--- a/packages/client/src/runtime/source-repos.ts
+++ b/packages/client/src/runtime/source-repos.ts
@@ -1,0 +1,106 @@
+import { existsSync } from "node:fs";
+import { type AgentRuntimeConfigPayload, deriveRepoLocalPath } from "@first-tree/shared";
+import { isHubWorktreeMarker, type PredeclaredSourceRepo } from "./bootstrap.js";
+import { resolveGitRepoTargetPath } from "./git-local-path.js";
+import { deriveSessionBranchName, type GitMirrorManager } from "./git-mirror-manager.js";
+import type { SessionContext } from "./handler.js";
+import { withWorktreePathLock } from "./worktree-mutex.js";
+
+export type PrepareSourceReposParams = {
+  workspace: string;
+  payload: AgentRuntimeConfigPayload | undefined;
+  sessionCtx: SessionContext;
+  gitMirrorManager: GitMirrorManager | null;
+  /** Branch-owner key; falls back to the agent id when null. */
+  agentName: string | null;
+};
+
+/**
+ * Materialise a payload's predeclared `gitRepos` into the agent home and return
+ * the prompt-facing source-repo list (absolute path + upstream coordinates).
+ * Shared by the claude-code (SDK) and claude-code-tui handlers so the
+ * worktree-path mutex and Hub-worktree-marker reuse semantics stay in one place.
+ *
+ * Concurrency: per-process per-path mutex (`withWorktreePathLock`) so two
+ * sessions starting at the same time don't race `git worktree add` for the
+ * same path. Reuse only when the target is a Hub-managed worktree
+ * (`isHubWorktreeMarker`); a non-First Tree directory at the target is logged
+ * and left to `createWorktree` to fail loudly rather than being silently
+ * adopted as a source repo.
+ *
+ * Fail-fast per PRD D10/D13/D14: any failure aborts the session and bubbles up.
+ */
+export async function prepareSourceRepos(params: PrepareSourceReposParams): Promise<PredeclaredSourceRepo[]> {
+  const { workspace, payload, sessionCtx, gitMirrorManager, agentName } = params;
+  const sourceRepos: PredeclaredSourceRepo[] = [];
+
+  if (!gitMirrorManager || !payload?.gitRepos?.length) return sourceRepos;
+
+  for (const repo of payload.gitRepos) {
+    const localPath = repo.localPath ?? deriveRepoLocalPath(repo.url);
+    // Source repos live at the TOP LEVEL of the agent home — no `worktrees/`
+    // prefix. The `worktrees/` subdir is reserved for on-demand worktrees.
+    const targetPath = resolveGitRepoTargetPath(workspace, localPath);
+    sessionCtx.log(`Git: preparing source repo ${repo.url} → ${localPath}${repo.ref ? ` @ ${repo.ref}` : ""}`);
+
+    // D14: ensureMirror is idempotent — clone once, fast return thereafter.
+    const mirror = await gitMirrorManager.ensureMirror(repo.url);
+    if (mirror.cloned) {
+      sessionCtx.log(`Git: cloned ${repo.url} in ${mirror.elapsedMs}ms`);
+    }
+
+    // D10: fresh fetch on every new dialog. Failure aborts session creation.
+    await gitMirrorManager.fetchMirror(repo.url);
+
+    const branchAgentKey = agentName ?? sessionCtx.agent.agentId;
+
+    // Serialise per absolute path so two concurrent sessions for the same
+    // agent can't both try to create the same checkout.
+    const { branchName } = await withWorktreePathLock(targetPath, async () => {
+      if (existsSync(targetPath)) {
+        if (isHubWorktreeMarker(targetPath)) {
+          sessionCtx.log(`Git: reusing existing source repo at ${localPath}`);
+          // Reuse path: branchName is deterministic for cleanup. With the
+          // per-agent shared-checkout model, sessionKey is the agentName (not
+          // chatId) so a checkout created by chat A is reused by chat B.
+          return {
+            branchName: deriveSessionBranchName(branchAgentKey, branchAgentKey, repo.url),
+            headCommit: null as string | null,
+          };
+        }
+        // Path occupied by a non-First Tree directory (operator placed it,
+        // leftover from an old layout, etc). Log it explicitly — createWorktree
+        // below will likely fail with a generic "path exists" error, and
+        // without this line the operator has no way to know why.
+        sessionCtx.log(
+          `Git: source-repo target ${localPath} occupied by a non-First Tree directory; ` +
+            "createWorktree will likely fail — move or remove the directory and re-run",
+        );
+      }
+      const created = await gitMirrorManager.createWorktree({
+        url: repo.url,
+        ref: repo.ref,
+        targetPath,
+        // sessionKey identifies the branch *owner*. In the per-agent-home model
+        // the owner is the agent, not the chat.
+        sessionKey: branchAgentKey,
+        agentName: branchAgentKey,
+      });
+      return { branchName: created.branchName, headCommit: created.headCommit as string | null };
+    });
+
+    // Per agent-session-cwd-redesign: predeclared source repos are agent-scoped
+    // persistent resources. They survive shutdown so the next chat finds them
+    // ready — so they are NOT tracked in the per-session worktree-cleanup list.
+    sourceRepos.push({
+      absolutePath: targetPath,
+      url: repo.url,
+      ...(repo.ref ? { ref: repo.ref } : {}),
+      branch: branchName,
+    });
+
+    sessionCtx.log(`Git: source repo at ${localPath} on ${branchName}`);
+  }
+
+  return sourceRepos;
+}


### PR DESCRIPTION
## PR3 of the claude-code-tui slice series — the runtime handler

Builds on #678 (provider registration) and #684 (capability probe). The PR1 startup guard (`hasHandler`) kept older clients inert until this handler exists; once this lands, a bound `claude-code-tui` agent actually runs.

### Scope (client only)
No `shared` / `web` / `server` changes — purely the runtime handler under `packages/client/src/handlers/claude-code-tui/`.

| File | Role |
|---|---|
| `index.ts` | `AgentHandler` impl — start / resume / inject / suspend / shutdown |
| `tmux-session.ts` | thin `tmux` wrapper — newSession / pasteText / sendKey / capturePane / waitForReady / listOwnedSessions / killSession |
| `transcript-tail.ts` | tails claude's per-session JSONL and emits raw entries |
| `tui-markers.ts` | shared marker/sentinel constants |
| `ask-user-degrader.ts` | AskUserQuestion → plain-text round-trip |
| `handlers/index.ts` | registration (same `claude` PATH resolution as claude-code) |

### Design (rationale: `experiments/tmux-claude-runtime/FINDINGS.md`, landing in PR5)
- **No hooks.** The per-session transcript JSONL + `capture-pane` are the only signals — input is injected via `paste-buffer`. This is the locked contract for the runtime.
- **Reuses claude-code internals:** `createToolCallProcessor` / `mapMcpServers` and the shared bootstrap helpers, so event semantics match the SDK handler.
- **AskUserQuestion degraded gracefully** to a plain-text round-trip via Escape-cancel — the tool stays enabled rather than erroring.
- **Orphan sweep:** stale `ftth-*` tmux sessions are killed on first handler instantiation per process (Hub Client is the only creator, so anything unknown is orphaned).
- **Respects the per-agent-cwd redesign:** `shutdown()` never wipes the shared agent home or source repos — only the on-demand worktrees this agent created.

### Verification
- typecheck 13/13 · build 6/6 · biome clean
- full client suite **992 passed** — TUI unit 21/21 (tmux-session 5, transcript-tail 11, ask-user-degrader 5) + builtin-handlers 7/7 (now asserts claude-code-tui registers + returns a valid handler)

### Notes
- Draft pending QA review.
- The e2e framework + scenarios (`packages/e2e/`) and the `experiments/` PoC are the **next** slice (PR5), kept out of here to keep this reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
