### PR TITLE
feat(web): add Claude Fable 5 to the agent model picker

### DIFF
--- a/packages/web/src/pages/agent-detail/model-section.tsx
+++ b/packages/web/src/pages/agent-detail/model-section.tsx
@@ -13,6 +13,10 @@ import { ConfigRow } from "./flat-section.js";
 export type ModelOption = SelectOption;
 
 export const CLAUDE_MODEL_OPTIONS: ModelOption[] = [
+  // Full id rather than the `fable` alias: older Claude Code builds don't know
+  // the alias, but pass unknown full ids through to the API, where
+  // `claude-fable-5` resolves natively.
+  { value: "claude-fable-5", label: "fable", hint: "most powerful" },
   { value: "opus", label: "opus", hint: "most capable" },
   { value: "sonnet", label: "sonnet", hint: "balanced" },
   { value: "haiku", label: "haiku", hint: "fastest" },


### PR DESCRIPTION
## Summary

- Add `claude-fable-5` ("fable", hint: most powerful) to `CLAUDE_MODEL_OPTIONS` so Fable is selectable from the agent-detail Runtime tab for `claude-code` / `claude-code-tui` agents.
- Use the full model id rather than the `fable` alias: older Claude Code builds don't know the alias, but they pass unknown full ids through to the API, where `claude-fable-5` resolves natively (it is the API-level alias).

## Why no other changes are needed

The model field is a pass-through string along the whole pipeline — `agent-runtime-config` schema (`z.string()`), `agent config set-model` CLI, the SDK handler (`buildClaudeQueryOptions` → `options.model`), and the TUI handler (`--model` flag). The web picker's preset list was the only place blocking Fable selection.

`isSameModelFamily` handles the three-segment `claude-fable-5` id correctly: swaps within Fable use in-flight `setModel`, cross-family swaps take the restart path.

## Verification

- `tsc --noEmit`, Biome, and web tests (11 files / 55 tests incl. agent-detail DOM + SSR smoke) pass.
- Real end-to-end call through `@anthropic-ai/claude-agent-sdk@0.2.84` + local `claude` 2.1.170 with `model: "claude-fable-5"` succeeds; the result's `modelUsage` reports `claude-fable-5`.

## Notes

- Client machines need a Claude Code build that knows Fable on PATH; the SDK's bundled CLI (0.2.84) predates Fable and is only used as a fallback when no local `claude` is found.
- `reasoningEffort` stays as-is: SDK 0.2.84's `EffortLevel` has no `xhigh` yet; revisit when bumping the SDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)