### PR TITLE
feat(client): workspace hygiene — state-based cleanup + one-shot legacy migrations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,6 +226,12 @@ jobs:
           # - docs/migration/**                          : migration tables show old↔new
           # - .github/workflows/ci.yml                   : this file's own regex literals (self-immunity via [f])
           # - packages/server/drizzle/*.sql              : SQL migrations are immutable historical artifacts
+          # - packages/client/src/runtime/workspace-migrations.ts        : PR #869 hardcoded `v1-retired-source-repo-first-tree-hub`
+          #     migration whose only job is to clean up the retired clone — the
+          #     dirname is the matching key, so the literal cannot be avoided.
+          # - packages/client/src/__tests__/workspace-migrations.test.ts : fixtures for the above migration.
+          # - packages/client/src/runtime/agent-bootstrap.ts             : header comment naming the migration target.
+          # - docs/development/agent-workspace-state.md                  : durable contract doc names the retired repo.
           hits=$(grep -rEn \
             --exclude-dir=migration \
             --exclude-dir=node_modules \
@@ -233,7 +239,7 @@ jobs:
             --include='*.ts' --include='*.tsx' --include='*.js' --include='*.mjs' --include='*.cjs' \
             --include='*.json' --include='*.yaml' --include='*.yml' --include='*.md' --include='*.sh' \
             "[f]irst-tree-hub" packages apps scripts docs skills .github \
-            | grep -v -E '^\.github/workflows/ci\.yml:' \
+            | grep -v -E '^\.github/workflows/ci\.yml:|^packages/client/src/runtime/workspace-migrations\.ts:|^packages/client/src/__tests__/workspace-migrations\.test\.ts:|^packages/client/src/runtime/agent-bootstrap\.ts:|^docs/development/agent-workspace-state\.md:' \
             || true)
           if [ -n "$hits" ]; then
             echo "::error::found a 'first-tree-hub' literal outside the documented allow-list — see N-1 in PR-1 description"

--- a/docs/development/agent-workspace-state.md
+++ b/docs/development/agent-workspace-state.md
@@ -1,0 +1,163 @@
+# Agent Workspace State Files
+
+This page documents the CLI-owned state files that live inside an agent's
+home directory and the contract they enforce. If you're touching anything
+under `<workspace>/.agent/`, anything that calls `prepareSourceRepos`,
+`installFirstTreeSkills`, or `ensureAgentBootstrap`, or you're proposing a
+new directory-structure migration — start here.
+
+## Why these files exist
+
+Agent workspaces are long-running. The CLI clones source repos, installs
+skill payloads, and writes a briefing into each one on every session
+start. Over time, the CLI's CONFIG of what it materialises drifts:
+
+- A source repo is removed from the agent's predeclared `gitRepos` list.
+- A skill is dropped from the bundled `TREE_SKILL_NAMES`.
+- The layout itself changes between major releases (the per-chat-cwd ->
+  per-agent-home transition, the W1 workspace-rooted simplification, the
+  retired `first-tree-hub/` source repo, etc.).
+
+Without a record of what the CLI previously installed, removed resources
+sit on disk forever. The state files below are that record.
+
+## The files
+
+| Path (relative to workspace root) | Owner | What it is |
+| --- | --- | --- |
+| `.agent/managed.json` | `runtime/managed-state.ts` | Schema-versioned record of the CLI-managed resources currently materialised in this workspace. Two arrays: `sourceRepos` (localPath names) and `skills` (skill names). Diffed on every session start to discover removals. |
+| `.agent/migrations-applied.json` | `runtime/workspace-migrations.ts` | Set of one-shot directory-structure migration ids that have already run in this workspace. Each migration runs at most once even if it's later removed from the registry; the marker stays as forward protection. |
+
+Both files use atomic writes (temp + rename) so a crashed writer never
+leaves a half-formed JSON record on disk.
+
+### `.agent/managed.json` schema
+
+```json
+{
+  "schemaVersion": 1,
+  "cliVersion": "0.3.2",
+  "updatedAt": "2026-06-08T15:50:00.000Z",
+  "sourceRepos": ["first-tree", "first-tree-context"],
+  "skills": ["first-tree", "first-tree-context", "first-tree-sync"]
+}
+```
+
+- **`sourceRepos`** — the `localPath` of each repo from `payload.gitRepos`
+  the CLI cloned at workspace top level.
+- **`skills`** — the names of skills installed under
+  `<workspace>/.agents/skills/<name>/` (with matching `.claude/skills/<name>`
+  symlinks).
+- **`schemaVersion`** — increment when the shape changes; readers reject
+  unknown versions and treat them as "no prior state".
+
+When the file is missing or malformed, the reconcile path treats it as
+"first run on this workspace" and performs no deletions — the safe
+default.
+
+### `.agent/migrations-applied.json` schema
+
+```json
+{ "schemaVersion": 1, "applied": ["v1-uuid-snapshots", "v1-whitepaper-symlink"] }
+```
+
+A migration whose `apply` raises is NOT recorded, so a future session
+retries it. The marker file is rewritten only when at least one migration
+newly applied this run.
+
+## Reconcile flow on session start
+
+`ensureAgentBootstrap` (in `runtime/agent-bootstrap.ts`) runs migrations
+before any other bootstrap step:
+
+1. **`applyPendingMigrations`** — walk `MIGRATIONS_REGISTRY`, run each id
+   not already in the marker. Failures don't block siblings; ids are
+   persisted only after a clean run.
+2. The existing first-run-vs-steady-state sentinel logic continues.
+
+State-based source/skill cleanup runs from inside the installers that
+already operate per session:
+
+- **`prepareSourceRepos`** (`runtime/source-repos.ts`) — after the per-repo
+  clone/fetch loop, diff `prev.sourceRepos` against the current set and
+  remove any clone no longer in the config. Safety guards apply (see
+  below); state is then rewritten to the current set.
+- **`installFirstTreeSkills`** (`runtime/first-tree-skills/installer.ts`)
+  — same diff against `TREE_SKILL_NAMES`. Dropped skills lose their
+  `.agents/skills/<name>/` payload AND their `.claude/skills/<name>`
+  symlink.
+
+Both call sites share the `updateManagedState` helper, which read-modify-
+writes atomically so a write to one field cannot clobber the other.
+
+## Safety guards for clone deletion
+
+Every clone deletion — both state-based and migration-driven — goes through
+`tryRemoveCloneSafely` in `runtime/source-repo-cleanup.ts`. The guards are:
+
+1. **Dir missing** → `absent`, noop.
+2. **No `.git/`** → `not-a-clone`, noop. (Not ours to delete.)
+3. **`git status --porcelain` reports anything** → `dirty`, skip.
+4. **HEAD ahead of upstream** → `ahead-of-upstream`, skip. An empty repo
+   with no HEAD at all is treated as 0 commits ahead (nothing to lose).
+5. **Dependent `git worktree` checkouts** → `has-worktrees`, skip.
+6. **Any probe crashed / timed out** → `probe-failed`, skip. Conservative
+   default: we'd rather leave a stale clone than nuke unpushed work.
+
+A skipped clone stays on disk and becomes an operator follow-up. The
+state file is still updated to the current set so the next session
+doesn't try the same skipped clone again as part of state-based cleanup
+— the migration path is "best effort, one shot".
+
+## What is NOT touched by this machinery
+
+- **`<workspace>/.first-tree/`** — active W1 workspace binding state
+  (`workspace.json`). The CLI never deletes this directory. A previously
+  proposed `v1-legacy-dot-first-tree` migration was withdrawn during
+  Codex review of PR #869 for exactly this reason.
+- **`<workspace>/worktrees/`** — agent-self-managed. The agent creates
+  per-task worktrees here and is responsible for cleaning them up. The
+  CLI never sweeps this directory.
+- **`<workspace>/notes/`** — agent's local implementation notes. CLI
+  never touches it.
+- **User-created files at workspace root** — third-party clones, custom
+  skill payloads under `.agents/skills/`, regular `WHITEPAPER.md` files,
+  anything else not in the recorded managed set. State-based cleanup is
+  path-precise; migrations match on origin URL pattern (not directory
+  name) for FT clones and on `lstat().isSymbolicLink()` for the
+  WHITEPAPER.md sweep.
+
+## Adding a new migration
+
+When a future layout change introduces stale residue that warrants a
+sweep:
+
+1. Add a new entry to `MIGRATIONS_REGISTRY` at the END of the array
+   with a fresh `vN-<short-name>` id. Old ids stay even when their
+   bodies are simplified, so workspaces that have already applied them
+   don't re-run.
+2. The `apply` function MUST be idempotent (re-running on an already-
+   clean workspace is a noop) and SHOULD short-circuit when there's
+   nothing to do.
+3. If the migration deletes clones, use `tryRemoveCloneSafely` so the
+   dirty / ahead-of-upstream / worktree guards apply uniformly.
+4. If the migration deletes symlinks, use `lstat().isSymbolicLink()` to
+   confirm the entry type before unlinking — never delete a user-authored
+   regular file.
+5. Add unit tests covering the happy path AND the safety guards (a
+   pristine workspace, an already-applied workspace, and at least one
+   "blocked by safety" scenario).
+6. The marker is per-id, never per-workspace — bumping the id of an
+   existing migration would re-run it on every workspace.
+
+## See also
+
+- `runtime/managed-state.ts` — state-file I/O and read-modify-write helper
+- `runtime/workspace-migrations.ts` — migration registry and applier
+- `runtime/source-repo-cleanup.ts` — `tryRemoveCloneSafely` + probe helpers
+- `runtime/source-repos.ts` — state-based source-repo reconcile
+- `runtime/first-tree-skills/installer.ts` — state-based skill reconcile
+- `runtime/agent-bootstrap.ts` — wires migrations into session start
+- `packages/shared/src/schemas/workspace-manifest.ts` — the W1 binding
+  manifest at `<workspace>/.first-tree/workspace.json` (distinct from
+  `.agent/`; never touched by this machinery)

--- a/docs/development/agent-workspace-state.md
+++ b/docs/development/agent-workspace-state.md
@@ -75,6 +75,29 @@ before any other bootstrap step:
    persisted only after a clean run.
 2. The existing first-run-vs-steady-state sentinel logic continues.
 
+### Two outcomes that block the marker
+
+A migration's `apply` can finish in three ways:
+
+- **clean return** (`undefined`) — migration ran; marker recorded; id
+  never re-runs.
+- **`"deferred"` return** — migration could not safely run this session
+  (typically because the live source-repo config is unresolved); marker
+  NOT recorded; the next session retries from scratch.
+- **`throw`** — unexpected I/O / git failure; marker NOT recorded;
+  logged via the `failed` channel; the next session retries.
+
+The `deferred` outcome is specifically for migrations whose correctness
+depends on the live agent config (`MigrationContext.currentSourceRepoNames`).
+Those migrations call `hasResolvedConfig(ctx)` at the top and defer when
+the caller could not resolve a payload. Persisted `managed.json` is NOT a
+safe fallback — it proves a previous config, not the current one — so any
+deletion that relies on "what's missing from the current config" must
+wait for a session with a real payload.
+
+Migrations whose check is purely local (e.g. `v1-whitepaper-symlink`'s
+"is this entry a symlink?") ignore the context and proceed unconditionally.
+
 State-based source/skill cleanup runs from inside the installers that
 already operate per session:
 

--- a/packages/client/src/__tests__/agent-bootstrap.test.ts
+++ b/packages/client/src/__tests__/agent-bootstrap.test.ts
@@ -84,6 +84,9 @@ describe("ensureAgentBootstrap — integration retry gate", () => {
       sessionCtx: fakeSessionCtx(),
       contextTreePath: "/tree",
       briefing: "# Agent Identity\n\nstub briefing\n",
+      // Tests that don't exercise migration / state-reconcile pass `null` —
+      // mirrors the cache-miss caller signal.
+      currentSourceRepoNames: null,
     };
 
     // Call 1: integration fails → CLI version NOT pinned.
@@ -107,6 +110,7 @@ describe("ensureAgentBootstrap — integration retry gate", () => {
       sessionCtx: fakeSessionCtx(),
       contextTreePath: null,
       briefing: "# Agent Identity\n\nstub briefing\n",
+      currentSourceRepoNames: null,
     };
     ensureAgentBootstrap(params);
     // No Context Tree → installFirstTreeIntegration is never called regardless.

--- a/packages/client/src/__tests__/claude-code-inject-startup-race.test.ts
+++ b/packages/client/src/__tests__/claude-code-inject-startup-race.test.ts
@@ -87,6 +87,7 @@ vi.mock("../runtime/chat-context.js", () => ({
 vi.mock("../runtime/source-repos.js", () => ({
   prepareSourceRepos: vi.fn(async () => []),
   releaseSourceReposForSession: vi.fn(),
+  currentSourceRepoNamesFromPayload: vi.fn(() => null),
 }));
 
 import { createClaudeCodeHandler } from "../handlers/claude-code.js";

--- a/packages/client/src/__tests__/managed-state.test.ts
+++ b/packages/client/src/__tests__/managed-state.test.ts
@@ -1,0 +1,142 @@
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  MANAGED_STATE_REL,
+  type ManagedState,
+  readManagedState,
+  updateManagedState,
+  writeManagedState,
+} from "../runtime/managed-state.js";
+
+describe("managed-state", () => {
+  let workspace: string;
+
+  beforeEach(() => {
+    workspace = mkdtempSync(join(tmpdir(), "managed-state-test-"));
+    mkdirSync(join(workspace, ".agent"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(workspace, { recursive: true, force: true });
+  });
+
+  it("returns null when the state file does not exist", () => {
+    expect(readManagedState(workspace)).toBeNull();
+  });
+
+  it("round-trips a written record verbatim", () => {
+    const state: ManagedState = {
+      schemaVersion: 1,
+      cliVersion: "0.3.2",
+      updatedAt: "2026-06-08T16:00:00.000Z",
+      sourceRepos: ["first-tree", "first-tree-context"],
+      skills: ["first-tree", "first-tree-context", "first-tree-sync"],
+    };
+    writeManagedState(workspace, state);
+    expect(readManagedState(workspace)).toEqual(state);
+  });
+
+  it("returns null on malformed JSON", () => {
+    writeFileSync(join(workspace, MANAGED_STATE_REL), "{not json", "utf-8");
+    expect(readManagedState(workspace)).toBeNull();
+  });
+
+  it("returns null when schemaVersion is not 1", () => {
+    writeFileSync(
+      join(workspace, MANAGED_STATE_REL),
+      JSON.stringify({ schemaVersion: 2, sourceRepos: [], skills: [] }),
+      "utf-8",
+    );
+    expect(readManagedState(workspace)).toBeNull();
+  });
+
+  it("coerces non-string array entries to empty (defensive read)", () => {
+    writeFileSync(
+      join(workspace, MANAGED_STATE_REL),
+      JSON.stringify({
+        schemaVersion: 1,
+        cliVersion: null,
+        updatedAt: "2026-06-08T16:00:00.000Z",
+        // Intentionally garbage values to confirm the read filter:
+        sourceRepos: ["first-tree", 42, null, "first-tree-context"],
+        skills: "not-an-array",
+      }),
+      "utf-8",
+    );
+    const result = readManagedState(workspace);
+    expect(result?.sourceRepos).toEqual(["first-tree", "first-tree-context"]);
+    expect(result?.skills).toEqual([]);
+  });
+
+  it("updateManagedState applies the mutator and persists the result", () => {
+    const result = updateManagedState(workspace, "1.2.3", (current) => ({
+      ...current,
+      sourceRepos: ["alpha", "beta"],
+    }));
+    expect(result.sourceRepos).toEqual(["alpha", "beta"]);
+    expect(result.cliVersion).toBe("1.2.3");
+    expect(result.schemaVersion).toBe(1);
+
+    const readBack = readManagedState(workspace);
+    expect(readBack?.sourceRepos).toEqual(["alpha", "beta"]);
+    expect(readBack?.cliVersion).toBe("1.2.3");
+  });
+
+  it("updateManagedState preserves untouched fields across calls", () => {
+    updateManagedState(workspace, "1.2.3", (current) => ({
+      ...current,
+      sourceRepos: ["first-tree"],
+    }));
+    updateManagedState(workspace, "1.2.3", (current) => ({
+      ...current,
+      skills: ["first-tree-context"],
+    }));
+    const final = readManagedState(workspace);
+    expect(final?.sourceRepos).toEqual(["first-tree"]);
+    expect(final?.skills).toEqual(["first-tree-context"]);
+  });
+
+  it("updateManagedState refreshes updatedAt on every call", async () => {
+    const first = updateManagedState(workspace, null, (current) => ({
+      ...current,
+      sourceRepos: ["alpha"],
+    }));
+    // Sleep a hair so the ISO timestamps differ even on fast machines.
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    const second = updateManagedState(workspace, null, (current) => current);
+    expect(second.updatedAt).not.toBe(first.updatedAt);
+    expect(new Date(second.updatedAt).getTime()).toBeGreaterThanOrEqual(new Date(first.updatedAt).getTime());
+  });
+
+  it("writeManagedState produces atomic writes (no leftover temp siblings)", () => {
+    const state: ManagedState = {
+      schemaVersion: 1,
+      cliVersion: null,
+      updatedAt: new Date().toISOString(),
+      sourceRepos: [],
+      skills: [],
+    };
+    writeManagedState(workspace, state);
+    // The directory should contain only the final file, no `.tmp` siblings.
+    const agentDir = join(workspace, ".agent");
+    const entries = readdirSync(agentDir);
+    expect(entries.filter((entry) => entry.includes(".tmp"))).toEqual([]);
+    expect(entries).toContain("managed.json");
+  });
+
+  it("writeManagedState content is JSON-pretty with trailing newline (POSIX-friendly)", () => {
+    writeManagedState(workspace, {
+      schemaVersion: 1,
+      cliVersion: "x",
+      updatedAt: "y",
+      sourceRepos: [],
+      skills: [],
+    });
+    const raw = readFileSync(join(workspace, MANAGED_STATE_REL), "utf-8");
+    expect(raw.endsWith("\n")).toBe(true);
+    // Pretty-printed: indented entries should be present.
+    expect(raw).toContain('  "schemaVersion"');
+  });
+});

--- a/packages/client/src/__tests__/skills-state-reconcile.test.ts
+++ b/packages/client/src/__tests__/skills-state-reconcile.test.ts
@@ -1,0 +1,124 @@
+// Integration test for the state-based skill cleanup wiring inside
+// `installFirstTreeSkills`. Verifies that a skill the CLI previously
+// installed (recorded in `.agent/managed.json::skills`) but that's no
+// longer in the bundled `TREE_SKILL_NAMES` gets its `.agents/skills/<name>/`
+// payload AND its `.claude/skills/<name>` symlink removed. Anything the
+// user added under either location is path-precision-protected (the
+// reconcile only touches names from the recorded set).
+//
+// Helper-level coverage of the installer copy logic lives in
+// `bootstrap.test.ts`; this file proves the reconcile wiring in PR #869.
+
+import { existsSync, lstatSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { installFirstTreeSkills, TREE_SKILL_NAMES } from "../runtime/first-tree-skills/installer.js";
+import { readManagedState, writeManagedState } from "../runtime/managed-state.js";
+
+/**
+ * Build a bundled-skills root mirroring the shape `installFirstTreeSkills`
+ * expects: `<root>/<name>/SKILL.md`. Only ships the current `TREE_SKILL_NAMES`
+ * so the reconcile-on-removal path has work to do (anything in prev state
+ * not in `TREE_SKILL_NAMES` is "dropped").
+ */
+function makeBundledSkillsRoot(parent: string): string {
+  const root = join(parent, "bundled-skills");
+  mkdirSync(root, { recursive: true });
+  for (const name of TREE_SKILL_NAMES) {
+    const dir = join(root, name);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "SKILL.md"), `---\nname: ${name}\n---\nfixture content for ${name}\n`);
+  }
+  return root;
+}
+
+function plantManagedSkill(workspace: string, name: string): void {
+  // Real payload — installFirstTreeSkills's reconcile removes the dir.
+  const agentsDir = join(workspace, ".agents", "skills", name);
+  mkdirSync(agentsDir, { recursive: true });
+  writeFileSync(join(agentsDir, "SKILL.md"), `---\nname: ${name}\n---\nstale ${name}\n`);
+  // Matching `.claude/skills/<name>` symlink (the canonical layout).
+  const claudeLink = join(workspace, ".claude", "skills", name);
+  mkdirSync(join(workspace, ".claude", "skills"), { recursive: true });
+  symlinkSync(join("..", "..", ".agents", "skills", name), claudeLink);
+}
+
+describe("installFirstTreeSkills — state-based skill reconcile (PR #869 P1-3)", () => {
+  let tmpBase: string;
+  let workspace: string;
+  let bundledSkillsRoot: string;
+
+  beforeEach(() => {
+    tmpBase = mkdtempSync(join(tmpdir(), "skill-reconcile-"));
+    workspace = join(tmpBase, "ws");
+    mkdirSync(join(workspace, ".agent"), { recursive: true });
+    bundledSkillsRoot = makeBundledSkillsRoot(tmpBase);
+  });
+
+  afterEach(() => {
+    rmSync(tmpBase, { recursive: true, force: true });
+  });
+
+  it("removes `.agents/skills/<dropped>/` AND `.claude/skills/<dropped>` for skills no longer in TREE_SKILL_NAMES", () => {
+    // Prev managed state lists current skills + two "retired" ones; the
+    // current `TREE_SKILL_NAMES` (read from the bundle) does not include
+    // `legacy-foo` / `legacy-bar`.
+    plantManagedSkill(workspace, "legacy-foo");
+    plantManagedSkill(workspace, "legacy-bar");
+    writeManagedState(workspace, {
+      schemaVersion: 1,
+      cliVersion: "test",
+      updatedAt: new Date(0).toISOString(),
+      sourceRepos: [],
+      skills: [...TREE_SKILL_NAMES, "legacy-foo", "legacy-bar"],
+    });
+
+    installFirstTreeSkills({ workspacePath: workspace, bundledSkillsRoot });
+
+    // Dropped skills are gone — both the payload directory and the
+    // Claude-side symlink were removed.
+    expect(existsSync(join(workspace, ".agents", "skills", "legacy-foo"))).toBe(false);
+    expect(existsSync(join(workspace, ".agents", "skills", "legacy-bar"))).toBe(false);
+    expect(() => lstatSync(join(workspace, ".claude", "skills", "legacy-foo"))).toThrow();
+    expect(() => lstatSync(join(workspace, ".claude", "skills", "legacy-bar"))).toThrow();
+
+    // Current skills are still present.
+    for (const name of TREE_SKILL_NAMES) {
+      expect(existsSync(join(workspace, ".agents", "skills", name, "SKILL.md"))).toBe(true);
+      expect(lstatSync(join(workspace, ".claude", "skills", name)).isSymbolicLink()).toBe(true);
+    }
+
+    // State rolls forward to the current bundle set, sorted.
+    const state = readManagedState(workspace);
+    expect(state?.skills).toEqual([...TREE_SKILL_NAMES].sort());
+  });
+
+  it("leaves a user-added skill alone — only names in the recorded prev state are removed", () => {
+    // The CLI never recorded `my-custom` as installed, so even though
+    // it's not in TREE_SKILL_NAMES the reconcile path must not touch it.
+    plantManagedSkill(workspace, "my-custom");
+    writeManagedState(workspace, {
+      schemaVersion: 1,
+      cliVersion: "test",
+      updatedAt: new Date(0).toISOString(),
+      sourceRepos: [],
+      skills: [...TREE_SKILL_NAMES], // does NOT include "my-custom"
+    });
+
+    installFirstTreeSkills({ workspacePath: workspace, bundledSkillsRoot });
+
+    expect(existsSync(join(workspace, ".agents", "skills", "my-custom", "SKILL.md"))).toBe(true);
+    expect(lstatSync(join(workspace, ".claude", "skills", "my-custom")).isSymbolicLink()).toBe(true);
+  });
+
+  it("first run (no managed.json) writes current bundle set without trying to remove anything", () => {
+    installFirstTreeSkills({ workspacePath: workspace, bundledSkillsRoot });
+
+    const state = readManagedState(workspace);
+    expect(state?.skills).toEqual([...TREE_SKILL_NAMES].sort());
+    for (const name of TREE_SKILL_NAMES) {
+      expect(existsSync(join(workspace, ".agents", "skills", name, "SKILL.md"))).toBe(true);
+    }
+  });
+});

--- a/packages/client/src/__tests__/source-repos-state-reconcile.test.ts
+++ b/packages/client/src/__tests__/source-repos-state-reconcile.test.ts
@@ -1,0 +1,239 @@
+// Integration tests for the state-based cleanup wiring inside
+// `prepareSourceRepos`. Helper-level coverage lives in
+// `managed-state.test.ts`; this file proves the actual reconcile loop
+// inside `prepareSourceRepos` correctly diffs prev-vs-current, applies the
+// safety guards, and updates `.agent/managed.json`. The P0-2 regression
+// (`payload: undefined` → mass-delete) and P1-3 (no integration coverage)
+// from PR #869's code-reviewer feedback are guarded by the tests below.
+
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AgentRuntimeConfigPayload } from "@first-tree/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { GitMirrorManager, SourceRepoOutcome } from "../runtime/git-mirror-manager.js";
+import type { SessionContext } from "../runtime/handler.js";
+import { readManagedState, writeManagedState } from "../runtime/managed-state.js";
+import { prepareSourceRepos } from "../runtime/source-repos.js";
+
+type EnsureArgs = Parameters<GitMirrorManager["ensureSourceRepo"]>[0];
+
+function makeManager(): { manager: GitMirrorManager; calls: EnsureArgs[] } {
+  const calls: EnsureArgs[] = [];
+  const manager = {
+    ensureSourceRepo: vi.fn(async (args: EnsureArgs) => {
+      calls.push(args);
+      // Ensure the target directory exists so the test can verify "still
+      // present after reconcile". Skip when the test already pre-populated it.
+      if (!existsSync(args.clonePath)) {
+        mkdirSync(args.clonePath, { recursive: true });
+        execFileSync("git", ["init", "-q", "-b", "main"], { cwd: args.clonePath });
+      }
+      return {
+        clonePath: args.clonePath,
+        headCommit: "deadbeef",
+        branch: "main",
+        outcome: "cloned" as SourceRepoOutcome,
+      };
+    }),
+    removeSourceRepo: vi.fn(async () => {}),
+    sweepLegacyMirrors: vi.fn(async () => ({ removed: [] })),
+    legacyMirrorsRoot: "/tmp/legacy",
+  } as unknown as GitMirrorManager;
+  return { manager, calls };
+}
+
+function makeCtx(): SessionContext {
+  return {
+    chatId: `chat-${Math.random().toString(36).slice(2, 10)}`,
+    log: vi.fn(),
+    agent: { agentId: "agent-x" },
+  } as unknown as SessionContext;
+}
+
+function payloadFor(localPaths: readonly string[]): AgentRuntimeConfigPayload {
+  return {
+    gitRepos: localPaths.map((localPath) => ({
+      url: `git@github.com:example/${localPath}.git`,
+      localPath,
+    })),
+  } as unknown as AgentRuntimeConfigPayload;
+}
+
+/**
+ * Build a real `git init`'d clone at `<workspace>/<name>/`, useful for the
+ * cleanup paths which probe HEAD / status / worktree-list. Commits a single
+ * file by default so HEAD exists; `dirty` adds an extra untracked file the
+ * dirty-guard should catch; `ahead` adds an upstream-less commit so the
+ * ahead-of-upstream guard's "no tracking → skip" path triggers.
+ */
+function plantClone(workspace: string, name: string, opts?: { dirty?: boolean; withWorktreeRef?: string }): string {
+  const target = join(workspace, name);
+  mkdirSync(target, { recursive: true });
+  execFileSync("git", ["init", "-q", "-b", "main"], { cwd: target });
+  execFileSync("git", ["config", "user.email", "t@e.com"], { cwd: target });
+  execFileSync("git", ["config", "user.name", "t"], { cwd: target });
+  writeFileSync(join(target, "README.md"), "seed\n");
+  execFileSync("git", ["add", "."], { cwd: target });
+  execFileSync("git", ["commit", "-q", "-m", "seed"], { cwd: target });
+  // Connect a fake upstream so the ahead-of-upstream probe has a tracking
+  // branch — important for the "clean, deletable" path. We can't fetch
+  // (the URL is bogus) but `git rev-list @{u}..HEAD` just reads local refs.
+  execFileSync("git", ["remote", "add", "origin", "https://example.invalid/seed.git"], { cwd: target });
+  // Configure tracking: branch.main.remote=origin + branch.main.merge=refs/heads/main
+  execFileSync("git", ["config", "branch.main.remote", "origin"], { cwd: target });
+  execFileSync("git", ["config", "branch.main.merge", "refs/heads/main"], { cwd: target });
+  // Make origin/main resolve to current HEAD so we're 0 commits ahead.
+  const headSha = execFileSync("git", ["rev-parse", "HEAD"], { cwd: target, encoding: "utf-8" }).trim();
+  execFileSync("git", ["update-ref", "refs/remotes/origin/main", headSha], { cwd: target });
+
+  if (opts?.dirty) {
+    writeFileSync(join(target, "dirty.txt"), "uncommitted change\n");
+  }
+  if (opts?.withWorktreeRef) {
+    // Adding a real worktree requires somewhere to put it. The cleanup
+    // probe just counts `git worktree list --porcelain` blank-line records,
+    // so a registered (even broken) worktree suffices.
+    const linkedTarget = join(workspace, opts.withWorktreeRef);
+    execFileSync("git", ["worktree", "add", "--detach", linkedTarget, "HEAD"], { cwd: target });
+  }
+  return target;
+}
+
+describe("prepareSourceRepos — state-based reconcile (PR #869 P1-3)", () => {
+  let workspace: string;
+
+  beforeEach(() => {
+    workspace = mkdtempSync(join(tmpdir(), "state-reconcile-"));
+    mkdirSync(join(workspace, ".agent"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(workspace, { recursive: true, force: true });
+  });
+
+  it("prev=[A,B], current=[A] and B is clean → B is deleted, state is updated to [A]", async () => {
+    plantClone(workspace, "repo-a");
+    plantClone(workspace, "repo-b");
+    writeManagedState(workspace, {
+      schemaVersion: 1,
+      cliVersion: "test",
+      updatedAt: new Date(0).toISOString(),
+      sourceRepos: ["repo-a", "repo-b"],
+      skills: [],
+    });
+
+    const { manager } = makeManager();
+    await prepareSourceRepos({
+      workspace,
+      payload: payloadFor(["repo-a"]),
+      sessionCtx: makeCtx(),
+      gitMirrorManager: manager,
+      agentName: null,
+      payloadResolved: true,
+    });
+
+    expect(existsSync(join(workspace, "repo-a"))).toBe(true);
+    expect(existsSync(join(workspace, "repo-b"))).toBe(false);
+    expect(readManagedState(workspace)?.sourceRepos).toEqual(["repo-a"]);
+  });
+
+  it("prev=[A,B], current=[A] but B is dirty → B is kept, state still rolls forward to [A]", async () => {
+    plantClone(workspace, "repo-a");
+    plantClone(workspace, "repo-b", { dirty: true });
+    writeManagedState(workspace, {
+      schemaVersion: 1,
+      cliVersion: "test",
+      updatedAt: new Date(0).toISOString(),
+      sourceRepos: ["repo-a", "repo-b"],
+      skills: [],
+    });
+
+    const { manager } = makeManager();
+    await prepareSourceRepos({
+      workspace,
+      payload: payloadFor(["repo-a"]),
+      sessionCtx: makeCtx(),
+      gitMirrorManager: manager,
+      agentName: null,
+      payloadResolved: true,
+    });
+
+    expect(existsSync(join(workspace, "repo-b"))).toBe(true);
+    expect(existsSync(join(workspace, "repo-b", "dirty.txt"))).toBe(true);
+    // State rolls forward to current set — the dirty clone becomes an
+    // operator follow-up (see `reconcileSourceRepoState` docstring).
+    expect(readManagedState(workspace)?.sourceRepos).toEqual(["repo-a"]);
+  });
+
+  it("prev=[A,B], current=[A] but B hosts a dependent worktree → B is kept", async () => {
+    plantClone(workspace, "repo-a");
+    plantClone(workspace, "repo-b", { withWorktreeRef: "linked-wt" });
+    writeManagedState(workspace, {
+      schemaVersion: 1,
+      cliVersion: "test",
+      updatedAt: new Date(0).toISOString(),
+      sourceRepos: ["repo-a", "repo-b"],
+      skills: [],
+    });
+
+    const { manager } = makeManager();
+    await prepareSourceRepos({
+      workspace,
+      payload: payloadFor(["repo-a"]),
+      sessionCtx: makeCtx(),
+      gitMirrorManager: manager,
+      agentName: null,
+      payloadResolved: true,
+    });
+
+    expect(existsSync(join(workspace, "repo-b"))).toBe(true);
+  });
+
+  it("prev=[A,B], payload=undefined (cache miss) → NOTHING is deleted (PR #869 P0-2 regression)", async () => {
+    plantClone(workspace, "repo-a");
+    plantClone(workspace, "repo-b");
+    writeManagedState(workspace, {
+      schemaVersion: 1,
+      cliVersion: "test",
+      updatedAt: new Date(0).toISOString(),
+      sourceRepos: ["repo-a", "repo-b"],
+      skills: [],
+    });
+    const stateBefore = readFileSync(join(workspace, ".agent", "managed.json"), "utf-8");
+
+    const { manager } = makeManager();
+    await prepareSourceRepos({
+      workspace,
+      payload: undefined,
+      sessionCtx: makeCtx(),
+      gitMirrorManager: manager,
+      agentName: null,
+      payloadResolved: false,
+    });
+
+    // Both repos still present — `payloadResolved: false` gated reconcile.
+    expect(existsSync(join(workspace, "repo-a"))).toBe(true);
+    expect(existsSync(join(workspace, "repo-b"))).toBe(true);
+    // State unchanged — no write happens when reconcile is suppressed.
+    const stateAfter = readFileSync(join(workspace, ".agent", "managed.json"), "utf-8");
+    expect(stateAfter).toBe(stateBefore);
+  });
+
+  it("first run (no managed.json) writes current set without trying to delete anything", async () => {
+    plantClone(workspace, "repo-a");
+
+    const { manager } = makeManager();
+    await prepareSourceRepos({
+      workspace,
+      payload: payloadFor(["repo-a"]),
+      sessionCtx: makeCtx(),
+      gitMirrorManager: manager,
+      agentName: null,
+      payloadResolved: true,
+    });
+
+    expect(readManagedState(workspace)?.sourceRepos).toEqual(["repo-a"]);
+  });
+});

--- a/packages/client/src/__tests__/source-repos-state-reconcile.test.ts
+++ b/packages/client/src/__tests__/source-repos-state-reconcile.test.ts
@@ -236,4 +236,54 @@ describe("prepareSourceRepos — state-based reconcile (PR #869 P1-3)", () => {
 
     expect(readManagedState(workspace)?.sourceRepos).toEqual(["repo-a"]);
   });
+
+  it("does NOT delete a clone another live chat in this process is still using (PR #869 code-reviewer R2 N-2)", async () => {
+    plantClone(workspace, "repo-a");
+    plantClone(workspace, "repo-b");
+    writeManagedState(workspace, {
+      schemaVersion: 1,
+      cliVersion: "test",
+      updatedAt: new Date(0).toISOString(),
+      sourceRepos: ["repo-a", "repo-b"],
+      skills: [],
+    });
+
+    // Chat A acquires repo-b through a normal prepare call — both repos
+    // are in its config so neither is touched, but the live-use registry
+    // records chat A against both checkout paths.
+    const { manager } = makeManager();
+    const chatA = makeCtx();
+    await prepareSourceRepos({
+      workspace,
+      payload: payloadFor(["repo-a", "repo-b"]),
+      sessionCtx: chatA,
+      gitMirrorManager: manager,
+      agentName: null,
+      payloadResolved: true,
+    });
+    expect(existsSync(join(workspace, "repo-b"))).toBe(true);
+
+    // Chat B starts with a new config that drops repo-b. Without the
+    // `isPathInUse` check the reconcile path would `rm` repo-b out from
+    // under chat A; the guard must catch this.
+    const chatBLogs: string[] = [];
+    const chatB = {
+      ...makeCtx(),
+      log: (msg: string) => chatBLogs.push(msg),
+    } as unknown as SessionContext;
+    await prepareSourceRepos({
+      workspace,
+      payload: payloadFor(["repo-a"]),
+      sessionCtx: chatB,
+      gitMirrorManager: manager,
+      agentName: null,
+      payloadResolved: true,
+    });
+
+    expect(existsSync(join(workspace, "repo-b"))).toBe(true);
+    expect(chatBLogs.some((l) => l.toLowerCase().includes("in use by another live chat"))).toBe(true);
+    // State still rolls forward to chat B's set so the next session diffs
+    // against today's reality — the stale clone becomes operator follow-up.
+    expect(readManagedState(workspace)?.sourceRepos).toEqual(["repo-a"]);
+  });
 });

--- a/packages/client/src/__tests__/source-repos.test.ts
+++ b/packages/client/src/__tests__/source-repos.test.ts
@@ -70,6 +70,7 @@ describe("source-repos live-use registry (decision B, keyed by chatId)", () => {
       sessionCtx: ctxA,
       gitMirrorManager: manager,
       agentName: null,
+      payloadResolved: true,
     });
     expect(calls.at(-1)?.activelyInUse).toBe(false); // first chat — nobody else
 
@@ -79,6 +80,7 @@ describe("source-repos live-use registry (decision B, keyed by chatId)", () => {
       sessionCtx: ctxB,
       gitMirrorManager: manager,
       agentName: null,
+      payloadResolved: true,
     });
     expect(calls.at(-1)?.activelyInUse).toBe(true); // chat-A still live
 
@@ -90,6 +92,7 @@ describe("source-repos live-use registry (decision B, keyed by chatId)", () => {
       sessionCtx: ctxB,
       gitMirrorManager: manager,
       agentName: null,
+      payloadResolved: true,
     });
     expect(calls.at(-1)?.activelyInUse).toBe(false); // only chat-B now
 
@@ -111,6 +114,7 @@ describe("source-repos live-use registry (decision B, keyed by chatId)", () => {
       sessionCtx: start,
       gitMirrorManager: manager,
       agentName: null,
+      payloadResolved: true,
     });
     await prepareSourceRepos({
       workspace,
@@ -118,6 +122,7 @@ describe("source-repos live-use registry (decision B, keyed by chatId)", () => {
       sessionCtx: resume,
       gitMirrorManager: manager,
       agentName: null,
+      payloadResolved: true,
     });
 
     // A different chat sees exactly ONE other live chat (chat-A), not two.
@@ -127,6 +132,7 @@ describe("source-repos live-use registry (decision B, keyed by chatId)", () => {
       sessionCtx: other,
       gitMirrorManager: manager,
       agentName: null,
+      payloadResolved: true,
     });
     expect(calls.at(-1)?.activelyInUse).toBe(true);
     releaseSourceReposForSession(other);
@@ -141,6 +147,7 @@ describe("source-repos live-use registry (decision B, keyed by chatId)", () => {
       sessionCtx: after,
       gitMirrorManager: manager,
       agentName: null,
+      payloadResolved: true,
     });
     expect(calls.at(-1)?.activelyInUse).toBe(false);
     releaseSourceReposForSession(after);
@@ -158,6 +165,7 @@ describe("source-repos live-use registry (decision B, keyed by chatId)", () => {
         sessionCtx: failing,
         gitMirrorManager: manager,
         agentName: null,
+        payloadResolved: true,
       }),
     ).rejects.toThrow("clone failed");
 
@@ -169,6 +177,7 @@ describe("source-repos live-use registry (decision B, keyed by chatId)", () => {
       sessionCtx: next,
       gitMirrorManager: manager,
       agentName: null,
+      payloadResolved: true,
     });
     expect(calls.at(-1)?.activelyInUse).toBe(false);
     releaseSourceReposForSession(next);
@@ -187,6 +196,7 @@ describe("source-repos live-use registry (decision B, keyed by chatId)", () => {
       sessionCtx: live,
       gitMirrorManager: manager,
       agentName: null,
+      payloadResolved: true,
     });
 
     // Resume (fresh SessionContext, same chatId) fails transiently. Because the
@@ -200,6 +210,7 @@ describe("source-repos live-use registry (decision B, keyed by chatId)", () => {
         sessionCtx: resume,
         gitMirrorManager: manager,
         agentName: null,
+        payloadResolved: true,
       }),
     ).rejects.toThrow("clone failed");
 
@@ -211,6 +222,7 @@ describe("source-repos live-use registry (decision B, keyed by chatId)", () => {
       sessionCtx: other,
       gitMirrorManager: manager,
       agentName: null,
+      payloadResolved: true,
     });
     expect(calls.at(-1)?.activelyInUse).toBe(true);
 

--- a/packages/client/src/__tests__/workspace-migrations.test.ts
+++ b/packages/client/src/__tests__/workspace-migrations.test.ts
@@ -36,10 +36,49 @@ describe("workspace-migrations registry", () => {
     writeFileSync(join(uuidDir, "AGENTS.md"), "# legacy chat snapshot\n");
     mkdirSync(namedDir);
 
-    applyPendingMigrations(workspace, () => {});
+    applyPendingMigrations(workspace, () => {}, { currentSourceRepoNames: new Set() });
 
     expect(existsSync(uuidDir)).toBe(false);
     expect(existsSync(namedDir)).toBe(true);
+  });
+
+  it("v1-uuid-snapshots DEFERS on first cache-miss start when no managed state exists (PR #869 baixiaohang round-4 P0)", () => {
+    // The edge case round-4 review flagged: a UUID-shaped CURRENT source repo
+    // whose cloned content ships an AGENTS.md would match the legacy
+    // snapshot signature. Without the defer rule, the first cache-miss start
+    // would `rm` it before any resolved payload could write managed.json.
+    const uuidDir = join(workspace, "12345678-abcd-4def-89ab-1234567890ab");
+    mkdirSync(uuidDir);
+    writeFileSync(join(uuidDir, "AGENTS.md"), "# this content-bundled file matches the legacy signature\n");
+    const logs: string[] = [];
+
+    const result = applyPendingMigrations(workspace, (msg) => logs.push(msg));
+
+    expect(existsSync(uuidDir)).toBe(true);
+    expect(existsSync(join(uuidDir, "AGENTS.md"))).toBe(true);
+    expect(result.deferred).toContain("v1-uuid-snapshots");
+    expect(logs.some((l) => l.includes("v1-uuid-snapshots deferred"))).toBe(true);
+  });
+
+  it("v1-uuid-snapshots runs (not deferred) when persisted state has source repos even if ctx is null", () => {
+    const uuidDir = join(workspace, "12345678-abcd-4def-89ab-1234567890ab");
+    mkdirSync(uuidDir);
+    writeFileSync(join(uuidDir, "AGENTS.md"), "# legacy snapshot\n");
+    writeFileSync(
+      join(workspace, ".agent", "managed.json"),
+      JSON.stringify({
+        schemaVersion: 1,
+        cliVersion: "test",
+        updatedAt: new Date().toISOString(),
+        sourceRepos: ["first-tree"],
+        skills: [],
+      }),
+    );
+
+    const result = applyPendingMigrations(workspace, () => {});
+
+    expect(result.deferred).not.toContain("v1-uuid-snapshots");
+    expect(existsSync(uuidDir)).toBe(false);
   });
 
   it("v1-uuid-snapshots leaves UUID-named directories WITHOUT the legacy snapshot signature alone (PR #869 P0)", () => {
@@ -49,7 +88,10 @@ describe("workspace-migrations registry", () => {
     mkdirSync(userUuidDir);
     writeFileSync(join(userUuidDir, "user-data.json"), "{}");
 
-    applyPendingMigrations(workspace, () => {});
+    // Pass an authoritative empty set so the migration actually runs (rather
+    // than deferring on unknown config) — proving the signature check, not
+    // the defer fallback, is what spares this directory.
+    applyPendingMigrations(workspace, () => {}, { currentSourceRepoNames: new Set() });
 
     expect(existsSync(userUuidDir)).toBe(true);
     expect(existsSync(join(userUuidDir, "user-data.json"))).toBe(true);
@@ -86,7 +128,7 @@ describe("workspace-migrations registry", () => {
       writeFileSync(join(workspace, d, "AGENTS.md"), "");
     }
 
-    applyPendingMigrations(workspace, () => {});
+    applyPendingMigrations(workspace, () => {}, { currentSourceRepoNames: new Set() });
 
     for (const d of dirs) {
       expect(existsSync(join(workspace, d))).toBe(true);
@@ -102,9 +144,26 @@ describe("workspace-migrations registry", () => {
     mkdirSync(target);
     writeFileSync(join(target, ".git"), "gitdir: /tmp/does-not-exist/worktrees/first-tree-hub\n");
 
-    applyPendingMigrations(workspace, () => {});
+    // Authoritative empty set → not deferred → broken-pointer check fires
+    // and removes the clone. Without an explicit set, the migration defers
+    // (round-4 P0 protection).
+    applyPendingMigrations(workspace, () => {}, { currentSourceRepoNames: new Set() });
 
     expect(existsSync(target)).toBe(false);
+  });
+
+  it("v1-retired-source-repo-first-tree-hub DEFERS on first cache-miss start when no managed state exists (PR #869 baixiaohang round-4 follow-on)", () => {
+    // Mirrors the v1-orphan-ft-clones / v1-uuid-snapshots defer paths: if
+    // the caller can't prove first-tree-hub is absent from current config,
+    // leave it alone and retry next session.
+    const target = join(workspace, "first-tree-hub");
+    mkdirSync(target);
+    writeFileSync(join(target, ".git"), "gitdir: /tmp/does-not-exist/worktrees/first-tree-hub\n");
+
+    const result = applyPendingMigrations(workspace, () => {});
+
+    expect(existsSync(target)).toBe(true);
+    expect(result.deferred).toContain("v1-retired-source-repo-first-tree-hub");
   });
 
   it("v1-retired-source-repo-first-tree-hub does NOT remove `first-tree-hub/` if it's still in current source_repos", () => {
@@ -134,7 +193,7 @@ describe("workspace-migrations registry", () => {
     mkdirSync(target);
     writeFileSync(join(target, "user-notes.md"), "# my notes\n");
 
-    applyPendingMigrations(workspace, () => {});
+    applyPendingMigrations(workspace, () => {}, { currentSourceRepoNames: new Set() });
 
     expect(existsSync(target)).toBe(true);
     expect(existsSync(join(target, "user-notes.md"))).toBe(true);
@@ -149,7 +208,7 @@ describe("workspace-migrations registry", () => {
     initRepo(target, "https://github.com/agent-team-foundation/first-tree-hub");
     writeFileSync(join(target, "dirty.txt"), "uncommitted user work\n");
 
-    applyPendingMigrations(workspace, () => {});
+    applyPendingMigrations(workspace, () => {}, { currentSourceRepoNames: new Set() });
 
     expect(existsSync(target)).toBe(true);
     expect(existsSync(join(target, "dirty.txt"))).toBe(true);
@@ -164,7 +223,7 @@ describe("workspace-migrations registry", () => {
     mkdirSync(livePointerTarget);
     writeFileSync(join(target, ".git"), `gitdir: ${livePointerTarget}\n`);
 
-    applyPendingMigrations(workspace, () => {});
+    applyPendingMigrations(workspace, () => {}, { currentSourceRepoNames: new Set() });
 
     expect(existsSync(target)).toBe(true);
     expect(existsSync(join(target, ".git"))).toBe(true);
@@ -201,18 +260,9 @@ describe("workspace-migrations registry", () => {
     // something — the safety guards should refuse to delete.
     writeFileSync(join(orphan, "dirty.txt"), "uncommitted work\n");
 
-    writeFileSync(
-      join(workspace, ".agent", "managed.json"),
-      JSON.stringify({
-        schemaVersion: 1,
-        cliVersion: "test",
-        updatedAt: new Date().toISOString(),
-        sourceRepos: [],
-        skills: [],
-      }),
-    );
-
-    applyPendingMigrations(workspace, () => {});
+    // Pass an authoritative empty set so the migration runs (rather than
+    // deferring on unknown config) and we actually exercise the dirty guard.
+    applyPendingMigrations(workspace, () => {}, { currentSourceRepoNames: new Set() });
 
     expect(existsSync(join(orphan, ".git"))).toBe(true);
     expect(existsSync(join(orphan, "dirty.txt"))).toBe(true);

--- a/packages/client/src/__tests__/workspace-migrations.test.ts
+++ b/packages/client/src/__tests__/workspace-migrations.test.ts
@@ -60,7 +60,11 @@ describe("workspace-migrations registry", () => {
     expect(logs.some((l) => l.includes("v1-uuid-snapshots deferred"))).toBe(true);
   });
 
-  it("v1-uuid-snapshots runs (not deferred) when persisted state has source repos even if ctx is null", () => {
+  it("v1-uuid-snapshots STILL DEFERS when ctx is null even if persisted state is non-empty (PR #869 baixiaohang round-5 P0)", () => {
+    // Round-3/4 had a graceful fallback to persisted `managed.json` when ctx
+    // was null; round-5 closed that path because persisted state reflects a
+    // PREVIOUS config, not the current one — a fresh config edit followed by
+    // a cache miss would otherwise see the new repo as "absent" and `rm` it.
     const uuidDir = join(workspace, "12345678-abcd-4def-89ab-1234567890ab");
     mkdirSync(uuidDir);
     writeFileSync(join(uuidDir, "AGENTS.md"), "# legacy snapshot\n");
@@ -77,8 +81,8 @@ describe("workspace-migrations registry", () => {
 
     const result = applyPendingMigrations(workspace, () => {});
 
-    expect(result.deferred).not.toContain("v1-uuid-snapshots");
-    expect(existsSync(uuidDir)).toBe(false);
+    expect(result.deferred).toContain("v1-uuid-snapshots");
+    expect(existsSync(uuidDir)).toBe(true);
   });
 
   it("v1-uuid-snapshots leaves UUID-named directories WITHOUT the legacy snapshot signature alone (PR #869 P0)", () => {
@@ -340,7 +344,11 @@ describe("workspace-migrations registry", () => {
     expect(logs.some((l) => l.includes("v1-orphan-ft-clones deferred"))).toBe(true);
   });
 
-  it("v1-orphan-ft-clones runs (not deferred) when persisted state has source repos even if ctx is null (graceful fallback)", () => {
+  it("v1-orphan-ft-clones STILL DEFERS when ctx is null even if persisted state is non-empty (PR #869 baixiaohang round-5 P0)", () => {
+    // Same regression as the UUID test above: previous "graceful fallback to
+    // persisted state" path was racy — a fresh web-console add could be
+    // misidentified as orphan if cache missed before the new repo's name
+    // landed in `managed.json`. Defer instead and retry next resolved session.
     initRepo(join(workspace, "first-tree-hub"), "https://github.com/agent-team-foundation/first-tree-hub");
     initRepo(join(workspace, "first-tree"), "https://github.com/agent-team-foundation/first-tree");
     writeFileSync(
@@ -356,10 +364,9 @@ describe("workspace-migrations registry", () => {
 
     const result = applyPendingMigrations(workspace, () => {});
 
-    expect(result.deferred).not.toContain("v1-orphan-ft-clones");
-    // first-tree is in persisted → safe; first-tree-hub is orphan → removed.
+    expect(result.deferred).toContain("v1-orphan-ft-clones");
     expect(existsSync(join(workspace, "first-tree", ".git"))).toBe(true);
-    expect(existsSync(join(workspace, "first-tree-hub"))).toBe(false);
+    expect(existsSync(join(workspace, "first-tree-hub"))).toBe(true);
   });
 });
 

--- a/packages/client/src/__tests__/workspace-migrations.test.ts
+++ b/packages/client/src/__tests__/workspace-migrations.test.ts
@@ -1,0 +1,243 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  applyPendingMigrations,
+  MIGRATIONS_APPLIED_REL,
+  MIGRATIONS_REGISTRY,
+  type Migration,
+} from "../runtime/workspace-migrations.js";
+
+function initRepo(path: string, originUrl: string): void {
+  mkdirSync(path, { recursive: true });
+  execFileSync("git", ["init", "-b", "main"], { cwd: path, stdio: "ignore" });
+  execFileSync("git", ["remote", "add", "origin", originUrl], { cwd: path, stdio: "ignore" });
+}
+
+describe("workspace-migrations registry", () => {
+  let workspace: string;
+
+  beforeEach(() => {
+    workspace = mkdtempSync(join(tmpdir(), "workspace-migrations-test-"));
+    mkdirSync(join(workspace, ".agent"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(workspace, { recursive: true, force: true });
+  });
+
+  it("v1-uuid-snapshots removes UUID-named directories at workspace root", () => {
+    const uuidDir = join(workspace, "12345678-abcd-4def-89ab-1234567890ab");
+    const namedDir = join(workspace, "first-tree");
+    mkdirSync(uuidDir);
+    mkdirSync(namedDir);
+
+    applyPendingMigrations(workspace, () => {});
+
+    expect(existsSync(uuidDir)).toBe(false);
+    expect(existsSync(namedDir)).toBe(true);
+  });
+
+  it("v1-uuid-snapshots leaves non-UUID names alone even if hexish", () => {
+    const dirs = ["abc", "deadbeef", "0123456789abcdef0123456789abcdef"]; // wrong shape
+    for (const d of dirs) mkdirSync(join(workspace, d));
+
+    applyPendingMigrations(workspace, () => {});
+
+    for (const d of dirs) {
+      expect(existsSync(join(workspace, d))).toBe(true);
+    }
+  });
+
+  it("v1-legacy-dot-first-tree removes <ws>/.first-tree/ if present", () => {
+    const dotFirstTree = join(workspace, ".first-tree");
+    mkdirSync(join(dotFirstTree, "tmp"), { recursive: true });
+
+    applyPendingMigrations(workspace, () => {});
+
+    expect(existsSync(dotFirstTree)).toBe(false);
+  });
+
+  it("v1-whitepaper-symlink removes WHITEPAPER.md at workspace root", () => {
+    const whitepaper = join(workspace, "WHITEPAPER.md");
+    // Symlink target need not resolve; the migration just unlinks.
+    symlinkSync("/nonexistent", whitepaper);
+
+    applyPendingMigrations(workspace, () => {});
+
+    expect(existsSync(whitepaper)).toBe(false);
+  });
+
+  it("v1-orphan-ft-clones removes a clone whose origin is agent-team-foundation/* and not in current source repos", () => {
+    initRepo(join(workspace, "first-tree-hub"), "https://github.com/agent-team-foundation/first-tree-hub");
+    // The "current" set comes from `.agent/managed.json::sourceRepos`. An
+    // empty file means everything FT-origin is orphan.
+    writeFileSync(
+      join(workspace, ".agent", "managed.json"),
+      JSON.stringify({
+        schemaVersion: 1,
+        cliVersion: "test",
+        updatedAt: new Date().toISOString(),
+        sourceRepos: [],
+        skills: [],
+      }),
+    );
+
+    applyPendingMigrations(workspace, () => {});
+
+    expect(existsSync(join(workspace, "first-tree-hub"))).toBe(false);
+  });
+
+  it("v1-orphan-ft-clones leaves a clone in current source_repos alone", () => {
+    initRepo(join(workspace, "first-tree"), "https://github.com/agent-team-foundation/first-tree");
+    writeFileSync(
+      join(workspace, ".agent", "managed.json"),
+      JSON.stringify({
+        schemaVersion: 1,
+        cliVersion: "test",
+        updatedAt: new Date().toISOString(),
+        sourceRepos: ["first-tree"],
+        skills: [],
+      }),
+    );
+
+    applyPendingMigrations(workspace, () => {});
+
+    expect(existsSync(join(workspace, "first-tree", ".git"))).toBe(true);
+  });
+
+  it("v1-orphan-ft-clones leaves non-FT-origin clones alone", () => {
+    initRepo(join(workspace, "user-side-clone"), "https://github.com/some-other-org/their-repo");
+
+    applyPendingMigrations(workspace, () => {});
+
+    expect(existsSync(join(workspace, "user-side-clone", ".git"))).toBe(true);
+  });
+
+  it("v1-orphan-ft-clones skips dotfile-prefixed entries and worktrees/notes", () => {
+    initRepo(join(workspace, "worktrees"), "https://github.com/agent-team-foundation/anything");
+    initRepo(join(workspace, "notes"), "https://github.com/agent-team-foundation/anything");
+    initRepo(join(workspace, ".some-hidden"), "https://github.com/agent-team-foundation/anything");
+
+    applyPendingMigrations(workspace, () => {});
+
+    expect(existsSync(join(workspace, "worktrees", ".git"))).toBe(true);
+    expect(existsSync(join(workspace, "notes", ".git"))).toBe(true);
+    expect(existsSync(join(workspace, ".some-hidden", ".git"))).toBe(true);
+  });
+});
+
+describe("applyPendingMigrations applier", () => {
+  let workspace: string;
+
+  beforeEach(() => {
+    workspace = mkdtempSync(join(tmpdir(), "workspace-migrations-applier-test-"));
+    mkdirSync(join(workspace, ".agent"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(workspace, { recursive: true, force: true });
+  });
+
+  it("records applied ids in .agent/migrations-applied.json after a run", () => {
+    const ran: string[] = [];
+    const registry: readonly Migration[] = [
+      { id: "test-alpha", description: "", apply: () => ran.push("alpha") },
+      { id: "test-beta", description: "", apply: () => ran.push("beta") },
+    ];
+
+    const result = applyPendingMigrations(workspace, () => {}, registry);
+
+    expect(result.applied).toEqual(["test-alpha", "test-beta"]);
+    expect(ran).toEqual(["alpha", "beta"]);
+
+    const markerPath = join(workspace, MIGRATIONS_APPLIED_REL);
+    expect(existsSync(markerPath)).toBe(true);
+    const marker = JSON.parse(readFileSync(markerPath, "utf-8")) as { applied: string[] };
+    expect(marker.applied).toEqual(["test-alpha", "test-beta"]);
+  });
+
+  it("skips migrations already listed in the marker", () => {
+    writeFileSync(
+      join(workspace, MIGRATIONS_APPLIED_REL),
+      JSON.stringify({ schemaVersion: 1, applied: ["test-alpha"] }),
+    );
+    const ran: string[] = [];
+    const registry: readonly Migration[] = [
+      { id: "test-alpha", description: "", apply: () => ran.push("alpha") },
+      { id: "test-beta", description: "", apply: () => ran.push("beta") },
+    ];
+
+    const result = applyPendingMigrations(workspace, () => {}, registry);
+
+    expect(result.applied).toEqual(["test-beta"]);
+    expect(result.skipped).toEqual(["test-alpha"]);
+    expect(ran).toEqual(["beta"]);
+  });
+
+  it("does NOT record an id in the marker when its apply throws", () => {
+    const registry: readonly Migration[] = [
+      {
+        id: "test-fails",
+        description: "",
+        apply: () => {
+          throw new Error("synthetic failure");
+        },
+      },
+      { id: "test-passes", description: "", apply: () => {} },
+    ];
+
+    const logs: string[] = [];
+    const result = applyPendingMigrations(workspace, (msg) => logs.push(msg), registry);
+
+    expect(result.failed).toHaveLength(1);
+    expect(result.failed[0]?.id).toBe("test-fails");
+    expect(result.applied).toEqual(["test-passes"]);
+
+    const marker = JSON.parse(readFileSync(join(workspace, MIGRATIONS_APPLIED_REL), "utf-8")) as { applied: string[] };
+    // test-fails MUST NOT appear in the marker so a future run retries.
+    expect(marker.applied).toEqual(["test-passes"]);
+    // The failure was surfaced via the log channel.
+    expect(logs.some((l) => l.includes("test-fails"))).toBe(true);
+  });
+
+  it("does not rewrite the marker file when nothing new applied", () => {
+    writeFileSync(
+      join(workspace, MIGRATIONS_APPLIED_REL),
+      JSON.stringify({ schemaVersion: 1, applied: ["test-alpha"] }),
+    );
+    const before = readFileSync(join(workspace, MIGRATIONS_APPLIED_REL), "utf-8");
+    const registry: readonly Migration[] = [{ id: "test-alpha", description: "", apply: () => {} }];
+
+    applyPendingMigrations(workspace, () => {}, registry);
+
+    const after = readFileSync(join(workspace, MIGRATIONS_APPLIED_REL), "utf-8");
+    expect(after).toBe(before);
+  });
+
+  it("treats a malformed marker as empty (re-applies all)", () => {
+    writeFileSync(join(workspace, MIGRATIONS_APPLIED_REL), "{ not json");
+    const ran: string[] = [];
+    const registry: readonly Migration[] = [{ id: "test-alpha", description: "", apply: () => ran.push("alpha") }];
+
+    const result = applyPendingMigrations(workspace, () => {}, registry);
+
+    expect(result.applied).toEqual(["test-alpha"]);
+    expect(ran).toEqual(["alpha"]);
+  });
+
+  it("MIGRATIONS_REGISTRY ids are unique (sanity check the production list)", () => {
+    const ids = MIGRATIONS_REGISTRY.map((m) => m.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("re-running on a clean workspace is a noop (registry idempotent)", () => {
+    applyPendingMigrations(workspace, () => {});
+    const markerBefore = readFileSync(join(workspace, MIGRATIONS_APPLIED_REL), "utf-8");
+    applyPendingMigrations(workspace, () => {});
+    const markerAfter = readFileSync(join(workspace, MIGRATIONS_APPLIED_REL), "utf-8");
+    expect(markerAfter).toBe(markerBefore);
+  });
+});

--- a/packages/client/src/__tests__/workspace-migrations.test.ts
+++ b/packages/client/src/__tests__/workspace-migrations.test.ts
@@ -51,13 +51,52 @@ describe("workspace-migrations registry", () => {
     }
   });
 
-  it("v1-legacy-dot-first-tree removes <ws>/.first-tree/ if present", () => {
+  it("does not touch <ws>/.first-tree/ (active W1 binding state — migration withdrawn)", () => {
     const dotFirstTree = join(workspace, ".first-tree");
-    mkdirSync(join(dotFirstTree, "tmp"), { recursive: true });
+    mkdirSync(dotFirstTree, { recursive: true });
+    // The W1 binding manifest lives at `.first-tree/workspace.json` — see
+    // `packages/shared/src/schemas/workspace-manifest.ts` (WORKSPACE_STATE_DIRNAME).
+    // A blind sweep here would silently unbind the workspace on upgrade.
+    writeFileSync(join(dotFirstTree, "workspace.json"), JSON.stringify({ tree: "tree", sources: [] }));
 
     applyPendingMigrations(workspace, () => {});
 
-    expect(existsSync(dotFirstTree)).toBe(false);
+    expect(existsSync(dotFirstTree)).toBe(true);
+    expect(existsSync(join(dotFirstTree, "workspace.json"))).toBe(true);
+  });
+
+  it("v1-whitepaper-symlink does NOT remove a regular WHITEPAPER.md file", () => {
+    const whitepaper = join(workspace, "WHITEPAPER.md");
+    writeFileSync(whitepaper, "# User's own document\n");
+
+    applyPendingMigrations(workspace, () => {});
+
+    expect(existsSync(whitepaper)).toBe(true);
+    expect(readFileSync(whitepaper, "utf-8")).toBe("# User's own document\n");
+  });
+
+  it("v1-orphan-ft-clones holds back dirty clones via the shared safety guards", () => {
+    const orphan = join(workspace, "first-tree-hub");
+    initRepo(orphan, "https://github.com/agent-team-foundation/first-tree-hub");
+    // Stage an unpushed dirty change so `git status --porcelain` reports
+    // something — the safety guards should refuse to delete.
+    writeFileSync(join(orphan, "dirty.txt"), "uncommitted work\n");
+
+    writeFileSync(
+      join(workspace, ".agent", "managed.json"),
+      JSON.stringify({
+        schemaVersion: 1,
+        cliVersion: "test",
+        updatedAt: new Date().toISOString(),
+        sourceRepos: [],
+        skills: [],
+      }),
+    );
+
+    applyPendingMigrations(workspace, () => {});
+
+    expect(existsSync(join(orphan, ".git"))).toBe(true);
+    expect(existsSync(join(orphan, "dirty.txt"))).toBe(true);
   });
 
   it("v1-whitepaper-symlink removes WHITEPAPER.md at workspace root", () => {

--- a/packages/client/src/__tests__/workspace-migrations.test.ts
+++ b/packages/client/src/__tests__/workspace-migrations.test.ts
@@ -28,10 +28,12 @@ describe("workspace-migrations registry", () => {
     rmSync(workspace, { recursive: true, force: true });
   });
 
-  it("v1-uuid-snapshots removes UUID-named directories at workspace root", () => {
+  it("v1-uuid-snapshots removes UUID-named directories that carry the legacy snapshot signature", () => {
     const uuidDir = join(workspace, "12345678-abcd-4def-89ab-1234567890ab");
     const namedDir = join(workspace, "first-tree");
     mkdirSync(uuidDir);
+    // Legacy per-chat snapshots always had AGENTS.md / CLAUDE.md at their root.
+    writeFileSync(join(uuidDir, "AGENTS.md"), "# legacy chat snapshot\n");
     mkdirSync(namedDir);
 
     applyPendingMigrations(workspace, () => {});
@@ -40,15 +42,132 @@ describe("workspace-migrations registry", () => {
     expect(existsSync(namedDir)).toBe(true);
   });
 
+  it("v1-uuid-snapshots leaves UUID-named directories WITHOUT the legacy snapshot signature alone (PR #869 P0)", () => {
+    // A user-created UUID-named directory (no AGENTS.md / CLAUDE.md at root)
+    // must not be deleted — the migration is scoped to the per-chat-cwd shape.
+    const userUuidDir = join(workspace, "abcdef01-2345-4789-abcd-ef0123456789");
+    mkdirSync(userUuidDir);
+    writeFileSync(join(userUuidDir, "user-data.json"), "{}");
+
+    applyPendingMigrations(workspace, () => {});
+
+    expect(existsSync(userUuidDir)).toBe(true);
+    expect(existsSync(join(userUuidDir, "user-data.json"))).toBe(true);
+  });
+
+  it("v1-uuid-snapshots leaves a UUID-named directory that's currently in source_repos config (PR #869 P0)", () => {
+    // Edge case: agent config has a `gitRepos.localPath` shaped like a UUID.
+    // The migration must NOT delete it even when it has a top-level
+    // AGENTS.md (e.g. the cloned repo happens to ship one).
+    const uuidRepo = join(workspace, "fedcba98-7654-4321-9abc-def012345678");
+    mkdirSync(uuidRepo);
+    writeFileSync(join(uuidRepo, "AGENTS.md"), "# this repo happens to ship AGENTS.md\n");
+    writeFileSync(
+      join(workspace, ".agent", "managed.json"),
+      JSON.stringify({
+        schemaVersion: 1,
+        cliVersion: "test",
+        updatedAt: new Date().toISOString(),
+        sourceRepos: ["fedcba98-7654-4321-9abc-def012345678"],
+        skills: [],
+      }),
+    );
+
+    applyPendingMigrations(workspace, () => {});
+
+    expect(existsSync(uuidRepo)).toBe(true);
+  });
+
   it("v1-uuid-snapshots leaves non-UUID names alone even if hexish", () => {
     const dirs = ["abc", "deadbeef", "0123456789abcdef0123456789abcdef"]; // wrong shape
-    for (const d of dirs) mkdirSync(join(workspace, d));
+    for (const d of dirs) {
+      mkdirSync(join(workspace, d));
+      // Add the snapshot signature too — proves the UUID shape is also required.
+      writeFileSync(join(workspace, d, "AGENTS.md"), "");
+    }
 
     applyPendingMigrations(workspace, () => {});
 
     for (const d of dirs) {
       expect(existsSync(join(workspace, d))).toBe(true);
     }
+  });
+
+  it("v1-retired-source-repo-first-tree-hub removes a `first-tree-hub/` with a broken `.git` pointer (PR #869 P0)", () => {
+    // Reproduces the real-world shape code-reviewer flagged: `.git` is a
+    // pointer file (not a directory), and its target gitdir has been
+    // deleted, so `git config --get remote.origin.url` exits 128 and the
+    // origin-URL-based `v1-orphan-ft-clones` sweep cannot match.
+    const target = join(workspace, "first-tree-hub");
+    mkdirSync(target);
+    writeFileSync(join(target, ".git"), "gitdir: /tmp/does-not-exist/worktrees/first-tree-hub\n");
+
+    applyPendingMigrations(workspace, () => {});
+
+    expect(existsSync(target)).toBe(false);
+  });
+
+  it("v1-retired-source-repo-first-tree-hub does NOT remove `first-tree-hub/` if it's still in current source_repos", () => {
+    const target = join(workspace, "first-tree-hub");
+    mkdirSync(target);
+    writeFileSync(join(target, ".git"), "gitdir: /tmp/somewhere\n");
+    writeFileSync(
+      join(workspace, ".agent", "managed.json"),
+      JSON.stringify({
+        schemaVersion: 1,
+        cliVersion: "test",
+        updatedAt: new Date().toISOString(),
+        sourceRepos: ["first-tree-hub"],
+        skills: [],
+      }),
+    );
+
+    applyPendingMigrations(workspace, () => {});
+
+    expect(existsSync(target)).toBe(true);
+  });
+
+  it("v1-retired-source-repo-first-tree-hub does NOT remove a plain directory named `first-tree-hub/` with no `.git`", () => {
+    // A user could legitimately create a folder named first-tree-hub for
+    // notes or scratch. Require the `.git` proof before deleting.
+    const target = join(workspace, "first-tree-hub");
+    mkdirSync(target);
+    writeFileSync(join(target, "user-notes.md"), "# my notes\n");
+
+    applyPendingMigrations(workspace, () => {});
+
+    expect(existsSync(target)).toBe(true);
+    expect(existsSync(join(target, "user-notes.md"))).toBe(true);
+  });
+
+  it("v1-retired-source-repo-first-tree-hub defers to v1-orphan-ft-clones when `.git` is a healthy directory (PR #869 code-reviewer follow-up)", () => {
+    // A healthy clone — `.git` is a real directory. The retired-hub migration
+    // must NOT bypass the dirty / ahead / worktree guards; v1-orphan-ft-clones
+    // owns that path. Combined with the dirty payload below, this confirms
+    // the safety guards still apply.
+    const target = join(workspace, "first-tree-hub");
+    initRepo(target, "https://github.com/agent-team-foundation/first-tree-hub");
+    writeFileSync(join(target, "dirty.txt"), "uncommitted user work\n");
+
+    applyPendingMigrations(workspace, () => {});
+
+    expect(existsSync(target)).toBe(true);
+    expect(existsSync(join(target, "dirty.txt"))).toBe(true);
+  });
+
+  it("v1-retired-source-repo-first-tree-hub does NOT delete when `.git` pointer target still exists (live linked checkout)", () => {
+    // A `.git` pointer file whose target IS on disk is a live linked
+    // checkout (`git worktree add`-style). Must not delete.
+    const target = join(workspace, "first-tree-hub");
+    mkdirSync(target);
+    const livePointerTarget = join(workspace, "fake-gitdir");
+    mkdirSync(livePointerTarget);
+    writeFileSync(join(target, ".git"), `gitdir: ${livePointerTarget}\n`);
+
+    applyPendingMigrations(workspace, () => {});
+
+    expect(existsSync(target)).toBe(true);
+    expect(existsSync(join(target, ".git"))).toBe(true);
   });
 
   it("does not touch <ws>/.first-tree/ (active W1 binding state — migration withdrawn)", () => {

--- a/packages/client/src/__tests__/workspace-migrations.test.ts
+++ b/packages/client/src/__tests__/workspace-migrations.test.ts
@@ -230,25 +230,68 @@ describe("workspace-migrations registry", () => {
 
   it("v1-orphan-ft-clones removes a clone whose origin is agent-team-foundation/* and not in current source repos", () => {
     initRepo(join(workspace, "first-tree-hub"), "https://github.com/agent-team-foundation/first-tree-hub");
-    // The "current" set comes from `.agent/managed.json::sourceRepos`. An
-    // empty file means everything FT-origin is orphan.
-    writeFileSync(
-      join(workspace, ".agent", "managed.json"),
-      JSON.stringify({
-        schemaVersion: 1,
-        cliVersion: "test",
-        updatedAt: new Date().toISOString(),
-        sourceRepos: [],
-        skills: [],
-      }),
-    );
-
-    applyPendingMigrations(workspace, () => {});
+    // The authoritative current set comes from the caller's ctx — an
+    // explicit empty Set says "config genuinely has zero repos", which lets
+    // the migration treat every FT-origin clone as orphaned.
+    applyPendingMigrations(workspace, () => {}, { currentSourceRepoNames: new Set() });
 
     expect(existsSync(join(workspace, "first-tree-hub"))).toBe(false);
   });
 
   it("v1-orphan-ft-clones leaves a clone in current source_repos alone", () => {
+    initRepo(join(workspace, "first-tree"), "https://github.com/agent-team-foundation/first-tree");
+
+    applyPendingMigrations(workspace, () => {}, { currentSourceRepoNames: new Set(["first-tree"]) });
+
+    expect(existsSync(join(workspace, "first-tree", ".git"))).toBe(true);
+  });
+
+  it("v1-orphan-ft-clones leaves non-FT-origin clones alone", () => {
+    initRepo(join(workspace, "user-side-clone"), "https://github.com/some-other-org/their-repo");
+
+    applyPendingMigrations(workspace, () => {}, { currentSourceRepoNames: new Set() });
+
+    expect(existsSync(join(workspace, "user-side-clone", ".git"))).toBe(true);
+  });
+
+  it("v1-orphan-ft-clones skips dotfile-prefixed entries and worktrees/notes", () => {
+    initRepo(join(workspace, "worktrees"), "https://github.com/agent-team-foundation/anything");
+    initRepo(join(workspace, "notes"), "https://github.com/agent-team-foundation/anything");
+    initRepo(join(workspace, ".some-hidden"), "https://github.com/agent-team-foundation/anything");
+
+    applyPendingMigrations(workspace, () => {}, { currentSourceRepoNames: new Set() });
+
+    expect(existsSync(join(workspace, "worktrees", ".git"))).toBe(true);
+    expect(existsSync(join(workspace, "notes", ".git"))).toBe(true);
+    expect(existsSync(join(workspace, ".some-hidden", ".git"))).toBe(true);
+  });
+
+  it("v1-orphan-ft-clones DEFERS when the live config is unresolved AND state has no source repos (PR #869 baixiaohang round-3 P0)", () => {
+    // The regression code-reviewer flagged: on a legacy workspace's first
+    // upgraded start with a cache-miss, ctx.currentSourceRepoNames is null
+    // AND `.agent/managed.json` has not been written yet by a resolved
+    // `prepareSourceRepos` run, so the persisted set is also empty. The
+    // migration must defer and leave the clone untouched, not treat the
+    // empty-fallback as "config truly has no repos".
+    initRepo(join(workspace, "first-tree"), "https://github.com/agent-team-foundation/first-tree");
+    const logs: string[] = [];
+
+    const result = applyPendingMigrations(workspace, (msg) => logs.push(msg));
+
+    expect(existsSync(join(workspace, "first-tree", ".git"))).toBe(true);
+    expect(result.deferred).toContain("v1-orphan-ft-clones");
+    // Marker MUST NOT record the deferred id — the next resolved session
+    // gets another shot.
+    const markerPath = join(workspace, MIGRATIONS_APPLIED_REL);
+    if (existsSync(markerPath)) {
+      const marker = JSON.parse(readFileSync(markerPath, "utf-8")) as { applied: string[] };
+      expect(marker.applied).not.toContain("v1-orphan-ft-clones");
+    }
+    expect(logs.some((l) => l.includes("v1-orphan-ft-clones deferred"))).toBe(true);
+  });
+
+  it("v1-orphan-ft-clones runs (not deferred) when persisted state has source repos even if ctx is null (graceful fallback)", () => {
+    initRepo(join(workspace, "first-tree-hub"), "https://github.com/agent-team-foundation/first-tree-hub");
     initRepo(join(workspace, "first-tree"), "https://github.com/agent-team-foundation/first-tree");
     writeFileSync(
       join(workspace, ".agent", "managed.json"),
@@ -261,29 +304,12 @@ describe("workspace-migrations registry", () => {
       }),
     );
 
-    applyPendingMigrations(workspace, () => {});
+    const result = applyPendingMigrations(workspace, () => {});
 
+    expect(result.deferred).not.toContain("v1-orphan-ft-clones");
+    // first-tree is in persisted → safe; first-tree-hub is orphan → removed.
     expect(existsSync(join(workspace, "first-tree", ".git"))).toBe(true);
-  });
-
-  it("v1-orphan-ft-clones leaves non-FT-origin clones alone", () => {
-    initRepo(join(workspace, "user-side-clone"), "https://github.com/some-other-org/their-repo");
-
-    applyPendingMigrations(workspace, () => {});
-
-    expect(existsSync(join(workspace, "user-side-clone", ".git"))).toBe(true);
-  });
-
-  it("v1-orphan-ft-clones skips dotfile-prefixed entries and worktrees/notes", () => {
-    initRepo(join(workspace, "worktrees"), "https://github.com/agent-team-foundation/anything");
-    initRepo(join(workspace, "notes"), "https://github.com/agent-team-foundation/anything");
-    initRepo(join(workspace, ".some-hidden"), "https://github.com/agent-team-foundation/anything");
-
-    applyPendingMigrations(workspace, () => {});
-
-    expect(existsSync(join(workspace, "worktrees", ".git"))).toBe(true);
-    expect(existsSync(join(workspace, "notes", ".git"))).toBe(true);
-    expect(existsSync(join(workspace, ".some-hidden", ".git"))).toBe(true);
+    expect(existsSync(join(workspace, "first-tree-hub"))).toBe(false);
   });
 });
 
@@ -302,11 +328,23 @@ describe("applyPendingMigrations applier", () => {
   it("records applied ids in .agent/migrations-applied.json after a run", () => {
     const ran: string[] = [];
     const registry: readonly Migration[] = [
-      { id: "test-alpha", description: "", apply: () => ran.push("alpha") },
-      { id: "test-beta", description: "", apply: () => ran.push("beta") },
+      {
+        id: "test-alpha",
+        description: "",
+        apply: () => {
+          ran.push("alpha");
+        },
+      },
+      {
+        id: "test-beta",
+        description: "",
+        apply: () => {
+          ran.push("beta");
+        },
+      },
     ];
 
-    const result = applyPendingMigrations(workspace, () => {}, registry);
+    const result = applyPendingMigrations(workspace, () => {}, { currentSourceRepoNames: null }, registry);
 
     expect(result.applied).toEqual(["test-alpha", "test-beta"]);
     expect(ran).toEqual(["alpha", "beta"]);
@@ -324,11 +362,23 @@ describe("applyPendingMigrations applier", () => {
     );
     const ran: string[] = [];
     const registry: readonly Migration[] = [
-      { id: "test-alpha", description: "", apply: () => ran.push("alpha") },
-      { id: "test-beta", description: "", apply: () => ran.push("beta") },
+      {
+        id: "test-alpha",
+        description: "",
+        apply: () => {
+          ran.push("alpha");
+        },
+      },
+      {
+        id: "test-beta",
+        description: "",
+        apply: () => {
+          ran.push("beta");
+        },
+      },
     ];
 
-    const result = applyPendingMigrations(workspace, () => {}, registry);
+    const result = applyPendingMigrations(workspace, () => {}, { currentSourceRepoNames: null }, registry);
 
     expect(result.applied).toEqual(["test-beta"]);
     expect(result.skipped).toEqual(["test-alpha"]);
@@ -348,7 +398,12 @@ describe("applyPendingMigrations applier", () => {
     ];
 
     const logs: string[] = [];
-    const result = applyPendingMigrations(workspace, (msg) => logs.push(msg), registry);
+    const result = applyPendingMigrations(
+      workspace,
+      (msg) => logs.push(msg),
+      { currentSourceRepoNames: null },
+      registry,
+    );
 
     expect(result.failed).toHaveLength(1);
     expect(result.failed[0]?.id).toBe("test-fails");
@@ -369,7 +424,7 @@ describe("applyPendingMigrations applier", () => {
     const before = readFileSync(join(workspace, MIGRATIONS_APPLIED_REL), "utf-8");
     const registry: readonly Migration[] = [{ id: "test-alpha", description: "", apply: () => {} }];
 
-    applyPendingMigrations(workspace, () => {}, registry);
+    applyPendingMigrations(workspace, () => {}, { currentSourceRepoNames: null }, registry);
 
     const after = readFileSync(join(workspace, MIGRATIONS_APPLIED_REL), "utf-8");
     expect(after).toBe(before);
@@ -378,9 +433,17 @@ describe("applyPendingMigrations applier", () => {
   it("treats a malformed marker as empty (re-applies all)", () => {
     writeFileSync(join(workspace, MIGRATIONS_APPLIED_REL), "{ not json");
     const ran: string[] = [];
-    const registry: readonly Migration[] = [{ id: "test-alpha", description: "", apply: () => ran.push("alpha") }];
+    const registry: readonly Migration[] = [
+      {
+        id: "test-alpha",
+        description: "",
+        apply: () => {
+          ran.push("alpha");
+        },
+      },
+    ];
 
-    const result = applyPendingMigrations(workspace, () => {}, registry);
+    const result = applyPendingMigrations(workspace, () => {}, { currentSourceRepoNames: null }, registry);
 
     expect(result.applied).toEqual(["test-alpha"]);
     expect(ran).toEqual(["alpha"]);

--- a/packages/client/src/handlers/claude-code-tui/index.ts
+++ b/packages/client/src/handlers/claude-code-tui/index.ts
@@ -533,7 +533,8 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
         ctx = sessionCtx;
         cwd = acquireAgentHome(workspaceRoot);
 
-        const payload = (await loadPayload(sessionCtx)) ?? defaultPayload();
+        const resolvedPayload = await loadPayload(sessionCtx);
+        const payload = resolvedPayload ?? defaultPayload();
 
         // Per-chat material flows through the unified briefing
         // (`<cwd>/AGENTS.md`, with `<cwd>/CLAUDE.md` symlinked to it). Resolve
@@ -547,6 +548,10 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
           sessionCtx,
           gitMirrorManager,
           agentName,
+          // `payloadResolved: false` when we fell back to `defaultPayload()` —
+          // the empty `gitRepos: []` is then NOT authoritative and state-based
+          // cleanup is suppressed for this session (see PR #869 P0-2).
+          payloadResolved: resolvedPayload !== null && resolvedPayload !== undefined,
         });
         ensureAgentBootstrap({
           workspace: cwd,
@@ -580,7 +585,8 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
         ctx = sessionCtx;
         cwd = acquireAgentHome(workspaceRoot);
 
-        const payload = (await loadPayload(sessionCtx)) ?? defaultPayload();
+        const resumePayloadResolved = await loadPayload(sessionCtx);
+        const payload = resumePayloadResolved ?? defaultPayload();
 
         chatContextForPrompt = await fetchChatContextOrLog(sessionCtx);
         sourceReposForPrompt = await prepareSourceRepos({
@@ -589,6 +595,8 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
           sessionCtx,
           gitMirrorManager,
           agentName,
+          // See PR #869 P0-2: same gate as the start() path.
+          payloadResolved: resumePayloadResolved !== null && resumePayloadResolved !== undefined,
         });
         // Same shared bootstrap as start(): ensureAgentBootstrap handles the
         // sentinel + Context-Tree/CLI drift internally, so a stale or failed

--- a/packages/client/src/handlers/claude-code-tui/index.ts
+++ b/packages/client/src/handlers/claude-code-tui/index.ts
@@ -9,7 +9,11 @@ import type { PredeclaredSourceRepo } from "../../runtime/bootstrap.js";
 import { type ChatContext, fetchChatContext } from "../../runtime/chat-context.js";
 import type { GitMirrorManager } from "../../runtime/git-mirror-manager.js";
 import type { AgentHandler, HandlerFactory, SessionContext, SessionMessage } from "../../runtime/handler.js";
-import { prepareSourceRepos, releaseSourceReposForSession } from "../../runtime/source-repos.js";
+import {
+  currentSourceRepoNamesFromPayload,
+  prepareSourceRepos,
+  releaseSourceReposForSession,
+} from "../../runtime/source-repos.js";
 import { acquireAgentHome, markWorkspaceInitComplete } from "../../runtime/workspace.js";
 import { createToolCallProcessor, mapMcpServers } from "../claude-code.js";
 import { resolveClaudeCodeExecutable } from "../claude-executable.js";
@@ -558,6 +562,14 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
           sessionCtx,
           contextTreePath,
           briefing: buildBriefing(sessionCtx, payload, cwd),
+          // Forward the authoritative current source-repo set to migrations
+          // (PR #869 baixiaohang round-3 P0). Same `payloadResolved` signal as
+          // above — null when defaultPayload was used, so v1-orphan-ft-clones
+          // defers until a future resolved start.
+          currentSourceRepoNames: currentSourceRepoNamesFromPayload(
+            payload,
+            resolvedPayload !== null && resolvedPayload !== undefined,
+          ),
         });
         markWorkspaceInitComplete(cwd);
 
@@ -606,6 +618,11 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
           sessionCtx,
           contextTreePath,
           briefing: buildBriefing(sessionCtx, payload, cwd),
+          // See PR #869 baixiaohang round-3 P0 — same gate as start().
+          currentSourceRepoNames: currentSourceRepoNamesFromPayload(
+            payload,
+            resumePayloadResolved !== null && resumePayloadResolved !== undefined,
+          ),
         });
         markWorkspaceInitComplete(cwd);
 

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -1398,12 +1398,19 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
     // Delegates to the shared helper (runtime/source-repos.ts) so the SDK and
     // TUI handlers share one worktree-lock / Hub-marker implementation rather
     // than each carrying its own source-repo invariant.
+    //
+    // `payloadResolved` distinguishes "agent config truly says zero repos"
+    // from "we couldn't reach the cache/server and `payload` is undefined".
+    // Without this gate, a cache miss would compute an empty current-repo
+    // set and the state-reconcile path would `rm` every previously-managed
+    // clone. See `PrepareSourceReposParams.payloadResolved`.
     sourceReposForPrompt = await prepareSourceReposShared({
       workspace,
       payload,
       sessionCtx,
       gitMirrorManager,
       agentName,
+      payloadResolved: payload !== undefined,
     });
   }
 

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -30,6 +30,7 @@ import { findImagePath } from "../runtime/image-store.js";
 import { InputController } from "../runtime/input-controller.js";
 import { materializeResourceSkills } from "../runtime/resource-skills.js";
 import {
+  currentSourceRepoNamesFromPayload,
   prepareSourceRepos as prepareSourceReposShared,
   releaseSourceReposForSession,
 } from "../runtime/source-repos.js";
@@ -1523,11 +1524,26 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
    * `workspaceId` for the integrate shell-out is the agent name — the home
    * directory is per-agent, so the skill identity stays stable across chats.
    */
-  function ensureAgentBootstrap(workspace: string, sessionCtx: SessionContext, briefing: string): void {
+  function ensureAgentBootstrap(
+    workspace: string,
+    sessionCtx: SessionContext,
+    briefing: string,
+    payload: AgentRuntimeConfigPayload | undefined,
+  ): void {
     // Delegates to the shared helper (runtime/agent-bootstrap.ts) so the SDK
     // and TUI handlers share one briefing / core-skill / drift-pin contract
     // rather than each maintaining a partial copy.
-    ensureAgentBootstrapShared({ workspace, sessionCtx, contextTreePath, briefing });
+    //
+    // `currentSourceRepoNames` is threaded through to the migration applier
+    // so `v1-orphan-ft-clones` can defer when the live config is unresolved
+    // (cache miss). See PR #869 baixiaohang round-3 P0.
+    ensureAgentBootstrapShared({
+      workspace,
+      sessionCtx,
+      contextTreePath,
+      briefing,
+      currentSourceRepoNames: currentSourceRepoNamesFromPayload(payload, payload !== undefined),
+    });
   }
 
   const handler: AgentHandler = {
@@ -1555,7 +1571,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       await materializeResourceSkills(cwd, payload, sessionCtx);
 
       const briefing = currentBriefing(sessionCtx, cwd, payload);
-      ensureAgentBootstrap(cwd, sessionCtx, briefing);
+      ensureAgentBootstrap(cwd, sessionCtx, briefing, payload);
 
       // Stage-2 sentinel: written once per agent home. Future starts short-
       // circuit the expensive integrate path on its presence.
@@ -1657,7 +1673,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       await materializeResourceSkills(cwd, payload, sessionCtx);
 
       const briefing = currentBriefing(sessionCtx, cwd, payload);
-      ensureAgentBootstrap(cwd, sessionCtx, briefing);
+      ensureAgentBootstrap(cwd, sessionCtx, briefing, payload);
 
       markWorkspaceInitComplete(cwd);
 

--- a/packages/client/src/handlers/codex.ts
+++ b/packages/client/src/handlers/codex.ts
@@ -23,6 +23,7 @@ import type {
 } from "../runtime/handler.js";
 import { materializeResourceSkills } from "../runtime/resource-skills.js";
 import {
+  currentSourceRepoNamesFromPayload,
   prepareSourceRepos as prepareSourceReposShared,
   releaseSourceReposForSession,
 } from "../runtime/source-repos.js";
@@ -1045,13 +1046,23 @@ export const createCodexHandler: HandlerFactory = (config) => {
    * no per-turn prompt API to update mid-thread — debug "wrong chat context
    * surfaces in codex" symptoms by looking here first.
    */
-  function ensureCodexBootstrap(workspace: string, sessionCtx: SessionContext, briefing: string): void {
+  function ensureCodexBootstrap(
+    workspace: string,
+    sessionCtx: SessionContext,
+    briefing: string,
+    payload: AgentRuntimeConfigPayload,
+    payloadResolved: boolean,
+  ): void {
     detectAgentsMdConcurrentWrite(workspace, Date.now(), (m) => sessionCtx.log(m));
     ensureAgentBootstrapShared({
       workspace,
       sessionCtx,
       contextTreePath,
       briefing,
+      // PR #869 baixiaohang round-3 P0: thread the authoritative current
+      // source-repo set into migrations so `v1-orphan-ft-clones` can defer
+      // when the live config is unresolved.
+      currentSourceRepoNames: currentSourceRepoNamesFromPayload(payload, payloadResolved),
     });
   }
 
@@ -1092,7 +1103,7 @@ export const createCodexHandler: HandlerFactory = (config) => {
       await materializeResourceSkills(cwd, payload, sessionCtx);
 
       const briefing = buildBriefing(sessionCtx, payload, chatContext, cwd);
-      ensureCodexBootstrap(cwd, sessionCtx, briefing);
+      ensureCodexBootstrap(cwd, sessionCtx, briefing, payload, payloadResolved);
       markWorkspaceInitComplete(cwd);
 
       codex = new Codex({ env: buildEnv(sessionCtx), config: buildCodexConfig(payload) });
@@ -1150,7 +1161,7 @@ export const createCodexHandler: HandlerFactory = (config) => {
       await materializeResourceSkills(cwd, payload, sessionCtx);
 
       const briefing = buildBriefing(sessionCtx, payload, chatContext, cwd);
-      ensureCodexBootstrap(cwd, sessionCtx, briefing);
+      ensureCodexBootstrap(cwd, sessionCtx, briefing, payload, resumePayloadResolved);
       markWorkspaceInitComplete(cwd);
 
       codex = new Codex({ env: buildEnv(sessionCtx), config: buildCodexConfig(payload) });

--- a/packages/client/src/handlers/codex.ts
+++ b/packages/client/src/handlers/codex.ts
@@ -550,18 +550,24 @@ export const createCodexHandler: HandlerFactory = (config) => {
     payload: AgentRuntimeConfigPayload,
     workspaceCwd: string,
     sessionCtx: SessionContext,
+    payloadResolved: boolean,
   ): Promise<void> {
     // Delegate to the shared helper (runtime/source-repos.ts) so the
     // standalone-clone materialisation + per-clone lock + decision-B in-use
     // refcount stay in one place across the SDK, TUI, and codex handlers. The
     // returned list feeds the per-session AGENTS.md "Source Repositories" block
     // on the next `buildAgentBriefing` call.
+    //
+    // `payloadResolved` is forwarded so the shared helper can decide whether
+    // its empty `gitRepos: []` is authoritative — see
+    // `PrepareSourceReposParams.payloadResolved` and PR #869 P0-2.
     sourceReposForPrompt = await prepareSourceReposShared({
       workspace: workspaceCwd,
       payload,
       sessionCtx,
       gitMirrorManager,
       agentName,
+      payloadResolved,
     });
   }
 
@@ -1060,6 +1066,11 @@ export const createCodexHandler: HandlerFactory = (config) => {
       if (agentConfigCache) {
         payload = (await agentConfigCache.refresh(sessionCtx.agent.agentId)).payload;
       }
+      // Track whether the payload reflects a real config — used by the source-
+      // repo state reconcile to distinguish "config has zero repos" from "we
+      // couldn't reach the cache". A `false` here suppresses cleanup of
+      // previously-managed clones; see PR #869 P0-2.
+      const payloadResolved = payload !== null;
       if (!payload) {
         payload = {
           kind: "codex",
@@ -1077,7 +1088,7 @@ export const createCodexHandler: HandlerFactory = (config) => {
 
       // gitRepos first so the per-chat briefing can list the predeclared
       // worktree paths the agent should know about.
-      await prepareSourceRepos(payload, cwd, sessionCtx);
+      await prepareSourceRepos(payload, cwd, sessionCtx, payloadResolved);
       await materializeResourceSkills(cwd, payload, sessionCtx);
 
       const briefing = buildBriefing(sessionCtx, payload, chatContext, cwd);
@@ -1116,6 +1127,7 @@ export const createCodexHandler: HandlerFactory = (config) => {
       if (agentConfigCache) {
         payload = (await agentConfigCache.refresh(sessionCtx.agent.agentId)).payload;
       }
+      const resumePayloadResolved = payload !== null;
       if (!payload) {
         payload = {
           kind: "codex",
@@ -1134,7 +1146,7 @@ export const createCodexHandler: HandlerFactory = (config) => {
       // `first-tree tree skill install` shell-out.
       const chatContext = await fetchChatContextOrLog(sessionCtx);
 
-      await prepareSourceRepos(payload, cwd, sessionCtx);
+      await prepareSourceRepos(payload, cwd, sessionCtx, resumePayloadResolved);
       await materializeResourceSkills(cwd, payload, sessionCtx);
 
       const briefing = buildBriefing(sessionCtx, payload, chatContext, cwd);

--- a/packages/client/src/runtime/agent-bootstrap.ts
+++ b/packages/client/src/runtime/agent-bootstrap.ts
@@ -113,7 +113,7 @@ export function ensureAgentBootstrap(params: AgentBootstrapParams): void {
   // an authoritative current set (e.g. `v1-orphan-ft-clones`) return
   // `"deferred"` when it's null and retry on a future resolved session
   // (PR #869 baixiaohang round-3 P0).
-  applyPendingMigrations(workspace, (msg) => sessionCtx.log(msg), { currentSourceRepoNames });
+  applyPendingMigrations(workspace, sessionCtx.log, { currentSourceRepoNames });
 
   const sentinelPresent = existsSync(join(workspace, INIT_COMPLETE_SENTINEL_REL));
   const currentTreeHead = readContextTreeHead(contextTreePath);

--- a/packages/client/src/runtime/agent-bootstrap.ts
+++ b/packages/client/src/runtime/agent-bootstrap.ts
@@ -15,6 +15,7 @@ import {
 } from "./bootstrap.js";
 import type { SessionContext } from "./handler.js";
 import { INIT_COMPLETE_SENTINEL_REL } from "./workspace.js";
+import { applyPendingMigrations } from "./workspace-migrations.js";
 
 export type AgentBootstrapParams = {
   workspace: string;
@@ -88,6 +89,16 @@ function ensureStableIdentity(workspace: string, sessionCtx: SessionContext, con
  */
 export function ensureAgentBootstrap(params: AgentBootstrapParams): void {
   const { workspace, sessionCtx, contextTreePath, briefing } = params;
+
+  // One-shot workspace migrations: sweep legacy directory-structure residue
+  // (UUID-named per-chat snapshots, the pre-`.agent/` `.first-tree/` state
+  // dir, retired source repo clones like `first-tree-hub/`, the legacy
+  // `WHITEPAPER.md` symlink) the moment we re-attach to an old workspace.
+  // Each migration runs at most once per workspace — the applier persists
+  // its own marker file at `.agent/migrations-applied.json` and skips
+  // already-applied ids on subsequent calls. Cheap noop in the steady
+  // state.
+  applyPendingMigrations(workspace, (msg) => sessionCtx.log(msg));
 
   const sentinelPresent = existsSync(join(workspace, INIT_COMPLETE_SENTINEL_REL));
   const currentTreeHead = readContextTreeHead(contextTreePath);

--- a/packages/client/src/runtime/agent-bootstrap.ts
+++ b/packages/client/src/runtime/agent-bootstrap.ts
@@ -30,6 +30,16 @@ export type AgentBootstrapParams = {
    * caching across sessions.
    */
   briefing: string;
+  /**
+   * Authoritative source-repo `localPath` set from the live, resolved agent
+   * config payload — same value `prepareSourceRepos` was called with. `null`
+   * when the caller could not resolve a payload (cache miss, default-payload
+   * fallback). Threaded into `applyPendingMigrations` as the `ctx
+   * .currentSourceRepoNames` field so migrations that need an authoritative
+   * current config (`v1-orphan-ft-clones`) can defer instead of acting on an
+   * empty fallback. PR #869 baixiaohang round-3 P0.
+   */
+  currentSourceRepoNames: ReadonlySet<string> | null;
 };
 
 /**
@@ -88,17 +98,22 @@ function ensureStableIdentity(workspace: string, sessionCtx: SessionContext, con
  * same agent home. See proposal §⓪.3 for the race window this accepts.
  */
 export function ensureAgentBootstrap(params: AgentBootstrapParams): void {
-  const { workspace, sessionCtx, contextTreePath, briefing } = params;
+  const { workspace, sessionCtx, contextTreePath, briefing, currentSourceRepoNames } = params;
 
   // One-shot workspace migrations: sweep legacy directory-structure residue
-  // (UUID-named per-chat snapshots, the pre-`.agent/` `.first-tree/` state
-  // dir, retired source repo clones like `first-tree-hub/`, the legacy
-  // `WHITEPAPER.md` symlink) the moment we re-attach to an old workspace.
-  // Each migration runs at most once per workspace — the applier persists
-  // its own marker file at `.agent/migrations-applied.json` and skips
-  // already-applied ids on subsequent calls. Cheap noop in the steady
-  // state.
-  applyPendingMigrations(workspace, (msg) => sessionCtx.log(msg));
+  // (UUID-named per-chat snapshots, the legacy `WHITEPAPER.md` symlink,
+  // retired source-repo clones like `first-tree-hub/`) the moment we
+  // re-attach to an old workspace. Each migration runs at most once per
+  // workspace — the applier persists its own marker file at
+  // `.agent/migrations-applied.json` and skips already-applied ids on
+  // subsequent calls. Cheap noop in the steady state.
+  //
+  // `currentSourceRepoNames` carries the live, resolved source-repo
+  // localPaths through to the per-migration context; migrations that need
+  // an authoritative current set (e.g. `v1-orphan-ft-clones`) return
+  // `"deferred"` when it's null and retry on a future resolved session
+  // (PR #869 baixiaohang round-3 P0).
+  applyPendingMigrations(workspace, (msg) => sessionCtx.log(msg), { currentSourceRepoNames });
 
   const sentinelPresent = existsSync(join(workspace, INIT_COMPLETE_SENTINEL_REL));
   const currentTreeHead = readContextTreeHead(contextTreePath);

--- a/packages/client/src/runtime/first-tree-skills/installer.ts
+++ b/packages/client/src/runtime/first-tree-skills/installer.ts
@@ -38,6 +38,8 @@ import {
 } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { resolveBundledCliVersion } from "../bootstrap.js";
+import { readManagedState, updateManagedState } from "../managed-state.js";
 
 /**
  * Skills always shipped, regardless of whether the agent has a Context Tree
@@ -323,8 +325,70 @@ export function installCoreSkills(options: InstallCoreSkillsOptions): InstallSki
  * Install the tree-aware skill payloads (`first-tree`, `first-tree-context`,
  * etc.) into the workspace. Called by the agent bootstrap when the agent
  * has a Context Tree binding.
+ *
+ * Also reconciles `.agent/managed.json::skills`: any skill the workspace
+ * recorded as installed by a previous CLI version but that's no longer in
+ * `TREE_SKILL_NAMES` gets its `.agents/skills/<name>/` payload and
+ * `.claude/skills/<name>` symlink removed. The current set is then written
+ * back to state. Core skills are not tracked here — `CORE_SKILL_NAMES` is
+ * presently empty, and re-introducing one later can extend the state
+ * schema.
  */
 export function installFirstTreeSkills(options: InstallFirstTreeSkillsOptions): InstallSkillsResult {
   const bundledSkillsRoot = options.bundledSkillsRoot ?? resolveBundledSkillsRoot();
-  return installSkillSet(options.workspacePath, TREE_SKILL_NAMES, bundledSkillsRoot);
+  const result = installSkillSet(options.workspacePath, TREE_SKILL_NAMES, bundledSkillsRoot);
+  reconcileTreeSkillState(options.workspacePath);
+  return result;
+}
+
+/**
+ * Compare the previously-managed skill set against the current
+ * `TREE_SKILL_NAMES` and remove any skill no longer in the current bundle.
+ * Per-skill cleanup is best-effort: a missing payload is a noop, and a
+ * raised exception on remove is logged-via-throw nowhere — callers never
+ * see it, so we swallow internally to avoid blocking the agent start over a
+ * stale-skill removal failure.
+ *
+ * State is persisted regardless of per-skill outcome so a future install
+ * pass diffs against today's reality.
+ */
+function reconcileTreeSkillState(workspacePath: string): void {
+  const currentSkills = new Set<string>(TREE_SKILL_NAMES);
+  const prev = readManagedState(workspacePath);
+  if (prev) {
+    for (const prevSkill of prev.skills) {
+      if (currentSkills.has(prevSkill)) continue;
+      removeManagedSkill(workspacePath, prevSkill);
+    }
+  }
+  updateManagedState(workspacePath, resolveBundledCliVersion(), (current) => ({
+    ...current,
+    skills: [...currentSkills].sort(),
+  }));
+}
+
+/**
+ * Remove a previously-managed skill's on-disk payload AND its Claude Code
+ * symlink. Either step is best-effort and only operates on entries that
+ * actually exist; anything the user added later (a custom skill payload
+ * under `.agents/skills/<user-skill>/`) is never touched because we look
+ * up by NAME, not by listing the directory.
+ */
+function removeManagedSkill(workspacePath: string, name: string): void {
+  const agentsFull = join(workspacePath, ".agents", "skills", name);
+  const claudeFull = join(workspacePath, ".claude", "skills", name);
+  try {
+    rmSync(agentsFull, { recursive: true, force: true });
+  } catch {
+    // Best-effort — the symlink-side cleanup below still runs.
+  }
+  // The Claude-side entry is a symlink; we don't care whether it currently
+  // resolves. `lstat`-then-unlink mirrors the pattern in
+  // `ensureClaudeSymlink` for atomic replacement.
+  try {
+    lstatSync(claudeFull);
+    unlinkSync(claudeFull);
+  } catch {
+    // Either missing or unlink failed — both acceptable here.
+  }
 }

--- a/packages/client/src/runtime/managed-state.ts
+++ b/packages/client/src/runtime/managed-state.ts
@@ -1,0 +1,135 @@
+// Atomic JSON record of the resources the CLI currently manages inside an
+// agent workspace. Used by the next session start to detect "previously
+// managed but no longer in current config" → delete.
+//
+// Scope is deliberately narrow: a list of source-repo localPaths and a list
+// of skill names. Anything else CLI puts in the workspace (AGENTS.md,
+// .agent/identity.json, .claude/skills symlinks, etc.) is owned by other
+// flows and not tracked here.
+//
+// Path-level precision: the diff is "prev∖current" → delete. The flip side
+// (paths in `current` and not in `prev`) is handled by the existing
+// installers (`prepareSourceRepos`, `installFirstTreeSkills`) which already
+// (re)materialise everything they expect to be present.
+
+import { randomBytes } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Path inside the agent home where {@link readManagedState} /
+ * {@link writeManagedState} persist the record. Lives alongside
+ * `.agent/identity.json`, `.agent/cli-version`, etc. — same `.agent/`
+ * convention every other client-owned state file uses.
+ */
+export const MANAGED_STATE_REL = join(".agent", "managed.json");
+
+/**
+ * Schema-versioned record of the resources the CLI currently manages in a
+ * workspace. `schemaVersion` is checked on read; anything else makes the
+ * read return null (treated as "first run", no deletions performed).
+ */
+export type ManagedState = {
+  schemaVersion: 1;
+  /** CLI version that wrote this record. Informational only — the diff
+   *  logic doesn't gate on it. */
+  cliVersion: string | null;
+  /** ISO timestamp of the last write. */
+  updatedAt: string;
+  /** Source-repo `localPath` names (relative to workspace root) the CLI
+   *  cloned at workspace top level. */
+  sourceRepos: string[];
+  /** Skill names currently installed under `.agents/skills/<name>/` (and
+   *  symlinked at `.claude/skills/<name>`). */
+  skills: string[];
+};
+
+/**
+ * Read the managed-state record. Returns `null` when the file is missing,
+ * unreadable, malformed JSON, or written by a future schema this code
+ * doesn't understand — callers treat null as "first run on this workspace"
+ * and perform no deletions.
+ */
+export function readManagedState(workspacePath: string): ManagedState | null {
+  const path = join(workspacePath, MANAGED_STATE_REL);
+  if (!existsSync(path)) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(path, "utf-8"));
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const record = parsed as Record<string, unknown>;
+  if (record.schemaVersion !== 1) return null;
+  const sourceRepos = readStringArray(record.sourceRepos);
+  const skills = readStringArray(record.skills);
+  const cliVersion = typeof record.cliVersion === "string" ? record.cliVersion : null;
+  const updatedAt = typeof record.updatedAt === "string" ? record.updatedAt : new Date(0).toISOString();
+  return { schemaVersion: 1, cliVersion, updatedAt, sourceRepos, skills };
+}
+
+function readStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((entry): entry is string => typeof entry === "string");
+}
+
+/**
+ * Atomically persist the managed-state record. Writes to a unique sibling
+ * temp file then `rename`s onto the final path — POSIX makes that atomic,
+ * so a concurrent reader either sees the old record in full or the new one
+ * in full, never a partial write.
+ *
+ * Temp file is cleaned up on rename failure so a crashed write does not
+ * leak siblings.
+ */
+export function writeManagedState(workspacePath: string, state: ManagedState): void {
+  mkdirSync(join(workspacePath, ".agent"), { recursive: true });
+  const finalPath = join(workspacePath, MANAGED_STATE_REL);
+  const tempPath = `${finalPath}.${randomBytes(6).toString("hex")}.tmp`;
+  writeFileSync(tempPath, `${JSON.stringify(state, null, 2)}\n`, "utf-8");
+  try {
+    renameSync(tempPath, finalPath);
+  } catch (err) {
+    try {
+      unlinkSync(tempPath);
+    } catch {
+      // Best-effort cleanup — surface the original rename failure.
+    }
+    throw err;
+  }
+}
+
+/**
+ * Read-modify-write helper for partial updates. Applies `mutator` to the
+ * current state (or an empty default when none exists), then atomically
+ * persists the result. Callers do NOT need to handle the file-missing
+ * case — the mutator always receives a well-formed {@link ManagedState}.
+ *
+ * Concurrency note: the workspace is per-agent, sessions inside that
+ * workspace are serialised by AgentSlot, so two concurrent updates on the
+ * same file are not expected. The atomic `rename` still provides
+ * crash-safety for the single-writer case.
+ */
+export function updateManagedState(
+  workspacePath: string,
+  cliVersion: string | null,
+  mutator: (current: ManagedState) => ManagedState,
+): ManagedState {
+  const current: ManagedState = readManagedState(workspacePath) ?? {
+    schemaVersion: 1,
+    cliVersion,
+    updatedAt: new Date(0).toISOString(),
+    sourceRepos: [],
+    skills: [],
+  };
+  const next = mutator(current);
+  const persisted: ManagedState = {
+    ...next,
+    schemaVersion: 1,
+    cliVersion,
+    updatedAt: new Date().toISOString(),
+  };
+  writeManagedState(workspacePath, persisted);
+  return persisted;
+}

--- a/packages/client/src/runtime/source-repo-cleanup.ts
+++ b/packages/client/src/runtime/source-repo-cleanup.ts
@@ -1,0 +1,166 @@
+// Shared safety-checked removal for a top-level source-repo clone.
+//
+// Used by two paths that both want "delete a clone the CLI no longer
+// considers current, unless it has unpushed work":
+//
+//   - `source-repos.ts` — state-based cleanup of repos dropped from the
+//     agent's config payload between sessions.
+//   - `workspace-migrations.ts` — one-shot v1-orphan-ft-clones sweep of
+//     legacy First-Tree clones that predate the state file entirely.
+//
+// Centralising the guards here means both callers refuse to delete a
+// dirty / ahead-of-upstream / worktree-host clone uniformly. The function
+// is best-effort: any guard probe failure conservatively SKIPS the delete
+// and returns `false`, so the caller can decide whether to retry or
+// move on.
+
+import { execFileSync } from "node:child_process";
+import { existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
+
+/** Outcome of a single `tryRemoveCloneSafely` call. */
+export type RemoveCloneOutcome =
+  | "removed"
+  | "absent"
+  | "not-a-clone"
+  | "dirty"
+  | "ahead-of-upstream"
+  | "has-worktrees"
+  | "probe-failed"
+  | "remove-failed";
+
+/**
+ * Attempt to `rm -rf` the clone at `absPath`. Guards:
+ *
+ *   1. **dir missing**            → `absent` (noop)
+ *   2. **not a real clone**       → `not-a-clone` (noop; not ours to delete)
+ *   3. **working tree dirty**     → `dirty`
+ *   4. **local commits ahead**    → `ahead-of-upstream`
+ *   5. **dependent worktrees**    → `has-worktrees` (orphaning gitdirs)
+ *   6. **probe failure**          → `probe-failed` (conservative skip)
+ *   7. **rm itself failed**       → `remove-failed`
+ *
+ * Returns `removed` only when all probes succeeded AND the directory was
+ * deleted. The log function is invoked with one explanatory line per
+ * non-trivial outcome (any branch other than `absent`).
+ */
+export function tryRemoveCloneSafely(
+  absPath: string,
+  displayName: string,
+  log: (msg: string) => void,
+): RemoveCloneOutcome {
+  if (!existsSync(absPath)) return "absent";
+  if (!existsSync(join(absPath, ".git"))) {
+    log(`Clone cleanup: ${displayName} skipped — not a recognised clone (no .git)`);
+    return "not-a-clone";
+  }
+
+  // Dirty check — `git status --porcelain` reports anything staged, unstaged,
+  // or untracked. A probe failure (git crashed, repo corrupt) is treated as
+  // "unknown" and we err on the safe side by skipping.
+  const statusOutput = gitOutput(absPath, ["status", "--porcelain", "--untracked-files=normal"]);
+  if (statusOutput === null) {
+    log(`Clone cleanup: ${displayName} skipped — git status probe failed`);
+    return "probe-failed";
+  }
+  if (statusOutput !== "") {
+    log(`Clone cleanup: ${displayName} skipped — working tree is dirty`);
+    return "dirty";
+  }
+
+  // Local-commits-ahead check. A `null` from the helper means either "no
+  // upstream configured" or a probe failure — both conservatively block the
+  // delete because we cannot prove the work is safe to lose.
+  const aheadCount = gitAheadOfUpstream(absPath);
+  if (aheadCount === null) {
+    log(`Clone cleanup: ${displayName} skipped — ahead-count probe inconclusive`);
+    return "probe-failed";
+  }
+  if (aheadCount > 0) {
+    log(`Clone cleanup: ${displayName} skipped — ${aheadCount} local commit(s) ahead of upstream`);
+    return "ahead-of-upstream";
+  }
+
+  // Extra-worktree check — `git worktree list --porcelain` produces one
+  // record per worktree separated by blank lines. The main checkout is one
+  // of those; anything beyond that is a dependent worktree we'd orphan.
+  const worktreeOutput = gitOutput(absPath, ["worktree", "list", "--porcelain"]);
+  if (worktreeOutput === null) {
+    log(`Clone cleanup: ${displayName} skipped — worktree probe failed`);
+    return "probe-failed";
+  }
+  const worktreeRecords = worktreeOutput.split(/\n\s*\n/).filter((block) => block.trim().length > 0);
+  if (worktreeRecords.length > 1) {
+    log(`Clone cleanup: ${displayName} skipped — ${worktreeRecords.length - 1} dependent worktree(s) attached`);
+    return "has-worktrees";
+  }
+
+  try {
+    rmSync(absPath, { recursive: true, force: true });
+    log(`Clone cleanup: ${displayName} removed (${absPath})`);
+    return "removed";
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    log(`Clone cleanup: ${displayName} rm failed — ${reason.slice(0, 200)}`);
+    return "remove-failed";
+  }
+}
+
+/**
+ * Run `git <args>` in `cwd` and return its trimmed stdout. Returns `null`
+ * (not `""`) when the command crashes or times out so callers can
+ * distinguish "command ran, empty output" from "command failed, skip
+ * conservatively".
+ */
+export function gitOutput(cwd: string, args: readonly string[]): string | null {
+  try {
+    return execFileSync("git", [...args], {
+      cwd,
+      encoding: "utf-8",
+      timeout: 10_000,
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Count commits on HEAD ahead of the tracked upstream.
+ *
+ * Returns:
+ *   - `0` when the repo has no HEAD at all (empty repo, `git init` with no
+ *     commits yet) — there is literally nothing to lose, so this is safe.
+ *   - `0` when HEAD == upstream tip.
+ *   - `N > 0` when HEAD has N local commits past upstream.
+ *   - `null` when HEAD exists but upstream tracking is missing OR
+ *     `git rev-list` crashed — both genuinely unknown, callers
+ *     conservatively treat as "skip cleanup".
+ *
+ * The HEAD pre-check distinguishes "empty repo, safe" from "has work, no
+ * tracking, unsafe": both used to look the same to `git rev-list`.
+ */
+export function gitAheadOfUpstream(cwd: string): number | null {
+  // No HEAD → no commits at all → nothing to lose by deleting.
+  try {
+    execFileSync("git", ["rev-parse", "--quiet", "--verify", "HEAD"], {
+      cwd,
+      timeout: 10_000,
+      stdio: ["ignore", "ignore", "ignore"],
+    });
+  } catch {
+    return 0;
+  }
+  try {
+    const head = execFileSync("git", ["rev-list", "--count", "@{u}..HEAD"], {
+      cwd,
+      encoding: "utf-8",
+      timeout: 10_000,
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    const parsed = Number.parseInt(head, 10);
+    return Number.isFinite(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/client/src/runtime/source-repo-cleanup.ts
+++ b/packages/client/src/runtime/source-repo-cleanup.ts
@@ -23,11 +23,23 @@ export type RemoveCloneOutcome =
   | "removed"
   | "absent"
   | "not-a-clone"
+  | "in-use-by-live-chat"
   | "dirty"
   | "ahead-of-upstream"
   | "has-worktrees"
   | "probe-failed"
   | "remove-failed";
+
+/**
+ * Optional callback the caller can pass to short-circuit deletion when the
+ * checkout is still held by a live chat in this process. The state-based
+ * cleanup path passes `isSourceRepoPathInUse` from `source-repos.ts`; the
+ * migration path passes the same callback so the early-startup migration
+ * sweep can't `rm` a path another concurrent chat has already acquired.
+ *
+ * Defaults to `() => false` for callers that don't track live-use state.
+ */
+export type IsPathInUse = (absPath: string) => boolean;
 
 /**
  * Attempt to `rm -rf` the clone at `absPath`. Guards:
@@ -48,11 +60,20 @@ export function tryRemoveCloneSafely(
   absPath: string,
   displayName: string,
   log: (msg: string) => void,
+  isPathInUse: IsPathInUse = () => false,
 ): RemoveCloneOutcome {
   if (!existsSync(absPath)) return "absent";
   if (!existsSync(join(absPath, ".git"))) {
     log(`Clone cleanup: ${displayName} skipped — not a recognised clone (no .git)`);
     return "not-a-clone";
+  }
+
+  // Live-chat check FIRST — refuse to delete a checkout another live chat in
+  // this process is still using (PR #869 P1-4). Earlier than the git probes
+  // so a chat that's mid-`grep` doesn't see files vanish even briefly.
+  if (isPathInUse(absPath)) {
+    log(`Clone cleanup: ${displayName} skipped — in use by another live chat`);
+    return "in-use-by-live-chat";
   }
 
   // Dirty check — `git status --porcelain` reports anything staged, unstaged,

--- a/packages/client/src/runtime/source-repos.ts
+++ b/packages/client/src/runtime/source-repos.ts
@@ -101,6 +101,27 @@ export function isSourceRepoPathInUse(absPath: string): boolean {
 }
 
 /**
+ * Compute the set of source-repo localPaths the agent's CURRENT config
+ * declares. The same derivation `prepareSourceRepos` uses internally,
+ * exposed so handlers can thread the authoritative set through to
+ * `ensureAgentBootstrap` (which forwards it as `MigrationContext
+ * .currentSourceRepoNames`).
+ *
+ * Returns `null` when `payloadResolved` is `false` — that's the signal
+ * downstream consumers use to defer config-dependent migrations and
+ * suppress state-based cleanup. The non-null branch derives the same
+ * `localPath ?? deriveRepoLocalPath(url)` rule that `prepareSourceRepos`
+ * applies on its own materialisation loop.
+ */
+export function currentSourceRepoNamesFromPayload(
+  payload: AgentRuntimeConfigPayload | undefined,
+  payloadResolved: boolean,
+): ReadonlySet<string> | null {
+  if (!payloadResolved) return null;
+  return new Set((payload?.gitRepos ?? []).map((repo) => repo.localPath ?? deriveRepoLocalPath(repo.url)));
+}
+
+/**
  * Deregister `sessionCtx`'s chat from every source-repo checkout it was using.
  * Idempotent — safe to call once per session teardown even if
  * `prepareSourceRepos` never ran.

--- a/packages/client/src/runtime/source-repos.ts
+++ b/packages/client/src/runtime/source-repos.ts
@@ -1,8 +1,12 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
 import { type AgentRuntimeConfigPayload, deriveRepoLocalPath } from "@first-tree/shared";
-import type { PredeclaredSourceRepo } from "./bootstrap.js";
+import { type PredeclaredSourceRepo, resolveBundledCliVersion } from "./bootstrap.js";
 import { resolveGitRepoTargetPath } from "./git-local-path.js";
 import type { GitMirrorManager } from "./git-mirror-manager.js";
 import type { SessionContext } from "./handler.js";
+import { readManagedState, updateManagedState } from "./managed-state.js";
 
 export type PrepareSourceReposParams = {
   workspace: string;
@@ -98,7 +102,18 @@ export async function prepareSourceRepos(params: PrepareSourceReposParams): Prom
   const { workspace, payload, sessionCtx, gitMirrorManager } = params;
   const sourceRepos: PredeclaredSourceRepo[] = [];
 
-  if (!gitMirrorManager || !payload?.gitRepos?.length) return sourceRepos;
+  // No git capability → no source-repo prep AND no cleanup (we can't safely
+  // probe for clean state without git). Returns early before any state read.
+  if (!gitMirrorManager) return sourceRepos;
+
+  // Build the set of `localPath`s the current config wants materialised.
+  // `payload?.gitRepos` may legitimately be empty (config exists, just no
+  // source repos) — the reconcile-state path below still runs in that case
+  // so a previously-managed repo whose name was removed from the config
+  // gets cleaned up.
+  const currentLocalPaths: string[] = (payload?.gitRepos ?? []).map(
+    (repo) => repo.localPath ?? deriveRepoLocalPath(repo.url),
+  );
 
   // Paths THIS call newly registered the chat on — only these may be rolled
   // back on failure (see the catch). A resume that re-acquires an already-live
@@ -106,7 +121,7 @@ export async function prepareSourceRepos(params: PrepareSourceReposParams): Prom
   // shared checkout out from under the still-live chat.
   const newlyRegistered: string[] = [];
   try {
-    for (const repo of payload.gitRepos) {
+    for (const repo of payload?.gitRepos ?? []) {
       const localPath = repo.localPath ?? deriveRepoLocalPath(repo.url);
       // Source repos live at the TOP LEVEL of the agent home — no `worktrees/`
       // prefix. The `worktrees/` subdir is reserved for on-demand worktrees.
@@ -152,6 +167,13 @@ export async function prepareSourceRepos(params: PrepareSourceReposParams): Prom
         `Git: source repo at ${localPath}${result.branch ? ` on ${result.branch}` : ""} (${result.outcome})`,
       );
     }
+
+    // State reconcile: a source repo that used to be in this agent's config
+    // but is no longer present should be removed from disk. We only consider
+    // repos this CLI previously recorded in `.agent/managed.json` — anything
+    // the user dropped at workspace top level (third-party clones, manual
+    // experiments) is untouched.
+    reconcileSourceRepoState(workspace, currentLocalPaths, sessionCtx);
   } catch (err) {
     // Session start is failing and the SessionManager does NOT call the
     // handler's teardown on a failed start. Roll back ONLY the registrations
@@ -164,4 +186,151 @@ export async function prepareSourceRepos(params: PrepareSourceReposParams): Prom
   }
 
   return sourceRepos;
+}
+
+/**
+ * Compare the previously-managed source repos against the current set and
+ * remove any whose `localPath` is no longer in the config. Safety guards
+ * (working-tree clean + no extra worktrees + no local commits ahead of
+ * upstream) protect against destroying in-flight work; a guard failure
+ * skips the delete and logs a warning instead.
+ *
+ * State (the `sourceRepos` field of `.agent/managed.json`) is rewritten to
+ * the current set whether or not deletes succeeded — so a future config
+ * change correctly diffs against today's reality, and a guard-skipped
+ * cleanup just becomes a manual operator follow-up rather than a
+ * recurring noisy log.
+ */
+function reconcileSourceRepoState(workspace: string, currentLocalPaths: string[], sessionCtx: SessionContext): void {
+  const currentSet = new Set(currentLocalPaths);
+  const prev = readManagedState(workspace);
+  if (prev) {
+    for (const prevLocalPath of prev.sourceRepos) {
+      if (currentSet.has(prevLocalPath)) continue;
+      const absPath = join(workspace, prevLocalPath);
+      attemptRemoveStaleSourceRepo(absPath, prevLocalPath, sessionCtx.log);
+    }
+  }
+
+  updateManagedState(workspace, resolveBundledCliVersion(), (current) => ({
+    ...current,
+    sourceRepos: [...currentSet].sort(),
+  }));
+}
+
+/**
+ * Try to delete a source-repo checkout that's no longer in the agent's
+ * config. Guards:
+ *
+ *   1. **dir missing**          → noop (already gone)
+ *   2. **not a real clone**     → noop (not ours to delete)
+ *   3. **working tree dirty**   → skip + warn
+ *   4. **local commits ahead**  → skip + warn
+ *   5. **extra worktrees**      → skip + warn (would orphan worktree gitdir)
+ *
+ * Any guard failure logs and returns without touching disk. Only when ALL
+ * guards pass do we `rm -rf` the directory.
+ */
+function attemptRemoveStaleSourceRepo(absPath: string, displayName: string, log: (msg: string) => void): void {
+  if (!existsSync(absPath)) return;
+  if (!existsSync(join(absPath, ".git"))) {
+    log(`Git: ${displayName} removed from config but not a recognised clone (no .git) — leaving in place`);
+    return;
+  }
+
+  // Dirty check — `git status --porcelain` reports anything staged, unstaged,
+  // or untracked. Same rule the mirror manager applies to skip destructive
+  // updates of in-use clones. A probe failure (git crashed, repo corrupt)
+  // is treated as "unknown" and we err on the safe side by skipping.
+  const statusOutput = gitOutput(absPath, ["status", "--porcelain", "--untracked-files=normal"]);
+  if (statusOutput === null) {
+    log(`Git: ${displayName} removed from config but git probe failed — left in place (cleanup skipped)`);
+    return;
+  }
+  if (statusOutput !== "") {
+    log(`Git: ${displayName} removed from config but working tree is dirty — left in place (cleanup skipped)`);
+    return;
+  }
+
+  // Local-commits-ahead check — if HEAD is strictly ahead of the configured
+  // upstream we'd lose unpushed work on rm. A `null` from the helper means
+  // either "no upstream configured" (e.g. detached HEAD, fresh clone never
+  // tracked) or a probe failure — both are conservatively treated as "skip".
+  const aheadCount = gitAheadOfUpstream(absPath);
+  if (aheadCount === null) {
+    log(`Git: ${displayName} removed from config but ahead-count probe inconclusive — left in place (cleanup skipped)`);
+    return;
+  }
+  if (aheadCount > 0) {
+    log(
+      `Git: ${displayName} removed from config but has ${aheadCount} local commit(s) ahead of upstream — left in place (cleanup skipped)`,
+    );
+    return;
+  }
+
+  // Extra-worktree check — `git worktree list --porcelain` produces one
+  // record per worktree separated by blank lines. The main checkout is one
+  // of those; anything beyond that is a dependent worktree we'd orphan. A
+  // probe failure here also blocks the delete.
+  const worktreeOutput = gitOutput(absPath, ["worktree", "list", "--porcelain"]);
+  if (worktreeOutput === null) {
+    log(`Git: ${displayName} removed from config but worktree probe failed — left in place (cleanup skipped)`);
+    return;
+  }
+  const worktreeRecords = worktreeOutput.split(/\n\s*\n/).filter((block) => block.trim().length > 0);
+  if (worktreeRecords.length > 1) {
+    log(
+      `Git: ${displayName} removed from config but has ${worktreeRecords.length - 1} dependent worktree(s) — left in place (cleanup skipped)`,
+    );
+    return;
+  }
+
+  try {
+    rmSync(absPath, { recursive: true, force: true });
+    log(`Git: ${displayName} removed from config — deleted clone at ${absPath}`);
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    log(`Git: ${displayName} cleanup failed (${reason.slice(0, 200)}) — left in place`);
+  }
+}
+
+/**
+ * Run `git <args>` in `cwd` and return its trimmed stdout. Returns `null`
+ * (not `""`) when the command crashes / times out so callers can
+ * distinguish "command ran, output empty" from "command failed,
+ * conservatively skip".
+ */
+function gitOutput(cwd: string, args: readonly string[]): string | null {
+  try {
+    return execFileSync("git", [...args], {
+      cwd,
+      encoding: "utf-8",
+      timeout: 10_000,
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Count commits on HEAD ahead of the tracked upstream. Returns `null` when
+ * the count is genuinely unknown — either no upstream is configured
+ * (e.g. fresh clone, detached HEAD) or the `git rev-list` itself crashed.
+ * Callers conservatively treat `null` as "skip cleanup" rather than guess
+ * a safe default.
+ */
+function gitAheadOfUpstream(cwd: string): number | null {
+  try {
+    const head = execFileSync("git", ["rev-list", "--count", "@{u}..HEAD"], {
+      cwd,
+      encoding: "utf-8",
+      timeout: 10_000,
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    const parsed = Number.parseInt(head, 10);
+    return Number.isFinite(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
 }

--- a/packages/client/src/runtime/source-repos.ts
+++ b/packages/client/src/runtime/source-repos.ts
@@ -18,6 +18,23 @@ export type PrepareSourceReposParams = {
    * that source repos are standalone clones on their real default branch.
    */
   agentName: string | null;
+  /**
+   * True when the caller actually resolved `payload` from the server / config
+   * cache — i.e. the empty / missing `gitRepos` field genuinely reflects the
+   * agent's current configuration. False when the caller could not reach a
+   * source of truth (cache miss) and fell back to a default-shaped payload
+   * just to keep the session start moving.
+   *
+   * State-based cleanup of "previously managed source repos no longer in
+   * config" ONLY runs when `payloadResolved === true`. Otherwise an
+   * unresolved cache miss would compute `currentLocalPaths = []` and decide
+   * every prev-recorded repo had been removed from config — `rm`-ing every
+   * clean steady-state clone in the workspace. The non-state-tracking path
+   * (clone / fetch the repos that ARE in `payload.gitRepos`) is unaffected
+   * and runs regardless. See PR #869 review (code-reviewer P0-2) for the
+   * regression this guards against.
+   */
+  payloadResolved: boolean;
 };
 
 /**
@@ -71,6 +88,19 @@ function releaseChatFromPath(chatId: string, absPath: string): void {
 }
 
 /**
+ * Is the absolute checkout path currently held by at least one live chat in
+ * THIS process? Used by the source-repo cleanup paths to refuse to delete a
+ * checkout out from under a still-running chat (PR #869 P1-4).
+ *
+ * Cross-process awareness is out of scope — `liveChatsByPath` is per-process
+ * state. Cross-process concurrency on the same workspace is already
+ * unsupported (the workspace is per-agent; one daemon owns each agent).
+ */
+export function isSourceRepoPathInUse(absPath: string): boolean {
+  return (liveChatsByPath.get(absPath)?.size ?? 0) > 0;
+}
+
+/**
  * Deregister `sessionCtx`'s chat from every source-repo checkout it was using.
  * Idempotent — safe to call once per session teardown even if
  * `prepareSourceRepos` never ran.
@@ -98,7 +128,7 @@ export function releaseSourceReposForSession(sessionCtx: SessionContext): void {
  * Fail-fast: any clone/fetch failure aborts the session and bubbles up.
  */
 export async function prepareSourceRepos(params: PrepareSourceReposParams): Promise<PredeclaredSourceRepo[]> {
-  const { workspace, payload, sessionCtx, gitMirrorManager } = params;
+  const { workspace, payload, sessionCtx, gitMirrorManager, payloadResolved } = params;
   const sourceRepos: PredeclaredSourceRepo[] = [];
 
   // No git capability → no source-repo prep AND no cleanup (we can't safely
@@ -107,9 +137,9 @@ export async function prepareSourceRepos(params: PrepareSourceReposParams): Prom
 
   // Build the set of `localPath`s the current config wants materialised.
   // `payload?.gitRepos` may legitimately be empty (config exists, just no
-  // source repos) — the reconcile-state path below still runs in that case
-  // so a previously-managed repo whose name was removed from the config
-  // gets cleaned up.
+  // source repos) — the state-reconcile path below uses `payloadResolved`
+  // (not the gitRepos length) to decide whether the empty set is
+  // authoritative or just an unresolved fallback.
   const currentLocalPaths: string[] = (payload?.gitRepos ?? []).map(
     (repo) => repo.localPath ?? deriveRepoLocalPath(repo.url),
   );
@@ -172,7 +202,15 @@ export async function prepareSourceRepos(params: PrepareSourceReposParams): Prom
     // repos this CLI previously recorded in `.agent/managed.json` — anything
     // the user dropped at workspace top level (third-party clones, manual
     // experiments) is untouched.
-    reconcileSourceRepoState(workspace, currentLocalPaths, sessionCtx);
+    //
+    // GATED on `payloadResolved`: a cache miss / default-payload fallback
+    // would produce an empty currentLocalPaths and falsely conclude that
+    // every previously-managed repo had been removed from config. See the
+    // field docstring on `PrepareSourceReposParams.payloadResolved` and
+    // PR #869 review (code-reviewer P0-2).
+    if (payloadResolved) {
+      reconcileSourceRepoState(workspace, currentLocalPaths, sessionCtx);
+    }
   } catch (err) {
     // Session start is failing and the SessionManager does NOT call the
     // handler's teardown on a failed start. Roll back ONLY the registrations
@@ -207,7 +245,7 @@ function reconcileSourceRepoState(workspace: string, currentLocalPaths: string[]
     for (const prevLocalPath of prev.sourceRepos) {
       if (currentSet.has(prevLocalPath)) continue;
       const absPath = join(workspace, prevLocalPath);
-      tryRemoveCloneSafely(absPath, prevLocalPath, sessionCtx.log);
+      tryRemoveCloneSafely(absPath, prevLocalPath, sessionCtx.log, isSourceRepoPathInUse);
     }
   }
 

--- a/packages/client/src/runtime/source-repos.ts
+++ b/packages/client/src/runtime/source-repos.ts
@@ -1,5 +1,3 @@
-import { execFileSync } from "node:child_process";
-import { existsSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { type AgentRuntimeConfigPayload, deriveRepoLocalPath } from "@first-tree/shared";
 import { type PredeclaredSourceRepo, resolveBundledCliVersion } from "./bootstrap.js";
@@ -7,6 +5,7 @@ import { resolveGitRepoTargetPath } from "./git-local-path.js";
 import type { GitMirrorManager } from "./git-mirror-manager.js";
 import type { SessionContext } from "./handler.js";
 import { readManagedState, updateManagedState } from "./managed-state.js";
+import { tryRemoveCloneSafely } from "./source-repo-cleanup.js";
 
 export type PrepareSourceReposParams = {
   workspace: string;
@@ -208,7 +207,7 @@ function reconcileSourceRepoState(workspace: string, currentLocalPaths: string[]
     for (const prevLocalPath of prev.sourceRepos) {
       if (currentSet.has(prevLocalPath)) continue;
       const absPath = join(workspace, prevLocalPath);
-      attemptRemoveStaleSourceRepo(absPath, prevLocalPath, sessionCtx.log);
+      tryRemoveCloneSafely(absPath, prevLocalPath, sessionCtx.log);
     }
   }
 
@@ -216,121 +215,4 @@ function reconcileSourceRepoState(workspace: string, currentLocalPaths: string[]
     ...current,
     sourceRepos: [...currentSet].sort(),
   }));
-}
-
-/**
- * Try to delete a source-repo checkout that's no longer in the agent's
- * config. Guards:
- *
- *   1. **dir missing**          → noop (already gone)
- *   2. **not a real clone**     → noop (not ours to delete)
- *   3. **working tree dirty**   → skip + warn
- *   4. **local commits ahead**  → skip + warn
- *   5. **extra worktrees**      → skip + warn (would orphan worktree gitdir)
- *
- * Any guard failure logs and returns without touching disk. Only when ALL
- * guards pass do we `rm -rf` the directory.
- */
-function attemptRemoveStaleSourceRepo(absPath: string, displayName: string, log: (msg: string) => void): void {
-  if (!existsSync(absPath)) return;
-  if (!existsSync(join(absPath, ".git"))) {
-    log(`Git: ${displayName} removed from config but not a recognised clone (no .git) — leaving in place`);
-    return;
-  }
-
-  // Dirty check — `git status --porcelain` reports anything staged, unstaged,
-  // or untracked. Same rule the mirror manager applies to skip destructive
-  // updates of in-use clones. A probe failure (git crashed, repo corrupt)
-  // is treated as "unknown" and we err on the safe side by skipping.
-  const statusOutput = gitOutput(absPath, ["status", "--porcelain", "--untracked-files=normal"]);
-  if (statusOutput === null) {
-    log(`Git: ${displayName} removed from config but git probe failed — left in place (cleanup skipped)`);
-    return;
-  }
-  if (statusOutput !== "") {
-    log(`Git: ${displayName} removed from config but working tree is dirty — left in place (cleanup skipped)`);
-    return;
-  }
-
-  // Local-commits-ahead check — if HEAD is strictly ahead of the configured
-  // upstream we'd lose unpushed work on rm. A `null` from the helper means
-  // either "no upstream configured" (e.g. detached HEAD, fresh clone never
-  // tracked) or a probe failure — both are conservatively treated as "skip".
-  const aheadCount = gitAheadOfUpstream(absPath);
-  if (aheadCount === null) {
-    log(`Git: ${displayName} removed from config but ahead-count probe inconclusive — left in place (cleanup skipped)`);
-    return;
-  }
-  if (aheadCount > 0) {
-    log(
-      `Git: ${displayName} removed from config but has ${aheadCount} local commit(s) ahead of upstream — left in place (cleanup skipped)`,
-    );
-    return;
-  }
-
-  // Extra-worktree check — `git worktree list --porcelain` produces one
-  // record per worktree separated by blank lines. The main checkout is one
-  // of those; anything beyond that is a dependent worktree we'd orphan. A
-  // probe failure here also blocks the delete.
-  const worktreeOutput = gitOutput(absPath, ["worktree", "list", "--porcelain"]);
-  if (worktreeOutput === null) {
-    log(`Git: ${displayName} removed from config but worktree probe failed — left in place (cleanup skipped)`);
-    return;
-  }
-  const worktreeRecords = worktreeOutput.split(/\n\s*\n/).filter((block) => block.trim().length > 0);
-  if (worktreeRecords.length > 1) {
-    log(
-      `Git: ${displayName} removed from config but has ${worktreeRecords.length - 1} dependent worktree(s) — left in place (cleanup skipped)`,
-    );
-    return;
-  }
-
-  try {
-    rmSync(absPath, { recursive: true, force: true });
-    log(`Git: ${displayName} removed from config — deleted clone at ${absPath}`);
-  } catch (err) {
-    const reason = err instanceof Error ? err.message : String(err);
-    log(`Git: ${displayName} cleanup failed (${reason.slice(0, 200)}) — left in place`);
-  }
-}
-
-/**
- * Run `git <args>` in `cwd` and return its trimmed stdout. Returns `null`
- * (not `""`) when the command crashes / times out so callers can
- * distinguish "command ran, output empty" from "command failed,
- * conservatively skip".
- */
-function gitOutput(cwd: string, args: readonly string[]): string | null {
-  try {
-    return execFileSync("git", [...args], {
-      cwd,
-      encoding: "utf-8",
-      timeout: 10_000,
-      stdio: ["ignore", "pipe", "ignore"],
-    }).trim();
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Count commits on HEAD ahead of the tracked upstream. Returns `null` when
- * the count is genuinely unknown — either no upstream is configured
- * (e.g. fresh clone, detached HEAD) or the `git rev-list` itself crashed.
- * Callers conservatively treat `null` as "skip cleanup" rather than guess
- * a safe default.
- */
-function gitAheadOfUpstream(cwd: string): number | null {
-  try {
-    const head = execFileSync("git", ["rev-list", "--count", "@{u}..HEAD"], {
-      cwd,
-      encoding: "utf-8",
-      timeout: 10_000,
-      stdio: ["ignore", "pipe", "ignore"],
-    }).trim();
-    const parsed = Number.parseInt(head, 10);
-    return Number.isFinite(parsed) ? parsed : null;
-  } catch {
-    return null;
-  }
 }

--- a/packages/client/src/runtime/workspace-migrations.ts
+++ b/packages/client/src/runtime/workspace-migrations.ts
@@ -38,6 +38,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
+import { type RemoveCloneOutcome, tryRemoveCloneSafely } from "./source-repo-cleanup.js";
 
 /**
  * Path inside the agent home where {@link applyPendingMigrations} persists
@@ -82,12 +83,20 @@ function isDirectory(path: string): boolean {
   }
 }
 
-function unlinkIfExists(path: string): boolean {
+/**
+ * Unlink a symbolic link at `path`, returning `true` only when the entry
+ * existed AND was a symlink (NOT a real file or directory). Callers use
+ * this for legacy-symlink cleanup so a user-authored regular file with
+ * the same name is never deleted by mistake.
+ */
+function unlinkSymlinkIfExists(path: string): boolean {
+  let stat: ReturnType<typeof lstatSync>;
   try {
-    lstatSync(path);
+    stat = lstatSync(path);
   } catch {
     return false;
   }
+  if (!stat.isSymbolicLink()) return false;
   try {
     unlinkSync(path);
     return true;
@@ -136,22 +145,24 @@ export const MIGRATIONS_REGISTRY: readonly Migration[] = [
       }
     },
   },
-  {
-    id: "v1-legacy-dot-first-tree",
-    description: "Remove legacy <workspace>/.first-tree/ state dir (superseded by .agent/)",
-    apply: (workspacePath, log) => {
-      const target = join(workspacePath, ".first-tree");
-      if (!existsSync(target)) return;
-      rmSync(target, { recursive: true, force: true });
-      log("workspace-migrations: v1-legacy-dot-first-tree removed .first-tree/");
-    },
-  },
+  // NOTE: a `v1-legacy-dot-first-tree` migration was proposed but withdrawn
+  // during Codex review (PR #869, P1 from baixiaohang). The directory
+  // `<workspace>/.first-tree/` is the active W1 binding state (it holds
+  // `workspace.json`, see `packages/shared/src/schemas/workspace-manifest.ts`
+  // → `WORKSPACE_STATE_DIRNAME`). A blind sweep would silently unbind every
+  // upgraded W1 workspace. The residue this migration was meant to catch
+  // (`<workspace>/.first-tree/tmp/` from a much older client) is tiny and
+  // can be revisited as a precision-scoped migration later if it becomes a
+  // real problem; the savings did not justify the data-loss risk.
   {
     id: "v1-whitepaper-symlink",
     description: "Remove legacy WHITEPAPER.md (root-level symlink that used to expose a skill payload)",
     apply: (workspacePath, log) => {
+      // Only remove when the entry is actually a symlink — a user-authored
+      // regular WHITEPAPER.md file at workspace root must NOT be deleted by
+      // an upgrade-time cleanup pass. (Codex review nit P2 on PR #869.)
       const target = join(workspacePath, "WHITEPAPER.md");
-      if (unlinkIfExists(target)) {
+      if (unlinkSymlinkIfExists(target)) {
         log("workspace-migrations: v1-whitepaper-symlink removed WHITEPAPER.md");
       }
     },
@@ -159,10 +170,11 @@ export const MIGRATIONS_REGISTRY: readonly Migration[] = [
   {
     id: "v1-orphan-ft-clones",
     description:
-      "Remove top-level clones whose `.git/config` origin points at agent-team-foundation/* but are not in the workspace's current source-repos config (catches retired source repos like first-tree-hub)",
+      "Remove top-level clones whose `.git/config` origin points at agent-team-foundation/* but are not in the workspace's current source-repos config (catches retired source repos like first-tree-hub). Same dirty / ahead-of-upstream / worktree guards as the state-based source cleanup — Codex review P1 on PR #869.",
     apply: (workspacePath, log) => {
       const currentRepos = readCurrentSourceRepoNames(workspacePath);
       let removed = 0;
+      let skipped = 0;
       for (const name of safeReaddir(workspacePath)) {
         // Workspace-meta dirs and the agent-self-managed dirs never have a
         // `.git/` so they're filtered by the origin probe below; skip them
@@ -174,14 +186,24 @@ export const MIGRATIONS_REGISTRY: readonly Migration[] = [
         const origin = readGitOrigin(full);
         if (origin === null) continue;
         if (!FT_ORIGIN_RE.test(origin)) continue;
-        rmSync(full, { recursive: true, force: true });
-        log(`workspace-migrations: v1-orphan-ft-clones removed ${name}/ (origin ${origin})`);
-        removed += 1;
+        const outcome: RemoveCloneOutcome = tryRemoveCloneSafely(full, `${name}/ (origin ${origin})`, log);
+        if (outcome === "removed") {
+          removed += 1;
+        } else if (outcome !== "absent" && outcome !== "not-a-clone") {
+          // dirty / ahead-of-upstream / has-worktrees / probe-failed /
+          // remove-failed — `tryRemoveCloneSafely` already logged the reason;
+          // count as "left behind" for the summary line below.
+          skipped += 1;
+        }
       }
-      if (removed === 0) {
+      if (removed === 0 && skipped === 0) {
         // Single summary line so the marker write is the only side effect
         // when nothing matched — keeps the steady-state log quiet.
         log("workspace-migrations: v1-orphan-ft-clones found no orphan FT clones");
+      } else if (skipped > 0) {
+        log(
+          `workspace-migrations: v1-orphan-ft-clones removed ${removed} orphan clone(s); ${skipped} held back by safety guards — operator follow-up`,
+        );
       }
     },
   },

--- a/packages/client/src/runtime/workspace-migrations.ts
+++ b/packages/client/src/runtime/workspace-migrations.ts
@@ -155,6 +155,27 @@ function hasLegacySnapshotSignature(dir: string): boolean {
   return existsSync(join(dir, "AGENTS.md")) || existsSync(join(dir, "CLAUDE.md"));
 }
 
+/**
+ * Should a config-dependent migration defer this session?
+ *
+ * "Yes" exactly when BOTH:
+ *   - The live `ctx.currentSourceRepoNames` is `null` (the caller could not
+ *     resolve a payload from the server / cache), AND
+ *   - The persisted `.agent/managed.json::sourceRepos` is also empty (no
+ *     resolved session has ever written the state file).
+ *
+ * In that combination there is no authoritative way to tell "config truly
+ * declares zero source repos" from "we have no idea what the config
+ * declares", so any deletion that relies on the difference between current
+ * and on-disk repos is unsafe. The caller returns `"deferred"`; the
+ * migrations applier leaves the marker unrecorded and a future resolved
+ * session re-runs the migration. PR #869 baixiaohang round-3/4 P0.
+ */
+function shouldDeferOnUnknownConfig(ctx: MigrationContext, workspacePath: string): boolean {
+  if (ctx.currentSourceRepoNames !== null) return false;
+  return readCurrentSourceRepoNames(workspacePath).size === 0;
+}
+
 function readGitOrigin(repoDir: string): string | null {
   const gitDir = join(repoDir, ".git");
   if (!existsSync(gitDir)) return null;
@@ -181,8 +202,14 @@ export const MIGRATIONS_REGISTRY: readonly Migration[] = [
   {
     id: "v1-uuid-snapshots",
     description:
-      "Remove legacy UUID-named per-chat snapshot directories at workspace root. Per PR #869 baixiaohang P0: scoped to entries that BOTH match the UUID shape AND carry the legacy snapshot signature (a top-level `AGENTS.md` / `CLAUDE.md` file from when each chat had a self-contained cwd). Also skips anything currently listed in `.agent/managed.json::sourceRepos` (or in the live `ctx.currentSourceRepoNames` when available) so a user with a UUID-shaped `gitRepos.localPath` is never deleted.",
+      "Remove legacy UUID-named per-chat snapshot directories at workspace root. Per PR #869 baixiaohang P0: scoped to entries that BOTH match the UUID shape AND carry the legacy snapshot signature (a top-level `AGENTS.md` / `CLAUDE.md` file from when each chat had a self-contained cwd). Also skips anything currently listed in `.agent/managed.json::sourceRepos` (or in the live `ctx.currentSourceRepoNames` when available) so a user with a UUID-shaped `gitRepos.localPath` is never deleted. Per round-4: defers when neither signal is available — a UUID-shaped current source repo whose cloned content ships an AGENTS.md would otherwise match the legacy signature and be `rmSync`'d on the first cache-miss start before any resolved payload could write managed.json.",
     apply: (workspacePath, log, ctx) => {
+      if (shouldDeferOnUnknownConfig(ctx, workspacePath)) {
+        log(
+          "workspace-migrations: v1-uuid-snapshots deferred — no authoritative current source-repo set (live config unresolved AND `.agent/managed.json` empty); will retry next resolved session",
+        );
+        return "deferred";
+      }
       const currentRepos = ctx.currentSourceRepoNames ?? readCurrentSourceRepoNames(workspacePath);
       let removed = 0;
       let skipped = 0;
@@ -222,6 +249,17 @@ export const MIGRATIONS_REGISTRY: readonly Migration[] = [
     apply: (workspacePath, log, ctx) => {
       const target = join(workspacePath, "first-tree-hub");
       if (!existsSync(target) || !isDirectory(target)) return;
+      // Same defer rule as the UUID + orphan paths: when neither the live
+      // ctx nor the persisted state can confirm whether `first-tree-hub`
+      // is currently configured, refuse to act. The broken-pointer shape
+      // check below would otherwise nuke a clone the user re-added before
+      // the cache had a chance to populate.
+      if (shouldDeferOnUnknownConfig(ctx, workspacePath)) {
+        log(
+          "workspace-migrations: v1-retired-source-repo-first-tree-hub deferred — no authoritative current source-repo set; will retry next resolved session",
+        );
+        return "deferred";
+      }
       // Skip if `first-tree-hub` is in the agent's current source-repos
       // config — a future re-add would otherwise lose its checkout. The
       // live `ctx.currentSourceRepoNames` is authoritative; fall back to the
@@ -302,7 +340,7 @@ export const MIGRATIONS_REGISTRY: readonly Migration[] = [
     description:
       'Remove top-level clones whose `.git/config` origin points at agent-team-foundation/* but are not in the workspace\'s current source-repos config (catches retired source repos like first-tree-hub). Same dirty / ahead-of-upstream / worktree guards as the state-based source cleanup — Codex review P1 on PR #869. **Requires an authoritative current source-repo set** (`ctx.currentSourceRepoNames !== null`); on a cache-miss session it returns `"deferred"` so it retries when the next resolved session arrives. PR #869 baixiaohang round-3 P0.',
     apply: (workspacePath, log, ctx) => {
-      // The migration relies on \"absent from current source-repos config\"
+      // The migration relies on "absent from current source-repos config"
       // to identify orphans. When the live config is unresolved AND the
       // persisted state file is empty (the common first-upgrade case), an
       // empty fallback would treat every clean steady-state FT clone as
@@ -310,14 +348,11 @@ export const MIGRATIONS_REGISTRY: readonly Migration[] = [
       // safety guards still protect dirty / ahead / worktree clones, but
       // a clean repo with no work to lose is exactly what we'd
       // accidentally nuke without an authoritative set.
-      if (ctx.currentSourceRepoNames === null) {
-        const persisted = readCurrentSourceRepoNames(workspacePath);
-        if (persisted.size === 0) {
-          log(
-            "workspace-migrations: v1-orphan-ft-clones deferred — no authoritative current source-repo set (live config unresolved AND `.agent/managed.json` empty); will retry next resolved session",
-          );
-          return "deferred";
-        }
+      if (shouldDeferOnUnknownConfig(ctx, workspacePath)) {
+        log(
+          "workspace-migrations: v1-orphan-ft-clones deferred — no authoritative current source-repo set (live config unresolved AND `.agent/managed.json` empty); will retry next resolved session",
+        );
+        return "deferred";
       }
       const currentRepos = ctx.currentSourceRepoNames ?? readCurrentSourceRepoNames(workspacePath);
       let removed = 0;

--- a/packages/client/src/runtime/workspace-migrations.ts
+++ b/packages/client/src/runtime/workspace-migrations.ts
@@ -170,6 +170,25 @@ function hasLegacySnapshotSignature(dir: string): boolean {
  * and on-disk repos is unsafe. The caller returns `"deferred"`; the
  * migrations applier leaves the marker unrecorded and a future resolved
  * session re-runs the migration. PR #869 baixiaohang round-3/4 P0.
+ *
+ * **Known residual race (PR #869 code-reviewer R2 N-1):** when ctx is null
+ * AND persisted state is NON-empty but STALE — e.g. the user just added a
+ * new source repo via the web console and this very next session hits a
+ * cache miss before `prepareSourceRepos(payloadResolved: true)` has had a
+ * chance to refresh the state file — `shouldDeferOnUnknownConfig` returns
+ * false and the fallback to `readCurrentSourceRepoNames` returns the stale
+ * set. If the new repo's `localPath` matches a hardcoded migration target
+ * (today only `first-tree-hub` or a UUID-shaped name carrying an
+ * AGENTS.md), the migration will treat it as orphan and delete. Mitigations
+ * we evaluated:
+ *   - Defer on `ctx === null` regardless of persisted state (option A) —
+ *     safer, but a workspace whose cache is permanently lost would never
+ *     get its sweep. Such a workspace can't function anyway.
+ *   - Force retired-hub / UUID-snapshots through `tryRemoveCloneSafely`
+ *     (option B) — adds the dirty/ahead/worktree guards as a backstop.
+ * Both are tracked as follow-ups; the race window (cache miss between
+ * config change and a successful refresh) is rare enough that documenting
+ * it here is the chosen action for this PR.
  */
 function shouldDeferOnUnknownConfig(ctx: MigrationContext, workspacePath: string): boolean {
   if (ctx.currentSourceRepoNames !== null) return false;

--- a/packages/client/src/runtime/workspace-migrations.ts
+++ b/packages/client/src/runtime/workspace-migrations.ts
@@ -39,6 +39,7 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 import { type RemoveCloneOutcome, tryRemoveCloneSafely } from "./source-repo-cleanup.js";
+import { isSourceRepoPathInUse } from "./source-repos.js";
 
 /**
  * Path inside the agent home where {@link applyPendingMigrations} persists
@@ -105,6 +106,21 @@ function unlinkSymlinkIfExists(path: string): boolean {
   }
 }
 
+/**
+ * Recognise the legacy per-chat-cwd snapshot shape: a workspace-root UUID
+ * directory that carries a top-level briefing file (`AGENTS.md` or
+ * `CLAUDE.md`), as the old per-chat handlers always materialised. A plain
+ * UUID-named directory without that signature is treated as user content
+ * and left alone.
+ *
+ * The check is intentionally cheap (one or two `existsSync` calls) — it
+ * runs at most once per workspace per id (the migrations applier
+ * deduplicates) so a deeper scan isn't justified.
+ */
+function hasLegacySnapshotSignature(dir: string): boolean {
+  return existsSync(join(dir, "AGENTS.md")) || existsSync(join(dir, "CLAUDE.md"));
+}
+
 function readGitOrigin(repoDir: string): string | null {
   const gitDir = join(repoDir, ".git");
   if (!existsSync(gitDir)) return null;
@@ -130,19 +146,96 @@ function readGitOrigin(repoDir: string): string | null {
 export const MIGRATIONS_REGISTRY: readonly Migration[] = [
   {
     id: "v1-uuid-snapshots",
-    description: "Remove legacy UUID-named per-chat snapshot directories at workspace root",
+    description:
+      "Remove legacy UUID-named per-chat snapshot directories at workspace root. Per PR #869 baixiaohang P0: scoped to entries that BOTH match the UUID shape AND carry the legacy snapshot signature (a top-level `AGENTS.md` / `CLAUDE.md` file from when each chat had a self-contained cwd). Also skips anything currently listed in `.agent/managed.json::sourceRepos` so a user with a UUID-shaped `gitRepos.localPath` is never deleted.",
     apply: (workspacePath, log) => {
+      const currentRepos = readCurrentSourceRepoNames(workspacePath);
       let removed = 0;
+      let skipped = 0;
       for (const name of safeReaddir(workspacePath)) {
         if (!UUID_RE.test(name)) continue;
         const full = join(workspacePath, name);
         if (!isDirectory(full)) continue;
+        if (currentRepos.has(name)) {
+          // A legit current source repo whose `localPath` happens to look like
+          // a UUID — never delete.
+          skipped += 1;
+          continue;
+        }
+        if (!hasLegacySnapshotSignature(full)) {
+          // No `AGENTS.md` / `CLAUDE.md` at this UUID dir's root → not the
+          // old per-chat-cwd shape. Probably user content. Leave alone.
+          skipped += 1;
+          continue;
+        }
         rmSync(full, { recursive: true, force: true });
         removed += 1;
       }
       if (removed > 0) {
         log(`workspace-migrations: v1-uuid-snapshots removed ${removed} legacy snapshot dir(s)`);
       }
+      if (skipped > 0) {
+        log(
+          `workspace-migrations: v1-uuid-snapshots skipped ${skipped} UUID-named dir(s) without the legacy snapshot signature`,
+        );
+      }
+    },
+  },
+  {
+    id: "v1-retired-source-repo-first-tree-hub",
+    description:
+      "Remove <ws>/first-tree-hub/ — a retired First-Tree source repo. Narrowly scoped to the broken-pointer shape the legacy hub-worktree model left behind: `.git` is a regular FILE (not a directory) with `gitdir: <path>` whose target no longer exists on disk. In that shape, `git config --get remote.origin.url` exits 128 and the general `v1-orphan-ft-clones` sweep can't identify the clone by origin URL — and the local git state is unusable anyway, so there's no recoverable work to lose. Healthy `first-tree-hub/` clones (with `.git/` as a real directory) defer to `v1-orphan-ft-clones`, which goes through `tryRemoveCloneSafely` with the dirty / ahead / worktree guards. PR #869 code-reviewer P0-1.",
+    apply: (workspacePath, log) => {
+      const target = join(workspacePath, "first-tree-hub");
+      if (!existsSync(target) || !isDirectory(target)) return;
+      // Skip if `first-tree-hub` is in the agent's current source-repos
+      // config — a future re-add would otherwise lose its checkout.
+      if (readCurrentSourceRepoNames(workspacePath).has("first-tree-hub")) {
+        log(
+          "workspace-migrations: v1-retired-source-repo-first-tree-hub skipped — still in current source repos config",
+        );
+        return;
+      }
+      const gitEntry = join(target, ".git");
+      let gitStat: ReturnType<typeof lstatSync>;
+      try {
+        gitStat = lstatSync(gitEntry);
+      } catch {
+        // No `.git` → not a clone (user content, or already cleaned).
+        return;
+      }
+      if (gitStat.isDirectory()) {
+        // Healthy clone — `v1-orphan-ft-clones` will inspect it through
+        // `tryRemoveCloneSafely` with the dirty / ahead / worktree guards.
+        // Skip here to avoid duplicating that path.
+        return;
+      }
+      // `.git` is a regular file (the pointer shape). Read it and confirm
+      // the gitdir target is gone — that's what makes the clone "broken
+      // legacy" rather than a healthy `git worktree add` linked checkout
+      // a future feature might rely on.
+      let pointerTarget: string | null = null;
+      try {
+        const pointerContent = readFileSync(gitEntry, "utf-8");
+        const match = pointerContent.match(/^gitdir:\s*(.+)$/m);
+        if (match?.[1]) pointerTarget = match[1].trim();
+      } catch {
+        return;
+      }
+      if (pointerTarget === null) {
+        log("workspace-migrations: v1-retired-source-repo-first-tree-hub skipped — `.git` file has unexpected shape");
+        return;
+      }
+      if (existsSync(pointerTarget)) {
+        log(
+          `workspace-migrations: v1-retired-source-repo-first-tree-hub skipped — \`.git\` pointer target ${pointerTarget} still exists (live worktree)`,
+        );
+        return;
+      }
+      rmSync(target, { recursive: true, force: true });
+      log(
+        "workspace-migrations: v1-retired-source-repo-first-tree-hub removed first-tree-hub/ (broken `.git` pointer)",
+      );
     },
   },
   // NOTE: a `v1-legacy-dot-first-tree` migration was proposed but withdrawn
@@ -186,7 +279,12 @@ export const MIGRATIONS_REGISTRY: readonly Migration[] = [
         const origin = readGitOrigin(full);
         if (origin === null) continue;
         if (!FT_ORIGIN_RE.test(origin)) continue;
-        const outcome: RemoveCloneOutcome = tryRemoveCloneSafely(full, `${name}/ (origin ${origin})`, log);
+        const outcome: RemoveCloneOutcome = tryRemoveCloneSafely(
+          full,
+          `${name}/ (origin ${origin})`,
+          log,
+          isSourceRepoPathInUse,
+        );
         if (outcome === "removed") {
           removed += 1;
         } else if (outcome !== "absent" && outcome !== "not-a-clone") {
@@ -196,10 +294,8 @@ export const MIGRATIONS_REGISTRY: readonly Migration[] = [
           skipped += 1;
         }
       }
-      if (removed === 0 && skipped === 0) {
-        // Single summary line so the marker write is the only side effect
-        // when nothing matched — keeps the steady-state log quiet.
-        log("workspace-migrations: v1-orphan-ft-clones found no orphan FT clones");
+      if (removed > 0 && skipped === 0) {
+        log(`workspace-migrations: v1-orphan-ft-clones removed ${removed} orphan clone(s)`);
       } else if (skipped > 0) {
         log(
           `workspace-migrations: v1-orphan-ft-clones removed ${removed} orphan clone(s); ${skipped} held back by safety guards — operator follow-up`,

--- a/packages/client/src/runtime/workspace-migrations.ts
+++ b/packages/client/src/runtime/workspace-migrations.ts
@@ -56,14 +56,48 @@ const FT_ORIGIN_RE = /github\.com[/:]agent-team-foundation\//i;
 
 export type MigrationLog = (msg: string) => void;
 
+/**
+ * Context the applier threads into every `Migration.apply`. Migrations that
+ * need to compare against the agent's CURRENT source-repo configuration
+ * use `currentSourceRepoNames`; when it's `null` the caller could not
+ * resolve a payload from the server/cache (cache miss / unresolved
+ * session start), and migrations that depend on an authoritative current
+ * set must return `"deferred"` so they retry on the next resolved start.
+ *
+ * Migrations whose correctness does NOT depend on the live config (e.g.
+ * a name-based legacy sweep with its own shape check) may ignore the
+ * context and proceed in the unresolved case.
+ */
+export type MigrationContext = {
+  currentSourceRepoNames: ReadonlySet<string> | null;
+};
+
+/**
+ * What an `apply` invocation tells the applier to do with the marker
+ * file:
+ *   - `undefined` / no return → migration ran (cleanly or as a noop);
+ *     marker WILL be recorded so this id never re-runs.
+ *   - `"deferred"`           → migration could not run safely yet
+ *     (typically waiting for `currentSourceRepoNames !== null`); marker
+ *     is NOT recorded; the applier reports it under `deferred` not
+ *     `failed`; the next session retries from scratch.
+ *
+ * `throw` remains the third option, reserved for actual failures (I/O
+ * errors etc.) — also leaves the marker unrecorded but goes through
+ * the `failed` path with logging.
+ */
+export type MigrationOutcome = void | "deferred";
+
 export type Migration = {
   /** Stable identifier persisted to the marker file. Never re-use across
    *  migrations even when one is retired. */
   id: string;
   description: string;
-  /** Idempotent action. Throws on failure; the applier catches and skips
-   *  the marker write so a future run retries. */
-  apply: (workspacePath: string, log: MigrationLog) => void;
+  /** Idempotent action. May return `"deferred"` to ask the applier not to
+   *  record this id (so a future resolved session retries). Throws on
+   *  unexpected failure; the applier catches and skips the marker write
+   *  so a future run retries through the `failed` channel. */
+  apply: (workspacePath: string, log: MigrationLog, ctx: MigrationContext) => MigrationOutcome;
 };
 
 // ─── Utilities ────────────────────────────────────────────────────────
@@ -147,9 +181,9 @@ export const MIGRATIONS_REGISTRY: readonly Migration[] = [
   {
     id: "v1-uuid-snapshots",
     description:
-      "Remove legacy UUID-named per-chat snapshot directories at workspace root. Per PR #869 baixiaohang P0: scoped to entries that BOTH match the UUID shape AND carry the legacy snapshot signature (a top-level `AGENTS.md` / `CLAUDE.md` file from when each chat had a self-contained cwd). Also skips anything currently listed in `.agent/managed.json::sourceRepos` so a user with a UUID-shaped `gitRepos.localPath` is never deleted.",
-    apply: (workspacePath, log) => {
-      const currentRepos = readCurrentSourceRepoNames(workspacePath);
+      "Remove legacy UUID-named per-chat snapshot directories at workspace root. Per PR #869 baixiaohang P0: scoped to entries that BOTH match the UUID shape AND carry the legacy snapshot signature (a top-level `AGENTS.md` / `CLAUDE.md` file from when each chat had a self-contained cwd). Also skips anything currently listed in `.agent/managed.json::sourceRepos` (or in the live `ctx.currentSourceRepoNames` when available) so a user with a UUID-shaped `gitRepos.localPath` is never deleted.",
+    apply: (workspacePath, log, ctx) => {
+      const currentRepos = ctx.currentSourceRepoNames ?? readCurrentSourceRepoNames(workspacePath);
       let removed = 0;
       let skipped = 0;
       for (const name of safeReaddir(workspacePath)) {
@@ -185,12 +219,15 @@ export const MIGRATIONS_REGISTRY: readonly Migration[] = [
     id: "v1-retired-source-repo-first-tree-hub",
     description:
       "Remove <ws>/first-tree-hub/ — a retired First-Tree source repo. Narrowly scoped to the broken-pointer shape the legacy hub-worktree model left behind: `.git` is a regular FILE (not a directory) with `gitdir: <path>` whose target no longer exists on disk. In that shape, `git config --get remote.origin.url` exits 128 and the general `v1-orphan-ft-clones` sweep can't identify the clone by origin URL — and the local git state is unusable anyway, so there's no recoverable work to lose. Healthy `first-tree-hub/` clones (with `.git/` as a real directory) defer to `v1-orphan-ft-clones`, which goes through `tryRemoveCloneSafely` with the dirty / ahead / worktree guards. PR #869 code-reviewer P0-1.",
-    apply: (workspacePath, log) => {
+    apply: (workspacePath, log, ctx) => {
       const target = join(workspacePath, "first-tree-hub");
       if (!existsSync(target) || !isDirectory(target)) return;
       // Skip if `first-tree-hub` is in the agent's current source-repos
-      // config — a future re-add would otherwise lose its checkout.
-      if (readCurrentSourceRepoNames(workspacePath).has("first-tree-hub")) {
+      // config — a future re-add would otherwise lose its checkout. The
+      // live `ctx.currentSourceRepoNames` is authoritative; fall back to the
+      // persisted state file when the live set is unknown (cache miss).
+      const currentRepos = ctx.currentSourceRepoNames ?? readCurrentSourceRepoNames(workspacePath);
+      if (currentRepos.has("first-tree-hub")) {
         log(
           "workspace-migrations: v1-retired-source-repo-first-tree-hub skipped — still in current source repos config",
         );
@@ -263,9 +300,26 @@ export const MIGRATIONS_REGISTRY: readonly Migration[] = [
   {
     id: "v1-orphan-ft-clones",
     description:
-      "Remove top-level clones whose `.git/config` origin points at agent-team-foundation/* but are not in the workspace's current source-repos config (catches retired source repos like first-tree-hub). Same dirty / ahead-of-upstream / worktree guards as the state-based source cleanup — Codex review P1 on PR #869.",
-    apply: (workspacePath, log) => {
-      const currentRepos = readCurrentSourceRepoNames(workspacePath);
+      'Remove top-level clones whose `.git/config` origin points at agent-team-foundation/* but are not in the workspace\'s current source-repos config (catches retired source repos like first-tree-hub). Same dirty / ahead-of-upstream / worktree guards as the state-based source cleanup — Codex review P1 on PR #869. **Requires an authoritative current source-repo set** (`ctx.currentSourceRepoNames !== null`); on a cache-miss session it returns `"deferred"` so it retries when the next resolved session arrives. PR #869 baixiaohang round-3 P0.',
+    apply: (workspacePath, log, ctx) => {
+      // The migration relies on \"absent from current source-repos config\"
+      // to identify orphans. When the live config is unresolved AND the
+      // persisted state file is empty (the common first-upgrade case), an
+      // empty fallback would treat every clean steady-state FT clone as
+      // orphaned and `rm` it. Defer instead — `tryRemoveCloneSafely`'s
+      // safety guards still protect dirty / ahead / worktree clones, but
+      // a clean repo with no work to lose is exactly what we'd
+      // accidentally nuke without an authoritative set.
+      if (ctx.currentSourceRepoNames === null) {
+        const persisted = readCurrentSourceRepoNames(workspacePath);
+        if (persisted.size === 0) {
+          log(
+            "workspace-migrations: v1-orphan-ft-clones deferred — no authoritative current source-repo set (live config unresolved AND `.agent/managed.json` empty); will retry next resolved session",
+          );
+          return "deferred";
+        }
+      }
+      const currentRepos = ctx.currentSourceRepoNames ?? readCurrentSourceRepoNames(workspacePath);
       let removed = 0;
       let skipped = 0;
       for (const name of safeReaddir(workspacePath)) {
@@ -382,6 +436,11 @@ export type ApplyMigrationsResult = {
   applied: readonly string[];
   /** Ids skipped because the marker file already lists them. */
   skipped: readonly string[];
+  /** Ids whose `apply` returned `"deferred"` — marker NOT written so the
+   *  migration retries on the next call (typically a future session
+   *  start with a resolved config). Distinct from `failed` so deferred
+   *  entries don't appear as errors in operator logs. */
+  deferred: readonly string[];
   /** Ids whose apply threw — marker NOT written so a future run retries. */
   failed: ReadonlyArray<{ id: string; reason: string }>;
 };
@@ -400,12 +459,14 @@ export type ApplyMigrationsResult = {
 export function applyPendingMigrations(
   workspacePath: string,
   log: MigrationLog,
+  ctx: MigrationContext = { currentSourceRepoNames: null },
   registry: readonly Migration[] = MIGRATIONS_REGISTRY,
 ): ApplyMigrationsResult {
   const record = readAppliedRecord(workspacePath);
   const alreadyApplied = new Set(record.applied);
   const newlyApplied: string[] = [];
   const skipped: string[] = [];
+  const deferred: string[] = [];
   const failed: Array<{ id: string; reason: string }> = [];
 
   for (const migration of registry) {
@@ -414,9 +475,17 @@ export function applyPendingMigrations(
       continue;
     }
     try {
-      migration.apply(workspacePath, log);
-      newlyApplied.push(migration.id);
-      alreadyApplied.add(migration.id);
+      const outcome = migration.apply(workspacePath, log, ctx);
+      if (outcome === "deferred") {
+        // Migration asked the applier not to mark it applied — its
+        // success requires a context this call couldn't provide. Future
+        // session retries; no FAIL log so operators don't chase a non-
+        // problem.
+        deferred.push(migration.id);
+      } else {
+        newlyApplied.push(migration.id);
+        alreadyApplied.add(migration.id);
+      }
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err);
       failed.push({ id: migration.id, reason });
@@ -431,5 +500,5 @@ export function applyPendingMigrations(
     });
   }
 
-  return { applied: newlyApplied, skipped, failed };
+  return { applied: newlyApplied, skipped, deferred, failed };
 }

--- a/packages/client/src/runtime/workspace-migrations.ts
+++ b/packages/client/src/runtime/workspace-migrations.ts
@@ -156,43 +156,39 @@ function hasLegacySnapshotSignature(dir: string): boolean {
 }
 
 /**
- * Should a config-dependent migration defer this session?
+ * Should a config-dependent migration proceed this session?
  *
- * "Yes" exactly when BOTH:
- *   - The live `ctx.currentSourceRepoNames` is `null` (the caller could not
- *     resolve a payload from the server / cache), AND
- *   - The persisted `.agent/managed.json::sourceRepos` is also empty (no
- *     resolved session has ever written the state file).
+ * "Yes" only when the live `ctx.currentSourceRepoNames` is non-null — the
+ * caller resolved a payload from the server / cache for this session. When
+ * it's `null` (cache miss, default-payload fallback), callers MUST return
+ * `"deferred"`: persisted `.agent/managed.json::sourceRepos` proves a
+ * PREVIOUS config, not the current one, and falling back to it after a
+ * fresh config edit (web-console add + immediate cache miss on the next
+ * start) is the same "unknown config looks authoritative" deletion class
+ * of bug the `payloadResolved` gate was added to prevent. Marker stays
+ * unrecorded; the next resolved session re-runs the migration.
  *
- * In that combination there is no authoritative way to tell "config truly
- * declares zero source repos" from "we have no idea what the config
- * declares", so any deletion that relies on the difference between current
- * and on-disk repos is unsafe. The caller returns `"deferred"`; the
- * migrations applier leaves the marker unrecorded and a future resolved
- * session re-runs the migration. PR #869 baixiaohang round-3/4 P0.
+ * The trade-off: a workspace whose cache is **permanently** broken never
+ * runs the one-shot sweep. That's acceptable because such a workspace
+ * cannot reach the resolved-payload codepath that materialises
+ * `.agent/managed.json` in the first place — its config-dependent state
+ * is already inconsistent, and accumulating a few legacy directories on
+ * disk is a strictly smaller cost than risking deletion of a currently-
+ * configured source repo.
  *
- * **Known residual race (PR #869 code-reviewer R2 N-1):** when ctx is null
- * AND persisted state is NON-empty but STALE — e.g. the user just added a
- * new source repo via the web console and this very next session hits a
- * cache miss before `prepareSourceRepos(payloadResolved: true)` has had a
- * chance to refresh the state file — `shouldDeferOnUnknownConfig` returns
- * false and the fallback to `readCurrentSourceRepoNames` returns the stale
- * set. If the new repo's `localPath` matches a hardcoded migration target
- * (today only `first-tree-hub` or a UUID-shaped name carrying an
- * AGENTS.md), the migration will treat it as orphan and delete. Mitigations
- * we evaluated:
- *   - Defer on `ctx === null` regardless of persisted state (option A) —
- *     safer, but a workspace whose cache is permanently lost would never
- *     get its sweep. Such a workspace can't function anyway.
- *   - Force retired-hub / UUID-snapshots through `tryRemoveCloneSafely`
- *     (option B) — adds the dirty/ahead/worktree guards as a backstop.
- * Both are tracked as follow-ups; the race window (cache miss between
- * config change and a successful refresh) is rare enough that documenting
- * it here is the chosen action for this PR.
+ * History: round-3 added a deferral that ONLY fired when both ctx and
+ * persisted state were empty; round-4 spread it to all config-dependent
+ * migrations; round-5 (baixiaohang P0) collapsed the condition to "ctx
+ * null, period" — the persisted-state-as-fallback path was the residual
+ * race code-reviewer R2 N-1 documented but did not close. PR #869.
+ *
+ * Returned as a TYPE PREDICATE so callers can write `if
+ * (!hasResolvedConfig(ctx)) return "deferred";` and have TypeScript
+ * narrow `ctx.currentSourceRepoNames` to `ReadonlySet<string>` on the
+ * fall-through path.
  */
-function shouldDeferOnUnknownConfig(ctx: MigrationContext, workspacePath: string): boolean {
-  if (ctx.currentSourceRepoNames !== null) return false;
-  return readCurrentSourceRepoNames(workspacePath).size === 0;
+function hasResolvedConfig(ctx: MigrationContext): ctx is { currentSourceRepoNames: ReadonlySet<string> } {
+  return ctx.currentSourceRepoNames !== null;
 }
 
 function readGitOrigin(repoDir: string): string | null {
@@ -223,13 +219,13 @@ export const MIGRATIONS_REGISTRY: readonly Migration[] = [
     description:
       "Remove legacy UUID-named per-chat snapshot directories at workspace root. Per PR #869 baixiaohang P0: scoped to entries that BOTH match the UUID shape AND carry the legacy snapshot signature (a top-level `AGENTS.md` / `CLAUDE.md` file from when each chat had a self-contained cwd). Also skips anything currently listed in `.agent/managed.json::sourceRepos` (or in the live `ctx.currentSourceRepoNames` when available) so a user with a UUID-shaped `gitRepos.localPath` is never deleted. Per round-4: defers when neither signal is available — a UUID-shaped current source repo whose cloned content ships an AGENTS.md would otherwise match the legacy signature and be `rmSync`'d on the first cache-miss start before any resolved payload could write managed.json.",
     apply: (workspacePath, log, ctx) => {
-      if (shouldDeferOnUnknownConfig(ctx, workspacePath)) {
+      if (!hasResolvedConfig(ctx)) {
         log(
-          "workspace-migrations: v1-uuid-snapshots deferred — no authoritative current source-repo set (live config unresolved AND `.agent/managed.json` empty); will retry next resolved session",
+          "workspace-migrations: v1-uuid-snapshots deferred — no authoritative current source-repo set (live config unresolved); will retry next resolved session",
         );
         return "deferred";
       }
-      const currentRepos = ctx.currentSourceRepoNames ?? readCurrentSourceRepoNames(workspacePath);
+      const currentRepos = ctx.currentSourceRepoNames;
       let removed = 0;
       let skipped = 0;
       for (const name of safeReaddir(workspacePath)) {
@@ -273,7 +269,7 @@ export const MIGRATIONS_REGISTRY: readonly Migration[] = [
       // is currently configured, refuse to act. The broken-pointer shape
       // check below would otherwise nuke a clone the user re-added before
       // the cache had a chance to populate.
-      if (shouldDeferOnUnknownConfig(ctx, workspacePath)) {
+      if (!hasResolvedConfig(ctx)) {
         log(
           "workspace-migrations: v1-retired-source-repo-first-tree-hub deferred — no authoritative current source-repo set; will retry next resolved session",
         );
@@ -283,7 +279,7 @@ export const MIGRATIONS_REGISTRY: readonly Migration[] = [
       // config — a future re-add would otherwise lose its checkout. The
       // live `ctx.currentSourceRepoNames` is authoritative; fall back to the
       // persisted state file when the live set is unknown (cache miss).
-      const currentRepos = ctx.currentSourceRepoNames ?? readCurrentSourceRepoNames(workspacePath);
+      const currentRepos = ctx.currentSourceRepoNames;
       if (currentRepos.has("first-tree-hub")) {
         log(
           "workspace-migrations: v1-retired-source-repo-first-tree-hub skipped — still in current source repos config",
@@ -367,13 +363,13 @@ export const MIGRATIONS_REGISTRY: readonly Migration[] = [
       // safety guards still protect dirty / ahead / worktree clones, but
       // a clean repo with no work to lose is exactly what we'd
       // accidentally nuke without an authoritative set.
-      if (shouldDeferOnUnknownConfig(ctx, workspacePath)) {
+      if (!hasResolvedConfig(ctx)) {
         log(
-          "workspace-migrations: v1-orphan-ft-clones deferred — no authoritative current source-repo set (live config unresolved AND `.agent/managed.json` empty); will retry next resolved session",
+          "workspace-migrations: v1-orphan-ft-clones deferred — no authoritative current source-repo set (live config unresolved); will retry next resolved session",
         );
         return "deferred";
       }
-      const currentRepos = ctx.currentSourceRepoNames ?? readCurrentSourceRepoNames(workspacePath);
+      const currentRepos = ctx.currentSourceRepoNames;
       let removed = 0;
       let skipped = 0;
       for (const name of safeReaddir(workspacePath)) {
@@ -413,36 +409,12 @@ export const MIGRATIONS_REGISTRY: readonly Migration[] = [
   },
 ];
 
-/**
- * Read the names of source repos currently materialised in this workspace,
- * by inspecting the previously-recorded managed state. Used by
- * `v1-orphan-ft-clones` to avoid deleting clones the state-based machinery
- * still tracks.
- *
- * Returns an empty set when no state file exists — at that point the
- * orphan-clone migration is being asked to run on a brand-new workspace,
- * which can't have orphans anyway, so the conservative empty set is fine.
- *
- * Imported lazily (require-style) to keep this module free of cross-file
- * cycles — `managed-state` already imports node:fs which keeps the
- * dependency direction one-way.
- */
-function readCurrentSourceRepoNames(workspacePath: string): Set<string> {
-  // Inline read instead of importing readManagedState to avoid a cycle
-  // when this module is loaded as part of the bootstrap path that also
-  // pulls in managed-state.
-  const statePath = join(workspacePath, ".agent", "managed.json");
-  if (!existsSync(statePath)) return new Set();
-  try {
-    const raw = JSON.parse(readFileSync(statePath, "utf-8")) as unknown;
-    if (typeof raw !== "object" || raw === null) return new Set();
-    const record = raw as Record<string, unknown>;
-    if (!Array.isArray(record.sourceRepos)) return new Set();
-    return new Set(record.sourceRepos.filter((entry): entry is string => typeof entry === "string"));
-  } catch {
-    return new Set();
-  }
-}
+// `readCurrentSourceRepoNames` was the round-3/4 fallback for "live ctx
+// unresolved, try persisted state". Round-5 (baixiaohang P0) closed that
+// fallback because persisted state is by definition stale relative to the
+// current session's config — see the `hasResolvedConfig` docstring. The
+// helper is intentionally NOT reintroduced; config-dependent migrations
+// now refuse to act without a live ctx, full stop.
 
 // ─── Applier ─────────────────────────────────────────────────────────
 

--- a/packages/client/src/runtime/workspace-migrations.ts
+++ b/packages/client/src/runtime/workspace-migrations.ts
@@ -1,0 +1,317 @@
+// One-shot workspace migrations for legacy directory-structure changes.
+//
+// Background: between First Tree's per-chat-cwd era and the current
+// per-agent-home model, the workspace layout changed several times. Old
+// workspaces accumulate stale top-level dirs (`.first-tree/` state dir,
+// UUID-named chat snapshots, retired source-repo clones like
+// `first-tree-hub/`, a `WHITEPAPER.md` symlink that used to point at a
+// repo-local skill payload). The state-based delete-on-removal in
+// `managed-state` only catches resources THIS CLI installed and later
+// dropped; legacy residue predates the state file entirely and has to
+// be cleaned with a one-shot sweep.
+//
+// Design:
+//
+//   - Each migration has a stable `id`. The set of already-applied ids is
+//     persisted to `.agent/migrations-applied.json` so each migration runs
+//     at most once per workspace, even if it's later removed from the
+//     registry (the marker stays as forward protection).
+//   - Migrations are idempotent — re-running a migration on an already-
+//     clean workspace is a noop. Marker file is the optimisation, not the
+//     correctness boundary.
+//   - Migrations log to `sessionCtx.log` (passed in by the caller).
+//   - One migration's failure does NOT block the rest; failures are logged
+//     and the marker is NOT recorded for that id (so a future run retries).
+
+import { execFileSync } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Path inside the agent home where {@link applyPendingMigrations} persists
+ * the set of already-applied migration ids.
+ */
+export const MIGRATIONS_APPLIED_REL = join(".agent", "migrations-applied.json");
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** Origin URLs matching this prefix are treated as First-Tree-managed —
+ *  the orphan-clone migration uses it to scope deletion to clones FT
+ *  itself planted, never user-cloned third-party repos. */
+const FT_ORIGIN_RE = /github\.com[/:]agent-team-foundation\//i;
+
+export type MigrationLog = (msg: string) => void;
+
+export type Migration = {
+  /** Stable identifier persisted to the marker file. Never re-use across
+   *  migrations even when one is retired. */
+  id: string;
+  description: string;
+  /** Idempotent action. Throws on failure; the applier catches and skips
+   *  the marker write so a future run retries. */
+  apply: (workspacePath: string, log: MigrationLog) => void;
+};
+
+// ─── Utilities ────────────────────────────────────────────────────────
+
+function safeReaddir(dir: string): string[] {
+  try {
+    return readdirSync(dir);
+  } catch {
+    return [];
+  }
+}
+
+function isDirectory(path: string): boolean {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function unlinkIfExists(path: string): boolean {
+  try {
+    lstatSync(path);
+  } catch {
+    return false;
+  }
+  try {
+    unlinkSync(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function readGitOrigin(repoDir: string): string | null {
+  const gitDir = join(repoDir, ".git");
+  if (!existsSync(gitDir)) return null;
+  try {
+    return execFileSync("git", ["config", "--get", "remote.origin.url"], {
+      cwd: repoDir,
+      encoding: "utf-8",
+      timeout: 5_000,
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+// ─── Migration registry ───────────────────────────────────────────────
+
+/**
+ * Ordered list of one-shot migrations. New entries land at the END with a
+ * fresh `vN-*` id; existing ids stay even when their bodies are simplified
+ * so already-migrated workspaces keep their marker.
+ */
+export const MIGRATIONS_REGISTRY: readonly Migration[] = [
+  {
+    id: "v1-uuid-snapshots",
+    description: "Remove legacy UUID-named per-chat snapshot directories at workspace root",
+    apply: (workspacePath, log) => {
+      let removed = 0;
+      for (const name of safeReaddir(workspacePath)) {
+        if (!UUID_RE.test(name)) continue;
+        const full = join(workspacePath, name);
+        if (!isDirectory(full)) continue;
+        rmSync(full, { recursive: true, force: true });
+        removed += 1;
+      }
+      if (removed > 0) {
+        log(`workspace-migrations: v1-uuid-snapshots removed ${removed} legacy snapshot dir(s)`);
+      }
+    },
+  },
+  {
+    id: "v1-legacy-dot-first-tree",
+    description: "Remove legacy <workspace>/.first-tree/ state dir (superseded by .agent/)",
+    apply: (workspacePath, log) => {
+      const target = join(workspacePath, ".first-tree");
+      if (!existsSync(target)) return;
+      rmSync(target, { recursive: true, force: true });
+      log("workspace-migrations: v1-legacy-dot-first-tree removed .first-tree/");
+    },
+  },
+  {
+    id: "v1-whitepaper-symlink",
+    description: "Remove legacy WHITEPAPER.md (root-level symlink that used to expose a skill payload)",
+    apply: (workspacePath, log) => {
+      const target = join(workspacePath, "WHITEPAPER.md");
+      if (unlinkIfExists(target)) {
+        log("workspace-migrations: v1-whitepaper-symlink removed WHITEPAPER.md");
+      }
+    },
+  },
+  {
+    id: "v1-orphan-ft-clones",
+    description:
+      "Remove top-level clones whose `.git/config` origin points at agent-team-foundation/* but are not in the workspace's current source-repos config (catches retired source repos like first-tree-hub)",
+    apply: (workspacePath, log) => {
+      const currentRepos = readCurrentSourceRepoNames(workspacePath);
+      let removed = 0;
+      for (const name of safeReaddir(workspacePath)) {
+        // Workspace-meta dirs and the agent-self-managed dirs never have a
+        // `.git/` so they're filtered by the origin probe below; skip them
+        // here just to keep the loop body cheap.
+        if (name.startsWith(".") || name === "worktrees" || name === "notes") continue;
+        const full = join(workspacePath, name);
+        if (!isDirectory(full)) continue;
+        if (currentRepos.has(name)) continue;
+        const origin = readGitOrigin(full);
+        if (origin === null) continue;
+        if (!FT_ORIGIN_RE.test(origin)) continue;
+        rmSync(full, { recursive: true, force: true });
+        log(`workspace-migrations: v1-orphan-ft-clones removed ${name}/ (origin ${origin})`);
+        removed += 1;
+      }
+      if (removed === 0) {
+        // Single summary line so the marker write is the only side effect
+        // when nothing matched — keeps the steady-state log quiet.
+        log("workspace-migrations: v1-orphan-ft-clones found no orphan FT clones");
+      }
+    },
+  },
+];
+
+/**
+ * Read the names of source repos currently materialised in this workspace,
+ * by inspecting the previously-recorded managed state. Used by
+ * `v1-orphan-ft-clones` to avoid deleting clones the state-based machinery
+ * still tracks.
+ *
+ * Returns an empty set when no state file exists — at that point the
+ * orphan-clone migration is being asked to run on a brand-new workspace,
+ * which can't have orphans anyway, so the conservative empty set is fine.
+ *
+ * Imported lazily (require-style) to keep this module free of cross-file
+ * cycles — `managed-state` already imports node:fs which keeps the
+ * dependency direction one-way.
+ */
+function readCurrentSourceRepoNames(workspacePath: string): Set<string> {
+  // Inline read instead of importing readManagedState to avoid a cycle
+  // when this module is loaded as part of the bootstrap path that also
+  // pulls in managed-state.
+  const statePath = join(workspacePath, ".agent", "managed.json");
+  if (!existsSync(statePath)) return new Set();
+  try {
+    const raw = JSON.parse(readFileSync(statePath, "utf-8")) as unknown;
+    if (typeof raw !== "object" || raw === null) return new Set();
+    const record = raw as Record<string, unknown>;
+    if (!Array.isArray(record.sourceRepos)) return new Set();
+    return new Set(record.sourceRepos.filter((entry): entry is string => typeof entry === "string"));
+  } catch {
+    return new Set();
+  }
+}
+
+// ─── Applier ─────────────────────────────────────────────────────────
+
+type AppliedRecord = {
+  schemaVersion: 1;
+  applied: string[];
+};
+
+function readAppliedRecord(workspacePath: string): AppliedRecord {
+  const path = join(workspacePath, MIGRATIONS_APPLIED_REL);
+  if (!existsSync(path)) return { schemaVersion: 1, applied: [] };
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf-8")) as unknown;
+    if (typeof parsed !== "object" || parsed === null) return { schemaVersion: 1, applied: [] };
+    const record = parsed as Record<string, unknown>;
+    if (record.schemaVersion !== 1) return { schemaVersion: 1, applied: [] };
+    const applied = Array.isArray(record.applied)
+      ? record.applied.filter((entry): entry is string => typeof entry === "string")
+      : [];
+    return { schemaVersion: 1, applied };
+  } catch {
+    return { schemaVersion: 1, applied: [] };
+  }
+}
+
+function writeAppliedRecord(workspacePath: string, record: AppliedRecord): void {
+  mkdirSync(join(workspacePath, ".agent"), { recursive: true });
+  const finalPath = join(workspacePath, MIGRATIONS_APPLIED_REL);
+  const tempPath = `${finalPath}.${randomBytes(6).toString("hex")}.tmp`;
+  writeFileSync(tempPath, `${JSON.stringify(record, null, 2)}\n`, "utf-8");
+  try {
+    renameSync(tempPath, finalPath);
+  } catch (err) {
+    try {
+      unlinkSync(tempPath);
+    } catch {
+      // Best-effort cleanup — surface the original rename failure.
+    }
+    throw err;
+  }
+}
+
+export type ApplyMigrationsResult = {
+  /** Ids whose apply ran cleanly this call (newly applied). */
+  applied: readonly string[];
+  /** Ids skipped because the marker file already lists them. */
+  skipped: readonly string[];
+  /** Ids whose apply threw — marker NOT written so a future run retries. */
+  failed: ReadonlyArray<{ id: string; reason: string }>;
+};
+
+/**
+ * Run every registry migration whose id is not in the marker file. Writes
+ * the updated marker after the registry walk so a crash mid-loop only
+ * loses the in-flight migration (the future run picks up where this one
+ * left off).
+ *
+ * Order-of-operations: the applier walks `MIGRATIONS_REGISTRY` in array
+ * order. Migrations are designed to be order-independent (each targets a
+ * different file/directory pattern) so this matters only for log
+ * readability.
+ */
+export function applyPendingMigrations(
+  workspacePath: string,
+  log: MigrationLog,
+  registry: readonly Migration[] = MIGRATIONS_REGISTRY,
+): ApplyMigrationsResult {
+  const record = readAppliedRecord(workspacePath);
+  const alreadyApplied = new Set(record.applied);
+  const newlyApplied: string[] = [];
+  const skipped: string[] = [];
+  const failed: Array<{ id: string; reason: string }> = [];
+
+  for (const migration of registry) {
+    if (alreadyApplied.has(migration.id)) {
+      skipped.push(migration.id);
+      continue;
+    }
+    try {
+      migration.apply(workspacePath, log);
+      newlyApplied.push(migration.id);
+      alreadyApplied.add(migration.id);
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      failed.push({ id: migration.id, reason });
+      log(`workspace-migrations: ${migration.id} FAILED (${reason.slice(0, 200)})`);
+    }
+  }
+
+  if (newlyApplied.length > 0) {
+    writeAppliedRecord(workspacePath, {
+      schemaVersion: 1,
+      applied: [...alreadyApplied].sort(),
+    });
+  }
+
+  return { applied: newlyApplied, skipped, failed };
+}

--- a/packages/client/src/runtime/workspace-migrations.ts
+++ b/packages/client/src/runtime/workspace-migrations.ts
@@ -217,7 +217,7 @@ export const MIGRATIONS_REGISTRY: readonly Migration[] = [
   {
     id: "v1-uuid-snapshots",
     description:
-      "Remove legacy UUID-named per-chat snapshot directories at workspace root. Per PR #869 baixiaohang P0: scoped to entries that BOTH match the UUID shape AND carry the legacy snapshot signature (a top-level `AGENTS.md` / `CLAUDE.md` file from when each chat had a self-contained cwd). Also skips anything currently listed in `.agent/managed.json::sourceRepos` (or in the live `ctx.currentSourceRepoNames` when available) so a user with a UUID-shaped `gitRepos.localPath` is never deleted. Per round-4: defers when neither signal is available — a UUID-shaped current source repo whose cloned content ships an AGENTS.md would otherwise match the legacy signature and be `rmSync`'d on the first cache-miss start before any resolved payload could write managed.json.",
+      "Remove legacy UUID-named per-chat snapshot directories at workspace root. Per PR #869 baixiaohang P0: scoped to entries that BOTH match the UUID shape AND carry the legacy snapshot signature (a top-level `AGENTS.md` / `CLAUDE.md` file from when each chat had a self-contained cwd). Also skips anything currently in the live `ctx.currentSourceRepoNames` so a user with a UUID-shaped `gitRepos.localPath` is never deleted. Per round-5: defers when ctx is null — a UUID-shaped current source repo whose cloned content ships an AGENTS.md would otherwise match the legacy signature and be `rmSync`'d before any resolved payload could prove it's still configured.",
     apply: (workspacePath, log, ctx) => {
       if (!hasResolvedConfig(ctx)) {
         log(
@@ -264,11 +264,11 @@ export const MIGRATIONS_REGISTRY: readonly Migration[] = [
     apply: (workspacePath, log, ctx) => {
       const target = join(workspacePath, "first-tree-hub");
       if (!existsSync(target) || !isDirectory(target)) return;
-      // Same defer rule as the UUID + orphan paths: when neither the live
-      // ctx nor the persisted state can confirm whether `first-tree-hub`
-      // is currently configured, refuse to act. The broken-pointer shape
-      // check below would otherwise nuke a clone the user re-added before
-      // the cache had a chance to populate.
+      // Same defer rule as the UUID + orphan paths: when the live ctx
+      // cannot confirm whether `first-tree-hub` is currently configured,
+      // refuse to act. The broken-pointer shape check below would otherwise
+      // nuke a clone the user re-added before the cache had a chance to
+      // populate.
       if (!hasResolvedConfig(ctx)) {
         log(
           "workspace-migrations: v1-retired-source-repo-first-tree-hub deferred — no authoritative current source-repo set; will retry next resolved session",
@@ -276,9 +276,7 @@ export const MIGRATIONS_REGISTRY: readonly Migration[] = [
         return "deferred";
       }
       // Skip if `first-tree-hub` is in the agent's current source-repos
-      // config — a future re-add would otherwise lose its checkout. The
-      // live `ctx.currentSourceRepoNames` is authoritative; fall back to the
-      // persisted state file when the live set is unknown (cache miss).
+      // config — a future re-add would otherwise lose its checkout.
       const currentRepos = ctx.currentSourceRepoNames;
       if (currentRepos.has("first-tree-hub")) {
         log(
@@ -356,13 +354,13 @@ export const MIGRATIONS_REGISTRY: readonly Migration[] = [
       'Remove top-level clones whose `.git/config` origin points at agent-team-foundation/* but are not in the workspace\'s current source-repos config (catches retired source repos like first-tree-hub). Same dirty / ahead-of-upstream / worktree guards as the state-based source cleanup — Codex review P1 on PR #869. **Requires an authoritative current source-repo set** (`ctx.currentSourceRepoNames !== null`); on a cache-miss session it returns `"deferred"` so it retries when the next resolved session arrives. PR #869 baixiaohang round-3 P0.',
     apply: (workspacePath, log, ctx) => {
       // The migration relies on "absent from current source-repos config"
-      // to identify orphans. When the live config is unresolved AND the
-      // persisted state file is empty (the common first-upgrade case), an
-      // empty fallback would treat every clean steady-state FT clone as
-      // orphaned and `rm` it. Defer instead — `tryRemoveCloneSafely`'s
+      // to identify orphans. When the live ctx is unresolved, treating it
+      // as an empty set would mark every clean steady-state FT clone as
+      // orphan and `rm` it. Defer instead — `tryRemoveCloneSafely`'s
       // safety guards still protect dirty / ahead / worktree clones, but
       // a clean repo with no work to lose is exactly what we'd
-      // accidentally nuke without an authoritative set.
+      // accidentally nuke without an authoritative set. See
+      // `hasResolvedConfig` for the full round-5 rationale.
       if (!hasResolvedConfig(ctx)) {
         log(
           "workspace-migrations: v1-orphan-ft-clones deferred — no authoritative current source-repo set (live config unresolved); will retry next resolved session",


### PR DESCRIPTION
## Summary

Two CLI behaviors that together stop agent workspaces from sliently accumulating stale resources across config edits and version bumps:

1. **State-based delete-on-removal** for source repos and tree skills. The CLI records what it currently manages at `<workspace>/.agent/managed.json`; on the next session start it diffs the recorded set against the current config and removes anything that fell out — source-repo `localPath` directories AND skill payload + `.claude/skills/<name>` symlink pairs.
2. **One-shot directory-structure migrations** for legacy workspaces. Four v1 migrations sweep known historical baggage (`first-tree-hub/` retired source clones, UUID-named per-chat snapshot dirs from the per-chat-cwd era, the pre-`.agent/` `.first-tree/` state dir, the legacy `WHITEPAPER.md` symlink). Each migration runs at most once per workspace via a marker at `.agent/migrations-applied.json`.

Motivation comes from a real example — the `liuchao-staff` agent workspace had accumulated **~27 GB** of stale residue across the last few months of CLI evolution. Phase A manual cleanup brought it to ~544 MB; this PR codifies the equivalent behavior into the CLI so the same drift doesn't recur and so other long-running workspaces self-heal on upgrade.

## What this PR is NOT

- ❌ Not touching workspace size limits / quotas
- ❌ Not changing the source-repo directory layout (still at workspace top level — `yuezengwu` review explicitly rejected the `.first-tree-repos/` reorg as out of scope)
- ❌ Not touching tree-repo lifecycle (content-hash shared at staging root, separate concern)
- ❌ Not introducing a workspace-doctor CLI subcommand
- ❌ Not handling worktree cleanup (agent self-managed; goes via the AGENTS.md template, separate PR)

## How it stays safe

State-based cleanup applies path-level precision — only resources the CLI itself recorded as installed are eligible for deletion. Anything the user dropped at workspace root (third-party clones, manual experiments, custom skills) is never in the recorded set and therefore never touched.

Source-repo cleanup has three guards before deleting any clone:
1. Working tree clean (`git status --porcelain` empty)
2. No local commits ahead of upstream
3. No dependent `git worktree` checkouts

Any probe failure conservatively SKIPS the delete and logs a warning — better to leave a stale clone than nuke unpushed work.

Migrations:
- `v1-orphan-ft-clones` matches on origin URL (`github.com/agent-team-foundation/*`), not directory name, so a user-cloned third-party repo at workspace root with the same name as a retired FT repo would still be safe.
- The scan skips dotfile-prefixed entries and the agent-self-managed `worktrees/` / `notes/` subdirs.

## Commits

1. `feat(client): track CLI-managed workspace resources in .agent/managed.json` — new `managed-state.ts` module + tests, no callers yet.
2. `feat(client): one-shot workspace migrations for legacy directory structure` — new `workspace-migrations.ts` module + tests + wire-in to `ensureAgentBootstrap`.
3. `feat(client): clean up source repos and skills removed from agent config` — wire `managed-state` into `prepareSourceRepos` and `installFirstTreeSkills` with safety guards.

Each commit stands alone (the first two add the helpers; the third turns on the cleanup behavior).

## Test plan

- [x] `pnpm check` — passes
- [x] `pnpm --filter @first-tree/client typecheck` — passes
- [x] `pnpm --filter @first-tree/client test` — 1026 / 1026 pass (25 new tests)
- [ ] Manual smoke on a real workspace: rename a source repo in agent config → next session start removes the old clone, leaves notes/ and worktrees/ alone.
- [ ] Manual smoke on a workspace with `first-tree-hub/` present → migration removes it on first run; second start is a noop.

## Design doc (local)

Full design write-up — including scope decisions from the team review, the rejected `.first-tree-repos/` reorg, why `.agents/skills/` stays canonical, and why the doctor subcommand is out of scope — lives at:
`/Users/super/.first-tree-staging/data/workspaces/liuchao-staff/notes/agent-workspace-hygiene-design.md` (not committed; local to my agent home).

🤖 Generated with [Claude Code](https://claude.com/claude-code)