### PR TITLE
fix: show total tokens in usage activity

### DIFF
--- a/packages/web/src/pages/agent-detail/__tests__/usage-tab.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/usage-tab.test.tsx
@@ -244,16 +244,33 @@ afterEach(() => {
 describe("UsageTab", () => {
   it("renders activity, recent turns, and chat navigation", async () => {
     const { UsageTab } = await import("../usage-tab.js");
+    const today = new Date();
+    today.setUTCHours(0, 0, 0, 0);
+    usageMocks.getAgentUsageSummary.mockResolvedValue(
+      summary({
+        daily: [
+          {
+            date: today.toISOString().slice(0, 10),
+            inputTokens: 9_000,
+            cachedInputTokens: 1_000,
+            outputTokens: 500,
+            turns: 4,
+          },
+        ],
+      }),
+    );
 
     const { container, root } = await renderUsageTab(<UsageTab />);
+    const activityCells = [...container.querySelectorAll("span.usage-cal-cell[role='img']")];
     expect(container.textContent).not.toContain("Usage overview");
     expect(container.textContent).toContain("Activity");
     expect(container.textContent).toContain("last 90 days");
-    expect(container.querySelectorAll("span.usage-cal-cell[role='img']").length).toBe(90);
+    expect(activityCells.length).toBe(90);
     expect(container.textContent).toContain("Active days");
     expect(container.textContent).toContain("Peak day");
     expect(container.textContent).toContain("Recent turns");
-    expect(container.textContent).toContain("Daily input tokens. Darker cells mean more usage.");
+    expect(container.textContent).toContain("Daily total tokens. Darker cells mean more usage.");
+    expect(activityCells.find((cell) => cell.getAttribute("aria-label")?.includes("10.5K total tokens"))).toBeDefined();
     expect(container.textContent).toContain("Last 10 turns from the last 30 days.");
     expect(container.textContent).toContain("Launch planning");
     expect(container.textContent).toContain("private chat");

--- a/packages/web/src/pages/agent-detail/usage-tab.tsx
+++ b/packages/web/src/pages/agent-detail/usage-tab.tsx
@@ -94,7 +94,7 @@ function ActivityBlock({
           </span>
         </>
       }
-      description="Daily input tokens. Darker cells mean more usage."
+      description="Daily total tokens. Darker cells mean more usage."
       action={<DensityLegend />}
     >
       {isError ? (
@@ -214,7 +214,7 @@ function Cell({
     <span
       role="img"
       aria-label={`${WEEKDAYS[day.weekday]} ${MONTHS[day.month]} ${day.day}: ${
-        day.tokens > 0 ? `${formatCompactCount(day.tokens)} input tokens` : "no activity"
+        day.tokens > 0 ? `${formatCompactCount(day.tokens)} total tokens` : "no activity"
       }`}
       onMouseEnter={onEnter}
       onMouseLeave={onLeave}
@@ -226,7 +226,7 @@ function Cell({
 
 function CellTooltip({ day, anchorX, anchorY }: { day: DayBucket; anchorX: number; anchorY: number }): ReactElement {
   const label = `${WEEKDAYS[day.weekday]} · ${MONTHS[day.month]} ${day.day}, ${day.year}`;
-  const value = day.tokens > 0 ? `${formatCompactCount(day.tokens)} input tokens` : "No activity";
+  const value = day.tokens > 0 ? `${formatCompactCount(day.tokens)} total tokens` : "No activity";
   return (
     <div role="tooltip" className="usage-cal-tooltip" style={{ left: anchorX, top: anchorY }}>
       <div className="text-eyebrow mono" style={{ color: "var(--fg-3)" }}>
@@ -259,7 +259,7 @@ function ActivityStatsPanel({
           </>
         }
       />
-      <StatTile label="Avg input / day" value={formatCompactCount(stats.avgPerDay)} mono />
+      <StatTile label="Avg tokens / day" value={formatCompactCount(stats.avgPerDay)} mono />
       <StatTile label="Peak day" value={peakLabel} mono />
       <StatTile
         label="Current streak"
@@ -417,7 +417,9 @@ function buildDays(daily: UsageAgentSummary["daily"] | undefined): DayBucket[] {
   // UTC consistently — local-tz Date methods would shift weekday/date by ±1
   // half the day in non-UTC zones and silently miss the join key.
   const byDate = new Map<string, number>();
-  for (const d of daily ?? []) byDate.set(d.date, d.inputTokens);
+  for (const d of daily ?? []) {
+    byDate.set(d.date, d.inputTokens + d.cachedInputTokens + d.outputTokens);
+  }
   const today = new Date();
   today.setUTCHours(0, 0, 0, 0);
   const days: DayBucket[] = [];


### PR DESCRIPTION
## Summary
- update the agent Usage activity calendar to aggregate input, cached input, and output tokens
- relabel the activity description, tooltip, aria text, and average stat as total tokens
- add a regression assertion for daily total token rendering

## Verification
- pnpm --filter @first-tree/web test -- src/pages/agent-detail/__tests__/usage-tab.test.tsx --maxWorkers=2
- pnpm check
- pnpm typecheck