### PR TITLE
chore(client): nits + tests for source-repo cleanup retry classification

### DIFF
--- a/packages/client/src/__tests__/source-repo-cleanup.test.ts
+++ b/packages/client/src/__tests__/source-repo-cleanup.test.ts
@@ -11,8 +11,9 @@ import { isFinalRemoveOutcome, type RemoveCloneOutcome } from "../runtime/source
  * inline so a new union member added in source without a matching entry
  * here trips a TypeScript error at the `satisfies` line — the test then
  * fails to compile, forcing the author to decide whether the new outcome
- * is final or retry-eligible. This is the "防御未来给 union 加成员忘了
- * 分类" anchor (PR #913 code-reviewer follow-up nit 3).
+ * is final or retry-eligible. This is the anchor against "added a new
+ * outcome and forgot to classify it" (PR #913 code-reviewer follow-up
+ * nit 3).
  */
 const OUTCOME_EXPECTATIONS = {
   removed: true,

--- a/packages/client/src/__tests__/source-repo-cleanup.test.ts
+++ b/packages/client/src/__tests__/source-repo-cleanup.test.ts
@@ -1,0 +1,47 @@
+// Unit tests for helpers in `runtime/source-repo-cleanup.ts`. The companion
+// integration tests for the state-based reconcile loop live in
+// `source-repos-state-reconcile.test.ts`; this file pins the smaller
+// classification helpers that drive that loop's branches.
+
+import { describe, expect, it } from "vitest";
+import { isFinalRemoveOutcome, type RemoveCloneOutcome } from "../runtime/source-repo-cleanup.js";
+
+/**
+ * Exhaustive snapshot of every variant in `RemoveCloneOutcome`. Listed
+ * inline so a new union member added in source without a matching entry
+ * here trips a TypeScript error at the `satisfies` line — the test then
+ * fails to compile, forcing the author to decide whether the new outcome
+ * is final or retry-eligible. This is the "防御未来给 union 加成员忘了
+ * 分类" anchor (PR #913 code-reviewer follow-up nit 3).
+ */
+const OUTCOME_EXPECTATIONS = {
+  removed: true,
+  absent: true,
+  "not-a-clone": true,
+  "in-use-by-live-chat": false,
+  dirty: false,
+  "ahead-of-upstream": false,
+  "has-worktrees": false,
+  "probe-failed": false,
+  "remove-failed": false,
+} as const satisfies Record<RemoveCloneOutcome, boolean>;
+
+describe("isFinalRemoveOutcome — full RemoveCloneOutcome enumeration", () => {
+  for (const [outcome, expected] of Object.entries(OUTCOME_EXPECTATIONS) as ReadonlyArray<
+    [RemoveCloneOutcome, boolean]
+  >) {
+    it(`${outcome} → ${expected ? "final (drop from managed state)" : "retry-eligible (keep in managed state)"}`, () => {
+      expect(isFinalRemoveOutcome(outcome)).toBe(expected);
+    });
+  }
+
+  it("exactly 3 outcomes are final", () => {
+    const finalCount = Object.values(OUTCOME_EXPECTATIONS).filter(Boolean).length;
+    expect(finalCount).toBe(3);
+  });
+
+  it("exactly 6 outcomes are retry-eligible", () => {
+    const retryCount = Object.values(OUTCOME_EXPECTATIONS).filter((v) => !v).length;
+    expect(retryCount).toBe(6);
+  });
+});

--- a/packages/client/src/__tests__/source-repos-state-reconcile.test.ts
+++ b/packages/client/src/__tests__/source-repos-state-reconcile.test.ts
@@ -15,7 +15,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GitMirrorManager, SourceRepoOutcome } from "../runtime/git-mirror-manager.js";
 import type { SessionContext } from "../runtime/handler.js";
 import { readManagedState, writeManagedState } from "../runtime/managed-state.js";
-import { prepareSourceRepos } from "../runtime/source-repos.js";
+import { prepareSourceRepos, releaseSourceReposForSession } from "../runtime/source-repos.js";
 
 type EnsureArgs = Parameters<GitMirrorManager["ensureSourceRepo"]>[0];
 
@@ -330,5 +330,61 @@ describe("prepareSourceRepos — state-based reconcile (PR #869 P1-3)", () => {
     // Retained for retry — when chat A teardown releases the live-use lock,
     // a later session can complete the delete.
     expect(readManagedState(workspace)?.sourceRepos).toEqual(["repo-a", "repo-b"]);
+  });
+
+  it("in-use B retained → after chat A teardown, next reconcile completes the delete and drops state", async () => {
+    plantClone(workspace, "repo-a");
+    plantClone(workspace, "repo-b");
+    writeManagedState(workspace, {
+      schemaVersion: 1,
+      cliVersion: "test",
+      updatedAt: new Date(0).toISOString(),
+      sourceRepos: ["repo-a", "repo-b"],
+      skills: [],
+    });
+
+    // Session 1: chat A acquires both repos under the old (broader) config.
+    const { manager } = makeManager();
+    const chatA = makeCtx();
+    await prepareSourceRepos({
+      workspace,
+      payload: payloadFor(["repo-a", "repo-b"]),
+      sessionCtx: chatA,
+      gitMirrorManager: manager,
+      agentName: null,
+      payloadResolved: true,
+    });
+
+    // Session 2: chat B reconciles against the new config (drops repo-b),
+    // hits the live-use guard, retains repo-b in state.
+    await prepareSourceRepos({
+      workspace,
+      payload: payloadFor(["repo-a"]),
+      sessionCtx: makeCtx(),
+      gitMirrorManager: manager,
+      agentName: null,
+      payloadResolved: true,
+    });
+    expect(existsSync(join(workspace, "repo-b"))).toBe(true);
+    expect(readManagedState(workspace)?.sourceRepos).toEqual(["repo-a", "repo-b"]);
+
+    // Chat A tears down between sessions, releasing the live-use lock on
+    // both checkout paths.
+    releaseSourceReposForSession(chatA);
+
+    // Session 3: chat C reconciles with the same reduced config. The
+    // live-use guard now passes (no chat holds repo-b), the other safety
+    // probes pass (clean, no worktrees, 0 ahead), and the delete completes.
+    // The entry then drops from managed state.
+    await prepareSourceRepos({
+      workspace,
+      payload: payloadFor(["repo-a"]),
+      sessionCtx: makeCtx(),
+      gitMirrorManager: manager,
+      agentName: null,
+      payloadResolved: true,
+    });
+    expect(existsSync(join(workspace, "repo-b"))).toBe(false);
+    expect(readManagedState(workspace)?.sourceRepos).toEqual(["repo-a"]);
   });
 });

--- a/packages/client/src/runtime/source-repo-cleanup.ts
+++ b/packages/client/src/runtime/source-repo-cleanup.ts
@@ -36,15 +36,32 @@ export type RemoveCloneOutcome =
  * prev-but-no-longer-current entries can be forgotten vs. which must stay
  * tracked so the next session retries.
  *
- * Final outcomes (`removed`, `absent`, `not-a-clone`) all mean further
+ * **Final outcomes** (`removed`, `absent`, `not-a-clone`) all mean further
  * probing accomplishes nothing — the directory is gone, was already gone,
  * or is structurally not a clone we manage.
  *
- * Every other outcome (`dirty`, `ahead-of-upstream`, `has-worktrees`,
- * `in-use-by-live-chat`, `probe-failed`, `remove-failed`) reflects a
- * condition that an operator action (commit / push / close a worktree /
- * end a live session / fix permissions) can clear, so the next session's
- * probe might succeed. Those entries stay in managed state for retry.
+ * `not-a-clone` is the conservative-but-asymmetric one: we accept that a
+ * clone whose `.git/` was manually removed by the user or an external
+ * process becomes invisible to bookkeeping. Treating it as retry-eligible
+ * would re-probe forever without recovery (`.git/` rarely comes back), so
+ * dropping the entry and leaving the directory on disk as an operator
+ * follow-up is the better trade.
+ *
+ * **Retry-eligible outcomes** (`dirty`, `ahead-of-upstream`, `has-worktrees`,
+ * `in-use-by-live-chat`, `probe-failed`, `remove-failed`) each reflect a
+ * condition that some clearable action can resolve, so the next session's
+ * probe might succeed. Typical recoveries:
+ *
+ * - `dirty` / `ahead-of-upstream` → operator commits / pushes / discards
+ * - `has-worktrees` → operator `git worktree remove`s the dependent checkouts
+ * - `in-use-by-live-chat` → the other live chat ends, releasing the path
+ * - `probe-failed` → transient git crash / timeout clears on retry
+ * - `remove-failed` → underlying filesystem condition clears (permissions,
+ *   `EBUSY` from an open file handle, a read-only mount, `ENOSPC` on the
+ *   directory containing the trash buffer, etc.)
+ *
+ * Entries with retry-eligible outcomes stay in managed state until a future
+ * session reaches a final outcome.
  */
 export function isFinalRemoveOutcome(outcome: RemoveCloneOutcome): boolean {
   return outcome === "removed" || outcome === "absent" || outcome === "not-a-clone";


### PR DESCRIPTION
## Summary

Follow-up to #913 — addresses the non-blocking nits surfaced during post-merge review (code-reviewer + codex-assistant). No behavior change; tightens the docstring and adds defensive test coverage.

### Docstring updates — `isFinalRemoveOutcome`

- Spells out the conservative-but-asymmetric handling of `not-a-clone`. Treating a manually-broken clone (user/external process removed `.git/`) as retry-eligible would re-probe forever without recovery, so dropping the entry and leaving the directory as an operator follow-up is the better trade. Made explicit in the jsdoc.
- Tightens the recovery-path list per retry-eligible outcome. `remove-failed` in particular now lists `EBUSY` (open file handle), read-only mount, and `ENOSPC` on the trash-buffer directory alongside permissions — not just the latter.

### Tests

**New: `source-repo-cleanup.test.ts`** — exhaustive enumeration of all 9 `RemoveCloneOutcome` variants against `isFinalRemoveOutcome`. Expectations live in a `Record<RemoveCloneOutcome, boolean>` with a `satisfies` constraint, so a new union member added in source without a matching entry trips a TypeScript error at compile time. Forces the next author to classify deliberately.

**Extended: `source-repos-state-reconcile.test.ts`** — adds a third full retry cycle, this time for `in-use-by-live-chat`:

1. Chat A acquires both repos under the broader config.
2. Chat B's reconcile (narrower config) skips repo-b due to live-use guard, retains it in state.
3. Chat A teardown via `releaseSourceReposForSession` clears the lock.
4. Chat C's reconcile completes the delete and drops state.

Pairs with the existing dirty-cycle test to anchor a second blocker category — different from `dirty` since `in-use` is process-internal release, not operator action.

### Related

- Tracks the structural-symmetry follow-up for `installFirstTreeSkills` separately in #914 — same first-skip-forever-orphan shape on the skill-side path, but lower blast radius and no outcome type yet.

## Test plan

- [x] `pnpm exec vitest run packages/client/src/__tests__/source-repo-cleanup.test.ts packages/client/src/__tests__/source-repos-state-reconcile.test.ts` — 19/19 pass (11 new enumeration + 8 integration including the new in-use cycle)
- [x] `pnpm typecheck` — 11/11 packages clean (includes the `satisfies` constraint compile-time check)
- [x] `pnpm check` (biome) — no new findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)