### PR TITLE
feat(web): Settings → Resources UX polish

### DIFF
--- a/packages/web/src/pages/__tests__/resource-editors-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/resource-editors-dom.test.tsx
@@ -61,7 +61,36 @@ async function flush(): Promise<void> {
     await Promise.resolve();
     await Promise.resolve();
     await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
   });
+}
+
+/**
+ * Poll for a button by text, flushing between attempts. Radix Popover / Dialog
+ * render their contents through a portal on an async tick, so a single flush()
+ * after the trigger click can race the option appearing (flaky under slower
+ * CI timing). Wait until it's there instead of assuming one tick is enough.
+ */
+async function waitForButton(text: string): Promise<HTMLButtonElement> {
+  for (let i = 0; i < 50; i++) {
+    const found = byText(text);
+    if (found) return found;
+    await flush();
+  }
+  throw new Error(`waitForButton: "${text}" never appeared`);
+}
+
+/** Wait until a button is present AND enabled, then click it. */
+async function clickWhenEnabled(text: string): Promise<void> {
+  for (let i = 0; i < 50; i++) {
+    const found = byText(text);
+    if (found && !found.disabled) {
+      await click(found);
+      return;
+    }
+    await flush();
+  }
+  throw new Error(`clickWhenEnabled: "${text}" never became enabled`);
 }
 
 async function render(): Promise<{ root: Root }> {
@@ -313,11 +342,48 @@ describe("resource editors", () => {
     await click(byText("Cancel"));
     expect(resourceMocks.retireResource).not.toHaveBeenCalled();
 
-    // Re-open and confirm → retire fires once with the resource id.
+    // Re-open and confirm → retire fires once with the resource id. The confirm
+    // re-disables briefly while the impact re-fetches, so wait for it to enable.
     await click(byAria("Retire github"));
-    await click(byText("Retire"));
+    await clickWhenEnabled("Retire");
     expect(resourceMocks.retireResource).toHaveBeenCalledTimes(1);
     expect(resourceMocks.retireResource.mock.calls[0]?.[0]).toBe("mcp-1");
+    await act(async () => root.unmount());
+  });
+
+  it("re-checks impact on every open — never confirms against a cached stale count", async () => {
+    // A fresh controllable promise per call lets us prove the second open
+    // re-fetches (gcTime: 0) instead of reusing the first open's cached count.
+    const resolvers: Array<(v: { affectedAgentCount: number; promptOverflowAgentCount: number; agents: [] }) => void> =
+      [];
+    resourceMocks.previewResourceImpact.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvers.push(resolve);
+        }),
+    );
+    const { root } = await render();
+
+    // Open #1: pending → disabled; resolve → enabled.
+    await click(byAria("Retire github"));
+    expect(byText("Retire")?.disabled).toBe(true);
+    await act(async () => {
+      resolvers[0]?.({ affectedAgentCount: 1, promptOverflowAgentCount: 0, agents: [] });
+    });
+    await flush();
+    expect(byText("Retire")?.disabled).toBe(false);
+    await click(byText("Cancel"));
+
+    // Reopen: must re-fetch and re-disable (not reuse the cached count), so a
+    // background refetch can't leave a stale-but-clickable confirm.
+    await click(byAria("Retire github"));
+    expect(resourceMocks.previewResourceImpact).toHaveBeenCalledTimes(2);
+    expect(byText("Retire")?.disabled).toBe(true);
+    await act(async () => {
+      resolvers[1]?.({ affectedAgentCount: 1, promptOverflowAgentCount: 0, agents: [] });
+    });
+    await flush();
+    expect(byText("Retire")?.disabled).toBe(false);
     await act(async () => root.unmount());
   });
 
@@ -371,7 +437,7 @@ describe("resource editors", () => {
     });
     const { root } = await render();
     await click(byText("Add resource"));
-    await click(byText("Prompt"));
+    await click(await waitForButton("Prompt"));
     const body = document.getElementById("prompt-body");
     if (!(body instanceof HTMLTextAreaElement)) throw new Error("prompt-body");
     await act(async () => {
@@ -381,11 +447,13 @@ describe("resource editors", () => {
 
     // First click runs the silent overflow check → warns, does NOT save yet.
     await click(byText("Create"));
+    // The check is async (impact preview) — wait for the warning to surface.
+    await waitForButton("Save anyway");
     expect(resourceMocks.createTeamResource).not.toHaveBeenCalled();
     expect(document.body.textContent).toContain("exceed the prompt budget for 2 agents");
 
     // Second click ("Save anyway") commits.
-    await click(byText("Save anyway"));
+    await click(await waitForButton("Save anyway"));
     expect(resourceMocks.createTeamResource).toHaveBeenCalledTimes(1);
     await act(async () => root.unmount());
   });

--- a/packages/web/src/pages/__tests__/resource-editors-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/resource-editors-dom.test.tsx
@@ -18,6 +18,7 @@ const resourceMocks = vi.hoisted(() => ({
   updateResource: vi.fn(),
   retireResource: vi.fn(),
   previewOrgResourceImpact: vi.fn(),
+  previewResourceImpact: vi.fn(),
 }));
 
 vi.mock("../../auth/auth-context.js", () => ({ useAuth: () => authMock.value }));
@@ -65,13 +66,16 @@ async function flush(): Promise<void> {
 
 async function render(): Promise<{ root: Root }> {
   const { SettingsResourcesPage } = await import("../settings/resources.js");
+  const { ToastProvider } = await import("../../components/ui/toast.js");
   const container = document.createElement("div");
   document.body.appendChild(container);
   const root = createRoot(container);
   await act(async () => {
     root.render(
       <QueryClientProvider client={createClient()}>
-        <SettingsResourcesPage />
+        <ToastProvider>
+          <SettingsResourcesPage />
+        </ToastProvider>
       </QueryClientProvider>,
     );
   });
@@ -126,7 +130,17 @@ beforeEach(() => {
     row({ id: "new", type: "repo", name: "x", payload: { url: "x" } }),
   );
   resourceMocks.updateResource.mockResolvedValue(GITHUB_MCP);
-  resourceMocks.retireResource.mockResolvedValue({ affectedAgentCount: 0, promptOverflowAgentCount: 0 });
+  resourceMocks.retireResource.mockResolvedValue({ affectedAgentCount: 0, promptOverflowAgentCount: 0, agents: [] });
+  resourceMocks.previewOrgResourceImpact.mockResolvedValue({
+    affectedAgentCount: 0,
+    promptOverflowAgentCount: 0,
+    agents: [],
+  });
+  resourceMocks.previewResourceImpact.mockResolvedValue({
+    affectedAgentCount: 0,
+    promptOverflowAgentCount: 0,
+    agents: [],
+  });
 });
 
 afterEach(() => {
@@ -277,12 +291,102 @@ describe("resource editors", () => {
     await act(async () => root.unmount());
   });
 
-  it("hides add / edit / retire affordances for members", async () => {
+  it("hides add / edit / retire affordances for members but keeps preview", async () => {
     authMock.value = { role: "member", organizationId: "org-1", meLoaded: true };
     const { root } = await render();
     expect(byText("Add resource")).toBeUndefined();
     expect(byAria("Edit github")).toBeUndefined();
     expect(byAria("Retire github")).toBeUndefined();
+    // Read-only preview is available to every member.
+    expect(byAria("Preview github")).toBeTruthy();
+    await act(async () => root.unmount());
+  });
+
+  it("requires a confirm step before retiring (cancel does not retire)", async () => {
+    const { root } = await render();
+    // Trash no longer retires on one click — it opens a confirm dialog.
+    await click(byAria("Retire github"));
+    expect(resourceMocks.retireResource).not.toHaveBeenCalled();
+    expect(document.body.textContent).toContain('Retire "github"?');
+
+    // Cancel backs out without retiring.
+    await click(byText("Cancel"));
+    expect(resourceMocks.retireResource).not.toHaveBeenCalled();
+
+    // Re-open and confirm → retire fires once with the resource id.
+    await click(byAria("Retire github"));
+    await click(byText("Retire"));
+    expect(resourceMocks.retireResource).toHaveBeenCalledTimes(1);
+    expect(resourceMocks.retireResource.mock.calls[0]?.[0]).toBe("mcp-1");
+    await act(async () => root.unmount());
+  });
+
+  it("disables the confirm button until the impact check resolves", async () => {
+    // Hold the impact check open so we can observe the pending state.
+    let resolveImpact: (v: { affectedAgentCount: number; promptOverflowAgentCount: number; agents: [] }) => void =
+      () => {};
+    resourceMocks.previewResourceImpact.mockReturnValue(
+      new Promise((r) => {
+        resolveImpact = r;
+      }),
+    );
+    const { root } = await render();
+    await click(byAria("Retire github"));
+    // While "Checking impact…", the confirm is disabled — can't retire blind.
+    expect(byText("Retire")?.disabled).toBe(true);
+    expect(resourceMocks.retireResource).not.toHaveBeenCalled();
+
+    // Once the count is in, the button enables.
+    await act(async () => {
+      resolveImpact({ affectedAgentCount: 2, promptOverflowAgentCount: 0, agents: [] });
+    });
+    await flush();
+    expect(byText("Retire")?.disabled).toBe(false);
+    await act(async () => root.unmount());
+  });
+
+  it("opens a read-only preview from the eye icon", async () => {
+    resourceMocks.listTeamResources.mockResolvedValue([
+      row({
+        id: "prompt-1",
+        type: "prompt",
+        name: "house style",
+        payload: { body: "# Voice\nWrite plainly.", description: "Tone guide" },
+      }),
+    ]);
+    const { root } = await render();
+    await click(byAria("Preview house style"));
+    // Read-only detail shows the full body content, not a one-line summary.
+    expect(document.body.textContent).toContain("Write plainly.");
+    // No edit controls inside the preview.
+    expect(document.getElementById("prompt-body")).toBeNull();
+    await act(async () => root.unmount());
+  });
+
+  it("warns on prompt overflow before saving, then saves on confirm", async () => {
+    resourceMocks.previewOrgResourceImpact.mockResolvedValue({
+      affectedAgentCount: 3,
+      promptOverflowAgentCount: 2,
+      agents: [],
+    });
+    const { root } = await render();
+    await click(byText("Add resource"));
+    await click(byText("Prompt"));
+    const body = document.getElementById("prompt-body");
+    if (!(body instanceof HTMLTextAreaElement)) throw new Error("prompt-body");
+    await act(async () => {
+      Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value")?.set?.call(body, "long body");
+      body.dispatchEvent(new InputEvent("input", { bubbles: true }));
+    });
+
+    // First click runs the silent overflow check → warns, does NOT save yet.
+    await click(byText("Create"));
+    expect(resourceMocks.createTeamResource).not.toHaveBeenCalled();
+    expect(document.body.textContent).toContain("exceed the prompt budget for 2 agents");
+
+    // Second click ("Save anyway") commits.
+    await click(byText("Save anyway"));
+    expect(resourceMocks.createTeamResource).toHaveBeenCalledTimes(1);
     await act(async () => root.unmount());
   });
 });

--- a/packages/web/src/pages/__tests__/resource-editors-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/resource-editors-dom.test.tsx
@@ -80,6 +80,19 @@ async function waitForButton(text: string): Promise<HTMLButtonElement> {
   throw new Error(`waitForButton: "${text}" never appeared`);
 }
 
+/**
+ * Close any open overlay (Radix Dialog / our Popover both dismiss on Escape).
+ * Call before unmounting a test that left a dialog open, so the overlay's
+ * cleanup runs while mounted instead of racing unmount and leaking body
+ * attributes (pointer-events / scroll-lock) into the next test.
+ */
+async function pressEscape(): Promise<void> {
+  await act(async () => {
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+  });
+  await flush();
+}
+
 /** Wait until a button is present AND enabled, then click it. */
 async function clickWhenEnabled(text: string): Promise<void> {
   for (let i = 0; i < 50; i++) {
@@ -153,6 +166,18 @@ function lastByPlaceholder(placeholder: string): HTMLInputElement {
 
 beforeEach(() => {
   document.body.innerHTML = "";
+  // Radix Dialog (+ react-remove-scroll) sets attributes/styles on <body>/<html>
+  // while open — pointer-events, aria-hidden, inert, data-scroll-locked. In
+  // happy-dom these can survive a root.unmount(), so a dialog test would poison
+  // the next test's portal rendering (e.g. the Add-resource popover never
+  // mounting). Scrub them so every test starts from a clean document.
+  for (const el of [document.body, document.documentElement]) {
+    el.removeAttribute("style");
+    el.removeAttribute("aria-hidden");
+    el.removeAttribute("inert");
+    el.removeAttribute("data-scroll-locked");
+    el.removeAttribute("data-aria-hidden");
+  }
   authMock.value = { role: "admin", organizationId: "org-1", meLoaded: true };
   resourceMocks.listTeamResources.mockResolvedValue([GITHUB_MCP]);
   resourceMocks.createTeamResource.mockResolvedValue(
@@ -384,6 +409,7 @@ describe("resource editors", () => {
     });
     await flush();
     expect(byText("Retire")?.disabled).toBe(false);
+    await pressEscape();
     await act(async () => root.unmount());
   });
 
@@ -408,6 +434,7 @@ describe("resource editors", () => {
     });
     await flush();
     expect(byText("Retire")?.disabled).toBe(false);
+    await pressEscape();
     await act(async () => root.unmount());
   });
 
@@ -426,6 +453,7 @@ describe("resource editors", () => {
     expect(document.body.textContent).toContain("Write plainly.");
     // No edit controls inside the preview.
     expect(document.getElementById("prompt-body")).toBeNull();
+    await pressEscape();
     await act(async () => root.unmount());
   });
 
@@ -435,9 +463,24 @@ describe("resource editors", () => {
       promptOverflowAgentCount: 2,
       agents: [],
     });
-    const { root } = await render();
-    await click(byText("Add resource"));
-    await click(await waitForButton("Prompt"));
+    // Render the prompt editor directly rather than driving the Add-resource
+    // Popover. The assertion target is the overflow save flow, not menu
+    // navigation (already covered by the create tests above) — and opening a
+    // portal-anchored Popover after the Dialog-heavy tests in this file is a
+    // CI-only teardown-leak hazard. Mounting the editor sidesteps it entirely.
+    const { ResourceEditor } = await import("../settings/resource-editors.js");
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={createClient()}>
+          <ResourceEditor state={{ mode: "create", type: "prompt" }} onClose={() => {}} />
+        </QueryClientProvider>,
+      );
+    });
+    await flush();
+
     const body = document.getElementById("prompt-body");
     if (!(body instanceof HTMLTextAreaElement)) throw new Error("prompt-body");
     await act(async () => {
@@ -455,6 +498,7 @@ describe("resource editors", () => {
     // Second click ("Save anyway") commits.
     await click(await waitForButton("Save anyway"));
     expect(resourceMocks.createTeamResource).toHaveBeenCalledTimes(1);
+    await pressEscape();
     await act(async () => root.unmount());
   });
 });

--- a/packages/web/src/pages/resources-preview.tsx
+++ b/packages/web/src/pages/resources-preview.tsx
@@ -44,33 +44,59 @@ const SAMPLE: ResourceRow[] = [
     type: "repo",
     name: "first-tree",
     defaultEnabled: "recommended",
-    payload: { url: "git@github.com:agent-team-foundation/first-tree.git" },
+    // A deliberately long URL so the row truncation + hover tooltip is testable.
+    payload: { url: "git@github.com:agent-team-foundation/first-tree-monorepo-with-a-very-long-name.git" },
   }),
   row({
     id: "r2",
     type: "repo",
     name: "context-tree",
-    payload: { url: "git@github.com:agent-team-foundation/context-tree.git" },
+    payload: { url: "git@github.com:agent-team-foundation/context-tree.git", defaultBranch: "main" },
   }),
   row({
     id: "r3",
     type: "prompt",
     name: "Code review checklist",
     defaultEnabled: "recommended",
-    payload: { description: "House rules for reviewing a diff before approval." },
+    payload: {
+      description: "House rules for reviewing a diff before approval.",
+      body: "# Code review checklist\n\n- **Correctness** — does it do what the PR says?\n- **Tests** — new behaviour covered, edge cases included.\n- **Security** — no secrets, no SQL string-building, trust boundaries respected.\n- **Style** — tokens not raw values, no `any`, no `as` without a reason.\n\nApprove only when every box is honestly ticked.",
+    },
   }),
   row({
     id: "r4",
-    type: "skill",
-    name: "release-notes",
-    payload: { description: "Draft release notes from a merged PR range." },
+    type: "prompt",
+    // No description → list summary falls back to a stripped body snippet
+    // (instead of the old meaningless "N chars").
+    name: "Tone guide",
+    payload: {
+      body: "Write plainly and directly. Prefer short sentences. Avoid filler like *very*, *really*, *just*. Lead with the conclusion, then the reasoning.",
+    },
   }),
   row({
     id: "r5",
+    type: "skill",
+    name: "release-notes",
+    payload: {
+      name: "release-notes",
+      namespace: "team",
+      description: "Draft release notes from a merged PR range.",
+      body: "## release-notes\n\nGiven a PR range, group merged PRs into **Features / Fixes / Chores** and write a one-line human summary for each. Link every entry to its PR.",
+      metadata: { category: "writing" },
+    },
+  }),
+  row({
+    id: "r6",
     type: "mcp",
     name: "github",
     defaultEnabled: "recommended",
     payload: { name: "github", transport: "http", url: "https://mcp.example.com/github" },
+  }),
+  row({
+    id: "r7",
+    type: "mcp",
+    name: "local-tools",
+    payload: { name: "local-tools", transport: "stdio", command: "npx", args: ["-y", "@team/mcp-tools", "--verbose"] },
   }),
 ];
 

--- a/packages/web/src/pages/settings/resource-editors.tsx
+++ b/packages/web/src/pages/settings/resource-editors.tsx
@@ -1,7 +1,7 @@
 import type { CreateTeamResource, ResourceRow, ResourceType } from "@first-tree/shared";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Plus, Trash2 } from "lucide-react";
-import { type FormEvent, type ReactNode, useState } from "react";
+import { type FormEvent, type ReactNode, useRef, useState } from "react";
 import {
   createTeamResource,
   previewOrgResourceImpact,
@@ -167,16 +167,23 @@ export function ResourceEditor({ state, onClose }: { state: EditorState; onClose
 // ─────────────────────────────────────────────────────────────────────────
 
 type SaveApi = {
-  submit: (payload: CreateTeamResource) => void;
-  preview: (payload: CreateTeamResource) => void;
+  /** Entry point. For prompt/skill, runs a silent prompt-overflow check first
+   *  (zero friction when there's no overflow); otherwise saves directly. */
+  requestSave: (payload: CreateTeamResource) => void;
   saving: boolean;
+  checking: boolean;
   error: string | null;
-  impact: string | null;
+  /** Set when a prompt-overflow was detected and the user must confirm. */
+  overflowWarning: string | null;
 };
 
 function useResourceSave(state: EditorState, onDone: () => void): SaveApi {
   const [error, setError] = useState<string | null>(null);
-  const [impact, setImpact] = useState<string | null>(null);
+  const [overflowWarning, setOverflowWarning] = useState<string | null>(null);
+  // Once the user has seen the overflow warning, the next submit goes through.
+  // Sticky for the editor's lifetime — editing the body after acknowledging
+  // won't re-trigger the check, which is an acceptable trade for v1.
+  const acknowledged = useRef(false);
 
   const createMut = useMutation({
     mutationFn: createTeamResource,
@@ -193,7 +200,14 @@ function useResourceSave(state: EditorState, onDone: () => void): SaveApi {
     onSuccess: onDone,
     onError: (e) => setError(e instanceof Error ? e.message : String(e)),
   });
-  const previewMut = useMutation({
+
+  const doSubmit = (payload: CreateTeamResource) => {
+    setError(null);
+    if (state.mode === "edit") updateMut.mutate(payload);
+    else createMut.mutate(payload);
+  };
+
+  const overflowMut = useMutation({
     // Edit must use the per-resource impact endpoint — the org endpoint only
     // simulates a brand-new recommended resource and under-reports changes to
     // an existing (e.g. available, already-bound) one.
@@ -201,21 +215,36 @@ function useResourceSave(state: EditorState, onDone: () => void): SaveApi {
       const body = { type: payload.type, defaultEnabled: payload.defaultEnabled, payload: payload.payload };
       return state.mode === "edit" ? previewResourceImpact(state.resource.id, body) : previewOrgResourceImpact(body);
     },
-    onSuccess: (r) =>
-      setImpact(`${r.affectedAgentCount} agents affected, ${r.promptOverflowAgentCount} prompt overflows`),
-    onError: (e) => setError(e instanceof Error ? e.message : String(e)),
+    onSuccess: (r, payload) => {
+      const overflow = r?.promptOverflowAgentCount ?? 0;
+      if (overflow > 0) {
+        acknowledged.current = true;
+        setOverflowWarning(
+          `Saving this will exceed the prompt budget for ${overflow} agent${overflow === 1 ? "" : "s"}. Save anyway?`,
+        );
+        return;
+      }
+      doSubmit(payload);
+    },
+    // A failed soft-check must not block saving — fall through to the real save.
+    onError: (_e, payload) => doSubmit(payload),
   });
 
   return {
-    submit: (payload) => {
+    requestSave: (payload) => {
       setError(null);
-      if (state.mode === "edit") updateMut.mutate(payload);
-      else createMut.mutate(payload);
+      // Only prompt/skill bodies can overflow an agent's prompt budget.
+      const gated = payload.type === "prompt" || payload.type === "skill";
+      if (!gated || acknowledged.current) {
+        doSubmit(payload);
+        return;
+      }
+      overflowMut.mutate(payload);
     },
-    preview: (payload) => previewMut.mutate(payload),
     saving: createMut.isPending || updateMut.isPending,
+    checking: overflowMut.isPending,
     error,
-    impact,
+    overflowWarning,
   };
 }
 
@@ -378,16 +407,14 @@ function pairsToRecord(pairs: [string, string][]): Record<string, string> {
   return out;
 }
 
-// Shared footer (Cancel · Preview · Save) — reused by every editor.
+// Shared footer (Cancel · Save) — reused by every editor.
 function EditorFooter({
   save,
-  payload,
   saveLabel,
   onCancel,
   localError,
 }: {
   save: SaveApi;
-  payload: () => CreateTeamResource;
   saveLabel: string;
   onCancel: () => void;
   /** Client-side validation message (blocks submit before the API call). */
@@ -395,9 +422,9 @@ function EditorFooter({
 }) {
   return (
     <>
-      {save.impact ? (
-        <p className="text-caption" style={{ color: "var(--fg-3)" }}>
-          {save.impact}
+      {save.overflowWarning ? (
+        <p className="text-caption" style={{ color: "var(--state-blocked)" }}>
+          {save.overflowWarning}
         </p>
       ) : null}
       {localError || save.error ? (
@@ -408,11 +435,8 @@ function EditorFooter({
       <Button type="button" variant="ghost" onClick={onCancel}>
         Cancel
       </Button>
-      <Button type="button" variant="outline" onClick={() => save.preview(payload())}>
-        Preview
-      </Button>
-      <Button type="submit" disabled={save.saving}>
-        {saveLabel}
+      <Button type="submit" disabled={save.saving || save.checking}>
+        {save.overflowWarning ? "Save anyway" : saveLabel}
       </Button>
     </>
   );
@@ -593,7 +617,7 @@ function ModalEditor({
     const v = validate?.() ?? null;
     setLocalError(v);
     if (v) return;
-    save.submit(payload());
+    save.requestSave(payload());
   };
   return (
     <Dialog open onOpenChange={(o) => (!o ? onClose() : undefined)}>
@@ -610,7 +634,6 @@ function ModalEditor({
           <DialogFooter>
             <EditorFooter
               save={save}
-              payload={payload}
               saveLabel={state.mode === "edit" ? "Save" : "Create"}
               onCancel={onClose}
               localError={localError}

--- a/packages/web/src/pages/settings/resource-preview-dialog.tsx
+++ b/packages/web/src/pages/settings/resource-preview-dialog.tsx
@@ -1,0 +1,186 @@
+import type { ResourceRow } from "@first-tree/shared";
+import type { ReactNode } from "react";
+import { Badge } from "../../components/ui/badge.js";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "../../components/ui/dialog.js";
+import { Markdown } from "../../components/ui/markdown.js";
+
+/**
+ * Read-only detail view for a single team resource. Opened from the eye icon on
+ * each row — visible to every member (not just admins), since it mutates
+ * nothing. Renders straight from the row's `payload`; no extra fetch.
+ *
+ * prompt / skill bodies render as Markdown (the list only shows a one-line
+ * summary); repo shows a clickable URL; mcp shows its transport/command config.
+ * Per the design system, read-only content is plain labeled text — not wrapped
+ * in a filled/bordered card (card chrome = interactivity).
+ */
+
+// Safe reads off the `unknown` resource payload (mirrors resource-editors.tsx).
+function str(payload: unknown, key: string): string {
+  if (payload && typeof payload === "object" && key in payload) {
+    const v = (payload as Record<string, unknown>)[key];
+    if (typeof v === "string") return v;
+  }
+  return "";
+}
+function strList(payload: unknown, key: string): string[] {
+  if (payload && typeof payload === "object" && key in payload) {
+    const v = (payload as Record<string, unknown>)[key];
+    if (Array.isArray(v)) return v.filter((x): x is string => typeof x === "string");
+  }
+  return [];
+}
+function entries(payload: unknown, key: string): [string, string][] {
+  if (payload && typeof payload === "object" && key in payload) {
+    const v = (payload as Record<string, unknown>)[key];
+    if (v && typeof v === "object") {
+      return Object.entries(v).map(([k, val]) => [k, typeof val === "string" ? val : JSON.stringify(val)]);
+    }
+  }
+  return [];
+}
+
+function Detail({ label, mono, children }: { label: string; mono?: boolean; children: ReactNode }) {
+  return (
+    <div className="space-y-1">
+      <p className="m-0 text-label" style={{ color: "var(--fg-3)" }}>
+        {label}
+      </p>
+      <div className={mono ? "text-body mono" : "text-body"} style={{ color: "var(--fg)", overflowWrap: "anywhere" }}>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function BodyDetail({ body }: { body: string }) {
+  return (
+    <div className="space-y-1">
+      <p className="m-0 text-label" style={{ color: "var(--fg-3)" }}>
+        Body
+      </p>
+      {body.trim() ? (
+        <Markdown>{body}</Markdown>
+      ) : (
+        <p className="m-0 text-body" style={{ color: "var(--fg-4)" }}>
+          Empty.
+        </p>
+      )}
+    </div>
+  );
+}
+
+function PreviewFields({ resource }: { resource: ResourceRow }) {
+  const p = resource.payload;
+  if (resource.type === "repo") {
+    const url = str(p, "url");
+    const branch = str(p, "defaultBranch");
+    return (
+      <>
+        {url ? (
+          <Detail label="Repository URL" mono>
+            <a
+              href={url}
+              target="_blank"
+              rel="noreferrer"
+              className="hover:underline"
+              style={{ color: "var(--primary)" }}
+            >
+              {url}
+            </a>
+          </Detail>
+        ) : null}
+        <Detail label="Default branch" mono>
+          {branch || "Repository default"}
+        </Detail>
+      </>
+    );
+  }
+  if (resource.type === "mcp") {
+    const transport = str(p, "transport");
+    const command = str(p, "command");
+    const args = strList(p, "args");
+    const url = str(p, "url");
+    return (
+      <>
+        <Detail label="Server id" mono>
+          {str(p, "name") || resource.name}
+        </Detail>
+        <Detail label="Transport" mono>
+          {transport || "stdio"}
+        </Detail>
+        {command ? (
+          <Detail label="Command" mono>
+            {command}
+          </Detail>
+        ) : null}
+        {args.length ? (
+          <Detail label="Args" mono>
+            <div className="flex flex-col" style={{ gap: "var(--sp-0_5)" }}>
+              {args.map((a, i) => (
+                // biome-ignore lint/suspicious/noArrayIndexKey: positional, read-only
+                <span key={i}>{a}</span>
+              ))}
+            </div>
+          </Detail>
+        ) : null}
+        {url ? (
+          <Detail label="URL" mono>
+            {url}
+          </Detail>
+        ) : null}
+      </>
+    );
+  }
+  // prompt / skill
+  const description = str(p, "description");
+  const namespace = str(p, "namespace");
+  const meta = entries(p, "metadata");
+  return (
+    <>
+      {resource.type === "skill" ? (
+        <Detail label="Skill id" mono>
+          {str(p, "name") || resource.name}
+        </Detail>
+      ) : null}
+      {namespace ? (
+        <Detail label="Namespace" mono>
+          {namespace}
+        </Detail>
+      ) : null}
+      {description ? <Detail label="Description">{description}</Detail> : null}
+      <BodyDetail body={str(p, "body")} />
+      {meta.length ? (
+        <Detail label="Metadata" mono>
+          <div className="flex flex-col" style={{ gap: "var(--sp-0_5)" }}>
+            {meta.map(([k, v]) => (
+              <span key={k}>
+                {k}: {v}
+              </span>
+            ))}
+          </div>
+        </Detail>
+      ) : null}
+    </>
+  );
+}
+
+export function ResourcePreviewDialog({ resource, onClose }: { resource: ResourceRow; onClose: () => void }) {
+  return (
+    <Dialog open onOpenChange={(o) => (!o ? onClose() : undefined)}>
+      <DialogContent aria-describedby={undefined}>
+        <DialogHeader>
+          <DialogTitle>{resource.name}</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4" style={{ maxHeight: "70vh", overflowY: "auto" }}>
+          <div>
+            <Badge variant={resource.defaultEnabled === "recommended" ? "secondary" : "outline"}>
+              {resource.defaultEnabled}
+            </Badge>
+          </div>
+          <PreviewFields resource={resource} />
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/web/src/pages/settings/resources.tsx
+++ b/packages/web/src/pages/settings/resources.tsx
@@ -54,6 +54,11 @@ export function SettingsResourcesPage() {
       addToast({ title: `Retired "${retireTarget?.name ?? "resource"}"` });
       setRetireTarget(null);
     },
+    onError: (e) => {
+      // Surface the failure instead of silently re-enabling the dialog; the
+      // dialog stays open so the user can retry or cancel.
+      addToast({ title: "Couldn't retire resource", description: e instanceof Error ? e.message : String(e) });
+    },
   });
 
   const grouped = useMemo(() => {
@@ -234,12 +239,19 @@ function RetireConfirmDialog(props: {
   onCancel: () => void;
   onConfirm: () => void;
 }) {
+  // Destructive action: never confirm against a stale count. `gcTime: 0` drops
+  // the cache when the dialog closes, so each open re-fetches fresh rather than
+  // reusing a prior result; the confirm button + copy then gate on `isFetching`
+  // (not just `isPending`) so an in-flight (re)fetch keeps it blocked.
   const impactQuery = useQuery({
     queryKey: ["resource-impact", props.resource.id],
     queryFn: () => previewResourceImpact(props.resource.id),
+    gcTime: 0,
+    staleTime: 0,
   });
+  const checking = impactQuery.isFetching;
   const count = impactQuery.data?.affectedAgentCount;
-  const impactLine = impactQuery.isLoading
+  const impactLine = checking
     ? "Checking impact…"
     : count === undefined
       ? "This removes the resource from the team's runtime defaults."
@@ -259,15 +271,11 @@ function RetireConfirmDialog(props: {
             Cancel
           </Button>
           {/* Block the confirm until the impact check resolves, so the user
-              can't retire before seeing how many agents it affects. `isPending`
-              clears on both success and error — a failed soft-check never locks
-              the button. */}
-          <Button
-            type="button"
-            variant="destructive"
-            onClick={props.onConfirm}
-            disabled={props.retiring || impactQuery.isPending}
-          >
+              can't retire before seeing how many agents it affects. `isFetching`
+              (not just `isPending`) also blocks a background refetch on reopen,
+              so a cached stale count is never confirmable; it clears on both
+              success and error, so a failed check never locks the button. */}
+          <Button type="button" variant="destructive" onClick={props.onConfirm} disabled={props.retiring || checking}>
             {props.retiring ? "Retiring…" : "Retire"}
           </Button>
         </DialogFooter>

--- a/packages/web/src/pages/settings/resources.tsx
+++ b/packages/web/src/pages/settings/resources.tsx
@@ -1,13 +1,23 @@
 import type { ResourceRow, ResourceType } from "@first-tree/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Pencil, Trash2 } from "lucide-react";
+import { Eye, Pencil, Trash2 } from "lucide-react";
 import { useMemo, useState } from "react";
-import { listTeamResources, retireResource } from "../../api/resources.js";
+import { listTeamResources, previewResourceImpact, retireResource } from "../../api/resources.js";
 import { useAuth } from "../../auth/auth-context.js";
 import { Badge } from "../../components/ui/badge.js";
 import { Button } from "../../components/ui/button.js";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "../../components/ui/dialog.js";
 import { PageHeader } from "../../components/ui/page-header.js";
 import { Section } from "../../components/ui/section.js";
+import { useToast } from "../../components/ui/toast.js";
+import { stripInlineMarkdown } from "../../lib/strip-inline-markdown.js";
 import {
   AddResourceMenu,
   type EditorState,
@@ -15,26 +25,35 @@ import {
   ResourceEditor,
   typeLabelPlural,
 } from "./resource-editors.js";
+import { ResourcePreviewDialog } from "./resource-preview-dialog.js";
 
 /**
  * Settings → Resources. Org-scoped runtime resources (repo / prompt / skill /
  * mcp) the team's agents consume. Lives under Settings (an org-admin config
  * surface), not on the Team roster — see the Settings IA in settings.tsx.
  *
- * Visible to all members (read-only); only admins see add / edit / retire
- * affordances. Adding is type-first: one "Add resource" menu picks the type,
- * then a per-type editor opens (repo/mcp in a modal, prompt/skill in a side
- * sheet — see resource-editors.tsx). The same editors handle edit, prefilled.
+ * Visible to all members. Everyone can open the read-only preview (the eye
+ * icon); only admins see add / edit / retire affordances. Adding is type-first:
+ * one "Add resource" menu picks the type, then a per-type editor opens (all
+ * four render in a modal — see resource-editors.tsx). The same editors handle
+ * edit, prefilled.
  */
 export function SettingsResourcesPage() {
   const { role } = useAuth();
   const isAdmin = role === "admin";
   const queryClient = useQueryClient();
+  const { addToast } = useToast();
   const [editor, setEditor] = useState<EditorState | null>(null);
+  const [preview, setPreview] = useState<ResourceRow | null>(null);
+  const [retireTarget, setRetireTarget] = useState<ResourceRow | null>(null);
   const resourcesQuery = useQuery({ queryKey: ["team-resources"], queryFn: listTeamResources });
   const retireMut = useMutation({
     mutationFn: retireResource,
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["team-resources"] }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["team-resources"] });
+      addToast({ title: `Retired "${retireTarget?.name ?? "resource"}"` });
+      setRetireTarget(null);
+    },
   });
 
   const grouped = useMemo(() => {
@@ -76,9 +95,9 @@ export function SettingsResourcesPage() {
                       key={resource.id}
                       resource={resource}
                       canEdit={isAdmin}
-                      retiring={retireMut.isPending}
+                      onPreview={() => setPreview(resource)}
                       onEdit={() => setEditor({ mode: "edit", type: resource.type, resource })}
-                      onRetire={() => retireMut.mutate(resource.id)}
+                      onRetire={() => setRetireTarget(resource)}
                     />
                   ))
                 )}
@@ -96,26 +115,49 @@ export function SettingsResourcesPage() {
           onClose={() => setEditor(null)}
         />
       ) : null}
+      {preview ? <ResourcePreviewDialog resource={preview} onClose={() => setPreview(null)} /> : null}
+      {retireTarget ? (
+        <RetireConfirmDialog
+          resource={retireTarget}
+          retiring={retireMut.isPending}
+          onCancel={() => setRetireTarget(null)}
+          onConfirm={() => retireMut.mutate(retireTarget.id)}
+        />
+      ) : null}
     </>
   );
+}
+
+/** One-line list summary. Prompt/skill prefer description, then a stripped body
+ *  snippet — never the meaningless raw character count. */
+function summarize(resource: ResourceRow): string {
+  const payload = resource.payload;
+  const read = (key: string): string => {
+    if (payload && typeof payload === "object" && key in payload) {
+      const v = (payload as Record<string, unknown>)[key];
+      if (typeof v === "string") return v;
+    }
+    return "";
+  };
+  if (resource.type === "repo") return read("url");
+  if (resource.type === "mcp") return read("url") || read("command");
+  // prompt / skill
+  const description = read("description");
+  if (description) return description;
+  const body = read("body");
+  if (!body) return "";
+  const snippet = stripInlineMarkdown(body.replace(/\s+/g, " ")).trim();
+  return snippet.length > 140 ? `${snippet.slice(0, 140)}…` : snippet;
 }
 
 function ResourceListRow(props: {
   resource: ResourceRow;
   canEdit: boolean;
-  retiring: boolean;
+  onPreview: () => void;
   onEdit: () => void;
   onRetire: () => void;
 }) {
-  const payload = props.resource.payload as Record<string, unknown>;
-  const detail =
-    typeof payload.url === "string"
-      ? payload.url
-      : typeof payload.description === "string"
-        ? payload.description
-        : typeof payload.body === "string"
-          ? `${payload.body.length} chars`
-          : "";
+  const detail = summarize(props.resource);
   return (
     <div
       className="group flex items-center gap-3"
@@ -123,7 +165,7 @@ function ResourceListRow(props: {
     >
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
-          <p className="m-0 text-body font-medium truncate" style={{ color: "var(--fg)" }}>
+          <p className="m-0 text-body font-medium truncate" style={{ color: "var(--fg)" }} title={props.resource.name}>
             {props.resource.name}
           </p>
           <Badge variant={props.resource.defaultEnabled === "recommended" ? "secondary" : "outline"}>
@@ -131,34 +173,105 @@ function ResourceListRow(props: {
           </Badge>
         </div>
         {detail ? (
-          <p className="m-0 text-caption truncate mono" style={{ color: "var(--fg-3)", marginTop: "var(--sp-0_5)" }}>
+          <p
+            className="m-0 text-caption truncate mono"
+            style={{ color: "var(--fg-3)", marginTop: "var(--sp-0_5)" }}
+            title={detail}
+          >
             {detail}
           </p>
         ) : null}
       </div>
-      {props.canEdit ? (
-        <div className="flex items-center opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
-          <Button
-            type="button"
-            variant="ghost"
-            size="xs"
-            aria-label={`Edit ${props.resource.name}`}
-            onClick={props.onEdit}
-          >
-            <Pencil className="h-4 w-4" />
-          </Button>
-          <Button
-            type="button"
-            variant="ghost"
-            size="xs"
-            aria-label={`Retire ${props.resource.name}`}
-            disabled={props.retiring}
-            onClick={props.onRetire}
-          >
-            <Trash2 className="h-4 w-4" />
-          </Button>
-        </div>
-      ) : null}
+      {/* Row actions reveal on hover (pointer devices) and stay visible on
+          coarse/touch pointers that have no hover state. Preview (eye) is
+          available to every member; edit / retire are admin-only. The eye
+          follows the same reveal behaviour as edit/retire for consistency. */}
+      <div className="flex items-center opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 pointer-coarse:opacity-100">
+        <Button
+          type="button"
+          variant="ghost"
+          size="xs"
+          aria-label={`Preview ${props.resource.name}`}
+          onClick={props.onPreview}
+        >
+          <Eye className="h-4 w-4" />
+        </Button>
+        {props.canEdit ? (
+          <>
+            <Button
+              type="button"
+              variant="ghost"
+              size="xs"
+              aria-label={`Edit ${props.resource.name}`}
+              onClick={props.onEdit}
+            >
+              <Pencil className="h-4 w-4" />
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="xs"
+              aria-label={`Retire ${props.resource.name}`}
+              onClick={props.onRetire}
+            >
+              <Trash2 className="h-4 w-4" />
+            </Button>
+          </>
+        ) : null}
+      </div>
     </div>
+  );
+}
+
+/**
+ * Retire confirmation. Retiring bumps every consuming agent's config version,
+ * so we fetch the impact (how many agents) and show it before the user
+ * commits — and require an explicit confirm rather than retiring on one click.
+ */
+function RetireConfirmDialog(props: {
+  resource: ResourceRow;
+  retiring: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  const impactQuery = useQuery({
+    queryKey: ["resource-impact", props.resource.id],
+    queryFn: () => previewResourceImpact(props.resource.id),
+  });
+  const count = impactQuery.data?.affectedAgentCount;
+  const impactLine = impactQuery.isLoading
+    ? "Checking impact…"
+    : count === undefined
+      ? "This removes the resource from the team's runtime defaults."
+      : count === 0
+        ? "No agents currently use this resource."
+        : `This will update ${count} agent${count === 1 ? "" : "s"} that use this resource.`;
+
+  return (
+    <Dialog open onOpenChange={(o) => (!o ? props.onCancel() : undefined)}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Retire "{props.resource.name}"?</DialogTitle>
+        </DialogHeader>
+        <DialogDescription style={{ color: "var(--fg-2)" }}>{impactLine}</DialogDescription>
+        <DialogFooter>
+          <Button type="button" variant="ghost" onClick={props.onCancel} disabled={props.retiring}>
+            Cancel
+          </Button>
+          {/* Block the confirm until the impact check resolves, so the user
+              can't retire before seeing how many agents it affects. `isPending`
+              clears on both success and error — a failed soft-check never locks
+              the button. */}
+          <Button
+            type="button"
+            variant="destructive"
+            onClick={props.onConfirm}
+            disabled={props.retiring || impactQuery.isPending}
+          >
+            {props.retiring ? "Retiring…" : "Retire"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }


### PR DESCRIPTION
## What & why
Polish the **Settings → Resources** page (org-scoped runtime resources: repo / prompt / skill / mcp) from a user review. Six requested items plus one follow-up. **Frontend only — no backend or shared-type changes**; all server endpoints already existed.

## Changes
1. **Delete (retire)二次确认** — the trash icon now opens a confirm dialog instead of retiring on one click. It fetches `previewResourceImpact` and shows **how many agents the retire will affect** (retire bumps each consuming agent's config version). Success raises a toast; per-row, no global disable.
2. **Long-text tooltip** — truncated row name + summary get a native `title` so the full value is visible on hover (zero design-token risk).
3. **Read-only content preview** (new) — an **eye icon** opens a per-type detail dialog, **visible to every member** (read-only, not admin-gated). prompt/skill render their **full body as Markdown**; repo shows a clickable URL; mcp shows transport/command/args/url. Renders straight from row data — no extra fetch.
4. **Drop the misnamed "Preview" button** in the editor (it computed *impact*, not content) — and **preserve the overflow warning**: prompt/skill run a silent prompt-overflow check on save. Zero friction when there's no overflow; a **"Save anyway" warning + confirm** only when an agent's prompt budget would overflow (soft check — a failed check never blocks saving).
5. **Touch reachability** — row actions reveal on hover for pointer devices but stay visible on coarse (touch) pointers (`pointer-coarse`).
6. **Prompt summary** — prefer `description`, else a stripped body snippet; drop the meaningless **"N chars"**.

### Follow-up (from review)
- **Confirm disabled until the impact check resolves** — the Retire button is disabled while the affected-agent count is still loading, so you can't retire before seeing it. `isPending` clears on both success and error, so a failed soft-check never locks the button.
- Row actions made consistent: the eye follows the same hover-reveal behaviour as edit/retire.

## Files
- `packages/web/src/pages/settings/resources.tsx` — row actions, retire confirm dialog, tooltip, touch, summary
- `packages/web/src/pages/settings/resource-preview-dialog.tsx` — **new** read-only preview
- `packages/web/src/pages/settings/resource-editors.tsx` — remove Preview button, overflow inline confirm
- `packages/web/src/pages/resources-preview.tsx` — enrich DEV `/preview/resources` sample data (long URL, bodies, etc.)
- `packages/web/src/pages/__tests__/resource-editors-dom.test.tsx` — DOM tests 7 → 12

## Verification
- `pnpm check` (biome), `pnpm typecheck` (incl. web `lint:tokens`), `pnpm test` — all green.
- Resources DOM tests grew 7 → 12: retire requires confirm / cancel does not retire, eye opens read-only preview, overflow warns then saves, confirm disabled until impact resolves.
- Manually dogfooded against staging data via a local dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)