### PR TITLE
fix(server): admin-gate the onboarding installation-repos endpoint

### DIFF
--- a/packages/server/src/__tests__/github-app-repositories.test.ts
+++ b/packages/server/src/__tests__/github-app-repositories.test.ts
@@ -15,9 +15,12 @@ const { privateKey: TEST_APP_PRIVATE_KEY_PEM } = generateKeyPairSync("rsa", {
 });
 
 /**
- * `GET /orgs/:orgId/github-app-installation/repositories` — member-readable
- * list of the repos the team's GitHub App installation can access. Powers
- * the onboarding admin connect-code project picker.
+ * `GET /orgs/:orgId/github-app-installation/repositories` — admin-only list
+ * of the repos the team's GitHub App installation can access. Powers the
+ * onboarding admin connect-code project picker. Admin-gated (not
+ * member-readable like `/exists`) because the response is the full
+ * installation candidate catalog — private repo names / clone URLs the
+ * caller may not be a GitHub collaborator on.
  *
  * The product is team-by-default, so the picker offers the team's *org*
  * code (the installation's grant) rather than the admin's personal

--- a/packages/server/src/__tests__/github-app-repositories.test.ts
+++ b/packages/server/src/__tests__/github-app-repositories.test.ts
@@ -177,10 +177,11 @@ describe("GET /orgs/:orgId/github-app-installation/repositories", () => {
     expect(res.json<{ code: string }>().code).toBe("no_installation");
   });
 
-  it("is member-readable (a non-admin member can list the team's repos)", async () => {
+  it("requires admin — a non-admin member is forbidden (the response is the full installation catalog)", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app, { username: `r-admin-${crypto.randomUUID().slice(0, 8)}` });
 
+    // Demote to a plain member, then re-login so the JWT carries role:member.
     const userId = (
       await app.db.select({ id: users.id }).from(users).where(eq(users.username, admin.username)).limit(1)
     )[0]?.id;
@@ -196,16 +197,16 @@ describe("GET /orgs/:orgId/github-app-installation/repositories", () => {
     });
     const fresh = loginRes.json<{ accessToken: string }>();
 
+    // Even with an installation bound, a non-admin must be refused before any
+    // GitHub call — the payload exposes the full installation candidate
+    // catalog (private repo names / clone URLs), which is admin-only.
     await seedInstallation(app, admin.organizationId, 910_002);
-    restoreFetch = stubGithub([{ full_name: "acme/web", pushed_at: "2025-01-01T00:00:00Z" }]);
 
     const res = await app.inject({
       method: "GET",
       url: `/api/v1/orgs/${admin.organizationId}/github-app-installation/repositories`,
       headers: { authorization: `Bearer ${fresh.accessToken}` },
     });
-    // The admin-gated details GET would 403 here; this member-readable route must 200.
-    expect(res.statusCode).toBe(200);
-    expect(res.json<{ repos: Array<{ fullName: string }> }>().repos.map((r) => r.fullName)).toEqual(["acme/web"]);
+    expect(res.statusCode).toBe(403);
   });
 });

--- a/packages/server/src/api/orgs/github-app.ts
+++ b/packages/server/src/api/orgs/github-app.ts
@@ -125,9 +125,9 @@ export async function orgGithubAppRoutes(app: FastifyInstance): Promise<void> {
   });
 
   /**
-   * GET `/repositories` — member-readable list of the repos this team's
-   * GitHub App installation can access. Powers the onboarding admin
-   * connect-code project picker.
+   * GET `/repositories` — admin-only list of the repos this team's GitHub
+   * App installation can access. Powers the onboarding admin connect-code
+   * project picker.
    *
    * Why this instead of the caller's OAuth `/user/repos` (the `/me/github/repos`
    * endpoint): the product is team-by-default, so the picker should offer
@@ -137,6 +137,14 @@ export async function orgGithubAppRoutes(app: FastifyInstance): Promise<void> {
    * and we only ever list repos the agent can actually reach (no picking a
    * repo the installation can't touch, which would 403 on the first git op).
    *
+   * Admin-gated (NOT member-readable like `/exists`): the response is the
+   * full installation candidate catalog — every reachable repo's name,
+   * clone URL, default branch and private flag — which can include private
+   * repos a given member isn't even a GitHub collaborator on. `/exists` is
+   * not a precedent (it returns a boolean, not a catalog), and the only
+   * consumer is the admin-path connect-code step (`connect-code` is in
+   * ADMIN_STEPS only), so least-privilege costs nothing here.
+   *
    * Failure shapes (each a distinct `code` so the picker can react):
    *   - no installation bound      → 503 `no_installation` ("connect code first / later")
    *   - installation suspended     → 503 `suspended`
@@ -144,7 +152,7 @@ export async function orgGithubAppRoutes(app: FastifyInstance): Promise<void> {
    *   - mint / GitHub upstream blip → 502 `upstream`
    */
   app.get<{ Params: { orgId: string } }>("/repositories", async (request, reply) => {
-    const scope = await requireOrgMembership(request, app.db);
+    const scope = await requireOrgAdmin(request, app.db);
     const row = await findInstallationByOrg(app.db, scope.organizationId);
     const mint = await mintContextTreeInstallationToken(row, app.config.oauth?.githubApp);
     if (!mint.ok) {


### PR DESCRIPTION
Follow-up to **#803** review. Both reviewers (codex-assistant `request_changes` R5, yuezengwu concur + withdrew approval) flagged that the new `GET /orgs/:orgId/github-app-installation/repositories` endpoint was member-readable while returning the **full installation candidate catalog** — every reachable repo's `fullName`, `cloneUrl`, `defaultBranch`, and `private` flag, which can include private repos a given member isn't even a GitHub collaborator on. That's broader than the member-readable `/exists` (a boolean) or `source_repos` (the team's *already-bound* repos only).

#803 had already merged when the review landed (race), so this is the focused follow-up.

## Change
- `packages/server/src/api/orgs/github-app.ts`: `requireOrgMembership` → `requireOrgAdmin` on `/repositories` (+ doc comment explaining why this one is admin-only, unlike `/exists`).
- `packages/server/src/__tests__/github-app-repositories.test.ts`: the old "member-readable" test now asserts a non-admin member gets **403**.

## Why it's lossless
`listOrgGithubRepos` has exactly one product caller — `step-connect-code.tsx`. `connect-code` is in `ADMIN_STEPS` only (not `INVITEE_STEPS`), and `resolveOnboardingPath` returns `"admin"` only for `role === "admin"`. The invitee/member kickoff picker stays on `/user/repos`. So no non-admin ever legitimately calls this — least-privilege, zero functional loss.

## Gates
`pnpm typecheck` + `pnpm --filter @first-tree/server test` (1294) + biome — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)