### PR TITLE
fix(web): form-control width + page-action button consistency

### DIFF
--- a/packages/web/src/components/ui/select.tsx
+++ b/packages/web/src/components/ui/select.tsx
@@ -280,7 +280,7 @@ export function Select({
   const optionId = (i: number): string => `${baseId}-opt-${i}`;
 
   return (
-    <div className={cn("max-w-md", className)}>
+    <div className={cn("w-full", className)}>
       <button
         ref={triggerRef}
         id={id}

--- a/packages/web/src/pages/agent-detail/env-section.tsx
+++ b/packages/web/src/pages/agent-detail/env-section.tsx
@@ -51,7 +51,7 @@ export function EnvSection(props: EnvSectionProps) {
 
   const action = !props.disabled ? (
     <Button size="xs" variant="outline" onClick={() => setDialog({ mode: "add" })}>
-      <Plus className="h-3 w-3" /> Add variable
+      <Plus className="h-3.5 w-3.5" /> Add variable
     </Button>
   ) : null;
 

--- a/packages/web/src/pages/agent-detail/git-section.tsx
+++ b/packages/web/src/pages/agent-detail/git-section.tsx
@@ -38,7 +38,7 @@ export function GitSection(props: GitSectionProps) {
 
   const action = !props.disabled ? (
     <Button size="xs" variant="outline" onClick={() => setDialog({ mode: "add" })}>
-      <Plus className="h-3 w-3" /> Add repository
+      <Plus className="h-3.5 w-3.5" /> Add repository
     </Button>
   ) : null;
 

--- a/packages/web/src/pages/agent-detail/mcp-section.tsx
+++ b/packages/web/src/pages/agent-detail/mcp-section.tsx
@@ -61,7 +61,7 @@ export function McpSection(props: McpSectionProps) {
 
   const action = !props.disabled ? (
     <Button size="xs" variant="outline" onClick={() => setDialog({ mode: "add" })}>
-      <Plus className="h-3 w-3" /> Add
+      <Plus className="h-3.5 w-3.5" /> Add
     </Button>
   ) : null;
 

--- a/packages/web/src/pages/agent-detail/model-section.tsx
+++ b/packages/web/src/pages/agent-detail/model-section.tsx
@@ -89,15 +89,7 @@ export function ModelSection({
         ) : null
       }
     >
-      <Select
-        options={items}
-        value={value}
-        onChange={onChange}
-        disabled={disabled}
-        mono
-        aria-label="Model"
-        className="w-full max-w-none"
-      />
+      <Select options={items} value={value} onChange={onChange} disabled={disabled} mono aria-label="Model" />
     </ConfigRow>
   );
 }

--- a/packages/web/src/pages/agent-detail/reasoning-effort-section.tsx
+++ b/packages/web/src/pages/agent-detail/reasoning-effort-section.tsx
@@ -94,7 +94,6 @@ export function ReasoningEffortSection({
         disabled={disabled}
         placeholder="(unset)"
         aria-label="Reasoning effort"
-        className="w-full max-w-none"
       />
     </ConfigRow>
   );

--- a/packages/web/src/pages/agent-detail/resources-tab.tsx
+++ b/packages/web/src/pages/agent-detail/resources-tab.tsx
@@ -73,11 +73,11 @@ export function ResourcesTab() {
           action={
             canEdit && type === "repo" ? (
               <Button size="xs" variant="outline" onClick={() => setRepoOpen(true)}>
-                <Plus className="h-3 w-3" /> Agent repo
+                <Plus className="h-3.5 w-3.5" /> Agent repo
               </Button>
             ) : canEdit && type === "prompt" ? (
               <Button size="xs" variant="outline" onClick={() => setPromptOpen({ replacesResourceId: null })}>
-                <Plus className="h-3 w-3" /> Inline prompt
+                <Plus className="h-3.5 w-3.5" /> Inline prompt
               </Button>
             ) : null
           }

--- a/packages/web/src/pages/clients.tsx
+++ b/packages/web/src/pages/clients.tsx
@@ -324,7 +324,7 @@ export function ClientsPage({ embedded = false }: { embedded?: boolean } = {}) {
         right={
           showHeaderConnectButton ? (
             <Button variant="outline" size="sm" onClick={openNewConnection}>
-              <Plus className="h-3 w-3" />
+              <Plus className="h-3.5 w-3.5" />
               Connect
             </Button>
           ) : undefined
@@ -491,8 +491,8 @@ export function ClientsPage({ embedded = false }: { embedded?: boolean } = {}) {
               style={{ color: "var(--fg-3)", gap: "var(--sp-3)" }}
             >
               <span>No computers connected yet.</span>
-              <Button size="sm" onClick={openNewConnection}>
-                <Plus className="h-3 w-3" />
+              <Button size="sm" variant="cta" onClick={openNewConnection}>
+                <Plus className="h-3.5 w-3.5" />
                 Connect your first computer
               </Button>
             </div>
@@ -513,8 +513,8 @@ export function ClientsPage({ embedded = false }: { embedded?: boolean } = {}) {
                       style={{ color: "var(--fg-3)", gap: "var(--sp-3)", padding: "var(--sp-4) 0" }}
                     >
                       <span className="text-body">No computers of your own.</span>
-                      <Button size="sm" onClick={openNewConnection}>
-                        <Plus className="h-3 w-3" />
+                      <Button size="sm" variant="cta" onClick={openNewConnection}>
+                        <Plus className="h-3.5 w-3.5" />
                         Connect your first computer
                       </Button>
                     </div>

--- a/packages/web/src/pages/settings/resource-editors.tsx
+++ b/packages/web/src/pages/settings/resource-editors.tsx
@@ -110,8 +110,8 @@ export function AddResourceMenu({ onPick }: { onPick: (type: ResourceType) => vo
     <Popover
       align="end"
       trigger={({ open, toggle }) => (
-        <Button size="sm" aria-expanded={open} onClick={toggle}>
-          <Plus className="h-4 w-4" /> Add resource
+        <Button size="sm" variant="cta" aria-expanded={open} onClick={toggle}>
+          <Plus className="h-3.5 w-3.5" /> Add resource
         </Button>
       )}
     >

--- a/packages/web/src/pages/workspace/center/no-chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/no-chat-view.tsx
@@ -19,8 +19,8 @@ export function NoChatView({ onNewChat }: { onNewChat: () => void }) {
           Start a new chat to put your agent to work, or open an existing one from the list.
         </div>
         <div className="flex justify-center">
-          <Button type="button" onClick={onNewChat}>
-            <Plus className="h-4 w-4" />
+          <Button type="button" variant="cta" onClick={onNewChat}>
+            <Plus className="h-3.5 w-3.5" />
             <span>New chat</span>
           </Button>
         </div>


### PR DESCRIPTION
Two small, independent web UI consistency fixes, bundled per request.

## ① Select / Input equal width

The `Select` wrapper hard-coded `max-w-md` (448px) while `Input` uses `w-full`, so dropdowns rendered ~64px narrower than inputs in any form wider than 448px (e.g. the 512px `max-w-lg` MCP dialog) — the right edges didn't line up.

- `select.tsx`: wrapper `max-w-md` → `w-full`, so Select and Input follow the same width rule and fill their container.
- Dropped the now-redundant `w-full max-w-none` overrides that `model-section` / `reasoning-effort-section` used to fight the cap.
- Net −9 lines, 3 files.

Affected, now aligned: MCP dialog (Transport vs Name/Command), Identity (Visibility / Delegate), re-bind (Computer), Settings → Resources editors (Default / Transport).

## ② Page-action button consistency

Page-level primary creation actions were a mix of `cta`, `default`, and `outline` with three different Plus-icon sizes. Unified per DESIGN.md's one-hero-per-surface rule:

- **Brand-green `cta`** = each surface's single primary creation action: New agent, Add resource, empty-state "Connect your first computer", "New chat".
- **Neutral `outline`** = secondary / section actions: header `+Connect` (secondary; the empty-state has the hero), per-section Add (MCP / Git / Env / Resources, list rows).
- **Plus icons** standardized to 14px (`h-3.5`) everywhere, matching the canonical Team header (was 12 / 14 / 16px).
- 7 files, +14/−14.

## Verification
- `pnpm check` (biome) ✓
- `pnpm --filter @first-tree/web typecheck` (tsc + lint:tokens) ✓
- `pnpm --filter @first-tree/web test` — 667/667 ✓

> Review note: the Select-width alignment is best eyeballed live — open the MCP config dialog and confirm the Transport dropdown and the Name/Command inputs share the same right edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)