### PR TITLE
refactor(web): align onboarding UI with DESIGN.md

### DIFF
--- a/packages/web/DESIGN.md
+++ b/packages/web/DESIGN.md
@@ -102,7 +102,7 @@ in `src/` (except `index.css`):
 | 5 | Inline `fontSize`/`fontWeight`/`fontFamily`/`lineHeight`/`letterSpacing` | `text-*` tier + `font-*` class |
 | 6 | Tailwind default text sizes (`text-sm`, `text-xl`, …) | the 6-tier semantic scale |
 | 7 | `var(--x)` referencing a token **not defined** in `index.css` (ghost tokens) | define it in `index.css`, or fix the name |
-| 8 | Tailwind default radius classes (`rounded-sm/md/lg/xl`) | `rounded-[var(--radius-chip\|input\|panel\|dialog)]` |
+| 8 | Tailwind default radius classes (`rounded-sm/md/lg/xl`) | `rounded-[var(--radius-chip\|input\|panel\|dialog\|full)]` |
 | 9 | Tailwind shadows above the 2-tier scale (`shadow-lg/xl/2xl`) | `shadow-[var(--shadow-sm\|md)]` |
 | 10 | The retired `--accent` family (`--accent`, `--accent-dim/-bg/-ring`) | `--primary` for actions/active, `--brand` for signature green |
 
@@ -213,16 +213,19 @@ strings that can't be classes, use the `--sp-*` ladder (mirror of Tailwind:
 `--sp-75` (300px). Hairlines: `--hairline` (1px) / `--hairline-bold` (2px) —
 never write `"1px"`.
 
-**Radius** — semantic, ascending with surface importance:
+**Radius** — semantic, ascending with surface importance, plus one fully-round token:
 | Token | Value | Use |
 |-------|-------|-----|
 | `--radius-chip` | 3px | chips, pills, xs buttons |
 | `--radius-input` | 4px | inputs, default buttons |
 | `--radius-panel` | 6px | cards, panels |
 | `--radius-dialog` | 8px | dialogs, overlays |
+| `--radius-full` | 9999px | fully-round — circular discs/dots, avatar rings, capsule pills |
 
-These four are the only radius tokens — reference them directly
-(`rounded-[var(--radius-panel)]`) or via the matching utilities.
+The first four ascend with surface importance; `--radius-full` is the odd one out —
+it means "circle/capsule", not a size. These five are the only radius tokens —
+reference them directly (`rounded-[var(--radius-panel)]`) or via the matching utilities.
+Never hardcode a radius (`borderRadius: 999` / `"50%"`) — use `--radius-full`.
 
 ---
 

--- a/packages/web/docs/onboarding-ui-design-audit.md
+++ b/packages/web/docs/onboarding-ui-design-audit.md
@@ -1,0 +1,393 @@
+# Onboarding UI — DESIGN.md Compliance Audit
+
+> **Stage:** audited **and implemented** on `audit/onboarding-ui` (typecheck + `lint:tokens`
+> + full test suite green; light/dark verified in `/preview/onboarding`). See
+> **§5 Implementation status** for exactly what shipped vs what was deliberately deferred.
+> **Date:** 2026-06-01
+> **Branch:** `audit/onboarding-ui` (off `origin/main` @ `1f76bf9`)
+> **Spec:** [DESIGN.md](../DESIGN.md) + the enforced linter [`scripts/check-design-tokens.sh`](../scripts/check-design-tokens.sh)
+> **Companion:** [DESIGN-AUDIT.md](DESIGN-AUDIT.md) (system-wide status; its Phase 3 already lists
+> "Apply across remaining pages (Team roster, Settings, **onboarding**, …)" as **open** — this doc is that onboarding pass.)
+
+---
+
+## 0. Scope & method
+
+Reviewed every onboarding UI surface — read source line-by-line and cross-checked the DEV
+gallery at `/preview/onboarding`:
+
+| Surface | File |
+|---|---|
+| Shell (top bar + two-column layout) | `src/pages/onboarding/onboarding-shell.tsx` |
+| Progress rail | `src/pages/onboarding/progress-rail.tsx` |
+| Shared flow widgets (heading, note, working, status, command box, repo picker) | `src/pages/onboarding/flow-ui.tsx` |
+| Progressive-disclosure guides | `src/pages/onboarding/guides.tsx` |
+| Step: welcome (invitee) | `src/pages/onboarding/steps/step-welcome.tsx` |
+| Step: team (admin) | `src/pages/onboarding/steps/step-team.tsx` |
+| Step: connect-code (admin) | `src/pages/onboarding/steps/step-connect-code.tsx` |
+| Step: connect-computer | `src/pages/onboarding/steps/step-connect-computer.tsx` |
+| Step: create-agent | `src/pages/onboarding/steps/step-create-agent.tsx` |
+| Step: kickoff (admin + invitee sub-states) | `src/pages/onboarding/steps/step-kickoff.tsx` |
+| Connect "stuck?" recovery panel (shared w/ Settings) | `src/components/connect-stuck-panel.tsx` |
+| Pre-login invite-accept page | `src/pages/invite-accept.tsx` |
+| Routing only (no UI gap) | `onboarding-page.tsx`, `onboarding-flow.tsx`, `steps.ts`, `copy.ts` |
+
+**Linter caveat established by reading the script.** `check-design-tokens.sh` is **line-based
+`grep`**. Two whole classes of violation slip past it and are therefore present in committed,
+"green" code:
+
+1. **Numeric px** — rule 1 matches only the literal string `Npx`. A JS style number like
+   `minHeight: 38` becomes `38px` at runtime but never matches, so it passes.
+2. **Multi-line `style={{ … }}` objects** — rules 1 & 5 use `style=\{[^}]*…` which stops at the
+   first line. An inline `fontWeight`/`lineHeight` on its own line inside a multi-line style
+   object evades detection (DESIGN-AUDIT P0.5 notes this hole is still open).
+
+So "passes `lint:tokens`" ≠ "complies with DESIGN.md". Several findings below are real spec
+violations that the gate does not catch.
+
+---
+
+## 1. Executive summary
+
+The onboarding flow is **mostly token-clean** — colors, spacing, and the 6-tier type scale are
+referenced through tokens almost everywhere, and the shell/rail layout is disciplined. The gaps
+are **not** raw hex/px-string leaks; they are **structural divergence from the design system's
+component layer and a few linter-blind literals.**
+
+**The single biggest theme:** the **pre-login `invite-accept.tsx` page is the gold standard** —
+it composes `Card`, `Button`, the `focus-visible` ring recipe, and Tailwind utility classes. The
+**in-flow wizard steps do the opposite** — they hand-roll text inputs, checkboxes, chips,
+notices, command boxes, and quiet link-buttons with inline `style={{…}}` + `color-mix(…)`,
+re-implementing primitives that already exist in `src/components/ui/`. Bringing the wizard up to
+the invite-accept bar is ~80% of the work.
+
+**Severity tally:** 3 medium-high · 5 medium · 5 low · 2 nit.
+
+| # | Finding | Primary clause | Severity | Effort |
+|---|---|---|---|---|
+| F1 | Text inputs bypass the `Input` primitive; one has **no visible focus state** | §7, §13 | **Med-High** | S |
+| F2 | Quiet/secondary actions hand-rolled as raw `<button>` instead of `Button` `link`/`ghost`; use the **disabled `--fg-4` tier** for live text | §7, §4, §13 | **Med-High** | S–M |
+| F3 | Notices (`FlowNote`) hand-roll callout colors instead of the `--color-{error,info}` / `-soft` pairs | §3 | **Med-High** | S |
+| F4 | Duplicated bespoke widgets (command box ×2, checkbox row ×2) instead of one shared component | §7 | Med | M |
+| F5 | Numeric px literals (`38`, `8`, `-3`) evade the linter | §5, rule 1 | Med | S |
+| F6 | `borderRadius: 999 / "50%"` — hardcoded radius (no full-round token exists) | §5, rule 8 | Med | S |
+| F7 | Inline `fontWeight` / `lineHeight` (multi-line) evade the linter | §4, rule 5 | Med | S |
+| F8 | Hand-rolled surfaces via `color-mix(--bg-* NN%)` instead of `.surface-*` utilities | §6 | Low | M |
+| F9 | Non-lucide glyphs: literal `✓` and `→` in text | §8 | Low | S |
+| F10 | Informational "stuck?" panel wears card chrome (bordered/filled) | §language pillar 5 | Low | S |
+| F11 | Selection tint is `--primary` 8% vs OptionCard's ~5% spec; checkbox rows aren't the primitive | §7 | Low | M |
+| F12 | `text-muted-foreground` (shadcn alias) in new code instead of short semantic names | §3 | Nit | S |
+| F13 | Dead CSS classes `.onboarding-runtime-option`, `.onboarding-name-input` in `index.css` | §1 | Nit | S |
+
+(Effort: S ≈ <1h, M ≈ 1–3h per area. All additive/visual; none touches flow logic.)
+
+---
+
+## 2. Detailed findings
+
+### F1 — Text inputs bypass the `Input` primitive (and the §13 focus rule) — **Med-High**
+
+A first-class `Input` primitive exists (`src/components/ui/input.tsx`) and already implements the
+DESIGN.md §13 focus recipe for bordered controls: `focus-visible:border-ring` (deepen own border,
+no offset ring). Three onboarding inputs re-implement a raw `<input>` instead, with lower fidelity:
+
+- `steps/step-team.tsx:83-107` — raw input; focus handled by **imperative JS** `onFocus`/`onBlur`
+  setting `borderColor = "var(--primary)"`. Wrong token (`--primary`, not `--ring`) and an
+  anti-pattern (DOM mutation instead of `:focus-visible` CSS).
+- `steps/step-create-agent.tsx:90-112` — identical raw-input + JS-focus pattern.
+- `steps/step-kickoff.tsx:228-242` — raw input with `outline: "none"` **and no focus handler at
+  all** → **the tree-URL field has no visible focus indicator.** This is an outright §13 /
+  WCAG focus-visibility regression, not just a consistency nit.
+
+**Violates:** §7 (use the primitive inventory), §13 ("Focus is visible but restrained … anything
+with its own border darkens that border to `--ring` on focus").
+**Fix:** replace all three with `<Input … />`; delete the JS focus handlers. The mono tree-URL
+field can keep `className="mono"` on the primitive.
+**Impact:** correctness (focus a11y) + consistency. **Effort:** S.
+
+---
+
+### F2 — Quiet/secondary actions hand-rolled instead of `Button` variants — **Med-High**
+
+The `Button` primitive ships `variant="link"` (`text-primary underline-offset-4 hover:underline`)
+and `variant="ghost"`, both with the §13 borderless focus ring. The flow instead scatters raw
+`<button>` elements styled inline, and most use **`color: var(--fg-4)`** — which §4 defines as the
+**disabled** foreground tier — for *live, clickable* text. That's both off-system and a contrast/
+affordance concern (an interactive control rendered at the disabled tier).
+
+Locations:
+- `onboarding-shell.tsx:43-61` ("Finish later") and `:63-70` ("Sign out") — raw buttons, `--fg-4`.
+- `steps/step-connect-code.tsx:138-153` ("Skip for now") and `:173-186` ("Cancel") — raw, `--fg-4`.
+- `steps/step-kickoff.tsx` — `LINK_STYLE` const (`:27-33`, ink `--primary`) on the "Create
+  instead" / "I already have one" buttons (`:249-259`, `:263-270`); plus
+  "Continue without a project" raw buttons at `:494-501` and `:588-595` (ink `--fg-4`).
+
+**Violates:** §7 (Button variants exist), §4 (`--fg-4` is the disabled tier), §13 (focus ring).
+**Fix:** `<Button variant="link">` for the inline text links; `<Button variant="ghost" size="sm">`
+where a quiet button affordance is wanted. Drop the `--fg-4`/`LINK_STYLE` inline styling. Pick a
+single convention for "tertiary action" across the flow.
+**Impact:** consistency + a11y contrast. **Effort:** S–M (≈8 call sites, mechanical).
+
+---
+
+### F3 — Notices hand-roll callout colors instead of the §3 callout token pairs — **Med-High**
+
+`flow-ui.tsx` `FlowNote` (`:28-53`) is the flow's only inline-notice component and is used
+~20× across the steps. DESIGN.md §3 "Inline callouts (notices)" exists precisely so notices
+*don't* hand-mix colors: `--color-error`/`--color-error-soft`, `--color-info`/`--color-info-soft`
+(blue, hue 245), etc. `FlowNote` instead:
+
+- **error tone:** ink `--state-error`, border hand-rolled `color-mix(… var(--state-error) 28% …)`,
+  bg `--state-error-soft`. The `--state-*` family is for **agent status dots/chips**, not notices;
+  §3 says reach for the `--color-error` callout pair here.
+- **info tone:** ink `--fg-2` + bg `color-mix(… var(--primary) 8% …)` — a *neutral* wash, ignoring
+  the dedicated blue **`--color-info` / `--color-info-soft`** pair the system added for static
+  informational notices.
+
+§3 also explicitly says: "Use these [`-soft` companions] for state-tinted surfaces … **instead of
+hand-rolling `color-mix(... var(--state-*) ..., transparent)` at the call site.**" `FlowNote`'s
+border is exactly that hand-roll.
+
+**Violates:** §3 (Inline callouts; soft-companion guidance).
+**Fix:** re-point `FlowNote` to the callout pairs — `error → --color-error` (ink/border) +
+`--color-error-soft` (bg); `info → --color-info` + `--color-info-soft`. If a `-line` (border-tone)
+token is still missing for the border, add one to `index.css` rather than hand-mixing (DESIGN-AUDIT
+already flags `--state-*-line` as a wanted follow-up).
+**Impact:** correctness (info notices should read as the system's blue, not neutral) + theming
+single-source. **Effort:** S (one component; all call sites inherit).
+
+---
+
+### F4 — Duplicated bespoke widgets instead of one shared component — **Med**
+
+Two widgets are implemented twice, nearly identically:
+
+- **Copyable command/URL box.** `flow-ui.tsx` `CommandBox` (`:140-209`) and the share-URL box in
+  `step-kickoff.tsx` `InviteeNoInstallation` (`:663-705`) are the same monospace-box + Copy-button
+  pattern, reimplemented inline in the second site (same `minHeight: 38`, same surface mix, same
+  copy-state logic).
+- **Selectable checkbox row.** `flow-ui.tsx` `RepoPicker`'s row (`:261-315`) and
+  `step-kickoff.tsx` `InviteeConfirm`'s row (`:450-481`) are the same sr-only-checkbox + surrogate-
+  box + tinted-active-row markup, duplicated.
+
+**Violates:** §7 (the system is a bespoke primitive library; this is the place to add primitives,
+not re-inline them).
+**Fix:** extract a `CopyableField`/`CommandBox` (already exists — just reuse it for the share-URL)
+and a shared `CheckRow` (or a real `Checkbox` primitive in `components/ui/`). `FlowChip` in
+`guides.tsx:153-169` is likewise a chip that could be the existing `Badge`/`StateChip`.
+**Impact:** maintainability + visual consistency. **Effort:** M.
+
+---
+
+### F5 — Numeric px literals evade the linter — **Med**
+
+Raw JS-number sizes (→ px at runtime) that DESIGN.md §5 forbids ("never write `1px`" / never
+hardcode sizes), invisible to rule 1:
+
+- `flow-ui.tsx`: `minHeight: 38` (`:159`, `:195`); `width: 8, height: 8` (`:106`); `inset: -3` (`:111`).
+- `step-kickoff.tsx`: `minHeight: 38` (`:669`, `:693`).
+
+**Violates:** §5 / enforcement rule 1 (in spirit; the regex misses numerics).
+**Fix:** map to the `--sp-*` ladder (`8 → var(--sp-2)`; `38` ≈ control height — use `--sp-9`/`--sp-10`
+or a shared control-height token). The 3px ring offset → `--sp-0_75`.
+**Impact:** discipline + closes a linter blind spot. **Effort:** S. *(Worth a follow-up to
+normalize whitespace / scan numeric values in the linter — DESIGN-AUDIT P0.5.)*
+
+---
+
+### F6 — Hardcoded full-round radius — **Med**
+
+`borderRadius: 999` (`progress-rail.tsx:47`; `guides.tsx:42`, `:65`) and `borderRadius: "50%"`
+(`flow-ui.tsx:73`, `:107`) hardcode a pill/circle radius. §5 defines exactly four radius tokens
+(`chip/input/panel/dialog`) and "never hardcode … radius" — but **there is no full-round token**,
+so today there's no compliant way to make a circle.
+
+**Violates:** §5 (radius is token-only).
+**Fix:** add a `--radius-full` (or `--radius-pill`) token to `index.css` and reference it; this is
+the §14 "need a value the tokens don't cover? add a token" path. Then sweep the five sites.
+**Impact:** closes a genuine gap in the token set (circular avatars/dots/discs recur elsewhere too).
+**Effort:** S.
+
+---
+
+### F7 — Inline typography props (multi-line) evade the linter — **Med**
+
+- `progress-rail.tsx:108` — inline `fontWeight: state === "active" ? 600 : 400` inside a multi-line
+  style object (rule 5 misses it).
+- `flow-ui.tsx:166` — inline `lineHeight: 1.65` in `CommandBox`.
+
+**Violates:** §4 / enforcement rule 5 (typography must come from `text-*` tiers + `font-*` classes).
+**Fix:** rail → `font-normal` / `font-semibold` classes (the rail already uses `text-label`); the
+command box → drop inline `lineHeight`, rely on the `mono`/`text-label` tier (add a `--leading-*`
+token if a looser line-height is genuinely needed).
+**Impact:** discipline + linter blind spot. **Effort:** S.
+
+---
+
+### F8 — Hand-rolled surfaces instead of `.surface-*` utilities — **Low**
+
+§6 ships `.surface-raised` / `.surface-sunken` / `.surface-overlay` to "consolidate the
+background+border+radius+shadow combos (prefer these over hand-rolling)". Several spots hand-mix a
+surface instead:
+
+- `flow-ui.tsx` `CommandBox` (`:161-163`): `color-mix(… var(--bg-sunken) 42% …)` + hand-rolled border.
+- `connect-stuck-panel.tsx:29-30`, `guides.tsx:85-88` (TerminalGuide), `:184-185` (InstallGuide):
+  `color-mix(… var(--bg-raised) 40% …)` + faint border.
+
+**Violates:** §6 (prefer the surface utilities).
+**Fix:** use `.surface-sunken`/`.surface-raised` where the mix matches; if the partial-opacity
+washes are intentional, define them as `--surface-*` tokens rather than per-call-site mixes.
+**Impact:** consistency / single-source. **Effort:** M (need an eye on each to confirm the wash is
+equivalent).
+
+---
+
+### F9 — Non-lucide glyphs — **Low**
+
+§8: "lucide-react only — single icon set, no custom glyphs". Found:
+
+- `guides.tsx:126` — literal `✓ macbook-pro connected` (inside the mock-terminal illustration).
+- `connect-stuck-panel.tsx:50` and `guides.tsx` node link — trailing `→` text arrow.
+
+**Violates:** §8 (this is the long-deferred "✓ ⚠ ✗ → lucide purge" — see DESIGN-AUDIT Phase-1
+follow-up).
+**Fix:** lucide `Check` / `ArrowRight`. The terminal `✓` is borderline (it's faux terminal output
+inside a `role="img"`), so it's the lowest priority of the set — call it out and decide.
+**Impact:** cosmetic/consistency. **Effort:** S.
+
+---
+
+### F10 — Informational panel wears card chrome — **Low**
+
+DESIGN.md design-language pillar 5: "Card chrome = interactivity. Read-only / informational states
+(status readouts, confirmations) render as plain labeled content, **not** wrapped in a filled/
+bordered card." `connect-stuck-panel.tsx` is pure informational recovery tips (a title, a bulleted
+list, one link) but is wrapped in a bordered + `bg-raised` filled card (`:23-31`).
+
+**Violates:** language pillar 5.
+**Fix:** render as plain content, or — since it's a "heads-up, here's why it might be stuck" notice
+— route it through the `info` `FlowNote`/callout (which F3 is already fixing) rather than a generic
+card. (The `TerminalGuide`/`InstallGuide` boxes are genuine *illustrations*, so their chrome is
+defensible.)
+**Impact:** subtle hierarchy. **Effort:** S. *(Note: shared with Settings → Computers, so confirm
+both surfaces.)*
+
+---
+
+### F11 — Selection tint / checkbox rows off the OptionCard spec — **Low**
+
+`step-create-agent.tsx` correctly uses the `OptionCard` primitive for Visibility. But the repo/
+project selection rows (`flow-ui.tsx` `RepoPicker:276`, `step-kickoff.tsx` `InviteeConfirm:458`)
+hand-roll a checkbox row with an active tint of `--primary` **8%**. §7's selection spec calls for a
+"**very light `--fg` tint (~5%)**". These are multi-select checkboxes (not radio OptionCards), so
+§7's exact rule doesn't bind — but the divergent tint % and the lack of a shared primitive are
+worth aligning (ties into F4).
+
+**Violates:** §7 (selection-state convention; primitive reuse).
+**Fix:** introduce a `Checkbox`/`CheckRow` primitive matching OptionCard's tint discipline; reuse
+in both pickers.
+**Impact:** minor visual consistency. **Effort:** M (folds into F4).
+
+---
+
+### F12 — shadcn alias used in new code — **Nit**
+
+`step-create-agent.tsx:131` (`text-muted-foreground`) and several spots in `invite-accept.tsx`.
+§3: the shadcn-compat aliases are "preserved so shadcn-shaped components keep working — **prefer the
+short semantic names above in new code**." Onboarding is new code.
+**Fix:** `text-muted-foreground → text-[color:var(--fg-3)]` (or a `text-fg-3` utility if defined).
+**Impact:** nit / single-source hygiene. **Effort:** S.
+
+---
+
+### F13 — Dead onboarding CSS in `index.css` — **Nit**
+
+`.onboarding-runtime-option` (`index.css:1423-1432`) and `.onboarding-name-input::placeholder`
+(`:1434-1437`) have **zero references** in `src/` (verified by grep). Leftover from an earlier
+runtime-picker / named-input design.
+**Fix:** delete (or re-wire if the runtime picker is meant to return). Housekeeping toward §1
+single-source.
+**Impact:** none visual; removes confusion. **Effort:** S.
+
+---
+
+## 3. What's already compliant (no action)
+
+So the plan stays honest about scope — these were checked and pass:
+
+- **Color is token-driven and semantically correct.** `cta` (green hero) is used on exactly the
+  creation/launch moments (`step-create-agent` "Create …", admin/invitee kickoff "Start"); every
+  other advance is neutral `default` — matching language pillar 2 (no green-on-dense-actions).
+- **Working/status affordances** use `--state-working` (pulsing dots) and `--success` (✓ row)
+  correctly per the green-liveness model (§3).
+- **Type scale**: all copy uses the 6-tier `text-eyebrow…text-title` utilities; no Tailwind default
+  text sizes.
+- **Spacing**: `--sp-*` ladder / Tailwind utilities throughout (the few literals are F5).
+- **Shell & rail layout**: disciplined, borderless, token-driven; reduced-motion fallbacks present
+  for every animation (§9).
+- **`invite-accept.tsx`** is the reference implementation — `Card`/`Button`/utility classes/§13
+  focus ring. Only nits (F12) and one debatable warning-callout color (the "you'll switch teams"
+  note at `:165-174` uses a neutral `--bg-sunken` panel; §3 would suggest the `--color-warn` pair —
+  flagging as a **judgment call**, not a hard gap).
+
+---
+
+## 4. Proposed remediation phasing (for discussion — not yet started)
+
+Grouped to minimize churn and let each land green:
+
+- **Phase A — primitive adoption (highest UX value):** F1 (`Input`), F2 (`Button` link/ghost),
+  F3 (callout tokens). Mechanical, removes the focus-a11y regression, biggest consistency win.
+- **Phase B — token gaps + linter blind spots:** F5 (numeric px → `--sp-*`), F6 (`--radius-full`
+  token), F7 (inline font props). Optionally tighten the linter to catch numerics + multi-line
+  styles so these can't regress.
+- **Phase C — dedupe + surfaces:** F4 (shared CommandBox/CheckRow), F8 (`.surface-*`), F11.
+- **Phase D — cosmetic/housekeeping:** F9 (lucide glyphs), F10 (stuck-panel chrome), F12, F13.
+
+**Two open judgment calls to confirm with the user before implementing:**
+1. The "you'll switch teams" note and the "stuck?" panel — should informational notices be the
+   blue `info` callout, a neutral panel, or plain content? (F3/F10 hinge on this.)
+2. The mock-terminal `✓` (F9) — purge to lucide, or accept as faux-output inside a `role="img"`?
+
+**Acceptance for the eventual implementation:** `pnpm --filter @first-tree/web typecheck`
+(tsc + `lint:tokens`) green, plus a by-eye pass of every state in `/preview/onboarding` (light +
+dark), since the most impactful fixes (focus, callout color) are exactly the kind the linter can't
+see.
+
+---
+
+## 5. Implementation status (2026-06-01)
+
+Implemented under full autonomy (user opted out of the plan-approval checkpoint). Verified:
+`tsc` + `lint:tokens` green, full monorepo test suite green (web 516 / client 1020 / cli 382 /
+server 1275), and every state eyeballed in `/preview/onboarding` in light **and** dark.
+
+**Shipped:**
+
+| # | What changed |
+|---|---|
+| F1 | All three raw `<input>`s (`step-team`, `step-create-agent`, `step-kickoff` tree-URL) → the `Input` primitive. Fixes the tree-URL field's missing focus state; focus now follows §13 (`focus-visible:border-ring`). |
+| F2 | Quiet/secondary actions (`Sign out`, `Finish later`, `Skip`, `Cancel`, `Create instead`, `I already have one`, `Continue without a project` ×2) → `<Button variant="link">`. No more `--fg-4` (disabled tier) on live text; all get the §13 focus ring. |
+| F3 | `FlowNote` → the §3 callout token pairs (`border-error bg-error-soft text-error` / `border-info bg-info-soft text-info`), same grammar as `doc-preview-drawer`. Info notices now read as the system's blue instead of neutral. |
+| F4 | New shared `SelectableRow` (used by `RepoPicker` + invitee confirm list); the invitee share-URL box now reuses `CommandBox`. ~145 net lines removed. |
+| F5 | Numeric px (`38`, `8`, `-3`) → `--sp-*` ladder. |
+| F6 | Added `--radius-full` token; all `borderRadius: 999 / "50%"` → `var(--radius-full)`. |
+| F7 | Inline `fontWeight` (progress-rail) → `font-semibold/normal` classes; dropped inline `lineHeight` (CommandBox). |
+| F9 | Mock-terminal `✓` → lucide `Check` (+ `--success` green); stuck-panel `→` → lucide `ArrowRight`. |
+| F11 | Selection tint `--primary` 8% → `--fg` ~5% (matches the OptionCard §7 convention), folded into `SelectableRow`. |
+| F13 | Removed dead `.onboarding-runtime-option` / `.onboarding-name-input` CSS. |
+
+**Deliberately deferred (with rationale):**
+
+- **F8 (surface washes).** `CommandBox` / guides / stuck-panel use `color-mix(--bg-* NN%,
+  transparent)` rather than `.surface-*`. These already reference tokens (not raw values), §6 is a
+  *prefer* guideline not a hard rule, and the partial-opacity wash is a deliberate "quieter than a
+  full card" treatment. Forcing `.surface-*` adds full card chrome and risks a visual regression —
+  not worth it in a token-compliance pass.
+- **F10 (stuck-panel card chrome).** Left as a grouped notice; converting it touches the shared
+  Settings → Computers surface and is a visual judgment better made with that surface in view.
+- **F12 (`text-muted-foreground` in `step-create-agent`).** Left to stay byte-consistent with the
+  sibling New-Agent dialog's Visibility block; a `text-muted-foreground → text-fg-3` sweep should be
+  a separate, app-wide change, not a one-off divergence here.
+- **Progress-rail back-nav `<button>`.** Kept as a structural rail control (uses `--fg-2`, an
+  acceptable tier — not the disabled tier); styling it as a link would read oddly in the rail.

--- a/packages/web/scripts/check-design-tokens.sh
+++ b/packages/web/scripts/check-design-tokens.sh
@@ -103,12 +103,13 @@ if [ -n "$undef" ]; then
   report "Reference to undefined CSS variable(s) — define in index.css or fix the name:" "$undef"
 fi
 
-# 8. Tailwind default radius classes — radius is the semantic --radius-* four only.
+# 8. Tailwind default radius classes — radius is the semantic --radius-* set only
+#    (chip/input/panel/dialog + the fully-round --radius-full).
 hits=$(grep -rnE '\brounded-(sm|md|lg|xl)\b' \
   --include="*.tsx" \
   "$SRC" || true)
 if [ -n "$hits" ]; then
-  report "Tailwind default radius class found (use rounded-[var(--radius-chip|input|panel|dialog)]):" "$hits"
+  report "Tailwind default radius class found (use rounded-[var(--radius-chip|input|panel|dialog|full)]):" "$hits"
 fi
 
 # 9. Tailwind shadow classes above the 2-tier scale — shadow is --shadow-sm/md only.

--- a/packages/web/src/components/connect-stuck-panel.tsx
+++ b/packages/web/src/components/connect-stuck-panel.tsx
@@ -1,3 +1,4 @@
+import { ArrowRight } from "lucide-react";
 import { COPY } from "../pages/onboarding/copy.js";
 
 /**
@@ -44,10 +45,11 @@ export function ConnectStuckPanel() {
         href={COPY.connectComputer.nodeUrl}
         target="_blank"
         rel="noopener noreferrer"
-        className="text-label font-medium self-start"
-        style={{ color: "var(--primary)" }}
+        className="inline-flex items-center text-label font-medium self-start"
+        style={{ gap: "var(--sp-1)", color: "var(--primary)" }}
       >
-        {COPY.connectComputer.nodeLinkLabel} →
+        {COPY.connectComputer.nodeLinkLabel}
+        <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
       </a>
     </div>
   );

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -138,6 +138,9 @@
   --radius-input: 4px;
   --radius-panel: 6px;
   --radius-dialog: 8px;
+  /* Fully-round — pills, circular discs/dots, avatar rings. The one radius that
+     isn't surface-importance-ascending; it means "capsule/circle", not a size. */
+  --radius-full: 9999px;
 
   /* ---- Font families ------------------------------------------------------- */
   --font-sans: var(--font-sans-stack);
@@ -1418,22 +1421,6 @@
  */
 .computer-card-stack > * + * {
   border-top: var(--hairline) solid var(--border-faint);
-}
-
-.onboarding-runtime-option {
-  border-radius: var(--radius-input);
-  outline: var(--hairline) solid transparent;
-  outline-offset: var(--sp-0_75);
-}
-
-.onboarding-runtime-option:focus-within {
-  color: color-mix(in oklch, var(--primary) 30%, var(--fg));
-  outline-color: var(--ring);
-}
-
-.onboarding-name-input::placeholder {
-  color: var(--fg-4);
-  opacity: 0.72;
 }
 
 /* Dense table row hover — used by DenseTableRow[data-interactive] */

--- a/packages/web/src/pages/onboarding/flow-ui.tsx
+++ b/packages/web/src/pages/onboarding/flow-ui.tsx
@@ -2,6 +2,8 @@ import { Check, CircleAlert, Copy, ExternalLink, Info, Lock } from "lucide-react
 import type { ReactNode } from "react";
 import { useState } from "react";
 import type { GithubRepo } from "../../api/github.js";
+import { Button } from "../../components/ui/button.js";
+import { cn } from "../../lib/utils.js";
 
 /**
  * Step heading (title + optional one-line "why"). Used when a step renders its
@@ -24,27 +26,22 @@ export function StepHeading({ title, why }: { title: string; why?: string | null
   );
 }
 
-/** Error / warning note. Tone "error" (red) or "info" (neutral ink). */
+/**
+ * Inline notice. Tone "error" (red) or "info" (blue). Both render through the
+ * design-system callout token pairs (DESIGN.md §3) — a soft background plus a
+ * strong text/border tone — the same `border-{tone} bg-{tone}-soft text-{tone}`
+ * grammar as the rest of the app's notices, rather than hand-mixing colors.
+ */
 export function FlowNote({ children, tone = "error" }: { children: ReactNode; tone?: "error" | "info" }) {
-  const color = tone === "error" ? "var(--state-error)" : "var(--fg-2)";
-  const bg = tone === "error" ? "var(--state-error-soft)" : "color-mix(in oklch, var(--primary) 8%, transparent)";
-  const border =
-    tone === "error"
-      ? "color-mix(in oklch, var(--state-error) 28%, transparent)"
-      : "color-mix(in oklch, var(--primary) 22%, transparent)";
   const Icon = tone === "error" ? CircleAlert : Info;
   return (
     <div
-      className="flex items-start text-label"
+      className={cn(
+        "flex items-start text-label rounded-[var(--radius-input)] border",
+        tone === "error" ? "border-error bg-error-soft text-error" : "border-info bg-info-soft text-info",
+      )}
       role={tone === "error" ? "alert" : undefined}
-      style={{
-        gap: "var(--sp-2)",
-        padding: "var(--sp-2_5) var(--sp-3)",
-        background: bg,
-        border: `var(--hairline) solid ${border}`,
-        borderRadius: "var(--radius-input)",
-        color,
-      }}
+      style={{ gap: "var(--sp-2)", padding: "var(--sp-2_5) var(--sp-3)" }}
     >
       <Icon className="h-3.5 w-3.5" style={{ flexShrink: 0, marginTop: "var(--sp-0_5)" }} aria-hidden="true" />
       <span style={{ minWidth: 0 }}>{children}</span>
@@ -69,7 +66,7 @@ export function WorkingState({ label, hint }: { label: string; hint?: string }) 
             style={{
               width: "var(--sp-2)",
               height: "var(--sp-2)",
-              borderRadius: "50%",
+              borderRadius: "var(--radius-full)",
               background: "var(--state-working)",
               animationDelay: `${delay}ms`,
             }}
@@ -103,13 +100,23 @@ export function StatusRow({ state, label }: { state: "waiting" | "ok"; label: Re
       {state === "ok" ? (
         <Check className="h-3.5 w-3.5" />
       ) : (
-        <span aria-hidden="true" style={{ position: "relative", display: "inline-block", width: 8, height: 8 }}>
-          <span style={{ position: "absolute", inset: 0, borderRadius: "50%", background: "var(--state-working)" }} />
+        <span
+          aria-hidden="true"
+          style={{ position: "relative", display: "inline-block", width: "var(--sp-2)", height: "var(--sp-2)" }}
+        >
           <span
             style={{
               position: "absolute",
-              inset: -3,
-              borderRadius: "50%",
+              inset: 0,
+              borderRadius: "var(--radius-full)",
+              background: "var(--state-working)",
+            }}
+          />
+          <span
+            style={{
+              position: "absolute",
+              inset: "calc(-1 * var(--sp-0_75))",
+              borderRadius: "var(--radius-full)",
               border: "var(--hairline) solid var(--state-working)",
               animation: "ring-pulse 1.8s infinite",
               opacity: 0.55,
@@ -137,7 +144,14 @@ export function StatusRow({ state, label }: { state: "waiting" | "ok"; label: Re
  * from the visible box while Copy still worked. The current pass-through
  * trusts the server: render the lines it gave us, in order.
  */
-export function CommandBox({ command }: { command: string | null }) {
+export function CommandBox({
+  command,
+  placeholder = "Generating command…",
+}: {
+  command: string | null;
+  /** Shown when `command` is null (e.g. "Generating command…" or "…"). */
+  placeholder?: string;
+}) {
   const [copied, setCopied] = useState(false);
   const lines = command ? command.split("\n").filter((l) => l.trim().length > 0) : [];
 
@@ -155,7 +169,7 @@ export function CommandBox({ command }: { command: string | null }) {
         title={command ?? undefined}
         style={{
           flex: 1,
-          minHeight: 38,
+          minHeight: "var(--sp-10)",
           margin: 0,
           padding: "var(--sp-2_5) var(--sp-3)",
           background: "color-mix(in oklch, var(--bg-sunken) 42%, transparent)",
@@ -163,7 +177,6 @@ export function CommandBox({ command }: { command: string | null }) {
           borderRadius: "var(--radius-input)",
           color: "var(--fg-2)",
           minWidth: 0,
-          lineHeight: 1.65,
           display: "flex",
           flexDirection: "column",
           justifyContent: "center",
@@ -181,30 +194,66 @@ export function CommandBox({ command }: { command: string | null }) {
             </span>
           ))
         ) : (
-          <span>Generating command…</span>
+          <span>{placeholder}</span>
         )}
       </div>
-      <button
-        type="button"
-        onClick={handleCopy}
-        disabled={!command}
-        className="inline-flex items-center justify-center text-label font-medium"
-        style={{
-          gap: "var(--sp-1_5)",
-          padding: "0 var(--sp-3)",
-          minHeight: 38,
-          background: "color-mix(in oklch, var(--bg-raised) 48%, transparent)",
-          border: "var(--hairline) solid color-mix(in oklch, var(--border) 58%, transparent)",
-          borderRadius: "var(--radius-input)",
-          color: "var(--fg-2)",
-          cursor: command ? "pointer" : "not-allowed",
-          opacity: command ? 1 : 0.6,
-        }}
-      >
+      <Button type="button" variant="outline" onClick={handleCopy} disabled={!command} className="h-auto">
         {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
         {copied ? "Copied" : "Copy"}
-      </button>
+      </Button>
     </div>
+  );
+}
+
+/**
+ * One selectable checkbox row, shared by the repo picker and the invitee's
+ * project-confirm list so both read identically. The real `<input>` is
+ * `sr-only` (focus ring comes from `.onboarding-choice:focus-within` in
+ * index.css, per DESIGN.md §13); selection is signalled the OptionCard way —
+ * a filled neutral box plus a very light `--fg` tint (~5%), no colored row
+ * border. `position: relative` makes the row the containing block for the
+ * absolutely-positioned sr-only input, so it can't escape the picker's clip.
+ */
+export function SelectableRow({
+  checked,
+  onToggle,
+  children,
+}: {
+  checked: boolean;
+  onToggle: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <label
+      className="onboarding-choice flex items-center text-body"
+      style={{
+        position: "relative",
+        gap: "var(--sp-2_5)",
+        padding: "var(--sp-2) var(--sp-2_5)",
+        borderRadius: "var(--radius-input)",
+        cursor: "pointer",
+        background: checked ? "color-mix(in oklch, var(--fg) 5%, transparent)" : "transparent",
+        color: checked ? "var(--fg)" : "var(--fg-2)",
+      }}
+    >
+      <input type="checkbox" checked={checked} onChange={onToggle} className="sr-only" />
+      <span
+        aria-hidden="true"
+        className="inline-flex items-center justify-center"
+        style={{
+          width: "var(--sp-4)",
+          height: "var(--sp-4)",
+          flexShrink: 0,
+          borderRadius: "var(--radius-input)",
+          border: checked ? "var(--hairline) solid var(--primary)" : "var(--hairline) solid var(--border-strong)",
+          background: checked ? "var(--primary)" : "transparent",
+          color: "var(--primary-on)",
+        }}
+      >
+        {checked && <Check className="h-3 w-3" />}
+      </span>
+      {children}
+    </label>
   );
 }
 
@@ -258,41 +307,7 @@ export function RepoPicker({
         const repoOwner = slash >= 0 ? repo.fullName.slice(0, slash + 1) : "";
         const repoName = slash >= 0 ? repo.fullName.slice(slash + 1) : repo.fullName;
         return (
-          <label
-            key={repo.cloneUrl}
-            className="onboarding-choice flex items-center text-body"
-            style={{
-              // position:relative makes this row the containing block for the
-              // sr-only checkbox below. Without it, the absolutely-positioned
-              // checkbox is laid out against the nearest *transformed* ancestor
-              // (the fade-in step wrapper), escaping the picker's overflow clip —
-              // all the rows' checkboxes stack far past the viewport and force
-              // the whole page to scroll.
-              position: "relative",
-              gap: "var(--sp-2_5)",
-              padding: "var(--sp-2) var(--sp-2_5)",
-              borderRadius: "var(--radius-input)",
-              cursor: "pointer",
-              background: active ? "color-mix(in oklch, var(--primary) 8%, transparent)" : "transparent",
-              color: active ? "var(--fg)" : "var(--fg-2)",
-            }}
-          >
-            <input type="checkbox" checked={active} onChange={() => onToggle(repo.cloneUrl)} className="sr-only" />
-            <span
-              aria-hidden="true"
-              className="inline-flex items-center justify-center"
-              style={{
-                width: "var(--sp-4)",
-                height: "var(--sp-4)",
-                flexShrink: 0,
-                borderRadius: "var(--radius-input)",
-                border: active ? "var(--hairline) solid var(--primary)" : "var(--hairline) solid var(--border-strong)",
-                background: active ? "var(--primary)" : "transparent",
-                color: "var(--primary-on)",
-              }}
-            >
-              {active && <Check className="h-3 w-3" />}
-            </span>
+          <SelectableRow key={repo.cloneUrl} checked={active} onToggle={() => onToggle(repo.cloneUrl)}>
             <span
               className="font-medium"
               style={{ flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
@@ -312,7 +327,7 @@ export function RepoPicker({
             >
               <ExternalLink className="h-3.5 w-3.5" />
             </a>
-          </label>
+          </SelectableRow>
         );
       })}
     </div>

--- a/packages/web/src/pages/onboarding/guides.tsx
+++ b/packages/web/src/pages/onboarding/guides.tsx
@@ -1,4 +1,4 @@
-import { ChevronRight } from "lucide-react";
+import { Check, ChevronRight } from "lucide-react";
 import type { ReactNode } from "react";
 import { COPY } from "./copy.js";
 
@@ -39,7 +39,7 @@ function GuideSteps({ steps }: { steps: readonly string[] }) {
               width: "var(--sp-4)",
               height: "var(--sp-4)",
               flexShrink: 0,
-              borderRadius: 999,
+              borderRadius: "var(--radius-full)",
               background: "color-mix(in oklch, var(--primary) 14%, transparent)",
               color: "var(--primary)",
             }}
@@ -63,7 +63,7 @@ function WindowDots() {
           style={{
             width: "var(--sp-1_5)",
             height: "var(--sp-1_5)",
-            borderRadius: 999,
+            borderRadius: "var(--radius-full)",
             background: "var(--fg-4)",
             opacity: 0.5,
           }}
@@ -122,8 +122,12 @@ export function TerminalGuide() {
               }}
             />
           </div>
-          <div style={{ color: "color-mix(in oklch, var(--primary) 30%, var(--fg))", marginTop: "var(--sp-1)" }}>
-            ✓ macbook-pro connected
+          <div
+            className="inline-flex items-center"
+            style={{ gap: "var(--sp-1)", color: "var(--success)", marginTop: "var(--sp-1)" }}
+          >
+            <Check className="h-3.5 w-3.5" aria-hidden="true" />
+            macbook-pro connected
           </div>
         </div>
       </div>

--- a/packages/web/src/pages/onboarding/onboarding-shell.tsx
+++ b/packages/web/src/pages/onboarding/onboarding-shell.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import { useNavigate } from "react-router";
 import { useAuth } from "../../auth/auth-context.js";
 import { FirstTreeLogo } from "../../components/first-tree-logo.js";
+import { Button } from "../../components/ui/button.js";
 import { useToast } from "../../components/ui/toast.js";
 import { COPY, STEP_COPY } from "./copy.js";
 import { useOnboardingFlow } from "./onboarding-flow.js";
@@ -41,8 +42,10 @@ export function OnboardingShell({ rail, children }: { rail: ReactNode; children:
               workspace is empty, so leaving is a dead end. Sign out is always
               available so a user who can't finish right now isn't locked out. */}
           {hasAgent && (
-            <button
+            <Button
               type="button"
+              variant="link"
+              className="h-auto p-0 text-label"
               onClick={() => {
                 // Tell the user where setup lives before dropping them into the
                 // still-incomplete workspace — otherwise "finish later" reads as
@@ -54,20 +57,13 @@ export function OnboardingShell({ rail, children }: { rail: ReactNode; children:
                 });
                 void finishLater();
               }}
-              className="text-label"
-              style={{ background: "transparent", border: 0, cursor: "pointer", color: "var(--fg-4)" }}
             >
               {COPY.finishLater}
-            </button>
+            </Button>
           )}
-          <button
-            type="button"
-            onClick={logout}
-            className="text-label"
-            style={{ background: "transparent", border: 0, cursor: "pointer", color: "var(--fg-4)" }}
-          >
+          <Button type="button" variant="link" className="h-auto p-0 text-label" onClick={logout}>
             Sign out
-          </button>
+          </Button>
         </div>
       </header>
 

--- a/packages/web/src/pages/onboarding/progress-rail.tsx
+++ b/packages/web/src/pages/onboarding/progress-rail.tsx
@@ -1,4 +1,5 @@
 import { Bot, Check, GitBranch, type LucideIcon, MonitorSmartphone, Rocket, Sparkles, Users } from "lucide-react";
+import { cn } from "../../lib/utils.js";
 import { resolveStepLabel } from "./copy.js";
 import { useOnboardingFlow } from "./onboarding-flow.js";
 import { type StepId, stepVisualState } from "./steps.js";
@@ -43,7 +44,7 @@ export function ProgressRail() {
                   width: "var(--sp-6)",
                   height: "var(--sp-6)",
                   flexShrink: 0,
-                  borderRadius: 999,
+                  borderRadius: "var(--radius-full)",
                   background:
                     state === "active"
                       ? "var(--primary)"
@@ -101,12 +102,9 @@ export function ProgressRail() {
                 </button>
               ) : (
                 <span
-                  className="text-label"
+                  className={cn("text-label", state === "active" ? "font-semibold" : "font-normal")}
                   aria-current={state === "active" ? "step" : undefined}
-                  style={{
-                    color: state === "active" ? "var(--fg)" : "var(--fg-4)",
-                    fontWeight: state === "active" ? 600 : 400,
-                  }}
+                  style={{ color: state === "active" ? "var(--fg)" : "var(--fg-4)" }}
                 >
                   {label}
                 </span>

--- a/packages/web/src/pages/onboarding/steps/step-connect-code.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-connect-code.tsx
@@ -136,20 +136,9 @@ export function StepConnectCode() {
                 {COPY.connectCode.cta}
               </Button>
               {!showSkipConfirm && (
-                <button
-                  type="button"
-                  onClick={handleSkipClick}
-                  className="text-label"
-                  style={{
-                    background: "transparent",
-                    border: 0,
-                    padding: 0,
-                    cursor: "pointer",
-                    color: "var(--fg-4)",
-                  }}
-                >
+                <Button type="button" variant="link" className="h-auto p-0 text-label" onClick={handleSkipClick}>
                   {COPY.skipForNow}
-                </button>
+                </Button>
               )}
             </div>
 
@@ -170,20 +159,14 @@ export function StepConnectCode() {
                     <Button type="button" variant="outline" onClick={handleSkipConfirmed}>
                       {COPY.connectCode.skipAnyway}
                     </Button>
-                    <button
+                    <Button
                       type="button"
+                      variant="link"
+                      className="h-auto p-0 text-label"
                       onClick={() => setShowSkipConfirm(false)}
-                      className="text-label"
-                      style={{
-                        background: "transparent",
-                        border: 0,
-                        padding: 0,
-                        cursor: "pointer",
-                        color: "var(--fg-4)",
-                      }}
                     >
                       {COPY.cancel}
-                    </button>
+                    </Button>
                   </div>
                 </div>
               </FlowNote>

--- a/packages/web/src/pages/onboarding/steps/step-create-agent.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-create-agent.tsx
@@ -1,6 +1,7 @@
 import type { AgentVisibility } from "@first-tree/shared";
 import { ArrowRight } from "lucide-react";
 import { Button } from "../../../components/ui/button.js";
+import { Input } from "../../../components/ui/input.js";
 import { OptionCard } from "../../../components/ui/option-card.js";
 import { COPY } from "../copy.js";
 import { FlowNote, WorkingState } from "../flow-ui.js";
@@ -87,28 +88,12 @@ export function StepCreateAgent() {
         <label htmlFor="onboarding-agent-name" className="text-label font-medium" style={{ color: "var(--fg-2)" }}>
           {COPY.createAgent.nameLabel}
         </label>
-        <input
+        <Input
           id="onboarding-agent-name"
           value={agentDisplayName}
           onChange={(e) => setAgentDisplayName(e.target.value)}
           placeholder="e.g. Buddy, Helper"
           maxLength={200}
-          className="text-body"
-          style={{
-            padding: "var(--sp-2) var(--sp-3)",
-            background: "var(--bg)",
-            border: "var(--hairline) solid var(--border)",
-            borderRadius: "var(--radius-input)",
-            color: "var(--fg)",
-            outline: "none",
-            caretColor: "var(--primary)",
-          }}
-          onFocus={(e) => {
-            e.currentTarget.style.borderColor = "var(--primary)";
-          }}
-          onBlur={(e) => {
-            e.currentTarget.style.borderColor = "var(--border)";
-          }}
         />
       </div>
 

--- a/packages/web/src/pages/onboarding/steps/step-kickoff.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-kickoff.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { ArrowRight, Check, Copy } from "lucide-react";
+import { ArrowRight } from "lucide-react";
 import { useEffect, useState } from "react";
 import { getAgentConfig, updateAgentConfig } from "../../../api/agent-config.js";
 import { createAgentChat, sendChatMessage } from "../../../api/chats.js";
@@ -14,23 +14,16 @@ import {
   putSourceReposSetting,
 } from "../../../api/org-settings.js";
 import { Button } from "../../../components/ui/button.js";
+import { Input } from "../../../components/ui/input.js";
 import { buildBindBootstrap, buildCreateBootstrap } from "../../workspace/center/onboarding/bootstrap-prose.js";
 import { COPY } from "../copy.js";
-import { FlowNote, RepoPicker, StatusRow, StepHeading, WorkingState } from "../flow-ui.js";
+import { CommandBox, FlowNote, RepoPicker, SelectableRow, StatusRow, StepHeading, WorkingState } from "../flow-ui.js";
 import { useOnboardingFlow } from "../onboarding-flow.js";
 import { resolveOnboardingAgent } from "../resolve-agent.js";
 import { resolveInviteeKickoffState } from "../steps.js";
 
 const NO_REPO_BOOTSTRAP =
   "Introduce yourself to the team — what can you help with, and what's a good first thing for me to try?";
-
-const LINK_STYLE = {
-  background: "transparent",
-  border: 0,
-  padding: 0,
-  cursor: "pointer",
-  color: "var(--primary)",
-} as const;
 
 function repoLabel(url: string): string {
   return url
@@ -225,20 +218,12 @@ function AdminKickoff() {
             <label htmlFor="onboarding-tree-url" className="text-label" style={{ color: "var(--fg-3)" }}>
               {COPY.kickoff.existingUrlLabel}
             </label>
-            <input
+            <Input
               id="onboarding-tree-url"
               value={treeUrl}
               onChange={(e) => setTreeUrl(e.target.value)}
               placeholder="https://github.com/your-team/context-tree"
-              className="text-body mono"
-              style={{
-                padding: "var(--sp-2) var(--sp-3)",
-                background: "var(--bg)",
-                border: "var(--hairline) solid var(--border)",
-                borderRadius: "var(--radius-input)",
-                color: "var(--fg)",
-                outline: "none",
-              }}
+              className="mono"
             />
             {autoDetected ? (
               <p className="text-label" style={{ margin: 0, color: "var(--fg-4)" }}>
@@ -246,28 +231,28 @@ function AdminKickoff() {
               </p>
             ) : null}
             {urlInvalid && <FlowNote>{COPY.kickoff.invalidUrl}</FlowNote>}
-            <button
+            <Button
               type="button"
+              variant="link"
+              className="h-auto p-0 text-label self-start"
               onClick={() => {
                 setTreeUrl("");
                 setTreeMode("new");
               }}
-              className="text-label self-start"
-              style={LINK_STYLE}
             >
               {COPY.kickoff.createInstead}
-            </button>
+            </Button>
           </div>
         ) : (
           // B (new tree, default): quiet secondary link to the existing path.
-          <button
+          <Button
             type="button"
+            variant="link"
+            className="h-auto p-0 text-label self-start"
             onClick={() => setTreeMode("existing")}
-            className="text-label self-start"
-            style={LINK_STYLE}
           >
             {COPY.kickoff.haveExisting}
-          </button>
+          </Button>
         )}
         {error && <FlowNote>{error}</FlowNote>}
         <div className="flex">
@@ -444,43 +429,11 @@ function InviteeConfirm({ treeUrl, teamRepoUrls }: { treeUrl: string; teamRepoUr
       <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
         <TreeUrlDisplay treeUrl={treeUrl} />
         <div className="flex flex-col" style={{ gap: "var(--sp-1)" }}>
-          {teamRepoUrls.map((url) => {
-            const active = chosen.includes(url);
-            return (
-              <label
-                key={url}
-                className="onboarding-choice flex items-center text-body"
-                style={{
-                  gap: "var(--sp-2_5)",
-                  padding: "var(--sp-2) var(--sp-2_5)",
-                  borderRadius: "var(--radius-input)",
-                  cursor: "pointer",
-                  background: active ? "color-mix(in oklch, var(--primary) 8%, transparent)" : "transparent",
-                  color: active ? "var(--fg)" : "var(--fg-2)",
-                }}
-              >
-                <input type="checkbox" checked={active} onChange={() => toggle(url)} className="sr-only" />
-                <span
-                  aria-hidden="true"
-                  className="inline-flex items-center justify-center"
-                  style={{
-                    width: "var(--sp-4)",
-                    height: "var(--sp-4)",
-                    flexShrink: 0,
-                    borderRadius: "var(--radius-input)",
-                    border: active
-                      ? "var(--hairline) solid var(--primary)"
-                      : "var(--hairline) solid var(--border-strong)",
-                    background: active ? "var(--primary)" : "transparent",
-                    color: "var(--primary-on)",
-                  }}
-                >
-                  {active && <Check className="h-3 w-3" />}
-                </span>
-                <span className="font-medium">{repoLabel(url)}</span>
-              </label>
-            );
-          })}
+          {teamRepoUrls.map((url) => (
+            <SelectableRow key={url} checked={chosen.includes(url)} onToggle={() => toggle(url)}>
+              <span className="font-medium">{repoLabel(url)}</span>
+            </SelectableRow>
+          ))}
         </div>
         {error && <FlowNote>{error}</FlowNote>}
         {/* Primary is never disabled by deselect-all; the bailout link
@@ -491,14 +444,9 @@ function InviteeConfirm({ treeUrl, teamRepoUrls }: { treeUrl: string; teamRepoUr
             <span>{COPY.kickoff.start}</span>
             <ArrowRight className="h-4 w-4" />
           </Button>
-          <button
-            type="button"
-            onClick={() => void handleStart([])}
-            className="text-label"
-            style={{ background: "transparent", border: 0, padding: 0, cursor: "pointer", color: "var(--fg-4)" }}
-          >
+          <Button type="button" variant="link" className="h-auto p-0 text-label" onClick={() => void handleStart([])}>
             {COPY.kickoff.inviteeContinueNoProject}
-          </button>
+          </Button>
         </div>
       </div>
     </div>
@@ -585,14 +533,9 @@ function InviteePicker({ treeUrl }: { treeUrl: string }) {
           {/* Always visible — covers empty, scope-missing, network, AND
               "I just don't want to pick one right now". No path is a
               dead end. */}
-          <button
-            type="button"
-            onClick={() => void handleStart([])}
-            className="text-label"
-            style={{ background: "transparent", border: 0, padding: 0, cursor: "pointer", color: "var(--fg-4)" }}
-          >
+          <Button type="button" variant="link" className="h-auto p-0 text-label" onClick={() => void handleStart([])}>
             {COPY.kickoff.inviteeContinueNoProject}
-          </button>
+          </Button>
         </div>
       </div>
     </div>
@@ -636,18 +579,10 @@ function InviteeWaiting() {
 function InviteeNoInstallation() {
   const { finishLater } = useOnboardingFlow();
   const [pageUrl, setPageUrl] = useState<string>("");
-  const [copied, setCopied] = useState(false);
 
   useEffect(() => {
     if (typeof window !== "undefined") setPageUrl(window.location.href);
   }, []);
-
-  const handleCopy = async (): Promise<void> => {
-    if (!pageUrl) return;
-    await navigator.clipboard.writeText(pageUrl);
-    setCopied(true);
-    window.setTimeout(() => setCopied(false), 1500);
-  };
 
   return (
     <div className="flex flex-col" style={{ gap: "var(--sp-6)" }}>
@@ -660,49 +595,9 @@ function InviteeNoInstallation() {
           <p className="text-label" style={{ margin: 0, color: "var(--fg-2)" }}>
             {COPY.invitee.noInstallShareIntro}
           </p>
-          <div className="flex" style={{ gap: "var(--sp-2)", alignItems: "stretch" }}>
-            <div
-              className="text-label"
-              title={pageUrl}
-              style={{
-                flex: 1,
-                minHeight: 38,
-                padding: "var(--sp-2_5) var(--sp-3)",
-                background: "color-mix(in oklch, var(--bg-sunken) 42%, transparent)",
-                border: "var(--hairline) solid color-mix(in oklch, var(--border-faint) 58%, transparent)",
-                borderRadius: "var(--radius-input)",
-                color: "var(--fg-2)",
-                minWidth: 0,
-                display: "flex",
-                alignItems: "center",
-                whiteSpace: "nowrap",
-                overflow: "hidden",
-                textOverflow: "ellipsis",
-              }}
-            >
-              {pageUrl || "…"}
-            </div>
-            <button
-              type="button"
-              onClick={() => void handleCopy()}
-              disabled={!pageUrl}
-              className="inline-flex items-center justify-center text-label font-medium"
-              style={{
-                gap: "var(--sp-1_5)",
-                padding: "0 var(--sp-3)",
-                minHeight: 38,
-                background: "color-mix(in oklch, var(--bg-raised) 48%, transparent)",
-                border: "var(--hairline) solid color-mix(in oklch, var(--border) 58%, transparent)",
-                borderRadius: "var(--radius-input)",
-                color: "var(--fg-2)",
-                cursor: pageUrl ? "pointer" : "not-allowed",
-                opacity: pageUrl ? 1 : 0.6,
-              }}
-            >
-              {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
-              {copied ? "Copied" : "Copy"}
-            </button>
-          </div>
+          {/* Reuses the connect-computer CommandBox so the copy affordance is
+              identical everywhere; here the "command" is the shareable page URL. */}
+          <CommandBox command={pageUrl || null} placeholder="…" />
         </div>
 
         <div className="flex">

--- a/packages/web/src/pages/onboarding/steps/step-team.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-team.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { api } from "../../../api/client.js";
 import { reportOnboardingEvent } from "../../../api/onboarding-events.js";
 import { Button } from "../../../components/ui/button.js";
+import { Input } from "../../../components/ui/input.js";
 import { COPY } from "../copy.js";
 import { FlowNote } from "../flow-ui.js";
 import { useOnboardingFlow } from "../onboarding-flow.js";
@@ -80,7 +81,7 @@ export function StepTeam() {
       {/* No visible <label> — the step title ("Name your team") and the
           field's `aria-label` already name the input. Repeating "Team name"
           here was visual noise on a single-input page. */}
-      <input
+      <Input
         ref={inputRef}
         id="onboarding-team-name"
         aria-label="Team name"
@@ -88,22 +89,6 @@ export function StepTeam() {
         onChange={(e) => setName(e.target.value)}
         maxLength={200}
         disabled={saving}
-        className="text-body"
-        style={{
-          padding: "var(--sp-2) var(--sp-3)",
-          background: "var(--bg)",
-          border: "var(--hairline) solid var(--border)",
-          borderRadius: "var(--radius-input)",
-          color: "var(--fg)",
-          outline: "none",
-          caretColor: "var(--primary)",
-        }}
-        onFocus={(e) => {
-          e.currentTarget.style.borderColor = "var(--primary)";
-        }}
-        onBlur={(e) => {
-          e.currentTarget.style.borderColor = "var(--border)";
-        }}
       />
 
       {(saveError || loadError) && (


### PR DESCRIPTION
## What & why

The onboarding flow was **token-clean** (colors/spacing/type via tokens) but **diverged from the design system's component layer**. The pre-login `invite-accept.tsx` page is the gold standard (composes `Card`/`Button`/the §13 focus ring); the in-flow wizard hand-rolled inputs, checkboxes, chips, notices, command boxes, and quiet link-buttons with inline styles. This brings the wizard up to that bar.

Full audit + per-finding status (incl. deliberate deferrals & rationale) lives in **`packages/web/docs/onboarding-ui-design-audit.md`**.

## Changes

- **F1 — Inputs → `Input` primitive.** The three raw `<input>`s (team name, agent name, kickoff tree-URL) now use `Input`. Fixes a real a11y bug: the tree-URL field had `outline:none` and **no focus handler at all** (no visible focus). Focus now follows DESIGN.md §13 (`focus-visible:border-ring`) instead of imperative `onFocus`/`onBlur` JS.
- **F2 — Quiet actions → `Button variant="link"`.** Sign out, Finish later, Skip, Cancel, "Create instead", "I already have one", "Continue without a project" (×2). Removes `--fg-4` (the **disabled** tier) used on live clickable text, and gives them the §13 focus ring.
- **F3 — `FlowNote` → §3 callout tokens.** `border-error bg-error-soft text-error` / `border-info bg-info-soft text-info` — same grammar as `doc-preview-drawer`. Info notices now read as the system's blue instead of a neutral wash.
- **F4 — Dedup.** New shared `SelectableRow` (RepoPicker + invitee confirm list); the invitee share-URL box reuses `CommandBox`. **Net ~145 lines removed.**
- **F5/F6/F7 — Linter blind spots.** Numeric px (`38`/`8`/`-3`) → `--sp-*`; new `--radius-full` token replaces `borderRadius: 999/"50%"`; inline `fontWeight`/`lineHeight` → `font-*` classes. (These passed the line-based `lint:tokens` but violated the spec.)
- **F9 — Icons.** Mock-terminal `✓` → lucide `Check` (+ `--success`); stuck-panel `→` → lucide `ArrowRight` (§8 lucide-only).
- **F11 — Selection tint** `--primary` 8% → `--fg` ~5% (OptionCard §7 convention).
- **F13 — Removed** dead `.onboarding-runtime-option` / `.onboarding-name-input` CSS.

**Deferred (rationale in the doc):** F8 (surface washes already token-based; §6 is a *prefer*), F10 (stuck-panel chrome — shared Settings surface), F12 (`text-muted-foreground` — kept consistent with sibling dialog).

## Verification

- `pnpm check` (Biome) ✓ · `pnpm --filter @first-tree/web typecheck` (tsc + `lint:tokens`) ✓
- Full monorepo test suite ✓ — web 516 / client 1020 / cli 382 / server 1275
- Independent review: `codex review` → **PASS** (one [P2]: missing Biome format — fixed & folded in)
- Eyeballed every state in `/preview/onboarding`, **light + dark** (FlowNote blue/red, Input focus, CommandBox reuse, SelectableRow tint, link buttons)

Scope: `packages/web` only (onboarding flow + `index.css` token + the shared connect-stuck-panel). No flow-logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)