### PR TITLE
refactor(client): tighten # Required Reading prose (yuezengwu nits 1+2)

### DIFF
--- a/packages/client/src/__tests__/agent-briefing.test.ts
+++ b/packages/client/src/__tests__/agent-briefing.test.ts
@@ -152,11 +152,26 @@ describe("buildAgentBriefing — # Required Reading (unconditional skill-load ma
     expect(briefing).toMatch(/you MUST\s+load both skills below/);
     expect(briefing).toContain("**`first-tree`**");
     expect(briefing).toContain("**`first-tree-context`**");
-    // Reminds the agent that the inline briefing intentionally does
-    // not duplicate the skill bodies — so it can't rationalise
-    // skipping the load.
-    expect(briefing).toMatch(/intentionally NOT duplicated[\s\n]+inline/);
-    expect(briefing).toMatch(/minimum mechanics you need to operate at all/);
+    // Bootstrapping framing — the mandate IS the first step of the
+    // skill-described pre-task hygiene, not "even before" those
+    // checks (which would be self-contradictory: you can't run the
+    // checks before you've read the skill that lists them).
+    expect(briefing).toMatch(/loading them \*\*is\*\* the first step of the[\s\n]+pre-task hygiene/);
+    // Briefing↔skill split: minimum mechanics inline, durable rules
+    // in full in the skills. Honest about the partial summarisation
+    // (final-text contract is in the briefing's Communication block;
+    // write-side gate is in `## Writing the Tree`) — the briefing
+    // can't claim "not duplicated" without contradicting itself.
+    expect(briefing).toMatch(/minimum\s+mechanics you need to operate at all/);
+    expect(briefing).toMatch(/durable\s+rules in full/);
+    expect(briefing).toMatch(/only summarising the slices/);
+    // The cost-of-skipping list names what's actually missing from
+    // the inline briefing (the daemon-lifecycle invariants, the full
+    // Communication Principles, source-system boundary, Hard Rules +
+    // Double Test) — not a blanket "not duplicated" claim.
+    expect(briefing).toMatch(/daemon-lifecycle invariants/);
+    expect(briefing).toMatch(/Hard Rules \+ Double Test/);
+    expect(briefing).toMatch(/either omits or only summarises/);
     // Calls out the on-demand-only sibling so the agent doesn't
     // over-load every First Tree family skill on every task.
     expect(briefing).toContain("`first-tree-sync`");

--- a/packages/client/src/runtime/agent-briefing.ts
+++ b/packages/client/src/runtime/agent-briefing.ts
@@ -120,11 +120,13 @@ function requiredReadingSection(contextTreePath: string | null): string | null {
   return `# Required Reading
 
 Before responding to any non-trivial instruction in this chat, you MUST
-load both skills below — even before the pre-task hygiene checks they
-describe. The \`# Working in First Tree\` section above carries the
-minimum mechanics you need to operate at all (final-text contract,
-chat send, working directory, CLI surface); the skills below carry
-the durable rules that are intentionally NOT duplicated inline.
+load both skills below — loading them **is** the first step of the
+pre-task hygiene the \`first-tree\` skill itself describes. The
+\`# Working in First Tree\` section above carries the minimum
+mechanics you need to operate at all (final-text contract, chat send,
+working directory, CLI surface); the skills below carry the durable
+rules in full, with the inline briefing only summarising the slices
+needed for those workspace-collab basics.
 
 1. **\`first-tree\`** — what First Tree is, the three-principal model
    (Server / Client / Agent), the Communication Principles in full,
@@ -139,10 +141,11 @@ These two are unconditional. The remaining First Tree skill
 (\`first-tree-sync\`) loads on demand based on the task signal as
 listed in the First Tree Family map below.
 
-Skipping either skill costs you daemon-lifecycle constraints,
-communication contracts, or write-side hard rules that are not
-duplicated in this briefing — acting without them is the #1 source
-of advice that conflicts with reality.`;
+Skipping either skill costs you the daemon-lifecycle invariants, the
+full Communication Principles, the source-system boundary, and the
+write-side Hard Rules + Double Test — content the inline briefing
+either omits or only summarises. Acting without them is the #1
+source of advice that conflicts with reality.`;
 }
 
 // --- # Working in First Tree -------------------------------------------------


### PR DESCRIPTION
## Summary

Follow-up to #851 addressing two non-blocking nits from yuezengwu's review that arrived after merge. Prose-only changes inside `requiredReadingSection()` + matching test anchor updates.

## Nit 1 — Logical contradiction in the MUST framing

**Before** (post-#851):
> "you MUST load both skills below — even before the pre-task hygiene checks they describe"

The pre-task hygiene is described **by** the `first-tree` skill body. So "even before the checks they describe" is circular — you cannot run the checks before you've read the skill that lists them.

**After:**
> "you MUST load both skills below — loading them **is** the first step of the pre-task hygiene the `first-tree` skill itself describes"

Same semantics (load these first), no self-contradiction.

## Nit 2 — Over-claim about non-duplication

**Before** (two instances, post-#851):
- "the durable rules that are intentionally NOT duplicated inline"
- "Skipping either skill costs you daemon-lifecycle constraints, communication contracts, or write-side hard rules that are **not duplicated in this briefing**"

But the inline briefing actually summarises some of those rules: the final-text contract is in `communicationBlock`, the load-skill-before-write mandate is in `## Writing the Tree`. If an agent diffs the two surfaces it catches the briefing in a self-contradiction, which degrades trust in the rest of the mandate.

**After:**
- Framing: "the skills below carry the durable rules in full, with the inline briefing only summarising the slices needed for those workspace-collab basics"
- Cost list: "Skipping either skill costs you the daemon-lifecycle invariants, the full Communication Principles, the source-system boundary, and the write-side Hard Rules + Double Test — content the inline briefing either omits or only summarises"

Names what's *actually* missing inline, leaves room for the slices that genuinely are summarised.

## Tests

- Replaced the `intentionally NOT duplicated` anchor with three sharper anchors: `loading them \*\*is\*\* the first step...`, `durable rules in full`, `only summarising the slices`.
- Replaced the blanket `not duplicated` anchor with two specific ones: `daemon-lifecycle invariants`, `Hard Rules \+ Double Test`, `either omits or only summarises`.
- Added `\s+` tolerance on `minimum mechanics` and `durable rules` anchors — line wrapping shifted those words to end-of-line in the new prose.

## Nit 3 — explicitly deferred

`## Agent-Specific Prompt` (H2) currently sits under `# Required Reading` (H1) in semantic-tree terms, since Required Reading came in between Identity and the per-agent prompt. Per yuezengwu's recommendation ("完全可以下个 PR 处理"), promoting to `# Agent-Specific Prompt` is a separate structural PR — not bundled here.

## Verification

- [x] `pnpm --filter @first-tree/client test agent-briefing` — 27/27 pass
- [x] `pnpm --filter @first-tree/client test` — 1027/1027 pass
- [x] `pnpm check` — clean (1185 files, biome)
- [x] `pnpm typecheck` — clean (11/11 tasks)

## Related

- Parent PR: #851 (merged `ef6d717`)
- Tree companion: agent-team-foundation/first-tree-context#438 (open) — durable policy unchanged by this prose tightening, so no tree-side delta needed.