### PR TITLE
fix(client): managed-state writes to .first-tree-workspace/, not legacy .agent/

### DIFF
--- a/docs/development/agent-workspace-state.md
+++ b/docs/development/agent-workspace-state.md
@@ -2,7 +2,7 @@
 
 This page documents the CLI-owned state files that live inside an agent's
 home directory and the contract they enforce. If you're touching anything
-under `<workspace>/.agent/`, anything that calls `prepareSourceRepos`,
+under `<workspace>/.first-tree-workspace/`, anything that calls `prepareSourceRepos`,
 `installFirstTreeSkills`, or `ensureAgentBootstrap`, or you're proposing a
 new directory-structure migration — start here.
 
@@ -25,13 +25,13 @@ sit on disk forever. The state files below are that record.
 
 | Path (relative to workspace root) | Owner | What it is |
 | --- | --- | --- |
-| `.agent/managed.json` | `runtime/managed-state.ts` | Schema-versioned record of the CLI-managed resources currently materialised in this workspace. Two arrays: `sourceRepos` (localPath names) and `skills` (skill names). Diffed on every session start to discover removals. |
-| `.agent/migrations-applied.json` | `runtime/workspace-migrations.ts` | Set of one-shot directory-structure migration ids that have already run in this workspace. Each migration runs at most once even if it's later removed from the registry; the marker stays as forward protection. |
+| `.first-tree-workspace/managed.json` | `runtime/managed-state.ts` | Schema-versioned record of the CLI-managed resources currently materialised in this workspace. Two arrays: `sourceRepos` (localPath names) and `skills` (skill names). Diffed on every session start to discover removals. |
+| `.first-tree-workspace/migrations-applied.json` | `runtime/workspace-migrations.ts` | Set of one-shot directory-structure migration ids that have already run in this workspace. Each migration runs at most once even if it's later removed from the registry; the marker stays as forward protection. |
 
 Both files use atomic writes (temp + rename) so a crashed writer never
 leaves a half-formed JSON record on disk.
 
-### `.agent/managed.json` schema
+### `.first-tree-workspace/managed.json` schema
 
 ```json
 {
@@ -55,7 +55,7 @@ When the file is missing or malformed, the reconcile path treats it as
 "first run on this workspace" and performs no deletions — the safe
 default.
 
-### `.agent/migrations-applied.json` schema
+### `.first-tree-workspace/migrations-applied.json` schema
 
 ```json
 { "schemaVersion": 1, "applied": ["v1-uuid-snapshots", "v1-whitepaper-symlink"] }
@@ -183,4 +183,4 @@ sweep:
 - `runtime/agent-bootstrap.ts` — wires migrations into session start
 - `packages/shared/src/schemas/workspace-manifest.ts` — the W1 binding
   manifest at `<workspace>/.first-tree/workspace.json` (distinct from
-  `.agent/`; never touched by this machinery)
+  `.first-tree-workspace/`; never touched by this machinery)

--- a/packages/client/src/__tests__/managed-state.test.ts
+++ b/packages/client/src/__tests__/managed-state.test.ts
@@ -15,7 +15,7 @@ describe("managed-state", () => {
 
   beforeEach(() => {
     workspace = mkdtempSync(join(tmpdir(), "managed-state-test-"));
-    mkdirSync(join(workspace, ".agent"), { recursive: true });
+    mkdirSync(join(workspace, ".first-tree-workspace"), { recursive: true });
   });
 
   afterEach(() => {
@@ -120,7 +120,7 @@ describe("managed-state", () => {
     };
     writeManagedState(workspace, state);
     // The directory should contain only the final file, no `.tmp` siblings.
-    const agentDir = join(workspace, ".agent");
+    const agentDir = join(workspace, ".first-tree-workspace");
     const entries = readdirSync(agentDir);
     expect(entries.filter((entry) => entry.includes(".tmp"))).toEqual([]);
     expect(entries).toContain("managed.json");

--- a/packages/client/src/__tests__/skills-state-reconcile.test.ts
+++ b/packages/client/src/__tests__/skills-state-reconcile.test.ts
@@ -52,7 +52,7 @@ describe("installFirstTreeSkills — state-based skill reconcile (PR #869 P1-3)"
   beforeEach(() => {
     tmpBase = mkdtempSync(join(tmpdir(), "skill-reconcile-"));
     workspace = join(tmpBase, "ws");
-    mkdirSync(join(workspace, ".agent"), { recursive: true });
+    mkdirSync(join(workspace, ".first-tree-workspace"), { recursive: true });
     bundledSkillsRoot = makeBundledSkillsRoot(tmpBase);
   });
 

--- a/packages/client/src/__tests__/source-repos-state-reconcile.test.ts
+++ b/packages/client/src/__tests__/source-repos-state-reconcile.test.ts
@@ -106,7 +106,7 @@ describe("prepareSourceRepos — state-based reconcile (PR #869 P1-3)", () => {
 
   beforeEach(() => {
     workspace = mkdtempSync(join(tmpdir(), "state-reconcile-"));
-    mkdirSync(join(workspace, ".agent"), { recursive: true });
+    mkdirSync(join(workspace, ".first-tree-workspace"), { recursive: true });
   });
 
   afterEach(() => {
@@ -201,7 +201,7 @@ describe("prepareSourceRepos — state-based reconcile (PR #869 P1-3)", () => {
       sourceRepos: ["repo-a", "repo-b"],
       skills: [],
     });
-    const stateBefore = readFileSync(join(workspace, ".agent", "managed.json"), "utf-8");
+    const stateBefore = readFileSync(join(workspace, ".first-tree-workspace", "managed.json"), "utf-8");
 
     const { manager } = makeManager();
     await prepareSourceRepos({
@@ -217,7 +217,7 @@ describe("prepareSourceRepos — state-based reconcile (PR #869 P1-3)", () => {
     expect(existsSync(join(workspace, "repo-a"))).toBe(true);
     expect(existsSync(join(workspace, "repo-b"))).toBe(true);
     // State unchanged — no write happens when reconcile is suppressed.
-    const stateAfter = readFileSync(join(workspace, ".agent", "managed.json"), "utf-8");
+    const stateAfter = readFileSync(join(workspace, ".first-tree-workspace", "managed.json"), "utf-8");
     expect(stateAfter).toBe(stateBefore);
   });
 

--- a/packages/client/src/__tests__/workspace-migrations.test.ts
+++ b/packages/client/src/__tests__/workspace-migrations.test.ts
@@ -1,5 +1,14 @@
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -367,6 +376,72 @@ describe("workspace-migrations registry", () => {
     expect(result.deferred).toContain("v1-orphan-ft-clones");
     expect(existsSync(join(workspace, "first-tree", ".git"))).toBe(true);
     expect(existsSync(join(workspace, "first-tree-hub"))).toBe(true);
+  });
+
+  it("v1-orphan-skills removes hardcoded legacy skill payloads + matching .claude symlinks", () => {
+    // Plant each of the 6 retired skills on disk in the canonical layout
+    // (`.agents/skills/<name>/SKILL.md` + `.claude/skills/<name>` symlink).
+    // The migration must remove all of them in one pass.
+    const legacy = [
+      "attention",
+      "first-tree-cloud",
+      "first-tree-github-scan",
+      "first-tree-onboarding",
+      "first-tree-write",
+      "github-scan",
+    ];
+    mkdirSync(join(workspace, ".claude", "skills"), { recursive: true });
+    for (const name of legacy) {
+      const agentsDir = join(workspace, ".agents", "skills", name);
+      mkdirSync(agentsDir, { recursive: true });
+      writeFileSync(join(agentsDir, "SKILL.md"), `---\nname: ${name}\n---\nstale ${name}\n`);
+      symlinkSync(join("..", "..", ".agents", "skills", name), join(workspace, ".claude", "skills", name));
+    }
+
+    const result = applyPendingMigrations(workspace, () => {}, { currentSourceRepoNames: new Set() });
+
+    for (const name of legacy) {
+      expect(existsSync(join(workspace, ".agents", "skills", name))).toBe(false);
+      // The symlink itself should be gone, not just dangling.
+      expect(() => lstatSync(join(workspace, ".claude", "skills", name))).toThrow();
+    }
+    expect(result.applied).toContain("v1-orphan-skills");
+  });
+
+  it("v1-orphan-skills leaves current skill payloads alone (only the hardcoded historical list matches)", () => {
+    // Plant a currently-bundled skill alongside one of the legacy names.
+    // The current skill must survive; the legacy one must go.
+    mkdirSync(join(workspace, ".claude", "skills"), { recursive: true });
+    const currentName = "first-tree-context"; // still in TREE_SKILL_NAMES
+    const legacyName = "first-tree-cloud"; // retired
+    for (const name of [currentName, legacyName]) {
+      const agentsDir = join(workspace, ".agents", "skills", name);
+      mkdirSync(agentsDir, { recursive: true });
+      writeFileSync(join(agentsDir, "SKILL.md"), `---\nname: ${name}\n---\n`);
+      symlinkSync(join("..", "..", ".agents", "skills", name), join(workspace, ".claude", "skills", name));
+    }
+
+    applyPendingMigrations(workspace, () => {}, { currentSourceRepoNames: new Set() });
+
+    expect(existsSync(join(workspace, ".agents", "skills", currentName, "SKILL.md"))).toBe(true);
+    expect(lstatSync(join(workspace, ".claude", "skills", currentName)).isSymbolicLink()).toBe(true);
+    expect(existsSync(join(workspace, ".agents", "skills", legacyName))).toBe(false);
+  });
+
+  it("v1-orphan-skills does NOT remove a `.claude/skills/<legacy>` entry that's a regular directory (not a symlink)", () => {
+    // A user-authored regular directory at the Claude path — the migration
+    // unlinks ONLY when the entry is a symbolic link, so this should
+    // survive. The `.agents/skills/<legacy>/` payload (if any) is still
+    // removed because that path IS owned by the CLI by convention.
+    const name = "attention";
+    const claudeDir = join(workspace, ".claude", "skills", name);
+    mkdirSync(claudeDir, { recursive: true });
+    writeFileSync(join(claudeDir, "user-content.md"), "# my notes\n");
+
+    applyPendingMigrations(workspace, () => {}, { currentSourceRepoNames: new Set() });
+
+    expect(existsSync(claudeDir)).toBe(true);
+    expect(existsSync(join(claudeDir, "user-content.md"))).toBe(true);
   });
 });
 

--- a/packages/client/src/__tests__/workspace-migrations.test.ts
+++ b/packages/client/src/__tests__/workspace-migrations.test.ts
@@ -21,7 +21,7 @@ describe("workspace-migrations registry", () => {
 
   beforeEach(() => {
     workspace = mkdtempSync(join(tmpdir(), "workspace-migrations-test-"));
-    mkdirSync(join(workspace, ".agent"), { recursive: true });
+    mkdirSync(join(workspace, ".first-tree-workspace"), { recursive: true });
   });
 
   afterEach(() => {
@@ -69,7 +69,7 @@ describe("workspace-migrations registry", () => {
     mkdirSync(uuidDir);
     writeFileSync(join(uuidDir, "AGENTS.md"), "# legacy snapshot\n");
     writeFileSync(
-      join(workspace, ".agent", "managed.json"),
+      join(workspace, ".first-tree-workspace", "managed.json"),
       JSON.stringify({
         schemaVersion: 1,
         cliVersion: "test",
@@ -109,7 +109,7 @@ describe("workspace-migrations registry", () => {
     mkdirSync(uuidRepo);
     writeFileSync(join(uuidRepo, "AGENTS.md"), "# this repo happens to ship AGENTS.md\n");
     writeFileSync(
-      join(workspace, ".agent", "managed.json"),
+      join(workspace, ".first-tree-workspace", "managed.json"),
       JSON.stringify({
         schemaVersion: 1,
         cliVersion: "test",
@@ -175,7 +175,7 @@ describe("workspace-migrations registry", () => {
     mkdirSync(target);
     writeFileSync(join(target, ".git"), "gitdir: /tmp/somewhere\n");
     writeFileSync(
-      join(workspace, ".agent", "managed.json"),
+      join(workspace, ".first-tree-workspace", "managed.json"),
       JSON.stringify({
         schemaVersion: 1,
         cliVersion: "test",
@@ -352,7 +352,7 @@ describe("workspace-migrations registry", () => {
     initRepo(join(workspace, "first-tree-hub"), "https://github.com/agent-team-foundation/first-tree-hub");
     initRepo(join(workspace, "first-tree"), "https://github.com/agent-team-foundation/first-tree");
     writeFileSync(
-      join(workspace, ".agent", "managed.json"),
+      join(workspace, ".first-tree-workspace", "managed.json"),
       JSON.stringify({
         schemaVersion: 1,
         cliVersion: "test",
@@ -375,7 +375,7 @@ describe("applyPendingMigrations applier", () => {
 
   beforeEach(() => {
     workspace = mkdtempSync(join(tmpdir(), "workspace-migrations-applier-test-"));
-    mkdirSync(join(workspace, ".agent"), { recursive: true });
+    mkdirSync(join(workspace, ".first-tree-workspace"), { recursive: true });
   });
 
   afterEach(() => {

--- a/packages/client/src/runtime/managed-state.ts
+++ b/packages/client/src/runtime/managed-state.ts
@@ -4,7 +4,7 @@
 //
 // Scope is deliberately narrow: a list of source-repo localPaths and a list
 // of skill names. Anything else CLI puts in the workspace (AGENTS.md,
-// .agent/identity.json, .claude/skills symlinks, etc.) is owned by other
+// .first-tree-workspace/identity.json, .claude/skills symlinks, etc.) is owned by other
 // flows and not tracked here.
 //
 // Path-level precision: the diff is "prev∖current" → delete. The flip side
@@ -17,12 +17,23 @@ import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileS
 import { join } from "node:path";
 
 /**
+ * The per-agent runtime directory name. Mirrors `bootstrap.ts ::
+ * FIRST_TREE_RUNTIME_DIR` (which itself aliases `FIRST_TREE_WORKSPACE_MARKER`);
+ * inlined as a literal here to avoid a top-level import cycle
+ * (`bootstrap` → `first-tree-skills/installer` → `managed-state` →
+ * `bootstrap` would evaluate the constant before bootstrap finishes
+ * initialising, leaving it `undefined`). Keep in sync with the source of
+ * truth in `bootstrap.ts`.
+ */
+const RUNTIME_DIR = ".first-tree-workspace";
+
+/**
  * Path inside the agent home where {@link readManagedState} /
  * {@link writeManagedState} persist the record. Lives alongside
- * `.agent/identity.json`, `.agent/cli-version`, etc. — same `.agent/`
+ * `identity.json`, `cli-version`, etc. — same per-agent runtime-dir
  * convention every other client-owned state file uses.
  */
-export const MANAGED_STATE_REL = join(".agent", "managed.json");
+export const MANAGED_STATE_REL = join(RUNTIME_DIR, "managed.json");
 
 /**
  * Schema-versioned record of the resources the CLI currently manages in a
@@ -84,7 +95,7 @@ function readStringArray(value: unknown): string[] {
  * leak siblings.
  */
 export function writeManagedState(workspacePath: string, state: ManagedState): void {
-  mkdirSync(join(workspacePath, ".agent"), { recursive: true });
+  mkdirSync(join(workspacePath, RUNTIME_DIR), { recursive: true });
   const finalPath = join(workspacePath, MANAGED_STATE_REL);
   const tempPath = `${finalPath}.${randomBytes(6).toString("hex")}.tmp`;
   writeFileSync(tempPath, `${JSON.stringify(state, null, 2)}\n`, "utf-8");

--- a/packages/client/src/runtime/workspace-migrations.ts
+++ b/packages/client/src/runtime/workspace-migrations.ts
@@ -414,6 +414,63 @@ export const MIGRATIONS_REGISTRY: readonly Migration[] = [
       }
     },
   },
+  {
+    id: "v1-orphan-skills",
+    description:
+      "Remove `.agents/skills/<name>/` payloads (and matching `.claude/skills/<name>` symlinks) for a hardcoded list of historical skill names that the CLI used to ship but has since retired. PR #869's state-based `reconcileTreeSkillState` only removes skills it previously recorded in `managed.json::skills`; legacy residue installed before state tracking existed sits on disk forever without an explicit sweep. Because the marker is one-shot per workspace, even if a future bundle re-introduces one of these names, the migration cannot redelete it on a workspace that already applied this id. PR #898 follow-up.",
+    apply: (workspacePath, log) => {
+      // Historical skill names — once shipped with the CLI, since retired.
+      // Each gets its `.agents/skills/<name>/` payload removed AND its
+      // `.claude/skills/<name>` companion symlink removed when present.
+      // Add new names to the end of this list when retiring a bundled
+      // skill; never remove or reorder existing entries (marker is by id,
+      // not by list contents).
+      const historicalNames = [
+        "attention",
+        "first-tree-cloud",
+        "first-tree-github-scan",
+        "first-tree-onboarding",
+        "first-tree-write",
+        "github-scan",
+      ];
+      let removed = 0;
+      for (const name of historicalNames) {
+        const agentsPath = join(workspacePath, ".agents", "skills", name);
+        const claudePath = join(workspacePath, ".claude", "skills", name);
+        let removedAny = false;
+        if (existsSync(agentsPath) && isDirectory(agentsPath)) {
+          rmSync(agentsPath, { recursive: true, force: true });
+          removedAny = true;
+        }
+        // Only unlink the `.claude/skills/<name>` entry when it really is a
+        // symlink — a user-authored regular directory there would NOT be
+        // touched (defensive, mirrors the `v1-whitepaper-symlink` shape
+        // check). The companion symlink is always how the installer wires
+        // these up, so a real-FT install will match.
+        let claudeStat: ReturnType<typeof lstatSync> | null = null;
+        try {
+          claudeStat = lstatSync(claudePath);
+        } catch {
+          // missing — nothing to do
+        }
+        if (claudeStat?.isSymbolicLink()) {
+          try {
+            unlinkSync(claudePath);
+            removedAny = true;
+          } catch {
+            // best-effort; the payload removal above is the main goal
+          }
+        }
+        if (removedAny) {
+          log(`workspace-migrations: v1-orphan-skills removed legacy skill ${name}/`);
+          removed += 1;
+        }
+      }
+      if (removed > 0) {
+        log(`workspace-migrations: v1-orphan-skills removed ${removed} legacy skill(s)`);
+      }
+    },
+  },
 ];
 
 // `readCurrentSourceRepoNames` was the round-3/4 fallback for "live ctx

--- a/packages/client/src/runtime/workspace-migrations.ts
+++ b/packages/client/src/runtime/workspace-migrations.ts
@@ -13,7 +13,7 @@
 // Design:
 //
 //   - Each migration has a stable `id`. The set of already-applied ids is
-//     persisted to `.agent/migrations-applied.json` so each migration runs
+//     persisted to `.first-tree-workspace/migrations-applied.json` so each migration runs
 //     at most once per workspace, even if it's later removed from the
 //     registry (the marker stays as forward protection).
 //   - Migrations are idempotent — re-running a migration on an already-
@@ -42,10 +42,19 @@ import { type RemoveCloneOutcome, tryRemoveCloneSafely } from "./source-repo-cle
 import { isSourceRepoPathInUse } from "./source-repos.js";
 
 /**
- * Path inside the agent home where {@link applyPendingMigrations} persists
- * the set of already-applied migration ids.
+ * The per-agent runtime directory name. Mirrors `bootstrap.ts ::
+ * FIRST_TREE_RUNTIME_DIR` — inlined to avoid a top-level import cycle (see
+ * the matching note in `managed-state.ts`). Keep in sync with the source
+ * of truth in `bootstrap.ts`.
  */
-export const MIGRATIONS_APPLIED_REL = join(".agent", "migrations-applied.json");
+const RUNTIME_DIR = ".first-tree-workspace";
+
+/**
+ * Path inside the agent home where {@link applyPendingMigrations} persists
+ * the set of already-applied migration ids. Same runtime-dir convention as
+ * `identity.json`, `cli-version`, and `managed.json`.
+ */
+export const MIGRATIONS_APPLIED_REL = join(RUNTIME_DIR, "migrations-applied.json");
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -161,7 +170,7 @@ function hasLegacySnapshotSignature(dir: string): boolean {
  * "Yes" only when the live `ctx.currentSourceRepoNames` is non-null — the
  * caller resolved a payload from the server / cache for this session. When
  * it's `null` (cache miss, default-payload fallback), callers MUST return
- * `"deferred"`: persisted `.agent/managed.json::sourceRepos` proves a
+ * `"deferred"`: persisted `.first-tree-workspace/managed.json::sourceRepos` proves a
  * PREVIOUS config, not the current one, and falling back to it after a
  * fresh config edit (web-console add + immediate cache miss on the next
  * start) is the same "unknown config looks authoritative" deletion class
@@ -171,7 +180,7 @@ function hasLegacySnapshotSignature(dir: string): boolean {
  * The trade-off: a workspace whose cache is **permanently** broken never
  * runs the one-shot sweep. That's acceptable because such a workspace
  * cannot reach the resolved-payload codepath that materialises
- * `.agent/managed.json` in the first place — its config-dependent state
+ * `.first-tree-workspace/managed.json` in the first place — its config-dependent state
  * is already inconsistent, and accumulating a few legacy directories on
  * disk is a strictly smaller cost than risking deletion of a currently-
  * configured source repo.
@@ -439,7 +448,7 @@ function readAppliedRecord(workspacePath: string): AppliedRecord {
 }
 
 function writeAppliedRecord(workspacePath: string, record: AppliedRecord): void {
-  mkdirSync(join(workspacePath, ".agent"), { recursive: true });
+  mkdirSync(join(workspacePath, RUNTIME_DIR), { recursive: true });
   const finalPath = join(workspacePath, MIGRATIONS_APPLIED_REL);
   const tempPath = `${finalPath}.${randomBytes(6).toString("hex")}.tmp`;
   writeFileSync(tempPath, `${JSON.stringify(record, null, 2)}\n`, "utf-8");


### PR DESCRIPTION
## Summary

Two related fixes, both follow-up to PR #869:

### 1. `managed-state.ts` + `workspace-migrations.ts` write to the wrong dir (`.agent/` instead of `.first-tree-workspace/`)

PR #859 (`rename agent runtime dir to .first-tree-workspace`) landed between PR #869 being authored and merged. #859 retitled the runtime dir constant in `bootstrap.ts` (`FIRST_TREE_RUNTIME_DIR = FIRST_TREE_WORKSPACE_MARKER`) and updated every other state-file consumer in the codebase — but #869's two new modules weren't in that sweep, presumably because they didn't exist yet on main when #859 ran its global rename.

**Production symptom** (caught by @liuchao-001 on the `liuchao-staff` agent):

- `prepareSourceRepos` / `reconcileTreeSkillState` write to `.agent/managed.json`.
- `ensureWorkspaceRuntimeDir`'s `mergeLegacyRuntimeDir` runs later in the bootstrap path and merges `.agent/` → `.first-tree-workspace/` with **target-wins** conflict policy.
- First session after #869 shipped: target didn't exist → whole-dir rename → state landed in target with first-run defaults (`skills: []`).
- Every subsequent session: source dir re-created by my code, merge discards it. The target managed.json stays **frozen** at the first-run snapshot.
- Net effect: `reconcileTreeSkillState` never gets to populate `managed.json::skills`, the whole state-reconcile path is silently inert.

**Fix**: switch both modules to use `.first-tree-workspace/`. Not via `import { FIRST_TREE_RUNTIME_DIR } from "./bootstrap.js"` — that introduces a top-level circular-import init bug (`bootstrap` → `first-tree-skills/installer` → `managed-state` would evaluate `MANAGED_STATE_REL = join(FIRST_TREE_RUNTIME_DIR, "managed.json")` while `bootstrap` is still initialising; the constant reads `undefined` and `join` throws). Inline the literal `".first-tree-workspace"` with a cross-reference comment to `bootstrap.ts :: FIRST_TREE_RUNTIME_DIR` as source of truth — same pattern `bootstrap.ts` itself uses for `FIRST_TREE_WORKSPACE_MARKER`.

### 2. `v1-orphan-skills` migration cleans hardcoded legacy skill list

PR #869's state-based skill reconcile is path-precise: it only removes skills it previously recorded in `managed.json::skills`. Legacy skill payloads installed before state tracking existed — e.g. the 6 skills the CLI used to bundle (`attention`, `first-tree-cloud`, `first-tree-github-scan`, `first-tree-onboarding`, `first-tree-write`, `github-scan`) — sit on disk forever without an explicit sweep.

This commit adds `v1-orphan-skills`: hardcoded one-shot migration that removes both the `.agents/skills/<name>/` payload AND the matching `.claude/skills/<name>` symlink for each historical name. Defensive about user-authored content: the Claude symlink is only unlinked when it actually IS a symlink (matches `v1-whitepaper-symlink` shape).

## Test plan

- [x] `pnpm typecheck`: clean
- [x] `pnpm check` (biome): clean
- [x] `pnpm --filter @first-tree/client test src/__tests__/{managed-state,workspace-migrations,source-repos-state-reconcile,skills-state-reconcile}.test.ts`: **51 / 51 pass** (3 new orphan-skills tests added)
- [ ] Verification on a real workspace once shipped:
  - Next session: `managed.json::skills` populates to current `TREE_SKILL_NAMES` (no longer frozen at `[]`).
  - Next migration run: the 6 historical skills get cleared from `.agents/skills/` and their `.claude/skills/` symlinks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)