### PR TITLE
feat(client): retain skipped source-repo cleanups in managed state for retry

### DIFF
--- a/docs/development/agent-workspace-state.md
+++ b/docs/development/agent-workspace-state.md
@@ -104,7 +104,9 @@ already operate per session:
 - **`prepareSourceRepos`** (`runtime/source-repos.ts`) — after the per-repo
   clone/fetch loop, diff `prev.sourceRepos` against the current set and
   remove any clone no longer in the config. Safety guards apply (see
-  below); state is then rewritten to the current set.
+  below); the new state is `current ∪ (prev items the guards refused to
+  delete)`, so a guard-skipped clone stays tracked and the next session
+  retries.
 - **`installFirstTreeSkills`** (`runtime/first-tree-skills/installer.ts`)
   — same diff against `TREE_SKILL_NAMES`. Dropped skills lose their
   `.agents/skills/<name>/` payload AND their `.claude/skills/<name>`
@@ -127,10 +129,24 @@ Every clone deletion — both state-based and migration-driven — goes through
 6. **Any probe crashed / timed out** → `probe-failed`, skip. Conservative
    default: we'd rather leave a stale clone than nuke unpushed work.
 
-A skipped clone stays on disk and becomes an operator follow-up. The
-state file is still updated to the current set so the next session
-doesn't try the same skipped clone again as part of state-based cleanup
-— the migration path is "best effort, one shot".
+A skipped clone stays on disk **and stays in
+`.first-tree-workspace/managed.json::sourceRepos`** so the next session's
+state-based reconcile re-runs the probes. The conditions that block a
+delete (uncommitted work, commits ahead of upstream, an attached worktree,
+a live chat holding the path, a transient probe / rm failure) are all
+operator-clearable between sessions; once cleared, the follow-up reconcile
+completes the delete. Recurring "skipped — working tree is dirty" log
+lines on persistent blockers are accepted as the cost of self-healing.
+
+Only **final** outcomes — `removed` (we deleted it just now), `absent`
+(already gone), or `not-a-clone` (no `.git/` — never ours to delete) —
+drop the entry from managed state and stop further retries. The
+classification lives in `isFinalRemoveOutcome` next to the
+`RemoveCloneOutcome` definition in `runtime/source-repo-cleanup.ts`.
+
+The migration path (`workspace-migrations.ts`) is unchanged — that one is
+still "best effort, one shot" because it's gated by `migrations-applied.json`
+and re-runs only when the marker is missing.
 
 ## What is NOT touched by this machinery
 

--- a/packages/client/src/__tests__/source-repos-state-reconcile.test.ts
+++ b/packages/client/src/__tests__/source-repos-state-reconcile.test.ts
@@ -139,7 +139,7 @@ describe("prepareSourceRepos — state-based reconcile (PR #869 P1-3)", () => {
     expect(readManagedState(workspace)?.sourceRepos).toEqual(["repo-a"]);
   });
 
-  it("prev=[A,B], current=[A] but B is dirty → B is kept, state still rolls forward to [A]", async () => {
+  it("prev=[A,B], current=[A] but B is dirty → B is kept on disk AND retained in state for retry", async () => {
     plantClone(workspace, "repo-a");
     plantClone(workspace, "repo-b", { dirty: true });
     writeManagedState(workspace, {
@@ -162,12 +162,14 @@ describe("prepareSourceRepos — state-based reconcile (PR #869 P1-3)", () => {
 
     expect(existsSync(join(workspace, "repo-b"))).toBe(true);
     expect(existsSync(join(workspace, "repo-b", "dirty.txt"))).toBe(true);
-    // State rolls forward to current set — the dirty clone becomes an
-    // operator follow-up (see `reconcileSourceRepoState` docstring).
-    expect(readManagedState(workspace)?.sourceRepos).toEqual(["repo-a"]);
+    // Retry semantics: a guard-skipped delete stays in managed state so the
+    // next session re-runs the probes. See `reconcileSourceRepoState`
+    // docstring — the operator clearing the dirty state between sessions
+    // is exactly the recovery path we want to remain open.
+    expect(readManagedState(workspace)?.sourceRepos).toEqual(["repo-a", "repo-b"]);
   });
 
-  it("prev=[A,B], current=[A] but B hosts a dependent worktree → B is kept", async () => {
+  it("prev=[A,B], current=[A] but B hosts a dependent worktree → B is kept on disk AND retained in state", async () => {
     plantClone(workspace, "repo-a");
     plantClone(workspace, "repo-b", { withWorktreeRef: "linked-wt" });
     writeManagedState(workspace, {
@@ -189,6 +191,49 @@ describe("prepareSourceRepos — state-based reconcile (PR #869 P1-3)", () => {
     });
 
     expect(existsSync(join(workspace, "repo-b"))).toBe(true);
+    // Retained for retry — once the operator removes the dependent worktree,
+    // the next reconcile completes the delete.
+    expect(readManagedState(workspace)?.sourceRepos).toEqual(["repo-a", "repo-b"]);
+  });
+
+  it("dirty B retained → next session, after operator cleans B, is finally removed and dropped from state", async () => {
+    plantClone(workspace, "repo-a");
+    const repoB = plantClone(workspace, "repo-b", { dirty: true });
+    writeManagedState(workspace, {
+      schemaVersion: 1,
+      cliVersion: "test",
+      updatedAt: new Date(0).toISOString(),
+      sourceRepos: ["repo-a", "repo-b"],
+      skills: [],
+    });
+
+    // Session 1: B dirty → skip + retain in state.
+    const { manager } = makeManager();
+    await prepareSourceRepos({
+      workspace,
+      payload: payloadFor(["repo-a"]),
+      sessionCtx: makeCtx(),
+      gitMirrorManager: manager,
+      agentName: null,
+      payloadResolved: true,
+    });
+    expect(existsSync(repoB)).toBe(true);
+    expect(readManagedState(workspace)?.sourceRepos).toEqual(["repo-a", "repo-b"]);
+
+    // Operator cleans B between sessions.
+    rmSync(join(repoB, "dirty.txt"));
+
+    // Session 2: B is now clean → removed + dropped from state.
+    await prepareSourceRepos({
+      workspace,
+      payload: payloadFor(["repo-a"]),
+      sessionCtx: makeCtx(),
+      gitMirrorManager: manager,
+      agentName: null,
+      payloadResolved: true,
+    });
+    expect(existsSync(repoB)).toBe(false);
+    expect(readManagedState(workspace)?.sourceRepos).toEqual(["repo-a"]);
   });
 
   it("prev=[A,B], payload=undefined (cache miss) → NOTHING is deleted (PR #869 P0-2 regression)", async () => {
@@ -282,8 +327,8 @@ describe("prepareSourceRepos — state-based reconcile (PR #869 P1-3)", () => {
 
     expect(existsSync(join(workspace, "repo-b"))).toBe(true);
     expect(chatBLogs.some((l) => l.toLowerCase().includes("in use by another live chat"))).toBe(true);
-    // State still rolls forward to chat B's set so the next session diffs
-    // against today's reality — the stale clone becomes operator follow-up.
-    expect(readManagedState(workspace)?.sourceRepos).toEqual(["repo-a"]);
+    // Retained for retry — when chat A teardown releases the live-use lock,
+    // a later session can complete the delete.
+    expect(readManagedState(workspace)?.sourceRepos).toEqual(["repo-a", "repo-b"]);
   });
 });

--- a/packages/client/src/runtime/source-repo-cleanup.ts
+++ b/packages/client/src/runtime/source-repo-cleanup.ts
@@ -31,6 +31,26 @@ export type RemoveCloneOutcome =
   | "remove-failed";
 
 /**
+ * Whether a removal outcome counts as "work complete; drop the entry from
+ * managed state". The state-based reconcile path uses this to decide which
+ * prev-but-no-longer-current entries can be forgotten vs. which must stay
+ * tracked so the next session retries.
+ *
+ * Final outcomes (`removed`, `absent`, `not-a-clone`) all mean further
+ * probing accomplishes nothing — the directory is gone, was already gone,
+ * or is structurally not a clone we manage.
+ *
+ * Every other outcome (`dirty`, `ahead-of-upstream`, `has-worktrees`,
+ * `in-use-by-live-chat`, `probe-failed`, `remove-failed`) reflects a
+ * condition that an operator action (commit / push / close a worktree /
+ * end a live session / fix permissions) can clear, so the next session's
+ * probe might succeed. Those entries stay in managed state for retry.
+ */
+export function isFinalRemoveOutcome(outcome: RemoveCloneOutcome): boolean {
+  return outcome === "removed" || outcome === "absent" || outcome === "not-a-clone";
+}
+
+/**
  * Optional callback the caller can pass to short-circuit deletion when the
  * checkout is still held by a live chat in this process. The state-based
  * cleanup path passes `isSourceRepoPathInUse` from `source-repos.ts`; the

--- a/packages/client/src/runtime/source-repos.ts
+++ b/packages/client/src/runtime/source-repos.ts
@@ -5,7 +5,7 @@ import { resolveGitRepoTargetPath } from "./git-local-path.js";
 import type { GitMirrorManager } from "./git-mirror-manager.js";
 import type { SessionContext } from "./handler.js";
 import { readManagedState, updateManagedState } from "./managed-state.js";
-import { tryRemoveCloneSafely } from "./source-repo-cleanup.js";
+import { isFinalRemoveOutcome, tryRemoveCloneSafely } from "./source-repo-cleanup.js";
 
 export type PrepareSourceReposParams = {
   workspace: string;
@@ -261,25 +261,41 @@ export async function prepareSourceRepos(params: PrepareSourceReposParams): Prom
  * upstream) protect against destroying in-flight work; a guard failure
  * skips the delete and logs a warning instead.
  *
- * State (the `sourceRepos` field of `.agent/managed.json`) is rewritten to
- * the current set whether or not deletes succeeded — so a future config
- * change correctly diffs against today's reality, and a guard-skipped
- * cleanup just becomes a manual operator follow-up rather than a
- * recurring noisy log.
+ * **Retry semantics for skipped deletes.** A clone that the safety guards
+ * refuse to remove (dirty / ahead-of-upstream / has-worktrees /
+ * in-use-by-live-chat / probe-failed / remove-failed) stays in
+ * `.first-tree-workspace/managed.json::sourceRepos` so the NEXT session's
+ * reconcile re-runs the probes. The blocking condition is typically
+ * operator-clearable between sessions (commit / push / close the dependent
+ * worktree / end the live chat / fix permissions); once cleared, the
+ * follow-up reconcile completes the delete.
+ *
+ * Only "final" outcomes — `removed` (we deleted it), `absent` (already
+ * gone), or `not-a-clone` (structurally not ours to delete, ever) — drop
+ * the entry from managed state and stop further retries. Log noise on
+ * recurring skips is accepted as the cost of self-healing; the alternative
+ * (forget about the orphan after one skip) leaves the operator with no
+ * automatic cleanup once the blocker is resolved.
  */
 function reconcileSourceRepoState(workspace: string, currentLocalPaths: string[], sessionCtx: SessionContext): void {
   const currentSet = new Set(currentLocalPaths);
+  const retainedForRetry: string[] = [];
   const prev = readManagedState(workspace);
   if (prev) {
     for (const prevLocalPath of prev.sourceRepos) {
       if (currentSet.has(prevLocalPath)) continue;
       const absPath = join(workspace, prevLocalPath);
-      tryRemoveCloneSafely(absPath, prevLocalPath, sessionCtx.log, isSourceRepoPathInUse);
+      const outcome = tryRemoveCloneSafely(absPath, prevLocalPath, sessionCtx.log, isSourceRepoPathInUse);
+      // Recoverable skip → keep tracking this clone so the next session's
+      // reconcile re-evaluates the safety guards. See the docstring above
+      // for the full classification.
+      if (!isFinalRemoveOutcome(outcome)) retainedForRetry.push(prevLocalPath);
     }
   }
 
+  const nextSourceRepos = new Set([...currentSet, ...retainedForRetry]);
   updateManagedState(workspace, resolveBundledCliVersion(), (current) => ({
     ...current,
-    sourceRepos: [...currentSet].sort(),
+    sourceRepos: [...nextSourceRepos].sort(),
   }));
 }


### PR DESCRIPTION
## Summary

State-based source-repo cleanup in `reconcileSourceRepoState` previously dropped a prev-but-no-longer-current entry from `managed.json::sourceRepos` on the **first** session pass — even when the safety guards (dirty / ahead-of-upstream / has-worktrees / in-use-by-live-chat / probe-failed / remove-failed) refused the delete. Once dropped, no future session ever retried the delete, even after the operator cleared the blocking condition.

The user-reported symptom is exactly that: `first-tree-context` was removed from a workspace's per-agent resources, but the directory had attached `git worktree` checkouts, so the delete was skipped — and the directory then sat as a permanent orphan because the entry was already gone from managed state.

This PR makes the cleanup **self-healing**: skipped entries stay tracked, next session retries.

- **What changes**: in `reconcileSourceRepoState`, the new managed-state `sourceRepos` set is `current ∪ (prev items the guards refused to delete)` instead of just `current`. The next session's reconcile re-runs `tryRemoveCloneSafely` against retained entries; once the blocker is cleared, the delete completes and the entry drops.
- **What stays**: final outcomes (`removed` / `absent` / `not-a-clone`) still drop the entry — nothing to retry against. Captured in the new `isFinalRemoveOutcome` helper next to `RemoveCloneOutcome` in `runtime/source-repo-cleanup.ts`.
- **What's NOT touched**: `workspace-migrations.ts` keeps its "best effort, one shot" contract (gated by `migrations-applied.json`); the skill-reconcile path (`installFirstTreeSkills`) also unchanged — it has no operator-clearable guards, only transient rm failures. If we want skills to retry too, that's a follow-up.

Accepted trade-off: a persistent blocker (e.g. uncommitted work the operator never cleans) produces recurring "skipped — working tree is dirty" log lines every session. The previous design swallowed the log noise at the cost of zero auto-recovery; we're flipping that.

## Test plan

- [x] `pnpm exec vitest run packages/client/src/__tests__/source-repos-state-reconcile.test.ts` — 7/7 pass
  - 2 existing tests updated: dirty-skip and live-use-skip now assert state retention instead of "rolls forward"
  - 1 new test: full retry cycle — session 1 skips dirty repo, operator cleans it, session 2 completes the delete
- [x] `pnpm typecheck` — 11/11 packages clean
- [x] `pnpm check` (biome) — no new findings (the one pre-existing `Migration` `void`→`undefined` info is on unrelated code)
- [x] Doc updated: `docs/development/agent-workspace-state.md` reconcile-flow + safety-guards sections now describe retry semantics + the `isFinalRemoveOutcome` boundary

## Related context

Originated from a workspace state where `first-tree-context` couldn't be auto-removed because it had attached worktrees. After this PR, the same situation self-heals: operator removes the worktrees → next session's reconcile completes the delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)