### PR TITLE
fix(client): queue injects before handlers are ready

### DIFF
--- a/packages/client/src/__tests__/claude-code-inject-startup-race.test.ts
+++ b/packages/client/src/__tests__/claude-code-inject-startup-race.test.ts
@@ -101,7 +101,10 @@ function makeMessage(id: string, content: string): SessionMessage {
   };
 }
 
-function makeContext(markCompleted: (count?: number) => void): SessionContext {
+function makeContext(
+  markCompleted: (count?: number) => void,
+  opts: { formatInboundContent?: SessionContext["formatInboundContent"] } = {},
+): SessionContext {
   const sendMessage = vi.fn().mockResolvedValue(undefined);
   return {
     agent: {
@@ -120,6 +123,7 @@ function makeContext(markCompleted: (count?: number) => void): SessionContext {
     setRuntimeState: () => {},
     emitEvent: () => {},
     ...mockCtxPlumbing({ sendMessage }, "chat-claude-startup-race"),
+    ...(opts.formatInboundContent ? { formatInboundContent: opts.formatInboundContent } : {}),
     markCompleted,
   };
 }
@@ -179,6 +183,53 @@ describe("claude-code handler startup inject queue", () => {
     expect(state.observedInputs[0]).toContain("first");
     expect(state.observedInputs[1]).toContain("second");
     expect(completedCounts).toEqual([undefined, undefined]);
+
+    await handler.shutdown();
+  });
+
+  it("keeps startup-queued injects ahead of ready-state injects after start returns", async () => {
+    const completedCounts: Array<number | undefined> = [];
+    const releaseSecond: { current: (() => void) | null } = { current: null };
+    const secondGate = new Promise<void>((resolve) => {
+      releaseSecond.current = resolve;
+    });
+    const handler = createClaudeCodeHandler({ workspaceRoot });
+    const ctx = makeContext(
+      (count) => {
+        completedCounts.push(count);
+      },
+      {
+        formatInboundContent: async (message) => {
+          if (message.id === "m2") await secondGate;
+          const raw = typeof message.content === "string" ? message.content : JSON.stringify(message.content);
+          return `[From: ${message.senderId}]\n\n${raw}`;
+        },
+      },
+    );
+
+    const startPromise = handler.start(makeMessage("m1", "first"), ctx);
+    await Promise.resolve();
+    handler.inject(makeMessage("m2", "second"));
+
+    state.resolveChatContext?.({
+      chatId: "chat-claude-startup-race",
+      title: "startup race",
+      topic: null,
+      participants: [],
+    });
+
+    await startPromise;
+    handler.inject(makeMessage("m3", "third"));
+    await new Promise((resolve) => setImmediate(resolve));
+    releaseSecond.current?.();
+
+    await waitFor(() => state.observedInputs.length === 3);
+    await waitFor(() => completedCounts.length === 3);
+
+    expect(state.observedInputs[0]).toContain("first");
+    expect(state.observedInputs[1]).toContain("second");
+    expect(state.observedInputs[2]).toContain("third");
+    expect(completedCounts).toEqual([undefined, undefined, undefined]);
 
     await handler.shutdown();
   });

--- a/packages/client/src/__tests__/claude-code-inject-startup-race.test.ts
+++ b/packages/client/src/__tests__/claude-code-inject-startup-race.test.ts
@@ -1,0 +1,185 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChatContext } from "../runtime/chat-context.js";
+import type { SessionContext, SessionMessage } from "../runtime/handler.js";
+import { mockCtxPlumbing } from "./test-helpers.js";
+
+const state = vi.hoisted(() => ({
+  chatContextPromise: null as Promise<ChatContext> | null,
+  resolveChatContext: null as ((value: ChatContext) => void) | null,
+  observedInputs: [] as string[],
+  pendingResults: [] as unknown[],
+  waiters: [] as Array<() => void>,
+}));
+
+function wakeQuery(): void {
+  const waiters = state.waiters.splice(0);
+  for (const waiter of waiters) waiter();
+}
+
+function flattenContent(content: unknown): string {
+  return typeof content === "string" ? content : JSON.stringify(content);
+}
+
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (args: { prompt: AsyncIterable<{ message: { content: unknown } }> }) => {
+    let closed = false;
+
+    void (async () => {
+      for await (const sdkMsg of args.prompt) {
+        state.observedInputs.push(flattenContent(sdkMsg.message.content));
+        const turn = state.observedInputs.length;
+        state.pendingResults.push({
+          type: "result",
+          subtype: "success",
+          result: `reply ${turn}`,
+        });
+        wakeQuery();
+      }
+      closed = true;
+      wakeQuery();
+    })();
+
+    return {
+      [Symbol.asyncIterator]() {
+        return {
+          next: async (): Promise<IteratorResult<unknown>> => {
+            while (state.pendingResults.length === 0 && !closed) {
+              await new Promise<void>((resolve) => state.waiters.push(resolve));
+            }
+            const value = state.pendingResults.shift();
+            if (value) return { value, done: false };
+            return { value: undefined, done: true };
+          },
+        };
+      },
+      close: () => {
+        closed = true;
+        wakeQuery();
+      },
+      setModel: async () => {},
+    };
+  },
+}));
+
+vi.mock("../runtime/agent-bootstrap.js", () => ({
+  ensureAgentBootstrap: vi.fn(),
+}));
+
+vi.mock("../runtime/bootstrap.js", () => ({
+  FIRST_TREE_WORKSPACE_MARKER: ".first-tree-workspace",
+  buildChatSystemPrompt: vi.fn(() => ""),
+}));
+
+vi.mock("../runtime/chat-context.js", () => ({
+  fetchChatContext: vi.fn(async () => {
+    if (!state.chatContextPromise) throw new Error("chat context gate was not initialised");
+    return state.chatContextPromise;
+  }),
+}));
+
+vi.mock("../runtime/source-repos.js", () => ({
+  prepareSourceRepos: vi.fn(async () => []),
+}));
+
+import { createClaudeCodeHandler } from "../handlers/claude-code.js";
+
+const AGENT_ID = "019e71d2-c9ec-7f11-86bf-5dfc9e873338";
+
+let workspaceRoot: string;
+
+function makeMessage(id: string, content: string): SessionMessage {
+  return {
+    id,
+    chatId: "chat-claude-startup-race",
+    senderId: "sender-1",
+    format: "text",
+    content,
+    metadata: {},
+  };
+}
+
+function makeContext(markCompleted: (count?: number) => void): SessionContext {
+  const sendMessage = vi.fn().mockResolvedValue(undefined);
+  return {
+    agent: {
+      agentId: AGENT_ID,
+      inboxId: `inbox_${AGENT_ID}`,
+      displayName: "codex-developer",
+      type: "agent",
+      visibility: "organization",
+      delegateMention: null,
+      metadata: {},
+    },
+    sdk: { serverUrl: "http://test", sendMessage } as unknown as SessionContext["sdk"],
+    chatId: "chat-claude-startup-race",
+    log: () => {},
+    touch: () => {},
+    setRuntimeState: () => {},
+    emitEvent: () => {},
+    ...mockCtxPlumbing({ sendMessage }, "chat-claude-startup-race"),
+    markCompleted,
+  };
+}
+
+async function waitFor(assertion: () => boolean): Promise<void> {
+  const deadline = Date.now() + 1000;
+  while (!assertion()) {
+    if (Date.now() > deadline) throw new Error("timed out waiting for assertion");
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+}
+
+beforeEach(() => {
+  workspaceRoot = mkdtempSync(join(tmpdir(), "ft-claude-startup-race-"));
+  state.observedInputs.length = 0;
+  state.pendingResults.length = 0;
+  state.waiters.length = 0;
+  state.chatContextPromise = new Promise((resolve) => {
+    state.resolveChatContext = resolve;
+  });
+});
+
+afterEach(() => {
+  rmSync(workspaceRoot, { recursive: true, force: true });
+  state.chatContextPromise = null;
+  state.resolveChatContext = null;
+  state.pendingResults.length = 0;
+  wakeQuery();
+});
+
+describe("claude-code handler startup inject queue", () => {
+  it("queues injects received before the InputController exists so their inbox entries stay aligned with acks", async () => {
+    const completedCounts: Array<number | undefined> = [];
+    const handler = createClaudeCodeHandler({ workspaceRoot });
+    const ctx = makeContext((count) => {
+      completedCounts.push(count);
+    });
+
+    const startPromise = handler.start(makeMessage("m1", "first"), ctx);
+    await Promise.resolve();
+
+    // The handler has a session id, but startup is still waiting on chat
+    // context; `spawnQuery` has not created the InputController yet.
+    handler.inject(makeMessage("m2", "second"));
+
+    state.resolveChatContext?.({
+      chatId: "chat-claude-startup-race",
+      title: "startup race",
+      topic: null,
+      participants: [],
+    });
+
+    await startPromise;
+    await waitFor(() => state.observedInputs.length === 2);
+    await waitFor(() => completedCounts.length === 2);
+
+    expect(state.observedInputs[0]).toContain("first");
+    expect(state.observedInputs[1]).toContain("second");
+    expect(completedCounts).toEqual([undefined, undefined]);
+
+    await handler.shutdown();
+  });
+});

--- a/packages/client/src/__tests__/codex-inject-startup-race.test.ts
+++ b/packages/client/src/__tests__/codex-inject-startup-race.test.ts
@@ -52,6 +52,7 @@ vi.mock("../runtime/bootstrap.js", () => ({
   bootstrapWorkspace: vi.fn(),
   buildChatSystemPrompt: vi.fn(() => ""),
   deepEqualIdentity: vi.fn(() => true),
+  generateToolsDoc: vi.fn(() => ""),
   installCoreSkills: vi.fn(),
   installFirstTreeIntegration: vi.fn(() => true),
   isHubWorktreeMarker: vi.fn(() => false),

--- a/packages/client/src/__tests__/codex-inject-startup-race.test.ts
+++ b/packages/client/src/__tests__/codex-inject-startup-race.test.ts
@@ -1,0 +1,190 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChatContext } from "../runtime/chat-context.js";
+import type { SessionContext, SessionMessage } from "../runtime/handler.js";
+import { mockCtxPlumbing } from "./test-helpers.js";
+
+const state = vi.hoisted(() => ({
+  chatContextPromise: null as Promise<ChatContext> | null,
+  resolveChatContext: null as ((value: ChatContext) => void) | null,
+  runInputs: [] as unknown[],
+}));
+
+vi.mock("@openai/codex-sdk", () => {
+  const usage = {
+    input_tokens: 1,
+    cached_input_tokens: 0,
+    output_tokens: 1,
+    reasoning_output_tokens: 0,
+  };
+
+  const thread = {
+    id: "thread-test",
+    async runStreamed(input: unknown) {
+      state.runInputs.push(input);
+      const turn = state.runInputs.length;
+      return {
+        events: (async function* () {
+          yield { type: "thread.started", thread_id: "thread-test" };
+          yield { type: "item.completed", item: { type: "agent_message", text: `reply ${turn}` } };
+          yield { type: "turn.completed", usage };
+        })(),
+      };
+    },
+  };
+
+  return {
+    Codex: class {
+      startThread() {
+        return thread;
+      }
+      resumeThread() {
+        return thread;
+      }
+    },
+  };
+});
+
+vi.mock("../runtime/bootstrap.js", () => ({
+  FIRST_TREE_WORKSPACE_MARKER: ".first-tree-workspace",
+  bootstrapWorkspace: vi.fn(),
+  buildChatSystemPrompt: vi.fn(() => ""),
+  deepEqualIdentity: vi.fn(() => true),
+  installCoreSkills: vi.fn(),
+  installFirstTreeIntegration: vi.fn(() => true),
+  isHubWorktreeMarker: vi.fn(() => false),
+  readCachedBundledCliVersion: vi.fn(() => null),
+  readCachedContextTreeHead: vi.fn(() => null),
+  readContextTreeHead: vi.fn(() => null),
+  resolveBundledCliVersion: vi.fn(() => "0.0.0-test"),
+  writeBundledCliVersion: vi.fn(),
+  writeContextTreeHead: vi.fn(),
+}));
+
+vi.mock("../runtime/chat-context.js", () => ({
+  fetchChatContext: vi.fn(async () => {
+    if (!state.chatContextPromise) throw new Error("chat context gate was not initialised");
+    return state.chatContextPromise;
+  }),
+}));
+
+import { createCodexHandler } from "../handlers/codex.js";
+
+const AGENT_ID = "019e71c9-88d2-70be-be67-fdb033b2ef0b";
+
+let workspaceRoot: string;
+
+function makeMessage(id: string, content: string): SessionMessage {
+  return {
+    id,
+    chatId: "chat-startup-race",
+    senderId: "sender-1",
+    format: "text",
+    content,
+    metadata: {},
+  };
+}
+
+function makeContext(markCompleted: (count?: number) => void): SessionContext {
+  const sendMessage = vi.fn().mockResolvedValue(undefined);
+  return {
+    agent: {
+      agentId: AGENT_ID,
+      inboxId: `inbox_${AGENT_ID}`,
+      displayName: "codex-assistant",
+      type: "agent",
+      visibility: "organization",
+      delegateMention: null,
+      metadata: {},
+    },
+    sdk: { serverUrl: "http://test", sendMessage } as unknown as SessionContext["sdk"],
+    chatId: "chat-startup-race",
+    log: () => {},
+    touch: () => {},
+    setRuntimeState: () => {},
+    emitEvent: () => {},
+    ...mockCtxPlumbing({ sendMessage }, "chat-startup-race"),
+    markCompleted,
+  };
+}
+
+beforeEach(() => {
+  workspaceRoot = mkdtempSync(join(tmpdir(), "ft-codex-startup-race-"));
+  state.runInputs.length = 0;
+  state.chatContextPromise = new Promise((resolve) => {
+    state.resolveChatContext = resolve;
+  });
+});
+
+afterEach(() => {
+  rmSync(workspaceRoot, { recursive: true, force: true });
+  state.chatContextPromise = null;
+  state.resolveChatContext = null;
+});
+
+describe("codex handler startup inject queue", () => {
+  it("queues injects received before the Codex thread exists so their inbox entries stay aligned with acks", async () => {
+    const completedCounts: Array<number | undefined> = [];
+    const handler = createCodexHandler({ workspaceRoot });
+    const ctx = makeContext((count) => {
+      completedCounts.push(count);
+    });
+
+    const startPromise = handler.start(makeMessage("m1", "first"), ctx);
+    await Promise.resolve();
+
+    // The handler is active, but startup is still waiting on chat context;
+    // `thread` and `currentTurnPromise` do not exist yet.
+    handler.inject(makeMessage("m2", "second"));
+
+    state.resolveChatContext?.({
+      chatId: "chat-startup-race",
+      title: "startup race",
+      topic: null,
+      participants: [],
+    });
+
+    await startPromise;
+    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(state.runInputs).toHaveLength(2);
+    expect(String(state.runInputs[0])).toContain("first");
+    expect(String(state.runInputs[1])).toContain("second");
+    expect(completedCounts).toEqual([1, 1]);
+
+    await handler.shutdown();
+  });
+
+  it("serializes ready-state injects through one drainer instead of starting parallel turns", async () => {
+    const completedCounts: Array<number | undefined> = [];
+    const handler = createCodexHandler({ workspaceRoot });
+    const ctx = makeContext((count) => {
+      completedCounts.push(count);
+    });
+
+    state.resolveChatContext?.({
+      chatId: "chat-startup-race",
+      title: "startup race",
+      topic: null,
+      participants: [],
+    });
+
+    await handler.start(makeMessage("m1", "first"), ctx);
+
+    handler.inject(makeMessage("m2", "second"));
+    handler.inject(makeMessage("m3", "third"));
+
+    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(state.runInputs).toHaveLength(2);
+    expect(String(state.runInputs[1])).toContain("second");
+    expect(String(state.runInputs[1])).toContain("third");
+    expect(completedCounts).toEqual([1, 2]);
+
+    await handler.shutdown();
+  });
+});

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -580,7 +580,8 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
    * when the session ends or `start()` runs for a fresh session.
    */
   let chatContextForPrompt: ChatContext | undefined;
-  const queuedStartupMessages: SessionMessage[] = [];
+  const queuedInjectedMessages: SessionMessage[] = [];
+  let injectDrainInProgress = false;
   /**
    * Predeclared source repos materialised by `prepareSourceRepos`. Surfaced in
    * the per-turn prompt block so the LLM knows the absolute paths without
@@ -869,16 +870,26 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
     }
   }
 
-  function scheduleInjectedMessage(message: SessionMessage, sessionCtx: SessionContext, sessionId: string): void {
-    void pushInjectedMessage(message, sessionCtx, sessionId);
-  }
-
-  function drainStartupMessages(sessionCtx: SessionContext, sessionId: string): void {
-    const drained = queuedStartupMessages.splice(0);
-    if (drained.length === 0) return;
+  function scheduleInjectedMessagesDrain(sessionCtx: SessionContext, sessionId: string): void {
+    if (!inputController || injectDrainInProgress) return;
     void (async () => {
-      for (const message of drained) {
-        await pushInjectedMessage(message, sessionCtx, sessionId);
+      injectDrainInProgress = true;
+      try {
+        while (
+          queuedInjectedMessages.length > 0 &&
+          inputController &&
+          ctx === sessionCtx &&
+          claudeSessionId === sessionId
+        ) {
+          const message = queuedInjectedMessages.shift();
+          if (!message) continue;
+          await pushInjectedMessage(message, sessionCtx, sessionId);
+        }
+      } finally {
+        injectDrainInProgress = false;
+        if (queuedInjectedMessages.length > 0 && inputController && ctx && claudeSessionId) {
+          scheduleInjectedMessagesDrain(ctx, claudeSessionId);
+        }
       }
     })();
   }
@@ -1506,7 +1517,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       stashedSdkMessage = sdkMsg;
       spawnQuery(claudeSessionId, sessionCtx, undefined, chatContext);
       inputController?.push(sdkMsg);
-      drainStartupMessages(sessionCtx, claudeSessionId);
+      scheduleInjectedMessagesDrain(sessionCtx, claudeSessionId);
 
       sessionCtx.log(`Session started (${claudeSessionId})`);
       return claudeSessionId;
@@ -1554,7 +1565,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
         if (sdkMsg) {
           inputController?.push(sdkMsg);
         }
-        drainStartupMessages(sessionCtx, sessionId);
+        scheduleInjectedMessagesDrain(sessionCtx, sessionId);
         sessionCtx.log(`Session resumed at legacy cwd (${sessionId})`);
         return sessionId;
       }
@@ -1594,7 +1605,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
         if (freshSdkMsg) {
           inputController?.push(freshSdkMsg);
         }
-        drainStartupMessages(sessionCtx, freshSessionId);
+        scheduleInjectedMessagesDrain(sessionCtx, freshSessionId);
         sessionCtx.log(`Session started (${freshSessionId}, replacing ${sessionId})`);
         return freshSessionId;
       }
@@ -1609,7 +1620,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       if (resumeSdkMsg) {
         inputController?.push(resumeSdkMsg);
       }
-      drainStartupMessages(sessionCtx, sessionId);
+      scheduleInjectedMessagesDrain(sessionCtx, sessionId);
 
       sessionCtx.log(`Session resumed (${sessionId})`);
       return sessionId;
@@ -1622,15 +1633,8 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       }
       const sessionCtx = ctx;
       const sid = claudeSessionId;
-      if (!inputController) {
-        queuedStartupMessages.push(message);
-        return;
-      }
-      // Step 6: switch (in-flight or restart) BEFORE injecting if the cached
-      // config is newer than the one we launched with. Errors are logged
-      // and we still deliver against the existing query — better than
-      // dropping the user message.
-      scheduleInjectedMessage(message, sessionCtx, sid);
+      queuedInjectedMessages.push(message);
+      scheduleInjectedMessagesDrain(sessionCtx, sid);
     },
 
     async suspend() {
@@ -1657,7 +1661,8 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       // be moot. Resume goes through `handler.resume(message, sessionId)`
       // which re-stashes from its own argument.
       stashedSdkMessage = null;
-      queuedStartupMessages.length = 0;
+      queuedInjectedMessages.length = 0;
+      injectDrainInProgress = false;
     },
 
     async shutdown() {

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -580,6 +580,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
    * when the session ends or `start()` runs for a fresh session.
    */
   let chatContextForPrompt: ChatContext | undefined;
+  const queuedStartupMessages: SessionMessage[] = [];
   /**
    * Predeclared source repos materialised by `prepareSourceRepos`. Surfaced in
    * the per-turn prompt block so the LLM knows the absolute paths without
@@ -840,6 +841,46 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
   function ackTurnClose(sessionCtx: SessionContext): void {
     sessionCtx.markCompleted();
     stashedSdkMessage = null;
+  }
+
+  async function pushInjectedMessage(
+    message: SessionMessage,
+    sessionCtx: SessionContext,
+    sessionId: string,
+  ): Promise<void> {
+    try {
+      await maybeSwitchConfig(sessionCtx);
+    } catch (err) {
+      sessionCtx.log(`maybeSwitchConfig errored: ${err instanceof Error ? err.message : String(err)}`);
+    }
+
+    try {
+      const sdkMsg = await toSDKUserMessage(message, sessionCtx, sessionId);
+      stashedSdkMessage = sdkMsg;
+      inputController?.push(sdkMsg);
+    } catch (err) {
+      sessionCtx.log(`toSDKUserMessage errored: ${err instanceof Error ? err.message : String(err)}`);
+      // `toSDKUserMessage` failed before the SDK ever saw the
+      // message, so no `result` event will ever fire to pair this
+      // entry with a `markCompleted()`. Ack here — re-handling on
+      // redelivery would re-hit the same conversion error
+      // (permanent failure semantics, design §4).
+      sessionCtx.markCompleted(1);
+    }
+  }
+
+  function scheduleInjectedMessage(message: SessionMessage, sessionCtx: SessionContext, sessionId: string): void {
+    void pushInjectedMessage(message, sessionCtx, sessionId);
+  }
+
+  function drainStartupMessages(sessionCtx: SessionContext, sessionId: string): void {
+    const drained = queuedStartupMessages.splice(0);
+    if (drained.length === 0) return;
+    void (async () => {
+      for (const message of drained) {
+        await pushInjectedMessage(message, sessionCtx, sessionId);
+      }
+    })();
   }
 
   /**
@@ -1465,6 +1506,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       stashedSdkMessage = sdkMsg;
       spawnQuery(claudeSessionId, sessionCtx, undefined, chatContext);
       inputController?.push(sdkMsg);
+      drainStartupMessages(sessionCtx, claudeSessionId);
 
       sessionCtx.log(`Session started (${claudeSessionId})`);
       return claudeSessionId;
@@ -1512,6 +1554,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
         if (sdkMsg) {
           inputController?.push(sdkMsg);
         }
+        drainStartupMessages(sessionCtx, sessionId);
         sessionCtx.log(`Session resumed at legacy cwd (${sessionId})`);
         return sessionId;
       }
@@ -1551,6 +1594,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
         if (freshSdkMsg) {
           inputController?.push(freshSdkMsg);
         }
+        drainStartupMessages(sessionCtx, freshSessionId);
         sessionCtx.log(`Session started (${freshSessionId}, replacing ${sessionId})`);
         return freshSessionId;
       }
@@ -1565,41 +1609,28 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       if (resumeSdkMsg) {
         inputController?.push(resumeSdkMsg);
       }
+      drainStartupMessages(sessionCtx, sessionId);
 
       sessionCtx.log(`Session resumed (${sessionId})`);
       return sessionId;
     },
 
     inject(message) {
-      if (!inputController || !claudeSessionId || !ctx) {
+      if (!claudeSessionId || !ctx) {
         ctx?.log("inject() called but no active session — dropping message");
         return;
       }
       const sessionCtx = ctx;
       const sid = claudeSessionId;
+      if (!inputController) {
+        queuedStartupMessages.push(message);
+        return;
+      }
       // Step 6: switch (in-flight or restart) BEFORE injecting if the cached
       // config is newer than the one we launched with. Errors are logged
       // and we still deliver against the existing query — better than
       // dropping the user message.
-      void maybeSwitchConfig(sessionCtx)
-        .catch((err) => {
-          sessionCtx.log(`maybeSwitchConfig errored: ${err instanceof Error ? err.message : String(err)}`);
-        })
-        .finally(async () => {
-          try {
-            const sdkMsg = await toSDKUserMessage(message, sessionCtx, sid);
-            stashedSdkMessage = sdkMsg;
-            inputController?.push(sdkMsg);
-          } catch (err) {
-            sessionCtx.log(`toSDKUserMessage errored: ${err instanceof Error ? err.message : String(err)}`);
-            // `toSDKUserMessage` failed before the SDK ever saw the
-            // message, so no `result` event will ever fire to pair this
-            // entry with a `markCompleted()`. Ack here — re-handling on
-            // redelivery would re-hit the same conversion error
-            // (permanent failure semantics, design §4).
-            sessionCtx.markCompleted(1);
-          }
-        });
+      scheduleInjectedMessage(message, sessionCtx, sid);
     },
 
     async suspend() {
@@ -1626,6 +1657,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       // be moot. Resume goes through `handler.resume(message, sessionId)`
       // which re-stashes from its own argument.
       stashedSdkMessage = null;
+      queuedStartupMessages.length = 0;
     },
 
     async shutdown() {

--- a/packages/client/src/handlers/codex.ts
+++ b/packages/client/src/handlers/codex.ts
@@ -364,6 +364,7 @@ export const createCodexHandler: HandlerFactory = (config) => {
   let currentTurnPromise: Promise<void> | null = null;
   let ctx: SessionContext | null = null;
   let drainScheduled = false;
+  let drainInProgress = false;
   const queuedMessages: SessionMessage[] = [];
   const ownedWorktrees: Worktree[] = [];
   /**
@@ -936,17 +937,29 @@ export const createCodexHandler: HandlerFactory = (config) => {
       );
     }
 
-    // Drain queued messages — schedules at most one follow-up at a time so
-    // a runaway inject loop can't recurse into stack overflow.
-    if (queuedMessages.length > 0 && !drainScheduled) {
-      drainScheduled = true;
-      setImmediate(() => {
-        drainScheduled = false;
-        const drained = queuedMessages.splice(0);
-        if (drained.length === 0 || !ctx || !thread) return;
-        void mergeAndRun(drained, ctx);
+    scheduleQueuedMessagesDrain();
+  }
+
+  function scheduleQueuedMessagesDrain(): void {
+    if (drainScheduled || drainInProgress) return;
+    if (queuedMessages.length === 0 || !ctx || !thread || currentTurnPromise) return;
+
+    drainScheduled = true;
+    setImmediate(() => {
+      drainScheduled = false;
+      if (drainInProgress || queuedMessages.length === 0 || !ctx || !thread || currentTurnPromise) {
+        scheduleQueuedMessagesDrain();
+        return;
+      }
+
+      const drained = queuedMessages.splice(0);
+      const sessionCtx = ctx;
+      drainInProgress = true;
+      void mergeAndRun(drained, sessionCtx).finally(() => {
+        drainInProgress = false;
+        scheduleQueuedMessagesDrain();
       });
-    }
+    });
   }
 
   async function mergeAndRun(drained: SessionMessage[], sessionCtx: SessionContext): Promise<void> {
@@ -1226,28 +1239,13 @@ export const createCodexHandler: HandlerFactory = (config) => {
 
     inject(message) {
       // Fire-and-forget — Codex turns are run-to-completion, so the message
-      // is buffered and drained on the next available turn. If the thread
-      // isn't running anything right now, schedule a turn immediately.
-      if (currentTurnPromise) {
-        queuedMessages.push(message);
-        return;
-      }
-      const sessionCtx = ctx;
-      if (!sessionCtx || !thread) return;
-      void (async () => {
-        try {
-          const input = await toCodexInput(message, sessionCtx);
-          // Single inject, single entry — runTurn will ack exactly one.
-          await runTurn(input, sessionCtx, 1);
-        } catch (err) {
-          sessionCtx.log(`codex inject failed: ${err instanceof Error ? err.message : String(err)}`);
-          // `toCodexInput` / `runTurn` threw before any markCompleted —
-          // the entry is still in flight. Ack so the row doesn't loop
-          // server-side as `delivered`; redelivery would re-hit the same
-          // failure. Mirrors design §4 "permanent → ack".
-          sessionCtx.markCompleted(1);
-        }
-      })();
+      // is buffered and drained on the next available turn. Queue every
+      // inject instead of only mid-turn injects so the async gap before
+      // `runTurn()` sets `currentTurnPromise` cannot start parallel turns
+      // and desynchronise the in-flight entry FIFO.
+      if (!ctx) return;
+      queuedMessages.push(message);
+      scheduleQueuedMessagesDrain();
     },
 
     async suspend() {


### PR DESCRIPTION
## Summary
- queue Codex injected messages through a single drainer so entries registered before or between turns stay aligned with actual turns
- queue Claude Code injected messages received after session identity exists but before `InputController` is ready, then drain them after the initial prompt is pushed
- add startup race regression tests for both handlers, plus a Codex ready-state double-inject serialization case

## Tests
- pnpm --filter @first-tree/client exec vitest run src/__tests__/codex-inject-startup-race.test.ts src/__tests__/claude-code-inject-startup-race.test.ts --maxWorkers=2
- pnpm --filter @first-tree/client exec vitest run src/__tests__/claude-code-turn-end.test.ts src/__tests__/claude-code-stream-error-retry-replay.test.ts --maxWorkers=2
- pnpm --filter @first-tree/client exec biome check src/handlers/codex.ts src/handlers/claude-code.ts src/__tests__/codex-inject-startup-race.test.ts src/__tests__/claude-code-inject-startup-race.test.ts
- pnpm --filter @first-tree/client typecheck
- pnpm --filter @first-tree/client test -- --maxWorkers=2
- git diff --check
