### PR TITLE
feat(invite): make invite link discoverable and member-shareable (#836)

### DIFF
--- a/packages/server/src/__tests__/invitations.test.ts
+++ b/packages/server/src/__tests__/invitations.test.ts
@@ -88,7 +88,7 @@ describe("Invitation lifecycle", () => {
     expect(oldRow[0]?.revokedAt).not.toBeNull();
   });
 
-  it("non-admin cannot fetch or rotate invitations", async () => {
+  it("non-admin member can fetch/share the link but cannot rotate it", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
     // Demote: create a second member with role=member via raw insert
@@ -111,12 +111,25 @@ describe("Invitation lifecycle", () => {
       username: `peer-${otherUserId.slice(0, 8)}`,
     });
     const tokens = await signTokensForUser(app.config.secrets.jwtSecret, otherUserId, app.config.auth);
-    const res = await app.inject({
+
+    // Sharing the link is member-level: GET succeeds and returns the active link.
+    const fetchRes = await app.inject({
+      method: "GET",
+      url: `/api/v1/orgs/${admin.organizationId}/invitations`,
+      headers: { authorization: `Bearer ${tokens.accessToken}` },
+    });
+    expect(fetchRes.statusCode).toBe(200);
+    const body = fetchRes.json<{ token: string; inviteUrl: string }>();
+    expect(body.token).toMatch(/^[A-Za-z0-9_-]{20,}$/);
+    expect(body.inviteUrl).toContain(`/invite/${body.token}`);
+
+    // Rotation is destructive and stays admin-only: member is refused.
+    const rotateRes = await app.inject({
       method: "POST",
       url: `/api/v1/orgs/${admin.organizationId}/invitations/rotate`,
       headers: { authorization: `Bearer ${tokens.accessToken}` },
     });
-    expect(res.statusCode).toBe(403);
+    expect(rotateRes.statusCode).toBe(403);
   });
 
   it("admin from org A cannot rotate invitations of org B", async () => {

--- a/packages/server/src/api/orgs/invitations.ts
+++ b/packages/server/src/api/orgs/invitations.ts
@@ -1,12 +1,19 @@
 import type { FastifyInstance } from "fastify";
-import { requireOrgAdmin } from "../../scope/require-org.js";
+import { requireOrgAdmin, requireOrgMembership } from "../../scope/require-org.js";
 import { buildInviteUrl, ensureActiveInvitation, rotateInvitation } from "../../services/invitation.js";
 import { resolvePublicUrl } from "../../utils/public-url.js";
 
-/** Class B — `/api/v1/orgs/:orgId/invitations`. Admin-only. */
+/**
+ * Class B — `/api/v1/orgs/:orgId/invitations`.
+ *
+ * Reading/sharing the invite link is a member-level capability — inviting
+ * more people into a team is core to every member's job (issue 836). Rotation
+ * (revoke + replace) stays admin-only because it is a destructive lifecycle
+ * act that invalidates the link everyone else may already be sharing.
+ */
 export async function orgInvitationRoutes(app: FastifyInstance): Promise<void> {
   app.get<{ Params: { orgId: string } }>("/", async (request) => {
-    const scope = await requireOrgAdmin(request, app.db);
+    const scope = await requireOrgMembership(request, app.db);
     const inv = await ensureActiveInvitation(app.db, scope.organizationId, scope.userId);
     return {
       id: inv.id,

--- a/packages/web/src/components/invite-dialog.tsx
+++ b/packages/web/src/components/invite-dialog.tsx
@@ -1,0 +1,21 @@
+import { InviteLinkPanel } from "../pages/invite-link-panel.js";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "./ui/dialog.js";
+
+/**
+ * Shared invite dialog. Used by both the avatar UserMenu and the Team page so
+ * the invite entry is reachable from a global, role-agnostic surface rather
+ * than only the Team admin corner (issue 836). The panel inside role-forks:
+ * every member can copy the link; only admins see Rotate.
+ */
+export function InviteDialog({ open, onOpenChange }: { open: boolean; onOpenChange: (open: boolean) => void }) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Invite teammates</DialogTitle>
+        </DialogHeader>
+        <InviteLinkPanel />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/web/src/components/user-menu.tsx
+++ b/packages/web/src/components/user-menu.tsx
@@ -1,10 +1,11 @@
 import type { OrgBrief } from "@first-tree/shared";
-import { Check, LogOut, Plus, UserPlus } from "lucide-react";
+import { Check, Link2, LogOut, Plus, UserPlus } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router";
 import { api } from "../api/client.js";
 import { useAuth } from "../auth/auth-context.js";
 import { Avatar } from "./avatar.js";
+import { InviteDialog } from "./invite-dialog.js";
 import { TeamSetupModal } from "./team-setup-modal.js";
 
 /**
@@ -21,6 +22,7 @@ export function UserMenu() {
   const navigate = useNavigate();
   const [orgs, setOrgs] = useState<OrgBrief[]>([]);
   const [open, setOpen] = useState(false);
+  const [inviteOpen, setInviteOpen] = useState(false);
   const [setupAction, setSetupAction] = useState<"create" | "join" | null>(null);
   const ref = useRef<HTMLDivElement>(null);
 
@@ -82,6 +84,10 @@ export function UserMenu() {
   const openJoin = () => {
     setOpen(false);
     setSetupAction("join");
+  };
+  const openInvite = () => {
+    setOpen(false);
+    setInviteOpen(true);
   };
 
   return (
@@ -186,6 +192,22 @@ export function UserMenu() {
                 <UserPlus className="h-3.5 w-3.5" />
                 <span>Join with invite link</span>
               </button>
+              {/* Invite teammates — the global, role-agnostic entry to share the
+                  org's invite link from any page (issue 836). Only shown when a
+                  team is selected, since the link is org-scoped; the dialog's
+                  panel role-forks (members copy, admins also rotate). */}
+              {organizationId && (
+                <button
+                  type="button"
+                  role="menuitem"
+                  onClick={openInvite}
+                  className="flex w-full items-center gap-2 px-4 py-1.5 text-left text-body hover:bg-accent transition-colors"
+                  style={{ color: "var(--fg)" }}
+                >
+                  <Link2 className="h-3.5 w-3.5" />
+                  <span>Invite teammates</span>
+                </button>
+              )}
             </div>
 
             {/* User actions */}
@@ -209,6 +231,7 @@ export function UserMenu() {
       </div>
 
       <TeamSetupModal action={setupAction} onClose={() => setSetupAction(null)} />
+      <InviteDialog open={inviteOpen} onOpenChange={setInviteOpen} />
     </>
   );
 }

--- a/packages/web/src/pages/invite-link-panel.tsx
+++ b/packages/web/src/pages/invite-link-panel.tsx
@@ -3,7 +3,6 @@ import { useEffect, useState } from "react";
 import { api, withOrgAt } from "../api/client.js";
 import { useAuth } from "../auth/auth-context.js";
 import { Button } from "../components/ui/button.js";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../components/ui/card.js";
 
 /** Render the expiry timestamp as "in N days · 2026/5/6" — both relative
  *  and absolute, so the admin doesn't have to do arithmetic. */
@@ -18,17 +17,19 @@ function formatExpiry(iso: string): string {
 }
 
 /**
- * Admin panel for the org's *current* invite link. v1 enforces "one
- * active link per org" via the `uq_invitations_active_per_org` partial
- * unique index, so the UI surfaces a single share URL with a "rotate"
- * action that revokes-and-replaces in one transaction.
+ * Body of the org's invite dialog (the surrounding chrome + title live in
+ * `InviteDialog`). v1 enforces "one active link per org" via the
+ * `uq_invitations_active_per_org` partial unique index, so the UI surfaces a
+ * single share URL.
  *
- * Links auto-expire after `INVITATION_DEFAULT_TTL_DAYS` to bound the
- * blast radius of accidental link leakage. Admin extends by clicking
- * Rotate (mints a fresh link with a fresh timer).
+ * Role-forked (issue 836): every member can read and Copy the link, since
+ * inviting people is core to every member's job; only admins see Rotate, which
+ * revokes the prior link and resets its 7-day (`INVITATION_DEFAULT_TTL_DAYS`)
+ * timer.
  */
 export function InviteLinkPanel() {
-  const { organizationId } = useAuth();
+  const { organizationId, role } = useAuth();
+  const isAdmin = role === "admin";
   const [invite, setInvite] = useState<InvitationView | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
@@ -61,50 +62,55 @@ export function InviteLinkPanel() {
   };
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Invite link</CardTitle>
-        <CardDescription>
-          Anyone with this link can join your team as a member. Links expire after {INVITATION_DEFAULT_TTL_DAYS} days;
-          rotating revokes the old link instantly and resets the timer.
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="space-y-3">
-        {error && (
-          <div className="rounded-[var(--radius-panel)] bg-destructive/10 p-2 text-label text-destructive">{error}</div>
-        )}
-        {invite ? (
+    <div className="space-y-3">
+      <p className="text-label text-muted-foreground">
+        {isAdmin ? (
           <>
-            <div className="flex gap-2">
-              <input
-                readOnly
-                className="flex-1 rounded-[var(--radius-panel)] border bg-muted px-2 py-1 text-label font-mono"
-                value={invite.inviteUrl}
-              />
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={() => {
-                  void navigator.clipboard.writeText(invite.inviteUrl);
-                  setCopied(true);
-                  setTimeout(() => setCopied(false), 1500);
-                }}
-              >
-                {copied ? "Copied!" : "Copy"}
-              </Button>
+            Anyone with this link can join your team as a member. Links expire after {INVITATION_DEFAULT_TTL_DAYS} days;
+            rotating revokes the old link instantly and resets the timer.
+          </>
+        ) : (
+          <>
+            Anyone with this link can join your team as a member. Links expire after {INVITATION_DEFAULT_TTL_DAYS} days.
+          </>
+        )}
+      </p>
+      {error && (
+        <div className="rounded-[var(--radius-panel)] bg-destructive/10 p-2 text-label text-destructive">{error}</div>
+      )}
+      {invite ? (
+        <>
+          <div className="flex gap-2">
+            <input
+              readOnly
+              className="flex-1 rounded-[var(--radius-panel)] border bg-muted px-2 py-1 text-label font-mono"
+              value={invite.inviteUrl}
+            />
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => {
+                void navigator.clipboard.writeText(invite.inviteUrl);
+                setCopied(true);
+                setTimeout(() => setCopied(false), 1500);
+              }}
+            >
+              {copied ? "Copied!" : "Copy"}
+            </Button>
+            {isAdmin && (
               <Button size="sm" onClick={rotate} disabled={busy}>
                 {busy ? "Rotating…" : "Rotate"}
               </Button>
-            </div>
-            <p className="text-label text-muted-foreground">
-              Created {new Date(invite.createdAt).toLocaleString()}
-              {invite.expiresAt ? ` · ${formatExpiry(invite.expiresAt)}` : " · no expiry"}
-            </p>
-          </>
-        ) : (
-          <p className="text-label text-muted-foreground">Loading…</p>
-        )}
-      </CardContent>
-    </Card>
+            )}
+          </div>
+          <p className="text-label text-muted-foreground">
+            Created {new Date(invite.createdAt).toLocaleString()}
+            {invite.expiresAt ? ` · ${formatExpiry(invite.expiresAt)}` : " · no expiry"}
+          </p>
+        </>
+      ) : (
+        <p className="text-label text-muted-foreground">Loading…</p>
+      )}
+    </div>
   );
 }

--- a/packages/web/src/pages/team/__tests__/team-page-dom.test.tsx
+++ b/packages/web/src/pages/team/__tests__/team-page-dom.test.tsx
@@ -597,7 +597,9 @@ describe("TeamPage", () => {
     await waitForText(container, "Kael");
     expect(agentMocks.listAgents).toHaveBeenCalledWith({ limit: 100 });
     expect(agentMocks.listAllAgents).not.toHaveBeenCalled();
-    expect(container.textContent).not.toContain("Invite link");
+    // Issue 836: sharing the invite link is member-level, so the "Invite link"
+    // entry is no longer admin-gated — non-admins see it too.
+    expect(container.textContent).toContain("Invite link");
     expect(container.textContent).not.toContain("Design Critique");
     expect(container.textContent).toContain("Ops Helper");
 

--- a/packages/web/src/pages/team/__tests__/team-table-dom.test.tsx
+++ b/packages/web/src/pages/team/__tests__/team-table-dom.test.tsx
@@ -158,6 +158,7 @@ function createProps(overrides: Partial<TeamTableProps> = {}): TeamTableProps {
     searchActive: false,
     agentFilter: "all",
     onAgentFilter: vi.fn(),
+    onInvite: vi.fn(),
     ...overrides,
   };
 }

--- a/packages/web/src/pages/team/index.tsx
+++ b/packages/web/src/pages/team/index.tsx
@@ -20,6 +20,7 @@ import {
   AgentDeleteConfirmDialog,
   AgentSuspendConfirmDialog,
 } from "../../components/agent-lifecycle-confirm-dialog.js";
+import { InviteDialog } from "../../components/invite-dialog.js";
 import { NewAgentDialog } from "../../components/new-agent-dialog.js";
 import { Button } from "../../components/ui/button.js";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "../../components/ui/dialog.js";
@@ -28,7 +29,6 @@ import { Label } from "../../components/ui/label.js";
 import { PageHeader } from "../../components/ui/page-header.js";
 import { useMemberNameMap } from "../../lib/use-member-name-map.js";
 import { formatRelative } from "../../lib/utils.js";
-import { InviteLinkPanel } from "../invite-link-panel.js";
 import { type AgentRow, type HumanRow, type RowAction, TeamTable } from "./team-table.js";
 
 /**
@@ -312,13 +312,13 @@ export function TeamPage() {
               <Plus className="h-3.5 w-3.5" />
               New agent
             </Button>
-            {/* Secondary, admin-only — neutral outline, never green. */}
-            {isAdmin && (
-              <Button size="sm" variant="outline" onClick={() => setInviteOpen(true)}>
-                <Link2 className="h-3.5 w-3.5" />
-                Invite link
-              </Button>
-            )}
+            {/* Secondary, member-level — neutral outline, never green. Sharing
+                the invite link is a member-level capability (issue 836); the
+                dialog's panel role-forks so only admins see Rotate. */}
+            <Button size="sm" variant="outline" onClick={() => setInviteOpen(true)}>
+              <Link2 className="h-3.5 w-3.5" />
+              Invite link
+            </Button>
           </div>
         }
       />
@@ -363,18 +363,12 @@ export function TeamPage() {
             searchActive={search.length > 0}
             agentFilter={agentFilter}
             onAgentFilter={handleAgentFilterChange}
+            onInvite={() => setInviteOpen(true)}
           />
         )}
       </div>
 
-      <Dialog open={inviteOpen} onOpenChange={setInviteOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Invite link</DialogTitle>
-          </DialogHeader>
-          <InviteLinkPanel />
-        </DialogContent>
-      </Dialog>
+      <InviteDialog open={inviteOpen} onOpenChange={setInviteOpen} />
 
       <NewAgentDialog
         open={createOpen}

--- a/packages/web/src/pages/team/team-table.tsx
+++ b/packages/web/src/pages/team/team-table.tsx
@@ -1,7 +1,8 @@
 import type { Agent, PresenceStatus, UsageByAgentRow } from "@first-tree/shared";
-import { Bot, ChevronDown, Lock, type LucideIcon, User } from "lucide-react";
+import { Bot, ChevronDown, Link2, Lock, type LucideIcon, User } from "lucide-react";
 import { type ReactNode, useEffect, useState } from "react";
 import { Avatar } from "../../components/avatar.js";
+import { Button } from "../../components/ui/button.js";
 import { DenseBadge } from "../../components/ui/dense-badge.js";
 import { Popover } from "../../components/ui/popover.js";
 import { PresenceChip, runtimeStateToPresence } from "../../components/ui/presence-chip.js";
@@ -187,6 +188,8 @@ export type TeamTableProps = {
   /** Agent-only scope filter, surfaced in the Agent teammates header. */
   agentFilter: "all" | "mine";
   onAgentFilter: (next: "all" | "mine") => void;
+  /** Open the shared invite dialog from the Human empty-state CTA (issue 836). */
+  onInvite: () => void;
 };
 
 export function TeamTable(props: TeamTableProps) {
@@ -577,7 +580,7 @@ function StatusCell({ status, lastSeenAt }: { status: PresenceStatus; lastSeenAt
 // ─────────────────────────────────────────────────────────────────────────
 
 function HumanSection(props: TeamTableProps & { compact: boolean }) {
-  const { humans, compact, searchActive } = props;
+  const { humans, compact, searchActive, onInvite } = props;
   const [collapsed, toggle] = useCollapsed("team.collapse.humans");
   return (
     <section style={{ marginTop: "var(--sp-6)" }}>
@@ -611,9 +614,27 @@ function HumanSection(props: TeamTableProps & { compact: boolean }) {
         <div style={{ paddingLeft: SECTION_BODY_INDENT }}>
           {compact ? null : <HumanColumnHeader />}
           {humans.length === 0 ? (
-            <div className="text-caption" style={{ color: "var(--fg-4)", padding: "0 var(--sp-2) var(--sp-3)" }}>
-              {searchActive ? "No humans match this search." : "No members yet."}
-            </div>
+            searchActive ? (
+              <div className="text-caption" style={{ color: "var(--fg-4)", padding: "0 var(--sp-2) var(--sp-3)" }}>
+                No humans match this search.
+              </div>
+            ) : (
+              // Issue 836: the empty roster is exactly where a user reaches for
+              // "invite" — replace the dead "No members yet." text with a live
+              // CTA that opens the shared invite dialog (any member can share).
+              <div
+                className="flex flex-col items-start"
+                style={{ gap: "var(--sp-2)", padding: "0 var(--sp-2) var(--sp-3)" }}
+              >
+                <span className="text-caption" style={{ color: "var(--fg-4)" }}>
+                  No teammates yet — invite people to join your team.
+                </span>
+                <Button size="sm" variant="outline" onClick={onInvite}>
+                  <Link2 className="h-3.5 w-3.5" />
+                  Invite teammates
+                </Button>
+              </div>
+            )
           ) : (
             humans.map((row) => <HumanRowView key={row.id} row={row} {...props} />)
           )}


### PR DESCRIPTION
Fixes #836.

## Problem
User research (#836) surfaced two issues:
1. The invite entry was **undiscoverable** — the only entry was an admin-gated "Invite link" button buried in the Team tab. Two users didn't know they could invite at all.
2. There was a **dead control** — the empty Human roster rendered a non-interactive "No members yet." exactly where users reached to invite.

## Decision (from #836, confirmed by owner)
- **Sharing** the invite link is a **member-level** capability — inviting people into a team is core to every member's job.
- **Rotating** the link (revoke + replace) stays **admin-only** — it's a destructive lifecycle act that invalidates the link everyone else may be sharing.
- The invite entry must be reachable from a **global, role-agnostic surface**, not only the Team admin corner.

## Changes
**Server**
- `GET /orgs/:orgId/invitations`: `requireOrgAdmin` → `requireOrgMembership` (any active member can read/copy; first GET auto-creates via `ensureActiveInvitation`).
- `POST .../rotate`: unchanged — stays `requireOrgAdmin`.
- Tests: split the old "non-admin can't fetch or rotate" into **member can GET + receive a link** and **member rotate → 403**.

**Web**
- New global entry **"Invite teammates"** in the avatar `UserMenu` (any tab, any role; shown when a team is selected).
- Extracted a shared **`InviteDialog`** so `UserMenu` and the Team page reuse one dialog (no duplicated markup).
- `InviteLinkPanel` **role-forks**: every member sees URL + **Copy**; only admins see **Rotate**. Dropped the inner `Card` chrome so the dialog has a single title ("Invite teammates").
- Team page header **"Invite link"** button **ungated** (members can open it; the panel self-hides Rotate).
- Team Human empty state: dead "No members yet." → live **"Invite teammates"** CTA opening the same dialog.

## Merge order (prerequisite)
Context-tree PR **agent-team-foundation/first-tree-context#429** records the member-level access contract (`team/invitations.md`). Merge it **before (or together with)** this code PR so other agents don't read the stale "admin manages the link" contract.

## Verification
- `pnpm check` (biome) ✓ · `pnpm --filter @first-tree/web typecheck` (tsc + lint:tokens) ✓ · server typecheck ✓
- server tests 1295 ✓ (invitations 8 ✓) · web tests 684 ✓ (team-page / team-table / web-dom-interactions / team-preview all pass)
- Note: the full `pnpm test` shows a pre-existing flaky `client-connection-auth-expired` (WebSocket reconnect timing; package untouched here) — passes in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)