### PR TITLE
Fix WS auth handshake classification

### DIFF
--- a/apps/cli/src/__tests__/client-runtime-context-tree.test.ts
+++ b/apps/cli/src/__tests__/client-runtime-context-tree.test.ts
@@ -510,6 +510,12 @@ describe("ClientRuntime context-tree wiring", () => {
     if (!paused) throw new Error("auth:paused listener missing");
     paused("auth_refresh_failed", new Error("refresh rejected"));
     expect(print.status).toHaveBeenCalledWith("✗", "auth rejected — pausing agents until fresh credentials arrive.");
+    expect(print.status).toHaveBeenCalledWith("", "refresh rejected");
+    const structured = new Error("Server rejected access token");
+    Object.defineProperty(structured, "authCode", { value: "invalid_token" });
+    Object.defineProperty(structured, "authMessage", { value: "signature mismatch" });
+    paused("auth_rejected", structured);
+    expect(print.status).toHaveBeenCalledWith("", "Auth rejection code: invalid_token — signature mismatch");
     expect(rt.isPaused()).toBe(true);
 
     const resumed = connectionListeners.get("auth:resumed");

--- a/apps/cli/src/core/client-runtime.ts
+++ b/apps/cli/src/core/client-runtime.ts
@@ -38,6 +38,13 @@ export function isAgentSuspendedBindError(error: unknown): boolean {
   return msg.includes("agent_suspended");
 }
 
+function authPausedDetail(error: Error): string {
+  const authCode = "authCode" in error && typeof error.authCode === "string" ? error.authCode : null;
+  const authMessage = "authMessage" in error && typeof error.authMessage === "string" ? error.authMessage : null;
+  if (!authCode) return error.message;
+  return `Auth rejection code: ${authCode}${authMessage ? ` — ${authMessage}` : ""}`;
+}
+
 export type ClientRuntimeOptions = {
   /**
    * Version of the Command package this process was launched from. Passed to
@@ -142,7 +149,7 @@ export class ClientRuntime {
     this.connection.on("auth:paused", (reason, err) => {
       print.blank();
       print.status("✗", "auth rejected — pausing agents until fresh credentials arrive.");
-      print.status("", err.message);
+      print.status("", authPausedDetail(err));
       print.status("", "Recovery: get a new connect token from the First Tree web console");
       print.status("", "          (Computers → + New Connection), then re-run `first-tree login <token>`.");
       print.status("", `Paused reason: ${reason}. Process is staying alive — no restart needed after login.`);

--- a/packages/client/src/__tests__/auth-paused.test.ts
+++ b/packages/client/src/__tests__/auth-paused.test.ts
@@ -113,6 +113,35 @@ describe("ClientConnection — auth paused mode (Bug 2)", () => {
     await connection.disconnect();
   }, 10_000);
 
+  it("structured auth:rejected includes the rejection code in paused error", async () => {
+    wss.on("connection", (ws: WebSocket) => {
+      ws.on("message", (raw) => {
+        const msg = JSON.parse(String(raw)) as { type: string };
+        if (msg.type === "auth") {
+          ws.send(JSON.stringify({ type: "auth:rejected", code: "invalid_token", message: "signature mismatch" }));
+        }
+      });
+    });
+
+    const connection = new ClientConnection({
+      serverUrl,
+      clientId: "client_paused_rejected_structured",
+      getAccessToken: async () => "tok",
+    });
+
+    const pausedErrors: Error[] = [];
+    connection.on("auth:paused", (_reason, err) => pausedErrors.push(err));
+    connection.on("error", () => {});
+
+    await expect(connection.connect()).rejects.toThrow(/invalid_token/);
+    expect(connection.isPaused()).toBe(true);
+    expect(connection.getPausedReason()).toBe("auth_rejected");
+    expect(pausedErrors[0]?.message).toContain("invalid_token");
+    expect(pausedErrors[0]?.message).toContain("signature mismatch");
+
+    await connection.disconnect();
+  }, 10_000);
+
   it("clearPaused emits auth:resumed and re-arms reconnect", async () => {
     class AuthRefreshFailedError extends Error {
       constructor() {

--- a/packages/client/src/__tests__/client-connection-auth-classification.test.ts
+++ b/packages/client/src/__tests__/client-connection-auth-classification.test.ts
@@ -1,0 +1,119 @@
+import { createServer, type Server as HttpServer } from "node:http";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { type WebSocket, WebSocketServer } from "ws";
+import { ClientConnection } from "../client-connection.js";
+
+describe("ClientConnection — auth handshake classification", () => {
+  let httpServer: HttpServer;
+  let wss: WebSocketServer;
+  let serverUrl: string;
+
+  beforeEach(async () => {
+    httpServer = createServer();
+    wss = new WebSocketServer({ server: httpServer, path: "/api/v1/agent/ws/client" });
+    await new Promise<void>((resolve) => httpServer.listen(0, "127.0.0.1", resolve));
+    const addr = httpServer.address();
+    if (!addr || typeof addr === "string") throw new Error("no server address");
+    serverUrl = `http://127.0.0.1:${addr.port}`;
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => wss.close(() => resolve()));
+    await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+  });
+
+  it("auth:retryable reconnects with backoff and does not enter paused mode", async () => {
+    let attempts = 0;
+    const openTimes: number[] = [];
+    wss.on("connection", (ws: WebSocket) => {
+      const attempt = ++attempts;
+      openTimes.push(Date.now());
+      ws.on("message", (raw) => {
+        const msg = JSON.parse(String(raw)) as { type: string };
+        if (msg.type === "auth" && attempt === 1) {
+          ws.send(
+            JSON.stringify({
+              type: "auth:retryable",
+              code: "auth_backend_unavailable",
+              retryAfterMs: 1200,
+              message: "database unavailable",
+            }),
+          );
+          return;
+        }
+        if (msg.type === "auth") {
+          ws.send(JSON.stringify({ type: "auth:ok" }));
+          return;
+        }
+        if (msg.type === "client:register") {
+          ws.send(JSON.stringify({ type: "client:registered" }));
+        }
+      });
+    });
+
+    const connection = new ClientConnection({
+      serverUrl,
+      clientId: "client_retryable_auth",
+      getAccessToken: async () => "tok",
+    });
+
+    const paused: string[] = [];
+    connection.on("auth:paused", (reason) => paused.push(reason));
+    connection.on("error", () => {});
+
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0);
+    try {
+      await connection.connect();
+    } finally {
+      randomSpy.mockRestore();
+    }
+
+    expect(connection.isConnected).toBe(true);
+    expect(connection.isPaused()).toBe(false);
+    expect(paused).toEqual([]);
+    expect(attempts).toBe(2);
+    expect((openTimes[1] ?? 0) - (openTimes[0] ?? 0)).toBeGreaterThanOrEqual(1150);
+
+    await connection.disconnect();
+  }, 10_000);
+
+  it("close-before-ready 1013 reconnects and does not enter paused mode", async () => {
+    let attempts = 0;
+    wss.on("connection", (ws: WebSocket) => {
+      const attempt = ++attempts;
+      ws.on("message", (raw) => {
+        const msg = JSON.parse(String(raw)) as { type: string };
+        if (msg.type === "auth") {
+          ws.send(JSON.stringify({ type: "auth:ok" }));
+          return;
+        }
+        if (msg.type === "client:register" && attempt === 1) {
+          ws.close(1013, "try again later");
+          return;
+        }
+        if (msg.type === "client:register") {
+          ws.send(JSON.stringify({ type: "client:registered" }));
+        }
+      });
+    });
+
+    const connection = new ClientConnection({
+      serverUrl,
+      clientId: "client_retryable_1013",
+      getAccessToken: async () => "tok",
+    });
+
+    const paused: string[] = [];
+    connection.on("auth:paused", (reason) => paused.push(reason));
+    connection.on("error", () => {});
+
+    await connection.connect();
+
+    expect(connection.isConnected).toBe(true);
+    expect(connection.isPaused()).toBe(false);
+    expect(paused).toEqual([]);
+    expect(attempts).toBe(2);
+
+    await connection.disconnect();
+  }, 10_000);
+});

--- a/packages/client/src/client-connection.ts
+++ b/packages/client/src/client-connection.ts
@@ -4,7 +4,11 @@ import { hostname as getHostname, platform } from "node:os";
 import {
   type AgentBindRejectReason,
   type AgentPinnedMessage,
+  type AuthRejectedCode,
   agentPinnedMessageSchema,
+  authExpiredFrameSchema,
+  authRejectedFrameSchema,
+  authRetryableFrameSchema,
   type ClientPausedReason,
   type InboxDeliverFrame,
   inboxAckAcceptedFrameSchema,
@@ -239,6 +243,26 @@ export class ClientUserMismatchError extends Error {
   constructor(message = "Client belongs to a different user") {
     super(message);
     this.name = "ClientUserMismatchError";
+  }
+}
+
+class ServerAuthRejectedError extends Error {
+  readonly authCode: AuthRejectedCode | undefined;
+  readonly authMessage: string | undefined;
+
+  constructor(opts: { code?: AuthRejectedCode; message?: string; legacyReason?: string; unsupportedCode?: string }) {
+    const detail =
+      opts.code !== undefined
+        ? `code ${opts.code}${opts.message ? `: ${opts.message}` : ""}`
+        : opts.unsupportedCode !== undefined
+          ? `unsupported code ${opts.unsupportedCode}`
+          : opts.legacyReason !== undefined
+            ? `legacy reason: ${opts.legacyReason}`
+            : "legacy frame without code";
+    super(`Server rejected access token (auth:rejected, ${detail})`);
+    this.name = "ServerAuthRejectedError";
+    this.authCode = opts.code;
+    this.authMessage = opts.message;
   }
 }
 
@@ -797,9 +821,9 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
           // a fresh `connect()` once login succeeds.
           if (this.pausedReason !== null) throw err;
           attempt++;
-          const delayMs = Math.min(RECONNECT_BASE_MS * 2 ** (attempt - 1), RECONNECT_MAX_MS);
+          const { delayMs, floorMs } = this.consumeReconnectDelay(attempt);
           this.wsLogger.warn(
-            { attempt, delayMs, err: err instanceof Error ? err.message : String(err) },
+            { attempt, delayMs, floorMs: floorMs || undefined, err: err instanceof Error ? err.message : String(err) },
             "initial connect failed, will retry",
           );
           this.emit("error", err instanceof Error ? err : new Error(String(err)));
@@ -1124,25 +1148,68 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
       return;
     }
 
-    if (type === "auth:rejected" || type === "auth:expired") {
+    if (type === "auth:expired") {
       // The close handler reads `this.registered` to decide whether to
       // reconnect; clearing it here would make that decision see post-close
       // state and skip the reconnect after a mid-session auth:expired push.
-      if (type === "auth:expired") {
-        this.authLogger.info("token expired, reconnecting with fresh token");
-        this.emit("auth:expired");
-      } else {
-        // auth:rejected means the token itself was refused — retrying with
-        // the same token would just thrash. Bug 2 fix: instead of marking
-        // the connection closed (and letting the consumer process.exit 75
-        // into a systemd restart storm), enter paused mode. The operator
-        // recovers by running `first-tree login <new-token>`; the
-        // credentials-watcher calls `clearPaused()` and a fresh reconnect
-        // re-handshakes with the new token.
-        this.authLogger.warn("auth rejected by server");
-        this.enterPausedMode("auth_rejected", new Error("Server rejected access token (auth:rejected)"));
+      const parsed = authExpiredFrameSchema.safeParse(msg);
+      if (!parsed.success) {
+        this.authLogger.warn(
+          { issues: parsed.error.issues.map((i) => i.message) },
+          "auth:expired frame did not match current schema; treating by frame type",
+        );
       }
+      this.authLogger.info("token expired, reconnecting with fresh token");
+      this.emit("auth:expired");
       this.ws?.close(4401, type);
+      return;
+    }
+
+    if (type === "auth:retryable") {
+      const parsed = authRetryableFrameSchema.safeParse(msg);
+      if (parsed.success) {
+        const { code, retryAfterMs, message } = parsed.data;
+        if (retryAfterMs !== undefined) {
+          this.nextReconnectMinDelayMs = Math.max(this.nextReconnectMinDelayMs, retryAfterMs);
+        }
+        this.authLogger.warn({ code, retryAfterMs, message }, "server reported retryable auth handshake failure");
+      } else {
+        this.authLogger.warn(
+          { issues: parsed.error.issues.map((i) => i.message) },
+          "auth:retryable frame did not match current schema; retrying by frame type",
+        );
+      }
+      this.ws?.close(1013, "auth retryable");
+      return;
+    }
+
+    if (type === "auth:rejected") {
+      // auth:rejected means deterministic credential/identity failure.
+      // Retryable server-side handshake failures must arrive as
+      // auth:retryable or a retryable close code, never as a message string
+      // that the client has to interpret.
+      const parsed = authRejectedFrameSchema.safeParse(msg);
+      const err = parsed.success
+        ? new ServerAuthRejectedError({ code: parsed.data.code, message: parsed.data.message })
+        : new ServerAuthRejectedError({
+            unsupportedCode: typeof msg.code === "string" ? msg.code : undefined,
+            legacyReason: typeof msg.reason === "string" ? msg.reason : undefined,
+          });
+      if (parsed.success) {
+        this.authLogger.warn({ code: parsed.data.code, message: parsed.data.message }, "auth rejected by server");
+      } else {
+        this.authLogger.warn(
+          {
+            rawCode: typeof msg.code === "string" ? msg.code : undefined,
+            legacyReason: typeof msg.reason === "string" ? msg.reason : undefined,
+            issues: parsed.error.issues.map((i) => i.message),
+          },
+          "auth:rejected frame did not match current schema; treating as deterministic auth rejection",
+        );
+      }
+      this.lastHandshakeError = err;
+      this.enterPausedMode("auth_rejected", err);
+      this.ws?.close(4401, "auth rejected");
       return;
     }
 
@@ -1566,6 +1633,21 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
     this.emit("resilience.connection.paused", { reason });
   }
 
+  private consumeReconnectDelay(attempt: number): { delayMs: number; floorMs: number } {
+    const exponential = Math.min(RECONNECT_BASE_MS * 2 ** (attempt - 1), RECONNECT_MAX_MS);
+    const floorMs = this.nextReconnectMinDelayMs;
+    this.nextReconnectMinDelayMs = 0;
+    let delayMs = Math.max(exponential, floorMs);
+    if (floorMs > 0) {
+      // Add up to 20% jitter only to explicit retry floors, where many
+      // clients may otherwise wake at the same server-suggested deadline.
+      // Never subtract from the floor: Retry-After is a lower bound.
+      const jitter = delayMs * 0.2 * Math.random();
+      delayMs = Math.round(delayMs + jitter);
+    }
+    return { delayMs, floorMs };
+  }
+
   private scheduleReconnect(): void {
     // Guard against an entry from auth:fatal / disconnect() racing with the
     // close handler — `closing=true` means "no more reconnects", honoured here.
@@ -1578,26 +1660,9 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
     this.reconnectAttempt++;
     this.emit("reconnecting", this.reconnectAttempt);
 
-    const exponential = Math.min(RECONNECT_BASE_MS * 2 ** (this.reconnectAttempt - 1), RECONNECT_MAX_MS);
-    // Honour a 429 Retry-After from the most recent refresh attempt: take
-    // whichever is larger, then consume the floor so subsequent attempts
-    // (after the limiter window opens up again) revert to the normal
-    // exponential schedule. Without this, the next attempt would also
-    // wait ≥retryAfter, effectively halting reconnects until manual reset.
-    const floor = this.nextReconnectMinDelayMs;
-    this.nextReconnectMinDelayMs = 0;
-    let delay = Math.max(exponential, floor);
-    if (floor > 0) {
-      // ±20% jitter applies only to the 429 path, where multiple clients
-      // sharing an IP (NAT / CI pool) can otherwise all hit the same
-      // Retry-After deadline simultaneously and reform the limiter spike.
-      // Organic exponential backoff doesn't need jitter — each connection
-      // entered the loop at its own arbitrary moment already.
-      const jitter = delay * 0.2 * (Math.random() * 2 - 1);
-      delay = Math.max(0, Math.round(delay + jitter));
-    }
+    const { delayMs, floorMs } = this.consumeReconnectDelay(this.reconnectAttempt);
     this.wsLogger.debug(
-      { attempt: this.reconnectAttempt, delayMs: delay, floorMs: floor || undefined },
+      { attempt: this.reconnectAttempt, delayMs, floorMs: floorMs || undefined },
       "scheduling reconnect",
     );
     this.reconnectTimer = setTimeout(() => {
@@ -1608,7 +1673,7 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
           if (!this.closing) this.scheduleReconnect();
         });
       }
-    }, delay);
+    }, delayMs);
   }
 
   private startHeartbeat(): void {

--- a/packages/server/src/__tests__/ws-auth-classification.test.ts
+++ b/packages/server/src/__tests__/ws-auth-classification.test.ts
@@ -1,0 +1,313 @@
+import { WS_AUTH_FRAME_TIMEOUT_MS } from "@first-tree/shared";
+import { context as otelContext, trace } from "@opentelemetry/api";
+import { AsyncHooksContextManager } from "@opentelemetry/context-async-hooks";
+import { BasicTracerProvider, InMemorySpanExporter, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base";
+import { eq } from "drizzle-orm";
+import type { FastifyInstance } from "fastify";
+import { SignJWT } from "jose";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import WebSocket from "ws";
+import { users } from "../db/schema/users.js";
+import * as clientService from "../services/client.js";
+import { createTestAdmin, createTestApp } from "./helpers.js";
+
+describe("WS auth handshake classification", () => {
+  const exporter = new InMemorySpanExporter();
+  const provider = new BasicTracerProvider({
+    spanProcessors: [new SimpleSpanProcessor(exporter)],
+  });
+  const contextManager = new AsyncHooksContextManager();
+  let app: FastifyInstance;
+  let wsUrl: string;
+  let adminUserId: string;
+  let adminMemberId: string;
+  let adminOrgId: string;
+  let adminRole: string;
+  const jwtSecret = process.env.JWT_SECRET ?? "test-jwt-secret-key-for-vitest";
+
+  async function signJwt(
+    opts: { sub?: string; secret?: string; type?: string; expiresInSeconds?: number } = {},
+  ): Promise<string> {
+    const secret = new TextEncoder().encode(opts.secret ?? jwtSecret);
+    const now = Math.floor(Date.now() / 1000);
+    return new SignJWT({
+      sub: opts.sub ?? adminUserId,
+      memberId: adminMemberId,
+      organizationId: adminOrgId,
+      role: adminRole,
+      type: opts.type ?? "access",
+    })
+      .setProtectedHeader({ alg: "HS256" })
+      .setIssuedAt(now)
+      .setExpirationTime(now + (opts.expiresInSeconds ?? 300))
+      .sign(secret);
+  }
+
+  function waitForFrame(ws: WebSocket, matcher: (msg: unknown) => boolean, timeoutMs = 5000): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        ws.off("message", onMessage);
+        reject(new Error(`timeout waiting for frame (${timeoutMs}ms)`));
+      }, timeoutMs);
+      const onMessage = (raw: WebSocket.RawData) => {
+        try {
+          const msg = JSON.parse(raw.toString());
+          if (matcher(msg)) {
+            clearTimeout(timer);
+            ws.off("message", onMessage);
+            resolve(msg);
+          }
+        } catch {
+          // skip non-JSON frames
+        }
+      };
+      ws.on("message", onMessage);
+    });
+  }
+
+  function waitForClose(ws: WebSocket, timeoutMs = 5000): Promise<number> {
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error(`timeout waiting for close (${timeoutMs}ms)`)), timeoutMs);
+      ws.once("close", (code) => {
+        clearTimeout(timer);
+        resolve(code);
+      });
+    });
+  }
+
+  async function connectionSpanAttrs(timeoutMs = 1000): Promise<Record<string, unknown>> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const span = exporter.getFinishedSpans().find((s) => s.name === "ws.connection");
+      if (span) return span.attributes;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    throw new Error("expected finished ws.connection span");
+  }
+
+  async function openAndSendAuth(token: string, frames: unknown[] = []): Promise<WebSocket> {
+    const ws = new WebSocket(wsUrl);
+    ws.on("message", (raw) => {
+      try {
+        frames.push(JSON.parse(raw.toString()));
+      } catch {
+        // ignore
+      }
+    });
+    await new Promise<void>((resolve, reject) => {
+      ws.once("open", () => resolve());
+      ws.once("error", reject);
+    });
+    ws.send(JSON.stringify({ type: "auth", token }));
+    return ws;
+  }
+
+  beforeAll(async () => {
+    contextManager.enable();
+    otelContext.setGlobalContextManager(contextManager);
+    trace.setGlobalTracerProvider(provider);
+    app = await createTestApp();
+    await app.listen({ port: 0, host: "127.0.0.1" });
+    const addr = app.server.address();
+    if (!addr || typeof addr === "string") throw new Error("test server has no address");
+    wsUrl = `ws://127.0.0.1:${addr.port}/api/v1/agent/ws/client`;
+  });
+
+  beforeEach(async () => {
+    exporter.reset();
+    const admin = await createTestAdmin(app, { username: `ws-auth-${crypto.randomUUID().slice(0, 8)}` });
+    adminUserId = admin.userId;
+    adminMemberId = admin.memberId;
+    adminOrgId = admin.organizationId;
+    adminRole = "admin";
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await provider.shutdown();
+    trace.disable();
+    otelContext.disable();
+    contextManager.disable();
+  });
+
+  it("auth frame timeout emits auth:retryable and closes 1013", async () => {
+    const ws = new WebSocket(wsUrl);
+    await new Promise<void>((resolve, reject) => {
+      ws.once("open", () => resolve());
+      ws.once("error", reject);
+    });
+
+    const frame = await waitForFrame(
+      ws,
+      (m) => (m as { type?: string }).type === "auth:retryable",
+      WS_AUTH_FRAME_TIMEOUT_MS + 2000,
+    );
+    const closeCode = await waitForClose(ws);
+
+    expect(frame).toMatchObject({ type: "auth:retryable", code: "auth_timeout" });
+    expect(closeCode).toBe(1013);
+    await expect(connectionSpanAttrs()).resolves.toMatchObject({
+      "auth.ws.phase": "auth_frame_timeout",
+      "auth.ws.outcome": "retryable",
+      "auth.ws.code": "auth_timeout",
+      "auth.ws.retryable": true,
+      "auth.ws.close_code": 1013,
+    });
+  });
+
+  it("expired JWT emits auth:expired and closes 4401", async () => {
+    const token = await signJwt({ expiresInSeconds: -60 });
+    const ws = await openAndSendAuth(token);
+
+    const frame = await waitForFrame(ws, (m) => (m as { type?: string }).type === "auth:expired");
+    const closeCode = await waitForClose(ws);
+
+    expect(frame).toEqual({ type: "auth:expired" });
+    expect(closeCode).toBe(4401);
+    await expect(connectionSpanAttrs()).resolves.toMatchObject({
+      "auth.ws.phase": "jwt_verify",
+      "auth.ws.outcome": "expired",
+      "auth.ws.code": "jwt_expired",
+      "auth.ws.retryable": true,
+      "auth.ws.close_code": 4401,
+      "auth.ws.untrusted.sub": adminUserId,
+      "auth.ws.untrusted.type": "access",
+    });
+  });
+
+  it("invalid signature emits auth:rejected invalid_token", async () => {
+    const token = await signJwt({ secret: "wrong-test-secret" });
+    const ws = await openAndSendAuth(token);
+
+    const frame = await waitForFrame(ws, (m) => (m as { type?: string }).type === "auth:rejected");
+    const closeCode = await waitForClose(ws);
+
+    expect(frame).toMatchObject({ type: "auth:rejected", code: "invalid_token" });
+    expect(closeCode).toBe(4401);
+    await expect(connectionSpanAttrs()).resolves.toMatchObject({
+      "auth.ws.phase": "jwt_verify",
+      "auth.ws.outcome": "rejected",
+      "auth.ws.code": "invalid_token",
+      "auth.ws.retryable": false,
+      "auth.ws.close_code": 4401,
+    });
+    expect(typeof (await connectionSpanAttrs())["auth.ws.error_class"]).toBe("string");
+  });
+
+  it("missing user emits auth:rejected user_not_found", async () => {
+    const token = await signJwt({ sub: `missing-${crypto.randomUUID()}` });
+    const ws = await openAndSendAuth(token);
+
+    const frame = await waitForFrame(ws, (m) => (m as { type?: string }).type === "auth:rejected");
+    const closeCode = await waitForClose(ws);
+
+    expect(frame).toMatchObject({ type: "auth:rejected", code: "user_not_found" });
+    expect(closeCode).toBe(4401);
+  });
+
+  it("suspended user emits auth:rejected user_suspended", async () => {
+    await app.db.update(users).set({ status: "suspended" }).where(eq(users.id, adminUserId));
+    const token = await signJwt();
+    const ws = await openAndSendAuth(token);
+
+    const frame = await waitForFrame(ws, (m) => (m as { type?: string }).type === "auth:rejected");
+    const closeCode = await waitForClose(ws);
+
+    expect(frame).toMatchObject({ type: "auth:rejected", code: "user_suspended" });
+    expect(closeCode).toBe(4401);
+  });
+
+  it("DB error during auth lookup emits auth:retryable and closes 1013", async () => {
+    const token = await signJwt();
+    const selectSpy = vi.spyOn(app.db, "select").mockImplementation(() => {
+      throw new Error("database unavailable");
+    });
+
+    try {
+      const ws = await openAndSendAuth(token);
+      const frame = await waitForFrame(ws, (m) => (m as { type?: string }).type === "auth:retryable");
+      const closeCode = await waitForClose(ws);
+
+      expect(frame).toMatchObject({ type: "auth:retryable", code: "auth_backend_unavailable" });
+      expect(closeCode).toBe(1013);
+      await expect(connectionSpanAttrs()).resolves.toMatchObject({
+        "auth.ws.phase": "user_lookup",
+        "auth.ws.outcome": "retryable",
+        "auth.ws.code": "auth_backend_unavailable",
+        "auth.ws.retryable": true,
+        "auth.ws.close_code": 1013,
+        "auth.ws.error_class": "Error",
+      });
+    } finally {
+      selectSpy.mockRestore();
+    }
+  });
+
+  it("post-auth welcome failure is retryable and never maps to auth:rejected", async () => {
+    const token = await signJwt();
+    const frames: unknown[] = [];
+    const originalCommandVersion = app.commandVersion;
+    app.commandVersion = () => {
+      throw new Error("version unavailable");
+    };
+
+    try {
+      const ws = await openAndSendAuth(token, frames);
+      const retryable = await waitForFrame(ws, (m) => (m as { type?: string }).type === "auth:retryable");
+      const closeCode = await waitForClose(ws);
+
+      expect(frames).toContainEqual({ type: "auth:ok" });
+      expect(retryable).toMatchObject({ type: "auth:retryable", code: "handshake_internal_error" });
+      expect(frames.some((frame) => (frame as { type?: string }).type === "auth:rejected")).toBe(false);
+      expect(closeCode).toBe(1011);
+      await expect(connectionSpanAttrs()).resolves.toMatchObject({
+        "user.id": adminUserId,
+        "auth.ws.phase": "post_auth_welcome",
+        "auth.ws.outcome": "retryable",
+        "auth.ws.code": "handshake_internal_error",
+        "auth.ws.retryable": true,
+        "auth.ws.close_code": 1011,
+        "auth.ws.error_class": "Error",
+      });
+    } finally {
+      app.commandVersion = originalCommandVersion;
+    }
+  });
+
+  it("client register rejection records client_register phase before closing 4403", async () => {
+    const token = await signJwt();
+    const registerSpy = vi.spyOn(clientService, "registerClient").mockRejectedValue(new Error("register unavailable"));
+
+    try {
+      const ws = await openAndSendAuth(token);
+      await waitForFrame(ws, (m) => (m as { type?: string }).type === "server:welcome");
+
+      ws.send(
+        JSON.stringify({
+          type: "client:register",
+          clientId: `client-${crypto.randomUUID()}`,
+        }),
+      );
+
+      const rejected = await waitForFrame(ws, (m) => (m as { type?: string }).type === "client:register:rejected");
+      const closeCode = await waitForClose(ws);
+
+      expect(rejected).toMatchObject({
+        type: "client:register:rejected",
+        message: "register unavailable",
+      });
+      expect(closeCode).toBe(4403);
+      await expect(connectionSpanAttrs()).resolves.toMatchObject({
+        "user.id": adminUserId,
+        "auth.ws.phase": "client_register",
+        "auth.ws.outcome": "rejected",
+        "auth.ws.code": "client_register_failed",
+        "auth.ws.retryable": false,
+        "auth.ws.close_code": 4403,
+        "auth.ws.error_class": "Error",
+      });
+    } finally {
+      registerSpy.mockRestore();
+    }
+  });
+});

--- a/packages/server/src/api/agent/ws-client.ts
+++ b/packages/server/src/api/agent/ws-client.ts
@@ -1,6 +1,10 @@
 import {
   AGENT_BIND_REJECT_REASONS,
   type AgentBindRejectReason,
+  AUTH_REJECTED_CODES,
+  AUTH_RETRYABLE_CODES,
+  type AuthRejectedCode,
+  type AuthRetryableCode,
   agentBindRequestSchema,
   agentPinnedMessageSchema,
   clientRegisterSchema,
@@ -28,9 +32,13 @@ import { members } from "../../db/schema/members.js";
 import { users } from "../../db/schema/users.js";
 import { ClientOrgMismatchError, ClientUserMismatchError } from "../../errors.js";
 import {
+  classifyJoseError,
+  decodeJwtForTrace,
   endWsConnectionSpan,
+  type JwtFailureReason,
   setWsConnectionAttrs,
   startWsConnectionSpan,
+  untrustedAttrs,
   withWsMessageSpan,
 } from "../../observability/index.js";
 import * as activityService from "../../services/activity.js";
@@ -77,7 +85,9 @@ const wsMessageSchema = z.object({
  * Protocol (unified-user-token milestone):
  *   1. Client connects; server waits up to {@link WS_AUTH_FRAME_TIMEOUT_MS}
  *      for the first `auth` frame carrying a member access JWT.
- *      Failure ⇒ server sends `auth:rejected` and closes (code 4401).
+ *      Deterministic credential/identity failures ⇒ `auth:rejected` + 4401;
+ *      expiry ⇒ `auth:expired` + 4401; transient handshake failures ⇒
+ *      `auth:retryable` / 1011 / 1013.
  *   2. `client:register` — bind the client_id to the authenticated user.
  *   3. `agent:bind` — run Rule R-RUN (no token); populate presence.
  *   4. `session:state` / `runtime:state` / `session:event` / `heartbeat`.
@@ -99,6 +109,141 @@ const wsMessageSchema = z.object({
 type AuthenticatedSession = {
   userId: string;
 };
+
+type WsAuthPhase =
+  | "auth_frame_timeout"
+  | "auth_frame_validation"
+  | "jwt_verify"
+  | "claims_validation"
+  | "user_lookup"
+  | "post_auth_welcome"
+  | "client_register";
+
+type WsAuthOutcome = "accepted" | "expired" | "rejected" | "retryable" | "protocol_error";
+
+function sendJsonOrThrow(socket: WebSocket, frame: unknown): void {
+  if (socket.readyState !== socket.OPEN) {
+    throw new Error("WebSocket is not open");
+  }
+  socket.send(JSON.stringify(frame));
+}
+
+function setAuthWsAttrs(
+  socket: WebSocket,
+  attrs: {
+    phase: WsAuthPhase;
+    outcome: WsAuthOutcome;
+    code: string;
+    retryable: boolean;
+    closeCode?: number;
+    errorClass?: string;
+    extraAttrs?: Record<string, string | number | boolean>;
+  },
+): void {
+  setWsConnectionAttrs(socket, {
+    "auth.ws.phase": attrs.phase,
+    "auth.ws.outcome": attrs.outcome,
+    "auth.ws.code": attrs.code,
+    "auth.ws.retryable": attrs.retryable,
+    "auth.ws.close_code": attrs.closeCode,
+    ...(attrs.errorClass ? { "auth.ws.error_class": attrs.errorClass } : {}),
+    ...(attrs.extraAttrs ?? {}),
+  });
+}
+
+function closeWithAuthRejected(
+  socket: WebSocket,
+  phase: WsAuthPhase,
+  code: AuthRejectedCode,
+  message?: string,
+  errorClass?: string,
+  extraAttrs?: Record<string, string | number | boolean>,
+): void {
+  setAuthWsAttrs(socket, {
+    phase,
+    outcome: "rejected",
+    code,
+    retryable: false,
+    closeCode: 4401,
+    errorClass,
+    extraAttrs,
+  });
+  try {
+    sendJsonOrThrow(socket, {
+      type: "auth:rejected",
+      code,
+      ...(message ? { message } : {}),
+    });
+  } catch {
+    // socket may already be gone; close below is still idempotent
+  }
+  socket.close(4401, "auth rejected");
+}
+
+function closeWithAuthExpired(
+  socket: WebSocket,
+  phase: WsAuthPhase,
+  extraAttrs?: Record<string, string | number | boolean>,
+  errorClass?: string,
+): void {
+  setAuthWsAttrs(socket, {
+    phase,
+    outcome: "expired",
+    code: "jwt_expired",
+    retryable: true,
+    closeCode: 4401,
+    extraAttrs,
+    errorClass,
+  });
+  try {
+    sendJsonOrThrow(socket, { type: "auth:expired" });
+  } catch {
+    // socket may already be gone
+  }
+  socket.close(4401, "auth expired");
+}
+
+function closeWithAuthRetryable(
+  socket: WebSocket,
+  phase: WsAuthPhase,
+  code: AuthRetryableCode,
+  closeCode: 1011 | 1013,
+  message?: string,
+  errorClass?: string,
+): void {
+  setAuthWsAttrs(socket, { phase, outcome: "retryable", code, retryable: true, closeCode, errorClass });
+  try {
+    sendJsonOrThrow(socket, {
+      type: "auth:retryable",
+      code,
+      ...(message ? { message } : {}),
+    });
+  } catch {
+    // socket may already be gone
+  }
+  socket.close(closeCode, "auth retryable");
+}
+
+function joseErrorCode(err: unknown): string | undefined {
+  if (typeof err !== "object" || err === null) return undefined;
+  if (!("code" in err)) return undefined;
+  const code = err.code;
+  return typeof code === "string" ? code : undefined;
+}
+
+function rejectedCodeForJoseError(reason: JwtFailureReason, err: unknown): AuthRejectedCode {
+  if (joseErrorCode(err) === "ERR_JWT_CLAIM_VALIDATION_FAILED") {
+    return AUTH_REJECTED_CODES.INVALID_CLAIMS;
+  }
+  switch (reason) {
+    case "jwt_signature_invalid":
+    case "jwt_malformed":
+    case "jwt_verify_failed":
+      return AUTH_REJECTED_CODES.INVALID_TOKEN;
+    case "jwt_expired":
+      return AUTH_REJECTED_CODES.INVALID_TOKEN;
+  }
+}
 
 function sendRejected(socket: WebSocket, ref: string | undefined, reason: AgentBindRejectReason): void {
   socket.send(JSON.stringify({ type: "agent:bind:rejected", ref, reason }));
@@ -331,14 +476,44 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
         return next;
       }
 
-      const authTimeout = setTimeout(() => {
+      let authTimeout: NodeJS.Timeout | null = null;
+      const clearAuthTimeout = () => {
+        if (!authTimeout) return;
+        clearTimeout(authTimeout);
+        authTimeout = null;
+      };
+      const rejectAuthAndClose = (
+        phase: WsAuthPhase,
+        code: AuthRejectedCode,
+        message?: string,
+        errorClass?: string,
+        extraAttrs?: Record<string, string | number | boolean>,
+      ) => {
+        clearAuthTimeout();
+        closeWithAuthRejected(socket, phase, code, message, errorClass, extraAttrs);
+      };
+      const expireAuthAndCloseWithAttrs = (
+        phase: WsAuthPhase,
+        extraAttrs?: Record<string, string | number | boolean>,
+        errorClass?: string,
+      ) => {
+        clearAuthTimeout();
+        closeWithAuthExpired(socket, phase, extraAttrs, errorClass);
+      };
+      const retryAuthAndClose = (
+        phase: WsAuthPhase,
+        code: AuthRetryableCode,
+        closeCode: 1011 | 1013,
+        message?: string,
+        errorClass?: string,
+      ) => {
+        clearAuthTimeout();
+        closeWithAuthRetryable(socket, phase, code, closeCode, message, errorClass);
+      };
+
+      authTimeout = setTimeout(() => {
         if (!session) {
-          try {
-            socket.send(JSON.stringify({ type: "auth:rejected", reason: "timeout" }));
-          } catch {
-            // socket may already be closed
-          }
-          socket.close(4401, "auth timeout");
+          retryAuthAndClose("auth_frame_timeout", AUTH_RETRYABLE_CODES.AUTH_TIMEOUT, 1013, "auth frame timeout");
         }
       }, WS_AUTH_FRAME_TIMEOUT_MS);
 
@@ -351,12 +526,7 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
         const delay = expSeconds * 1000 - Date.now();
         if (delay <= 0) return;
         authExpiryTimer = setTimeout(() => {
-          try {
-            socket.send(JSON.stringify({ type: "auth:expired" }));
-          } catch {
-            // ignore
-          }
-          socket.close(4401, "auth expired");
+          closeWithAuthExpired(socket, "jwt_verify");
         }, delay);
       };
 
@@ -365,13 +535,29 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
         try {
           msg = JSON.parse(String(raw));
         } catch {
-          socket.send(JSON.stringify({ type: "error", message: "Invalid JSON" }));
+          if (!session) {
+            rejectAuthAndClose(
+              "auth_frame_validation",
+              AUTH_REJECTED_CODES.INVALID_AUTH_FRAME,
+              "invalid JSON auth frame",
+            );
+          } else {
+            socket.send(JSON.stringify({ type: "error", message: "Invalid JSON" }));
+          }
           return;
         }
 
         const parsed = wsMessageSchema.safeParse(msg);
         if (!parsed.success) {
-          socket.send(JSON.stringify({ type: "error", message: "Invalid message format" }));
+          if (!session) {
+            rejectAuthAndClose(
+              "auth_frame_validation",
+              AUTH_REJECTED_CODES.INVALID_AUTH_FRAME,
+              "invalid auth message format",
+            );
+          } else {
+            socket.send(JSON.stringify({ type: "error", message: "Invalid message format" }));
+          }
           return;
         }
 
@@ -380,50 +566,102 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
         // ── Auth gate — the very first frame must be {type:"auth"}.
         if (!session) {
           if (type !== "auth") {
-            socket.send(JSON.stringify({ type: "auth:rejected", reason: "not_authenticated" }));
-            socket.close(4401, "not authenticated");
+            rejectAuthAndClose(
+              "auth_frame_validation",
+              AUTH_REJECTED_CODES.INVALID_AUTH_FRAME,
+              "first frame must be auth",
+            );
             return;
           }
           const authParsed = wsAuthFrameSchema.safeParse(msg);
           if (!authParsed.success) {
-            socket.send(JSON.stringify({ type: "auth:rejected", reason: "invalid_frame" }));
-            socket.close(4401, "invalid auth");
+            rejectAuthAndClose("auth_frame_validation", AUTH_REJECTED_CODES.INVALID_AUTH_FRAME, "invalid auth frame");
             return;
           }
 
+          const token = authParsed.data.token;
+          let payload: Awaited<ReturnType<typeof jwtVerify>>["payload"];
           try {
-            const { payload } = await jwtVerify(authParsed.data.token, jwtSecretBytes);
-            const claims = payload as {
-              sub?: string;
-              memberId?: string;
-              organizationId?: string;
-              role?: string;
-              type?: string;
-              exp?: number;
-            };
-            if (claims.type !== "access" || !claims.sub) {
-              throw new Error("Invalid token claims");
+            const verified = await jwtVerify(token, jwtSecretBytes);
+            payload = verified.payload;
+          } catch (err) {
+            const reason = classifyJoseError(err);
+            const traceClaims = untrustedAttrs("auth.ws", decodeJwtForTrace(token));
+            const errorClass = err instanceof Error ? err.name : reason;
+            if (reason === "jwt_expired") {
+              expireAuthAndCloseWithAttrs("jwt_verify", traceClaims, errorClass);
+              return;
             }
+            rejectAuthAndClose(
+              "jwt_verify",
+              rejectedCodeForJoseError(reason, err),
+              "JWT verification failed",
+              errorClass,
+              traceClaims,
+            );
+            return;
+          }
 
-            const [user] = await app.db
+          const tokenType = payload.type;
+          if (tokenType !== "access") {
+            rejectAuthAndClose(
+              "claims_validation",
+              tokenType === undefined ? AUTH_REJECTED_CODES.INVALID_CLAIMS : AUTH_REJECTED_CODES.WRONG_TOKEN_TYPE,
+              "member access token required",
+              tokenType === undefined ? "missing_token_type" : "wrong_token_type",
+            );
+            return;
+          }
+          const userId = payload.sub;
+          if (typeof userId !== "string" || userId.length === 0) {
+            rejectAuthAndClose(
+              "claims_validation",
+              AUTH_REJECTED_CODES.INVALID_CLAIMS,
+              "missing subject claim",
+              "missing_sub",
+            );
+            return;
+          }
+
+          let user: { id: string; status: string } | undefined;
+          try {
+            [user] = await app.db
               .select({ id: users.id, status: users.status })
               .from(users)
-              .where(eq(users.id, claims.sub))
+              .where(eq(users.id, userId))
               .limit(1);
-            if (!user || user.status !== "active") {
-              throw new Error("User not found or suspended");
-            }
+          } catch (err) {
+            app.log.warn({ err, userId }, "WS auth user lookup failed; asking client to retry");
+            retryAuthAndClose(
+              "user_lookup",
+              AUTH_RETRYABLE_CODES.AUTH_BACKEND_UNAVAILABLE,
+              1013,
+              "authentication backend unavailable",
+              err instanceof Error ? err.name : "UnknownError",
+            );
+            return;
+          }
+          if (!user) {
+            rejectAuthAndClose("user_lookup", AUTH_REJECTED_CODES.USER_NOT_FOUND, "user not found");
+            return;
+          }
+          if (user.status !== "active") {
+            rejectAuthAndClose("user_lookup", AUTH_REJECTED_CODES.USER_SUSPENDED, "user suspended");
+            return;
+          }
 
-            // Session is org-free (decouple-client-from-identity §4.2). The
-            // JWT's `organizationId`/`memberId`/`role` claims are recorded as
-            // hints only; bind-time R-RUN re-resolves the agent's owner
-            // through `agents → manager → user` against the live DB.
-            session = { userId: user.id };
-            jwtDefaultOrgId = typeof claims.organizationId === "string" ? claims.organizationId : null;
-            setWsConnectionAttrs(socket, { "user.id": user.id });
-            clearTimeout(authTimeout);
-            scheduleAuthExpiry(claims.exp);
-            socket.send(JSON.stringify({ type: "auth:ok" }));
+          // Session is org-free (decouple-client-from-identity §4.2). The
+          // JWT's `organizationId`/`memberId`/`role` claims are recorded as
+          // hints only; bind-time R-RUN re-resolves the agent's owner
+          // through `agents → manager → user` against the live DB.
+          session = { userId: user.id };
+          jwtDefaultOrgId = typeof payload.organizationId === "string" ? payload.organizationId : null;
+          setWsConnectionAttrs(socket, { "user.id": user.id });
+          clearAuthTimeout();
+          scheduleAuthExpiry(payload.exp);
+
+          try {
+            sendJsonOrThrow(socket, { type: "auth:ok" });
             // Wire-additive: older clients drop the unknown type; newer ones
             // use it to detect version drift. `capabilities.wsInboxDeliver`
             // must stay `true` here so 0.10.4 ~ 0.14.2 clients suppress
@@ -431,18 +669,27 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
             // would fall back to `GET /inbox` + `POST /inbox/:id/ack` and
             // the missing ack endpoint would loop messages forever. 0.14.3+
             // clients ignore the field entirely.
-            socket.send(
-              JSON.stringify({
-                type: "server:welcome",
-                serverCommandVersion: app.commandVersion(),
-                serverTimeMs: Date.now(),
-                capabilities: { wsInboxDeliver: true, wsInboxAckConfirm: true },
-              }),
-            );
+            sendJsonOrThrow(socket, {
+              type: "server:welcome",
+              serverCommandVersion: app.commandVersion(),
+              serverTimeMs: Date.now(),
+              capabilities: { wsInboxDeliver: true, wsInboxAckConfirm: true },
+            });
+            setAuthWsAttrs(socket, {
+              phase: "post_auth_welcome",
+              outcome: "accepted",
+              code: "auth_ok",
+              retryable: false,
+            });
           } catch (err) {
-            const message = err instanceof Error ? err.message : "auth failure";
-            socket.send(JSON.stringify({ type: "auth:rejected", reason: message }));
-            socket.close(4401, "auth rejected");
+            app.log.warn({ err, userId: user.id }, "WS post-auth handshake failed; asking client to retry");
+            retryAuthAndClose(
+              "post_auth_welcome",
+              AUTH_RETRYABLE_CODES.HANDSHAKE_INTERNAL_ERROR,
+              1011,
+              "post-auth handshake failed",
+              err instanceof Error ? err.name : "UnknownError",
+            );
           }
           return;
         }
@@ -472,6 +719,13 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
                 placeholderOrgId = m?.organizationId ?? null;
               }
               if (!placeholderOrgId) {
+                setAuthWsAttrs(socket, {
+                  phase: "client_register",
+                  outcome: "rejected",
+                  code: "no_membership",
+                  retryable: false,
+                  closeCode: 4403,
+                });
                 socket.send(
                   JSON.stringify({
                     type: "client:register:rejected",
@@ -500,6 +754,14 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
                     : err instanceof ClientOrgMismatchError
                       ? err.code
                       : undefined;
+                setAuthWsAttrs(socket, {
+                  phase: "client_register",
+                  outcome: "rejected",
+                  code: code ?? "client_register_failed",
+                  retryable: false,
+                  closeCode: 4403,
+                  errorClass: err instanceof Error ? err.name : "UnknownError",
+                });
                 socket.send(
                   JSON.stringify({
                     type: "client:register:rejected",
@@ -1103,7 +1365,7 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
 
       socket.on("close", async (closeCode?: number) => {
         endWsConnectionSpan(socket, closeCode);
-        clearTimeout(authTimeout);
+        clearAuthTimeout();
         if (authExpiryTimer) clearTimeout(authExpiryTimer);
 
         for (const [, info] of boundAgents) {

--- a/packages/shared/src/__tests__/ws-auth-schema.test.ts
+++ b/packages/shared/src/__tests__/ws-auth-schema.test.ts
@@ -1,5 +1,76 @@
 import { describe, expect, it } from "vitest";
-import { serverWelcomeFrameSchema } from "../schemas/ws-auth.js";
+import {
+  authControlFrameSchema,
+  authExpiredFrameSchema,
+  authRejectedFrameSchema,
+  authRetryableFrameSchema,
+  serverWelcomeFrameSchema,
+} from "../schemas/ws-auth.js";
+
+describe("auth control frame schemas", () => {
+  it("accepts auth:rejected with a finite rejection code", () => {
+    const res = authRejectedFrameSchema.safeParse({
+      type: "auth:rejected",
+      code: "invalid_token",
+      message: "signature verification failed",
+    });
+    expect(res.success).toBe(true);
+  });
+
+  it("accepts auth:expired without a free-form payload", () => {
+    const res = authExpiredFrameSchema.safeParse({ type: "auth:expired" });
+    expect(res.success).toBe(true);
+  });
+
+  it("accepts auth:retryable with retryAfterMs", () => {
+    const res = authRetryableFrameSchema.safeParse({
+      type: "auth:retryable",
+      code: "auth_backend_unavailable",
+      retryAfterMs: 2500,
+      message: "database unavailable",
+    });
+    expect(res.success).toBe(true);
+  });
+
+  it("classifies auth_timeout as retryable, not rejected", () => {
+    expect(
+      authRetryableFrameSchema.safeParse({
+        type: "auth:retryable",
+        code: "auth_timeout",
+      }).success,
+    ).toBe(true);
+    expect(
+      authRejectedFrameSchema.safeParse({
+        type: "auth:rejected",
+        code: "auth_timeout",
+      }).success,
+    ).toBe(false);
+  });
+
+  it("parses the finite auth control union by frame type", () => {
+    const res = authControlFrameSchema.safeParse({
+      type: "auth:retryable",
+      code: "server_draining",
+    });
+    expect(res.success).toBe(true);
+  });
+
+  it("rejects unknown auth:rejected codes", () => {
+    const res = authRejectedFrameSchema.safeParse({
+      type: "auth:rejected",
+      code: "please_login_again",
+    });
+    expect(res.success).toBe(false);
+  });
+
+  it("rejects unknown auth:retryable codes", () => {
+    const res = authRetryableFrameSchema.safeParse({
+      type: "auth:retryable",
+      code: "try_sometime",
+    });
+    expect(res.success).toBe(false);
+  });
+});
 
 describe("serverWelcomeFrameSchema", () => {
   it("accepts a well-formed frame", () => {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -729,8 +729,26 @@ export {
   workspaceManifestSchema,
 } from "./schemas/workspace-manifest.js";
 // -- WebSocket handshake frames --
-export type { ServerCapabilities, ServerWelcomeFrame, WsAuthFrame } from "./schemas/ws-auth.js";
+export type {
+  AuthControlFrame,
+  AuthExpiredFrame,
+  AuthRejectedCode,
+  AuthRejectedFrame,
+  AuthRetryableCode,
+  AuthRetryableFrame,
+  ServerCapabilities,
+  ServerWelcomeFrame,
+  WsAuthFrame,
+} from "./schemas/ws-auth.js";
 export {
+  AUTH_REJECTED_CODES,
+  AUTH_RETRYABLE_CODES,
+  authControlFrameSchema,
+  authExpiredFrameSchema,
+  authRejectedCodeSchema,
+  authRejectedFrameSchema,
+  authRetryableCodeSchema,
+  authRetryableFrameSchema,
   serverCapabilitiesSchema,
   serverWelcomeFrameSchema,
   WS_AUTH_FRAME_TIMEOUT_MS,

--- a/packages/shared/src/schemas/ws-auth.ts
+++ b/packages/shared/src/schemas/ws-auth.ts
@@ -2,8 +2,9 @@ import { z } from "zod";
 
 /**
  * First-frame auth envelope sent by the SDK on the client WS connection.
- * The server rejects the connection with close code 4401 if this frame does
- * not arrive within {@link WS_AUTH_FRAME_TIMEOUT_MS} or fails verification.
+ * The server asks the client to retry with close code 1013 if this frame does
+ * not arrive within {@link WS_AUTH_FRAME_TIMEOUT_MS}; malformed frames still
+ * close as deterministic auth rejections.
  */
 export const wsAuthFrameSchema = z.object({
   type: z.literal("auth"),
@@ -13,6 +14,65 @@ export type WsAuthFrame = z.infer<typeof wsAuthFrameSchema>;
 
 /** How long the server waits for the first `auth` frame before closing the WS. */
 export const WS_AUTH_FRAME_TIMEOUT_MS = 5_000;
+
+export const AUTH_REJECTED_CODES = {
+  INVALID_TOKEN: "invalid_token",
+  INVALID_CLAIMS: "invalid_claims",
+  WRONG_TOKEN_TYPE: "wrong_token_type",
+  USER_NOT_FOUND: "user_not_found",
+  USER_SUSPENDED: "user_suspended",
+  INVALID_AUTH_FRAME: "invalid_auth_frame",
+} as const;
+export const authRejectedCodeSchema = z.enum([
+  "invalid_token",
+  "invalid_claims",
+  "wrong_token_type",
+  "user_not_found",
+  "user_suspended",
+  "invalid_auth_frame",
+]);
+export type AuthRejectedCode = z.infer<typeof authRejectedCodeSchema>;
+
+export const AUTH_RETRYABLE_CODES = {
+  AUTH_BACKEND_UNAVAILABLE: "auth_backend_unavailable",
+  HANDSHAKE_INTERNAL_ERROR: "handshake_internal_error",
+  AUTH_TIMEOUT: "auth_timeout",
+  SERVER_DRAINING: "server_draining",
+} as const;
+export const authRetryableCodeSchema = z.enum([
+  "auth_backend_unavailable",
+  "handshake_internal_error",
+  "auth_timeout",
+  "server_draining",
+]);
+export type AuthRetryableCode = z.infer<typeof authRetryableCodeSchema>;
+
+export const authRejectedFrameSchema = z.object({
+  type: z.literal("auth:rejected"),
+  code: authRejectedCodeSchema,
+  message: z.string().min(1).optional(),
+});
+export type AuthRejectedFrame = z.infer<typeof authRejectedFrameSchema>;
+
+export const authExpiredFrameSchema = z.object({
+  type: z.literal("auth:expired"),
+});
+export type AuthExpiredFrame = z.infer<typeof authExpiredFrameSchema>;
+
+export const authRetryableFrameSchema = z.object({
+  type: z.literal("auth:retryable"),
+  code: authRetryableCodeSchema,
+  retryAfterMs: z.number().int().positive().optional(),
+  message: z.string().min(1).optional(),
+});
+export type AuthRetryableFrame = z.infer<typeof authRetryableFrameSchema>;
+
+export const authControlFrameSchema = z.discriminatedUnion("type", [
+  authRejectedFrameSchema,
+  authExpiredFrameSchema,
+  authRetryableFrameSchema,
+]);
+export type AuthControlFrame = z.infer<typeof authControlFrameSchema>;
 
 /**
  * Negotiable wire-protocol features the server advertises in its `welcome`


### PR DESCRIPTION
## Summary

- add finite shared schemas for `auth:rejected`, `auth:expired`, and `auth:retryable` WS auth control frames
- classify server WS auth handshake failures by phase, emitting retryable frames/1011/1013 for transient or post-auth failures instead of `auth:rejected`
- treat auth-frame timeout as retryable (`auth:retryable` + `auth_timeout` + 1013) so slow/cold clients reconnect instead of entering auth-paused mode
- enrich the `ws.connection` span with `auth.ws.phase/outcome/code/retryable/close_code/error_class` and safe untrusted JWT trace attrs, including `client_register` attrs before 4403 register rejections
- update the client auth state machine to use frame type/code only, keep retryable failures reconnecting without auth-paused, and preserve `retryAfterMs` as a reconnect floor
- surface structured auth pause details in CLI output and add shared/server/client/CLI regression coverage

## Tests

- `pnpm --filter @first-tree/shared exec vitest run src/__tests__/ws-auth-schema.test.ts --maxWorkers=2`
- `pnpm --filter @first-tree/server exec vitest run src/__tests__/ws-auth-classification.test.ts --maxWorkers=2`
- `pnpm --filter @first-tree/client exec vitest run src/__tests__/auth-paused.test.ts src/__tests__/client-connection-auth-expired.test.ts src/__tests__/client-connection-auth-classification.test.ts --maxWorkers=2`
- `pnpm --filter first-tree-dev exec vitest run src/__tests__/client-runtime-context-tree.test.ts --maxWorkers=2`
- `pnpm --filter @first-tree/server exec vitest run src/__tests__/ws-auth-classification.test.ts src/__tests__/ws-jwt-refresh.test.ts src/__tests__/ws-server-welcome.test.ts --maxWorkers=2`
- `pnpm check`
- `pnpm typecheck`

`pnpm check` still reports the existing `packages/client/src/runtime/workspace-migrations.ts` `void | "deferred"` warning.

## Review follow-up

Addressed yuezengwu's non-blocking suggestions for this PR:

- `auth_frame_timeout` now emits `auth:retryable` with code `auth_timeout` and closes 1013.
- 4403 `client:register:rejected` paths now write `auth.ws.phase = "client_register"` and related span attrs before closing.

`server_draining` remains a forward-compatible retryable code and is not emitted by this change.
