### PR TITLE
fix(server): restore unread badge when agent emits final-text turn output

### DIFF
--- a/packages/server/src/__tests__/agent-final-text-purpose.test.ts
+++ b/packages/server/src/__tests__/agent-final-text-purpose.test.ts
@@ -2,8 +2,9 @@ import { and, eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 import { inboxEntries } from "../db/schema/inbox-entries.js";
 import { createChat } from "../services/chat.js";
+import { createMeChat, listMeChats } from "../services/me-chat.js";
 import { sendMessage } from "../services/message.js";
-import { createTestAgent, useTestApp } from "./helpers.js";
+import { createTestAdmin, createTestAgent, useTestApp } from "./helpers.js";
 
 /**
  * `purpose: "agent-final-text"` bypass channel.
@@ -164,6 +165,125 @@ describe("sendMessage — agent-final-text bypass (v1 §四 改造 4 b)", () => 
       purpose: "agent-final-text",
     });
     expect(res.statusCode).toBe(201);
+  });
+
+  /*
+   * Unread badge propagation on `agent-final-text`.
+   *
+   * The original symptom (production bug, 2026-06-01): after PR #633 retired
+   * implicit routing, an agent's final-text turn output stopped bumping the
+   * human peer's `chat_user_state.unread_mention_count`, because the message
+   * carries empty `metadata.mentions` and `chat-projection.applyAfterFanOut`
+   * early-returned on `mentionedAgentIds.length === 0`. The chat list lost
+   * its red dot when an agent finished a turn — the "agent done" signal
+   * humans rely on.
+   *
+   * The fix opts the projection into a final-text-specific bump branch that
+   * targets only human stakeholders:
+   *   - speaker branch: human speakers in this chat (the 1:1 peer)
+   *   - watcher branch: watchers whose managed agent IS the sender (the
+   *     group case where the manager doesn't speak)
+   * Other agent speakers are NOT bumped — final-text never wakes another
+   * agent, and we don't want to pollute their unread state either.
+   */
+  it("bumps the human peer's unread counter in a 1:1 chat (regression for the lost red dot)", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const peer = await createTestAgent(app, { name: `ft1-${crypto.randomUUID().slice(0, 6)}` });
+
+    const { chatId } = await createMeChat(app.db, admin.humanAgentUuid, admin.organizationId, {
+      participantIds: [peer.agent.uuid],
+    });
+
+    await sendMessage(app.db, chatId, peer.agent.uuid, {
+      source: "api",
+      format: "text",
+      content: "i am done — turn ended",
+      purpose: "agent-final-text",
+    });
+
+    const list = await listMeChats(app.db, admin.humanAgentUuid, admin.memberId, admin.organizationId, {
+      limit: 10,
+      filter: "all",
+      engagement: "all",
+    });
+    const row = list.rows.find((r) => r.chatId === chatId);
+    expect(row?.unreadMentionCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it("bumps the manager-watcher's unread when the watched agent emits final text in a group chat", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const { createAgent } = await import("../services/agent.js");
+    const managed = await createAgent(app.db, {
+      name: `ftw-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "Watched",
+      managerId: admin.memberId,
+      organizationId: admin.organizationId,
+      clientId: undefined,
+    });
+    // Peer is owned by a different admin, so admin is a watcher of `managed`
+    // only — not a speaker of this chat.
+    const peer = await createTestAgent(app, { name: `ftp-${crypto.randomUUID().slice(0, 6)}` });
+
+    const { chatId } = await createMeChat(app.db, peer.agent.uuid, peer.organizationId, {
+      participantIds: [managed.uuid],
+    });
+
+    await sendMessage(app.db, chatId, managed.uuid, {
+      source: "api",
+      format: "text",
+      content: "turn done from managed",
+      purpose: "agent-final-text",
+    });
+
+    const list = await listMeChats(app.db, admin.humanAgentUuid, admin.memberId, admin.organizationId, {
+      limit: 10,
+      filter: "all",
+      engagement: "all",
+    });
+    const row = list.rows.find((r) => r.chatId === chatId);
+    expect(row?.unreadMentionCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it("does NOT bump non-human speaker peers' unread state on final text (avoid polluting agent unread state)", async () => {
+    // Two agents under one admin; admin watches both. The sender's final
+    // text should bump the watcher (admin) but NOT the other agent peer.
+    // Pins the narrow target set: humans + watchers-of-sender only.
+    const app = getApp();
+    const a = await createTestAgent(app, { name: `ftns-${crypto.randomUUID().slice(0, 6)}` });
+    const { createAgent } = await import("../services/agent.js");
+    const b = await createAgent(app.db, {
+      name: `ftnp-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "Other",
+      managerId: a.memberId,
+      organizationId: a.organizationId,
+      clientId: undefined,
+    });
+
+    const chat = await createChat(app.db, a.agent.uuid, {
+      type: "group",
+      participantIds: [b.uuid],
+    });
+
+    await sendMessage(app.db, chat.id, a.agent.uuid, {
+      source: "api",
+      format: "text",
+      content: "final from a",
+      purpose: "agent-final-text",
+    });
+
+    // Lookup `b`'s row directly via the chat_user_state — listMeChats is
+    // user-scoped and `b` doesn't have a human-side identity, so query
+    // the table directly.
+    const { sql } = await import("drizzle-orm");
+    const rows = (await app.db.execute(
+      sql`SELECT unread_mention_count FROM chat_user_state WHERE chat_id = ${chat.id} AND agent_id = ${b.uuid}`,
+    )) as unknown as Array<{ unread_mention_count: number }>;
+    // Either no row (lazy-materialised, 0 by default) or a row with 0.
+    expect(rows[0]?.unread_mention_count ?? 0).toBe(0);
   });
 
   it("API integration: same endpoint without `purpose` still rejects no-mention sends with 400 (regression)", async () => {

--- a/packages/server/src/__tests__/agent-final-text-purpose.test.ts
+++ b/packages/server/src/__tests__/agent-final-text-purpose.test.ts
@@ -247,6 +247,73 @@ describe("sendMessage — agent-final-text bypass (v1 §四 改造 4 b)", () => 
     expect(row?.unreadMentionCount).toBeGreaterThanOrEqual(1);
   });
 
+  it("counts +1 per message even when final-text also names the human peer explicitly (no double-bump)", async () => {
+    // Regression guard for the codex review point on PR #728:
+    // `agent-final-text` + explicit `metadata.mentions: [human]` previously
+    // hit both the final-text speaker branch AND the mention speaker
+    // branch in two separate UPSERTs, incrementing the human's counter
+    // twice for a single message. The UNION'd UPSERT collapses the
+    // duplicate target row so the counter advances by exactly +1.
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const peer = await createTestAgent(app, { name: `ftd-${crypto.randomUUID().slice(0, 6)}` });
+
+    const { chatId } = await createMeChat(app.db, admin.humanAgentUuid, admin.organizationId, {
+      participantIds: [peer.agent.uuid],
+    });
+
+    await sendMessage(app.db, chatId, peer.agent.uuid, {
+      source: "api",
+      format: "text",
+      content: "done",
+      metadata: { mentions: [admin.humanAgentUuid] },
+      purpose: "agent-final-text",
+    });
+
+    const list = await listMeChats(app.db, admin.humanAgentUuid, admin.memberId, admin.organizationId, {
+      limit: 10,
+      filter: "all",
+      engagement: "all",
+    });
+    const row = list.rows.find((r) => r.chatId === chatId);
+    expect(row?.unreadMentionCount).toBe(1);
+  });
+
+  it("does NOT bump on a human-sender send that smuggles `purpose: agent-final-text` (sender-type gate)", async () => {
+    // Regression guard for the codex review point on PR #728:
+    // `purpose` lives on the shared sendMessage schema, so nothing at
+    // the route layer forbids a human sender from setting
+    // `agent-final-text`. The unread-bump branch is gated on
+    // `senderRow.type !== "human"` so a human's send never lands
+    // unread-bumps on co-speakers from this code path; mention-driven
+    // unread (the explicit path) is unaffected and still works.
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const peer = await createTestAgent(app, { name: `fth-${crypto.randomUUID().slice(0, 6)}` });
+
+    const { chatId } = await createMeChat(app.db, admin.humanAgentUuid, admin.organizationId, {
+      participantIds: [peer.agent.uuid],
+    });
+
+    // Human sends with the agent-final-text marker but NO mentions. The
+    // bump should not fire because the sender is human.
+    await sendMessage(app.db, chatId, admin.humanAgentUuid, {
+      source: "api",
+      format: "text",
+      content: "human-flavoured 'final text'",
+      purpose: "agent-final-text",
+    });
+
+    // Peer is an agent — query chat_user_state directly. The lazy-
+    // materialised row should be absent (or 0) since neither branch
+    // fired.
+    const { sql } = await import("drizzle-orm");
+    const rows = (await app.db.execute(
+      sql`SELECT unread_mention_count FROM chat_user_state WHERE chat_id = ${chatId} AND agent_id = ${peer.agent.uuid}`,
+    )) as unknown as Array<{ unread_mention_count: number }>;
+    expect(rows[0]?.unread_mention_count ?? 0).toBe(0);
+  });
+
   it("does NOT bump non-human speaker peers' unread state on final text (avoid polluting agent unread state)", async () => {
     // Two agents under one admin; admin watches both. The sender's final
     // text should bump the watcher (admin) but NOT the other agent peer.

--- a/packages/server/src/services/chat-projection.ts
+++ b/packages/server/src/services/chat-projection.ts
@@ -17,6 +17,12 @@
  *      speaking participants AND for watcher rows whose managed agent was
  *      mentioned. Sender row is excluded.
  *
+ *   3b. Agent-final-text unread bump: when the message is an agent's final
+ *      turn output (`bumpForAgentFinalText`, mentions-empty by construction),
+ *      bump `unread_mention_count` for human speakers (≠ sender) and for
+ *      watchers whose managed agent is the sender. Restores the "agent
+ *      finished → red dot" UX after PR #633 retired implicit 1:1 dmAuto.
+ *
  *   4. Realtime kick: fire-and-forget `pg_notify('chat_message_events', …)`
  *      so admin WS sockets can translate it into a `chat:message` frame.
  *      Failure is swallowed — durable persistence is the correctness path.
@@ -92,6 +98,19 @@ export type ApplyAfterFanOutInput = {
   contentPreview: string;
   /** When set, used as the `last_message_at` instead of NOW(). */
   messageCreatedAt?: Date;
+  /**
+   * When the send is an agent's final-text turn output (`purpose ===
+   * "agent-final-text"` upstream), bump the unread counter for human
+   * stakeholders of this chat even though the message has no `@`-mentions.
+   * Targets:
+   *   - human speakers (≠ sender) in this chat — the 1:1 human peer case.
+   *   - watcher rows whose managed agent IS the sender — the group-chat
+   *     case where the manager is a watcher, not a speaker.
+   * Restores the "agent finished → red dot for the human" UX that the
+   * previous 1:1 dmAuto + extractMentionsFromContent path provided before
+   * PR #633 retired implicit routing.
+   */
+  bumpForAgentFinalText?: boolean;
 };
 
 /**
@@ -100,7 +119,7 @@ export type ApplyAfterFanOutInput = {
  * is empty (degenerate case skips the mention UPDATEs).
  */
 export async function applyAfterFanOut(tx: DbLike, input: ApplyAfterFanOutInput): Promise<void> {
-  const { chatId, senderId, mentionedAgentIds, contentPreview, messageCreatedAt } = input;
+  const { chatId, senderId, mentionedAgentIds, contentPreview, messageCreatedAt, bumpForAgentFinalText } = input;
   const previewClipped = contentPreview.length > 0 ? contentPreview.slice(0, 200) : null;
   const ts = messageCreatedAt ?? new Date();
 
@@ -129,6 +148,55 @@ export async function applyAfterFanOut(tx: DbLike, input: ApplyAfterFanOutInput)
      WHERE chat_id = ${chatId}
        AND engagement_status = ${ARCHIVED}
   `);
+
+  // 3b. Agent-final-text unread bump (no mention required).
+  //
+  // `purpose === "agent-final-text"` (see services/message.ts purposeProfile)
+  // produces a message with empty `metadata.mentions` by construction: the
+  // explicit-only routing contract introduced in PR #633 made it the one
+  // legal mentions-empty path. As a side-effect the original 1:1 dmAuto
+  // projection — which silently bumped the human peer's unread counter so
+  // the chat list showed a red dot when their agent finished a turn —
+  // was retired with no replacement, and the badge stopped appearing.
+  //
+  // We restore that signal here without re-introducing implicit wake-up:
+  // inbox `notify=false` from `purposeProfile.forceSilentFanOut` still
+  // holds (no agent session is woken), but `chat_user_state.
+  // unread_mention_count` is bumped for the humans who should notice the
+  // agent's final output:
+  //   - speaker branch: human speakers (≠ sender) in this chat — covers
+  //     the 1:1 human-↔-agent case.
+  //   - watcher branch: watchers whose managed agent IS the sender —
+  //     covers group chats where the manager watches but does not speak.
+  // Both branches are keyed off `chat_membership.access_mode`, which is
+  // mutually exclusive per (chat, agent), so the UNION stays disjoint.
+  if (bumpForAgentFinalText) {
+    await tx.execute(sql`
+      INSERT INTO chat_user_state (chat_id, agent_id, unread_mention_count)
+      SELECT chat_id, agent_id, 1
+        FROM (
+          SELECT cm.chat_id, cm.agent_id
+            FROM chat_membership cm
+            JOIN agents a ON a.uuid = cm.agent_id
+           WHERE cm.chat_id     = ${chatId}
+             AND cm.access_mode = 'speaker'
+             AND cm.agent_id   <> ${senderId}
+             AND a.type         = 'human'
+          UNION
+          SELECT cm.chat_id, cm.agent_id
+            FROM chat_membership cm
+            JOIN members m ON m.agent_id    = cm.agent_id
+            JOIN agents  a ON a.manager_id  = m.id
+           WHERE cm.chat_id     = ${chatId}
+             AND cm.access_mode = 'watcher'
+             AND a.uuid         = ${senderId}
+             AND a.type        <> 'human'
+             AND m.status       = 'active'
+        ) targets
+      ON CONFLICT (chat_id, agent_id)
+      DO UPDATE SET unread_mention_count = chat_user_state.unread_mention_count + 1
+    `);
+  }
 
   if (mentionedAgentIds.length === 0) return;
 

--- a/packages/server/src/services/chat-projection.ts
+++ b/packages/server/src/services/chat-projection.ts
@@ -13,15 +13,15 @@
  *      from `archived` → `active` for everyone watching this chat. `deleted`
  *      rows are sticky and intentionally untouched.
  *
- *   3. Mention propagation: increment `unread_mention_count` for mentioned
- *      speaking participants AND for watcher rows whose managed agent was
- *      mentioned. Sender row is excluded.
- *
- *   3b. Agent-final-text unread bump: when the message is an agent's final
- *      turn output (`bumpForAgentFinalText`, mentions-empty by construction),
- *      bump `unread_mention_count` for human speakers (≠ sender) and for
- *      watchers whose managed agent is the sender. Restores the "agent
- *      finished → red dot" UX after PR #633 retired implicit 1:1 dmAuto.
+ *   3. Unread counter propagation: increment `unread_mention_count` via a
+ *      single UNION'd UPSERT. Branches: mentioned speakers (≠ sender),
+ *      watchers whose managed non-human agent was mentioned, plus —
+ *      when `bumpForAgentFinalText` is set — human speakers (≠ sender)
+ *      and watchers whose managed agent IS the sender. UNION dedupes any
+ *      target row that satisfies more than one branch so the counter
+ *      advances by exactly +1 per message. The final-text branch
+ *      restores the "agent finished → red dot" UX that PR #633 retired
+ *      along with the 1:1 dmAuto projection.
  *
  *   4. Realtime kick: fire-and-forget `pg_notify('chat_message_events', …)`
  *      so admin WS sockets can translate it into a `chat:message` frame.
@@ -149,105 +149,96 @@ export async function applyAfterFanOut(tx: DbLike, input: ApplyAfterFanOutInput)
        AND engagement_status = ${ARCHIVED}
   `);
 
-  // 3b. Agent-final-text unread bump (no mention required).
+  // 3. Unread counter propagation — single UPSERT into chat_user_state.
   //
-  // `purpose === "agent-final-text"` (see services/message.ts purposeProfile)
-  // produces a message with empty `metadata.mentions` by construction: the
-  // explicit-only routing contract introduced in PR #633 made it the one
-  // legal mentions-empty path. As a side-effect the original 1:1 dmAuto
-  // projection — which silently bumped the human peer's unread counter so
-  // the chat list showed a red dot when their agent finished a turn —
-  // was retired with no replacement, and the badge stopped appearing.
+  // Two source signals feed the same counter and must be merged before
+  // the UPSERT to keep `+1 per message` semantics intact:
   //
-  // We restore that signal here without re-introducing implicit wake-up:
-  // inbox `notify=false` from `purposeProfile.forceSilentFanOut` still
-  // holds (no agent session is woken), but `chat_user_state.
-  // unread_mention_count` is bumped for the humans who should notice the
-  // agent's final output:
-  //   - speaker branch: human speakers (≠ sender) in this chat — covers
-  //     the 1:1 human-↔-agent case.
-  //   - watcher branch: watchers whose managed agent IS the sender —
-  //     covers group chats where the manager watches but does not speak.
-  // Both branches are keyed off `chat_membership.access_mode`, which is
-  // mutually exclusive per (chat, agent), so the UNION stays disjoint.
-  if (bumpForAgentFinalText) {
-    await tx.execute(sql`
-      INSERT INTO chat_user_state (chat_id, agent_id, unread_mention_count)
-      SELECT chat_id, agent_id, 1
-        FROM (
-          SELECT cm.chat_id, cm.agent_id
-            FROM chat_membership cm
-            JOIN agents a ON a.uuid = cm.agent_id
-           WHERE cm.chat_id     = ${chatId}
-             AND cm.access_mode = 'speaker'
-             AND cm.agent_id   <> ${senderId}
-             AND a.type         = 'human'
-          UNION
-          SELECT cm.chat_id, cm.agent_id
-            FROM chat_membership cm
-            JOIN members m ON m.agent_id    = cm.agent_id
-            JOIN agents  a ON a.manager_id  = m.id
-           WHERE cm.chat_id     = ${chatId}
-             AND cm.access_mode = 'watcher'
-             AND a.uuid         = ${senderId}
-             AND a.type        <> 'human'
-             AND m.status       = 'active'
-        ) targets
-      ON CONFLICT (chat_id, agent_id)
-      DO UPDATE SET unread_mention_count = chat_user_state.unread_mention_count + 1
+  //   A. Mention propagation (always on when the message has explicit
+  //      mentions). Speaker branch: mentioned ∩ chat speakers, sender
+  //      excluded. Watcher branch: watchers whose managed non-human
+  //      agent was mentioned.
+  //
+  //   B. Agent-final-text bump (only when `bumpForAgentFinalText`).
+  //      `purpose === "agent-final-text"` carries empty mentions by
+  //      construction — PR #633's explicit-only contract made it the
+  //      one legal mentions-empty path, which incidentally retired the
+  //      1:1 dmAuto projection that used to bump the human peer's red
+  //      dot when their agent finished a turn. We restore that signal
+  //      here without re-introducing implicit wake-up (inbox stays
+  //      `notify=false` via `purposeProfile.forceSilentFanOut`).
+  //      Speaker branch: human speakers (≠ sender) in this chat —
+  //      covers 1:1 human-↔-agent. Watcher branch: watchers whose
+  //      managed agent IS the sender — covers group chats where the
+  //      manager doesn't speak.
+  //
+  // All applicable branches are UNIONed into a single SELECT. UNION is
+  // set-distinct, so a target row that satisfies more than one branch
+  // (e.g. final-text + explicit mention of the same human peer)
+  // collapses to a single row → `unread_mention_count` advances by
+  // exactly +1 per message regardless of how many branches hit it.
+  // ON CONFLICT semantics mirror the prior implementation: missing
+  // row → INSERT count=1; existing → UPDATE count = count + 1.
+  const wantsMentionBump = mentionedAgentIds.length > 0;
+  if (!wantsMentionBump && !bumpForAgentFinalText) return;
+
+  const branches: ReturnType<typeof sql>[] = [];
+
+  if (wantsMentionBump) {
+    const mentionedList = sql.join(
+      mentionedAgentIds.map((id) => sql`${id}`),
+      sql`, `,
+    );
+    branches.push(sql`
+      SELECT cm.chat_id, cm.agent_id
+        FROM chat_membership cm
+       WHERE cm.chat_id     = ${chatId}
+         AND cm.access_mode = 'speaker'
+         AND cm.agent_id    IN (${mentionedList})
+         AND cm.agent_id   <> ${senderId}
+    `);
+    branches.push(sql`
+      SELECT cm.chat_id, cm.agent_id
+        FROM chat_membership cm
+        JOIN members m  ON m.agent_id    = cm.agent_id
+        JOIN agents  a  ON a.manager_id  = m.id
+       WHERE cm.chat_id     = ${chatId}
+         AND cm.access_mode = 'watcher'
+         AND a.uuid         IN (${mentionedList})
+         AND a.type        <> 'human'
+         AND m.status       = 'active'
     `);
   }
 
-  if (mentionedAgentIds.length === 0) return;
+  if (bumpForAgentFinalText) {
+    branches.push(sql`
+      SELECT cm.chat_id, cm.agent_id
+        FROM chat_membership cm
+        JOIN agents a ON a.uuid = cm.agent_id
+       WHERE cm.chat_id     = ${chatId}
+         AND cm.access_mode = 'speaker'
+         AND cm.agent_id   <> ${senderId}
+         AND a.type         = 'human'
+    `);
+    branches.push(sql`
+      SELECT cm.chat_id, cm.agent_id
+        FROM chat_membership cm
+        JOIN members m ON m.agent_id    = cm.agent_id
+        JOIN agents  a ON a.manager_id  = m.id
+       WHERE cm.chat_id     = ${chatId}
+         AND cm.access_mode = 'watcher'
+         AND a.uuid         = ${senderId}
+         AND a.type        <> 'human'
+         AND m.status       = 'active'
+    `);
+  }
 
-  // 3. Mention counter propagation — single UPSERT into chat_user_state.
-  //
-  // The target set is built via a UNION of two disjoint queries
-  // (access_mode='speaker' XOR access_mode='watcher' is enforced by the
-  // chat_membership table structure), so the same (chat_id, agent_id)
-  // row never appears twice in the VALUES list — safe for ON CONFLICT
-  // DO UPDATE.
-  //
-  // Speaker branch:
-  //   - target = mentioned ∩ chat speakers, sender excluded
-  //   - these agents were directly @-mentioned in the message
-  //
-  // Watcher branch:
-  //   - target = (manager's human-agent) of any mentioned non-human,
-  //     restricted to watchers of this chat (i.e. the manager itself
-  //     is NOT a speaker — otherwise their counter is already bumped
-  //     by the speaker branch via the explicit @ on themselves).
-  //   - sender exclusion is not needed here: the sender is by
-  //     definition a speaker, never a watcher row.
-  //
-  // chat_user_state rows are lazily materialised: missing → INSERT
-  // with count=1; existing → UPDATE count = count + 1.
-  const mentionedList = sql.join(
-    mentionedAgentIds.map((id) => sql`${id}`),
-    sql`, `,
-  );
+  const targets = sql.join(branches, sql` UNION `);
 
   await tx.execute(sql`
     INSERT INTO chat_user_state (chat_id, agent_id, unread_mention_count)
     SELECT chat_id, agent_id, 1
-      FROM (
-        SELECT cm.chat_id, cm.agent_id
-          FROM chat_membership cm
-         WHERE cm.chat_id     = ${chatId}
-           AND cm.access_mode = 'speaker'
-           AND cm.agent_id    IN (${mentionedList})
-           AND cm.agent_id   <> ${senderId}
-        UNION
-        SELECT cm.chat_id, cm.agent_id
-          FROM chat_membership cm
-          JOIN members m  ON m.agent_id    = cm.agent_id
-          JOIN agents  a  ON a.manager_id  = m.id
-         WHERE cm.chat_id     = ${chatId}
-           AND cm.access_mode = 'watcher'
-           AND a.uuid         IN (${mentionedList})
-           AND a.type        <> 'human'
-           AND m.status       = 'active'
-      ) targets
+      FROM (${targets}) targets
     ON CONFLICT (chat_id, agent_id)
     DO UPDATE SET unread_mention_count = chat_user_state.unread_mention_count + 1
   `);

--- a/packages/server/src/services/message.ts
+++ b/packages/server/src/services/message.ts
@@ -459,7 +459,13 @@ async function sendMessageInner(
       mentionedAgentIds: mergedMentions,
       contentPreview: previewText,
       messageCreatedAt: msg.createdAt,
-      bumpForAgentFinalText: isAgentFinalText,
+      // Restrict the final-text unread bump to non-human senders.
+      // `purpose` lives on the shared sendMessage schema, so a human-
+      // authored web send could in principle set it; gating here keeps
+      // the human-as-sender path out of the new projection branch even
+      // if the rest of `agent-final-text` semantics (skipMentionEnforcement,
+      // forceSilentFanOut) happen to fire for that caller.
+      bumpForAgentFinalText: isAgentFinalText && senderRow.type !== "human",
     });
 
     return {

--- a/packages/server/src/services/message.ts
+++ b/packages/server/src/services/message.ts
@@ -459,6 +459,7 @@ async function sendMessageInner(
       mentionedAgentIds: mergedMentions,
       contentPreview: previewText,
       messageCreatedAt: msg.createdAt,
+      bumpForAgentFinalText: isAgentFinalText,
     });
 
     return {


### PR DESCRIPTION
## Summary
- Agent finishing a turn (`purpose: "agent-final-text"`) stopped triggering the human's chat-list red dot after PR #633 retired the 1:1 implicit `dmAuto` projection. The final-text path carries empty `metadata.mentions` by construction, and `applyAfterFanOut` early-returns before any `unread_mention_count` bump.
- Add a final-text-specific UPSERT branch in `chat-projection.applyAfterFanOut` that bumps unread only for human stakeholders: human speakers (≠ sender) in this chat, and watchers whose managed agent IS the sender. `forceSilentFanOut` still holds — no agent session is woken; only the human red dot returns.
- `message.ts` plumbs `isAgentFinalText` through as `bumpForAgentFinalText`.

## Why this scope
- Other agent speakers are deliberately NOT bumped: final-text never wakes another agent, and we don't want to pollute non-human unread state with "another agent finished" signals.
- 1:1 dmAuto + `extractMentionsFromContent` are not reintroduced — the fix lives in the projection, not in routing.

## Reproduction (QA, staging, 2026-06-01)
- Chat `9a3a8292-1bad-4105-b5e8-665b3bada304` (human ↔ `yzw-assistant`): after agent final text at `08:38:20Z`, human-side `/orgs/:orgId/chats` returned `unreadMentionCount=0`. Manual `POST /chats/:chatId/unread` could push it to 1 → confirms badge data source works; problem isolated to the projection path.
- Full QA repro report: `/Users/yuezengwu/.first-tree-staging/data/workspaces/qa/.qa-local/unread-final-badge-repro-20260601/report.md`
- QA regression report on the fix: `/Users/yuezengwu/.first-tree-staging/data/workspaces/qa/.qa-local/final-text-unread-fix-regression-20260601/report.md`

## Test plan
- [x] `pnpm --filter @first-tree/server exec vitest run src/__tests__/agent-final-text-purpose.test.ts` — 9/9 (3 new + 6 existing)
- [x] `pnpm --filter @first-tree/server exec vitest run src/__tests__/me-chat-service.test.ts src/__tests__/direct-chat-auto-mention.test.ts` — 31/31 (adjacent regression)
- [x] `pnpm --filter @first-tree/server test` — 152 files / 1262 tests pass
- [x] `pnpm check` — pass (1227 files)
- [x] `pnpm typecheck` — pass (13/13 turbo tasks)
- [x] `git diff --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)