### PR TITLE
fix(cli): unlink WHITEPAPER symlinks directly

### DIFF
--- a/apps/cli/src/__tests__/tree-skill-lib.test.ts
+++ b/apps/cli/src/__tests__/tree-skill-lib.test.ts
@@ -6,6 +6,7 @@ import {
   readlinkSync,
   rmSync,
   symlinkSync,
+  unlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -198,17 +199,17 @@ describe("tree skill library", () => {
     expect(readlinkSync(join(root, "WHITEPAPER.md"))).toBe(join(".agents", "skills", "first-tree", "SKILL.md"));
     expect(upsertWhitepaperFile(root)).toBe("unchanged");
 
-    rmSync(join(root, "WHITEPAPER.md"));
+    unlinkSync(join(root, "WHITEPAPER.md"));
     symlinkSync("old-target", join(root, "WHITEPAPER.md"));
     expect(upsertWhitepaperFile(root)).toBe("updated");
     expect(readlinkSync(join(root, "WHITEPAPER.md"))).toBe(join(".agents", "skills", "first-tree", "SKILL.md"));
 
-    rmSync(join(root, "WHITEPAPER.md"));
+    unlinkSync(join(root, "WHITEPAPER.md"));
     writeFileSync(join(root, "WHITEPAPER.md"), "custom\n");
     expect(upsertWhitepaperFile(root)).toBe("skipped");
     expect(readFileSync(join(root, "WHITEPAPER.md"), "utf8")).toBe("custom\n");
 
-    rmSync(join(root, "WHITEPAPER.md"));
+    unlinkSync(join(root, "WHITEPAPER.md"));
     mkdirSync(join(root, "WHITEPAPER.md"));
     expect(upsertWhitepaperFile(root)).toBe("skipped");
     expect(existsSync(join(root, "WHITEPAPER.md"))).toBe(true);

--- a/apps/cli/src/commands/tree/skill-lib.ts
+++ b/apps/cli/src/commands/tree/skill-lib.ts
@@ -1,4 +1,14 @@
-import { cpSync, existsSync, lstatSync, mkdirSync, readFileSync, readlinkSync, rmSync, symlinkSync } from "node:fs";
+import {
+  cpSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readlinkSync,
+  rmSync,
+  symlinkSync,
+  unlinkSync,
+} from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -524,7 +534,7 @@ export function upsertWhitepaperFile(targetRoot: string): ManagedFileAction {
   }
 
   if (existing.kind === "symlink") {
-    rmSync(fullPath, { force: true });
+    unlinkSync(fullPath);
     symlinkSync(WHITEPAPER_SYMLINK_TARGET, fullPath);
     return "updated";
   }


### PR DESCRIPTION
## Summary
- replace the WHITEPAPER symlink with unlinkSync after lstat has identified it as a symlink
- use unlinkSync in the WHITEPAPER unit test setup so local cleanup does not depend on rmSync symlink behavior

Closes #718.

## Tests
- pnpm --filter first-tree-dev exec vitest run src/__tests__/tree-skill-lib.test.ts --testNamePattern 'WHITEPAPER'
- pnpm --filter first-tree-dev exec vitest run src/__tests__/tree-skill-lib.test.ts
- pnpm --filter first-tree-dev exec biome check src/commands/tree/skill-lib.ts src/__tests__/tree-skill-lib.test.ts
- pnpm --filter first-tree-dev test