### PR TITLE
fix(web): tune conversation list rail visuals

### DIFF
--- a/packages/web/src/components/chat/chat-row-avatar.tsx
+++ b/packages/web/src/components/chat/chat-row-avatar.tsx
@@ -214,9 +214,9 @@ export function ChatRowAvatar({
 /** Avatar top-right corner marker geometry (no design token covers a one-off
  *  badge; named here for self-documentation, matching `CORNER_BADGE_SIZE`).
  *  `DOT` = plain unread dot; `MARK` = the slightly larger failed glyph badge. */
-const CORNER_DOT_SIZE = 11;
-const CORNER_MARK_SIZE = 15;
-const CORNER_OFFSET = -3;
+const CORNER_DOT_SIZE = 9;
+const CORNER_MARK_SIZE = 13;
+const CORNER_OFFSET = -2;
 
 /**
  * Conversation-list corner marker (mainstream-IM placement: avatar top-right).

--- a/packages/web/src/pages/workspace/conversations/__tests__/conversation-list-dom.test.tsx
+++ b/packages/web/src/pages/workspace/conversations/__tests__/conversation-list-dom.test.tsx
@@ -328,9 +328,7 @@ describe("ConversationList", () => {
     await click([...document.body.querySelectorAll("button")].find((button) => button.textContent === "Done") ?? null);
 
     await click(container.querySelector('button[aria-haspopup="listbox"]'));
-    await click(
-      [...document.body.querySelectorAll("button")].find((button) => button.textContent === "By time") ?? null,
-    );
+    await click([...document.body.querySelectorAll("button")].find((button) => button.textContent === "Time") ?? null);
     expect(container.textContent).toContain("Older");
 
     await click(container.querySelector('button[aria-label="Filter"]'));

--- a/packages/web/src/pages/workspace/conversations/filter-popover.tsx
+++ b/packages/web/src/pages/workspace/conversations/filter-popover.tsx
@@ -29,8 +29,8 @@ export function originLabel(source: ChatSource): string {
  * popover — grouping is a view-mode preference, not a daily-touch control.
  */
 export const GROUP_OPTIONS: ReadonlyArray<{ value: GroupMode; label: string }> = [
-  { value: "recency", label: "By time" },
-  { value: "source", label: "By source" },
+  { value: "recency", label: "Time" },
+  { value: "source", label: "Source" },
 ];
 
 type FilterPopoverProps = {

--- a/packages/web/src/pages/workspace/conversations/index.tsx
+++ b/packages/web/src/pages/workspace/conversations/index.tsx
@@ -360,10 +360,7 @@ export function ConversationList({
       <div className="shrink-0 flex flex-col" style={{ borderBottom: "var(--hairline) solid var(--border-faint)" }}>
         {/* Row 1 — primary action (New chat) + filter entry (⚙). Kept on
             its own line so it never crowds against the filter triad. */}
-        <div
-          className="flex items-center"
-          style={{ gap: "var(--sp-1)", padding: "var(--sp-2_5) var(--sp-3) var(--sp-2)" }}
-        >
+        <div className="flex items-center" style={{ gap: "var(--sp-1)", padding: "var(--sp-2_5) var(--sp-3)" }}>
           <button
             type="button"
             onClick={onNewChat}
@@ -554,7 +551,7 @@ export function ConversationList({
                           selfAgentId={selfAgentId ?? ""}
                           unreadCount={row.unreadMentionCount}
                           failed={failed}
-                          size={28}
+                          size={26}
                           muted
                           badge={false}
                           statusDot
@@ -562,8 +559,8 @@ export function ConversationList({
                         <span
                           className="truncate text-subtitle"
                           style={{
-                            color: "var(--fg)",
-                            fontWeight: hasUnread ? 700 : 600,
+                            color: hasUnread || isSelected ? "var(--fg)" : "var(--fg-2)",
+                            fontWeight: hasUnread ? 700 : 500,
                             flex: 1,
                             minWidth: 0,
                           }}
@@ -635,7 +632,7 @@ export function ConversationList({
 }
 
 /**
- * Header Group-by dropdown on the filter row (`By time` / `By source`).
+ * Header Group-by dropdown on the filter row (`Time` / `Source`).
  * Group-by is a visible header control — more discoverable, and doubles as a
  * soft filter via grouping — so the `⚙` popover holds only Status + Source.
  * Headless `Popover` + listbox semantics, matching the rail's de-chipped
@@ -665,10 +662,10 @@ function GroupDropdown({ group, onGroupChange }: { group: GroupMode; onGroupChan
             color: "var(--fg-2)",
           }}
         >
-          {/* Grouping-mode icon replaces the redundant "Group" word prefix
-              (was "Group By time" — Group + By read as duplicated). */}
+          {/* Grouping-mode icon carries the "group by" affordance; the visible
+              label stays compact (`Time` / `Source`) for the narrow rail. */}
           <ListTree size={13} strokeWidth={1.75} style={{ color: "var(--fg-4)" }} aria-hidden />
-          <span>{current?.label ?? "By time"}</span>
+          <span>{current?.label ?? "Time"}</span>
           <ChevronDown size={12} strokeWidth={1.75} />
         </button>
       )}


### PR DESCRIPTION
Follow-up to #739 after reviewing the conversation list rail in the workspace preview.

## Changes
- Reduce chat-list avatar size from 28px to 26px.
- Scale the list-only avatar corner markers down with the smaller avatar.
- Lower read-row title weight and color so unread rows remain the primary emphasis.
- Add a small amount of spacing between the header action row and the filter row.
- Shorten group labels from `By time` / `By source` to `Time` / `Source` while keeping `Group by` accessible labeling.

## Validation
- `pnpm --filter @first-tree/web typecheck`
- `pnpm --filter @first-tree/web test -- src/pages/workspace/conversations/__tests__/conversation-list-dom.test.tsx` (ran the web suite: 92 files / 614 tests)
- `git diff --check`