### PR TITLE
fix(web): soften conversation list avatar hues

### DIFF
--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -339,7 +339,7 @@
 
   /* Muted (low-chroma) companions of the avatar hues. Same lightness +
      hue angle as their vivid sibling — only the chroma is dropped to a
-     uniform ~0.06 — so identity stays recognisable (you can still tell
+     uniform ~0.05 — so identity stays recognisable (you can still tell
      the green agent from the blue one) while the disc reads as a quiet
      tinted neutral rather than a saturated swatch. The conversation
      list uses these (`muted` path in `pickAvatarHue` /
@@ -348,14 +348,14 @@
      where only a few appear at once. Lightness is unchanged, so the
      near-white `--fg-on-vivid` initials keep the same AA contrast as on
      the vivid set. */
-  --avatar-hue-0-muted: oklch(0.66 0.06 150);
-  --avatar-hue-1-muted: oklch(0.62 0.06 250);
-  --avatar-hue-2-muted: oklch(0.6 0.06 295);
-  --avatar-hue-3-muted: oklch(0.65 0.06 0);
-  --avatar-hue-4-muted: oklch(0.68 0.06 50);
-  --avatar-hue-5-muted: oklch(0.65 0.06 200);
-  --avatar-hue-6-muted: oklch(0.72 0.06 90);
-  --avatar-hue-7-muted: oklch(0.55 0.06 270);
+  --avatar-hue-0-muted: oklch(0.66 0.05 150);
+  --avatar-hue-1-muted: oklch(0.62 0.05 250);
+  --avatar-hue-2-muted: oklch(0.6 0.05 295);
+  --avatar-hue-3-muted: oklch(0.65 0.05 0);
+  --avatar-hue-4-muted: oklch(0.68 0.05 50);
+  --avatar-hue-5-muted: oklch(0.65 0.05 200);
+  --avatar-hue-6-muted: oklch(0.72 0.05 90);
+  --avatar-hue-7-muted: oklch(0.55 0.05 270);
 
   --radius: 0.5rem;
 

--- a/packages/web/src/pages/team/__tests__/team-page-dom.test.tsx
+++ b/packages/web/src/pages/team/__tests__/team-page-dom.test.tsx
@@ -453,6 +453,7 @@ function seedDefaultMocks(): void {
 
 beforeEach(() => {
   document.body.innerHTML = "";
+  window.localStorage.clear();
   installBrowserStubs();
   vi.clearAllMocks();
   routerMocks.navigate.mockClear();
@@ -588,6 +589,25 @@ describe("TeamPage", () => {
     await click(container.querySelector('button[aria-label="Actions for Ops Helper"]'));
     await waitForText(container, "Chat");
     expect(exactButton(container, "Suspend")).toBeNull();
+
+    await act(async () => root.unmount());
+  });
+
+  it("remembers the agent filter preference", async () => {
+    window.localStorage.setItem("first-tree:team-agent-filter:v1", "mine");
+    const { TeamPage } = await import("../index.js");
+    const { container, root } = await renderDom(<TeamPage />);
+
+    await waitForText(container, "Kael");
+    expect(exactButton(container, "Mine")?.getAttribute("aria-pressed")).toBe("true");
+    expect(container.textContent).not.toContain("Ops Helper");
+
+    await click(exactButton(container, "All"));
+    expect(window.localStorage.getItem("first-tree:team-agent-filter:v1")).toBe("all");
+    expect(exactButton(container, "All")?.getAttribute("aria-pressed")).toBe("true");
+
+    await click(exactButton(container, "Mine"));
+    expect(window.localStorage.getItem("first-tree:team-agent-filter:v1")).toBe("mine");
 
     await act(async () => root.unmount());
   });

--- a/packages/web/src/pages/team/index.tsx
+++ b/packages/web/src/pages/team/index.tsx
@@ -74,6 +74,26 @@ type AgentLifecycleTarget = {
 
 const AGENT_PAGE_SIZE = 100;
 const MAX_AGENT_PAGES = 100;
+const AGENT_FILTER_STORAGE_KEY = "first-tree:team-agent-filter:v1";
+
+function readAgentFilterPreference(): AgentFilter {
+  if (typeof window === "undefined") return "all";
+  try {
+    const stored = window.localStorage?.getItem?.(AGENT_FILTER_STORAGE_KEY);
+    return stored === "mine" ? "mine" : "all";
+  } catch {
+    return "all";
+  }
+}
+
+function writeAgentFilterPreference(next: AgentFilter): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage?.setItem?.(AGENT_FILTER_STORAGE_KEY, next);
+  } catch {
+    // Preference storage is best-effort; the current in-memory filter still works.
+  }
+}
 
 export async function fetchAllAgents(
   fetchPage: (params: { limit: number; cursor?: string }) => Promise<{ items: Agent[]; nextCursor: string | null }>,
@@ -99,7 +119,7 @@ export function TeamPage() {
   const [inviteOpen, setInviteOpen] = useState(false);
   const [createOpen, setCreateOpen] = useState(false);
   const [editTarget, setEditTarget] = useState<MemberEditTarget | null>(null);
-  const [agentFilter, setAgentFilter] = useState<AgentFilter>("all");
+  const [agentFilter, setAgentFilter] = useState<AgentFilter>(() => readAgentFilterPreference());
   const [suspendTarget, setSuspendTarget] = useState<AgentLifecycleTarget | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<AgentLifecycleTarget | null>(null);
   const [query, setQuery] = useState("");
@@ -208,6 +228,10 @@ export function TeamPage() {
   });
 
   const search = query.trim().toLowerCase();
+  const handleAgentFilterChange = (next: AgentFilter) => {
+    setAgentFilter(next);
+    writeAgentFilterPreference(next);
+  };
   const { publicAgents, privateAgents, humans, agentCount } = useMemo(
     () =>
       buildTeamData({
@@ -338,7 +362,7 @@ export function TeamPage() {
             }
             searchActive={search.length > 0}
             agentFilter={agentFilter}
-            onAgentFilter={setAgentFilter}
+            onAgentFilter={handleAgentFilterChange}
           />
         )}
       </div>

--- a/packages/web/src/pages/workspace/conversations/__tests__/conversation-list-dom.test.tsx
+++ b/packages/web/src/pages/workspace/conversations/__tests__/conversation-list-dom.test.tsx
@@ -376,4 +376,29 @@ describe("ConversationList", () => {
     const draft = await renderDom(<StatefulList selectedChatId={DRAFT_CHAT_ID} nextCursor={null} />);
     expect(buttonByText(draft, "New chat").getAttribute("aria-current")).toBe("page");
   });
+
+  it("keeps the unread filter selected when there are no unread chats", async () => {
+    const readOnlyRows = [row({ chatId: "chat-read", title: "Read chat" })];
+    const container = await renderDom(
+      <StatefulList rows={readOnlyRows} nextCursor={null} />,
+      createClient(readOnlyRows, null),
+    );
+
+    expect(buttonByText(container, "Unread").getAttribute("aria-pressed")).toBe("false");
+
+    await click(buttonByText(container, "Unread"));
+
+    expect(meChatMocks.listMeChats).toHaveBeenCalledWith({
+      filter: "unread",
+      engagement: "active",
+      watching: undefined,
+      origin: undefined,
+      with: undefined,
+    });
+    expect(buttonByText(container, "Unread").getAttribute("aria-pressed")).toBe("true");
+    expect(buttonByText(container, "All").getAttribute("aria-pressed")).toBe("false");
+    expect(container.textContent).toContain("No unread conversations.");
+    expect(container.textContent).toContain("All caught up.");
+    expect(container.textContent).not.toContain("Start with New chat.");
+  });
 });

--- a/packages/web/src/pages/workspace/conversations/index.tsx
+++ b/packages/web/src/pages/workspace/conversations/index.tsx
@@ -292,15 +292,21 @@ export function ConversationList({
 
   const totalUnread = useMemo(() => allRows.reduce((acc, r) => acc + (r.unreadMentionCount > 0 ? 1 : 0), 0), [allRows]);
   const isDraftActive = selectedChatId === DRAFT_CHAT_ID;
-
-  // Auto-recover from the unread-filter dead-end: when the user reads
-  // every unread chat, the visible list collapses to zero and there's
-  // no signal to switch back. Flip the triad back to `all` for them.
-  useEffect(() => {
-    if (railFilter === "unread" && totalUnread === 0 && data && !isLoading) {
-      onRailFilterChange("all");
+  // The chip row mirrors only origin + participants (the removable
+  // multi-selects). Scope is surfaced by the popover badge, not a chip.
+  const hasActiveChips = origin.length > 0 || participants.length > 0;
+  const emptyCopy = (() => {
+    if (railFilter === "unread") {
+      return { title: "No unread conversations.", detail: "All caught up." };
     }
-  }, [railFilter, totalUnread, data, isLoading, onRailFilterChange]);
+    if (railFilter === "watching") {
+      return { title: "No watched conversations.", detail: "Switch to All to see active conversations." };
+    }
+    if (hasActiveChips || engagement !== "active") {
+      return { title: "No matching conversations.", detail: "Clear filters to see more conversations." };
+    }
+    return { title: "No conversations yet.", detail: "Start with New chat." };
+  })();
 
   const isBucketCollapsed = (key: string, defaultCollapsed: boolean): boolean => {
     const override = bucketCollapse.get(key);
@@ -325,9 +331,6 @@ export function ConversationList({
   // header: origin, participants, and a non-default scope. The primary
   // triad (unread / watching) lives in the header and is not counted here.
   const popoverFilterCount = origin.length + participants.length + (engagement !== "active" ? 1 : 0);
-  // The chip row mirrors only origin + participants (the removable
-  // multi-selects). Scope is surfaced by the popover badge, not a chip.
-  const hasActiveChips = origin.length > 0 || participants.length > 0;
 
   const resolveAgentName = useAgentNameMap();
 
@@ -480,9 +483,9 @@ export function ConversationList({
         )}
         {!isLoading && allRows.length === 0 && (
           <div className="text-center text-body" style={{ padding: "var(--sp-6) var(--sp-3)", color: "var(--fg-3)" }}>
-            <p style={{ margin: 0 }}>No conversations yet.</p>
+            <p style={{ margin: 0 }}>{emptyCopy.title}</p>
             <p className="text-label" style={{ margin: "var(--sp-1) 0 0", color: "var(--fg-4)" }}>
-              Start with New chat.
+              {emptyCopy.detail}
             </p>
           </div>
         )}


### PR DESCRIPTION
## Summary
- lower muted conversation-list avatar chroma from ~0.06 to ~0.05
- remember the Team page All/Mine filter preference locally
- keep the conversation-list Unread filter selectable when it has no results, with filter-aware empty copy

## Validation
- pnpm --filter @first-tree/web test -- src/pages/workspace/conversations/__tests__/conversation-list-dom.test.tsx src/pages/team/__tests__/team-page-dom.test.tsx
- pnpm check
- pnpm typecheck
- node scripts/check-migrations.mjs
- git diff --check