### PR TITLE
feat(web): repo resources are always On by default

### DIFF
--- a/packages/web/src/pages/agent-detail/__tests__/resources-savebar-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/resources-savebar-dom.test.tsx
@@ -359,6 +359,50 @@ describe("ResourcesTab and SaveBar", () => {
     });
   });
 
+  it("excludes opt-in (available) repos from the agent repo add menu", async () => {
+    const layoutMocks = await import("../layout-context.js");
+    const spy = vi.spyOn(layoutMocks, "useAgentDetailContext");
+    spy.mockReturnValue(context());
+    // A legacy team repo still flagged Opt-in (available). Team repos are now
+    // always On by default, so it must NOT be offered as an "enable from team"
+    // option on the agent.
+    agentResourceMocks.getAgentResources.mockResolvedValue(
+      agentResources({
+        availableTeamResources: [
+          {
+            id: "repo-available",
+            organizationId: "org-1",
+            type: "repo",
+            scope: "team",
+            ownerAgentId: null,
+            name: "Opt-in repo",
+            repoCanonicalKey: null,
+            defaultEnabled: "available",
+            status: "active",
+            payload: { url: "https://github.com/acme/optin.git" },
+            createdBy: "member-1",
+            updatedBy: "member-1",
+            createdAt: NOW,
+            updatedAt: NOW,
+          },
+        ],
+      }),
+    );
+    const { ResourcesTab } = await import("../resources-tab.js");
+
+    const container = await renderWithContext(<ResourcesTab />);
+    await waitForText(container, "Code repositories");
+
+    // Open the repo section's add menu (panel portals to document.body).
+    await click(container.querySelector('button[aria-label="Add Repo"]'));
+    // The opt-in repo is not enableable, and there's no "Enable from team" list…
+    expect(buttonByText(document.body, "Opt-in repo")).toBeNull();
+    expect(document.body.textContent).not.toContain("Enable from team");
+    // …but the menu stays actionable: add a private repo or jump to Settings.
+    expect(buttonByText(document.body, "Add agent repo")).toBeTruthy();
+    expect(buttonByText(document.body, "Manage in Settings → Resources")).toBeTruthy();
+  });
+
   it("keeps the MCP add menu actionable with no team MCP (routes to Settings, no dead end)", async () => {
     const layoutMocks = await import("../layout-context.js");
     const spy = vi.spyOn(layoutMocks, "useAgentDetailContext");

--- a/packages/web/src/pages/agent-detail/resources-tab.tsx
+++ b/packages/web/src/pages/agent-detail/resources-tab.tsx
@@ -68,8 +68,12 @@ export function ResourcesTab() {
   const currentBindings = data.bindings;
   const mutateBindings = (next: AgentResourceBindingInput[]) => updateMut.mutate(next);
   const activeBindingIds = new Set(currentBindings.map((b) => b.resourceId).filter((id): id is string => !!id));
+  // Opt-in team resources an agent can enable for itself. Repos are excluded:
+  // team repos are always On by default now (no per-repo Opt-in), so they never
+  // appear in the "Enable from team" list. skill / mcp still support opt-in.
   const available = data.availableTeamResources.filter(
-    (resource) => resource.defaultEnabled === "available" && !activeBindingIds.has(resource.id),
+    (resource) =>
+      resource.defaultEnabled === "available" && resource.type !== "repo" && !activeBindingIds.has(resource.id),
   );
 
   return (
@@ -155,8 +159,9 @@ export function ResourcesTab() {
 /**
  * Per-section add control on the agent Capabilities tab. One "+ <Type>" trigger
  * opens a context menu:
- *   - repo: "Add agent repo" (a private, agent-scoped repo) plus any opt-in team
- *     repos to enable.
+ *   - repo: "Add agent repo" (a private, agent-scoped repo). Team repos are
+ *     always On by default (no per-repo Opt-in), so there's no "enable from
+ *     team" list for repos.
  *   - skill / mcp: opt-in team resources to enable. These types have no
  *     agent-private form (the binding model supports private repos and inline
  *     prompts only), so when the team offers none the menu still routes the user

--- a/packages/web/src/pages/settings/resource-editors.tsx
+++ b/packages/web/src/pages/settings/resource-editors.tsx
@@ -444,12 +444,15 @@ function RepoEditor({ state, save, onClose }: EditorProps) {
   const [name, setName] = useState(init?.name ?? "");
   const [url, setUrl] = useState(str(init?.payload, "url"));
   const [defaultBranch, setDefaultBranch] = useState(str(init?.payload, "defaultBranch"));
-  const [mode, setMode] = useState<DefaultMode>(asDefaultMode(init?.defaultEnabled ?? "available"));
 
+  // Repos are always a team-wide default for now: we don't offer per-repo
+  // Opt-in, so pin `defaultEnabled: "recommended"` instead of rendering the
+  // On-by-default / Opt-in selector the other resource types show. Editing a
+  // legacy Opt-in repo and saving normalizes it to recommended.
   const payload = (): CreateTeamResource => ({
     type: "repo",
     name: name.trim() || url.trim(),
-    defaultEnabled: mode,
+    defaultEnabled: "recommended",
     payload: { url: url.trim(), ...(defaultBranch.trim() ? { defaultBranch: defaultBranch.trim() } : {}) },
   });
 
@@ -474,7 +477,9 @@ function RepoEditor({ state, save, onClose }: EditorProps) {
         placeholder="main"
         mono
       />
-      <DefaultModeField value={mode} onChange={setMode} />
+      <p className="text-label" style={{ color: "var(--fg-3)", margin: 0 }}>
+        On by default — every agent gets this repo.
+      </p>
     </ModalEditor>
   );
 }


### PR DESCRIPTION
## What

Repos can no longer be configured as **Opt-in** anywhere in the UI — team repos are always On by default for now. Two surfaces:

**1. Settings → Resources (`RepoEditor`)**
- Drops the **On-by-default / Opt-in** selector and pins `defaultEnabled: "recommended"`.
- A short static line replaces it: *"On by default — every agent gets this repo."*
- Editing a legacy Opt-in repo and saving normalizes it to `recommended`.
- Other resource types (MCP / Instructions / Skills) keep their selector unchanged.

**2. Agent Detail → Capabilities (`resources-tab.tsx`)**
- Since repos can never be `available` now, the per-agent **"Enable from team"** list should never offer one. Repos are excluded from the enableable set.
- The repo "+" menu now shows only **"Add agent repo…"** + the **"Manage in Settings → Resources"** link — still actionable, no dead end.
- skill / mcp opt-in is unchanged.
- Regression test added: a legacy `available` repo is not offered to enable.

## Why

Per-repo Opt-in isn't offered yet — a temporary product decision, not a schema change. The server still accepts both `recommended` and `available`; this is frontend-only.

## Scope deliberately excluded

- No server/schema change.
- No DB migration to bulk-flip existing `available` repos (they normalize on next edit-save; legacy ones just keep their "Opt-in" badge in the Settings list until then).
- No Context Tree write — `system/cloud/agents/resources.md` still defines both modes as valid; this temporary UI restriction doesn't change the durable resource model.

## Verification

- `tsc --noEmit` ✓ + design-token guardrails ✓
- `resource-editors-dom.test.tsx` ✓, `resources-savebar-dom.test.tsx` ✓ (incl. new repo-exclusion test), `agent-detail-page-dom.test.tsx` ✓
- Biome clean ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)