### PR TITLE
feat(client): make first-tree + first-tree-context skills unconditional via # Required Reading

### DIFF
--- a/packages/client/src/__tests__/agent-briefing.test.ts
+++ b/packages/client/src/__tests__/agent-briefing.test.ts
@@ -75,6 +75,7 @@ describe("buildAgentBriefing — top-level structure & section order", () => {
       "## Asking Humans",
       "## Chat Topic",
       "## CLI Overview",
+      "# Required Reading",
       "# Context Tree",
       "## Core Model",
       "## Reading the Tree",
@@ -130,6 +131,115 @@ describe("buildAgentBriefing — top-level structure & section order", () => {
     const realPayload = { ...emptyPayload, prompt: { append: "Follow the local implementation plan." } };
     const briefing = buildAgentBriefing(makeOpts({ payload: realPayload }));
     expect(briefing).toContain("## Agent-Specific Prompt\n\nFollow the local implementation plan.");
+  });
+});
+
+describe("buildAgentBriefing — # Required Reading (unconditional skill-load mandate)", () => {
+  // The inline briefing is a routing index, not a substitute for the
+  // skill payloads. `# Required Reading` is the hard mandate that
+  // guarantees `first-tree` and `first-tree-context` get loaded on
+  // every task — otherwise progressive disclosure (keyword-triggered)
+  // can silently skip them and the agent acts without the rules in
+  // those skills (daemon lifecycle, hard write rules, etc.).
+
+  it("emits the # Required Reading section for tree-bound agents with MUST framing and both skill names", () => {
+    const briefing = buildAgentBriefing(makeOpts({ contextTreePath: "/tree" }));
+
+    expect(briefing).toContain("# Required Reading");
+    // Hard-mandate anchors — progressive disclosure is opt-in by
+    // default; this block makes the two routing-critical skills
+    // mandatory regardless of what the user types.
+    expect(briefing).toMatch(/you MUST\s+load both skills below/);
+    expect(briefing).toContain("**`first-tree`**");
+    expect(briefing).toContain("**`first-tree-context`**");
+    // Reminds the agent that the inline briefing intentionally does
+    // not duplicate the skill bodies — so it can't rationalise
+    // skipping the load.
+    expect(briefing).toMatch(/intentionally NOT duplicated[\s\n]+inline/);
+    expect(briefing).toMatch(/minimum mechanics you need to operate at all/);
+    // Calls out the on-demand-only sibling so the agent doesn't
+    // over-load every First Tree family skill on every task.
+    expect(briefing).toContain("`first-tree-sync`");
+  });
+
+  it("places # Required Reading immediately after # Working in First Tree (its CLI Overview tail) and before # Context Tree", () => {
+    // Placement rationale: the agent first reads the inline
+    // workspace-collab basics (chat send, working directory,
+    // communication) it needs to operate at all, then hits the hard
+    // mandate to load `first-tree` + `first-tree-context` before any
+    // real work. The mandate sits adjacent to `# Context Tree` because
+    // the two skills cover the read/write rules for that section.
+    const payload = {
+      kind: "claude-code" as const,
+      model: "",
+      prompt: { append: "You are staff: design, implement, and coordinate review." },
+      mcpServers: [],
+      env: [],
+      gitRepos: [],
+      resourceSkills: [],
+      reasoningEffort: "" as const,
+    };
+    const briefing = buildAgentBriefing(makeOpts({ payload, contextTreePath: "/tree" }));
+
+    const identityIdx = briefing.indexOf("# Identity");
+    const agentPromptIdx = briefing.indexOf("## Agent-Specific Prompt");
+    const workingIdx = briefing.indexOf("# Working in First Tree");
+    const cliOverviewIdx = briefing.indexOf("## CLI Overview");
+    const requiredIdx = briefing.indexOf("# Required Reading");
+    const contextTreeIdx = briefing.indexOf("# Context Tree");
+
+    expect(identityIdx).toBeGreaterThanOrEqual(0);
+    expect(agentPromptIdx).toBeGreaterThan(identityIdx);
+    expect(workingIdx).toBeGreaterThan(agentPromptIdx);
+    // CLI Overview is the last subsection of `# Working in First Tree`,
+    // so Required Reading must land after it.
+    expect(cliOverviewIdx).toBeGreaterThan(workingIdx);
+    expect(requiredIdx).toBeGreaterThan(cliOverviewIdx);
+    // And immediately before `# Context Tree` — no other top-level
+    // section may slip between them.
+    expect(contextTreeIdx).toBeGreaterThan(requiredIdx);
+  });
+
+  it("omits # Required Reading for tree-less agents (the skill payloads are not installed on disk for them)", () => {
+    // `installFirstTreeIntegration` is short-circuited when
+    // `contextTreePath === null`, so the SKILL.md payloads under
+    // `<workspace>/.agents/skills/` never get materialised. Mandating
+    // a load would point at files that aren't there. The Tree
+    // Location stub already surfaces the gap to a human.
+    const briefing = buildAgentBriefing(makeOpts({ contextTreePath: null }));
+    expect(briefing).not.toContain("# Required Reading");
+  });
+
+  it("flags `first-tree` and `first-tree-context` as unconditional in the ## First Tree Family map (consistent with # Required Reading)", () => {
+    // The Skill Map's framing has to match the # Required Reading
+    // mandate, otherwise the agent gets contradictory signals
+    // (progressive-disclosure-only vs. unconditional). Pin both
+    // rows' new "unconditional" label and the head paragraph that
+    // calls them out.
+    const briefing = buildAgentBriefing(makeOpts({ contextTreePath: "/tree" }));
+    const familyMap = briefing.slice(briefing.indexOf("## First Tree Family"));
+
+    // Head paragraph explicitly names both unconditional skills and
+    // points back at the # Required Reading anchor.
+    expect(familyMap).toMatch(
+      /`first-tree` and `first-tree-context` are \*\*unconditional\*\* — load\s+them on every task per `# Required Reading` above\./,
+    );
+
+    // Both unconditional rows must carry the "unconditional" label
+    // inline so the table is self-explanatory even when read in
+    // isolation.
+    const firstTreeRow = familyMap.match(/\|\s*`first-tree`\s*\|[^\n]*/)?.[0] ?? "";
+    expect(firstTreeRow).toContain("unconditional");
+    expect(firstTreeRow).toContain("`# Required Reading`");
+
+    const contextRow = familyMap.match(/\|\s*`first-tree-context`\s*\|[^\n]*/)?.[0] ?? "";
+    expect(contextRow).toContain("unconditional");
+    expect(contextRow).toContain("`# Required Reading`");
+
+    // On-demand rows must NOT pick up the unconditional label by
+    // accident — they're triggered by keyword / task signal.
+    const syncRow = familyMap.match(/\|\s*`first-tree-sync`\s*\|[^\n]*/)?.[0] ?? "";
+    expect(syncRow).not.toContain("unconditional");
   });
 });
 

--- a/packages/client/src/runtime/agent-briefing.ts
+++ b/packages/client/src/runtime/agent-briefing.ts
@@ -33,10 +33,11 @@ export type BuildAgentBriefingOptions = {
  *        intro · Working Directory · Source Repositories · Worktrees ·
  *        Communication · Workspace Collaboration · Asking Humans ·
  *        Chat Topic · CLI Overview
- *   4. `# Context Tree`                        — per binding, with subsections:
+ *   4. `# Required Reading`                    — tree-bound only; unconditional load of `first-tree` + `first-tree-context`
+ *   5. `# Context Tree`                        — per binding, with subsections:
  *        Core Model · Reading the Tree · Writing the Tree · Tree Location
- *   5. `# Skills`                              — Team Skills (if any) + First Tree Family
- *   6. `## Current Chat Context`               — per-chat (issue #808 will move it out)
+ *   6. `# Skills`                              — Team Skills (if any) + First Tree Family
+ *   7. `## Current Chat Context`               — per-chat (issue #808 will move it out)
  */
 export function buildAgentBriefing(opts: BuildAgentBriefingOptions): string {
   const sections: string[] = [];
@@ -49,6 +50,21 @@ export function buildAgentBriefing(opts: BuildAgentBriefingOptions): string {
   }
 
   sections.push(workingInFirstTreeSection({ agentHome: opts.workspacePath, sourceRepos: opts.sourceRepos }));
+
+  // `# Required Reading` — sits AFTER `# Working in First Tree` so the
+  // agent first reads the inline workspace-collab basics (chat send,
+  // working directory, communication contract) it needs to operate at
+  // all, then hits the hard mandate to load `first-tree` and
+  // `first-tree-context` before doing any real work. Placing it
+  // immediately before `# Context Tree` also keeps the mandate adjacent
+  // to the content domains the two skills cover. Gated on
+  // `contextTreePath !== null` for the same reason `skillsSection`
+  // gates `firstTreeFamilyMap`: a tree-less agent has no First Tree
+  // skill payloads installed on disk (`installFirstTreeIntegration`
+  // is short-circuited in `agent-bootstrap.ts`), so mandating a load
+  // would point at files that don't exist.
+  const requiredReading = requiredReadingSection(opts.contextTreePath);
+  if (requiredReading) sections.push(requiredReading);
 
   sections.push(contextTreeSection(opts.contextTreePath));
 
@@ -68,6 +84,65 @@ function identitySection(identity: AgentIdentity): string {
   const name = identity.displayName ?? identity.agentId;
   const kind = identity.visibility === "private" ? "a personal assistant agent" : "an autonomous agent";
   return `# Identity\n\nYou are ${name}, ${kind}.`;
+}
+
+// --- # Required Reading -----------------------------------------------------
+
+/**
+ * Hard mandate that the agent load `first-tree` and `first-tree-context`
+ * before doing any non-trivial work, regardless of whether the user
+ * mentioned chat / context keywords that would otherwise trigger
+ * progressive disclosure.
+ *
+ * Rationale: the inline briefing is a routing index, not a substitute. The
+ * skill payloads carry rules that are NOT duplicated here:
+ *
+ *  - `first-tree` ships the three-principal model, the Communication
+ *    Principles in full (final-text contract / decision guide / silent
+ *    turn / chat-context-missing fallback / channel-binary substitution),
+ *    the Hosting-Daemon mental model and its do-not-stop-yourself
+ *    invariant, the CLI Namespace Map, and the mandatory pre-task
+ *    hygiene (workspace binding check / tree HEAD freshness / role-fork).
+ *  - `first-tree-context` ships the Source-System Boundary, the Hard
+ *    Rules 1-7 (default to not writing / read before write / smallest
+ *    correct edit / no diffs / verify gate / ownership through humans /
+ *    `decisionLocksCode`), the Double Test, Node Shape, and the
+ *    Worked Examples.
+ *
+ * Both are gated on `contextTreePath !== null` because the runtime only
+ * installs the SKILL.md payloads to disk when a Context Tree is bound
+ * (see `runtime/first-tree-skills/installer.ts` and the short-circuit in
+ * `agent-bootstrap.ts`). Telling a tree-less agent to load them would
+ * point at files that aren't there.
+ */
+function requiredReadingSection(contextTreePath: string | null): string | null {
+  if (contextTreePath === null) return null;
+  return `# Required Reading
+
+Before responding to any non-trivial instruction in this chat, you MUST
+load both skills below — even before the pre-task hygiene checks they
+describe. The \`# Working in First Tree\` section above carries the
+minimum mechanics you need to operate at all (final-text contract,
+chat send, working directory, CLI surface); the skills below carry
+the durable rules that are intentionally NOT duplicated inline.
+
+1. **\`first-tree\`** — what First Tree is, the three-principal model
+   (Server / Client / Agent), the Communication Principles in full,
+   the Hosting-Daemon mental model (and its do-not-stop-yourself
+   invariant), the CLI Namespace Map, and the mandatory pre-task
+   hygiene (workspace binding check / tree HEAD freshness / role-fork).
+2. **\`first-tree-context\`** — what a Context Tree is, the
+   source-system boundary, how to read the tree before acting, and
+   the Hard Rules + Double Test that govern every tree write.
+
+These two are unconditional. The remaining First Tree skill
+(\`first-tree-sync\`) loads on demand based on the task signal as
+listed in the First Tree Family map below.
+
+Skipping either skill costs you daemon-lifecycle constraints,
+communication contracts, or write-side hard rules that are not
+duplicated in this briefing — acting without them is the #1 source
+of advice that conflicts with reality.`;
 }
 
 // --- # Working in First Tree -------------------------------------------------
@@ -409,16 +484,17 @@ function firstTreeFamilyMap(): string {
   // list against the prebuild copy script.
   return `## First Tree Family
 
-Skill \`description\` fields drive progressive disclosure — the runtime
-loads the full skill when you mention its domain. This map is the
-curated routing index for the First Tree family; for general / harness
-skills (\`tdoc\`, \`review\`, \`simplify\`, \`update-config\`, …) trust
-the auto-injected list.
+\`first-tree\` and \`first-tree-context\` are **unconditional** — load
+them on every task per \`# Required Reading\` above. The remaining
+row loads on demand: each skill's \`description\` field drives
+progressive disclosure when you mention its domain. For general /
+harness skills (\`tdoc\`, \`review\`, \`simplify\`, \`update-config\`,
+…) trust the auto-injected list.
 
 | Skill | Load when |
 |---|---|
-| \`first-tree\`         | communication principles / pre-task hygiene / CLI namespace map |
-| \`first-tree-context\` | read context before acting OR write tree updates from a specific PR / doc / note |
+| \`first-tree\`         | unconditional (see \`# Required Reading\`) — communication principles, pre-task hygiene, CLI namespace map |
+| \`first-tree-context\` | unconditional (see \`# Required Reading\`) — read context before acting OR write tree updates from a specific PR / doc / note |
 | \`first-tree-sync\`    | "is the tree up to date?" — broad drift audit, no source |`;
 }
 


### PR DESCRIPTION
## Summary

The inline AGENTS.md / CLAUDE.md briefing was a routing index that leaned on each skill's `description` field to trigger progressive disclosure. That made `first-tree` and `first-tree-context` opt-in on keyword match — agents could (and did) act without ever loading them, missing rules that live in the skill bodies and are **not** duplicated in the inline briefing:

- `first-tree` skill body: three-principal model, full Communication Principles, Hosting-Daemon mental model (don't stop yourself), CLI Namespace Map, mandatory pre-task hygiene (binding check / tree HEAD freshness / role-fork).
- `first-tree-context` skill body: Source-System Boundary, Hard Rules 1–7, Double Test, Node Shape, Worked Examples.

This PR adds a new `# Required Reading` section to the briefing that mandates loading both skills as the agent's first action on any non-trivial task. The `## First Tree Family` map is updated in lockstep so the two surfaces give consistent signals.

## What changed

- **`packages/client/src/runtime/agent-briefing.ts`**
  - New `requiredReadingSection()` emits a hard MUST mandate to load `first-tree` and `first-tree-context` before responding.
  - Wired into `buildAgentBriefing()` between `# Identity` and `## Agent-Specific Prompt`, so the mandate frames whatever per-agent role brief the operator configured.
  - Gated on `contextTreePath !== null` (mirrors `skillsSection`): tree-less agents have no SKILL.md payloads on disk via `installFirstTreeIntegration`, so the mandate is omitted to avoid pointing at non-existent files. The existing Tree Location stub continues to surface the binding gap to a human.
  - `firstTreeFamilyMap()` framing rewritten: `first-tree` + `first-tree-context` rows now carry an explicit `unconditional (see # Required Reading)` label; the on-demand rows (`first-tree-onboarding`, `first-tree-sync`) keep their progressive-disclosure semantics.
- **`packages/client/src/__tests__/agent-briefing.test.ts`**
  - Section-order invariant updated to include `# Required Reading` between `# Identity` and `# Working in First Tree`.
  - New `describe` block with 4 dedicated assertions: MUST framing + both skill names; position between Identity and Agent-Specific Prompt (so it frames the per-agent brief); omission for tree-less agents; consistency between `# Required Reading` and the `## First Tree Family` table's unconditional rows (anti-drift).

## Test plan

- [x] `pnpm --filter @first-tree/client test agent-briefing` — 27/27 pass
- [x] `pnpm --filter @first-tree/client test` — 1024/1024 pass
- [x] `pnpm check` — clean (1221 files, biome)
- [x] `pnpm typecheck` — clean (11/11 tasks)
- [x] `pnpm test` — full repo: server 1301/1301 pass; all 5 packages green

## Out of scope (explicit)

- **Tree-root `AGENTS.md` reinforcer**: tree repo `/AGENTS.md` is currently a stopgap awaiting #794 + new first-tree CLI release. Once that lands, the same mandate can be additionally written there so every workspace bound to that tree inherits it — but the runtime-injected briefing here already covers every agent regardless. Worth a follow-up PR after #794 lands; not needed for this fix.
- Renaming `AGENT.md` → `AGENTS.md` in the `## Reading the Tree` block (it currently says "If the root also contains an `AGENT.md`, read it too"). The tree-context skill on main already uses `AGENTS.md` everywhere; the briefing prose can catch up in a follow-up.