### PR TITLE
feat(web): agent-detail PR3 — agent switcher + ContextBar identity + chrome dedup

### DIFF
--- a/packages/web/src/pages/agent-detail-preview.tsx
+++ b/packages/web/src/pages/agent-detail-preview.tsx
@@ -2,6 +2,7 @@ import type { Agent, AgentResourcesOutput, AgentRuntimeConfig } from "@first-tre
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 import { Outlet, Route, Routes } from "react-router";
+import { AgentSwitcherStrip } from "./agent-detail/agent-switcher-strip.js";
 import { ResourceTypeSection } from "./agent-detail/capability-section.js";
 import type { AgentDetailContext } from "./agent-detail/layout-context.js";
 import { PromptTab } from "./agent-detail/prompt-tab.js";
@@ -300,6 +301,15 @@ function buildClient(): QueryClient {
     },
   });
   client.setQueryData(["agent-resources", UUID], RESOURCES);
+  // Seed the agent switcher list (both admin/member keys, since preview auth is
+  // ambient). fetchAllAgents flattens to Agent[].
+  const switcherAgents: Agent[] = [
+    AGENT,
+    { ...AGENT, uuid: "agent-preview-2", name: "nova", displayName: "Nova", runtimeState: "working" },
+    { ...AGENT, uuid: "agent-preview-3", name: "atlas", displayName: "Atlas Researcher", runtimeState: null },
+  ];
+  client.setQueryData(["agents", "team-page", "admin"], switcherAgents);
+  client.setQueryData(["agents", "team-page", "member"], switcherAgents);
   return client;
 }
 
@@ -322,6 +332,17 @@ export function AgentDetailPreviewPage() {
     <QueryClientProvider client={client}>
       <div style={{ minHeight: "100vh", background: "var(--bg)" }}>
         <div className="mx-auto" style={{ maxWidth: 720, padding: "var(--sp-6) var(--sp-4)" }}>
+          <h1 className="text-title m-0" style={{ color: "var(--fg)" }}>
+            Agent switcher (vertical B)
+          </h1>
+          <p className="text-body" style={{ color: "var(--fg-3)", marginTop: "var(--sp-1)" }}>
+            Replaces the breadcrumb: ‹ Team + avatar-over-name items, current agent selected (brand ring), presence
+            dots. Switching is leave-guarded.
+          </p>
+          <div style={{ marginTop: "var(--sp-4)", marginBottom: "var(--sp-8)" }}>
+            <AgentSwitcherStrip currentAgent={AGENT} currentTabPath="profile" onNavigate={() => {}} />
+          </div>
+
           <h1 className="text-title m-0" style={{ color: "var(--fg)" }}>
             Environment tab — Repositories
           </h1>

--- a/packages/web/src/pages/agent-detail.tsx
+++ b/packages/web/src/pages/agent-detail.tsx
@@ -1,6 +1,6 @@
 import type { RuntimeProvider } from "@first-tree/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ArrowLeft, MessageSquare, Monitor } from "lucide-react";
+import { MessageSquare, Monitor } from "lucide-react";
 import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Outlet, useLocation, useNavigate, useParams } from "react-router";
 import { type HubClient, listClients } from "./../api/activity.js";
@@ -32,12 +32,14 @@ import { useWorkspaceViewport } from "./../hooks/use-viewport.js";
 import { cn } from "./../lib/utils.js";
 import { canManageAgentDetail } from "./agent-detail/access.js";
 import { isBindableClient } from "./agent-detail/action-state.js";
+import { AgentSwitcherStrip } from "./agent-detail/agent-switcher-strip.js";
 import { useAgentResources } from "./agent-detail/capability-section.js";
 import { ContextBar } from "./agent-detail/context-bar.js";
 import type { AgentDetailContext } from "./agent-detail/layout-context.js";
 import { ReBindDialog } from "./agent-detail/re-bind-dialog.js";
 import { SaveBar, sectionAnchorId } from "./agent-detail/save-bar.js";
 import { deriveSaveHint } from "./agent-detail/save-hint.js";
+import { buildTabs, type TabDef } from "./agent-detail/tabs.js";
 import { type DraftSectionName, useConfigDraft } from "./agent-detail/use-config-draft.js";
 import { useLegacyAnchorRedirect } from "./agent-detail/use-legacy-anchor-redirect.js";
 
@@ -50,32 +52,17 @@ const SECTION_TO_TAB: Record<DraftSectionName, string> = {
   git: "runtime",
 };
 
-type TabDef = { key: string; label: string; path: string };
-
-// IA labels only — routing `path` and the `key` (draft / deep-link mapping) are
-// kept stable so existing URLs and `SECTION_TO_TAB` keep resolving:
-//   runtime → "Environment", capabilities → "Tools & skills".
-function buildTabs(canEditConfig: boolean, isHuman: boolean): TabDef[] {
-  const tabs: TabDef[] = [{ key: "profile", label: "Profile", path: "profile" }];
-  if (canEditConfig) {
-    tabs.push(
-      { key: "runtime", label: "Environment", path: "runtime" },
-      { key: "prompt", label: "Instructions", path: "prompt" },
-      { key: "capabilities", label: "Tools & skills", path: "capabilities" },
-    );
-  } else if (!isHuman) {
-    tabs.push({ key: "capabilities", label: "Tools & skills", path: "capabilities" });
-  }
-  // Usage is an observation surface, not part of the edit flow. Keep it at
-  // the end so configuration tabs read left-to-right as the setup workflow.
-  // Human-type agents have no token usage to show.
-  if (!isHuman) {
-    tabs.push({ key: "usage", label: "Usage", path: "usage" });
-  }
-  return tabs;
+export function AgentDetailPage() {
+  const params = useParams<{ uuid: string }>();
+  // Remount the whole page on agent switch. The switcher navigates in place
+  // (only `:uuid` changes), so the route element stays mounted; without a key the
+  // previous agent's config draft, pending-nav, and dialog state would leak into
+  // the next agent — notably useConfigDraft only re-seeds from null, so a clean
+  // switch would otherwise render/save agent A's model/env against agent B.
+  return <AgentDetailPageView key={params.uuid ?? ""} />;
 }
 
-export function AgentDetailPage() {
+function AgentDetailPageView() {
   const params = useParams<{ uuid: string }>();
   const uuid = params.uuid ?? "";
   const navigate = useNavigate();
@@ -343,6 +330,12 @@ export function AgentDetailPage() {
     const last = segments[segments.length - 1] ?? "";
     return tabs.find((t) => t.path === last)?.key ?? "profile";
   }, [location.pathname, tabs]);
+  // The actual current tab PATH (what the switcher preserves when switching
+  // agents). Derived from the key rather than assuming key === path.
+  const currentTabPath = useMemo(
+    () => tabs.find((t) => t.key === currentTabKey)?.path ?? "profile",
+    [tabs, currentTabKey],
+  );
 
   if (agentQuery.isLoading) {
     return (
@@ -438,15 +431,6 @@ export function AgentDetailPage() {
     boundClientId && canEditConfig ? (boundClient?.hostname ?? boundClientId) : null;
 
   const setupRuntimeProvider: RuntimeProvider = agent.runtimeProvider ?? "claude-code";
-  // Exhaustive map (not a binary ternary) so adding a provider to
-  // RuntimeProvider forces this label to be filled in — prevents a new
-  // runtime from silently rendering as "Claude Code" in the context bar.
-  const CONTEXT_RUNTIME_LABEL: Record<RuntimeProvider, string> = {
-    "claude-code": "Claude Code",
-    "claude-code-tui": "Claude Code (TUI)",
-    codex: "Codex",
-  };
-  const contextRuntimeLabel = CONTEXT_RUNTIME_LABEL[setupRuntimeProvider];
 
   const refreshAgent = async () => {
     await queryClient.invalidateQueries({ queryKey: ["agent", uuid] });
@@ -498,33 +482,12 @@ export function AgentDetailPage() {
   return (
     <div className="flex flex-col" style={{ minHeight: "calc(100vh - var(--sp-10))" }}>
       <div style={{ padding: "var(--sp-4) var(--sp-5) var(--sp-3)" }}>
-        {isNarrow ? (
-          <button
-            type="button"
-            onClick={() => guardedNavigate("/team")}
-            aria-label="Back to agents"
-            className="inline-flex items-center bg-transparent border-0 cursor-pointer transition-colors hover:text-[var(--fg)] text-caption"
-            style={{
-              color: "var(--fg-3)",
-              minHeight: "var(--sp-7)",
-              padding: "0 var(--sp-1_5)",
-              marginBottom: "var(--sp-2)",
-              marginLeft: "calc(var(--sp-1_5) * -1)",
-              gap: "var(--sp-1)",
-            }}
-          >
-            <ArrowLeft className="h-3 w-3" />
-            Agents
-          </button>
-        ) : (
-          <Breadcrumb style={{ marginBottom: "var(--sp-2)" }}>
-            <BreadcrumbLink onClick={() => guardedNavigate("/team")}>Team</BreadcrumbLink>
-            <BreadcrumbSep />
-            <BreadcrumbLink onClick={() => guardedNavigate("/team")}>Agents</BreadcrumbLink>
-            <BreadcrumbSep />
-            <BreadcrumbCurrent>{agent.displayName}</BreadcrumbCurrent>
-          </Breadcrumb>
-        )}
+        {/* Agent switcher (vertical-B) replaces the breadcrumb: jump between agents
+            (and back to Team) without losing the agent context. Leaving via it is
+            leave-guarded. */}
+        <div style={{ marginBottom: "var(--sp-2)" }}>
+          <AgentSwitcherStrip currentAgent={agent} currentTabPath={currentTabPath} onNavigate={guardedNavigate} />
+        </div>
         <div className="flex w-full items-center gap-2">
           <Avatar
             src={agent.avatarImageUrl}
@@ -544,12 +507,16 @@ export function AgentDetailPage() {
             )}
           </div>
           <div className="flex items-center gap-2 shrink-0">
-            <PresenceChip status={runtimeStateToPresence(agent.runtimeState)} />
-            {activeSessions > 0 && (
-              <span className="mono text-caption" style={{ color: "var(--fg-3)" }}>
-                {activeSessions} active
-              </span>
-            )}
+            {/* One status cluster: presence (with label) + active-session count
+                folded in, instead of scattered indicators. */}
+            <span className="inline-flex items-center gap-1.5">
+              <PresenceChip status={runtimeStateToPresence(agent.runtimeState)} />
+              {activeSessions > 0 && (
+                <span className="mono text-caption" style={{ color: "var(--fg-4)" }}>
+                  · {activeSessions} active
+                </span>
+              )}
+            </span>
             <Button
               variant="ghost"
               size="xs"
@@ -570,7 +537,14 @@ export function AgentDetailPage() {
       <div ref={headerSentinelRef} aria-hidden style={{ height: 0 }} />
 
       {!isHuman && (
-        <ContextBar runtimeLabel={contextRuntimeLabel} computerLabel={boundClientLabel} visible={contextBarVisible} />
+        <ContextBar
+          displayName={agent.displayName}
+          avatarImageUrl={agent.avatarImageUrl}
+          avatarColorToken={agent.avatarColorToken}
+          seed={agent.uuid}
+          runtimeState={agent.runtimeState}
+          visible={contextBarVisible}
+        />
       )}
 
       <TabsNav tabs={tabs} agentUuid={uuid} currentTabKey={currentTabKey} dirtyTabs={dirtyTabs} badges={tabBadges} />

--- a/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
@@ -26,6 +26,8 @@ const agentConfigMocks = vi.hoisted(() => ({
 const agentMocks = vi.hoisted(() => ({
   deleteAgent: vi.fn(),
   getAgent: vi.fn(),
+  listAgents: vi.fn(),
+  listAllAgents: vi.fn(),
   reactivateAgent: vi.fn(),
   rebindAgent: vi.fn(),
   suspendAgent: vi.fn(),
@@ -350,6 +352,14 @@ beforeEach(() => {
   vi.clearAllMocks();
   authMock.value = { memberId: "member-self", role: "admin" };
   agentMocks.getAgent.mockResolvedValue(agent());
+  // Agent switcher list (admin → listAllAgents). Include a second agent so the
+  // switcher has a switch target.
+  const switcherAgents = {
+    items: [agent(), agent({ uuid: "agent-2", name: "nova", displayName: "Nova" })],
+    nextCursor: null,
+  };
+  agentMocks.listAllAgents.mockResolvedValue(switcherAgents);
+  agentMocks.listAgents.mockResolvedValue(switcherAgents);
   agentMocks.updateAgent.mockResolvedValue(agent());
   agentMocks.suspendAgent.mockResolvedValue(agent({ status: "suspended" }));
   agentMocks.reactivateAgent.mockResolvedValue(agent());
@@ -873,6 +883,26 @@ describe("AgentDetailPage", () => {
     await waitForCondition(
       () => !document.body.textContent?.includes("Leave with unsaved changes?"),
       "Expected leave guard to dismiss on cancel",
+    );
+
+    await act(async () => root.unmount());
+  });
+
+  it("guards switching to another agent via the switcher when the draft is dirty", async () => {
+    const { RuntimeTab } = await import("../runtime-tab.js");
+    const { container, root } = await renderDom("/agents/agent-1/runtime", <RuntimeTab />);
+    await waitForText(container, "Model settings");
+    await waitForText(container, "Nova"); // switcher list loaded (Kael + Nova)
+    await chooseSelectOption(container.querySelector('button[aria-label="Model"]'), "opus");
+    await waitForText(container, "Configuration changes in");
+
+    // Clicking another agent in the switcher leaves the current agent → guarded.
+    await click([...container.querySelectorAll("button")].find((b) => b.textContent?.includes("Nova")) ?? null);
+    await waitForText(document.body, "Leave with unsaved changes?");
+    await click(exactButtonByText(document.body, "Cancel"));
+    await waitForCondition(
+      () => !document.body.textContent?.includes("Leave with unsaved changes?"),
+      "Expected switcher leave guard to dismiss on cancel",
     );
 
     await act(async () => root.unmount());

--- a/packages/web/src/pages/agent-detail/__tests__/context-bar-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/context-bar-dom.test.tsx
@@ -25,24 +25,18 @@ afterEach(() => {
 });
 
 describe("ContextBar", () => {
-  it("renders runtime and optional computer labels only when visible", async () => {
+  it("renders the agent identity only when visible", async () => {
     const { ContextBar } = await import("../context-bar.js");
     const hidden = await renderDom(
-      <ContextBar runtimeLabel="Claude Code" computerLabel="gandy-macbook" visible={false} />,
+      <ContextBar displayName="Kael" seed="agent-1" runtimeState="idle" visible={false} />,
     );
     expect(hidden.container.textContent).toBe("");
     await act(async () => hidden.root.unmount());
 
-    const withoutComputer = await renderDom(<ContextBar runtimeLabel="Codex" computerLabel={null} />);
-    expect(withoutComputer.container.textContent).toContain("Runs on");
-    expect(withoutComputer.container.textContent).toContain("Codex");
-    expect(withoutComputer.container.textContent).not.toContain("@");
-    await act(async () => withoutComputer.root.unmount());
-
-    const withComputer = await renderDom(<ContextBar runtimeLabel="Claude Code" computerLabel="gandy-macbook" />);
-    expect(withComputer.container.textContent).toContain("Claude Code");
-    expect(withComputer.container.textContent).toContain("@");
-    expect(withComputer.container.textContent).toContain("gandy-macbook");
-    await act(async () => withComputer.root.unmount());
+    const shown = await renderDom(<ContextBar displayName="Kael" seed="agent-1" runtimeState="idle" />);
+    // Identity (name) is pinned; the old "Runs on <runtime> @ <computer>" strap is gone.
+    expect(shown.container.textContent).toContain("Kael");
+    expect(shown.container.textContent).not.toContain("Runs on");
+    await act(async () => shown.root.unmount());
   });
 });

--- a/packages/web/src/pages/agent-detail/agent-switcher-strip.tsx
+++ b/packages/web/src/pages/agent-detail/agent-switcher-strip.tsx
@@ -1,0 +1,233 @@
+import type { Agent } from "@first-tree/shared";
+import { useQuery } from "@tanstack/react-query";
+import { ChevronLeft } from "lucide-react";
+import { type ReactNode, useCallback, useEffect, useRef, useState } from "react";
+import { listAgents, listAllAgents } from "../../api/agents.js";
+import { useAuth } from "../../auth/auth-context.js";
+import { Avatar } from "../../components/avatar.js";
+import { presenceChipView, runtimeStateToPresence } from "../../components/ui/presence-chip.js";
+import { matchesAgentScope, readAgentFilterPreference } from "../team/agent-filter.js";
+import { fetchAllAgents } from "../team/index.js";
+import { resolveTabPath } from "./tabs.js";
+
+/**
+ * Agent switcher (vertical-B): replaces the breadcrumb at the top of agent
+ * detail. A horizontal strip of avatar-over-name items, leftmost a "‹ Team"
+ * back affordance, the current agent selected. Switching agents (and Team) goes
+ * through `onNavigate` = the page's `guardedNavigate`, so an unsaved config
+ * draft prompts a confirm before leaving.
+ *
+ * Scope follows the Team page's All/Mine preference (shared `agent-filter`
+ * module), read once on mount — the filter can only change on the Team page,
+ * where this strip is unmounted, so read-on-mount fully covers a single tab.
+ * The current agent is always included even when scope would exclude it.
+ */
+export function AgentSwitcherStrip({
+  currentAgent,
+  currentTabPath,
+  onNavigate,
+}: {
+  currentAgent: Agent;
+  currentTabPath: string;
+  onNavigate: (to: string) => void;
+}) {
+  const { memberId, role } = useAuth();
+  const isAdmin = role === "admin";
+  // Read-on-mount (see header comment): the All/Mine toggle lives on the Team
+  // page; while this strip is mounted the preference cannot change.
+  const [filter] = useState(() => readAgentFilterPreference());
+
+  const agentsQuery = useQuery({
+    // Same key + fetcher as the Team page, so navigating from Team is a cache hit.
+    queryKey: ["agents", "team-page", isAdmin ? "admin" : "member"],
+    queryFn: () => fetchAllAgents((params) => (isAdmin ? listAllAgents(params) : listAgents(params))),
+    // Mirror the Team page cadence so other agents' presence dots stay fresh.
+    refetchInterval: 10_000,
+  });
+
+  const all = agentsQuery.data ?? [];
+  // Switcher lists agents (not human members); the current agent is force-included
+  // even if scope/type would exclude it, so you can always see where you are.
+  const inScope = all.filter((a) => a.type !== "human" && matchesAgentScope(a, filter, memberId));
+  const base: Agent[] = inScope.some((a) => a.uuid === currentAgent.uuid)
+    ? inScope
+    : [currentAgent, ...inScope.filter((a) => a.uuid !== currentAgent.uuid)];
+  // Render the current agent from the live (10s-polled) `currentAgent` prop, not
+  // the switcher query row, so the selected chip's name/avatar/presence never
+  // lags the header for the agent you're actually on.
+  const items: Agent[] = base.map((a) => (a.uuid === currentAgent.uuid ? currentAgent : a));
+
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const [edges, setEdges] = useState({ left: false, right: false });
+  const updateEdges = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const maxScroll = el.scrollWidth - el.clientWidth;
+    setEdges({ left: el.scrollLeft > 1, right: el.scrollLeft < maxScroll - 1 });
+  }, []);
+
+  // Keep the selected agent in horizontal view and refresh the fades when the
+  // list changes. Adjust scrollLeft directly (NOT scrollIntoView) so we never
+  // scroll the PAGE vertically back up to the header when the user is deep in a tab.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: currentAgent.uuid / items.length drive the re-scroll; reading the DOM, not these values.
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const active = el.querySelector<HTMLElement>('[aria-current="true"]');
+    if (active) {
+      const aRect = active.getBoundingClientRect();
+      const cRect = el.getBoundingClientRect();
+      if (aRect.left < cRect.left) el.scrollLeft += aRect.left - cRect.left;
+      else if (aRect.right > cRect.right) el.scrollLeft += aRect.right - cRect.right;
+    }
+    updateEdges();
+  }, [currentAgent.uuid, items.length, updateEdges]);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver(updateEdges);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [updateEdges]);
+
+  return (
+    <div style={{ position: "relative" }}>
+      <div
+        ref={scrollRef}
+        onScroll={updateEdges}
+        className="flex items-start"
+        style={{ gap: "var(--sp-2)", overflowX: "auto", paddingBottom: "var(--sp-1)" }}
+      >
+        <StripButton onClick={() => onNavigate("/team")} label="Team" ariaLabel="Back to team">
+          <span
+            className="flex items-center justify-center shrink-0"
+            style={{
+              width: 36,
+              height: 36,
+              borderRadius: "50%",
+              border: "var(--hairline) solid var(--border)",
+              background: "var(--bg-raised)",
+              color: "var(--fg-3)",
+            }}
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </span>
+        </StripButton>
+
+        {items.map((a) => {
+          const selected = a.uuid === currentAgent.uuid;
+          const presence = presenceChipView(runtimeStateToPresence(a.runtimeState));
+          return (
+            <StripButton
+              key={a.uuid}
+              ariaCurrent={selected}
+              label={a.displayName}
+              title={a.displayName}
+              // Clicking the already-selected agent is a no-op — it isn't a
+              // "leave", so it must not trip the leave guard (which would offer to
+              // discard the draft for a navigation back to the same page).
+              onClick={
+                selected
+                  ? undefined
+                  : () => onNavigate(`/agents/${a.uuid}/${resolveTabPath(a, memberId, role, currentTabPath)}`)
+              }
+            >
+              <span className="relative inline-flex shrink-0" style={{ width: 36, height: 36 }}>
+                <span
+                  className="inline-flex items-center justify-center"
+                  style={{
+                    width: 36,
+                    height: 36,
+                    borderRadius: "50%",
+                    padding: selected ? 2 : 0,
+                    border: selected
+                      ? "var(--hairline-bold) solid var(--primary)"
+                      : "var(--hairline) solid transparent",
+                    background: selected ? "var(--bg-active)" : "transparent",
+                  }}
+                >
+                  <Avatar
+                    src={a.avatarImageUrl}
+                    name={a.displayName}
+                    size={selected ? 30 : 34}
+                    colorToken={a.avatarColorToken}
+                    seed={a.uuid}
+                  />
+                </span>
+                <span
+                  aria-hidden
+                  className="absolute inline-block rounded-full"
+                  style={{
+                    right: 0,
+                    bottom: 0,
+                    width: "var(--sp-2)",
+                    height: "var(--sp-2)",
+                    background: presence.color,
+                    boxShadow: "0 0 0 var(--hairline-bold) var(--bg-raised)",
+                  }}
+                />
+              </span>
+            </StripButton>
+          );
+        })}
+      </div>
+      {edges.left ? <EdgeFade side="left" /> : null}
+      {edges.right ? <EdgeFade side="right" /> : null}
+    </div>
+  );
+}
+
+function StripButton({
+  children,
+  label,
+  title,
+  ariaLabel,
+  ariaCurrent,
+  onClick,
+}: {
+  children: ReactNode;
+  label: string;
+  title?: string;
+  ariaLabel?: string;
+  ariaCurrent?: boolean;
+  onClick?: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={ariaLabel}
+      aria-current={ariaCurrent ? "true" : undefined}
+      title={title}
+      className="flex shrink-0 cursor-pointer flex-col items-center bg-transparent border-0 transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring rounded-[var(--radius-input)]"
+      style={{ gap: "var(--sp-1)", padding: "var(--sp-1) var(--sp-0_5)", width: "var(--sp-16)" }}
+    >
+      {children}
+      <span
+        className="text-caption w-full truncate text-center"
+        style={{ color: ariaCurrent ? "var(--fg)" : "var(--fg-3)" }}
+      >
+        {label}
+      </span>
+    </button>
+  );
+}
+
+function EdgeFade({ side }: { side: "left" | "right" }) {
+  return (
+    <div
+      aria-hidden
+      style={{
+        position: "absolute",
+        top: 0,
+        bottom: 0,
+        left: side === "left" ? 0 : undefined,
+        right: side === "right" ? 0 : undefined,
+        width: "var(--sp-6)",
+        pointerEvents: "none",
+        background: `linear-gradient(to ${side === "left" ? "right" : "left"}, var(--bg), transparent)`,
+      }}
+    />
+  );
+}

--- a/packages/web/src/pages/agent-detail/context-bar.tsx
+++ b/packages/web/src/pages/agent-detail/context-bar.tsx
@@ -1,35 +1,42 @@
-/**
- * Sticky context bar for the agent detail page. Renders the fixed
- * "Runs on <runtime> @ <computer>" strap so the operator always knows which
- * runtime + binding the page is editing once they've scrolled past the top
- * header (which surfaces the same facts plus model/sessions tiles).
- *
- * Model is intentionally NOT shown here — it is already present in the always-
- * visible top header tiles, so duplicating it adds noise without information.
- *
- * The bar sits **inside** the scrollable main column directly under the page
- * header, so the breadcrumb+title stays at the top (only this bar sticks).
- *
- * Visibility is driven by the parent (see `AgentDetailPage`): an
- * IntersectionObserver on a sentinel at the bottom of the top header toggles
- * `visible`, avoiding first-screen duplication.
- */
+import { Avatar } from "../../components/avatar.js";
+import { PresenceChip, runtimeStateToPresence } from "../../components/ui/presence-chip.js";
 
+/**
+ * Sticky identity bar for the agent detail page. Once the operator scrolls past
+ * the top header (which carries the switcher + title), this bar takes over to
+ * keep "which agent am I looking at" visible: avatar + name + presence.
+ *
+ * It used to repeat "Runs on <runtime> @ <computer>", which duplicated the
+ * Environment tab's Execution section. Identity is the thing that actually needs
+ * to stay pinned while scrolling a long tab.
+ *
+ * The top switcher and this bar never show at once — the bar is gated by an
+ * IntersectionObserver on a sentinel under the header (see `AgentDetailPage`),
+ * so it only appears after the switcher has scrolled away.
+ */
 export type ContextBarProps = {
-  runtimeLabel: string;
-  computerLabel: string | null;
-  /**
-   * When false, the bar is not rendered at all. Defaults to true so callers
-   * that don't want visibility control get the always-on behaviour.
-   */
+  displayName: string;
+  avatarImageUrl?: string | null;
+  avatarColorToken?: string | null;
+  /** Stable seed for the fallback avatar color (the agent uuid). */
+  seed: string;
+  runtimeState: string | null | undefined;
+  /** When false, the bar is not rendered at all. */
   visible?: boolean;
 };
 
-export function ContextBar({ runtimeLabel, computerLabel, visible = true }: ContextBarProps) {
+export function ContextBar({
+  displayName,
+  avatarImageUrl,
+  avatarColorToken,
+  seed,
+  runtimeState,
+  visible = true,
+}: ContextBarProps) {
   if (!visible) return null;
   return (
     <div
-      className="sticky z-20 flex items-center justify-between gap-3 backdrop-blur"
+      className="sticky z-20 flex items-center gap-2 backdrop-blur"
       style={{
         top: 0,
         padding: "var(--sp-1_75) var(--sp-5)",
@@ -37,19 +44,11 @@ export function ContextBar({ runtimeLabel, computerLabel, visible = true }: Cont
         borderBottom: "var(--hairline) solid var(--border-faint)",
       }}
     >
-      <div className="mono text-caption flex items-center gap-2" style={{ color: "var(--fg-3)" }}>
-        <span>
-          Runs on <span style={{ color: "var(--fg-2)" }}>{runtimeLabel}</span>
-        </span>
-        {computerLabel && (
-          <>
-            <span style={{ color: "var(--fg-4)" }} aria-hidden>
-              @
-            </span>
-            <span style={{ color: "var(--fg-2)" }}>{computerLabel}</span>
-          </>
-        )}
-      </div>
+      <Avatar src={avatarImageUrl} name={displayName} size={20} colorToken={avatarColorToken} seed={seed} />
+      <span className="text-body font-medium min-w-0 flex-1 truncate" style={{ color: "var(--fg)" }}>
+        {displayName}
+      </span>
+      <PresenceChip status={runtimeStateToPresence(runtimeState)} className="shrink-0" />
     </div>
   );
 }

--- a/packages/web/src/pages/agent-detail/tabs.ts
+++ b/packages/web/src/pages/agent-detail/tabs.ts
@@ -1,0 +1,62 @@
+import type { Agent } from "@first-tree/shared";
+import { canManageAgentDetail } from "./access.js";
+
+export type TabDef = { key: string; label: string; path: string };
+
+// IA labels only. Routing `path` and the `key` (draft / deep-link mapping) are
+// kept stable so existing URLs and SECTION_TO_TAB keep resolving.
+const TAB_LABELS: Record<string, string> = {
+  profile: "Profile",
+  runtime: "Environment",
+  prompt: "Instructions",
+  capabilities: "Tools & skills",
+  usage: "Usage",
+};
+
+/**
+ * Single source of truth for WHICH tabs exist for an agent (key + path),
+ * independent of label/order. `buildTabs` adds the display label on top, and the
+ * agent switcher uses this to know whether a target agent supports the current
+ * tab — so the two can never drift on tab availability.
+ */
+export function tabKeysFor(canEditConfig: boolean, isHuman: boolean): { key: string; path: string }[] {
+  const tabs: { key: string; path: string }[] = [{ key: "profile", path: "profile" }];
+  if (canEditConfig) {
+    tabs.push(
+      { key: "runtime", path: "runtime" },
+      { key: "prompt", path: "prompt" },
+      { key: "capabilities", path: "capabilities" },
+    );
+  } else if (!isHuman) {
+    tabs.push({ key: "capabilities", path: "capabilities" });
+  }
+  // Usage is an observation surface, kept last; human-type agents have no token usage.
+  if (!isHuman) {
+    tabs.push({ key: "usage", path: "usage" });
+  }
+  return tabs;
+}
+
+export function buildTabs(canEditConfig: boolean, isHuman: boolean): TabDef[] {
+  return tabKeysFor(canEditConfig, isHuman).map((t) => ({ ...t, label: TAB_LABELS[t.key] ?? t.key }));
+}
+
+/** Mirror of the shell's `canEditConfig` derivation, for any agent (e.g. switcher targets). */
+export function canEditConfigFor(agent: Agent, memberId: string | null, role: string | null): boolean {
+  return agent.type !== "human" && canManageAgentDetail(agent, memberId, role);
+}
+
+/**
+ * Which tab PATH to open when switching to `agent`: keep the current tab when the
+ * target supports it, else fall back to profile. (Some tabs render blank rather
+ * than redirect for unsupported agents, so we resolve this up front.)
+ */
+export function resolveTabPath(
+  agent: Agent,
+  memberId: string | null,
+  role: string | null,
+  currentPath: string,
+): string {
+  const paths = tabKeysFor(canEditConfigFor(agent, memberId, role), agent.type === "human").map((t) => t.path);
+  return paths.includes(currentPath) ? currentPath : "profile";
+}

--- a/packages/web/src/pages/team/agent-filter.ts
+++ b/packages/web/src/pages/team/agent-filter.ts
@@ -1,0 +1,40 @@
+import type { Agent } from "@first-tree/shared";
+
+/**
+ * The agent-only "All | Mine" scope, shared between the Team page (where it's
+ * toggled) and the agent-detail switcher (which follows it read-only). Single
+ * source of truth for the persisted preference + the membership predicate so the
+ * two surfaces can never drift.
+ */
+export type AgentFilter = "all" | "mine";
+
+const AGENT_FILTER_STORAGE_KEY = "first-tree:team-agent-filter:v1";
+
+export function readAgentFilterPreference(): AgentFilter {
+  if (typeof window === "undefined") return "all";
+  try {
+    const stored = window.localStorage?.getItem?.(AGENT_FILTER_STORAGE_KEY);
+    return stored === "mine" ? "mine" : "all";
+  } catch {
+    return "all";
+  }
+}
+
+export function writeAgentFilterPreference(next: AgentFilter): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage?.setItem?.(AGENT_FILTER_STORAGE_KEY, next);
+  } catch {
+    // Preference storage is best-effort; the current in-memory filter still works.
+  }
+}
+
+/**
+ * Whether an agent falls inside the current scope. "all" matches everything;
+ * "mine" matches only agents the viewer manages. (Visibility filtering is a
+ * separate, page-specific concern and is NOT folded in here.)
+ */
+export function matchesAgentScope(agent: Agent, filter: AgentFilter, selfMemberId: string | null): boolean {
+  if (filter === "all") return true;
+  return agent.managerId === selfMemberId;
+}

--- a/packages/web/src/pages/team/index.tsx
+++ b/packages/web/src/pages/team/index.tsx
@@ -29,6 +29,12 @@ import { Label } from "../../components/ui/label.js";
 import { PageHeader } from "../../components/ui/page-header.js";
 import { useMemberNameMap } from "../../lib/use-member-name-map.js";
 import { formatRelative } from "../../lib/utils.js";
+import {
+  type AgentFilter,
+  matchesAgentScope,
+  readAgentFilterPreference,
+  writeAgentFilterPreference,
+} from "./agent-filter.js";
 import { type AgentRow, type HumanRow, type RowAction, TeamTable } from "./team-table.js";
 
 /**
@@ -64,8 +70,6 @@ type MemberEditTarget = {
   role: string;
 };
 
-type AgentFilter = "all" | "mine";
-
 /** Target for the suspend / delete confirm dialogs (adopted from main PR 673). */
 type AgentLifecycleTarget = {
   uuid: string;
@@ -74,26 +78,6 @@ type AgentLifecycleTarget = {
 
 const AGENT_PAGE_SIZE = 100;
 const MAX_AGENT_PAGES = 100;
-const AGENT_FILTER_STORAGE_KEY = "first-tree:team-agent-filter:v1";
-
-function readAgentFilterPreference(): AgentFilter {
-  if (typeof window === "undefined") return "all";
-  try {
-    const stored = window.localStorage?.getItem?.(AGENT_FILTER_STORAGE_KEY);
-    return stored === "mine" ? "mine" : "all";
-  } catch {
-    return "all";
-  }
-}
-
-function writeAgentFilterPreference(next: AgentFilter): void {
-  if (typeof window === "undefined") return;
-  try {
-    window.localStorage?.setItem?.(AGENT_FILTER_STORAGE_KEY, next);
-  } catch {
-    // Preference storage is best-effort; the current in-memory filter still works.
-  }
-}
 
 export async function fetchAllAgents(
   fetchPage: (params: { limit: number; cursor?: string }) => Promise<{ items: Agent[]; nextCursor: string | null }>,
@@ -484,7 +468,7 @@ export function buildTeamData(args: {
     // Members only see their own private agents; admins see all.
     if (a.visibility === "private" && !isAdmin && a.managerId !== selfMemberId) return false;
     // `Mine` filter: across both groups, only agents the viewer manages.
-    if (filter === "mine" && a.managerId !== selfMemberId) return false;
+    if (!matchesAgentScope(a, filter, selfMemberId)) return false;
     return matchAgent(a);
   };
 


### PR DESCRIPTION
## What & why

PR3 of 3 in the agent-detail optimization — the **agent switcher + top-bar chrome** pass. **Stacked on PR2** (#871): base is `feat/agent-detail-pr2-save-behavior`, so review only the incremental diff here. Lands after PR1 → PR2.

Goal: replace the breadcrumb with a fast agent switcher, and stop the ContextBar from duplicating the Execution section.

## Changes

- **Agent switcher (vertical-B)** — new `agent-switcher-strip.tsx` replaces the breadcrumb: a horizontal strip of avatar-over-name items, leftmost `‹ Team`, the current agent selected (brand ring + presence dot). Switching agents / going to Team routes through the page's `guardedNavigate` (PR2), so an unsaved config draft prompts a confirm; the selected agent is a no-op (not a "leave"). Overflow scrolls with edge fades; the active item is kept in horizontal view; names truncate with a title tooltip.
- **Scope follows All/Mine, single source of truth** — extracted the `AgentFilter` type / storage key / read+write + the membership predicate into `pages/team/agent-filter.ts`; the Team page now consumes it (zero behavior change). Read-on-mount (the toggle only lives on the Team page, where this strip is unmounted). The current agent is always included even when scope would exclude it, and is rendered from the live (10s-polled) agent prop so the selected chip never lags the header.
- **Current tab preserved on switch** — falls back to profile when the target agent doesn't support it. New `tabs.ts` is now the single source of tab existence: `buildTabs` derives from `tabKeysFor`, and the switcher uses the same to resolve the target path.
- **Page remounts on agent switch** — `AgentDetailPage` keys an inner `AgentDetailPageView` by `:uuid`. The switcher navigates in place (only the param changes), so without this the previous agent's config draft / pending-nav / dialog state would leak into the next agent (`useConfigDraft` only re-seeds from null).
- **ContextBar → identity** — was "Runs on \<runtime\> @ \<computer\>" (duplicated Execution); now avatar + name + presence. It only appears after the switcher scrolls away (sentinel IntersectionObserver), so the two never overlap.
- **Header chrome converged** — presence (already labelled) + active-session count folded into one status cluster.

## Review (2 independent rounds, codex)

- **R1:** caught a real **[P1]** — in-place agent switch leaked the previous agent's config draft (fixed via the uuid-keyed remount above) — and a **[P2]** — clicking the already-selected agent tripped the leave guard (now a no-op).
- **R2 (challenge):** no P1; 4 fixed — selected chip used the unpolled query row (now the live agent prop + 10s poll on the switcher query); `scrollIntoView` could scroll the page vertically (now horizontal-only `scrollLeft`); ContextBar `truncate` needed `min-w-0 flex-1`; `resolveTabPath` received the tab key not the path (now the real path).

## Testing

- Switcher render/scope + leave-guard-on-switch tests; ContextBar identity test; DEV `/preview/agent-detail` gains a switcher panel (verified via headless browser).
- Gates (full repo): `biome check` (1194) · typecheck (11 pkgs) · `lint:tokens` · web tests **694**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
