### PR TITLE
fix: avoid late Codex retry abort

### DIFF
--- a/packages/client/src/__tests__/codex-resilience.test.ts
+++ b/packages/client/src/__tests__/codex-resilience.test.ts
@@ -25,10 +25,9 @@ const usage = (input: number, cached: number, output: number, reasoning = 0) => 
  *     between tests — otherwise leaked state from one test contaminates
  *     the next.
  *
- * The full `runTurn` retry loop (mock Codex + Thread + SessionContext) is
- * intentionally NOT covered here — testing it end-to-end requires faking
- * the bootstrap / git-mirror / first-tree integration chain, which would
- * double the PR scope. The retry path's correctness rests on:
+ * The full `runTurn` retry loop needs a mock Codex + Thread + SessionContext,
+ * so the targeted regression for that state machine lives in
+ * `codex-retry-abort.test.ts`. The classifier path's correctness here rests on:
  *   1. typecheck (covers `usageBox` narrowing + control flow)
  *   2. `isTransientCodexErrorMessage` table (this file)
  *   3. the existing `codex-bootstrap.test.ts` / `codex-thread-options.test.ts`

--- a/packages/client/src/__tests__/codex-retry-abort.test.ts
+++ b/packages/client/src/__tests__/codex-retry-abort.test.ts
@@ -1,0 +1,226 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { SessionEvent } from "@first-tree/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChatContext } from "../runtime/chat-context.js";
+import type { SessionContext, SessionMessage } from "../runtime/handler.js";
+import { mockCtxPlumbing } from "./test-helpers.js";
+
+type MockState = {
+  runInputs: unknown[];
+  signals: AbortSignal[];
+  streamClosedByAttempt: boolean[];
+  lateAbortAfterClose: boolean;
+};
+
+const state = vi.hoisted<MockState>(() => ({
+  runInputs: [],
+  signals: [],
+  streamClosedByAttempt: [],
+  lateAbortAfterClose: false,
+}));
+
+vi.mock("@openai/codex-sdk", () => {
+  const usage = {
+    input_tokens: 1,
+    cached_input_tokens: 0,
+    output_tokens: 1,
+    reasoning_output_tokens: 0,
+  };
+
+  const thread = {
+    id: "thread-retry-abort",
+    async runStreamed(input: unknown, opts: { signal?: AbortSignal } = {}) {
+      state.runInputs.push(input);
+      const attempt = state.runInputs.length;
+      const attemptIndex = attempt - 1;
+      const signal = opts.signal;
+      if (signal) {
+        state.signals.push(signal);
+        signal.addEventListener("abort", () => {
+          if (state.streamClosedByAttempt[attemptIndex]) state.lateAbortAfterClose = true;
+        });
+      }
+
+      return {
+        events: (async function* () {
+          try {
+            yield { type: "thread.started", thread_id: "thread-retry-abort" };
+            if (attempt === 1) {
+              yield { type: "error", message: "stream disconnected before completion: fetch failed" };
+              return;
+            }
+            yield {
+              type: "item.completed",
+              item: { type: "agent_message", text: "retry succeeded" },
+            };
+            yield { type: "turn.completed", usage };
+          } finally {
+            state.streamClosedByAttempt[attemptIndex] = true;
+          }
+        })(),
+      };
+    },
+  };
+
+  return {
+    Codex: class {
+      startThread() {
+        return thread;
+      }
+      resumeThread() {
+        return thread;
+      }
+    },
+  };
+});
+
+vi.mock("../runtime/bootstrap.js", () => ({
+  FIRST_TREE_WORKSPACE_MARKER: ".first-tree-workspace",
+  bootstrapWorkspace: vi.fn(),
+  buildChatSystemPrompt: vi.fn(() => ""),
+  deepEqualIdentity: vi.fn(() => true),
+  generateToolsDoc: vi.fn(() => ""),
+  installCoreSkills: vi.fn(),
+  installFirstTreeIntegration: vi.fn(() => true),
+  isHubWorktreeMarker: vi.fn(() => false),
+  readCachedBundledCliVersion: vi.fn(() => null),
+  readCachedContextTreeHead: vi.fn(() => null),
+  readContextTreeHead: vi.fn(() => null),
+  resolveBundledCliVersion: vi.fn(() => "0.0.0-test"),
+  writeBundledCliVersion: vi.fn(),
+  writeContextTreeHead: vi.fn(),
+}));
+
+vi.mock("../runtime/chat-context.js", () => ({
+  fetchChatContext: vi.fn(async (): Promise<ChatContext> => {
+    return {
+      chatId: "chat-retry-abort",
+      title: "retry abort",
+      topic: null,
+      participants: [],
+    };
+  }),
+}));
+
+import { createCodexHandler } from "../handlers/codex.js";
+
+const AGENT_ID = "019e71c9-88d2-70be-be67-fdb033b2ef0b";
+
+let workspaceRoot: string;
+
+type SendMessageMock = ReturnType<typeof vi.fn<(chatId: string, body: Record<string, unknown>) => Promise<unknown>>>;
+
+function makeMessage(id: string, content: string): SessionMessage {
+  return {
+    id,
+    chatId: "chat-retry-abort",
+    senderId: "sender-1",
+    format: "text",
+    content,
+    metadata: {},
+  };
+}
+
+function makeContext(
+  markCompleted: (count?: number) => void,
+  opts: {
+    sendMessage?: SendMessageMock;
+    emitEvent?: SessionContext["emitEvent"];
+    log?: SessionContext["log"];
+  } = {},
+): SessionContext {
+  const sendMessage =
+    opts.sendMessage ??
+    vi.fn<(chatId: string, body: Record<string, unknown>) => Promise<unknown>>().mockResolvedValue(undefined);
+  return {
+    agent: {
+      agentId: AGENT_ID,
+      inboxId: `inbox_${AGENT_ID}`,
+      displayName: "codex-assistant",
+      type: "agent",
+      visibility: "organization",
+      delegateMention: null,
+      metadata: {},
+    },
+    sdk: { serverUrl: "http://test", sendMessage } as unknown as SessionContext["sdk"],
+    chatId: "chat-retry-abort",
+    log: opts.log ?? (() => {}),
+    touch: () => {},
+    setRuntimeState: () => {},
+    emitEvent: opts.emitEvent ?? (() => {}),
+    ...mockCtxPlumbing({ sendMessage }, "chat-retry-abort"),
+    markCompleted,
+  };
+}
+
+async function waitForMicrotasks(predicate: () => boolean, label: string): Promise<void> {
+  for (let i = 0; i < 20; i++) {
+    if (predicate()) return;
+    await Promise.resolve();
+  }
+  throw new Error(`timed out waiting for ${label}`);
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  workspaceRoot = mkdtempSync(join(tmpdir(), "ft-codex-retry-abort-"));
+  state.runInputs.length = 0;
+  state.signals.length = 0;
+  state.streamClosedByAttempt.length = 0;
+  state.lateAbortAfterClose = false;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  rmSync(workspaceRoot, { recursive: true, force: true });
+});
+
+describe("codex handler retry abort cleanup", () => {
+  it("retries a transient stream failure without aborting the per-attempt signal after iterator close", async () => {
+    const completedCounts: Array<number | undefined> = [];
+    const logs: string[] = [];
+    const sendMessage = vi
+      .fn<(chatId: string, body: Record<string, unknown>) => Promise<unknown>>()
+      .mockResolvedValue(undefined);
+    const emitEvent = vi.fn<(event: SessionEvent) => void>();
+    const handler = createCodexHandler({ workspaceRoot });
+    const ctx = makeContext((count) => completedCounts.push(count), {
+      sendMessage,
+      emitEvent,
+      log: (message) => logs.push(message),
+    });
+
+    const startPromise = handler.start(makeMessage("m1", "first"), ctx);
+
+    await waitForMicrotasks(
+      () => state.streamClosedByAttempt[0] === true && logs.some((message) => message.includes("codex turn retry")),
+      "first attempt retry backoff",
+    );
+
+    expect(state.runInputs).toHaveLength(1);
+    expect(state.lateAbortAfterClose).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(500);
+    await startPromise;
+
+    const events = emitEvent.mock.calls.map(([event]) => event);
+    const assistantTexts: string[] = [];
+    for (const event of events) {
+      if (event.kind === "assistant_text") assistantTexts.push(event.payload.text);
+    }
+
+    expect(state.runInputs).toHaveLength(2);
+    expect(state.signals).toHaveLength(2);
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage.mock.calls[0]?.[1].content).toBe("retry succeeded");
+    expect(assistantTexts).toEqual(["retry succeeded"]);
+    expect(events.some((event) => event.kind === "error")).toBe(false);
+    expect(events.some((event) => event.kind === "turn_end" && event.payload.status === "success")).toBe(true);
+    expect(completedCounts).toEqual([1]);
+    expect(state.lateAbortAfterClose).toBe(false);
+
+    await handler.shutdown();
+  });
+});

--- a/packages/client/src/handlers/codex.ts
+++ b/packages/client/src/handlers/codex.ts
@@ -829,15 +829,12 @@ export const createCodexHandler: HandlerFactory = (config) => {
         let retryDelay = 0;
         let retryReason = "";
 
-        // Per-attempt child AbortController (PR #600 review nit #4): the
-        // codex-sdk Thread exposes no explicit close/cancel beyond the
-        // AbortSignal passed to runStreamed. If we `break` out of the
-        // for-await on a transient `turn.failed` and reuse the parent
-        // signal, the SDK's background generator + child-process stdout
-        // reader can keep draining the dead stream until child exit.
-        // A fresh child controller per attempt lets us explicitly tear
-        // down the previous stream before starting the next, while
-        // suspend/shutdown still cascades down via the parent listener.
+        // Per-attempt child AbortController (PR #600 review nit #4): keep
+        // parent suspend/shutdown cancellation scoped to the active
+        // runStreamed() call without reusing the parent signal across retry
+        // attempts. Retry teardown itself is handled by closing the async
+        // iterator; aborting this signal after the SDK stream has closed can
+        // surface a late ChildProcess AbortError after SDK listeners are gone.
         const attemptAbort = new AbortController();
         const onParentAbort = (): void => attemptAbort.abort();
         abort.signal.addEventListener("abort", onParentAbort, { once: true });
@@ -923,16 +920,18 @@ export const createCodexHandler: HandlerFactory = (config) => {
         }
 
         if (!retryRequested) break;
-        // Explicit tear-down: kill the previous stream before the backoff
-        // sleep so its drain doesn't overlap the next attempt's child
-        // process. No-op if the parent already aborted (the listener
-        // above already cascaded).
-        attemptAbort.abort();
+        // Breaking out of the for-await has already closed the SDK event
+        // iterator for this attempt. Do not abort the per-attempt spawn
+        // signal here: in @openai/codex-sdk cleanup may already have removed
+        // child listeners, and a late abort can become an unhandled
+        // ChildProcess AbortError that crashes the client. The backoff still
+        // listens to the parent signal below, so suspend/shutdown can cut it
+        // short without starting another attempt.
         sessionCtx.log(`codex turn retry ${attempt + 1}/${MAX_TURN_RETRIES + 1} after ${retryDelay}ms; ${retryReason}`);
         try {
           // Sleep on PARENT signal: only suspend/shutdown should cut
-          // short the backoff window, not the retry-triggered abort we
-          // just fired on the per-attempt controller.
+          // short the backoff window. The per-attempt signal belongs to the
+          // already-closed SDK iterator and is intentionally left untouched.
           await sleepWithAbort(retryDelay, abort.signal);
         } catch {
           // AbortError — suspend/shutdown raced ahead; let the abort path


### PR DESCRIPTION
## Summary

- Stop aborting the per-attempt Codex spawn signal after the SDK event iterator has already closed during retry cleanup.
- Keep parent suspend/shutdown cancellation intact through the active-attempt listener and parent-signal backoff sleep.
- Add a focused regression test that retries a transient stream failure without a late post-close abort, then verifies final forwarding, `turn_end:success`, and `markCompleted(1)` semantics.

## Review

- Reviewed by `codex-reviewer` in the workspace chat.
- Initial review found no blocking issues and suggested one comment cleanup.
- Follow-up review passed after the comment was updated.

## Testing

- `pnpm --filter @first-tree/client exec vitest run --passWithNoTests --maxWorkers=2 codex-retry-abort codex-resilience`
- `pnpm --filter @first-tree/client exec vitest run --passWithNoTests --maxWorkers=2`
- `pnpm --filter first-tree-dev typecheck`
- `pnpm --filter first-tree-dev build`
- `pnpm check` (exit 0; reports one existing info-level style suggestion in untouched `packages/client/src/handlers/claude-code-tui/tmux-session.ts`)
