### PR TITLE
feat(web): link header brand to the marketing site

### DIFF
--- a/packages/web/src/components/layout.tsx
+++ b/packages/web/src/components/layout.tsx
@@ -16,6 +16,12 @@ const navTabs = [
   { to: "/settings", label: "Settings", end: false },
 ];
 
+// Parent brand site. The dashboard is the cloud / collaboration layer of First
+// Tree, so the header brand links out to the marketing site. Naming mirrors the
+// landing `footer.tsx` constant of the same value. Opens in a new tab so the
+// click never interrupts the user's in-app work.
+const PARENT_URL = "https://first-tree.ai";
+
 export function Layout() {
   const [paletteOpen, setPaletteOpen] = useState(false);
 
@@ -96,13 +102,21 @@ export function Layout() {
         {/* Brand cluster: logo + name welded together, then the optional chip. */}
         {dropBrand ? null : (
           <div className="flex items-center" style={{ gap: "var(--sp-3_5)", justifySelf: "start", minWidth: 0 }}>
-            <span className="flex items-center" style={{ gap: 10, flexShrink: 0 }}>
+            {/* Brand links out to the parent marketing site in a new tab. */}
+            <a
+              href={PARENT_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="First Tree — open first-tree.ai in a new tab"
+              className="flex items-center cursor-pointer"
+              style={{ gap: 10, flexShrink: 0 }}
+            >
               <FirstTreeLogo width={16} height={18} style={{ color: "var(--fg)" }} />
               {/* Brand uses the `text-title` token (16 / 600 / -0.2 letter-spacing). */}
               <span className="text-title" style={{ color: "var(--fg)" }}>
                 First Tree
               </span>
-            </span>
+            </a>
             <DisconnectChip />
           </div>
         )}


### PR DESCRIPTION
## What

The in-app workspace header's left-side brand cluster (`FirstTreeLogo` + the "First Tree" name) in `packages/web/src/components/layout.tsx` was display-only — clicking it did nothing. This wraps it in an anchor that opens the parent marketing site, so users can reach **https://first-tree.ai** from anywhere in the app.

## Details

- **New tab**: `target="_blank"` + `rel="noopener noreferrer"` — the click never interrupts the user's in-app work.
- **No hardcoded URL scatter**: adds a `PARENT_URL` constant mirroring the value/naming already used in the landing `footer.tsx`.
- **Scope kept tight**: only the logo + name are wrapped. The adjacent `DisconnectChip` is untouched, and all existing styles/spacing (`gap`, `flexShrink`, `text-title`, `--fg`) are preserved, so the layout is visually unchanged. `cursor-pointer` added for the hover affordance.
- **Landing nav untouched**: `pages/landing/nav.tsx` still links to the in-site home `/` — out of scope here by design.

## Acceptance

1. ✅ From any in-app workspace page, clicking the top-left logo or product name opens https://first-tree.ai in a new tab.
2. ✅ Hover shows a clickable cursor; visual layout/spacing unchanged.
3. ✅ Landing page behavior unchanged.

## Verification

- `pnpm --filter @first-tree/web typecheck` (tsc + `lint:tokens` gate) — green
- `pnpm check` (biome) — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)