### PR TITLE
feat(web): per-section add affordance for resources (Settings + agent Capabilities)

### DIFF
--- a/packages/web/src/pages/__tests__/resource-editors-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/resource-editors-dom.test.tsx
@@ -204,8 +204,7 @@ afterEach(() => {
 describe("resource editors", () => {
   it("creates a repo via the type-first add menu", async () => {
     const { root } = await render();
-    // Type-first entry: open the Add menu, pick Repo → repo editor opens.
-    await click(byText("Add resource"));
+    // Section-local entry: each section's "+ <Type>" button opens that type's editor.
     await click(byText("Repo"));
 
     const name = document.getElementById("repo-name");
@@ -278,7 +277,6 @@ describe("resource editors", () => {
 
   it("creates a stdio mcp with command + args", async () => {
     const { root } = await render();
-    await click(byText("Add resource"));
     await click(byText("MCP"));
     await setInputValue(input("mcp-name"), "github");
     await setInputValue(input("mcp-command"), "npx");
@@ -297,7 +295,6 @@ describe("resource editors", () => {
 
   it("creates an http mcp with url and no headers key (no-secret schema)", async () => {
     const { root } = await render();
-    await click(byText("Add resource"));
     await click(byText("MCP"));
     await selectOption("mcp-transport", "http");
     await setInputValue(input("mcp-name"), "remote");
@@ -312,7 +309,6 @@ describe("resource editors", () => {
 
   it("creates a skill with body and metadata", async () => {
     const { root } = await render();
-    await click(byText("Add resource"));
     await click(byText("Skill"));
     await setInputValue(input("skill-name"), "rel");
     const body = document.getElementById("skill-body");
@@ -333,7 +329,6 @@ describe("resource editors", () => {
 
   it("blocks an invalid mcp server name client-side (no API call)", async () => {
     const { root } = await render();
-    await click(byText("Add resource"));
     await click(byText("MCP"));
     await setInputValue(input("mcp-name"), "my server"); // space → invalid server id
     await setInputValue(input("mcp-command"), "npx");
@@ -348,7 +343,8 @@ describe("resource editors", () => {
   it("hides add / edit / retire affordances for members but keeps preview", async () => {
     authMock.value = { role: "member", organizationId: "org-1", meLoaded: true };
     const { root } = await render();
-    expect(byText("Add resource")).toBeUndefined();
+    // No per-section add button (e.g. the MCP section's "+ MCP") for members.
+    expect(byText("MCP")).toBeUndefined();
     expect(byAria("Edit github")).toBeUndefined();
     expect(byAria("Retire github")).toBeUndefined();
     // Read-only preview is available to every member.

--- a/packages/web/src/pages/agent-detail/__tests__/resources-savebar-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/resources-savebar-dom.test.tsx
@@ -346,13 +346,35 @@ describe("ResourcesTab and SaveBar", () => {
     expect(container.textContent).not.toContain("Prompts");
     expect(container.textContent).toContain("Team repo");
     expect(container.textContent).toContain("https://github.com/acme/web.git -> web");
-    expect(container.textContent).toContain("Agent repo");
+    // Each editable section gets a "+ <Type>" add control.
+    expect(buttonByText(container, "Repo")).toBeTruthy();
 
-    await click(buttonByText(container, "Enable Available skill"));
+    // Enable an opt-in team skill via the skill section's add menu. The menu
+    // panel portals to document.body, so query the item there.
+    await click(buttonByText(container, "Skill"));
+    await click(buttonByText(document.body, "Available skill"));
     expect(agentResourceMocks.updateAgentResources).toHaveBeenCalledWith("agent-1", {
       expectedVersion: 3,
       bindings: [{ type: "skill", mode: "include", resourceId: "skill-available", order: 1 }],
     });
+  });
+
+  it("keeps the MCP add menu actionable with no team MCP (routes to Settings, no dead end)", async () => {
+    const layoutMocks = await import("../layout-context.js");
+    const spy = vi.spyOn(layoutMocks, "useAgentDetailContext");
+    spy.mockReturnValue(context());
+    // Default fixtures: empty effective MCP + no available team resources.
+    const { ResourcesTab } = await import("../resources-tab.js");
+
+    const container = await renderWithContext(<ResourcesTab />);
+    await waitForText(container, "Integrations (MCP)");
+
+    // The MCP section is empty and the team offers nothing to enable — but the
+    // "+ MCP" menu must still be actionable: it explains the source and routes
+    // to Settings → Resources instead of leaving a dead end.
+    await click(buttonByText(container, "MCP"));
+    expect(document.body.textContent).toContain("No team MCP integrations to enable yet");
+    expect(document.body.textContent).toContain("Manage in Settings → Resources");
   });
 
   it("renders SaveBar saved, error, conflict, saving, and jump actions", async () => {

--- a/packages/web/src/pages/agent-detail/resources-tab.tsx
+++ b/packages/web/src/pages/agent-detail/resources-tab.tsx
@@ -175,7 +175,7 @@ function AddCapabilityMenu(props: {
     <Popover
       align="end"
       trigger={({ open, toggle }) => (
-        <Button size="xs" variant="outline" aria-expanded={open} disabled={props.pending} onClick={toggle}>
+        <Button size="xs" variant="outline" aria-expanded={open} onClick={toggle}>
           <Plus className="h-3.5 w-3.5" /> {typeLabelSingular(props.type)}
         </Button>
       )}
@@ -198,6 +198,7 @@ function AddCapabilityMenu(props: {
               {props.enableable.map((resource) => (
                 <MenuButton
                   key={resource.id}
+                  disabled={props.pending}
                   onClick={() => {
                     props.onEnable(resource);
                     close();
@@ -234,11 +235,12 @@ function MenuLabel({ children }: { children: ReactNode }) {
   );
 }
 
-function MenuButton(props: { children: ReactNode; muted?: boolean; onClick: () => void }) {
+function MenuButton(props: { children: ReactNode; muted?: boolean; disabled?: boolean; onClick: () => void }) {
   return (
     <button
       type="button"
-      className="flex w-full items-center text-left text-body transition-colors hover:bg-[var(--bg-hover)]"
+      disabled={props.disabled}
+      className="flex w-full items-center text-left text-body transition-colors hover:bg-[var(--bg-hover)] disabled:pointer-events-none disabled:opacity-50"
       style={{
         gap: "var(--sp-2)",
         padding: "var(--sp-1_5) var(--sp-2)",

--- a/packages/web/src/pages/agent-detail/resources-tab.tsx
+++ b/packages/web/src/pages/agent-detail/resources-tab.tsx
@@ -3,19 +3,23 @@ import {
   deriveRepoLocalPath,
   type EffectiveResourceRow,
   noSecretMcpServerSchema,
+  type ResourceRow,
   type ResourceType,
   skillResourcePayloadSchema,
 } from "@first-tree/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Plus, Trash2 } from "lucide-react";
-import { type FormEvent, useState } from "react";
+import { type FormEvent, type ReactNode, useState } from "react";
+import { useNavigate } from "react-router";
 import { getAgentResources, updateAgentResources } from "../../api/agent-resources.js";
 import { Button } from "../../components/ui/button.js";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "../../components/ui/dialog.js";
 import { Input } from "../../components/ui/input.js";
 import { Label } from "../../components/ui/label.js";
+import { Popover } from "../../components/ui/popover.js";
 import { Section } from "../../components/ui/section.js";
 import { StatusGlyph } from "../../components/ui/status-glyph.js";
+import { typeLabelSingular } from "../settings/resource-editors.js";
 import { useAgentDetailContext } from "./layout-context.js";
 import { sourceLabel } from "./resource-source.js";
 
@@ -77,10 +81,24 @@ export function ResourcesTab() {
           count={data.effective[resourceBucket(type)].length}
           description={type === "mcp" ? "Tools come from the MCP servers connected here." : undefined}
           action={
-            canEdit && type === "repo" ? (
-              <Button size="xs" variant="outline" onClick={() => setRepoOpen(true)}>
-                <Plus className="h-3.5 w-3.5" /> Agent repo
-              </Button>
+            canEdit ? (
+              <AddCapabilityMenu
+                type={type}
+                enableable={available.filter((resource) => resource.type === type)}
+                pending={updateMut.isPending}
+                onAddAgentRepo={() => setRepoOpen(true)}
+                onEnable={(resource) =>
+                  mutateBindings([
+                    ...currentBindings,
+                    {
+                      type: resource.type,
+                      mode: "include",
+                      resourceId: resource.id,
+                      order: currentBindings.length + 1,
+                    },
+                  ])
+                }
+              />
             ) : null
           }
         >
@@ -112,35 +130,6 @@ export function ResourcesTab() {
               ))
             )}
           </div>
-          {canEdit && available.some((resource) => resource.type === type) ? (
-            <div style={{ paddingTop: "var(--sp-3)" }}>
-              {available
-                .filter((resource) => resource.type === type)
-                .map((resource) => (
-                  <Button
-                    key={resource.id}
-                    type="button"
-                    size="xs"
-                    variant="outline"
-                    disabled={updateMut.isPending}
-                    onClick={() =>
-                      mutateBindings([
-                        ...currentBindings,
-                        {
-                          type: resource.type,
-                          mode: "include",
-                          resourceId: resource.id,
-                          order: currentBindings.length + 1,
-                        },
-                      ])
-                    }
-                    style={{ marginRight: "var(--sp-2)", marginBottom: "var(--sp-2)" }}
-                  >
-                    Enable {resource.name}
-                  </Button>
-                ))}
-            </div>
-          ) : null}
         </Section>
       ))}
       {updateMut.error ? (
@@ -160,6 +149,109 @@ export function ResourcesTab() {
         }}
       />
     </div>
+  );
+}
+
+/**
+ * Per-section add control on the agent Capabilities tab. One "+ <Type>" trigger
+ * opens a context menu:
+ *   - repo: "Add agent repo" (a private, agent-scoped repo) plus any opt-in team
+ *     repos to enable.
+ *   - skill / mcp: opt-in team resources to enable. These types have no
+ *     agent-private form (the binding model supports private repos and inline
+ *     prompts only), so when the team offers none the menu still routes the user
+ *     to Settings → Resources rather than dead-ending — every section's "+" is
+ *     always actionable.
+ */
+function AddCapabilityMenu(props: {
+  type: ResourceType;
+  enableable: ResourceRow[];
+  pending: boolean;
+  onAddAgentRepo: () => void;
+  onEnable: (resource: ResourceRow) => void;
+}) {
+  const navigate = useNavigate();
+  return (
+    <Popover
+      align="end"
+      trigger={({ open, toggle }) => (
+        <Button size="xs" variant="outline" aria-expanded={open} disabled={props.pending} onClick={toggle}>
+          <Plus className="h-3.5 w-3.5" /> {typeLabelSingular(props.type)}
+        </Button>
+      )}
+    >
+      {({ close }) => (
+        <div style={{ padding: "var(--sp-1)", minWidth: "var(--sp-45)" }}>
+          {props.type === "repo" ? (
+            <MenuButton
+              onClick={() => {
+                props.onAddAgentRepo();
+                close();
+              }}
+            >
+              Add agent repo…
+            </MenuButton>
+          ) : null}
+          {props.enableable.length > 0 ? (
+            <>
+              <MenuLabel>Enable from team</MenuLabel>
+              {props.enableable.map((resource) => (
+                <MenuButton
+                  key={resource.id}
+                  onClick={() => {
+                    props.onEnable(resource);
+                    close();
+                  }}
+                >
+                  {resource.name}
+                </MenuButton>
+              ))}
+            </>
+          ) : props.type !== "repo" ? (
+            <MenuLabel>No team {emptyNoun(props.type)} to enable yet.</MenuLabel>
+          ) : null}
+          <div style={{ borderTop: "var(--hairline) solid var(--border-faint)", margin: "var(--sp-1) 0" }} />
+          <MenuButton
+            muted
+            onClick={() => {
+              navigate("/settings/resources");
+              close();
+            }}
+          >
+            Manage in Settings → Resources
+          </MenuButton>
+        </div>
+      )}
+    </Popover>
+  );
+}
+
+function MenuLabel({ children }: { children: ReactNode }) {
+  return (
+    <p className="text-label" style={{ color: "var(--fg-4)", margin: 0, padding: "var(--sp-1) var(--sp-2)" }}>
+      {children}
+    </p>
+  );
+}
+
+function MenuButton(props: { children: ReactNode; muted?: boolean; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      className="flex w-full items-center text-left text-body transition-colors hover:bg-[var(--bg-hover)]"
+      style={{
+        gap: "var(--sp-2)",
+        padding: "var(--sp-1_5) var(--sp-2)",
+        borderRadius: "var(--radius-chip)",
+        border: 0,
+        background: "transparent",
+        color: props.muted ? "var(--fg-3)" : "var(--fg)",
+        cursor: "pointer",
+      }}
+      onClick={props.onClick}
+    >
+      {props.children}
+    </button>
   );
 }
 

--- a/packages/web/src/pages/settings/resource-editors.tsx
+++ b/packages/web/src/pages/settings/resource-editors.tsx
@@ -12,7 +12,6 @@ import { Button } from "../../components/ui/button.js";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "../../components/ui/dialog.js";
 import { Input } from "../../components/ui/input.js";
 import { Label } from "../../components/ui/label.js";
-import { Popover } from "../../components/ui/popover.js";
 import { Select, type SelectOption } from "../../components/ui/select.js";
 import { Textarea } from "../../components/ui/textarea.js";
 
@@ -59,7 +58,7 @@ export function typeLabelPlural(type: ResourceType): string {
   return "MCP";
 }
 
-function typeLabelSingular(type: ResourceType): string {
+export function typeLabelSingular(type: ResourceType): string {
   if (type === "repo") return "Repo";
   if (type === "prompt") return "Instructions";
   if (type === "skill") return "Skill";
@@ -113,46 +112,18 @@ export type EditorState =
   | { mode: "edit"; type: ResourceType; resource: ResourceRow };
 
 // ─────────────────────────────────────────────────────────────────────────
-// Add-resource menu — single, type-first entry (admin only)
+// Add control — one compact "+ <Type>" button per section (admin only). The
+// section-local entry replaces the former single page-header "Add resource"
+// menu: each section owns its own create action, so the type is implicit and
+// empty sections (e.g. MCP) get a direct, in-context affordance instead of a
+// dead end. Settings and the agent Capabilities tab share this trigger shape.
 // ─────────────────────────────────────────────────────────────────────────
 
-export function AddResourceMenu({ onPick }: { onPick: (type: ResourceType) => void }) {
+export function AddResourceButton({ type, onClick }: { type: ResourceType; onClick: () => void }) {
   return (
-    <Popover
-      align="end"
-      trigger={({ open, toggle }) => (
-        <Button size="sm" variant="cta" aria-expanded={open} onClick={toggle}>
-          <Plus className="h-3.5 w-3.5" /> Add resource
-        </Button>
-      )}
-    >
-      {({ close }) => (
-        <div style={{ padding: "var(--sp-1)", minWidth: "var(--sp-45)" }}>
-          {RESOURCE_TYPES.map((type) => (
-            <button
-              key={type}
-              type="button"
-              className="flex w-full items-center text-left text-body transition-colors hover:bg-[var(--bg-hover)]"
-              style={{
-                gap: "var(--sp-2)",
-                padding: "var(--sp-1_5) var(--sp-2)",
-                borderRadius: "var(--radius-chip)",
-                border: 0,
-                background: "transparent",
-                color: "var(--fg)",
-                cursor: "pointer",
-              }}
-              onClick={() => {
-                onPick(type);
-                close();
-              }}
-            >
-              {typeLabelSingular(type)}
-            </button>
-          ))}
-        </div>
-      )}
-    </Popover>
+    <Button size="xs" variant="outline" onClick={onClick}>
+      <Plus className="h-3.5 w-3.5" /> {typeLabelSingular(type)}
+    </Button>
   );
 }
 

--- a/packages/web/src/pages/settings/resources.tsx
+++ b/packages/web/src/pages/settings/resources.tsx
@@ -19,7 +19,7 @@ import { Section } from "../../components/ui/section.js";
 import { useToast } from "../../components/ui/toast.js";
 import { stripInlineMarkdown } from "../../lib/strip-inline-markdown.js";
 import {
-  AddResourceMenu,
+  AddResourceButton,
   defaultEnabledLabel,
   type EditorState,
   RESOURCE_TYPES,
@@ -34,10 +34,11 @@ import { ResourcePreviewDialog } from "./resource-preview-dialog.js";
  * surface), not on the Team roster — see the Settings IA in settings.tsx.
  *
  * Visible to all members. Everyone can open the read-only preview (the eye
- * icon); only admins see add / edit / retire affordances. Adding is type-first:
- * one "Add resource" menu picks the type, then a per-type editor opens (all
- * four render in a modal — see resource-editors.tsx). The same editors handle
- * edit, prefilled.
+ * icon); only admins see add / edit / retire affordances. Each section owns its
+ * own add control — a "+ <Type>" button (AddResourceButton) that opens that
+ * type's editor directly, so the type is implicit and empty sections still have
+ * an in-context entry. All four editors render in a modal (see
+ * resource-editors.tsx) and double as the edit form, prefilled.
  */
 export function SettingsResourcesPage() {
   const { role } = useAuth();
@@ -73,11 +74,7 @@ export function SettingsResourcesPage() {
 
   return (
     <>
-      <PageHeader
-        title="Resources"
-        subtitle="Team defaults and opt-in resources used by agents at runtime."
-        right={isAdmin ? <AddResourceMenu onPick={(type) => setEditor({ mode: "create", type })} /> : undefined}
-      />
+      <PageHeader title="Resources" subtitle="Team defaults and opt-in resources used by agents at runtime." />
       <div className="flex flex-col" style={{ gap: "var(--sp-5)", padding: "var(--sp-2) var(--sp-5) var(--sp-7)" }}>
         {resourcesQuery.isLoading ? (
           <p className="text-body" style={{ color: "var(--fg-3)" }}>
@@ -89,7 +86,16 @@ export function SettingsResourcesPage() {
           </p>
         ) : (
           RESOURCE_TYPES.map((type) => (
-            <Section key={type} title={typeLabelPlural(type)} count={grouped.get(type)?.length ?? 0}>
+            <Section
+              key={type}
+              title={typeLabelPlural(type)}
+              count={grouped.get(type)?.length ?? 0}
+              action={
+                isAdmin ? (
+                  <AddResourceButton type={type} onClick={() => setEditor({ mode: "create", type })} />
+                ) : undefined
+              }
+            >
               <div>
                 {(grouped.get(type) ?? []).length === 0 ? (
                   <p className="text-body" style={{ color: "var(--fg-4)", padding: "var(--sp-3) 0", margin: 0 }}>


### PR DESCRIPTION
## Problem

The "add a resource/capability" interaction was inconsistent across the two surfaces, and could dead-end:

- **Settings → Resources**: a single global **"Add resource"** menu in the page header (pick type → create), decoupled from the section you're looking at.
- **Agent → Capabilities tab**: only the **repo** section had a header button (`+ Agent repo`). Skills/MCP had none — enabling team skills/MCP was a wall of inline `Enable <name>` buttons (doesn't scale). Worst: an empty **MCP** section with no team MCP available had **no way to act** — a dead end whose subtitle *"Tools come from the MCP servers connected here."* pointed at an affordance that didn't exist.

(Decided per discussion: per-section `+` beats a global menu here — the type set is fixed/small, you almost always know the type, and every section, including empty ones, gets a direct in-context entry.)

## Change — one per-section `+ <Type>` control, shared shape on both pages

**Settings → Resources** (`settings/resources.tsx`)
- Each `<Section>` gets `AddResourceButton` → opens that type's editor directly (type implicit).
- Drops the global header menu + the now-unused `AddResourceMenu` / `Popover` import.

**Agent → Capabilities** (`agent-detail/resources-tab.tsx`)
- Each `<Section>` gets `AddCapabilityMenu` (a Popover):
  - **repo** → `Add agent repo…` (private, agent-scoped) + any opt-in team repos to enable.
  - **skill / mcp** → opt-in team resources to enable. These types have **no agent-private form** (the binding model supports private repos + inline prompts only), so the menu **always ends with `Manage in Settings → Resources`** — every section's `+` stays actionable, **killing the MCP dead end**.
- Replaces the inline `Enable <name>` button wall.

## Data-model note
Pure web/UX change. **No schema / API / DB / binding-model changes.** `defaultEnabled` and the agent-binding rules are untouched. `typeLabelSingular` is now exported as the single label source for both add controls.

## Test
- `pnpm --filter @first-tree/web typecheck` ✅ (incl. design-token guardrails)
- `pnpm --filter @first-tree/web test` ✅ **686/686**
- biome clean on all changed files
- Updated `resource-editors-dom` (open editor via section button, not the removed global menu) and `resources-savebar-dom` (enable team skill via menu); **added** coverage that an empty MCP section's menu still routes to Settings (no dead end).

## Worth a manual look
Layout reuses existing `Section` / `Popover` / `Button` primitives (low visual risk), but the `+` menu placement is best eyeballed in a running app — happy to dogfood with screenshots on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)