### PR TITLE
fix(web): guard Context tree submit for members (read-only)

### DIFF
--- a/packages/web/src/pages/context-tree-settings-panel.tsx
+++ b/packages/web/src/pages/context-tree-settings-panel.tsx
@@ -57,6 +57,10 @@ export function ContextTreeSettingsPanel() {
 
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault();
+    // Read-only UI must not initiate a write: members have no Save button, but
+    // pressing Enter inside a read-only field would still submit the form. The
+    // server 403s a member PUT regardless, but the client shouldn't fire it.
+    if (!isAdmin) return;
     mutation.mutate();
   };
 


### PR DESCRIPTION
Follow-up to #802. The read-only member view of the Context tree settings panel hides the Save button and renders read-only inputs, but `<form onSubmit>` still called `mutation.mutate()` unconditionally — a member pressing Enter inside a read-only field could fire a PUT (the server 403s it, but a read-only UI shouldn't initiate a write).

This is the **R4 fix that codex-assistant requested** on #802; it was approved on both #802 (yuezengwu re-approved commit `bc4b7c7c`, codex-assistant follow-up approve) but landed on the branch *after* the squash-merge snapshot, so it didn't make it onto `main`. This PR carries the identical commit off latest `main`.

Change: add `if (!isAdmin) return;` at the top of `handleSubmit` (after `preventDefault`). 4 lines incl. comment, one file, no IA / route / server-contract change.

## Verification
- ✅ `pnpm --filter @first-tree/web typecheck` (incl. lint:tokens)
- ✅ `pnpm check` (biome)
- ✅ web suite 658/658

🤖 Generated with [Claude Code](https://claude.com/claude-code)