### PR TITLE
fix: refresh auto-update target before install

### DIFF
--- a/apps/cli/src/__tests__/daemon-start-command.test.ts
+++ b/apps/cli/src/__tests__/daemon-start-command.test.ts
@@ -26,6 +26,7 @@ const coreMocks = vi.hoisted(() => ({
   promptMissingFields: vi.fn(),
   promptUpdate: vi.fn(),
   reconcileLocalRuntimeProviders: vi.fn(),
+  refreshServerUpdateTarget: vi.fn(),
   startClientService: vi.fn(),
   uploadAgentSkills: vi.fn(),
   uploadClientCapabilities: vi.fn(),

--- a/apps/cli/src/commands/daemon/start.ts
+++ b/apps/cli/src/commands/daemon/start.ts
@@ -36,6 +36,7 @@ import {
   promptMissingFields,
   promptUpdate,
   reconcileLocalRuntimeProviders,
+  refreshServerUpdateTarget,
   startClientService,
   uploadAgentSkills,
   uploadClientCapabilities,
@@ -232,6 +233,7 @@ export function registerDaemonStartCommand(daemon: Command): void {
             updateConfig: config.update,
             prompt: managed ? declineUpdate : promptUpdate,
             executeUpdate,
+            refreshServerTarget: refreshServerUpdateTarget,
           },
         });
         runtimeRef = runtime;

--- a/apps/cli/src/commands/login.ts
+++ b/apps/cli/src/commands/login.ts
@@ -28,6 +28,7 @@ import {
   loadCredentials,
   migrateLocalAgentDirs,
   promptUpdate,
+  refreshServerUpdateTarget,
   saveCredentials,
 } from "../core/index.js";
 import { print } from "../core/output.js";
@@ -204,6 +205,7 @@ export function registerLoginCommand(program: Command): void {
             updateConfig: config.update,
             prompt: promptUpdate,
             executeUpdate: createExecuteUpdate({ managed: false }),
+            refreshServerTarget: refreshServerUpdateTarget,
           },
         });
         for (const [name, agentConfig] of agents) runtime.addAgent(name, agentConfig);

--- a/apps/cli/src/core/index.ts
+++ b/apps/cli/src/core/index.ts
@@ -95,7 +95,13 @@ export {
   installGlobalSpec,
   PACKAGE_NAME,
 } from "./update.js";
-export { createExecuteUpdate, declineUpdate, promptUpdate, SELF_RESTART_EXIT_CODE } from "./update-glue.js";
+export {
+  createExecuteUpdate,
+  declineUpdate,
+  promptUpdate,
+  refreshServerUpdateTarget,
+  SELF_RESTART_EXIT_CODE,
+} from "./update-glue.js";
 export {
   defaultUpdateStatePath,
   isLoopGuarded,

--- a/apps/cli/src/core/update-glue.ts
+++ b/apps/cli/src/core/update-glue.ts
@@ -1,10 +1,10 @@
 import { spawnSync } from "node:child_process";
-import type { ExecuteUpdateFn, UpdatePromptFn } from "@first-tree/client";
+import type { ExecuteUpdateFn, RefreshUpdateTargetFn, UpdatePromptFn } from "@first-tree/client";
 import { confirm } from "@inquirer/prompts";
 import * as semver from "semver";
 import { channelConfig } from "./channel.js";
 import { print } from "./output.js";
-import { detectInstallMode, installGlobalSpec, PACKAGE_NAME } from "./update.js";
+import { detectInstallMode, fetchServerCommandVersion, installGlobalSpec, PACKAGE_NAME } from "./update.js";
 import { isLoopGuarded, recordUpdateAttempt } from "./update-state.js";
 
 /** Reserved exit code that means "clean self-restart, service manager please bring me back". */
@@ -38,6 +38,11 @@ export const promptUpdate: UpdatePromptFn = async ({ currentVersion, targetVersi
  * instead of blocking on a TTY confirm.
  */
 export const declineUpdate: UpdatePromptFn = async () => false;
+
+export const refreshServerUpdateTarget: RefreshUpdateTargetFn = async () => {
+  const result = await fetchServerCommandVersion();
+  return result.ok ? { ok: true, targetVersion: result.version } : result;
+};
 
 export type UpdateFailedPayload = {
   targetVersion: string;

--- a/packages/client/src/__tests__/update-manager.test.ts
+++ b/packages/client/src/__tests__/update-manager.test.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from "node:events";
 import type { ClientConfig } from "@first-tree/shared/config";
 import { describe, expect, it, vi } from "vitest";
 import type { ServerWelcome } from "../client-connection.js";
+import type { RefreshUpdateTargetResult } from "../runtime/update-manager.js";
 import { UpdateManager } from "../runtime/update-manager.js";
 
 /**
@@ -350,6 +351,128 @@ describe("UpdateManager decision flow", () => {
 
       expect(getQuietGateSnapshot).toHaveBeenCalledTimes(2);
       expect(executeUpdate).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("policy=auto, reconnect coalesces the latest welcome target while the quiet gate waits", async () => {
+    vi.useFakeTimers();
+    try {
+      const conn = makeFakeConnection();
+      const executeUpdate = vi.fn(async () => ({ installed: false }));
+      const snapshots = [
+        { activeCount: 1, lastActivityMs: Date.now() },
+        { activeCount: 0, lastActivityMs: 0 },
+      ];
+      const getQuietGateSnapshot = vi.fn(() => snapshots.shift() ?? { activeCount: 0, lastActivityMs: 0 });
+
+      UpdateManager.attach(conn, {
+        currentVersion: "0.8.4",
+        updateConfig: makeUpdateConfig({
+          policy: "auto",
+          restart_quiet_seconds: 30,
+          restart_check_interval_seconds: 10,
+        }),
+        isTTY: false,
+        log: () => {},
+        getQuietGateSnapshot,
+        prompt: async () => false,
+        executeUpdate,
+      });
+
+      conn.emitWelcome(makeWelcome("1.0.0", true));
+      await vi.advanceTimersByTimeAsync(1);
+      conn.emitWelcome(makeWelcome("0.9.2", true));
+
+      await vi.advanceTimersByTimeAsync(10_000);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(executeUpdate).toHaveBeenCalledOnce();
+      expect(executeUpdate).toHaveBeenCalledWith({ currentVersion: "0.8.4", targetVersion: "0.9.2" });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("policy=auto refreshes the server target after the quiet gate and accepts rollback above current", async () => {
+    vi.useFakeTimers();
+    try {
+      const conn = makeFakeConnection();
+      const executeUpdate = vi.fn(async () => ({ installed: false }));
+      const refreshServerTarget = vi.fn(
+        async (): Promise<RefreshUpdateTargetResult> => ({ ok: true, targetVersion: "0.9.2" }),
+      );
+      const snapshots = [
+        { activeCount: 1, lastActivityMs: Date.now() },
+        { activeCount: 0, lastActivityMs: 0 },
+      ];
+      const getQuietGateSnapshot = vi.fn(() => snapshots.shift() ?? { activeCount: 0, lastActivityMs: 0 });
+
+      UpdateManager.attach(conn, {
+        currentVersion: "0.8.4",
+        updateConfig: makeUpdateConfig({
+          policy: "auto",
+          restart_quiet_seconds: 30,
+          restart_check_interval_seconds: 10,
+        }),
+        isTTY: false,
+        log: () => {},
+        getQuietGateSnapshot,
+        prompt: async () => false,
+        executeUpdate,
+        refreshServerTarget,
+      });
+
+      conn.emitWelcome(makeWelcome("1.0.0", true));
+      await vi.advanceTimersByTimeAsync(1);
+      await vi.advanceTimersByTimeAsync(10_000);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(refreshServerTarget).toHaveBeenCalledOnce();
+      expect(executeUpdate).toHaveBeenCalledOnce();
+      expect(executeUpdate).toHaveBeenCalledWith({ currentVersion: "0.8.4", targetVersion: "0.9.2" });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("policy=auto skips when the refreshed server target is older than the running version", async () => {
+    vi.useFakeTimers();
+    try {
+      const conn = makeFakeConnection();
+      const executeUpdate = vi.fn(async () => ({ installed: false }));
+      const refreshServerTarget = vi.fn(
+        async (): Promise<RefreshUpdateTargetResult> => ({ ok: true, targetVersion: "0.9.2" }),
+      );
+      const snapshots = [
+        { activeCount: 1, lastActivityMs: Date.now() },
+        { activeCount: 0, lastActivityMs: 0 },
+      ];
+      const getQuietGateSnapshot = vi.fn(() => snapshots.shift() ?? { activeCount: 0, lastActivityMs: 0 });
+
+      UpdateManager.attach(conn, {
+        currentVersion: "0.9.3",
+        updateConfig: makeUpdateConfig({
+          policy: "auto",
+          restart_quiet_seconds: 30,
+          restart_check_interval_seconds: 10,
+        }),
+        isTTY: false,
+        log: () => {},
+        getQuietGateSnapshot,
+        prompt: async () => false,
+        executeUpdate,
+        refreshServerTarget,
+      });
+
+      conn.emitWelcome(makeWelcome("1.0.0", true));
+      await vi.advanceTimersByTimeAsync(1);
+      await vi.advanceTimersByTimeAsync(10_000);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(refreshServerTarget).toHaveBeenCalledOnce();
+      expect(executeUpdate).not.toHaveBeenCalled();
     } finally {
       vi.useRealTimers();
     }

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -69,6 +69,8 @@ export type {
   ExecuteUpdateFn,
   ExecuteUpdateResult,
   QuietGateSnapshot,
+  RefreshUpdateTargetFn,
+  RefreshUpdateTargetResult,
   UpdateHooks,
   UpdateLogger,
   UpdateLogLevel,

--- a/packages/client/src/runtime/update-manager.ts
+++ b/packages/client/src/runtime/update-manager.ts
@@ -57,6 +57,15 @@ export type ExecuteUpdateResult = {
  */
 export type ExecuteUpdateFn = (opts: { currentVersion: string; targetVersion: string }) => Promise<ExecuteUpdateResult>;
 
+export type RefreshUpdateTargetResult = { ok: true; targetVersion: string } | { ok: false; reason: string };
+
+/**
+ * Optional command-layer hook for re-reading the server's current update target
+ * immediately before an automatic install. This stays outside the Client
+ * package so UpdateManager does not learn CLI config or HTTP bootstrap details.
+ */
+export type RefreshUpdateTargetFn = () => Promise<RefreshUpdateTargetResult>;
+
 export type UpdateManagerOptions = {
   currentVersion: string;
   updateConfig: ClientConfig["update"];
@@ -66,6 +75,7 @@ export type UpdateManagerOptions = {
   getQuietGateSnapshot: () => QuietGateSnapshot;
   prompt: UpdatePromptFn;
   executeUpdate: ExecuteUpdateFn;
+  refreshServerTarget?: RefreshUpdateTargetFn;
 };
 
 /**
@@ -77,6 +87,7 @@ export type UpdateHooks = {
   updateConfig: ClientConfig["update"];
   prompt: UpdatePromptFn;
   executeUpdate: ExecuteUpdateFn;
+  refreshServerTarget?: RefreshUpdateTargetFn;
 };
 
 /**
@@ -91,6 +102,12 @@ export class UpdateManager {
   private updateInFlight = false;
   private quietGateTimer: ReturnType<typeof setTimeout> | null = null;
   private disposed = false;
+  /**
+   * Last valid server target observed while an update decision is running.
+   * Later observations replace earlier ones even when the version is lower:
+   * server target rollback from B to C must install C, not semver-max(B, C).
+   */
+  private latestObservedTarget: string | null = null;
   /**
    * Set when a standalone (unmanaged) executeUpdate reports `installed: true`
    * without exiting. The new bits are on disk; subsequent welcome frames must
@@ -127,27 +144,40 @@ export class UpdateManager {
   }
 
   private async onWelcome(welcome: ServerWelcome): Promise<void> {
-    if (this.disposed || this.updateInFlight || this.pendingRestart) return;
+    if (this.disposed || this.pendingRestart) return;
+    const target = this.normalizeAdvertisedTarget(welcome.frame.serverCommandVersion);
+    if (!target) return;
+    if (this.updateInFlight) {
+      this.latestObservedTarget = target;
+      this.options.log("debug", `Coalesced server update target ${target} while update decision is in flight`);
+      return;
+    }
     // Claim the slot for the entire decision flow (not just runUpdate): a
     // `policy=auto` TTY path awaits a 5s sleep + the quiet gate, and a
     // reconnect storm inside that window would otherwise fan out parallel
     // decisions.
+    this.latestObservedTarget = target;
     this.updateInFlight = true;
     try {
-      await this.decide(welcome);
+      await this.decide(welcome, target);
     } finally {
       this.updateInFlight = false;
+      this.latestObservedTarget = null;
     }
   }
 
-  private async decide(welcome: ServerWelcome): Promise<void> {
-    const { serverCommandVersion: target } = welcome.frame;
+  private normalizeAdvertisedTarget(target: string): string | null {
+    const normalized = semver.valid(target);
+    if (!normalized) {
+      this.options.log("warn", `Server advertised invalid version "${target}"; skipping drift check`);
+      return null;
+    }
+    return normalized;
+  }
+
+  private async decide(welcome: ServerWelcome, target: string): Promise<void> {
     const current = this.options.currentVersion;
 
-    if (!semver.valid(target)) {
-      this.options.log("warn", `Server advertised invalid version "${target}"; skipping drift check`);
-      return;
-    }
     if (!semver.valid(current)) {
       this.options.log("warn", `Own version "${current}" is not valid SemVer; skipping drift check`);
       return;
@@ -209,7 +239,60 @@ export class UpdateManager {
       await this.waitForQuietGate();
       if (this.disposed) return;
     }
-    await this.runUpdate(current, target);
+    const resolvedTarget = await this.resolveAutoTargetBeforeUpdate(current, target);
+    if (this.disposed || resolvedTarget === null) return;
+    await this.runUpdate(current, resolvedTarget);
+  }
+
+  private async resolveAutoTargetBeforeUpdate(current: string, initialTarget: string): Promise<string | null> {
+    let target = this.latestObservedTarget ?? initialTarget;
+    const refreshedTarget = await this.refreshServerTarget(target);
+    if (refreshedTarget) {
+      target = refreshedTarget;
+    } else {
+      target = this.latestObservedTarget ?? target;
+    }
+
+    if (semver.eq(target, current)) {
+      this.options.log("info", `Server update target ${target} now matches running version; skipping self-update`);
+      return null;
+    }
+    if (semver.lt(target, current)) {
+      this.options.log("info", `Server update target ${target} is older than running ${current}; skipping self-update`);
+      return null;
+    }
+    return target;
+  }
+
+  private async refreshServerTarget(fallbackTarget: string): Promise<string | null> {
+    const refresh = this.options.refreshServerTarget;
+    if (!refresh) return null;
+    try {
+      const result = await refresh();
+      if (!result.ok) {
+        this.options.log(
+          "warn",
+          `Could not refresh server update target (${result.reason}); continuing with ${fallbackTarget}`,
+        );
+        return null;
+      }
+      const normalized = semver.valid(result.targetVersion);
+      if (!normalized) {
+        this.options.log(
+          "warn",
+          `Server target refresh returned invalid version "${result.targetVersion}"; continuing with ${fallbackTarget}`,
+        );
+        return null;
+      }
+      if (normalized !== fallbackTarget) {
+        this.options.log("info", `Server update target refreshed: ${fallbackTarget} -> ${normalized}`);
+      }
+      return normalized;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.options.log("warn", `Server target refresh threw: ${msg}; continuing with ${fallbackTarget}`);
+      return null;
+    }
   }
 
   private async waitForQuietGate(): Promise<void> {


### PR DESCRIPTION
## Summary

- Refresh the server-recommended update target immediately before automatic self-update installs.
- Coalesce valid `server:welcome` targets while an update decision is waiting on the quiet gate, with the latest server target taking precedence even when it is lower than the original pending target.
- Preserve the existing no-downgrade-below-current contract and keep prompt/off behavior unchanged.

## Validation

- [x] `pnpm check`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- `pnpm --filter @first-tree/client test -- update-manager` (95 files / 1070 tests passed)
- `pnpm --filter first-tree-dev test -- daemon-start-command login-command update-glue` (58 files / 427 tests passed)
- `pnpm --filter @first-tree/client typecheck`
- `pnpm --filter first-tree-dev typecheck`
- `git diff --check`

## Change Surface

- [ ] `apps/cli` public CLI or help output
- [ ] tree onboarding / binding / inspection behavior
- [ ] shipped or planned skill topology
- [ ] docs or contributor-facing repository metadata
- [ ] CI / packaging / release plumbing

## Notes

- package or install behavior changes: daemon auto-update now best-effort refreshes the current server target before installing, while still installing an exact server target and refusing targets older than the running version.
- docs or tests updated to match: added UpdateManager tests for quiet-gate target coalescing, refresh rollback above current, and refresh below-current skip.
- follow-up work: optional coverage for a refresh-await race where a later welcome arrives while refresh is pending and refresh then fails.
