### PR TITLE
feat(client): unify agent briefing in AGENTS.md + CLAUDE.md symlink

### DIFF
--- a/packages/client/src/__tests__/agent-bootstrap.test.ts
+++ b/packages/client/src/__tests__/agent-bootstrap.test.ts
@@ -16,6 +16,7 @@ vi.mock("../runtime/bootstrap.js", () => ({
   readCachedContextTreeHead: vi.fn(() => state.cachedTreeHead),
   resolveBundledCliVersion: vi.fn(() => "1.0.0"),
   readCachedBundledCliVersion: vi.fn(() => state.cachedCli),
+  writeAgentBriefing: vi.fn(),
   writeContextTreeHead: vi.fn((_w: string, h: string | null) => {
     state.cachedTreeHead = h;
   }),
@@ -84,6 +85,7 @@ describe("ensureAgentBootstrap — integration retry gate", () => {
       contextTreePath: "/tree",
       contextTreeRepoUrl: null,
       agentName: "agent-1",
+      briefing: "# Agent Identity\n\nstub briefing\n",
     };
 
     // Call 1: integration fails → CLI version NOT pinned.
@@ -108,6 +110,7 @@ describe("ensureAgentBootstrap — integration retry gate", () => {
       contextTreePath: null,
       contextTreeRepoUrl: null,
       agentName: "agent-1",
+      briefing: "# Agent Identity\n\nstub briefing\n",
     };
     ensureAgentBootstrap(params);
     // No Context Tree → installFirstTreeIntegration is never called regardless.

--- a/packages/client/src/__tests__/agent-cwd-redesign.e2e.test.ts
+++ b/packages/client/src/__tests__/agent-cwd-redesign.e2e.test.ts
@@ -222,7 +222,7 @@ describe("Phase E · agent cwd redesign — end-to-end invariants", () => {
     rmSync(dataDir, { recursive: true, force: true });
   });
 
-  it("E4: system prompt contains new redesign sections; no legacy 'Predeclared worktrees' wording", async () => {
+  it("E4: unified briefing contains new redesign sections in AGENTS.md (CLAUDE.md symlinks to it); no legacy 'Predeclared worktrees' wording", async () => {
     capturedSdkOptions.length = 0;
     const dataDir = mkdtempSync(join(tmpdir(), "ftt-e4-"));
     const workspaceRoot = join(dataDir, "workspaces", "agent-1");
@@ -234,26 +234,33 @@ describe("Phase E · agent cwd redesign — end-to-end invariants", () => {
     const handler = createClaudeCodeHandler({ workspaceRoot, agentConfigCache: cache, gitMirrorManager });
     await handler.start(makeMessage("chat-e4", "msg-e4"), buildSessionCtx("chat-e4"));
 
-    expect(capturedSdkOptions.length).toBeGreaterThan(0);
-    const lastOptions = capturedSdkOptions[capturedSdkOptions.length - 1]?.options;
-    const systemPrompt = lastOptions?.systemPrompt as { append?: string } | undefined;
-    expect(systemPrompt).toBeDefined();
-    const append = systemPrompt?.append ?? "";
+    // Per the unified-briefing redesign the SDK no longer carries a
+    // `systemPrompt.append` — agent identity / working-dir convention /
+    // source repos / chat context all flow through AGENTS.md (with
+    // CLAUDE.md symlinked to it). Assert against the on-disk briefing.
+    const agentsMdPath = join(workspaceRoot, "AGENTS.md");
+    const claudeMdPath = join(workspaceRoot, "CLAUDE.md");
+    expect(existsSync(agentsMdPath)).toBe(true);
+    expect(existsSync(claudeMdPath)).toBe(true);
+    const briefing = readFileSync(agentsMdPath, "utf-8");
 
     // New redesign sections — must be present.
-    expect(append).toContain("# Working Directory Convention");
-    expect(append).toContain("## Source Repositories");
-    expect(append).toContain("## Creating Worktrees On Demand");
-    expect(append).toContain("git worktree add");
-    expect(append).toContain("No worktrees are pre-created");
+    expect(briefing).toContain("# Working Directory Convention");
+    expect(briefing).toContain("## Source Repositories");
+    expect(briefing).toContain("## Creating Worktrees On Demand");
+    expect(briefing).toContain("git worktree add");
+    expect(briefing).toContain("No worktrees are pre-created");
 
-    // Top-level path of predeclared repo surfaces in prompt.
-    expect(append).toContain(join(workspaceRoot, "lib"));
+    // Top-level path of predeclared repo surfaces in the briefing.
+    expect(briefing).toContain(join(workspaceRoot, "lib"));
 
     // Legacy wording from the previous design MUST be gone.
-    expect(append).not.toContain("Predeclared worktrees");
+    expect(briefing).not.toContain("Predeclared worktrees");
     // Negation: the repo path should NOT be presented under worktrees/.
-    expect(append).not.toContain(`${workspaceRoot}/worktrees/lib`);
+    expect(briefing).not.toContain(`${workspaceRoot}/worktrees/lib`);
+
+    // CLAUDE.md symlinks to AGENTS.md — reading it yields the same payload.
+    expect(readFileSync(claudeMdPath, "utf-8")).toBe(briefing);
 
     await handler.shutdown();
     rmSync(dataDir, { recursive: true, force: true });
@@ -438,11 +445,22 @@ describe("Phase E · agent cwd redesign — end-to-end invariants", () => {
       // cwd points at the legacy chat dir, NOT at the agent home root.
       expect(lastOptions?.cwd).toBe(legacyCwd);
 
-      // The legacy dir's existing files are untouched — we intentionally
-      // skip ensureAgentBootstrap so the v1.x layout (CLAUDE.md, identity.json)
-      // is not overwritten with new-design files.
-      expect(readFileSync(join(legacyCwd, "CLAUDE.md"), "utf-8")).toBe("legacy session prompt\n");
+      // The legacy `.agent/` layout is left alone — we still skip
+      // `ensureAgentBootstrap` so v1.x identity.json and source-repo
+      // checkouts at `<localPath>/` survive intact.
       expect(readFileSync(join(legacyCwd, ".agent", "identity.json"), "utf-8")).toBe('{"agentId":"legacy"}');
+
+      // CLAUDE.md / AGENTS.md are refreshed though — without the SDK
+      // `systemPrompt.append` channel the unified briefing MUST be
+      // materialised in the legacy cwd, otherwise the resumed session
+      // would only see the v1.x stable CLAUDE.md and lose
+      // `payload.prompt.append` / Current Chat Context. The briefing now
+      // lands as AGENTS.md, and CLAUDE.md becomes a relative symlink to it.
+      const refreshedClaudeMd = readFileSync(join(legacyCwd, "CLAUDE.md"), "utf-8");
+      expect(refreshedClaudeMd).not.toBe("legacy session prompt\n");
+      expect(refreshedClaudeMd).toContain("# Agent Identity");
+      expect(refreshedClaudeMd).toContain("# Working Directory Convention");
+      expect(readFileSync(join(legacyCwd, "AGENTS.md"), "utf-8")).toBe(refreshedClaudeMd);
 
       await handler.shutdown();
     } finally {

--- a/packages/client/src/__tests__/claude-code-inject-startup-race.test.ts
+++ b/packages/client/src/__tests__/claude-code-inject-startup-race.test.ts
@@ -71,6 +71,11 @@ vi.mock("../runtime/agent-bootstrap.js", () => ({
 vi.mock("../runtime/bootstrap.js", () => ({
   FIRST_TREE_WORKSPACE_MARKER: ".first-tree-workspace",
   buildChatSystemPrompt: vi.fn(() => ""),
+  writeAgentBriefing: vi.fn(),
+}));
+
+vi.mock("../runtime/agent-briefing.js", () => ({
+  buildAgentBriefing: vi.fn(() => ""),
 }));
 
 vi.mock("../runtime/chat-context.js", () => ({

--- a/packages/client/src/__tests__/claude-query-options.test.ts
+++ b/packages/client/src/__tests__/claude-query-options.test.ts
@@ -19,34 +19,38 @@ function claudePayload(
 }
 
 describe("buildClaudeQueryOptions", () => {
-  it("returns an empty slice when there is no payload and no append", () => {
-    expect(buildClaudeQueryOptions(undefined, "")).toEqual({});
+  // Per the unified-briefing redesign the SDK query no longer carries a
+  // `systemPrompt.append` — agent identity / prompt.append / chat context all
+  // ship through `<cwd>/CLAUDE.md` (symlinked to AGENTS.md, written by
+  // `writeAgentBriefing`). buildClaudeQueryOptions therefore covers only the
+  // model / mcp / reasoning-effort slice.
+
+  it("returns an empty slice when there is no payload", () => {
+    expect(buildClaudeQueryOptions(undefined)).toEqual({});
   });
 
   it("omits `effort` when reasoningEffort is '' (inherit the local effortLevel)", () => {
-    const opts = buildClaudeQueryOptions(claudePayload({ reasoningEffort: "" }), "");
+    const opts = buildClaudeQueryOptions(claudePayload({ reasoningEffort: "" }));
     expect("effort" in opts).toBe(false);
   });
 
   it("passes `effort` explicitly when a value is configured (overrides local)", () => {
-    expect(buildClaudeQueryOptions(claudePayload({ reasoningEffort: "low" }), "").effort).toBe("low");
-    expect(buildClaudeQueryOptions(claudePayload({ reasoningEffort: "max" }), "").effort).toBe("max");
+    expect(buildClaudeQueryOptions(claudePayload({ reasoningEffort: "low" })).effort).toBe("low");
+    expect(buildClaudeQueryOptions(claudePayload({ reasoningEffort: "max" })).effort).toBe("max");
   });
 
-  it("maps model, systemPrompt append, and mcpServers from the payload", () => {
+  it("maps model and mcpServers from the payload", () => {
     const opts = buildClaudeQueryOptions(
       claudePayload({
         model: "sonnet",
         mcpServers: [{ name: "demo", transport: "stdio", command: "echo" }],
       }),
-      "extra instructions",
     );
     expect(opts.model).toBe("sonnet");
-    expect(opts.systemPrompt).toEqual({ type: "preset", preset: "claude_code", append: "extra instructions" });
     expect(opts.mcpServers).toEqual({ demo: { type: "stdio", command: "echo", args: undefined } });
   });
 
   it("omits model when empty (defers to SDK / local settings)", () => {
-    expect("model" in buildClaudeQueryOptions(claudePayload({ model: "" }), "")).toBe(false);
+    expect("model" in buildClaudeQueryOptions(claudePayload({ model: "" }))).toBe(false);
   });
 });

--- a/packages/client/src/__tests__/codex-bootstrap.test.ts
+++ b/packages/client/src/__tests__/codex-bootstrap.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { AgentRuntimeConfigPayload } from "@first-tree/shared";
@@ -63,31 +63,12 @@ describe("bootstrapWorkspace — codex briefing + workspace marker", () => {
     expect(existsSync(join(workspacePath, FIRST_TREE_WORKSPACE_MARKER))).toBe(true);
   });
 
-  it("writes AGENTS.md when briefing.format='agents-md'", () => {
-    bootstrapWorkspace({
-      workspacePath,
-      identity: {
-        agentId: "agent-1",
-        inboxId: "inbox_agent-1",
-        displayName: "Tester",
-        type: "agent",
-        visibility: "organization",
-        delegateMention: null,
-        metadata: {},
-      },
-      contextTreePath: null,
-      serverUrl: "http://first-tree.test",
-      briefing: { format: "agents-md", content: "# Hello\n\nFollow your team's playbook.\n" },
-    });
-
-    const agentsPath = join(workspacePath, "AGENTS.md");
-    expect(existsSync(agentsPath)).toBe(true);
-    const text = readFileSync(agentsPath, "utf-8");
-    expect(text).toContain("Hello");
-    expect(text).toContain("Follow your team's playbook.");
-  });
-
-  it("does not write AGENTS.md when no briefing is supplied (claude-code path)", () => {
+  it("bootstrapWorkspace no longer writes the briefing (callers route through writeAgentBriefing)", () => {
+    // Briefing materialisation is now the caller's responsibility — the
+    // handler computes the unified briefing via `buildAgentBriefing` and
+    // hands it to `writeAgentBriefing` (or to `ensureAgentBootstrap` which
+    // calls writeAgentBriefing internally). `bootstrapWorkspace` is back to
+    // owning only the stable `.agent/` layout.
     bootstrapWorkspace({
       workspacePath,
       identity: {
@@ -104,9 +85,10 @@ describe("bootstrapWorkspace — codex briefing + workspace marker", () => {
     });
 
     expect(existsSync(join(workspacePath, "AGENTS.md"))).toBe(false);
+    expect(existsSync(join(workspacePath, "CLAUDE.md"))).toBe(false);
   });
 
-  it("inlines First Tree tools and messaging rules into the Codex AGENTS.md briefing", () => {
+  it("inlines First Tree tools and messaging rules into the unified briefing", () => {
     setCliBinding({ binName: "first-tree-staging", packageName: "first-tree-staging" });
     const chatContext: ChatContext = {
       chatId: "chat-1",
@@ -119,12 +101,24 @@ describe("bootstrapWorkspace — codex briefing + workspace marker", () => {
     };
 
     const briefing = buildCodexAgentBriefing(
+      {
+        agentId: "codex-developer",
+        inboxId: "inbox_codex-developer",
+        displayName: "Codex Developer",
+        type: "agent",
+        visibility: "organization",
+        delegateMention: null,
+        metadata: {},
+      },
       codexPayload({ prompt: { append: "Follow the local implementation plan." } }),
       chatContext,
       "/workspaces/codex-developer",
       [],
     );
 
+    expect(briefing).toContain("# Agent Identity");
+    expect(briefing).toContain("Codex Developer");
+    expect(briefing).toContain("## Agent-Specific Behavior");
     expect(briefing).toContain("Follow the local implementation plan.");
     expect(briefing).toContain("## Current Chat Context");
     expect(briefing).toContain("# First Tree Agent Runtime");

--- a/packages/client/src/__tests__/codex-inject-startup-race.test.ts
+++ b/packages/client/src/__tests__/codex-inject-startup-race.test.ts
@@ -77,6 +77,7 @@ vi.mock("../runtime/bootstrap.js", () => ({
   readCachedContextTreeHead: vi.fn(() => null),
   readContextTreeHead: vi.fn(() => null),
   resolveBundledCliVersion: vi.fn(() => "0.0.0-test"),
+  writeAgentBriefing: vi.fn(),
   writeBundledCliVersion: vi.fn(),
   writeContextTreeHead: vi.fn(),
 }));

--- a/packages/client/src/__tests__/codex-retry-abort.test.ts
+++ b/packages/client/src/__tests__/codex-retry-abort.test.ts
@@ -89,6 +89,7 @@ vi.mock("../runtime/bootstrap.js", () => ({
   readCachedContextTreeHead: vi.fn(() => null),
   readContextTreeHead: vi.fn(() => null),
   resolveBundledCliVersion: vi.fn(() => "0.0.0-test"),
+  writeAgentBriefing: vi.fn(),
   writeBundledCliVersion: vi.fn(),
   writeContextTreeHead: vi.fn(),
 }));

--- a/packages/client/src/handlers/claude-code-tui/index.ts
+++ b/packages/client/src/handlers/claude-code-tui/index.ts
@@ -3,8 +3,9 @@ import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { type AgentRuntimeConfigPayload, DEFAULT_CLAUDE_CODE_TUI_RUNTIME_CONFIG_PAYLOAD } from "@first-tree/shared";
 import { ensureAgentBootstrap } from "../../runtime/agent-bootstrap.js";
+import { buildAgentBriefing } from "../../runtime/agent-briefing.js";
 import type { AgentConfigCache } from "../../runtime/agent-config-cache.js";
-import { buildChatSystemPrompt, type PredeclaredSourceRepo } from "../../runtime/bootstrap.js";
+import type { PredeclaredSourceRepo } from "../../runtime/bootstrap.js";
 import { type ChatContext, fetchChatContext } from "../../runtime/chat-context.js";
 import type { GitMirrorManager } from "../../runtime/git-mirror-manager.js";
 import type { AgentHandler, HandlerFactory, SessionContext, SessionMessage } from "../../runtime/handler.js";
@@ -32,7 +33,6 @@ const TURN_TIMEOUT_MS = 10 * 60 * 1000;
 const TURN_POLL_MS = 250;
 const TURN_GRACE_MS = 1500;
 const READY_TIMEOUT_MS = 30_000;
-const SHORT_PROMPT_INLINE_THRESHOLD = 200;
 
 type Worktree = { url: string; path: string; branchName: string };
 
@@ -106,10 +106,11 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
   let configTempDir: string | null = null;
   const queuedMessages: SessionMessage[] = [];
   const ownedWorktrees: Worktree[] = [];
-  // Per-chat state captured at session start — surfaced into the
-  // --append-system-prompt block via buildChatSystemPrompt. Unlike the SDK
-  // path the TUI handler can't update the prompt between turns (claude is a
-  // persistent process), so we snapshot once per startClaude().
+  // Per-chat state captured at session start — feeds the unified briefing
+  // (AGENTS.md / CLAUDE.md symlink) that claude reads at startup via
+  // `--setting-sources user,project`. The TUI handler can't update the
+  // briefing mid-thread (claude is a persistent process holding the file
+  // contents in memory), so we snapshot once per startClaude().
   let chatContextForPrompt: ChatContext | undefined;
   let sourceReposForPrompt: PredeclaredSourceRepo[] = [];
 
@@ -128,24 +129,21 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
   }
 
   /**
-   * Compose the `--append-system-prompt` content: agent-config-managed
-   * append (from payload.prompt.append) + the per-chat block built via
-   * `buildChatSystemPrompt` (working-dir convention, source repos,
-   * worktree-on-demand, chat context). Mirrors the claude-code SDK
-   * handler's `combinedAppend` — both providers feed claude through the
-   * same prompt-append channel; we just deliver it via a CLI flag instead
-   * of a Query option.
+   * Build the unified briefing for the current session — agent identity,
+   * payload.prompt.append, source-repo list, chat context, and the Context
+   * Tree / runtime sections. Materialised by {@link ensureAgentBootstrap} as
+   * `<cwd>/AGENTS.md` (with `<cwd>/CLAUDE.md` symlinked to it) before claude
+   * spawns; the CLI then loads CLAUDE.md via `--setting-sources user,project`.
    */
-  function buildPromptAppend(payload: AgentRuntimeConfigPayload, workspaceCwd: string | null): string {
-    const agentConfigAppend = payload.prompt.append?.trim() ?? "";
-    const perChatAppend = workspaceCwd
-      ? buildChatSystemPrompt({
-          agentHome: workspaceCwd,
-          chatContext: chatContextForPrompt,
-          sourceRepos: sourceReposForPrompt,
-        }).trim()
-      : "";
-    return [agentConfigAppend, perChatAppend].filter((s) => s.length > 0).join("\n\n");
+  function buildBriefing(sessionCtx: SessionContext, payload: AgentRuntimeConfigPayload, workspaceCwd: string): string {
+    return buildAgentBriefing({
+      identity: sessionCtx.agent,
+      payload,
+      chatContext: chatContextForPrompt,
+      workspacePath: workspaceCwd,
+      sourceRepos: sourceReposForPrompt,
+      contextTreePath,
+    });
   }
 
   async function fetchChatContextOrLog(sessionCtx: SessionContext): Promise<ChatContext | undefined> {
@@ -197,17 +195,6 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
     const tempDir = ensureConfigTempDir(workspaceCwd, sessionId);
     configTempDir = tempDir;
 
-    const promptAppend = buildPromptAppend(payload, workspaceCwd).trim();
-    if (promptAppend.length > 0) {
-      if (promptAppend.length <= SHORT_PROMPT_INLINE_THRESHOLD && !promptAppend.includes("\n")) {
-        args.push("--append-system-prompt", shellQuote(promptAppend));
-      } else {
-        const path = join(tempDir, "system-prompt-append.txt");
-        writeFileSync(path, promptAppend, "utf-8");
-        args.push("--append-system-prompt-file", shellQuote(path));
-      }
-    }
-
     if (payload.mcpServers.length > 0) {
       const mcpConfigPath = join(tempDir, "mcp-config.json");
       writeFileSync(mcpConfigPath, JSON.stringify({ mcpServers: mapMcpServers(payload) }, null, 2), "utf-8");
@@ -215,6 +202,9 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
       args.push("--strict-mcp-config");
     }
 
+    // The unified briefing is delivered via `<cwd>/CLAUDE.md` (symlink to
+    // AGENTS.md) which `--setting-sources user,project` instructs claude to
+    // load at startup. No `--append-system-prompt` is needed anymore.
     args.push("--setting-sources", "user,project");
 
     return args.join(" ");
@@ -539,18 +529,26 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
 
         const payload = (await loadPayload(sessionCtx)) ?? defaultPayload();
 
-        // Per-chat material flows through the system-prompt-append channel built
-        // in `buildPromptAppend`. The stable agent-home bootstrap (CLAUDE.md
-        // briefing, core skills, Context-Tree/CLI drift pins) is the SAME shared
-        // contract the SDK handler uses — see runtime/agent-bootstrap.ts.
+        // Per-chat material flows through the unified briefing
+        // (`<cwd>/AGENTS.md`, with `<cwd>/CLAUDE.md` symlinked to it). Resolve
+        // chat-context and source repos BEFORE bootstrap so the briefing the
+        // shared `ensureAgentBootstrap` materialises is fully populated; claude
+        // then reads CLAUDE.md once on spawn via `--setting-sources project`.
         chatContextForPrompt = await fetchChatContextOrLog(sessionCtx);
-        ensureAgentBootstrap({ workspace: cwd, sessionCtx, contextTreePath, contextTreeRepoUrl, agentName });
         sourceReposForPrompt = await prepareSourceRepos({
           workspace: cwd,
           payload,
           sessionCtx,
           gitMirrorManager,
           agentName,
+        });
+        ensureAgentBootstrap({
+          workspace: cwd,
+          sessionCtx,
+          contextTreePath,
+          contextTreeRepoUrl,
+          agentName,
+          briefing: buildBriefing(sessionCtx, payload, cwd),
         });
         markWorkspaceInitComplete(cwd);
 
@@ -581,16 +579,23 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
         const payload = (await loadPayload(sessionCtx)) ?? defaultPayload();
 
         chatContextForPrompt = await fetchChatContextOrLog(sessionCtx);
-        // Same shared bootstrap as start(): ensureAgentBootstrap handles the
-        // sentinel + Context-Tree/CLI drift internally, so a stale or failed
-        // integration is re-run on resume instead of being skipped.
-        ensureAgentBootstrap({ workspace: cwd, sessionCtx, contextTreePath, contextTreeRepoUrl, agentName });
         sourceReposForPrompt = await prepareSourceRepos({
           workspace: cwd,
           payload,
           sessionCtx,
           gitMirrorManager,
           agentName,
+        });
+        // Same shared bootstrap as start(): ensureAgentBootstrap handles the
+        // sentinel + Context-Tree/CLI drift internally, so a stale or failed
+        // integration is re-run on resume instead of being skipped.
+        ensureAgentBootstrap({
+          workspace: cwd,
+          sessionCtx,
+          contextTreePath,
+          contextTreeRepoUrl,
+          agentName,
+          briefing: buildBriefing(sessionCtx, payload, cwd),
         });
         markWorkspaceInitComplete(cwd);
 

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -18,8 +18,9 @@ import {
   SUPPORTED_IMAGE_MIMES as SHARED_SUPPORTED_IMAGE_MIMES,
 } from "@first-tree/shared";
 import { ensureAgentBootstrap as ensureAgentBootstrapShared } from "../runtime/agent-bootstrap.js";
+import { buildAgentBriefing } from "../runtime/agent-briefing.js";
 import type { AgentConfigCache } from "../runtime/agent-config-cache.js";
-import { buildChatSystemPrompt, type PredeclaredSourceRepo } from "../runtime/bootstrap.js";
+import { type PredeclaredSourceRepo, writeAgentBriefing } from "../runtime/bootstrap.js";
 import { type ChatContext, fetchChatContext } from "../runtime/chat-context.js";
 import { toolFileRefsFromShellCommand } from "../runtime/context-tree-file-refs.js";
 import { classify } from "../runtime/error-taxonomy.js";
@@ -27,7 +28,7 @@ import type { GitMirrorManager } from "../runtime/git-mirror-manager.js";
 import type { AgentHandler, HandlerFactory, SessionContext, SessionMessage } from "../runtime/handler.js";
 import { findImagePath } from "../runtime/image-store.js";
 import { InputController } from "../runtime/input-controller.js";
-import { buildResourceSkillsBriefing, materializeResourceSkills } from "../runtime/resource-skills.js";
+import { materializeResourceSkills } from "../runtime/resource-skills.js";
 import { prepareSourceRepos as prepareSourceReposShared } from "../runtime/source-repos.js";
 import { acquireAgentHome, markWorkspaceInitComplete } from "../runtime/workspace.js";
 import { formatAuthHint, isClaudeAuthError } from "./auth-error-hint.js";
@@ -511,31 +512,30 @@ export function mapMcpServers(payload: AgentRuntimeConfigPayload): Record<string
 /** Payload-derived slice of the Claude Code SDK query options. */
 export type ClaudeQueryConfigOptions = {
   model?: string;
-  systemPrompt?: { type: "preset"; preset: "claude_code"; append: string };
   mcpServers?: Record<string, McpServerConfig>;
   effort?: EffortLevel;
 };
 
 /**
- * Build the config-derived slice of the SDK query options (model, systemPrompt
- * append, MCP servers, reasoning effort). Kept pure and exported so these
- * mappings are unit-testable; the session-bound options (env, canUseTool,
- * abortController, sessionId/resume) stay inline in `buildQuery`.
+ * Build the config-derived slice of the SDK query options (model, MCP
+ * servers, reasoning effort). Kept pure and exported so these mappings are
+ * unit-testable; the session-bound options (env, canUseTool, abortController,
+ * sessionId/resume) stay inline in `buildQuery`.
+ *
+ * Per-agent prompt instructions, working-directory convention, source-repo
+ * list, and Current Chat Context land in `<cwd>/AGENTS.md` (which `CLAUDE.md`
+ * symlinks to). The Claude Code SDK loads CLAUDE.md via `settingSources:
+ * ["project"]`, so the briefing file is the single channel — there is no
+ * SDK-side `systemPrompt.append` anymore.
  *
  * Reasoning effort: the claude variant's `""` is an inherit sentinel — when
  * set we omit the `effort` option so the SDK falls back to the operator's local
  * `~/.claude/settings.json` effortLevel (preserving pre-feature behavior). A
  * non-empty value is passed explicitly and overrides that local setting.
  */
-export function buildClaudeQueryOptions(
-  payload: AgentRuntimeConfigPayload | undefined,
-  combinedAppend: string,
-): ClaudeQueryConfigOptions {
+export function buildClaudeQueryOptions(payload: AgentRuntimeConfigPayload | undefined): ClaudeQueryConfigOptions {
   const options: ClaudeQueryConfigOptions = {};
   if (payload?.model) options.model = payload.model;
-  if (combinedAppend.length > 0) {
-    options.systemPrompt = { type: "preset", preset: "claude_code", append: combinedAppend };
-  }
   if (payload?.mcpServers.length) options.mcpServers = mapMcpServers(payload);
   if (payload?.kind === "claude-code" && payload.reasoningEffort) {
     options.effort = payload.reasoningEffort;
@@ -808,12 +808,12 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
   }
 
   /** Create query and input controller, then start consumer loop. */
-  function spawnQuery(sessionId: string, sessionCtx: SessionContext, resume?: string, chatContext?: ChatContext): void {
-    // Stash the chat-context so respawn (config hot-switch retry) keeps it
-    // available without the caller having to thread it through again.
-    if (chatContext !== undefined) {
-      chatContextForPrompt = chatContext;
-    }
+  function spawnQuery(sessionId: string, sessionCtx: SessionContext, resume?: string): void {
+    // The latest chat-context and source-repo snapshot live in module-scoped
+    // caches (`chatContextForPrompt`, `sourceReposForPrompt`) which the
+    // handler refreshes in start/resume BEFORE this call. `maybeSwitchConfig`
+    // additionally rewrites the briefing before invoking `buildQuery` so a
+    // mid-session config swap surfaces in the freshly read CLAUDE.md.
     buildQuery(sessionId, sessionCtx, resume);
     recordAppliedPayload(sessionCtx);
     consumerDone = consumeOutput(sessionCtx);
@@ -937,24 +937,6 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
 
     const payload = agentConfigCache?.get(sessionCtx.agent.agentId)?.payload;
 
-    // Compose `systemPrompt.append`: agent-config-managed append (server) +
-    // per-chat block (built from the latest chatContext + predeclared
-    // worktrees). The SDK only accepts a single string here, so we
-    // concatenate with a blank-line separator. Either piece may be empty;
-    // the systemPrompt option is omitted entirely if the combined string
-    // is empty so we don't change SDK behavior for callers that never had
-    // a server-managed append.
-    const agentConfigAppend = payload?.prompt.append?.trim() ?? "";
-    const perChatAppend = cwd
-      ? buildChatSystemPrompt({
-          agentHome: cwd,
-          chatContext: chatContextForPrompt,
-          sourceRepos: sourceReposForPrompt,
-        }).trim()
-      : "";
-    const skillsAppend = cwd ? buildResourceSkillsBriefing(cwd, payload).trim() : "";
-    const combinedAppend = [agentConfigAppend, skillsAppend, perChatAppend].filter((s) => s.length > 0).join("\n\n");
-
     currentQuery = claudeQuery({
       prompt: inputController.iterable,
       options: {
@@ -967,13 +949,18 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
         allowDangerouslySkipPermissions: true,
         // SDK 0.2.84 defaults to isolation mode — no filesystem settings are
         // read. We opt into both `user` and `project`:
-        //   - `project` loads the workspace CLAUDE.md generated by bootstrap
-        //     (agent identity + First Tree SDK usage + tools reference).
+        //   - `project` loads the workspace CLAUDE.md (symlinked to AGENTS.md
+        //     written by `writeAgentBriefing`). That single briefing carries
+        //     identity, the per-agent prompt.append, working-dir convention,
+        //     source-repo list, Current Chat Context, operating instructions,
+        //     domain map, and the First Tree Agent Runtime block — the entire
+        //     channel that used to split between SDK `systemPrompt.append` and
+        //     a stable CLAUDE.md is now this one file.
         //   - `user` inherits the operator's local `~/.claude/settings.json`
         //     so their Claude Code customizations (thinking mode, effortLevel,
         //     outputStyle, statusLine, plugins, skills, hooks, MCP servers)
         //     carry over to agent sessions on their machine. Server-managed
-        //     fields (model, systemPrompt, env, permissionMode, and the First Tree
+        //     fields (model, env, permissionMode, and the First Tree
         //     `mcpServers` list) still win because they are passed as
         //     explicit SDK options below, which layer on top of settings.
         settingSources: ["user", "project"],
@@ -983,9 +970,9 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
         // surfaces in a session.
         disallowedTools: ["AskUserQuestion"],
         ...(claudeCodeExecutable ? { pathToClaudeCodeExecutable: claudeCodeExecutable } : {}),
-        // model / systemPrompt / mcpServers / effort — the config-derived slice.
-        // `effort: ""` (inherit) is omitted so the SDK uses the local effortLevel.
-        ...buildClaudeQueryOptions(payload, combinedAppend),
+        // model / mcpServers / effort — the config-derived slice. `effort: ""`
+        // (inherit) is omitted so the SDK uses the local effortLevel.
+        ...buildClaudeQueryOptions(payload),
       },
     });
   }
@@ -1026,6 +1013,15 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
     // still iterating the OLD query and will exit once `oldQuery.close()`
     // drains it, so the new query would otherwise have no reader.
     sessionCtx.log(`[configHotSwitch] path=restart fromVersion=${appliedConfigVersion} toVersion=${cached.version}`);
+    // Rewrite AGENTS.md (CLAUDE.md symlink) with the new payload so the
+    // restarted SDK Query — which reads CLAUDE.md via `settingSources:
+    // ["project"]` on construction — picks up the new prompt.append. The
+    // briefing is now the single channel; without this rewrite the swap
+    // would update model/mcp/effort but silently leave the per-agent prompt
+    // at the old version until the next session restart.
+    if (cwd) {
+      writeAgentBriefing(cwd, currentBriefing(sessionCtx, cwd, newPayload));
+    }
     const sid = claudeSessionId;
     const oldQuery = currentQuery;
     buildQuery(sid, sessionCtx, sid);
@@ -1462,6 +1458,28 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
   }
 
   /**
+   * Build the unified briefing for the current session state — agent identity,
+   * the latest `prompt.append`, source-repo list, the latest chat-context
+   * snapshot, and the Context Tree / runtime sections. The handler rebuilds
+   * this on every start/resume and on config hot-switch so AGENTS.md (and the
+   * CLAUDE.md symlink the Claude Code SDK reads) is always current.
+   */
+  function currentBriefing(
+    sessionCtx: SessionContext,
+    workspace: string,
+    payload: AgentRuntimeConfigPayload | null | undefined,
+  ): string {
+    return buildAgentBriefing({
+      identity: sessionCtx.agent,
+      payload: payload ?? null,
+      chatContext: chatContextForPrompt,
+      workspacePath: workspace,
+      sourceRepos: sourceReposForPrompt,
+      contextTreePath,
+    });
+  }
+
+  /**
    * Run the expensive first-time bootstrap (full stable layout + `first-tree
    * tree skill install` shell-out). Gated by the stage-2 sentinel + Context-Tree
    * HEAD drift detection (proposals/agent-session-cwd-redesign §⑤.3):
@@ -1469,16 +1487,20 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
    *   - Sentinel absent → full bootstrap.
    *   - Sentinel present + Tree HEAD unchanged → cheap identity refresh only.
    *   - Sentinel present + Tree HEAD drifted → full bootstrap re-runs so the
-   *     stable CLAUDE.md and first-tree skill pick up the new tree state.
+   *     stable .agent/ layout and first-tree skill pick up the new tree state.
+   *
+   * The unified briefing is rewritten on every call regardless of the drift
+   * decision — chat context and the agent payload may have changed between
+   * sessions for the same agent home.
    *
    * `workspaceId` for the integrate shell-out is the agent name — the home
    * directory is per-agent, so the skill identity stays stable across chats.
    */
-  function ensureAgentBootstrap(workspace: string, sessionCtx: SessionContext): void {
+  function ensureAgentBootstrap(workspace: string, sessionCtx: SessionContext, briefing: string): void {
     // Delegates to the shared helper (runtime/agent-bootstrap.ts) so the SDK
     // and TUI handlers share one briefing / core-skill / drift-pin contract
     // rather than each maintaining a partial copy.
-    ensureAgentBootstrapShared({ workspace, sessionCtx, contextTreePath, contextTreeRepoUrl, agentName });
+    ensureAgentBootstrapShared({ workspace, sessionCtx, contextTreePath, contextTreeRepoUrl, agentName, briefing });
   }
 
   const handler: AgentHandler = {
@@ -1490,15 +1512,23 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       // boundary marker on first call; afterwards it is a no-op.
       cwd = acquireAgentHome(workspaceRoot);
 
-      // Fetch chat-context for per-turn prompt injection (Step 4 wires it).
-      const chatContext = await fetchChatContextOrLog(sessionCtx);
-      ensureAgentBootstrap(cwd, sessionCtx);
-
-      // Materialise gitRepos under `<cwd>/worktrees/<name>` before the
-      // child process starts. Failures here abort session creation (D10/D13).
+      // Resolve the per-chat inputs that drive the unified briefing BEFORE
+      // bootstrap: the briefing is the single channel that materialises agent
+      // identity, payload.prompt.append, source-repo list, and Current Chat
+      // Context for the Claude Code SDK (read via `settingSources:
+      // ["project"]` from CLAUDE.md → AGENTS.md). Bootstrap must therefore
+      // see fully-resolved inputs.
       const payload = agentConfigCache?.get(sessionCtx.agent.agentId)?.payload;
+      const chatContext = await fetchChatContextOrLog(sessionCtx);
+      chatContextForPrompt = chatContext;
+      // Materialise gitRepos under `<cwd>/<localPath>/` before computing the
+      // briefing so the source-repo list reflects what the agent will see on
+      // disk. Failures here abort session creation (D10/D13).
       await prepareSourceRepos(cwd, payload, sessionCtx);
       await materializeResourceSkills(cwd, payload, sessionCtx);
+
+      const briefing = currentBriefing(sessionCtx, cwd, payload);
+      ensureAgentBootstrap(cwd, sessionCtx, briefing);
 
       // Stage-2 sentinel: written once per agent home. Future starts short-
       // circuit the expensive integrate path on its presence.
@@ -1515,7 +1545,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       // `claude-code-stream-error-retry-replay.test.ts` regression.
       const sdkMsg = await toSDKUserMessage(message, sessionCtx, claudeSessionId);
       stashedSdkMessage = sdkMsg;
-      spawnQuery(claudeSessionId, sessionCtx, undefined, chatContext);
+      spawnQuery(claudeSessionId, sessionCtx);
       inputController?.push(sdkMsg);
       scheduleInjectedMessagesDrain(sessionCtx, claudeSessionId);
 
@@ -1546,13 +1576,27 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
           `Resume: detected pre-redesign SDK transcript at legacy cwd ${legacyCwd}; ` +
             "running this session under the legacy per-chat layout to preserve agent memory",
         );
+        const payload = agentConfigCache?.get(sessionCtx.agent.agentId)?.payload;
         const chatContext = await fetchChatContextOrLog(sessionCtx);
+        chatContextForPrompt = chatContext;
         // Intentionally NOT calling ensureAgentBootstrap / prepareSourceRepos /
         // markWorkspaceInitComplete here — those write the new agent-home
-        // layout, which would pollute the legacy chat dir. The dir already
-        // carries the v1.x bootstrap output (CLAUDE.md, AGENTS.md, .agent/,
-        // <localPath>/ source repos), and the agent reads it via the SDK's
-        // `settingSources: ["project"]` option.
+        // layout, which would pollute the legacy chat dir's v1.x `.agent/`
+        // and `<localPath>/` source repos.
+        //
+        // We DO refresh the briefing (writeAgentBriefing only touches the
+        // AGENTS.md file + CLAUDE.md symlink, not `.agent/` or source repos)
+        // because under the unified-briefing redesign the SDK no longer has
+        // a `systemPrompt.append` path — without this rewrite a legacy resume
+        // would only see the stale v1.x stable CLAUDE.md, dropping the
+        // current `prompt.append`, resource-skill briefing, and Current Chat
+        // Context the previous per-turn SDK append used to deliver.
+        // `sourceReposForPrompt` stays `[]` here on purpose: we don't run
+        // `prepareSourceRepos` against the legacy cwd, so the briefing's
+        // Source Repositories section is omitted for legacy resumes. The
+        // agent still finds the v1.x checkouts at their original `<localPath>/`
+        // — just without a top-level enumeration in the prompt.
+        writeAgentBriefing(legacyCwd, currentBriefing(sessionCtx, legacyCwd, payload));
         // Same convert-stash-then-spawn ordering as `start()` so a stream
         // error fired on the first turn of the resumed session can replay
         // through `respawnQuery`.
@@ -1561,7 +1605,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
           sdkMsg = await toSDKUserMessage(message, sessionCtx, sessionId);
           stashedSdkMessage = sdkMsg;
         }
-        spawnQuery(sessionId, sessionCtx, sessionId, chatContext);
+        spawnQuery(sessionId, sessionCtx, sessionId);
         if (sdkMsg) {
           inputController?.push(sdkMsg);
         }
@@ -1577,12 +1621,14 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       // sentinel gates the expensive integrate. The cheap stable-identity
       // hash check runs every time so agent rename / inboxId changes
       // propagate even after the sentinel is set (R5 in the proposal).
-      const chatContext = await fetchChatContextOrLog(sessionCtx);
-      ensureAgentBootstrap(cwd, sessionCtx);
-
       const payload = agentConfigCache?.get(sessionCtx.agent.agentId)?.payload;
+      const chatContext = await fetchChatContextOrLog(sessionCtx);
+      chatContextForPrompt = chatContext;
       await prepareSourceRepos(cwd, payload, sessionCtx);
       await materializeResourceSkills(cwd, payload, sessionCtx);
+
+      const briefing = currentBriefing(sessionCtx, cwd, payload);
+      ensureAgentBootstrap(cwd, sessionCtx, briefing);
 
       markWorkspaceInitComplete(cwd);
 
@@ -1602,7 +1648,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
           freshSdkMsg = await toSDKUserMessage(message, sessionCtx, freshSessionId);
           stashedSdkMessage = freshSdkMsg;
         }
-        spawnQuery(freshSessionId, sessionCtx, undefined, chatContext);
+        spawnQuery(freshSessionId, sessionCtx);
         if (freshSdkMsg) {
           inputController?.push(freshSdkMsg);
         }
@@ -1617,7 +1663,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
         resumeSdkMsg = await toSDKUserMessage(message, sessionCtx, sessionId);
         stashedSdkMessage = resumeSdkMsg;
       }
-      spawnQuery(sessionId, sessionCtx, sessionId, chatContext);
+      spawnQuery(sessionId, sessionCtx, sessionId);
       if (resumeSdkMsg) {
         inputController?.push(resumeSdkMsg);
       }

--- a/packages/client/src/handlers/codex.ts
+++ b/packages/client/src/handlers/codex.ts
@@ -1,5 +1,5 @@
-import { existsSync, readFileSync } from "node:fs";
-import { isAbsolute, join, relative, resolve } from "node:path";
+import { existsSync } from "node:fs";
+import { isAbsolute, relative, resolve } from "node:path";
 import {
   type AgentRuntimeConfigPayload,
   deriveRepoLocalPath,
@@ -7,31 +7,23 @@ import {
   type ToolFileRef,
 } from "@first-tree/shared";
 import { Codex, type Input, type Thread, type ThreadItem, type ThreadOptions, type Usage } from "@openai/codex-sdk";
+import { ensureAgentBootstrap as ensureAgentBootstrapShared } from "../runtime/agent-bootstrap.js";
+import { buildAgentBriefing } from "../runtime/agent-briefing.js";
 import type { AgentConfigCache } from "../runtime/agent-config-cache.js";
-import {
-  bootstrapWorkspace,
-  buildChatSystemPrompt,
-  deepEqualIdentity,
-  FIRST_TREE_WORKSPACE_MARKER,
-  generateToolsDoc,
-  installCoreSkills,
-  installFirstTreeIntegration,
-  isHubWorktreeMarker,
-  type PredeclaredSourceRepo,
-  readCachedBundledCliVersion,
-  readCachedContextTreeHead,
-  readContextTreeHead,
-  resolveBundledCliVersion,
-  writeBundledCliVersion,
-  writeContextTreeHead,
-} from "../runtime/bootstrap.js";
+import { FIRST_TREE_WORKSPACE_MARKER, isHubWorktreeMarker, type PredeclaredSourceRepo } from "../runtime/bootstrap.js";
 import { type ChatContext, fetchChatContext } from "../runtime/chat-context.js";
 import { toolFileRefsFromShellCommand } from "../runtime/context-tree-file-refs.js";
 import { resolveGitRepoTargetPath } from "../runtime/git-local-path.js";
 import { deriveSessionBranchName, type GitMirrorManager } from "../runtime/git-mirror-manager.js";
-import type { AgentHandler, HandlerFactory, SessionContext, SessionMessage } from "../runtime/handler.js";
-import { buildResourceSkillsBriefing, materializeResourceSkills } from "../runtime/resource-skills.js";
-import { acquireAgentHome, INIT_COMPLETE_SENTINEL_REL, markWorkspaceInitComplete } from "../runtime/workspace.js";
+import type {
+  AgentHandler,
+  AgentIdentity,
+  HandlerFactory,
+  SessionContext,
+  SessionMessage,
+} from "../runtime/handler.js";
+import { materializeResourceSkills } from "../runtime/resource-skills.js";
+import { acquireAgentHome, markWorkspaceInitComplete } from "../runtime/workspace.js";
 import { withWorktreePathLock } from "../runtime/worktree-mutex.js";
 import { formatAuthHint, isCodexAuthError } from "./auth-error-hint.js";
 
@@ -324,45 +316,27 @@ export function buildCodexThreadOptions(payload: AgentRuntimeConfigPayload, work
   return opts;
 }
 
+/**
+ * Thin wrapper over the unified {@link buildAgentBriefing} kept for the
+ * codex-bootstrap test suite. Production paths call `buildAgentBriefing`
+ * directly via the inner `buildBriefing` helper inside the handler closure.
+ */
 export function buildCodexAgentBriefing(
+  identity: AgentIdentity,
   payload: AgentRuntimeConfigPayload,
   chatContext: ChatContext | undefined,
   workspaceCwd: string,
-  sourceRepos: PredeclaredSourceRepo[],
+  sourceRepos: ReadonlyArray<PredeclaredSourceRepo>,
+  contextTreePath: string | null = null,
 ): string {
-  const lines: string[] = [];
-  lines.push("# Agent Briefing");
-  lines.push("");
-  if (payload.prompt.append.trim()) {
-    lines.push(payload.prompt.append.trim());
-    lines.push("");
-  }
-  const skillsBriefing = buildResourceSkillsBriefing(workspaceCwd, payload).trim();
-  if (skillsBriefing.length > 0) {
-    lines.push(skillsBriefing);
-    lines.push("");
-  }
-  // Per agent-session-cwd-redesign: the Claude Code handler injects the
-  // working-directory convention + worktree list + chat context via the
-  // SDK's `systemPrompt.append`. Codex has no equivalent option, so we
-  // serialise the same block into AGENTS.md instead. The codex CLI reads
-  // AGENTS.md once at thread startup, so concurrent sessions for the same
-  // agent only race during the short window between bootstrap and CLI
-  // launch — accepted under proposal §⓪.3.
-  const perChatBlock = buildChatSystemPrompt({
-    agentHome: workspaceCwd,
+  return buildAgentBriefing({
+    identity,
+    payload,
     chatContext,
+    workspacePath: workspaceCwd,
     sourceRepos,
-  }).trim();
-  if (perChatBlock.length > 0) {
-    lines.push(perChatBlock);
-    lines.push("");
-  }
-  lines.push(generateToolsDoc().trim());
-  lines.push("");
-  lines.push("Refer to `.agent/identity.json` for your agent identity, and `.agent/context/`");
-  lines.push("for organisational context (when configured).");
-  return lines.join("\n").concat("\n");
+    contextTreePath,
+  });
 }
 
 function contextTreeTargetPathOf(
@@ -537,12 +511,20 @@ export const createCodexHandler: HandlerFactory = (config) => {
     return cfg;
   }
 
-  function buildAgentBriefing(
+  function buildBriefing(
+    sessionCtx: SessionContext,
     payload: AgentRuntimeConfigPayload,
     chatContext: ChatContext | undefined,
     workspaceCwd: string,
   ): string {
-    return buildCodexAgentBriefing(payload, chatContext, workspaceCwd, sourceReposForPrompt);
+    return buildAgentBriefing({
+      identity: sessionCtx.agent,
+      payload,
+      chatContext,
+      workspacePath: workspaceCwd,
+      sourceRepos: sourceReposForPrompt,
+      contextTreePath,
+    });
   }
 
   /**
@@ -1106,148 +1088,27 @@ export const createCodexHandler: HandlerFactory = (config) => {
   }
 
   /**
-   * Install the first-tree skill + binding block; no-op when context tree is
-   * unconfigured. Returns the integration result so the caller can decide
-   * whether to pin the CLI-version drift marker (don't pin on failure or the
-   * next start skips the retry).
-   */
-  function ensureFirstTreeBinding(workspace: string, sessionCtx: SessionContext): boolean {
-    if (!contextTreePath) return true;
-    return installFirstTreeIntegration({
-      workspacePath: workspace,
-      contextTreePath,
-      // Workspace id identifies the agent home (per agent-session-cwd-
-      // redesign), not the chat — so the first-tree skill installs once and
-      // remains stable across every chat session of this agent.
-      workspaceId: agentName ?? sessionCtx.agent.agentId,
-      treeRepoUrl: contextTreeRepoUrl ?? undefined,
-      log: (msg) => sessionCtx.log(msg),
-    });
-  }
-
-  /**
-   * Run the expensive first-time bootstrap (full stable layout + `first-tree
-   * tree skill install` shell-out + briefing write) or — when the sentinel and
-   * Context-Tree HEAD match the cached state — only refresh the per-chat
-   * briefing (AGENTS.md). Mirrors the claude-code handler's
-   * `ensureAgentBootstrap` so both handlers converge on identical per-agent-
-   * home bootstrap semantics.
+   * Bootstrap wrapper around the shared {@link ensureAgentBootstrapShared}
+   * helper that adds codex's AGENTS.md concurrent-write detector.
    *
-   * 🔥 RACE WINDOW (proposal §⓪.3 accepted): unlike claude-code's
-   * `systemPrompt.append`, codex has no per-turn prompt injection. We
-   * therefore write the per-chat block (Current Chat Context, source repo
-   * list) **into AGENTS.md on every start/resume**. Two chats starting
-   * concurrently for the same agent can clobber each other's briefing
-   * between the write and the codex CLI's first read — accepted in the
-   * proposal because the window is short (millis between bootstrap and CLI
-   * spawn). If you are debugging "wrong chat context surfaces in codex",
-   * look here first.
-   *
-   * Note: AGENTS.md is **always rewritten** because it carries per-chat
-   * content (Current Chat Context, predeclared worktree list) and codex has
-   * no equivalent of Claude SDK's `appendSystemPrompt`.
+   * 🔥 RACE WINDOW (proposal §⓪.3 accepted): the codex CLI reads AGENTS.md
+   * once at thread startup, so two writers landing inside the race window
+   * mean the second writer likely clobbered the first briefing before codex
+   * read it. Claude Code has the same property now that the briefing is the
+   * single channel, but Codex still hits this most visibly because there is
+   * no per-turn prompt API to update mid-thread — debug "wrong chat context
+   * surfaces in codex" symptoms by looking here first.
    */
   function ensureCodexBootstrap(workspace: string, sessionCtx: SessionContext, briefing: string): void {
-    // Race-window detector: every `ensureCodexBootstrap` call rewrites
-    // AGENTS.md (per-chat block always changes). The detector logs when
-    // two writes for the same workspace land inside the race window — see
-    // proposal §⓪.3. Fix lives upstream (per-turn prompt API); we surface
-    // the operational signal so "wrong chat context surfaces in codex"
-    // bugs can be triaged.
     detectAgentsMdConcurrentWrite(workspace, Date.now(), (m) => sessionCtx.log(m));
-
-    const sentinelPresent = existsSync(join(workspace, INIT_COMPLETE_SENTINEL_REL));
-    const currentTreeHead = readContextTreeHead(contextTreePath);
-    const cachedTreeHead = readCachedContextTreeHead(workspace);
-    if (cachedTreeHead !== null && currentTreeHead === null) {
-      // PR #506 review Q1: drift detection silently fails when the head
-      // probe errors out — log the asymmetry so it isn't invisible.
-      sessionCtx.log(
-        `Context Tree HEAD probe returned null while cached value is ` +
-          `${cachedTreeHead.slice(0, 7)}; drift detection bypassed for this start`,
-      );
-    }
-    const treeDrifted = currentTreeHead !== null && cachedTreeHead !== null && currentTreeHead !== cachedTreeHead;
-
-    // CLI-version drift forces a fresh `installFirstTreeIntegration` so the
-    // shipped `.agents/skills/*` payload tracks `first-tree upgrade` even
-    // when the Context Tree HEAD is unchanged. Same "fail open" rule as
-    // tree drift: a null on either side means "unknown" and we do not
-    // force re-bootstrap.
-    const currentCliVersion = resolveBundledCliVersion();
-    const cachedCliVersion = readCachedBundledCliVersion(workspace);
-    const cliDrifted =
-      currentCliVersion !== null && cachedCliVersion !== null && currentCliVersion !== cachedCliVersion;
-
-    if (sentinelPresent && !treeDrifted && !cliDrifted) {
-      // Fast path: identity hash check, briefing rewrite, no integrate.
-      const identityPath = join(workspace, ".agent", "identity.json");
-      const desired = {
-        agentId: sessionCtx.agent.agentId,
-        displayName: sessionCtx.agent.displayName,
-        type: sessionCtx.agent.type,
-        delegateMention: sessionCtx.agent.delegateMention,
-        metadata: sessionCtx.agent.metadata,
-        serverUrl: sessionCtx.sdk.serverUrl,
-        contextTreePath,
-      };
-      let identityMatches = false;
-      if (existsSync(identityPath)) {
-        try {
-          identityMatches = deepEqualIdentity(JSON.parse(readFileSync(identityPath, "utf-8")), desired);
-        } catch {
-          identityMatches = false;
-        }
-      }
-      // Bootstrap writes identity, context dir, tools.md, briefing (AGENTS.md),
-      // and the boundary marker. We always call it — even when identity
-      // matches — because briefing changes every session (per-chat block).
-      bootstrapWorkspace({
-        workspacePath: workspace,
-        identity: sessionCtx.agent,
-        contextTreePath,
-        serverUrl: sessionCtx.sdk.serverUrl,
-        briefing: { format: "agents-md", content: briefing },
-      });
-      if (!identityMatches) {
-        sessionCtx.log("Agent identity drift detected; .agent/ refreshed");
-      }
-      return;
-    }
-
-    if (sentinelPresent && treeDrifted) {
-      sessionCtx.log(
-        `Context Tree HEAD changed (${cachedTreeHead?.slice(0, 7)} → ${currentTreeHead?.slice(0, 7)}); re-running bootstrap`,
-      );
-    }
-    if (sentinelPresent && cliDrifted) {
-      sessionCtx.log(
-        `Bundled CLI version changed (${cachedCliVersion} → ${currentCliVersion}); re-running bootstrap to refresh skills`,
-      );
-    }
-
-    bootstrapWorkspace({
-      workspacePath: workspace,
-      identity: sessionCtx.agent,
+    ensureAgentBootstrapShared({
+      workspace,
+      sessionCtx,
       contextTreePath,
-      serverUrl: sessionCtx.sdk.serverUrl,
-      briefing: { format: "agents-md", content: briefing },
+      contextTreeRepoUrl,
+      agentName,
+      briefing,
     });
-    // Core skills ship with every agent, with or without a Context Tree.
-    // The core skill set is currently empty, so this is effectively a no-op;
-    // the wiring stays so re-introducing one needs no handler change.
-    installCoreSkills({
-      workspacePath: workspace,
-      log: (msg) => sessionCtx.log(msg),
-    });
-    const integrationOk = ensureFirstTreeBinding(workspace, sessionCtx);
-    writeContextTreeHead(workspace, currentTreeHead);
-    // Only pin the CLI version when integrate actually succeeded — pinning
-    // on a failed run would silently mask the gap and the next start would
-    // skip the retry that this drift trigger exists to perform.
-    if (integrationOk) {
-      writeBundledCliVersion(workspace, currentCliVersion);
-    }
   }
 
   return {
@@ -1281,7 +1142,7 @@ export const createCodexHandler: HandlerFactory = (config) => {
       await prepareSourceRepos(payload, cwd, sessionCtx);
       await materializeResourceSkills(cwd, payload, sessionCtx);
 
-      const briefing = buildAgentBriefing(payload, chatContext, cwd);
+      const briefing = buildBriefing(sessionCtx, payload, chatContext, cwd);
       ensureCodexBootstrap(cwd, sessionCtx, briefing);
       markWorkspaceInitComplete(cwd);
 
@@ -1338,7 +1199,7 @@ export const createCodexHandler: HandlerFactory = (config) => {
       await prepareSourceRepos(payload, cwd, sessionCtx);
       await materializeResourceSkills(cwd, payload, sessionCtx);
 
-      const briefing = buildAgentBriefing(payload, chatContext, cwd);
+      const briefing = buildBriefing(sessionCtx, payload, chatContext, cwd);
       ensureCodexBootstrap(cwd, sessionCtx, briefing);
       markWorkspaceInitComplete(cwd);
 

--- a/packages/client/src/runtime/agent-bootstrap.ts
+++ b/packages/client/src/runtime/agent-bootstrap.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import {
   bootstrapWorkspace,
@@ -9,10 +9,11 @@ import {
   readCachedContextTreeHead,
   readContextTreeHead,
   resolveBundledCliVersion,
+  writeAgentBriefing,
   writeBundledCliVersion,
   writeContextTreeHead,
 } from "./bootstrap.js";
-import type { AgentIdentity, SessionContext } from "./handler.js";
+import type { SessionContext } from "./handler.js";
 import { INIT_COMPLETE_SENTINEL_REL } from "./workspace.js";
 
 export type AgentBootstrapParams = {
@@ -22,74 +23,26 @@ export type AgentBootstrapParams = {
   contextTreeRepoUrl: string | null;
   /** Stable workspace id for the integrate shell-out; falls back to agent id. */
   agentName: string | null;
+  /**
+   * Pre-rendered briefing for this turn. Built by {@link buildAgentBriefing}
+   * and written to `<workspace>/AGENTS.md` on every start/resume (CLAUDE.md is
+   * symlinked to it). The briefing changes per chat — Current Chat Context,
+   * participants, and the latest agent config payload all flow through this
+   * parameter — so callers MUST recompute it before every call instead of
+   * caching across sessions.
+   */
+  briefing: string;
 };
 
 /**
- * Generate the **stable** CLAUDE.md materialised at the agent home root.
- *
- * Per agent-session-cwd-redesign: this file contains only agent-level content
- * (identity, org domain map, Context Tree pointer, tools reference). Per-chat
- * content is injected per turn (via the SDK `appendSystemPrompt` or the TUI
- * `--append-system-prompt`) so two concurrent chats sharing this cwd never see
- * each other's data on disk.
- *
- * Per PRD D7 the agent's behavior instructions live in server-managed
- * `agent_configs.payload.prompt.append`, not in this file.
- */
-export function generateStableClaudeMd(
-  workspacePath: string,
-  identity: AgentIdentity,
-  contextTreePath: string | null,
-): void {
-  const sections: string[] = [];
-  const contextDir = join(workspacePath, ".agent", "context");
-
-  // --- Identity ---
-  // Post-type-merge (migration 0051): the "personal assistant" vs "autonomous
-  // bot" framing is carried by `agents.visibility`, not `delegateMention`.
-  const name = identity.displayName ?? identity.agentId;
-  if (identity.visibility === "private") {
-    sections.push(`# Agent Identity\n\nYou are ${name}, a personal assistant agent.\n`);
-  } else {
-    sections.push(`# Agent Identity\n\nYou are ${name}, an autonomous agent.\n`);
-  }
-
-  // --- Context Tree operating instructions (AGENT.md) ---
-  const agentInstructionsPath = join(contextDir, "agent-instructions.md");
-  if (existsSync(agentInstructionsPath)) {
-    const instructions = readFileSync(agentInstructionsPath, "utf-8");
-    sections.push(`## Operating Instructions\n\n${instructions}\n`);
-  }
-
-  // --- Organization domain map (root NODE.md) ---
-  const domainMapPath = join(contextDir, "domain-map.md");
-  if (existsSync(domainMapPath)) {
-    const domainMap = readFileSync(domainMapPath, "utf-8");
-    sections.push(`## Organization Domain Map\n\n${domainMap}\n`);
-  }
-
-  // --- Context Tree location for on-demand reading ---
-  if (contextTreePath) {
-    sections.push(
-      `## Context Tree Location\n\nThe full Context Tree is available at: \`${contextTreePath}\`\n\nRead specific domain nodes as needed following the operating instructions above.\n`,
-    );
-  }
-
-  // --- Tools reference ---
-  const toolsPath = join(workspacePath, ".agent", "tools.md");
-  if (existsSync(toolsPath)) {
-    const toolsContent = readFileSync(toolsPath, "utf-8");
-    sections.push(toolsContent);
-  }
-
-  writeFileSync(join(workspacePath, "CLAUDE.md"), sections.join("\n"), "utf-8");
-}
-
-/**
  * Hash-check the existing identity.json against current agent metadata and
- * rewrite the stable `.agent/` section + CLAUDE.md only when something changed.
- * Runs OUT of the sentinel gate so agent rename / inboxId / metadata edits
- * still propagate after first bootstrap (proposal R5).
+ * rewrite the stable `.agent/` section only when something changed. Runs OUT
+ * of the sentinel gate so agent rename / inboxId / metadata edits still
+ * propagate after first bootstrap (proposal R5).
+ *
+ * The unified briefing is rewritten by the caller via {@link
+ * writeAgentBriefing} on every start/resume regardless of this check —
+ * identity drift only forces the heavier `.agent/` refresh.
  */
 function ensureStableIdentity(workspace: string, sessionCtx: SessionContext, contextTreePath: string | null): void {
   const identityPath = join(workspace, ".agent", "identity.json");
@@ -119,22 +72,23 @@ function ensureStableIdentity(workspace: string, sessionCtx: SessionContext, con
     contextTreePath,
     serverUrl: sessionCtx.sdk.serverUrl,
   });
-  generateStableClaudeMd(workspace, sessionCtx.agent, contextTreePath);
 }
 
 /**
- * Run the agent-home bootstrap that every Claude-driven handler shares: stable
- * `.agent/` layout + CLAUDE.md briefing, core-skill install, and (for
- * Context-Tree-bound agents) `first-tree tree skill install`. Gated by the
- * stage-2 sentinel + Context-Tree-HEAD / CLI-version drift detection so a
- * changed tree or a `first-tree upgrade` forces a refresh, while the
- * steady-state path is a cheap identity check.
+ * Run the agent-home bootstrap that every handler shares: stable `.agent/`
+ * layout, unified briefing rewrite (AGENTS.md + CLAUDE.md symlink), core-skill
+ * install, and (for Context-Tree-bound agents) `first-tree tree skill install`.
+ * Gated by the stage-2 sentinel + Context-Tree-HEAD / CLI-version drift
+ * detection so a changed tree or a `first-tree upgrade` forces a refresh,
+ * while the steady-state path is a cheap identity check.
  *
- * Extracted from the claude-code SDK handler so the claude-code-tui handler
- * gets the identical briefing/skill/drift contract instead of a partial copy.
+ * The unified briefing is **always rewritten** on every call, irrespective of
+ * drift — it carries per-chat content (chat ID, participants, source-repo
+ * list, current payload prompt.append) that changes between sessions for the
+ * same agent home. See proposal §⓪.3 for the race window this accepts.
  */
 export function ensureAgentBootstrap(params: AgentBootstrapParams): void {
-  const { workspace, sessionCtx, contextTreePath, contextTreeRepoUrl, agentName } = params;
+  const { workspace, sessionCtx, contextTreePath, contextTreeRepoUrl, agentName, briefing } = params;
 
   const sentinelPresent = existsSync(join(workspace, INIT_COMPLETE_SENTINEL_REL));
   const currentTreeHead = readContextTreeHead(contextTreePath);
@@ -169,6 +123,7 @@ export function ensureAgentBootstrap(params: AgentBootstrapParams): void {
 
   if (sentinelPresent && !treeDrifted && !cliDrifted && !integrationNeverPinned) {
     ensureStableIdentity(workspace, sessionCtx, contextTreePath);
+    writeAgentBriefing(workspace, briefing);
     return;
   }
 
@@ -189,7 +144,7 @@ export function ensureAgentBootstrap(params: AgentBootstrapParams): void {
     contextTreePath,
     serverUrl: sessionCtx.sdk.serverUrl,
   });
-  generateStableClaudeMd(workspace, sessionCtx.agent, contextTreePath);
+  writeAgentBriefing(workspace, briefing);
 
   // Core skills ship with every agent, tree or not. The core skill set is
   // currently empty so this is effectively a no-op, but the wiring stays so

--- a/packages/client/src/runtime/agent-briefing.ts
+++ b/packages/client/src/runtime/agent-briefing.ts
@@ -1,0 +1,105 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { AgentRuntimeConfigPayload } from "@first-tree/shared";
+import { buildChatSystemPrompt, generateToolsDoc, type PredeclaredSourceRepo } from "./bootstrap.js";
+import type { ChatContext } from "./chat-context.js";
+import type { AgentIdentity } from "./handler.js";
+import { buildResourceSkillsBriefing } from "./resource-skills.js";
+
+export type BuildAgentBriefingOptions = {
+  identity: AgentIdentity;
+  payload: AgentRuntimeConfigPayload | null;
+  chatContext: ChatContext | undefined;
+  workspacePath: string;
+  sourceRepos: ReadonlyArray<PredeclaredSourceRepo>;
+  contextTreePath: string | null;
+};
+
+/**
+ * Build the unified agent briefing materialised at `<workspacePath>/AGENTS.md`.
+ * `<workspacePath>/CLAUDE.md` is a symlink to it (see {@link ensureClaudeMdSymlink}),
+ * so Codex (which walks up for `AGENTS.md`) and Claude Code (which loads
+ * `CLAUDE.md` via `settingSources: ["project"]`) read the same content.
+ *
+ * One channel, all sections — no more split between a stable on-disk briefing
+ * and a per-turn SDK `systemPrompt.append`. The hub-managed
+ * `agent_configs.payload.prompt.append` lands here too, so admin updates take
+ * effect on the next session start/resume via briefing rewrite (same semantics
+ * Codex has carried since proposal §⓪.3).
+ *
+ * Section order (omit any block that has no content):
+ *   1. `# Agent Identity`
+ *   2. `## Agent-Specific Behavior`  (per-agent prompt.append)
+ *   3. `# Working Directory Convention` + `## Source Repositories` +
+ *      `## Creating Worktrees On Demand` + `## Current Chat Context`
+ *      (built by {@link buildChatSystemPrompt})
+ *   4. `## Operating Instructions` (AGENT.md), `## Organization Domain Map`
+ *      (root NODE.md), `## Context Tree Location` — all gated on
+ *      `contextTreePath !== null`
+ *   5. `# First Tree Agent Runtime` ({@link generateToolsDoc})
+ */
+export function buildAgentBriefing(opts: BuildAgentBriefingOptions): string {
+  const sections: string[] = [];
+
+  sections.push(identitySection(opts.identity));
+
+  const agentBehavior = opts.payload?.prompt.append?.trim() ?? "";
+  if (agentBehavior) {
+    sections.push(`## Agent-Specific Behavior\n\n${agentBehavior}`);
+  }
+
+  const skillsBlock = buildResourceSkillsBriefing(opts.workspacePath, opts.payload).trim();
+  if (skillsBlock) {
+    sections.push(skillsBlock);
+  }
+
+  const workingEnv = buildChatSystemPrompt({
+    agentHome: opts.workspacePath,
+    chatContext: opts.chatContext,
+    sourceRepos: opts.sourceRepos,
+  });
+  if (workingEnv) sections.push(workingEnv);
+
+  if (opts.contextTreePath) {
+    const ctxSection = contextTreeSections(opts.contextTreePath);
+    if (ctxSection) sections.push(ctxSection);
+  }
+
+  sections.push(generateToolsDoc().trim());
+
+  return `${sections.join("\n\n")}\n`;
+}
+
+function identitySection(identity: AgentIdentity): string {
+  const name = identity.displayName ?? identity.agentId;
+  const kind = identity.visibility === "private" ? "a personal assistant agent" : "an autonomous agent";
+  return `# Agent Identity\n\nYou are ${name}, ${kind}.`;
+}
+
+/**
+ * Read AGENT.md / NODE.md directly from the bound Context Tree checkout. We
+ * intentionally do not read the staged `.agent/context/` copies here because
+ * the handler builds the briefing *before* `bootstrapWorkspace` runs (the
+ * briefing then drives the AGENTS.md write that bootstrap performs). Reading
+ * the live tree avoids a stale-copy window after upstream tree updates.
+ */
+function contextTreeSections(contextTreePath: string): string | null {
+  const sections: string[] = [];
+
+  const instructionsPath = join(contextTreePath, "AGENT.md");
+  if (existsSync(instructionsPath)) {
+    sections.push(`## Operating Instructions\n\n${readFileSync(instructionsPath, "utf-8").trim()}`);
+  }
+
+  const domainMapPath = join(contextTreePath, "NODE.md");
+  if (existsSync(domainMapPath)) {
+    sections.push(`## Organization Domain Map\n\n${readFileSync(domainMapPath, "utf-8").trim()}`);
+  }
+
+  sections.push(
+    `## Context Tree Location\n\nThe full Context Tree is available at: \`${contextTreePath}\`\n\n` +
+      "Read specific domain nodes as needed following the operating instructions above.",
+  );
+
+  return sections.length > 0 ? sections.join("\n\n") : null;
+}

--- a/packages/client/src/runtime/bootstrap.ts
+++ b/packages/client/src/runtime/bootstrap.ts
@@ -332,6 +332,17 @@ export function writeAgentBriefing(workspacePath: string, content: string): void
  * atomic, and the rename overwrites any existing file or symlink in place.
  * The temp file is cleaned up on any failure so a crashed write does not
  * leak siblings.
+ *
+ * ⚠️ SDK assumption (regression-watch on `@anthropic-ai/claude-agent-sdk`
+ * version bumps): this layout relies on the Claude Code SDK enumerating
+ * ONLY `<cwd>/CLAUDE.md` as a Project memory file — the SDK does not look
+ * for `<cwd>/AGENTS.md` separately, so the symlink is resolved
+ * transparently with no double-load. Verified on 0.2.84 (`grep -c
+ * '"AGENTS.md"' cli.js` → 0; `grep -c '"CLAUDE.md"' cli.js` → 13, all on
+ * Project / User / Local / Managed memory paths). If a future SDK adds
+ * AGENTS.md as a sibling Project memory entry, the briefing would
+ * double-load — re-run the manual probes documented in tree-context PR
+ * #397 before upgrading the SDK major version.
  */
 export function ensureClaudeMdSymlink(workspacePath: string): void {
   const claudeMd = join(workspacePath, "CLAUDE.md");

--- a/packages/client/src/runtime/bootstrap.ts
+++ b/packages/client/src/runtime/bootstrap.ts
@@ -1,6 +1,19 @@
 import { execFile, execFileSync } from "node:child_process";
-import { createHash } from "node:crypto";
-import { copyFileSync, existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { createHash, randomBytes } from "node:crypto";
+import {
+  copyFileSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readlinkSync,
+  renameSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
@@ -293,13 +306,55 @@ export async function syncAgentContextTree(
  */
 export const FIRST_TREE_WORKSPACE_MARKER = ".first-tree-workspace";
 
-export type AgentBriefingFormat = "claude" | "agents-md";
+/**
+ * Materialise the unified agent briefing at `<workspacePath>/AGENTS.md` and
+ * keep `<workspacePath>/CLAUDE.md` as a relative symlink to it.
+ *
+ * One file, both providers: Codex's `project_root_markers` walk finds
+ * `AGENTS.md` directly; Claude Code's `settingSources: ["project"]` follows
+ * the `CLAUDE.md` symlink. Edits to the briefing layout only need to land in
+ * the {@link buildAgentBriefing} producer.
+ */
+export function writeAgentBriefing(workspacePath: string, content: string): void {
+  writeFileSync(join(workspacePath, "AGENTS.md"), content, "utf-8");
+  ensureClaudeMdSymlink(workspacePath);
+}
 
-export type AgentBriefing = {
-  format: AgentBriefingFormat;
-  /** Pre-rendered markdown to materialise as the briefing file. */
-  content: string;
-};
+/**
+ * Make `<workspacePath>/CLAUDE.md` a relative symlink to `AGENTS.md`. Replaces
+ * a stale regular file or broken/mis-targeted symlink left from earlier
+ * bootstrap formats; a no-op when the symlink is already correct.
+ *
+ * Atomically swaps in the new symlink via `rename` so two concurrent
+ * same-agent starts can't race the unlink/symlink pair into an `EEXIST`
+ * (PR #797 review nit #3). We materialise the new link at a unique
+ * sibling path, then `rename` it onto `CLAUDE.md` — POSIX makes that
+ * atomic, and the rename overwrites any existing file or symlink in place.
+ * The temp file is cleaned up on any failure so a crashed write does not
+ * leak siblings.
+ */
+export function ensureClaudeMdSymlink(workspacePath: string): void {
+  const claudeMd = join(workspacePath, "CLAUDE.md");
+  const targetRel = "AGENTS.md";
+  try {
+    const stats = lstatSync(claudeMd);
+    if (stats.isSymbolicLink() && readlinkSync(claudeMd) === targetRel) return;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+  }
+  const tempPath = join(workspacePath, `.CLAUDE.md.${randomBytes(6).toString("hex")}.tmp`);
+  symlinkSync(targetRel, tempPath);
+  try {
+    renameSync(tempPath, claudeMd);
+  } catch (err) {
+    try {
+      unlinkSync(tempPath);
+    } catch {
+      // Best-effort cleanup — surface the original rename failure.
+    }
+    throw err;
+  }
+}
 
 /**
  * Path to the cached Context-Tree HEAD inside the agent home. Used by the
@@ -475,33 +530,26 @@ export type BootstrapOptions = {
   identity: AgentIdentity;
   contextTreePath: string | null;
   serverUrl: string;
-  /**
-   * Provider-specific runtime briefing materialised at the workspace root.
-   * `agents-md` writes `AGENTS.md` (Codex reads it from the project root via
-   * the marker); `claude` is a no-op file-write because Claude Code receives
-   * the system prompt through the SDK option directly.
-   */
-  briefing?: AgentBriefing;
 };
 
 /**
  * Bootstrap the agent's home directory with stable, agent-level files plus
- * the workspace-root marker (and an optional provider-specific briefing).
+ * the workspace-root marker.
  *
  * Writes identity.json, context/agent-instructions.md (if context tree
- * available), tools.md, the `.first-tree-workspace` marker, and — for
- * Codex — `AGENTS.md`. Per the agent-session-cwd-redesign (proposals/
- * 2026-05-19) **only agent-level stable fields** live in identity.json;
- * per-chat data (chatId, participants) is injected per turn via the
- * Claude/Codex SDK system-prompt append channel, built by
- * {@link buildChatSystemPrompt}.
+ * available), tools.md, and the `.first-tree-workspace` marker. Per the
+ * agent-session-cwd-redesign (proposals/2026-05-19) **only agent-level stable
+ * fields** live in identity.json; per-chat data (chatId, participants) flows
+ * through the unified per-turn briefing file written by {@link
+ * writeAgentBriefing} (which the handler invokes on every start/resume after
+ * computing the briefing content via {@link buildAgentBriefing}).
  *
  * Idempotent: safe to call on every handler start() / resume(), though in
  * the per-agent-home model the handler short-circuits this when the
  * `.agent/init-complete` sentinel is already present.
  */
 export function bootstrapWorkspace(options: BootstrapOptions): void {
-  const { workspacePath, identity, contextTreePath, serverUrl, briefing } = options;
+  const { workspacePath, identity, contextTreePath, serverUrl } = options;
   const agentDir = join(workspacePath, ".agent");
   const contextDir = join(agentDir, "context");
 
@@ -527,10 +575,10 @@ export function bootstrapWorkspace(options: BootstrapOptions): void {
   };
   writeFileSync(join(agentDir, "identity.json"), JSON.stringify(identityData, null, 2), "utf-8");
 
-  // 2. Copy organizational context from Context Tree (if available).
-  // Per PRD D7, the agent's behavior instructions live in the server-managed
-  // `agent_configs.payload.prompt.append` and are injected via the Claude
-  // Code SDK's `systemPrompt.append`, not via a workspace file.
+  // 2. Copy organizational context from Context Tree (if available). The
+  //    briefing builder reads back agent-instructions.md / domain-map.md from
+  //    here when assembling AGENTS.md, so this is also the staging area for
+  //    the unified briefing's tree sections.
   if (contextTreePath) {
     // Agent operating instructions (AGENT.md)
     const agentMdPath = join(contextTreePath, "AGENT.md");
@@ -552,11 +600,6 @@ export function bootstrapWorkspace(options: BootstrapOptions): void {
   //    sees the briefing in this workspace and not whatever sits in the
   //    operator's HOME / git root.
   writeFileSync(join(workspacePath, FIRST_TREE_WORKSPACE_MARKER), "", "utf-8");
-
-  // 5. Provider-specific briefing
-  if (briefing?.format === "agents-md") {
-    writeFileSync(join(workspacePath, "AGENTS.md"), briefing.content, "utf-8");
-  }
 }
 
 export type InstallFirstTreeIntegrationExec = (


### PR DESCRIPTION
## Summary

- Collapses the split where per-agent `prompt.append` + per-chat block were injected via SDK `systemPrompt.append` while identity + tree sections lived in a separate stable `CLAUDE.md`. The unified briefing is now materialised once as `<cwd>/AGENTS.md`, with `<cwd>/CLAUDE.md` as a symlink to it. One file, both providers — Codex walks for `AGENTS.md`, Claude Code reads `CLAUDE.md` via `settingSources: ["project"]`.
- Hub-managed `agent_configs.payload.prompt.append` now lands in the file too, so admin updates take effect on the next session start / resume (or on `maybeSwitchConfig` Path B for Claude Code SDK), via briefing rewrite — same per-turn semantics Codex had since proposal §⓪.3.
- Drops the `--append-system-prompt[-file]` path in the Claude Code TUI handler and the `systemPrompt` slice of `buildClaudeQueryOptions` in the SDK handler. The briefing is now the single channel.

## What's new

- `runtime/agent-briefing.ts` → `buildAgentBriefing()` produces the unified briefing (Identity → `Agent-Specific Behavior` → `Team Skills` → Working Directory Convention → Source Repos → Worktree convention → Current Chat Context → Operating Instructions → Domain Map → Context Tree pointer → First Tree Agent Runtime).
- `runtime/bootstrap.ts` → `writeAgentBriefing(workspace, content)` writes `AGENTS.md` and calls `ensureClaudeMdSymlink()` to point `CLAUDE.md` at it. `bootstrapWorkspace` no longer takes a `briefing` field.
- `runtime/agent-bootstrap.ts` → `ensureAgentBootstrap` now takes `briefing: string` and always rewrites the briefing on every call (drift logic still gates the heavier `.agent/` + integrate work).
- Codex handler reuses the shared `ensureAgentBootstrap`; the race detector stays as a thin wrapper.
- Tests updated for the new shape (`agent-cwd-redesign.e2e.test.ts` E4 now asserts against `AGENTS.md` / `CLAUDE.md` instead of captured SDK options).

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm check` (biome) clean
- [x] `pnpm test` — 1019 passed / 2 skipped on `@first-tree/client`; full monorepo test run green
- [x] `pnpm build` clean
- [ ] Manual: spin up a claude-code agent locally, confirm `AGENTS.md` exists with all sections and `CLAUDE.md` is a symlink to it (`ls -l workspaces/<agent>/`).
- [ ] Manual: trigger a config hot-switch (admin payload change), confirm briefing is rewritten before the SDK restart picks up new prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)