### PR TITLE
refactor(web): bring P4 RequestCard + needs_you marker into DESIGN.md conformance

### DIFF
--- a/packages/web/DESIGN.md
+++ b/packages/web/DESIGN.md
@@ -34,8 +34,12 @@
    arrivals — the new-message pill + divider — are green). Working-green is told
    apart from success-green by **form** (pulsing dot + glow vs a static ✓
    glyph), not hue. The states that want your attention are **warm** so they pop
-   against the green/blue live baseline: blocked = orange,
-   error = red. Present-but-idle = blue; offline = gray.
+   against the green/blue live baseline: needs-you (your action / unsaved) =
+   amber, blocked = orange, error = red. Present-but-idle = blue; offline =
+   gray. Where several attention states share one dense surface — the
+   conversation-list corner mark — they collapse to a single attention red and
+   are told apart by *form* (failed `!` / needs-you `?` / unread plain dot),
+   because hue is unreliable at a 9–13px badge (form over hue again).
 4. **Mature collaboration craft, not borrowed color.** Borrow the *discipline*
    — a neutral gray token ramp, hairline borders, soft low-opacity elevation,
    thin line icons, search + underline tabs, rounded-square avatars,
@@ -58,6 +62,7 @@
 | live arrival (new-message pill + divider) | green |
 | selected conversation (liveness) | green (left-rail + tint — distinct from a selected *tab*, which stays neutral) |
 | idle / present | blue (`--state-idle`) |
+| needs you / unsaved (your action) | amber (`--state-needs-you`) |
 | blocked / stuck | orange (`--state-blocked`) |
 | error / failed | red (`--state-error`) |
 | offline | dim gray (`--state-offline`) |
@@ -145,10 +150,17 @@ for text sitting on a saturated colored surface (badges, avatars) and does
 |-------|-----|---------|
 | `--state-working` | green `150` | alive / working — pulses (+ glow on the chat chip); told apart from success by form, not hue |
 | `--state-idle` | blue `245` | present / idle (at rest) |
+| `--state-needs-you` | amber `75` | your action needed / unsaved — distinct from blocked orange; ships a `-soft` fill + `--fg-needs-you-strong` AA text companion (draft chip, tab unsaved dot, open-question REQUEST chip) |
 | `--state-blocked` | orange `58` | blocked / stuck — also the shared caution / warning hue |
 | `--state-error` | red `25` | error / failed |
 | `--state-offline` | dim gray | offline |
 | `--state-unread` | = error | notification/attention (kept separate identifier on purpose) |
+
+> **Conversation-list corner mark is the one place these don't carry their own
+> hue.** failed / needs-you / unread collapse to a single attention **red** and
+> are told apart by glyph (`!` / `?` / plain dot) — see [§7](#7-components) /
+> `chat-row-avatar.tsx`. Everywhere else (chips, dots, tints) each state keeps
+> its semantic hue.
 
 Each state also ships a **soft** companion fill — `--state-working-soft` …
 `--state-offline-soft` (one canonical 14% translucent mix). Use these for

--- a/packages/web/src/components/chat/__tests__/request-card-dom.test.tsx
+++ b/packages/web/src/components/chat/__tests__/request-card-dom.test.tsx
@@ -102,4 +102,26 @@ describe("RequestCard rendering", () => {
     expect(container.textContent).toContain("REQUEST");
     expect(container.textContent).toContain("Rollout");
   });
+
+  it("namespaces option radio groups by message id so two open requests don't merge", async () => {
+    // Question ids are only request-local (both cards use `q1`). The radio
+    // `name` must be namespaced by message id, or the browser groups the two
+    // cards' real radio inputs together and selecting in one clears the other.
+    const a: Message = { ...requestMsg(), id: "reqA" };
+    const b: Message = { ...requestMsg(), id: "reqB" };
+    const container = await renderDom(
+      wrap(
+        <>
+          <RequestCard message={a} thread={[a]} viewerAgentId={HUMAN} body={<div />} resolveAgentName={(id) => id} />
+          <RequestCard message={b} thread={[b]} viewerAgentId={HUMAN} body={<div />} resolveAgentName={(id) => id} />
+        </>,
+      ),
+    );
+    const names = new Set(
+      Array.from(container.querySelectorAll("input[type='radio']")).map((el) => el.getAttribute("name")),
+    );
+    // Two distinct, message-scoped groups — never the bare local id.
+    expect(names).toEqual(new Set(["reqA:q1", "reqB:q1"]));
+    expect(names.has("q1")).toBe(false);
+  });
 });

--- a/packages/web/src/components/chat/__tests__/request-card-dom.test.tsx
+++ b/packages/web/src/components/chat/__tests__/request-card-dom.test.tsx
@@ -97,6 +97,9 @@ describe("RequestCard rendering", () => {
     );
     expect(container.textContent).not.toContain(BODY);
     expect(container.textContent).not.toContain("Ship 5% or 20%?");
-    expect(container.textContent).toContain("Expand");
+    // Collapsed row is a single clickable button (chevron + chip + subject
+    // summary); the whole row expands on click — no separate "Expand" word.
+    expect(container.textContent).toContain("REQUEST");
+    expect(container.textContent).toContain("Rollout");
   });
 });

--- a/packages/web/src/components/chat/chat-row-avatar.tsx
+++ b/packages/web/src/components/chat/chat-row-avatar.tsx
@@ -155,8 +155,9 @@ export function ChatRowAvatar({
    *  unread for the corner badge. */
   failed?: boolean;
   /** Caller has an unanswered open question (`format=request`) directed at
-   *  them here (`openRequestCount > 0`). Amber corner dot; ranks between
-   *  failed and unread. */
+   *  them here (`openRequestCount > 0`). Red `?` corner mark (same attention
+   *  red as failed/unread, told apart by glyph); ranks between failed and
+   *  unread. */
   needsYou?: boolean;
   /** Pixel diameter of the avatar disc. Default 36 fits the narrow rail. */
   size?: number;
@@ -226,13 +227,19 @@ const CORNER_OFFSET = -2;
 
 /**
  * Conversation-list corner marker (mainstream-IM placement: avatar top-right).
- * Failed uses a semantic `!` glyph; `needs_you` (an unanswered open question
- * directed at you) is an amber dot; plain unread is a red dot.
- * Priority: failed > needs_you > unread; renders nothing otherwise.
+ *
+ * One single attention colour (red) for all three states — they are told
+ * apart by *form*, not hue (DESIGN.md pillar 3: "told apart by form, not
+ * hue"; §13: signals stay colour-independent). The glyph encodes which:
+ *   - failed    → `!` (an agent errored)
+ *   - needs_you → `?` (an unanswered open question directed at you)
+ *   - unread    → a plain dot (no glyph)
+ * Glyph-vs-plain-dot also mirrors the priority order failed > needs_you >
+ * unread; renders nothing otherwise.
  */
 function ListCornerMark({ failed, needsYou, unread }: { failed: boolean; needsYou: boolean; unread: boolean }) {
   if (failed) return <CornerMark background="var(--state-error)" fg="var(--fg-on-vivid)" glyph="!" />;
-  if (needsYou) return <CornerMark background="var(--state-needs-you)" />;
+  if (needsYou) return <CornerMark background="var(--state-error)" fg="var(--fg-on-vivid)" glyph="?" />;
   if (unread) return <CornerMark background="var(--state-unread)" />;
   return null;
 }

--- a/packages/web/src/components/chat/request-card.tsx
+++ b/packages/web/src/components/chat/request-card.tsx
@@ -263,7 +263,11 @@ export function RequestCard({
                     <OptionCard
                       key={opt}
                       layout="pill"
-                      name={q.id}
+                      // Namespace the radio group by message id: question ids
+                      // are only request-local (`q1`, …), so two open requests
+                      // in one chat would otherwise share a real radio group and
+                      // selecting in one card would clear the other's DOM state.
+                      name={`${message.id}:${q.id}`}
                       checked={choices[q.id] === opt}
                       disabled={!canAnswer}
                       onSelect={() => setChoices((prev) => ({ ...prev, [q.id]: opt }))}

--- a/packages/web/src/components/chat/request-card.tsx
+++ b/packages/web/src/components/chat/request-card.tsx
@@ -10,49 +10,49 @@
  * viewers get it collapsed by default. Answering sends a normal reply message
  * with `inReplyTo` pointing at the request (the server's −1 / red-dot clear
  * keys off exactly that) — no new endpoint. See proposals/group-chat-unified-send §D1.
+ *
+ * Design (DESIGN.md): `open` keeps card chrome because it is *interactive*
+ * (pillar 5). `resolved` / `closed` are read-only and render as plain labeled
+ * content — no filled/bordered card. Actions reuse the `Button` primitive
+ * (neutral, never green — pillar 2); single-select options reuse `OptionCard`
+ * (neutral dot + tint selection, never a colored border — §7); chips and
+ * affordances use lucide icons, never custom glyphs (§8).
  */
 import type { Message, OpenQuestionItem } from "@first-tree/shared";
 import { useMutation } from "@tanstack/react-query";
-import { type KeyboardEvent, type ReactNode, useMemo, useState } from "react";
+import { ArrowRight, Ban, ChevronRight, CircleCheck, MessageCircleQuestion } from "lucide-react";
+import { type ComponentType, type KeyboardEvent, type ReactNode, useMemo, useState } from "react";
 import { sendChatMessage } from "../../api/chats.js";
+import { Button } from "../ui/button.js";
+import { OptionCard } from "../ui/option-card.js";
 import {
   defaultExpanded,
   deriveRequestState,
   isRelatedViewer,
   isReplacedByNewRequest,
   parseAnswerSelections,
+  type RequestState,
   readMentions,
   readRequestPayload,
 } from "./request-state.js";
 
-const CHIP = {
+type ChipSpec = { label: string; Icon: ComponentType<{ size?: number }>; bg: string; fg: string };
+
+const CHIP: Record<RequestState, ChipSpec> = {
+  // amber needs-you — the open question's "your action needed" lifecycle state.
   open: {
     label: "REQUEST",
-    glyph: "◆",
+    Icon: MessageCircleQuestion,
     bg: "var(--state-needs-you-soft)",
     fg: "var(--fg-needs-you-strong)",
-    bd: "color-mix(in oklch, var(--state-needs-you) 30%, transparent)",
-    left: "var(--state-needs-you)",
   },
-  resolved: {
-    label: "RESOLVED",
-    glyph: "✓",
-    bg: "var(--brand-bg)",
-    fg: "var(--brand-dim)",
-    bd: "var(--brand-ring)",
-    left: "var(--brand)",
-  },
-  closed: {
-    label: "CLOSED",
-    glyph: "⊘",
-    bg: "var(--bg-sunken)",
-    fg: "var(--fg-3)",
-    bd: "var(--border-strong)",
-    left: "var(--border-strong)",
-  },
-} as const;
+  // success green — answered.
+  resolved: { label: "RESOLVED", Icon: CircleCheck, bg: "var(--bg-success-soft)", fg: "var(--fg-success-strong)" },
+  // neutral sunken — withdrawn / superseded.
+  closed: { label: "CLOSED", Icon: Ban, bg: "var(--bg-sunken)", fg: "var(--fg-3)" },
+};
 
-function Chip({ state, target }: { state: keyof typeof CHIP; target?: string }) {
+function Chip({ state, target }: { state: RequestState; target?: string }) {
   const c = CHIP[state];
   return (
     <span
@@ -60,16 +60,16 @@ function Chip({ state, target }: { state: keyof typeof CHIP; target?: string }) 
       style={{
         display: "inline-flex",
         alignItems: "center",
-        gap: 4,
+        gap: "var(--sp-1)",
         padding: "var(--sp-px) var(--sp-1_5)",
         borderRadius: "var(--radius-chip)",
         background: c.bg,
-        border: `var(--hairline) solid ${c.bd}`,
         color: c.fg,
         whiteSpace: "nowrap",
       }}
     >
-      {c.glyph} {c.label}
+      <c.Icon size={11} />
+      {c.label}
       {target ? ` · @${target}` : null}
     </span>
   );
@@ -108,8 +108,8 @@ export function RequestCard({
   const [free, setFree] = useState<Record<string, string>>({});
 
   // For a resolved request, recover the chosen answers from the resolving
-  // reply so the card can highlight them (keyed by prompt). Empty when the
-  // answer was a free-form composer reply that doesn't match the format.
+  // reply so the card can echo them (keyed by prompt). Empty when the answer
+  // was a free-form composer reply that doesn't match the format.
   const selections = useMemo<Record<string, string>>(() => {
     if (state !== "resolved" || !payload) return {};
     const reply = thread.find((m) => m.inReplyTo === message.id && targets.includes(m.senderId));
@@ -166,10 +166,10 @@ export function RequestCard({
         className="text-body"
         style={{
           display: "flex",
-          alignItems: "baseline",
-          gap: 7,
+          alignItems: "center",
+          gap: "var(--sp-1_5)",
           flexWrap: "wrap",
-          marginTop: 4,
+          marginTop: "var(--sp-1)",
           background: "none",
           border: "none",
           padding: 0,
@@ -178,7 +178,7 @@ export function RequestCard({
           width: "100%",
         }}
       >
-        <span style={{ color: "var(--fg-4)" }}>▸</span>
+        <ChevronRight size={13} className="shrink-0" style={{ color: "var(--fg-4)" }} />
         <Chip state={state} />
         <span className="font-semibold" style={{ color: state === "open" ? "var(--fg-2)" : "var(--fg-3)" }}>
           {subject}
@@ -186,16 +186,14 @@ export function RequestCard({
         <span className="mono text-caption" style={{ color: "var(--fg-4)" }}>
           {targetLabel ? `· @${targetLabel} ` : ""}· {summary}
         </span>
-        <span style={{ color: "var(--fg-4)" }}>· Expand</span>
       </button>
     );
   }
 
   // ── Expanded
-  const c = CHIP[state];
   return (
-    <div style={{ marginTop: 4 }}>
-      <div style={{ display: "flex", alignItems: "baseline", gap: 8, flexWrap: "wrap" }}>
+    <div style={{ marginTop: "var(--sp-1)" }}>
+      <div style={{ display: "flex", alignItems: "baseline", gap: "var(--sp-2)", flexWrap: "wrap" }}>
         <Chip state={state} target={targetLabel} />
         <span
           className="text-subtitle font-semibold"
@@ -203,7 +201,7 @@ export function RequestCard({
         >
           {subject}
         </span>
-        {state === "open" && isTarget ? (
+        {canAnswer ? (
           <span className="mono text-caption" style={{ marginLeft: "auto", color: "var(--fg-4)" }}>
             awaiting your answer
           </span>
@@ -214,7 +212,7 @@ export function RequestCard({
             onClick={() => setExpanded(false)}
             className="mono text-caption"
             style={{
-              marginLeft: state === "open" && isTarget ? 8 : "auto",
+              marginLeft: canAnswer ? "var(--sp-2)" : "auto",
               background: "none",
               border: "none",
               color: "var(--fg-4)",
@@ -227,75 +225,52 @@ export function RequestCard({
       </div>
 
       {/* long markdown body */}
-      <div style={{ marginTop: 6 }}>{body}</div>
+      <div style={{ marginTop: "var(--sp-1_5)" }}>{body}</div>
 
-      {/* answer block */}
-      {payload ? (
+      {/* state-specific block: `open` keeps interactive card chrome; `resolved`
+          / `closed` are read-only and render as plain labeled content — no
+          filled/bordered card (DESIGN.md pillar 5). */}
+      {state === "open" && payload ? (
         <div
           style={{
-            marginTop: 11,
+            marginTop: "var(--sp-3)",
             border: "var(--hairline) solid var(--border)",
-            borderLeft: `var(--hairline-bold) solid ${c.left}`,
             borderRadius: "var(--radius-panel)",
-            background:
-              state === "open"
-                ? "color-mix(in oklch, var(--state-needs-you) 4%, var(--bg-raised))"
-                : "var(--bg-sunken)",
+            background: "color-mix(in oklch, var(--state-needs-you) 4%, var(--bg-raised))",
             padding: "var(--sp-2_5) var(--sp-3)",
           }}
         >
           <div
             className="mono text-caption font-semibold"
-            style={{ color: c.fg, textTransform: "uppercase", marginBottom: 8 }}
+            style={{ color: "var(--fg-needs-you-strong)", textTransform: "uppercase", marginBottom: "var(--sp-2)" }}
           >
-            {state === "resolved"
-              ? "Answered"
-              : state === "closed"
-                ? superseded
-                  ? "Closed · superseded by an updated question"
-                  : "Closed · withdrawn by the asker"
-                : canAnswer
-                  ? `Your answer · ${questionCount} question${questionCount === 1 ? "" : "s"}`
-                  : `Questions · ${questionCount}`}
+            {canAnswer
+              ? `Your answer · ${questionCount} question${questionCount === 1 ? "" : "s"}`
+              : `Questions · ${questionCount}`}
           </div>
 
           {payload.questions.map((q, i) => (
-            <div key={q.id} style={{ margin: i === 0 ? "0" : "var(--sp-3) 0 0" }}>
+            <div key={q.id} style={{ marginTop: i === 0 ? 0 : "var(--sp-3)" }}>
               <div className="text-body font-medium" style={{ color: "var(--fg)" }}>
-                <span
-                  className="mono text-caption"
-                  style={{ color: "var(--fg-4)", marginRight: 6 }}
-                >{`Q${i + 1}`}</span>
+                <span className="mono text-caption" style={{ color: "var(--fg-4)", marginRight: "var(--sp-1_5)" }}>
+                  {`Q${i + 1}`}
+                </span>
                 {q.prompt}
               </div>
               {q.kind === "single" ? (
-                <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginTop: 6 }}>
-                  {q.options.map((opt) => {
-                    const staged = canAnswer && choices[q.id] === opt;
-                    const isChosen = selections[q.prompt] === opt;
-                    const highlight = staged || isChosen;
-                    const dim = state === "resolved" && selections[q.prompt] !== undefined && !isChosen;
-                    return (
-                      <button
-                        key={opt}
-                        type="button"
-                        disabled={!canAnswer}
-                        onClick={() => setChoices((prev) => ({ ...prev, [q.id]: opt }))}
-                        className={highlight ? "text-body font-semibold" : "text-body"}
-                        style={{
-                          padding: "var(--sp-1) var(--sp-2_5)",
-                          borderRadius: "var(--radius-input)",
-                          border: `var(--hairline) solid ${highlight ? "var(--brand)" : "var(--border-strong)"}`,
-                          background: highlight ? "var(--brand-bg)" : "var(--bg-raised)",
-                          color: highlight ? "var(--brand-dim)" : "var(--fg)",
-                          cursor: canAnswer ? "pointer" : "default",
-                          opacity: dim ? 0.4 : canAnswer || highlight ? 1 : 0.6,
-                        }}
-                      >
-                        {opt}
-                      </button>
-                    );
-                  })}
+                <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--sp-1_5)", marginTop: "var(--sp-1_5)" }}>
+                  {q.options.map((opt) => (
+                    <OptionCard
+                      key={opt}
+                      layout="pill"
+                      name={q.id}
+                      checked={choices[q.id] === opt}
+                      disabled={!canAnswer}
+                      onSelect={() => setChoices((prev) => ({ ...prev, [q.id]: opt }))}
+                    >
+                      <span className="text-body">{opt}</span>
+                    </OptionCard>
+                  ))}
                 </div>
               ) : canAnswer ? (
                 <textarea
@@ -306,30 +281,18 @@ export function RequestCard({
                   className="text-body"
                   style={{
                     width: "100%",
-                    marginTop: 6,
+                    marginTop: "var(--sp-1_5)",
                     border: "var(--hairline) solid var(--border-strong)",
                     borderRadius: "var(--radius-input)",
                     background: "var(--bg-raised)",
                     padding: "var(--sp-1_5) var(--sp-2)",
                     color: "var(--fg)",
-                    minHeight: 42,
+                    minHeight: "var(--sp-10)",
                     resize: "vertical",
                   }}
                 />
-              ) : selections[q.prompt] ? (
-                <div
-                  className="text-body"
-                  style={{
-                    marginTop: 6,
-                    color: "var(--fg-2)",
-                    borderLeft: "var(--hairline-bold) solid var(--border)",
-                    paddingLeft: "var(--sp-2)",
-                  }}
-                >
-                  {selections[q.prompt]}
-                </div>
               ) : (
-                <div className="text-caption mono" style={{ color: "var(--fg-4)", marginTop: 4 }}>
+                <div className="text-caption mono" style={{ color: "var(--fg-4)", marginTop: "var(--sp-1)" }}>
                   (free-text answer)
                 </div>
               )}
@@ -339,31 +302,23 @@ export function RequestCard({
           {canAnswer ? (
             <div
               style={{
-                marginTop: 12,
+                marginTop: "var(--sp-3)",
                 display: "flex",
                 alignItems: "center",
-                gap: 10,
+                gap: "var(--sp-2_5)",
                 borderTop: "var(--hairline) solid var(--border-faint)",
-                paddingTop: 10,
+                paddingTop: "var(--sp-2_5)",
               }}
             >
-              <button
+              <Button
                 type="button"
+                size="sm"
                 onClick={submit}
                 onKeyDown={onKeyDown}
                 disabled={!allRequiredAnswered || mut.isPending}
-                className="text-body font-semibold"
-                style={{
-                  padding: "var(--sp-1_25) var(--sp-4)",
-                  borderRadius: "var(--radius-input)",
-                  border: "none",
-                  cursor: !allRequiredAnswered || mut.isPending ? "not-allowed" : "pointer",
-                  background: !allRequiredAnswered || mut.isPending ? "var(--bg-active)" : "var(--brand)",
-                  color: !allRequiredAnswered || mut.isPending ? "var(--fg-4)" : "var(--primary-on)",
-                }}
               >
                 {mut.isPending ? "Sending…" : "Reply"}
-              </button>
+              </Button>
               <span className="mono text-caption" style={{ color: "var(--fg-4)" }}>
                 Selections are staged — Reply to send (⌘↵)
               </span>
@@ -371,9 +326,53 @@ export function RequestCard({
           ) : null}
 
           {mut.isError ? (
-            <div className="text-caption mono" style={{ color: "var(--state-error)", marginTop: 6 }}>
+            <div className="text-caption mono" style={{ color: "var(--state-error)", marginTop: "var(--sp-1_5)" }}>
               Failed to send — try again.
             </div>
+          ) : null}
+        </div>
+      ) : null}
+
+      {/* resolved — read-only echo of the chosen answers, no card chrome */}
+      {state === "resolved" && payload ? (
+        <div
+          style={{
+            marginTop: "var(--sp-2)",
+            paddingTop: "var(--sp-2)",
+            borderTop: "var(--hairline) solid var(--border-faint)",
+          }}
+        >
+          {payload.questions.map((q, i) => (
+            <div
+              key={q.id}
+              className="text-body"
+              style={{
+                display: "flex",
+                alignItems: "baseline",
+                flexWrap: "wrap",
+                gap: "var(--sp-2)",
+                marginTop: i === 0 ? 0 : "var(--sp-1)",
+              }}
+            >
+              <span className="mono text-caption" style={{ color: "var(--fg-4)" }}>{`Q${i + 1}`}</span>
+              <span style={{ color: "var(--fg-3)" }}>{q.prompt}</span>
+              <ArrowRight size={13} className="shrink-0 self-center" style={{ color: "var(--fg-4)" }} />
+              <span className="font-medium" style={{ color: "var(--fg)" }}>
+                {selections[q.prompt] ?? "answered"}
+              </span>
+            </div>
+          ))}
+        </div>
+      ) : null}
+
+      {/* closed — read-only one-line status, no card chrome */}
+      {state === "closed" ? (
+        <div className="text-body" style={{ marginTop: "var(--sp-1_5)", color: "var(--fg-3)" }}>
+          {superseded ? "Superseded by an updated question." : "Withdrawn by the asker."}
+          {questionCount > 0 ? (
+            <span style={{ color: "var(--fg-4)" }}>
+              {` · ${questionCount} question${questionCount === 1 ? "" : "s"} unanswered`}
+            </span>
           ) : null}
         </div>
       ) : null}


### PR DESCRIPTION
## 目标

#782 ship 的 P4 UI 通过了 token 守卫，但在守卫**抓不到的语义规范**上偏离了 `DESIGN.md`。本 PR 让 P4 UI 回到规范 —— DESIGN.md 是 source of truth。纯 web UI / 文档改动，无 server / schema / 行为变化。

## 改动

### `RequestCard`（request-card.tsx）
- **Reply 按钮**复用中性 `Button`（原 brand-green —— 违 pillar 2「日常动作用 neutral，绿色只留 hero/creation」的 green-primary collision）。
- **单选项**复用 `OptionCard`（中性填充圆点 + tint；原饱和绿边框/绿底 —— 违 §7 OptionCard 选中态规则）。
- **chip / 折叠字形** `◆ ⊘ ▸` → lucide 图标（§8 lucide-only）。
- **`resolved` / `closed` 去卡壳**：只读态改朴素标注内容，不裹 filled/bordered 卡（pillar 5「informational ≠ card」）。`open` 保留卡壳，因为它是交互态。
- 间距全归一到 `--sp-*` 阶梯（§5）。

### 会话列表 corner mark（chat-row-avatar.tsx）
- `needs_you` 原是 amber 点，与红色 unread 点**只靠色相区分**。改为三态统一 attention **红**，靠**形态**区分：failed `!` / needs_you `?` / unread 纯点 —— pillar 3「told apart by form, not hue」/ §13 信号 color-independent。

### `DESIGN.md`
- 把 amber `--state-needs-you` 登记进「Semantic color map」+「State/status」两张表 + pillar 3 暖色句（它早已通过 draft chip / tab 未保存点 / REQUEST chip 在用，只是文档漏登）。
- 注明会话列表 corner mark 的单红 + 字形例外，使 rail-vs-chip 的颜色差异是有意为之。

## 校验
- ✅ `tsc --noEmit`
- ✅ `lint:tokens`（design-token 守卫干净）
- ✅ `biome check`
- ✅ web 全量测试 **639/639**
- ✅ **截图 QA PASS**（@qa，桌面 1440×1000 + 移动 390×844；OPEN 中性 Reply 实测 `oklch(0.21 0 0)`、OptionCard 中性选中态、RESOLVED/CLOSED 去卡壳、withdrawn/superseded 文案、replacement 新 OPEN、free-text 回显、左栏 needs_you 统一红 `?`、无横向溢出/重叠）

🤖 Generated with [Claude Code](https://claude.com/claude-code)