### PR TITLE
refactor(web): summarize enabled rows in the Instructions list

### DIFF
--- a/packages/web/src/pages/agent-detail-preview.tsx
+++ b/packages/web/src/pages/agent-detail-preview.tsx
@@ -96,7 +96,8 @@ const RESOURCES: AgentResourcesOutput = {
         defaultEnabled: "recommended",
         payload: null,
         repo: null,
-        promptBody: "Follow the team house style when reviewing diffs.",
+        promptBody:
+          "Follow the team house style when reviewing diffs.\n\n- Prefer small, focused changes.\n- Call out missing tests and error handling.\n- Flag any public-API change for a second reviewer.\n- Keep comments about the code, not the author.",
         unavailableReason: null,
         order: 0,
       },
@@ -264,7 +265,8 @@ const CONFIG: AgentRuntimeConfig = {
   payload: {
     kind: "claude-code",
     prompt: {
-      append: "Follow the team house style when reviewing diffs.\n\nAlways summarize tradeoffs before recommending.",
+      append:
+        "Follow the team house style when reviewing diffs.\n\n- Prefer small, focused changes.\n- Call out missing tests and error handling.\n- Flag any public-API change for a second reviewer.\n- Keep comments about the code, not the author.\n\nAlways summarize tradeoffs before recommending.",
     },
     model: "sonnet",
     reasoningEffort: "high",

--- a/packages/web/src/pages/agent-detail/prompt-tab.tsx
+++ b/packages/web/src/pages/agent-detail/prompt-tab.tsx
@@ -360,7 +360,15 @@ function PromptResourceBlocks(props: {
         action={action}
         separated={index > 0}
       >
-        {isEditingRow ? editorNode : <PromptBody body={row.promptBody ?? ""} />}
+        {/* Only enabled rows are merged into the Effective preview, so only they
+            get the short summary; unavailable rows keep full text to stay inspectable. */}
+        {isEditingRow ? (
+          editorNode
+        ) : row.mode === "enabled" ? (
+          <PromptSummary body={row.promptBody ?? ""} />
+        ) : (
+          <PromptBody body={row.promptBody ?? ""} />
+        )}
       </PromptResourceBlock>
     );
   });
@@ -400,6 +408,8 @@ function PromptResourceBlocks(props: {
         action={action}
         separated={blocks.length > 0}
       >
+        {/* Inactive (disabled/overridden) prompts are NOT in the Effective preview,
+            so this row is the only place to inspect the full body — render it in full. */}
         <PromptBody body={row.promptBody ?? ""} />
       </PromptResourceBlock>,
     );
@@ -556,6 +566,20 @@ function PromptBlockAction(props: { label: string; onClick: () => void; disabled
   );
 }
 
+// Active rows show only a short summary — their full merged text lives in the
+// "Effective instructions" preview at the bottom, so we don't render whole bodies twice.
+function PromptSummary(props: { body: string }) {
+  return props.body ? (
+    <p className="m-0 text-caption line-clamp-2" style={{ color: "var(--fg-3)" }}>
+      {props.body}
+    </p>
+  ) : (
+    <span className="text-muted-foreground">No instructions yet.</span>
+  );
+}
+
+// Full body — used for inactive (disabled/overridden) rows, which are absent from
+// the Effective preview and so need their complete text inspectable here.
 function PromptBody(props: { body: string }) {
   return props.body ? (
     <Markdown>{props.body}</Markdown>


### PR DESCRIPTION
## Why

Follow-up to #817. The Instructions tab rendered each prompt's full body **twice** — once in the management list and again in the bottom **Effective instructions** preview — so a single-instruction agent looked like it was showing the same text duplicated.

## What changed (UI-only, 2 files)

- **Enabled** instruction rows (the ones merged into the Effective preview) now show a **two-line summary**: name + source label + status marker + actions + a clamped body preview. The full merged text lives only in the Effective instructions preview → no more duplicate full bodies.
- Rows **not** represented in the Effective preview keep their **full body**, since the list row is the only place to inspect them: `disabled` / `overridden` / `unavailable` (e.g. `prompt_budget_exceeded`) render in full. (Rule: only rows that appear in the preview get summarized.)
- Editing is unchanged — Customize/Edit still expands the full editor.
- DEV `/preview/agent-detail` sample beefed up (a long multi-line team instruction + an Off row) so the list-summary vs full-preview contrast is obvious.

Not touched: backend prompt assembly, the `Team Resource:` section titles in the resolved prompt, binding semantics, source-label copy, Capabilities tab.

## Testing
- `pnpm --filter @first-tree/web typecheck` (tsc + lint:tokens) ✓
- `pnpm check` (biome) ✓
- Full web suite **668/668** ✓
- `codex review` 3 rounds — first two caught that disabled/overridden then unavailable rows must not be truncated (fixed); final pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)