### PR TITLE
refactor(web): keep agent-detail tabs on the uniform rail (follow-up to #917)

### DIFF
--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -476,15 +476,10 @@
   --sp-70: 17.5rem; /* 280px */
   --sp-75: 18.75rem; /* 300px */
 
-  /* Agent detail content rail — the readable width for text/config tabs
-     (Profile / Environment / Instructions / Tools & skills). Header, tabs, and
-     content share it, centered like the context / team / settings pages. */
+  /* Agent detail content rail — one uniform readable width across every tab
+     (header, tabs, and content all share it), centered like the context / team
+     / settings pages. */
   --agent-detail-rail: 52rem;
-  /* Wider rail for the data-dense Usage tab (activity calendar + multi-column
-     token table), which needs more horizontal room than prose/config surfaces.
-     The whole page column (header + tabs + content) widens together on Usage so
-     it stays a single coherent column rather than content overflowing its tabs. */
-  --agent-detail-rail-wide: 64rem;
   --agent-detail-error-rail: 30rem;
   /* Shared label column for ConfigRow / IdentityField / DangerActionRow grids. */
   --agent-detail-label-col: 8.25rem;

--- a/packages/web/src/pages/agent-detail.tsx
+++ b/packages/web/src/pages/agent-detail.tsx
@@ -336,11 +336,6 @@ function AgentDetailPageView() {
     () => tabs.find((t) => t.key === currentTabKey)?.path ?? "profile",
     [tabs, currentTabKey],
   );
-  // The Usage tab is data-dense (activity calendar + multi-column token table)
-  // and needs a wider rail than the prose/config tabs. The whole page column
-  // (header + tabs + content) shares this value so it stays one coherent column
-  // instead of content overflowing its own tab bar.
-  const railVar = currentTabKey === "usage" ? "var(--agent-detail-rail-wide)" : "var(--agent-detail-rail)";
 
   if (agentQuery.isLoading) {
     return (
@@ -491,7 +486,7 @@ function AgentDetailPageView() {
             so the switcher and title row align with everything below. */}
         <div
           style={{
-            maxWidth: railVar,
+            maxWidth: "var(--agent-detail-rail)",
             marginLeft: "auto",
             marginRight: "auto",
             paddingLeft: "var(--sp-5)",
@@ -564,14 +559,7 @@ function AgentDetailPageView() {
         />
       )}
 
-      <TabsNav
-        tabs={tabs}
-        agentUuid={uuid}
-        currentTabKey={currentTabKey}
-        dirtyTabs={dirtyTabs}
-        badges={tabBadges}
-        railVar={railVar}
-      />
+      <TabsNav tabs={tabs} agentUuid={uuid} currentTabKey={currentTabKey} dirtyTabs={dirtyTabs} badges={tabBadges} />
 
       <div
         className="w-full flex-1"
@@ -581,10 +569,9 @@ function AgentDetailPageView() {
           flexDirection: "column",
           gap: "var(--sp-5)",
           width: "100%",
-          // Rail width tracks the active tab: the standard readable rail for
-          // prose/config tabs, a wider one for the data-dense Usage tab. The
-          // header + tab bar above share the same value (see railVar).
-          maxWidth: railVar,
+          // One uniform rail across every tab (no per-tab width jump), centered
+          // to match the context / team / settings pages.
+          maxWidth: "var(--agent-detail-rail)",
           marginLeft: "auto",
           marginRight: "auto",
         }}
@@ -724,15 +711,12 @@ function TabsNav({
   currentTabKey,
   dirtyTabs,
   badges,
-  railVar,
 }: {
   tabs: TabDef[];
   agentUuid: string;
   currentTabKey: string;
   dirtyTabs: ReadonlySet<string>;
   badges: Record<string, number>;
-  /** Rail width for the active tab — kept in sync with the header + content. */
-  railVar: string;
 }) {
   const navigate = useNavigate();
   const scrollRef = useRef<HTMLDivElement | null>(null);
@@ -812,7 +796,7 @@ function TabsNav({
           style={{
             gap: "var(--sp-0_5)",
             width: "100%",
-            maxWidth: railVar,
+            maxWidth: "var(--agent-detail-rail)",
             marginLeft: "auto",
             marginRight: "auto",
             paddingLeft: "var(--sp-5)",


### PR DESCRIPTION
## What & why

Follow-up to #917. That PR gave the **Usage tab a wider rail** (`--agent-detail-rail-wide: 64rem`) while the other tabs stayed at 52rem. In practice that made the **whole page column (header + tab bar + content) jump 52rem → 64rem when you switch to/from Usage** — a jarring width change that reads as inconsistent with the other sub-tabs and with the rest of the admin surfaces (context / team / settings all use the 52rem rail).

This reverts just that width decision: **every tab shares the uniform 52rem rail again** (no per-tab jump). The Usage table/calendar stay within it (and scroll on very narrow widths, exactly as before #917). All the other #917 changes — the `ResourceRowView` row primitive, selection-state unification, token/a11y/copy cleanup — are untouched.

## Change
- Remove `--agent-detail-rail-wide` and the `railVar` plumbing (header / `TabsNav` / content all return to `var(--agent-detail-rail)`).
- Keep `--agent-detail-label-col` (still used by ConfigRow / IdentityField / DangerActionRow).

2 files, -30/+9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)