### PR TITLE
refactor(web): quiet per-section resource add control to a ghost + icon

### DIFF
--- a/packages/web/src/pages/__tests__/resource-editors-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/resource-editors-dom.test.tsx
@@ -204,8 +204,8 @@ afterEach(() => {
 describe("resource editors", () => {
   it("creates a repo via the type-first add menu", async () => {
     const { root } = await render();
-    // Section-local entry: each section's "+ <Type>" button opens that type's editor.
-    await click(byText("Repo"));
+    // Section-local entry: each section's "+" icon (aria "Add <Type>") opens that type's editor.
+    await click(byAria("Add Repo"));
 
     const name = document.getElementById("repo-name");
     const url = document.getElementById("repo-url");
@@ -277,7 +277,7 @@ describe("resource editors", () => {
 
   it("creates a stdio mcp with command + args", async () => {
     const { root } = await render();
-    await click(byText("MCP"));
+    await click(byAria("Add MCP"));
     await setInputValue(input("mcp-name"), "github");
     await setInputValue(input("mcp-command"), "npx");
     await click(byText("Add")); // add an args row
@@ -295,7 +295,7 @@ describe("resource editors", () => {
 
   it("creates an http mcp with url and no headers key (no-secret schema)", async () => {
     const { root } = await render();
-    await click(byText("MCP"));
+    await click(byAria("Add MCP"));
     await selectOption("mcp-transport", "http");
     await setInputValue(input("mcp-name"), "remote");
     await setInputValue(input("mcp-url"), "https://x.example.com/sse");
@@ -309,7 +309,7 @@ describe("resource editors", () => {
 
   it("creates a skill with body and metadata", async () => {
     const { root } = await render();
-    await click(byText("Skill"));
+    await click(byAria("Add Skill"));
     await setInputValue(input("skill-name"), "rel");
     const body = document.getElementById("skill-body");
     if (!(body instanceof HTMLTextAreaElement)) throw new Error("skill-body");
@@ -329,7 +329,7 @@ describe("resource editors", () => {
 
   it("blocks an invalid mcp server name client-side (no API call)", async () => {
     const { root } = await render();
-    await click(byText("MCP"));
+    await click(byAria("Add MCP"));
     await setInputValue(input("mcp-name"), "my server"); // space → invalid server id
     await setInputValue(input("mcp-command"), "npx");
     await click(byText("Create"));
@@ -343,8 +343,8 @@ describe("resource editors", () => {
   it("hides add / edit / retire affordances for members but keeps preview", async () => {
     authMock.value = { role: "member", organizationId: "org-1", meLoaded: true };
     const { root } = await render();
-    // No per-section add button (e.g. the MCP section's "+ MCP") for members.
-    expect(byText("MCP")).toBeUndefined();
+    // No per-section add button (e.g. the MCP section's "+" / "Add MCP") for members.
+    expect(byAria("Add MCP")).toBeUndefined();
     expect(byAria("Edit github")).toBeUndefined();
     expect(byAria("Retire github")).toBeUndefined();
     // Read-only preview is available to every member.

--- a/packages/web/src/pages/agent-detail/__tests__/resources-savebar-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/resources-savebar-dom.test.tsx
@@ -346,12 +346,12 @@ describe("ResourcesTab and SaveBar", () => {
     expect(container.textContent).not.toContain("Prompts");
     expect(container.textContent).toContain("Team repo");
     expect(container.textContent).toContain("https://github.com/acme/web.git -> web");
-    // Each editable section gets a "+ <Type>" add control.
-    expect(buttonByText(container, "Repo")).toBeTruthy();
+    // Each editable section gets a quiet "+" add control (aria "Add <Type>").
+    expect(container.querySelector('button[aria-label="Add Repo"]')).toBeTruthy();
 
     // Enable an opt-in team skill via the skill section's add menu. The menu
     // panel portals to document.body, so query the item there.
-    await click(buttonByText(container, "Skill"));
+    await click(container.querySelector('button[aria-label="Add Skill"]'));
     await click(buttonByText(document.body, "Available skill"));
     expect(agentResourceMocks.updateAgentResources).toHaveBeenCalledWith("agent-1", {
       expectedVersion: 3,
@@ -370,9 +370,9 @@ describe("ResourcesTab and SaveBar", () => {
     await waitForText(container, "Integrations (MCP)");
 
     // The MCP section is empty and the team offers nothing to enable — but the
-    // "+ MCP" menu must still be actionable: it explains the source and routes
-    // to Settings → Resources instead of leaving a dead end.
-    await click(buttonByText(container, "MCP"));
+    // "+" (Add MCP) menu must still be actionable: it explains the source and
+    // routes to Settings → Resources instead of leaving a dead end.
+    await click(container.querySelector('button[aria-label="Add MCP"]'));
     expect(document.body.textContent).toContain("No team MCP integrations to enable yet");
     expect(document.body.textContent).toContain("Manage in Settings → Resources");
   });

--- a/packages/web/src/pages/agent-detail/resources-tab.tsx
+++ b/packages/web/src/pages/agent-detail/resources-tab.tsx
@@ -174,11 +174,14 @@ function AddCapabilityMenu(props: {
   return (
     <Popover
       align="end"
-      trigger={({ open, toggle }) => (
-        <Button size="xs" variant="outline" aria-expanded={open} onClick={toggle}>
-          <Plus className="h-3.5 w-3.5" /> {typeLabelSingular(props.type)}
-        </Button>
-      )}
+      trigger={({ open, toggle }) => {
+        const label = `Add ${typeLabelSingular(props.type)}`;
+        return (
+          <Button size="xs" variant="ghost" aria-expanded={open} aria-label={label} title={label} onClick={toggle}>
+            <Plus className="h-4 w-4" />
+          </Button>
+        );
+      }}
     >
       {({ close }) => (
         <div style={{ padding: "var(--sp-1)", minWidth: "var(--sp-45)" }}>

--- a/packages/web/src/pages/settings/resource-editors.tsx
+++ b/packages/web/src/pages/settings/resource-editors.tsx
@@ -112,17 +112,21 @@ export type EditorState =
   | { mode: "edit"; type: ResourceType; resource: ResourceRow };
 
 // ─────────────────────────────────────────────────────────────────────────
-// Add control — one compact "+ <Type>" button per section (admin only). The
-// section-local entry replaces the former single page-header "Add resource"
-// menu: each section owns its own create action, so the type is implicit and
-// empty sections (e.g. MCP) get a direct, in-context affordance instead of a
-// dead end. Settings and the agent Capabilities tab share this trigger shape.
+// Add control — one quiet "+" icon per section (admin only). The section-local
+// entry replaces the former single page-header "Add resource" menu: each section
+// owns its own create action, so the type is implicit (the icon sits beside its
+// section title) and empty sections (e.g. MCP) still get a direct, in-context
+// affordance instead of a dead end. Rendered as a ghost icon — not a bordered
+// "+ <Type>" button — so a page of sections doesn't read as a column of loud
+// buttons; the type is carried by aria-label + tooltip. Settings and the agent
+// Capabilities tab share this trigger shape.
 // ─────────────────────────────────────────────────────────────────────────
 
 export function AddResourceButton({ type, onClick }: { type: ResourceType; onClick: () => void }) {
+  const label = `Add ${typeLabelSingular(type)}`;
   return (
-    <Button size="xs" variant="outline" onClick={onClick}>
-      <Plus className="h-3.5 w-3.5" /> {typeLabelSingular(type)}
+    <Button size="xs" variant="ghost" aria-label={label} title={label} onClick={onClick}>
+      <Plus className="h-4 w-4" />
     </Button>
   );
 }


### PR DESCRIPTION
## Why
Follow-up to #847. The per-section add control rendered as a **bordered `+ <Type>` text button**. With 3–4 sections (plus row actions like `Disable`), a page read as a column of loud bordered buttons — the "too many buttons" feeling.

## Change
Downgrade both **shared** entry points to a quiet **`ghost` "+" icon**:
- **Settings → Resources** (`AddResourceButton`)
- **Agent → Capabilities** (`AddCapabilityMenu` trigger)

The resource type is carried by `aria-label` + `title` tooltip (`Add Repo` / `Add Skill` / `Add MCP` / `Add Instructions`) and by the icon sitting beside its section title — discoverability holds, visual weight drops. Both pages stay consistent (one shared shape).

No behaviour/structure change: per-section entry is still always present (empty sections — e.g. MCP — keep their in-context affordance, no dead end), admin/`canEdit` gating unchanged.

## Test
- `pnpm --filter @first-tree/web typecheck` ✅ (incl. design-token guardrails)
- `pnpm --filter @first-tree/web test` ✅ **686/686**
- biome clean
- Tests updated to locate the icon-only control by `aria-label` instead of button text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)