### PR TITLE
fix: add websocket close grace for client presence

### DIFF
--- a/packages/server/src/__tests__/ws-client-reconnect-race.test.ts
+++ b/packages/server/src/__tests__/ws-client-reconnect-race.test.ts
@@ -3,7 +3,10 @@ import type { FastifyInstance } from "fastify";
 import { SignJWT } from "jose";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import WebSocket from "ws";
+import { agentPresence } from "../db/schema/agent-presence.js";
 import { clients } from "../db/schema/clients.js";
+import { createAgent } from "../services/agent.js";
+import * as clientService from "../services/client.js";
 import { createTestAdmin, createTestApp } from "./helpers.js";
 
 /**
@@ -82,6 +85,48 @@ describe("WS client reconnect race — late onClose must not clobber a fresh sta
     return ws;
   }
 
+  async function waitForFrame(
+    ws: WebSocket,
+    predicate: (msg: { type?: string }) => boolean,
+  ): Promise<{ type?: string }> {
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        ws.off("message", onMessage);
+        reject(new Error("frame timeout"));
+      }, 5000);
+      const onMessage = (raw: WebSocket.RawData) => {
+        const msg = JSON.parse(raw.toString()) as { type?: string };
+        if (!predicate(msg)) return;
+        clearTimeout(timer);
+        ws.off("message", onMessage);
+        resolve(msg);
+      };
+      ws.on("message", onMessage);
+    });
+  }
+
+  async function createBoundAgent(ws: WebSocket, clientId: string): Promise<string> {
+    const agent = await createAgent(app.db, {
+      name: `race-agent-${crypto.randomUUID().slice(0, 8)}`,
+      type: "agent",
+      displayName: "Race Agent",
+      managerId: memberId,
+      clientId,
+      runtimeProvider: "claude-code",
+    });
+    ws.send(
+      JSON.stringify({
+        type: "agent:bind",
+        ref: `bind-${crypto.randomUUID()}`,
+        agentId: agent.uuid,
+        runtimeType: "claude-code",
+      }),
+    );
+    const msg = await waitForFrame(ws, (m) => m.type === "agent:bound" || m.type === "agent:bind:rejected");
+    expect(msg.type).toBe("agent:bound");
+    return agent.uuid;
+  }
+
   beforeAll(async () => {
     app = await createTestApp();
     await app.listen({ port: 0, host: "127.0.0.1" });
@@ -142,20 +187,40 @@ describe("WS client reconnect race — late onClose must not clobber a fresh sta
     ws2.close();
   }, 10_000);
 
-  it("still writes 'disconnected' when the only socket closes (no replacement)", async () => {
-    // Sanity: the fix must not break the normal disconnect path. A
-    // single client opening then closing must end up disconnected in
-    // the DB, otherwise we'd have leaked the entire status signal.
+  it("keeps client and agent presence connected during the socket-close grace window", async () => {
+    // A single socket close is only a transport loss. Proactive auth
+    // refreshes and short network blips reconnect quickly, so the DB
+    // should keep the last connected presence until heartbeat staleness
+    // cleanup proves the client is gone.
     const token = await signAccess();
     const clientId = `client_${crypto.randomUUID().slice(0, 8)}`;
 
     const ws = await authAndRegister(token, clientId);
+    const agentId = await createBoundAgent(ws, clientId);
     const closed = new Promise<void>((resolve) => ws.on("close", () => resolve()));
     ws.close();
     await closed;
     await new Promise((r) => setTimeout(r, 100));
 
     const [row] = await app.db.select().from(clients).where(eq(clients.id, clientId));
-    expect(row?.status).toBe("disconnected");
+    expect(row?.status).toBe("connected");
+
+    const [presence] = await app.db.select().from(agentPresence).where(eq(agentPresence.agentId, agentId));
+    expect(presence?.status).toBe("online");
+    expect(presence?.clientId).toBe(clientId);
+    expect(presence?.runtimeState).toBe("idle");
+
+    const staleAt = new Date(Date.now() - 120_000);
+    await app.db.update(clients).set({ lastSeenAt: staleAt }).where(eq(clients.id, clientId));
+
+    await expect(clientService.cleanupStaleClients(app.db, 60)).resolves.toBe(1);
+
+    const [staleClient] = await app.db.select().from(clients).where(eq(clients.id, clientId));
+    expect(staleClient?.status).toBe("disconnected");
+
+    const [stalePresence] = await app.db.select().from(agentPresence).where(eq(agentPresence.agentId, agentId));
+    expect(stalePresence?.status).toBe("offline");
+    expect(stalePresence?.clientId).toBeNull();
+    expect(stalePresence?.runtimeState).toBeNull();
   }, 10_000);
 });

--- a/packages/server/src/api/agent/ws-client.ts
+++ b/packages/server/src/api/agent/ws-client.ts
@@ -1041,16 +1041,8 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
         clearTimeout(authTimeout);
         if (authExpiryTimer) clearTimeout(authExpiryTimer);
 
-        for (const [agentId, info] of boundAgents) {
+        for (const [, info] of boundAgents) {
           notifier.unsubscribe(info.inboxId, socket);
-          const currentOwner = connectionManager.getAgentClientId(agentId);
-          if (currentOwner === clientId) {
-            try {
-              await presenceService.unbindAgent(app.db, agentId);
-            } catch {
-              // best-effort
-            }
-          }
         }
         boundAgents.clear();
 
@@ -1066,20 +1058,12 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
           //   t2  the t0 onClose finally awaits to disconnectClient and would
           //       happily stamp clients.status='disconnected', clobbering t1
           //
-          // `isActiveClientConnection` returns false at t2 because the in-
-          // memory entry now points at the *new* socket, not us. Skip the DB
-          // write in that case so the new connection's `connected` status
-          // survives. Bug captured live at /clients[0].status='disconnected'
-          // with last_seen_at 13s old + a fully-registered client.log.
-          const stillActive = connectionManager.isActiveClientConnection(clientId, socket);
+          // A WebSocket close is only a transport loss. Proactive auth
+          // refreshes and short network blips reconnect in seconds, so do not
+          // stamp the client or agents disconnected here. Heartbeat staleness
+          // cleanup owns the grace window and marks the client/agents offline
+          // only if they do not reconnect in time.
           connectionManager.removeClientConnection(clientId, socket);
-          if (stillActive) {
-            try {
-              await clientService.disconnectClient(app.db, clientId);
-            } catch {
-              // best-effort
-            }
-          }
         }
       });
     });

--- a/packages/server/src/services/client.ts
+++ b/packages/server/src/services/client.ts
@@ -456,21 +456,25 @@ export async function retireClient(db: Database, clientId: string): Promise<void
 }
 
 /**
- * System-scope sweep: mark clients as disconnected when their last-seen
- * server instance stopped sending heartbeats. Runs globally across all orgs
- * by design — it is invoked only by internal timers, never from a
- * user-scoped request, so the per-org filter the read paths enforce does not
- * apply. Org isolation on the data these clients belong to is still
- * enforced at the read paths (see `assertClientOwner` / `listClients`).
+ * System-scope sweep: mark clients as disconnected when their own heartbeat
+ * is stale, or when their last-seen server instance stopped sending
+ * heartbeats. Runs globally across all orgs by design — it is invoked only by
+ * internal timers, never from a user-scoped request, so the per-org filter the
+ * read paths enforce does not apply. Org isolation on the data these clients
+ * belong to is still enforced at the read paths (see `assertClientOwner` /
+ * `listClients`).
  */
 export async function cleanupStaleClients(db: Database, staleSeconds = 60): Promise<number> {
   const result = await db.execute<{ id: string }>(sql`
     UPDATE clients SET status = 'disconnected'
-    WHERE instance_id IN (
-      SELECT instance_id FROM server_instances
-      WHERE last_heartbeat < NOW() - make_interval(secs => ${staleSeconds})
+    WHERE status = 'connected'
+    AND (
+      last_seen_at < NOW() - make_interval(secs => ${staleSeconds})
+      OR instance_id IN (
+        SELECT instance_id FROM server_instances
+        WHERE last_heartbeat < NOW() - make_interval(secs => ${staleSeconds})
+      )
     )
-    AND status = 'connected'
     RETURNING id
   `);
 
@@ -478,7 +482,7 @@ export async function cleanupStaleClients(db: Database, staleSeconds = 60): Prom
     const staleIds = result.map((r) => r.id);
     await db
       .update(agentPresence)
-      .set({ status: "offline", ...runtimeFieldsReset(new Date()) })
+      .set({ status: "offline", clientId: null, ...runtimeFieldsReset(new Date()) })
       .where(inArray(agentPresence.clientId, staleIds));
   }
 


### PR DESCRIPTION
## Summary
- stop treating ordinary client WebSocket close as immediate client/agent offline
- let heartbeat staleness cleanup own the grace window for client and agent presence
- extend the reconnect race regression test to cover client and agent presence during socket-close grace

## Validation
- pnpm --filter @first-tree/server exec vitest run src/__tests__/ws-client-reconnect-race.test.ts --pool=forks --poolOptions.forks.maxForks=1 --poolOptions.forks.minForks=1
- pnpm check
- pnpm typecheck