### PR TITLE
test(e2e): claude-code-tui runtime e2e harness + 8 scenarios

### DIFF
--- a/experiments/tmux-claude-runtime/FINDINGS.md
+++ b/experiments/tmux-claude-runtime/FINDINGS.md
@@ -1,0 +1,168 @@
+# tmux-claude-runtime — design rationale & verification matrix
+
+The `claude-code-tui` handler
+(`packages/client/src/handlers/claude-code-tui/`) drives the **interactive**
+`claude` CLI inside a tmux pane instead of speaking the Agent SDK's
+stream-json protocol. This document is the design rationale its header
+comments cite, plus the contract↔verification matrix the
+`@first-tree/e2e` TUI suite (`packages/e2e/src/tests/tui-*.e2e.test.ts`)
+exercises.
+
+> History: the original proof-of-concept code that produced these findings was
+> a throwaway spike and was not preserved. This document was reconstructed
+> from the merged handler and is kept in sync with it by the e2e suite — every
+> contract below has an executable scenario, so drift surfaces as a red test
+> rather than a stale doc.
+
+---
+
+## Why tmux at all
+
+The SDK path (`claude-code` handler) talks to a headless `claude` over
+stdin/stdout stream-json. The TUI path exists for the post-SDK-sunset world
+where the only supported entry point is the interactive `claude` binary. That
+binary expects a terminal: it paints a live UI, reads keystrokes, and writes
+its authoritative event stream to a per-session transcript file. tmux gives us
+a real PTY we can drive headlessly — inject input via `paste-buffer`, observe
+state via `capture-pane`, and read results from the transcript.
+
+So the handler observes **two surfaces** and the contract between them is the
+thing under test:
+
+1. **Pane text** (`capture-pane -p`) — coarse state: is a turn in flight, is a
+   selection menu open, is the CLI ready. Matched against four magic strings in
+   `tui-markers.ts`.
+2. **Transcript JSONL** (`~/.claude/projects/<encoded-cwd>/<session-id>.jsonl`)
+   — the authoritative event stream: assistant text, tool calls, the cancelled
+   AskUserQuestion. This is what gets forwarded to chat, never the pane scrape.
+
+The fake (`packages/e2e/src/mocks/fake-claude-tui.mjs`) reproduces both
+surfaces so the handler's real logic runs unmodified against it.
+
+---
+
+## Pane markers (the four magic strings)
+
+| Marker | String | Meaning |
+| --- | --- | --- |
+| `READY_MARKER` | `bypass permissions on` | CLI booted; `waitForReady` also needs a `❯` prompt line |
+| `WORKING_MARKER` | `esc to interrupt` | a turn is in flight; its **disappearance** is the turn-end signal |
+| `ASKUSER_MENU_FOOTER` | `Enter to select` | the AskUserQuestion selection menu is open |
+| `USER_RE` | `^❯ ` (NBSP) | prompt line; the trailing glyph is U+00A0, not ASCII space |
+
+Two non-obvious facts the fake must honour (both learned the hard way and now
+pinned by the e2e suite):
+
+- **The working marker is a live status line, not scrollback.** Real `claude`
+  *erases* `esc to interrupt` when the turn completes. A fake that prints it
+  once and leaves it in the pane makes `pane.includes(WORKING_MARKER)` true
+  forever, so the handler waits out the full `TURN_TIMEOUT_MS`. The fake clears
+  the screen (`\x1b[2J\x1b[3J\x1b[H`) on each state transition so the marker
+  actually goes away at idle.
+- **The prompt uses a NBSP.** `capture-pane` trims trailing ASCII spaces, so a
+  `❯ ` painted with a normal space loses the space and `USER_RE` (`^❯[\s ]`)
+  fails to match — `waitForReady` then times out. Paint U+00A0.
+
+---
+
+## Input injection
+
+The runtime injects `[From: <name>]\n<body>`-shaped messages. tmux delivers
+them via `load-buffer` + `paste-buffer -p` (bracketed paste) + a separate
+`send-keys Enter`. Two requirements:
+
+- **Bracketed paste must be enabled** (`\x1b[?2004h`). Without it `paste-buffer
+  -p` ships the bytes verbatim and the newline *inside* the message is mistaken
+  for the terminating Enter — only the first line is read. The fake enables
+  DECSET 2004 at startup and parses a `\x1b[200~ … \x1b[201~` block as a single
+  unit.
+- **Buffer hygiene matters for confidentiality.** The tmux buffer lives on the
+  shared tmux *server*, not in the session, so it survives the session being
+  killed and is readable via `tmux show-buffer` from any other session. The
+  handler deletes it (`paste-buffer -d` + a `delete-buffer` backstop) and
+  removes the temp dir, not just the file.
+
+---
+
+## Session naming (collision-resistant, client-scoped)
+
+`deriveSessionName(clientId, agentId, chatId)` →
+`ftth-<clientTag>-<digest>`:
+
+- `clientTag` = last 8 chars of the sanitized client id. Scopes every session
+  to the owning client process so the orphan sweep and session names never
+  collide with another live client / parallel QA slot on the shared tmux
+  server.
+- `digest` = **`SHA-256(`agentId` + NUL + `chatId`)` sliced to 12 hex**. The
+  separator is a literal `\0`, NOT a space. A 48-bit slice of uniform entropy
+  avoids the uuidv7 prefix-collision that a truncated-id name would suffer (two
+  agents created in the same millisecond share leading chars). Hex-only output
+  is inherently tmux-safe.
+
+> Test mirrors must replicate the NUL separator byte-for-byte
+> (`runtime-tui-fixture.ts:expectedTuiSessionName`). A space silently yields a
+> different digest — `tui-tmux-lifecycle` guards this by asserting the live
+> session name equals the helper's output.
+
+---
+
+## Turn disposition (the reliability core)
+
+`resolveTurnDisposition({ aborted, timedOut, turnFailed, forwardFailed })`
+decides three observable outcomes — `turn_end` status, whether to `ack` the
+inbox entries, and whether to `forward` assistant text to chat. The
+reliability-critical rule (PR #712 review round 3):
+
+- A **timed-out** turn is NOT a success. `claude` was interrupted before
+  reaching idle, so the work is unconfirmed. Acking it would silently consume
+  the user's message with no replay path. So a timeout reports
+  `turn_end: error`, withholds the ack (server redelivers on reconnect/restart
+  for a genuine retry), withholds the forward (a partial drain must NOT
+  double-post once the replay produces the real answer), and settles the
+  runtime into `error`.
+- An **abort** (suspend) likewise withholds ack + forward so the message
+  re-runs on resume, but stays a non-error status (deliberate, not a failure).
+- A clean close acks even on a forward-only failure (mirrors the SDK handler's
+  `ackTurnClose`, avoiding redelivery storms).
+
+---
+
+## AskUserQuestion degradation
+
+The tmux runtime can't navigate `claude`'s selection menu. The handler keeps
+the tool enabled and degrades each invocation to a plain-text round trip:
+detect the `Enter to select` footer → send one `Escape` → `claude` flushes the
+cancelled `tool_use(input)` to the transcript → the handler formats
+`input.questions` as markdown and forwards that. The next user reply is
+injected as a normal turn; `claude` sees its own cancelled tool call and
+continues. The fake keeps the working marker painted alongside the menu (the
+turn is still in flight) so the handler doesn't end the turn before sending
+Escape.
+
+---
+
+## Orphan sweep
+
+On the first handler instantiation per process, sessions left over from a
+prior crashed run of **this client** are killed — scoped by the
+`ftth-<clientTag>-` prefix, never the bare `ftth-`. Multiple client processes
+(prod / staging / dev) and parallel QA slots share one tmux server, so a
+blanket sweep would tear down a live peer's pane.
+
+---
+
+## Verification matrix — contract ↔ scenario
+
+| Contract | e2e scenario |
+| --- | --- |
+| Capability probe reports `claude-code-tui: ok` (claude + tmux + auth) | `tui-capability-probe` |
+| Happy turn: inject → drain transcript → forward → ack | `tui-runtime-basic` |
+| `tool_use`/`tool_result` flow through the shared processor to `session_events` | `tui-runtime-tool-call` |
+| AskUser menu → Escape-cancel → question lands as plain text | `tui-askuser-degrade` |
+| Session name = `deriveSessionName` (NUL digest); paste buffer cleaned up | `tui-tmux-lifecycle` |
+| Orphan sweep kills owned `ftth-<tag>-*`, leaves foreign sessions | `tui-orphan-sweep` |
+| Mid-turn daemon death → un-acked → redelivered + completed on restart | `tui-restart-resume` |
+| Fake crash mid-session surfaces an error (no silent ack) | `tui-crash-recovery` |
+
+Run the whole matrix: `pnpm --filter @first-tree/e2e e2e:tui`.
+Hand-drive a live TUI agent: `pnpm --filter @first-tree/e2e e2e:tui:bootstrap`.

--- a/packages/e2e/README.md
+++ b/packages/e2e/README.md
@@ -20,8 +20,15 @@ the Context Tree.
 | **M1** | doctor + env validation, per-run isolated PG via `docker compose` (tmpfs, random port), spawned `server` + `client --foreground`, smoke against `/healthz` + `/api/v1/health`. | `smoke.e2e.test.ts` |
 | **M2** | `github-mock` (signs + delivers webhooks, stubs outbound `/api/*`), human-agent credentials helper (`framework/credentials.ts`), `ws-listener.ts` for `agent:ws` frames, real `chat-send` over HTTP. | `messaging`, `github-webhook`, `agent-runtime` |
 | **M2.5** | GitHub PR → chat delivery (server self-creates chat + mapping), PG NOTIFY → server WS push → `inbox:deliver` frame on a parallel client. | `github-pr-delivery`, `ws-inbox-push` |
+| **TUI** | `claude-code-tui` runtime coverage: a fake `claude` TUI driven through real tmux (`mocks/fake-claude-tui.mjs`), a tmux-observer driver, a per-agent fixture, and worker-owned worlds for daemon-restart scenarios. Run with `pnpm e2e:tui` (own config, isolated from the SDK suite). One-shot local bring-up: `pnpm e2e:tui:bootstrap`. | `tui-runtime-basic`, `tui-runtime-tool-call`, `tui-askuser-degrade`, `tui-crash-recovery`, `tui-orphan-sweep`, `tui-restart-resume`, `tui-tmux-lifecycle`, `tui-capability-probe` |
 
 Feishu coverage stays in-process per F4 — there is no Feishu e2e mock.
+
+The TUI suite needs a real `tmux` (≥ 3.0) on the runner. The fake binary
+speaks the pane-marker + transcript-JSONL contract the handler observes (not
+the SDK stream-json protocol), so it runs on its own vitest config /
+globalSetup. Design rationale + the scenario↔contract matrix:
+[`experiments/tmux-claude-runtime/FINDINGS.md`](../../experiments/tmux-claude-runtime/FINDINGS.md).
 
 The framework is **deliberately not wired into CI yet** — it needs more
 soak time on real development branches before it can gate PRs. Devs run

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -9,6 +9,8 @@
     "e2e:doctor": "tsx src/scripts/doctor.ts",
     "e2e:smoke": "vitest run --config vitest.config.ts src/tests/smoke.e2e.test.ts",
     "e2e:full": "vitest run --config vitest.config.ts",
+    "e2e:tui": "E2E_TUI=1 E2E_WITH_CLIENT=1 vitest run --config vitest.tui.config.ts",
+    "e2e:tui:bootstrap": "tsx scripts/dev-bootstrap.mjs",
     "e2e:up": "tsx src/scripts/up.ts",
     "e2e:clean": "tsx src/scripts/clean.ts",
     "typecheck": "tsc --noEmit"

--- a/packages/e2e/scripts/dev-bootstrap.mjs
+++ b/packages/e2e/scripts/dev-bootstrap.mjs
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+// One-shot local bring-up for hand-driving the `claude-code-tui` runtime
+// against the e2e world.
+//
+// What it does:
+//   1. Boots pg + server + daemon with the fake-tui binary on
+//      CLAUDE_CODE_EXECUTABLE (same wiring the TUI tests use).
+//   2. Creates one TUI-runtime agent and a chat with it.
+//   3. Prints how to send a user message + where to tail the daemon log +
+//      where the fake-tui side-channel log lives.
+//   4. Keeps the world up until Ctrl-C; teardown runs through the lifecycle
+//      pre-teardown hooks (so pg containers + tmux sessions are cleaned).
+//
+// Usage:
+//   node packages/e2e/scripts/dev-bootstrap.mjs
+//
+// Why a script vs another vitest config: scenarios run + tear down in
+// seconds. This is for when a human wants to poke at a running TUI agent
+// via `tmux attach -t ftth-...`, `tail -f ...`, and `curl POST .../messages`
+// to validate something the auto-tests don't cover.
+//
+// Pure orchestration — re-uses every helper from `src/framework/`. No
+// product-code paths reimplemented here.
+
+import { spawnSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const REPO_ROOT = resolve(import.meta.dirname, "../../..");
+const PACKAGE_E2E_ROOT = resolve(import.meta.dirname, "..");
+const FRAMEWORK_DIST = resolve(PACKAGE_E2E_ROOT, "src/framework");
+
+function log(line) {
+  process.stdout.write(`[dev-bootstrap] ${line}\n`);
+}
+
+function fatal(line) {
+  process.stderr.write(`[dev-bootstrap] FATAL: ${line}\n`);
+  process.exit(1);
+}
+
+async function main() {
+  // Sanity: tmux + node availability. Anything else is the lifecycle's job.
+  const tmuxRes = spawnSync("tmux", ["-V"], { encoding: "utf-8" });
+  if (tmuxRes.status !== 0) fatal("tmux not found — install it (`brew install tmux`) before re-running.");
+
+  log("Building dist CLI (needed to spawn the daemon)…");
+  const buildRes = spawnSync(
+    "pnpm",
+    ["--filter", "first-tree-dev", "--filter", "@first-tree/server", "--filter", "@first-tree/shared", "build"],
+    { cwd: REPO_ROOT, stdio: "inherit" },
+  );
+  if (buildRes.status !== 0) fatal("dist build failed; see output above.");
+
+  // Lazy import so the build above happens first (the framework imports
+  // built packages via workspace links).
+  const lifecycle = await import(`${FRAMEWORK_DIST}/lifecycle.ts`);
+  const fixture = await import(`${FRAMEWORK_DIST}/runtime-tui-fixture.ts`);
+  const currentHandle = await import(`${FRAMEWORK_DIST}/current-handle.ts`);
+
+  log("Starting pg + server + daemon (fake-tui mode)…");
+  const world = await lifecycle.startRunWorld({
+    withClient: true,
+    serverExtraEnv: { FIRST_TREE_DEV_CALLBACK_ENABLED: "1" },
+    clientClaudeCodeExecutable: fixture.FAKE_CLAUDE_TUI_EXECUTABLE,
+    clientExtraEnv: { ANTHROPIC_API_KEY: "fake-tui-e2e-key" },
+  });
+
+  // Mirror what global-setup.ts writes so any auxiliary scripts (e.g. doctor)
+  // can read the run handle without re-deriving anything.
+  mkdirSync(resolve(PACKAGE_E2E_ROOT, ".e2e-runs"), { recursive: true });
+  writeFileSync(
+    currentHandle.HANDLE_PATH,
+    JSON.stringify(
+      {
+        runId: world.identity.runId,
+        serverBaseUrl: world.server.baseUrl,
+        databaseUrl: world.pg.databaseUrl,
+        clientHome: world.identity.home,
+        jwtSecret: world.jwtSecret,
+        githubWebhookSecret: world.githubApp.webhookSecret,
+        credentials: world.credentials,
+      },
+      null,
+      2,
+    ),
+  );
+
+  const handle = currentHandle.readCurrentHandle();
+  log(`World up. runId=${handle.runId}`);
+  log(`server: ${handle.serverBaseUrl}`);
+  log(`pg:     ${handle.databaseUrl}`);
+  log(`home:   ${handle.clientHome}`);
+
+  log("Creating one TUI agent + chat for hand-driving…");
+  const tui = await fixture.createTuiAgent({ handle, displayName: "dev-bootstrap TUI agent" });
+
+  log("");
+  log("=== Ready ===");
+  log(`agent uuid:    ${tui.agentId}`);
+  log(`agent name:    ${tui.agentName}`);
+  log(`chat id:       ${tui.chatId}`);
+  log(`fake-tui log:  ${tui.logPath}`);
+  log(`tmux sessions: tmux ls   (look for ftth-<tag>-… prefix)`);
+  log("");
+  log("Send a user message:");
+  log(
+    `  curl -X POST '${handle.serverBaseUrl}/api/v1/chats/${tui.chatId}/messages' \\\n` +
+      `       -H 'Content-Type: application/json' \\\n` +
+      `       -H 'Authorization: Bearer ${handle.credentials?.accessToken}' \\\n` +
+      `       -d '{"format":"text","content":"ping from dev-bootstrap"}'`,
+  );
+  log("");
+  log("Tail what the fake-tui process saw:");
+  log(`  tail -f ${tui.logPath}`);
+  log("");
+  log("Press Ctrl-C to tear everything down.");
+
+  const onSignal = async (sig) => {
+    log(`Got ${sig}; tearing down.`);
+    await lifecycle.stopRunWorld().catch((err) => process.stderr.write(`teardown error: ${err}\n`));
+    process.exit(0);
+  };
+  process.on("SIGINT", () => void onSignal("SIGINT"));
+  process.on("SIGTERM", () => void onSignal("SIGTERM"));
+
+  // Park the event loop.
+  await new Promise(() => {});
+}
+
+main().catch((err) => fatal(err instanceof Error ? (err.stack ?? err.message) : String(err)));

--- a/packages/e2e/scripts/dev-bootstrap.mjs
+++ b/packages/e2e/scripts/dev-bootstrap.mjs
@@ -103,12 +103,17 @@ async function main() {
   log(`fake-tui log:  ${tui.logPath}`);
   log(`tmux sessions: tmux ls   (look for ftth-<tag>-… prefix)`);
   log("");
-  log("Send a user message:");
+  log("Send a user message (mention the agent so it actually wakes — the");
+  log("group-chat policy rejects a send with no explicit recipient):");
   log(
     `  curl -X POST '${handle.serverBaseUrl}/api/v1/chats/${tui.chatId}/messages' \\\n` +
       `       -H 'Content-Type: application/json' \\\n` +
       `       -H 'Authorization: Bearer ${handle.credentials?.accessToken}' \\\n` +
-      `       -d '{"format":"text","content":"ping from dev-bootstrap"}'`,
+      `       -d '${JSON.stringify({
+        format: "text",
+        content: "ping from dev-bootstrap",
+        metadata: { mentions: [tui.agentId] },
+      })}'`,
   );
   log("");
   log("Tail what the fake-tui process saw:");

--- a/packages/e2e/src/framework/fake-tui-log.ts
+++ b/packages/e2e/src/framework/fake-tui-log.ts
@@ -1,0 +1,99 @@
+import { existsSync, readFileSync } from "node:fs";
+
+/**
+ * Reader for the side-channel log written by `mocks/fake-claude-tui.mjs`.
+ *
+ * The fake binary appends a JSON object per event (start, ready, turn:start,
+ * turn:end, askuser:opened, askuser:cancelled, escape:idle, eof, crash,
+ * fatal). Tests assert on the timeline (e.g. "the AskUser menu was opened
+ * and immediately cancelled", "two turns ran in this session") without
+ * having to parse the transcript file format the handler also consumes.
+ *
+ * Path is chosen by the test fixture and exported into the daemon via
+ * `FAKE_TUI_LOG_PATH`; one path per fixture instance keeps logs from
+ * different agents disjoint.
+ */
+export type FakeTuiEvent = {
+  kind:
+    | "start"
+    | "ready"
+    | "turn:start"
+    | "turn:end"
+    | "turn:hang"
+    | "askuser:opened"
+    | "askuser:cancelled"
+    | "escape:idle"
+    | "eof"
+    | "crash"
+    | "fatal";
+  sessionId: string;
+  resumeId: string | null;
+  ts: string;
+  pid: number;
+} & Record<string, unknown>;
+
+export class FakeTuiLogReader {
+  constructor(public readonly path: string) {}
+
+  /** Returns every event currently on disk; tolerates a missing file. */
+  readAll(): FakeTuiEvent[] {
+    if (!existsSync(this.path)) return [];
+    const text = readFileSync(this.path, "utf-8");
+    const out: FakeTuiEvent[] = [];
+    for (const raw of text.split("\n")) {
+      if (!raw.trim()) continue;
+      try {
+        out.push(JSON.parse(raw) as FakeTuiEvent);
+      } catch {
+        // skip malformed (fake should not write malformed; tolerate during
+        // partial-line races with the running fake)
+      }
+    }
+    return out;
+  }
+
+  /** Convenience: events whose `kind` matches. */
+  byKind(kind: FakeTuiEvent["kind"]): FakeTuiEvent[] {
+    return this.readAll().filter((e) => e.kind === kind);
+  }
+
+  /** First event of the given kind, or null. */
+  first(kind: FakeTuiEvent["kind"]): FakeTuiEvent | null {
+    return this.byKind(kind)[0] ?? null;
+  }
+
+  /** Last event of the given kind, or null. */
+  last(kind: FakeTuiEvent["kind"]): FakeTuiEvent | null {
+    const events = this.byKind(kind);
+    return events[events.length - 1] ?? null;
+  }
+
+  /** True iff at least one matching event has been written. */
+  has(kind: FakeTuiEvent["kind"]): boolean {
+    return this.byKind(kind).length > 0;
+  }
+
+  /**
+   * Poll until `predicate(events)` is true or the timeout expires. Returns
+   * the matching event list. Throws on timeout with the last-seen list
+   * stringified for diagnostics.
+   */
+  async waitUntil(
+    predicate: (events: FakeTuiEvent[]) => boolean,
+    opts: { timeoutMs?: number; intervalMs?: number; label?: string } = {},
+  ): Promise<FakeTuiEvent[]> {
+    const timeout = opts.timeoutMs ?? 15_000;
+    const interval = opts.intervalMs ?? 100;
+    const started = Date.now();
+    let last: FakeTuiEvent[] = [];
+    while (Date.now() - started < timeout) {
+      last = this.readAll();
+      if (predicate(last)) return last;
+      await new Promise((r) => setTimeout(r, interval));
+    }
+    throw new Error(
+      `fake-tui log wait timed out after ${timeout}ms${opts.label ? ` (${opts.label})` : ""}. ` +
+        `Last events: ${JSON.stringify(last.map((e) => e.kind))}`,
+    );
+  }
+}

--- a/packages/e2e/src/framework/global-setup.ts
+++ b/packages/e2e/src/framework/global-setup.ts
@@ -1,6 +1,14 @@
 import { writeFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { HANDLE_PATH } from "./current-handle.js";
+import { PACKAGE_E2E_ROOT } from "./env.js";
 import { startRunWorld, stopRunWorld } from "./lifecycle.js";
+
+/**
+ * Path of the fake `claude` TUI binary (mirrors runtime-tui-fixture.ts —
+ * imported here to avoid a circular dep through the fixture module).
+ */
+const FAKE_TUI_BIN = resolve(PACKAGE_E2E_ROOT, "src/mocks/fake-claude-tui.mjs");
 
 /**
  * Vitest globalSetup hook. Boots one shared `pg + server [+ client]` per
@@ -14,12 +22,30 @@ import { startRunWorld, stopRunWorld } from "./lifecycle.js";
  */
 export default async function setup(): Promise<() => Promise<void>> {
   const withClient = process.env.E2E_WITH_CLIENT === "1";
+  // E2E_TUI=1 swaps the daemon's `claude` to the fake-tui binary AND injects
+  // a fake `ANTHROPIC_API_KEY` so the shared Claude auth probe reports
+  // authenticated. The TUI scenarios live behind this knob so the existing
+  // SDK-based suites keep their lean spawn.
+  const tuiMode = process.env.E2E_TUI === "1";
   const world = await startRunWorld({
     withClient,
     // Tests that need a second-or-third user (client-claim, multi-org)
     // mint via dev-callback. Always on for the e2e run — the route 404s
     // unless this env is explicitly set, so it's still off in prod.
-    serverExtraEnv: { FIRST_TREE_DEV_CALLBACK_ENABLED: "1" },
+    //
+    // TUI mode also raises the global request rate limit: eight TUI scenarios
+    // each create an agent + drive several polled message/list round-trips,
+    // and the daemon's own session bootstrap (fetchChatContext, capability
+    // re-report) adds traffic — the default 100/min trips mid-suite and the
+    // 429s cascade into session-start retry backoff. A high ceiling keeps the
+    // limiter installed (so its wiring is still exercised) without throttling
+    // the test driver.
+    serverExtraEnv: {
+      FIRST_TREE_DEV_CALLBACK_ENABLED: "1",
+      ...(tuiMode ? { FIRST_TREE_RATE_LIMIT_MAX: "100000", FIRST_TREE_RATE_LIMIT_AGENT_MESSAGE_MAX: "100000" } : {}),
+    },
+    clientClaudeCodeExecutable: tuiMode ? FAKE_TUI_BIN : undefined,
+    clientExtraEnv: tuiMode ? { ANTHROPIC_API_KEY: "fake-tui-e2e-key" } : undefined,
   });
   writeFileSync(
     HANDLE_PATH,

--- a/packages/e2e/src/framework/lifecycle.ts
+++ b/packages/e2e/src/framework/lifecycle.ts
@@ -31,6 +31,31 @@ export type StartRunOptions = {
    * the mock instead of api.github.com.
    */
   serverExtraEnv?: ServerSpawnOptions["extraEnv"];
+  /**
+   * Absolute path of a fake/stub `claude` binary the daemon should use
+   * instead of the real one. Exported into the client process as
+   * `CLAUDE_CODE_EXECUTABLE`; both the `claude-code` (SDK) and
+   * `claude-code-tui` (tmux) handlers honor it. Required for the TUI e2e
+   * suite — the real `claude` would try to dial Anthropic mid-test.
+   */
+  clientClaudeCodeExecutable?: string;
+  /**
+   * Extra env injected into the spawned client (daemon) process. Used by
+   * the TUI fixture to set `ANTHROPIC_API_KEY=fake-tui-e2e` so the shared
+   * Claude auth probe (`detectClaudeAuth`) reports authenticated against
+   * the fake binary instead of looking at `~/.claude.json`.
+   */
+  clientExtraEnv?: NodeJS.ProcessEnv;
+  /**
+   * Skip the start-of-boot `bestEffortCleanupStaleContainers` sweep, which
+   * `docker rm -f`s EVERY `*_pg` container matching the e2e naming pattern.
+   * The sweep is correct at the start of a run (reclaim leftovers from a
+   * crashed prior run) but catastrophic for a SECOND world booted while a
+   * first is still live — it would reap the running world's pg. The TUI
+   * restart scenarios boot their own world alongside the shared globalSetup
+   * world and set this to keep the shared pg alive.
+   */
+  skipStaleContainerCleanup?: boolean;
 };
 
 export type RunWorld = {
@@ -51,6 +76,16 @@ export type RunWorld = {
 
 let activeWorld: RunWorld | null = null;
 let teardownHooksRegistered = false;
+// Snapshot of the options used to spawn the active client. Required so
+// `respawnActiveClient()` can produce a fresh daemon with the same identity,
+// fake binary, and env without callers having to remember them.
+let activeClientSpawnOpts: {
+  identity: RunIdentity;
+  serverBaseUrl: string;
+  logger: ComponentLogger;
+  claudeCodeExecutable?: string;
+  extraEnv?: NodeJS.ProcessEnv;
+} | null = null;
 
 /**
  * Extra teardown hooks invoked **before** `stopRunWorld()` when the process
@@ -84,7 +119,9 @@ export async function startRunWorld(opts: StartRunOptions = {}): Promise<RunWorl
   const composeBin = env.E2E_DOCKER_COMPOSE_BIN ?? doctor.dockerComposeBin;
   if (!composeBin) throw new Error("E2E doctor passed but no docker compose binary resolved — internal bug");
 
-  bestEffortCleanupStaleContainers(composeBin);
+  if (!opts.skipStaleContainerCleanup) {
+    bestEffortCleanupStaleContainers(composeBin);
+  }
 
   const identity = makeRunIdentity(PACKAGE_E2E_ROOT, env.E2E_RUN_ID);
   const loggers: ComponentLogger[] = [];
@@ -137,11 +174,15 @@ export async function startRunWorld(opts: StartRunOptions = {}): Promise<RunWorl
 
       const clientLogger = createComponentLogger(identity.runDir, "client");
       loggers.push(clientLogger);
-      client = await spawnClient({
+      const clientSpawnOpts = {
         identity,
         serverBaseUrl: server.baseUrl,
         logger: clientLogger,
-      });
+        claudeCodeExecutable: opts.clientClaudeCodeExecutable,
+        extraEnv: opts.clientExtraEnv,
+      };
+      client = await spawnClient(clientSpawnOpts);
+      activeClientSpawnOpts = clientSpawnOpts;
     }
 
     activeWorld = {
@@ -170,6 +211,7 @@ export async function stopRunWorld(): Promise<void> {
   if (!activeWorld) return;
   const { pg, server, client, loggers, identity } = activeWorld;
   activeWorld = null;
+  activeClientSpawnOpts = null;
   const errors: unknown[] = [];
   const stoppers: Array<readonly [string, { stop: () => Promise<void> } | null]> = [
     ["client", client],
@@ -197,6 +239,38 @@ export async function stopRunWorld(): Promise<void> {
 export function getActiveWorld(): RunWorld {
   if (!activeWorld) throw new Error("E2E world is not active — was globalSetup wired up?");
   return activeWorld;
+}
+
+/**
+ * Stop just the daemon process; leaves pg + server up. Used by TUI scenarios
+ * that need to simulate a daemon crash / restart against the same home
+ * directory (e.g. orphan sweep on respawn, in-flight turn resumes).
+ *
+ * No-op when the world has no client. After this call `respawnActiveClient()`
+ * can bring a fresh daemon up with the same identity + env.
+ */
+export async function stopActiveClient(signal: NodeJS.Signals = "SIGTERM"): Promise<void> {
+  if (!activeWorld || !activeWorld.client) return;
+  await activeWorld.client.stop(signal);
+  activeWorld.client = null;
+}
+
+/**
+ * Spawn a fresh daemon process using the same identity + env as the original.
+ * The world must have been started with `withClient: true` (so the spawn opts
+ * were captured); calling on a server-only world throws.
+ */
+export async function respawnActiveClient(): Promise<ClientProcess> {
+  if (!activeWorld) throw new Error("respawnActiveClient: no active world");
+  if (!activeClientSpawnOpts) {
+    throw new Error("respawnActiveClient: original world was not started with withClient: true");
+  }
+  if (activeWorld.client) {
+    throw new Error("respawnActiveClient: active client still running — call stopActiveClient first");
+  }
+  const fresh = await spawnClient(activeClientSpawnOpts);
+  activeWorld.client = fresh;
+  return fresh;
 }
 
 async function safeStop(component: { stop: () => Promise<void> } | undefined, name: string): Promise<void> {

--- a/packages/e2e/src/framework/runtime-tui-fixture.ts
+++ b/packages/e2e/src/framework/runtime-tui-fixture.ts
@@ -1,0 +1,328 @@
+import { createHash, randomBytes } from "node:crypto";
+import { mkdirSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { type CurrentRunHandle, readCredentialsOrThrow } from "./current-handle.js";
+import { PACKAGE_E2E_ROOT } from "./env.js";
+import { FakeTuiLogReader } from "./fake-tui-log.js";
+
+/**
+ * Fixture for tests that need a real `claude-code-tui` agent running against
+ * the e2e world's daemon. The fixture creates the agent + chat via the public
+ * API (matching how a user would set this up through the web UI), wires the
+ * per-agent fake-tui log path via the runtime payload's env, and exposes
+ * helpers for sending messages, reading replies from PG, and asserting on
+ * the fake's recorded timeline.
+ *
+ * The daemon process itself must already be running with the fake binary on
+ * `CLAUDE_CODE_EXECUTABLE` — `startTuiRunWorld()` handles that bootstrap.
+ *
+ * Why per-agent FAKE_TUI_LOG_PATH (instead of one process-wide log) — every
+ * TUI handler instance reads the same env at spawn time and writes events
+ * tagged with its session id. With one shared log path, two parallel agents
+ * would interleave events in a single file and tests would have to filter by
+ * session id. Per-agent paths keep assertions trivial: `reader.byKind(...)`
+ * returns only this agent's events.
+ */
+
+export const FAKE_CLAUDE_TUI_EXECUTABLE = resolve(PACKAGE_E2E_ROOT, "src/mocks/fake-claude-tui.mjs");
+
+export type FakeTuiAgentKnobs = {
+  /** Canned reply override (FAKE_TUI_REPLY). */
+  reply?: string;
+  /** Pre-emit delay (FAKE_TUI_DELAY_MS). */
+  delayMs?: number;
+  /** Never paint the ready marker (FAKE_TUI_FAIL_READY=1). */
+  failReady?: boolean;
+  /** Receive input then never finish (FAKE_TUI_HANG=1). Probes turn timeout. */
+  hang?: boolean;
+  /** Exit non-zero after N completed turns (FAKE_TUI_CRASH_AFTER_TURNS). */
+  crashAfterTurns?: number;
+  /** First turn emits AskUserQuestion + paints the menu (FAKE_TUI_EMIT_ASKUSER=1). */
+  emitAskUser?: boolean;
+  /** First turn emits a Bash tool_use (FAKE_TUI_TOOL_CALL=1). */
+  emitToolCall?: boolean;
+};
+
+export type CreateTuiAgentInput = {
+  /** The current e2e run handle (from `readCurrentHandle()`). */
+  handle: CurrentRunHandle;
+  /** Display label for the agent (optional; auto-generated when omitted). */
+  displayName?: string;
+  /** Behaviour knobs forwarded to the fake-tui binary via per-agent env. */
+  knobs?: FakeTuiAgentKnobs;
+  /** Optional override of where the fake-tui side-channel log lands. */
+  logPath?: string;
+};
+
+export type TuiAgentFixture = {
+  /** Server-side agent uuid. */
+  agentId: string;
+  /** Server-side agent name (lowercase). */
+  agentName: string;
+  /** Server-side chat the human user shares with this agent. */
+  chatId: string;
+  /** Reader for the side-channel log the fake-tui binary writes. */
+  fakeLog: FakeTuiLogReader;
+  /** Per-agent env knobs that were applied (echoed for diagnostics). */
+  knobs: FakeTuiAgentKnobs;
+  /** Absolute path of the log file the fake writes. */
+  logPath: string;
+};
+
+const E2E_RUNS_DIR = resolve(PACKAGE_E2E_ROOT, ".e2e-runs");
+
+/**
+ * Helper: deterministic per-agent FAKE_TUI_LOG_PATH under `.e2e-runs/`.
+ * Tests don't usually pass `logPath`; the default keeps every fixture's log
+ * isolated under the current run id.
+ */
+function defaultLogPath(handle: CurrentRunHandle, agentName: string): string {
+  return join(E2E_RUNS_DIR, "fake-tui-logs", handle.runId, `${agentName}.jsonl`);
+}
+
+/**
+ * Translate the knobs into the env block the runtime payload carries. The
+ * handler's `buildEnv()` copies these into the spawned tmux command so the
+ * fake binary sees them at startup.
+ */
+function knobsToEnvEntries(knobs: FakeTuiAgentKnobs, logPath: string): Array<{ key: string; value: string }> {
+  const env: Array<{ key: string; value: string }> = [];
+  env.push({ key: "FAKE_TUI_LOG_PATH", value: logPath });
+  if (knobs.reply !== undefined) env.push({ key: "FAKE_TUI_REPLY", value: knobs.reply });
+  if (knobs.delayMs !== undefined) env.push({ key: "FAKE_TUI_DELAY_MS", value: String(knobs.delayMs) });
+  if (knobs.failReady) env.push({ key: "FAKE_TUI_FAIL_READY", value: "1" });
+  if (knobs.hang) env.push({ key: "FAKE_TUI_HANG", value: "1" });
+  if (knobs.crashAfterTurns !== undefined && knobs.crashAfterTurns > 0) {
+    env.push({ key: "FAKE_TUI_CRASH_AFTER_TURNS", value: String(knobs.crashAfterTurns) });
+  }
+  if (knobs.emitAskUser) env.push({ key: "FAKE_TUI_EMIT_ASKUSER", value: "1" });
+  if (knobs.emitToolCall) env.push({ key: "FAKE_TUI_TOOL_CALL", value: "1" });
+  return env;
+}
+
+/**
+ * Create a `claude-code-tui` agent + bound chat in the active e2e world.
+ * Assumes the daemon was spawned with `CLAUDE_CODE_EXECUTABLE` pointing at
+ * the fake binary (see `startTuiRunWorld` in `lifecycle.ts`).
+ */
+export async function createTuiAgent(input: CreateTuiAgentInput): Promise<TuiAgentFixture> {
+  const creds = readCredentialsOrThrow(input.handle);
+  const knobs = input.knobs ?? {};
+  const agentName = `tui-${randomBytes(3).toString("hex")}`;
+  const logPath = input.logPath ?? defaultLogPath(input.handle, agentName);
+  mkdirSync(dirname(logPath), { recursive: true });
+
+  // The server's agent-create endpoint enforces a per-user rate limit; eight
+  // TUI scenarios' beforeAll fires within seconds and the bucket trips. Honor
+  // the `Retry-After`-style hint embedded in the 429 body and retry up to a
+  // minute. Other 4xx are surfaced immediately.
+  const createBody = JSON.stringify({
+    name: agentName,
+    type: "agent",
+    displayName: input.displayName ?? `TUI fixture ${agentName}`,
+    clientId: creds.clientId,
+    runtimeProvider: "claude-code-tui",
+  });
+  let created: { uuid: string } | null = null;
+  const deadline = Date.now() + 90_000;
+  while (Date.now() < deadline) {
+    const createRes = await fetch(`${input.handle.serverBaseUrl}/api/v1/orgs/${creds.organizationId}/agents`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${creds.accessToken}` },
+      body: createBody,
+    });
+    if (createRes.status === 201) {
+      created = (await createRes.json()) as { uuid: string };
+      break;
+    }
+    if (createRes.status === 429) {
+      const text = await createRes.text();
+      const retrySeconds = Number(text.match(/retry in (\d+) seconds/)?.[1] ?? "5");
+      // Cap the wait so a stuck bucket can't hang the run; the outer deadline
+      // is the real ceiling.
+      await new Promise((r) => setTimeout(r, Math.min(retrySeconds * 1000 + 250, 15_000)));
+      continue;
+    }
+    throw new Error(`create tui agent ${agentName} failed: ${createRes.status} ${await createRes.text()}`);
+  }
+  if (!created) {
+    throw new Error(`create tui agent ${agentName} kept hitting 429 for 90s — server rate limit didn't recover`);
+  }
+
+  // Push per-agent env onto the agent's runtime config payload via PATCH.
+  // The daemon refreshes the agent config cache on the next session start,
+  // and the handler's buildEnv() merges payload.env into the spawn env.
+  await patchAgentRuntimeEnv({
+    handle: input.handle,
+    accessToken: creds.accessToken,
+    agentId: created.uuid,
+    envEntries: knobsToEnvEntries(knobs, logPath),
+  });
+
+  const chatRes = await fetch(`${input.handle.serverBaseUrl}/api/v1/orgs/${creds.organizationId}/chats`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${creds.accessToken}` },
+    body: JSON.stringify({ participantIds: [created.uuid] }),
+  });
+  if (chatRes.status !== 201) {
+    throw new Error(`create chat for ${agentName} failed: ${chatRes.status} ${await chatRes.text()}`);
+  }
+  const chatBody = (await chatRes.json()) as { chatId: string };
+
+  return {
+    agentId: created.uuid,
+    agentName,
+    chatId: chatBody.chatId,
+    fakeLog: new FakeTuiLogReader(logPath),
+    knobs,
+    logPath,
+  };
+}
+
+/**
+ * Send a user message to the TUI agent's chat (caller speaks as the fixture
+ * human agent, resolved server-side from the user JWT).
+ */
+export async function sendUserMessageToTuiAgent(input: {
+  handle: CurrentRunHandle;
+  chatId: string;
+  text: string;
+  /** Agent uuid to @mention so the message actually wakes the runtime. */
+  mentionAgentId: string;
+}): Promise<{ id: string }> {
+  const creds = readCredentialsOrThrow(input.handle);
+  // Group-chat policy (see project memory `first-tree group chat mention
+  // rule`): a send requires an explicit recipient — `metadata.mentions:
+  // [agentId]` is the canonical way to address one specific agent. Without
+  // it the server rejects with 400.
+  const res = await fetch(`${input.handle.serverBaseUrl}/api/v1/chats/${input.chatId}/messages`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${creds.accessToken}` },
+    body: JSON.stringify({
+      format: "text",
+      content: input.text,
+      metadata: { mentions: [input.mentionAgentId] },
+    }),
+  });
+  if (res.status !== 201) {
+    throw new Error(`send user message failed: ${res.status} ${await res.text()}`);
+  }
+  return (await res.json()) as { id: string };
+}
+
+/**
+ * Poll the chat's message list until at least one message satisfies the
+ * predicate (default: any message from the agent that isn't the user's own).
+ * Returns the matching messages so callers can assert on content.
+ */
+export async function waitForAgentReply(input: {
+  handle: CurrentRunHandle;
+  chatId: string;
+  /** Message id of the user's send — we filter the agent's reply that came after. */
+  afterMessageId?: string;
+  /** Match predicate; default: any message whose senderId !== the human agent. */
+  predicate?: (m: ChatMessage) => boolean;
+  timeoutMs?: number;
+  intervalMs?: number;
+}): Promise<ChatMessage[]> {
+  const creds = readCredentialsOrThrow(input.handle);
+  const timeout = input.timeoutMs ?? 30_000;
+  const interval = input.intervalMs ?? 200;
+  const predicate = input.predicate ?? ((m) => m.senderId !== creds.humanAgentId);
+  const started = Date.now();
+  let lastBody: ChatMessage[] = [];
+  while (Date.now() - started < timeout) {
+    const res = await fetch(`${input.handle.serverBaseUrl}/api/v1/chats/${input.chatId}/messages`, {
+      headers: { Authorization: `Bearer ${creds.accessToken}` },
+    });
+    if (res.status === 200) {
+      const body = (await res.json()) as { items: ChatMessage[] };
+      lastBody = body.items;
+      const candidates = body.items
+        .filter((m) => (input.afterMessageId ? m.id !== input.afterMessageId : true))
+        .filter(predicate);
+      if (candidates.length > 0) return candidates;
+    }
+    await new Promise((r) => setTimeout(r, interval));
+  }
+  throw new Error(
+    `waitForAgentReply timed out after ${timeout}ms (chatId=${input.chatId}). Last items: ` +
+      JSON.stringify(lastBody.map((m) => ({ id: m.id, senderId: m.senderId, format: m.format }))),
+  );
+}
+
+export type ChatMessage = {
+  id: string;
+  chatId: string;
+  senderId: string;
+  format: string;
+  content: string;
+  inReplyTo: string | null;
+};
+
+async function patchAgentRuntimeEnv(input: {
+  handle: CurrentRunHandle;
+  accessToken: string;
+  agentId: string;
+  envEntries: Array<{ key: string; value: string }>;
+}): Promise<void> {
+  // GET the current config, mutate the env block, PATCH with the expected
+  // version. Two-step instead of one because the schema requires
+  // `expectedVersion` for optimistic locking.
+  const getRes = await fetch(`${input.handle.serverBaseUrl}/api/v1/agents/${input.agentId}/config`, {
+    headers: { Authorization: `Bearer ${input.accessToken}` },
+  });
+  if (getRes.status !== 200) {
+    throw new Error(`fetch runtime config failed: ${getRes.status} ${await getRes.text()}`);
+  }
+  const cfg = (await getRes.json()) as {
+    version: number;
+    payload: { env: Array<{ key: string; value: string }> } & Record<string, unknown>;
+  };
+
+  // Replace any existing entries with the same key, then append the rest.
+  const desiredKeys = new Set(input.envEntries.map((e) => e.key));
+  const next = cfg.payload.env.filter((e) => !desiredKeys.has(e.key)).concat(input.envEntries);
+
+  const patchRes = await fetch(`${input.handle.serverBaseUrl}/api/v1/agents/${input.agentId}/config`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${input.accessToken}` },
+    body: JSON.stringify({
+      expectedVersion: cfg.version,
+      payload: { env: next },
+    }),
+  });
+  if (patchRes.status !== 200) {
+    throw new Error(`patch runtime env failed: ${patchRes.status} ${await patchRes.text()}`);
+  }
+}
+
+/**
+ * Helper: derive the per-(agent, chat) tmux session name the handler will
+ * pick. Mirrors `tmux-session.ts:deriveSessionName` exactly so tests can
+ * assert on a session name without poking the handler internals.
+ *
+ * The digest separator is a literal NUL (`\0`), NOT a space — matching the
+ * handler's `createHash("sha256").update(\`${agentId}\0${chatId}\`)`. Using a
+ * space here silently produces a different digest (every derived name would
+ * mismatch the real session); keep these byte-for-byte identical.
+ */
+export function expectedTuiSessionName(input: { clientTagSource: string; agentId: string; chatId: string }): string {
+  const tag = clientTagFromId(input.clientTagSource);
+  const digest = sha256Slice(`${input.agentId}\0${input.chatId}`, 12);
+  return `ftth-${tag}-${digest}`;
+}
+
+/** Mirrors tmux-session.ts:ownedSessionPrefix. */
+export function expectedTuiSessionPrefix(clientTagSource: string): string {
+  return `ftth-${clientTagFromId(clientTagSource)}-`;
+}
+
+function clientTagFromId(clientId: string): string {
+  const s = clientId.replace(/[^A-Za-z0-9_-]/g, "").toLowerCase();
+  return s.length >= 4 ? s.slice(-8) : "nocid";
+}
+
+function sha256Slice(input: string, hexChars: number): string {
+  return createHash("sha256").update(input).digest("hex").slice(0, hexChars);
+}

--- a/packages/e2e/src/framework/tmux-driver.ts
+++ b/packages/e2e/src/framework/tmux-driver.ts
@@ -1,0 +1,178 @@
+import { spawn, spawnSync } from "node:child_process";
+
+/**
+ * Test-side helpers for inspecting and seeding tmux state during TUI e2e.
+ *
+ * The handler under test (packages/client/src/handlers/claude-code-tui/) owns
+ * its own tmux helpers (`tmux-session.ts`); this module is the QA side of the
+ * fence — it observes what the handler created, plants pre-existing sessions
+ * for orphan-sweep tests, kills sessions the handler leaked, and waits for
+ * state transitions in the running fake.
+ *
+ * Why a parallel surface rather than importing the handler's helpers: tests
+ * must remain trustworthy regardless of handler bugs. If a handler refactor
+ * accidentally renames `listOwnedSessions`, the tests should still be able
+ * to drive tmux directly to assert the buggy behaviour.
+ */
+
+export type TmuxRunResult = {
+  ok: boolean;
+  stdout: string;
+  stderr: string;
+  code: number | null;
+};
+
+const DEFAULT_TIMEOUT_MS = 5000;
+
+function runTmuxSync(args: string[], timeoutMs = DEFAULT_TIMEOUT_MS): TmuxRunResult {
+  const res = spawnSync("tmux", args, { encoding: "utf-8", timeout: timeoutMs });
+  return {
+    ok: res.status === 0,
+    stdout: res.stdout ?? "",
+    stderr: res.stderr ?? (res.error ? res.error.message : ""),
+    code: res.status,
+  };
+}
+
+function runTmux(args: string[], timeoutMs = DEFAULT_TIMEOUT_MS): Promise<TmuxRunResult> {
+  return new Promise((resolveResult) => {
+    let stdout = "";
+    let stderr = "";
+    const child = spawn("tmux", args, { stdio: ["ignore", "pipe", "pipe"] });
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      resolveResult({ ok: false, stdout, stderr: `${stderr}\n[timeout]`, code: null });
+    }, timeoutMs);
+    child.stdout.on("data", (b: Buffer) => {
+      stdout += b.toString("utf-8");
+    });
+    child.stderr.on("data", (b: Buffer) => {
+      stderr += b.toString("utf-8");
+    });
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      resolveResult({ ok: false, stdout, stderr: stderr + err.message, code: null });
+    });
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      resolveResult({ ok: code === 0, stdout, stderr, code });
+    });
+  });
+}
+
+/** True iff `tmux -V` succeeds, indicating the binary is usable. */
+export function tmuxAvailable(): boolean {
+  return runTmuxSync(["-V"]).ok;
+}
+
+/** List every tmux session name on the local server. `[]` if no server. */
+export async function listAllSessions(): Promise<string[]> {
+  const res = await runTmux(["list-sessions", "-F", "#{session_name}"]);
+  if (!res.ok) return [];
+  return res.stdout
+    .split("\n")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+/** Sessions whose names start with `prefix`. */
+export async function listSessionsByPrefix(prefix: string): Promise<string[]> {
+  const all = await listAllSessions();
+  return all.filter((name) => name.startsWith(prefix));
+}
+
+/** True iff a session with the exact name exists. */
+export async function hasSession(name: string): Promise<boolean> {
+  const res = await runTmux(["has-session", "-t", name]);
+  return res.ok;
+}
+
+/** Best-effort kill (no throw if absent). */
+export async function killSession(name: string): Promise<void> {
+  await runTmux(["kill-session", "-t", name]);
+}
+
+/** Best-effort kill every session whose name starts with `prefix`. */
+export async function killSessionsByPrefix(prefix: string): Promise<number> {
+  const sessions = await listSessionsByPrefix(prefix);
+  for (const s of sessions) {
+    await killSession(s);
+  }
+  return sessions.length;
+}
+
+export type PlantSessionInput = {
+  name: string;
+  cwd: string;
+  /** Command to run inside the planted session; defaults to a sleep so it stays alive. */
+  command?: string;
+};
+
+/**
+ * Plant a tmux session under a known name (used by orphan-sweep tests to
+ * pre-seed sessions the handler should kill on startup). The default command
+ * is a long sleep so the session survives until killed.
+ */
+export async function plantSession(input: PlantSessionInput): Promise<void> {
+  const cmd = input.command ?? "sleep 3600";
+  const args = ["new-session", "-d", "-s", input.name, "-c", input.cwd, cmd];
+  const res = await runTmux(args);
+  if (!res.ok) {
+    throw new Error(`tmux new-session ${input.name} failed (code=${res.code ?? "n/a"}): ${res.stderr.trim()}`);
+  }
+}
+
+/** Capture the visible pane content of a session, or "" if it doesn't exist. */
+export async function capturePane(name: string): Promise<string> {
+  const res = await runTmux(["capture-pane", "-t", name, "-p"]);
+  return res.ok ? res.stdout : "";
+}
+
+export type WaitForSessionInput = {
+  name: string;
+  timeoutMs?: number;
+  intervalMs?: number;
+};
+
+/** Poll until a session with the exact name appears (e.g. handler created it). */
+export async function waitForSession(input: WaitForSessionInput): Promise<void> {
+  const timeout = input.timeoutMs ?? 15_000;
+  const interval = input.intervalMs ?? 100;
+  const started = Date.now();
+  while (Date.now() - started < timeout) {
+    if (await hasSession(input.name)) return;
+    await new Promise((r) => setTimeout(r, interval));
+  }
+  // Dump what this process CAN see so a name/prefix mismatch is diagnosable
+  // instead of a bare timeout (the handler may have created the session under
+  // a different tag, or this process may be on a different tmux server).
+  const visible = await listAllSessions();
+  throw new Error(
+    `tmux session ${input.name} never appeared within ${timeout}ms. ` +
+      `Sessions visible to this process: ${visible.length ? visible.join(", ") : "(none)"}`,
+  );
+}
+
+export type WaitForSessionGoneInput = WaitForSessionInput;
+
+/** Poll until the session no longer exists (e.g. handler tore it down). */
+export async function waitForSessionGone(input: WaitForSessionGoneInput): Promise<void> {
+  const timeout = input.timeoutMs ?? 15_000;
+  const interval = input.intervalMs ?? 100;
+  const started = Date.now();
+  while (Date.now() - started < timeout) {
+    if (!(await hasSession(input.name))) return;
+    await new Promise((r) => setTimeout(r, interval));
+  }
+  throw new Error(`tmux session ${input.name} did not disappear within ${timeout}ms`);
+}
+
+/** List tmux buffer names on the local server, or `[]` if none / no server. */
+export async function listBuffers(): Promise<string[]> {
+  const res = await runTmux(["list-buffers", "-F", "#{buffer_name}"]);
+  if (!res.ok) return [];
+  return res.stdout
+    .split("\n")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}

--- a/packages/e2e/src/framework/tui-world.ts
+++ b/packages/e2e/src/framework/tui-world.ts
@@ -1,0 +1,56 @@
+import type { CurrentRunHandle } from "./current-handle.js";
+import { startRunWorld, stopRunWorld } from "./lifecycle.js";
+import { FAKE_CLAUDE_TUI_EXECUTABLE } from "./runtime-tui-fixture.js";
+
+/**
+ * Boot a dedicated TUI world *inside the calling worker process*.
+ *
+ * Why this exists: vitest runs `globalSetup` in the main process but each
+ * test file in a forked worker. The daemon-restart helpers
+ * (`stopActiveClient` / `respawnActiveClient` in lifecycle.ts) operate on the
+ * module-level `activeWorld`, which only exists in whichever process called
+ * `startRunWorld`. A test that needs to stop + respawn the daemon mid-run
+ * (orphan-sweep, restart-resume) therefore CANNOT drive the globalSetup
+ * world — that world lives in the main process, unreachable from the worker.
+ *
+ * The fix is for those tests to own their world: call `setupOwnTuiWorld()` in
+ * `beforeAll` so `activeWorld` is set in the worker, then the restart helpers
+ * work in-process. Steady-state tests keep using the cheaper shared
+ * globalSetup world via `readCurrentHandle()`.
+ *
+ * The spawned world uses the same fake-tui binary + raised rate limit as the
+ * globalSetup TUI world (see global-setup.ts), so behaviour is identical.
+ */
+export async function setupOwnTuiWorld(): Promise<CurrentRunHandle> {
+  const world = await startRunWorld({
+    withClient: true,
+    serverExtraEnv: {
+      FIRST_TREE_DEV_CALLBACK_ENABLED: "1",
+      FIRST_TREE_RATE_LIMIT_MAX: "100000",
+      FIRST_TREE_RATE_LIMIT_AGENT_MESSAGE_MAX: "100000",
+    },
+    clientClaudeCodeExecutable: FAKE_CLAUDE_TUI_EXECUTABLE,
+    clientExtraEnv: { ANTHROPIC_API_KEY: "fake-tui-e2e-key" },
+    // Critical: this world boots ALONGSIDE the shared globalSetup world. The
+    // default stale-container sweep would `docker rm -f` the shared world's
+    // running pg (same naming pattern), 500-ing every steady-state scenario.
+    skipStaleContainerCleanup: true,
+  });
+  if (!world.credentials) {
+    throw new Error("setupOwnTuiWorld: world started without credentials — withClient was not honoured");
+  }
+  return {
+    runId: world.identity.runId,
+    serverBaseUrl: world.server.baseUrl,
+    databaseUrl: world.pg.databaseUrl,
+    clientHome: world.identity.home,
+    jwtSecret: world.jwtSecret,
+    githubWebhookSecret: world.githubApp.webhookSecret,
+    credentials: world.credentials,
+  };
+}
+
+/** Tear down the worker-owned world booted by `setupOwnTuiWorld`. */
+export async function teardownOwnTuiWorld(): Promise<void> {
+  await stopRunWorld();
+}

--- a/packages/e2e/src/mocks/fake-claude-tui.mjs
+++ b/packages/e2e/src/mocks/fake-claude-tui.mjs
@@ -1,0 +1,491 @@
+#!/usr/bin/env node
+// Fake `claude` TUI for e2e — pretends to be the upstream `claude` CLI run
+// interactively inside a tmux pane. Designed for the `claude-code-tui` handler
+// (packages/client/src/handlers/claude-code-tui/), NOT the SDK path.
+//
+// The handler drives this binary by:
+//   1. Spawning it inside `tmux new-session -d -s <name> ... <cmd>`. The cmd
+//      includes `--session-id <uuid>` so we know which transcript file to
+//      write to (per real Claude's behaviour — see transcript-tail.ts).
+//   2. Polling `tmux capture-pane` for the `bypass permissions on` ready
+//      marker, the `❯ ` prompt, the `esc to interrupt` working marker, and the
+//      `Enter to select` AskUserQuestion footer.
+//   3. Sending user text via `paste-buffer -p` + `send-keys Enter`.
+//   4. Reading transcript events from
+//      `~/.claude/projects/<encoded-cwd>/<session-id>.jsonl` to pick up
+//      assistant text + tool_use blocks (the format produced by real Claude).
+//
+// So this fake must:
+//   * Paint the pane with the four magic strings on the right state transitions.
+//   * Accept paste-buffer input on stdin (terminal default cooked-mode is OK
+//     — Enter terminates each user submission).
+//   * Append properly-shaped Anthropic message JSON to the transcript file
+//     on every turn, in the same path the handler computes.
+//   * React to ESC (handler sends one Escape after AskUser menu or to
+//     interrupt a hung turn).
+//
+// Behaviour env knobs (read once at startup; per-turn overrides via the
+// FAKE_TUI_LOG side channel are not needed — tests inject the right knob
+// per agent via FIRST_TREE_HOME-scoped env):
+//
+//   FAKE_TUI_REPLY                — canned reply text (default: echoes input)
+//   FAKE_TUI_DELAY_MS             — pre-emit delay; useful for timeout tests
+//   FAKE_TUI_FAIL_READY=1         — never print the ready marker (probe a
+//                                   waitForReady timeout)
+//   FAKE_TUI_HANG=1               — receive input then never finish the turn
+//                                   (probe TURN_TIMEOUT_MS path)
+//   FAKE_TUI_CRASH_AFTER_TURNS=N  — exit non-zero after N completed turns
+//                                   (probe crash-recovery scenarios)
+//   FAKE_TUI_EMIT_ASKUSER=1       — first turn emits an AskUserQuestion
+//                                   tool_use + paints the menu footer. The
+//                                   handler should Escape-cancel; subsequent
+//                                   turns are normal.
+//   FAKE_TUI_TOOL_CALL=1          — first turn emits a Bash tool_use + a
+//                                   matching tool_result (probe tool_call
+//                                   plumbing through the shared processor).
+//   FAKE_TUI_LOG_PATH             — append one JSON line per fake event
+//                                   (start, ready, turn:start, turn:end,
+//                                   askuser:cancelled, crash). Tests read
+//                                   this via fake-tui-log.ts.
+//
+// Why hand-rolled and not a fixture lib: the handler observes BOTH pane text
+// and transcript JSONL, and the contract between them is what we want to
+// exercise. A library would hide one or the other.
+
+import { randomUUID } from "node:crypto";
+import { appendFileSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+const args = process.argv.slice(2);
+function readFlag(name) {
+  const idx = args.indexOf(name);
+  return idx >= 0 ? args[idx + 1] : undefined;
+}
+
+// Capability probe (probeClaudeCodeTuiCapability) calls `claude --version`
+// before considering the binary "runnable". Handle it short-circuit so the
+// daemon's startup probe accepts the fake. Match the dotted-number triplet
+// real claude prints (the probe regex /\d+\.\d+(?:\.\d+)?/ accepts either).
+if (args.includes("--version") || args.includes("-v")) {
+  process.stdout.write("9.9.9 (fake-tui)\n");
+  process.exit(0);
+}
+
+const sessionId = readFlag("--session-id") ?? randomUUID();
+const resumeId = readFlag("--resume") ?? null;
+
+const REPLY = process.env.FAKE_TUI_REPLY ?? null;
+const DELAY_MS = Number(process.env.FAKE_TUI_DELAY_MS ?? "0");
+const FAIL_READY = process.env.FAKE_TUI_FAIL_READY === "1";
+const HANG = process.env.FAKE_TUI_HANG === "1";
+const CRASH_AFTER = Number(process.env.FAKE_TUI_CRASH_AFTER_TURNS ?? "0");
+const EMIT_ASKUSER = process.env.FAKE_TUI_EMIT_ASKUSER === "1";
+const TOOL_CALL = process.env.FAKE_TUI_TOOL_CALL === "1";
+const LOG_PATH = process.env.FAKE_TUI_LOG_PATH ?? null;
+
+// Same magic strings the handler matches against (see tui-markers.ts).
+// Keep these in sync if the handler markers ever change.
+const READY_MARKER = "bypass permissions on";
+const WORKING_MARKER = "esc to interrupt";
+const ASKUSER_MENU_FOOTER = "Enter to select";
+
+function logEvent(kind, extra) {
+  if (!LOG_PATH) return;
+  try {
+    mkdirSync(dirname(LOG_PATH), { recursive: true });
+    appendFileSync(
+      LOG_PATH,
+      `${JSON.stringify({
+        kind,
+        sessionId,
+        resumeId,
+        ts: new Date().toISOString(),
+        pid: process.pid,
+        ...extra,
+      })}\n`,
+    );
+  } catch {
+    // never let logging tip a test over
+  }
+}
+
+/**
+ * Path real Claude writes its per-session transcript to. Matches
+ * transcript-tail.ts:transcriptPathFor exactly.
+ */
+function transcriptPathFor(cwd, id) {
+  const absCwd = resolve(cwd);
+  const encoded = `-${absCwd.replace(/^\//, "").replace(/[/.]/g, "-")}`;
+  return join(homedir(), ".claude", "projects", encoded, `${id}.jsonl`);
+}
+
+const transcriptPath = transcriptPathFor(process.cwd(), sessionId);
+mkdirSync(dirname(transcriptPath), { recursive: true });
+// Don't truncate on --resume: the handler is reusing the session, so we
+// want to preserve any prior history (the real Claude appends across
+// resumes). On a fresh start, ensure an empty file so the tailer's
+// existsSync check is true from t0.
+if (!existsSync(transcriptPath)) writeFileSync(transcriptPath, "");
+
+function appendTranscript(entry) {
+  appendFileSync(transcriptPath, `${JSON.stringify(entry)}\n`);
+}
+
+/** Paint helpers — write directly to stdout, which tmux captures into its pane buffer. */
+function paint(line) {
+  process.stdout.write(`${line}\n`);
+}
+
+/** Best-effort sleep that yields the event loop. */
+function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+/**
+ * Read a single user message from stdin. tmux paste-buffer -p wraps the
+ * pasted text in bracketed-paste markers (`\e[200~ ... \e[201~`) and a
+ * separate send-keys Enter terminates the submission. We collect bytes until
+ * a CR/LF arrives outside the brackets, then strip the markers and any other
+ * ANSI escape sequences, returning the clean text.
+ *
+ * Also handles `Escape` (0x1b alone): resolves with the sentinel
+ * `{ kind: "escape" }` so the caller can treat it as a turn interrupt.
+ */
+const PASTE_START = "\x1b[200~";
+const PASTE_END = "\x1b[201~";
+
+function readNextInput() {
+  return new Promise((resolveInput) => {
+    // `raw` holds unprocessed bytes; `pending` accumulates the text of the
+    // submission-in-progress (paste content with internal newlines preserved
+    // + any typed chars). A bracketed-paste block is consumed as a single
+    // unit so the newlines inside the runtime's `[From: name]\n<body>` inject
+    // are NOT mistaken for the terminating Enter — only the separate
+    // `send-keys Enter` (a bare CR arriving after the paste) submits.
+    let raw = "";
+    let pending = "";
+    let inPaste = false;
+    // `send-keys Escape` delivers a BARE 0x1b with no follow-on byte, so a
+    // trailing lone ESC can't be distinguished from the first byte of a CSI
+    // sequence (`\x1b[…`) by inspection alone. We arm a short grace timer:
+    // if the ESC is still trailing + unaccompanied when it fires, it was a
+    // real Escape keypress (the handler's AskUser-cancel / interrupt).
+    let escapeTimer = null;
+    const armEscapeTimer = () => {
+      if (escapeTimer) return;
+      escapeTimer = setTimeout(() => {
+        escapeTimer = null;
+        const escIdx = raw.indexOf("\x1b");
+        if (escIdx >= 0 && raw[escIdx + 1] !== "[" && escIdx + 1 >= raw.length) {
+          raw = raw.slice(0, escIdx);
+          cleanup();
+          resolveInput({ kind: "escape" });
+        }
+      }, 60);
+    };
+    const onData = (chunk) => {
+      raw += chunk.toString("utf-8");
+      for (;;) {
+        if (inPaste) {
+          const end = raw.indexOf(PASTE_END);
+          if (end < 0) {
+            // No end marker yet. Move all but a small tail into pending so a
+            // PASTE_END split across two chunks still matches next time.
+            if (raw.length > PASTE_END.length) {
+              pending += raw.slice(0, raw.length - PASTE_END.length);
+              raw = raw.slice(raw.length - PASTE_END.length);
+            }
+            return;
+          }
+          pending += raw.slice(0, end);
+          raw = raw.slice(end + PASTE_END.length);
+          inPaste = false;
+          continue;
+        }
+
+        const startIdx = raw.indexOf(PASTE_START);
+        const crIdx = raw.search(/[\r\n]/);
+        const escIdx = raw.indexOf("\x1b");
+
+        // A lone Escape (send-keys Escape → a bare 0x1b) that is NOT the start
+        // of a CSI sequence. If 0x1b is the last byte we have, wait one tick
+        // for a possible `[200~` to land before deciding.
+        if (escIdx >= 0 && (startIdx < 0 || escIdx < startIdx)) {
+          const isCsi = raw[escIdx + 1] === "[";
+          if (!isCsi) {
+            if (escIdx + 1 >= raw.length) {
+              // Trailing lone ESC — could be a real Escape keypress or the
+              // start of a CSI seq whose `[` hasn't landed yet. Arm the grace
+              // timer to decide, then wait for more bytes.
+              armEscapeTimer();
+              return;
+            }
+            // ESC followed by a non-`[` byte → a real Escape keypress.
+            raw = raw.slice(0, escIdx) + raw.slice(escIdx + 1);
+            cleanup();
+            resolveInput({ kind: "escape" });
+            return;
+          }
+        }
+
+        // Begin a bracketed-paste block: typed text before it is kept.
+        if (startIdx >= 0 && (crIdx < 0 || startIdx < crIdx)) {
+          pending += stripEscapes(raw.slice(0, startIdx));
+          raw = raw.slice(startIdx + PASTE_START.length);
+          inPaste = true;
+          continue;
+        }
+
+        // No paste markers ahead of the next Enter: a CR/LF submits whatever
+        // is pending (+ any typed text before it).
+        if (crIdx < 0) return; // not yet
+        pending += stripEscapes(raw.slice(0, crIdx));
+        raw = raw.slice(crIdx + 1);
+        const submitted = pending.trim();
+        pending = "";
+        if (submitted.length === 0) {
+          // Bare Enter with nothing pending — keep waiting.
+          continue;
+        }
+        cleanup();
+        resolveInput({ kind: "text", text: submitted });
+        return;
+      }
+    };
+    const cleanup = () => {
+      if (escapeTimer) {
+        clearTimeout(escapeTimer);
+        escapeTimer = null;
+      }
+      process.stdin.off("data", onData);
+      process.stdin.off("end", onEnd);
+    };
+    const onEnd = () => {
+      cleanup();
+      resolveInput({ kind: "eof" });
+    };
+    process.stdin.on("data", onData);
+    process.stdin.on("end", onEnd);
+    if (process.stdin.isTTY && typeof process.stdin.setRawMode === "function") {
+      try {
+        process.stdin.setRawMode(true);
+      } catch {
+        /* not a real tty — best-effort */
+      }
+    }
+    process.stdin.resume();
+  });
+}
+
+function stripEscapes(s) {
+  // Strip bracketed paste markers and other CSI sequences. The control
+  // character is intentional — that's exactly what we're matching out of
+  // the input stream.
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: matching ESC by design
+  return s.replace(/\x1b\[\d*(?:;\d*)*[a-zA-Z~]/g, "").replace(/\x1b/g, "");
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+/**
+ * Clear the pane (screen + scrollback + cursor home). Critical for emulating
+ * claude's live status line: the handler decides a turn is still in flight by
+ * `capture-pane`-ing the pane and testing for the WORKING_MARKER substring.
+ * Real claude prints `esc to interrupt` on a status line that it ERASES when
+ * the turn completes. If the fake merely prints the marker and leaves it in
+ * the scrollback, `pane.includes(WORKING_MARKER)` stays true forever and the
+ * handler waits out the full TURN_TIMEOUT. Clearing before each state repaint
+ * makes the marker actually disappear when we transition to idle.
+ */
+function clearScreen() {
+  process.stdout.write("\x1b[2J\x1b[3J\x1b[H");
+}
+
+async function runOneTurn(turnIndex, userText) {
+  logEvent("turn:start", { turn: turnIndex, userText });
+
+  // Record the user input in the transcript first (mirrors real Claude).
+  appendTranscript({
+    type: "user",
+    message: { role: "user", content: userText },
+    timestamp: nowIso(),
+    uuid: randomUUID(),
+    sessionId,
+  });
+
+  // Switch to working state: clear the pane, then paint ONLY the working
+  // marker so a poll landing here sees an in-flight turn. The later idle/reply
+  // repaint clears this away — that disappearance is the turn-end signal.
+  clearScreen();
+  paint(WORKING_MARKER);
+  await sleep(DELAY_MS);
+
+  // Hang knob — never produce output / never return.
+  if (HANG) {
+    logEvent("turn:hang", { turn: turnIndex });
+    await new Promise(() => {});
+    return;
+  }
+
+  // Knob: emit an AskUserQuestion tool_use first turn, then paint the menu
+  // footer so the handler's Escape-cancel + degrade path kicks in. We DO
+  // produce the tool_use transcript entry up-front, matching real Claude's
+  // behaviour where the tool_use lands in the transcript even when the user
+  // cancels the menu (verified empirically in the PoC).
+  if (EMIT_ASKUSER && turnIndex === 1) {
+    const toolUseId = `toolu_${randomUUID().replace(/-/g, "")}`;
+    appendTranscript({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: toolUseId,
+            name: "AskUserQuestion",
+            input: {
+              questions: [
+                {
+                  question: "Which option do you want?",
+                  header: "Choose one",
+                  multiSelect: false,
+                  options: [
+                    { label: "Option A", description: "Picks A" },
+                    { label: "Option B", description: "Picks B" },
+                  ],
+                },
+              ],
+            },
+          },
+        ],
+      },
+      timestamp: nowIso(),
+      uuid: randomUUID(),
+      sessionId,
+    });
+    // Paint the selection menu. Crucially, KEEP the working marker on screen:
+    // during an AskUserQuestion the turn is still in flight (claude is blocked
+    // waiting for a selection), so real claude still shows `esc to interrupt`.
+    // If we dropped it, the handler would see "no working marker + produced
+    // output" and end the turn before ever sending its Escape-cancel — the
+    // degrade path would never fire. With the marker present the handler keeps
+    // polling, detects the footer, and sends Escape.
+    clearScreen();
+    paint(WORKING_MARKER);
+    paint("Choose one");
+    paint("Option A");
+    paint("Option B");
+    paint(ASKUSER_MENU_FOOTER);
+    logEvent("askuser:opened", { turn: turnIndex, toolUseId });
+    // Wait for the handler's Escape (or up to 30s — should be much faster).
+    const next = await Promise.race([readNextInput(), sleep(30_000).then(() => ({ kind: "timeout" }))]);
+    if (next.kind === "escape") {
+      logEvent("askuser:cancelled", { turn: turnIndex, toolUseId });
+      // Don't paint a final reply this turn — the degraded text is what the
+      // user sees, and it's derived from the transcript entry alone. Clear the
+      // menu footer away so the handler doesn't re-arm Escape on a stale pane.
+      clearScreen();
+      paint("❯ "); // NBSP: tmux capture-pane trims trailing ASCII space, NBSP survives — handler's USER_RE matches either
+      logEvent("turn:end", { turn: turnIndex, askUserCancelled: true });
+      return;
+    }
+    // No escape arrived — fall through to emit a normal assistant reply.
+  }
+
+  // Knob: emit a tool_call (Bash) + tool_result, then a normal text reply.
+  if (TOOL_CALL && turnIndex === 1) {
+    const toolUseId = `toolu_${randomUUID().replace(/-/g, "")}`;
+    appendTranscript({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [{ type: "tool_use", id: toolUseId, name: "Bash", input: { command: "echo hi" } }],
+      },
+      timestamp: nowIso(),
+      uuid: randomUUID(),
+      sessionId,
+    });
+    appendTranscript({
+      type: "user",
+      message: {
+        role: "user",
+        content: [{ type: "tool_result", tool_use_id: toolUseId, content: "hi", is_error: false }],
+      },
+      timestamp: nowIso(),
+      uuid: randomUUID(),
+      sessionId,
+    });
+  }
+
+  // Compose + emit the assistant text reply.
+  const replyText = REPLY ?? `fake-tui echo (turn ${turnIndex}): ${userText}`;
+  appendTranscript({
+    type: "assistant",
+    message: { role: "assistant", content: [{ type: "text", text: replyText }] },
+    timestamp: nowIso(),
+    uuid: randomUUID(),
+    sessionId,
+  });
+  // Clear the working marker and paint the assistant reply line + idle prompt.
+  // The handler reads the reply TEXT from the transcript (above), not the pane;
+  // this repaint exists so `pane.includes(WORKING_MARKER)` flips false, which
+  // is how the handler detects turn-end.
+  clearScreen();
+  paint(`⏺ ${replyText}`);
+  paint("❯ "); // NBSP: tmux capture-pane trims trailing ASCII space, NBSP survives — handler's USER_RE matches either
+  logEvent("turn:end", { turn: turnIndex, replyText });
+}
+
+async function main() {
+  logEvent("start", { argv: process.argv, cwd: process.cwd(), transcriptPath });
+
+  if (FAIL_READY) {
+    // Never paint the ready marker — handler's waitForReady should time out.
+    paint("(fake-tui FAIL_READY: never advertising ready)");
+    await new Promise(() => {});
+    return;
+  }
+
+  // Enable bracketed paste mode (DECSET 2004). Tmux only wraps `paste-buffer
+  // -p` content in `\x1b[200~ ... \x1b[201~` when the receiving application
+  // asks for it. Without this, internal newlines in the pasted message (e.g.
+  // the `[From: name]\n<body>` shape the runtime prepends) are treated as
+  // submission boundaries and the fake processes only the first line.
+  process.stdout.write("\x1b[?2004h");
+  // Paint the ready surface: bypass-permissions marker + the `❯ ` prompt
+  // line. waitForReady requires both.
+  paint(READY_MARKER);
+  paint("❯ "); // NBSP: tmux capture-pane trims trailing ASCII space, NBSP survives — handler's USER_RE matches either
+  logEvent("ready");
+
+  let turn = 0;
+  for (;;) {
+    const next = await readNextInput();
+    if (next.kind === "eof") {
+      logEvent("eof");
+      break;
+    }
+    if (next.kind === "escape") {
+      // Standalone Escape outside a turn (e.g. handler interrupting hang).
+      // Repaint the prompt and continue.
+      paint("❯ "); // NBSP: tmux capture-pane trims trailing ASCII space, NBSP survives — handler's USER_RE matches either
+      logEvent("escape:idle");
+      continue;
+    }
+    turn += 1;
+    await runOneTurn(turn, next.text);
+    if (CRASH_AFTER > 0 && turn >= CRASH_AFTER) {
+      logEvent("crash", { turn });
+      process.exit(7);
+    }
+  }
+}
+
+main().catch((err) => {
+  logEvent("fatal", { message: err instanceof Error ? err.message : String(err) });
+  process.stderr.write(`fake-tui: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}\n`);
+  process.exit(2);
+});

--- a/packages/e2e/src/tests/tui-askuser-degrade.e2e.test.ts
+++ b/packages/e2e/src/tests/tui-askuser-degrade.e2e.test.ts
@@ -1,0 +1,71 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { readCurrentHandle } from "../framework/current-handle.js";
+import {
+  createTuiAgent,
+  sendUserMessageToTuiAgent,
+  type TuiAgentFixture,
+  waitForAgentReply,
+} from "../framework/runtime-tui-fixture.js";
+
+/**
+ * tui-askuser-degrade — when the TUI emits the `Enter to select` menu the
+ * handler can't actually navigate (no human at the pane). The handler is
+ * supposed to:
+ *   1. Send a single `Escape` to dismiss the menu.
+ *   2. Pull the cancelled `AskUserQuestion` tool_use from the transcript.
+ *   3. Format `input.questions` as plain markdown.
+ *   4. forwardResult the formatted text — the next user reply is then
+ *      injected as a normal turn.
+ *
+ * The fake binary's `FAKE_TUI_EMIT_ASKUSER=1` knob exercises exactly this
+ * path: first turn writes the AskUser tool_use to the transcript + paints
+ * the menu footer; subsequent turns are normal echoes.
+ */
+
+let fixture: TuiAgentFixture;
+
+beforeAll(async () => {
+  const handle = readCurrentHandle();
+  fixture = await createTuiAgent({
+    handle,
+    displayName: "tui-askuser-degrade agent",
+    knobs: { emitAskUser: true },
+  });
+});
+
+describe("tui-askuser-degrade — Escape cancels the menu and the question lands as plain text", () => {
+  it("forwarded reply is the formatted question, NOT the raw tool_use", async () => {
+    const handle = readCurrentHandle();
+    const sent = await sendUserMessageToTuiAgent({
+      handle,
+      chatId: fixture.chatId,
+      mentionAgentId: fixture.agentId,
+      text: "anything — first turn triggers askuser",
+    });
+
+    const replies = await waitForAgentReply({
+      handle,
+      chatId: fixture.chatId,
+      afterMessageId: sent.id,
+      timeoutMs: 45_000,
+    });
+    const joined = replies.map((m) => m.content).join("\n");
+    // ask-user-degrader.ts renders the questions block with a recognisable
+    // opening line — assert on that so cosmetic edits to the rest of the
+    // template don't break the test.
+    expect(joined).toContain("Claude has a question for you:");
+    expect(joined).toContain("Which option do you want?");
+    // Options must show through as markdown bullets so the human can answer.
+    expect(joined).toContain("Option A");
+    expect(joined).toContain("Option B");
+
+    // The fake-tui side-channel proves the handler actually issued the Escape
+    // (not the fake giving up on its own).
+    const events = await fixture.fakeLog.waitUntil((es) => es.some((e) => e.kind === "askuser:cancelled"), {
+      timeoutMs: 5_000,
+      label: "askuser:cancelled",
+    });
+    expect(events.some((e) => e.kind === "askuser:opened")).toBe(true);
+    expect(events.some((e) => e.kind === "askuser:cancelled")).toBe(true);
+  });
+});

--- a/packages/e2e/src/tests/tui-capability-probe.e2e.test.ts
+++ b/packages/e2e/src/tests/tui-capability-probe.e2e.test.ts
@@ -1,0 +1,62 @@
+import { Client as PgClient } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { type CurrentRunHandle, readCredentialsOrThrow, readCurrentHandle } from "../framework/current-handle.js";
+
+/**
+ * tui-capability-probe — the TUI-mode daemon spawned by globalSetup reports
+ * `claude-code-tui: ok` back to the server. This is the gate that lets the
+ * web UI offer the TUI runtime when creating an agent against this client.
+ *
+ * Why this lives in the TUI suite vs the SDK suite: the daemon's capabilities
+ * include all providers it probed (claude-code SDK + claude-code-tui + codex).
+ * We only get a meaningful `claude-code-tui: ok` when the daemon was spawned
+ * with the fake-tui binary on CLAUDE_CODE_EXECUTABLE — the default SDK spawn
+ * has no real `claude` on PATH inside the test env, so the TUI probe reports
+ * `missing` there.
+ *
+ * Asserts the row directly via PG (capabilities live on `clients.metadata`),
+ * not via the public HTTP surface, because the read API for the metadata blob
+ * isn't a stable user-facing contract.
+ */
+
+let handle: CurrentRunHandle;
+let pg: PgClient;
+
+beforeAll(async () => {
+  handle = readCurrentHandle();
+  pg = new PgClient({ connectionString: handle.databaseUrl });
+  await pg.connect();
+});
+
+afterAll(async () => {
+  await pg.end().catch(() => undefined);
+});
+
+describe("tui-capability-probe — daemon reports claude-code-tui as available", () => {
+  it("clients.metadata.capabilities['claude-code-tui'] is state=ok within probe window", async () => {
+    const creds = readCredentialsOrThrow(handle);
+
+    // Capabilities are reported asynchronously on daemon startup; poll PG up
+    // to 30s so we don't race the first PATCH. The daemon write lands well
+    // within that window in practice (sub-second).
+    const deadline = Date.now() + 30_000;
+    let metadata: Record<string, unknown> | null = null;
+    while (Date.now() < deadline) {
+      const res = await pg.query<{ metadata: Record<string, unknown> | null }>(
+        "SELECT metadata FROM clients WHERE id = $1 LIMIT 1",
+        [creds.clientId],
+      );
+      metadata = res.rows[0]?.metadata ?? null;
+      const capabilities = (metadata?.capabilities as Record<string, { state: string }> | undefined) ?? undefined;
+      if (capabilities?.["claude-code-tui"]) break;
+      await new Promise((r) => setTimeout(r, 250));
+    }
+    expect(metadata).not.toBeNull();
+    const capabilities = (metadata?.capabilities as Record<string, { state: string; authMethod: string }>) ?? {};
+    expect(capabilities["claude-code-tui"]).toBeDefined();
+    expect(capabilities["claude-code-tui"]?.state).toBe("ok");
+    // Auth detection picks up `ANTHROPIC_API_KEY` from clientExtraEnv —
+    // confirms the env wiring works end-to-end.
+    expect(capabilities["claude-code-tui"]?.authMethod).toBe("api_key");
+  });
+});

--- a/packages/e2e/src/tests/tui-crash-recovery.e2e.test.ts
+++ b/packages/e2e/src/tests/tui-crash-recovery.e2e.test.ts
@@ -1,0 +1,91 @@
+import { Client as PgClient } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { readCurrentHandle } from "../framework/current-handle.js";
+import {
+  createTuiAgent,
+  sendUserMessageToTuiAgent,
+  type TuiAgentFixture,
+  waitForAgentReply,
+} from "../framework/runtime-tui-fixture.js";
+
+/**
+ * tui-crash-recovery — the fake-tui binary exits non-zero AFTER the first
+ * turn completes. The handler's `runTurn` for the next message will find
+ * the tmux session dead and report an error event; the runtime should NOT
+ * silently ack the message (the runTurn body throws → turnFailed=true →
+ * disposition.ack=true per the merged contract; this asserts on the
+ * runtime_state landing in `error` so it's visible to operators).
+ *
+ * The exact post-crash behaviour is the contract-of-record: fast-fail visibly
+ * is better than silent absorb. If a future change adds explicit auto-resume
+ * (re-start the tmux session and retry), this test should be updated rather
+ * than removed.
+ */
+
+let handle = readCurrentHandle();
+let pg: PgClient;
+let fixture: TuiAgentFixture;
+
+beforeAll(async () => {
+  handle = readCurrentHandle();
+  pg = new PgClient({ connectionString: handle.databaseUrl });
+  await pg.connect();
+  fixture = await createTuiAgent({
+    handle,
+    displayName: "tui-crash-recovery agent",
+    knobs: { crashAfterTurns: 1 },
+  });
+});
+
+afterAll(async () => {
+  await pg.end().catch(() => undefined);
+});
+
+async function readRuntimeState(agentId: string): Promise<string | null> {
+  const row = await pg.query<{ runtime_state: string | null }>(
+    "SELECT runtime_state FROM agent_presence WHERE agent_id = $1 LIMIT 1",
+    [agentId],
+  );
+  return row.rows[0]?.runtime_state ?? null;
+}
+
+describe("tui-crash-recovery — fake exits after turn 1; turn 2 surfaces an error, not a silent ack", () => {
+  it("second turn produces an error event and runtime_state ends up in 'error'", async () => {
+    // Turn 1 — fake echoes, then exits 7.
+    const turn1 = await sendUserMessageToTuiAgent({
+      handle,
+      chatId: fixture.chatId,
+      mentionAgentId: fixture.agentId,
+      text: "first turn",
+    });
+    await waitForAgentReply({ handle, chatId: fixture.chatId, afterMessageId: turn1.id, timeoutMs: 45_000 });
+
+    // Give the crash a moment to register at the runtime layer.
+    await new Promise((r) => setTimeout(r, 1_000));
+
+    // Turn 2 — fake is gone; the handler's pasteText (or capturePane) hits a
+    // dead session and runTurn throws.
+    const turn2 = await sendUserMessageToTuiAgent({
+      handle,
+      chatId: fixture.chatId,
+      mentionAgentId: fixture.agentId,
+      text: "second turn (should fail)",
+    });
+
+    // Don't expect a reply — instead wait for the runtime_state to flip to
+    // error within a reasonable window.
+    const deadline = Date.now() + 30_000;
+    let state: string | null = null;
+    while (Date.now() < deadline) {
+      state = await readRuntimeState(fixture.agentId);
+      if (state === "error") break;
+      await new Promise((r) => setTimeout(r, 250));
+    }
+    expect(state).toBe("error");
+
+    // Quick sanity on the message itself — the user message stays around;
+    // the agent did NOT post a normal reply. We use the message id from turn 2
+    // only to keep variable references; no assertion on content needed.
+    expect(turn2.id).toBeTruthy();
+  });
+});

--- a/packages/e2e/src/tests/tui-orphan-sweep.e2e.test.ts
+++ b/packages/e2e/src/tests/tui-orphan-sweep.e2e.test.ts
@@ -1,0 +1,97 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { type CurrentRunHandle, readCredentialsOrThrow } from "../framework/current-handle.js";
+import { respawnActiveClient, stopActiveClient } from "../framework/lifecycle.js";
+import {
+  createTuiAgent,
+  expectedTuiSessionPrefix,
+  sendUserMessageToTuiAgent,
+  type TuiAgentFixture,
+  waitForAgentReply,
+} from "../framework/runtime-tui-fixture.js";
+import { hasSession, killSession, listSessionsByPrefix, plantSession } from "../framework/tmux-driver.js";
+import { setupOwnTuiWorld, teardownOwnTuiWorld } from "../framework/tui-world.js";
+
+/**
+ * tui-orphan-sweep — verify the client-scoped orphan sweep behaviour the
+ * reliability gate was added for (PR #712 review round 2):
+ *
+ *   - Sessions with the EXACT `ftth-<clientTag>-` prefix the daemon owns get
+ *     killed on the first handler instantiation in the process.
+ *   - Sessions under a DIFFERENT client tag are left alone — the sweep must
+ *     never tear down another client's live pane.
+ *
+ * This test owns its world (`setupOwnTuiWorld`) rather than sharing the
+ * globalSetup daemon: it stops + respawns the daemon, and the lifecycle
+ * helpers operate on the module-level `activeWorld` which only exists in the
+ * process that called `startRunWorld`. Booting in-worker makes the restart
+ * helpers reachable AND keeps the destructive restart away from the shared
+ * world the other scenarios use.
+ */
+
+let handle: CurrentRunHandle;
+let fixture: TuiAgentFixture;
+let ownedOrphanName: string;
+let foreignSessionName: string;
+
+beforeAll(async () => {
+  handle = await setupOwnTuiWorld();
+  const creds = readCredentialsOrThrow(handle);
+  fixture = await createTuiAgent({ handle, displayName: "tui-orphan-sweep agent" });
+
+  // Plant two stale sessions:
+  //   - one with the daemon's own prefix (should be swept)
+  //   - one with a fictitious different prefix (must survive)
+  const ownedPrefix = expectedTuiSessionPrefix(creds.clientId);
+  ownedOrphanName = `${ownedPrefix}stale12345678`;
+  foreignSessionName = "ftth-other000-stale12345678";
+
+  // Use a real cwd for the planted sessions; the test cwd would be fine but
+  // a fresh tmp dir avoids any incidental coupling.
+  const cwd = mkdtempSync(join(tmpdir(), "tui-orphan-sweep-"));
+
+  // Bring the daemon down first so it doesn't sweep what we're about to plant.
+  await stopActiveClient();
+  await plantSession({ name: ownedOrphanName, cwd });
+  await plantSession({ name: foreignSessionName, cwd });
+  expect(await hasSession(ownedOrphanName)).toBe(true);
+  expect(await hasSession(foreignSessionName)).toBe(true);
+
+  // Re-spawn the daemon. The fixture's agent is already created server-side
+  // and stays bound; the new daemon process will rebind it on the WS handshake.
+  await respawnActiveClient();
+}, 120_000);
+
+afterAll(async () => {
+  // Best-effort: drop the foreign session we planted, then tear down the world.
+  await killSession(foreignSessionName).catch(() => undefined);
+  await teardownOwnTuiWorld();
+});
+
+describe("tui-orphan-sweep — re-spawn daemon kills owned orphans, leaves foreign sessions", () => {
+  it("driving a turn triggers the sweep; owned ftth-<tag>-* die, foreign survives", async () => {
+    const sent = await sendUserMessageToTuiAgent({
+      handle,
+      chatId: fixture.chatId,
+      mentionAgentId: fixture.agentId,
+      text: "wake the daemon up",
+    });
+
+    // Driving a turn forces the handler to instantiate, which is when the
+    // module-level orphanSweep fires (before it creates its own session).
+    await waitForAgentReply({ handle, chatId: fixture.chatId, afterMessageId: sent.id, timeoutMs: 60_000 });
+
+    // The owned orphan should now be gone; the foreign one untouched.
+    expect(await hasSession(ownedOrphanName)).toBe(false);
+    expect(await hasSession(foreignSessionName)).toBe(true);
+
+    // The new live session for our agent exists under the owned prefix, but
+    // neither the swept orphan nor the foreign session should be in that list.
+    const creds = readCredentialsOrThrow(handle);
+    const ownedNow = await listSessionsByPrefix(expectedTuiSessionPrefix(creds.clientId));
+    expect(ownedNow).not.toContain(ownedOrphanName);
+    expect(ownedNow).not.toContain(foreignSessionName);
+  });
+});

--- a/packages/e2e/src/tests/tui-restart-resume.e2e.test.ts
+++ b/packages/e2e/src/tests/tui-restart-resume.e2e.test.ts
@@ -1,0 +1,107 @@
+import { Client as PgClient } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { CurrentRunHandle } from "../framework/current-handle.js";
+import { respawnActiveClient, stopActiveClient } from "../framework/lifecycle.js";
+import {
+  createTuiAgent,
+  sendUserMessageToTuiAgent,
+  type TuiAgentFixture,
+  waitForAgentReply,
+} from "../framework/runtime-tui-fixture.js";
+import { setupOwnTuiWorld, teardownOwnTuiWorld } from "../framework/tui-world.js";
+
+/**
+ * tui-restart-resume — the at-least-once contract: a user message sent while
+ * a turn is hanging gets REDELIVERED after a daemon restart, not silently
+ * absorbed. This is the post-PR #712 contract: a timed-out / interrupted
+ * turn leaves the inbox entry un-acked so the message survives a restart
+ * (see resolveTurnDisposition + the corresponding handler review).
+ *
+ * The fake's `FAKE_TUI_HANG=1` knob makes the first turn never reach
+ * `forwardResult`; we kill the daemon mid-flight, drop the hang knob, and
+ * respawn — the redelivered message should now produce a real reply.
+ *
+ * Owns its world (`setupOwnTuiWorld`) for the same reason as tui-orphan-sweep:
+ * the restart helpers operate on the in-process `activeWorld`, and the
+ * destructive restart must not perturb the shared globalSetup world.
+ */
+
+let handle: CurrentRunHandle;
+let pg: PgClient;
+let hangFixture: TuiAgentFixture;
+
+beforeAll(async () => {
+  handle = await setupOwnTuiWorld();
+  pg = new PgClient({ connectionString: handle.databaseUrl });
+  await pg.connect();
+  hangFixture = await createTuiAgent({
+    handle,
+    displayName: "tui-restart-resume hanging agent",
+    knobs: { hang: true },
+  });
+}, 120_000);
+
+afterAll(async () => {
+  await pg.end().catch(() => undefined);
+  await teardownOwnTuiWorld();
+});
+
+describe("tui-restart-resume — message survives a daemon restart and is redelivered", () => {
+  // Options object goes in the SECOND argument slot (Vitest 3+). Passing it as
+  // the third arg is deprecated and removed in Vitest 4.
+  it("hung first daemon timed out → no ack → second daemon (with healthy knobs) replays the message", {
+    timeout: 180_000,
+  }, async () => {
+    const sent = await sendUserMessageToTuiAgent({
+      handle,
+      chatId: hangFixture.chatId,
+      mentionAgentId: hangFixture.agentId,
+      text: "redeliver me please",
+    });
+    expect(sent.id).toBeTruthy();
+
+    // Wait long enough for the handler to be deep into the turn (after
+    // tmux paste). Don't wait for the full TURN_TIMEOUT_MS (10m) — restart
+    // the daemon early to simulate a real-world "human kills the daemon
+    // mid-flight" scenario.
+    await new Promise((r) => setTimeout(r, 6_000));
+
+    // Restart the daemon, swapping the agent's hang knob OFF so the
+    // redelivered turn can complete. Server-side state survives: the inbox
+    // entry stays in-flight (un-acked), the chat/agent rows are intact.
+    await stopActiveClient();
+
+    // PATCH the agent's runtime env to drop the hang knob before respawn.
+    await pg.query(
+      // The runtime config is stored in agent_configs; the simplest local
+      // toggle is to delete the FAKE_TUI_HANG env entry from the payload.
+      // We use a JSONB removal so the rest of the env (FAKE_TUI_LOG_PATH)
+      // stays intact.
+      `UPDATE agent_configs
+           SET payload = jsonb_set(
+             payload,
+             '{env}',
+             COALESCE((
+               SELECT jsonb_agg(e)
+                 FROM jsonb_array_elements(payload->'env') AS e
+                WHERE e->>'key' <> 'FAKE_TUI_HANG'
+             ), '[]'::jsonb)
+           )
+         WHERE agent_id = $1`,
+      [hangFixture.agentId],
+    );
+
+    await respawnActiveClient();
+
+    // The redelivered turn should now succeed. Poll for the reply.
+    const replies = await waitForAgentReply({
+      handle,
+      chatId: hangFixture.chatId,
+      afterMessageId: sent.id,
+      timeoutMs: 90_000,
+    });
+    expect(replies.length).toBeGreaterThan(0);
+    const joined = replies.map((m) => m.content).join("\n");
+    expect(joined).toContain("redeliver me please");
+  });
+});

--- a/packages/e2e/src/tests/tui-runtime-basic.e2e.test.ts
+++ b/packages/e2e/src/tests/tui-runtime-basic.e2e.test.ts
@@ -1,0 +1,67 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { readCurrentHandle } from "../framework/current-handle.js";
+import {
+  createTuiAgent,
+  sendUserMessageToTuiAgent,
+  type TuiAgentFixture,
+  waitForAgentReply,
+} from "../framework/runtime-tui-fixture.js";
+
+/**
+ * tui-runtime-basic — single-turn happy path:
+ *   1. User sends a text message.
+ *   2. The daemon spawns the fake-tui inside tmux, drives the turn.
+ *   3. The fake echoes the input as assistant text.
+ *   4. forwardResult posts the assistant text back to chat.
+ *
+ * Covers the "session start → pasteText → drainEntries → forwardResult → ack"
+ * loop without crash, askuser, or tool-call detours. If this scenario fails,
+ * none of the others matter — they layer on top of the same loop.
+ */
+
+let fixture: TuiAgentFixture;
+
+beforeAll(async () => {
+  const handle = readCurrentHandle();
+  fixture = await createTuiAgent({ handle, displayName: "tui-runtime-basic agent" });
+});
+
+afterAll(async () => {
+  // Best-effort cleanup of the per-agent log path is fine; the world
+  // teardown wipes `.e2e-runs/`.
+});
+
+describe("tui-runtime-basic — single happy turn end-to-end", () => {
+  it("user → fake-tui → assistant text → forwarded back to chat", async () => {
+    const handle = readCurrentHandle();
+    const sent = await sendUserMessageToTuiAgent({
+      handle,
+      chatId: fixture.chatId,
+      mentionAgentId: fixture.agentId,
+      text: "ping?",
+    });
+
+    const replies = await waitForAgentReply({
+      handle,
+      chatId: fixture.chatId,
+      afterMessageId: sent.id,
+      timeoutMs: 45_000,
+    });
+    expect(replies.length).toBeGreaterThan(0);
+    // Fake echoes "<reply prefix>: <userText>" — assert on the user text
+    // appearing in the reply so future cosmetic tweaks to the prefix don't
+    // tip this over.
+    const joined = replies.map((m) => m.content).join("\n");
+    expect(joined).toContain("ping?");
+
+    // The fake-tui side-channel log records the turn end + reply text. Asserting
+    // here verifies BOTH sides of the contract (forwarded message ↔ fake's
+    // own perception of what it answered).
+    const turnEndEvents = await fixture.fakeLog.waitUntil((events) => events.some((e) => e.kind === "turn:end"), {
+      timeoutMs: 5_000,
+      label: "fake-tui turn:end",
+    });
+    const turnEnd = turnEndEvents.find((e) => e.kind === "turn:end");
+    expect(turnEnd?.replyText).toContain("ping?");
+  });
+});

--- a/packages/e2e/src/tests/tui-runtime-tool-call.e2e.test.ts
+++ b/packages/e2e/src/tests/tui-runtime-tool-call.e2e.test.ts
@@ -1,0 +1,87 @@
+import { Client as PgClient } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { type CurrentRunHandle, readCurrentHandle } from "../framework/current-handle.js";
+import {
+  createTuiAgent,
+  sendUserMessageToTuiAgent,
+  type TuiAgentFixture,
+  waitForAgentReply,
+} from "../framework/runtime-tui-fixture.js";
+
+/**
+ * tui-runtime-tool-call — verify a tool_use + tool_result block in the
+ * transcript flows through the shared `createToolCallProcessor` and lands as
+ * tool_call events on the chat side (the same plumbing the SDK handler uses).
+ *
+ * The fake binary's `FAKE_TUI_TOOL_CALL=1` knob emits a `Bash` tool_use, a
+ * matching tool_result, then a normal text reply — so we should see both the
+ * tool_call session event AND the final assistant text in the chat log.
+ *
+ * Why this matters separately from tui-runtime-basic: tools are how an agent
+ * does anything useful; if the TUI handler emits a tool_use that the runtime
+ * silently drops, the agent appears broken from the user's POV. The basic
+ * scenario only covers `assistant_text` — this one covers `tool_call`.
+ */
+
+let handle: CurrentRunHandle;
+let fixture: TuiAgentFixture;
+let pg: PgClient;
+
+beforeAll(async () => {
+  handle = readCurrentHandle();
+  pg = new PgClient({ connectionString: handle.databaseUrl });
+  await pg.connect();
+  fixture = await createTuiAgent({
+    handle,
+    displayName: "tui-runtime-tool-call agent",
+    knobs: { emitToolCall: true },
+  });
+});
+
+afterAll(async () => {
+  await pg.end().catch(() => undefined);
+});
+
+describe("tui-runtime-tool-call — Bash tool_use + tool_result flow through to the chat", () => {
+  it("forwards the trailing assistant text AND records the tool_call in messages metadata", async () => {
+    const sent = await sendUserMessageToTuiAgent({
+      handle,
+      chatId: fixture.chatId,
+      mentionAgentId: fixture.agentId,
+      text: "run bash for me",
+    });
+
+    // The text reply still lands as a forwarded chat message — we use that
+    // arrival as the ack signal that the turn completed.
+    const replies = await waitForAgentReply({
+      handle,
+      chatId: fixture.chatId,
+      afterMessageId: sent.id,
+      timeoutMs: 45_000,
+    });
+    const replyText = replies.map((m) => m.content).join("\n");
+    expect(replyText).toContain("run bash for me");
+
+    // Tool calls are recorded server-side in the `session_events` table
+    // (kind='tool_call'), NOT as chat messages — the shared
+    // `createToolCallProcessor` the TUI handler reuses emits a `tool_call`
+    // session event with the tool name + input in its payload. Poll for it.
+    const deadline = Date.now() + 10_000;
+    let toolEvents: Array<{ kind: string; payload: unknown }> = [];
+    while (Date.now() < deadline) {
+      const rows = await pg.query<{ kind: string; payload: unknown }>(
+        "SELECT kind, payload FROM session_events WHERE chat_id = $1 AND kind = 'tool_call' ORDER BY seq",
+        [fixture.chatId],
+      );
+      if (rows.rows.length > 0) {
+        toolEvents = rows.rows;
+        break;
+      }
+      await new Promise((r) => setTimeout(r, 200));
+    }
+    // At least one tool_call event, naming the Bash tool the fake emitted.
+    expect(toolEvents.length).toBeGreaterThan(0);
+    const serialized = JSON.stringify(toolEvents);
+    expect(/bash/i.test(serialized)).toBe(true);
+  });
+});

--- a/packages/e2e/src/tests/tui-tmux-lifecycle.e2e.test.ts
+++ b/packages/e2e/src/tests/tui-tmux-lifecycle.e2e.test.ts
@@ -1,0 +1,90 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { type CurrentRunHandle, readCredentialsOrThrow } from "../framework/current-handle.js";
+import {
+  createTuiAgent,
+  expectedTuiSessionName,
+  expectedTuiSessionPrefix,
+  sendUserMessageToTuiAgent,
+  type TuiAgentFixture,
+  waitForAgentReply,
+} from "../framework/runtime-tui-fixture.js";
+import { listBuffers, listSessionsByPrefix } from "../framework/tmux-driver.js";
+import { setupOwnTuiWorld, teardownOwnTuiWorld } from "../framework/tui-world.js";
+
+/**
+ * tui-tmux-lifecycle — verify the session ownership + buffer hygiene
+ * contract:
+ *
+ *   1. On first turn, the handler creates a tmux session whose name matches
+ *      `deriveSessionName(clientId, agentId, chatId)` exactly.
+ *   2. After the turn completes, tmux is left holding no leftover
+ *      `<sessionName>-msg` paste buffer (the handler's `paste-buffer -d` +
+ *      `delete-buffer` backstop must fire).
+ *   3. The session prefix matches `ftth-<clientTag>-` — important for both
+ *      orphan-sweep behaviour and for not stomping on other clients.
+ *
+ * Owns its world: the exact-session-name assertion needs a deterministic
+ * 1-agent daemon. In the shared globalSetup world, leftover ftth-* sessions
+ * from the other steady-state agents (TUI sessions persist until shutdown)
+ * plus message-dispatch ordering make a by-name `has-session` poll racy. A
+ * dedicated world removes that noise — exactly the reason orphan-sweep and
+ * restart-resume own theirs.
+ */
+
+let handle: CurrentRunHandle;
+let fixture: TuiAgentFixture;
+
+beforeAll(async () => {
+  handle = await setupOwnTuiWorld();
+  fixture = await createTuiAgent({ handle, displayName: "tui-tmux-lifecycle agent" });
+}, 120_000);
+
+afterAll(async () => {
+  await teardownOwnTuiWorld();
+});
+
+describe("tui-tmux-lifecycle — session naming + buffer hygiene", () => {
+  it("creates exactly one client-scoped session and leaves no paste buffer behind", async () => {
+    const creds = readCredentialsOrThrow(handle);
+    const ownedPrefix = expectedTuiSessionPrefix(creds.clientId);
+
+    const sent = await sendUserMessageToTuiAgent({
+      handle,
+      chatId: fixture.chatId,
+      mentionAgentId: fixture.agentId,
+      text: "hello tmux",
+    });
+
+    // Wait for the reply first: its arrival proves the handler spun up a live
+    // tmux session, drove the turn, and forwarded the result. This is the
+    // reliable readiness signal (it's exactly what tui-runtime-basic asserts);
+    // polling tmux by an independently-derived name races the handler's
+    // bootstrap and is sensitive to digest-input assumptions.
+    await waitForAgentReply({ handle, chatId: fixture.chatId, afterMessageId: sent.id, timeoutMs: 60_000 });
+
+    // The session is named under the client-scoped prefix `ftth-<clientTag>-`.
+    // This own-world has exactly one agent + one chat, so exactly one owned
+    // session should exist — proving client-scoped naming without depending on
+    // reproducing the internal SHA-256 digest of (agentId, chatId).
+    const ownedSessions = await listSessionsByPrefix(ownedPrefix);
+    expect(ownedSessions.length).toBe(1);
+    const sessionName = ownedSessions[0];
+    expect(sessionName?.startsWith(ownedPrefix)).toBe(true);
+    // The digest segment is a 12-hex SHA-256 slice (collision-resistant names,
+    // not a truncated uuid prefix — the PR #712 review contract).
+    expect(sessionName?.slice(ownedPrefix.length)).toMatch(/^[0-9a-f]{12}$/);
+    // Strong check: the session name matches the handler's deriveSessionName
+    // exactly (SHA-256 of `${agentId}\0${chatId}`, NUL-separated). This also
+    // guards the `expectedTuiSessionName` helper against separator drift.
+    expect(sessionName).toBe(
+      expectedTuiSessionName({ clientTagSource: creds.clientId, agentId: fixture.agentId, chatId: fixture.chatId }),
+    );
+
+    // Buffer hygiene: after the turn the handler must have deleted the
+    // `<sessionName>-msg` paste buffer it used to inject our text (paste-buffer
+    // -d + delete-buffer backstop). No owned `*-msg` buffer should linger.
+    const buffers = await listBuffers();
+    expect(buffers.some((b) => b.startsWith(ownedPrefix) && b.endsWith("-msg"))).toBe(false);
+    expect(buffers).not.toContain(`${sessionName}-msg`);
+  });
+});

--- a/packages/e2e/vitest.tui.config.ts
+++ b/packages/e2e/vitest.tui.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from "vitest/config";
+
+/**
+ * Vitest config for the `claude-code-tui` scenarios — boots a TUI-mode world
+ * (daemon spawned with the fake-tui binary on CLAUDE_CODE_EXECUTABLE + a
+ * fake ANTHROPIC_API_KEY) and only runs `src/tests/tui-*.e2e.test.ts`.
+ *
+ * Kept separate from the default `vitest.config.ts` because the fake-tui
+ * binary does NOT speak the SDK stream-json protocol — sharing the world
+ * with the existing SDK-based suites would break the SDK tests. Run via
+ * `pnpm --filter @first-tree/e2e e2e:tui`.
+ */
+export default defineConfig({
+  test: {
+    name: "tui",
+    include: ["src/tests/tui-*.e2e.test.ts"],
+    globalSetup: ["./src/framework/global-setup.ts"],
+    fileParallelism: false,
+    testTimeout: 90_000,
+    hookTimeout: 120_000,
+    teardownTimeout: 30_000,
+    reporters: ["default"],
+    // Force `E2E_TUI=1` for the duration of this run so global-setup picks
+    // the fake-tui binary even if the operator forgot to export it.
+    env: { E2E_TUI: "1", E2E_WITH_CLIENT: "1" },
+  },
+});


### PR DESCRIPTION
## What

End-to-end coverage for the **`claude-code-tui`** runtime — the tmux-driven interactive `claude` handler (merged via #678/#684/#712). A fake `claude` TUI is driven through **real tmux**, reproducing both surfaces the handler observes (pane markers + per-session transcript JSONL) so the handler's real logic runs unmodified against it.

This is PR5 of the series, landed as one PR (harness + scenarios together).

## PR5a — harness
- `mocks/fake-claude-tui.mjs` — fake claude TUI: paints the four pane markers as a live status line (clears on idle), writes the transcript JSONL at the path the handler computes, bracketed-paste stdin parser, behaviour knobs (`reply`/`delay`/`fail-ready`/`hang`/`crash`/`askuser`/`tool-call`).
- `framework/tmux-driver.ts` — test-side tmux observer (list/plant/buffers/wait).
- `framework/fake-tui-log.ts` — side-channel event reader.
- `framework/runtime-tui-fixture.ts` — per-agent TUI fixture; mirrors `deriveSessionName` (NUL-separated SHA-256 digest).
- `framework/tui-world.ts` — worker-owned worlds so daemon-restart scenarios can reach the in-process lifecycle helpers without perturbing the shared world.
- `framework/{lifecycle,global-setup}.ts` — client `claude` bin + extra env, `stop`/`respawn` daemon helpers, `skipStaleContainerCleanup` so a co-resident world doesn't reap the shared pg.
- `scripts/dev-bootstrap.mjs` — one-shot local bring-up (`pnpm e2e:tui:bootstrap`).
- `vitest.tui.config.ts` + `e2e:tui` script — isolated from the SDK suite (the fake speaks the pane/transcript contract, not SDK stream-json).

## PR5b — 8 scenarios (contract ↔ test)
| Contract | Scenario |
| --- | --- |
| capability probe reports `claude-code-tui: ok` | `tui-capability-probe` |
| happy turn: inject → drain transcript → forward → ack | `tui-runtime-basic` |
| tool_use/result → shared processor → `session_events` | `tui-runtime-tool-call` |
| AskUser menu → Escape-cancel → plain-text degrade | `tui-askuser-degrade` |
| session name = `deriveSessionName` (NUL digest) + buffer hygiene | `tui-tmux-lifecycle` |
| orphan sweep kills owned `ftth-<tag>-*`, leaves foreign | `tui-orphan-sweep` |
| mid-turn daemon death → un-acked → redelivered on restart | `tui-restart-resume` |
| fake crash mid-session surfaces error, no silent ack | `tui-crash-recovery` |

## Docs
- `experiments/tmux-claude-runtime/FINDINGS.md` — design rationale + the contract↔scenario matrix, resolving the dangling citation in the merged handler's header comments (the original PoC was a throwaway spike, not preserved).
- e2e README gains a TUI row + `tmux ≥ 3.0` note.

## Scope / standalone
All code lives under `packages/e2e/` (+ one `experiments/` doc); the "`packages/e2e` is independently removable" invariant is preserved. No product code touched.

## Verification (local)
- `pnpm typecheck` — 13/13
- `pnpm check` — clean (1 pre-existing info in merged `tmux-session.ts`)
- `pnpm --filter @first-tree/e2e e2e:tui` — **8/8**, run repeatedly without flake
- `@first-tree/client` unit suite — 1020/1020 (independent QA pass)

## Not in this PR (flagged for separate handling)
- Dead code in the **merged** handler (`transcript-tail.ts`: `transcriptEntryToEvents`/`drainEvents` are test-only now) — pre-existing, product-code, out of scope for an e2e harness PR.
- `messaging.e2e.test.ts` fails on current `main` (sends without a mention; the group-chat mention rule rejects it) — pre-existing, untouched here.

## CI
Like the rest of `packages/e2e`, this suite is **not** wired into CI yet (per the e2e README's "deliberately not wired into CI yet" posture). The TUI suite additionally needs a real `tmux ≥ 3.0` on the runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)