### PR TITLE
refactor: simplify the team skill dialog fields

### DIFF
--- a/packages/web/src/pages/__tests__/resource-editors-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/resource-editors-dom.test.tsx
@@ -307,7 +307,7 @@ describe("resource editors", () => {
     await act(async () => root.unmount());
   });
 
-  it("creates a skill with body and metadata", async () => {
+  it("creates a skill with name + content, exposing no namespace/metadata inputs", async () => {
     const { root } = await render();
     await click(byAria("Add Skill"));
     await setInputValue(input("skill-name"), "rel");
@@ -317,13 +317,16 @@ describe("resource editors", () => {
       Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value")?.set?.call(body, "hello world");
       body.dispatchEvent(new InputEvent("input", { bubbles: true }));
     });
-    await click(byText("Add")); // metadata row
-    await setInputValue(lastByPlaceholder("key"), "team");
-    await setInputValue(lastByPlaceholder("value"), "core");
+    // Namespace + metadata were removed (schema-leaking, no guidance); the body
+    // field is now labelled "Content".
+    expect(document.getElementById("skill-namespace")).toBeNull();
+    expect(document.body.textContent).toContain("Content");
+    expect(document.body.textContent).not.toContain("Metadata");
     await click(byText("Create"));
 
     const payload = resourceMocks.createTeamResource.mock.calls[0]?.[0]?.payload;
-    expect(payload).toEqual(expect.objectContaining({ name: "rel", body: "hello world", metadata: { team: "core" } }));
+    expect(payload).toEqual(expect.objectContaining({ name: "rel", body: "hello world", metadata: {} }));
+    expect("namespace" in payload).toBe(false);
     await act(async () => root.unmount());
   });
 

--- a/packages/web/src/pages/settings/resource-editors.tsx
+++ b/packages/web/src/pages/settings/resource-editors.tsx
@@ -89,9 +89,9 @@ function record(payload: unknown, key: string): [string, string][] {
   }
   return [];
 }
-// Entries whose value is NOT a string — the string-only KeyValueField can't
-// display these, so we preserve them untouched across an edit instead of
-// dropping them (skill `metadata` is z.record(string, unknown)).
+// Non-string entries of a record payload. Skill `metadata` is
+// z.record(string, unknown) and is no longer user-editable; this preserves any
+// non-string values an imported skill carried so an edit doesn't drop them.
 function nonStringRecord(payload: unknown, key: string): Record<string, unknown> {
   const out: Record<string, unknown> = {};
   if (payload && typeof payload === "object" && key in payload) {
@@ -329,56 +329,6 @@ function StringListField({
         ))}
         <div>
           <Button type="button" variant="outline" size="xs" onClick={() => onChange([...values, ""])}>
-            <Plus className="h-3.5 w-3.5" /> Add
-          </Button>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-/** Repeatable key/value rows (MCP headers, skill metadata). */
-function KeyValueField({
-  label,
-  pairs,
-  onChange,
-}: {
-  label: string;
-  pairs: [string, string][];
-  onChange: (next: [string, string][]) => void;
-}) {
-  return (
-    <div className="space-y-2">
-      <Label>{label}</Label>
-      <div className="flex flex-col" style={{ gap: "var(--sp-2)" }}>
-        {pairs.map(([k, v], i) => (
-          // biome-ignore lint/suspicious/noArrayIndexKey: positional rows, no stable id
-          <div key={i} className="flex items-center" style={{ gap: "var(--sp-2)" }}>
-            <Input
-              value={k}
-              className="mono"
-              placeholder="key"
-              onChange={(e) => onChange(pairs.map((p, j) => (j === i ? [e.target.value, p[1]] : p)))}
-            />
-            <Input
-              value={v}
-              className="mono"
-              placeholder="value"
-              onChange={(e) => onChange(pairs.map((p, j) => (j === i ? [p[0], e.target.value] : p)))}
-            />
-            <Button
-              type="button"
-              variant="ghost"
-              size="xs"
-              aria-label={`Remove ${label} row`}
-              onClick={() => onChange(pairs.filter((_, j) => j !== i))}
-            >
-              <Trash2 className="h-4 w-4" />
-            </Button>
-          </div>
-        ))}
-        <div>
-          <Button type="button" variant="outline" size="xs" onClick={() => onChange([...pairs, ["", ""]])}>
             <Plus className="h-3.5 w-3.5" /> Add
           </Button>
         </div>
@@ -676,14 +626,19 @@ function SkillEditor({ state, save, onClose }: EditorProps) {
   // Editable field is the skill id (`payload.name`); prefill from it so an edit
   // round-trips the real skill name, not a divergent display name.
   const [name, setName] = useState(str(init?.payload, "name") || init?.name || "");
-  const [namespace, setNamespace] = useState(str(init?.payload, "namespace"));
   const [description, setDescription] = useState(str(init?.payload, "description"));
   const [body, setBody] = useState(str(init?.payload, "body"));
-  const [metadata, setMetadata] = useState<[string, string][]>(record(init?.payload, "metadata"));
   const [mode, setMode] = useState<DefaultMode>(asDefaultMode(init?.defaultEnabled ?? "available"));
-  // Non-string metadata values aren't editable in the key/value UI; keep them
-  // so an edit doesn't silently drop them.
-  const preservedMeta = nonStringRecord(init?.payload, "metadata");
+  // Namespace and metadata are no longer editable here: they leaked the storage
+  // schema into a form a human authoring a team skill has no use for (namespace
+  // is a plugin-origin concept; metadata is a free-form bag with zero guidance).
+  // Still round-trip whatever an imported SKILL.md carried so editing a skill
+  // never silently drops those values.
+  const preservedNamespace = str(init?.payload, "namespace");
+  const preservedMeta = {
+    ...nonStringRecord(init?.payload, "metadata"),
+    ...pairsToRecord(record(init?.payload, "metadata")),
+  };
 
   const payload = (): CreateTeamResource => {
     const skillName = name.trim() || "skill";
@@ -694,10 +649,10 @@ function SkillEditor({ state, save, onClose }: EditorProps) {
       defaultEnabled: mode,
       payload: {
         name: skillName,
-        ...(namespace.trim() ? { namespace: namespace.trim() } : {}),
+        ...(preservedNamespace.trim() ? { namespace: preservedNamespace.trim() } : {}),
         description: description.trim() || skillName,
         body,
-        metadata: { ...preservedMeta, ...pairsToRecord(metadata) },
+        metadata: preservedMeta,
       },
     };
   };
@@ -706,31 +661,31 @@ function SkillEditor({ state, save, onClose }: EditorProps) {
     <ModalEditor state={state} save={save} onClose={onClose} payload={payload}>
       <Field id="skill-name" label="Name" value={name} onChange={setName} placeholder="release-notes" mono />
       <Field
-        id="skill-namespace"
-        label="Namespace"
-        hint="Optional."
-        value={namespace}
-        onChange={setNamespace}
-        placeholder="team"
-        mono
-      />
-      <Field
         id="skill-desc"
         label="Description"
         value={description}
         onChange={setDescription}
         placeholder="What this skill does"
       />
-      <BodyField id="skill-body" value={body} onChange={setBody} />
-      <KeyValueField label="Metadata" pairs={metadata} onChange={setMetadata} />
+      <BodyField id="skill-body" label="Content" value={body} onChange={setBody} />
       <DefaultModeField value={mode} onChange={setMode} />
     </ModalEditor>
   );
 }
 
-function BodyField({ id, value, onChange }: { id: string; value: string; onChange: (v: string) => void }) {
+function BodyField({
+  id,
+  value,
+  onChange,
+  label = "Body",
+}: {
+  id: string;
+  value: string;
+  onChange: (v: string) => void;
+  label?: string;
+}) {
   return (
-    <FieldShell id={id} label="Body">
+    <FieldShell id={id} label={label}>
       <Textarea
         id={id}
         value={value}

--- a/packages/web/src/pages/settings/resource-preview-dialog.tsx
+++ b/packages/web/src/pages/settings/resource-preview-dialog.tsx
@@ -156,7 +156,7 @@ function MetaFields({ resource }: { resource: ResourceRow }) {
   return (
     <>
       {resource.type === "skill" ? (
-        <Detail label="Skill id" mono>
+        <Detail label="Name" mono>
           {str(p, "name") || resource.name}
         </Detail>
       ) : null}
@@ -215,7 +215,7 @@ export function ResourcePreviewDialog({ resource, onClose }: { resource: Resourc
             style={{ borderTop: "var(--hairline) solid var(--border-faint)" }}
           >
             <p className="m-0 text-label" style={{ color: "var(--fg-3)" }}>
-              Body
+              {resource.type === "skill" ? "Content" : "Body"}
             </p>
             <BodyDetail body={body} />
           </div>


### PR DESCRIPTION
## What

Trims the **team skill** create/edit dialog (Settings → Resources, and the agent Capabilities add-flow) down to the fields a user authoring a skill actually needs, and keeps the read-only preview consistent with it.

Before: Name · **Namespace** · Description · **Body** · **Metadata** · Default
After:  Name · Description · **Content** · Default

## Why

- **Remove Namespace** — a plugin-origin concept (`<namespace>:<name>`). A human hand-writing a team skill has nothing meaningful to put there; the empty field just invites confusion.
- **Remove Metadata** — a free-form `key/value` bag (`z.record(string, unknown)`) with zero guidance. It only ever made sense as an import round-trip, never as a manual input. The careful `nonStringRecord`/preserve logic in the original code is itself the tell that it's a machine field, not a human one.
- **"Body" → "Content"** — "Body" is developer jargon (HTTP/email/request body). "Content" is plain. "Instructions" is already the prompt tab name, so it's off the table for skills.

Grounded in the context tree (`system/cloud/agents/resources.md`, `product/surfaces/team-and-agent-model.md`): user-facing surfaces use product language, not the system/schema model (the same reason `resources` is split into **Capabilities** / **Instructions** in the UI).

## Data safety

Both removed values are **still round-tripped untouched on edit** — an imported `SKILL.md` that carried a namespace or metadata never loses them when an admin edits the skill. They simply have no editable input anymore. The preview dialog still renders them conditionally if present.

## Scope: what changed and what deliberately didn't

| Surface | Change |
|---|---|
| Skill create/edit dialog (`resource-editors.tsx`) | remove Namespace + Metadata inputs, Body→Content, drop now-unused `KeyValueField` |
| Resource preview dialog (`resource-preview-dialog.tsx`) | Body→Content (skill), "Skill id"→"Name" to match the editor |
| Resource list / Capabilities tab | no change — show none of these fields |
| Slash-command popover | **deliberately untouched** — its `namespace` comes from a *different* schema (agent-reported plugin skills, `SkillDescriptor`), unrelated to the team-skill `payload.namespace` removed here |

## Test

- Updated the `resource-editors` DOM test to assert the form exposes no namespace/metadata inputs, shows "Content", and produces `metadata: {}` with no `namespace`.
- `pnpm biome check`, `pnpm --filter @first-tree/web typecheck`, and the affected vitest suites all green (21 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)