### PR TITLE
refactor(web): unify agent-detail rows + selection state, widen Usage rail

### DIFF
--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -476,11 +476,18 @@
   --sp-70: 17.5rem; /* 280px */
   --sp-75: 18.75rem; /* 300px */
 
-  /* Agent detail content rail — one uniform readable width across every tab
-     (header, tabs, and content all share it), centered like the context / team
-     / settings pages. */
+  /* Agent detail content rail — the readable width for text/config tabs
+     (Profile / Environment / Instructions / Tools & skills). Header, tabs, and
+     content share it, centered like the context / team / settings pages. */
   --agent-detail-rail: 52rem;
+  /* Wider rail for the data-dense Usage tab (activity calendar + multi-column
+     token table), which needs more horizontal room than prose/config surfaces.
+     The whole page column (header + tabs + content) widens together on Usage so
+     it stays a single coherent column rather than content overflowing its tabs. */
+  --agent-detail-rail-wide: 64rem;
   --agent-detail-error-rail: 30rem;
+  /* Shared label column for ConfigRow / IdentityField / DangerActionRow grids. */
+  --agent-detail-label-col: 8.25rem;
 
   /* Default color-scheme so native form controls, scrollbars, and the
      canvas match the light theme (.dark flips this to dark below). */

--- a/packages/web/src/pages/agent-detail.tsx
+++ b/packages/web/src/pages/agent-detail.tsx
@@ -336,6 +336,11 @@ function AgentDetailPageView() {
     () => tabs.find((t) => t.key === currentTabKey)?.path ?? "profile",
     [tabs, currentTabKey],
   );
+  // The Usage tab is data-dense (activity calendar + multi-column token table)
+  // and needs a wider rail than the prose/config tabs. The whole page column
+  // (header + tabs + content) shares this value so it stays one coherent column
+  // instead of content overflowing its own tab bar.
+  const railVar = currentTabKey === "usage" ? "var(--agent-detail-rail-wide)" : "var(--agent-detail-rail)";
 
   if (agentQuery.isLoading) {
     return (
@@ -486,7 +491,7 @@ function AgentDetailPageView() {
             so the switcher and title row align with everything below. */}
         <div
           style={{
-            maxWidth: "var(--agent-detail-rail)",
+            maxWidth: railVar,
             marginLeft: "auto",
             marginRight: "auto",
             paddingLeft: "var(--sp-5)",
@@ -559,7 +564,14 @@ function AgentDetailPageView() {
         />
       )}
 
-      <TabsNav tabs={tabs} agentUuid={uuid} currentTabKey={currentTabKey} dirtyTabs={dirtyTabs} badges={tabBadges} />
+      <TabsNav
+        tabs={tabs}
+        agentUuid={uuid}
+        currentTabKey={currentTabKey}
+        dirtyTabs={dirtyTabs}
+        badges={tabBadges}
+        railVar={railVar}
+      />
 
       <div
         className="w-full flex-1"
@@ -569,9 +581,10 @@ function AgentDetailPageView() {
           flexDirection: "column",
           gap: "var(--sp-5)",
           width: "100%",
-          // One uniform rail across every tab (no per-tab 52↔70 jump), centered
-          // to match the context / team / settings pages.
-          maxWidth: "var(--agent-detail-rail)",
+          // Rail width tracks the active tab: the standard readable rail for
+          // prose/config tabs, a wider one for the data-dense Usage tab. The
+          // header + tab bar above share the same value (see railVar).
+          maxWidth: railVar,
           marginLeft: "auto",
           marginRight: "auto",
         }}
@@ -711,12 +724,15 @@ function TabsNav({
   currentTabKey,
   dirtyTabs,
   badges,
+  railVar,
 }: {
   tabs: TabDef[];
   agentUuid: string;
   currentTabKey: string;
   dirtyTabs: ReadonlySet<string>;
   badges: Record<string, number>;
+  /** Rail width for the active tab — kept in sync with the header + content. */
+  railVar: string;
 }) {
   const navigate = useNavigate();
   const scrollRef = useRef<HTMLDivElement | null>(null);
@@ -794,9 +810,9 @@ function TabsNav({
         <div
           className="flex items-end"
           style={{
-            gap: 2,
+            gap: "var(--sp-0_5)",
             width: "100%",
-            maxWidth: "var(--agent-detail-rail)",
+            maxWidth: railVar,
             marginLeft: "auto",
             marginRight: "auto",
             paddingLeft: "var(--sp-5)",

--- a/packages/web/src/pages/agent-detail/agent-switcher-strip.tsx
+++ b/packages/web/src/pages/agent-detail/agent-switcher-strip.tsx
@@ -105,7 +105,7 @@ export function AgentSwitcherStrip({
             style={{
               width: 36,
               height: 36,
-              borderRadius: "50%",
+              borderRadius: "var(--radius-full)",
               border: "var(--hairline) solid var(--border)",
               background: "var(--bg-raised)",
               color: "var(--fg-3)",
@@ -133,24 +133,25 @@ export function AgentSwitcherStrip({
                   : () => onNavigate(`/agents/${a.uuid}/${resolveTabPath(a, memberId, role, currentTabPath)}`)
               }
             >
+              {/* Selection is signalled by the label underline + weight below
+                  (tab-style), not a heavy/colored ring around the avatar — so the
+                  avatar size is constant (no select-time shrink/jump) and follows
+                  the OptionCard rule of never using a heavier border for selection. */}
               <span className="relative inline-flex shrink-0" style={{ width: 36, height: 36 }}>
                 <span
                   className="inline-flex items-center justify-center"
                   style={{
                     width: 36,
                     height: 36,
-                    borderRadius: "50%",
-                    padding: selected ? 2 : 0,
-                    border: selected
-                      ? "var(--hairline-bold) solid var(--primary)"
-                      : "var(--hairline) solid transparent",
+                    borderRadius: "var(--radius-full)",
+                    border: "var(--hairline) solid transparent",
                     background: selected ? "var(--bg-active)" : "transparent",
                   }}
                 >
                   <Avatar
                     src={a.avatarImageUrl}
                     name={a.displayName}
-                    size={selected ? 30 : 34}
+                    size={34}
                     colorToken={a.avatarColorToken}
                     seed={a.uuid}
                   />
@@ -205,8 +206,14 @@ function StripButton({
     >
       {children}
       <span
-        className="text-caption w-full truncate text-center"
-        style={{ color: ariaCurrent ? "var(--fg)" : "var(--fg-3)" }}
+        className="text-caption max-w-full truncate text-center"
+        style={{
+          color: ariaCurrent ? "var(--fg)" : "var(--fg-3)",
+          paddingBottom: "var(--sp-0_5)",
+          borderBottom: ariaCurrent
+            ? "var(--hairline-bold) solid var(--primary)"
+            : "var(--hairline-bold) solid transparent",
+        }}
       >
         {label}
       </span>

--- a/packages/web/src/pages/agent-detail/appearance-section.tsx
+++ b/packages/web/src/pages/agent-detail/appearance-section.tsx
@@ -31,7 +31,7 @@ export function AvatarPreview({ agent, size }: { agent: Agent; size: number }) {
         alt={agent.displayName}
         width={size}
         height={size}
-        style={{ width: size, height: size, borderRadius: "50%", objectFit: "cover", display: "block" }}
+        style={{ width: size, height: size, borderRadius: "var(--radius-full)", objectFit: "cover", display: "block" }}
       />
     );
   }
@@ -47,7 +47,7 @@ export function AvatarPreview({ agent, size }: { agent: Agent; size: number }) {
         justifyContent: "center",
         width: size,
         height: size,
-        borderRadius: "50%",
+        borderRadius: "var(--radius-full)",
         background: resolveAvatarHue(agent.avatarColorToken, agent.uuid),
         color: "var(--fg-on-vivid)",
         fontSize: initialFontSize,
@@ -78,8 +78,8 @@ export function AppearanceSection({ agent, canEdit = true, onEdit, variant = "se
       aria-label="Edit avatar"
       title="Edit avatar"
       onClick={onEdit}
-      className="relative inline-flex shrink-0 cursor-pointer items-center justify-center border-0 bg-transparent p-0"
-      style={{ width: 56, height: 56, borderRadius: "50%" }}
+      className="relative inline-flex shrink-0 cursor-pointer items-center justify-center border-0 bg-transparent p-0 rounded-[var(--radius-full)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1"
+      style={{ width: 56, height: 56 }}
     >
       <AvatarPreview agent={agent} size={56} />
       <span
@@ -90,7 +90,7 @@ export function AppearanceSection({ agent, canEdit = true, onEdit, variant = "se
           bottom: -2,
           width: 20,
           height: 20,
-          borderRadius: "50%",
+          borderRadius: "var(--radius-full)",
           background: "var(--bg-raised)",
           border: "var(--hairline) solid var(--border)",
           color: "var(--fg-2)",

--- a/packages/web/src/pages/agent-detail/capability-section.tsx
+++ b/packages/web/src/pages/agent-detail/capability-section.tsx
@@ -9,7 +9,7 @@ import {
   skillResourcePayloadSchema,
 } from "@first-tree/shared";
 import { type QueryClient, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Plus, Trash2 } from "lucide-react";
+import { Plus } from "lucide-react";
 import { type FormEvent, type ReactNode, useState } from "react";
 import { useNavigate } from "react-router";
 import { getAgentResources, updateAgentResources } from "../../api/agent-resources.js";
@@ -20,8 +20,8 @@ import { Input } from "../../components/ui/input.js";
 import { Label } from "../../components/ui/label.js";
 import { Popover } from "../../components/ui/popover.js";
 import { Section } from "../../components/ui/section.js";
-import { StatusGlyph } from "../../components/ui/status-glyph.js";
 import { typeLabelSingular } from "../settings/resource-editors.js";
+import { ResourceRowView, RowAction } from "./resource-row.js";
 import { sourceLabel } from "./resource-source.js";
 import { titleWithSemantics, useJustSaved } from "./save-semantics.js";
 
@@ -163,7 +163,7 @@ export function ResourceTypeSection(props: {
       <div>
         {rows.length === 0 ? (
           <p className="text-body" style={{ color: "var(--fg-4)", padding: "var(--sp-3) 0", margin: 0 }}>
-            No {emptyNoun(type)} enabled.
+            No {emptyNoun(type)} yet.
           </p>
         ) : (
           rows.map((row) => (
@@ -330,54 +330,38 @@ function EffectiveRow(props: {
   const source = sourceLabel(props.row.source);
   const canRemove = props.row.bindingId && props.bindings.some((b) => b.id === props.row.bindingId);
   const canDisable = props.row.resourceId && props.row.source === "team_recommended" && props.row.mode === "enabled";
-  return (
-    <div
-      className="flex items-center gap-3"
-      style={{ padding: "var(--sp-3) 0", borderBottom: "var(--hairline) solid var(--border-faint)" }}
-    >
-      <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-2">
-          <p className="m-0 text-body font-medium truncate" style={{ color: "var(--fg)" }}>
-            {props.row.name}
-          </p>
-          {status ? (
-            <span className="mono inline-flex items-center gap-1.5 text-caption" style={{ color: status.color }}>
-              <StatusGlyph colorVar={status.color} shape="dot" size={7} ariaLabel={status.label} />
-              {status.label}
-            </span>
-          ) : null}
-          <span className="text-caption" style={{ color: "var(--fg-4)" }}>
-            {source}
-          </span>
-        </div>
-        {subtitle ? (
-          <p className="m-0 text-caption truncate mono" style={{ color: "var(--fg-3)", marginTop: "var(--sp-0_5)" }}>
-            {subtitle}
-          </p>
+  // Mono only for technical detail (repo URL, MCP command). A skill description
+  // and an "unavailable" failure reason are prose and stay in the sans body.
+  const monoPeek = props.row.mode !== "unavailable" && (props.row.type === "repo" || props.row.type === "mcp");
+  const actions =
+    props.canEdit && (canDisable || canRemove) ? (
+      <>
+        {canDisable ? (
+          <RowAction
+            label="Disable"
+            disabled={props.pending}
+            onClick={() => props.onDisable(props.row.resourceId ?? "")}
+          />
         ) : null}
-      </div>
-      {props.canEdit && canDisable ? (
-        <Button
-          size="xs"
-          variant="ghost"
-          disabled={props.pending}
-          onClick={() => props.onDisable(props.row.resourceId ?? "")}
-        >
-          Disable
-        </Button>
-      ) : null}
-      {props.canEdit && canRemove ? (
-        <Button
-          size="xs"
-          variant="ghost"
-          disabled={props.pending}
-          aria-label={`Remove ${props.row.name}`}
-          onClick={() => props.onRemoveBinding(props.row.bindingId ?? "")}
-        >
-          <Trash2 className="h-4 w-4" />
-        </Button>
-      ) : null}
-    </div>
+        {canRemove ? (
+          <RowAction
+            icon="remove"
+            label={`Remove ${props.row.name}`}
+            disabled={props.pending}
+            onClick={() => props.onRemoveBinding(props.row.bindingId ?? "")}
+          />
+        ) : null}
+      </>
+    ) : null;
+  return (
+    <ResourceRowView
+      name={props.row.name}
+      source={source}
+      status={status}
+      peek={subtitle}
+      monoPeek={monoPeek}
+      actions={actions}
+    />
   );
 }
 

--- a/packages/web/src/pages/agent-detail/danger-zone.tsx
+++ b/packages/web/src/pages/agent-detail/danger-zone.tsx
@@ -134,7 +134,7 @@ export function DangerZone(props: DangerZoneProps) {
 function DangerActionRow({ label, description, action }: { label: string; description: ReactNode; action: ReactNode }) {
   return (
     <div
-      className="grid grid-cols-1 gap-2 text-body md:grid-cols-[8.25rem_minmax(0,1fr)_auto] md:items-center md:gap-4"
+      className="grid grid-cols-1 gap-2 text-body md:grid-cols-[var(--agent-detail-label-col)_minmax(0,1fr)_auto] md:items-center md:gap-4"
       style={{
         padding: "var(--sp-3) 0",
         borderBottom: "var(--hairline) solid var(--border-faint)",

--- a/packages/web/src/pages/agent-detail/env-section.tsx
+++ b/packages/web/src/pages/agent-detail/env-section.tsx
@@ -96,7 +96,7 @@ export function EnvSection(props: EnvSectionProps) {
                   <button
                     type="button"
                     onClick={() => canReveal && toggleReveal(item.key)}
-                    className="bg-transparent border-0 cursor-pointer inline-flex items-center text-muted-foreground"
+                    className="bg-transparent border-0 p-0 cursor-pointer inline-flex items-center text-muted-foreground rounded-[var(--radius-chip)] disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1"
                     title={
                       canReveal
                         ? isRevealed
@@ -106,7 +106,6 @@ export function EnvSection(props: EnvSectionProps) {
                     }
                     aria-label={isRevealed ? "Hide value" : "Reveal value"}
                     disabled={!canReveal}
-                    style={{ padding: 0, opacity: canReveal ? 1 : 0.4 }}
                   >
                     {isRevealed ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
                   </button>

--- a/packages/web/src/pages/agent-detail/flat-section.tsx
+++ b/packages/web/src/pages/agent-detail/flat-section.tsx
@@ -37,7 +37,7 @@ export function ConfigRow({
 }: ConfigRowProps) {
   return (
     <div
-      className="grid grid-cols-1 gap-2 text-body md:grid-cols-[8.25rem_minmax(0,1fr)_auto_auto] md:items-start md:gap-4"
+      className="grid grid-cols-1 gap-2 text-body md:grid-cols-[var(--agent-detail-label-col)_minmax(0,1fr)_auto_auto] md:items-start md:gap-4"
       style={{
         padding: "var(--sp-2_5) 0",
         borderBottom: "var(--hairline) solid var(--border-faint)",

--- a/packages/web/src/pages/agent-detail/identity-section.tsx
+++ b/packages/web/src/pages/agent-detail/identity-section.tsx
@@ -136,7 +136,7 @@ function VisibilityBadge({ visibility }: { visibility: Agent["visibility"] }) {
 function IdentityField({ label, children }: { label: string; children: ReactNode }) {
   return (
     <div
-      className="grid min-w-0 grid-cols-1 items-baseline gap-1 sm:grid-cols-[8.25rem_minmax(0,1fr)] sm:gap-4"
+      className="grid min-w-0 grid-cols-1 items-baseline gap-1 sm:grid-cols-[var(--agent-detail-label-col)_minmax(0,1fr)] sm:gap-4"
       style={{ padding: "var(--sp-2) 0", borderBottom: "var(--hairline) solid var(--border-faint)" }}
     >
       <div className="text-body truncate" style={{ color: "var(--fg-3)" }}>

--- a/packages/web/src/pages/agent-detail/profile-edit-dialog.tsx
+++ b/packages/web/src/pages/agent-detail/profile-edit-dialog.tsx
@@ -6,6 +6,7 @@ import {
   type UpdateAgent,
 } from "@first-tree/shared";
 import { useQuery } from "@tanstack/react-query";
+import { Check } from "lucide-react";
 import { type ChangeEvent, type FormEvent, useEffect, useMemo, useRef, useState } from "react";
 import { deleteAgentAvatar, listAgents, uploadAgentAvatar } from "../../api/agents.js";
 import { useAuth } from "../../auth/auth-context.js";
@@ -373,47 +374,51 @@ function Swatch({
   background: string;
   isAuto?: boolean;
 }) {
-  const size = 32;
+  // Selection follows the OptionCard rule: the border stays the same faint
+  // hairline in both states; selection is signalled by a filled neutral marker,
+  // never a heavier/darker border. The marker is a small check BADGE in the
+  // corner (not a centered glyph) so the "Auto" swatch keeps its centered "A"
+  // identity even when it's the selected colour.
   return (
     <button
       type="button"
       onClick={onClick}
       aria-pressed={selected}
       title={label}
+      className="relative inline-flex items-center justify-center focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1"
       style={{
-        position: "relative",
-        width: size,
-        height: size,
-        borderRadius: "50%",
+        width: "var(--sp-8)",
+        height: "var(--sp-8)",
+        borderRadius: "var(--radius-full)",
         background,
-        border: selected ? "var(--hairline-bold) solid var(--fg)" : "var(--hairline) solid var(--border)",
+        border: "var(--hairline) solid var(--border)",
         cursor: "pointer",
         padding: 0,
-        outline: "none",
-        display: "inline-flex",
-        alignItems: "center",
-        justifyContent: "center",
       }}
     >
-      {isAuto && (
-        <span
-          aria-hidden
-          style={{
-            position: "absolute",
-            inset: 4,
-            borderRadius: "50%",
-            background: "var(--bg-raised)",
-            color: "var(--fg-3)",
-            fontSize: 10,
-            fontWeight: 600,
-            display: "inline-flex",
-            alignItems: "center",
-            justifyContent: "center",
-          }}
-        >
+      {isAuto ? (
+        <span aria-hidden className="text-eyebrow" style={{ color: "var(--fg-on-vivid)" }}>
           A
         </span>
-      )}
+      ) : null}
+      {selected ? (
+        <span
+          aria-hidden
+          className="absolute inline-flex items-center justify-center"
+          style={{
+            right: -2,
+            bottom: -2,
+            width: "var(--sp-3_5)",
+            height: "var(--sp-3_5)",
+            borderRadius: "var(--radius-full)",
+            background: "var(--fg)",
+            color: "var(--bg-raised)",
+            border: "var(--hairline) solid var(--bg-raised)",
+          }}
+        >
+          <Check className="h-2.5 w-2.5" strokeWidth={3} />
+        </span>
+      ) : null}
     </button>
   );
 }

--- a/packages/web/src/pages/agent-detail/prompt-tab.tsx
+++ b/packages/web/src/pages/agent-detail/prompt-tab.tsx
@@ -4,7 +4,7 @@ import {
   PROMPT_APPEND_MAX_LENGTH,
 } from "@first-tree/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ChevronDown, ChevronUp, Eye, Pencil, Plus, Trash2 } from "lucide-react";
+import { Eye, Plus } from "lucide-react";
 import { type FormEvent, type ReactNode, useEffect, useRef, useState } from "react";
 import { Navigate } from "react-router";
 import { getAgentResources, updateAgentResources } from "../../api/agent-resources.js";
@@ -20,10 +20,10 @@ import {
 import { Markdown } from "../../components/ui/markdown.js";
 import { Popover } from "../../components/ui/popover.js";
 import { Section } from "../../components/ui/section.js";
-import { StatusGlyph } from "../../components/ui/status-glyph.js";
 import { Textarea } from "../../components/ui/textarea.js";
 import { agentResourcesMutationHandlers, statusMarker } from "./capability-section.js";
 import { useAgentDetailContext } from "./layout-context.js";
+import { ResourceRowView, RowAction, type RowStatusMarker } from "./resource-row.js";
 import { sourceLabel } from "./resource-source.js";
 import { titleWithSemantics, useJustSaved } from "./save-semantics.js";
 
@@ -387,7 +387,9 @@ function PromptResourceBlocks(props: {
     return (
       <PromptResourceBlock
         key={row.id}
-        title={<PromptBlockHeading name={promptBlockName(row)} source={row.source} marker={statusMarker(row.mode)} />}
+        name={promptBlockName(row)}
+        source={row.source}
+        marker={statusMarker(row.mode)}
         action={action}
         body={row.promptBody ?? ""}
         expanded={expandedIds.has(row.id)}
@@ -401,7 +403,8 @@ function PromptResourceBlocks(props: {
     blocks.push(
       <PromptResourceBlock
         key="agent-custom-editor"
-        title={<PromptBlockHeading name={null} source="inline_prompt" />}
+        name={null}
+        source="inline_prompt"
         body=""
         expanded
         onToggle={() => {}}
@@ -419,7 +422,7 @@ function PromptResourceBlocks(props: {
       !!row.bindingId &&
       (row.mode === "disabled" || !enabledBindingIds.has(row.bindingId));
     const action = manageable ? (
-      <PromptBlockAction
+      <RowAction
         label={row.mode === "disabled" ? "Re-enable" : "Remove"}
         icon={row.mode === "disabled" ? undefined : "remove"}
         disabled={props.busy}
@@ -429,7 +432,9 @@ function PromptResourceBlocks(props: {
     blocks.push(
       <PromptResourceBlock
         key={row.id}
-        title={<PromptBlockHeading name={promptBlockName(row)} source={row.source} marker={statusMarker(row.mode)} />}
+        name={promptBlockName(row)}
+        source={row.source}
+        marker={statusMarker(row.mode)}
         action={action}
         body={row.promptBody ?? ""}
         expanded={expandedIds.has(row.id)}
@@ -446,16 +451,13 @@ function PromptResourceBlocks(props: {
     blocks.push(
       <PromptResourceBlock
         key={orphanId}
-        title={<PromptBlockHeading name={null} source="inline_prompt" />}
+        name={null}
+        source="inline_prompt"
         action={
           props.editor || !props.canEdit ? null : (
             <div className="flex gap-2">
-              <PromptBlockAction
-                icon="edit"
-                label="Edit custom instructions"
-                onClick={() => props.onEditBinding(bindingId)}
-              />
-              <PromptBlockAction
+              <RowAction icon="edit" label="Edit custom instructions" onClick={() => props.onEditBinding(bindingId)} />
+              <RowAction
                 label="Remove"
                 icon="remove"
                 disabled={props.busy}
@@ -494,7 +496,7 @@ function promptRowAction(
 ): ReactNode {
   const buttons: ReactNode[] = [];
   const remove = (
-    <PromptBlockAction
+    <RowAction
       key="remove"
       label="Remove"
       icon="remove"
@@ -504,26 +506,16 @@ function promptRowAction(
   );
   if (row.source === "inline_prompt") {
     buttons.push(
-      <PromptBlockAction
-        key="edit"
-        icon="edit"
-        label="Edit custom instructions"
-        onClick={() => props.onStartEdit(row)}
-      />,
+      <RowAction key="edit" icon="edit" label="Edit custom instructions" onClick={() => props.onStartEdit(row)} />,
     );
     if (row.bindingId) buttons.push(remove);
   } else if (row.source.startsWith("team_") && row.resourceId) {
     buttons.push(
-      <PromptBlockAction
-        key="customize"
-        icon="edit"
-        label="Customize for this agent"
-        onClick={() => props.onStartEdit(row)}
-      />,
+      <RowAction key="customize" icon="edit" label="Customize for this agent" onClick={() => props.onStartEdit(row)} />,
     );
     if (row.source === "team_recommended") {
       buttons.push(
-        <PromptBlockAction
+        <RowAction
           key="disable"
           label="Disable"
           disabled={props.busy}
@@ -568,73 +560,48 @@ function PromptPanel(props: { children: ReactNode; minHeight?: string; sunken?: 
   );
 }
 
-// One instruction row, matching the shared `EffectiveRow` skeleton (Environment /
-// Tools & skills): a flat two-line row — line 1 = title + source + status + right-
-// aligned ghost actions + chevron; line 2 = a one-line truncated content peek. The
-// row expands in place: the full Markdown (or the inline editor) renders in a sunken
-// contained block below. Short, single-line prompts have no chevron, so the list
-// stays calm.
+// One instruction row — a thin wrapper over the shared `ResourceRowView`
+// primitive (the same flat skeleton the Tools & skills / Environment resource
+// rows use): name → source → status, right-aligned ghost actions, a one-line
+// peek, and an in-place sunken expansion holding the full Markdown or the inline
+// editor. Short, single-line prompts have no chevron, so the list stays calm.
 function PromptResourceBlock(props: {
-  title: ReactNode;
+  name: string | null;
+  source: EffectivePromptRow["source"];
+  marker?: RowStatusMarker;
   action?: ReactNode;
   body: string;
   expanded: boolean;
   onToggle: () => void;
-  /** When present (editor active), the sunken area always shows this instead of Markdown. */
+  /** When present (editor active), the sunken area shows this instead of Markdown. */
   editor?: ReactNode;
 }) {
   const peek = peekLine(props.body);
-  // Keep the existing guard: trivially-short single-line prompts need no expander.
+  // Trivially-short single-line prompts need no expander.
   const canExpand = props.body.length > 120 || props.body.includes("\n");
-  const showSunken = props.editor ? true : props.expanded && !!props.body;
   return (
-    <div style={{ padding: "var(--sp-3) 0", borderBottom: "var(--hairline) solid var(--border-faint)" }}>
-      {/* Title + actions. On mobile they stack (title row, then the action group
-          wraps below) so the long management buttons never overflow a phone width;
-          on sm+ they sit on one row with the actions right-aligned. */}
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:gap-3">
-        <div className="min-w-0 flex-1">{props.title}</div>
-        {props.action || (!props.editor && canExpand) ? (
-          <div className="flex flex-wrap items-center gap-1 shrink-0">
-            {props.action}
-            {props.editor ? null : canExpand ? (
-              <Button
-                type="button"
-                size="xs"
-                variant="ghost"
-                aria-expanded={props.expanded}
-                aria-label={props.expanded ? "Collapse instructions" : "Expand instructions"}
-                onClick={props.onToggle}
-              >
-                {props.expanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
-              </Button>
-            ) : null}
+    <ResourceRowView
+      name={props.name}
+      source={sourceLabel(props.source)}
+      status={props.marker}
+      peek={peek || undefined}
+      actions={props.action}
+      emptyPeek="No instructions yet."
+      expandLabel="instructions"
+      expand={{
+        canExpand,
+        expanded: props.expanded,
+        onToggle: props.onToggle,
+        // Cap prose to a readable measure (~66–75ch), matching the Effective
+        // instructions dialog (max-w-2xl) instead of stretching the full rail.
+        body: props.body ? (
+          <div className="max-w-2xl">
+            <Markdown>{props.body}</Markdown>
           </div>
-        ) : null}
-      </div>
-      {showSunken ? (
-        <div
-          className="text-body"
-          style={{
-            marginTop: "var(--sp-2)",
-            background: "var(--bg-sunken)",
-            border: "var(--hairline) solid var(--border-faint)",
-            borderRadius: "var(--radius-panel)",
-            padding: "var(--sp-3)",
-          }}
-        >
-          {props.editor ? props.editor : <Markdown>{props.body}</Markdown>}
-        </div>
-      ) : peek ? (
-        <p className="m-0 text-caption truncate" style={{ color: "var(--fg-3)", marginTop: "var(--sp-0_5)" }}>
-          {peek}
-        </p>
-      ) : (
-        <p className="m-0 text-caption text-muted-foreground" style={{ marginTop: "var(--sp-0_5)" }}>
-          No instructions yet.
-        </p>
-      )}
-    </div>
+        ) : null,
+      }}
+      editor={props.editor ?? undefined}
+    />
   );
 }
 
@@ -646,38 +613,6 @@ function peekLine(body: string): string {
     if (line) return line;
   }
   return "";
-}
-
-function PromptBlockAction(props: {
-  label: string;
-  onClick: () => void;
-  disabled?: boolean;
-  /** "edit" → pencil icon only; "remove" → trash icon only; undefined → text label.
-   *  Icon-only keeps the widest controls (e.g. "Customize for this agent") from
-   *  overflowing the flat row on narrow screens; the label moves to aria-label/title. */
-  icon?: "edit" | "remove";
-}) {
-  if (props.icon) {
-    const Icon = props.icon === "remove" ? Trash2 : Pencil;
-    return (
-      <Button
-        type="button"
-        size="xs"
-        variant="ghost"
-        disabled={props.disabled}
-        aria-label={props.label}
-        title={props.label}
-        onClick={props.onClick}
-      >
-        <Icon className="h-4 w-4" />
-      </Button>
-    );
-  }
-  return (
-    <Button type="button" size="xs" variant="ghost" disabled={props.disabled} onClick={props.onClick}>
-      {props.label}
-    </Button>
-  );
 }
 
 // Per-section add control on the Instructions tab. One "+" trigger opens a menu:
@@ -795,34 +730,6 @@ function promptBlockName(row: EffectivePromptRow): string | null {
   return row.name;
 }
 
-function PromptBlockHeading(props: {
-  name: string | null;
-  source: EffectivePromptRow["source"];
-  marker?: { label: string; color: string } | null;
-}) {
-  return (
-    <span className="inline-flex items-center gap-2">
-      {props.name ? (
-        <span className="text-body font-medium truncate" style={{ color: "var(--fg)" }}>
-          {props.name}
-        </span>
-      ) : null}
-      <span className="text-caption font-normal" style={{ color: "var(--fg-4)" }}>
-        {sourceLabel(props.source)}
-      </span>
-      {props.marker ? (
-        <span
-          className="mono inline-flex items-center gap-1.5 text-caption font-normal"
-          style={{ color: props.marker.color }}
-        >
-          <StatusGlyph colorVar={props.marker.color} shape="dot" size={7} ariaLabel={props.marker.label} />
-          {props.marker.label}
-        </span>
-      ) : null}
-    </span>
-  );
-}
-
 function InlineCustomPromptEditor(props: {
   body: string;
   error: string | null;
@@ -854,7 +761,7 @@ function InlineCustomPromptEditor(props: {
   }
 
   return (
-    <form onSubmit={submit} className="space-y-2">
+    <form onSubmit={submit} className="max-w-2xl space-y-2">
       <Textarea
         id="custom-prompt-body"
         ref={taRef}
@@ -901,7 +808,7 @@ function InlineCustomPromptEditor(props: {
             Cancel
           </Button>
           <Button type="submit" size="xs" variant="outline" disabled={props.saving}>
-            {props.saving ? "Saving..." : "Save instructions"}
+            {props.saving ? "Saving…" : "Save instructions"}
           </Button>
         </div>
       </div>

--- a/packages/web/src/pages/agent-detail/re-bind-dialog.tsx
+++ b/packages/web/src/pages/agent-detail/re-bind-dialog.tsx
@@ -20,6 +20,7 @@ import {
   DialogTitle,
 } from "../../components/ui/dialog.js";
 import { Label } from "../../components/ui/label.js";
+import { OptionCard } from "../../components/ui/option-card.js";
 import { Select, type SelectOption } from "../../components/ui/select.js";
 
 const PROVIDER_LABEL: Record<RuntimeProvider, string> = {
@@ -152,33 +153,24 @@ export function ReBindDialog({ open, onOpenChange, agent }: Props) {
             <div className="space-y-2">
               {PROVIDER_ORDER.map((provider) => {
                 const entry = selectedCapabilities?.[provider] ?? null;
-                const enabled = !!entry && entry.state !== "missing";
+                // A provider with no/missing SDK stays SELECTABLE — picking it
+                // surfaces the "override capability check" force checkbox below —
+                // so it's never `disabled`, only described as missing in the caption.
                 const checked = selectedProvider === provider;
                 return (
-                  <label
+                  <OptionCard
                     key={provider}
-                    className={
-                      checked
-                        ? "flex items-start gap-3 rounded-[var(--radius-panel)] border border-primary bg-primary/5 p-3 cursor-pointer"
-                        : enabled
-                          ? "flex items-start gap-3 rounded-[var(--radius-panel)] border border-border p-3 cursor-pointer hover:bg-accent/30"
-                          : "flex items-start gap-3 rounded-[var(--radius-panel)] border border-border p-3 opacity-60"
-                    }
+                    name="rebind-runtime"
+                    checked={checked}
+                    onSelect={() => setSelectedProvider(provider)}
                   >
-                    <input
-                      type="radio"
-                      name="rebind-runtime"
-                      checked={checked}
-                      onChange={() => setSelectedProvider(provider)}
-                      className="mt-1"
-                    />
                     <div>
                       <div className="text-body font-medium">{PROVIDER_LABEL[provider]}</div>
                       <div className="text-caption" style={{ color: "var(--fg-3)" }}>
                         {capabilityCaption(entry, provider)}
                       </div>
                     </div>
-                  </label>
+                  </OptionCard>
                 );
               })}
             </div>

--- a/packages/web/src/pages/agent-detail/resource-row.tsx
+++ b/packages/web/src/pages/agent-detail/resource-row.tsx
@@ -1,0 +1,174 @@
+import { ChevronDown, ChevronUp, Pencil, Trash2 } from "lucide-react";
+import type { ReactNode } from "react";
+import { Button } from "../../components/ui/button.js";
+import { StatusGlyph } from "../../components/ui/status-glyph.js";
+import { cn } from "../../lib/utils.js";
+
+/**
+ * The single flat row primitive for every "effective resource" on the agent
+ * detail page — instructions (Instructions tab), skills + MCP (Tools & skills),
+ * and repositories (Environment). Before this, the Instructions tab and the
+ * shared resource sections rendered near-identical-but-divergent rows: the
+ * metadata order was reversed (name → source → status here vs name → status →
+ * source there), row padding differed, and only Instructions could expand.
+ *
+ * `ResourceRow` locks all of that down so the rows read identically wherever
+ * they appear:
+ *   - line 1: name → source → status, then a right-aligned action group, then an
+ *     optional expand chevron;
+ *   - line 2 (collapsed): a single-line truncated `peek`;
+ *   - expanded / editing: a sunken contained block below.
+ */
+export type RowStatusMarker = { label: string; color: string } | null;
+
+export function ResourceRowView(props: {
+  /** Row title. `null` when the row has no resource name (inline custom prompt);
+   *  the peek then carries identity. */
+  name: ReactNode | null;
+  /** Already-resolved source label text (e.g. "From your team"). */
+  source: ReactNode;
+  /** Off / Overridden / Can't load marker — omitted for a normal enabled row. */
+  status?: RowStatusMarker;
+  /** Collapsed single-line preview. */
+  peek?: ReactNode;
+  /** Render the peek in mono — for technical content (repo URL, MCP command),
+   *  NOT for prose (a skill description). */
+  monoPeek?: boolean;
+  /** Right-aligned ghost action group (use `RowAction`). */
+  actions?: ReactNode;
+  /** Expand affordance + body rendered in the sunken block when expanded. */
+  expand?: { canExpand: boolean; expanded: boolean; onToggle: () => void; body: ReactNode };
+  /** When set, the sunken block always shows this (an inline editor) regardless
+   *  of expand state, and the chevron is suppressed. */
+  editor?: ReactNode;
+  /** Shown when there is neither a peek nor an expanded body (e.g. "No instructions yet."). */
+  emptyPeek?: ReactNode;
+  /** Noun for the expand/collapse control's aria-label (e.g. "instructions"), so the
+   *  shared row still announces WHAT expands. Falls back to a bare "Expand"/"Collapse". */
+  expandLabel?: string;
+}): ReactNode {
+  const expanded = !!props.expand?.expanded;
+  const canExpand = !props.editor && !!props.expand?.canExpand;
+  const showSunken = props.editor ? true : expanded && !!props.expand?.body;
+  return (
+    <div
+      style={{
+        padding: "var(--sp-3) 0",
+        borderBottom: "var(--hairline) solid var(--border-faint)",
+      }}
+    >
+      {/* Title + actions. On mobile they stack (title, then the action group wraps
+          below) so long management buttons never overflow a phone width; on sm+
+          they sit on one row with the actions right-aligned. */}
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:gap-3">
+        <div className="min-w-0 flex-1">
+          <RowHeading name={props.name} source={props.source} status={props.status} />
+        </div>
+        {props.actions || canExpand ? (
+          <div className="flex flex-wrap items-center gap-1 shrink-0">
+            {props.actions}
+            {canExpand ? (
+              <Button
+                type="button"
+                size="xs"
+                variant="ghost"
+                aria-expanded={expanded}
+                aria-label={
+                  expanded
+                    ? `Collapse${props.expandLabel ? ` ${props.expandLabel}` : ""}`
+                    : `Expand${props.expandLabel ? ` ${props.expandLabel}` : ""}`
+                }
+                onClick={props.expand?.onToggle}
+              >
+                {expanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+              </Button>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+      {showSunken ? (
+        <div
+          className="text-body"
+          style={{
+            marginTop: "var(--sp-2)",
+            background: "var(--bg-sunken)",
+            border: "var(--hairline) solid var(--border-faint)",
+            borderRadius: "var(--radius-panel)",
+            padding: "var(--sp-3)",
+          }}
+        >
+          {props.editor ? props.editor : props.expand?.body}
+        </div>
+      ) : props.peek ? (
+        <p
+          className={cn("m-0 text-caption truncate", props.monoPeek && "mono")}
+          style={{ color: "var(--fg-3)", marginTop: "var(--sp-0_5)" }}
+        >
+          {props.peek}
+        </p>
+      ) : props.emptyPeek ? (
+        <p className="m-0 text-caption text-muted-foreground" style={{ marginTop: "var(--sp-0_5)" }}>
+          {props.emptyPeek}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+function RowHeading({ name, source, status }: { name: ReactNode | null; source: ReactNode; status?: RowStatusMarker }) {
+  return (
+    <span className="inline-flex items-center gap-2">
+      {name ? (
+        <span className="text-body font-medium truncate" style={{ color: "var(--fg)" }}>
+          {name}
+        </span>
+      ) : null}
+      <span className="text-caption font-normal" style={{ color: "var(--fg-4)" }}>
+        {source}
+      </span>
+      {status ? (
+        <span
+          className="mono inline-flex items-center gap-1.5 text-caption font-normal"
+          style={{ color: status.color }}
+        >
+          <StatusGlyph colorVar={status.color} shape="dot" size={7} ariaLabel={status.label} />
+          {status.label}
+        </span>
+      ) : null}
+    </span>
+  );
+}
+
+/**
+ * One ghost action button for a ResourceRow. `icon` collapses the control to a
+ * single glyph (label moves to aria-label/title) so the widest controls don't
+ * overflow the flat row on narrow screens; text mode keeps the label inline.
+ */
+export function RowAction(props: {
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+  icon?: "edit" | "remove";
+}): ReactNode {
+  if (props.icon) {
+    const Icon = props.icon === "remove" ? Trash2 : Pencil;
+    return (
+      <Button
+        type="button"
+        size="xs"
+        variant="ghost"
+        disabled={props.disabled}
+        aria-label={props.label}
+        title={props.label}
+        onClick={props.onClick}
+      >
+        <Icon className="h-4 w-4" />
+      </Button>
+    );
+  }
+  return (
+    <Button type="button" size="xs" variant="ghost" disabled={props.disabled} onClick={props.onClick}>
+      {props.label}
+    </Button>
+  );
+}

--- a/packages/web/src/pages/agent-detail/save-bar.tsx
+++ b/packages/web/src/pages/agent-detail/save-bar.tsx
@@ -59,7 +59,7 @@ export function SaveBar(props: SaveBarProps) {
                 style={{
                   width: "var(--sp-2)",
                   height: "var(--sp-2)",
-                  borderRadius: "50%",
+                  borderRadius: "var(--radius-full)",
                   background: "var(--fg-4)",
                   flexShrink: 0,
                 }}
@@ -74,7 +74,7 @@ export function SaveBar(props: SaveBarProps) {
                     key={s}
                     type="button"
                     onClick={() => props.onJumpTo(s)}
-                    className="text-caption transition-colors hover:bg-accent border border-border rounded-[var(--radius-chip)] focus-visible:outline-none focus-visible:border-ring"
+                    className="text-caption transition-colors hover:bg-[var(--bg-hover)] border border-border rounded-[var(--radius-chip)] focus-visible:outline-none focus-visible:border-ring"
                     style={{
                       padding: "var(--sp-0_5) var(--sp-1_5)",
                       background: "var(--bg-raised)",


### PR DESCRIPTION
## What & why

A design-consistency pass on the **Agent detail page**. The page was structurally sound but had three "almost-the-same-but-not" patterns that read as assembled rather than unified. This collapses them and cleans up the supporting tokens/a11y.

### 1. One row primitive (`ResourceRowView`)
Instructions (`PromptResourceBlock`) and Tools & skills / repos (`EffectiveRow`) rendered near-identical-but-divergent rows — the metadata order was even **reversed** (`name → source → status` vs `name → status → source`), padding differed, and only Instructions could expand. They now share `resource-row.tsx`:
- metadata order locked to **name → source → status**, padding unified at 12px;
- skill **descriptions no longer forced to mono** (only repo URLs / MCP commands are);
- one shared `RowAction`; deletes the duplicated `PromptBlockHeading` / local `PromptBlockAction`.

### 2. Usage tab width
The page used one 52rem rail for every tab — too wide for prose/forms, **too narrow for the data-dense Usage tab** (activity calendar + 7-col token table, which was being squeezed + horizontally scrolled). Adds `--agent-detail-rail-wide: 64rem`; the Usage tab widens the whole page column (header + tabs + content via `railVar`) so it stays one coherent column, while other tabs stay 52rem. Instructions prose is capped to `max-w-2xl` to match the Effective-instructions dialog.

### 3. Selection state → `OptionCard` language
Selection was drawn three different ways, none matching the in-house `OptionCard` rule (faint border + neutral marker, never a heavier/colored border):
- **agent switcher**: constant 34px avatar + label underline (no select-time shrink/ring);
- **avatar swatch**: faint border + neutral corner check badge (Auto keeps its "A");
- **re-bind runtime radios**: now use `<OptionCard>`.

### 4. Token / a11y / copy cleanup
`borderRadius:"50%"` → `--radius-full`, `8.25rem` label column → `--agent-detail-label-col`, `Saving...` → `Saving…`, empty-state "enabled." → "yet.", focus-visible rings on avatar-edit + env-reveal buttons, expand control keeps an aria-label noun.

## Verification
`tsc --noEmit` ✓ · `lint:tokens` ✓ · `biome check` ✓ · **107/107** web tests ✓

Independent multi-angle code review (line-by-line / removed-behavior / cross-file+a11y / cleanup-altitude + verify): **no blockers**. Four surfaced nits were applied (chevron aria-label context, Auto-swatch identity, dead `lastRow` prop, `RowStatusMarker` reuse).

## Deliberately deferred (not in this PR)
- **Add-menu merge** (`AddInstructionsMenu` / `AddCapabilityMenu`): pure dedup, two visually-identical menus, regression risk > value — fast-follow.
- **Dead `git-section` / `mcp-section`**: orphaned from routing but still rendered by ~150 lines of live DOM tests — needs its own coupling investigation.
- **Loading skeletons** and an **Environment control width cap**: net-new UI / touches shared `ConfigRow` — low value, broader risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)