### PR TITLE
fix(server): skip auto-archive for human-owned chats

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -466,6 +466,9 @@ and are not used by the CLI. They are listed here for ops reference.
 | `FIRST_TREE_ARCHIVE_MAPPED_IDLE_SECONDS` | `3600` |
 | `FIRST_TREE_ARCHIVE_UNMAPPED_IDLE_SECONDS` | `43200` |
 
+`FIRST_TREE_ARCHIVE_UNMAPPED_IDLE_SECONDS` applies only to chats with no
+GitHub mapping and no human owner.
+
 **Observability:**
 
 | Variable | Purpose | Default |

--- a/packages/server/src/__tests__/chat-archive.test.ts
+++ b/packages/server/src/__tests__/chat-archive.test.ts
@@ -5,9 +5,9 @@
  *   Route A — chats with GitHub mappings: archive when every mapped entity
  *             is terminal AND `last_message_at` is older than the mapped
  *             idle threshold.
- *   Route B — chats with no GitHub mapping: archive (chat, user) pairs
- *             with no unread mentions AND `last_message_at` older than the
- *             unmapped idle threshold.
+ *   Route B — chats with no GitHub mapping and no human owner: archive
+ *             (chat, user) pairs with no unread mentions AND
+ *             `last_message_at` older than the unmapped idle threshold.
  *
  * Also asserts the shared per-user safety guards: deleted-sticky and
  * already-archived rows are never touched; sweeps are idempotent.
@@ -22,6 +22,7 @@ import { chatUserState } from "../db/schema/chat-user-state.js";
 import { chats } from "../db/schema/chats.js";
 import { githubEntityChatMappings } from "../db/schema/github-entity-chat-mappings.js";
 import { sweepChatArchive } from "../services/chat-archive.js";
+import { createMeChat } from "../services/me-chat.js";
 import { createTestAdmin, useTestApp } from "./helpers.js";
 
 type App = ReturnType<ReturnType<typeof useTestApp>>;
@@ -426,6 +427,22 @@ describe("sweepChatArchive — Route B (chats with no GitHub mapping)", () => {
     await sweepChatArchive(app.db);
 
     expect(await getEngagement(app, chatId, human)).toBe("active");
+  });
+
+  it("does not archive a manually created chat owned by a human", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const delegate = await seedDelegateAgent(app, admin.organizationId, admin.memberId);
+    const { chatId } = await createMeChat(app.db, admin.humanAgentUuid, admin.organizationId, {
+      participantIds: [delegate],
+    });
+    await app.db.update(chats).set({ lastMessageAt: longAgo() }).where(eq(chats.id, chatId));
+    await seedReadAcknowledgement(app, chatId, admin.humanAgentUuid);
+
+    const result = await sweepChatArchive(app.db);
+
+    expect(result.unmappedRowsArchived).toBe(0);
+    expect(await getEngagement(app, chatId, admin.humanAgentUuid)).toBe("active");
   });
 
   it("does not archive chats that have GitHub mappings (Route A's responsibility)", async () => {

--- a/packages/server/src/services/chat-archive.ts
+++ b/packages/server/src/services/chat-archive.ts
@@ -14,9 +14,11 @@
  *     been silent for `mappedIdleSeconds` (default 1h). Additionally:
  *     skip individual users whose `unread_mention_count > 0`.
  *
- *   Route B — chats with no GitHub mapping. Archive only the (chat, user)
- *     pairs where the user has no unread mentions AND the chat has been
- *     silent for `unmappedIdleSeconds` (default 12h).
+ *   Route B — chats with no GitHub mapping and no human owner. Archive only
+ *     the (chat, user) pairs where the user has no unread mentions AND the
+ *     chat has been silent for `unmappedIdleSeconds` (default 12h). Human-
+ *     owned chats are user-created workspace conversations and must stay
+ *     active until explicitly archived.
  *
  * Per-user safety: writes use the same UPSERT + setWhere guard as the
  * removed `archiveChatsForMergedPr` — only implicit-active or
@@ -115,9 +117,12 @@ async function sweepMapped(db: Database, idleSeconds: number, batchSize: number)
 }
 
 /**
- * Route B: chats with no GitHub mapping that have been silent past
- * `idleSeconds`, restricted to per-(chat, user) rows that all of:
+ * Route B: chats with no GitHub mapping and no human owner that have been
+ * silent past `idleSeconds`, restricted to per-(chat, user) rows that all of:
  *
+ *   - the chat is not owned by a human speaker — human-owned chats are
+ *     manually created workspace conversations and should not disappear from
+ *     Active merely because they are quiet,
  *   - the user has acknowledged the chat at least once (`last_read_at IS
  *     NOT NULL`) — never auto-archive a view the user has never even
  *     opened; without this guard a never-clicked watcher would find the
@@ -153,6 +158,14 @@ async function sweepUnmapped(db: Database, idleSeconds: number, batchSize: numbe
        AND c.parent_chat_id IS NULL
        AND c.last_message_at IS NOT NULL
        AND c.last_message_at < NOW() - make_interval(secs => ${idleSeconds})
+       AND NOT EXISTS (
+         SELECT 1
+           FROM chat_membership owner_cm
+           JOIN agents owner_a ON owner_a.uuid = owner_cm.agent_id
+          WHERE owner_cm.chat_id = c.id
+            AND owner_cm.role = 'owner'
+            AND owner_a.type = 'human'
+       )
        AND cus.last_read_at IS NOT NULL
        AND cus.unread_mention_count = 0
        AND cus.engagement_status = 'active'

--- a/packages/shared/src/config/server-config.ts
+++ b/packages/shared/src/config/server-config.ts
@@ -394,9 +394,9 @@ export const serverConfigSchema = defineConfig({
       },
     ),
     /**
-     * Idle threshold for chats with no GitHub mapping. Per (chat, user) —
-     * users with unread mentions are skipped; users without an unread
-     * stay archived after this much silence.
+     * Idle threshold for chats with no GitHub mapping and no human owner.
+     * Per (chat, user) — users with unread mentions are skipped; users
+     * without an unread stay archived after this much silence.
      */
     archiveUnmappedIdleSeconds: field(
       z.coerce


### PR DESCRIPTION
## Summary
- exclude chats with a human owner from the unmapped auto-archive route
- keep GitHub-mapped archive behavior unchanged
- add a regression test for manually created chats staying active after idle/read

## Verification
- pnpm exec vitest run src/__tests__/chat-archive.test.ts --maxWorkers=2 (from packages/server)
- pnpm check
- pnpm typecheck