### PR TITLE
Allow tree verify on W1 clean checkouts

### DIFF
--- a/apps/cli/src/__tests__/tree-verify-workspace-sync.test.ts
+++ b/apps/cli/src/__tests__/tree-verify-workspace-sync.test.ts
@@ -95,6 +95,27 @@ function writeValidTree(root: string): void {
   });
 }
 
+function writeValidW1Tree(root: string): void {
+  writeFileSync(join(root, ".git"), "gitdir: /tmp/tree\n");
+  writeFileSync(join(root, "NODE.md"), ["---", "title: Root", "owners: [team]", "---", "", "# Root", ""].join("\n"));
+  mkdirSync(join(root, "members", "gandy"), { recursive: true });
+  writeFileSync(
+    join(root, "members", "gandy", "NODE.md"),
+    [
+      "---",
+      "title: Gandy",
+      "owners: [gandy]",
+      "type: human",
+      "role: Engineer",
+      "domains: [platform]",
+      "---",
+      "",
+      "# Gandy",
+      "",
+    ].join("\n"),
+  );
+}
+
 function makeGitRepo(root: string): void {
   mkdirSync(root, { recursive: true });
   writeFileSync(join(root, ".git"), "gitdir: /tmp/mock\n");
@@ -134,6 +155,23 @@ describe("tree verify command", () => {
     expect(process.exitCode).toBeUndefined();
   });
 
+  it("accepts a W1 clean tree checkout without pre-W1 runtime metadata", async () => {
+    const root = makeTempDir("ft-tree-verify-w1-clean-");
+    writeValidW1Tree(root);
+    const { verifyCommand } = await import("../commands/tree/verify.js");
+
+    verifyCommand.action(context(commandWithOptions({ treePath: root }), false));
+
+    const output = vi
+      .mocked(console.log)
+      .mock.calls.map((call) => String(call[0]))
+      .join("\n");
+    expect(output).toContain("[PASS] framework version");
+    expect(output).toContain("[PASS] tree state");
+    expect(output).toContain("All checks passed");
+    expect(process.exitCode).toBeUndefined();
+  });
+
   it("reports missing files, invalid frontmatter, validator errors, and unchecked progress", async () => {
     const root = makeTempDir("ft-tree-verify-fail-");
     mkdirSync(join(root, ".first-tree"), { recursive: true });
@@ -149,11 +187,8 @@ describe("tree verify command", () => {
       .mocked(console.log)
       .mock.calls.map((call) => String(call[0]))
       .join("\n");
-    expect(output).toContain("[FAIL] framework version");
-    expect(output).toContain("[FAIL] tree state");
-    expect(output).toContain(
-      "Managed tree identity is missing — expected .first-tree/tree.json (or a legacy AGENTS.md / CLAUDE.md identity block).",
-    );
+    expect(output).toContain("[PASS] framework version");
+    expect(output).toContain("[PASS] tree state");
     expect(output).toContain("Root NODE.md is missing owners");
     expect(output).toContain("Unchecked progress item: Decide owner");
     expect(output).toContain("Some checks failed");

--- a/apps/cli/src/commands/tree/verify.ts
+++ b/apps/cli/src/commands/tree/verify.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 
 import type { Command } from "commander";
@@ -6,7 +6,7 @@ import type { Command } from "commander";
 import { channelConfig } from "../../core/channel.js";
 import type { CommandContext, SubcommandModule } from "../types.js";
 import { readSourceBindingContract } from "./binding-contract.js";
-import { TREE_PROGRESS_FILE, TREE_VERSION_FILE } from "./binding-state.js";
+import { TREE_PROGRESS_FILE } from "./binding-state.js";
 import { resolveRepoRoot } from "./shared.js";
 import { readTreeIdentityContract } from "./tree-identity.js";
 import { runValidateMembers } from "./validate-members.js";
@@ -105,11 +105,15 @@ function verifyTreeRoot(targetRoot: string): VerifySummary {
   const progressItems = readUncheckedProgressItems(targetRoot);
   const nodeResult = runValidateNodes(targetRoot);
   const memberResult = runValidateMembers(targetRoot);
+  // W1 moved workspace/tree identity out of the tree repo and into the
+  // workspace-root manifest. A fresh CI checkout of a tree repo is therefore
+  // valid without the pre-W1 `.first-tree/VERSION` / `tree.json` files.
+  // Keep these rows as compatibility signals for existing parsers, but do not
+  // fail validation on metadata that is no longer durable tree content.
   const summary: VerifySummary = {
     checks: {
       frameworkVersion: {
-        ok: existsSync(join(targetRoot, TREE_VERSION_FILE)),
-        ...(existsSync(join(targetRoot, TREE_VERSION_FILE)) ? {} : { errors: [`.first-tree/VERSION is missing.`] }),
+        ok: true,
       },
       members: {
         ok: memberResult.exitCode === 0,
@@ -131,14 +135,7 @@ function verifyTreeRoot(targetRoot: string): VerifySummary {
         ...(rootNodeErrors.length === 0 ? {} : { errors: rootNodeErrors }),
       },
       treeState: {
-        ok: readTreeIdentityContract(targetRoot) !== undefined,
-        ...(readTreeIdentityContract(targetRoot) !== undefined
-          ? {}
-          : {
-              errors: [
-                "Managed tree identity is missing — expected .first-tree/tree.json (or a legacy AGENTS.md / CLAUDE.md identity block).",
-              ],
-            }),
+        ok: true,
       },
     },
     ok: false,


### PR DESCRIPTION
## Summary

- Treat pre-W1 `.first-tree/VERSION` and `.first-tree/tree.json` as optional legacy runtime metadata in `tree verify`.
- Keep the existing source-repo misuse guard intact.
- Add regression coverage for a clean W1 Context Tree checkout with no committed runtime metadata.

## Why

`first-tree-context` removed tracked W1 residue from the tree repo, but the published verifier still failed fresh CI checkouts because it required `.first-tree/VERSION` and tree identity files that are no longer durable tree content. The verifier should validate the tree structure itself; workspace/tree binding state now lives outside the tree repo.

## Verification

- `pnpm --filter first-tree-dev test -- src/__tests__/tree-verify-workspace-sync.test.ts`
  - This ran the CLI package test suite in this worktree: 58 test files / 428 tests passed.
- `node apps/cli/dist/cli/index.mjs tree verify --tree-path /home/bai/.first-tree-staging/data/workspaces/codex-architect/first-tree-context`
  - Passed against a clean `first-tree-context` checkout that only has `.first-tree/hooks/pre-push` and no `.first-tree/VERSION` / `.first-tree/tree.json`.
