### PR TITLE
docs(readme): banner/badges header + cloud.first-tree.ai app CTA

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,7 @@ context, and every useful outcome can make the next task smarter.
   <tr>
     <td align="center"><strong>Works<br/>with</strong></td>
     <td align="center"><picture><source media="(prefers-color-scheme: dark)" srcset="assets/logos/claude-code-dark.svg"><img src="assets/logos/claude-code-light.svg" width="32" alt="Claude Code" /></picture><br/><sub>Claude Code</sub></td>
-    <td align="center"><img src="assets/logos/openclaw.png" width="32" alt="OpenClaw" /><br/><sub>OpenClaw</sub></td>
     <td align="center"><picture><source media="(prefers-color-scheme: dark)" srcset="assets/logos/codex-dark.svg"><img src="assets/logos/codex-light.svg" width="32" alt="Codex" /></picture><br/><sub>Codex</sub></td>
-    <td align="center"><picture><source media="(prefers-color-scheme: dark)" srcset="assets/logos/cursor-dark.svg"><img src="assets/logos/cursor-light.svg" width="32" alt="Cursor" /></picture><br/><sub>Cursor</sub></td>
-    <td align="center"><picture><source media="(prefers-color-scheme: dark)" srcset="assets/logos/gemini-dark.svg"><img src="assets/logos/gemini-light.svg" width="32" alt="Gemini CLI" /></picture><br/><sub>Gemini CLI</sub></td>
     <td align="center"><picture><source media="(prefers-color-scheme: dark)" srcset="assets/logos/github-dark.svg"><img src="assets/logos/github-light.svg" width="32" alt="GitHub" /></picture><br/><sub>GitHub</sub></td>
     <td align="center"><picture><source media="(prefers-color-scheme: dark)" srcset="assets/logos/mcp-dark.svg"><img src="assets/logos/mcp-light.svg" width="32" alt="MCP" /></picture><br/><sub>MCP</sub></td>
   </tr>

--- a/README.md
+++ b/README.md
@@ -1,8 +1,31 @@
-# First-Tree
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="assets/banner-dark.png">
+    <source media="(prefers-color-scheme: light)" srcset="assets/banner-light.png">
+    <img src="assets/banner-light.png" alt="First Tree" width="100%">
+  </picture>
+</p>
+
+<p align="center">
+  <a href="https://cloud.first-tree.ai"><strong>Open App</strong></a> &middot;
+  <a href="#get-started"><strong>Get Started</strong></a> &middot;
+  <a href="#how-it-works"><strong>How It Works</strong></a> &middot;
+  <a href="docs/quickstart.md"><strong>Quickstart</strong></a> &middot;
+  <a href="https://github.com/agent-team-foundation/first-tree/discussions"><strong>Discussions</strong></a>
+</p>
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/first-tree"><img src="https://img.shields.io/npm/v/first-tree?style=for-the-badge&color=FFD700&label=npm" alt="npm version"></a>
+  <a href="https://github.com/agent-team-foundation/first-tree/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/agent-team-foundation/first-tree/ci.yml?style=for-the-badge&label=CI" alt="CI"></a>
+  <a href="https://github.com/agent-team-foundation/first-tree/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-green?style=for-the-badge" alt="License: Apache 2.0"></a>
+  <a href="https://github.com/agent-team-foundation/first-tree/stargazers"><img src="https://img.shields.io/github/stars/agent-team-foundation/first-tree?style=for-the-badge&color=blueviolet" alt="GitHub stars"></a>
+</p>
 
 <p align="center">
   English | <a href="README_zh-CN.md">中文</a>
 </p>
+
+# First-Tree
 
 **Context-grounded agentic work for teams.**
 
@@ -15,6 +38,23 @@ before they work; useful outcomes can flow back into it after the work is done.
 
 The result is a human-agent work loop where every task can start with more team
 context, and every useful outcome can make the next task smarter.
+
+<div align="center">
+<table>
+  <tr>
+    <td align="center"><strong>Works<br/>with</strong></td>
+    <td align="center"><picture><source media="(prefers-color-scheme: dark)" srcset="assets/logos/claude-code-dark.svg"><img src="assets/logos/claude-code-light.svg" width="32" alt="Claude Code" /></picture><br/><sub>Claude Code</sub></td>
+    <td align="center"><img src="assets/logos/openclaw.png" width="32" alt="OpenClaw" /><br/><sub>OpenClaw</sub></td>
+    <td align="center"><picture><source media="(prefers-color-scheme: dark)" srcset="assets/logos/codex-dark.svg"><img src="assets/logos/codex-light.svg" width="32" alt="Codex" /></picture><br/><sub>Codex</sub></td>
+    <td align="center"><picture><source media="(prefers-color-scheme: dark)" srcset="assets/logos/cursor-dark.svg"><img src="assets/logos/cursor-light.svg" width="32" alt="Cursor" /></picture><br/><sub>Cursor</sub></td>
+    <td align="center"><picture><source media="(prefers-color-scheme: dark)" srcset="assets/logos/gemini-dark.svg"><img src="assets/logos/gemini-light.svg" width="32" alt="Gemini CLI" /></picture><br/><sub>Gemini CLI</sub></td>
+    <td align="center"><picture><source media="(prefers-color-scheme: dark)" srcset="assets/logos/github-dark.svg"><img src="assets/logos/github-light.svg" width="32" alt="GitHub" /></picture><br/><sub>GitHub</sub></td>
+    <td align="center"><picture><source media="(prefers-color-scheme: dark)" srcset="assets/logos/mcp-dark.svg"><img src="assets/logos/mcp-light.svg" width="32" alt="MCP" /></picture><br/><sub>MCP</sub></td>
+  </tr>
+</table>
+</div>
+
+---
 
 ## Why First Tree
 
@@ -77,9 +117,10 @@ during, and after execution.
 
 ## Get Started
 
-Sign in at <https://first-tree.ai> or your own deployment. The guided setup
-walks you through the first run: name your team, connect a computer, create
-your first agent, connect code, and start work.
+Open the app at **<https://cloud.first-tree.ai>** (or your own deployment) and
+sign in. Learn more at <https://first-tree.ai>. The guided setup walks you
+through the first run: name your team, connect a computer, create your first
+agent, connect code, and start work.
 
 See the [Quickstart](docs/quickstart.md) for the full walkthrough.
 


### PR DESCRIPTION
## What

Refreshes `README.md` with the visual styling from `first-tree-legacy` and points the primary call-to-action at the product app.

- **Header styling** carried over from the legacy README:
  - Centered banner with light/dark `<picture>` switch
  - Nav bar (Open App · Get Started · How It Works · Quickstart · Discussions)
  - shields.io badges (npm, CI, License, stars)
  - "Works with" runtime-logo table (Claude Code, OpenClaw, Codex, Cursor, Gemini CLI, GitHub, MCP)
- **Primary CTA → the app:** `https://cloud.first-tree.ai` is now the "Open App" / Get-Started link; `https://first-tree.ai` is kept as the "Learn more" marketing link.

## Why

The current README was plain prose with no header, and the "Get Started" link sent users to the marketing landing page instead of the actual app.

## Notes

- **Docs-only.** No feature/content claims changed — same body copy as current `main`.
- All referenced assets already exist under `assets/` (banner + 7 logos); verified no broken paths.
- Both URLs verified live (200).
- `README_zh-CN.md` is unchanged in this PR — flagging in case we want to mirror the header there as a follow-up.

Refs #855

---
🤖 This PR was prepared by an AI agent (Claude) on behalf of @serenakeyitan.