### PR TITLE
fix(client): inline tools doc in codex briefing

### DIFF
--- a/packages/client/src/__tests__/bootstrap.test.ts
+++ b/packages/client/src/__tests__/bootstrap.test.ts
@@ -9,6 +9,7 @@ import {
   CONTEXT_TREE_HEAD_REL,
   type ContextTreeBinding,
   deepEqualIdentity,
+  generateToolsDoc,
   type InstallFirstTreeIntegrationExec,
   installCoreSkills,
   installFirstTreeIntegration,
@@ -254,6 +255,21 @@ describe("bootstrapWorkspace", () => {
     // requires改造 4 to overwrite.
     expect(content).not.toContain("Your final text response is automatically delivered");
     expect(content).not.toMatch(/Otherwise it falls back to a direct chat/i);
+  });
+
+  it("tools.md is generated from the shared tools doc helper", () => {
+    const workspace = join(tmpBase, "ws-tools-helper");
+    mkdirSync(workspace, { recursive: true });
+
+    bootstrapWorkspace({
+      workspacePath: workspace,
+      identity: makeIdentity(),
+      contextTreePath: null,
+      serverUrl: "http://localhost:8000",
+    });
+
+    const content = readFileSync(join(workspace, ".agent", "tools.md"), "utf-8");
+    expect(content).toBe(generateToolsDoc());
   });
 
   it("tools.md uses the channel-resolved binary name when the CLI binding points at staging", () => {

--- a/packages/client/src/__tests__/codex-bootstrap.test.ts
+++ b/packages/client/src/__tests__/codex-bootstrap.test.ts
@@ -1,8 +1,11 @@
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { AgentRuntimeConfigPayload } from "@first-tree/shared";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { buildCodexAgentBriefing } from "../handlers/codex.js";
 import { bootstrapWorkspace, FIRST_TREE_WORKSPACE_MARKER } from "../runtime/bootstrap.js";
+import type { ChatContext } from "../runtime/chat-context.js";
 import { setCliBinding } from "../runtime/cli-binding.js";
 
 // `bootstrapWorkspace` internally writes `.agent/tools.md`, which reads the
@@ -13,6 +16,21 @@ import { setCliBinding } from "../runtime/cli-binding.js";
 beforeAll(() => {
   setCliBinding({ binName: "first-tree", packageName: "first-tree" });
 });
+
+function codexPayload(
+  overrides: Partial<Extract<AgentRuntimeConfigPayload, { kind: "codex" }>> = {},
+): AgentRuntimeConfigPayload {
+  return {
+    kind: "codex",
+    prompt: { append: "" },
+    model: "",
+    mcpServers: [],
+    env: [],
+    gitRepos: [],
+    reasoningEffort: "high",
+    ...overrides,
+  };
+}
 
 describe("bootstrapWorkspace — codex briefing + workspace marker", () => {
   let workspacePath: string;
@@ -85,5 +103,34 @@ describe("bootstrapWorkspace — codex briefing + workspace marker", () => {
     });
 
     expect(existsSync(join(workspacePath, "AGENTS.md"))).toBe(false);
+  });
+
+  it("inlines First Tree tools and messaging rules into the Codex AGENTS.md briefing", () => {
+    setCliBinding({ binName: "first-tree-staging", packageName: "first-tree-staging" });
+    const chatContext: ChatContext = {
+      chatId: "chat-1",
+      title: "Codex routing",
+      topic: "Codex routing",
+      participants: [
+        { name: "baixiaohang", displayName: "Bai Xiaohang", type: "human" },
+        { name: "codex-developer", displayName: "Codex Developer", type: "agent" },
+      ],
+    };
+
+    const briefing = buildCodexAgentBriefing(
+      codexPayload({ prompt: { append: "Follow the local implementation plan." } }),
+      chatContext,
+      "/workspaces/codex-developer",
+      [],
+    );
+
+    expect(briefing).toContain("Follow the local implementation plan.");
+    expect(briefing).toContain("## Current Chat Context");
+    expect(briefing).toContain("# First Tree Agent Runtime");
+    expect(briefing).toContain("## Communication Rules");
+    expect(briefing).toContain("first-tree-staging chat invite");
+    expect(briefing).toContain("first-tree-staging chat send");
+    expect(briefing).toContain("does NOT wake other agents");
+    expect(briefing).not.toContain("`.agent/tools.md` for the");
   });
 });

--- a/packages/client/src/handlers/codex.ts
+++ b/packages/client/src/handlers/codex.ts
@@ -8,6 +8,7 @@ import {
   buildChatSystemPrompt,
   deepEqualIdentity,
   FIRST_TREE_WORKSPACE_MARKER,
+  generateToolsDoc,
   installCoreSkills,
   installFirstTreeIntegration,
   isHubWorktreeMarker,
@@ -316,6 +317,42 @@ export function buildCodexThreadOptions(payload: AgentRuntimeConfigPayload, work
   return opts;
 }
 
+export function buildCodexAgentBriefing(
+  payload: AgentRuntimeConfigPayload,
+  chatContext: ChatContext | undefined,
+  workspaceCwd: string,
+  sourceRepos: PredeclaredSourceRepo[],
+): string {
+  const lines: string[] = [];
+  lines.push("# Agent Briefing");
+  lines.push("");
+  if (payload.prompt.append.trim()) {
+    lines.push(payload.prompt.append.trim());
+    lines.push("");
+  }
+  // Per agent-session-cwd-redesign: the Claude Code handler injects the
+  // working-directory convention + worktree list + chat context via the
+  // SDK's `systemPrompt.append`. Codex has no equivalent option, so we
+  // serialise the same block into AGENTS.md instead. The codex CLI reads
+  // AGENTS.md once at thread startup, so concurrent sessions for the same
+  // agent only race during the short window between bootstrap and CLI
+  // launch — accepted under proposal §⓪.3.
+  const perChatBlock = buildChatSystemPrompt({
+    agentHome: workspaceCwd,
+    chatContext,
+    sourceRepos,
+  }).trim();
+  if (perChatBlock.length > 0) {
+    lines.push(perChatBlock);
+    lines.push("");
+  }
+  lines.push(generateToolsDoc().trim());
+  lines.push("");
+  lines.push("Refer to `.agent/identity.json` for your agent identity, and `.agent/context/`");
+  lines.push("for organisational context (when configured).");
+  return lines.join("\n").concat("\n");
+}
+
 /**
  * Codex Handler — session-oriented handler using `@openai/codex-sdk`.
  *
@@ -423,33 +460,7 @@ export const createCodexHandler: HandlerFactory = (config) => {
     chatContext: ChatContext | undefined,
     workspaceCwd: string,
   ): string {
-    const lines: string[] = [];
-    lines.push("# Agent Briefing");
-    lines.push("");
-    if (payload.prompt.append.trim()) {
-      lines.push(payload.prompt.append.trim());
-      lines.push("");
-    }
-    // Per agent-session-cwd-redesign: the Claude Code handler injects the
-    // working-directory convention + worktree list + chat context via the
-    // SDK's `systemPrompt.append`. Codex has no equivalent option, so we
-    // serialise the same block into AGENTS.md instead. The codex CLI reads
-    // AGENTS.md once at thread startup, so concurrent sessions for the same
-    // agent only race during the short window between bootstrap and CLI
-    // launch — accepted under proposal §⓪.3.
-    const perChatBlock = buildChatSystemPrompt({
-      agentHome: workspaceCwd,
-      chatContext,
-      sourceRepos: sourceReposForPrompt,
-    }).trim();
-    if (perChatBlock.length > 0) {
-      lines.push(perChatBlock);
-      lines.push("");
-    }
-    lines.push("Refer to `.agent/identity.json` for your agent identity, `.agent/tools.md` for the");
-    lines.push("first-tree SDK reference, and `.agent/context/` for organisational context");
-    lines.push("(when configured).");
-    return lines.join("\n").concat("\n");
+    return buildCodexAgentBriefing(payload, chatContext, workspaceCwd, sourceReposForPrompt);
   }
 
   /**

--- a/packages/client/src/runtime/bootstrap.ts
+++ b/packages/client/src/runtime/bootstrap.ts
@@ -960,7 +960,7 @@ export function buildChatSystemPrompt(options: BuildChatSystemPromptOptions): st
   return sections.join("\n\n");
 }
 
-function generateToolsDoc(): string {
+export function generateToolsDoc(): string {
   // CLI binary name resolved at runtime from the channel-aware binding the
   // CLI entrypoint installs via `setCliBinding`. Prod = "first-tree", staging
   // = "first-tree-staging", dev = "first-tree-dev". Baking the channel-correct


### PR DESCRIPTION
## Summary

- Export the shared `generateToolsDoc()` helper so Codex briefing generation and `.agent/tools.md` use the same source text.
- Inline the First Tree tools/runtime documentation into Codex `AGENTS.md` via `buildCodexAgentBriefing()` instead of only pointing to `.agent/tools.md`.
- Add regression coverage for Codex briefing messaging rules and `.agent/tools.md` helper parity.

Refs #726.

## Validation

- `pnpm --filter @first-tree/client exec vitest run --maxWorkers=2 src/__tests__/codex-bootstrap.test.ts src/__tests__/bootstrap.test.ts`
- `pnpm check`
- `pnpm typecheck`

Notes: `pnpm check` still reports an existing Biome info-level template-literal suggestion in `packages/client/src/handlers/claude-code-tui/tmux-session.ts`; the command exits successfully.
