### PR TITLE
feat(web): clarify Context Tree copy in onboarding (#834)

### DIFF
--- a/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
+++ b/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
@@ -1461,7 +1461,7 @@ describe("web DOM interaction coverage", () => {
       setTreeUrl,
       markTreeAutoInitDone,
     });
-    await waitForText("Start building your Context Tree", adminAutoDetect.container);
+    await waitForText("Start your Context Tree", adminAutoDetect.container);
     expect(markTreeAutoInitDone).toHaveBeenCalled();
     expect(setTreeMode).toHaveBeenCalledWith("existing");
     expect(setTreeUrl).toHaveBeenCalledWith("https://github.com/acme/context-tree");

--- a/packages/web/src/pages/onboarding/copy.ts
+++ b/packages/web/src/pages/onboarding/copy.ts
@@ -39,7 +39,11 @@ export const STEP_COPY: Record<StepId, StepCopy> = {
   },
   "connect-code": {
     title: "Connect your code",
-    why: "Connect your GitHub projects so your agent can work on them.",
+    // Answer "why connect a repo?" in value terms (the issue-834 UR gap): connecting
+    // isn't just access — it's how the agent learns the project and turns it
+    // into the team's shared context. The second clause reassures the user the
+    // agent won't touch their code unsupervised.
+    why: "Connect a project — your agent learns it and turns it into shared context. It never changes your code without your okay.",
   },
   "connect-computer": {
     title: "Connect your computer",
@@ -207,14 +211,18 @@ export const COPY = {
     // admin — new Context Tree (default when the team has none yet). This is
     // the first time the user meets "Context Tree", so lead with a plain
     // one-line gloss of what it is + why it helps before saying what happens.
-    newTitle: "Start building your Context Tree",
+    // Approval is phrased concretely ("nothing's saved unless you say yes")
+    // instead of "walking you through each change to approve" — the latter
+    // reads vague about what is actually being approved (per issue-834 copy review).
+    newTitle: "Start your Context Tree",
     newWhy:
-      "A Context Tree is a living map of how your team works, so your agent starts with real context instead of guessing. You're all set — your agent builds it with you in the chat, walking you through each change to approve.",
+      "Your Context Tree is your team's shared memory — what agents need to work like they already know your project. Your agent drafts the first pieces with you in the chat, and nothing's saved unless you say yes.",
     haveExisting: "I already have a Context Tree",
-    // admin — existing Context Tree (auto-detected from team settings, or pasted)
+    // admin — existing Context Tree (auto-detected from team settings, or pasted).
+    // Same gloss as newWhy so both kickoff paths teach the concept identically.
     existingTitle: "Use your team's Context Tree",
     existingWhy:
-      "Your team already has a Context Tree — your agent will build on it, walking you through each change to approve in the chat.",
+      "Your Context Tree is your team's shared memory — what agents need to work like they already know your project. Your team already has one; your agent builds on it with you in the chat, and nothing's saved unless you say yes.",
     existingUrlLabel: "Context Tree link",
     autoDetectedNote: "Your team already has one — your agent will build on it. Edit the link or create a new one.",
     createInstead: "Create new instead",


### PR DESCRIPTION
Closes #834 (copy/understanding scope only — build-time and connect-repo flow are out of scope per the issue).

## Problem
Onboarding never explained **what a Context Tree is** or **why connecting a repo matters**. The term "Context Tree" first appeared only at the final kickoff step, with no value framing — exactly the confusion User A reported in the user research ("不知道 context tree 是什么、为什么要连 repo").

## Changes (all in `packages/web/src/pages/onboarding/copy.ts`)
- **connect-code `why`** — reframed from bare repo access to the value it unlocks: the agent learns the project and turns it into the team's *shared context*, plus a reassurance it won't touch code unsupervised.
  - before: `Connect your GitHub projects so your agent can work on them.`
  - after: `Connect a project — your agent learns it and turns it into shared context. It never changes your code without your okay.`
- **kickoff `newTitle`** → `Start your Context Tree`
- **kickoff `newWhy` / `existingWhy`** — name "Context Tree" with a plain gloss (*your team's shared memory*) and phrase approval concretely (*nothing's saved unless you say yes*) instead of the vaguer "walking you through each change to approve". Same gloss on both tree paths so they teach the concept identically.

Deliberately **not** touching per-agent context framing — the Context tab currently only surfaces the team tree, so claiming "each agent's context" would over-promise unshipped UI.

## Notes
- Base had already added a `living map` gloss to `newWhy`; this replaces it with the reviewed wording (decision made with the product owner).
- Updated a now-stale title assertion in `web-dom-interactions.test.tsx`.

## Verification
- `tsc --noEmit` ✅ · `lint:tokens` ✅ · biome ✅
- web test suite: **673/673** ✅
- independent codex review: **PASS** (no actionable findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)