### PR TITLE
refactor(web): align Context tab with shared layout + design tokens

### DIFF
--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -407,30 +407,31 @@
   /* Dialog / lightbox scrim (both modes — uniformly dark). */
   --overlay-scrim: oklch(0 0 0 / 0.55);
 
-  /* ── Context-tree "live" page palette (/context hero) ─────────────────────
-     A bespoke set — cool blue "ink" + faint-green card surfaces — lifted here
-     from the hardcoded oklch in the .context-live-* rules below so the page's
-     palette lives in one place. Value-preserving 1:1 lift (a later pass can
-     rationalize the near-duplicate inks). Light-only: the page predates dark
-     theming and these values are mode-independent (unchanged behavior). */
-  --context-ink: oklch(0.2 0.04 265);
-  --context-ink-em: oklch(0.25 0.04 265);
-  --context-ink-dim: oklch(0.52 0.035 255);
-  --context-ink-summary: oklch(0.2 0.035 255);
-  --context-ink-scale: oklch(0.18 0.04 255);
-  --context-ink-node: oklch(0.23 0.025 255);
-  --context-ink-mark: oklch(0.22 0.04 255);
-  --context-mark-bg: oklch(0.91 0.01 255 / 0.72);
-  --context-shadow: oklch(0.25 0.04 255 / 0.08);
-  --context-card-edge: oklch(0.89 0.008 150);
-  --context-card-edge-hover: oklch(0.78 0.09 150);
-  --context-card-edge-live: oklch(0.78 0.13 150);
-  --context-card-bg: oklch(0.98 0.003 150 / 0.9);
-  --context-card-bg-live: oklch(0.985 0.012 150 / 0.94);
-  --context-summary-edge: oklch(0.88 0.008 150);
-  --context-summary-bg: oklch(1 0 0 / 0.86);
-  --context-halo: oklch(0.72 0.17 150 / 0.34);
-  --context-pin-glow: oklch(0.72 0.17 150 / 0.18);
+  /* ── Context page palette ─────────────────────────────────────────────────
+     The /context tab now consumes the neutral semantic ramp like every other
+     tab. Every entry resolves through --fg* / --bg* / --border* / --brand /
+     --success, all of which have .dark overrides, so the page inherits dark
+     mode automatically. Kept as a thin alias layer so the .context-* rules
+     below still read by intent ("ink", "card", "halo"). This replaces the old
+     bespoke light-only blue-ink palette, which broke dark mode and violated
+     the near-monochrome rule (DESIGN Pillars 1 & 4, §10). */
+  --context-ink: var(--fg);
+  --context-ink-em: var(--fg);
+  --context-ink-dim: var(--fg-3);
+  --context-ink-summary: var(--fg-2);
+  --context-ink-scale: var(--fg);
+  --context-ink-node: var(--fg-2);
+  --context-ink-mark: var(--fg);
+  --context-mark-bg: var(--bg-sunken);
+  --context-card-edge: var(--border);
+  --context-card-edge-hover: var(--border-strong);
+  --context-card-edge-live: var(--success);
+  --context-card-bg: var(--bg-raised);
+  --context-card-bg-live: var(--brand-bg);
+  --context-summary-edge: var(--border);
+  --context-summary-bg: var(--bg-raised);
+  --context-halo: color-mix(in oklch, var(--brand) 34%, transparent);
+  --context-pin-glow: color-mix(in oklch, var(--success) 18%, transparent);
 
   /* Hairline widths. Exposing these as vars lets component inline styles
      reference --hairline / --hairline-bold instead of writing "1px" /
@@ -868,81 +869,68 @@
   animation: subtle-fade 180ms ease-out;
 }
 
+/* Left-aligned content column that fills the shared 960 canvas, matching the
+   Team / Agent Detail tabs (same `--sp-2 --sp-5 --sp-7` content padding under a
+   PageHeader). No min-height / centering — the page used to render as a
+   centered hero landing surface, which made its content read narrower than
+   every other tab. */
 .context-live-page {
-  min-height: calc(100vh - 74px);
-  align-items: center;
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-6);
   padding: var(--sp-2) var(--sp-5) var(--sp-7);
 }
 
-.context-live-hero {
-  display: flex;
-  flex-direction: column;
+/* Live-sync chip in the PageHeader right slot: pulsing glow dot + "LIVE"
+   eyebrow + last-synced time. Always-present liveness signal, dense. */
+.context-live-status {
+  display: inline-flex;
   align-items: center;
-  gap: var(--sp-2);
-  padding-top: var(--sp-8);
-  text-align: center;
+  gap: var(--sp-1_5);
 }
 
-.context-live-title-row {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: var(--sp-3);
+/* .context-live-label color is set inline to the severity tone (green when
+   healthy); typography comes from the text-eyebrow tier class. */
+.context-live-time {
+  color: var(--fg-3);
 }
 
 .context-live-dot {
-  width: var(--sp-4);
-  height: var(--sp-4);
-  border-radius: 50%;
+  width: var(--sp-2);
+  height: var(--sp-2);
+  border-radius: var(--radius-full);
   flex: 0 0 auto;
   animation: context-live-dot-pulse 2.4s ease-in-out infinite;
 }
 
-.context-live-title {
-  color: var(--context-ink);
-  font-size: 44px;
-  font-weight: 700;
-  line-height: 1.05;
-}
-
-.context-live-subtitle {
-  color: var(--context-ink-dim);
-}
-
-.context-live-subtitle strong {
-  color: var(--context-ink-em);
-  font-weight: 700;
-}
-
-.context-live-status-detail {
-  max-width: 560px;
-  color: var(--fg-3);
-}
-
 .context-map-section {
-  width: min(100%, 1120px);
+  width: 100%;
   display: flex;
   flex-direction: column;
-  align-items: center;
   gap: var(--sp-2);
 }
 
 .context-map-kicker {
-  color: var(--context-ink-dim);
-  font-size: 12px;
-  font-weight: 700;
+  color: var(--fg-3);
 }
 
+/* Contained module: the change map reads as a deliberate left-aligned well
+   (sunken surface so the raised domain cards pop) rather than a diagram
+   floating in whitespace. */
 .context-map-frame {
   width: 100%;
-  min-height: 400px;
+  min-height: 360px;
+  padding: var(--sp-4);
+  border: var(--hairline) solid var(--border-faint);
+  border-radius: var(--radius-panel);
+  background: var(--bg-sunken);
   overflow: hidden;
 }
 
 .context-network-svg {
   display: block;
   width: 100%;
-  height: 400px;
+  height: 328px;
 }
 
 .context-network-card-wrap {
@@ -969,9 +957,9 @@
   gap: var(--sp-1);
   padding: var(--sp-3) var(--sp-4);
   border: var(--hairline) solid var(--context-card-edge);
-  border-radius: var(--radius-dialog);
+  border-radius: var(--radius-panel);
   background: var(--context-card-bg);
-  box-shadow: 0 8px 28px var(--context-shadow);
+  box-shadow: var(--shadow-sm);
   color: var(--fg);
   text-align: left;
   transition:
@@ -999,9 +987,9 @@
   justify-content: center;
   gap: var(--sp-1);
   border: var(--hairline) solid var(--context-summary-edge);
-  border-radius: var(--radius-dialog);
+  border-radius: var(--radius-panel);
   background: var(--context-summary-bg);
-  box-shadow: 0 14px 36px var(--context-shadow);
+  box-shadow: var(--shadow-md);
   color: var(--fg);
   text-align: center;
 }
@@ -1011,17 +999,17 @@
   width: var(--sp-11);
   height: var(--sp-11);
   place-items: center;
-  border-radius: 50%;
+  border-radius: var(--radius-full);
   background: var(--brand-bg);
   color: var(--success);
 }
 
+/* Typography for the summary card comes from the text-* tier classes applied
+   in context.tsx (text-eyebrow / text-title / text-caption); these rules carry
+   only color + layout. */
 .context-network-summary-title {
   color: var(--context-ink-summary);
-  font-size: 13px;
-  font-weight: 700;
   line-height: 1.15;
-  text-transform: uppercase;
 }
 
 .context-network-summary-scale {
@@ -1030,15 +1018,11 @@
   justify-content: center;
   gap: var(--sp-1);
   color: var(--context-ink-scale);
-  font-size: 40px;
-  font-weight: 500;
   line-height: 1;
 }
 
-.context-network-summary-scale span {
+.context-network-summary-unit {
   color: var(--context-ink-dim);
-  font-size: 12px;
-  font-weight: 500;
 }
 
 .context-network-summary-badge {
@@ -1046,7 +1030,6 @@
   border-radius: var(--radius-chip);
   background: var(--brand-bg);
   color: var(--success);
-  font-weight: 600;
 }
 
 .context-network-pin {
@@ -1055,7 +1038,7 @@
   right: calc(var(--sp-1) * -1);
   width: var(--sp-3);
   height: var(--sp-3);
-  border-radius: 50%;
+  border-radius: var(--radius-full);
   background: var(--success);
   box-shadow: 0 0 0 var(--sp-0_75) var(--context-pin-glow);
 }
@@ -1099,23 +1082,21 @@
 }
 
 .context-signal {
-  width: min(100%, 760px);
+  width: 100%;
   display: flex;
-  flex-direction: column;
-  gap: var(--sp-0_5);
-  padding: 0 var(--sp-2);
-  line-height: 1.35;
-  text-align: center;
+  flex-wrap: wrap;
+  gap: var(--sp-0_5) var(--sp-1);
+  line-height: 1.45;
 }
 
 .context-signal mark {
   display: inline-block;
   margin: 0 var(--sp-0_5);
   padding: 0 var(--sp-1);
-  border-radius: var(--radius-input);
+  border-radius: var(--radius-chip);
   background: var(--context-mark-bg);
   color: var(--context-ink-mark);
-  font-weight: 700;
+  font-weight: 600;
 }
 
 /*
@@ -1130,16 +1111,14 @@
  * because the list re-renders every 30s for the "Xm ago" tick.
  */
 .context-usage-feed {
-  width: min(100%, 760px);
-  margin: 0 auto;
+  width: 100%;
   display: flex;
   flex-direction: column;
   gap: var(--sp-2);
 }
 
 .context-io-agents {
-  width: min(100%, 760px);
-  margin: 0 auto;
+  width: 100%;
   display: flex;
   flex-direction: column;
   gap: var(--sp-1);
@@ -1170,7 +1149,7 @@
   align-items: center;
   gap: var(--sp-1_5);
   padding: var(--sp-1_5) var(--sp-3);
-  border-top: 1px solid var(--border);
+  border-top: var(--hairline) solid var(--border);
 }
 
 .context-io-agent-main {
@@ -1208,7 +1187,7 @@
 .context-usage-feed-live-dot {
   width: var(--sp-1);
   height: var(--sp-1);
-  border-radius: 50%;
+  border-radius: var(--radius-full);
   background: var(--success);
   animation: context-usage-feed-pulse 2.4s ease-in-out infinite;
   flex: 0 0 auto;
@@ -1259,20 +1238,20 @@
 
 .context-usage-feed-row {
   display: grid;
-  grid-template-columns: 16px 22px 1fr auto;
+  grid-template-columns: var(--sp-4) 22px 1fr auto;
   align-items: center;
   gap: var(--sp-1_5);
   padding: var(--sp-1_5) 0;
-  font-size: 13.5px;
+  font-size: 13px;
   line-height: 1.4;
 }
 
 .context-usage-feed-dot {
   width: var(--sp-1);
   height: var(--sp-1);
-  border-radius: 50%;
+  border-radius: var(--radius-full);
   background: var(--success);
-  margin-left: 3px;
+  margin-left: var(--sp-0_75);
   position: relative;
   z-index: 1;
   /* Page-bg ring "breaks" the dashed rail at this dot. */
@@ -1291,7 +1270,7 @@
 .context-usage-feed-avatar {
   width: 22px;
   height: 22px;
-  border-radius: 50%;
+  border-radius: var(--radius-full);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -1447,20 +1426,6 @@
   .context-live-page {
     padding-right: var(--sp-3);
     padding-left: var(--sp-3);
-  }
-
-  .context-live-hero {
-    padding-top: var(--sp-4);
-  }
-
-  .context-live-title-row {
-    align-items: flex-start;
-    gap: var(--sp-2);
-  }
-
-  .context-live-title {
-    font-size: 34px;
-    text-align: left;
   }
 
   .context-map-frame {

--- a/packages/web/src/pages/__tests__/context-page-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/context-page-dom.test.tsx
@@ -182,7 +182,9 @@ describe("ContextPage DOM behavior", () => {
 
     const { container, root, queryClient } = await renderDom(<ContextPage previewSnapshot={liveSnapshot} />);
     expect(contextApiMocks.getContextTreeSnapshot).not.toHaveBeenCalled();
-    expect(container.textContent).toContain("Context tree is live");
+    // The old centered "Context tree is live" hero is now a LIVE chip in the
+    // PageHeader right slot; the warning detail still renders via ContextStatusNote.
+    expect(container.textContent).toContain("LIVE");
     expect(container.textContent).toContain("Tree sync is stale.");
     expect(container.textContent).toContain("4 agents");
     expect(container.textContent).toContain("18 reads");
@@ -241,7 +243,10 @@ describe("ContextPage DOM behavior", () => {
     const { container, root } = await renderDom(<ContextPage previewSnapshot={empty} />);
     expect(container.textContent).toContain("No context updates in the past 7 days.");
     expect(container.textContent).toContain("No explicit Context Tree read/write recorded in the last 7 days.");
-    expect(container.textContent).not.toContain("LIVE");
+    // LIVE reflects the tree's sync liveness, not usage: a synced (active)
+    // snapshot shows the header LIVE chip even with zero reads/writes / no
+    // events (the streaming IO feed is what hides when empty).
+    expect(container.textContent).toContain("LIVE");
     await act(async () => root.unmount());
   });
 
@@ -290,7 +295,7 @@ describe("ContextPage DOM behavior", () => {
     await act(async () => {
       resolveSnapshot(snapshot());
     });
-    await waitForText(loading.container, "Context tree is live");
+    await waitForText(loading.container, "LIVE");
     await act(async () => loading.root.unmount());
 
     contextApiMocks.getContextTreeSnapshot.mockRejectedValueOnce(new Error("Snapshot unavailable"));
@@ -300,7 +305,14 @@ describe("ContextPage DOM behavior", () => {
 
     authMock.value = { organizationId: null };
     const noOrg = await renderDom(<ContextPage />);
-    expect(noOrg.container.textContent).toBe("/");
+    // No org → query disabled, no snapshot. The page renders only its
+    // PageHeader chrome (always present, like every other tab) — no live
+    // chip, no IO feed, and no navigation occurs.
+    expect(noOrg.container.querySelector('[data-testid="location"]')?.textContent).toBe("/");
+    expect(noOrg.container.textContent).not.toContain("LIVE");
+    // Assert the IO feed section element is absent (robust to its label text)
+    // rather than matching a sublabel string that the data model may rename.
+    expect(noOrg.container.querySelector(".context-usage-feed")).toBeNull();
     expect(contextApiMocks.getContextTreeSnapshot).toHaveBeenCalledTimes(2);
     await act(async () => noOrg.root.unmount());
   });

--- a/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
+++ b/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
@@ -869,7 +869,7 @@ describe("page SSR smoke coverage", () => {
     expect(renderPage(<StyleguidePreviewPage />)).toContain("First Tree");
     expect(renderPage(<OnboardingPreviewPage />)).toContain("Onboarding");
     expect(renderPage(<ChatRowAvatarPreviewPage />)).toContain("Chat Row Avatar");
-    expect(renderPage(<ContextPreviewPage />)).toContain("Context tree");
+    expect(renderPage(<ContextPreviewPage />)).toContain("Context Tree");
     expect(renderPage(<ComposeStatusBarPreviewPage />)).toContain("ComposeStatusBar");
     expect(renderPage(<TeamPreviewPage />)).toContain("Agent teammates");
   });

--- a/packages/web/src/pages/context-preview.tsx
+++ b/packages/web/src/pages/context-preview.tsx
@@ -17,8 +17,10 @@ const PREVIEW_NAV_TABS = [
  *
  *  - PreviewHeader  — static, non-interactive copy of the Layout top bar so
  *                     the preview matches production framing.
- *  - main wrapper   — same `p-6 max-w-[1280] mx-auto` content geometry as
- *                     Layout, so width/padding stay aligned with the Team tab.
+ *  - main wrapper   — same `p-6 max-w-[960] mx-auto` content geometry as
+ *                     Layout, so width/padding stay aligned with the Team tab
+ *                     (960 is the shared content canvas; the old 1280 here
+ *                     overstated the real width).
  *
  * The header is presentational only — none of its buttons / tabs do anything.
  * That's intentional: this route is for visual review, not navigation.
@@ -28,7 +30,7 @@ export function ContextPreviewPage() {
     <div className="flex flex-col overflow-hidden" style={{ height: "100vh", background: "var(--bg)" }}>
       <PreviewHeader />
       <main className="flex-1 overflow-auto">
-        <div className="p-6 mx-auto" style={{ maxWidth: 1280 }}>
+        <div className="p-4 lg:p-6 mx-auto" style={{ maxWidth: 960 }}>
           <ContextPage previewSnapshot={MOCK_CONTEXT_SNAPSHOT} />
         </div>
       </main>

--- a/packages/web/src/pages/context.tsx
+++ b/packages/web/src/pages/context.tsx
@@ -12,6 +12,7 @@ import { useNavigate } from "react-router";
 import { getContextTreeSnapshot } from "../api/context-tree.js";
 import { useAuth } from "../auth/auth-context.js";
 import { resolveAvatarHue } from "../components/chat/chat-row-avatar.js";
+import { PageHeader } from "../components/ui/page-header.js";
 import { Panel, PanelBody } from "../components/ui/panel.js";
 
 const CONTEXT_WINDOW = "7d";
@@ -50,67 +51,80 @@ export function ContextPage({ previewSnapshot }: { previewSnapshot?: ContextTree
     setSelectedUpdateId(snapshot.updates[0]?.id ?? null);
   }, [selectedUpdateId, snapshot]);
 
+  const liveStatusReady = snapshot && (preview || !query.isLoading) && snapshot.snapshotStatus !== "unavailable";
+
   return (
-    <div
-      className="context-live-page"
-      style={{
-        display: "flex",
-        flexDirection: "column",
-        gap: "var(--sp-10)",
-      }}
-    >
-      {!preview && query.isLoading ? <LoadingState /> : null}
-      {!preview && query.error ? (
-        <ErrorState message={query.error instanceof Error ? query.error.message : "Failed to load"} />
-      ) : null}
-      {snapshot && (preview || !query.isLoading) ? (
-        snapshot.snapshotStatus === "unavailable" ? (
-          <UnavailableState snapshot={snapshot} />
-        ) : (
-          <>
-            <LiveContextHero snapshot={snapshot} />
-            <ChangeMap
-              snapshot={snapshot}
-              selectedNodeId={selectedNodeId}
-              onSelectNode={(nodeId) => {
-                const matchingUpdate = snapshot.updates.find((update) => update.nodeId === nodeId);
-                setSelectedUpdateId(matchingUpdate?.id ?? null);
-              }}
-            />
-            <ContextSignal snapshot={snapshot} />
-            <ContextIoByAgent snapshot={snapshot} />
-            <ContextUsageFeed snapshot={snapshot} />
-          </>
-        )
-      ) : null}
-    </div>
+    <>
+      <PageHeader
+        title="Context"
+        subtitle="Your team's Context Tree."
+        right={liveStatusReady ? <LiveStatus snapshot={snapshot} /> : null}
+      />
+      <div className="context-live-page">
+        {!preview && query.isLoading ? <LoadingState /> : null}
+        {!preview && query.error ? (
+          <ErrorState message={query.error instanceof Error ? query.error.message : "Failed to load"} />
+        ) : null}
+        {snapshot && (preview || !query.isLoading) ? (
+          snapshot.snapshotStatus === "unavailable" ? (
+            <UnavailableState snapshot={snapshot} />
+          ) : (
+            <>
+              <ContextStatusNote snapshot={snapshot} />
+              <ChangeMap
+                snapshot={snapshot}
+                selectedNodeId={selectedNodeId}
+                onSelectNode={(nodeId) => {
+                  const matchingUpdate = snapshot.updates.find((update) => update.nodeId === nodeId);
+                  setSelectedUpdateId(matchingUpdate?.id ?? null);
+                }}
+              />
+              <ContextSignal snapshot={snapshot} />
+              <ContextIoByAgent snapshot={snapshot} />
+              <ContextUsageFeed snapshot={snapshot} />
+            </>
+          )
+        ) : null}
+      </div>
+    </>
   );
 }
 
-function LiveContextHero({ snapshot }: { snapshot: ContextTreeSnapshot }) {
-  const lastUpdated = exactTimeLabel(snapshot.syncedAt) ?? "sync time unknown";
+/**
+ * Live-sync chip for the page header's right slot. A severity-toned dot pulses
+ * with a glow (DESIGN: green = the living system, working-form = pulse + glow),
+ * next to a "LIVE" eyebrow and the exact last-synced time. The always-present
+ * liveness signal in dense, left-of-the-page-edge chrome — no marketing hero.
+ */
+function LiveStatus({ snapshot }: { snapshot: ContextTreeSnapshot }) {
+  const lastUpdated = exactTimeLabel(snapshot.syncedAt);
   const statusTone = severityColor(snapshot.contextStatus.severity);
-  const statusDetail =
-    snapshot.contextStatus.severity === "ok" ? null : (snapshot.contextStatus.detail ?? snapshot.contextStatus.label);
-
   return (
-    <section className="context-live-hero" aria-label={snapshot.contextStatus.label}>
-      <div className="context-live-title-row">
-        <span
-          aria-hidden="true"
-          className="context-live-dot"
-          style={{
-            background: statusTone,
-            ["--context-live-dot-color" as string]: statusTone,
-          }}
-        />
-        <h2 className="m-0 context-live-title">Context tree is live</h2>
-      </div>
-      <div className="text-lead context-live-subtitle">
-        Last updated at <strong>{lastUpdated}</strong>
-      </div>
-      {statusDetail ? <div className="text-body context-live-status-detail">{statusDetail}</div> : null}
-    </section>
+    <span className="context-live-status" title={snapshot.contextStatus.label}>
+      <span
+        aria-hidden="true"
+        className="context-live-dot"
+        style={{ background: statusTone, ["--context-live-dot-color" as string]: statusTone }}
+      />
+      <span className="text-eyebrow context-live-label" style={{ color: statusTone }}>
+        LIVE
+      </span>
+      {lastUpdated ? <span className="text-label context-live-time">· synced {lastUpdated}</span> : null}
+    </span>
+  );
+}
+
+/** Inline notice shown only when the tree sync is not healthy (warning/danger);
+ *  the ok path stays chrome-free per the read-only / informational rule. */
+function ContextStatusNote({ snapshot }: { snapshot: ContextTreeSnapshot }) {
+  if (snapshot.contextStatus.severity === "ok") return null;
+  const detail = snapshot.contextStatus.detail ?? snapshot.contextStatus.label;
+  const tone = severityColor(snapshot.contextStatus.severity);
+  return (
+    <div className="flex items-center text-label" style={{ gap: "var(--sp-2)", color: tone }}>
+      <AlertTriangle size={14} aria-hidden="true" />
+      <span>{detail}</span>
+    </div>
   );
 }
 
@@ -164,12 +178,12 @@ function ChangeMap({
                 <span className="context-network-summary-icon" aria-hidden="true">
                   <Network size={30} strokeWidth={2.3} />
                 </span>
-                <span className="context-network-summary-title">Context Tree</span>
-                <span className="context-network-summary-scale">
+                <span className="text-eyebrow context-network-summary-title">Context Tree</span>
+                <span className="text-title context-network-summary-scale">
                   {formatNumber(snapshot.nodes.length)}
-                  <span>total nodes</span>
+                  <span className="text-caption context-network-summary-unit">total nodes</span>
                 </span>
-                <span className="text-body context-network-summary-badge">
+                <span className="text-caption font-semibold context-network-summary-badge">
                   +{formatNumber(summaryUpdateCount)} updates
                 </span>
               </div>
@@ -220,14 +234,14 @@ function ContextSignal({ snapshot }: { snapshot: ContextTreeSnapshot }) {
 
   if (snapshot.io.summary.read.eventCount === 0 && snapshot.io.summary.write.eventCount === 0) {
     return (
-      <div className="text-lead context-signal" style={{ color: "var(--fg-3)" }}>
+      <div className="text-body context-signal" style={{ color: "var(--fg-3)" }}>
         <span>No explicit Context Tree read/write recorded in the last {windowText}.</span>
       </div>
     );
   }
 
   return (
-    <div className="text-lead context-signal" style={{ color: "var(--fg-3)" }}>
+    <div className="text-body context-signal" style={{ color: "var(--fg-3)" }}>
       <span>
         In the last {windowText}, <mark>{readAgentText}</mark>
       </span>


### PR DESCRIPTION
## What

Realigns the `/context` tab to the dense, left-aligned admin layout shared by Team / Agent Detail, and brings its bespoke styling onto the design system. Originated from a DESIGN.md compliance + width-consistency audit of the Context tab.

## Why

The Context tab was built as a centered, marketing-style "hero/landing" surface (oversized centered title, 760px-capped content, decorative blue ink, bespoke `.context-*` palette). That made its content read narrower than every other tab and broke several DESIGN.md rules — the worst being **no dark-mode support** (the palette was light-only with no `.dark` override, so the page was unreadable in dark).

## Changes

- **Layout** — replace the centered oversized hero with a standard `PageHeader`; content sections now fill the shared **960** canvas left-aligned, matching Team / Agent Detail.
- **Liveness** — kept, but as a compact **"LIVE" chip** (pulsing glow dot + last-synced time) in the header right slot, instead of the big centered "Context tree is live" hero.
- **Dark mode (bug fix)** — the light-only blue-ink palette is replaced by neutral semantic-token aliases (`--fg` / `--bg` / `--border` / `--brand`), so the page now inherits `.dark` like every other tab.
- **Token-ization** — `50%` → `--radius-full`, raw box-shadows → `--shadow-*`, off-scale font sizes → `text-*` tiers, raw px → `--sp-*`.
- **Preview** — fix the `/preview/context` wrapper width `1280` → `960` to match the real Layout canvas (it previously overstated the width).

## Testing

- `pnpm --filter @first-tree/web typecheck` (tsc + `lint:tokens` gate) ✅ `design-token guardrails clean`
- `pnpm --filter @first-tree/web test` ✅ 58 files / **508 tests passed**
- `pnpm check` (biome) ✅
- Browser-verified `/preview/context` in **light + dark** — both render correctly (dark was broken before).

Scope: `packages/web` only (4 files). No `version` fields touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)