### PR TITLE
fix: recover inbox delivery on suspend

### DIFF
--- a/packages/client/src/__tests__/client-connection-websocket-coverage.test.ts
+++ b/packages/client/src/__tests__/client-connection-websocket-coverage.test.ts
@@ -390,6 +390,48 @@ describe("ClientConnection — WebSocket edge coverage", () => {
     await expect(ackPromise).resolves.toBeUndefined();
   });
 
+  it("sends inbox recovery requests and settles on accepted or rejected frames", async () => {
+    const connection = await makeConnection();
+    const internal = priv(connection);
+    const socket = await openRegisteredConnection(connection, { wsInboxAckConfirm: true });
+
+    const bindPromise = internal.sendBind("agent-1", "codex");
+    const bindFrame = parseSent(socket, socket.sent.length - 1);
+    socket.emitMessage({
+      type: "agent:bound",
+      ref: bindFrame.ref,
+      agentId: "agent-1",
+      displayName: "Agent One",
+      agentType: "agent",
+    });
+    await bindPromise;
+
+    const accepted = connection.sendInboxRecover("agent-1", "chat-1");
+    const recoverFrame = parseSent(socket, socket.sent.length - 1);
+    expect(recoverFrame).toMatchObject({ type: "inbox:recover", agentId: "agent-1", chatId: "chat-1" });
+    expect(typeof recoverFrame.ref).toBe("string");
+
+    socket.emitMessage({
+      type: "inbox:recover:accepted",
+      ref: recoverFrame.ref,
+      agentId: "agent-1",
+      chatId: "chat-1",
+      resetCount: 1,
+    });
+    await expect(accepted).resolves.toBeUndefined();
+
+    const rejected = connection.sendInboxRecover("agent-1", "chat-2");
+    const rejectFrame = parseSent(socket, socket.sent.length - 1);
+    socket.emitMessage({
+      type: "inbox:recover:rejected",
+      ref: rejectFrame.ref,
+      agentId: "agent-1",
+      chatId: "chat-2",
+      reason: "recover_failed",
+    });
+    await expect(rejected).rejects.toThrow("recover_failed");
+  });
+
   it("holds agent-scoped confirmed inbox ACKs until that agent is rebound on the current socket", async () => {
     const connection = await makeConnection();
     const internal = priv(connection);

--- a/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
+++ b/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
@@ -132,6 +132,7 @@ function makeManager(
     handlers?: AgentHandler[];
     handlerFactory?: HandlerFactory;
     ackEntry?: (entryId: number) => Promise<void>;
+    recoverChat?: (chatId: string) => Promise<void>;
     registryPath?: string;
     concurrency?: number;
     maxSessions?: number;
@@ -172,6 +173,7 @@ function makeManager(
     registryPath: opts.registryPath,
     agentConfigCache: opts.agentConfigCache,
     ackEntry: opts.ackEntry ?? vi.fn<(entryId: number) => Promise<void>>().mockResolvedValue(undefined),
+    recoverChat: opts.recoverChat,
     onStateChange: opts.onStateChange,
     onRuntimeStateChange: opts.onRuntimeStateChange,
     onSessionRuntimeChange: opts.onSessionRuntimeChange,
@@ -252,15 +254,19 @@ describe("SessionManager edge coverage", () => {
       .mockResolvedValueOnce(undefined)
       .mockRejectedValueOnce(new Error("ack offline"))
       .mockResolvedValue(undefined);
+    const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
     const states: Array<{ chatId: string; state: SessionState }> = [];
     const sm = makeManager({
       handlers: [first, handler()],
       ackEntry,
+      recoverChat,
       concurrency: 1,
       onStateChange: (chatId, state) => states.push({ chatId, state }),
     });
 
-    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-active" }));
+    const firstEntry = mockEntry({ id: 1, chatId: "chat-active" });
+    await sm.dispatch(firstEntry);
+    await sm.dispatch(firstEntry);
     expect(sm.activeCount).toBe(1);
     expect(sm.getQuietGateSnapshot().activeCount).toBe(1);
     expect(sm.getQuietGateSnapshot().lastActivityMs).toBeGreaterThan(0);
@@ -268,9 +274,11 @@ describe("SessionManager edge coverage", () => {
     await sm.handleCommand("missing", "session:terminate");
     await sm.handleCommand("chat-active", "session:suspend");
     await sm.dispatch(mockEntry({ id: 2, chatId: "chat-active" }));
-    // Ack-through fail-closed: suspending abandons unfinished delivered
-    // entries and blocks same-chat delivery until bind reset/redelivery.
+    // Same-socket recovery fail-closed: suspending clears unfinished local
+    // entries and newer same-chat input asks the server to reset/redeliver
+    // before the handler resumes.
     expect(internals(sm).inFlightEntries.has("chat-active")).toBe(false);
+    expect(recoverChat).toHaveBeenCalledTimes(2);
     expect(ackEntry).not.toHaveBeenCalledWith(2);
 
     internals(sm).pendingQueue.push({ chatId: "chat-queued", message: makeMessage("chat-queued") });

--- a/packages/client/src/__tests__/session-manager.test.ts
+++ b/packages/client/src/__tests__/session-manager.test.ts
@@ -55,6 +55,7 @@ function createSessionManager(opts: {
   concurrency?: number;
   log?: pino.Logger;
   agentConfigCache?: AgentConfigCache;
+  recoverChat?: (chatId: string) => Promise<void>;
 }) {
   const handler = opts.handler ?? createMockHandler();
   const factory: HandlerFactory = () => handler;
@@ -82,6 +83,7 @@ function createSessionManager(opts: {
     sdk,
     log: opts.log ?? silentLogger(),
     ackEntry: opts.ackEntry ?? mockAckEntry(),
+    recoverChat: opts.recoverChat,
     agentConfigCache: opts.agentConfigCache,
   });
 }
@@ -254,34 +256,38 @@ describe("SessionManager", () => {
     const startSpy = vi.fn(async (_msg: unknown, _ctx: SessionContext) => "session-id-mock");
     const resumeSpy = vi.fn(async (_msg: unknown, _sid: string, _ctx: SessionContext) => "session-id-mock");
     const handler = createMockHandler({ start: startSpy, resume: resumeSpy });
+    const recoverChat = vi.fn().mockResolvedValue(undefined);
     const sm = createSessionManager({
       ackEntry,
       handler,
       session: { idle_timeout: 300, max_sessions: 2, working_grace_seconds: 3600, reconcile_interval_seconds: 300 },
+      recoverChat,
     });
 
     // Fill the session pool: chat-a then chat-b. chat-a becomes LRU.
-    await sm.dispatch(mockEntry({ id: 70, chatId: "chat-a", messageId: "msg-a" }));
-    await sm.dispatch(mockEntry({ id: 71, chatId: "chat-b", messageId: "msg-b" }));
+    const chatA = mockEntry({ id: 70, chatId: "chat-a", messageId: "msg-a" });
+    const chatB = mockEntry({ id: 71, chatId: "chat-b", messageId: "msg-b" });
+    await sm.dispatch(chatA);
+    await sm.dispatch(chatA);
+    await sm.dispatch(chatB);
+    await sm.dispatch(chatB);
     expect(startSpy).toHaveBeenCalledTimes(2);
 
     // chat-c trips evictIfNeeded — sessions.size (2) >= max_sessions (2),
     // chat-a is the LRU candidate and gets evicted (chat-a:msg-a should
     // come out of the dedup set as part of eviction).
-    await sm.dispatch(mockEntry({ id: 72, chatId: "chat-c", messageId: "msg-c" }));
+    const chatC = mockEntry({ id: 72, chatId: "chat-c", messageId: "msg-c" });
+    await sm.dispatch(chatC);
+    await sm.dispatch(chatC);
     expect(startSpy).toHaveBeenCalledTimes(3);
     // Nothing has been acked yet — none of the mock handlers call markCompleted.
     expect(ackEntry).not.toHaveBeenCalled();
 
-    // Simulate server-side bind-reset redelivery of the SAME entry for
-    // the LRU-evicted chat. The bind event clears the local recovery guard;
-    // if the dedup key were still around this
-    // would dedup-hit and (post-#1-fix) get re-acked, shortcutting
-    // recovery. With the dedup key dropped at eviction time, the entry
-    // routes normally through startNewSession → handler.resume against
-    // the saved evictedMappings.
-    sm.noteBindRecoveryComplete();
-    await sm.dispatch(mockEntry({ id: 70, chatId: "chat-a", messageId: "msg-a" }));
+    // Simulate chat-scoped recovery and redelivery of the SAME entry for
+    // the LRU-evicted chat. The first dispatch asks the server to recover;
+    // the second represents the redelivered frame.
+    await sm.dispatch(chatA);
+    await sm.dispatch(chatA);
 
     // Recovery path: handler.resume invoked once for chat-a (it was
     // evicted, so the new dispatch resumes from evictedMappings).
@@ -498,27 +504,35 @@ describe("SessionManager", () => {
       sdk,
       log: silentLogger(),
       ackEntry: mockAckEntry(),
+      recoverChat: vi.fn().mockResolvedValue(undefined),
     });
 
     // Fill up max_sessions
-    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-1" }));
-    await sm.dispatch(mockEntry({ id: 2, chatId: "chat-2" }));
+    const chat1 = mockEntry({ id: 1, chatId: "chat-1" });
+    const chat2 = mockEntry({ id: 2, chatId: "chat-2" });
+    const chat3 = mockEntry({ id: 3, chatId: "chat-3" });
+    const chat4 = mockEntry({ id: 4, chatId: "chat-4" });
+    const chat1Return = mockEntry({ id: 5, chatId: "chat-1" });
+    await sm.dispatch(chat1);
+    await sm.dispatch(chat1);
+    await sm.dispatch(chat2);
+    await sm.dispatch(chat2);
     expect(sm.totalCount).toBe(2);
 
     // Third chat evicts chat-1 (LRU)
-    await sm.dispatch(mockEntry({ id: 3, chatId: "chat-3" }));
+    await sm.dispatch(chat3);
+    await sm.dispatch(chat3);
     expect(sm.totalCount).toBe(2);
 
     // Fourth chat evicts chat-2
-    await sm.dispatch(mockEntry({ id: 4, chatId: "chat-4" }));
+    await sm.dispatch(chat4);
+    await sm.dispatch(chat4);
     expect(sm.totalCount).toBe(2);
 
-    // Simulate the next agent:bind reset before redelivery into an evicted
-    // chat. Until that happens the runtime blocks the chat to avoid
-    // ack-through committing abandoned delivered entries.
-    sm.noteBindRecoveryComplete();
-    // Now send a message to evicted chat-1 — should resume, not start
-    await sm.dispatch(mockEntry({ id: 5, chatId: "chat-1" }));
+    // Send a message to evicted chat-1: first dispatch triggers recovery,
+    // second dispatch represents redelivery and should resume, not start.
+    await sm.dispatch(chat1Return);
+    await sm.dispatch(chat1Return);
 
     const chat1Events = lifecycleCalls.filter((e) => e.chatId === "chat-1");
     expect(chat1Events).toHaveLength(2);
@@ -630,7 +644,11 @@ describe("SessionManager dispatch integration", () => {
  * contract for each entry-point dispatch can hit.
  */
 describe("SessionManager ackEntry callback (deferred ack)", () => {
-  function buildSm(ackEntry: (entryId: number) => Promise<void>, handler?: AgentHandler) {
+  function buildSm(
+    ackEntry: (entryId: number) => Promise<void>,
+    handler?: AgentHandler,
+    recoverChat?: (chatId: string) => Promise<void>,
+  ) {
     const h = handler ?? createMockHandler();
     const sdk = mockSdk();
     const sm = new SessionManager({
@@ -650,6 +668,7 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
       sdk,
       log: silentLogger(),
       ackEntry,
+      recoverChat,
     });
     return { sm, handler: h };
   }
@@ -833,8 +852,9 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     await sm.shutdown();
   });
 
-  it("fails closed when routeMessage fails after an entry was marked admitted", async () => {
+  it("clears local tracking when routeMessage fails and lets later input trigger chat recovery", async () => {
     const ackEntry = vi.fn().mockResolvedValue(undefined);
+    const recoverChat = vi.fn().mockResolvedValue(undefined);
     const recoveryStart = vi.fn(async () => "session-id-recovery");
     let factoryCalls = 0;
     const factory = vi.fn<HandlerFactory>(() => {
@@ -859,41 +879,99 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
       sdk: mockSdk(),
       log: silentLogger(),
       ackEntry,
+      recoverChat,
     });
 
-    await expect(sm.dispatch(mockEntry({ id: 1, chatId: "chat-route-fail", messageId: "msg-a1" }))).rejects.toThrow(
-      "handler factory offline",
-    );
+    const first = mockEntry({ id: 1, chatId: "chat-route-fail", messageId: "msg-a1" });
+    await sm.dispatch(first);
+    expect(recoverChat).toHaveBeenCalledTimes(1);
+    expect(factory).not.toHaveBeenCalled();
+
+    await expect(sm.dispatch(first)).rejects.toThrow("handler factory offline");
+    expect(factory).toHaveBeenCalledTimes(1);
 
     await sm.dispatch(mockEntry({ id: 2, chatId: "chat-route-fail", messageId: "msg-a2" }));
-    expect(factory).toHaveBeenCalledTimes(1);
+    expect(recoverChat).toHaveBeenCalledTimes(2);
     expect(recoveryStart).not.toHaveBeenCalled();
     expect(ackEntry).not.toHaveBeenCalled();
 
     await sm.shutdown();
   });
 
-  it("suspend abandons unfinished in-flight entries and blocks newer same-chat delivery until bind recovery", async () => {
+  it("suspend acks consumed entries and lets newer same-chat input trigger recovery before resume", async () => {
     const ackEntry = vi.fn().mockResolvedValue(undefined);
+    const recoverChat = vi.fn().mockResolvedValue(undefined);
     let capturedCtx: SessionContext | undefined;
+    let firstMessage: Parameters<AgentHandler["start"]>[0] | undefined;
     const resumeSpy = vi.fn(async () => "session-id-mock");
+    const startSpy = vi.fn(async (m: Parameters<AgentHandler["start"]>[0], ctx: SessionContext) => {
+      firstMessage = m;
+      capturedCtx = ctx;
+      return "session-id-mock";
+    });
     const handler = createMockHandler({
-      async start(_m, ctx) {
+      start: startSpy,
+      resume: resumeSpy,
+    });
+    const { sm } = buildSm(ackEntry, handler, recoverChat);
+
+    const first = mockEntry({ id: 30, chatId: "chat-suspend", messageId: "msg-a1" });
+    await sm.dispatch(first);
+    expect(recoverChat).toHaveBeenCalledTimes(1);
+    await sm.dispatch(first);
+    expect(startSpy).toHaveBeenCalledTimes(1);
+
+    if (firstMessage) capturedCtx?.markMessagesConsumed(firstMessage);
+    await sm.handleCommand("chat-suspend", "session:suspend");
+    await Promise.resolve();
+    expect(ackEntry).toHaveBeenCalledTimes(1);
+    expect(ackEntry).toHaveBeenCalledWith(30);
+
+    await sm.dispatch(mockEntry({ id: 31, chatId: "chat-suspend", messageId: "msg-a2" }));
+    expect(recoverChat).toHaveBeenCalledTimes(2);
+    expect(resumeSpy).not.toHaveBeenCalled();
+
+    await sm.dispatch(mockEntry({ id: 31, chatId: "chat-suspend", messageId: "msg-a2" }));
+    expect(resumeSpy).toHaveBeenCalledTimes(1);
+    expect(ackEntry).toHaveBeenCalledTimes(1);
+
+    await sm.shutdown();
+  });
+
+  it("suspend leaves injected but not consumed entries unacked for recovery", async () => {
+    const ackEntry = vi.fn().mockResolvedValue(undefined);
+    const recoverChat = vi.fn().mockResolvedValue(undefined);
+    let capturedCtx: SessionContext | undefined;
+    let firstMessage: Parameters<AgentHandler["start"]>[0] | undefined;
+    const injected: Parameters<AgentHandler["inject"]>[0][] = [];
+    const handler = createMockHandler({
+      async start(m, ctx) {
+        firstMessage = m;
         capturedCtx = ctx;
         return "session-id-mock";
       },
-      resume: resumeSpy,
+      inject: vi.fn((m) => {
+        injected.push(m);
+      }),
     });
-    const { sm } = buildSm(ackEntry, handler);
+    const { sm } = buildSm(ackEntry, handler, recoverChat);
 
-    await sm.dispatch(mockEntry({ id: 30, chatId: "chat-suspend", messageId: "msg-a1" }));
-    await sm.handleCommand("chat-suspend", "session:suspend");
-    await sm.dispatch(mockEntry({ id: 31, chatId: "chat-suspend", messageId: "msg-a2" }));
+    const first = mockEntry({ id: 32, chatId: "chat-suspend-queue", messageId: "msg-q1" });
+    await sm.dispatch(first);
+    await sm.dispatch(first);
+    if (firstMessage) capturedCtx?.markMessagesConsumed(firstMessage);
 
-    capturedCtx?.markCompleted();
+    await sm.dispatch(mockEntry({ id: 33, chatId: "chat-suspend-queue", messageId: "msg-q2" }));
+    expect(injected).toHaveLength(1);
+
+    await sm.handleCommand("chat-suspend-queue", "session:suspend");
     await Promise.resolve();
-    expect(resumeSpy).not.toHaveBeenCalled();
-    expect(ackEntry).not.toHaveBeenCalled();
+    expect(ackEntry).toHaveBeenCalledTimes(1);
+    expect(ackEntry).toHaveBeenCalledWith(32);
+
+    await sm.dispatch(mockEntry({ id: 34, chatId: "chat-suspend-queue", messageId: "msg-q3" }));
+    expect(recoverChat).toHaveBeenCalledTimes(2);
+    expect(ackEntry).toHaveBeenCalledTimes(1);
 
     await sm.shutdown();
   });
@@ -927,10 +1005,69 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     await sm.shutdown();
   });
 
+  it("retryable no-ack while active requires chat recovery before newer input reaches the handler", async () => {
+    const ackEntry = vi.fn().mockResolvedValue(undefined);
+    const recoverChat = vi.fn().mockResolvedValue(undefined);
+    let capturedCtx: SessionContext | undefined;
+    let firstMessage: Parameters<AgentHandler["start"]>[0] | undefined;
+    const injectSpy = vi.fn();
+    const startSpy = vi.fn(async (m: Parameters<AgentHandler["start"]>[0], ctx: SessionContext) => {
+      firstMessage = m;
+      capturedCtx = ctx;
+      return "session-id-mock";
+    });
+    const handler = createMockHandler({
+      start: startSpy,
+      inject: injectSpy,
+    });
+    const { sm } = buildSm(ackEntry, handler, recoverChat);
+
+    const first = mockEntry({ id: 42, chatId: "chat-retryable-recover", messageId: "msg-r1" });
+    await sm.dispatch(first);
+    await sm.dispatch(first);
+    expect(recoverChat).toHaveBeenCalledTimes(1);
+    expect(startSpy).toHaveBeenCalledTimes(1);
+
+    if (firstMessage) capturedCtx?.markMessagesRetryable(firstMessage, "turn_timeout");
+
+    await sm.dispatch(mockEntry({ id: 43, chatId: "chat-retryable-recover", messageId: "msg-r2" }));
+    expect(recoverChat).toHaveBeenCalledTimes(2);
+    expect(injectSpy).not.toHaveBeenCalled();
+    expect(ackEntry).not.toHaveBeenCalled();
+
+    await sm.shutdown();
+  });
+
+  it("fails closed when recovery is required but recoverChat is not configured", async () => {
+    const ackEntry = vi.fn().mockResolvedValue(undefined);
+    let capturedCtx: SessionContext | undefined;
+    let firstMessage: Parameters<AgentHandler["start"]>[0] | undefined;
+    const injectSpy = vi.fn();
+    const handler = createMockHandler({
+      async start(m, ctx) {
+        firstMessage = m;
+        capturedCtx = ctx;
+        return "session-id-mock";
+      },
+      inject: injectSpy,
+    });
+    const { sm } = buildSm(ackEntry, handler);
+
+    await sm.dispatch(mockEntry({ id: 44, chatId: "chat-retryable-no-recover", messageId: "msg-nr1" }));
+    if (firstMessage) capturedCtx?.markMessagesRetryable(firstMessage, "turn_timeout");
+
+    await sm.dispatch(mockEntry({ id: 45, chatId: "chat-retryable-no-recover", messageId: "msg-nr2" }));
+    expect(injectSpy).not.toHaveBeenCalled();
+    expect(ackEntry).not.toHaveBeenCalled();
+
+    await sm.shutdown();
+  });
+
   it("ack waits for markCompleted when resuming an evicted session", async () => {
     // Seed an evicted session by exceeding concurrency=1, then dispatch into
     // the evicted chat to trigger the resume branch.
     const ackEntry = vi.fn().mockResolvedValue(undefined);
+    const recoverChat = vi.fn().mockResolvedValue(undefined);
     const capturedCtxs: SessionContext[] = [];
     const handler = createMockHandler({
       async start(_m, ctx) {
@@ -960,11 +1097,16 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
       sdk,
       log: silentLogger(),
       ackEntry,
+      recoverChat,
     });
 
     // Start chat-a, then chat-b which evicts chat-a (max_sessions=1).
-    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
-    await sm.dispatch(mockEntry({ id: 2, chatId: "chat-b" }));
+    const chatA = mockEntry({ id: 1, chatId: "chat-a" });
+    const chatB = mockEntry({ id: 2, chatId: "chat-b" });
+    await sm.dispatch(chatA);
+    await sm.dispatch(chatA);
+    await sm.dispatch(chatB);
+    await sm.dispatch(chatB);
     // Close chat-a and chat-b's start turns so their entries don't pollute
     // the resume-branch ack assertion.
     capturedCtxs[0]?.markCompleted();
@@ -972,9 +1114,11 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     await Promise.resolve();
     ackEntry.mockClear();
 
-    // Dispatching back into chat-a after bind reset hits the resume branch.
-    sm.noteBindRecoveryComplete();
-    await sm.dispatch(mockEntry({ id: 3, chatId: "chat-a", messageId: "msg-resume" }));
+    // Dispatching back into chat-a first triggers chat-scoped recovery; the
+    // redelivered frame then hits the resume branch.
+    const chatAResume = mockEntry({ id: 3, chatId: "chat-a", messageId: "msg-resume" });
+    await sm.dispatch(chatAResume);
+    await sm.dispatch(chatAResume);
     expect(ackEntry).not.toHaveBeenCalled();
 
     capturedCtxs[2]?.markCompleted();

--- a/packages/client/src/__tests__/session-start-error-signaling.test.ts
+++ b/packages/client/src/__tests__/session-start-error-signaling.test.ts
@@ -259,6 +259,7 @@ describe("SessionManager: session-resume failure signalling (F2, resume path)", 
     onStateChange?: (chatId: string, state: SessionState) => void;
     onSessionEvent?: (chatId: string, event: SessionEvent) => void;
     sdk?: FirstTreeHubSDK;
+    recoverChat?: (chatId: string) => Promise<void>;
   }) {
     const queue = [...opts.handlerQueue];
     return new SessionManager({
@@ -280,6 +281,7 @@ describe("SessionManager: session-resume failure signalling (F2, resume path)", 
       ackEntry: vi.fn<(entryId: number) => Promise<void>>().mockResolvedValue(undefined),
       onStateChange: opts.onStateChange,
       onSessionEvent: opts.onSessionEvent,
+      recoverChat: opts.recoverChat,
     });
   }
 
@@ -289,6 +291,7 @@ describe("SessionManager: session-resume failure signalling (F2, resume path)", 
     const stateChanges: Array<{ chatId: string; state: SessionState }> = [];
     const events: Array<{ chatId: string; event: SessionEvent }> = [];
     const { sdk, sendMessage } = mockSdk();
+    const recoverChat = vi.fn().mockResolvedValue(undefined);
     const handlerA: AgentHandler = {
       start: vi.fn().mockResolvedValue("session-A"),
       resume: vi.fn().mockRejectedValue(new FakeClientUserMismatchError("git mirror fetch failed: connection refused")),
@@ -301,12 +304,18 @@ describe("SessionManager: session-resume failure signalling (F2, resume path)", 
       sdk,
       onStateChange: (chatId, state) => stateChanges.push({ chatId, state }),
       onSessionEvent: (chatId, event) => events.push({ chatId, event }),
+      recoverChat,
     });
 
-    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-A" })); // start succeeds
-    await sm.dispatch(mockEntry({ id: 2, chatId: "chat-B" })); // preempts chat-A
-    sm.noteBindRecoveryComplete(); // bind reset completed; redelivery may resume chat-A
-    await sm.dispatch(mockEntry({ id: 3, chatId: "chat-A" })); // resume → throws
+    const chatAStart = mockEntry({ id: 1, chatId: "chat-A" });
+    const chatBStart = mockEntry({ id: 2, chatId: "chat-B" });
+    const chatAResume = mockEntry({ id: 3, chatId: "chat-A" });
+    await sm.dispatch(chatAStart); // asks for recovery
+    await sm.dispatch(chatAStart); // redelivery starts chat-A
+    await sm.dispatch(chatBStart); // asks for recovery
+    await sm.dispatch(chatBStart); // redelivery starts chat-B and preempts chat-A
+    await sm.dispatch(chatAResume); // asks for recovery of chat-A's unacked tail
+    await sm.dispatch(chatAResume); // redelivery resumes chat-A → throws
 
     const chatAStates = stateChanges.filter((c) => c.chatId === "chat-A").map((c) => c.state);
     expect(chatAStates.at(-1)).toBe("errored");
@@ -336,6 +345,7 @@ describe("SessionManager: session-resume failure signalling (F2, resume path)", 
 
   it("allows the next inbound message for the same chat to start a fresh session after a resume failure", async () => {
     const stateChanges: Array<{ chatId: string; state: SessionState }> = [];
+    const recoverChat = vi.fn().mockResolvedValue(undefined);
     const handlerA: AgentHandler = {
       start: vi.fn().mockResolvedValue("session-A"),
       resume: vi.fn().mockRejectedValue(new FakeClientUserMismatchError("resume blew up")),
@@ -347,17 +357,25 @@ describe("SessionManager: session-resume failure signalling (F2, resume path)", 
     const sm = makeSerializedManager({
       handlerQueue: [handlerA, workingHandler("session-B"), handlerARecovery],
       onStateChange: (chatId, state) => stateChanges.push({ chatId, state }),
+      recoverChat,
     });
 
-    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-A" }));
-    await sm.dispatch(mockEntry({ id: 2, chatId: "chat-B" }));
-    sm.noteBindRecoveryComplete(); // bind reset completed; redelivery may resume chat-A
-    await sm.dispatch(mockEntry({ id: 3, chatId: "chat-A" })); // resume → errored
+    const chatAStart = mockEntry({ id: 1, chatId: "chat-A" });
+    const chatBStart = mockEntry({ id: 2, chatId: "chat-B" });
+    const chatAResume = mockEntry({ id: 3, chatId: "chat-A" });
+    const chatARecovery = mockEntry({ id: 4, chatId: "chat-A" });
+    await sm.dispatch(chatAStart);
+    await sm.dispatch(chatAStart);
+    await sm.dispatch(chatBStart);
+    await sm.dispatch(chatBStart);
+    await sm.dispatch(chatAResume);
+    await sm.dispatch(chatAResume); // resume → errored
 
     // A fresh inbound for chat-A should route as start (entry was dropped
     // on resume failure — the resume catch tears down the same way the
     // start catch does, so there's no "stuck suspended" entry blocking it).
-    await sm.dispatch(mockEntry({ id: 4, chatId: "chat-A" }));
+    await sm.dispatch(chatARecovery);
+    await sm.dispatch(chatARecovery);
     expect(handlerARecovery.start).toHaveBeenCalledTimes(1);
     expect(stateChanges.filter((c) => c.chatId === "chat-A").at(-1)?.state).toBe("active");
 

--- a/packages/client/src/__tests__/session-state-notifications.test.ts
+++ b/packages/client/src/__tests__/session-state-notifications.test.ts
@@ -45,6 +45,7 @@ function createSessionManager(opts: {
   log?: pino.Logger;
   onStateChange?: (chatId: string, state: SessionState) => void;
   onSessionRuntimeChange?: (chatId: string, state: RuntimeState) => void;
+  recoverChat?: (chatId: string) => Promise<void>;
 }) {
   const handler = opts.handler ?? createMockHandler();
   const factory: HandlerFactory = opts.handlerFactory ?? (() => handler);
@@ -74,6 +75,7 @@ function createSessionManager(opts: {
     ackEntry: vi.fn<(entryId: number) => Promise<void>>().mockResolvedValue(undefined),
     onStateChange: opts.onStateChange,
     onSessionRuntimeChange: opts.onSessionRuntimeChange,
+    recoverChat: opts.recoverChat,
   });
 }
 
@@ -146,17 +148,25 @@ describe("SessionManager: state notifications", () => {
 
   it("fires onStateChange('active') on resume after suspension", async () => {
     const stateChanges: Array<{ chatId: string; state: SessionState }> = [];
+    const recoverChat = vi.fn().mockResolvedValue(undefined);
     const sm = createSessionManager({
       concurrency: 1,
       onStateChange: (chatId, state) => stateChanges.push({ chatId, state }),
+      recoverChat,
     });
 
     // chat-a starts (active), chat-b preempts chat-a (suspended → active)
-    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
-    await sm.dispatch(mockEntry({ id: 2, chatId: "chat-b" }));
-    // After bind reset, chat-a may resume and preempt chat-b.
-    sm.noteBindRecoveryComplete();
-    await sm.dispatch(mockEntry({ id: 3, chatId: "chat-a" }));
+    const chatA = mockEntry({ id: 1, chatId: "chat-a" });
+    const chatB = mockEntry({ id: 2, chatId: "chat-b" });
+    const chatAResume = mockEntry({ id: 3, chatId: "chat-a" });
+    await sm.dispatch(chatA);
+    await sm.dispatch(chatA);
+    await sm.dispatch(chatB);
+    await sm.dispatch(chatB);
+    // Resume now goes through chat-scoped recovery first; the second dispatch
+    // represents the redelivered frame that can enter the resume branch.
+    await sm.dispatch(chatAResume);
+    await sm.dispatch(chatAResume);
 
     const chatAChanges = stateChanges.filter((c) => c.chatId === "chat-a");
     expect(chatAChanges).toEqual([

--- a/packages/client/src/__tests__/test-helpers.ts
+++ b/packages/client/src/__tests__/test-helpers.ts
@@ -23,6 +23,7 @@ export function mockCtxPlumbing(
 ): {
   forwardResult: (text: string) => Promise<void>;
   markCompleted: () => void;
+  markMessagesConsumed: (messages: SessionMessage | readonly SessionMessage[]) => void;
   markMessagesCompleted: (messages: SessionMessage | readonly SessionMessage[]) => void;
   markMessagesRetryable: (messages: SessionMessage | readonly SessionMessage[], reason: string) => void;
   buildAgentEnv: (env: NodeJS.ProcessEnv) => NodeJS.ProcessEnv;
@@ -35,6 +36,7 @@ export function mockCtxPlumbing(
     },
     // Default stub: tests that care about ack timing override via spies.
     markCompleted: () => {},
+    markMessagesConsumed: () => {},
     markMessagesCompleted: () => {},
     markMessagesRetryable: () => {},
     buildAgentEnv: (env) => env,

--- a/packages/client/src/client-connection.ts
+++ b/packages/client/src/client-connection.ts
@@ -10,6 +10,8 @@ import {
   inboxAckAcceptedFrameSchema,
   inboxAckRejectedFrameSchema,
   inboxDeliverFrameSchema,
+  inboxRecoverAcceptedFrameSchema,
+  inboxRecoverRejectedFrameSchema,
   type RuntimeState,
   type ServerWelcomeFrame,
   type SessionEvent,
@@ -39,6 +41,17 @@ type PendingInboxAck = {
   agentId?: string;
   ref: string;
   attempts: number;
+  firstSentAt: number;
+  timer: ReturnType<typeof setTimeout> | null;
+  promise: Promise<void>;
+  resolve: () => void;
+  reject: (err: Error) => void;
+};
+
+type PendingInboxRecover = {
+  agentId: string;
+  chatId: string;
+  ref: string;
   firstSentAt: number;
   timer: ReturnType<typeof setTimeout> | null;
   promise: Promise<void>;
@@ -234,6 +247,7 @@ const RECONNECT_MAX_MS = 30_000;
 const WS_CONNECT_TIMEOUT_MS = 10_000;
 const HEARTBEAT_INTERVAL_MS = 30_000;
 const INBOX_ACK_CONFIRM_TIMEOUT_MS = 3_000;
+const INBOX_RECOVER_CONFIRM_TIMEOUT_MS = 3_000;
 /**
  * Silence watchdog: if no server frame (data message OR control-frame pong)
  * arrives within this many ms, the socket is presumed dead and terminated so
@@ -421,6 +435,7 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
    */
   private readonly bindRetryRecords = new Map<string, BindRetryRecord>();
   private readonly pendingInboxAcks = new Map<number, PendingInboxAck>();
+  private readonly pendingInboxRecovers = new Map<string, PendingInboxRecover>();
   private readonly socketBoundAgentIds = new Set<string>();
 
   constructor(config: ClientConnectionConfig) {
@@ -500,6 +515,54 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
     const pending = this.createPendingInboxAck(entryId, agentId);
     this.pendingInboxAcks.set(entryId, pending);
     this.sendPendingInboxAck(pending, false);
+    return pending.promise;
+  }
+
+  /**
+   * Ask the server to reset delivered-but-unacked entries for one chat and
+   * redeliver them on this socket. Unlike ACKs, recovery is bounded: callers
+   * must get an accepted/rejected/timeout outcome instead of waiting forever
+   * behind a per-chat recovery gate.
+   */
+  sendInboxRecover(agentId: string, chatId: string): Promise<void> {
+    if (
+      !this.ws ||
+      this.ws.readyState !== WebSocket.OPEN ||
+      !this.registered ||
+      !this.socketBoundAgentIds.has(agentId)
+    ) {
+      return Promise.reject(new Error("inbox:recover unavailable; socket not bound"));
+    }
+
+    const pending: PendingInboxRecover = {
+      agentId,
+      chatId,
+      ref: `recover_${randomUUID().slice(0, 12)}`,
+      firstSentAt: Date.now(),
+      timer: null,
+      promise: Promise.resolve(),
+      resolve: () => {},
+      reject: () => {},
+    };
+    pending.promise = new Promise<void>((resolve, reject) => {
+      pending.resolve = resolve;
+      pending.reject = reject;
+    });
+    this.pendingInboxRecovers.set(pending.ref, pending);
+    this.ws.send(JSON.stringify({ type: "inbox:recover", ref: pending.ref, agentId, chatId }));
+    this.wsLogger.debug(
+      {
+        agentId,
+        chatId,
+        ref: pending.ref,
+        recoverEvent: "inbox_recover_sent",
+      },
+      "inbox:recover sent",
+    );
+    pending.timer = setTimeout(() => {
+      if (!this.pendingInboxRecovers.has(pending.ref)) return;
+      this.rejectPendingInboxRecover(pending, "timeout");
+    }, INBOX_RECOVER_CONFIRM_TIMEOUT_MS);
     return pending.promise;
   }
 
@@ -657,6 +720,47 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
     }
   }
 
+  private resolvePendingInboxRecover(pending: PendingInboxRecover, resetCount: number): void {
+    this.clearPendingInboxRecoverTimer(pending);
+    this.pendingInboxRecovers.delete(pending.ref);
+    this.wsLogger.debug(
+      {
+        agentId: pending.agentId,
+        chatId: pending.chatId,
+        ref: pending.ref,
+        resetCount,
+        latencyMs: Date.now() - pending.firstSentAt,
+        recoverEvent: "inbox_recover_accepted",
+      },
+      "inbox:recover accepted",
+    );
+    pending.resolve();
+  }
+
+  private rejectPendingInboxRecover(pending: PendingInboxRecover, reason: string): void {
+    this.clearPendingInboxRecoverTimer(pending);
+    this.pendingInboxRecovers.delete(pending.ref);
+    this.wsLogger.warn(
+      {
+        agentId: pending.agentId,
+        chatId: pending.chatId,
+        ref: pending.ref,
+        reason,
+        latencyMs: Date.now() - pending.firstSentAt,
+        recoverEvent: "inbox_recover_rejected",
+      },
+      "inbox:recover rejected",
+    );
+    pending.reject(new Error(`inbox:recover rejected (${reason})`));
+  }
+
+  private clearPendingInboxRecoverTimer(pending: PendingInboxRecover): void {
+    if (pending.timer) {
+      clearTimeout(pending.timer);
+      pending.timer = null;
+    }
+  }
+
   private inboxAckConnectionState(): string {
     if (!this.ws) return "no_socket";
     if (this.ws.readyState !== WebSocket.OPEN) return `socket_${this.ws.readyState}`;
@@ -731,6 +835,7 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
     this.boundAgents.delete(agentId);
     this.socketBoundAgentIds.delete(agentId);
     this.rejectPendingInboxAcksForAgent(agentId, "agent_unbound");
+    this.rejectPendingInboxRecoversForAgent(agentId, "agent_unbound");
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
     this.ws.send(JSON.stringify({ type: "agent:unbind", agentId }));
   }
@@ -776,6 +881,7 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
     this.clearTimers();
     this.rejectAllPendingBinds("Client disconnected");
     this.rejectAllPendingInboxAcks("Client disconnected");
+    this.rejectAllPendingInboxRecovers("Client disconnected");
     if (this.ws) {
       this.ws.removeAllListeners();
       if (this.ws.readyState === WebSocket.OPEN) {
@@ -933,10 +1039,12 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
         this.stopHeartbeat();
         this.clearAuthRefreshTimer();
         this.clearPendingInboxAckTimers();
+        this.clearPendingInboxRecoverTimers();
         const wasRegistered = this.registered;
         this.registered = false;
         this.socketBoundAgentIds.clear();
         this.rejectAllPendingBinds("WebSocket closed");
+        this.rejectAllPendingInboxRecovers("WebSocket closed");
 
         if (!settled) {
           this.wsLogger.warn({ code }, "closed before ready");
@@ -1145,6 +1253,7 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
         }
         this.bindRetryRecords.set(pending.agentId, record);
         this.rejectPendingInboxAcksForAgent(pending.agentId, `agent_bind_rejected:${reason}`);
+        this.rejectPendingInboxRecoversForAgent(pending.agentId, `agent_bind_rejected:${reason}`);
         this.emit("agent:bind:rejected", reason, pending.agentId);
         pending.reject(new Error(`agent:bind rejected (${reason})`));
       }
@@ -1156,6 +1265,7 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
       this.boundAgents.delete(agentId);
       this.socketBoundAgentIds.delete(agentId);
       this.rejectPendingInboxAcksForAgent(agentId, "agent_unbound");
+      this.rejectPendingInboxRecoversForAgent(agentId, "agent_unbound");
       this.emit("agent:unbound", agentId);
       return;
     }
@@ -1178,6 +1288,7 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
         this.boundAgents.delete(agentId);
         this.socketBoundAgentIds.delete(agentId);
         this.rejectPendingInboxAcksForAgent(agentId, "agent_force_disconnect");
+        this.rejectPendingInboxRecoversForAgent(agentId, "agent_force_disconnect");
         this.emit("agent:unbound", agentId, typeof msg.reason === "string" ? msg.reason : "server_forced");
       }
       return;
@@ -1248,6 +1359,58 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
         return;
       }
       this.rejectPendingInboxAck(pending, parsed.data.reason);
+      return;
+    }
+
+    if (type === "inbox:recover:accepted") {
+      const parsed = inboxRecoverAcceptedFrameSchema.safeParse(msg);
+      if (!parsed.success) {
+        this.wsLogger.warn(
+          { issues: parsed.error.issues.map((i) => i.message) },
+          "ignoring malformed inbox:recover:accepted frame",
+        );
+        return;
+      }
+      const pending = this.pendingInboxRecovers.get(parsed.data.ref);
+      if (!pending || pending.agentId !== parsed.data.agentId || pending.chatId !== parsed.data.chatId) {
+        this.wsLogger.debug(
+          {
+            agentId: parsed.data.agentId,
+            chatId: parsed.data.chatId,
+            ref: parsed.data.ref,
+            recoverEvent: "inbox_recover_no_match",
+          },
+          "inbox:recover:accepted matched no pending recovery",
+        );
+        return;
+      }
+      this.resolvePendingInboxRecover(pending, parsed.data.resetCount);
+      return;
+    }
+
+    if (type === "inbox:recover:rejected") {
+      const parsed = inboxRecoverRejectedFrameSchema.safeParse(msg);
+      if (!parsed.success) {
+        this.wsLogger.warn(
+          { issues: parsed.error.issues.map((i) => i.message) },
+          "ignoring malformed inbox:recover:rejected frame",
+        );
+        return;
+      }
+      const pending = this.pendingInboxRecovers.get(parsed.data.ref);
+      if (!pending || pending.agentId !== parsed.data.agentId) {
+        this.wsLogger.debug(
+          {
+            agentId: parsed.data.agentId,
+            chatId: parsed.data.chatId ?? null,
+            ref: parsed.data.ref,
+            recoverEvent: "inbox_recover_no_match",
+          },
+          "inbox:recover:rejected matched no pending recovery",
+        );
+        return;
+      }
+      this.rejectPendingInboxRecover(pending, parsed.data.reason);
       return;
     }
 
@@ -1329,6 +1492,7 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
           lastReasonCode: record.lastReason,
         });
         this.rejectPendingInboxAcksForAgent(desired.agentId, "agent_rebind_skipped");
+        this.rejectPendingInboxRecoversForAgent(desired.agentId, "agent_rebind_skipped");
         continue;
       }
       const previousAttempts = record?.attempts ?? 0;
@@ -1522,9 +1686,29 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
     }
   }
 
+  private rejectAllPendingInboxRecovers(reason: string): void {
+    for (const pending of this.pendingInboxRecovers.values()) {
+      this.clearPendingInboxRecoverTimer(pending);
+      pending.reject(new Error(reason));
+    }
+    this.pendingInboxRecovers.clear();
+  }
+
+  private rejectPendingInboxRecoversForAgent(agentId: string, reason: string): void {
+    for (const pending of [...this.pendingInboxRecovers.values()]) {
+      if (pending.agentId === agentId) this.rejectPendingInboxRecover(pending, reason);
+    }
+  }
+
   private clearPendingInboxAckTimers(): void {
     for (const pending of this.pendingInboxAcks.values()) {
       this.clearPendingInboxAckTimer(pending);
+    }
+  }
+
+  private clearPendingInboxRecoverTimers(): void {
+    for (const pending of this.pendingInboxRecovers.values()) {
+      this.clearPendingInboxRecoverTimer(pending);
     }
   }
 
@@ -1540,6 +1724,7 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
     }
     this.clearAuthRefreshTimer();
     this.clearPendingInboxAckTimers();
+    this.clearPendingInboxRecoverTimers();
   }
 
   private clearAuthRefreshTimer(): void {

--- a/packages/client/src/handlers/claude-code-tui/index.ts
+++ b/packages/client/src/handlers/claude-code-tui/index.ts
@@ -321,6 +321,7 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
     if (!tmuxSessionName || !transcriptTailer) {
       throw new Error("runTurn called before session was prepared");
     }
+    sessionCtx.markMessagesConsumed(messages);
     sessionCtx.setRuntimeState("working");
     turnAborted = false;
 

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -847,7 +847,19 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
     } else {
       sessionCtx.markCompleted();
     }
+    markCurrentPendingMessageConsumed(sessionCtx);
     stashedSdkMessage = null;
+  }
+
+  function pushPendingAckMessage(message: SessionMessage, sessionCtx: SessionContext): void {
+    const wasEmpty = pendingAckMessages.length === 0;
+    pendingAckMessages.push(message);
+    if (wasEmpty) sessionCtx.markMessagesConsumed(message);
+  }
+
+  function markCurrentPendingMessageConsumed(sessionCtx: SessionContext): void {
+    const current = pendingAckMessages[0];
+    if (current) sessionCtx.markMessagesConsumed(current);
   }
 
   async function pushInjectedMessage(
@@ -865,7 +877,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       const sdkMsg = await toSDKUserMessage(message, sessionCtx, sessionId);
       stashedSdkMessage = sdkMsg;
       inputController?.push(sdkMsg);
-      pendingAckMessages.push(message);
+      pushPendingAckMessage(message, sessionCtx);
     } catch (err) {
       sessionCtx.log(`toSDKUserMessage errored: ${err instanceof Error ? err.message : String(err)}`);
       // `toSDKUserMessage` failed before the SDK ever saw the
@@ -1568,7 +1580,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       stashedSdkMessage = sdkMsg;
       spawnQuery(claudeSessionId, sessionCtx);
       inputController?.push(sdkMsg);
-      pendingAckMessages.push(message);
+      pushPendingAckMessage(message, sessionCtx);
       scheduleInjectedMessagesDrain(sessionCtx, claudeSessionId);
 
       sessionCtx.log(`Session started (${claudeSessionId})`);
@@ -1631,7 +1643,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
         spawnQuery(sessionId, sessionCtx, sessionId);
         if (sdkMsg) {
           inputController?.push(sdkMsg);
-          if (message) pendingAckMessages.push(message);
+          if (message) pushPendingAckMessage(message, sessionCtx);
         }
         scheduleInjectedMessagesDrain(sessionCtx, sessionId);
         sessionCtx.log(`Session resumed at legacy cwd (${sessionId})`);
@@ -1675,7 +1687,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
         spawnQuery(freshSessionId, sessionCtx);
         if (freshSdkMsg) {
           inputController?.push(freshSdkMsg);
-          if (message) pendingAckMessages.push(message);
+          if (message) pushPendingAckMessage(message, sessionCtx);
         }
         scheduleInjectedMessagesDrain(sessionCtx, freshSessionId);
         sessionCtx.log(`Session started (${freshSessionId}, replacing ${sessionId})`);
@@ -1691,7 +1703,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       spawnQuery(sessionId, sessionCtx, sessionId);
       if (resumeSdkMsg) {
         inputController?.push(resumeSdkMsg);
-        if (message) pendingAckMessages.push(message);
+        if (message) pushPendingAckMessage(message, sessionCtx);
       }
       scheduleInjectedMessagesDrain(sessionCtx, sessionId);
 

--- a/packages/client/src/handlers/codex.ts
+++ b/packages/client/src/handlers/codex.ts
@@ -734,6 +734,7 @@ export const createCodexHandler: HandlerFactory = (config) => {
     const activeThread = thread;
     if (!activeThread) return;
 
+    sessionCtx.markMessagesConsumed(messages);
     const abort = new AbortController();
     currentAbort = abort;
     sessionCtx.setRuntimeState("working");

--- a/packages/client/src/runtime/agent-slot.ts
+++ b/packages/client/src/runtime/agent-slot.ts
@@ -204,6 +204,7 @@ export class AgentSlot {
       const gitMirrorManager = this.config.gitMirrorManager;
 
       const ackEntry = (entryId: number) => this.clientConnection.sendInboxAck(entryId, agent.agentId);
+      const recoverChat = (chatId: string) => this.clientConnection.sendInboxRecover(agent.agentId, chatId);
 
       this.sessionManager = new SessionManager({
         session: this.config.session,
@@ -236,6 +237,7 @@ export class AgentSlot {
         registryPath,
         agentConfigCache: this.agentConfigCache,
         ackEntry,
+        recoverChat,
         onStateChange: (chatId, state) => this.reportSessionState(chatId, state),
         onRuntimeStateChange: (state) => this.reportRuntimeState(state),
         onSessionEvent: (chatId, event) => this.reportSessionEvent(chatId, event),

--- a/packages/client/src/runtime/handler.ts
+++ b/packages/client/src/runtime/handler.ts
@@ -73,6 +73,14 @@ export type SessionContext = HandlerContext & {
   markCompleted: () => void;
 
   /**
+   * Mark the concrete message or fused batch as entered into the current
+   * provider turn. This is an in-memory boundary used by suspend: consumed
+   * entries can be ACKed when the turn is paused, while handler queues that
+   * have not entered the provider stay unacked for recovery.
+   */
+  markMessagesConsumed: (messages: SessionMessage | readonly SessionMessage[]) => void;
+
+  /**
    * Mark the concrete message or fused message batch a handler has actually
    * consumed. The runtime sends one `inbox:ack` for the last message's
    * `inboxEntryId`; the server interprets it as ack-through for the chat's
@@ -84,9 +92,8 @@ export type SessionContext = HandlerContext & {
 
   /**
    * Mark a concrete message or batch as abandoned by a retryable path
-   * (suspend, abort, timeout). The runtime must not let a later message in
-   * the same chat ack-through these entries, so it fails closed until the
-   * next bind reset redelivers from the server's oldest unacked entry.
+   * (abort, timeout, unknown failure). The runtime leaves the server-side
+   * entries unacked; a later chat recovery or bind reset redelivers them.
    */
   markMessagesRetryable: (messages: SessionMessage | readonly SessionMessage[], reason: string) => void;
 

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -202,6 +202,11 @@ type SessionManagerConfig = {
    * same socket that delivered it.
    */
   ackEntry: (entryId: number) => Promise<void>;
+  /**
+   * Same-socket chat recovery: reset delivered-but-unacked entries for the
+   * chat back to pending and redeliver them on this connection.
+   */
+  recoverChat?: (chatId: string) => Promise<void>;
   /** Callback when a session state changes (per-session granularity). */
   onStateChange?: (chatId: string, state: SessionState) => void;
   /** Callback when aggregated runtime state changes. */
@@ -262,7 +267,8 @@ type TrackedInFlightEntry = {
   entryId: number;
   messageId: string;
   dedupKey: string;
-  admitted: boolean;
+  accepted: boolean;
+  consumed: boolean;
 };
 
 /**
@@ -312,20 +318,16 @@ export class SessionManager {
   private readonly inFlightEntries = new Map<string, TrackedInFlightEntry[]>();
   /**
    * Per-chat admission barrier. It serializes the pre-handler admission phase
-   * only: config refresh, eager asset fetch, marking the entry admitted, and
+   * only: config refresh, eager asset fetch, marking the entry accepted, and
    * invoking `routeMessage()`. It deliberately does NOT wait for the handler's
    * turn promise to settle, so A2 can still be appended/injected while A1's
    * attempt is running; it just cannot overtake A1 before A1 reaches handler
    * membership.
    */
   private readonly admissionQueues = new Map<string, Promise<void>>();
-  /**
-   * Chats whose local handler state was abandoned while server-side entries
-   * may still be `delivered`. Until the next bind reset, processing a newer
-   * entry in that chat could make ack-through commit an older abandoned entry,
-   * so dispatch fails closed and waits for bind recovery.
-   */
-  private readonly needsBindRecovery = new Set<string>();
+  private readonly recoveringChats = new Map<string, Promise<void>>();
+  private readonly recoveryActivationReady = new Set<string>();
+  private readonly requiresInboxRecovery = new Set<string>();
   private readonly pendingQueue: PendingMessage[] = [];
   private readonly lastReportedStates = new Map<string, SessionState>();
   private readonly sessionRuntimeStates = new Map<string, RuntimeState>();
@@ -377,11 +379,8 @@ export class SessionManager {
     const chatId = entry.chatId ?? entry.message.chatId;
     const messageId = entry.message.id;
 
-    if (this.needsBindRecovery.has(chatId)) {
-      this.config.log.warn(
-        { chatId, messageId, entryId: entry.id },
-        "chat has abandoned delivered entries; deferring inbox delivery until bind reset",
-      );
+    if (this.shouldRecoverBeforeDispatch(chatId)) {
+      await this.recoverChatBeforeDispatch(chatId, entry.id, messageId);
       return;
     }
 
@@ -405,13 +404,13 @@ export class SessionManager {
     // Track before routing. The handler (or teardown path) commits by
     // message identity once work is complete; nothing acks until then.
     const queue = this.inFlightEntries.get(chatId);
-    const tracked = { entryId: entry.id, messageId, dedupKey, admitted: false };
+    const tracked = { entryId: entry.id, messageId, dedupKey, accepted: false, consumed: false };
     if (queue) queue.push(tracked);
     else this.inFlightEntries.set(chatId, [tracked]);
 
     let routePromise: Promise<void> | undefined;
     await this.withAdmissionBarrier(chatId, async () => {
-      if (this.needsBindRecovery.has(chatId) || !this.isTrackedEntry(chatId, entry.id)) return;
+      if (!this.isTrackedEntry(chatId, entry.id)) return;
 
       // 2. Step 4: refresh runtime config if the message brought a newer
       // version. This is the *only* trigger for active-session re-config —
@@ -437,7 +436,7 @@ export class SessionManager {
         }
       }
 
-      if (this.needsBindRecovery.has(chatId) || !this.isTrackedEntry(chatId, entry.id)) return;
+      if (!this.isTrackedEntry(chatId, entry.id)) return;
 
       // Note: the "mention_only" filter now lives on the server (see
       // services/message.ts sendMessage fan-out). If an entry reaches dispatch
@@ -454,7 +453,7 @@ export class SessionManager {
       // "not available on this device" placeholder for that ref.
       await this.ensureImagesLocal(message);
 
-      if (this.needsBindRecovery.has(chatId) || !this.markTrackedEntryAdmitted(chatId, entry.id)) return;
+      if (!this.markTrackedEntryAccepted(chatId, entry.id)) return;
 
       // 5. Route by session state. ACK no longer happens inside route — the
       // entry sits in `inFlightEntries` until the handler completes the
@@ -464,7 +463,7 @@ export class SessionManager {
       // this entry has reached handler membership.
       routePromise = this.routeMessage(chatId, message).catch((err) => {
         if (this.isTrackedEntry(chatId, entry.id)) {
-          this.abandonInFlightForBindRecovery(chatId, "route_message_failed");
+          this.clearInFlightForRecovery(chatId, "route_message_failed");
         }
         throw err;
       });
@@ -670,12 +669,12 @@ export class SessionManager {
   }
 
   /**
-   * The server resets delivered-but-unacked rows back to pending during
-   * `agent:bind`. After that point chats blocked by local abandoned state can
-   * safely accept redelivery again.
+   * Compatibility hook for AgentSlot's bind listener. Bind-time recovery is
+   * now server-driven; chat-scoped same-socket recovery is requested lazily
+   * by `dispatch` when no healthy live handler exists.
    */
   noteBindRecoveryComplete(): void {
-    this.needsBindRecovery.clear();
+    // Intentionally no-op.
   }
 
   // ---- Internal -----------------------------------------------------------
@@ -695,11 +694,57 @@ export class SessionManager {
     return this.inFlightEntries.get(chatId)?.some((tracked) => tracked.entryId === entryId) ?? false;
   }
 
-  private markTrackedEntryAdmitted(chatId: string, entryId: number): boolean {
+  private markTrackedEntryAccepted(chatId: string, entryId: number): boolean {
     const tracked = this.inFlightEntries.get(chatId)?.find((entry) => entry.entryId === entryId);
     if (!tracked) return false;
-    tracked.admitted = true;
+    tracked.accepted = true;
     return true;
+  }
+
+  private hasHealthyLiveHandler(chatId: string): boolean {
+    const entry = this.sessions.get(chatId);
+    return entry?.status === "active" && entry.suspending === null;
+  }
+
+  private shouldRecoverBeforeDispatch(chatId: string): boolean {
+    if (this.recoveryActivationReady.has(chatId)) {
+      this.recoveryActivationReady.delete(chatId);
+      return false;
+    }
+    if (this.requiresInboxRecovery.has(chatId)) return true;
+    return Boolean(this.config.recoverChat) && !this.hasHealthyLiveHandler(chatId);
+  }
+
+  private async recoverChatBeforeDispatch(chatId: string, entryId: number, messageId: string): Promise<void> {
+    const existing = this.recoveringChats.get(chatId);
+    if (existing) {
+      await existing;
+      return;
+    }
+    const recoverChat = this.config.recoverChat;
+    if (!recoverChat) {
+      this.config.log.error(
+        { chatId, entryId, messageId },
+        "chat requires inbox recovery but no recoverChat callback is configured; deferring dispatch",
+      );
+      return;
+    }
+
+    let recovery: Promise<void>;
+    recovery = recoverChat(chatId)
+      .then(() => {
+        this.requiresInboxRecovery.delete(chatId);
+        this.recoveryActivationReady.add(chatId);
+        this.config.log.debug({ chatId, entryId, messageId }, "chat inbox recovery accepted before dispatch");
+      })
+      .catch((err) => {
+        this.config.log.warn({ chatId, entryId, messageId, err }, "chat inbox recovery failed before dispatch");
+      })
+      .finally(() => {
+        if (this.recoveringChats.get(chatId) === recovery) this.recoveringChats.delete(chatId);
+      });
+    this.recoveringChats.set(chatId, recovery);
+    await recovery;
   }
 
   private async routeMessage(chatId: string, message: SessionMessage): Promise<void> {
@@ -1188,7 +1233,8 @@ export class SessionManager {
   }
 
   private suspendSession(entry: SessionEntry): void {
-    this.abandonInFlightForBindRecovery(entry.chatId, "session_suspended");
+    this.ackConsumedInFlightForSuspend(entry.chatId);
+    this.clearInFlightForRecovery(entry.chatId, "session_suspended_unconsumed_tail");
     entry.status = "suspended";
     this._activeCount--;
     // Clear per-session runtime state on suspend
@@ -1269,9 +1315,9 @@ export class SessionManager {
       this.currentTrigger.delete(candidate.key);
       // Drop local in-flight tracking too — the handler is gone, so no
       // markCompleted will ever fire. The server-side entries stay
-      // `delivered`; the next `agent:bind` resets them back to `pending`
-      // for redelivery against a fresh session.
-      this.abandonInFlightForBindRecovery(candidate.key, "session_evicted");
+      // `delivered`; a later chat recovery or bind reset redelivers them
+      // against a fresh session.
+      this.clearInFlightForRecovery(candidate.key, "session_evicted");
       this.recomputeRuntimeState();
       this.persistRegistry();
     }
@@ -1383,17 +1429,6 @@ export class SessionManager {
       return;
     }
 
-    const prefix = queue.slice(0, index + 1);
-    const unadmitted = prefix.filter((tracked) => !tracked.admitted);
-    if (unadmitted.length > 0) {
-      this.config.log.warn(
-        { chatId, throughEntryId, unadmittedEntryIds: unadmitted.map((entry) => entry.entryId) },
-        "attempt completion ignored for unadmitted inbox prefix",
-      );
-      this.abandonInFlightForBindRecovery(chatId, "unadmitted_ack_prefix");
-      return;
-    }
-
     const committed = queue.splice(0, index + 1);
     for (const tracked of committed) {
       this.deduplicator.drop(tracked.dedupKey);
@@ -1410,16 +1445,45 @@ export class SessionManager {
     if (entryId !== undefined) this.ackThroughTrackedEntry(chatId, entryId);
   }
 
-  private abandonInFlightForBindRecovery(chatId: string, reason: string): void {
+  private clearInFlightForRecovery(chatId: string, reason: string): void {
     const queue = this.inFlightEntries.get(chatId);
     if (!queue || queue.length === 0) return;
     this.inFlightEntries.delete(chatId);
     this.deduplicator.dropByPrefix(`${chatId}:`);
-    this.needsBindRecovery.add(chatId);
+    this.requiresInboxRecovery.add(chatId);
     this.config.log.warn(
       { chatId, reason, entryIds: queue.map((entry) => entry.entryId) },
-      "abandoned in-flight inbox entries; waiting for bind recovery",
+      "cleared local in-flight inbox entries; waiting for recovery redelivery",
     );
+  }
+
+  private ackConsumedInFlightForSuspend(chatId: string): void {
+    const queue = this.inFlightEntries.get(chatId);
+    if (!queue || queue.length === 0) return;
+
+    let consumedPrefixCount = 0;
+    for (const tracked of queue) {
+      if (!tracked.consumed) break;
+      consumedPrefixCount++;
+    }
+    if (consumedPrefixCount === 0) return;
+
+    const lastConsumed = queue[consumedPrefixCount - 1];
+    if (lastConsumed) this.ackThroughTrackedEntry(chatId, lastConsumed.entryId);
+  }
+
+  private markMessagesConsumed(chatId: string, messages: SessionMessage | readonly SessionMessage[]): void {
+    const queue = this.inFlightEntries.get(chatId);
+    if (!queue || queue.length === 0) return;
+    const batch = Array.isArray(messages) ? messages : [messages];
+    const consumedIds = new Set<number>();
+    for (const message of batch) {
+      if (message.chatId === chatId && message.inboxEntryId !== undefined) consumedIds.add(message.inboxEntryId);
+    }
+    if (consumedIds.size === 0) return;
+    for (const tracked of queue) {
+      if (consumedIds.has(tracked.entryId)) tracked.consumed = true;
+    }
   }
 
   private markMessagesCompleted(chatId: string, messages: SessionMessage | readonly SessionMessage[]): void {
@@ -1449,7 +1513,7 @@ export class SessionManager {
         (this.inFlightEntries.get(chatId) ?? []).some((entry) => entry.entryId === message.inboxEntryId),
     );
     if (!hasTrackedMessage) return;
-    this.abandonInFlightForBindRecovery(chatId, reason);
+    this.clearInFlightForRecovery(chatId, reason);
   }
 
   /**
@@ -1463,17 +1527,17 @@ export class SessionManager {
   private drainAllInFlightEntries(chatId: string): void {
     const queue = this.inFlightEntries.get(chatId);
     if (!queue || queue.length === 0) return;
-    let admittedPrefixCount = 0;
+    let acceptedPrefixCount = 0;
     for (const tracked of queue) {
-      if (!tracked.admitted) break;
-      admittedPrefixCount++;
+      if (!tracked.accepted) break;
+      acceptedPrefixCount++;
     }
-    if (admittedPrefixCount > 0) {
-      const lastAdmitted = queue[admittedPrefixCount - 1];
-      if (lastAdmitted) this.ackThroughTrackedEntry(chatId, lastAdmitted.entryId);
+    if (acceptedPrefixCount > 0) {
+      const lastAccepted = queue[acceptedPrefixCount - 1];
+      if (lastAccepted) this.ackThroughTrackedEntry(chatId, lastAccepted.entryId);
     }
     if (this.inFlightEntries.has(chatId)) {
-      this.abandonInFlightForBindRecovery(chatId, "drain_unadmitted_remainder");
+      this.clearInFlightForRecovery(chatId, "drain_unaccepted_remainder");
     }
   }
 
@@ -1559,6 +1623,9 @@ export class SessionManager {
       forwardResult,
       markCompleted: () => {
         this.ackOldestTrackedEntry(chatId);
+      },
+      markMessagesConsumed: (messages) => {
+        this.markMessagesConsumed(chatId, messages);
       },
       markMessagesCompleted: (messages) => {
         this.markMessagesCompleted(chatId, messages);

--- a/packages/server/src/__tests__/inbox-bind-recovery.test.ts
+++ b/packages/server/src/__tests__/inbox-bind-recovery.test.ts
@@ -173,3 +173,64 @@ describe("inbox bind-time recovery (resetDeliveredForInboxes)", () => {
     expect(after[0]?.retryCount).toBe(0);
   });
 });
+
+describe("inbox same-socket chat recovery", () => {
+  const getApp = useTestApp();
+
+  it("resets delivered rows for one chat and drains only that chat", async () => {
+    const app = getApp();
+    const uid = crypto.randomUUID().slice(0, 6);
+    const a1 = await createTestAgent(app, { name: `recover-a1-${uid}` });
+    const a2 = await createTestAgent(app, { name: `recover-a2-${uid}` });
+
+    const chat1Res = await a1.request("POST", "/api/v1/agent/chats", {
+      type: "group",
+      participantIds: [a2.agent.uuid],
+    });
+    const chat1Id = chat1Res.json().id;
+    const chat2Res = await a1.request("POST", "/api/v1/agent/chats", {
+      type: "group",
+      participantIds: [a2.agent.uuid],
+    });
+    const chat2Id = chat2Res.json().id;
+
+    const msg1Res = await a1.request("POST", `/api/v1/agent/chats/${chat1Id}/messages`, {
+      format: "text",
+      content: "recover chat one",
+      receiverNames: [a2.agent.name],
+    });
+    const msg2Res = await a1.request("POST", `/api/v1/agent/chats/${chat2Id}/messages`, {
+      format: "text",
+      content: "recover chat two",
+      receiverNames: [a2.agent.name],
+    });
+
+    const claimed1 = await inboxService.claimAndBuildForPush(app.db, a2.agent.inboxId, msg1Res.json().id);
+    expect(claimed1).toHaveLength(1);
+    const claimed1Row = claimed1[0];
+    if (!claimed1Row) throw new Error("expected claimed chat1 inbox row");
+
+    const recovered = await inboxService.recoverUnackedForScope(app.db, {
+      inboxId: a2.agent.inboxId,
+      chatId: chat1Id,
+    });
+    expect(recovered.resetEntryIds).toEqual([claimed1Row.id]);
+
+    const drained = await inboxService.claimBacklogForPushForChat(app.db, a2.agent.inboxId, chat1Id, 10);
+    expect(drained.map((entry) => entry.id)).toEqual([claimed1Row.id]);
+
+    const chat2Rows = await app.db
+      .select({ id: inboxEntries.id, status: inboxEntries.status, messageId: inboxEntries.messageId })
+      .from(inboxEntries)
+      .where(
+        and(
+          eq(inboxEntries.inboxId, a2.agent.inboxId),
+          eq(inboxEntries.chatId, chat2Id),
+          eq(inboxEntries.notify, true),
+        ),
+      );
+    expect(chat2Rows).toHaveLength(1);
+    expect(chat2Rows[0]?.messageId).toBe(msg2Res.json().id);
+    expect(chat2Rows[0]?.status).toBe("pending");
+  });
+});

--- a/packages/server/src/api/agent/ws-client.ts
+++ b/packages/server/src/api/agent/ws-client.ts
@@ -7,6 +7,7 @@ import {
   type InboxEntryWithMessage,
   inboxAckFrameSchema,
   inboxDeliverFrameSchema,
+  inboxRecoverFrameSchema,
   runtimeStateMessageSchema,
   sessionEventMessageSchema,
   sessionReconcileRequestSchema,
@@ -139,21 +140,20 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
       >();
 
       /**
-       * Per-agent in-flight `inbox:deliver` counter for backpressure. Lives on
-       * the socket — when the WS closes it goes with it; that's intentional,
-       * because re-counting on a fresh connection would bias the cap against
-       * a healthy reconnect.
+       * Per-agent in-flight `inbox:deliver` ids for backpressure. Tracking ids
+       * instead of a scalar counter lets same-socket recovery remove exactly
+       * the reset rows before redelivery, so the cap cannot leak when an entry
+       * is delivered twice on the same connection.
        */
-      const inboxInFlight = new Map<string, number>();
+      const inboxInFlightEntryIds = new Map<string, Set<number>>();
       /**
-       * Per-agent delivery queue for all server-originated `inbox:deliver`
-       * frames on this socket. Ack-through relies on the client seeing each
-       * `(agent,chat)` stream oldest-first; without this queue, concurrent
-       * NOTIFY handlers or post-ack drains can `SKIP LOCKED` different rows
-       * and send a newer same-chat frame before an older one has reached the
-       * client.
+       * Socket-wide inbox operation queue. This is intentionally stronger than
+       * per-agent delivery serialization: `inbox:ack` does not carry an
+       * agentId, so putting ACK DB updates, recovery resets, and delivery
+       * drains in one FIFO is the simple way to preserve WS frame order for
+       * the ACK/recover race.
        */
-      const inboxDeliveryQueues = new Map<string, Promise<void>>();
+      let inboxOperationQueue: Promise<void> = Promise.resolve();
 
       function isAgentStillRoutedHere(agentId: string): boolean {
         return (
@@ -161,14 +161,29 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
         );
       }
 
-      function chainInboxDelivery(agentId: string, op: () => Promise<void>): Promise<void> {
-        const prev = inboxDeliveryQueues.get(agentId) ?? Promise.resolve();
+      function inboxInFlightCount(agentId: string): number {
+        return inboxInFlightEntryIds.get(agentId)?.size ?? 0;
+      }
+
+      function addInboxInFlight(agentId: string, entryId: number): void {
+        const current = inboxInFlightEntryIds.get(agentId) ?? new Set<number>();
+        current.add(entryId);
+        inboxInFlightEntryIds.set(agentId, current);
+      }
+
+      function removeInboxInFlight(agentId: string, entryIds: readonly number[]): void {
+        const current = inboxInFlightEntryIds.get(agentId);
+        if (!current) return;
+        for (const entryId of entryIds) {
+          current.delete(entryId);
+        }
+        if (current.size === 0) inboxInFlightEntryIds.delete(agentId);
+      }
+
+      function chainInboxDelivery(_agentId: string, op: () => Promise<void>): Promise<void> {
+        const prev = inboxOperationQueue;
         const next = prev.then(op, op);
-        inboxDeliveryQueues.set(agentId, next);
-        const cleanup = () => {
-          if (inboxDeliveryQueues.get(agentId) === next) inboxDeliveryQueues.delete(agentId);
-        };
-        void next.then(cleanup, cleanup);
+        inboxOperationQueue = next.catch(() => {});
         return next;
       }
 
@@ -250,11 +265,14 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
       async function drainBacklogForAgent(
         agentId: string,
         inboxId: string,
-        trigger?: { source: "notify"; messageId: string } | { source: "bind" | "ack" },
+        trigger?:
+          | { source: "notify"; messageId: string }
+          | { source: "bind" | "ack" }
+          | { source: "recover"; chatId: string },
       ): Promise<void> {
         if (socket.readyState !== socket.OPEN) return;
         if (!isAgentStillRoutedHere(agentId)) return;
-        const inFlight = inboxInFlight.get(agentId) ?? 0;
+        const inFlight = inboxInFlightCount(agentId);
         const slotsFree = inboxMaxInFlightPerAgent - inFlight;
         if (slotsFree <= 0) {
           if (trigger?.source === "notify") {
@@ -275,16 +293,19 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
 
         let entries: InboxEntryWithMessage[];
         try {
-          entries = await inboxService.claimBacklogForPush(app.db, inboxId, limit);
+          entries =
+            trigger?.source === "recover"
+              ? await inboxService.claimBacklogForPushForChat(app.db, inboxId, trigger.chatId, limit)
+              : await inboxService.claimBacklogForPush(app.db, inboxId, limit);
         } catch (err) {
           app.log.error({ err, agentId, inboxId, limit }, "claimBacklogForPush failed");
           return;
         }
 
         for (const entry of entries) {
-          inboxInFlight.set(agentId, (inboxInFlight.get(agentId) ?? 0) + 1);
+          addInboxInFlight(agentId, entry.id);
           if (!sendInboxDeliverFrame(entry)) {
-            inboxInFlight.set(agentId, Math.max(0, (inboxInFlight.get(agentId) ?? 1) - 1));
+            removeInboxInFlight(agentId, [entry.id]);
             // Socket gone mid-drain — stop pushing. Remaining entries stay
             // 'delivered'; the next bind from this client resets them and
             // re-drains.
@@ -695,8 +716,7 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
               await presenceService.unbindAgent(app.db, agentId);
               connectionManager.unbindAgentFromClient(agentId);
               boundAgents.delete(agentId);
-              inboxInFlight.delete(agentId);
-              inboxDeliveryQueues.delete(agentId);
+              inboxInFlightEntryIds.delete(agentId);
 
               socket.send(JSON.stringify({ type: "agent:unbound", agentId }));
             } else if (type === "session:state") {
@@ -931,25 +951,49 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
               }
               const { entryId, ref } = payloadResult.data;
 
-              // Find the agent / inbox this entry belongs to from the bind
-              // map. We never trust an `agentId` from the wire here — that
-              // would let one bound agent ack another agent's entry. Instead
-              // we resolve the inbox via the DB (one round-trip) and check
-              // the resulting inboxId is in this socket's bound set.
-              try {
-                const ackResult = await inboxService.ackEntryByIdForBoundAgents(
-                  app.db,
-                  entryId,
-                  [...boundAgents.values()].map((a) => a.inboxId),
-                );
-                if (!ackResult.ok) {
+              await chainInboxDelivery("__socket", async () => {
+                try {
+                  const ackResult = await inboxService.ackEntryByIdForBoundAgents(
+                    app.db,
+                    entryId,
+                    [...boundAgents.values()].map((a) => a.inboxId),
+                  );
+                  if (!ackResult.ok) {
+                    if (ref) {
+                      socket.send(
+                        JSON.stringify({
+                          type: "inbox:ack:rejected",
+                          entryId,
+                          ref,
+                          reason: ackResult.reason,
+                        }),
+                      );
+                    }
+                    app.log.debug(
+                      {
+                        clientId,
+                        entryId,
+                        ref,
+                        agentId: null,
+                        boundInboxes: boundAgents.size,
+                        reason: ackResult.reason,
+                        ackEvent: "inbox_ack_rejected",
+                      },
+                      "inbox:ack rejected",
+                    );
+                    return;
+                  }
+                  // Find the agentId that owns this inbox to decrement the
+                  // counter and trigger backlog drain.
+                  const owner = [...boundAgents.values()].find((a) => a.inboxId === ackResult.throughEntry.inboxId);
                   if (ref) {
                     socket.send(
                       JSON.stringify({
-                        type: "inbox:ack:rejected",
+                        type: "inbox:ack:accepted",
                         entryId,
                         ref,
-                        reason: ackResult.reason,
+                        disposition: ackResult.disposition,
+                        ackedCount: ackResult.ackedCount,
                       }),
                     );
                   }
@@ -958,59 +1002,87 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
                       clientId,
                       entryId,
                       ref,
-                      agentId: null,
-                      boundInboxes: boundAgents.size,
-                      reason: ackResult.reason,
-                      ackEvent: "inbox_ack_rejected",
+                      agentId: owner?.agentId ?? null,
+                      disposition: ackResult.disposition,
+                      ackedCount: ackResult.ackedCount,
+                      ackedEntryIds: ackResult.ackedEntryIds,
+                      ackEvent: "inbox_ack_accepted",
                     },
-                    "inbox:ack rejected",
+                    "inbox:ack accepted",
+                  );
+                  if (owner && ackResult.ackedEntryIds.length > 0) {
+                    removeInboxInFlight(owner.agentId, ackResult.ackedEntryIds);
+                    // Slot freed → top up. Cheap when no backlog (single SQL
+                    // statement returning 0 rows). Critical when the cap was
+                    // hit and queued NOTIFYs got dropped (proposal §3.5).
+                    await drainBacklogForAgent(owner.agentId, owner.inboxId, { source: "ack" });
+                  }
+                } catch (err) {
+                  app.log.error({ err, entryId }, "inbox:ack handling failed");
+                }
+              });
+            } else if (type === "inbox:recover") {
+              const payloadResult = inboxRecoverFrameSchema.safeParse(msg);
+              if (!payloadResult.success) {
+                app.log.warn(
+                  {
+                    clientId,
+                    issues: payloadResult.error.issues.map((i) => ({
+                      path: i.path.join("."),
+                      code: i.code,
+                      message: i.message,
+                    })),
+                  },
+                  "malformed inbox:recover frame — replying error",
+                );
+                socket.send(JSON.stringify({ type: "error", message: "Malformed inbox:recover frame" }));
+                return;
+              }
+              const { agentId, chatId, ref } = payloadResult.data;
+              await chainInboxDelivery("__socket", async () => {
+                const info = boundAgents.get(agentId);
+                if (!info || !isAgentStillRoutedHere(agentId)) {
+                  socket.send(
+                    JSON.stringify({
+                      type: "inbox:recover:rejected",
+                      ref,
+                      agentId,
+                      chatId,
+                      reason: "agent_not_bound",
+                    }),
                   );
                   return;
                 }
-                // Find the agentId that owns this inbox to decrement the
-                // counter and trigger backlog drain.
-                const owner = [...boundAgents.values()].find((a) => a.inboxId === ackResult.throughEntry.inboxId);
-                if (ref) {
+
+                try {
+                  const recovered = await inboxService.recoverUnackedForScope(app.db, {
+                    inboxId: info.inboxId,
+                    chatId,
+                  });
+                  removeInboxInFlight(agentId, recovered.resetEntryIds);
                   socket.send(
                     JSON.stringify({
-                      type: "inbox:ack:accepted",
-                      entryId,
+                      type: "inbox:recover:accepted",
                       ref,
-                      disposition: ackResult.disposition,
-                      ackedCount: ackResult.ackedCount,
+                      agentId,
+                      chatId,
+                      resetCount: recovered.resetEntryIds.length,
+                    }),
+                  );
+                  await drainBacklogForAgent(agentId, info.inboxId, { source: "recover", chatId });
+                } catch (err) {
+                  app.log.error({ err, agentId, chatId }, "inbox:recover handling failed");
+                  socket.send(
+                    JSON.stringify({
+                      type: "inbox:recover:rejected",
+                      ref,
+                      agentId,
+                      chatId,
+                      reason: "recover_failed",
                     }),
                   );
                 }
-                app.log.debug(
-                  {
-                    clientId,
-                    entryId,
-                    ref,
-                    agentId: owner?.agentId ?? null,
-                    disposition: ackResult.disposition,
-                    ackedCount: ackResult.ackedCount,
-                    ackedEntryIds: ackResult.ackedEntryIds,
-                    ackEvent: "inbox_ack_accepted",
-                  },
-                  "inbox:ack accepted",
-                );
-                if (owner && ackResult.ackedCount > 0) {
-                  inboxInFlight.set(
-                    owner.agentId,
-                    Math.max(0, (inboxInFlight.get(owner.agentId) ?? ackResult.ackedCount) - ackResult.ackedCount),
-                  );
-                  // Slot freed → top up. Cheap when no backlog (single SQL
-                  // statement returning 0 rows). Critical when the cap was
-                  // hit and queued NOTIFYs got dropped (proposal §3.5).
-                  chainInboxDelivery(owner.agentId, () =>
-                    drainBacklogForAgent(owner.agentId, owner.inboxId, { source: "ack" }),
-                  ).catch((err) => {
-                    app.log.error({ err, agentId: owner.agentId }, "post-ack backlog drain crashed");
-                  });
-                }
-              } catch (err) {
-                app.log.error({ err, entryId }, "inbox:ack handling failed");
-              }
+              });
             } else if (type === "heartbeat") {
               if (clientId) {
                 await clientService.heartbeatClient(app.db, clientId);
@@ -1038,7 +1110,7 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
           notifier.unsubscribe(info.inboxId, socket);
         }
         boundAgents.clear();
-        inboxDeliveryQueues.clear();
+        inboxInFlightEntryIds.clear();
 
         if (clientId) {
           // Reconnect-race guard. A typical `systemctl restart` produces this

--- a/packages/server/src/services/inbox.ts
+++ b/packages/server/src/services/inbox.ts
@@ -113,7 +113,7 @@ export async function pollInbox(db: Database, inboxId: string, limit: number) {
   );
 }
 
-async function pollInboxInner(db: Database, inboxId: string, limit: number) {
+async function pollInboxInner(db: Database, inboxId: string, limit: number, chatId?: string) {
   return db.transaction(async (tx) => {
     // Claim pending notify=true entries (active triggers). Silent rows
     // (notify=false) are intentionally excluded — they piggy-back on the
@@ -123,13 +123,31 @@ async function pollInboxInner(db: Database, inboxId: string, limit: number) {
     // pollers / WS-push handlers from claiming the same row twice. The outer
     // UPDATE then flips status to 'delivered' on whichever rows the subquery
     // successfully locked — canonical PG SKIP-LOCKED queue idiom.
-    const targetIds = tx
-      .select({ id: inboxEntries.id })
-      .from(inboxEntries)
-      .where(and(eq(inboxEntries.inboxId, inboxId), eq(inboxEntries.status, "pending"), eq(inboxEntries.notify, true)))
-      .orderBy(asc(inboxEntries.createdAt), asc(inboxEntries.id))
-      .limit(limit)
-      .for("update", { skipLocked: true });
+    const targetIds =
+      chatId === undefined
+        ? tx
+            .select({ id: inboxEntries.id })
+            .from(inboxEntries)
+            .where(
+              and(eq(inboxEntries.inboxId, inboxId), eq(inboxEntries.status, "pending"), eq(inboxEntries.notify, true)),
+            )
+            .orderBy(asc(inboxEntries.createdAt), asc(inboxEntries.id))
+            .limit(limit)
+            .for("update", { skipLocked: true })
+        : tx
+            .select({ id: inboxEntries.id })
+            .from(inboxEntries)
+            .where(
+              and(
+                eq(inboxEntries.inboxId, inboxId),
+                eq(inboxEntries.chatId, chatId),
+                eq(inboxEntries.status, "pending"),
+                eq(inboxEntries.notify, true),
+              ),
+            )
+            .orderBy(asc(inboxEntries.createdAt), asc(inboxEntries.id))
+            .limit(limit)
+            .for("update", { skipLocked: true });
 
     const claimed = await tx
       .update(inboxEntries)
@@ -309,6 +327,24 @@ export async function claimBacklogForPush(
 ): Promise<InboxEntryWithMessage[]> {
   return withSpan("inbox.deliver.backlog", { "inbox.id": inboxId, "inbox.backlog.limit": limit }, () =>
     pollInboxInner(db, inboxId, limit),
+  );
+}
+
+/**
+ * Chat-scoped WS backlog path used after same-socket recovery. It mirrors
+ * `claimBacklogForPush`, but limits the claim to the chat that asked for
+ * recovery so another chat's backlog cannot consume the recovery window.
+ */
+export async function claimBacklogForPushForChat(
+  db: Database,
+  inboxId: string,
+  chatId: string,
+  limit: number,
+): Promise<InboxEntryWithMessage[]> {
+  return withSpan(
+    "inbox.deliver.backlog.chat",
+    { "inbox.id": inboxId, "chat.id": chatId, "inbox.backlog.limit": limit },
+    () => pollInboxInner(db, inboxId, limit, chatId),
   );
 }
 
@@ -512,6 +548,41 @@ export async function ackThroughEntryIdForBoundAgents(
 }
 
 export const ackEntryByIdForBoundAgents = ackThroughEntryIdForBoundAgents;
+
+export type RecoverUnackedForScopeResult = {
+  resetEntryIds: number[];
+};
+
+/**
+ * Reset delivered-but-unacked notify rows for a single inbox, optionally
+ * narrowed to one chat, and return the concrete ids that were reset. The id
+ * list lets the WS layer remove only those entries from same-socket in-flight
+ * accounting before it redelivers them.
+ */
+export async function recoverUnackedForScope(
+  db: Database,
+  opts: { inboxId: string; chatId?: string },
+): Promise<RecoverUnackedForScopeResult> {
+  const reset = await db
+    .update(inboxEntries)
+    .set({ status: "pending" })
+    .where(
+      opts.chatId === undefined
+        ? and(
+            eq(inboxEntries.inboxId, opts.inboxId),
+            eq(inboxEntries.status, "delivered"),
+            eq(inboxEntries.notify, true),
+          )
+        : and(
+            eq(inboxEntries.inboxId, opts.inboxId),
+            eq(inboxEntries.chatId, opts.chatId),
+            eq(inboxEntries.status, "delivered"),
+            eq(inboxEntries.notify, true),
+          ),
+    )
+    .returning({ id: inboxEntries.id });
+  return { resetEntryIds: reset.map((row) => row.id) };
+}
 
 /**
  * Reset every `delivered` entry across the given `inboxIds` back to `pending`

--- a/packages/shared/src/__tests__/inbox-frames-schema.test.ts
+++ b/packages/shared/src/__tests__/inbox-frames-schema.test.ts
@@ -4,6 +4,9 @@ import {
   inboxAckFrameSchema,
   inboxAckRejectedFrameSchema,
   inboxDeliverFrameSchema,
+  inboxRecoverAcceptedFrameSchema,
+  inboxRecoverFrameSchema,
+  inboxRecoverRejectedFrameSchema,
 } from "../schemas/inbox-frames.js";
 
 const baseClientMessage = {
@@ -200,6 +203,54 @@ describe("inboxAckRejectedFrameSchema", () => {
       entryId: 7,
       ref: "ack_123",
       reason: "not_found_or_not_bound",
+    });
+    expect(res.success).toBe(true);
+  });
+});
+
+describe("inboxRecoverFrameSchema", () => {
+  it("accepts a chat recovery request", () => {
+    const res = inboxRecoverFrameSchema.safeParse({
+      type: "inbox:recover",
+      ref: "recover_123",
+      agentId: "agent_1",
+      chatId: "chat_1",
+    });
+    expect(res.success).toBe(true);
+  });
+
+  it("rejects an empty chat id", () => {
+    const res = inboxRecoverFrameSchema.safeParse({
+      type: "inbox:recover",
+      ref: "recover_123",
+      agentId: "agent_1",
+      chatId: "",
+    });
+    expect(res.success).toBe(false);
+  });
+});
+
+describe("inboxRecoverAcceptedFrameSchema", () => {
+  it("accepts a recovery confirmation", () => {
+    const res = inboxRecoverAcceptedFrameSchema.safeParse({
+      type: "inbox:recover:accepted",
+      ref: "recover_123",
+      agentId: "agent_1",
+      chatId: "chat_1",
+      resetCount: 2,
+    });
+    expect(res.success).toBe(true);
+  });
+});
+
+describe("inboxRecoverRejectedFrameSchema", () => {
+  it("accepts a recovery rejection", () => {
+    const res = inboxRecoverRejectedFrameSchema.safeParse({
+      type: "inbox:recover:rejected",
+      ref: "recover_123",
+      agentId: "agent_1",
+      chatId: "chat_1",
+      reason: "agent_not_bound",
     });
     expect(res.success).toBe(true);
   });

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -333,6 +333,10 @@ export type {
   InboxAckRejectedFrame,
   InboxAckRejectedReason,
   InboxDeliverFrame,
+  InboxRecoverAcceptedFrame,
+  InboxRecoverFrame,
+  InboxRecoverRejectedFrame,
+  InboxRecoverRejectedReason,
 } from "./schemas/inbox-frames.js";
 // -- WebSocket inbox data-plane frames --
 export {
@@ -342,6 +346,10 @@ export {
   inboxAckRejectedFrameSchema,
   inboxAckRejectedReasonSchema,
   inboxDeliverFrameSchema,
+  inboxRecoverAcceptedFrameSchema,
+  inboxRecoverFrameSchema,
+  inboxRecoverRejectedFrameSchema,
+  inboxRecoverRejectedReasonSchema,
 } from "./schemas/inbox-frames.js";
 export {
   INVITATION_DEFAULT_TTL_DAYS,

--- a/packages/shared/src/schemas/inbox-frames.ts
+++ b/packages/shared/src/schemas/inbox-frames.ts
@@ -60,3 +60,36 @@ export const inboxAckRejectedFrameSchema = z.object({
   reason: inboxAckRejectedReasonSchema,
 });
 export type InboxAckRejectedFrame = z.infer<typeof inboxAckRejectedFrameSchema>;
+
+/**
+ * client → server: ask the server to reset delivered-but-unacked entries for
+ * one chat back to pending so the active socket can redeliver them.
+ */
+export const inboxRecoverFrameSchema = z.object({
+  type: z.literal("inbox:recover"),
+  ref: z.string().min(1),
+  agentId: z.string().min(1),
+  chatId: z.string().min(1),
+});
+export type InboxRecoverFrame = z.infer<typeof inboxRecoverFrameSchema>;
+
+export const inboxRecoverRejectedReasonSchema = z.enum(["agent_not_bound", "chat_id_required", "recover_failed"]);
+export type InboxRecoverRejectedReason = z.infer<typeof inboxRecoverRejectedReasonSchema>;
+
+export const inboxRecoverAcceptedFrameSchema = z.object({
+  type: z.literal("inbox:recover:accepted"),
+  ref: z.string().min(1),
+  agentId: z.string().min(1),
+  chatId: z.string().min(1),
+  resetCount: z.number().int().nonnegative(),
+});
+export type InboxRecoverAcceptedFrame = z.infer<typeof inboxRecoverAcceptedFrameSchema>;
+
+export const inboxRecoverRejectedFrameSchema = z.object({
+  type: z.literal("inbox:recover:rejected"),
+  ref: z.string().min(1),
+  agentId: z.string().min(1),
+  chatId: z.string().min(1).optional(),
+  reason: inboxRecoverRejectedReasonSchema,
+});
+export type InboxRecoverRejectedFrame = z.infer<typeof inboxRecoverRejectedFrameSchema>;

--- a/packages/shared/src/schemas/inbox-frames.ts
+++ b/packages/shared/src/schemas/inbox-frames.ts
@@ -73,7 +73,7 @@ export const inboxRecoverFrameSchema = z.object({
 });
 export type InboxRecoverFrame = z.infer<typeof inboxRecoverFrameSchema>;
 
-export const inboxRecoverRejectedReasonSchema = z.enum(["agent_not_bound", "chat_id_required", "recover_failed"]);
+export const inboxRecoverRejectedReasonSchema = z.enum(["agent_not_bound", "recover_failed"]);
 export type InboxRecoverRejectedReason = z.infer<typeof inboxRecoverRejectedReasonSchema>;
 
 export const inboxRecoverAcceptedFrameSchema = z.object({


### PR DESCRIPTION
## Summary
- add same-socket `inbox:recover` frames and chat-scoped recovery for delivered-but-unacked inbox rows
- ACK only handler-reported consumed provider-turn messages on suspend, leaving queued/unconsumed input for recovery
- serialize ACK, recovery reset, and delivery drain on the server socket FIFO, with entry-id based in-flight accounting
- fail closed after local in-flight tracking is cleared without ACK until chat recovery runs

## Context
- Context Tree PR: https://github.com/agent-team-foundation/first-tree-context/pull/448
- Local design doc intentionally not included: `docs/session-recovery-ack-design.md`

## Validation
- pnpm --filter @first-tree/client exec vitest run src/__tests__/session-manager.test.ts src/__tests__/session-manager-edge-coverage.test.ts
- pnpm --filter @first-tree/client exec vitest run src/__tests__/client-connection-websocket-coverage.test.ts
- pnpm --filter @first-tree/shared test -- inbox-frames-schema.test.ts
- pnpm --filter @first-tree/server exec vitest run src/__tests__/inbox-bind-recovery.test.ts src/__tests__/inbox-ws-push.test.ts
- pnpm check
- pnpm typecheck