### PR TITLE
chore(web): use realistic team name in onboarding preview gallery

### DIFF
--- a/packages/web/src/pages/onboarding-preview.tsx
+++ b/packages/web/src/pages/onboarding-preview.tsx
@@ -38,7 +38,12 @@ import type { ComputerConnection } from "./onboarding/use-computer-connection.js
  */
 
 const ORG_ID = "org-acme";
-const TEAM_NAME = "Acme";
+// Mirror the real signup default: the server auto-names a solo team
+// `${login}'s team` (see packages/server/src/api/auth/github.ts), and the
+// welcome step pre-fills the input with that value verbatim. Using the real
+// shape here (vs a generic "Acme") keeps the gallery faithful for design
+// review and matches the file's existing "Gandy" persona (DEFAULT_AGENT_NAME).
+const TEAM_NAME = "Gandy's team";
 const TREE_URL = "https://github.com/acme/context-tree";
 const DEFAULT_AGENT_NAME = "Gandy's assistant";
 const SAMPLE_CLI = "npm install -g first-tree\nfirst-tree login ft_3aK9d2hQ7s_pVx1n8Wc4Lr6";


### PR DESCRIPTION
## What

The onboarding **preview gallery** (`/preview/onboarding`) seeded the team-name fixture with a generic `"Acme"`:

```ts
const TEAM_NAME = "Acme";
```

But the real signup default is `` `${login}'s team` `` — auto-named server-side in `packages/server/src/api/auth/github.ts` and pre-filled **verbatim** as the input's real value on the welcome step (`step-team.tsx`). So the gallery showed something users never actually see.

This PR seeds the gallery with `"Gandy's team"` so it mirrors the real shape and stays consistent with the file's existing `"Gandy"` persona (`DEFAULT_AGENT_NAME = "Gandy's assistant"`).

## Why

During a design review of the welcome screen, the `"Acme"` fixture misled us into thinking it was the shipped default team name. A faithful fixture prevents that, and lets reviewers judge the real text shape (the `'s team` suffix, longer login lengths) instead of a generic word.

## Scope

- **One line + a clarifying comment** in `onboarding-preview.tsx`.
- Preview fixture only — **no behavior change**.
- Untouched: tests asserting `"Acme"` (their own fixtures) and the invitee-flow `"Acme Inc"` (joining someone else's company team — realistic as-is).

## Verification

- `pnpm --filter @first-tree/web typecheck` ✓
- `pnpm check` ✓ (sole warning is a pre-existing `MigrationOutcome` item, unrelated)
- `pnpm --filter @first-tree/web test` ✓ **694/694** (incl. the SSR smoke test that renders preview pages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)