### PR TITLE
chore: retire hub database defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,7 @@
 # PostgreSQL connection URL
 # Local dev: docker compose up -d (provides postgres at localhost:5432)
 # Supabase: use the direct connection (port 5432), NOT pooled (port 6543)
-FIRST_TREE_DATABASE_URL=postgresql://firsttreehub:firsttreehub@localhost:5432/firsttreehub
+FIRST_TREE_DATABASE_URL=postgresql://firsttree:firsttree@localhost:5432/firsttree
 
 # Bind address — MUST be 0.0.0.0 in Docker; 127.0.0.1 for local
 FIRST_TREE_HOST=0.0.0.0

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -28,7 +28,7 @@ packages and home dirs, one per channel:
 
 Auto-update is now gated on a channel-mismatch guard: a binary refuses
 to install a target version whose channel does not match its own (e.g.
-prod CLI refuses `…-staging.X.Y`). Misconfigured hub servers can no
+prod CLI refuses `…-staging.X.Y`). Misconfigured servers can no
 longer brick a connected daemon by advertising a cross-channel version.
 
 ### Team-member staging migration

--- a/apps/cli/scripts/e2e-auto-agent-add.ts
+++ b/apps/cli/scripts/e2e-auto-agent-add.ts
@@ -61,7 +61,7 @@ async function signMemberJwt(userId: string, memberId: string, organizationId: s
 
 // Reach into the already-running local Postgres and provision a fresh database
 // for this run. We drop it on teardown so repeat runs stay clean.
-const ADMIN_URL = process.env.E2E_PG_ADMIN_URL ?? "postgresql://firsttreehub:firsttreehub@localhost:5432/postgres";
+const ADMIN_URL = process.env.E2E_PG_ADMIN_URL ?? "postgresql://firsttree:firsttree@localhost:5432/postgres";
 const dbSuffix = crypto.randomUUID().slice(0, 8).replace(/-/g, "");
 const TEST_DB_NAME = `ft_first_tree_e2e_${dbSuffix}`;
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,13 +4,13 @@ services:
     ports:
       - "${POSTGRES_PORT:-5432}:5432"
     environment:
-      POSTGRES_DB: ${POSTGRES_DB:-firsttreehub}
-      POSTGRES_USER: ${POSTGRES_USER:-firsttreehub}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-firsttreehub}
+      POSTGRES_DB: ${POSTGRES_DB:-firsttree}
+      POSTGRES_USER: ${POSTGRES_USER:-firsttree}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-firsttree}
     volumes:
       - pgdata:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-firsttreehub}"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-firsttree}"]
       interval: 5s
       timeout: 3s
       retries: 5

--- a/packages/server/scripts/start-demo.mjs
+++ b/packages/server/scripts/start-demo.mjs
@@ -7,7 +7,7 @@
 // web has been built to ../web/dist.
 //
 // Run from packages/server:
-//   DATABASE_URL=postgresql://firsttreehub:firsttreehub@localhost:5432/fth_e2e_askuser \
+//   DATABASE_URL=postgresql://firsttree:firsttree@localhost:5432/fth_e2e_askuser \
 //   PORT=8000 \
 //   npx tsx scripts/start-demo.mjs
 


### PR DESCRIPTION
## Summary
- Rename local development Postgres defaults from `firsttreehub` to `firsttree` in `.env.example` and `docker-compose.yml`.
- Align e2e/demo helper defaults with the new local dev database credentials.
- Clean one non-historical migration-guide sentence from "hub servers" to generic server language.

## Intentionally retained
- Historical migration paths and env mappings such as `~/.first-tree/hub/`, `FIRST_TREE_HUB_*`, and old service-unit names.
- Guard literals such as `first-tree hub` in `scripts/check-no-old-names.sh`.
- Internal/protocol identifiers already called out in prior PRs (`FirstTreeHubSDK`, `HubClient`, `hubOrganizationId`, `x-hub-signature-256`, etc.).

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm check`
- `docker compose config`
- `pnpm --filter first-tree-dev typecheck`
- `rg -n "firsttreehub|Misconfigured hub servers|production hub schema|hub servers" --glob '!node_modules' --glob '!dist'` returns no matches
