### PR TITLE
test(e2e): port direct CLI onboarding from legacy bash (Phase A of #725)

### DIFF
--- a/packages/e2e/src/framework/cli-driver/exec.ts
+++ b/packages/e2e/src/framework/cli-driver/exec.ts
@@ -52,6 +52,12 @@ export type ExecCliOptions = CliEnvOptions & {
   args: string[];
   /** Hard wall-clock timeout in ms. Default 30s. */
   timeoutMs?: number;
+  /**
+   * Working directory the spawned CLI runs from. Defaults to `REPO_ROOT`.
+   * Commands that resolve files via `process.cwd()` (e.g. `tree inspect`,
+   * `tree init` against a local source repo fixture) need this.
+   */
+  cwd?: string;
 };
 
 /**
@@ -66,7 +72,7 @@ export async function execCli(opts: ExecCliOptions): Promise<CliExecResult> {
   const child = spawn(process.execPath, [CLI_ENTRY, ...opts.args], {
     env,
     stdio: ["ignore", "pipe", "pipe"],
-    cwd: REPO_ROOT,
+    cwd: opts.cwd ?? REPO_ROOT,
   });
   let stdout = "";
   let stderr = "";

--- a/packages/e2e/src/framework/cli-json.ts
+++ b/packages/e2e/src/framework/cli-json.ts
@@ -1,0 +1,56 @@
+import { type CliExecResult, execCli, type ExecCliOptions } from "./cli-driver/exec.js";
+
+export type CliJsonResult<T> = {
+  /** Parsed stdout JSON. */
+  json: T;
+  /** Raw stdout, kept for assertions that look at side-channel text. */
+  stdout: string;
+  /** Raw stderr, kept for failure diagnostics. */
+  stderr: string;
+  /** Resolved process exit code. Always 0 when this resolves successfully. */
+  exitCode: number;
+  /** Wall-clock duration of the spawned process. */
+  durationMs: number;
+};
+
+/**
+ * Run a one-shot CLI invocation that is expected to print a single JSON
+ * document on stdout (typically commands invoked with `--json`).
+ *
+ * Failure modes that throw:
+ *   - process exit code !== 0
+ *   - stdout is empty
+ *   - stdout is not valid JSON
+ *
+ * Each error message includes the args / cwd / captured stdio so vitest's
+ * formatted failure has enough to debug without rerunning by hand.
+ */
+export async function runCliJson<T>(opts: ExecCliOptions): Promise<CliJsonResult<T>> {
+  const result: CliExecResult = await execCli(opts);
+  const ctx = `args=[${opts.args.join(" ")}] cwd=${opts.cwd ?? "<repo-root>"}`;
+
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `runCliJson: CLI exited with code ${result.exitCode} (${ctx})\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+    );
+  }
+  if (result.stdout.trim().length === 0) {
+    throw new Error(`runCliJson: CLI produced empty stdout (${ctx})\nstderr:\n${result.stderr}`);
+  }
+
+  let parsed: T;
+  try {
+    parsed = JSON.parse(result.stdout) as T;
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    throw new Error(`runCliJson: stdout was not valid JSON (${ctx}): ${reason}\nstdout:\n${result.stdout}`);
+  }
+
+  return {
+    json: parsed,
+    stdout: result.stdout,
+    stderr: result.stderr,
+    exitCode: result.exitCode,
+    durationMs: result.durationMs,
+  };
+}

--- a/packages/e2e/src/framework/cli-json.ts
+++ b/packages/e2e/src/framework/cli-json.ts
@@ -1,4 +1,4 @@
-import { type CliExecResult, execCli, type ExecCliOptions } from "./cli-driver/exec.js";
+import { type CliExecResult, type ExecCliOptions, execCli } from "./cli-driver/exec.js";
 
 export type CliJsonResult<T> = {
   /** Parsed stdout JSON. */

--- a/packages/e2e/src/framework/local-git-fixture.ts
+++ b/packages/e2e/src/framework/local-git-fixture.ts
@@ -1,0 +1,64 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+
+/**
+ * Minimal local git repo fixture for onboarding-style e2e tests that need a
+ * "fresh source repo" to point the CLI at, without cloning anything off the
+ * network.
+ *
+ * Layout (`mkdtempSync` mints the parent so concurrent describes never collide):
+ *
+ *   $TMPDIR/first-tree-e2e-fixture-XXXX/source/        ← initialized git repo
+ *
+ * `first-tree tree init` creates its sibling tree dir under the same minted
+ * parent (`.../source-tree`), so `cleanup()` rms the whole parent and clears
+ * both repos in one shot.
+ */
+
+export type LocalGitFixture = {
+  /** Absolute path to the initialized source repo (a real git checkout). */
+  repoRoot: string;
+  /** Recursively rm the minted parent dir — i.e. both `source/` and any tree
+   * dir the CLI placed alongside it. Safe to call multiple times. */
+  cleanup: () => void;
+};
+
+export function makeLocalGitFixture(): LocalGitFixture {
+  const parentDir = mkdtempSync(resolve(tmpdir(), "first-tree-e2e-fixture-"));
+  const repoRoot = resolve(parentDir, "source");
+
+  mkdirSync(repoRoot, { recursive: true });
+  writeFileSync(
+    resolve(repoRoot, "README.md"),
+    "# onboarding-direct fixture\n\nLocal fixture for e2e — created by makeLocalGitFixture.\n",
+  );
+
+  // -b main pins the default branch so the test is independent of the
+  // executor's `init.defaultBranch` config. Identity is set inline because
+  // CI runners may not have a global user.email/name configured.
+  const git = (args: string[]): void => {
+    execFileSync("git", args, {
+      cwd: repoRoot,
+      stdio: ["ignore", "ignore", "pipe"],
+      env: {
+        ...process.env,
+        GIT_AUTHOR_NAME: "first-tree e2e",
+        GIT_AUTHOR_EMAIL: "e2e@first-tree.invalid",
+        GIT_COMMITTER_NAME: "first-tree e2e",
+        GIT_COMMITTER_EMAIL: "e2e@first-tree.invalid",
+      },
+    });
+  };
+  git(["init", "-q", "-b", "main"]);
+  git(["add", "README.md"]);
+  git(["commit", "-q", "-m", "chore: initial fixture"]);
+
+  return {
+    repoRoot,
+    cleanup: () => {
+      rmSync(parentDir, { recursive: true, force: true });
+    },
+  };
+}

--- a/packages/e2e/src/tests/onboarding-direct.e2e.test.ts
+++ b/packages/e2e/src/tests/onboarding-direct.e2e.test.ts
@@ -1,0 +1,136 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { execCli } from "../framework/cli-driver/exec.js";
+import { runCliJson } from "../framework/cli-json.js";
+import { type CurrentRunHandle, readCurrentHandle } from "../framework/current-handle.js";
+import { type LocalGitFixture, makeLocalGitFixture } from "../framework/local-git-fixture.js";
+
+/**
+ * Direct CLI onboarding e2e — replaces the direct-CLI section of the legacy
+ * `e2e/onboarding-smoke.sh` (see issue #725).
+ *
+ * Scope: pure local CLI behavior. No server contact, no docker (beyond the
+ * globalSetup PG + server that other tests rely on). Source repo is a local
+ * temp git fixture (`makeLocalGitFixture`) rather than an external clone, so
+ * this test does not inherit flake from any demo repo on github.com.
+ *
+ * Sequence:
+ *   1. tree inspect       → role must be `unbound-source-repo`
+ *   2. tree init           → emits treeRoot (sibling dedicated tree dir)
+ *   3. tree inspect        → role must be `source-repo-bound`
+ *   4. tree verify         → ok === true
+ *   5. tree automation install --tier 2 --dry-run → stage === `write_rule_layer`
+ *   6. tree skill doctor   → runs to completion, emits valid JSON
+ *
+ * File-landing assertions after the chain:
+ *   - source/AGENTS.md, source/CLAUDE.md (source repo gets the managed block)
+ *   - tree/.github/workflows/validate.yml (first line is the template marker)
+ *   - tree/.first-tree/agent-templates/{developer,code-reviewer}.yaml
+ *   - tree/.first-tree/org.yaml
+ */
+
+type InspectResult = { role: string };
+type InitResult = { treeRoot: string };
+type VerifyResult = { ok: boolean };
+type AutomationDryRunResult = { stage: string };
+
+let handle: CurrentRunHandle;
+let fixture: LocalGitFixture;
+
+beforeAll(() => {
+  // We don't *use* the world handle here — the test is local-CLI only — but
+  // reading it forces an explicit setup failure if globalSetup did not run,
+  // instead of the test silently succeeding against whatever happens to be
+  // on disk.
+  handle = readCurrentHandle();
+  fixture = makeLocalGitFixture();
+});
+
+afterAll(() => {
+  fixture?.cleanup();
+});
+
+describe("direct CLI onboarding — local fixture, no external clone", () => {
+  it("walks inspect → init → verify → skill doctor against a fresh source repo", async () => {
+    const cwd = fixture.repoRoot;
+    const cliEnv = { home: handle.clientHome, serverBaseUrl: handle.serverBaseUrl };
+
+    const before = await runCliJson<InspectResult>({
+      ...cliEnv,
+      cwd,
+      args: ["tree", "inspect", "--json"],
+    });
+    expect(before.json.role, "fresh fixture should report as unbound-source-repo before init").toBe(
+      "unbound-source-repo",
+    );
+
+    const init = await runCliJson<InitResult>({
+      ...cliEnv,
+      cwd,
+      args: ["tree", "init", "--json", "--no-recursive"],
+    });
+    expect(init.json.treeRoot, "tree init should report a treeRoot path").toBeTruthy();
+    const treeRoot = init.json.treeRoot;
+
+    const after = await runCliJson<InspectResult>({
+      ...cliEnv,
+      cwd,
+      args: ["tree", "inspect", "--json"],
+    });
+    expect(after.json.role, "source repo should be bound after tree init").toBe("source-repo-bound");
+
+    const verify = await runCliJson<VerifyResult>({
+      ...cliEnv,
+      cwd,
+      args: ["tree", "verify", "--json", "--tree-path", treeRoot],
+    });
+    expect(verify.json.ok, "tree verify should report ok=true on a freshly onboarded tree").toBe(true);
+
+    const automation = await runCliJson<AutomationDryRunResult>({
+      ...cliEnv,
+      cwd,
+      args: ["tree", "automation", "install", "--tier", "2", "--tree-path", treeRoot, "--dry-run", "--json"],
+    });
+    expect(automation.json.stage, "automation install --dry-run should report stage=write_rule_layer").toBe(
+      "write_rule_layer",
+    );
+
+    // skill doctor: mirror the legacy bash semantics — capture stdout and
+    // confirm it is valid JSON, but do NOT gate on exit code. Doctor exits
+    // non-zero when shipped skill payloads are out of sync, which is a real
+    // signal worth surfacing but is not the contract this test pins (Phase B
+    // will add a dedicated skill-doctor health test).
+    const doctor = await execCli({
+      ...cliEnv,
+      cwd,
+      args: ["tree", "skill", "doctor", "--json", "--root", cwd],
+    });
+    expect(doctor.stdout.trim(), "skill doctor should emit JSON to stdout").not.toBe("");
+    expect(() => JSON.parse(doctor.stdout), `skill doctor stdout was not valid JSON:\n${doctor.stdout}`).not.toThrow();
+
+    // Source repo: managed-block files land on the source side.
+    expect(existsSync(resolve(cwd, "AGENTS.md")), "AGENTS.md should be written into the source repo").toBe(true);
+    expect(existsSync(resolve(cwd, "CLAUDE.md")), "CLAUDE.md should be written into the source repo").toBe(true);
+
+    // Tree repo: workflow + agent templates + org config land on the tree side.
+    const validateYml = resolve(treeRoot, ".github/workflows/validate.yml");
+    expect(existsSync(validateYml), "validate.yml should be written into the tree repo").toBe(true);
+    const firstLine = readFileSync(validateYml, "utf8").split(/\r?\n/, 1)[0];
+    expect(firstLine, "validate.yml first line must be the managed template marker").toBe(
+      "# first-tree-template-version: 2",
+    );
+
+    expect(
+      existsSync(resolve(treeRoot, ".first-tree/agent-templates/developer.yaml")),
+      "developer.yaml agent template should be written into the tree repo",
+    ).toBe(true);
+    expect(
+      existsSync(resolve(treeRoot, ".first-tree/agent-templates/code-reviewer.yaml")),
+      "code-reviewer.yaml agent template should be written into the tree repo",
+    ).toBe(true);
+    expect(existsSync(resolve(treeRoot, ".first-tree/org.yaml")), "org.yaml should be written into the tree repo").toBe(
+      true,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Phase A of #725 — replaces the direct-CLI section of `e2e/onboarding-smoke.sh` with a real Vitest e2e under `packages/e2e`. Source repo is a local temp git fixture (no external clone), so the test does not inherit demo-repo flake.

Confirmed direction with @baixiaohang in [issue #725](https://github.com/agent-team-foundation/first-tree/issues/725):
- ✅ Phase A here (this PR)
- Phase B: codex/claude prompt onboarding dropped, live GitHub `validate.yml` folded into a template self-test — follow-up PRs
- Phase C: delete `e2e/*.sh` + rewrite `.github/workflows/agent-e2e.yml` — final follow-up

## What the test covers

Chain: `tree inspect → tree init → tree inspect → tree verify → tree automation install --tier 2 --dry-run → tree skill doctor`

Assertions:
- `inspect` role flips from `unbound-source-repo` → `source-repo-bound`
- `init` reports a non-empty `treeRoot`
- `verify ok === true`
- `automation install --dry-run` reports `stage === "write_rule_layer"`
- `skill doctor` runs to completion and emits valid JSON (mirrors legacy bash — does not gate exit code; Phase B will add a dedicated skill-doctor health test)
- Source repo files: `AGENTS.md`, `CLAUDE.md`
- Tree repo files: `.github/workflows/validate.yml` (first line is `# first-tree-template-version: 2`), `.first-tree/agent-templates/{developer,code-reviewer}.yaml`, `.first-tree/org.yaml`

## Files

| File | Type | Notes |
|---|---|---|
| `packages/e2e/src/framework/cli-driver/exec.ts` | mod | optional `cwd?: string` on `ExecCliOptions`; default unchanged |
| `packages/e2e/src/framework/cli-json.ts` | new | `runCliJson<T>` wraps `execCli` with JSON parse + exit-code gate |
| `packages/e2e/src/framework/local-git-fixture.ts` | new | `mkdtemp` + `git init/commit`; returns `{ repoRoot, cleanup }` |
| `packages/e2e/src/tests/onboarding-direct.e2e.test.ts` | new | the test itself |

No changes to product packages (`apps/cli`, `packages/server`, `packages/client`, `packages/web`). QA agent independently confirmed the same: only the e2e test package is touched and no product package reverse-imports `@first-tree/e2e`.

## Test plan

- [x] `pnpm --filter @first-tree/e2e typecheck` passes
- [x] `pnpm --filter @first-tree/e2e exec vitest run src/tests/onboarding-direct.e2e.test.ts src/tests/smoke.e2e.test.ts` — 2 files / 4 tests passing
- [x] `pnpm --filter first-tree-dev build` passes
- [x] `pnpm --filter @first-tree/server build` passes
- [x] Full `E2E_WITH_CLIENT=1 pnpm e2e:full` run does not regress (10 failures here vs 11 on `origin/main` — the unrelated existing flakes are not from this PR)
- [ ] CI green

## Out of scope

- Wiring `onboarding-direct.e2e.test.ts` into `pnpm e2e:smoke` (currently only included by `e2e:full`) — keep the script footprint minimal until Phase C
- Deleting `e2e/onboarding-smoke.sh` / `e2e/github-validate-e2e.sh` and rewriting `.github/workflows/agent-e2e.yml` — Phase C