### PR TITLE
feat(web): reorder Environment tab + read-only Context tree row

### DIFF
--- a/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
@@ -53,7 +53,12 @@ const authMock = vi.hoisted(() => ({
   value: {
     memberId: "member-self",
     role: "admin",
+    organizationId: "org-1",
   },
+}));
+
+const orgSettingsMocks = vi.hoisted(() => ({
+  getContextTreeSetting: vi.fn(),
 }));
 
 vi.mock("../../../api/activity.js", async (importOriginal) => ({
@@ -84,6 +89,8 @@ vi.mock("../../../api/usage.js", async (importOriginal) => ({
 vi.mock("../../../auth/auth-context.js", () => ({
   useAuth: () => authMock.value,
 }));
+
+vi.mock("../../../api/org-settings.js", () => orgSettingsMocks);
 
 const NOW = "2026-05-28T12:00:00.000Z";
 
@@ -350,7 +357,8 @@ beforeEach(() => {
   installBrowserStubs();
   document.body.innerHTML = "";
   vi.clearAllMocks();
-  authMock.value = { memberId: "member-self", role: "admin" };
+  authMock.value = { memberId: "member-self", role: "admin", organizationId: "org-1" };
+  orgSettingsMocks.getContextTreeSetting.mockResolvedValue({ repo: "https://github.com/acme/tree", branch: "main" });
   agentMocks.getAgent.mockResolvedValue(agent());
   // Agent switcher list (admin → listAllAgents). Include a second agent so the
   // switcher has a switch target.

--- a/packages/web/src/pages/agent-detail/runtime-tab.tsx
+++ b/packages/web/src/pages/agent-detail/runtime-tab.tsx
@@ -1,8 +1,13 @@
-import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { type ReactNode, useMemo } from "react";
 import { Navigate } from "react-router";
+import { getContextTreeSetting } from "../../api/org-settings.js";
+import { useAuth } from "../../auth/auth-context.js";
+import { Button } from "../../components/ui/button.js";
 import { Section } from "../../components/ui/section.js";
 import { ResourceTypeSection, useAgentResources } from "./capability-section.js";
 import { EnvSection } from "./env-section.js";
+import { ConfigRow } from "./flat-section.js";
 import { useAgentDetailContext } from "./layout-context.js";
 import { ModelSection } from "./model-section.js";
 import { ReasoningEffortSection } from "./reasoning-effort-section.js";
@@ -43,8 +48,10 @@ export function RuntimeTab() {
           Failed to load configuration: {String(ctx.configError)}
         </div>
       )}
-      {/* Immediate zone — Execution + Repositories. Both save the moment you act
-          (bind/re-bind, repo add/remove); no SaveBar involvement. */}
+      {/* Section order follows the conceptual grouping (runtime → workspace):
+          Execution → Model settings → Repositories → Context tree → Env vars.
+          Save semantics aren't carried by physical adjacency — each section keeps
+          its own immediate / draft tag — so the order is free to read top-down. */}
       {ctx.config && (
         <RuntimeSection
           runtimeProvider={ctx.setupRuntimeProvider}
@@ -57,35 +64,8 @@ export function RuntimeTab() {
           onRebind={ctx.agent.clientId ? ctx.onOpenRebindDialog : undefined}
         />
       )}
-      <div id={sectionAnchorId("git")} style={{ marginTop: "var(--sp-8)" }}>
-        {repos.isLoading ? (
-          <div className="text-body" style={{ color: "var(--fg-3)" }}>
-            Loading repositories…
-          </div>
-        ) : repos.error || !repos.data ? (
-          <div className="text-body" style={{ color: "var(--state-error)" }}>
-            {repos.error instanceof Error ? repos.error.message : "Failed to load repositories"}
-          </div>
-        ) : (
-          <ResourceTypeSection
-            type="repo"
-            data={repos.data}
-            canEdit={canEditResources}
-            pending={repos.pending}
-            onMutate={repos.mutateBindings}
-            saved={repos.justSaved}
-            onNavigateAway={ctx.guardedNavigate}
-          />
-        )}
-        {repos.saveError ? (
-          <p className="text-body" style={{ color: "var(--state-error)", margin: "var(--sp-2) 0 0" }}>
-            {repos.saveError instanceof Error ? repos.saveError.message : "Failed to save repositories"}
-          </p>
-        ) : null}
-      </div>
 
-      {/* Draft zone — Model settings + Environment variables. These stage into the
-          SaveBar and commit together; their dirty-dots drive the bar. */}
+      {/* Model settings (draft — stages into the SaveBar). */}
       {ctx.config && (
         <div style={{ marginTop: "var(--sp-8)" }}>
           <Section
@@ -115,6 +95,42 @@ export function RuntimeTab() {
           </Section>
         </div>
       )}
+
+      {/* Repositories (immediate — saves on add/remove, not via the SaveBar). */}
+      <div id={sectionAnchorId("git")} style={{ marginTop: "var(--sp-8)" }}>
+        {repos.isLoading ? (
+          <div className="text-body" style={{ color: "var(--fg-3)" }}>
+            Loading repositories…
+          </div>
+        ) : repos.error || !repos.data ? (
+          <div className="text-body" style={{ color: "var(--state-error)" }}>
+            {repos.error instanceof Error ? repos.error.message : "Failed to load repositories"}
+          </div>
+        ) : (
+          <ResourceTypeSection
+            type="repo"
+            data={repos.data}
+            canEdit={canEditResources}
+            pending={repos.pending}
+            onMutate={repos.mutateBindings}
+            saved={repos.justSaved}
+            onNavigateAway={ctx.guardedNavigate}
+          />
+        )}
+        {repos.saveError ? (
+          <p className="text-body" style={{ color: "var(--state-error)", margin: "var(--sp-2) 0 0" }}>
+            {repos.saveError instanceof Error ? repos.saveError.message : "Failed to save repositories"}
+          </p>
+        ) : null}
+      </div>
+
+      {/* Context tree — read-only, org-level. Part of the agent's runtime
+          environment (injected at startup) but managed in Settings, not here. */}
+      <div style={{ marginTop: "var(--sp-8)" }}>
+        <ContextTreeRow onManage={() => ctx.guardedNavigate("/settings/context")} />
+      </div>
+
+      {/* Environment variables (draft — stages into the SaveBar). */}
       {ctx.config && (
         <div id={sectionAnchorId("env")} style={{ marginTop: "var(--sp-8)" }}>
           <EnvSection
@@ -129,5 +145,50 @@ export function RuntimeTab() {
         </div>
       )}
     </>
+  );
+}
+
+/**
+ * Read-only view of the org-level Context tree binding. The tree is injected
+ * into every agent's workspace at startup, so it's genuinely part of this
+ * agent's runtime environment — but it's an org-wide setting, not per-agent and
+ * not editable here. This row only displays it (no inputs, not part of the
+ * SaveBar) and links out to Settings → Context tree for changes.
+ */
+function ContextTreeRow({ onManage }: { onManage: () => void }): ReactNode {
+  const { organizationId } = useAuth();
+  const query = useQuery({
+    queryKey: ["org-context-tree", organizationId],
+    queryFn: () => getContextTreeSetting(organizationId ?? ""),
+    enabled: !!organizationId,
+  });
+
+  let value: ReactNode;
+  let description: ReactNode = "Injected into this agent's workspace at startup.";
+  if (!organizationId || query.isLoading) {
+    value = <span style={{ color: "var(--fg-4)" }}>Loading…</span>;
+  } else if (query.error) {
+    // Quiet failure — never crash the tab over an optional, read-only row.
+    value = <span style={{ color: "var(--fg-4)" }}>Couldn't load context tree.</span>;
+    description = null;
+  } else if (!query.data?.repo) {
+    value = <span style={{ color: "var(--fg-3)" }}>No context tree configured</span>;
+  } else {
+    value = `${query.data.repo}@${query.data.branch ?? "main"}`;
+  }
+
+  return (
+    <Section title="Workspace context" description="Read-only — the team's Context tree, managed in Settings.">
+      <ConfigRow
+        label="Context tree"
+        value={value}
+        description={description}
+        action={
+          <Button size="xs" variant="ghost" onClick={onManage} title="Open the org Context tree setting">
+            Manage in Settings → Context tree
+          </Button>
+        }
+      />
+    </Section>
   );
 }


### PR DESCRIPTION
Part 3/3 of the agent-detail page redesign (Environment tab).

## What changes
- **Reorder** sections by concept (runtime → workspace): **Execution → Model settings → Repositories → Context tree → Environment variables**. They were grouped by save-semantics (immediate/draft), which split the tightly-coupled Execution and Model sections apart. Each section already shows its own immediate/draft tag, so physical adjacency isn't needed to convey save behavior.
- Add a **read-only "Workspace context" row** showing the org-level Context tree binding (`repo@branch`). The tree is injected into every agent's workspace at startup, so it's genuinely part of this agent's runtime environment — but it's an **org-wide setting, not per-agent**, so the row is display-only (no inputs, not part of the SaveBar) and links out to **Settings → Context tree**. Loading / error / empty (`No context tree configured`) states are handled and never crash the tab.

## Scope / safety
- Pure frontend. Files: `runtime-tab.tsx` (+ a DOM-test mock for the org-settings query).
- Reuses `getContextTreeSetting` (member-readable), `Section`, `ConfigRow`.
- `typecheck` clean; **700/700** tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)