### PR TITLE
feat(web): agent identity hovercard in chat

### DIFF
--- a/packages/web/src/components/chat/__tests__/agent-hovercard.test.tsx
+++ b/packages/web/src/components/chat/__tests__/agent-hovercard.test.tsx
@@ -1,0 +1,321 @@
+// @vitest-environment happy-dom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, type ReactElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getChat: vi.fn(),
+  fetchChatAgentStatuses: vi.fn(),
+  getAgent: vi.fn(),
+}));
+
+vi.mock("../../../api/chats.js", () => ({ getChat: mocks.getChat }));
+vi.mock("../../../api/agent-status.js", () => ({
+  chatAgentStatusQueryKey: (chatId: string) => ["chat-agent-status", chatId],
+  fetchChatAgentStatuses: mocks.fetchChatAgentStatuses,
+}));
+vi.mock("../../../api/agents.js", () => ({ getAgent: mocks.getAgent }));
+vi.mock("../../../lib/use-member-name-map.js", () => ({
+  useMemberNameMap: () => (id: string | null | undefined) => (id === "m1" ? "Gandy" : "—"),
+}));
+vi.mock("../../../lib/use-client-map.js", () => ({
+  useClientMap: () => ({
+    resolve: (id: string | null | undefined) => (id === "c1" ? { hostname: "gandy-mbp" } : null),
+  }),
+}));
+
+// Imported after the mocks are registered.
+import { AgentHovercard } from "../agent-hovercard.js";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: Root | null = null;
+let container: HTMLElement | null = null;
+let queryClient: QueryClient;
+let latestPath = "";
+
+function LocationProbe(): null {
+  latestPath = useLocation().pathname + useLocation().search;
+  return null;
+}
+
+function render(ui: ReactElement): void {
+  act(() => {
+    root?.render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={["/start"]}>
+          <LocationProbe />
+          <Routes>
+            <Route path="*" element={ui} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+  });
+}
+
+function flush(): Promise<void> {
+  return act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+async function waitFor(assertion: () => void): Promise<void> {
+  let lastErr: unknown;
+  for (let i = 0; i < 25; i++) {
+    try {
+      assertion();
+      return;
+    } catch (err) {
+      lastErr = err;
+    }
+    await flush();
+  }
+  throw lastErr;
+}
+
+// Pass A is read from the warm React Query cache (ChatView keeps it hot in the
+// real app). Seed it directly so the test mirrors that warm-cache open.
+function seedPassA(chatId: string, participants: unknown, statuses: unknown): void {
+  queryClient.setQueryData(["chat-detail", chatId], { participants });
+  queryClient.setQueryData(["chat-agent-status", chatId], statuses);
+}
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  // staleTime: Infinity so the seeded Pass A cache (chat-detail / agent-status)
+  // is never background-refetched; Pass B (getAgent) has no seed, so it still
+  // fetches on open.
+  queryClient = new QueryClient({ defaultOptions: { queries: { retry: false, staleTime: Number.POSITIVE_INFINITY } } });
+  Object.defineProperty(window, "innerWidth", { configurable: true, value: 1400 });
+  Object.defineProperty(window, "innerHeight", { configurable: true, value: 900 });
+  mocks.getChat.mockReset();
+  mocks.fetchChatAgentStatuses.mockReset();
+  mocks.getAgent.mockReset();
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container?.remove();
+  container = null;
+  root = null;
+  document.body.innerHTML = "";
+});
+
+const AGENT_PARTICIPANT = {
+  agentId: "a1",
+  role: "member",
+  mode: "active",
+  joinedAt: "2026-01-01T00:00:00.000Z",
+  name: "aria",
+  displayName: "Aria",
+  type: "agent",
+  avatarColorToken: null,
+  avatarImageUrl: null,
+};
+
+const HUMAN_PARTICIPANT = {
+  agentId: "h1",
+  role: "owner",
+  mode: "active",
+  joinedAt: "2026-01-01T00:00:00.000Z",
+  name: "gandy",
+  displayName: "Gandy",
+  type: "human",
+  avatarColorToken: null,
+  avatarImageUrl: null,
+};
+
+const AGENT_DTO = {
+  uuid: "a1",
+  name: "aria",
+  displayName: "Aria",
+  type: "agent",
+  managerId: "m1",
+  clientId: "c1",
+  runtimeProvider: "claude-code",
+  avatarColorToken: null,
+  avatarImageUrl: null,
+};
+
+async function openCard(): Promise<HTMLElement> {
+  const trigger = container?.querySelector<HTMLButtonElement>("button");
+  if (!trigger) throw new Error("trigger not found");
+  await act(async () => {
+    trigger.click();
+    await Promise.resolve();
+  });
+  await flush();
+  const card = document.body.querySelector<HTMLElement>('[role="dialog"]');
+  if (!card) throw new Error("card did not open");
+  return card;
+}
+
+describe("AgentHovercard", () => {
+  it("is closed until the trigger is activated", async () => {
+    seedPassA("chat-1", [AGENT_PARTICIPANT], []);
+    mocks.getAgent.mockResolvedValue(AGENT_DTO);
+    render(
+      <AgentHovercard agentId="a1" chatId="chat-1" name="Aria">
+        <span>Aria</span>
+      </AgentHovercard>,
+    );
+    await flush();
+    expect(document.body.querySelector('[role="dialog"]')).toBeNull();
+  });
+
+  it("shows identity, Owner and Runs-on for an agent (Pass B)", async () => {
+    seedPassA(
+      "chat-1",
+      [AGENT_PARTICIPANT],
+      [
+        {
+          agentId: "a1",
+          main: "ready",
+          reachable: true,
+          engagement: "active",
+          working: false,
+          errored: false,
+          activity: null,
+        },
+      ],
+    );
+    mocks.getAgent.mockResolvedValue(AGENT_DTO);
+    render(
+      <AgentHovercard agentId="a1" chatId="chat-1" name="Aria">
+        <span>Aria</span>
+      </AgentHovercard>,
+    );
+    await flush();
+    const card = await openCard();
+    await waitFor(() => {
+      expect(card.textContent).toContain("Aria");
+      expect(card.textContent).toContain("@aria");
+      expect(card.textContent).toContain("Owner");
+      expect(card.textContent).toContain("Gandy");
+      expect(card.textContent).toContain("Runs on");
+      expect(card.textContent).toContain("claude-code");
+      expect(card.textContent).toContain("gandy-mbp");
+      expect(card.textContent).toContain("Open details");
+      expect(card.textContent).toContain("Chat");
+    });
+    expect(mocks.getAgent).toHaveBeenCalledWith("a1");
+  });
+
+  it("renders a LIVE pill and Working row when the agent is working", async () => {
+    seedPassA(
+      "chat-1",
+      [AGENT_PARTICIPANT],
+      [
+        {
+          agentId: "a1",
+          main: "working",
+          reachable: true,
+          engagement: "active",
+          working: true,
+          errored: false,
+          activity: {
+            agentId: "a1",
+            kind: "tool_call",
+            label: "Bash",
+            startedAt: "2026-01-01T00:00:00.000Z",
+          },
+        },
+      ],
+    );
+    mocks.getAgent.mockResolvedValue(AGENT_DTO);
+    render(
+      <AgentHovercard agentId="a1" chatId="chat-1" name="Aria">
+        <span>Aria</span>
+      </AgentHovercard>,
+    );
+    await flush();
+    const card = await openCard();
+    await waitFor(() => {
+      expect(card.textContent).toContain("LIVE");
+      expect(card.textContent).toContain("Working");
+    });
+  });
+
+  it("navigates to agent details from the Open details action", async () => {
+    seedPassA("chat-1", [AGENT_PARTICIPANT], []);
+    mocks.getAgent.mockResolvedValue(AGENT_DTO);
+    render(
+      <AgentHovercard agentId="a1" chatId="chat-1" name="Aria">
+        <span>Aria</span>
+      </AgentHovercard>,
+    );
+    await flush();
+    const card = await openCard();
+    let openDetails: HTMLButtonElement | undefined;
+    await waitFor(() => {
+      openDetails = [...card.querySelectorAll("button")].find((b) => b.textContent?.includes("Open details"));
+      if (!openDetails) throw new Error("Open details not rendered yet");
+    });
+    await act(async () => {
+      openDetails?.click();
+      await Promise.resolve();
+    });
+    expect(latestPath).toBe("/agents/a1/profile");
+  });
+
+  it("renders the human variant with only a Message action (no Pass B)", async () => {
+    seedPassA("chat-1", [HUMAN_PARTICIPANT], []);
+    render(
+      <AgentHovercard agentId="h1" chatId="chat-1" name="Gandy">
+        <span>Gandy</span>
+      </AgentHovercard>,
+    );
+    await flush();
+    const card = await openCard();
+    await waitFor(() => {
+      expect(card.textContent).toContain("Gandy");
+      expect(card.textContent).toContain("@gandy");
+      expect(card.textContent).toContain("Message");
+    });
+    expect(card.textContent).not.toContain("Owner");
+    expect(card.textContent).not.toContain("Runs on");
+    expect(mocks.getAgent).not.toHaveBeenCalled();
+  });
+
+  it("degrades to identity + Chat when the agent is not readable (Pass B 404)", async () => {
+    // A private agent visible via chat membership but not via GET /agents/:uuid.
+    seedPassA(
+      "chat-1",
+      [AGENT_PARTICIPANT],
+      [
+        {
+          agentId: "a1",
+          main: "ready",
+          reachable: true,
+          engagement: "active",
+          working: false,
+          errored: false,
+          activity: null,
+        },
+      ],
+    );
+    mocks.getAgent.mockRejectedValue(new Error("404"));
+    render(
+      <AgentHovercard agentId="a1" chatId="chat-1" name="Aria">
+        <span>Aria</span>
+      </AgentHovercard>,
+    );
+    await flush();
+    const card = await openCard();
+    await waitFor(() => {
+      expect(card.textContent).toContain("Aria");
+      expect(card.textContent).toContain("Chat");
+    });
+    // No Pass-B fields and no Open details (it would 404 the same way).
+    expect(card.textContent).not.toContain("Owner");
+    expect(card.textContent).not.toContain("Runs on");
+    expect(card.textContent).not.toContain("Open details");
+  });
+});

--- a/packages/web/src/components/chat/__tests__/agent-hovercard.test.tsx
+++ b/packages/web/src/components/chat/__tests__/agent-hovercard.test.tsx
@@ -309,13 +309,16 @@ describe("AgentHovercard", () => {
     );
     await flush();
     const card = await openCard();
+    // Wait for the degraded END state, not the loading state: while getAgent is
+    // still pending, detailsAccessible is true and Owner/Runs-on/Open details
+    // render (with skeletons). Fold the negatives + the Chat-only button set
+    // into the waited condition so the assertions run only after the 404 lands.
     await waitFor(() => {
       expect(card.textContent).toContain("Aria");
-      expect(card.textContent).toContain("Chat");
+      expect([...card.querySelectorAll("button")].map((b) => b.textContent)).toEqual(["Chat"]);
+      expect(card.textContent).not.toContain("Owner");
+      expect(card.textContent).not.toContain("Runs on");
+      expect(card.textContent).not.toContain("Open details");
     });
-    // No Pass-B fields and no Open details (it would 404 the same way).
-    expect(card.textContent).not.toContain("Owner");
-    expect(card.textContent).not.toContain("Runs on");
-    expect(card.textContent).not.toContain("Open details");
   });
 });

--- a/packages/web/src/components/chat/agent-hovercard.tsx
+++ b/packages/web/src/components/chat/agent-hovercard.tsx
@@ -1,0 +1,273 @@
+import type { AgentChatStatus } from "@first-tree/shared";
+import { useQuery } from "@tanstack/react-query";
+import { ArrowRight, MessageSquare } from "lucide-react";
+import type { ReactNode } from "react";
+import { useNavigate } from "react-router";
+import { chatAgentStatusQueryKey, fetchChatAgentStatuses } from "../../api/agent-status.js";
+import { getAgent } from "../../api/agents.js";
+import { getChat } from "../../api/chats.js";
+import { viewOf } from "../../lib/agent-status-view.js";
+import { useClientMap } from "../../lib/use-client-map.js";
+import { useMemberNameMap } from "../../lib/use-member-name-map.js";
+import { Avatar } from "../avatar.js";
+import { Button } from "../ui/button.js";
+import { HoverCard, type HoverCardPlacement } from "../ui/hover-card.js";
+import { StatusGlyph } from "../ui/status-glyph.js";
+import { WorkingChip } from "./working-chip.js";
+
+/**
+ * Shared agent identity hovercard. Wraps any trigger (avatar + name cluster) and,
+ * on hover/focus, previews the agent's identity + live status + Owner / Runs-on,
+ * with `Open details →` / `Chat` actions — so a user in a chat has an in-context
+ * door to the agent without leaving the conversation.
+ *
+ * Two-pass data (never blocks on a fetch):
+ *  - Pass A (instant): identity + type/role from the chat participant list and
+ *    live status from the chat agent-status — both already cached by ChatView.
+ *  - Pass B (lazy on open): Owner + Runs-on from a single getAgent(agentId)
+ *    (managerId → member name; runtimeProvider + clientId → hostname). The body
+ *    only mounts when the card opens, so this query is naturally lazy.
+ */
+export function AgentHovercard({
+  agentId,
+  chatId,
+  name,
+  placement = "bottom",
+  triggerClassName,
+  children,
+}: {
+  agentId: string;
+  chatId: string;
+  /**
+   * Display name of the target, for the trigger's accessible label. Required so
+   * each trigger announces a distinct name — without it the fixed label would
+   * override the visible name text and read identically for every agent.
+   */
+  name: string;
+  placement?: HoverCardPlacement;
+  triggerClassName?: string;
+  children: ReactNode;
+}) {
+  return (
+    <HoverCard
+      placement={placement}
+      ariaLabel={`${name} — view details`}
+      triggerClassName={triggerClassName}
+      contentStyle={{
+        width: "var(--sp-70)",
+        maxWidth: "calc(100vw - var(--sp-4))",
+        background: "var(--bg-raised)",
+        border: "var(--hairline) solid var(--border)",
+        borderRadius: "var(--radius-panel)",
+        boxShadow: "var(--shadow-md)",
+        padding: "var(--sp-3)",
+      }}
+      content={({ close }) => <AgentHovercardBody agentId={agentId} chatId={chatId} onAction={close} />}
+    >
+      {children}
+    </HoverCard>
+  );
+}
+
+function AgentHovercardBody({ agentId, chatId, onAction }: { agentId: string; chatId: string; onAction: () => void }) {
+  const navigate = useNavigate();
+  const resolveMember = useMemberNameMap();
+  const { resolve: resolveClient } = useClientMap();
+
+  // Pass A — cached by ChatView, so these are hits (instant). staleTime keeps a
+  // warm cache from refetching on every card open: scanning many names in a busy
+  // timeline/sidebar would otherwise fire a GET /chats/:id + /agent-status per
+  // hover. ChatView's own observers (agent-status refetchInterval + WS
+  // invalidation) keep the data fresh; the card only needs to read it.
+  const chatQ = useQuery({
+    queryKey: ["chat-detail", chatId],
+    queryFn: () => getChat(chatId),
+    staleTime: 30_000,
+  });
+  const statusQ = useQuery({
+    queryKey: chatAgentStatusQueryKey(chatId),
+    queryFn: () => fetchChatAgentStatuses(chatId),
+    staleTime: 30_000,
+  });
+
+  const participant = chatQ.data?.participants.find((p) => p.agentId === agentId);
+  const status: AgentChatStatus | null = statusQ.data?.find((s) => s.agentId === agentId) ?? null;
+
+  // Pass B — lazy: this body only mounts while the card is open. Gated on the
+  // chat (Pass A) resolving so the human check is decided from real data —
+  // otherwise a cold-cache open would fire getAgent before we know the type and
+  // 404 on a human. In practice ChatView keeps Pass A warm, so this is instant.
+  const agentQ = useQuery({
+    queryKey: ["agent", agentId],
+    queryFn: () => getAgent(agentId),
+    enabled: chatQ.isSuccess && participant?.type !== "human",
+    staleTime: 30_000,
+  });
+
+  const isHuman = (participant?.type ?? agentQ.data?.type) === "human";
+  const displayName = participant?.displayName ?? agentQ.data?.displayName ?? "…";
+  const handle = participant?.name ?? agentQ.data?.name ?? agentId.slice(0, 8);
+  const avatarImageUrl = participant?.avatarImageUrl ?? agentQ.data?.avatarImageUrl ?? null;
+  const avatarColorToken = participant?.avatarColorToken ?? agentQ.data?.avatarColorToken ?? null;
+
+  const main = status?.main;
+  const isWorking = main === "working" || main === "failed";
+  const workingActivity = isWorking ? (status?.activity ?? null) : null;
+  // Pass B 404s for a private agent visible only via chat membership (getAgent +
+  // the agent-detail route are both visibility-gated). When that happens, drop
+  // the Owner/Runs-on rows and the Open details action rather than show dashes
+  // and route to a page the viewer can't open.
+  const detailsAccessible = !agentQ.isError;
+  const showMeta = detailsAccessible || workingActivity !== null;
+
+  function openDetails() {
+    onAction();
+    navigate(`/agents/${agentId}/profile`);
+  }
+  function openChat() {
+    onAction();
+    // Type-agnostic draft compose (same path as the agent-detail Chat button);
+    // works for agents and humans without an agent-vs-human chat-create fork.
+    navigate(`/?c=draft&with=${encodeURIComponent(agentId)}`);
+  }
+
+  return (
+    <div className="flex flex-col" style={{ gap: "var(--sp-2_5)" }}>
+      {/* Head */}
+      <div className="flex items-center" style={{ gap: "var(--sp-2_5)" }}>
+        <span className="relative shrink-0" style={{ width: 38, height: 38 }}>
+          <Avatar src={avatarImageUrl} name={displayName} seed={agentId} colorToken={avatarColorToken} size={38} />
+          {!isHuman && status ? <StatusDot status={status} /> : null}
+        </span>
+        <div className="flex min-w-0 flex-1 flex-col" style={{ gap: 1 }}>
+          <div className="truncate text-subtitle" style={{ color: "var(--fg)" }}>
+            {displayName}
+          </div>
+          <div className="mono text-caption truncate" style={{ color: "var(--fg-4)" }}>
+            @{handle}
+          </div>
+        </div>
+        {!isHuman && main === "working" ? (
+          <span className="mono text-eyebrow shrink-0" style={{ color: "var(--state-working)" }}>
+            LIVE
+          </span>
+        ) : null}
+      </div>
+
+      {/* Agent-only meta + actions. Humans get just a Message action. */}
+      {isHuman ? (
+        <>
+          <Divider />
+          <Button size="sm" variant="outline" onClick={openChat}>
+            <MessageSquare className="h-4 w-4" />
+            Message
+          </Button>
+        </>
+      ) : (
+        <>
+          {showMeta ? (
+            <>
+              <Divider />
+              <div className="flex flex-col" style={{ gap: "var(--sp-1_5)" }}>
+                {detailsAccessible ? (
+                  <>
+                    <MetaRow label="Owner">
+                      {agentQ.isLoading ? <Skeleton /> : resolveMember(agentQ.data?.managerId)}
+                    </MetaRow>
+                    <MetaRow label="Runs on">
+                      {agentQ.isLoading ? (
+                        <Skeleton />
+                      ) : agentQ.data?.clientId ? (
+                        <span className="mono">
+                          {agentQ.data.runtimeProvider} ·{" "}
+                          {resolveClient(agentQ.data.clientId)?.hostname ?? agentQ.data.clientId}
+                        </span>
+                      ) : (
+                        <span style={{ color: "var(--fg-4)" }}>— not bound</span>
+                      )}
+                    </MetaRow>
+                  </>
+                ) : null}
+                {workingActivity ? (
+                  <MetaRow label="Working">
+                    <WorkingChip activity={workingActivity} showDot={false} />
+                  </MetaRow>
+                ) : null}
+              </div>
+            </>
+          ) : null}
+          <Divider />
+          <div className="flex" style={{ gap: "var(--sp-2)" }}>
+            {detailsAccessible ? (
+              <>
+                <Button size="sm" onClick={openDetails} style={{ flex: 1 }}>
+                  Open details
+                  <ArrowRight className="h-4 w-4" />
+                </Button>
+                <Button size="sm" variant="ghost" onClick={openChat}>
+                  <MessageSquare className="h-4 w-4" />
+                  Chat
+                </Button>
+              </>
+            ) : (
+              // Pass B 404 → a private agent the viewer can see in chat but not
+              // open via /agents/:uuid. Hide Owner/Runs-on + Open details (they'd
+              // 404); keep Chat (they already share this chat).
+              <Button size="sm" variant="outline" onClick={openChat} style={{ flex: 1 }}>
+                <MessageSquare className="h-4 w-4" />
+                Chat
+              </Button>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+function MetaRow({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="grid items-baseline" style={{ gridTemplateColumns: "var(--sp-16) 1fr", gap: "var(--sp-2)" }}>
+      <div className="text-eyebrow" style={{ color: "var(--fg-4)" }}>
+        {label}
+      </div>
+      <div className="text-caption min-w-0 truncate" style={{ color: "var(--fg-2)" }}>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function Divider() {
+  return <div style={{ borderTop: "var(--hairline) solid var(--border-faint)" }} />;
+}
+
+function Skeleton() {
+  return (
+    <span
+      aria-hidden
+      className="inline-block rounded-[var(--radius-chip)]"
+      style={{ width: "var(--sp-20)", height: "var(--sp-2_5)", background: "var(--bg-sunken)" }}
+    />
+  );
+}
+
+/**
+ * The avatar status dot — same `viewOf` vocabulary (shape / colour / pulse) as
+ * the right-sidebar AgentStatusRow, so an agent reads identically in both places.
+ */
+function StatusDot({ status }: { status: AgentChatStatus }) {
+  const view = viewOf(status.main);
+  return (
+    <span className="absolute" style={{ right: -2, bottom: -3 }}>
+      <StatusGlyph
+        colorVar={view.colorVar}
+        shape={view.shape}
+        pulse={view.pulse}
+        size={9}
+        ariaLabel={view.label}
+        separator
+      />
+    </span>
+  );
+}

--- a/packages/web/src/components/chat/agent-status-panel.tsx
+++ b/packages/web/src/components/chat/agent-status-panel.tsx
@@ -8,6 +8,7 @@ import { toneOf } from "../../lib/tones.js";
 import { isJumpable, useMountedAnchors } from "../../lib/use-mounted-anchors.js";
 import { Avatar } from "../avatar.js";
 import { StatusGlyph } from "../ui/status-glyph.js";
+import { AgentHovercard } from "./agent-hovercard.js";
 import { TimelineJumpButton } from "./timeline-jump-button.js";
 import { WorkingChip } from "./working-chip.js";
 
@@ -118,36 +119,52 @@ function AgentStatusRow({
       className="flex items-center transition-colors hover:bg-[var(--bg-hover)]"
       style={{ gap: "var(--sp-2_5)", padding: "var(--sp-1_75) var(--sp-2)", borderRadius: "var(--radius-input)" }}
     >
-      <div className="relative shrink-0" style={{ width: 28, height: 28 }}>
-        <Avatar
-          src={agent.avatarImageUrl}
-          name={agent.displayName}
-          seed={agent.agentId}
-          colorToken={agent.avatarColorToken}
-          size={28}
-        />
-        {view ? (
-          <span
-            className="absolute"
-            style={{
-              right: -2,
-              bottom: -3,
-            }}
-          >
-            <StatusGlyph
-              colorVar={view.colorVar}
-              shape={view.shape}
-              pulse={view.pulse}
-              size={9}
-              ariaLabel={view.label}
-              separator
-            />
-          </span>
-        ) : null}
-      </div>
+      <AgentHovercard
+        agentId={agent.agentId}
+        chatId={chatId}
+        name={agent.displayName}
+        placement="left"
+        triggerClassName="block shrink-0 cursor-pointer rounded-full"
+      >
+        <span className="relative block" style={{ width: 28, height: 28 }}>
+          <Avatar
+            src={agent.avatarImageUrl}
+            name={agent.displayName}
+            seed={agent.agentId}
+            colorToken={agent.avatarColorToken}
+            size={28}
+          />
+          {view ? (
+            <span
+              className="absolute"
+              style={{
+                right: -2,
+                bottom: -3,
+              }}
+            >
+              <StatusGlyph
+                colorVar={view.colorVar}
+                shape={view.shape}
+                pulse={view.pulse}
+                size={9}
+                ariaLabel={view.label}
+                separator
+              />
+            </span>
+          ) : null}
+        </span>
+      </AgentHovercard>
 
       <div className="flex min-w-0 flex-1 flex-col" style={{ gap: 2 }}>
-        <div className="truncate text-subtitle">{agent.displayName}</div>
+        <AgentHovercard
+          agentId={agent.agentId}
+          chatId={chatId}
+          name={agent.displayName}
+          placement="left"
+          triggerClassName="block max-w-full cursor-pointer truncate text-left text-subtitle hover:underline"
+        >
+          {agent.displayName}
+        </AgentHovercard>
         <SecondLine status={status} mounted={mounted} />
       </div>
 

--- a/packages/web/src/components/ui/hover-card.tsx
+++ b/packages/web/src/components/ui/hover-card.tsx
@@ -1,0 +1,238 @@
+import { type ReactNode, useCallback, useEffect, useId, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { useLocation } from "react-router";
+
+/**
+ * Hover-intent floating card primitive (no dependency). Generic interaction
+ * shell — knows nothing about agents. `<AgentHovercard>` (and later @mention
+ * chips) build their content on top.
+ *
+ * Behavior:
+ *  - desktop: hover the trigger ~400ms (intent) to open; a ~150ms grace lets the
+ *    pointer cross the gap into the card without closing.
+ *  - click the trigger = open + PIN (won't dismiss on mouse-out).
+ *  - close: mouse-out past grace (unpinned) / Esc / outside click / scroll /
+ *    route change.
+ *  - a11y: the trigger is a focusable control (aria-haspopup/expanded);
+ *    Enter/Space opens and moves focus into the card; Esc closes + restores focus.
+ *  - portal + viewport-aware placement with flip/clamp.
+ *
+ * Positioning is hand-rolled (matches the repo's dependency-light style). If it
+ * ever can't keep the card in view, swap to @floating-ui — the API here is small.
+ */
+
+const OPEN_DELAY_MS = 400;
+const CLOSE_GRACE_MS = 150;
+const VIEWPORT_MARGIN = 8;
+
+export type HoverCardPlacement = "left" | "right" | "bottom";
+
+type Coords = { top: number; left: number };
+
+export function HoverCard({
+  children,
+  content,
+  placement = "bottom",
+  contentClassName,
+  contentStyle,
+  triggerClassName,
+  ariaLabel,
+}: {
+  /** The inline trigger (e.g. avatar + name cluster). */
+  children: ReactNode;
+  /** Floating card body; receives `close` to wire action buttons. */
+  content: (api: { close: () => void }) => ReactNode;
+  placement?: HoverCardPlacement;
+  contentClassName?: string;
+  contentStyle?: React.CSSProperties;
+  triggerClassName?: string;
+  ariaLabel?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const [pinned, setPinned] = useState(false);
+  const [coords, setCoords] = useState<Coords | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const cardRef = useRef<HTMLDivElement | null>(null);
+  const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const openTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const focusOnOpen = useRef(false);
+  const panelId = useId();
+  const location = useLocation();
+
+  const clearTimers = useCallback(() => {
+    if (closeTimer.current) clearTimeout(closeTimer.current);
+    if (openTimer.current) clearTimeout(openTimer.current);
+    closeTimer.current = null;
+    openTimer.current = null;
+  }, []);
+
+  const close = useCallback(() => {
+    clearTimers();
+    setOpen(false);
+    setPinned(false);
+  }, [clearTimers]);
+
+  // Route change closes the card (it may unmount the trigger / point at a stale agent).
+  // biome-ignore lint/correctness/useExhaustiveDependencies: location.pathname is the close trigger; close is stable.
+  useEffect(() => {
+    close();
+  }, [location.pathname]);
+
+  // Position the card on open (and on resize), with flip + clamp to viewport.
+  useLayoutEffect(() => {
+    if (!open) return;
+    const place = () => {
+      const t = triggerRef.current;
+      const card = cardRef.current;
+      if (!t || !card) return;
+      const tr = t.getBoundingClientRect();
+      const cw = card.offsetWidth;
+      const ch = card.offsetHeight;
+      const vw = window.innerWidth;
+      const vh = window.innerHeight;
+
+      let left: number;
+      let top: number;
+      if (placement === "left" || placement === "right") {
+        // Vertically aligned to the trigger; horizontally beside it, flip if needed.
+        const wantLeft = placement === "left";
+        const leftPos = tr.left - cw - 6;
+        const rightPos = tr.right + 6;
+        const fitsLeft = leftPos >= VIEWPORT_MARGIN;
+        const fitsRight = rightPos + cw <= vw - VIEWPORT_MARGIN;
+        left = wantLeft ? (fitsLeft ? leftPos : rightPos) : fitsRight ? rightPos : leftPos;
+        top = tr.top;
+      } else {
+        // bottom: below the trigger, flip above if it would overflow.
+        left = tr.left;
+        const belowTop = tr.bottom + 6;
+        const aboveTop = tr.top - ch - 6;
+        top = belowTop + ch <= vh - VIEWPORT_MARGIN || aboveTop < VIEWPORT_MARGIN ? belowTop : aboveTop;
+      }
+      // Clamp inside the viewport on both axes.
+      left = Math.max(VIEWPORT_MARGIN, Math.min(left, vw - cw - VIEWPORT_MARGIN));
+      top = Math.max(VIEWPORT_MARGIN, Math.min(top, vh - ch - VIEWPORT_MARGIN));
+      setCoords({ top, left });
+    };
+    place();
+    window.addEventListener("resize", place);
+    return () => window.removeEventListener("resize", place);
+  }, [open, placement]);
+
+  // Move focus into the card when opened via keyboard.
+  useEffect(() => {
+    if (!open || !focusOnOpen.current) return;
+    focusOnOpen.current = false;
+    const card = cardRef.current;
+    if (!card) return;
+    const focusable = card.querySelector<HTMLElement>('a[href],button:not([disabled]),[tabindex]:not([tabindex="-1"])');
+    (focusable ?? card).focus();
+  }, [open]);
+
+  // Global close listeners while open: Esc, outside click/pointer, scroll.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        close();
+        triggerRef.current?.focus();
+      }
+    };
+    const onPointerDown = (e: PointerEvent) => {
+      const target = e.target as Node;
+      if (triggerRef.current?.contains(target) || cardRef.current?.contains(target)) return;
+      close();
+    };
+    const onScroll = () => close();
+    document.addEventListener("keydown", onKey, true);
+    document.addEventListener("pointerdown", onPointerDown, true);
+    // Capture scroll on any scroller; ignore scrolls inside the card itself.
+    window.addEventListener("scroll", onScroll, true);
+    return () => {
+      document.removeEventListener("keydown", onKey, true);
+      document.removeEventListener("pointerdown", onPointerDown, true);
+      window.removeEventListener("scroll", onScroll, true);
+    };
+  }, [open, close]);
+
+  useEffect(() => clearTimers, [clearTimers]);
+
+  const scheduleOpen = () => {
+    clearTimers();
+    openTimer.current = setTimeout(() => setOpen(true), OPEN_DELAY_MS);
+  };
+  const scheduleClose = () => {
+    if (pinned) return;
+    clearTimers();
+    closeTimer.current = setTimeout(() => setOpen(false), CLOSE_GRACE_MS);
+  };
+  const cancelClose = () => {
+    if (closeTimer.current) clearTimeout(closeTimer.current);
+    closeTimer.current = null;
+  };
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        aria-controls={open ? panelId : undefined}
+        aria-label={ariaLabel}
+        className={triggerClassName}
+        onPointerEnter={(e) => {
+          if (e.pointerType === "mouse") scheduleOpen();
+        }}
+        onPointerLeave={(e) => {
+          if (e.pointerType === "mouse") scheduleClose();
+        }}
+        onClick={() => {
+          clearTimers();
+          setPinned(true);
+          setOpen(true);
+        }}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            clearTimers();
+            focusOnOpen.current = true;
+            setPinned(true);
+            setOpen(true);
+          }
+        }}
+      >
+        {children}
+      </button>
+      {open
+        ? createPortal(
+            <div
+              ref={cardRef}
+              id={panelId}
+              role="dialog"
+              aria-label={ariaLabel}
+              tabIndex={-1}
+              className={contentClassName}
+              style={{
+                position: "fixed",
+                top: coords?.top ?? -9999,
+                left: coords?.left ?? -9999,
+                zIndex: 60,
+                // Hidden until positioned, so it never flashes at the origin.
+                visibility: coords ? "visible" : "hidden",
+                ...contentStyle,
+              }}
+              onPointerEnter={cancelClose}
+              onPointerLeave={(e) => {
+                if (e.pointerType === "mouse") scheduleClose();
+              }}
+            >
+              {content({ close })}
+            </div>,
+            document.body,
+          )
+        : null}
+    </>
+  );
+}

--- a/packages/web/src/components/ui/hover-card.tsx
+++ b/packages/web/src/components/ui/hover-card.tsx
@@ -144,10 +144,15 @@ export function HoverCard({
       if (triggerRef.current?.contains(target) || cardRef.current?.contains(target)) return;
       close();
     };
-    const onScroll = () => close();
+    // Capture scroll on any scroller closes the card — except a scroll that
+    // originates inside the card body (if it ever becomes scrollable), so the
+    // card doesn't dismiss itself when the user scrolls its own content.
+    const onScroll = (e: Event) => {
+      if (cardRef.current?.contains(e.target as Node)) return;
+      close();
+    };
     document.addEventListener("keydown", onKey, true);
     document.addEventListener("pointerdown", onPointerDown, true);
-    // Capture scroll on any scroller; ignore scrolls inside the card itself.
     window.addEventListener("scroll", onScroll, true);
     return () => {
       document.removeEventListener("keydown", onKey, true);

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -64,6 +64,7 @@ import {
 import { useAuth } from "../../../auth/auth-context.js";
 import { AddParticipantDropdown } from "../../../components/add-participant-dropdown.js";
 import { Avatar as RealAvatar } from "../../../components/avatar.js";
+import { AgentHovercard } from "../../../components/chat/agent-hovercard.js";
 import { ComposeStatusBar } from "../../../components/chat/compose-status-bar.js";
 import {
   GITHUB_SYSTEM_SENDER_NAME,
@@ -492,23 +493,40 @@ function TextRow({
       {isGithubSystem ? (
         <GithubSystemAvatar size={20} />
       ) : (
-        <Avatar
+        <AgentHovercard
+          agentId={msg.senderId}
+          chatId={msg.chatId}
           name={senderName}
-          imageUrl={agentAvatarFn(msg.senderId)}
-          seed={msg.senderId}
-          colorToken={agentColorTokenFn(msg.senderId)}
-        />
+          placement="right"
+          triggerClassName="block cursor-pointer self-start rounded-full"
+        >
+          <Avatar
+            name={senderName}
+            imageUrl={agentAvatarFn(msg.senderId)}
+            seed={msg.senderId}
+            colorToken={agentColorTokenFn(msg.senderId)}
+          />
+        </AgentHovercard>
       )}
       <div className="min-w-0">
         <div className="flex items-baseline" style={{ gap: 8 }}>
-          <span
-            className="mono text-body font-semibold"
-            style={{
-              color: isSelf ? "var(--fg)" : "var(--primary)",
-            }}
-          >
-            {senderName}
-          </span>
+          {isGithubSystem ? (
+            <span className="mono text-body font-semibold" style={{ color: isSelf ? "var(--fg)" : "var(--primary)" }}>
+              {senderName}
+            </span>
+          ) : (
+            <AgentHovercard
+              agentId={msg.senderId}
+              chatId={msg.chatId}
+              name={senderName}
+              placement="bottom"
+              triggerClassName="cursor-pointer hover:underline"
+            >
+              <span className="mono text-body font-semibold" style={{ color: isSelf ? "var(--fg)" : "var(--primary)" }}>
+                {senderName}
+              </span>
+            </AgentHovercard>
+          )}
           <span className="mono text-caption" style={{ color: "var(--fg-4)" }}>
             {formatClockTime(msg.createdAt)}
           </span>


### PR DESCRIPTION
## What

Adds a hover/click **agent identity hovercard** at agent avatar + name locations in chat, so a user can preview an agent — identity, live status, Owner, Runs-on — and jump to its details or start a chat **without leaving the conversation**.

## How

- **`components/ui/hover-card.tsx`** — generic, dependency-free hover-intent floating-card primitive. Open delay (~400ms) + close grace (~150ms) so the pointer can cross the gap into the card; click-to-pin; dismiss on Esc / outside-pointerdown / scroll(capture) / route change; portal to `document.body`; viewport-aware placement with flip + clamp; a11y (`aria-haspopup="dialog"`, keyboard open moves focus into the card, Esc restores focus to the trigger). Knows nothing about agents.
- **`components/chat/agent-hovercard.tsx`** — two-pass data, never blocks:
  - **Pass A** (instant, zero request): identity + type from the warm `chat-detail` participant cache, live status from the chat agent-status cache — both already kept hot by ChatView.
  - **Pass B** (lazy on open): a single `getAgent(agentId)` for Owner (managerId → member name) and Runs-on (runtimeProvider + clientId → hostname). The card body only mounts when open, so this is naturally lazy.
  - Variants: **agent** / **human** (Message-only) / **working** (LIVE pill + Working row). Actions: `Open details →` `/agents/:id/profile`; `Chat` / `Message` → `/?c=draft&with=<id>` (type-agnostic draft compose, same path as the agent-detail Chat button).
- **Mount points**: sidebar `AgentStatusRow` (avatar + name as triggers — the SecondLine timeline-jump and Pause controls are left untouched) and chat **message bubbles** (avatar + sender name). GitHub-system messages are **not** wrapped (no real agent identity).

## Reviewer focus

1. **Trigger gesture/exit audit** — both mount points: avatar + name trigger only; they don't swallow the SecondLine timeline-jump or Pause; bubbles wrap only rows that actually render an avatar + name (no continuation rows); system messages skipped.
2. **Private-agent 404 degradation** — a private agent visible via chat membership but `visibility`-gated on `/agents/:uuid`: `getAgent` 404s → the card drops Owner/Runs-on and the (also-404) `Open details`, showing identity + status + a full-width `Chat`. (Covered by a degradation test.)
3. **Two-pass data** — Pass A reads warm cache (zero request, instant); Pass B is lazy `getAgent` with `staleTime: 30_000` so scanning many names in a busy timeline/sidebar doesn't refetch `GET /chats/:id` + `/agent-status` per open.
4. **HoverCard primitive** — flip+clamp stays in viewport; every dismiss path; a11y (focus into card, Esc restores focus).

## Verification

- `pnpm check` clean · `pnpm typecheck` 11/11 · **700 web tests** (6 new hovercard tests).
- Three independent codex reviews (high effort): passes 1–2 surfaced 3 `[P2]` issues (private-agent 404, refetch-on-open, aria-label clobbering the visible name) — all fixed; pass 3 clean.
- Visual check via a temporary DEV preview (reverted, not committed): agent-ready / working (LIVE + Working row) / human (Message-only) variants + dark mode all correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)