### PR TITLE
fix(skills): align first-tree-cloud skill metadata to renamed slug

### DIFF
--- a/skills/first-tree-cloud/agents/openai.yaml
+++ b/skills/first-tree-cloud/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "First Tree CLI"
-  short_description: "Install, operate, and modify First Tree CLI"
-  default_prompt: "Use $first-tree-cli to install, inspect, configure, onboard, debug, and operate First Tree correctly."
+  display_name: "First Tree Cloud"
+  short_description: "Install, operate, and use First Tree's CLI / cloud layer"
+  default_prompt: "Use $first-tree-cloud to install, inspect, configure, onboard, debug, and operate First Tree correctly."

--- a/skills/first-tree-cloud/evals/evals.json
+++ b/skills/first-tree-cloud/evals/evals.json
@@ -1,5 +1,5 @@
 {
-  "skill_name": "first-tree-cli",
+  "skill_name": "first-tree-cloud",
   "evals": [
     {
       "id": 0,


### PR DESCRIPTION
## Summary

Follow-up to #743. After that PR wired `first-tree-cloud` into `tree skill install/upgrade`, two payload files were still keyed on the old `first-tree-cli` slug:

- `skills/first-tree-cloud/agents/openai.yaml` — `display_name`, `short_description`, and `default_prompt` (`$first-tree-cli`) referenced the old name.
- `skills/first-tree-cloud/evals/evals.json` — `skill_name: "first-tree-cli"`.

Now that the payload installs into target repos, those stale references would surface to end users (the `$first-tree-cli` variable wouldn't resolve, and eval tooling would key off the wrong slug). This PR aligns both to `first-tree-cloud`.

Caught by baixiaohang's codex-assistant review on #743.

## Test plan

- [x] `pnpm validate:skill` passes
- [x] `pnpm check` passes
- [x] Diff is name-only (2 files, 4 line changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)