### PR TITLE
fix(web): delegate candidates use organization visibility + fix popover click leak

### DIFF
--- a/packages/web/src/pages/agent-detail/identity-section.tsx
+++ b/packages/web/src/pages/agent-detail/identity-section.tsx
@@ -116,12 +116,10 @@ function IdentityEditDialog({ agent, open, onOpenChange, onSave }: IdentityDialo
     queryKey: ["agents-for-delegate"],
     queryFn: async () => {
       const res = await listAgents({ limit: 100 });
-      // Post-type-merge: pre-merge `personal_assistant` and
-      // `autonomous_agent` collapsed into a single `agent` type. The
-      // "personal" framing is now carried by visibility=private, which is
-      // the default the new-agent dialog already picks for the assistant
-      // creation flow.
-      return res.items.filter((a) => a.type === "agent" && a.visibility === "private" && a.status === "active");
+      // Delegate candidates must be team-visible: a delegate acts on the
+      // human's behalf in team chats, so it has to be mentionable by the team
+      // (visibility=organization). Private agents are excluded.
+      return res.items.filter((a) => a.type === "agent" && a.visibility === "organization" && a.status === "active");
     },
     enabled: open && isHuman,
   });
@@ -205,7 +203,7 @@ function IdentityEditDialog({ agent, open, onOpenChange, onSave }: IdentityDialo
                 onChange={(e) => setDelegateMention(e.target.value)}
                 className="flex h-9 w-full rounded-[var(--radius-input)] border border-input bg-transparent px-3 py-1 text-body shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
               >
-                <option value="">None</option>
+                <option value="">Remove delegate</option>
                 {assistantsQuery.data?.map((a) => (
                   <option key={a.uuid} value={a.uuid}>
                     {a.displayName ? `${a.displayName} (@${a.name ?? a.uuid})` : a.name ? `@${a.name}` : a.uuid}

--- a/packages/web/src/pages/team/__tests__/team-groups.test.ts
+++ b/packages/web/src/pages/team/__tests__/team-groups.test.ts
@@ -215,42 +215,40 @@ describe("buildTeamData", () => {
 });
 
 describe("selectDelegateCandidates", () => {
-  it("returns only the given manager's active private assistants", () => {
+  it("returns only the given manager's active team-visible (organization) agents", () => {
+    const mineOrg = agent({
+      uuid: "mine-org",
+      type: "agent",
+      displayName: "Mine",
+      visibility: "organization",
+      managerId: "member-1",
+    });
+    const theirOrg = agent({
+      uuid: "their-org",
+      type: "agent",
+      displayName: "Theirs",
+      visibility: "organization",
+      managerId: "member-2",
+    });
     const minePrivate = agent({
       uuid: "mine-private",
       type: "agent",
-      displayName: "Mine",
+      displayName: "Private",
       visibility: "private",
       managerId: "member-1",
-    });
-    const theirPrivate = agent({
-      uuid: "their-private",
-      type: "agent",
-      displayName: "Theirs",
-      visibility: "private",
-      managerId: "member-2",
     });
     const suspended = agent({
       uuid: "suspended",
       type: "agent",
       displayName: "Suspended",
-      visibility: "private",
-      status: "suspended",
-      managerId: "member-1",
-    });
-    const autonomous = agent({
-      uuid: "auto",
-      type: "agent",
-      displayName: "Cron",
       visibility: "organization",
+      status: "suspended",
       managerId: "member-1",
     });
     const human = agent({ uuid: "human-1", type: "human", displayName: "Ada", managerId: "member-1" });
 
     expect(
-      selectDelegateCandidates([minePrivate, theirPrivate, suspended, autonomous, human], "member-1").map(
-        (a) => a.uuid,
-      ),
-    ).toEqual(["mine-private"]);
+      selectDelegateCandidates([mineOrg, theirOrg, minePrivate, suspended, human], "member-1").map((a) => a.uuid),
+    ).toEqual(["mine-org"]);
   });
 });

--- a/packages/web/src/pages/team/index.tsx
+++ b/packages/web/src/pages/team/index.tsx
@@ -517,11 +517,14 @@ export function buildTeamData(args: {
 }
 
 export function selectDelegateCandidates(agents: Agent[], managerId: string | null | undefined): Agent[] {
-  // Personal assistants the viewer manages: type=agent + private + active +
-  // managed by the viewer. The managerId filter is the issue 669 candidate fix —
-  // the selector only lists the user's own agents, not the whole org's.
+  // Delegate candidates are the viewer's own team-visible assistants:
+  // type=agent + organization-visible + active + managed by the viewer.
+  // Private agents are excluded — a delegate acts on the human's behalf in
+  // team chats, so it must be mentionable by the team (visibility=organization).
+  // The managerId filter is the issue 669 candidate fix — the selector only
+  // lists the user's own agents, not the whole org's.
   return agents.filter(
-    (a) => a.type === "agent" && a.visibility === "private" && a.status === "active" && a.managerId === managerId,
+    (a) => a.type === "agent" && a.visibility === "organization" && a.status === "active" && a.managerId === managerId,
   );
 }
 

--- a/packages/web/src/pages/team/team-table.tsx
+++ b/packages/web/src/pages/team/team-table.tsx
@@ -640,14 +640,28 @@ function DelegateCell({
         )}
       >
         {({ close }) => (
-          <DelegateSelector
-            current={row.delegate?.uuid ?? null}
-            candidates={candidates}
-            onPick={(uuid) => {
-              onSetDelegate(row.agentId, uuid);
-              close();
+          // The Popover panel is portal-rendered to <body>, but React still
+          // replays synthetic events through the COMPONENT tree — so a click
+          // (or Enter) inside it bubbles up to the row's onClick / onKeyDown
+          // (rowOpenProps) and wrongly opens the profile dialog. Isolate the
+          // panel's pointer/keyboard events from the row here; Escape is left
+          // to propagate so Popover's window-level handler can still close it.
+          // biome-ignore lint/a11y/noStaticElementInteractions: wrapper only stops event bubbling, not an interactive control
+          <div
+            onClick={(e) => e.stopPropagation()}
+            onKeyDown={(e) => {
+              if (e.key !== "Escape") e.stopPropagation();
             }}
-          />
+          >
+            <DelegateSelector
+              current={row.delegate?.uuid ?? null}
+              candidates={candidates}
+              onPick={(uuid) => {
+                onSetDelegate(row.agentId, uuid);
+                close();
+              }}
+            />
+          </div>
         )}
       </Popover>
     );
@@ -688,11 +702,11 @@ function DelegateSelector({
       <DelegateOption
         active={current === null}
         onClick={() => onPick(null)}
-        primary={<span style={{ color: "var(--fg-3)" }}>None</span>}
+        primary={<span style={{ color: "var(--fg-3)" }}>Remove delegate</span>}
       />
       {candidates.length === 0 ? (
         <div className="text-caption" style={{ color: "var(--fg-4)", padding: "var(--sp-1_5) var(--sp-2)" }}>
-          No personal assistants yet.
+          Only team-visible agents can be a delegate.
         </div>
       ) : (
         candidates.map((agent) => (


### PR DESCRIPTION
## What & why

Three fixes to the Team-page delegate selector, all reported by @gandy2025.

### 1. Candidates must be team-visible (`organization`), not `private`
`selectDelegateCandidates` and the agent-detail `agents-for-delegate` query required `visibility === "private"`. But new agents now default to `organization` (the new-agent dialog is the only thing that opts into private), so the private rule hid every freshly-created agent from the picker — the symptom that kicked this off. A delegate acts on the human's behalf **in team chats**, so it must be team-mentionable (`organization`).

Backend (`services/agent.ts`) only validates that the delegate target exists and is in the same org — it does **not** require a visibility — so this is a frontend-only change.

### 2. Clearer dropdown copy
- Clear option: `None` → **"Remove delegate"**
- Empty state: → **"Only team-visible agents can be a delegate."**

### 3. Click-region overlap (the real bug behind "set delegate pops the whole-row dialog")
The delegate `Popover` panel is `createPortal`-ed to `<body>`, but React replays synthetic events through the **component tree**, not the DOM tree. So a click (or Enter) on an option bubbled up to the row's `onClick`/`onKeyDown` (`rowOpenProps`) and wrongly opened the member profile dialog. Fix isolates the panel's pointer/keyboard events from the row; **Escape is left to propagate** so the popover's window-level handler still closes it.

## Tests
- Updated `selectDelegateCandidates` unit test to assert the organization rule.
- `pnpm --filter @first-tree/web typecheck` ✓ (tsc + design-token lint)
- Full web suite: **514/514 pass**
- biome ✓

## Verification
Verified against live dev data (agent-team-foundation org, 22 agents): the Team page renders and the delegate cell resolves an organization agent. #3 is a DOM-event behavior best confirmed in a live env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)