### PR TITLE
[codex] rename agent runtime dir to .first-tree-workspace

### DIFF
--- a/apps/cli/src/__tests__/migrate-agent-dirs.test.ts
+++ b/apps/cli/src/__tests__/migrate-agent-dirs.test.ts
@@ -1,4 +1,13 @@
-import { mkdirSync, mkdtempSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -28,6 +37,19 @@ function writeWorkspace(root: string, name: string) {
   mkdirSync(join(dir, "chat-1"), { recursive: true });
   writeFileSync(join(dir, "chat-1", "noop"), "");
   return dir;
+}
+
+function writeLegacyRuntime(root: string, name: string, opts?: { markerFile?: boolean }) {
+  const workspace = writeWorkspace(root, name);
+  mkdirSync(join(workspace, ".agent", "context"), { recursive: true });
+  writeFileSync(join(workspace, ".agent", "identity.json"), '{"agentId":"legacy"}');
+  writeFileSync(join(workspace, ".agent", "cli-version"), "0.1.0\n");
+  writeFileSync(join(workspace, ".agent", "tools.md"), "legacy tools");
+  writeFileSync(join(workspace, ".agent", "context", "agent-instructions.md"), "legacy");
+  if (opts?.markerFile) {
+    writeFileSync(join(workspace, ".first-tree-workspace"), "");
+  }
+  return workspace;
 }
 
 function writeSessionFile(root: string, name: string) {
@@ -82,6 +104,25 @@ describe("migrateLocalAgentDirs", () => {
     expect(readdirSync(dirs({ root }).agentsDir).sort()).toEqual(["alice", "bob"]);
   });
 
+  it("migrates a legacy runtime dir even when the local agent dir name already matches", async () => {
+    writeAgentYaml(root, "alice", "uuid-1");
+    writeLegacyRuntime(root, "alice", { markerFile: true });
+
+    const res = await migrateLocalAgentDirs({
+      ...dirs({ root }),
+      resolver: mkResolver({ "uuid-1": "alice" }),
+    });
+
+    expect(res).toEqual({ scanned: 1, renamed: 0, skipped: 0, errors: 0 });
+    expect(existsSync(join(dirs({ root }).workspacesDir, "alice", ".agent"))).toBe(false);
+    expect(statSync(join(dirs({ root }).workspacesDir, "alice", ".first-tree-workspace")).isDirectory()).toBe(true);
+    expect(
+      readFileSync(join(dirs({ root }).workspacesDir, "alice", ".first-tree-workspace", "identity.json"), "utf-8"),
+    ).toBe('{"agentId":"legacy"}');
+    expect(existsSync(join(dirs({ root }).workspacesDir, "alice", ".first-tree-workspace", "tools.md"))).toBe(false);
+    expect(existsSync(join(dirs({ root }).workspacesDir, "alice", ".first-tree-workspace", "context"))).toBe(false);
+  });
+
   it("renames config dir, workspace, and sessions file when the server name differs", async () => {
     writeAgentYaml(root, "old-alias", "uuid-1");
     writeWorkspace(root, "old-alias");
@@ -95,6 +136,23 @@ describe("migrateLocalAgentDirs", () => {
     expect(readdirSync(dirs({ root }).agentsDir)).toEqual(["alice"]);
     expect(statSync(join(dirs({ root }).workspacesDir, "alice")).isDirectory()).toBe(true);
     expect(statSync(join(dirs({ root }).sessionsDir, "alice.json")).isFile()).toBe(true);
+  });
+
+  it("migrates the legacy runtime layout during a workspace rename", async () => {
+    writeAgentYaml(root, "old-alias", "uuid-1");
+    writeLegacyRuntime(root, "old-alias", { markerFile: true });
+
+    const res = await migrateLocalAgentDirs({
+      ...dirs({ root }),
+      resolver: mkResolver({ "uuid-1": "alice" }),
+    });
+
+    expect(res.renamed).toBe(1);
+    expect(existsSync(join(dirs({ root }).workspacesDir, "old-alias"))).toBe(false);
+    expect(statSync(join(dirs({ root }).workspacesDir, "alice", ".first-tree-workspace")).isDirectory()).toBe(true);
+    expect(existsSync(join(dirs({ root }).workspacesDir, "alice", ".agent"))).toBe(false);
+    expect(existsSync(join(dirs({ root }).workspacesDir, "alice", ".first-tree-workspace", "context"))).toBe(false);
+    expect(existsSync(join(dirs({ root }).workspacesDir, "alice", ".first-tree-workspace", "tools.md"))).toBe(false);
   });
 
   it("skips without clobbering when the target config dir already exists", async () => {
@@ -161,8 +219,8 @@ describe("migrateLocalAgentDirs", () => {
 
   it("leaves old workspace in place and logs when the new workspace target already exists (partial failure)", async () => {
     writeAgentYaml(root, "old-alias", "uuid-1");
-    writeWorkspace(root, "old-alias");
-    writeWorkspace(root, "alice"); // pre-existing target — rename would clobber
+    writeLegacyRuntime(root, "old-alias");
+    writeLegacyRuntime(root, "alice"); // pre-existing target — rename would clobber
     writeSessionFile(root, "old-alias");
     const res = await migrateLocalAgentDirs({
       ...dirs({ root }),
@@ -174,6 +232,10 @@ describe("migrateLocalAgentDirs", () => {
     // Both workspaces should still exist.
     const wsNames = readdirSync(dirs({ root }).workspacesDir).sort();
     expect(wsNames).toEqual(["alice", "old-alias"]);
+    expect(statSync(join(dirs({ root }).workspacesDir, "alice", ".first-tree-workspace")).isDirectory()).toBe(true);
+    expect(existsSync(join(dirs({ root }).workspacesDir, "alice", ".agent"))).toBe(false);
+    expect(existsSync(join(dirs({ root }).workspacesDir, "alice", ".first-tree-workspace", "context"))).toBe(false);
+    expect(existsSync(join(dirs({ root }).workspacesDir, "alice", ".first-tree-workspace", "tools.md"))).toBe(false);
   });
 
   it("skips and logs when agent.yaml is malformed (does not abort migration for healthy siblings)", async () => {

--- a/apps/cli/src/core/migrate-agent-dirs.ts
+++ b/apps/cli/src/core/migrate-agent-dirs.ts
@@ -1,5 +1,6 @@
 import { existsSync, readdirSync, readFileSync, renameSync, statSync } from "node:fs";
 import { join } from "node:path";
+import { migrateLegacyRuntimeLayout } from "@first-tree/client";
 import { parse as parseYaml } from "yaml";
 import { cliFetch } from "./cli-fetch.js";
 import { print } from "./output.js";
@@ -117,6 +118,23 @@ function readAgentId(agentYamlPath: string): string | null {
   }
 }
 
+function migrateWorkspaceRuntimeDir(workspacePath: string, agentName: string, result: AgentDirMigrationResult): void {
+  if (!existsSync(workspacePath)) return;
+  try {
+    if (!statSync(workspacePath).isDirectory()) return;
+  } catch {
+    return;
+  }
+
+  try {
+    migrateLegacyRuntimeLayout(workspacePath);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    print.status("⚠️", `agent-dir migration: runtime-dir migration failed for "${agentName}": ${msg}`);
+    result.errors += 1;
+  }
+}
+
 /**
  * Walk `agentsDir`, for each local agent compare the dir name to the
  * server's canonical `name`, and rename the dir + workspaces/sessions
@@ -161,6 +179,7 @@ export async function migrateLocalAgentDirs(opts: {
 
   for (const dirName of dirNames) {
     const agentYamlPath = join(agentsDir, dirName, "agent.yaml");
+    const oldWorkspace = join(workspacesDir, dirName);
     const agentId = readAgentId(agentYamlPath);
     if (!agentId) {
       // Non-agent directory, or a malformed yaml. Log only when a yaml
@@ -196,7 +215,10 @@ export async function migrateLocalAgentDirs(opts: {
       result.skipped += 1;
       continue;
     }
-    if (serverName === dirName) continue;
+    if (serverName === dirName) {
+      migrateWorkspaceRuntimeDir(oldWorkspace, dirName, result);
+      continue;
+    }
 
     const oldDir = join(agentsDir, dirName);
     const newDir = join(agentsDir, serverName);
@@ -208,6 +230,8 @@ export async function migrateLocalAgentDirs(opts: {
       result.skipped += 1;
       continue;
     }
+
+    migrateWorkspaceRuntimeDir(oldWorkspace, dirName, result);
 
     try {
       renameSync(oldDir, newDir);
@@ -224,7 +248,6 @@ export async function migrateLocalAgentDirs(opts: {
     // on failure — the config dir is the canonical marker for "migrated",
     // so mismatched workspace/session leftovers show up as orphans (not
     // wedged state).
-    const oldWorkspace = join(workspacesDir, dirName);
     const newWorkspace = join(workspacesDir, serverName);
     if (existsSync(oldWorkspace)) {
       try {
@@ -242,6 +265,8 @@ export async function migrateLocalAgentDirs(opts: {
         result.errors += 1;
       }
     }
+
+    migrateWorkspaceRuntimeDir(newWorkspace, serverName, result);
 
     const oldSessions = join(sessionsDir, `${dirName}.json`);
     const newSessions = join(sessionsDir, `${serverName}.json`);

--- a/packages/client/src/__tests__/agent-bootstrap.test.ts
+++ b/packages/client/src/__tests__/agent-bootstrap.test.ts
@@ -8,7 +8,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const state = vi.hoisted(() => ({ cachedTreeHead: null as string | null, cachedCli: null as string | null }));
 
 vi.mock("../runtime/bootstrap.js", () => ({
+  FIRST_TREE_RUNTIME_DIR: ".first-tree-workspace",
+  IDENTITY_JSON_REL: ".first-tree-workspace/identity.json",
   bootstrapWorkspace: vi.fn(),
+  ensureWorkspaceRuntimeDir: vi.fn(),
   installCoreSkills: vi.fn(),
   installFirstTreeIntegration: vi.fn(),
   deepEqualIdentity: vi.fn(() => false),
@@ -62,7 +65,6 @@ describe("ensureAgentBootstrap — integration retry gate", () => {
     // fast path forever.
     const sentinel = join(workspace, INIT_COMPLETE_SENTINEL_REL);
     mkdirSync(dirname(sentinel), { recursive: true });
-    mkdirSync(join(workspace, ".agent"), { recursive: true });
     writeFileSync(sentinel, "1", "utf-8");
 
     state.cachedTreeHead = null;

--- a/packages/client/src/__tests__/agent-cwd-redesign.e2e.test.ts
+++ b/packages/client/src/__tests__/agent-cwd-redesign.e2e.test.ts
@@ -26,7 +26,7 @@ import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
  *       On Demand"; does NOT contain legacy "Predeclared worktrees".
  *   E5  Concurrent two-chat start mutex serialises filesystem writes —
  *       no race throws or missing checkouts.
- *   E6  `.agent/identity.json` carries agent-level stable fields only —
+ *   E6  `.first-tree-workspace/identity.json` carries agent-level stable fields only —
  *       no `chatId` / `chatContext`.
  *   E7  Legacy `<chatId>/` directories that pre-date the redesign are
  *       left untouched when a fresh session starts.
@@ -53,6 +53,7 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => {
 });
 
 import { createClaudeCodeHandler } from "../handlers/claude-code.js";
+import { IDENTITY_JSON_REL } from "../runtime/bootstrap.js";
 import { createAgentConfigCache } from "../runtime/agent-config-cache.js";
 import { createGitMirrorManager, type GitMirrorManager } from "../runtime/git-mirror-manager.js";
 import type { SessionContext } from "../runtime/handler.js";
@@ -321,7 +322,7 @@ describe("Phase E · agent cwd redesign — end-to-end invariants", () => {
     const handler = createClaudeCodeHandler({ workspaceRoot, agentConfigCache: cache, gitMirrorManager });
     await handler.start(makeMessage("chat-e6", "msg-e6"), buildSessionCtx("chat-e6"));
 
-    const identityPath = join(workspaceRoot, ".agent", "identity.json");
+    const identityPath = join(workspaceRoot, IDENTITY_JSON_REL);
     expect(existsSync(identityPath)).toBe(true);
     const identity = JSON.parse(readFileSync(identityPath, "utf-8"));
 
@@ -356,7 +357,7 @@ describe("Phase E · agent cwd redesign — end-to-end invariants", () => {
     await handler.start(makeMessage("chat-e7", "msg-e7"), buildSessionCtx("chat-e7"));
 
     // Fresh session creates agent home + new layout.
-    expect(existsSync(join(workspaceRoot, ".agent", "identity.json"))).toBe(true);
+    expect(existsSync(join(workspaceRoot, IDENTITY_JSON_REL))).toBe(true);
 
     // Legacy dir survives byte-identical — that's the migration story.
     expect(existsSync(legacyChatDir)).toBe(true);

--- a/packages/client/src/__tests__/agent-cwd-redesign.e2e.test.ts
+++ b/packages/client/src/__tests__/agent-cwd-redesign.e2e.test.ts
@@ -53,8 +53,8 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => {
 });
 
 import { createClaudeCodeHandler } from "../handlers/claude-code.js";
-import { IDENTITY_JSON_REL } from "../runtime/bootstrap.js";
 import { createAgentConfigCache } from "../runtime/agent-config-cache.js";
+import { IDENTITY_JSON_REL } from "../runtime/bootstrap.js";
 import { createGitMirrorManager, type GitMirrorManager } from "../runtime/git-mirror-manager.js";
 import type { SessionContext } from "../runtime/handler.js";
 import { INIT_COMPLETE_SENTINEL_REL } from "../runtime/workspace.js";

--- a/packages/client/src/__tests__/bootstrap.test.ts
+++ b/packages/client/src/__tests__/bootstrap.test.ts
@@ -2,6 +2,7 @@ import { execFileSync } from "node:child_process";
 import {
   chmodSync,
   existsSync,
+  lstatSync,
   mkdirSync,
   readFileSync,
   readlinkSync,
@@ -15,6 +16,8 @@ import {
   BUNDLED_CLI_VERSION_REL,
   bootstrapWorkspace,
   CONTEXT_TREE_HEAD_REL,
+  FIRST_TREE_RUNTIME_DIR,
+  IDENTITY_JSON_REL,
   type ContextTreeBinding,
   deepEqualIdentity,
   installCoreSkills,
@@ -186,7 +189,7 @@ describe("bootstrapWorkspace", () => {
       serverUrl: "http://localhost:8000",
     });
 
-    const identityPath = join(workspace, ".agent", "identity.json");
+    const identityPath = join(workspace, IDENTITY_JSON_REL);
     expect(existsSync(identityPath)).toBe(true);
 
     const data = JSON.parse(readFileSync(identityPath, "utf-8"));
@@ -217,7 +220,43 @@ describe("bootstrapWorkspace", () => {
       serverUrl: "http://localhost:8000",
     });
 
-    expect(existsSync(join(workspace, ".agent", "tools.md"))).toBe(false);
+    expect(existsSync(join(workspace, FIRST_TREE_RUNTIME_DIR, "tools.md"))).toBe(false);
+  });
+
+  it("migrates a legacy .agent/ runtime dir into .first-tree-workspace/", () => {
+    const workspace = join(tmpBase, "ws-migrate-legacy-agent");
+    mkdirSync(join(workspace, ".agent"), { recursive: true });
+    writeFileSync(join(workspace, ".agent", "identity.json"), '{"agentId":"legacy-agent"}');
+    writeFileSync(join(workspace, ".first-tree-workspace"), "", "utf-8");
+
+    bootstrapWorkspace({
+      workspacePath: workspace,
+      identity: makeIdentity({ agentId: "new-agent" }),
+      contextTreePath: null,
+      serverUrl: "http://localhost:8000",
+    });
+
+    expect(existsSync(join(workspace, ".agent"))).toBe(false);
+    expect(existsSync(join(workspace, FIRST_TREE_RUNTIME_DIR))).toBe(true);
+    expect(existsSync(join(workspace, IDENTITY_JSON_REL))).toBe(true);
+    expect(lstatSync(join(workspace, FIRST_TREE_RUNTIME_DIR)).isDirectory()).toBe(true);
+    const data = JSON.parse(readFileSync(join(workspace, IDENTITY_JSON_REL), "utf-8"));
+    expect(data.agentId).toBe("new-agent");
+  });
+
+  it("prunes a migrated legacy tools.md during bootstrap", () => {
+    const workspace = join(tmpBase, "ws-prune-legacy-tools");
+    mkdirSync(join(workspace, ".agent"), { recursive: true });
+    writeFileSync(join(workspace, ".agent", "tools.md"), "legacy tools");
+
+    bootstrapWorkspace({
+      workspacePath: workspace,
+      identity: makeIdentity(),
+      contextTreePath: null,
+      serverUrl: "http://localhost:8000",
+    });
+
+    expect(existsSync(join(workspace, FIRST_TREE_RUNTIME_DIR, "tools.md"))).toBe(false);
   });
 
   it("prunes a legacy `.agent/context/` staging directory on re-bootstrap", () => {
@@ -239,7 +278,7 @@ describe("bootstrapWorkspace", () => {
       serverUrl: "http://localhost:8000",
     });
 
-    expect(existsSync(join(workspace, ".agent", "context"))).toBe(false);
+    expect(existsSync(join(workspace, FIRST_TREE_RUNTIME_DIR, "context"))).toBe(false);
   });
 
   it("does not write self.md (per PRD D7 — prompt lives in agent_configs)", () => {
@@ -253,7 +292,7 @@ describe("bootstrapWorkspace", () => {
       serverUrl: "http://localhost:8000",
     });
 
-    const selfPath = join(workspace, ".agent", "context", "self.md");
+    const selfPath = join(workspace, FIRST_TREE_RUNTIME_DIR, "context", "self.md");
     expect(existsSync(selfPath)).toBe(false);
   });
 
@@ -268,7 +307,7 @@ describe("bootstrapWorkspace", () => {
       serverUrl: "http://localhost:8000",
     });
 
-    const selfPath = join(workspace, ".agent", "context", "self.md");
+    const selfPath = join(workspace, FIRST_TREE_RUNTIME_DIR, "context", "self.md");
     expect(existsSync(selfPath)).toBe(false);
   });
 
@@ -285,10 +324,10 @@ describe("bootstrapWorkspace", () => {
       serverUrl: "http://localhost:8000",
     });
 
-    const selfPath = join(workspace, ".agent", "context", "self.md");
+    const selfPath = join(workspace, FIRST_TREE_RUNTIME_DIR, "context", "self.md");
     expect(existsSync(selfPath)).toBe(false);
     // identity.json should still exist
-    expect(existsSync(join(workspace, ".agent", "identity.json"))).toBe(true);
+    expect(existsSync(join(workspace, IDENTITY_JSON_REL))).toBe(true);
   });
 
   it("no longer stages AGENT.md / NODE.md under `.agent/context/` (briefing references the tree path instead)", () => {
@@ -310,9 +349,9 @@ describe("bootstrapWorkspace", () => {
       serverUrl: "http://localhost:8000",
     });
 
-    expect(existsSync(join(workspace, ".agent", "context", "agent-instructions.md"))).toBe(false);
-    expect(existsSync(join(workspace, ".agent", "context", "domain-map.md"))).toBe(false);
-    expect(existsSync(join(workspace, ".agent", "context"))).toBe(false);
+    expect(existsSync(join(workspace, FIRST_TREE_RUNTIME_DIR, "context", "agent-instructions.md"))).toBe(false);
+    expect(existsSync(join(workspace, FIRST_TREE_RUNTIME_DIR, "context", "domain-map.md"))).toBe(false);
+    expect(existsSync(join(workspace, FIRST_TREE_RUNTIME_DIR, "context"))).toBe(false);
   });
 
   it("does not write degraded.md when contextTreePath is null (no Context Tree is normal)", () => {
@@ -326,7 +365,7 @@ describe("bootstrapWorkspace", () => {
       serverUrl: "http://localhost:8000",
     });
 
-    const degradedPath = join(workspace, ".agent", "context", "degraded.md");
+    const degradedPath = join(workspace, FIRST_TREE_RUNTIME_DIR, "context", "degraded.md");
     expect(existsSync(degradedPath)).toBe(false);
   });
 
@@ -348,7 +387,7 @@ describe("bootstrapWorkspace", () => {
       serverUrl: "http://localhost:8000",
     });
 
-    const data = JSON.parse(readFileSync(join(workspace, ".agent", "identity.json"), "utf-8"));
+    const data = JSON.parse(readFileSync(join(workspace, IDENTITY_JSON_REL), "utf-8"));
     expect(data.agentId).toBe("new-agent");
   });
 });
@@ -706,7 +745,7 @@ describe("Context Tree HEAD drift helpers", () => {
   it("readCachedContextTreeHead returns null when the cache file cannot be read", () => {
     const workspace = join(tmpBase, "tree-head-cache-unreadable");
     const path = join(workspace, CONTEXT_TREE_HEAD_REL);
-    mkdirSync(join(workspace, ".agent"), { recursive: true });
+    mkdirSync(join(workspace, FIRST_TREE_RUNTIME_DIR), { recursive: true });
     writeFileSync(path, "abc123");
     chmodSync(path, 0);
 
@@ -715,7 +754,7 @@ describe("Context Tree HEAD drift helpers", () => {
 
   it("readCachedContextTreeHead returns null for an empty cache file", () => {
     const workspace = join(tmpBase, "tree-head-cache-empty");
-    mkdirSync(join(workspace, ".agent"), { recursive: true });
+    mkdirSync(join(workspace, FIRST_TREE_RUNTIME_DIR), { recursive: true });
     writeFileSync(join(workspace, CONTEXT_TREE_HEAD_REL), "  \n");
 
     expect(readCachedContextTreeHead(workspace)).toBeNull();
@@ -844,7 +883,7 @@ describe("Bundled CLI version drift helpers", () => {
 
   it("trims whitespace from the cached version on read", () => {
     const workspace = join(tmpBase, "cli-version-trim");
-    mkdirSync(join(workspace, ".agent"), { recursive: true });
+    mkdirSync(join(workspace, FIRST_TREE_RUNTIME_DIR), { recursive: true });
     writeFileSync(join(workspace, BUNDLED_CLI_VERSION_REL), "  0.5.3-staging.1.1  \n");
     expect(readCachedBundledCliVersion(workspace)).toBe("0.5.3-staging.1.1");
   });
@@ -852,7 +891,7 @@ describe("Bundled CLI version drift helpers", () => {
   it("readCachedBundledCliVersion returns null when the cache file cannot be read", () => {
     const workspace = join(tmpBase, "cli-version-unreadable");
     const path = join(workspace, BUNDLED_CLI_VERSION_REL);
-    mkdirSync(join(workspace, ".agent"), { recursive: true });
+    mkdirSync(join(workspace, FIRST_TREE_RUNTIME_DIR), { recursive: true });
     writeFileSync(path, "0.5.3");
     chmodSync(path, 0);
 
@@ -861,7 +900,7 @@ describe("Bundled CLI version drift helpers", () => {
 
   it("readCachedBundledCliVersion returns null for an empty cache file", () => {
     const workspace = join(tmpBase, "cli-version-empty");
-    mkdirSync(join(workspace, ".agent"), { recursive: true });
+    mkdirSync(join(workspace, FIRST_TREE_RUNTIME_DIR), { recursive: true });
     writeFileSync(join(workspace, BUNDLED_CLI_VERSION_REL), "  \n");
 
     expect(readCachedBundledCliVersion(workspace)).toBeNull();

--- a/packages/client/src/__tests__/bootstrap.test.ts
+++ b/packages/client/src/__tests__/bootstrap.test.ts
@@ -7,6 +7,7 @@ import {
   readFileSync,
   readlinkSync,
   rmSync,
+  symlinkSync,
   utimesSync,
   writeFileSync,
 } from "node:fs";
@@ -257,6 +258,47 @@ describe("bootstrapWorkspace", () => {
     });
 
     expect(existsSync(join(workspace, FIRST_TREE_RUNTIME_DIR, "tools.md"))).toBe(false);
+  });
+
+  it("keeps current runtime entries when legacy paths collide during migration", () => {
+    const workspace = join(tmpBase, "ws-legacy-collision");
+    mkdirSync(join(workspace, FIRST_TREE_RUNTIME_DIR, "dir-wins"), { recursive: true });
+    writeFileSync(join(workspace, FIRST_TREE_RUNTIME_DIR, "dir-wins", "keep.txt"), "target-dir");
+    writeFileSync(join(workspace, FIRST_TREE_RUNTIME_DIR, "file-wins"), "target-file");
+    mkdirSync(join(workspace, ".agent", "file-wins"), { recursive: true });
+    writeFileSync(join(workspace, ".agent", "file-wins", "legacy.txt"), "legacy-dir");
+    writeFileSync(join(workspace, ".agent", "dir-wins"), "legacy-file");
+
+    bootstrapWorkspace({
+      workspacePath: workspace,
+      identity: makeIdentity(),
+      contextTreePath: null,
+      serverUrl: "http://localhost:8000",
+    });
+
+    expect(lstatSync(join(workspace, FIRST_TREE_RUNTIME_DIR, "dir-wins")).isDirectory()).toBe(true);
+    expect(readFileSync(join(workspace, FIRST_TREE_RUNTIME_DIR, "dir-wins", "keep.txt"), "utf-8")).toBe(
+      "target-dir",
+    );
+    expect(lstatSync(join(workspace, FIRST_TREE_RUNTIME_DIR, "file-wins")).isFile()).toBe(true);
+    expect(readFileSync(join(workspace, FIRST_TREE_RUNTIME_DIR, "file-wins"), "utf-8")).toBe("target-file");
+    expect(existsSync(join(workspace, ".agent"))).toBe(false);
+  });
+
+  it("replaces a dangling .first-tree-workspace symlink with the runtime directory", () => {
+    const workspace = join(tmpBase, "ws-dangling-runtime-marker");
+    mkdirSync(workspace, { recursive: true });
+    symlinkSync(join(workspace, "missing-marker-target"), join(workspace, FIRST_TREE_RUNTIME_DIR));
+
+    bootstrapWorkspace({
+      workspacePath: workspace,
+      identity: makeIdentity(),
+      contextTreePath: null,
+      serverUrl: "http://localhost:8000",
+    });
+
+    expect(lstatSync(join(workspace, FIRST_TREE_RUNTIME_DIR)).isDirectory()).toBe(true);
+    expect(existsSync(join(workspace, IDENTITY_JSON_REL))).toBe(true);
   });
 
   it("prunes a legacy `.agent/context/` staging directory on re-bootstrap", () => {

--- a/packages/client/src/__tests__/bootstrap.test.ts
+++ b/packages/client/src/__tests__/bootstrap.test.ts
@@ -17,10 +17,10 @@ import {
   BUNDLED_CLI_VERSION_REL,
   bootstrapWorkspace,
   CONTEXT_TREE_HEAD_REL,
-  FIRST_TREE_RUNTIME_DIR,
-  IDENTITY_JSON_REL,
   type ContextTreeBinding,
   deepEqualIdentity,
+  FIRST_TREE_RUNTIME_DIR,
+  IDENTITY_JSON_REL,
   installCoreSkills,
   installFirstTreeIntegration,
   readCachedBundledCliVersion,
@@ -277,9 +277,7 @@ describe("bootstrapWorkspace", () => {
     });
 
     expect(lstatSync(join(workspace, FIRST_TREE_RUNTIME_DIR, "dir-wins")).isDirectory()).toBe(true);
-    expect(readFileSync(join(workspace, FIRST_TREE_RUNTIME_DIR, "dir-wins", "keep.txt"), "utf-8")).toBe(
-      "target-dir",
-    );
+    expect(readFileSync(join(workspace, FIRST_TREE_RUNTIME_DIR, "dir-wins", "keep.txt"), "utf-8")).toBe("target-dir");
     expect(lstatSync(join(workspace, FIRST_TREE_RUNTIME_DIR, "file-wins")).isFile()).toBe(true);
     expect(readFileSync(join(workspace, FIRST_TREE_RUNTIME_DIR, "file-wins"), "utf-8")).toBe("target-file");
     expect(existsSync(join(workspace, ".agent"))).toBe(false);

--- a/packages/client/src/__tests__/claude-code-inject-startup-race.test.ts
+++ b/packages/client/src/__tests__/claude-code-inject-startup-race.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -69,7 +69,13 @@ vi.mock("../runtime/agent-bootstrap.js", () => ({
 }));
 
 vi.mock("../runtime/bootstrap.js", () => ({
+  FIRST_TREE_RUNTIME_DIR: ".first-tree-workspace",
   FIRST_TREE_WORKSPACE_MARKER: ".first-tree-workspace",
+  ensureWorkspaceRuntimeDir: vi.fn((workspacePath: string) => {
+    const dir = join(workspacePath, ".first-tree-workspace");
+    mkdirSync(dir, { recursive: true });
+    return dir;
+  }),
   writeAgentBriefing: vi.fn(),
 }));
 

--- a/packages/client/src/__tests__/codex-bootstrap.test.ts
+++ b/packages/client/src/__tests__/codex-bootstrap.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { existsSync, lstatSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { AgentRuntimeConfigPayload } from "@first-tree/shared";
@@ -45,7 +45,7 @@ describe("bootstrapWorkspace — codex briefing + workspace marker", () => {
     rmSync(workspacePath, { recursive: true, force: true });
   });
 
-  it("writes the .first-tree-workspace marker for every workspace", () => {
+  it("writes the .first-tree-workspace marker directory for every workspace", () => {
     bootstrapWorkspace({
       workspacePath,
       identity: {
@@ -62,6 +62,7 @@ describe("bootstrapWorkspace — codex briefing + workspace marker", () => {
     });
 
     expect(existsSync(join(workspacePath, FIRST_TREE_WORKSPACE_MARKER))).toBe(true);
+    expect(lstatSync(join(workspacePath, FIRST_TREE_WORKSPACE_MARKER)).isDirectory()).toBe(true);
   });
 
   it("bootstrapWorkspace no longer writes the briefing (callers route through writeAgentBriefing)", () => {
@@ -69,7 +70,7 @@ describe("bootstrapWorkspace — codex briefing + workspace marker", () => {
     // handler computes the unified briefing via `buildAgentBriefing` and
     // hands it to `writeAgentBriefing` (or to `ensureAgentBootstrap` which
     // calls writeAgentBriefing internally). `bootstrapWorkspace` is back to
-    // owning only the stable `.agent/` layout.
+    // owning only the stable `.first-tree-workspace/` layout.
     bootstrapWorkspace({
       workspacePath,
       identity: {

--- a/packages/client/src/__tests__/codex-inject-startup-race.test.ts
+++ b/packages/client/src/__tests__/codex-inject-startup-race.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { SessionEvent } from "@first-tree/shared";
@@ -65,9 +65,15 @@ vi.mock("@openai/codex-sdk", () => {
 });
 
 vi.mock("../runtime/bootstrap.js", () => ({
+  FIRST_TREE_RUNTIME_DIR: ".first-tree-workspace",
   FIRST_TREE_WORKSPACE_MARKER: ".first-tree-workspace",
   bootstrapWorkspace: vi.fn(),
   deepEqualIdentity: vi.fn(() => true),
+  ensureWorkspaceRuntimeDir: vi.fn((workspacePath: string) => {
+    const dir = join(workspacePath, ".first-tree-workspace");
+    mkdirSync(dir, { recursive: true });
+    return dir;
+  }),
   installCoreSkills: vi.fn(),
   installFirstTreeIntegration: vi.fn(() => true),
   isHubWorktreeMarker: vi.fn(() => false),

--- a/packages/client/src/__tests__/codex-retry-abort.test.ts
+++ b/packages/client/src/__tests__/codex-retry-abort.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { SessionEvent } from "@first-tree/shared";
@@ -77,9 +77,15 @@ vi.mock("@openai/codex-sdk", () => {
 });
 
 vi.mock("../runtime/bootstrap.js", () => ({
+  FIRST_TREE_RUNTIME_DIR: ".first-tree-workspace",
   FIRST_TREE_WORKSPACE_MARKER: ".first-tree-workspace",
   bootstrapWorkspace: vi.fn(),
   deepEqualIdentity: vi.fn(() => true),
+  ensureWorkspaceRuntimeDir: vi.fn((workspacePath: string) => {
+    const dir = join(workspacePath, ".first-tree-workspace");
+    mkdirSync(dir, { recursive: true });
+    return dir;
+  }),
   installCoreSkills: vi.fn(),
   installFirstTreeIntegration: vi.fn(() => true),
   isHubWorktreeMarker: vi.fn(() => false),

--- a/packages/client/src/__tests__/workspace.test.ts
+++ b/packages/client/src/__tests__/workspace.test.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { FIRST_TREE_WORKSPACE_MARKER } from "../runtime/bootstrap.js";
+import { FIRST_TREE_RUNTIME_DIR, FIRST_TREE_WORKSPACE_MARKER, IDENTITY_JSON_REL } from "../runtime/bootstrap.js";
 import {
   acquireAgentHome,
   acquireWorkspace,
@@ -21,8 +21,8 @@ import {
  *
  *  - acquireAgentHome is idempotent: creates the dir on first call, returns
  *    the same path thereafter, never wipes existing content.
- *  - The boundary marker (`.first-tree-workspace`) is written once at the
- *    agent home root so Codex's `project_root_markers` stops there.
+ *  - The boundary marker directory (`.first-tree-workspace/`) is written once
+ *    at the agent home root so Codex's `project_root_markers` stops there.
  *  - The sentinel write/clear pair is the drift-detection knob: clear it when
  *    Context Tree commit changes, write it after bootstrap succeeds.
  */
@@ -39,7 +39,7 @@ afterEach(() => {
 });
 
 describe("acquireAgentHome", () => {
-  it("creates the agent home and writes the boundary marker on first call", () => {
+  it("creates the agent home and writes the boundary marker directory on first call", () => {
     const home = join(root, AGENT_NAME);
     const cwd = acquireAgentHome(home);
 
@@ -68,7 +68,7 @@ describe("acquireAgentHome", () => {
     // NOT by rming the directory. acquireAgentHome must not touch contents.
     const home = join(root, AGENT_NAME);
     mkdirSync(home, { recursive: true });
-    writeFileSync(join(home, FIRST_TREE_WORKSPACE_MARKER), "", "utf-8");
+    mkdirSync(join(home, FIRST_TREE_WORKSPACE_MARKER), { recursive: true });
     writeFileSync(join(home, "preexisting.txt"), "keep me", "utf-8");
 
     acquireAgentHome(home);
@@ -90,10 +90,10 @@ describe("markWorkspaceInitComplete / clearWorkspaceInitComplete", () => {
     expect(new Date(body.completedAt).toString()).not.toBe("Invalid Date");
   });
 
-  it("creates .agent/ if missing (defensive)", () => {
+  it("creates the runtime marker directory if missing (defensive)", () => {
     const home = acquireAgentHome(join(root, AGENT_NAME));
     markWorkspaceInitComplete(home);
-    expect(existsSync(join(home, ".agent"))).toBe(true);
+    expect(existsSync(join(home, FIRST_TREE_RUNTIME_DIR))).toBe(true);
   });
 
   it("is idempotent — writing twice leaves a valid sentinel", () => {
@@ -107,12 +107,12 @@ describe("markWorkspaceInitComplete / clearWorkspaceInitComplete", () => {
   it("clearWorkspaceInitComplete removes the sentinel, leaving everything else alone", () => {
     const home = acquireAgentHome(join(root, AGENT_NAME));
     markWorkspaceInitComplete(home);
-    writeFileSync(join(home, ".agent", "identity.json"), "{}", "utf-8");
+    writeFileSync(join(home, IDENTITY_JSON_REL), "{}", "utf-8");
 
     clearWorkspaceInitComplete(home);
 
     expect(existsSync(join(home, INIT_COMPLETE_SENTINEL_REL))).toBe(false);
-    expect(existsSync(join(home, ".agent", "identity.json"))).toBe(true);
+    expect(existsSync(join(home, IDENTITY_JSON_REL))).toBe(true);
     expect(existsSync(join(home, FIRST_TREE_WORKSPACE_MARKER))).toBe(true);
   });
 
@@ -157,8 +157,7 @@ describe("acquireWorkspace (deprecated legacy shim)", () => {
     // Production handlers no longer call this; the shim must therefore not
     // implement the old half-baked rm logic.
     const dir = join(root, "chat-abc");
-    mkdirSync(join(dir, ".agent"), { recursive: true });
-    writeFileSync(join(dir, FIRST_TREE_WORKSPACE_MARKER), "", "utf-8");
+    mkdirSync(join(dir, FIRST_TREE_RUNTIME_DIR), { recursive: true });
     writeFileSync(join(dir, "leftover.txt"), "untouched", "utf-8");
 
     acquireWorkspace(root, "chat-abc");

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -1507,7 +1507,8 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
    *   - Sentinel absent → full bootstrap.
    *   - Sentinel present + Tree HEAD unchanged → cheap identity refresh only.
    *   - Sentinel present + Tree HEAD drifted → full bootstrap re-runs so the
-   *     stable .agent/ layout and first-tree skill pick up the new tree state.
+   *     stable `.first-tree-workspace/` layout and first-tree skill pick up
+   *     the new tree state.
    *
    * The unified briefing is rewritten on every call regardless of the drift
    * decision — chat context and the agent payload may have changed between
@@ -1586,8 +1587,8 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       // conversation found ...`. To preserve the agent's SDK turn history
       // across upgrade, probe the legacy chat dir first — if the transcript
       // is there, run the resume against the legacy cwd verbatim and skip
-      // every piece of agent-home setup (the legacy dir already has its
-      // own `.agent/`, CLAUDE.md, and gitRepos checkout at top-level).
+      // every piece of agent-home setup (the legacy dir already has its own
+      // legacy `.agent/`, CLAUDE.md, and gitRepos checkout at top-level).
       const legacyCwd = join(workspaceRoot, sessionCtx.chatId);
       const isLegacy = existsSync(legacyCwd) && claudeSessionFileExists(legacyCwd, sessionId);
 
@@ -1601,14 +1602,15 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
         const chatContext = await fetchChatContextOrLog(sessionCtx);
         chatContextForPrompt = chatContext;
         // Intentionally NOT calling ensureAgentBootstrap / prepareSourceRepos /
-        // markWorkspaceInitComplete here — those write the new agent-home
-        // layout, which would pollute the legacy chat dir's v1.x `.agent/`
-        // and `<localPath>/` source repos.
+        // markWorkspaceInitComplete here — those write the new
+        // `.first-tree-workspace/` agent-home layout, which would pollute the
+        // legacy chat dir's v1.x `.agent/` and `<localPath>/` source repos.
         //
         // We DO refresh the briefing (writeAgentBriefing only touches the
-        // AGENTS.md file + CLAUDE.md symlink, not `.agent/` or source repos)
-        // because under the unified-briefing redesign the SDK no longer has
-        // a `systemPrompt.append` path — without this rewrite a legacy resume
+        // AGENTS.md file + CLAUDE.md symlink, not `.first-tree-workspace/`,
+        // the legacy `.agent/`, or source repos) because under the
+        // unified-briefing redesign the SDK no longer has a
+        // `systemPrompt.append` path — without this rewrite a legacy resume
         // would only see the stale v1.x stable CLAUDE.md, dropping the
         // current `prompt.append`, resource-skill briefing, and Current Chat
         // Context the previous per-turn SDK append used to deliver.

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -18,7 +18,13 @@ export {
 export type { AgentSlotConfig } from "./runtime/agent-slot.js";
 export { AgentSlot } from "./runtime/agent-slot.js";
 export type { ContextTreeBinding } from "./runtime/bootstrap.js";
-export { contextTreeCloneDir, syncAgentContextTree, syncContextTree } from "./runtime/bootstrap.js";
+export {
+  contextTreeCloneDir,
+  ensureWorkspaceRuntimeDir,
+  migrateLegacyRuntimeLayout,
+  syncAgentContextTree,
+  syncContextTree,
+} from "./runtime/bootstrap.js";
 // Capabilities
 export { probeClaudeCodeCapability } from "./runtime/capabilities/claude-code.js";
 export { probeCodexCapability } from "./runtime/capabilities/codex.js";

--- a/packages/client/src/runtime/agent-bootstrap.ts
+++ b/packages/client/src/runtime/agent-bootstrap.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import {
   bootstrapWorkspace,
   deepEqualIdentity,
+  IDENTITY_JSON_REL,
   installCoreSkills,
   installFirstTreeIntegration,
   readCachedBundledCliVersion,
@@ -33,16 +34,17 @@ export type AgentBootstrapParams = {
 
 /**
  * Hash-check the existing identity.json against current agent metadata and
- * rewrite the stable `.agent/` section only when something changed. Runs OUT
+ * rewrite the stable `.first-tree-workspace/` section only when something
+ * changed. Runs OUT
  * of the sentinel gate so agent rename / inboxId / metadata edits still
  * propagate after first bootstrap (proposal R5).
  *
  * The unified briefing is rewritten by the caller via {@link
  * writeAgentBriefing} on every start/resume regardless of this check —
- * identity drift only forces the heavier `.agent/` refresh.
+ * identity drift only forces the heavier `.first-tree-workspace/` refresh.
  */
 function ensureStableIdentity(workspace: string, sessionCtx: SessionContext, contextTreePath: string | null): void {
-  const identityPath = join(workspace, ".agent", "identity.json");
+  const identityPath = join(workspace, IDENTITY_JSON_REL);
   const desired = {
     agentId: sessionCtx.agent.agentId,
     displayName: sessionCtx.agent.displayName,
@@ -72,9 +74,10 @@ function ensureStableIdentity(workspace: string, sessionCtx: SessionContext, con
 }
 
 /**
- * Run the agent-home bootstrap that every handler shares: stable `.agent/`
- * layout, unified briefing rewrite (AGENTS.md + CLAUDE.md symlink), core-skill
- * install, and (for Context-Tree-bound agents) the inline first-tree skill
+ * Run the agent-home bootstrap that every handler shares: stable
+ * `.first-tree-workspace/` layout, unified briefing rewrite (AGENTS.md +
+ * CLAUDE.md symlink), core-skill install, and (for Context-Tree-bound agents)
+ * the inline first-tree skill
  * install (`installFirstTreeIntegration`, which copies bundled skill payloads
  * straight from `@first-tree/client`'s own `skills/` directory). Gated by the
  * stage-2 sentinel + Context-Tree-HEAD / Client-version drift detection so a

--- a/packages/client/src/runtime/bootstrap.ts
+++ b/packages/client/src/runtime/bootstrap.ts
@@ -623,6 +623,26 @@ export function ensureWorkspaceRuntimeDir(workspacePath: string): string {
   return runtimeDir;
 }
 
+/**
+ * Apply the legacy runtime-layout migration without rewriting identity or any
+ * other bootstrap-managed files. Shared by handler bootstrap and the client
+ * startup migration so both converge on the same cleanup: move `.agent/`
+ * into `.first-tree-workspace/`, then prune legacy `.agent/context/` and
+ * `.agent/tools.md` payloads that the unified briefing replaced.
+ */
+export function migrateLegacyRuntimeLayout(workspacePath: string): string {
+  const runtimeDir = ensureWorkspaceRuntimeDir(workspacePath);
+  const legacyContextDir = join(runtimeDir, "context");
+  if (existsSync(legacyContextDir)) {
+    rmSync(legacyContextDir, { recursive: true, force: true });
+  }
+  const legacyToolsMd = join(runtimeDir, "tools.md");
+  if (existsSync(legacyToolsMd)) {
+    rmSync(legacyToolsMd, { force: true });
+  }
+  return runtimeDir;
+}
+
 export type BootstrapOptions = {
   workspacePath: string;
   identity: AgentIdentity;
@@ -652,19 +672,7 @@ export type BootstrapOptions = {
  */
 export function bootstrapWorkspace(options: BootstrapOptions): void {
   const { workspacePath, identity, contextTreePath, serverUrl } = options;
-  const agentDir = ensureWorkspaceRuntimeDir(workspacePath);
-  // Legacy `.agent/context/` staging directory; pruned at bootstrap so a
-  // resumed agent home that pre-dates this PR doesn't keep stale
-  // agent-instructions.md / domain-map.md / tools.md around. The unified
-  // briefing replaces them.
-  const legacyContextDir = join(agentDir, "context");
-  if (existsSync(legacyContextDir)) {
-    rmSync(legacyContextDir, { recursive: true, force: true });
-  }
-  const legacyToolsMd = join(agentDir, "tools.md");
-  if (existsSync(legacyToolsMd)) {
-    rmSync(legacyToolsMd, { force: true });
-  }
+  const agentDir = migrateLegacyRuntimeLayout(workspacePath);
 
   // 1. Write identity.json — agent-level stable fields only. chatId /
   //    chatContext used to live here but are now injected per turn so a

--- a/packages/client/src/runtime/bootstrap.ts
+++ b/packages/client/src/runtime/bootstrap.ts
@@ -4,6 +4,7 @@ import {
   existsSync,
   lstatSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
   readlinkSync,
   renameSync,
@@ -298,12 +299,16 @@ export async function syncAgentContextTree(
 }
 
 /**
- * Marker file written into every workspace so the Codex CLI's project-root
- * detection (configured via `project_root_markers: ["first-tree-workspace"]`)
- * stops at the workspace boundary instead of walking up the filesystem and
- * loading an unintended `AGENTS.md` from the operator's home or repo root.
+ * Marker directory written into every workspace so the Codex CLI's
+ * project-root detection (configured via
+ * `project_root_markers: [".first-tree-workspace"]`) stops at the workspace
+ * boundary instead of walking up the filesystem and loading an unintended
+ * `AGENTS.md` from the operator's home or repo root.
  */
 export const FIRST_TREE_WORKSPACE_MARKER = ".first-tree-workspace";
+export const FIRST_TREE_RUNTIME_DIR = FIRST_TREE_WORKSPACE_MARKER;
+export const LEGACY_AGENT_RUNTIME_DIR = ".agent";
+export const IDENTITY_JSON_REL = join(FIRST_TREE_RUNTIME_DIR, "identity.json");
 
 /**
  * Materialise the unified agent briefing at `<workspacePath>/AGENTS.md` and
@@ -372,7 +377,7 @@ export function ensureClaudeMdSymlink(workspacePath: string): void {
  * trigger a fresh `installFirstTreeIntegration` (proposals/agent-session-
  * cwd-redesign.20260519.md §⑤.3).
  */
-export const CONTEXT_TREE_HEAD_REL = join(".agent", "context-tree-head");
+export const CONTEXT_TREE_HEAD_REL = join(FIRST_TREE_RUNTIME_DIR, "context-tree-head");
 
 /**
  * Best-effort read of the Context Tree's current HEAD commit. Returns `null`
@@ -414,11 +419,12 @@ export function readCachedContextTreeHead(workspacePath: string): string | null 
  * `.agents/skills/*` after a `first-tree upgrade` until the Context Tree
  * happens to move.
  */
-export const BUNDLED_CLI_VERSION_REL = join(".agent", "cli-version");
+export const BUNDLED_CLI_VERSION_REL = join(FIRST_TREE_RUNTIME_DIR, "cli-version");
 
 /**
  * Resolve a stable identifier for the bundled CLI that the handler can
- * compare against the cached `.agent/cli-version` to detect upgrades.
+ * compare against the cached `.first-tree-workspace/cli-version` to detect
+ * upgrades.
  *
  * Behaviour by channel:
  *
@@ -486,7 +492,7 @@ export function resolveBundledCliVersion(moduleUrl: string = import.meta.url): s
   // CliBinding's docblock). Anywhere else (prod / staging / uninitialised)
   // we keep the bare version — staging/prod have a release-bumped
   // version that already changes per build, so a fingerprint would just
-  // be noise in the `.agent/cli-version` pin.
+  // be noise in the `.first-tree-workspace/cli-version` pin.
   let isDevChannel = false;
   try {
     isDevChannel = getCliBinding().packageName === null;
@@ -523,7 +529,7 @@ export function readCachedBundledCliVersion(workspacePath: string): string | nul
 export function writeBundledCliVersion(workspacePath: string, version: string | null): void {
   if (!version) return;
   const path = join(workspacePath, BUNDLED_CLI_VERSION_REL);
-  mkdirSync(join(workspacePath, ".agent"), { recursive: true });
+  ensureWorkspaceRuntimeDir(workspacePath);
   writeFileSync(path, version, "utf-8");
 }
 
@@ -531,8 +537,64 @@ export function writeBundledCliVersion(workspacePath: string, version: string | 
 export function writeContextTreeHead(workspacePath: string, head: string | null): void {
   const path = join(workspacePath, CONTEXT_TREE_HEAD_REL);
   if (head === null) return;
-  mkdirSync(join(workspacePath, ".agent"), { recursive: true });
+  ensureWorkspaceRuntimeDir(workspacePath);
   writeFileSync(path, head, "utf-8");
+}
+
+function mergeLegacyRuntimeDir(sourceDir: string, targetDir: string): void {
+  mkdirSync(targetDir, { recursive: true });
+  for (const entry of readdirSync(sourceDir)) {
+    const sourcePath = join(sourceDir, entry);
+    const targetPath = join(targetDir, entry);
+    const sourceStats = lstatSync(sourcePath);
+    if (sourceStats.isDirectory()) {
+      if (existsSync(targetPath) && lstatSync(targetPath).isDirectory()) {
+        mergeLegacyRuntimeDir(sourcePath, targetPath);
+      } else if (!existsSync(targetPath)) {
+        renameSync(sourcePath, targetPath);
+      } else {
+        rmSync(sourcePath, { recursive: true, force: true });
+      }
+      continue;
+    }
+    if (!existsSync(targetPath)) {
+      renameSync(sourcePath, targetPath);
+    } else {
+      rmSync(sourcePath, { recursive: true, force: true });
+    }
+  }
+  rmSync(sourceDir, { recursive: true, force: true });
+}
+
+/**
+ * Converge the runtime state onto the current `.first-tree-workspace/` layout.
+ *
+ * Legacy states we still heal automatically:
+ *
+ * - root marker file `.first-tree-workspace` from the pre-directory layout
+ * - stable runtime dir `.agent/` from the pre-rename layout
+ *
+ * The resulting directory both stores the stable runtime files and acts as the
+ * root marker Codex uses for project detection.
+ */
+export function ensureWorkspaceRuntimeDir(workspacePath: string): string {
+  const runtimeDir = join(workspacePath, FIRST_TREE_RUNTIME_DIR);
+  const legacyAgentDir = join(workspacePath, LEGACY_AGENT_RUNTIME_DIR);
+
+  if (existsSync(runtimeDir) && lstatSync(runtimeDir).isFile()) {
+    unlinkSync(runtimeDir);
+  }
+
+  if (existsSync(legacyAgentDir) && lstatSync(legacyAgentDir).isDirectory()) {
+    if (existsSync(runtimeDir) && lstatSync(runtimeDir).isDirectory()) {
+      mergeLegacyRuntimeDir(legacyAgentDir, runtimeDir);
+    } else if (!existsSync(runtimeDir)) {
+      renameSync(legacyAgentDir, runtimeDir);
+    }
+  }
+
+  mkdirSync(runtimeDir, { recursive: true });
+  return runtimeDir;
 }
 
 export type BootstrapOptions = {
@@ -543,28 +605,28 @@ export type BootstrapOptions = {
 };
 
 /**
- * Bootstrap the agent's home directory with stable, agent-level files plus
- * the workspace-root marker.
+ * Bootstrap the agent's home directory with stable, agent-level files inside
+ * the workspace-root marker directory.
  *
- * Writes identity.json and the `.first-tree-workspace` marker. Per the
+ * Writes identity.json into `.first-tree-workspace/`. Per the
  * agent-session-cwd-redesign (proposals/2026-05-19) **only agent-level stable
  * fields** live in identity.json; per-chat data (chatId, participants) flows
  * through the unified per-turn briefing file written by {@link
  * writeAgentBriefing} (which the handler invokes on every start/resume after
  * computing the briefing content via {@link buildAgentBriefing}).
  *
- * The bootstrap no longer stages AGENT.md / NODE.md copies under
- * `.agent/context/` and no longer emits `.agent/tools.md`. The unified
- * briefing owns all of that content; the runtime briefing is the single
- * source of agent-level instructions on disk.
+ * The bootstrap no longer stages AGENT.md / NODE.md copies under the legacy
+ * `.agent/context/` tree and no longer emits `.agent/tools.md`. The unified
+ * briefing owns all of that content; the runtime briefing is the single source
+ * of agent-level instructions on disk.
  *
  * Idempotent: safe to call on every handler start() / resume(), though in
  * the per-agent-home model the handler short-circuits this when the
- * `.agent/init-complete` sentinel is already present.
+ * `.first-tree-workspace/init-complete` sentinel is already present.
  */
 export function bootstrapWorkspace(options: BootstrapOptions): void {
   const { workspacePath, identity, contextTreePath, serverUrl } = options;
-  const agentDir = join(workspacePath, ".agent");
+  const agentDir = ensureWorkspaceRuntimeDir(workspacePath);
   // Legacy `.agent/context/` staging directory; pruned at bootstrap so a
   // resumed agent home that pre-dates this PR doesn't keep stale
   // agent-instructions.md / domain-map.md / tools.md around. The unified
@@ -573,7 +635,10 @@ export function bootstrapWorkspace(options: BootstrapOptions): void {
   if (existsSync(legacyContextDir)) {
     rmSync(legacyContextDir, { recursive: true, force: true });
   }
-  mkdirSync(agentDir, { recursive: true });
+  const legacyToolsMd = join(agentDir, "tools.md");
+  if (existsSync(legacyToolsMd)) {
+    rmSync(legacyToolsMd, { force: true });
+  }
 
   // 1. Write identity.json — agent-level stable fields only. chatId /
   //    chatContext used to live here but are now injected per turn so a
@@ -590,11 +655,6 @@ export function bootstrapWorkspace(options: BootstrapOptions): void {
     contextTreePath,
   };
   writeFileSync(join(agentDir, "identity.json"), JSON.stringify(identityData, null, 2), "utf-8");
-
-  // 2. Workspace-root marker — gates Codex's AGENTS.md walk-up so the agent
-  //    sees the briefing in this workspace and not whatever sits in the
-  //    operator's HOME / git root.
-  writeFileSync(join(workspacePath, FIRST_TREE_WORKSPACE_MARKER), "", "utf-8");
 }
 
 export type InstallFirstTreeIntegrationOptions = {
@@ -728,7 +788,8 @@ export function isHubWorktreeMarker(path: string): boolean {
 
 /**
  * Field-by-field equality for the identity record both handlers write into
- * `.agent/identity.json`. Implemented manually so a missing key on disk
+ * `.first-tree-workspace/identity.json`. Implemented manually so a missing key
+ * on disk
  * (older bootstrap) is treated as drift even when `JSON.stringify` happens
  * to match by chance.
  *

--- a/packages/client/src/runtime/bootstrap.ts
+++ b/packages/client/src/runtime/bootstrap.ts
@@ -814,10 +814,9 @@ export function isHubWorktreeMarker(path: string): boolean {
 
 /**
  * Field-by-field equality for the identity record both handlers write into
- * `.first-tree-workspace/identity.json`. Implemented manually so a missing key
- * on disk
- * (older bootstrap) is treated as drift even when `JSON.stringify` happens
- * to match by chance.
+ * `.first-tree-workspace/identity.json`. Implemented manually so a missing
+ * key on disk from an older bootstrap is treated as drift even when
+ * `JSON.stringify` happens to match by chance.
  *
  * Shared between claude-code and codex handlers — both call
  * `ensureStableIdentity` / `ensureCodexBootstrap` to hash-check before

--- a/packages/client/src/runtime/bootstrap.ts
+++ b/packages/client/src/runtime/bootstrap.ts
@@ -541,6 +541,23 @@ export function writeContextTreeHead(workspacePath: string, head: string | null)
   writeFileSync(path, head, "utf-8");
 }
 
+function lstatIfExists(path: string) {
+  try {
+    return lstatSync(path);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw err;
+  }
+}
+
+/**
+ * Merge legacy `.agent/` entries into `.first-tree-workspace/`.
+ *
+ * Conflict policy is intentionally "target wins": if a path already exists in
+ * the target, the legacy source entry at that path is pruned instead of
+ * overwriting newer runtime state. That keeps partial upgrades and repeated
+ * bootstraps idempotent.
+ */
 function mergeLegacyRuntimeDir(sourceDir: string, targetDir: string): void {
   mkdirSync(targetDir, { recursive: true });
   for (const entry of readdirSync(sourceDir)) {
@@ -576,19 +593,28 @@ function mergeLegacyRuntimeDir(sourceDir: string, targetDir: string): void {
  *
  * The resulting directory both stores the stable runtime files and acts as the
  * root marker Codex uses for project detection.
+ *
+ * Note: apps/cli still has a separate W1 migration path that reasons about a
+ * legacy file marker named `.first-tree-workspace` inside user workspaces.
+ * This helper only heals the per-agent runtime home under
+ * `<dataDir>/workspaces/<agent>/`, so replacing a pre-existing file or symlink
+ * here does not participate in CLI workspace detection.
  */
 export function ensureWorkspaceRuntimeDir(workspacePath: string): string {
   const runtimeDir = join(workspacePath, FIRST_TREE_RUNTIME_DIR);
   const legacyAgentDir = join(workspacePath, LEGACY_AGENT_RUNTIME_DIR);
+  const runtimeStats = lstatIfExists(runtimeDir);
 
-  if (existsSync(runtimeDir) && lstatSync(runtimeDir).isFile()) {
+  if (runtimeStats && !runtimeStats.isDirectory()) {
     unlinkSync(runtimeDir);
   }
 
-  if (existsSync(legacyAgentDir) && lstatSync(legacyAgentDir).isDirectory()) {
-    if (existsSync(runtimeDir) && lstatSync(runtimeDir).isDirectory()) {
+  const legacyAgentStats = lstatIfExists(legacyAgentDir);
+  const currentRuntimeStats = lstatIfExists(runtimeDir);
+  if (legacyAgentStats?.isDirectory()) {
+    if (currentRuntimeStats?.isDirectory()) {
       mergeLegacyRuntimeDir(legacyAgentDir, runtimeDir);
-    } else if (!existsSync(runtimeDir)) {
+    } else if (!currentRuntimeStats) {
       renameSync(legacyAgentDir, runtimeDir);
     }
   }

--- a/packages/client/src/runtime/workspace.ts
+++ b/packages/client/src/runtime/workspace.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { FIRST_TREE_WORKSPACE_MARKER } from "./bootstrap.js";
+import { ensureWorkspaceRuntimeDir, FIRST_TREE_RUNTIME_DIR } from "./bootstrap.js";
 
 /** Retained as an exported constant so external callers that imported it
  *  before the per-agent-home refactor still compile. The runtime no longer
@@ -20,12 +20,13 @@ export const DEFAULT_WORKSPACE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
  * contract is: sentinel-absent ⇒ re-run `runBootstrap` (idempotent), which
  * overwrites the bootstrap-managed files in place.
  */
-export const INIT_COMPLETE_SENTINEL_REL = join(".agent", "init-complete");
+export const INIT_COMPLETE_SENTINEL_REL = join(FIRST_TREE_RUNTIME_DIR, "init-complete");
 
 /**
  * Acquire the agent's home directory (shared by every chat session for this
- * agent). Idempotent: first call creates the directory and writes the
- * boundary marker; subsequent calls just return the path.
+ * agent). Idempotent: first call creates the directory and converges the
+ * runtime state into the workspace marker directory; subsequent calls just
+ * return the path.
  *
  * Per the agent-session-cwd-redesign proposal, the cwd is **per-agent**, not
  * per-chat: same agent → same cwd across every chat. Per-chat differentiation
@@ -33,10 +34,7 @@ export const INIT_COMPLETE_SENTINEL_REL = join(".agent", "init-complete");
  */
 export function acquireAgentHome(agentHome: string): string {
   mkdirSync(agentHome, { recursive: true });
-  const markerPath = join(agentHome, FIRST_TREE_WORKSPACE_MARKER);
-  if (!existsSync(markerPath)) {
-    writeFileSync(markerPath, "", "utf-8");
-  }
+  ensureWorkspaceRuntimeDir(agentHome);
   return agentHome;
 }
 
@@ -61,7 +59,7 @@ export function acquireWorkspace(workspaceRoot: string, chatId: string): string 
  */
 export function markWorkspaceInitComplete(agentHome: string): void {
   const path = join(agentHome, INIT_COMPLETE_SENTINEL_REL);
-  mkdirSync(join(agentHome, ".agent"), { recursive: true });
+  ensureWorkspaceRuntimeDir(agentHome);
   writeFileSync(path, JSON.stringify({ completedAt: new Date().toISOString(), schemaVersion: 1 }), "utf-8");
 }
 


### PR DESCRIPTION
## Summary
- rename the stable agent runtime state root from `.agent/` to `.first-tree-workspace/`
- make `.first-tree-workspace/` serve as both the Codex workspace marker and the runtime state directory
- auto-migrate legacy `.agent/` state and prune legacy `.agent/tools.md` / `.agent/context/` on bootstrap

## Why
The previous layout split runtime state across a root marker file and a separate `.agent/` directory. This change collapses them into one runtime directory while preserving workspace boundary detection and startup self-healing.

## Validation
- `pnpm --dir packages/client test`
- `pnpm --dir packages/client typecheck`
- `pnpm check`
