### PR TITLE
feat(tree): add context tree browser command

### DIFF
--- a/apps/cli/src/__tests__/command-registration-smoke.test.ts
+++ b/apps/cli/src/__tests__/command-registration-smoke.test.ts
@@ -103,10 +103,9 @@ describe("CLI command registration", () => {
     expect(subcommands(agent, "workspace")).toEqual(["clean"]);
 
     const tree = command(root, "tree");
-    // Only `verify` survives — the rest of the namespace was retired in
-    // the 2026-06 cleanup (cloud now owns workspace + tree provisioning;
-    // client runtime inlines its own skill payload install).
-    expect(tree.commands.map((entry) => entry.name()).sort()).toEqual(["verify"]);
+    // `verify` survived the 2026-06 cleanup, and `tree` is the narrow
+    // hierarchy browser added back for agents and scripted consumers.
+    expect(tree.commands.map((entry) => entry.name()).sort()).toEqual(["tree", "verify"]);
   });
 
   it("keeps important options on high-risk commands", () => {
@@ -128,5 +127,17 @@ describe("CLI command registration", () => {
       "--type",
     ]);
     expect(optionNames(command(command(root, "daemon"), "start"))).toEqual(["--foreground", "--no-interactive"]);
+    expect(optionNames(command(command(root, "tree"), "tree"))).toEqual(["--level", "--pattern"]);
+  });
+
+  it("exposes help for the Context Tree browser command", () => {
+    const root = new Command();
+    registerTreeCommands(root);
+
+    const help = command(command(root, "tree"), "tree").helpInformation();
+
+    expect(help).toContain("Browse Context Tree nodes as a hierarchy.");
+    expect(help).toContain("--level <depth>");
+    expect(help).toContain("--pattern <pattern>");
   });
 });

--- a/apps/cli/src/__tests__/tree-tree-command.test.ts
+++ b/apps/cli/src/__tests__/tree-tree-command.test.ts
@@ -1,0 +1,344 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { parseTreeLevel, renderContextTree, runTreeTreeCommand } from "../commands/tree/tree.js";
+import type { CommandContext } from "../commands/types.js";
+import { setJsonMode } from "../core/output.js";
+
+const originalCwd = process.cwd();
+const originalFirstTreeJson = process.env.FIRST_TREE_JSON;
+const tempDirs: string[] = [];
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function writeNode(path: string, title: string, description?: string): void {
+  const descriptionLine = description === undefined ? "" : `description: ${description}\n`;
+  writeFileSync(join(path, "NODE.md"), `---\ntitle: ${title}\n${descriptionLine}---\n# ${title}\n`);
+}
+
+function writeLeaf(path: string, title: string, description?: string): void {
+  const descriptionLine = description === undefined ? "" : `description: ${description}\n`;
+  writeFileSync(path, `---\ntitle: ${title}\n${descriptionLine}---\n# ${title}\n`);
+}
+
+function makeTreeFixture(): string {
+  const base = makeTempDir("ft-tree-tree-");
+  const root = join(base, "knowledge");
+  const domains = join(root, "domains");
+  const api = join(domains, "api");
+  const scratch = join(root, "scratch");
+
+  mkdirSync(api, { recursive: true });
+  mkdirSync(scratch, { recursive: true });
+
+  writeNode(root, "Root Node", "Root description");
+  writeNode(domains, "Domains", "Product domains");
+  writeNode(api, "API");
+  writeLeaf(join(api, "auth.md"), "Auth Leaf", "Login flows");
+  writeLeaf(join(api, "payments.md"), "Payments Leaf", "Billing flows");
+  writeLeaf(join(domains, "ops.md"), "Operations Leaf", "Runbooks");
+  writeLeaf(join(root, "guide.md"), "Guide Leaf", "How to navigate");
+  writeLeaf(join(scratch, "note.md"), "Scratch Note", "Temporary details");
+
+  writeFileSync(join(root, "AGENTS.md"), "---\ntitle: Should Skip Agents\n---\n");
+  writeFileSync(join(root, "CLAUDE.md"), "---\ntitle: Should Skip Claude\n---\n");
+  writeLeaf(join(root, ".secret.md"), "Should Skip Hidden File", "Hidden");
+
+  for (const generatedDir of [".hidden", "node_modules", "__pycache__", "dist", "build", ".next", ".turbo"]) {
+    const ignored = join(root, generatedDir);
+    mkdirSync(ignored, { recursive: true });
+    writeNode(ignored, "Should Skip Generated", "Generated");
+    writeLeaf(join(ignored, "ignored.md"), "Should Skip Leaf", "Generated");
+  }
+
+  return root;
+}
+
+function commandWithOptions(options: Record<string, unknown>): Command {
+  const command = new Command("test");
+  for (const [key, value] of Object.entries(options)) {
+    command.setOptionValue(key, value);
+  }
+  return command;
+}
+
+function context(command: Command, options: Partial<CommandContext["options"]> = {}): CommandContext {
+  return { command, options: { debug: false, json: false, quiet: false, ...options } };
+}
+
+class ProcessExit extends Error {
+  constructor(public exitCode: number) {
+    super(`process.exit:${exitCode}`);
+    this.name = "ProcessExit";
+  }
+}
+
+beforeEach(() => {
+  setJsonMode(false);
+  process.exitCode = undefined;
+});
+
+afterEach(() => {
+  if (originalFirstTreeJson === undefined) {
+    delete process.env.FIRST_TREE_JSON;
+  } else {
+    process.env.FIRST_TREE_JSON = originalFirstTreeJson;
+  }
+
+  setJsonMode(false);
+  vi.restoreAllMocks();
+  process.chdir(originalCwd);
+  process.exitCode = undefined;
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("tree tree renderer", () => {
+  it("renders the current node, child directory nodes, and leaf markdown nodes", () => {
+    const root = makeTreeFixture();
+
+    expect(renderContextTree(root)).toBe(
+      [
+        'knowledge/ [NODE.md] title="Root Node" description="Root description"',
+        '├── domains/ [NODE.md] title="Domains" description="Product domains"',
+        '│   ├── api/ [NODE.md] title="API" description="-"',
+        '│   │   ├── auth.md title="Auth Leaf" description="Login flows"',
+        '│   │   └── payments.md title="Payments Leaf" description="Billing flows"',
+        '│   └── ops.md title="Operations Leaf" description="Runbooks"',
+        '├── guide.md title="Guide Leaf" description="How to navigate"',
+        '└── scratch/ title="-" description="-"',
+        '    └── note.md title="Scratch Note" description="Temporary details"',
+      ].join("\n"),
+    );
+  });
+
+  it("applies deterministic depth limits", () => {
+    const root = makeTreeFixture();
+
+    expect(renderContextTree(root, { maxDepth: 0 })).toBe(
+      'knowledge/ [NODE.md] title="Root Node" description="Root description"',
+    );
+    expect(renderContextTree(root, { maxDepth: 1 })).toBe(
+      [
+        'knowledge/ [NODE.md] title="Root Node" description="Root description"',
+        '├── domains/ [NODE.md] title="Domains" description="Product domains"',
+        '└── guide.md title="Guide Leaf" description="How to navigate"',
+      ].join("\n"),
+    );
+    expect(renderContextTree(root, { maxDepth: 2 })).toBe(
+      [
+        'knowledge/ [NODE.md] title="Root Node" description="Root description"',
+        '├── domains/ [NODE.md] title="Domains" description="Product domains"',
+        '│   ├── api/ [NODE.md] title="API" description="-"',
+        '│   └── ops.md title="Operations Leaf" description="Runbooks"',
+        '├── guide.md title="Guide Leaf" description="How to navigate"',
+        '└── scratch/ title="-" description="-"',
+        '    └── note.md title="Scratch Note" description="Temporary details"',
+      ].join("\n"),
+    );
+  });
+
+  it("matches patterns against relative path, basename, title, and description", () => {
+    const root = makeTreeFixture();
+
+    expect(renderContextTree(root, { pattern: "domains/api/auth.md" })).toContain(
+      'auth.md title="Auth Leaf" description="Login flows"',
+    );
+    expect(renderContextTree(root, { pattern: "guide.md" })).toContain(
+      'guide.md title="Guide Leaf" description="How to navigate"',
+    );
+    expect(renderContextTree(root, { pattern: "Auth*" })).toContain(
+      'auth.md title="Auth Leaf" description="Login flows"',
+    );
+    expect(renderContextTree(root, { pattern: "Billing*" })).toContain(
+      'payments.md title="Payments Leaf" description="Billing flows"',
+    );
+  });
+
+  it("preserves ancestors for matched descendants after applying depth limits", () => {
+    const root = makeTreeFixture();
+
+    expect(renderContextTree(root, { pattern: "Payments*" })).toBe(
+      [
+        'knowledge/ [NODE.md] title="Root Node" description="Root description"',
+        '└── domains/ [NODE.md] title="Domains" description="Product domains"',
+        '    └── api/ [NODE.md] title="API" description="-"',
+        '        └── payments.md title="Payments Leaf" description="Billing flows"',
+      ].join("\n"),
+    );
+    expect(renderContextTree(root, { maxDepth: 2, pattern: "Payments*" })).toBe(
+      'knowledge/ [NODE.md] title="Root Node" description="Root description"',
+    );
+  });
+
+  it("skips hidden and generated paths plus non-node framework markdown files", () => {
+    const root = makeTreeFixture();
+    const output = renderContextTree(root);
+
+    expect(output).not.toContain("Should Skip");
+    expect(output).not.toContain("AGENTS.md");
+    expect(output).not.toContain("CLAUDE.md");
+    expect(output).not.toContain(".secret.md");
+    expect(output).not.toContain("node_modules");
+    expect(output).not.toContain("__pycache__");
+    expect(output).not.toContain("dist/");
+    expect(output).not.toContain("build/");
+    expect(output).not.toContain(".next");
+    expect(output).not.toContain(".turbo");
+  });
+});
+
+describe("tree tree command action", () => {
+  it("prints the rendered tree from the current directory to stderr in human mode", () => {
+    const root = makeTreeFixture();
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    process.chdir(root);
+
+    runTreeTreeCommand(context(commandWithOptions({ level: "1" })));
+
+    expect(stdout.mock.calls.map((call) => String(call[0])).join("")).toBe("");
+    expect(stderr.mock.calls.map((call) => String(call[0])).join("")).toBe(
+      `${[
+        'knowledge/ [NODE.md] title="Root Node" description="Root description"',
+        '├── domains/ [NODE.md] title="Domains" description="Product domains"',
+        '└── guide.md title="Guide Leaf" description="How to navigate"',
+      ].join("\n")}\n`,
+    );
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it("prints a JSON envelope to stdout in explicit JSON mode", () => {
+    const root = makeTreeFixture();
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    process.chdir(root);
+    const expectedRoot = process.cwd();
+
+    runTreeTreeCommand(context(commandWithOptions({ level: "3", pattern: "Auth*" }), { json: true }));
+
+    expect(stderr.mock.calls.map((call) => String(call[0])).join("")).toBe("");
+    const envelope = JSON.parse(stdout.mock.calls.map((call) => String(call[0])).join(""));
+
+    expect(envelope).toMatchObject({
+      ok: true,
+      data: {
+        root: expectedRoot,
+        options: {
+          level: 3,
+          pattern: "Auth*",
+        },
+        tree: {
+          kind: "directory",
+          name: "knowledge",
+          relativePath: "",
+          depth: 0,
+          metadata: {
+            title: "Root Node",
+            description: "Root description",
+          },
+          hasNode: true,
+        },
+      },
+    });
+    expect(envelope.data.tree.children).toEqual([
+      {
+        kind: "directory",
+        name: "domains",
+        relativePath: "domains",
+        depth: 1,
+        metadata: {
+          title: "Domains",
+          description: "Product domains",
+        },
+        hasNode: true,
+        children: [
+          {
+            kind: "directory",
+            name: "api",
+            relativePath: "domains/api",
+            depth: 2,
+            metadata: {
+              title: "API",
+              description: "-",
+            },
+            hasNode: true,
+            children: [
+              {
+                kind: "file",
+                name: "auth.md",
+                relativePath: "domains/api/auth.md",
+                depth: 3,
+                metadata: {
+                  title: "Auth Leaf",
+                  description: "Login flows",
+                },
+                hasNode: false,
+                children: [],
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("prints JSON when the global Print layer is already in JSON mode", () => {
+    const root = makeTreeFixture();
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    process.chdir(root);
+    const expectedRoot = process.cwd();
+    process.env.FIRST_TREE_JSON = "1";
+    setJsonMode(process.env.FIRST_TREE_JSON === "1");
+
+    runTreeTreeCommand(context(commandWithOptions({ level: "0" }), { json: false }));
+
+    expect(stderr.mock.calls.map((call) => String(call[0])).join("")).toBe("");
+    expect(JSON.parse(stdout.mock.calls.map((call) => String(call[0])).join(""))).toMatchObject({
+      ok: true,
+      data: {
+        root: expectedRoot,
+        options: {
+          level: 0,
+        },
+        tree: {
+          name: "knowledge",
+          children: [],
+        },
+      },
+    });
+  });
+
+  it("rejects negative and non-integer levels with a stable error envelope", () => {
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const exit = vi.spyOn(process, "exit").mockImplementation((code?: string | number | null): never => {
+      throw new ProcessExit(typeof code === "number" ? code : 0);
+    });
+
+    expect(() => parseTreeLevel("-1")).toThrow("Invalid --level");
+    expect(() => parseTreeLevel("1.5")).toThrow("Invalid --level");
+
+    expect(() => runTreeTreeCommand(context(commandWithOptions({ level: "-1" })))).toThrow(ProcessExit);
+
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(stdout.mock.calls.map((call) => String(call[0])).join("")).toBe("");
+    expect(JSON.parse(stderr.mock.calls.map((call) => String(call[0])).join(""))).toEqual({
+      ok: false,
+      error: {
+        code: "TREE_TREE_INVALID_LEVEL",
+        message: "Invalid --level: expected a non-negative integer.",
+      },
+    });
+  });
+});

--- a/apps/cli/src/__tests__/tree-tree-command.test.ts
+++ b/apps/cli/src/__tests__/tree-tree-command.test.ts
@@ -18,37 +18,64 @@ function makeTempDir(prefix: string): string {
   return dir;
 }
 
+function frontmatter(fields: string): string {
+  return `---\n${fields}---\n`;
+}
+
 function writeNode(path: string, title: string, description?: string): void {
   const descriptionLine = description === undefined ? "" : `description: ${description}\n`;
-  writeFileSync(join(path, "NODE.md"), `---\ntitle: ${title}\n${descriptionLine}---\n# ${title}\n`);
+  writeFileSync(
+    join(path, "NODE.md"),
+    `${frontmatter(`title: ${title}\nowners: [alice]\n${descriptionLine}`)}# ${title}\n`,
+  );
 }
 
 function writeLeaf(path: string, title: string, description?: string): void {
   const descriptionLine = description === undefined ? "" : `description: ${description}\n`;
-  writeFileSync(path, `---\ntitle: ${title}\n${descriptionLine}---\n# ${title}\n`);
+  writeFileSync(path, `${frontmatter(`title: ${title}\nowners: [alice]\n${descriptionLine}`)}# ${title}\n`);
+}
+
+function writeMarkdown(path: string, fields: string): void {
+  writeFileSync(path, `${frontmatter(fields)}# Invalid\n`);
 }
 
 function makeTreeFixture(): string {
   const base = makeTempDir("ft-tree-tree-");
   const root = join(base, "knowledge");
-  const domains = join(root, "domains");
-  const api = join(domains, "api");
+  const docs = join(root, "docs");
+  const development = join(docs, "development");
+  const deep = join(development, "deep");
+  const missingTitle = join(root, "missing-title");
+  const missingOwners = join(root, "missing-owners");
+  const emptyOwners = join(root, "empty-owners");
   const scratch = join(root, "scratch");
 
-  mkdirSync(api, { recursive: true });
+  mkdirSync(deep, { recursive: true });
+  mkdirSync(missingTitle, { recursive: true });
+  mkdirSync(missingOwners, { recursive: true });
+  mkdirSync(emptyOwners, { recursive: true });
   mkdirSync(scratch, { recursive: true });
+  mkdirSync(join(root, ".git"), { recursive: true });
 
   writeNode(root, "Root Node", "Root description");
-  writeNode(domains, "Domains", "Product domains");
-  writeNode(api, "API");
-  writeLeaf(join(api, "auth.md"), "Auth Leaf", "Login flows");
-  writeLeaf(join(api, "payments.md"), "Payments Leaf", "Billing flows");
-  writeLeaf(join(domains, "ops.md"), "Operations Leaf", "Runbooks");
+  writeNode(docs, "Docs", "Documentation");
+  writeNode(development, "Development");
+  writeNode(deep, "Deep Area", "Deep context");
+  writeLeaf(join(deep, "leaf.md"), "Deep Leaf", "Deep leaf detail");
+  writeLeaf(join(development, "http.md"), "HTTP Leaf", "HTTP routes");
+  writeLeaf(join(docs, "ops.md"), "Operations Leaf", "Runbooks");
   writeLeaf(join(root, "guide.md"), "Guide Leaf", "How to navigate");
-  writeLeaf(join(scratch, "note.md"), "Scratch Note", "Temporary details");
 
-  writeFileSync(join(root, "AGENTS.md"), "---\ntitle: Should Skip Agents\n---\n");
-  writeFileSync(join(root, "CLAUDE.md"), "---\ntitle: Should Skip Claude\n---\n");
+  writeMarkdown(join(missingTitle, "NODE.md"), "owners: [alice]\n");
+  writeMarkdown(join(missingOwners, "NODE.md"), "title: Missing Owners\n");
+  writeMarkdown(join(emptyOwners, "NODE.md"), "title: Empty Owners\nowners: []\n");
+  writeMarkdown(join(development, "missing-title.md"), "owners: [alice]\n");
+  writeMarkdown(join(development, "missing-owners.md"), "title: Missing Owners Leaf\n");
+  writeMarkdown(join(development, "empty-owners.md"), "title: Empty Owners Leaf\nowners: []\n");
+  writeLeaf(join(scratch, "note.md"), "Scratch Note", "Temporary details");
+  writeFileSync(join(development, "notes.txt"), "not markdown\n");
+  writeFileSync(join(root, "AGENTS.md"), frontmatter("title: Should Skip Agents\nowners: [alice]\n"));
+  writeFileSync(join(root, "CLAUDE.md"), frontmatter("title: Should Skip Claude\nowners: [alice]\n"));
   writeLeaf(join(root, ".secret.md"), "Should Skip Hidden File", "Hidden");
 
   for (const generatedDir of [".hidden", "node_modules", "__pycache__", "dist", "build", ".next", ".turbo"]) {
@@ -61,16 +88,23 @@ function makeTreeFixture(): string {
   return root;
 }
 
-function commandWithOptions(options: Record<string, unknown>): Command {
+function commandWithOptions(options: Record<string, unknown>, args: string[] = []): Command {
   const command = new Command("test");
+  command.args = args;
+
   for (const [key, value] of Object.entries(options)) {
     command.setOptionValue(key, value);
   }
+
   return command;
 }
 
 function context(command: Command, options: Partial<CommandContext["options"]> = {}): CommandContext {
   return { command, options: { debug: false, json: false, quiet: false, ...options } };
+}
+
+function readMockOutput(spy: { mock: { calls: readonly (readonly unknown[])[] } }): string {
+  return spy.mock.calls.map((call) => String(call[0])).join("");
 }
 
 class ProcessExit extends Error {
@@ -103,87 +137,82 @@ afterEach(() => {
 });
 
 describe("tree tree renderer", () => {
-  it("renders the current node, child directory nodes, and leaf markdown nodes", () => {
+  it("renders only valid Context Tree nodes with concise metadata labels", () => {
     const root = makeTreeFixture();
 
     expect(renderContextTree(root)).toBe(
       [
-        'knowledge/ [NODE.md] title="Root Node" description="Root description"',
-        '├── domains/ [NODE.md] title="Domains" description="Product domains"',
-        '│   ├── api/ [NODE.md] title="API" description="-"',
-        '│   │   ├── auth.md title="Auth Leaf" description="Login flows"',
-        '│   │   └── payments.md title="Payments Leaf" description="Billing flows"',
-        '│   └── ops.md title="Operations Leaf" description="Runbooks"',
-        '├── guide.md title="Guide Leaf" description="How to navigate"',
-        '└── scratch/ title="-" description="-"',
-        '    └── note.md title="Scratch Note" description="Temporary details"',
+        "knowledge/ [Root Node] -> Root description",
+        "├── docs/ [Docs] -> Documentation",
+        "│   ├── docs/development/ [Development]",
+        "│   │   ├── docs/development/deep/ [Deep Area] -> Deep context",
+        "│   │   │   └── docs/development/deep/leaf.md [Deep Leaf] -> Deep leaf detail",
+        "│   │   └── docs/development/http.md [HTTP Leaf] -> HTTP routes",
+        "│   └── docs/ops.md [Operations Leaf] -> Runbooks",
+        "└── guide.md [Guide Leaf] -> How to navigate",
       ].join("\n"),
     );
   });
 
-  it("applies deterministic depth limits", () => {
+  it("applies depth limits only below the selected target path", () => {
     const root = makeTreeFixture();
 
-    expect(renderContextTree(root, { maxDepth: 0 })).toBe(
-      'knowledge/ [NODE.md] title="Root Node" description="Root description"',
-    );
-    expect(renderContextTree(root, { maxDepth: 1 })).toBe(
+    expect(renderContextTree(root, { maxDepth: 0, path: "docs/development" })).toBe(
       [
-        'knowledge/ [NODE.md] title="Root Node" description="Root description"',
-        '├── domains/ [NODE.md] title="Domains" description="Product domains"',
-        '└── guide.md title="Guide Leaf" description="How to navigate"',
+        "knowledge/ [Root Node] -> Root description",
+        "└── docs/ [Docs] -> Documentation",
+        "    └── docs/development/ [Development]",
       ].join("\n"),
     );
-    expect(renderContextTree(root, { maxDepth: 2 })).toBe(
+    expect(renderContextTree(root, { maxDepth: 1, path: "docs/development" })).toBe(
       [
-        'knowledge/ [NODE.md] title="Root Node" description="Root description"',
-        '├── domains/ [NODE.md] title="Domains" description="Product domains"',
-        '│   ├── api/ [NODE.md] title="API" description="-"',
-        '│   └── ops.md title="Operations Leaf" description="Runbooks"',
-        '├── guide.md title="Guide Leaf" description="How to navigate"',
-        '└── scratch/ title="-" description="-"',
-        '    └── note.md title="Scratch Note" description="Temporary details"',
+        "knowledge/ [Root Node] -> Root description",
+        "└── docs/ [Docs] -> Documentation",
+        "    └── docs/development/ [Development]",
+        "        ├── docs/development/deep/ [Deep Area] -> Deep context",
+        "        └── docs/development/http.md [HTTP Leaf] -> HTTP routes",
       ].join("\n"),
     );
   });
 
-  it("matches patterns against relative path, basename, title, and description", () => {
+  it("matches patterns against relative path, filename, title, and description while preserving ancestors", () => {
     const root = makeTreeFixture();
 
-    expect(renderContextTree(root, { pattern: "domains/api/auth.md" })).toContain(
-      'auth.md title="Auth Leaf" description="Login flows"',
+    expect(renderContextTree(root, { pattern: "docs/development/http.md" })).toContain(
+      "docs/development/http.md [HTTP Leaf] -> HTTP routes",
     );
-    expect(renderContextTree(root, { pattern: "guide.md" })).toContain(
-      'guide.md title="Guide Leaf" description="How to navigate"',
+    expect(renderContextTree(root, { pattern: "http.md" })).toContain(
+      "docs/development/http.md [HTTP Leaf] -> HTTP routes",
     );
-    expect(renderContextTree(root, { pattern: "Auth*" })).toContain(
-      'auth.md title="Auth Leaf" description="Login flows"',
+    expect(renderContextTree(root, { pattern: "HTTP*" })).toContain(
+      "docs/development/http.md [HTTP Leaf] -> HTTP routes",
     );
-    expect(renderContextTree(root, { pattern: "Billing*" })).toContain(
-      'payments.md title="Payments Leaf" description="Billing flows"',
-    );
-  });
-
-  it("preserves ancestors for matched descendants after applying depth limits", () => {
-    const root = makeTreeFixture();
-
-    expect(renderContextTree(root, { pattern: "Payments*" })).toBe(
+    expect(renderContextTree(root, { pattern: "Deep leaf*" })).toBe(
       [
-        'knowledge/ [NODE.md] title="Root Node" description="Root description"',
-        '└── domains/ [NODE.md] title="Domains" description="Product domains"',
-        '    └── api/ [NODE.md] title="API" description="-"',
-        '        └── payments.md title="Payments Leaf" description="Billing flows"',
+        "knowledge/ [Root Node] -> Root description",
+        "└── docs/ [Docs] -> Documentation",
+        "    └── docs/development/ [Development]",
+        "        └── docs/development/deep/ [Deep Area] -> Deep context",
+        "            └── docs/development/deep/leaf.md [Deep Leaf] -> Deep leaf detail",
       ].join("\n"),
     );
-    expect(renderContextTree(root, { maxDepth: 2, pattern: "Payments*" })).toBe(
-      'knowledge/ [NODE.md] title="Root Node" description="Root description"',
+    expect(renderContextTree(root, { maxDepth: 0, path: "docs/development", pattern: "Deep*" })).toBe(
+      [
+        "knowledge/ [Root Node] -> Root description",
+        "└── docs/ [Docs] -> Documentation",
+        "    └── docs/development/ [Development]",
+      ].join("\n"),
     );
   });
 
-  it("skips hidden and generated paths plus non-node framework markdown files", () => {
+  it("filters invalid markdown nodes, hidden paths, generated directories, and non-markdown files", () => {
     const root = makeTreeFixture();
     const output = renderContextTree(root);
 
+    expect(output).not.toContain("Missing");
+    expect(output).not.toContain("Empty Owners");
+    expect(output).not.toContain("Scratch Note");
+    expect(output).not.toContain("notes.txt");
     expect(output).not.toContain("Should Skip");
     expect(output).not.toContain("AGENTS.md");
     expect(output).not.toContain("CLAUDE.md");
@@ -198,23 +227,59 @@ describe("tree tree renderer", () => {
 });
 
 describe("tree tree command action", () => {
-  it("prints the rendered tree from the current directory to stderr in human mode", () => {
+  it("prints the selected subtree with repo-root ancestor context in human mode", () => {
     const root = makeTreeFixture();
     const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
     const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
     process.chdir(root);
 
-    runTreeTreeCommand(context(commandWithOptions({ level: "1" })));
+    runTreeTreeCommand(context(commandWithOptions({}, ["docs/development"])));
 
-    expect(stdout.mock.calls.map((call) => String(call[0])).join("")).toBe("");
-    expect(stderr.mock.calls.map((call) => String(call[0])).join("")).toBe(
+    expect(readMockOutput(stdout)).toBe("");
+    expect(readMockOutput(stderr)).toBe(
       `${[
-        'knowledge/ [NODE.md] title="Root Node" description="Root description"',
-        '├── domains/ [NODE.md] title="Domains" description="Product domains"',
-        '└── guide.md title="Guide Leaf" description="How to navigate"',
+        "knowledge/ [Root Node] -> Root description",
+        "└── docs/ [Docs] -> Documentation",
+        "    └── docs/development/ [Development]",
+        "        ├── docs/development/deep/ [Deep Area] -> Deep context",
+        "        │   └── docs/development/deep/leaf.md [Deep Leaf] -> Deep leaf detail",
+        "        └── docs/development/http.md [HTTP Leaf] -> HTTP routes",
       ].join("\n")}\n`,
     );
     expect(process.exitCode).toBeUndefined();
+  });
+
+  it("treats a non-numeric -L value as a path only when no positional path is present", () => {
+    const root = makeTreeFixture();
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    process.chdir(root);
+
+    runTreeTreeCommand(context(commandWithOptions({ level: "docs/development" })));
+
+    expect(readMockOutput(stdout)).toBe("");
+    expect(readMockOutput(stderr)).toContain("docs/development/http.md [HTTP Leaf] -> HTTP routes");
+    expect(readMockOutput(stderr)).not.toContain("guide.md [Guide Leaf]");
+  });
+
+  it("combines numeric -L depth with a positional path", () => {
+    const root = makeTreeFixture();
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    process.chdir(root);
+
+    runTreeTreeCommand(context(commandWithOptions({ level: "1" }, ["docs/development"])));
+
+    expect(readMockOutput(stdout)).toBe("");
+    expect(readMockOutput(stderr)).toBe(
+      `${[
+        "knowledge/ [Root Node] -> Root description",
+        "└── docs/ [Docs] -> Documentation",
+        "    └── docs/development/ [Development]",
+        "        ├── docs/development/deep/ [Deep Area] -> Deep context",
+        "        └── docs/development/http.md [HTTP Leaf] -> HTTP routes",
+      ].join("\n")}\n`,
+    );
   });
 
   it("prints a JSON envelope to stdout in explicit JSON mode", () => {
@@ -224,18 +289,22 @@ describe("tree tree command action", () => {
     process.chdir(root);
     const expectedRoot = process.cwd();
 
-    runTreeTreeCommand(context(commandWithOptions({ level: "3", pattern: "Auth*" }), { json: true }));
+    runTreeTreeCommand(
+      context(commandWithOptions({ level: "1", pattern: "HTTP*" }, ["docs/development"]), { json: true }),
+    );
 
-    expect(stderr.mock.calls.map((call) => String(call[0])).join("")).toBe("");
-    const envelope = JSON.parse(stdout.mock.calls.map((call) => String(call[0])).join(""));
+    expect(readMockOutput(stderr)).toBe("");
+    const envelope = JSON.parse(readMockOutput(stdout));
 
     expect(envelope).toMatchObject({
       ok: true,
       data: {
         root: expectedRoot,
+        target: "docs/development",
         options: {
-          level: 3,
-          pattern: "Auth*",
+          level: 1,
+          pattern: "HTTP*",
+          path: "docs/development",
         },
         tree: {
           kind: "directory",
@@ -245,6 +314,7 @@ describe("tree tree command action", () => {
           metadata: {
             title: "Root Node",
             description: "Root description",
+            owners: ["alice"],
           },
           hasNode: true,
         },
@@ -253,34 +323,36 @@ describe("tree tree command action", () => {
     expect(envelope.data.tree.children).toEqual([
       {
         kind: "directory",
-        name: "domains",
-        relativePath: "domains",
+        name: "docs",
+        relativePath: "docs",
         depth: 1,
         metadata: {
-          title: "Domains",
-          description: "Product domains",
+          title: "Docs",
+          description: "Documentation",
+          owners: ["alice"],
         },
         hasNode: true,
         children: [
           {
             kind: "directory",
-            name: "api",
-            relativePath: "domains/api",
+            name: "development",
+            relativePath: "docs/development",
             depth: 2,
             metadata: {
-              title: "API",
-              description: "-",
+              title: "Development",
+              owners: ["alice"],
             },
             hasNode: true,
             children: [
               {
                 kind: "file",
-                name: "auth.md",
-                relativePath: "domains/api/auth.md",
+                name: "http.md",
+                relativePath: "docs/development/http.md",
                 depth: 3,
                 metadata: {
-                  title: "Auth Leaf",
-                  description: "Login flows",
+                  title: "HTTP Leaf",
+                  description: "HTTP routes",
+                  owners: ["alice"],
                 },
                 hasNode: false,
                 children: [],
@@ -301,30 +373,86 @@ describe("tree tree command action", () => {
     process.env.FIRST_TREE_JSON = "1";
     setJsonMode(process.env.FIRST_TREE_JSON === "1");
 
-    runTreeTreeCommand(context(commandWithOptions({ level: "0" }), { json: false }));
+    runTreeTreeCommand(context(commandWithOptions({ level: "0" }, ["docs/development"]), { json: false }));
 
-    expect(stderr.mock.calls.map((call) => String(call[0])).join("")).toBe("");
-    expect(JSON.parse(stdout.mock.calls.map((call) => String(call[0])).join(""))).toMatchObject({
+    expect(readMockOutput(stderr)).toBe("");
+    expect(JSON.parse(readMockOutput(stdout))).toMatchObject({
       ok: true,
       data: {
         root: expectedRoot,
+        target: "docs/development",
         options: {
           level: 0,
+          path: "docs/development",
         },
         tree: {
           name: "knowledge",
-          children: [],
+          children: [
+            {
+              name: "docs",
+              children: [
+                {
+                  name: "development",
+                  children: [],
+                },
+              ],
+            },
+          ],
         },
       },
     });
   });
 
-  it("rejects negative and non-integer levels with a stable error envelope", () => {
+  it("rejects invalid paths with a stable error envelope", () => {
+    const root = makeTreeFixture();
     const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
     const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
     const exit = vi.spyOn(process, "exit").mockImplementation((code?: string | number | null): never => {
       throw new ProcessExit(typeof code === "number" ? code : 0);
     });
+    process.chdir(root);
+
+    expect(() => runTreeTreeCommand(context(commandWithOptions({}, ["missing"])))).toThrow(ProcessExit);
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(readMockOutput(stdout)).toBe("");
+    expect(JSON.parse(readMockOutput(stderr))).toEqual({
+      ok: false,
+      error: {
+        code: "TREE_TREE_INVALID_PATH",
+        message: 'Path "missing" is not an existing directory.',
+      },
+    });
+  });
+
+  it("rejects repo-outside paths with a stable error envelope", () => {
+    const root = makeTreeFixture();
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const exit = vi.spyOn(process, "exit").mockImplementation((code?: string | number | null): never => {
+      throw new ProcessExit(typeof code === "number" ? code : 0);
+    });
+    process.chdir(root);
+
+    expect(() => runTreeTreeCommand(context(commandWithOptions({}, [".."])))).toThrow(ProcessExit);
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(readMockOutput(stdout)).toBe("");
+    expect(JSON.parse(readMockOutput(stderr))).toEqual({
+      ok: false,
+      error: {
+        code: "TREE_TREE_INVALID_PATH",
+        message: 'Path ".." is outside the git repository.',
+      },
+    });
+  });
+
+  it("rejects negative and non-integer levels with a stable error envelope", () => {
+    const root = makeTreeFixture();
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const exit = vi.spyOn(process, "exit").mockImplementation((code?: string | number | null): never => {
+      throw new ProcessExit(typeof code === "number" ? code : 0);
+    });
+    process.chdir(root);
 
     expect(() => parseTreeLevel("-1")).toThrow("Invalid --level");
     expect(() => parseTreeLevel("1.5")).toThrow("Invalid --level");
@@ -332,8 +460,8 @@ describe("tree tree command action", () => {
     expect(() => runTreeTreeCommand(context(commandWithOptions({ level: "-1" })))).toThrow(ProcessExit);
 
     expect(exit).toHaveBeenCalledWith(1);
-    expect(stdout.mock.calls.map((call) => String(call[0])).join("")).toBe("");
-    expect(JSON.parse(stderr.mock.calls.map((call) => String(call[0])).join(""))).toEqual({
+    expect(readMockOutput(stdout)).toBe("");
+    expect(JSON.parse(readMockOutput(stderr))).toEqual({
       ok: false,
       error: {
         code: "TREE_TREE_INVALID_LEVEL",

--- a/apps/cli/src/__tests__/tree-tree-command.test.ts
+++ b/apps/cli/src/__tests__/tree-tree-command.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -441,6 +441,36 @@ describe("tree tree command action", () => {
       error: {
         code: "TREE_TREE_INVALID_PATH",
         message: 'Path ".." is outside the git repository.',
+      },
+    });
+  });
+
+  it("rejects symlink targets that escape the repo with a stable error envelope", (ctx) => {
+    const root = makeTreeFixture();
+    const outsideRoot = makeTempDir("ft-tree-tree-outside-");
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const exit = vi.spyOn(process, "exit").mockImplementation((code?: string | number | null): never => {
+      throw new ProcessExit(typeof code === "number" ? code : 0);
+    });
+    writeNode(outsideRoot, "Outside Node", "Escaped context");
+
+    try {
+      symlinkSync(outsideRoot, join(root, "outside"), "dir");
+    } catch {
+      ctx.skip("Symlink creation is not supported in this environment.");
+    }
+
+    process.chdir(root);
+
+    expect(() => runTreeTreeCommand(context(commandWithOptions({}, ["outside"])))).toThrow(ProcessExit);
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(readMockOutput(stdout)).toBe("");
+    expect(JSON.parse(readMockOutput(stderr))).toEqual({
+      ok: false,
+      error: {
+        code: "TREE_TREE_INVALID_PATH",
+        message: 'Path "outside" is outside the git repository.',
       },
     });
   });

--- a/apps/cli/src/commands/tree/index.ts
+++ b/apps/cli/src/commands/tree/index.ts
@@ -1,18 +1,22 @@
 import type { Command } from "commander";
 import { registerSubcommands } from "../groups.js";
 import type { CommandModule } from "../types.js";
+import { treeTreeCommand } from "./tree.js";
 import { verifyCommand } from "./verify.js";
 
 /**
- * The `first-tree tree` namespace was retired in 2026-06; `verify` is the
- * sole survivor because tree-side CI workflows (and humans inspecting a
- * tree by hand) still need a structure validator. Everything else —
- * `init` / `migrate` / `upgrade` / `status` / `codeowners` / `claude-hook`
- * / `inject` / `review` / `automation` / `skill` groups — was deleted
- * because the cloud now owns workspace + tree provisioning, agent
- * runtime now inlines its own skill payload install (PR #844), and the
- * deleted commands had no remaining caller. See PR following #844 for
- * the deletion commit.
+ * The `first-tree tree` namespace was retired in 2026-06 except for:
+ * - `verify`, because tree-side CI workflows and humans inspecting a tree
+ *   by hand still need a structure validator.
+ * - `tree`, because agents and scripted consumers need a lightweight
+ *   Context Tree hierarchy browser.
+ *
+ * Everything else — `init` / `migrate` / `upgrade` / `status` /
+ * `codeowners` / `claude-hook` / `inject` / `review` / `automation` /
+ * `skill` groups — was deleted because the cloud now owns workspace + tree
+ * provisioning, agent runtime now inlines its own skill payload install (PR
+ * #844), and the deleted commands had no remaining caller. See PR following
+ * #844 for the deletion commit.
  */
 export function registerTreeCommands(program: Command): void {
   treeCommand.register(program);
@@ -20,17 +24,17 @@ export function registerTreeCommands(program: Command): void {
 
 export const treeCommand: CommandModule = {
   name: "tree",
-  description: "Validate a Context Tree (the only surviving tree subcommand).",
+  description: "Validate or browse a Context Tree.",
   register(program: Command): void {
     const command = program
       .command("tree")
-      .description("Validate a Context Tree (the only surviving tree subcommand).")
+      .description("Validate or browse a Context Tree.")
       .helpCommand(false)
       .allowExcessArguments(false)
       .action(() => {
         command.outputHelp();
       });
 
-    registerSubcommands(command, [verifyCommand]);
+    registerSubcommands(command, [verifyCommand, treeTreeCommand]);
   },
 };

--- a/apps/cli/src/commands/tree/tree.ts
+++ b/apps/cli/src/commands/tree/tree.ts
@@ -1,0 +1,382 @@
+import type { Dirent } from "node:fs";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { basename, join, relative, resolve } from "node:path";
+
+import type { Command } from "commander";
+import matter from "gray-matter";
+
+import { isJsonMode, print } from "../../core/output.js";
+import type { CommandContext, SubcommandModule } from "../types.js";
+import { asString, isRecord } from "./shared.js";
+
+export type NodeMetadata = {
+  title: string;
+  description: string;
+};
+
+export type ContextTreeNode = {
+  kind: "directory" | "file";
+  name: string;
+  relativePath: string;
+  depth: number;
+  metadata: NodeMetadata;
+  hasNode: boolean;
+  children: ContextTreeNode[];
+};
+
+type RenderContextTreeOptions = {
+  maxDepth?: number;
+  pattern?: string;
+};
+
+export type ReadContextTreeSnapshotOptions = {
+  level?: number;
+  pattern?: string;
+};
+
+export type ContextTreeSnapshot = {
+  root: string;
+  options: ReadContextTreeSnapshotOptions;
+  tree: ContextTreeNode;
+};
+
+const NODE_FILE = "NODE.md";
+const LEAF_FILE_EXCLUDES = new Set([NODE_FILE, "AGENTS.md", "CLAUDE.md"]);
+const SKIPPED_DIRECTORY_NAMES = new Set(["node_modules", "__pycache__", "dist", "build", ".next", ".turbo"]);
+const MISSING_METADATA = "-";
+const TREE_TREE_INVALID_LEVEL = "TREE_TREE_INVALID_LEVEL";
+const TREE_TREE_FAILED = "TREE_TREE_FAILED";
+
+function isHidden(name: string): boolean {
+  return name.startsWith(".");
+}
+
+function toPosixRelativePath(root: string, target: string): string {
+  return relative(root, target).replace(/\\/gu, "/");
+}
+
+function fileHasMarkdownExtension(name: string): boolean {
+  return name.endsWith(".md");
+}
+
+function readFrontmatterMetadata(path: string): NodeMetadata {
+  try {
+    const parsed = matter(readFileSync(path, "utf-8"));
+    const data: unknown = parsed.data;
+
+    if (!isRecord(data)) {
+      return { title: MISSING_METADATA, description: MISSING_METADATA };
+    }
+
+    return {
+      title: asString(data.title) ?? MISSING_METADATA,
+      description: asString(data.description) ?? MISSING_METADATA,
+    };
+  } catch {
+    return { title: MISSING_METADATA, description: MISSING_METADATA };
+  }
+}
+
+function escapeDisplayValue(value: string): string {
+  return value
+    .replace(/\\/gu, "\\\\")
+    .replace(/"/gu, '\\"')
+    .replace(/\r/gu, "\\r")
+    .replace(/\n/gu, "\\n")
+    .replace(/\t/gu, "\\t");
+}
+
+function formatMetadata(metadata: NodeMetadata): string {
+  return `title="${escapeDisplayValue(metadata.title)}" description="${escapeDisplayValue(metadata.description)}"`;
+}
+
+function formatNodeLine(node: ContextTreeNode): string {
+  if (node.kind === "file") {
+    return `${node.name} ${formatMetadata(node.metadata)}`;
+  }
+
+  const nodeMarker = node.hasNode ? " [NODE.md]" : "";
+  return `${node.name}/${nodeMarker} ${formatMetadata(node.metadata)}`;
+}
+
+function compareEntryNames(left: string, right: string): number {
+  if (left < right) {
+    return -1;
+  }
+
+  if (left > right) {
+    return 1;
+  }
+
+  return 0;
+}
+
+function shouldSkipDirectory(name: string): boolean {
+  return isHidden(name) || SKIPPED_DIRECTORY_NAMES.has(name);
+}
+
+function shouldSkipFile(name: string): boolean {
+  return isHidden(name) || !fileHasMarkdownExtension(name) || LEAF_FILE_EXCLUDES.has(name);
+}
+
+function isFile(path: string): boolean {
+  try {
+    return statSync(path).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function readDirectoryEntries(path: string): Dirent[] {
+  try {
+    return readdirSync(path, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory() || entry.isFile())
+      .sort((left, right) => compareEntryNames(left.name, right.name));
+  } catch {
+    return [];
+  }
+}
+
+function buildDirectoryNode(root: string, path: string, depth: number, name: string): ContextTreeNode {
+  const nodePath = join(path, NODE_FILE);
+  const hasNode = isFile(nodePath);
+  const metadata = readFrontmatterMetadata(nodePath);
+  const relativePath = toPosixRelativePath(root, path);
+  const children: ContextTreeNode[] = [];
+
+  for (const entry of readDirectoryEntries(path)) {
+    const entryName = entry.name;
+    const childPath = join(path, entryName);
+
+    if (entry.isDirectory()) {
+      if (shouldSkipDirectory(entryName)) {
+        continue;
+      }
+
+      children.push(buildDirectoryNode(root, childPath, depth + 1, entryName));
+      continue;
+    }
+
+    if (!entry.isFile() || shouldSkipFile(entryName)) {
+      continue;
+    }
+
+    children.push({
+      kind: "file",
+      name: entryName,
+      relativePath: toPosixRelativePath(root, childPath),
+      depth: depth + 1,
+      metadata: readFrontmatterMetadata(childPath),
+      hasNode: false,
+      children: [],
+    });
+  }
+
+  return {
+    kind: "directory",
+    name,
+    relativePath,
+    depth,
+    metadata,
+    hasNode,
+    children,
+  };
+}
+
+function cloneWithDepthLimit(node: ContextTreeNode, maxDepth: number | undefined): ContextTreeNode | null {
+  if (maxDepth !== undefined && node.depth > maxDepth) {
+    return null;
+  }
+
+  return {
+    ...node,
+    children: node.children
+      .map((child) => cloneWithDepthLimit(child, maxDepth))
+      .filter((child): child is ContextTreeNode => child !== null),
+  };
+}
+
+function globToRegex(pattern: string): RegExp {
+  let source = "^";
+
+  for (const char of pattern) {
+    if (char === "*") {
+      source += "[^/]*";
+      continue;
+    }
+
+    if (char === "?") {
+      source += "[^/]";
+      continue;
+    }
+
+    source += char.replace(/[|\\{}()[\]^$+?.]/gu, "\\$&");
+  }
+
+  source += "$";
+  return new RegExp(source, "u");
+}
+
+function nodeMatchesPattern(node: ContextTreeNode, pattern: RegExp): boolean {
+  return [node.relativePath, node.name, node.metadata.title, node.metadata.description].some((candidate) =>
+    pattern.test(candidate),
+  );
+}
+
+function cloneWithPattern(node: ContextTreeNode, pattern: RegExp, forceKeep: boolean): ContextTreeNode | null {
+  const children = node.children
+    .map((child) => cloneWithPattern(child, pattern, false))
+    .filter((child): child is ContextTreeNode => child !== null);
+  const selfMatches = nodeMatchesPattern(node, pattern);
+  const keepDirectoryAncestor = node.kind === "directory" && children.length > 0;
+
+  if (!forceKeep && !selfMatches && !keepDirectoryAncestor) {
+    return null;
+  }
+
+  return {
+    ...node,
+    children,
+  };
+}
+
+function pruneRenderableDirectories(node: ContextTreeNode, forceKeep: boolean): ContextTreeNode | null {
+  const children = node.children
+    .map((child) => pruneRenderableDirectories(child, false))
+    .filter((child): child is ContextTreeNode => child !== null);
+  const isRenderableDirectory = node.kind === "directory" && (node.hasNode || children.length > 0 || forceKeep);
+
+  if (node.kind === "file" || isRenderableDirectory) {
+    return { ...node, children };
+  }
+
+  return null;
+}
+
+function collectRenderedLines(node: ContextTreeNode, prefix: string, isLast: boolean, lines: string[]): void {
+  if (node.depth === 0) {
+    lines.push(formatNodeLine(node));
+  } else {
+    lines.push(`${prefix}${isLast ? "└── " : "├── "}${formatNodeLine(node)}`);
+  }
+
+  const childPrefix = node.depth === 0 ? "" : `${prefix}${isLast ? "    " : "│   "}`;
+
+  node.children.forEach((child, index) => {
+    collectRenderedLines(child, childPrefix, index === node.children.length - 1, lines);
+  });
+}
+
+export function parseTreeLevel(value: unknown): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value !== "string" || !/^\d+$/u.test(value)) {
+    throw new Error("Invalid --level: expected a non-negative integer.");
+  }
+
+  const level = Number(value);
+
+  if (!Number.isSafeInteger(level)) {
+    throw new Error("Invalid --level: expected a non-negative integer.");
+  }
+
+  return level;
+}
+
+function normalizeSnapshotOptions(options: ReadContextTreeSnapshotOptions): ReadContextTreeSnapshotOptions {
+  const normalized: ReadContextTreeSnapshotOptions = {};
+
+  if (options.level !== undefined) {
+    normalized.level = options.level;
+  }
+
+  if (options.pattern !== undefined) {
+    normalized.pattern = options.pattern;
+  }
+
+  return normalized;
+}
+
+export function readContextTreeSnapshot(
+  root: string,
+  options: ReadContextTreeSnapshotOptions = {},
+): ContextTreeSnapshot {
+  const resolvedRoot = resolve(root);
+  const rootName = basename(resolvedRoot) || resolvedRoot;
+  const discovered = buildDirectoryNode(resolvedRoot, resolvedRoot, 0, rootName);
+  const depthLimited = cloneWithDepthLimit(discovered, options.level);
+
+  if (depthLimited === null) {
+    throw new Error("Context Tree root was excluded by the depth limit.");
+  }
+
+  const patternFiltered =
+    options.pattern === undefined ? depthLimited : cloneWithPattern(depthLimited, globToRegex(options.pattern), true);
+  const renderable = patternFiltered === null ? null : pruneRenderableDirectories(patternFiltered, true);
+
+  if (renderable === null) {
+    throw new Error("Context Tree root was removed by the renderable node filter.");
+  }
+
+  return {
+    root: resolvedRoot,
+    options: normalizeSnapshotOptions(options),
+    tree: renderable,
+  };
+}
+
+function renderContextTreeSnapshot(snapshot: ContextTreeSnapshot): string {
+  const lines: string[] = [];
+  collectRenderedLines(snapshot.tree, "", true, lines);
+  return lines.join("\n");
+}
+
+export function renderContextTree(root: string, options: RenderContextTreeOptions = {}): string {
+  return renderContextTreeSnapshot(
+    readContextTreeSnapshot(root, {
+      level: options.maxDepth,
+      pattern: options.pattern,
+    }),
+  );
+}
+
+function configureTreeTreeCommand(command: Command): void {
+  command
+    .option("-L, --level <depth>", "max display depth, where the current directory is depth 0")
+    .option(
+      "-P, --pattern <pattern>",
+      "shell-style glob filter matched against path, filename, title, and description",
+    );
+}
+
+export function runTreeTreeCommand(context: CommandContext): void {
+  try {
+    const options = context.command.opts<Record<string, unknown>>();
+    const snapshot = readContextTreeSnapshot(process.cwd(), {
+      level: parseTreeLevel(options.level),
+      pattern: asString(options.pattern),
+    });
+
+    if (context.options.json || isJsonMode()) {
+      print.result(snapshot);
+      return;
+    }
+
+    print.line(`${renderContextTreeSnapshot(snapshot)}\n`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const code = message.startsWith("Invalid --level") ? TREE_TREE_INVALID_LEVEL : TREE_TREE_FAILED;
+    print.fail(code, message);
+  }
+}
+
+export const treeTreeCommand: SubcommandModule = {
+  name: "tree",
+  alias: "",
+  summary: "",
+  description: "Browse Context Tree nodes as a hierarchy.",
+  configure: configureTreeTreeCommand,
+  action: runTreeTreeCommand,
+};

--- a/apps/cli/src/commands/tree/tree.ts
+++ b/apps/cli/src/commands/tree/tree.ts
@@ -1,5 +1,5 @@
 import type { Dirent } from "node:fs";
-import { readdirSync, readFileSync, statSync } from "node:fs";
+import { readdirSync, readFileSync, realpathSync, statSync } from "node:fs";
 import { basename, isAbsolute, join, relative, resolve } from "node:path";
 
 import type { Command } from "commander";
@@ -208,6 +208,10 @@ function isDirectory(path: string): boolean {
 function isPathInsideOrEqual(root: string, target: string): boolean {
   const relativePath = relative(root, target);
   return relativePath === "" || (!relativePath.startsWith("..") && !isAbsolute(relativePath));
+}
+
+function isRealPathInsideOrEqual(root: string, target: string): boolean {
+  return isPathInsideOrEqual(realpathSync(root), realpathSync(target));
 }
 
 function splitRelativePath(path: string): string[] {
@@ -480,7 +484,7 @@ function resolveTreeTarget(cwd: string, path: string): ResolvedTreeTarget {
     throw new TreeTreeCommandError(TREE_TREE_INVALID_PATH, `Path "${path}" is not an existing directory.`);
   }
 
-  if (!isPathInsideOrEqual(repoRoot, targetPath)) {
+  if (!isRealPathInsideOrEqual(repoRoot, targetPath)) {
     throw new TreeTreeCommandError(TREE_TREE_INVALID_PATH, `Path "${path}" is outside the git repository.`);
   }
 
@@ -494,12 +498,12 @@ function resolveSnapshotTarget(root: string, target: string | undefined): Resolv
   const repoRoot = resolve(root);
   const targetPath = resolve(repoRoot, target ?? "");
 
-  if (!isPathInsideOrEqual(repoRoot, targetPath)) {
-    throw new TreeTreeCommandError(TREE_TREE_INVALID_PATH, `Path "${target ?? "."}" is outside the git repository.`);
-  }
-
   if (!isDirectory(targetPath)) {
     throw new TreeTreeCommandError(TREE_TREE_INVALID_PATH, `Path "${target ?? "."}" is not an existing directory.`);
+  }
+
+  if (!isRealPathInsideOrEqual(repoRoot, targetPath)) {
+    throw new TreeTreeCommandError(TREE_TREE_INVALID_PATH, `Path "${target ?? "."}" is outside the git repository.`);
   }
 
   return {

--- a/apps/cli/src/commands/tree/tree.ts
+++ b/apps/cli/src/commands/tree/tree.ts
@@ -1,17 +1,18 @@
 import type { Dirent } from "node:fs";
 import { readdirSync, readFileSync, statSync } from "node:fs";
-import { basename, join, relative, resolve } from "node:path";
+import { basename, isAbsolute, join, relative, resolve } from "node:path";
 
 import type { Command } from "commander";
 import matter from "gray-matter";
 
 import { isJsonMode, print } from "../../core/output.js";
 import type { CommandContext, SubcommandModule } from "../types.js";
-import { asString, isRecord } from "./shared.js";
+import { asString, findGitRoot, isRecord } from "./shared.js";
 
 export type NodeMetadata = {
   title: string;
-  description: string;
+  description?: string;
+  owners: string[];
 };
 
 export type ContextTreeNode = {
@@ -27,25 +28,50 @@ export type ContextTreeNode = {
 type RenderContextTreeOptions = {
   maxDepth?: number;
   pattern?: string;
+  path?: string;
 };
 
 export type ReadContextTreeSnapshotOptions = {
   level?: number;
   pattern?: string;
+  path?: string;
+  target?: string;
 };
 
 export type ContextTreeSnapshot = {
   root: string;
+  target: string;
   options: ReadContextTreeSnapshotOptions;
   tree: ContextTreeNode;
+};
+
+type ParsedTreeTreeOptions = {
+  level?: number;
+  pattern?: string;
+  path: string;
+};
+
+type ResolvedTreeTarget = {
+  repoRoot: string;
+  targetRelativePath: string;
 };
 
 const NODE_FILE = "NODE.md";
 const LEAF_FILE_EXCLUDES = new Set([NODE_FILE, "AGENTS.md", "CLAUDE.md"]);
 const SKIPPED_DIRECTORY_NAMES = new Set(["node_modules", "__pycache__", "dist", "build", ".next", ".turbo"]);
-const MISSING_METADATA = "-";
 const TREE_TREE_INVALID_LEVEL = "TREE_TREE_INVALID_LEVEL";
+const TREE_TREE_INVALID_PATH = "TREE_TREE_INVALID_PATH";
 const TREE_TREE_FAILED = "TREE_TREE_FAILED";
+
+class TreeTreeCommandError extends Error {
+  constructor(
+    public readonly code: typeof TREE_TREE_INVALID_LEVEL | typeof TREE_TREE_INVALID_PATH | typeof TREE_TREE_FAILED,
+    message: string,
+  ) {
+    super(message);
+    this.name = "TreeTreeCommandError";
+  }
+}
 
 function isHidden(name: string): boolean {
   return name.startsWith(".");
@@ -59,44 +85,78 @@ function fileHasMarkdownExtension(name: string): boolean {
   return name.endsWith(".md");
 }
 
-function readFrontmatterMetadata(path: string): NodeMetadata {
+function asNonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function asNonEmptyStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value) || value.length === 0) {
+    return undefined;
+  }
+
+  const items: string[] = [];
+
+  for (const item of value) {
+    const normalized = asNonEmptyString(item);
+
+    if (normalized === undefined) {
+      return undefined;
+    }
+
+    items.push(normalized);
+  }
+
+  return items;
+}
+
+function readFrontmatterMetadata(path: string): NodeMetadata | null {
   try {
     const parsed = matter(readFileSync(path, "utf-8"));
     const data: unknown = parsed.data;
 
     if (!isRecord(data)) {
-      return { title: MISSING_METADATA, description: MISSING_METADATA };
+      return null;
+    }
+
+    const title = asNonEmptyString(data.title);
+    const owners = asNonEmptyStringArray(data.owners);
+
+    if (title === undefined || owners === undefined) {
+      return null;
     }
 
     return {
-      title: asString(data.title) ?? MISSING_METADATA,
-      description: asString(data.description) ?? MISSING_METADATA,
+      title,
+      description: asNonEmptyString(data.description),
+      owners,
     };
   } catch {
-    return { title: MISSING_METADATA, description: MISSING_METADATA };
+    return null;
   }
 }
 
-function escapeDisplayValue(value: string): string {
-  return value
-    .replace(/\\/gu, "\\\\")
-    .replace(/"/gu, '\\"')
-    .replace(/\r/gu, "\\r")
-    .replace(/\n/gu, "\\n")
-    .replace(/\t/gu, "\\t");
+function formatDisplayValue(value: string): string {
+  return value.replace(/\s+/gu, " ").trim();
 }
 
-function formatMetadata(metadata: NodeMetadata): string {
-  return `title="${escapeDisplayValue(metadata.title)}" description="${escapeDisplayValue(metadata.description)}"`;
+function formatDisplayPath(node: ContextTreeNode): string {
+  if (node.relativePath.length === 0) {
+    return `${node.name}/`;
+  }
+
+  return node.kind === "directory" ? `${node.relativePath}/` : node.relativePath;
 }
 
 function formatNodeLine(node: ContextTreeNode): string {
-  if (node.kind === "file") {
-    return `${node.name} ${formatMetadata(node.metadata)}`;
-  }
+  const description =
+    node.metadata.description === undefined ? "" : ` -> ${formatDisplayValue(node.metadata.description)}`;
 
-  const nodeMarker = node.hasNode ? " [NODE.md]" : "";
-  return `${node.name}/${nodeMarker} ${formatMetadata(node.metadata)}`;
+  return `${formatDisplayPath(node)} [${formatDisplayValue(node.metadata.title)}]${description}`;
 }
 
 function compareEntryNames(left: string, right: string): number {
@@ -137,39 +197,97 @@ function readDirectoryEntries(path: string): Dirent[] {
   }
 }
 
-function buildDirectoryNode(root: string, path: string, depth: number, name: string): ContextTreeNode {
+function isDirectory(path: string): boolean {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function isPathInsideOrEqual(root: string, target: string): boolean {
+  const relativePath = relative(root, target);
+  return relativePath === "" || (!relativePath.startsWith("..") && !isAbsolute(relativePath));
+}
+
+function splitRelativePath(path: string): string[] {
+  if (path.length === 0) {
+    return [];
+  }
+
+  return path.split("/").filter((segment) => segment.length > 0);
+}
+
+function formatTargetForMessage(path: string): string {
+  return path.length === 0 ? "." : path;
+}
+
+function buildDirectoryNode(
+  root: string,
+  path: string,
+  depth: number,
+  name: string,
+  targetSegments: string[],
+): ContextTreeNode | null {
   const nodePath = join(path, NODE_FILE);
   const hasNode = isFile(nodePath);
   const metadata = readFrontmatterMetadata(nodePath);
   const relativePath = toPosixRelativePath(root, path);
   const children: ContextTreeNode[] = [];
 
-  for (const entry of readDirectoryEntries(path)) {
-    const entryName = entry.name;
-    const childPath = join(path, entryName);
+  if (!hasNode || metadata === null) {
+    return null;
+  }
 
-    if (entry.isDirectory()) {
-      if (shouldSkipDirectory(entryName)) {
+  if (targetSegments.length > 0) {
+    const [nextSegment, ...remainingSegments] = targetSegments;
+
+    if (!shouldSkipDirectory(nextSegment)) {
+      const child = buildDirectoryNode(root, join(path, nextSegment), depth + 1, nextSegment, remainingSegments);
+
+      if (child !== null) {
+        children.push(child);
+      }
+    }
+  } else {
+    for (const entry of readDirectoryEntries(path)) {
+      const entryName = entry.name;
+      const childPath = join(path, entryName);
+
+      if (entry.isDirectory()) {
+        if (shouldSkipDirectory(entryName)) {
+          continue;
+        }
+
+        const child = buildDirectoryNode(root, childPath, depth + 1, entryName, []);
+
+        if (child !== null) {
+          children.push(child);
+        }
+
         continue;
       }
 
-      children.push(buildDirectoryNode(root, childPath, depth + 1, entryName));
-      continue;
-    }
+      if (!entry.isFile() || shouldSkipFile(entryName)) {
+        continue;
+      }
 
-    if (!entry.isFile() || shouldSkipFile(entryName)) {
-      continue;
-    }
+      const childMetadata = readFrontmatterMetadata(childPath);
 
-    children.push({
-      kind: "file",
-      name: entryName,
-      relativePath: toPosixRelativePath(root, childPath),
-      depth: depth + 1,
-      metadata: readFrontmatterMetadata(childPath),
-      hasNode: false,
-      children: [],
-    });
+      if (childMetadata === null) {
+        continue;
+      }
+
+      children.push({
+        kind: "file",
+        name: entryName,
+        relativePath: toPosixRelativePath(root, childPath),
+        depth: depth + 1,
+        metadata: childMetadata,
+        hasNode: false,
+        children: [],
+      });
+    }
   }
 
   return {
@@ -178,20 +296,24 @@ function buildDirectoryNode(root: string, path: string, depth: number, name: str
     relativePath,
     depth,
     metadata,
-    hasNode,
+    hasNode: true,
     children,
   };
 }
 
-function cloneWithDepthLimit(node: ContextTreeNode, maxDepth: number | undefined): ContextTreeNode | null {
-  if (maxDepth !== undefined && node.depth > maxDepth) {
+function cloneWithTargetDepthLimit(
+  node: ContextTreeNode,
+  maxDepth: number | undefined,
+  targetDepth: number,
+): ContextTreeNode | null {
+  if (maxDepth !== undefined && node.depth > targetDepth && node.depth > targetDepth + maxDepth) {
     return null;
   }
 
   return {
     ...node,
     children: node.children
-      .map((child) => cloneWithDepthLimit(child, maxDepth))
+      .map((child) => cloneWithTargetDepthLimit(child, maxDepth, targetDepth))
       .filter((child): child is ContextTreeNode => child !== null),
   };
 }
@@ -218,19 +340,37 @@ function globToRegex(pattern: string): RegExp {
 }
 
 function nodeMatchesPattern(node: ContextTreeNode, pattern: RegExp): boolean {
-  return [node.relativePath, node.name, node.metadata.title, node.metadata.description].some((candidate) =>
-    pattern.test(candidate),
-  );
+  const candidates = [node.relativePath, formatDisplayPath(node), node.name, node.metadata.title];
+
+  if (node.metadata.description !== undefined) {
+    candidates.push(node.metadata.description);
+  }
+
+  return candidates.some((candidate) => pattern.test(candidate));
 }
 
-function cloneWithPattern(node: ContextTreeNode, pattern: RegExp, forceKeep: boolean): ContextTreeNode | null {
+function isAncestorOrSelfPath(candidate: string, target: string): boolean {
+  if (candidate.length === 0) {
+    return true;
+  }
+
+  return target === candidate || target.startsWith(`${candidate}/`);
+}
+
+function cloneWithPattern(
+  node: ContextTreeNode,
+  pattern: RegExp,
+  targetRelativePath: string,
+  forceKeep: boolean,
+): ContextTreeNode | null {
   const children = node.children
-    .map((child) => cloneWithPattern(child, pattern, false))
+    .map((child) => cloneWithPattern(child, pattern, targetRelativePath, false))
     .filter((child): child is ContextTreeNode => child !== null);
   const selfMatches = nodeMatchesPattern(node, pattern);
   const keepDirectoryAncestor = node.kind === "directory" && children.length > 0;
+  const keepTargetContext = node.kind === "directory" && isAncestorOrSelfPath(node.relativePath, targetRelativePath);
 
-  if (!forceKeep && !selfMatches && !keepDirectoryAncestor) {
+  if (!forceKeep && !selfMatches && !keepDirectoryAncestor && !keepTargetContext) {
     return null;
   }
 
@@ -238,19 +378,6 @@ function cloneWithPattern(node: ContextTreeNode, pattern: RegExp, forceKeep: boo
     ...node,
     children,
   };
-}
-
-function pruneRenderableDirectories(node: ContextTreeNode, forceKeep: boolean): ContextTreeNode | null {
-  const children = node.children
-    .map((child) => pruneRenderableDirectories(child, false))
-    .filter((child): child is ContextTreeNode => child !== null);
-  const isRenderableDirectory = node.kind === "directory" && (node.hasNode || children.length > 0 || forceKeep);
-
-  if (node.kind === "file" || isRenderableDirectory) {
-    return { ...node, children };
-  }
-
-  return null;
 }
 
 function collectRenderedLines(node: ContextTreeNode, prefix: string, isLast: boolean, lines: string[]): void {
@@ -285,6 +412,43 @@ export function parseTreeLevel(value: unknown): number | undefined {
   return level;
 }
 
+function looksLikeNumericLevelInput(value: string): boolean {
+  return /^[-+]?\d/u.test(value);
+}
+
+function parseTreeTreeOptions(options: Record<string, unknown>, args: string[]): ParsedTreeTreeOptions {
+  if (args.length > 1) {
+    throw new TreeTreeCommandError(TREE_TREE_INVALID_PATH, "Invalid path: expected at most one directory path.");
+  }
+
+  const positionalPath = args[0];
+  const rawLevel = options.level;
+  let level: number | undefined;
+  let path = positionalPath ?? ".";
+
+  if (rawLevel !== undefined) {
+    if (typeof rawLevel !== "string") {
+      throw new TreeTreeCommandError(TREE_TREE_INVALID_LEVEL, "Invalid --level: expected a non-negative integer.");
+    }
+
+    try {
+      level = parseTreeLevel(rawLevel);
+    } catch (error) {
+      if (positionalPath === undefined && !looksLikeNumericLevelInput(rawLevel)) {
+        path = rawLevel;
+      } else {
+        throw error;
+      }
+    }
+  }
+
+  return {
+    level,
+    pattern: asString(options.pattern),
+    path,
+  };
+}
+
 function normalizeSnapshotOptions(options: ReadContextTreeSnapshotOptions): ReadContextTreeSnapshotOptions {
   const normalized: ReadContextTreeSnapshotOptions = {};
 
@@ -296,34 +460,101 @@ function normalizeSnapshotOptions(options: ReadContextTreeSnapshotOptions): Read
     normalized.pattern = options.pattern;
   }
 
+  if (options.path !== undefined) {
+    normalized.path = options.path;
+  }
+
   return normalized;
+}
+
+function resolveTreeTarget(cwd: string, path: string): ResolvedTreeTarget {
+  const repoRoot = findGitRoot(cwd);
+
+  if (repoRoot === undefined) {
+    throw new TreeTreeCommandError(TREE_TREE_INVALID_PATH, "Path must be inside a git repository.");
+  }
+
+  const targetPath = resolve(cwd, path);
+
+  if (!isDirectory(targetPath)) {
+    throw new TreeTreeCommandError(TREE_TREE_INVALID_PATH, `Path "${path}" is not an existing directory.`);
+  }
+
+  if (!isPathInsideOrEqual(repoRoot, targetPath)) {
+    throw new TreeTreeCommandError(TREE_TREE_INVALID_PATH, `Path "${path}" is outside the git repository.`);
+  }
+
+  return {
+    repoRoot,
+    targetRelativePath: toPosixRelativePath(repoRoot, targetPath),
+  };
+}
+
+function resolveSnapshotTarget(root: string, target: string | undefined): ResolvedTreeTarget {
+  const repoRoot = resolve(root);
+  const targetPath = resolve(repoRoot, target ?? "");
+
+  if (!isPathInsideOrEqual(repoRoot, targetPath)) {
+    throw new TreeTreeCommandError(TREE_TREE_INVALID_PATH, `Path "${target ?? "."}" is outside the git repository.`);
+  }
+
+  if (!isDirectory(targetPath)) {
+    throw new TreeTreeCommandError(TREE_TREE_INVALID_PATH, `Path "${target ?? "."}" is not an existing directory.`);
+  }
+
+  return {
+    repoRoot,
+    targetRelativePath: toPosixRelativePath(repoRoot, targetPath),
+  };
+}
+
+function hasDirectoryNode(node: ContextTreeNode, relativePath: string): boolean {
+  if (node.kind === "directory" && node.relativePath === relativePath) {
+    return true;
+  }
+
+  return node.children.some((child) => hasDirectoryNode(child, relativePath));
 }
 
 export function readContextTreeSnapshot(
   root: string,
   options: ReadContextTreeSnapshotOptions = {},
 ): ContextTreeSnapshot {
-  const resolvedRoot = resolve(root);
-  const rootName = basename(resolvedRoot) || resolvedRoot;
-  const discovered = buildDirectoryNode(resolvedRoot, resolvedRoot, 0, rootName);
-  const depthLimited = cloneWithDepthLimit(discovered, options.level);
+  const resolvedTarget = resolveSnapshotTarget(root, options.target);
+  const rootName = basename(resolvedTarget.repoRoot) || resolvedTarget.repoRoot;
+  const targetSegments = splitRelativePath(resolvedTarget.targetRelativePath);
+  const discovered = buildDirectoryNode(resolvedTarget.repoRoot, resolvedTarget.repoRoot, 0, rootName, targetSegments);
+
+  if (discovered === null) {
+    throw new Error(`No valid Context Tree root node found at ${NODE_FILE}.`);
+  }
+
+  if (!hasDirectoryNode(discovered, resolvedTarget.targetRelativePath)) {
+    throw new Error(
+      `Target path "${formatTargetForMessage(resolvedTarget.targetRelativePath)}" is not a valid Context Tree directory node.`,
+    );
+  }
+
+  const depthLimited = cloneWithTargetDepthLimit(discovered, options.level, targetSegments.length);
 
   if (depthLimited === null) {
     throw new Error("Context Tree root was excluded by the depth limit.");
   }
 
   const patternFiltered =
-    options.pattern === undefined ? depthLimited : cloneWithPattern(depthLimited, globToRegex(options.pattern), true);
-  const renderable = patternFiltered === null ? null : pruneRenderableDirectories(patternFiltered, true);
+    options.pattern === undefined
+      ? depthLimited
+      : cloneWithPattern(depthLimited, globToRegex(options.pattern), resolvedTarget.targetRelativePath, true);
 
-  if (renderable === null) {
-    throw new Error("Context Tree root was removed by the renderable node filter.");
+  if (patternFiltered === null) {
+    throw new Error("Context Tree root was removed by the pattern filter.");
   }
 
   return {
-    root: resolvedRoot,
+    root: resolvedTarget.repoRoot,
+    target: resolvedTarget.targetRelativePath,
     options: normalizeSnapshotOptions(options),
-    tree: renderable,
+    tree: patternFiltered,
   };
 }
 
@@ -338,13 +569,17 @@ export function renderContextTree(root: string, options: RenderContextTreeOption
     readContextTreeSnapshot(root, {
       level: options.maxDepth,
       pattern: options.pattern,
+      path: options.path,
+      target: options.path,
     }),
   );
 }
 
 function configureTreeTreeCommand(command: Command): void {
   command
-    .option("-L, --level <depth>", "max display depth, where the current directory is depth 0")
+    .argument("[path]", "directory path to browse, resolved relative to the current working directory")
+    .allowExcessArguments(false)
+    .option("-L, --level <depth>", "max descendant depth below the target directory")
     .option(
       "-P, --pattern <pattern>",
       "shell-style glob filter matched against path, filename, title, and description",
@@ -354,9 +589,13 @@ function configureTreeTreeCommand(command: Command): void {
 export function runTreeTreeCommand(context: CommandContext): void {
   try {
     const options = context.command.opts<Record<string, unknown>>();
-    const snapshot = readContextTreeSnapshot(process.cwd(), {
-      level: parseTreeLevel(options.level),
-      pattern: asString(options.pattern),
+    const parsedOptions = parseTreeTreeOptions(options, context.command.args);
+    const resolvedTarget = resolveTreeTarget(process.cwd(), parsedOptions.path);
+    const snapshot = readContextTreeSnapshot(resolvedTarget.repoRoot, {
+      level: parsedOptions.level,
+      pattern: parsedOptions.pattern,
+      path: parsedOptions.path,
+      target: resolvedTarget.targetRelativePath,
     });
 
     if (context.options.json || isJsonMode()) {
@@ -367,7 +606,12 @@ export function runTreeTreeCommand(context: CommandContext): void {
     print.line(`${renderContextTreeSnapshot(snapshot)}\n`);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    const code = message.startsWith("Invalid --level") ? TREE_TREE_INVALID_LEVEL : TREE_TREE_FAILED;
+    const code =
+      error instanceof TreeTreeCommandError
+        ? error.code
+        : message.startsWith("Invalid --level")
+          ? TREE_TREE_INVALID_LEVEL
+          : TREE_TREE_FAILED;
     print.fail(code, message);
   }
 }

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -45,7 +45,7 @@ first-tree
 ├── org ...                  Organization-level operations
 ├── daemon ...               Background daemon (start, stop, status, doctor)
 ├── config ...               View/modify this machine's client.yaml
-└── tree verify              Validate a Context Tree's structure (the only surviving `tree` subcommand)
+└── tree ...                 Validate and browse Context Trees
 ```
 
 ---
@@ -340,19 +340,40 @@ server-side `agent_configs` row through the Admin API.
 
 ## tree
 
-Context Tree structural validation. **`verify` is the only surviving
-`tree` subcommand** — the rest of the namespace (`init` / `migrate` /
-`upgrade` / `status` / `codeowners` / `claude-hook` / `inject` / `review`
-/ `automation` / `skill` groups) was retired in the 2026-06 cleanup
-because the cloud now owns workspace + tree provisioning and the client
-runtime inlines its own skill payload install (see PR following #844).
+Context Tree structural validation and hierarchy browsing. **`verify`
+and `tree` are the only surviving `tree` subcommands** — the rest of the
+namespace (`init` / `migrate` / `upgrade` / `status` / `codeowners` /
+`claude-hook` / `inject` / `review` / `automation` / `skill` groups) was
+retired in the 2026-06 cleanup because the cloud now owns workspace +
+tree provisioning and the client runtime inlines its own skill payload
+install (see PR following #844).
 
 ```
 first-tree tree
-└── verify [--tree-path PATH]                # validate a Context Tree repo
+├── verify [--tree-path PATH]                # validate a Context Tree repo
+└── tree [-L depth] [-P pattern]             # browse Context Tree nodes as a hierarchy
 ```
 
 Run `first-tree tree verify --help` for options.
+
+`first-tree tree tree` starts at the current directory, renders directory
+nodes from each `NODE.md`, and renders Markdown leaf nodes other than
+`NODE.md`, `AGENTS.md`, and `CLAUDE.md`. It skips hidden paths and common
+generated directories (`node_modules`, `__pycache__`, `dist`, `build`,
+`.next`, `.turbo`). Metadata comes only from YAML frontmatter; missing
+`title` or `description` prints `-`.
+
+Options:
+
+- `-L, --level <depth>` — maximum display depth, where the current directory is depth `0`.
+- `-P, --pattern <pattern>` — case-sensitive shell-style glob filter matched against relative path, filename, `title`, and `description`; matching descendants keep their ancestors visible.
+
+With global `--json` or `FIRST_TREE_JSON=1`, `first-tree tree tree`
+emits a single `{ ok: true, data }` envelope on stdout. `data.tree`
+contains the same pruned hierarchy as structured nodes with
+`kind`, `name`, `relativePath`, `depth`, `metadata`, `hasNode`, and
+`children` fields. Human tree text is written to stderr so stdout stays
+reserved for machine-readable JSON.
 
 ## Environment variables
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -351,29 +351,52 @@ install (see PR following #844).
 ```
 first-tree tree
 ├── verify [--tree-path PATH]                # validate a Context Tree repo
-└── tree [-L depth] [-P pattern]             # browse Context Tree nodes as a hierarchy
+└── tree [path] [-L depth] [-P pattern]      # browse Context Tree nodes as a hierarchy
 ```
 
 Run `first-tree tree verify --help` for options.
 
-`first-tree tree tree` starts at the current directory, renders directory
-nodes from each `NODE.md`, and renders Markdown leaf nodes other than
-`NODE.md`, `AGENTS.md`, and `CLAUDE.md`. It skips hidden paths and common
-generated directories (`node_modules`, `__pycache__`, `dist`, `build`,
-`.next`, `.turbo`). Metadata comes only from YAML frontmatter; missing
-`title` or `description` prints `-`.
+`first-tree tree tree [path]` resolves `path` relative to the current
+working directory, then renders from the current git repository root down
+to that target directory and its descendants. Without `path`, the target is
+the current directory. The target must be an existing directory inside the
+current git repo.
+
+Directory nodes come from that directory's `NODE.md`. Leaf nodes come from
+Markdown files other than `NODE.md`, `AGENTS.md`, and `CLAUDE.md`. A
+Markdown file is renderable only when its YAML frontmatter has a non-empty
+string `title` and a non-empty array `owners`; `description` is optional.
+The `owners` field is used for filtering and included in JSON, but is not
+shown in human output. Hidden paths and common generated directories
+(`node_modules`, `__pycache__`, `dist`, `build`, `.next`, `.turbo`) are
+skipped.
+
+Human output is written as a tree whose node labels use:
+
+```text
+relative/path/ [Title] -> Description
+relative/path.md [Title]
+```
+
+Directory labels end with `/`. The repository root line uses the repo
+directory name, for example `first-tree-context/ [Context Tree] -> Root
+index for the First Tree context tree.`. When `description` is missing,
+the `-> Description` suffix is omitted.
 
 Options:
 
-- `-L, --level <depth>` — maximum display depth, where the current directory is depth `0`.
+- `-L, --level <depth>` — maximum descendant depth below the target directory. Ancestors from the git repo root to the target are always kept. For path-tolerant CLI use, `tree tree -L docs/development` is treated as `tree tree docs/development`; `tree tree -L 2 docs/development` applies depth `2` to that path.
 - `-P, --pattern <pattern>` — case-sensitive shell-style glob filter matched against relative path, filename, `title`, and `description`; matching descendants keep their ancestors visible.
 
 With global `--json` or `FIRST_TREE_JSON=1`, `first-tree tree tree`
-emits a single `{ ok: true, data }` envelope on stdout. `data.tree`
-contains the same pruned hierarchy as structured nodes with
-`kind`, `name`, `relativePath`, `depth`, `metadata`, `hasNode`, and
-`children` fields. Human tree text is written to stderr so stdout stays
-reserved for machine-readable JSON.
+emits a single `{ ok: true, data }` envelope on stdout. `data.root` is the
+git repo root, `data.target` is the resolved target directory relative to
+that root, and `data.options` records the parsed `level`, `pattern`, and
+effective `path`. `data.tree` contains the same filtered hierarchy as
+structured nodes with `kind`, `name`, `relativePath`, `depth`, `metadata`,
+`hasNode`, and `children` fields; `metadata` includes `title`, optional
+`description`, and `owners`. Human tree text is written to stderr so stdout
+stays reserved for machine-readable JSON.
 
 ## Environment variables
 


### PR DESCRIPTION
## Summary
- add `first-tree tree tree` for read-only Context Tree hierarchy browsing
- render `NODE.md` directory nodes and Markdown leaf nodes with frontmatter title/description
- support `--level` depth limiting and `--pattern` glob filtering while preserving matched ancestors
- add focused renderer/action tests, command registration smoke coverage, and CLI reference docs

## Verification
- `pnpm --filter first-tree-dev test -- tree`
- `pnpm check && pnpm typecheck`