### PR TITLE
fix: scope onboarding agent-readiness to the org and land invitees in the right org

### DIFF
--- a/packages/server/src/__tests__/me-onboarding.test.ts
+++ b/packages/server/src/__tests__/me-onboarding.test.ts
@@ -1,5 +1,7 @@
+import crypto from "node:crypto";
 import { eq } from "drizzle-orm";
 import { describe, expect, it, vi } from "vitest";
+import { agents } from "../db/schema/agents.js";
 import { authIdentities } from "../db/schema/auth-identities.js";
 import { users } from "../db/schema/users.js";
 import { encryptValue } from "../services/crypto.js";
@@ -437,5 +439,49 @@ describe("POST /me/onboarding-completed", () => {
       payload: {},
     });
     expect(res.statusCode).toBe(401);
+  });
+});
+
+describe("GET /me — per-membership hasUsableAgent", () => {
+  const getApp = useTestApp();
+
+  type MeMembershipsBody = { memberships: Array<{ organizationId: string; hasUsableAgent: boolean }> };
+
+  it("is false for a fresh org (only the seeded human agent), true once a non-human agent exists", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+
+    const before = await app.inject({
+      method: "GET",
+      url: "/api/v1/me",
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+    });
+    const beforeRow = before
+      .json<MeMembershipsBody>()
+      .memberships.find((m) => m.organizationId === admin.organizationId);
+    expect(beforeRow?.hasUsableAgent).toBe(false);
+
+    // Drop in a non-human agent the admin manages (private — own agents
+    // count regardless of visibility).
+    const uuid = crypto.randomUUID();
+    await app.db.insert(agents).values({
+      uuid,
+      name: `a-${uuid.slice(0, 8)}`,
+      organizationId: admin.organizationId,
+      type: "agent",
+      displayName: "Assistant",
+      inboxId: `inbox_${uuid}`,
+      status: "active",
+      visibility: "private",
+      managerId: admin.memberId,
+    });
+
+    const after = await app.inject({
+      method: "GET",
+      url: "/api/v1/me",
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+    });
+    const afterRow = after.json<MeMembershipsBody>().memberships.find((m) => m.organizationId === admin.organizationId);
+    expect(afterRow?.hasUsableAgent).toBe(true);
   });
 });

--- a/packages/server/src/__tests__/oauth-flow.test.ts
+++ b/packages/server/src/__tests__/oauth-flow.test.ts
@@ -49,6 +49,10 @@ describe("GitHub OAuth onboarding flow", () => {
     // in onboarding Step 1.
     expect(orgRow.displayName).toBe("octocat's team");
 
+    // The callback carries the resolved org back so the web selects it
+    // (overriding any stale localStorage org) — here the freshly-minted team.
+    expect(params.get("org")).toBe(orgRow.id);
+
     // The new user is its admin.
     const memberRows = await app.db.select().from(members).where(eq(members.organizationId, orgRow.id));
     expect(memberRows).toHaveLength(1);
@@ -248,6 +252,9 @@ describe("GitHub OAuth invite-only single-org entry gate", () => {
     const params = new URLSearchParams(fragment);
     expect(params.get("joinPath")).toBe("invite");
     expect(params.get("next")).toBe("/");
+    // The invited org is carried back in the fragment so the web makes it the
+    // active selection instead of dropping the invitee into a stale org.
+    expect(params.get("org")).toBe(allowedOrganizationId);
 
     const userId = await findGithubUserId(app, "1201");
     const memberRows = await app.db.select().from(members).where(eq(members.userId, userId));

--- a/packages/server/src/__tests__/onboarding-readiness.test.ts
+++ b/packages/server/src/__tests__/onboarding-readiness.test.ts
@@ -1,0 +1,124 @@
+import crypto from "node:crypto";
+import { describe, expect, it } from "vitest";
+import type { Database } from "../db/connection.js";
+import { agents } from "../db/schema/agents.js";
+import { listOrgsWithUsableNonHumanAgent } from "../services/access-control.js";
+import { ensureMembership } from "../services/membership.js";
+import { createTestAdmin, useTestApp } from "./helpers.js";
+
+/**
+ * Direct-insert an agent row, bypassing the createAgent service ceremony
+ * (client pinning, quota, agent_configs) — the readiness helper only reads
+ * the `agents` table, so a plain row is enough to exercise its predicate.
+ */
+async function insertAgent(
+  db: Database,
+  opts: {
+    orgId: string;
+    managerId: string;
+    visibility: "private" | "organization";
+    status?: "active" | "suspended" | "deleted";
+    type?: "agent" | "human";
+  },
+): Promise<void> {
+  const uuid = crypto.randomUUID();
+  await db.insert(agents).values({
+    uuid,
+    name: `a-${uuid.slice(0, 8)}`,
+    organizationId: opts.orgId,
+    type: opts.type ?? "agent",
+    displayName: "Fixture Agent",
+    inboxId: `inbox_${uuid}`,
+    status: opts.status ?? "active",
+    visibility: opts.visibility,
+    managerId: opts.managerId,
+  });
+}
+
+describe("listOrgsWithUsableNonHumanAgent", () => {
+  const getApp = useTestApp();
+
+  it("an org with only the seeded human agent is NOT ready", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const set = await listOrgsWithUsableNonHumanAgent(app.db, [
+      { memberId: admin.memberId, organizationId: admin.organizationId },
+    ]);
+    // The human agent ensureMembership seeds is org-visible but type=human,
+    // so it must be excluded — a brand-new team is not "ready".
+    expect(set.has(admin.organizationId)).toBe(false);
+  });
+
+  it("my own active non-human agent makes the org ready — even when private", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    await insertAgent(app.db, { orgId: admin.organizationId, managerId: admin.memberId, visibility: "private" });
+    const set = await listOrgsWithUsableNonHumanAgent(app.db, [
+      { memberId: admin.memberId, organizationId: admin.organizationId },
+    ]);
+    expect(set.has(admin.organizationId)).toBe(true);
+  });
+
+  it("a suspended or deleted own agent does NOT count", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    await insertAgent(app.db, {
+      orgId: admin.organizationId,
+      managerId: admin.memberId,
+      visibility: "organization",
+      status: "suspended",
+    });
+    await insertAgent(app.db, {
+      orgId: admin.organizationId,
+      managerId: admin.memberId,
+      visibility: "organization",
+      status: "deleted",
+    });
+    const set = await listOrgsWithUsableNonHumanAgent(app.db, [
+      { memberId: admin.memberId, organizationId: admin.organizationId },
+    ]);
+    expect(set.has(admin.organizationId)).toBe(false);
+  });
+
+  it("another member's ORGANIZATION-visible agent counts for me (shared mature org)", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const other = await createTestAdmin(app); // just to mint a second user
+    const memberB = await ensureMembership(app.db, {
+      userId: other.userId,
+      organizationId: admin.organizationId,
+      role: "member",
+      displayName: "Member B",
+      username: `b-${crypto.randomUUID().slice(0, 6)}`,
+    });
+    await insertAgent(app.db, { orgId: admin.organizationId, managerId: memberB.id, visibility: "organization" });
+    const set = await listOrgsWithUsableNonHumanAgent(app.db, [
+      { memberId: admin.memberId, organizationId: admin.organizationId },
+    ]);
+    expect(set.has(admin.organizationId)).toBe(true);
+  });
+
+  it("another member's PRIVATE agent does NOT count for me (all-private org is not ready)", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const other = await createTestAdmin(app);
+    const memberB = await ensureMembership(app.db, {
+      userId: other.userId,
+      organizationId: admin.organizationId,
+      role: "member",
+      displayName: "Member B",
+      username: `b-${crypto.randomUUID().slice(0, 6)}`,
+    });
+    await insertAgent(app.db, { orgId: admin.organizationId, managerId: memberB.id, visibility: "private" });
+    const set = await listOrgsWithUsableNonHumanAgent(app.db, [
+      { memberId: admin.memberId, organizationId: admin.organizationId },
+    ]);
+    expect(set.has(admin.organizationId)).toBe(false);
+  });
+
+  it("returns an empty set for a caller with no memberships (no query)", async () => {
+    const app = getApp();
+    const set = await listOrgsWithUsableNonHumanAgent(app.db, []);
+    expect(set.size).toBe(0);
+  });
+});

--- a/packages/server/src/api/auth/github.ts
+++ b/packages/server/src/api/auth/github.ts
@@ -500,11 +500,18 @@ async function completeOauthFlow(
 
   const tokens = await signTokensForUser(app.config.secrets.jwtSecret, userId, app.config.auth);
 
-  const fragment = new URLSearchParams({
+  // Carry the org this callback resolved to (the invited org for an invite
+  // link, otherwise the user's primary/personal org) so the web can make it
+  // the active selection. Without this the client keeps whatever stale org
+  // sits in `localStorage.selectedOrganizationId`, dropping an invitee into
+  // their *previous* org instead of the one they just joined.
+  const fragmentParams: Record<string, string> = {
     access: tokens.accessToken,
     refresh: tokens.refreshToken,
     next,
     joinPath,
-  }).toString();
+  };
+  if (resolvedOrganizationId) fragmentParams.org = resolvedOrganizationId;
+  const fragment = new URLSearchParams(fragmentParams).toString();
   return reply.redirect(`/auth/github/complete#${fragment}`, 302);
 }

--- a/packages/server/src/api/me.ts
+++ b/packages/server/src/api/me.ts
@@ -16,7 +16,7 @@ import { members } from "../db/schema/members.js";
 import { users } from "../db/schema/users.js";
 import { NotFoundError } from "../errors.js";
 import { requireUser } from "../scope/require-user.js";
-import { listAgentsManagedByUser } from "../services/access-control.js";
+import { listAgentsManagedByUser, listOrgsWithUsableNonHumanAgent } from "../services/access-control.js";
 import { resolveAvatarImageUrl } from "../services/agent.js";
 import * as authService from "../services/auth.js";
 import * as clientService from "../services/client.js";
@@ -79,6 +79,17 @@ export async function meRoutes(app: FastifyInstance): Promise<void> {
       memberships.map((mb) => mb.organizationId),
     );
 
+    // Org-scoped onboarding readiness: which of the caller's orgs already
+    // hold a non-human agent THIS member can use (own or org-visible). The
+    // web onboarding gate keys the create-agent step off this per-org bit
+    // rather than the account-level `onboardingCompletedAt`, so a returning
+    // user who joins a brand-new / all-private org is still walked through
+    // creating an agent there. One query for the whole list — no N+1.
+    const orgsWithUsableAgent = await listOrgsWithUsableNonHumanAgent(
+      app.db,
+      memberships.map((mb) => ({ memberId: mb.memberId, organizationId: mb.organizationId })),
+    );
+
     // Surface invite URL only for users who admin at least one org. The
     // web client picks the relevant org from `selectedOrganizationId`
     // first; this is purely a convenience fallback for the default org.
@@ -103,6 +114,7 @@ export async function meRoutes(app: FastifyInstance): Promise<void> {
         role: mb.role,
         agentId: mb.agentId,
         orgHasOtherMembers: (memberCounts.get(mb.organizationId) ?? 1) > 1,
+        hasUsableAgent: orgsWithUsableAgent.has(mb.organizationId),
       })),
       onboarding: {
         step: onboardingStep,

--- a/packages/server/src/services/access-control.ts
+++ b/packages/server/src/services/access-control.ts
@@ -15,7 +15,7 @@
  */
 
 import { AGENT_STATUSES, AGENT_VISIBILITY } from "@first-tree/shared";
-import { and, eq, ne, or, type SQL } from "drizzle-orm";
+import { and, eq, inArray, ne, or, type SQL } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 import { agents } from "../db/schema/agents.js";
 import { members } from "../db/schema/members.js";
@@ -88,4 +88,38 @@ export async function listAgentsManagedByUser(
     .innerJoin(members, eq(agents.managerId, members.id))
     .leftJoin(users, eq(users.id, members.userId))
     .where(and(eq(members.userId, userId), eq(members.status, "active"), ne(agents.status, AGENT_STATUSES.DELETED)));
+}
+
+/**
+ * Org-scoped onboarding readiness. Given the caller's memberships (one
+ * `(memberId, organizationId)` row per org they belong to), return the set
+ * of orgIds in which the member has at least one *usable* non-human agent —
+ * usable = active AND (organization-visible OR managed by that member).
+ *
+ * This is the org-level "is this team set up for me" signal that gates the
+ * onboarding create-agent step. A private agent owned by *another* member
+ * does NOT count (the caller can't use it), so a freshly-joined or
+ * all-private org is correctly reported as not-ready even for a user who
+ * already completed onboarding in some other org. One query for the whole
+ * membership list — no N+1.
+ */
+export async function listOrgsWithUsableNonHumanAgent(
+  db: Database,
+  memberRows: ReadonlyArray<{ memberId: string; organizationId: string }>,
+): Promise<Set<string>> {
+  if (memberRows.length === 0) return new Set<string>();
+  const orgIds = memberRows.map((m) => m.organizationId);
+  const memberIds = memberRows.map((m) => m.memberId);
+  const rows = await db
+    .selectDistinct({ organizationId: agents.organizationId })
+    .from(agents)
+    .where(
+      and(
+        inArray(agents.organizationId, orgIds),
+        ne(agents.type, "human"),
+        eq(agents.status, AGENT_STATUSES.ACTIVE),
+        or(eq(agents.visibility, AGENT_VISIBILITY.ORGANIZATION), inArray(agents.managerId, memberIds)),
+      ),
+    );
+  return new Set(rows.map((r) => r.organizationId));
 }

--- a/packages/shared/src/schemas/me-extras.ts
+++ b/packages/shared/src/schemas/me-extras.ts
@@ -81,6 +81,14 @@ export type OnboardingEvent = z.infer<typeof onboardingEventSchema>;
  * The web onboarding flow uses this to derive "is this a solo team or a
  * team-of-teammates" without relying on the per-tab `joinPath` flag, which
  * can be lost on a different tab / device mid-onboarding.
+ *
+ * `hasUsableAgent` is true when this member can actually use a non-human
+ * agent in that org — one they manage themselves OR one another member set
+ * to `visibility="organization"`. It is the org-scoped "is this team set up
+ * for me" signal that gates onboarding's create-agent step: onboarding
+ * completion is otherwise account-level (a returning user who set up an
+ * agent in any prior org), which would wrongly skip create-agent when they
+ * join a brand-new / all-private org where they have nothing to use.
  */
 export const meMembershipSchema = z.object({
   id: z.string(),
@@ -89,5 +97,6 @@ export const meMembershipSchema = z.object({
   role: z.enum(["admin", "member"]),
   agentId: z.string(),
   orgHasOtherMembers: z.boolean(),
+  hasUsableAgent: z.boolean(),
 });
 export type MeMembership = z.infer<typeof meMembershipSchema>;

--- a/packages/web/src/auth/__tests__/auth-context-provider.test.tsx
+++ b/packages/web/src/auth/__tests__/auth-context-provider.test.tsx
@@ -57,6 +57,7 @@ const MEMBERSHIPS: MeMembership[] = [
     role: "admin",
     agentId: "human-agent-1",
     orgHasOtherMembers: true,
+    hasUsableAgent: true,
   },
   {
     id: "member-2",
@@ -65,6 +66,7 @@ const MEMBERSHIPS: MeMembership[] = [
     role: "member",
     agentId: "human-agent-2",
     orgHasOtherMembers: false,
+    hasUsableAgent: false,
   },
 ];
 

--- a/packages/web/src/auth/auth-context.tsx
+++ b/packages/web/src/auth/auth-context.tsx
@@ -74,6 +74,16 @@ type AuthContextValue = {
    * `sessionStorage.joinPath` flag could not.
    */
   orgHasOtherMembers: boolean;
+  /**
+   * `true` when the currently selected org holds a non-human agent this
+   * member can use — one they manage themselves OR one set to
+   * `visibility="organization"`. Sourced from `/me`'s per-membership
+   * `hasUsableAgent`. This is the org-scoped readiness the onboarding gate
+   * uses for the create-agent step, replacing the account-level
+   * `onboardingCompletedAt` short-circuit (which wrongly skipped onboarding
+   * for a returning user joining a brand-new / all-private org).
+   */
+  currentOrgHasUsableAgent: boolean;
   onboardingStep: "connect" | "create_agent" | "completed" | null;
   /**
    * ISO timestamp when the user dismissed onboarding ("finish later").
@@ -347,6 +357,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         agentId: currentMembership?.agentId ?? null,
         teamDisplayName: currentMembership?.organizationName ?? null,
         orgHasOtherMembers: currentMembership?.orgHasOtherMembers ?? false,
+        currentOrgHasUsableAgent: currentMembership?.hasUsableAgent ?? false,
         onboardingStep,
         onboardingDismissedAt,
         onboardingCompletedAt,

--- a/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
+++ b/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
@@ -44,6 +44,9 @@ const authMock = vi.hoisted(() => {
       agentId: nullableString("human-agent-self"),
       teamDisplayName: nullableString("Acme"),
       orgHasOtherMembers: true,
+      // Fully set-up user: connected + the selected org has a usable agent,
+      // so the workspace renders rather than redirecting to onboarding.
+      currentOrgHasUsableAgent: true,
       onboardingStep: onboardingStep("completed"),
       onboardingDismissedAt: nullableString(null),
       onboardingCompletedAt: nullableString("2026-05-01T00:00:00.000Z"),

--- a/packages/web/src/pages/invite-accept.tsx
+++ b/packages/web/src/pages/invite-accept.tsx
@@ -1,4 +1,4 @@
-import type { InvitationPreview, OrgBrief } from "@first-tree/shared";
+import type { InvitationPreview } from "@first-tree/shared";
 import { ArrowLeft, Github, TriangleAlert } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router";
@@ -28,11 +28,14 @@ import { markOnboardingResume } from "../utils/onboarding-flags.js";
 export function InviteAcceptPage() {
   const { token } = useParams<{ token: string }>();
   const navigate = useNavigate();
-  const { isAuthenticated, adoptTokens } = useAuth();
+  const { isAuthenticated, adoptTokens, selectOrganization, teamDisplayName } = useAuth();
   const [preview, setPreview] = useState<InvitationPreview | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
-  const [currentTeamName, setCurrentTeamName] = useState<string | null>(null);
+  // Current team name for the "you'll switch from X to Y" warning. Comes
+  // straight from the auth context's selected membership — no extra fetch.
+  // (`null` for unauthenticated visitors, which hides the warning.)
+  const currentTeamName = teamDisplayName;
 
   useEffect(() => {
     if (!token) return;
@@ -49,24 +52,6 @@ export function InviteAcceptPage() {
       }
     })();
   }, [token]);
-
-  // For the switch warning we need the current team's displayName, not just
-  // the orgId from the JWT. Fetched lazily — no-op for unauthenticated visitors.
-  useEffect(() => {
-    if (!isAuthenticated) return;
-    void (async () => {
-      try {
-        const orgs = await api.get<OrgBrief[]>("/me/organizations");
-        // The /me JWT carries `organizationId`; resolve via the listing so we
-        // get the human-readable display name.
-        const me = await api.get<{ member: { organizationId: string } }>("/me");
-        const current = orgs.find((o) => o.id === me.member.organizationId);
-        setCurrentTeamName(current?.displayName ?? null);
-      } catch {
-        // best-effort — switch warning just stays hidden
-      }
-    })();
-  }, [isAuthenticated]);
 
   if (!token)
     return (
@@ -97,6 +82,10 @@ export function InviteAcceptPage() {
         tokens: { accessToken: string; refreshToken: string };
       }>("/me/organizations/join", { token });
       await adoptTokens(res.tokens);
+      // Make the just-joined org the active selection, overriding any stale
+      // org left in localStorage — otherwise the user lands back in their
+      // previous team instead of the one they accepted the invite for.
+      await selectOrganization(res.organizationId);
       markOnboardingResume("invite");
       navigate("/", { replace: true });
     } catch (err) {

--- a/packages/web/src/pages/oauth-complete.tsx
+++ b/packages/web/src/pages/oauth-complete.tsx
@@ -16,7 +16,7 @@ import { markOnboardingResume } from "../utils/onboarding-flags.js";
  */
 export function OAuthCompletePage() {
   const navigate = useNavigate();
-  const { adoptTokens } = useAuth();
+  const { adoptTokens, selectOrganization } = useAuth();
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -26,6 +26,11 @@ export function OAuthCompletePage() {
     const refreshToken = params.get("refresh");
     const next = safeRedirectPath(params.get("next"));
     const joinPath = params.get("joinPath");
+    // The org this callback resolved to (invited org for an invite link).
+    // Selecting it overrides any stale `selectedOrganizationId` left in
+    // localStorage so an invitee lands in the org they just joined, not a
+    // previously-used one.
+    const org = params.get("org");
 
     if (!accessToken || !refreshToken) {
       setError("Sign-in did not complete. Please try again.");
@@ -45,9 +50,12 @@ export function OAuthCompletePage() {
 
     void (async () => {
       await adoptTokens({ accessToken, refreshToken });
+      // Set the active org BEFORE navigating so the workspace/onboarding
+      // gate evaluates against the just-joined org rather than a stale one.
+      if (org) await selectOrganization(org);
       navigate(next, { replace: true });
     })();
-  }, [adoptTokens, navigate]);
+  }, [adoptTokens, selectOrganization, navigate]);
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-background text-body text-muted-foreground">

--- a/packages/web/src/pages/onboarding/__tests__/steps.test.ts
+++ b/packages/web/src/pages/onboarding/__tests__/steps.test.ts
@@ -94,17 +94,25 @@ describe("shouldEnterOnboarding", () => {
   const base = {
     meLoaded: true,
     onboardingStep: "connect" as const,
+    currentOrgReady: false,
     onboardingDismissedAt: null,
-    onboardingCompletedAt: null,
   };
   it("redirects a fresh incomplete user (no computer yet → connect)", () => {
     expect(shouldEnterOnboarding(base)).toBe(true);
   });
-  it("redirects a user with a computer but no agent (create_agent)", () => {
-    expect(shouldEnterOnboarding({ ...base, onboardingStep: "create_agent" })).toBe(true);
+  it("redirects a connected user whose current org has no usable agent (create_agent)", () => {
+    expect(shouldEnterOnboarding({ ...base, onboardingStep: "create_agent", currentOrgReady: false })).toBe(true);
   });
-  it("bounces a server-completed-but-unfinished user so they resume the Context Tree kickoff", () => {
-    expect(shouldEnterOnboarding({ ...base, onboardingStep: "completed" })).toBe(true);
+  it("redirects an account-completed user who joined a brand-new / all-private org (org not ready)", () => {
+    // The whole point of the org-level gate: a returning user who set up an
+    // agent in a *prior* org must still create one here.
+    expect(shouldEnterOnboarding({ ...base, onboardingStep: "completed", currentOrgReady: false })).toBe(true);
+  });
+  it("does NOT redirect when connected and the current org already has a usable agent", () => {
+    expect(shouldEnterOnboarding({ ...base, onboardingStep: "completed", currentOrgReady: true })).toBe(false);
+    // Even a shared (org-visible) agent created by someone else counts — a
+    // user joining a mature org doesn't need to build their own.
+    expect(shouldEnterOnboarding({ ...base, onboardingStep: "create_agent", currentOrgReady: true })).toBe(false);
   });
   it("does not redirect before /me loads", () => {
     expect(shouldEnterOnboarding({ ...base, meLoaded: false })).toBe(false);
@@ -114,15 +122,6 @@ describe("shouldEnterOnboarding", () => {
   });
   it("does not redirect a dismissed user (they chose to hide it)", () => {
     expect(shouldEnterOnboarding({ ...base, onboardingDismissedAt: "2026-05-22T00:00:00Z" })).toBe(false);
-  });
-  it("does not redirect a terminally-finished user (completed step + completed_at set)", () => {
-    expect(
-      shouldEnterOnboarding({
-        ...base,
-        onboardingStep: "completed",
-        onboardingCompletedAt: "2026-05-22T00:00:00Z",
-      }),
-    ).toBe(false);
   });
 });
 
@@ -158,19 +157,28 @@ describe("shouldLeaveOnboarding", () => {
   const base = {
     meLoaded: true,
     onboardingStep: "connect" as const,
+    currentOrgReady: false,
     onboardingDismissedAt: null,
-    onboardingCompletedAt: null,
   };
-  it("leaves only once terminally complete", () => {
-    expect(shouldLeaveOnboarding({ ...base, onboardingCompletedAt: "2026-05-22T00:00:00Z" })).toBe(true);
+  it("leaves once connected AND the current org has a usable agent", () => {
+    expect(shouldLeaveOnboarding({ ...base, onboardingStep: "completed", currentOrgReady: true })).toBe(true);
   });
-  it("stays for an incomplete user", () => {
+  it("stays while the user hasn't connected a computer yet (connect step)", () => {
     expect(shouldLeaveOnboarding(base)).toBe(false);
+    expect(shouldLeaveOnboarding({ ...base, currentOrgReady: true })).toBe(false);
   });
-  it("stays for a merely-dismissed user who deliberately returned via Resume", () => {
-    expect(shouldLeaveOnboarding({ ...base, onboardingDismissedAt: "2026-05-22T00:00:00Z" })).toBe(false);
+  it("stays for a connected user whose current org still has no usable agent", () => {
+    expect(shouldLeaveOnboarding({ ...base, onboardingStep: "create_agent", currentOrgReady: false })).toBe(false);
+    expect(shouldLeaveOnboarding({ ...base, onboardingStep: "completed", currentOrgReady: false })).toBe(false);
+  });
+  it("does not strand a merely-dismissed user who returned via Resume into an unready org", () => {
+    expect(
+      shouldLeaveOnboarding({ ...base, onboardingStep: "create_agent", onboardingDismissedAt: "2026-05-22T00:00:00Z" }),
+    ).toBe(false);
   });
   it("waits for /me before deciding", () => {
-    expect(shouldLeaveOnboarding({ ...base, meLoaded: false, onboardingCompletedAt: "x" })).toBe(false);
+    expect(
+      shouldLeaveOnboarding({ ...base, meLoaded: false, onboardingStep: "completed", currentOrgReady: true }),
+    ).toBe(false);
   });
 });

--- a/packages/web/src/pages/onboarding/onboarding-flow.tsx
+++ b/packages/web/src/pages/onboarding/onboarding-flow.tsx
@@ -2,7 +2,14 @@ import type { AgentVisibility } from "@first-tree/shared";
 import { createContext, type ReactNode, useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router";
 import { useAuth } from "../../auth/auth-context.js";
-import { clampStepIndex, getStepSequence, inferInitialStepIndex, type OnboardingPath, type StepId } from "./steps.js";
+import {
+  clampStepIndex,
+  getStepSequence,
+  inferInitialStepIndex,
+  type OnboardingPath,
+  type ServerOnboardingStep,
+  type StepId,
+} from "./steps.js";
 import { type AgentCreationPhase, type CreateAgentArgs, useAgentCreation } from "./use-agent-creation.js";
 import { type ComputerConnection, useComputerConnection } from "./use-computer-connection.js";
 
@@ -101,19 +108,33 @@ export function OnboardingFlowProvider({ path, children }: { path: OnboardingPat
     teamDisplayName,
     orgHasOtherMembers,
     onboardingStep,
+    currentOrgHasUsableAgent,
     refreshMe,
     dismissOnboarding,
     markOnboardingCompleted,
   } = useAuth();
 
+  // Org-aware step. `onboardingStep` from /me is account-level: its
+  // `create_agent` / `completed` value reflects whether the user has set up
+  // an agent in *any* org. For step selection we care about the *current*
+  // org, so once past the account-level `connect` stage we recompute
+  // create_agent vs completed from this org's readiness — otherwise a
+  // returning user joining an empty org would skip straight to kickoff.
+  const orgStep: ServerOnboardingStep =
+    onboardingStep === "connect" || onboardingStep === null
+      ? onboardingStep
+      : currentOrgHasUsableAgent
+        ? "completed"
+        : "create_agent";
+
   const sequence = getStepSequence(path);
   const [activeIndex, setActiveIndex] = useState<number>(() => {
     const inferred = inferInitialStepIndex(path, {
-      onboardingStep,
+      onboardingStep: orgStep,
       // We can't observe finer team-rename state synchronously; the team
       // step is cheap to revisit, so default returning admins past it only
       // when the server already proves a computer exists.
-      teamSettled: onboardingStep !== "connect",
+      teamSettled: orgStep !== "connect",
     });
     // Resume a persisted position, but never drop *behind* what the server
     // can prove (so a stale marker can't strand a user before their real
@@ -199,7 +220,7 @@ export function OnboardingFlowProvider({ path, children }: { path: OnboardingPat
       createAgent,
       retryAgent,
       createdAgentUuid,
-      hasAgent: onboardingStep === "completed" || createdAgentUuid !== null,
+      hasAgent: orgStep === "completed" || createdAgentUuid !== null,
       selectedRepoUrls,
       setSelectedRepoUrls,
       treeMode,
@@ -232,7 +253,7 @@ export function OnboardingFlowProvider({ path, children }: { path: OnboardingPat
       createAgent,
       retryAgent,
       createdAgentUuid,
-      onboardingStep,
+      orgStep,
       selectedRepoUrls,
       treeMode,
       treeUrl,

--- a/packages/web/src/pages/onboarding/onboarding-page.tsx
+++ b/packages/web/src/pages/onboarding/onboarding-page.tsx
@@ -18,12 +18,19 @@ import { resolveOnboardingPath, shouldLeaveOnboarding } from "./steps.js";
  * here; once setup is terminally complete this route bounces back to `/`.
  */
 export function OnboardingPage() {
-  const { meLoaded, role, onboardingStep, onboardingDismissedAt, onboardingCompletedAt } = useAuth();
+  const { meLoaded, role, onboardingStep, onboardingDismissedAt, currentOrgHasUsableAgent } = useAuth();
 
   if (!meLoaded) {
     return <div className="min-h-screen bg-background" />;
   }
-  if (shouldLeaveOnboarding({ meLoaded, onboardingStep, onboardingDismissedAt, onboardingCompletedAt })) {
+  if (
+    shouldLeaveOnboarding({
+      meLoaded,
+      onboardingStep,
+      onboardingDismissedAt,
+      currentOrgReady: currentOrgHasUsableAgent,
+    })
+  ) {
     return <Navigate to="/" replace />;
   }
 

--- a/packages/web/src/pages/onboarding/steps.ts
+++ b/packages/web/src/pages/onboarding/steps.ts
@@ -112,51 +112,68 @@ export function stepVisualState(index: number, activeIndex: number): StepVisualS
 export type OnboardingGateFacts = {
   /** `false` until `/me` has resolved at least once. */
   meLoaded: boolean;
+  /**
+   * Account-level server step from `/me`. Only its `connect` / `null` value
+   * is consulted here — it tells us whether the user has connected a runtime
+   * client yet (a once-per-account step). The `create_agent` / `completed`
+   * distinction is org-specific and comes from `currentOrgReady` instead.
+   */
   onboardingStep: ServerOnboardingStep;
+  /**
+   * Whether the *currently selected* org has a non-human agent this member
+   * can use (own or org-visible) — `auth.currentOrgHasUsableAgent`. Replaces
+   * the old account-level `onboardingCompletedAt` short-circuit so a
+   * returning user joining a brand-new / all-private org is still routed
+   * through create-agent for that org.
+   */
+  currentOrgReady: boolean;
   onboardingDismissedAt: string | null;
-  onboardingCompletedAt: string | null;
 };
 
 /**
  * Should the workspace root (`/`) bounce an authenticated user into the
  * standalone onboarding flow?
  *
- * Yes whenever the user has *started but not finished* setup — server step
- * `connect`, `create_agent`, or `completed` (computer + agent exist but the
- * Context Tree kickoff hasn't run) — and they haven't terminally completed
- * or hidden onboarding. The standalone flow resumes at the right step. The
- * `completed` case is now redirected (it previously fell through to an inline
- * workspace onboarding, which has been retired).
+ * Two independent gates, in order:
+ *   1. Account-level — the user hasn't connected a runtime client yet
+ *      (server step `connect` / null). Connecting a computer is a
+ *      once-per-account step, so this is judged user-wide.
+ *   2. Org-level — they're connected, but the *selected* org has no agent
+ *      they can use (`!currentOrgReady`). This is what makes a returning,
+ *      already-onboarded user still get walked through create-agent when
+ *      they join a brand-new or all-private org.
  *
- * The `completed_at` guard is what protects genuinely-finished users: once
- * setup is terminally complete the stamp is set and they're never bounced.
- * (Legacy caveat: a user who predates the `completed_at` column has step
- * `completed` + a null stamp, so they'd be redirected once — acceptable, the
- * now-removed inline onboarding showed them the same kickoff anyway; a one-off
- * `onboarding_completed_at` backfill would remove even that.)
+ * A user who explicitly dismissed onboarding ("finish later") is never
+ * bounced. Note there is deliberately no account-level "completed" escape
+ * hatch anymore — readiness is always evaluated against the current org.
  */
 export function shouldEnterOnboarding(facts: OnboardingGateFacts): boolean {
   if (!facts.meLoaded) return false;
-  if (facts.onboardingCompletedAt) return false;
   if (facts.onboardingDismissedAt) return false;
-  return (
-    facts.onboardingStep === "connect" ||
-    facts.onboardingStep === "create_agent" ||
-    facts.onboardingStep === "completed"
-  );
+  // A null step means /me hasn't reported one (e.g. a transient failure after
+  // meLoaded flipped) — don't bounce on incomplete data.
+  if (facts.onboardingStep === null) return false;
+  // (1) No runtime client connected yet → start at "connect a computer".
+  if (facts.onboardingStep === "connect") return true;
+  // (2) Connected, but this org has no usable agent → "create an agent" here.
+  if (!facts.currentOrgReady) return true;
+  return false;
 }
 
 /**
  * Should the `/onboarding` route bounce the user back to the workspace?
  *
- * Only once setup is terminally complete — so a finished user can't get
- * stranded on the wizard, while a still-incomplete (or merely dismissed,
- * but deliberately returning via "Resume") user is allowed to stay and
- * work through it.
+ * Once there is nothing left to set up *for the selected org*: the user is
+ * connected AND the org has a usable agent. A user still on `connect`, or in
+ * an org without a usable agent, is allowed to stay and work through the
+ * wizard (including a "finish later"-dismissed user who deliberately
+ * returned via "Resume"). Mirror image of `shouldEnterOnboarding` minus the
+ * dismiss escape hatch, so the two can't fight over the same user.
  */
 export function shouldLeaveOnboarding(facts: OnboardingGateFacts): boolean {
   if (!facts.meLoaded) return false;
-  return facts.onboardingCompletedAt !== null;
+  if (facts.onboardingStep === "connect" || facts.onboardingStep === null) return false;
+  return facts.currentOrgReady;
 }
 
 /**

--- a/packages/web/src/pages/workspace/index.tsx
+++ b/packages/web/src/pages/workspace/index.tsx
@@ -97,7 +97,7 @@ export function parseParticipantList(params: URLSearchParams): string[] {
 
 export function WorkspacePage() {
   const [searchParams, setSearchParams] = useSearchParams();
-  const { meLoaded, onboardingStep, onboardingDismissedAt, onboardingCompletedAt } = useAuth();
+  const { meLoaded, onboardingStep, onboardingDismissedAt, currentOrgHasUsableAgent } = useAuth();
   const selectedChatId = searchParams.get("c");
   const legacyAgentId = searchParams.get("a");
   const legacySource = searchParams.get("source");
@@ -243,7 +243,14 @@ export function WorkspacePage() {
   // flow — including the server-`completed`-but-no-kickoff case. Only
   // terminally completed or dismissed users fall through to the normal
   // workspace; the old inline center-panel onboarding has been retired.
-  if (shouldEnterOnboarding({ meLoaded, onboardingStep, onboardingDismissedAt, onboardingCompletedAt })) {
+  if (
+    shouldEnterOnboarding({
+      meLoaded,
+      onboardingStep,
+      onboardingDismissedAt,
+      currentOrgReady: currentOrgHasUsableAgent,
+    })
+  ) {
     return <Navigate to="/onboarding" replace />;
   }
 


### PR DESCRIPTION
## Problem

An invited user who clicked an invite link, logged in via GitHub, and had **already onboarded in some other org** landed straight on the workspace — skipping onboarding — and in a **stale org**, not the one they were invited to.

Root cause was two independent issues that fired together:

1. **Onboarding completion was account-level.** The workspace gate keyed off `users.onboardingCompletedAt` (a write-once user column) and a user-scoped agent check (`inferOnboardingStep`: "does this user manage a non-human agent in *any* org"). A returning user joining a brand-new or all-private org was treated as already set up, even with no agent they could use there.
2. **The joined org was never made active.** The invite created the membership server-side, but the client kept whatever org sat in `localStorage.selectedOrganizationId`, so the invitee landed in their previous org.

## Changes

**A. Onboarding "agent readiness" → org/member level (no schema change, no migration)**
- New `listOrgsWithUsableNonHumanAgent` (`services/access-control.ts`): per org, does the member have a usable non-human agent — active AND (`visibility="organization"` OR managed by them)? A private agent owned by another member does **not** count.
- `/me` now returns per-membership `hasUsableAgent` (`api/me.ts`, `shared` `meMembershipSchema`).
- Web gate (`onboarding/steps.ts`) enters onboarding when the user hasn't connected a client **or** the selected org has no usable agent. `onboardingCompletedAt` is kept for the Settings entry-point but is no longer the workspace gate.

**B. Land invitees in the right org**
- OAuth callback carries the resolved org back in the redirect fragment (`org=`, `api/auth/github.ts`); `oauth-complete.tsx` calls `selectOrganization(org)` before navigating.
- Authenticated invite Join path (`invite-accept.tsx`) selects `res.organizationId`.

**C. Drive-by fix**
- The invite page "switch from X to Y" warning read a non-existent `/me` field and never showed; now reads `teamDisplayName` from the auth context (drops two redundant requests too).

## Intentional behavior changes (signed off)
- Multi-org users who land in an org where they have no usable agent are now routed to create one there (previously skipped account-wide).
- An admin who created an agent but never finished the kickoff step is no longer auto-resumed into the wizard from the workspace root (kickoff is still reachable from Settings).

## Verification
- Full web suite: **515 passed**. Full server suite: **1270 passed** (real Postgres via testcontainers).
- `pnpm typecheck` (all packages) **13/13**; `pnpm check` (biome) clean; web `lint:tokens` clean.
- New tests: `onboarding-readiness.test.ts` (visibility/own/suspended/cross-member matrix), `/me hasUsableAgent` wiring, `steps.test.ts` gate truth table, OAuth `org=` fragment assertions.
- Independent review via OpenAI Codex CLI (`codex review --uncommitted`): no findings.
- Rebased onto latest `main`; suites re-run green post-rebase.

Live local-hub click-through deferred to the pre-merge runtime-E2E gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
