### PR TITLE
refactor(web): tighten conversation list row spacing

### DIFF
--- a/packages/web/src/pages/chat-row-avatar-preview.tsx
+++ b/packages/web/src/pages/chat-row-avatar-preview.tsx
@@ -261,7 +261,7 @@ function PreviewCard({ name, row }: { name: string; row: MeChatRow }) {
         className="w-full text-left flex items-center"
         style={{
           padding: "var(--sp-2) var(--sp-3)",
-          gap: "var(--sp-2_5)",
+          gap: "var(--sp-2)",
           background: "transparent",
           borderLeft: "var(--hairline-bold) solid transparent",
           width: 320,

--- a/packages/web/src/pages/workspace/conversations/index.tsx
+++ b/packages/web/src/pages/workspace/conversations/index.tsx
@@ -535,11 +535,12 @@ export function ConversationList({
                           "hover:bg-[var(--bg-hover)]",
                         )}
                         style={{
-                          // Single-line rows, but with comfortable vertical
-                          // breathing room (--sp-2_5) so the list doesn't read as
-                          // a dense wall — still well under the old two-line row.
-                          padding: "var(--sp-2_5) var(--sp-3)",
-                          gap: "var(--sp-2_5)",
+                          // Single-line rows tuned for desktop-inbox density:
+                          // tightened vertical padding (--sp-2) now that the
+                          // preview subtitle line is gone, so more conversations
+                          // fit per screen without reading as a dense wall.
+                          padding: "var(--sp-2) var(--sp-3)",
+                          gap: "var(--sp-2)",
                           background: isSelected ? "var(--brand-bg)" : "transparent",
                           // Left bar is the SELECTED affordance only (DESIGN.md:
                           // selected = green left-rail + tint). Attention no longer


### PR DESCRIPTION
## What

Tightens the workspace conversation-list (left rail) row spacing now that #739 collapsed rows to a single line.

- Conversation row vertical padding `--sp-2_5` (10px) → `--sp-2` (8px); horizontal `--sp-3` (12px) unchanged.
- Avatar↔title `gap` `--sp-2_5` → `--sp-2`.
- `chat-row-avatar-preview.tsx` gap synced to `--sp-2` so its "mirror production geometry verbatim" comment holds (its padding was already `--sp-2`).

Row height drops ~46px → ~42px, fitting a couple more conversations per screen — better for a desktop inbox. `conversation-list-preview.tsx` needs no change: it renders the real `ConversationList`.

## Why

Single-line rows inherited the two-line era's padding, so the list read loose after the preview subtitle line was removed.

## Out of scope (intentionally unchanged)

- Title read/unread font-weight (`hasUnread ? 700 : 500`).
- DESIGN.md.

## Verification

- ✅ `pnpm --filter @first-tree/web typecheck` (tsc + `lint:tokens`) — design-token guardrails clean, all values via spacing tokens, no magic numbers.
- ✅ `pnpm --filter @first-tree/web test` — 616 passed / 92 files; no snapshot updates needed (conversation-list-dom does not assert on spacing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)