### PR TITLE
Disable legacy MCP config writes

### DIFF
--- a/apps/cli/src/__tests__/agent-config-cli.test.ts
+++ b/apps/cli/src/__tests__/agent-config-cli.test.ts
@@ -1,6 +1,17 @@
 import { Command } from "commander";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { registerAgentConfigCommands } from "../commands/agent/config/index.js";
+
+const failMock = vi.hoisted(() =>
+  vi.fn((code: string, message: string, exitCode = 1) => {
+    throw Object.assign(new Error(message), { code, exitCode });
+  }),
+);
+
+vi.mock("../cli/output.js", () => ({
+  fail: failMock,
+  success: vi.fn(),
+}));
 
 describe("agent config CLI registration (Step 8)", () => {
   it("registers all 8 subcommands under `config`", () => {
@@ -42,5 +53,21 @@ describe("agent config CLI registration (Step 8)", () => {
     expect(opts).toContain("--command");
     expect(opts).toContain("--url");
     expect(opts).toContain("--args");
+  });
+
+  it("add-mcp is registered but exits before writing legacy MCP config", async () => {
+    const root = new Command();
+    root.exitOverride();
+    const agent = root.command("agent");
+    registerAgentConfigCommands(agent);
+
+    await expect(
+      root.parseAsync(["node", "test", "agent", "config", "add-mcp", "kael", "--name", "docs", "--transport", "http"]),
+    ).rejects.toMatchObject({ code: "LEGACY_MCP_CONFIG_DISABLED", exitCode: 2 });
+    expect(failMock).toHaveBeenCalledWith(
+      "LEGACY_MCP_CONFIG_DISABLED",
+      expect.stringContaining("Team MCP Resources"),
+      2,
+    );
   });
 });

--- a/apps/cli/src/__tests__/daemon-start-command.test.ts
+++ b/apps/cli/src/__tests__/daemon-start-command.test.ts
@@ -20,6 +20,7 @@ const coreMocks = vi.hoisted(() => ({
   getClientServiceStatus: vi.fn(),
   handleClientOrgMismatch: vi.fn(),
   isServiceSupported: vi.fn(),
+  listPinnedAgents: vi.fn(),
   loadCredentials: vi.fn(),
   migrateLocalAgentDirs: vi.fn(),
   promptMissingFields: vi.fn(),
@@ -95,6 +96,9 @@ beforeEach(() => {
   });
   coreMocks.startClientService.mockReturnValue({ ok: true });
   coreMocks.ensureFreshAccessToken.mockResolvedValue("access-token");
+  coreMocks.listPinnedAgents.mockResolvedValue([
+    { agentId: "agent-1", clientId: "client_1234abcd", runtimeProvider: "claude-code", status: "active" },
+  ]);
   coreMocks.promptMissingFields.mockResolvedValue(undefined);
   coreMocks.createApiNameResolver.mockReturnValue(async () => "kael");
   coreMocks.createExecuteUpdate.mockReturnValue(async () => undefined);
@@ -231,11 +235,43 @@ describe("daemon start command", () => {
     expect(coreMocks.uploadClientCapabilities).toHaveBeenCalledWith(
       expect.objectContaining({ clientId: "client_1234abcd", capabilities: { "claude-code": { state: "ok" } } }),
     );
+    expect(coreMocks.listPinnedAgents).toHaveBeenCalledWith({
+      serverUrl: "https://first-tree.example",
+      accessToken: "access-token",
+    });
     expect(coreMocks.uploadAgentSkills).toHaveBeenCalledWith(
       expect.objectContaining({ agentId: "agent-1", skills: [{ name: "review", description: "Review code." }] }),
     );
     expect(runtimeInstance.watchAgentsDir).toHaveBeenCalledWith(join(home, "config", "agents"));
     expect(output()).toContain("Error: stop after watch");
+  });
+
+  it("skips skill upload for stale local aliases that are not pinned to this client", async () => {
+    mkdirSync(join(home, "config", "agents", "developer"), { recursive: true });
+    writeFileSync(
+      join(home, "config", "agents", "developer", "agent.yaml"),
+      "agentId: stale-agent\nruntime: claude-code\n",
+    );
+
+    await expect(runStart(["--foreground"])).rejects.toMatchObject({ exitCode: 1 });
+
+    expect(runtimeInstance.addAgent).toHaveBeenCalledWith(
+      "developer",
+      expect.objectContaining({ agentId: "stale-agent" }),
+    );
+    expect(coreMocks.uploadAgentSkills).toHaveBeenCalledTimes(1);
+    expect(coreMocks.uploadAgentSkills).toHaveBeenCalledWith(expect.objectContaining({ agentId: "agent-1" }));
+    expect(output()).toContain("skills upload for developer skipped");
+    expect(output()).toContain("agent prune --dry-run");
+  });
+
+  it("keeps best-effort skill upload when pinned-agent filtering is unavailable", async () => {
+    coreMocks.listPinnedAgents.mockRejectedValueOnce(new Error("pin check failed"));
+
+    await expect(runStart(["--foreground"])).rejects.toMatchObject({ exitCode: 1 });
+
+    expect(coreMocks.uploadAgentSkills).toHaveBeenCalledWith(expect.objectContaining({ agentId: "agent-1" }));
+    expect(output()).toContain("skills upload pin check skipped: pin check failed");
   });
 
   it("uses service-mode logging and non-interactive prompts for supervisor children", async () => {

--- a/apps/cli/src/__tests__/runtime-provider-reconcile.test.ts
+++ b/apps/cli/src/__tests__/runtime-provider-reconcile.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { parse as parseYaml } from "yaml";
 import {
+  listPinnedAgents,
   reconcileLocalRuntimeProviders,
   uploadAgentSkills,
   uploadClientCapabilities,
@@ -11,6 +12,7 @@ import {
 
 /**
  * Two CLI helpers, both fetch-driven against the server:
+ *   - `listPinnedAgents` reads the server-authoritative local-agent set.
  *   - `reconcileLocalRuntimeProviders` rewrites local `agent.yaml::runtime`
  *     when it disagrees with `agents.runtime_provider` (server authoritative).
  *   - `uploadClientCapabilities` PATCHes the per-machine probe results to
@@ -22,6 +24,41 @@ import {
  * `agentId` or rewrites every yaml unconditionally would only surface at
  * production startup.
  */
+describe("listPinnedAgents", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("GETs /me/pinned-agents with the user access token", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify([{ agentId: "agent-1", clientId: "client-1", runtimeProvider: "claude-code" }]), {
+        status: 200,
+      }),
+    );
+
+    const rows = await listPinnedAgents({ serverUrl: "http://first-tree.test", accessToken: "tok-xyz" });
+
+    expect(rows).toEqual([{ agentId: "agent-1", clientId: "client-1", runtimeProvider: "claude-code" }]);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://first-tree.test/api/v1/me/pinned-agents",
+      expect.objectContaining({ headers: expect.objectContaining({ Authorization: "Bearer tok-xyz" }) }),
+    );
+  });
+
+  it("throws on non-OK status so daemon startup can fall back to best-effort upload", async () => {
+    fetchMock.mockResolvedValue(new Response("nope", { status: 500 }));
+
+    await expect(listPinnedAgents({ serverUrl: "http://first-tree.test", accessToken: "tok" })).rejects.toThrow(/500/);
+  });
+});
+
 describe("reconcileLocalRuntimeProviders", () => {
   let agentsDir: string;
   let fetchMock: ReturnType<typeof vi.fn>;

--- a/apps/cli/src/commands/agent/config/add-mcp.ts
+++ b/apps/cli/src/commands/agent/config/add-mcp.ts
@@ -1,44 +1,19 @@
-import type { AgentRuntimeConfigPayload } from "@first-tree/shared";
 import type { Command } from "commander";
-import { fail, success } from "../../../cli/output.js";
-import { ensureFreshAdminToken, resolveServerUrl } from "../../../core/bootstrap.js";
-import { getCurrent, patchConfig, resolveAgentRecord } from "./_shared/fetchers.js";
+import { fail } from "../../../cli/output.js";
+
+const LEGACY_MCP_WRITE_DISABLED_MESSAGE =
+  "Legacy per-agent MCP config writes are disabled. MCP configuration will be managed by Team MCP Resources.";
 
 export function registerAgentConfigAddMcpCommand(config: Command): void {
   config
     .command("add-mcp <agent>")
-    .description("Add or replace an MCP server (replace-by-name semantics)")
-    .requiredOption("--name <name>", "MCP server name")
-    .requiredOption("--transport <transport>", "stdio | http | sse")
+    .description("Disabled: legacy per-agent MCP config writes are closed")
+    .option("--name <name>", "MCP server name")
+    .option("--transport <transport>", "stdio | http | sse")
     .option("--command <command>", "stdio command")
     .option("--args <args...>", "stdio command args")
     .option("--url <url>", "http/sse URL")
-    .action(
-      async (
-        agentName: string,
-        opts: { name: string; transport: string; command?: string; args?: string[]; url?: string },
-      ) => {
-        const serverUrl = resolveServerUrl(process.env.FIRST_TREE_SERVER_URL);
-        const adminToken = await ensureFreshAdminToken();
-        const { uuid } = await resolveAgentRecord(serverUrl, adminToken, agentName);
-        const current = await getCurrent(serverUrl, adminToken, uuid);
-
-        let server: AgentRuntimeConfigPayload["mcpServers"][number];
-        if (opts.transport === "stdio") {
-          if (!opts.command) fail("MISSING_COMMAND", "stdio transport requires --command", 2);
-          server = { name: opts.name, transport: "stdio", command: opts.command, args: opts.args };
-        } else if (opts.transport === "http" || opts.transport === "sse") {
-          if (!opts.url) fail("MISSING_URL", `${opts.transport} transport requires --url`, 2);
-          server = { name: opts.name, transport: opts.transport, url: opts.url };
-        } else {
-          fail("BAD_TRANSPORT", `transport must be stdio|http|sse, got ${opts.transport}`, 2);
-        }
-
-        const remaining = current.payload.mcpServers.filter((s) => s.name !== opts.name);
-        const updated = await patchConfig(serverUrl, adminToken, uuid, current.version, {
-          mcpServers: [...remaining, server],
-        });
-        success({ agentId: updated.agentId, version: updated.version, mcpServer: opts.name });
-      },
-    );
+    .action(async () => {
+      fail("LEGACY_MCP_CONFIG_DISABLED", LEGACY_MCP_WRITE_DISABLED_MESSAGE, 2);
+    });
 }

--- a/apps/cli/src/commands/daemon/start.ts
+++ b/apps/cli/src/commands/daemon/start.ts
@@ -30,6 +30,7 @@ import {
   getClientServiceStatus,
   handleClientOrgMismatch,
   isServiceSupported,
+  listPinnedAgents,
   loadCredentials,
   migrateLocalAgentDirs,
   promptMissingFields,
@@ -272,9 +273,32 @@ export function registerDaemonStartCommand(daemon: Command): void {
               warn: (msg) => print.status("⚠️", `skill scan: ${msg}`),
             });
             const accessToken = await ensureFreshAccessToken();
+            let pinnedByAgentId: Map<string, { agentId: string; clientId: string }> | null = null;
+            try {
+              const pinned = await listPinnedAgents({ serverUrl: config.server.url, accessToken });
+              pinnedByAgentId = new Map(pinned.map((agent) => [agent.agentId, agent]));
+            } catch (err) {
+              const msg = err instanceof Error ? err.message : String(err);
+              print.status("⚠️", `skills upload pin check skipped: ${msg}`);
+            }
             await Promise.all(
               claudeAgents.map(async ([name, c]) => {
                 try {
+                  const pinned = pinnedByAgentId?.get(c.agentId);
+                  if (pinnedByAgentId && !pinned) {
+                    print.status(
+                      "⚠️",
+                      `skills upload for ${name} skipped: local agent ${c.agentId} is not pinned to this user; run \`first-tree agent prune --dry-run\` to inspect stale aliases.`,
+                    );
+                    return;
+                  }
+                  if (pinned && pinned.clientId !== config.client.id) {
+                    print.status(
+                      "⚠️",
+                      `skills upload for ${name} skipped: local agent ${c.agentId} is pinned to another client (${pinned.clientId}); run \`first-tree agent prune --dry-run\` to inspect stale aliases.`,
+                    );
+                    return;
+                  }
                   await uploadAgentSkills({
                     serverUrl: config.server.url,
                     accessToken,

--- a/apps/cli/src/core/index.ts
+++ b/apps/cli/src/core/index.ts
@@ -58,8 +58,10 @@ export {
 export { blank, status } from "./output.js";
 // Interactive prompts
 export { isInteractive, promptAddAgent, promptMissingFields } from "./prompt.js";
+export type { PinnedAgentRuntimeRecord } from "./runtime-provider-reconcile.js";
 // Pre-flight runtime-provider reconciliation (P2 — capabilities + YAML rewrite)
 export {
+  listPinnedAgents,
   reconcileLocalRuntimeProviders,
   uploadAgentSkills,
   uploadClientCapabilities,

--- a/apps/cli/src/core/runtime-provider-reconcile.ts
+++ b/apps/cli/src/core/runtime-provider-reconcile.ts
@@ -13,6 +13,21 @@ type AuthoritativePinnedAgent = {
   status?: string;
 };
 
+export type PinnedAgentRuntimeRecord = AuthoritativePinnedAgent;
+
+export async function listPinnedAgents(opts: {
+  serverUrl: string;
+  accessToken: string;
+}): Promise<PinnedAgentRuntimeRecord[]> {
+  const res = await cliFetch(`${opts.serverUrl}/api/v1/me/pinned-agents`, {
+    headers: { Authorization: `Bearer ${opts.accessToken}` },
+  });
+  if (!res.ok) {
+    throw new Error(`server returned ${res.status} on /me/pinned-agents`);
+  }
+  return (await res.json()) as PinnedAgentRuntimeRecord[];
+}
+
 /**
  * Pre-flight reconciliation called before the agents loop spawns. Pulls
  * authoritative `runtime_provider` for every non-deleted agent the calling
@@ -28,13 +43,7 @@ export async function reconcileLocalRuntimeProviders(opts: {
   agentsDir: string;
   log?: LogFn;
 }): Promise<void> {
-  const res = await cliFetch(`${opts.serverUrl}/api/v1/me/pinned-agents`, {
-    headers: { Authorization: `Bearer ${opts.accessToken}` },
-  });
-  if (!res.ok) {
-    throw new Error(`server returned ${res.status} on /clients/me/agents`);
-  }
-  const items = (await res.json()) as AuthoritativePinnedAgent[];
+  const items = await listPinnedAgents(opts);
   const byAgentId = new Map(items.map((it) => [it.agentId, it]));
 
   if (!existsSync(opts.agentsDir)) return;

--- a/packages/server/src/__tests__/admin-agent-config.test.ts
+++ b/packages/server/src/__tests__/admin-agent-config.test.ts
@@ -75,11 +75,12 @@ describe("Admin agent-config API (Step 2)", () => {
     expect(seed.statusCode).toBe(200);
     await app.configService.flush(agent.uuid);
 
-    // Touch only `mcpServers`. The service must preserve the other 4 fields.
+    // Touch only `reasoningEffort`. The service must preserve the list fields
+    // and prompt/model values.
     const partial = await req("PATCH", `/api/v1/agents/${agent.uuid}/config`, {
       expectedVersion: 2,
       payload: {
-        mcpServers: [{ name: "demo", transport: "stdio", command: "echo" }],
+        reasoningEffort: "high",
       },
     });
     expect(partial.statusCode).toBe(200);
@@ -91,7 +92,31 @@ describe("Admin agent-config API (Step 2)", () => {
     expect(payload.model).toBe("claude-sonnet-4-6");
     expect(payload.env).toEqual([{ key: "FOO", value: "bar", sensitive: false }]);
     expect(payload.gitRepos).toEqual([{ url: "https://example.com/r.git" }]);
-    expect(payload.mcpServers).toEqual([{ name: "demo", transport: "stdio", command: "echo" }]);
+    expect(payload.mcpServers).toEqual([]);
+    expect(payload.reasoningEffort).toBe("high");
+  });
+
+  it("rejects legacy MCP config writes in PATCH and dry-run", async () => {
+    const app = getApp();
+    const req = await authedRequest(app);
+    const agent = await (await seedAgentFactory(app))({
+      name: `cfg-mcp-disabled-${crypto.randomUUID().slice(0, 8)}`,
+      type: "agent",
+    });
+    const payload = {
+      mcpServers: [{ name: "demo", transport: "stdio", command: "echo" }],
+    };
+
+    const patch = await req("PATCH", `/api/v1/agents/${agent.uuid}/config`, {
+      expectedVersion: 1,
+      payload,
+    });
+    expect(patch.statusCode).toBe(400);
+    expect(patch.json<{ error: string }>().error).toContain("Legacy per-agent MCP config writes are disabled");
+
+    const dry = await req("POST", `/api/v1/agents/${agent.uuid}/config/dry-run`, { payload });
+    expect(dry.statusCode).toBe(400);
+    expect(dry.json<{ error: string }>().error).toContain("Team MCP Resources");
   });
 
   it("reasoning effort: defaults to '', persists a valid value, rejects a codex-only value with 400", async () => {

--- a/packages/server/src/services/config-service.ts
+++ b/packages/server/src/services/config-service.ts
@@ -14,11 +14,13 @@ import { and, eq, sql } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 import { agentConfigs } from "../db/schema/agent-configs.js";
 import { agents } from "../db/schema/agents.js";
-import { ConflictError, NotFoundError } from "../errors.js";
+import { BadRequestError, ConflictError, NotFoundError } from "../errors.js";
 import { decryptValue, encryptValue, isEncryptedValue } from "./crypto.js";
 import type { Notifier } from "./notifier.js";
 
 const DEBOUNCE_WINDOW_MS = 300;
+const LEGACY_MCP_WRITE_DISABLED_MESSAGE =
+  "Legacy per-agent MCP config writes are disabled. MCP configuration will be managed by Team MCP Resources.";
 
 type PendingWrite = {
   /** All callers waiting on the aggregated write. Each carries its own
@@ -111,6 +113,7 @@ export function createConfigService(opts: ConfigServiceOptions): ConfigService {
    *     for M1 (admins resend the full list — matches the Web form).
    */
   function applyPatch(current: AgentRuntimeConfigPayload, patch: AgentRuntimeConfigPatch): AgentRuntimeConfigPayload {
+    rejectLegacyMcpWrite(patch);
     const next = {
       // `kind` is pinned to `agents.runtime_provider` and never patchable
       // from the config side; preserve the current value here and let
@@ -126,6 +129,12 @@ export function createConfigService(opts: ConfigServiceOptions): ConfigService {
       reasoningEffort: patch.reasoningEffort ?? current.reasoningEffort,
     } as AgentRuntimeConfigPayload;
     return next;
+  }
+
+  function rejectLegacyMcpWrite(patch: AgentRuntimeConfigPatch): void {
+    if (Object.hasOwn(patch, "mcpServers")) {
+      throw new BadRequestError(LEGACY_MCP_WRITE_DISABLED_MESSAGE, { code: "legacy_mcp_config_disabled" });
+    }
   }
 
   function mergeEnv(currentEnv: EnvEntry[], patchEnv: EnvEntry[]): EnvEntry[] {

--- a/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
+++ b/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
@@ -988,6 +988,16 @@ describe("page SSR smoke coverage", () => {
         ),
       ).toContain(expected);
     }
+    expect(
+      renderPage(
+        <Routes>
+          <Route path="/agents/:uuid" element={<AgentDetailPage />}>
+            <Route path="tools" element={<ToolsTab />} />
+          </Route>
+        </Routes>,
+        "/agents/agent-1/tools",
+      ),
+    ).toContain("Legacy per-agent MCP editing is disabled");
   });
 
   it("renders agent detail sections with populated draft rows", async () => {

--- a/packages/web/src/pages/agent-detail/__tests__/use-config-draft.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/use-config-draft.test.tsx
@@ -99,7 +99,6 @@ describe("useConfigDraft", () => {
 
     expect(latest?.summary.counts).toMatchObject({ mcp: 1, env: 2, git: 1 });
     expect(latest?.buildPayloadPatch()).toMatchObject({
-      mcpServers: [{ name: "docs", transport: "http", url: "https://docs.example.com/mcp" }],
       env: [
         { key: "MODE", value: "dev", sensitive: false },
         { key: "NEW_FLAG", value: "1", sensitive: false },
@@ -109,6 +108,7 @@ describe("useConfigDraft", () => {
         { url: "git@github.com:acme/api.git", localPath: "api" },
       ],
     });
+    expect(latest?.buildPayloadPatch()).not.toHaveProperty("mcpServers");
 
     act(() => {
       latest?.undoDeleteEnv("env-1");

--- a/packages/web/src/pages/agent-detail/tools-tab.tsx
+++ b/packages/web/src/pages/agent-detail/tools-tab.tsx
@@ -1,16 +1,10 @@
-import { useMemo } from "react";
 import { Navigate } from "react-router";
+import { Section } from "../../components/ui/section.js";
 import { useAgentDetailContext } from "./layout-context.js";
-import { McpSection } from "./mcp-section.js";
 import { sectionAnchorId } from "./save-bar.js";
 
 export function ToolsTab() {
   const ctx = useAgentDetailContext();
-  const otherNames = useMemo(() => {
-    const active = ctx.draft.draft.mcp.filter((i) => i.status !== "deleted");
-    return (exceptKey: string | null): ReadonlySet<string> =>
-      new Set(active.filter((i) => i.key !== exceptKey).map((i) => i.value.name.toLowerCase()));
-  }, [ctx.draft.draft.mcp]);
 
   // Hidden from buildTabs for non-config-editable agents; redirect stale
   // deep links to Profile so we don't render a blank page.
@@ -18,15 +12,30 @@ export function ToolsTab() {
   if (!ctx.config) return null;
   return (
     <div id={sectionAnchorId("mcp")}>
-      <McpSection
-        items={ctx.draft.draft.mcp}
-        otherNames={otherNames}
-        onAdd={ctx.draft.addMcp}
-        onUpdate={ctx.draft.updateMcp}
-        onDelete={ctx.draft.deleteMcp}
-        onUndoDelete={ctx.draft.undoDeleteMcp}
-        disabled={ctx.agent.status !== "active"}
-      />
+      <Section
+        title="MCP servers"
+        count={ctx.draft.draft.mcp.filter((item) => item.status !== "deleted").length}
+        description="Legacy per-agent MCP editing is disabled. Team MCP Resources will manage MCP configuration."
+      >
+        {ctx.draft.draft.mcp.length === 0 ? (
+          <p className="text-body text-muted-foreground" style={{ padding: "var(--sp-3) 0" }}>
+            No MCP servers are configured.
+          </p>
+        ) : (
+          <div className="space-y-2" style={{ padding: "var(--sp-3) 0" }}>
+            {ctx.draft.draft.mcp
+              .filter((item) => item.status !== "deleted")
+              .map((item) => (
+                <div key={item.key} className="flex min-w-0 items-center gap-2 text-body">
+                  <span className="text-caption rounded bg-muted px-1.5 py-0.5 font-mono shrink-0">
+                    {item.value.transport}
+                  </span>
+                  <span className="font-medium font-mono shrink-0">{item.value.name}</span>
+                </div>
+              ))}
+          </div>
+        )}
+      </Section>
     </div>
   );
 }

--- a/packages/web/src/pages/agent-detail/use-config-draft.ts
+++ b/packages/web/src/pages/agent-detail/use-config-draft.ts
@@ -248,10 +248,8 @@ export function useConfigDraft(cfg: AgentRuntimeConfig | undefined): UseConfigDr
     if (promptDirty) patch.prompt = { append: draft.promptAppend };
     if (modelDirty) patch.model = draft.model;
     if (reasoningEffortDirty) patch.reasoningEffort = draft.reasoningEffort;
-    const mcpDirty = summary.counts.mcp > 0;
     const envDirty = summary.counts.env > 0;
     const gitDirty = summary.counts.git > 0;
-    if (mcpDirty) patch.mcpServers = draft.mcp.filter((i) => i.status !== "deleted").map((i) => i.value);
     if (envDirty) {
       patch.env = draft.env
         .filter((i) => i.status !== "deleted")


### PR DESCRIPTION
## Summary
- Web/CLI/Server close the legacy `mcpServers` write entry points.
- Runtime consumption of `payload.mcpServers` is preserved for existing resolved config paths.
- Skill discovery/upload reporting remains enabled; daemon now skips stale local aliases that are not pinned to this client before uploading skills.
- `GET/PATCH /api/v1/agents/:uuid/skills` stays available.

## Tests
- `pnpm --dir packages/server exec vitest run src/__tests__/admin-agent-config.test.ts src/__tests__/agent-skills.test.ts`
- `pnpm --dir packages/web exec vitest run src/pages/__tests__/page-ssr-smoke.test.tsx src/pages/__tests__/web-dom-interactions.test.tsx src/pages/agent-detail/__tests__/use-config-draft.test.tsx`
- `pnpm --dir apps/cli exec vitest run src/__tests__/agent-config-cli.test.ts`
- `pnpm --dir apps/cli exec vitest run src/__tests__/daemon-start-command.test.ts src/__tests__/runtime-provider-reconcile.test.ts src/__tests__/agent-config-cli.test.ts`
- `pnpm --dir packages/server exec vitest run src/__tests__/agent-skills.test.ts`
- `pnpm exec biome check apps/cli/src/__tests__/agent-config-cli.test.ts apps/cli/src/commands/agent/config/add-mcp.ts packages/server/src/__tests__/admin-agent-config.test.ts packages/server/src/services/config-service.ts packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx packages/web/src/pages/agent-detail/__tests__/use-config-draft.test.tsx packages/web/src/pages/agent-detail/tools-tab.tsx packages/web/src/pages/agent-detail/use-config-draft.ts`
- `pnpm exec biome check apps/cli/src/core/runtime-provider-reconcile.ts apps/cli/src/core/index.ts apps/cli/src/commands/daemon/start.ts apps/cli/src/__tests__/runtime-provider-reconcile.test.ts apps/cli/src/__tests__/daemon-start-command.test.ts`

## Reviewer note
- codex-reviewer has reviewed and approved the original MCP write-shielding change.
- The only noted behavior is that an expired `expectedVersion` can return 409 before the MCP-specific rejection; this is acceptable optimistic-lock behavior.
- Follow-up investigation found the skills-upload 404 was not a route/path issue; it was stale local agent alias handling. This PR now skips those stale aliases and points operators at `first-tree agent prune --dry-run`.