### PR TITLE
fix(tree): resolve tree via workspace.json under the W1 layout

### DIFF
--- a/apps/cli/src/__tests__/tree-extra-coverage.test.ts
+++ b/apps/cli/src/__tests__/tree-extra-coverage.test.ts
@@ -8,6 +8,7 @@ import { writeTreeState } from "../commands/tree/binding-state.js";
 import { buildSourceIntegrationBlock } from "../commands/tree/source-integration.js";
 import { syncTreeIdentityFiles } from "../commands/tree/tree-identity.js";
 import type { CommandContext } from "../commands/types.js";
+import { writeWorkspaceManifest } from "../core/workspace.js";
 
 const tempDirs: string[] = [];
 const originalCwd = process.cwd();
@@ -142,6 +143,138 @@ describe("tree first context bundle", () => {
       treeRoot: fallback,
     });
     expect(buildTreeFirstContextBundle(makeTempDir("ft-tree-context-empty-"))).toBeNull();
+  });
+
+  // Regression — until now, `resolveTreeContextRoot` only looked for the tree
+  // as a sibling of the cwd (`dirname(cwd)/<treeName>`). Under W1 the tree
+  // lives **inside** the workspace at `<workspaceRoot>/<manifest.tree>`, so
+  // `tree inject` returned 0 bytes from any W1 workspace cwd. The fix
+  // resolves via the workspace manifest first.
+  it("resolves the tree via .first-tree/workspace.json under the W1 layout", async () => {
+    const { buildTreeFirstContextBundle } = await import("../commands/tree/tree-first-context.js");
+
+    const workspaceRoot = makeTempDir("ft-w1-resolver-ws-");
+    const treeRoot = join(workspaceRoot, "my-workspace-tree");
+    mkdirSync(treeRoot, { recursive: true });
+    writeTreeRoot(treeRoot, { repoName: "my-workspace-tree" });
+    writeWorkspaceManifest(workspaceRoot, { tree: "my-workspace-tree", sources: [] });
+
+    // Case A: cwd === workspace root. workspace-root binding contract is
+    // present; entrypoint comes from the binding ("/").
+    writePromptFiles(
+      workspaceRoot,
+      buildSourceIntegrationBlock("my-workspace-tree", {
+        bindingMode: "workspace-root",
+        entrypoint: "/",
+        workspaceId: "acme",
+      }),
+    );
+    const wsBundle = buildTreeFirstContextBundle(workspaceRoot);
+    expect(wsBundle?.treeRoot).toBe(treeRoot);
+    expect(wsBundle?.additionalContext).toContain("# Root Context");
+    expect(wsBundle?.additionalContext).toContain("Current entrypoint: `/`");
+
+    // Case B: cwd is a workspace-member subdir with its own binding contract.
+    // Walk-up still finds the manifest; entrypoint comes from the member's
+    // binding ("/repos/product-repo").
+    const memberRoot = join(workspaceRoot, "repos", "product-repo");
+    mkdirSync(memberRoot, { recursive: true });
+    writePromptFiles(
+      memberRoot,
+      buildSourceIntegrationBlock("my-workspace-tree", {
+        bindingMode: "workspace-member",
+        entrypoint: "/repos/product-repo",
+        workspaceId: "acme",
+      }),
+    );
+    const memberBundle = buildTreeFirstContextBundle(memberRoot);
+    expect(memberBundle?.treeRoot).toBe(treeRoot);
+    expect(memberBundle?.additionalContext).toContain("Current entrypoint: `/repos/product-repo`");
+
+    // Case C: cwd is some other directory inside the workspace with no
+    // binding contract of its own (e.g. a scratch dir). Walk-up still
+    // resolves; entrypoint is derived from the filesystem relative path.
+    const scratch = join(workspaceRoot, "scratch", "play");
+    mkdirSync(scratch, { recursive: true });
+    const scratchBundle = buildTreeFirstContextBundle(scratch);
+    expect(scratchBundle?.treeRoot).toBe(treeRoot);
+    expect(scratchBundle?.additionalContext).toContain("Current entrypoint: `/scratch/play`");
+  });
+
+  it("falls back to the legacy sibling layout when no workspace manifest is present", async () => {
+    // Pre-W1 layout still in the wild — cwd has a binding contract but no
+    // workspace.json above it; tree sits next to the source as a sibling.
+    const { buildTreeFirstContextBundle } = await import("../commands/tree/tree-first-context.js");
+
+    const enclosing = makeTempDir("ft-legacy-sibling-");
+    const source = join(enclosing, "source");
+    const tree = join(enclosing, "context-tree");
+    mkdirSync(source, { recursive: true });
+    mkdirSync(tree, { recursive: true });
+    writeTreeRoot(tree);
+    writePromptFiles(
+      source,
+      buildSourceIntegrationBlock("context-tree", {
+        bindingMode: "workspace-member",
+        entrypoint: "/source",
+      }),
+    );
+
+    const bundle = buildTreeFirstContextBundle(source);
+    expect(bundle?.treeRoot).toBe(tree);
+    expect(bundle?.additionalContext).toContain("Current entrypoint: `/source`");
+  });
+
+  it("prefers the workspace manifest tree over a legacy sibling when both would match", async () => {
+    const { buildTreeFirstContextBundle } = await import("../commands/tree/tree-first-context.js");
+
+    const enclosing = makeTempDir("ft-w1-vs-legacy-");
+    const workspaceRoot = join(enclosing, "workspace");
+    const w1Tree = join(workspaceRoot, "my-workspace-tree");
+    const legacySibling = join(enclosing, "my-workspace-tree");
+    mkdirSync(w1Tree, { recursive: true });
+    mkdirSync(legacySibling, { recursive: true });
+    writeTreeRoot(w1Tree, { repoName: "my-workspace-tree" });
+    writeTreeRoot(legacySibling, { repoName: "my-workspace-tree" });
+    writeWorkspaceManifest(workspaceRoot, { tree: "my-workspace-tree", sources: [] });
+    writePromptFiles(
+      workspaceRoot,
+      buildSourceIntegrationBlock("my-workspace-tree", {
+        bindingMode: "workspace-root",
+        entrypoint: "/",
+        workspaceId: "acme",
+      }),
+    );
+
+    expect(buildTreeFirstContextBundle(workspaceRoot)?.treeRoot).toBe(w1Tree);
+  });
+
+  it("falls through to legacy / fallback paths when the workspace manifest points at a non-tree", async () => {
+    // workspace.json exists but its `tree` path is not actually a tree.
+    // The legacy fallback should still kick in if the source binding can
+    // find a sibling tree.
+    const { buildTreeFirstContextBundle } = await import("../commands/tree/tree-first-context.js");
+
+    const enclosing = makeTempDir("ft-w1-malformed-");
+    const workspaceRoot = join(enclosing, "workspace");
+    const stub = join(workspaceRoot, "not-a-tree");
+    const realSibling = join(enclosing, "context-tree");
+    mkdirSync(stub, { recursive: true });
+    mkdirSync(realSibling, { recursive: true });
+    writeTreeRoot(realSibling);
+    writeWorkspaceManifest(workspaceRoot, { tree: "not-a-tree", sources: [] });
+    writePromptFiles(
+      workspaceRoot,
+      buildSourceIntegrationBlock("context-tree", {
+        bindingMode: "workspace-root",
+        entrypoint: "/",
+        workspaceId: "acme",
+      }),
+    );
+
+    // W1 path can't resolve `not-a-tree` → falls through to legacy sibling
+    // resolution which finds `context-tree` next to the workspace.
+    expect(buildTreeFirstContextBundle(workspaceRoot)?.treeRoot).toBe(realSibling);
   });
 });
 

--- a/apps/cli/src/commands/tree/tree-first-context.ts
+++ b/apps/cli/src/commands/tree/tree-first-context.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname, join, relative } from "node:path";
+import { discoverWorkspaceRoot, readWorkspaceManifest } from "../../core/workspace.js";
 import { readSourceBindingContract } from "./binding-contract.js";
 import { TREE_SOURCE_REPOS_FILE } from "./binding-state.js";
 import { buildSourceRepoIndexTable } from "./source-repo-index.js";
@@ -47,6 +48,7 @@ export function buildTreeFirstContextBundle(currentRoot: string): TreeFirstConte
 }
 
 function resolveTreeContextRoot(currentRoot: string): ResolvedTreeContextRoot | null {
+  // Case 1: cwd itself is a tree repo root.
   if (readTreeIdentityContract(currentRoot) !== undefined) {
     return {
       entrypointLabel: "tree repo root",
@@ -55,10 +57,25 @@ function resolveTreeContextRoot(currentRoot: string): ResolvedTreeContextRoot | 
   }
 
   const sourceBinding = readSourceBindingContract(currentRoot);
+
+  // Case 2 (canonical W1 layout): walk up from cwd to find a
+  // `.first-tree/workspace.json` and resolve the tree at
+  // `<workspaceRoot>/<manifest.tree>`. This handles every cwd inside a
+  // W1 workspace — workspace root itself, a workspace-member subdir, or
+  // any other path inside the workspace — even when cwd does not carry a
+  // source binding contract of its own.
+  const w1Resolved = resolveViaWorkspaceManifest(currentRoot, sourceBinding);
+  if (w1Resolved !== null) {
+    return w1Resolved;
+  }
+
+  // The pre-W1 fallbacks below require a source binding contract at cwd.
   if (sourceBinding === undefined || sourceBinding.treeRepoName === undefined) {
     return null;
   }
 
+  // Case 3 (legacy pre-W1 sibling layout): tree lives at
+  // `<dirname(cwd)>/<treeName>`.
   const siblingRoot = join(dirname(currentRoot), sourceBinding.treeRepoName);
   if (readTreeIdentityContract(siblingRoot) !== undefined) {
     return {
@@ -68,6 +85,8 @@ function resolveTreeContextRoot(currentRoot: string): ResolvedTreeContextRoot | 
     };
   }
 
+  // Case 4: ephemeral working copy at `<cwd>/.first-tree/tmp/<treeName>`,
+  // used by tasks that clone a tree on demand.
   const tempRoot = join(currentRoot, ".first-tree", "tmp", sourceBinding.treeRepoName);
   if (readTreeIdentityContract(tempRoot) !== undefined) {
     return {
@@ -78,6 +97,55 @@ function resolveTreeContextRoot(currentRoot: string): ResolvedTreeContextRoot | 
   }
 
   return null;
+}
+
+function resolveViaWorkspaceManifest(
+  currentRoot: string,
+  sourceBinding: ReturnType<typeof readSourceBindingContract>,
+): ResolvedTreeContextRoot | null {
+  const workspaceRoot = discoverWorkspaceRoot(currentRoot);
+  if (workspaceRoot === undefined) {
+    return null;
+  }
+
+  // Tolerate malformed / unreadable manifests; just fall through so the
+  // legacy resolution paths still get a chance.
+  let manifestTree: string;
+  try {
+    manifestTree = readWorkspaceManifest(workspaceRoot).tree;
+  } catch {
+    return null;
+  }
+
+  const treeRoot = join(workspaceRoot, manifestTree);
+  if (readTreeIdentityContract(treeRoot) === undefined) {
+    return null;
+  }
+
+  return {
+    currentEntrypoint: computeCurrentEntrypoint(currentRoot, workspaceRoot, sourceBinding),
+    entrypointLabel: "bound source/workspace root",
+    treeRoot,
+  };
+}
+
+function computeCurrentEntrypoint(
+  currentRoot: string,
+  workspaceRoot: string,
+  sourceBinding: ReturnType<typeof readSourceBindingContract>,
+): string {
+  // Prefer the explicit entrypoint string when the cwd carries a source
+  // binding contract — it is the value the workspace was configured with
+  // and matches what the rest of the CLI reports.
+  if (sourceBinding?.entrypoint !== undefined) {
+    return sourceBinding.entrypoint;
+  }
+
+  // Otherwise derive it from the filesystem: cwd's path relative to the
+  // workspace root, leading-slash-prefixed. cwd === workspace root yields
+  // "/".
+  const rel = relative(workspaceRoot, currentRoot);
+  return rel === "" ? "/" : `/${rel}`;
 }
 
 function readFallbackLocalNode(currentRoot: string): TreeFirstContextBundle | null {


### PR DESCRIPTION
## Summary

`tree inject` returned **0 bytes from any cwd inside a W1 workspace** — including the workspace root itself, which is the exact cwd from which the managed SessionStart hooks installed by #796 fire. Effect: agents launched under W1 received an empty `additionalContext` payload even when everything else (hook installation, npm version, file permissions) was correct.

Found during end-to-end verification after #794/#796 merged, reported by @liuchao-001.

## Root cause

`resolveTreeContextRoot` only checked three locations after determining cwd was not itself a tree:

1. `<dirname(cwd)>/<treeName>` (pre-W1 sibling layout)
2. `<cwd>/.first-tree/tmp/<treeName>` (ephemeral working copies)
3. else → return null

Under W1 the tree lives at `<workspaceRoot>/<manifest.tree>` — an immediate subdirectory of the workspace root, recorded in `<workspaceRoot>/.first-tree/workspace.json`. None of the three locations checked above match. From workspace-root cwd, the sibling check looked for the tree as a peer of the workspace directory instead of inside it; from any deeper cwd, the binding contract pinned a sibling that did not exist.

## Fix

Add a canonical W1 resolution path that runs **before** the legacy sibling check:

- Walk up from `currentRoot` to discover the nearest `.first-tree/workspace.json` via `discoverWorkspaceRoot` — the same walker `first-tree tree status` uses.
- Read the manifest's `tree` field and join it onto the workspace root to get the canonical tree path.
- Verify a tree identity contract exists there before returning, so a workspace whose manifest points at a non-tree directory still falls through to the legacy fallbacks (the tmp-checkout path remains intact).

Because W1 covers cwds without a binding contract (e.g. a scratch dir inside the workspace), the new path runs even when `readSourceBindingContract(currentRoot)` returns `undefined`. The returned `currentEntrypoint` prefers `sourceBinding.entrypoint` when one is present; otherwise it derives a `/`-prefixed path relative to the workspace root.

## Tests

Extend `tree-extra-coverage.test.ts`:

- workspace-root cwd → tree resolved, entrypoint reported as `/` from the binding contract.
- workspace-member cwd → walk-up still finds the manifest; binding's own entrypoint (`/repos/product-repo`) is used.
- bindingless cwd inside the workspace (a scratch dir) → walk-up still works; entrypoint is derived from the filesystem (`/scratch/play`).
- explicit "legacy sibling, no manifest" case → fallback path still fires.
- W1 + legacy sibling both available → W1 wins (canonical layout has precedence).
- W1 manifest points at a non-tree path → fall through to legacy sibling resolution still finds the real tree.

## End-to-end verification with the dev CLI

```
$ first-tree-dev tree init --scope workspace --workspace-id acme --tree-mode shared
... bootstraps workspace + tree ...

$ first-tree-dev tree inject   # from workspace root
-> 790-byte SessionStart payload, entrypoint `/`

$ first-tree-dev tree inject   # from <ws>/repos/some-source
-> 807-byte SessionStart payload, entrypoint `/repos/some-source`

$ first-tree-dev tree inject   # from tree-repo root
-> 803-byte SessionStart payload, entrypoint `tree repo root`
```

All three produce valid `hookSpecificOutput.SessionStart` JSON; the first two are the previously-broken paths.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — **506 passed** (was 502, +4 new)
- [x] `pnpm check` (biome) clean
- [x] Dev-installed CLI E2E covers workspace-root / workspace-member subdir / tree-repo root

## Related

- #794 (tree-side AGENTS.md / CLAUDE.md removed)
- #796 (agent hooks scoped to workspace-root only — the hooks installed there now finally get a non-empty payload from `tree inject`)
