### PR TITLE
fix(web): suppress agent-detail TabBar vertical scrollbar (overflow-y:hidden)

### DIFF
--- a/packages/web/src/components/ui/tab-bar.tsx
+++ b/packages/web/src/components/ui/tab-bar.tsx
@@ -18,12 +18,13 @@ export const TabBar = forwardRef<HTMLDivElement, TabBarProps>(function TabBar({ 
       className={cn("flex items-end", className)}
       style={{
         gap: 2,
-        // minHeight (not a fixed height): the active Tab uses marginBottom:-1 to
-        // overlap the bar's bottom border, making its content one pixel taller
-        // than the row. With a fixed height + a horizontally-scrolling consumer
-        // (overflowX:auto coerces overflow-y from visible to auto), that extra
-        // pixel surfaced a spurious VERTICAL scrollbar. Letting the bar grow to
-        // its content removes the overflow without clipping the focus ring/underline.
+        // minHeight (not a fixed height) so the bar grows with its content / focus
+        // ring. NOTE: the active Tab's marginBottom:-1 makes its border-box one
+        // pixel taller than the bar, and a horizontally-scrolling consumer
+        // (overflowX:auto) coerces overflow-y to auto → a spurious VERTICAL
+        // scrollbar over that extra pixel. minHeight does NOT fix that; the
+        // consumer must also set overflowY:hidden
+        // (see TabsNav in agent-detail.tsx).
         minHeight: 34,
         padding: "0 var(--sp-5)",
         borderBottom: "var(--hairline) solid var(--border)",

--- a/packages/web/src/pages/agent-detail.tsx
+++ b/packages/web/src/pages/agent-detail.tsx
@@ -761,7 +761,13 @@ function TabsNav({
         ref={scrollRef}
         role="tablist"
         aria-label="Agent configuration sections"
-        style={{ overflowX: "auto" }}
+        // overflowY:hidden (not just minHeight): the active Tab's marginBottom:-1
+        // makes its border-box one pixel taller than the bar, and overflowX:auto
+        // coerces overflow-y from visible to auto → a spurious VERTICAL scrollbar
+        // over that extra pixel. Hiding overflow-y suppresses the scrollbar while
+        // keeping the active underline on the baseline and the focus ring intact
+        // (verified visually).
+        style={{ overflowX: "auto", overflowY: "hidden" }}
         onScroll={updateEdges}
       >
         {tabs.map((t) => {


### PR DESCRIPTION
## What & why

The agent-detail TabBar still showed a spurious **vertical scrollbar** (reported after the earlier `minHeight` change, which did **not** fix it).

**Root cause:** the active `Tab` uses `marginBottom:-1` to overlap the bar's bottom border, making its border-box one pixel taller than the bar. The TabsNav consumer sets `overflow-x:auto` for horizontal scrolling, which coerces `overflow-y` from `visible` to `auto` → a scrollbar appears over that one-pixel overflow. `minHeight` can't fix this (the overhang is independent of the bar's height).

**Fix:** add `overflow-y: hidden` to the TabsNav scroll container (`agent-detail.tsx`). Also corrected the now-inaccurate `minHeight` comment in `tab-bar.tsx`.

## Verification (visual — the part the earlier fix missed)

A DOM test can't see a scrollbar, so this was verified in the browser (DEV preview, isolated repro of the real `TabBar` + active `Tab` in a narrow `overflow-x:auto` container, buggy vs fixed side by side):

1. **Scrollbar gone** — buggy bar: `overflow-y:auto` + `scrollHeight(70) > clientHeight(69)` → scrollbar; fixed bar: same one-pixel overflow but `overflow-y:hidden` → no scrollbar.
2. **Active underline stays on the baseline** — unchanged in both (the rejected `padding-bottom:1px` alternative lifts it off the baseline).
3. **Focus ring intact** — a focused tab in the fixed bar renders its full ring, not clipped (and `overflow-x:auto` already coerced `overflow-y` to auto before, so this is no worse than shipped behavior).

(The repro was temporary and is **not** part of this diff.)

## Diff

Two lines of style/comment: `overflow-y: hidden` on the TabsNav `TabBar` style + corrected comments. No logic change.

Gates: `biome check` (1196) · typecheck (11 pkgs) · `lint:tokens` · web tests **694**. codex review: no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
