### PR TITLE
Track Context Tree shell reads

### DIFF
--- a/packages/client/src/__tests__/claude-code-tool-events.test.ts
+++ b/packages/client/src/__tests__/claude-code-tool-events.test.ts
@@ -412,17 +412,52 @@ describe("createToolCallProcessor — Context Tree file refs", () => {
     expect(usageEventCount(emit)).toBe(0);
   });
 
-  it("does NOT attach file refs for unsupported tools even if an arg path is under the tree", () => {
+  it("attaches file refs when Bash reads a Context Tree file", () => {
     const emit = vi.fn<(event: SessionEvent) => void>();
-    const processor = createToolCallProcessor(emit, binding);
+    const processor = createToolCallProcessor(emit, { ...binding, branch: "main" }, { cwd: "/home/op/project" });
 
-    processor.onMessage(
-      assistantToolUse("r7", "Bash", { command: `cat ${TREE}/NODE.md`, file_path: `${TREE}/NODE.md` }),
-    );
+    processor.onMessage(assistantToolUse("r7", "Bash", { command: `cat ${TREE}/NODE.md` }));
     processor.onMessage(userToolResult("r7", "contents"));
 
     const final = toolCallEvents(emit).find(
       (event) => event.payload.toolUseId === "r7" && event.payload.status === "ok",
+    );
+    expect(final?.payload.toolFileRefs).toEqual([
+      {
+        origin: "tool_arg",
+        localPath: `${TREE}/NODE.md`,
+        repoUrl: "https://github.com/example/tree",
+        repoBranch: "main",
+        repoRelativePath: "NODE.md",
+        pathKind: "file",
+      },
+    ]);
+    expect(usageEventCount(emit)).toBe(0);
+  });
+
+  it("does NOT attach Bash file refs when the shell command fails", () => {
+    const emit = vi.fn<(event: SessionEvent) => void>();
+    const processor = createToolCallProcessor(emit, binding, { cwd: "/home/op/project" });
+
+    processor.onMessage(assistantToolUse("r7-fail", "Bash", { command: `cat ${TREE}/NODE.md` }));
+    processor.onMessage(userToolResult("r7-fail", "ENOENT", true));
+
+    const final = toolCallEvents(emit).find(
+      (event) => event.payload.toolUseId === "r7-fail" && event.payload.status === "error",
+    );
+    expect(final?.payload.toolFileRefs).toBeUndefined();
+    expect(usageEventCount(emit)).toBe(0);
+  });
+
+  it("does NOT attach file refs for unsupported tools even if an arg path is under the tree", () => {
+    const emit = vi.fn<(event: SessionEvent) => void>();
+    const processor = createToolCallProcessor(emit, binding);
+
+    processor.onMessage(assistantToolUse("r7-unsupported", "TodoWrite", { file_path: `${TREE}/NODE.md` }));
+    processor.onMessage(userToolResult("r7-unsupported", "contents"));
+
+    const final = toolCallEvents(emit).find(
+      (event) => event.payload.toolUseId === "r7-unsupported" && event.payload.status === "ok",
     );
     expect(final?.payload.toolFileRefs).toBeUndefined();
     expect(usageEventCount(emit)).toBe(0);

--- a/packages/client/src/__tests__/codex-context-tree-io.test.ts
+++ b/packages/client/src/__tests__/codex-context-tree-io.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { collectCodexFileChangePaths, toolFileRefsFromCodexFileChange } from "../handlers/codex.js";
+import { toolFileRefsFromShellCommand } from "../runtime/context-tree-file-refs.js";
 
 describe("Codex Context Tree file refs", () => {
   it("collects explicit path fields and object keys from file_change payloads", () => {
@@ -47,5 +48,38 @@ describe("Codex Context Tree file refs", () => {
         pathKind: "file",
       },
     ]);
+  });
+
+  it("emits shell read refs for Codex command_execution paths under the Context Tree checkout", () => {
+    const refs = toolFileRefsFromShellCommand({
+      command: "sed -n '1,240p' /home/op/context-tree/NODE.md",
+      cwd: "/home/op/source",
+      contextTreePath: "/home/op/context-tree",
+      contextTreeRepoUrl: "https://github.com/acme/first-tree-context.git",
+      contextTreeBranch: "main",
+    });
+
+    expect(refs).toEqual([
+      {
+        origin: "tool_arg",
+        localPath: "/home/op/context-tree/NODE.md",
+        repoUrl: "https://github.com/acme/first-tree-context.git",
+        repoBranch: "main",
+        repoRelativePath: "NODE.md",
+        pathKind: "file",
+      },
+    ]);
+  });
+
+  it("rejects Codex shell read candidates outside the Context Tree checkout or using write syntax", () => {
+    const base = {
+      cwd: "/home/op/source",
+      contextTreePath: "/home/op/context-tree",
+      contextTreeRepoUrl: "https://github.com/acme/first-tree-context.git",
+    };
+
+    expect(toolFileRefsFromShellCommand({ ...base, command: "cat /home/op/context-tree-sibling/NODE.md" })).toEqual([]);
+    expect(toolFileRefsFromShellCommand({ ...base, command: "cat /home/op/context-tree/NODE.md | head" })).toEqual([]);
+    expect(toolFileRefsFromShellCommand({ ...base, command: "echo x > /home/op/context-tree/NODE.md" })).toEqual([]);
   });
 });

--- a/packages/client/src/__tests__/context-tree-file-refs.test.ts
+++ b/packages/client/src/__tests__/context-tree-file-refs.test.ts
@@ -1,0 +1,137 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { toolFileRefsFromShellCommand } from "../runtime/context-tree-file-refs.js";
+
+describe("toolFileRefsFromShellCommand", () => {
+  let root: string;
+  let tree: string;
+  let source: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "first-tree-shell-refs-"));
+    tree = join(root, "context-tree");
+    source = join(root, "source");
+    mkdirSync(join(tree, "members", "alice"), { recursive: true });
+    mkdirSync(join(tree, "roadmap"), { recursive: true });
+    mkdirSync(source, { recursive: true });
+    writeFileSync(join(tree, "NODE.md"), "root");
+    writeFileSync(join(tree, "members", "alice", "NODE.md"), "member");
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("maps a Codex-style sed read to one Context Tree file ref", () => {
+    const refs = toolFileRefsFromShellCommand({
+      command: `sed -n '1,240p' ${join(tree, "NODE.md")}`,
+      cwd: source,
+      contextTreePath: tree,
+      contextTreeRepoUrl: "https://github.com/acme/first-tree-context.git",
+      contextTreeBranch: "main",
+    });
+
+    expect(refs).toEqual([
+      {
+        origin: "tool_arg",
+        localPath: join(tree, "NODE.md"),
+        repoUrl: "https://github.com/acme/first-tree-context.git",
+        repoBranch: "main",
+        repoRelativePath: "NODE.md",
+        pathKind: "file",
+      },
+    ]);
+  });
+
+  it("maps relative paths when cwd is inside the Context Tree", () => {
+    const refs = toolFileRefsFromShellCommand({
+      command: "cat members/alice/NODE.md",
+      cwd: tree,
+      contextTreePath: tree,
+      contextTreeRepoUrl: "https://github.com/acme/first-tree-context.git",
+    });
+
+    expect(refs).toEqual([
+      {
+        origin: "tool_arg",
+        localPath: join(tree, "members", "alice", "NODE.md"),
+        repoUrl: "https://github.com/acme/first-tree-context.git",
+        repoRelativePath: "members/alice/NODE.md",
+        pathKind: "file",
+      },
+    ]);
+  });
+
+  it("emits a directory ref for rg files mode", () => {
+    const refs = toolFileRefsFromShellCommand({
+      command: `rg --files ${join(tree, "roadmap")}`,
+      cwd: source,
+      contextTreePath: tree,
+      contextTreeRepoUrl: "https://github.com/acme/first-tree-context.git",
+    });
+
+    expect(refs).toEqual([
+      {
+        origin: "tool_arg",
+        localPath: join(tree, "roadmap"),
+        repoUrl: "https://github.com/acme/first-tree-context.git",
+        repoRelativePath: "roadmap",
+        pathKind: "directory",
+      },
+    ]);
+  });
+
+  it("rejects sibling-prefix paths outside the Context Tree root", () => {
+    const sibling = join(root, "context-tree-other");
+    mkdirSync(sibling, { recursive: true });
+    writeFileSync(join(sibling, "NODE.md"), "outside");
+
+    expect(
+      toolFileRefsFromShellCommand({
+        command: `cat ${join(sibling, "NODE.md")}`,
+        cwd: source,
+        contextTreePath: tree,
+        contextTreeRepoUrl: "https://github.com/acme/first-tree-context.git",
+      }),
+    ).toEqual([]);
+  });
+
+  it("rejects complex or mutating shell candidates", () => {
+    const base = {
+      cwd: source,
+      contextTreePath: tree,
+      contextTreeRepoUrl: "https://github.com/acme/first-tree-context.git",
+    };
+
+    expect(toolFileRefsFromShellCommand({ ...base, command: `cat ${join(tree, "NODE.md")} | head` })).toEqual([]);
+    expect(toolFileRefsFromShellCommand({ ...base, command: `echo x > ${join(tree, "NODE.md")}` })).toEqual([]);
+    expect(toolFileRefsFromShellCommand({ ...base, command: `tee ${join(tree, "NODE.md")}` })).toEqual([]);
+    expect(toolFileRefsFromShellCommand({ ...base, command: `sed -i 's/a/b/' ${join(tree, "NODE.md")}` })).toEqual([]);
+    expect(toolFileRefsFromShellCommand({ ...base, command: `find ${tree} -delete` })).toEqual([]);
+    expect(toolFileRefsFromShellCommand({ ...base, command: `find ${tree} -exec rm {} \\;` })).toEqual([]);
+  });
+
+  it("does not emit refs for unquoted comment text when cwd is the Context Tree", () => {
+    expect(
+      toolFileRefsFromShellCommand({
+        command: "cat NODE.md # members/alice/NODE.md",
+        cwd: tree,
+        contextTreePath: tree,
+        contextTreeRepoUrl: "https://github.com/acme/first-tree-context.git",
+      }),
+    ).toEqual([]);
+  });
+
+  it("does not emit local-only refs when Context Tree binding evidence is missing", () => {
+    expect(
+      toolFileRefsFromShellCommand({
+        command: `cat ${join(tree, "NODE.md")}`,
+        cwd: source,
+        contextTreePath: tree,
+        contextTreeRepoUrl: null,
+      }),
+    ).toEqual([]);
+  });
+});

--- a/packages/client/src/handlers/claude-code-tui/index.ts
+++ b/packages/client/src/handlers/claude-code-tui/index.ts
@@ -310,6 +310,7 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
       turnProcessor = createToolCallProcessor(
         (event) => sessionCtx.emitEvent(event),
         contextTreePath ? { path: contextTreePath, repoUrl: contextTreeRepoUrl, branch: contextTreeBranch } : undefined,
+        { cwd },
       );
     }
     return turnProcessor;

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -21,6 +21,7 @@ import { ensureAgentBootstrap as ensureAgentBootstrapShared } from "../runtime/a
 import type { AgentConfigCache } from "../runtime/agent-config-cache.js";
 import { buildChatSystemPrompt, type PredeclaredSourceRepo } from "../runtime/bootstrap.js";
 import { type ChatContext, fetchChatContext } from "../runtime/chat-context.js";
+import { toolFileRefsFromShellCommand } from "../runtime/context-tree-file-refs.js";
 import { classify } from "../runtime/error-taxonomy.js";
 import type { GitMirrorManager } from "../runtime/git-mirror-manager.js";
 import type { AgentHandler, HandlerFactory, SessionContext, SessionMessage } from "../runtime/handler.js";
@@ -361,6 +362,32 @@ function toolFileRef(toolName: string, input: unknown, contextTree?: ContextTree
   };
 }
 
+function readCommandArg(input: unknown): string | null {
+  if (!input || typeof input !== "object") return null;
+  const command = (input as { command?: unknown }).command;
+  return typeof command === "string" ? command : null;
+}
+
+function toolFileRefs(
+  toolName: string,
+  input: unknown,
+  contextTree: ContextTreeBinding | undefined,
+  cwd: string | null | undefined,
+): ToolFileRef[] {
+  const directRef = toolFileRef(toolName, input, contextTree);
+  if (directRef) return [directRef];
+  if (toolName !== "Bash" || !cwd) return [];
+  const command = readCommandArg(input);
+  if (command === null) return [];
+  return toolFileRefsFromShellCommand({
+    command,
+    cwd,
+    contextTreePath: contextTree?.path ?? null,
+    contextTreeRepoUrl: contextTree?.repoUrl ?? null,
+    contextTreeBranch: contextTree?.branch ?? null,
+  });
+}
+
 /**
  * Pair `tool_use` (assistant) with `tool_result` (user) blocks and emit a
  * `tool_call` event per pair. Unpaired entries are flushed as `status: "pending"`.
@@ -378,6 +405,7 @@ export type ToolCallProcessor = {
 export function createToolCallProcessor(
   emit: (event: SessionEvent) => void,
   contextTree?: ContextTreeBinding,
+  options: { cwd?: string | null } = {},
 ): ToolCallProcessor {
   type Pending = { toolUseId: string; name: string; args: unknown; startedAt: number };
   const pending = new Map<string, Pending>();
@@ -389,10 +417,7 @@ export function createToolCallProcessor(
     const durationMs = Date.now() - entry.startedAt;
     const previewRaw = extractToolResultText(block.content);
     const resultPreview = previewRaw.length > 0 ? previewRaw.slice(0, TOOL_RESULT_PREVIEW_LIMIT) : undefined;
-    const toolFileRefs =
-      status === "ok"
-        ? [toolFileRef(entry.name, entry.args, contextTree)].filter((ref): ref is ToolFileRef => ref !== null)
-        : [];
+    const refs = status === "ok" ? toolFileRefs(entry.name, entry.args, contextTree, options.cwd) : [];
 
     emit({
       kind: "tool_call",
@@ -403,7 +428,7 @@ export function createToolCallProcessor(
         status,
         durationMs,
         ...(resultPreview !== undefined ? { resultPreview } : {}),
-        ...(toolFileRefs.length > 0 ? { toolFileRefs } : {}),
+        ...(refs.length > 0 ? { toolFileRefs: refs } : {}),
       },
     });
 
@@ -1013,11 +1038,15 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
   }
 
   async function consumeOutput(sessionCtx: SessionContext): Promise<void> {
-    const toolCallProcessor = createToolCallProcessor((event) => sessionCtx.emitEvent(event), {
-      path: contextTreePath,
-      repoUrl: contextTreeRepoUrl,
-      branch: contextTreeBranch,
-    });
+    const toolCallProcessor = createToolCallProcessor(
+      (event) => sessionCtx.emitEvent(event),
+      {
+        path: contextTreePath,
+        repoUrl: contextTreeRepoUrl,
+        branch: contextTreeBranch,
+      },
+      { cwd },
+    );
     // Auth-failure hint emission flag. Set when we detect a typed
     // `authentication_failed` on assistant / auth_status messages. Consulted
     // in the result-error branch so we don't double-emit (once as a hint,

--- a/packages/client/src/handlers/codex.ts
+++ b/packages/client/src/handlers/codex.ts
@@ -26,6 +26,7 @@ import {
   writeContextTreeHead,
 } from "../runtime/bootstrap.js";
 import { type ChatContext, fetchChatContext } from "../runtime/chat-context.js";
+import { toolFileRefsFromShellCommand } from "../runtime/context-tree-file-refs.js";
 import { resolveGitRepoTargetPath } from "../runtime/git-local-path.js";
 import { deriveSessionBranchName, type GitMirrorManager } from "../runtime/git-mirror-manager.js";
 import type { AgentHandler, HandlerFactory, SessionContext, SessionMessage } from "../runtime/handler.js";
@@ -555,13 +556,6 @@ export const createCodexHandler: HandlerFactory = (config) => {
     return sessionCtx.formatInboundContent(message).then((text) => text);
   }
 
-  // NOTE: codex's stream exposes only `command_execution` (shell) items — it
-  // cannot cleanly tell which Context Tree node a turn read without parsing
-  // shell commands. Rather than emit a fake per-turn signal (the old
-  // `emitContextTreeUsage` did), codex produces NO `context_tree_usage` events.
-  // Precise codex tree-read tracking is a known gap (P1). See the claude-code
-  // handler's tool-call processor for the real per-read signal.
-
   async function prepareSourceRepos(
     payload: AgentRuntimeConfigPayload,
     workspaceCwd: string,
@@ -681,12 +675,23 @@ export const createCodexHandler: HandlerFactory = (config) => {
             : item.status === "failed"
               ? ("error" as const)
               : ("pending" as const);
+        const toolFileRefs =
+          status === "ok" && cwd
+            ? toolFileRefsFromShellCommand({
+                command: item.command,
+                cwd,
+                contextTreePath,
+                contextTreeRepoUrl,
+                contextTreeBranch,
+              })
+            : undefined;
         emitToolCall(sessionCtx, {
           toolUseId: item.id,
           name: "command",
-          args: { command: item.command },
+          args: { command: item.command, ...(cwd ? { cwd } : {}) },
           status,
           resultPreview: item.aggregated_output,
+          toolFileRefs,
         });
         return "";
       }

--- a/packages/client/src/runtime/context-tree-file-refs.ts
+++ b/packages/client/src/runtime/context-tree-file-refs.ts
@@ -1,0 +1,66 @@
+import { statSync } from "node:fs";
+import { isAbsolute, relative, resolve } from "node:path";
+import { classifyShellCommandIo, type ShellIoPathKindHint, type ToolFileRef } from "@first-tree/shared";
+
+export type ShellCommandFileRefsInput = {
+  command: string;
+  cwd: string;
+  contextTreePath: string | null;
+  contextTreeRepoUrl: string | null;
+  contextTreeBranch?: string | null;
+};
+
+function toPosixPath(path: string): string {
+  return path.replaceAll("\\", "/");
+}
+
+function pathInsideContextTree(absolutePath: string, contextTreePath: string): string | null {
+  const relativePath = relative(contextTreePath, absolutePath);
+  if (relativePath === "") return "/";
+  if (relativePath.startsWith("..") || isAbsolute(relativePath)) return null;
+  return toPosixPath(relativePath);
+}
+
+function pathKindOf(
+  absolutePath: string,
+  repoRelativePath: string,
+  hint: ShellIoPathKindHint,
+): NonNullable<ToolFileRef["pathKind"]> {
+  if (repoRelativePath === "/") return "repo";
+  try {
+    const stat = statSync(absolutePath);
+    if (stat.isDirectory()) return "directory";
+    return "file";
+  } catch {
+    return hint === "directory" ? "directory" : "file";
+  }
+}
+
+export function toolFileRefsFromShellCommand(input: ShellCommandFileRefsInput): ToolFileRef[] {
+  if (!input.contextTreePath || !input.contextTreeRepoUrl) return [];
+
+  const classification = classifyShellCommandIo(input.command);
+  if (!classification.supported || classification.action !== "read") return [];
+
+  const refs: ToolFileRef[] = [];
+  const seen = new Set<string>();
+  const contextTreeRoot = resolve(input.contextTreePath);
+  for (const pathArg of classification.pathArgs) {
+    const absolutePath = isAbsolute(pathArg.raw) ? resolve(pathArg.raw) : resolve(input.cwd, pathArg.raw);
+    if (seen.has(absolutePath)) continue;
+    seen.add(absolutePath);
+
+    const repoRelativePath = pathInsideContextTree(absolutePath, contextTreeRoot);
+    if (repoRelativePath === null) continue;
+
+    refs.push({
+      origin: "tool_arg",
+      localPath: absolutePath,
+      repoUrl: input.contextTreeRepoUrl,
+      ...(input.contextTreeBranch ? { repoBranch: input.contextTreeBranch } : {}),
+      repoRelativePath,
+      pathKind: pathKindOf(absolutePath, repoRelativePath, pathArg.pathKindHint),
+    });
+  }
+  return refs;
+}

--- a/packages/server/src/__tests__/context-tree-io.test.ts
+++ b/packages/server/src/__tests__/context-tree-io.test.ts
@@ -2,7 +2,11 @@ import { eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 import { chats } from "../db/schema/chats.js";
 import { contextTreeIoEvents } from "../db/schema/context-tree-io-events.js";
-import { recordFromSessionEvent, summarizeContextTreeIo } from "../services/context-tree-io.js";
+import {
+  explainContextTreeIoDecision,
+  recordFromSessionEvent,
+  summarizeContextTreeIo,
+} from "../services/context-tree-io.js";
 import { putOrgSetting } from "../services/org-settings.js";
 import { appendEvent } from "../services/session-event.js";
 import { createTestAgent, useTestApp } from "./helpers.js";
@@ -252,16 +256,97 @@ describe("context-tree IO service", () => {
     expect(invalidPathRows).toHaveLength(0);
   });
 
-  it("rejects shell command file refs until server-side command parsing exists", async () => {
+  it("derives shell command read IO for Codex command and Claude Bash", async () => {
     const app = getApp();
     const seed = await seedContextTreeChat();
 
-    const persisted = await appendEvent(app.db, seed.agent.uuid, seed.chatId, {
+    const codexRead = await appendEvent(app.db, seed.agent.uuid, seed.chatId, {
       kind: "tool_call",
       payload: {
-        toolUseId: "tu-shell",
+        toolUseId: "tu-codex-shell",
+        name: "command",
+        args: { command: "sed -n '1,120p' /tmp/context-tree/NODE.md" },
+        status: "ok",
+        toolFileRefs: [
+          {
+            origin: "tool_arg",
+            repoUrl: TREE_REPO,
+            repoBranch: "main",
+            repoRelativePath: "NODE.md",
+            pathKind: "file",
+          },
+        ],
+      },
+    });
+    const claudeRead = await appendEvent(app.db, seed.agent.uuid, seed.chatId, {
+      kind: "tool_call",
+      payload: {
+        toolUseId: "tu-claude-shell",
         name: "Bash",
-        args: { command: "cat /tmp/context-tree/NODE.md" },
+        args: { command: "cat /tmp/context-tree/practices/NODE.md" },
+        status: "ok",
+        toolFileRefs: [
+          {
+            origin: "tool_arg",
+            repoUrl: TREE_REPO,
+            repoBranch: "main",
+            repoRelativePath: "practices/NODE.md",
+            pathKind: "file",
+          },
+        ],
+      },
+    });
+
+    for (const item of [
+      { runtimeProvider: "codex", sessionEvent: codexRead },
+      { runtimeProvider: "claude-code", sessionEvent: claudeRead },
+    ]) {
+      await recordFromSessionEvent(app.db, {
+        organizationId: seed.organizationId,
+        agentId: seed.agent.uuid,
+        chatId: seed.chatId,
+        runtimeProvider: item.runtimeProvider,
+        sessionEvent: item.sessionEvent,
+      });
+    }
+
+    const rows = await app.db.select().from(contextTreeIoEvents).where(eq(contextTreeIoEvents.chatId, seed.chatId));
+    expect(rows).toHaveLength(2);
+    expect(
+      rows
+        .map((row) => ({
+          runtimeProvider: row.runtimeProvider,
+          action: row.action,
+          source: row.source,
+          targetPath: row.targetPath,
+        }))
+        .sort((a, b) => a.runtimeProvider.localeCompare(b.runtimeProvider)),
+    ).toEqual([
+      {
+        runtimeProvider: "claude-code",
+        action: "read",
+        source: "shell_command",
+        targetPath: "practices/NODE.md",
+      },
+      {
+        runtimeProvider: "codex",
+        action: "read",
+        source: "shell_command",
+        targetPath: "NODE.md",
+      },
+    ]);
+  });
+
+  it("keeps shell write commands unsupported and explains common skip reasons", async () => {
+    const app = getApp();
+    const seed = await seedContextTreeChat();
+
+    const shellWrite = await appendEvent(app.db, seed.agent.uuid, seed.chatId, {
+      kind: "tool_call",
+      payload: {
+        toolUseId: "tu-shell-write",
+        name: "command",
+        args: { command: "echo x > /tmp/context-tree/NODE.md" },
         status: "ok",
         toolFileRefs: [
           {
@@ -279,14 +364,108 @@ describe("context-tree IO service", () => {
       organizationId: seed.organizationId,
       agentId: seed.agent.uuid,
       chatId: seed.chatId,
-      runtimeProvider: "claude-code",
-      sessionEvent: persisted,
+      runtimeProvider: "codex",
+      sessionEvent: shellWrite,
     });
 
     const rows = await app.db
       .select()
       .from(contextTreeIoEvents)
-      .where(eq(contextTreeIoEvents.sourceSessionEventId, persisted.id));
+      .where(eq(contextTreeIoEvents.sourceSessionEventId, shellWrite.id));
     expect(rows).toHaveLength(0);
+    expect(
+      explainContextTreeIoDecision({
+        runtimeProvider: "codex",
+        sessionEvent: shellWrite,
+        bindingRepo: TREE_REPO,
+      }),
+    ).toEqual({ recordable: false, reason: "unsupported_shell_command" });
+    expect(
+      explainContextTreeIoDecision({
+        runtimeProvider: "codex",
+        sessionEvent: {
+          kind: "tool_call",
+          payload: {
+            toolUseId: "tu-no-refs",
+            name: "command",
+            args: { command: "cat /tmp/context-tree/NODE.md" },
+            status: "ok",
+          },
+        },
+        bindingRepo: TREE_REPO,
+      }),
+    ).toEqual({ recordable: false, reason: "no_tool_file_refs" });
+    expect(
+      explainContextTreeIoDecision({
+        runtimeProvider: "codex",
+        sessionEvent: {
+          kind: "tool_call",
+          payload: {
+            toolUseId: "tu-repo-mismatch",
+            name: "command",
+            args: { command: "cat /tmp/context-tree/NODE.md" },
+            status: "ok",
+            toolFileRefs: [
+              {
+                origin: "tool_arg",
+                repoUrl: "https://github.com/acme/other.git",
+                repoBranch: "main",
+                repoRelativePath: "NODE.md",
+                pathKind: "file",
+              },
+            ],
+          },
+        },
+        bindingRepo: TREE_REPO,
+      }),
+    ).toEqual({ recordable: false, reason: "ref_repo_mismatch" });
+    expect(
+      explainContextTreeIoDecision({
+        runtimeProvider: "codex",
+        sessionEvent: {
+          kind: "tool_call",
+          payload: {
+            toolUseId: "tu-find-delete",
+            name: "command",
+            args: { command: "find /tmp/context-tree -delete" },
+            status: "ok",
+            toolFileRefs: [
+              {
+                origin: "tool_arg",
+                repoUrl: TREE_REPO,
+                repoBranch: "main",
+                repoRelativePath: "/",
+                pathKind: "repo",
+              },
+            ],
+          },
+        },
+        bindingRepo: TREE_REPO,
+      }),
+    ).toEqual({ recordable: false, reason: "unsupported_shell_command" });
+    expect(
+      explainContextTreeIoDecision({
+        runtimeProvider: "codex",
+        sessionEvent: {
+          kind: "tool_call",
+          payload: {
+            toolUseId: "tu-comment",
+            name: "command",
+            args: { command: "cat NODE.md # members/alice/NODE.md" },
+            status: "ok",
+            toolFileRefs: [
+              {
+                origin: "tool_arg",
+                repoUrl: TREE_REPO,
+                repoBranch: "main",
+                repoRelativePath: "members/alice/NODE.md",
+                pathKind: "file",
+              },
+            ],
+          },
+        },
+        bindingRepo: TREE_REPO,
+      }),
+    ).toEqual({ recordable: false, reason: "unsupported_shell_command" });
   });
 });

--- a/packages/server/src/__tests__/ws-session-event.test.ts
+++ b/packages/server/src/__tests__/ws-session-event.test.ts
@@ -54,7 +54,7 @@ describe("Agent WS — session event protocol (S10)", () => {
       .sign(secret);
   }
 
-  async function seedBoundAgent(suffix: string) {
+  async function seedBoundAgent(suffix: string, runtimeProvider: "claude-code" | "codex" = "claude-code") {
     const orgId = await resolveDefaultOrgId(app.db);
     const userId = uuidv7();
     const memberId = uuidv7();
@@ -101,6 +101,7 @@ describe("Agent WS — session event protocol (S10)", () => {
         managerId: memberId,
         clientId,
         organizationId: orgId,
+        runtimeProvider,
       });
     });
 
@@ -148,9 +149,9 @@ describe("Agent WS — session event protocol (S10)", () => {
         type: "agent:bind",
         agentId: seed.agent.uuid,
         ref: "bind-1",
-        // Match the seeded agent's `runtime_provider` (defaults to claude-code)
-        // so the post-0026 RUNTIME_PROVIDER_MISMATCH check passes.
-        runtimeType: "claude-code",
+        // Match the seeded agent's `runtime_provider` so the post-0026
+        // RUNTIME_PROVIDER_MISMATCH check passes.
+        runtimeType: seed.agent.runtimeProvider,
         runtimeVersion: "0.0.0",
       }),
     );
@@ -283,6 +284,70 @@ describe("Agent WS — session event protocol (S10)", () => {
         action: "write",
         source: "claude_write_tool",
         targetPath: "domains/runtime/NODE.md",
+      });
+    } finally {
+      ws.close();
+      await new Promise<void>((r) => ws.once("close", () => r()));
+    }
+  }, 15000);
+
+  it("persists Context Tree IO from a Codex shell read `session:event` frame", async () => {
+    const seed = await seedBoundAgent("context-shell-codex", "codex");
+    const ws = await openBoundSocket(seed);
+    const chatId = `chat-${crypto.randomUUID()}`;
+    const treeRepoUrl = "https://github.com/acme/first-tree-context.git";
+
+    try {
+      await putOrgSetting(
+        app.db,
+        seed.organizationId,
+        "context_tree",
+        { repo: treeRepoUrl, branch: "main" },
+        { updatedBy: seed.userId },
+      );
+      await app.db.insert(chats).values({ id: chatId, organizationId: seed.organizationId });
+
+      ws.send(
+        JSON.stringify({
+          type: "session:event",
+          agentId: seed.agent.uuid,
+          chatId,
+          event: {
+            kind: "tool_call",
+            payload: {
+              toolUseId: "tu-codex-shell-read",
+              name: "command",
+              args: { command: "sed -n '1,120p' /tmp/context-tree/NODE.md", cwd: "/tmp/source" },
+              status: "ok",
+              toolFileRefs: [
+                {
+                  origin: "tool_arg",
+                  repoUrl: treeRepoUrl,
+                  repoBranch: "main",
+                  repoRelativePath: "NODE.md",
+                  pathKind: "file",
+                },
+              ],
+            },
+          },
+        }),
+      );
+
+      const ioRows = await waitForCondition(async () => {
+        const rows = await app.db.select().from(contextTreeIoEvents).where(eq(contextTreeIoEvents.chatId, chatId));
+        return rows.length > 0 ? rows : null;
+      });
+      const { items } = await sessionEventService.listEvents(app.db, seed.agent.uuid, chatId, { limit: 10 });
+
+      expect(items).toHaveLength(1);
+      expect(ioRows).toHaveLength(1);
+      expect(ioRows[0]).toMatchObject({
+        agentId: seed.agent.uuid,
+        chatId,
+        runtimeProvider: "codex",
+        action: "read",
+        source: "shell_command",
+        targetPath: "NODE.md",
       });
     } finally {
       ws.close();

--- a/packages/server/src/services/context-tree-io.ts
+++ b/packages/server/src/services/context-tree-io.ts
@@ -6,6 +6,7 @@ import {
   type ContextTreeIoSource,
   type ContextTreeIoSummary,
   type ContextTreeIoTargetKind,
+  classifyShellCommandIo,
   contextTreeIoSourceSchema,
   type SessionEvent,
   sessionEventSchema,
@@ -19,11 +20,13 @@ import { chatMembership } from "../db/schema/chat-membership.js";
 import { chats } from "../db/schema/chats.js";
 import { contextTreeIoEvents } from "../db/schema/context-tree-io-events.js";
 import { sessionEvents } from "../db/schema/session-events.js";
+import { createLogger } from "../observability/index.js";
 import { getOrgContextTree } from "./org-settings.js";
 
 const CONTEXT_TREE_IO_FEED_LIMIT = 50;
 const CLAUDE_READ_TOOLS = new Set(["Read", "NotebookRead"]);
 const CLAUDE_WRITE_TOOLS = new Set(["Write", "Edit", "MultiEdit"]);
+const log = createLogger("ContextTreeIo");
 
 export type ContextTreeIoViewer = {
   humanAgentId: string;
@@ -60,6 +63,54 @@ type NormalizedFileRef = {
   targetPath: string;
   metadata: Record<string, unknown>;
 };
+
+type NormalizedFileRefRecord = {
+  normalized: NormalizedFileRef;
+  sourceIndex: number;
+};
+
+export type ContextTreeIoSkipReason =
+  | "no_org_context_tree_binding"
+  | "event_kind_not_io"
+  | "status_not_ok"
+  | "unsupported_tool"
+  | "unsupported_shell_command"
+  | "no_tool_file_refs"
+  | "ref_schema_invalid"
+  | "ref_repo_mismatch"
+  | "ref_path_invalid"
+  | "chat_not_in_org";
+
+export type ContextTreeIoDecision =
+  | {
+      recordable: true;
+    }
+  | {
+      recordable: false;
+      reason: ContextTreeIoSkipReason;
+    };
+
+export type ExplainContextTreeIoDecisionInput = {
+  runtimeProvider: string;
+  sessionEvent: {
+    kind: string;
+    payload: unknown;
+  };
+  bindingRepo: string | null | undefined;
+  bindingBranch?: string | null;
+  chatInOrg?: boolean;
+};
+
+type InternalContextTreeIoDecision =
+  | {
+      recordable: true;
+      derivation: EventIoDerivation;
+      refs: NormalizedFileRefRecord[];
+    }
+  | {
+      recordable: false;
+      reason: ContextTreeIoSkipReason;
+    };
 
 function canonicalRepoUrl(value: string | null | undefined): string | null {
   const trimmed = value?.trim();
@@ -105,9 +156,31 @@ function isClaudeRuntime(runtimeProvider: string): boolean {
   return runtimeProvider === "claude-code" || runtimeProvider === "claude-code-tui";
 }
 
-function deriveEventIo(event: SessionEvent, runtimeProvider: string): EventIoDerivation | null {
+function shellCommandArg(event: SessionEvent): string | null {
+  if (event.kind !== "tool_call") return null;
+  const args = event.payload.args;
+  if (!args || typeof args !== "object") return null;
+  const command = (args as { command?: unknown }).command;
+  return typeof command === "string" ? command : null;
+}
+
+function shellToolCanRead(event: SessionEvent): boolean {
+  const command = shellCommandArg(event);
+  if (command === null) return false;
+  const classification = classifyShellCommandIo(command);
+  return classification.supported && classification.action === "read";
+}
+
+function isShellTool(runtimeProvider: string, toolName: string): boolean {
+  return (
+    (runtimeProvider === "codex" && toolName === "command") || (isClaudeRuntime(runtimeProvider) && toolName === "Bash")
+  );
+}
+
+function deriveEventIo(event: SessionEvent, runtimeProvider: string): EventIoDerivation | ContextTreeIoSkipReason {
   if (event.kind === "context_tree_usage") return { action: "read", source: "legacy_context_tree_usage" };
-  if (event.kind !== "tool_call" || event.payload.status !== "ok") return null;
+  if (event.kind !== "tool_call") return "event_kind_not_io";
+  if (event.payload.status !== "ok") return "status_not_ok";
 
   const toolName = event.payload.name;
   if (runtimeProvider === "codex" && toolName === "file_change") {
@@ -119,10 +192,11 @@ function deriveEventIo(event: SessionEvent, runtimeProvider: string): EventIoDer
   if (isClaudeRuntime(runtimeProvider) && CLAUDE_WRITE_TOOLS.has(toolName)) {
     return { action: "write", source: "claude_write_tool" };
   }
+  if (isShellTool(runtimeProvider, toolName)) {
+    return shellToolCanRead(event) ? { action: "read", source: "shell_command" } : "unsupported_shell_command";
+  }
 
-  // P1 only: shell read tracking needs a server-side command parser before it
-  // can become a trusted fact. Bash/Codex command tool calls are ignored here.
-  return null;
+  return "unsupported_tool";
 }
 
 function legacyFileRef(event: SessionEvent, bindingRepo: string, bindingBranch: string): ToolFileRef | null {
@@ -151,54 +225,148 @@ function extractFileRefs(event: SessionEvent, bindingRepo: string, bindingBranch
   return records;
 }
 
-function normalizeFileRef(ref: ToolFileRef, bindingRepo: string, bindingBranch: string): NormalizedFileRef | null {
+function normalizeFileRef(
+  ref: ToolFileRef,
+  bindingRepo: string,
+  bindingBranch: string,
+): { ok: true; normalized: NormalizedFileRef } | { ok: false; reason: ContextTreeIoSkipReason } {
   const parsed = toolFileRefSchema.safeParse(ref);
-  if (!parsed.success) return null;
+  if (!parsed.success) return { ok: false, reason: "ref_schema_invalid" };
 
   const expectedRepo = canonicalRepoUrl(bindingRepo);
   const reportedRepo = canonicalRepoUrl(parsed.data.repoUrl);
-  if (!expectedRepo || !reportedRepo || expectedRepo !== reportedRepo) return null;
+  if (!expectedRepo || !reportedRepo || expectedRepo !== reportedRepo) {
+    return { ok: false, reason: "ref_repo_mismatch" };
+  }
 
   const targetKind = parsed.data.pathKind ?? "file";
-  if (!parsed.data.repoRelativePath) return null;
+  if (!parsed.data.repoRelativePath) return { ok: false, reason: "ref_path_invalid" };
   const targetPath = normalizeTargetPath(parsed.data.repoRelativePath, targetKind);
-  if (!targetPath) return null;
+  if (!targetPath) return { ok: false, reason: "ref_path_invalid" };
 
   return {
-    treeRepoUrl: bindingRepo,
-    treeBranch: parsed.data.repoBranch ?? bindingBranch,
-    targetKind,
-    targetPath,
-    metadata: {
-      origin: parsed.data.origin,
-      ...(parsed.data.localPath ? { localPath: parsed.data.localPath } : {}),
+    ok: true,
+    normalized: {
+      treeRepoUrl: bindingRepo,
+      treeBranch: parsed.data.repoBranch ?? bindingBranch,
+      targetKind,
+      targetPath,
+      metadata: {
+        origin: parsed.data.origin,
+        ...(parsed.data.localPath ? { localPath: parsed.data.localPath } : {}),
+      },
     },
   };
 }
 
+function buildContextTreeIoDecision(input: {
+  event: SessionEvent;
+  runtimeProvider: string;
+  bindingRepo: string | null | undefined;
+  bindingBranch: string;
+  chatInOrg?: boolean;
+}): InternalContextTreeIoDecision {
+  if (!input.bindingRepo) return { recordable: false, reason: "no_org_context_tree_binding" };
+
+  const derivation = deriveEventIo(input.event, input.runtimeProvider);
+  if (typeof derivation === "string") return { recordable: false, reason: derivation };
+
+  const refs = extractFileRefs(input.event, input.bindingRepo, input.bindingBranch);
+  if (refs.length === 0) return { recordable: false, reason: "no_tool_file_refs" };
+
+  const normalizedRefs: NormalizedFileRefRecord[] = [];
+  let firstRejectedReason: ContextTreeIoSkipReason | null = null;
+  for (const { ref, sourceIndex } of refs) {
+    const normalized = normalizeFileRef(ref, input.bindingRepo, input.bindingBranch);
+    if (!normalized.ok) {
+      firstRejectedReason ??= normalized.reason;
+      continue;
+    }
+    normalizedRefs.push({ normalized: normalized.normalized, sourceIndex });
+  }
+
+  if (normalizedRefs.length === 0) {
+    return { recordable: false, reason: firstRejectedReason ?? "ref_schema_invalid" };
+  }
+  if (input.chatInOrg === false) return { recordable: false, reason: "chat_not_in_org" };
+
+  return { recordable: true, derivation, refs: normalizedRefs };
+}
+
+function toolNameOf(event: SessionEvent): string | null {
+  return event.kind === "tool_call" ? event.payload.name : null;
+}
+
+export function explainContextTreeIoDecision(input: ExplainContextTreeIoDecisionInput): ContextTreeIoDecision {
+  const parsed = sessionEventSchema.safeParse({
+    kind: input.sessionEvent.kind,
+    payload: input.sessionEvent.payload,
+  });
+  if (!parsed.success) return { recordable: false, reason: "event_kind_not_io" };
+
+  const decision = buildContextTreeIoDecision({
+    event: parsed.data,
+    runtimeProvider: input.runtimeProvider,
+    bindingRepo: input.bindingRepo,
+    bindingBranch: input.bindingBranch ?? "main",
+    chatInOrg: input.chatInOrg,
+  });
+  return decision.recordable ? { recordable: true } : { recordable: false, reason: decision.reason };
+}
+
 export async function recordFromSessionEvent(db: Database, input: RecordContextTreeIoInput): Promise<void> {
   const binding = await getOrgContextTree(db, input.organizationId);
-  if (!binding.repo) return;
   const bindingBranch = binding.branch ?? "main";
 
   const event = sessionEventSchema.parse({ kind: input.sessionEvent.kind, payload: input.sessionEvent.payload });
-  const derivation = deriveEventIo(event, input.runtimeProvider);
-  if (!derivation) return;
-  const refs = extractFileRefs(event, binding.repo, bindingBranch);
-  if (refs.length === 0) return;
+  const decision = buildContextTreeIoDecision({
+    event,
+    runtimeProvider: input.runtimeProvider,
+    bindingRepo: binding.repo,
+    bindingBranch,
+  });
+  if (!decision.recordable) {
+    log.debug(
+      {
+        reason: decision.reason,
+        organizationId: input.organizationId,
+        agentId: input.agentId,
+        chatId: input.chatId,
+        sessionEventId: input.sessionEvent.id,
+        runtimeProvider: input.runtimeProvider,
+        eventKind: event.kind,
+        toolName: toolNameOf(event),
+      },
+      "context tree io event skipped",
+    );
+    return;
+  }
 
   const [chat] = await db
     .select({ id: chats.id })
     .from(chats)
     .where(and(eq(chats.id, input.chatId), eq(chats.organizationId, input.organizationId)))
     .limit(1);
-  if (!chat) return;
+  if (!chat) {
+    log.debug(
+      {
+        reason: "chat_not_in_org",
+        organizationId: input.organizationId,
+        agentId: input.agentId,
+        chatId: input.chatId,
+        sessionEventId: input.sessionEvent.id,
+        runtimeProvider: input.runtimeProvider,
+        eventKind: event.kind,
+        toolName: toolNameOf(event),
+      },
+      "context tree io event skipped",
+    );
+    return;
+  }
 
   const createdAt = new Date(input.sessionEvent.createdAt);
   const rows = [];
-  for (const { ref, sourceIndex } of refs) {
-    const normalized = normalizeFileRef(ref, binding.repo, bindingBranch);
-    if (!normalized) continue;
+  for (const { normalized, sourceIndex } of decision.refs) {
     rows.push({
       id: `${input.sessionEvent.id}:${sourceIndex}`,
       organizationId: input.organizationId,
@@ -207,8 +375,8 @@ export async function recordFromSessionEvent(db: Database, input: RecordContextT
       sourceSessionEventId: input.sessionEvent.id,
       sourceIndex,
       runtimeProvider: input.runtimeProvider,
-      action: derivation.action,
-      source: derivation.source,
+      action: decision.derivation.action,
+      source: decision.derivation.source,
       treeRepoUrl: normalized.treeRepoUrl,
       treeBranch: normalized.treeBranch,
       targetKind: normalized.targetKind,

--- a/packages/shared/src/__tests__/shell-command-io.test.ts
+++ b/packages/shared/src/__tests__/shell-command-io.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import { classifyShellCommandIo } from "../shell-command-io.js";
+
+describe("classifyShellCommandIo", () => {
+  it("classifies sed file operands after options and script", () => {
+    expect(classifyShellCommandIo("sed -n '1,240p' /tree/NODE.md")).toEqual({
+      supported: true,
+      action: "read",
+      commandName: "sed",
+      pathArgs: [{ raw: "/tree/NODE.md", pathKindHint: "file" }],
+    });
+  });
+
+  it("classifies simple file read commands with relative paths", () => {
+    expect(classifyShellCommandIo("cat NODE.md docs/guide.md")).toEqual({
+      supported: true,
+      action: "read",
+      commandName: "cat",
+      pathArgs: [
+        { raw: "NODE.md", pathKindHint: "file" },
+        { raw: "docs/guide.md", pathKindHint: "file" },
+      ],
+    });
+  });
+
+  it("classifies ripgrep files mode directory operands", () => {
+    expect(classifyShellCommandIo("rg --files /tree")).toEqual({
+      supported: true,
+      action: "read",
+      commandName: "rg",
+      pathArgs: [{ raw: "/tree", pathKindHint: "directory" }],
+    });
+  });
+
+  it("classifies grep path operands after the pattern", () => {
+    expect(classifyShellCommandIo("grep -R Context /tree/practices")).toEqual({
+      supported: true,
+      action: "read",
+      commandName: "grep",
+      pathArgs: [{ raw: "/tree/practices", pathKindHint: "unknown" }],
+    });
+  });
+
+  it("skips grep option values before finding path operands", () => {
+    expect(classifyShellCommandIo("grep -R -C 2 --include '*.md' Context /tree")).toEqual({
+      supported: true,
+      action: "read",
+      commandName: "grep",
+      pathArgs: [{ raw: "/tree", pathKindHint: "unknown" }],
+    });
+  });
+
+  it("rejects unsupported grep options instead of guessing path positions", () => {
+    expect(classifyShellCommandIo("grep --custom-option value Context /tree")).toEqual({
+      supported: false,
+      reason: "unsupported_tool",
+      commandName: "grep",
+    });
+  });
+
+  it("rejects complex shell syntax", () => {
+    expect(classifyShellCommandIo("cat /tree/NODE.md | head")).toEqual({
+      supported: false,
+      reason: "complex_shell",
+    });
+    expect(classifyShellCommandIo("cat /tree/NODE.md > /tmp/out")).toEqual({
+      supported: false,
+      reason: "complex_shell",
+    });
+  });
+
+  it("rejects dynamic path syntax in path positions", () => {
+    expect(classifyShellCommandIo("cat $TREE/NODE.md")).toEqual({
+      supported: false,
+      reason: "dynamic_path",
+      commandName: "cat",
+    });
+    expect(classifyShellCommandIo("cat /tree/*.md")).toEqual({
+      supported: false,
+      reason: "dynamic_path",
+      commandName: "cat",
+    });
+  });
+
+  it("rejects mutating commands and sed in-place edits", () => {
+    expect(classifyShellCommandIo("tee /tree/NODE.md")).toEqual({
+      supported: false,
+      reason: "write_or_mutation",
+      commandName: "tee",
+    });
+    expect(classifyShellCommandIo("sed -i 's/a/b/' /tree/NODE.md")).toEqual({
+      supported: false,
+      reason: "write_or_mutation",
+      commandName: "sed",
+    });
+  });
+
+  it("rejects find expressions with mutating action primaries", () => {
+    expect(classifyShellCommandIo("find /tree -delete")).toEqual({
+      supported: false,
+      reason: "write_or_mutation",
+      commandName: "find",
+    });
+    expect(classifyShellCommandIo("find /tree -exec rm {} \\;")).toEqual({
+      supported: false,
+      reason: "write_or_mutation",
+      commandName: "find",
+    });
+  });
+
+  it("rejects unquoted shell comments instead of parsing comment text as paths", () => {
+    expect(classifyShellCommandIo("cat NODE.md # docs/secret.md")).toEqual({
+      supported: false,
+      reason: "complex_shell",
+    });
+  });
+
+  it("rejects commands without explicit path operands", () => {
+    expect(classifyShellCommandIo("rg Context")).toEqual({
+      supported: false,
+      reason: "no_explicit_path",
+      commandName: "rg",
+    });
+    expect(classifyShellCommandIo("ls")).toEqual({
+      supported: false,
+      reason: "no_explicit_path",
+      commandName: "ls",
+    });
+    expect(classifyShellCommandIo("cat -")).toEqual({
+      supported: false,
+      reason: "no_explicit_path",
+      commandName: "cat",
+    });
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -673,3 +673,10 @@ export {
   WS_AUTH_FRAME_TIMEOUT_MS,
   wsAuthFrameSchema,
 } from "./schemas/ws-auth.js";
+export {
+  classifyShellCommandIo,
+  type ShellIoClassification,
+  type ShellIoPathArg,
+  type ShellIoPathKindHint,
+  type ShellIoUnsupportedReason,
+} from "./shell-command-io.js";

--- a/packages/shared/src/shell-command-io.ts
+++ b/packages/shared/src/shell-command-io.ts
@@ -1,0 +1,524 @@
+export type ShellIoPathKindHint = "file" | "directory" | "unknown";
+
+export type ShellIoPathArg = {
+  raw: string;
+  pathKindHint: ShellIoPathKindHint;
+};
+
+export type ShellIoUnsupportedReason =
+  | "empty"
+  | "unsupported_tool"
+  | "complex_shell"
+  | "write_or_mutation"
+  | "no_explicit_path"
+  | "dynamic_path";
+
+export type ShellIoClassification =
+  | {
+      supported: true;
+      action: "read";
+      commandName: string;
+      pathArgs: ShellIoPathArg[];
+    }
+  | {
+      supported: false;
+      reason: ShellIoUnsupportedReason;
+      commandName?: string;
+    };
+
+type ShellToken = {
+  value: string;
+  dynamic: boolean;
+};
+
+type TokenizeResult =
+  | {
+      ok: true;
+      tokens: ShellToken[];
+    }
+  | {
+      ok: false;
+      reason: ShellIoUnsupportedReason;
+    };
+
+const MUTATING_OR_AMBIGUOUS_TOOLS = new Set([
+  "awk",
+  "bash",
+  "chmod",
+  "chown",
+  "cp",
+  "dd",
+  "echo",
+  "install",
+  "mkdir",
+  "mv",
+  "node",
+  "perl",
+  "printf",
+  "python",
+  "python3",
+  "rm",
+  "rmdir",
+  "sed-i",
+  "sh",
+  "tee",
+  "touch",
+  "truncate",
+  "xargs",
+  "zsh",
+]);
+
+const SIMPLE_FILE_READ_TOOLS = new Set(["cat", "head", "nl", "tail", "wc"]);
+const HEAD_TAIL_VALUE_OPTIONS = new Set(["-c", "--bytes", "-n", "--lines"]);
+const SED_SCRIPT_OPTIONS = new Set(["-e", "--expression", "-f", "--file"]);
+const GREP_PATTERN_OPTIONS = new Set(["-e", "--regexp", "-f", "--file"]);
+const GREP_VALUE_OPTIONS = new Set([
+  ...GREP_PATTERN_OPTIONS,
+  "-A",
+  "--after-context",
+  "-B",
+  "--before-context",
+  "-C",
+  "--context",
+  "-D",
+  "--devices",
+  "-d",
+  "--directories",
+  "-m",
+  "--max-count",
+  "--binary-files",
+  "--color",
+  "--colour",
+  "--exclude",
+  "--exclude-dir",
+  "--exclude-from",
+  "--group-separator",
+  "--include",
+  "--include-dir",
+  "--label",
+]);
+const GREP_BOOLEAN_OPTIONS = new Set([
+  "-a",
+  "--text",
+  "-b",
+  "--byte-offset",
+  "-c",
+  "--count",
+  "-E",
+  "--extended-regexp",
+  "-F",
+  "--fixed-strings",
+  "-G",
+  "--basic-regexp",
+  "-H",
+  "--with-filename",
+  "-h",
+  "--no-filename",
+  "-I",
+  "-i",
+  "--ignore-case",
+  "-L",
+  "--files-without-match",
+  "-l",
+  "--files-with-matches",
+  "-n",
+  "--line-number",
+  "-o",
+  "--only-matching",
+  "-P",
+  "--perl-regexp",
+  "-q",
+  "--quiet",
+  "--silent",
+  "-R",
+  "-r",
+  "--recursive",
+  "--dereference-recursive",
+  "-s",
+  "--no-messages",
+  "-U",
+  "--binary",
+  "-v",
+  "--invert-match",
+  "-w",
+  "--word-regexp",
+  "-x",
+  "--line-regexp",
+  "-z",
+  "--null-data",
+]);
+const RG_VALUE_OPTIONS = new Set([
+  "-A",
+  "--after-context",
+  "-B",
+  "--before-context",
+  "-C",
+  "--context",
+  "-e",
+  "--regexp",
+  "-f",
+  "--file",
+  "-g",
+  "--glob",
+  "-m",
+  "--max-count",
+  "-t",
+  "--type",
+  "-T",
+  "--type-not",
+]);
+const FIND_MUTATING_PRIMARIES = new Set([
+  "-delete",
+  "-exec",
+  "-execdir",
+  "-fls",
+  "-fprint",
+  "-fprint0",
+  "-fprintf",
+  "-ok",
+  "-okdir",
+]);
+
+function tokenizeSimpleShell(command: string): TokenizeResult {
+  if (command.trim().length === 0) return { ok: false, reason: "empty" };
+
+  const tokens: ShellToken[] = [];
+  let value = "";
+  let dynamic = false;
+  let quote: "'" | '"' | null = null;
+
+  const flush = (): void => {
+    if (value.length === 0) return;
+    tokens.push({ value, dynamic });
+    value = "";
+    dynamic = false;
+  };
+
+  for (let i = 0; i < command.length; i++) {
+    const ch = command[i];
+    if (ch === undefined) break;
+
+    if (quote === "'") {
+      if (ch === "'") {
+        quote = null;
+      } else {
+        value += ch;
+      }
+      continue;
+    }
+
+    if (quote === '"') {
+      if (ch === '"') {
+        quote = null;
+        continue;
+      }
+      if (ch === "\\") {
+        const next = command[i + 1];
+        if (next === undefined) return { ok: false, reason: "complex_shell" };
+        value += next;
+        i++;
+        continue;
+      }
+      if (ch === "$" || ch === "`") dynamic = true;
+      value += ch;
+      continue;
+    }
+
+    if (/\s/.test(ch)) {
+      flush();
+      continue;
+    }
+    if (ch === "'" || ch === '"') {
+      quote = ch;
+      continue;
+    }
+    if (ch === "#" && value.length === 0) {
+      return { ok: false, reason: "complex_shell" };
+    }
+    if (ch === "\\") {
+      const next = command[i + 1];
+      if (next === undefined) return { ok: false, reason: "complex_shell" };
+      value += next;
+      i++;
+      continue;
+    }
+    if (ch === "|" || ch === ";" || ch === "&" || ch === ">" || ch === "<" || ch === "\n" || ch === "\r") {
+      return { ok: false, reason: "complex_shell" };
+    }
+    if (ch === "`") dynamic = true;
+    if (ch === "$") dynamic = true;
+    value += ch;
+  }
+
+  if (quote !== null) return { ok: false, reason: "complex_shell" };
+  flush();
+  return tokens.length === 0 ? { ok: false, reason: "empty" } : { ok: true, tokens };
+}
+
+function commandBasename(value: string): string {
+  const normalized = value.replace(/\\/g, "/");
+  const parts = normalized.split("/").filter((part) => part.length > 0);
+  return (parts.at(-1) ?? normalized).toLowerCase();
+}
+
+function isOptionToken(value: string): boolean {
+  return value !== "-" && value !== "--" && value.startsWith("-");
+}
+
+function optionBase(value: string): string {
+  const equalsAt = value.indexOf("=");
+  return equalsAt === -1 ? value : value.slice(0, equalsAt);
+}
+
+function optionConsumesSeparateValue(value: string, options: ReadonlySet<string>): boolean {
+  if (value.includes("=")) return false;
+  return options.has(value);
+}
+
+function isKnownBooleanOption(value: string, options: ReadonlySet<string>): boolean {
+  if (options.has(value)) return true;
+  if (!/^-[A-Za-z]+$/.test(value) || value.startsWith("--")) return false;
+  return value
+    .slice(1)
+    .split("")
+    .every((flag) => options.has(`-${flag}`));
+}
+
+function hasDynamicPathSyntax(token: ShellToken): boolean {
+  return (
+    token.dynamic ||
+    token.value.startsWith("~") ||
+    token.value.includes("$") ||
+    token.value.includes("`") ||
+    /[*?[\]{}]/.test(token.value)
+  );
+}
+
+function pathArg(token: ShellToken, pathKindHint: ShellIoPathKindHint): ShellIoPathArg | ShellIoUnsupportedReason {
+  if (token.value.length === 0 || hasDynamicPathSyntax(token)) return "dynamic_path";
+  return { raw: token.value, pathKindHint };
+}
+
+function finishPathArgs(
+  commandName: string,
+  tokens: ShellToken[],
+  pathKindHint: ShellIoPathKindHint,
+): ShellIoClassification {
+  if (tokens.length === 0) return { supported: false, reason: "no_explicit_path", commandName };
+  const pathArgs: ShellIoPathArg[] = [];
+  for (const token of tokens) {
+    if (token.value === "-") continue;
+    const arg = pathArg(token, pathKindHint);
+    if (typeof arg === "string") return { supported: false, reason: arg, commandName };
+    pathArgs.push(arg);
+  }
+  if (pathArgs.length === 0) return { supported: false, reason: "no_explicit_path", commandName };
+  return { supported: true, action: "read", commandName, pathArgs };
+}
+
+function classifySimpleFileRead(commandName: string, tokens: ShellToken[]): ShellIoClassification {
+  const paths: ShellToken[] = [];
+  let afterDoubleDash = false;
+  for (let i = 1; i < tokens.length; i++) {
+    const token = tokens[i];
+    if (!token) break;
+    const value = token.value;
+    if (!afterDoubleDash && value === "--") {
+      afterDoubleDash = true;
+      continue;
+    }
+    if (!afterDoubleDash && (commandName === "head" || commandName === "tail")) {
+      if (optionConsumesSeparateValue(value, HEAD_TAIL_VALUE_OPTIONS)) {
+        i++;
+        continue;
+      }
+    }
+    if (!afterDoubleDash && isOptionToken(value)) continue;
+    paths.push(token);
+  }
+  return finishPathArgs(commandName, paths, "file");
+}
+
+function classifySed(tokens: ShellToken[]): ShellIoClassification {
+  const commandName = "sed";
+  const paths: ShellToken[] = [];
+  let scriptProvided = false;
+  let afterDoubleDash = false;
+
+  for (let i = 1; i < tokens.length; i++) {
+    const token = tokens[i];
+    if (!token) break;
+    const value = token.value;
+    if (!afterDoubleDash && value === "--") {
+      afterDoubleDash = true;
+      continue;
+    }
+    if (!afterDoubleDash && (value === "-i" || value.startsWith("-i") || optionBase(value) === "--in-place")) {
+      return { supported: false, reason: "write_or_mutation", commandName };
+    }
+    if (!afterDoubleDash && isOptionToken(value)) {
+      const base = optionBase(value);
+      if (SED_SCRIPT_OPTIONS.has(base)) {
+        scriptProvided = true;
+        if (optionConsumesSeparateValue(value, SED_SCRIPT_OPTIONS)) i++;
+      }
+      continue;
+    }
+    if (!scriptProvided) {
+      scriptProvided = true;
+      continue;
+    }
+    paths.push(token);
+  }
+
+  return finishPathArgs(commandName, paths, "file");
+}
+
+function classifyGrep(tokens: ShellToken[]): ShellIoClassification {
+  const commandName = "grep";
+  const paths: ShellToken[] = [];
+  let patternProvided = false;
+  let afterDoubleDash = false;
+
+  for (let i = 1; i < tokens.length; i++) {
+    const token = tokens[i];
+    if (!token) break;
+    const value = token.value;
+    if (!afterDoubleDash && value === "--") {
+      afterDoubleDash = true;
+      continue;
+    }
+    if (!afterDoubleDash && isOptionToken(value)) {
+      const base = optionBase(value);
+      if (GREP_PATTERN_OPTIONS.has(base)) {
+        patternProvided = true;
+      }
+      if (optionConsumesSeparateValue(value, GREP_VALUE_OPTIONS)) i++;
+      if (!GREP_VALUE_OPTIONS.has(base) && !isKnownBooleanOption(value, GREP_BOOLEAN_OPTIONS)) {
+        return { supported: false, reason: "unsupported_tool", commandName };
+      }
+      continue;
+    }
+    if (!patternProvided) {
+      patternProvided = true;
+      continue;
+    }
+    paths.push(token);
+  }
+
+  return finishPathArgs(commandName, paths, "unknown");
+}
+
+function classifyRipgrep(tokens: ShellToken[]): ShellIoClassification {
+  const commandName = "rg";
+  const paths: ShellToken[] = [];
+  let filesMode = false;
+  let patternProvided = false;
+  let afterDoubleDash = false;
+
+  for (let i = 1; i < tokens.length; i++) {
+    const token = tokens[i];
+    if (!token) break;
+    const value = token.value;
+    if (!afterDoubleDash && value === "--") {
+      afterDoubleDash = true;
+      continue;
+    }
+    if (!afterDoubleDash && value === "--files") {
+      filesMode = true;
+      continue;
+    }
+    if (!afterDoubleDash && isOptionToken(value)) {
+      const base = optionBase(value);
+      if (RG_VALUE_OPTIONS.has(base)) {
+        if (base === "-e" || base === "--regexp" || base === "-f" || base === "--file") patternProvided = true;
+        if (optionConsumesSeparateValue(value, RG_VALUE_OPTIONS)) i++;
+      }
+      continue;
+    }
+    if (filesMode) {
+      paths.push(token);
+      continue;
+    }
+    if (!patternProvided) {
+      patternProvided = true;
+      continue;
+    }
+    paths.push(token);
+  }
+
+  return finishPathArgs(commandName, paths, filesMode ? "directory" : "unknown");
+}
+
+function classifyFind(tokens: ShellToken[]): ShellIoClassification {
+  const commandName = "find";
+  const paths: ShellToken[] = [];
+  let afterDoubleDash = false;
+  let expressionStart = tokens.length;
+
+  for (let i = 1; i < tokens.length; i++) {
+    const token = tokens[i];
+    if (!token) break;
+    const value = token.value;
+    if (!afterDoubleDash && value === "--") {
+      afterDoubleDash = true;
+      continue;
+    }
+    if (!afterDoubleDash && (value.startsWith("-") || value === "!" || value === "(" || value === ")")) {
+      expressionStart = i;
+      break;
+    }
+    paths.push(token);
+  }
+
+  for (let i = expressionStart; i < tokens.length; i++) {
+    const value = tokens[i]?.value;
+    if (value && FIND_MUTATING_PRIMARIES.has(value)) {
+      return { supported: false, reason: "write_or_mutation", commandName };
+    }
+  }
+
+  return finishPathArgs(commandName, paths, "directory");
+}
+
+function classifyLs(tokens: ShellToken[]): ShellIoClassification {
+  const commandName = "ls";
+  const paths: ShellToken[] = [];
+  let afterDoubleDash = false;
+
+  for (let i = 1; i < tokens.length; i++) {
+    const token = tokens[i];
+    if (!token) break;
+    const value = token.value;
+    if (!afterDoubleDash && value === "--") {
+      afterDoubleDash = true;
+      continue;
+    }
+    if (!afterDoubleDash && isOptionToken(value)) continue;
+    paths.push(token);
+  }
+
+  return finishPathArgs(commandName, paths, "unknown");
+}
+
+export function classifyShellCommandIo(command: string): ShellIoClassification {
+  const tokenized = tokenizeSimpleShell(command);
+  if (!tokenized.ok) return { supported: false, reason: tokenized.reason };
+
+  const commandToken = tokenized.tokens[0];
+  if (!commandToken) return { supported: false, reason: "empty" };
+  if (commandToken.dynamic) return { supported: false, reason: "dynamic_path" };
+
+  const commandName = commandBasename(commandToken.value);
+  if (MUTATING_OR_AMBIGUOUS_TOOLS.has(commandName)) {
+    return { supported: false, reason: "write_or_mutation", commandName };
+  }
+  if (SIMPLE_FILE_READ_TOOLS.has(commandName)) return classifySimpleFileRead(commandName, tokenized.tokens);
+  if (commandName === "sed") return classifySed(tokenized.tokens);
+  if (commandName === "grep") return classifyGrep(tokenized.tokens);
+  if (commandName === "rg") return classifyRipgrep(tokenized.tokens);
+  if (commandName === "find") return classifyFind(tokenized.tokens);
+  if (commandName === "ls") return classifyLs(tokenized.tokens);
+
+  return { supported: false, reason: "unsupported_tool", commandName };
+}


### PR DESCRIPTION
## Summary
- add a conservative shared shell IO classifier for explicit Context Tree reads
- attach Context Tree repo refs for Codex `command` and Claude Code/TUI `Bash` reads when paths resolve under the local Context Tree checkout
- derive `source=shell_command` IO rows on the server with skip-reason diagnostics while preserving existing direct write tracking

## Scope
- shell read tracking only
- no shell write tracking
- no `resultPreview` inference
- no DB migration

## Verification
- `pnpm --filter @first-tree/shared exec vitest run src/__tests__/shell-command-io.test.ts --poolOptions.threads.maxThreads=2 --poolOptions.threads.minThreads=1`
- `pnpm --filter @first-tree/client exec vitest run src/__tests__/context-tree-file-refs.test.ts src/__tests__/codex-context-tree-io.test.ts src/__tests__/claude-code-tool-events.test.ts --poolOptions.threads.maxThreads=2 --poolOptions.threads.minThreads=1`
- `pnpm --filter @first-tree/server exec vitest run src/__tests__/context-tree-io.test.ts src/__tests__/ws-session-event.test.ts --poolOptions.threads.maxThreads=2 --poolOptions.threads.minThreads=1`
- `pnpm check`
- `pnpm typecheck`

## Review
- codex-reviewer reviewed the worktree and found two shell-classifier blockers
- fixed `find` mutation primaries and unquoted shell comments
- reviewer re-reviewed and found no remaining blockers