### PR TITLE
fix(web): edit custom prompt inline

### DIFF
--- a/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
@@ -395,12 +395,13 @@ describe("AgentDetailPage", () => {
     expect(container.textContent).toContain("Always explain tradeoffs.");
 
     await click(exactButtonByText(container, "Edit custom prompt"));
-    await waitForText(document.body, "Save prompt");
-    const textarea = document.body.querySelector<HTMLTextAreaElement>("#custom-prompt-body");
+    await waitForText(container, "Save prompt");
+    const textarea = container.querySelector<HTMLTextAreaElement>("#custom-prompt-body");
     expect(textarea?.value).toBe("Always explain tradeoffs.");
+    expect(textarea?.style.minHeight).toBe("16rem");
     if (!textarea) throw new Error("Expected custom prompt textarea");
     await setValue(textarea, "Prefer concise answers.");
-    await click(exactButtonByText(document.body, "Save prompt"));
+    await click(exactButtonByText(container, "Save prompt"));
     await waitForCondition(
       () => agentResourceMocks.updateAgentResources.mock.calls.length > 0,
       "Expected prompt resource update",
@@ -455,12 +456,12 @@ describe("AgentDetailPage", () => {
     const { container, root } = await renderDom("/agents/agent-1/prompt", <PromptTab />);
     await waitForText(container, "Effective prompt");
     await click(exactButtonByText(container, "Edit custom prompt"));
-    await waitForText(document.body, "Save prompt");
-    const textarea = document.body.querySelector<HTMLTextAreaElement>("#custom-prompt-body");
+    await waitForText(container, "Save prompt");
+    const textarea = container.querySelector<HTMLTextAreaElement>("#custom-prompt-body");
     expect(textarea?.value).toBe("Use the team style guide.");
     if (!textarea) throw new Error("Expected custom prompt textarea");
     await setValue(textarea, "Use the agent-specific style guide.");
-    await click(exactButtonByText(document.body, "Save prompt"));
+    await click(exactButtonByText(container, "Save prompt"));
     await waitForCondition(
       () => agentResourceMocks.updateAgentResources.mock.calls.length > 0,
       "Expected prompt resource update",
@@ -523,12 +524,12 @@ describe("AgentDetailPage", () => {
     const { container, root } = await renderDom("/agents/agent-1/prompt", <PromptTab />);
     await waitForText(container, "Effective prompt");
     await click(exactButtonByText(container, "Edit custom prompt"));
-    await waitForText(document.body, "Save prompt");
-    const textarea = document.body.querySelector<HTMLTextAreaElement>("#custom-prompt-body");
+    await waitForText(container, "Save prompt");
+    const textarea = container.querySelector<HTMLTextAreaElement>("#custom-prompt-body");
     expect(textarea?.value).toBe("Use the team style guide.");
     if (!textarea) throw new Error("Expected custom prompt textarea");
     await setValue(textarea, "Use the agent-specific style guide.");
-    await click(exactButtonByText(document.body, "Save prompt"));
+    await click(exactButtonByText(container, "Save prompt"));
     await waitForCondition(
       () => agentResourceMocks.updateAgentResources.mock.calls.length > 0,
       "Expected prompt resource update",
@@ -567,23 +568,23 @@ describe("AgentDetailPage", () => {
     const { container, root } = await renderDom("/agents/agent-1/prompt", <PromptTab />);
     await waitForText(container, "No prompt resources enabled.");
     await click(exactButtonByText(container, "Edit custom prompt"));
-    await waitForText(document.body, "Save prompt");
-    await click(exactButtonByText(document.body, "Save prompt"));
-    await waitForText(document.body, "Prompt body is required.");
-    await click(exactButtonByText(document.body, "Cancel"));
+    await waitForText(container, "Save prompt");
+    await click(exactButtonByText(container, "Save prompt"));
+    await waitForText(container, "Prompt body is required.");
+    await click(exactButtonByText(container, "Cancel"));
     await waitForCondition(
-      () => !document.body.textContent?.includes("Prompt body is required."),
+      () => !container.textContent?.includes("Prompt body is required."),
       "Expected prompt body validation error to clear",
     );
 
     await click(exactButtonByText(container, "Edit custom prompt"));
-    await waitForText(document.body, "Save prompt");
-    expect(document.body.textContent).not.toContain("Prompt body is required.");
-    const textarea = document.body.querySelector<HTMLTextAreaElement>("#custom-prompt-body");
+    await waitForText(container, "Save prompt");
+    expect(container.textContent).not.toContain("Prompt body is required.");
+    const textarea = container.querySelector<HTMLTextAreaElement>("#custom-prompt-body");
     expect(textarea?.value).toBe("");
     if (!textarea) throw new Error("Expected custom prompt textarea");
     await setValue(textarea, "Prefer concise answers.");
-    await click(exactButtonByText(document.body, "Save prompt"));
+    await click(exactButtonByText(container, "Save prompt"));
     await waitForCondition(
       () => agentResourceMocks.updateAgentResources.mock.calls.length > 0,
       "Expected prompt resource update",

--- a/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
@@ -377,8 +377,33 @@ afterEach(() => {
 });
 
 describe("AgentDetailPage", () => {
-  it("renders the effective prompt and edits the custom prompt inline", async () => {
+  it("renders prompt resource blocks and edits the custom prompt inline", async () => {
     const { PromptTab } = await import("../prompt-tab.js");
+    agentResourceMocks.getAgentResources.mockResolvedValueOnce(
+      agentResources({
+        effective: {
+          version: 7,
+          repos: [],
+          prompts: [
+            effectivePrompt({
+              id: "resource:team-prompt-1",
+              bindingId: null,
+              resourceId: "team-prompt-1",
+              name: "Team style guide",
+              scope: "team",
+              source: "team_recommended",
+              defaultEnabled: "recommended",
+              promptBody: "Use the team style guide.",
+              order: 0,
+            }),
+            effectivePrompt(),
+          ],
+          skills: [],
+          mcp: [],
+          unavailable: [],
+        },
+      }),
+    );
 
     const { container, root } = await renderDom("/agents/agent-1/prompt", <PromptTab />);
     await waitForText(container, "Effective prompt");
@@ -393,9 +418,14 @@ describe("AgentDetailPage", () => {
       "Usage",
     ]);
     expect(container.textContent).toContain("Always explain tradeoffs.");
+    await waitForText(container, "Team Resource: Team style guide");
+    expect(container.textContent).toContain("Use the team style guide.");
+    expect(container.textContent).toContain("Agent Resource: inline prompt");
 
     await click(exactButtonByText(container, "Edit custom prompt"));
     await waitForText(container, "Save prompt");
+    expect(container.textContent).toContain("Team Resource: Team style guide");
+    expect(container.textContent).toContain("Use the team style guide.");
     const textarea = container.querySelector<HTMLTextAreaElement>("#custom-prompt-body");
     expect(textarea?.value).toBe("Always explain tradeoffs.");
     expect(textarea?.style.minHeight).toBe("16rem");
@@ -455,7 +485,7 @@ describe("AgentDetailPage", () => {
 
     const { container, root } = await renderDom("/agents/agent-1/prompt", <PromptTab />);
     await waitForText(container, "Effective prompt");
-    await click(exactButtonByText(container, "Edit custom prompt"));
+    await click(exactButtonByText(container, "Customize for this agent"));
     await waitForText(container, "Save prompt");
     const textarea = container.querySelector<HTMLTextAreaElement>("#custom-prompt-body");
     expect(textarea?.value).toBe("Use the team style guide.");
@@ -523,7 +553,7 @@ describe("AgentDetailPage", () => {
 
     const { container, root } = await renderDom("/agents/agent-1/prompt", <PromptTab />);
     await waitForText(container, "Effective prompt");
-    await click(exactButtonByText(container, "Edit custom prompt"));
+    await click(exactButtonByText(container, "Customize for this agent"));
     await waitForText(container, "Save prompt");
     const textarea = container.querySelector<HTMLTextAreaElement>("#custom-prompt-body");
     expect(textarea?.value).toBe("Use the team style guide.");
@@ -567,7 +597,7 @@ describe("AgentDetailPage", () => {
 
     const { container, root } = await renderDom("/agents/agent-1/prompt", <PromptTab />);
     await waitForText(container, "No prompt resources enabled.");
-    await click(exactButtonByText(container, "Edit custom prompt"));
+    await click(exactButtonByText(container, "Add custom prompt"));
     await waitForText(container, "Save prompt");
     await click(exactButtonByText(container, "Save prompt"));
     await waitForText(container, "Prompt body is required.");
@@ -577,7 +607,7 @@ describe("AgentDetailPage", () => {
       "Expected prompt body validation error to clear",
     );
 
-    await click(exactButtonByText(container, "Edit custom prompt"));
+    await click(exactButtonByText(container, "Add custom prompt"));
     await waitForText(container, "Save prompt");
     expect(container.textContent).not.toContain("Prompt body is required.");
     const textarea = container.querySelector<HTMLTextAreaElement>("#custom-prompt-body");

--- a/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
@@ -455,6 +455,85 @@ describe("AgentDetailPage", () => {
     await act(async () => root.unmount());
   });
 
+  it("keeps the edit entry visible when an inline prompt binding has an empty body", async () => {
+    const { PromptTab } = await import("../prompt-tab.js");
+    agentResourceMocks.getAgentResources.mockResolvedValueOnce(
+      agentResources({
+        effective: {
+          version: 7,
+          repos: [],
+          prompts: [
+            effectivePrompt({
+              id: "resource:team-prompt-1",
+              bindingId: null,
+              resourceId: "team-prompt-1",
+              name: "Team style guide",
+              scope: "team",
+              source: "team_recommended",
+              defaultEnabled: "recommended",
+              promptBody: "Use the team style guide.",
+              order: 0,
+            }),
+            effectivePrompt({
+              id: "binding:inline-1:enabled",
+              bindingId: "inline-1",
+              promptBody: "",
+              order: 1,
+            }),
+          ],
+          skills: [],
+          mcp: [],
+          unavailable: [],
+        },
+        bindings: [
+          {
+            id: "inline-1",
+            type: "prompt",
+            mode: "include",
+            resourceId: null,
+            replacesResourceId: null,
+            inlinePromptBody: "",
+            order: 1,
+          },
+        ],
+      }),
+    );
+
+    const { container, root } = await renderDom("/agents/agent-1/prompt", <PromptTab />);
+    await waitForText(container, "Team Resource: Team style guide");
+    await waitForText(container, "Agent Resource: custom prompt");
+    expect(container.textContent).toContain("No prompt body.");
+
+    await click(exactButtonByText(container, "Edit custom prompt"));
+    await waitForText(container, "Save prompt");
+    expect(container.textContent).toContain("Use the team style guide.");
+    const textarea = container.querySelector<HTMLTextAreaElement>("#custom-prompt-body");
+    expect(textarea?.value).toBe("");
+    if (!textarea) throw new Error("Expected custom prompt textarea");
+    await setValue(textarea, "Recovered custom prompt.");
+    await click(exactButtonByText(container, "Save prompt"));
+    await waitForCondition(
+      () => agentResourceMocks.updateAgentResources.mock.calls.length > 0,
+      "Expected prompt resource update",
+    );
+    expect(agentResourceMocks.updateAgentResources).toHaveBeenCalledWith("agent-1", {
+      expectedVersion: 7,
+      bindings: [
+        {
+          id: "inline-1",
+          type: "prompt",
+          mode: "include",
+          resourceId: null,
+          replacesResourceId: null,
+          inlinePromptBody: "Recovered custom prompt.",
+          order: 1,
+        },
+      ],
+    });
+
+    await act(async () => root.unmount());
+  });
+
   it("creates an inline replacement when editing a recommended team prompt", async () => {
     const { PromptTab } = await import("../prompt-tab.js");
     agentResourceMocks.getAgentResources.mockResolvedValueOnce(

--- a/packages/web/src/pages/agent-detail/prompt-tab.tsx
+++ b/packages/web/src/pages/agent-detail/prompt-tab.tsx
@@ -5,7 +5,7 @@ import {
 } from "@first-tree/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Pencil } from "lucide-react";
-import { type FormEvent, useEffect, useRef, useState } from "react";
+import { type FormEvent, type ReactNode, useEffect, useRef, useState } from "react";
 import { Navigate } from "react-router";
 import { getAgentResources, updateAgentResources } from "../../api/agent-resources.js";
 import { Button } from "../../components/ui/button.js";
@@ -42,59 +42,37 @@ export function PromptTab() {
   const prompt = ctx.config?.payload.prompt.append ?? "";
   const canEditPrompt = ctx.canManageAgent && ctx.agent.status === "active";
   const resourceError = resourcesQuery.error instanceof Error ? resourcesQuery.error.message : null;
+  const resources = resourcesQuery.data;
+  const editorError = savePromptMut.error instanceof Error ? savePromptMut.error.message : null;
+
+  function openPromptEditor() {
+    if (!resources) return;
+    savePromptMut.reset();
+    setEditor(createPromptEditorState(resources));
+  }
+
+  function closePromptEditor() {
+    savePromptMut.reset();
+    setEditor(null);
+  }
+
   return (
-    <Section
-      title="Effective prompt"
-      description="Resolved from Team and Agent prompt resources."
-      action={
-        canEditPrompt && !editor ? (
-          <Button
-            type="button"
-            size="xs"
-            variant="outline"
-            disabled={resourcesQuery.isLoading || !!resourceError}
-            onClick={() => {
-              if (!resourcesQuery.data) return;
-              setEditor(createPromptEditorState(resourcesQuery.data));
-              savePromptMut.reset();
-            }}
-          >
-            <Pencil className="h-3 w-3" />
-            Edit custom prompt
-          </Button>
-        ) : null
-      }
-    >
+    <Section title="Effective prompt" description="Resolved from Team and Agent prompt resources.">
       <div style={{ padding: "var(--sp-3) 0", borderBottom: "var(--hairline) solid var(--border-faint)" }}>
-        {editor ? (
-          <InlineCustomPromptEditor
-            body={editor.body}
-            error={savePromptMut.error instanceof Error ? savePromptMut.error.message : null}
+        {resources ? (
+          <PromptResourceBlocks
+            data={resources}
+            editor={editor}
+            error={editorError}
             saving={savePromptMut.isPending}
+            canEdit={canEditPrompt && !resourceError}
+            onStartEdit={openPromptEditor}
             onBodyChange={(body) => setEditor((current) => (current ? { ...current, body } : current))}
-            onCancel={() => {
-              savePromptMut.reset();
-              setEditor(null);
-            }}
+            onCancel={closePromptEditor}
             onSubmit={(body) => savePromptMut.mutate(body)}
           />
         ) : (
-          <div
-            className="text-body"
-            style={{
-              minHeight: prompt ? "10rem" : undefined,
-              border: "var(--hairline) solid var(--border-faint)",
-              borderRadius: "var(--radius-panel)",
-              background: prompt ? "var(--bg)" : "var(--bg-sunken)",
-              padding: "var(--sp-3)",
-            }}
-          >
-            {prompt ? (
-              <Markdown>{prompt}</Markdown>
-            ) : (
-              <span className="text-muted-foreground">No prompt resources enabled.</span>
-            )}
-          </div>
+          <PromptFallbackPanel prompt={prompt} />
         )}
       </div>
       {resourceError ? (
@@ -110,6 +88,8 @@ type PromptEditorState = {
   body: string;
   target: PromptEditorTarget;
 };
+
+type EffectivePromptRow = AgentResourcesOutput["effective"]["prompts"][number];
 
 type PromptEditorTarget =
   | { kind: "update-inline"; bindingIndex: number }
@@ -218,6 +198,174 @@ function convertPromptBindingToInline(
 
 function nextOrder(bindings: readonly AgentResourceBindingInput[]): number {
   return bindings.reduce((max, binding) => Math.max(max, binding.order ?? 0), 0) + 1;
+}
+
+function PromptResourceBlocks(props: {
+  data: AgentResourcesOutput;
+  editor: PromptEditorState | null;
+  error: string | null;
+  saving: boolean;
+  canEdit: boolean;
+  onStartEdit: () => void;
+  onBodyChange: (body: string) => void;
+  onCancel: () => void;
+  onSubmit: (body: string) => void;
+}) {
+  const rows = enabledPromptRows(props.data);
+  const inlineBinding = findInlinePromptBinding(props.data.bindings);
+  const editableBindingId = inlineBinding?.binding.id ?? null;
+  const singleTeamPrompt = findSingleEnabledTeamPrompt(props.data);
+  const editorIsInline = props.editor?.target.kind === "update-inline";
+  const editorNeedsAgentBlock = props.editor !== null && !editorIsInline;
+  const shouldShowCustomPlaceholder =
+    !props.editor && props.canEdit && !editableBindingId && (rows.length === 0 || !singleTeamPrompt);
+  const blocks: ReactNode[] = rows.map((row, index) => {
+    const isEditableInlineRow = !!row.bindingId && row.bindingId === editableBindingId;
+    const isEditingRow = !!props.editor && editorIsInline && isEditableInlineRow;
+    const action =
+      props.canEdit && !props.editor && isEditableInlineRow ? (
+        <PromptBlockAction label="Edit custom prompt" onClick={props.onStartEdit} />
+      ) : props.canEdit && !props.editor && !editableBindingId && singleTeamPrompt?.id === row.id ? (
+        <PromptBlockAction label="Customize for this agent" onClick={props.onStartEdit} />
+      ) : null;
+
+    return (
+      <PromptResourceBlock key={row.id} title={promptResourceTitle(row)} action={action} separated={index > 0}>
+        {isEditingRow && props.editor ? (
+          <InlineCustomPromptEditor
+            body={props.editor.body}
+            error={props.error}
+            saving={props.saving}
+            onBodyChange={props.onBodyChange}
+            onCancel={props.onCancel}
+            onSubmit={props.onSubmit}
+          />
+        ) : (
+          <PromptBody body={row.promptBody ?? ""} />
+        )}
+      </PromptResourceBlock>
+    );
+  });
+
+  if (editorNeedsAgentBlock && props.editor) {
+    blocks.push(
+      <PromptResourceBlock
+        key="agent-custom-editor"
+        title="Agent Resource: custom prompt"
+        separated={blocks.length > 0}
+      >
+        <InlineCustomPromptEditor
+          body={props.editor.body}
+          error={props.error}
+          saving={props.saving}
+          onBodyChange={props.onBodyChange}
+          onCancel={props.onCancel}
+          onSubmit={props.onSubmit}
+        />
+      </PromptResourceBlock>,
+    );
+  } else if (shouldShowCustomPlaceholder) {
+    blocks.push(
+      <PromptResourceBlock
+        key="agent-custom-placeholder"
+        title="Agent Resource: custom prompt"
+        action={<PromptBlockAction label="Add custom prompt" onClick={props.onStartEdit} />}
+        separated={blocks.length > 0}
+      >
+        <span className="text-muted-foreground">
+          {rows.length === 0 ? "No prompt resources enabled." : "No custom prompt yet."}
+        </span>
+      </PromptResourceBlock>,
+    );
+  }
+
+  return (
+    <PromptPanel>
+      {blocks.length > 0 ? blocks : <span className="text-muted-foreground">No prompt resources enabled.</span>}
+    </PromptPanel>
+  );
+}
+
+function PromptFallbackPanel(props: { prompt: string }) {
+  return (
+    <PromptPanel minHeight={props.prompt ? "10rem" : undefined} sunken={!props.prompt}>
+      {props.prompt ? (
+        <Markdown>{props.prompt}</Markdown>
+      ) : (
+        <span className="text-muted-foreground">No prompt resources enabled.</span>
+      )}
+    </PromptPanel>
+  );
+}
+
+function PromptPanel(props: { children: ReactNode; minHeight?: string; sunken?: boolean }) {
+  return (
+    <div
+      className="text-body"
+      style={{
+        minHeight: props.minHeight,
+        border: "var(--hairline) solid var(--border-faint)",
+        borderRadius: "var(--radius-panel)",
+        background: props.sunken ? "var(--bg-sunken)" : "var(--bg)",
+        padding: "var(--sp-3)",
+      }}
+    >
+      {props.children}
+    </div>
+  );
+}
+
+function PromptResourceBlock(props: { title: string; action?: ReactNode; children: ReactNode; separated?: boolean }) {
+  return (
+    <div
+      style={{
+        paddingTop: props.separated ? "var(--sp-3)" : undefined,
+        marginTop: props.separated ? "var(--sp-3)" : undefined,
+        borderTop: props.separated ? "var(--hairline) solid var(--border-faint)" : undefined,
+      }}
+    >
+      <div
+        className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between"
+        style={{ marginBottom: "var(--sp-2)" }}
+      >
+        <h3 className="text-subtitle m-0">{props.title}</h3>
+        {props.action}
+      </div>
+      {props.children}
+    </div>
+  );
+}
+
+function PromptBlockAction(props: { label: string; onClick: () => void }) {
+  return (
+    <Button type="button" size="xs" variant="outline" onClick={props.onClick}>
+      <Pencil className="h-3 w-3" />
+      {props.label}
+    </Button>
+  );
+}
+
+function PromptBody(props: { body: string }) {
+  return props.body ? (
+    <Markdown>{props.body}</Markdown>
+  ) : (
+    <span className="text-muted-foreground">No prompt body.</span>
+  );
+}
+
+function enabledPromptRows(data: AgentResourcesOutput): EffectivePromptRow[] {
+  return data.effective.prompts.filter((row) => row.mode === "enabled" && !!row.promptBody);
+}
+
+function findSingleEnabledTeamPrompt(data: AgentResourcesOutput): EffectivePromptRow | null {
+  const rows = enabledPromptRows(data).filter((row) => row.resourceId && row.source.startsWith("team_"));
+  return rows.length === 1 ? (rows[0] ?? null) : null;
+}
+
+function promptResourceTitle(row: EffectivePromptRow): string {
+  if (row.source.startsWith("team_")) return `Team Resource: ${row.name}`;
+  if (row.source === "inline_prompt") return "Agent Resource: inline prompt";
+  return `Agent Resource: ${row.name}`;
 }
 
 function InlineCustomPromptEditor(props: {

--- a/packages/web/src/pages/agent-detail/prompt-tab.tsx
+++ b/packages/web/src/pages/agent-detail/prompt-tab.tsx
@@ -5,12 +5,11 @@ import {
 } from "@first-tree/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Pencil } from "lucide-react";
-import { type FormEvent, useState } from "react";
+import { type FormEvent, useEffect, useRef, useState } from "react";
 import { Navigate } from "react-router";
 import { getAgentResources, updateAgentResources } from "../../api/agent-resources.js";
 import { Button } from "../../components/ui/button.js";
-import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "../../components/ui/dialog.js";
-import { Label } from "../../components/ui/label.js";
+import { Markdown } from "../../components/ui/markdown.js";
 import { Section } from "../../components/ui/section.js";
 import { Textarea } from "../../components/ui/textarea.js";
 import { useAgentDetailContext } from "./layout-context.js";
@@ -44,63 +43,66 @@ export function PromptTab() {
   const canEditPrompt = ctx.canManageAgent && ctx.agent.status === "active";
   const resourceError = resourcesQuery.error instanceof Error ? resourcesQuery.error.message : null;
   return (
-    <>
-      <Section
-        title="Effective prompt"
-        description="Resolved from Team and Agent prompt resources."
-        action={
-          canEditPrompt ? (
-            <Button
-              type="button"
-              size="xs"
-              variant="outline"
-              disabled={resourcesQuery.isLoading || !!resourceError}
-              onClick={() => {
-                if (!resourcesQuery.data) return;
-                setEditor(createPromptEditorState(resourcesQuery.data));
-                savePromptMut.reset();
-              }}
-            >
-              <Pencil className="h-3 w-3" />
-              Edit custom prompt
-            </Button>
-          ) : null
-        }
-      >
-        {prompt ? (
-          <pre
-            className="whitespace-pre-wrap text-body"
-            style={{
-              margin: 0,
-              padding: "var(--sp-3) 0",
-              borderBottom: "var(--hairline) solid var(--border-faint)",
-              color: "var(--fg-2)",
+    <Section
+      title="Effective prompt"
+      description="Resolved from Team and Agent prompt resources."
+      action={
+        canEditPrompt && !editor ? (
+          <Button
+            type="button"
+            size="xs"
+            variant="outline"
+            disabled={resourcesQuery.isLoading || !!resourceError}
+            onClick={() => {
+              if (!resourcesQuery.data) return;
+              setEditor(createPromptEditorState(resourcesQuery.data));
+              savePromptMut.reset();
             }}
           >
-            {prompt}
-          </pre>
+            <Pencil className="h-3 w-3" />
+            Edit custom prompt
+          </Button>
+        ) : null
+      }
+    >
+      <div style={{ padding: "var(--sp-3) 0", borderBottom: "var(--hairline) solid var(--border-faint)" }}>
+        {editor ? (
+          <InlineCustomPromptEditor
+            body={editor.body}
+            error={savePromptMut.error instanceof Error ? savePromptMut.error.message : null}
+            saving={savePromptMut.isPending}
+            onBodyChange={(body) => setEditor((current) => (current ? { ...current, body } : current))}
+            onCancel={() => {
+              savePromptMut.reset();
+              setEditor(null);
+            }}
+            onSubmit={(body) => savePromptMut.mutate(body)}
+          />
         ) : (
-          <p className="text-body" style={{ color: "var(--fg-4)", margin: 0, padding: "var(--sp-3) 0" }}>
-            No prompt resources enabled.
-          </p>
+          <div
+            className="text-body"
+            style={{
+              minHeight: prompt ? "10rem" : undefined,
+              border: "var(--hairline) solid var(--border-faint)",
+              borderRadius: "var(--radius-panel)",
+              background: prompt ? "var(--bg)" : "var(--bg-sunken)",
+              padding: "var(--sp-3)",
+            }}
+          >
+            {prompt ? (
+              <Markdown>{prompt}</Markdown>
+            ) : (
+              <span className="text-muted-foreground">No prompt resources enabled.</span>
+            )}
+          </div>
         )}
-        {resourceError ? (
-          <p className="text-body" style={{ color: "var(--state-error)", margin: 0, padding: "var(--sp-3) 0" }}>
-            {resourceError}
-          </p>
-        ) : null}
-      </Section>
-      <CustomPromptDialog
-        editor={editor}
-        error={savePromptMut.error instanceof Error ? savePromptMut.error.message : null}
-        saving={savePromptMut.isPending}
-        onOpenChange={(open) => {
-          if (!open) setEditor(null);
-        }}
-        onBodyChange={(body) => setEditor((current) => (current ? { ...current, body } : current))}
-        onSubmit={(body) => savePromptMut.mutate(body)}
-      />
-    </>
+      </div>
+      {resourceError ? (
+        <p className="text-body" style={{ color: "var(--state-error)", margin: 0, padding: "var(--sp-3) 0" }}>
+          {resourceError}
+        </p>
+      ) : null}
+    </Section>
   );
 }
 
@@ -218,81 +220,93 @@ function nextOrder(bindings: readonly AgentResourceBindingInput[]): number {
   return bindings.reduce((max, binding) => Math.max(max, binding.order ?? 0), 0) + 1;
 }
 
-function CustomPromptDialog(props: {
-  editor: PromptEditorState | null;
+function InlineCustomPromptEditor(props: {
+  body: string;
   error: string | null;
   saving: boolean;
-  onOpenChange: (open: boolean) => void;
   onBodyChange: (body: string) => void;
+  onCancel: () => void;
   onSubmit: (body: string) => void;
 }) {
   const [localError, setLocalError] = useState<string | null>(null);
-  const body = props.editor?.body ?? "";
-  const open = props.editor !== null;
+  const taRef = useRef<HTMLTextAreaElement | null>(null);
+  const countLabel = `${props.body.length.toLocaleString()} / ${PROMPT_APPEND_MAX_LENGTH.toLocaleString()}`;
 
-  function close() {
-    setLocalError(null);
-    props.onOpenChange(false);
-  }
+  useEffect(() => {
+    const ta = taRef.current;
+    if (!ta) return;
+    ta.focus();
+    ta.setSelectionRange(ta.value.length, ta.value.length);
+    resizeTextarea(ta);
+  }, []);
 
   function submit(e: FormEvent) {
     e.preventDefault();
-    if (!body.trim()) {
+    if (!props.body.trim()) {
       setLocalError("Prompt body is required.");
       return;
     }
     setLocalError(null);
-    props.onSubmit(body);
+    props.onSubmit(props.body);
   }
 
   return (
-    <Dialog
-      open={open}
-      onOpenChange={(nextOpen) => {
-        if (nextOpen) {
-          props.onOpenChange(true);
-        } else {
-          close();
-        }
-      }}
-    >
-      <DialogContent aria-describedby={undefined}>
-        <DialogHeader>
-          <DialogTitle>Edit custom prompt</DialogTitle>
-        </DialogHeader>
-        <form onSubmit={submit} className="space-y-4">
-          <div className="space-y-2">
-            <Label htmlFor="custom-prompt-body">Body</Label>
-            <Textarea
-              id="custom-prompt-body"
-              value={body}
-              onChange={(e) => {
-                setLocalError(null);
-                props.onBodyChange(e.target.value);
-              }}
-              className="min-h-64 font-mono"
-              maxLength={PROMPT_APPEND_MAX_LENGTH}
-              spellCheck={false}
-            />
-            <p className="text-caption m-0" style={{ color: "var(--fg-4)" }}>
-              {body.length.toLocaleString()} / {PROMPT_APPEND_MAX_LENGTH.toLocaleString()}
-            </p>
-          </div>
-          {localError || props.error ? (
-            <p className="text-body" style={{ color: "var(--state-error)" }}>
-              {localError ?? props.error}
-            </p>
-          ) : null}
-          <DialogFooter>
-            <Button type="button" variant="ghost" onClick={close} disabled={props.saving}>
-              Cancel
-            </Button>
-            <Button type="submit" disabled={props.saving}>
-              {props.saving ? "Saving..." : "Save prompt"}
-            </Button>
-          </DialogFooter>
-        </form>
-      </DialogContent>
-    </Dialog>
+    <form onSubmit={submit} className="space-y-2">
+      <Textarea
+        id="custom-prompt-body"
+        ref={taRef}
+        value={props.body}
+        onChange={(e) => {
+          setLocalError(null);
+          props.onBodyChange(e.target.value);
+          resizeTextarea(e.currentTarget);
+        }}
+        onKeyDown={(e) => {
+          if (e.key === "Escape") {
+            e.preventDefault();
+            setLocalError(null);
+            props.onCancel();
+          }
+        }}
+        className="resize-none overflow-hidden font-mono"
+        style={{ minHeight: "16rem" }}
+        placeholder="Add persistent instructions for how this agent should behave."
+        maxLength={PROMPT_APPEND_MAX_LENGTH}
+        spellCheck={false}
+        disabled={props.saving}
+      />
+      {localError || props.error ? (
+        <p className="text-body" style={{ color: "var(--state-error)" }}>
+          {localError ?? props.error}
+        </p>
+      ) : null}
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <p className="text-caption m-0" style={{ color: "var(--fg-4)" }}>
+          {countLabel}
+        </p>
+        <div className="flex justify-end gap-2">
+          <Button
+            type="button"
+            size="xs"
+            variant="ghost"
+            onClick={() => {
+              setLocalError(null);
+              props.onCancel();
+            }}
+            disabled={props.saving}
+          >
+            Cancel
+          </Button>
+          <Button type="submit" size="xs" variant="outline" disabled={props.saving}>
+            {props.saving ? "Saving..." : "Save prompt"}
+          </Button>
+        </div>
+      </div>
+    </form>
   );
+}
+
+function resizeTextarea(textarea: HTMLTextAreaElement) {
+  textarea.style.height = "auto";
+  textarea.style.height = `${textarea.scrollHeight}px`;
 }

--- a/packages/web/src/pages/agent-detail/prompt-tab.tsx
+++ b/packages/web/src/pages/agent-detail/prompt-tab.tsx
@@ -214,11 +214,15 @@ function PromptResourceBlocks(props: {
   const rows = enabledPromptRows(props.data);
   const inlineBinding = findInlinePromptBinding(props.data.bindings);
   const editableBindingId = inlineBinding?.binding.id ?? null;
+  const editableInlineRowExists = !!editableBindingId && rows.some((row) => row.bindingId === editableBindingId);
+  const hasHiddenInlineBinding = !!editableBindingId && !editableInlineRowExists;
   const singleTeamPrompt = findSingleEnabledTeamPrompt(props.data);
-  const editorIsInline = props.editor?.target.kind === "update-inline";
+  const editorIsInline = props.editor?.target.kind === "update-inline" && editableInlineRowExists;
   const editorNeedsAgentBlock = props.editor !== null && !editorIsInline;
   const shouldShowCustomPlaceholder =
-    !props.editor && props.canEdit && !editableBindingId && (rows.length === 0 || !singleTeamPrompt);
+    !props.editor &&
+    props.canEdit &&
+    (hasHiddenInlineBinding || (!editableBindingId && (rows.length === 0 || !singleTeamPrompt)));
   const blocks: ReactNode[] = rows.map((row, index) => {
     const isEditableInlineRow = !!row.bindingId && row.bindingId === editableBindingId;
     const isEditingRow = !!props.editor && editorIsInline && isEditableInlineRow;
@@ -269,11 +273,20 @@ function PromptResourceBlocks(props: {
       <PromptResourceBlock
         key="agent-custom-placeholder"
         title="Agent Resource: custom prompt"
-        action={<PromptBlockAction label="Add custom prompt" onClick={props.onStartEdit} />}
+        action={
+          <PromptBlockAction
+            label={hasHiddenInlineBinding ? "Edit custom prompt" : "Add custom prompt"}
+            onClick={props.onStartEdit}
+          />
+        }
         separated={blocks.length > 0}
       >
         <span className="text-muted-foreground">
-          {rows.length === 0 ? "No prompt resources enabled." : "No custom prompt yet."}
+          {hasHiddenInlineBinding
+            ? "No prompt body."
+            : rows.length === 0
+              ? "No prompt resources enabled."
+              : "No custom prompt yet."}
         </span>
       </PromptResourceBlock>,
     );


### PR DESCRIPTION
## Summary
- render the effective prompt as prompt resource blocks so team/org prompts and agent custom prompts stay visible together
- keep custom prompt editing inline and scoped to the agent custom prompt block, preserving the PR #800 save semantics for update/replace/add prompt bindings
- keep the edit entry available for the defensive empty-inline-body case and save back to the existing inline binding
- update DOM tests for resource block rendering, inline editor placement, binding update paths, and the empty inline fallback

## Review
- codex-reviewer: LGTM / no findings
- GitHub re-review for `3a7e2ca2`: approved; the low-severity empty inline prompt note has been addressed in `c6133e3e`

## Verification
- `pnpm --dir packages/web exec vitest run src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx --maxWorkers=2`
- `pnpm check`
- `pnpm typecheck`
- `git diff --check`

Note: the targeted happy-dom test still emits the existing teardown AbortError noise, but the suite passes.
