### PR TITLE
Harden: make explicit-recipient enforcement the default in sendMessage()

### DIFF
--- a/packages/server/src/__tests__/add-participant-backfill.test.ts
+++ b/packages/server/src/__tests__/add-participant-backfill.test.ts
@@ -63,7 +63,13 @@ describe("addParticipant — silent-context backfill (v1 §四 改造 2)", () =>
 
     const total = PRECEDING_CONTEXT_MAX_ENTRIES + 5;
     for (let i = 0; i < total; i++) {
-      await sendMessage(app.db, chat.id, owner.agent.uuid, { source: "api", format: "text", content: `msg-${i}` });
+      await sendMessage(
+        app.db,
+        chat.id,
+        owner.agent.uuid,
+        { source: "api", format: "text", content: `msg-${i}` },
+        { allowRecipientlessSend: true },
+      );
     }
 
     const ownerSilentBefore = await countSilentEntries(app.db, owner.agent.inboxId, chat.id);
@@ -96,7 +102,13 @@ describe("addParticipant — silent-context backfill (v1 §四 改造 2)", () =>
 
     const total = 7;
     for (let i = 0; i < total; i++) {
-      await sendMessage(app.db, chat.id, owner.agent.uuid, { source: "api", format: "text", content: `m${i}` });
+      await sendMessage(
+        app.db,
+        chat.id,
+        owner.agent.uuid,
+        { source: "api", format: "text", content: `m${i}` },
+        { allowRecipientlessSend: true },
+      );
     }
 
     await addParticipant(app.db, chat.id, owner.agent.uuid, { agentId: newcomer.agent.uuid });
@@ -132,7 +144,13 @@ describe("addParticipant — silent-context backfill (v1 §四 改造 2)", () =>
       type: "group",
       participantIds: [peer.agent.uuid],
     });
-    await sendMessage(app.db, chat.id, owner.agent.uuid, { source: "api", format: "text", content: "hi" });
+    await sendMessage(
+      app.db,
+      chat.id,
+      owner.agent.uuid,
+      { source: "api", format: "text", content: "hi" },
+      { allowRecipientlessSend: true },
+    );
 
     const peerSilentBefore = await countSilentEntries(app.db, peer.agent.inboxId, chat.id);
     const peerNotifyBefore = await countNotifyEntries(app.db, peer.agent.inboxId, chat.id);
@@ -161,14 +179,38 @@ describe("addParticipant — silent-context backfill (v1 §四 改造 2)", () =>
       type: "group",
       participantIds: [peer.agent.uuid],
     });
-    await sendMessage(app.db, chat.id, owner.agent.uuid, { source: "api", format: "text", content: "before-1" });
-    await sendMessage(app.db, chat.id, owner.agent.uuid, { source: "api", format: "text", content: "before-2" });
+    await sendMessage(
+      app.db,
+      chat.id,
+      owner.agent.uuid,
+      { source: "api", format: "text", content: "before-1" },
+      { allowRecipientlessSend: true },
+    );
+    await sendMessage(
+      app.db,
+      chat.id,
+      owner.agent.uuid,
+      { source: "api", format: "text", content: "before-2" },
+      { allowRecipientlessSend: true },
+    );
 
     await addParticipant(app.db, chat.id, owner.agent.uuid, { agentId: newcomer.agent.uuid });
     const afterJoin = await countSilentEntries(app.db, newcomer.agent.inboxId, chat.id);
 
-    await sendMessage(app.db, chat.id, owner.agent.uuid, { source: "api", format: "text", content: "after-1" });
-    await sendMessage(app.db, chat.id, owner.agent.uuid, { source: "api", format: "text", content: "after-2" });
+    await sendMessage(
+      app.db,
+      chat.id,
+      owner.agent.uuid,
+      { source: "api", format: "text", content: "after-1" },
+      { allowRecipientlessSend: true },
+    );
+    await sendMessage(
+      app.db,
+      chat.id,
+      owner.agent.uuid,
+      { source: "api", format: "text", content: "after-2" },
+      { allowRecipientlessSend: true },
+    );
 
     expect(await countSilentEntries(app.db, newcomer.agent.inboxId, chat.id)).toBe(afterJoin + 2);
     // No notify rows on the joiner yet — they have not been @-mentioned.
@@ -197,11 +239,17 @@ describe("addParticipant — silent-context backfill (v1 §四 改造 2)", () =>
     // Seed enough history for a meaningful ordering check.
     const seeded: string[] = [];
     for (let i = 0; i < 5; i++) {
-      const r = await sendMessage(app.db, chat.id, owner.agent.uuid, {
-        source: "api",
-        format: "text",
-        content: `seed-${i}`,
-      });
+      const r = await sendMessage(
+        app.db,
+        chat.id,
+        owner.agent.uuid,
+        {
+          source: "api",
+          format: "text",
+          content: `seed-${i}`,
+        },
+        { allowRecipientlessSend: true },
+      );
       seeded.push(r.message.id);
     }
 

--- a/packages/server/src/__tests__/agent-final-text-purpose.test.ts
+++ b/packages/server/src/__tests__/agent-final-text-purpose.test.ts
@@ -10,8 +10,8 @@ import { createTestAdmin, createTestAgent, useTestApp } from "./helpers.js";
  * `purpose: "agent-final-text"` bypass channel.
  *
  * `result-sink.forwardResult` calls `sdk.sendMessage` with this tag set.
- * Without the bypass, the server's `enforceMention` guard rejects every
- * write that has no explicit `metadata.mentions` / `receiverNames` / `addressedTo`.
+ * Without the bypass, the server's default explicit-recipient guard rejects
+ * every write that has no explicit `metadata.mentions` / `receiverNames` / `addressedTo`.
  * These tests pin:
  *
  *   1. chat + no mentions + `purpose` tag → message stored, every fan-out
@@ -39,18 +39,12 @@ describe("sendMessage — agent-final-text bypass (v1 §四 改造 4 b)", () => 
       participantIds: [peerA.agent.uuid, peerB.agent.uuid],
     });
 
-    const result = await sendMessage(
-      app.db,
-      chat.id,
-      peerA.agent.uuid,
-      {
-        source: "api",
-        format: "text",
-        content: "i am done — turn ended",
-        purpose: "agent-final-text",
-      },
-      { enforceMention: true },
-    );
+    const result = await sendMessage(app.db, chat.id, peerA.agent.uuid, {
+      source: "api",
+      format: "text",
+      content: "i am done — turn ended",
+      purpose: "agent-final-text",
+    });
 
     expect(result.message).toBeDefined();
     // No wake-ups: recipients list is empty (the inbox writes still happen
@@ -69,18 +63,12 @@ describe("sendMessage — agent-final-text bypass (v1 §四 改造 4 b)", () => 
       participantIds: [peerA.agent.uuid, peerB.agent.uuid],
     });
 
-    const r = await sendMessage(
-      app.db,
-      chat.id,
-      peerA.agent.uuid,
-      {
-        source: "api",
-        format: "text",
-        content: "final text broadcast",
-        purpose: "agent-final-text",
-      },
-      { enforceMention: true },
-    );
+    const r = await sendMessage(app.db, chat.id, peerA.agent.uuid, {
+      source: "api",
+      format: "text",
+      content: "final text broadcast",
+      purpose: "agent-final-text",
+    });
 
     // Every fan-out row for this message must be notify=false.
     const fanRows = await app.db
@@ -105,13 +93,11 @@ describe("sendMessage — agent-final-text bypass (v1 §四 改造 4 b)", () => 
     });
 
     await expect(
-      sendMessage(
-        app.db,
-        chat.id,
-        peerA.agent.uuid,
-        { source: "api", format: "text", content: "i am done — turn ended" },
-        { enforceMention: true },
-      ),
+      sendMessage(app.db, chat.id, peerA.agent.uuid, {
+        source: "api",
+        format: "text",
+        content: "i am done — turn ended",
+      }),
     ).rejects.toThrow(/explicit recipient/i);
   });
 
@@ -353,8 +339,8 @@ describe("sendMessage — agent-final-text bypass (v1 §四 改造 4 b)", () => 
   });
 
   it("API integration: same endpoint without `purpose` still rejects no-mention sends with 400 (regression)", async () => {
-    // `enforceMention` now applies to every chat shape (no more 1:1
-    // bypass); pick a real group here for parity with the original
+    // The default explicit-recipient guard applies to every chat shape (no
+    // more 1:1 bypass); pick a real group here for parity with the original
     // regression scenario.
     const app = getApp();
     const sender = await createTestAgent(app, { type: "agent" });

--- a/packages/server/src/__tests__/agent-send-mention-injection.test.ts
+++ b/packages/server/src/__tests__/agent-send-mention-injection.test.ts
@@ -17,12 +17,14 @@ import { createTestAgent, useTestApp } from "./helpers.js";
  * Spec (post-retire of content extraction — see services/message.ts
  * "Routing contract"):
  *
- *   `enforceMention` — reject sends where no recipient (other than the
- *     sender) is declared via `metadata.mentions` (uuids),
- *     `receiverNames` (names, resolved by the server), or
- *     `addressedToAgentIds` (system-routed). The web and agent SDK
- *     endpoints opt-in; adapters and webhooks do not.
- *     `purpose: "agent-final-text"` bypasses the check unconditionally.
+ *   Explicit-recipient enforcement (DEFAULT ON) — reject sends where no
+ *     recipient (other than the sender) is declared via `metadata.mentions`
+ *     (uuids), `receiverNames` (names, resolved by the server), or
+ *     `addressedToAgentIds` (system-routed, counted only when it resolves to
+ *     an active speaker). Every entry point inherits this; there is no opt-in
+ *     flag. `purpose: "agent-final-text"` and the trusted `allowRecipientlessSend`
+ *     opt-out (system delivery paths whose addressing may resolve to no live
+ *     speaker, e.g. github-delivery) bypass the check.
  *     The server NEVER parses `@<name>` tokens out of content — clients
  *     must resolve mentions themselves and declare routing explicitly.
  *
@@ -65,20 +67,14 @@ describe("mention enforcement + content normalisation", () => {
     return { sender, peer, chat };
   }
 
-  // ─── enforceMention ────────────────────────────────────────────────────
+  // ─── explicit-recipient enforcement (default on) ────────────────────────
 
-  describe("enforceMention rejects sends with no declared recipient", () => {
+  describe("explicit-recipient enforcement (default) rejects sends with no recipient", () => {
     it("rejects when no routing is declared at all", async () => {
       const app = getApp();
       const { sender, chat } = await setupGroup(crypto.randomUUID().slice(0, 6));
       await expect(
-        sendMessage(
-          app.db,
-          chat.id,
-          sender.agent.uuid,
-          { source: "api", format: "text", content: "broadcast" },
-          { enforceMention: true },
-        ),
+        sendMessage(app.db, chat.id, sender.agent.uuid, { source: "api", format: "text", content: "broadcast" }),
       ).rejects.toThrow(/explicit recipient/i);
     });
 
@@ -86,13 +82,12 @@ describe("mention enforcement + content normalisation", () => {
       const app = getApp();
       const { sender, chat } = await setupGroup(crypto.randomUUID().slice(0, 6));
       await expect(
-        sendMessage(
-          app.db,
-          chat.id,
-          sender.agent.uuid,
-          { source: "api", format: "text", content: "talking to myself", metadata: { mentions: [sender.agent.uuid] } },
-          { enforceMention: true },
-        ),
+        sendMessage(app.db, chat.id, sender.agent.uuid, {
+          source: "api",
+          format: "text",
+          content: "talking to myself",
+          metadata: { mentions: [sender.agent.uuid] },
+        }),
       ).rejects.toThrow(/explicit recipient/i);
     });
 
@@ -105,13 +100,11 @@ describe("mention enforcement + content normalisation", () => {
       const uid = crypto.randomUUID().slice(0, 6);
       const { sender, peerA, chat } = await setupGroup(uid);
       await expect(
-        sendMessage(
-          app.db,
-          chat.id,
-          sender.agent.uuid,
-          { source: "api", format: "text", content: `@${peerA.name} status?` },
-          { enforceMention: true },
-        ),
+        sendMessage(app.db, chat.id, sender.agent.uuid, {
+          source: "api",
+          format: "text",
+          content: `@${peerA.name} status?`,
+        }),
       ).rejects.toThrow(/explicit recipient/i);
     });
 
@@ -119,13 +112,12 @@ describe("mention enforcement + content normalisation", () => {
       const app = getApp();
       const uid = crypto.randomUUID().slice(0, 6);
       const { sender, peerA, chat } = await setupGroup(uid);
-      const result = await sendMessage(
-        app.db,
-        chat.id,
-        sender.agent.uuid,
-        { source: "api", format: "text", content: "ping", metadata: { mentions: [peerA.uuid] } },
-        { enforceMention: true },
-      );
+      const result = await sendMessage(app.db, chat.id, sender.agent.uuid, {
+        source: "api",
+        format: "text",
+        content: "ping",
+        metadata: { mentions: [peerA.uuid] },
+      });
       expect(result.message).toBeDefined();
     });
 
@@ -134,13 +126,12 @@ describe("mention enforcement + content normalisation", () => {
       const uid = crypto.randomUUID().slice(0, 6);
       const { sender, peerA, chat } = await setupGroup(uid);
       if (!peerA.name) throw new Error("peerA name missing");
-      const result = await sendMessage(
-        app.db,
-        chat.id,
-        sender.agent.uuid,
-        { source: "api", format: "text", content: "ping", receiverNames: [peerA.name] },
-        { enforceMention: true },
-      );
+      const result = await sendMessage(app.db, chat.id, sender.agent.uuid, {
+        source: "api",
+        format: "text",
+        content: "ping",
+        receiverNames: [peerA.name],
+      });
       expect(result.message).toBeDefined();
       const meta = (result.message.metadata ?? {}) as { mentions?: unknown };
       expect(meta.mentions).toEqual([peerA.uuid]);
@@ -157,9 +148,46 @@ describe("mention enforcement + content normalisation", () => {
         chat.id,
         sender.agent.uuid,
         { source: "api", format: "text", content: "system event" },
-        { enforceMention: true, addressedToAgentIds: [peerA.uuid] },
+        { addressedToAgentIds: [peerA.uuid] },
       );
       expect(result.message).toBeDefined();
+    });
+
+    it("rejects when addressedToAgentIds resolves to no active speaker (resolution-based, not array length)", async () => {
+      // The guard counts a system-routing override only when it resolves to an
+      // active, non-sender speaker of this chat — array length alone is not
+      // enough. An id that is not a live speaker reaches no one, so it must not
+      // satisfy the explicit-recipient requirement.
+      const app = getApp();
+      const uid = crypto.randomUUID().slice(0, 6);
+      const { sender, chat } = await setupGroup(uid);
+      await expect(
+        sendMessage(
+          app.db,
+          chat.id,
+          sender.agent.uuid,
+          { source: "api", format: "text", content: "system event" },
+          { addressedToAgentIds: [crypto.randomUUID()] },
+        ),
+      ).rejects.toThrow(/explicit recipient/i);
+    });
+
+    it("accepts a recipientless system send when allowRecipientlessSend opts out (degenerate addressing)", async () => {
+      // The trusted opt-out is what lets a system delivery path (github-delivery)
+      // write a history/context row when its addressing resolves to no live
+      // speaker — without it, the resolution-based guard above would throw.
+      const app = getApp();
+      const uid = crypto.randomUUID().slice(0, 6);
+      const { sender, chat } = await setupGroup(uid);
+      const result = await sendMessage(
+        app.db,
+        chat.id,
+        sender.agent.uuid,
+        { source: "api", format: "text", content: "system event" },
+        { addressedToAgentIds: [crypto.randomUUID()], allowRecipientlessSend: true },
+      );
+      expect(result.message).toBeDefined();
+      expect(result.recipients).toHaveLength(0);
     });
 
     it("explicit metadata.mentions is the single source of truth (content @<name> ignored)", async () => {
@@ -169,13 +197,12 @@ describe("mention enforcement + content normalisation", () => {
       const app = getApp();
       const uid = crypto.randomUUID().slice(0, 6);
       const { sender, peerA, peerB, chat } = await setupGroup(uid);
-      const result = await sendMessage(
-        app.db,
-        chat.id,
-        sender.agent.uuid,
-        { source: "api", format: "text", content: `@${peerA.name} ping`, metadata: { mentions: [peerB.uuid] } },
-        { enforceMention: true },
-      );
+      const result = await sendMessage(app.db, chat.id, sender.agent.uuid, {
+        source: "api",
+        format: "text",
+        content: `@${peerA.name} ping`,
+        metadata: { mentions: [peerB.uuid] },
+      });
       const meta = (result.message.metadata ?? {}) as { mentions?: unknown };
       expect(meta.mentions).toEqual([peerB.uuid]);
     });
@@ -189,37 +216,35 @@ describe("mention enforcement + content normalisation", () => {
       const app = getApp();
       const { sender, chat } = await setupDirect(crypto.randomUUID().slice(0, 6));
       await expect(
-        sendMessage(
-          app.db,
-          chat.id,
-          sender.agent.uuid,
-          { source: "api", format: "text", content: "hi" },
-          { enforceMention: true },
-        ),
+        sendMessage(app.db, chat.id, sender.agent.uuid, { source: "api", format: "text", content: "hi" }),
       ).rejects.toThrow(/explicit recipient/i);
     });
 
     it("accepts a 1:1 send when the peer is declared in metadata.mentions (web composer pattern)", async () => {
       const app = getApp();
       const { sender, peer, chat } = await setupDirect(crypto.randomUUID().slice(0, 6));
+      const result = await sendMessage(app.db, chat.id, sender.agent.uuid, {
+        source: "api",
+        format: "text",
+        content: "hi",
+        metadata: { mentions: [peer.uuid] },
+      });
+      expect(result.message).toBeDefined();
+    });
+
+    it("does NOT enforce when allowRecipientlessSend opts out (trusted system delivery paths)", async () => {
+      // The default-on guard is the contract; the only escape hatch for a
+      // trusted server-internal path whose addressing can be empty (e.g.
+      // github-delivery) is the explicit `allowRecipientlessSend` opt-out.
+      const app = getApp();
+      const { sender, chat } = await setupGroup(crypto.randomUUID().slice(0, 6));
       const result = await sendMessage(
         app.db,
         chat.id,
         sender.agent.uuid,
-        { source: "api", format: "text", content: "hi", metadata: { mentions: [peer.uuid] } },
-        { enforceMention: true },
+        { source: "api", format: "text", content: "system broadcast" },
+        { allowRecipientlessSend: true },
       );
-      expect(result.message).toBeDefined();
-    });
-
-    it("does NOT enforce when the flag is off (adapters / webhooks / system tasks)", async () => {
-      const app = getApp();
-      const { sender, chat } = await setupGroup(crypto.randomUUID().slice(0, 6));
-      const result = await sendMessage(app.db, chat.id, sender.agent.uuid, {
-        source: "api",
-        format: "text",
-        content: "system broadcast",
-      });
       expect(result.message).toBeDefined();
     });
   });
@@ -408,7 +433,7 @@ describe("mention enforcement + content normalisation", () => {
 
   // ─── Combined: enforce + normalise on the same call ────────────────────
 
-  describe("enforceMention + normalizeMentionsInContent together (the agent endpoint configuration)", () => {
+  describe("default enforcement + normalizeMentionsInContent together (the agent endpoint configuration)", () => {
     it("rejects unaddressed sends even when normalisation is on", async () => {
       const app = getApp();
       const { sender, chat } = await setupGroup(crypto.randomUUID().slice(0, 6));
@@ -418,7 +443,7 @@ describe("mention enforcement + content normalisation", () => {
           chat.id,
           sender.agent.uuid,
           { source: "api", format: "text", content: "hi" },
-          { enforceMention: true, normalizeMentionsInContent: true },
+          { normalizeMentionsInContent: true },
         ),
       ).rejects.toThrow(/explicit recipient/i);
     });
@@ -434,7 +459,7 @@ describe("mention enforcement + content normalisation", () => {
         chat.id,
         sender.agent.uuid,
         { source: "api", format: "text", content: "今天是 2026-04-27。", metadata: { mentions: [peerA.uuid] } },
-        { enforceMention: true, normalizeMentionsInContent: true },
+        { normalizeMentionsInContent: true },
       );
       expect(result.message.content).toBe(`@${peerA.name} 今天是 2026-04-27。`);
 
@@ -564,7 +589,7 @@ describe("mention enforcement + content normalisation", () => {
         chat.id,
         sender.agent.uuid,
         { source: "api", format: "text", content: "ok", metadata: { mentions: [peerA.uuid] } },
-        { enforceMention: true, normalizeMentionsInContent: true },
+        { normalizeMentionsInContent: true },
       );
       const [row] = await app.db.select().from(messages).where(eq(messages.id, result.message.id)).limit(1);
       if (!row) throw new Error("message row missing");
@@ -578,13 +603,7 @@ describe("mention enforcement + content normalisation", () => {
       const { sender, chat } = await setupGroup(crypto.randomUUID().slice(0, 6));
       const beforeCount = await app.db.select({ id: messages.id }).from(messages).where(eq(messages.chatId, chat.id));
       await expect(
-        sendMessage(
-          app.db,
-          chat.id,
-          sender.agent.uuid,
-          { source: "api", format: "text", content: "broadcast" },
-          { enforceMention: true },
-        ),
+        sendMessage(app.db, chat.id, sender.agent.uuid, { source: "api", format: "text", content: "broadcast" }),
       ).rejects.toThrow();
       const afterCount = await app.db.select({ id: messages.id }).from(messages).where(eq(messages.chatId, chat.id));
       expect(afterCount.length).toBe(beforeCount.length);

--- a/packages/server/src/__tests__/chat-detail-title.test.ts
+++ b/packages/server/src/__tests__/chat-detail-title.test.ts
@@ -46,11 +46,17 @@ describe("getChatDetail — server-resolved title (v1.7)", () => {
       type: "group",
       participantIds: [peer.agent.uuid],
     });
-    await sendMessage(app.db, chat.id, owner.agent.uuid, {
-      source: "api",
-      format: "text",
-      content: "Let's coordinate the design review tomorrow",
-    });
+    await sendMessage(
+      app.db,
+      chat.id,
+      owner.agent.uuid,
+      {
+        source: "api",
+        format: "text",
+        content: "Let's coordinate the design review tomorrow",
+      },
+      { allowRecipientlessSend: true },
+    );
     const detail = await getChatDetail(app.db, chat.id, owner.agent.uuid);
     expect(detail.topic).toBeNull();
     expect(detail.title).toBe("Let's coordinate the design review tomorrow");

--- a/packages/server/src/__tests__/direct-chat-auto-mention.test.ts
+++ b/packages/server/src/__tests__/direct-chat-auto-mention.test.ts
@@ -157,11 +157,17 @@ describe("1:1 chat wake-up + unread badge (explicit-mention contract)", () => {
     const { chatId } = await createMeChat(app.db, admin.humanAgentUuid, admin.organizationId, {
       participantIds: [peer.agent.uuid],
     });
-    await sendMessage(app.db, chatId, admin.humanAgentUuid, {
-      source: "api",
-      format: "text",
-      content: "hi, no mentions",
-    });
+    await sendMessage(
+      app.db,
+      chatId,
+      admin.humanAgentUuid,
+      {
+        source: "api",
+        format: "text",
+        content: "hi, no mentions",
+      },
+      { allowRecipientlessSend: true },
+    );
 
     expect(await notifyInboxRows(chatId, peer.agent.uuid)).toHaveLength(0);
     expect(await loadUnread(chatId, peer.agent.uuid, peer.memberId, peer.organizationId)).toBe(0);

--- a/packages/server/src/__tests__/direct-chat-mention-mode.test.ts
+++ b/packages/server/src/__tests__/direct-chat-mention-mode.test.ts
@@ -103,11 +103,17 @@ describe("chat membership + fan-out semantics (explicit-only)", () => {
         type: "group",
         participantIds: [agent.uuid],
       });
-      await sendMessage(app.db, chat.id, human.agent.uuid, {
-        source: "web",
-        format: "text",
-        content: "what's the date?",
-      });
+      await sendMessage(
+        app.db,
+        chat.id,
+        human.agent.uuid,
+        {
+          source: "web",
+          format: "text",
+          content: "what's the date?",
+        },
+        { allowRecipientlessSend: true },
+      );
 
       expect(await notifyEntries(chat.id, agent.uuid)).toHaveLength(0);
     });
@@ -204,11 +210,17 @@ describe("chat membership + fan-out semantics (explicit-only)", () => {
         type: "group",
         participantIds: [a1.uuid, a2.uuid],
       });
-      await sendMessage(app.db, chat.id, human.agent.uuid, {
-        source: "web",
-        format: "text",
-        content: "team status?",
-      });
+      await sendMessage(
+        app.db,
+        chat.id,
+        human.agent.uuid,
+        {
+          source: "web",
+          format: "text",
+          content: "team status?",
+        },
+        { allowRecipientlessSend: true },
+      );
 
       expect(await notifyEntries(chat.id, a1.uuid)).toHaveLength(0);
       expect(await notifyEntries(chat.id, a2.uuid)).toHaveLength(0);

--- a/packages/server/src/__tests__/github-delivery.test.ts
+++ b/packages/server/src/__tests__/github-delivery.test.ts
@@ -134,6 +134,81 @@ describe("deliverNormalizedEvent", () => {
     expect(content.reason).toBe("subscribed");
   });
 
+  it("delivers a recipientless card when the delegate is not a live speaker (trusted opt-out, wakes no one)", async () => {
+    // Empty-addressing system path: github-delivery addresses the delegate via
+    // `addressedToAgentIds`, but on some events that delegate is not an active
+    // speaker of the bound chat, so the addressing resolves to no live
+    // recipient. The default explicit-recipient guard would reject such a send;
+    // github-delivery declares `allowRecipientlessSend` so the card still lands
+    // as a history/context row for human observers. This pins that the trusted
+    // opt-out is load-bearing — the delivery must NOT throw and must wake no one.
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const delegate = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-${randomUUID().slice(0, 6)}`,
+    });
+    const human = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `human-${randomUUID().slice(0, 6)}`,
+      delegateMention: delegate,
+    });
+
+    // Bind a chat for the entity, but make ONLY the human a speaker — the
+    // delegate is deliberately not a member, so the card's addressing resolves
+    // to no live speaker.
+    const chatId = `chat_${randomUUID()}`;
+    await app.db.insert(chats).values({ id: chatId, organizationId: admin.organizationId, type: "direct" });
+    await app.db.insert(chatMembership).values({
+      chatId,
+      agentId: human,
+      role: "owner",
+      accessMode: "speaker",
+      mode: "full",
+      source: "manual",
+    });
+    await app.db.insert(githubEntityChatMappings).values({
+      organizationId: admin.organizationId,
+      humanAgentId: human,
+      delegateAgentId: delegate,
+      entityType: "pull_request",
+      entityKey: "owner/repo#201",
+      chatId,
+      boundVia: "direct",
+    });
+
+    const target: AudienceTarget = {
+      humanAgentId: human,
+      delegateAgentId: delegate,
+      kind: "existing",
+      chatId,
+      involveReason: null,
+      involveLogin: null,
+    };
+    const event = makeEvent({
+      orgId: admin.organizationId,
+      entityType: "pull_request",
+      entityKey: "owner/repo#201",
+    });
+
+    const stats = await deliverNormalizedEvent(app, event, [target]);
+
+    // Delivery succeeds (no throw despite recipientless addressing).
+    expect(stats).toEqual({ delivered: 1, newChats: 0, failed: 0 });
+    const sent = await app.db.select().from(messages).where(eq(messages.chatId, chatId));
+    expect(sent).toHaveLength(1);
+    expect(sent[0]?.format).toBe("card");
+    // Wakes no one: the delegate has no inbox row at all (not a participant),
+    // so nothing was fanned out / notified.
+    const delegateEntries = await app.db
+      .select()
+      .from(inboxEntries)
+      .where(and(eq(inboxEntries.chatId, chatId), eq(inboxEntries.notify, true)));
+    expect(delegateEntries).toHaveLength(0);
+  });
+
   it("refreshes chats.topic to match the current entity title on each subsequent event for a github-bound chat", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);

--- a/packages/server/src/__tests__/inbox-ws-push.test.ts
+++ b/packages/server/src/__tests__/inbox-ws-push.test.ts
@@ -158,9 +158,27 @@ describe("inbox WS data-plane claim helpers", () => {
 
     // Three silent messages (no mentions → silent context rows), then a
     // trigger that explicitly mentions observer.
-    await sendMessage(app.db, chat.id, human.uuid, { source: "api", format: "text", content: "first silent" });
-    await sendMessage(app.db, chat.id, human.uuid, { source: "api", format: "text", content: "second silent" });
-    await sendMessage(app.db, chat.id, human.uuid, { source: "api", format: "text", content: "third silent" });
+    await sendMessage(
+      app.db,
+      chat.id,
+      human.uuid,
+      { source: "api", format: "text", content: "first silent" },
+      { allowRecipientlessSend: true },
+    );
+    await sendMessage(
+      app.db,
+      chat.id,
+      human.uuid,
+      { source: "api", format: "text", content: "second silent" },
+      { allowRecipientlessSend: true },
+    );
+    await sendMessage(
+      app.db,
+      chat.id,
+      human.uuid,
+      { source: "api", format: "text", content: "third silent" },
+      { allowRecipientlessSend: true },
+    );
     const trigger = await sendMessage(app.db, chat.id, human.uuid, {
       source: "api",
       format: "text",

--- a/packages/server/src/__tests__/me-chat-service.test.ts
+++ b/packages/server/src/__tests__/me-chat-service.test.ts
@@ -124,7 +124,13 @@ describe("chat-first workspace service layer", () => {
     });
 
     // peer sends a message into the chat
-    await sendMessage(app.db, chatId, peer.agent.uuid, { source: "api", format: "text", content: "hello @managed" });
+    await sendMessage(
+      app.db,
+      chatId,
+      peer.agent.uuid,
+      { source: "api", format: "text", content: "hello @managed" },
+      { allowRecipientlessSend: true },
+    );
 
     // admin's human agent (the watcher) must NOT have an inbox entry for this chat
     const inboxRows = await app.db.execute<{ count: number }>(sql`
@@ -551,11 +557,17 @@ describe("chat-first workspace service layer", () => {
     // peer @-mentions admin (the watcher) by name. Mention extraction reads
     // speakers only, so admin is NOT in the candidate set — the resulting
     // message must NOT bump admin's `unread_mention_count`.
-    await sendMessage(app.db, chatId, peer.agent.uuid, {
-      source: "api",
-      format: "text",
-      content: `Hi @${admin.username}, please look`,
-    });
+    await sendMessage(
+      app.db,
+      chatId,
+      peer.agent.uuid,
+      {
+        source: "api",
+        format: "text",
+        content: `Hi @${admin.username}, please look`,
+      },
+      { allowRecipientlessSend: true },
+    );
 
     const [adminStateRow] = await app.db.execute<{ unread_mention_count: number | null }>(sql`
       SELECT unread_mention_count FROM chat_user_state
@@ -583,7 +595,13 @@ describe("chat-first workspace service layer", () => {
     const c3 = await createMeChat(app.db, admin.humanAgentUuid, admin.organizationId, {
       participantIds: [peer.agent.uuid],
     });
-    await sendMessage(app.db, c1.chatId, admin.humanAgentUuid, { source: "api", format: "text", content: "hi" });
+    await sendMessage(
+      app.db,
+      c1.chatId,
+      admin.humanAgentUuid,
+      { source: "api", format: "text", content: "hi" },
+      { allowRecipientlessSend: true },
+    );
 
     // Page size 2: first page is [c1, one of c2/c3]; second page returns
     // exactly the missing one.
@@ -734,7 +752,13 @@ describe("chat-first workspace service layer", () => {
     });
     await setChatEngagement(app.db, chatId, admin.humanAgentUuid, "archived");
 
-    await sendMessage(app.db, chatId, peer.agent.uuid, { source: "api", format: "text", content: "ping" });
+    await sendMessage(
+      app.db,
+      chatId,
+      peer.agent.uuid,
+      { source: "api", format: "text", content: "ping" },
+      { allowRecipientlessSend: true },
+    );
 
     const [row] = await app.db.execute<{ engagement_status: string }>(
       sql`SELECT engagement_status FROM chat_user_state
@@ -753,7 +777,13 @@ describe("chat-first workspace service layer", () => {
     });
     await setChatEngagement(app.db, chatId, admin.humanAgentUuid, "deleted");
 
-    await sendMessage(app.db, chatId, peer.agent.uuid, { source: "api", format: "text", content: "ping" });
+    await sendMessage(
+      app.db,
+      chatId,
+      peer.agent.uuid,
+      { source: "api", format: "text", content: "ping" },
+      { allowRecipientlessSend: true },
+    );
 
     const [row] = await app.db.execute<{ engagement_status: string }>(
       sql`SELECT engagement_status FROM chat_user_state

--- a/packages/server/src/__tests__/mention-fanout.test.ts
+++ b/packages/server/src/__tests__/mention-fanout.test.ts
@@ -105,11 +105,17 @@ describe("server routing + fan-out filter (explicit mentions only)", () => {
     const uid = crypto.randomUUID().slice(0, 6);
     const { sender, obsA, chat } = await setupGroup(app, uid);
 
-    await sendMessage(app.db, chat.id, sender.agent.uuid, {
-      source: "api",
-      format: "text",
-      content: `@mf-obsA-${uid} please review`,
-    });
+    await sendMessage(
+      app.db,
+      chat.id,
+      sender.agent.uuid,
+      {
+        source: "api",
+        format: "text",
+        content: `@mf-obsA-${uid} please review`,
+      },
+      { allowRecipientlessSend: true },
+    );
 
     expect(await inboxEntriesFor(app, chat.id, obsA.uuid)).toHaveLength(0);
   });
@@ -120,11 +126,17 @@ describe("server routing + fan-out filter (explicit mentions only)", () => {
     const { sender, obsA, obsB, chat } = await setupGroup(app, uid);
     await setParticipantMode(app, chat.id, obsA.uuid, "full");
 
-    await sendMessage(app.db, chat.id, sender.agent.uuid, {
-      source: "api",
-      format: "text",
-      content: "nothing specific, team",
-    });
+    await sendMessage(
+      app.db,
+      chat.id,
+      sender.agent.uuid,
+      {
+        source: "api",
+        format: "text",
+        content: "nothing specific, team",
+      },
+      { allowRecipientlessSend: true },
+    );
 
     expect(await inboxEntriesFor(app, chat.id, obsA.uuid)).toHaveLength(0);
     expect(await inboxEntriesFor(app, chat.id, obsB.uuid)).toHaveLength(0);
@@ -221,11 +233,17 @@ describe("server routing + fan-out filter (explicit mentions only)", () => {
     const uid = crypto.randomUUID().slice(0, 6);
     const { sender, chat } = await setupGroup(app, uid);
 
-    await sendMessage(app.db, chat.id, sender.agent.uuid, {
-      source: "api",
-      format: "text",
-      content: "earlier chatter",
-    });
+    await sendMessage(
+      app.db,
+      chat.id,
+      sender.agent.uuid,
+      {
+        source: "api",
+        format: "text",
+        content: "earlier chatter",
+      },
+      { allowRecipientlessSend: true },
+    );
 
     const { agent: late } = await createTestAgent(app, { name: `mf-late-${uid}` });
     await app.db.update(agents).set({ managerId: sender.memberId }).where(eq(agents.uuid, late.uuid));
@@ -240,11 +258,17 @@ describe("server routing + fan-out filter (explicit mentions only)", () => {
     const app = getApp();
     const uid = crypto.randomUUID().slice(0, 6);
     const { sender, chat } = await setupGroup(app, uid);
-    const { message } = await sendMessage(app.db, chat.id, sender.agent.uuid, {
-      source: "api",
-      format: "text",
-      content: "generic chatter",
-    });
+    const { message } = await sendMessage(
+      app.db,
+      chat.id,
+      sender.agent.uuid,
+      {
+        source: "api",
+        format: "text",
+        content: "generic chatter",
+      },
+      { allowRecipientlessSend: true },
+    );
     const meta = (message.metadata ?? {}) as Record<string, unknown>;
     expect(meta).not.toHaveProperty("mentions");
   });
@@ -265,22 +289,17 @@ describe("server routing + fan-out filter (explicit mentions only)", () => {
     expect(await inboxEntriesFor(app, chat.id, obsA.uuid)).toHaveLength(1);
   });
 
-  it("rejects a no-recipient send under enforceMention: there is no no-mention path", async () => {
+  it("rejects a no-recipient send: there is no no-mention path", async () => {
     // A group chat has no no-recipient send. A message that names no one is
     // rejected regardless of caller — there is no broadcast opt-in that lets
-    // an un-addressed message through.
+    // an un-addressed message through. Enforcement is the default now, so a
+    // bare send carries no flag and still rejects.
     const app = getApp();
     const uid = crypto.randomUUID().slice(0, 6);
     const { sender, chat } = await setupGroup(app, uid);
 
     await expect(
-      sendMessage(
-        app.db,
-        chat.id,
-        sender.agent.uuid,
-        { source: "api", format: "text", content: "no recipient" },
-        { enforceMention: true },
-      ),
+      sendMessage(app.db, chat.id, sender.agent.uuid, { source: "api", format: "text", content: "no recipient" }),
     ).rejects.toThrow(/recipient/i);
   });
 });

--- a/packages/server/src/__tests__/message-recipients.test.ts
+++ b/packages/server/src/__tests__/message-recipients.test.ts
@@ -44,11 +44,17 @@ describe("sendMessage returns recipients", () => {
       participantIds: [],
     });
 
-    const result = await sendMessage(app.db, chat.id, a1.uuid, {
-      source: "api",
-      format: "text",
-      content: "talking to myself",
-    });
+    const result = await sendMessage(
+      app.db,
+      chat.id,
+      a1.uuid,
+      {
+        source: "api",
+        format: "text",
+        content: "talking to myself",
+      },
+      { allowRecipientlessSend: true },
+    );
 
     expect(result.recipients).toHaveLength(0);
   });

--- a/packages/server/src/__tests__/message-session-creation.test.ts
+++ b/packages/server/src/__tests__/message-session-creation.test.ts
@@ -106,7 +106,13 @@ describe("sendMessage — predictive session activation (M plan Step 1b)", () =>
     });
 
     // No @, no metadata.mentions → nobody wakes (silent fan-out).
-    await sendMessage(app.db, chat.id, sender.uuid, { source: "web", format: "text", content: "hello team" });
+    await sendMessage(
+      app.db,
+      chat.id,
+      sender.uuid,
+      { source: "web", format: "text", content: "hello team" },
+      { allowRecipientlessSend: true },
+    );
     expect(await readSessionState(app, mentioned.uuid, chat.id)).toBeNull();
     expect(await readSessionState(app, silent.uuid, chat.id)).toBeNull();
 

--- a/packages/server/src/__tests__/open-question.test.ts
+++ b/packages/server/src/__tests__/open-question.test.ts
@@ -114,22 +114,34 @@ describe("open-question (format=request) + open_request_count", () => {
     expect(await openReqCount(app, chat.id, human.uuid)).toBe(1);
 
     // First answer from the target → -1.
-    await sendMessage(app.db, chat.id, human.uuid, {
-      source: "web",
-      format: "text",
-      content: "Let's do 5%.",
-      inReplyTo: question.id,
-    });
+    await sendMessage(
+      app.db,
+      chat.id,
+      human.uuid,
+      {
+        source: "web",
+        format: "text",
+        content: "Let's do 5%.",
+        inReplyTo: question.id,
+      },
+      { allowRecipientlessSend: true },
+    );
     expect(await openReqCount(app, chat.id, human.uuid)).toBe(0);
 
     // A second reply to the SAME question must NOT decrement again (idempotent,
     // floored at zero).
-    await sendMessage(app.db, chat.id, human.uuid, {
-      source: "web",
-      format: "text",
-      content: "...actually still 5%.",
-      inReplyTo: question.id,
-    });
+    await sendMessage(
+      app.db,
+      chat.id,
+      human.uuid,
+      {
+        source: "web",
+        format: "text",
+        content: "...actually still 5%.",
+        inReplyTo: question.id,
+      },
+      { allowRecipientlessSend: true },
+    );
     expect(await openReqCount(app, chat.id, human.uuid)).toBe(0);
   });
 
@@ -147,11 +159,17 @@ describe("open-question (format=request) + open_request_count", () => {
     expect(await openReqCount(app, chat.id, human.uuid)).toBe(1);
 
     // Human chats without inReplyTo — not an answer to the question.
-    await sendMessage(app.db, chat.id, human.uuid, {
-      source: "web",
-      format: "text",
-      content: "give me a sec",
-    });
+    await sendMessage(
+      app.db,
+      chat.id,
+      human.uuid,
+      {
+        source: "web",
+        format: "text",
+        content: "give me a sec",
+      },
+      { allowRecipientlessSend: true },
+    );
     expect(await openReqCount(app, chat.id, human.uuid)).toBe(1);
   });
 
@@ -199,21 +217,33 @@ describe("open-question (format=request) + open_request_count", () => {
 
     // The ASKER (not the target) replies to its own request with a plain text
     // message → active close/withdraw → the target's count clears.
-    await sendMessage(app.db, chat.id, asker.agent.uuid, {
-      source: "api",
-      format: "text",
-      content: "Never mind — resolved this offline, closing.",
-      inReplyTo: question.id,
-    });
+    await sendMessage(
+      app.db,
+      chat.id,
+      asker.agent.uuid,
+      {
+        source: "api",
+        format: "text",
+        content: "Never mind — resolved this offline, closing.",
+        inReplyTo: question.id,
+      },
+      { allowRecipientlessSend: true },
+    );
     expect(await openReqCount(app, chat.id, human.uuid)).toBe(0);
 
     // A second close (or any later reply) is a no-op — floored at zero.
-    await sendMessage(app.db, chat.id, asker.agent.uuid, {
-      source: "api",
-      format: "text",
-      content: "(still closed)",
-      inReplyTo: question.id,
-    });
+    await sendMessage(
+      app.db,
+      chat.id,
+      asker.agent.uuid,
+      {
+        source: "api",
+        format: "text",
+        content: "(still closed)",
+        inReplyTo: question.id,
+      },
+      { allowRecipientlessSend: true },
+    );
     expect(await openReqCount(app, chat.id, human.uuid)).toBe(0);
   });
 
@@ -233,7 +263,13 @@ describe("open-question (format=request) + open_request_count", () => {
       content: "ratio?",
       metadata: { mentions: [human.uuid], request: { question: "5% or 20%?" } },
     });
-    await sendMessage(app.db, chat.id, human.uuid, { source: "web", format: "text", content: "5%", inReplyTo: q1.id });
+    await sendMessage(
+      app.db,
+      chat.id,
+      human.uuid,
+      { source: "web", format: "text", content: "5%", inReplyTo: q1.id },
+      { allowRecipientlessSend: true },
+    );
     expect(await openReqCount(app, chat.id, human.uuid)).toBe(0);
 
     // Asker follows up with a NEW request replying to the resolved q1.
@@ -315,12 +351,18 @@ describe("open_request_count surfaces in the listMeChats projection (needs_you r
     expect(listAfterRaise.rows.find((r) => r.chatId === chat.id)?.openRequestCount).toBe(1);
 
     // Human answers (reply threaded to the question) → counter clears.
-    await sendMessage(app.db, chat.id, admin.humanAgentUuid, {
-      source: "web",
-      format: "text",
-      content: "yes, ship it",
-      inReplyTo: question.id,
-    });
+    await sendMessage(
+      app.db,
+      chat.id,
+      admin.humanAgentUuid,
+      {
+        source: "web",
+        format: "text",
+        content: "yes, ship it",
+        inReplyTo: question.id,
+      },
+      { allowRecipientlessSend: true },
+    );
 
     const listAfterAnswer = await listMeChats(app.db, admin.humanAgentUuid, admin.memberId, admin.organizationId, {
       limit: 50,

--- a/packages/server/src/__tests__/participant-invite.test.ts
+++ b/packages/server/src/__tests__/participant-invite.test.ts
@@ -225,11 +225,17 @@ describe("inviteParticipantsToChat", () => {
       participantIds: [peer.agent.uuid],
     });
     for (let i = 0; i < 6; i++) {
-      await sendMessage(app.db, chat.id, owner.agent.uuid, {
-        source: "api",
-        format: "text",
-        content: `inv-${i}`,
-      });
+      await sendMessage(
+        app.db,
+        chat.id,
+        owner.agent.uuid,
+        {
+          source: "api",
+          format: "text",
+          content: `inv-${i}`,
+        },
+        { allowRecipientlessSend: true },
+      );
     }
 
     await inviteParticipantsToChat(app.db, {

--- a/packages/server/src/__tests__/participant-mode-backfill.test.ts
+++ b/packages/server/src/__tests__/participant-mode-backfill.test.ts
@@ -56,7 +56,15 @@ describe("addChatParticipants — silent-context backfill invariant", () => {
       participantIds: [peer.agent.uuid],
     });
     for (let i = 0; i < 7; i++) {
-      await sendMessage(app.db, chat.id, owner.agent.uuid, { source: "api", format: "text", content: `m${i}` });
+      await sendMessage(
+        app.db,
+        chat.id,
+        owner.agent.uuid,
+        { source: "api", format: "text", content: `m${i}` },
+        {
+          allowRecipientlessSend: true,
+        },
+      );
     }
 
     await app.db.transaction((tx) =>
@@ -80,7 +88,15 @@ describe("addChatParticipants — silent-context backfill invariant", () => {
       participantIds: [peer.agent.uuid],
     });
     for (let i = 0; i < 4; i++) {
-      await sendMessage(app.db, chat.id, owner.agent.uuid, { source: "api", format: "text", content: `w${i}` });
+      await sendMessage(
+        app.db,
+        chat.id,
+        owner.agent.uuid,
+        { source: "api", format: "text", content: `w${i}` },
+        {
+          allowRecipientlessSend: true,
+        },
+      );
     }
 
     // Seed a watcher row directly — recomputeChatWatchers would also work
@@ -115,7 +131,15 @@ describe("addChatParticipants — silent-context backfill invariant", () => {
       participantIds: [newcomer.agent.uuid],
     });
     for (let i = 0; i < 3; i++) {
-      await sendMessage(app.db, chat.id, owner.agent.uuid, { source: "api", format: "text", content: `n${i}` });
+      await sendMessage(
+        app.db,
+        chat.id,
+        owner.agent.uuid,
+        { source: "api", format: "text", content: `n${i}` },
+        {
+          allowRecipientlessSend: true,
+        },
+      );
     }
 
     // `newcomer` was added as a speaker at chat creation time; createChat
@@ -142,7 +166,15 @@ describe("addChatParticipants — silent-context backfill invariant", () => {
       participantIds: [existing.agent.uuid],
     });
     for (let i = 0; i < 5; i++) {
-      await sendMessage(app.db, chat.id, owner.agent.uuid, { source: "api", format: "text", content: `b${i}` });
+      await sendMessage(
+        app.db,
+        chat.id,
+        owner.agent.uuid,
+        { source: "api", format: "text", content: `b${i}` },
+        {
+          allowRecipientlessSend: true,
+        },
+      );
     }
 
     const existingBefore = await countSilentEntries(app.db, existing.agent.inboxId, chat.id);
@@ -181,11 +213,17 @@ describe("backfill invariant — service entrypoints (regression: PR #393 follow
       participantIds: [peer.agent.uuid],
     });
     for (let i = 0; i < 6; i++) {
-      await sendMessage(app.db, chat.id, owner.humanAgentUuid, {
-        source: "api",
-        format: "text",
-        content: `web-${i}`,
-      });
+      await sendMessage(
+        app.db,
+        chat.id,
+        owner.humanAgentUuid,
+        {
+          source: "api",
+          format: "text",
+          content: `web-${i}`,
+        },
+        { allowRecipientlessSend: true },
+      );
     }
 
     await addMeChatParticipants(app.db, chat.id, owner.humanAgentUuid, owner.organizationId, {
@@ -210,7 +248,15 @@ describe("backfill invariant — service entrypoints (regression: PR #393 follow
       participantIds: [peer.agent.uuid],
     });
     for (let i = 0; i < 5; i++) {
-      await sendMessage(app.db, chat.id, owner.agent.uuid, { source: "api", format: "text", content: `e${i}` });
+      await sendMessage(
+        app.db,
+        chat.id,
+        owner.agent.uuid,
+        { source: "api", format: "text", content: `e${i}` },
+        {
+          allowRecipientlessSend: true,
+        },
+      );
     }
 
     await ensureParticipant(app.db, chat.id, newcomer.agent.uuid);
@@ -234,7 +280,15 @@ describe("backfill invariant — service entrypoints (regression: PR #393 follow
     });
     const total = PRECEDING_CONTEXT_MAX_ENTRIES + 10;
     for (let i = 0; i < total; i++) {
-      await sendMessage(app.db, chat.id, owner.agent.uuid, { source: "api", format: "text", content: `c${i}` });
+      await sendMessage(
+        app.db,
+        chat.id,
+        owner.agent.uuid,
+        { source: "api", format: "text", content: `c${i}` },
+        {
+          allowRecipientlessSend: true,
+        },
+      );
     }
 
     await app.db.transaction((tx) => addChatParticipants(tx, chat.id, [{ agentId: newcomer.agent.uuid }]));

--- a/packages/server/src/api/agent/messages.ts
+++ b/packages/server/src/api/agent/messages.ts
@@ -70,13 +70,13 @@ export async function agentMessageRoutes(app: FastifyInstance): Promise<void> {
         identity.uuid,
         body,
         {
-          // Explicit-only contract: agent SDK callers (CLI `chat send`,
-          // result-sink, etc.) declare routing via `receiverNames` or
-          // `metadata.mentions`, or set `purpose: "agent-final-text"` for
-          // silent history-only sends. The server no longer parses
-          // `@<name>` out of content — see `services/message.ts`
-          // Routing contract.
-          enforceMention: true,
+          // Explicit-recipient enforcement is the default in `sendMessage()`;
+          // this route carries no business flag. Agent SDK callers (CLI
+          // `chat send`, result-sink, etc.) declare routing via `receiverNames`
+          // or `metadata.mentions`, or set `purpose: "agent-final-text"` for
+          // silent history-only sends. The server no longer parses `@<name>`
+          // out of content — see `services/message.ts` Routing contract.
+          //
           // Auto-prepend `@<name>` for declared mentions missing from the
           // body so the rendered message matches the routing decision
           // (mainly: result-sink puts the trigger sender in `mentions` but

--- a/packages/server/src/api/chats.ts
+++ b/packages/server/src/api/chats.ts
@@ -335,22 +335,15 @@ export async function chatRoutes(app: FastifyInstance): Promise<void> {
 
     await ensureParticipant(app.db, request.params.chatId, scope.humanAgentId);
 
-    const result = await sendMessage(
-      app.db,
-      request.params.chatId,
-      scope.humanAgentId,
-      { ...body, source: "web" },
-      {
-        // Explicit-only contract: the web composer resolves `@<name>` chips
-        // client-side via `segmentMentions(content, participants)` and posts
-        // the resolved uuids in `metadata.mentions`. In 2-speaker chats the
-        // composer auto-injects the peer's uuid so 1:1 typing without an `@`
-        // still reaches the recipient. Either way, `metadata.mentions` is
-        // expected to be non-empty here; the server no longer parses
-        // content. See `services/message.ts` Routing contract.
-        enforceMention: true,
-      },
-    );
+    // Explicit-recipient enforcement is the default in `sendMessage()`; this
+    // route carries no business flag. The web composer resolves `@<name>` chips
+    // client-side via `segmentMentions(content, participants)` and posts the
+    // resolved uuids in `metadata.mentions`. In 2-speaker chats the composer
+    // auto-injects the peer's uuid so 1:1 typing without an `@` still reaches
+    // the recipient. Either way, `metadata.mentions` is expected to be non-empty
+    // here; the server no longer parses content. See `services/message.ts`
+    // Routing contract.
+    const result = await sendMessage(app.db, request.params.chatId, scope.humanAgentId, { ...body, source: "web" });
 
     notifyRecipients(app.notifier, result.recipients, result.message.id);
 

--- a/packages/server/src/services/github-delivery.ts
+++ b/packages/server/src/services/github-delivery.ts
@@ -127,6 +127,18 @@ export async function deliverNormalizedEvent(
           // so HTTP boundaries cannot impersonate the GitHub sender in the
           // chat UI. This is the one trusted-internal path.
           allowSystemSender: true,
+          // Opt out of the default explicit-recipient guard. This trusted
+          // system delivery owns and validates its own addressing
+          // (`addressedToAgentIds` derived from the resolved audience row),
+          // but the delegate may not be a speaker of the bound chat on some
+          // events, so the addressing resolves to no live recipient. Such a
+          // card is still a valid history/context row for human observers;
+          // without this opt-out the default guard would make this trusted path
+          // start throwing. (A delegate that IS a speaker but suspended/deleted
+          // is rejected earlier by the addressed-recipient status check — that
+          // is a separate, intentional guard, not covered by this opt-out.)
+          // See SendMessageOptions docs.
+          allowRecipientlessSend: true,
         },
       );
       notifyRecipients(app.notifier, recipients, message.id);

--- a/packages/server/src/services/message.ts
+++ b/packages/server/src/services/message.ts
@@ -69,22 +69,33 @@ export type SendMessageResult = {
 
 export type SendMessageOptions = {
   /**
-   * When true, reject the send with `BadRequestError` if no recipient is
-   * declared — neither `metadata.mentions` (uuids), `data.receiverNames`
-   * (names), nor `addressedToAgentIds` (system routing). Used by both the
-   * human web endpoint and the agent SDK endpoint so every message that
-   * reaches the server arrives with an explicit routing intent.
+   * Trusted-internal opt-out from the default explicit-recipient guard.
    *
-   * The only legal way to satisfy this option with empty routing is to
-   * declare `data.purpose === "agent-final-text"`, which marks the send as
-   * a silent history-only write (result-sink's final-text turn).
+   * `sendMessage()` enforces explicit-recipient routing **by default**: a send
+   * that declares no recipient (no `metadata.mentions`, no `data.receiverNames`,
+   * no `addressedToAgentIds`) is rejected with `BadRequestError`. This is the
+   * durable contract — the server rejects a no-recipient send regardless of
+   * caller (see `system/cloud/chat/messaging.md` "Addressing Is Required To
+   * Send"). The two user entry points (web `api/chats.ts`, agent SDK
+   * `api/agent/messages.ts`) therefore carry no business flag; they inherit the
+   * default.
    *
-   * Server-internal callers (adapter inbound, github-delivery) leave this
-   * off because their routing decisions are owned by the caller and
-   * validated upstream; they pass `metadata.mentions` or
-   * `addressedToAgentIds` directly.
+   * The one other send shape that legitimately carries no recipient bypasses
+   * the guard without this option: `data.purpose === "agent-final-text"` — an
+   * agent's own final response surfaced for human observers, silent by
+   * construction (self-declared via `purposeProfile.skipMentionEnforcement`).
+   *
+   * This option is the **only** other escape hatch, reserved for trusted
+   * server-internal delivery paths whose addressing is owned and validated by
+   * the caller and **can legitimately resolve to no live speaker for some
+   * events** — today only `github-delivery.deliverNormalizedEvent`, whose card
+   * addressing (`addressedToAgentIds` derived from the audience row) may name a
+   * delegate that is not a speaker of the bound chat. Such a send writes a
+   * silent history/context row for human observers rather than reaching an
+   * inbox. Set it only on a path you have audited; never thread it through an
+   * HTTP boundary.
    */
-  enforceMention?: boolean;
+  allowRecipientlessSend?: boolean;
   /**
    * When true and `data.content` is a string, prepend `@<name>` tokens for
    * any participant in `metadata.mentions` whose name is missing from the
@@ -141,16 +152,21 @@ export async function sendMessage(
  * Routing contract (post-retire of content extraction)
  * ====================================================
  *
- * Every wake-up requires the caller to declare routing intent explicitly,
- * by one of:
+ * Every wake-up requires the caller to declare routing intent explicitly.
+ * Explicit-recipient enforcement is ON BY DEFAULT in `sendMessage()`; a send
+ * that declares no recipient is rejected unless it is one of the silent shapes
+ * below. Routing is declared by one of:
  *
  *   - `data.metadata.mentions: string[]` — agent uuids (resolved upstream)
  *   - `data.receiverNames: string[]` — agent names; resolved here against
  *     the chat's speaker list
  *   - `options.addressedToAgentIds` — system-routed override (e.g. github
- *     delivery)
+ *     delivery), counted only when it resolves to an active speaker
+ *
+ * Recipient-less sends are rejected by default, except these declared-silent
+ * shapes:
  *   - `data.purpose === "agent-final-text"` — silent history-only write
- *     (the only legal mentions-empty case under `enforceMention`)
+ *   - `options.allowRecipientlessSend === true` — trusted system opt-out
  *
  * The server never parses `@<name>` tokens out of content. Clients that
  * surface IM-style `@-mention` UX (web composer, future mobile) must
@@ -336,10 +352,12 @@ async function sendMessageInner(
           forceSilentFanOut: false,
         };
 
-    // Mention enforcement (explicit-only contract). Reject the send when
-    // the caller opted in via `enforceMention` but declared no routing
-    // intent — `metadata.mentions`, `receiverNames`, and
-    // `addressedToAgentIds` are the three legal declarations.
+    // Mention enforcement (explicit-only contract) — DEFAULT ON. Reject the
+    // send when no routing intent is declared — `metadata.mentions`,
+    // `receiverNames`, and `addressedToAgentIds` are the three legal
+    // declarations. The invariant lives here in the write path so every entry
+    // point inherits it; a new send caller cannot silently re-open the
+    // "write to chat history with no recipient" footgun by forgetting a flag.
     //
     // Applies to every chat shape (1:1 included): the previous "1:1
     // implicit wake" bypass was removed when the explicit contract took
@@ -347,17 +365,28 @@ async function sendMessageInner(
     // `metadata.mentions` for 2-speaker chats so this check passes
     // transparently.
     //
-    // `purpose === "agent-final-text"` bypasses via
-    // `purposeProfile.skipMentionEnforcement` — final-text is silent-by-
-    // construction so it never needs to name a recipient.
-    //
-    // There is no no-recipient send path: a group chat rejects any send that
-    // names no one. The only mentions-empty exception is `agent-final-text`
-    // above (an agent's own response for humans, not a message into the room).
-    if (options.enforceMention && !purposeProfile.skipMentionEnforcement) {
+    // Two send shapes legitimately carry no recipient and bypass the guard:
+    //   - `purpose === "agent-final-text"` (via
+    //     `purposeProfile.skipMentionEnforcement`) — silent-by-construction
+    //     final text, never needs to name a recipient.
+    //   - `options.allowRecipientlessSend` — trusted server-internal opt-out
+    //     for system delivery paths whose addressing can legitimately resolve
+    //     to no live speaker (today: github-delivery). See the option's doc.
+    const skipRecipientEnforcement = purposeProfile.skipMentionEnforcement || options.allowRecipientlessSend === true;
+    if (!skipRecipientEnforcement) {
       const recipientMentions = mergedMentions.filter((id) => id !== senderId);
-      const hasAddressed = (options.addressedToAgentIds?.length ?? 0) > 0;
-      if (recipientMentions.length === 0 && !hasAddressed) {
+      // A system-routing override (`addressedToAgentIds`) only satisfies the
+      // guard when it resolves to an active, non-sender speaker of this chat.
+      // Counting raw array length instead would let addressing that reaches no
+      // one slip through (`[undefined]`, `[senderId]`, or an id that is not a
+      // live speaker) — the same silent-dead-end the guard exists to prevent.
+      // A trusted system path whose addressing can legitimately resolve to no
+      // speaker (github-delivery) declares `allowRecipientlessSend` to opt out
+      // above rather than lean on that hole.
+      const hasActiveAddressed = (options.addressedToAgentIds ?? []).some(
+        (id) => id !== senderId && participantsById.get(id)?.status === "active",
+      );
+      if (recipientMentions.length === 0 && !hasActiveAddressed) {
         throw new BadRequestError(
           "Sending a message requires an explicit recipient. " +
             "Pass `metadata.mentions: [agentId]` (or `receiverNames: [name]`) to declare routing, " +

--- a/packages/web/src/pages/onboarding/steps/step-kickoff.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-kickoff.tsx
@@ -73,7 +73,7 @@ async function runKickoff(args: {
   try {
     // `createAgentChat` constructs a 1:1 chat with the bootstrap agent —
     // declare the agent as the explicit recipient so the server's
-    // `enforceMention` check passes (the legacy 1:1 implicit-wake
+    // explicit-recipient enforcement check passes (the legacy 1:1 implicit-wake
     // bypass is gone). Without this, the kickoff message would 400.
     await sendChatMessage(chat.id, args.bootstrap, [agent.uuid]);
   } catch (err) {

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -1265,7 +1265,7 @@ export function ChatView({
       setUploading(true);
       setUploadError(null);
       // Carry the routing mentions onto each image message so the
-      // server's `enforceMention` check accepts file-format sends.
+      // server's explicit-recipient enforcement check accepts file-format sends.
       // `effectiveSendMentions` already includes the 1:1 peer (per the
       // explicit-only contract), so the file path works in both DM and
       // group chats — without this every image POST would 400.
@@ -2271,7 +2271,7 @@ export function ChatView({
    *     resolved. The send-button gate (`requiresMention &&
    *     draftMentions.length === 0`) already prevents sending with an
    *     empty mention set in groups, matching the server's
-   *     `enforceMention` check.
+   *     explicit-recipient enforcement check.
    */
   const peerAgentId = useMemo<string | null>(() => {
     if (!chatDetail || !myAgentId) return null;

--- a/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
+++ b/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
@@ -35,7 +35,7 @@ import { cn } from "../../../lib/utils.js";
  *     "ask my PA something" case is zero-step. Stable across clicks —
  *     no runtime-presence MRU here, see issue 342.
  *
- *   - Textarea carries the message content. Server's `enforceMention`
+ *   - Textarea carries the message content. Server's explicit-recipient enforcement
  *     contract requires an explicit recipient on every send — for 1:1
  *     (single chip) the composer auto-injects the chip's uuid into
  *     `metadata.mentions` so a bare body still passes; for groups
@@ -55,7 +55,7 @@ import { cn } from "../../../lib/utils.js";
  *     chat exists. An image-only send (empty body) is allowed; a group
  *     (2+ chips) still needs an `@` in the body so each file POST
  *     carries non-empty `metadata.mentions` and clears the server's
- *     per-message `enforceMention` check.
+ *     per-message explicit-recipient enforcement check.
  *
  * On send: createMeChat({participantIds: chips ∪ body @s}) → stage each
  * image into IndexedDB → single `sendFileMessageBatch` carrying caption +
@@ -358,10 +358,10 @@ export function NewChatDraft({
       // sends still go through `sendChatMessage` below.
       if (images.length > 0) {
         // Carry the resolved mentions onto the batched file send so the
-        // single POST clears the server's `enforceMention` check. 1:1
+        // single POST clears the server's explicit-recipient enforcement check. 1:1
         // drafts have `mentions` already auto-injected by handleSend (the
         // single chip's uuid); group drafts carry the body's `@-mention`
-        // set. The server applies `enforceMention` to every chat shape now,
+        // set. The server applies explicit-recipient enforcement to every chat shape now,
         // so no path can rely on an empty-mentions skip.
         const imageMetadata = mentions.length > 0 ? { mentions } : undefined;
         const attachments: ImageRefContent[] = [];
@@ -420,7 +420,7 @@ export function NewChatDraft({
     // in-chat composer's "text non-empty or has image" rule).
     if (draft.trim().length === 0 && pendingImages.length === 0) return false;
     // Groups still need an explicit `@` even for image-only sends: the
-    // server's `enforceMention` runs per message regardless of format,
+    // server's explicit-recipient enforcement runs per message regardless of format,
     // and group chats can't rely on the 1:1 auto-inject path.
     if (chips.length >= 2 && bodyMentions.length === 0) return false;
     return true;


### PR DESCRIPTION
Closes #897. Fast-follow to #885.

## Goal
Move the explicit-recipient invariant into the message write path so every send caller inherits it, instead of each entry point remembering `enforceMention: true`. A future send path that forgot the flag would silently reopen the "write to chat history with no recipient" footgun #885 closed.

## Changes (production)
- **`services/message.ts`** — removed the opt-in `enforceMention?`; enforcement is now **on by default**. Added one trusted opt-out `allowRecipientlessSend?`.
- **Loophole closed:** `addressedToAgentIds` counted by array length let `[undefined]` / `[senderId]` / a non-speaker id satisfy the guard while reaching no one. It now counts **only when it resolves to an active, non-sender speaker**.
- **`services/github-delivery.ts`** — declares `allowRecipientlessSend: true`: when the delegate is **not a speaker of the bound chat**, the card writes a silent history/context row instead of throwing. A delegate that *is* a speaker but suspended/deleted is still rejected by the pre-existing addressed-recipient status check (separate guard, not covered by this opt-out).
- **`api/chats.ts` + `api/agent/messages.ts`** — drop `enforceMention: true`; inherit the default.
- `agent-final-text` is the only other self-declared silent form.

## Audit
Every `sendMessage` caller checked; **`enforceMention` is gone repo-wide**.

## Tests
- New: resolution-based guard rejects degenerate addressing; opt-out admits it; github-delivery delivers on a no-live-speaker delegate without throwing and wakes no one.
- `typecheck` + `biome` clean; **158 files / 1317 tests pass**. Rebased onto current `main` (post-#885); **no `broadcast` references remain**.

## Context Tree
agent-team-foundation/first-tree-context#463 — silent send forms are **agent final text** and **trusted system delivery** (no broadcast; #885 removed it).
