### PR TITLE
refactor(client): per-agent standalone source-repo clones, retire shared git-mirror layer

### DIFF
--- a/apps/cli/src/__tests__/client-runtime-context-tree.test.ts
+++ b/apps/cli/src/__tests__/client-runtime-context-tree.test.ts
@@ -56,7 +56,7 @@ const watchMockProbe = importedWatch;
 const RUNTIME_TEST_TIMEOUT_MS = 15_000;
 const disposeMock = vi.fn();
 const killAllMock = vi.fn(async () => undefined);
-const sweepMock = vi.fn(async () => ({ scanned: 0, deleted: 0, failed: 0 }));
+const sweepMock = vi.fn(async () => ({ removed: [] as string[] }));
 let connectionMaxListeners = 10;
 const connectionMock = {
   clientId: "client-test",
@@ -111,13 +111,10 @@ vi.mock("@first-tree/client", () => {
     },
     UpdateManager: { attach: vi.fn(() => ({ dispose: disposeMock })) },
     createGitMirrorManager: vi.fn(() => ({
-      ensureMirror: vi.fn(),
-      fetchMirror: vi.fn(),
-      createWorktree: vi.fn(),
-      removeWorktree: vi.fn(),
-      gcMirrors: vi.fn(async () => ({ removed: [] })),
-      gcOrphanSessionBranches: sweepMock,
-      mirrorsRoot: "/tmp/fake-mirrors",
+      ensureSourceRepo: vi.fn(),
+      removeSourceRepo: vi.fn(),
+      sweepLegacyMirrors: sweepMock,
+      legacyMirrorsRoot: "/tmp/fake-mirrors",
     })),
     createLogger: vi.fn(() => ({
       info: vi.fn(),
@@ -184,7 +181,7 @@ describe("ClientRuntime context-tree wiring", () => {
     disposeMock.mockClear();
     killAllMock.mockClear();
     sweepMock.mockReset();
-    sweepMock.mockResolvedValue({ scanned: 0, deleted: 0, failed: 0 });
+    sweepMock.mockResolvedValue({ removed: [] });
   });
 
   afterEach(() => {
@@ -282,7 +279,7 @@ describe("ClientRuntime context-tree wiring", () => {
   it("handles connection events, update hooks, and graceful stop", async () => {
     const { print } = await import("../core/output.js");
     const client = await import("@first-tree/client");
-    sweepMock.mockResolvedValueOnce({ scanned: 3, deleted: 2, failed: 1 });
+    sweepMock.mockResolvedValueOnce({ removed: ["abc", "def"] });
     slotInstances.length = 0;
 
     const update = {
@@ -311,10 +308,7 @@ describe("ClientRuntime context-tree wiring", () => {
       getQuietGateSnapshot: () => { activeCount: number; lastActivityMs: number };
     };
     expect(updateOptions.getQuietGateSnapshot()).toEqual({ activeCount: 2, lastActivityMs: 400 });
-    expect(print.status).toHaveBeenCalledWith(
-      "[git-mirror]",
-      "swept orphan session branches — scanned=3 deleted=2 failed=1",
-    );
+    expect(print.status).toHaveBeenCalledWith("[git-mirror]", "removed legacy shared git-mirrors tree (2 entries)");
 
     connectionMock.isPaused.mockReturnValue(true);
     connectionMock.getPausedReason.mockReturnValue("auth_refresh_failed");
@@ -346,7 +340,7 @@ describe("ClientRuntime context-tree wiring", () => {
 
     await rt.start();
 
-    expect(print.status).toHaveBeenCalledWith("⚠️", "git-mirror orphan sweep failed: gc failed");
+    expect(print.status).toHaveBeenCalledWith("⚠️", "legacy git-mirrors sweep failed: gc failed");
     expect(print.status).toHaveBeenCalledWith("", "no agents configured yet.");
     expect(print.status).toHaveBeenCalledWith(
       "",

--- a/apps/cli/src/core/client-runtime.ts
+++ b/apps/cli/src/core/client-runtime.ts
@@ -70,9 +70,9 @@ export class ClientRuntime {
   private readonly connection: ClientConnection;
   /**
    * One GitMirrorManager per runtime — every slot gets the same instance.
-   * The manager's per-URL serial queue is what stops two agents on the same
-   * chat from racing on `git worktree add` against the shared bare mirror's
-   * `config`; one manager per slot would defeat the lock.
+   * The manager's per-clone-path serial queue is what stops two sessions of the
+   * same agent from racing a clone / update on the same source-repo checkout;
+   * one manager per slot would defeat the lock.
    */
   private readonly gitMirrorManager: GitMirrorManager;
   private readonly agents: AgentEntry[] = [];
@@ -234,23 +234,18 @@ export class ClientRuntime {
   }
 
   async start(): Promise<void> {
-    // Sweep orphan `hub-session-*` branches left over from previous runs
-    // before any slot can race a `git worktree add`. Sessions suspend on idle
-    // rather than terminate, so the cleanup path that normally runs
-    // `branch -D` (handler.shutdown → cleanupGitWorktrees → removeWorktree)
-    // fires only on explicit terminate/eviction. Without this sweep, every
-    // crash or `branch -D` failure leaks a `[branch "..."]` segment in the
-    // shared bare mirror's `config` forever.
+    // One-time cleanup of the legacy shared `<dataDir>/git-mirrors/` tree left
+    // by the pre-per-agent-source-repo bare-mirror model. Pure cache, no state.
     try {
-      const sweep = await this.gitMirrorManager.gcOrphanSessionBranches();
-      if (sweep.scanned > 0) {
+      const sweep = await this.gitMirrorManager.sweepLegacyMirrors();
+      if (sweep.removed.length > 0) {
         print.status(
           "[git-mirror]",
-          `swept orphan session branches — scanned=${sweep.scanned} deleted=${sweep.deleted} failed=${sweep.failed}`,
+          `removed legacy shared git-mirrors tree (${sweep.removed.length} entr${sweep.removed.length === 1 ? "y" : "ies"})`,
         );
       }
     } catch (err) {
-      print.status("⚠️", `git-mirror orphan sweep failed: ${err instanceof Error ? err.message : String(err)}`);
+      print.status("⚠️", `legacy git-mirrors sweep failed: ${err instanceof Error ? err.message : String(err)}`);
     }
 
     // Attach before connecting so the first welcome frame on a stale client

--- a/packages/client/src/__tests__/agent-briefing.test.ts
+++ b/packages/client/src/__tests__/agent-briefing.test.ts
@@ -323,9 +323,11 @@ describe("buildAgentBriefing — # Working in First Tree subsections", () => {
     expect(briefing).toContain(`\`${AGENT_HOME}/web\``);
     // Partial entry — only url should appear, ref/branch parens omitted.
     expect(briefing).not.toMatch(/url=git@github\.com:example\/web\.git,\s*ref=/);
-    // Pre-checked-out warning (issue #655) so the agent doesn't reuse the
-    // stale hub-session branch for new work.
-    expect(briefing).toContain("refreshed during this chat");
+    // Per-agent-source-repo: standalone clones are kept current each chat, but
+    // the agent must not edit them in place (that would block the auto-update).
+    expect(briefing).toContain("keeps each one current");
+    expect(briefing).toContain("latest default branch");
+    expect(briefing).toContain("**not** edit");
     expect(briefing).toContain("git fetch origin");
     expect(briefing).toContain("origin/main");
   });

--- a/packages/client/src/__tests__/agent-cwd-redesign.e2e.test.ts
+++ b/packages/client/src/__tests__/agent-cwd-redesign.e2e.test.ts
@@ -1,5 +1,5 @@
 import { execSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import type { AgentRuntimeConfig } from "@first-tree/shared";
@@ -199,21 +199,23 @@ describe("Phase E · agent cwd redesign — end-to-end invariants", () => {
     expect(existsSync(sentinelPath)).toBe(true);
     expect(existsSync(sourceRepoPath)).toBe(true);
 
-    // Capture repo `.git` pointer — if bootstrap is skipped on chat 2 the
-    // worktree's mirror linkage must NOT be recreated.
-    const repoGitDir1 = readFileSync(join(sourceRepoPath, ".git"), "utf-8");
+    // The standalone clone has a real `.git` DIRECTORY (not a worktree pointer
+    // file). Drop a marker INSIDE the clone — a re-clone on chat 2 would wipe
+    // the directory and take the marker with it; reuse must preserve it.
+    expect(statSync(join(sourceRepoPath, ".git")).isDirectory()).toBe(true);
+    const reuseMarker = join(sourceRepoPath, ".reuse-marker");
+    writeFileSync(reuseMarker, "chat-A");
     await h1.shutdown();
 
     // Second chat — different chatId, same workspaceRoot.
     const h2 = createClaudeCodeHandler({ workspaceRoot, agentConfigCache: cache, gitMirrorManager });
     await h2.start(makeMessage("chat-B", "msg-B1"), buildSessionCtx("chat-B"));
 
-    // The source repo path AND its underlying .git pointer must survive
-    // unchanged (sentinel-guarded bootstrap means createWorktree did NOT run
-    // a second time).
+    // The source repo AND the in-clone marker must survive (the clone was
+    // reused, not re-cloned a second time).
     expect(existsSync(sourceRepoPath)).toBe(true);
-    const repoGitDir2 = readFileSync(join(sourceRepoPath, ".git"), "utf-8");
-    expect(repoGitDir2).toBe(repoGitDir1);
+    expect(existsSync(reuseMarker)).toBe(true);
+    expect(readFileSync(reuseMarker, "utf-8")).toBe("chat-A");
     // Sentinel re-written is fine (idempotent) — the body's `completedAt`
     // refreshes — but the file must still exist.
     expect(existsSync(sentinelPath)).toBe(true);

--- a/packages/client/src/__tests__/agent-slot.test.ts
+++ b/packages/client/src/__tests__/agent-slot.test.ts
@@ -262,9 +262,10 @@ async function makeSlot(options?: {
     clientConnection: connection as unknown as ClientConnection,
     // AgentSlot passes this object through to SessionManager; these tests do not exercise git mirror behavior.
     gitMirrorManager: {
-      createWorktree: vi.fn(),
-      removeWorktree: vi.fn(),
-      gcOrphanSessionBranches: vi.fn(),
+      ensureSourceRepo: vi.fn(),
+      removeSourceRepo: vi.fn(),
+      sweepLegacyMirrors: vi.fn(),
+      legacyMirrorsRoot: "/tmp/fake-mirrors",
     } as unknown as GitMirrorManager,
   };
   return { slot: new AgentSlot(config), connection, sdk, state };

--- a/packages/client/src/__tests__/claude-code-inject-startup-race.test.ts
+++ b/packages/client/src/__tests__/claude-code-inject-startup-race.test.ts
@@ -86,6 +86,7 @@ vi.mock("../runtime/chat-context.js", () => ({
 
 vi.mock("../runtime/source-repos.js", () => ({
   prepareSourceRepos: vi.fn(async () => []),
+  releaseSourceReposForSession: vi.fn(),
 }));
 
 import { createClaudeCodeHandler } from "../handlers/claude-code.js";

--- a/packages/client/src/__tests__/git-mirror-manager.test.ts
+++ b/packages/client/src/__tests__/git-mirror-manager.test.ts
@@ -1,13 +1,11 @@
 import { type ChildProcess, execSync, spawn } from "node:child_process";
-import { createHash } from "node:crypto";
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   canonicalizeRepoUrl,
   createGitMirrorManager,
-  deriveSessionBranchName,
   GitMirrorAuthError,
   GitMirrorError,
   type GitMirrorManager,
@@ -15,7 +13,6 @@ import {
   GitMirrorWorktreeConflictError,
   hashUrl,
   httpsToSshBaseRewrite,
-  isConfigLockError,
   isLikelyAuthFailure,
   isLikelyHttpsAuthFailure,
   isLikelySshAuthFailure,
@@ -55,14 +52,6 @@ function makeManager(): GitMirrorManager {
     dataDir: mkdtempSync(join(tmpdir(), "ftt-mgr-")),
     cloneTimeoutMs: 30_000,
   });
-}
-
-function makeLogSpies() {
-  const spies = { warn: vi.fn(), info: vi.fn(), debug: vi.fn() };
-  return {
-    spies,
-    log: spies as unknown as Parameters<typeof createGitMirrorManager>[0]["log"],
-  };
 }
 
 function createFakeBareMirror(dataDir: string, url: string): string {
@@ -150,1056 +139,230 @@ async function withFakeLsofPid(pid: number, run: () => Promise<void>): Promise<v
   }
 }
 
-async function withFakePath(files: Record<string, string>, run: () => Promise<void>): Promise<void> {
-  const binDir = mkdtempSync(join(tmpdir(), "ftt-fake-path-"));
-  const oldPath = process.env.PATH;
-  for (const [name, body] of Object.entries(files)) {
-    writeFileSync(join(binDir, name), body, { encoding: "utf-8", mode: 0o755 });
-  }
-  process.env.PATH = binDir;
+// ── per-agent-source-repo: standalone clone lifecycle ─────────────────────
 
-  try {
-    await run();
-  } finally {
-    if (oldPath === undefined) {
-      delete process.env.PATH;
-    } else {
-      process.env.PATH = oldPath;
-    }
-    rmSync(binDir, { recursive: true, force: true });
-  }
+/** Build a throwaway bare upstream with two commits on `main`. */
+function seedBareRepo(branch = "main"): { url: string; tip: string; prev: string } {
+  const dir = mkdtempSync(join(tmpdir(), "ftt-fixt-"));
+  const seed = join(dir, "seed");
+  mkdirSync(seed, { recursive: true });
+  execSync(`git init -q -b ${branch}`, { cwd: seed });
+  execSync("git config user.email t@e.com && git config user.name t", { cwd: seed });
+  writeFileSync(join(seed, "README.md"), "v1");
+  execSync("git add . && git commit -q -m c1", { cwd: seed });
+  const prev = execSync("git rev-parse HEAD", { cwd: seed }).toString().trim();
+  writeFileSync(join(seed, "README.md"), "v2");
+  execSync("git add . && git commit -q -m c2", { cwd: seed });
+  const tip = execSync("git rev-parse HEAD", { cwd: seed }).toString().trim();
+  const bare = join(dir, "bare.git");
+  execSync(`git clone -q --bare ${seed} ${bare}`);
+  return { url: bare, tip, prev };
 }
 
-function tryGitIn(cwd: string, args: string): { ok: boolean; stdout: string } {
-  try {
-    return {
-      ok: true,
-      stdout: execSync(`git ${args}`, { cwd, stdio: ["ignore", "pipe", "pipe"] })
-        .toString()
-        .trim(),
-    };
-  } catch (err) {
-    return { ok: false, stdout: (err as { stdout?: Buffer }).stdout?.toString() ?? "" };
-  }
+/** Push one new commit to `main` of a bare upstream; returns the new tip sha. */
+function pushCommit(url: string, marker: string): string {
+  const tmp = mkdtempSync(join(tmpdir(), "ftt-push-"));
+  execSync(`git clone -q ${url} ${tmp}`);
+  execSync("git config user.email t@e.com && git config user.name t", { cwd: tmp });
+  writeFileSync(join(tmp, `n-${marker}.txt`), marker);
+  execSync(`git add . && git commit -q -m advance-${marker} && git push -q origin main`, { cwd: tmp });
+  const sha = execSync("git rev-parse HEAD", { cwd: tmp }).toString().trim();
+  rmSync(tmp, { recursive: true, force: true });
+  return sha;
 }
 
-describe("GitMirrorManager — lifecycle", () => {
-  it("ensureMirror bootstraps once and is idempotent", async () => {
-    const m = makeManager();
-    const first = await m.ensureMirror(fixtureUrl);
-    expect(first.cloned).toBe(true);
-    expect(existsSync(join(first.mirrorPath, "HEAD"))).toBe(true);
+function newDataDir(): string {
+  return mkdtempSync(join(tmpdir(), "ftt-srcrepo-"));
+}
 
-    const second = await m.ensureMirror(fixtureUrl);
-    expect(second.cloned).toBe(false);
-    expect(second.mirrorPath).toBe(first.mirrorPath);
+describe("GitMirrorManager — source repo lifecycle (per-agent clone)", () => {
+  it("ensureSourceRepo clones a fresh standalone repo on the default branch", async () => {
+    const m = makeManager();
+    const clonePath = join(newDataDir(), "repo");
+    const r = await m.ensureSourceRepo({ url: fixtureUrl, clonePath });
+    expect(r.outcome).toBe("cloned");
+    expect(r.branch).toBe("main");
+    // A real standalone clone has a `.git` directory, not a worktree `.git` file.
+    expect(statSync(join(clonePath, ".git")).isDirectory()).toBe(true);
+    expect(gitIn(clonePath, "rev-parse HEAD")).toBe(initialMainSha);
   });
 
-  it("ensureMirror logs a fresh mirror bootstrap when a logger is configured", async () => {
-    const { spies, log } = makeLogSpies();
-    const m = createGitMirrorManager({
-      dataDir: mkdtempSync(join(tmpdir(), "ftt-ensure-log-")),
-      cloneTimeoutMs: 30_000,
-      log,
-    });
+  it("is idempotent — re-running with no upstream change reports unchanged", async () => {
+    const m = makeManager();
+    const clonePath = join(newDataDir(), "repo");
+    await m.ensureSourceRepo({ url: fixtureUrl, clonePath });
+    const r2 = await m.ensureSourceRepo({ url: fixtureUrl, clonePath });
+    expect(r2.outcome).toBe("unchanged");
+    expect(gitIn(clonePath, "rev-parse HEAD")).toBe(initialMainSha);
+  });
 
-    await m.ensureMirror(fixtureUrl);
+  it("brings the checkout to the latest default branch when upstream advances", async () => {
+    const { url, tip } = seedBareRepo();
+    const m = makeManager();
+    const clonePath = join(newDataDir(), "repo");
+    const first = await m.ensureSourceRepo({ url, clonePath });
+    expect(first.headCommit).toBe(tip);
+    const newTip = pushCommit(url, "adv");
+    const r = await m.ensureSourceRepo({ url, clonePath });
+    expect(r.outcome).toBe("updated");
+    expect(r.headCommit).toBe(newTip);
+    expect(gitIn(clonePath, "rev-parse HEAD")).toBe(newTip);
+  });
 
-    expect(spies.debug).toHaveBeenCalledWith(
-      expect.objectContaining({ gitUrl: fixtureUrl, cloned: true }),
-      "mirror ensured",
+  it("leaves a dirty checkout at its current commit (skipped-dirty)", async () => {
+    const { url, tip } = seedBareRepo();
+    const m = makeManager();
+    const clonePath = join(newDataDir(), "repo");
+    await m.ensureSourceRepo({ url, clonePath });
+    writeFileSync(join(clonePath, "README.md"), "locally edited");
+    const newTip = pushCommit(url, "dirty");
+    expect(newTip).not.toBe(tip);
+    const r = await m.ensureSourceRepo({ url, clonePath });
+    expect(r.outcome).toBe("skipped-dirty");
+    expect(r.headCommit).toBe(tip);
+    expect(gitIn(clonePath, "rev-parse HEAD")).toBe(tip);
+  });
+
+  it("skips the update while another live session is using the checkout (skipped-in-use)", async () => {
+    const { url, tip } = seedBareRepo();
+    const m = makeManager();
+    const clonePath = join(newDataDir(), "repo");
+    await m.ensureSourceRepo({ url, clonePath });
+    pushCommit(url, "inuse");
+    const r = await m.ensureSourceRepo({ url, clonePath, activelyInUse: true });
+    expect(r.outcome).toBe("skipped-in-use");
+    expect(r.headCommit).toBe(tip);
+  });
+
+  it("checks out an explicit commit SHA detached (no branch chase)", async () => {
+    const { url, prev } = seedBareRepo();
+    const m = makeManager();
+    const clonePath = join(newDataDir(), "repo");
+    const r = await m.ensureSourceRepo({ url, ref: prev, clonePath });
+    expect(r.outcome).toBe("cloned");
+    expect(r.branch).toBeUndefined();
+    expect(gitIn(clonePath, "rev-parse HEAD")).toBe(prev);
+  });
+
+  it("reconciles origin url + default branch when the configured url repoints to a different repo", async () => {
+    const a = seedBareRepo("main");
+    // Repo B has a DIFFERENT default branch name — exercises the origin/HEAD
+    // refresh in reconcileOrigin (a plain fetch would leave origin/HEAD on
+    // "main", which doesn't exist in B).
+    const b = seedBareRepo("trunk");
+    const m = makeManager();
+    const clonePath = join(newDataDir(), "repo");
+    // First materialise against repo A.
+    const r1 = await m.ensureSourceRepo({ url: a.url, clonePath });
+    expect(r1.headCommit).toBe(a.tip);
+    expect(gitIn(clonePath, "config --get remote.origin.url")).toBe(a.url);
+    // Re-point the same checkout at repo B → origin url + origin/HEAD reconciled
+    // and the clean working tree moves to B's tip on B's default branch.
+    const r2 = await m.ensureSourceRepo({ url: b.url, clonePath });
+    expect(gitIn(clonePath, "config --get remote.origin.url")).toBe(b.url);
+    expect(gitIn(clonePath, "rev-parse HEAD")).toBe(b.tip);
+    expect(r2.branch).toBe("trunk");
+  });
+
+  it("preserves local commits ahead of upstream instead of resetting (skipped-local-commits)", async () => {
+    const { url, tip } = seedBareRepo();
+    const m = makeManager();
+    const clonePath = join(newDataDir(), "repo");
+    await m.ensureSourceRepo({ url, clonePath });
+    // Commit local work on top of main (clean working tree afterwards).
+    execSync("git config user.email t@e.com && git config user.name t", { cwd: clonePath });
+    writeFileSync(join(clonePath, "local.txt"), "agent work");
+    execSync("git add . && git commit -q -m local-work", { cwd: clonePath });
+    const localHead = gitIn(clonePath, "rev-parse HEAD");
+    // Upstream advances too — the destructive reset would orphan the local commit.
+    const upstream = pushCommit(url, "up");
+    const r = await m.ensureSourceRepo({ url, clonePath });
+    expect(r.outcome).toBe("skipped-local-commits");
+    expect(gitIn(clonePath, "rev-parse HEAD")).toBe(localHead); // NOT reset
+    expect(existsSync(join(clonePath, "local.txt"))).toBe(true);
+    expect(localHead).not.toBe(tip);
+    expect(upstream).not.toBe(localHead);
+  });
+
+  it("throws a conflict for a non-managed occupant with no managed root (preserves operator data)", async () => {
+    const m = makeManager();
+    const clonePath = join(newDataDir(), "repo");
+    mkdirSync(clonePath, { recursive: true });
+    writeFileSync(join(clonePath, "stray.txt"), "operator data");
+    await expect(m.ensureSourceRepo({ url: fixtureUrl, clonePath })).rejects.toBeInstanceOf(
+      GitMirrorWorktreeConflictError,
     );
+    expect(existsSync(join(clonePath, "stray.txt"))).toBe(true);
   });
 
-  it("ensureMirror configures the mirror with remote-tracking fetch refspec (no mirror flag)", async () => {
+  it("auto-recovers a non-managed occupant inside a managed root", async () => {
+    const dataDir = newDataDir();
+    const managedRoot = join(dataDir, "workspaces");
+    const m = createGitMirrorManager({ dataDir, cloneTimeoutMs: 30_000, hubManagedRoots: [managedRoot] });
+    const clonePath = join(managedRoot, "agent", "repo");
+    mkdirSync(clonePath, { recursive: true });
+    writeFileSync(join(clonePath, "stray.txt"), "leftover");
+    const r = await m.ensureSourceRepo({ url: fixtureUrl, clonePath });
+    expect(r.outcome).toBe("cloned");
+    expect(statSync(join(clonePath, ".git")).isDirectory()).toBe(true);
+    expect(existsSync(join(clonePath, "stray.txt"))).toBe(false);
+  });
+
+  it("migrates a legacy shared-mirror worktree (.git file) to a standalone clone", async () => {
+    const dataDir = newDataDir();
+    const managedRoot = join(dataDir, "workspaces");
+    const m = createGitMirrorManager({ dataDir, cloneTimeoutMs: 30_000, hubManagedRoots: [managedRoot] });
+    const clonePath = join(managedRoot, "agent", "repo");
+    mkdirSync(clonePath, { recursive: true });
+    // Simulate the old layout: a `.git` FILE pointing into git-mirrors.
+    writeFileSync(join(clonePath, ".git"), "gitdir: /some/old/git-mirrors/deadbeef/worktrees/x\n");
+    writeFileSync(join(clonePath, "README.md"), "stale worktree content");
+    const r = await m.ensureSourceRepo({ url: fixtureUrl, clonePath });
+    expect(r.outcome).toBe("migrated-recloned");
+    expect(statSync(join(clonePath, ".git")).isDirectory()).toBe(true);
+    expect(gitIn(clonePath, "rev-parse HEAD")).toBe(initialMainSha);
+  });
+
+  it("removeSourceRepo deletes the clone directory", async () => {
     const m = makeManager();
-    const { mirrorPath } = await m.ensureMirror(fixtureUrl);
-    expect(gitIn(mirrorPath, "config --get remote.origin.fetch")).toBe("+refs/heads/*:refs/remotes/origin/*");
-    expect(tryGitIn(mirrorPath, "config --get remote.origin.mirror").ok).toBe(false);
-    expect(gitIn(mirrorPath, "config --get remote.origin.url")).toBe(fixtureUrl);
+    const clonePath = join(newDataDir(), "repo");
+    await m.ensureSourceRepo({ url: fixtureUrl, clonePath });
+    await m.removeSourceRepo({ clonePath });
+    expect(existsSync(clonePath)).toBe(false);
   });
 
-  it("createWorktree creates a session branch, attached (not detached)", async () => {
-    const m = makeManager();
-    await m.ensureMirror(fixtureUrl);
-    const target = join(workRoot, "wt-attached");
-    const { worktreePath, headCommit, branchName } = await m.createWorktree({
-      url: fixtureUrl,
-      targetPath: target,
-      sessionKey: "chat-1",
-      agentName: "agent-x",
-    });
-    expect(worktreePath).toBe(target);
-    expect(headCommit).toMatch(/^[0-9a-f]{40}$/);
-    expect(branchName).toBe(deriveSessionBranchName("chat-1", "agent-x", fixtureUrl));
-    // HEAD should be a symbolic ref to the session branch (not detached).
-    expect(gitIn(target, "symbolic-ref HEAD")).toBe(`refs/heads/${branchName}`);
-    expect(existsSync(join(target, "README.md"))).toBe(true);
-  });
-
-  it("createWorktree accepts an explicit commit SHA ref", async () => {
-    const m = makeManager();
-    await m.ensureMirror(fixtureUrl);
-    const target = join(workRoot, "wt-explicit-sha");
-    const result = await m.createWorktree({
-      url: fixtureUrl,
-      ref: initialMainSha,
-      targetPath: target,
-      sessionKey: "chat-sha",
-      agentName: "agent-x",
-    });
-
-    expect(result.headCommit).toBe(initialMainSha);
-    expect(gitIn(target, "rev-parse HEAD")).toBe(initialMainSha);
-  });
-
-  it("throws when creating or fetching without a mirror", async () => {
-    const m = makeManager();
-    await expect(
-      m.createWorktree({
-        url: fixtureUrl,
-        targetPath: join(workRoot, "missing-mirror-wt"),
-        sessionKey: "missing",
-        agentName: "agent-x",
-      }),
-    ).rejects.toThrow(`Cannot create worktree — no mirror exists for "${fixtureUrl}"`);
-    await expect(m.fetchMirror(fixtureUrl)).rejects.toThrow(`Cannot fetch — no mirror exists for "${fixtureUrl}"`);
-  });
-
-  it("gcMirrors no-ops when the mirror root does not exist and skips non-bare entries", async () => {
-    const m = makeManager();
-    expect(await m.gcMirrors(new Set())).toEqual({ removed: [] });
-
-    mkdirSync(join(m.mirrorsRoot, "not-a-bare-repo"), { recursive: true });
-    expect(await m.gcMirrors(new Set())).toEqual({ removed: [] });
-    expect(existsSync(join(m.mirrorsRoot, "not-a-bare-repo"))).toBe(true);
-  });
-
-  it("different session keys produce disjoint branches on the same mirror", async () => {
-    const m = makeManager();
-    await m.ensureMirror(fixtureUrl);
-    const a = join(workRoot, "two-sess-a");
-    const b = join(workRoot, "two-sess-b");
-    const ra = await m.createWorktree({ url: fixtureUrl, targetPath: a, sessionKey: "chat-A", agentName: "agent-x" });
-    const rb = await m.createWorktree({ url: fixtureUrl, targetPath: b, sessionKey: "chat-B", agentName: "agent-x" });
-    expect(ra.branchName).not.toBe(rb.branchName);
-    writeFileSync(join(a, "scratch.txt"), "in A only");
-    expect(existsSync(join(a, "scratch.txt"))).toBe(true);
-    expect(existsSync(join(b, "scratch.txt"))).toBe(false);
-  });
-
-  it("reuses an already-attached worktree for the same session branch", async () => {
-    const m = makeManager();
-    await m.ensureMirror(fixtureUrl);
-    const target = join(workRoot, "reuse-same-session");
-    const first = await m.createWorktree({
-      url: fixtureUrl,
-      targetPath: target,
-      sessionKey: "reuse-chat",
-      agentName: "agent-x",
-    });
-    const second = await m.createWorktree({
-      url: fixtureUrl,
-      targetPath: target,
-      sessionKey: "reuse-chat",
-      agentName: "agent-x",
-    });
-
-    expect(second.branchName).toBe(first.branchName);
-    expect(second.headCommit).toBe(first.headCommit);
-  });
-
-  it("(sameSessionKey, differentAgents) produces disjoint branches — fixes group-chat collision", async () => {
-    // Reproduces the bug from docs/workspace-session-branch-collision-fix-design.md
-    // §1: in a group chat, multiple agents reach `createWorktree` with the
-    // SAME `sessionKey` (= chatId). Pre-fix the derived branch name was
-    // `(sessionKey, url)`-only, so the second agent's `git worktree add`
-    // failed with `fatal: '<branch>' is already used by worktree at ...`.
-    // Post-fix the branch name also folds in `agentName`, so peer agents
-    // get disjoint branches and both worktrees succeed.
-    const m = makeManager();
-    await m.ensureMirror(fixtureUrl);
-    const sharedChat = "shared-chat-1";
-    const targetA = join(workRoot, "peer-agent-a");
-    const targetB = join(workRoot, "peer-agent-b");
-    const ra = await m.createWorktree({
-      url: fixtureUrl,
-      targetPath: targetA,
-      sessionKey: sharedChat,
-      agentName: "architect",
-    });
-    const rb = await m.createWorktree({
-      url: fixtureUrl,
-      targetPath: targetB,
-      sessionKey: sharedChat,
-      agentName: "developer",
-    });
-    expect(ra.branchName).not.toBe(rb.branchName);
-    expect(ra.branchName).toBe(deriveSessionBranchName(sharedChat, "architect", fixtureUrl));
-    expect(rb.branchName).toBe(deriveSessionBranchName(sharedChat, "developer", fixtureUrl));
-    // Both worktrees materialise — pre-fix the second one would have thrown.
-    expect(existsSync(join(targetA, "README.md"))).toBe(true);
-    expect(existsSync(join(targetB, "README.md"))).toBe(true);
-  });
-
-  it("createWorktree rejects a non-First Tree occupant (D13)", async () => {
-    const m = makeManager();
-    await m.ensureMirror(fixtureUrl);
-    const occupied = join(workRoot, "occupied");
-    mkdirSync(occupied, { recursive: true });
-    writeFileSync(join(occupied, "user-data.txt"), "important");
-    await expect(
-      m.createWorktree({ url: fixtureUrl, targetPath: occupied, sessionKey: "chat-C", agentName: "agent-x" }),
-    ).rejects.toBeInstanceOf(GitMirrorWorktreeConflictError);
-    expect(existsSync(join(occupied, "user-data.txt"))).toBe(true);
-  });
-
-  it("createWorktree classifies file and special-file D13 occupants and logs conflicts", async () => {
-    const { spies, log } = makeLogSpies();
-    const dataDir = mkdtempSync(join(tmpdir(), "ftt-d13-kind-"));
-    const m = createGitMirrorManager({ dataDir, cloneTimeoutMs: 30_000, log });
-    await m.ensureMirror(fixtureUrl);
-
-    const occupiedFile = join(workRoot, "occupied-file");
-    writeFileSync(occupiedFile, "important");
-    await expect(
-      m.createWorktree({ url: fixtureUrl, targetPath: occupiedFile, sessionKey: "chat-file", agentName: "agent-x" }),
-    ).rejects.toThrow("occupied by file");
-
-    const occupiedGitRepo = join(workRoot, "occupied-git-repo");
-    mkdirSync(join(occupiedGitRepo, ".git"), { recursive: true });
-    await expect(
-      m.createWorktree({
-        url: fixtureUrl,
-        targetPath: occupiedGitRepo,
-        sessionKey: "chat-git-repo",
-        agentName: "agent-x",
-      }),
-    ).rejects.toThrow("occupied by git-repo");
-
-    const occupiedFifo = join(workRoot, "occupied-fifo");
-    execSync(`mkfifo "${occupiedFifo}"`);
+  it("removeSourceRepo kills a holder process inside a managed root before deleting", async () => {
+    const dataDir = newDataDir();
+    const managedRoot = join(dataDir, "workspaces");
+    const m = createGitMirrorManager({ dataDir, cloneTimeoutMs: 30_000, hubManagedRoots: [managedRoot] });
+    const clonePath = join(managedRoot, "agent", "repo");
+    await m.ensureSourceRepo({ url: fixtureUrl, clonePath });
+    const { pid, proc } = await spawnLongLivedChildInDir(clonePath);
     try {
-      await expect(
-        m.createWorktree({ url: fixtureUrl, targetPath: occupiedFifo, sessionKey: "chat-fifo", agentName: "agent-x" }),
-      ).rejects.toThrow("occupied by other");
-    } finally {
-      rmSync(occupiedFifo, { force: true });
-    }
-
-    expect(spies.warn).toHaveBeenCalledWith(
-      expect.objectContaining({ targetPath: occupiedFile, occupantKind: "file" }),
-      "worktree create conflict",
-    );
-    expect(spies.warn).toHaveBeenCalledWith(
-      expect.objectContaining({ targetPath: occupiedGitRepo, occupantKind: "git-repo" }),
-      "worktree create conflict",
-    );
-    expect(spies.warn).toHaveBeenCalledWith(
-      expect.objectContaining({ targetPath: occupiedFifo, occupantKind: "other" }),
-      "worktree create conflict",
-    );
-
-    rmSync(dataDir, { recursive: true, force: true });
-  });
-
-  it("createWorktree auto-recovers when a leftover sits in a First Tree-managed root", async () => {
-    // Reproduces the production incident: previous session left a directory
-    // tree at the worktree target (typical cause: orphaned vite/.vite dep
-    // cache rewritten by a daemonised dev server after the worktree was
-    // removed). Without self-heal the next session start throws D13. With
-    // `hubManagedRoots` configured, the manager rm -rf's the leftover and
-    // proceeds with `worktree add`.
-    const dataDir = mkdtempSync(join(tmpdir(), "ftt-heal-"));
-    const managedRoot = join(dataDir, "workspaces");
-    mkdirSync(managedRoot, { recursive: true });
-    const m = createGitMirrorManager({ dataDir, cloneTimeoutMs: 30_000, hubManagedRoots: [managedRoot] });
-    await m.ensureMirror(fixtureUrl);
-
-    const target = join(managedRoot, "agent-x", "chat-X", "agent-worktree");
-    // Recreate the production shape — packages/web/.vite/deps/_metadata.json,
-    // no `.git` marker.
-    mkdirSync(join(target, "packages", "web", ".vite", "deps"), { recursive: true });
-    writeFileSync(join(target, "packages", "web", ".vite", "deps", "_metadata.json"), "{}");
-
-    const created = await m.createWorktree({
-      url: fixtureUrl,
-      targetPath: target,
-      sessionKey: "chat-X",
-      agentName: "agent-x",
-    });
-    expect(created.worktreePath).toBe(target);
-    expect(existsSync(join(target, "README.md"))).toBe(true);
-    // The leftover cache dir is gone — the new checkout doesn't carry
-    // `packages/web/` because the fixture repo doesn't have one.
-    expect(existsSync(join(target, "packages"))).toBe(false);
-
-    rmSync(dataDir, { recursive: true, force: true });
-  });
-
-  it("createWorktree logs First Tree-managed leftover auto-recovery", async () => {
-    const { spies, log } = makeLogSpies();
-    const dataDir = mkdtempSync(join(tmpdir(), "ftt-heal-log-"));
-    const managedRoot = join(dataDir, "workspaces");
-    mkdirSync(managedRoot, { recursive: true });
-    const m = createGitMirrorManager({ dataDir, cloneTimeoutMs: 30_000, hubManagedRoots: [managedRoot], log });
-    await m.ensureMirror(fixtureUrl);
-
-    const target = join(managedRoot, "agent-x", "chat-log", "agent-worktree");
-    mkdirSync(target, { recursive: true });
-    writeFileSync(join(target, "leftover.txt"), "cache");
-
-    await m.createWorktree({ url: fixtureUrl, targetPath: target, sessionKey: "chat-log", agentName: "agent-x" });
-
-    expect(spies.warn).toHaveBeenCalledWith(
-      expect.objectContaining({ targetPath: target, occupantKind: "directory", hubManagedRoots: [managedRoot] }),
-      "worktree target occupied inside First Tree-managed root — auto-recovering (kill holders + rm -rf)",
-    );
-
-    rmSync(dataDir, { recursive: true, force: true });
-  });
-
-  it("createWorktree fails loudly when First Tree-managed leftover cleanup cannot remove the target", async () => {
-    if (process.getuid?.() === 0) return;
-    const dataDir = mkdtempSync(join(tmpdir(), "ftt-heal-rm-fail-"));
-    const managedRoot = join(dataDir, "workspaces");
-    const lockedParent = join(managedRoot, "locked");
-    const target = join(lockedParent, "agent-worktree");
-    mkdirSync(target, { recursive: true });
-    writeFileSync(join(target, "leftover.txt"), "cache");
-    const m = createGitMirrorManager({ dataDir, cloneTimeoutMs: 30_000, hubManagedRoots: [managedRoot] });
-    await m.ensureMirror(fixtureUrl);
-
-    chmodSync(lockedParent, 0o555);
-    try {
-      await expect(
-        m.createWorktree({ url: fixtureUrl, targetPath: target, sessionKey: "chat-rm-fail", agentName: "agent-x" }),
-      ).rejects.toThrow("cleanup failed after killing holders");
-    } finally {
-      chmodSync(lockedParent, 0o755);
-      rmSync(dataDir, { recursive: true, force: true });
-    }
-  });
-
-  it("createWorktree still throws D13 for occupants outside every managed root", async () => {
-    // Belt-and-braces for the safety guard: even with `hubManagedRoots`
-    // configured, targets OUTSIDE every managed root must still fail loud
-    // rather than silently delete operator data.
-    const dataDir = mkdtempSync(join(tmpdir(), "ftt-heal-guard-"));
-    const managedRoot = join(dataDir, "workspaces");
-    mkdirSync(managedRoot, { recursive: true });
-    const m = createGitMirrorManager({ dataDir, cloneTimeoutMs: 30_000, hubManagedRoots: [managedRoot] });
-    await m.ensureMirror(fixtureUrl);
-
-    // Target lives outside `managedRoot` — operator-supplied path.
-    const outside = join(workRoot, "operator-dir");
-    mkdirSync(outside, { recursive: true });
-    writeFileSync(join(outside, "user-data.txt"), "important");
-    await expect(
-      m.createWorktree({ url: fixtureUrl, targetPath: outside, sessionKey: "chat-O", agentName: "agent-x" }),
-    ).rejects.toBeInstanceOf(GitMirrorWorktreeConflictError);
-    expect(existsSync(join(outside, "user-data.txt"))).toBe(true);
-
-    rmSync(dataDir, { recursive: true, force: true });
-  });
-
-  it("createWorktree kills a process holding the leftover before recovery", async () => {
-    // Simulates the actual orphan: a long-running child (e.g. vite) whose cwd
-    // is the leftover dir. Without the pre-rm kill the rm -rf races against
-    // the child's writes and the worktree add can find the dir non-empty
-    // again. After the fix, the child gets SIGTERM'd, the rm sticks, and
-    // `git worktree add` succeeds.
-    const dataDir = mkdtempSync(join(tmpdir(), "ftt-heal-kill-"));
-    const managedRoot = join(dataDir, "workspaces");
-    mkdirSync(managedRoot, { recursive: true });
-    const m = createGitMirrorManager({ dataDir, cloneTimeoutMs: 30_000, hubManagedRoots: [managedRoot] });
-    await m.ensureMirror(fixtureUrl);
-
-    const target = join(managedRoot, "agent-x", "chat-Y", "agent-worktree");
-    mkdirSync(target, { recursive: true });
-    writeFileSync(join(target, "leftover.txt"), "cache");
-
-    // Spawn an orphan with cwd inside the leftover. Detach so it survives
-    // its parent; the test process kills it via the manager's recovery path.
-    const child = await spawnLongLivedChildInDir(target);
-    expect(processIsAlive(child.pid)).toBe(true);
-
-    try {
-      await withFakeLsofPid(child.pid, async () => {
-        const created = await m.createWorktree({
-          url: fixtureUrl,
-          targetPath: target,
-          sessionKey: "chat-Y",
-          agentName: "agent-x",
-        });
-        expect(created.worktreePath).toBe(target);
+      await withFakeLsofPid(pid, async () => {
+        await m.removeSourceRepo({ clonePath });
       });
-      expect(existsSync(join(target, "README.md"))).toBe(true);
-      expect(existsSync(join(target, "leftover.txt"))).toBe(false);
-      expect(await waitForProcessExit(child.proc, child.pid)).toBe(true);
+      expect(await waitForProcessExit(proc, pid)).toBe(true);
+      expect(existsSync(clonePath)).toBe(false);
     } finally {
-      // Belt-and-braces in case the recovery path didn't kill it.
-      try {
-        process.kill(child.pid, "SIGKILL");
-      } catch {
-        // ignore — already reaped
-      }
-      rmSync(dataDir, { recursive: true, force: true });
+      if (processIsAlive(pid)) process.kill(pid, "SIGKILL");
     }
   });
 
-  it("removeWorktree kills processes whose cwd is inside the worktree before deleting", async () => {
-    // The other half of the orphan story: when a session ends with a child
-    // (vite / esbuild / test watcher) still holding the worktree as cwd,
-    // `git worktree remove --force` may succeed but the child immediately
-    // recreates files under the deleted path. We pre-kill so the next session
-    // start sees an empty parent and the `worktree add` is clean.
-    const dataDir = mkdtempSync(join(tmpdir(), "ftt-rm-kill-"));
-    const managedRoot = join(dataDir, "workspaces");
-    mkdirSync(managedRoot, { recursive: true });
-    const m = createGitMirrorManager({ dataDir, cloneTimeoutMs: 30_000, hubManagedRoots: [managedRoot] });
-    await m.ensureMirror(fixtureUrl);
-    const target = join(managedRoot, "agent-x", "chat-Z", "agent-worktree");
-    const { branchName } = await m.createWorktree({
-      url: fixtureUrl,
-      targetPath: target,
-      sessionKey: "chat-Z",
-      agentName: "agent-x",
-    });
-    const child = await spawnLongLivedChildInDir(target);
-    expect(processIsAlive(child.pid)).toBe(true);
-
-    try {
-      await withFakeLsofPid(child.pid, async () => {
-        await m.removeWorktree({ url: fixtureUrl, path: target, branchName });
-      });
-      expect(existsSync(target)).toBe(false);
-      expect(await waitForProcessExit(child.proc, child.pid)).toBe(true);
-    } finally {
-      try {
-        process.kill(child.pid, "SIGKILL");
-      } catch {
-        // ignore — already reaped
-      }
-      rmSync(dataDir, { recursive: true, force: true });
-    }
-  });
-
-  it("removeWorktree deletes both the worktree and the session branch", async () => {
-    const m = makeManager();
-    const { mirrorPath } = await m.ensureMirror(fixtureUrl);
-    const target = join(workRoot, "remove-target");
-    const { branchName } = await m.createWorktree({
-      url: fixtureUrl,
-      targetPath: target,
-      sessionKey: "chat-rm",
-      agentName: "agent-x",
-    });
-    expect(tryGitIn(mirrorPath, `rev-parse --verify --quiet refs/heads/${branchName}`).ok).toBe(true);
-    await m.removeWorktree({ url: fixtureUrl, path: target, branchName });
-    expect(existsSync(target)).toBe(false);
-    expect(tryGitIn(mirrorPath, `rev-parse --verify --quiet refs/heads/${branchName}`).ok).toBe(false);
-  });
-
-  it("removeWorktree removes orphan directories when the mirror is already gone", async () => {
-    const m = makeManager();
-    const orphan = join(workRoot, "orphan-no-mirror");
-    mkdirSync(orphan, { recursive: true });
-    writeFileSync(join(orphan, "leftover.txt"), "orphan");
-
-    await m.removeWorktree({ url: fixtureUrl, path: orphan, branchName: "hub-session-orphan" });
-
-    expect(existsSync(orphan)).toBe(false);
-  });
-
-  it("removeWorktree prunes stale bookkeeping when the path is already gone", async () => {
-    const m = makeManager();
-    await m.ensureMirror(fixtureUrl);
-    const target = join(workRoot, "remove-already-gone");
-    const { branchName } = await m.createWorktree({
-      url: fixtureUrl,
-      targetPath: target,
-      sessionKey: "remove-gone",
-      agentName: "agent-x",
-    });
-    rmSync(target, { recursive: true, force: true });
-
-    await m.removeWorktree({ url: fixtureUrl, path: target, branchName });
-
-    expect(existsSync(target)).toBe(false);
-  });
-
-  it("removeWorktree removes an orphan dir when git worktree remove cannot", async () => {
-    const dataDir = mkdtempSync(join(tmpdir(), "ftt-remove-orphan-"));
+  it("sweepLegacyMirrors removes the legacy shared git-mirrors tree", async () => {
+    const dataDir = newDataDir();
     const m = createGitMirrorManager({ dataDir, cloneTimeoutMs: 30_000 });
-    createFakeBareMirror(dataDir, fixtureUrl);
-    const target = join(workRoot, "remove-orphan-dir");
-    mkdirSync(target, { recursive: true });
-    writeFileSync(join(target, "orphan.txt"), "leftover");
-
-    await withFakePath(
-      {
-        git: `#!/bin/sh
-case "$*" in
-  *"worktree remove"*) exit 1 ;;
-  *"rev-parse --verify"*) exit 1 ;;
-  *) exit 0 ;;
-esac
-`,
-      },
-      async () => {
-        await m.removeWorktree({ url: fixtureUrl, path: target, branchName: "hub-session-orphan" });
-      },
-    );
-
-    expect(existsSync(target)).toBe(false);
-    rmSync(dataDir, { recursive: true, force: true });
+    const fake = createFakeBareMirror(dataDir, fixtureUrl);
+    expect(existsSync(fake)).toBe(true);
+    const swept = await m.sweepLegacyMirrors();
+    expect(swept.removed.length).toBeGreaterThan(0);
+    expect(existsSync(m.legacyMirrorsRoot)).toBe(false);
   });
 
-  it("removeWorktree logs when branch deletion fails", async () => {
-    const dataDir = mkdtempSync(join(tmpdir(), "ftt-remove-branch-fail-"));
-    const log = { warn: vi.fn(), info: vi.fn(), debug: vi.fn() };
-    const m = createGitMirrorManager({
-      dataDir,
-      cloneTimeoutMs: 30_000,
-      log: log as unknown as Parameters<typeof createGitMirrorManager>[0]["log"],
-    });
-    createFakeBareMirror(dataDir, fixtureUrl);
-
-    await withFakePath(
-      {
-        git: `#!/bin/sh
-case "$*" in
-  *"rev-parse --verify"*) exit 0 ;;
-  *"branch -D"*) exit 1 ;;
-  *) exit 0 ;;
-esac
-`,
-      },
-      async () => {
-        await m.removeWorktree({
-          url: fixtureUrl,
-          path: join(workRoot, "missing-remove-path"),
-          branchName: "hub-session-leak",
-        });
-      },
-    );
-
-    expect(log.warn).toHaveBeenCalledWith(
-      expect.objectContaining({ branchName: "hub-session-leak" }),
-      "branch -D failed during removeWorktree — config segment will leak until next gcOrphanSessionBranches",
-    );
-    rmSync(dataDir, { recursive: true, force: true });
-  });
-
-  it("gcMirrors removes mirrors not in the referenced set", async () => {
+  it("sweepLegacyMirrors is a no-op when there is no legacy tree", async () => {
     const m = makeManager();
-    await m.ensureMirror(fixtureUrl);
-    expect(readdirSync(m.mirrorsRoot).length).toBe(1);
-    const { removed } = await m.gcMirrors(new Set());
-    expect(removed).toHaveLength(1);
-    expect(readdirSync(m.mirrorsRoot).length).toBe(0);
-  });
-
-  it("gcMirrors keeps mirrors still referenced", async () => {
-    const m = makeManager();
-    await m.ensureMirror(fixtureUrl);
-    const { removed } = await m.gcMirrors(new Set([fixtureUrl]));
-    expect(removed).toEqual([]);
-  });
-
-  it("gcOrphanSessionBranches removes hub-session branches that no live worktree holds", async () => {
-    const m = makeManager();
-    const { mirrorPath } = await m.ensureMirror(fixtureUrl);
-    // One live worktree — its branch must survive the sweep.
-    const liveTarget = join(workRoot, "gc-live");
-    const { branchName: liveBranch } = await m.createWorktree({
-      url: fixtureUrl,
-      targetPath: liveTarget,
-      sessionKey: "gc-live",
-      agentName: "agent-x",
-    });
-    // Two orphans: a `hub-session-` branch with no worktree, and an unrelated
-    // local branch the sweep must NOT touch (only `hub-session-*` is in scope).
-    const baseSha = gitIn(mirrorPath, `rev-parse refs/heads/${liveBranch}`);
-    execSync(`git branch hub-session-orphan-aaaaaaaa ${baseSha}`, { cwd: mirrorPath });
-    execSync(`git branch unrelated-feature ${baseSha}`, { cwd: mirrorPath });
-    expect(tryGitIn(mirrorPath, "rev-parse --verify --quiet refs/heads/hub-session-orphan-aaaaaaaa").ok).toBe(true);
-
-    const result = await m.gcOrphanSessionBranches();
-    expect(result.deleted).toBe(1);
-    expect(result.failed).toBe(0);
-    expect(tryGitIn(mirrorPath, "rev-parse --verify --quiet refs/heads/hub-session-orphan-aaaaaaaa").ok).toBe(false);
-    // Live worktree's branch is untouched.
-    expect(tryGitIn(mirrorPath, `rev-parse --verify --quiet refs/heads/${liveBranch}`).ok).toBe(true);
-    // Non-session branch is out of scope and stays.
-    expect(tryGitIn(mirrorPath, "rev-parse --verify --quiet refs/heads/unrelated-feature").ok).toBe(true);
-  });
-
-  it("gcOrphanSessionBranches is a no-op when the mirrors root is empty", async () => {
-    const m = makeManager();
-    const result = await m.gcOrphanSessionBranches();
-    expect(result).toEqual({ scanned: 0, deleted: 0, failed: 0 });
-  });
-
-  it("gcOrphanSessionBranches skips non-bare entries under the mirrors root", async () => {
-    const m = makeManager();
-    mkdirSync(join(m.mirrorsRoot, "not-bare"), { recursive: true });
-
-    const result = await m.gcOrphanSessionBranches();
-
-    expect(result).toEqual({ scanned: 0, deleted: 0, failed: 0 });
-  });
-
-  it("gcOrphanSessionBranches skips a mirror when worktree listing fails", async () => {
-    const dataDir = mkdtempSync(join(tmpdir(), "ftt-gc-worktree-list-fail-"));
-    const { spies, log } = makeLogSpies();
-    const m = createGitMirrorManager({ dataDir, cloneTimeoutMs: 30_000, log });
-    createFakeBareMirror(dataDir, fixtureUrl);
-
-    await withFakePath(
-      {
-        git: `#!/bin/sh
-case "$*" in
-  *"worktree list"*) exit 2 ;;
-  *) exit 0 ;;
-esac
-`,
-      },
-      async () => {
-        await expect(m.gcOrphanSessionBranches()).resolves.toEqual({ scanned: 0, deleted: 0, failed: 0 });
-      },
-    );
-
-    expect(spies.warn).toHaveBeenCalledWith(
-      expect.objectContaining({ mirror: hashUrl(fixtureUrl) }),
-      "gcOrphanSessionBranches: worktree list failed — skipping mirror",
-    );
-    rmSync(dataDir, { recursive: true, force: true });
-  });
-
-  it("gcOrphanSessionBranches skips a mirror when branch listing fails", async () => {
-    const dataDir = mkdtempSync(join(tmpdir(), "ftt-gc-branch-list-fail-"));
-    const { spies, log } = makeLogSpies();
-    const m = createGitMirrorManager({ dataDir, cloneTimeoutMs: 30_000, log });
-    createFakeBareMirror(dataDir, fixtureUrl);
-
-    await withFakePath(
-      {
-        git: `#!/bin/sh
-case "$*" in
-  *"worktree list"*) exit 0 ;;
-  *"for-each-ref"*) exit 2 ;;
-  *) exit 0 ;;
-esac
-`,
-      },
-      async () => {
-        await expect(m.gcOrphanSessionBranches()).resolves.toEqual({ scanned: 0, deleted: 0, failed: 0 });
-      },
-    );
-
-    expect(spies.warn).toHaveBeenCalledWith(
-      expect.objectContaining({ mirror: hashUrl(fixtureUrl) }),
-      "gcOrphanSessionBranches: branch listing failed — skipping mirror",
-    );
-    rmSync(dataDir, { recursive: true, force: true });
-  });
-
-  it("gcOrphanSessionBranches counts a failed orphan branch deletion", async () => {
-    const dataDir = mkdtempSync(join(tmpdir(), "ftt-gc-delete-fail-"));
-    const { spies, log } = makeLogSpies();
-    const m = createGitMirrorManager({ dataDir, cloneTimeoutMs: 30_000, log });
-    createFakeBareMirror(dataDir, fixtureUrl);
-
-    await withFakePath(
-      {
-        git: `#!/bin/sh
-case "$*" in
-  *"worktree list"*) exit 0 ;;
-  *"for-each-ref"*) echo "hub-session-orphan-aaaaaaaa"; exit 0 ;;
-  *"branch -D"*) exit 1 ;;
-  *) exit 0 ;;
-esac
-`,
-      },
-      async () => {
-        await expect(m.gcOrphanSessionBranches()).resolves.toEqual({ scanned: 1, deleted: 0, failed: 1 });
-      },
-    );
-
-    expect(spies.warn).toHaveBeenCalledWith(
-      expect.objectContaining({ mirror: hashUrl(fixtureUrl), branch: "hub-session-orphan-aaaaaaaa" }),
-      "gcOrphanSessionBranches: branch -D failed",
-    );
-    expect(spies.info).toHaveBeenCalledWith(
-      { scanned: 1, deleted: 0, failed: 1 },
-      "gcOrphanSessionBranches: swept orphan session branches",
-    );
-    rmSync(dataDir, { recursive: true, force: true });
-  });
-});
-
-describe("GitMirrorManager — session isolation regressions", () => {
-  it("incident 1: fetch does not mutate session branches when upstream advances", async () => {
-    // Reproduce the original data-loss scenario: session branch is attached in
-    // a worktree, upstream force-moves main to a new commit, fetch runs — the
-    // session branch and the worktree's HEAD must survive untouched.
-    const m = makeManager();
-    const { mirrorPath } = await m.ensureMirror(fixtureUrl);
-    const target = join(workRoot, "incident-1");
-    const { branchName, headCommit } = await m.createWorktree({
-      url: fixtureUrl,
-      targetPath: target,
-      sessionKey: "incident-1",
-      agentName: "agent-x",
-    });
-
-    // Advance upstream by one commit (plain commit, not force-push — good enough
-    // because the old mirror refspec would still force-overwrite local main).
-    const upstreamClone = mkdtempSync(join(tmpdir(), "ftt-upstream-"));
-    execSync(`git clone -q ${fixtureUrl} ${upstreamClone}`);
-    execSync("git config user.email test@example.com && git config user.name test", { cwd: upstreamClone });
-    writeFileSync(join(upstreamClone, "README.md"), "advanced");
-    execSync("git add . && git commit -q -m advance", { cwd: upstreamClone });
-    execSync("git push -q origin main", { cwd: upstreamClone });
-
-    await m.fetchMirror(fixtureUrl);
-
-    expect(gitIn(mirrorPath, `rev-parse refs/heads/${branchName}`)).toBe(headCommit);
-    expect(gitIn(target, "rev-parse HEAD")).toBe(headCommit);
-    expect(gitIn(mirrorPath, "rev-parse refs/remotes/origin/main")).not.toBe(headCommit);
-
-    // Restore fixture upstream to its original HEAD so later tests see the
-    // expected baseline state.
-    execSync(`git reset --hard ${initialMainSha}`, { cwd: upstreamClone });
-    execSync("git push -q --force origin main", { cwd: upstreamClone });
-    rmSync(upstreamClone, { recursive: true, force: true });
-  });
-
-  it("incident 2: fetch --prune does not remove local heads that never had an upstream counterpart", async () => {
-    const m = makeManager();
-    const { mirrorPath } = await m.ensureMirror(fixtureUrl);
-    // Create a local branch directly in the mirror that upstream never had.
-    const localOnlySha = gitIn(mirrorPath, "rev-parse refs/remotes/origin/main");
-    execSync(`git branch local-only ${localOnlySha}`, { cwd: mirrorPath });
-    expect(tryGitIn(mirrorPath, "rev-parse --verify --quiet refs/heads/local-only").ok).toBe(true);
-
-    await m.fetchMirror(fixtureUrl);
-
-    expect(tryGitIn(mirrorPath, "rev-parse --verify --quiet refs/heads/local-only").ok).toBe(true);
-  });
-
-  it("incident 3: fetchMirror succeeds even when multiple session branches are checked out", async () => {
-    const m = makeManager();
-    await m.ensureMirror(fixtureUrl);
-    const a = join(workRoot, "incident-3-a");
-    const b = join(workRoot, "incident-3-b");
-    await m.createWorktree({ url: fixtureUrl, targetPath: a, sessionKey: "incident-3-A", agentName: "agent-x" });
-    await m.createWorktree({ url: fixtureUrl, targetPath: b, sessionKey: "incident-3-B", agentName: "agent-x" });
-    await expect(m.fetchMirror(fixtureUrl)).resolves.toBeDefined();
-  });
-});
-
-describe("GitMirrorManager — migration from legacy mirror config", () => {
-  it("ensureMirror rewrites legacy --mirror config to the safe refspec", async () => {
-    const tmpData = mkdtempSync(join(tmpdir(), "ftt-legacy-"));
-    const m = createGitMirrorManager({ dataDir: tmpData, cloneTimeoutMs: 30_000 });
-
-    // Hand-roll a legacy mirror: `git clone --mirror` sets
-    // `fetch = +refs/*:refs/*` and `mirror = true`.
-    const legacyPath = join(tmpData, "git-mirrors", createHash("sha256").update(fixtureUrl).digest("hex").slice(0, 32));
-    mkdirSync(join(tmpData, "git-mirrors"), { recursive: true });
-    execSync(`git clone -q --mirror ${fixtureUrl} ${legacyPath}`);
-    expect(gitIn(legacyPath, "config --get remote.origin.mirror")).toBe("true");
-
-    // Run ensureMirror — should rewrite the config in-place.
-    const result = await m.ensureMirror(fixtureUrl);
-    expect(result.cloned).toBe(false);
-    expect(gitIn(legacyPath, "config --get remote.origin.fetch")).toBe("+refs/heads/*:refs/remotes/origin/*");
-    expect(tryGitIn(legacyPath, "config --get remote.origin.mirror").ok).toBe(false);
-
-    // Second call is a no-op (idempotent).
-    await m.ensureMirror(fixtureUrl);
-    expect(gitIn(legacyPath, "config --get remote.origin.fetch")).toBe("+refs/heads/*:refs/remotes/origin/*");
-  });
-});
-
-describe("GitMirrorManager — git process failures", () => {
-  it("classifies config lock errors only for GitMirrorError instances", () => {
-    expect(isConfigLockError(new Error("could not lock config file"))).toBe(false);
-    expect(isConfigLockError(new GitMirrorError("error: could not lock config file config.lock"))).toBe(true);
-  });
-
-  it("surfaces git subprocess timeouts and cleans the partial mirror", async () => {
-    await withFakePath(
-      {
-        git: "#!/bin/sh\n/bin/sleep 5\n",
-      },
-      async () => {
-        const dataDir = mkdtempSync(join(tmpdir(), "ftt-timeout-"));
-        const { spies, log } = makeLogSpies();
-        const m = createGitMirrorManager({ dataDir, cloneTimeoutMs: 5, log });
-
-        await expect(m.ensureMirror(fixtureUrl)).rejects.toBeInstanceOf(GitMirrorTimeoutError);
-        expect(existsSync(m.mirrorsRoot)).toBe(true);
-        expect(readdirSync(m.mirrorsRoot)).toHaveLength(0);
-        expect(spies.warn).toHaveBeenCalledWith(
-          expect.objectContaining({ gitUrl: fixtureUrl, timeoutMs: 5, elapsedMs: 5 }),
-          "mirror clone timeout",
-        );
-      },
-    );
-  });
-
-  it("surfaces git spawn errors when git is not on PATH", async () => {
-    await withFakePath({}, async () => {
-      const m = createGitMirrorManager({ dataDir: mkdtempSync(join(tmpdir(), "ftt-no-git-")), cloneTimeoutMs: 30_000 });
-      await expect(m.ensureMirror(fixtureUrl)).rejects.toMatchObject({ code: "ENOENT" });
-    });
-  });
-
-  it("uses the clone timeout from FIRST_TREE_GIT_CLONE_TIMEOUT_MS when no option is provided", async () => {
-    const oldTimeout = process.env.FIRST_TREE_GIT_CLONE_TIMEOUT_MS;
-    process.env.FIRST_TREE_GIT_CLONE_TIMEOUT_MS = "5";
-    try {
-      await withFakePath(
-        {
-          git: "#!/bin/sh\n/bin/sleep 5\n",
-        },
-        async () => {
-          const m = createGitMirrorManager({ dataDir: mkdtempSync(join(tmpdir(), "ftt-env-timeout-")) });
-          await expect(m.ensureMirror(fixtureUrl)).rejects.toBeInstanceOf(GitMirrorTimeoutError);
-        },
-      );
-    } finally {
-      if (oldTimeout === undefined) {
-        delete process.env.FIRST_TREE_GIT_CLONE_TIMEOUT_MS;
-      } else {
-        process.env.FIRST_TREE_GIT_CLONE_TIMEOUT_MS = oldTimeout;
-      }
-    }
-  });
-
-  it("fetchMirror logs auth, timeout, and generic git failure categories", async () => {
-    const authUrl = "https://github.com/acme/auth-fail.git";
-    const authDataDir = mkdtempSync(join(tmpdir(), "ftt-fetch-auth-log-"));
-    const authLog = makeLogSpies();
-    const authManager = createGitMirrorManager({ dataDir: authDataDir, cloneTimeoutMs: 30_000, log: authLog.log });
-    createFakeBareMirror(authDataDir, authUrl);
-    await withFakePath(
-      {
-        git: `#!/bin/sh
-case "$*" in
-  *insteadOf*) echo "git@github.com: Permission denied (publickey)." >&2; exit 128 ;;
-  *"fetch --prune origin"*) echo "fatal: Authentication failed for 'https://github.com/acme/auth-fail.git/'" >&2; exit 128 ;;
-  *) exit 0 ;;
-esac
-`,
-      },
-      async () => {
-        await expect(authManager.fetchMirror(authUrl)).rejects.toBeInstanceOf(GitMirrorAuthError);
-      },
-    );
-    expect(authLog.spies.warn).toHaveBeenCalledWith(
-      expect.objectContaining({ gitUrl: authUrl, errorCode: "auth-failed" }),
-      "mirror fetch failed",
-    );
-
-    const timeoutUrl = "https://github.com/acme/timeout.git";
-    const timeoutDataDir = mkdtempSync(join(tmpdir(), "ftt-fetch-timeout-log-"));
-    const timeoutLog = makeLogSpies();
-    const timeoutManager = createGitMirrorManager({ dataDir: timeoutDataDir, cloneTimeoutMs: 5, log: timeoutLog.log });
-    createFakeBareMirror(timeoutDataDir, timeoutUrl);
-    await withFakePath(
-      {
-        git: "#!/bin/sh\n/bin/sleep 5\n",
-      },
-      async () => {
-        await expect(timeoutManager.fetchMirror(timeoutUrl)).rejects.toBeInstanceOf(GitMirrorTimeoutError);
-      },
-    );
-    expect(timeoutLog.spies.warn).toHaveBeenCalledWith(
-      expect.objectContaining({ gitUrl: timeoutUrl, errorCode: "timeout" }),
-      "mirror fetch failed",
-    );
-
-    const gitFailUrl = "https://github.com/acme/git-fail.git";
-    const gitFailDataDir = mkdtempSync(join(tmpdir(), "ftt-fetch-git-log-"));
-    const gitFailLog = makeLogSpies();
-    const gitFailManager = createGitMirrorManager({
-      dataDir: gitFailDataDir,
-      cloneTimeoutMs: 30_000,
-      log: gitFailLog.log,
-    });
-    createFakeBareMirror(gitFailDataDir, gitFailUrl);
-    await withFakePath(
-      {
-        git: '#!/bin/sh\necho "fatal: repository not found" >&2\nexit 128\n',
-      },
-      async () => {
-        await expect(gitFailManager.fetchMirror(gitFailUrl)).rejects.toBeInstanceOf(GitMirrorError);
-      },
-    );
-    expect(gitFailLog.spies.warn).toHaveBeenCalledWith(
-      expect.objectContaining({ gitUrl: gitFailUrl, errorCode: "git-failed" }),
-      "mirror fetch failed",
-    );
-
-    const spawnFailUrl = "https://github.com/acme/spawn-fail.git";
-    const spawnFailDataDir = mkdtempSync(join(tmpdir(), "ftt-fetch-spawn-log-"));
-    const spawnFailLog = makeLogSpies();
-    const spawnFailManager = createGitMirrorManager({
-      dataDir: spawnFailDataDir,
-      cloneTimeoutMs: 30_000,
-      log: spawnFailLog.log,
-    });
-    createFakeBareMirror(spawnFailDataDir, spawnFailUrl);
-    await withFakePath({}, async () => {
-      await expect(spawnFailManager.fetchMirror(spawnFailUrl)).rejects.toMatchObject({ code: "ENOENT" });
-    });
-    expect(spawnFailLog.spies.warn).toHaveBeenCalledWith(
-      expect.objectContaining({ gitUrl: spawnFailUrl, errorCode: "unknown" }),
-      "mirror fetch failed",
-    );
-
-    rmSync(authDataDir, { recursive: true, force: true });
-    rmSync(timeoutDataDir, { recursive: true, force: true });
-    rmSync(gitFailDataDir, { recursive: true, force: true });
-    rmSync(spawnFailDataDir, { recursive: true, force: true });
-  });
-});
-
-describe("GitMirrorManager — crash recovery", () => {
-  it("reattaches to an existing session branch when the worktree directory is missing", async () => {
-    // Simulate a crashed session: branch exists in the mirror, path has been
-    // manually cleaned up. Next session start must attach the branch to a new
-    // worktree path rather than failing because the branch already exists.
-    const m = makeManager();
-    const { mirrorPath } = await m.ensureMirror(fixtureUrl);
-    const firstTarget = join(workRoot, "crash-first");
-    const { branchName, headCommit } = await m.createWorktree({
-      url: fixtureUrl,
-      targetPath: firstTarget,
-      sessionKey: "crashy",
-      agentName: "agent-x",
-    });
-    // User or an external process removed the worktree dir without running
-    // `git worktree remove`. Git marks it prunable on next access.
-    rmSync(firstTarget, { recursive: true, force: true });
-    execSync("git worktree prune", { cwd: mirrorPath });
-    expect(tryGitIn(mirrorPath, `rev-parse --verify --quiet refs/heads/${branchName}`).ok).toBe(true);
-
-    const reopened = await m.createWorktree({
-      url: fixtureUrl,
-      targetPath: firstTarget,
-      sessionKey: "crashy",
-      agentName: "agent-x",
-    });
-    expect(reopened.branchName).toBe(branchName);
-    expect(reopened.headCommit).toBe(headCommit);
-    expect(existsSync(join(firstTarget, "README.md"))).toBe(true);
-  });
-
-  it("self-heals when origin/HEAD is missing on createWorktree without an explicit ref", async () => {
-    // Reproduces the production failure mode: a mirror created before the
-    // bidirectional-fallback fix had `set-head --auto` run over a protocol
-    // whose creds were missing — `gitOk` swallowed the failure and left
-    // `refs/remotes/origin/HEAD` unset. Subsequent `createWorktree({ ref:
-    // undefined })` (the default-branch path) blew up in `resolveBase`.
-    //
-    // Now `resolveBase` self-heals: if origin/HEAD is missing, it retries
-    // `set-head --auto` (via the fallback-aware path) before giving up.
-    const m = makeManager();
-    const { mirrorPath } = await m.ensureMirror(fixtureUrl);
-    // Force the broken state: remove origin/HEAD that bootstrap had set.
-    rmSync(join(mirrorPath, "refs", "remotes", "origin", "HEAD"), { force: true });
-    // Sanity check the precondition we're reproducing.
-    expect(tryGitIn(mirrorPath, "rev-parse --verify --quiet refs/remotes/origin/HEAD").ok).toBe(false);
-
-    // createWorktree without an explicit `ref` exercises the default-branch
-    // path through resolveBase — this used to throw with
-    // "Cannot resolve default branch: refs/remotes/origin/HEAD is missing".
-    const target = join(workRoot, "self-heal");
-    const result = await m.createWorktree({
-      url: fixtureUrl,
-      targetPath: target,
-      sessionKey: "self-heal-1",
-      agentName: "agent-x",
-    });
-    expect(result.headCommit).toMatch(/^[0-9a-f]{40}$/);
-    expect(tryGitIn(mirrorPath, "rev-parse --verify --quiet refs/remotes/origin/HEAD").ok).toBe(true);
-  });
-
-  it("prunes a stale worktree registration before re-creating at the same path", async () => {
-    // PR #393 dogfood: the bare mirror retained a "prunable" worktree
-    // admin record after an external `rm -rf` of the worktree directory.
-    // Subsequent `git worktree add -b <newBranch> <samePath> ...` failed
-    // with `fatal: '<path>' is a missing but already registered worktree`.
-    // The fix runs `git worktree prune` inside `createWorktree` so dead
-    // records are cleared before the add attempt.
-    //
-    // Setup: create a worktree, rm -rf the dir WITHOUT running prune
-    // (mimics the dogfood crash), then call `createWorktree` for a
-    // DIFFERENT sessionKey/branch at the same path. Without the fix git
-    // would error; with the fix it succeeds.
-    const m = makeManager();
-    const { mirrorPath } = await m.ensureMirror(fixtureUrl);
-    const target = join(workRoot, "prune-collision");
-
-    // 1. First session: writes a worktree + branch + registration.
-    const first = await m.createWorktree({
-      url: fixtureUrl,
-      targetPath: target,
-      sessionKey: "session-A",
-      agentName: "agent-x",
-    });
-    expect(existsSync(target)).toBe(true);
-
-    // 2. Simulate external wipe: directory gone, branch + worktree admin
-    //    record still in the bare mirror. (No `git worktree prune` here.)
-    rmSync(target, { recursive: true, force: true });
-    expect(existsSync(target)).toBe(false);
-    // Sanity: the admin record is still around — `git worktree list` shows
-    // the path as prunable.
-    const listed = execSync("git worktree list --porcelain", { cwd: mirrorPath }).toString();
-    expect(listed).toContain(target);
-
-    // 3. New session targets the same path with a NEW branch (different
-    //    sessionKey → different hash). Without the prune fix this throws
-    //    "missing but already registered worktree".
-    const second = await m.createWorktree({
-      url: fixtureUrl,
-      targetPath: target,
-      sessionKey: "session-B-different-key",
-      agentName: "agent-x",
-    });
-    expect(second.branchName).not.toBe(first.branchName);
-    expect(existsSync(join(target, "README.md"))).toBe(true);
-  });
-
-  it("refuses to proceed when the worktree path exists but the session branch is missing", async () => {
-    // Simulates ref-level corruption: the worktree directory survives on disk,
-    // but the session branch in the mirror has vanished (manual ref tampering,
-    // disk restore from a partial backup, etc.). createWorktree must refuse
-    // rather than silently recreate an unrelated branch at the same path.
-    const m = makeManager();
-    const { mirrorPath } = await m.ensureMirror(fixtureUrl);
-    const target = join(workRoot, "crash-ghost");
-    const { branchName } = await m.createWorktree({
-      url: fixtureUrl,
-      targetPath: target,
-      sessionKey: "ghosty",
-      agentName: "agent-x",
-    });
-    // Bypass git's safety net and delete the ref file directly. Works against
-    // loose refs; a freshly-created branch never reaches packed-refs.
-    const refPath = join(mirrorPath, "refs", "heads", branchName);
-    rmSync(refPath, { force: true });
-
-    await expect(
-      m.createWorktree({ url: fixtureUrl, targetPath: target, sessionKey: "ghosty", agentName: "agent-x" }),
-    ).rejects.toBeInstanceOf(GitMirrorError);
+    const swept = await m.sweepLegacyMirrors();
+    expect(swept.removed).toEqual([]);
   });
 });
 
@@ -1743,20 +906,13 @@ describe("GitMirrorManager — canonical URL hashing (canonicalizeRepoUrl + hash
   });
 });
 
-describe("GitMirrorManager — ssh fallback", () => {
-  it("does NOT touch ssh path for non-https origins (file://, ssh://) — failure surfaces raw", async () => {
-    // The fixture URL is file:// — even if we point it at a corrupt repo and
-    // fetch fails, the manager must surface the raw `GitMirrorError`, not
-    // `GitMirrorAuthError`. Fallback is HTTPS-only by design; misclassifying
-    // a file:// failure as "try ssh" would mask real bugs and waste a retry.
+describe("GitMirrorManager — protocol fallback (clone)", () => {
+  it("does NOT classify a non-https failure as auth — clone of an unreachable file:// URL throws raw GitMirrorError", async () => {
     const m = makeManager();
-    const { mirrorPath } = await m.ensureMirror(fixtureUrl);
-    // Corrupt the mirror's origin to an unreachable file:// path.
-    execSync("git remote set-url origin file:///nonexistent/path/that/does/not/exist.git", { cwd: mirrorPath });
-
+    const clonePath = join(mkdtempSync(join(tmpdir(), "ftt-srcrepo-")), "repo");
     let caught: unknown;
     try {
-      await m.fetchMirror(fixtureUrl);
+      await m.ensureSourceRepo({ url: "file:///nonexistent/path/does/not/exist.git", clonePath });
     } catch (err) {
       caught = err;
     }
@@ -1764,29 +920,18 @@ describe("GitMirrorManager — ssh fallback", () => {
     expect(caught).not.toBeInstanceOf(GitMirrorAuthError);
   });
 
-  // 30s vitest timeout: `Connection refused` is in the transient-retry set
-  // (intentionally — localhost-proxy listeners commonly bounce), so this
-  // test now eats the full ~5s of retry sleeps plus 4 × git-curl-fail-fast
-  // attempts before reaching the terminal assertion. On Linux dev machines
-  // that pushes wall-clock to ~15s, past vitest's default 5s testTimeout.
-  // CI Linux runners aren't affected, but cross-platform portability
-  // matters — see PR #548 review feedback.
-  it("does NOT classify a non-credential https failure as auth — bootstrap against an unreachable https URL throws raw GitMirrorError", async () => {
-    // Drive `ensureMirror` (which goes through the same `fetchOrigin` helper
-    // as `fetchMirror`) against an https URL whose connect() always refuses.
-    // The bootstrap MUST fail with the raw `GitMirrorError` — wrapping a
-    // connect-refused error in `GitMirrorAuthError` would falsely imply that
-    // ssh was tried and also failed for credential reasons.
-    //
-    // Port 1 is reserved & always refuses connections → fast deterministic
-    // failure, no real network egress, safe in any CI sandbox.
+  // Port 1 is reserved & always refuses connections → fast deterministic
+  // failure, no real network egress. `Connection refused` is in the transient
+  // set so this eats the ~5s retry budget before surfacing — keep the 30s cap.
+  it("does NOT classify a connect-refused https failure as auth — clone throws raw GitMirrorError", async () => {
     const m = createGitMirrorManager({
       dataDir: mkdtempSync(join(tmpdir(), "ftt-mgr-https-")),
       cloneTimeoutMs: 15_000,
     });
+    const clonePath = join(mkdtempSync(join(tmpdir(), "ftt-srcrepo-")), "repo");
     let caught: unknown;
     try {
-      await m.ensureMirror("https://127.0.0.1:1/nope.git");
+      await m.ensureSourceRepo({ url: "https://127.0.0.1:1/nope.git", clonePath });
     } catch (err) {
       caught = err;
     }
@@ -1796,79 +941,16 @@ describe("GitMirrorManager — ssh fallback", () => {
 });
 
 describe("GitMirrorManager — concurrency", () => {
-  it("collapses parallel ensureMirror calls onto a single bootstrap", async () => {
+  it("serialises parallel ensureSourceRepo calls on the same clone path onto a single clone", async () => {
     const m = makeManager();
-    const [a, b] = await Promise.all([m.ensureMirror(fixtureUrl), m.ensureMirror(fixtureUrl)]);
-    // Exactly one of the two saw the cold path.
-    expect([a.cloned, b.cloned].sort()).toEqual([false, true]);
-    expect(a.mirrorPath).toBe(b.mirrorPath);
-  });
-
-  it("serialises parallel createWorktree calls on the same URL (config-lock contention)", async () => {
-    // `git worktree add -b` writes to the mirror's `config` file to set
-    // upstream tracking. Running two adds in parallel without a lock causes
-    // the second to fail with "could not lock config file" (found via E2E).
-    const m = makeManager();
-    await m.ensureMirror(fixtureUrl);
-    const a = join(workRoot, "conc-a");
-    const b = join(workRoot, "conc-b");
-    const [ra, rb] = await Promise.all([
-      m.createWorktree({ url: fixtureUrl, targetPath: a, sessionKey: "conc-A", agentName: "agent-x" }),
-      m.createWorktree({ url: fixtureUrl, targetPath: b, sessionKey: "conc-B", agentName: "agent-x" }),
+    const clonePath = join(mkdtempSync(join(tmpdir(), "ftt-srcrepo-")), "repo");
+    const [a, b] = await Promise.all([
+      m.ensureSourceRepo({ url: fixtureUrl, clonePath }),
+      m.ensureSourceRepo({ url: fixtureUrl, clonePath }),
     ]);
-    expect(ra.branchName).not.toBe(rb.branchName);
-    expect(existsSync(a)).toBe(true);
-    expect(existsSync(b)).toBe(true);
-  });
-
-  it("retries createWorktree when git reports config.lock contention", async () => {
-    const dataDir = mkdtempSync(join(tmpdir(), "ftt-config-lock-"));
-    const { spies, log } = makeLogSpies();
-    const m = createGitMirrorManager({ dataDir, cloneTimeoutMs: 30_000, log });
-    createFakeBareMirror(dataDir, fixtureUrl);
-    const target = join(workRoot, "config-lock-retry");
-    const counter = join(dataDir, "worktree-add-count");
-
-    await withFakePath(
-      {
-        git: `#!/bin/sh
-case "$*" in
-  *"worktree prune"*) exit 0 ;;
-  *"rev-parse --verify --quiet refs/heads/"*) exit 1 ;;
-  *"cat-file -e"*) exit 0 ;;
-  *"worktree add -b"*)
-    count=$(/bin/cat "${counter}" 2>/dev/null || echo 0)
-    count=$((count + 1))
-    echo "$count" > "${counter}"
-    if [ "$count" = "1" ]; then
-      echo "error: could not lock config file config.lock" >&2
-      exit 255
-    fi
-    /bin/mkdir -p "$5"
-    exit 0
-    ;;
-  *"rev-parse HEAD"*) echo "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"; exit 0 ;;
-  *) exit 0 ;;
-esac
-`,
-      },
-      async () => {
-        const result = await m.createWorktree({
-          url: fixtureUrl,
-          ref: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-          targetPath: target,
-          sessionKey: "lock-chat",
-          agentName: "agent-x",
-        });
-        expect(result.headCommit).toBe("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
-      },
-    );
-
-    expect(existsSync(target)).toBe(true);
-    expect(spies.warn).toHaveBeenCalledWith(
-      expect.objectContaining({ gitUrl: fixtureUrl, branchName: expect.stringMatching(/^hub-session-/), attempt: 1 }),
-      "worktree add hit config lock contention — retrying",
-    );
-    rmSync(dataDir, { recursive: true, force: true });
+    // Exactly one did the cold clone; the other saw the established clone.
+    expect([a.outcome, b.outcome].sort()).toEqual(["cloned", "unchanged"]);
+    expect(statSync(join(clonePath, ".git")).isDirectory()).toBe(true);
+    expect(gitIn(clonePath, "rev-parse HEAD")).toBe(initialMainSha);
   });
 });

--- a/packages/client/src/__tests__/git-mirror-manager.test.ts
+++ b/packages/client/src/__tests__/git-mirror-manager.test.ts
@@ -1,5 +1,5 @@
 import { type ChildProcess, execSync, spawn } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -363,6 +363,24 @@ describe("GitMirrorManager — source repo lifecycle (per-agent clone)", () => {
     const m = makeManager();
     const swept = await m.sweepLegacyMirrors();
     expect(swept.removed).toEqual([]);
+  });
+
+  it("sweepLegacyMirrors refuses to descend a symlinked cache root (no escape outside dataDir)", async () => {
+    const dataDir = newDataDir();
+    const m = createGitMirrorManager({ dataDir, cloneTimeoutMs: 30_000 });
+    // External dir the cache-root symlink points at — its contents MUST survive.
+    const external = mkdtempSync(join(tmpdir(), "ftt-external-"));
+    writeFileSync(join(external, "precious.txt"), "do not delete");
+    // Replace <dataDir>/git-mirrors with a symlink to the external dir.
+    symlinkSync(external, m.legacyMirrorsRoot);
+
+    const swept = await m.sweepLegacyMirrors();
+
+    expect(swept.removed).toEqual([]);
+    // Symlink target untouched; only the link entry itself is removed.
+    expect(existsSync(join(external, "precious.txt"))).toBe(true);
+    expect(existsSync(m.legacyMirrorsRoot)).toBe(false);
+    rmSync(external, { recursive: true, force: true });
   });
 });
 

--- a/packages/client/src/__tests__/gitrepos-session-integration.test.ts
+++ b/packages/client/src/__tests__/gitrepos-session-integration.test.ts
@@ -1,5 +1,5 @@
 import { execSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { AgentRuntimeConfig } from "@first-tree/shared";
@@ -144,8 +144,8 @@ describe("claude-code handler gitRepos wiring (PRD §5.1.5)", () => {
     expect(existsSync(sourceRepoPath)).toBe(true);
     expect(existsSync(join(sourceRepoPath, "README.md"))).toBe(true);
     expect(readFileSync(join(sourceRepoPath, "README.md"), "utf-8")).toContain("fixture repo");
-    // A worktree-style checkout has a .git FILE (not directory) pointing at the bare mirror.
-    expect(existsSync(join(sourceRepoPath, ".git"))).toBe(true);
+    // A standalone clone has a real `.git` DIRECTORY (not a worktree `.git` file).
+    expect(statSync(join(sourceRepoPath, ".git")).isDirectory()).toBe(true);
     // The `worktrees/` subdir is NOT pre-created — it's the agent's on-demand
     // space, populated only when the agent runs `git worktree add` itself.
     expect(existsSync(join(workspaceRoot, "worktrees"))).toBe(false);
@@ -156,8 +156,8 @@ describe("claude-code handler gitRepos wiring (PRD §5.1.5)", () => {
     await handler.shutdown();
     expect(existsSync(sourceRepoPath)).toBe(true);
     expect(existsSync(workspaceRoot)).toBe(true);
-    // Bare mirror is shared across sessions — must survive session cleanup.
-    expect(existsSync(gitMirrorManager.mirrorsRoot)).toBe(true);
+    // No shared bare-mirror tree exists in the per-agent-clone model.
+    expect(existsSync(gitMirrorManager.legacyMirrorsRoot)).toBe(false);
   });
 
   it("aborts session creation when a gitRepo URL is unreachable (PRD D10)", async () => {
@@ -220,11 +220,8 @@ describe("claude-code handler gitRepos wiring (PRD §5.1.5)", () => {
       ctx,
     );
 
-    // No mirror should have been created since no repos.
-    if (existsSync(gitMirrorManager.mirrorsRoot)) {
-      const { readdirSync } = await import("node:fs");
-      expect(readdirSync(gitMirrorManager.mirrorsRoot)).toHaveLength(0);
-    }
+    // No source repos configured → nothing materialised, and no legacy mirror tree.
+    expect(existsSync(gitMirrorManager.legacyMirrorsRoot)).toBe(false);
 
     await handler.shutdown();
   });

--- a/packages/client/src/__tests__/runtime.test.ts
+++ b/packages/client/src/__tests__/runtime.test.ts
@@ -31,7 +31,7 @@ type MockRuntimeState = {
   slots: FakeSlot[];
   connections: FakeConnection[];
   gitManager: {
-    gcOrphanSessionBranches: ReturnType<typeof vi.fn<() => Promise<{ scanned: number }>>>;
+    sweepLegacyMirrors: ReturnType<typeof vi.fn<() => Promise<{ removed: string[] }>>>;
   };
   logger: {
     info: ReturnType<typeof vi.fn>;
@@ -111,8 +111,8 @@ function makeUpdateHooks(): UpdateHooks {
 
 function installRuntimeMocks(options?: {
   slotBehavior?: Record<string, SlotBehavior>;
-  gcResult?: { scanned: number };
-  gcError?: Error;
+  sweepResult?: { removed: string[] };
+  sweepError?: Error;
   snapshots?: Record<string, { activeCount: number; lastActivityMs: number }>;
   stopPromise?: Promise<void>;
 }): MockRuntimeState {
@@ -122,9 +122,9 @@ function installRuntimeMocks(options?: {
     slots: [],
     connections: [],
     gitManager: {
-      gcOrphanSessionBranches: vi.fn(async () => {
-        if (options?.gcError) throw options.gcError;
-        return options?.gcResult ?? { scanned: 0 };
+      sweepLegacyMirrors: vi.fn(async () => {
+        if (options?.sweepError) throw options.sweepError;
+        return options?.sweepResult ?? { removed: [] };
       }),
     },
     logger: {
@@ -277,7 +277,7 @@ describe("AgentRuntime", () => {
 
   it("starts, attaches updates, reports partial slot failures, and shuts down on SIGINT", async () => {
     const state = installRuntimeMocks({
-      gcResult: { scanned: 2 },
+      sweepResult: { removed: ["abc", "def"] },
       slotBehavior: { beta: "reject" },
       snapshots: {
         alpha: { activeCount: 1, lastActivityMs: 10 },
@@ -298,8 +298,8 @@ describe("AgentRuntime", () => {
     const started = runtime.start();
     await vi.waitFor(() => expect(signals.getSigint()).not.toBeNull());
 
-    expect(state.gitManager.gcOrphanSessionBranches).toHaveBeenCalledTimes(1);
-    expect(state.logger.info).toHaveBeenCalledWith({ scanned: 2 }, "swept orphan session branches");
+    expect(state.gitManager.sweepLegacyMirrors).toHaveBeenCalledTimes(1);
+    expect(state.logger.info).toHaveBeenCalledWith({ removed: 2 }, "removed legacy shared git-mirrors tree");
     expect(state.updateAttach).toHaveBeenCalledTimes(1);
     expect(state.updateOptions?.getQuietGateSnapshot()).toEqual({ activeCount: 3, lastActivityMs: 30 });
     state.updateOptions?.log("info", "update log line");
@@ -335,7 +335,7 @@ describe("AgentRuntime", () => {
   });
 
   it("logs GC failures and can shut down through SIGTERM without update hooks", async () => {
-    const state = installRuntimeMocks({ gcError: new Error("gc failed") });
+    const state = installRuntimeMocks({ sweepError: new Error("gc failed") });
     const signals = captureProcessSignals();
     const { AgentRuntime } = await import("../runtime/runtime.js");
     const runtime = new AgentRuntime({
@@ -351,7 +351,7 @@ describe("AgentRuntime", () => {
     await expect(started).resolves.toBeUndefined();
     expect(state.logger.warn).toHaveBeenCalledWith(
       { err: new Error("gc failed") },
-      "gcOrphanSessionBranches threw — continuing startup",
+      "sweepLegacyMirrors threw — continuing startup",
     );
     expect(state.updateAttach).not.toHaveBeenCalled();
     expect(state.updateDispose).not.toHaveBeenCalled();

--- a/packages/client/src/__tests__/source-repos.test.ts
+++ b/packages/client/src/__tests__/source-repos.test.ts
@@ -1,0 +1,220 @@
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AgentRuntimeConfigPayload } from "@first-tree/shared";
+import { describe, expect, it, vi } from "vitest";
+import type { GitMirrorManager, SourceRepoOutcome } from "../runtime/git-mirror-manager.js";
+import type { SessionContext } from "../runtime/handler.js";
+import { prepareSourceRepos, releaseSourceReposForSession } from "../runtime/source-repos.js";
+
+/**
+ * Decision-B "live use" registry semantics (per-agent-source-repo). These are
+ * pure in-process bookkeeping tests — the GitMirrorManager is mocked so we can
+ * observe the `activelyInUse` flag each `ensureSourceRepo` call receives without
+ * touching git.
+ */
+
+type EnsureArgs = Parameters<GitMirrorManager["ensureSourceRepo"]>[0];
+
+function makeManager(opts?: { onEnsure?: (args: EnsureArgs) => void; throwOnCall?: number }): {
+  manager: GitMirrorManager;
+  calls: EnsureArgs[];
+} {
+  const calls: EnsureArgs[] = [];
+  const manager = {
+    ensureSourceRepo: vi.fn(async (args: EnsureArgs) => {
+      calls.push(args);
+      opts?.onEnsure?.(args);
+      if (opts?.throwOnCall && calls.length === opts.throwOnCall) {
+        throw new Error("clone failed");
+      }
+      return {
+        clonePath: args.clonePath,
+        headCommit: "deadbeef",
+        branch: "main",
+        outcome: "cloned" as SourceRepoOutcome,
+      };
+    }),
+    removeSourceRepo: vi.fn(async () => {}),
+    sweepLegacyMirrors: vi.fn(async () => ({ removed: [] })),
+    legacyMirrorsRoot: "/tmp/legacy",
+  } as unknown as GitMirrorManager;
+  return { manager, calls };
+}
+
+function makeCtx(chatId: string): SessionContext {
+  return { chatId, log: vi.fn(), agent: { agentId: "agent-x" } } as unknown as SessionContext;
+}
+
+function payloadFor(localPath: string): AgentRuntimeConfigPayload {
+  return { gitRepos: [{ url: "git@github.com:example/repo.git", localPath }] } as unknown as AgentRuntimeConfigPayload;
+}
+
+// Unique workspace per test so the module-level registry (keyed by absolute
+// path) never collides across tests in this file.
+let n = 0;
+function freshWorkspace(): string {
+  n += 1;
+  return join(tmpdir(), `ftt-srcrepo-reg-${n}`);
+}
+
+describe("source-repos live-use registry (decision B, keyed by chatId)", () => {
+  it("a second concurrent chat on the same checkout is told it is in use; releasing the first clears it", async () => {
+    const workspace = freshWorkspace();
+    const { manager, calls } = makeManager();
+    const ctxA = makeCtx("chat-A");
+    const ctxB = makeCtx("chat-B");
+
+    await prepareSourceRepos({
+      workspace,
+      payload: payloadFor("repo"),
+      sessionCtx: ctxA,
+      gitMirrorManager: manager,
+      agentName: null,
+    });
+    expect(calls.at(-1)?.activelyInUse).toBe(false); // first chat — nobody else
+
+    await prepareSourceRepos({
+      workspace,
+      payload: payloadFor("repo"),
+      sessionCtx: ctxB,
+      gitMirrorManager: manager,
+      agentName: null,
+    });
+    expect(calls.at(-1)?.activelyInUse).toBe(true); // chat-A still live
+
+    releaseSourceReposForSession(ctxA);
+
+    await prepareSourceRepos({
+      workspace,
+      payload: payloadFor("repo"),
+      sessionCtx: ctxB,
+      gitMirrorManager: manager,
+      agentName: null,
+    });
+    expect(calls.at(-1)?.activelyInUse).toBe(false); // only chat-B now
+
+    releaseSourceReposForSession(ctxB);
+  });
+
+  it("start → resume of the SAME chat (fresh SessionContext, same chatId) does not leak — one release clears it", async () => {
+    const workspace = freshWorkspace();
+    const { manager, calls } = makeManager();
+    // Two distinct SessionContext objects, same chatId — models the runtime
+    // handing a fresh ctx to each resume.
+    const start = makeCtx("chat-A");
+    const resume = makeCtx("chat-A");
+    const other = makeCtx("chat-B");
+
+    await prepareSourceRepos({
+      workspace,
+      payload: payloadFor("repo"),
+      sessionCtx: start,
+      gitMirrorManager: manager,
+      agentName: null,
+    });
+    await prepareSourceRepos({
+      workspace,
+      payload: payloadFor("repo"),
+      sessionCtx: resume,
+      gitMirrorManager: manager,
+      agentName: null,
+    });
+
+    // A different chat sees exactly ONE other live chat (chat-A), not two.
+    await prepareSourceRepos({
+      workspace,
+      payload: payloadFor("repo"),
+      sessionCtx: other,
+      gitMirrorManager: manager,
+      agentName: null,
+    });
+    expect(calls.at(-1)?.activelyInUse).toBe(true);
+    releaseSourceReposForSession(other);
+
+    // A single release of chat-A (object identity irrelevant — keyed by chatId)
+    // fully clears it; the next chat sees the checkout free.
+    releaseSourceReposForSession(resume);
+    const after = makeCtx("chat-C");
+    await prepareSourceRepos({
+      workspace,
+      payload: payloadFor("repo"),
+      sessionCtx: after,
+      gitMirrorManager: manager,
+      agentName: null,
+    });
+    expect(calls.at(-1)?.activelyInUse).toBe(false);
+    releaseSourceReposForSession(after);
+  });
+
+  it("a failed start releases its registration so it does not pin future sessions", async () => {
+    const workspace = freshWorkspace();
+    const { manager, calls } = makeManager({ throwOnCall: 1 });
+    const failing = makeCtx("chat-A");
+
+    await expect(
+      prepareSourceRepos({
+        workspace,
+        payload: payloadFor("repo"),
+        sessionCtx: failing,
+        gitMirrorManager: manager,
+        agentName: null,
+      }),
+    ).rejects.toThrow("clone failed");
+
+    // A later chat must NOT see the dead chat-A as a live user.
+    const next = makeCtx("chat-B");
+    await prepareSourceRepos({
+      workspace,
+      payload: payloadFor("repo"),
+      sessionCtx: next,
+      gitMirrorManager: manager,
+      agentName: null,
+    });
+    expect(calls.at(-1)?.activelyInUse).toBe(false);
+    releaseSourceReposForSession(next);
+  });
+
+  it("a transient failure on a re-acquire (resume) does NOT deregister a still-live chat", async () => {
+    const workspace = freshWorkspace();
+    // Throw on the SECOND ensureSourceRepo call (the chat's resume), not the first (start).
+    const { manager, calls } = makeManager({ throwOnCall: 2 });
+    const live = makeCtx("chat-A");
+
+    // Start succeeds → chat-A registered + live.
+    await prepareSourceRepos({
+      workspace,
+      payload: payloadFor("repo"),
+      sessionCtx: live,
+      gitMirrorManager: manager,
+      agentName: null,
+    });
+
+    // Resume (fresh SessionContext, same chatId) fails transiently. Because the
+    // chat was ALREADY registered (firstRegistration=false), the failure must
+    // NOT roll back its liveness — the session manager keeps it alive for retry.
+    const resume = makeCtx("chat-A");
+    await expect(
+      prepareSourceRepos({
+        workspace,
+        payload: payloadFor("repo"),
+        sessionCtx: resume,
+        gitMirrorManager: manager,
+        agentName: null,
+      }),
+    ).rejects.toThrow("clone failed");
+
+    // A concurrent chat must STILL see chat-A as a live user → not safe to reset.
+    const other = makeCtx("chat-B");
+    await prepareSourceRepos({
+      workspace,
+      payload: payloadFor("repo"),
+      sessionCtx: other,
+      gitMirrorManager: manager,
+      agentName: null,
+    });
+    expect(calls.at(-1)?.activelyInUse).toBe(true);
+
+    releaseSourceReposForSession(live);
+    releaseSourceReposForSession(other);
+  });
+});

--- a/packages/client/src/handlers/claude-code-tui/index.ts
+++ b/packages/client/src/handlers/claude-code-tui/index.ts
@@ -9,7 +9,7 @@ import type { PredeclaredSourceRepo } from "../../runtime/bootstrap.js";
 import { type ChatContext, fetchChatContext } from "../../runtime/chat-context.js";
 import type { GitMirrorManager } from "../../runtime/git-mirror-manager.js";
 import type { AgentHandler, HandlerFactory, SessionContext, SessionMessage } from "../../runtime/handler.js";
-import { prepareSourceRepos } from "../../runtime/source-repos.js";
+import { prepareSourceRepos, releaseSourceReposForSession } from "../../runtime/source-repos.js";
 import { acquireAgentHome, markWorkspaceInitComplete } from "../../runtime/workspace.js";
 import { createToolCallProcessor, mapMcpServers } from "../claude-code.js";
 import { resolveClaudeCodeExecutable } from "../claude-executable.js";
@@ -34,7 +34,7 @@ const TURN_POLL_MS = 250;
 const TURN_GRACE_MS = 1500;
 const READY_TIMEOUT_MS = 30_000;
 
-type Worktree = { url: string; path: string; branchName: string };
+type Worktree = { clonePath: string };
 
 /**
  * Module-level lazy sweep: on first handler instantiation in this process, kill
@@ -669,12 +669,15 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
       // against. Source repos are also intentionally left in place
       // (proposals/agent-session-cwd-redesign §⑤). On-demand worktrees the
       // agent created under `<cwd>/worktrees/<name>/` belong to the agent.
+      if (ctx) releaseSourceReposForSession(ctx);
       if (gitMirrorManager) {
         for (const wt of ownedWorktrees) {
           try {
-            await gitMirrorManager.removeWorktree({ url: wt.url, path: wt.path, branchName: wt.branchName });
+            await gitMirrorManager.removeSourceRepo({ clonePath: wt.clonePath });
           } catch (err) {
-            ctx?.log(`tui worktree cleanup failed (${wt.path}): ${err instanceof Error ? err.message : String(err)}`);
+            ctx?.log(
+              `tui worktree cleanup failed (${wt.clonePath}): ${err instanceof Error ? err.message : String(err)}`,
+            );
           }
         }
         ownedWorktrees.length = 0;

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -29,7 +29,10 @@ import type { AgentHandler, HandlerFactory, SessionContext, SessionMessage } fro
 import { findImagePath } from "../runtime/image-store.js";
 import { InputController } from "../runtime/input-controller.js";
 import { materializeResourceSkills } from "../runtime/resource-skills.js";
-import { prepareSourceRepos as prepareSourceReposShared } from "../runtime/source-repos.js";
+import {
+  prepareSourceRepos as prepareSourceReposShared,
+  releaseSourceReposForSession,
+} from "../runtime/source-repos.js";
 import { acquireAgentHome, markWorkspaceInitComplete } from "../runtime/workspace.js";
 import { formatAuthHint, isClaudeAuthError } from "./auth-error-hint.js";
 import { resolveClaudeCodeExecutable } from "./claude-executable.js";
@@ -592,8 +595,14 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
   let appliedConfigVersion = 0;
   let appliedModel = "";
   let appliedPayload: AgentRuntimeConfigPayload | null = null;
-  /** Worktrees materialised for this session — each entry removed on shutdown. */
-  const ownedWorktrees: Array<{ url: string; path: string; branchName: string }> = [];
+  /**
+   * On-demand worktrees materialised for this session — each entry `rm -rf`'d on
+   * shutdown via `removeSourceRepo`. INVARIANT: only ever push paths under
+   * `<agentHome>/worktrees/` here. NEVER push a predeclared source-repo path —
+   * those are agent-scoped persistent clones shared across chats, and cleanup
+   * would delete another chat's checkout. (Currently nothing pushes here.)
+   */
+  const ownedWorktrees: Array<{ clonePath: string }> = [];
   /**
    * Latest chat-context snapshot for the active session. Used to build the
    * per-turn system-prompt block injected via `systemPrompt.append`. Cleared
@@ -1365,13 +1374,14 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
    *
    * Idempotent across sessions: with the per-agent-home model the checkout
    * is **shared** across every chat for this agent. First call clones the
-   * bare mirror + creates the working tree; subsequent calls fetch (so the
-   * bare mirror picks up upstream changes) and reuse the existing checkout
-   * in place — no reset, so any pending state the LLM left behind survives.
+   * repo as a standalone clone; subsequent calls fetch and — when the
+   * checkout is clean and not in use by another live session — bring it to
+   * the latest default branch. A dirty or in-use checkout is left at its
+   * current commit, so pending state the LLM left behind survives.
    *
-   * Concurrency: per-process per-path mutex (`withWorktreePathLock`) so two
-   * sessions starting at the same time don't race `git worktree add` for the
-   * same path. See proposals/agent-session-cwd-redesign.20260519.md §⑧ R1.
+   * Concurrency: the manager serialises per clone path so two sessions
+   * starting at the same time don't race a clone / update for the same path.
+   * See proposals/agent-session-cwd-redesign.20260519.md §⑧ R1.
    *
    * Side effect: refreshes `sourceReposForPrompt` so the unified briefing
    * builder (`runtime/agent-briefing.ts` → `## Source Repositories`) can
@@ -1399,15 +1409,18 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
 
   /** Tear down all worktrees this session owns; best-effort. */
   async function cleanupGitWorktrees(sessionCtx: SessionContext): Promise<void> {
+    // Drop this session's live-use references on shared source-repo checkouts so
+    // a later session is free to bring them to the latest default branch.
+    releaseSourceReposForSession(sessionCtx);
     if (!gitMirrorManager) return;
     while (ownedWorktrees.length > 0) {
       const entry = ownedWorktrees.pop();
       if (!entry) continue;
       try {
-        await gitMirrorManager.removeWorktree(entry);
+        await gitMirrorManager.removeSourceRepo(entry);
       } catch (err) {
         sessionCtx.log(
-          `Git: removeWorktree(${entry.path}) failed — ${err instanceof Error ? err.message : String(err)}`,
+          `Git: removeSourceRepo(${entry.clonePath}) failed — ${err instanceof Error ? err.message : String(err)}`,
         );
       }
     }

--- a/packages/client/src/handlers/codex.ts
+++ b/packages/client/src/handlers/codex.ts
@@ -1,4 +1,3 @@
-import { existsSync } from "node:fs";
 import { isAbsolute, relative, resolve } from "node:path";
 import {
   type AgentRuntimeConfigPayload,
@@ -10,11 +9,11 @@ import { Codex, type Input, type Thread, type ThreadItem, type ThreadOptions, ty
 import { ensureAgentBootstrap as ensureAgentBootstrapShared } from "../runtime/agent-bootstrap.js";
 import { buildAgentBriefing } from "../runtime/agent-briefing.js";
 import type { AgentConfigCache } from "../runtime/agent-config-cache.js";
-import { FIRST_TREE_WORKSPACE_MARKER, isHubWorktreeMarker, type PredeclaredSourceRepo } from "../runtime/bootstrap.js";
+import { FIRST_TREE_WORKSPACE_MARKER, type PredeclaredSourceRepo } from "../runtime/bootstrap.js";
 import { type ChatContext, fetchChatContext } from "../runtime/chat-context.js";
 import { toolFileRefsFromShellCommand } from "../runtime/context-tree-file-refs.js";
 import { resolveGitRepoTargetPath } from "../runtime/git-local-path.js";
-import { deriveSessionBranchName, type GitMirrorManager } from "../runtime/git-mirror-manager.js";
+import type { GitMirrorManager } from "../runtime/git-mirror-manager.js";
 import type {
   AgentHandler,
   AgentIdentity,
@@ -23,8 +22,11 @@ import type {
   SessionMessage,
 } from "../runtime/handler.js";
 import { materializeResourceSkills } from "../runtime/resource-skills.js";
+import {
+  prepareSourceRepos as prepareSourceReposShared,
+  releaseSourceReposForSession,
+} from "../runtime/source-repos.js";
 import { acquireAgentHome, markWorkspaceInitComplete } from "../runtime/workspace.js";
-import { withWorktreePathLock } from "../runtime/worktree-mutex.js";
 import { formatAuthHint, isCodexAuthError } from "./auth-error-hint.js";
 
 /**
@@ -38,7 +40,7 @@ type CodexConfigObject = { [key: string]: CodexConfigValue };
 const ASSISTANT_TEXT_EVENT_LIMIT = 8000;
 const RESULT_PREVIEW_LIMIT = 400;
 
-type Worktree = { url: string; path: string; branchName: string };
+type Worktree = { clonePath: string };
 
 /**
  * Turn-level retry budget for transient codex failures.
@@ -549,68 +551,18 @@ export const createCodexHandler: HandlerFactory = (config) => {
     workspaceCwd: string,
     sessionCtx: SessionContext,
   ): Promise<void> {
-    // Reset the prompt-facing list so a config change between sessions is
-    // reflected on the next `buildAgentBriefing` call.
-    sourceReposForPrompt = [];
-    if (!gitMirrorManager) return;
-
-    const branchAgentKey = agentName ?? sessionCtx.agent.agentId;
-    for (const repo of payload.gitRepos) {
-      const localPath = repo.localPath ?? deriveRepoLocalPath(repo.url);
-      if (!localPath) continue;
-      // Per agent-session-cwd-redesign (2026-05-22 redesign): predeclared
-      // source repos live at the TOP LEVEL of the agent home — NOT under
-      // `worktrees/`. The `worktrees/` subdir is reserved for on-demand
-      // worktrees the agent itself creates per task.
-      const targetPath = resolveGitRepoTargetPath(workspaceCwd, localPath);
-      try {
-        await gitMirrorManager.ensureMirror(repo.url);
-        await gitMirrorManager.fetchMirror(repo.url);
-
-        // Mirror claude-code's reuse contract (PR #506 review B2): only
-        // reuse when the target IS a First Tree-managed worktree, and surface a
-        // deterministic branchName so the prompt block stays consistent
-        // across sessions. Without the `isHubWorktreeMarker` check, an
-        // operator-placed directory would be silently reused; without the
-        // deterministic branch derivation, codex's "Source Repositories"
-        // prompt section would lose the `branch=` field on every reuse.
-        const branchName = await withWorktreePathLock(targetPath, async () => {
-          if (existsSync(targetPath)) {
-            if (isHubWorktreeMarker(targetPath)) {
-              sessionCtx.log(`Git: reusing existing source repo at ${localPath}`);
-              return deriveSessionBranchName(branchAgentKey, branchAgentKey, repo.url);
-            }
-            // Path occupied by something we didn't create — log so the
-            // operator can find this in the codex log when `createWorktree`
-            // throws on the next line (S1 in PR #506 review).
-            sessionCtx.log(
-              `Git: source-repo target ${localPath} occupied by a non-First Tree directory; ` +
-                "createWorktree will likely fail",
-            );
-          }
-          const created = await gitMirrorManager.createWorktree({
-            url: repo.url,
-            ref: repo.ref,
-            targetPath,
-            sessionKey: branchAgentKey,
-            agentName: branchAgentKey,
-          });
-          return created.branchName;
-        });
-
-        // Shared resource — DO NOT track in ownedWorktrees (which the legacy
-        // shutdown path used to schedule removal).
-        sourceReposForPrompt.push({
-          absolutePath: targetPath,
-          url: repo.url,
-          ...(repo.ref ? { ref: repo.ref } : {}),
-          branch: branchName,
-        });
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        throw new Error(`codex git materialisation failed for ${repo.url}: ${msg}`);
-      }
-    }
+    // Delegate to the shared helper (runtime/source-repos.ts) so the
+    // standalone-clone materialisation + per-clone lock + decision-B in-use
+    // refcount stay in one place across the SDK, TUI, and codex handlers. The
+    // returned list feeds the per-session AGENTS.md "Source Repositories" block
+    // on the next `buildAgentBriefing` call.
+    sourceReposForPrompt = await prepareSourceReposShared({
+      workspace: workspaceCwd,
+      payload,
+      sessionCtx,
+      gitMirrorManager,
+      agentName,
+    });
   }
 
   function emitToolCall(
@@ -1246,12 +1198,15 @@ export const createCodexHandler: HandlerFactory = (config) => {
       // intentionally skip `ownedWorktrees.push`) get torn down here. Future
       // ad-hoc worktree creation sites can opt in by pushing to
       // `ownedWorktrees`.
+      if (ctx) releaseSourceReposForSession(ctx);
       if (gitMirrorManager) {
         for (const wt of ownedWorktrees) {
           try {
-            await gitMirrorManager.removeWorktree({ url: wt.url, path: wt.path, branchName: wt.branchName });
+            await gitMirrorManager.removeSourceRepo({ clonePath: wt.clonePath });
           } catch (err) {
-            ctx?.log(`codex worktree cleanup failed (${wt.path}): ${err instanceof Error ? err.message : String(err)}`);
+            ctx?.log(
+              `codex worktree cleanup failed (${wt.clonePath}): ${err instanceof Error ? err.message : String(err)}`,
+            );
           }
         }
         ownedWorktrees.length = 0;

--- a/packages/client/src/runtime/agent-briefing.ts
+++ b/packages/client/src/runtime/agent-briefing.ts
@@ -210,13 +210,15 @@ function sourceRepositoriesBlock(sourceRepos: ReadonlyArray<PredeclaredSourceRep
   const lines: string[] = ["## Source Repositories", ""];
   lines.push(
     "The following repositories are pre-checked-out at the top level of your",
-    "working directory. They sit on a long-lived hub-session branch that is",
-    "**not** refreshed during this chat — the code may be many commits behind",
-    "`origin/main`. Use them only for read-only orientation (grep, file layout,",
-    "`git log`); for anything that must reflect current `main` (review, analysis,",
-    "code changes), do not reuse this checkout — create a fresh worktree off",
-    "`origin/<base>` (see below). Shared across every chat of this agent; do",
-    "not modify them in place or switch their branches.",
+    "working directory as standalone clones. First Tree keeps each one current:",
+    "at the start of every chat it fetches and — when the checkout is clean and",
+    "not in use by another live session — brings it to the latest default branch.",
+    "So unless it was left dirty or busy, the code here already reflects current",
+    "`origin/<default>`. Use them for read-only orientation (grep, file layout,",
+    "`git log`) and as the base for new worktrees (see below). Do **not** edit",
+    "them in place or switch their branches — local changes block the auto-update,",
+    "and the `worktrees/` flow is the place for any code work. Shared across",
+    "every chat of this agent.",
   );
   lines.push("");
   for (const repo of sourceRepos) {

--- a/packages/client/src/runtime/git-mirror-manager.ts
+++ b/packages/client/src/runtime/git-mirror-manager.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { existsSync, lstatSync, mkdirSync, readdirSync, rmSync, statSync } from "node:fs";
+import { existsSync, lstatSync, mkdirSync, readdirSync, rmSync, statSync, unlinkSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import type { pino } from "../observability/logger.js";
 import { getChildProcessRegistry } from "./child-process-registry.js";
@@ -416,10 +416,10 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
     if (canonicalizeRepoUrl(current) !== canonicalizeRepoUrl(url)) {
       await git(["remote", "set-url", "origin", url], absTarget, 10_000);
       // The new upstream may have a different default branch name (e.g.
-      // master → main). A plain fetch does NOT refresh `refs/remotes/origin/HEAD`,
-      // so without this the no-`ref` update path would resolve the OLD repo's
-      // default branch. Best-effort — `defaultBranchShort` self-heals again later.
-      await gitOk(["remote", "set-head", "origin", "--auto"], absTarget, 30_000);
+      // master → main), leaving `refs/remotes/origin/HEAD` pointing at the OLD
+      // default. `defaultBranchShort` detects + refreshes that staleness AFTER
+      // the fetch (refreshing it here, pre-fetch, is unreliable — the target
+      // remote-tracking ref doesn't exist yet on some git versions).
       log?.info(
         { clonePath: absTarget, from: current, to: url },
         "source-repo origin URL reconciled to configured url",
@@ -467,12 +467,21 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
 
   /** Short name of the remote default branch, e.g. `main`. Null if unresolved. */
   async function defaultBranchShort(absTarget: string): Promise<string | null> {
-    // `git symbolic-ref refs/remotes/origin/HEAD` → `refs/remotes/origin/main`
+    // `git symbolic-ref refs/remotes/origin/HEAD` → `refs/remotes/origin/main`.
+    // Only TRUST it when its target remote-tracking ref actually exists — after
+    // an origin repoint to a repo with a different default branch name,
+    // origin/HEAD can be STALE (still points at the old default, whose ref no
+    // longer exists post-fetch). A stale or missing HEAD falls through to the
+    // refresh below.
     try {
       const { stdout } = await git(["symbolic-ref", "refs/remotes/origin/HEAD"], absTarget, 10_000);
-      const ref = stdout.trim();
-      const m = ref.match(/^refs\/remotes\/origin\/(.+)$/);
-      if (m?.[1]) return m[1];
+      const m = stdout.trim().match(/^refs\/remotes\/origin\/(.+)$/);
+      if (
+        m?.[1] &&
+        (await gitOk(["rev-parse", "--verify", "--quiet", `refs/remotes/origin/${m[1]}`], absTarget, 10_000))
+      ) {
+        return m[1];
+      }
     } catch {
       // origin/HEAD not set — fall through to the repair below.
     }
@@ -712,7 +721,32 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
     },
 
     async sweepLegacyMirrors() {
-      if (!existsSync(legacyMirrorsRoot)) return { removed: [] };
+      // `lstat` (NOT `existsSync`, which follows links): if `git-mirrors` was
+      // replaced by a symlink, `readdirSync` would enumerate the link TARGET and
+      // the per-child `rm -rf` would delete contents OUTSIDE `<dataDir>` — an
+      // escape past every other guard in this module. We only ever recurse into
+      // a real directory we own; a symlink / non-directory at the cache root is
+      // not something First Tree created, so we unlink the entry itself (never
+      // descend into a symlink target) and stop.
+      let rootStat: ReturnType<typeof lstatSync>;
+      try {
+        rootStat = lstatSync(legacyMirrorsRoot);
+      } catch {
+        return { removed: [] }; // absent
+      }
+      if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) {
+        try {
+          // `unlinkSync` removes the symlink (or stray file) itself and never
+          // follows into / deletes a symlink target's contents.
+          unlinkSync(legacyMirrorsRoot);
+        } catch (err) {
+          log?.warn(
+            { legacyMirrorsRoot, err: err instanceof Error ? err.message : String(err) },
+            "sweepLegacyMirrors: cache root is a symlink/non-directory — removed the entry itself, did not descend",
+          );
+        }
+        return { removed: [] };
+      }
       const removed: string[] = [];
       try {
         for (const entry of readdirSync(legacyMirrorsRoot)) {

--- a/packages/client/src/runtime/git-mirror-manager.ts
+++ b/packages/client/src/runtime/git-mirror-manager.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, readdirSync, rmSync, statSync } from "node:fs";
+import { existsSync, lstatSync, mkdirSync, readdirSync, rmSync, statSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import type { pino } from "../observability/logger.js";
 import { getChildProcessRegistry } from "./child-process-registry.js";
@@ -7,22 +7,11 @@ import { isUnderManagedRoot, killProcessesHoldingPath } from "./worktree-cleanup
 
 const DEFAULT_CLONE_TIMEOUT_MS = 5 * 60 * 1000;
 
-const FETCH_REFSPEC = "+refs/heads/*:refs/remotes/origin/*";
-const SESSION_BRANCH_PREFIX = "hub-session";
-
 /**
- * Backoff schedule for retrying a remote-talking git op (`fetch`,
- * `remote set-head --auto`) on a transient network-layer failure. Each entry
- * is the wait BEFORE the next attempt, so this lays out 4 attempts total
- * (1 initial + 3 retries) with a worst-case sleep budget of ~5s **per
- * protocol attempt**.
- *
- * Per-call totals depend on whether the helper chains a primary + fallback:
- *   - `fetchOrigin` ≤ 5s sleep budget: the SSH fallback only fires when
- *     the primary's terminal failure is credential-shaped, which a transient
- *     stderr will never be. So a transient-only failure burns ~5s.
- *   - `setHeadAuto` ≤ 10s sleep budget: the fallback fires on ANY terminal
- *     primary failure, so a doubly-transient run burns ~5s + ~5s ≈ 10s.
+ * Backoff schedule for retrying a remote-talking git op (`clone`, `fetch`)
+ * on a transient network-layer failure. Each entry is the wait BEFORE the
+ * next attempt, so this lays out 4 attempts total (1 initial + 3 retries)
+ * with a worst-case sleep budget of ~5s **per protocol attempt**.
  *
  * Tuned for the operator-visible case of session start/resume hitting a
  * proxy / VPN that flips a rule, restarts a TUN, or drops a TLS handshake
@@ -35,34 +24,40 @@ const SESSION_BRANCH_PREFIX = "hub-session";
 const NETWORK_RETRY_DELAYS_MS: readonly number[] = [500, 1500, 3000];
 
 /**
- * Per-URL bare mirror manager.
+ * Per-agent standalone source-repo manager.
  *
- * Layout:
- *   <dataDir>/git-mirrors/<sha256(url)>/  ← bare repo (shared object store)
+ * Layout (post per-agent-source-repo refactor):
+ *   <workspaces>/<agent>/<repo>/      ← a real, standalone `git clone` with its
+ *                                       own `.git` dir and full object store.
  *
- * Isolation model:
- * - The mirror is configured with `remote.origin.fetch = +refs/heads/*:refs/remotes/origin/*`
- *   and `remote.origin.mirror` unset. `git fetch` therefore writes only to
- *   `refs/remotes/origin/*` and never touches `refs/heads/*`.
- * - Each session owns a dedicated local branch `hub-session-<sessionHash>-<urlHash>`
- *   in the mirror. Worktrees attach to that branch, not to a remote-tracking ref,
- *   so two sessions on the same URL get disjoint branch names and cannot
- *   collide on `git worktree add` or on `git fetch` ref locks.
+ * There is NO shared `<dataDir>/git-mirrors/` bare-mirror layer anymore. Each
+ * agent home owns its own clone of every configured source repo and is
+ * responsible for keeping it current. The clone the agent greps for
+ * orientation IS the clone that gets fetched+updated IS the clone that on-demand
+ * worktrees (`<agent>/worktrees/<task>/`) branch from — one fresh source of
+ * truth per agent.
  *
- * Authentication strategy:
+ * Update model (per session / dialog):
+ * - `git fetch --prune origin` always runs (fresh remote refs).
+ * - The working checkout is brought to the latest default branch (or the
+ *   pinned `ref`) with a hard `checkout -B`, but ONLY when it is safe:
+ *     · the working tree is clean (no uncommitted/untracked changes), and
+ *     · no other live chat of this agent is currently using the checkout
+ *       (the `activelyInUse` flag — see source-repos.ts live-use registry).
+ *   A dirty or in-use checkout is left at its current commit and a warning is
+ *   logged. We never silently `reset --hard` over local work or yank the
+ *   ground out from under a running session's `grep`.
+ *
+ * Authentication strategy (unchanged from the mirror era):
  * - Credentials are delegated to the host Git environment (credential
  *   helpers, GCM, ssh agent, on-disk keys). Every spawned `git` has
  *   `GIT_TERMINAL_PROMPT=0` so missing credentials fail fast instead of
  *   blocking on a tty that doesn't exist under systemd / launchd.
- * - When `fetch origin` fails with a credential-shaped error, we
+ * - When `clone` / `fetch origin` fails with a credential-shaped error, we
  *   transparently retry once via the *peer* protocol (HTTPS → SSH or
- *   SSH → HTTPS, decided by the configured origin URL), using a
- *   process-scoped `git -c url.<peer-base>.insteadOf=<origin-base>`
- *   rewrite. No host gitconfig is touched and no on-disk
- *   `remote.origin.url` is mutated. Mirror dir hashes use the canonical
- *   form (host + path), so HTTPS and SSH addressing of the same repo
- *   collapse to one mirror dir on disk regardless of which protocol the
- *   admin configured.
+ *   SSH → HTTPS, decided by the configured URL), using a process-scoped
+ *   `git -c url.<peer-base>.insteadOf=<origin-base>` rewrite. No host
+ *   gitconfig is touched and no on-disk `remote.origin.url` is mutated.
  */
 export type GitMirrorManagerOptions = {
   dataDir: string;
@@ -70,100 +65,103 @@ export type GitMirrorManagerOptions = {
   log?: pino.Logger;
   /**
    * Paths under which First Tree owns the directory tree end-to-end (typically
-   * `<dataDir>/workspaces`). When a worktree target sits inside one of these
-   * roots and a stale non-managed leftover is found at session start, the
-   * manager auto-recovers — kill any process still holding the path, `rm -rf`
-   * the leftover, then proceed with the normal `git worktree add` flow.
+   * `<dataDir>/workspaces`). When a source-repo target sits inside one of these
+   * roots and a stale non-managed leftover (or a legacy shared-mirror worktree)
+   * is found at session start, the manager auto-recovers — kill any process
+   * still holding the path, `rm -rf` the leftover, then re-clone.
    *
-   * Targets OUTSIDE every managed root still fail loud with D13: those are
+   * Targets OUTSIDE every managed root still fail loud: those are
    * operator-supplied paths and we refuse to silently delete user data.
    *
-   * Omit to disable self-healing (current D13-always-throws behaviour). The
-   * production runtimes always pass the workspaces root; tests opt in
-   * explicitly to exercise the recovery path.
+   * Omit to disable self-healing (throws on conflict instead). The production
+   * runtimes always pass the workspaces root; tests opt in explicitly to
+   * exercise the recovery path.
    */
   hubManagedRoots?: readonly string[];
 };
 
+/**
+ * Outcome of an `ensureSourceRepo` call, for logging / test assertions.
+ *   - `cloned`            fresh clone created
+ *   - `migrated-recloned` legacy shared-mirror worktree replaced with a clone
+ *   - `updated`           existing clone fast-forwarded to a new commit
+ *   - `unchanged`         existing clone fetched but already at target commit
+ *   - `skipped-dirty`         left as-is: working tree had local changes
+ *   - `skipped-local-commits` left as-is: branch has local commits ahead of upstream
+ *   - `skipped-in-use`        left as-is: another live session is using it
+ */
+export type SourceRepoOutcome =
+  | "cloned"
+  | "migrated-recloned"
+  | "updated"
+  | "unchanged"
+  | "skipped-dirty"
+  | "skipped-local-commits"
+  | "skipped-in-use";
+
 export interface GitMirrorManager {
-  ensureMirror(url: string): Promise<{ mirrorPath: string; elapsedMs: number; cloned: boolean }>;
-  fetchMirror(url: string): Promise<{ elapsedMs: number }>;
-  createWorktree(args: {
+  /**
+   * Ensure a standalone clone exists at `clonePath` and (when safe) is brought
+   * up to the latest default branch / pinned `ref`. Idempotent.
+   */
+  ensureSourceRepo(args: {
     url: string;
     ref?: string;
-    targetPath: string;
-    sessionKey: string;
+    clonePath: string;
     /**
-     * Identifier for the agent owning this worktree. Required so the derived
-     * branch name does not collide with peer agents in the same chat — see
-     * `deriveSessionBranchName` docblock.
+     * True when another live chat of this agent is currently using this
+     * checkout. The destructive `checkout -B` update is skipped when set, so a
+     * running chat's working tree never shifts mid-task. The caller owns the
+     * live-use registry (see source-repos.ts).
      */
-    agentName: string;
-  }): Promise<{ worktreePath: string; headCommit: string; branchName: string }>;
-  removeWorktree(args: { url: string; path: string; branchName: string }): Promise<void>;
-  gcMirrors(stillReferencedUrls: Set<string>): Promise<{ removed: string[] }>;
+    activelyInUse?: boolean;
+  }): Promise<{
+    clonePath: string;
+    headCommit: string;
+    /** Short name of the checked-out branch, or undefined when detached (pinned SHA). */
+    branch?: string;
+    outcome: SourceRepoOutcome;
+  }>;
+
+  /** Remove a standalone source-repo clone (best-effort, kills holders first). */
+  removeSourceRepo(args: { clonePath: string }): Promise<void>;
+
   /**
-   * Sweep `hub-session-*` branch refs (and their `[branch "..."]` config
-   * segments) that no live worktree holds across every mirror.
-   *
-   * Intra-process safety: callers must invoke this when no slot is mid-way
-   * through `createWorktree` on the same runtime — i.e. at runtime boot,
-   * before any slot starts. No `withUrlLock` is taken; the caller's timing
-   * is the guarantee.
-   *
-   * Cross-process caveat: a peer First Tree client (rare — happens during in-place
-   * upgrades or when an old install still runs in parallel) creating a
-   * worktree in its own `add` sequence has a microsecond window where the
-   * branch ref exists but its worktree admin record doesn't yet. If our
-   * scan lands in that window, we may delete a branch the peer is about to
-   * attach. The peer's next step then fails with "no such ref" (visible in
-   * their stderr), so the operator notices — but the failure is theirs, not
-   * data loss on our side. Not worth a cross-process lock for that window.
+   * One-time cleanup: delete the legacy shared `<dataDir>/git-mirrors/` tree
+   * left behind by the pre-refactor bare-mirror model. Pure cache, no state —
+   * safe to remove wholesale. Called once at runtime boot.
    */
-  gcOrphanSessionBranches(): Promise<{ scanned: number; deleted: number; failed: number }>;
-  readonly mirrorsRoot: string;
+  sweepLegacyMirrors(): Promise<{ removed: string[] }>;
+
+  /** Absolute path of the legacy shared-mirror root (for logging / tests). */
+  readonly legacyMirrorsRoot: string;
 }
 
 /**
- * Hash a repo URL into the mirror directory name.
- *
- * The hash is computed over a *canonical* form (host + path, lowercased
- * host, no `.git` suffix, no leading/trailing slash, no protocol, no
- * `user@` prefix), so the same upstream repo addressed via any of the
- * accepted forms (HTTPS, `ssh://`, or scp-like) all land in the same
- * mirror dir. That matters because:
- *   - admins may write any of those three forms into `source_repos[].url`
- *     (the schema accepts all of them)
- *   - the `fetchOrigin` fallback below transparently swaps protocols when
- *     credentials are missing — without canonical hashing, the fallback
- *     would silently maintain a second mirror dir
- *
- * Migration cost: pre-existing mirrors created before this change use the
- * raw-URL hash and will be orphaned after the upgrade. `gcMirrors` removes
- * them on the next run; the next fetch repopulates the canonical-keyed
- * mirror. No data loss — mirror is a cache, not state.
+ * Hash a repo URL into a stable short id over a *canonical* form (host + path,
+ * lowercased host, no `.git` suffix, no protocol, no `user@` prefix), so the
+ * same upstream repo addressed via any accepted form (HTTPS, `ssh://`, or
+ * scp-like) collapses to the same id. Retained for the legacy-mirror sweep and
+ * for any URL-keyed bookkeeping callers still want. Exported for unit testing.
  */
 export function hashUrl(url: string): string {
   return createHash("sha256").update(canonicalizeRepoUrl(url)).digest("hex").slice(0, 32);
 }
 
 /**
- * Reduce a repo URL to `<host[:port]>/<path-without-.git>`. Used as the
- * input to the mirror dir hash and exposed for unit testing.
+ * Reduce a repo URL to `<host[:port]>/<path-without-.git>`. Exposed for unit
+ * testing.
  *
  *   `https://github.com/foo/bar.git`         → `github.com/foo/bar`
  *   `git@github.com:foo/bar.git`             → `github.com/foo/bar`
  *   `ssh://git@github.com/foo/bar.git`       → `github.com/foo/bar`
  *   `ssh://git@gitlab.example.com:2222/x/y`  → `gitlab.example.com:2222/x/y`
  *
- * Falls back to the raw input for un-parseable strings — better to keep
- * a stable mirror than to throw mid-bootstrap.
+ * Falls back to the raw input for un-parseable strings.
  */
 export function canonicalizeRepoUrl(url: string): string {
-  // scp-like: `[user@]host:path` (no `://`, exactly one `:` between host
-  // and path, path doesn't look like a port number, path forbids leading
-  // `/` and any `:`/`@` — same rules as `SCP_LIKE_SSH_RE` in the shared
-  // schema, so what passes input validation is also what we can canonicalise.
+  // scp-like: `[user@]host:path` (no `://`, exactly one `:` between host and
+  // path, path doesn't look like a port number).
   if (!url.includes("://")) {
     const m = url.match(/^(?:[A-Za-z0-9_.-]+@)?([A-Za-z0-9.-]+):([^/@:\s][^@:\s]*)$/);
     const host = m?.[1];
@@ -176,8 +174,6 @@ export function canonicalizeRepoUrl(url: string): string {
   try {
     const parsed = new URL(url);
     const host = parsed.hostname.toLowerCase();
-    // Drop the port when it matches the protocol's default — keeps `https`
-    // and `ssh` (port 22) addressing the same upstream collapse to one dir.
     const portIsDefault =
       parsed.port === "" ||
       (parsed.protocol === "https:" && parsed.port === "443") ||
@@ -191,9 +187,7 @@ export function canonicalizeRepoUrl(url: string): string {
 }
 
 /**
- * Strip leading slashes, trailing slashes, and a trailing `.git`. Used by
- * `canonicalizeRepoUrl` so that `…/foo/bar`, `…/foo/bar/`, and `…/foo/bar.git`
- * all collapse to the same canonical path (and therefore the same mirror dir).
+ * Strip leading slashes, trailing slashes, and a trailing `.git`.
  */
 function normalizePath(rawPath: string): string {
   return rawPath
@@ -202,71 +196,25 @@ function normalizePath(rawPath: string): string {
     .replace(/\.git$/i, "");
 }
 
-function shortHash(input: string): string {
-  return createHash("sha256").update(input).digest("hex").slice(0, 8);
-}
-
-/**
- * Branch name a session's worktree attaches to. The hash inputs include the
- * agent dimension because `(chat, url)` alone is not unique: two agents that
- * share a chat each open their own worktree at
- * `<workspaces>/<agent>/<chatId>/...`, and git refuses to point two worktrees
- * at the same branch (`fatal: '<branch>' is already used by worktree at …`).
- * Hash inputs are joined with `:` so `(chatA, agentB)` cannot collide with
- * `(chatAB, "")`.
- *
- * The caller picks `agentName`. Prefer the operator-stable name
- * (`config.yaml::agents.<name>`); fall back to `agent.agentId` (a UUID,
- * globally unique) when the stable name isn't available. Anything stable
- * across `start` and `resume` for the same `(agent, chat)` pair will do —
- * the contract is "no collision with a peer agent in the same chat", not
- * "human-readable in the branch name".
- *
- * See docs/workspace-session-branch-collision-fix-design.md §3.2.
- */
-export function deriveSessionBranchName(sessionKey: string, agentName: string, url: string): string {
-  return `${SESSION_BRANCH_PREFIX}-${shortHash(`${sessionKey}:${agentName}`)}-${shortHash(url)}`;
-}
-
 /**
  * A value is SHA-like when it's a 7–40 character hex string. Used to decide
- * whether `ref` should be resolved via the remote namespace (branch name) or
- * used as-is (commit hash).
+ * whether `ref` is a pinned commit (checkout detached, do not chase the
+ * default branch) or a branch name (track + update to latest).
  */
 function looksLikeCommitSha(ref: string): boolean {
   return /^[0-9a-f]{7,40}$/i.test(ref);
 }
 
-/**
- * Identifies the cross-process `<gitdir>/config.lock` contention that
- * `git worktree add -b` surfaces as exit code 255 with stderr containing
- * `error: could not lock config file …`. Triggered when a peer git process
- * (e.g. a second First Tree client running an old install in parallel) is mid-way
- * through writing the same shared bare mirror's `config`. Safe to retry —
- * see the createWorktree retry loop for the recovery argument.
- */
-export function isConfigLockError(err: unknown): boolean {
-  if (!(err instanceof GitMirrorError)) return false;
-  return /could not lock config file/i.test(err.message);
-}
-
 export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirrorManager {
-  const mirrorsRoot = join(opts.dataDir, "git-mirrors");
+  const legacyMirrorsRoot = join(opts.dataDir, "git-mirrors");
   const cloneTimeoutMs =
     opts.cloneTimeoutMs ?? Number(process.env.FIRST_TREE_GIT_CLONE_TIMEOUT_MS ?? DEFAULT_CLONE_TIMEOUT_MS);
   const log = opts.log;
   const resolvedDataDir = resolve(opts.dataDir);
   const hubManagedRoots = (opts.hubManagedRoots ?? []).map((p) => resolve(p));
   // Fail loud at construction if any managed root would let the self-heal
-  // branch escape `<dataDir>`. Without this guard a misconfigured caller
-  // (`hubManagedRoots: ["/"]`, `[os.homedir()]`, etc.) would weaponise the
-  // `createWorktree` rm -rf path against arbitrary host paths. Strict subdir:
-  // the root itself MUST sit inside `dataDir` and MUST NOT equal `dataDir`
-  // (so we never grant "the whole First Tree data dir is fair game").
-  //
-  // Aggregate every bad root into one error so an operator who misconfigured
-  // multiple entries sees the whole picture on their first startup attempt
-  // instead of grinding through one-fix-then-restart cycles.
+  // rm -rf escape `<dataDir>`. Strict subdir: the root itself MUST sit inside
+  // `dataDir` and MUST NOT equal `dataDir`.
   const badRoots = hubManagedRoots.filter((root) => !isUnderManagedRoot(root, [resolvedDataDir]));
   if (badRoots.length > 0) {
     throw new GitMirrorError(
@@ -274,55 +222,39 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
     );
   }
 
-  // Per-URL serial queue. Prevents concurrent ensureMirror / fetchMirror /
-  // gcMirrors for the same URL from racing on the same directory.
-  const urlLocks = new Map<string, Promise<unknown>>();
+  // Per-clonePath serial queue. Prevents concurrent ensureSourceRepo /
+  // removeSourceRepo for the same checkout from racing on the same directory.
+  const pathLocks = new Map<string, Promise<unknown>>();
 
-  function withUrlLock<T>(url: string, op: () => Promise<T>): Promise<T> {
-    const key = hashUrl(url);
-    const prev = urlLocks.get(key) ?? Promise.resolve();
+  function withPathLock<T>(clonePath: string, op: () => Promise<T>): Promise<T> {
+    const key = resolve(clonePath);
+    const prev = pathLocks.get(key) ?? Promise.resolve();
     const next = prev.then(op, op);
-    urlLocks.set(key, next);
-    // Drop the map entry once the tail resolves so a long-lived manager doesn't
-    // leak one entry per URL forever. Silently swallow errors on this side
-    // channel — the real rejection is delivered via the returned `next`.
+    pathLocks.set(key, next);
     next.then(
       () => {
-        if (urlLocks.get(key) === next) urlLocks.delete(key);
+        if (pathLocks.get(key) === next) pathLocks.delete(key);
       },
       () => {
-        if (urlLocks.get(key) === next) urlLocks.delete(key);
+        if (pathLocks.get(key) === next) pathLocks.delete(key);
       },
     );
     return next;
   }
 
-  function mirrorDir(url: string): string {
-    return join(mirrorsRoot, hashUrl(url));
-  }
-
   async function git(args: string[], cwd: string | null, timeoutMs: number, env?: NodeJS.ProcessEnv) {
     const start = Date.now();
     // Always disable git's tty prompt — under systemd / launchd the tty open
-    // returns ENXIO ("No such device or address") which manifests as a confusing
-    // `could not read Username for '<realm>'` line in stderr; under interactive
-    // shells it would block the request indefinitely instead of failing fast
-    // (defeating the ssh-fallback path below). Callers can still override by
-    // passing an `env` that sets `GIT_TERMINAL_PROMPT` explicitly.
-    // Force `LC_ALL=C` so git/ssh stderr stays in English regardless of the
-    // caller's locale — the credential-shape and transient-network heuristics
-    // below match against stderr substrings, and a localized message would
-    // silently break classification (and the protocol-fallback decision that
-    // hangs off it). Placed after the spread so it overrides any inherited
-    // LC_ALL from `process.env`; `GIT_TERMINAL_PROMPT` stays before the spread
-    // so tests can opt back into prompting if they need to.
+    // returns ENXIO which manifests as a confusing `could not read Username`
+    // line in stderr; under interactive shells it would block indefinitely
+    // (defeating the protocol-fallback path below). Force `LC_ALL=C` so
+    // git/ssh stderr stays English regardless of locale — the credential-shape
+    // and transient-network heuristics match against stderr substrings.
     const baseEnv = env ?? process.env;
     const finalEnv = { GIT_TERMINAL_PROMPT: "0", ...baseEnv, LC_ALL: "C" };
     return await new Promise<{ stdout: string; stderr: string; elapsedMs: number }>((resolveExec, rejectExec) => {
-      // Bug 3 fix: track every git subprocess in the ChildProcessRegistry so
-      // the lifecycle shutdown hook can kill stragglers if systemd SIGTERMs
-      // us mid-fetch. The existing per-call setTimeout below still owns the
-      // operation timeout; the registry provides a global cleanup tracker.
+      // Track every git subprocess in the ChildProcessRegistry so the lifecycle
+      // shutdown hook can kill stragglers if systemd SIGTERMs us mid-fetch.
       const { child: proc } = getChildProcessRegistry().spawn("git", args, {
         category: "git",
         label: `git ${args.join(" ").slice(0, 120)}`,
@@ -383,93 +315,28 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
   }
 
   /**
-   * `git fetch --prune origin` with one-shot bidirectional protocol fallback.
+   * Run a remote-talking git op (`clone` / `fetch`) with one-shot bidirectional
+   * protocol fallback. Decides direction from `url`'s protocol:
+   *   - HTTPS → on credential-shaped failure, retry as SSH
+   *   - SSH   → on credential-shaped failure, retry as HTTPS
+   * Network failures, missing-ref errors, and TLS surprises propagate as-is.
    *
-   * Decides direction from `originUrl`'s protocol:
-   *   - HTTPS origin → on credential-shaped failure, retry as SSH
-   *   - SSH   origin → on credential-shaped failure, retry as HTTPS
-   * The fallback fires only when **all** hold:
-   *   1. The first attempt failed with a credential-shaped error in the
-   *      direction-appropriate sense (`isLikelyHttpsAuthFailure` /
-   *      `isLikelySshAuthFailure`). Network failures, missing-ref errors,
-   *      and TLS/host-key surprises propagate as-is — those won't be cured
-   *      by switching transports and silently retrying would mask real bugs.
-   *   2. The origin URL maps to a usable peer-protocol form
-   *      (see `httpsToSshBaseRewrite` / `sshToHttpsBaseRewrite`). Custom
-   *      ports beyond the protocol default disable the rewrite — there's no
-   *      universal mapping between `https://host:8443` and an SSH peer.
-   *
-   * Implementation: the retry uses `git -c url.<peer-base>.insteadOf=<origin-base>`
-   * — git resolves origin's URL through that rewrite for the duration of
-   * one subprocess and never persists anything to disk. The mirror's
-   * `remote.origin.url` stays as configured, so the next fetch starts back
-   * at the original protocol unless this fallback fires again.
+   * The retry uses `git -c url.<peer-base>.insteadOf=<origin-base>` — git
+   * resolves the URL through that rewrite for one subprocess and never persists
+   * anything. `partialCleanup` is invoked between attempts so a half-written
+   * clone dir is removed before the fallback retries the same target.
    */
-  /**
-   * `remote set-head --auto` is a remote-talking op too — under the same
-   * credential rules as `fetch`. If we don't apply the same fallback,
-   * mirrors whose HTTPS creds are missing end up with `refs/remotes/origin/HEAD`
-   * unset, which then breaks `resolveBase()` for callers without an explicit
-   * `ref` (the default-branch lookup throws).
-   *
-   * Strategy mirrors `fetchOrigin`: try the configured protocol first, fall
-   * back to the peer protocol once via `-c url.<peer>.insteadOf=<origin>`.
-   * Returns true on either success, false if both attempts failed (which
-   * mirrors the historical `gitOk` semantics — non-fatal). No `GitMirrorAuthError`
-   * here: callers that need origin/HEAD already get a clear
-   * `GitMirrorError("Cannot resolve default branch …")` if both attempts fail.
-   */
-  /**
-   * Worst-case sleep budget: ~10s (primary ~5s + fallback ~5s). Unlike
-   * `fetchOrigin`, which gates fallback on a credential-shaped terminal
-   * error, `setHeadAuto` always falls through on any primary failure, so
-   * a doubly-transient run pays both retry budgets. Per-call 30s timeout
-   * still caps each individual git invocation.
-   */
-  async function setHeadAuto(mirrorPath: string, originUrl: string): Promise<boolean> {
+  async function remoteGitWithProtocolFallback(args: {
+    gitArgs: string[];
+    cwd: string | null;
+    url: string;
+    opLabel: string;
+    partialCleanup?: () => void;
+  }): Promise<{ elapsedMs: number; usedFallback: boolean }> {
+    const { gitArgs, cwd, url, opLabel, partialCleanup } = args;
+    const direction = pickFallbackDirection(url);
     try {
-      await gitWithNetworkRetry(["remote", "set-head", "origin", "--auto"], mirrorPath, 30_000, "set-head:primary");
-      return true;
-    } catch {
-      // Primary attempt failed terminally (after any transient retries). Fall
-      // through to the SSH-side rewrite — same fallback rules as fetchOrigin.
-    }
-    const direction = pickFallbackDirection(originUrl);
-    if (!direction) return false;
-    try {
-      await gitWithNetworkRetry(
-        ["-c", `url.${direction.peerBase}.insteadOf=${direction.originBase}`, "remote", "set-head", "origin", "--auto"],
-        mirrorPath,
-        30_000,
-        "set-head:fallback",
-      );
-      return true;
-    } catch {
-      return false;
-    }
-  }
-
-  async function readOriginUrl(mirrorPath: string): Promise<string | null> {
-    try {
-      const { stdout } = await git(["config", "--get", "remote.origin.url"], mirrorPath, 10_000);
-      return stdout.trim() || null;
-    } catch {
-      return null;
-    }
-  }
-
-  async function fetchOrigin(
-    mirrorPath: string,
-    originUrl: string,
-  ): Promise<{ elapsedMs: number; usedFallback: boolean }> {
-    const direction = pickFallbackDirection(originUrl);
-    try {
-      const { elapsedMs } = await gitWithNetworkRetry(
-        ["fetch", "--prune", "origin"],
-        mirrorPath,
-        cloneTimeoutMs,
-        "fetch:primary",
-      );
+      const { elapsedMs } = await gitWithNetworkRetry(gitArgs, cwd, cloneTimeoutMs, `${opLabel}:primary`);
       return { elapsedMs, usedFallback: false };
     } catch (primaryErr) {
       const primaryMessage = primaryErr instanceof Error ? primaryErr.message : String(primaryErr);
@@ -478,26 +345,27 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
       }
       log?.info(
         {
-          gitUrl: originUrl,
+          gitUrl: url,
           fromProtocol: direction.fromProtocol,
           toProtocol: direction.toProtocol,
           peerBase: direction.peerBase,
         },
-        "fetch failed with credential-shaped error; retrying with peer-protocol insteadOf rewrite",
+        `${opLabel} failed with credential-shaped error; retrying with peer-protocol insteadOf rewrite`,
       );
+      partialCleanup?.();
       try {
         const { elapsedMs } = await gitWithNetworkRetry(
-          ["-c", `url.${direction.peerBase}.insteadOf=${direction.originBase}`, "fetch", "--prune", "origin"],
-          mirrorPath,
+          ["-c", `url.${direction.peerBase}.insteadOf=${direction.originBase}`, ...gitArgs],
+          cwd,
           cloneTimeoutMs,
-          "fetch:fallback",
+          `${opLabel}:fallback`,
         );
-        log?.info({ gitUrl: originUrl, toProtocol: direction.toProtocol }, "protocol-fallback fetch succeeded");
+        log?.info({ gitUrl: url, toProtocol: direction.toProtocol }, `protocol-fallback ${opLabel} succeeded`);
         return { elapsedMs, usedFallback: true };
       } catch (peerErr) {
         const peerMessage = peerErr instanceof Error ? peerErr.message : String(peerErr);
         throw new GitMirrorAuthError(
-          `Could not fetch ${originUrl} over ${direction.fromProtocol.toUpperCase()} or ${direction.toProtocol.toUpperCase()}. ` +
+          `Could not ${opLabel} ${url} over ${direction.fromProtocol.toUpperCase()} or ${direction.toProtocol.toUpperCase()}. ` +
             `${direction.fromProtocol.toUpperCase()} attempt failed: ${truncate(primaryMessage)} ` +
             `${direction.toProtocol.toUpperCase()} retry (${direction.peerBase}) failed: ${truncate(peerMessage)}`,
         );
@@ -505,172 +373,288 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
     }
   }
 
-  /**
-   * Bring the mirror's config to the invariant expected by this module:
-   * fetch refspec = `+refs/heads/*:refs/remotes/origin/*`, `remote.origin.mirror`
-   * absent, `refs/remotes/origin/HEAD` resolvable.
-   *
-   * Called from `ensureMirror` on every invocation — both the fresh-clone path
-   * (ensures our own bootstrap wrote the right values) and the pre-existing
-   * mirror path (repairs drift from the legacy `--mirror` config).
-   */
-  async function assertMirrorConfig(mirrorPath: string, url: string): Promise<{ migrated: boolean }> {
-    let migrated = false;
-
-    // Read current fetch spec. `--get-all` returns every value on its own line;
-    // empty stdout means the key is absent.
-    let currentFetch = "";
+  /** Fresh `git clone <url> <clonePath>` with protocol fallback. `clonePath` must not yet exist / be empty. */
+  async function cloneRepo(absTarget: string, url: string): Promise<void> {
+    mkdirSync(dirname(absTarget), { recursive: true });
     try {
-      const { stdout } = await git(["config", "--get-all", "remote.origin.fetch"], mirrorPath, 10_000);
-      currentFetch = stdout.trim();
-    } catch {
-      currentFetch = "";
+      await remoteGitWithProtocolFallback({
+        gitArgs: ["clone", url, absTarget],
+        cwd: null,
+        url,
+        opLabel: "clone",
+        partialCleanup: () => {
+          if (existsSync(absTarget)) rmSync(absTarget, { recursive: true, force: true });
+        },
+      });
+    } catch (err) {
+      // Leave no half-written clone behind for the next session to trip over.
+      if (existsSync(absTarget)) rmSync(absTarget, { recursive: true, force: true });
+      throw err;
     }
+  }
 
-    if (currentFetch !== FETCH_REFSPEC) {
-      // Replace whatever is there with exactly our refspec.
-      await git(["config", "--replace-all", "remote.origin.fetch", FETCH_REFSPEC], mirrorPath, 10_000);
-      migrated = true;
-    }
-
-    // `mirror = true` forces every fetch to prune & force-update every ref —
-    // must be unset for our refspec to behave as intended.
-    const mirrorFlag = await gitOk(["config", "--get", "remote.origin.mirror"], mirrorPath, 10_000);
-    if (mirrorFlag) {
-      await git(["config", "--unset-all", "remote.origin.mirror"], mirrorPath, 10_000);
-      migrated = true;
-    }
-
-    // Ensure origin URL matches (a mismatched URL would make migration silently
-    // pick up from the wrong upstream — refuse).
+  /**
+   * Reconcile an existing clone's `remote.origin.url` with the configured `url`.
+   * An operator may have repointed this localPath at a different repo, or
+   * switched protocols (HTTPS ↔ SSH). Compared canonically so an equivalent
+   * re-addressing of the same upstream is a no-op; a genuine change is written
+   * so the subsequent fetch + `checkout -B` track the configured upstream
+   * instead of silently serving the old one.
+   */
+  async function reconcileOrigin(absTarget: string, url: string): Promise<void> {
+    let current = "";
     try {
-      const { stdout } = await git(["config", "--get", "remote.origin.url"], mirrorPath, 10_000);
-      const currentUrl = stdout.trim();
-      if (currentUrl !== url) {
-        await git(["config", "--replace-all", "remote.origin.url", url], mirrorPath, 10_000);
-        migrated = true;
-      }
+      const { stdout } = await git(["config", "--get", "remote.origin.url"], absTarget, 10_000);
+      current = stdout.trim();
     } catch {
-      await git(["remote", "add", "origin", url], mirrorPath, 10_000);
-      migrated = true;
+      current = "";
     }
-
-    if (migrated) {
-      // Populate `refs/remotes/origin/*` and set `origin/HEAD`. Without this,
-      // newly-migrated mirrors have no remote-tracking refs to base worktrees on.
-      await fetchOrigin(mirrorPath, url);
-      await setHeadAuto(mirrorPath, url);
-      log?.info({ gitUrl: url }, "mirror config migrated");
+    if (!current) {
+      await git(["remote", "add", "origin", url], absTarget, 10_000);
+      return;
     }
-
-    return { migrated };
-  }
-
-  /**
-   * Bootstrap a fresh mirror at `mirrorPath`. Uses `git init --bare` +
-   * manual remote setup rather than `git clone --mirror` / `git clone --bare`,
-   * so we never transiently have the mirror configured to force-write
-   * `refs/heads/*` on fetch.
-   */
-  async function bootstrapMirror(mirrorPath: string, url: string): Promise<void> {
-    mkdirSync(dirname(mirrorPath), { recursive: true });
-    await git(["init", "--bare", mirrorPath], null, cloneTimeoutMs);
-    await git(["remote", "add", "origin", url], mirrorPath, 10_000);
-    await git(["config", "--replace-all", "remote.origin.fetch", FETCH_REFSPEC], mirrorPath, 10_000);
-    await fetchOrigin(mirrorPath, url);
-    await setHeadAuto(mirrorPath, url);
-  }
-
-  async function branchExists(mirrorPath: string, branchName: string): Promise<boolean> {
-    return await gitOk(["rev-parse", "--verify", "--quiet", `refs/heads/${branchName}`], mirrorPath, 10_000);
-  }
-
-  /**
-   * Resolve the commit-ish to base a new session branch on.
-   *
-   * - explicit SHA → use as-is
-   * - explicit branch name → prefer `refs/remotes/origin/<ref>`, fall back to
-   *   a literal SHA resolution in case the caller handed us a short commit
-   * - `ref` absent → `refs/remotes/origin/HEAD`
-   */
-  async function resolveBase(mirrorPath: string, ref: string | undefined): Promise<string> {
-    if (!ref) {
-      if (await gitOk(["rev-parse", "--verify", "--quiet", "refs/remotes/origin/HEAD"], mirrorPath, 10_000)) {
-        return "refs/remotes/origin/HEAD";
-      }
-      // Self-heal: mirrors created before the bidirectional-fallback fix may
-      // have had `set-head --auto` run over a broken protocol and skipped
-      // silently, leaving origin/HEAD unset. Try once now via the same
-      // fallback-aware path. No-op if it succeeds-then-fails-again.
-      const url = await readOriginUrl(mirrorPath);
-      if (url && (await setHeadAuto(mirrorPath, url))) {
-        if (await gitOk(["rev-parse", "--verify", "--quiet", "refs/remotes/origin/HEAD"], mirrorPath, 10_000)) {
-          log?.info({ mirrorPath, gitUrl: url }, "origin/HEAD self-healed via setHeadAuto");
-          return "refs/remotes/origin/HEAD";
-        }
-      }
-      throw new GitMirrorError(
-        "Cannot resolve default branch: refs/remotes/origin/HEAD is missing. Re-run with an explicit `ref`.",
+    if (canonicalizeRepoUrl(current) !== canonicalizeRepoUrl(url)) {
+      await git(["remote", "set-url", "origin", url], absTarget, 10_000);
+      // The new upstream may have a different default branch name (e.g.
+      // master → main). A plain fetch does NOT refresh `refs/remotes/origin/HEAD`,
+      // so without this the no-`ref` update path would resolve the OLD repo's
+      // default branch. Best-effort — `defaultBranchShort` self-heals again later.
+      await gitOk(["remote", "set-head", "origin", "--auto"], absTarget, 30_000);
+      log?.info(
+        { clonePath: absTarget, from: current, to: url },
+        "source-repo origin URL reconciled to configured url",
       );
     }
-    if (looksLikeCommitSha(ref)) {
-      if (await gitOk(["cat-file", "-e", ref], mirrorPath, 10_000)) return ref;
+  }
+
+  /** `git fetch --prune origin` against an existing clone, with protocol fallback. */
+  async function fetchClone(absTarget: string, url: string): Promise<{ elapsedMs: number }> {
+    const { elapsedMs } = await remoteGitWithProtocolFallback({
+      gitArgs: ["fetch", "--prune", "origin"],
+      cwd: absTarget,
+      url,
+      opLabel: "fetch",
+    });
+    return { elapsedMs };
+  }
+
+  async function headCommit(absTarget: string): Promise<string> {
+    const head = await git(["rev-parse", "HEAD"], absTarget, 30_000);
+    return head.stdout.trim();
+  }
+
+  /** Short branch name, or undefined when detached (`git rev-parse --abbrev-ref HEAD` → `HEAD`). */
+  async function currentBranch(absTarget: string): Promise<string | undefined> {
+    try {
+      const { stdout } = await git(["rev-parse", "--abbrev-ref", "HEAD"], absTarget, 10_000);
+      const name = stdout.trim();
+      return name && name !== "HEAD" ? name : undefined;
+    } catch {
+      return undefined;
     }
-    const remoteRef = `refs/remotes/origin/${ref}`;
-    if (await gitOk(["rev-parse", "--verify", "--quiet", remoteRef], mirrorPath, 10_000)) {
-      return remoteRef;
+  }
+
+  /**
+   * A working tree is "dirty" when `git status --porcelain` reports anything —
+   * staged, unstaged, or untracked (gitignored paths like `node_modules` /
+   * build caches do NOT appear, so a freshly-cloned, never-installed repo reads
+   * clean). Dirty checkouts are left untouched by the update path.
+   */
+  async function isDirty(absTarget: string): Promise<boolean> {
+    const { stdout } = await git(["status", "--porcelain", "--untracked-files=normal"], absTarget, 30_000);
+    return stdout.trim().length > 0;
+  }
+
+  /** Short name of the remote default branch, e.g. `main`. Null if unresolved. */
+  async function defaultBranchShort(absTarget: string): Promise<string | null> {
+    // `git symbolic-ref refs/remotes/origin/HEAD` → `refs/remotes/origin/main`
+    try {
+      const { stdout } = await git(["symbolic-ref", "refs/remotes/origin/HEAD"], absTarget, 10_000);
+      const ref = stdout.trim();
+      const m = ref.match(/^refs\/remotes\/origin\/(.+)$/);
+      if (m?.[1]) return m[1];
+    } catch {
+      // origin/HEAD not set — fall through to the repair below.
     }
-    // Last resort: let git resolve `ref` against whatever it can find (tags,
-    // local heads, etc.). If this fails the error surfaces to the caller.
-    return ref;
+    // Self-heal: ask the remote which branch HEAD points at and set it locally.
+    if (await gitOk(["remote", "set-head", "origin", "--auto"], absTarget, 30_000)) {
+      try {
+        const { stdout } = await git(["symbolic-ref", "refs/remotes/origin/HEAD"], absTarget, 10_000);
+        const m = stdout.trim().match(/^refs\/remotes\/origin\/(.+)$/);
+        if (m?.[1]) return m[1];
+      } catch {
+        // give up below
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Is `absTarget` a First Tree-managed standalone clone? True when it has a real
+   * `.git` *directory* (not the `.git` *file* of a legacy shared-mirror
+   * worktree, and not a non-git directory an operator dropped there).
+   */
+  function isStandaloneClone(absTarget: string): boolean {
+    const gitPath = join(absTarget, ".git");
+    if (!existsSync(gitPath)) return false;
+    try {
+      return statSync(gitPath).isDirectory();
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Is `absTarget` a legacy shared-mirror worktree (the pre-refactor layout)?
+   * Those have a `.git` *file* that points back into `<dataDir>/git-mirrors/`.
+   * Detected so the first post-upgrade session can migrate it to a standalone
+   * clone in place.
+   */
+  function isLegacyWorktreeCheckout(absTarget: string): boolean {
+    const gitPath = join(absTarget, ".git");
+    if (!existsSync(gitPath)) return false;
+    try {
+      return statSync(gitPath).isFile();
+    } catch {
+      return false;
+    }
+  }
+
+  /** Wipe a leftover at `absTarget` (killing holders if under a managed root) so a clone can take its place. */
+  async function reclaimTarget(absTarget: string, reason: string): Promise<void> {
+    if (hubManagedRoots.length > 0 && isUnderManagedRoot(absTarget, hubManagedRoots)) {
+      log?.warn({ targetPath: absTarget, reason }, "reclaiming source-repo target (kill holders + rm -rf)");
+      await killProcessesHoldingPath(absTarget, log);
+      rmSync(absTarget, { recursive: true, force: true });
+      if (existsSync(absTarget)) {
+        throw new GitMirrorWorktreeConflictError(
+          `Source-repo target "${absTarget}" still occupied after reclaim (${reason}) — aborting`,
+        );
+      }
+      return;
+    }
+    throw new GitMirrorWorktreeConflictError(
+      `Source-repo target "${absTarget}" occupied by ${classifyOccupant(absTarget)} (${reason}) and not inside a First Tree-managed root — aborting (refusing to delete operator data)`,
+    );
+  }
+
+  /**
+   * Bring a clean, not-in-use clone to the requested commit-ish.
+   * - explicit SHA `ref`   → detached checkout at that commit (pinned; no chase)
+   * - explicit branch `ref`→ `checkout -B <ref> origin/<ref>`
+   * - no `ref`             → `checkout -B <default> origin/<default>`
+   *
+   * Returns `"skipped-local-commits"` (and makes NO change) when the checkout's
+   * current HEAD is strictly ahead of the resolved branch tip on the *same*
+   * lineage — i.e. someone committed local work on top of the tracked branch.
+   * `checkout -B` would orphan those commits, so we refuse and leave the
+   * checkout as-is. A diverged/unrelated HEAD (e.g. after an origin repoint) is
+   * NOT ahead-on-the-same-lineage, so it still resets cleanly. A pinned SHA
+   * `ref` is explicit operator intent and is always applied.
+   */
+  async function updateToLatest(
+    absTarget: string,
+    ref: string | undefined,
+  ): Promise<"applied" | "skipped-local-commits"> {
+    if (ref && looksLikeCommitSha(ref)) {
+      if (await gitOk(["cat-file", "-e", ref], absTarget, 10_000)) {
+        await git(["checkout", "--force", "--detach", ref], absTarget, cloneTimeoutMs);
+        return "applied";
+      }
+      // Not a known object — fall through to treat it as a branch name.
+    }
+    const branch = ref ?? (await defaultBranchShort(absTarget));
+    if (!branch) {
+      throw new GitMirrorError(
+        `Cannot update "${absTarget}": no ref given and refs/remotes/origin/HEAD is unresolvable. Re-run with an explicit ref.`,
+      );
+    }
+    const remoteRef = `refs/remotes/origin/${branch}`;
+    if (!(await gitOk(["rev-parse", "--verify", "--quiet", remoteRef], absTarget, 10_000))) {
+      throw new GitMirrorError(
+        `Cannot update "${absTarget}": remote-tracking ref "${remoteRef}" not found after fetch.`,
+      );
+    }
+    // Data-loss guard: skip the destructive reset when HEAD carries commits the
+    // remote tip does NOT contain, on a *shared* history — i.e. local work
+    // committed on top of (or diverged from) the tracked branch. `checkout -B`
+    // would orphan those commits.
+    //   - related (common ancestor exists) AND HEAD not an ancestor of remote
+    //     → HEAD has its own commits → SKIP.
+    //   - HEAD is an ancestor of remote (fast-forward, incl. equal)        → reset.
+    //   - unrelated history (no common ancestor, e.g. origin repointed at a
+    //     different repo)                                                  → reset.
+    const related = await gitOk(["merge-base", remoteRef, "HEAD"], absTarget, 10_000);
+    const headIsAncestorOfRemote = await gitOk(["merge-base", "--is-ancestor", "HEAD", remoteRef], absTarget, 10_000);
+    if (related && !headIsAncestorOfRemote) {
+      return "skipped-local-commits";
+    }
+    // `checkout -B` with a clean tree moves the local branch to the remote tip
+    // and updates the working tree. Force-guards against a transient index lock.
+    await git(["checkout", "-B", branch, remoteRef], absTarget, cloneTimeoutMs);
+    return "applied";
   }
 
   return {
-    get mirrorsRoot() {
-      return mirrorsRoot;
+    get legacyMirrorsRoot() {
+      return legacyMirrorsRoot;
     },
 
-    ensureMirror(url) {
-      return withUrlLock(url, async () => {
-        mkdirSync(mirrorsRoot, { recursive: true });
-        const path = mirrorDir(url);
-        if (existsSync(join(path, "HEAD"))) {
-          const { migrated } = await assertMirrorConfig(path, url);
-          if (migrated) {
-            // migration fetched already; report elapsed as 0 to preserve the
-            // existing "cloned === false => fast path" contract.
-          }
-          return { mirrorPath: path, elapsedMs: 0, cloned: false };
-        }
-        const start = Date.now();
-        try {
-          await bootstrapMirror(path, url);
-          const elapsedMs = Date.now() - start;
-          log?.debug({ gitUrl: url, elapsedMs, cloned: true }, "mirror ensured");
-          return { mirrorPath: path, elapsedMs, cloned: true };
-        } catch (err) {
-          if (err instanceof GitMirrorTimeoutError) {
-            log?.warn({ gitUrl: url, timeoutMs: cloneTimeoutMs, elapsedMs: cloneTimeoutMs }, "mirror clone timeout");
-          }
-          if (existsSync(path)) rmSync(path, { recursive: true, force: true });
-          throw err;
-        }
-      });
-    },
+    ensureSourceRepo({ url, ref, clonePath, activelyInUse }) {
+      return withPathLock(clonePath, async () => {
+        const absTarget = resolve(clonePath);
+        const finish = async (outcome: SourceRepoOutcome) => ({
+          clonePath: absTarget,
+          headCommit: await headCommit(absTarget),
+          branch: await currentBranch(absTarget),
+          outcome,
+        });
 
-    fetchMirror(url) {
-      return withUrlLock(url, async () => {
-        const path = mirrorDir(url);
-        if (!existsSync(join(path, "HEAD"))) {
-          throw new GitMirrorError(`Cannot fetch — no mirror exists for "${url}"`);
-        }
+        // (0) A symlink at the target is never one of our clones — `existsSync`
+        // / `statSync` follow links, so without this guard a symlink pointing at
+        // some real `.git` dir would be adopted and fetched/`checkout -B`'d
+        // against the operator's link target. Reclaim it (inside a managed root)
+        // or fail loud. `lstat` so a dangling link is caught too.
+        let linkStat: ReturnType<typeof lstatSync> | null = null;
         try {
-          const { elapsedMs } = await fetchOrigin(path, url);
-          return { elapsedMs };
+          linkStat = lstatSync(absTarget);
+        } catch {
+          linkStat = null;
+        }
+        if (linkStat?.isSymbolicLink()) {
+          await reclaimTarget(absTarget, "symlink occupant");
+        }
+
+        // (1) Migration: a legacy shared-mirror worktree (`.git` is a FILE) →
+        // replace in place with a standalone clone.
+        if (existsSync(absTarget) && isLegacyWorktreeCheckout(absTarget)) {
+          await reclaimTarget(absTarget, "legacy shared-mirror worktree");
+          await cloneRepo(absTarget, url);
+          if (ref) await updateToLatest(absTarget, ref);
+          return finish("migrated-recloned");
+        }
+
+        // (2) Existing path occupied by a non-managed directory → reclaim or fail.
+        if (existsSync(absTarget) && !isStandaloneClone(absTarget)) {
+          await reclaimTarget(absTarget, "non-managed directory");
+        }
+
+        // (3) Fresh clone.
+        if (!existsSync(absTarget)) {
+          await cloneRepo(absTarget, url);
+          if (ref) await updateToLatest(absTarget, ref);
+          return finish("cloned");
+        }
+
+        // (4) Managed standalone clone → reconcile origin, fetch, then update when safe.
+        try {
+          await reconcileOrigin(absTarget, url);
+          await fetchClone(absTarget, url);
         } catch (err) {
           log?.warn(
             {
               gitUrl: url,
+              clonePath: absTarget,
               errorCode:
                 err instanceof GitMirrorAuthError
                   ? "auth-failed"
@@ -681,270 +665,74 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
                       : "unknown",
               stderr: err instanceof Error ? err.message.slice(0, 1024) : String(err).slice(0, 1024),
             },
-            "mirror fetch failed",
+            "source-repo fetch failed",
           );
           throw err;
         }
+
+        if (activelyInUse) {
+          log?.debug({ clonePath: absTarget }, "source-repo update skipped — another live session is using it");
+          return finish("skipped-in-use");
+        }
+        if (await isDirty(absTarget)) {
+          log?.warn(
+            { clonePath: absTarget },
+            "source-repo has local changes — leaving at current commit, not updating to latest",
+          );
+          return finish("skipped-dirty");
+        }
+
+        const before = await headCommit(absTarget);
+        const update = await updateToLatest(absTarget, ref);
+        if (update === "skipped-local-commits") {
+          log?.warn(
+            { clonePath: absTarget },
+            "source-repo has local commits ahead of upstream — leaving at current commit, not resetting to latest",
+          );
+          return finish("skipped-local-commits");
+        }
+        const after = await headCommit(absTarget);
+        return finish(after === before ? "unchanged" : "updated");
       });
     },
 
-    createWorktree({ url, ref, targetPath, sessionKey, agentName }) {
-      return withUrlLock(url, async () => {
-        const mirror = mirrorDir(url);
-        if (!existsSync(join(mirror, "HEAD"))) {
-          throw new GitMirrorError(`Cannot create worktree — no mirror exists for "${url}"`);
-        }
-        const absTarget = resolve(targetPath);
-        const branchName = deriveSessionBranchName(sessionKey, agentName, url);
-
-        // D13: target path must be free OR a First Tree-managed worktree we can reuse.
-        // Self-heal exception: when the path sits inside a First Tree-managed root the
-        // leftover is almost always an orphaned dev-server cache (vite/.vite,
-        // node_modules/.cache, etc) re-written by a daemonised child that
-        // outlived the previous session — see worktree-cleanup.ts header for
-        // the full incident. Kill any process still holding it, rm -rf, and
-        // fall through to the normal `git worktree add` path.
-        if (existsSync(absTarget) && !isHubManagedWorktree(absTarget)) {
-          const occupantKind = classifyOccupant(absTarget);
-          if (hubManagedRoots.length > 0 && isUnderManagedRoot(absTarget, hubManagedRoots)) {
-            log?.warn(
-              {
-                gitUrl: url,
-                targetPath: absTarget,
-                occupantKind,
-                hubManagedRoots,
-              },
-              "worktree target occupied inside First Tree-managed root — auto-recovering (kill holders + rm -rf)",
-            );
-            await killProcessesHoldingPath(absTarget, log);
-            try {
-              rmSync(absTarget, { recursive: true, force: true });
-            } catch (err) {
-              throw new GitMirrorWorktreeConflictError(
-                `Worktree target "${absTarget}" cleanup failed after killing holders: ${
-                  err instanceof Error ? err.message : String(err)
-                } (D13)`,
-              );
-            }
-            if (existsSync(absTarget)) {
-              throw new GitMirrorWorktreeConflictError(
-                `Worktree target "${absTarget}" still occupied after auto-recovery — aborting (D13)`,
-              );
-            }
-          } else {
-            log?.warn(
-              {
-                gitUrl: url,
-                targetPath: absTarget,
-                occupantKind,
-              },
-              "worktree create conflict",
-            );
-            throw new GitMirrorWorktreeConflictError(
-              `Worktree target "${absTarget}" is already occupied by ${occupantKind} — aborting (D13)`,
-            );
-          }
-        }
-
-        // Crash-recovery matrix + cross-process race recovery, wrapped in a
-        // retry loop. `withUrlLock` already serialises everything in *this*
-        // process, but the shared bare mirror has no inter-process lock —
-        // a second First Tree client (rare, but happens during in-place upgrades or
-        // when an old install hasn't been uninstalled) can still race on
-        // `<gitdir>/config.lock` while writing upstream tracking, which makes
-        // `worktree add -b` exit 255 with `could not lock config file`.
-        //
-        // A config-lock failure happens in git's `setup_tracking` step, which
-        // runs AFTER the branch ref + worktree admin record + path dir are
-        // created. So the failure leaves the repo in either `path + hasBranch`
-        // or `!path + hasBranch` depending on exactly which sub-step lost the
-        // race — but the matrix below handles both: reuse (short-circuit) or
-        // attach-existing (`worktree add <path> <branch>`, no `-b`), neither
-        // of which writes upstream config, so retry cannot re-collide.
-        const maxAttempts = 3;
-        for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-          // Pre-add cleanup: when a previous owner of `absTarget` crashed or
-          // the directory was wiped externally, the bare mirror retains a
-          // "prunable" worktree admin record. A subsequent `git worktree add`
-          // against the same path then fails with
-          //   `fatal: '<path>' is a missing but already registered worktree`.
-          // `prune` is idempotent and safe — it only removes records whose
-          // backing directory no longer exists. Live worktrees that we own
-          // (e.g. the same agent's other chats) are untouched.
-          await gitOk(["worktree", "prune"], mirror, 10_000);
-
-          const pathExists = existsSync(absTarget);
-          const hasBranch = await branchExists(mirror, branchName);
-
-          mkdirSync(dirname(absTarget), { recursive: true });
-
-          // Crash-recovery matrix (see refactor plan §5.3):
-          //   path + branch    → reuse (short-circuit here even though callers also
-          //                       short-circuit; defensive, cheap)
-          //   !path + !branch  → `worktree add -b <branch> <path> <base>`
-          //   !path + branch   → `worktree add <path> <branch>` (attach existing)
-          //   path + !branch   → corruption; refuse rather than guess
-          try {
-            if (pathExists && hasBranch) {
-              // Already wired up — treat as successful reuse.
-            } else if (pathExists && !hasBranch) {
-              throw new GitMirrorError(
-                `Worktree directory "${absTarget}" exists as a First Tree worktree but the expected session branch "${branchName}" is missing in the mirror — manual cleanup required`,
-              );
-            } else if (!pathExists && hasBranch) {
-              await git(["worktree", "add", absTarget, branchName], mirror, cloneTimeoutMs);
-            } else {
-              const base = await resolveBase(mirror, ref);
-              await git(["worktree", "add", "-b", branchName, absTarget, base], mirror, cloneTimeoutMs);
-            }
-            break;
-          } catch (err) {
-            if (attempt < maxAttempts && isConfigLockError(err)) {
-              const delayMs = 50 * 2 ** (attempt - 1) + Math.floor(Math.random() * 50);
-              log?.warn(
-                { gitUrl: url, branchName, attempt, delayMs },
-                "worktree add hit config lock contention — retrying",
-              );
-              await new Promise((r) => setTimeout(r, delayMs));
-              continue;
-            }
-            throw err;
-          }
-        }
-
-        const head = await git(["rev-parse", "HEAD"], absTarget, 30_000);
-        return { worktreePath: absTarget, headCommit: head.stdout.trim(), branchName };
-      });
-    },
-
-    removeWorktree({ url, path, branchName }) {
-      return withUrlLock(url, async () => {
-        const absTarget = resolve(path);
-        const mirror = mirrorDir(url);
+    removeSourceRepo({ clonePath }) {
+      return withPathLock(clonePath, async () => {
+        const absTarget = resolve(clonePath);
         // Kill any daemonised child the previous session left behind (vite,
-        // esbuild, test watcher, ...) BEFORE we try to rmdir. Without this the
-        // child keeps writing under `absTarget`, which both makes
-        // `git worktree remove` flaky AND repopulates the directory between
-        // the rm and the next session's `worktree add` — exactly the D13
-        // failure mode this commit fixes. Gated by `hubManagedRoots` so we
-        // never signal processes whose cwd happens to be an operator path.
+        // esbuild, test watcher, ...) BEFORE rmdir — otherwise it keeps writing
+        // under `absTarget` and repopulates the dir between rm and the next
+        // session's clone. Gated by `hubManagedRoots` so we never signal
+        // processes whose cwd is an operator path.
         if (hubManagedRoots.length > 0 && isUnderManagedRoot(absTarget, hubManagedRoots) && existsSync(absTarget)) {
           await killProcessesHoldingPath(absTarget, log);
         }
-        if (!isBareRepo(mirror)) {
-          // Mirror was already GC'd; just rm the orphan dir if it exists.
-          if (existsSync(absTarget)) rmSync(absTarget, { recursive: true, force: true });
-          return;
-        }
-        if (existsSync(absTarget)) {
-          await gitOk(["worktree", "remove", "--force", absTarget], mirror, 30_000);
-        } else {
-          // Path is already gone — let git prune its bookkeeping so later
-          // worktree-add calls don't hit the stale admin record.
-          await gitOk(["worktree", "prune"], mirror, 30_000);
-        }
-        if (existsSync(absTarget)) {
-          // Worktree wasn't git-registered (orphan dir) — rm for tidiness.
-          rmSync(absTarget, { recursive: true, force: true });
-        }
-        if (await branchExists(mirror, branchName)) {
-          const ok = await gitOk(["branch", "-D", branchName], mirror, 10_000);
-          if (!ok) {
-            // The `[branch "..."]` segment will linger in the shared bare
-            // mirror's `config` until startup GC sweeps it. Surface it so the
-            // operator can correlate with whatever held the branch (usually a
-            // peer worktree git's still holding a lock, or a renamed branch).
-            log?.warn(
-              { gitUrl: url, branchName, mirror },
-              "branch -D failed during removeWorktree — config segment will leak until next gcOrphanSessionBranches",
-            );
-          }
-        }
+        if (existsSync(absTarget)) rmSync(absTarget, { recursive: true, force: true });
       });
     },
 
-    async gcMirrors(stillReferencedUrls) {
-      if (!existsSync(mirrorsRoot)) return { removed: [] };
-      const wantedHashes = new Set([...stillReferencedUrls].map(hashUrl));
+    async sweepLegacyMirrors() {
+      if (!existsSync(legacyMirrorsRoot)) return { removed: [] };
       const removed: string[] = [];
-      for (const entry of readdirSync(mirrorsRoot)) {
-        if (wantedHashes.has(entry)) continue;
-        const path = join(mirrorsRoot, entry);
-        if (!isBareRepo(path)) continue;
-        rmSync(path, { recursive: true, force: true });
-        removed.push(entry);
+      try {
+        for (const entry of readdirSync(legacyMirrorsRoot)) {
+          const path = join(legacyMirrorsRoot, entry);
+          rmSync(path, { recursive: true, force: true });
+          removed.push(entry);
+        }
+        rmSync(legacyMirrorsRoot, { recursive: true, force: true });
+      } catch (err) {
+        log?.warn(
+          { legacyMirrorsRoot, err: err instanceof Error ? err.message : String(err) },
+          "sweepLegacyMirrors: partial failure removing legacy shared-mirror tree",
+        );
+      }
+      if (removed.length > 0) {
+        log?.info({ legacyMirrorsRoot, removed: removed.length }, "swept legacy shared git-mirrors tree");
       }
       return { removed };
     },
-
-    async gcOrphanSessionBranches() {
-      if (!existsSync(mirrorsRoot)) return { scanned: 0, deleted: 0, failed: 0 };
-      let scanned = 0;
-      let deleted = 0;
-      let failed = 0;
-      for (const entry of readdirSync(mirrorsRoot)) {
-        const mirror = join(mirrorsRoot, entry);
-        if (!isBareRepo(mirror)) continue;
-        // Branches held by a live worktree — must NOT be deleted. `branch -D`
-        // would refuse anyway, but skipping them avoids the noisy warn log.
-        const held = new Set<string>();
-        try {
-          const list = await git(["worktree", "list", "--porcelain"], mirror, 10_000);
-          for (const line of list.stdout.split("\n")) {
-            const m = line.match(/^branch refs\/heads\/(.+)$/);
-            if (m?.[1]) held.add(m[1]);
-          }
-        } catch (err) {
-          log?.warn({ mirror: entry, err }, "gcOrphanSessionBranches: worktree list failed — skipping mirror");
-          continue;
-        }
-        let sessionBranches: string[];
-        try {
-          const out = await git(
-            ["for-each-ref", "--format=%(refname:short)", `refs/heads/${SESSION_BRANCH_PREFIX}-*`],
-            mirror,
-            10_000,
-          );
-          sessionBranches = out.stdout
-            .split("\n")
-            .map((s) => s.trim())
-            .filter((s) => s.length > 0);
-        } catch (err) {
-          log?.warn({ mirror: entry, err }, "gcOrphanSessionBranches: branch listing failed — skipping mirror");
-          continue;
-        }
-        for (const branch of sessionBranches) {
-          scanned++;
-          if (held.has(branch)) continue;
-          const ok = await gitOk(["branch", "-D", branch], mirror, 10_000);
-          if (ok) {
-            deleted++;
-          } else {
-            failed++;
-            log?.warn({ mirror: entry, branch }, "gcOrphanSessionBranches: branch -D failed");
-          }
-        }
-      }
-      if (deleted > 0 || failed > 0) {
-        log?.info({ scanned, deleted, failed }, "gcOrphanSessionBranches: swept orphan session branches");
-      }
-      return { scanned, deleted, failed };
-    },
   };
-}
-
-function isBareRepo(p: string): boolean {
-  return existsSync(join(p, "HEAD")) && existsSync(join(p, "objects"));
-}
-
-function isHubManagedWorktree(p: string): boolean {
-  const gitMarker = join(p, ".git");
-  if (!existsSync(gitMarker)) return false;
-  try {
-    return statSync(gitMarker).isFile();
-  } catch {
-    return false;
-  }
 }
 
 function classifyOccupant(p: string): string {
@@ -984,9 +772,10 @@ export class GitMirrorWorktreeConflictError extends GitMirrorError {
 }
 
 /**
- * Thrown when both the HTTPS fetch and the SSH fallback fail. The message
- * carries trimmed stderr from both attempts so the operator can see whether
- * the host's HTTPS credentials are missing, the SSH key is missing, or both.
+ * Thrown when both the primary protocol and the peer-protocol fallback fail.
+ * The message carries trimmed stderr from both attempts so the operator can see
+ * whether the host's HTTPS credentials are missing, the SSH key is missing, or
+ * both.
  */
 export class GitMirrorAuthError extends GitMirrorError {
   constructor(message: string) {
@@ -999,11 +788,8 @@ export class GitMirrorAuthError extends GitMirrorError {
  * Heuristic for HTTPS-side credential failures. Matches the indicators git
  * itself emits over libcurl / git-credential helpers, regardless of platform.
  *
- * Negative space (intentionally NOT matched): network errors
- * (`Could not resolve host`, `connection refused`), repo errors
- * (`Repository not found`, `couldn't find remote ref`), TLS errors
- * (`SSL certificate problem`). Those won't be cured by switching transports
- * and silently retrying would mask the real bug.
+ * Negative space (intentionally NOT matched): network errors, repo errors,
+ * TLS errors — those won't be cured by switching transports.
  *
  * Exported for unit testing.
  */
@@ -1022,33 +808,17 @@ export function isLikelyHttpsAuthFailure(message: string): boolean {
 }
 
 /**
- * Heuristic for SSH-side credential failures (no key on disk, key not
- * accepted by remote, agent has nothing usable, host key mismatch).
+ * Heuristic for SSH-side credential failures (no key on disk, key not accepted
+ * by remote, agent has nothing usable, host key mismatch).
  *
- * Negative space (intentionally NOT matched):
- *   - SSH-level network errors (`Could not resolve hostname`,
- *     `Connection refused`, `Connection timed out`). Those are reachability
- *     issues — switching to HTTPS won't help unless the network policy
- *     specifically blocks port 22, which is rare enough that we'd rather
- *     surface the original error than guess.
- *   - `fatal: Could not read from remote repository.` on its own. Git
- *     appends that line to *every* SSH transport failure regardless of
- *     cause (auth reject, timeout, DNS, refused, …), so it carries no
- *     classification signal — matching it would re-classify network errors
- *     as auth failures and trigger a noisy HTTPS retry that fails again on
- *     SSH-only hosts. The real auth fingerprints below (`Permission denied`,
- *     `Host key verification failed`, host-key/algorithm negotiation) are
- *     specific enough on their own.
+ * Negative space (intentionally NOT matched): SSH-level network errors, and the
+ * generic `fatal: Could not read from remote repository.` line (git appends it
+ * to *every* SSH transport failure regardless of cause).
  *
  * Exported for unit testing.
  */
 export function isLikelySshAuthFailure(message: string): boolean {
   if (!message) return false;
-  // `Permission denied (<method-list>)` covers publickey-only rejects,
-  // mixed-method rejects (e.g. `publickey,password`), and gssapi-with-mic;
-  // `Permission denied, please try again.` covers the password-prompt
-  // rejection path. We collapse them into one disjunction since both
-  // forms only occur in ssh auth failure context.
   return (
     /Permission denied\s*(?:\(|,)/i.test(message) ||
     /Host key verification failed/i.test(message) ||
@@ -1059,60 +829,30 @@ export function isLikelySshAuthFailure(message: string): boolean {
 
 /**
  * Back-compat alias — matches *either* HTTPS or SSH credential failures.
- * Internal callers prefer the direction-specific predicates so a misfired
- * fallback doesn't classify an SSH host-key failure as an "HTTPS auth"
- * problem (or vice versa). This union form is kept for ad-hoc use sites.
+ * Internal callers prefer the direction-specific predicates.
  */
 export function isLikelyAuthFailure(message: string): boolean {
   return isLikelyHttpsAuthFailure(message) || isLikelySshAuthFailure(message);
 }
 
 /**
- * Heuristic for transient network-layer failures emitted by `git` over
- * HTTPS or SSH. These are the failure modes a brief proxy/VPN hiccup, TLS
- * handshake blip, or peer connection reset produces mid-fetch — exactly
- * what `SSL_connect: SSL_ERROR_SYSCALL` looks like when Surge / Clash
- * swaps a rule mid-flight, what `early EOF` looks like when an HTTP/2
- * stream is reset, and what `Connection refused` looks like when a local
- * proxy listener restarts.
+ * Heuristic for transient network-layer failures emitted by `git` over HTTPS or
+ * SSH — a brief proxy/VPN hiccup, TLS handshake blip, or peer connection reset
+ * mid-fetch. Used by `gitWithNetworkRetry` around `clone` and `fetch`.
  *
- * Used by the `gitWithNetworkRetry` wrapper around `fetch` and
- * `remote set-head --auto` to absorb the kind of hiccup that today
- * surfaces as `Session start/resume failed (…)` in chat and only goes
- * away when the operator manually @-mentions the agent again two seconds
- * later.
+ * Negative space (intentionally NOT matched): credential failures (handled by
+ * the protocol-fallback path), deterministic content errors, TLS trust
+ * failures, and our own per-call timeout.
  *
- * Negative space (intentionally NOT matched):
- *   - credential failures — handled by the protocol-fallback path; retrying
- *     in the same protocol won't help.
- *   - `Repository not found`, `couldn't find remote ref` — deterministic
- *     content errors; a 500ms retry won't fix them.
- *   - `SSL certificate problem` — TLS trust failures; retrying won't help
- *     and silently masking them would hide a real misconfiguration.
- *   - `git … timed out after Xms` — our own per-call timeout. The op was
- *     making progress (or wasn't); either way another full timeout window
- *     is the wrong response.
- *
- * On localhost-proxy specifically (the common case for this codebase),
- * `ECONNREFUSED` IS a transient signal — when Surge / Clash bounces the
- * listener, the next attempt sees the same listener back up within
- * seconds. This is why we diverge from the SDK's `doFetch` policy (which
- * does NOT retry `ECONNREFUSED` because there the peer is the remote server).
+ * On localhost-proxy specifically, `ECONNREFUSED` IS a transient signal — when
+ * Surge / Clash bounces the listener, the next attempt sees it back up within
+ * seconds.
  *
  * Exported for unit testing.
  */
 export function isLikelyTransientNetworkError(message: string): boolean {
   if (!message) return false;
-  // Don't shadow a credential failure: switching to SSH is the right move
-  // for those, retrying the same protocol is not.
   if (isLikelyHttpsAuthFailure(message) || isLikelySshAuthFailure(message)) return false;
-  // Don't shadow a TLS trust failure: those are deterministic misconfigurations
-  // (custom intercepting cert chain, expired cert, missing CA bundle, …) that
-  // a 5s retry budget won't fix. Burning the budget AND emitting transient-
-  // warning log lines for a deterministic failure would also mislead operators
-  // diagnosing a real cert problem. Matches both the user-friendly form
-  // (`SSL certificate problem: …`) and the raw OpenSSL form
-  // (`error:…:SSL routines::certificate verify failed`).
   if (
     /SSL certificate problem/i.test(message) ||
     /server certificate verification failed/i.test(message) ||
@@ -1124,11 +864,6 @@ export function isLikelyTransientNetworkError(message: string): boolean {
     return false;
   return (
     /SSL_ERROR_SYSCALL/i.test(message) ||
-    // OpenSSL's transient "the peer closed mid-stream" signal. Matches the
-    // raw form (`error:…:SSL routines::unexpected eof while reading`) emitted
-    // when github.com's edge resets the TLS connection mid-fetch. Narrowly
-    // scoped to the exact phrase to avoid re-introducing the broad
-    // `SSL routines` match that swept up cert verify failures.
     /unexpected eof while reading/i.test(message) ||
     /TLS handshake|gnutls_handshake|gnutls\s+recv\s+error/i.test(message) ||
     /\bConnection reset(?:\s+by\s+peer)?\b/i.test(message) ||
@@ -1151,22 +886,14 @@ export function isLikelyTransientNetworkError(message: string): boolean {
 }
 
 /**
- * Map an HTTPS git URL to the `insteadOf` rewrite needed to make git resolve
- * it through SSH. Returns *base* strings (suitable for
- * `git -c url.<sshBase>.insteadOf=<httpsBase>`) — git's `insteadOf` is a
- * prefix match, so we only need the host segment.
+ * Map an HTTPS git URL to the `insteadOf` rewrite needed to make git resolve it
+ * through SSH. Returns *base* strings (suitable for
+ * `git -c url.<sshBase>.insteadOf=<httpsBase>`).
  *
  *   `https://github.com/owner/repo.git` → `git@github.com:` / `https://github.com/`
  *
- * Returns `null` for inputs that should NOT trigger fallback:
- *   - non-HTTPS URLs (already SSH, `git://`, `file://`, etc.)
- *   - URLs with embedded credentials (schema rejects these on input;
- *     belt-and-braces — never silently downgrade auth strength)
- *   - HTTPS URLs with a non-default port — there is no portable mapping to
- *     an SSH port (HTTPS:8443 ↔ SSH:???), so we refuse to guess
- *   - URLs that fail to parse
- *
- * Exported for unit testing.
+ * Returns `null` for inputs that should NOT trigger fallback (non-HTTPS,
+ * embedded creds, non-default port, unparseable). Exported for unit testing.
  */
 export function httpsToSshBaseRewrite(url: string): { httpsBase: string; sshBase: string } | null {
   if (!url || !/^https:\/\//i.test(url)) return null;
@@ -1179,7 +906,6 @@ export function httpsToSshBaseRewrite(url: string): { httpsBase: string; sshBase
   if (parsed.protocol !== "https:") return null;
   if (parsed.username.length > 0 || parsed.password.length > 0) return null;
   if (!parsed.hostname) return null;
-  // Reject non-default HTTPS ports — see docstring.
   if (parsed.port && parsed.port !== "443") return null;
   return {
     httpsBase: `https://${parsed.hostname}/`,
@@ -1192,39 +918,23 @@ export function httpsToSshBaseRewrite(url: string): { httpsBase: string; sshBase
  * `insteadOf` rewrite for resolving via HTTPS. Mirror of
  * `httpsToSshBaseRewrite`.
  *
- *   `git@github.com:owner/repo.git`           → `git@github.com:` / `https://github.com/`
- *   `ssh://git@github.com/owner/repo.git`     → `ssh://git@github.com/` / `https://github.com/`
- *   `ssh://git@gitlab.example.com:22/x/y.git` → `ssh://git@gitlab.example.com:22/` / `https://gitlab.example.com/`
- *
- * Returns `null` when:
- *   - URL is not SSH-shaped
- *   - URL has an embedded password (`user:pass@`)
- *   - SSH URL has a non-default port (≠ 22) — no portable mapping to HTTPS
- *
+ * Returns `null` when not SSH-shaped, embedded password, or non-default port.
  * Exported for unit testing.
  */
 export function sshToHttpsBaseRewrite(url: string): { sshBase: string; httpsBase: string } | null {
   if (!url) return null;
-  // scp-like: `[user@]host:path` (no `://`). Mirrors `SCP_LIKE_SSH_RE` in
-  // the shared schema — path forbids leading `/`, any `:` or `@` (so inputs
-  // like `git:secret@github.com:owner/repo.git`, which superficially fit a
-  // greedy first-colon split, are rejected).
   if (!url.includes("://")) {
     const m = url.match(/^((?:[A-Za-z0-9_.-]+@)?)([A-Za-z0-9.-]+):([^/@:\s][^@:\s]*)$/);
     const userAt = m?.[1];
     const host = m?.[2];
     const path = m?.[3];
     if (userAt === undefined || !host || !path) return null;
-    // Path that is purely digits (optionally followed by `/` or end) means
-    // git would parse it as `host:port` via ssh:// — refuse the ambiguous
-    // case rather than fabricate a base.
     if (/^\d+(?:\/|$)/.test(path)) return null;
     return {
       sshBase: `${userAt}${host}:`,
       httpsBase: `https://${host}/`,
     };
   }
-  // ssh:// form
   let parsed: URL;
   try {
     parsed = new URL(url);
@@ -1236,9 +946,6 @@ export function sshToHttpsBaseRewrite(url: string): { sshBase: string; httpsBase
   if (!parsed.hostname) return null;
   if (parsed.port && parsed.port !== "22") return null;
   const userAt = parsed.username.length > 0 ? `${parsed.username}@` : "";
-  // The on-config origin URL contains either `ssh://user@host/...` or
-  // `ssh://user@host:22/...` — match whichever the input actually used so
-  // git's prefix matcher hits.
   const sshBase = parsed.port
     ? `ssh://${userAt}${parsed.hostname}:${parsed.port}/`
     : `ssh://${userAt}${parsed.hostname}/`;
@@ -1251,7 +958,7 @@ export function sshToHttpsBaseRewrite(url: string): { sshBase: string; httpsBase
 type FallbackDirection = {
   fromProtocol: "https" | "ssh";
   toProtocol: "https" | "ssh";
-  /** The base prefix git will see in the on-disk `remote.origin.url`. */
+  /** The base prefix git will see in the on-disk URL. */
   originBase: string;
   /** The base prefix to rewrite to (the peer-protocol form). */
   peerBase: string;
@@ -1260,10 +967,8 @@ type FallbackDirection = {
 };
 
 /**
- * Same shape as `SCP_LIKE_SSH_RE` in the shared schema — kept in sync so
- * what the schema accepts is exactly what we route through the SSH-side
- * fallback. Single source of truth would be ideal, but cross-package import
- * for a regex isn't worth the build coupling.
+ * Same shape as `SCP_LIKE_SSH_RE` in the shared schema — kept in sync so what
+ * the schema accepts is exactly what we route through the SSH-side fallback.
  */
 const SCP_LIKE_RE = /^(?:[A-Za-z0-9_.-]+@)?[A-Za-z0-9.-]+:(?!\d+(?:\/|$))[^/:@\s][^:@\s]*$/;
 
@@ -1300,18 +1005,12 @@ function truncate(text: string, max = 512): string {
 
 /**
  * Run `op` once, and on a `isRetryable`-classified failure replay it on the
- * given backoff schedule. Non-retryable failures propagate to the caller
- * immediately — those won't be cured by waiting and silently retrying would
- * mask real bugs and exhaust the retry budget.
+ * given backoff schedule. Non-retryable failures propagate immediately.
  *
- * Per-attempt timeouts (when `op` enforces one of its own) are NOT reset
- * across attempts: each attempt gets its own full budget. Right policy for
- * `git fetch` where a slow but progressing transfer on attempt N+1 should
- * not be aborted because attempt N ate part of a shared budget.
+ * Per-attempt timeouts (when `op` enforces one of its own) are NOT reset across
+ * attempts: each attempt gets its own full budget.
  *
- * Exported so unit tests can drive the retry policy with a mock `op`
- * instead of standing up a real flaky network. Module-scope so the helper
- * stays pure and side-effect-free.
+ * Exported so unit tests can drive the retry policy with a mock `op`.
  */
 export async function retryOnTransientNetwork<T>(
   op: (attempt: number) => Promise<T>,
@@ -1332,9 +1031,6 @@ export async function retryOnTransientNetwork<T>(
       const message = err instanceof Error ? err.message : String(err);
       if (!isRetryable(message)) throw err;
       if (attempt === maxAttempts) throw err;
-      // `delaysMs.length === maxAttempts - 1`, so `attempt - 1` is in range
-      // for every iteration that reaches this line. The explicit guard keeps
-      // TS strict happy without resorting to a non-null assertion.
       const baseDelay = delaysMs[attempt - 1];
       if (baseDelay === undefined) throw err;
       const jitter = Math.floor(Math.random() * Math.max(1, Math.floor(baseDelay / 4)));
@@ -1343,6 +1039,5 @@ export async function retryOnTransientNetwork<T>(
       await new Promise((r) => setTimeout(r, delayMs));
     }
   }
-  // Unreachable — the loop always either returns or throws by `maxAttempts`.
   throw lastErr;
 }

--- a/packages/client/src/runtime/runtime.ts
+++ b/packages/client/src/runtime/runtime.ts
@@ -136,19 +136,16 @@ export class AgentRuntime {
   }
 
   async start(): Promise<void> {
-    // Sweep orphan `hub-session-*` branches left over from previous runs
-    // before any slot can race a `git worktree add`. The session-branch
-    // config segments would otherwise accumulate forever — First Tree sessions
-    // suspend on idle rather than terminate, so `removeWorktree` (which
-    // deletes branches) only fires on explicit terminate/eviction.
+    // One-time cleanup of the legacy shared `<dataDir>/git-mirrors/` tree left
+    // by the pre-per-agent-source-repo bare-mirror model. Pure cache, no state.
     // Failures are advisory: log and continue startup.
     try {
-      const sweep = await this.gitMirrorManager.gcOrphanSessionBranches();
-      if (sweep.scanned > 0) {
-        this.logger.info(sweep, "swept orphan session branches");
+      const sweep = await this.gitMirrorManager.sweepLegacyMirrors();
+      if (sweep.removed.length > 0) {
+        this.logger.info({ removed: sweep.removed.length }, "removed legacy shared git-mirrors tree");
       }
     } catch (err) {
-      this.logger.warn({ err }, "gcOrphanSessionBranches threw — continuing startup");
+      this.logger.warn({ err }, "sweepLegacyMirrors threw — continuing startup");
     }
 
     // Attach before connecting so the first welcome frame on a stale Client

--- a/packages/client/src/runtime/source-repos.ts
+++ b/packages/client/src/runtime/source-repos.ts
@@ -1,105 +1,166 @@
-import { existsSync } from "node:fs";
 import { type AgentRuntimeConfigPayload, deriveRepoLocalPath } from "@first-tree/shared";
-import { isHubWorktreeMarker, type PredeclaredSourceRepo } from "./bootstrap.js";
+import type { PredeclaredSourceRepo } from "./bootstrap.js";
 import { resolveGitRepoTargetPath } from "./git-local-path.js";
-import { deriveSessionBranchName, type GitMirrorManager } from "./git-mirror-manager.js";
+import type { GitMirrorManager } from "./git-mirror-manager.js";
 import type { SessionContext } from "./handler.js";
-import { withWorktreePathLock } from "./worktree-mutex.js";
 
 export type PrepareSourceReposParams = {
   workspace: string;
   payload: AgentRuntimeConfigPayload | undefined;
   sessionCtx: SessionContext;
   gitMirrorManager: GitMirrorManager | null;
-  /** Branch-owner key; falls back to the agent id when null. */
+  /**
+   * Branch-owner key; falls back to the agent id when null. Retained for API
+   * compatibility with the handlers — no longer used for branch derivation now
+   * that source repos are standalone clones on their real default branch.
+   */
   agentName: string | null;
 };
 
 /**
- * Materialise a payload's predeclared `gitRepos` into the agent home and return
- * the prompt-facing source-repo list (absolute path + upstream coordinates).
- * Shared by the claude-code (SDK) and claude-code-tui handlers so the
- * worktree-path mutex and Hub-worktree-marker reuse semantics stay in one place.
+ * In-process "live use" registry per source-repo checkout: absolute path → set
+ * of live **chat ids** currently using that checkout. Source repos are
+ * agent-scoped and shared across that agent's chats, so two live chats of the
+ * same agent can reference one clone at once.
  *
- * Concurrency: per-process per-path mutex (`withWorktreePathLock`) so two
- * sessions starting at the same time don't race `git worktree add` for the
- * same path. Reuse only when the target is a Hub-managed worktree
- * (`isHubWorktreeMarker`); a non-First Tree directory at the target is logged
- * and left to `createWorktree` to fail loudly rather than being silently
- * adopted as a source repo.
+ * Keyed by `chatId` (stable across a chat's start → suspend → resume), NOT by
+ * the per-call `SessionContext` object: the runtime hands each resume a FRESH
+ * `SessionContext`, so object keying would re-acquire on every resume and the
+ * teardown (which only sees the current ctx) would never release the earlier
+ * one — permanently pinning the path into skip-update mode.
  *
- * Fail-fast per PRD D10/D13/D14: any failure aborts the session and bubbles up.
+ * Decision B (per-agent-source-repo design): a destructive update
+ * (`checkout -B` to the latest default branch) must NOT run while another live
+ * chat is using the checkout — otherwise that chat's `grep` / file reads shift
+ * mid-task. `prepareSourceRepos` registers the chat for the session's lifetime
+ * and passes `activelyInUse = (some other live chat holds it)` to the manager,
+ * which then leaves an in-use checkout at its current commit. The chat is
+ * deregistered at teardown via `releaseSourceReposForSession` (and on a failed
+ * start, by `prepareSourceRepos` itself).
+ */
+const liveChatsByPath = new Map<string, Set<string>>();
+
+function acquireSourceRepo(chatId: string, absPath: string): { activelyInUse: boolean; firstRegistration: boolean } {
+  const chats = liveChatsByPath.get(absPath) ?? new Set<string>();
+  // "Active use by someone else" = a *different* live chat already holds it.
+  // Adding our own chatId is idempotent, so start/suspend/resume of one chat
+  // never double-registers.
+  let othersUsing = false;
+  for (const c of chats) {
+    if (c !== chatId) {
+      othersUsing = true;
+      break;
+    }
+  }
+  // `firstRegistration` tells the caller whether THIS call newly registered the
+  // chat (vs the chat already being registered from a prior live start). Only a
+  // first registration may be rolled back on failure — see prepareSourceRepos.
+  const firstRegistration = !chats.has(chatId);
+  chats.add(chatId);
+  liveChatsByPath.set(absPath, chats);
+  return { activelyInUse: othersUsing, firstRegistration };
+}
+
+function releaseChatFromPath(chatId: string, absPath: string): void {
+  const chats = liveChatsByPath.get(absPath);
+  if (!chats) return;
+  if (chats.delete(chatId) && chats.size === 0) liveChatsByPath.delete(absPath);
+}
+
+/**
+ * Deregister `sessionCtx`'s chat from every source-repo checkout it was using.
+ * Idempotent — safe to call once per session teardown even if
+ * `prepareSourceRepos` never ran.
+ */
+export function releaseSourceReposForSession(sessionCtx: SessionContext): void {
+  const { chatId } = sessionCtx;
+  for (const [absPath, chats] of liveChatsByPath) {
+    if (chats.delete(chatId) && chats.size === 0) liveChatsByPath.delete(absPath);
+  }
+}
+
+/**
+ * Materialise a payload's predeclared `gitRepos` into the agent home as
+ * standalone clones and return the prompt-facing source-repo list (absolute
+ * path + upstream coordinates + checked-out branch). Shared by the claude-code
+ * (SDK) and claude-code-tui handlers.
+ *
+ * Per the per-agent-source-repo refactor: each repo is a real `git clone` at
+ * the TOP LEVEL of the agent home (NOT under `worktrees/`, which stays reserved
+ * for on-demand worktrees the agent creates per task). Every dialog fetches and
+ * — when the checkout is clean and not in use by another live session — brings
+ * it to the latest default branch. Concurrency for the same path is serialised
+ * inside the manager (`withPathLock`).
+ *
+ * Fail-fast: any clone/fetch failure aborts the session and bubbles up.
  */
 export async function prepareSourceRepos(params: PrepareSourceReposParams): Promise<PredeclaredSourceRepo[]> {
-  const { workspace, payload, sessionCtx, gitMirrorManager, agentName } = params;
+  const { workspace, payload, sessionCtx, gitMirrorManager } = params;
   const sourceRepos: PredeclaredSourceRepo[] = [];
 
   if (!gitMirrorManager || !payload?.gitRepos?.length) return sourceRepos;
 
-  for (const repo of payload.gitRepos) {
-    const localPath = repo.localPath ?? deriveRepoLocalPath(repo.url);
-    // Source repos live at the TOP LEVEL of the agent home — no `worktrees/`
-    // prefix. The `worktrees/` subdir is reserved for on-demand worktrees.
-    const targetPath = resolveGitRepoTargetPath(workspace, localPath);
-    sessionCtx.log(`Git: preparing source repo ${repo.url} → ${localPath}${repo.ref ? ` @ ${repo.ref}` : ""}`);
+  // Paths THIS call newly registered the chat on — only these may be rolled
+  // back on failure (see the catch). A resume that re-acquires an already-live
+  // registration must NOT be rolled back, or a concurrent chat could reset the
+  // shared checkout out from under the still-live chat.
+  const newlyRegistered: string[] = [];
+  try {
+    for (const repo of payload.gitRepos) {
+      const localPath = repo.localPath ?? deriveRepoLocalPath(repo.url);
+      // Source repos live at the TOP LEVEL of the agent home — no `worktrees/`
+      // prefix. The `worktrees/` subdir is reserved for on-demand worktrees.
+      const targetPath = resolveGitRepoTargetPath(workspace, localPath);
+      sessionCtx.log(`Git: preparing source repo ${repo.url} → ${localPath}${repo.ref ? ` @ ${repo.ref}` : ""}`);
 
-    // D14: ensureMirror is idempotent — clone once, fast return thereafter.
-    const mirror = await gitMirrorManager.ensureMirror(repo.url);
-    if (mirror.cloned) {
-      sessionCtx.log(`Git: cloned ${repo.url} in ${mirror.elapsedMs}ms`);
-    }
+      // Decision B: register this chat as a live user of the checkout and learn
+      // whether another live chat is already using it (→ skip the destructive
+      // update).
+      const { activelyInUse, firstRegistration } = acquireSourceRepo(sessionCtx.chatId, targetPath);
+      if (firstRegistration) newlyRegistered.push(targetPath);
 
-    // D10: fresh fetch on every new dialog. Failure aborts session creation.
-    await gitMirrorManager.fetchMirror(repo.url);
-
-    const branchAgentKey = agentName ?? sessionCtx.agent.agentId;
-
-    // Serialise per absolute path so two concurrent sessions for the same
-    // agent can't both try to create the same checkout.
-    const { branchName } = await withWorktreePathLock(targetPath, async () => {
-      if (existsSync(targetPath)) {
-        if (isHubWorktreeMarker(targetPath)) {
-          sessionCtx.log(`Git: reusing existing source repo at ${localPath}`);
-          // Reuse path: branchName is deterministic for cleanup. With the
-          // per-agent shared-checkout model, sessionKey is the agentName (not
-          // chatId) so a checkout created by chat A is reused by chat B.
-          return {
-            branchName: deriveSessionBranchName(branchAgentKey, branchAgentKey, repo.url),
-            headCommit: null as string | null,
-          };
-        }
-        // Path occupied by a non-First Tree directory (operator placed it,
-        // leftover from an old layout, etc). Log it explicitly — createWorktree
-        // below will likely fail with a generic "path exists" error, and
-        // without this line the operator has no way to know why.
-        sessionCtx.log(
-          `Git: source-repo target ${localPath} occupied by a non-First Tree directory; ` +
-            "createWorktree will likely fail — move or remove the directory and re-run",
-        );
-      }
-      const created = await gitMirrorManager.createWorktree({
+      const result = await gitMirrorManager.ensureSourceRepo({
         url: repo.url,
         ref: repo.ref,
-        targetPath,
-        // sessionKey identifies the branch *owner*. In the per-agent-home model
-        // the owner is the agent, not the chat.
-        sessionKey: branchAgentKey,
-        agentName: branchAgentKey,
+        clonePath: targetPath,
+        activelyInUse,
       });
-      return { branchName: created.branchName, headCommit: created.headCommit as string | null };
-    });
 
-    // Per agent-session-cwd-redesign: predeclared source repos are agent-scoped
-    // persistent resources. They survive shutdown so the next chat finds them
-    // ready — so they are NOT tracked in the per-session worktree-cleanup list.
-    sourceRepos.push({
-      absolutePath: targetPath,
-      url: repo.url,
-      ...(repo.ref ? { ref: repo.ref } : {}),
-      branch: branchName,
-    });
+      if (result.outcome === "cloned") {
+        sessionCtx.log(`Git: cloned ${repo.url}`);
+      } else if (result.outcome === "migrated-recloned") {
+        sessionCtx.log(`Git: migrated legacy shared-mirror checkout of ${repo.url} to a standalone clone`);
+      } else if (result.outcome === "skipped-dirty") {
+        sessionCtx.log(`Git: ${localPath} has local changes — left at current commit (not updated to latest)`);
+      } else if (result.outcome === "skipped-local-commits") {
+        sessionCtx.log(`Git: ${localPath} has local commits ahead of upstream — left at current commit`);
+      } else if (result.outcome === "skipped-in-use") {
+        sessionCtx.log(`Git: ${localPath} in use by another live chat — left at current commit`);
+      }
 
-    sessionCtx.log(`Git: source repo at ${localPath} on ${branchName}`);
+      // Per agent-session-cwd-redesign: predeclared source repos are agent-scoped
+      // persistent resources. They survive shutdown so the next chat finds them
+      // ready — so they are NOT tracked in the per-session worktree-cleanup list.
+      sourceRepos.push({
+        absolutePath: targetPath,
+        url: repo.url,
+        ...(repo.ref ? { ref: repo.ref } : {}),
+        ...(result.branch ? { branch: result.branch } : {}),
+      });
+
+      sessionCtx.log(
+        `Git: source repo at ${localPath}${result.branch ? ` on ${result.branch}` : ""} (${result.outcome})`,
+      );
+    }
+  } catch (err) {
+    // Session start is failing and the SessionManager does NOT call the
+    // handler's teardown on a failed start. Roll back ONLY the registrations
+    // this call created so a dead chat does not pin the checkout into
+    // skip-update mode — while leaving intact any registration that a still-live
+    // chat already held (e.g. a transient failure on resume, which the manager
+    // keeps alive for retry).
+    for (const p of newlyRegistered) releaseChatFromPath(sessionCtx.chatId, p);
+    throw err;
   }
 
   return sourceRepos;

--- a/packages/client/src/runtime/worktree-cleanup.ts
+++ b/packages/client/src/runtime/worktree-cleanup.ts
@@ -12,13 +12,13 @@ import type { pino } from "../observability/logger.js";
  * to a different process group, or simply not tracked by the SDK. The orphan
  * keeps the cwd open, keeps writing cache files (`.vite/deps/...`,
  * `node_modules/.cache/...`) under the just-deleted directory, and on the next
- * session start the rebuilt path collides with the D13 guard in
- * `createWorktree` because there's a non-empty dir but no `.git` marker.
+ * session start the rebuilt path collides with the conflict guard in
+ * `ensureSourceRepo` because there's a non-empty dir but no managed `.git` clone.
  *
  * Two consumers:
- *   - `removeWorktree` calls `killProcessesHoldingPath` BEFORE `git worktree
- *     remove --force` so the rmdir actually sticks.
- *   - `createWorktree` calls `killProcessesHoldingPath` then `rmSync` when a
+ *   - `removeSourceRepo` calls `killProcessesHoldingPath` BEFORE `rm -rf` of
+ *     the clone so the rmdir actually sticks.
+ *   - `ensureSourceRepo` calls `killProcessesHoldingPath` then `rmSync` when a
  *     non-managed leftover sits in a path under a First Tree-managed root — see the
  *     `hubManagedRoots` option on `GitMirrorManager`.
  *


### PR DESCRIPTION
## Goal

Source-repo checkouts the agent sees were **stale**: the old model kept a shared bare mirror at `<dataDir>/git-mirrors/<hash>` fresh on every dialog, but the flat checkout under the agent home was a worktree pinned to a long-lived `hub-session` branch and **never updated** — so `git log`/`grep` in the agent home could lag `origin/main` by dozens of commits.

This makes **each agent own a real standalone `git clone`** of every predeclared source repo at `<agentHome>/<localPath>/`. The clone the agent greps **is** the clone that gets fetched + updated **is** the base for on-demand worktrees — one fresh source of truth per agent. The shared `git-mirrors/` layer is removed.

## Update policy (each session)

`git fetch`, then bring the clone to the latest default branch **only when safe**:
- **dirty** working tree → leave as-is (`skipped-dirty`)
- **local commits ahead of upstream** (on a shared lineage) → leave as-is, never orphan them (`skipped-local-commits`)
- **another live chat of the same agent is using it** → leave as-is so its files don't shift mid-task (`skipped-in-use`)

Pinned-SHA `ref`s are honored detached. Origin URL **and** default-branch (`origin/HEAD`) are reconciled when an operator repoints a `localPath` at a different repo.

## Migration & safety

- Legacy shared-mirror worktrees (a `.git` **file** pointing into `git-mirrors/`) migrate in place to standalone clones on first session.
- The old `<dataDir>/git-mirrors/` tree is swept once at boot (pure cache).
- The kill-holders + `rm -rf` self-heal and the `hubManagedRoots` strict-subdir construction guard carry over unchanged; a symlink occupant is now reclaimed/refused too.
- Decision-B liveness is keyed by **chatId** (stable across start/suspend/resume), with per-call rollback so a failed start (or a transient resume failure the SessionManager keeps alive for retry) never leaks or steals liveness.

## Tests / validation

- New `source-repos.test.ts` (live-use registry: cross-chat skip, suspend/resume idempotency, failed-start rollback, resume-failure preserves liveness).
- Rewrote `git-mirror-manager.test.ts` integration suite for the clone model; added `skipped-local-commits`, origin+default-branch reconcile, symlink reclaim, in-use/dirty skip.
- `pnpm check` (1186 files) ✓ · `pnpm typecheck` (11) ✓ · client **1000** ✓ · cli **410** ✓
- Independent local QA (two clean regression passes by @qa against this exact diff on latest `main`): client + CLI suites, `e2e:doctor`, `e2e:smoke`, spawned-dist `cli-chat-send` E2E all pass.

## ⚠️ Landing dependency — Context Tree PR first

This removes the client-side shared bare mirror. The tree node [`system/cloud/runtime/client-runtime.md`](https://github.com/agent-team-foundation/first-tree-context) describes the old mechanism and is updated in a paired **first-tree-context PR** that should land before/with this one. (The `system/architecture.md` bare-mirror invariant is about the **breeze** daemon — a separate component — and is intentionally untouched.)

cc infra owners @liuchao-001 @286ljb @baixiaohang for the core-runtime review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)