### PR TITLE
refactor(tree): stop generating tree-side AGENTS.md / CLAUDE.md

### DIFF
--- a/apps/cli/src/__tests__/tree-repo-registry.test.ts
+++ b/apps/cli/src/__tests__/tree-repo-registry.test.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { writeTreeBinding } from "../commands/tree/binding-state.js";
+import { TREE_CODE_REPOS_FILE, writeTreeBinding } from "../commands/tree/binding-state.js";
 import {
   buildTreeCodeRepoIndexNote,
   listKnownTreeCodeRepos,
@@ -110,21 +110,82 @@ describe("tree code repo registry", () => {
     ]);
   });
 
-  it("upserts one repository while preserving known entries and skips invalid input or missing files", () => {
+  it("upserts one repository while preserving known entries and skips invalid input", () => {
     writePromptFile("AGENTS.md");
     expect(syncTreeCodeRepoRegistry(root, ["https://github.com/acme/web.git"])).toBe("updated");
 
     expect(upsertTreeCodeRepoRegistry(root, "git@github.com:acme/api.git")).toBe("updated");
     expect(listKnownTreeCodeRepos(root).map((repo) => repo.slug)).toEqual(["acme/api", "acme/web"]);
     expect(upsertTreeCodeRepoRegistry(root, "not a github remote")).toBe("skipped");
+  });
 
-    const missingRoot = mkdtempSync(join(tmpdir(), "ft-tree-repo-registry-missing-"));
-    try {
-      expect(syncTreeCodeRepoRegistry(missingRoot, ["https://github.com/acme/web.git"])).toBe("skipped");
-      expect(existsSync(join(missingRoot, "AGENTS.md"))).toBe(false);
-    } finally {
-      rmSync(missingRoot, { recursive: true, force: true });
-    }
+  // Regression — issue surfaced on PR #794 (yuezengwu + baixiaohang Finding 2).
+  // Before the fix, `syncTreeCodeRepoRegistry` only wrote into tree-root
+  // `AGENTS.md` / `CLAUDE.md` and returned "skipped" when neither existed.
+  // Since PR #794 deletes those files from new trees, a fresh `tree init` with
+  // a GitHub origin used to produce an empty `source-repos.md`.
+  it("persists registry to `.first-tree/code-repos.json` for new trees that no longer carry AGENTS.md / CLAUDE.md", () => {
+    expect(existsSync(join(root, "AGENTS.md"))).toBe(false);
+    expect(existsSync(join(root, "CLAUDE.md"))).toBe(false);
+
+    const action = syncTreeCodeRepoRegistry(root, ["https://github.com/acme/web.git", "git@github.com:acme/api.git"]);
+
+    expect(action).toBe("created");
+    const persistedPath = join(root, TREE_CODE_REPOS_FILE);
+    expect(existsSync(persistedPath)).toBe(true);
+    const persisted = JSON.parse(readFileSync(persistedPath, "utf8")) as {
+      repos: Array<{ slug: string; url: string }>;
+      schemaVersion: number;
+    };
+    expect(persisted.schemaVersion).toBe(1);
+    expect(persisted.repos.map((r) => r.slug)).toEqual(["acme/api", "acme/web"]);
+    expect(listKnownTreeCodeRepos(root).map((repo) => repo.slug)).toEqual(["acme/api", "acme/web"]);
+
+    // Tree-root prompt files are not created as a side effect of registering.
+    expect(existsSync(join(root, "AGENTS.md"))).toBe(false);
+    expect(existsSync(join(root, "CLAUDE.md"))).toBe(false);
+  });
+
+  it("re-syncing the same registry to a new tree is idempotent", () => {
+    expect(syncTreeCodeRepoRegistry(root, ["https://github.com/acme/web.git"])).toBe("created");
+    expect(syncTreeCodeRepoRegistry(root, ["https://github.com/acme/web.git"])).toBe("unchanged");
+  });
+
+  it("`listKnownTreeCodeRepos` prefers `.first-tree/code-repos.json` over legacy AGENTS.md / CLAUDE.md", () => {
+    // Legacy registry says "old"; new JSON store says "new". Read path must
+    // prefer the JSON.
+    writePromptFile(
+      "AGENTS.md",
+      [
+        "<!-- BEGIN FIRST-TREE-CODE-REPO-REGISTRY -->",
+        "<!--",
+        "FIRST-TREE-CODE-REPO-REGISTRY: managed-block-v1",
+        "FIRST-TREE-CODE-REPO: `https://github.com/acme/legacy`",
+        "-->",
+        "<!-- END FIRST-TREE-CODE-REPO-REGISTRY -->",
+        "",
+      ].join("\n"),
+    );
+    syncTreeCodeRepoRegistry(root, ["https://github.com/acme/new.git"]);
+
+    expect(listKnownTreeCodeRepos(root).map((repo) => repo.slug)).toEqual(["acme/new"]);
+  });
+
+  it("`syncTreeCodeRepoRegistry` mirrors writes into legacy AGENTS.md / CLAUDE.md when they exist", () => {
+    // Migration safety: a tree predating PR #794 still has the prompt files;
+    // the registry should keep them in sync alongside the canonical JSON
+    // store so contributors still reading those files see the same data.
+    writePromptFile("AGENTS.md");
+
+    syncTreeCodeRepoRegistry(root, ["https://github.com/acme/web.git"]);
+
+    const agents = readFileSync(join(root, "AGENTS.md"), "utf8");
+    expect(agents).toContain("FIRST-TREE-CODE-REPO: `https://github.com/acme/web`");
+
+    const persisted = JSON.parse(readFileSync(join(root, TREE_CODE_REPOS_FILE), "utf8")) as {
+      repos: Array<{ slug: string }>;
+    };
+    expect(persisted.repos.map((r) => r.slug)).toEqual(["acme/web"]);
   });
 
   it("builds the source repo index note", () => {

--- a/apps/cli/src/commands/tree/binding-state.ts
+++ b/apps/cli/src/commands/tree/binding-state.ts
@@ -28,6 +28,7 @@ export const TREE_VERSION_FILE = join(TREE_RUNTIME_ROOT, "VERSION");
 export const TREE_PROGRESS_FILE = join(TREE_RUNTIME_ROOT, "progress.md");
 export const SOURCE_STATE_FILE = join(TREE_RUNTIME_ROOT, "source.json");
 export const TREE_STATE_FILE = join(TREE_RUNTIME_ROOT, "tree.json");
+export const TREE_CODE_REPOS_FILE = join(TREE_RUNTIME_ROOT, "code-repos.json");
 export const TREE_BINDINGS_DIR = join(TREE_RUNTIME_ROOT, "bindings");
 export const TREE_SOURCE_REPOS_FILE = "source-repos.md";
 

--- a/apps/cli/src/commands/tree/bootstrap.ts
+++ b/apps/cli/src/commands/tree/bootstrap.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 
-import { TREE_PROGRESS_FILE, TREE_VERSION_FILE } from "./binding-state.js";
+import { buildTreeId, TREE_PROGRESS_FILE, TREE_VERSION_FILE, treeStatePath, writeTreeState } from "./binding-state.js";
 import type { Tier0RuleLayerSummary } from "./rule-layer.js";
 import { ensureTier0RuleLayer } from "./rule-layer.js";
 import { isGitRepoRoot, repoNameForRoot, runCommand } from "./shared.js";
@@ -71,6 +71,19 @@ export function bootstrapTreeRoot(targetRoot: string, options?: BootstrapOptions
   writeIfMissing(join(targetRoot, TREE_VERSION_FILE), "0.4.0-alpha.1");
   writeIfMissing(join(targetRoot, TREE_PROGRESS_FILE), renderTreeProgress());
   const tier0RuleLayer = ensureTier0RuleLayer(targetRoot);
+
+  // Persist tree identity to `.first-tree/tree.json`. This is the canonical
+  // identity store now that tree-side AGENTS.md / CLAUDE.md no longer ship
+  // with a managed identity block. `syncTreeIdentityFiles` below still
+  // refreshes the legacy framework block when those files exist (so existing
+  // trees keep working), but it is no longer the source of truth.
+  if (!existsSync(treeStatePath(targetRoot))) {
+    writeTreeState(targetRoot, {
+      treeId: buildTreeId(treeRepoName),
+      treeMode,
+      treeRepoName,
+    });
+  }
 
   syncTreeIdentityFiles(targetRoot, {
     treeMode,

--- a/apps/cli/src/commands/tree/bootstrap.ts
+++ b/apps/cli/src/commands/tree/bootstrap.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, symlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 
 import { TREE_PROGRESS_FILE, TREE_VERSION_FILE } from "./binding-state.js";
@@ -16,7 +16,6 @@ import {
   renderMembersDomainNode,
   renderOrgConfigPlaceholder,
   renderRootNode,
-  renderTreeAgentsInstructions,
   renderTreeProgress,
 } from "./tree-templates.js";
 
@@ -51,15 +50,6 @@ function writeIfMissing(path: string, contents: string): void {
   writeFileSync(path, `${contents.trimEnd()}\n`);
 }
 
-function ensureClaudeSymlink(targetRoot: string): void {
-  const claudePath = join(targetRoot, "CLAUDE.md");
-  if (existsSync(claudePath)) {
-    return;
-  }
-
-  symlinkSync("AGENTS.md", claudePath);
-}
-
 export function bootstrapTreeRoot(targetRoot: string, options?: BootstrapOptions): BootstrapSummary {
   const treeMode = options?.treeMode === "shared" ? "shared" : "dedicated";
   const treeRepoName = repoNameForRoot(targetRoot);
@@ -70,8 +60,6 @@ export function bootstrapTreeRoot(targetRoot: string, options?: BootstrapOptions
   upsertLocalTreeGitIgnore(targetRoot);
 
   writeIfMissing(join(targetRoot, "NODE.md"), renderRootNode("Context Tree"));
-  writeIfMissing(join(targetRoot, "AGENTS.md"), renderTreeAgentsInstructions());
-  ensureClaudeSymlink(targetRoot);
   writeIfMissing(join(targetRoot, "members", "NODE.md"), renderMembersDomainNode());
   writeIfMissing(join(targetRoot, "members", "owner", "NODE.md"), renderDefaultMemberNode());
   writeIfMissing(join(targetRoot, ".first-tree", "agent-templates", "developer.yaml"), renderDeveloperAgentTemplate());

--- a/apps/cli/src/commands/tree/tree-repo-registry.ts
+++ b/apps/cli/src/commands/tree/tree-repo-registry.ts
@@ -1,8 +1,15 @@
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 
-import { listTreeBindings, TREE_SOURCE_REPOS_FILE } from "./binding-state.js";
+import { listTreeBindings, TREE_CODE_REPOS_FILE, TREE_SOURCE_REPOS_FILE } from "./binding-state.js";
 import { ensureTrailingNewline, parseGitHubRemoteUrl } from "./shared.js";
+
+const CODE_REPOS_SCHEMA_VERSION = 1;
+
+type CodeReposFile = {
+  repos: ManagedTreeCodeRepo[];
+  schemaVersion: number;
+};
 
 const TREE_CODE_REPO_REGISTRY_BEGIN = "<!-- BEGIN FIRST-TREE-CODE-REPO-REGISTRY -->";
 const TREE_CODE_REPO_REGISTRY_END = "<!-- END FIRST-TREE-CODE-REPO-REGISTRY -->";
@@ -143,7 +150,59 @@ function writeRegistryFile(path: string, repos: ManagedTreeCodeRepo[]): SyncActi
   return current === null ? "created" : "updated";
 }
 
+function readCodeReposFile(treeRoot: string): ManagedTreeCodeRepo[] {
+  const path = join(treeRoot, TREE_CODE_REPOS_FILE);
+
+  if (!existsSync(path)) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf-8")) as unknown;
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      "repos" in parsed &&
+      Array.isArray((parsed as { repos: unknown }).repos)
+    ) {
+      const file = parsed as CodeReposFile;
+      return dedupeRepos(
+        file.repos
+          .map((repo) => normalizeGitHubRepoUrl(repo.url))
+          .filter((repo): repo is ManagedTreeCodeRepo => repo !== undefined),
+      );
+    }
+  } catch {
+    // fall through to empty
+  }
+
+  return [];
+}
+
+function writeCodeReposFile(treeRoot: string, repos: ManagedTreeCodeRepo[]): SyncAction {
+  const path = join(treeRoot, TREE_CODE_REPOS_FILE);
+  const next = `${JSON.stringify({ repos, schemaVersion: CODE_REPOS_SCHEMA_VERSION }, null, 2)}\n`;
+  const current = existsSync(path) ? readFileSync(path, "utf-8") : null;
+
+  if (current === next) {
+    return "unchanged";
+  }
+
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, next);
+  return current === null ? "created" : "updated";
+}
+
 export function listKnownTreeCodeRepos(treeRoot: string): ManagedTreeCodeRepo[] {
+  // `.first-tree/code-repos.json` is the canonical store. Tree-root
+  // `AGENTS.md` / `CLAUDE.md` were the v0.x storage and are read here only as
+  // a legacy fallback (those files are no longer generated; see #794). When
+  // both are empty, fall back to walking the source bindings directory.
+  const persisted = readCodeReposFile(treeRoot);
+  if (persisted.length > 0) {
+    return persisted;
+  }
+
   for (const file of TREE_REGISTRY_FILES) {
     const path = join(treeRoot, file);
 
@@ -168,8 +227,12 @@ export function syncTreeCodeRepoRegistry(treeRoot: string, repoUrls: string[]): 
       .filter((value): value is ManagedTreeCodeRepo => value !== undefined),
   );
 
-  let overallAction: SyncAction = "skipped";
+  // Canonical write: always persist to `.first-tree/code-repos.json`.
+  let overallAction: SyncAction = writeCodeReposFile(treeRoot, repos);
 
+  // Legacy mirrors: if tree-root `AGENTS.md` / `CLAUDE.md` still exist on an
+  // older tree, keep their managed registry block in sync. New trees no
+  // longer generate these files so this loop is a no-op for them.
   for (const file of TREE_REGISTRY_FILES) {
     const path = join(treeRoot, file);
 
@@ -179,8 +242,6 @@ export function syncTreeCodeRepoRegistry(treeRoot: string, repoUrls: string[]): 
 
     const action = writeRegistryFile(path, repos);
     if (action === "created" || action === "updated") {
-      overallAction = action;
-    } else if (overallAction === "skipped") {
       overallAction = action;
     }
   }

--- a/apps/cli/src/commands/tree/tree-templates.ts
+++ b/apps/cli/src/commands/tree/tree-templates.ts
@@ -9,21 +9,9 @@ export function renderRootNode(treeTitle: string): string {
     "",
     `# ${treeTitle}`,
     "",
-    "The living source of truth for your organization. A structured knowledge base that agents and humans build and maintain together across one or more source repositories and systems.",
-    "",
-    "---",
-    "",
     "## Domains",
     "",
     "- **[members/](members/NODE.md)** — Team member definitions and responsibilities.",
-    "",
-    "---",
-    "",
-    "## Working with the Tree",
-    "",
-    "Keep decision context here. Keep implementation detail in the source repos this tree describes.",
-    "",
-    "See [AGENTS.md](AGENTS.md) for agent instructions — the before/during/after workflow, ownership model, and tree maintenance.",
     "",
   ].join("\n");
 }
@@ -678,52 +666,6 @@ export function renderReviewEnforcerWorkflow(): string {
     "                `Auto-dismissed: cross-owner PRs require approval from a ` +",
     "                `frontmatter-listed owner. Eligible: ${intersection.join(', ')}.`",
     "            });",
-  ].join("\n");
-}
-
-/**
- * Render the Context-Tree framework block injected into a tree-bound agent's
- * AGENTS.md.
- */
-export function renderTreeAgentsInstructions(): string {
-  return [
-    "<!-- BEGIN CONTEXT-TREE FRAMEWORK — do not edit this section -->",
-    "# Agent Instructions for Context Tree",
-    "",
-    "You are working in a **Context Tree** — the living source of truth for decisions across the organization. Read and follow this before doing anything.",
-    "",
-    "## Principles",
-    "",
-    "1. **Source of truth for decisions, not execution.** The tree captures the *what* and *why* — strategic choices, cross-domain relationships, constraints. Execution details stay in source systems.",
-    "2. **Agents are first-class participants.** The tree is designed to be navigated and updated by agents, not just humans.",
-    "3. **Transparency by default.** All information is readable by everyone. Writing requires owner approval; reading is open.",
-    "4. **Git-native tree structure.** Each node is a file; each domain is a directory.",
-    "",
-    "## Before Every Task",
-    "",
-    "1. Read the root NODE.md to understand the domain map.",
-    "2. Read the NODE.md of every domain relevant to your task.",
-    "3. Follow soft_links and read the linked nodes too.",
-    "4. Read relevant leaf nodes before making cross-domain decisions.",
-    "",
-    "## During the Task",
-    "",
-    "- Decide in the tree, execute in source systems.",
-    "- Keep execution detail in code repos and runtime systems.",
-    "- Respect ownership fields in node frontmatter.",
-    "",
-    "## After Every Task",
-    "",
-    "- If you suspect the task changed decisions, constraints, rationale, ownership, or shared workspace relationships, confirm whether the tree needs updating before opening any code PR. A tree PR is shared-state and externally visible, so the decision needs human endorsement when it is not obvious. Asking a human is [pending redesign, 自行判断].",
-    "- If a tree update is needed (or the change is obviously tree-relevant), open the tree PR first, then the source/workspace code PR.",
-    "- If the task changed only implementation details, skip the tree PR — open only the source/workspace code PR.",
-    "",
-    "<!-- END CONTEXT-TREE FRAMEWORK -->",
-    "",
-    "# Project-Specific Instructions",
-    "",
-    "<!-- Add your project-specific agent instructions below this line. -->",
-    "",
   ].join("\n");
 }
 

--- a/apps/cli/src/commands/tree/upgrade.ts
+++ b/apps/cli/src/commands/tree/upgrade.ts
@@ -90,7 +90,7 @@ function upgradeSourceRoot(targetRoot: string, bundledSkillVersion: string): Upg
 function upgradeTreeRoot(targetRoot: string, bundledSkillVersion: string): UpgradeSummary {
   const treeIdentity = readTreeIdentityContract(targetRoot);
   if (treeIdentity === undefined) {
-    throw new Error("No managed tree identity was found in `.first-tree/` state.");
+    throw new Error(".first-tree/tree.json is missing — cannot resolve tree identity.");
   }
 
   copyCanonicalSkills(targetRoot);

--- a/apps/cli/src/commands/tree/upgrade.ts
+++ b/apps/cli/src/commands/tree/upgrade.ts
@@ -90,7 +90,7 @@ function upgradeSourceRoot(targetRoot: string, bundledSkillVersion: string): Upg
 function upgradeTreeRoot(targetRoot: string, bundledSkillVersion: string): UpgradeSummary {
   const treeIdentity = readTreeIdentityContract(targetRoot);
   if (treeIdentity === undefined) {
-    throw new Error("No managed tree identity was found in `AGENTS.md` or `CLAUDE.md`.");
+    throw new Error("No managed tree identity was found in `.first-tree/` state.");
   }
 
   copyCanonicalSkills(targetRoot);

--- a/apps/cli/tests/template-write.test.ts
+++ b/apps/cli/tests/template-write.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
+import { readTreeState } from "../src/commands/tree/binding-state.js";
 import { bootstrapTreeRoot } from "../src/commands/tree/bootstrap.js";
 import { readCurrentCliVersion } from "../src/commands/tree/cli-version.js";
 import {
@@ -12,6 +13,7 @@ import {
   validateWorkflowPath,
 } from "../src/commands/tree/rule-layer.js";
 import { parseTemplateVersion, writeTemplatedFile } from "../src/commands/tree/template-write.js";
+import { readTreeIdentityContract } from "../src/commands/tree/tree-identity.js";
 import { upgradeTargetRoot } from "../src/commands/tree/upgrade.js";
 
 const tempDirs: string[] = [];
@@ -104,6 +106,23 @@ describe("tree rule-layer templates", () => {
     expect(readFileSync(workflowPath, "utf8")).toContain(
       `run: npx -p first-tree@${readCurrentCliVersion()} first-tree tree verify`,
     );
+  });
+
+  it("persists tree identity to .first-tree/tree.json so verify and upgrade can resolve it", () => {
+    const root = makeTempDir("first-tree-bootstrap-identity-");
+
+    bootstrapTreeRoot(root, { treeMode: "shared" });
+
+    const state = readTreeState(root);
+    expect(state).not.toBeNull();
+    expect(state?.treeMode).toBe("shared");
+    expect(state?.treeRepoName.length ?? 0).toBeGreaterThan(0);
+    expect(state?.treeId.length ?? 0).toBeGreaterThan(0);
+
+    const identity = readTreeIdentityContract(root);
+    expect(identity).toBeDefined();
+    expect(identity?.treeRepoName).toBe(state?.treeRepoName);
+    expect(identity?.treeMode).toBe("shared");
   });
 
   it("upgrades existing tree roots by adding the missing Tier 0 validate workflow", () => {


### PR DESCRIPTION
## Summary

Tree-side `AGENTS.md` / `CLAUDE.md` were carrying a framework block that duplicated agent behavior regulation already shipped through the `first-tree` skills and the workspace-level managed block. The tree-repo copy was also strictly weaker than `practices/tree-maintenance.md` and **factually wrong** about the gate model (claimed "Writing requires owner approval" while `self_owner` PRs auto-merge).

Companion to [first-tree-context#394](https://github.com/agent-team-foundation/first-tree-context/pull/394), which removed the existing tree-side files from the org's tree repo. This PR removes them from the tooling so future `first-tree tree init` calls don't reproduce what we just deleted.

Direction set by @liuchao-001:

> 事实上这个 tree repo 的 agents.md 和 claude.md 应该删掉。我们在 agent workspace 层级有 agents.md 在规范 agent 行为。tree-templates.ts 要跟上新shape。

## Where agent behavior regulation lives now

- **Workspace-level `AGENTS.md` / `CLAUDE.md`** — the managed `FIRST-TREE-SOURCE-INTEGRATION` block written by `upsertSourceIntegrationFiles` into each bound source/workspace root. Untouched by this PR.
- **`first-tree` / `first-tree-context` / `first-tree-write` skills** — the workflow / writing discipline layer.
- **`practices/tree-maintenance.md`** in the tree — the canonical gate / tiered write model.

Tree repos now hold just the org data (`NODE.md` domain map, leaves, `members/`, `.first-tree/` state).

## Where tree identity lives now

**`.first-tree/tree.json`** — written by `bootstrap.ts` (new, see "Bug fix" below). `readTreeIdentityContract()` reads from this; the legacy `AGENTS.md` framework block remains as a fallback so existing trees keep working.

## Changes

**`tree-templates.ts`:**
- Simplify `renderRootNode()` to the minimal "frontmatter + title + domain pointer" shape — drops the preamble, the "Working with the Tree" section, and the `See AGENTS.md` pointer
- Remove `renderTreeAgentsInstructions()` (the framework block source)

**`bootstrap.ts`:**
- Stop writing tree-root `AGENTS.md`
- Stop creating the `CLAUDE.md` → `AGENTS.md` symlink; drop the helper
- **Write `.first-tree/tree.json`** via `writeTreeState` (idempotent — skipped if already present, e.g. on republish)

**`verify.ts`:**
- Drop the `agentInstructions` check (was requiring tree-root `AGENTS.md` / `CLAUDE.md` with the framework marker)
- Update the `treeState` error message — `.first-tree/tree.json is missing.` (matches the existing `.first-tree/VERSION is missing.` style)

**`upgrade.ts`:**
- Update the tree-side identity error message to `.first-tree/tree.json is missing — cannot resolve tree identity.`. The source-side error (line 50) is **unchanged** because source/workspace `AGENTS.md` / `CLAUDE.md` still carry the `FIRST-TREE-SOURCE-INTEGRATION` block

**`tests/template-write.test.ts`:**
- New regression test: `bootstrap → readTreeState + readTreeIdentityContract both defined`. Without the bootstrap fix above, this fails — closes the test gap that let the original CRITICAL bug through

## Bug fix mid-PR

[Initial commit had a CRITICAL bug flagged by @code-reviewer]: removing tree-side AGENTS.md / CLAUDE.md without giving tree identity a production writer made every new bootstrap fail subsequent verify / upgrade. `.first-tree/tree.json` had **zero** production writers — only test fixtures used it. The follow-up commit:

1. Adds `writeTreeState(targetRoot, { treeId, treeMode, treeRepoName })` to `bootstrap.ts`
2. Adds the regression test described above
3. Polishes the cosmetic backticks in the verify error message

## Migration / backward compat

- **Existing trees with tree-side `AGENTS.md`:** continue to work. `readManagedTreeIdentity()` still reads from the framework block. `syncTreeIdentityFiles()` only writes when the file exists (`if (!existsSync) continue`), so it doesn't resurrect files we deleted in agent-team-foundation/first-tree-context#394.
- **No active removal of legacy files in `upgrade`:** conservative — avoids the risk of clobbering user-added project-specific content that may have been appended below the framework block. Manual cleanup is safe (`rm AGENTS.md CLAUDE.md`).
- **No `--clean-legacy` flag:** [agreed with @code-reviewer review feedback] — one-shot migration shouldn't earn a permanent CLI flag.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — **483 passed** (was 482, +1 regression test)
- [x] `pnpm check` (biome) clean
- [x] Existing tests that simulate legacy trees (write AGENTS.md framework marker as fixture) still pass — these now exercise the legacy read path

## Coordination: PR A needs this to ship first

[first-tree-context#394](https://github.com/agent-team-foundation/first-tree-context/pull/394)'s `validate` CI runs `npx -p first-tree first-tree tree verify` against the **published** first-tree, which still has the `agentInstructions` check that this PR removes. That PR's validate stays red until:

1. This PR merges
2. first-tree publishes a release containing this fix
3. (optional, if validate.yml pins a version) first-tree-context bumps the pinned version

If validate.yml uses `latest` (or `@<unpinned>`), step 3 isn't needed — once the new release is published, re-running validate on PR A will turn it green.

## Follow-up (separate PR, first-tree-context repo)

[code-reviewer flagged] `first-tree-context-management/{NODE.md, source-workspace-installation.md, workspace-layout-simplification.md}` still describe tree-side `AGENTS.md` / `CLAUDE.md` as canonical tree-repo files. Those design statements become factually wrong with this PR + #394 landed. They'll be swept in a follow-up cross-owner PR against first-tree-context (needs bingran-you / 286ljb review).
