### PR TITLE
refactor(web): simplify Context tab — drop BY AGENT, refine signal copy

### DIFF
--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -1117,64 +1117,6 @@
   gap: var(--sp-2);
 }
 
-.context-io-agents {
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  gap: var(--sp-1);
-}
-
-.context-io-agents-header {
-  display: grid;
-  grid-template-columns: 1fr auto;
-  gap: var(--sp-2);
-  padding: 0 var(--sp-3);
-  color: var(--fg-3);
-  font-size: 11px;
-  font-weight: 700;
-  text-transform: uppercase;
-}
-
-.context-io-agents-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-}
-
-.context-io-agent-row {
-  display: grid;
-  grid-template-columns: 22px minmax(0, 1fr) auto;
-  align-items: center;
-  gap: var(--sp-1_5);
-  padding: var(--sp-1_5) var(--sp-3);
-  border-top: var(--hairline) solid var(--border);
-}
-
-.context-io-agent-main {
-  min-width: 0;
-  display: flex;
-  align-items: baseline;
-  gap: var(--sp-1);
-  overflow: hidden;
-}
-
-.context-io-agent-main > span:first-child {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.context-io-agent-counts {
-  display: flex;
-  align-items: center;
-  gap: var(--sp-2);
-  color: var(--fg-2);
-  font-size: 12px;
-  font-variant-numeric: tabular-nums;
-}
-
 .context-usage-feed-header {
   display: flex;
   align-items: center;

--- a/packages/web/src/pages/__tests__/context-page-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/context-page-dom.test.tsx
@@ -187,9 +187,9 @@ describe("ContextPage DOM behavior", () => {
     expect(container.textContent).toContain("LIVE");
     expect(container.textContent).toContain("Tree sync is stale.");
     expect(container.textContent).toContain("4 agents");
-    expect(container.textContent).toContain("18 reads");
+    expect(container.textContent).toContain("read the tree 18 times");
     expect(container.textContent).toContain("2 agents");
-    expect(container.textContent).toContain("5 writes");
+    expect(container.textContent).toContain("wrote 5 times");
     expect(container.textContent).toContain("23total nodes");
     expect(container.textContent).toContain("+6 updates");
     expect(container.textContent).toContain("QB");
@@ -242,7 +242,7 @@ describe("ContextPage DOM behavior", () => {
 
     const { container, root } = await renderDom(<ContextPage previewSnapshot={empty} />);
     expect(container.textContent).toContain("No context updates in the past 7 days.");
-    expect(container.textContent).toContain("No explicit Context Tree read/write recorded in the last 7 days.");
+    expect(container.textContent).toContain("No Context Tree reads or writes in the past 7 days.");
     // LIVE reflects the tree's sync liveness, not usage: a synced (active)
     // snapshot shows the header LIVE chip even with zero reads/writes / no
     // events (the streaming IO feed is what hides when empty).

--- a/packages/web/src/pages/context.tsx
+++ b/packages/web/src/pages/context.tsx
@@ -80,7 +80,6 @@ export function ContextPage({ previewSnapshot }: { previewSnapshot?: ContextTree
                 }}
               />
               <ContextSignal snapshot={snapshot} />
-              <ContextIoByAgent snapshot={snapshot} />
               <ContextUsageFeed snapshot={snapshot} />
             </>
           )
@@ -227,15 +226,15 @@ function ContextSignal({ snapshot }: { snapshot: ContextTreeSnapshot }) {
     snapshot.io.summary.read.agentCount === 1 ? "1 agent" : `${snapshot.io.summary.read.agentCount} agents`;
   const writeAgentText =
     snapshot.io.summary.write.agentCount === 1 ? "1 agent" : `${snapshot.io.summary.write.agentCount} agents`;
-  const readText =
-    snapshot.io.summary.read.eventCount === 1 ? "1 read" : `${snapshot.io.summary.read.eventCount} reads`;
-  const writeText =
-    snapshot.io.summary.write.eventCount === 1 ? "1 write" : `${snapshot.io.summary.write.eventCount} writes`;
+  const readTimesText =
+    snapshot.io.summary.read.eventCount === 1 ? "1 time" : `${snapshot.io.summary.read.eventCount} times`;
+  const writeTimesText =
+    snapshot.io.summary.write.eventCount === 1 ? "1 time" : `${snapshot.io.summary.write.eventCount} times`;
 
   if (snapshot.io.summary.read.eventCount === 0 && snapshot.io.summary.write.eventCount === 0) {
     return (
       <div className="text-body context-signal" style={{ color: "var(--fg-3)" }}>
-        <span>No explicit Context Tree read/write recorded in the last {windowText}.</span>
+        <span>No Context Tree reads or writes in the past {windowText}.</span>
       </div>
     );
   }
@@ -243,46 +242,12 @@ function ContextSignal({ snapshot }: { snapshot: ContextTreeSnapshot }) {
   return (
     <div className="text-body context-signal" style={{ color: "var(--fg-3)" }}>
       <span>
-        In the last {windowText}, <mark>{readAgentText}</mark>
+        In the past {windowText}, <mark>{readAgentText}</mark> read the tree <mark>{readTimesText}</mark>
       </span>
       <span>
-        made <mark>{readText}</mark> and <mark>{writeAgentText}</mark> made <mark>{writeText}</mark>.
+        and <mark>{writeAgentText}</mark> wrote <mark>{writeTimesText}</mark>.
       </span>
     </div>
-  );
-}
-
-function ContextIoByAgent({ snapshot }: { snapshot: ContextTreeSnapshot }) {
-  const agents = snapshot.io.agents.slice(0, 8);
-  if (agents.length === 0) return null;
-
-  return (
-    <section className="context-io-agents" aria-label="Context Tree IO by agent">
-      <div className="context-io-agents-header">
-        <span>By agent</span>
-        <span>Explicit IO</span>
-      </div>
-      <ul className="context-io-agents-list">
-        {agents.map((agent) => {
-          const hue = resolveAvatarHue(agent.agentAvatarColorToken, agent.agentId);
-          return (
-            <li key={agent.agentId} className="context-io-agent-row">
-              <span className="context-usage-feed-avatar" aria-hidden="true" style={{ background: hue }}>
-                {agentInitials(agent.agentName)}
-              </span>
-              <span className="context-io-agent-main">
-                <span className="context-usage-feed-agent">{agent.agentName}</span>
-                <span className="context-usage-feed-action">{agent.runtimeProvider}</span>
-              </span>
-              <span className="context-io-agent-counts">
-                <span>{formatNumber(agent.readCount)} read</span>
-                <span>{formatNumber(agent.writeCount)} write</span>
-              </span>
-            </li>
-          );
-        })}
-      </ul>
-    </section>
   );
 }
 


### PR DESCRIPTION
## What

Trims the Context tab to its essentials and smooths the summary copy.

**1. Remove the BY AGENT IO table (`ContextIoByAgent`).** It restated the same "who read/wrote how much" that the `ContextSignal` one-liner directly above it already conveys. With it gone the page reads cleanly top-to-bottom: **change map → one-line signal → LIVE feed**.
- Dropped the component + its call site, and the 6 sole-use CSS classes (`.context-io-agents*`).
- `snapshot.io.agents` is no longer read on the web side. The `@first-tree/shared` type is intentionally **left untouched** (front-end stops consuming it only).

**2. Refine `ContextSignal` copy** for a smoother, consistent voice:
- Unify the window phrasing on **"past 7 days"** (was "last").
- `made N reads/writes` → **`read the tree N times`** / **`wrote N times`**, keeping singular handling for both agents and times (`1 agent`, `1 time`).
- Empty state → `No Context Tree reads or writes in the past 7 days.`
- Highlighted numbers still use `<mark>`.

Synced the Context DOM test assertions to the new copy.

## Scope

3 files, all under `packages/web`: `pages/context.tsx`, `index.css`, `pages/__tests__/context-page-dom.test.tsx`. No backend / shared changes.

## Verification

- `pnpm --filter @first-tree/web typecheck` (tsc + lint:tokens) ✓
- biome clean ✓
- 616 web tests pass ✓
- `/preview/context` verified in **light + dark**: BY AGENT gone, new signal renders correctly, LIVE feed unchanged.

## Review

Reviewed PASS (independent reviewer + manual, covering dead-code/leftover refs, singular-plural edges, test/i18n blast radius, backend scope). Two optional nits noted and deferred as out-of-scope (both pre-existing, non-regressions): the mixed-zero phrasing ("0 agents … 0 times") and the untested `1 time` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)