### PR TITLE
test: clean final hub fixture hostname

### DIFF
--- a/apps/cli/src/__tests__/client-runtime-context-tree.test.ts
+++ b/apps/cli/src/__tests__/client-runtime-context-tree.test.ts
@@ -461,7 +461,7 @@ describe("ClientRuntime context-tree wiring", () => {
     vi.mocked(fs.watch).mockReturnValueOnce(fakeWatcher as unknown as ReturnType<typeof fs.watch>);
 
     const { ClientRuntime } = await import("../core/client-runtime.js");
-    const rt = new ClientRuntime("https://hub.test", "client-test");
+    const rt = new ClientRuntime("https://first-tree.test", "client-test");
     const agentsDir = join(home, "config", "agents");
     mkdirSync(agentsDir, { recursive: true });
     rt.watchAgentsDir(agentsDir);


### PR DESCRIPTION
## Summary
- Replace one missed `https://hub.test` fixture in `client-runtime-context-tree.test.ts` with `https://first-tree.test`.
- No production code or behavior changes.

## Audit note
A focused scan for the previously-cleaned stale patterns now has no matches:

`firsttreehub|hub\.test|hub\.example|ft-hub|ft_hub|hub servers|production hub schema|Hub down|hub down|hub offline|hub unavailable|hub unreachable|Hub SDK reference|hub web console|core hub routing|hub-side|hub client runtime`

Remaining `hub` occurrences are intentional categories: internal identifiers (`FirstTreeHubSDK`, `HubClient`, `HubUrlDerivationError`, etc.), protocol/schema names (`hub_organization_id`, `x-hub-signature-256`, Kael `hub_*` payload fields), historical migration/proposal paths, `agent-hub` Context Tree paths, `hub-session-*` branch compatibility, and legacy cleanup matchers.

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm check`
- `pnpm --filter first-tree-dev exec vitest run --maxWorkers=2 src/__tests__/client-runtime-context-tree.test.ts`
