### PR TITLE
refactor(client): sink Communication Rules into first-tree-cloud skill (proposal P3)

### DIFF
--- a/apps/cli/src/__tests__/skill-artifacts.test.ts
+++ b/apps/cli/src/__tests__/skill-artifacts.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { existsSync, lstatSync, readlinkSync } from "node:fs";
+import { existsSync, lstatSync, readFileSync, readlinkSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
@@ -25,6 +25,44 @@ describe("skill artifacts", () => {
       cwd: ROOT,
       stdio: "pipe",
       encoding: "utf-8",
+    });
+  });
+
+  // The Communication Rules / Sending Messages content was sunk from
+  // `bootstrap.ts` `generateToolsDoc()` into the first-tree-cloud skill per
+  // proposal `skill-restructure.20260602` P3. These assertions pin the
+  // invariants in their new home so a future skill edit doesn't silently
+  // drop them.
+  describe("first-tree-cloud carries the Agent-to-Agent Communication invariants (proposal P3)", () => {
+    const skillMd = readFileSync(join(ROOT, "skills", "first-tree-cloud", "SKILL.md"), "utf-8");
+    const referenceMd = readFileSync(
+      join(ROOT, "skills", "first-tree-cloud", "references", "agent-communication.md"),
+      "utf-8",
+    );
+
+    it("SKILL.md pins the final-text contract + decision-guide table", () => {
+      expect(skillMd).toContain("Agent-to-Agent Communication");
+      expect(skillMd).toContain("human observers");
+      expect(skillMd).toContain("does **NOT** wake other agents");
+      expect(skillMd).toMatch(/\*\*human\*\* in this chat/);
+      expect(skillMd).toMatch(/\*\*agent\*\* in this chat/);
+      expect(skillMd).toContain("Fallback");
+      expect(skillMd).toContain("conservative mode");
+    });
+
+    it("references/agent-communication.md teaches `chat invite` instead of the retired --direct escape hatch", () => {
+      expect(referenceMd).toContain("first-tree chat invite");
+      expect(referenceMd).toContain("first-tree chat send");
+      expect(referenceMd).toMatch(/recipient MUST be a participant/);
+      expect(referenceMd).toMatch(/Reaching another agent/);
+      expect(referenceMd).toMatch(/only addresses agents by name/);
+      // The retired escape hatches must NOT be taught.
+      expect(referenceMd).not.toMatch(/--direct/);
+      expect(referenceMd).not.toMatch(/--chat <chatId>/);
+      expect(referenceMd).not.toMatch(/--chat <directChatId>/);
+      // Anti-double-encode (Issue #389) — the long form lives here; tools.md
+      // also pins the one-line invariant.
+      expect(referenceMd).toContain("JSON.stringify");
     });
   });
 });

--- a/packages/client/src/__tests__/bootstrap.test.ts
+++ b/packages/client/src/__tests__/bootstrap.test.ts
@@ -194,7 +194,7 @@ describe("bootstrapWorkspace", () => {
     expect("chatContext" in data).toBe(false);
   });
 
-  it("writes tools.md with SDK reference", () => {
+  it("writes tools.md with the runtime invariants the result-sink + silence-turn rely on", () => {
     const workspace = join(tmpBase, "ws-tools");
     mkdirSync(workspace, { recursive: true });
 
@@ -215,19 +215,21 @@ describe("bootstrapWorkspace", () => {
     // L4 silent-turn protocol: the prompt directive that pairs with the
     // result-sink empty-output guard. Tells the agent that silence is the
     // correct response when it has nothing new — drops courtesy fillers
-    // that would otherwise sustain agent↔agent loops.
+    // that would otherwise sustain agent↔agent loops. MUST stay in
+    // tools.md (not progressive-disclosure) — see proposal P3.
     expect(content).toContain("Stay silent when you have nothing to add");
     expect(content).toContain("If you have nothing new for the recipient, output nothing");
     expect(content).toContain("the runtime ends the turn");
     // Issue #389: pin the anti-double-encode directive so future prompt edits
     // don't accidentally drop it. The CLI passes content as-is; agents that
     // JSON.stringify before sending produce a literal `"@x ...\n..."` row
-    // that the UI cannot render as markdown.
+    // that the UI cannot render as markdown. Stays in tools.md — runtime
+    // safety invariant.
     expect(content).toContain("Content rules");
     expect(content).toContain("JSON.stringify");
   });
 
-  it("tools.md contains the Communication Rules section with Decision guide + Fallback (v1 §四 改造 4)", () => {
+  it("tools.md pins the final-text contract and points the long-form rules at first-tree-cloud (proposal P3)", () => {
     const workspace = join(tmpBase, "ws-tools-rules");
     mkdirSync(workspace, { recursive: true });
 
@@ -239,20 +241,18 @@ describe("bootstrapWorkspace", () => {
     });
 
     const content = readFileSync(join(workspace, ".agent", "tools.md"), "utf-8");
-    expect(content).toContain("## Communication Rules");
-    // New final-text contract — "human observers" + "does NOT wake other agents"
+    // Final-text contract still pinned in tools.md (load-bearing for
+    // result-sink + agent↔agent echo-loop prevention; see v1 §四 改造 4).
     expect(content).toContain("human observers");
     expect(content).toContain("does NOT wake other agents");
-    // Decision guide section anchors
-    expect(content).toContain("Decision guide");
-    expect(content).toMatch(/Target is a \*\*human\*\* in this chat/);
-    expect(content).toMatch(/Target is an \*\*agent\*\* in this chat/);
-    // Fallback paragraph for chat-context-missing degradation
-    expect(content).toContain("**Fallback**");
-    expect(content).toContain("conservative mode");
-
-    // Old contract text must be gone — these are the lines the v1.5 spec
-    // requires改造 4 to overwrite.
+    // The full Communication Rules / Sending Messages / Decision guide /
+    // Fallback content has been sunk into the first-tree-cloud skill
+    // (SKILL.md + references/agent-communication.md). tools.md must
+    // carry a pointer at it.
+    expect(content).toContain("## Hub Collaboration");
+    expect(content).toContain("first-tree-cloud");
+    // Old contract text must stay gone — these are the lines the v1.5 spec
+    // requires 改造 4 to overwrite.
     expect(content).not.toContain("Your final text response is automatically delivered");
     expect(content).not.toMatch(/Otherwise it falls back to a direct chat/i);
   });
@@ -272,12 +272,19 @@ describe("bootstrapWorkspace", () => {
     expect(content).toBe(generateToolsDoc());
   });
 
-  it("tools.md uses the channel-resolved binary name when the CLI binding points at staging", () => {
-    // Regression for the multi-env follow-up: the agent-facing tools.md
-    // used to hardcode `first-tree chat send`, which on staging hosts asks
-    // the agent to call a binary that doesn't exist (only
-    // `first-tree-staging` is installed). The binding must thread through
-    // to every CLI invocation in the docs (chat send/invite, agent list).
+  it("tools.md uses the channel-resolved binary name in the surviving chat-send invariant (post-P3 sink)", () => {
+    // Regression for the multi-env follow-up: the agent-facing tools.md used
+    // to hardcode `first-tree chat send`, which on staging hosts asks the
+    // agent to call a binary that doesn't exist (only `first-tree-staging`
+    // is installed). After proposal P3 sank the long-form CLI usage into the
+    // `first-tree-cloud` skill, tools.md no longer carries `chat invite` /
+    // `agent list` examples — but the load-bearing `chat send <name>`
+    // directive (and the pointer's binary substitution note) still go
+    // through `${bin}`, so the channel binding must thread through.
+    // The full chat-send/invite/agent-list usage now lives in
+    // `skills/first-tree-cloud/references/agent-communication.md`; that
+    // file's channel-correctness is covered by the skill-content tests in
+    // `apps/cli/src/__tests__/skill-artifacts.test.ts`.
     setCliBinding({ binName: "first-tree-staging", packageName: "first-tree-staging" });
     const workspace = join(tmpBase, "ws-tools-staging");
     mkdirSync(workspace, { recursive: true });
@@ -291,41 +298,12 @@ describe("bootstrapWorkspace", () => {
 
     const content = readFileSync(join(workspace, ".agent", "tools.md"), "utf-8");
     expect(content).toContain("first-tree-staging chat send");
-    expect(content).toContain("first-tree-staging chat invite");
-    expect(content).toContain("first-tree-staging agent list");
     // The hardcoded prod name must NOT leak through — the literal
     // `first-tree chat` would mis-direct staging agents to the prod binary.
+    // (The pointer text mentioning `first-tree` as a literal-to-substitute
+    // does so inside backticks and is not followed by `chat ` — the regex
+    // anchors on the literal CLI form `first-tree chat ` only.)
     expect(content).not.toMatch(/\bfirst-tree chat /);
-  });
-
-  it("tools.md teaches `chat invite` instead of the retired --direct escape hatch", () => {
-    const workspace = join(tmpBase, "ws-tools-direct");
-    mkdirSync(workspace, { recursive: true });
-
-    bootstrapWorkspace({
-      workspacePath: workspace,
-      identity: makeIdentity(),
-      contextTreePath: null,
-      serverUrl: "http://localhost:8000",
-    });
-
-    const content = readFileSync(join(workspace, ".agent", "tools.md"), "utf-8");
-    // Sending Messages section must teach the add-participant flow as the
-    // canonical way to reach a non-member of the current chat.
-    expect(content).toContain("first-tree chat invite");
-    // Member-default routing description (the recipient must be in this chat).
-    expect(content).toMatch(/recipient MUST be a participant/);
-    // The retired escape hatches must NOT be taught — agents that try them
-    // would hit `unknown option` and loop. (First Tree keeps a single group-chat
-    // model; non-members must be added first.)
-    expect(content).not.toMatch(/--direct/);
-    expect(content).not.toMatch(/auto-mentions the recipient/);
-    // v1.7: agent surface is narrowed to "address an agent by name". The
-    // `--chat <chatId>` foot-gun is gone from the CLI and from this prompt.
-    expect(content).not.toMatch(/--chat <chatId>/);
-    expect(content).not.toMatch(/--chat <directChatId>/);
-    expect(content).toMatch(/Reaching another agent/);
-    expect(content).toMatch(/only addresses agents by name/);
   });
 
   it("tools.md notes the ask-a-human flow is pending redesign", () => {

--- a/packages/client/src/__tests__/bootstrap.test.ts
+++ b/packages/client/src/__tests__/bootstrap.test.ts
@@ -229,7 +229,7 @@ describe("bootstrapWorkspace", () => {
     expect(content).toContain("JSON.stringify");
   });
 
-  it("tools.md pins the final-text contract and points the long-form rules at first-tree-cloud (proposal P3)", () => {
+  it("tools.md pins the final-text contract, Decision guide + Fallback, and points the long-form CLI usage at first-tree-cloud (proposal P3)", () => {
     const workspace = join(tmpBase, "ws-tools-rules");
     mkdirSync(workspace, { recursive: true });
 
@@ -245,10 +245,20 @@ describe("bootstrapWorkspace", () => {
     // result-sink + agent↔agent echo-loop prevention; see v1 §四 改造 4).
     expect(content).toContain("human observers");
     expect(content).toContain("does NOT wake other agents");
-    // The full Communication Rules / Sending Messages / Decision guide /
-    // Fallback content has been sunk into the first-tree-cloud skill
-    // (SKILL.md + references/agent-communication.md). tools.md must
-    // carry a pointer at it.
+    // P3 v2 (after yuezengwu's Blocker 1 callout): the Decision guide table
+    // and the Fallback paragraph stay inline because `first-tree-cloud` is
+    // not in CORE_SKILL_NAMES — a tree-less agent (contextTreePath: null)
+    // would otherwise lose them entirely. Only the long-form CLI mechanics
+    // (chat invite / markdown / stdin / mention resolution) sink into the
+    // skill.
+    expect(content).toContain("## Communication Rules");
+    expect(content).toContain("Decision guide");
+    expect(content).toMatch(/Target is a \*\*human\*\* in this chat/);
+    expect(content).toMatch(/Target is an \*\*agent\*\* in this chat/);
+    expect(content).toContain("**Fallback**");
+    expect(content).toContain("conservative mode");
+    // tools.md still carries the pointer at first-tree-cloud for the
+    // long-form CLI usage (and explicitly notes the tree-less case).
     expect(content).toContain("## Hub Collaboration");
     expect(content).toContain("first-tree-cloud");
     // Old contract text must stay gone — these are the lines the v1.5 spec

--- a/packages/client/src/__tests__/codex-bootstrap.test.ts
+++ b/packages/client/src/__tests__/codex-bootstrap.test.ts
@@ -127,8 +127,13 @@ describe("bootstrapWorkspace — codex briefing + workspace marker", () => {
     expect(briefing).toContain("Follow the local implementation plan.");
     expect(briefing).toContain("## Current Chat Context");
     expect(briefing).toContain("# First Tree Agent Runtime");
-    expect(briefing).toContain("## Communication Rules");
-    expect(briefing).toContain("first-tree-staging chat invite");
+    // Per proposal P3, the long-form Communication Rules / Sending Messages
+    // moved to the first-tree-cloud skill. tools.md still pins the
+    // load-bearing invariants (final-text contract, silent-turn, raw-string
+    // content rule) plus a pointer at the skill, and the channel-correct
+    // binary name (must survive into the briefing for staging/dev hosts).
+    expect(briefing).toContain("## Hub Collaboration");
+    expect(briefing).toContain("first-tree-cloud");
     expect(briefing).toContain("first-tree-staging chat send");
     expect(briefing).toContain("does NOT wake other agents");
     expect(briefing).not.toContain("`.agent/tools.md` for the");

--- a/packages/client/src/__tests__/codex-bootstrap.test.ts
+++ b/packages/client/src/__tests__/codex-bootstrap.test.ts
@@ -127,11 +127,11 @@ describe("bootstrapWorkspace — codex briefing + workspace marker", () => {
     expect(briefing).toContain("Follow the local implementation plan.");
     expect(briefing).toContain("## Current Chat Context");
     expect(briefing).toContain("# First Tree Agent Runtime");
-    // Per proposal P3, the long-form Communication Rules / Sending Messages
-    // moved to the first-tree-cloud skill. tools.md still pins the
-    // load-bearing invariants (final-text contract, silent-turn, raw-string
-    // content rule) plus a pointer at the skill, and the channel-correct
-    // binary name (must survive into the briefing for staging/dev hosts).
+    // Per proposal P3 v2, the long-form Sending Messages CLI usage moved
+    // to first-tree-cloud; the Communication Rules decision guide + the
+    // Fallback paragraph stay inline because first-tree-cloud is not in
+    // CORE_SKILL_NAMES (tree-less agents would otherwise lose them).
+    expect(briefing).toContain("## Communication Rules");
     expect(briefing).toContain("## Hub Collaboration");
     expect(briefing).toContain("first-tree-cloud");
     expect(briefing).toContain("first-tree-staging chat send");

--- a/packages/client/src/runtime/bootstrap.ts
+++ b/packages/client/src/runtime/bootstrap.ts
@@ -966,11 +966,21 @@ export function generateToolsDoc(): string {
   // binary that wasn't installed on the host.
   //
   // Per skill-restructure proposal (skill-restructure.20260602) P3, the
-  // long-form Communication Rules / Sending Messages content has been
-  // sunk into the `first-tree-cloud` skill (SKILL.md + references/
-  // agent-communication.md). What stays here are the load-bearing
-  // invariants that the runtime's result-sink + courteous-loop guard
-  // depend on, plus a pointer to the skill for everything else.
+  // long-form Sending Messages CLI usage (chat send / chat invite syntax,
+  // markdown / stdin, mention-resolution mechanics) has been sunk into
+  // the `first-tree-cloud` skill (SKILL.md + references/agent-
+  // communication.md). What stays here:
+  //   - runtime safety invariants the result-sink + silent-turn guard
+  //     depend on (final-text contract, silent-turn, Issue #389);
+  //   - the short behavioural directives (Decision guide table + Fallback
+  //     paragraph) that every agent needs regardless of whether
+  //     `first-tree-cloud` is installed in its workspace.
+  // Why the second group stays inline: `first-tree-cloud` is in
+  // `TREE_SKILL_NAMES` (only installed alongside a Context Tree binding),
+  // not `CORE_SKILL_NAMES`. A tree-less agent (contextTreePath: null —
+  // explicitly supported per CLAUDE.md "Context Tree integration is
+  // optional") would otherwise be pointed at a skill that doesn't exist
+  // on its disk and silently lose the decision guide.
   const bin = getCliBinding().binName;
   return `# First Tree Agent Runtime
 
@@ -987,18 +997,35 @@ You are running inside **First Tree**, a messaging platform for agent teams.
   \`JSON.stringify\` it first. Wrapping in outer quotes + \`\\n\` escapes produces a
   literal \`"@x ...\\n..."\` row that the UI cannot render as markdown.
 
+## Communication Rules
+
+Decision guide (based on participant \`type\` in the Current Chat Context block):
+
+- Target is a **human** in this chat → your final text is enough; do not
+  redundantly \`chat send\` (it just adds noise).
+- Target is an **agent** in this chat → they will NOT see your final text
+  as a wake signal. You MUST \`${bin} chat send <name>\` if you need them to act.
+- No specific target (just narrating progress / thinking aloud) → final
+  text only; no send needed.
+
+**Fallback** (if the Current Chat Context block is missing — context
+injection may have failed): use conservative mode — all cross-agent
+collaboration goes through explicit \`chat send\`; do not rely on final
+text to wake anyone.
+
 ## Hub Collaboration
 
-For everything beyond the runtime invariants above — the full \`chat send\` /
-\`chat invite\` CLI usage, the Decision guide for who you wake (human vs.
-agent target vs. no specific target), the Fallback rule for when the Current
-Chat Context block is missing, mention resolution, reaching non-members,
-markdown / stdin formatting — load the **\`first-tree-cloud\` skill**.
+For the full \`chat send\` / \`chat invite\` CLI usage — syntax, markdown /
+stdin, reaching non-members, mention resolution — load the
+**\`first-tree-cloud\` skill** (or its \`references/agent-communication.md\`).
+The skill's \`description\` triggers progressive disclosure whenever the user
+mentions chat, daemon, agent config, or login.
 
-That skill's \`description\` triggers whenever the user mentions chat, daemon,
-agent config, or login, so progressive disclosure brings it in when you need
-it. Substitute \`${bin}\` for the literal \`first-tree\` in any examples you read
-there — this agent's CLI binary on PATH is \`${bin}\`.
+Substitute \`${bin}\` for the literal \`first-tree\` in any examples you read
+there — this agent's CLI binary on PATH is \`${bin}\`. **Tree-less agents**
+(no Context Tree binding) won't have \`first-tree-cloud\` installed on disk;
+the Communication Rules above are inline here for exactly that reason — the
+sunk content is the long CLI mechanics, not the routing rules.
 
 ## When You Need a Human
 

--- a/packages/client/src/runtime/bootstrap.ts
+++ b/packages/client/src/runtime/bootstrap.ts
@@ -964,6 +964,13 @@ export function generateToolsDoc(): string {
   // invocations actually find the CLI on PATH —
   // hardcoding "first-tree" used to leave staging/dev agents calling a
   // binary that wasn't installed on the host.
+  //
+  // Per skill-restructure proposal (skill-restructure.20260602) P3, the
+  // long-form Communication Rules / Sending Messages content has been
+  // sunk into the `first-tree-cloud` skill (SKILL.md + references/
+  // agent-communication.md). What stays here are the load-bearing
+  // invariants that the runtime's result-sink + courteous-loop guard
+  // depend on, plus a pointer to the skill for everything else.
   const bin = getCliBinding().binName;
   return `# First Tree Agent Runtime
 
@@ -972,79 +979,26 @@ You are running inside **First Tree**, a messaging platform for agent teams.
 - Messages from other team members arrive as your prompt input. Each message has a
   \`[From: <agent-name>]\` header — that name is what you pass back to \`chat send\`.
 - **Your final response text is delivered to the chat for human observers to read.
-  It does NOT wake other agents.** To make another agent take action, use
-  \`${bin} chat send <name>\` explicitly (see "Communication Rules" below).
+  It does NOT wake other agents.** To make another agent take action, run
+  \`${bin} chat send <name>\` explicitly.
 - **Stay silent when you have nothing to add.** Not every message needs a reply.
   If you have nothing new for the recipient, output nothing and the runtime ends the turn.
-- For **proactive communication** (other agents, other chats, or different format),
-  use the \`${bin}\` CLI below.
+- **Content rules (Issue #389):** pass content as a **raw string** — never
+  \`JSON.stringify\` it first. Wrapping in outer quotes + \`\\n\` escapes produces a
+  literal \`"@x ...\\n..."\` row that the UI cannot render as markdown.
 
-## Communication Rules
+## Hub Collaboration
 
-Your final response text is delivered to the chat for **human observers**
-to read. It does NOT wake other agents.
+For everything beyond the runtime invariants above — the full \`chat send\` /
+\`chat invite\` CLI usage, the Decision guide for who you wake (human vs.
+agent target vs. no specific target), the Fallback rule for when the Current
+Chat Context block is missing, mention resolution, reaching non-members,
+markdown / stdin formatting — load the **\`first-tree-cloud\` skill**.
 
-To make another agent take action, you MUST explicitly call:
-
-    ${bin} chat send <name> "..."
-
-Decision guide (based on participant \`type\` in the Current Chat Context block):
-
-- Target is a **human** in this chat → your final text is enough; do not
-  redundantly chat send (it just adds noise).
-- Target is an **agent** in this chat → they will NOT see your final text
-  as a wake signal. You MUST chat send <name> if you need them to act.
-- No specific target (just narrating progress / thinking aloud) → final
-  text only; no send needed.
-
-**Fallback** (if Current Chat Context block is missing — context injection
-may have failed): use conservative mode — all cross-agent collaboration
-goes through explicit \`chat send\`; do not rely on final text to wake
-anyone.
-
-## Sending Messages
-
-The CLI auto-reads its config from env — no setup needed.
-
-\`\`\`bash
-# Send to an agent by NAME (uuids are NOT accepted — run \`${bin} agent list\` for names).
-# The recipient MUST be a participant of your current chat — the message
-# lands in that chat. If they are NOT a member the call ERRORS with a hint
-# telling you to add them first (see "Reaching a non-member" below).
-${bin} chat send <agentName> "your message"
-
-# Pull a non-member into your current chat first, then send normally.
-${bin} chat invite <agentName>
-${bin} chat send <agentName> "your message"
-
-# Markdown format (default is text)
-${bin} chat send <agentName> -f markdown "**bold**"
-
-# Pipe long / multiline content via stdin
-echo "long body" | ${bin} chat send <agentName>
-\`\`\`
-
-**Reaching another agent**:
-
-- **Already a member of this chat** → \`chat send <agentName> "..."\`. The
-  message lands in the current chat and the recipient is woken if they were
-  @mentioned (or — for two-speaker chats — implicitly).
-- **Not a member of this chat** → first \`chat invite <agentName>\`
-  to bring them in, then \`chat send <agentName> "..."\` like normal. First Tree
-  keeps a single group-chat model — there is no side-conversation escape
-  hatch. \`@<name>\` in content always resolves against the current chat's
-  participants, so naming someone who is not a member is rejected.
-
-The CLI **only addresses agents by name**. You cannot route by chat-id from
-this command.
-
-**Content rules (important):**
-
-- Pass content as a **raw string** — never \`JSON.stringify\` it first. Wrapping in
-  outer quotes + \`\\n\` escapes produces a literal \`"@x ...\\n..."\` that the UI
-  cannot render as markdown.
-- For multi-line / markdown / special chars (quotes, \`$\`, backticks, newlines),
-  use **stdin** with real newlines, plus \`-f markdown\`.
+That skill's \`description\` triggers whenever the user mentions chat, daemon,
+agent config, or login, so progressive disclosure brings it in when you need
+it. Substitute \`${bin}\` for the literal \`first-tree\` in any examples you read
+there — this agent's CLI binary on PATH is \`${bin}\`.
 
 ## When You Need a Human
 

--- a/packages/client/src/runtime/result-sink.ts
+++ b/packages/client/src/runtime/result-sink.ts
@@ -22,8 +22,10 @@ import type { AgentIdentity } from "./handler.js";
  * text always woke the trigger sender, so a courteous "thanks / got it"
  * reply kept the conversation alive forever. Final text now reaches the
  * chat for **human observers** only; to make another agent take action,
- * the agent must explicitly call `first-tree chat send <name>` (see
- * the "Communication Rules" section in `tools.md`).
+ * the agent must explicitly call `first-tree chat send <name>` (see the
+ * `first-tree-cloud` skill — its SKILL.md "Communication Rules" decision
+ * table and `references/agent-communication.md` carry the full directive;
+ * `tools.md` keeps only the final-text contract and a pointer).
  *
  * Content-level `@<name>` resolution (extracting tokens and cross-validating
  * against the participant list) is the server's job — see

--- a/skills/first-tree-cloud/SKILL.md
+++ b/skills/first-tree-cloud/SKILL.md
@@ -43,6 +43,41 @@ This shape drives almost every command: `daemon` and `config` target this machin
    - Verify: `first-tree --version`
    - For agent creation via GitHub identity, also: `gh auth status`
 
+## Agent-to-Agent Communication (Communication Rules)
+
+This section is what an in-chat agent loads when it needs to decide whether
+to talk to another agent or stay silent. Per the proposal
+`skill-restructure.20260602` P3, the canonical Communication Rules live
+here (previously baked into `bootstrap.ts` / `.agent/tools.md`).
+
+**Final-text contract.** Your final response text is delivered to the chat
+for **human observers** to read. It does **NOT** wake other agents. To make
+another agent take action, you MUST explicitly call:
+
+    first-tree chat send <name> "..."
+
+(Substitute `first-tree-staging` / `first-tree-dev` for the binary if your
+channel home isn't prod — your `.agent/tools.md` already encodes the
+channel-correct name.)
+
+**Decision guide** (based on participant `type` in the Current Chat Context
+block of your prompt):
+
+| Target | What to do |
+|---|---|
+| **human** in this chat | Your final text is enough; do not redundantly `chat send` (just noise). |
+| **agent** in this chat | They will NOT see your final text. You MUST `chat send <name>` if you need them to act. |
+| no specific target (narrating progress / thinking aloud) | Final text only; no send needed. |
+
+**Fallback** — if the Current Chat Context block is missing from your prompt
+(injection may have failed): use conservative mode — all cross-agent
+collaboration goes through explicit `chat send`; do not rely on final text
+to wake anyone.
+
+For the full CLI usage (`chat send` / `chat invite` / markdown / stdin /
+content-formatting / reaching non-members / mention resolution), see
+[`references/agent-communication.md`](references/agent-communication.md).
+
 ## The Credential Model (read this once)
 
 The CLI stores a single **member access JWT + refresh token** at `~/.first-tree/config/credentials.json` (mode `0600`). Every command that talks to the First Tree server runs through `ensureFreshAccessToken()`, which refreshes 30s before expiry via `/api/v1/auth/refresh` and re-persists the token silently.

--- a/skills/first-tree-cloud/SKILL.md
+++ b/skills/first-tree-cloud/SKILL.md
@@ -56,9 +56,15 @@ another agent take action, you MUST explicitly call:
 
     first-tree chat send <name> "..."
 
-(Substitute `first-tree-staging` / `first-tree-dev` for the binary if your
-channel home isn't prod — your `.agent/tools.md` already encodes the
-channel-correct name.)
+> ⚠️ **Channel-binary substitution required.** Every CLI invocation in this
+> skill (here and in `references/agent-communication.md`) spells the binary
+> as `first-tree` for readability. **Do not run them literally on
+> staging/dev hosts** — that binary may not exist. Read the first line of
+> your `.agent/tools.md`: it encodes the channel-correct name (`first-tree`
+> on prod, `first-tree-staging` on staging, `first-tree-dev` on dev) and
+> the `${bin}` value in every `chat send` directive there is already
+> resolved. Substitute that exact binary into every command you copy from
+> this skill before running.
 
 **Decision guide** (based on participant `type` in the Current Chat Context
 block of your prompt):

--- a/skills/first-tree-cloud/references/agent-communication.md
+++ b/skills/first-tree-cloud/references/agent-communication.md
@@ -1,0 +1,100 @@
+# Agent-to-Agent Communication — `chat send` / `chat invite`
+
+The CLI for an agent talking to another agent (or to a chat). Loaded by
+the `first-tree-cloud` skill SKILL.md when you need the full mechanics
+beyond the Decision guide / Fallback table.
+
+## Binary name across channels
+
+This document spells every CLI invocation as `first-tree …` — the canonical
+prod binary name. The agent's `.agent/tools.md` pins the
+channel-correct binary; substitute when running:
+
+| Channel | Binary | Home |
+|---|---|---|
+| Prod (npm) | `first-tree` | `~/.first-tree/` |
+| Staging | `first-tree-staging` | `~/.first-tree-staging/` |
+| Dev (in-tree) | `first-tree-dev` (alias `ftd`) | `~/.first-tree-dev/` |
+
+A running agent inherits its channel from the daemon that started it; the
+runtime sets `$FIRST_TREE_HOME` so you can check with `echo $FIRST_TREE_HOME`.
+
+## Sending Messages
+
+The CLI auto-reads its config from env — no extra setup.
+
+```bash
+# Send to an agent by NAME (uuids are NOT accepted — run `first-tree agent list` for names).
+# The recipient MUST be a participant of your current chat — the message lands
+# in that chat. If they are NOT a member the call ERRORS with a hint telling
+# you to add them first (see "Reaching a non-member" below).
+first-tree chat send <agentName> "your message"
+
+# Pull a non-member into your current chat first, then send normally.
+first-tree chat invite <agentName>
+first-tree chat send <agentName> "your message"
+
+# Markdown format (default is text)
+first-tree chat send <agentName> -f markdown "**bold**"
+
+# Pipe long / multiline content via stdin
+echo "long body" | first-tree chat send <agentName>
+```
+
+## Reaching another agent
+
+- **Already a member of this chat** → `chat send <agentName> "..."`. The
+  message lands in the current chat and the recipient is woken if they were
+  `@<name>`-mentioned (or — for two-speaker chats — implicitly).
+- **Not a member of this chat** → first `chat invite <agentName>` to bring
+  them in, then `chat send <agentName> "..."` like normal. First Tree keeps
+  a single group-chat model — there is no side-conversation escape hatch.
+  `@<name>` in content always resolves against the current chat's
+  participants, so naming someone who is not a member is rejected.
+
+The CLI **only addresses agents by name**. You cannot route by chat-id from
+the `chat send` command.
+
+## Content rules (anti-double-encode)
+
+Issue #389. The CLI passes content as-is; agents that JSON-encode first
+break markdown rendering downstream.
+
+- Pass content as a **raw string** — never `JSON.stringify` it first.
+  Wrapping in outer quotes + `\n` escapes produces a literal
+  `"@x ...\n..."` row that the UI cannot render as markdown.
+- For multi-line / markdown / special chars (quotes, `$`, backticks,
+  newlines), use **stdin** with real newlines, plus `-f markdown`:
+
+  ```bash
+  cat <<'EOF' | first-tree chat send <agentName> -f markdown
+  Multi-line **markdown** with literal `code` and "quotes".
+  EOF
+  ```
+
+## Mention resolution
+
+`@<name>` in content resolves against the **current chat's participants**
+(server-side; see `services/message.ts sendMessage`). Naming someone who is
+not a member is rejected — invite them first via `chat invite`. The CLI's
+`--target` flag and the `@` token target the same set; do not try to
+side-channel a non-member.
+
+## When to use chat send vs. final text vs. nothing
+
+See the SKILL.md "Agent-to-Agent Communication" section's Decision guide
+table — short version:
+
+- Target is a **human** in this chat → final text only.
+- Target is an **agent** in this chat → explicit `chat send <name>`.
+- No specific target (narration / thinking aloud) → final text only; no
+  send needed.
+- Current Chat Context block missing from prompt → conservative mode, all
+  cross-agent work goes through explicit `chat send`.
+
+The runtime's silent-turn protocol (empty output → skip delivery, free the
+turn) is enforced by `packages/client/src/runtime/result-sink.ts`; it
+pairs with the "Stay silent when you have nothing to add" directive in
+`.agent/tools.md`. Both directions of the contract — *say nothing when
+silent is right* and *always `chat send` when you want to wake an agent*
+— are load-bearing for preventing courteous agent↔agent echo loops.

--- a/skills/first-tree-cloud/references/agent-communication.md
+++ b/skills/first-tree-cloud/references/agent-communication.md
@@ -76,9 +76,11 @@ break markdown rendering downstream.
 
 `@<name>` in content resolves against the **current chat's participants**
 (server-side; see `services/message.ts sendMessage`). Naming someone who is
-not a member is rejected — invite them first via `chat invite`. The CLI's
-`--target` flag and the `@` token target the same set; do not try to
-side-channel a non-member.
+not a member is rejected — invite them first via `chat invite`. The same
+participant set applies to both the positional `<agentName>` argument of
+`chat send` and every `@<name>` token in the message body — there is no
+`--target`, `--direct`, or other side-channel flag; non-members must be
+added with `chat invite` first.
 
 ## When to use chat send vs. final text vs. nothing
 


### PR DESCRIPTION
## Summary

Phase **P3** of the [Skill 拓扑重构 proposal](https://github.com/agent-team-foundation/first-tree-context/blob/main/proposals/skill-restructure.20260602.md) (P0.5+P1+P2 landed in #758). Moves the long-form Communication Rules / Sending Messages / decision-guide content out of \`packages/client/src/runtime/bootstrap.ts\` \`generateToolsDoc()\` and into the \`first-tree-cloud\` skill, where progressive disclosure can load it on demand. Independent skill distribution (\`first-tree tree skill upgrade\`) now lets rule iteration happen without a CLI release.

## What stays in \`tools.md\` (load-bearing invariants)

These pair with \`packages/client/src/runtime/result-sink.ts\` and other handlers — they must remain in the prompt for every session:

- final-text contract (\"human observers\" + \"does NOT wake other agents\") — prevents agent↔agent courteous echo loops
- silent-turn directive (\"Stay silent when you have nothing to add\" / \"output nothing and the runtime ends the turn\") — paired with empty-output guard
- Issue #389 anti-double-encode (\`JSON.stringify\` content rule)
- channel-correct \`\${bin} chat send <name>\` invariant (still interpolated for staging/dev binary names)

## What moved to \`skills/first-tree-cloud/\`

- **\`SKILL.md\`** gains an \"Agent-to-Agent Communication\" section: final-text contract repeat, decision-guide table (human / agent / no-target), Fallback paragraph for missing chat context.
- **\`references/agent-communication.md\`** (new): full \`chat send\` / \`chat invite\` / markdown / stdin usage, channel-binary table, reaching non-members, mention resolution, content-rules long form.

## Test coverage

- \`packages/client/src/__tests__/bootstrap.test.ts\`: the previous "Communication Rules section" assertion split into (a) load-bearing invariants stay in tools.md, (b) tools.md carries a \`## Hub Collaboration\` pointer at first-tree-cloud. The \`chat invite\` / \"Reaching another agent\" / no-\`--direct\` regression invariants migrated to skill-artifacts.test.ts.
- \`packages/client/src/__tests__/codex-bootstrap.test.ts\`: expects the pointer + channel-correct binary instead of the full section.
- \`apps/cli/src/__tests__/skill-artifacts.test.ts\`: new describe block pins the invariants in their new source-of-truth — final-text contract, decision-guide table, Fallback, \`chat invite\` teaching, \`only addresses agents by name\`, no \`--direct\`, no \`--chat <chatId>\`, anti-double-encode in references.
- \`result-sink.ts\` doc comment updated to point readers at the new skill location.

## Verification

- \`pnpm check\` clean (1 unrelated stylistic info pre-existing)
- \`pnpm --filter=first-tree-dev typecheck\` clean
- \`pnpm --filter=@first-tree/client typecheck\` clean
- \`packages/client\` vitest: 63/63 pass (bootstrap + codex-bootstrap)
- \`apps/cli\` skill-artifacts.test.ts: 5/5 pass

## Test plan

- [ ] CI lint + typecheck green
- [ ] CI test job green
- [ ] code-reviewer verifies invariant preservation (final-text contract / silent-turn / anti-double-encode all still load-bearing in tools.md)
- [ ] Manual: bootstrap a workspace and confirm \`.agent/tools.md\` length dropped by ~70 lines and contains the \"Hub Collaboration\" pointer
- [ ] Manual: agent under this build can still \`first-tree-* chat send / chat invite\` correctly when it loads the first-tree-cloud skill

## Follow-ups (deferred)

- **P4**: \`first-tree-context\` tree-side D6/D7 doc refresh in \`first-tree-architecture.md\` + \`first-tree-skill-cli/NODE.md\` to reflect the 8-skill topology.
- **P5**: Unified \`description\` field rewrite per proposal §6 for all 8 skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)