### PR TITLE
feat(web): agent-detail PR2 — save semantics, Environment zones, leave guard, one Profile edit

### DIFF
--- a/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
+++ b/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
@@ -996,20 +996,19 @@ describe("page SSR smoke coverage", () => {
     const { RuntimeSection } = await import("../agent-detail/runtime-section.js");
 
     const noop = () => undefined;
-    const asyncNoop = async () => undefined;
     const row = <T,>(key: string, value: T) => ({ key, value, baseline: value, status: "unchanged" as const });
     const rendered = renderPage(
       <>
-        <IdentitySection agent={agent()} onSave={asyncNoop} />
-        <AppearanceSection agent={agent()} onSave={asyncNoop} onRefresh={asyncNoop} />
+        <IdentitySection agent={agent()} />
+        <AppearanceSection agent={agent()} />
         <RuntimeSection
           runtimeProvider="claude-code"
           computerLabel="gandy-macbook"
           canBindComputer={false}
           onBindComputer={noop}
-          modelSlot={<ModelSection value="sonnet" baseline="opus" onChange={noop} onRevert={noop} />}
-          effortSlot={<ReasoningEffortSection value="high" baseline="" onChange={noop} onRevert={noop} />}
         />
+        <ModelSection value="sonnet" baseline="opus" onChange={noop} onRevert={noop} />
+        <ReasoningEffortSection value="high" baseline="" onChange={noop} onRevert={noop} />
         <McpSection
           items={AGENT_CONFIG.payload.mcpServers.map((item, index) => row(`mcp-${index}`, item))}
           otherNames={() => new Set()}

--- a/packages/web/src/pages/agent-detail.tsx
+++ b/packages/web/src/pages/agent-detail.tsx
@@ -36,7 +36,7 @@ import { useAgentResources } from "./agent-detail/capability-section.js";
 import { ContextBar } from "./agent-detail/context-bar.js";
 import type { AgentDetailContext } from "./agent-detail/layout-context.js";
 import { ReBindDialog } from "./agent-detail/re-bind-dialog.js";
-import { SaveBar } from "./agent-detail/save-bar.js";
+import { SaveBar, sectionAnchorId } from "./agent-detail/save-bar.js";
 import { deriveSaveHint } from "./agent-detail/save-hint.js";
 import { type DraftSectionName, useConfigDraft } from "./agent-detail/use-config-draft.js";
 import { useLegacyAnchorRedirect } from "./agent-detail/use-legacy-anchor-redirect.js";
@@ -258,6 +258,26 @@ export function AgentDetailPage() {
 
   const [discardDialogOpen, setDiscardDialogOpen] = useState(false);
 
+  // Leave guard. react-router's `useBlocker` is unavailable here — the app uses
+  // a declarative <BrowserRouter>, not a data router, so useBlocker throws via
+  // its useDataRouterContext invariant. Instead we collar this page's own "leave"
+  // entries and confirm before discarding the config draft: breadcrumb, back,
+  // Chat, the in-page "Manage in Settings" / "Open Computers" links, and PR3's
+  // agent switcher (via the context-exposed `guardedNavigate`). beforeunload
+  // still covers hard exits (refresh / close).
+  // Known gaps (follow-up; the only clean fix is a data-router migration, which
+  // is a separate app-wide change): the GLOBAL top nav (Workspace / Context /
+  // Team / Settings in layout.tsx) and browser back/forward (popstate) route
+  // around this guard — beforeunload doesn't catch SPA popstate either.
+  const [pendingNav, setPendingNav] = useState<string | null>(null);
+  const guardedNavigate = useCallback(
+    (to: string) => {
+      if (draft.summary.anyDirty) setPendingNav(to);
+      else navigate(to);
+    },
+    [draft.summary.anyDirty, navigate],
+  );
+
   const [dryRunText, setDryRunText] = useState<string | null>(null);
   const dryRunMutation = useMutation({
     mutationFn: () => dryRunAgentConfig(uuid, draft.buildPayloadPatch()),
@@ -444,6 +464,7 @@ export function AgentDetailPage() {
     isHuman,
     canManageAgent,
     canEditConfig,
+    guardedNavigate,
     draft,
     config: cfgQuery.data,
     configLoading: cfgQuery.isLoading,
@@ -480,7 +501,7 @@ export function AgentDetailPage() {
         {isNarrow ? (
           <button
             type="button"
-            onClick={() => navigate("/team")}
+            onClick={() => guardedNavigate("/team")}
             aria-label="Back to agents"
             className="inline-flex items-center bg-transparent border-0 cursor-pointer transition-colors hover:text-[var(--fg)] text-caption"
             style={{
@@ -497,9 +518,9 @@ export function AgentDetailPage() {
           </button>
         ) : (
           <Breadcrumb style={{ marginBottom: "var(--sp-2)" }}>
-            <BreadcrumbLink onClick={() => navigate("/team")}>Team</BreadcrumbLink>
+            <BreadcrumbLink onClick={() => guardedNavigate("/team")}>Team</BreadcrumbLink>
             <BreadcrumbSep />
-            <BreadcrumbLink onClick={() => navigate("/team")}>Agents</BreadcrumbLink>
+            <BreadcrumbLink onClick={() => guardedNavigate("/team")}>Agents</BreadcrumbLink>
             <BreadcrumbSep />
             <BreadcrumbCurrent>{agent.displayName}</BreadcrumbCurrent>
           </Breadcrumb>
@@ -534,7 +555,7 @@ export function AgentDetailPage() {
               size="xs"
               onClick={() => {
                 const search = new URLSearchParams({ c: "draft", with: agent.uuid });
-                navigate(`/?${search.toString()}`);
+                guardedNavigate(`/?${search.toString()}`);
               }}
               title="Start a chat with this agent"
               aria-label="Start chat"
@@ -588,7 +609,15 @@ export function AgentDetailPage() {
           onReloadRemote={() => {
             void reloadRemote();
           }}
-          onJumpTo={(section) => navigate(`/agents/${uuid}/${SECTION_TO_TAB[section]}`, { replace: true })}
+          onJumpTo={(section) => {
+            // Same-agent navigation (no leave guard), then scroll the dirty
+            // section into view — the tab alone lands at the top, which after the
+            // Environment zoning can be far above env / model.
+            navigate(`/agents/${uuid}/${SECTION_TO_TAB[section]}`, { replace: true });
+            setTimeout(() => {
+              document.getElementById(sectionAnchorId(section))?.scrollIntoView({ behavior: "smooth", block: "start" });
+            }, 50);
+          }}
         />
       )}
 
@@ -596,7 +625,7 @@ export function AgentDetailPage() {
         open={discardDialogOpen}
         onOpenChange={setDiscardDialogOpen}
         title="Discard unsaved changes?"
-        description="Your edits to Instructions / Runtime / Capabilities will be reverted to the last saved baseline."
+        description="Your unsaved Model / Environment changes will be reverted to the last saved baseline."
         confirmLabel="Discard changes"
         destructive
         onConfirm={() => {
@@ -604,6 +633,25 @@ export function AgentDetailPage() {
           setSaveError(null);
           setConflictMsg(null);
           setDiscardDialogOpen(false);
+        }}
+      />
+
+      <ConfirmDialog
+        open={pendingNav !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingNav(null);
+        }}
+        title="Leave with unsaved changes?"
+        description="Your unsaved Model / Environment changes will be discarded if you leave this agent."
+        confirmLabel="Discard & leave"
+        destructive
+        onConfirm={() => {
+          const to = pendingNav;
+          draft.resetAll();
+          setSaveError(null);
+          setConflictMsg(null);
+          setPendingNav(null);
+          if (to) navigate(to);
         }}
       />
 
@@ -639,6 +687,7 @@ export function AgentDetailPage() {
                 clients={clientsQuery.data ?? []}
                 selected={bindClientSelected}
                 onSelect={setBindClientSelected}
+                onOpenComputers={() => guardedNavigate("/settings/computers")}
               />
             )}
             {bindClientError && (
@@ -827,12 +876,13 @@ function BindClientList({
   clients,
   selected,
   onSelect,
+  onOpenComputers,
 }: {
   clients: HubClient[];
   selected: string;
   onSelect: (id: string) => void;
+  onOpenComputers: () => void;
 }) {
-  const navigate = useNavigate();
   const bindable = clients.filter(isBindableClient);
   if (bindable.length === 0) {
     return (
@@ -860,14 +910,7 @@ function BindClientList({
               Connect a computer first, then return here to bind this agent.
             </p>
           </div>
-          <Button
-            type="button"
-            variant="outline"
-            size="xs"
-            onClick={() => {
-              navigate("/settings/computers");
-            }}
-          >
+          <Button type="button" variant="outline" size="xs" onClick={onOpenComputers}>
             Open Computers
           </Button>
         </div>

--- a/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
@@ -8,6 +8,7 @@ import { MemoryRouter, Navigate, Route, Routes, useLocation } from "react-router
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { HubClient } from "../../../api/activity.js";
 import { ApiError } from "../../../api/client.js";
+import { UsageTab } from "../usage-tab.js";
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -41,6 +42,11 @@ const sessionMocks = vi.hoisted(() => ({
   listAgentSessions: vi.fn(),
 }));
 
+const usageMocks = vi.hoisted(() => ({
+  getAgentUsageSummary: vi.fn(),
+  getAgentUsageTurns: vi.fn(),
+}));
+
 const authMock = vi.hoisted(() => ({
   value: {
     memberId: "member-self",
@@ -65,6 +71,12 @@ vi.mock("../../../api/agent-resources.js", () => agentResourceMocks);
 vi.mock("../../../api/sessions.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../../api/sessions.js")>()),
   listAgentSessions: sessionMocks.listAgentSessions,
+}));
+
+vi.mock("../../../api/usage.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../api/usage.js")>()),
+  getAgentUsageSummary: usageMocks.getAgentUsageSummary,
+  getAgentUsageTurns: usageMocks.getAgentUsageTurns,
 }));
 
 vi.mock("../../../auth/auth-context.js", () => ({
@@ -275,6 +287,7 @@ async function renderDom(route: string, child: ReactElement): Promise<{ containe
               <Route path="prompt" element={child} />
               <Route path="resources" element={<div>Resources route</div>} />
               <Route path="runtime" element={child} />
+              <Route path="usage" element={<UsageTab />} />
               <Route path="setup" element={<Navigate to="../runtime" replace />} />
             </Route>
             <Route path="/" element={<LocationEcho />} />
@@ -375,6 +388,23 @@ beforeEach(() => {
     client({ id: "client-2", hostname: "alice-linux", os: "linux" }),
   ]);
   sessionMocks.listAgentSessions.mockResolvedValue([{ chatId: "chat-1" }]);
+  usageMocks.getAgentUsageSummary.mockResolvedValue({ daily: [], totals: {} });
+  usageMocks.getAgentUsageTurns.mockResolvedValue({
+    rows: [
+      {
+        chatId: "chat-7",
+        seq: 1,
+        chatTitle: "Launch planning",
+        provider: "claude-code",
+        model: "sonnet",
+        inputTokens: 100,
+        cachedInputTokens: 0,
+        outputTokens: 50,
+        createdAt: NOW,
+      },
+    ],
+    nextCursor: null,
+  });
 });
 
 afterEach(() => {
@@ -819,6 +849,31 @@ describe("AgentDetailPage", () => {
     const profileTab = [...container.querySelectorAll('[role="tab"]')].find((t) => t.textContent?.trim() === "Profile");
     await click(profileTab ?? null);
     expect(document.body.textContent).not.toContain("Leave with unsaved changes?");
+
+    await act(async () => root.unmount());
+  });
+
+  it("guards the Usage tab's recent-turn chat link when the draft is dirty", async () => {
+    const { RuntimeTab } = await import("../runtime-tab.js");
+    const { container, root } = await renderDom("/agents/agent-1/runtime", <RuntimeTab />);
+    await waitForText(container, "Model settings");
+    // Dirty the config draft on Environment, then switch to Usage (same agent —
+    // not guarded; the draft persists across tabs).
+    await chooseSelectOption(container.querySelector('button[aria-label="Model"]'), "opus");
+    await waitForText(container, "Configuration changes in");
+    const usageTab = [...container.querySelectorAll('[role="tab"]')].find((t) => t.textContent?.trim() === "Usage");
+    await click(usageTab ?? null);
+    await waitForText(container, "Launch planning");
+
+    // Opening a recent-turn chat leaves the agent → guarded; cancel keeps the page.
+    await click([...container.querySelectorAll("button")].find((b) => b.textContent === "Launch planning") ?? null);
+    await waitForText(document.body, "Leave with unsaved changes?");
+    expect(container.textContent).not.toContain("/?chat=");
+    await click(exactButtonByText(document.body, "Cancel"));
+    await waitForCondition(
+      () => !document.body.textContent?.includes("Leave with unsaved changes?"),
+      "Expected leave guard to dismiss on cancel",
+    );
 
     await act(async () => root.unmount());
   });

--- a/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
@@ -778,6 +778,51 @@ describe("AgentDetailPage", () => {
     await act(async () => root.unmount());
   });
 
+  it("guards leaving with an unsaved config draft (confirm discards, cancel stays)", async () => {
+    const { RuntimeTab } = await import("../runtime-tab.js");
+    const { container, root } = await renderDom("/agents/agent-1/runtime", <RuntimeTab />);
+    await waitForText(container, "Model settings");
+
+    // Dirty the config draft by changing the model — the SaveBar appears.
+    await chooseSelectOption(container.querySelector('button[aria-label="Model"]'), "opus");
+    await waitForText(container, "Configuration changes in");
+
+    // Leaving via the header Chat button is guarded.
+    await click(container.querySelector('button[aria-label="Start chat"]'));
+    await waitForText(document.body, "Leave with unsaved changes?");
+    expect(container.textContent).not.toContain("/?c=draft");
+
+    // Cancel keeps us on the page (no navigation).
+    await click(exactButtonByText(document.body, "Cancel"));
+    await waitForCondition(
+      () => !document.body.textContent?.includes("Leave with unsaved changes?"),
+      "Expected leave guard to dismiss on cancel",
+    );
+
+    // Re-trigger and discard → navigation proceeds.
+    await click(container.querySelector('button[aria-label="Start chat"]'));
+    await waitForText(document.body, "Leave with unsaved changes?");
+    await click(exactButtonByText(document.body, "Discard & leave"));
+    await waitForText(container, "/?c=draft&with=agent-1");
+
+    await act(async () => root.unmount());
+  });
+
+  it("does not guard same-agent tab navigation (draft persists across tabs)", async () => {
+    const { RuntimeTab } = await import("../runtime-tab.js");
+    const { container, root } = await renderDom("/agents/agent-1/runtime", <RuntimeTab />);
+    await waitForText(container, "Model settings");
+    await chooseSelectOption(container.querySelector('button[aria-label="Model"]'), "opus");
+    await waitForText(container, "Configuration changes in");
+
+    // Switching tabs within the same agent must NOT pop the leave guard.
+    const profileTab = [...container.querySelectorAll('[role="tab"]')].find((t) => t.textContent?.trim() === "Profile");
+    await click(profileTab ?? null);
+    expect(document.body.textContent).not.toContain("Leave with unsaved changes?");
+
+    await act(async () => root.unmount());
+  });
+
   it("starts a draft chat with the current agent from the header", async () => {
     const { PromptTab } = await import("../prompt-tab.js");
     const { container, root } = await renderDom("/agents/agent-1/prompt", <PromptTab />);

--- a/packages/web/src/pages/agent-detail/__tests__/appearance-identity-options-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/appearance-identity-options-dom.test.tsx
@@ -216,73 +216,49 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe("AppearanceSection", () => {
-  it("edits avatar color, uploads a resized image, removes an image, and reports save errors", async () => {
+describe("AppearanceSection (display-only)", () => {
+  it("shows avatar summary and routes Edit + avatar to the unified dialog", async () => {
     const { AppearanceSection } = await import("../appearance-section.js");
-    const onSave = vi.fn().mockResolvedValue(undefined);
-    const onRefresh = vi.fn().mockResolvedValue(undefined);
+    const onEdit = vi.fn();
 
-    const first = await renderDom(
-      <AppearanceSection agent={agent({ avatarColorToken: "hue-1" })} onSave={onSave} onRefresh={onRefresh} />,
-    );
-    expect(first.container.textContent).toContain("Color hue-1");
-
-    await click(buttonByText(first.container, "Edit"));
-    expect(document.body.textContent).toContain("Edit Appearance");
-    await click(document.body.querySelector('button[title="hue-3"]'));
-    await click(buttonByText(document.body, "Save"));
-    expect(onSave).toHaveBeenCalledWith({ avatarColorToken: "hue-3" });
-
-    await act(async () => first.root.unmount());
-
-    const second = await renderDom(
+    const withImage = await renderDom(
       <AppearanceSection
         agent={agent({ avatarColorToken: "hue-3", avatarImageUrl: "/avatars/agent-1.png" })}
-        onSave={onSave}
-        onRefresh={onRefresh}
+        onEdit={onEdit}
       />,
     );
-    expect(second.container.textContent).toContain("Custom image");
-    expect(second.container.querySelector('img[alt="Kael"]')).toBeTruthy();
-
-    await click(buttonByText(second.container, "Edit"));
-    const fileInput = document.body.querySelector<HTMLInputElement>('input[type="file"]');
-    if (!fileInput) throw new Error("Expected file input");
-    await setFileInput(fileInput, new File(["avatar"], "avatar.png", { type: "image/png" }));
-    expect(agentApiMocks.uploadAgentAvatar).toHaveBeenCalledWith("agent-1", expect.any(Blob));
-    expect(onRefresh).toHaveBeenCalled();
-
-    await click(buttonByText(document.body, "Remove image"));
-    expect(agentApiMocks.deleteAgentAvatar).toHaveBeenCalledWith("agent-1");
-
-    onSave.mockRejectedValueOnce(new Error("Color update failed"));
-    await click(document.body.querySelector('button[title="Auto"]'));
-    await click(buttonByText(document.body, "Save"));
-    expect(document.body.textContent).toContain("Color update failed");
-
-    await act(async () => second.root.unmount());
+    expect(withImage.container.textContent).toContain("Custom image");
+    expect(withImage.container.querySelector('img[alt="Kael"]')).toBeTruthy();
+    await click(buttonByText(withImage.container, "Edit"));
+    await click(withImage.container.querySelector('button[aria-label="Edit avatar"]'));
+    expect(onEdit).toHaveBeenCalledTimes(2);
+    await act(async () => withImage.root.unmount());
   });
 
-  it("hides edit controls when the caller cannot edit or the agent is inactive", async () => {
+  it("hides the edit affordance when the caller cannot edit, the agent is inactive, or no onEdit is given", async () => {
     const { AppearanceSection } = await import("../appearance-section.js");
-    const onSave = vi.fn();
+    const onEdit = vi.fn();
 
-    const readOnly = await renderDom(<AppearanceSection agent={agent()} canEdit={false} onSave={onSave} />);
+    const readOnly = await renderDom(<AppearanceSection agent={agent()} canEdit={false} onEdit={onEdit} />);
     expect(buttonByText(readOnly.container, "Edit")).toBeNull();
     await act(async () => readOnly.root.unmount());
 
     const inactive = await renderDom(
-      <AppearanceSection agent={agent({ status: "suspended" })} canEdit onSave={onSave} />,
+      <AppearanceSection agent={agent({ status: "suspended" })} canEdit onEdit={onEdit} />,
     );
     expect(buttonByText(inactive.container, "Edit")).toBeNull();
     await act(async () => inactive.root.unmount());
+
+    const noHandler = await renderDom(<AppearanceSection agent={agent()} canEdit />);
+    expect(buttonByText(noHandler.container, "Edit")).toBeNull();
+    await act(async () => noHandler.root.unmount());
   });
 });
 
-describe("IdentitySection", () => {
-  it("renders resolved identity metadata and saves human identity edits", async () => {
+describe("IdentitySection (display-only)", () => {
+  it("renders resolved identity metadata and routes Edit to the unified dialog", async () => {
     const { IdentitySection } = await import("../identity-section.js");
-    const onSave = vi.fn().mockResolvedValue(undefined);
+    const onEdit = vi.fn();
     const human = agent({
       uuid: "human-1",
       name: "bestony",
@@ -293,7 +269,7 @@ describe("IdentitySection", () => {
       metadata: { tree: { role: "Maintainer", domains: ["agent-hub", "first_tree"] } },
     });
 
-    const { container, root } = await renderDom(<IdentitySection agent={human} onSave={onSave} />);
+    const { container, root } = await renderDom(<IdentitySection agent={human} onEdit={onEdit} />);
     await flush();
     expect(container.textContent).toContain("Manager User");
     expect(container.textContent).toContain("Helper");
@@ -303,71 +279,137 @@ describe("IdentitySection", () => {
     expect(container.textContent).toContain("First tree");
 
     await click(buttonByText(container, "Edit"));
-    const disabledName = document.body.querySelector<HTMLInputElement>("input.font-mono");
-    expect(disabledName?.value).toBe("@bestony");
-    expect(disabledName?.disabled).toBe(true);
-
-    const displayInput = document.body.querySelector<HTMLInputElement>("#id-display");
-    const visibilitySelect = document.body.querySelector<HTMLButtonElement>("#id-visibility");
-    const delegateSelect = document.body.querySelector<HTMLButtonElement>("#id-delegate");
-    if (!displayInput || !visibilitySelect || !delegateSelect) throw new Error("Expected identity fields");
-
-    await setInputValue(displayInput, " ");
-    await click(buttonByText(document.body, "Save"));
-    expect(document.body.textContent).toContain("Display name is required.");
-    expect(onSave).not.toHaveBeenCalled();
-
-    await setInputValue(displayInput, "Bestony Renamed");
-    await chooseSelectOption(visibilitySelect, "Visible to your team");
-    await chooseSelectOption(delegateSelect, "Second Helper");
-    await click(buttonByText(document.body, "Save"));
-    expect(onSave).toHaveBeenCalledWith({
-      displayName: "Bestony Renamed",
-      delegateMention: "delegate-2",
-      visibility: "organization",
-    });
-
-    await act(async () => root.unmount());
-  });
-
-  it("disables visibility for non-owners and surfaces save errors", async () => {
-    const { IdentitySection } = await import("../identity-section.js");
-    authMock.value = { memberId: "member-other", role: "member", agentId: "human-other" };
-    const onSave = vi.fn().mockRejectedValueOnce(new Error("Identity update failed"));
-    const { container, root } = await renderDom(
-      <IdentitySection
-        agent={agent({ managerId: "member-self", visibility: "private", metadata: { tree: { domains: [""] } } })}
-        onSave={onSave}
-      />,
-    );
-
-    await click(buttonByText(container, "Edit"));
-    const visibilitySelect = document.body.querySelector<HTMLButtonElement>("#id-visibility");
-    expect(visibilitySelect?.disabled).toBe(true);
-    expect(document.body.textContent).toContain("Only the owner or an admin can change this agent's visibility.");
-
-    const displayInput = document.body.querySelector<HTMLInputElement>("#id-display");
-    if (!displayInput) throw new Error("Expected display field");
-    await setInputValue(displayInput, "Kael Updated");
-    await click(buttonByText(document.body, "Save"));
-    expect(onSave).toHaveBeenCalledWith({
-      displayName: "Kael Updated",
-    });
-    expect(document.body.textContent).toContain("Identity update failed");
-
+    expect(onEdit).toHaveBeenCalledTimes(1);
     await act(async () => root.unmount());
   });
 
   it("omits edit controls for read-only or inactive agents", async () => {
     const { IdentitySection } = await import("../identity-section.js");
-    const onSave = vi.fn();
-    const readOnly = await renderDom(<IdentitySection agent={agent()} canEdit={false} onSave={onSave} />);
+    const readOnly = await renderDom(<IdentitySection agent={agent()} canEdit={false} onEdit={vi.fn()} />);
     expect(buttonByText(readOnly.container, "Edit")).toBeNull();
     await act(async () => readOnly.root.unmount());
 
-    const inactive = await renderDom(<IdentitySection agent={agent({ status: "deleted" })} onSave={onSave} />);
+    const inactive = await renderDom(<IdentitySection agent={agent({ status: "deleted" })} onEdit={vi.fn()} />);
     expect(buttonByText(inactive.container, "Edit")).toBeNull();
     await act(async () => inactive.root.unmount());
+  });
+});
+
+describe("ProfileEditDialog (merged identity + appearance)", () => {
+  it("saves identity + color in one call, uploads/removes image eagerly, and flashes saved", async () => {
+    const { ProfileEditDialog } = await import("../profile-edit-dialog.js");
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    const onRefresh = vi.fn().mockResolvedValue(undefined);
+    const onSaved = vi.fn();
+    const onOpenChange = vi.fn();
+
+    const { root } = await renderDom(
+      <ProfileEditDialog
+        agent={agent({ avatarColorToken: "hue-1", avatarImageUrl: "/avatars/agent-1.png" })}
+        open
+        onOpenChange={onOpenChange}
+        onSave={onSave}
+        onRefresh={onRefresh}
+        onSaved={onSaved}
+      />,
+    );
+    expect(document.body.textContent).toContain("Edit profile");
+
+    // Image is eager — applies on pick/remove, separate from the Save button.
+    const fileInput = document.body.querySelector<HTMLInputElement>('input[type="file"]');
+    if (!fileInput) throw new Error("Expected file input");
+    await setFileInput(fileInput, new File(["avatar"], "avatar.png", { type: "image/png" }));
+    expect(agentApiMocks.uploadAgentAvatar).toHaveBeenCalledWith("agent-1", expect.any(Blob));
+    expect(onRefresh).toHaveBeenCalled();
+    await click(buttonByText(document.body, "Remove image"));
+    expect(agentApiMocks.deleteAgentAvatar).toHaveBeenCalledWith("agent-1");
+
+    // Save commits identity fields + the fallback color in one PATCH.
+    await click(document.body.querySelector('button[title="hue-3"]'));
+    await click(buttonByText(document.body, "Save"));
+    expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ displayName: "Kael", avatarColorToken: "hue-3" }));
+    expect(onSaved).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+
+    await act(async () => root.unmount());
+  });
+
+  it("blocks save on empty name and keeps the dialog open on a save failure (partial failure)", async () => {
+    const { ProfileEditDialog } = await import("../profile-edit-dialog.js");
+    const onSave = vi.fn().mockRejectedValueOnce(new Error("Identity update failed"));
+    const onSaved = vi.fn();
+    const onOpenChange = vi.fn();
+
+    const { root } = await renderDom(
+      <ProfileEditDialog agent={agent()} open onOpenChange={onOpenChange} onSave={onSave} onSaved={onSaved} />,
+    );
+
+    const displayInput = document.body.querySelector<HTMLInputElement>("#profile-display");
+    if (!displayInput) throw new Error("Expected display field");
+    await setInputValue(displayInput, " ");
+    await click(buttonByText(document.body, "Save"));
+    expect(document.body.textContent).toContain("Display name is required.");
+    expect(onSave).not.toHaveBeenCalled();
+
+    await setInputValue(displayInput, "Kael Updated");
+    await click(buttonByText(document.body, "Save"));
+    expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ displayName: "Kael Updated" }));
+    // Save failed → dialog stays open (no close), error surfaced, no saved flash.
+    expect(document.body.textContent).toContain("Identity update failed");
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+    expect(onSaved).not.toHaveBeenCalled();
+
+    await act(async () => root.unmount());
+  });
+
+  it("edits human visibility + delegate, and disables visibility for non-owners", async () => {
+    const { ProfileEditDialog } = await import("../profile-edit-dialog.js");
+    const human = agent({
+      uuid: "human-1",
+      name: "bestony",
+      displayName: "Bestony",
+      type: "human",
+      visibility: "private",
+    });
+    const onSave = vi.fn().mockResolvedValue(undefined);
+
+    const owner = await renderDom(
+      <ProfileEditDialog agent={human} open onOpenChange={vi.fn()} onSave={onSave} onSaved={vi.fn()} />,
+    );
+    const disabledName = document.body.querySelector<HTMLInputElement>("input.font-mono");
+    expect(disabledName?.value).toBe("@bestony");
+    expect(disabledName?.disabled).toBe(true);
+    const displayInput = document.body.querySelector<HTMLInputElement>("#profile-display");
+    const visibilitySelect = document.body.querySelector<HTMLButtonElement>("#profile-visibility");
+    const delegateSelect = document.body.querySelector<HTMLButtonElement>("#profile-delegate");
+    if (!displayInput || !visibilitySelect || !delegateSelect) throw new Error("Expected fields");
+    await setInputValue(displayInput, "Bestony Renamed");
+    await chooseSelectOption(visibilitySelect, "Visible to your team");
+    await chooseSelectOption(delegateSelect, "Second Helper");
+    await click(buttonByText(document.body, "Save"));
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        displayName: "Bestony Renamed",
+        delegateMention: "delegate-2",
+        visibility: "organization",
+      }),
+    );
+    await act(async () => owner.root.unmount());
+
+    authMock.value = { memberId: "member-other", role: "member", agentId: "human-other" };
+    const nonOwner = await renderDom(
+      <ProfileEditDialog
+        agent={agent({ managerId: "member-self", visibility: "private" })}
+        open
+        onOpenChange={vi.fn()}
+        onSave={vi.fn()}
+        onSaved={vi.fn()}
+      />,
+    );
+    const lockedVisibility = document.body.querySelector<HTMLButtonElement>("#profile-visibility");
+    expect(lockedVisibility?.disabled).toBe(true);
+    expect(document.body.textContent).toContain("Only the owner or an admin can change this agent's visibility.");
+    await act(async () => nonOwner.root.unmount());
   });
 });
 

--- a/packages/web/src/pages/agent-detail/__tests__/resources-savebar-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/resources-savebar-dom.test.tsx
@@ -155,6 +155,7 @@ function context(overrides: Partial<AgentDetailContext> = {}): AgentDetailContex
     isHuman: false,
     canManageAgent: true,
     canEditConfig: true,
+    guardedNavigate: vi.fn(),
     draft: draft(overrides.draft),
     config: config(),
     configLoading: false,

--- a/packages/web/src/pages/agent-detail/__tests__/usage-tab.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/usage-tab.test.tsx
@@ -75,6 +75,7 @@ function createContext(overrides: Partial<AgentDetailContext> = {}): AgentDetail
     isHuman: baseAgent.type === "human",
     canManageAgent: true,
     canEditConfig: true,
+    guardedNavigate: vi.fn(),
     draft: {} as AgentDetailContext["draft"],
     config: undefined,
     configLoading: false,

--- a/packages/web/src/pages/agent-detail/__tests__/usage-tab.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/usage-tab.test.tsx
@@ -286,7 +286,8 @@ describe("UsageTab", () => {
     await click(
       [...container.querySelectorAll("button")].find((button) => button.textContent === "Launch planning") ?? null,
     );
-    expect(routerMocks.navigate).toHaveBeenCalledWith("/?chat=chat-1");
+    // Opening a chat from Usage goes through the leave guard, not raw navigate.
+    expect(contextMock.value?.guardedNavigate).toHaveBeenCalledWith("/?chat=chat-1");
 
     await act(async () => root.unmount());
   });

--- a/packages/web/src/pages/agent-detail/appearance-section.tsx
+++ b/packages/web/src/pages/agent-detail/appearance-section.tsx
@@ -1,41 +1,21 @@
-import { type Agent, AVATAR_COLOR_TOKENS, type AvatarColorToken, type UpdateAgent } from "@first-tree/shared";
+import type { Agent } from "@first-tree/shared";
 import { Pencil } from "lucide-react";
-import { type ChangeEvent, type FormEvent, useEffect, useRef, useState } from "react";
-import { deleteAgentAvatar, uploadAgentAvatar } from "../../api/agents.js";
 import { resolveAvatarHue } from "../../components/chat/chat-row-avatar.js";
 import { Button } from "../../components/ui/button.js";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "../../components/ui/dialog.js";
-import { Label } from "../../components/ui/label.js";
 import { Section } from "../../components/ui/section.js";
 
 /**
- * Appearance — manager-configurable avatar color + image.
- *
- * Color writes go through PATCH /agents/:uuid (`avatarColorToken`).
- * Image writes go through dedicated PUT/DELETE /agents/:uuid/avatar so the
- * raw bytes don't have to share a JSON envelope. The dialog applies image
- * mutations eagerly (no Save click needed) but defers the color change to
- * the Save button so the user can preview before committing.
+ * Appearance — display of the agent's avatar (image or fallback color/initial).
+ * Editing is handled by the unified ProfileEditDialog owned by the Profile tab,
+ * so this is display-only: the Edit button and the avatar both call `onEdit`.
  *
  * Render priority: image → color override + initial → hashed color + initial.
  */
-
-const AVATAR_TARGET_SIZE = 256;
-const ACCEPTED_INPUT_TYPES = "image/png,image/jpeg,image/webp";
-
 export type AppearanceSectionProps = {
   agent: Agent;
   canEdit?: boolean;
-  onSave: (patch: UpdateAgent) => Promise<void>;
-  /** Re-fetch the agent after a mutation that bypasses the standard PATCH. */
-  onRefresh?: () => Promise<void> | void;
+  /** Opens the unified Profile edit dialog; omit to hide the edit affordance. */
+  onEdit?: () => void;
   variant?: "section" | "inline";
 };
 
@@ -43,7 +23,7 @@ function initial(s: string): string {
   return s.trim()[0]?.toUpperCase() ?? "?";
 }
 
-function AvatarPreview({ agent, size }: { agent: Agent; size: number }) {
+export function AvatarPreview({ agent, size }: { agent: Agent; size: number }) {
   if (agent.avatarImageUrl) {
     return (
       <img
@@ -81,20 +61,13 @@ function AvatarPreview({ agent, size }: { agent: Agent; size: number }) {
   );
 }
 
-export function AppearanceSection({
-  agent,
-  canEdit = true,
-  onSave,
-  onRefresh,
-  variant = "section",
-}: AppearanceSectionProps) {
-  const [open, setOpen] = useState(false);
+export function AppearanceSection({ agent, canEdit = true, onEdit, variant = "section" }: AppearanceSectionProps) {
   const colorLabel =
     typeof agent.avatarColorToken === "string" && agent.avatarColorToken.length > 0 ? agent.avatarColorToken : "auto";
 
-  const canOpenEditor = canEdit && agent.status === "active";
+  const canOpenEditor = canEdit && !!onEdit && agent.status === "active";
   const action = canOpenEditor ? (
-    <Button size="xs" variant="outline" onClick={() => setOpen(true)}>
+    <Button size="xs" variant="outline" onClick={onEdit}>
       <Pencil className="h-3 w-3" /> Edit
     </Button>
   ) : null;
@@ -104,7 +77,7 @@ export function AppearanceSection({
       type="button"
       aria-label="Edit avatar"
       title="Edit avatar"
-      onClick={() => setOpen(true)}
+      onClick={onEdit}
       className="relative inline-flex shrink-0 cursor-pointer items-center justify-center border-0 bg-transparent p-0"
       style={{ width: 56, height: 56, borderRadius: "50%" }}
     >
@@ -131,33 +104,28 @@ export function AppearanceSection({
   );
 
   const content = (
-    <>
-      <div
-        className="flex min-w-0 items-center gap-3"
-        style={{
-          padding: "var(--sp-3) 0",
-          borderBottom: variant === "inline" ? undefined : "var(--hairline) solid var(--border-faint)",
-        }}
-      >
-        {avatar}
-        <div className="min-w-0">
-          <div className="text-body font-medium" style={{ color: "var(--fg)" }}>
-            {agent.avatarImageUrl ? "Custom image" : "Generated avatar"}
-          </div>
-          <div className="text-caption" style={{ color: "var(--fg-4)", marginTop: "var(--sp-0_5)" }}>
-            {agent.avatarImageUrl ? "Image uploaded" : "No custom image uploaded"} · Color {colorLabel}
-          </div>
-          {variant === "section" && (
-            <div className="text-caption" style={{ color: "var(--fg-4)", marginTop: "var(--sp-1)" }}>
-              Updates appear immediately in chats, lists, and mentions.
-            </div>
-          )}
+    <div
+      className="flex min-w-0 items-center gap-3"
+      style={{
+        padding: "var(--sp-3) 0",
+        borderBottom: variant === "inline" ? undefined : "var(--hairline) solid var(--border-faint)",
+      }}
+    >
+      {avatar}
+      <div className="min-w-0">
+        <div className="text-body font-medium" style={{ color: "var(--fg)" }}>
+          {agent.avatarImageUrl ? "Custom image" : "Generated avatar"}
         </div>
+        <div className="text-caption" style={{ color: "var(--fg-4)", marginTop: "var(--sp-0_5)" }}>
+          {agent.avatarImageUrl ? "Image uploaded" : "No custom image uploaded"} · Color {colorLabel}
+        </div>
+        {variant === "section" && (
+          <div className="text-caption" style={{ color: "var(--fg-4)", marginTop: "var(--sp-1)" }}>
+            Updates appear immediately in chats, lists, and mentions.
+          </div>
+        )}
       </div>
-      {canEdit && (
-        <AppearanceEditDialog agent={agent} open={open} onOpenChange={setOpen} onSave={onSave} onRefresh={onRefresh} />
-      )}
-    </>
+    </div>
   );
 
   if (variant === "inline") {
@@ -172,257 +140,5 @@ export function AppearanceSection({
     >
       {content}
     </Section>
-  );
-}
-
-type DialogProps = {
-  agent: Agent;
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  onSave: (patch: UpdateAgent) => Promise<void>;
-  onRefresh?: () => Promise<void> | void;
-};
-
-/**
- * Resize an uploaded image to a square `AVATAR_TARGET_SIZE`×`AVATAR_TARGET_SIZE`
- * WEBP via an offscreen canvas. We center-crop to a square first so portrait
- * / landscape sources land sensibly. Returns the resulting `Blob` ready for
- * upload. Throws when the source can't be decoded.
- */
-async function resizeToSquareWebp(file: File): Promise<Blob> {
-  const url = URL.createObjectURL(file);
-  try {
-    const img = await new Promise<HTMLImageElement>((resolve, reject) => {
-      const el = new Image();
-      el.onload = () => resolve(el);
-      el.onerror = () => reject(new Error("Unable to decode the selected image."));
-      el.src = url;
-    });
-    const side = Math.min(img.naturalWidth, img.naturalHeight);
-    const sx = Math.max(0, Math.round((img.naturalWidth - side) / 2));
-    const sy = Math.max(0, Math.round((img.naturalHeight - side) / 2));
-
-    const canvas = document.createElement("canvas");
-    canvas.width = AVATAR_TARGET_SIZE;
-    canvas.height = AVATAR_TARGET_SIZE;
-    const ctx = canvas.getContext("2d");
-    if (!ctx) throw new Error("Canvas 2D context is unavailable in this browser.");
-    ctx.drawImage(img, sx, sy, side, side, 0, 0, AVATAR_TARGET_SIZE, AVATAR_TARGET_SIZE);
-
-    const blob: Blob | null = await new Promise((resolve) => canvas.toBlob((b) => resolve(b), "image/webp", 0.85));
-    if (!blob) throw new Error("Failed to encode resized image to WEBP.");
-    return blob;
-  } finally {
-    URL.revokeObjectURL(url);
-  }
-}
-
-function AppearanceEditDialog({ agent, open, onOpenChange, onSave, onRefresh }: DialogProps) {
-  const initialColor: AvatarColorToken | null = AVATAR_COLOR_TOKENS.find((t) => t === agent.avatarColorToken) ?? null;
-  const [picked, setPicked] = useState<AvatarColorToken | null>(initialColor);
-  const [saving, setSaving] = useState(false);
-  const [uploading, setUploading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const fileInputRef = useRef<HTMLInputElement | null>(null);
-
-  useEffect(() => {
-    if (open) {
-      setPicked(initialColor);
-      setError(null);
-    }
-  }, [open, initialColor]);
-
-  async function submit(e: FormEvent) {
-    e.preventDefault();
-    setError(null);
-    setSaving(true);
-    try {
-      await onSave({ avatarColorToken: picked });
-      onOpenChange(false);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
-    } finally {
-      setSaving(false);
-    }
-  }
-
-  async function onFileChange(e: ChangeEvent<HTMLInputElement>) {
-    const file = e.target.files?.[0];
-    // Reset the input so picking the same file twice still fires `change`.
-    if (fileInputRef.current) fileInputRef.current.value = "";
-    if (!file) return;
-    setError(null);
-    setUploading(true);
-    try {
-      const blob = await resizeToSquareWebp(file);
-      await uploadAgentAvatar(agent.uuid, blob);
-      await onRefresh?.();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
-    } finally {
-      setUploading(false);
-    }
-  }
-
-  async function onRemoveImage() {
-    setError(null);
-    setUploading(true);
-    try {
-      await deleteAgentAvatar(agent.uuid);
-      await onRefresh?.();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
-    } finally {
-      setUploading(false);
-    }
-  }
-
-  const previewAgent: Agent = { ...agent, avatarColorToken: picked };
-  const hasImage = !!agent.avatarImageUrl;
-
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Edit Appearance</DialogTitle>
-          <DialogDescription>
-            Update the avatar image and fallback color used in chats, lists, and mentions.
-          </DialogDescription>
-        </DialogHeader>
-        <form onSubmit={submit} className="space-y-5">
-          <div className="space-y-2">
-            <Label>Preview</Label>
-            <div className="flex items-center gap-3">
-              <AvatarPreview agent={previewAgent} size={64} />
-              <AvatarPreview agent={previewAgent} size={32} />
-              <span className="text-caption text-muted-foreground">Large and compact surfaces</span>
-            </div>
-          </div>
-
-          <div className="space-y-2">
-            <Label>Image</Label>
-            <div className="flex flex-wrap items-center gap-2">
-              <input
-                ref={fileInputRef}
-                type="file"
-                accept={ACCEPTED_INPUT_TYPES}
-                onChange={onFileChange}
-                style={{ display: "none" }}
-              />
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={() => fileInputRef.current?.click()}
-                disabled={uploading || saving}
-              >
-                {uploading ? "Uploading…" : hasImage ? "Replace image" : "Upload image"}
-              </Button>
-              {hasImage && (
-                <Button type="button" variant="ghost" size="sm" onClick={onRemoveImage} disabled={uploading || saving}>
-                  Remove image
-                </Button>
-              )}
-            </div>
-            <p className="text-caption text-muted-foreground">
-              PNG / JPEG / WEBP. Square images work best. An image takes precedence over the color below.
-            </p>
-          </div>
-
-          <div className="space-y-2">
-            <Label>Color</Label>
-            <div className="flex flex-wrap gap-2">
-              <Swatch
-                label="Auto"
-                selected={picked === null}
-                onClick={() => setPicked(null)}
-                background={resolveAvatarHue(null, agent.uuid)}
-                isAuto
-              />
-              {AVATAR_COLOR_TOKENS.map((token) => (
-                <Swatch
-                  key={token}
-                  label={token}
-                  selected={picked === token}
-                  onClick={() => setPicked(token)}
-                  background={`var(--avatar-${token})`}
-                />
-              ))}
-            </div>
-            <p className="text-caption text-muted-foreground">
-              Auto chooses a stable color for this agent. The color is used only when no image is set.
-            </p>
-          </div>
-
-          {error && <p className="text-body text-destructive">{error}</p>}
-          <DialogFooter>
-            <Button type="button" variant="ghost" onClick={() => onOpenChange(false)} disabled={saving || uploading}>
-              Cancel
-            </Button>
-            <Button type="submit" disabled={saving || uploading}>
-              {saving ? "Saving…" : "Save"}
-            </Button>
-          </DialogFooter>
-        </form>
-      </DialogContent>
-    </Dialog>
-  );
-}
-
-function Swatch({
-  label,
-  selected,
-  onClick,
-  background,
-  isAuto,
-}: {
-  label: string;
-  selected: boolean;
-  onClick: () => void;
-  background: string;
-  isAuto?: boolean;
-}) {
-  const size = 32;
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      aria-pressed={selected}
-      title={label}
-      style={{
-        position: "relative",
-        width: size,
-        height: size,
-        borderRadius: "50%",
-        background,
-        border: selected ? "var(--hairline-bold) solid var(--fg)" : "var(--hairline) solid var(--border)",
-        cursor: "pointer",
-        padding: 0,
-        outline: "none",
-        display: "inline-flex",
-        alignItems: "center",
-        justifyContent: "center",
-      }}
-    >
-      {isAuto && (
-        <span
-          aria-hidden
-          style={{
-            position: "absolute",
-            inset: 4,
-            borderRadius: "50%",
-            background: "var(--bg-raised)",
-            color: "var(--fg-3)",
-            fontSize: 10,
-            fontWeight: 600,
-            display: "inline-flex",
-            alignItems: "center",
-            justifyContent: "center",
-          }}
-        >
-          A
-        </span>
-      )}
-    </button>
   );
 }

--- a/packages/web/src/pages/agent-detail/capability-section.tsx
+++ b/packages/web/src/pages/agent-detail/capability-section.tsx
@@ -23,6 +23,7 @@ import { Section } from "../../components/ui/section.js";
 import { StatusGlyph } from "../../components/ui/status-glyph.js";
 import { typeLabelSingular } from "../settings/resource-editors.js";
 import { sourceLabel } from "./resource-source.js";
+import { titleWithSemantics, useJustSaved } from "./save-semantics.js";
 
 /**
  * Shared agent-resource (repo / skill / mcp) section, used by two tabs:
@@ -43,6 +44,8 @@ export type AgentResourcesController = {
   mutateBindings: (bindings: AgentResourceBindingInput[]) => void;
   pending: boolean;
   saveError: unknown;
+  /** True for ~2.5s after a successful immediate save (drives the "Saved" tag). */
+  justSaved: boolean;
 };
 
 /**
@@ -79,6 +82,7 @@ export function agentResourcesMutationHandlers(
 
 export function useAgentResources(uuid: string, opts: { enabled: boolean }): AgentResourcesController {
   const queryClient = useQueryClient();
+  const { justSaved, markSaved } = useJustSaved();
   const resourcesQuery = useQuery({
     queryKey: ["agent-resources", uuid],
     queryFn: () => getAgentResources(uuid),
@@ -89,7 +93,7 @@ export function useAgentResources(uuid: string, opts: { enabled: boolean }): Age
       if (!resourcesQuery.data) throw new Error("resources not loaded");
       return updateAgentResources(uuid, { expectedVersion: resourcesQuery.data.version, bindings });
     },
-    ...agentResourcesMutationHandlers(queryClient, uuid),
+    ...agentResourcesMutationHandlers(queryClient, uuid, { onSuccessAfter: markSaved }),
   });
   return {
     data: resourcesQuery.data,
@@ -98,6 +102,7 @@ export function useAgentResources(uuid: string, opts: { enabled: boolean }): Age
     mutateBindings: updateMut.mutate,
     pending: updateMut.isPending,
     saveError: updateMut.error,
+    justSaved,
   };
 }
 
@@ -112,9 +117,13 @@ export function ResourceTypeSection(props: {
   canEdit: boolean;
   pending: boolean;
   onMutate: (bindings: AgentResourceBindingInput[]) => void;
+  /** Flash a "Saved" tag after a successful immediate write (from useAgentResources). */
+  saved?: boolean;
+  /** Leave-guarded navigate for the "Manage in Settings" exit (omit in previews). */
+  onNavigateAway?: (to: string) => void;
 }) {
   const [repoOpen, setRepoOpen] = useState(false);
-  const { type, data, canEdit, pending, onMutate } = props;
+  const { type, data, canEdit, pending, onMutate, saved, onNavigateAway } = props;
   const currentBindings = data.bindings;
   const activeBindingIds = new Set(currentBindings.map((b) => b.resourceId).filter((id): id is string => !!id));
   // Opt-in team resources an agent can enable for itself. Repos are excluded:
@@ -130,7 +139,7 @@ export function ResourceTypeSection(props: {
   const rows = data.effective[resourceBucket(type)];
   return (
     <Section
-      title={typeLabel(type)}
+      title={titleWithSemantics(typeLabel(type), "immediate", saved)}
       count={rows.length}
       description={type === "mcp" ? "From the MCP servers you connect." : undefined}
       action={
@@ -139,6 +148,7 @@ export function ResourceTypeSection(props: {
             type={type}
             enableable={enableable}
             pending={pending}
+            onNavigateAway={onNavigateAway}
             onAddAgentRepo={() => setRepoOpen(true)}
             onEnable={(resource) =>
               onMutate([
@@ -210,8 +220,11 @@ function AddCapabilityMenu(props: {
   pending: boolean;
   onAddAgentRepo: () => void;
   onEnable: (resource: ResourceRow) => void;
+  /** Leave-guarded navigate for "Manage in Settings"; falls back to plain navigate. */
+  onNavigateAway?: (to: string) => void;
 }) {
   const navigate = useNavigate();
+  const goToSettings = () => (props.onNavigateAway ?? navigate)("/settings/resources");
   return (
     <Popover
       align="end"
@@ -259,7 +272,7 @@ function AddCapabilityMenu(props: {
           <MenuButton
             muted
             onClick={() => {
-              navigate("/settings/resources");
+              goToSettings();
               close();
             }}
           >

--- a/packages/web/src/pages/agent-detail/env-section.tsx
+++ b/packages/web/src/pages/agent-detail/env-section.tsx
@@ -15,6 +15,7 @@ import { Label } from "../../components/ui/label.js";
 import { Section } from "../../components/ui/section.js";
 import { ListRow } from "./list-row.js";
 import { ResourceEmptyState } from "./resource-empty-state.js";
+import { titleWithSemantics } from "./save-semantics.js";
 import type { DraftListItem } from "./use-config-draft.js";
 
 /**
@@ -57,7 +58,7 @@ export function EnvSection(props: EnvSectionProps) {
 
   return (
     <Section
-      title="Environment variables"
+      title={titleWithSemantics("Environment variables", "draft")}
       count={activeCount}
       description="Injected into this agent's runtime process. Sensitive values are encrypted and hidden after save."
       action={action}

--- a/packages/web/src/pages/agent-detail/identity-section.tsx
+++ b/packages/web/src/pages/agent-detail/identity-section.tsx
@@ -1,50 +1,34 @@
-import { AGENT_VISIBILITY, type Agent, type UpdateAgent } from "@first-tree/shared";
-import { useQuery } from "@tanstack/react-query";
+import { AGENT_VISIBILITY, type Agent } from "@first-tree/shared";
 import { Pencil } from "lucide-react";
-import { type FormEvent, type ReactNode, useEffect, useMemo, useState } from "react";
-import { listAgents } from "../../api/agents.js";
-import { useAuth } from "../../auth/auth-context.js";
+import type { ReactNode } from "react";
 import { AgentChip } from "../../components/agent-chip.js";
 import { Avatar } from "../../components/avatar.js";
 import { Button } from "../../components/ui/button.js";
 import { DenseBadge } from "../../components/ui/dense-badge.js";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "../../components/ui/dialog.js";
-import { Input } from "../../components/ui/input.js";
-import { Label } from "../../components/ui/label.js";
 import { Section } from "../../components/ui/section.js";
-import { Select, type SelectOption } from "../../components/ui/select.js";
 import { useAgentIdentityMap } from "../../lib/use-agent-name-map.js";
 import { useMemberNameMap } from "../../lib/use-member-name-map.js";
+import { titleWithSemantics } from "./save-semantics.js";
 
 const VISIBILITY_COPY = {
-  [AGENT_VISIBILITY.ORGANIZATION]: {
-    label: "Visible to your team",
-    description: "Anyone on your team can @mention and chat with it.",
-  },
-  [AGENT_VISIBILITY.PRIVATE]: {
-    label: "Private to you",
-    description: "Only this agent's owner can see and chat with it.",
-  },
+  [AGENT_VISIBILITY.ORGANIZATION]: { label: "Visible to your team" },
+  [AGENT_VISIBILITY.PRIVATE]: { label: "Private to you" },
 } as const;
 
 /**
- * Redesign §5.3 Identity — a compact two-line summary plus a dedicated
- * Edit dialog whose Save goes **straight to the identity API**, bypassing the
- * page-level Save Bar (PRD §6 "config and identity are separate APIs").
+ * Identity — a compact field summary. Editing is handled by the unified
+ * ProfileEditDialog owned by the Profile tab (identity + appearance in one
+ * Edit), so this component is display-only and surfaces a single Edit entry
+ * via `onEdit`.
  */
-
 export type IdentitySectionProps = {
   agent: Agent;
   canEdit?: boolean;
-  onSave: (patch: UpdateAgent) => Promise<void>;
-  title?: ReactNode;
+  /** Opens the unified Profile edit dialog; omit to hide the Edit affordance. */
+  onEdit?: () => void;
+  /** Flash a "Saved" tag after a successful immediate save. */
+  saved?: boolean;
+  title?: string;
   description?: ReactNode;
   aside?: ReactNode;
 };
@@ -52,12 +36,12 @@ export type IdentitySectionProps = {
 export function IdentitySection({
   agent,
   canEdit = true,
-  onSave,
+  onEdit,
+  saved = false,
   title = "Identity",
   description = "Identity saves immediately; runtime behavior is configured from the other tabs.",
   aside,
 }: IdentitySectionProps) {
-  const [open, setOpen] = useState(false);
   const resolveAgent = useAgentIdentityMap();
   const resolveMember = useMemberNameMap();
 
@@ -73,14 +57,14 @@ export function IdentitySection({
   const hasOrganizationContext = role || domains.length > 0;
 
   const action =
-    canEdit && agent.status === "active" ? (
-      <Button size="xs" variant="outline" onClick={() => setOpen(true)}>
-        <Pencil className="h-3 w-3" /> {aside ? "Edit identity" : "Edit"}
+    canEdit && onEdit && agent.status === "active" ? (
+      <Button size="xs" variant="outline" onClick={onEdit}>
+        <Pencil className="h-3 w-3" /> Edit
       </Button>
     ) : null;
 
   return (
-    <Section title={title} description={description} action={action}>
+    <Section title={titleWithSemantics(title, "immediate", saved)} description={description} action={action}>
       <div
         className={aside ? "grid gap-4 lg:grid-cols-[minmax(0,1.5fr)_minmax(18rem,0.85fr)] lg:gap-8" : undefined}
         style={{ padding: "var(--sp-3) 0", borderBottom: "var(--hairline) solid var(--border-faint)" }}
@@ -125,208 +109,14 @@ export function IdentitySection({
           </div>
         )}
       </div>
-      {canEdit && <IdentityEditDialog agent={agent} open={open} onOpenChange={setOpen} onSave={onSave} />}
     </Section>
   );
 }
 
-type IdentityDialogProps = {
-  agent: Agent;
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  onSave: (patch: UpdateAgent) => Promise<void>;
-};
-
-function IdentityEditDialog({ agent, open, onOpenChange, onSave }: IdentityDialogProps) {
-  const { memberId, role, agentId } = useAuth();
-  const resolveAgent = useAgentIdentityMap();
-  const [displayName, setDisplayName] = useState(agent.displayName);
-  const [delegateMention, setDelegateMention] = useState(agent.delegateMention ?? "");
-  const [visibility, setVisibility] = useState(agent.visibility);
-  const [saving, setSaving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (open) {
-      setDisplayName(agent.displayName);
-      setDelegateMention(agent.delegateMention ?? "");
-      setVisibility(agent.visibility);
-      setError(null);
-    }
-  }, [open, agent]);
-
-  const isHuman = agent.type === "human";
-  // Only the agent's owner (stored as managerId) or an admin can change visibility. The backend
-  // enforces this via assertCanManage; this mirrors that on the UI so the
-  // field is disabled when the caller can't persist the change anyway.
-  const canChangeVisibility = role === "admin" || agent.managerId === memberId;
-  // A delegate is a personal choice — only the member themselves may set it,
-  // NOT an admin acting on their behalf. The backend enforces this (403);
-  // mirror it here so the control is disabled when the caller can't persist.
-  // Use the SAME truth source the server uses (scope.humanAgentId === target
-  // uuid): useAuth().agentId is the caller's own human-agent uuid. A
-  // managerId-based check could drift from this if the manager is reassigned.
-  const canEditDelegate = isHuman && agent.uuid === agentId;
-  // For non-owners the selector is read-only, so resolve the assigned delegate
-  // to show the truth as text instead of a disabled <select>.
-  const delegateIdentity = agent.delegateMention ? resolveAgent(agent.delegateMention) : null;
-  const assistantsQuery = useQuery({
-    queryKey: ["agents-for-delegate", memberId],
-    queryFn: async () => {
-      const res = await listAgents({ limit: 100 });
-      // Candidates mirror the Team page selector: the member's own team-visible
-      // (organization), active agents. Private agents are excluded because a
-      // delegate acts on the member's behalf in team chats and must be
-      // team-mentionable.
-      return res.items.filter(
-        (a) =>
-          a.type === "agent" && a.visibility === "organization" && a.status === "active" && a.managerId === memberId,
-      );
-    },
-    enabled: open && canEditDelegate,
-  });
-  const delegateOptions: SelectOption[] = useMemo(
-    () => [
-      { value: "", label: "Remove delegate" },
-      ...(assistantsQuery.data?.map((a) => ({
-        value: a.uuid,
-        label: a.displayName ? `${a.displayName} (@${a.name ?? a.uuid})` : a.name ? `@${a.name}` : a.uuid,
-      })) ?? []),
-    ],
-    [assistantsQuery.data],
-  );
-  const visibilityHelp = VISIBILITY_COPY[visibility].description;
-
-  async function submit(e: FormEvent) {
-    e.preventDefault();
-    setError(null);
-    // Display name is required after Phase 2 — reject empty locally so the
-    // server 400 doesn't bubble up as a mystery "validation failed".
-    const trimmed = displayName.trim();
-    if (!trimmed) {
-      setError("Display name is required.");
-      return;
-    }
-    setSaving(true);
-    try {
-      const patch: UpdateAgent = {
-        displayName: trimmed,
-      };
-      // Only send delegateMention when the caller owns this agent. Otherwise an
-      // admin editing someone else's display name would carry the field and trip
-      // the server-side self-only guard (403).
-      if (canEditDelegate) {
-        patch.delegateMention = delegateMention || null;
-      }
-      if (visibility !== agent.visibility) {
-        patch.visibility = visibility;
-      }
-      await onSave(patch);
-      onOpenChange(false);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
-    } finally {
-      setSaving(false);
-    }
-  }
-
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Edit Identity</DialogTitle>
-          <DialogDescription>
-            Identity updates save immediately. Runtime behavior is configured from the other tabs.
-          </DialogDescription>
-        </DialogHeader>
-        <form onSubmit={submit} className="space-y-4">
-          <div className="space-y-2">
-            <Label>Agent name</Label>
-            <Input value={agent.name ? `@${agent.name}` : ""} disabled className="font-mono" />
-            <p className="text-caption text-muted-foreground">
-              Agent name is permanent after creation — used in @mentions and CLI commands.
-            </p>
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="id-display">Display name</Label>
-            <Input
-              id="id-display"
-              value={displayName}
-              onChange={(e) => setDisplayName(e.target.value)}
-              placeholder="How teammates see this agent"
-              maxLength={200}
-            />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="id-visibility">Visibility</Label>
-            <Select
-              id="id-visibility"
-              aria-label="Visibility"
-              value={visibility}
-              onChange={(v) => setVisibility(v as typeof visibility)}
-              disabled={!canChangeVisibility}
-              options={[
-                { value: AGENT_VISIBILITY.ORGANIZATION, label: VISIBILITY_COPY[AGENT_VISIBILITY.ORGANIZATION].label },
-                { value: AGENT_VISIBILITY.PRIVATE, label: VISIBILITY_COPY[AGENT_VISIBILITY.PRIVATE].label },
-              ]}
-            />
-            <p className="text-caption text-muted-foreground">
-              {canChangeVisibility ? visibilityHelp : "Only the owner or an admin can change this agent's visibility."}
-            </p>
-          </div>
-          {isHuman && (
-            <div className="space-y-2">
-              <Label htmlFor="id-delegate">Delegate Mention</Label>
-              {canEditDelegate ? (
-                <Select
-                  id="id-delegate"
-                  aria-label="Delegate Mention"
-                  value={delegateMention}
-                  onChange={setDelegateMention}
-                  options={delegateOptions}
-                  searchable
-                />
-              ) : (
-                // Read-only for non-owners: show the assigned delegate as text.
-                // A disabled <select> would have no matching option (the query
-                // is gated to owners) and misrender the value as "Remove delegate".
-                <div className="flex h-9 w-full items-center rounded-[var(--radius-input)] border border-input bg-transparent px-3 text-body opacity-70">
-                  {delegateIdentity ? (
-                    <AgentChip name={delegateIdentity.name} displayName={delegateIdentity.displayName} />
-                  ) : (
-                    <span className="text-muted-foreground">No delegate</span>
-                  )}
-                </div>
-              )}
-              <p className="text-caption text-muted-foreground">
-                {canEditDelegate
-                  ? "Assistant that acts on behalf of this agent."
-                  : "Only the member themselves can set their own delegate."}
-              </p>
-            </div>
-          )}
-          {error && <p className="text-body text-destructive">{error}</p>}
-          <DialogFooter>
-            <Button type="button" variant="ghost" onClick={() => onOpenChange(false)} disabled={saving}>
-              Cancel
-            </Button>
-            <Button type="submit" disabled={saving}>
-              {saving ? "Saving…" : "Save"}
-            </Button>
-          </DialogFooter>
-        </form>
-      </DialogContent>
-    </Dialog>
-  );
-}
-
 /**
- * Domain tags come from `metadata.tree.domains` and mirror the Context
- * Tree's top-level directory names (`kael`, `agent-hub`, `first-tree-skill-cli`,
- * …). They're free-form strings, not a closed enum, so we lean on a
- * lightweight transform instead of a hard-coded map: kebab/snake → spaces,
- * then capitalize the first letter so the chip reads as sentence-case
- * ("Agent hub", "First tree skill cli") rather than as a code token.
+ * Domain tags come from `metadata.tree.domains` and mirror the Context Tree's
+ * top-level directory names. They're free-form strings, not a closed enum, so
+ * we lean on a lightweight transform: kebab/snake → spaces, then capitalize.
  */
 function humanizeDomain(domain: string): string {
   if (!domain) return domain;

--- a/packages/web/src/pages/agent-detail/layout-context.ts
+++ b/packages/web/src/pages/agent-detail/layout-context.ts
@@ -18,6 +18,12 @@ export type AgentDetailContext = {
   canManageAgent: boolean;
   canEditConfig: boolean;
 
+  // Navigate away from this agent's detail page with the unsaved-draft leave
+  // guard applied (confirm + discard if the config draft is dirty). Use this for
+  // any control that LEAVES the current agent — notably PR3's agent switcher.
+  // Same-agent tab navigation should use plain navigate(): the draft persists.
+  guardedNavigate: (to: string) => void;
+
   // Config + draft (shared across Runtime / Prompt / Resources)
   draft: UseConfigDraftResult;
   config: AgentRuntimeConfig | undefined;

--- a/packages/web/src/pages/agent-detail/profile-edit-dialog.tsx
+++ b/packages/web/src/pages/agent-detail/profile-edit-dialog.tsx
@@ -1,0 +1,419 @@
+import {
+  AGENT_VISIBILITY,
+  type Agent,
+  AVATAR_COLOR_TOKENS,
+  type AvatarColorToken,
+  type UpdateAgent,
+} from "@first-tree/shared";
+import { useQuery } from "@tanstack/react-query";
+import { type ChangeEvent, type FormEvent, useEffect, useMemo, useRef, useState } from "react";
+import { deleteAgentAvatar, listAgents, uploadAgentAvatar } from "../../api/agents.js";
+import { useAuth } from "../../auth/auth-context.js";
+import { AgentChip } from "../../components/agent-chip.js";
+import { resolveAvatarHue } from "../../components/chat/chat-row-avatar.js";
+import { Button } from "../../components/ui/button.js";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "../../components/ui/dialog.js";
+import { Input } from "../../components/ui/input.js";
+import { Label } from "../../components/ui/label.js";
+import { Select, type SelectOption } from "../../components/ui/select.js";
+import { useAgentIdentityMap } from "../../lib/use-agent-name-map.js";
+import { AvatarPreview } from "./appearance-section.js";
+
+/**
+ * PR2 §Profile: one "Edit profile" dialog merging the former Identity and
+ * Appearance dialogs. Two independent save paths, each with its own error so a
+ * partial failure never silently swallows one half:
+ *   - Identity + fallback color → one PATCH /agents/:uuid on the Save button
+ *     (`onSave`). Closes the dialog + flashes "Saved" only when this succeeds.
+ *   - Avatar image → eager PUT/DELETE /agents/:uuid/avatar on pick/remove
+ *     (raw bytes don't share the JSON envelope); never closes the dialog.
+ */
+
+const AVATAR_TARGET_SIZE = 256;
+const ACCEPTED_INPUT_TYPES = "image/png,image/jpeg,image/webp";
+
+const VISIBILITY_LABELS = {
+  [AGENT_VISIBILITY.ORGANIZATION]: "Visible to your team",
+  [AGENT_VISIBILITY.PRIVATE]: "Private to you",
+} as const;
+
+async function resizeToSquareWebp(file: File): Promise<Blob> {
+  const url = URL.createObjectURL(file);
+  try {
+    const img = await new Promise<HTMLImageElement>((resolve, reject) => {
+      const el = new Image();
+      el.onload = () => resolve(el);
+      el.onerror = () => reject(new Error("Unable to decode the selected image."));
+      el.src = url;
+    });
+    const side = Math.min(img.naturalWidth, img.naturalHeight);
+    const sx = Math.max(0, Math.round((img.naturalWidth - side) / 2));
+    const sy = Math.max(0, Math.round((img.naturalHeight - side) / 2));
+    const canvas = document.createElement("canvas");
+    canvas.width = AVATAR_TARGET_SIZE;
+    canvas.height = AVATAR_TARGET_SIZE;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) throw new Error("Canvas 2D context is unavailable in this browser.");
+    ctx.drawImage(img, sx, sy, side, side, 0, 0, AVATAR_TARGET_SIZE, AVATAR_TARGET_SIZE);
+    const blob: Blob | null = await new Promise((resolve) => canvas.toBlob((b) => resolve(b), "image/webp", 0.85));
+    if (!blob) throw new Error("Failed to encode resized image to WEBP.");
+    return blob;
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}
+
+export type ProfileEditDialogProps = {
+  agent: Agent;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSave: (patch: UpdateAgent) => Promise<void>;
+  /** Re-fetch the agent after an eager image mutation that bypasses PATCH. */
+  onRefresh?: () => Promise<void> | void;
+  /** Called after a successful identity+color save (drives the section "Saved" tag). */
+  onSaved?: () => void;
+};
+
+export function ProfileEditDialog({ agent, open, onOpenChange, onSave, onRefresh, onSaved }: ProfileEditDialogProps) {
+  const { memberId, role, agentId } = useAuth();
+  const resolveAgent = useAgentIdentityMap();
+
+  const initialColor: AvatarColorToken | null = AVATAR_COLOR_TOKENS.find((t) => t === agent.avatarColorToken) ?? null;
+  const [displayName, setDisplayName] = useState(agent.displayName);
+  const [delegateMention, setDelegateMention] = useState(agent.delegateMention ?? "");
+  const [visibility, setVisibility] = useState(agent.visibility);
+  const [picked, setPicked] = useState<AvatarColorToken | null>(initialColor);
+  const [saving, setSaving] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [imageError, setImageError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const initializedFor = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      initializedFor.current = null;
+      return;
+    }
+    // Snapshot the form ONCE per (open, agent), not on every agent change. The
+    // eager avatar upload/remove calls onRefresh, which swaps the agent prop
+    // while the dialog is open — re-snapshotting here would silently wipe the
+    // user's unsaved identity/color edits. The ref guards same-agent refreshes;
+    // we still re-init on a fresh open or a switch to a different agent.
+    if (initializedFor.current === agent.uuid) return;
+    initializedFor.current = agent.uuid;
+    setDisplayName(agent.displayName);
+    setDelegateMention(agent.delegateMention ?? "");
+    setVisibility(agent.visibility);
+    setPicked(AVATAR_COLOR_TOKENS.find((t) => t === agent.avatarColorToken) ?? null);
+    setFormError(null);
+    setImageError(null);
+  }, [open, agent]);
+
+  const isHuman = agent.type === "human";
+  const canChangeVisibility = role === "admin" || agent.managerId === memberId;
+  const canEditDelegate = isHuman && agent.uuid === agentId;
+  const delegateIdentity = agent.delegateMention ? resolveAgent(agent.delegateMention) : null;
+
+  const assistantsQuery = useQuery({
+    queryKey: ["agents-for-delegate", memberId],
+    queryFn: async () => {
+      const res = await listAgents({ limit: 100 });
+      return res.items.filter(
+        (a) =>
+          a.type === "agent" && a.visibility === "organization" && a.status === "active" && a.managerId === memberId,
+      );
+    },
+    enabled: open && canEditDelegate,
+  });
+  const delegateOptions: SelectOption[] = useMemo(
+    () => [
+      { value: "", label: "Remove delegate" },
+      ...(assistantsQuery.data?.map((a) => ({
+        value: a.uuid,
+        label: a.displayName ? `${a.displayName} (@${a.name ?? a.uuid})` : a.name ? `@${a.name}` : a.uuid,
+      })) ?? []),
+    ],
+    [assistantsQuery.data],
+  );
+
+  async function submit(e: FormEvent) {
+    e.preventDefault();
+    setFormError(null);
+    const trimmed = displayName.trim();
+    if (!trimmed) {
+      setFormError("Display name is required.");
+      return;
+    }
+    setSaving(true);
+    try {
+      // Identity fields and the fallback color are all PATCH /agents/:uuid, so
+      // they go in one atomic call. Image is handled eagerly below, separately.
+      const patch: UpdateAgent = { displayName: trimmed, avatarColorToken: picked };
+      if (canEditDelegate) patch.delegateMention = delegateMention || null;
+      if (visibility !== agent.visibility) patch.visibility = visibility;
+      await onSave(patch);
+      onSaved?.();
+      onOpenChange(false);
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function onFileChange(e: ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (fileInputRef.current) fileInputRef.current.value = "";
+    if (!file) return;
+    setImageError(null);
+    setUploading(true);
+    try {
+      const blob = await resizeToSquareWebp(file);
+      await uploadAgentAvatar(agent.uuid, blob);
+      await onRefresh?.();
+    } catch (err) {
+      setImageError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setUploading(false);
+    }
+  }
+
+  async function onRemoveImage() {
+    setImageError(null);
+    setUploading(true);
+    try {
+      await deleteAgentAvatar(agent.uuid);
+      await onRefresh?.();
+    } catch (err) {
+      setImageError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setUploading(false);
+    }
+  }
+
+  const previewAgent: Agent = { ...agent, avatarColorToken: picked };
+  const hasImage = !!agent.avatarImageUrl;
+  const visibilityHelp = canChangeVisibility
+    ? visibility === AGENT_VISIBILITY.ORGANIZATION
+      ? "Anyone on your team can @mention and chat with it."
+      : "Only this agent's owner can see and chat with it."
+    : "Only the owner or an admin can change this agent's visibility.";
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Edit profile</DialogTitle>
+          <DialogDescription>
+            Identity and appearance save immediately. Runtime behavior is configured from the other tabs.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={submit} className="space-y-5">
+          {/* Identity */}
+          <div className="space-y-2">
+            <Label>Agent name</Label>
+            <Input value={agent.name ? `@${agent.name}` : ""} disabled className="font-mono" />
+            <p className="text-caption text-muted-foreground">
+              Agent name is permanent after creation — used in @mentions and CLI commands.
+            </p>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="profile-display">Display name</Label>
+            <Input
+              id="profile-display"
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+              placeholder="How teammates see this agent"
+              maxLength={200}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="profile-visibility">Visibility</Label>
+            <Select
+              id="profile-visibility"
+              aria-label="Visibility"
+              value={visibility}
+              onChange={(v) => setVisibility(v as typeof visibility)}
+              disabled={!canChangeVisibility}
+              options={[
+                { value: AGENT_VISIBILITY.ORGANIZATION, label: VISIBILITY_LABELS[AGENT_VISIBILITY.ORGANIZATION] },
+                { value: AGENT_VISIBILITY.PRIVATE, label: VISIBILITY_LABELS[AGENT_VISIBILITY.PRIVATE] },
+              ]}
+            />
+            <p className="text-caption text-muted-foreground">{visibilityHelp}</p>
+          </div>
+          {isHuman && (
+            <div className="space-y-2">
+              <Label htmlFor="profile-delegate">Delegate Mention</Label>
+              {canEditDelegate ? (
+                <Select
+                  id="profile-delegate"
+                  aria-label="Delegate Mention"
+                  value={delegateMention}
+                  onChange={setDelegateMention}
+                  options={delegateOptions}
+                  searchable
+                />
+              ) : (
+                <div className="flex h-9 w-full items-center rounded-[var(--radius-input)] border border-input bg-transparent px-3 text-body opacity-70">
+                  {delegateIdentity ? (
+                    <AgentChip name={delegateIdentity.name} displayName={delegateIdentity.displayName} />
+                  ) : (
+                    <span className="text-muted-foreground">No delegate</span>
+                  )}
+                </div>
+              )}
+              <p className="text-caption text-muted-foreground">
+                {canEditDelegate
+                  ? "Assistant that acts on behalf of this agent."
+                  : "Only the member themselves can set their own delegate."}
+              </p>
+            </div>
+          )}
+
+          {/* Appearance */}
+          <div className="space-y-2">
+            <Label>Avatar</Label>
+            <div className="flex items-center gap-3">
+              <AvatarPreview agent={previewAgent} size={64} />
+              <AvatarPreview agent={previewAgent} size={32} />
+              <span className="text-caption text-muted-foreground">Large and compact surfaces</span>
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label>Image</Label>
+            <div className="flex flex-wrap items-center gap-2">
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept={ACCEPTED_INPUT_TYPES}
+                onChange={onFileChange}
+                style={{ display: "none" }}
+              />
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => fileInputRef.current?.click()}
+                disabled={uploading || saving}
+              >
+                {uploading ? "Uploading…" : hasImage ? "Replace image" : "Upload image"}
+              </Button>
+              {hasImage && (
+                <Button type="button" variant="ghost" size="sm" onClick={onRemoveImage} disabled={uploading || saving}>
+                  Remove image
+                </Button>
+              )}
+            </div>
+            <p className="text-caption text-muted-foreground">
+              PNG / JPEG / WEBP. Square images work best. An image takes precedence over the color below. Image changes
+              save immediately.
+            </p>
+            {imageError && <p className="text-body text-destructive">{imageError}</p>}
+          </div>
+          <div className="space-y-2">
+            <Label>Color</Label>
+            <div className="flex flex-wrap gap-2">
+              <Swatch
+                label="Auto"
+                selected={picked === null}
+                onClick={() => setPicked(null)}
+                background={resolveAvatarHue(null, agent.uuid)}
+                isAuto
+              />
+              {AVATAR_COLOR_TOKENS.map((token) => (
+                <Swatch
+                  key={token}
+                  label={token}
+                  selected={picked === token}
+                  onClick={() => setPicked(token)}
+                  background={`var(--avatar-${token})`}
+                />
+              ))}
+            </div>
+            <p className="text-caption text-muted-foreground">
+              Auto chooses a stable color for this agent. The color is used only when no image is set, and saves with
+              the identity fields below.
+            </p>
+          </div>
+
+          {formError && <p className="text-body text-destructive">{formError}</p>}
+          <DialogFooter>
+            <Button type="button" variant="ghost" onClick={() => onOpenChange(false)} disabled={saving || uploading}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={saving || uploading}>
+              {saving ? "Saving…" : "Save"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function Swatch({
+  label,
+  selected,
+  onClick,
+  background,
+  isAuto,
+}: {
+  label: string;
+  selected: boolean;
+  onClick: () => void;
+  background: string;
+  isAuto?: boolean;
+}) {
+  const size = 32;
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={selected}
+      title={label}
+      style={{
+        position: "relative",
+        width: size,
+        height: size,
+        borderRadius: "50%",
+        background,
+        border: selected ? "var(--hairline-bold) solid var(--fg)" : "var(--hairline) solid var(--border)",
+        cursor: "pointer",
+        padding: 0,
+        outline: "none",
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      {isAuto && (
+        <span
+          aria-hidden
+          style={{
+            position: "absolute",
+            inset: 4,
+            borderRadius: "50%",
+            background: "var(--bg-raised)",
+            color: "var(--fg-3)",
+            fontSize: 10,
+            fontWeight: 600,
+            display: "inline-flex",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          A
+        </span>
+      )}
+    </button>
+  );
+}

--- a/packages/web/src/pages/agent-detail/profile-tab.tsx
+++ b/packages/web/src/pages/agent-detail/profile-tab.tsx
@@ -1,27 +1,29 @@
+import { useState } from "react";
 import { AppearanceSection } from "./appearance-section.js";
 import { DangerZone } from "./danger-zone.js";
 import { IdentitySection } from "./identity-section.js";
 import { useAgentDetailContext } from "./layout-context.js";
+import { ProfileEditDialog } from "./profile-edit-dialog.js";
+import { useJustSaved } from "./save-semantics.js";
 
 export function ProfileTab() {
   const ctx = useAgentDetailContext();
+  const { justSaved, markSaved } = useJustSaved();
+  const [editOpen, setEditOpen] = useState(false);
+  // Identity + Appearance share one Edit entry (PR2 §Profile). Both the Identity
+  // section's Edit button and the avatar open the same unified dialog.
+  const onEdit = ctx.canManageAgent && ctx.agent.status === "active" ? () => setEditOpen(true) : undefined;
+
   return (
     <>
       <IdentitySection
         agent={ctx.agent}
         canEdit={ctx.canManageAgent}
-        onSave={ctx.saveIdentity}
+        onEdit={onEdit}
+        saved={justSaved}
         title="Identity"
         description={null}
-        aside={
-          <AppearanceSection
-            agent={ctx.agent}
-            canEdit={ctx.canManageAgent}
-            onSave={ctx.saveIdentity}
-            onRefresh={ctx.refreshAgent}
-            variant="inline"
-          />
-        }
+        aside={<AppearanceSection agent={ctx.agent} canEdit={ctx.canManageAgent} onEdit={onEdit} variant="inline" />}
       />
       {/* Agent lifecycle is identity-level, so destructive controls stay at the
           end of Profile instead of mixing with runtime configuration. */}
@@ -35,6 +37,16 @@ export function ProfileTab() {
           onSuspend={ctx.onSuspend}
           onReactivate={ctx.onReactivate}
           onDelete={ctx.onDelete}
+        />
+      )}
+      {ctx.canManageAgent && (
+        <ProfileEditDialog
+          agent={ctx.agent}
+          open={editOpen}
+          onOpenChange={setEditOpen}
+          onSave={ctx.saveIdentity}
+          onRefresh={ctx.refreshAgent}
+          onSaved={markSaved}
         />
       )}
     </>

--- a/packages/web/src/pages/agent-detail/prompt-tab.tsx
+++ b/packages/web/src/pages/agent-detail/prompt-tab.tsx
@@ -6,7 +6,7 @@ import {
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Pencil, Plus } from "lucide-react";
 import { type FormEvent, type ReactNode, useEffect, useRef, useState } from "react";
-import { Navigate, useNavigate } from "react-router";
+import { Navigate } from "react-router";
 import { getAgentResources, updateAgentResources } from "../../api/agent-resources.js";
 import { Button } from "../../components/ui/button.js";
 import { Markdown } from "../../components/ui/markdown.js";
@@ -17,12 +17,14 @@ import { Textarea } from "../../components/ui/textarea.js";
 import { agentResourcesMutationHandlers } from "./capability-section.js";
 import { useAgentDetailContext } from "./layout-context.js";
 import { sourceLabel } from "./resource-source.js";
+import { titleWithSemantics, useJustSaved } from "./save-semantics.js";
 
 type AvailablePrompt = { id: string; name: string };
 
 export function PromptTab() {
   const ctx = useAgentDetailContext();
   const queryClient = useQueryClient();
+  const { justSaved, markSaved } = useJustSaved();
   const [editor, setEditor] = useState<PromptEditorState | null>(null);
   const resourcesQuery = useQuery({
     queryKey: ["agent-resources", ctx.uuid],
@@ -39,7 +41,12 @@ export function PromptTab() {
     },
     // Same hardening as the shared resource hook (stale-GET cancel + 409 refetch),
     // since the shell now also observes this cache. `onSuccessAfter` closes the editor.
-    ...agentResourcesMutationHandlers(queryClient, ctx.uuid, { onSuccessAfter: () => setEditor(null) }),
+    ...agentResourcesMutationHandlers(queryClient, ctx.uuid, {
+      onSuccessAfter: () => {
+        setEditor(null);
+        markSaved();
+      },
+    }),
   });
   // All prompt-binding management (enable / disable / remove / re-enable) goes
   // through one mutation that submits the full bindings array. The old Resources
@@ -49,7 +56,7 @@ export function PromptTab() {
       if (!resourcesQuery.data) throw new Error("prompt resources not loaded");
       return updateAgentResources(ctx.uuid, { expectedVersion: resourcesQuery.data.version, bindings });
     },
-    ...agentResourcesMutationHandlers(queryClient, ctx.uuid),
+    ...agentResourcesMutationHandlers(queryClient, ctx.uuid, { onSuccessAfter: markSaved }),
   });
   if (ctx.isHuman) return <Navigate to="../profile" replace />;
   if (!ctx.config && ctx.configLoading) return null;
@@ -113,7 +120,7 @@ export function PromptTab() {
   return (
     <div className="flex flex-col" style={{ gap: "var(--sp-5)" }}>
       <Section
-        title="Instructions"
+        title={titleWithSemantics("Instructions", "immediate", justSaved)}
         description="Team and your own instructions for this agent — toggle, customize, or add your own."
         action={
           canEditPrompt && !resourceError && !editor && resources ? (
@@ -122,6 +129,7 @@ export function PromptTab() {
               pending={bindingMut.isPending}
               onAddCustom={() => openPromptEditor(null)}
               onEnable={enablePrompt}
+              onNavigateAway={ctx.guardedNavigate}
             />
           ) : null
         }
@@ -602,8 +610,9 @@ function AddInstructionsMenu(props: {
   pending: boolean;
   onAddCustom: () => void;
   onEnable: (resourceId: string) => void;
+  /** Leave-guarded navigate for the "Manage in Settings" exit. */
+  onNavigateAway: (to: string) => void;
 }) {
-  const navigate = useNavigate();
   return (
     <Popover
       align="end"
@@ -654,7 +663,7 @@ function AddInstructionsMenu(props: {
           <InstructionsMenuButton
             muted
             onClick={() => {
-              navigate("/settings/resources");
+              props.onNavigateAway("/settings/resources");
               close();
             }}
           >

--- a/packages/web/src/pages/agent-detail/resources-tab.tsx
+++ b/packages/web/src/pages/agent-detail/resources-tab.tsx
@@ -1,4 +1,5 @@
 import type { ResourceType } from "@first-tree/shared";
+import { useState } from "react";
 import { ResourceTypeSection, useAgentResources } from "./capability-section.js";
 import { useAgentDetailContext } from "./layout-context.js";
 
@@ -10,6 +11,9 @@ const RESOURCE_TYPES: ResourceType[] = ["skill", "mcp"];
 export function ResourcesTab() {
   const ctx = useAgentDetailContext();
   const resources = useAgentResources(ctx.uuid, { enabled: !!ctx.uuid && !ctx.isHuman });
+  // Skill and MCP share one resource mutation/justSaved flag, so flash "Saved"
+  // only on the section that was actually edited (tracked at click time).
+  const [lastSavedType, setLastSavedType] = useState<ResourceType | null>(null);
 
   if (ctx.isHuman) return null;
   if (resources.isLoading) {
@@ -39,7 +43,12 @@ export function ResourcesTab() {
           data={data}
           canEdit={canEdit}
           pending={resources.pending}
-          onMutate={resources.mutateBindings}
+          onMutate={(bindings) => {
+            setLastSavedType(type);
+            resources.mutateBindings(bindings);
+          }}
+          saved={resources.justSaved && lastSavedType === type}
+          onNavigateAway={ctx.guardedNavigate}
         />
       ))}
       {resources.saveError ? (

--- a/packages/web/src/pages/agent-detail/runtime-section.tsx
+++ b/packages/web/src/pages/agent-detail/runtime-section.tsx
@@ -4,7 +4,12 @@ import type { ReactNode } from "react";
 import { Button } from "../../components/ui/button.js";
 import { Section } from "../../components/ui/section.js";
 import { ConfigRow } from "./flat-section.js";
+import { titleWithSemantics } from "./save-semantics.js";
 
+// Execution (computer + runtime) is the immediate-save half of the Environment
+// tab. Model / reasoning (draft, SaveBar) render separately in the tab's draft
+// zone — they used to be slotted in here, but PR2 splits the two save semantics
+// into distinct zones, so this section is Execution-only now.
 export type RuntimeSectionProps = {
   runtimeProvider: RuntimeProvider;
   /** Display label of the bound computer; null when no computer is bound yet. */
@@ -18,10 +23,6 @@ export type RuntimeSectionProps = {
   /** When set, the bound-computer card surfaces a "Re-bind" button that
    *  opens the unified ReBindDialog (UX U2). Available only on bound agents. */
   onRebind?: () => void;
-  /** Slot for the Model dropdown — we reuse the existing ModelSection via composition. */
-  modelSlot: ReactNode;
-  /** Slot for the Reasoning effort dropdown — same composition pattern as the model slot. */
-  effortSlot?: ReactNode;
 };
 
 const RUNTIME_COPY: Record<RuntimeProvider, { name: string; caption: string }> = {
@@ -42,44 +43,33 @@ const RUNTIME_COPY: Record<RuntimeProvider, { name: string; caption: string }> =
 export function RuntimeSection(props: RuntimeSectionProps) {
   const copy = RUNTIME_COPY[props.runtimeProvider];
   return (
-    <>
-      <Section
-        title="Execution"
-        description="Computer and runtime changes apply immediately through bind or re-bind."
-        action={
-          props.computerLabel && props.onRebind ? (
-            <Button
-              size="xs"
-              variant="outline"
-              onClick={props.onRebind}
-              title="Move this agent to another computer or runtime"
-            >
-              <Link2 className="h-3 w-3" />
-              Re-bind
-            </Button>
-          ) : null
-        }
-      >
-        <ComputerRow
-          computerLabel={props.computerLabel}
-          statusLoading={props.computerStatusLoading ?? false}
-          statusError={props.computerStatusError ?? null}
-          canBindComputer={props.canBindComputer}
-          bindPending={props.bindComputerPending ?? false}
-          onBindComputer={props.onBindComputer}
-        />
-        <RuntimeRow name={copy.name} caption={copy.caption} />
-      </Section>
-      <div style={{ marginTop: "var(--sp-8)" }}>
-        <Section
-          title="Model settings"
-          description="Model and reasoning settings remain drafts until saved from the Save bar."
-        >
-          {props.modelSlot}
-          {props.effortSlot}
-        </Section>
-      </div>
-    </>
+    <Section
+      title={titleWithSemantics("Execution", "immediate")}
+      description="Computer and runtime changes apply immediately through bind or re-bind."
+      action={
+        props.computerLabel && props.onRebind ? (
+          <Button
+            size="xs"
+            variant="outline"
+            onClick={props.onRebind}
+            title="Move this agent to another computer or runtime"
+          >
+            <Link2 className="h-3 w-3" />
+            Re-bind
+          </Button>
+        ) : null
+      }
+    >
+      <ComputerRow
+        computerLabel={props.computerLabel}
+        statusLoading={props.computerStatusLoading ?? false}
+        statusError={props.computerStatusError ?? null}
+        canBindComputer={props.canBindComputer}
+        bindPending={props.bindComputerPending ?? false}
+        onBindComputer={props.onBindComputer}
+      />
+      <RuntimeRow name={copy.name} caption={copy.caption} />
+    </Section>
   );
 }
 

--- a/packages/web/src/pages/agent-detail/runtime-tab.tsx
+++ b/packages/web/src/pages/agent-detail/runtime-tab.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { Navigate } from "react-router";
+import { Section } from "../../components/ui/section.js";
 import { ResourceTypeSection, useAgentResources } from "./capability-section.js";
 import { EnvSection } from "./env-section.js";
 import { useAgentDetailContext } from "./layout-context.js";
@@ -7,6 +8,7 @@ import { ModelSection } from "./model-section.js";
 import { ReasoningEffortSection } from "./reasoning-effort-section.js";
 import { RuntimeSection } from "./runtime-section.js";
 import { sectionAnchorId } from "./save-bar.js";
+import { titleWithSemantics } from "./save-semantics.js";
 
 export function RuntimeTab() {
   const ctx = useAgentDetailContext();
@@ -41,6 +43,8 @@ export function RuntimeTab() {
           Failed to load configuration: {String(ctx.configError)}
         </div>
       )}
+      {/* Immediate zone — Execution + Repositories. Both save the moment you act
+          (bind/re-bind, repo add/remove); no SaveBar involvement. */}
       {ctx.config && (
         <RuntimeSection
           runtimeProvider={ctx.setupRuntimeProvider}
@@ -51,30 +55,6 @@ export function RuntimeTab() {
           bindComputerPending={ctx.bindClientPending}
           onBindComputer={ctx.onOpenBindDialog}
           onRebind={ctx.agent.clientId ? ctx.onOpenRebindDialog : undefined}
-          modelSlot={
-            <div id={sectionAnchorId("model")}>
-              <ModelSection
-                value={ctx.draft.draft.model}
-                baseline={ctx.config?.payload.model ?? ""}
-                onChange={ctx.draft.setModel}
-                onRevert={ctx.draft.revertModel}
-                disabled={ctx.agent.status !== "active"}
-                provider={ctx.setupRuntimeProvider}
-              />
-            </div>
-          }
-          effortSlot={
-            <div id={sectionAnchorId("effort")}>
-              <ReasoningEffortSection
-                value={ctx.draft.draft.reasoningEffort}
-                baseline={ctx.config?.payload.reasoningEffort ?? ""}
-                onChange={ctx.draft.setReasoningEffort}
-                onRevert={ctx.draft.revertReasoningEffort}
-                disabled={ctx.agent.status !== "active"}
-                provider={ctx.setupRuntimeProvider}
-              />
-            </div>
-          }
         />
       )}
       <div id={sectionAnchorId("git")} style={{ marginTop: "var(--sp-8)" }}>
@@ -93,6 +73,8 @@ export function RuntimeTab() {
             canEdit={canEditResources}
             pending={repos.pending}
             onMutate={repos.mutateBindings}
+            saved={repos.justSaved}
+            onNavigateAway={ctx.guardedNavigate}
           />
         )}
         {repos.saveError ? (
@@ -101,6 +83,38 @@ export function RuntimeTab() {
           </p>
         ) : null}
       </div>
+
+      {/* Draft zone — Model settings + Environment variables. These stage into the
+          SaveBar and commit together; their dirty-dots drive the bar. */}
+      {ctx.config && (
+        <div style={{ marginTop: "var(--sp-8)" }}>
+          <Section
+            title={titleWithSemantics("Model settings", "draft")}
+            description="Model and reasoning settings remain drafts until saved from the Save bar."
+          >
+            <div id={sectionAnchorId("model")}>
+              <ModelSection
+                value={ctx.draft.draft.model}
+                baseline={ctx.config?.payload.model ?? ""}
+                onChange={ctx.draft.setModel}
+                onRevert={ctx.draft.revertModel}
+                disabled={ctx.agent.status !== "active"}
+                provider={ctx.setupRuntimeProvider}
+              />
+            </div>
+            <div id={sectionAnchorId("effort")}>
+              <ReasoningEffortSection
+                value={ctx.draft.draft.reasoningEffort}
+                baseline={ctx.config?.payload.reasoningEffort ?? ""}
+                onChange={ctx.draft.setReasoningEffort}
+                onRevert={ctx.draft.revertReasoningEffort}
+                disabled={ctx.agent.status !== "active"}
+                provider={ctx.setupRuntimeProvider}
+              />
+            </div>
+          </Section>
+        </div>
+      )}
       {ctx.config && (
         <div id={sectionAnchorId("env")} style={{ marginTop: "var(--sp-8)" }}>
           <EnvSection

--- a/packages/web/src/pages/agent-detail/save-semantics.tsx
+++ b/packages/web/src/pages/agent-detail/save-semantics.tsx
@@ -1,0 +1,76 @@
+import { Check } from "lucide-react";
+import { useEffect, useState } from "react";
+
+/**
+ * The two save semantics on the agent-detail page, made explicit (PR2 P0).
+ * Every section is one of exactly two kinds, with ONE canonical label each so
+ * the distinction reads at a glance:
+ *   - immediate: writes land as soon as you make them (identity, appearance,
+ *     bind/re-bind, repositories, skills, MCP, instructions).
+ *   - draft: changes are staged and committed together from the Save bar
+ *     (model, reasoning effort, environment variables).
+ */
+export type SaveSemanticsKind = "immediate" | "draft";
+
+const LABELS: Record<SaveSemanticsKind, string> = {
+  immediate: "Applies immediately",
+  draft: "Saved from the Save bar",
+};
+
+/**
+ * Quiet tag rendered next to a section title. For immediate sections it flips to
+ * a transient "Saved" check right after a successful write (drive `saved` from
+ * `useJustSaved`); draft sections never flash here — the Save bar owns their
+ * saved state.
+ */
+export function SaveSemanticsTag({ kind, saved = false }: { kind: SaveSemanticsKind; saved?: boolean }) {
+  if (saved && kind === "immediate") {
+    return (
+      <span
+        className="inline-flex items-center gap-1 text-caption font-normal"
+        style={{ color: "var(--success)" }}
+        role="status"
+      >
+        <Check className="h-3 w-3" />
+        Saved
+      </span>
+    );
+  }
+  return (
+    <span className="text-caption font-normal" style={{ color: "var(--fg-4)" }}>
+      {LABELS[kind]}
+    </span>
+  );
+}
+
+/** Compose a section title with its save-semantics tag in one inline row. */
+export function titleWithSemantics(title: string, kind: SaveSemanticsKind, saved?: boolean) {
+  return (
+    <span className="inline-flex items-baseline gap-2">
+      <span>{title}</span>
+      <SaveSemanticsTag kind={kind} saved={saved} />
+    </span>
+  );
+}
+
+/**
+ * Tracks a brief "just saved" window for an immediate-save surface. Returns the
+ * flag plus a `markSaved` to call from a mutation's success path. Centralized so
+ * every immediate surface flashes the same 2.5s confirmation (mirrors the
+ * SaveBar's own justSaved timing).
+ */
+export function useJustSaved(): { justSaved: boolean; markSaved: () => void } {
+  // Tick-based, not a plain boolean: each markSaved bumps `tick`, which re-runs
+  // the effect and restarts the 2.5s window even when a save lands while the
+  // previous "Saved" is still showing (a boolean would no-op the second save and
+  // let the confirmation expire early).
+  const [tick, setTick] = useState(0);
+  const [justSaved, setJustSaved] = useState(false);
+  useEffect(() => {
+    if (tick === 0) return;
+    setJustSaved(true);
+    const t = setTimeout(() => setJustSaved(false), 2500);
+    return () => clearTimeout(t);
+  }, [tick]);
+  return { justSaved, markSaved: () => setTick((t) => t + 1) };
+}

--- a/packages/web/src/pages/agent-detail/usage-tab.tsx
+++ b/packages/web/src/pages/agent-detail/usage-tab.tsx
@@ -1,7 +1,6 @@
 import type { UsageAgentSummary, UsageTurnRow } from "@first-tree/shared";
 import { useQuery } from "@tanstack/react-query";
 import { type CSSProperties, type ReactElement, type ReactNode, useEffect, useMemo, useState } from "react";
-import { useNavigate } from "react-router";
 import { getAgentUsageSummary, getAgentUsageTurns } from "../../api/usage.js";
 import { Button } from "../../components/ui/button.js";
 import { Section } from "../../components/ui/section.js";
@@ -77,6 +76,9 @@ export function UsageTab(): ReactElement {
         rows={turnsQuery.data?.rows ?? []}
         isLoading={turnsQuery.isLoading}
         isError={turnsQuery.isError}
+        // Opening a chat leaves the agent — route through the leave guard so an
+        // unsaved Environment draft (carried across tabs) isn't silently lost.
+        onOpenChat={(chatId) => ctx.guardedNavigate(`/?chat=${encodeURIComponent(chatId)}`)}
         hasMore={turnsQuery.data?.nextCursor != null && turnsLimit < MAX_TURNS}
         loadingMore={growing}
         onShowMore={() => {
@@ -313,6 +315,7 @@ function RecentTurnsBlock({
   rows,
   isLoading,
   isError,
+  onOpenChat,
   hasMore,
   loadingMore,
   onShowMore,
@@ -320,6 +323,7 @@ function RecentTurnsBlock({
   rows: UsageTurnRow[];
   isLoading: boolean;
   isError: boolean;
+  onOpenChat: (chatId: string) => void;
   hasMore: boolean;
   loadingMore: boolean;
   onShowMore: () => void;
@@ -334,7 +338,7 @@ function RecentTurnsBlock({
         <UsagePlaceholder>No turns recorded in the last 30 days.</UsagePlaceholder>
       ) : (
         <>
-          <TurnsTable rows={rows} />
+          <TurnsTable rows={rows} onOpenChat={onOpenChat} />
           {hasMore ? (
             <div className="flex justify-center" style={{ marginTop: "var(--sp-3)" }}>
               <Button size="xs" variant="outline" disabled={loadingMore} onClick={onShowMore}>
@@ -348,8 +352,13 @@ function RecentTurnsBlock({
   );
 }
 
-function TurnsTable({ rows }: { rows: UsageTurnRow[] }): ReactElement {
-  const navigate = useNavigate();
+function TurnsTable({
+  rows,
+  onOpenChat,
+}: {
+  rows: UsageTurnRow[];
+  onOpenChat: (chatId: string) => void;
+}): ReactElement {
   const totalFor = (r: UsageTurnRow) => r.inputTokens + r.cachedInputTokens + r.outputTokens;
   const max = Math.max(1, ...rows.map(totalFor));
   return (
@@ -378,7 +387,7 @@ function TurnsTable({ rows }: { rows: UsageTurnRow[] }): ReactElement {
                   {r.chatTitle ? (
                     <button
                       type="button"
-                      onClick={() => navigate(`/?chat=${encodeURIComponent(r.chatId)}`)}
+                      onClick={() => onOpenChat(r.chatId)}
                       className="text-body font-medium"
                       style={{
                         background: "transparent",

--- a/packages/web/src/pages/agent-detail/use-legacy-anchor-redirect.ts
+++ b/packages/web/src/pages/agent-detail/use-legacy-anchor-redirect.ts
@@ -18,6 +18,9 @@ const HASH_TO_TAB: Record<string, string> = {
   "agent-cfg-mcp": "capabilities",
   "ad-advanced": "capabilities",
   "agent-cfg-env": "runtime",
+  // Model / reasoning effort live on the Environment (runtime) tab's draft zone.
+  "agent-cfg-model": "runtime",
+  "agent-cfg-effort": "runtime",
   // Repos moved to the Environment (runtime) tab.
   "agent-cfg-git": "runtime",
   // Lifecycle lives at the bottom of Profile — keep the danger anchor alive.


### PR DESCRIPTION
## What & why

PR2 of 3 in the agent-detail optimization — the **save & edit behavior (P0)** pass. **Stacked on PR1** (#868): base is `feat/agent-detail-pr1-structure`, so review only the incremental diff here. Merge PR1 first; this rebases to `main` after.

Goal: make the page's two save semantics obvious, zone the Environment tab by them, guard against losing unsaved work, and collapse Profile to one Edit.

## Changes

- **Two save semantics, explicit.** One canonical tag pair next to each section title — **"Applies immediately"** (identity, appearance, repos, skills, MCP, instructions) vs **"Saved from the Save bar"** (model, reasoning effort, env). Immediate sections flash a transient "Saved" (shared `useJustSaved`, tick-based so repeated saves re-arm the 2.5s window).
- **Environment zoned by semantics.** Immediate zone (Execution + Repositories) then draft zone (Model settings + Environment variables → SaveBar). Model settings moved out of `RuntimeSection` into the draft zone.
- **Leave guard.** `useBlocker` is unavailable here — the app uses a declarative `<BrowserRouter>`, not a data router, so `useBlocker` throws via `useDataRouterContext`'s invariant. Instead a `guardedNavigate` collars every in-page "leave this agent" exit (breadcrumb, back, Chat, "Manage in Settings", "Open Computers") and confirms via the existing ConfirmDialog when the config draft is dirty; it's exposed on the outlet context for PR3's switcher. `beforeunload` covers hard exits. **Known gap (follow-up; clean fix is a data-router migration):** the global top nav (layout.tsx) and browser back/forward (popstate) route around the guard.
- **One Profile edit.** Identity + Appearance merged into a single "Edit profile" dialog (`profile-edit-dialog.tsx`). Identity + fallback color commit together in one PATCH; the avatar image stays eager (separate endpoint) with its own error. **Partial failure keeps the dialog open and shows which half failed.** Form state is snapshotted once per (open, agent.uuid) so the eager image refresh can't wipe unsaved identity/color edits.

## Review (2 independent rounds, codex)

- **R1 (review):** found a real interaction bug — the merged dialog's eager avatar upload calls `onRefresh`, swapping the `agent` prop and resetting unsaved identity/color fields. Fixed with a uuid-keyed ref-guard (init only on fresh open / different agent).
- **R2 (challenge):** 5 findings, all fixed — **[P1]** in-page exits ("Open Computers", "Manage in Settings") bypassed the guard → all routed through `guardedNavigate`; **[P2]** legacy `agent-cfg-model`/`agent-cfg-effort` anchors missing from the redirect map → added; **[P2]** SaveBar "Jump to" only switched tab → now scrolls to the section anchor; **[P2]** Tools & skills "Saved" flashed on both Skill+MCP → scoped to the edited section; **[P3]** `useJustSaved` timer didn't re-arm on a repeat save → tick-based.

## Testing

- Rewrote the appearance/identity DOM tests for the merged dialog + display-only sections; added leave-guard (confirm discards / cancel stays) and same-agent-tab-switch (not guarded) tests.
- Gates (full repo): `biome check` (1191) · typecheck (11 pkgs) · `lint:tokens` · web tests **692**.
- UI: DEV `/preview/agent-detail` — semantic tags + disclosure verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
