### PR TITLE
feat: align upgrade with server target

### DIFF
--- a/apps/cli/src/__tests__/agent-lifecycle-commands-extra.test.ts
+++ b/apps/cli/src/__tests__/agent-lifecycle-commands-extra.test.ts
@@ -32,11 +32,13 @@ const coreMocks = vi.hoisted(() => ({
   detectInstallMode: vi.fn(),
   ensureFreshAccessToken: vi.fn(),
   fetchLatestVersion: vi.fn(),
+  fetchServerCommandVersion: vi.fn(),
   findStaleAliases: vi.fn(),
   formatStaleReason: vi.fn((reason: string) => reason),
   getClientServiceStatus: vi.fn(),
   installClientService: vi.fn(),
   installGlobalLatest: vi.fn(),
+  installGlobalSpec: vi.fn(),
   isServiceSupported: vi.fn(),
   PACKAGE_NAME: "first-tree",
   promptAddAgent: vi.fn(),
@@ -104,6 +106,10 @@ beforeEach(() => {
   bootstrapMocks.saveAgentConfig.mockReturnValue(join(tempDir, "agents", "kael"));
   coreMocks.ensureFreshAccessToken.mockResolvedValue("user-token");
   coreMocks.resolveServerUrl.mockReturnValue("https://hub.example");
+  coreMocks.fetchLatestVersion.mockReturnValue({ ok: true, version: "99.0.0" });
+  coreMocks.fetchServerCommandVersion.mockResolvedValue({ ok: true, version: "99.0.0" });
+  coreMocks.installGlobalLatest.mockResolvedValue({ ok: true, installedVersion: "99.0.0" });
+  coreMocks.installGlobalSpec.mockResolvedValue({ ok: true, installedVersion: "99.0.0" });
   cliFetchMock.mockReset();
   coreMocks.promptAddAgent.mockResolvedValue({ name: "kael", agentId: "agent-1" });
   coreMocks.findStaleAliases.mockResolvedValue([
@@ -301,19 +307,28 @@ describe("logout and upgrade commands", () => {
     expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain("npm i -g first-tree");
 
     coreMocks.detectInstallMode.mockReturnValue("global");
-    coreMocks.fetchLatestVersion.mockReturnValueOnce({ ok: false, reason: "registry down" });
+    coreMocks.fetchServerCommandVersion.mockResolvedValueOnce({ ok: false, reason: "server down" });
     await expect(runTopLevel(registerUpgradeCommand, ["upgrade"])).rejects.toMatchObject({ code: 1 });
+    expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain(
+      "first-tree-dev upgrade --latest",
+    );
 
-    coreMocks.fetchLatestVersion.mockReturnValue({ ok: true, version: "99.0.0" });
     await runTopLevel(registerUpgradeCommand, ["upgrade", "--check"]);
     expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain("Upgrade available");
 
-    coreMocks.installGlobalLatest.mockResolvedValueOnce({ ok: false, reason: "permission denied" });
+    coreMocks.fetchLatestVersion.mockReturnValueOnce({ ok: true, version: "100.0.0" });
+    await runTopLevel(registerUpgradeCommand, ["upgrade", "--check", "--latest"]);
+    expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain("100.0.0");
+
+    await runTopLevel(registerUpgradeCommand, ["upgrade", "--latest", "--no-restart"]);
+    expect(coreMocks.installGlobalLatest).toHaveBeenCalled();
+
+    coreMocks.installGlobalSpec.mockResolvedValueOnce({ ok: false, reason: "permission denied" });
     await expect(runTopLevel(registerUpgradeCommand, ["upgrade"])).rejects.toMatchObject({ code: 1 });
 
-    coreMocks.installGlobalLatest.mockResolvedValue({ ok: true, installedVersion: "99.0.0" });
     await runTopLevel(registerUpgradeCommand, ["upgrade", "--no-restart"]);
-    expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain("Skipping restart");
+    expect(coreMocks.installGlobalSpec).toHaveBeenCalledWith("99.0.0");
+    expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain("first-tree-dev daemon restart");
 
     coreMocks.isServiceSupported.mockReturnValueOnce(false);
     await runTopLevel(registerUpgradeCommand, ["upgrade"]);

--- a/apps/cli/src/__tests__/core-attention-update-extra.test.ts
+++ b/apps/cli/src/__tests__/core-attention-update-extra.test.ts
@@ -11,6 +11,7 @@ const bootstrapMocks = vi.hoisted(() => ({
 }));
 
 const printLineMock = vi.hoisted(() => vi.fn());
+const cliFetchMock = vi.hoisted(() => vi.fn());
 
 const childRegistryMocks = vi.hoisted(() => ({
   classify: vi.fn(),
@@ -21,6 +22,7 @@ const childRegistryMocks = vi.hoisted(() => ({
 const spawnSyncMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../core/bootstrap.js", () => bootstrapMocks);
+vi.mock("../core/cli-fetch.js", () => ({ cliFetch: cliFetchMock }));
 vi.mock("../core/output.js", () => ({ print: { line: printLineMock } }));
 vi.mock("@first-tree/client", () => childRegistryMocks);
 vi.mock("node:child_process", () => ({ spawnSync: spawnSyncMock }));
@@ -34,6 +36,14 @@ function installSpawn(child: MockChild): void {
   childRegistryMocks.getChildProcessRegistry.mockReturnValue({
     spawn: vi.fn(() => ({ child })),
   });
+}
+
+function jsonResponse(body: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    json: vi.fn(async () => body),
+  } as unknown as Response;
 }
 
 beforeEach(() => {
@@ -169,5 +179,25 @@ describe("core update helpers", () => {
 
     spawnSyncMock.mockReturnValueOnce({ status: 0, stdout: "latest\n", stderr: "" });
     expect(fetchLatestVersion()).toEqual({ ok: false, reason: "npm view returned non-semver value: latest" });
+  });
+
+  it("fetches the server command version from bootstrap config", async () => {
+    const { fetchServerCommandVersion } = await import("../core/update.js");
+
+    cliFetchMock.mockResolvedValueOnce(jsonResponse({ serverCommandVersion: "v0.6.0" }));
+    await expect(fetchServerCommandVersion()).resolves.toEqual({ ok: true, version: "0.6.0" });
+    expect(cliFetchMock).toHaveBeenCalledWith(
+      "https://hub.example/api/v1/bootstrap/config",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+
+    cliFetchMock.mockResolvedValueOnce(jsonResponse({ serverCommandVersion: "latest" }));
+    await expect(fetchServerCommandVersion()).resolves.toEqual({
+      ok: false,
+      reason: "server returned non-semver version: latest",
+    });
+
+    cliFetchMock.mockResolvedValueOnce(jsonResponse({}, false, 503));
+    await expect(fetchServerCommandVersion()).resolves.toEqual({ ok: false, reason: "server returned HTTP 503" });
   });
 });

--- a/apps/cli/src/commands/upgrade.ts
+++ b/apps/cli/src/commands/upgrade.ts
@@ -1,12 +1,15 @@
 import type { Command } from "commander";
 import * as semver from "semver";
+import { channelConfig } from "../core/channel.js";
 import {
   COMMAND_VERSION,
   detectInstallMode,
   fetchLatestVersion,
+  fetchServerCommandVersion,
   getClientServiceStatus,
   installClientService,
   installGlobalLatest,
+  installGlobalSpec,
   isServiceSupported,
   PACKAGE_NAME,
   restartClientService,
@@ -23,16 +26,19 @@ import { print } from "../core/output.js";
  * Pairs with — but does not replace — the server-driven UpdateManager
  * (packages/client/src/runtime/update-manager.ts), which fires automatically
  * when a connected client falls behind the server-bundled version. This
- * command is the manual equivalent: same install + restart sequence, but
- * triggered on the operator's terms.
+ * command is the manual equivalent by default: same server-selected target
+ * version plus the same install + restart sequence, but triggered on the
+ * operator's terms. `--latest` is the explicit npm bypass.
  */
 export function registerUpgradeCommand(program: Command): void {
   program
     .command("upgrade")
-    .description("Upgrade first-tree to the latest published version and restart the daemon")
+    .description("Upgrade first-tree to the server-recommended version and restart the daemon")
     .option("--check", "Only check whether a newer version is available; do not install")
+    .option("--latest", "Bypass the server target and install npm latest")
     .option("--no-restart", "Install the new version but skip restarting the background service")
-    .action(async (options: { check?: boolean; restart?: boolean }) => {
+    .action(async (options: { check?: boolean; latest?: boolean; restart?: boolean }) => {
+      const binName = channelConfig.binName;
       const mode = detectInstallMode();
       if (mode === "source") {
         print.line("\n  Running from a source checkout — `upgrade` is a no-op.\n");
@@ -49,53 +55,60 @@ export function registerUpgradeCommand(program: Command): void {
         return;
       }
 
-      print.line("\n  Checking npm registry...\n");
-      const latest = fetchLatestVersion();
-      if (!latest.ok) {
-        print.line(`  Could not fetch latest version: ${latest.reason}\n\n`);
+      const useNpmLatest = options.latest === true;
+      print.line(useNpmLatest ? "\n  Checking npm registry...\n" : "\n  Checking server update target...\n");
+      const target = useNpmLatest ? fetchLatestVersion() : await fetchServerCommandVersion();
+      if (!target.ok) {
+        const targetLabel = useNpmLatest ? "latest version" : "server update target";
+        print.line(`  Could not fetch ${targetLabel}: ${target.reason}\n`);
+        if (!useNpmLatest) {
+          print.line(`  Run \`${binName} upgrade --latest\` to install npm latest instead.\n`);
+        }
+        print.line("\n");
         process.exit(1);
       }
 
       const current = COMMAND_VERSION;
-      const cmp = semver.valid(current) ? semver.compare(current, latest.version) : -1;
+      const sourceLabel = useNpmLatest ? "npm latest" : "server target";
+      const cmp = semver.valid(current) ? semver.compare(current, target.version) : -1;
       if (cmp >= 0) {
-        print.line(`  Already on ${current} (latest is ${latest.version}).\n\n`);
+        print.line(`  Already on ${current} (${sourceLabel} is ${target.version}).\n\n`);
         return;
       }
 
       if (options.check) {
-        print.line(`  Upgrade available: ${current} → ${latest.version}\n`);
-        print.line("  Run `first-tree upgrade` to install.\n\n");
+        print.line(`  Upgrade available: ${current} → ${target.version}\n`);
+        print.line(`  Run \`${binName} upgrade${useNpmLatest ? " --latest" : ""}\` to install.\n\n`);
         return;
       }
 
-      print.line(`  Upgrading ${current} → ${latest.version}...\n`);
-      const installRes = await installGlobalLatest();
+      print.line(`  Upgrading ${current} → ${target.version}...\n`);
+      const installRes = useNpmLatest ? await installGlobalLatest() : await installGlobalSpec(target.version);
       if (!installRes.ok) {
         print.line(`\n  Install failed: ${installRes.reason}\n\n`);
         process.exit(1);
       }
-      const installed = installRes.installedVersion ?? latest.version;
+      const installed = installRes.installedVersion ?? target.version;
       print.line(`  Installed ${installed}.\n`);
 
       // Restart the service so the new binary actually starts handling
       // connections. Skipped under --no-restart so power users can stage
       // the bits and time the cutover themselves.
       if (options.restart === false) {
-        print.line("  Skipping restart (--no-restart). Run `first-tree daemon restart` when ready.\n\n");
+        print.line(`  Skipping restart (--no-restart). Run \`${binName} daemon restart\` when ready.\n\n`);
         return;
       }
 
       if (!isServiceSupported()) {
         print.line(`  No service manager on ${process.platform}; restart your inline `);
-        print.line("`daemon start` process to pick up the new version.\n\n");
+        print.line(`\`${binName} daemon start\` process to pick up the new version.\n\n`);
         return;
       }
 
       const svc = getClientServiceStatus();
       if (svc.state === "not-installed") {
         print.line("  No background service installed — nothing to restart.\n");
-        print.line("  Run `first-tree login <token>` to set one up.\n\n");
+        print.line(`  Run \`${binName} login <token>\` to set one up.\n\n`);
         return;
       }
 
@@ -120,14 +133,14 @@ export function registerUpgradeCommand(program: Command): void {
       }
 
       if (svc.state === "inactive") {
-        print.line("  Service is stopped — leaving it stopped. Use `daemon start` to bring it up.\n\n");
+        print.line(`  Service is stopped — leaving it stopped. Use \`${binName} daemon start\` to bring it up.\n\n`);
         return;
       }
 
       const restartRes = restartClientService();
       if (!restartRes.ok) {
         print.line(`\n  Service restart failed: ${restartRes.reason}\n`);
-        print.line("  Run `first-tree daemon restart` to retry.\n\n");
+        print.line(`  Run \`${binName} daemon restart\` to retry.\n\n`);
         process.exit(1);
       }
       print.line(`  Service restarted on ${installed}.\n\n`);

--- a/apps/cli/src/core/index.ts
+++ b/apps/cli/src/core/index.ts
@@ -84,12 +84,13 @@ export {
   stopClientService,
   uninstallClientService,
 } from "./service-install.js";
-export type { ExecuteUpdateResult, InstallMode } from "./update.js";
+export type { ExecuteUpdateResult, InstallMode, VersionLookupResult } from "./update.js";
 // Self-update glue — exported so both `client start` and `connect <token>`
 // can pass identical prompt / install callbacks to the ClientRuntime.
 export {
   detectInstallMode,
   fetchLatestVersion,
+  fetchServerCommandVersion,
   installGlobalLatest,
   installGlobalSpec,
   PACKAGE_NAME,

--- a/apps/cli/src/core/update.ts
+++ b/apps/cli/src/core/update.ts
@@ -4,13 +4,16 @@ import { dirname, join, resolve } from "node:path";
 import { classify, ERROR_KINDS, getChildProcessRegistry } from "@first-tree/client";
 import { inferChannelFromVersion } from "@first-tree/shared/channel";
 import * as semver from "semver";
+import { resolveServerUrl } from "./bootstrap.js";
 import { channelConfig } from "./channel.js";
+import { cliFetch } from "./cli-fetch.js";
 import { print } from "./output.js";
 
 /** Hard ceiling on a single `npm install -g` invocation (5 min). */
 const NPM_INSTALL_TIMEOUT_MS = 5 * 60 * 1000;
 
 export type InstallMode = "global" | "npx" | "source";
+export type VersionLookupResult = { ok: true; version: string } | { ok: false; reason: string };
 
 /**
  * npm package name this binary self-updates against. Derived from the
@@ -38,7 +41,7 @@ function resolveNpmCommand(): string {
  * `npm install -g <pkg>@latest` makes sense.
  *
  *  - `"global"`: launched from an `npm install -g` install. The self-update
- *    reinstalls the same package at `@latest`.
+ *    can reinstall the same package at a caller-selected spec.
  *  - `"source"`: launched from inside a git checkout (dev / monorepo). Update
  *    is a no-op; operator should `git pull`.
  *  - `"npx"` (fallback): any other path (e.g. one-shot `npx`, pnpm dlx). Auto
@@ -178,12 +181,11 @@ function looksLikeVersion(spec: string): boolean {
  * that (so the UpdateManager can attempt the restart itself while this
  * function remains side-effect-scoped).
  *
- * Why both shapes exist: the auto-update path receives `targetVersion` from
- * the server `welcome` frame and MUST install that exact version — using
- * `@latest` from auto-update would silently mis-resolve once the server
- * starts advertising alpha builds (alpha lives on a different dist-tag).
- * The manual `first-tree upgrade` CLI keeps the dist-tag form so users
- * who type the command without args still get "newest stable on npm".
+ * Why both shapes exist: the auto-update path and the default manual
+ * `first-tree upgrade` command receive an exact target version from the
+ * server and MUST install that exact version. The explicit
+ * `first-tree upgrade --latest` escape hatch keeps the dist-tag form for
+ * operators who want the freshest package directly from npm.
  */
 export async function installGlobalSpec(spec: string): Promise<ExecuteUpdateResult> {
   if (!isSafeInstallSpec(spec)) {
@@ -290,13 +292,60 @@ export async function installGlobalSpec(spec: string): Promise<ExecuteUpdateResu
 }
 
 /**
- * Back-compat shim: install `<pkg>@latest`. The manual `first-tree
- * update` CLI uses this so an operator-typed `update` keeps the
- * "newest stable on npm" behaviour. Auto-update prefers `installGlobalSpec`
- * with the welcome frame's `targetVersion`.
+ * Back-compat shim: install `<pkg>@latest`. Used by
+ * `first-tree upgrade --latest`; managed update paths prefer
+ * `installGlobalSpec` with the server-advertised target version.
  */
 export async function installGlobalLatest(): Promise<ExecuteUpdateResult> {
   return installGlobalSpec("latest");
+}
+
+/**
+ * Look up the server-recommended CLI version from the public bootstrap
+ * config endpoint. This is the default manual-upgrade source so operators
+ * follow the same rollout target as connected clients.
+ */
+export async function fetchServerCommandVersion(timeoutMs = 10_000): Promise<VersionLookupResult> {
+  let serverUrl: string;
+  try {
+    serverUrl = resolveServerUrl();
+  } catch (err) {
+    return { ok: false, reason: err instanceof Error ? err.message : String(err) };
+  }
+
+  let res: Response;
+  try {
+    res = await cliFetch(`${serverUrl.replace(/\/+$/, "")}/api/v1/bootstrap/config`, {
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch (err) {
+    return { ok: false, reason: err instanceof Error ? err.message : String(err) };
+  }
+
+  if (!res.ok) {
+    return { ok: false, reason: `server returned HTTP ${res.status}` };
+  }
+
+  let body: unknown;
+  try {
+    body = await res.json();
+  } catch (err) {
+    return { ok: false, reason: `server returned invalid JSON: ${err instanceof Error ? err.message : String(err)}` };
+  }
+
+  if (body === null || typeof body !== "object") {
+    return { ok: false, reason: "server returned invalid bootstrap config" };
+  }
+
+  const version = Reflect.get(body, "serverCommandVersion");
+  if (typeof version !== "string" || version.length === 0) {
+    return { ok: false, reason: "server did not provide serverCommandVersion" };
+  }
+  const normalized = semver.valid(version);
+  if (!normalized) {
+    return { ok: false, reason: `server returned non-semver version: ${version.slice(0, 80)}` };
+  }
+  return { ok: true, version: normalized };
 }
 
 /**
@@ -328,7 +377,7 @@ function escapeForRegex(s: string): string {
  * honored — important for corporate users routed through Verdaccio /
  * Artifactory mirrors.
  */
-export function fetchLatestVersion(timeoutMs = 10_000): { ok: true; version: string } | { ok: false; reason: string } {
+export function fetchLatestVersion(timeoutMs = 10_000): VersionLookupResult {
   if (PACKAGE_NAME === null) {
     return { ok: false, reason: "this binary's channel does not publish to npm (dev channel)." };
   }

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -97,16 +97,19 @@ red and you want a guided drill-down.
 ## upgrade
 
 ```
-first-tree upgrade [--check] [--no-restart]
+first-tree upgrade [--check] [--latest] [--no-restart]
 ```
 
-Self-update for the CLI: query npm for the latest published version,
-install it globally, refresh the systemd unit / launchd plist on top of
-the new bits, then restart the client service.
+Self-update for the CLI: query the configured server for its recommended
+Command version, install that exact version globally, refresh the systemd
+unit / launchd plist on top of the new bits, then restart the client
+service. Use `--latest` only when you intentionally want to bypass the
+server target and install npm latest directly.
 
 | Flag | Effect |
 |---|---|
 | `--check` | Only check for an available version; print "update available" or "already on latest". Do not install. |
+| `--latest` | Bypass the server target and query npm for the package's latest published version. |
 | `--no-restart` | Install the new version and refresh the unit file, but leave the running service alone. Used for staged rollouts. |
 
 Refusing to run from a source checkout (anywhere under a `.git`

--- a/docs/development/local-dev-isolation.md
+++ b/docs/development/local-dev-isolation.md
@@ -99,8 +99,9 @@ first-tree-staging login <staging-token>
 ## When to use which install
 
 - **`scripts/dev-install.sh`** — actively iterating on CLI / client /
-  shared code. Build is local, no npm round-trip. `upgrade` short-circuits
-  because `detectInstallMode()` returns `"source"`.
+  shared code. Build is local, no server or npm upgrade round-trip.
+  `upgrade` short-circuits because `detectInstallMode()` returns
+  `"source"`.
 - **Direct `pnpm --filter ... dev`** — running parts of the system in
   isolation (server-only, web-only) where you don't need the full CLI
   surface. `tsx` runs against source.
@@ -114,9 +115,10 @@ first-tree-staging login <staging-token>
   you also run an in-tree server (`pnpm --filter @first-tree/server dev`),
   use a separate DB URL via `FIRST_TREE_DATABASE_URL`.
 - Global npm packages. If you have both staging and prod installed,
-  upgrading either (e.g. via `first-tree-staging upgrade`) goes through
-  npm and affects your machine-wide install. Dev is immune because its
-  source-checkout install mode short-circuits the upgrade path.
+  upgrading either (e.g. via `first-tree-staging upgrade`) follows that
+  channel's configured server target and affects your machine-wide install.
+  `--latest` bypasses the server and goes directly to npm. Dev is immune
+  because its source-checkout install mode short-circuits the upgrade path.
 
 ## Tearing down a dev install
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -43,6 +43,7 @@
     "jose": "^6.0.0",
     "pino": "^9.5.0",
     "postgres": "^3.4.0",
+    "semver": "^7.7.4",
     "zod": "^4.0.0"
   },
   "devDependencies": {
@@ -52,6 +53,7 @@
     "@testcontainers/postgresql": "^11.13.0",
     "@types/bcrypt": "^5.0.0",
     "@types/node": "^22.16.0",
+    "@types/semver": "^7.7.1",
     "@types/ws": "^8.18.1",
     "@vitest/coverage-v8": "3.2.4",
     "drizzle-kit": "^0.31.0",

--- a/packages/server/src/__tests__/bootstrap-config.test.ts
+++ b/packages/server/src/__tests__/bootstrap-config.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { useTestApp } from "./helpers.js";
+
+describe("GET /bootstrap/config", () => {
+  const getApp = useTestApp();
+
+  it("returns the public server command version", async () => {
+    const app = getApp();
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/bootstrap/config",
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({
+      allowedOrg: null,
+      serverCommandVersion: "test.version",
+    });
+  });
+});

--- a/packages/server/src/__tests__/helpers.ts
+++ b/packages/server/src/__tests__/helpers.ts
@@ -50,13 +50,14 @@ type AgentRequestFn = (
 ) => Promise<InjectResponse>;
 
 /**
- * Optional overrides for `createTestApp` / `useTestApp`. Today only the
- * rate-limit caps are tunable — the default config sets all caps to 10000 so
- * existing tests never trip them; tests that specifically exercise limiter
- * behavior (e.g. `agent-messages-rate-limit.test.ts`) override the relevant
- * field down to a small number to keep the test loop tight.
+ * Optional overrides for `createTestApp` / `useTestApp`. The default config
+ * sets rate-limit caps to 10000 so existing tests never trip them; tests that
+ * specifically exercise limiter behavior (e.g. `agent-messages-rate-limit.test.ts`)
+ * override the relevant field down to a small number to keep the test loop tight.
  */
 export type CreateTestAppOptions = {
+  channel?: Config["channel"];
+  commandVersion?: string;
   rateLimit?: Partial<NonNullable<Config["rateLimit"]>>;
   allowedOrganizationId?: string;
   /**
@@ -86,7 +87,7 @@ export async function createTestApp(opts: CreateTestAppOptions = {}): Promise<Fa
     contextTreeSnapshotMax: 10000,
   };
   const config: Config = {
-    channel: "dev",
+    channel: opts.channel ?? "dev",
     database: {
       url: process.env.DATABASE_URL ?? "",
       provider: "external",
@@ -148,7 +149,7 @@ export async function createTestApp(opts: CreateTestAppOptions = {}): Promise<Fa
     update: {
       // Pin a deterministic version so welcome-frame tests can assert
       // exact equality without coupling to the in-tree package.json.
-      commandVersion: "test.version",
+      commandVersion: opts.commandVersion ?? "test.version",
       // Long enough that the timer never fires inside a test run — we
       // call `refresh()` manually when a test needs a forced poll.
       pollIntervalMinutes: 1440,

--- a/packages/server/src/__tests__/me-clients-list.test.ts
+++ b/packages/server/src/__tests__/me-clients-list.test.ts
@@ -16,6 +16,8 @@ import { createAdminContext, seedClient, useTestApp } from "./helpers.js";
  */
 describe("GET /me/clients", () => {
   const getApp = useTestApp();
+  const getSemverApp = useTestApp({ commandVersion: "0.6.0" });
+  const getProdApp = useTestApp({ channel: "prod", commandVersion: "0.6.0" });
 
   /** Attach `userId` to a fresh side-org as `role`. */
   async function attachMember(
@@ -82,6 +84,51 @@ describe("GET /me/clients", () => {
     // org where the caller is a non-admin member — proving the route is
     // user-scope, not org-admin-scope.
     expect(ids).toEqual([a.clientId, aSecondInOrgB].sort());
+  });
+
+  it("includes the server command version hint only when the client is behind on dev/staging", async () => {
+    const app = getSemverApp();
+    const ctx = await createAdminContext(app);
+    await app.db.update(clients).set({ sdkVersion: "0.5.0" }).where(eq(clients.id, ctx.clientId));
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/me/clients",
+      headers: { authorization: `Bearer ${ctx.accessToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as Array<{ id: string; serverCommandVersion?: string }>;
+    const row = body.find((c) => c.id === ctx.clientId);
+    expect(row?.serverCommandVersion).toBe("0.6.0");
+
+    await app.db.update(clients).set({ sdkVersion: "0.6.0" }).where(eq(clients.id, ctx.clientId));
+
+    const freshRes = await app.inject({
+      method: "GET",
+      url: "/api/v1/me/clients",
+      headers: { authorization: `Bearer ${ctx.accessToken}` },
+    });
+    expect(freshRes.statusCode).toBe(200);
+    const freshBody = freshRes.json() as Array<{ id: string; serverCommandVersion?: string }>;
+    const freshRow = freshBody.find((c) => c.id === ctx.clientId);
+    expect(freshRow?.serverCommandVersion).toBeUndefined();
+  });
+
+  it("omits the server command version hint in prod", async () => {
+    const app = getProdApp();
+    const ctx = await createAdminContext(app);
+    await app.db.update(clients).set({ sdkVersion: "0.5.0" }).where(eq(clients.id, ctx.clientId));
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/me/clients",
+      headers: { authorization: `Bearer ${ctx.accessToken}` },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as Array<{ id: string; serverCommandVersion?: string }>;
+    const row = body.find((c) => c.id === ctx.clientId);
+    expect(row?.serverCommandVersion).toBeUndefined();
   });
 
   it("requires authentication", async () => {
@@ -174,6 +221,7 @@ describe("GET /me/clients", () => {
  */
 describe("GET /orgs/:orgId/clients (admin team view)", () => {
   const getApp = useTestApp();
+  const getSemverApp = useTestApp({ commandVersion: "0.6.0" });
 
   it("includes capabilities for clients in the team listing", async () => {
     const app = getApp();
@@ -206,6 +254,23 @@ describe("GET /orgs/:orgId/clients (admin team view)", () => {
     expect(row).toBeDefined();
     expect(row?.capabilities["claude-code"]?.state).toBe("unauthenticated");
     expect(row?.capabilities["claude-code"]?.sdkVersion).toBe("0.8.1");
+  });
+
+  it("includes server command version for stale clients in the team listing", async () => {
+    const app = getSemverApp();
+    const admin = await createAdminContext(app);
+    await app.db.update(clients).set({ sdkVersion: "0.5.0" }).where(eq(clients.id, admin.clientId));
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/orgs/${encodeURIComponent(admin.organizationId)}/clients`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as Array<{ id: string; serverCommandVersion?: string }>;
+    const row = body.find((c) => c.id === admin.clientId);
+    expect(row).toBeDefined();
+    expect(row?.serverCommandVersion).toBe("0.6.0");
   });
 
   it("returns an empty capabilities object for clients that have not reported any", async () => {

--- a/packages/server/src/api/bootstrap/config.ts
+++ b/packages/server/src/api/bootstrap/config.ts
@@ -1,6 +1,6 @@
 import type { FastifyInstance } from "fastify";
 
-export async function bootstrapConfigRoutes(_app: FastifyInstance): Promise<void> {
+export async function bootstrapConfigRoutes(app: FastifyInstance): Promise<void> {
   /**
    * Public endpoint — returns bootstrap prerequisites for CLI auto-discovery.
    *
@@ -9,7 +9,7 @@ export async function bootstrapConfigRoutes(_app: FastifyInstance): Promise<void
    * (see issue #255). A public bootstrap endpoint can't resolve an
    * installation without a caller, so the field is surfaced as `null`.
    */
-  _app.get("/config", async () => {
-    return { allowedOrg: null as string | null };
+  app.get("/config", async () => {
+    return { allowedOrg: null as string | null, serverCommandVersion: app.commandVersion() };
   });
 }

--- a/packages/server/src/api/client-command-version.ts
+++ b/packages/server/src/api/client-command-version.ts
@@ -1,0 +1,98 @@
+import type { FastifyInstance } from "fastify";
+
+export function clientCommandVersionHint(
+  app: FastifyInstance,
+  clientVersion: string | null | undefined,
+): { serverCommandVersion?: string } {
+  if (app.config.channel !== "dev" && app.config.channel !== "staging") return {};
+
+  const serverCommandVersion = app.commandVersion();
+  if (isUpdateAvailable(clientVersion, serverCommandVersion)) {
+    return { serverCommandVersion };
+  }
+  return {};
+}
+
+type ParsedVersion = {
+  major: number;
+  minor: number;
+  patch: number;
+  prerelease: string[];
+};
+
+const SEMVER_RE =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+const NUMERIC_IDENTIFIER_RE = /^(0|[1-9]\d*)$/;
+
+function isUpdateAvailable(current: string | null | undefined, target: string | null | undefined): boolean {
+  const currentVersion = parseVersion(current);
+  const targetVersion = parseVersion(target);
+  if (!currentVersion || !targetVersion) return false;
+  return compareVersion(currentVersion, targetVersion) < 0;
+}
+
+function parseVersion(value: string | null | undefined): ParsedVersion | null {
+  if (!value) return null;
+  const match = SEMVER_RE.exec(value.trim());
+  if (!match) return null;
+
+  const major = parseInteger(match[1]);
+  const minor = parseInteger(match[2]);
+  const patch = parseInteger(match[3]);
+  if (major === null || minor === null || patch === null) return null;
+
+  const prerelease = match[4]?.split(".") ?? [];
+  for (const identifier of prerelease) {
+    if (/^\d+$/.test(identifier) && !NUMERIC_IDENTIFIER_RE.test(identifier)) return null;
+  }
+
+  return { major, minor, patch, prerelease };
+}
+
+function parseInteger(value: string | undefined): number | null {
+  if (!value) return null;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : null;
+}
+
+function compareVersion(left: ParsedVersion, right: ParsedVersion): number {
+  const major = compareNumber(left.major, right.major);
+  if (major !== 0) return major;
+  const minor = compareNumber(left.minor, right.minor);
+  if (minor !== 0) return minor;
+  const patch = compareNumber(left.patch, right.patch);
+  if (patch !== 0) return patch;
+  return comparePrerelease(left.prerelease, right.prerelease);
+}
+
+function compareNumber(left: number, right: number): number {
+  if (left === right) return 0;
+  return left < right ? -1 : 1;
+}
+
+function comparePrerelease(left: string[], right: string[]): number {
+  if (left.length === 0 && right.length === 0) return 0;
+  if (left.length === 0) return 1;
+  if (right.length === 0) return -1;
+
+  const length = Math.max(left.length, right.length);
+  for (let i = 0; i < length; i++) {
+    const leftIdentifier = left[i];
+    const rightIdentifier = right[i];
+    if (leftIdentifier === undefined) return -1;
+    if (rightIdentifier === undefined) return 1;
+    const comparison = comparePrereleaseIdentifier(leftIdentifier, rightIdentifier);
+    if (comparison !== 0) return comparison;
+  }
+  return 0;
+}
+
+function comparePrereleaseIdentifier(left: string, right: string): number {
+  const leftNumeric = NUMERIC_IDENTIFIER_RE.test(left);
+  const rightNumeric = NUMERIC_IDENTIFIER_RE.test(right);
+  if (leftNumeric && rightNumeric) return compareNumber(Number(left), Number(right));
+  if (leftNumeric) return -1;
+  if (rightNumeric) return 1;
+  if (left === right) return 0;
+  return left < right ? -1 : 1;
+}

--- a/packages/server/src/api/client-command-version.ts
+++ b/packages/server/src/api/client-command-version.ts
@@ -1,4 +1,5 @@
 import type { FastifyInstance } from "fastify";
+import * as semver from "semver";
 
 export function clientCommandVersionHint(
   app: FastifyInstance,
@@ -6,93 +7,10 @@ export function clientCommandVersionHint(
 ): { serverCommandVersion?: string } {
   if (app.config.channel !== "dev" && app.config.channel !== "staging") return {};
 
-  const serverCommandVersion = app.commandVersion();
-  if (isUpdateAvailable(clientVersion, serverCommandVersion)) {
+  const currentVersion = semver.valid(clientVersion);
+  const serverCommandVersion = semver.valid(app.commandVersion());
+  if (currentVersion && serverCommandVersion && semver.lt(currentVersion, serverCommandVersion)) {
     return { serverCommandVersion };
   }
   return {};
-}
-
-type ParsedVersion = {
-  major: number;
-  minor: number;
-  patch: number;
-  prerelease: string[];
-};
-
-const SEMVER_RE =
-  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
-const NUMERIC_IDENTIFIER_RE = /^(0|[1-9]\d*)$/;
-
-function isUpdateAvailable(current: string | null | undefined, target: string | null | undefined): boolean {
-  const currentVersion = parseVersion(current);
-  const targetVersion = parseVersion(target);
-  if (!currentVersion || !targetVersion) return false;
-  return compareVersion(currentVersion, targetVersion) < 0;
-}
-
-function parseVersion(value: string | null | undefined): ParsedVersion | null {
-  if (!value) return null;
-  const match = SEMVER_RE.exec(value.trim());
-  if (!match) return null;
-
-  const major = parseInteger(match[1]);
-  const minor = parseInteger(match[2]);
-  const patch = parseInteger(match[3]);
-  if (major === null || minor === null || patch === null) return null;
-
-  const prerelease = match[4]?.split(".") ?? [];
-  for (const identifier of prerelease) {
-    if (/^\d+$/.test(identifier) && !NUMERIC_IDENTIFIER_RE.test(identifier)) return null;
-  }
-
-  return { major, minor, patch, prerelease };
-}
-
-function parseInteger(value: string | undefined): number | null {
-  if (!value) return null;
-  const parsed = Number(value);
-  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : null;
-}
-
-function compareVersion(left: ParsedVersion, right: ParsedVersion): number {
-  const major = compareNumber(left.major, right.major);
-  if (major !== 0) return major;
-  const minor = compareNumber(left.minor, right.minor);
-  if (minor !== 0) return minor;
-  const patch = compareNumber(left.patch, right.patch);
-  if (patch !== 0) return patch;
-  return comparePrerelease(left.prerelease, right.prerelease);
-}
-
-function compareNumber(left: number, right: number): number {
-  if (left === right) return 0;
-  return left < right ? -1 : 1;
-}
-
-function comparePrerelease(left: string[], right: string[]): number {
-  if (left.length === 0 && right.length === 0) return 0;
-  if (left.length === 0) return 1;
-  if (right.length === 0) return -1;
-
-  const length = Math.max(left.length, right.length);
-  for (let i = 0; i < length; i++) {
-    const leftIdentifier = left[i];
-    const rightIdentifier = right[i];
-    if (leftIdentifier === undefined) return -1;
-    if (rightIdentifier === undefined) return 1;
-    const comparison = comparePrereleaseIdentifier(leftIdentifier, rightIdentifier);
-    if (comparison !== 0) return comparison;
-  }
-  return 0;
-}
-
-function comparePrereleaseIdentifier(left: string, right: string): number {
-  const leftNumeric = NUMERIC_IDENTIFIER_RE.test(left);
-  const rightNumeric = NUMERIC_IDENTIFIER_RE.test(right);
-  if (leftNumeric && rightNumeric) return compareNumber(Number(left), Number(right));
-  if (leftNumeric) return -1;
-  if (rightNumeric) return 1;
-  if (left === right) return 0;
-  return left < right ? -1 : 1;
 }

--- a/packages/server/src/api/clients.ts
+++ b/packages/server/src/api/clients.ts
@@ -5,6 +5,7 @@ import { expiryToSeconds } from "../services/auth.js";
 import * as clientService from "../services/client.js";
 import { forceDisconnectClient } from "../services/connection-manager.js";
 import { serializeDate } from "../utils.js";
+import { clientCommandVersionHint } from "./client-command-version.js";
 
 /**
  * Class C — `/api/v1/clients/:id` and member-self utilities. A client is
@@ -33,6 +34,7 @@ export async function clientRoutes(app: FastifyInstance): Promise<void> {
       lastSeenAt: client.lastSeenAt.toISOString(),
       capabilities,
       lastUpdateAttempt: clientService.extractLastUpdateAttempt(client.metadata),
+      ...clientCommandVersionHint(app, client.sdkVersion),
     };
   });
 

--- a/packages/server/src/api/me.ts
+++ b/packages/server/src/api/me.ts
@@ -34,6 +34,7 @@ import {
 } from "../services/membership.js";
 import { resolvePublicUrl } from "../utils/public-url.js";
 import { serializeDate } from "../utils.js";
+import { clientCommandVersionHint } from "./client-command-version.js";
 
 /**
  * `/me` and self-service organization routes (Class A — User-scoped).
@@ -458,6 +459,7 @@ export async function meRoutes(app: FastifyInstance): Promise<void> {
       lastSeenAt: c.lastSeenAt.toISOString(),
       capabilities: clientService.extractCapabilities(c.metadata),
       lastUpdateAttempt: clientService.extractLastUpdateAttempt(c.metadata),
+      ...clientCommandVersionHint(app, c.sdkVersion),
     }));
   });
 

--- a/packages/server/src/api/orgs/clients.ts
+++ b/packages/server/src/api/orgs/clients.ts
@@ -3,6 +3,7 @@ import { requireOrgAdmin } from "../../scope/require-org.js";
 import { expiryToSeconds } from "../../services/auth.js";
 import * as clientService from "../../services/client.js";
 import { serializeDate } from "../../utils.js";
+import { clientCommandVersionHint } from "../client-command-version.js";
 
 /**
  * Class B — `/api/v1/orgs/:orgId/clients`. Lists clients belonging to
@@ -28,6 +29,7 @@ export async function orgClientRoutes(app: FastifyInstance): Promise<void> {
       lastSeenAt: c.lastSeenAt.toISOString(),
       capabilities: clientService.extractCapabilities(c.metadata),
       lastUpdateAttempt: clientService.extractLastUpdateAttempt(c.metadata),
+      ...clientCommandVersionHint(app, c.sdkVersion),
     }));
   });
 }

--- a/packages/web/src/api/activity.ts
+++ b/packages/web/src/api/activity.ts
@@ -39,6 +39,7 @@ export type HubClient = {
   /** Server-derived from offline duration vs refresh-token TTL. See clientAuthStateSchema in shared. */
   authState: "ok" | "expired";
   sdkVersion: string | null;
+  serverCommandVersion?: string | null;
   hostname: string | null;
   os: string | null;
   agentCount: number;

--- a/packages/web/src/pages/clients/__tests__/clients-page-cards-dom.test.tsx
+++ b/packages/web/src/pages/clients/__tests__/clients-page-cards-dom.test.tsx
@@ -112,6 +112,7 @@ function client(overrides: Partial<HubClient> = {}): HubClient {
     status: overrides.status ?? "connected",
     authState: overrides.authState ?? "ok",
     sdkVersion: overrides.sdkVersion ?? "0.5.0",
+    ...(overrides.serverCommandVersion !== undefined ? { serverCommandVersion: overrides.serverCommandVersion } : {}),
     hostname: overrides.hostname ?? "gandy-macbook",
     os: overrides.os ?? "darwin",
     agentCount: overrides.agentCount ?? 1,
@@ -420,6 +421,32 @@ describe("ClientsPage computer cards", () => {
     await click(exactButton(container, "Connect"));
     await waitForText(document.body, "Connect computer");
     await click(exactButton(document.body, "Cancel"));
+
+    await act(async () => root.unmount());
+  });
+
+  it("shows the server-reported update target when a computer is behind", async () => {
+    const { ClientsPage } = await import("../../clients.js");
+    const updating = client({
+      id: "client-update",
+      hostname: "needs-update",
+      sdkVersion: "0.5.0",
+      serverCommandVersion: "0.6.0",
+    });
+    activityMocks.listOrgClients.mockResolvedValueOnce([updating]);
+    activityMocks.listClients.mockResolvedValueOnce([updating]);
+    activityMocks.getActivityOverview.mockResolvedValueOnce({
+      clients: 1,
+      agents: [],
+      running: 0,
+      total: 0,
+      byState: {},
+    });
+
+    const { container, root } = await renderDom(<ClientsPage />);
+
+    await waitForText(container, "needs-update");
+    await waitForText(container, "Update available 0.6.0");
 
     await act(async () => root.unmount());
   });

--- a/packages/web/src/pages/clients/cards/shared/compact-meta-line.tsx
+++ b/packages/web/src/pages/clients/cards/shared/compact-meta-line.tsx
@@ -48,6 +48,9 @@ export function CompactMetaLine({
   // identifier with no hint that it's the First Tree CLI version.
   if (client.sdkVersion) segments.push(`first-tree ${client.sdkVersion}`);
   if (client.os) segments.push(client.os);
+  if (client.serverCommandVersion) {
+    segments.push(`Update available ${client.serverCommandVersion}`);
+  }
   if (segments.length === 0) return null;
   return (
     <div

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,6 +232,9 @@ importers:
       postgres:
         specifier: ^3.4.0
         version: 3.4.8
+      semver:
+        specifier: ^7.7.4
+        version: 7.7.4
       zod:
         specifier: ^4.0.0
         version: 4.3.6
@@ -254,6 +257,9 @@ importers:
       '@types/node':
         specifier: ^22.16.0
         version: 22.19.15
+      '@types/semver':
+        specifier: ^7.7.1
+        version: 7.7.1
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1


### PR DESCRIPTION
## Summary
- Make `first-tree upgrade` default to the server-advertised command version from bootstrap config, while `--latest` keeps the npm-latest escape hatch.
- Return optional `serverCommandVersion` from clients responses only in dev/staging and only when the specific client is behind the server command version.
- Simplify the Computers UI to render the update hint only when the server sends `serverCommandVersion`.
- Update CLI/local-dev docs.

## Context Tree
- Durable contract PR: https://github.com/agent-team-foundation/first-tree-context/pull/435

## Review
- `codex-reviewer`: LGTM / no blocking findings.

## Validation
- `pnpm --filter first-tree-dev exec vitest run --passWithNoTests --maxWorkers=2 src/__tests__/agent-lifecycle-commands-extra.test.ts src/__tests__/core-attention-update-extra.test.ts`
- `pnpm --filter @first-tree/server exec vitest run --maxWorkers=2 src/__tests__/me-clients-list.test.ts src/__tests__/bootstrap-config.test.ts`
- `pnpm --filter @first-tree/web exec vitest run --passWithNoTests --maxWorkers=2 src/pages/clients/__tests__/clients-page-cards-dom.test.tsx`
- `pnpm check && pnpm typecheck`
- `git diff --check origin/main..HEAD`
