### PR TITLE
Detect gh PR creation with repo flags

### DIFF
--- a/packages/server/src/__tests__/github-entity-extractor.test.ts
+++ b/packages/server/src/__tests__/github-entity-extractor.test.ts
@@ -45,6 +45,40 @@ describe("extractGithubEntity", () => {
     });
   });
 
+  it("extracts a pull_request entity from Codex bash-wrapped gh commands with a repo flag", () => {
+    const result = extractGithubEntity(
+      basePayload({
+        name: "command",
+        args: {
+          command:
+            '/bin/bash -lc \'gh -R baixiaohang/first-tree-agent-prompts pr create --base main --head prompt-git-autonomy-362531 --title "Allow codex agents to refresh their workspaces" --body "body"\'',
+        },
+        resultPreview: "https://github.com/baixiaohang/first-tree-agent-prompts/pull/6\n",
+      }),
+    );
+    expect(result).toEqual({
+      entityType: "pull_request",
+      entityKey: "baixiaohang/first-tree-agent-prompts#6",
+      entityUrl: "https://github.com/baixiaohang/first-tree-agent-prompts/pull/6",
+      source: "bash-gh-pr",
+    });
+  });
+
+  it("extracts a pull_request entity from gh commands with an equals-form repo flag", () => {
+    const result = extractGithubEntity(
+      basePayload({
+        args: { command: "gh --repo=owner/repo pr create --title feat --body body" },
+        resultPreview: "https://github.com/owner/repo/pull/79",
+      }),
+    );
+    expect(result).toEqual({
+      entityType: "pull_request",
+      entityKey: "owner/repo#79",
+      entityUrl: "https://github.com/owner/repo/pull/79",
+      source: "bash-gh-pr",
+    });
+  });
+
   it("extracts an issue entity from `gh issue create` output", () => {
     const result = extractGithubEntity(
       basePayload({
@@ -56,6 +90,21 @@ describe("extractGithubEntity", () => {
       entityType: "issue",
       entityKey: "owner/repo#77",
       entityUrl: "https://github.com/owner/repo/issues/77",
+      source: "bash-gh-issue",
+    });
+  });
+
+  it("extracts an issue entity from gh commands with a global repo flag", () => {
+    const result = extractGithubEntity(
+      basePayload({
+        args: { command: "gh --repo owner/repo issue create --title bug --body details" },
+        resultPreview: "https://github.com/owner/repo/issues/78",
+      }),
+    );
+    expect(result).toEqual({
+      entityType: "issue",
+      entityKey: "owner/repo#78",
+      entityUrl: "https://github.com/owner/repo/issues/78",
       source: "bash-gh-issue",
     });
   });
@@ -104,6 +153,18 @@ describe("extractGithubEntity", () => {
         basePayload({
           args: { command: "gh pr list" },
           resultPreview: "#1 fix bug https://github.com/owner/repo/pull/1",
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it("ignores long dash-token gh commands that do not create an entity", () => {
+    const dashTokens = Array.from({ length: 48 }, () => "-x").join(" ");
+    expect(
+      extractGithubEntity(
+        basePayload({
+          args: { command: `gh ${dashTokens} zzz` },
+          resultPreview: "https://github.com/owner/repo/pull/1",
         }),
       ),
     ).toBeNull();

--- a/packages/server/src/services/github-entity-extractor.ts
+++ b/packages/server/src/services/github-entity-extractor.ts
@@ -31,8 +31,15 @@ export type ExtractedEntity = {
   source: "bash-gh-pr" | "bash-gh-issue";
 };
 
-const PR_COMMAND_RE = /\bgh\s+pr\s+create\b/;
-const ISSUE_COMMAND_RE = /\bgh\s+issue\s+create\b/;
+const SHELL_WORD_RE = String.raw`(?:"[^"]*"|'[^']*'|[^\s]+)`;
+const GH_GLOBAL_OPTION_RE = String.raw`-{1,2}[^\s=]+(?:=${SHELL_WORD_RE})?(?:\s+${SHELL_WORD_RE})?`;
+const MAX_GH_GLOBAL_OPTIONS = 12;
+const PR_COMMAND_RE = new RegExp(
+  String.raw`\bgh(?:\s+${GH_GLOBAL_OPTION_RE}){0,${MAX_GH_GLOBAL_OPTIONS}}\s+pr\s+create\b`,
+);
+const ISSUE_COMMAND_RE = new RegExp(
+  String.raw`\bgh(?:\s+${GH_GLOBAL_OPTION_RE}){0,${MAX_GH_GLOBAL_OPTIONS}}\s+issue\s+create\b`,
+);
 const PR_URL_RE = /https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/pull\/(\d+)/;
 const ISSUE_URL_RE = /https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/issues\/(\d+)/;
 const SHELL_TOOL_NAMES = new Set(["Bash", "command"]);
@@ -43,7 +50,8 @@ export function extractGithubEntity(payload: ToolCallEventPayload): ExtractedEnt
 
   const args = payload.args;
   if (typeof args !== "object" || args === null) return null;
-  const command = (args as { command?: unknown }).command;
+  if (!("command" in args)) return null;
+  const command = args.command;
   if (typeof command !== "string") return null;
 
   const preview = payload.resultPreview ?? "";


### PR DESCRIPTION
## Summary
- detect `gh pr create` and `gh issue create` when global gh flags such as `-R` / `--repo` appear before the subcommand
- add regression coverage for Codex bash-wrapped `gh -R ... pr create` output
- keep the binding path scoped to successful shell tool calls with GitHub URLs in `resultPreview`

## Verification
- `VITEST_MAX_FORKS=2 pnpm --filter @first-tree/server exec vitest run src/__tests__/github-entity-extractor.test.ts`
- `VITEST_MAX_FORKS=2 pnpm --filter @first-tree/server test -- src/__tests__/github-entity-extractor.test.ts` (ran full server suite due package-script arg forwarding; 153 files / 1270 tests passed)
- `pnpm check`
- `pnpm typecheck`
- `pnpm --filter @first-tree/server typecheck`
- `git diff --check`