### PR TITLE
fix: avoid client listener warning with many agents

### DIFF
--- a/apps/cli/src/__tests__/client-runtime-context-tree.test.ts
+++ b/apps/cli/src/__tests__/client-runtime-context-tree.test.ts
@@ -23,6 +23,7 @@ const RUNTIME_TEST_TIMEOUT_MS = 15_000;
 const disposeMock = vi.fn();
 const killAllMock = vi.fn(async () => undefined);
 const sweepMock = vi.fn(async () => ({ scanned: 0, deleted: 0, failed: 0 }));
+let connectionMaxListeners = 10;
 const connectionMock = {
   clientId: "client-test",
   on: vi.fn((event: string, fn: (...args: unknown[]) => void) => {
@@ -34,6 +35,10 @@ const connectionMock = {
   isPaused: vi.fn(() => false),
   getPausedReason: vi.fn<() => ClientPausedReason | null>(() => null),
   clearPaused: vi.fn(),
+  getMaxListeners: vi.fn(() => connectionMaxListeners),
+  setMaxListeners: vi.fn((n: number) => {
+    connectionMaxListeners = n;
+  }),
 };
 vi.mock("@first-tree/client", () => {
   class FakeAgentSlot {
@@ -59,6 +64,8 @@ vi.mock("@first-tree/client", () => {
       isPaused = connectionMock.isPaused;
       getPausedReason = connectionMock.getPausedReason;
       clearPaused = connectionMock.clearPaused;
+      getMaxListeners = connectionMock.getMaxListeners;
+      setMaxListeners = connectionMock.setMaxListeners;
     },
     UpdateManager: { attach: vi.fn(() => ({ dispose: disposeMock })) },
     createGitMirrorManager: vi.fn(() => ({
@@ -128,6 +135,9 @@ describe("ClientRuntime context-tree wiring", () => {
     connectionMock.getPausedReason.mockReset();
     connectionMock.getPausedReason.mockReturnValue(null);
     connectionMock.clearPaused.mockClear();
+    connectionMaxListeners = 10;
+    connectionMock.getMaxListeners.mockClear();
+    connectionMock.setMaxListeners.mockClear();
     disposeMock.mockClear();
     killAllMock.mockClear();
     sweepMock.mockReset();
@@ -164,6 +174,21 @@ describe("ClientRuntime context-tree wiring", () => {
     },
     RUNTIME_TEST_TIMEOUT_MS,
   );
+
+  it("raises the shared connection listener limit as agent slots are added", async () => {
+    const { ClientRuntime } = await import("../core/client-runtime.js");
+    const rt = new ClientRuntime("https://first-tree.test", "client-test");
+    for (let i = 0; i < 11; i++) {
+      rt.addAgent(`agent-${i}`, {
+        agentId: `agent-id-${i}`,
+        runtime: "claude-code",
+        session: { idle_timeout: 300, max_sessions: 4, working_grace_seconds: 3600 },
+        concurrency: 1,
+      } as unknown as Parameters<typeof rt.addAgent>[1]);
+    }
+
+    expect(connectionMock.setMaxListeners).toHaveBeenLastCalledWith(12);
+  });
 
   it(
     "reports suspended local aliases as skipped instead of connection failures",

--- a/apps/cli/src/core/client-runtime.ts
+++ b/apps/cli/src/core/client-runtime.ts
@@ -31,7 +31,7 @@ type AgentEntry = {
 
 type AgentStartState = "idle" | "starting" | "running" | "suspended-skipped" | "failed";
 
-const CLIENT_RUNTIME_AGENT_EVENT_LISTENERS = 1;
+const CLIENT_RUNTIME_AGENT_UNBOUND_LISTENER_COUNT = 1;
 
 export function isAgentSuspendedBindError(error: unknown): boolean {
   const msg = error instanceof Error ? error.message : String(error);
@@ -226,7 +226,7 @@ export class ClientRuntime {
   }
 
   private refreshConnectionListenerLimit(): void {
-    const requiredListenersPerEvent = this.agents.length + CLIENT_RUNTIME_AGENT_EVENT_LISTENERS;
+    const requiredListenersPerEvent = this.agents.length + CLIENT_RUNTIME_AGENT_UNBOUND_LISTENER_COUNT;
     const currentLimit = this.connection.getMaxListeners();
     if (currentLimit !== 0 && currentLimit < requiredListenersPerEvent) {
       this.connection.setMaxListeners(requiredListenersPerEvent);

--- a/apps/cli/src/core/client-runtime.ts
+++ b/apps/cli/src/core/client-runtime.ts
@@ -31,6 +31,8 @@ type AgentEntry = {
 
 type AgentStartState = "idle" | "starting" | "running" | "suspended-skipped" | "failed";
 
+const CLIENT_RUNTIME_AGENT_EVENT_LISTENERS = 1;
+
 export function isAgentSuspendedBindError(error: unknown): boolean {
   const msg = error instanceof Error ? error.message : String(error);
   return msg.includes("agent_suspended");
@@ -220,6 +222,15 @@ export class ClientRuntime {
     this.agents.push({ name, slot, state: "idle" });
     this.agentNames.add(name);
     this.agentIds.add(config.agentId);
+    this.refreshConnectionListenerLimit();
+  }
+
+  private refreshConnectionListenerLimit(): void {
+    const requiredListenersPerEvent = this.agents.length + CLIENT_RUNTIME_AGENT_EVENT_LISTENERS;
+    const currentLimit = this.connection.getMaxListeners();
+    if (currentLimit !== 0 && currentLimit < requiredListenersPerEvent) {
+      this.connection.setMaxListeners(requiredListenersPerEvent);
+    }
   }
 
   async start(): Promise<void> {

--- a/packages/client/src/__tests__/runtime.test.ts
+++ b/packages/client/src/__tests__/runtime.test.ts
@@ -74,6 +74,28 @@ function makeRuntimeConfig(): RuntimeConfig {
   };
 }
 
+function makeRuntimeConfigWithAgentCount(count: number): RuntimeConfig {
+  const agents: RuntimeConfig["agents"] = {};
+  for (let i = 0; i < count; i++) {
+    const name = `agent-${i}`;
+    agents[name] = {
+      agentId: `agent-id-${i}`,
+      type: "claude-code",
+      session: {
+        idle_timeout: 300,
+        max_sessions: 10,
+        working_grace_seconds: 3600,
+        reconcile_interval_seconds: 300,
+      },
+      concurrency: 2,
+    };
+  }
+  return {
+    server: "http://first-tree.test",
+    agents,
+  };
+}
+
 function makeUpdateHooks(): UpdateHooks {
   return {
     updateConfig: {
@@ -239,6 +261,18 @@ describe("AgentRuntime", () => {
     });
     expect(state.slots.map((slot) => `${slot.name}:${slot.agentId}`)).toEqual(["alpha:agent-alpha", "beta:agent-beta"]);
     expect(state.logger.error).toHaveBeenCalledWith({ err: new Error("socket failed") }, "client connection error");
+  });
+
+  it("raises the shared connection listener limit for multi-agent runtimes", async () => {
+    const state = installRuntimeMocks();
+    const { AgentRuntime } = await import("../runtime/runtime.js");
+
+    new AgentRuntime({
+      config: makeRuntimeConfigWithAgentCount(12),
+      getAccessToken: async () => "token",
+    });
+
+    expect(state.connections[0]?.getMaxListeners()).toBe(12);
   });
 
   it("starts, attaches updates, reports partial slot failures, and shuts down on SIGINT", async () => {

--- a/packages/client/src/runtime/runtime.ts
+++ b/packages/client/src/runtime/runtime.ts
@@ -113,6 +113,15 @@ export class AgentRuntime {
         }),
       );
     }
+    this.refreshConnectionListenerLimit();
+  }
+
+  private refreshConnectionListenerLimit(): void {
+    const requiredListenersPerEvent = this.slots.length;
+    const currentLimit = this.clientConnection.getMaxListeners();
+    if (currentLimit !== 0 && currentLimit < requiredListenersPerEvent) {
+      this.clientConnection.setMaxListeners(requiredListenersPerEvent);
+    }
   }
 
   private aggregateQuietGate(): { activeCount: number; lastActivityMs: number } {


### PR DESCRIPTION
## Summary
- raise the shared ClientConnection listener limit based on configured agent slot count
- cover both CLI ClientRuntime and package AgentRuntime paths
- add regression tests for multi-agent listener capacity

## Review
- codex-reviewer: LGTM / no blocking findings

## Tests
- pnpm --filter first-tree-dev exec vitest run src/__tests__/client-runtime-context-tree.test.ts --passWithNoTests
- pnpm --filter @first-tree/client exec vitest run src/__tests__/runtime.test.ts --passWithNoTests
- pnpm check
- pnpm typecheck