### PR TITLE
fix: degrade transient source-repo fetch failures to the existing checkout (#865)

### DIFF
--- a/packages/client/src/__tests__/git-mirror-manager.test.ts
+++ b/packages/client/src/__tests__/git-mirror-manager.test.ts
@@ -284,6 +284,63 @@ describe("GitMirrorManager — source repo lifecycle (per-agent clone)", () => {
     expect(upstream).not.toBe(localHead);
   });
 
+  it("degrades to the existing checkout when a SAME-repo fetch fails transiently (stale-offline)", async () => {
+    // Issue #865: an existing, usable clone of the SAME repo + a transient
+    // network fetch failure must NOT abort — leave the checkout at its current
+    // commit and continue on the last-good source so the agent stays answerable.
+    //
+    // Deterministic repro of the incident shape: build a real standalone clone
+    // whose origin ALREADY matches the configured upstream, then point that
+    // upstream at an unreachable endpoint so the next fetch fails transiently
+    // (connection refused). Because origin already matches the configured url,
+    // reconcileOrigin does NOT repoint (this is the "same repo" path, not a
+    // repoint). Port 1 ≠ 443 also disables the https→ssh protocol fallback,
+    // keeping it a same-protocol transient failure.
+    const { url: bare, tip } = seedBareRepo();
+    const clonePath = join(newDataDir(), "repo");
+    execSync(`git clone -q ${bare} ${clonePath}`);
+    const unreachable = "https://127.0.0.1:1/same-repo.git";
+    execSync(`git remote set-url origin ${unreachable}`, { cwd: clonePath });
+    const m = makeManager();
+    const r = await m.ensureSourceRepo({ url: unreachable, clonePath });
+    expect(r.outcome).toBe("stale-offline");
+    expect(r.headCommit).toBe(tip); // left at current commit, not aborted
+    expect(gitIn(clonePath, "rev-parse HEAD")).toBe(tip);
+    // gitWithNetworkRetry burns its full transient-retry budget (~3 backed-off
+    // attempts) before the degrade fires, so allow more than the 5s default.
+  }, 30_000);
+
+  it("fails closed when origin is being repointed to a different repo, even on a transient fetch failure", async () => {
+    // Boundary flagged by codex-developer + reproduced by QA on issue #865: the
+    // degrade must apply only to "same repo, fetch temporarily unavailable", NOT
+    // to "configured repo changed but the confirming fetch could not run". Here
+    // the configured url repoints to a DIFFERENT repo whose fetch fails
+    // transiently — serving repo A's checkout as repo B would be wrong, so this
+    // must fail closed.
+    const { url, tip } = seedBareRepo();
+    const m = makeManager();
+    const clonePath = join(newDataDir(), "repo");
+    const first = await m.ensureSourceRepo({ url, clonePath });
+    expect(first.headCommit).toBe(tip);
+    await expect(m.ensureSourceRepo({ url: "https://127.0.0.1:1/different.git", clonePath })).rejects.toBeInstanceOf(
+      GitMirrorError,
+    );
+  }, 30_000);
+
+  it("still fails closed on a hard (non-transient) fetch failure even with an existing checkout", async () => {
+    // Negative case for the stale-offline degrade: a deterministic, non-network
+    // failure (repository does not exist) must still bubble up — degrading would
+    // mask a real, non-self-healing problem.
+    const { url, tip } = seedBareRepo();
+    const m = makeManager();
+    const clonePath = join(newDataDir(), "repo");
+    const first = await m.ensureSourceRepo({ url, clonePath });
+    expect(first.headCommit).toBe(tip);
+    await expect(
+      m.ensureSourceRepo({ url: "file:///first-tree-nonexistent-repo-865.git", clonePath }),
+    ).rejects.toBeInstanceOf(GitMirrorError);
+  });
+
   it("throws a conflict for a non-managed occupant with no managed root (preserves operator data)", async () => {
     const m = makeManager();
     const clonePath = join(newDataDir(), "repo");
@@ -503,6 +560,10 @@ describe("GitMirrorManager — transient network error heuristic (isLikelyTransi
     // distinct from `SSL_ERROR_SYSCALL` and distinct from the cert-verify
     // failures (negative case below). Narrow pattern by design.
     "fatal: unable to access 'https://github.com/x/y/': error:0A000126:SSL routines::unexpected eof while reading",
+    // Issue #865 — the two verbatim operator-reported forms that motivated the
+    // degrade-on-transient-fetch-failure path. Neither was matched before.
+    "git fetch --prune origin exited with code 128: fatal: unable to access 'https://github.com/agent-team-foundation/first-tree/': Error in the HTTP2 framing layer",
+    "error: RPC failed; curl 28 Failed to connect to github.com port 443 after 75002 ms: Couldn't connect to server",
   ])("matches transient network error: %s", (msg) => {
     expect(isLikelyTransientNetworkError(msg)).toBe(true);
   });

--- a/packages/client/src/__tests__/git-mirror-manager.test.ts
+++ b/packages/client/src/__tests__/git-mirror-manager.test.ts
@@ -327,6 +327,37 @@ describe("GitMirrorManager — source repo lifecycle (per-agent clone)", () => {
     );
   }, 30_000);
 
+  it("still degrades when the configured ref already matches the checked-out HEAD", async () => {
+    // ref is honored: HEAD is at `tip` and config pins `ref` to that same
+    // commit, so the degrade does not advertise a HEAD different from `ref`.
+    const { url: bare, tip } = seedBareRepo();
+    const clonePath = join(newDataDir(), "repo");
+    execSync(`git clone -q ${bare} ${clonePath}`); // HEAD at tip
+    const unreachable = "https://127.0.0.1:1/same-repo.git";
+    execSync(`git remote set-url origin ${unreachable}`, { cwd: clonePath });
+    const m = makeManager();
+    const r = await m.ensureSourceRepo({ url: unreachable, ref: tip, clonePath });
+    expect(r.outcome).toBe("stale-offline");
+    expect(r.headCommit).toBe(tip);
+  }, 30_000);
+
+  it("fails closed when a transient fetch cannot confirm a configured ref the checkout is not at", async () => {
+    // R4 (codex-assistant): the checkout is on `main` (HEAD = tip), config pins
+    // `ref` to a different commit (`prev`) that exists locally but is NOT the
+    // current HEAD, and the confirming fetch fails transiently. Returning
+    // stale-offline would advertise the repo as being at `ref` while serving
+    // `tip` — and break the honor-the-pinned-commit-as-is contract. Must fail
+    // closed.
+    const { url: bare, tip, prev } = seedBareRepo();
+    expect(prev).not.toBe(tip);
+    const clonePath = join(newDataDir(), "repo");
+    execSync(`git clone -q ${bare} ${clonePath}`); // HEAD at tip, prev is an ancestor present locally
+    const unreachable = "https://127.0.0.1:1/same-repo.git";
+    execSync(`git remote set-url origin ${unreachable}`, { cwd: clonePath });
+    const m = makeManager();
+    await expect(m.ensureSourceRepo({ url: unreachable, ref: prev, clonePath })).rejects.toBeInstanceOf(GitMirrorError);
+  }, 30_000);
+
   it("still fails closed on a hard (non-transient) fetch failure even with an existing checkout", async () => {
     // Negative case for the stale-offline degrade: a deterministic, non-network
     // failure (repository does not exist) must still bubble up — degrading would

--- a/packages/client/src/runtime/git-mirror-manager.ts
+++ b/packages/client/src/runtime/git-mirror-manager.ts
@@ -89,6 +89,10 @@ export type GitMirrorManagerOptions = {
  *   - `skipped-dirty`         left as-is: working tree had local changes
  *   - `skipped-local-commits` left as-is: branch has local commits ahead of upstream
  *   - `skipped-in-use`        left as-is: another live session is using it
+ *   - `stale-offline`         left as-is: fetch failed with a transient network
+ *                             error on an existing usable checkout — degraded to
+ *                             the last-good local source instead of aborting the
+ *                             session (see step (4) in `ensureSourceRepo`)
  */
 export type SourceRepoOutcome =
   | "cloned"
@@ -97,7 +101,8 @@ export type SourceRepoOutcome =
   | "unchanged"
   | "skipped-dirty"
   | "skipped-local-commits"
-  | "skipped-in-use";
+  | "skipped-in-use"
+  | "stale-offline";
 
 export interface GitMirrorManager {
   /**
@@ -401,6 +406,24 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
    * so the subsequent fetch + `checkout -B` track the configured upstream
    * instead of silently serving the old one.
    */
+  /**
+   * True when `absTarget`'s current `remote.origin.url` already canonically
+   * matches the configured `url` — i.e. reconcileOrigin would NOT repoint origin
+   * to a different repo. Mirrors reconcileOrigin's own canonical comparison.
+   * Gates the transient `stale-offline` degrade: serving the local checkout is
+   * only safe when it is the SAME repo. Treats an unreadable / missing origin as
+   * "not matching" (fail closed).
+   */
+  async function originCanonicallyMatches(absTarget: string, url: string): Promise<boolean> {
+    try {
+      const { stdout } = await git(["config", "--get", "remote.origin.url"], absTarget, 10_000);
+      const current = stdout.trim();
+      return current.length > 0 && canonicalizeRepoUrl(current) === canonicalizeRepoUrl(url);
+    } catch {
+      return false;
+    }
+  }
+
   async function reconcileOrigin(absTarget: string, url: string): Promise<void> {
     let current = "";
     try {
@@ -656,10 +679,61 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
         }
 
         // (4) Managed standalone clone → reconcile origin, fetch, then update when safe.
+        //
+        // Capture whether origin ALREADY canonically matched the configured
+        // upstream *before* reconcileOrigin can repoint it. The transient
+        // degrade below is only safe for the SAME repo: if this call is
+        // repointing origin to a different repo and the confirming fetch then
+        // fails, the local checkout is the OLD repo's content and must NOT be
+        // served as the newly-configured source.
+        const originMatchedBeforeFetch = await originCanonicallyMatches(absTarget, url);
         try {
           await reconcileOrigin(absTarget, url);
           await fetchClone(absTarget, url);
         } catch (err) {
+          const stderr = err instanceof Error ? err.message : String(err);
+
+          // Degrade-on-transient-fetch-failure: when GitHub is briefly
+          // unreachable (a network blip, not an auth/corrupt/TLS-trust fault)
+          // and a usable checkout of the SAME repo already exists on disk, do
+          // NOT abort session start/resume — leave the clone at its current
+          // commit and continue on the last-good source. The agent stays
+          // answerable (e.g. to debug the very outage that broke the network),
+          // and the next session's fetch recovers it implicitly. Same "left at
+          // current commit" contract as the skipped-* outcomes; the only new
+          // thing is that the fetch itself didn't succeed.
+          //
+          // Strictly gated — every one of these must hold, else fail closed:
+          //   • high-confidence transient *network* error (not auth / corrupt /
+          //     TLS-trust / our own timeout / repo-not-found);
+          //   • `absTarget` is a real standalone clone with a resolvable HEAD;
+          //   • origin already matched the configured upstream (no repoint —
+          //     "configured repo changed but fetch could not confirm it" fails
+          //     closed);
+          //   • any pinned `ref` already resolves locally (never serve a
+          //     checkout that predates a just-changed ref the fetch couldn't
+          //     confirm).
+          // Silently serving a stale checkout otherwise would mask a real,
+          // non-self-healing problem.
+          if (isLikelyTransientNetworkError(stderr) && isStandaloneClone(absTarget) && originMatchedBeforeFetch) {
+            let usableHead = false;
+            try {
+              await headCommit(absTarget);
+              usableHead = true;
+            } catch {
+              usableHead = false;
+            }
+            const refResolvesLocally =
+              !ref || (await gitOk(["rev-parse", "--verify", "--quiet", `${ref}^{commit}`], absTarget, 10_000));
+            if (usableHead && refResolvesLocally) {
+              log?.warn(
+                { gitUrl: url, clonePath: absTarget, stderr: stderr.slice(0, 1024) },
+                "source-repo fetch failed (transient network) — using existing local checkout, left at current commit (stale)",
+              );
+              return finish("stale-offline");
+            }
+          }
+
           log?.warn(
             {
               gitUrl: url,
@@ -672,7 +746,7 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
                     : err instanceof GitMirrorError
                       ? "git-failed"
                       : "unknown",
-              stderr: err instanceof Error ? err.message.slice(0, 1024) : String(err).slice(0, 1024),
+              stderr: stderr.slice(0, 1024),
             },
             "source-repo fetch failed",
           );
@@ -907,6 +981,13 @@ export function isLikelyTransientNetworkError(message: string): boolean {
     /\bNetwork is unreachable\b/i.test(message) ||
     /Could not resolve host(?:name)?/i.test(message) ||
     /Temporary failure in name resolution/i.test(message) ||
+    // curl 7: `Failed to connect to <host> port <n> ...` and curl 28's
+    // `Couldn't connect to server` — a server unreachable / connect timeout.
+    /Failed to connect to\s+\S+\s+port\s+\d+/i.test(message) ||
+    /Couldn't connect to server/i.test(message) ||
+    // HTTP/2 transport framing fault (libcurl `CURLE_HTTP2`) seen as a
+    // mid-handshake `Error in the HTTP2 framing layer` against github.com.
+    /Error in the HTTP[/]?2 framing layer/i.test(message) ||
     /\bRPC failed\b/i.test(message) ||
     /\bearly EOF\b/i.test(message) ||
     /the remote end hung up unexpectedly/i.test(message) ||

--- a/packages/client/src/runtime/git-mirror-manager.ts
+++ b/packages/client/src/runtime/git-mirror-manager.ts
@@ -466,6 +466,21 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
     return head.stdout.trim();
   }
 
+  /**
+   * Resolve `ref` (branch / tag / commit) to a commit SHA in the LOCAL clone, or
+   * null when it does not resolve locally. Used to confirm a configured `ref` is
+   * already the checked-out HEAD before degrading to `stale-offline`.
+   */
+  async function localRefCommit(absTarget: string, ref: string): Promise<string | null> {
+    try {
+      const { stdout } = await git(["rev-parse", "--verify", "--quiet", `${ref}^{commit}`], absTarget, 10_000);
+      const sha = stdout.trim();
+      return sha.length > 0 ? sha : null;
+    } catch {
+      return null;
+    }
+  }
+
   /** Short branch name, or undefined when detached (`git rev-parse --abbrev-ref HEAD` → `HEAD`). */
   async function currentBranch(absTarget: string): Promise<string | undefined> {
     try {
@@ -710,22 +725,25 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
           //   • origin already matched the configured upstream (no repoint —
           //     "configured repo changed but fetch could not confirm it" fails
           //     closed);
-          //   • any pinned `ref` already resolves locally (never serve a
-          //     checkout that predates a just-changed ref the fetch couldn't
-          //     confirm).
+          //   • any configured `ref` is ALREADY the checked-out HEAD. It is not
+          //     enough that `ref` merely resolves locally: prepareSourceRepos
+          //     surfaces the configured `ref` to the runtime/briefing, so
+          //     returning a HEAD that differs from `ref` would advertise the
+          //     repo as being at `ref` while serving another commit — and for a
+          //     pinned commit, break the honor-as-is contract. When `ref` has
+          //     just changed to something the current HEAD is not at, fail
+          //     closed (we cannot move to it safely without a confirmed fetch).
           // Silently serving a stale checkout otherwise would mask a real,
           // non-self-healing problem.
           if (isLikelyTransientNetworkError(stderr) && isStandaloneClone(absTarget) && originMatchedBeforeFetch) {
-            let usableHead = false;
+            let headSha: string | null = null;
             try {
-              await headCommit(absTarget);
-              usableHead = true;
+              headSha = await headCommit(absTarget);
             } catch {
-              usableHead = false;
+              headSha = null;
             }
-            const refResolvesLocally =
-              !ref || (await gitOk(["rev-parse", "--verify", "--quiet", `${ref}^{commit}`], absTarget, 10_000));
-            if (usableHead && refResolvesLocally) {
+            const refSatisfiedByHead = !ref || (headSha !== null && (await localRefCommit(absTarget, ref)) === headSha);
+            if (headSha !== null && refSatisfiedByHead) {
               log?.warn(
                 { gitUrl: url, clonePath: absTarget, stderr: stderr.slice(0, 1024) },
                 "source-repo fetch failed (transient network) — using existing local checkout, left at current commit (stale)",

--- a/packages/client/src/runtime/source-repos.ts
+++ b/packages/client/src/runtime/source-repos.ts
@@ -92,7 +92,11 @@ export function releaseSourceReposForSession(sessionCtx: SessionContext): void {
  * it to the latest default branch. Concurrency for the same path is serialised
  * inside the manager (`withPathLock`).
  *
- * Fail-fast: any clone/fetch failure aborts the session and bubbles up.
+ * Fail-fast, with one degrade: a transient *network* fetch failure on an
+ * already-existing usable checkout does NOT abort — the manager leaves the
+ * clone at its current commit (`stale-offline`) so the agent stays answerable
+ * on the last-good source. Every other failure (first-clone failure, auth,
+ * corrupt, wrong origin, TLS trust) still aborts the session and bubbles up.
  */
 export async function prepareSourceRepos(params: PrepareSourceReposParams): Promise<PredeclaredSourceRepo[]> {
   const { workspace, payload, sessionCtx, gitMirrorManager } = params;
@@ -136,6 +140,10 @@ export async function prepareSourceRepos(params: PrepareSourceReposParams): Prom
         sessionCtx.log(`Git: ${localPath} has local commits ahead of upstream — left at current commit`);
       } else if (result.outcome === "skipped-in-use") {
         sessionCtx.log(`Git: ${localPath} in use by another live chat — left at current commit`);
+      } else if (result.outcome === "stale-offline") {
+        sessionCtx.log(
+          `Git: ${localPath} could not be fetched (transient network) — using existing local checkout, left at current commit (stale)`,
+        );
       }
 
       // Per agent-session-cwd-redesign: predeclared source repos are agent-scoped


### PR DESCRIPTION
## Summary

Fixes #865 — a transient GitHub/network failure while preparing predeclared source repos aborted agent session start/resume, making the agent unusable (including for debugging the very outage).

When a usable clone of the **same** repo already exists on disk, a transient fetch failure now degrades to the last-good local checkout (new `stale-offline` outcome) instead of failing the session — the same "left at current commit" contract as the existing `skipped-*` outcomes. No new degraded state/mode and no recovery machinery: the next session's fetch recovers it implicitly, and because start now succeeds, the retry-storm / log-spam loop from the incident disappears on its own.

## Safety boundary (fails closed)

Degrade applies only when **all** hold; otherwise the failure still bubbles up:
- origin already canonically matched the configured upstream **before** `reconcileOrigin` (no repoint — never serve repo A's checkout as repo B);
- high-confidence transient *network* error (not auth / corrupt / wrong-origin / TLS-trust / our own timeout / repo-not-found);
- a real standalone clone with a resolvable HEAD;
- any pinned `ref` already resolves locally.

First-clone failures (no local checkout to fall back to) stay fail-fast.

## Also

`isLikelyTransientNetworkError` now matches the incident's own error strings (`Error in the HTTP2 framing layer`; curl 28 `Failed to connect ... Couldn't connect to server`), which were previously unmatched — without this, the degrade would not trigger for the reported failure.

## Tests

- same-repo transient fetch failure → `stale-offline` (deterministic: origin pre-matched + unreachable endpoint)
- origin repoint + transient failure → fail-closed (boundary flagged in review by codex-developer and reproduced by QA)
- hard non-transient failure with an existing checkout → fail-closed
- incident error strings added to the transient-predicate cases

`@first-tree/client`: 90 files / 1010 tests passed; typecheck + biome clean. Verified on latest `main` (17368b27).

## Not in scope (per the design discussion on #865)

No `source-unavailable` first-clone mode, no AGENTS.md briefing / status / Web-Console surfacing, no circuit-breaker/recovery state machine — deliberately avoided as over-engineering. Surfacing is a single daemon `warn` log, same as `skipped-*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
