### PR TITLE
fix(web): edit custom prompts from prompt tab

### DIFF
--- a/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
@@ -73,6 +73,29 @@ vi.mock("../../../auth/auth-context.js", () => ({
 
 const NOW = "2026-05-28T12:00:00.000Z";
 
+type EffectivePromptRow = AgentResourcesOutput["effective"]["prompts"][number];
+
+function effectivePrompt(overrides: Partial<EffectivePromptRow> = {}): EffectivePromptRow {
+  const base: EffectivePromptRow = {
+    id: "binding:inline-1:enabled",
+    bindingId: "inline-1",
+    resourceId: null,
+    replacesResourceId: null,
+    type: "prompt",
+    name: "Inline prompt",
+    scope: null,
+    source: "inline_prompt",
+    mode: "enabled",
+    defaultEnabled: null,
+    payload: null,
+    repo: null,
+    promptBody: "Always explain tradeoffs.",
+    unavailableReason: null,
+    order: 1,
+  };
+  return { ...base, ...overrides };
+}
+
 function agent(overrides: Partial<Agent> = {}): Agent {
   return {
     uuid: overrides.uuid ?? "agent-1",
@@ -122,25 +145,7 @@ function agentResources(overrides: Partial<AgentResourcesOutput> = {}): AgentRes
     effective: overrides.effective ?? {
       version: overrides.version ?? 7,
       repos: [],
-      prompts: [
-        {
-          id: "binding:inline-1:enabled",
-          bindingId: "inline-1",
-          resourceId: null,
-          replacesResourceId: null,
-          type: "prompt",
-          name: "Inline prompt",
-          scope: null,
-          source: "inline_prompt",
-          mode: "enabled",
-          defaultEnabled: null,
-          payload: null,
-          repo: null,
-          promptBody: "Always explain tradeoffs.",
-          unavailableReason: null,
-          order: 1,
-        },
-      ],
+      prompts: [effectivePrompt()],
       skills: [],
       mcp: [],
       unavailable: [],
@@ -415,6 +420,187 @@ describe("AgentDetailPage", () => {
       ],
     });
     expect(container.textContent).not.toContain("Resources route");
+
+    await act(async () => root.unmount());
+  });
+
+  it("creates an inline replacement when editing a recommended team prompt", async () => {
+    const { PromptTab } = await import("../prompt-tab.js");
+    agentResourceMocks.getAgentResources.mockResolvedValueOnce(
+      agentResources({
+        effective: {
+          version: 7,
+          repos: [],
+          prompts: [
+            effectivePrompt({
+              id: "resource:team-prompt-1",
+              bindingId: null,
+              resourceId: "team-prompt-1",
+              name: "Team style guide",
+              scope: "team",
+              source: "team_recommended",
+              defaultEnabled: "recommended",
+              promptBody: "Use the team style guide.",
+              order: 0,
+            }),
+          ],
+          skills: [],
+          mcp: [],
+          unavailable: [],
+        },
+        bindings: [],
+      }),
+    );
+
+    const { container, root } = await renderDom("/agents/agent-1/prompt", <PromptTab />);
+    await waitForText(container, "Effective prompt");
+    await click(exactButtonByText(container, "Edit custom prompt"));
+    await waitForText(document.body, "Save prompt");
+    const textarea = document.body.querySelector<HTMLTextAreaElement>("#custom-prompt-body");
+    expect(textarea?.value).toBe("Use the team style guide.");
+    if (!textarea) throw new Error("Expected custom prompt textarea");
+    await setValue(textarea, "Use the agent-specific style guide.");
+    await click(exactButtonByText(document.body, "Save prompt"));
+    await waitForCondition(
+      () => agentResourceMocks.updateAgentResources.mock.calls.length > 0,
+      "Expected prompt resource update",
+    );
+    expect(agentResourceMocks.updateAgentResources).toHaveBeenCalledWith("agent-1", {
+      expectedVersion: 7,
+      bindings: [
+        {
+          type: "prompt",
+          mode: "replace",
+          resourceId: null,
+          replacesResourceId: "team-prompt-1",
+          inlinePromptBody: "Use the agent-specific style guide.",
+          order: 1,
+        },
+      ],
+    });
+
+    await act(async () => root.unmount());
+  });
+
+  it("converts an explicit recommended prompt binding to an inline replacement", async () => {
+    const { PromptTab } = await import("../prompt-tab.js");
+    agentResourceMocks.getAgentResources.mockResolvedValueOnce(
+      agentResources({
+        effective: {
+          version: 7,
+          repos: [],
+          prompts: [
+            effectivePrompt({
+              id: "binding:team-binding-1:enabled",
+              bindingId: "team-binding-1",
+              resourceId: "team-prompt-1",
+              name: "Team style guide",
+              scope: "team",
+              source: "team_recommended",
+              defaultEnabled: "recommended",
+              promptBody: "Use the team style guide.",
+              order: 2,
+            }),
+          ],
+          skills: [],
+          mcp: [],
+          unavailable: [],
+        },
+        bindings: [
+          {
+            id: "team-binding-1",
+            type: "prompt",
+            mode: "include",
+            resourceId: "team-prompt-1",
+            replacesResourceId: null,
+            inlinePromptBody: null,
+            order: 2,
+          },
+        ],
+      }),
+    );
+
+    const { container, root } = await renderDom("/agents/agent-1/prompt", <PromptTab />);
+    await waitForText(container, "Effective prompt");
+    await click(exactButtonByText(container, "Edit custom prompt"));
+    await waitForText(document.body, "Save prompt");
+    const textarea = document.body.querySelector<HTMLTextAreaElement>("#custom-prompt-body");
+    expect(textarea?.value).toBe("Use the team style guide.");
+    if (!textarea) throw new Error("Expected custom prompt textarea");
+    await setValue(textarea, "Use the agent-specific style guide.");
+    await click(exactButtonByText(document.body, "Save prompt"));
+    await waitForCondition(
+      () => agentResourceMocks.updateAgentResources.mock.calls.length > 0,
+      "Expected prompt resource update",
+    );
+    expect(agentResourceMocks.updateAgentResources).toHaveBeenCalledWith("agent-1", {
+      expectedVersion: 7,
+      bindings: [
+        {
+          id: "team-binding-1",
+          type: "prompt",
+          mode: "replace",
+          resourceId: null,
+          replacesResourceId: "team-prompt-1",
+          inlinePromptBody: "Use the agent-specific style guide.",
+          order: 2,
+        },
+      ],
+    });
+
+    await act(async () => root.unmount());
+  });
+
+  it("adds an inline prompt and clears local validation errors on cancel", async () => {
+    const { PromptTab } = await import("../prompt-tab.js");
+    const emptyConfig = config();
+    agentConfigMocks.getAgentConfig.mockResolvedValueOnce(
+      config({ payload: { ...emptyConfig.payload, prompt: { append: "" } } }),
+    );
+    agentResourceMocks.getAgentResources.mockResolvedValueOnce(
+      agentResources({
+        effective: { version: 7, repos: [], prompts: [], skills: [], mcp: [], unavailable: [] },
+        bindings: [],
+      }),
+    );
+
+    const { container, root } = await renderDom("/agents/agent-1/prompt", <PromptTab />);
+    await waitForText(container, "No prompt resources enabled.");
+    await click(exactButtonByText(container, "Edit custom prompt"));
+    await waitForText(document.body, "Save prompt");
+    await click(exactButtonByText(document.body, "Save prompt"));
+    await waitForText(document.body, "Prompt body is required.");
+    await click(exactButtonByText(document.body, "Cancel"));
+    await waitForCondition(
+      () => !document.body.textContent?.includes("Prompt body is required."),
+      "Expected prompt body validation error to clear",
+    );
+
+    await click(exactButtonByText(container, "Edit custom prompt"));
+    await waitForText(document.body, "Save prompt");
+    expect(document.body.textContent).not.toContain("Prompt body is required.");
+    const textarea = document.body.querySelector<HTMLTextAreaElement>("#custom-prompt-body");
+    expect(textarea?.value).toBe("");
+    if (!textarea) throw new Error("Expected custom prompt textarea");
+    await setValue(textarea, "Prefer concise answers.");
+    await click(exactButtonByText(document.body, "Save prompt"));
+    await waitForCondition(
+      () => agentResourceMocks.updateAgentResources.mock.calls.length > 0,
+      "Expected prompt resource update",
+    );
+    expect(agentResourceMocks.updateAgentResources).toHaveBeenCalledWith("agent-1", {
+      expectedVersion: 7,
+      bindings: [
+        {
+          type: "prompt",
+          mode: "include",
+          resourceId: null,
+          replacesResourceId: null,
+          inlinePromptBody: "Prefer concise answers.",
+          order: 1,
+        },
+      ],
+    });
 
     await act(async () => root.unmount());
   });

--- a/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 
-import type { Agent, AgentRuntimeConfig } from "@first-tree/shared";
+import type { Agent, AgentResourcesOutput, AgentRuntimeConfig } from "@first-tree/shared";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, type ReactElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
@@ -32,6 +32,11 @@ const agentMocks = vi.hoisted(() => ({
   updateAgent: vi.fn(),
 }));
 
+const agentResourceMocks = vi.hoisted(() => ({
+  getAgentResources: vi.fn(),
+  updateAgentResources: vi.fn(),
+}));
+
 const sessionMocks = vi.hoisted(() => ({
   listAgentSessions: vi.fn(),
 }));
@@ -54,6 +59,8 @@ vi.mock("../../../api/agents.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../../api/agents.js")>()),
   ...agentMocks,
 }));
+
+vi.mock("../../../api/agent-resources.js", () => agentResourceMocks);
 
 vi.mock("../../../api/sessions.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../../api/sessions.js")>()),
@@ -106,6 +113,50 @@ function config(overrides: Partial<AgentRuntimeConfig> = {}): AgentRuntimeConfig
     },
     updatedAt: overrides.updatedAt ?? NOW,
     updatedBy: overrides.updatedBy ?? "member-self",
+  };
+}
+
+function agentResources(overrides: Partial<AgentResourcesOutput> = {}): AgentResourcesOutput {
+  return {
+    version: overrides.version ?? 7,
+    effective: overrides.effective ?? {
+      version: overrides.version ?? 7,
+      repos: [],
+      prompts: [
+        {
+          id: "binding:inline-1:enabled",
+          bindingId: "inline-1",
+          resourceId: null,
+          replacesResourceId: null,
+          type: "prompt",
+          name: "Inline prompt",
+          scope: null,
+          source: "inline_prompt",
+          mode: "enabled",
+          defaultEnabled: null,
+          payload: null,
+          repo: null,
+          promptBody: "Always explain tradeoffs.",
+          unavailableReason: null,
+          order: 1,
+        },
+      ],
+      skills: [],
+      mcp: [],
+      unavailable: [],
+    },
+    bindings: overrides.bindings ?? [
+      {
+        id: "inline-1",
+        type: "prompt",
+        mode: "include",
+        resourceId: null,
+        replacesResourceId: null,
+        inlinePromptBody: "Always explain tradeoffs.",
+        order: 1,
+      },
+    ],
+    availableTeamResources: overrides.availableTeamResources ?? [],
   };
 }
 
@@ -295,6 +346,11 @@ beforeEach(() => {
     },
   });
   agentMocks.rebindAgent.mockResolvedValue(agent({ clientId: "client-2", runtimeProvider: "codex" }));
+  agentResourceMocks.getAgentResources.mockResolvedValue(agentResources());
+  agentResourceMocks.updateAgentResources.mockImplementation(
+    async (_agentId: string, body: { bindings: AgentResourcesOutput["bindings"] }) =>
+      agentResources({ version: 8, bindings: body.bindings }),
+  );
   agentConfigMocks.getAgentConfig.mockResolvedValue(config());
   agentConfigMocks.updateAgentConfig.mockResolvedValue(config({ version: 8 }));
   agentConfigMocks.dryRunAgentConfig.mockResolvedValue({ diff: [{ op: "replace", path: "/prompt/append" }] });
@@ -316,7 +372,7 @@ afterEach(() => {
 });
 
 describe("AgentDetailPage", () => {
-  it("renders the effective prompt and links prompt editing to resources", async () => {
+  it("renders the effective prompt and edits the custom prompt inline", async () => {
     const { PromptTab } = await import("../prompt-tab.js");
 
     const { container, root } = await renderDom("/agents/agent-1/prompt", <PromptTab />);
@@ -333,8 +389,32 @@ describe("AgentDetailPage", () => {
     ]);
     expect(container.textContent).toContain("Always explain tradeoffs.");
 
-    await click(exactButtonByText(container, "Edit resources"));
-    await waitForText(container, "Resources route");
+    await click(exactButtonByText(container, "Edit custom prompt"));
+    await waitForText(document.body, "Save prompt");
+    const textarea = document.body.querySelector<HTMLTextAreaElement>("#custom-prompt-body");
+    expect(textarea?.value).toBe("Always explain tradeoffs.");
+    if (!textarea) throw new Error("Expected custom prompt textarea");
+    await setValue(textarea, "Prefer concise answers.");
+    await click(exactButtonByText(document.body, "Save prompt"));
+    await waitForCondition(
+      () => agentResourceMocks.updateAgentResources.mock.calls.length > 0,
+      "Expected prompt resource update",
+    );
+    expect(agentResourceMocks.updateAgentResources).toHaveBeenCalledWith("agent-1", {
+      expectedVersion: 7,
+      bindings: [
+        {
+          id: "inline-1",
+          type: "prompt",
+          mode: "include",
+          resourceId: null,
+          replacesResourceId: null,
+          inlinePromptBody: "Prefer concise answers.",
+          order: 1,
+        },
+      ],
+    });
+    expect(container.textContent).not.toContain("Resources route");
 
     await act(async () => root.unmount());
   });

--- a/packages/web/src/pages/agent-detail/prompt-tab.tsx
+++ b/packages/web/src/pages/agent-detail/prompt-tab.tsx
@@ -111,7 +111,7 @@ type PromptEditorState = {
 
 type PromptEditorTarget =
   | { kind: "update-inline"; bindingIndex: number }
-  | { kind: "convert-binding"; bindingIndex: number }
+  | { kind: "convert-binding"; bindingIndex: number; replacesResourceId: string | null }
   | { kind: "replace-resource"; replacesResourceId: string }
   | { kind: "add-inline" };
 
@@ -155,7 +155,11 @@ function seedFromSingleTeamPrompt(data: AgentResourcesOutput): { body: string; t
       target:
         bindingIndex === null
           ? { kind: "replace-resource", replacesResourceId: row.resourceId }
-          : { kind: "convert-binding", bindingIndex },
+          : {
+              kind: "convert-binding",
+              bindingIndex,
+              replacesResourceId: row.source === "team_recommended" ? row.resourceId : null,
+            },
     };
   }
   return { body: "", target: { kind: "add-inline" } };
@@ -179,14 +183,7 @@ function updatePromptBindings(
   }
   if (target.kind === "convert-binding") {
     return bindings.map((binding, index) =>
-      index === target.bindingIndex
-        ? {
-            ...binding,
-            resourceId: null,
-            inlinePromptBody: body,
-            replacesResourceId: binding.mode === "replace" ? binding.replacesResourceId : null,
-          }
-        : binding,
+      index === target.bindingIndex ? convertPromptBindingToInline(binding, target.replacesResourceId, body) : binding,
     );
   }
   return [
@@ -200,6 +197,21 @@ function updatePromptBindings(
       order: nextOrder(bindings),
     },
   ];
+}
+
+function convertPromptBindingToInline(
+  binding: AgentResourceBindingInput,
+  replacesResourceId: string | null,
+  body: string,
+): AgentResourceBindingInput {
+  const replaceTarget = binding.mode === "replace" ? (binding.replacesResourceId ?? null) : replacesResourceId;
+  return {
+    ...binding,
+    mode: replaceTarget ? "replace" : "include",
+    resourceId: null,
+    inlinePromptBody: body,
+    replacesResourceId: replaceTarget,
+  };
 }
 
 function nextOrder(bindings: readonly AgentResourceBindingInput[]): number {
@@ -218,6 +230,11 @@ function CustomPromptDialog(props: {
   const body = props.editor?.body ?? "";
   const open = props.editor !== null;
 
+  function close() {
+    setLocalError(null);
+    props.onOpenChange(false);
+  }
+
   function submit(e: FormEvent) {
     e.preventDefault();
     if (!body.trim()) {
@@ -232,8 +249,11 @@ function CustomPromptDialog(props: {
     <Dialog
       open={open}
       onOpenChange={(nextOpen) => {
-        if (!nextOpen) setLocalError(null);
-        props.onOpenChange(nextOpen);
+        if (nextOpen) {
+          props.onOpenChange(true);
+        } else {
+          close();
+        }
       }}
     >
       <DialogContent aria-describedby={undefined}>
@@ -264,7 +284,7 @@ function CustomPromptDialog(props: {
             </p>
           ) : null}
           <DialogFooter>
-            <Button type="button" variant="ghost" onClick={() => props.onOpenChange(false)} disabled={props.saving}>
+            <Button type="button" variant="ghost" onClick={close} disabled={props.saving}>
               Cancel
             </Button>
             <Button type="submit" disabled={props.saving}>

--- a/packages/web/src/pages/agent-detail/prompt-tab.tsx
+++ b/packages/web/src/pages/agent-detail/prompt-tab.tsx
@@ -1,43 +1,278 @@
-import { Navigate, useNavigate } from "react-router";
+import {
+  type AgentResourceBindingInput,
+  type AgentResourcesOutput,
+  PROMPT_APPEND_MAX_LENGTH,
+} from "@first-tree/shared";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Pencil } from "lucide-react";
+import { type FormEvent, useState } from "react";
+import { Navigate } from "react-router";
+import { getAgentResources, updateAgentResources } from "../../api/agent-resources.js";
 import { Button } from "../../components/ui/button.js";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "../../components/ui/dialog.js";
+import { Label } from "../../components/ui/label.js";
 import { Section } from "../../components/ui/section.js";
+import { Textarea } from "../../components/ui/textarea.js";
 import { useAgentDetailContext } from "./layout-context.js";
 
 export function PromptTab() {
   const ctx = useAgentDetailContext();
-  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [editor, setEditor] = useState<PromptEditorState | null>(null);
+  const resourcesQuery = useQuery({
+    queryKey: ["agent-resources", ctx.uuid],
+    queryFn: () => getAgentResources(ctx.uuid),
+    enabled: !!ctx.uuid && ctx.canManageAgent && !ctx.isHuman,
+  });
+  const savePromptMut = useMutation({
+    mutationFn: (body: string) => {
+      if (!resourcesQuery.data || !editor) throw new Error("prompt resources not loaded");
+      return updateAgentResources(ctx.uuid, {
+        expectedVersion: resourcesQuery.data.version,
+        bindings: updatePromptBindings(resourcesQuery.data.bindings, editor, body),
+      });
+    },
+    onSuccess: (next) => {
+      queryClient.setQueryData(["agent-resources", ctx.uuid], next);
+      queryClient.invalidateQueries({ queryKey: ["agent-config", ctx.uuid] });
+      setEditor(null);
+    },
+  });
   if (ctx.isHuman) return <Navigate to="../profile" replace />;
   if (!ctx.config && ctx.configLoading) return null;
   const prompt = ctx.config?.payload.prompt.append ?? "";
+  const canEditPrompt = ctx.canManageAgent && ctx.agent.status === "active";
+  const resourceError = resourcesQuery.error instanceof Error ? resourcesQuery.error.message : null;
   return (
-    <Section
-      title="Effective prompt"
-      description="Resolved from Team and Agent prompt resources."
-      action={
-        ctx.canManageAgent ? (
-          <Button type="button" size="xs" variant="outline" onClick={() => navigate("../resources")}>
-            Edit resources
-          </Button>
-        ) : null
-      }
+    <>
+      <Section
+        title="Effective prompt"
+        description="Resolved from Team and Agent prompt resources."
+        action={
+          canEditPrompt ? (
+            <Button
+              type="button"
+              size="xs"
+              variant="outline"
+              disabled={resourcesQuery.isLoading || !!resourceError}
+              onClick={() => {
+                if (!resourcesQuery.data) return;
+                setEditor(createPromptEditorState(resourcesQuery.data));
+                savePromptMut.reset();
+              }}
+            >
+              <Pencil className="h-3 w-3" />
+              Edit custom prompt
+            </Button>
+          ) : null
+        }
+      >
+        {prompt ? (
+          <pre
+            className="whitespace-pre-wrap text-body"
+            style={{
+              margin: 0,
+              padding: "var(--sp-3) 0",
+              borderBottom: "var(--hairline) solid var(--border-faint)",
+              color: "var(--fg-2)",
+            }}
+          >
+            {prompt}
+          </pre>
+        ) : (
+          <p className="text-body" style={{ color: "var(--fg-4)", margin: 0, padding: "var(--sp-3) 0" }}>
+            No prompt resources enabled.
+          </p>
+        )}
+        {resourceError ? (
+          <p className="text-body" style={{ color: "var(--state-error)", margin: 0, padding: "var(--sp-3) 0" }}>
+            {resourceError}
+          </p>
+        ) : null}
+      </Section>
+      <CustomPromptDialog
+        editor={editor}
+        error={savePromptMut.error instanceof Error ? savePromptMut.error.message : null}
+        saving={savePromptMut.isPending}
+        onOpenChange={(open) => {
+          if (!open) setEditor(null);
+        }}
+        onBodyChange={(body) => setEditor((current) => (current ? { ...current, body } : current))}
+        onSubmit={(body) => savePromptMut.mutate(body)}
+      />
+    </>
+  );
+}
+
+type PromptEditorState = {
+  body: string;
+  target: PromptEditorTarget;
+};
+
+type PromptEditorTarget =
+  | { kind: "update-inline"; bindingIndex: number }
+  | { kind: "convert-binding"; bindingIndex: number }
+  | { kind: "replace-resource"; replacesResourceId: string }
+  | { kind: "add-inline" };
+
+function createPromptEditorState(data: AgentResourcesOutput): PromptEditorState {
+  const existing = findInlinePromptBinding(data.bindings);
+  if (existing) {
+    return {
+      body: existing.binding.inlinePromptBody ?? "",
+      target: { kind: "update-inline", bindingIndex: existing.index },
+    };
+  }
+  const seed = seedFromSingleTeamPrompt(data);
+  return {
+    body: seed.body,
+    target: seed.target,
+  };
+}
+
+function findInlinePromptBinding(
+  bindings: readonly AgentResourceBindingInput[],
+): { binding: AgentResourceBindingInput; index: number } | null {
+  for (let index = 0; index < bindings.length; index++) {
+    const binding = bindings[index];
+    if (!binding) continue;
+    if (binding.type === "prompt" && binding.mode !== "disable" && typeof binding.inlinePromptBody === "string") {
+      return { binding, index };
+    }
+  }
+  return null;
+}
+
+function seedFromSingleTeamPrompt(data: AgentResourcesOutput): { body: string; target: PromptEditorTarget } {
+  const enabledTeamPrompts = data.effective.prompts.filter(
+    (row) => row.mode === "enabled" && row.resourceId && row.source.startsWith("team_") && row.promptBody,
+  );
+  const [row] = enabledTeamPrompts;
+  if (enabledTeamPrompts.length === 1 && row?.resourceId && row.promptBody) {
+    const bindingIndex = row.bindingId ? findBindingIndexById(data.bindings, row.bindingId) : null;
+    return {
+      body: row.promptBody,
+      target:
+        bindingIndex === null
+          ? { kind: "replace-resource", replacesResourceId: row.resourceId }
+          : { kind: "convert-binding", bindingIndex },
+    };
+  }
+  return { body: "", target: { kind: "add-inline" } };
+}
+
+function findBindingIndexById(bindings: readonly AgentResourceBindingInput[], bindingId: string): number | null {
+  const index = bindings.findIndex((binding) => binding.id === bindingId);
+  return index >= 0 ? index : null;
+}
+
+function updatePromptBindings(
+  bindings: readonly AgentResourceBindingInput[],
+  editor: PromptEditorState,
+  body: string,
+): AgentResourceBindingInput[] {
+  const target = editor.target;
+  if (target.kind === "update-inline") {
+    return bindings.map((binding, index) =>
+      index === target.bindingIndex ? { ...binding, inlinePromptBody: body } : binding,
+    );
+  }
+  if (target.kind === "convert-binding") {
+    return bindings.map((binding, index) =>
+      index === target.bindingIndex
+        ? {
+            ...binding,
+            resourceId: null,
+            inlinePromptBody: body,
+            replacesResourceId: binding.mode === "replace" ? binding.replacesResourceId : null,
+          }
+        : binding,
+    );
+  }
+  return [
+    ...bindings,
+    {
+      type: "prompt",
+      mode: target.kind === "replace-resource" ? "replace" : "include",
+      resourceId: null,
+      replacesResourceId: target.kind === "replace-resource" ? target.replacesResourceId : null,
+      inlinePromptBody: body,
+      order: nextOrder(bindings),
+    },
+  ];
+}
+
+function nextOrder(bindings: readonly AgentResourceBindingInput[]): number {
+  return bindings.reduce((max, binding) => Math.max(max, binding.order ?? 0), 0) + 1;
+}
+
+function CustomPromptDialog(props: {
+  editor: PromptEditorState | null;
+  error: string | null;
+  saving: boolean;
+  onOpenChange: (open: boolean) => void;
+  onBodyChange: (body: string) => void;
+  onSubmit: (body: string) => void;
+}) {
+  const [localError, setLocalError] = useState<string | null>(null);
+  const body = props.editor?.body ?? "";
+  const open = props.editor !== null;
+
+  function submit(e: FormEvent) {
+    e.preventDefault();
+    if (!body.trim()) {
+      setLocalError("Prompt body is required.");
+      return;
+    }
+    setLocalError(null);
+    props.onSubmit(body);
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) setLocalError(null);
+        props.onOpenChange(nextOpen);
+      }}
     >
-      {prompt ? (
-        <pre
-          className="whitespace-pre-wrap text-body"
-          style={{
-            margin: 0,
-            padding: "var(--sp-3) 0",
-            borderBottom: "var(--hairline) solid var(--border-faint)",
-            color: "var(--fg-2)",
-          }}
-        >
-          {prompt}
-        </pre>
-      ) : (
-        <p className="text-body" style={{ color: "var(--fg-4)", margin: 0, padding: "var(--sp-3) 0" }}>
-          No prompt resources enabled.
-        </p>
-      )}
-    </Section>
+      <DialogContent aria-describedby={undefined}>
+        <DialogHeader>
+          <DialogTitle>Edit custom prompt</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={submit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="custom-prompt-body">Body</Label>
+            <Textarea
+              id="custom-prompt-body"
+              value={body}
+              onChange={(e) => {
+                setLocalError(null);
+                props.onBodyChange(e.target.value);
+              }}
+              className="min-h-64 font-mono"
+              maxLength={PROMPT_APPEND_MAX_LENGTH}
+              spellCheck={false}
+            />
+            <p className="text-caption m-0" style={{ color: "var(--fg-4)" }}>
+              {body.length.toLocaleString()} / {PROMPT_APPEND_MAX_LENGTH.toLocaleString()}
+            </p>
+          </div>
+          {localError || props.error ? (
+            <p className="text-body" style={{ color: "var(--state-error)" }}>
+              {localError ?? props.error}
+            </p>
+          ) : null}
+          <DialogFooter>
+            <Button type="button" variant="ghost" onClick={() => props.onOpenChange(false)} disabled={props.saving}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={props.saving}>
+              {props.saving ? "Saving..." : "Save prompt"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
   );
 }


### PR DESCRIPTION
## Summary
- keep the agent Prompt tab edit flow on the Prompt tab instead of routing to Resources
- edit agent inline prompt bindings directly through Agent Resources
- seed or convert custom prompt edits from the current prompt resource when applicable
- update the agent detail DOM test to cover inline custom prompt editing

## Review
- codex-reviewer: LGTM / no findings

## Verification
- `pnpm --dir packages/web exec vitest run src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx --maxWorkers=2`
- `pnpm check && pnpm typecheck`