### PR TITLE
test(e2e): route messaging.e2e sends with metadata.mentions

### DIFF
--- a/packages/e2e/src/tests/messaging.e2e.test.ts
+++ b/packages/e2e/src/tests/messaging.e2e.test.ts
@@ -76,7 +76,15 @@ describe("M2 messaging — user-scoped HTTP chat send + replyTo", () => {
     const res = await fetch(`${handle.serverBaseUrl}/api/v1/chats/${chatId}/messages`, {
       method: "POST",
       headers: { "Content-Type": "application/json", Authorization: `Bearer ${creds.accessToken}` },
-      body: JSON.stringify({ format: "text", content: "hello from e2e" }),
+      // Group-chat policy requires an explicit recipient — declare routing via
+      // `metadata.mentions: [agentUuid]`, the same channel the client runtime
+      // uses (see services/message.ts + runtime-tui-fixture.ts). Without it the
+      // send is rejected 400.
+      body: JSON.stringify({
+        format: "text",
+        content: "hello from e2e",
+        metadata: { mentions: [testAgentId] },
+      }),
     });
     expect(res.status).toBe(201);
     const body = (await res.json()) as { id: string; chatId: string; senderId: string };
@@ -93,7 +101,7 @@ describe("M2 messaging — user-scoped HTTP chat send + replyTo", () => {
     const first = await fetch(`${handle.serverBaseUrl}/api/v1/chats/${chatId}/messages`, {
       method: "POST",
       headers: { "Content-Type": "application/json", Authorization: `Bearer ${creds.accessToken}` },
-      body: JSON.stringify({ format: "text", content: "parent" }),
+      body: JSON.stringify({ format: "text", content: "parent", metadata: { mentions: [testAgentId] } }),
     });
     expect(first.status).toBe(201);
     const firstBody = (await first.json()) as { id: string };
@@ -101,7 +109,12 @@ describe("M2 messaging — user-scoped HTTP chat send + replyTo", () => {
     const reply = await fetch(`${handle.serverBaseUrl}/api/v1/chats/${chatId}/messages`, {
       method: "POST",
       headers: { "Content-Type": "application/json", Authorization: `Bearer ${creds.accessToken}` },
-      body: JSON.stringify({ format: "text", content: "child", inReplyTo: firstBody.id }),
+      body: JSON.stringify({
+        format: "text",
+        content: "child",
+        inReplyTo: firstBody.id,
+        metadata: { mentions: [testAgentId] },
+      }),
     });
     expect(reply.status).toBe(201);
     const replyBody = (await reply.json()) as { id: string };


### PR DESCRIPTION
## What

Fixes the pre-existing red `messaging.e2e.test.ts` on `main`. The group-chat policy requires every chat send to declare an explicit recipient; the test posted `{ format, content }` with no routing, so all three sends were rejected **400** ("Sending a message requires an explicit recipient…").

Adds `metadata.mentions: [testAgentId]` (agent-uuid routing) to the three sends — the channel the server expects (`services/message.ts`) and the one the client runtime + the merged TUI e2e fixture (`runtime-tui-fixture.ts`, #748) already use. Assertions are unchanged: 201, UUIDv7 id, `senderId`, and `inReplyTo` threading still hold.

## Why it was red

The mention rule landed after this test was written and the test was never reconciled. Surfaced while validating PR #748 (whose own TUI sends already route correctly, which is why #748 was green).

## Verification (local)

- `pnpm --filter @first-tree/e2e typecheck` — clean
- `E2E_WITH_CLIENT=1 vitest run … messaging.e2e.test.ts` — **2/2** (was 0/2)
- Re-ran alongside `agent-lifecycle` + `client-claim` — **9/9**, no collateral

## Scope

Single test file, `packages/e2e` only. No product code touched.

Fixes #750.

🤖 Generated with [Claude Code](https://claude.com/claude-code)