### PR TITLE
refactor(client): remove dead transcript-tail helpers in claude-code-tui handler

### DIFF
--- a/packages/client/src/__tests__/tui-transcript-tail.test.ts
+++ b/packages/client/src/__tests__/tui-transcript-tail.test.ts
@@ -2,11 +2,7 @@ import { appendFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "n
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import {
-  TranscriptTailer,
-  transcriptEntryToEvents,
-  transcriptPathFor,
-} from "../handlers/claude-code-tui/transcript-tail.js";
+import { TranscriptTailer, transcriptPathFor } from "../handlers/claude-code-tui/transcript-tail.js";
 
 describe("transcriptPathFor", () => {
   it("replaces forward-slashes and dots with dashes and prefixes with dash", () => {
@@ -18,50 +14,6 @@ describe("transcriptPathFor", () => {
     const abs = transcriptPathFor("./relative", "id");
     // resolve() applied: starts from process.cwd() so the encoding includes more dashes
     expect(abs).toMatch(/\/\.claude\/projects\/-.+\/id\.jsonl$/);
-  });
-});
-
-describe("transcriptEntryToEvents", () => {
-  it("maps user string content to user_text", () => {
-    const events = transcriptEntryToEvents({ type: "user", message: { content: "hi" }, timestamp: "t0" });
-    expect(events).toEqual([{ kind: "user_text", text: "hi", ts: "t0" }]);
-  });
-
-  it("maps user array content with tool_result block", () => {
-    const events = transcriptEntryToEvents({
-      type: "user",
-      message: {
-        content: [{ type: "tool_result", tool_use_id: "u1", is_error: false, content: "done" }],
-      },
-      timestamp: "t1",
-    });
-    expect(events).toEqual([{ kind: "tool_result", toolUseId: "u1", isError: false, content: "done", ts: "t1" }]);
-  });
-
-  it("maps assistant content with mixed block types", () => {
-    const events = transcriptEntryToEvents({
-      type: "assistant",
-      message: {
-        content: [
-          { type: "text", text: "Reasoning..." },
-          { type: "tool_use", id: "u2", name: "Bash", input: { command: "ls" } },
-          { type: "thinking", thinking: "internal monologue" },
-        ],
-      },
-      timestamp: "t2",
-    });
-    expect(events).toEqual([
-      { kind: "assistant_text", text: "Reasoning...", ts: "t2" },
-      { kind: "tool_use", toolUseId: "u2", name: "Bash", input: { command: "ls" }, ts: "t2" },
-      { kind: "thinking", text: "internal monologue", ts: "t2" },
-    ]);
-  });
-
-  it("ignores entries the runtime doesn't care about", () => {
-    expect(transcriptEntryToEvents({ type: "permission-mode" })).toEqual([]);
-    expect(transcriptEntryToEvents({ type: "file-history-snapshot" })).toEqual([]);
-    expect(transcriptEntryToEvents({ type: "system" })).toEqual([]);
-    expect(transcriptEntryToEvents({})).toEqual([]);
   });
 });
 
@@ -126,13 +78,5 @@ describe("TranscriptTailer", () => {
     const entries = tailer.drainEntries();
     expect(entries).toHaveLength(1);
     expect(entries[0]).toMatchObject({ type: "user" });
-  });
-
-  it("drainEvents is the mapped convenience over drainEntries", () => {
-    writeFileSync(filePath, "");
-    const tailer = new TranscriptTailer(filePath);
-    appendFileSync(filePath, `${JSON.stringify({ type: "user", message: { content: "x" } })}\n`);
-    const events = tailer.drainEvents();
-    expect(events).toEqual([{ kind: "user_text", text: "x", ts: undefined }]);
   });
 });

--- a/packages/client/src/handlers/claude-code-tui/transcript-tail.ts
+++ b/packages/client/src/handlers/claude-code-tui/transcript-tail.ts
@@ -44,78 +44,6 @@ export type RawTranscriptEntry = {
   [key: string]: unknown;
 };
 
-/** Mapped event used by tests and for the text-accumulation paths in the handler. */
-export type TranscriptEvent =
-  | { kind: "user_text"; text: string; ts?: string }
-  | { kind: "assistant_text"; text: string; ts?: string }
-  | { kind: "tool_use"; toolUseId: string; name: string; input: unknown; ts?: string }
-  | { kind: "tool_result"; toolUseId: string; isError: boolean; content: unknown; ts?: string }
-  | { kind: "thinking"; text: string; ts?: string };
-
-type AnthropicBlock = {
-  type?: string;
-  text?: string;
-  id?: string;
-  name?: string;
-  input?: unknown;
-  tool_use_id?: string;
-  is_error?: boolean;
-  content?: unknown;
-  thinking?: string;
-};
-
-/**
- * Convert one transcript entry into zero or more TranscriptEvents. Mostly
- * used in tests; the live handler also uses it to pick out assistant text
- * (for forwardResult) and tool_use blocks (for the shared tool-call processor).
- */
-export function transcriptEntryToEvents(entry: RawTranscriptEntry): TranscriptEvent[] {
-  if (entry?.type === "user") {
-    const content = entry.message?.content;
-    if (Array.isArray(content)) {
-      const out: TranscriptEvent[] = [];
-      for (const blk of content as AnthropicBlock[]) {
-        if (blk.type === "tool_result") {
-          out.push({
-            kind: "tool_result",
-            toolUseId: blk.tool_use_id ?? "",
-            isError: blk.is_error === true,
-            content: blk.content,
-            ts: entry.timestamp,
-          });
-        }
-      }
-      return out;
-    }
-    if (typeof content === "string") {
-      return [{ kind: "user_text", text: content, ts: entry.timestamp }];
-    }
-    return [];
-  }
-  if (entry?.type === "assistant") {
-    const content = entry.message?.content;
-    if (!Array.isArray(content)) return [];
-    const out: TranscriptEvent[] = [];
-    for (const blk of content as AnthropicBlock[]) {
-      if (blk.type === "text" && typeof blk.text === "string") {
-        out.push({ kind: "assistant_text", text: blk.text, ts: entry.timestamp });
-      } else if (blk.type === "tool_use") {
-        out.push({
-          kind: "tool_use",
-          toolUseId: blk.id ?? "",
-          name: blk.name ?? "",
-          input: blk.input,
-          ts: entry.timestamp,
-        });
-      } else if (blk.type === "thinking" && typeof blk.thinking === "string") {
-        out.push({ kind: "thinking", text: blk.thinking, ts: entry.timestamp });
-      }
-    }
-    return out;
-  }
-  return [];
-}
-
 /**
  * Tail an append-only JSONL transcript. Each `drainEntries()` returns raw
  * entries appended since the last call. Tolerates the file not yet existing
@@ -163,16 +91,5 @@ export class TranscriptTailer {
       }
     }
     return entries;
-  }
-
-  /** Convenience wrapper: read entries and immediately map them to events. */
-  drainEvents(): TranscriptEvent[] {
-    const out: TranscriptEvent[] = [];
-    for (const entry of this.drainEntries()) {
-      for (const ev of transcriptEntryToEvents(entry)) {
-        out.push(ev);
-      }
-    }
-    return out;
   }
 }


### PR DESCRIPTION
## What

Remove the transcript-tail event-mapping path that is referenced **only by tests** in the merged `claude-code-tui` handler:

- `transcriptEntryToEvents()`
- `TranscriptTailer.drainEvents()` (the sole caller of `transcriptEntryToEvents`)
- the now-orphaned `TranscriptEvent` union and `AnthropicBlock` type

The live handler consumes the transcript via `drainEntries()` and maps events through the shared tool-call processor, so this pair is dead production code. The test coverage that existed only to exercise them is dropped; `transcriptPathFor` and `TranscriptTailer.drainEntries()` (the raw-entry path the handler actually uses) are kept, along with their tests.

This was already noted as deferred during the PR3 (#712) self-review and surfaced again during PR5 TUI e2e review (#748).

## Scope / risk

- Product code, `packages/client` only — independent of the PR5 e2e harness (#748).
- Low risk: no live caller. Pure deletion (`+1 / -140`).

## Verification

- `pnpm --filter @first-tree/client typecheck` ✅
- `pnpm --filter @first-tree/client test` ✅ (1012 passed / 3 skipped)
- `pnpm check` ✅ (no new diagnostics)

Closes #749

🤖 Generated with [Claude Code](https://claude.com/claude-code)