### PR TITLE
fix(client): make Context Tree reading unconditional and authoritative in agent briefing

### DIFF
--- a/packages/client/src/__tests__/agent-briefing.test.ts
+++ b/packages/client/src/__tests__/agent-briefing.test.ts
@@ -316,9 +316,9 @@ describe("buildAgentBriefing — # Context Tree", () => {
     // legacy "`AGENT.md`" string in someone's `prompt.append`).
     expect(briefing).toMatch(/If the root also contains an `AGENT\.md`, ?\s*read it too/);
     expect(briefing).toContain("mandatory rules the org expects every agent");
-    expect(briefing).toContain("read tree nodes eagerly, not lazily");
-    expect(briefing).toContain("Pick up a new task or requirement");
-    expect(briefing).toContain("Task scope shifts mid-conversation");
+    expect(briefing).toContain("before you act on any instruction");
+    expect(briefing).toContain("the tree wins");
+    expect(briefing).toContain("eagerly, not lazily");
 
     // Writing discipline anchors — fresh vs persistent context framing and
     // the tree-PR-before-code-PR ordering rule. The prose wraps the

--- a/packages/client/src/runtime/agent-briefing.ts
+++ b/packages/client/src/runtime/agent-briefing.ts
@@ -297,23 +297,24 @@ For node anatomy, ownership tiers, and soft_link navigation, load
 
   blocks.push(`## Reading the Tree
 
-Always start by reading the tree's **root \`NODE.md\`** — it is the
-team's domain directory. **If the root also contains an \`AGENT.md\`,
-read it too** — it carries mandatory rules the org expects every agent
-to follow before acting. From there, navigate however suits you: Read,
-Grep, listing a domain folder, jumping via \`soft_links\`. The tree is
-just a filesystem; use whatever tool gets you to the right node.
+**Read the tree before you act on any instruction — every task, even
+ones that look like pure code, CLI, or review work.** An instruction is
+underspecified on its own; in this org the tree supplies the background,
+requirements, and constraints that make acting on it correct.
 
-You **must** read tree nodes eagerly, not lazily:
+Always start at the tree's **root \`NODE.md\`** — the team's domain
+directory. **If the root also contains an \`AGENT.md\`, read it too** —
+it carries mandatory rules the org expects every agent to follow before
+acting. From there, follow the index / \`soft_links\` down to the nodes
+your task touches; Read, Grep, or list folders to get there.
 
-- **Pick up a new task or requirement** → read every node that touches
-  the domain, owners, prior decisions, or constraints involved before
-  acting. Acting before reading is the #1 source of advice that
-  conflicts with reality.
-- **Task scope shifts mid-conversation** → if a new domain, repo, or
-  owner gets pulled in, read those nodes before continuing.
-- **In doubt** → re-read. Re-reading is cheap; stale assumptions are
-  expensive.`);
+Where the tree's requirements or constraints **conflict with the
+instruction, the tree wins** — follow it and surface the conflict.
+(Local memory is the opposite: it yields to the instruction.)
+
+Read eagerly, not lazily — acting before reading is the #1 source of
+advice that conflicts with reality. On scope shift to a new
+domain/repo/owner, read those nodes first; in doubt, re-read.`);
 
   blocks.push(`## Writing the Tree
 
@@ -328,7 +329,7 @@ The write trigger is **task completion** — the moment you're ready to
 open the code PR. If the task touched decisions, constraints, ownership,
 or cross-domain relationships, the **tree PR opens first, then the code
 PR** — otherwise other agents keep acting on the old tree.
-Implementation-only changes skip the tree.
+Implementation-only changes skip the tree PR — not the read.
 
 Before writing, you MUST load the relevant skill first and follow its
 workflow:

--- a/packages/client/src/runtime/agent-briefing.ts
+++ b/packages/client/src/runtime/agent-briefing.ts
@@ -329,7 +329,7 @@ The write trigger is **task completion** — the moment you're ready to
 open the code PR. If the task touched decisions, constraints, ownership,
 or cross-domain relationships, the **tree PR opens first, then the code
 PR** — otherwise other agents keep acting on the old tree.
-Implementation-only changes skip the tree PR — not the read.
+Implementation-only changes skip the tree write — not the read.
 
 Before writing, you MUST load the relevant skill first and follow its
 workflow:


### PR DESCRIPTION
## Why

A controlled eval (10 real instructions replayed under the **current** briefing, in an isolated sandbox agent) found agents read the Context Tree **before acting in only 3/10** runs — and **0/5** when the instruction looked like pure code / CLI / review work.

Root cause is the **briefing wording**, not the binding:
- `## Reading the Tree` gated the read on relevance ("read every node that **touches the domain, owners, prior decisions, or constraints involved**"), so an agent that judged its task "just code" had license to skip.
- `## Core Model` ("Execution detail stays in source systems") and `## Writing the Tree` ("Implementation-only changes skip the tree") reinforced that skip — the write-skip rule bled into reading.

This contradicts the org model: **every work context can supply background + requirements for an instruction, so reading must be unconditional**, and org context **outranks** the instruction (the opposite of local memory, which yields to it).

## What

Two minimal wording changes in `packages/client/src/runtime/agent-briefing.ts` — **no new sections / files / skills**:

1. **`## Reading the Tree` rewritten** — reading is now **unconditional** ("Read the tree before you act on any instruction — every task, even ones that look like pure code, CLI, or review work"), navigation is index / `soft_links`-driven, and the key new semantic: **where the tree's requirements/constraints conflict with the instruction, the tree wins** (local memory is the opposite — it yields to the instruction).
2. **`## Writing the Tree` scoped** — "Implementation-only changes skip the tree" → "…skip the tree **PR — not the read**", so the write-skip rule no longer bleeds into reading.

## Test

- `agent-briefing.test.ts` anchors updated (unconditional / precedence / eager); `agent-briefing` + `codex-bootstrap` suites green (26/26).
- `@first-tree/client` typecheck clean; biome clean on the two changed files.
- ⚠️ Repo-wide `pnpm check` / `pnpm typecheck` currently fail on **pre-existing** issues unrelated to this PR (biome "nested root configuration"; `@first-tree/web` missing `fake-indexeddb` devDep) — not introduced here.

## Note

This is a prompt-behavior change; the real validation is re-running the eval (currently 3/10, implicit 0/5) under the new briefing to confirm the implicit-task read rate moves. Opened as **draft** for review of the wording before that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)