### PR TITLE
feat(client): one-shot migration to remove legacy workspace .gitignore

### DIFF
--- a/packages/client/src/__tests__/workspace-migrations.test.ts
+++ b/packages/client/src/__tests__/workspace-migrations.test.ts
@@ -481,6 +481,50 @@ describe("workspace-migrations registry", () => {
     expect(result.applied).toContain("v1-legacy-workspace-gitignore");
     expect(existsSync(join(workspace, ".gitignore"))).toBe(false);
   });
+
+  it("v1-legacy-workspace-gitignore also strips the older `.first-tree/local-tree.json` entry (PR #929 S1)", () => {
+    // The #62 → #371 window of the retired writer included this entry. After
+    // #92 consolidated config into `source.json` the line became an orphan
+    // that no longer points at anything on disk; the migration must clean it
+    // up alongside the later three entries.
+    const target = join(workspace, ".gitignore");
+    writeFileSync(target, ".first-tree/local-tree.json\n.first-tree/tmp/\n");
+
+    applyPendingMigrations(workspace, () => {}, { currentSourceRepoNames: new Set() });
+
+    expect(existsSync(target)).toBe(false);
+  });
+
+  it("v1-legacy-workspace-gitignore does NOT touch a `.gitignore` that is a symlink (PR #929 S2)", () => {
+    // Shape-check guard — mirrors `v1-whitepaper-symlink` posture but in the
+    // opposite direction: that migration unlinks ONLY symlinks; this one
+    // touches ONLY regular files. A symlink at the workspace-root `.gitignore`
+    // is not what the retired writer produced and must survive untouched
+    // (and the target must not be read or rewritten).
+    const realFile = join(workspace, "elsewhere.gitignore");
+    writeFileSync(realFile, ".first-tree/tmp/\n");
+    const target = join(workspace, ".gitignore");
+    symlinkSync(realFile, target);
+
+    applyPendingMigrations(workspace, () => {}, { currentSourceRepoNames: new Set() });
+
+    expect(lstatSync(target).isSymbolicLink()).toBe(true);
+    expect(readFileSync(realFile, "utf-8")).toBe(".first-tree/tmp/\n");
+  });
+
+  it("v1-legacy-workspace-gitignore does NOT touch a `.gitignore` that is a directory (PR #929 S2)", () => {
+    // Another shape-check pair: a user-created directory at the
+    // workspace-root `.gitignore` path (unusual but possible) is not the
+    // legacy writer's output and must not be removed.
+    const target = join(workspace, ".gitignore");
+    mkdirSync(target);
+    writeFileSync(join(target, "inside"), "user content\n");
+
+    applyPendingMigrations(workspace, () => {}, { currentSourceRepoNames: new Set() });
+
+    expect(lstatSync(target).isDirectory()).toBe(true);
+    expect(readFileSync(join(target, "inside"), "utf-8")).toBe("user content\n");
+  });
 });
 
 describe("applyPendingMigrations applier", () => {

--- a/packages/client/src/__tests__/workspace-migrations.test.ts
+++ b/packages/client/src/__tests__/workspace-migrations.test.ts
@@ -443,6 +443,44 @@ describe("workspace-migrations registry", () => {
     expect(existsSync(claudeDir)).toBe(true);
     expect(existsSync(join(claudeDir, "user-content.md"))).toBe(true);
   });
+
+  it("v1-legacy-workspace-gitignore deletes a `.gitignore` that contains only the legacy entries", () => {
+    const target = join(workspace, ".gitignore");
+    writeFileSync(target, ".first-tree/tmp/\n.agents/skills/\n.claude/skills/\n");
+
+    applyPendingMigrations(workspace, () => {}, { currentSourceRepoNames: new Set() });
+
+    expect(existsSync(target)).toBe(false);
+  });
+
+  it("v1-legacy-workspace-gitignore strips legacy entries but preserves user content", () => {
+    // The retired writer UPSERTED into an existing file, so a user-authored
+    // `.gitignore` can carry the legacy entries alongside the user's own
+    // patterns. Only the legacy lines go; the rest stays.
+    const target = join(workspace, ".gitignore");
+    writeFileSync(target, "node_modules/\n.first-tree/tmp/\n.agents/skills/\n.claude/skills/\n*.log\n");
+
+    applyPendingMigrations(workspace, () => {}, { currentSourceRepoNames: new Set() });
+
+    expect(readFileSync(target, "utf-8")).toBe("node_modules/\n*.log\n");
+  });
+
+  it("v1-legacy-workspace-gitignore leaves a user `.gitignore` without legacy entries untouched", () => {
+    const target = join(workspace, ".gitignore");
+    const content = "node_modules/\ndist/\n";
+    writeFileSync(target, content);
+
+    applyPendingMigrations(workspace, () => {}, { currentSourceRepoNames: new Set() });
+
+    expect(readFileSync(target, "utf-8")).toBe(content);
+  });
+
+  it("v1-legacy-workspace-gitignore is a noop when no `.gitignore` exists", () => {
+    const result = applyPendingMigrations(workspace, () => {}, { currentSourceRepoNames: new Set() });
+
+    expect(result.applied).toContain("v1-legacy-workspace-gitignore");
+    expect(existsSync(join(workspace, ".gitignore"))).toBe(false);
+  });
 });
 
 describe("applyPendingMigrations applier", () => {

--- a/packages/client/src/runtime/workspace-migrations.ts
+++ b/packages/client/src/runtime/workspace-migrations.ts
@@ -474,7 +474,7 @@ export const MIGRATIONS_REGISTRY: readonly Migration[] = [
   {
     id: "v1-legacy-workspace-gitignore",
     description:
-      "Remove the workspace-root `.gitignore` that the retired `first-tree tree bootstrap/init/upgrade` commands used to write via `upsertLocalTreeGitIgnore` (entries: `.first-tree/tmp/`, `.agents/skills/`, `.claude/skills/`; writer deleted with the `tree` namespace in PR #848). The workspace root is no longer a git repo, so the file is inert residue. Because the old writer UPSERTED into a possibly user-authored `.gitignore`, this migration strips only the known legacy entries and deletes the file only when nothing else remains; any other user content is preserved.",
+      "Remove the workspace-root `.gitignore` that the retired `first-tree tree bootstrap/init/upgrade` commands used to write via `upsertLocalTreeGitIgnore` (writer deleted with the `tree` namespace in PR #848). The workspace root is no longer a git repo, so the file is inert residue. The legacy allow-list covers EVERY entry the writer ever produced across its history: `.first-tree/local-tree.json` (#62 → #371 window, retired when `.first-tree/source.json` consolidated in #92), `.first-tree/tmp/` (the long-running tempdir entry), `.agents/skills/` and `.claude/skills/` (added in the #510 v1.0 line). Because the old writer UPSERTED into a possibly user-authored `.gitignore`, this migration strips only those known legacy entries and deletes the file only when nothing else remains; any other user content is preserved. PR #929 code-reviewer S1.",
     apply: (workspacePath, log) => {
       const target = join(workspacePath, ".gitignore");
       // Only act on a regular file — a symlink or directory at this path is
@@ -487,7 +487,12 @@ export const MIGRATIONS_REGISTRY: readonly Migration[] = [
         return; // missing — nothing to do
       }
       if (!stat.isFile()) return;
-      const legacyEntries = new Set([".first-tree/tmp/", ".agents/skills/", ".claude/skills/"]);
+      const legacyEntries = new Set([
+        ".first-tree/local-tree.json",
+        ".first-tree/tmp/",
+        ".agents/skills/",
+        ".claude/skills/",
+      ]);
       const lines = readFileSync(target, "utf-8").replaceAll("\r\n", "\n").split("\n");
       const kept = lines.filter((line) => !legacyEntries.has(line.trim()));
       if (kept.length === lines.length) return; // no legacy entries present — user file, leave alone

--- a/packages/client/src/runtime/workspace-migrations.ts
+++ b/packages/client/src/runtime/workspace-migrations.ts
@@ -471,6 +471,38 @@ export const MIGRATIONS_REGISTRY: readonly Migration[] = [
       }
     },
   },
+  {
+    id: "v1-legacy-workspace-gitignore",
+    description:
+      "Remove the workspace-root `.gitignore` that the retired `first-tree tree bootstrap/init/upgrade` commands used to write via `upsertLocalTreeGitIgnore` (entries: `.first-tree/tmp/`, `.agents/skills/`, `.claude/skills/`; writer deleted with the `tree` namespace in PR #848). The workspace root is no longer a git repo, so the file is inert residue. Because the old writer UPSERTED into a possibly user-authored `.gitignore`, this migration strips only the known legacy entries and deletes the file only when nothing else remains; any other user content is preserved.",
+    apply: (workspacePath, log) => {
+      const target = join(workspacePath, ".gitignore");
+      // Only act on a regular file — a symlink or directory at this path is
+      // not the legacy writer's output (mirrors the `v1-whitepaper-symlink`
+      // shape-check posture).
+      let stat: ReturnType<typeof lstatSync>;
+      try {
+        stat = lstatSync(target);
+      } catch {
+        return; // missing — nothing to do
+      }
+      if (!stat.isFile()) return;
+      const legacyEntries = new Set([".first-tree/tmp/", ".agents/skills/", ".claude/skills/"]);
+      const lines = readFileSync(target, "utf-8").replaceAll("\r\n", "\n").split("\n");
+      const kept = lines.filter((line) => !legacyEntries.has(line.trim()));
+      if (kept.length === lines.length) return; // no legacy entries present — user file, leave alone
+      if (kept.every((line) => line.trim() === "")) {
+        unlinkSync(target);
+        log("workspace-migrations: v1-legacy-workspace-gitignore removed legacy workspace .gitignore");
+        return;
+      }
+      const body = kept.join("\n");
+      writeFileSync(target, body.endsWith("\n") ? body : `${body}\n`, "utf-8");
+      log(
+        "workspace-migrations: v1-legacy-workspace-gitignore stripped legacy entries from workspace .gitignore (user content preserved)",
+      );
+    },
+  },
 ];
 
 // `readCurrentSourceRepoNames` was the round-3/4 fallback for "live ctx


### PR DESCRIPTION
## Summary
- Adds `v1-legacy-workspace-gitignore` to the one-shot workspace-migrations registry (`packages/client/src/runtime/workspace-migrations.ts`).
- Background: the retired `tree bootstrap/init/upgrade` commands wrote `<workspace>/.gitignore` via `upsertLocalTreeGitIgnore`. The writer was removed with the `tree` namespace retirement (#848), so current main no longer creates the file — but existing workspaces keep the residue forever. This migration removes it on client upgrade.
- The legacy allow-list covers **every entry the writer ever produced across its history**:
  - `.first-tree/local-tree.json` — #62 (2026-04-06) → #371 (2026-05-02), retired when #92 consolidated config into `.first-tree/source.json`
  - `.first-tree/tmp/` — long-running tempdir entry, present through the writer's full lifetime
  - `.agents/skills/` and `.claude/skills/` — added in the #510 v1.0 line, present until the writer's deletion in #848
- Safety posture (mirrors `v1-whitepaper-symlink` / PR #869 conventions):
  - acts only on a regular file (`lstat.isFile()` shape check — symlink/dir untouched);
  - strips **only** the known legacy entries; because the old writer *upserted* into possibly user-authored files, any other content is preserved and the file is deleted only when nothing non-blank remains;
  - a user `.gitignore` with no legacy entries is left byte-identical;
  - purely local check — no dependency on the live source-repo config, so no `deferred` path needed;
  - idempotent; registered at the END of the registry with a fresh id.

## Test plan
- [x] 7 new unit tests in `workspace-migrations.test.ts` (39/39 pass):
  - exact-legacy file deleted; mixed file keeps user content; non-legacy user file untouched; missing file is a recorded noop
  - older `.first-tree/local-tree.json` entry also triggers cleanup (S1)
  - `.gitignore` as symlink → noop; `.gitignore` as directory → noop (S2 shape-check dual)
- [x] `pnpm check && pnpm typecheck`
- [x] Full client suite: only pre-existing `git-mirror-manager.test.ts` proxy-environment failures (untouched by this diff)
- [x] CI all green

## Review
- code-reviewer review v1: HEALTHY + 2 P3 (S1 allow-list, S2 shape-check tests) — both addressed in commit 3e88179f
- code-reviewer review v2: HEALTHY ✅ approve

🤖 Generated with [Claude Code](https://claude.com/claude-code)