### PR TITLE
fix(chat): require an explicit recipient for group-chat sends

### DIFF
--- a/apps/cli/src/commands/chat/send.ts
+++ b/apps/cli/src/commands/chat/send.ts
@@ -9,7 +9,6 @@ interface SendOptions {
   format: MessageFormat;
   metadata?: string;
   agent?: string;
-  broadcast?: boolean;
   request?: boolean;
   question?: string;
   option?: string[];
@@ -27,13 +26,12 @@ export function registerChatSendCommand(chat: Command): void {
     .description(
       "Send a message into the caller's current chat (FIRST_TREE_CHAT_ID). <name> is any participant — agent or " +
         "human; the recipient is @mentioned and woken (must already be a participant — `chat invite` an agent " +
-        "first). With --broadcast the message enters the stream but wakes no one. Use --request to ask a human an " +
+        "first). A message must name a recipient — there is no no-mention send. Use --request to ask a human an " +
         "open question, --reply-to to answer one.",
     )
     .option("-f, --format <format>", "Message format (text|markdown|card)", "text")
     .option("-m, --metadata <json>", "JSON metadata to attach")
     .option("--agent <name>", "Agent name on the First Tree server (default: first configured on this client)")
-    .option("-b, --broadcast", "Send with no @mention — enters the stream, wakes no one")
     .option(
       "--request",
       "Send as an open question (format=request) directed at a single human <name>. The message body carries the " +
@@ -55,17 +53,15 @@ export function registerChatSendCommand(chat: Command): void {
           );
         }
 
-        // Resolve target vs broadcast. In --broadcast mode there is no
-        // recipient, so the first positional is actually the message.
-        const broadcast = options.broadcast === true;
-        const target = broadcast ? undefined : name;
-        const inlineBody = broadcast ? (message ?? name) : message;
+        // Every send names a recipient: the first positional is the target,
+        // the second is the message body.
+        const target = name;
+        const inlineBody = message;
 
-        if (!broadcast && !target) {
+        if (!target) {
           fail(
             "NO_TARGET",
-            "Pass <name> to @mention a recipient, or use --broadcast to send with no @mention " +
-              "(enters the stream, wakes no one).",
+            "Pass <name> to @mention a recipient — a message must name a recipient (there is no no-mention send).",
             2,
           );
         }
@@ -140,14 +136,11 @@ export function registerChatSendCommand(chat: Command): void {
           source: "cli",
           // Server resolves the name against the chat's participant list and
           // adds it to mentions; an unknown name fails with a `chat invite`
-          // hint. Omitted in --broadcast mode → no @mention, no wake-up.
+          // hint.
           ...(target ? { receiverNames: [target] } : {}),
           // Answer/thread a prior message; the server's open-question counter
           // decrements off exactly this when the target answers a request.
           ...(options.replyTo ? { inReplyTo: options.replyTo } : {}),
-          // Explicit broadcast: enter the stream, wake no one, skip the
-          // group-chat @mention guard server-side.
-          ...(broadcast ? { broadcast: true } : {}),
         });
         success(result);
       } catch (error) {

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -249,7 +249,6 @@ first-tree chat
 ├── send <name> [message]                            # recipient is any participant (agent or human)
 │     --request / --question / --option              #   structured ask directed at a human
 │     --reply-to <messageId>                         #   answer/thread a question; clears red-dot
-│     --broadcast                                    #   enter the stream, wake no one
 ├── invite <agentName>                               # add to FIRST_TREE_CHAT_ID before send
 ├── list
 ├── history <chatId>

--- a/docs/development/comms-behavior-cases.md
+++ b/docs/development/comms-behavior-cases.md
@@ -34,7 +34,6 @@ Outcome vocabulary (`assert` references these):
 |---|---|
 | `REQUEST(human)` | `chat send <human> --request --question "..." [--option ...]` — a tracked ask (**human recipient only**; the server rejects a request directed at an agent) |
 | `SEND(agent)` | plain `chat send <agent> "..."` — wakes an agent |
-| `BROADCAST` | `chat send --broadcast "..."` — enters stream, wakes no one |
 | `FINAL_TEXT` | normal turn output, auto-bridged to the chat |
 | `SILENT` | empty output (silent-turn protocol) |
 | `¬X` | must NOT do X |

--- a/packages/client/src/runtime/agent-briefing.ts
+++ b/packages/client/src/runtime/agent-briefing.ts
@@ -265,9 +265,11 @@ participant \`type\` in the Current Chat Context block):
 - Plain reply / narration to a **human** → final text is enough; it is
   auto-delivered to the chat. Do **not** *also* fire a plain \`${bin} chat send\`
   to the same human — that double-posts. (The bullets above cover when an
-  explicit send is the right call: waking an agent, a \`--request\`, a broadcast.)
-- A note that should enter the stream but wake no one → \`${bin} chat send
-  --broadcast "..."\`.
+  explicit send is the right call: waking an agent or a \`--request\`.)
+
+Every \`chat send\` names a recipient — there is no no-mention send. A group
+chat rejects a message that addresses no one; pass \`<name>\` to @mention the
+recipient.
 
 **Fallback** (if the Current Chat Context block is missing — context
 injection may have failed): use conservative mode — all cross-agent
@@ -279,7 +281,7 @@ function workspaceCollaborationBlock(bin: string): string {
   return `## Workspace Collaboration
 
 For the full \`chat send\` / \`chat invite\` CLI usage — every mode
-(\`--request\` / \`--question\` / \`--broadcast\`), syntax,
+(\`--request\` / \`--question\`), syntax,
 markdown / stdin, reaching non-members, mention resolution — load the top-level
 **\`first-tree\` skill** (and its \`references/agent-communication.md\`).
 The skill's \`description\` triggers progressive disclosure whenever the

--- a/packages/server/src/__tests__/mention-fanout.test.ts
+++ b/packages/server/src/__tests__/mention-fanout.test.ts
@@ -265,13 +265,13 @@ describe("server routing + fan-out filter (explicit mentions only)", () => {
     expect(await inboxEntriesFor(app, chat.id, obsA.uuid)).toHaveLength(1);
   });
 
-  it("broadcast bypasses enforceMention: no @ enters the stream but wakes no one", async () => {
-    // proposal §D6 — explicit no-mention broadcast. Under enforceMention a
-    // no-recipient send is rejected; `broadcast: true` is the opt-in that
-    // lets it through, and it must still wake nobody.
+  it("rejects a no-recipient send under enforceMention: there is no no-mention path", async () => {
+    // A group chat has no no-recipient send. A message that names no one is
+    // rejected regardless of caller — there is no broadcast opt-in that lets
+    // an un-addressed message through.
     const app = getApp();
     const uid = crypto.randomUUID().slice(0, 6);
-    const { sender, obsA, chat } = await setupGroup(app, uid);
+    const { sender, chat } = await setupGroup(app, uid);
 
     await expect(
       sendMessage(
@@ -282,15 +282,5 @@ describe("server routing + fan-out filter (explicit mentions only)", () => {
         { enforceMention: true },
       ),
     ).rejects.toThrow(/recipient/i);
-
-    const { message } = await sendMessage(
-      app.db,
-      chat.id,
-      sender.agent.uuid,
-      { source: "api", format: "text", content: "we shipped", broadcast: true },
-      { enforceMention: true },
-    );
-    expect(message.id).toBeTruthy();
-    expect(await inboxEntriesFor(app, chat.id, obsA.uuid)).toHaveLength(0);
   });
 });

--- a/packages/server/src/services/message.ts
+++ b/packages/server/src/services/message.ts
@@ -320,8 +320,8 @@ async function sendMessageInner(
     //
     // `agent-final-text` profile rationale:
     //   - skip mention enforcement (final-text is the one legal mentions-
-    //     empty case: handler-initiated forward, not a user-typed
-    //     broadcast).
+    //     empty case: a handler-initiated forward of the agent's own response
+    //     for human observers, not a message addressed into the room).
     //   - force every fan-out row to notify=false (final text lands in
     //     chat history for human observers but never wakes another
     //     session). v1 §四 改造 4 (b) bypass channel.
@@ -351,11 +351,10 @@ async function sendMessageInner(
     // `purposeProfile.skipMentionEnforcement` — final-text is silent-by-
     // construction so it never needs to name a recipient.
     //
-    // `data.broadcast` is the explicit opt-in broadcast intent (CLI
-    // `chat send --broadcast`, web no-`@` send): enter the stream, wake no
-    // one. It deliberately bypasses the guard — a broadcast names no
-    // recipient by definition. See proposals/group-chat-unified-send §D6.
-    if (options.enforceMention && !purposeProfile.skipMentionEnforcement && !data.broadcast) {
+    // There is no no-recipient send path: a group chat rejects any send that
+    // names no one. The only mentions-empty exception is `agent-final-text`
+    // above (an agent's own response for humans, not a message into the room).
+    if (options.enforceMention && !purposeProfile.skipMentionEnforcement) {
       const recipientMentions = mergedMentions.filter((id) => id !== senderId);
       const hasAddressed = (options.addressedToAgentIds?.length ?? 0) > 0;
       if (recipientMentions.length === 0 && !hasAddressed) {

--- a/packages/shared/src/schemas/message.ts
+++ b/packages/shared/src/schemas/message.ts
@@ -92,8 +92,8 @@ export type OpenQuestionRequest = z.infer<typeof openQuestionRequestSchema>;
  *     reply text (today: `runtime/result-sink.ts`). Lands in chat history
  *     so human observers in the web UI can see what the agent is doing,
  *     but does not wake other agents and is not subject to the group-chat
- *     `@mention required` guard — it is not a user-typed group broadcast.
- *     v1 §四 改造 4 (b) bypass channel.
+ *     `@mention required` guard — it is an agent's own response surfaced
+ *     for humans, not a message addressed into the room.
  *
  * Default-`undefined` means a regular agent-initiated send (CLI `chat send`,
  * adapter, etc.) and goes through the normal enforcement profile.
@@ -118,15 +118,6 @@ export const sendMessageSchema = z.object({
    */
   source: messageSourceSchema.default("api"),
   purpose: messagePurposeSchema.optional(),
-  /**
-   * Explicit broadcast intent: enter the chat stream but wake no one and
-   * skip the group-chat `@mention required` guard. Opt-in — set by the CLI
-   * `chat send --broadcast` and the web composer's no-`@` send. Distinct from
-   * `purpose: "agent-final-text"` (which is a runtime-internal forward); this
-   * is a deliberate human/agent broadcast ("我搞完了 / 立场宣布"). See
-   * proposals/group-chat-unified-send §D6.
-   */
-  broadcast: z.boolean().optional(),
   /**
    * Recipient agent names that the server should resolve to uuids against
    * the chat's participant list and add to the message's `mentions`. Lets

--- a/packages/web/src/api/chats.ts
+++ b/packages/web/src/api/chats.ts
@@ -85,14 +85,13 @@ export function sendChatMessage(
   chatId: string,
   content: string,
   mentions: string[],
-  opts?: { inReplyTo?: string; broadcast?: boolean },
+  opts?: { inReplyTo?: string },
 ): Promise<Message> {
   return api.post<Message>(`/chats/${encodeURIComponent(chatId)}/messages`, {
     format: "text",
     content,
     ...(mentions.length > 0 ? { metadata: { mentions } } : {}),
     ...(opts?.inReplyTo ? { inReplyTo: opts.inReplyTo } : {}),
-    ...(opts?.broadcast ? { broadcast: true } : {}),
   });
 }
 

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -1129,20 +1129,9 @@ export function ChatView({
   );
 
   const sendMut = useMutation({
-    mutationFn: ({
-      content,
-      mentions,
-      broadcast,
-      inReplyTo,
-    }: {
-      content: string;
-      mentions: string[];
-      broadcast?: boolean;
-      inReplyTo?: string;
-    }) => {
-      const opts = { ...(broadcast ? { broadcast: true } : {}), ...(inReplyTo ? { inReplyTo } : {}) };
-      return Object.keys(opts).length > 0
-        ? sendChatMessage(chatId, content, mentions, opts)
+    mutationFn: ({ content, mentions, inReplyTo }: { content: string; mentions: string[]; inReplyTo?: string }) => {
+      return inReplyTo
+        ? sendChatMessage(chatId, content, mentions, { inReplyTo })
         : sendChatMessage(chatId, content, mentions);
     },
     // Optimistic insert: render the user's row above the composer immediately
@@ -1237,22 +1226,20 @@ export function ChatView({
     // nothing and the button stays disabled, prompting the user to use
     // the `[+]` button or the autocomplete picker.
 
-    // Group-chat send guard: don't fire requests we know the server (with
-    // proposal §3 enforcement) or downstream `mention_only` agents will drop.
-    // Applies to image-only sends too — the server-side mention check runs
-    // per message regardless of format, so an image without an addressee
-    // would 400 just like a text without an addressee (issue 387). Surface
-    // a hint when the user has only attached images so the silent-return
-    // doesn't look like a stuck send.
-    // No @mention in a group chat = an explicit BROADCAST: enter the stream,
-    // wake no one (proposal §D6). Text sends fall through with `broadcast`;
-    // image sends still need an addressee (the image fan-out path has no
-    // broadcast affordance yet), so keep the hint-and-return for those.
-    const broadcasting = requiresMention && draftMentions.length === 0;
-    if (broadcasting && images.length > 0) {
-      // English matches the other uploadError strings in this file
-      // (Failed to send image / Failed to add participants / Image too large).
-      setUploadError("@mention a group member in the text — images will be addressed to the same recipient(s).");
+    // Group-chat send guard: a multi-speaker chat has no no-recipient send
+    // path — every message must @mention at least one member. The send button
+    // is already disabled in this state (see the `disabled` prop below), so
+    // this is the Enter-key / programmatic backstop. Applies to image-only
+    // sends too: the server's mention check runs per message regardless of
+    // format, so an un-addressed image would 400 just like un-addressed text.
+    // Surface a hint when the user has only attached images so the
+    // silent-return doesn't look like a stuck send.
+    if (requiresMention && draftMentions.length === 0) {
+      if (images.length > 0) {
+        // English matches the other uploadError strings in this file
+        // (Failed to send image / Failed to add participants / Image too large).
+        setUploadError("@mention a group member in the text — images will be addressed to the same recipient(s).");
+      }
       return;
     }
 
@@ -1391,15 +1378,11 @@ export function ChatView({
 
     // Auto-thread an answer: a plain reply that @-mentions the agent which
     // asked an open question directed at me counts as the answer (proposal
-    // §D2) — attach `inReplyTo` so the server clears the red dot. Skipped for
-    // broadcasts (no mentions).
-    const answeredRequestId = broadcasting
-      ? undefined
-      : (findAnswerableRequestId(mergedMessages, myAgentId, effectiveSendMentions) ?? undefined);
+    // §D2) — attach `inReplyTo` so the server clears the red dot.
+    const answeredRequestId = findAnswerableRequestId(mergedMessages, myAgentId, effectiveSendMentions) ?? undefined;
     sendMut.mutate({
       content: text,
       mentions: effectiveSendMentions,
-      broadcast: broadcasting,
       inReplyTo: answeredRequestId,
     });
   };
@@ -3162,18 +3145,24 @@ export function ChatView({
                           <button
                             type="button"
                             onClick={handleSend}
-                            disabled={sendMut.isPending || uploading || (!draft.trim() && pendingImages.length === 0)}
+                            disabled={
+                              sendMut.isPending ||
+                              uploading ||
+                              (!draft.trim() && pendingImages.length === 0) ||
+                              (requiresMention && draftMentions.length === 0)
+                            }
                             title={
                               requiresMention && draftMentions.length === 0
-                                ? draft.trim()
-                                  ? "Broadcast — no @mention, enters the stream and wakes no one"
-                                  : "@mention a member, or type a message to broadcast"
+                                ? "@mention a member to send — a group message must address someone"
                                 : "Send (Enter)"
                             }
                             aria-label="Send"
                             className={cn(
                               "inline-flex items-center justify-center transition-opacity",
-                              (sendMut.isPending || uploading || (!draft.trim() && pendingImages.length === 0)) &&
+                              (sendMut.isPending ||
+                                uploading ||
+                                (!draft.trim() && pendingImages.length === 0) ||
+                                (requiresMention && draftMentions.length === 0)) &&
                                 "opacity-40 cursor-not-allowed",
                             )}
                             style={{

--- a/skills/first-tree/references/agent-communication.md
+++ b/skills/first-tree/references/agent-communication.md
@@ -53,13 +53,15 @@ Pick the mode by what you need back:
 | Plain | `chat send <name> "..."` | Wake / answer a specific participant in this chat. |
 | Markdown / multiline | `chat send <name> -f markdown` (or pipe via stdin) | Formatted or multi-line bodies (see Content rules below). |
 | **Ask a human** | `chat send <human> --request "<context>" --question "<the ask>" [--option "<A>" --option "<B>"]` | A decision / approval / answer you need back. Raises a tracked open question (red-dot / open-request count). `--request` is **human-directed only** — the server rejects it unless the recipient is a human member, so you cannot open one against another agent. It needs both a body (context) and `--question` (the bare ask). |
-| Broadcast | `chat send --broadcast "..."` | Enter the stream, wake no one (no `@mention`). |
+
+Every `chat send` names a recipient — there is no no-mention send. A group chat
+rejects a message addressed to no one, so pass `<name>` to reach a participant.
 
 Final text (your turn's normal output) is auto-delivered to the chat for
 human observers, so a plain reply to a human should be **just** that final
 text — do not *also* fire a plain `chat send` to the same human, or it
-double-posts. Reach for `chat send` when you need to wake an agent, ask a
-human something tracked (`--request`), or post a no-wake note (`--broadcast`).
+double-posts. Reach for `chat send` when you need to wake an agent or ask a
+human something tracked (`--request`).
 
 You never answer an open question yourself: a request can only be directed at a
 human, so when you ask one, the human's answer arrives back as an ordinary


### PR DESCRIPTION
## What

A **group (multi-speaker) chat now requires an explicit recipient to send** — there is no more no-mention "broadcast" path. A message that addresses no one is rejected at both the composer and the server, and the broadcast affordance is removed end to end.

| Scenario | Send with no `@` in the composer |
|---|---|
| **Group** (≥3 speakers) | ❌ Send button disabled — must `@mention` at least one member |
| **1:1** (2 speakers) | ✅ Sends as before — the only other speaker is auto-addressed |

## Changes

- **server** (`services/message.ts`): drop the `broadcast` bypass in mention enforcement → an un-addressed send is rejected regardless of caller (Web/CLI/API). `agent-final-text` still bypasses (it's an agent's own response for humans, not a message into the room).
- **shared** (`schemas/message.ts`): remove the `broadcast` field from `sendMessageSchema`.
- **web** (`chat-view.tsx`): disable the send button + Enter backstop in group chats with no mention (text and image sends); remove the broadcast send path. `api/chats.ts` drops the `broadcast` option.
- **cli** (`chat/send.ts`): remove `-b/--broadcast`; `chat send` always names a recipient.
- **client** (`agent-briefing.ts`): the injected communication rules now say every send names a recipient; a group chat rejects a message addressed to no one.

## Why

Reverses the no-mention broadcast affordance (D6 / "广播≠喊人" from the group-chat-unified-send proposal). A mention-less send let a person or agent post a message that reached no one's inbox while looking like ordinary participation — a silent dead-end. Two-speaker chats keep implicit-peer addressing.

The proposal's own risk register pre-identified this as a rollback trigger ("no-mention 滥用 … 若上升明显则回收").

## Tree

Durable contract already updated and merged: `system/cloud/chat/messaging.md` (first-tree-context PR #460, approved).

## Verification

- `pnpm check` ✅ · `pnpm typecheck` 11/11 ✅
- shared 388 ✅ · CLI 6 ✅ · web 694 ✅
- server integration suites need Postgres (Docker) → run in CI. The `mention-fanout` broadcast-bypass case is rewritten to assert a no-recipient send is rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)