### PR TITLE
fix(test): unbreak main — only flag retired --direct flag inside code blocks

### DIFF
--- a/apps/cli/src/__tests__/skill-artifacts.test.ts
+++ b/apps/cli/src/__tests__/skill-artifacts.test.ts
@@ -56,10 +56,19 @@ describe("skill artifacts", () => {
       expect(referenceMd).toMatch(/recipient MUST be a participant/);
       expect(referenceMd).toMatch(/Reaching another agent/);
       expect(referenceMd).toMatch(/only addresses agents by name/);
-      // The retired escape hatches must NOT be taught.
-      expect(referenceMd).not.toMatch(/--direct/);
-      expect(referenceMd).not.toMatch(/--chat <chatId>/);
-      expect(referenceMd).not.toMatch(/--chat <directChatId>/);
+      // The retired escape hatches must NOT be taught. The doc may still
+      // mention `--direct` (or the other retired flags) in prose to
+      // redirect agents that learned the old form ("no `--direct` flag
+      // exists; use `chat invite` instead"). Only flag them when they
+      // appear inside a fenced code block — that's where copy-execute
+      // happens, and that's what makes a flag "taught" rather than
+      // "described".
+      const codeBlocks = referenceMd.match(/```[\s\S]*?```/gu) ?? [];
+      for (const block of codeBlocks) {
+        expect(block).not.toMatch(/--direct\b/u);
+        expect(block).not.toMatch(/--chat <chatId>/u);
+        expect(block).not.toMatch(/--chat <directChatId>/u);
+      }
       // Anti-double-encode (Issue #389) — the long form lives here; tools.md
       // also pins the one-line invariant.
       expect(referenceMd).toContain("JSON.stringify");


### PR DESCRIPTION
## Summary

Quick fix for the test job that has been failing on every PR (including #762) since PR #763 (\`ac1ddbb4\`) landed.

PR #763 sunk Communication Rules into the \`first-tree-cloud\` skill, including a prose paragraph mentioning \`--direct\` to redirect agents that learned the retired form:

> "non-members must be added with \`chat invite\` first … no \`--target\`, \`--direct\`, or other side-channel flag"

The \`skill-artifacts.test.ts\` invariant asserted \`expect(referenceMd).not.toMatch(/--direct/)\` against the whole file, so the new prose mention trips it.

The test's intent — **don't TEACH \`--direct\`** — is still right; the assertion's blast radius is what's wrong. Tightened it to only flag the retired flags when they appear inside fenced code blocks (where copy-execute happens), so describing them in prose stays allowed.

## Test plan

- [x] \`pnpm --filter ./apps/cli exec vitest run src/__tests__/skill-artifacts.test.ts\` — 5/5 pass on this branch
- [x] \`pnpm --filter ./apps/cli typecheck\` — clean
- [x] \`pnpm check\` — clean
- [ ] CI green