### PR TITLE
fix(client): clarify async agent handoffs

### DIFF
--- a/packages/client/src/__tests__/agent-briefing.test.ts
+++ b/packages/client/src/__tests__/agent-briefing.test.ts
@@ -347,6 +347,8 @@ describe("buildAgentBriefing — # Working in First Tree subsections", () => {
     // structured --request ask path; agents must be woken explicitly.
     expect(briefing).toMatch(/\*\*Asking a human\*\*/);
     expect(briefing).toMatch(/Reaching an \*\*agent\*\*/);
+    expect(briefing).toContain("After an agent handoff, continue only independent work");
+    expect(briefing).toContain("do not poll status");
     expect(briefing).toContain("**Fallback**");
 
     expect(briefing).toContain("## Workspace Collaboration");

--- a/packages/client/src/runtime/agent-briefing.ts
+++ b/packages/client/src/runtime/agent-briefing.ts
@@ -259,6 +259,9 @@ participant \`type\` in the Current Chat Context block):
 
 - Reaching an **agent** to make them act → you MUST \`${bin} chat send <name>\`.
   They do NOT see your final text as a wake signal.
+- After an agent handoff, continue only independent work. If their reply is the
+  only remaining input, end the turn and wait to be woken; do not poll status
+  or escalate on delayed replies alone.
 - **Asking a human** for a decision, approval, or answer → \`${bin} chat send
   <name> --request --question "..."\` (see \`## Asking Humans\`). Don't bury the
   ask in final text — it has no red-dot and no tracked answer.

--- a/skills/first-tree/SKILL.md
+++ b/skills/first-tree/SKILL.md
@@ -78,6 +78,10 @@ auto-delivered fallback for plain replies.
 | **agent** | They will NOT see your final text. You MUST `chat send <name>` if you need them to act. |
 | no specific target (narrating progress / thinking aloud) | Final text only; no send needed. |
 
+After an agent handoff, continue only independent work. If their reply is
+the only remaining input, end the turn and wait to be woken; do not poll
+status or escalate on delayed replies alone.
+
 ### Stay silent when you have nothing to add
 
 The runtime's silent-turn protocol treats empty output as "skip delivery,

--- a/skills/first-tree/references/agent-communication.md
+++ b/skills/first-tree/references/agent-communication.md
@@ -119,6 +119,9 @@ See the SKILL.md Communication Principles' Decision guide table and the
 - **Human**, needs a decision / approval / answer → `chat send <name>
   --request --question "..."` (tracked ask, not buried in final text).
 - **Agent** → explicit `chat send <name>` (final text does not wake them).
+  After the handoff, continue only independent work; if their reply is the
+  only remaining input, end the turn and wait to be woken. Do not poll status
+  or escalate on delayed replies alone.
 - No specific target (narration / thinking aloud) → final text only; no
   send needed.
 - Current Chat Context block missing from prompt → conservative mode, all


### PR DESCRIPTION
## Summary
- Clarify that agent-to-agent handoffs are async: continue only independent work after sending to another agent.
- Tell agents to end the turn and wait to be woken when the peer reply is the only remaining input.
- Keep the runtime briefing, first-tree skill, and communication reference aligned.

## Tests
- pnpm --filter @first-tree/client test -- agent-briefing
- pnpm check
- pnpm typecheck
- pnpm validate:skill
- git diff --check

Note: pnpm check exits 0 with an existing warning in packages/client/src/runtime/workspace-migrations.ts:89.