### PR TITLE
fix(web): make Select options clickable inside modal dialogs

### DIFF
--- a/packages/web/src/components/ui/__tests__/select-portal.test.tsx
+++ b/packages/web/src/components/ui/__tests__/select-portal.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Select } from "../select.js";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+/**
+ * Regression guard for the Select-inside-modal-Dialog bug.
+ *
+ * The Select panel is portaled to `document.body`. A Radix modal `Dialog`
+ * (and `Popover`) set `pointer-events: none` on the body and only re-enable it
+ * inside their own content — which the portaled panel is NOT. Without an
+ * explicit `pointer-events: auto` on the panel, the options inherit `none` and
+ * become unclickable: the dropdown opens but you cannot pick another option.
+ *
+ * happy-dom does not model layout or inherited `pointer-events`, so it cannot
+ * reproduce the click failure itself (the real fix was verified in a browser).
+ * What it CAN pin cheaply is that the panel always carries the inline
+ * `pointer-events: auto` that overrides the inherited `none`. If a future
+ * refactor drops that style, this test fails before the bug ships again.
+ */
+describe("Select portal — pointer-events escape hatch", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function getTrigger(): HTMLButtonElement {
+    const trigger = document.querySelector<HTMLButtonElement>('[aria-label="Pick one"]');
+    if (!trigger) throw new Error("trigger not rendered");
+    return trigger;
+  }
+
+  it("renders the open panel with pointer-events:auto so it stays clickable inside a modal", () => {
+    act(() => {
+      root.render(
+        <Select
+          aria-label="Pick one"
+          value="a"
+          onChange={() => undefined}
+          options={[
+            { value: "a", label: "Alpha" },
+            { value: "b", label: "Bravo" },
+          ]}
+        />,
+      );
+    });
+
+    act(() => {
+      getTrigger().click();
+    });
+
+    // The panel is portaled to document.body, outside the React root container.
+    const listbox = document.querySelector<HTMLElement>('[role="listbox"]');
+    expect(listbox, "listbox should render once the panel is open").not.toBeNull();
+    const panel = listbox?.parentElement;
+    expect(panel, "panel wraps the listbox").not.toBeNull();
+    expect(panel?.style.pointerEvents).toBe("auto");
+  });
+});

--- a/packages/web/src/components/ui/select.tsx
+++ b/packages/web/src/components/ui/select.tsx
@@ -311,6 +311,19 @@ export function Select({
         createPortal(
           <div
             ref={panelRef}
+            // The panel is portaled to `document.body`, which sits OUTSIDE any
+            // open modal (Radix `Dialog`/`Popover` set `pointer-events: none`
+            // on the body and only re-enable it inside their own content). Two
+            // fixes are needed so the panel works inside a modal:
+            //   1. `pointerEvents: "auto"` re-enables clicks on this subtree,
+            //      overriding the inherited `none` from the body.
+            //   2. stop `pointerdown` from bubbling to the document so the host
+            //      modal's dismiss-on-outside-interaction listener doesn't see
+            //      an option click as an "outside" click and close itself.
+            // Our own outside-click handler listens on the document too, but it
+            // already early-returns for panel-contained targets, so swallowing
+            // these events here is safe.
+            onPointerDown={(e) => e.stopPropagation()}
             className="fixed z-50 flex flex-col overflow-hidden rounded-[var(--radius-input)]"
             style={{
               top: rect.top,
@@ -320,6 +333,7 @@ export function Select({
               background: "var(--bg-raised)",
               border: "var(--hairline) solid var(--border)",
               boxShadow: "var(--shadow-md)",
+              pointerEvents: "auto",
             }}
           >
             {searchable && (


### PR DESCRIPTION
## Problem

The Visibility dropdown in the **Edit Identity** dialog opens but you can't select another option (reported with screenshots). Root cause confirmed in a real browser, not theorized.

The `Select` panel is portaled to `document.body`, which sits **outside** any open Radix modal `Dialog`/`Popover`. Modal layers set `pointer-events: none` on the body and only re-enable it inside their own content. The portaled panel therefore inherited `none`:

- `getComputedStyle(option).pointerEvents === "none"`, `body === "none"`
- a **real** mouse click on an option times out / does nothing → value unchanged
- a synthetic `.click()` *does* change the value → proves `onChange` was never broken; only the real pointer was being blocked

This is a systemic `Select` bug — it affects every `Select`-in-`Dialog`: `identity-section`, `re-bind-dialog`, `mcp-section`, and `settings/resource-editors`.

## Fix

One change in the `Select` primitive, so all usages are repaired at once:

1. `pointerEvents: "auto"` on the portaled panel — overrides the inherited `none`.
2. `onPointerDown` stops propagation to the document — so the host modal's dismiss-on-outside-interaction listener doesn't treat an option click as an "outside" click and close the dialog.

## Verification (real browser, no-auth styleguide repro)

- ✅ Real click on an option changes the value and **keeps the dialog open**; panel closes after pick
- ✅ `Select` outside a dialog still works (model picker: opus → sonnet)
- ✅ outside-click still closes the dropdown
- ✅ `pnpm check` clean, `pnpm typecheck` 11/11, web tests **674 passed**
- ✅ new happy-dom regression test `select-portal.test.tsx` **fails without the fix** (`expected '' to be 'auto'`), passes with it

### Why existing tests didn't catch it

jsdom/happy-dom doesn't model layout or inherited `pointer-events`, so DOM tests stayed green while the real browser was broken. The new test pins the inline `pointer-events: auto` escape hatch as a cheap guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)