### PR TITLE
feat(context-tree): add GitHub repo initializer

### DIFF
--- a/docs/github-app-design-zh.md
+++ b/docs/github-app-design-zh.md
@@ -1,0 +1,97 @@
+# GitHub App Design
+
+This document records the GitHub App decisions referenced from code comments.
+The filename keeps the historical `-zh` suffix, but the repository standard is
+to write technical documentation in English.
+
+## D0a: One GitHub App, SaaS-Wide
+
+First Tree uses one centrally configured GitHub App per deployment. The App is
+the trust boundary for GitHub identity, installation tokens, repository access,
+and webhook delivery.
+
+The server stores installation metadata in `github_app_installations`. The row
+is a snapshot from GitHub webhooks, GitHub API reads, or the local development
+stub; GitHub remains the source of truth for the live permission grant.
+
+## D0b: GitHub App Settings Contract
+
+Permissions are declared in the GitHub App settings page, not passed in OAuth
+or install URLs. Install and authorize URLs only carry identity, callback, and
+state parameters; GitHub renders the current App permission contract from the
+App settings.
+
+Repository permissions:
+
+- `Administration`: Read and write
+- `Contents`: Read and write
+- `Pull requests`: Read and write
+- `Issues`: Read-only
+- `Metadata`: Read-only
+
+Organization permissions:
+
+- `Members`: Read-only
+
+Subscribed events:
+
+- `issues`
+- `issue_comment`
+- `pull_request`
+- `pull_request_review`
+- `push`
+- `installation`
+- `installation_repositories`
+- `member`
+
+Operator rollout note:
+
+- Operators must update the GitHub App settings to request
+  `Administration: Read and write`.
+- Existing installations must re-approve the permission upgrade in GitHub
+  before relying on one-click Context Tree initialization.
+- Until an installation is re-approved, initializer calls return
+  `installation_permissions_insufficient`.
+
+## D1: Login and Install Share the App Flow
+
+The GitHub App has "Request user authorization (OAuth) during installation"
+enabled. A first-time user can install the App and authorize identity in the
+same GitHub round trip, while a returning user can authorize without changing
+the installation.
+
+First Tree signs and verifies `state` for CSRF protection and for recovering
+the intended post-auth destination. Install CTAs use the App installation URL
+when the UI needs a repository picker and permission review; identity-only
+sign-in uses the App authorize URL.
+
+## D2: One Installation Binds to One First Tree Team
+
+Each GitHub App installation may bind to at most one First Tree team. The
+server enforces this with the `github_app_installations.hub_organization_id`
+binding and refuses to rebind an installation that is already claimed by a
+different team.
+
+This keeps repository grants, webhook fan-out, Context Tree initialization, and
+team membership semantics aligned around a single team boundary.
+
+## D3: Legacy OAuth and Per-Repo Webhooks Are Removed
+
+The GitHub App is the GitHub integration surface. Legacy per-repository OAuth
+and webhook setup paths are not part of the current contract; remaining code
+must tolerate historical identity metadata only where needed for migration and
+returning users.
+
+Webhook ingestion enters through the GitHub App webhook endpoint and uses the
+installation registry to resolve team ownership.
+
+## D4: Webhooks Drive Installation State
+
+GitHub installation, repository-selection, and member-related events refresh
+First Tree's installation snapshot. The stored `permissions` and `events`
+fields are forward-compatible records so new GitHub keys can be surfaced
+without a schema migration.
+
+Runtime actions that require stronger permissions, such as one-click Context
+Tree initialization, must gate on the live installation token response rather
+than assuming the stored snapshot is current.

--- a/packages/server/src/__tests__/context-tree-initialize.test.ts
+++ b/packages/server/src/__tests__/context-tree-initialize.test.ts
@@ -1,0 +1,328 @@
+import { eq } from "drizzle-orm";
+import type { FastifyInstance } from "fastify";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { authIdentities } from "../db/schema/auth-identities.js";
+import { members } from "../db/schema/members.js";
+import { organizations } from "../db/schema/organizations.js";
+import { decryptValue, encryptValue } from "../services/crypto.js";
+import { getOrgContextTree, putOrgSetting } from "../services/org-settings.js";
+import { uuidv7 } from "../uuid.js";
+import { createTestAdmin, useTestApp } from "./helpers.js";
+
+type TestAdmin = Awaited<ReturnType<typeof createTestAdmin>>;
+type FetchInput = Parameters<typeof globalThis.fetch>[0];
+type FetchInit = Parameters<typeof globalThis.fetch>[1];
+
+const GITHUB_API_BASE = "https://api.github.com";
+const TOKEN_URL = "https://github.com/login/oauth/access_token";
+
+describe("POST /orgs/:orgId/context-tree/initialize", () => {
+  const getApp = useTestApp();
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("creates a private GitHub repo, writes NODE.md, and persists context_tree", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    await seedGithubIdentity(app, admin, { login: "octocat", accessToken: "ghu_live" });
+    await app.db
+      .update(organizations)
+      .set({ displayName: "Acme Labs" })
+      .where(eq(organizations.id, admin.organizationId));
+
+    let createRepoPayload: unknown;
+    let createFilePayload: unknown;
+    mockFetch(async (url, init) => {
+      if (url === `${GITHUB_API_BASE}/user/repos`) {
+        expect(init?.headers).toEqual(expect.objectContaining({ Authorization: "Bearer ghu_live" }));
+        createRepoPayload = parseJsonBody(init);
+        return jsonResponse(
+          {
+            name: "acme-labs-context-tree",
+            full_name: "octocat/acme-labs-context-tree",
+            owner: { login: "octocat" },
+            clone_url: "https://github.com/octocat/acme-labs-context-tree.git",
+            html_url: "https://github.com/octocat/acme-labs-context-tree",
+            private: true,
+            default_branch: "main",
+          },
+          201,
+        );
+      }
+      if (url === `${GITHUB_API_BASE}/repos/octocat/acme-labs-context-tree/contents/NODE.md`) {
+        expect(init?.headers).toEqual(expect.objectContaining({ Authorization: "Bearer ghu_live" }));
+        createFilePayload = parseJsonBody(init);
+        return jsonResponse({ content: { path: "NODE.md" } }, 201);
+      }
+      return new Response(`unexpected fetch ${url}`, { status: 500 });
+    });
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/orgs/${admin.organizationId}/context-tree/initialize`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(res.json()).toEqual({
+      repo: "https://github.com/octocat/acme-labs-context-tree.git",
+      htmlUrl: "https://github.com/octocat/acme-labs-context-tree",
+      branch: "main",
+      nodePath: "NODE.md",
+    });
+    expect(createRepoPayload).toMatchObject({
+      name: "acme-labs-context-tree",
+      private: true,
+      auto_init: false,
+      description: "Acme Labs Context Tree",
+    });
+    expect(createFilePayload).toMatchObject({
+      branch: "main",
+      message: "Initialize Context Tree root node",
+    });
+    const nodeContent = readBase64Content(createFilePayload);
+    expect(nodeContent).toBe(`---
+title: "Acme Labs Context Tree"
+description: "Shared context, decisions, ownership, and operating knowledge for Acme Labs."
+owners: [octocat]
+---
+
+# Acme Labs's Context Tree
+`);
+
+    const setting = await getOrgContextTree(app.db, admin.organizationId);
+    expect(setting).toEqual({ repo: "https://github.com/octocat/acme-labs-context-tree.git", branch: "main" });
+  });
+
+  it("returns 409 without calling GitHub when context_tree.repo already exists", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    await putOrgSetting(
+      app.db,
+      admin.organizationId,
+      "context_tree",
+      { repo: "https://github.com/acme/existing-context-tree.git", branch: "main" },
+      { updatedBy: admin.userId },
+    );
+    const fetchSpy = mockFetch(async () => new Response("unexpected", { status: 500 }));
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/orgs/${admin.organizationId}/context-tree/initialize`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-admin members before calling GitHub", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const member = await createTestAdmin(app);
+    await app.db.update(members).set({ role: "member" }).where(eq(members.id, member.memberId));
+    const fetchSpy = mockFetch(async () => new Response("unexpected", { status: 500 }));
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/orgs/${admin.organizationId}/context-tree/initialize`,
+      headers: { authorization: `Bearer ${member.accessToken}` },
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns an actionable auth error when GitHub credentials are missing", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/orgs/${admin.organizationId}/context-tree/initialize`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(503);
+    expect(res.json<{ error: string }>().error).toMatch(/reconnect/i);
+  });
+
+  it("maps GitHub repo-name conflicts to 409", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    await seedGithubIdentity(app, admin, { login: "octocat", accessToken: "ghu_conflict" });
+    const fetchSpy = mockFetch(async (url) => {
+      if (url === `${GITHUB_API_BASE}/user/repos`) {
+        return jsonResponse({ message: "Repository creation failed." }, 422);
+      }
+      return new Response(`unexpected fetch ${url}`, { status: 500 });
+    });
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/orgs/${admin.organizationId}/context-tree/initialize`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json<{ error: string }>().error).toMatch(/already exists/i);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("refreshes an expired GitHub App user token before creating the repo", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    await seedGithubIdentity(app, admin, {
+      login: "octocat",
+      accessToken: "old-access",
+      accessTokenExpiresAt: "2000-01-01T00:00:00.000Z",
+      refreshToken: "old-refresh",
+      refreshTokenExpiresAt: "2099-01-01T00:00:00.000Z",
+    });
+
+    mockFetch(async (url, init) => {
+      if (url === TOKEN_URL) {
+        expect(parseJsonBody(init)).toMatchObject({
+          client_id: "test-app-client-id",
+          client_secret: "test-app-client-secret",
+          grant_type: "refresh_token",
+          refresh_token: "old-refresh",
+        });
+        return jsonResponse({
+          access_token: "new-access",
+          expires_in: 28_800,
+          refresh_token: "new-refresh",
+          refresh_token_expires_in: 15_552_000,
+          scope: "repo",
+          token_type: "bearer",
+        });
+      }
+      if (url === `${GITHUB_API_BASE}/user/repos`) {
+        expect(init?.headers).toEqual(expect.objectContaining({ Authorization: "Bearer new-access" }));
+        return jsonResponse(
+          {
+            name: "default-organization-context-tree",
+            full_name: "octocat/default-organization-context-tree",
+            owner: { login: "octocat" },
+            clone_url: "https://github.com/octocat/default-organization-context-tree.git",
+            html_url: "https://github.com/octocat/default-organization-context-tree",
+            private: true,
+            default_branch: "main",
+          },
+          201,
+        );
+      }
+      if (url === `${GITHUB_API_BASE}/repos/octocat/default-organization-context-tree/contents/NODE.md`) {
+        expect(init?.headers).toEqual(expect.objectContaining({ Authorization: "Bearer new-access" }));
+        return jsonResponse({ content: { path: "NODE.md" } }, 201);
+      }
+      return new Response(`unexpected fetch ${url}`, { status: 500 });
+    });
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/orgs/${admin.organizationId}/context-tree/initialize`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(201);
+    const [identity] = await app.db
+      .select({ metadata: authIdentities.metadata })
+      .from(authIdentities)
+      .where(eq(authIdentities.userId, admin.userId))
+      .limit(1);
+    const metadata = requireRecord(identity?.metadata);
+    expect(decryptValue(requireString(metadata, "accessToken"), app.config.secrets.encryptionKey)).toBe("new-access");
+    expect(decryptValue(requireString(metadata, "refreshToken"), app.config.secrets.encryptionKey)).toBe("new-refresh");
+  });
+});
+
+async function seedGithubIdentity(
+  app: FastifyInstance,
+  admin: TestAdmin,
+  opts: {
+    login: string;
+    accessToken: string;
+    accessTokenExpiresAt?: string;
+    refreshToken?: string;
+    refreshTokenExpiresAt?: string;
+  },
+): Promise<void> {
+  const metadata: Record<string, unknown> = {
+    login: opts.login,
+    accessToken: encryptValue(opts.accessToken, app.config.secrets.encryptionKey),
+  };
+  if (opts.accessTokenExpiresAt) metadata.accessTokenExpiresAt = opts.accessTokenExpiresAt;
+  if (opts.refreshToken) metadata.refreshToken = encryptValue(opts.refreshToken, app.config.secrets.encryptionKey);
+  if (opts.refreshTokenExpiresAt) metadata.refreshTokenExpiresAt = opts.refreshTokenExpiresAt;
+
+  await app.db.insert(authIdentities).values({
+    id: uuidv7(),
+    userId: admin.userId,
+    provider: "github",
+    identifier: "123456",
+    email: `${opts.login}@example.test`,
+    verifiedAt: new Date(),
+    metadata,
+  });
+}
+
+function mockFetch(handler: (url: string, init: FetchInit) => Promise<Response>) {
+  const fetchSpy = vi.fn((input: FetchInput, init?: FetchInit) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    return handler(url, init);
+  });
+  globalThis.fetch = fetchSpy;
+  return fetchSpy;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function parseJsonBody(init: FetchInit): unknown {
+  if (!init || typeof init.body !== "string") {
+    throw new Error("Expected JSON string body");
+  }
+  return JSON.parse(init.body);
+}
+
+function readBase64Content(value: unknown): string {
+  const record = requireRecord(value);
+  return Buffer.from(requireString(record, "content"), "base64").toString("utf8");
+}
+
+function requireRecord(value: unknown): Record<string, unknown> {
+  if (!isRecord(value)) {
+    throw new Error("Expected record");
+  }
+  return value;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function requireString(record: Record<string, unknown>, key: string): string {
+  const value = record[key];
+  if (typeof value !== "string") {
+    throw new Error(`Expected string field ${key}`);
+  }
+  return value;
+}

--- a/packages/server/src/__tests__/context-tree-initialize.test.ts
+++ b/packages/server/src/__tests__/context-tree-initialize.test.ts
@@ -1,10 +1,12 @@
+import { generateKeyPairSync } from "node:crypto";
 import { eq } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { authIdentities } from "../db/schema/auth-identities.js";
 import { members } from "../db/schema/members.js";
 import { organizations } from "../db/schema/organizations.js";
-import { decryptValue, encryptValue } from "../services/crypto.js";
+import { encryptValue } from "../services/crypto.js";
+import { bindInstallationToOrg, upsertInstallationFromMetadata } from "../services/github-app-installations.js";
 import { getOrgContextTree, putOrgSetting } from "../services/org-settings.js";
 import { uuidv7 } from "../uuid.js";
 import { createTestAdmin, useTestApp } from "./helpers.js";
@@ -14,10 +16,22 @@ type FetchInput = Parameters<typeof globalThis.fetch>[0];
 type FetchInit = Parameters<typeof globalThis.fetch>[1];
 
 const GITHUB_API_BASE = "https://api.github.com";
-const TOKEN_URL = "https://github.com/login/oauth/access_token";
+const INSTALLATION_TOKEN = "ghs_installation_token";
+const ACCOUNT_LOGIN = "acme-github";
+const REPO_NAME = "acme-labs-context-tree";
+const CLONE_URL = `https://github.com/${ACCOUNT_LOGIN}/${REPO_NAME}.git`;
+const HTML_URL = `https://github.com/${ACCOUNT_LOGIN}/${REPO_NAME}`;
+
+const { privateKey: githubAppPrivateKeyPem } = generateKeyPairSync("rsa", {
+  modulusLength: 2048,
+  privateKeyEncoding: { type: "pkcs8", format: "pem" },
+  publicKeyEncoding: { type: "spki", format: "pem" },
+});
+
+let nextInstallationId = 910_000;
 
 describe("POST /orgs/:orgId/context-tree/initialize", () => {
-  const getApp = useTestApp();
+  const getApp = useTestApp({ githubAppPrivateKeyPem });
   let originalFetch: typeof globalThis.fetch;
 
   beforeEach(() => {
@@ -26,60 +40,54 @@ describe("POST /orgs/:orgId/context-tree/initialize", () => {
 
   afterEach(() => {
     globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
   });
 
-  it("creates a private GitHub repo, writes NODE.md, and persists context_tree", async () => {
+  it("creates an organization repo with the bound installation token, writes NODE.md, and persists context_tree", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
-    await seedGithubIdentity(app, admin, { login: "octocat", accessToken: "ghu_live" });
-    await app.db
-      .update(organizations)
-      .set({ displayName: "Acme Labs" })
-      .where(eq(organizations.id, admin.organizationId));
+    const installationId = await seedInstallation(app, admin.organizationId);
+    await renameOrg(app, admin.organizationId, "Acme Labs");
 
     let createRepoPayload: unknown;
     let createFilePayload: unknown;
-    mockFetch(async (url, init) => {
-      if (url === `${GITHUB_API_BASE}/user/repos`) {
-        expect(init?.headers).toEqual(expect.objectContaining({ Authorization: "Bearer ghu_live" }));
-        createRepoPayload = parseJsonBody(init);
-        return jsonResponse(
-          {
-            name: "acme-labs-context-tree",
-            full_name: "octocat/acme-labs-context-tree",
-            owner: { login: "octocat" },
-            clone_url: "https://github.com/octocat/acme-labs-context-tree.git",
-            html_url: "https://github.com/octocat/acme-labs-context-tree",
-            private: true,
-            default_branch: "main",
-          },
-          201,
-        );
+    const fetchSpy = mockFetch(async (url, init) => {
+      if (url === installationTokenUrl(installationId)) {
+        expectAuth(init, "Bearer");
+        return installationTokenResponse();
       }
-      if (url === `${GITHUB_API_BASE}/repos/octocat/acme-labs-context-tree/contents/NODE.md`) {
-        expect(init?.headers).toEqual(expect.objectContaining({ Authorization: "Bearer ghu_live" }));
+      if (url === orgReposUrl(ACCOUNT_LOGIN)) {
+        expectAuth(init, `Bearer ${INSTALLATION_TOKEN}`);
+        createRepoPayload = parseJsonBody(init);
+        return githubRepoResponse(201);
+      }
+      if (url === repoUrl(ACCOUNT_LOGIN, REPO_NAME)) {
+        expectAuth(init, `Bearer ${INSTALLATION_TOKEN}`);
+        return githubRepoResponse(200);
+      }
+      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, "NODE.md", "main")) {
+        expectAuth(init, `Bearer ${INSTALLATION_TOKEN}`);
+        return jsonResponse({ message: "Not Found" }, 404);
+      }
+      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, "NODE.md")) {
+        expectAuth(init, `Bearer ${INSTALLATION_TOKEN}`);
         createFilePayload = parseJsonBody(init);
         return jsonResponse({ content: { path: "NODE.md" } }, 201);
       }
       return new Response(`unexpected fetch ${url}`, { status: 500 });
     });
 
-    const res = await app.inject({
-      method: "POST",
-      url: `/api/v1/orgs/${admin.organizationId}/context-tree/initialize`,
-      headers: { authorization: `Bearer ${admin.accessToken}` },
-      payload: {},
-    });
+    const res = await initialize(app, admin);
 
     expect(res.statusCode).toBe(201);
     expect(res.json()).toEqual({
-      repo: "https://github.com/octocat/acme-labs-context-tree.git",
-      htmlUrl: "https://github.com/octocat/acme-labs-context-tree",
+      repo: CLONE_URL,
+      htmlUrl: HTML_URL,
       branch: "main",
       nodePath: "NODE.md",
     });
     expect(createRepoPayload).toMatchObject({
-      name: "acme-labs-context-tree",
+      name: REPO_NAME,
       private: true,
       auto_init: false,
       description: "Acme Labs Context Tree",
@@ -92,14 +100,15 @@ describe("POST /orgs/:orgId/context-tree/initialize", () => {
     expect(nodeContent).toBe(`---
 title: "Acme Labs Context Tree"
 description: "Shared context, decisions, ownership, and operating knowledge for Acme Labs."
-owners: [octocat]
+owners: [${ACCOUNT_LOGIN}]
 ---
 
 # Acme Labs's Context Tree
 `);
+    expect(fetchSpy).toHaveBeenCalledTimes(5);
 
     const setting = await getOrgContextTree(app.db, admin.organizationId);
-    expect(setting).toEqual({ repo: "https://github.com/octocat/acme-labs-context-tree.git", branch: "main" });
+    expect(setting).toEqual({ repo: CLONE_URL, branch: "main" });
   });
 
   it("returns 409 without calling GitHub when context_tree.repo already exists", async () => {
@@ -114,12 +123,7 @@ owners: [octocat]
     );
     const fetchSpy = mockFetch(async () => new Response("unexpected", { status: 500 }));
 
-    const res = await app.inject({
-      method: "POST",
-      url: `/api/v1/orgs/${admin.organizationId}/context-tree/initialize`,
-      headers: { authorization: `Bearer ${admin.accessToken}` },
-      payload: {},
-    });
+    const res = await initialize(app, admin);
 
     expect(res.statusCode).toBe(409);
     expect(fetchSpy).not.toHaveBeenCalled();
@@ -129,126 +133,343 @@ owners: [octocat]
     const app = getApp();
     const admin = await createTestAdmin(app);
     const member = await createTestAdmin(app);
-    await app.db.update(members).set({ role: "member" }).where(eq(members.id, member.memberId));
+    await app.db
+      .update(members)
+      .set({ organizationId: admin.organizationId, role: "member" })
+      .where(eq(members.id, member.memberId));
     const fetchSpy = mockFetch(async () => new Response("unexpected", { status: 500 }));
 
-    const res = await app.inject({
-      method: "POST",
-      url: `/api/v1/orgs/${admin.organizationId}/context-tree/initialize`,
-      headers: { authorization: `Bearer ${member.accessToken}` },
-      payload: {},
-    });
+    const res = await initialize(app, { ...admin, accessToken: member.accessToken });
 
     expect(res.statusCode).toBe(403);
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  it("returns an actionable auth error when GitHub credentials are missing", async () => {
+  it("returns 503 no_installation without calling GitHub when no installation is bound", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
+    const fetchSpy = mockFetch(async () => new Response("unexpected", { status: 500 }));
 
-    const res = await app.inject({
-      method: "POST",
-      url: `/api/v1/orgs/${admin.organizationId}/context-tree/initialize`,
-      headers: { authorization: `Bearer ${admin.accessToken}` },
-      payload: {},
-    });
+    const res = await initialize(app, admin);
 
     expect(res.statusCode).toBe(503);
-    expect(res.json<{ error: string }>().error).toMatch(/reconnect/i);
+    expect(res.json()).toMatchObject({ code: "no_installation" });
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  it("maps GitHub repo-name conflicts to 409", async () => {
+  it("returns 503 not_configured without calling GitHub when server GitHub App config is missing", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
-    await seedGithubIdentity(app, admin, { login: "octocat", accessToken: "ghu_conflict" });
+    await seedInstallation(app, admin.organizationId);
+    const fetchSpy = mockFetch(async () => new Response("unexpected", { status: 500 }));
+    const originalOauth = app.config.oauth;
+    app.config.oauth = undefined;
+    try {
+      const res = await initialize(app, admin);
+
+      expect(res.statusCode).toBe(503);
+      expect(res.json()).toMatchObject({ code: "not_configured" });
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      app.config.oauth = originalOauth;
+    }
+  });
+
+  it("does not fall back to the signed-in user's GitHub token when the installation is bound elsewhere", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const otherOrganizationId = await createOrganization(app, "other-github-team");
+    await seedGithubIdentity(app, admin, { login: "octocat", accessToken: "ghu_personal" });
+    await seedInstallation(app, otherOrganizationId, { accountLogin: "octocat" });
     const fetchSpy = mockFetch(async (url) => {
       if (url === `${GITHUB_API_BASE}/user/repos`) {
-        return jsonResponse({ message: "Repository creation failed." }, 422);
+        return githubRepoResponse(201, { owner: "octocat", name: "personal-context-tree" });
       }
       return new Response(`unexpected fetch ${url}`, { status: 500 });
     });
 
-    const res = await app.inject({
-      method: "POST",
-      url: `/api/v1/orgs/${admin.organizationId}/context-tree/initialize`,
-      headers: { authorization: `Bearer ${admin.accessToken}` },
-      payload: {},
+    const res = await initialize(app, admin);
+
+    expect(res.statusCode).toBe(503);
+    expect(res.json()).toMatchObject({ code: "no_installation" });
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect((await getOrgContextTree(app.db, admin.organizationId)).repo).toBeUndefined();
+  });
+
+  it("returns 503 suspended when the bound installation is suspended", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    await seedInstallation(app, admin.organizationId, { suspendedAt: "2026-05-11T10:00:00Z" });
+    const fetchSpy = mockFetch(async () => new Response("unexpected", { status: 500 }));
+
+    const res = await initialize(app, admin);
+
+    expect(res.statusCode).toBe(503);
+    expect(res.json()).toMatchObject({ code: "suspended" });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns 502 upstream when installation-token minting fails", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const installationId = await seedInstallation(app, admin.organizationId);
+    const fetchSpy = mockFetch(async (url) => {
+      if (url === installationTokenUrl(installationId)) {
+        return jsonResponse({ message: "Bad credentials" }, 401);
+      }
+      return new Response(`unexpected fetch ${url}`, { status: 500 });
     });
 
-    expect(res.statusCode).toBe(409);
-    expect(res.json<{ error: string }>().error).toMatch(/already exists/i);
+    const res = await initialize(app, admin);
+
+    expect(res.statusCode).toBe(502);
+    expect(res.json()).toMatchObject({ code: "upstream" });
     expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
-  it("refreshes an expired GitHub App user token before creating the repo", async () => {
+  it("returns 409 selected_repositories_unsupported before creating anything", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
-    await seedGithubIdentity(app, admin, {
-      login: "octocat",
-      accessToken: "old-access",
-      accessTokenExpiresAt: "2000-01-01T00:00:00.000Z",
-      refreshToken: "old-refresh",
-      refreshTokenExpiresAt: "2099-01-01T00:00:00.000Z",
+    const installationId = await seedInstallation(app, admin.organizationId);
+    const fetchSpy = mockFetch(async (url) => {
+      if (url === installationTokenUrl(installationId)) {
+        return installationTokenResponse({ repository_selection: "selected" });
+      }
+      return new Response(`unexpected fetch ${url}`, { status: 500 });
     });
 
-    mockFetch(async (url, init) => {
-      if (url === TOKEN_URL) {
-        expect(parseJsonBody(init)).toMatchObject({
-          client_id: "test-app-client-id",
-          client_secret: "test-app-client-secret",
-          grant_type: "refresh_token",
-          refresh_token: "old-refresh",
-        });
-        return jsonResponse({
-          access_token: "new-access",
-          expires_in: 28_800,
-          refresh_token: "new-refresh",
-          refresh_token_expires_in: 15_552_000,
-          scope: "repo",
-          token_type: "bearer",
-        });
+    const res = await initialize(app, admin);
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json()).toMatchObject({ code: "selected_repositories_unsupported" });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  const permissionCases: Array<[string, Record<string, "read" | "write" | "admin">]> = [
+    ["administration", { administration: "read", contents: "write" }],
+    ["contents", { administration: "write", contents: "read" }],
+  ];
+  for (const [missingPermission, permissions] of permissionCases) {
+    it(`returns 403 installation_permissions_insufficient when ${missingPermission} is not write`, async () => {
+      const app = getApp();
+      const admin = await createTestAdmin(app);
+      const installationId = await seedInstallation(app, admin.organizationId);
+      const fetchSpy = mockFetch(async (url) => {
+        if (url === installationTokenUrl(installationId)) {
+          return installationTokenResponse({ permissions });
+        }
+        return new Response(`unexpected fetch ${url}`, { status: 500 });
+      });
+
+      const res = await initialize(app, admin);
+
+      expect(res.statusCode).toBe(403);
+      expect(res.json()).toMatchObject({ code: "installation_permissions_insufficient" });
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+  }
+
+  it("adopts an existing deterministic repo when create returns 422 and the installation can read it", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const installationId = await seedInstallation(app, admin.organizationId);
+    await renameOrg(app, admin.organizationId, "Acme Labs");
+    let fileWrites = 0;
+    const fetchSpy = mockFetch(async (url) => {
+      if (url === installationTokenUrl(installationId)) return installationTokenResponse();
+      if (url === orgReposUrl(ACCOUNT_LOGIN)) return jsonResponse({ message: "Repository creation failed." }, 422);
+      if (url === repoUrl(ACCOUNT_LOGIN, REPO_NAME)) return githubRepoResponse(200);
+      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, "NODE.md", "main")) {
+        return jsonResponse({ message: "Not Found" }, 404);
       }
-      if (url === `${GITHUB_API_BASE}/user/repos`) {
-        expect(init?.headers).toEqual(expect.objectContaining({ Authorization: "Bearer new-access" }));
-        return jsonResponse(
-          {
-            name: "default-organization-context-tree",
-            full_name: "octocat/default-organization-context-tree",
-            owner: { login: "octocat" },
-            clone_url: "https://github.com/octocat/default-organization-context-tree.git",
-            html_url: "https://github.com/octocat/default-organization-context-tree",
-            private: true,
-            default_branch: "main",
-          },
-          201,
-        );
-      }
-      if (url === `${GITHUB_API_BASE}/repos/octocat/default-organization-context-tree/contents/NODE.md`) {
-        expect(init?.headers).toEqual(expect.objectContaining({ Authorization: "Bearer new-access" }));
+      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, "NODE.md")) {
+        fileWrites += 1;
         return jsonResponse({ content: { path: "NODE.md" } }, 201);
       }
       return new Response(`unexpected fetch ${url}`, { status: 500 });
     });
 
-    const res = await app.inject({
-      method: "POST",
-      url: `/api/v1/orgs/${admin.organizationId}/context-tree/initialize`,
-      headers: { authorization: `Bearer ${admin.accessToken}` },
-      payload: {},
-    });
+    const res = await initialize(app, admin);
 
     expect(res.statusCode).toBe(201);
-    const [identity] = await app.db
-      .select({ metadata: authIdentities.metadata })
-      .from(authIdentities)
-      .where(eq(authIdentities.userId, admin.userId))
-      .limit(1);
-    const metadata = requireRecord(identity?.metadata);
-    expect(decryptValue(requireString(metadata, "accessToken"), app.config.secrets.encryptionKey)).toBe("new-access");
-    expect(decryptValue(requireString(metadata, "refreshToken"), app.config.secrets.encryptionKey)).toBe("new-refresh");
+    expect(fileWrites).toBe(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(5);
+    expect(await getOrgContextTree(app.db, admin.organizationId)).toEqual({ repo: CLONE_URL, branch: "main" });
+  });
+
+  it("returns 409 repo_unavailable when an existing deterministic repo is not readable by the installation", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const installationId = await seedInstallation(app, admin.organizationId);
+    await renameOrg(app, admin.organizationId, "Acme Labs");
+    const fetchSpy = mockFetch(async (url) => {
+      if (url === installationTokenUrl(installationId)) return installationTokenResponse();
+      if (url === orgReposUrl(ACCOUNT_LOGIN)) return jsonResponse({ message: "Repository creation failed." }, 422);
+      if (url === repoUrl(ACCOUNT_LOGIN, REPO_NAME)) return jsonResponse({ message: "Not Found" }, 404);
+      return new Response(`unexpected fetch ${url}`, { status: 500 });
+    });
+
+    const res = await initialize(app, admin);
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json()).toMatchObject({ code: "repo_unavailable" });
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+    expect((await getOrgContextTree(app.db, admin.organizationId)).repo).toBeUndefined();
+  });
+
+  it("adopts an existing repo with an existing NODE.md without rewriting the file", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const installationId = await seedInstallation(app, admin.organizationId);
+    await renameOrg(app, admin.organizationId, "Acme Labs");
+    let fileWrites = 0;
+    const fetchSpy = mockFetch(async (url) => {
+      if (url === installationTokenUrl(installationId)) return installationTokenResponse();
+      if (url === orgReposUrl(ACCOUNT_LOGIN)) return jsonResponse({ message: "Repository creation failed." }, 422);
+      if (url === repoUrl(ACCOUNT_LOGIN, REPO_NAME)) return githubRepoResponse(200);
+      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, "NODE.md", "main")) {
+        return jsonResponse({ path: "NODE.md" }, 200);
+      }
+      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, "NODE.md")) {
+        fileWrites += 1;
+        return jsonResponse({ content: { path: "NODE.md" } }, 201);
+      }
+      return new Response(`unexpected fetch ${url}`, { status: 500 });
+    });
+
+    const res = await initialize(app, admin);
+
+    expect(res.statusCode).toBe(201);
+    expect(fileWrites).toBe(0);
+    expect(fetchSpy).toHaveBeenCalledTimes(4);
+    expect(await getOrgContextTree(app.db, admin.organizationId)).toEqual({ repo: CLONE_URL, branch: "main" });
+  });
+
+  it("can retry successfully when the root-node write failed after repo creation", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const installationId = await seedInstallation(app, admin.organizationId);
+    await renameOrg(app, admin.organizationId, "Acme Labs");
+    let repoCreateCalls = 0;
+    let fileWriteCalls = 0;
+    mockFetch(async (url) => {
+      if (url === installationTokenUrl(installationId)) return installationTokenResponse();
+      if (url === orgReposUrl(ACCOUNT_LOGIN)) {
+        repoCreateCalls += 1;
+        return repoCreateCalls === 1
+          ? githubRepoResponse(201)
+          : jsonResponse({ message: "Repository creation failed." }, 422);
+      }
+      if (url === repoUrl(ACCOUNT_LOGIN, REPO_NAME)) return githubRepoResponse(200);
+      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, "NODE.md", "main")) {
+        return jsonResponse({ message: "Not Found" }, 404);
+      }
+      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, "NODE.md")) {
+        fileWriteCalls += 1;
+        return fileWriteCalls === 1
+          ? jsonResponse({ message: "GitHub unavailable" }, 500)
+          : jsonResponse({ content: { path: "NODE.md" } }, 201);
+      }
+      return new Response(`unexpected fetch ${url}`, { status: 500 });
+    });
+
+    const first = await initialize(app, admin);
+    expect(first.statusCode).toBe(502);
+    expect(first.json()).toMatchObject({ code: "upstream" });
+    expect((await getOrgContextTree(app.db, admin.organizationId)).repo).toBeUndefined();
+
+    const second = await initialize(app, admin);
+    expect(second.statusCode).toBe(201);
+    expect(repoCreateCalls).toBe(2);
+    expect(fileWriteCalls).toBe(2);
+    expect(await getOrgContextTree(app.db, admin.organizationId)).toEqual({ repo: CLONE_URL, branch: "main" });
+  });
+
+  it("can retry successfully when DB save failed after repo creation and root-node write", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const installationId = await seedInstallation(app, admin.organizationId);
+    await renameOrg(app, admin.organizationId, "Acme Labs");
+    let repoCreateCalls = 0;
+    let rootNodeExists = false;
+    vi.spyOn(app.db, "transaction").mockRejectedValueOnce(new Error("db down"));
+    mockFetch(async (url) => {
+      if (url === installationTokenUrl(installationId)) return installationTokenResponse();
+      if (url === orgReposUrl(ACCOUNT_LOGIN)) {
+        repoCreateCalls += 1;
+        return repoCreateCalls === 1
+          ? githubRepoResponse(201)
+          : jsonResponse({ message: "Repository creation failed." }, 422);
+      }
+      if (url === repoUrl(ACCOUNT_LOGIN, REPO_NAME)) return githubRepoResponse(200);
+      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, "NODE.md", "main")) {
+        return rootNodeExists ? jsonResponse({ path: "NODE.md" }, 200) : jsonResponse({ message: "Not Found" }, 404);
+      }
+      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, "NODE.md")) {
+        rootNodeExists = true;
+        return jsonResponse({ content: { path: "NODE.md" } }, 201);
+      }
+      return new Response(`unexpected fetch ${url}`, { status: 500 });
+    });
+
+    const first = await initialize(app, admin);
+    expect(first.statusCode).toBe(500);
+    expect(rootNodeExists).toBe(true);
+    expect((await getOrgContextTree(app.db, admin.organizationId)).repo).toBeUndefined();
+
+    const second = await initialize(app, admin);
+    expect(second.statusCode).toBe(201);
+    expect(repoCreateCalls).toBe(2);
+    expect(await getOrgContextTree(app.db, admin.organizationId)).toEqual({ repo: CLONE_URL, branch: "main" });
   });
 });
+
+async function initialize(app: FastifyInstance, admin: Pick<TestAdmin, "organizationId" | "accessToken">) {
+  return app.inject({
+    method: "POST",
+    url: `/api/v1/orgs/${admin.organizationId}/context-tree/initialize`,
+    headers: { authorization: `Bearer ${admin.accessToken}` },
+    payload: {},
+  });
+}
+
+async function renameOrg(app: FastifyInstance, organizationId: string, displayName: string): Promise<void> {
+  await app.db.update(organizations).set({ displayName }).where(eq(organizations.id, organizationId));
+}
+
+async function createOrganization(app: FastifyInstance, name: string): Promise<string> {
+  const id = uuidv7();
+  await app.db.insert(organizations).values({ id, name, displayName: name });
+  return id;
+}
+
+async function seedInstallation(
+  app: FastifyInstance,
+  organizationId: string,
+  opts: {
+    accountLogin?: string;
+    accountType?: "User" | "Organization";
+    permissions?: Record<string, "read" | "write" | "admin">;
+    repositoryEvents?: string[];
+    suspendedAt?: string | null;
+  } = {},
+): Promise<number> {
+  const installationId = nextInstallationId;
+  nextInstallationId += 1;
+  await upsertInstallationFromMetadata(app.db, {
+    installation: {
+      id: installationId,
+      accountType: opts.accountType ?? "Organization",
+      accountLogin: opts.accountLogin ?? ACCOUNT_LOGIN,
+      accountGithubId: installationId + 1_000_000,
+      permissions: opts.permissions ?? { administration: "write", contents: "write" },
+      events: opts.repositoryEvents ?? ["push"],
+      suspendedAt: opts.suspendedAt ?? null,
+    },
+  });
+  await bindInstallationToOrg(app.db, installationId, organizationId);
+  return installationId;
+}
 
 async function seedGithubIdentity(
   app: FastifyInstance,
@@ -256,19 +477,8 @@ async function seedGithubIdentity(
   opts: {
     login: string;
     accessToken: string;
-    accessTokenExpiresAt?: string;
-    refreshToken?: string;
-    refreshTokenExpiresAt?: string;
   },
 ): Promise<void> {
-  const metadata: Record<string, unknown> = {
-    login: opts.login,
-    accessToken: encryptValue(opts.accessToken, app.config.secrets.encryptionKey),
-  };
-  if (opts.accessTokenExpiresAt) metadata.accessTokenExpiresAt = opts.accessTokenExpiresAt;
-  if (opts.refreshToken) metadata.refreshToken = encryptValue(opts.refreshToken, app.config.secrets.encryptionKey);
-  if (opts.refreshTokenExpiresAt) metadata.refreshTokenExpiresAt = opts.refreshTokenExpiresAt;
-
   await app.db.insert(authIdentities).values({
     id: uuidv7(),
     userId: admin.userId,
@@ -276,7 +486,10 @@ async function seedGithubIdentity(
     identifier: "123456",
     email: `${opts.login}@example.test`,
     verifiedAt: new Date(),
-    metadata,
+    metadata: {
+      login: opts.login,
+      accessToken: encryptValue(opts.accessToken, app.config.secrets.encryptionKey),
+    },
   });
 }
 
@@ -289,11 +502,75 @@ function mockFetch(handler: (url: string, init: FetchInit) => Promise<Response>)
   return fetchSpy;
 }
 
+function installationTokenResponse(
+  overrides: {
+    permissions?: Record<string, "read" | "write" | "admin">;
+    repository_selection?: "all" | "selected";
+  } = {},
+): Response {
+  return jsonResponse(
+    {
+      token: INSTALLATION_TOKEN,
+      expires_at: "2026-05-15T01:00:00Z",
+      permissions: overrides.permissions ?? { administration: "write", contents: "write" },
+      repository_selection: overrides.repository_selection ?? "all",
+    },
+    201,
+  );
+}
+
+function githubRepoResponse(
+  status: number,
+  overrides: { owner?: string; name?: string; private?: boolean } = {},
+): Response {
+  const owner = overrides.owner ?? ACCOUNT_LOGIN;
+  const name = overrides.name ?? REPO_NAME;
+  return jsonResponse(
+    {
+      name,
+      full_name: `${owner}/${name}`,
+      owner: { login: owner },
+      clone_url: `https://github.com/${owner}/${name}.git`,
+      html_url: `https://github.com/${owner}/${name}`,
+      private: overrides.private ?? true,
+      default_branch: "main",
+    },
+    status,
+  );
+}
+
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
     status,
     headers: { "Content-Type": "application/json" },
   });
+}
+
+function installationTokenUrl(installationId: number): string {
+  return `${GITHUB_API_BASE}/app/installations/${installationId}/access_tokens`;
+}
+
+function orgReposUrl(org: string): string {
+  return `${GITHUB_API_BASE}/orgs/${encodeURIComponent(org)}/repos`;
+}
+
+function repoUrl(owner: string, repo: string): string {
+  return `${GITHUB_API_BASE}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`;
+}
+
+function contentsUrl(owner: string, repo: string, path: string, branch?: string): string {
+  const base = `${repoUrl(owner, repo)}/contents/${encodePath(path)}`;
+  return branch ? `${base}?ref=${encodeURIComponent(branch)}` : base;
+}
+
+function expectAuth(init: FetchInit, expectedAuthorization: string): void {
+  const headers = new Headers(init?.headers);
+  const actual = headers.get("authorization");
+  if (expectedAuthorization === "Bearer") {
+    expect(actual?.startsWith("Bearer ")).toBe(true);
+    return;
+  }
+  expect(actual).toBe(expectedAuthorization);
 }
 
 function parseJsonBody(init: FetchInit): unknown {
@@ -325,4 +602,12 @@ function requireString(record: Record<string, unknown>, key: string): string {
     throw new Error(`Expected string field ${key}`);
   }
   return value;
+}
+
+function encodePath(path: string): string {
+  return path
+    .split("/")
+    .filter((part) => part.length > 0)
+    .map((part) => encodeURIComponent(part))
+    .join("/");
 }

--- a/packages/server/src/__tests__/github-app-token.test.ts
+++ b/packages/server/src/__tests__/github-app-token.test.ts
@@ -74,7 +74,12 @@ describe("services/github-app-token", () => {
         );
       };
       const result = await mintContextTreeInstallationToken(installation, { appId, privateKeyPem }, { fetcher });
-      expect(result).toEqual({ ok: true, token: "ghs_installation_token" });
+      expect(result).toEqual({
+        ok: true,
+        token: "ghs_installation_token",
+        permissions: { contents: "read" },
+        repositorySelection: "selected",
+      });
       expect(calls).toEqual(["https://api.github.com/app/installations/7777/access_tokens"]);
     });
   });
@@ -84,7 +89,12 @@ describe("services/github-app-token", () => {
 
     it("returns the snapshot unchanged when the mint succeeded", () => {
       const snapshot = unavailableSnapshot("First Tree could not sync the configured Context Tree repo.");
-      const decorated = decorateSnapshotWithMintGuidance(snapshot, githubBinding, { ok: true, token: "ghs_t" });
+      const decorated = decorateSnapshotWithMintGuidance(snapshot, githubBinding, {
+        ok: true,
+        token: "ghs_t",
+        permissions: {},
+        repositorySelection: "all",
+      });
       expect(decorated).toBe(snapshot);
     });
 

--- a/packages/server/src/__tests__/github-app.test.ts
+++ b/packages/server/src/__tests__/github-app.test.ts
@@ -4,9 +4,13 @@ import { beforeAll, describe, expect, it } from "vitest";
 import {
   buildAppAuthorizeUrl,
   createAppJwt,
+  createOrganizationRepo,
+  createRepoFileWithToken,
   exchangeCodeForAppUserProfile,
   fetchInstallation,
   GithubAppApiError,
+  getRepoFileWithToken,
+  getRepository,
   listInstallationRepos,
   mintInstallationToken,
   refreshAppUserToken,
@@ -663,5 +667,133 @@ describe("services/github-app › listInstallationRepos", () => {
       );
     const repos = await listInstallationRepos("ghs_token", { fetcher });
     expect(repos.map((r) => r.fullName)).toEqual(["acme/new", "acme/old", "acme/null"]);
+  });
+});
+
+describe("services/github-app › installation repository helpers", () => {
+  type FetchInput = Parameters<typeof fetch>[0];
+  const urlOf = (input: FetchInput): string =>
+    typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+
+  function repoBody(owner = "acme", name = "tree") {
+    return {
+      name,
+      full_name: `${owner}/${name}`,
+      owner: { login: owner },
+      clone_url: `https://github.com/${owner}/${name}.git`,
+      html_url: `https://github.com/${owner}/${name}`,
+      private: true,
+      default_branch: "main",
+    };
+  }
+
+  it("creates an organization repo with an installation token and parses the repo shape", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const fetcher: typeof fetch = async (input, init) => {
+      calls.push({ url: urlOf(input), init });
+      return new Response(JSON.stringify(repoBody("acme", "team-context-tree")), {
+        status: 201,
+        headers: { "content-type": "application/json" },
+      });
+    };
+
+    const repo = await createOrganizationRepo(
+      "ghs_token",
+      { org: "acme", name: "team-context-tree", private: true, description: "Team Context Tree" },
+      { fetcher },
+    );
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.url).toBe("https://api.github.com/orgs/acme/repos");
+    expect(calls[0]?.init?.method).toBe("POST");
+    const headers = new Headers(calls[0]?.init?.headers);
+    expect(headers.get("authorization")).toBe("Bearer ghs_token");
+    expect(headers.get("x-github-api-version")).toBe("2022-11-28");
+    expect(JSON.parse(String(calls[0]?.init?.body))).toEqual({
+      name: "team-context-tree",
+      private: true,
+      auto_init: false,
+      description: "Team Context Tree",
+    });
+    expect(repo).toMatchObject({
+      name: "team-context-tree",
+      fullName: "acme/team-context-tree",
+      ownerLogin: "acme",
+      cloneUrl: "https://github.com/acme/team-context-tree.git",
+      htmlUrl: "https://github.com/acme/team-context-tree",
+      private: true,
+      defaultBranch: "main",
+    });
+  });
+
+  it("reads a repository with an installation token", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const fetcher: typeof fetch = async (input, init) => {
+      calls.push({ url: urlOf(input), init });
+      return new Response(JSON.stringify(repoBody("acme", "tree")), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    };
+
+    const repo = await getRepository("ghs_token", "acme", "tree", { fetcher });
+
+    expect(calls[0]?.url).toBe("https://api.github.com/repos/acme/tree");
+    expect(new Headers(calls[0]?.init?.headers).get("authorization")).toBe("Bearer ghs_token");
+    expect(repo.fullName).toBe("acme/tree");
+  });
+
+  it("creates and verifies a repo file with an installation token", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const fetcher: typeof fetch = async (input, init) => {
+      calls.push({ url: urlOf(input), init });
+      return new Response(JSON.stringify({ path: "NODE.md" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    };
+
+    await getRepoFileWithToken(
+      "ghs_token",
+      { owner: "acme", repo: "tree", path: "NODE.md", branch: "main" },
+      { fetcher },
+    );
+    await createRepoFileWithToken(
+      "ghs_token",
+      {
+        owner: "acme",
+        repo: "tree",
+        path: "NODE.md",
+        branch: "main",
+        message: "Initialize Context Tree root node",
+        contentBase64: "IyBUcmVlCg==",
+      },
+      { fetcher },
+    );
+
+    expect(calls[0]?.url).toBe("https://api.github.com/repos/acme/tree/contents/NODE.md?ref=main");
+    expect(calls[1]?.url).toBe("https://api.github.com/repos/acme/tree/contents/NODE.md");
+    expect(calls[1]?.init?.method).toBe("PUT");
+    expect(JSON.parse(String(calls[1]?.init?.body))).toEqual({
+      message: "Initialize Context Tree root node",
+      content: "IyBUcmVlCg==",
+      branch: "main",
+    });
+  });
+
+  it("throws GithubAppApiError with status and upstream message on helper failures", async () => {
+    const fetcher: typeof fetch = async () =>
+      new Response(JSON.stringify({ message: "Repository creation failed." }), {
+        status: 422,
+        headers: { "content-type": "application/json" },
+      });
+
+    await expect(
+      createOrganizationRepo("ghs_token", { org: "acme", name: "tree", private: true }, { fetcher }),
+    ).rejects.toMatchObject({
+      name: "GithubAppApiError",
+      status: 422,
+      message: expect.stringContaining("Repository creation failed."),
+    });
   });
 });

--- a/packages/server/src/__tests__/oauth-flow.test.ts
+++ b/packages/server/src/__tests__/oauth-flow.test.ts
@@ -399,7 +399,7 @@ describe("OAuth callback rejects malformed state", () => {
     expect(row?.hubOrganizationId).not.toBeNull();
     // App-declared permissions mirror D0b — the dev stub looks like a real
     // install for downstream QA.
-    expect(row?.permissions).toMatchObject({ contents: "write", members: "read" });
+    expect(row?.permissions).toMatchObject({ administration: "write", contents: "write", members: "read" });
   });
 
   it("dev-callback without installationId leaves github_app_installations untouched (legacy OAuth-only dev flow)", async () => {

--- a/packages/server/src/api/auth/github.ts
+++ b/packages/server/src/api/auth/github.ts
@@ -278,6 +278,7 @@ export async function githubOauthRoutes(app: FastifyInstance): Promise<void> {
             accountLogin: params.installationAccountLogin ?? params.login,
             accountGithubId: Number(params.installationAccountGithubId ?? params.githubId),
             permissions: {
+              administration: "write",
               contents: "write",
               pull_requests: "write",
               issues: "read",

--- a/packages/server/src/api/me.ts
+++ b/packages/server/src/api/me.ts
@@ -10,7 +10,6 @@ import { getChannelConfig } from "@first-tree/shared/channel";
 import { and, eq, isNull, ne } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { agents } from "../db/schema/agents.js";
-import { authIdentities } from "../db/schema/auth-identities.js";
 import { clients } from "../db/schema/clients.js";
 import { members } from "../db/schema/members.js";
 import { users } from "../db/schema/users.js";
@@ -20,9 +19,8 @@ import { listAgentsManagedByUser, listOrgsWithUsableNonHumanAgent } from "../ser
 import { resolveAvatarImageUrl } from "../services/agent.js";
 import * as authService from "../services/auth.js";
 import * as clientService from "../services/client.js";
-import { decryptValue, encryptValue } from "../services/crypto.js";
-import { GithubAppApiError, refreshAppUserToken } from "../services/github-app.js";
 import { GithubApiError, listUserRepos } from "../services/github-oauth.js";
+import { GithubUserTokenError, getFreshGithubUserToken } from "../services/github-user-token.js";
 import { buildInviteUrl, findActiveByToken, getActiveInvitation, recordRedemption } from "../services/invitation.js";
 import { updateOwnProfile } from "../services/member.js";
 import {
@@ -249,76 +247,26 @@ export async function meRoutes(app: FastifyInstance): Promise<void> {
    */
   app.get("/me/github/repos", async (request, reply) => {
     const { userId } = requireUser(request);
-    const [identity] = await app.db
-      .select({ metadata: authIdentities.metadata })
-      .from(authIdentities)
-      .where(and(eq(authIdentities.userId, userId), eq(authIdentities.provider, "github")))
-      .limit(1);
-    const metadata = identity?.metadata && typeof identity.metadata === "object" ? identity.metadata : null;
-    const encrypted =
-      metadata && "accessToken" in metadata ? (metadata as { accessToken?: unknown }).accessToken : undefined;
-    if (typeof encrypted !== "string" || !encrypted) {
-      return reply.status(503).send({ error: "GitHub access token unavailable — please reconnect your account" });
-    }
     let token: string;
     try {
-      token = decryptValue(encrypted, app.config.secrets.encryptionKey);
-    } catch {
-      return reply.status(503).send({ error: "GitHub access token could not be decoded — please reconnect" });
-    }
-
-    // Refresh-on-expiry: only attempt when the row carries the
-    // App-flavoured expiry fields. Legacy (pre-App) rows have only
-    // `accessToken` — those tokens don't expire, so skip refresh.
-    const appCfg = app.config.oauth?.githubApp;
-    const expiresAtRaw =
-      metadata && "accessTokenExpiresAt" in metadata
-        ? (metadata as { accessTokenExpiresAt?: unknown }).accessTokenExpiresAt
-        : undefined;
-    const encryptedRefresh =
-      metadata && "refreshToken" in metadata ? (metadata as { refreshToken?: unknown }).refreshToken : undefined;
-    if (typeof expiresAtRaw === "string" && typeof encryptedRefresh === "string" && encryptedRefresh && appCfg) {
-      const expiresAt = Date.parse(expiresAtRaw);
-      // 60-second buffer — refresh slightly early so we don't hit the
-      // window where the token is technically still valid but expires
-      // mid-request.
-      if (!Number.isNaN(expiresAt) && expiresAt - 60_000 <= Date.now()) {
-        try {
-          const refreshPlain = decryptValue(encryptedRefresh, app.config.secrets.encryptionKey);
-          const refreshed = await refreshAppUserToken(appCfg.clientId, appCfg.clientSecret, refreshPlain);
-          // Persist the new pair so subsequent calls don't re-refresh.
-          // GitHub rotates the refresh token on every refresh — using
-          // the old one after this point is `bad_refresh_token`.
-          const nextMetadata: Record<string, unknown> = {
-            ...(metadata ?? {}),
-            accessToken: encryptValue(refreshed.accessToken, app.config.secrets.encryptionKey),
-            accessTokenExpiresAt: refreshed.accessTokenExpiresAt,
-            refreshToken: encryptValue(refreshed.refreshToken, app.config.secrets.encryptionKey),
-            refreshTokenExpiresAt: refreshed.refreshTokenExpiresAt,
-          };
-          await app.db
-            .update(authIdentities)
-            .set({ metadata: nextMetadata, updatedAt: new Date() })
-            .where(and(eq(authIdentities.userId, userId), eq(authIdentities.provider, "github")));
-          token = refreshed.accessToken;
-        } catch (err) {
-          // Refresh failure → caller gets the same "please reconnect"
-          // 503 the legacy paths return. We DON'T fall back to the
-          // expired token because GitHub will reject it anyway and
-          // the user's experience is just a slightly slower 403.
-          app.log.warn({ err, userId }, "github app user-token refresh failed");
-          const status = err instanceof GithubAppApiError ? err.status : 503;
-          if (status === 401) {
-            return reply.status(403).send({
-              error: "Your GitHub session has expired. Please sign in again.",
-              code: "refresh_failed",
-            });
-          }
-          return reply
-            .status(503)
-            .send({ error: "Couldn't refresh GitHub credentials. Try again, or reconnect your GitHub account." });
+      const github = await getFreshGithubUserToken(
+        app.db,
+        userId,
+        app.config.secrets.encryptionKey,
+        app.config.oauth?.githubApp,
+      );
+      token = github.accessToken;
+    } catch (err) {
+      if (err instanceof GithubUserTokenError) {
+        if (err.cause) {
+          app.log.warn({ err: err.cause, userId }, "github user-token refresh failed");
         }
+        return reply.status(err.statusCode).send({
+          error: err.message,
+          ...(err.code ? { code: err.code } : {}),
+        });
       }
+      throw err;
     }
 
     try {

--- a/packages/server/src/api/orgs/context-tree.ts
+++ b/packages/server/src/api/orgs/context-tree.ts
@@ -1,9 +1,17 @@
 import { initializeContextTreeRequestSchema, initializeContextTreeResponseSchema } from "@first-tree/shared";
-import type { FastifyInstance } from "fastify";
-import { AppError, ConflictError, ForbiddenError } from "../../errors.js";
+import type { FastifyInstance, FastifyReply } from "fastify";
+import { ConflictError } from "../../errors.js";
 import { requireOrgAdmin } from "../../scope/require-org.js";
-import { createRepoFile, createUserRepo, GithubApiError } from "../../services/github-oauth.js";
-import { GithubUserTokenError, getFreshGithubUserToken } from "../../services/github-user-token.js";
+import {
+  createOrganizationRepo,
+  createRepoFileWithToken,
+  GithubAppApiError,
+  getRepoFileWithToken,
+  getRepository,
+} from "../../services/github-app.js";
+import { findInstallationByOrg, type InstallationRow } from "../../services/github-app-installations.js";
+import { mintContextTreeInstallationToken } from "../../services/github-app-token.js";
+import type { GithubCreatedRepo } from "../../services/github-oauth.js";
 import { getOrgContextTree, putOrgSetting } from "../../services/org-settings.js";
 import { getOrganization } from "../../services/organization.js";
 
@@ -22,25 +30,36 @@ export async function orgContextTreeRoutes(app: FastifyInstance): Promise<void> 
       throw new ConflictError("Context Tree repo is already configured for this team");
     }
 
-    let github: { accessToken: string; login: string };
-    try {
-      github = await getFreshGithubUserToken(
-        app.db,
-        scope.userId,
-        app.config.secrets.encryptionKey,
-        app.config.oauth?.githubApp,
-      );
-    } catch (err) {
-      if (err instanceof GithubUserTokenError) {
-        if (err.cause) {
-          app.log.warn({ err: err.cause, userId: scope.userId }, "context tree initialize: github token unavailable");
-        }
-        return reply.status(err.statusCode).send({
-          error: err.message,
-          ...(err.code ? { code: err.code } : {}),
-        });
-      }
-      throw err;
+    const installation = await findInstallationByOrg(app.db, scope.organizationId);
+    const mint = await mintContextTreeInstallationToken(installation, app.config.oauth?.githubApp);
+    if (!mint.ok) {
+      return sendMintFailure(reply, mint, scope.organizationId, app);
+    }
+    if (!installation) {
+      return reply.status(503).send({
+        error: "No GitHub App installation is connected for this team yet.",
+        code: "no_installation",
+      });
+    }
+    if (installation.accountType !== "Organization") {
+      return reply.status(409).send({
+        error: "One-click Context Tree initialization requires a GitHub organization installation.",
+        code: "organization_installation_required",
+      });
+    }
+    if (mint.repositorySelection !== "all") {
+      return reply.status(409).send({
+        error:
+          "One-click Context Tree initialization requires the GitHub App installation to have access to all repositories.",
+        code: "selected_repositories_unsupported",
+      });
+    }
+    if (!hasInitializationPermissions(mint.permissions)) {
+      return reply.status(403).send({
+        error:
+          "The GitHub App installation needs administration: write and contents: write permissions to initialize a Context Tree repo.",
+        code: "installation_permissions_insufficient",
+      });
     }
 
     const org = await getOrganization(app.db, scope.organizationId);
@@ -51,38 +70,67 @@ export async function orgContextTreeRoutes(app: FastifyInstance): Promise<void> 
         event: "context_tree.initialize.start",
         organizationId: scope.organizationId,
         userId: scope.userId,
-        githubLogin: github.login,
+        installationId: installation.installationId,
+        githubAccount: installation.accountLogin,
         repoName,
       },
-      "context tree initialize: creating github repo",
+      "context tree initialize: creating or adopting github repo",
     );
 
-    let repo: Awaited<ReturnType<typeof createUserRepo>>;
+    let repo: GithubCreatedRepo;
     try {
-      repo = await createUserRepo(github.accessToken, {
-        name: repoName,
-        private: true,
-        description: `${teamName} Context Tree`,
+      repo = await createOrAdoptContextTreeRepo({
+        installationToken: mint.token,
+        installation,
+        repoName,
+        teamName,
       });
     } catch (err) {
+      if (err instanceof ContextTreeInitializeError) {
+        app.log.warn(
+          {
+            err,
+            organizationId: scope.organizationId,
+            installationId: installation.installationId,
+            githubAccount: installation.accountLogin,
+            repoName,
+            code: err.code,
+          },
+          "context tree initialize: create or adopt github repo failed",
+        );
+        return reply.status(err.statusCode).send({ error: err.message, code: err.code });
+      }
       app.log.warn(
-        { err, organizationId: scope.organizationId, userId: scope.userId, githubLogin: github.login, repoName },
-        "context tree initialize: create github repo failed",
+        {
+          err,
+          organizationId: scope.organizationId,
+          installationId: installation.installationId,
+          githubAccount: installation.accountLogin,
+          repoName,
+        },
+        "context tree initialize: create or adopt github repo failed",
       );
-      throw mapCreateRepoError(err, github.login, repoName);
+      throw err;
     }
 
-    const nodeContent = initialRootNode(teamName, github.login);
+    const nodeContent = initialRootNode(teamName, installation.accountLogin);
     try {
-      await createRepoFile(github.accessToken, {
-        owner: repo.ownerLogin,
-        repo: repo.name,
-        path: ROOT_NODE_PATH,
-        branch: BRANCH,
-        message: "Initialize Context Tree root node",
-        contentBase64: Buffer.from(nodeContent, "utf8").toString("base64"),
-      });
+      await ensureRootNode(mint.token, repo, nodeContent);
     } catch (err) {
+      if (err instanceof ContextTreeInitializeError) {
+        app.log.warn(
+          {
+            err,
+            organizationId: scope.organizationId,
+            userId: scope.userId,
+            repo: repo.fullName,
+            nodePath: ROOT_NODE_PATH,
+            code: err.code,
+          },
+          "context tree initialize: create root node failed",
+        );
+        return reply.status(err.statusCode).send({ error: err.message, code: err.code });
+      }
       app.log.warn(
         {
           err,
@@ -93,7 +141,7 @@ export async function orgContextTreeRoutes(app: FastifyInstance): Promise<void> 
         },
         "context tree initialize: create root node failed",
       );
-      throw mapCreateNodeError(err);
+      throw err;
     }
 
     const setting = await putOrgSetting(
@@ -126,27 +174,146 @@ export async function orgContextTreeRoutes(app: FastifyInstance): Promise<void> 
   });
 }
 
-function mapCreateRepoError(err: unknown, login: string, repoName: string): AppError {
-  if (err instanceof GithubApiError) {
-    if (err.status === 422) {
-      return new ConflictError(`GitHub repo ${login}/${repoName} already exists or the name is unavailable`);
-    }
-    if (err.status === 401 || err.status === 403) {
-      return new ForbiddenError(
-        "GitHub refused repo creation. Please reconnect your GitHub account and grant private repo access.",
-      );
-    }
+class ContextTreeInitializeError extends Error {
+  constructor(
+    public readonly statusCode: number,
+    public readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ContextTreeInitializeError";
   }
-  return new AppError(502, "Couldn't create the GitHub repo. Try again in a moment.");
 }
 
-function mapCreateNodeError(err: unknown): AppError {
-  if (err instanceof GithubApiError && (err.status === 401 || err.status === 403)) {
-    return new ForbiddenError(
-      "GitHub refused Context Tree root-node creation. Please reconnect your GitHub account and grant repo access.",
-    );
+function sendMintFailure(
+  reply: FastifyReply,
+  mint: Exclude<Awaited<ReturnType<typeof mintContextTreeInstallationToken>>, { ok: true }>,
+  organizationId: string,
+  app: FastifyInstance,
+) {
+  if (mint.reason === "no-installation") {
+    return reply
+      .status(503)
+      .send({ error: "No GitHub App installation is connected for this team yet.", code: "no_installation" });
   }
-  return new AppError(502, "Couldn't initialize the Context Tree root node. Try again in a moment.");
+  if (mint.reason === "suspended") {
+    return reply.status(503).send({ error: "This team's GitHub App installation is suspended.", code: "suspended" });
+  }
+  if (mint.reason === "no-app-config") {
+    return reply.status(503).send({ error: "GitHub App is not configured on this server.", code: "not_configured" });
+  }
+  app.log.warn({ organizationId, detail: mint.detail }, "context tree initialize: installation token mint failed");
+  return reply.status(502).send({ error: "Couldn't reach GitHub. Try again in a moment.", code: "upstream" });
+}
+
+function hasInitializationPermissions(permissions: Record<string, "read" | "write" | "admin">): boolean {
+  return permissions.administration === "write" && permissions.contents === "write";
+}
+
+async function createOrAdoptContextTreeRepo(input: {
+  installationToken: string;
+  installation: InstallationRow;
+  repoName: string;
+  teamName: string;
+}): Promise<GithubCreatedRepo> {
+  try {
+    const created = await createOrganizationRepo(input.installationToken, {
+      org: input.installation.accountLogin,
+      name: input.repoName,
+      private: true,
+      description: `${input.teamName} Context Tree`,
+    });
+    return await verifyCreatedRepository(input.installationToken, created.ownerLogin, created.name);
+  } catch (err) {
+    if (err instanceof GithubAppApiError && err.status === 422) {
+      return await adoptExistingRepository(input.installationToken, input.installation.accountLogin, input.repoName);
+    }
+    throw mapUpstreamError(err, "Couldn't create the GitHub repo. Try again in a moment.");
+  }
+}
+
+async function verifyCreatedRepository(
+  installationToken: string,
+  owner: string,
+  repoName: string,
+): Promise<GithubCreatedRepo> {
+  try {
+    return await getRepository(installationToken, owner, repoName);
+  } catch (err) {
+    throw mapUpstreamError(err, "Couldn't verify the created GitHub repo. Try again in a moment.");
+  }
+}
+
+async function adoptExistingRepository(
+  installationToken: string,
+  owner: string,
+  repoName: string,
+): Promise<GithubCreatedRepo> {
+  try {
+    return await getRepository(installationToken, owner, repoName);
+  } catch (err) {
+    if (err instanceof GithubAppApiError && (err.status === 403 || err.status === 404)) {
+      throw new ContextTreeInitializeError(
+        409,
+        "repo_unavailable",
+        `GitHub repo ${owner}/${repoName} already exists but is not accessible to this team's GitHub App installation.`,
+      );
+    }
+    throw mapUpstreamError(err, "Couldn't verify the existing GitHub repo. Try again in a moment.");
+  }
+}
+
+async function ensureRootNode(installationToken: string, repo: GithubCreatedRepo, nodeContent: string): Promise<void> {
+  try {
+    await getRepoFileWithToken(installationToken, {
+      owner: repo.ownerLogin,
+      repo: repo.name,
+      path: ROOT_NODE_PATH,
+      branch: BRANCH,
+    });
+    return;
+  } catch (err) {
+    if (!(err instanceof GithubAppApiError) || err.status !== 404) {
+      throw mapUpstreamError(err, "Couldn't verify the Context Tree root node. Try again in a moment.");
+    }
+  }
+
+  try {
+    await createRepoFileWithToken(installationToken, {
+      owner: repo.ownerLogin,
+      repo: repo.name,
+      path: ROOT_NODE_PATH,
+      branch: BRANCH,
+      message: "Initialize Context Tree root node",
+      contentBase64: Buffer.from(nodeContent, "utf8").toString("base64"),
+    });
+  } catch (err) {
+    if (err instanceof GithubAppApiError && (err.status === 409 || err.status === 422)) {
+      await verifyExistingRootNode(installationToken, repo);
+      return;
+    }
+    throw mapUpstreamError(err, "Couldn't initialize the Context Tree root node. Try again in a moment.");
+  }
+}
+
+async function verifyExistingRootNode(installationToken: string, repo: GithubCreatedRepo): Promise<void> {
+  try {
+    await getRepoFileWithToken(installationToken, {
+      owner: repo.ownerLogin,
+      repo: repo.name,
+      path: ROOT_NODE_PATH,
+      branch: BRANCH,
+    });
+  } catch (err) {
+    throw mapUpstreamError(err, "Couldn't verify the existing Context Tree root node. Try again in a moment.");
+  }
+}
+
+function mapUpstreamError(err: unknown, message: string): ContextTreeInitializeError {
+  if (err instanceof ContextTreeInitializeError) {
+    return err;
+  }
+  return new ContextTreeInitializeError(502, "upstream", message);
 }
 
 function contextTreeRepoName(teamName: string): string {

--- a/packages/server/src/api/orgs/context-tree.ts
+++ b/packages/server/src/api/orgs/context-tree.ts
@@ -1,0 +1,187 @@
+import { initializeContextTreeRequestSchema, initializeContextTreeResponseSchema } from "@first-tree/shared";
+import type { FastifyInstance } from "fastify";
+import { AppError, ConflictError, ForbiddenError } from "../../errors.js";
+import { requireOrgAdmin } from "../../scope/require-org.js";
+import { createRepoFile, createUserRepo, GithubApiError } from "../../services/github-oauth.js";
+import { GithubUserTokenError, getFreshGithubUserToken } from "../../services/github-user-token.js";
+import { getOrgContextTree, putOrgSetting } from "../../services/org-settings.js";
+import { getOrganization } from "../../services/organization.js";
+
+const BRANCH = "main";
+const ROOT_NODE_PATH = "NODE.md";
+const REPO_SUFFIX = "-context-tree";
+const GITHUB_REPO_NAME_MAX_LENGTH = 100;
+
+export async function orgContextTreeRoutes(app: FastifyInstance): Promise<void> {
+  app.post<{ Params: { orgId: string }; Body: unknown }>("/initialize", async (request, reply) => {
+    initializeContextTreeRequestSchema.parse(request.body ?? {});
+    const scope = await requireOrgAdmin(request, app.db);
+
+    const existing = await getOrgContextTree(app.db, scope.organizationId);
+    if (existing.repo) {
+      throw new ConflictError("Context Tree repo is already configured for this team");
+    }
+
+    let github: { accessToken: string; login: string };
+    try {
+      github = await getFreshGithubUserToken(
+        app.db,
+        scope.userId,
+        app.config.secrets.encryptionKey,
+        app.config.oauth?.githubApp,
+      );
+    } catch (err) {
+      if (err instanceof GithubUserTokenError) {
+        if (err.cause) {
+          app.log.warn({ err: err.cause, userId: scope.userId }, "context tree initialize: github token unavailable");
+        }
+        return reply.status(err.statusCode).send({
+          error: err.message,
+          ...(err.code ? { code: err.code } : {}),
+        });
+      }
+      throw err;
+    }
+
+    const org = await getOrganization(app.db, scope.organizationId);
+    const teamName = normalizeInlineText(org.displayName) || org.name;
+    const repoName = contextTreeRepoName(teamName);
+    app.log.info(
+      {
+        event: "context_tree.initialize.start",
+        organizationId: scope.organizationId,
+        userId: scope.userId,
+        githubLogin: github.login,
+        repoName,
+      },
+      "context tree initialize: creating github repo",
+    );
+
+    let repo: Awaited<ReturnType<typeof createUserRepo>>;
+    try {
+      repo = await createUserRepo(github.accessToken, {
+        name: repoName,
+        private: true,
+        description: `${teamName} Context Tree`,
+      });
+    } catch (err) {
+      app.log.warn(
+        { err, organizationId: scope.organizationId, userId: scope.userId, githubLogin: github.login, repoName },
+        "context tree initialize: create github repo failed",
+      );
+      throw mapCreateRepoError(err, github.login, repoName);
+    }
+
+    const nodeContent = initialRootNode(teamName, github.login);
+    try {
+      await createRepoFile(github.accessToken, {
+        owner: repo.ownerLogin,
+        repo: repo.name,
+        path: ROOT_NODE_PATH,
+        branch: BRANCH,
+        message: "Initialize Context Tree root node",
+        contentBase64: Buffer.from(nodeContent, "utf8").toString("base64"),
+      });
+    } catch (err) {
+      app.log.warn(
+        {
+          err,
+          organizationId: scope.organizationId,
+          userId: scope.userId,
+          repo: repo.fullName,
+          nodePath: ROOT_NODE_PATH,
+        },
+        "context tree initialize: create root node failed",
+      );
+      throw mapCreateNodeError(err);
+    }
+
+    const setting = await putOrgSetting(
+      app.db,
+      scope.organizationId,
+      "context_tree",
+      { repo: repo.cloneUrl, branch: BRANCH },
+      { updatedBy: scope.userId },
+    );
+
+    app.log.info(
+      {
+        event: "context_tree.initialize.complete",
+        organizationId: scope.organizationId,
+        userId: scope.userId,
+        repo: repo.fullName,
+        nodePath: ROOT_NODE_PATH,
+      },
+      "context tree initialize: saved organization setting",
+    );
+
+    return reply.status(201).send(
+      initializeContextTreeResponseSchema.parse({
+        repo: setting.repo ?? repo.cloneUrl,
+        htmlUrl: repo.htmlUrl,
+        branch: BRANCH,
+        nodePath: ROOT_NODE_PATH,
+      }),
+    );
+  });
+}
+
+function mapCreateRepoError(err: unknown, login: string, repoName: string): AppError {
+  if (err instanceof GithubApiError) {
+    if (err.status === 422) {
+      return new ConflictError(`GitHub repo ${login}/${repoName} already exists or the name is unavailable`);
+    }
+    if (err.status === 401 || err.status === 403) {
+      return new ForbiddenError(
+        "GitHub refused repo creation. Please reconnect your GitHub account and grant private repo access.",
+      );
+    }
+  }
+  return new AppError(502, "Couldn't create the GitHub repo. Try again in a moment.");
+}
+
+function mapCreateNodeError(err: unknown): AppError {
+  if (err instanceof GithubApiError && (err.status === 401 || err.status === 403)) {
+    return new ForbiddenError(
+      "GitHub refused Context Tree root-node creation. Please reconnect your GitHub account and grant repo access.",
+    );
+  }
+  return new AppError(502, "Couldn't initialize the Context Tree root node. Try again in a moment.");
+}
+
+function contextTreeRepoName(teamName: string): string {
+  const maxBaseLength = GITHUB_REPO_NAME_MAX_LENGTH - REPO_SUFFIX.length;
+  const base = slugifyRepoBase(teamName).slice(0, maxBaseLength).replace(/-+$/g, "") || "team";
+  return `${base}${REPO_SUFFIX}`;
+}
+
+function slugifyRepoBase(value: string): string {
+  const ascii = value.normalize("NFKD").replace(/[\u0300-\u036f]/g, "");
+  const slug = ascii
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/-{2,}/g, "-");
+  return slug || "team";
+}
+
+function initialRootNode(teamName: string, githubLogin: string): string {
+  const title = `${teamName} Context Tree`;
+  const description = `Shared context, decisions, ownership, and operating knowledge for ${teamName}.`;
+  return `---
+title: ${yamlDoubleQuote(title)}
+description: ${yamlDoubleQuote(description)}
+owners: [${githubLogin}]
+---
+
+# ${teamName}'s Context Tree
+`;
+}
+
+function yamlDoubleQuote(value: string): string {
+  return JSON.stringify(normalizeInlineText(value));
+}
+
+function normalizeInlineText(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -45,6 +45,7 @@ import { orgAgentRoutes } from "./api/orgs/agents.js";
 import { orgAttachmentRoutes } from "./api/orgs/attachments.js";
 import { orgChatRoutes } from "./api/orgs/chats.js";
 import { orgClientRoutes } from "./api/orgs/clients.js";
+import { orgContextTreeRoutes } from "./api/orgs/context-tree.js";
 import { orgContextTreeSnapshotRoutes } from "./api/orgs/context-tree-snapshot.js";
 import { orgGithubAppRoutes } from "./api/orgs/github-app.js";
 import { orgIdentityRoutes } from "./api/orgs/identity.js";
@@ -540,6 +541,7 @@ export async function buildApp(config: Config) {
           await scope.register(orgSettingsRoutes, { prefix: "/settings" });
           await scope.register(orgResourceRoutes, { prefix: "/resources" });
           await scope.register(orgGithubAppRoutes, { prefix: "/github-app-installation" });
+          await scope.register(orgContextTreeRoutes, { prefix: "/context-tree" });
           await scope.register(orgContextTreeSnapshotRoutes, { prefix: "/context-tree" });
           await scope.register(orgAttachmentRoutes, { prefix: "/attachments" });
         }),

--- a/packages/server/src/services/github-app-token.ts
+++ b/packages/server/src/services/github-app-token.ts
@@ -1,6 +1,12 @@
 import type { ContextTreeSnapshot } from "@first-tree/shared";
 import { type ContextTreeBinding, isGithubRemoteBinding } from "./context-tree-snapshot.js";
-import { createAppJwt, GithubAppApiError, type GithubAppCredentials, mintInstallationToken } from "./github-app.js";
+import {
+  createAppJwt,
+  GithubAppApiError,
+  type GithubAppCredentials,
+  type InstallationToken,
+  mintInstallationToken,
+} from "./github-app.js";
 import type { InstallationRow } from "./github-app-installations.js";
 
 /**
@@ -14,7 +20,12 @@ import type { InstallationRow } from "./github-app-installations.js";
  *                 pick a user-facing remediation message.
  */
 export type ContextTreeInstallationTokenResult =
-  | { ok: true; token: string }
+  | {
+      ok: true;
+      token: string;
+      permissions: InstallationToken["permissions"];
+      repositorySelection: InstallationToken["repositorySelection"];
+    }
   | { ok: false; reason: "no-app-config" | "no-installation" | "suspended" | "mint-failed"; detail?: string };
 
 export type MintContextTreeInstallationTokenOptions = {
@@ -59,7 +70,12 @@ export async function mintContextTreeInstallationToken(
       privateKeyPem: appCredentials.privateKeyPem,
     });
     const minted = await mintInstallationToken(appJwt, installation.installationId, { fetcher: options.fetcher });
-    return { ok: true, token: minted.token };
+    return {
+      ok: true,
+      token: minted.token,
+      permissions: minted.permissions,
+      repositorySelection: minted.repositorySelection,
+    };
   } catch (error) {
     const detail =
       error instanceof GithubAppApiError

--- a/packages/server/src/services/github-app.ts
+++ b/packages/server/src/services/github-app.ts
@@ -1,7 +1,7 @@
 import { importPKCS8, SignJWT } from "jose";
 import type { GithubProfile } from "./auth-identity.js";
 import { GITHUB_API_BASE } from "./github-api-base.js";
-import type { GithubRepo } from "./github-oauth.js";
+import type { GithubCreatedRepo, GithubRepo } from "./github-oauth.js";
 
 /**
  * GitHub App service helpers. Two surfaces that ride on top of an App's
@@ -50,6 +50,11 @@ const APP_JWT_IAT_SKEW_SECONDS = 60;
 const APP_INSTALLATION_TOKEN_URL = (id: number) => `${GITHUB_API_BASE}/app/installations/${id}/access_tokens`;
 const APP_INSTALLATION_URL = (id: number) => `${GITHUB_API_BASE}/app/installations/${id}`;
 const INSTALLATION_REPOS_URL = `${GITHUB_API_BASE}/installation/repositories`;
+const ORGANIZATION_REPOS_URL = (org: string) => `${GITHUB_API_BASE}/orgs/${encodeURIComponent(org)}/repos`;
+const REPOSITORY_URL = (owner: string, repo: string) =>
+  `${GITHUB_API_BASE}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`;
+const REPOSITORY_CONTENTS_URL = (owner: string, repo: string, path: string) =>
+  `${REPOSITORY_URL(owner, repo)}/contents/${encodePath(path)}`;
 const OAUTH_TOKEN_URL = "https://github.com/login/oauth/access_token";
 const OAUTH_AUTHORIZE_URL = "https://github.com/login/oauth/authorize";
 const USER_API_URL = `${GITHUB_API_BASE}/user`;
@@ -354,6 +359,95 @@ export async function listInstallationRepos(
   return out;
 }
 
+/**
+ * Create a repository under an organization account using a GitHub App
+ * installation token. GitHub supports this only for organization installs
+ * whose token has `administration: write`; callers should enforce that before
+ * invoking the upstream side effect so permission failures are stable and
+ * explainable.
+ */
+export async function createOrganizationRepo(
+  installationToken: string,
+  input: { org: string; name: string; description?: string; private: boolean },
+  opts: { fetcher?: typeof fetch } = {},
+): Promise<GithubCreatedRepo> {
+  const fetcher = opts.fetcher ?? fetch;
+  const payload: Record<string, unknown> = {
+    name: input.name,
+    private: input.private,
+    auto_init: false,
+  };
+  if (input.description) payload.description = input.description;
+
+  const res = await fetcher(ORGANIZATION_REPOS_URL(input.org), {
+    method: "POST",
+    headers: githubJsonHeaders(installationToken),
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    throw await githubAppApiError(res, "GitHub organization repo create failed");
+  }
+  return parseGithubRepo(await res.json(), "GitHub organization repo create returned an invalid response");
+}
+
+/**
+ * Read a repository with an installation token. The Context Tree initializer
+ * uses this as the same authority check the snapshot path relies on: if the
+ * bound installation cannot read the repo, First Tree must not persist it as
+ * this team's tree binding.
+ */
+export async function getRepository(
+  installationToken: string,
+  owner: string,
+  repo: string,
+  opts: { fetcher?: typeof fetch } = {},
+): Promise<GithubCreatedRepo> {
+  const fetcher = opts.fetcher ?? fetch;
+  const res = await fetcher(REPOSITORY_URL(owner, repo), {
+    headers: githubJsonHeaders(installationToken),
+  });
+  if (!res.ok) {
+    throw await githubAppApiError(res, "GitHub repository fetch failed");
+  }
+  return parseGithubRepo(await res.json(), "GitHub repository fetch returned an invalid response");
+}
+
+export async function getRepoFileWithToken(
+  installationToken: string,
+  input: { owner: string; repo: string; path: string; branch: string },
+  opts: { fetcher?: typeof fetch } = {},
+): Promise<void> {
+  const fetcher = opts.fetcher ?? fetch;
+  const url = new URL(REPOSITORY_CONTENTS_URL(input.owner, input.repo, input.path));
+  url.searchParams.set("ref", input.branch);
+  const res = await fetcher(url.toString(), {
+    headers: githubJsonHeaders(installationToken),
+  });
+  if (!res.ok) {
+    throw await githubAppApiError(res, "GitHub file fetch failed");
+  }
+}
+
+export async function createRepoFileWithToken(
+  installationToken: string,
+  input: { owner: string; repo: string; path: string; branch: string; message: string; contentBase64: string },
+  opts: { fetcher?: typeof fetch } = {},
+): Promise<void> {
+  const fetcher = opts.fetcher ?? fetch;
+  const res = await fetcher(REPOSITORY_CONTENTS_URL(input.owner, input.repo, input.path), {
+    method: "PUT",
+    headers: githubJsonHeaders(installationToken),
+    body: JSON.stringify({
+      message: input.message,
+      content: input.contentBase64,
+      branch: input.branch,
+    }),
+  });
+  if (!res.ok) {
+    throw await githubAppApiError(res, "GitHub file create failed");
+  }
+}
+
 export type RefreshedUserToken = {
   accessToken: string;
   /** ISO-8601. Typically ~8h after issue. */
@@ -369,6 +463,84 @@ export type RefreshedUserToken = {
   /** Granted scopes, comma-joined. Forwarded verbatim from GitHub. */
   scope: string;
 };
+
+function githubJsonHeaders(accessToken: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${accessToken}`,
+    Accept: "application/vnd.github+json",
+    "Content-Type": "application/json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+}
+
+async function githubAppApiError(res: Response, fallback: string): Promise<GithubAppApiError> {
+  const upstreamMessage = await readGithubErrorMessage(res);
+  return new GithubAppApiError(
+    res.status,
+    `${fallback} (${res.status})${upstreamMessage ? `: ${upstreamMessage}` : ""}`,
+  );
+}
+
+async function readGithubErrorMessage(res: Response): Promise<string | null> {
+  const contentType = res.headers.get("content-type") ?? "";
+  if (contentType.includes("application/json")) {
+    const body = await res.json().catch(() => null);
+    if (isRecord(body)) {
+      const message = readString(body, "message");
+      if (message) return message;
+    }
+    return null;
+  }
+  const text = await res.text().catch(() => "");
+  const trimmed = text.trim();
+  return trimmed.length > 0 ? trimmed.slice(0, 200) : null;
+}
+
+function parseGithubRepo(body: unknown, invalidMessage: string): GithubCreatedRepo {
+  if (!isRecord(body)) {
+    throw new GithubAppApiError(502, invalidMessage);
+  }
+  const owner = isRecord(body.owner) ? readString(body.owner, "login") : null;
+  const name = readString(body, "name");
+  const fullName = readString(body, "full_name");
+  const cloneUrl = readString(body, "clone_url");
+  const htmlUrl = readString(body, "html_url");
+  const isPrivate = readBoolean(body, "private");
+  if (!owner || !name || !fullName || !cloneUrl || !htmlUrl || isPrivate === null) {
+    throw new GithubAppApiError(502, invalidMessage);
+  }
+  return {
+    name,
+    fullName,
+    ownerLogin: owner,
+    cloneUrl,
+    htmlUrl,
+    private: isPrivate,
+    defaultBranch: readString(body, "default_branch"),
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function readString(record: Record<string, unknown>, key: string): string | null {
+  const value = record[key];
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function readBoolean(record: Record<string, unknown>, key: string): boolean | null {
+  const value = record[key];
+  return typeof value === "boolean" ? value : null;
+}
+
+function encodePath(path: string): string {
+  return path
+    .split("/")
+    .filter((part) => part.length > 0)
+    .map((part) => encodeURIComponent(part))
+    .join("/");
+}
 
 /**
  * Trade an expiring user-to-server access token for a fresh pair using

--- a/packages/server/src/services/github-oauth.ts
+++ b/packages/server/src/services/github-oauth.ts
@@ -29,6 +29,16 @@ export type GithubRepo = {
   pushedAt: string | null;
 };
 
+export type GithubCreatedRepo = {
+  name: string;
+  fullName: string;
+  ownerLogin: string;
+  cloneUrl: string;
+  htmlUrl: string;
+  private: boolean;
+  defaultBranch: string | null;
+};
+
 /**
  * Thrown when GitHub's API returns a non-2xx for a token-scoped call.
  * Carries the HTTP status so callers can distinguish auth failures (401 /
@@ -91,4 +101,107 @@ export async function listUserRepos(
     if (rows.length < perPage) break;
   }
   return out;
+}
+
+export async function createUserRepo(
+  accessToken: string,
+  input: { name: string; description?: string; private: boolean },
+  opts: { fetcher?: typeof fetch } = {},
+): Promise<GithubCreatedRepo> {
+  const fetcher = opts.fetcher ?? fetch;
+  const payload: Record<string, unknown> = {
+    name: input.name,
+    private: input.private,
+    auto_init: false,
+  };
+  if (input.description) payload.description = input.description;
+
+  const res = await fetcher(`${GITHUB_API_BASE}/user/repos`, {
+    method: "POST",
+    headers: githubJsonHeaders(accessToken),
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    throw new GithubApiError(res.status, `GitHub repo create failed (${res.status})`);
+  }
+  return parseCreatedRepo(await res.json());
+}
+
+export async function createRepoFile(
+  accessToken: string,
+  input: { owner: string; repo: string; path: string; branch: string; message: string; contentBase64: string },
+  opts: { fetcher?: typeof fetch } = {},
+): Promise<void> {
+  const fetcher = opts.fetcher ?? fetch;
+  const path = encodePath(input.path);
+  const res = await fetcher(
+    `${GITHUB_API_BASE}/repos/${encodeURIComponent(input.owner)}/${encodeURIComponent(input.repo)}/contents/${path}`,
+    {
+      method: "PUT",
+      headers: githubJsonHeaders(accessToken),
+      body: JSON.stringify({
+        message: input.message,
+        content: input.contentBase64,
+        branch: input.branch,
+      }),
+    },
+  );
+  if (!res.ok) {
+    throw new GithubApiError(res.status, `GitHub file create failed (${res.status})`);
+  }
+}
+
+function githubJsonHeaders(accessToken: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${accessToken}`,
+    Accept: "application/vnd.github+json",
+    "Content-Type": "application/json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+}
+
+function parseCreatedRepo(body: unknown): GithubCreatedRepo {
+  if (!isRecord(body)) {
+    throw new GithubApiError(502, "GitHub repo create returned an invalid response");
+  }
+  const owner = isRecord(body.owner) ? readString(body.owner, "login") : null;
+  const name = readString(body, "name");
+  const fullName = readString(body, "full_name");
+  const cloneUrl = readString(body, "clone_url");
+  const htmlUrl = readString(body, "html_url");
+  const isPrivate = readBoolean(body, "private");
+  if (!owner || !name || !fullName || !cloneUrl || !htmlUrl || isPrivate === null) {
+    throw new GithubApiError(502, "GitHub repo create returned an invalid response");
+  }
+  return {
+    name,
+    fullName,
+    ownerLogin: owner,
+    cloneUrl,
+    htmlUrl,
+    private: isPrivate,
+    defaultBranch: readString(body, "default_branch"),
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function readString(record: Record<string, unknown>, key: string): string | null {
+  const value = record[key];
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function readBoolean(record: Record<string, unknown>, key: string): boolean | null {
+  const value = record[key];
+  return typeof value === "boolean" ? value : null;
+}
+
+function encodePath(path: string): string {
+  return path
+    .split("/")
+    .filter((part) => part.length > 0)
+    .map((part) => encodeURIComponent(part))
+    .join("/");
 }

--- a/packages/server/src/services/github-user-token.ts
+++ b/packages/server/src/services/github-user-token.ts
@@ -1,0 +1,113 @@
+import { and, eq } from "drizzle-orm";
+import type { Database } from "../db/connection.js";
+import { authIdentities } from "../db/schema/auth-identities.js";
+import { decryptValue, encryptValue } from "./crypto.js";
+import { GithubAppApiError, refreshAppUserToken } from "./github-app.js";
+
+const REFRESH_BUFFER_MS = 60_000;
+
+export type GithubUserTokenRefreshConfig = {
+  clientId: string;
+  clientSecret: string;
+};
+
+export type GithubUserToken = {
+  accessToken: string;
+  login: string;
+  githubId: string;
+};
+
+export class GithubUserTokenError extends Error {
+  constructor(
+    public readonly statusCode: 403 | 503,
+    message: string,
+    public readonly code?: string,
+    public readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = "GithubUserTokenError";
+  }
+}
+
+export async function getFreshGithubUserToken(
+  db: Database,
+  userId: string,
+  encryptionKey: string,
+  refreshConfig: GithubUserTokenRefreshConfig | undefined,
+): Promise<GithubUserToken> {
+  const [identity] = await db
+    .select({ identifier: authIdentities.identifier, metadata: authIdentities.metadata })
+    .from(authIdentities)
+    .where(and(eq(authIdentities.userId, userId), eq(authIdentities.provider, "github")))
+    .limit(1);
+
+  const metadata = isRecord(identity?.metadata) ? identity.metadata : null;
+  const login = metadata ? readString(metadata, "login") : null;
+  const encrypted = metadata ? readString(metadata, "accessToken") : null;
+  if (!identity || !metadata || !login || !encrypted) {
+    throw new GithubUserTokenError(503, "GitHub credentials unavailable. Please reconnect your GitHub account.");
+  }
+
+  let accessToken: string;
+  try {
+    accessToken = decryptValue(encrypted, encryptionKey);
+  } catch (err) {
+    throw new GithubUserTokenError(
+      503,
+      "GitHub access token could not be decoded. Please reconnect your GitHub account.",
+      undefined,
+      err,
+    );
+  }
+
+  const expiresAtRaw = readString(metadata, "accessTokenExpiresAt");
+  const encryptedRefresh = readString(metadata, "refreshToken");
+  if (expiresAtRaw && encryptedRefresh && refreshConfig) {
+    const expiresAt = Date.parse(expiresAtRaw);
+    if (!Number.isNaN(expiresAt) && expiresAt - REFRESH_BUFFER_MS <= Date.now()) {
+      try {
+        const refreshPlain = decryptValue(encryptedRefresh, encryptionKey);
+        const refreshed = await refreshAppUserToken(refreshConfig.clientId, refreshConfig.clientSecret, refreshPlain);
+        const nextMetadata: Record<string, unknown> = {
+          ...metadata,
+          accessToken: encryptValue(refreshed.accessToken, encryptionKey),
+          accessTokenExpiresAt: refreshed.accessTokenExpiresAt,
+          refreshToken: encryptValue(refreshed.refreshToken, encryptionKey),
+          refreshTokenExpiresAt: refreshed.refreshTokenExpiresAt,
+        };
+        await db
+          .update(authIdentities)
+          .set({ metadata: nextMetadata, updatedAt: new Date() })
+          .where(and(eq(authIdentities.userId, userId), eq(authIdentities.provider, "github")));
+        accessToken = refreshed.accessToken;
+      } catch (err) {
+        const status = err instanceof GithubAppApiError ? err.status : 503;
+        if (status === 401) {
+          throw new GithubUserTokenError(
+            403,
+            "Your GitHub session has expired. Please sign in again.",
+            "refresh_failed",
+            err,
+          );
+        }
+        throw new GithubUserTokenError(
+          503,
+          "Couldn't refresh GitHub credentials. Try again, or reconnect your GitHub account.",
+          undefined,
+          err,
+        );
+      }
+    }
+  }
+
+  return { accessToken, login, githubId: identity.identifier };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function readString(record: Record<string, unknown>, key: string): string | null {
+  const value = record[key];
+  return typeof value === "string" && value.length > 0 ? value : null;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -284,6 +284,10 @@ export {
   contextTreeUpdateSchema,
   contextTreeUsageEventSchema,
   contextTreeUsageSummarySchema,
+  type InitializeContextTreeRequest,
+  type InitializeContextTreeResponse,
+  initializeContextTreeRequestSchema,
+  initializeContextTreeResponseSchema,
 } from "./schemas/context-tree.js";
 export {
   GITHUB_ACCOUNT_TYPES,

--- a/packages/shared/src/schemas/context-tree.ts
+++ b/packages/shared/src/schemas/context-tree.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { repoUrlSchema } from "./org-settings.js";
 
 export const CONTEXT_TREE_SNAPSHOT_STATUSES = {
   ACTIVE: "active",
@@ -247,3 +248,14 @@ export const contextTreeSnapshotSchema = z.object({
   changes: z.array(contextTreeChangeSchema),
 });
 export type ContextTreeSnapshot = z.infer<typeof contextTreeSnapshotSchema>;
+
+export const initializeContextTreeRequestSchema = z.object({}).strict();
+export type InitializeContextTreeRequest = z.infer<typeof initializeContextTreeRequestSchema>;
+
+export const initializeContextTreeResponseSchema = z.object({
+  repo: repoUrlSchema,
+  htmlUrl: z.string().url(),
+  branch: z.literal("main"),
+  nodePath: z.literal("NODE.md"),
+});
+export type InitializeContextTreeResponse = z.infer<typeof initializeContextTreeResponseSchema>;

--- a/packages/web/src/api/__tests__/api-wrappers.test.ts
+++ b/packages/web/src/api/__tests__/api-wrappers.test.ts
@@ -72,6 +72,7 @@ describe("api wrapper paths", () => {
     await activity.generateConnectToken();
 
     await contextTree.getContextTreeSnapshot("org/id", "7d");
+    await contextTree.initializeContextTree("org/id");
     await orgSettings.getContextTreeSetting("org/id");
     await orgSettings.putContextTreeSetting("org/id", { repo: "https://github.com/acme/tree", branch: "main" });
     await orgSettings.deleteContextTreeSetting("org/id");
@@ -114,6 +115,7 @@ describe("api wrapper paths", () => {
     expect(apiMock.post).toHaveBeenCalledWith("/agents/agent%2Fid/reset-activity");
     expect(apiMock.post).toHaveBeenCalledWith("/me/connect-tokens");
     expect(apiMock.get).toHaveBeenCalledWith("/orgs/org%2Fid/context-tree/snapshot?window=7d");
+    expect(apiMock.post).toHaveBeenCalledWith("/orgs/org%2Fid/context-tree/initialize", {});
     expect(apiMock.put).toHaveBeenCalledWith("/orgs/org%2Fid/settings/context_tree", {
       repo: "https://github.com/acme/tree",
       branch: "main",

--- a/packages/web/src/api/context-tree.ts
+++ b/packages/web/src/api/context-tree.ts
@@ -1,4 +1,4 @@
-import type { ContextTreeSnapshot } from "@first-tree/shared";
+import type { ContextTreeSnapshot, InitializeContextTreeResponse } from "@first-tree/shared";
 import { api, withOrgAt } from "./client.js";
 
 export type ContextTreeWindow = "1d" | "7d" | "30d";
@@ -9,4 +9,8 @@ export function getContextTreeSnapshot(
 ): Promise<ContextTreeSnapshot> {
   const query = `?window=${encodeURIComponent(window)}`;
   return api.get<ContextTreeSnapshot>(withOrgAt(organizationId, `/context-tree/snapshot${query}`));
+}
+
+export function initializeContextTree(organizationId: string): Promise<InitializeContextTreeResponse> {
+  return api.post<InitializeContextTreeResponse>(withOrgAt(organizationId, "/context-tree/initialize"), {});
 }

--- a/packages/web/src/pages/__tests__/context-page-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/context-page-dom.test.tsx
@@ -12,11 +12,13 @@ globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
 const contextApiMocks = vi.hoisted(() => ({
   getContextTreeSnapshot: vi.fn(),
+  initializeContextTree: vi.fn(),
 }));
 
 const authMock = vi.hoisted(() => ({
   value: {
     organizationId: "org-1" as string | null,
+    role: "member" as "admin" | "member" | null,
   },
 }));
 
@@ -114,6 +116,15 @@ async function waitForText(container: ParentNode, text: string, timeoutMs = 3000
   throw new Error(`Missing text: ${text}\n${container.textContent ?? ""}`);
 }
 
+async function waitForCondition(predicate: () => boolean, message: string, timeoutMs = 3000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await flush();
+  }
+  throw new Error(message);
+}
+
 function snapshot(overrides: Partial<ContextTreeSnapshot> = {}): ContextTreeSnapshot {
   return {
     ...MOCK_CONTEXT_SNAPSHOT,
@@ -157,8 +168,15 @@ function buttonByText(container: ParentNode, text: string): HTMLButtonElement | 
 beforeEach(() => {
   document.body.innerHTML = "";
   vi.useRealTimers();
-  authMock.value = { organizationId: "org-1" };
+  authMock.value = { organizationId: "org-1", role: "member" };
   contextApiMocks.getContextTreeSnapshot.mockReset();
+  contextApiMocks.initializeContextTree.mockReset();
+  contextApiMocks.initializeContextTree.mockResolvedValue({
+    repo: "https://github.com/acme/acme-context-tree.git",
+    htmlUrl: "https://github.com/acme/acme-context-tree",
+    branch: "main",
+    nodePath: "NODE.md",
+  });
 });
 
 afterEach(() => {
@@ -277,8 +295,56 @@ describe("ContextPage DOM behavior", () => {
       />,
     );
     expect(disconnected.container.textContent).toContain("Connect Context Tree");
-    expect(disconnected.container.textContent).toContain("Connect a Context Tree repo");
+    expect(disconnected.container.textContent).toContain("Ask an admin to initialize");
+    expect(buttonByText(disconnected.container, "Create private GitHub repo")).toBeNull();
     await act(async () => disconnected.root.unmount());
+  });
+
+  it("initializes the context tree from the live unavailable admin state", async () => {
+    authMock.value = { organizationId: "org-1", role: "admin" };
+    const { ContextPage } = await import("../context.js");
+    const unavailable = snapshot({
+      repo: null,
+      branch: null,
+      snapshotStatus: "unavailable",
+      contextStatus: { label: "Not configured", detail: null, severity: "warning" },
+    });
+    contextApiMocks.getContextTreeSnapshot.mockResolvedValue(unavailable);
+    let resolveInitialize: (value: { repo: string; htmlUrl: string; branch: "main"; nodePath: "NODE.md" }) => void =
+      () => undefined;
+    contextApiMocks.initializeContextTree.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveInitialize = resolve;
+      }),
+    );
+
+    const { container, root, queryClient } = await renderDom(<ContextPage />);
+    await waitForText(container, "Create private GitHub repo");
+
+    await click(buttonByText(container, "Create private GitHub repo"));
+    expect(contextApiMocks.initializeContextTree).toHaveBeenCalledWith("org-1");
+    expect(container.textContent).toContain("Creating private GitHub repo");
+    expect(container.textContent).toContain("Initializing root NODE.md");
+    expect(container.textContent).toContain("Saving team setting");
+
+    await act(async () => {
+      resolveInitialize({
+        repo: "https://github.com/acme/acme-context-tree.git",
+        htmlUrl: "https://github.com/acme/acme-context-tree",
+        branch: "main",
+        nodePath: "NODE.md",
+      });
+    });
+    await waitForCondition(
+      () => contextApiMocks.getContextTreeSnapshot.mock.calls.length > 1,
+      "Expected snapshot query to refetch after initialization",
+    );
+    expect(queryClient.getQueryData(["org-setting", "org-1", "context_tree"])).toEqual({
+      repo: "https://github.com/acme/acme-context-tree.git",
+      branch: "main",
+    });
+
+    await act(async () => root.unmount());
   });
 
   it("loads and errors through the live query path", async () => {
@@ -303,7 +369,7 @@ describe("ContextPage DOM behavior", () => {
     await waitForText(failed.container, "Snapshot unavailable");
     await act(async () => failed.root.unmount());
 
-    authMock.value = { organizationId: null };
+    authMock.value = { organizationId: null, role: null };
     const noOrg = await renderDom(<ContextPage />);
     // No org → query disabled, no snapshot. The page renders only its
     // PageHeader chrome (always present, like every other tab) — no live

--- a/packages/web/src/pages/__tests__/settings-panels-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/settings-panels-dom.test.tsx
@@ -30,6 +30,10 @@ const settingsMocks = vi.hoisted(() => ({
   putSourceReposSetting: vi.fn(),
 }));
 
+const contextApiMocks = vi.hoisted(() => ({
+  initializeContextTree: vi.fn(),
+}));
+
 const viewportMock = vi.hoisted(() => ({
   value: "xl" as "xl" | "md" | "narrow",
 }));
@@ -41,6 +45,8 @@ vi.mock("../../auth/auth-context.js", () => ({
 vi.mock("../../api/organizations.js", () => orgMocks);
 
 vi.mock("../../api/org-settings.js", () => settingsMocks);
+
+vi.mock("../../api/context-tree.js", () => contextApiMocks);
 
 vi.mock("../../hooks/use-viewport.js", () => ({
   useWorkspaceViewport: () => viewportMock.value,
@@ -130,6 +136,14 @@ async function renderPanel(element: ReactElement): Promise<{ container: HTMLElem
   return { container, root };
 }
 
+async function click(element: Element | null): Promise<void> {
+  if (!element) throw new Error("Expected element to click");
+  await act(async () => {
+    element.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+  });
+  await flush();
+}
+
 async function waitForText(container: ParentNode, text: string, timeoutMs = 3000): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
@@ -179,6 +193,12 @@ beforeEach(() => {
   settingsMocks.putContextTreeSetting.mockImplementation(async (_id: string, body: Partial<OrgContextTreeOutput>) =>
     contextTree(body),
   );
+  contextApiMocks.initializeContextTree.mockResolvedValue({
+    repo: "https://github.com/acme/acme-context-tree.git",
+    htmlUrl: "https://github.com/acme/acme-context-tree",
+    branch: "main",
+    nodePath: "NODE.md",
+  });
   settingsMocks.getSourceReposSetting.mockResolvedValue(sourceRepos());
   settingsMocks.putSourceReposSetting.mockImplementation(async (_id: string, body: Partial<OrgSourceReposOutput>) =>
     sourceRepos(body),
@@ -275,6 +295,47 @@ describe("settings panels", () => {
     await act(async () => failed.root.unmount());
   });
 
+  it("initializes an empty context tree setting for admins", async () => {
+    settingsMocks.getContextTreeSetting.mockResolvedValueOnce({ branch: "main" });
+    let resolveInitialize: (value: { repo: string; htmlUrl: string; branch: "main"; nodePath: "NODE.md" }) => void =
+      () => undefined;
+    contextApiMocks.initializeContextTree.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveInitialize = resolve;
+      }),
+    );
+
+    const { ContextTreeSettingsPanel } = await import("../context-tree-settings-panel.js");
+    const { container, root } = await renderPanel(<ContextTreeSettingsPanel />);
+    await waitForText(container, "Create private GitHub repo");
+
+    await click(
+      [...container.querySelectorAll("button")].find((button) => button.textContent?.includes("Create")) ?? null,
+    );
+    expect(contextApiMocks.initializeContextTree).toHaveBeenCalledWith("org-1");
+    expect(container.textContent).toContain("Creating private GitHub repo");
+    expect(container.textContent).toContain("Initializing root NODE.md");
+    expect(container.textContent).toContain("Saving team setting");
+
+    await act(async () => {
+      resolveInitialize({
+        repo: "https://github.com/acme/acme-context-tree.git",
+        htmlUrl: "https://github.com/acme/acme-context-tree",
+        branch: "main",
+        nodePath: "NODE.md",
+      });
+    });
+    await waitForCondition(
+      () =>
+        container.querySelectorAll<HTMLInputElement>("input")[0]?.value ===
+        "https://github.com/acme/acme-context-tree.git",
+      "Expected initialized repo to populate the form",
+    );
+    expect(container.querySelectorAll<HTMLInputElement>("input")[1]?.value).toBe("main");
+
+    await act(async () => root.unmount());
+  });
+
   it("renders the context tree binding read-only for members", async () => {
     const { ContextTreeSettingsPanel } = await import("../context-tree-settings-panel.js");
     authMock.value = { ...authMock.value, role: "member" };
@@ -287,6 +348,16 @@ describe("settings panels", () => {
     }
     // No Save affordance for members.
     expect(container.querySelector('button[type="submit"]')).toBeNull();
+    await act(async () => root.unmount());
+  });
+
+  it("shows admin-required copy for members when no context tree repo is configured", async () => {
+    settingsMocks.getContextTreeSetting.mockResolvedValueOnce({ branch: "main" });
+    const { ContextTreeSettingsPanel } = await import("../context-tree-settings-panel.js");
+    authMock.value = { ...authMock.value, role: "member" };
+    const { container, root } = await renderPanel(<ContextTreeSettingsPanel />);
+    await waitForText(container, "Ask an admin to initialize");
+    expect(container.textContent).not.toContain("Create private GitHub repo");
     await act(async () => root.unmount());
   });
 });

--- a/packages/web/src/pages/context-tree-initializer.tsx
+++ b/packages/web/src/pages/context-tree-initializer.tsx
@@ -1,0 +1,65 @@
+import type { InitializeContextTreeResponse } from "@first-tree/shared";
+import { useMutation } from "@tanstack/react-query";
+import { GitBranchPlus, Loader2 } from "lucide-react";
+import { initializeContextTree } from "../api/context-tree.js";
+import { Button } from "../components/ui/button.js";
+
+type ContextTreeInitializerProps = {
+  organizationId: string | null;
+  onInitialized: (result: InitializeContextTreeResponse) => void | Promise<void>;
+};
+
+export function ContextTreeInitializer({ organizationId, onInitialized }: ContextTreeInitializerProps) {
+  const mutation = useMutation({
+    mutationFn: () => {
+      if (!organizationId) throw new Error("Organization not loaded");
+      return initializeContextTree(organizationId);
+    },
+    onSuccess: onInitialized,
+  });
+
+  return (
+    <div style={{ display: "grid", gap: "var(--sp-2)", marginBottom: "var(--sp-4)" }}>
+      <Button
+        type="button"
+        variant="cta"
+        size="sm"
+        onClick={() => mutation.mutate()}
+        disabled={!organizationId || mutation.isPending}
+        style={{ justifySelf: "start" }}
+      >
+        {mutation.isPending ? (
+          <Loader2 size={15} className="animate-spin" aria-hidden="true" />
+        ) : (
+          <GitBranchPlus size={15} aria-hidden="true" />
+        )}
+        Create private GitHub repo
+      </Button>
+      {mutation.isPending ? (
+        <div
+          className="text-label"
+          aria-live="polite"
+          style={{ display: "grid", gap: "var(--sp-1)", color: "var(--fg-3)" }}
+        >
+          <ProgressLine text="Creating private GitHub repo" />
+          <ProgressLine text="Initializing root NODE.md" />
+          <ProgressLine text="Saving team setting" />
+        </div>
+      ) : null}
+      {mutation.error instanceof Error ? (
+        <div className="text-body" style={{ color: "var(--state-error)" }}>
+          {mutation.error.message}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function ProgressLine({ text }: { text: string }) {
+  return (
+    <span className="inline-flex items-center" style={{ gap: "var(--sp-1_5)" }}>
+      <Loader2 size={13} className="animate-spin" aria-hidden="true" />
+      {text}
+    </span>
+  );
+}

--- a/packages/web/src/pages/context-tree-settings-panel.tsx
+++ b/packages/web/src/pages/context-tree-settings-panel.tsx
@@ -1,9 +1,11 @@
+import type { InitializeContextTreeResponse } from "@first-tree/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { type FormEvent, useEffect, useState } from "react";
 import { getContextTreeSetting, putContextTreeSetting } from "../api/org-settings.js";
 import { useAuth } from "../auth/auth-context.js";
 import { Section } from "../components/ui/section.js";
 import { SettingsField, SettingsSaveButton } from "../components/ui/settings-field.js";
+import { ContextTreeInitializer } from "./context-tree-initializer.js";
 
 /**
  * Section for the per-org Context Tree binding (repo / branch). Replaces the
@@ -33,6 +35,7 @@ export function ContextTreeSettingsPanel() {
   const [repo, setRepo] = useState("");
   const [branch, setBranch] = useState("");
   const [saved, setSaved] = useState(false);
+  const hasConfiguredRepo = !!settingQuery.data?.repo;
 
   useEffect(() => {
     if (!settingQuery.data) return;
@@ -64,6 +67,15 @@ export function ContextTreeSettingsPanel() {
     mutation.mutate();
   };
 
+  const handleInitialized = (result: InitializeContextTreeResponse) => {
+    const next = { repo: result.repo, branch: result.branch };
+    queryClient.setQueryData(["org-setting", organizationId, "context_tree"], next);
+    setRepo(result.repo);
+    setBranch(result.branch);
+    setSaved(true);
+    setTimeout(() => setSaved(false), 2000);
+  };
+
   return (
     <Section
       title="Context tree"
@@ -79,6 +91,14 @@ export function ContextTreeSettingsPanel() {
         </div>
       ) : (
         <form onSubmit={handleSubmit}>
+          {isAdmin && !hasConfiguredRepo ? (
+            <ContextTreeInitializer organizationId={organizationId} onInitialized={handleInitialized} />
+          ) : null}
+          {!isAdmin && !hasConfiguredRepo ? (
+            <div className="text-body" style={{ color: "var(--fg-3)", marginBottom: "var(--sp-4)" }}>
+              Ask an admin to initialize this team's Context Tree.
+            </div>
+          ) : null}
           <SettingsField
             label="Repo URL"
             hint="HTTPS URL of the Context Tree git repository for this team."

--- a/packages/web/src/pages/context.tsx
+++ b/packages/web/src/pages/context.tsx
@@ -3,8 +3,9 @@ import type {
   ContextTreeIoEvent,
   ContextTreeNode,
   ContextTreeSnapshot,
+  InitializeContextTreeResponse,
 } from "@first-tree/shared";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { stratify, tree } from "d3-hierarchy";
 import { AlertTriangle, Network, RefreshCw } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
@@ -14,6 +15,7 @@ import { useAuth } from "../auth/auth-context.js";
 import { resolveAvatarHue } from "../components/chat/chat-row-avatar.js";
 import { PageHeader } from "../components/ui/page-header.js";
 import { Panel, PanelBody } from "../components/ui/panel.js";
+import { ContextTreeInitializer } from "./context-tree-initializer.js";
 
 const CONTEXT_WINDOW = "7d";
 // Live-feed refetch cadence. The usage feed inside the snapshot is what wants
@@ -23,9 +25,11 @@ const CONTEXT_WINDOW = "7d";
 const CONTEXT_REFETCH_MS = 20_000;
 
 export function ContextPage({ previewSnapshot }: { previewSnapshot?: ContextTreeSnapshot } = {}) {
-  const { organizationId } = useAuth();
+  const { organizationId, role } = useAuth();
+  const queryClient = useQueryClient();
   const [selectedUpdateId, setSelectedUpdateId] = useState<string | null>(null);
   const preview = previewSnapshot !== undefined;
+  const isAdmin = role === "admin";
 
   const query = useQuery({
     queryKey: ["context-tree-snapshot", organizationId, CONTEXT_WINDOW, preview],
@@ -52,6 +56,17 @@ export function ContextPage({ previewSnapshot }: { previewSnapshot?: ContextTree
   }, [selectedUpdateId, snapshot]);
 
   const liveStatusReady = snapshot && (preview || !query.isLoading) && snapshot.snapshotStatus !== "unavailable";
+  const handleContextInitialized = async (result: InitializeContextTreeResponse) => {
+    if (!organizationId) return;
+    queryClient.setQueryData(["org-setting", organizationId, "context_tree"], {
+      repo: result.repo,
+      branch: result.branch,
+    });
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: ["context-tree-snapshot", organizationId] }),
+      queryClient.invalidateQueries({ queryKey: ["org-setting", organizationId, "context_tree"] }),
+    ]);
+  };
 
   return (
     <>
@@ -67,7 +82,13 @@ export function ContextPage({ previewSnapshot }: { previewSnapshot?: ContextTree
         ) : null}
         {snapshot && (preview || !query.isLoading) ? (
           snapshot.snapshotStatus === "unavailable" ? (
-            <UnavailableState snapshot={snapshot} />
+            <UnavailableState
+              snapshot={snapshot}
+              isAdmin={isAdmin}
+              canInitialize={!preview && isAdmin && !snapshot.repo}
+              organizationId={organizationId}
+              onInitialized={handleContextInitialized}
+            />
           ) : (
             <>
               <ContextStatusNote snapshot={snapshot} />
@@ -446,11 +467,25 @@ function ErrorState({ message }: { message: string }) {
   );
 }
 
-function UnavailableState({ snapshot }: { snapshot: ContextTreeSnapshot }) {
+function UnavailableState({
+  snapshot,
+  isAdmin,
+  canInitialize,
+  organizationId,
+  onInitialized,
+}: {
+  snapshot: ContextTreeSnapshot;
+  isAdmin: boolean;
+  canInitialize: boolean;
+  organizationId: string | null;
+  onInitialized: (result: InitializeContextTreeResponse) => void | Promise<void>;
+}) {
   const title = snapshot.repo ? "Context Tree sync unavailable" : "Connect Context Tree";
   const detail = snapshot.repo
     ? "First Tree cannot read the team Context Tree yet. Agents and users will see context here after the server can sync the configured repo."
-    : "Connect a Context Tree repo to show the team knowledge agents can use.";
+    : isAdmin
+      ? "Create a private GitHub repo to initialize the team Context Tree."
+      : "Ask an admin to initialize this team's Context Tree.";
   const syncDetail = snapshot.contextStatus.detail;
   const repoLabel = snapshot.repo ? redactRepoForDisplay(snapshot.repo) : null;
   return (
@@ -466,6 +501,11 @@ function UnavailableState({ snapshot }: { snapshot: ContextTreeSnapshot }) {
             {syncDetail ? (
               <div className="text-label" style={{ color: "var(--fg-3)", marginTop: "var(--sp-2)" }}>
                 {syncDetail}
+              </div>
+            ) : null}
+            {canInitialize ? (
+              <div style={{ marginTop: "var(--sp-3)" }}>
+                <ContextTreeInitializer organizationId={organizationId} onInitialized={onInitialized} />
               </div>
             ) : null}
             {snapshot.repo || snapshot.branch ? (


### PR DESCRIPTION
## Summary
- Add an admin-only Context Tree initializer at `POST /api/v1/orgs/:orgId/context-tree/initialize`.
- Create a private GitHub repo under the signed-in user, write the root `NODE.md`, and persist the org `context_tree` binding.
- Surface the initializer in Settings > Context tree and the `/context` unavailable state, with admin/member-specific UI.

## Testing
- `pnpm --filter @first-tree/server test -- src/__tests__/context-tree-initialize.test.ts src/__tests__/me-onboarding.test.ts src/__tests__/org-settings.test.ts`
- `pnpm --filter @first-tree/web test -- src/pages/__tests__/settings-panels-dom.test.tsx src/pages/__tests__/context-page-dom.test.tsx src/api/__tests__/api-wrappers.test.ts`
- `pnpm typecheck`
- `pnpm exec biome check <changed files>`

Note: full local `pnpm check` is currently blocked by unrelated untracked `packages/skill-evals/` formatting diagnostics and a pre-existing `packages/client/src/runtime/workspace-migrations.ts` lint warning.