### PR TITLE
fix: commit inbox acks through delivered prefix

### DIFF
--- a/packages/client/scripts/copy-bundled-skills.mjs
+++ b/packages/client/scripts/copy-bundled-skills.mjs
@@ -18,13 +18,7 @@ import { fileURLToPath } from "node:url";
 // To add a skill: drop its directory under repo-root `skills/<name>/`, then
 // add the name here. To retire one: remove it from this list AND delete the
 // directory under repo-root `skills/`.
-const BUNDLED_SKILLS = [
-  "first-tree",
-  "first-tree-context",
-  "first-tree-onboarding",
-  "first-tree-sync",
-  "first-tree-write",
-];
+const BUNDLED_SKILLS = ["first-tree", "first-tree-context", "first-tree-onboarding", "first-tree-sync"];
 
 function findRepoRoot(startDir) {
   let currentDir = resolve(startDir);

--- a/packages/client/src/__tests__/bootstrap.test.ts
+++ b/packages/client/src/__tests__/bootstrap.test.ts
@@ -391,13 +391,7 @@ function makeFixtureSkillsRoot(
 }
 
 describe("installFirstTreeIntegration (inline skill installer)", () => {
-  const TREE_SKILLS = [
-    "first-tree",
-    "first-tree-context",
-    "first-tree-onboarding",
-    "first-tree-sync",
-    "first-tree-write",
-  ];
+  const TREE_SKILLS = ["first-tree", "first-tree-context", "first-tree-onboarding", "first-tree-sync"];
 
   function expectSkillInstalled(workspace: string, name: string): void {
     const agentsDir = join(workspace, ".agents", "skills", name);
@@ -488,7 +482,6 @@ describe("installFirstTreeIntegration (inline skill installer)", () => {
       { name: "first-tree-context", version: "1.0.0" },
       { name: "first-tree-onboarding", version: "1.0.0" },
       { name: "first-tree-sync", version: "1.0.0" },
-      { name: "first-tree-write", version: "1.0.0" },
     ]);
 
     const logs: string[] = [];
@@ -531,9 +524,7 @@ describe("installFirstTreeIntegration (inline skill installer)", () => {
     // first-tree installs successfully, the others all fail.
     expectSkillInstalled(workspace, "first-tree");
     expect(existsSync(join(workspace, ".agents", "skills", "first-tree-sync"))).toBe(false);
-    expect(logs.join("\n")).toContain(
-      "failed first-tree-context, first-tree-onboarding, first-tree-sync, first-tree-write",
-    );
+    expect(logs.join("\n")).toContain("failed first-tree-context, first-tree-onboarding, first-tree-sync");
     expect(logs.join("\n")).toContain("First-tree skill install failed (first-tree-context)");
   });
 
@@ -902,13 +893,7 @@ describe("deepEqualIdentity", () => {
  * giving it a complete vs incomplete bundled-skills layout.
  */
 describe("CLI-version pin contract (handler invariants)", () => {
-  const TREE_SKILLS = [
-    "first-tree",
-    "first-tree-context",
-    "first-tree-onboarding",
-    "first-tree-sync",
-    "first-tree-write",
-  ];
+  const TREE_SKILLS = ["first-tree", "first-tree-context", "first-tree-onboarding", "first-tree-sync"];
 
   it("does not overwrite the existing pin when integrate fails — next start retries", () => {
     const workspace = join(tmpBase, "cli-pin-failure-keeps-stale");

--- a/packages/client/src/__tests__/claude-code-inject-startup-race.test.ts
+++ b/packages/client/src/__tests__/claude-code-inject-startup-race.test.ts
@@ -129,6 +129,7 @@ function makeContext(
     ...mockCtxPlumbing({ sendMessage }, "chat-claude-startup-race"),
     ...(opts.formatInboundContent ? { formatInboundContent: opts.formatInboundContent } : {}),
     markCompleted,
+    markMessagesCompleted: () => markCompleted(),
   };
 }
 

--- a/packages/client/src/__tests__/claude-code-stream-error-retry-replay.test.ts
+++ b/packages/client/src/__tests__/claude-code-stream-error-retry-replay.test.ts
@@ -155,6 +155,7 @@ describe("claude-code handler — transient stream-error retry replays user mess
       emitEvent: (e) => emitted.push(e),
       ...mockCtxPlumbing({ sendMessage }, "chat-stream-retry"),
       markCompleted,
+      markMessagesCompleted: () => markCompleted(),
     };
 
     await handler.start(

--- a/packages/client/src/__tests__/claude-code-turn-end-auto-resume-fail.test.ts
+++ b/packages/client/src/__tests__/claude-code-turn-end-auto-resume-fail.test.ts
@@ -109,6 +109,7 @@ describe("claude-code handler — auto-resume failure surfacing", () => {
       emitEvent: (e) => emitted.push(e),
       ...mockCtxPlumbing({ sendMessage }, "chat-resume-fail"),
       markCompleted,
+      markMessagesCompleted: () => markCompleted(),
     };
 
     await handler.start(

--- a/packages/client/src/__tests__/claude-code-turn-end-retry-exhausted.test.ts
+++ b/packages/client/src/__tests__/claude-code-turn-end-retry-exhausted.test.ts
@@ -95,6 +95,7 @@ describe("claude-code handler — retry-exhausted surfacing", () => {
       emitEvent: (e) => emitted.push(e),
       ...mockCtxPlumbing({ sendMessage }, "chat-retry"),
       markCompleted,
+      markMessagesCompleted: () => markCompleted(),
     };
 
     await handler.start(

--- a/packages/client/src/__tests__/client-connection-inbox-malformed.test.ts
+++ b/packages/client/src/__tests__/client-connection-inbox-malformed.test.ts
@@ -74,7 +74,7 @@ describe("ClientConnection — malformed inbox:deliver frame", () => {
     await new Promise<void>((resolve) => httpServer.close(() => resolve()));
   });
 
-  it("best-effort acks the entryId so the next bind reset doesn't replay the unparseable frame", async () => {
+  it("does not ack a malformed frame even when entryId is usable", async () => {
     const token = makeJwt({ exp: Math.floor(Date.now() / 1000) + 3600 });
     const setup: ServerSetup = {
       ackedEntryIds: [],
@@ -100,20 +100,8 @@ describe("ClientConnection — malformed inbox:deliver frame", () => {
     await connection.connect();
     expect(connection.isConnected).toBe(true);
 
-    await new Promise<void>((resolve, reject) => {
-      const timer = setTimeout(() => reject(new Error("ack not received within 2s")), 2_000);
-      const check = (): void => {
-        if (setup.ackedEntryIds.includes(9999)) {
-          clearTimeout(timer);
-          resolve();
-          return;
-        }
-        setTimeout(check, 25);
-      };
-      check();
-    });
-
-    expect(setup.ackedEntryIds).toEqual([9999]);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(setup.ackedEntryIds).toEqual([]);
 
     await connection.disconnect();
   }, 10_000);

--- a/packages/client/src/__tests__/codex-inject-startup-race.test.ts
+++ b/packages/client/src/__tests__/codex-inject-startup-race.test.ts
@@ -131,6 +131,7 @@ function makeContext(
     emitEvent: opts.emitEvent ?? (() => {}),
     ...mockCtxPlumbing({ sendMessage }, "chat-startup-race"),
     markCompleted,
+    markMessagesCompleted: (messages) => markCompleted(Array.isArray(messages) ? messages.length : 1),
   };
 }
 

--- a/packages/client/src/__tests__/codex-retry-abort.test.ts
+++ b/packages/client/src/__tests__/codex-retry-abort.test.ts
@@ -151,6 +151,7 @@ function makeContext(
     emitEvent: opts.emitEvent ?? (() => {}),
     ...mockCtxPlumbing({ sendMessage }, "chat-retry-abort"),
     markCompleted,
+    markMessagesCompleted: (messages) => markCompleted(Array.isArray(messages) ? messages.length : 1),
   };
 }
 

--- a/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
+++ b/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
@@ -36,7 +36,7 @@ type SessionManagerInternals = {
   // entryId tracking moved out of PendingMessage and into a per-chat
   // FIFO (`inFlightEntries`) per the in-flight message recovery PR.
   pendingQueue: Array<{ message: SessionMessage; chatId: string }>;
-  inFlightEntries: Map<string, number[]>;
+  inFlightEntries: Map<string, Array<{ entryId: number; messageId: string; dedupKey: string }>>;
   _activeCount: number;
   acquireActiveSlot(chatId: string, message: SessionMessage): boolean;
   routeMessage(chatId: string, message: SessionMessage): Promise<void>;
@@ -48,7 +48,6 @@ type SessionManagerInternals = {
   notifySessionState(chatId: string, state: SessionState): void;
   reaffirmRuntimeStates(): void;
   persistRegistry(): void;
-  ackInFlightEntries(chatId: string, count: number): void;
   drainAllInFlightEntries(chatId: string): void;
 };
 
@@ -269,11 +268,9 @@ describe("SessionManager edge coverage", () => {
     await sm.handleCommand("missing", "session:terminate");
     await sm.handleCommand("chat-active", "session:suspend");
     await sm.dispatch(mockEntry({ id: 2, chatId: "chat-active" }));
-    // Post inflight-message-recovery: dispatch defers ack until the
-    // handler calls `ctx.markCompleted()` (or session-manager drains on
-    // terminate / permanent failure). The entry sits in the per-chat
-    // FIFO `inFlightEntries`. Verify that's where it lands.
-    expect(internals(sm).inFlightEntries.get("chat-active")).toContain(2);
+    // Ack-through fail-closed: suspending abandons unfinished delivered
+    // entries and blocks same-chat delivery until bind reset/redelivery.
+    expect(internals(sm).inFlightEntries.has("chat-active")).toBe(false);
     expect(ackEntry).not.toHaveBeenCalledWith(2);
 
     internals(sm).pendingQueue.push({ chatId: "chat-queued", message: makeMessage("chat-queued") });

--- a/packages/client/src/__tests__/session-manager.test.ts
+++ b/packages/client/src/__tests__/session-manager.test.ts
@@ -1,5 +1,7 @@
+import type { AgentRuntimeConfig } from "@first-tree/shared";
 import type pino from "pino";
 import { describe, expect, it, vi } from "vitest";
+import type { AgentConfigCache } from "../runtime/agent-config-cache.js";
 import type { AgentHandler, HandlerFactory, SessionContext } from "../runtime/handler.js";
 import { SessionManager } from "../runtime/session-manager.js";
 import type { FirstTreeHubSDK } from "../sdk.js";
@@ -18,6 +20,14 @@ function mockSdk(): FirstTreeHubSDK {
 /** Create a vi-mocked WS ack callback for SessionManager tests. */
 function mockAckEntry() {
   return vi.fn<(entryId: number) => Promise<void>>().mockResolvedValue(undefined);
+}
+
+function deferred<T>() {
+  let resolve: (value: T) => void = () => {};
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
 }
 
 /** Create a mock handler conforming to the new session-oriented interface. */
@@ -44,6 +54,7 @@ function createSessionManager(opts: {
   };
   concurrency?: number;
   log?: pino.Logger;
+  agentConfigCache?: AgentConfigCache;
 }) {
   const handler = opts.handler ?? createMockHandler();
   const factory: HandlerFactory = () => handler;
@@ -71,6 +82,7 @@ function createSessionManager(opts: {
     sdk,
     log: opts.log ?? silentLogger(),
     ackEntry: opts.ackEntry ?? mockAckEntry(),
+    agentConfigCache: opts.agentConfigCache,
   });
 }
 
@@ -188,14 +200,13 @@ describe("SessionManager", () => {
 
   it("still deduplicates genuine redelivery within the same chat", async () => {
     // Counterpart to the cross-chat-key test above: within a single chat,
-    // at-least-once delivery must still be idempotent. Two entries with the
-    // same (chatId, messageId) but different inbox entry ids must collapse
-    // to one handler invocation.
+    // at-least-once delivery of the same active entry must still be
+    // idempotent.
     const handler = createMockHandler();
     const sm = createSessionManager({ handler });
 
     await sm.dispatch(mockEntry({ id: 20, chatId: "chat-x", messageId: "msg-redeliver" }));
-    await sm.dispatch(mockEntry({ id: 21, chatId: "chat-x", messageId: "msg-redeliver" }));
+    await sm.dispatch(mockEntry({ id: 20, chatId: "chat-x", messageId: "msg-redeliver" }));
 
     expect(handler.start).toHaveBeenCalledTimes(1);
 
@@ -263,11 +274,13 @@ describe("SessionManager", () => {
     expect(ackEntry).not.toHaveBeenCalled();
 
     // Simulate server-side bind-reset redelivery of the SAME entry for
-    // the LRU-evicted chat. If the dedup key were still around this
+    // the LRU-evicted chat. The bind event clears the local recovery guard;
+    // if the dedup key were still around this
     // would dedup-hit and (post-#1-fix) get re-acked, shortcutting
     // recovery. With the dedup key dropped at eviction time, the entry
     // routes normally through startNewSession → handler.resume against
     // the saved evictedMappings.
+    sm.noteBindRecoveryComplete();
     await sm.dispatch(mockEntry({ id: 70, chatId: "chat-a", messageId: "msg-a" }));
 
     // Recovery path: handler.resume invoked once for chat-a (it was
@@ -280,26 +293,15 @@ describe("SessionManager", () => {
     await sm.shutdown();
   });
 
-  it("re-acks a dedup-hit when the entry is no longer in-flight (turn already markCompleted, prior ack lost)", async () => {
-    // Repro of the bug behind "agent re-outputs after client restart":
-    //   1. dispatch entry N, handler runs the turn, markCompleted shifts
-    //      N out of inFlightEntries and fires `ackEntry(N)`.
-    //   2. The ack frame never lands server-side (fire-and-forget WS / TCP
-    //      half-open / reaper-race against `ackEntryByIdForBoundAgents`'s
-    //      `status='delivered'` filter).
-    //   3. The next `agent:bind` resets the entry from delivered → pending
-    //      and `drainBacklogForAgent` redelivers the same entryId.
-    //   4. dispatch sees the same (chatId, messageId) in dedup → short-
-    //      circuits. Pre-fix: silent return, entry stays delivered, loop
-    //      until process restart. Post-fix: re-ack the entry so the server
-    //      marks it acked and stops redelivering.
+  it("drops dedup after completion so ack-lost redelivery re-enters the handler instead of re-acking", async () => {
     const ackEntry = mockAckEntry();
     let capturedCtx: SessionContext | undefined;
     const startSpy = vi.fn(async (_msg: unknown, ctx: SessionContext) => {
       capturedCtx = ctx;
       return "session-id-mock";
     });
-    const handler = createMockHandler({ start: startSpy });
+    const injectSpy = vi.fn();
+    const handler = createMockHandler({ start: startSpy, inject: injectSpy });
     const sm = createSessionManager({ ackEntry, handler });
 
     // Turn 1: original delivery.
@@ -310,15 +312,15 @@ describe("SessionManager", () => {
     expect(ackEntry).toHaveBeenLastCalledWith(60);
 
     // Simulate server-side bind-reset redelivery of the same entryId after
-    // the original ack went missing. Entry is no longer in inFlightEntries.
+    // the original ack went missing. The completed entry's dedup key was
+    // dropped when ack-through was sent, so this is treated as at-least-once
+    // redelivery and re-enters the active handler instead of sending a
+    // standalone re-ack from the dedup branch.
     await sm.dispatch(mockEntry({ id: 60, chatId: "chat-redeliver", messageId: "msg-redeliver" }));
 
-    // Handler did NOT re-run (dedup still suppresses processing).
     expect(startSpy).toHaveBeenCalledTimes(1);
-    // But the re-ack DID fire so the server can mark the entry acked and
-    // stop the redelivery loop.
-    expect(ackEntry).toHaveBeenCalledTimes(2);
-    expect(ackEntry).toHaveBeenLastCalledWith(60);
+    expect(injectSpy).toHaveBeenCalledTimes(1);
+    expect(ackEntry).toHaveBeenCalledTimes(1);
 
     await sm.shutdown();
   });
@@ -511,6 +513,10 @@ describe("SessionManager", () => {
     await sm.dispatch(mockEntry({ id: 4, chatId: "chat-4" }));
     expect(sm.totalCount).toBe(2);
 
+    // Simulate the next agent:bind reset before redelivery into an evicted
+    // chat. Until that happens the runtime blocks the chat to avoid
+    // ack-through committing abandoned delivered entries.
+    sm.noteBindRecoveryComplete();
     // Now send a message to evicted chat-1 — should resume, not start
     await sm.dispatch(mockEntry({ id: 5, chatId: "chat-1" }));
 
@@ -670,39 +676,36 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     await sm.shutdown();
   });
 
-  it("markCompleted() shifts one entry by default — pairs one user message with one assistant turn", async () => {
-    // Reviewer Blocking 1 regression. Two consecutive dispatches into a
-    // single active chat push two entries onto the FIFO. The handler's
-    // turn for the FIRST message must ack ONLY the first entry; the
-    // second stays queued for its own turn's markCompleted. The previous
-    // implementation drained the whole queue per markCompleted and
-    // would silently ack message #2 before its handler turn completed —
-    // making a crash between the two turns lose message #2 forever.
+  it("markMessagesCompleted(message) acks through the concrete consumed entry only", async () => {
     const ackEntry = vi.fn().mockResolvedValue(undefined);
     let capturedCtx: SessionContext | undefined;
+    let firstMessage: Parameters<AgentHandler["start"]>[0] | undefined;
+    const injected: Parameters<AgentHandler["inject"]>[0][] = [];
     const handler = createMockHandler({
-      async start(_m, ctx) {
+      async start(m, ctx) {
+        firstMessage = m;
         capturedCtx = ctx;
         return "session-id-mock";
       },
+      inject: vi.fn((m) => {
+        injected.push(m);
+      }),
     });
     const { sm } = buildSm(ackEntry, handler);
 
     await sm.dispatch(mockEntry({ id: 1, chatId: "chat-1" }));
-    // Second dispatch hits the `active` inject branch — entry sits behind
-    // entry #1 in the FIFO.
     await sm.dispatch(mockEntry({ id: 2, chatId: "chat-1" }));
 
     expect(ackEntry).not.toHaveBeenCalled();
 
     // First turn closes — ack entry #1 only.
-    capturedCtx?.markCompleted();
+    if (firstMessage) capturedCtx?.markMessagesCompleted(firstMessage);
     await Promise.resolve();
     expect(ackEntry).toHaveBeenCalledTimes(1);
     expect(ackEntry).toHaveBeenCalledWith(1);
 
     // Second turn closes — ack entry #2.
-    capturedCtx?.markCompleted();
+    if (injected[0]) capturedCtx?.markMessagesCompleted(injected[0]);
     await Promise.resolve();
     expect(ackEntry).toHaveBeenCalledTimes(2);
     expect(ackEntry).toHaveBeenNthCalledWith(2, 2);
@@ -710,20 +713,20 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     await sm.shutdown();
   });
 
-  it("markCompleted(n) acks N entries atomically — covers codex mergeAndRun fused-turn semantics", async () => {
-    // Codex's `mergeAndRun` fuses N injected messages into one SDK turn
-    // emitting one forwardResult. The handler passes `drained.length` so
-    // ALL fused entries get acked together. We simulate that here: A
-    // arrives, B & C arrive during A's turn (mid-turn injects); when A's
-    // turn ends the handler acks `count = 1` for A; when the fused B+C
-    // turn ends it acks `count = 2` for the pair.
+  it("markMessagesCompleted(batch) sends one ack-through for the batch tail", async () => {
     const ackEntry = vi.fn().mockResolvedValue(undefined);
     let capturedCtx: SessionContext | undefined;
+    let firstMessage: Parameters<AgentHandler["start"]>[0] | undefined;
+    const injected: Parameters<AgentHandler["inject"]>[0][] = [];
     const handler = createMockHandler({
-      async start(_m, ctx) {
+      async start(m, ctx) {
+        firstMessage = m;
         capturedCtx = ctx;
         return "session-id-mock";
       },
+      inject: vi.fn((m) => {
+        injected.push(m);
+      }),
     });
     const { sm } = buildSm(ackEntry, handler);
 
@@ -733,28 +736,27 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     expect(ackEntry).not.toHaveBeenCalled();
 
     // First turn (just message 10).
-    capturedCtx?.markCompleted(1);
+    if (firstMessage) capturedCtx?.markMessagesCompleted(firstMessage);
     await Promise.resolve();
     expect(ackEntry).toHaveBeenCalledTimes(1);
     expect(ackEntry).toHaveBeenCalledWith(10);
 
     // Fused turn (messages 11 + 12 batched into one runTurn).
-    capturedCtx?.markCompleted(2);
+    capturedCtx?.markMessagesCompleted(injected);
     await Promise.resolve();
-    expect(ackEntry).toHaveBeenCalledTimes(3);
-    expect(ackEntry).toHaveBeenNthCalledWith(2, 11);
-    expect(ackEntry).toHaveBeenNthCalledWith(3, 12);
+    expect(ackEntry).toHaveBeenCalledTimes(2);
+    expect(ackEntry).toHaveBeenNthCalledWith(2, 12);
 
     await sm.shutdown();
   });
 
-  it("markCompleted(count) clamps to queue length — over-counting drains the rest, not negative entries", async () => {
-    // Defensive: a handler bug or codex mergeAndRun count drift must not
-    // crash or ack phantom entries. The shift just stops at the queue end.
+  it("markMessagesCompleted ignores stale messages that are no longer tracked", async () => {
     const ackEntry = vi.fn().mockResolvedValue(undefined);
     let capturedCtx: SessionContext | undefined;
+    let capturedMessage: Parameters<AgentHandler["start"]>[0] | undefined;
     const handler = createMockHandler({
-      async start(_m, ctx) {
+      async start(m, ctx) {
+        capturedMessage = m;
         capturedCtx = ctx;
         return "session-id-mock";
       },
@@ -762,16 +764,165 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     const { sm } = buildSm(ackEntry, handler);
 
     await sm.dispatch(mockEntry({ id: 20, chatId: "chat-clamp" }));
-    capturedCtx?.markCompleted(99); // queue length is 1
+    if (capturedMessage) capturedCtx?.markMessagesCompleted(capturedMessage);
     await Promise.resolve();
     expect(ackEntry).toHaveBeenCalledTimes(1);
     expect(ackEntry).toHaveBeenCalledWith(20);
 
-    // Further calls with an empty queue are no-ops.
-    capturedCtx?.markCompleted();
-    capturedCtx?.markCompleted(5);
+    if (capturedMessage) capturedCtx?.markMessagesCompleted(capturedMessage);
     await Promise.resolve();
     expect(ackEntry).toHaveBeenCalledTimes(1);
+
+    await sm.shutdown();
+  });
+
+  it("serializes same-chat admission before routing later delivered frames", async () => {
+    const ackEntry = vi.fn().mockResolvedValue(undefined);
+    const firstRefresh = deferred<AgentRuntimeConfig>();
+    let refreshCalls = 0;
+    const agentConfigCache: AgentConfigCache = {
+      get: vi.fn(),
+      refreshIfNewer: vi.fn(() => {
+        refreshCalls++;
+        return refreshCalls === 1 ? firstRefresh.promise : Promise.resolve({} as AgentRuntimeConfig);
+      }),
+      refresh: vi.fn(async () => ({}) as AgentRuntimeConfig),
+      updateUrls: vi.fn(),
+      allReferencedUrls: vi.fn(() => new Set<string>()),
+      forget: vi.fn(),
+    };
+    const routed: string[] = [];
+    const injected: Parameters<AgentHandler["inject"]>[0][] = [];
+    let capturedCtx: SessionContext | undefined;
+    const handler = createMockHandler({
+      async start(m, ctx) {
+        routed.push(`start:${m.id}`);
+        capturedCtx = ctx;
+        return "session-id-mock";
+      },
+      inject: vi.fn((m) => {
+        routed.push(`inject:${m.id}`);
+        injected.push(m);
+      }),
+    });
+    const sm = createSessionManager({ ackEntry, handler, agentConfigCache });
+
+    const firstDispatch = sm.dispatch(mockEntry({ id: 1, chatId: "chat-admit", messageId: "msg-a1" }));
+    await vi.waitFor(() => expect(agentConfigCache.refreshIfNewer).toHaveBeenCalledTimes(1));
+
+    const secondDispatch = sm.dispatch(mockEntry({ id: 2, chatId: "chat-admit", messageId: "msg-a2" }));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(routed).toEqual([]);
+    expect(handler.inject).not.toHaveBeenCalled();
+    expect(ackEntry).not.toHaveBeenCalled();
+
+    firstRefresh.resolve({} as AgentRuntimeConfig);
+    await firstDispatch;
+    await secondDispatch;
+
+    expect(routed).toEqual(["start:msg-a1", "inject:msg-a2"]);
+    expect(agentConfigCache.refreshIfNewer).toHaveBeenCalledTimes(2);
+
+    if (injected[0]) capturedCtx?.markMessagesCompleted(injected[0]);
+    await Promise.resolve();
+    expect(ackEntry).toHaveBeenCalledTimes(1);
+    expect(ackEntry).toHaveBeenCalledWith(2);
+
+    await sm.shutdown();
+  });
+
+  it("fails closed when routeMessage fails after an entry was marked admitted", async () => {
+    const ackEntry = vi.fn().mockResolvedValue(undefined);
+    const recoveryStart = vi.fn(async () => "session-id-recovery");
+    let factoryCalls = 0;
+    const factory = vi.fn<HandlerFactory>(() => {
+      factoryCalls++;
+      if (factoryCalls === 1) throw new Error("handler factory offline");
+      return createMockHandler({ start: recoveryStart });
+    });
+    const sm = new SessionManager({
+      session: { idle_timeout: 300, max_sessions: 10, working_grace_seconds: 3600, reconcile_interval_seconds: 300 },
+      concurrency: 5,
+      handlerFactory: factory,
+      handlerConfig: { workspaceRoot: "/tmp/test" },
+      agentIdentity: {
+        agentId: "agent-1",
+        inboxId: "inbox-agent-1",
+        displayName: "Agent",
+        type: "agent",
+        visibility: "organization",
+        delegateMention: null,
+        metadata: {},
+      },
+      sdk: mockSdk(),
+      log: silentLogger(),
+      ackEntry,
+    });
+
+    await expect(sm.dispatch(mockEntry({ id: 1, chatId: "chat-route-fail", messageId: "msg-a1" }))).rejects.toThrow(
+      "handler factory offline",
+    );
+
+    await sm.dispatch(mockEntry({ id: 2, chatId: "chat-route-fail", messageId: "msg-a2" }));
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(recoveryStart).not.toHaveBeenCalled();
+    expect(ackEntry).not.toHaveBeenCalled();
+
+    await sm.shutdown();
+  });
+
+  it("suspend abandons unfinished in-flight entries and blocks newer same-chat delivery until bind recovery", async () => {
+    const ackEntry = vi.fn().mockResolvedValue(undefined);
+    let capturedCtx: SessionContext | undefined;
+    const resumeSpy = vi.fn(async () => "session-id-mock");
+    const handler = createMockHandler({
+      async start(_m, ctx) {
+        capturedCtx = ctx;
+        return "session-id-mock";
+      },
+      resume: resumeSpy,
+    });
+    const { sm } = buildSm(ackEntry, handler);
+
+    await sm.dispatch(mockEntry({ id: 30, chatId: "chat-suspend", messageId: "msg-a1" }));
+    await sm.handleCommand("chat-suspend", "session:suspend");
+    await sm.dispatch(mockEntry({ id: 31, chatId: "chat-suspend", messageId: "msg-a2" }));
+
+    capturedCtx?.markCompleted();
+    await Promise.resolve();
+    expect(resumeSpy).not.toHaveBeenCalled();
+    expect(ackEntry).not.toHaveBeenCalled();
+
+    await sm.shutdown();
+  });
+
+  it("retryable attempt abandonment prevents a later queued message from acking through the old entry", async () => {
+    const ackEntry = vi.fn().mockResolvedValue(undefined);
+    let capturedCtx: SessionContext | undefined;
+    let firstMessage: Parameters<AgentHandler["start"]>[0] | undefined;
+    const injected: Parameters<AgentHandler["inject"]>[0][] = [];
+    const handler = createMockHandler({
+      async start(m, ctx) {
+        firstMessage = m;
+        capturedCtx = ctx;
+        return "session-id-mock";
+      },
+      inject: vi.fn((m) => {
+        injected.push(m);
+      }),
+    });
+    const { sm } = buildSm(ackEntry, handler);
+
+    await sm.dispatch(mockEntry({ id: 40, chatId: "chat-retryable", messageId: "msg-a1" }));
+    await sm.dispatch(mockEntry({ id: 41, chatId: "chat-retryable", messageId: "msg-a2" }));
+
+    if (firstMessage) capturedCtx?.markMessagesRetryable(firstMessage, "turn_timeout");
+    if (injected[0]) capturedCtx?.markMessagesCompleted(injected[0]);
+    await Promise.resolve();
+
+    expect(ackEntry).not.toHaveBeenCalled();
 
     await sm.shutdown();
   });
@@ -821,7 +972,8 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     await Promise.resolve();
     ackEntry.mockClear();
 
-    // Dispatching back into chat-a hits the resume branch.
+    // Dispatching back into chat-a after bind reset hits the resume branch.
+    sm.noteBindRecoveryComplete();
     await sm.dispatch(mockEntry({ id: 3, chatId: "chat-a", messageId: "msg-resume" }));
     expect(ackEntry).not.toHaveBeenCalled();
 

--- a/packages/client/src/__tests__/session-runtime-state.test.ts
+++ b/packages/client/src/__tests__/session-runtime-state.test.ts
@@ -447,12 +447,11 @@ describe("SessionManager: per-(agent,chat) runtime callback (#553 rebase)", () =
   });
 });
 
-describe("SessionManager: pending-queue entry tracking under concurrency preemption", () => {
-  it("preserves entryId through the pending queue so a later markCompleted still drains it", async () => {
-    // Post-inflight-message-recovery: dispatch only enqueues. Both entries
-    // sit in `inFlightEntries` even when one of them is held in the
-    // pending queue (concurrency=1 forces chat-b to wait for chat-a to be
-    // preempted). Acks only fire when each handler closes its turn.
+describe("SessionManager: ack-through guard under concurrency preemption", () => {
+  it("abandons a preempted unfinished entry and only acks the newly completed chat", async () => {
+    // Ack-through fail-closed: preempting chat-a means its unfinished
+    // delivered entry must not be committed by a stale completion. chat-b
+    // can complete its own attempt and ack only its through cursor.
     const ackEntry = mockAckEntry();
     const ctxs: Record<string, SessionContext> = {};
     const handler = createMockHandler({
@@ -469,11 +468,12 @@ describe("SessionManager: pending-queue entry tracking under concurrency preempt
     await sm.dispatch(mockEntry({ id: 2, chatId: "chat-b" }));
     expect(ackEntry).not.toHaveBeenCalled();
 
-    // Each handler completes its turn — both should ack.
+    // chat-a's stale completion is ignored; chat-b completes normally.
     ctxs["chat-a"]?.markCompleted();
     ctxs["chat-b"]?.markCompleted();
     await Promise.resolve();
-    expect(ackEntry).toHaveBeenCalledWith(1);
+    expect(ackEntry).toHaveBeenCalledTimes(1);
+    expect(ackEntry).not.toHaveBeenCalledWith(1);
     expect(ackEntry).toHaveBeenCalledWith(2);
 
     await sm.shutdown();

--- a/packages/client/src/__tests__/session-start-error-signaling.test.ts
+++ b/packages/client/src/__tests__/session-start-error-signaling.test.ts
@@ -305,6 +305,7 @@ describe("SessionManager: session-resume failure signalling (F2, resume path)", 
 
     await sm.dispatch(mockEntry({ id: 1, chatId: "chat-A" })); // start succeeds
     await sm.dispatch(mockEntry({ id: 2, chatId: "chat-B" })); // preempts chat-A
+    sm.noteBindRecoveryComplete(); // bind reset completed; redelivery may resume chat-A
     await sm.dispatch(mockEntry({ id: 3, chatId: "chat-A" })); // resume → throws
 
     const chatAStates = stateChanges.filter((c) => c.chatId === "chat-A").map((c) => c.state);
@@ -350,6 +351,7 @@ describe("SessionManager: session-resume failure signalling (F2, resume path)", 
 
     await sm.dispatch(mockEntry({ id: 1, chatId: "chat-A" }));
     await sm.dispatch(mockEntry({ id: 2, chatId: "chat-B" }));
+    sm.noteBindRecoveryComplete(); // bind reset completed; redelivery may resume chat-A
     await sm.dispatch(mockEntry({ id: 3, chatId: "chat-A" })); // resume → errored
 
     // A fresh inbound for chat-A should route as start (entry was dropped

--- a/packages/client/src/__tests__/session-state-notifications.test.ts
+++ b/packages/client/src/__tests__/session-state-notifications.test.ts
@@ -154,7 +154,8 @@ describe("SessionManager: state notifications", () => {
     // chat-a starts (active), chat-b preempts chat-a (suspended → active)
     await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
     await sm.dispatch(mockEntry({ id: 2, chatId: "chat-b" }));
-    // chat-a resumes, preempting chat-b
+    // After bind reset, chat-a may resume and preempt chat-b.
+    sm.noteBindRecoveryComplete();
     await sm.dispatch(mockEntry({ id: 3, chatId: "chat-a" }));
 
     const chatAChanges = stateChanges.filter((c) => c.chatId === "chat-a");

--- a/packages/client/src/__tests__/test-helpers.ts
+++ b/packages/client/src/__tests__/test-helpers.ts
@@ -23,6 +23,8 @@ export function mockCtxPlumbing(
 ): {
   forwardResult: (text: string) => Promise<void>;
   markCompleted: () => void;
+  markMessagesCompleted: (messages: SessionMessage | readonly SessionMessage[]) => void;
+  markMessagesRetryable: (messages: SessionMessage | readonly SessionMessage[], reason: string) => void;
   buildAgentEnv: (env: NodeJS.ProcessEnv) => NodeJS.ProcessEnv;
   formatInboundContent: (msg: SessionMessage) => Promise<string>;
   resolveSenderLabel: (senderId: string) => Promise<string>;
@@ -33,6 +35,8 @@ export function mockCtxPlumbing(
     },
     // Default stub: tests that care about ack timing override via spies.
     markCompleted: () => {},
+    markMessagesCompleted: () => {},
+    markMessagesRetryable: () => {},
     buildAgentEnv: (env) => env,
     formatInboundContent: async (msg) => {
       const raw = typeof msg.content === "string" ? msg.content : JSON.stringify(msg.content);

--- a/packages/client/src/client-connection.ts
+++ b/packages/client/src/client-connection.ts
@@ -1254,30 +1254,13 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
     if (type === "inbox:deliver") {
       const parsed = inboxDeliverFrameSchema.safeParse(msg);
       if (!parsed.success) {
-        // Best-effort ack: without it the entry stays `delivered`
-        // server-side and the next `agent:bind` resets it back to
-        // `pending` and re-pushes the same frame (see
-        // inflight-message-recovery-design.md §4) — which this build is
-        // guaranteed to drop again, so we'd loop on every reconnect. By
-        // acking we close the row out: a malformed frame this build
-        // cannot parse will never be parseable. `entryId` is a top-level
-        // field and usually survives when inner `message` validation is
-        // what failed (see frameKeys). Logged separately as
-        // `entryIdAcked` so operators can correlate.
+        // Do not ack malformed deliver frames. `inbox:ack` is ack-through
+        // now, so using it here could commit earlier delivered rows whose
+        // handler work has not completed. Leave the row delivered; the next
+        // bind reset will replay it and surface the schema drift again.
         const rawEntryId = msg.entryId;
-        // Match `inboxAckFrameSchema`: non-negative integer. A `typeof "number"`
-        // check alone would let NaN / Infinity / floats slip through and ack
-        // would silently no-op on the server side (rejected by its own schema).
-        const entryIdAcked =
+        const entryIdDropped =
           typeof rawEntryId === "number" && Number.isInteger(rawEntryId) && rawEntryId >= 0 ? rawEntryId : null;
-        if (entryIdAcked !== null) {
-          this.sendInboxAck(entryIdAcked).catch((err) => {
-            this.wsLogger.warn(
-              { entryId: entryIdAcked, err: err instanceof Error ? err.message : String(err) },
-              "malformed inbox:deliver best-effort ack failed",
-            );
-          });
-        }
         // Per-issue path/message + the receiving frame keys so we can pinpoint
         // shape drift between server build and client schema during gradual
         // rollouts. Frame body intentionally not logged in full — message
@@ -1292,7 +1275,7 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
             })),
             frameKeys: Object.keys(msg),
             messageKeys: msg.message && typeof msg.message === "object" ? Object.keys(msg.message) : null,
-            entryIdAcked,
+            entryIdDropped,
           },
           "malformed inbox:deliver frame — dropping",
         );

--- a/packages/client/src/handlers/claude-code-tui/index.ts
+++ b/packages/client/src/handlers/claude-code-tui/index.ts
@@ -317,7 +317,7 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
     }
   }
 
-  async function runTurn(text: string, sessionCtx: SessionContext, ackCount = 1): Promise<void> {
+  async function runTurn(text: string, sessionCtx: SessionContext, messages: readonly SessionMessage[]): Promise<void> {
     if (!tmuxSessionName || !transcriptTailer) {
       throw new Error("runTurn called before session was prepared");
     }
@@ -440,7 +440,10 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
     const disposition = resolveTurnDisposition({ aborted: turnAborted, timedOut, turnFailed, forwardFailed });
     sessionCtx.emitEvent({ kind: "turn_end", payload: { status: disposition.status } });
     if (disposition.ack) {
-      sessionCtx.markCompleted(ackCount);
+      sessionCtx.markMessagesCompleted(messages);
+    } else {
+      const reason = timedOut ? "turn_timeout" : turnAborted ? "turn_aborted" : "turn_retryable";
+      sessionCtx.markMessagesRetryable(messages, reason);
     }
     sessionCtx.setRuntimeState(disposition.runtimeState);
     resetProcessor();
@@ -469,8 +472,11 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
           sessionCtx.log(`tui inject formatInboundContent failed: ${err instanceof Error ? err.message : String(err)}`);
         }
       }
-      if (inputs.length === 0) return;
-      await runTurn(inputs.join("\n\n"), sessionCtx, drained.length);
+      if (inputs.length === 0) {
+        sessionCtx.markMessagesCompleted(drained);
+        return;
+      }
+      await runTurn(inputs.join("\n\n"), sessionCtx, drained);
     })();
     currentTurnPromise = promise;
     void promise
@@ -553,7 +559,7 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
         const sessionId = await startClaude({ sessionCtx, resumeSessionId: null });
 
         const inputText = await sessionCtx.formatInboundContent(message);
-        currentTurnPromise = runTurn(inputText, sessionCtx, 1);
+        currentTurnPromise = runTurn(inputText, sessionCtx, [message]);
         try {
           await currentTurnPromise;
         } finally {
@@ -599,7 +605,7 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
 
         if (message) {
           const inputText = await sessionCtx.formatInboundContent(message);
-          currentTurnPromise = runTurn(inputText, sessionCtx, 1);
+          currentTurnPromise = runTurn(inputText, sessionCtx, [message]);
           try {
             await currentTurnPromise;
           } finally {

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -601,6 +601,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
    */
   let chatContextForPrompt: ChatContext | undefined;
   const queuedInjectedMessages: SessionMessage[] = [];
+  const pendingAckMessages: SessionMessage[] = [];
   let injectDrainInProgress = false;
   /**
    * Predeclared source repos materialised by `prepareSourceRepos`. Surfaced in
@@ -820,18 +821,23 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
   }
 
   /**
-   * Single helper for "turn closed → ack the in-flight inbox entry AND
+   * Single helper for "turn closed → ack the pending inbox message AND
    * drop the replay stash". The two operations are paired everywhere a
    * turn finishes (success / sniff-permanent / forward-error / no-result /
    * non-success subtype / MAX_RETRIES / respawn-fail) — folding them into
    * one call keeps the invariant "stash lives only as long as the turn
    * still might need a replay" enforced in one place. Use the raw
-   * `markCompleted(count)` directly for per-entry acks (e.g. inject's
-   * `toSDKUserMessage` catch) where the semantics is "ack this single
-   * inbox entry, NOT close the active turn".
+   * `markMessagesCompleted(message)` directly for per-message terminal
+   * failures (e.g. inject's `toSDKUserMessage` catch) where the semantics is
+   * "commit this single inbox message, NOT close the active SDK turn".
    */
   function ackTurnClose(sessionCtx: SessionContext): void {
-    sessionCtx.markCompleted();
+    const message = pendingAckMessages.shift();
+    if (message) {
+      sessionCtx.markMessagesCompleted(message);
+    } else {
+      sessionCtx.markCompleted();
+    }
     stashedSdkMessage = null;
   }
 
@@ -850,14 +856,15 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       const sdkMsg = await toSDKUserMessage(message, sessionCtx, sessionId);
       stashedSdkMessage = sdkMsg;
       inputController?.push(sdkMsg);
+      pendingAckMessages.push(message);
     } catch (err) {
       sessionCtx.log(`toSDKUserMessage errored: ${err instanceof Error ? err.message : String(err)}`);
       // `toSDKUserMessage` failed before the SDK ever saw the
       // message, so no `result` event will ever fire to pair this
-      // entry with a `markCompleted()`. Ack here — re-handling on
+      // entry with an SDK result. Ack here — re-handling on
       // redelivery would re-hit the same conversion error
       // (permanent failure semantics, design §4).
-      sessionCtx.markCompleted(1);
+      sessionCtx.markMessagesCompleted(message);
     }
   }
 
@@ -1547,6 +1554,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       stashedSdkMessage = sdkMsg;
       spawnQuery(claudeSessionId, sessionCtx);
       inputController?.push(sdkMsg);
+      pendingAckMessages.push(message);
       scheduleInjectedMessagesDrain(sessionCtx, claudeSessionId);
 
       sessionCtx.log(`Session started (${claudeSessionId})`);
@@ -1608,6 +1616,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
         spawnQuery(sessionId, sessionCtx, sessionId);
         if (sdkMsg) {
           inputController?.push(sdkMsg);
+          if (message) pendingAckMessages.push(message);
         }
         scheduleInjectedMessagesDrain(sessionCtx, sessionId);
         sessionCtx.log(`Session resumed at legacy cwd (${sessionId})`);
@@ -1651,6 +1660,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
         spawnQuery(freshSessionId, sessionCtx);
         if (freshSdkMsg) {
           inputController?.push(freshSdkMsg);
+          if (message) pendingAckMessages.push(message);
         }
         scheduleInjectedMessagesDrain(sessionCtx, freshSessionId);
         sessionCtx.log(`Session started (${freshSessionId}, replacing ${sessionId})`);
@@ -1666,6 +1676,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       spawnQuery(sessionId, sessionCtx, sessionId);
       if (resumeSdkMsg) {
         inputController?.push(resumeSdkMsg);
+        if (message) pendingAckMessages.push(message);
       }
       scheduleInjectedMessagesDrain(sessionCtx, sessionId);
 
@@ -1709,6 +1720,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       // which re-stashes from its own argument.
       stashedSdkMessage = null;
       queuedInjectedMessages.length = 0;
+      pendingAckMessages.length = 0;
       injectDrainInProgress = false;
     },
 

--- a/packages/client/src/handlers/codex.ts
+++ b/packages/client/src/handlers/codex.ts
@@ -773,16 +773,12 @@ export const createCodexHandler: HandlerFactory = (config) => {
   /**
    * Run one Codex turn.
    *
-   * `entryCount` is the number of inbox entries this turn is consuming —
-   * always 1 for `start` / `resume` / single-inject paths, and `N` when
-   * `mergeAndRun` fuses N queued messages into one input. The runtime acks
-   * exactly `entryCount` entries from the chat's in-flight FIFO once the
-   * turn closes (markCompleted N). Drift between this number and what the
-   * SDK actually consumed loses the per-turn pairing — under-counts leak
-   * entries (stay `delivered` server-side until next bind), over-counts
-   * ack future turns prematurely (loss on crash).
+   * `messages` is the concrete inbox batch this turn consumed — always one
+   * message for start / resume / single-inject paths, and N when mergeAndRun
+   * fuses queued messages into one input. Completion acks through the last
+   * consumed message id instead of shifting a count from SessionManager state.
    */
-  async function runTurn(input: Input, sessionCtx: SessionContext, entryCount: number): Promise<void> {
+  async function runTurn(input: Input, sessionCtx: SessionContext, messages: readonly SessionMessage[]): Promise<void> {
     const activeThread = thread;
     if (!activeThread) return;
 
@@ -1014,11 +1010,8 @@ export const createCodexHandler: HandlerFactory = (config) => {
     // Ack the entries this turn consumed. All four turn outcomes (success,
     // silent / no-text, SDK turn.failed, forwardResult failure) are
     // terminal for this turn — redelivery would either replay an already-
-    // delivered reply or re-hit the same failure. Pass `entryCount` so a
-    // fused `mergeAndRun` (N injected messages → one turn) acks exactly
-    // those N entries and leaves any in-flight entries for the NEXT turn
-    // alone.
-    sessionCtx.markCompleted(entryCount);
+    // delivered reply or re-hit the same failure.
+    sessionCtx.markMessagesCompleted(messages);
 
     // Structured usage / timing log — emitted via `sessionCtx.log` rather
     // than a new SessionEvent kind so we stay inside the codex handler
@@ -1076,15 +1069,10 @@ export const createCodexHandler: HandlerFactory = (config) => {
       // permanent failure for this batch (redelivery would re-hit the same
       // format errors). Ack the entries so they don't leak in
       // `inFlightEntries` and pile up server-side as `delivered` rows.
-      sessionCtx.markCompleted(drained.length);
+      sessionCtx.markMessagesCompleted(drained);
       return;
     }
-    // `drained.length` is the authoritative fused-entry count — formatting
-    // a single message could throw (it gets logged and skipped above) but
-    // the inbox entry was still pushed at dispatch time, so it must still
-    // be acked. Using `inputs.length` here would leak the formatting-failed
-    // entry until the next bind reset.
-    await runTurn(inputs.join("\n\n"), sessionCtx, drained.length);
+    await runTurn(inputs.join("\n\n"), sessionCtx, drained);
   }
 
   /**
@@ -1155,7 +1143,7 @@ export const createCodexHandler: HandlerFactory = (config) => {
       threadIsFresh = true;
 
       const input = await toCodexInput(message, sessionCtx);
-      await runTurn(input, sessionCtx, 1);
+      await runTurn(input, sessionCtx, [message]);
 
       // Codex assigns thread_id via `thread.started` during the first turn;
       // fall back to whatever `Thread` exposes if the event was missed.
@@ -1210,7 +1198,7 @@ export const createCodexHandler: HandlerFactory = (config) => {
 
       if (message) {
         const input = await toCodexInput(message, sessionCtx);
-        await runTurn(input, sessionCtx, 1);
+        await runTurn(input, sessionCtx, [message]);
       }
       return sessionId;
     },
@@ -1220,7 +1208,7 @@ export const createCodexHandler: HandlerFactory = (config) => {
       // is buffered and drained on the next available turn. Queue every
       // inject instead of only mid-turn injects so the async gap before
       // `runTurn()` sets `currentTurnPromise` cannot start parallel turns
-      // and desynchronise the in-flight entry FIFO.
+      // and desynchronise completion from the messages actually consumed.
       if (!ctx) return;
       queuedMessages.push(message);
       scheduleQueuedMessagesDrain();

--- a/packages/client/src/runtime/agent-slot.ts
+++ b/packages/client/src/runtime/agent-slot.ts
@@ -123,6 +123,9 @@ export class AgentSlot {
     };
     const onBound = (boundAgent: { agentId: string }) => {
       if (boundAgent.agentId === this.config.agentId) {
+        if (typeof this.sessionManager?.noteBindRecoveryComplete === "function") {
+          this.sessionManager.noteBindRecoveryComplete();
+        }
         // `fullStateSync` short-circuits when `sessionManager` is null,
         // so it's safe to fire on the FIRST `agent:bound` (which now
         // reaches this listener because we attached it pre-bind) — the

--- a/packages/client/src/runtime/deduplicator.ts
+++ b/packages/client/src/runtime/deduplicator.ts
@@ -60,6 +60,13 @@ export class Deduplicator {
     this.order.push(...kept);
   }
 
+  /** Drop one recorded id if present. */
+  drop(id: string): void {
+    if (!this.seen.delete(id)) return;
+    const index = this.order.indexOf(id);
+    if (index >= 0) this.order.splice(index, 1);
+  }
+
   get size(): number {
     return this.seen.size;
   }

--- a/packages/client/src/runtime/first-tree-skills/installer.ts
+++ b/packages/client/src/runtime/first-tree-skills/installer.ts
@@ -58,7 +58,6 @@ export const TREE_SKILL_NAMES = [
   "first-tree-context",
   "first-tree-onboarding",
   "first-tree-sync",
-  "first-tree-write",
 ] as const;
 
 export type CoreSkillName = (typeof CORE_SKILL_NAMES)[number];

--- a/packages/client/src/runtime/handler.ts
+++ b/packages/client/src/runtime/handler.ts
@@ -66,34 +66,29 @@ export type SessionContext = HandlerContext & {
   forwardResult: (text: string) => Promise<void>;
 
   /**
-   * Ack `count` in-flight inbox entries for this chat — the runtime holds
-   * a FIFO queue per chat populated at `dispatch()` time. Each call shifts
-   * `count` entries off the head of that queue and acks them; the default
-   * `count = 1` matches the "one user message → one assistant turn" model
-   * that claude-code's streaming-input path produces.
-   *
-   * Call this once the handler has finished a turn (forwardResult success,
-   * silent turn, SDK reported "no result", or a permanent error the
-   * runtime surfaces via `emitEvent`). The runtime does NOT auto-ack on
-   * `forwardResult` because not every "turn done" path produces text.
-   *
-   * **`count` for batched / fused turns**: codex's `mergeAndRun` fuses N
-   * `inject()`-queued messages into a single `runTurn` that emits one
-   * `forwardResult`. Pass `count = N` so all N entries are acked atomically
-   * with the turn. Mis-counting under-acks (entries leak server-side, stay
-   * `delivered` until next bind reset) or over-acks (entries for the
-   * *next* turn get acked while still in-flight, risking loss on crash) —
-   * keep `count` in lockstep with the SDK's actual fused-message tally.
-   *
-   * Idempotent — shifting from an empty queue is a no-op. NOT to be
-   * called on transient errors that the handler intends to retry; leaving
-   * the entries queued keeps the server-side `delivered` state until the
-   * retry's eventual success (or until the client crashes and the next
-   * `agent:bind` resets them back to `pending`).
-   *
-   * See docs/inflight-message-recovery-design.md §4.
+   * Mark a single-message turn complete. Built-in handlers should prefer
+   * `markMessagesCompleted(messageOrBatch)` so the runtime can ack-through
+   * the exact inbox entry the handler actually consumed.
    */
-  markCompleted: (count?: number) => void;
+  markCompleted: () => void;
+
+  /**
+   * Mark the concrete message or fused message batch a handler has actually
+   * consumed. The runtime sends one `inbox:ack` for the last message's
+   * `inboxEntryId`; the server interprets it as ack-through for the chat's
+   * delivered prefix. This replaces the old `markCompleted(count)` FIFO
+   * pairing, which could ack an older queued entry while the completed entry
+   * remained unacked.
+   */
+  markMessagesCompleted: (messages: SessionMessage | readonly SessionMessage[]) => void;
+
+  /**
+   * Mark a concrete message or batch as abandoned by a retryable path
+   * (suspend, abort, timeout). The runtime must not let a later message in
+   * the same chat ack-through these entries, so it fails closed until the
+   * next bind reset redelivers from the server's oldest unacked entry.
+   */
+  markMessagesRetryable: (messages: SessionMessage | readonly SessionMessage[], reason: string) => void;
 
   /**
    * Build env for CLI sub-processes that shell out to the `first-tree`
@@ -125,6 +120,8 @@ export type SessionContext = HandlerContext & {
 
 /** Message content extracted from an inbox entry (no entry metadata). */
 export type SessionMessage = {
+  /** Inbox entry id that delivered this message to the current agent. */
+  inboxEntryId?: number;
   /** Message ID (UUID v7). */
   id: string;
   /** Chat this message belongs to. */

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -258,6 +258,13 @@ function previousAvailable(entry: SessionEntry): boolean {
   return Boolean(entry.claudeSessionId) || Boolean(entry.retryFromEvicted?.claudeSessionId);
 }
 
+type TrackedInFlightEntry = {
+  entryId: number;
+  messageId: string;
+  dedupKey: string;
+  admitted: boolean;
+};
+
 /**
  * Encode a resilience event into the closed `error` event payload by
  * prefixing the message with the event name. Future server-side consumers
@@ -284,10 +291,11 @@ export class SessionManager {
   private readonly currentTrigger = new Map<string, Trigger>();
   private readonly registry: SessionRegistry | null;
   /**
-   * In-flight inbox entries per chat — FIFO of entryIds populated at
-   * `dispatch()` time and drained when the handler calls
-   * `ctx.markCompleted()` after a turn (or when the runtime tears a session
-   * down on a permanent failure / terminate command).
+   * In-flight inbox entries per chat — delivered entries that this process
+   * has handed toward a handler and has not yet committed. Completion is
+   * identity based: handlers report the concrete SessionMessage or fused
+   * batch they actually consumed, and the runtime sends one ack-through for
+   * that batch's last inbox entry.
    *
    * Kept here (not on `SessionEntry`) because dispatch may push an entryId
    * before any session record exists for the chat (`startNewSession` runs
@@ -295,11 +303,29 @@ export class SessionManager {
    * suspended / evicted between dispatch and markCompleted.
    *
    * Sized small in practice: usually 1, briefly up to N when several
-   * messages land while a turn is mid-flight (codex `mergeAndRun` fuses
-   * them into a single forwardResult). See
+   * messages land while a turn is mid-flight. Entries that were delivered
+   * but only queued inside a handler remain tracked until the handler's
+   * actual consuming turn calls `markMessagesCompleted`.
+   * See
    * docs/inflight-message-recovery-design.md §4.
    */
-  private readonly inFlightEntries = new Map<string, number[]>();
+  private readonly inFlightEntries = new Map<string, TrackedInFlightEntry[]>();
+  /**
+   * Per-chat admission barrier. It serializes the pre-handler admission phase
+   * only: config refresh, eager asset fetch, marking the entry admitted, and
+   * invoking `routeMessage()`. It deliberately does NOT wait for the handler's
+   * turn promise to settle, so A2 can still be appended/injected while A1's
+   * attempt is running; it just cannot overtake A1 before A1 reaches handler
+   * membership.
+   */
+  private readonly admissionQueues = new Map<string, Promise<void>>();
+  /**
+   * Chats whose local handler state was abandoned while server-side entries
+   * may still be `delivered`. Until the next bind reset, processing a newer
+   * entry in that chat could make ack-through commit an older abandoned entry,
+   * so dispatch fails closed and waits for bind recovery.
+   */
+  private readonly needsBindRecovery = new Set<string>();
   private readonly pendingQueue: PendingMessage[] = [];
   private readonly lastReportedStates = new Map<string, SessionState>();
   private readonly sessionRuntimeStates = new Map<string, RuntimeState>();
@@ -333,7 +359,7 @@ export class SessionManager {
 
   /**
    * Dispatch an inbox entry. ACK is deferred until the handler reports a
-   * completed turn via `ctx.markCompleted()`.
+   * completed turn via `ctx.markMessagesCompleted(...)`.
    *
    * Delayed ACK semantics (post inflight-message-recovery): the entry stays
    * `delivered` server-side until forwardResult succeeds (or the handler
@@ -351,105 +377,100 @@ export class SessionManager {
     const chatId = entry.chatId ?? entry.message.chatId;
     const messageId = entry.message.id;
 
-    // 1. Deduplication — key by (chatId, messageId). Cross-chat reply
-    // routing has been removed (see first-tree-context PR #281) so a single
-    // message now produces exactly one inbox entry per recipient, but the
-    // server-side identity is still (inboxId, messageId, chatId) and we
-    // mirror it defensively in case a legacy entry surfaces or fan-out is
-    // ever extended again.
-    //
-    // Network-blip redelivery (server resets `delivered → pending` on every
-    // `agent:bind`) also lands here for the duration of one process: if
-    // we've already processed this messageId in-memory the dedup short-
-    // circuits before we re-enqueue an entry that the previous turn will
-    // ack on its own.
-    //
-    // Re-ack on dedup hit (post inflight-message-recovery). Three paths
-    // remove an entryId from `inFlightEntries`:
-    //   (a) `markCompleted` via `ackInFlightEntries`  — entry was acked.
-    //   (b) `drainAllInFlightEntries` (terminate / permanent error)
-    //                                                — entry was acked.
-    //   (c) `evictIfNeeded` LRU eviction              — entry was NOT
-    //       acked, and the recovery contract is "server's bind-reset
-    //       redelivers against a fresh session." The LRU path synchronously
-    //       drops this chat's dedup keys (see `evictIfNeeded`), so by the
-    //       time the redelivery reaches dispatch the messageId is NOT in
-    //       the dedup set and we don't land in this branch at all.
-    // That leaves (a) and (b) as the only ways to arrive here with the
-    // entry already off the in-flight queue. Both mean the ack frame was
-    // already sent — and since the server is still redelivering this
-    // entryId, that ack didn't land (fire-and-forget WS / TCP half-open /
-    // reaper race against `ackEntryByIdForBoundAgents`'s `status='delivered'`
-    // filter). Re-ack closes the "reset on bind → redeliver → dedup-hit →
-    // never ack" loop that otherwise persists until process restart (at
-    // which point the dedup is empty, the redelivered entry is mis-
-    // classified as a fresh message, and the agent re-runs the turn).
-    // If the entry IS still in `inFlightEntries` we leave it alone — the
-    // turn's eventual `markCompleted` will ack it, and acking early would
-    // prematurely defuse the recovery path if the client crashes mid-turn.
-    const dedupKey = `${chatId}:${messageId}`;
-    if (this.deduplicator.isDuplicate(dedupKey)) {
-      const queue = this.inFlightEntries.get(chatId);
-      const stillInFlight = queue ? queue.includes(entry.id) : false;
-      this.config.log.debug({ chatId, messageId, entryId: entry.id, stillInFlight }, "duplicate message, skipping");
-      if (!stillInFlight) {
-        this.config.ackEntry(entry.id).catch((err) => {
-          this.config.log.warn({ chatId, messageId, entryId: entry.id, err }, "dedup-hit re-ack failed");
-        });
-      }
+    if (this.needsBindRecovery.has(chatId)) {
+      this.config.log.warn(
+        { chatId, messageId, entryId: entry.id },
+        "chat has abandoned delivered entries; deferring inbox delivery until bind reset",
+      );
       return;
     }
 
-    // Push the entry into the in-flight FIFO BEFORE routing. The handler
-    // (or the session-manager teardown path) drains the queue via
-    // `markCompleted()` once the turn is complete; nothing acks until then.
-    const queue = this.inFlightEntries.get(chatId);
-    if (queue) queue.push(entry.id);
-    else this.inFlightEntries.set(chatId, [entry.id]);
-
-    // 2. Step 4: refresh runtime config if the message brought a newer
-    // version. This is the *only* trigger for active-session re-config —
-    // matches PRD §7.2. Failures are logged but do not block delivery on
-    // M1: handler integration in Step 6 will decide whether to use the
-    // stale config or hold the message until the server recovers.
-    if (this.config.agentConfigCache) {
-      try {
-        await this.config.agentConfigCache.refreshIfNewer(
-          this.config.agentIdentity.agentId,
-          entry.message.configVersion,
-        );
-      } catch (err) {
-        this.config.log.warn(
-          {
-            chatId,
-            agentId: this.config.agentIdentity.agentId,
-            incomingVersion: entry.message.configVersion,
-            err,
-          },
-          "config version mismatch — skipping refresh",
-        );
-      }
+    // 1. Deduplication — key by (chatId, messageId). Dedup is now only an
+    // in-process duplicate-injection guard for entries still tracked by the
+    // active local turn/batch. It must not independently re-ack: ack-through
+    // can commit older delivered prefix rows, so only a concrete successful
+    // turn completion may send the cursor.
+    const dedupKey = `${chatId}:${messageId}`;
+    if (this.deduplicator.isDuplicate(dedupKey)) {
+      const queue = this.inFlightEntries.get(chatId);
+      const stillInFlight = queue ? queue.some((tracked) => tracked.entryId === entry.id) : false;
+      this.config.log.debug({ chatId, messageId, entryId: entry.id, stillInFlight }, "duplicate message observed");
+      if (stillInFlight) return;
+      this.config.log.debug(
+        { chatId, messageId, entryId: entry.id },
+        "duplicate key is not tied to an active entry; reprocessing redelivery",
+      );
     }
 
-    // Note: the "mention_only" filter now lives on the server (see
-    // services/message.ts sendMessage fan-out). If an entry reaches dispatch
-    // we assume server already decided we should handle it — this avoids a
-    // double-guard that drifted between server / client in early M1.
+    // Track before routing. The handler (or teardown path) commits by
+    // message identity once work is complete; nothing acks until then.
+    const queue = this.inFlightEntries.get(chatId);
+    const tracked = { entryId: entry.id, messageId, dedupKey, admitted: false };
+    if (queue) queue.push(tracked);
+    else this.inFlightEntries.set(chatId, [tracked]);
 
-    // 4. Extract message content (handler does not see inbox metadata)
-    const message = this.extractMessage(entry);
+    let routePromise: Promise<void> | undefined;
+    await this.withAdmissionBarrier(chatId, async () => {
+      if (this.needsBindRecovery.has(chatId) || !this.isTrackedEntry(chatId, entry.id)) return;
 
-    // 4b. Pull any referenced image bytes to local disk before the handler
-    // renders. Bytes live in the server's `attachments` object store (uploaded
-    // by the sender); each client fetches once and caches under the chat's
-    // images dir. Best-effort — a failed fetch leaves the handler to surface a
-    // "not available on this device" placeholder for that ref.
-    await this.ensureImagesLocal(message);
+      // 2. Step 4: refresh runtime config if the message brought a newer
+      // version. This is the *only* trigger for active-session re-config —
+      // matches PRD §7.2. Failures are logged but do not block delivery on
+      // M1: handler integration in Step 6 will decide whether to use the
+      // stale config or hold the message until the server recovers.
+      if (this.config.agentConfigCache) {
+        try {
+          await this.config.agentConfigCache.refreshIfNewer(
+            this.config.agentIdentity.agentId,
+            entry.message.configVersion,
+          );
+        } catch (err) {
+          this.config.log.warn(
+            {
+              chatId,
+              agentId: this.config.agentIdentity.agentId,
+              incomingVersion: entry.message.configVersion,
+              err,
+            },
+            "config version mismatch — skipping refresh",
+          );
+        }
+      }
 
-    // 5. Route by session state. ACK no longer happens inside route — the
-    // entry sits in `inFlightEntries` until the handler calls
-    // `ctx.markCompleted()` at turn end.
-    await this.routeMessage(chatId, message);
+      if (this.needsBindRecovery.has(chatId) || !this.isTrackedEntry(chatId, entry.id)) return;
+
+      // Note: the "mention_only" filter now lives on the server (see
+      // services/message.ts sendMessage fan-out). If an entry reaches dispatch
+      // we assume server already decided we should handle it — this avoids a
+      // double-guard that drifted between server / client in early M1.
+
+      // 4. Extract message content (handler does not see inbox metadata)
+      const message = this.extractMessage(entry);
+
+      // 4b. Pull any referenced image bytes to local disk before the handler
+      // renders. Bytes live in the server's `attachments` object store (uploaded
+      // by the sender); each client fetches once and caches under the chat's
+      // images dir. Best-effort — a failed fetch leaves the handler to surface a
+      // "not available on this device" placeholder for that ref.
+      await this.ensureImagesLocal(message);
+
+      if (this.needsBindRecovery.has(chatId) || !this.markTrackedEntryAdmitted(chatId, entry.id)) return;
+
+      // 5. Route by session state. ACK no longer happens inside route — the
+      // entry sits in `inFlightEntries` until the handler completes the
+      // concrete message/batch it actually consumed. Do not await inside the
+      // admission barrier: for Codex/TUI, route promises can span the whole
+      // turn, but same-chat later messages must still be able to append once
+      // this entry has reached handler membership.
+      routePromise = this.routeMessage(chatId, message).catch((err) => {
+        if (this.isTrackedEntry(chatId, entry.id)) {
+          this.abandonInFlightForBindRecovery(chatId, "route_message_failed");
+        }
+        throw err;
+      });
+    });
+
+    if (routePromise) await routePromise;
   }
 
   /**
@@ -648,7 +669,38 @@ export class SessionManager {
     return [...this.evictedMappings.keys()];
   }
 
+  /**
+   * The server resets delivered-but-unacked rows back to pending during
+   * `agent:bind`. After that point chats blocked by local abandoned state can
+   * safely accept redelivery again.
+   */
+  noteBindRecoveryComplete(): void {
+    this.needsBindRecovery.clear();
+  }
+
   // ---- Internal -----------------------------------------------------------
+
+  private async withAdmissionBarrier(chatId: string, op: () => Promise<void>): Promise<void> {
+    const prev = this.admissionQueues.get(chatId) ?? Promise.resolve();
+    const next = prev.then(op, op);
+    this.admissionQueues.set(chatId, next);
+    const cleanup = () => {
+      if (this.admissionQueues.get(chatId) === next) this.admissionQueues.delete(chatId);
+    };
+    void next.then(cleanup, cleanup);
+    await next;
+  }
+
+  private isTrackedEntry(chatId: string, entryId: number): boolean {
+    return this.inFlightEntries.get(chatId)?.some((tracked) => tracked.entryId === entryId) ?? false;
+  }
+
+  private markTrackedEntryAdmitted(chatId: string, entryId: number): boolean {
+    const tracked = this.inFlightEntries.get(chatId)?.find((entry) => entry.entryId === entryId);
+    if (!tracked) return false;
+    tracked.admitted = true;
+    return true;
+  }
 
   private async routeMessage(chatId: string, message: SessionMessage): Promise<void> {
     // Record the trigger BEFORE dispatching to any handler path (start /
@@ -667,8 +719,8 @@ export class SessionManager {
     // user message is a strong signal the user is waiting — replace the
     // stored startMessage so the retry uses the fresher content, then fire
     // an immediate retry. The new entry sits alongside any prior entries in
-    // `inFlightEntries[chatId]`; the retry's eventual forwardResult drains
-    // the whole queue via `markCompleted()`.
+    // `inFlightEntries[chatId]`; the retry's eventual forwardResult commits
+    // the concrete message/batch it consumed.
     if (existing && existing.retryAttempt > 0) {
       existing.startMessage = message;
       this.triggerImmediateRetry(chatId);
@@ -1136,6 +1188,7 @@ export class SessionManager {
   }
 
   private suspendSession(entry: SessionEntry): void {
+    this.abandonInFlightForBindRecovery(entry.chatId, "session_suspended");
     entry.status = "suspended";
     this._activeCount--;
     // Clear per-session runtime state on suspend
@@ -1218,16 +1271,7 @@ export class SessionManager {
       // markCompleted will ever fire. The server-side entries stay
       // `delivered`; the next `agent:bind` resets them back to `pending`
       // for redelivery against a fresh session.
-      this.inFlightEntries.delete(candidate.key);
-      // Synchronously drop the same chat's dedup keys. Without this, the
-      // `dispatch()` dedup-hit short-circuit (post-fix: ack-on-dedup-hit
-      // when the entry isn't in-flight) would treat the bind-reset
-      // redelivery as "already handled" and ack it — shortcutting the
-      // recovery path the comment above describes. The invariant we want
-      // to preserve: a dedup hit means "this entryId was acked or will be
-      // acked by an in-flight turn"; LRU eviction breaks neither half, so
-      // the key must come out with the entry.
-      this.deduplicator.dropByPrefix(`${candidate.key}:`);
+      this.abandonInFlightForBindRecovery(candidate.key, "session_evicted");
       this.recomputeRuntimeState();
       this.persistRegistry();
     }
@@ -1330,38 +1374,82 @@ export class SessionManager {
     this.config.onStateChange(chatId, state);
   }
 
-  /**
-   * Shift up to `count` in-flight entries off the head of this chat's
-   * FIFO and ack each one over the WS data plane. Called by the handler
-   * via `ctx.markCompleted(count)` when a turn closes cleanly
-   * (forwardResult success, silent turn, SDK-reported "no result", or
-   * permanent error surfaced through `emitEvent`).
-   *
-   * One-shift-per-turn pairing is the invariant: claude-code's
-   * streaming-input model produces one SDK `result` event per user
-   * message pushed, so `count = 1` per turn keeps the queue aligned with
-   * the SDK's user-message tally. Codex's `mergeAndRun` fuses N injected
-   * messages into a single turn — it passes `count = N` so the matching
-   * fused entries clear together. Over-shifting (count > queue.length)
-   * is clamped to "drain all"; under-shifting leaves entries queued for
-   * the next turn (or the next bind reset on crash).
-   *
-   * Idempotent — a missing or empty queue is a no-op. Ack failures are
-   * logged but never thrown: the entry stays `delivered` server-side and
-   * the next `agent:bind` resets it back to `pending` if recovery is still
-   * needed.
-   */
-  private ackInFlightEntries(chatId: string, count: number): void {
-    if (count <= 0) return;
+  private ackThroughTrackedEntry(chatId: string, throughEntryId: number): void {
     const queue = this.inFlightEntries.get(chatId);
     if (!queue || queue.length === 0) return;
-    const shifted = queue.splice(0, count);
-    if (queue.length === 0) this.inFlightEntries.delete(chatId);
-    for (const entryId of shifted) {
-      this.config.ackEntry(entryId).catch((err) => {
-        this.config.log.warn({ chatId, entryId, err }, "ACK failed, continuing");
-      });
+    const index = queue.findIndex((tracked) => tracked.entryId === throughEntryId);
+    if (index < 0) {
+      this.config.log.warn({ chatId, throughEntryId }, "attempt completion ignored for untracked inbox entry");
+      return;
     }
+
+    const prefix = queue.slice(0, index + 1);
+    const unadmitted = prefix.filter((tracked) => !tracked.admitted);
+    if (unadmitted.length > 0) {
+      this.config.log.warn(
+        { chatId, throughEntryId, unadmittedEntryIds: unadmitted.map((entry) => entry.entryId) },
+        "attempt completion ignored for unadmitted inbox prefix",
+      );
+      this.abandonInFlightForBindRecovery(chatId, "unadmitted_ack_prefix");
+      return;
+    }
+
+    const committed = queue.splice(0, index + 1);
+    for (const tracked of committed) {
+      this.deduplicator.drop(tracked.dedupKey);
+    }
+    if (queue.length === 0) this.inFlightEntries.delete(chatId);
+
+    this.config.ackEntry(throughEntryId).catch((err) => {
+      this.config.log.warn({ chatId, entryId: throughEntryId, err }, "ACK-through failed, continuing");
+    });
+  }
+
+  private ackOldestTrackedEntry(chatId: string): void {
+    const entryId = this.inFlightEntries.get(chatId)?.[0]?.entryId;
+    if (entryId !== undefined) this.ackThroughTrackedEntry(chatId, entryId);
+  }
+
+  private abandonInFlightForBindRecovery(chatId: string, reason: string): void {
+    const queue = this.inFlightEntries.get(chatId);
+    if (!queue || queue.length === 0) return;
+    this.inFlightEntries.delete(chatId);
+    this.deduplicator.dropByPrefix(`${chatId}:`);
+    this.needsBindRecovery.add(chatId);
+    this.config.log.warn(
+      { chatId, reason, entryIds: queue.map((entry) => entry.entryId) },
+      "abandoned in-flight inbox entries; waiting for bind recovery",
+    );
+  }
+
+  private markMessagesCompleted(chatId: string, messages: SessionMessage | readonly SessionMessage[]): void {
+    const batch = Array.isArray(messages) ? messages : [messages];
+    let throughEntryId: number | undefined;
+    for (const message of batch) {
+      if (message.chatId !== chatId) continue;
+      if (message.inboxEntryId !== undefined) throughEntryId = message.inboxEntryId;
+    }
+    if (throughEntryId === undefined) {
+      this.config.log.warn({ chatId }, "attempt completion ignored because no inboxEntryId was provided");
+      return;
+    }
+    this.ackThroughTrackedEntry(chatId, throughEntryId);
+  }
+
+  private markMessagesRetryable(
+    chatId: string,
+    messages: SessionMessage | readonly SessionMessage[],
+    reason: string,
+  ): void {
+    const batch = Array.isArray(messages) ? messages : [messages];
+    const hasTrackedMessage = batch.some(
+      (message) =>
+        message.chatId === chatId &&
+        message.inboxEntryId !== undefined &&
+        (this.inFlightEntries.get(chatId) ?? []).some((entry) => entry.entryId === message.inboxEntryId),
+    );
+    if (!hasTrackedMessage) return;
+    this.abandonInFlightForBindRecovery(chatId, reason);
   }
 
   /**
@@ -1370,12 +1458,23 @@ export class SessionManager {
    * entry is doomed) and on permanent `handler.start` / `handler.resume`
    * failure (re-handling on redelivery would re-hit the same permanent
    * error, so acking avoids a loop). NOT to be called from handlers — the
-   * per-turn pairing path is `markCompleted(count)`.
+   * per-turn pairing path is `markMessagesCompleted(messageOrBatch)`.
    */
   private drainAllInFlightEntries(chatId: string): void {
     const queue = this.inFlightEntries.get(chatId);
     if (!queue || queue.length === 0) return;
-    this.ackInFlightEntries(chatId, queue.length);
+    let admittedPrefixCount = 0;
+    for (const tracked of queue) {
+      if (!tracked.admitted) break;
+      admittedPrefixCount++;
+    }
+    if (admittedPrefixCount > 0) {
+      const lastAdmitted = queue[admittedPrefixCount - 1];
+      if (lastAdmitted) this.ackThroughTrackedEntry(chatId, lastAdmitted.entryId);
+    }
+    if (this.inFlightEntries.has(chatId)) {
+      this.abandonInFlightForBindRecovery(chatId, "drain_unadmitted_remainder");
+    }
   }
 
   private buildSessionContext(chatId: string): SessionContext {
@@ -1458,8 +1557,14 @@ export class SessionManager {
         this.config.onSessionEvent?.(chatId, event);
       },
       forwardResult,
-      markCompleted: (count) => {
-        this.ackInFlightEntries(chatId, count ?? 1);
+      markCompleted: () => {
+        this.ackOldestTrackedEntry(chatId);
+      },
+      markMessagesCompleted: (messages) => {
+        this.markMessagesCompleted(chatId, messages);
+      },
+      markMessagesRetryable: (messages, reason) => {
+        this.markMessagesRetryable(chatId, messages, reason);
       },
       buildAgentEnv: (parentEnv) => buildAgentEnv(parentEnv, envCtx),
       formatInboundContent: (message) => formatInboundContent(message, participants),
@@ -1560,6 +1665,7 @@ export class SessionManager {
   private extractMessage(entry: InboxEntryWithMessage): SessionMessage {
     const msg = entry.message;
     return {
+      inboxEntryId: entry.id,
       id: msg.id,
       chatId: entry.chatId ?? msg.chatId,
       senderId: msg.senderId,

--- a/packages/server/src/__tests__/inbox-ws-push.test.ts
+++ b/packages/server/src/__tests__/inbox-ws-push.test.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "drizzle-orm";
+import { and, asc, eq } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { describe, expect, it } from "vitest";
 import { chatMembership } from "../db/schema/chat-membership.js";
@@ -38,6 +38,34 @@ describe("inbox WS data-plane claim helpers", () => {
     return { a2, messageId: msgRes.json().id, chatId };
   }
 
+  async function seedDeliverables(app: FastifyInstance, count: number) {
+    const uid = crypto.randomUUID().slice(0, 6);
+    const a1 = await createTestAgent(app, { name: `wspm-a1-${uid}` });
+    const a2 = await createTestAgent(app, { name: `wspm-a2-${uid}` });
+    const chatRes = await a1.request("POST", "/api/v1/agent/chats", {
+      type: "group",
+      participantIds: [a2.agent.uuid],
+    });
+    const chatId = chatRes.json().id;
+    const messageIds: string[] = [];
+    for (let i = 0; i < count; i++) {
+      const msgRes = await a1.request("POST", `/api/v1/agent/chats/${chatId}/messages`, {
+        format: "text",
+        content: `WS push test ${i}`,
+        receiverNames: [a2.agent.name],
+      });
+      messageIds.push(msgRes.json().id);
+    }
+    const rows = await app.db
+      .select()
+      .from(inboxEntries)
+      .where(
+        and(eq(inboxEntries.inboxId, a2.agent.inboxId), eq(inboxEntries.chatId, chatId), eq(inboxEntries.notify, true)),
+      )
+      .orderBy(asc(inboxEntries.id));
+    return { a2, chatId, messageIds, rows };
+  }
+
   it("claimAndBuildForPush atomically claims a pending entry and bundles it", async () => {
     const app = getApp();
     const { a2, messageId } = await seedDeliverable(app);
@@ -71,6 +99,27 @@ describe("inbox WS data-plane claim helpers", () => {
     // `[]`, NOT throw, otherwise a NOTIFY storm crashes the LISTEN loop.
     const second = await inboxService.claimAndBuildForPush(app.db, a2.agent.inboxId, messageId);
     expect(second).toEqual([]);
+  });
+
+  it("claimAndBuildForPush claims the same-chat pending prefix through a newer target", async () => {
+    const app = getApp();
+    const { a2, messageIds, rows } = await seedDeliverables(app, 2);
+    const first = rows[0];
+    const second = rows[1];
+    if (!first || !second) throw new Error("expected two inbox rows");
+
+    const claimed = await inboxService.claimAndBuildForPush(app.db, a2.agent.inboxId, messageIds[1] ?? "");
+    expect(claimed.map((entry) => entry.id)).toEqual([first.id, second.id]);
+
+    const after = await app.db
+      .select({ id: inboxEntries.id, status: inboxEntries.status })
+      .from(inboxEntries)
+      .where(and(eq(inboxEntries.inboxId, a2.agent.inboxId), eq(inboxEntries.notify, true)))
+      .orderBy(asc(inboxEntries.id));
+    expect(after.map((row) => [row.id, row.status])).toEqual([
+      [first.id, "delivered"],
+      [second.id, "delivered"],
+    ]);
   });
 
   it("claimAndBuildForPush bundles silent context for a mention_only trigger", async () => {
@@ -187,6 +236,98 @@ describe("inbox WS data-plane claim helpers", () => {
     for (const e of drained) expect(typeof e.id).toBe("number");
   });
 
+  it("ackEntryByIdForBoundAgents commits delivered notify=true prefix through the target entry", async () => {
+    const app = getApp();
+    const { a2, messageIds, rows } = await seedDeliverables(app, 2);
+    const first = rows[0];
+    const second = rows[1];
+    if (!first || !second) throw new Error("expected two inbox rows");
+
+    await inboxService.claimAndBuildForPush(app.db, a2.agent.inboxId, messageIds[0] ?? "");
+    await inboxService.claimAndBuildForPush(app.db, a2.agent.inboxId, messageIds[1] ?? "");
+
+    const accepted = await inboxService.ackEntryByIdForBoundAgents(app.db, second.id, [a2.agent.inboxId]);
+    expect(accepted.ok).toBe(true);
+    if (!accepted.ok) throw new Error("ack-through unexpectedly rejected");
+    expect(accepted.disposition).toBe("acked");
+    expect(accepted.ackedCount).toBe(2);
+    expect(accepted.ackedEntryIds).toEqual([first.id, second.id]);
+    expect(accepted.throughEntry.id).toBe(second.id);
+
+    const after = await app.db
+      .select({ id: inboxEntries.id, status: inboxEntries.status })
+      .from(inboxEntries)
+      .where(and(eq(inboxEntries.inboxId, a2.agent.inboxId), eq(inboxEntries.notify, true)))
+      .orderBy(asc(inboxEntries.id));
+    expect(after.map((row) => [row.id, row.status])).toEqual([
+      [first.id, "acked"],
+      [second.id, "acked"],
+    ]);
+  });
+
+  it("ackEntryByIdForBoundAgents rejects an ack-through when an earlier notify=true row is pending", async () => {
+    const app = getApp();
+    const { a2, rows } = await seedDeliverables(app, 2);
+    const first = rows[0];
+    const second = rows[1];
+    if (!first || !second) throw new Error("expected two inbox rows");
+
+    await app.db
+      .update(inboxEntries)
+      .set({ status: "delivered", deliveredAt: new Date() })
+      .where(eq(inboxEntries.id, second.id));
+
+    const rejected = await inboxService.ackEntryByIdForBoundAgents(app.db, second.id, [a2.agent.inboxId]);
+    expect(rejected).toEqual({ ok: false, reason: "prefix_gap" });
+
+    const after = await app.db
+      .select({ id: inboxEntries.id, status: inboxEntries.status })
+      .from(inboxEntries)
+      .where(and(eq(inboxEntries.inboxId, a2.agent.inboxId), eq(inboxEntries.notify, true)))
+      .orderBy(asc(inboxEntries.id));
+    expect(after.map((row) => [row.id, row.status])).toEqual([
+      [first.id, "pending"],
+      [second.id, "delivered"],
+    ]);
+  });
+
+  it("ackEntryByIdForBoundAgents rejects an ack-through when an earlier notify=true row failed", async () => {
+    const app = getApp();
+    const { a2, rows } = await seedDeliverables(app, 2);
+    const first = rows[0];
+    const second = rows[1];
+    if (!first || !second) throw new Error("expected two inbox rows");
+
+    await app.db.update(inboxEntries).set({ status: "failed" }).where(eq(inboxEntries.id, first.id));
+    await app.db
+      .update(inboxEntries)
+      .set({ status: "delivered", deliveredAt: new Date() })
+      .where(eq(inboxEntries.id, second.id));
+
+    const rejected = await inboxService.ackEntryByIdForBoundAgents(app.db, second.id, [a2.agent.inboxId]);
+    expect(rejected).toEqual({ ok: false, reason: "prefix_gap" });
+  });
+
+  it("ackEntryByIdForBoundAgents commits only delivered rows after an already-acked prefix", async () => {
+    const app = getApp();
+    const { a2, messageIds, rows } = await seedDeliverables(app, 2);
+    const first = rows[0];
+    const second = rows[1];
+    if (!first || !second) throw new Error("expected two inbox rows");
+
+    await app.db
+      .update(inboxEntries)
+      .set({ status: "acked", ackedAt: new Date() })
+      .where(eq(inboxEntries.id, first.id));
+    await inboxService.claimAndBuildForPush(app.db, a2.agent.inboxId, messageIds[1] ?? "");
+
+    const accepted = await inboxService.ackEntryByIdForBoundAgents(app.db, second.id, [a2.agent.inboxId]);
+    expect(accepted.ok).toBe(true);
+    if (!accepted.ok) throw new Error("ack-through unexpectedly rejected");
+    expect(accepted.ackedCount).toBe(1);
+    expect(accepted.ackedEntryIds).toEqual([second.id]);
+  });
+
   it("ackEntryByIdForBoundAgents acks only entries in the supplied inbox set", async () => {
     const app = getApp();
     const { a2, messageId } = await seedDeliverable(app);
@@ -209,8 +350,8 @@ describe("inbox WS data-plane claim helpers", () => {
     expect(accepted.ok).toBe(true);
     if (!accepted.ok) throw new Error("ack unexpectedly rejected");
     expect(accepted.disposition).toBe("acked");
-    expect(accepted.transitionedFromDelivered).toBe(true);
-    expect(accepted.entry.status).toBe("acked");
+    expect(accepted.ackedCount).toBe(1);
+    expect(accepted.throughEntry.status).toBe("acked");
   });
 
   it("ackEntryByIdForBoundAgents accepts when the inbox list contains the owner alongside other inboxes", async () => {
@@ -233,8 +374,8 @@ describe("inbox WS data-plane claim helpers", () => {
     ]);
     expect(accepted.ok).toBe(true);
     if (!accepted.ok) throw new Error("ack unexpectedly rejected");
-    expect(accepted.entry.status).toBe("acked");
-    expect(accepted.entry.inboxId).toBe(a2.agent.inboxId);
+    expect(accepted.throughEntry.status).toBe("acked");
+    expect(accepted.throughEntry.inboxId).toBe(a2.agent.inboxId);
   });
 
   it("ackEntryByIdForBoundAgents accepts duplicate ACKs idempotently", async () => {
@@ -252,11 +393,11 @@ describe("inbox WS data-plane claim helpers", () => {
     expect(second.ok).toBe(true);
     if (!second.ok) throw new Error("duplicate ack unexpectedly rejected");
     expect(second.disposition).toBe("already_acked");
-    expect(second.transitionedFromDelivered).toBe(false);
-    expect(second.entry.status).toBe("acked");
+    expect(second.ackedCount).toBe(0);
+    expect(second.throughEntry.status).toBe("acked");
   });
 
-  it("ackEntryByIdForBoundAgents accepts an owned pending row to close bind-reset races", async () => {
+  it("ackEntryByIdForBoundAgents rejects an owned pending row as a prefix gap", async () => {
     const app = getApp();
     const { a2, messageId } = await seedDeliverable(app);
 
@@ -265,11 +406,7 @@ describe("inbox WS data-plane claim helpers", () => {
     expect(entry.status).toBe("pending");
 
     const accepted = await inboxService.ackEntryByIdForBoundAgents(app.db, entry.id, [a2.agent.inboxId]);
-    expect(accepted.ok).toBe(true);
-    if (!accepted.ok) throw new Error("pending ack unexpectedly rejected");
-    expect(accepted.disposition).toBe("accepted_from_pending");
-    expect(accepted.transitionedFromDelivered).toBe(false);
-    expect(accepted.entry.status).toBe("acked");
+    expect(accepted).toEqual({ ok: false, reason: "prefix_gap" });
   });
 
   it("ackEntryByIdForBoundAgents rejects terminal failed rows", async () => {
@@ -284,7 +421,7 @@ describe("inbox WS data-plane claim helpers", () => {
     if (!entry) throw new Error("seed entry missing");
 
     const rejected = await inboxService.ackEntryByIdForBoundAgents(app.db, entry.id, [a2.agent.inboxId]);
-    expect(rejected).toEqual({ ok: false, reason: "failed_or_dead" });
+    expect(rejected).toEqual({ ok: false, reason: "prefix_gap" });
   });
 
   it("ackEntryByIdForBoundAgents short-circuits on empty inbox list", async () => {

--- a/packages/server/src/__tests__/ws-inbox-delivery-order.test.ts
+++ b/packages/server/src/__tests__/ws-inbox-delivery-order.test.ts
@@ -1,0 +1,149 @@
+import type { InboxDeliverFrame } from "@first-tree/shared";
+import type { FastifyInstance } from "fastify";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import WebSocket from "ws";
+import { createAgent } from "../services/agent.js";
+import { createChat } from "../services/chat.js";
+import { sendMessage } from "../services/message.js";
+import { createAdminContext, createTestApp } from "./helpers.js";
+
+describe("Agent WS — inbox delivery ordering", () => {
+  let app: FastifyInstance;
+  let wsUrl: string;
+
+  function waitForFrame(ws: WebSocket, match: (m: unknown) => boolean, timeoutMs = 5000): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        ws.off("message", onMessage);
+        reject(new Error(`timeout waiting for frame (${timeoutMs}ms)`));
+      }, timeoutMs);
+      const onMessage = (raw: WebSocket.RawData) => {
+        try {
+          const msg = JSON.parse(raw.toString());
+          if (match(msg)) {
+            clearTimeout(timer);
+            ws.off("message", onMessage);
+            resolve(msg);
+          }
+        } catch {
+          // ignore non-JSON frames
+        }
+      };
+      ws.on("message", onMessage);
+    });
+  }
+
+  function collectDeliverFrames(ws: WebSocket, count: number, timeoutMs = 5000): Promise<InboxDeliverFrame[]> {
+    return new Promise((resolve, reject) => {
+      const frames: InboxDeliverFrame[] = [];
+      const timer = setTimeout(() => {
+        ws.off("message", onMessage);
+        reject(new Error(`timeout waiting for ${count} inbox:deliver frames (${timeoutMs}ms)`));
+      }, timeoutMs);
+      const onMessage = (raw: WebSocket.RawData) => {
+        try {
+          const msg = JSON.parse(raw.toString()) as Partial<InboxDeliverFrame> & { type?: string };
+          if (msg.type !== "inbox:deliver") return;
+          frames.push(msg as InboxDeliverFrame);
+          if (frames.length === count) {
+            clearTimeout(timer);
+            ws.off("message", onMessage);
+            resolve(frames);
+          }
+        } catch {
+          // ignore non-JSON frames
+        }
+      };
+      ws.on("message", onMessage);
+    });
+  }
+
+  async function openBoundSocket(seed: {
+    accessToken: string;
+    clientId: string;
+    agentId: string;
+    runtimeProvider: string;
+  }): Promise<WebSocket> {
+    const ws = new WebSocket(wsUrl);
+    await new Promise<void>((resolve, reject) => {
+      ws.once("open", () => resolve());
+      ws.once("error", reject);
+    });
+
+    ws.send(JSON.stringify({ type: "auth", token: seed.accessToken }));
+    await waitForFrame(ws, (m) => (m as { type?: string }).type === "auth:ok");
+
+    ws.send(JSON.stringify({ type: "client:register", clientId: seed.clientId }));
+    await waitForFrame(ws, (m) => (m as { type?: string }).type === "client:registered");
+
+    ws.send(
+      JSON.stringify({
+        type: "agent:bind",
+        agentId: seed.agentId,
+        ref: "bind-order",
+        runtimeType: seed.runtimeProvider,
+        runtimeVersion: "0.0.0",
+      }),
+    );
+    await waitForFrame(ws, (m) => (m as { type?: string }).type === "agent:bound");
+    return ws;
+  }
+
+  beforeAll(async () => {
+    app = await createTestApp();
+    await app.listen({ port: 0, host: "127.0.0.1" });
+    const addr = app.server.address();
+    if (!addr || typeof addr === "string") throw new Error("test server has no address");
+    wsUrl = `ws://127.0.0.1:${addr.port}/api/v1/agent/ws/client`;
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+
+  it("treats NOTIFY messageId as a wake hint and delivers older same-chat pending entries first", async () => {
+    const admin = await createAdminContext(app, { username: `ws-order-${crypto.randomUUID().slice(0, 6)}` });
+    const agent = await createAgent(app.db, {
+      name: `ws-order-agent-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      managerId: admin.memberId,
+      clientId: admin.clientId,
+      organizationId: admin.organizationId,
+    });
+    const chat = await createChat(app.db, admin.humanAgentUuid, {
+      type: "group",
+      participantIds: [agent.uuid],
+    });
+    const ws = await openBoundSocket({
+      accessToken: admin.accessToken,
+      clientId: admin.clientId,
+      agentId: agent.uuid,
+      runtimeProvider: agent.runtimeProvider,
+    });
+
+    try {
+      const first = await sendMessage(app.db, chat.id, admin.humanAgentUuid, {
+        source: "api",
+        format: "text",
+        content: "A1",
+        metadata: { mentions: [agent.uuid] },
+      });
+      const second = await sendMessage(app.db, chat.id, admin.humanAgentUuid, {
+        source: "api",
+        format: "text",
+        content: "A2",
+        metadata: { mentions: [agent.uuid] },
+      });
+
+      const framesPromise = collectDeliverFrames(ws, 2);
+      await app.notifier.notify(agent.inboxId, second.message.id);
+      const frames = await framesPromise;
+
+      expect(frames.map((frame) => frame.message.id)).toEqual([first.message.id, second.message.id]);
+      expect(frames.map((frame) => frame.message.content)).toEqual(["A1", "A2"]);
+    } finally {
+      ws.close();
+      await new Promise<void>((resolve) => ws.once("close", () => resolve()));
+    }
+  }, 15000);
+});

--- a/packages/server/src/api/agent/ws-client.ts
+++ b/packages/server/src/api/agent/ws-client.ts
@@ -145,11 +145,31 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
        * a healthy reconnect.
        */
       const inboxInFlight = new Map<string, number>();
+      /**
+       * Per-agent delivery queue for all server-originated `inbox:deliver`
+       * frames on this socket. Ack-through relies on the client seeing each
+       * `(agent,chat)` stream oldest-first; without this queue, concurrent
+       * NOTIFY handlers or post-ack drains can `SKIP LOCKED` different rows
+       * and send a newer same-chat frame before an older one has reached the
+       * client.
+       */
+      const inboxDeliveryQueues = new Map<string, Promise<void>>();
 
       function isAgentStillRoutedHere(agentId: string): boolean {
         return (
           boundAgents.has(agentId) && clientId !== null && connectionManager.getAgentClientId(agentId) === clientId
         );
+      }
+
+      function chainInboxDelivery(agentId: string, op: () => Promise<void>): Promise<void> {
+        const prev = inboxDeliveryQueues.get(agentId) ?? Promise.resolve();
+        const next = prev.then(op, op);
+        inboxDeliveryQueues.set(agentId, next);
+        const cleanup = () => {
+          if (inboxDeliveryQueues.get(agentId) === next) inboxDeliveryQueues.delete(agentId);
+        };
+        void next.then(cleanup, cleanup);
+        return next;
       }
 
       /**
@@ -201,67 +221,15 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
       }
 
       /**
-       * Build the per-socket push handler bound to a specific agent. Closes
-       * over `agentId`, `inboxId`, the socket, and the in-flight counter.
-       *
-       * Backpressure: when the agent is at-cap we drop the NOTIFY (entry
-       * stays `pending` server-side) and a debug log records the drop so
-       * staging can correlate "messages slow" reports against cap hits.
-       * The dropped row is replayed by `drainBacklogForAgent` once an ack
-       * frees a slot, or by the next NOTIFY when we're back below cap (§3.5).
-       *
-       * Multi-row claims: a single `(inboxId, messageId)` pair maps to
-       * exactly one `inbox_entries` row now that cross-chat reply routing
-       * has been removed (see first-tree-context PR #281). The claim still
-       * returns an array — `claimAndBuildForPush` is defensive against
-       * legacy duplicates and any future fan-out variant.
-       *
-       * The cap is intentionally **soft**: claim happens after the gate
-       * check, so any N>1 future claim could nudge in-flight slightly past
-       * `inboxMaxInFlightPerAgent`. N is bounded by the
-       * `(inbox_id, message_id, chat_id)` unique constraint, so worst-case
-       * overshoot is small and the memory headroom in §3.5's 64MB estimate
-       * covers it.
+       * Build the per-socket push handler bound to a specific agent. A NOTIFY
+       * is only a wake-up hint; the handler drains pending backlog oldest-first
+       * instead of exact-claiming the notified messageId. The per-agent delivery
+       * queue above serializes claim+send so two NOTIFYs cannot reorder same-chat
+       * frames before the client records attempt membership.
        */
       function makeInboxPushHandler(agentId: string, inboxId: string): InboxPushHandler {
-        return async (messageId: string) => {
-          if (!isAgentStillRoutedHere(agentId)) return;
-          const current = inboxInFlight.get(agentId) ?? 0;
-          if (current >= inboxMaxInFlightPerAgent) {
-            app.log.debug(
-              { agentId, inboxId, messageId, inFlightCount: current, cap: inboxMaxInFlightPerAgent },
-              "inbox push: at cap, dropping NOTIFY (will replay via post-ack drain)",
-            );
-            return;
-          }
-
-          let entries: InboxEntryWithMessage[];
-          try {
-            entries = await inboxService.claimAndBuildForPush(app.db, inboxId, messageId);
-          } catch (err) {
-            app.log.error({ err, inboxId, messageId, agentId }, "claimAndBuildForPush failed");
-            return;
-          }
-          if (entries.length === 0) {
-            // Benign race — another instance (or the post-ack backlog drain)
-            // claimed it first.
-            return;
-          }
-
-          for (const entry of entries) {
-            inboxInFlight.set(agentId, (inboxInFlight.get(agentId) ?? 0) + 1);
-            if (!sendInboxDeliverFrame(entry)) {
-              // Socket dropped mid-loop. The entry is still 'delivered' in
-              // the DB; the next `agent:bind` from any client on this inbox
-              // resets it back to 'pending' for redelivery (see
-              // inflight-message-recovery-design.md §4). Release the slot
-              // we just took, then bail — remaining unsent entries also
-              // stay 'delivered' until the next bind.
-              inboxInFlight.set(agentId, Math.max(0, (inboxInFlight.get(agentId) ?? 1) - 1));
-              return;
-            }
-          }
-        };
+        return (messageId: string) =>
+          chainInboxDelivery(agentId, () => drainBacklogForAgent(agentId, inboxId, { source: "notify", messageId }));
       }
 
       /**
@@ -275,19 +243,34 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
        *   2. Right after an `inbox:ack` — top up the in-flight slot just
        *      freed, in case the previous NOTIFY was dropped at-cap.
        *
-       * The cap is **soft**: this function reads `slotsFree` once before the
-       * `claimBacklogForPush` round-trip, and a NOTIFY-driven push handler
-       * may increment the counter concurrently. In the worst case in-flight
-       * temporarily exceeds the cap by the number of concurrent pushes. With
-       * the default cap of 32 and N ≤ 2 per push handler invocation, the
-       * memory headroom in §3.5's 64MB estimate covers this.
+       * Delivery operations are serialized per agent, so `slotsFree` and the
+       * subsequent claim/send loop observe one consistent per-socket in-flight
+       * counter. That ordering is part of the ack-through safety contract.
        */
-      async function drainBacklogForAgent(agentId: string, inboxId: string): Promise<void> {
+      async function drainBacklogForAgent(
+        agentId: string,
+        inboxId: string,
+        trigger?: { source: "notify"; messageId: string } | { source: "bind" | "ack" },
+      ): Promise<void> {
         if (socket.readyState !== socket.OPEN) return;
         if (!isAgentStillRoutedHere(agentId)) return;
         const inFlight = inboxInFlight.get(agentId) ?? 0;
         const slotsFree = inboxMaxInFlightPerAgent - inFlight;
-        if (slotsFree <= 0) return;
+        if (slotsFree <= 0) {
+          if (trigger?.source === "notify") {
+            app.log.debug(
+              {
+                agentId,
+                inboxId,
+                messageId: trigger.messageId,
+                inFlightCount: inFlight,
+                cap: inboxMaxInFlightPerAgent,
+              },
+              "inbox push: at cap, dropping NOTIFY (will replay via post-ack drain)",
+            );
+          }
+          return;
+        }
         const limit = Math.min(slotsFree, INBOX_BACKLOG_BATCH_LIMIT);
 
         let entries: InboxEntryWithMessage[];
@@ -648,28 +631,13 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
                 runtimeProvider: agent.runtimeProvider,
               });
 
-              // Subscribe to NOTIFY traffic with a per-socket push handler so
-              // NOTIFYs land as `inbox:deliver` frames on this connection.
-              notifier.subscribe(agent.inboxId, socket, makeInboxPushHandler(agent.id, agent.inboxId));
-
-              socket.send(
-                JSON.stringify({
-                  type: "agent:bound",
-                  ref,
-                  agentId: agent.id,
-                  displayName: agent.displayName,
-                  agentType: agent.type,
-                }),
-              );
-
               // In-flight recovery: a freshly-(re)connected client may not
               // have acked entries the previous socket received before it
               // dropped (process crash, network blip, etc.). Reset every
               // `delivered` row for this inbox back to `pending` so the
-              // follow-up `drainBacklogForAgent` re-pushes them. Network-
-              // blip duplicates are absorbed by the client's `(chatId,
-              // messageId)` Deduplicator. See
-              // docs/inflight-message-recovery-design.md §4.
+              // follow-up `drainBacklogForAgent` re-pushes them. This must
+              // complete before `agent:bound`: clients clear their local
+              // bind-recovery guard when they observe that frame.
               try {
                 const reset = await inboxService.resetDeliveredForInboxes(app.db, [agent.inboxId]);
                 if (reset > 0) {
@@ -688,12 +656,28 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
                 );
               }
 
+              // Subscribe to NOTIFY traffic with a per-socket push handler so
+              // NOTIFYs land as `inbox:deliver` frames on this connection.
+              notifier.subscribe(agent.inboxId, socket, makeInboxPushHandler(agent.id, agent.inboxId));
+
+              socket.send(
+                JSON.stringify({
+                  type: "agent:bound",
+                  ref,
+                  agentId: agent.id,
+                  displayName: agent.displayName,
+                  agentType: agent.type,
+                }),
+              );
+
               // Reconnect/recovery: drain any pending entries that piled up
               // while this socket was offline (or while another instance held
               // the subscription), plus everything the bind-time reset above
               // just flipped from `delivered` to `pending`. Failures are
               // logged inside the helper — don't crash the bind path.
-              drainBacklogForAgent(agent.id, agent.inboxId).catch((err) => {
+              chainInboxDelivery(agent.id, () =>
+                drainBacklogForAgent(agent.id, agent.inboxId, { source: "bind" }),
+              ).catch((err) => {
                 app.log.error({ err, agentId: agent.id }, "post-bind backlog drain crashed");
               });
             } else if (type === "agent:unbind") {
@@ -712,6 +696,7 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
               connectionManager.unbindAgentFromClient(agentId);
               boundAgents.delete(agentId);
               inboxInFlight.delete(agentId);
+              inboxDeliveryQueues.delete(agentId);
 
               socket.send(JSON.stringify({ type: "agent:unbound", agentId }));
             } else if (type === "session:state") {
@@ -984,7 +969,7 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
                 }
                 // Find the agentId that owns this inbox to decrement the
                 // counter and trigger backlog drain.
-                const owner = [...boundAgents.values()].find((a) => a.inboxId === ackResult.entry.inboxId);
+                const owner = [...boundAgents.values()].find((a) => a.inboxId === ackResult.throughEntry.inboxId);
                 if (ref) {
                   socket.send(
                     JSON.stringify({
@@ -992,6 +977,7 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
                       entryId,
                       ref,
                       disposition: ackResult.disposition,
+                      ackedCount: ackResult.ackedCount,
                     }),
                   );
                 }
@@ -1002,16 +988,23 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
                     ref,
                     agentId: owner?.agentId ?? null,
                     disposition: ackResult.disposition,
+                    ackedCount: ackResult.ackedCount,
+                    ackedEntryIds: ackResult.ackedEntryIds,
                     ackEvent: "inbox_ack_accepted",
                   },
                   "inbox:ack accepted",
                 );
-                if (owner && ackResult.transitionedFromDelivered) {
-                  inboxInFlight.set(owner.agentId, Math.max(0, (inboxInFlight.get(owner.agentId) ?? 1) - 1));
+                if (owner && ackResult.ackedCount > 0) {
+                  inboxInFlight.set(
+                    owner.agentId,
+                    Math.max(0, (inboxInFlight.get(owner.agentId) ?? ackResult.ackedCount) - ackResult.ackedCount),
+                  );
                   // Slot freed → top up. Cheap when no backlog (single SQL
                   // statement returning 0 rows). Critical when the cap was
                   // hit and queued NOTIFYs got dropped (proposal §3.5).
-                  drainBacklogForAgent(owner.agentId, owner.inboxId).catch((err) => {
+                  chainInboxDelivery(owner.agentId, () =>
+                    drainBacklogForAgent(owner.agentId, owner.inboxId, { source: "ack" }),
+                  ).catch((err) => {
                     app.log.error({ err, agentId: owner.agentId }, "post-ack backlog drain crashed");
                   });
                 }
@@ -1045,6 +1038,7 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
           notifier.unsubscribe(info.inboxId, socket);
         }
         boundAgents.clear();
+        inboxDeliveryQueues.clear();
 
         if (clientId) {
           // Reconnect-race guard. A typical `systemctl restart` produces this

--- a/packages/server/src/services/inbox.ts
+++ b/packages/server/src/services/inbox.ts
@@ -1,5 +1,5 @@
 import type { InboxEntryWithMessage, PrecedingMessage } from "@first-tree/shared";
-import { and, asc, desc, eq, gt, inArray, lt, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, inArray, isNull, lt, sql } from "drizzle-orm";
 import type { PgDatabase, PgQueryResultHKT } from "drizzle-orm/pg-core";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import type { Database } from "../db/connection.js";
@@ -16,11 +16,12 @@ type ClaimedEntry = typeof inboxEntries.$inferSelect;
 export type AckEntryResult =
   | {
       ok: true;
-      entry: typeof inboxEntries.$inferSelect;
-      disposition: "acked" | "already_acked" | "accepted_from_pending";
-      transitionedFromDelivered: boolean;
+      throughEntry: typeof inboxEntries.$inferSelect;
+      disposition: "acked" | "already_acked";
+      ackedCount: number;
+      ackedEntryIds: number[];
     }
-  | { ok: false; reason: "not_found_or_not_bound" | "failed_or_dead" };
+  | { ok: false; reason: "not_found_or_not_bound" | "non_notify" | "prefix_gap" };
 
 /** Structurally-typed DB so both `Database` and transaction clients work. */
 type TxLike = Pick<PostgresJsDatabase<Record<string, never>>, "select" | "update" | "delete" | "insert">;
@@ -126,7 +127,7 @@ async function pollInboxInner(db: Database, inboxId: string, limit: number) {
       .select({ id: inboxEntries.id })
       .from(inboxEntries)
       .where(and(eq(inboxEntries.inboxId, inboxId), eq(inboxEntries.status, "pending"), eq(inboxEntries.notify, true)))
-      .orderBy(asc(inboxEntries.createdAt))
+      .orderBy(asc(inboxEntries.createdAt), asc(inboxEntries.id))
       .limit(limit)
       .for("update", { skipLocked: true });
 
@@ -165,10 +166,10 @@ export async function bundleDeliveryWithSilentContext(
   if (claimed.length === 0) return [];
 
   // PostgreSQL's UPDATE...RETURNING does not guarantee row order, so we sort
-  // by createdAt (ascending) before assembling the response. Downstream
+  // by createdAt/id (ascending) before assembling the response. Downstream
   // consumers — and silent-context bundling in particular — depend on
   // chronological order to split context windows correctly.
-  claimed.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+  claimed.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime() || a.id - b.id);
 
   const precedingByEntryId = await collectPrecedingContext(tx, inboxId, claimed);
 
@@ -224,30 +225,19 @@ export async function bundleDeliveryWithSilentContext(
 }
 
 /**
- * Realistic upper bound on rows a single NOTIFY references. The unique
- * constraint `(inbox_id, message_id, chat_id)` caps a `(inbox, message)`
- * pair at one row per chatId. With cross-chat reply routing removed
- * (first-tree-context PR #281), a regular fan-out yields exactly one row;
- * 8 leaves headroom for any future fan-out variant without requiring a
- * schema change here.
- */
-const PUSH_CLAIM_BATCH_LIMIT = 8;
-
-/**
- * WS-push path: atomically claim every pending entry the just-fired
- * `NOTIFY (inboxId:messageId)` references and assemble their wire payloads.
+ * WS-push helper for a just-fired `NOTIFY (inboxId:messageId)`: find the
+ * pending target entry, then atomically claim the same-chat pending prefix
+ * through that target.
  *
  * Returns `[]` if no row matches — benign race with another server instance
  * (or the debug `GET /inbox` endpoint) that already claimed the entry.
  * NOTIFY is fire-and-forget (proposal §3.2).
  *
- * Why an array, not a single row: kept defensive after the cross-chat
- * reply-routing fan-out (which previously wrote a second `(inbox, message)`
- * row keyed by chatId) was removed. The unique key is still
- * `(inbox_id, message_id, chat_id)`, so any future fan-out variant that
- * legitimately produces more than one row per NOTIFY drops in without a
- * shape change. Aligning with `pollInboxInner`'s `LIMIT N` shape also keeps
- * push/poll behaviour interchangeable.
+ * Ack-through safety depends on this prefix behavior: a newer entry must not
+ * be claimed/sent while an older same-chat pending entry remains invisible to
+ * the client attempt. The production WS handler additionally serializes
+ * delivery per agent before sending frames, so the claimed prefix is emitted
+ * oldest-first on the socket.
  */
 export async function claimAndBuildForPush(
   db: Database,
@@ -256,8 +246,8 @@ export async function claimAndBuildForPush(
 ): Promise<InboxEntryWithMessage[]> {
   return withSpan("inbox.deliver.push", { "inbox.id": inboxId, "message.id": messageId }, () =>
     db.transaction(async (tx) => {
-      const targetIds = tx
-        .select({ id: inboxEntries.id })
+      const [target] = await tx
+        .select({ id: inboxEntries.id, chatId: inboxEntries.chatId })
         .from(inboxEntries)
         .where(
           and(
@@ -267,9 +257,27 @@ export async function claimAndBuildForPush(
             eq(inboxEntries.notify, true),
           ),
         )
-        .orderBy(asc(inboxEntries.createdAt))
-        .limit(PUSH_CLAIM_BATCH_LIMIT)
-        .for("update", { skipLocked: true });
+        .orderBy(asc(inboxEntries.createdAt), asc(inboxEntries.id))
+        .for("update")
+        .limit(1);
+      if (!target) return [];
+
+      const chatPredicate =
+        target.chatId === null ? isNull(inboxEntries.chatId) : eq(inboxEntries.chatId, target.chatId);
+      const targetIds = tx
+        .select({ id: inboxEntries.id })
+        .from(inboxEntries)
+        .where(
+          and(
+            eq(inboxEntries.inboxId, inboxId),
+            chatPredicate,
+            eq(inboxEntries.status, "pending"),
+            eq(inboxEntries.notify, true),
+            sql`${inboxEntries.id} <= ${target.id}`,
+          ),
+        )
+        .orderBy(asc(inboxEntries.id))
+        .for("update");
 
       const claimed = await tx
         .update(inboxEntries)
@@ -327,7 +335,7 @@ async function collectPrecedingContext(
   }
 
   for (const [chatId, chatTriggers] of byChat) {
-    chatTriggers.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+    chatTriggers.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime() || a.id - b.id);
 
     // For each trigger, fetch silent context strictly before it (and after
     // the previous trigger in this batch). Window: 24h before the trigger.
@@ -422,15 +430,19 @@ async function collectPrecedingContext(
 }
 
 /**
- * Ack an entry from the WS data plane, scoped to the inboxes the connected
- * socket has bound. The operation is idempotent: duplicate ACKs for `acked`
- * rows are accepted, and owned `pending` rows may be ACKed to close the
- * bind-reset race after the client has already completed the turn.
+ * Commit inbox progress through the supplied entry id from the WS data plane,
+ * scoped to the inboxes the connected socket has bound.
+ *
+ * `entryId` is interpreted as a cursor, not as an exact single-row ack:
+ * every notify=true row in the same `(inboxId, chatId)` partition up to that
+ * id must already be `acked` or `delivered`. Delivered rows in that contiguous
+ * prefix are atomically marked `acked`; `pending` / `failed` gaps reject the
+ * commit so the database cannot persist `A pending, B acked`.
  *
  * Trusts only the `inboxId` set the connected socket has bound (no `inboxId`
  * on the wire), and short-circuits on an empty `inboxIds`.
  */
-export async function ackEntryByIdForBoundAgents(
+export async function ackThroughEntryIdForBoundAgents(
   db: Database,
   entryId: number,
   inboxIds: string[],
@@ -445,35 +457,56 @@ export async function ackEntryByIdForBoundAgents(
         .for("update")
         .limit(1);
       if (!entry) return { ok: false, reason: "not_found_or_not_bound" };
-      if (entry.status === "acked") {
-        return { ok: true, entry, disposition: "already_acked", transitionedFromDelivered: false };
-      }
-      if (entry.status !== "delivered" && entry.status !== "pending") {
-        return { ok: false, reason: "failed_or_dead" };
-      }
+      if (!entry.notify) return { ok: false, reason: "non_notify" };
 
-      const previousStatus = entry.status;
-      const [updated] = await tx
-        .update(inboxEntries)
-        .set({ status: "acked", ackedAt: new Date() })
+      const chatPredicate = entry.chatId === null ? isNull(inboxEntries.chatId) : eq(inboxEntries.chatId, entry.chatId);
+      const prefixRows = await tx
+        .select()
+        .from(inboxEntries)
         .where(
           and(
-            eq(inboxEntries.id, entryId),
-            inArray(inboxEntries.inboxId, inboxIds),
-            eq(inboxEntries.status, previousStatus),
+            eq(inboxEntries.inboxId, entry.inboxId),
+            chatPredicate,
+            eq(inboxEntries.notify, true),
+            sql`${inboxEntries.id} <= ${entryId}`,
           ),
         )
+        .orderBy(asc(inboxEntries.id))
+        .for("update");
+
+      if (prefixRows.some((row) => row.status !== "acked" && row.status !== "delivered")) {
+        return { ok: false, reason: "prefix_gap" };
+      }
+
+      const deliveredIds = prefixRows.filter((row) => row.status === "delivered").map((row) => row.id);
+      if (deliveredIds.length === 0) {
+        return {
+          ok: true,
+          throughEntry: entry,
+          disposition: "already_acked",
+          ackedCount: 0,
+          ackedEntryIds: [],
+        };
+      }
+
+      const updated = await tx
+        .update(inboxEntries)
+        .set({ status: "acked", ackedAt: new Date() })
+        .where(and(inArray(inboxEntries.id, deliveredIds), eq(inboxEntries.status, "delivered")))
         .returning();
-      if (!updated) return { ok: false, reason: "not_found_or_not_bound" };
+      const updatedThroughEntry = updated.find((row) => row.id === entryId) ?? entry;
       return {
         ok: true,
-        entry: updated,
-        disposition: previousStatus === "delivered" ? "acked" : "accepted_from_pending",
-        transitionedFromDelivered: previousStatus === "delivered",
+        throughEntry: updatedThroughEntry,
+        disposition: "acked",
+        ackedCount: updated.length,
+        ackedEntryIds: updated.map((row) => row.id),
       };
     });
   });
 }
+
+export const ackEntryByIdForBoundAgents = ackThroughEntryIdForBoundAgents;
 
 /**
  * Reset every `delivered` entry across the given `inboxIds` back to `pending`

--- a/packages/server/src/services/inbox.ts
+++ b/packages/server/src/services/inbox.ts
@@ -144,10 +144,10 @@ async function pollInboxInner(db: Database, inboxId: string, limit: number) {
 /**
  * Shared payload assembler for already-claimed `inbox_entries` rows.
  *
- * Both the debug `GET /inbox` path (`pollInbox`) and the WS push path
- * (`claimAndBuildForPush`) call this with rows they have just `UPDATE`d to
+ * `pollInbox`, the production WS backlog drain, and the exact-message
+ * prefix-claim helper call this with rows they have just `UPDATE`d to
  * `status='delivered'`. Keeping the silent-context bundling in one place is
- * the only way to keep the two paths from drifting (proposal
+ * the only way to keep delivery paths from drifting (proposal
  * hub-inbox-ws-data-plane §3.2 risk #1).
  *
  * Steps:
@@ -225,9 +225,15 @@ export async function bundleDeliveryWithSilentContext(
 }
 
 /**
- * WS-push helper for a just-fired `NOTIFY (inboxId:messageId)`: find the
- * pending target entry, then atomically claim the same-chat pending prefix
- * through that target.
+ * Exact-message prefix-claim helper: find the pending target entry for a
+ * `messageId`, then atomically claim the same-chat pending prefix through
+ * that target.
+ *
+ * Production WS delivery no longer exact-claims NOTIFY message ids; it treats
+ * NOTIFY as a wake-up hint and drains backlog oldest-first through
+ * `claimBacklogForPush()`. This helper remains for direct tests and any
+ * explicit exact-message claim callers that need the same ack-through prefix
+ * safety.
  *
  * Returns `[]` if no row matches — benign race with another server instance
  * (or the debug `GET /inbox` endpoint) that already claimed the entry.
@@ -235,9 +241,8 @@ export async function bundleDeliveryWithSilentContext(
  *
  * Ack-through safety depends on this prefix behavior: a newer entry must not
  * be claimed/sent while an older same-chat pending entry remains invisible to
- * the client attempt. The production WS handler additionally serializes
- * delivery per agent before sending frames, so the claimed prefix is emitted
- * oldest-first on the socket.
+ * the client attempt. Callers that send the returned frames must preserve the
+ * returned oldest-first order.
  */
 export async function claimAndBuildForPush(
   db: Database,

--- a/packages/shared/src/__tests__/inbox-frames-schema.test.ts
+++ b/packages/shared/src/__tests__/inbox-frames-schema.test.ts
@@ -187,6 +187,7 @@ describe("inboxAckAcceptedFrameSchema", () => {
       entryId: 7,
       ref: "ack_123",
       disposition: "accepted_from_pending",
+      ackedCount: 2,
     });
     expect(res.success).toBe(true);
   });

--- a/packages/shared/src/schemas/inbox-frames.ts
+++ b/packages/shared/src/schemas/inbox-frames.ts
@@ -36,7 +36,12 @@ export type InboxAckFrame = z.infer<typeof inboxAckFrameSchema>;
 export const inboxAckAcceptedDispositionSchema = z.enum(["acked", "already_acked", "accepted_from_pending"]);
 export type InboxAckAcceptedDisposition = z.infer<typeof inboxAckAcceptedDispositionSchema>;
 
-export const inboxAckRejectedReasonSchema = z.enum(["not_found_or_not_bound", "failed_or_dead"]);
+export const inboxAckRejectedReasonSchema = z.enum([
+  "not_found_or_not_bound",
+  "failed_or_dead",
+  "non_notify",
+  "prefix_gap",
+]);
 export type InboxAckRejectedReason = z.infer<typeof inboxAckRejectedReasonSchema>;
 
 export const inboxAckAcceptedFrameSchema = z.object({
@@ -44,6 +49,7 @@ export const inboxAckAcceptedFrameSchema = z.object({
   entryId: z.number().int().nonnegative(),
   ref: z.string().min(1),
   disposition: inboxAckAcceptedDispositionSchema,
+  ackedCount: z.number().int().nonnegative().optional(),
 });
 export type InboxAckAcceptedFrame = z.infer<typeof inboxAckAcceptedFrameSchema>;
 


### PR DESCRIPTION
## Summary
- change `inbox:ack { entryId }` handling to commit the delivered prefix through the target entry for the same inbox/chat partition
- replace count/FIFO-based client completion with concrete message completion and per-chat ordered admission guards
- fail closed for abandoned, retryable, malformed, or route-failed inbox deliveries so later entries cannot through-commit unfinished older work
- serialize server inbox delivery/drain paths and add regression coverage for ack-through ordering
- after rebasing onto latest `main`, sync the client bundled skill lists with the retired `first-tree-write` skill so validation remains green

## Validation
- `pnpm check`
- `pnpm typecheck`
- `pnpm --filter @first-tree/client exec vitest run --maxWorkers=2`
- `pnpm --filter @first-tree/server exec vitest run --maxWorkers=2 src/__tests__/ws-inbox-delivery-order.test.ts src/__tests__/inbox-ws-push.test.ts src/__tests__/inbox-bind-recovery.test.ts`
- `pnpm --filter @first-tree/shared exec vitest run --maxWorkers=2 src/__tests__/inbox-frames-schema.test.ts`
- `git diff --check`

## Review
- Design reviewed and confirmed in the First Tree agent chat.
- `codex-reviewer` performed code review and follow-up reviews; latest review found no blocking issues.
