### PR TITLE
fix(cli): stage bundled skills for npm publish

### DIFF
--- a/.github/workflows/publish-npm-package.yml
+++ b/.github/workflows/publish-npm-package.yml
@@ -159,6 +159,10 @@ jobs:
 
       - run: pnpm typecheck
 
+      - name: Stage bundled CLI skills
+        working-directory: apps/cli
+        run: npm run package:stage-skills
+
       - name: Publish to npm
         working-directory: apps/cli
         run: npm publish --tag latest --access public
@@ -314,6 +318,11 @@ jobs:
 
       - if: steps.version.outputs.publish == 'true'
         run: pnpm build
+
+      - name: Stage bundled CLI skills
+        if: steps.version.outputs.publish == 'true'
+        working-directory: apps/cli
+        run: npm run package:stage-skills
 
       - name: Publish to npm
         if: steps.version.outputs.publish == 'true'

--- a/apps/cli/.gitignore
+++ b/apps/cli/.gitignore
@@ -1,8 +1,8 @@
-# Created at publish time by `pnpm run prepack` (copies monorepo `../../skills`
-# in so npm pack / npm publish include the bundled skill payloads). Removed
-# again by `postpack`. Ignored here so a failed pack run (or a developer
-# poking at the publish pipeline) does not leave a duplicate copy of the
-# canonical `skills/` tree staged for commit.
+# Created at publish time by `npm run package:stage-skills` / `prepack`
+# (copies monorepo `../../skills` in so npm pack / npm publish include the
+# bundled skill payloads). Removed again by `postpack`. Ignored here so a
+# failed pack run (or a developer poking at the publish pipeline) does not
+# leave a duplicate copy of the canonical `skills/` tree staged for commit.
 #
 # If a local `npm pack` is interrupted between `prepack` and `postpack` (or
 # `postpack` fails for some reason), a stale `apps/cli/skills/` snapshot can

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -40,7 +40,8 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run --passWithNoTests",
     "coverage": "pnpm run build && vitest run --coverage --passWithNoTests",
-    "prepack": "rm -rf skills && cp -R ../../skills .",
+    "package:stage-skills": "node scripts/stage-bundled-skills.mjs",
+    "prepack": "node scripts/stage-bundled-skills.mjs",
     "postpack": "rm -rf skills"
   },
   "license": "Apache-2.0",

--- a/apps/cli/scripts/stage-bundled-skills.mjs
+++ b/apps/cli/scripts/stage-bundled-skills.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+
+import { cpSync, existsSync, rmSync, statSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_CLI_ROOT = resolve(SCRIPT_DIR, "..");
+const REQUIRED_SKILL_NAMES = [
+  "first-tree",
+  "first-tree-context",
+  "first-tree-onboarding",
+  "first-tree-sync",
+  "first-tree-write",
+];
+
+function assertDirectory(path, label) {
+  if (!existsSync(path)) {
+    throw new Error(`${label} does not exist: ${path}`);
+  }
+  if (!statSync(path).isDirectory()) {
+    throw new Error(`${label} is not a directory: ${path}`);
+  }
+}
+
+function assertFile(path, label) {
+  if (!existsSync(path)) {
+    throw new Error(`${label} does not exist: ${path}`);
+  }
+  if (!statSync(path).isFile()) {
+    throw new Error(`${label} is not a file: ${path}`);
+  }
+}
+
+function resolveStagingPaths(options = {}) {
+  const cliRoot = resolve(options.cliRoot ?? DEFAULT_CLI_ROOT);
+  const repoRoot = resolve(options.repoRoot ?? resolve(cliRoot, "../.."));
+  const sourceSkillsRoot = resolve(options.sourceSkillsRoot ?? resolve(repoRoot, "skills"));
+  const targetSkillsRoot = resolve(options.targetSkillsRoot ?? resolve(cliRoot, "skills"));
+
+  return {
+    cliRoot,
+    repoRoot,
+    sourceSkillsRoot,
+    targetSkillsRoot,
+  };
+}
+
+function validateSkillPayload(root, label) {
+  assertDirectory(root, label);
+
+  for (const skillName of REQUIRED_SKILL_NAMES) {
+    assertFile(resolve(root, skillName, "SKILL.md"), `${label} ${skillName}/SKILL.md`);
+  }
+}
+
+function stageBundledSkills(options = {}) {
+  const logger = options.logger ?? console;
+  const paths = resolveStagingPaths(options);
+
+  if (paths.sourceSkillsRoot === paths.targetSkillsRoot) {
+    throw new Error(`Refusing to stage skills because source and target are the same path: ${paths.sourceSkillsRoot}`);
+  }
+
+  validateSkillPayload(paths.sourceSkillsRoot, "source skills root");
+
+  logger.info(
+    `[stage-bundled-skills] staging bundled skills from ${paths.sourceSkillsRoot} to ${paths.targetSkillsRoot}`,
+  );
+
+  rmSync(paths.targetSkillsRoot, { recursive: true, force: true });
+  cpSync(paths.sourceSkillsRoot, paths.targetSkillsRoot, { recursive: true, dereference: false });
+
+  validateSkillPayload(paths.targetSkillsRoot, "staged skills root");
+
+  logger.info(`[stage-bundled-skills] staged ${REQUIRED_SKILL_NAMES.length} bundled skills`);
+
+  return {
+    ...paths,
+    skillNames: [...REQUIRED_SKILL_NAMES],
+  };
+}
+
+function isDirectRun() {
+  return process.argv[1] !== undefined && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+}
+
+if (isDirectRun()) {
+  try {
+    stageBundledSkills();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`[stage-bundled-skills] failed: ${message}`);
+    process.exitCode = 1;
+  }
+}
+
+export { REQUIRED_SKILL_NAMES, stageBundledSkills };

--- a/apps/cli/src/__tests__/package-metadata.test.ts
+++ b/apps/cli/src/__tests__/package-metadata.test.ts
@@ -35,6 +35,12 @@ describe("npm package metadata", () => {
     expect(files).toEqual(expect.arrayContaining(["dist", "README.md", "LICENSE"]));
   });
 
+  it("includes bundled skills in the tarball allow-list", () => {
+    const files = packageFiles(readJson(join(CLI_ROOT, "package.json")));
+
+    expect(files).toEqual(expect.arrayContaining(["skills"]));
+  });
+
   it("keeps a package-local README for the npm registry page", () => {
     const readmePath = join(CLI_ROOT, "README.md");
 

--- a/apps/cli/src/__tests__/skill-package-staging.test.ts
+++ b/apps/cli/src/__tests__/skill-package-staging.test.ts
@@ -1,0 +1,70 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const CLI_ROOT = resolve(HERE, "../..");
+const REPO_ROOT = resolve(CLI_ROOT, "../..");
+const SCRIPT_PATH = join(CLI_ROOT, "scripts", "stage-bundled-skills.mjs");
+const STAGED_SKILLS_ROOT = join(CLI_ROOT, "skills");
+const REQUIRED_SKILL_NAMES = [
+  "first-tree",
+  "first-tree-context",
+  "first-tree-onboarding",
+  "first-tree-sync",
+  "first-tree-write",
+];
+
+function removeStagedSkills(): void {
+  rmSync(STAGED_SKILLS_ROOT, { recursive: true, force: true });
+}
+
+function runStagingScript(): string {
+  const result = spawnSync(process.execPath, [SCRIPT_PATH], {
+    cwd: CLI_ROOT,
+    encoding: "utf-8",
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  expect(result.stderr).toBe("");
+  expect(result.status).toBe(0);
+  expect(result.stdout).toContain("staged 5 bundled skills");
+
+  return result.stdout;
+}
+
+afterEach(() => {
+  removeStagedSkills();
+});
+
+describe("bundled skill package staging", () => {
+  it("copies repo-root skills into apps/cli/skills and removes stale files first", () => {
+    removeStagedSkills();
+
+    runStagingScript();
+
+    writeFileSync(join(STAGED_SKILLS_ROOT, "stale-root.txt"), "stale\n");
+    writeFileSync(join(STAGED_SKILLS_ROOT, "first-tree", "stale.txt"), "stale\n");
+
+    const stdout = runStagingScript();
+
+    for (const skillName of REQUIRED_SKILL_NAMES) {
+      const sourceSkill = join(REPO_ROOT, "skills", skillName, "SKILL.md");
+      const stagedSkill = join(STAGED_SKILLS_ROOT, skillName, "SKILL.md");
+
+      expect(existsSync(stagedSkill)).toBe(true);
+      expect(readFileSync(stagedSkill, "utf-8")).toBe(readFileSync(sourceSkill, "utf-8"));
+    }
+
+    expect(existsSync(join(STAGED_SKILLS_ROOT, "stale-root.txt"))).toBe(false);
+    expect(existsSync(join(STAGED_SKILLS_ROOT, "first-tree", "stale.txt"))).toBe(false);
+    expect(stdout).toContain(join(REPO_ROOT, "skills"));
+    expect(stdout).toContain(STAGED_SKILLS_ROOT);
+  });
+});


### PR DESCRIPTION
## Summary
- add a package staging script that copies repo-root `skills/` into `apps/cli/skills/` after clearing stale copies
- run the staging script from CLI `prepack` and explicitly before prod/staging npm publish
- add package metadata and staging-script coverage for bundled skill tarball contents

## Verification
- `pnpm --filter first-tree-dev test -- package-metadata skill`
- `pnpm check`
- `pnpm typecheck`
- `pnpm --filter first-tree-dev build`
- `npm run package:stage-skills`
- `npm pack --dry-run --json` confirmed bundled skill files including `skills/first-tree/SKILL.md`
- `git diff --check`