### PR TITLE
feat(web): onboarding connect-code new-tab install + copy/state cleanup

### DIFF
--- a/packages/server/src/api/orgs/__tests__/post-install-next.test.ts
+++ b/packages/server/src/api/orgs/__tests__/post-install-next.test.ts
@@ -9,6 +9,7 @@ import { ALLOWED_POST_INSTALL_NEXT, resolvePostInstallNext } from "../github-app
 describe("resolvePostInstallNext", () => {
   it("passes through allowlisted internal paths", () => {
     expect(resolvePostInstallNext("/onboarding")).toBe("/onboarding");
+    expect(resolvePostInstallNext("/onboarding/connected")).toBe("/onboarding/connected");
     expect(resolvePostInstallNext("/settings/github")).toBe("/settings/github");
   });
 
@@ -24,7 +25,7 @@ describe("resolvePostInstallNext", () => {
     expect(resolvePostInstallNext("")).toBe("/settings/github");
   });
 
-  it("only allows the two known internal destinations", () => {
-    expect([...ALLOWED_POST_INSTALL_NEXT].sort()).toEqual(["/onboarding", "/settings/github"]);
+  it("only allows the known internal destinations", () => {
+    expect([...ALLOWED_POST_INSTALL_NEXT].sort()).toEqual(["/onboarding", "/onboarding/connected", "/settings/github"]);
   });
 });

--- a/packages/server/src/api/orgs/github-app.ts
+++ b/packages/server/src/api/orgs/github-app.ts
@@ -40,7 +40,14 @@ const POST_INSTALL_NEXT = "/settings/github";
  * Allowlisted — never reflect a caller-supplied path verbatim into the
  * signed redirect, so a crafted `?next=` can't become an open redirect.
  */
-export const ALLOWED_POST_INSTALL_NEXT: ReadonlySet<string> = new Set([POST_INSTALL_NEXT, "/onboarding"]);
+export const ALLOWED_POST_INSTALL_NEXT: ReadonlySet<string> = new Set([
+  POST_INSTALL_NEXT,
+  "/onboarding",
+  // Tiny "connected — you can close this tab" landing: onboarding connect-code
+  // installs in a popup and lands the popup here so it can auto-close while the
+  // original tab keeps polling.
+  "/onboarding/connected",
+]);
 
 /**
  * Resolve the post-install redirect destination from a caller-supplied

--- a/packages/web/src/app.tsx
+++ b/packages/web/src/app.tsx
@@ -16,6 +16,7 @@ import { ContextPage } from "./pages/context.js";
 import { InviteAcceptPage } from "./pages/invite-accept.js";
 import { LoginPage } from "./pages/login.js";
 import { OAuthCompletePage } from "./pages/oauth-complete.js";
+import { GithubConnectedPage } from "./pages/onboarding/github-connected.js";
 import { OnboardingPage } from "./pages/onboarding/onboarding-page.js";
 import { SettingsComputersPage } from "./pages/settings/computers.js";
 import { SettingsContextTreePage } from "./pages/settings/context-tree.js";
@@ -97,6 +98,8 @@ export function App() {
               {/* /signup retired — Continue with GitHub on /login covers signup. */}
               <Route path="/signup" element={<Navigate to="/login" replace />} />
               <Route path="/auth/github/complete" element={<OAuthCompletePage />} />
+              {/* Public: the connect-code install popup lands here to auto-close. */}
+              <Route path="/onboarding/connected" element={<GithubConnectedPage />} />
               <Route path="/invite/:token" element={<InviteAcceptPage />} />
               {ContextPreviewPage ? (
                 <Route

--- a/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
+++ b/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
@@ -1221,7 +1221,7 @@ describe("page SSR smoke coverage", () => {
     expect(html).toContain("Heads up");
     expect(html).toContain("gandy-macbook connected");
     expect(html).toContain("Install Node.js");
-    expect(html).toContain("Choose your projects");
+    expect(html).toContain("Pick repos");
 
     expect(await renderOnboardingStep(<StepTeam />, { activeStep: "team" })).toContain(
       "What should we call your team?",
@@ -1235,11 +1235,11 @@ describe("page SSR smoke coverage", () => {
     );
     expect(
       await renderOnboardingStep(<StepCreateAgent />, { activeStep: "create-agent", agentPhase: "creating" }),
-    ).toContain("Setting up your agent");
+    ).toContain("Bringing your agent online");
     expect(
       await renderOnboardingStep(<StepCreateAgent />, { activeStep: "create-agent", agentPhase: "timeout" }),
-    ).toContain("longer than expected");
-    expect(await renderOnboardingStep(<StepConnectCode />, { activeStep: "connect-code" })).toContain("Which projects");
+    ).toContain("online yet");
+    expect(await renderOnboardingStep(<StepConnectCode />, { activeStep: "connect-code" })).toContain("Which repos");
     expect(await renderOnboardingStep(<StepKickoff />, { activeStep: "kickoff" })).toContain(
       "Use your team&#x27;s Context Tree",
     );

--- a/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
+++ b/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
@@ -1188,6 +1188,7 @@ describe("page SSR smoke coverage", () => {
     const { ConnectStuckPanel } = await import("../../components/connect-stuck-panel.js");
     const { CommandBox, FlowNote, RepoPicker, StatusRow, WorkingState } = await import("../onboarding/flow-ui.js");
     const { InstallGuide, ShowMeHow, TerminalGuide } = await import("../onboarding/guides.js");
+    const { GithubConnectedPage } = await import("../onboarding/github-connected.js");
     const { StepConnectCode } = await import("../onboarding/steps/step-connect-code.js");
     const { StepConnectComputer } = await import("../onboarding/steps/step-connect-computer.js");
     const { StepCreateAgent } = await import("../onboarding/steps/step-create-agent.js");
@@ -1222,6 +1223,13 @@ describe("page SSR smoke coverage", () => {
     expect(html).toContain("gandy-macbook connected");
     expect(html).toContain("Install Node.js");
     expect(html).toContain("Pick repos");
+
+    // The install-popup landing page (auto-closes the script-opened tab; the
+    // effect is a no-op under SSR). Confirms it renders + carries role=status.
+    const connectedHtml = renderPage(<GithubConnectedPage />);
+    expect(connectedHtml).toContain("Connected");
+    expect(connectedHtml).toContain("close this tab");
+    expect(connectedHtml).toContain('role="status"');
 
     expect(await renderOnboardingStep(<StepTeam />, { activeStep: "team" })).toContain(
       "What should we call your team?",

--- a/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
+++ b/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
@@ -1239,7 +1239,7 @@ describe("page SSR smoke coverage", () => {
     expect(
       await renderOnboardingStep(<StepCreateAgent />, { activeStep: "create-agent", agentPhase: "timeout" }),
     ).toContain("online yet");
-    expect(await renderOnboardingStep(<StepConnectCode />, { activeStep: "connect-code" })).toContain("Which repos");
+    expect(await renderOnboardingStep(<StepConnectCode />, { activeStep: "connect-code" })).toContain("Pick repos");
     expect(await renderOnboardingStep(<StepKickoff />, { activeStep: "kickoff" })).toContain(
       "Use your team&#x27;s Context Tree",
     );

--- a/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
+++ b/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
@@ -1333,10 +1333,10 @@ describe("web DOM interaction coverage", () => {
     });
 
     const disconnected = await renderOnboardingDom(<StepConnectCode />, { activeStep: "connect-code" });
-    await waitForText("Install First Tree on GitHub", disconnected.container);
+    await waitForText("Install on GitHub", disconnected.container);
     await click(
       [...disconnected.container.querySelectorAll("button")].find((button) =>
-        button.textContent?.includes("Install First Tree on GitHub"),
+        button.textContent?.includes("Install on GitHub"),
       ) ?? null,
     );
     expect(githubAppMocks.getGithubAppInstallUrl).toHaveBeenCalledWith("org-1", "/onboarding");
@@ -1346,7 +1346,7 @@ describe("web DOM interaction coverage", () => {
     // Skip is one click now — a legitimate, recoverable choice goes straight
     // through with no confirm gate (the old "Skip connecting code?" panel +
     // Keep-connecting / Skip-anyway was confirmshaming and was removed).
-    expect(disconnected.container.textContent).toContain("You can connect code anytime from Settings.");
+    expect(disconnected.container.textContent).toContain("You can connect a repo anytime from Settings.");
     await click(
       [...disconnected.container.querySelectorAll("button")].find((button) =>
         button.textContent?.includes("Skip for now"),
@@ -1375,7 +1375,7 @@ describe("web DOM interaction coverage", () => {
       setSelectedRepoUrls,
       goNext: vi.fn(),
     });
-    await waitForText("Which projects should your agent work on?", connected.container);
+    await waitForText("Which repos should your agent work on?", connected.container);
     await waitForText("acme/web", connected.container);
     await click(
       [...connected.container.querySelectorAll("label")].find((label) => label.textContent?.includes("acme/web")) ??
@@ -1384,7 +1384,7 @@ describe("web DOM interaction coverage", () => {
     expect(setSelectedRepoUrls).toHaveBeenCalledWith(["https://github.com/acme/web.git"]);
     await click(
       [...connected.container.querySelectorAll("button")].find((button) =>
-        button.textContent?.includes("Continue without a project"),
+        button.textContent?.includes("Continue without a repo"),
       ) ?? null,
     );
     expect(connected.flow.goNext).toHaveBeenCalled();
@@ -1405,7 +1405,7 @@ describe("web DOM interaction coverage", () => {
     });
     githubMocks.listOrgGithubRepos.mockRejectedValueOnce(new ApiError(403, "scope missing"));
     const scopeMissing = await renderOnboardingDom(<StepConnectCode />, { activeStep: "connect-code" });
-    await waitForText("Reconnect GitHub with project access", scopeMissing.container);
+    await waitForText("Reconnect GitHub with repo access", scopeMissing.container);
     await unmountRoot(scopeMissing.root);
 
     // A non-403 failure from the org repo endpoint (502 upstream / 503
@@ -1426,21 +1426,21 @@ describe("web DOM interaction coverage", () => {
     });
     githubMocks.listOrgGithubRepos.mockRejectedValueOnce(new ApiError(503, "no installation"));
     const loadFailed = await renderOnboardingDom(<StepConnectCode />, { activeStep: "connect-code" });
-    await waitForText("Couldn't load your team's projects", loadFailed.container);
+    await waitForText("Couldn't load your team's repos", loadFailed.container);
     await unmountRoot(loadFailed.root);
 
     githubAppMocks.getGithubAppInstallUrl.mockRejectedValueOnce(new ApiError(503, "not configured"));
     const notConfigured = await renderOnboardingDom(<StepConnectCode />, { activeStep: "connect-code" });
-    await waitForText("Install First Tree on GitHub", notConfigured.container);
+    await waitForText("Install on GitHub", notConfigured.container);
     await click(
       [...notConfigured.container.querySelectorAll("button")].find((button) =>
-        button.textContent?.includes("Install First Tree on GitHub"),
+        button.textContent?.includes("Install on GitHub"),
       ) ?? null,
     );
-    await waitForText("Code connection isn't set up here yet.", notConfigured.container);
+    await waitForText("Connecting a repo isn't set up here yet", notConfigured.container);
     await click(
       [...notConfigured.container.querySelectorAll("button")].find((button) =>
-        button.textContent?.includes("Continue without connecting code"),
+        button.textContent?.includes("Continue without a repo"),
       ) ?? null,
     );
     expect(notConfigured.flow.goNext).toHaveBeenCalled();
@@ -1560,7 +1560,7 @@ describe("web DOM interaction coverage", () => {
       path: "invitee",
       activeStep: "kickoff",
     });
-    await waitForText("your team's code isn't connected yet", inviteeNoInstall.container);
+    await waitForText("your team's repo isn't connected yet", inviteeNoInstall.container);
     await click(
       [...inviteeNoInstall.container.querySelectorAll("button")].find((button) =>
         button.textContent?.includes("Copy"),
@@ -1576,7 +1576,7 @@ describe("web DOM interaction coverage", () => {
     await waitForText("Your team is ready", inviteeConfirm.container);
     await click(
       [...inviteeConfirm.container.querySelectorAll("button")].find((button) =>
-        button.textContent?.includes("Continue without a project"),
+        button.textContent?.includes("Continue without a repo"),
       ) ?? null,
     );
     expect(chatApiMocks.sendChatMessage).toHaveBeenCalledWith("chat-onboarding", expect.any(String), ["agent-1"]);
@@ -1592,7 +1592,7 @@ describe("web DOM interaction coverage", () => {
       path: "invitee",
       activeStep: "kickoff",
     });
-    await waitForText("Reconnect GitHub with project access", inviteePickerScope.container);
+    await waitForText("Reconnect GitHub with repo access", inviteePickerScope.container);
     await unmountRoot(inviteePickerScope.root);
 
     resourceMocks.listTeamResourcesForOrg.mockResolvedValueOnce([]);
@@ -1601,7 +1601,7 @@ describe("web DOM interaction coverage", () => {
       path: "invitee",
       activeStep: "kickoff",
     });
-    await waitForText("Couldn't load your projects", inviteePickerNetwork.container);
+    await waitForText("Couldn't load your repos", inviteePickerNetwork.container);
   });
 
   it("edits MCP server rows through validation, stdio, and HTTP submissions", async () => {

--- a/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
+++ b/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
@@ -1454,6 +1454,32 @@ describe("web DOM interaction coverage", () => {
     expect(notConfigured.flow.goNext).toHaveBeenCalled();
   });
 
+  it("falls back to a full-page redirect when the install popup is blocked", async () => {
+    const { StepConnectCode } = await import("../onboarding/steps/step-connect-code.js");
+    // A fresh attempt: clear any marker a prior test left so the CTA is enabled.
+    sessionStorage.removeItem("onboarding:connect-code:install-attempt");
+    const assign = vi.fn();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...window.location, assign, href: "http://localhost/onboarding" },
+    });
+    // Popup blocked → window.open returns null → we must fall back to a
+    // full-page redirect rather than silently dropping the install.
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
+
+    const blocked = await renderOnboardingDom(<StepConnectCode />, { activeStep: "connect-code" });
+    await waitForText("Install on GitHub", blocked.container);
+    await click(
+      [...blocked.container.querySelectorAll("button")].find((button) =>
+        button.textContent?.includes("Install on GitHub"),
+      ) ?? null,
+    );
+    expect(githubAppMocks.getGithubAppInstallUrl).toHaveBeenCalledWith("org-1", "/onboarding/connected");
+    expect(openSpy).toHaveBeenCalledWith("", "_blank");
+    expect(assign).toHaveBeenCalledWith("https://github.com/apps/first-tree/installations/new");
+    await unmountRoot(blocked.root);
+  });
+
   it("drives StepKickoff admin and invitee start flows", async () => {
     const { ApiError } = await import("../../api/client.js");
     const { StepKickoff } = await import("../onboarding/steps/step-kickoff.js");

--- a/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
+++ b/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
@@ -1437,7 +1437,7 @@ describe("web DOM interaction coverage", () => {
         button.textContent?.includes("Install on GitHub"),
       ) ?? null,
     );
-    await waitForText("Connecting a repo isn't set up here yet", notConfigured.container);
+    await waitForText("Couldn't connect a repo here right now", notConfigured.container);
     await click(
       [...notConfigured.container.querySelectorAll("button")].find((button) =>
         button.textContent?.includes("Continue without a repo"),

--- a/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
+++ b/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
@@ -1466,6 +1466,7 @@ describe("web DOM interaction coverage", () => {
     // Popup blocked → window.open returns null → we must fall back to a
     // full-page redirect rather than silently dropping the install.
     const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
+    githubAppMocks.getGithubAppInstallUrl.mockClear();
 
     const blocked = await renderOnboardingDom(<StepConnectCode />, { activeStep: "connect-code" });
     await waitForText("Install on GitHub", blocked.container);
@@ -1474,10 +1475,42 @@ describe("web DOM interaction coverage", () => {
         button.textContent?.includes("Install on GitHub"),
       ) ?? null,
     );
-    expect(githubAppMocks.getGithubAppInstallUrl).toHaveBeenCalledWith("org-1", "/onboarding/connected");
+    // Blocked path redirects THIS tab, so it must come back to the wizard
+    // (/onboarding) — not the popup auto-close page, which would strand it.
+    expect(githubAppMocks.getGithubAppInstallUrl).toHaveBeenCalledWith("org-1", "/onboarding");
     expect(openSpy).toHaveBeenCalledWith("", "_blank");
     expect(assign).toHaveBeenCalledWith("https://github.com/apps/first-tree/installations/new");
     await unmountRoot(blocked.root);
+  });
+
+  it("locks the Install CTA after launch and re-enables only via Start over", async () => {
+    const { StepConnectCode } = await import("../onboarding/steps/step-connect-code.js");
+    sessionStorage.removeItem("onboarding:connect-code:install-attempt");
+    const installTab = { location: { href: "" }, close: vi.fn() };
+    vi.spyOn(window, "open").mockReturnValue(installTab as unknown as Window);
+    githubAppMocks.getGithubAppInstallUrl.mockClear();
+
+    const view = await renderOnboardingDom(<StepConnectCode />, { activeStep: "connect-code" });
+    await waitForText("Install on GitHub", view.container);
+    const installBtn = (): HTMLButtonElement | null =>
+      [...view.container.querySelectorAll<HTMLButtonElement>("button")].find((b) =>
+        b.textContent?.includes("Install on GitHub"),
+      ) ?? null;
+
+    await click(installBtn());
+    expect(githubAppMocks.getGithubAppInstallUrl).toHaveBeenCalledTimes(1);
+    // The original tab stays mounted and polls; the CTA must lock so a second
+    // click can't re-mint and clobber the in-flight attempt's state nonce.
+    expect(installBtn()?.disabled).toBe(true);
+    await click(installBtn());
+    expect(githubAppMocks.getGithubAppInstallUrl).toHaveBeenCalledTimes(1);
+
+    // Retry is explicit + user-initiated, never a timed auto-unlock.
+    await click(
+      [...view.container.querySelectorAll("button")].find((b) => b.textContent?.includes("Start over")) ?? null,
+    );
+    expect(installBtn()?.disabled).toBe(false);
+    await unmountRoot(view.root);
   });
 
   it("drives StepKickoff admin and invitee start flows", async () => {

--- a/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
+++ b/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
@@ -1331,6 +1331,10 @@ describe("web DOM interaction coverage", () => {
       configurable: true,
       value: { ...window.location, assign, href: "http://localhost/onboarding" },
     });
+    // connect-code opens the install in a new tab (popup) and fills its location
+    // once the URL is minted; stub window.open to capture that.
+    const installTab = { location: { href: "" }, close: vi.fn() };
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(installTab as unknown as Window);
 
     const disconnected = await renderOnboardingDom(<StepConnectCode />, { activeStep: "connect-code" });
     await waitForText("Install on GitHub", disconnected.container);
@@ -1339,14 +1343,15 @@ describe("web DOM interaction coverage", () => {
         button.textContent?.includes("Install on GitHub"),
       ) ?? null,
     );
-    expect(githubAppMocks.getGithubAppInstallUrl).toHaveBeenCalledWith("org-1", "/onboarding");
+    expect(githubAppMocks.getGithubAppInstallUrl).toHaveBeenCalledWith("org-1", "/onboarding/connected");
     expect(sessionStorage.getItem("onboarding:connect-code:install-attempt")).toBeTruthy();
-    expect(assign).toHaveBeenCalledWith("https://github.com/apps/first-tree/installations/new");
+    expect(openSpy).toHaveBeenCalledWith("", "_blank");
+    expect(installTab.location.href).toBe("https://github.com/apps/first-tree/installations/new");
 
     // Skip is one click now — a legitimate, recoverable choice goes straight
     // through with no confirm gate (the old "Skip connecting code?" panel +
     // Keep-connecting / Skip-anyway was confirmshaming and was removed).
-    expect(disconnected.container.textContent).toContain("You can connect a repo anytime from Settings.");
+    expect(disconnected.container.textContent).toContain("connect anytime from Settings.");
     await click(
       [...disconnected.container.querySelectorAll("button")].find((button) =>
         button.textContent?.includes("Skip for now"),
@@ -1403,14 +1408,17 @@ describe("web DOM interaction coverage", () => {
       createdAt: NOW,
       updatedAt: NOW,
     });
-    githubMocks.listOrgGithubRepos.mockRejectedValueOnce(new ApiError(403, "scope missing"));
-    const scopeMissing = await renderOnboardingDom(<StepConnectCode />, { activeStep: "connect-code" });
-    await waitForText("Reconnect GitHub with repo access", scopeMissing.container);
-    await unmountRoot(scopeMissing.root);
+    // A 403 from the org repo endpoint is `requireOrgAdmin` ("not an org
+    // admin"), not a GitHub-scope problem (the repos come from the App
+    // installation token, not the caller's OAuth). It folds into the same
+    // honest load-failed message — there's no "reconnect GitHub" recovery.
+    githubMocks.listOrgGithubRepos.mockRejectedValueOnce(new ApiError(403, "admin required"));
+    const adminForbidden = await renderOnboardingDom(<StepConnectCode />, { activeStep: "connect-code" });
+    await waitForText("Couldn't load your team's repos", adminForbidden.container);
+    await unmountRoot(adminForbidden.root);
 
-    // A non-403 failure from the org repo endpoint (502 upstream / 503
-    // no_installation|suspended) must show an honest load-failed message, not
-    // fall through to the empty "no projects" state.
+    // A 502 (upstream) / 503 (no_installation|suspended) failure shows the same
+    // honest load-failed message, not the empty "no projects" state.
     githubAppMocks.getGithubAppInstallation.mockResolvedValueOnce({
       installationId: 42,
       accountLogin: "acme",

--- a/packages/web/src/pages/onboarding-preview.tsx
+++ b/packages/web/src/pages/onboarding-preview.tsx
@@ -483,13 +483,6 @@ const SCENARIOS: Scenario[] = [
     wizard: { step: "connect-code", net: { installed: true, repos: [] } },
   },
   {
-    id: "admin-code-scope",
-    label: "Scope missing",
-    group: "4 · Connect code",
-    role: "admin",
-    wizard: { step: "connect-code", net: { installed: true, repos: "scope" } },
-  },
-  {
     id: "admin-code-loadfailed",
     label: "Load failed",
     group: "4 · Connect code",

--- a/packages/web/src/pages/onboarding-preview.tsx
+++ b/packages/web/src/pages/onboarding-preview.tsx
@@ -432,14 +432,14 @@ const SCENARIOS: Scenario[] = [
   },
   {
     id: "admin-code-err-notconfigured",
-    label: "Install error · not configured (click Install)",
+    label: "Install error · can't connect · 503 (click Install)",
     group: "4 · Connect code",
     role: "admin",
     wizard: { step: "connect-code", net: { installed: false, installUrlError: 503 } },
   },
   {
     id: "admin-code-err-notadmin",
-    label: "Install error · not a team admin (click Install)",
+    label: "Install error · can't connect · 403 (click Install)",
     group: "4 · Connect code",
     role: "admin",
     wizard: { step: "connect-code", net: { installed: false, installUrlError: 403 } },

--- a/packages/web/src/pages/onboarding-preview.tsx
+++ b/packages/web/src/pages/onboarding-preview.tsx
@@ -100,7 +100,12 @@ const NOOP = (): void => {};
 const ASYNC_NOOP = async (): Promise<void> => {};
 
 // ── Computer-connection fixtures (drive the connect-computer + create-agent steps) ──
-const COMPUTER: Record<"waiting" | "tokenError" | "detecting" | "noRuntime" | "ready", ComputerConnection> = {
+// `selectedRuntime` / `setSelectedRuntime` are made interactive per-scenario in
+// WizardScenarioView (state-backed), so the runtime pills actually switch.
+const COMPUTER: Record<
+  "waiting" | "tokenError" | "detecting" | "noRuntime" | "ready" | "readyMulti",
+  ComputerConnection
+> = {
   waiting: {
     connectedClient: null,
     capabilitiesLoaded: false,
@@ -141,10 +146,22 @@ const COMPUTER: Record<"waiting" | "tokenError" | "detecting" | "noRuntime" | "r
     tokenError: null,
     retry: NOOP,
   },
+  // Exactly one runtime → the step renders a confirmation line (no picker).
   ready: {
     connectedClient: HOST,
     capabilitiesLoaded: true,
     okRuntimes: ["claude-code"],
+    selectedRuntime: "claude-code",
+    setSelectedRuntime: NOOP,
+    cliCommand: SAMPLE_CLI,
+    tokenError: null,
+    retry: NOOP,
+  },
+  // Multiple runtimes → the step renders the single-select runtime list.
+  readyMulti: {
+    connectedClient: HOST,
+    capabilitiesLoaded: true,
+    okRuntimes: ["claude-code", "codex", "claude-code-tui"],
     selectedRuntime: "claude-code",
     setSelectedRuntime: NOOP,
     cliCommand: SAMPLE_CLI,
@@ -175,6 +192,9 @@ type NetProfile = {
   repos?: RepoOutcome;
   /** GET /orgs/:id/github-app-installation — 200 vs 404 */
   installed?: boolean;
+  /** When true, the installation query never resolves (stays loading) — used to
+      hold the post-click "Waiting for GitHub…" state without it flipping to stuck. */
+  installPending?: boolean;
   /** GET /orgs/:id/github-app-installation/exists */
   installExists?: boolean;
   /** GET /orgs/:id/settings/context_tree → { repo } */
@@ -183,7 +203,7 @@ type NetProfile = {
   sourceRepos?: string[];
   /**
    * GET /orgs/:id/github-app-installation/install-url — when set, the install
-   * URL mint fails with this status, so clicking "Install First Tree on GitHub"
+   * URL mint fails with this status, so clicking "Install on GitHub"
    * surfaces the matching installError state (503 → not_configured, 403 →
    * not_admin, else → generic). Omit it and the call falls through (real
    * fetch), so only the error scenarios opt in.
@@ -225,6 +245,7 @@ function handleNet(rawUrl: string): Promise<Response> | Response | null {
   if (p === "/me/github/repos") return reposResponse(activeNet.repos);
   if (p === `/orgs/${ORG_ID}/github-app-installation/repositories`) return reposResponse(activeNet.repos);
   if (p === `/orgs/${ORG_ID}/github-app-installation`) {
+    if (activeNet.installPending) return new Promise<Response>(() => {});
     return activeNet.installed
       ? jsonResponse({ installed: true })
       : statusResponse(404, "No GitHub App installation is bound to this team");
@@ -287,6 +308,13 @@ type WizardSpec = {
    * component's short delay). Mirrors the per-tab key StepConnectCode sets.
    */
   seedInstallAttempt?: boolean;
+  /**
+   * Render connect-computer in its "stuck" state (help auto-opens, label flips
+   * to "Taking a while?"). The real state is gated on a 75s internal timer
+   * (STUCK_AFTER_MS) that fixtures can't force, so the preview seeds it directly
+   * via StepConnectComputer's `initialStuck` prop.
+   */
+  connectStuck?: boolean;
 };
 
 // Per-tab marker StepConnectCode reads to detect "came back without an install"
@@ -336,10 +364,24 @@ const SCENARIOS: Scenario[] = [
   },
   {
     id: "admin-cc-ready",
-    label: "Connected · ready",
+    label: "Connected · ready (1 runtime)",
     group: "2 · Connect computer",
     role: "admin",
     wizard: { step: "connect-computer", flow: { computer: COMPUTER.ready } },
+  },
+  {
+    id: "admin-cc-ready-multi",
+    label: "Connected · ready (multiple runtimes)",
+    group: "2 · Connect computer",
+    role: "admin",
+    wizard: { step: "connect-computer", flow: { computer: COMPUTER.readyMulti } },
+  },
+  {
+    id: "admin-cc-stuck",
+    label: "Waiting · stuck (Need help)",
+    group: "2 · Connect computer",
+    role: "admin",
+    wizard: { step: "connect-computer", flow: { computer: COMPUTER.waiting }, connectStuck: true },
   },
 
   {
@@ -373,6 +415,13 @@ const SCENARIOS: Scenario[] = [
       flow: { computer: COMPUTER.ready, agentPhase: "idle", agentError: "Couldn't create your agent" },
     },
   },
+  {
+    id: "admin-ca-computer-lost",
+    label: "Form · computer disconnected",
+    group: "3 · Create agent",
+    role: "admin",
+    wizard: { step: "create-agent", flow: { computer: COMPUTER.waiting, agentPhase: "idle" } },
+  },
 
   {
     id: "admin-code-notinstalled",
@@ -403,6 +452,16 @@ const SCENARIOS: Scenario[] = [
     wizard: { step: "connect-code", net: { installed: false, installUrlError: 500 } },
   },
   {
+    id: "admin-code-waiting",
+    label: "Waiting for GitHub (after click)",
+    group: "4 · Connect code",
+    role: "admin",
+    // installPending keeps the install query loading so it holds "Waiting for
+    // GitHub…" without the 5s stuck timer firing; seedInstallAttempt marks the
+    // click so the status shows (pre-click there's nothing to wait for).
+    wizard: { step: "connect-code", net: { installPending: true }, seedInstallAttempt: true },
+  },
+  {
     id: "admin-code-stuck",
     label: "Came back without install (stuck → Need help)",
     group: "4 · Connect code",
@@ -411,14 +470,14 @@ const SCENARIOS: Scenario[] = [
   },
   {
     id: "admin-code-loading",
-    label: "Loading projects",
+    label: "Loading repos",
     group: "4 · Connect code",
     role: "admin",
     wizard: { step: "connect-code", net: { installed: true, repos: "pending" } },
   },
   {
     id: "admin-code-norepos",
-    label: "No projects",
+    label: "No repos",
     group: "4 · Connect code",
     role: "admin",
     wizard: { step: "connect-code", net: { installed: true, repos: [] } },
@@ -431,8 +490,15 @@ const SCENARIOS: Scenario[] = [
     wizard: { step: "connect-code", net: { installed: true, repos: "scope" } },
   },
   {
+    id: "admin-code-loadfailed",
+    label: "Load failed",
+    group: "4 · Connect code",
+    role: "admin",
+    wizard: { step: "connect-code", net: { installed: true, repos: "neterror" } },
+  },
+  {
     id: "admin-code-repos",
-    label: "Pick projects",
+    label: "Pick repos",
     group: "4 · Connect code",
     role: "admin",
     wizard: { step: "connect-code", net: { installed: true, repos: REPOS } },
@@ -440,7 +506,7 @@ const SCENARIOS: Scenario[] = [
 
   {
     id: "admin-ko-noproject",
-    label: "No project",
+    label: "No repo",
     group: "5 · Kickoff",
     role: "admin",
     wizard: { step: "kickoff", flow: { selectedRepoUrls: [] } },
@@ -623,10 +689,24 @@ const SCENARIOS: Scenario[] = [
   },
   {
     id: "inv-cc-ready",
-    label: "Connected · ready",
+    label: "Connected · ready (1 runtime)",
     group: "2 · Connect computer",
     role: "invitee",
     wizard: { step: "connect-computer", flow: { computer: COMPUTER.ready } },
+  },
+  {
+    id: "inv-cc-ready-multi",
+    label: "Connected · ready (multiple runtimes)",
+    group: "2 · Connect computer",
+    role: "invitee",
+    wizard: { step: "connect-computer", flow: { computer: COMPUTER.readyMulti } },
+  },
+  {
+    id: "inv-cc-stuck",
+    label: "Waiting · stuck (Need help)",
+    group: "2 · Connect computer",
+    role: "invitee",
+    wizard: { step: "connect-computer", flow: { computer: COMPUTER.waiting }, connectStuck: true },
   },
 
   {
@@ -660,6 +740,13 @@ const SCENARIOS: Scenario[] = [
       flow: { computer: COMPUTER.ready, agentPhase: "idle", agentError: "Couldn't create your agent" },
     },
   },
+  {
+    id: "inv-ca-computer-lost",
+    label: "Form · computer disconnected",
+    group: "3 · Create agent",
+    role: "invitee",
+    wizard: { step: "create-agent", flow: { computer: COMPUTER.waiting, agentPhase: "idle" } },
+  },
 
   {
     id: "inv-ko-waiting",
@@ -677,7 +764,7 @@ const SCENARIOS: Scenario[] = [
   },
   {
     id: "inv-ko-confirm",
-    label: "Confirm team projects",
+    label: "Confirm team repos",
     group: "4 · Kickoff (start work)",
     role: "invitee",
     wizard: { step: "kickoff", net: { contextTree: TREE_URL, installExists: true, sourceRepos: [REPO_WEB, REPO_API] } },
@@ -691,7 +778,7 @@ const SCENARIOS: Scenario[] = [
   },
   {
     id: "inv-ko-picker-empty",
-    label: "Picker · no projects",
+    label: "Picker · no repos",
     group: "4 · Kickoff (start work)",
     role: "invitee",
     wizard: { step: "kickoff", net: { contextTree: TREE_URL, installExists: true, sourceRepos: [], repos: [] } },
@@ -772,14 +859,14 @@ function baseFlow(path: OnboardingPath): OnboardingFlowValue {
   };
 }
 
-function StepBody({ step }: { step: StepId }): ReactNode {
+function StepBody({ step, connectStuck }: { step: StepId; connectStuck?: boolean }): ReactNode {
   switch (step) {
     case "team":
       return <StepTeam />;
     case "connect-code":
       return <StepConnectCode />;
     case "connect-computer":
-      return <StepConnectComputer />;
+      return <StepConnectComputer initialStuck={connectStuck} />;
     case "create-agent":
       return <StepCreateAgent />;
     case "kickoff":
@@ -804,14 +891,18 @@ function WizardScenarioView({ spec, role }: { spec: WizardSpec; role: Role }) {
   const [treeMode, setTreeMode] = useState<TreeMode>(init.treeMode ?? "new");
   const [treeUrl, setTreeUrl] = useState<string>(init.treeUrl ?? "");
   const [treeAutoInitDone, setTreeAutoInitDone] = useState<boolean>(init.treeAutoInitDone ?? false);
+  // Back the injected computer's runtime selection with local state so the
+  // single-select runtime pills actually switch when clicked.
+  const [selectedRuntime, setSelectedRuntime] = useState<string | null>(init.computer?.selectedRuntime ?? null);
 
   const queryClient = useMemo(
     () => new QueryClient({ defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } } }),
     [],
   );
 
+  const base = baseFlow(path);
   const flow: OnboardingFlowValue = {
-    ...baseFlow(path),
+    ...base,
     ...init,
     path,
     sequence,
@@ -829,12 +920,15 @@ function WizardScenarioView({ spec, role }: { spec: WizardSpec; role: Role }) {
     setTreeUrl,
     treeAutoInitDone,
     markTreeAutoInitDone: () => setTreeAutoInitDone(true),
+    // Override the injected computer's runtime selection with the stateful
+    // pair so clicking a runtime pill re-renders with the new choice.
+    computer: init.computer ? { ...init.computer, selectedRuntime, setSelectedRuntime } : base.computer,
   };
 
   return (
     <QueryClientProvider client={queryClient}>
       <OnboardingFlowContext.Provider value={flow}>
-        <OnboardingShell>{spec.body ?? <StepBody step={spec.step} />}</OnboardingShell>
+        <OnboardingShell>{spec.body ?? <StepBody step={spec.step} connectStuck={spec.connectStuck} />}</OnboardingShell>
       </OnboardingFlowContext.Provider>
     </QueryClientProvider>
   );

--- a/packages/web/src/pages/onboarding/__tests__/shell-rail-team-dom.test.tsx
+++ b/packages/web/src/pages/onboarding/__tests__/shell-rail-team-dom.test.tsx
@@ -150,7 +150,7 @@ describe("onboarding shell and team step", () => {
     expect(container.textContent).toContain("First Tree");
     // config step → top segmented progress shows position (admin has 3)
     expect(container.textContent).toContain("Step 1 of 3");
-    expect(container.textContent).toContain("Connect your computer");
+    expect(container.textContent).toContain("Set up where your agent runs");
     expect(container.textContent).toContain("Step body");
 
     await click(

--- a/packages/web/src/pages/onboarding/copy.ts
+++ b/packages/web/src/pages/onboarding/copy.ts
@@ -50,7 +50,7 @@ export const STEP_COPY: Record<StepId, StepCopy> = {
     // clearer than the beginner-softened "project". Role-framed and agent-centric,
     // matching the connect-computer title; NOT "your agent's repo" (the repo
     // belongs to the user/team, the agent only works on it).
-    title: "Connect the repo your agent works on",
+    title: "Connect the repos your agent works on",
     // Answer "why connect a repo?" in value terms (the issue-834 UR gap): connecting
     // isn't just access — it's how the agent learns the repo and turns it
     // into the team's shared context. The second clause reassures the user the
@@ -138,11 +138,8 @@ export const COPY = {
     phases: ["Connect GitHub", "Pick repos"],
     cta: "Install on GitHub",
     waiting: "Waiting for GitHub…",
-    connected: "Connected",
-    /** Richer connected confirmation once repos are known: org (when there's a
-        single owner) + count, e.g. "Connected to acme · 3 repos". */
-    connectedSummary: (count: number, org: string | null) =>
-      `Connected${org ? ` to ${org}` : ""} · ${count} repo${count === 1 ? "" : "s"}`,
+    // (connected status row removed — the PhaseNav's "✓ Connect GitHub" already
+    // signals the connection, and the repo picker shows the org + repos.)
     pickProject: "Which repos should your agent work on?",
     /** Loading state for the repo picker (was hardcoded in the step). */
     loading: "Loading your repos…",
@@ -166,17 +163,16 @@ export const COPY = {
     continueNoProject: "Continue without a repo",
     pickHint: "Pick one or more repos for your agent — or continue without any for now.",
     /**
-     * Non-owner hint shown under the primary CTA. We deliberately don't hand
-     * out a copy-the-install-link button — GitHub's install URL is bound to
-     * a per-browser `oauth_state_nonce` cookie, so a link opened in someone
-     * else's browser would fail the callback. GitHub already routes
-     * non-owner installs through an owner-approval flow, so the right
-     * advice is to click Install anyway and let GitHub handle the ask.
+     * Shown under the CTA/Skip row: the install caveat (who can install) merged
+     * with the skip reassurance into one muted line. `emphasis` renders bold so
+     * the gating fact ("a GitHub org owner") stands out. The Request-instead-of-
+     * Install mechanic lives in Need help? (step 3), keeping this one tight line.
      */
-    notOwnerHint:
-      "Only a GitHub org owner can install First Tree. If you're not one, GitHub shows Request instead of Install — sending it asks an owner to approve.",
-    /** Connected but GitHub access lacks repo scope — explain; the link carries the verb. */
-    scopeMissing: "Couldn't see your repos — First Tree needs permission to read them.",
+    notOwnerHint: {
+      pre: "Only ",
+      emphasis: "a GitHub org owner",
+      post: " can install First Tree — if that's not you, clicking Install asks an owner to approve. You can skip and connect anytime from Settings.",
+    },
     /**
      * Replaces the "Waiting for GitHub…" status once the user returns from the
      * install dialog without an installation (postAttemptStuck). Guidance-y, so
@@ -205,19 +201,7 @@ export const COPY = {
     troubleshootTitle: "If it didn't connect:",
     troubleshootBody:
       "Make sure you clicked Install (or Request) on GitHub. If you're not a GitHub org owner, an owner has to approve it — once they do, it connects here automatically.",
-    /**
-     * Calm, always-visible reassurance shown beside the skip affordance so
-     * the choice is *informed before* clicking. Replaces the old confirm
-     * panel (a "Skip connecting code?" title + consequence bullets +
-     * Keep-connecting / Skip-anyway), which confirmshamed a legitimate,
-     * fully-recoverable choice — re-asking the question, leading with a
-     * teammates-will-hit-errors scare, and under-weighting the real exit.
-     * The "agent starts with just an intro" consequence is already stated
-     * honestly on the kickoff no-project screen, so one recovery line is
-     * enough here; the team-level consequence (invitees need the install)
-     * is caught gracefully by the invitee no-installation screen.
-     */
-    skipReassure: "You can connect a repo anytime from Settings.",
+    // (skipReassure merged into `notOwnerHint` — one muted line under the row.)
   },
   /** connect-computer states */
   connectComputer: {

--- a/packages/web/src/pages/onboarding/copy.ts
+++ b/packages/web/src/pages/onboarding/copy.ts
@@ -1,10 +1,15 @@
 /**
  * Every user-facing string in the onboarding flow, in one place.
  *
- * Goal: a complete beginner — someone who has never heard "repo", "runtime",
- * or "binding" — can read these and know what to do and why.
- * The vocabulary is deliberately small: "team", "your project", "a computer",
- * "agent", "Context Tree". We distinguish people from AI: human members are
+ * Goal: a near-beginner can read these and know what to do and why. The
+ * vocabulary is deliberately small: "team", "a computer", "agent", "Context
+ * Tree". Two implementation words are used DELIBERATELY where the step's
+ * audience already knows them and a softer word would be vaguer: "agent
+ * runtime" in connect-computer (the user just ran a terminal command) and
+ * "repo" in connect-computer's sibling connect-code / kickoff (they're
+ * installing a GitHub App — and "project" is ambiguous next to GitHub's own
+ * "Projects" feature). "binding" and other deep internals still never leak.
+ * We distinguish people from AI: human members are
  * "teammates", the AI workers are "agents" (matching the rest of the product;
  * "AI agent" on first mention, then just "agent"). "Context Tree" is the one
  * product concept we deliberately teach (with a plain-language gloss on first
@@ -38,15 +43,37 @@ export const STEP_COPY: Record<StepId, StepCopy> = {
     why: "Let's start with your team — where you, your teammates, and your AI agents work together.",
   },
   "connect-code": {
-    title: "Connect your code",
+    // "repo" (not "project"): this step connects a GitHub repository — the App
+    // install dialog and the picker below both show repos as owner/name, and
+    // "project" is ambiguous in a GitHub context (GitHub has a separate "Projects"
+    // feature). This audience installs a GitHub App + runs a CLI, so "repo" reads
+    // clearer than the beginner-softened "project". Role-framed and agent-centric,
+    // matching the connect-computer title; NOT "your agent's repo" (the repo
+    // belongs to the user/team, the agent only works on it).
+    title: "Connect the repo your agent works on",
     // Answer "why connect a repo?" in value terms (the issue-834 UR gap): connecting
-    // isn't just access — it's how the agent learns the project and turns it
+    // isn't just access — it's how the agent learns the repo and turns it
     // into the team's shared context. The second clause reassures the user the
     // agent won't touch their code unsupervised.
-    why: "Connect a project — your agent learns it and turns it into shared context. It never changes your code without your okay.",
+    why: "Connect a repo so your agent can learn your codebase and work on it. It never changes your code without your okay.",
   },
   "connect-computer": {
-    title: "Connect your computer",
+    // Names where the *agent* runs, not a bare "Connect your computer" — the
+    // latter read as an unmotivated demand ("why am I connecting my computer?")
+    // as the first hands-on step. We frame it around the agent (the flow's
+    // spine) but via its *place/role* ("where your agent runs"), not possession
+    // ("your agent's computer"): this step precedes create-agent, so a
+    // possessive would claim the agent before it exists. "Set up" (not "Connect"):
+    // the action is provisioning a machine — running a command, readying a runtime —
+    // not wiring it to something. We say "where your agent runs", NOT "the computer
+    // your agent runs on": the per-state subtitle already names the concrete noun
+    // ("…on a computer you pick. Run the command below.") and the screen visibly
+    // concerns a computer, so repeating it in the title is redundant and just makes
+    // the title the longest in the flow. Title carries the place/why; subtitle carries
+    // the concrete what. "runs" is plain English, deliberately not the banned
+    // implementation word "runtime"; rhymes with the connected subtitle "This is
+    // where your agent will run".
+    title: "Set up where your agent runs",
     // why is rendered per-state by StepConnectComputer (the "run the command
     // below" line is only true while waiting — once connected there's no
     // command shown, so a static shell subtitle would read as stale). The
@@ -54,10 +81,14 @@ export const STEP_COPY: Record<StepId, StepCopy> = {
     why: "",
   },
   "create-agent": {
-    // "an agent", not "your agent": it can be team-visible (see the Visibility
-    // choice), so "your" would over-claim private ownership. No `why` — the
-    // title + form are self-explanatory; a subtitle would only restate fields.
-    title: "Create an agent",
+    // "your first agent": warmer + a milestone framing that fits building out a team
+    // of agents ("first" implies more to come). We re-introduce "your" — earlier copy
+    // deliberately said "an agent" to avoid over-claiming private ownership (the agent
+    // can be team-visible) — but "first" reframes "your" as a creation milestone (the
+    // first one you make) rather than exclusive possession, which reads honestly even
+    // for a team-visible agent. NOT "your AI teammate": the vocabulary reserves
+    // "teammate" for humans and "agent" for AI. No `why` — title + form self-explain.
+    title: "Create your first agent",
     why: "",
   },
   kickoff: {
@@ -102,27 +133,28 @@ export const COPY = {
     // `STEP_COPY['connect-code'].why` verbatim and had no remaining
     // consumer after the connect-code step started reading from
     // STEP_COPY directly. Keep the why as the single source of truth.
-    cta: "Install First Tree on GitHub",
+    cta: "Install on GitHub",
     waiting: "Waiting for GitHub…",
     connected: "Connected",
-    pickProject: "Which projects should your agent work on?",
+    pickProject: "Which repos should your agent work on?",
+    /** Loading state for the repo picker (was hardcoded in the step). */
+    loading: "Loading your repos…",
     // The picker is sourced from the team's GitHub App installation grant, so
     // "your GitHub account" would be wrong — an empty list means the App was
     // connected but isn't granted any repos yet.
-    noRepos: "No projects are connected to your team's GitHub yet — add some on GitHub, or continue without one.",
+    noRepos: "No repos are shared with First Tree yet — add some on GitHub, or continue without one.",
     // Shown when the org-scoped repo list fails to load (502 upstream / 503
     // suspended etc.). The new installation-backed endpoint can return these,
     // and without this branch the failure was misrendered as an empty
-    // "no projects" list. The "Continue without a project" button below keeps
+    // "no projects" list. The "Continue without a repo" button below keeps
     // it from being a dead end.
-    loadFailed: "Couldn't load your team's projects. Try again in a moment — or continue without one.",
-    reconnect: "Reconnect GitHub with project access",
-    notConfigured:
-      "Code connection isn't set up here yet. You can continue now and connect a project later from Settings.",
-    notAdmin: "Only a team admin can connect code. Ask an admin to finish this, or continue for now.",
-    continueWithout: "Continue without connecting code",
-    continueNoProject: "Continue without a project",
-    pickHint: "Pick one or more projects for your agent — or continue without any for now.",
+    loadFailed: "Couldn't load your team's repos — continue without one for now.",
+    reconnect: "Reconnect GitHub with repo access",
+    notConfigured: "Connecting a repo isn't set up here yet — continue now and add one later from Settings.",
+    notAdmin: "Only a team admin can connect a repo. Ask an admin to finish this, or continue for now.",
+    continueWithout: "Continue without a repo",
+    continueNoProject: "Continue without a repo",
+    pickHint: "Pick one or more repos for your agent — or continue without any for now.",
     /**
      * Non-owner hint shown under the primary CTA. We deliberately don't hand
      * out a copy-the-install-link button — GitHub's install URL is bound to
@@ -132,24 +164,37 @@ export const COPY = {
      * advice is to click Install anyway and let GitHub handle the ask.
      */
     notOwnerHint:
-      "Only a GitHub org owner can connect your team's code. Not one? Installing sends them a request — continue now and connect it later.",
+      "Only a GitHub org owner can install First Tree. If you're not one, GitHub shows Request instead of Install — sending it asks an owner to approve.",
     /** Connected but GitHub access lacks repo scope — explain; the link carries the verb. */
-    scopeMissing: "Couldn't see your projects — your GitHub access is missing project read permission.",
+    scopeMissing: "Couldn't see your repos — First Tree needs permission to read them.",
     /**
      * Replaces the "Waiting for GitHub…" status once the user returns from the
      * install dialog without an installation (postAttemptStuck). Guidance-y, so
      * the auto-opened "Need help?" below isn't missed — not a flat "still
      * waiting" (which would contradict the help saying it didn't go through).
      */
-    stuckStatus: "Still not connected? The steps under Need help? can get you unstuck.",
+    stuckStatus: "Still not connected? The Need help? steps below can fix it.",
     /**
      * Troubleshooting shown inside the "Need help?" disclosure (alongside the
      * InstallGuide how-to), mirroring connect-computer. The disclosure
      * auto-opens when the user returns from GitHub without an installation, so
      * the title is state-neutral (it can also be opened proactively).
      */
-    troubleshootTitle: "If GitHub didn't add First Tree:",
-    troubleshootBody: "Click Install again — it'll ask an org owner to approve if you're not one.",
+    /** "Need help?" InstallGuide — a 3-beat visual flow + numbered how-to,
+        written to match GitHub's REAL App-install screen: choose where to
+        install → pick repo access (all / select) → click Install (or Request,
+        for non-owners) → auto-return. */
+    installFlow: ["Choose org", "Pick repos", "Install", "Back here"],
+    installFlowAria: "Flow: choose your org, pick repos, click Install on GitHub, then return to setup.",
+    installSteps: [
+      "Choose where to install First Tree — your team's GitHub org (or your account, if your repos live there).",
+      "Pick which repos it can access: all of them, or just the ones you choose.",
+      "Click Install. Not a GitHub org owner? The button says Request instead — an owner approves it.",
+      "GitHub sends you straight back here, and this page connects on its own.",
+    ],
+    troubleshootTitle: "If it didn't connect:",
+    troubleshootBody:
+      "Make sure you clicked Install (or Request) on GitHub. If you're not a GitHub org owner, an owner has to approve it — once they do, it connects here automatically.",
     /**
      * Calm, always-visible reassurance shown beside the skip affordance so
      * the choice is *informed before* clicking. Replaces the old confirm
@@ -162,7 +207,7 @@ export const COPY = {
      * enough here; the team-level consequence (invitees need the install)
      * is caught gracefully by the invitee no-installation screen.
      */
-    skipReassure: "You can connect code anytime from Settings.",
+    skipReassure: "You can connect a repo anytime from Settings.",
   },
   /** connect-computer states */
   connectComputer: {
@@ -170,13 +215,33 @@ export const COPY = {
     // command-pointing line only holds while waiting; once connected we swap
     // to a neutral confirmation so it doesn't tell the user to "run the
     // command below" when no command is shown.
-    whyWaiting: "Your agent does real work on a computer you pick. Run the command below.",
-    whyConnected: "This is where your agent will run.",
+    // "does its work" (not "does real work" / "gets work done"): answers "why
+    // connect a computer?" by naming the mechanism — the agent runs and does its
+    // work on the machine you pick. Stays general (the agent's work isn't only
+    // code: research, docs, Context Tree, tasks), so we avoid narrowing examples
+    // like "writes code". The trailing "to connect one" gives the bare command a
+    // purpose (closes the loop).
+    whyWaiting: "Your agent does its work on a computer you pick. Run the command below to connect one.",
+    whyConnected: "Your computer's connected — this is where your agent will run.",
     waiting: "Waiting for your computer…",
     connected: "connected",
     noRuntime:
-      "Your computer is connected, but it doesn't have an AI coding tool ready yet. Install one (like Claude Code) on that computer and sign in — then it'll show up here automatically.",
+      "Your computer is connected, but no agent runtime is ready yet. Install one (like Claude Code) on that computer and sign in — then it'll show up here automatically.",
     detecting: "Checking what's installed…",
+    /**
+     * Ready · exactly one runtime detected — nothing to choose, so name the
+     * tool and confirm. `name` is the friendly PROVIDER_LABEL (e.g. "Claude
+     * Code"). We say "runtime" deliberately here (and in `runtimesReady` /
+     * noRuntime): by this step the user has run a terminal command, so the
+     * precise word reads better than a vaguer "tool", and it stays consistent
+     * across all three runtime states.
+     */
+    runtimeReady: (name: string) => `${name} runtime is ready — your agent will use it.`,
+    /**
+     * Ready · two or more runtimes detected — state the count and prompt the
+     * user to pick which one powers the agent (a single-select list follows).
+     */
+    runtimesReady: (count: number) => `${count} agent runtimes are ready — pick which one runs your agent.`,
     stuckTitle: "Taking a while? A few common reasons:",
     stuckReasons: [
       "If you saw “command not found”, your computer needs Node.js first — it's a free install. Get it, then run the command again.",
@@ -199,12 +264,26 @@ export const COPY = {
   /** create-agent states */
   createAgent: {
     nameLabel: "What should we call your agent?",
-    creating: "Setting up your agent…",
-    creatingHint: "Usually about 10 seconds",
-    timeoutTitle: "This is taking longer than expected.",
+    // "Bringing your agent online…" (not "Setting up…"): the step creates the
+    // agent then polls until it comes online, and "set up" echoed step1's title
+    // ("Set up where your agent runs"). Pairs with timeout's "isn't online yet".
+    creating: "Bringing your agent online…",
+    creatingHint: "This usually takes a few seconds.",
+    // Timeout: created but didn't report online within 30s. ONE paragraph, no
+    // separate bold title — the shell already renders the step h1 ("Create your
+    // first agent"), so a second heading read as a stacked double-title. Leads
+    // with the situation, then causes + fix. "agent runtime" matches connect-computer.
     timeoutBody:
-      "Your agent was created, but it hasn't come online yet. The computer it runs on may have gone to sleep or lost its connection, or its AI coding tool couldn't start. Check that computer, then try again.",
+      "Your agent isn't online yet — it was created, but the computer it runs on may have gone to sleep, lost its connection, or its agent runtime didn't start. Check that computer, then try again.",
     retry: "Try again",
+    /** Shown on the form when the computer isn't connected (Create is disabled).
+        Rendered as one line with an inline "reconnect it" link (→ connect-computer)
+        rather than a separate orphaned link line. Auto-clears on reconnect. */
+    computerDisconnected: {
+      pre: "Your computer isn't connected — ",
+      link: "reconnect it",
+      post: " to create your agent.",
+    },
   },
   /** kickoff / "Start" states (title/why are per-state, rendered by the step) */
   kickoff: {
@@ -229,15 +308,16 @@ export const COPY = {
     // admin — no project connected
     noProjectTitle: "Start your agent",
     noProjectBody:
-      "No project connected, so your agent will start with a quick intro. Connect a project later from Settings to give it real context.",
-    // invitee — team's tree is ready, pick a project
-    inviteePickerTitle: "Pick a project to work on",
-    inviteePickerWhy: "Your team's set up — pick which of your own projects your agent should help with.",
+      "No repo connected, so your agent will start with a quick intro. Connect a repo later from Settings to give it real context.",
+    // invitee — team's tree is ready, pick a repo
+    inviteePickerTitle: "Pick a repo to work on",
+    inviteePickerWhy: "Your team's set up — pick which of your own repos your agent should help with.",
+    inviteePickerLoading: "Loading your repos…",
     inviteePickerEmpty:
-      "No projects found on your GitHub account yet. You can continue without one and add later from Settings.",
-    inviteePickerScopeMissing: "Couldn't see your projects — your GitHub access is missing project read permission.",
-    inviteePickerNetworkError: "Couldn't load your projects. Try again in a moment.",
-    inviteeContinueNoProject: "Continue without a project",
+      "No repos found on your GitHub account yet. You can continue without one and add later from Settings.",
+    inviteePickerScopeMissing: "Couldn't see your repos — First Tree needs permission to read them.",
+    inviteePickerNetworkError: "Couldn't load your repos. Try again in a moment.",
+    inviteeContinueNoProject: "Continue without a repo",
     /** Shown atop confirm / picker so invitee knows where the work lands. */
     treeLabel: "Context Tree",
     // Launch CTA — per-substate so it names what's actually starting:
@@ -256,18 +336,18 @@ export const COPY = {
   invitee: {
     waitingTitle: "Waiting for your team to set up",
     waitingBody:
-      "Your team's admin is still setting up projects and a Context Tree. This page updates on its own as soon as they're done.",
+      "Your team's admin is still setting up repos and a Context Tree. This page updates on its own as soon as they're done.",
     waitingStatus: "Watching for updates…",
     // NEW: admin set up tree but never connected the GitHub App. Without
     // an installation, every git op the agent runs will 403, so we hard-stop
     // the invitee here rather than letting them sail into the picker.
-    noInstallTitle: "Almost there — your team's code isn't connected yet",
+    noInstallTitle: "Almost there — your team's repo isn't connected yet",
     noInstallBody:
-      "Your team's admin set up the Context Tree but hasn't connected code on GitHub yet. Your agent needs that connection to do real work.",
+      "Your team's admin set up the Context Tree but hasn't connected a repo on GitHub yet. Your agent needs that connection to do real work.",
     noInstallStatus: "Watching for the connection…",
-    noInstallShareIntro: "Send this link so your admin can connect your team's code:",
+    noInstallShareIntro: "Send this link so your admin can connect your team's repo:",
     confirmTitle: "Your team is ready",
-    confirmBody: "Your team set up its projects and Context Tree. Pick what your agent should work on.",
+    confirmBody: "Your team set up its repos and Context Tree. Pick what your agent should work on.",
     // Bailout on the waiting / no-installation screens — proceed with your
     // own agent now instead of waiting on the team. Framed positively around
     // the agent (was "Start chatting anyway"; "anyway" read as defiant/
@@ -278,7 +358,7 @@ export const COPY = {
   errors: {
     generic: "Something went wrong. Try again in a moment.",
     chatFailed: "Couldn't start the first task. Try again.",
-    agentFailed: "Couldn't create your agent. Try again.",
+    agentFailed: "Couldn't create your agent — please try again.",
     noAgent: "We couldn't find your agent. Go back a step and create one.",
   },
 } as const;

--- a/packages/web/src/pages/onboarding/copy.ts
+++ b/packages/web/src/pages/onboarding/copy.ts
@@ -133,6 +133,9 @@ export const COPY = {
     // `STEP_COPY['connect-code'].why` verbatim and had no remaining
     // consumer after the connect-code step started reading from
     // STEP_COPY directly. Keep the why as the single source of truth.
+    /** The step's two sub-phases, shown as an in-step indicator so the user can
+        see it's "connect, then pick" and where they are. */
+    phases: ["Connect GitHub", "Pick repos"],
     cta: "Install on GitHub",
     waiting: "Waiting for GitHub…",
     connected: "Connected",

--- a/packages/web/src/pages/onboarding/copy.ts
+++ b/packages/web/src/pages/onboarding/copy.ts
@@ -173,13 +173,12 @@ export const COPY = {
       emphasis: "a GitHub org owner",
       post: " can install First Tree — if that's not you, clicking Install asks an owner to approve. You can skip and connect anytime from Settings.",
     },
-    /**
-     * Replaces the "Waiting for GitHub…" status once the user returns from the
-     * install dialog without an installation (postAttemptStuck). Guidance-y, so
-     * the auto-opened "Need help?" below isn't missed — not a flat "still
-     * waiting" (which would contradict the help saying it didn't go through).
-     */
-    stuckStatus: "Still not connected? The Need help? steps below can fix it.",
+    /** Explicit "abandon the in-flight attempt and re-mint" action, shown under
+        the "Waiting for GitHub…" status. Retry is deliberate (not an
+        auto-unlocked button) because a fresh install URL overwrites the
+        `oauth_state_nonce` cookie — re-minting while the first install tab is
+        mid-flow would fail its callback. */
+    restartInstall: "Start over",
     /**
      * Troubleshooting shown inside the "Need help?" disclosure (alongside the
      * InstallGuide how-to), mirroring connect-computer. The disclosure

--- a/packages/web/src/pages/onboarding/copy.ts
+++ b/packages/web/src/pages/onboarding/copy.ts
@@ -136,6 +136,10 @@ export const COPY = {
     cta: "Install on GitHub",
     waiting: "Waiting for GitHub…",
     connected: "Connected",
+    /** Richer connected confirmation once repos are known: org (when there's a
+        single owner) + count, e.g. "Connected to acme · 3 repos". */
+    connectedSummary: (count: number, org: string | null) =>
+      `Connected${org ? ` to ${org}` : ""} · ${count} repo${count === 1 ? "" : "s"}`,
     pickProject: "Which repos should your agent work on?",
     /** Loading state for the repo picker (was hardcoded in the step). */
     loading: "Loading your repos…",
@@ -150,8 +154,11 @@ export const COPY = {
     // it from being a dead end.
     loadFailed: "Couldn't load your team's repos — continue without one for now.",
     reconnect: "Reconnect GitHub with repo access",
-    notConfigured: "Connecting a repo isn't set up here yet — continue now and add one later from Settings.",
-    notAdmin: "Only a team admin can connect a repo. Ask an admin to finish this, or continue for now.",
+    // Collapsed the two rare, not-user-fixable install errors (App not set up on
+    // this server / caller lacks permission) into one recoverable message — the
+    // action is the same either way (continue, set up later), so two separate
+    // screens added surface without adding clarity.
+    cantConnect: "Couldn't connect a repo here right now — continue now and add one later from Settings.",
     continueWithout: "Continue without a repo",
     continueNoProject: "Continue without a repo",
     pickHint: "Pick one or more repos for your agent — or continue without any for now.",

--- a/packages/web/src/pages/onboarding/github-connected.tsx
+++ b/packages/web/src/pages/onboarding/github-connected.tsx
@@ -1,0 +1,48 @@
+import { Check } from "lucide-react";
+import { useEffect } from "react";
+
+/**
+ * Landing page for the connect-code install popup. The connect-code step opens
+ * the GitHub App install in a new tab with `next=/onboarding/connected`, so
+ * GitHub's callback lands the popup here. We confirm and auto-close the tab (it
+ * was script-opened, so `window.close()` is allowed); the original setup tab
+ * detects the new installation via its poll and advances on its own. If the
+ * browser refuses to close the tab, the message tells the user to close it.
+ *
+ * Public route (no auth gate): it does nothing sensitive, and gating it would
+ * risk the onboarding redirect bouncing this throwaway tab elsewhere.
+ */
+export function GithubConnectedPage() {
+  useEffect(() => {
+    // A brief beat so the confirmation registers, then close.
+    const timer = window.setTimeout(() => window.close(), 900);
+    return () => window.clearTimeout(timer);
+  }, []);
+
+  return (
+    <div
+      className="flex h-screen flex-col items-center justify-center text-center bg-background"
+      style={{ gap: "var(--sp-3)", padding: "var(--sp-6)" }}
+    >
+      <span
+        aria-hidden="true"
+        className="inline-flex items-center justify-center"
+        style={{
+          width: "var(--sp-10)",
+          height: "var(--sp-10)",
+          borderRadius: "var(--radius-full)",
+          background: "color-mix(in oklch, var(--success) 16%, transparent)",
+          color: "var(--success)",
+        }}
+      >
+        <Check className="h-5 w-5" />
+      </span>
+      <p className="text-subtitle font-semibold" style={{ margin: 0, color: "var(--fg)" }}>
+        Connected
+      </p>
+      <p className="text-body" style={{ margin: 0, color: "var(--fg-3)", maxWidth: "22rem" }}>
+        You can close this tab — setup continues in your other tab.
+      </p>
+    </div>
+  );
+}

--- a/packages/web/src/pages/onboarding/github-connected.tsx
+++ b/packages/web/src/pages/onboarding/github-connected.tsx
@@ -21,6 +21,7 @@ export function GithubConnectedPage() {
 
   return (
     <div
+      role="status"
       className="flex h-screen flex-col items-center justify-center text-center bg-background"
       style={{ gap: "var(--sp-3)", padding: "var(--sp-6)" }}
     >

--- a/packages/web/src/pages/onboarding/guides.tsx
+++ b/packages/web/src/pages/onboarding/guides.tsx
@@ -1,5 +1,5 @@
 import { Check, ChevronRight } from "lucide-react";
-import type { ReactNode } from "react";
+import { Fragment, type ReactNode } from "react";
 import { COPY } from "./copy.js";
 
 /**
@@ -217,7 +217,7 @@ export function InstallGuide() {
     <div>
       <div
         role="img"
-        aria-label="Flow: choose your projects on GitHub, click install, then return to setup."
+        aria-label={COPY.connectCode.installFlowAria}
         className="flex items-center"
         style={{
           gap: "var(--sp-2)",
@@ -228,19 +228,20 @@ export function InstallGuide() {
           background: "color-mix(in oklch, var(--bg-raised) 40%, transparent)",
         }}
       >
-        <FlowChip label="Choose your projects" />
-        <ChevronRight className="h-3.5 w-3.5" style={{ color: "var(--fg-4)", flexShrink: 0 }} aria-hidden="true" />
-        <FlowChip label="Click Install" />
-        <ChevronRight className="h-3.5 w-3.5" style={{ color: "var(--fg-4)", flexShrink: 0 }} aria-hidden="true" />
-        <FlowChip label="Back here automatically" />
+        {COPY.connectCode.installFlow.map((label, i) => (
+          <Fragment key={label}>
+            {i > 0 && (
+              <ChevronRight
+                className="h-3.5 w-3.5"
+                style={{ color: "var(--fg-4)", flexShrink: 0 }}
+                aria-hidden="true"
+              />
+            )}
+            <FlowChip label={label} />
+          </Fragment>
+        ))}
       </div>
-      <GuideSteps
-        steps={[
-          "GitHub asks which projects First Tree may access — pick yours.",
-          "Click the green Install button.",
-          "GitHub sends you straight back here to keep going.",
-        ]}
-      />
+      <GuideSteps steps={COPY.connectCode.installSteps} />
     </div>
   );
 }

--- a/packages/web/src/pages/onboarding/steps/step-connect-code.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-connect-code.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
-import { ArrowRight, Github } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { ArrowRight, Check, ChevronRight, Github } from "lucide-react";
+import { Fragment, useEffect, useRef, useState } from "react";
 import { ApiError } from "../../../api/client.js";
 import { listOrgGithubRepos } from "../../../api/github.js";
 import { getGithubAppInstallation, getGithubAppInstallUrl } from "../../../api/github-app.js";
@@ -157,6 +157,7 @@ export function StepConnectCode() {
   if (!installed) {
     return (
       <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
+        <PhaseNav phase="connect" />
         {/* Intro is now embedded into the step `why` via STEP_COPY — no
             separate reassurance paragraph (folded into why) and no
             "alreadyInstalledHint" (the share-link affordance below covers
@@ -232,6 +233,7 @@ export function StepConnectCode() {
   // ── Connected — pick the project ─────────────────────────────────────
   return (
     <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
+      <PhaseNav phase="pick" />
       <StatusRow state="ok" label={connectedLabel} />
 
       <div className="flex flex-col" style={{ gap: "var(--sp-2)" }}>
@@ -278,6 +280,64 @@ export function StepConnectCode() {
           <ArrowRight className="h-4 w-4" />
         </Button>
       </div>
+    </div>
+  );
+}
+
+/**
+ * In-step two-phase indicator (Connect GitHub → Pick repos) so the user can see
+ * this step is two parts and where they are. Numbered/checked to mirror the
+ * GuideSteps badges; distinct from the shell's overall "Step N of M" (no number
+ * counter here, to avoid a competing step count).
+ */
+function PhaseNav({ phase }: { phase: "connect" | "pick" }) {
+  const activeIndex = phase === "connect" ? 0 : 1;
+  return (
+    <div className="flex items-center" style={{ gap: "var(--sp-2)" }}>
+      {COPY.connectCode.phases.map((label, i) => {
+        const state = i < activeIndex ? "done" : i === activeIndex ? "active" : "todo";
+        return (
+          <Fragment key={label}>
+            {i > 0 && (
+              <ChevronRight
+                className="h-3.5 w-3.5"
+                style={{ color: "var(--fg-4)", flexShrink: 0 }}
+                aria-hidden="true"
+              />
+            )}
+            <span className="inline-flex items-center text-label" style={{ gap: "var(--sp-1_5)" }}>
+              <span
+                aria-hidden="true"
+                className="mono inline-flex items-center justify-center"
+                style={{
+                  width: "var(--sp-4)",
+                  height: "var(--sp-4)",
+                  flexShrink: 0,
+                  borderRadius: "var(--radius-full)",
+                  background:
+                    state === "active"
+                      ? "var(--primary)"
+                      : state === "done"
+                        ? "color-mix(in oklch, var(--primary) 14%, transparent)"
+                        : "transparent",
+                  border: state === "todo" ? "var(--hairline) solid var(--border-strong)" : "none",
+                  color: state === "active" ? "var(--primary-on)" : "var(--primary)",
+                }}
+              >
+                {state === "done" ? <Check className="h-3 w-3" /> : i + 1}
+              </span>
+              <span
+                style={{
+                  color: state === "active" ? "var(--fg)" : "var(--fg-4)",
+                  fontWeight: state === "active" ? 600 : 400,
+                }}
+              >
+                {label}
+              </span>
+            </span>
+          </Fragment>
+        );
+      })}
     </div>
   );
 }

--- a/packages/web/src/pages/onboarding/steps/step-connect-code.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-connect-code.tsx
@@ -34,7 +34,6 @@ export function StepConnectCode() {
   const { organizationId, goNext, selectedRepoUrls, setSelectedRepoUrls } = useOnboardingFlow();
   const [installError, setInstallError] = useState<"not_configured" | "not_admin" | "generic" | null>(null);
   const [redirecting, setRedirecting] = useState(false);
-  const [postAttemptStuck, setPostAttemptStuck] = useState(false);
   // Whether the user has actually kicked off an install (this tab). We only
   // show the "Waiting for GitHub…" status once they have — before the first
   // click there's nothing to wait for, and a pre-action "Waiting…" reads as
@@ -54,32 +53,18 @@ export function StepConnectCode() {
 
   const installed = !!installQuery.data;
 
-  // Detect "user clicked Install, went to GitHub, came back without an
-  // install row". If we observe the attempt marker but still no installation
-  // a few seconds after the query has settled, surface a soft hint with
-  // recovery options. (Polling continues, so a slow webhook still wins.)
+  // In the new-tab flow the original tab never navigates away — it just keeps
+  // polling (above) and advances once the installation row appears. So we can't
+  // infer "stuck" from elapsed time: a timer would fire mid-install, and
+  // re-enabling the CTA on it let a second mint overwrite the first attempt's
+  // `oauth_state_nonce` cookie and break its callback. Recovery is instead an
+  // explicit, user-initiated "Start over" (handleStartOver). Here we only clear
+  // the attempt marker once the install actually lands.
   useEffect(() => {
-    if (installed) {
-      window.sessionStorage.removeItem(INSTALL_ATTEMPT_KEY);
-      setPostAttemptStuck(false);
-      return;
-    }
-    if (typeof window === "undefined") return;
-    const attempted = window.sessionStorage.getItem(INSTALL_ATTEMPT_KEY);
-    if (!attempted) return;
-    if (installQuery.isLoading) return;
-    // Give the post-redirect webhook a moment before crying foul.
-    const t = window.setTimeout(() => setPostAttemptStuck(true), 5000);
-    return () => window.clearTimeout(t);
-  }, [installed, installQuery.isLoading]);
+    if (installed) window.sessionStorage.removeItem(INSTALL_ATTEMPT_KEY);
+  }, [installed]);
 
-  // "Need help?" auto-opens when the user returns from GitHub without an
-  // install — same "stuck → help opens" behavior as connect-computer (just
-  // triggered by a failed return rather than a timer).
   const [helpOpen, setHelpOpen] = useState(false);
-  useEffect(() => {
-    if (postAttemptStuck) setHelpOpen(true);
-  }, [postAttemptStuck]);
 
   // Team-by-default: the admin picks from the team's *org* code, sourced
   // from the GitHub App installation's repo grant (not the admin's personal
@@ -114,9 +99,6 @@ export function StepConnectCode() {
   const handleConnect = async (): Promise<void> => {
     if (!organizationId) return;
     setInstallError(null);
-    // Re-arm the "waiting" window on a retry so the stuck hint and the CTA
-    // disable behave as if this were a fresh attempt.
-    setPostAttemptStuck(false);
     setRedirecting(true);
     // Open the tab synchronously inside the click gesture so the browser doesn't
     // treat the post-await window.open as a blocked popup; fill its location once
@@ -124,8 +106,14 @@ export function StepConnectCode() {
     // tab and lands it on /onboarding/connected to auto-close, while this tab
     // keeps polling and advances on its own.
     const installTab = window.open("", "_blank");
+    // The post-install landing differs by path: a real popup (has an opener)
+    // lands on /onboarding/connected to auto-close; but if the popup was blocked
+    // we redirect THIS tab, so it must return to the wizard itself (/onboarding)
+    // — sending it to /onboarding/connected would strand the user on a "close
+    // this tab — setup continues in your other tab" screen with no other tab.
+    const postInstallNext = installTab ? "/onboarding/connected" : "/onboarding";
     try {
-      const url = await getGithubAppInstallUrl(organizationId, "/onboarding/connected");
+      const url = await getGithubAppInstallUrl(organizationId, postInstallNext);
       window.sessionStorage.setItem(INSTALL_ATTEMPT_KEY, String(Date.now()));
       setAttempted(true);
       if (installTab) installTab.location.href = url;
@@ -147,6 +135,16 @@ export function StepConnectCode() {
   const handleSkip = (): void => {
     window.sessionStorage.removeItem(INSTALL_ATTEMPT_KEY);
     goNext();
+  };
+
+  // Explicit, user-initiated retry: abandon the in-flight attempt and re-enable
+  // the CTA for a fresh mint. Deliberate by design — a new install URL
+  // overwrites the `oauth_state_nonce` cookie, so this must be a conscious
+  // "the GitHub tab didn't work, start fresh", never an auto-unlocked re-click.
+  const handleStartOver = (): void => {
+    window.sessionStorage.removeItem(INSTALL_ATTEMPT_KEY);
+    setAttempted(false);
+    setInstallError(null);
   };
 
   const toggleRepo = (cloneUrl: string): void => {
@@ -180,14 +178,15 @@ export function StepConnectCode() {
                 footer. Skip goes straight through (no confirm gate); the
                 muted reassurance line below keeps the choice informed. */}
             <div className="flex items-center" style={{ gap: "var(--sp-4)", flexWrap: "wrap" }}>
-              {/* Disable while a launch is in flight AND during the post-launch
-                  "waiting" window, so a second click can't open another install
-                  tab / re-mint. Re-enable once we detect the user came back
-                  without an install (postAttemptStuck) so they can retry. */}
+              {/* Lock the CTA once an attempt is in flight. The original tab
+                  never navigates away here, so a second mint would overwrite the
+                  first attempt's `oauth_state_nonce` cookie and break its
+                  callback — retry is the explicit "Start over" below, never a
+                  timed auto-unlock. */}
               <Button
                 type="button"
                 onClick={() => void handleConnect()}
-                disabled={redirecting || (attempted && !postAttemptStuck) || !organizationId}
+                disabled={redirecting || attempted || !organizationId}
               >
                 <Github className="h-4 w-4" />
                 {COPY.connectCode.cta}
@@ -211,15 +210,22 @@ export function StepConnectCode() {
               </FlowHint>
             )}
             {/* Status only after the user has actually started an install:
-                before the first click there's nothing to wait for, so showing
-                "Waiting for GitHub…" up front reads as "waiting for what?".
-                Once they come back without an install, a flat "Waiting…" would
-                contradict the auto-opened help that says it didn't go through —
-                swap to a guidance line that points there. */}
-            {postAttemptStuck ? (
-              <FlowHint>{COPY.connectCode.stuckStatus}</FlowHint>
-            ) : attempted ? (
-              <StatusRow state="waiting" label={COPY.connectCode.waiting} />
+                before the first click there's nothing to wait for. The original
+                tab keeps polling and advances on its own once the install lands;
+                if the GitHub tab didn't work, "Start over" re-mints (the only
+                safe way to retry — see the CTA-lock note above). */}
+            {attempted ? (
+              <div className="flex flex-col" style={{ gap: "var(--sp-1)" }}>
+                <StatusRow state="waiting" label={COPY.connectCode.waiting} />
+                <Button
+                  type="button"
+                  variant="link"
+                  className="h-auto self-start p-0 text-label"
+                  onClick={handleStartOver}
+                >
+                  {COPY.connectCode.restartInstall}
+                </Button>
+              </div>
             ) : null}
 
             <ShowMeHow open={helpOpen} onToggle={setHelpOpen}>

--- a/packages/web/src/pages/onboarding/steps/step-connect-code.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-connect-code.tsx
@@ -114,6 +114,9 @@ export function StepConnectCode() {
   const handleConnect = async (): Promise<void> => {
     if (!organizationId) return;
     setInstallError(null);
+    // Re-arm the "waiting" window on a retry so the stuck hint and the CTA
+    // disable behave as if this were a fresh attempt.
+    setPostAttemptStuck(false);
     setRedirecting(true);
     // Open the tab synchronously inside the click gesture so the browser doesn't
     // treat the post-await window.open as a blocked popup; fill its location once
@@ -177,7 +180,15 @@ export function StepConnectCode() {
                 footer. Skip goes straight through (no confirm gate); the
                 muted reassurance line below keeps the choice informed. */}
             <div className="flex items-center" style={{ gap: "var(--sp-4)", flexWrap: "wrap" }}>
-              <Button type="button" onClick={() => void handleConnect()} disabled={redirecting || !organizationId}>
+              {/* Disable while a launch is in flight AND during the post-launch
+                  "waiting" window, so a second click can't open another install
+                  tab / re-mint. Re-enable once we detect the user came back
+                  without an install (postAttemptStuck) so they can retry. */}
+              <Button
+                type="button"
+                onClick={() => void handleConnect()}
+                disabled={redirecting || (attempted && !postAttemptStuck) || !organizationId}
+              >
                 <Github className="h-4 w-4" />
                 {COPY.connectCode.cta}
               </Button>

--- a/packages/web/src/pages/onboarding/steps/step-connect-code.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-connect-code.tsx
@@ -11,7 +11,7 @@ import { InstallGuide, InstallTroubleshooting, ShowMeHow } from "../guides.js";
 import { useOnboardingFlow } from "../onboarding-flow.js";
 
 /**
- * Session marker — set when the user clicks "Install First Tree on GitHub"
+ * Session marker — set when the user clicks "Install on GitHub"
  * so we can detect "came back without an install" on the next render.
  * Cleared once an install is observed or the user skips. Per-tab so we
  * never confuse a different login attempt's state.
@@ -235,7 +235,7 @@ export function StepConnectCode() {
           </FlowHint>
         ) : reposQuery.isLoading ? (
           <p className="text-label" style={{ margin: 0, color: "var(--fg-4)" }}>
-            Loading your projects…
+            {COPY.connectCode.loading}
           </p>
         ) : loadFailed ? (
           <FlowHint tone="error" role="alert">

--- a/packages/web/src/pages/onboarding/steps/step-connect-code.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-connect-code.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { ArrowRight, Github } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { ApiError } from "../../../api/client.js";
 import { listOrgGithubRepos } from "../../../api/github.js";
 import { getGithubAppInstallation, getGithubAppInstallUrl } from "../../../api/github-app.js";
@@ -97,6 +97,28 @@ export function StepConnectCode() {
   const loadFailed = !!reposQuery.error && !scopeMissing;
   const hasPickableRepos = !reposQuery.error && (reposQuery.data?.length ?? 0) > 0;
 
+  // Default the picker to every granted repo so the user doesn't re-pick what
+  // they just granted on GitHub (they can narrow by unchecking). One-shot when
+  // repos first load — after that we never fight a deliberate "none".
+  const preselectedRef = useRef(false);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: one-shot on first repo load; reads selection at fire time
+  useEffect(() => {
+    if (preselectedRef.current) return;
+    const loaded = reposQuery.data;
+    if (!loaded || loaded.length === 0) return;
+    preselectedRef.current = true;
+    if (selectedRepoUrls.length === 0) setSelectedRepoUrls(loaded.map((r) => r.cloneUrl));
+  }, [reposQuery.data]);
+
+  // Connected confirmation: org (when all repos share one owner) + count.
+  const grantedRepos = reposQuery.data ?? [];
+  const grantedOwners = [...new Set(grantedRepos.map((r) => r.fullName.split("/")[0] ?? ""))];
+  const grantedOrg = grantedOwners.length === 1 ? grantedOwners[0] || null : null;
+  const connectedLabel =
+    grantedRepos.length > 0
+      ? COPY.connectCode.connectedSummary(grantedRepos.length, grantedOrg)
+      : COPY.connectCode.connected;
+
   const handleConnect = async (): Promise<void> => {
     if (!organizationId) return;
     setInstallError(null);
@@ -140,14 +162,9 @@ export function StepConnectCode() {
             "alreadyInstalledHint" (the share-link affordance below covers
             the same recovery path more clearly). */}
 
-        {installError === "not_configured" ? (
+        {installError === "not_configured" || installError === "not_admin" ? (
           <>
-            <FlowHint>{COPY.connectCode.notConfigured}</FlowHint>
-            <ContinueWithout onClick={goNext} />
-          </>
-        ) : installError === "not_admin" ? (
-          <>
-            <FlowHint>{COPY.connectCode.notAdmin}</FlowHint>
+            <FlowHint>{COPY.connectCode.cantConnect}</FlowHint>
             <ContinueWithout onClick={goNext} />
           </>
         ) : (
@@ -215,7 +232,7 @@ export function StepConnectCode() {
   // ── Connected — pick the project ─────────────────────────────────────
   return (
     <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
-      <StatusRow state="ok" label={COPY.connectCode.connected} />
+      <StatusRow state="ok" label={connectedLabel} />
 
       <div className="flex flex-col" style={{ gap: "var(--sp-2)" }}>
         <p className="text-label font-medium" style={{ margin: 0, color: "var(--fg-2)" }}>

--- a/packages/web/src/pages/onboarding/steps/step-connect-code.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-connect-code.tsx
@@ -89,12 +89,13 @@ export function StepConnectCode() {
     queryFn: () => listOrgGithubRepos(organizationId ?? ""),
     enabled: installed && !!organizationId,
   });
-  const scopeMissing = reposQuery.error instanceof ApiError && reposQuery.error.status === 403;
-  // The installation-backed endpoint can fail with 502 (upstream) / 503
-  // (no_installation / suspended / not_configured). Treat any non-403 error
-  // as a load failure with an honest message rather than letting it fall
-  // through to the empty "no projects" state.
-  const loadFailed = !!reposQuery.error && !scopeMissing;
+  // Any repo-list error → one honest "couldn't load" message. The repos come
+  // from the App *installation* token (server-minted), not the caller's OAuth,
+  // so failures are 502 (upstream) / 503 (no_installation / suspended /
+  // not_configured). A 403 here is `requireOrgAdmin` ("not an org admin"), not
+  // a GitHub-scope problem — and connect-code is admin-only, so it's
+  // effectively unreachable; a "reconnect GitHub" wouldn't fix it anyway.
+  const loadFailed = !!reposQuery.error;
   const hasPickableRepos = !reposQuery.error && (reposQuery.data?.length ?? 0) > 0;
 
   // Default the picker to every granted repo so the user doesn't re-pick what
@@ -110,25 +111,25 @@ export function StepConnectCode() {
     if (selectedRepoUrls.length === 0) setSelectedRepoUrls(loaded.map((r) => r.cloneUrl));
   }, [reposQuery.data]);
 
-  // Connected confirmation: org (when all repos share one owner) + count.
-  const grantedRepos = reposQuery.data ?? [];
-  const grantedOwners = [...new Set(grantedRepos.map((r) => r.fullName.split("/")[0] ?? ""))];
-  const grantedOrg = grantedOwners.length === 1 ? grantedOwners[0] || null : null;
-  const connectedLabel =
-    grantedRepos.length > 0
-      ? COPY.connectCode.connectedSummary(grantedRepos.length, grantedOrg)
-      : COPY.connectCode.connected;
-
   const handleConnect = async (): Promise<void> => {
     if (!organizationId) return;
     setInstallError(null);
     setRedirecting(true);
+    // Open the tab synchronously inside the click gesture so the browser doesn't
+    // treat the post-await window.open as a blocked popup; fill its location once
+    // the install URL is minted (or close it on failure). GitHub installs in that
+    // tab and lands it on /onboarding/connected to auto-close, while this tab
+    // keeps polling and advances on its own.
+    const installTab = window.open("", "_blank");
     try {
-      const url = await getGithubAppInstallUrl(organizationId, "/onboarding");
+      const url = await getGithubAppInstallUrl(organizationId, "/onboarding/connected");
       window.sessionStorage.setItem(INSTALL_ATTEMPT_KEY, String(Date.now()));
       setAttempted(true);
-      window.location.assign(url);
+      if (installTab) installTab.location.href = url;
+      else window.location.assign(url); // popup blocked — fall back to a full redirect
+      setRedirecting(false);
     } catch (err) {
+      installTab?.close();
       setRedirecting(false);
       if (err instanceof ApiError && err.status === 503) setInstallError("not_configured");
       else if (err instanceof ApiError && err.status === 403) setInstallError("not_admin");
@@ -184,8 +185,13 @@ export function StepConnectCode() {
                 {COPY.skipForNow}
               </Button>
             </div>
+            {/* Merged caveat + skip reassurance; the gating fact is bolded. */}
             <p className="text-label" style={{ margin: 0, color: "var(--fg-4)" }}>
-              {COPY.connectCode.skipReassure}
+              {COPY.connectCode.notOwnerHint.pre}
+              <span className="font-medium" style={{ color: "var(--fg-3)" }}>
+                {COPY.connectCode.notOwnerHint.emphasis}
+              </span>
+              {COPY.connectCode.notOwnerHint.post}
             </p>
 
             {installError === "generic" && (
@@ -205,21 +211,6 @@ export function StepConnectCode() {
               <StatusRow state="waiting" label={COPY.connectCode.waiting} />
             ) : null}
 
-            {/* Non-owner hint. We can't hand the user a shareable install
-                URL because the OAuth state JWT is paired with a per-browser
-                `oauth_state_nonce` cookie — a copied URL opened in the org
-                owner's browser would fail the callback's state-nonce check.
-                Instead, lean on GitHub's own "request approval" flow: if a
-                non-owner clicks the Install button, GitHub itself routes
-                the request to org owners for approval, and once approved
-                the bounce-back lands in the original (cookie-bearing)
-                browser. So: just tell them to click Install anyway.
-                Server-side shareable links (signed token instead of cookie
-                nonce) is a follow-up. */}
-            <p className="text-label" style={{ margin: 0, color: "var(--fg-4)" }}>
-              {COPY.connectCode.notOwnerHint}
-            </p>
-
             <ShowMeHow open={helpOpen} onToggle={setHelpOpen}>
               <InstallGuide />
               <InstallTroubleshooting />
@@ -234,25 +225,18 @@ export function StepConnectCode() {
   return (
     <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
       <PhaseNav phase="pick" />
-      <StatusRow state="ok" label={connectedLabel} />
 
       <div className="flex flex-col" style={{ gap: "var(--sp-2)" }}>
-        <p className="text-label font-medium" style={{ margin: 0, color: "var(--fg-2)" }}>
-          {COPY.connectCode.pickProject}
-        </p>
+        {/* The "which repos" prompt only makes sense when there's a list to
+            pick from — in loading / load-failed / empty states it would ask
+            the user to choose repos we can't even show. */}
+        {hasPickableRepos && (
+          <p className="text-label font-medium" style={{ margin: 0, color: "var(--fg-2)" }}>
+            {COPY.connectCode.pickProject}
+          </p>
+        )}
 
-        {scopeMissing ? (
-          <FlowHint>
-            {COPY.connectCode.scopeMissing}{" "}
-            <a
-              href="/api/v1/auth/github/start?next=/onboarding"
-              className="font-medium"
-              style={{ color: "var(--primary)" }}
-            >
-              {COPY.connectCode.reconnect}
-            </a>
-          </FlowHint>
-        ) : reposQuery.isLoading ? (
+        {reposQuery.isLoading ? (
           <p className="text-label" style={{ margin: 0, color: "var(--fg-4)" }}>
             {COPY.connectCode.loading}
           </p>

--- a/packages/web/src/pages/onboarding/steps/step-connect-computer.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-connect-computer.tsx
@@ -1,11 +1,34 @@
+import { RUNTIME_PROVIDERS, type RuntimeProvider } from "@first-tree/shared";
 import { ArrowRight } from "lucide-react";
 import { useEffect, useState } from "react";
 import { STUCK_AFTER_MS } from "../../../components/connect-stuck-panel.js";
 import { Button } from "../../../components/ui/button.js";
+import { OptionCard } from "../../../components/ui/option-card.js";
+import { PROVIDER_LABEL } from "../../clients/cards/shared/providers.js";
 import { COPY } from "../copy.js";
 import { CommandBox, FlowHint, StatusRow } from "../flow-ui.js";
 import { ConnectTroubleshooting, ShowMeHow, TerminalGuide } from "../guides.js";
 import { useOnboardingFlow } from "../onboarding-flow.js";
+
+const KNOWN_RUNTIME_PROVIDERS: readonly string[] = Object.values(RUNTIME_PROVIDERS);
+
+/**
+ * Narrow a wire-string provider to the shared `RuntimeProvider` enum before
+ * handing it to `PROVIDER_LABEL`. Mirrors the guard in
+ * `clients/cards/shared/bound-agents-list.tsx` — recognised providers get the
+ * shared display, anything truly unknown is dropped rather than leaked raw.
+ */
+function asRuntimeProvider(provider: string): RuntimeProvider | null {
+  // Single `as` after an includes-guard, matching the accepted pattern in
+  // bound-agents-list / new-agent-dialog (the enum has no runtime type guard).
+  return KNOWN_RUNTIME_PROVIDERS.includes(provider) ? (provider as RuntimeProvider) : null;
+}
+
+/** Friendly runtime label, falling back to the raw id if it's not a known one. */
+function runtimeLabel(provider: string): string {
+  const known = asRuntimeProvider(provider);
+  return known ? PROVIDER_LABEL[known] : provider;
+}
 
 /**
  * Connect the computer the agent will run on. The user pastes a one-liner into
@@ -19,15 +42,33 @@ import { useOnboardingFlow } from "../onboarding-flow.js";
  * and the hard token-mint error stay inline; the error offers a Try again
  * (the hook also retries silently first, so most blips never surface).
  */
-export function StepConnectComputer() {
+export function StepConnectComputer({ initialStuck = false }: { initialStuck?: boolean } = {}) {
   const { computer, goNext } = useOnboardingFlow();
-  const { connectedClient, capabilitiesLoaded, okRuntimes, cliCommand, tokenError, retry } = computer;
+  const {
+    connectedClient,
+    capabilitiesLoaded,
+    okRuntimes,
+    selectedRuntime,
+    setSelectedRuntime,
+    cliCommand,
+    tokenError,
+    retry,
+  } = computer;
 
   const noRuntime = !!connectedClient && capabilitiesLoaded && okRuntimes.length === 0;
   const ready = !!connectedClient && okRuntimes.length > 0;
 
+  // Ready runtimes narrowed to the shared enum, for the single-select pills.
+  // (≥2 → pick one; exactly one → just confirm it.)
+  const okProviders = okRuntimes.flatMap((p) => {
+    const provider = asRuntimeProvider(p);
+    return provider ? [provider] : [];
+  });
+
   // Flip to "stuck" if the command doesn't connect within a reasonable window.
-  const [stuck, setStuck] = useState(false);
+  // `initialStuck` lets the DEV preview render the stuck state directly (the
+  // real timer takes STUCK_AFTER_MS); production never passes it.
+  const [stuck, setStuck] = useState(initialStuck);
   useEffect(() => {
     if (connectedClient) {
       setStuck(false);
@@ -96,7 +137,35 @@ export function StepConnectComputer() {
             // Light treatment, consistent with the rest — the disabled Continue
             // already signals "one more thing before you can move on".
             <FlowHint>{COPY.connectComputer.noRuntime}</FlowHint>
-          ) : null}
+          ) : okProviders.length <= 1 ? (
+            // Exactly one runtime detected — nothing to choose, so name it and
+            // confirm the agent will use it.
+            <p className="text-body" style={{ margin: 0, color: "var(--fg-3)" }}>
+              {COPY.connectComputer.runtimeReady(runtimeLabel(selectedRuntime ?? okRuntimes[0] ?? ""))}
+            </p>
+          ) : (
+            // Two or more — count + a single-select list. Defaults to the
+            // auto-picked runtime; clicking a pill re-points `selectedRuntime`,
+            // which create-agent then uses as the agent's runtimeProvider.
+            <div className="flex flex-col" style={{ gap: "var(--sp-3)" }}>
+              <p className="text-body" style={{ margin: 0, color: "var(--fg-3)" }}>
+                {COPY.connectComputer.runtimesReady(okProviders.length)}
+              </p>
+              <div className="flex flex-wrap" style={{ gap: "var(--sp-2)" }}>
+                {okProviders.map((provider) => (
+                  <OptionCard
+                    key={provider}
+                    name="onboarding-runtime"
+                    layout="pill"
+                    checked={selectedRuntime === provider}
+                    onSelect={() => setSelectedRuntime(provider)}
+                  >
+                    <span className="text-body">{PROVIDER_LABEL[provider]}</span>
+                  </OptionCard>
+                ))}
+              </div>
+            </div>
+          )}
         </>
       )}
 

--- a/packages/web/src/pages/onboarding/steps/step-create-agent.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-create-agent.tsx
@@ -41,6 +41,8 @@ export function StepCreateAgent() {
     retryAgent,
     agentPhase,
     agentError,
+    goTo,
+    sequence,
   } = useOnboardingFlow();
 
   const trimmed = agentDisplayName.trim();
@@ -58,12 +60,8 @@ export function StepCreateAgent() {
   if (agentPhase === "timeout") {
     return (
       <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
-        <p className="text-subtitle font-semibold" style={{ color: "var(--fg)" }}>
-          {COPY.createAgent.timeoutTitle}
-        </p>
-        {/* Light treatment (consistent with the connect-computer states): the
-            heading already signals the problem, so the body is a plain line,
-            not a saturated callout box. */}
+        {/* One plain paragraph — the shell's step h1 ("Create your first agent")
+            already heads the screen, so no second bold title here — then retry. */}
         <p className="text-body" style={{ margin: 0, color: "var(--fg-3)" }}>
           {COPY.createAgent.timeoutBody}
         </p>
@@ -128,6 +126,25 @@ export function StepCreateAgent() {
         // Light inline error; the Create button right below is the retry.
         <FlowHint tone="error" role="alert">
           {COPY.errors.agentFailed}
+        </FlowHint>
+      )}
+
+      {!computer.connectedClient && (
+        // Computer dropped (slept / offline) or resumed here with it not
+        // connected — Create is gated on a live client. One line with the
+        // "reconnect it" action inline (→ connect-computer), not a separate
+        // orphaned link. Auto-clears once the poll sees it reconnect.
+        <FlowHint>
+          {COPY.createAgent.computerDisconnected.pre}
+          <button
+            type="button"
+            className="font-medium underline underline-offset-2"
+            style={{ color: "var(--primary)" }}
+            onClick={() => goTo(sequence.indexOf("connect-computer"))}
+          >
+            {COPY.createAgent.computerDisconnected.link}
+          </button>
+          {COPY.createAgent.computerDisconnected.post}
         </FlowHint>
       )}
 

--- a/packages/web/src/pages/onboarding/steps/step-kickoff.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-kickoff.tsx
@@ -517,7 +517,7 @@ function InviteePicker({ treeUrl }: { treeUrl: string }) {
         <TreeUrlDisplay treeUrl={treeUrl} />
         {reposQuery.isLoading ? (
           <p className="text-label" style={{ color: "var(--fg-4)" }}>
-            Loading your projects…
+            {COPY.kickoff.inviteePickerLoading}
           </p>
         ) : scopeMissing ? (
           <FlowHint>


### PR DESCRIPTION
## Summary

Onboarding flow polish, focused on the **connect-code** (admin) step, plus copy/runtime refinements across the wizard. Preview gallery (`/preview/onboarding`) renders the real components, so it tracks all of this automatically.

### Connect-code install in a new tab
- `handleConnect` opens the GitHub App install in a **new tab** opened synchronously inside the click gesture (so it isn't popup-blocked after the async URL mint), then fills the tab's location with the minted install URL (`next=/onboarding/connected`). The original tab keeps polling the installation query and advances on its own. Falls back to a full-page `window.location.assign` if the popup was blocked.
- New **public** landing route `/onboarding/connected` → `GithubConnectedPage`, which confirms and auto-closes the script-opened install tab (`role="status"` for a11y).
- Server: `/onboarding/connected` added to `ALLOWED_POST_INSTALL_NEXT` so `resolvePostInstallNext` validates the post-install redirect (exact-match allowlist — no open-redirect surface).
- Install CTA is disabled during the post-launch "waiting" window so a second click can't open another tab / re-mint; re-enabled once we detect the user returned without an install (`postAttemptStuck`) so retry still works.

### Dropped dead `scope-missing` state (connect-code)
The admin repos endpoint (`/orgs/:id/github/repos`) is **installation-token** based (server-minted), not the caller's OAuth — its failures are 502 (upstream) / 503 (no_installation / suspended / not_configured). The only 403 is `requireOrgAdmin` ("not an org admin"), which is unreachable in an admin-only step and not fixable by reconnecting GitHub. So the `scopeMissing` special-case + "Reconnect GitHub" link were removed; **all** repo-list errors now fold into one honest `loadFailed` message.

> The **invitee** kickoff picker (`/me/github/repos`, OAuth-based) genuinely returns `403 scope_missing` on a missing `repo` scope, so it **keeps** its scope-missing + reconnect path — that asymmetry is intentional.

### Copy / UI cleanup
- Title pluralized: "Connect the repos your agent works on".
- Merged the non-owner caveat + skip reassurance into one muted `notOwnerHint` line (gating fact bolded); removed the now-redundant "Connected" status row (PhaseNav ✓ + picker already convey it); gated the "Which repos" header to the pickable case.
- Earlier commits in the branch: onboarding copy/runtime-selection polish + preview states; preselect granted repos; two-phase (Connect GitHub → Pick repos) indicator.

## Review
Two independent code-review passes (both SHIP / SHIP-WITH-NITS, no HIGH findings). Both independently verified: the scope-missing-removal premise, the allowlist open-redirect guard stays sound, and no leaked/dangling tab on any path. Their actionable findings (double-tab guard, `role="status"`, popup-blocked + landing-page test coverage) are in the final commit.

## Test plan
- `pnpm --filter @first-tree/web typecheck` (incl. `lint:tokens`) — green
- `pnpm --filter @first-tree/web test` — green; added coverage for the new-tab open (`next=/onboarding/connected`), the popup-blocked full-redirect fallback, 403→loadFailed, the post-install-next allowlist, and an SSR render of `GithubConnectedPage`
- Server unit test `post-install-next.test.ts` updated (pure-function; runs in CI with Postgres)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
