### PR TITLE
feat(web): refine Team page usage, filters, and avatars

### DIFF
--- a/packages/web/src/pages/team/__tests__/team-groups.test.ts
+++ b/packages/web/src/pages/team/__tests__/team-groups.test.ts
@@ -84,7 +84,13 @@ describe("buildTeamData", () => {
     });
     const row = humans[0];
     if (!row) throw new Error("expected a human row");
-    expect(row.delegate).toEqual({ uuid: "assistant-1", name: "ada-helper", displayName: "Ada Assistant" });
+    expect(row.delegate).toEqual({
+      uuid: "assistant-1",
+      name: "ada-helper",
+      displayName: "Ada Assistant",
+      colorToken: null,
+      avatarImageUrl: null,
+    });
     // Only the user themselves can edit their own delegate (admins cannot).
     expect(row.canEditDelegate).toBe(true);
   });

--- a/packages/web/src/pages/team/index.tsx
+++ b/packages/web/src/pages/team/index.tsx
@@ -26,7 +26,6 @@ import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "
 import { Input } from "../../components/ui/input.js";
 import { Label } from "../../components/ui/label.js";
 import { PageHeader } from "../../components/ui/page-header.js";
-import { SegmentedControl } from "../../components/ui/segmented-control.js";
 import { useMemberNameMap } from "../../lib/use-member-name-map.js";
 import { formatRelative } from "../../lib/utils.js";
 import { InviteLinkPanel } from "../invite-link-panel.js";
@@ -278,7 +277,12 @@ export function TeamPage() {
         title="Team"
         subtitle="Agents and humans on your team."
         right={
+          // Page-level controls live on the title row: full-page search (it
+          // filters BOTH sections) sits left of the create actions. The
+          // agent-only All/Mine scope is NOT here — it lives in the Agent
+          // teammates header (it doesn't affect Human teammates).
           <div className="flex items-center" style={{ gap: "var(--sp-2)" }}>
+            <SearchBar query={query} onQuery={setQuery} />
             {/* Brand-green cta is reserved for the one creation/hero action. */}
             <Button size="sm" variant="cta" onClick={() => setCreateOpen(true)}>
               <Plus className="h-3.5 w-3.5" />
@@ -302,26 +306,6 @@ export function TeamPage() {
           gap: "var(--sp-1)",
         }}
       >
-        {/* Filter toolbar: the high-frequency All/Mine scope toggle leads (it
-            behaves as the default-view selector), with search adjacent to its
-            right. Grouped tight on the left as one cluster — not split to
-            opposite ends, which left dead space and read as stranded controls. */}
-        <div className="flex items-center" style={{ gap: "var(--sp-4)", marginBottom: "var(--sp-2)" }}>
-          {/* All/Mine scopes only the Agent section (Human teammates is never
-              filtered by it). Scope is carried by "Mine" = ownership semantics
-              and by the toggle sitting directly above the Agent section — no
-              explicit qualifier needed (it would just echo the section title). */}
-          <SegmentedControl
-            value={agentFilter}
-            onChange={setAgentFilter}
-            options={[
-              { value: "all", label: "All" },
-              { value: "mine", label: "Mine" },
-            ]}
-          />
-          <SearchBar query={query} onQuery={setQuery} />
-        </div>
-
         {agentsQuery.isLoading || membersQuery.isLoading ? (
           <div className="text-center py-8 text-body" style={{ color: "var(--fg-3)" }}>
             Loading…
@@ -353,6 +337,8 @@ export function TeamPage() {
               setDelegateMut.mutate({ humanAgentId, delegateMention: delegateUuid })
             }
             searchActive={search.length > 0}
+            agentFilter={agentFilter}
+            onAgentFilter={setAgentFilter}
           />
         )}
       </div>
@@ -430,8 +416,11 @@ function formatError(err: unknown): string {
 }
 
 function SearchBar({ query, onQuery }: { query: string; onQuery: (q: string) => void }) {
+  // Lives on the page title row next to the create buttons; fixed 180-wide
+  // (--sp-45) and h-8 so it sits at the same height as the adjacent `sm`
+  // buttons without crowding them.
   return (
-    <div className="relative" style={{ width: "var(--sp-60)", maxWidth: "100%" }}>
+    <div className="relative" style={{ width: "var(--sp-45)", maxWidth: "100%" }}>
       <Search
         aria-hidden
         className="h-3.5 w-3.5"
@@ -448,7 +437,7 @@ function SearchBar({ query, onQuery }: { query: string; onQuery: (q: string) => 
         onChange={(e) => onQuery(e.target.value)}
         placeholder="Search name or @handle"
         aria-label="Search team"
-        className="h-7 text-caption"
+        className="h-8 text-caption"
         style={{ paddingLeft: "var(--sp-5)" }}
       />
     </div>
@@ -506,7 +495,13 @@ export function buildTeamData(args: {
     if (!human?.delegateMention) return null;
     const d = agentByUuid.get(human.delegateMention);
     if (!d) return null;
-    return { uuid: d.uuid, name: d.name, displayName: d.displayName };
+    return {
+      uuid: d.uuid,
+      name: d.name,
+      displayName: d.displayName,
+      colorToken: d.avatarColorToken,
+      avatarImageUrl: d.avatarImageUrl,
+    };
   };
 
   const humans: HumanRow[] = members

--- a/packages/web/src/pages/team/team-table.tsx
+++ b/packages/web/src/pages/team/team-table.tsx
@@ -6,6 +6,7 @@ import { DenseBadge } from "../../components/ui/dense-badge.js";
 import { Popover } from "../../components/ui/popover.js";
 import { PresenceChip, runtimeStateToPresence } from "../../components/ui/presence-chip.js";
 import { type RowAction, RowActionsMenu } from "../../components/ui/row-actions-menu.js";
+import { SegmentedControl } from "../../components/ui/segmented-control.js";
 import { formatCompactCount, formatRelative } from "../../lib/utils.js";
 
 export type { RowAction };
@@ -34,7 +35,13 @@ export type HumanRow = {
   displayName: string;
   role: string;
   isSelf: boolean;
-  delegate: { uuid: string; name: string | null; displayName: string } | null;
+  delegate: {
+    uuid: string;
+    name: string | null;
+    displayName: string;
+    colorToken: string | null;
+    avatarImageUrl: string | null;
+  } | null;
   /** Whether the viewer can edit this human's delegate (self only, per spec). */
   canEditDelegate: boolean;
   /** Humanized "active X ago"; null renders "—" (Phase 2 wires the data). */
@@ -76,10 +83,10 @@ function rowOpenProps(onOpen: () => void, label: string) {
   } as const;
 }
 const ROW_GAP = "var(--sp-5)";
-// Agent middle band sub-grid: Owner | Runs on | Usage. The Usage min width is
-// kept generous to fit "1.24M · 142t" cells without ellipsis at the dominant
-// content density.
-const AGENT_MIDDLE_GRID = "minmax(0, 1.3fr) minmax(0, 1fr) minmax(calc(var(--sp-20) + var(--sp-10)), 1fr)";
+// Agent middle band sub-grid: Owner | Runs on | Usage. Usage is now just the
+// token magnitude (no turns), so its min track is trimmed — the reclaimed width
+// goes to Owner, which gained a small avatar before the name.
+const AGENT_MIDDLE_GRID = "minmax(0, 1.4fr) minmax(0, 1fr) minmax(var(--sp-16), 0.9fr)";
 // Compact (<64rem): collapse to Name | Status | Actions; fold the rest into
 // the name cell's meta line, all actions into one always-visible kebab.
 const COMPACT_GRID = "minmax(0, 1fr) auto auto";
@@ -91,6 +98,12 @@ const COMPACT_GRID = "minmax(0, 1fr) auto auto";
 // indentation. Kept as a single knob so the indent can be reintroduced if the
 // disclosure affordance ever returns to the left.
 const SECTION_BODY_INDENT = "0";
+
+// Avatar sizing. The Name-column identity avatar is the larger anchor; the
+// Owner / Delegate relationship avatars (which visualise the human⇄agent
+// delegation link) are a step smaller so the primary identity stays dominant.
+const NAME_AVATAR_SIZE = 24;
+const RELATION_AVATAR_SIZE = 18;
 
 /**
  * Per-section collapse state, persisted to localStorage so a member's
@@ -161,6 +174,9 @@ export type TeamTableProps = {
   onSetDelegate: (humanAgentId: string, delegateUuid: string | null) => void;
   /** Empty-state copy when search filters everything out. */
   searchActive: boolean;
+  /** Agent-only scope filter, surfaced in the Agent teammates header. */
+  agentFilter: "all" | "mine";
+  onAgentFilter: (next: "all" | "mine") => void;
 };
 
 export function TeamTable(props: TeamTableProps) {
@@ -178,38 +194,30 @@ export function TeamTable(props: TeamTableProps) {
 // ─────────────────────────────────────────────────────────────────────────
 
 function AgentSection(props: TeamTableProps & { compact: boolean }) {
-  const { publicAgents, privateAgents, agentCount, compact } = props;
+  const { publicAgents, privateAgents, agentCount, compact, agentFilter, onAgentFilter } = props;
   const [collapsed, toggle] = useCollapsed("team.collapse.agents");
   return (
     <section>
-      {/* Collapsible section header: icon + title + count sit flush-left, the
-          disclosure caret is right-aligned (accordion pattern). The whole row
-          is the toggle. The All/Mine filter lives in the page's filter toolbar
-          now, not here. */}
-      <button
-        type="button"
-        onClick={toggle}
-        aria-expanded={!collapsed}
-        className="flex w-full items-center text-left transition-colors hover:bg-[var(--bg-hover)]"
-        style={{
-          gap: "var(--sp-2)",
-          padding: "var(--sp-5) var(--sp-1) var(--sp-3)",
-          border: 0,
-          background: "transparent",
-          cursor: "pointer",
-          borderRadius: "var(--radius-input)",
-        }}
-      >
-        <Bot className="h-4 w-4" aria-hidden style={{ color: "var(--fg-3)" }} />
-        <h2 className="text-title m-0" style={{ color: "var(--fg)" }}>
-          Agent teammates
-        </h2>
-        <span className="text-label" style={{ color: "var(--fg-4)" }}>
-          {agentCount}
-        </span>
-        <span style={{ flex: 1 }} />
-        <CollapseCaret collapsed={collapsed} />
-      </button>
+      {/* The All/Mine scope filter lives in this header (it is agent-only — it
+          never affects the Human section), sitting to the left of the right-edge
+          disclosure caret. It is a sibling of the toggle buttons, never nested. */}
+      <SectionHeading
+        icon={Bot}
+        title="Agent teammates"
+        count={agentCount}
+        collapsed={collapsed}
+        onToggle={toggle}
+        actions={
+          <SegmentedControl
+            value={agentFilter}
+            onChange={onAgentFilter}
+            options={[
+              { value: "all", label: "All" },
+              { value: "mine", label: "Mine" },
+            ]}
+          />
+        }
+      />
 
       {collapsed ? null : (
         <div style={{ paddingLeft: SECTION_BODY_INDENT }}>
@@ -237,6 +245,76 @@ function AgentSection(props: TeamTableProps & { compact: boolean }) {
   );
 }
 
+/**
+ * Collapsible section header (right accordion). Icon + title + count sit
+ * flush-left in a toggle button that fills the row; the disclosure caret is a
+ * separate toggle button at the right edge. An optional `actions` slot (e.g.
+ * the Agent section's All/Mine filter) renders just left of the caret as a
+ * SIBLING — never nested inside a button, which would be invalid markup.
+ */
+function SectionHeading({
+  icon: Icon,
+  title,
+  count,
+  collapsed,
+  onToggle,
+  actions,
+}: {
+  icon: LucideIcon;
+  title: string;
+  count: number;
+  collapsed: boolean;
+  onToggle: () => void;
+  actions?: ReactNode;
+}) {
+  return (
+    <div
+      className="flex w-full items-center"
+      style={{ gap: "var(--sp-2)", padding: "var(--sp-5) var(--sp-1) var(--sp-3)" }}
+    >
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={!collapsed}
+        className="flex flex-1 items-center text-left transition-colors hover:bg-[var(--bg-hover)]"
+        style={{
+          gap: "var(--sp-2)",
+          minWidth: 0,
+          border: 0,
+          background: "transparent",
+          cursor: "pointer",
+          borderRadius: "var(--radius-input)",
+        }}
+      >
+        <Icon className="h-4 w-4 shrink-0" aria-hidden style={{ color: "var(--fg-3)" }} />
+        <h2 className="text-title m-0" style={{ color: "var(--fg)" }}>
+          {title}
+        </h2>
+        <span className="text-label" style={{ color: "var(--fg-4)" }}>
+          {count}
+        </span>
+        <span style={{ flex: 1 }} />
+      </button>
+      {actions}
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-label={`Toggle ${title}`}
+        className="flex items-center transition-colors hover:bg-[var(--bg-hover)]"
+        style={{
+          border: 0,
+          background: "transparent",
+          cursor: "pointer",
+          borderRadius: "var(--radius-input)",
+          padding: "var(--sp-1)",
+        }}
+      >
+        <CollapseCaret collapsed={collapsed} />
+      </button>
+    </div>
+  );
+}
+
 // Usage aggregation window is fixed at 7 days — the header is a plain
 // "Usage" label with no picker. Compact viewport omits the header row
 // entirely (the row's value still renders, just no column legend), which
@@ -260,7 +338,9 @@ function AgentColumnHeader() {
         {/* Right-aligned: Usage is a numeric column, so it reads as one and
             sits clear of the Runs-on column to its left. */}
         <span className="inline-flex items-center" style={{ justifySelf: "end" }}>
-          <HeaderLabel>Usage</HeaderLabel>
+          {/* Window is fixed at 7 days; the label makes that explicit so the
+              magnitude has a time context (no picker — fixed 7d). */}
+          <HeaderLabel>Usage · 7d</HeaderLabel>
         </span>
       </div>
       <span className="text-eyebrow" style={{ color: "var(--fg-4)", justifySelf: "end" }}>
@@ -378,7 +458,7 @@ function AgentRowView(props: TeamTableProps & { compact: boolean; row: AgentRow;
         hasTaglineSlot={false}
       />
       <div className="grid items-center min-w-0" style={{ gridTemplateColumns: AGENT_MIDDLE_GRID, gap: "var(--sp-4)" }}>
-        <OwnerCell managerLabel={managerLabel} isSelf={isOwnedBySelf} dim={dimOwner} />
+        <OwnerCell managerLabel={managerLabel} managerId={agent.managerId} isSelf={isOwnedBySelf} dim={dimOwner} />
         <RunsOnCell provider={agent.runtimeProvider} host={clientHost} />
         <UsageCell usage={usage} loading={usageLoading} />
       </div>
@@ -388,7 +468,17 @@ function AgentRowView(props: TeamTableProps & { compact: boolean; row: AgentRow;
   );
 }
 
-function OwnerCell({ managerLabel, isSelf, dim }: { managerLabel: string | null; isSelf: boolean; dim: boolean }) {
+function OwnerCell({
+  managerLabel,
+  managerId,
+  isSelf,
+  dim,
+}: {
+  managerLabel: string | null;
+  managerId: string | null;
+  isSelf: boolean;
+  dim: boolean;
+}) {
   if (!managerLabel) {
     return (
       <span className="text-label" style={{ color: "var(--fg-4)" }}>
@@ -396,10 +486,12 @@ function OwnerCell({ managerLabel, isSelf, dim }: { managerLabel: string | null;
       </span>
     );
   }
-  // Name only — the Owner chip intentionally drops the avatar (the leftmost
-  // Name column keeps its avatar). Keeps the middle band lean.
+  // The owner's small avatar precedes the name to make the human⇄agent
+  // ownership link legible at a glance; it's seeded by the manager's member id,
+  // so it matches that same person's avatar in the Human section.
   return (
-    <div className="flex items-center min-w-0" style={{ opacity: dim ? 0.5 : 1 }}>
+    <div className="flex items-center min-w-0" style={{ gap: "var(--sp-1_5)", opacity: dim ? 0.5 : 1 }}>
+      <Avatar name={managerLabel} seed={managerId ?? managerLabel} size={RELATION_AVATAR_SIZE} />
       {isSelf ? (
         <span className="text-body font-semibold truncate" style={{ color: "var(--fg)" }}>
           You
@@ -443,6 +535,9 @@ function UsageCell({ usage, loading }: { usage: UsageByAgentRow | null; loading:
     );
   }
   const totalTokens = usage.inputTokens + usage.cachedInputTokens + usage.outputTokens;
+  // Show only the token magnitude — the turn count was dropped from the cell (it
+  // crowded the column and truncated); turns remain in the hover title for the
+  // rare case someone wants the breakdown.
   return (
     <div
       className="text-caption mono truncate"
@@ -450,7 +545,6 @@ function UsageCell({ usage, loading }: { usage: UsageByAgentRow | null; loading:
       title={`Input ${usage.inputTokens.toLocaleString()} · Cached ${usage.cachedInputTokens.toLocaleString()} · Output ${usage.outputTokens.toLocaleString()} · ${usage.turns} turns`}
     >
       {formatCompactCount(totalTokens)}
-      <span style={{ color: "var(--fg-4)" }}>{` · ${usage.turns} turn${usage.turns === 1 ? "" : "s"}`}</span>
     </div>
   );
 }
@@ -700,10 +794,18 @@ function DelegateCell({
   return <DelegateChip delegate={row.delegate} />;
 }
 
-function DelegateChip({ delegate }: { delegate: { uuid: string; name: string | null; displayName: string } }) {
-  // Name only — the Delegate chip drops the avatar (parallels the Owner chip).
+function DelegateChip({ delegate }: { delegate: NonNullable<HumanRow["delegate"]> }) {
+  // The delegate agent's small avatar precedes the name (parallels the Owner
+  // chip) so the human⇄agent delegation link reads at a glance.
   return (
-    <span className="inline-flex items-center min-w-0">
+    <span className="inline-flex items-center min-w-0" style={{ gap: "var(--sp-1_5)" }}>
+      <Avatar
+        name={delegate.displayName}
+        src={delegate.avatarImageUrl}
+        colorToken={delegate.colorToken}
+        seed={delegate.uuid}
+        size={RELATION_AVATAR_SIZE}
+      />
       <span className="text-body truncate" style={{ color: "var(--fg-2)" }} title={delegate.displayName}>
         {delegate.displayName}
       </span>
@@ -815,7 +917,7 @@ function NameCell({
 }) {
   return (
     <div className="flex items-center min-w-0" style={{ gap: "var(--sp-2_5)" }}>
-      <Avatar name={displayName} src={avatarUrl} colorToken={colorToken} seed={seed} size={30} />
+      <Avatar name={displayName} src={avatarUrl} colorToken={colorToken} seed={seed} size={NAME_AVATAR_SIZE} />
       <div className="min-w-0">
         <div className="flex items-baseline min-w-0" style={{ gap: "var(--sp-1_5)" }}>
           <span className="text-subtitle truncate" style={{ color: "var(--fg)" }} title={displayName}>
@@ -935,9 +1037,10 @@ function agentMetaLine(
   usage: UsageByAgentRow | null,
 ): string {
   const owner = isSelf ? "You" : (managerLabel ?? "—");
+  // Token magnitude only — turns were dropped from the Usage display.
   const usageStr =
     usage && usage.turns > 0
-      ? `${formatCompactCount(usage.inputTokens + usage.cachedInputTokens + usage.outputTokens)} · ${usage.turns} turn${usage.turns === 1 ? "" : "s"}`
+      ? formatCompactCount(usage.inputTokens + usage.cachedInputTokens + usage.outputTokens)
       : "—";
   return `${owner} · ${provider} · ${usageStr}`;
 }


### PR DESCRIPTION
## What

A round of UI refinements to the Team page (`packages/web/src/pages/team`), driven by point-by-point review against a live preview. Pure frontend, no data-model changes.

### Changes
1. **Usage column** — show the token magnitude only (turns dropped from the cell, where they crowded the column and truncated; turns remain in the hover title). The header now labels the fixed window as **`Usage · 7d`** so the magnitude has a time context. Window stays fixed at 7d (no picker).
2. **Filter row reorg** — the standalone filter row is removed:
   - **All / Mine** moves into the **Agent teammates** section header (left of the disclosure caret). It is an *agent-only* scope filter (it never affected Human teammates), so it now sits with the section it actually controls.
   - **Search** moves up to the page title row, beside the create actions. It stays **page-level** (filters both Agent and Human sections). Fixed ~180px, height matched to the adjacent buttons.
3. **Avatars** — the Name-column identity avatar is a touch smaller, and a smaller relationship avatar is added to the **Owner** and **Delegate** cells to surface the human↔agent delegation link (owner avatar is seeded by the manager's member id, so it matches that person's avatar in the Human section).
4. **Human teammates** — stays a single ungrouped list (unchanged).

A left-alignment / indent-spine change was explored during review and **deliberately dropped** — the section/subgroup layout is unchanged from `main` (flat, right-edge accordion carets).

## Notes
- Human-row `⋯` menu is unchanged: it is conditional (admins get "Remove from org" on other members' rows; none on your own row or for non-admins).

## Verification
- `pnpm --filter @first-tree/web typecheck` (tsc + lint:tokens) ✓
- biome ✓
- `pnpm --filter @first-tree/web test` — 508/508 ✓
- Rebased onto latest `origin/main` before pushing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)