### PR TITLE
feat(web): clearer resource default labels + roomier prompt/skill editor

### DIFF
--- a/packages/web/src/pages/settings/resource-editors.tsx
+++ b/packages/web/src/pages/settings/resource-editors.tsx
@@ -32,9 +32,20 @@ const asDefaultMode = (v: string): DefaultMode => DEFAULT_MODES.find((d) => d ==
 const asTransport = (v: string): Transport => TRANSPORTS.find((t) => t === v) ?? "stdio";
 
 const DEFAULT_OPTIONS: SelectOption[] = [
-  { value: "available", label: "Available", hint: "Agents opt in" },
-  { value: "recommended", label: "Recommended", hint: "On by default" },
+  { value: "recommended", label: "On by default", hint: "Enabled for every agent" },
+  { value: "available", label: "Opt-in", hint: "Agents enable it themselves" },
 ];
+
+/**
+ * Human label for a resource's `defaultEnabled` mode. Single source of truth so
+ * the editor dropdown and the list / preview badges never drift apart. The raw
+ * enum (`recommended` / `available`) reads as a soft suggestion or mere
+ * existence; these phrasings name the actual behaviour (default-on vs opt-in).
+ */
+export function defaultEnabledLabel(value: DefaultMode | null): string {
+  if (value === null) return "";
+  return value === "recommended" ? "On by default" : "Opt-in";
+}
 const TRANSPORT_OPTIONS: SelectOption[] = TRANSPORTS.map((t) => ({ value: t, label: t }));
 // Mirrors MCP_NAME_PATTERN (agent-runtime-config.ts). Validated explicitly in
 // JS rather than via the HTML `pattern` attr — `pattern` is compiled with the
@@ -293,7 +304,7 @@ function FieldShell({ id, label, children }: { id: string; label: string; childr
 
 function DefaultModeField({ value, onChange }: { value: DefaultMode; onChange: (v: DefaultMode) => void }) {
   return (
-    <FieldShell id="resource-default" label="Default">
+    <FieldShell id="resource-default" label="Default for agents">
       <Select
         id="resource-default"
         aria-label="Default mode"
@@ -619,9 +630,14 @@ function ModalEditor({
     if (v) return;
     save.requestSave(payload());
   };
+  // prompt / skill carry a large markdown Body — widen to match the read-only
+  // preview dialog (max-w-2xl ≈ 80 monospace cols at the body font size) so
+  // editing the source isn't narrower than viewing it. repo / mcp are short
+  // forms; the default max-w-lg fits them without leaving dead space.
+  const wide = state.type === "prompt" || state.type === "skill";
   return (
     <Dialog open onOpenChange={(o) => (!o ? onClose() : undefined)}>
-      <DialogContent aria-describedby={undefined}>
+      <DialogContent aria-describedby={undefined} className={wide ? "max-w-2xl" : undefined}>
         <DialogHeader>
           <DialogTitle>{titleFor(state)}</DialogTitle>
         </DialogHeader>

--- a/packages/web/src/pages/settings/resource-preview-dialog.tsx
+++ b/packages/web/src/pages/settings/resource-preview-dialog.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import { Badge } from "../../components/ui/badge.js";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "../../components/ui/dialog.js";
 import { Markdown } from "../../components/ui/markdown.js";
+import { defaultEnabledLabel } from "./resource-editors.js";
 
 /**
  * Read-only detail view for a single team resource. Opened from the eye icon on
@@ -203,7 +204,7 @@ export function ResourcePreviewDialog({ resource, onClose }: { resource: Resourc
           </DialogHeader>
           <div>
             <Badge variant={resource.defaultEnabled === "recommended" ? "secondary" : "outline"}>
-              {resource.defaultEnabled}
+              {defaultEnabledLabel(resource.defaultEnabled)}
             </Badge>
           </div>
           <MetaFields resource={resource} />

--- a/packages/web/src/pages/settings/resources.tsx
+++ b/packages/web/src/pages/settings/resources.tsx
@@ -20,6 +20,7 @@ import { useToast } from "../../components/ui/toast.js";
 import { stripInlineMarkdown } from "../../lib/strip-inline-markdown.js";
 import {
   AddResourceMenu,
+  defaultEnabledLabel,
   type EditorState,
   RESOURCE_TYPES,
   ResourceEditor,
@@ -74,7 +75,7 @@ export function SettingsResourcesPage() {
     <>
       <PageHeader
         title="Resources"
-        subtitle="Team defaults and available resources used by agents at runtime."
+        subtitle="Team defaults and opt-in resources used by agents at runtime."
         right={isAdmin ? <AddResourceMenu onPick={(type) => setEditor({ mode: "create", type })} /> : undefined}
       />
       <div className="flex flex-col" style={{ gap: "var(--sp-5)", padding: "var(--sp-2) var(--sp-5) var(--sp-7)" }}>
@@ -174,7 +175,7 @@ function ResourceListRow(props: {
             {props.resource.name}
           </p>
           <Badge variant={props.resource.defaultEnabled === "recommended" ? "secondary" : "outline"}>
-            {props.resource.defaultEnabled}
+            {defaultEnabledLabel(props.resource.defaultEnabled)}
           </Badge>
         </div>
         {detail ? (


### PR DESCRIPTION
## What

Two small UX fixes in **Settings → Resources** (and the shared resource editor used by the agent Capabilities tab).

### 1. Clearer `defaultEnabled` labels
The field exposed its raw enum to users:
- **"recommended"** reads as a soft suggestion — but it means *on by default for every agent*.
- **"available"** reads as "it exists" — but it means *off by default, agents opt in*.

Relabelled on the axis they actually describe, via a single `defaultEnabledLabel()` helper so the **editor dropdown**, **list badge**, and **preview badge** can never drift:

| value (unchanged) | old label | new label | hint |
|---|---|---|---|
| `recommended` | Recommended | **On by default** | Enabled for every agent |
| `available` | Available | **Opt-in** | Agents enable it themselves |

Enum values, Zod schema, API, and DB are **unchanged** — copy only. Also: field label `Default` → `Default for agents`; page subtitle `available` → `opt-in`.

### 2. Roomier prompt/skill editor
prompt/skill carry a large markdown Body, but the editor used the default `max-w-lg` (~60 mono cols) while the **read-only preview of the same content already uses `max-w-2xl`** (~80 mono cols) — so editing was narrower than viewing. Now matched. repo/mcp stay `max-w-lg` (short forms; no dead space).

## Test
- `pnpm --filter @first-tree/web typecheck` ✅ (incl. design-token guardrails)
- `pnpm --filter @first-tree/web test` ✅ 685/685
- biome clean on changed files

## Scope notes
- No behaviour/data change; labels + one dialog width.
- A follow-up PR will unify the per-section "+" add affordance across Settings Resources and the agent Capabilities tab (discussed separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)