### PR TITLE
refactor(web): agent-detail PR1 — IA rename, repos→Environment, Instructions disclosure, TabBar

### DIFF
--- a/packages/web/src/components/ui/tab-bar.tsx
+++ b/packages/web/src/components/ui/tab-bar.tsx
@@ -1,4 +1,4 @@
-import type { HTMLAttributes, ReactNode } from "react";
+import { forwardRef, type HTMLAttributes, type ReactNode } from "react";
 import { cn } from "../../lib/utils.js";
 
 // Workspace-style underline tab bar.
@@ -11,13 +11,20 @@ import { cn } from "../../lib/utils.js";
 
 type TabBarProps = HTMLAttributes<HTMLDivElement>;
 
-export function TabBar({ className, style, ...rest }: TabBarProps) {
+export const TabBar = forwardRef<HTMLDivElement, TabBarProps>(function TabBar({ className, style, ...rest }, ref) {
   return (
     <div
+      ref={ref}
       className={cn("flex items-end", className)}
       style={{
         gap: 2,
-        height: 34,
+        // minHeight (not a fixed height): the active Tab uses marginBottom:-1 to
+        // overlap the bar's bottom border, making its content one pixel taller
+        // than the row. With a fixed height + a horizontally-scrolling consumer
+        // (overflowX:auto coerces overflow-y from visible to auto), that extra
+        // pixel surfaced a spurious VERTICAL scrollbar. Letting the bar grow to
+        // its content removes the overflow without clipping the focus ring/underline.
+        minHeight: 34,
         padding: "0 var(--sp-5)",
         borderBottom: "var(--hairline) solid var(--border)",
         background: "var(--bg-raised)",
@@ -26,7 +33,7 @@ export function TabBar({ className, style, ...rest }: TabBarProps) {
       {...rest}
     />
   );
-}
+});
 
 type TabProps = {
   active?: boolean;

--- a/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
+++ b/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
@@ -963,9 +963,11 @@ describe("page SSR smoke coverage", () => {
     expect(html).toContain("Profile");
 
     for (const [route, expected] of [
-      ["/agents/agent-1/runtime", "Runtime"],
+      // Repos render on the Environment (runtime) tab now; Tools & skills
+      // (resources route) lists only skills + MCP.
+      ["/agents/agent-1/runtime", "Team web"],
       ["/agents/agent-1/prompt", "Effective instructions"],
-      ["/agents/agent-1/resources", "Team web"],
+      ["/agents/agent-1/resources", "Integrations (MCP)"],
     ] as const) {
       expect(
         renderPage(

--- a/packages/web/src/pages/agent-detail-preview.tsx
+++ b/packages/web/src/pages/agent-detail-preview.tsx
@@ -2,6 +2,7 @@ import type { Agent, AgentResourcesOutput, AgentRuntimeConfig } from "@first-tre
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 import { Outlet, Route, Routes } from "react-router";
+import { ResourceTypeSection } from "./agent-detail/capability-section.js";
 import type { AgentDetailContext } from "./agent-detail/layout-context.js";
 import { PromptTab } from "./agent-detail/prompt-tab.js";
 import { ResourcesTab } from "./agent-detail/resources-tab.js";
@@ -322,11 +323,21 @@ export function AgentDetailPreviewPage() {
       <div style={{ minHeight: "100vh", background: "var(--bg)" }}>
         <div className="mx-auto" style={{ maxWidth: 720, padding: "var(--sp-6) var(--sp-4)" }}>
           <h1 className="text-title m-0" style={{ color: "var(--fg)" }}>
-            Capabilities tab
+            Environment tab — Repositories
           </h1>
           <p className="text-body" style={{ color: "var(--fg-3)", marginTop: "var(--sp-1)" }}>
-            Code repos / Skills / MCP — each row tagged From your team or Added by you; deviations show Off / Can't
-            load.
+            Code repositories live on the Environment tab now (they're part of the workspace the agent runs in). Saved
+            immediately — not part of the SaveBar draft.
+          </p>
+          <div style={{ marginTop: "var(--sp-4)", marginBottom: "var(--sp-8)" }}>
+            <ResourceTypeSection type="repo" data={RESOURCES} canEdit pending={false} onMutate={() => {}} />
+          </div>
+
+          <h1 className="text-title m-0" style={{ color: "var(--fg)" }}>
+            Tools &amp; skills tab
+          </h1>
+          <p className="text-body" style={{ color: "var(--fg-3)", marginTop: "var(--sp-1)" }}>
+            Skills / MCP — each row tagged From your team or Added by you; deviations show Off / Can't load.
           </p>
           <div style={{ marginTop: "var(--sp-4)", marginBottom: "var(--sp-8)" }}>
             <TabHost element={<ResourcesTab />} />
@@ -336,8 +347,9 @@ export function AgentDetailPreviewPage() {
             Instructions tab
           </h1>
           <p className="text-body" style={{ color: "var(--fg-3)", marginTop: "var(--sp-1)" }}>
-            Per-instruction management (Customize / Disable / Edit / Remove / Re-enable), optional team instructions to
-            enable, and the read-only merged Effective instructions at the bottom.
+            Per-instruction management (Customize / Disable / Edit / Remove / Re-enable) with each block collapsed to a
+            summary (Show full to expand), an Add menu for custom or team instructions, and the read-only merged
+            Effective instructions at the bottom.
           </p>
           <div style={{ marginTop: "var(--sp-4)" }}>
             <TabHost element={<PromptTab />} />

--- a/packages/web/src/pages/agent-detail.tsx
+++ b/packages/web/src/pages/agent-detail.tsx
@@ -27,11 +27,12 @@ import {
   DialogTitle,
 } from "./../components/ui/dialog.js";
 import { PresenceChip, runtimeStateToPresence } from "./../components/ui/presence-chip.js";
-import { Tab, TabBar } from "./../components/ui/tab-bar.js";
+import { Tab, TabBadge, TabBar } from "./../components/ui/tab-bar.js";
 import { useWorkspaceViewport } from "./../hooks/use-viewport.js";
 import { cn } from "./../lib/utils.js";
 import { canManageAgentDetail } from "./agent-detail/access.js";
 import { isBindableClient } from "./agent-detail/action-state.js";
+import { useAgentResources } from "./agent-detail/capability-section.js";
 import { ContextBar } from "./agent-detail/context-bar.js";
 import type { AgentDetailContext } from "./agent-detail/layout-context.js";
 import { ReBindDialog } from "./agent-detail/re-bind-dialog.js";
@@ -45,21 +46,25 @@ const SECTION_TO_TAB: Record<DraftSectionName, string> = {
   effort: "runtime",
   mcp: "capabilities",
   env: "runtime",
-  git: "capabilities",
+  // Repos render on the Environment (runtime) tab now, alongside env vars.
+  git: "runtime",
 };
 
 type TabDef = { key: string; label: string; path: string };
 
+// IA labels only — routing `path` and the `key` (draft / deep-link mapping) are
+// kept stable so existing URLs and `SECTION_TO_TAB` keep resolving:
+//   runtime → "Environment", capabilities → "Tools & skills".
 function buildTabs(canEditConfig: boolean, isHuman: boolean): TabDef[] {
   const tabs: TabDef[] = [{ key: "profile", label: "Profile", path: "profile" }];
   if (canEditConfig) {
     tabs.push(
-      { key: "runtime", label: "Runtime", path: "runtime" },
+      { key: "runtime", label: "Environment", path: "runtime" },
       { key: "prompt", label: "Instructions", path: "prompt" },
-      { key: "capabilities", label: "Capabilities", path: "capabilities" },
+      { key: "capabilities", label: "Tools & skills", path: "capabilities" },
     );
   } else if (!isHuman) {
-    tabs.push({ key: "capabilities", label: "Capabilities", path: "capabilities" });
+    tabs.push({ key: "capabilities", label: "Tools & skills", path: "capabilities" });
   }
   // Usage is an observation surface, not part of the edit flow. Keep it at
   // the end so configuration tabs read left-to-right as the setup workflow.
@@ -128,6 +133,14 @@ export function AgentDetailPage() {
     enabled: !!uuid && canEditConfig,
     refetchInterval: 30_000,
   });
+
+  // Shared agent-resources cache (skills / MCP / repos). Fetched here so the
+  // Tools & skills badge shows its effective count on first paint — the badge's
+  // whole point is "tell me there's something in here before I click". One light
+  // query in the same tier as agent-config / client-status; the Tools & skills
+  // and Environment tabs then read+write this same ["agent-resources", uuid]
+  // cache, so their useAgentResources calls become cache hits.
+  const toolsResources = useAgentResources(uuid, { enabled: !!uuid && agentQuery.data?.type !== "human" });
 
   const draft = useConfigDraft(cfgQuery.data);
   const [saveError, setSaveError] = useState<string | null>(null);
@@ -291,6 +304,18 @@ export function AgentDetailPage() {
     for (const s of draft.summary.dirtySections) set.add(SECTION_TO_TAB[s]);
     return set;
   }, [draft.summary.dirtySections]);
+
+  const tabBadges = useMemo<Record<string, number>>(() => {
+    const badges: Record<string, number> = {};
+    const d = toolsResources.data;
+    if (d) {
+      const count = d.effective.skills.length + d.effective.mcp.length;
+      // Don't badge an empty Tools & skills tab with a "0" — a count only earns
+      // its space when there's something to count.
+      if (count > 0) badges.capabilities = count;
+    }
+    return badges;
+  }, [toolsResources.data]);
 
   const tabs = useMemo(() => buildTabs(canEditConfig, isHumanLocal), [canEditConfig, isHumanLocal]);
   const currentTabKey = useMemo(() => {
@@ -527,7 +552,7 @@ export function AgentDetailPage() {
         <ContextBar runtimeLabel={contextRuntimeLabel} computerLabel={boundClientLabel} visible={contextBarVisible} />
       )}
 
-      <TabsNav tabs={tabs} agentUuid={uuid} currentTabKey={currentTabKey} dirtyTabs={dirtyTabs} />
+      <TabsNav tabs={tabs} agentUuid={uuid} currentTabKey={currentTabKey} dirtyTabs={dirtyTabs} badges={tabBadges} />
 
       <div
         className="w-full flex-1"
@@ -649,35 +674,113 @@ function TabsNav({
   agentUuid,
   currentTabKey,
   dirtyTabs,
+  badges,
 }: {
   tabs: TabDef[];
   agentUuid: string;
   currentTabKey: string;
   dirtyTabs: ReadonlySet<string>;
+  badges: Record<string, number>;
 }) {
   const navigate = useNavigate();
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const [edges, setEdges] = useState({ left: false, right: false });
+
+  // A single-tab agent (e.g. a human, who only has Profile) doesn't need a tab
+  // bar at all — rendering one lone underlined tab reads like chrome with no
+  // purpose.
+  const showBar = tabs.length > 1;
+
+  const updateEdges = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const maxScroll = el.scrollWidth - el.clientWidth;
+    setEdges({ left: el.scrollLeft > 1, right: el.scrollLeft < maxScroll - 1 });
+  }, []);
+
+  // Keep the active tab in view when the route changes (e.g. SaveBar "Jump to",
+  // or a deep link to a tab that sits off the right edge on a narrow screen) and
+  // recompute the overflow fades.
+  // `currentTabKey`, `tabs` and `badges` are intentional dependencies even though
+  // the body reads the active tab from the DOM rather than these variables:
+  //  - currentTabKey: programmatic route changes (SaveBar "Jump to", a deep link
+  //    to an off-screen tab) must re-scroll the active tab into view.
+  //  - tabs / badges: changing the tab set or a tab's badge changes the row's
+  //    scrollWidth, which ResizeObserver (it watches the box, not scrollWidth)
+  //    doesn't catch — so recompute the edge fades when they change.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: these deps drive the re-run; see comment above.
+  useEffect(() => {
+    if (!showBar) return;
+    const el = scrollRef.current;
+    if (!el) return;
+    el.querySelector('[aria-selected="true"]')?.scrollIntoView({ inline: "nearest", block: "nearest" });
+    updateEdges();
+  }, [showBar, currentTabKey, tabs, badges, updateEdges]);
+
+  useEffect(() => {
+    if (!showBar) return;
+    const el = scrollRef.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver(updateEdges);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [showBar, updateEdges]);
+
+  if (!showBar) return null;
+
   return (
-    // The full tab set can overflow a phone-width row, so the bar
-    // scrolls horizontally instead of wrapping; `shrink-0 whitespace-nowrap`
-    // on each Tab keeps labels at natural width and swipeable.
-    <TabBar role="tablist" aria-label="Agent configuration sections" style={{ overflowX: "auto" }}>
-      {tabs.map((t) => {
-        const active = currentTabKey === t.key;
-        return (
-          <Tab
-            key={t.key}
-            role="tab"
-            aria-selected={active}
-            active={active}
-            dirty={dirtyTabs.has(t.key)}
-            onClick={() => navigate(`/agents/${agentUuid}/${t.path}`, { replace: true })}
-            className="shrink-0 whitespace-nowrap"
-          >
-            {t.label}
-          </Tab>
-        );
-      })}
-    </TabBar>
+    // The full tab set can overflow a phone-width row, so the bar scrolls
+    // horizontally instead of wrapping; `shrink-0 whitespace-nowrap` on each Tab
+    // keeps labels at natural width and swipeable. Edge fades hint at content
+    // scrolled out of view; they sit above the bar and ignore pointer events.
+    <div style={{ position: "relative" }}>
+      <TabBar
+        ref={scrollRef}
+        role="tablist"
+        aria-label="Agent configuration sections"
+        style={{ overflowX: "auto" }}
+        onScroll={updateEdges}
+      >
+        {tabs.map((t) => {
+          const active = currentTabKey === t.key;
+          const badge = badges[t.key];
+          return (
+            <Tab
+              key={t.key}
+              role="tab"
+              aria-selected={active}
+              active={active}
+              dirty={dirtyTabs.has(t.key)}
+              onClick={() => navigate(`/agents/${agentUuid}/${t.path}`, { replace: true })}
+              className="shrink-0 whitespace-nowrap"
+            >
+              {t.label}
+              {badge != null ? <TabBadge>{badge}</TabBadge> : null}
+            </Tab>
+          );
+        })}
+      </TabBar>
+      {edges.left ? <TabEdgeFade side="left" /> : null}
+      {edges.right ? <TabEdgeFade side="right" /> : null}
+    </div>
+  );
+}
+
+function TabEdgeFade({ side }: { side: "left" | "right" }) {
+  return (
+    <div
+      aria-hidden
+      style={{
+        position: "absolute",
+        top: 0,
+        bottom: 0,
+        left: side === "left" ? 0 : undefined,
+        right: side === "right" ? 0 : undefined,
+        width: "var(--sp-6)",
+        pointerEvents: "none",
+        background: `linear-gradient(to ${side === "left" ? "right" : "left"}, var(--bg-raised), transparent)`,
+      }}
+    />
   );
 }
 

--- a/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
@@ -351,6 +351,12 @@ beforeEach(() => {
     },
   });
   agentMocks.rebindAgent.mockResolvedValue(agent({ clientId: "client-2", runtimeProvider: "codex" }));
+  // Use mockResolvedValue (persistent), not ...Once: the page shell now also
+  // observes agent-resources (to badge Tools & skills), so the query can be
+  // fetched more than once per render (a stale-time refetch fires when the tab's
+  // own observer mounts). The real GET is idempotent — every call returns the
+  // same state — so per-test overrides below also use mockResolvedValue; a
+  // one-shot mock with an empty fallback would clobber the cache on refetch.
   agentResourceMocks.getAgentResources.mockResolvedValue(agentResources());
   agentResourceMocks.updateAgentResources.mockImplementation(
     async (_agentId: string, body: { bindings: AgentResourcesOutput["bindings"] }) =>
@@ -379,7 +385,7 @@ afterEach(() => {
 describe("AgentDetailPage", () => {
   it("renders prompt resource blocks and edits the custom prompt inline", async () => {
     const { PromptTab } = await import("../prompt-tab.js");
-    agentResourceMocks.getAgentResources.mockResolvedValueOnce(
+    agentResourceMocks.getAgentResources.mockResolvedValue(
       agentResources({
         effective: {
           version: 7,
@@ -412,9 +418,9 @@ describe("AgentDetailPage", () => {
     expect(container.textContent).toContain("Chat");
     expect([...container.querySelectorAll('[role="tab"]')].map((tab) => tab.textContent?.trim())).toEqual([
       "Profile",
-      "Runtime",
+      "Environment",
       "Instructions",
-      "Capabilities",
+      "Tools & skills",
       "Usage",
     ]);
     expect(container.textContent).toContain("Always explain tradeoffs.");
@@ -457,7 +463,7 @@ describe("AgentDetailPage", () => {
 
   it("keeps the edit entry visible when an inline prompt binding has an empty body", async () => {
     const { PromptTab } = await import("../prompt-tab.js");
-    agentResourceMocks.getAgentResources.mockResolvedValueOnce(
+    agentResourceMocks.getAgentResources.mockResolvedValue(
       agentResources({
         effective: {
           version: 7,
@@ -536,7 +542,7 @@ describe("AgentDetailPage", () => {
 
   it("creates an inline replacement when editing a recommended team prompt", async () => {
     const { PromptTab } = await import("../prompt-tab.js");
-    agentResourceMocks.getAgentResources.mockResolvedValueOnce(
+    agentResourceMocks.getAgentResources.mockResolvedValue(
       agentResources({
         effective: {
           version: 7,
@@ -594,7 +600,7 @@ describe("AgentDetailPage", () => {
 
   it("converts an explicit recommended prompt binding to an inline replacement", async () => {
     const { PromptTab } = await import("../prompt-tab.js");
-    agentResourceMocks.getAgentResources.mockResolvedValueOnce(
+    agentResourceMocks.getAgentResources.mockResolvedValue(
       agentResources({
         effective: {
           version: 7,
@@ -663,7 +669,7 @@ describe("AgentDetailPage", () => {
 
   it("drops the existing include binding when disabling an explicitly-included recommended prompt", async () => {
     const { PromptTab } = await import("../prompt-tab.js");
-    agentResourceMocks.getAgentResources.mockResolvedValueOnce(
+    agentResourceMocks.getAgentResources.mockResolvedValue(
       agentResources({
         effective: {
           version: 7,
@@ -722,7 +728,7 @@ describe("AgentDetailPage", () => {
     agentConfigMocks.getAgentConfig.mockResolvedValueOnce(
       config({ payload: { ...emptyConfig.payload, prompt: { append: "" } } }),
     );
-    agentResourceMocks.getAgentResources.mockResolvedValueOnce(
+    agentResourceMocks.getAgentResources.mockResolvedValue(
       agentResources({
         effective: { version: 7, repos: [], prompts: [], skills: [], mcp: [], unavailable: [] },
         bindings: [],
@@ -731,7 +737,8 @@ describe("AgentDetailPage", () => {
 
     const { container, root } = await renderDom("/agents/agent-1/prompt", <PromptTab />);
     await waitForText(container, "No instructions yet.");
-    await click(exactButtonByText(container, "Add custom instructions"));
+    await click(container.querySelector('button[aria-label="Add instructions"]'));
+    await click(buttonByText(document.body, "Add custom instructions"));
     await waitForText(container, "Save instructions");
     await click(exactButtonByText(container, "Save instructions"));
     await waitForText(container, "Instructions are required.");
@@ -741,7 +748,8 @@ describe("AgentDetailPage", () => {
       "Expected prompt body validation error to clear",
     );
 
-    await click(exactButtonByText(container, "Add custom instructions"));
+    await click(container.querySelector('button[aria-label="Add instructions"]'));
+    await click(buttonByText(document.body, "Add custom instructions"));
     await waitForText(container, "Save instructions");
     expect(container.textContent).not.toContain("Instructions are required.");
     const textarea = container.querySelector<HTMLTextAreaElement>("#custom-prompt-body");

--- a/packages/web/src/pages/agent-detail/__tests__/resources-savebar-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/resources-savebar-dom.test.tsx
@@ -237,6 +237,19 @@ async function renderElement(element: ReactElement): Promise<HTMLElement> {
   return container;
 }
 
+// Render a presentational element that only needs a Router (e.g. ResourceTypeSection,
+// whose add menu uses useNavigate) — no outlet context or QueryClient required.
+async function renderRouted(element: ReactElement): Promise<HTMLElement> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root?.render(<MemoryRouter>{element}</MemoryRouter>);
+  });
+  await flush();
+  return container;
+}
+
 async function click(element: Element | null): Promise<void> {
   if (!element) throw new Error("Expected clickable element");
   await act(async () => {
@@ -272,8 +285,11 @@ describe("ResourcesTab and SaveBar", () => {
 
     spy.mockReturnValue(context({ canEditConfig: false, canManageAgent: false }));
     let container = await renderWithContext(<ResourcesTab />);
-    await waitForText(container, "Code repositories");
-    expect(container.textContent).toContain("Code repositories");
+    await waitForText(container, "Integrations (MCP)");
+    expect(container.textContent).toContain("Skills");
+    expect(container.textContent).toContain("Integrations (MCP)");
+    // Code repositories moved to the Environment tab — not on Tools & skills.
+    expect(container.textContent).not.toContain("Repositories");
     expect(container.textContent).not.toContain("Agent repo");
 
     await act(async () => root?.unmount());
@@ -339,15 +355,16 @@ describe("ResourcesTab and SaveBar", () => {
     const { ResourcesTab } = await import("../resources-tab.js");
 
     const container = await renderWithContext(<ResourcesTab />);
-    await waitForText(container, "Code repositories");
+    await waitForText(container, "Skills");
 
-    expect(container.textContent).toContain("Code repositories");
     expect(container.textContent).toContain("Skills");
+    expect(container.textContent).toContain("Integrations (MCP)");
     expect(container.textContent).not.toContain("Prompts");
-    expect(container.textContent).toContain("Team repo");
-    expect(container.textContent).toContain("https://github.com/acme/web.git -> web");
+    // Repos are not on this tab anymore (they moved to Environment).
+    expect(container.textContent).not.toContain("Repositories");
+    expect(container.textContent).not.toContain("Team repo");
     // Each editable section gets a quiet "+" add control (aria "Add <Type>").
-    expect(container.querySelector('button[aria-label="Add Repo"]')).toBeTruthy();
+    expect(container.querySelector('button[aria-label="Add Skill"]')).toBeTruthy();
 
     // Enable an opt-in team skill via the skill section's add menu. The menu
     // panel portals to document.body, so query the item there.
@@ -359,39 +376,66 @@ describe("ResourcesTab and SaveBar", () => {
     });
   });
 
-  it("excludes opt-in (available) repos from the agent repo add menu", async () => {
-    const layoutMocks = await import("../layout-context.js");
-    const spy = vi.spyOn(layoutMocks, "useAgentDetailContext");
-    spy.mockReturnValue(context());
-    // A legacy team repo still flagged Opt-in (available). Team repos are now
-    // always On by default, so it must NOT be offered as an "enable from team"
-    // option on the agent.
-    agentResourceMocks.getAgentResources.mockResolvedValue(
-      agentResources({
-        availableTeamResources: [
+  it("renders the repo section (Environment) with rows and an actionable add menu", async () => {
+    const { ResourceTypeSection } = await import("../capability-section.js");
+    // An enabled team repo to render, plus a legacy team repo still flagged
+    // Opt-in (available). Team repos are now always On by default, so the opt-in
+    // one must NOT be offered as an "enable from team" option.
+    const data = agentResources({
+      effective: {
+        version: 3,
+        repos: [
           {
-            id: "repo-available",
-            organizationId: "org-1",
+            id: "resource:repo-1",
+            bindingId: null,
+            resourceId: "repo-1",
+            replacesResourceId: null,
             type: "repo",
+            name: "Team repo",
             scope: "team",
-            ownerAgentId: null,
-            name: "Opt-in repo",
-            repoCanonicalKey: null,
-            defaultEnabled: "available",
-            status: "active",
-            payload: { url: "https://github.com/acme/optin.git" },
-            createdBy: "member-1",
-            updatedBy: "member-1",
-            createdAt: NOW,
-            updatedAt: NOW,
+            source: "team_recommended",
+            mode: "enabled",
+            defaultEnabled: "recommended",
+            payload: { url: "https://github.com/acme/web.git" },
+            repo: { url: "https://github.com/acme/web.git", localPath: "web" },
+            promptBody: null,
+            unavailableReason: null,
+            order: 0,
           },
         ],
-      }),
-    );
-    const { ResourcesTab } = await import("../resources-tab.js");
+        prompts: [],
+        skills: [],
+        mcp: [],
+        unavailable: [],
+      },
+      availableTeamResources: [
+        {
+          id: "repo-available",
+          organizationId: "org-1",
+          type: "repo",
+          scope: "team",
+          ownerAgentId: null,
+          name: "Opt-in repo",
+          repoCanonicalKey: null,
+          defaultEnabled: "available",
+          status: "active",
+          payload: { url: "https://github.com/acme/optin.git" },
+          createdBy: "member-1",
+          updatedBy: "member-1",
+          createdAt: NOW,
+          updatedAt: NOW,
+        },
+      ],
+    });
 
-    const container = await renderWithContext(<ResourcesTab />);
-    await waitForText(container, "Code repositories");
+    const container = await renderRouted(
+      <ResourceTypeSection type="repo" data={data} canEdit pending={false} onMutate={vi.fn()} />,
+    );
+
+    expect(container.textContent).toContain("Repositories");
+    expect(container.textContent).toContain("Team repo");
+    expect(container.textContent).toContain("https://github.com/acme/web.git -> web");
+    expect(container.querySelector('button[aria-label="Add Repo"]')).toBeTruthy();
 
     // Open the repo section's add menu (panel portals to document.body).
     await click(container.querySelector('button[aria-label="Add Repo"]'));

--- a/packages/web/src/pages/agent-detail/__tests__/usage-tab.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/usage-tab.test.tsx
@@ -271,7 +271,7 @@ describe("UsageTab", () => {
     expect(container.textContent).toContain("Recent turns");
     expect(container.textContent).toContain("Daily total tokens. Darker cells mean more usage.");
     expect(activityCells.find((cell) => cell.getAttribute("aria-label")?.includes("10.5K total tokens"))).toBeDefined();
-    expect(container.textContent).toContain("Last 10 turns from the last 30 days.");
+    expect(container.textContent).toContain("Your most recent turns from the last 30 days.");
     expect(container.textContent).toContain("Launch planning");
     expect(container.textContent).toContain("private chat");
     expect(container.textContent).toContain("claude-code/sonnet");

--- a/packages/web/src/pages/agent-detail/capability-section.tsx
+++ b/packages/web/src/pages/agent-detail/capability-section.tsx
@@ -8,7 +8,7 @@ import {
   type ResourceType,
   skillResourcePayloadSchema,
 } from "@first-tree/shared";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { type QueryClient, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Plus, Trash2 } from "lucide-react";
 import { type FormEvent, type ReactNode, useState } from "react";
 import { useNavigate } from "react-router";
@@ -45,6 +45,38 @@ export type AgentResourcesController = {
   saveError: unknown;
 };
 
+/**
+ * Shared success/error handlers for any mutation that writes the versioned
+ * `["agent-resources", uuid]` cache (the shared resource hook AND the Instructions
+ * tab's prompt-binding mutations). Centralized so every writer of this cache gets
+ * the same two protections, now that the page shell, Environment, Tools & skills,
+ * and Instructions all observe and write it:
+ *  - onSuccess cancels any in-flight GET before writing, so a stale response can't
+ *    resolve afterwards and clobber the version just written (which would desync
+ *    rows/badges and 409 the next mutation);
+ *  - onError refetches on a 409 so a retry uses the latest version instead of
+ *    dead-ending on the same stale expectedVersion.
+ */
+export function agentResourcesMutationHandlers(
+  queryClient: QueryClient,
+  uuid: string,
+  opts?: { onSuccessAfter?: () => void },
+): { onSuccess: (next: AgentResourcesOutput) => Promise<void>; onError: (err: unknown) => void } {
+  return {
+    onSuccess: async (next) => {
+      await queryClient.cancelQueries({ queryKey: ["agent-resources", uuid] });
+      queryClient.setQueryData(["agent-resources", uuid], next);
+      queryClient.invalidateQueries({ queryKey: ["agent-config", uuid] });
+      opts?.onSuccessAfter?.();
+    },
+    onError: (err) => {
+      if (err instanceof ApiError && err.status === 409) {
+        queryClient.invalidateQueries({ queryKey: ["agent-resources", uuid] });
+      }
+    },
+  };
+}
+
 export function useAgentResources(uuid: string, opts: { enabled: boolean }): AgentResourcesController {
   const queryClient = useQueryClient();
   const resourcesQuery = useQuery({
@@ -57,21 +89,7 @@ export function useAgentResources(uuid: string, opts: { enabled: boolean }): Age
       if (!resourcesQuery.data) throw new Error("resources not loaded");
       return updateAgentResources(uuid, { expectedVersion: resourcesQuery.data.version, bindings });
     },
-    onSuccess: async (next) => {
-      // Cancel any in-flight GET first: a stale response that started before this
-      // PATCH could otherwise resolve afterwards and clobber the version we just
-      // wrote, desyncing rows/badges and 409-ing the next mutation.
-      await queryClient.cancelQueries({ queryKey: ["agent-resources", uuid] });
-      queryClient.setQueryData(["agent-resources", uuid], next);
-      queryClient.invalidateQueries({ queryKey: ["agent-config", uuid] });
-    },
-    onError: (err) => {
-      // On a version conflict, refetch so a retry submits against the latest
-      // version instead of dead-ending on the same stale expectedVersion.
-      if (err instanceof ApiError && err.status === 409) {
-        queryClient.invalidateQueries({ queryKey: ["agent-resources", uuid] });
-      }
-    },
+    ...agentResourcesMutationHandlers(queryClient, uuid),
   });
   return {
     data: resourcesQuery.data,

--- a/packages/web/src/pages/agent-detail/capability-section.tsx
+++ b/packages/web/src/pages/agent-detail/capability-section.tsx
@@ -1,0 +1,490 @@
+import {
+  type AgentResourceBindingInput,
+  type AgentResourcesOutput,
+  deriveRepoLocalPath,
+  type EffectiveResourceRow,
+  noSecretMcpServerSchema,
+  type ResourceRow,
+  type ResourceType,
+  skillResourcePayloadSchema,
+} from "@first-tree/shared";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Plus, Trash2 } from "lucide-react";
+import { type FormEvent, type ReactNode, useState } from "react";
+import { useNavigate } from "react-router";
+import { getAgentResources, updateAgentResources } from "../../api/agent-resources.js";
+import { ApiError } from "../../api/client.js";
+import { Button } from "../../components/ui/button.js";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "../../components/ui/dialog.js";
+import { Input } from "../../components/ui/input.js";
+import { Label } from "../../components/ui/label.js";
+import { Popover } from "../../components/ui/popover.js";
+import { Section } from "../../components/ui/section.js";
+import { StatusGlyph } from "../../components/ui/status-glyph.js";
+import { typeLabelSingular } from "../settings/resource-editors.js";
+import { sourceLabel } from "./resource-source.js";
+
+/**
+ * Shared agent-resource (repo / skill / mcp) section, used by two tabs:
+ *   - Tools & skills tab (`resources-tab.tsx`) renders the `skill` + `mcp` sections.
+ *   - Environment tab (`runtime-tab.tsx`) renders the `repo` section.
+ *
+ * Both consume the SAME `["agent-resources", uuid]` React Query cache via
+ * `useAgentResources`, so a mutation on one tab is reflected on the other with
+ * no shell-level state lift. All resource bindings save IMMEDIATELY (optimistic,
+ * version-checked) — they are NOT part of the SaveBar draft.
+ */
+
+export type AgentResourcesController = {
+  data: AgentResourcesOutput | undefined;
+  isLoading: boolean;
+  error: unknown;
+  /** Submit the full bindings array; saves immediately. */
+  mutateBindings: (bindings: AgentResourceBindingInput[]) => void;
+  pending: boolean;
+  saveError: unknown;
+};
+
+export function useAgentResources(uuid: string, opts: { enabled: boolean }): AgentResourcesController {
+  const queryClient = useQueryClient();
+  const resourcesQuery = useQuery({
+    queryKey: ["agent-resources", uuid],
+    queryFn: () => getAgentResources(uuid),
+    enabled: opts.enabled,
+  });
+  const updateMut = useMutation({
+    mutationFn: (bindings: AgentResourceBindingInput[]) => {
+      if (!resourcesQuery.data) throw new Error("resources not loaded");
+      return updateAgentResources(uuid, { expectedVersion: resourcesQuery.data.version, bindings });
+    },
+    onSuccess: async (next) => {
+      // Cancel any in-flight GET first: a stale response that started before this
+      // PATCH could otherwise resolve afterwards and clobber the version we just
+      // wrote, desyncing rows/badges and 409-ing the next mutation.
+      await queryClient.cancelQueries({ queryKey: ["agent-resources", uuid] });
+      queryClient.setQueryData(["agent-resources", uuid], next);
+      queryClient.invalidateQueries({ queryKey: ["agent-config", uuid] });
+    },
+    onError: (err) => {
+      // On a version conflict, refetch so a retry submits against the latest
+      // version instead of dead-ending on the same stale expectedVersion.
+      if (err instanceof ApiError && err.status === 409) {
+        queryClient.invalidateQueries({ queryKey: ["agent-resources", uuid] });
+      }
+    },
+  });
+  return {
+    data: resourcesQuery.data,
+    isLoading: resourcesQuery.isLoading,
+    error: resourcesQuery.error,
+    mutateBindings: updateMut.mutate,
+    pending: updateMut.isPending,
+    saveError: updateMut.error,
+  };
+}
+
+/**
+ * One resource type's section (Section header + rows + add menu). Self-contained
+ * and presentational: it takes the loaded `data` and an `onMutate` callback, so
+ * it renders identically in the live tabs and in the DEV preview gallery.
+ */
+export function ResourceTypeSection(props: {
+  type: ResourceType;
+  data: AgentResourcesOutput;
+  canEdit: boolean;
+  pending: boolean;
+  onMutate: (bindings: AgentResourceBindingInput[]) => void;
+}) {
+  const [repoOpen, setRepoOpen] = useState(false);
+  const { type, data, canEdit, pending, onMutate } = props;
+  const currentBindings = data.bindings;
+  const activeBindingIds = new Set(currentBindings.map((b) => b.resourceId).filter((id): id is string => !!id));
+  // Opt-in team resources an agent can enable for itself. Repos are excluded:
+  // team repos are always On by default now (no per-repo Opt-in), so they never
+  // appear in the "Enable from team" list. skill / mcp still support opt-in.
+  const enableable = data.availableTeamResources.filter(
+    (resource) =>
+      resource.type === type &&
+      resource.defaultEnabled === "available" &&
+      resource.type !== "repo" &&
+      !activeBindingIds.has(resource.id),
+  );
+  const rows = data.effective[resourceBucket(type)];
+  return (
+    <Section
+      title={typeLabel(type)}
+      count={rows.length}
+      description={type === "mcp" ? "From the MCP servers you connect." : undefined}
+      action={
+        canEdit ? (
+          <AddCapabilityMenu
+            type={type}
+            enableable={enableable}
+            pending={pending}
+            onAddAgentRepo={() => setRepoOpen(true)}
+            onEnable={(resource) =>
+              onMutate([
+                ...currentBindings,
+                { type: resource.type, mode: "include", resourceId: resource.id, order: currentBindings.length + 1 },
+              ])
+            }
+          />
+        ) : null
+      }
+    >
+      <div>
+        {rows.length === 0 ? (
+          <p className="text-body" style={{ color: "var(--fg-4)", padding: "var(--sp-3) 0", margin: 0 }}>
+            No {emptyNoun(type)} enabled.
+          </p>
+        ) : (
+          rows.map((row) => (
+            <EffectiveRow
+              key={row.id}
+              row={row}
+              canEdit={canEdit}
+              bindings={currentBindings}
+              pending={pending}
+              onRemoveBinding={(bindingId) => onMutate(currentBindings.filter((b) => b.id !== bindingId))}
+              onDisable={(resourceId) =>
+                onMutate([
+                  // Drop any existing include/replace binding for this resource first —
+                  // otherwise the resolver sees include + disable and it stays enabled.
+                  ...currentBindings.filter((b) => b.resourceId !== resourceId && b.replacesResourceId !== resourceId),
+                  { type: row.type, mode: "disable", resourceId, order: currentBindings.length + 1 },
+                ])
+              }
+            />
+          ))
+        )}
+      </div>
+      {type === "repo" ? (
+        <AgentRepoDialog
+          open={repoOpen}
+          onOpenChange={setRepoOpen}
+          onSubmit={(repo) => {
+            onMutate([
+              ...currentBindings,
+              { type: "repo", mode: "include", agentExtraRepo: repo, order: currentBindings.length + 1 },
+            ]);
+            setRepoOpen(false);
+          }}
+        />
+      ) : null}
+    </Section>
+  );
+}
+
+/**
+ * Per-section add control. One "+ <Type>" trigger opens a context menu:
+ *   - repo: "Add agent repo" (a private, agent-scoped repo). Team repos are
+ *     always On by default (no per-repo Opt-in), so there's no "enable from
+ *     team" list for repos.
+ *   - skill / mcp: opt-in team resources to enable. These types have no
+ *     agent-private form (the binding model supports private repos and inline
+ *     prompts only), so when the team offers none the menu still routes the user
+ *     to Settings → Resources rather than dead-ending — every section's "+" is
+ *     always actionable.
+ */
+function AddCapabilityMenu(props: {
+  type: ResourceType;
+  enableable: ResourceRow[];
+  pending: boolean;
+  onAddAgentRepo: () => void;
+  onEnable: (resource: ResourceRow) => void;
+}) {
+  const navigate = useNavigate();
+  return (
+    <Popover
+      align="end"
+      trigger={({ open, toggle }) => {
+        const label = `Add ${typeLabelSingular(props.type)}`;
+        return (
+          <Button size="xs" variant="ghost" aria-expanded={open} aria-label={label} title={label} onClick={toggle}>
+            <Plus className="h-4 w-4" />
+          </Button>
+        );
+      }}
+    >
+      {({ close }) => (
+        <div style={{ padding: "var(--sp-1)", minWidth: "var(--sp-45)" }}>
+          {props.type === "repo" ? (
+            <MenuButton
+              onClick={() => {
+                props.onAddAgentRepo();
+                close();
+              }}
+            >
+              Add agent repo…
+            </MenuButton>
+          ) : null}
+          {props.enableable.length > 0 ? (
+            <>
+              <MenuLabel>Enable from team</MenuLabel>
+              {props.enableable.map((resource) => (
+                <MenuButton
+                  key={resource.id}
+                  disabled={props.pending}
+                  onClick={() => {
+                    props.onEnable(resource);
+                    close();
+                  }}
+                >
+                  {resource.name}
+                </MenuButton>
+              ))}
+            </>
+          ) : props.type !== "repo" ? (
+            <MenuLabel>No team {emptyNoun(props.type)} to enable yet.</MenuLabel>
+          ) : null}
+          <div style={{ borderTop: "var(--hairline) solid var(--border-faint)", margin: "var(--sp-1) 0" }} />
+          <MenuButton
+            muted
+            onClick={() => {
+              navigate("/settings/resources");
+              close();
+            }}
+          >
+            Manage in Settings → Resources
+          </MenuButton>
+        </div>
+      )}
+    </Popover>
+  );
+}
+
+function MenuLabel({ children }: { children: ReactNode }) {
+  return (
+    <p className="text-label" style={{ color: "var(--fg-4)", margin: 0, padding: "var(--sp-1) var(--sp-2)" }}>
+      {children}
+    </p>
+  );
+}
+
+function MenuButton(props: { children: ReactNode; muted?: boolean; disabled?: boolean; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      disabled={props.disabled}
+      className="flex w-full items-center text-left text-body transition-colors hover:bg-[var(--bg-hover)] disabled:pointer-events-none disabled:opacity-50"
+      style={{
+        gap: "var(--sp-2)",
+        padding: "var(--sp-1_5) var(--sp-2)",
+        borderRadius: "var(--radius-chip)",
+        border: 0,
+        background: "transparent",
+        color: props.muted ? "var(--fg-3)" : "var(--fg)",
+        cursor: "pointer",
+      }}
+      onClick={props.onClick}
+    >
+      {props.children}
+    </button>
+  );
+}
+
+function EffectiveRow(props: {
+  row: EffectiveResourceRow;
+  canEdit: boolean;
+  bindings: AgentResourceBindingInput[];
+  pending: boolean;
+  onRemoveBinding: (bindingId: string) => void;
+  onDisable: (resourceId: string) => void;
+}) {
+  // Unavailable rows surface the failure reason as the subtitle; everything
+  // else shows a type-appropriate detail. The subtitle never falls back to the
+  // raw `source` enum (that used to duplicate the source under skills/MCP rows).
+  const subtitle = props.row.mode === "unavailable" ? props.row.unavailableReason : rowSubtitle(props.row);
+  const status = statusMarker(props.row.mode);
+  const source = sourceLabel(props.row.source);
+  const canRemove = props.row.bindingId && props.bindings.some((b) => b.id === props.row.bindingId);
+  const canDisable = props.row.resourceId && props.row.source === "team_recommended" && props.row.mode === "enabled";
+  return (
+    <div
+      className="flex items-center gap-3"
+      style={{ padding: "var(--sp-3) 0", borderBottom: "var(--hairline) solid var(--border-faint)" }}
+    >
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <p className="m-0 text-body font-medium truncate" style={{ color: "var(--fg)" }}>
+            {props.row.name}
+          </p>
+          {status ? (
+            <span className="mono inline-flex items-center gap-1.5 text-caption" style={{ color: status.color }}>
+              <StatusGlyph colorVar={status.color} shape="dot" size={7} ariaLabel={status.label} />
+              {status.label}
+            </span>
+          ) : null}
+          <span className="text-caption" style={{ color: "var(--fg-4)" }}>
+            {source}
+          </span>
+        </div>
+        {subtitle ? (
+          <p className="m-0 text-caption truncate mono" style={{ color: "var(--fg-3)", marginTop: "var(--sp-0_5)" }}>
+            {subtitle}
+          </p>
+        ) : null}
+      </div>
+      {props.canEdit && canDisable ? (
+        <Button
+          size="xs"
+          variant="outline"
+          disabled={props.pending}
+          onClick={() => props.onDisable(props.row.resourceId ?? "")}
+        >
+          Disable
+        </Button>
+      ) : null}
+      {props.canEdit && canRemove ? (
+        <Button
+          size="xs"
+          variant="ghost"
+          disabled={props.pending}
+          aria-label={`Remove ${props.row.name}`}
+          onClick={() => props.onRemoveBinding(props.row.bindingId ?? "")}
+        >
+          <Trash2 className="h-4 w-4" />
+        </Button>
+      ) : null}
+    </div>
+  );
+}
+
+function AgentRepoDialog(props: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (repo: { url: string; name?: string; defaultBranch?: string }) => void;
+}) {
+  const [url, setUrl] = useState("");
+  const [name, setName] = useState("");
+  const [branch, setBranch] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  function submit(e: FormEvent) {
+    e.preventDefault();
+    const trimmed = url.trim();
+    if (!trimmed) {
+      setError("URL is required.");
+      return;
+    }
+    props.onSubmit({
+      url: trimmed,
+      ...(name.trim() ? { name: name.trim() } : { name: deriveRepoLocalPath(trimmed) }),
+      ...(branch.trim() ? { defaultBranch: branch.trim() } : {}),
+    });
+    setUrl("");
+    setName("");
+    setBranch("");
+  }
+  return (
+    <Dialog open={props.open} onOpenChange={props.onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add agent repository</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={submit} className="space-y-4">
+          <Field
+            id="agent-repo-url"
+            label="URL"
+            value={url}
+            onChange={setUrl}
+            placeholder="git@github.com:org/repo.git"
+            mono
+          />
+          <Field
+            id="agent-repo-name"
+            label="Name"
+            value={name}
+            onChange={setName}
+            placeholder={deriveRepoLocalPath(url) || "repo"}
+          />
+          <Field id="agent-repo-branch" label="Default branch" value={branch} onChange={setBranch} placeholder="main" />
+          {error ? (
+            <p className="text-body" style={{ color: "var(--state-error)" }}>
+              {error}
+            </p>
+          ) : null}
+          <DialogFooter>
+            <Button type="button" variant="ghost" onClick={() => props.onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit">Add</Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function Field(props: {
+  id: string;
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  mono?: boolean;
+}) {
+  return (
+    <div className="space-y-2">
+      <Label htmlFor={props.id}>{props.label}</Label>
+      <Input
+        id={props.id}
+        value={props.value}
+        onChange={(e) => props.onChange(e.target.value)}
+        placeholder={props.placeholder}
+        className={props.mono ? "mono" : undefined}
+      />
+    </div>
+  );
+}
+
+function resourceBucket(type: ResourceType): "repos" | "prompts" | "skills" | "mcp" {
+  if (type === "repo") return "repos";
+  if (type === "prompt") return "prompts";
+  if (type === "skill") return "skills";
+  return "mcp";
+}
+
+function typeLabel(type: ResourceType): string {
+  if (type === "repo") return "Repositories";
+  if (type === "prompt") return "Prompts";
+  if (type === "skill") return "Skills";
+  return "Integrations (MCP)";
+}
+
+function emptyNoun(type: ResourceType): string {
+  if (type === "repo") return "repositories";
+  if (type === "prompt") return "prompts";
+  if (type === "skill") return "skills";
+  return "MCP integrations";
+}
+
+/** One-line, human subtitle per resource type. Never the raw `source` enum. */
+function rowSubtitle(row: EffectiveResourceRow): string | null {
+  if (row.type === "repo") {
+    const url = row.repo?.url;
+    if (!url) return null;
+    return row.repo?.localPath ? `${url} -> ${row.repo.localPath}` : url;
+  }
+  if (row.type === "prompt") {
+    return row.promptBody ? `${row.promptBody.length} chars` : null;
+  }
+  if (row.type === "skill") {
+    const parsed = skillResourcePayloadSchema.safeParse(row.payload);
+    return parsed.success ? parsed.data.description : null;
+  }
+  const mcp = noSecretMcpServerSchema.safeParse(row.payload);
+  if (!mcp.success) return null;
+  return mcp.data.transport === "stdio" ? mcp.data.command : mcp.data.url;
+}
+
+/**
+ * Status marker — only rendered when a row deviates from the normal "enabled"
+ * state, so normal rows stay clean. `Off` (not `Disabled`) avoids colliding
+ * with the row's own `Disable` action button.
+ */
+function statusMarker(mode: EffectiveResourceRow["mode"]): { label: string; color: string } | null {
+  if (mode === "disabled") return { label: "Off", color: "var(--fg-4)" };
+  if (mode === "replaced") return { label: "Overridden", color: "var(--fg-4)" };
+  if (mode === "unavailable") return { label: "Can't load", color: "var(--state-error)" };
+  return null;
+}

--- a/packages/web/src/pages/agent-detail/prompt-tab.tsx
+++ b/packages/web/src/pages/agent-detail/prompt-tab.tsx
@@ -14,6 +14,7 @@ import { Popover } from "../../components/ui/popover.js";
 import { Section } from "../../components/ui/section.js";
 import { StatusGlyph } from "../../components/ui/status-glyph.js";
 import { Textarea } from "../../components/ui/textarea.js";
+import { agentResourcesMutationHandlers } from "./capability-section.js";
 import { useAgentDetailContext } from "./layout-context.js";
 import { sourceLabel } from "./resource-source.js";
 
@@ -36,11 +37,9 @@ export function PromptTab() {
         bindings: updatePromptBindings(resourcesQuery.data.bindings, editor, body),
       });
     },
-    onSuccess: (next) => {
-      queryClient.setQueryData(["agent-resources", ctx.uuid], next);
-      queryClient.invalidateQueries({ queryKey: ["agent-config", ctx.uuid] });
-      setEditor(null);
-    },
+    // Same hardening as the shared resource hook (stale-GET cancel + 409 refetch),
+    // since the shell now also observes this cache. `onSuccessAfter` closes the editor.
+    ...agentResourcesMutationHandlers(queryClient, ctx.uuid, { onSuccessAfter: () => setEditor(null) }),
   });
   // All prompt-binding management (enable / disable / remove / re-enable) goes
   // through one mutation that submits the full bindings array. The old Resources
@@ -50,10 +49,7 @@ export function PromptTab() {
       if (!resourcesQuery.data) throw new Error("prompt resources not loaded");
       return updateAgentResources(ctx.uuid, { expectedVersion: resourcesQuery.data.version, bindings });
     },
-    onSuccess: (next) => {
-      queryClient.setQueryData(["agent-resources", ctx.uuid], next);
-      queryClient.invalidateQueries({ queryKey: ["agent-config", ctx.uuid] });
-    },
+    ...agentResourcesMutationHandlers(queryClient, ctx.uuid),
   });
   if (ctx.isHuman) return <Navigate to="../profile" replace />;
   if (!ctx.config && ctx.configLoading) return null;

--- a/packages/web/src/pages/agent-detail/prompt-tab.tsx
+++ b/packages/web/src/pages/agent-detail/prompt-tab.tsx
@@ -4,17 +4,20 @@ import {
   PROMPT_APPEND_MAX_LENGTH,
 } from "@first-tree/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Pencil } from "lucide-react";
+import { Pencil, Plus } from "lucide-react";
 import { type FormEvent, type ReactNode, useEffect, useRef, useState } from "react";
-import { Navigate } from "react-router";
+import { Navigate, useNavigate } from "react-router";
 import { getAgentResources, updateAgentResources } from "../../api/agent-resources.js";
 import { Button } from "../../components/ui/button.js";
 import { Markdown } from "../../components/ui/markdown.js";
+import { Popover } from "../../components/ui/popover.js";
 import { Section } from "../../components/ui/section.js";
 import { StatusGlyph } from "../../components/ui/status-glyph.js";
 import { Textarea } from "../../components/ui/textarea.js";
 import { useAgentDetailContext } from "./layout-context.js";
 import { sourceLabel } from "./resource-source.js";
+
+type AvailablePrompt = { id: string; name: string };
 
 export function PromptTab() {
   const ctx = useAgentDetailContext();
@@ -118,9 +121,12 @@ export function PromptTab() {
         description="Team and your own instructions for this agent — toggle, customize, or add your own."
         action={
           canEditPrompt && !resourceError && !editor && resources ? (
-            <Button size="xs" variant="outline" onClick={() => openPromptEditor(null)}>
-              Add custom instructions
-            </Button>
+            <AddInstructionsMenu
+              available={availablePrompts}
+              pending={bindingMut.isPending}
+              onAddCustom={() => openPromptEditor(null)}
+              onEnable={enablePrompt}
+            />
           ) : null
         }
       >
@@ -156,46 +162,22 @@ export function PromptTab() {
           </p>
         ) : null}
       </Section>
-      {canEditPrompt && !resourceError && availablePrompts.length > 0 ? (
+      <div id="ad-effective-instructions">
         <Section
-          title="Available team instructions"
-          description="Optional instructions your team offers. Enable the ones you want this agent to use."
+          title="Effective instructions"
+          description="The full instructions this agent runs with, after your changes — team and custom, in order."
         >
-          {availablePrompts.map((resource) => (
-            <div
-              key={resource.id}
-              className="flex items-center justify-between gap-3"
-              style={{ padding: "var(--sp-3) 0", borderBottom: "var(--hairline) solid var(--border-faint)" }}
-            >
-              <p className="m-0 text-body font-medium truncate" style={{ color: "var(--fg)" }}>
-                {resource.name}
-              </p>
-              <Button
-                size="xs"
-                variant="outline"
-                disabled={bindingMut.isPending}
-                onClick={() => enablePrompt(resource.id)}
-              >
-                Enable
-              </Button>
-            </div>
-          ))}
+          <div style={{ paddingTop: "var(--sp-3)" }}>
+            <PromptPanel minHeight={prompt ? "10rem" : undefined} sunken={!prompt}>
+              {prompt ? (
+                <Markdown>{prompt}</Markdown>
+              ) : (
+                <span className="text-muted-foreground">No instructions yet.</span>
+              )}
+            </PromptPanel>
+          </div>
         </Section>
-      ) : null}
-      <Section
-        title="Effective instructions"
-        description="The full instructions this agent runs with, after your changes — team and custom, in order."
-      >
-        <div style={{ paddingTop: "var(--sp-3)" }}>
-          <PromptPanel minHeight={prompt ? "10rem" : undefined} sunken={!prompt}>
-            {prompt ? (
-              <Markdown>{prompt}</Markdown>
-            ) : (
-              <span className="text-muted-foreground">No instructions yet.</span>
-            )}
-          </PromptPanel>
-        </div>
-      </Section>
+      </div>
     </div>
   );
 }
@@ -316,6 +298,19 @@ function PromptResourceBlocks(props: {
   onRemoveBinding: (bindingId: string) => void;
   onEditBinding: (bindingId: string) => void;
 }) {
+  // Every instruction block collapses to a short summary by default and expands
+  // to its full body on demand — same affordance whether the block is enabled or
+  // inactive (disabled / overridden). This keeps the list scannable while the
+  // bottom "Effective instructions" panel stays the single full merged preview.
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(() => new Set());
+  const toggleExpand = (id: string) => {
+    setExpandedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
   const rows = enabledPromptRows(props.data);
   // Disabled / overridden prompts are hidden from the active list, but the user
   // must still be able to re-enable or revert them — render them below.
@@ -360,14 +355,14 @@ function PromptResourceBlocks(props: {
         action={action}
         separated={index > 0}
       >
-        {/* Only enabled rows are merged into the Effective preview, so only they
-            get the short summary; unavailable rows keep full text to stay inspectable. */}
         {isEditingRow ? (
           editorNode
-        ) : row.mode === "enabled" ? (
-          <PromptSummary body={row.promptBody ?? ""} />
         ) : (
-          <PromptBody body={row.promptBody ?? ""} />
+          <CollapsibleBody
+            body={row.promptBody ?? ""}
+            expanded={expandedIds.has(row.id)}
+            onToggle={() => toggleExpand(row.id)}
+          />
         )}
       </PromptResourceBlock>
     );
@@ -408,9 +403,11 @@ function PromptResourceBlocks(props: {
         action={action}
         separated={blocks.length > 0}
       >
-        {/* Inactive (disabled/overridden) prompts are NOT in the Effective preview,
-            so this row is the only place to inspect the full body — render it in full. */}
-        <PromptBody body={row.promptBody ?? ""} />
+        <CollapsibleBody
+          body={row.promptBody ?? ""}
+          expanded={expandedIds.has(row.id)}
+          onToggle={() => toggleExpand(row.id)}
+        />
       </PromptResourceBlock>,
     );
   }
@@ -566,25 +563,137 @@ function PromptBlockAction(props: { label: string; onClick: () => void; disabled
   );
 }
 
-// Active rows show only a short summary — their full merged text lives in the
-// "Effective instructions" preview at the bottom, so we don't render whole bodies twice.
-function PromptSummary(props: { body: string }) {
-  return props.body ? (
-    <p className="m-0 text-caption line-clamp-2" style={{ color: "var(--fg-3)" }}>
-      {props.body}
-    </p>
-  ) : (
-    <span className="text-muted-foreground">No instructions yet.</span>
+// One instruction block's body: a clamped summary by default, expandable to the
+// full Markdown. The expand toggle only appears when there's more to reveal than
+// the 2-line clamp shows (long body or multi-line), so short prompts stay clean.
+function CollapsibleBody(props: { body: string; expanded: boolean; onToggle: () => void }) {
+  if (!props.body) return <span className="text-muted-foreground">No instructions yet.</span>;
+  const canExpand = props.body.length > 120 || props.body.includes("\n");
+  return (
+    <div>
+      {props.expanded ? (
+        <Markdown>{props.body}</Markdown>
+      ) : (
+        <p className="m-0 text-caption line-clamp-2" style={{ color: "var(--fg-3)" }}>
+          {props.body}
+        </p>
+      )}
+      {canExpand ? <ExpandToggle expanded={props.expanded} onToggle={props.onToggle} /> : null}
+    </div>
   );
 }
 
-// Full body — used for inactive (disabled/overridden) rows, which are absent from
-// the Effective preview and so need their complete text inspectable here.
-function PromptBody(props: { body: string }) {
-  return props.body ? (
-    <Markdown>{props.body}</Markdown>
-  ) : (
-    <span className="text-muted-foreground">No instructions yet.</span>
+function ExpandToggle(props: { expanded: boolean; onToggle: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={props.onToggle}
+      aria-expanded={props.expanded}
+      className="mt-1 bg-transparent border-0 p-0 cursor-pointer text-caption font-medium transition-colors hover:text-[var(--fg)]"
+      style={{ color: "var(--fg-3)" }}
+    >
+      {props.expanded ? "Show less" : "Show full"}
+    </button>
+  );
+}
+
+// Per-section add control on the Instructions tab. One "+" trigger opens a menu:
+// add a custom inline instruction, enable an optional team instruction, or jump
+// to Settings → Resources. Mirrors the Tools & skills "Add" menu so the two add
+// paths (custom vs team) live in one place instead of a separate section.
+function AddInstructionsMenu(props: {
+  available: AvailablePrompt[];
+  pending: boolean;
+  onAddCustom: () => void;
+  onEnable: (resourceId: string) => void;
+}) {
+  const navigate = useNavigate();
+  return (
+    <Popover
+      align="end"
+      trigger={({ open, toggle }) => (
+        <Button
+          size="xs"
+          variant="outline"
+          aria-expanded={open}
+          aria-label="Add instructions"
+          title="Add instructions"
+          onClick={toggle}
+        >
+          <Plus className="h-3 w-3" />
+          Add
+        </Button>
+      )}
+    >
+      {({ close }) => (
+        <div style={{ padding: "var(--sp-1)", minWidth: "var(--sp-45)" }}>
+          <InstructionsMenuButton
+            onClick={() => {
+              props.onAddCustom();
+              close();
+            }}
+          >
+            Add custom instructions…
+          </InstructionsMenuButton>
+          {props.available.length > 0 ? (
+            <>
+              <p className="text-label" style={{ color: "var(--fg-4)", margin: 0, padding: "var(--sp-1) var(--sp-2)" }}>
+                Enable from team
+              </p>
+              {props.available.map((resource) => (
+                <InstructionsMenuButton
+                  key={resource.id}
+                  disabled={props.pending}
+                  onClick={() => {
+                    props.onEnable(resource.id);
+                    close();
+                  }}
+                >
+                  {resource.name}
+                </InstructionsMenuButton>
+              ))}
+            </>
+          ) : null}
+          <div style={{ borderTop: "var(--hairline) solid var(--border-faint)", margin: "var(--sp-1) 0" }} />
+          <InstructionsMenuButton
+            muted
+            onClick={() => {
+              navigate("/settings/resources");
+              close();
+            }}
+          >
+            Manage in Settings → Resources
+          </InstructionsMenuButton>
+        </div>
+      )}
+    </Popover>
+  );
+}
+
+function InstructionsMenuButton(props: {
+  children: ReactNode;
+  muted?: boolean;
+  disabled?: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      disabled={props.disabled}
+      className="flex w-full items-center text-left text-body transition-colors hover:bg-[var(--bg-hover)] disabled:pointer-events-none disabled:opacity-50"
+      style={{
+        gap: "var(--sp-2)",
+        padding: "var(--sp-1_5) var(--sp-2)",
+        borderRadius: "var(--radius-chip)",
+        border: 0,
+        background: "transparent",
+        color: props.muted ? "var(--fg-3)" : "var(--fg)",
+        cursor: "pointer",
+      }}
+      onClick={props.onClick}
+    >
+      {props.children}
+    </button>
   );
 }
 

--- a/packages/web/src/pages/agent-detail/resources-tab.tsx
+++ b/packages/web/src/pages/agent-detail/resources-tab.tsx
@@ -1,472 +1,52 @@
-import {
-  type AgentResourceBindingInput,
-  deriveRepoLocalPath,
-  type EffectiveResourceRow,
-  noSecretMcpServerSchema,
-  type ResourceRow,
-  type ResourceType,
-  skillResourcePayloadSchema,
-} from "@first-tree/shared";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Plus, Trash2 } from "lucide-react";
-import { type FormEvent, type ReactNode, useState } from "react";
-import { useNavigate } from "react-router";
-import { getAgentResources, updateAgentResources } from "../../api/agent-resources.js";
-import { Button } from "../../components/ui/button.js";
-import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "../../components/ui/dialog.js";
-import { Input } from "../../components/ui/input.js";
-import { Label } from "../../components/ui/label.js";
-import { Popover } from "../../components/ui/popover.js";
-import { Section } from "../../components/ui/section.js";
-import { StatusGlyph } from "../../components/ui/status-glyph.js";
-import { typeLabelSingular } from "../settings/resource-editors.js";
+import type { ResourceType } from "@first-tree/shared";
+import { ResourceTypeSection, useAgentResources } from "./capability-section.js";
 import { useAgentDetailContext } from "./layout-context.js";
-import { sourceLabel } from "./resource-source.js";
 
-// Prompts are managed in the Prompt tab, not here — Capabilities lists only
-// what the agent can use: code repos, skills, and MCP integrations.
-const RESOURCE_TYPES: ResourceType[] = ["repo", "skill", "mcp"];
+// The "Tools & skills" tab. Code repositories moved to the Environment tab
+// (they're part of the workspace the agent runs in); prompts are managed in the
+// Instructions tab. So this tab lists only skills and MCP integrations.
+const RESOURCE_TYPES: ResourceType[] = ["skill", "mcp"];
 
 export function ResourcesTab() {
   const ctx = useAgentDetailContext();
-  const queryClient = useQueryClient();
-  const [repoOpen, setRepoOpen] = useState(false);
-  const resourcesQuery = useQuery({
-    queryKey: ["agent-resources", ctx.uuid],
-    queryFn: () => getAgentResources(ctx.uuid),
-    enabled: !!ctx.uuid && !ctx.isHuman,
-  });
-  const updateMut = useMutation({
-    mutationFn: (bindings: AgentResourceBindingInput[]) => {
-      if (!resourcesQuery.data) throw new Error("resources not loaded");
-      return updateAgentResources(ctx.uuid, { expectedVersion: resourcesQuery.data.version, bindings });
-    },
-    onSuccess: (next) => {
-      queryClient.setQueryData(["agent-resources", ctx.uuid], next);
-      queryClient.invalidateQueries({ queryKey: ["agent-config", ctx.uuid] });
-    },
-  });
+  const resources = useAgentResources(ctx.uuid, { enabled: !!ctx.uuid && !ctx.isHuman });
 
   if (ctx.isHuman) return null;
-  if (resourcesQuery.isLoading) {
+  if (resources.isLoading) {
     return (
       <p className="text-body" style={{ color: "var(--fg-3)" }}>
         Loading...
       </p>
     );
   }
-  if (resourcesQuery.error || !resourcesQuery.data) {
+  if (resources.error || !resources.data) {
     return (
       <p className="text-body" style={{ color: "var(--state-error)" }}>
-        {resourcesQuery.error instanceof Error ? resourcesQuery.error.message : "Failed to load resources"}
+        {resources.error instanceof Error ? resources.error.message : "Failed to load resources"}
       </p>
     );
   }
 
-  const data = resourcesQuery.data;
+  const data = resources.data;
   const canEdit = ctx.canManageAgent && ctx.agent.status === "active";
-  const currentBindings = data.bindings;
-  const mutateBindings = (next: AgentResourceBindingInput[]) => updateMut.mutate(next);
-  const activeBindingIds = new Set(currentBindings.map((b) => b.resourceId).filter((id): id is string => !!id));
-  // Opt-in team resources an agent can enable for itself. Repos are excluded:
-  // team repos are always On by default now (no per-repo Opt-in), so they never
-  // appear in the "Enable from team" list. skill / mcp still support opt-in.
-  const available = data.availableTeamResources.filter(
-    (resource) =>
-      resource.defaultEnabled === "available" && resource.type !== "repo" && !activeBindingIds.has(resource.id),
-  );
 
   return (
     <div className="flex flex-col" style={{ gap: "var(--sp-5)" }}>
       {RESOURCE_TYPES.map((type) => (
-        <Section
+        <ResourceTypeSection
           key={type}
-          title={typeLabel(type)}
-          count={data.effective[resourceBucket(type)].length}
-          description={type === "mcp" ? "Tools come from the MCP servers connected here." : undefined}
-          action={
-            canEdit ? (
-              <AddCapabilityMenu
-                type={type}
-                enableable={available.filter((resource) => resource.type === type)}
-                pending={updateMut.isPending}
-                onAddAgentRepo={() => setRepoOpen(true)}
-                onEnable={(resource) =>
-                  mutateBindings([
-                    ...currentBindings,
-                    {
-                      type: resource.type,
-                      mode: "include",
-                      resourceId: resource.id,
-                      order: currentBindings.length + 1,
-                    },
-                  ])
-                }
-              />
-            ) : null
-          }
-        >
-          <div>
-            {data.effective[resourceBucket(type)].length === 0 ? (
-              <p className="text-body" style={{ color: "var(--fg-4)", padding: "var(--sp-3) 0", margin: 0 }}>
-                No {emptyNoun(type)} enabled.
-              </p>
-            ) : (
-              data.effective[resourceBucket(type)].map((row) => (
-                <EffectiveRow
-                  key={row.id}
-                  row={row}
-                  canEdit={canEdit}
-                  bindings={currentBindings}
-                  pending={updateMut.isPending}
-                  onRemoveBinding={(bindingId) => mutateBindings(currentBindings.filter((b) => b.id !== bindingId))}
-                  onDisable={(resourceId) =>
-                    mutateBindings([
-                      // Drop any existing include/replace binding for this resource first —
-                      // otherwise the resolver sees include + disable and it stays enabled.
-                      ...currentBindings.filter(
-                        (b) => b.resourceId !== resourceId && b.replacesResourceId !== resourceId,
-                      ),
-                      { type: row.type, mode: "disable", resourceId, order: currentBindings.length + 1 },
-                    ])
-                  }
-                />
-              ))
-            )}
-          </div>
-        </Section>
+          type={type}
+          data={data}
+          canEdit={canEdit}
+          pending={resources.pending}
+          onMutate={resources.mutateBindings}
+        />
       ))}
-      {updateMut.error ? (
+      {resources.saveError ? (
         <p className="text-body" style={{ color: "var(--state-error)" }}>
-          {updateMut.error instanceof Error ? updateMut.error.message : "Failed to save resources"}
+          {resources.saveError instanceof Error ? resources.saveError.message : "Failed to save resources"}
         </p>
       ) : null}
-      <AgentRepoDialog
-        open={repoOpen}
-        onOpenChange={setRepoOpen}
-        onSubmit={(repo) => {
-          mutateBindings([
-            ...currentBindings,
-            { type: "repo", mode: "include", agentExtraRepo: repo, order: currentBindings.length + 1 },
-          ]);
-          setRepoOpen(false);
-        }}
-      />
     </div>
   );
-}
-
-/**
- * Per-section add control on the agent Capabilities tab. One "+ <Type>" trigger
- * opens a context menu:
- *   - repo: "Add agent repo" (a private, agent-scoped repo). Team repos are
- *     always On by default (no per-repo Opt-in), so there's no "enable from
- *     team" list for repos.
- *   - skill / mcp: opt-in team resources to enable. These types have no
- *     agent-private form (the binding model supports private repos and inline
- *     prompts only), so when the team offers none the menu still routes the user
- *     to Settings → Resources rather than dead-ending — every section's "+" is
- *     always actionable.
- */
-function AddCapabilityMenu(props: {
-  type: ResourceType;
-  enableable: ResourceRow[];
-  pending: boolean;
-  onAddAgentRepo: () => void;
-  onEnable: (resource: ResourceRow) => void;
-}) {
-  const navigate = useNavigate();
-  return (
-    <Popover
-      align="end"
-      trigger={({ open, toggle }) => {
-        const label = `Add ${typeLabelSingular(props.type)}`;
-        return (
-          <Button size="xs" variant="ghost" aria-expanded={open} aria-label={label} title={label} onClick={toggle}>
-            <Plus className="h-4 w-4" />
-          </Button>
-        );
-      }}
-    >
-      {({ close }) => (
-        <div style={{ padding: "var(--sp-1)", minWidth: "var(--sp-45)" }}>
-          {props.type === "repo" ? (
-            <MenuButton
-              onClick={() => {
-                props.onAddAgentRepo();
-                close();
-              }}
-            >
-              Add agent repo…
-            </MenuButton>
-          ) : null}
-          {props.enableable.length > 0 ? (
-            <>
-              <MenuLabel>Enable from team</MenuLabel>
-              {props.enableable.map((resource) => (
-                <MenuButton
-                  key={resource.id}
-                  disabled={props.pending}
-                  onClick={() => {
-                    props.onEnable(resource);
-                    close();
-                  }}
-                >
-                  {resource.name}
-                </MenuButton>
-              ))}
-            </>
-          ) : props.type !== "repo" ? (
-            <MenuLabel>No team {emptyNoun(props.type)} to enable yet.</MenuLabel>
-          ) : null}
-          <div style={{ borderTop: "var(--hairline) solid var(--border-faint)", margin: "var(--sp-1) 0" }} />
-          <MenuButton
-            muted
-            onClick={() => {
-              navigate("/settings/resources");
-              close();
-            }}
-          >
-            Manage in Settings → Resources
-          </MenuButton>
-        </div>
-      )}
-    </Popover>
-  );
-}
-
-function MenuLabel({ children }: { children: ReactNode }) {
-  return (
-    <p className="text-label" style={{ color: "var(--fg-4)", margin: 0, padding: "var(--sp-1) var(--sp-2)" }}>
-      {children}
-    </p>
-  );
-}
-
-function MenuButton(props: { children: ReactNode; muted?: boolean; disabled?: boolean; onClick: () => void }) {
-  return (
-    <button
-      type="button"
-      disabled={props.disabled}
-      className="flex w-full items-center text-left text-body transition-colors hover:bg-[var(--bg-hover)] disabled:pointer-events-none disabled:opacity-50"
-      style={{
-        gap: "var(--sp-2)",
-        padding: "var(--sp-1_5) var(--sp-2)",
-        borderRadius: "var(--radius-chip)",
-        border: 0,
-        background: "transparent",
-        color: props.muted ? "var(--fg-3)" : "var(--fg)",
-        cursor: "pointer",
-      }}
-      onClick={props.onClick}
-    >
-      {props.children}
-    </button>
-  );
-}
-
-function EffectiveRow(props: {
-  row: EffectiveResourceRow;
-  canEdit: boolean;
-  bindings: AgentResourceBindingInput[];
-  pending: boolean;
-  onRemoveBinding: (bindingId: string) => void;
-  onDisable: (resourceId: string) => void;
-}) {
-  // Unavailable rows surface the failure reason as the subtitle; everything
-  // else shows a type-appropriate detail. The subtitle never falls back to the
-  // raw `source` enum (that used to duplicate the source under skills/MCP rows).
-  const subtitle = props.row.mode === "unavailable" ? props.row.unavailableReason : rowSubtitle(props.row);
-  const status = statusMarker(props.row.mode);
-  const source = sourceLabel(props.row.source);
-  const canRemove = props.row.bindingId && props.bindings.some((b) => b.id === props.row.bindingId);
-  const canDisable = props.row.resourceId && props.row.source === "team_recommended" && props.row.mode === "enabled";
-  return (
-    <div
-      className="flex items-center gap-3"
-      style={{ padding: "var(--sp-3) 0", borderBottom: "var(--hairline) solid var(--border-faint)" }}
-    >
-      <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-2">
-          <p className="m-0 text-body font-medium truncate" style={{ color: "var(--fg)" }}>
-            {props.row.name}
-          </p>
-          {status ? (
-            <span className="mono inline-flex items-center gap-1.5 text-caption" style={{ color: status.color }}>
-              <StatusGlyph colorVar={status.color} shape="dot" size={7} ariaLabel={status.label} />
-              {status.label}
-            </span>
-          ) : null}
-          <span className="text-caption" style={{ color: "var(--fg-4)" }}>
-            {source}
-          </span>
-        </div>
-        {subtitle ? (
-          <p className="m-0 text-caption truncate mono" style={{ color: "var(--fg-3)", marginTop: "var(--sp-0_5)" }}>
-            {subtitle}
-          </p>
-        ) : null}
-      </div>
-      {props.canEdit && canDisable ? (
-        <Button
-          size="xs"
-          variant="outline"
-          disabled={props.pending}
-          onClick={() => props.onDisable(props.row.resourceId ?? "")}
-        >
-          Disable
-        </Button>
-      ) : null}
-      {props.canEdit && canRemove ? (
-        <Button
-          size="xs"
-          variant="ghost"
-          disabled={props.pending}
-          aria-label={`Remove ${props.row.name}`}
-          onClick={() => props.onRemoveBinding(props.row.bindingId ?? "")}
-        >
-          <Trash2 className="h-4 w-4" />
-        </Button>
-      ) : null}
-    </div>
-  );
-}
-
-function AgentRepoDialog(props: {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  onSubmit: (repo: { url: string; name?: string; defaultBranch?: string }) => void;
-}) {
-  const [url, setUrl] = useState("");
-  const [name, setName] = useState("");
-  const [branch, setBranch] = useState("");
-  const [error, setError] = useState<string | null>(null);
-  function submit(e: FormEvent) {
-    e.preventDefault();
-    const trimmed = url.trim();
-    if (!trimmed) {
-      setError("URL is required.");
-      return;
-    }
-    props.onSubmit({
-      url: trimmed,
-      ...(name.trim() ? { name: name.trim() } : { name: deriveRepoLocalPath(trimmed) }),
-      ...(branch.trim() ? { defaultBranch: branch.trim() } : {}),
-    });
-    setUrl("");
-    setName("");
-    setBranch("");
-  }
-  return (
-    <Dialog open={props.open} onOpenChange={props.onOpenChange}>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Add agent repository</DialogTitle>
-        </DialogHeader>
-        <form onSubmit={submit} className="space-y-4">
-          <Field
-            id="agent-repo-url"
-            label="URL"
-            value={url}
-            onChange={setUrl}
-            placeholder="git@github.com:org/repo.git"
-            mono
-          />
-          <Field
-            id="agent-repo-name"
-            label="Name"
-            value={name}
-            onChange={setName}
-            placeholder={deriveRepoLocalPath(url) || "repo"}
-          />
-          <Field id="agent-repo-branch" label="Default branch" value={branch} onChange={setBranch} placeholder="main" />
-          {error ? (
-            <p className="text-body" style={{ color: "var(--state-error)" }}>
-              {error}
-            </p>
-          ) : null}
-          <DialogFooter>
-            <Button type="button" variant="ghost" onClick={() => props.onOpenChange(false)}>
-              Cancel
-            </Button>
-            <Button type="submit">Add</Button>
-          </DialogFooter>
-        </form>
-      </DialogContent>
-    </Dialog>
-  );
-}
-
-function Field(props: {
-  id: string;
-  label: string;
-  value: string;
-  onChange: (value: string) => void;
-  placeholder?: string;
-  mono?: boolean;
-}) {
-  return (
-    <div className="space-y-2">
-      <Label htmlFor={props.id}>{props.label}</Label>
-      <Input
-        id={props.id}
-        value={props.value}
-        onChange={(e) => props.onChange(e.target.value)}
-        placeholder={props.placeholder}
-        className={props.mono ? "mono" : undefined}
-      />
-    </div>
-  );
-}
-
-function resourceBucket(type: ResourceType): "repos" | "prompts" | "skills" | "mcp" {
-  if (type === "repo") return "repos";
-  if (type === "prompt") return "prompts";
-  if (type === "skill") return "skills";
-  return "mcp";
-}
-
-function typeLabel(type: ResourceType): string {
-  if (type === "repo") return "Code repositories";
-  if (type === "prompt") return "Prompts";
-  if (type === "skill") return "Skills";
-  return "Integrations (MCP)";
-}
-
-function emptyNoun(type: ResourceType): string {
-  if (type === "repo") return "code repositories";
-  if (type === "prompt") return "prompts";
-  if (type === "skill") return "skills";
-  return "MCP integrations";
-}
-
-/** One-line, human subtitle per resource type. Never the raw `source` enum. */
-function rowSubtitle(row: EffectiveResourceRow): string | null {
-  if (row.type === "repo") {
-    const url = row.repo?.url;
-    if (!url) return null;
-    return row.repo?.localPath ? `${url} -> ${row.repo.localPath}` : url;
-  }
-  if (row.type === "prompt") {
-    return row.promptBody ? `${row.promptBody.length} chars` : null;
-  }
-  if (row.type === "skill") {
-    const parsed = skillResourcePayloadSchema.safeParse(row.payload);
-    return parsed.success ? parsed.data.description : null;
-  }
-  const mcp = noSecretMcpServerSchema.safeParse(row.payload);
-  if (!mcp.success) return null;
-  return mcp.data.transport === "stdio" ? mcp.data.command : mcp.data.url;
-}
-
-/**
- * Status marker — only rendered when a row deviates from the normal "enabled"
- * state, so normal rows stay clean. `Off` (not `Disabled`) avoids colliding
- * with the row's own `Disable` action button.
- */
-function statusMarker(mode: EffectiveResourceRow["mode"]): { label: string; color: string } | null {
-  if (mode === "disabled") return { label: "Off", color: "var(--fg-4)" };
-  if (mode === "replaced") return { label: "Overridden", color: "var(--fg-4)" };
-  if (mode === "unavailable") return { label: "Can't load", color: "var(--state-error)" };
-  return null;
 }

--- a/packages/web/src/pages/agent-detail/runtime-tab.tsx
+++ b/packages/web/src/pages/agent-detail/runtime-tab.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { Navigate } from "react-router";
+import { ResourceTypeSection, useAgentResources } from "./capability-section.js";
 import { EnvSection } from "./env-section.js";
 import { useAgentDetailContext } from "./layout-context.js";
 import { ModelSection } from "./model-section.js";
@@ -14,6 +15,15 @@ export function RuntimeTab() {
     return (exceptKey: string | null): ReadonlySet<string> =>
       new Set(active.filter((i) => i.key !== exceptKey).map((i) => i.value.key));
   }, [ctx.draft.draft.env]);
+  // Code repositories are part of the workspace this agent runs in, so they live
+  // on Environment now (not Tools & skills). Unlike model/effort/env, repo
+  // changes save IMMEDIATELY through the agent-resources API — they're NOT part
+  // of the SaveBar draft. The shared `["agent-resources", uuid]` cache keeps this
+  // in sync with the Tools & skills tab (skills + MCP).
+  // Gate on canEditConfig (not just !isHuman): non-editors hit the redirect
+  // below, so there's no point firing an agent-resources GET for them.
+  const repos = useAgentResources(ctx.uuid, { enabled: !!ctx.uuid && ctx.canEditConfig });
+  const canEditResources = ctx.canManageAgent && ctx.agent.status === "active";
   // Human agents (and any role without canEditConfig) have no runtime to
   // configure. The tab is hidden from buildTabs, but a stale deep link to
   // /agents/:uuid/runtime would otherwise render a blank page; redirect to
@@ -67,6 +77,30 @@ export function RuntimeTab() {
           }
         />
       )}
+      <div id={sectionAnchorId("git")} style={{ marginTop: "var(--sp-8)" }}>
+        {repos.isLoading ? (
+          <div className="text-body" style={{ color: "var(--fg-3)" }}>
+            Loading repositories…
+          </div>
+        ) : repos.error || !repos.data ? (
+          <div className="text-body" style={{ color: "var(--state-error)" }}>
+            {repos.error instanceof Error ? repos.error.message : "Failed to load repositories"}
+          </div>
+        ) : (
+          <ResourceTypeSection
+            type="repo"
+            data={repos.data}
+            canEdit={canEditResources}
+            pending={repos.pending}
+            onMutate={repos.mutateBindings}
+          />
+        )}
+        {repos.saveError ? (
+          <p className="text-body" style={{ color: "var(--state-error)", margin: "var(--sp-2) 0 0" }}>
+            {repos.saveError instanceof Error ? repos.saveError.message : "Failed to save repositories"}
+          </p>
+        ) : null}
+      </div>
       {ctx.config && (
         <div id={sectionAnchorId("env")} style={{ marginTop: "var(--sp-8)" }}>
           <EnvSection

--- a/packages/web/src/pages/agent-detail/usage-tab.tsx
+++ b/packages/web/src/pages/agent-detail/usage-tab.tsx
@@ -1,14 +1,20 @@
 import type { UsageAgentSummary, UsageTurnRow } from "@first-tree/shared";
 import { useQuery } from "@tanstack/react-query";
-import { type CSSProperties, type ReactElement, type ReactNode, useMemo, useState } from "react";
+import { type CSSProperties, type ReactElement, type ReactNode, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router";
 import { getAgentUsageSummary, getAgentUsageTurns } from "../../api/usage.js";
+import { Button } from "../../components/ui/button.js";
 import { Section } from "../../components/ui/section.js";
 import { formatCompactCount, formatRelative } from "../../lib/utils.js";
 import { useAgentDetailContext } from "./layout-context.js";
 
 const ACTIVITY_GRID_DAYS = 90;
 const RECENT_TURNS_LIMIT = 10;
+// "Show more" grows the same single query's page size (the turns endpoint caps
+// at 200 server-side) rather than accumulating cursor pages — simpler, and the
+// volumes here are small.
+const TURNS_STEP = 20;
+const MAX_TURNS = 200;
 const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 const WEEKDAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 // Calendar columns are Sunday-first (row index 0 = Sunday, matching JS
@@ -38,13 +44,20 @@ export function UsageTab(): ReactElement {
     refetchInterval: 60_000,
     staleTime: 30_000,
   });
+  const [turnsLimit, setTurnsLimit] = useState(RECENT_TURNS_LIMIT);
+  // Tracks only a user-triggered "Show more" so the button shows "Loading…" for
+  // that, not for the silent 60s background refetch (which also flips isFetching).
+  const [growing, setGrowing] = useState(false);
   const turnsQuery = useQuery({
-    queryKey: ["usage-turns", ctx.agent.uuid, "30d", "first10"],
-    queryFn: () => getAgentUsageTurns(ctx.agent.uuid, { window: "30d", limit: RECENT_TURNS_LIMIT }),
+    queryKey: ["usage-turns", ctx.agent.uuid, "30d", turnsLimit],
+    queryFn: () => getAgentUsageTurns(ctx.agent.uuid, { window: "30d", limit: turnsLimit }),
     enabled: !ctx.isHuman,
     refetchInterval: 60_000,
     staleTime: 30_000,
   });
+  useEffect(() => {
+    if (!turnsQuery.isFetching) setGrowing(false);
+  }, [turnsQuery.isFetching]);
 
   if (ctx.isHuman) {
     return (
@@ -64,6 +77,12 @@ export function UsageTab(): ReactElement {
         rows={turnsQuery.data?.rows ?? []}
         isLoading={turnsQuery.isLoading}
         isError={turnsQuery.isError}
+        hasMore={turnsQuery.data?.nextCursor != null && turnsLimit < MAX_TURNS}
+        loadingMore={growing}
+        onShowMore={() => {
+          setGrowing(true);
+          setTurnsLimit((n) => Math.min(MAX_TURNS, n + TURNS_STEP));
+        }}
       />
     </>
   );
@@ -294,13 +313,19 @@ function RecentTurnsBlock({
   rows,
   isLoading,
   isError,
+  hasMore,
+  loadingMore,
+  onShowMore,
 }: {
   rows: UsageTurnRow[];
   isLoading: boolean;
   isError: boolean;
+  hasMore: boolean;
+  loadingMore: boolean;
+  onShowMore: () => void;
 }): ReactElement {
   return (
-    <Section title="Recent turns" description={`Last ${RECENT_TURNS_LIMIT} turns from the last 30 days.`}>
+    <Section title="Recent turns" description="Your most recent turns from the last 30 days.">
       {isError ? (
         <UsagePlaceholder tone="error">Failed to load recent turns.</UsagePlaceholder>
       ) : isLoading ? (
@@ -308,7 +333,16 @@ function RecentTurnsBlock({
       ) : rows.length === 0 ? (
         <UsagePlaceholder>No turns recorded in the last 30 days.</UsagePlaceholder>
       ) : (
-        <TurnsTable rows={rows} />
+        <>
+          <TurnsTable rows={rows} />
+          {hasMore ? (
+            <div className="flex justify-center" style={{ marginTop: "var(--sp-3)" }}>
+              <Button size="xs" variant="outline" disabled={loadingMore} onClick={onShowMore}>
+                {loadingMore ? "Loading…" : "Show more"}
+              </Button>
+            </div>
+          ) : null}
+        </>
       )}
     </Section>
   );

--- a/packages/web/src/pages/agent-detail/use-legacy-anchor-redirect.ts
+++ b/packages/web/src/pages/agent-detail/use-legacy-anchor-redirect.ts
@@ -18,7 +18,8 @@ const HASH_TO_TAB: Record<string, string> = {
   "agent-cfg-mcp": "capabilities",
   "ad-advanced": "capabilities",
   "agent-cfg-env": "runtime",
-  "agent-cfg-git": "capabilities",
+  // Repos moved to the Environment (runtime) tab.
+  "agent-cfg-git": "runtime",
   // Lifecycle lives at the bottom of Profile — keep the danger anchor alive.
   "ad-danger": "profile",
 };


### PR DESCRIPTION
## What & why

PR1 of 3 in the agent-detail page optimization (structure & navigation). Design is locked; this PR is the IA / layout pass. PR2 (save semantics + leave-guard) and PR3 (agent switcher) follow.

**Key correction baked in:** repos / skills / MCP are saved **immediately** via the agent-resources binding API (not the SaveBar config draft) — only model/effort/env are draft-backed. The old `git`/`mcp` draft-section components were already dead (test-only). This PR treats repos as immediate-save accordingly.

## Changes

- **IA labels:** Runtime → **Environment**, Capabilities → **Tools & skills**. Route `path`s and draft/anchor keys are unchanged to preserve deep links; `SECTION_TO_TAB.git` and the legacy `agent-cfg-git` anchor now resolve to the `runtime` tab.
- **Repos → Environment:** moved out of Tools & skills into an independent **Repositories** section on Environment (kept separate from env vars so the tab doesn't mix immediate-save and draft semantics in one block — PR2 will formalize the zoning). Extracted a shared `capability-section.tsx` (`useAgentResources` hook + presentational `ResourceTypeSection`) consumed by both tabs via the same `["agent-resources", uuid]` React Query cache. No shell-state lift.
- **Instructions:** enabled and disabled blocks now collapse to a 2-line summary with a **Show full** toggle (unified disclosure); the standalone "Available team instructions" section is folded into the section **Add** menu (custom + enable-from-team + Settings).
- **Tools & skills:** mcp subtitle → "From the MCP servers you connect."; tab badge shows the effective skill+mcp count (the shell fetches `agent-resources` once, `enabled: !isHuman`, same tier as agent-config/client-status; tabs become cache hits).
- **TabBar:** `height` → `minHeight` (fixes a spurious vertical scrollbar); overflow edge fades; `scrollIntoView` on the active tab for programmatic navigation (SaveBar "Jump to" / deep links); hidden when there's only one tab.
- **Usage:** "Show more" grows the turns page size (single query, capped 200 server-side).
- **Hardening (from review):** the shared resource mutation cancels in-flight GETs on success (prevents a stale GET clobbering the just-written version) and refetches on 409 (so a retry uses the latest version).
- Synced the DEV preview gallery + DOM/SSR tests.

## Out of scope (follow-ups)

- In-tab **section-nav** (the heaviest part of the TabBar work) is split into a small tail PR to keep this one reviewable.
- Dead `git-section.tsx` / `mcp-section.tsx` (+ their draft branches) left in place — separate cleanup PR.

## Review & testing

- **2 independent review rounds (codex review + challenge):** found and fixed a missing `currentTabKey` effect dependency (Jump-to/deep-link didn't scroll the active tab into view), two shared-cache races (in-flight GET clobber, 409 dead-end), a redundant repos fetch for non-editors, fade-recompute on badge width change, plus `aria-expanded` and a Show-more/background-refetch distinction. No P1s.
- **UI tested** via the DEV `/preview/agent-detail` gallery (headless browser): Repositories on Environment, Tools & skills (skills+MCP only), Instructions collapse/expand + Add menu, Effective instructions.
- **Gates (full repo):** `biome check` (1189 files) ✓ · typecheck (11 packages) ✓ · `lint:tokens` ✓ · web tests **688/688** ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
