### PR TITLE
fix(web): stop tailwind-merge eating button text colors at sm/xs

### DIFF
--- a/packages/web/src/components/ui/__tests__/button-variants.test.ts
+++ b/packages/web/src/components/ui/__tests__/button-variants.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { cn } from "../../../lib/utils.js";
+import { buttonVariants } from "../button.js";
+
+/**
+ * Regression guard for the "dark-on-dark Save button" bug.
+ *
+ * The design system's typography scale (text-label / text-body / …) ships as
+ * Tailwind v4 @theme font-size utilities. tailwind-merge's *default* config
+ * misclassifies those custom names as text-COLOR utilities, so a class string
+ * carrying both a color (text-primary-foreground) and a size (text-label, added
+ * by Button size="sm"/"xs") would have its color silently dropped — leaving small
+ * filled buttons inheriting --fg (dark text) on a dark bg. `cn()` registers the
+ * scale in the font-size group to keep the two in separate conflict groups.
+ *
+ * If someone reverts `cn` back to a bare twMerge, these assertions fail.
+ */
+describe("cn — custom typography scale does not eat text colors", () => {
+  it("keeps the text color when a custom font-size class follows it", () => {
+    const out = cn("text-primary-foreground", "text-label");
+    expect(out).toContain("text-primary-foreground");
+    expect(out).toContain("text-label");
+  });
+
+  it("still resolves two competing custom font-sizes to the last one", () => {
+    const out = cn("text-body", "text-label");
+    expect(out).toContain("text-label");
+    expect(out).not.toContain("text-body");
+  });
+});
+
+describe("buttonVariants — filled variants keep their text color at every size", () => {
+  // Every filled variant pairs a bg with an explicit on-color; small sizes append
+  // a custom font-size class (text-label) that must not strip that on-color.
+  const filled: Array<[string, string]> = [
+    ["default", "text-primary-foreground"],
+    ["destructive", "text-destructive-foreground"],
+    ["secondary", "text-secondary-foreground"],
+  ];
+
+  for (const [variant, expectedColor] of filled) {
+    for (const size of ["sm", "xs", "default"] as const) {
+      it(`${variant} @ ${size} retains ${expectedColor}`, () => {
+        const out = buttonVariants({ variant: variant as never, size });
+        expect(out).toContain(expectedColor);
+      });
+    }
+  }
+
+  it("cta @ sm retains its on-vivid text color", () => {
+    const out = buttonVariants({ variant: "cta", size: "sm" });
+    expect(out).toContain("text-[color:var(--fg-on-vivid)]");
+  });
+});

--- a/packages/web/src/lib/utils.ts
+++ b/packages/web/src/lib/utils.ts
@@ -1,5 +1,37 @@
 import { type ClassValue, clsx } from "clsx";
-import { twMerge } from "tailwind-merge";
+import { extendTailwindMerge } from "tailwind-merge";
+
+// The design system defines its typography scale (text-eyebrow … text-display)
+// as Tailwind v4 @theme font-size utilities — see the `@theme inline` block in
+// index.css. tailwind-merge's default config doesn't know these custom names, so
+// it misclassifies them as text-COLOR utilities. When a class string carries both
+// a color (e.g. `text-primary-foreground`) and a size (e.g. `text-label`, added by
+// Button size="sm"/"xs"), the default twMerge thinks they conflict and drops the
+// earlier color class — leaving small filled buttons with no text color (they then
+// inherit --fg → dark-on-dark). Registering the scale in the `font-size` group keeps
+// size and color in separate conflict groups so both survive.
+const twMerge = extendTailwindMerge({
+  extend: {
+    classGroups: {
+      "font-size": [
+        {
+          text: [
+            "eyebrow",
+            "caption",
+            "label",
+            "body",
+            "subtitle",
+            "title",
+            "live",
+            "lead",
+            "headline",
+            "display",
+          ],
+        },
+      ],
+    },
+  },
+});
 
 export function cn(...inputs: ClassValue[]): string {
   return twMerge(clsx(inputs));

--- a/packages/web/src/lib/utils.ts
+++ b/packages/web/src/lib/utils.ts
@@ -14,20 +14,7 @@ const twMerge = extendTailwindMerge({
   extend: {
     classGroups: {
       "font-size": [
-        {
-          text: [
-            "eyebrow",
-            "caption",
-            "label",
-            "body",
-            "subtitle",
-            "title",
-            "live",
-            "lead",
-            "headline",
-            "display",
-          ],
-        },
+        { text: ["eyebrow", "caption", "label", "body", "subtitle", "title", "lead", "headline", "display"] },
       ],
     },
   },


### PR DESCRIPTION
## Problem

On the agent-detail **Save bar**, the **Save** button rendered near-black background + **dark-gray text** — "Save" was nearly unreadable (reported with screenshot). The button's *background* was correct; its *text color* was being silently dropped.

## Root cause (not a save-bar mistake — a systemic `cn()` bug)

The design system's typography scale (`text-eyebrow … text-display`) ships as Tailwind v4 `@theme` **font-size** utilities. `cn()` used a bare `twMerge`, whose default config doesn't know these custom names and **misclassifies them as text-COLOR utilities**.

So when a class string carries both a color (`text-primary-foreground`) and a size (`text-label`, appended by `Button size="sm"/"xs"`), `twMerge` thought they conflicted and **dropped the earlier color class**. The button then inherited the page's dark `--fg` → dark-on-dark.

Verified with the repo's own `tailwind-merge`: at `size="sm"`/`"xs"`, **every filled variant** (`default` / `cta` / `destructive` / `secondary`) lost its text color. `size="default"` was unaffected (no `text-*` size class). So this hit small filled buttons app-wide, not just the Save bar.

## Fix

Root-cause, one change: `cn()` now uses `extendTailwindMerge` to register the custom scale in the **`font-size`** group, so size and color land in separate conflict groups and both survive. Zero hardcoded colors/sizes — fully token-driven, DESIGN.md-compliant. The save bar itself is untouched (its variant/hierarchy choices were already correct).

Adds `button-variants` regression tests that fail if `cn()` is reverted to a bare `twMerge`.

## Verification

- ✅ `pnpm --filter @first-tree/web typecheck` (tsc + `lint:tokens`) — clean
- ✅ New regression tests — 12/12 pass
- ✅ Full web suite — 500/500 pass (no regressions from this shared-util change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)