### PR TITLE
fix(cli): include bundled skills/ in the published npm tarball (audit PR-E)

### DIFF
--- a/apps/cli/.gitignore
+++ b/apps/cli/.gitignore
@@ -1,0 +1,6 @@
+# Created at publish time by `pnpm run prepack` (copies monorepo `../../skills`
+# in so npm pack / npm publish include the bundled skill payloads). Removed
+# again by `postpack`. Ignored here so a failed pack run (or a developer
+# poking at the publish pipeline) does not leave a duplicate copy of the
+# canonical `skills/` tree staged for commit.
+/skills/

--- a/apps/cli/.gitignore
+++ b/apps/cli/.gitignore
@@ -3,4 +3,11 @@
 # again by `postpack`. Ignored here so a failed pack run (or a developer
 # poking at the publish pipeline) does not leave a duplicate copy of the
 # canonical `skills/` tree staged for commit.
+#
+# If a local `npm pack` is interrupted between `prepack` and `postpack` (or
+# `postpack` fails for some reason), a stale `apps/cli/skills/` snapshot can
+# stay on disk. `bundledSkillsRootFrom` then prefers that snapshot over the
+# canonical `<repo>/skills/` (it walks up from `apps/cli/dist/cli/` and
+# stops at the first hit). If the dev CLI starts behaving as if a recent
+# `skills/` edit didn't take, run `rm -rf apps/cli/skills` and re-test.
 /skills/

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -27,6 +27,7 @@
   },
   "files": [
     "dist",
+    "skills",
     "README.md",
     "LICENSE"
   ],
@@ -38,7 +39,9 @@
     "build": "tsdown src/cli/index.ts src/index.ts --format esm --no-dts --external @anthropic-ai/claude-agent-sdk --external @openai/codex-sdk",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --passWithNoTests",
-    "coverage": "pnpm run build && vitest run --coverage --passWithNoTests"
+    "coverage": "pnpm run build && vitest run --coverage --passWithNoTests",
+    "prepack": "rm -rf skills && cp -R ../../skills .",
+    "postpack": "rm -rf skills"
   },
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary

PR-E of the post-W1 trailing edge audit (`first-tree-context-management/post-w1-trailing-edge-audit.md`, [tree PR #419](https://github.com/agent-team-foundation/first-tree-context/pull/419) merged). Second in the D → E → A → B → C sequence; D (#820) merged at `de45dc6`.

**Finding 8** — \`first-tree-staging\` (and prod \`first-tree\`) npm tarballs do not include the bundled \`skills/\` payload directory. \`apps/cli/package.json\` whitelists \`["dist", "README.md", "LICENSE"]\` and the monorepo's \`skills/\` lives at the repo root, not under \`apps/cli/\`, so the publish never picks it up.

Effect on users: first \`first-tree-staging tree init\` after \`npm install -g first-tree-staging\` throws \`Could not locate bundled \`skills/\` payloads\` and exits non-zero (PR-D #820 pinned the exit code; without that, users used to see exit 0 + no manifest). Onboarding cannot proceed.

This is independent of the W1 refactor — has been broken since the publish pipeline started.

## Files (+10/-1)

- \`apps/cli/package.json\`:
  - \`files\` array gains \`"skills"\`.
  - \`scripts.prepack\`: \`rm -rf skills && cp -R ../../skills .\` — materializes the bundled payload inside \`apps/cli/\` just before \`npm pack\` / \`npm publish\` walks the file list.
  - \`scripts.postpack\`: \`rm -rf skills\` — cleans the temporary copy on success.
- new \`apps/cli/.gitignore\`: ignores \`/skills/\`. Prevents an accidental local pack run from leaving a duplicate, staged-for-commit copy.

## Why prepack + cp (option B) over moving skills/ (option A)

The audit lists two options. **Option A** (move \`skills/\` under \`apps/cli/skills/\`) is structurally cleaner but touches many references — \`turbo.json\` build inputs, test paths, doc paths, agent home paths. **Option B** (prepack copy) is local to \`apps/cli/\` and leaves the dev tree alone:

- \`bundledSkillsRootFrom\` keeps walking up from the running \`dist/cli/index.mjs\`; in source checkouts it finds the canonical \`<repo>/skills/\` exactly as before. No runtime behavior change.
- \`pnpm install\` / \`pnpm build\` / \`pnpm test\` do not invoke \`prepack\` — it is npm's \`pack\`/\`publish\` hook only. Dev loops unchanged.
- \`apps/cli/turbo.json:8\` already lists \`"../../skills/**"\` as a build input, so the turbo cache invalidates correctly when canonical \`skills/\` changes.

## Test plan

- [x] \`cd apps/cli && npm pack --dry-run\` — prepack runs, enumerates every \`skills/<skill-name>/...\` file (5 shipped skills: first-tree, first-tree-context, first-tree-onboarding, first-tree-sync, first-tree-write), postpack removes the temporary copy.
- [x] \`pnpm check\` — Biome, 1214 files clean.
- [x] \`pnpm typecheck\` — green across all packages.
- [x] \`pnpm --filter first-tree-dev test\` — 70 test files / 502 tests pass (PR-D's new regression tests included).
- [ ] Post-merge: confirm next staging publish (auto-triggered by CI on main) installs cleanly via \`npm install -g first-tree-staging\` and \`tree init\` proceeds past the bundled-skills lookup. Cross-check against PR-D's regression test: failure here would now exit 1, not silently exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)