### PR TITLE
feat: source onboarding connect-code picker from the team's installation repos

### DIFF
--- a/packages/server/src/__tests__/github-app-repositories.test.ts
+++ b/packages/server/src/__tests__/github-app-repositories.test.ts
@@ -1,0 +1,155 @@
+import { generateKeyPairSync } from "node:crypto";
+import { eq } from "drizzle-orm";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { members } from "../db/schema/members.js";
+import { users } from "../db/schema/users.js";
+import { bindInstallationToOrg, upsertInstallationFromMetadata } from "../services/github-app-installations.js";
+import { createTestAdmin, useTestApp } from "./helpers.js";
+
+// A real RSA key so `createAppJwt` (which mints the installation token) can
+// actually sign — the helpers' default `privateKeyPem` is deliberate junk.
+const { privateKey: TEST_APP_PRIVATE_KEY_PEM } = generateKeyPairSync("rsa", {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: "spki", format: "pem" },
+  privateKeyEncoding: { type: "pkcs8", format: "pem" },
+});
+
+/**
+ * `GET /orgs/:orgId/github-app-installation/repositories` — member-readable
+ * list of the repos the team's GitHub App installation can access. Powers
+ * the onboarding admin connect-code project picker.
+ *
+ * The product is team-by-default, so the picker offers the team's *org*
+ * code (the installation's grant) rather than the admin's personal
+ * `/user/repos` — personal repos drop out and we only ever surface repos
+ * the agent can actually reach.
+ */
+describe("GET /orgs/:orgId/github-app-installation/repositories", () => {
+  const getApp = useTestApp({ githubAppPrivateKeyPem: TEST_APP_PRIVATE_KEY_PEM });
+
+  async function seedInstallation(app: ReturnType<typeof getApp>, orgId: string, installationId: number) {
+    await upsertInstallationFromMetadata(app.db, {
+      installation: {
+        id: installationId,
+        accountType: "Organization",
+        accountLogin: `org-${installationId}`,
+        accountGithubId: installationId * 10,
+        permissions: { contents: "read" },
+        events: [],
+        suspendedAt: null,
+      },
+    });
+    await bindInstallationToOrg(app.db, installationId, orgId);
+  }
+
+  /**
+   * Stub `globalThis.fetch` for the two GitHub round-trips this route makes:
+   * mint an installation token, then list `/installation/repositories`.
+   * Anything else falls through to the real fetch.
+   */
+  type FetchInput = Parameters<typeof globalThis.fetch>[0];
+  type FetchInit = Parameters<typeof globalThis.fetch>[1];
+  function stubGithub(repositories: Array<{ full_name: string; pushed_at: string | null }>): () => void {
+    const original = globalThis.fetch;
+    const spy = vi.fn(async (input: FetchInput, init?: FetchInit): Promise<Response> => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      if (/\/app\/installations\/\d+\/access_tokens$/.test(url)) {
+        return new Response(
+          JSON.stringify({ token: "ghs_stub", expires_at: "2099-01-01T00:00:00Z", repository_selection: "selected" }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      if (url.startsWith("https://api.github.com/installation/repositories")) {
+        return new Response(
+          JSON.stringify({
+            total_count: repositories.length,
+            repositories: repositories.map((r) => ({
+              full_name: r.full_name,
+              clone_url: `https://github.com/${r.full_name}.git`,
+              html_url: `https://github.com/${r.full_name}`,
+              private: true,
+              default_branch: "main",
+              pushed_at: r.pushed_at,
+            })),
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      return original(input, init);
+    });
+    globalThis.fetch = spy as typeof fetch;
+    return () => {
+      globalThis.fetch = original;
+    };
+  }
+
+  let restoreFetch: (() => void) | null = null;
+  afterEach(() => {
+    restoreFetch?.();
+    restoreFetch = null;
+  });
+
+  it("returns the installation's repos (org-scoped), sorted most-recently-pushed first", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `r-admin-${crypto.randomUUID().slice(0, 8)}` });
+    await seedInstallation(app, admin.organizationId, 910_001);
+    restoreFetch = stubGithub([
+      { full_name: "acme/old", pushed_at: "2024-01-01T00:00:00Z" },
+      { full_name: "acme/new", pushed_at: "2025-01-01T00:00:00Z" },
+    ]);
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/orgs/${admin.organizationId}/github-app-installation/repositories`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ repos: Array<{ fullName: string }> }>();
+    expect(body.repos.map((r) => r.fullName)).toEqual(["acme/new", "acme/old"]);
+  });
+
+  it("503 no_installation when the team has no installation bound", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `r-admin-${crypto.randomUUID().slice(0, 8)}` });
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/orgs/${admin.organizationId}/github-app-installation/repositories`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+    });
+    expect(res.statusCode).toBe(503);
+    expect(res.json<{ code: string }>().code).toBe("no_installation");
+  });
+
+  it("is member-readable (a non-admin member can list the team's repos)", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `r-admin-${crypto.randomUUID().slice(0, 8)}` });
+
+    const userId = (
+      await app.db.select({ id: users.id }).from(users).where(eq(users.username, admin.username)).limit(1)
+    )[0]?.id;
+    expect(userId).toBeDefined();
+    await app.db
+      .update(members)
+      .set({ role: "member" })
+      .where(eq(members.userId, userId ?? ""));
+    const loginRes = await app.inject({
+      method: "POST",
+      url: "/api/v1/auth/login",
+      payload: { username: admin.username, password: admin.password },
+    });
+    const fresh = loginRes.json<{ accessToken: string }>();
+
+    await seedInstallation(app, admin.organizationId, 910_002);
+    restoreFetch = stubGithub([{ full_name: "acme/web", pushed_at: "2025-01-01T00:00:00Z" }]);
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/orgs/${admin.organizationId}/github-app-installation/repositories`,
+      headers: { authorization: `Bearer ${fresh.accessToken}` },
+    });
+    // The admin-gated details GET would 403 here; this member-readable route must 200.
+    expect(res.statusCode).toBe(200);
+    expect(res.json<{ repos: Array<{ fullName: string }> }>().repos.map((r) => r.fullName)).toEqual(["acme/web"]);
+  });
+});

--- a/packages/server/src/__tests__/github-app-repositories.test.ts
+++ b/packages/server/src/__tests__/github-app-repositories.test.ts
@@ -27,7 +27,12 @@ const { privateKey: TEST_APP_PRIVATE_KEY_PEM } = generateKeyPairSync("rsa", {
 describe("GET /orgs/:orgId/github-app-installation/repositories", () => {
   const getApp = useTestApp({ githubAppPrivateKeyPem: TEST_APP_PRIVATE_KEY_PEM });
 
-  async function seedInstallation(app: ReturnType<typeof getApp>, orgId: string, installationId: number) {
+  async function seedInstallation(
+    app: ReturnType<typeof getApp>,
+    orgId: string,
+    installationId: number,
+    opts: { suspendedAt?: string | null } = {},
+  ) {
     await upsertInstallationFromMetadata(app.db, {
       installation: {
         id: installationId,
@@ -36,10 +41,32 @@ describe("GET /orgs/:orgId/github-app-installation/repositories", () => {
         accountGithubId: installationId * 10,
         permissions: { contents: "read" },
         events: [],
-        suspendedAt: null,
+        suspendedAt: opts.suspendedAt ?? null,
       },
     });
     await bindInstallationToOrg(app.db, installationId, orgId);
+  }
+
+  /** Stub `globalThis.fetch` to fail the `/installation/repositories` call. */
+  function stubGithubReposError(status: number): () => void {
+    const original = globalThis.fetch;
+    const spy = vi.fn(async (input: FetchInput, init?: FetchInit): Promise<Response> => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      if (/\/app\/installations\/\d+\/access_tokens$/.test(url)) {
+        return new Response(JSON.stringify({ token: "ghs_stub", expires_at: "2099-01-01T00:00:00Z" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (url.startsWith("https://api.github.com/installation/repositories")) {
+        return new Response("upstream boom", { status });
+      }
+      return original(input, init);
+    });
+    globalThis.fetch = spy as typeof fetch;
+    return () => {
+      globalThis.fetch = original;
+    };
   }
 
   /**
@@ -106,6 +133,35 @@ describe("GET /orgs/:orgId/github-app-installation/repositories", () => {
     expect(res.statusCode).toBe(200);
     const body = res.json<{ repos: Array<{ fullName: string }> }>();
     expect(body.repos.map((r) => r.fullName)).toEqual(["acme/new", "acme/old"]);
+  });
+
+  it("503 suspended when the installation is suspended", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `r-admin-${crypto.randomUUID().slice(0, 8)}` });
+    await seedInstallation(app, admin.organizationId, 910_003, { suspendedAt: "2025-01-01T00:00:00Z" });
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/orgs/${admin.organizationId}/github-app-installation/repositories`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+    });
+    expect(res.statusCode).toBe(503);
+    expect(res.json<{ code: string }>().code).toBe("suspended");
+  });
+
+  it("502 upstream when GitHub rejects the repo-list call", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `r-admin-${crypto.randomUUID().slice(0, 8)}` });
+    await seedInstallation(app, admin.organizationId, 910_004);
+    restoreFetch = stubGithubReposError(500);
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/orgs/${admin.organizationId}/github-app-installation/repositories`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+    });
+    expect(res.statusCode).toBe(502);
+    expect(res.json<{ code: string }>().code).toBe("upstream");
   });
 
   it("503 no_installation when the team has no installation bound", async () => {

--- a/packages/server/src/__tests__/github-app.test.ts
+++ b/packages/server/src/__tests__/github-app.test.ts
@@ -628,4 +628,40 @@ describe("services/github-app › listInstallationRepos", () => {
       status: 403,
     });
   });
+
+  it("stops at the maxPages cap even when every page is full", async () => {
+    const calls: number[] = [];
+    const fetcher: typeof fetch = async (input) => {
+      const page = Number(new URL(urlOf(input)).searchParams.get("page"));
+      calls.push(page);
+      // Always a full page (100) → only the maxPages cap can stop the walk.
+      return new Response(
+        JSON.stringify({
+          total_count: 1000,
+          repositories: Array.from({ length: 100 }, (_, i) => repo(`acme/p${page}-${i}`, "2024-01-01T00:00:00Z")),
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    };
+    const repos = await listInstallationRepos("ghs_token", { fetcher, maxPages: 3 });
+    expect(calls).toEqual([1, 2, 3]);
+    expect(repos).toHaveLength(300);
+  });
+
+  it("sorts repos with no pushedAt last", async () => {
+    const fetcher: typeof fetch = async () =>
+      new Response(
+        JSON.stringify({
+          total_count: 3,
+          repositories: [
+            repo("acme/null", null),
+            repo("acme/old", "2024-01-01T00:00:00Z"),
+            repo("acme/new", "2025-01-01T00:00:00Z"),
+          ],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    const repos = await listInstallationRepos("ghs_token", { fetcher });
+    expect(repos.map((r) => r.fullName)).toEqual(["acme/new", "acme/old", "acme/null"]);
+  });
 });

--- a/packages/server/src/__tests__/github-app.test.ts
+++ b/packages/server/src/__tests__/github-app.test.ts
@@ -7,6 +7,7 @@ import {
   exchangeCodeForAppUserProfile,
   fetchInstallation,
   GithubAppApiError,
+  listInstallationRepos,
   mintInstallationToken,
   refreshAppUserToken,
   verifyUserCanAdministerInstallation,
@@ -557,6 +558,74 @@ describe("services/github-app", () => {
       expect(err).toBeInstanceOf(GithubAppApiError);
       expect(err.status).toBe(500);
       expect(err.message).toContain("expires_in");
+    });
+  });
+});
+
+describe("services/github-app › listInstallationRepos", () => {
+  type FetchInput = Parameters<typeof fetch>[0];
+  const urlOf = (input: FetchInput): string =>
+    typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+
+  function repo(name: string, pushedAt: string | null) {
+    return {
+      full_name: name,
+      clone_url: `https://github.com/${name}.git`,
+      html_url: `https://github.com/${name}`,
+      private: true,
+      default_branch: "main",
+      pushed_at: pushedAt,
+    };
+  }
+
+  it("maps the installation repo envelope and sorts most-recently-pushed first", async () => {
+    const fetcher: typeof fetch = async (input) => {
+      expect(urlOf(input)).toContain("/installation/repositories");
+      return new Response(
+        JSON.stringify({
+          total_count: 2,
+          repositories: [repo("acme/old", "2024-01-01T00:00:00Z"), repo("acme/new", "2025-01-01T00:00:00Z")],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    };
+    const repos = await listInstallationRepos("ghs_token", { fetcher });
+    expect(repos.map((r) => r.fullName)).toEqual(["acme/new", "acme/old"]);
+    expect(repos[0]).toMatchObject({
+      fullName: "acme/new",
+      cloneUrl: "https://github.com/acme/new.git",
+      htmlUrl: "https://github.com/acme/new",
+      private: true,
+      defaultBranch: "main",
+      pushedAt: "2025-01-01T00:00:00Z",
+    });
+  });
+
+  it("walks pages until a short page (and stops)", async () => {
+    const calls: number[] = [];
+    const fetcher: typeof fetch = async (input) => {
+      const page = Number(new URL(urlOf(input)).searchParams.get("page"));
+      calls.push(page);
+      // Page 1 full (100), page 2 short (1) → stop after page 2.
+      const repositories =
+        page === 1
+          ? Array.from({ length: 100 }, (_, i) => repo(`acme/r${i}`, "2024-01-01T00:00:00Z"))
+          : [repo("acme/last", "2024-02-01T00:00:00Z")];
+      return new Response(JSON.stringify({ total_count: 101, repositories }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    };
+    const repos = await listInstallationRepos("ghs_token", { fetcher });
+    expect(calls).toEqual([1, 2]);
+    expect(repos).toHaveLength(101);
+  });
+
+  it("throws GithubAppApiError on a non-2xx (e.g. suspended → 403)", async () => {
+    const fetcher: typeof fetch = async () => new Response("forbidden", { status: 403 });
+    await expect(listInstallationRepos("ghs_token", { fetcher })).rejects.toMatchObject({
+      name: "GithubAppApiError",
+      status: 403,
     });
   });
 });

--- a/packages/server/src/api/orgs/github-app.ts
+++ b/packages/server/src/api/orgs/github-app.ts
@@ -12,6 +12,7 @@ import { getStoredGithubAccessToken } from "../../services/auth-identity.js";
 import {
   buildAppInstallUrl,
   GithubAppApiError,
+  listInstallationRepos,
   verifyUserCanAdministerInstallation,
 } from "../../services/github-app.js";
 import {
@@ -19,6 +20,7 @@ import {
   findInstallationByGithubId,
   findInstallationByOrg,
 } from "../../services/github-app-installations.js";
+import { mintContextTreeInstallationToken } from "../../services/github-app-token.js";
 import { OAUTH_STATE_COOKIE, OAUTH_STATE_COOKIE_MAX_AGE_S, signOAuthState } from "../../services/oauth-state.js";
 import { buildCookie } from "../auth/oauth-cookie.js";
 
@@ -120,6 +122,61 @@ export async function orgGithubAppRoutes(app: FastifyInstance): Promise<void> {
     const scope = await requireOrgMembership(request, app.db);
     const row = await findInstallationByOrg(app.db, scope.organizationId);
     return { exists: row !== null && row !== undefined };
+  });
+
+  /**
+   * GET `/repositories` — member-readable list of the repos this team's
+   * GitHub App installation can access. Powers the onboarding admin
+   * connect-code project picker.
+   *
+   * Why this instead of the caller's OAuth `/user/repos` (the `/me/github/repos`
+   * endpoint): the product is team-by-default, so the picker should offer
+   * the team's *org* code, not the admin's unrelated personal repos. The
+   * installation's repository set IS exactly that — the repos the App was
+   * granted on the bound org account — so personal repos fall out naturally
+   * and we only ever list repos the agent can actually reach (no picking a
+   * repo the installation can't touch, which would 403 on the first git op).
+   *
+   * Failure shapes (each a distinct `code` so the picker can react):
+   *   - no installation bound      → 503 `no_installation` ("connect code first / later")
+   *   - installation suspended     → 503 `suspended`
+   *   - App not configured server  → 503 `not_configured`
+   *   - mint / GitHub upstream blip → 502 `upstream`
+   */
+  app.get<{ Params: { orgId: string } }>("/repositories", async (request, reply) => {
+    const scope = await requireOrgMembership(request, app.db);
+    const row = await findInstallationByOrg(app.db, scope.organizationId);
+    const mint = await mintContextTreeInstallationToken(row, app.config.oauth?.githubApp);
+    if (!mint.ok) {
+      if (mint.reason === "no-installation") {
+        return reply
+          .status(503)
+          .send({ error: "No GitHub App installation is connected for this team yet.", code: "no_installation" });
+      }
+      if (mint.reason === "suspended") {
+        return reply
+          .status(503)
+          .send({ error: "This team's GitHub App installation is suspended.", code: "suspended" });
+      }
+      if (mint.reason === "no-app-config") {
+        return reply
+          .status(503)
+          .send({ error: "GitHub App is not configured on this server.", code: "not_configured" });
+      }
+      // mint-failed — a transient mint/upstream error.
+      app.log.warn(
+        { organizationId: scope.organizationId, detail: mint.detail },
+        "list installation repos: token mint failed",
+      );
+      return reply.status(502).send({ error: "Couldn't reach GitHub. Try again in a moment.", code: "upstream" });
+    }
+    try {
+      const repos = await listInstallationRepos(mint.token);
+      return { repos };
+    } catch (err) {
+      app.log.warn({ err, organizationId: scope.organizationId }, "list installation repos failed");
+      return reply.status(502).send({ error: "Couldn't reach GitHub. Try again in a moment.", code: "upstream" });
+    }
   });
 
   // ── POST-ish helper: build the "Install on GitHub" URL ──────────────

--- a/packages/server/src/services/github-app.ts
+++ b/packages/server/src/services/github-app.ts
@@ -1,6 +1,7 @@
 import { importPKCS8, SignJWT } from "jose";
 import type { GithubProfile } from "./auth-identity.js";
 import { GITHUB_API_BASE } from "./github-api-base.js";
+import type { GithubRepo } from "./github-oauth.js";
 
 /**
  * GitHub App service helpers. Two surfaces that ride on top of an App's
@@ -48,6 +49,7 @@ const APP_JWT_IAT_SKEW_SECONDS = 60;
 
 const APP_INSTALLATION_TOKEN_URL = (id: number) => `${GITHUB_API_BASE}/app/installations/${id}/access_tokens`;
 const APP_INSTALLATION_URL = (id: number) => `${GITHUB_API_BASE}/app/installations/${id}`;
+const INSTALLATION_REPOS_URL = `${GITHUB_API_BASE}/installation/repositories`;
 const OAUTH_TOKEN_URL = "https://github.com/login/oauth/access_token";
 const OAUTH_AUTHORIZE_URL = "https://github.com/login/oauth/authorize";
 const USER_API_URL = `${GITHUB_API_BASE}/user`;
@@ -280,6 +282,76 @@ export async function mintInstallationToken(
     // one fewer optional to thread through.
     repositorySelection: body.repository_selection ?? "all",
   };
+}
+
+/**
+ * List the repositories an installation can access, via
+ * `GET /installation/repositories` with an installation token (mint one
+ * with `mintInstallationToken` first).
+ *
+ * This is the honest "what can the agent actually work on" set: it's the
+ * subset of repos the App was granted on this account, so it's naturally
+ * scoped to the bound team org and excludes the caller's unrelated personal
+ * repos (which the team-by-default product deliberately does not surface in
+ * onboarding). Contrast `listUserRepos`, which proxies the *user's* OAuth
+ * `/user/repos` — personal + every org the user belongs to, with no notion
+ * of whether the agent can reach any of them.
+ *
+ * Returns the same `GithubRepo` shape as `listUserRepos` so the repo picker
+ * is source-agnostic. Sorted by most-recently-pushed (the endpoint has no
+ * `sort` param, so we order client-side to match the OAuth picker's feel).
+ * Walks paginated responses up to the cap.
+ *
+ * Throws `GithubAppApiError` on non-2xx (401 = bad/expired installation
+ * token, 403 = suspended, 5xx = transient upstream).
+ */
+export async function listInstallationRepos(
+  installationToken: string,
+  opts: { fetcher?: typeof fetch; perPage?: number; maxPages?: number } = {},
+): Promise<GithubRepo[]> {
+  const fetcher = opts.fetcher ?? fetch;
+  const perPage = opts.perPage ?? 100;
+  const maxPages = opts.maxPages ?? 5;
+  const out: GithubRepo[] = [];
+  for (let page = 1; page <= maxPages; page++) {
+    const res = await fetcher(`${INSTALLATION_REPOS_URL}?per_page=${perPage}&page=${page}`, {
+      headers: {
+        Authorization: `Bearer ${installationToken}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    });
+    if (!res.ok) {
+      throw new GithubAppApiError(res.status, `GitHub installation repo list failed (${res.status})`);
+    }
+    // Unlike `/user/repos` (a bare array), this endpoint wraps the page in
+    // `{ total_count, repositories: [...] }`.
+    const body = (await res.json()) as {
+      repositories?: Array<{
+        full_name: string;
+        clone_url: string;
+        html_url: string;
+        private: boolean;
+        default_branch?: string | null;
+        pushed_at?: string | null;
+      }>;
+    };
+    const rows = body.repositories ?? [];
+    for (const r of rows) {
+      out.push({
+        fullName: r.full_name,
+        cloneUrl: r.clone_url,
+        htmlUrl: r.html_url,
+        private: r.private,
+        defaultBranch: r.default_branch ?? null,
+        pushedAt: r.pushed_at ?? null,
+      });
+    }
+    if (rows.length < perPage) break;
+  }
+  // Most-recently-pushed first; repos without a pushedAt sort last.
+  out.sort((a, b) => (b.pushedAt ?? "").localeCompare(a.pushedAt ?? ""));
+  return out;
 }
 
 export type RefreshedUserToken = {

--- a/packages/web/src/api/github.ts
+++ b/packages/web/src/api/github.ts
@@ -12,10 +12,23 @@ export type GithubRepo = {
 /**
  * Fetch the caller's accessible GitHub repos. Server-side proxy that
  * decrypts the OAuth token captured at sign-in and calls
- * `https://api.github.com/user/repos`. Used by the onboarding Step 2
- * repo picker.
+ * `https://api.github.com/user/repos`. Personal + every org the user
+ * belongs to. Used by the invitee kickoff picker ("pick your own project").
  */
 export async function listGithubRepos(): Promise<GithubRepo[]> {
   const res = await api.get<{ repos: GithubRepo[] }>("/me/github/repos");
+  return res.repos;
+}
+
+/**
+ * Fetch the repos a team's GitHub App installation can access (org-scoped).
+ * Used by the admin connect-code picker: the product is team-by-default, so
+ * the picker offers the team's org code, not the admin's personal repos —
+ * and only repos the agent can actually reach (the installation's grant),
+ * never a repo that would 403 on the first git op. Backed by
+ * `GET /orgs/:orgId/github-app-installation/repositories`.
+ */
+export async function listOrgGithubRepos(organizationId: string): Promise<GithubRepo[]> {
+  const res = await api.get<{ repos: GithubRepo[] }>(`/orgs/${organizationId}/github-app-installation/repositories`);
   return res.repos;
 }

--- a/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
+++ b/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
@@ -1406,6 +1406,27 @@ describe("web DOM interaction coverage", () => {
     await waitForText("Reconnect GitHub with project access", scopeMissing.container);
     await unmountRoot(scopeMissing.root);
 
+    // A non-403 failure from the org repo endpoint (502 upstream / 503
+    // no_installation|suspended) must show an honest load-failed message, not
+    // fall through to the empty "no projects" state.
+    githubAppMocks.getGithubAppInstallation.mockResolvedValueOnce({
+      installationId: 42,
+      accountLogin: "acme",
+      accountType: "Organization",
+      accountGithubId: 123,
+      repositorySelection: "selected",
+      permissions: {},
+      events: [],
+      suspended: false,
+      manageUrl: "https://github.com/organizations/acme/settings/installations/42",
+      createdAt: NOW,
+      updatedAt: NOW,
+    });
+    githubMocks.listOrgGithubRepos.mockRejectedValueOnce(new ApiError(503, "no installation"));
+    const loadFailed = await renderOnboardingDom(<StepConnectCode />, { activeStep: "connect-code" });
+    await waitForText("Couldn't load your team's projects", loadFailed.container);
+    await unmountRoot(loadFailed.root);
+
     githubAppMocks.getGithubAppInstallUrl.mockRejectedValueOnce(new ApiError(503, "not configured"));
     const notConfigured = await renderOnboardingDom(<StepConnectCode />, { activeStep: "connect-code" });
     await waitForText("Install First Tree on GitHub", notConfigured.container);

--- a/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
+++ b/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
@@ -50,6 +50,7 @@ const chatApiMocks = vi.hoisted(() => ({
 
 const githubMocks = vi.hoisted(() => ({
   listGithubRepos: vi.fn(),
+  listOrgGithubRepos: vi.fn(),
 }));
 
 const githubAppMocks = vi.hoisted(() => ({
@@ -650,6 +651,7 @@ beforeEach(() => {
   chatApiMocks.sendChatMessage.mockResolvedValue(undefined);
   chatApiMocks.sendFileMessageBatch.mockResolvedValue(undefined);
   githubMocks.listGithubRepos.mockResolvedValue(GITHUB_REPOS);
+  githubMocks.listOrgGithubRepos.mockResolvedValue(GITHUB_REPOS);
   githubAppMocks.getGithubAppInstallation.mockResolvedValue(null);
   githubAppMocks.getGithubAppInstallationExists.mockResolvedValue(true);
   githubAppMocks.getGithubAppInstallUrl.mockResolvedValue("https://github.com/apps/first-tree/installations/new");
@@ -1399,7 +1401,7 @@ describe("web DOM interaction coverage", () => {
       createdAt: NOW,
       updatedAt: NOW,
     });
-    githubMocks.listGithubRepos.mockRejectedValueOnce(new ApiError(403, "scope missing"));
+    githubMocks.listOrgGithubRepos.mockRejectedValueOnce(new ApiError(403, "scope missing"));
     const scopeMissing = await renderOnboardingDom(<StepConnectCode />, { activeStep: "connect-code" });
     await waitForText("Reconnect GitHub with project access", scopeMissing.container);
     await unmountRoot(scopeMissing.root);

--- a/packages/web/src/pages/onboarding-preview.tsx
+++ b/packages/web/src/pages/onboarding-preview.tsx
@@ -213,7 +213,11 @@ function handleNet(rawUrl: string): Promise<Response> | Response | null {
   if (p === "/me/organizations") {
     return jsonResponse([{ id: ORG_ID, name: "acme", displayName: TEAM_NAME, role: "admin" }]);
   }
+  // Invitee kickoff picker → /me/github/repos; admin connect-code picker →
+  // the org-scoped installation repos. Both render from the same `repos`
+  // outcome so existing picker scenarios cover either source.
   if (p === "/me/github/repos") return reposResponse(activeNet.repos);
+  if (p === `/orgs/${ORG_ID}/github-app-installation/repositories`) return reposResponse(activeNet.repos);
   if (p === `/orgs/${ORG_ID}/github-app-installation`) {
     return activeNet.installed
       ? jsonResponse({ installed: true })

--- a/packages/web/src/pages/onboarding/copy.ts
+++ b/packages/web/src/pages/onboarding/copy.ts
@@ -98,7 +98,16 @@ export const COPY = {
     waiting: "Waiting for GitHub…",
     connected: "Connected",
     pickProject: "Which projects should your agent work on?",
-    noRepos: "No projects found on your GitHub account yet.",
+    // The picker is sourced from the team's GitHub App installation grant, so
+    // "your GitHub account" would be wrong — an empty list means the App was
+    // connected but isn't granted any repos yet.
+    noRepos: "No projects are connected to your team's GitHub yet — add some on GitHub, or continue without one.",
+    // Shown when the org-scoped repo list fails to load (502 upstream / 503
+    // suspended etc.). The new installation-backed endpoint can return these,
+    // and without this branch the failure was misrendered as an empty
+    // "no projects" list. The "Continue without a project" button below keeps
+    // it from being a dead end.
+    loadFailed: "Couldn't load your team's projects. Try again in a moment — or continue without one.",
     reconnect: "Reconnect GitHub with project access",
     notConfigured:
       "Code connection isn't set up here yet. You can continue now and connect a project later from Settings.",

--- a/packages/web/src/pages/onboarding/steps/step-connect-code.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-connect-code.tsx
@@ -2,7 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { ArrowRight, Github } from "lucide-react";
 import { useEffect, useState } from "react";
 import { ApiError } from "../../../api/client.js";
-import { listGithubRepos } from "../../../api/github.js";
+import { listOrgGithubRepos } from "../../../api/github.js";
 import { getGithubAppInstallation, getGithubAppInstallUrl } from "../../../api/github-app.js";
 import { Button } from "../../../components/ui/button.js";
 import { COPY } from "../copy.js";
@@ -74,10 +74,13 @@ export function StepConnectCode() {
     if (postAttemptStuck) setHelpOpen(true);
   }, [postAttemptStuck]);
 
+  // Team-by-default: the admin picks from the team's *org* code, sourced
+  // from the GitHub App installation's repo grant (not the admin's personal
+  // `/user/repos`). Only repos the agent can actually reach show up.
   const reposQuery = useQuery({
-    queryKey: ["onboarding", "github-repos"],
-    queryFn: listGithubRepos,
-    enabled: installed,
+    queryKey: ["onboarding", "org-github-repos", organizationId],
+    queryFn: () => listOrgGithubRepos(organizationId ?? ""),
+    enabled: installed && !!organizationId,
   });
   const scopeMissing = reposQuery.error instanceof ApiError && reposQuery.error.status === 403;
   const hasPickableRepos = !scopeMissing && (reposQuery.data?.length ?? 0) > 0;

--- a/packages/web/src/pages/onboarding/steps/step-connect-code.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-connect-code.tsx
@@ -83,7 +83,12 @@ export function StepConnectCode() {
     enabled: installed && !!organizationId,
   });
   const scopeMissing = reposQuery.error instanceof ApiError && reposQuery.error.status === 403;
-  const hasPickableRepos = !scopeMissing && (reposQuery.data?.length ?? 0) > 0;
+  // The installation-backed endpoint can fail with 502 (upstream) / 503
+  // (no_installation / suspended / not_configured). Treat any non-403 error
+  // as a load failure with an honest message rather than letting it fall
+  // through to the empty "no projects" state.
+  const loadFailed = !!reposQuery.error && !scopeMissing;
+  const hasPickableRepos = !reposQuery.error && (reposQuery.data?.length ?? 0) > 0;
 
   const handleConnect = async (): Promise<void> => {
     if (!organizationId) return;
@@ -222,6 +227,10 @@ export function StepConnectCode() {
           <p className="text-label" style={{ margin: 0, color: "var(--fg-4)" }}>
             Loading your projects…
           </p>
+        ) : loadFailed ? (
+          <FlowHint tone="error" role="alert">
+            {COPY.connectCode.loadFailed}
+          </FlowHint>
         ) : (reposQuery.data?.length ?? 0) === 0 ? (
           <FlowHint>{COPY.connectCode.noRepos}</FlowHint>
         ) : (


### PR DESCRIPTION
## Why

First Tree is team-by-default, but the onboarding **admin connect-code picker** was listing the caller's OAuth `/user/repos` — their personal repos plus every org they belong to, with no sense of whether the agent could actually reach any of them. So an admin could pick a personal repo (or an org the team's App isn't installed on), and the agent would 403 on its first git op.

## What

Source the picker from the team's **GitHub App installation grant** instead — exactly "what the agent can reach". Naturally org-scoped, so personal repos fall out for free.

**Server**
- `listInstallationRepos(token)` (`services/github-app.ts`) — lists `GET /installation/repositories` (mint a token via the existing `mintContextTreeInstallationToken` first). Same `GithubRepo` shape as `listUserRepos`, sorted most-recently-pushed, nulls last.
- `GET /orgs/:orgId/github-app-installation/repositories` (`api/orgs/github-app.ts`) — member-readable (mirrors `/exists`). Distinct failure codes: `no_installation` / `suspended` / `not_configured` → 503, `upstream` → 502.

**Web**
- `listOrgGithubRepos(orgId)`; the admin connect-code picker uses it, with an honest load-failed branch for the new 502/503 codes (never a dead end — "Continue without a project" stays).
- The **invitee** kickoff picker is intentionally left on `/user/repos` ("pick your own project" is a different intent, and an invitee isn't necessarily an org admin) — narrowing that is a separate follow-up.
- Preview gallery shim handles the new endpoint.

## Scope notes
- No DB / schema change. New read-only endpoint + a frontend data-source swap.
- Stacked conceptually on #785 (the connect-code redesign), which is now merged; this is rebased onto main and stands alone.

## Tests / gates
- Service unit (mapping / pagination / maxPages cap / nulls-last sort / non-2xx) + route integration (repos / no_installation / suspended / upstream / member-readable) + web DOM (load-failed branch).
- `pnpm typecheck` (11/11), `pnpm check` (biome), full `pnpm test` (server 1294, web 634) — all green.
- Three independent code reviews run pre-PR; the one substantive finding (mishandled 502/503 → misleading "no projects") is fixed in the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)