### PR TITLE
fix: align Codex final response handling

### DIFF
--- a/packages/client/src/__tests__/codex-inject-startup-race.test.ts
+++ b/packages/client/src/__tests__/codex-inject-startup-race.test.ts
@@ -1,6 +1,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { SessionEvent } from "@first-tree/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChatContext } from "../runtime/chat-context.js";
 import type { SessionContext, SessionMessage } from "../runtime/handler.js";
@@ -10,6 +11,9 @@ const state = vi.hoisted(() => ({
   chatContextPromise: null as Promise<ChatContext> | null,
   resolveChatContext: null as ((value: ChatContext) => void) | null,
   runInputs: [] as unknown[],
+  agentMessagesByTurn: new Map<number, string[]>(),
+  failureByTurn: new Map<number, string>(),
+  streamErrorByTurn: new Map<number, string>(),
 }));
 
 vi.mock("@openai/codex-sdk", () => {
@@ -28,7 +32,20 @@ vi.mock("@openai/codex-sdk", () => {
       return {
         events: (async function* () {
           yield { type: "thread.started", thread_id: "thread-test" };
-          yield { type: "item.completed", item: { type: "agent_message", text: `reply ${turn}` } };
+          const messages = state.agentMessagesByTurn.get(turn) ?? [`reply ${turn}`];
+          for (const text of messages) {
+            yield { type: "item.completed", item: { type: "agent_message", text } };
+          }
+          const failure = state.failureByTurn.get(turn);
+          if (failure) {
+            yield { type: "turn.failed", error: { message: failure } };
+            return;
+          }
+          const streamError = state.streamErrorByTurn.get(turn);
+          if (streamError) {
+            yield { type: "error", message: streamError };
+            return;
+          }
           yield { type: "turn.completed", usage };
         })(),
       };
@@ -88,8 +105,15 @@ function makeMessage(id: string, content: string): SessionMessage {
   };
 }
 
-function makeContext(markCompleted: (count?: number) => void): SessionContext {
-  const sendMessage = vi.fn().mockResolvedValue(undefined);
+type SendMessageMock = ReturnType<typeof vi.fn<(chatId: string, body: Record<string, unknown>) => Promise<unknown>>>;
+
+function makeContext(
+  markCompleted: (count?: number) => void,
+  opts: { sendMessage?: SendMessageMock; emitEvent?: SessionContext["emitEvent"] } = {},
+): SessionContext {
+  const sendMessage =
+    opts.sendMessage ??
+    vi.fn<(chatId: string, body: Record<string, unknown>) => Promise<unknown>>().mockResolvedValue(undefined);
   return {
     agent: {
       agentId: AGENT_ID,
@@ -105,7 +129,7 @@ function makeContext(markCompleted: (count?: number) => void): SessionContext {
     log: () => {},
     touch: () => {},
     setRuntimeState: () => {},
-    emitEvent: () => {},
+    emitEvent: opts.emitEvent ?? (() => {}),
     ...mockCtxPlumbing({ sendMessage }, "chat-startup-race"),
     markCompleted,
   };
@@ -114,6 +138,9 @@ function makeContext(markCompleted: (count?: number) => void): SessionContext {
 beforeEach(() => {
   workspaceRoot = mkdtempSync(join(tmpdir(), "ft-codex-startup-race-"));
   state.runInputs.length = 0;
+  state.agentMessagesByTurn.clear();
+  state.failureByTurn.clear();
+  state.streamErrorByTurn.clear();
   state.chatContextPromise = new Promise((resolve) => {
     state.resolveChatContext = resolve;
   });
@@ -185,6 +212,102 @@ describe("codex handler startup inject queue", () => {
     expect(String(state.runInputs[1])).toContain("second");
     expect(String(state.runInputs[1])).toContain("third");
     expect(completedCounts).toEqual([1, 2]);
+
+    await handler.shutdown();
+  });
+
+  it("forwards only the latest Codex agent_message as the final response", async () => {
+    const sendMessage = vi
+      .fn<(chatId: string, body: Record<string, unknown>) => Promise<unknown>>()
+      .mockResolvedValue(undefined);
+    const emitEvent = vi.fn<(event: SessionEvent) => void>();
+    const handler = createCodexHandler({ workspaceRoot });
+    const ctx = makeContext(() => {}, { sendMessage, emitEvent });
+
+    state.agentMessagesByTurn.set(1, ["working note", "final answer"]);
+    state.resolveChatContext?.({
+      chatId: "chat-startup-race",
+      title: "startup race",
+      topic: null,
+      participants: [],
+    });
+
+    await handler.start(makeMessage("m1", "first"), ctx);
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage.mock.calls[0]?.[1].content).toBe("final answer");
+    expect(
+      emitEvent.mock.calls
+        .map(([event]) => (event.kind === "assistant_text" ? event.payload.text : null))
+        .filter((text): text is string => typeof text === "string"),
+    ).toEqual(["working note", "final answer"]);
+
+    await handler.shutdown();
+  });
+
+  it("does not forward partial Codex text when the turn later fails", async () => {
+    const sendMessage = vi
+      .fn<(chatId: string, body: Record<string, unknown>) => Promise<unknown>>()
+      .mockResolvedValue(undefined);
+    const emitEvent = vi.fn<(event: SessionEvent) => void>();
+    const completedCounts: Array<number | undefined> = [];
+    const handler = createCodexHandler({ workspaceRoot });
+    const ctx = makeContext((count) => completedCounts.push(count), { sendMessage, emitEvent });
+
+    state.agentMessagesByTurn.set(1, ["working note"]);
+    state.failureByTurn.set(1, "codex failed");
+    state.resolveChatContext?.({
+      chatId: "chat-startup-race",
+      title: "startup race",
+      topic: null,
+      participants: [],
+    });
+
+    await handler.start(makeMessage("m1", "first"), ctx);
+
+    const events = emitEvent.mock.calls.map(([event]) => event);
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(
+      events.some(
+        (event) => event.kind === "error" && event.payload.source === "sdk" && event.payload.message === "codex failed",
+      ),
+    ).toBe(true);
+    expect(events.some((event) => event.kind === "turn_end" && event.payload.status === "error")).toBe(true);
+    expect(completedCounts).toEqual([1]);
+
+    await handler.shutdown();
+  });
+
+  it("does not forward partial Codex text when the stream emits a fatal error", async () => {
+    const sendMessage = vi
+      .fn<(chatId: string, body: Record<string, unknown>) => Promise<unknown>>()
+      .mockResolvedValue(undefined);
+    const emitEvent = vi.fn<(event: SessionEvent) => void>();
+    const completedCounts: Array<number | undefined> = [];
+    const handler = createCodexHandler({ workspaceRoot });
+    const ctx = makeContext((count) => completedCounts.push(count), { sendMessage, emitEvent });
+
+    state.agentMessagesByTurn.set(1, ["working note"]);
+    state.streamErrorByTurn.set(1, "codex stream error");
+    state.resolveChatContext?.({
+      chatId: "chat-startup-race",
+      title: "startup race",
+      topic: null,
+      participants: [],
+    });
+
+    await handler.start(makeMessage("m1", "first"), ctx);
+
+    const events = emitEvent.mock.calls.map(([event]) => event);
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(
+      events.some(
+        (event) =>
+          event.kind === "error" && event.payload.source === "sdk" && event.payload.message === "codex stream error",
+      ),
+    ).toBe(true);
+    expect(events.some((event) => event.kind === "turn_end" && event.payload.status === "error")).toBe(true);
+    expect(completedCounts).toEqual([1]);
 
     await handler.shutdown();
   });

--- a/packages/client/src/handlers/codex.ts
+++ b/packages/client/src/handlers/codex.ts
@@ -582,8 +582,8 @@ export const createCodexHandler: HandlerFactory = (config) => {
 
   /**
    * Translate one terminal `item.completed` payload into the runtime's event
-   * stream and, when the item is the assistant's final message, return the
-   * raw text so `runTurn` can stitch the per-turn reply together.
+   * stream and, when the item is assistant text, return the raw text so
+   * `runTurn` can track the SDK-style final response.
    */
   function processItem(item: ThreadItem, sessionCtx: SessionContext): string {
     switch (item.type) {
@@ -719,7 +719,7 @@ export const createCodexHandler: HandlerFactory = (config) => {
     // assistant_text / tool_call to the chat, re-running the turn would
     // double-render those items, so we stop retrying even if the SDK
     // surfaces a transient `turn.failed`.
-    const assistantTexts: string[] = [];
+    let finalResponse = "";
     let turnFailed = false;
     let userVisibleEmitted = false;
     // Wrapper object so TS doesn't narrow `lastUsage` to `null` based on the
@@ -729,9 +729,9 @@ export const createCodexHandler: HandlerFactory = (config) => {
     const turnStartedAt = Date.now();
     const promise = (async () => {
       for (let attempt = 0; attempt <= MAX_TURN_RETRIES; attempt++) {
-        // Reset per-attempt; assistantTexts intentionally persists across
+        // Reset per-attempt; finalResponse intentionally persists across
         // attempts only because we abort retries the moment any user-visible
-        // item is emitted, so the array is empty whenever a retry runs.
+        // item is emitted, so it is empty whenever a retry runs.
         turnFailed = false;
         let retryRequested = false;
         let retryDelay = 0;
@@ -762,7 +762,7 @@ export const createCodexHandler: HandlerFactory = (config) => {
                 // No-op — runtime state already "working".
               } else if (event.type === "item.completed") {
                 const text = processItem(event.item, sessionCtx);
-                if (text) assistantTexts.push(text);
+                if (text) finalResponse = text;
                 if (isUserVisibleItem(event.item)) userVisibleEmitted = true;
               } else if (event.type === "item.started" || event.type === "item.updated") {
                 // Stream-only intermediate states — claude-code likewise emits
@@ -792,6 +792,13 @@ export const createCodexHandler: HandlerFactory = (config) => {
                   payload: { source: "sdk", message },
                 });
               } else if (event.type === "error") {
+                if (!userVisibleEmitted && attempt < MAX_TURN_RETRIES && isTransientCodexErrorMessage(event.message)) {
+                  retryRequested = true;
+                  retryDelay = RETRY_BASE_MS * RETRY_MULTIPLIER ** attempt;
+                  retryReason = `stream error (transient): ${event.message}`;
+                  break;
+                }
+                turnFailed = true;
                 const message = isCodexAuthError(event.message)
                   ? formatAuthHint("codex", event.message)
                   : event.message;
@@ -856,12 +863,15 @@ export const createCodexHandler: HandlerFactory = (config) => {
       return;
     }
 
-    // `\n\n` between assistant messages so multi-message turns aren't fused
-    // into one blob (Codex can emit several `agent_message` items in a turn).
-    const accumulated = assistantTexts.join("\n\n");
+    // Match @openai/codex-sdk's Thread.run() success semantics: when a turn
+    // emits several non-empty agent_message items, finalResponse is the latest
+    // one. Earlier agent_message items remain live assistant_text progress
+    // events only. If the turn failed, do not forward partial text as a final
+    // chat message.
+    const accumulated = finalResponse;
 
     let forwardFailed = false;
-    if (accumulated.trim()) {
+    if (!turnFailed && accumulated.trim()) {
       try {
         await sessionCtx.forwardResult(accumulated);
       } catch (err) {


### PR DESCRIPTION
## Summary
- align Codex final response handling with `@openai/codex-sdk` and Claude Code semantics by forwarding only the latest non-empty successful `agent_message`
- keep intermediate Codex `agent_message` entries as live `assistant_text` progress events only
- prevent failed Codex turns (`turn.failed`, fatal stream `error`, and thrown stream errors) from forwarding partial text as final chat messages

## Verification
- `pnpm exec biome check packages/client/src/handlers/codex.ts packages/client/src/__tests__/codex-inject-startup-race.test.ts`
- `pnpm --filter @first-tree/client exec vitest run src/__tests__/codex-inject-startup-race.test.ts`
- `pnpm --filter @first-tree/client typecheck`

## Review
- Reviewed by `codex-reviewer` in First Tree chat; final复审通过, no remaining blockers.

## Notes
- Root `pnpm check` / `pnpm typecheck` still have unrelated pre-existing failures in `claude-code-tui/tmux-session.ts` lint and web attention/type fixture tests; not changed in this PR.
