### PR TITLE
fix(client): centralize session turn lifecycle

### DIFF
--- a/packages/client/src/__tests__/agent-cwd-redesign.e2e.test.ts
+++ b/packages/client/src/__tests__/agent-cwd-redesign.e2e.test.ts
@@ -56,7 +56,7 @@ import { createClaudeCodeHandler } from "../handlers/claude-code.js";
 import { createAgentConfigCache } from "../runtime/agent-config-cache.js";
 import { IDENTITY_JSON_REL } from "../runtime/bootstrap.js";
 import { createGitMirrorManager, type GitMirrorManager } from "../runtime/git-mirror-manager.js";
-import type { SessionContext } from "../runtime/handler.js";
+import type { ResumeUnavailableError, SessionContext } from "../runtime/handler.js";
 import { INIT_COMPLETE_SENTINEL_REL } from "../runtime/workspace.js";
 import { mockCtxPlumbing } from "./test-helpers.js";
 
@@ -117,8 +117,6 @@ function buildSessionCtx(chatId: string): SessionContext {
     sdk: { serverUrl: "http://test", sendMessage } as unknown as SessionContext["sdk"],
     chatId,
     log: () => {},
-    touch: () => {},
-    setRuntimeState: () => {},
     emitEvent: () => {},
     ...mockCtxPlumbing({ sendMessage }, chatId),
   };
@@ -370,12 +368,10 @@ describe("Phase E · agent cwd redesign — end-to-end invariants", () => {
     rmSync(dataDir, { recursive: true, force: true });
   });
 
-  it("E8: resume of a stale pre-upgrade sessionId falls back to fresh start (R2 fallback)", async () => {
-    // Defensive fallback path: when sessionId can't be located at EITHER
-    // cwd (legacy chatId dir or agent home), the handler mints a fresh
-    // id and starts cold — First Tree-side chat history is preserved.
-    // SessionManager then persists the returned id, so subsequent inbox
-    // messages resume against the new id cleanly (no permanent error loop).
+  it("E8: resume of a stale pre-upgrade sessionId reports typed transcript_missing", async () => {
+    // Defensive fallback path: when sessionId can't be located at EITHER cwd
+    // (legacy chatId dir or agent home), the handler must not mint a fresh id
+    // inside resume(). SessionManager owns explicit provider replacement.
     capturedSdkOptions.length = 0;
     const dataDir = mkdtempSync(join(tmpdir(), "ftt-e8-"));
     const workspaceRoot = join(dataDir, "workspaces", "agent-1");
@@ -387,25 +383,52 @@ describe("Phase E · agent cwd redesign — end-to-end invariants", () => {
     const handler = createClaudeCodeHandler({ workspaceRoot, agentConfigCache: cache, gitMirrorManager });
     // No transcript exists anywhere under `~/.claude/projects/<encoded-cwd>/`.
     const staleSessionId = "72a19485-ca9e-4bc3-9add-a57e8314e5c3";
-    const returnedSessionId = await handler.resume(
-      makeMessage("chat-e8", "msg-e8"),
-      staleSessionId,
-      buildSessionCtx("chat-e8"),
-    );
-
-    // Returned sessionId MUST differ from the stale input — that's how
-    // SessionManager learns to update its registry.
-    expect(returnedSessionId).not.toBe(staleSessionId);
-    expect(returnedSessionId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
-
-    // The SDK was invoked WITHOUT a resume argument (fresh start semantics).
-    expect(capturedSdkOptions.length).toBeGreaterThan(0);
-    const lastOptions = capturedSdkOptions[capturedSdkOptions.length - 1]?.options;
-    expect(lastOptions?.resume).toBeUndefined();
-    expect(lastOptions?.sessionId).toBe(returnedSessionId);
+    await expect(
+      handler.resume(makeMessage("chat-e8", "msg-e8"), staleSessionId, buildSessionCtx("chat-e8")),
+    ).rejects.toMatchObject({
+      name: "ResumeUnavailableError",
+      reason: "transcript_missing",
+    } satisfies Partial<ResumeUnavailableError>);
+    expect(capturedSdkOptions).toHaveLength(0);
 
     await handler.shutdown();
     rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it("E8b: new-design resume preserves old session id when the agent-home transcript exists", async () => {
+    capturedSdkOptions.length = 0;
+    const dataDir = mkdtempSync(join(tmpdir(), "ftt-e8b-"));
+    const workspaceRoot = join(dataDir, "workspaces", "agent-1");
+    const gitMirrorManager: GitMirrorManager = createGitMirrorManager({ dataDir });
+    mkdirSync(workspaceRoot, { recursive: true });
+
+    const sessionId = "bbbb1234-5678-90ab-cdef-1234567890ab";
+    const encoded = workspaceRoot.replace(/[^a-zA-Z0-9-]/g, "-");
+    const transcriptDir = join(homedir(), ".claude", "projects", encoded);
+    mkdirSync(transcriptDir, { recursive: true });
+    writeFileSync(join(transcriptDir, `${sessionId}.jsonl`), '{"type":"system","subtype":"init"}\n');
+
+    try {
+      const cache = buildCache([]);
+      await cache.refresh(AGENT_ID);
+
+      const handler = createClaudeCodeHandler({ workspaceRoot, agentConfigCache: cache, gitMirrorManager });
+      const returnedSessionId = await handler.resume(
+        makeMessage("chat-e8b", "msg-e8b"),
+        sessionId,
+        buildSessionCtx("chat-e8b"),
+      );
+
+      expect(returnedSessionId).toBe(sessionId);
+      const lastOptions = capturedSdkOptions[capturedSdkOptions.length - 1]?.options;
+      expect(lastOptions?.resume).toBe(sessionId);
+      expect(lastOptions?.cwd).toBe(workspaceRoot);
+
+      await handler.shutdown();
+    } finally {
+      rmSync(transcriptDir, { recursive: true, force: true });
+      rmSync(dataDir, { recursive: true, force: true });
+    }
   });
 
   it("E9: resume of a pre-redesign session routes to the legacy chat-dir cwd (R2 primary path)", async () => {

--- a/packages/client/src/__tests__/claude-code-inject-startup-race.test.ts
+++ b/packages/client/src/__tests__/claude-code-inject-startup-race.test.ts
@@ -114,7 +114,7 @@ function makeMessage(id: string, content: string): SessionMessage {
 }
 
 function makeContext(
-  markCompleted: (count?: number) => void,
+  finish: (count?: number) => void,
   opts: { formatInboundContent?: SessionContext["formatInboundContent"] } = {},
 ): SessionContext {
   const sendMessage = vi.fn().mockResolvedValue(undefined);
@@ -131,13 +131,10 @@ function makeContext(
     sdk: { serverUrl: "http://test", sendMessage } as unknown as SessionContext["sdk"],
     chatId: "chat-claude-startup-race",
     log: () => {},
-    touch: () => {},
-    setRuntimeState: () => {},
     emitEvent: () => {},
     ...mockCtxPlumbing({ sendMessage }, "chat-claude-startup-race"),
     ...(opts.formatInboundContent ? { formatInboundContent: opts.formatInboundContent } : {}),
-    markCompleted,
-    markMessagesCompleted: () => markCompleted(),
+    finishTurn: async (messages) => finish(Array.isArray(messages) ? messages.length : 1),
   };
 }
 
@@ -195,7 +192,7 @@ describe("claude-code handler startup inject queue", () => {
 
     expect(state.observedInputs[0]).toContain("first");
     expect(state.observedInputs[1]).toContain("second");
-    expect(completedCounts).toEqual([undefined, undefined]);
+    expect(completedCounts).toEqual([1, 1]);
 
     await handler.shutdown();
   });
@@ -242,7 +239,7 @@ describe("claude-code handler startup inject queue", () => {
     expect(state.observedInputs[0]).toContain("first");
     expect(state.observedInputs[1]).toContain("second");
     expect(state.observedInputs[2]).toContain("third");
-    expect(completedCounts).toEqual([undefined, undefined, undefined]);
+    expect(completedCounts).toEqual([1, 1, 1]);
 
     await handler.shutdown();
   });

--- a/packages/client/src/__tests__/claude-code-result-forward-fail.test.ts
+++ b/packages/client/src/__tests__/claude-code-result-forward-fail.test.ts
@@ -89,12 +89,13 @@ describe("claude-code handler — sendMessage failure surfaces lost result", () 
       sdk: { serverUrl: "http://test", sendMessage } as unknown as SessionContext["sdk"],
       chatId: "chat-1",
       log: () => {},
-      touch: () => {},
-      setRuntimeState: () => {},
       emitEvent: (e) => {
         emitted.push(e);
       },
       ...mockCtxPlumbing({ sendMessage }, "chat-1"),
+      finishTurn: async (_messages, outcome) => {
+        emitted.push({ kind: "turn_end", payload: { status: outcome.status } });
+      },
     };
 
     await handler.start(

--- a/packages/client/src/__tests__/claude-code-sdk-options.test.ts
+++ b/packages/client/src/__tests__/claude-code-sdk-options.test.ts
@@ -86,8 +86,6 @@ function buildSessionCtx(chatId: string): SessionContext {
     sdk: { serverUrl: "http://test", sendMessage } as unknown as SessionContext["sdk"],
     chatId,
     log: () => {},
-    touch: () => {},
-    setRuntimeState: () => {},
     emitEvent: () => {},
     ...mockCtxPlumbing({ sendMessage }, chatId),
   };

--- a/packages/client/src/__tests__/claude-code-stream-error-retry-replay.test.ts
+++ b/packages/client/src/__tests__/claude-code-stream-error-retry-replay.test.ts
@@ -130,8 +130,9 @@ describe("claude-code handler — transient stream-error retry replays user mess
     const sendMessage = vi.fn().mockResolvedValue(undefined);
     const emitted: SessionEvent[] = [];
     const logs: string[] = [];
-    const runtimeStates: string[] = [];
-    const markCompleted = vi.fn();
+    const finishTurn = vi.fn(async (_messages, outcome: { status: "success" | "error"; terminal?: boolean }) => {
+      emitted.push({ kind: "turn_end", payload: { status: outcome.status } });
+    });
 
     const cache = buildCache();
     await cache.refresh(AGENT_ID);
@@ -150,12 +151,9 @@ describe("claude-code handler — transient stream-error retry replays user mess
       sdk: { serverUrl: "http://test", sendMessage } as unknown as SessionContext["sdk"],
       chatId: "chat-stream-retry",
       log: (m) => logs.push(m),
-      touch: () => {},
-      setRuntimeState: (state) => runtimeStates.push(state),
       emitEvent: (e) => emitted.push(e),
       ...mockCtxPlumbing({ sendMessage }, "chat-stream-retry"),
-      markCompleted,
-      markMessagesCompleted: () => markCompleted(),
+      finishTurn,
     };
 
     await handler.start(
@@ -193,7 +191,8 @@ describe("claude-code handler — transient stream-error retry replays user mess
     // After both retries fail transient (same wrapped API error every
     // time), the handler must end in the retry-exhausted / permanent
     // branch and ack — per PR #612 § "permanent → ack".
-    expect(markCompleted).toHaveBeenCalledTimes(1);
+    expect(finishTurn).toHaveBeenCalledTimes(1);
+    expect(finishTurn.mock.calls[0]?.[1]).toEqual({ status: "error" });
 
     // A user-visible error must be surfaced on retry-exhaustion (so the
     // chat timeline shows what happened), AND the turn must be closed

--- a/packages/client/src/__tests__/claude-code-turn-end-auto-resume-fail.test.ts
+++ b/packages/client/src/__tests__/claude-code-turn-end-auto-resume-fail.test.ts
@@ -80,12 +80,13 @@ function buildCache() {
 }
 
 describe("claude-code handler — auto-resume failure surfacing", () => {
-  it("emits error + turn_end:error, flips runtimeState, AND acks the in-flight entry when respawnQuery throws", async () => {
+  it("emits error + turn_end:error and finishes the in-flight entry when respawnQuery throws", async () => {
     queryCallCount = 0;
     const sendMessage = vi.fn().mockResolvedValue(undefined);
     const emitted: SessionEvent[] = [];
-    const runtimeStates: string[] = [];
-    const markCompleted = vi.fn();
+    const finishTurn = vi.fn(async (_messages, outcome: { status: "success" | "error"; terminal?: boolean }) => {
+      emitted.push({ kind: "turn_end", payload: { status: outcome.status } });
+    });
 
     const cache = buildCache();
     await cache.refresh(AGENT_ID);
@@ -104,12 +105,9 @@ describe("claude-code handler — auto-resume failure surfacing", () => {
       sdk: { serverUrl: "http://test", sendMessage } as unknown as SessionContext["sdk"],
       chatId: "chat-resume-fail",
       log: () => {},
-      touch: () => {},
-      setRuntimeState: (state) => runtimeStates.push(state),
       emitEvent: (e) => emitted.push(e),
       ...mockCtxPlumbing({ sendMessage }, "chat-resume-fail"),
-      markCompleted,
-      markMessagesCompleted: () => markCompleted(),
+      finishTurn,
     };
 
     await handler.start(
@@ -139,14 +137,13 @@ describe("claude-code handler — auto-resume failure surfacing", () => {
     const turnEndIdx = emitted.findIndex((e) => e.kind === "turn_end");
     expect(errIdx).toBeLessThan(turnEndIdx);
 
-    // setRuntimeState("error") MUST run so the SessionManager can reclaim
-    // the slot even though respawnQuery never produced a working session.
-    expect(runtimeStates).toContain("error");
+    // terminal:true is the SessionManager-owned runtime error marker.
+    expect(finishTurn.mock.calls[0]?.[1]).toEqual({ status: "error", terminal: true });
 
     // Reviewer Blocking 2 regression: the auto-resume-failure return MUST
     // ack the entry. Without this the row stays `delivered` server-side
     // and the in-process Deduplicator collapses every bind-reset replay
     // (entry → server → push → dispatch dedup skip → never re-acked).
-    expect(markCompleted).toHaveBeenCalledTimes(1);
+    expect(finishTurn).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/client/src/__tests__/claude-code-turn-end-retry-exhausted.test.ts
+++ b/packages/client/src/__tests__/claude-code-turn-end-retry-exhausted.test.ts
@@ -67,11 +67,12 @@ function buildCache() {
 }
 
 describe("claude-code handler — retry-exhausted surfacing", () => {
-  it("emits error + turn_end:error, flips runtimeState to error, AND acks the in-flight entry after MAX_RETRIES", async () => {
+  it("emits error + turn_end:error and finishes the in-flight entry after MAX_RETRIES", async () => {
     const sendMessage = vi.fn().mockResolvedValue(undefined);
     const emitted: SessionEvent[] = [];
-    const runtimeStates: string[] = [];
-    const markCompleted = vi.fn();
+    const finishTurn = vi.fn(async (_messages, outcome: { status: "success" | "error"; terminal?: boolean }) => {
+      emitted.push({ kind: "turn_end", payload: { status: outcome.status } });
+    });
 
     const cache = buildCache();
     await cache.refresh(AGENT_ID);
@@ -90,12 +91,9 @@ describe("claude-code handler — retry-exhausted surfacing", () => {
       sdk: { serverUrl: "http://test", sendMessage } as unknown as SessionContext["sdk"],
       chatId: "chat-retry",
       log: () => {},
-      touch: () => {},
-      setRuntimeState: (state) => runtimeStates.push(state),
       emitEvent: (e) => emitted.push(e),
       ...mockCtxPlumbing({ sendMessage }, "chat-retry"),
-      markCompleted,
-      markMessagesCompleted: () => markCompleted(),
+      finishTurn,
     };
 
     await handler.start(
@@ -111,7 +109,8 @@ describe("claude-code handler — retry-exhausted surfacing", () => {
     // Reviewer Blocking 2 regression: the retry-exhausted return MUST ack
     // the entry. Without this the row sits `delivered` forever and the
     // in-process Deduplicator collapses every bind-reset replay.
-    expect(markCompleted).toHaveBeenCalledTimes(1);
+    expect(finishTurn).toHaveBeenCalledTimes(1);
+    expect(finishTurn.mock.calls[0]?.[1]).toEqual({ status: "error", terminal: true });
 
     const errors = emitted.filter((e) => e.kind === "error");
     expect(errors).toHaveLength(1);
@@ -134,18 +133,16 @@ describe("claude-code handler — retry-exhausted surfacing", () => {
     const turnEndIdx = emitted.findIndex((e) => e.kind === "turn_end");
     expect(errIdx).toBeLessThan(turnEndIdx);
 
-    // setRuntimeState("error") MUST run so the SessionManager's idle path
-    // can reclaim the slot. (Pre-fix this was the only signal of failure.)
-    expect(runtimeStates).toContain("error");
+    // terminal:true is now the SessionManager-owned runtime error marker.
   });
 
-  it("still flips runtimeState to error even when emitEvent throws", async () => {
+  it("still finishes with terminal error even when emitEvent throws", async () => {
     // Defensive contract: if the onSessionEvent callback throws (e.g. the
     // agent-slot reporting hits a dead WS), the handler must still run
-    // setRuntimeState("error") so the SessionManager can reclaim the slot.
+    // finishTurn(..., terminal:true) so the SessionManager can reclaim/report the slot.
     // Without this, the session stays counted as `working` forever.
     const sendMessage = vi.fn().mockResolvedValue(undefined);
-    const runtimeStates: string[] = [];
+    const finishTurn = vi.fn().mockResolvedValue(undefined);
 
     const cache = buildCache();
     await cache.refresh(AGENT_ID);
@@ -164,12 +161,11 @@ describe("claude-code handler — retry-exhausted surfacing", () => {
       sdk: { serverUrl: "http://test", sendMessage } as unknown as SessionContext["sdk"],
       chatId: "chat-retry-emit-throw",
       log: () => {},
-      touch: () => {},
-      setRuntimeState: (state) => runtimeStates.push(state),
       emitEvent: () => {
         throw new Error("event sink down");
       },
       ...mockCtxPlumbing({ sendMessage }, "chat-retry-emit-throw"),
+      finishTurn,
     };
 
     await handler.start(
@@ -179,6 +175,7 @@ describe("claude-code handler — retry-exhausted surfacing", () => {
     await handler.suspend();
     await new Promise((r) => setImmediate(r));
 
-    expect(runtimeStates).toContain("error");
+    expect(finishTurn).toHaveBeenCalledTimes(1);
+    expect(finishTurn.mock.calls[0]?.[1]).toEqual({ status: "error", terminal: true });
   });
 });

--- a/packages/client/src/__tests__/claude-code-turn-end-sdk-error.test.ts
+++ b/packages/client/src/__tests__/claude-code-turn-end-sdk-error.test.ts
@@ -93,10 +93,11 @@ describe("claude-code handler — turn_end on SDK-reported subtype error", () =>
       sdk: { serverUrl: "http://test", sendMessage } as unknown as SessionContext["sdk"],
       chatId: "chat-1",
       log: () => {},
-      touch: () => {},
-      setRuntimeState: () => {},
       emitEvent: (e) => emitted.push(e),
       ...mockCtxPlumbing({ sendMessage }, "chat-1"),
+      finishTurn: async (_messages, outcome) => {
+        emitted.push({ kind: "turn_end", payload: { status: outcome.status } });
+      },
     };
 
     await handler.start(

--- a/packages/client/src/__tests__/claude-code-turn-end-serialization.test.ts
+++ b/packages/client/src/__tests__/claude-code-turn-end-serialization.test.ts
@@ -120,12 +120,13 @@ describe("claude-code handler — turn_end serialization (race guard)", () => {
       sdk: { serverUrl: "http://test", sendMessage } as unknown as SessionContext["sdk"],
       chatId: "chat-1",
       log: () => {},
-      touch: () => {},
-      setRuntimeState: () => {},
       emitEvent: (e: SessionEvent) => {
         emitted.push({ kind: e.kind, at: Date.now() - start });
       },
       ...mockCtxPlumbing({ sendMessage }, "chat-1"),
+      finishTurn: async (_messages, _outcome) => {
+        emitted.push({ kind: "turn_end", at: Date.now() - start });
+      },
     };
 
     const startPromise = handler.start(

--- a/packages/client/src/__tests__/claude-code-turn-end.test.ts
+++ b/packages/client/src/__tests__/claude-code-turn-end.test.ts
@@ -91,10 +91,11 @@ describe("claude-code handler — turn_end emission", () => {
       sdk: { serverUrl: "http://test", sendMessage } as unknown as SessionContext["sdk"],
       chatId: "chat-1",
       log: () => {},
-      touch: () => {},
-      setRuntimeState: () => {},
       ...mockCtxPlumbing({ sendMessage }, "chat-1"),
       emitEvent: (e) => emitted.push(e),
+      finishTurn: async (_messages, outcome) => {
+        emitted.push({ kind: "turn_end", payload: { status: outcome.status } });
+      },
     };
 
     await handler.start(
@@ -132,12 +133,14 @@ describe("claude-code handler — turn_end emission", () => {
       sdk: { serverUrl: "http://test", sendMessage } as unknown as SessionContext["sdk"],
       chatId: "chat-1",
       log: () => {},
-      touch: () => {},
-      setRuntimeState: () => {},
       ...mockCtxPlumbing({ sendMessage }, "chat-1"),
       emitEvent: (e) => {
         if (e.kind === "turn_end") order.push(`turn_end:${e.payload.status}`);
         emitted.push(e);
+      },
+      finishTurn: async (_messages, outcome) => {
+        order.push(`turn_end:${outcome.status}`);
+        emitted.push({ kind: "turn_end", payload: { status: outcome.status } });
       },
     };
 

--- a/packages/client/src/__tests__/codex-inject-startup-race.test.ts
+++ b/packages/client/src/__tests__/codex-inject-startup-race.test.ts
@@ -14,6 +14,7 @@ const state = vi.hoisted(() => ({
   agentMessagesByTurn: new Map<number, string[]>(),
   failureByTurn: new Map<number, string>(),
   streamErrorByTurn: new Map<number, string>(),
+  resumeThreadCalls: [] as Array<{ threadId: string; options: unknown }>,
 }));
 
 vi.mock("@openai/codex-sdk", () => {
@@ -57,7 +58,8 @@ vi.mock("@openai/codex-sdk", () => {
       startThread() {
         return thread;
       }
-      resumeThread() {
+      resumeThread(threadId: string, options: unknown) {
+        state.resumeThreadCalls.push({ threadId, options });
         return thread;
       }
     },
@@ -113,7 +115,7 @@ function makeMessage(id: string, content: string): SessionMessage {
 type SendMessageMock = ReturnType<typeof vi.fn<(chatId: string, body: Record<string, unknown>) => Promise<unknown>>>;
 
 function makeContext(
-  markCompleted: (count?: number) => void,
+  finish: (count?: number) => void,
   opts: { sendMessage?: SendMessageMock; emitEvent?: SessionContext["emitEvent"] } = {},
 ): SessionContext {
   const sendMessage =
@@ -132,12 +134,12 @@ function makeContext(
     sdk: { serverUrl: "http://test", sendMessage } as unknown as SessionContext["sdk"],
     chatId: "chat-startup-race",
     log: () => {},
-    touch: () => {},
-    setRuntimeState: () => {},
     emitEvent: opts.emitEvent ?? (() => {}),
     ...mockCtxPlumbing({ sendMessage }, "chat-startup-race"),
-    markCompleted,
-    markMessagesCompleted: (messages) => markCompleted(Array.isArray(messages) ? messages.length : 1),
+    finishTurn: async (messages, outcome) => {
+      finish(Array.isArray(messages) ? messages.length : 1);
+      (opts.emitEvent ?? (() => {}))({ kind: "turn_end", payload: { status: outcome.status } });
+    },
   };
 }
 
@@ -147,6 +149,7 @@ beforeEach(() => {
   state.agentMessagesByTurn.clear();
   state.failureByTurn.clear();
   state.streamErrorByTurn.clear();
+  state.resumeThreadCalls.length = 0;
   state.chatContextPromise = new Promise((resolve) => {
     state.resolveChatContext = resolve;
   });
@@ -316,5 +319,26 @@ describe("codex handler startup inject queue", () => {
     expect(completedCounts).toEqual([1]);
 
     await handler.shutdown();
+  });
+
+  it("resumes the provided old thread id instead of starting a fresh thread", async () => {
+    const completedCounts: Array<number | undefined> = [];
+    const handler = createCodexHandler({ workspaceRoot });
+    const ctx = makeContext((count) => {
+      completedCounts.push(count);
+    });
+    state.resolveChatContext?.({
+      chatId: "chat-startup-race",
+      title: "startup race",
+      topic: null,
+      participants: [],
+    });
+
+    const returned = await handler.resume(makeMessage("m-old", "resume input"), "old-thread-id", ctx);
+
+    expect(returned).toBe("old-thread-id");
+    expect(state.resumeThreadCalls).toHaveLength(1);
+    expect(state.resumeThreadCalls[0]?.threadId).toBe("old-thread-id");
+    expect(completedCounts).toEqual([1]);
   });
 });

--- a/packages/client/src/__tests__/codex-retry-abort.test.ts
+++ b/packages/client/src/__tests__/codex-retry-abort.test.ts
@@ -129,7 +129,7 @@ function makeMessage(id: string, content: string): SessionMessage {
 }
 
 function makeContext(
-  markCompleted: (count?: number) => void,
+  finish: (count?: number) => void,
   opts: {
     sendMessage?: SendMessageMock;
     emitEvent?: SessionContext["emitEvent"];
@@ -152,12 +152,12 @@ function makeContext(
     sdk: { serverUrl: "http://test", sendMessage } as unknown as SessionContext["sdk"],
     chatId: "chat-retry-abort",
     log: opts.log ?? (() => {}),
-    touch: () => {},
-    setRuntimeState: () => {},
     emitEvent: opts.emitEvent ?? (() => {}),
     ...mockCtxPlumbing({ sendMessage }, "chat-retry-abort"),
-    markCompleted,
-    markMessagesCompleted: (messages) => markCompleted(Array.isArray(messages) ? messages.length : 1),
+    finishTurn: async (messages, outcome) => {
+      finish(Array.isArray(messages) ? messages.length : 1);
+      (opts.emitEvent ?? (() => {}))({ kind: "turn_end", payload: { status: outcome.status } });
+    },
   };
 }
 

--- a/packages/client/src/__tests__/gitrepos-session-integration.test.ts
+++ b/packages/client/src/__tests__/gitrepos-session-integration.test.ts
@@ -97,8 +97,6 @@ function buildSessionCtx(chatId: string, log: (msg: string) => void): SessionCon
     sdk: { serverUrl: "http://test", sendMessage } as unknown as SessionContext["sdk"],
     chatId,
     log,
-    touch: () => {},
-    setRuntimeState: () => {},
     emitEvent: () => {},
     ...mockCtxPlumbing({ sendMessage }, chatId),
   };

--- a/packages/client/src/__tests__/provider-bootstrap.test.ts
+++ b/packages/client/src/__tests__/provider-bootstrap.test.ts
@@ -68,7 +68,9 @@ function makeContext(
     log?: ReturnType<typeof vi.fn>;
     buildAgentEnv?: SessionContext["buildAgentEnv"];
     emitEvent?: SessionContext["emitEvent"];
+    forwardResult?: SessionContext["forwardResult"];
     recordProviderActivity?: SessionContext["recordProviderActivity"];
+    markMessagesConsumed?: SessionContext["markMessagesConsumed"];
     finishTurn?: SessionContext["finishTurn"];
     retryTurn?: SessionContext["retryTurn"];
   } = {},
@@ -82,9 +84,9 @@ function makeContext(
     chatId: "chat-1",
     log: spies.log ?? vi.fn(),
     emitEvent: spies.emitEvent ?? vi.fn(),
-    forwardResult: vi.fn(async () => {}),
+    forwardResult: spies.forwardResult ?? vi.fn(async () => {}),
     recordProviderActivity: spies.recordProviderActivity ?? vi.fn(),
-    markMessagesConsumed: vi.fn(),
+    markMessagesConsumed: spies.markMessagesConsumed ?? vi.fn(),
     finishTurn: spies.finishTurn ?? vi.fn(async () => {}),
     retryTurn: spies.retryTurn ?? vi.fn(),
     buildAgentEnv:
@@ -114,7 +116,9 @@ describe("ProviderBootstrap", () => {
     const chatContext = { chatId: "chat-1", participants: [] } as unknown as ChatContext;
     const sideEffects = {
       emitEvent: vi.fn(),
+      forwardResult: vi.fn(async () => {}),
       recordProviderActivity: vi.fn(),
+      markMessagesConsumed: vi.fn(),
       finishTurn: vi.fn(async () => {}),
       retryTurn: vi.fn(),
     };
@@ -176,7 +180,9 @@ describe("ProviderBootstrap", () => {
     expect(deps.markWorkspaceInitComplete).toHaveBeenCalledWith("/tmp/agent-home");
 
     expect(sideEffects.emitEvent).not.toHaveBeenCalled();
+    expect(sideEffects.forwardResult).not.toHaveBeenCalled();
     expect(sideEffects.recordProviderActivity).not.toHaveBeenCalled();
+    expect(sideEffects.markMessagesConsumed).not.toHaveBeenCalled();
     expect(sideEffects.finishTurn).not.toHaveBeenCalled();
     expect(sideEffects.retryTurn).not.toHaveBeenCalled();
   });

--- a/packages/client/src/__tests__/provider-bootstrap.test.ts
+++ b/packages/client/src/__tests__/provider-bootstrap.test.ts
@@ -1,0 +1,246 @@
+import type { AgentRuntimeConfig, AgentRuntimeConfigPayload } from "@first-tree/shared";
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildProviderEnv,
+  type ProviderBootstrapDeps,
+  prepareProviderBootstrap,
+} from "../handlers/provider-bootstrap.js";
+import type { AgentConfigCache } from "../runtime/agent-config-cache.js";
+import type { PredeclaredSourceRepo } from "../runtime/bootstrap.js";
+import type { ChatContext } from "../runtime/chat-context.js";
+import type { AgentIdentity, SessionContext, SessionMessage } from "../runtime/handler.js";
+import type { FirstTreeHubSDK } from "../sdk.js";
+
+const agent: AgentIdentity = {
+  agentId: "agent-1",
+  inboxId: "inbox-1",
+  displayName: "Agent One",
+  type: "agent",
+  visibility: "organization",
+  delegateMention: null,
+  metadata: {},
+};
+
+function payload(overrides: Partial<AgentRuntimeConfigPayload> = {}): AgentRuntimeConfigPayload {
+  const base: AgentRuntimeConfigPayload = {
+    kind: "codex",
+    prompt: { append: "Use repo context." },
+    model: "gpt-test",
+    mcpServers: [],
+    env: [{ key: "USER_VAR", value: "configured", sensitive: false }],
+    gitRepos: [{ url: "https://github.com/acme/repo", localPath: "repo" }],
+    resourceSkills: [],
+    reasoningEffort: "high",
+  };
+  return { ...base, ...overrides } as AgentRuntimeConfigPayload;
+}
+
+function config(runtimePayload: AgentRuntimeConfigPayload): AgentRuntimeConfig {
+  return {
+    agentId: agent.agentId,
+    version: 7,
+    payload: runtimePayload,
+    updatedAt: "2026-06-10T00:00:00.000Z",
+    updatedBy: "user-1",
+  };
+}
+
+function makeCache(runtimePayload: AgentRuntimeConfigPayload | null): AgentConfigCache {
+  const cfg = runtimePayload ? config(runtimePayload) : undefined;
+  return {
+    get: vi.fn(() => cfg),
+    refresh: vi.fn(async () => {
+      if (!cfg) throw new Error("no config");
+      return cfg;
+    }),
+    refreshIfNewer: vi.fn(async () => {
+      if (!cfg) throw new Error("no config");
+      return cfg;
+    }),
+    updateUrls: vi.fn(),
+    allReferencedUrls: vi.fn(() => new Set<string>()),
+    forget: vi.fn(),
+  };
+}
+
+function makeContext(
+  spies: {
+    log?: ReturnType<typeof vi.fn>;
+    buildAgentEnv?: SessionContext["buildAgentEnv"];
+    emitEvent?: SessionContext["emitEvent"];
+    recordProviderActivity?: SessionContext["recordProviderActivity"];
+    finishTurn?: SessionContext["finishTurn"];
+    retryTurn?: SessionContext["retryTurn"];
+  } = {},
+): SessionContext {
+  return {
+    agent,
+    sdk: {
+      serverUrl: "http://test",
+      sendMessage: vi.fn(),
+    } as unknown as FirstTreeHubSDK,
+    chatId: "chat-1",
+    log: spies.log ?? vi.fn(),
+    emitEvent: spies.emitEvent ?? vi.fn(),
+    forwardResult: vi.fn(async () => {}),
+    recordProviderActivity: spies.recordProviderActivity ?? vi.fn(),
+    markMessagesConsumed: vi.fn(),
+    finishTurn: spies.finishTurn ?? vi.fn(async () => {}),
+    retryTurn: spies.retryTurn ?? vi.fn(),
+    buildAgentEnv:
+      spies.buildAgentEnv ??
+      ((env) => ({
+        ...env,
+        FIRST_TREE_AGENT_ID: agent.agentId,
+        OMIT_ME: undefined,
+      })),
+    formatInboundContent: vi.fn(async (message: SessionMessage) =>
+      typeof message.content === "string" ? message.content : JSON.stringify(message.content),
+    ),
+    resolveSenderLabel: vi.fn(async (senderId: string) => senderId),
+  };
+}
+
+describe("ProviderBootstrap", () => {
+  it("prepares provider context and returns diagnostic bootstrap facts without session side effects", async () => {
+    const runtimePayload = payload();
+    const sourceRepos: PredeclaredSourceRepo[] = [
+      {
+        absolutePath: "/tmp/agent-home/repo",
+        url: "https://github.com/acme/repo",
+        branch: "main",
+      },
+    ];
+    const chatContext = { chatId: "chat-1", participants: [] } as unknown as ChatContext;
+    const sideEffects = {
+      emitEvent: vi.fn(),
+      recordProviderActivity: vi.fn(),
+      finishTurn: vi.fn(async () => {}),
+      retryTurn: vi.fn(),
+    };
+    const sessionCtx = makeContext(sideEffects);
+    const beforeBootstrap = vi.fn();
+    const deps = {
+      acquireAgentHome: vi.fn(() => "/tmp/agent-home"),
+      fetchChatContext: vi.fn(async () => chatContext),
+      prepareSourceRepos: vi.fn(async () => sourceRepos),
+      materializeResourceSkills: vi.fn(async () => {}),
+      buildAgentBriefing: vi.fn(() => "briefing"),
+      ensureAgentBootstrap: vi.fn<ProviderBootstrapDeps["ensureAgentBootstrap"]>(() => ({
+        treeDrifted: true,
+        cliDrifted: false,
+        bootstrapped: true,
+      })),
+      markWorkspaceInitComplete: vi.fn(),
+    } satisfies Partial<ProviderBootstrapDeps>;
+
+    const result = await prepareProviderBootstrap({
+      workspaceRoot: "/tmp/workspaces/agent",
+      sessionCtx,
+      contextTreePath: "/tmp/context-tree",
+      agentConfigCache: makeCache(runtimePayload),
+      gitMirrorManager: null,
+      agentName: "agent-one",
+      payloadStrategy: "cached",
+      envOptions: { trimUndefined: true },
+      beforeBootstrap,
+      deps,
+    });
+
+    expect(result.cwd).toBe("/tmp/agent-home");
+    expect(result.payload).toBe(runtimePayload);
+    expect(result.payloadResolved).toBe(true);
+    expect(result.chatContext).toBe(chatContext);
+    expect(result.sourceRepos).toBe(sourceRepos);
+    expect(result.briefing).toBe("briefing");
+    expect(result.bootstrap).toEqual({ treeDrifted: true, cliDrifted: false, bootstrapped: true });
+    expect(result.env).toMatchObject({ USER_VAR: "configured", FIRST_TREE_AGENT_ID: "agent-1" });
+    expect(result.env.OMIT_ME).toBeUndefined();
+
+    expect(deps.prepareSourceRepos).toHaveBeenCalledWith(
+      expect.objectContaining({ payload: runtimePayload, payloadResolved: true }),
+    );
+    expect(deps.materializeResourceSkills).toHaveBeenCalledWith("/tmp/agent-home", runtimePayload, sessionCtx);
+    expect(deps.buildAgentBriefing).toHaveBeenCalledWith(
+      expect.objectContaining({
+        identity: agent,
+        payload: runtimePayload,
+        chatContext,
+        sourceRepos,
+        contextTreePath: "/tmp/context-tree",
+      }),
+    );
+    const bootstrapArgs = deps.ensureAgentBootstrap.mock.calls[0]?.[0];
+    expect(bootstrapArgs?.currentSourceRepoNames ? [...bootstrapArgs.currentSourceRepoNames] : []).toEqual(["repo"]);
+    expect(beforeBootstrap).toHaveBeenCalledWith({ cwd: "/tmp/agent-home", sessionCtx });
+    expect(deps.markWorkspaceInitComplete).toHaveBeenCalledWith("/tmp/agent-home");
+
+    expect(sideEffects.emitEvent).not.toHaveBeenCalled();
+    expect(sideEffects.recordProviderActivity).not.toHaveBeenCalled();
+    expect(sideEffects.finishTurn).not.toHaveBeenCalled();
+    expect(sideEffects.retryTurn).not.toHaveBeenCalled();
+  });
+
+  it("uses default payloads without treating fallback source repos as authoritative", async () => {
+    const fallbackPayload = payload({ gitRepos: [] });
+    const log = vi.fn();
+    const sessionCtx = makeContext({ log });
+    const deps = {
+      acquireAgentHome: vi.fn(() => "/tmp/agent-home"),
+      fetchChatContext: vi.fn(async () => {
+        throw new Error("chat unavailable");
+      }),
+      prepareSourceRepos: vi.fn(async () => []),
+      materializeResourceSkills: vi.fn(async () => {}),
+      buildAgentBriefing: vi.fn(() => "fallback briefing"),
+      ensureAgentBootstrap: vi.fn<ProviderBootstrapDeps["ensureAgentBootstrap"]>(() => ({
+        treeDrifted: false,
+        cliDrifted: true,
+        bootstrapped: true,
+      })),
+      markWorkspaceInitComplete: vi.fn(),
+    } satisfies Partial<ProviderBootstrapDeps>;
+
+    const result = await prepareProviderBootstrap({
+      workspaceRoot: "/tmp/workspaces/agent",
+      sessionCtx,
+      contextTreePath: null,
+      agentConfigCache: null,
+      gitMirrorManager: null,
+      agentName: null,
+      payloadStrategy: "cached-or-refresh",
+      defaultPayload: () => fallbackPayload,
+      deps,
+    });
+
+    expect(result.payload).toBe(fallbackPayload);
+    expect(result.payloadResolved).toBe(false);
+    expect(result.chatContext).toBeUndefined();
+    expect(log).toHaveBeenCalledWith("fetchChatContext failed: chat unavailable");
+    expect(deps.prepareSourceRepos).toHaveBeenCalledWith(expect.objectContaining({ payloadResolved: false }));
+    expect(deps.ensureAgentBootstrap.mock.calls[0]?.[0].currentSourceRepoNames).toBeNull();
+  });
+
+  it("builds provider env with Claude parent markers stripped when requested", () => {
+    const previousClaudeCode = process.env.CLAUDECODE;
+    const previousEntrypoint = process.env.CLAUDE_CODE_ENTRYPOINT;
+    process.env.CLAUDECODE = "1";
+    process.env.CLAUDE_CODE_ENTRYPOINT = "nested";
+    try {
+      const env = buildProviderEnv(makeContext(), payload(), {
+        stripClaudeCodeParentEnv: true,
+        trimUndefined: true,
+      });
+      expect(env.CLAUDECODE).toBeUndefined();
+      expect(env.CLAUDE_CODE_ENTRYPOINT).toBeUndefined();
+      expect(env.USER_VAR).toBe("configured");
+      expect(env.FIRST_TREE_AGENT_ID).toBe("agent-1");
+      expect(env.OMIT_ME).toBeUndefined();
+    } finally {
+      if (previousClaudeCode === undefined) delete process.env.CLAUDECODE;
+      else process.env.CLAUDECODE = previousClaudeCode;
+      if (previousEntrypoint === undefined) delete process.env.CLAUDE_CODE_ENTRYPOINT;
+      else process.env.CLAUDE_CODE_ENTRYPOINT = previousEntrypoint;
+    }
+  });
+});

--- a/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
+++ b/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
@@ -10,6 +10,7 @@ import type {
 } from "@first-tree/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AgentHandler, HandlerFactory, SessionContext, SessionMessage } from "../runtime/handler.js";
+import { ResumeUnavailableError } from "../runtime/handler.js";
 import { SessionManager } from "../runtime/session-manager.js";
 import type { FirstTreeHubSDK } from "../sdk.js";
 import { recordingLogger, silentLogger } from "./_logger-helpers.js";
@@ -341,6 +342,93 @@ describe("SessionManager edge coverage", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
+  it("daemon restart with persisted mapping routes to resume(oldId), not start", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "ft-session-restart-resume-"));
+    const registryPath = join(dir, "sessions.json");
+    writeFileSync(
+      registryPath,
+      JSON.stringify({
+        version: 1,
+        entries: {
+          "chat-drift": {
+            claudeSessionId: "old-provider-session",
+            lastActivity: new Date(1_000).toISOString(),
+            status: "evicted",
+          },
+        },
+      }),
+      "utf-8",
+    );
+    const resumed = handler({
+      start: vi.fn().mockResolvedValue("new-provider-session"),
+      resume: vi.fn().mockResolvedValue("old-provider-session"),
+    });
+    const sm = makeManager({ handlers: [resumed], registryPath });
+
+    await sm.dispatch(mockEntry({ id: 51, chatId: "chat-drift" }));
+
+    expect(resumed.resume).toHaveBeenCalledWith(expect.anything(), "old-provider-session", expect.anything());
+    expect(resumed.start).not.toHaveBeenCalled();
+
+    await sm.shutdown();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("typed transcript_missing triggers explicit SessionManager replacement", async () => {
+    const events: SessionEvent[] = [];
+    const replacement = handler({
+      resume: vi.fn(async () => {
+        throw new ResumeUnavailableError("transcript_missing", "old transcript missing");
+      }),
+      start: vi.fn().mockResolvedValue("replacement-provider-session"),
+    });
+    const sm = makeManager({
+      handlers: [replacement],
+      onSessionEvent: (_chatId, event) => events.push(event),
+    });
+    internals(sm).evictedMappings.set("chat-replace", {
+      claudeSessionId: "old-provider-session",
+      lastActivity: 1_000,
+    });
+
+    await sm.dispatch(mockEntry({ id: 52, chatId: "chat-replace" }));
+
+    expect(replacement.resume).toHaveBeenCalledWith(expect.anything(), "old-provider-session", expect.anything());
+    expect(replacement.start).toHaveBeenCalledTimes(1);
+    expect(internals(sm).sessions.get("chat-replace")?.claudeSessionId).toBe("replacement-provider-session");
+    expect(
+      events.some(
+        (event) =>
+          event.kind === "error" &&
+          typeof event.payload.message === "string" &&
+          event.payload.message.includes("transcript_missing"),
+      ),
+    ).toBe(true);
+
+    await sm.shutdown();
+  });
+
+  it("no-input admin resume does not ack or create phantom in-flight delivery", async () => {
+    const ackEntry = vi.fn<(entryId: number) => Promise<void>>().mockResolvedValue(undefined);
+    const adminHandler = handler({ resume: vi.fn().mockResolvedValue("admin-session") });
+    const sm = makeManager({ handlers: [adminHandler], ackEntry, onSessionRuntimeChange: vi.fn() });
+    const record = makeSessionRecord("chat-admin", {
+      handler: adminHandler,
+      claudeSessionId: "admin-session",
+      status: "suspended",
+    });
+    internals(sm).sessions.set("chat-admin", record);
+
+    await internals(sm).resumeSession(record, undefined);
+
+    expect(adminHandler.resume).toHaveBeenCalledWith(undefined, "admin-session", expect.anything());
+    expect(ackEntry).not.toHaveBeenCalled();
+    expect(internals(sm).inFlightEntries.has("chat-admin")).toBe(false);
+    expect(sm.getSessionRuntimeStates()).toEqual([{ chatId: "chat-admin", runtimeState: "idle" }]);
+
+    await sm.shutdown();
+  });
+
   it("builds session context plumbing from cached config and falls back when self-fence refresh fails", async () => {
     const workspaceRoot = mkdtempSync(join(tmpdir(), "ft-session-context-"));
     const sdk = mockSdk();
@@ -368,7 +456,7 @@ describe("SessionManager edge coverage", () => {
       async start(_message, ctx) {
         captured = ctx;
         ctx.log("started");
-        ctx.touch();
+        ctx.recordProviderActivity();
         return "session-context";
       },
     });
@@ -480,7 +568,7 @@ describe("SessionManager edge coverage", () => {
   });
 
   it("waits for in-flight suspension and supports admin resume without a message", async () => {
-    const resume = vi.fn().mockResolvedValue("resumed-admin");
+    const resume = vi.fn().mockResolvedValue("old-session");
     const record = makeSessionRecord("chat-admin-resume", {
       status: "suspended",
       claudeSessionId: "old-session",
@@ -515,7 +603,7 @@ describe("SessionManager edge coverage", () => {
       concurrency: 1,
       handlers: [
         handler({ start: vi.fn().mockResolvedValue("retry-empty-start") }),
-        handler({ resume: vi.fn().mockResolvedValue("retry-from-evicted") }),
+        handler({ resume: vi.fn(async (_message, sessionId: string) => sessionId) }),
       ],
       onSessionEvent: (_chatId, event) => events.push(event),
     });
@@ -556,7 +644,7 @@ describe("SessionManager edge coverage", () => {
     });
     internals(sm).sessions.set("chat-retry-evicted", fromEvicted);
     await internals(sm).runRetry("chat-retry-evicted");
-    expect(fromEvicted.claudeSessionId).toBe("retry-from-evicted");
+    expect(fromEvicted.claudeSessionId).toBe("evicted-session");
 
     expect(events.some((event) => event.kind === "error")).toBe(true);
 
@@ -926,17 +1014,18 @@ describe("SessionManager edge coverage", () => {
     });
 
     await sm.dispatch(mockEntry({ id: 1, chatId: "chat-runtime" }));
-    expect(sm.getSessionRuntimeStates()).toEqual([{ chatId: "chat-runtime", runtimeState: "idle" }]);
+    expect(sm.getSessionRuntimeStates()).toEqual([{ chatId: "chat-runtime", runtimeState: "working" }]);
     if (!captured) throw new Error("context was not captured");
+    runtimeChanges.length = 0;
     await sm.handleCommand("chat-runtime", "session:suspend");
-    captured.setRuntimeState("working");
+    captured.recordProviderActivity();
     expect(runtimeChanges).not.toContain("working");
 
     internals(sm).reaffirmRuntimeStates();
     await sm.shutdown();
   });
 
-  it("uses idle fallback in evictIdle logging when no runtime state was recorded", async () => {
+  it("uses computed working state in evictIdle logging when delivery work is present", async () => {
     vi.useFakeTimers({ now: 100_000 });
     const log = recordingLogger();
     const first = handler();
@@ -964,9 +1053,9 @@ describe("SessionManager edge coverage", () => {
 
     vi.advanceTimersByTime(10_000);
 
-    expect(log.records.some((entry) => entry.msg === "session idle, suspending" && entry.runtimeState === "idle")).toBe(
-      true,
-    );
+    expect(
+      log.records.some((entry) => entry.msg === "session idle, suspending" && entry.runtimeState === "working"),
+    ).toBe(true);
     await sm.shutdown();
   });
 });

--- a/packages/client/src/__tests__/session-manager.test.ts
+++ b/packages/client/src/__tests__/session-manager.test.ts
@@ -24,10 +24,12 @@ function mockAckEntry() {
 
 function deferred<T>() {
   let resolve: (value: T) => void = () => {};
-  const promise = new Promise<T>((res) => {
+  let reject: (reason?: unknown) => void = () => {};
+  const promise = new Promise<T>((res, rej) => {
     resolve = res;
+    reject = rej;
   });
-  return { promise, resolve };
+  return { promise, resolve, reject };
 }
 
 /** Create a mock handler conforming to the new session-oriented interface. */
@@ -990,6 +992,39 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     expect(ackEntry).toHaveBeenCalledWith(35);
 
     await sm.dispatch(mockEntry({ id: 36, chatId: "chat-suspend-ack-fail", messageId: "msg-f2" }));
+    expect(resumeSpy).not.toHaveBeenCalled();
+
+    await sm.shutdown();
+  });
+
+  it("holds resume behind pending suspend ACK and gates recovery if that ACK rejects", async () => {
+    const ack = deferred<void>();
+    const ackEntry = vi.fn(() => ack.promise);
+    let capturedCtx: SessionContext | undefined;
+    let firstMessage: Parameters<AgentHandler["start"]>[0] | undefined;
+    const resumeSpy = vi.fn(async () => "session-id-mock");
+    const handler = createMockHandler({
+      async start(m, ctx) {
+        firstMessage = m;
+        capturedCtx = ctx;
+        return "session-id-mock";
+      },
+      resume: resumeSpy,
+    });
+    const { sm } = buildSm(ackEntry, handler);
+
+    await sm.dispatch(mockEntry({ id: 37, chatId: "chat-suspend-ack-pending", messageId: "msg-p1" }));
+    if (firstMessage) capturedCtx?.markMessagesConsumed(firstMessage);
+
+    await sm.handleCommand("chat-suspend-ack-pending", "session:suspend");
+    expect(ackEntry).toHaveBeenCalledWith(37);
+
+    const resumedInput = sm.dispatch(mockEntry({ id: 38, chatId: "chat-suspend-ack-pending", messageId: "msg-p2" }));
+    await Promise.resolve();
+    expect(resumeSpy).not.toHaveBeenCalled();
+
+    ack.reject(new Error("ack unavailable"));
+    await resumedInput;
     expect(resumeSpy).not.toHaveBeenCalled();
 
     await sm.shutdown();

--- a/packages/client/src/__tests__/session-manager.test.ts
+++ b/packages/client/src/__tests__/session-manager.test.ts
@@ -1068,6 +1068,47 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     await sm.shutdown();
   });
 
+  it("injects later same-chat messages after one waiter resumes a suspended session", async () => {
+    const ack = deferred<void>();
+    const ackEntry = vi.fn((entryId: number) => (entryId === 41 ? ack.promise : Promise.resolve()));
+    let capturedCtx: SessionContext | undefined;
+    let firstMessage: Parameters<AgentHandler["start"]>[0] | undefined;
+    const resumeSpy = vi.fn<AgentHandler["resume"]>(async () => "session-id-mock");
+    const injectSpy = vi.fn<AgentHandler["inject"]>();
+    const handler = createMockHandler({
+      async start(m, ctx) {
+        firstMessage = m;
+        capturedCtx = ctx;
+        return "session-id-mock";
+      },
+      resume: resumeSpy,
+      inject: injectSpy,
+    });
+    const { sm } = buildSm(ackEntry, handler);
+
+    await sm.dispatch(mockEntry({ id: 41, chatId: "chat-suspend-multi-waiter", messageId: "msg-w1" }));
+    if (firstMessage) capturedCtx?.markMessagesConsumed(firstMessage);
+
+    await sm.handleCommand("chat-suspend-multi-waiter", "session:suspend");
+    expect(ackEntry).toHaveBeenCalledWith(41);
+
+    const dispatchB = sm.dispatch(mockEntry({ id: 42, chatId: "chat-suspend-multi-waiter", messageId: "msg-w2" }));
+    const dispatchC = sm.dispatch(mockEntry({ id: 43, chatId: "chat-suspend-multi-waiter", messageId: "msg-w3" }));
+    await Promise.resolve();
+    expect(resumeSpy).not.toHaveBeenCalled();
+    expect(injectSpy).not.toHaveBeenCalled();
+
+    ack.resolve();
+    await Promise.all([dispatchB, dispatchC]);
+
+    expect(resumeSpy).toHaveBeenCalledTimes(1);
+    expect((resumeSpy.mock.calls[0]?.[0] as SessionMessage | undefined)?.id).toBe("msg-w2");
+    expect(injectSpy).toHaveBeenCalledTimes(1);
+    expect((injectSpy.mock.calls[0]?.[0] as SessionMessage | undefined)?.id).toBe("msg-w3");
+
+    await sm.shutdown();
+  });
+
   it("suspend leaves injected but not consumed entries unacked for recovery", async () => {
     const ackEntry = vi.fn().mockResolvedValue(undefined);
     const recoverChat = vi.fn().mockResolvedValue(undefined);

--- a/packages/client/src/__tests__/session-manager.test.ts
+++ b/packages/client/src/__tests__/session-manager.test.ts
@@ -2,7 +2,7 @@ import type { AgentRuntimeConfig } from "@first-tree/shared";
 import type pino from "pino";
 import { describe, expect, it, vi } from "vitest";
 import type { AgentConfigCache } from "../runtime/agent-config-cache.js";
-import type { AgentHandler, HandlerFactory, SessionContext } from "../runtime/handler.js";
+import type { AgentHandler, HandlerFactory, SessionContext, SessionMessage } from "../runtime/handler.js";
 import { SessionManager } from "../runtime/session-manager.js";
 import type { FirstTreeHubSDK } from "../sdk.js";
 import { recordingLogger, silentLogger } from "./_logger-helpers.js";
@@ -103,10 +103,10 @@ describe("SessionManager", () => {
     await sm.shutdown();
   });
 
-  it("does NOT ack on dispatch — entry is held until the handler calls markCompleted (in-flight recovery)", async () => {
+  it("does NOT ack on dispatch — entry is held until the handler calls finishTurn (in-flight recovery)", async () => {
     // Post-inflight-message-recovery: dispatch only enqueues the entry into
     // `inFlightEntries`. The ack waits for the handler to signal turn
-    // completion via `ctx.markCompleted()`. A bare-mocked handler never
+    // completion via `ctx.finishTurn(...)`. A bare-mocked handler never
     // closes the turn, so no ack is fired.
     const ackEntry = mockAckEntry();
     const sm = createSessionManager({ ackEntry });
@@ -118,12 +118,14 @@ describe("SessionManager", () => {
     await sm.shutdown();
   });
 
-  it("acks via the callback when the handler calls ctx.markCompleted()", async () => {
+  it("acks via the callback when the handler calls ctx.finishTurn()", async () => {
     // A handler that completes its turn cleanly drains the in-flight queue.
     const ackEntry = mockAckEntry();
     let capturedCtx: SessionContext | undefined;
+    let capturedMessage: Parameters<AgentHandler["start"]>[0] | undefined;
     const handler = createMockHandler({
-      async start(_msg, ctx) {
+      async start(msg, ctx) {
+        capturedMessage = msg;
         capturedCtx = ctx;
         return "session-id-mock";
       },
@@ -136,9 +138,7 @@ describe("SessionManager", () => {
     // Handler closes the turn — this is what claude-code / codex do after
     // forwardResult success.
     expect(capturedCtx).not.toBeNull();
-    capturedCtx?.markCompleted();
-    // Drain is fire-and-forget — yield once so the ackEntry promise settles.
-    await Promise.resolve();
+    if (capturedMessage) await capturedCtx?.finishTurn(capturedMessage, { status: "success" });
     expect(ackEntry).toHaveBeenCalledWith(42);
 
     await sm.shutdown();
@@ -215,12 +215,12 @@ describe("SessionManager", () => {
     await sm.shutdown();
   });
 
-  it("does NOT re-ack a dedup-hit while the entry is still in-flight (handler hasn't markCompleted yet)", async () => {
+  it("does NOT re-ack a dedup-hit while the entry is still in-flight (handler hasn't finishTurn yet)", async () => {
     // The first dispatch creates the in-flight slot; the second dispatch
     // (same chatId+messageId, same entryId — what `agent:bind` reset +
     // drainBacklog produces while a turn is still mid-flight) must NOT
     // ack — that would defuse inflight-message-recovery if this process
-    // crashed mid-turn. The eventual `markCompleted` is the only thing
+    // crashed mid-turn. The eventual `finishTurn` is the only thing
     // that should ack while the turn is open.
     const ackEntry = mockAckEntry();
     const handler = createMockHandler();
@@ -230,7 +230,7 @@ describe("SessionManager", () => {
     await sm.dispatch(mockEntry({ id: 50, chatId: "chat-mid", messageId: "msg-mid" }));
 
     // Second dispatch is a dedup-hit, but the entry is still in inFlightEntries
-    // (handler never called markCompleted in this test), so re-ack must be skipped.
+    // (handler never called finishTurn in this test), so re-ack must be skipped.
     expect(ackEntry).not.toHaveBeenCalled();
     expect(handler.start).toHaveBeenCalledTimes(1);
 
@@ -239,7 +239,7 @@ describe("SessionManager", () => {
 
   it("does NOT re-ack a dedup-hit whose chat was LRU-evicted — the bind-reset recovery path must stay open", async () => {
     // R5 boundary: LRU eviction removes the entry from `inFlightEntries`
-    // WITHOUT acking it (no handler will ever fire markCompleted). The
+    // WITHOUT acking it (no handler will ever fire finishTurn). The
     // recovery contract documented in `evictIfNeeded` is "server's
     // bind-reset redelivers against a fresh session." Pre-this-PR the
     // dispatch dedup short-circuit silently returned, the evicted chat's
@@ -280,7 +280,7 @@ describe("SessionManager", () => {
     await sm.dispatch(chatC);
     await sm.dispatch(chatC);
     expect(startSpy).toHaveBeenCalledTimes(3);
-    // Nothing has been acked yet — none of the mock handlers call markCompleted.
+    // Nothing has been acked yet — none of the mock handlers call finishTurn.
     expect(ackEntry).not.toHaveBeenCalled();
 
     // Simulate chat-scoped recovery and redelivery of the SAME entry for
@@ -293,7 +293,7 @@ describe("SessionManager", () => {
     // evicted, so the new dispatch resumes from evictedMappings).
     expect(resumeSpy).toHaveBeenCalledTimes(1);
     // Critically: NO ack for the evicted entry. The fresh session will
-    // ack it when its handler calls markCompleted at turn end.
+    // ack it when its handler calls finishTurn at turn end.
     expect(ackEntry).not.toHaveBeenCalled();
 
     await sm.shutdown();
@@ -302,7 +302,9 @@ describe("SessionManager", () => {
   it("drops dedup after completion so ack-lost redelivery re-enters the handler instead of re-acking", async () => {
     const ackEntry = mockAckEntry();
     let capturedCtx: SessionContext | undefined;
-    const startSpy = vi.fn(async (_msg: unknown, ctx: SessionContext) => {
+    let capturedMessage: Parameters<AgentHandler["start"]>[0] | undefined;
+    const startSpy = vi.fn(async (msg: Parameters<AgentHandler["start"]>[0], ctx: SessionContext) => {
+      capturedMessage = msg;
       capturedCtx = ctx;
       return "session-id-mock";
     });
@@ -312,8 +314,7 @@ describe("SessionManager", () => {
 
     // Turn 1: original delivery.
     await sm.dispatch(mockEntry({ id: 60, chatId: "chat-redeliver", messageId: "msg-redeliver" }));
-    capturedCtx?.markCompleted();
-    await Promise.resolve();
+    if (capturedMessage) await capturedCtx?.finishTurn(capturedMessage, { status: "success" });
     expect(ackEntry).toHaveBeenCalledTimes(1);
     expect(ackEntry).toHaveBeenLastCalledWith(60);
 
@@ -392,7 +393,7 @@ describe("SessionManager", () => {
     expect(handler.shutdown).toHaveBeenCalledTimes(1);
   });
 
-  it("passes SessionContext with chatId and touch()", async () => {
+  it("passes SessionContext with chatId and recordProviderActivity()", async () => {
     let capturedCtx: SessionContext | undefined;
     const handler = createMockHandler({
       async start(_msg, ctx) {
@@ -409,7 +410,7 @@ describe("SessionManager", () => {
     expect(capturedCtx).toBeDefined();
     expect(capturedCtx?.chatId).toBe("chat-1");
     expect(capturedCtx?.agent.agentId).toBe("agent-1");
-    expect(typeof capturedCtx?.touch).toBe("function");
+    expect(typeof capturedCtx?.recordProviderActivity).toBe("function");
     expect(typeof capturedCtx?.log).toBe("function");
     expect(capturedCtx?.sdk).toBe(sdk);
 
@@ -603,12 +604,14 @@ describe("SessionManager dispatch integration", () => {
     //
     // Post-inflight-message-recovery: dispatch starts the handler but does
     // NOT ack immediately; ack happens once the handler calls
-    // `ctx.markCompleted()`. We close the turn here to exercise both
+    // `ctx.finishTurn(...)`. We close the turn here to exercise both
     // halves of the contract.
     let capturedCtx: SessionContext | undefined;
+    let capturedMessage: Parameters<AgentHandler["start"]>[0] | undefined;
     const handler = createMockHandler();
     const startSpy = handler.start as ReturnType<typeof vi.fn>;
-    startSpy.mockImplementation(async (_msg: unknown, ctx: SessionContext) => {
+    startSpy.mockImplementation(async (msg: Parameters<AgentHandler["start"]>[0], ctx: SessionContext) => {
+      capturedMessage = msg;
       capturedCtx = ctx;
       return "session-id-mock";
     });
@@ -626,8 +629,7 @@ describe("SessionManager dispatch integration", () => {
     expect(handler.start).toHaveBeenCalledTimes(1);
     expect(ackEntry).not.toHaveBeenCalled();
 
-    capturedCtx?.markCompleted();
-    await Promise.resolve();
+    if (capturedMessage) await capturedCtx?.finishTurn(capturedMessage, { status: "success" });
     expect(ackEntry).toHaveBeenCalledWith(101);
 
     await sm.shutdown();
@@ -638,7 +640,7 @@ describe("SessionManager dispatch integration", () => {
  * `ackEntry` is the WS data-plane ack callback wired from AgentSlot to
  * `clientConnection.sendInboxAck`. Post-inflight-message-recovery the
  * runtime defers acks: every entry sits in `inFlightEntries[chatId]` until
- * the handler calls `ctx.markCompleted()`, the runtime drains the queue
+ * the handler calls `ctx.finishTurn(...)`, the runtime drains the queue
  * during a permanent failure / terminate teardown, or the next
  * `agent:bind` resets it server-side. Tests below pin the deferred-ack
  * contract for each entry-point dispatch can hit.
@@ -673,11 +675,13 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     return { sm, handler: h };
   }
 
-  it("ack waits for markCompleted when starting a new session", async () => {
+  it("ack waits for finishTurn when starting a new session", async () => {
     const ackEntry = vi.fn().mockResolvedValue(undefined);
     let capturedCtx: SessionContext | undefined;
+    let capturedMessage: Parameters<AgentHandler["start"]>[0] | undefined;
     const handler = createMockHandler({
-      async start(_m, ctx) {
+      async start(m, ctx) {
+        capturedMessage = m;
         capturedCtx = ctx;
         return "session-id-mock";
       },
@@ -687,15 +691,14 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     await sm.dispatch(mockEntry({ id: 1, chatId: "chat-1" }));
     expect(ackEntry).not.toHaveBeenCalled();
 
-    capturedCtx?.markCompleted();
-    await Promise.resolve();
+    if (capturedMessage) await capturedCtx?.finishTurn(capturedMessage, { status: "success" });
     expect(ackEntry).toHaveBeenCalledTimes(1);
     expect(ackEntry).toHaveBeenCalledWith(1);
 
     await sm.shutdown();
   });
 
-  it("markMessagesCompleted(message) acks through the concrete consumed entry only", async () => {
+  it("finishTurn(message) acks through the concrete consumed entry only", async () => {
     const ackEntry = vi.fn().mockResolvedValue(undefined);
     let capturedCtx: SessionContext | undefined;
     let firstMessage: Parameters<AgentHandler["start"]>[0] | undefined;
@@ -718,21 +721,19 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     expect(ackEntry).not.toHaveBeenCalled();
 
     // First turn closes — ack entry #1 only.
-    if (firstMessage) capturedCtx?.markMessagesCompleted(firstMessage);
-    await Promise.resolve();
+    if (firstMessage) await capturedCtx?.finishTurn(firstMessage, { status: "success" });
     expect(ackEntry).toHaveBeenCalledTimes(1);
     expect(ackEntry).toHaveBeenCalledWith(1);
 
     // Second turn closes — ack entry #2.
-    if (injected[0]) capturedCtx?.markMessagesCompleted(injected[0]);
-    await Promise.resolve();
+    if (injected[0]) await capturedCtx?.finishTurn(injected[0], { status: "success" });
     expect(ackEntry).toHaveBeenCalledTimes(2);
     expect(ackEntry).toHaveBeenNthCalledWith(2, 2);
 
     await sm.shutdown();
   });
 
-  it("markMessagesCompleted(batch) sends one ack-through for the batch tail", async () => {
+  it("finishTurn(batch) sends one ack-through for the batch tail", async () => {
     const ackEntry = vi.fn().mockResolvedValue(undefined);
     let capturedCtx: SessionContext | undefined;
     let firstMessage: Parameters<AgentHandler["start"]>[0] | undefined;
@@ -755,21 +756,19 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     expect(ackEntry).not.toHaveBeenCalled();
 
     // First turn (just message 10).
-    if (firstMessage) capturedCtx?.markMessagesCompleted(firstMessage);
-    await Promise.resolve();
+    if (firstMessage) await capturedCtx?.finishTurn(firstMessage, { status: "success" });
     expect(ackEntry).toHaveBeenCalledTimes(1);
     expect(ackEntry).toHaveBeenCalledWith(10);
 
     // Fused turn (messages 11 + 12 batched into one runTurn).
-    capturedCtx?.markMessagesCompleted(injected);
-    await Promise.resolve();
+    await capturedCtx?.finishTurn(injected, { status: "success" });
     expect(ackEntry).toHaveBeenCalledTimes(2);
     expect(ackEntry).toHaveBeenNthCalledWith(2, 12);
 
     await sm.shutdown();
   });
 
-  it("markMessagesCompleted ignores stale messages that are no longer tracked", async () => {
+  it("finishTurn ignores stale messages that are no longer tracked", async () => {
     const ackEntry = vi.fn().mockResolvedValue(undefined);
     let capturedCtx: SessionContext | undefined;
     let capturedMessage: Parameters<AgentHandler["start"]>[0] | undefined;
@@ -783,14 +782,45 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     const { sm } = buildSm(ackEntry, handler);
 
     await sm.dispatch(mockEntry({ id: 20, chatId: "chat-clamp" }));
-    if (capturedMessage) capturedCtx?.markMessagesCompleted(capturedMessage);
-    await Promise.resolve();
+    if (capturedMessage) await capturedCtx?.finishTurn(capturedMessage, { status: "success" });
     expect(ackEntry).toHaveBeenCalledTimes(1);
     expect(ackEntry).toHaveBeenCalledWith(20);
 
-    if (capturedMessage) capturedCtx?.markMessagesCompleted(capturedMessage);
-    await Promise.resolve();
+    if (capturedMessage) await capturedCtx?.finishTurn(capturedMessage, { status: "success" });
     expect(ackEntry).toHaveBeenCalledTimes(1);
+
+    await sm.shutdown();
+  });
+
+  it("finishTurn recomputes state and keeps the entry recoverable when ackEntry rejects", async () => {
+    const ackEntry = vi.fn<(entryId: number) => Promise<void>>().mockRejectedValue(new Error("ack down"));
+    const recoverChat = vi.fn().mockResolvedValue(undefined);
+    let capturedCtx: SessionContext | undefined;
+    let capturedMessage: Parameters<AgentHandler["start"]>[0] | undefined;
+    const handler = createMockHandler({
+      async start(m, ctx) {
+        capturedMessage = m;
+        capturedCtx = ctx;
+        return "session-id-mock";
+      },
+    });
+    const { sm } = buildSm(ackEntry, handler, recoverChat);
+
+    await sm.dispatch(mockEntry({ id: 21, chatId: "chat-ack-reject" }));
+    await sm.dispatch(mockEntry({ id: 21, chatId: "chat-ack-reject" }));
+    recoverChat.mockClear();
+    if (capturedMessage) await capturedCtx?.finishTurn(capturedMessage, { status: "success" });
+
+    expect(ackEntry).toHaveBeenCalledWith(21);
+    expect(sm.getSessionRuntimeStates()).toEqual([{ chatId: "chat-ack-reject", runtimeState: "working" }]);
+    expect(handler.inject).not.toHaveBeenCalled();
+
+    await sm.dispatch(mockEntry({ id: 21, chatId: "chat-ack-reject" }));
+    expect(recoverChat).toHaveBeenCalledWith("chat-ack-reject");
+    expect(handler.inject).not.toHaveBeenCalled();
+
+    await sm.dispatch(mockEntry({ id: 21, chatId: "chat-ack-reject" }));
+    expect(handler.inject).toHaveBeenCalledTimes(1);
 
     await sm.shutdown();
   });
@@ -844,8 +874,7 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     expect(routed).toEqual(["start:msg-a1", "inject:msg-a2"]);
     expect(agentConfigCache.refreshIfNewer).toHaveBeenCalledTimes(2);
 
-    if (injected[0]) capturedCtx?.markMessagesCompleted(injected[0]);
-    await Promise.resolve();
+    if (injected[0]) await capturedCtx?.finishTurn(injected[0], { status: "success" });
     expect(ackEntry).toHaveBeenCalledTimes(1);
     expect(ackEntry).toHaveBeenCalledWith(2);
 
@@ -996,9 +1025,8 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     await sm.dispatch(mockEntry({ id: 40, chatId: "chat-retryable", messageId: "msg-a1" }));
     await sm.dispatch(mockEntry({ id: 41, chatId: "chat-retryable", messageId: "msg-a2" }));
 
-    if (firstMessage) capturedCtx?.markMessagesRetryable(firstMessage, "turn_timeout");
-    if (injected[0]) capturedCtx?.markMessagesCompleted(injected[0]);
-    await Promise.resolve();
+    if (firstMessage) capturedCtx?.retryTurn(firstMessage, "turn_timeout");
+    if (injected[0]) await capturedCtx?.finishTurn(injected[0], { status: "success" });
 
     expect(ackEntry).not.toHaveBeenCalled();
 
@@ -1028,7 +1056,7 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     expect(recoverChat).toHaveBeenCalledTimes(1);
     expect(startSpy).toHaveBeenCalledTimes(1);
 
-    if (firstMessage) capturedCtx?.markMessagesRetryable(firstMessage, "turn_timeout");
+    if (firstMessage) capturedCtx?.retryTurn(firstMessage, "turn_timeout");
 
     await sm.dispatch(mockEntry({ id: 43, chatId: "chat-retryable-recover", messageId: "msg-r2" }));
     expect(recoverChat).toHaveBeenCalledTimes(2);
@@ -1054,7 +1082,7 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     const { sm } = buildSm(ackEntry, handler);
 
     await sm.dispatch(mockEntry({ id: 44, chatId: "chat-retryable-no-recover", messageId: "msg-nr1" }));
-    if (firstMessage) capturedCtx?.markMessagesRetryable(firstMessage, "turn_timeout");
+    if (firstMessage) capturedCtx?.retryTurn(firstMessage, "turn_timeout");
 
     await sm.dispatch(mockEntry({ id: 45, chatId: "chat-retryable-no-recover", messageId: "msg-nr2" }));
     expect(injectSpy).not.toHaveBeenCalled();
@@ -1063,19 +1091,22 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     await sm.shutdown();
   });
 
-  it("ack waits for markCompleted when resuming an evicted session", async () => {
+  it("ack waits for finishTurn when resuming an evicted session", async () => {
     // Seed an evicted session by exceeding concurrency=1, then dispatch into
     // the evicted chat to trigger the resume branch.
     const ackEntry = vi.fn().mockResolvedValue(undefined);
     const recoverChat = vi.fn().mockResolvedValue(undefined);
     const capturedCtxs: SessionContext[] = [];
+    const capturedMessages: SessionMessage[] = [];
     const handler = createMockHandler({
-      async start(_m, ctx) {
+      async start(m, ctx) {
         capturedCtxs.push(ctx);
+        capturedMessages.push(m);
         return "session-id-mock";
       },
-      async resume(_m, _sid, ctx) {
+      async resume(m, _sid, ctx) {
         capturedCtxs.push(ctx);
+        if (m) capturedMessages.push(m);
         return "session-id-mock";
       },
     });
@@ -1109,9 +1140,8 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     await sm.dispatch(chatB);
     // Close chat-a and chat-b's start turns so their entries don't pollute
     // the resume-branch ack assertion.
-    capturedCtxs[0]?.markCompleted();
-    capturedCtxs[1]?.markCompleted();
-    await Promise.resolve();
+    if (capturedMessages[0]) await capturedCtxs[0]?.finishTurn(capturedMessages[0], { status: "success" });
+    if (capturedMessages[1]) await capturedCtxs[1]?.finishTurn(capturedMessages[1], { status: "success" });
     ackEntry.mockClear();
 
     // Dispatching back into chat-a first triggers chat-scoped recovery; the
@@ -1121,8 +1151,7 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     await sm.dispatch(chatAResume);
     expect(ackEntry).not.toHaveBeenCalled();
 
-    capturedCtxs[2]?.markCompleted();
-    await Promise.resolve();
+    if (capturedMessages[2]) await capturedCtxs[2]?.finishTurn(capturedMessages[2], { status: "success" });
     expect(ackEntry).toHaveBeenCalledWith(3);
 
     await sm.shutdown();
@@ -1158,7 +1187,7 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
   it("does NOT ack on transient handler.start failure — retry path keeps the entry queued for forwardResult", async () => {
     // A 429-ish error is classified as transient; the runtime schedules a
     // retry inside `handleSessionFailure` and leaves the entry queued so
-    // the eventual successful retry can ack it via markCompleted.
+    // the eventual successful retry can ack it via finishTurn.
     const ackEntry = vi.fn().mockResolvedValue(undefined);
     const transientErr = Object.assign(new Error("rate limited"), { status: 429 });
     const handler = createMockHandler({
@@ -1178,8 +1207,8 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
   it("acks queued in-flight entries on session:terminate", async () => {
     const ackEntry = vi.fn().mockResolvedValue(undefined);
     // Handler whose `start` resolves quickly (matching production: start
-    // returns the sessionId; the turn closes later via markCompleted).
-    // markCompleted is NEVER called by this mock, so the entry sits in
+    // returns the sessionId; the turn closes later via finishTurn).
+    // finishTurn is NEVER called by this mock, so the entry sits in
     // `inFlightEntries` past the turn — exactly what terminate needs to
     // ack so the next bind doesn't redeliver.
     const handler = createMockHandler();

--- a/packages/client/src/__tests__/session-manager.test.ts
+++ b/packages/client/src/__tests__/session-manager.test.ts
@@ -1030,6 +1030,44 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     await sm.shutdown();
   });
 
+  it("does not resume a stale session entry after terminate wins the suspend ACK race", async () => {
+    const ack = deferred<void>();
+    const ackEntry = vi.fn((entryId: number) => (entryId === 39 ? ack.promise : Promise.resolve()));
+    let capturedCtx: SessionContext | undefined;
+    let firstMessage: Parameters<AgentHandler["start"]>[0] | undefined;
+    const resumeSpy = vi.fn(async () => "session-id-mock");
+    const handler = createMockHandler({
+      async start(m, ctx) {
+        firstMessage = m;
+        capturedCtx = ctx;
+        return "session-id-mock";
+      },
+      resume: resumeSpy,
+    });
+    const { sm } = buildSm(ackEntry, handler);
+
+    await sm.dispatch(mockEntry({ id: 39, chatId: "chat-suspend-terminate-race", messageId: "msg-t1" }));
+    if (firstMessage) capturedCtx?.markMessagesConsumed(firstMessage);
+
+    await sm.handleCommand("chat-suspend-terminate-race", "session:suspend");
+    expect(ackEntry).toHaveBeenCalledWith(39);
+
+    const resumedInput = sm.dispatch(mockEntry({ id: 40, chatId: "chat-suspend-terminate-race", messageId: "msg-t2" }));
+    await Promise.resolve();
+    expect(resumeSpy).not.toHaveBeenCalled();
+
+    await sm.handleCommand("chat-suspend-terminate-race", "session:terminate");
+    ack.resolve();
+    await resumedInput;
+
+    expect(resumeSpy).not.toHaveBeenCalled();
+    expect(sm.activeCount).toBe(0);
+    expect(sm.totalCount).toBe(0);
+    expect(sm.getHeldChatIds()).not.toContain("chat-suspend-terminate-race");
+
+    await sm.shutdown();
+  });
+
   it("suspend leaves injected but not consumed entries unacked for recovery", async () => {
     const ackEntry = vi.fn().mockResolvedValue(undefined);
     const recoverChat = vi.fn().mockResolvedValue(undefined);

--- a/packages/client/src/__tests__/session-manager.test.ts
+++ b/packages/client/src/__tests__/session-manager.test.ts
@@ -967,6 +967,34 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     await sm.shutdown();
   });
 
+  it("suspend ACK failure leaves consumed entries behind a recovery gate", async () => {
+    const ackEntry = vi.fn().mockRejectedValue(new Error("ack unavailable"));
+    let capturedCtx: SessionContext | undefined;
+    let firstMessage: Parameters<AgentHandler["start"]>[0] | undefined;
+    const resumeSpy = vi.fn(async () => "session-id-mock");
+    const handler = createMockHandler({
+      async start(m, ctx) {
+        firstMessage = m;
+        capturedCtx = ctx;
+        return "session-id-mock";
+      },
+      resume: resumeSpy,
+    });
+    const { sm } = buildSm(ackEntry, handler);
+
+    await sm.dispatch(mockEntry({ id: 35, chatId: "chat-suspend-ack-fail", messageId: "msg-f1" }));
+    if (firstMessage) capturedCtx?.markMessagesConsumed(firstMessage);
+
+    await sm.handleCommand("chat-suspend-ack-fail", "session:suspend");
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(ackEntry).toHaveBeenCalledWith(35);
+
+    await sm.dispatch(mockEntry({ id: 36, chatId: "chat-suspend-ack-fail", messageId: "msg-f2" }));
+    expect(resumeSpy).not.toHaveBeenCalled();
+
+    await sm.shutdown();
+  });
+
   it("suspend leaves injected but not consumed entries unacked for recovery", async () => {
     const ackEntry = vi.fn().mockResolvedValue(undefined);
     const recoverChat = vi.fn().mockResolvedValue(undefined);

--- a/packages/client/src/__tests__/session-runtime-state.test.ts
+++ b/packages/client/src/__tests__/session-runtime-state.test.ts
@@ -1,26 +1,15 @@
 import type pino from "pino";
 import { describe, expect, it, vi } from "vitest";
-import type { AgentHandler, HandlerFactory, SessionContext } from "../runtime/handler.js";
+import type { AgentHandler, HandlerFactory, SessionContext, SessionMessage } from "../runtime/handler.js";
 import { SessionManager } from "../runtime/session-manager.js";
 import type { FirstTreeHubSDK } from "../sdk.js";
 import { silentLogger } from "./_logger-helpers.js";
 import { mockEntry } from "./test-helpers.js";
 
-/** Assert value is defined and return it (avoids non-null assertions). */
 function defined<T>(value: T | undefined, label = "value"): T {
   expect(value, `${label} should be defined`).toBeDefined();
   return value as T;
 }
-
-/**
- * Tests for per-session runtime state aggregation and cleanup.
- *
- * Covers:
- * - Aggregate runtime state recomputation (idle → working → blocked → error priority)
- * - Runtime state cleanup on terminate command
- * - Runtime state cleanup on eviction
- * - Runtime state cleanup on start/resume failure
- */
 
 function mockSdk(): FirstTreeHubSDK {
   return {
@@ -92,353 +81,120 @@ function createSessionManager(opts: {
   });
 }
 
-describe("SessionManager: runtime state aggregation", () => {
-  it("fires onRuntimeStateChange when a session sets working state", async () => {
+describe("SessionManager runtime state reducer", () => {
+  it("reports working from in-flight delivery and idle after finishTurn", async () => {
     const runtimeChanges: Array<"idle" | "working" | "blocked" | "error"> = [];
     let capturedCtx: SessionContext | undefined;
-
+    let capturedMessage: SessionMessage | undefined;
     const handler = createMockHandler({
-      async start(_msg, ctx) {
+      async start(msg, ctx) {
+        capturedMessage = msg;
         capturedCtx = ctx;
         return "session-1";
       },
     });
-
-    const sm = createSessionManager({
-      handler,
-      onRuntimeStateChange: (state) => runtimeChanges.push(state),
-    });
+    const sm = createSessionManager({ handler, onRuntimeStateChange: (state) => runtimeChanges.push(state) });
 
     await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
-    expect(capturedCtx).toBeDefined();
-
-    // Handler sets working state
-    const ctx = defined(capturedCtx, "capturedCtx");
-    ctx.setRuntimeState("working");
     expect(runtimeChanges).toContain("working");
-
-    // Handler sets back to idle
-    ctx.setRuntimeState("idle");
-    expect(runtimeChanges[runtimeChanges.length - 1]).toBe("idle");
-
-    await sm.shutdown();
-  });
-
-  it("aggregates to highest priority: error > blocked > working > idle", async () => {
-    const runtimeChanges: Array<"idle" | "working" | "blocked" | "error"> = [];
-    const contexts: SessionContext[] = [];
-
-    const factory: HandlerFactory = () =>
-      createMockHandler({
-        async start(_msg, ctx) {
-          contexts.push(ctx);
-          return `session-${contexts.length}`;
-        },
-      });
-
-    const sm = createSessionManager({
-      handlerFactory: factory,
-      onRuntimeStateChange: (state) => runtimeChanges.push(state),
-    });
-
-    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
-    await sm.dispatch(mockEntry({ id: 2, chatId: "chat-b" }));
-    expect(contexts).toHaveLength(2);
-
-    // Both idle → aggregate stays idle (initial state, no explicit report yet)
-    runtimeChanges.length = 0;
-
-    const ctx0 = defined(contexts[0], "contexts[0]");
-    const ctx1 = defined(contexts[1], "contexts[1]");
-
-    // One working → aggregate = working
-    ctx0.setRuntimeState("working");
-    expect(runtimeChanges[runtimeChanges.length - 1]).toBe("working");
-
-    // Second also working → still working
-    ctx1.setRuntimeState("working");
-    expect(runtimeChanges[runtimeChanges.length - 1]).toBe("working");
-
-    // One error → aggregate = error (highest priority)
-    ctx0.setRuntimeState("error");
-    expect(runtimeChanges[runtimeChanges.length - 1]).toBe("error");
-
-    // Clear error, set blocked → aggregate = blocked
-    ctx0.setRuntimeState("blocked");
-    expect(runtimeChanges[runtimeChanges.length - 1]).toBe("blocked");
-
-    await sm.shutdown();
-  });
-
-  it("deduplicates aggregate state — no callback if state unchanged", async () => {
-    const runtimeChanges: Array<"idle" | "working" | "blocked" | "error"> = [];
-    let capturedCtx: SessionContext | undefined;
-
-    const handler = createMockHandler({
-      async start(_msg, ctx) {
-        capturedCtx = ctx;
-        return "s1";
-      },
-    });
-
-    const sm = createSessionManager({
-      handler,
-      onRuntimeStateChange: (state) => runtimeChanges.push(state),
-    });
-
-    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
-    runtimeChanges.length = 0;
-
-    const dedupCtx = defined(capturedCtx, "capturedCtx");
-    dedupCtx.setRuntimeState("working");
-    dedupCtx.setRuntimeState("working"); // duplicate — should not fire
-    dedupCtx.setRuntimeState("working"); // duplicate — should not fire
-    expect(runtimeChanges).toHaveLength(1);
-
-    await sm.shutdown();
-  });
-});
-
-describe("SessionManager: runtime state cleanup on terminate", () => {
-  it("clears session runtime state and recomputes aggregate on terminate", async () => {
-    const runtimeChanges: Array<"idle" | "working" | "blocked" | "error"> = [];
-    const contexts: SessionContext[] = [];
-
-    const factory: HandlerFactory = () =>
-      createMockHandler({
-        async start(_msg, ctx) {
-          contexts.push(ctx);
-          return `s-${contexts.length}`;
-        },
-      });
-
-    const sm = createSessionManager({
-      handlerFactory: factory,
-      onRuntimeStateChange: (state) => runtimeChanges.push(state),
-    });
-
-    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
-    await sm.dispatch(mockEntry({ id: 2, chatId: "chat-b" }));
-
-    // chat-a = working, chat-b = idle → aggregate = working
-    defined(contexts[0], "contexts[0]").setRuntimeState("working");
-    runtimeChanges.length = 0;
-
-    // Terminate chat-a → its "working" state should be cleaned up → aggregate = idle
-    await sm.handleCommand("chat-a", "session:terminate");
-
-    expect(runtimeChanges[runtimeChanges.length - 1]).toBe("idle");
-
-    await sm.shutdown();
-  });
-});
-
-describe("SessionManager: runtime state cleanup on eviction", () => {
-  it("clears session runtime state when evicted by max_sessions", async () => {
-    const runtimeChanges: Array<"idle" | "working" | "blocked" | "error"> = [];
-    const contexts: SessionContext[] = [];
-
-    const factory: HandlerFactory = () =>
-      createMockHandler({
-        async start(_msg, ctx) {
-          contexts.push(ctx);
-          return `s-${contexts.length}`;
-        },
-      });
-
-    const sm = createSessionManager({
-      session: { idle_timeout: 300, max_sessions: 2, working_grace_seconds: 3600, reconcile_interval_seconds: 300 },
-      handlerFactory: factory,
-      onRuntimeStateChange: (state) => runtimeChanges.push(state),
-    });
-
-    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
-    await sm.dispatch(mockEntry({ id: 2, chatId: "chat-b" }));
-
-    // chat-a = error → aggregate = error
-    defined(contexts[0], "contexts[0]").setRuntimeState("error");
-    runtimeChanges.length = 0;
-
-    // Third chat triggers eviction of LRU (chat-a with error) → aggregate should drop from error
-    await sm.dispatch(mockEntry({ id: 3, chatId: "chat-c" }));
-
-    // After chat-a evicted, its "error" state is gone, aggregate should not be "error"
-    const lastState = runtimeChanges[runtimeChanges.length - 1];
-    expect(lastState).not.toBe("error");
-
-    await sm.shutdown();
-  });
-});
-
-describe("SessionManager: runtime state cleanup on start failure", () => {
-  it("clears session runtime state when handler.start throws permanent error", async () => {
-    const runtimeChanges: Array<"idle" | "working" | "blocked" | "error"> = [];
-    let callCount = 0;
-
-    // After Task 3 (transient retry): transient errors keep the entry alive
-    // for retry; only permanent errors run the legacy teardown that this
-    // test guards. Use a permanent-classified error class.
-    class FakePermanentError extends Error {
-      override name = "ClientUserMismatchError";
-    }
-
-    const factory: HandlerFactory = () => {
-      callCount++;
-      if (callCount === 2) {
-        // Second handler throws on start with a permanent classification.
-        return createMockHandler({
-          async start() {
-            throw new FakePermanentError("start boom");
-          },
-        });
-      }
-      return createMockHandler();
-    };
-
-    const sm = createSessionManager({
-      handlerFactory: factory,
-      onRuntimeStateChange: (state) => runtimeChanges.push(state),
-      log: silentLogger(),
-    });
-
-    // First session starts fine
-    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
-    // Second session fails to start — should not leave orphaned runtime state
-    await sm.dispatch(mockEntry({ id: 2, chatId: "chat-b" }));
-
-    // Only chat-a should be tracked
-    expect(sm.totalCount).toBe(1);
-
-    // Aggregate should not be affected by the failed session
-    // If there was a leak, the failed session's state would pollute the aggregate
-    const lastState = runtimeChanges.length > 0 ? runtimeChanges[runtimeChanges.length - 1] : null;
-    // Should be null (no runtime state set) or "idle" — never "error" or "working"
-    expect(lastState === null || lastState === "idle").toBe(true);
-
-    await sm.shutdown();
-  });
-});
-
-describe("SessionManager: getAggregateRuntimeState()", () => {
-  it("returns null when no sessions have reported state", async () => {
-    const sm = createSessionManager({});
-    expect(sm.getAggregateRuntimeState()).toBeNull();
-    await sm.shutdown();
-  });
-
-  it("returns current aggregate after session reports", async () => {
-    let capturedCtx: SessionContext | undefined;
-    const handler = createMockHandler({
-      async start(_msg, ctx) {
-        capturedCtx = ctx;
-        return "s1";
-      },
-    });
-
-    const sm = createSessionManager({
-      handler,
-      onRuntimeStateChange: () => {},
-    });
-
-    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
-    defined(capturedCtx, "ctx").setRuntimeState("working");
     expect(sm.getAggregateRuntimeState()).toBe("working");
 
-    defined(capturedCtx, "ctx").setRuntimeState("idle");
+    await defined(capturedCtx, "ctx").finishTurn(defined(capturedMessage, "message"), { status: "success" });
+    expect(runtimeChanges[runtimeChanges.length - 1]).toBe("idle");
     expect(sm.getAggregateRuntimeState()).toBe("idle");
 
     await sm.shutdown();
   });
-});
 
-describe("SessionManager: per-(agent,chat) runtime callback (#553 rebase)", () => {
-  it("fires onSessionRuntimeChange with the chatId whenever a session reports runtime", async () => {
-    const events: Array<{ chatId: string; state: string }> = [];
+  it("keeps a consumed-but-unfinished turn working", async () => {
     let capturedCtx: SessionContext | undefined;
+    let capturedMessage: SessionMessage | undefined;
     const handler = createMockHandler({
-      async start(_msg, ctx) {
+      async start(msg, ctx) {
+        capturedMessage = msg;
         capturedCtx = ctx;
-        return "s1";
+        return "session-1";
       },
     });
-
-    const sm = createSessionManager({
-      handler,
-      onSessionRuntimeChange: (chatId, state) => events.push({ chatId, state }),
-    });
+    const sm = createSessionManager({ handler, onRuntimeStateChange: () => {} });
 
     await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
-    defined(capturedCtx, "ctx").setRuntimeState("working");
-    defined(capturedCtx, "ctx").setRuntimeState("idle");
+    defined(capturedCtx, "ctx").markMessagesConsumed(defined(capturedMessage, "message"));
 
-    // dispatch flow itself sets working before handler.start (the inject→working
-    // grace-window fix). We only care that the explicit setRuntimeState calls
-    // emitted with the right chatId.
-    const forChatA = events.filter((e) => e.chatId === "chat-a").map((e) => e.state);
-    expect(forChatA).toContain("working");
-    expect(forChatA).toContain("idle");
+    expect(sm.getSessionRuntimeStates()).toEqual([{ chatId: "chat-a", runtimeState: "working" }]);
 
     await sm.shutdown();
   });
 
-  it("getSessionRuntimeStates returns ACTIVE sessions only, defaulting to idle when unrecorded", async () => {
+  it("uses manager-owned terminal marker for runtime error projection", async () => {
+    const runtimeChanges: Array<"idle" | "working" | "blocked" | "error"> = [];
     let capturedCtx: SessionContext | undefined;
+    let capturedMessage: SessionMessage | undefined;
     const handler = createMockHandler({
-      async start(_msg, ctx) {
+      async start(msg, ctx) {
+        capturedMessage = msg;
         capturedCtx = ctx;
-        return "s-a";
+        return "session-1";
       },
     });
+    const sm = createSessionManager({ handler, onRuntimeStateChange: (state) => runtimeChanges.push(state) });
 
-    const sm = createSessionManager({ handler, onSessionRuntimeChange: () => {} });
     await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
-    defined(capturedCtx, "ctx").setRuntimeState("working");
+    await defined(capturedCtx, "ctx").finishTurn(defined(capturedMessage, "message"), {
+      status: "error",
+      terminal: true,
+    });
 
-    const snap = sm.getSessionRuntimeStates();
-    expect(snap).toEqual([{ chatId: "chat-a", runtimeState: "working" }]);
+    expect(runtimeChanges[runtimeChanges.length - 1]).toBe("error");
+    expect(sm.getSessionRuntimeStates()).toEqual([{ chatId: "chat-a", runtimeState: "error" }]);
 
     await sm.shutdown();
   });
 
-  it("re-affirm timer re-emits working / blocked / error, skips idle", async () => {
+  it("clears runtime projection on terminate", async () => {
+    const runtimeChanges: Array<"idle" | "working" | "blocked" | "error"> = [];
+    const handler = createMockHandler();
+    const sm = createSessionManager({ handler, onRuntimeStateChange: (state) => runtimeChanges.push(state) });
+
+    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
+    runtimeChanges.length = 0;
+
+    await sm.handleCommand("chat-a", "session:terminate");
+
+    expect(runtimeChanges[runtimeChanges.length - 1]).toBe("idle");
+    expect(sm.getSessionRuntimeStates()).toEqual([]);
+
+    await sm.shutdown();
+  });
+
+  it("re-affirm timer re-emits working and skips idle", async () => {
     vi.useFakeTimers();
     try {
       const seen: Array<{ chatId: string; state: string }> = [];
-      const contexts: SessionContext[] = [];
-      const factory: HandlerFactory = () =>
-        createMockHandler({
-          async start(_msg, ctx) {
-            contexts.push(ctx);
-            return `s-${contexts.length}`;
-          },
-        });
-
+      let ctx: SessionContext | undefined;
+      let message: SessionMessage | undefined;
+      const handler = createMockHandler({
+        async start(msg, sessionCtx) {
+          message = msg;
+          ctx = sessionCtx;
+          return "session-1";
+        },
+      });
       const sm = createSessionManager({
-        handlerFactory: factory,
+        handler,
         onSessionRuntimeChange: (chatId, state) => seen.push({ chatId, state }),
         session: { idle_timeout: 3600, max_sessions: 10, working_grace_seconds: 3600, reconcile_interval_seconds: 300 },
       });
 
       await sm.dispatch(mockEntry({ id: 1, chatId: "chat-w" }));
-      await sm.dispatch(mockEntry({ id: 2, chatId: "chat-i" }));
-      defined(contexts[0], "ctx0").setRuntimeState("working");
-      defined(contexts[1], "ctx1").setRuntimeState("idle");
-
-      // Drain the initial callback noise so the assertion below targets
-      // only re-affirm output.
       seen.length = 0;
-
-      // Reaffirm base = 20s + ±20% jitter — 60s straddles the upper bound
-      // (24s) twice so at least one fire is guaranteed even at max jitter.
       await vi.advanceTimersByTimeAsync(60_000);
+      expect(seen.some((event) => event.chatId === "chat-w" && event.state === "working")).toBe(true);
 
-      const reaffirms = seen.filter((e) => e.chatId === "chat-w" || e.chatId === "chat-i");
-      const workingReaffirms = reaffirms.filter((e) => e.chatId === "chat-w" && e.state === "working");
-      const idleReaffirms = reaffirms.filter((e) => e.chatId === "chat-i");
-      expect(workingReaffirms.length).toBeGreaterThanOrEqual(1);
-      // idle sessions must NEVER show up on the reaffirm channel — that's
-      // pure wire noise (server's fail-closed default already handles it).
-      expect(idleReaffirms).toHaveLength(0);
+      await defined(ctx, "ctx").finishTurn(defined(message, "message"), { status: "success" });
+      seen.length = 0;
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(seen).toEqual([]);
 
       await sm.shutdown();
     } finally {
@@ -447,67 +203,17 @@ describe("SessionManager: per-(agent,chat) runtime callback (#553 rebase)", () =
   });
 });
 
-describe("SessionManager: ack-through guard under concurrency preemption", () => {
-  it("abandons a preempted unfinished entry and only acks the newly completed chat", async () => {
-    // Ack-through fail-closed: preempting chat-a means its unfinished
-    // delivered entry must not be committed by a stale completion. chat-b
-    // can complete its own attempt and ack only its through cursor.
-    const ackEntry = mockAckEntry();
-    const ctxs: Record<string, SessionContext> = {};
-    const handler = createMockHandler({
-      async start(msg, ctx) {
-        ctxs[msg.chatId] = ctx;
-        return "session-id-mock";
-      },
-    });
-    const sm = createSessionManager({ ackEntry, handler, concurrency: 1 });
-
-    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
-    // chat-b's dispatch causes chat-a to be suspended (preempted for slot)
-    // and chat-b's handler.start to run.
-    await sm.dispatch(mockEntry({ id: 2, chatId: "chat-b" }));
-    expect(ackEntry).not.toHaveBeenCalled();
-
-    // chat-a's stale completion is ignored; chat-b completes normally.
-    ctxs["chat-a"]?.markCompleted();
-    ctxs["chat-b"]?.markCompleted();
-    await Promise.resolve();
-    expect(ackEntry).toHaveBeenCalledTimes(1);
-    expect(ackEntry).not.toHaveBeenCalledWith(1);
-    expect(ackEntry).toHaveBeenCalledWith(2);
-
-    await sm.shutdown();
-  });
-});
-
-describe("SessionManager.evictIdle — working-state grace window", () => {
-  // A long thinking turn or one giant SDK message produces no inbound events
-  // for minutes at a time, so `lastActivity` (refreshed only by handler
-  // `touch()`) drifts past `idle_timeout` even though the handler is still
-  // working. Without this grace window the runtime suspends the SDK
-  // mid-thought; with it, the slot survives until either work resumes or the
-  // upper bound `idle_timeout + working_grace_seconds` is exceeded.
-  it("does NOT suspend a session whose runtimeState is 'working' inside the grace window", async () => {
+describe("SessionManager.evictIdle with manager-owned runtime state", () => {
+  it("does NOT suspend a session with delivery work inside the grace window", async () => {
     vi.useFakeTimers();
     try {
-      let capturedCtx: SessionContext | undefined;
-      const handler = createMockHandler({
-        async start(_msg, ctx) {
-          capturedCtx = ctx;
-          return "s-working";
-        },
-      });
+      const handler = createMockHandler();
       const sm = createSessionManager({
         handler,
-        // 1s idle window + 60s grace — picked so a single 20s tick lands
-        // inside the grace window.
         session: { idle_timeout: 1, max_sessions: 10, working_grace_seconds: 60, reconcile_interval_seconds: 300 },
       });
 
       await sm.dispatch(mockEntry({ id: 1, chatId: "chat-thinking" }));
-      defined(capturedCtx, "ctx").setRuntimeState("working");
-
-      // 20s ≫ idle_timeout (1s) but ≪ idle_timeout + grace (61s).
       await vi.advanceTimersByTimeAsync(20_000);
 
       expect(handler.suspend).not.toHaveBeenCalled();
@@ -517,27 +223,16 @@ describe("SessionManager.evictIdle — working-state grace window", () => {
     }
   });
 
-  it("DOES suspend once inactiveMs exceeds idle_timeout + working_grace_seconds", async () => {
+  it("does suspend once delivery work exceeds idle_timeout + working_grace_seconds", async () => {
     vi.useFakeTimers();
     try {
-      let capturedCtx: SessionContext | undefined;
-      const handler = createMockHandler({
-        async start(_msg, ctx) {
-          capturedCtx = ctx;
-          return "s-stuck";
-        },
-      });
+      const handler = createMockHandler();
       const sm = createSessionManager({
         handler,
-        // 1s idle + 5s grace — the timer below blows past the 6s cap so
-        // the runtime should give up and reclaim the slot.
         session: { idle_timeout: 1, max_sessions: 10, working_grace_seconds: 5, reconcile_interval_seconds: 300 },
       });
 
       await sm.dispatch(mockEntry({ id: 1, chatId: "chat-stuck" }));
-      defined(capturedCtx, "ctx").setRuntimeState("working");
-
-      // 30s ≫ idle_timeout + grace (6s). evictIdle ticks every 10s.
       await vi.advanceTimersByTimeAsync(30_000);
 
       expect(handler.suspend).toHaveBeenCalledTimes(1);
@@ -547,44 +242,14 @@ describe("SessionManager.evictIdle — working-state grace window", () => {
     }
   });
 
-  // `blocked` is no longer auto-set by evictIdle (the 120s auto-migration
-  // was removed because reasoning-model thinking turns commonly exceed 2
-  // minutes between SDK events, producing false-positive UI warnings).
-  // The grace-window exemption still covers `blocked` so any handler that
-  // sets it explicitly — present or future — is treated like `working`.
-  it("also exempts 'blocked' from idle suspend inside the grace window", async () => {
+  it("idle sessions suspend at idle_timeout after finishTurn", async () => {
     vi.useFakeTimers();
     try {
       let capturedCtx: SessionContext | undefined;
+      let capturedMessage: SessionMessage | undefined;
       const handler = createMockHandler({
-        async start(_msg, ctx) {
-          capturedCtx = ctx;
-          return "s-blocked";
-        },
-      });
-      const sm = createSessionManager({
-        handler,
-        session: { idle_timeout: 1, max_sessions: 10, working_grace_seconds: 60, reconcile_interval_seconds: 300 },
-      });
-
-      await sm.dispatch(mockEntry({ id: 1, chatId: "chat-blocked" }));
-      defined(capturedCtx, "ctx").setRuntimeState("blocked");
-
-      await vi.advanceTimersByTimeAsync(20_000);
-
-      expect(handler.suspend).not.toHaveBeenCalled();
-      await sm.shutdown();
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it("'idle' runtimeState still suspends at idle_timeout (regression)", async () => {
-    vi.useFakeTimers();
-    try {
-      let capturedCtx: SessionContext | undefined;
-      const handler = createMockHandler({
-        async start(_msg, ctx) {
+        async start(msg, ctx) {
+          capturedMessage = msg;
           capturedCtx = ctx;
           return "s-idle";
         },
@@ -595,8 +260,7 @@ describe("SessionManager.evictIdle — working-state grace window", () => {
       });
 
       await sm.dispatch(mockEntry({ id: 1, chatId: "chat-idle" }));
-      defined(capturedCtx, "ctx").setRuntimeState("idle");
-
+      await defined(capturedCtx, "ctx").finishTurn(defined(capturedMessage, "message"), { status: "success" });
       await vi.advanceTimersByTimeAsync(20_000);
 
       expect(handler.suspend).toHaveBeenCalledTimes(1);
@@ -606,61 +270,14 @@ describe("SessionManager.evictIdle — working-state grace window", () => {
     }
   });
 
-  // Regression for the removed 120s working→blocked auto-migration.
-  // Before this change evictIdle would flip a `working` session to
-  // `blocked` after 2 minutes of SDK silence, surfacing as a yellow UI
-  // warning even when the agent was just deep-thinking. The grace
-  // window above proved that's never a real problem (we don't actually
-  // suspend), so the auto-migration was pure UX noise — removed.
-  it("does NOT auto-migrate 'working' → 'blocked' on inactivity (no false alarms during long reasoning)", async () => {
-    vi.useFakeTimers();
-    try {
-      const runtimeChanges: Array<"idle" | "working" | "blocked" | "error"> = [];
-      let capturedCtx: SessionContext | undefined;
-      const handler = createMockHandler({
-        async start(_msg, ctx) {
-          capturedCtx = ctx;
-          return "s-no-auto-blocked";
-        },
-      });
-      const sm = createSessionManager({
-        handler,
-        // Big idle_timeout so we don't trip the suspend path while we're
-        // proving the *non*-transition.
-        session: { idle_timeout: 3600, max_sessions: 10, working_grace_seconds: 60, reconcile_interval_seconds: 300 },
-        onRuntimeStateChange: (state) => runtimeChanges.push(state),
-      });
-
-      await sm.dispatch(mockEntry({ id: 1, chatId: "chat-thinking" }));
-      defined(capturedCtx, "ctx").setRuntimeState("working");
-      runtimeChanges.length = 0;
-
-      // Past the old 120s threshold; the runtime would previously have
-      // flipped the state to `blocked` here.
-      await vi.advanceTimersByTimeAsync(180_000);
-
-      expect(runtimeChanges).not.toContain("blocked");
-      expect(handler.suspend).not.toHaveBeenCalled();
-      await sm.shutdown();
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  // Reproduces the post-#477 regression observed in production: a turn that
-  // ends with `setRuntimeState("idle")` (handler claude-code does this on
-  // every result message) left the next inject-triggered turn observable
-  // as `idle`, so a long thinking turn that produced no SDK output for
-  // `idle_timeout` (300s) tripped evictIdle's suspend path even though the
-  // agent was still working. `dispatch` for an active chat must put the
-  // session back into `working` BEFORE the handler starts its next turn
-  // so the grace-window guard above kicks in.
-  it("'idle' → inject restores 'working' so the grace window protects long thinking turns", async () => {
+  it("idle to inject restores working so the grace window protects the next turn", async () => {
     vi.useFakeTimers();
     try {
       let capturedCtx: SessionContext | undefined;
+      let capturedMessage: SessionMessage | undefined;
       const handler = createMockHandler({
-        async start(_msg, ctx) {
+        async start(msg, ctx) {
+          capturedMessage = msg;
           capturedCtx = ctx;
           return "s-inject-grace";
         },
@@ -671,24 +288,14 @@ describe("SessionManager.evictIdle — working-state grace window", () => {
       });
 
       await sm.dispatch(mockEntry({ id: 1, chatId: "chat-inject" }));
-      // Handler completed its first turn — back to idle, mirroring
-      // claude-code.ts on every result message.
-      defined(capturedCtx, "ctx").setRuntimeState("idle");
+      await defined(capturedCtx, "ctx").finishTurn(defined(capturedMessage, "message"), { status: "success" });
 
-      // User sends a follow-up. Without the inject→working fix, this
-      // refreshes lastActivity but leaves runtimeState=idle, so the next
-      // evictIdle tick past idle_timeout would suspend the chat
-      // mid-thinking.
       await sm.dispatch(mockEntry({ id: 2, chatId: "chat-inject" }));
       expect(handler.inject).toHaveBeenCalledTimes(1);
 
-      // 20s ≫ idle_timeout (1s) but ≪ idle_timeout + grace (61s). The
-      // handler is "thinking" — no touch() calls — so lastActivity stays
-      // pinned at the inject moment. The grace window must keep the slot
-      // alive.
       await vi.advanceTimersByTimeAsync(20_000);
-
       expect(handler.suspend).not.toHaveBeenCalled();
+
       await sm.shutdown();
     } finally {
       vi.useRealTimers();

--- a/packages/client/src/__tests__/session-runtime-state.test.ts
+++ b/packages/client/src/__tests__/session-runtime-state.test.ts
@@ -1,3 +1,4 @@
+import type { SessionEvent } from "@first-tree/shared";
 import type pino from "pino";
 import { describe, expect, it, vi } from "vitest";
 import type { AgentHandler, HandlerFactory, SessionContext, SessionMessage } from "../runtime/handler.js";
@@ -49,6 +50,7 @@ function createSessionManager(opts: {
   log?: pino.Logger;
   onRuntimeStateChange?: (state: "idle" | "working" | "blocked" | "error") => void;
   onSessionRuntimeChange?: (chatId: string, state: "idle" | "working" | "blocked" | "error") => void;
+  onSessionEvent?: (chatId: string, event: SessionEvent) => void;
 }) {
   const handler = opts.handler ?? createMockHandler();
   const factory: HandlerFactory = opts.handlerFactory ?? (() => handler);
@@ -78,6 +80,7 @@ function createSessionManager(opts: {
     ackEntry: opts.ackEntry ?? mockAckEntry(),
     onRuntimeStateChange: opts.onRuntimeStateChange,
     onSessionRuntimeChange: opts.onSessionRuntimeChange,
+    onSessionEvent: opts.onSessionEvent,
   });
 }
 
@@ -147,6 +150,73 @@ describe("SessionManager runtime state reducer", () => {
 
     expect(runtimeChanges[runtimeChanges.length - 1]).toBe("error");
     expect(sm.getSessionRuntimeStates()).toEqual([{ chatId: "chat-a", runtimeState: "error" }]);
+
+    await sm.shutdown();
+  });
+
+  it("projects terminal no-ack retry turns as runtime error without acking", async () => {
+    const ackEntry = mockAckEntry();
+    const events: Array<{ chatId: string; event: SessionEvent }> = [];
+    let capturedCtx: SessionContext | undefined;
+    let capturedMessage: SessionMessage | undefined;
+    const handler = createMockHandler({
+      async start(msg, ctx) {
+        capturedMessage = msg;
+        capturedCtx = ctx;
+        return "session-1";
+      },
+    });
+    const sm = createSessionManager({
+      handler,
+      ackEntry,
+      onSessionEvent: (chatId, event) => events.push({ chatId, event }),
+    });
+
+    await sm.dispatch(mockEntry({ id: 2, chatId: "chat-timeout" }));
+    defined(capturedCtx, "ctx").retryTurn(defined(capturedMessage, "message"), "turn_timeout", {
+      status: "error",
+      terminal: true,
+    });
+
+    expect(ackEntry).not.toHaveBeenCalled();
+    expect(events).toContainEqual({
+      chatId: "chat-timeout",
+      event: { kind: "turn_end", payload: { status: "error" } },
+    });
+    expect(sm.getSessionRuntimeStates()).toEqual([{ chatId: "chat-timeout", runtimeState: "error" }]);
+
+    await sm.shutdown();
+  });
+
+  it("reports abandoned success turns as success while leaving recovery unacked", async () => {
+    const ackEntry = mockAckEntry();
+    const events: Array<{ chatId: string; event: SessionEvent }> = [];
+    let capturedCtx: SessionContext | undefined;
+    let capturedMessage: SessionMessage | undefined;
+    const handler = createMockHandler({
+      async start(msg, ctx) {
+        capturedMessage = msg;
+        capturedCtx = ctx;
+        return "session-1";
+      },
+    });
+    const sm = createSessionManager({
+      handler,
+      ackEntry,
+      onSessionEvent: (chatId, event) => events.push({ chatId, event }),
+    });
+
+    await sm.dispatch(mockEntry({ id: 3, chatId: "chat-abort" }));
+    defined(capturedCtx, "ctx").retryTurn(defined(capturedMessage, "message"), "turn_aborted", {
+      status: "success",
+    });
+
+    expect(ackEntry).not.toHaveBeenCalled();
+    expect(events).toContainEqual({
+      chatId: "chat-abort",
+      event: { kind: "turn_end", payload: { status: "success" } },
+    });
+    expect(sm.getSessionRuntimeStates()).toEqual([{ chatId: "chat-abort", runtimeState: "working" }]);
 
     await sm.shutdown();
   });

--- a/packages/client/src/__tests__/session-state-notifications.test.ts
+++ b/packages/client/src/__tests__/session-state-notifications.test.ts
@@ -189,30 +189,27 @@ describe("SessionManager: state notifications", () => {
 describe("SessionManager: state-before-runtime ordering (codex review P2)", () => {
   // The server's `setSessionRuntime` is active-gated — if `session:state
   // active` hasn't landed yet, any `session:runtime` for the same
-  // (agent, chat) is dropped. Handlers (codex especially) emit
-  // `setRuntimeState("working")` synchronously from inside handler.start(),
-  // and codex's start() awaits the WHOLE turn before returning. If
+  // (agent, chat) is dropped. SessionManager now computes runtime from
+  // delivery facts before invoking handler.start(), and codex's start()
+  // awaits the WHOLE turn before returning. If
   // SessionManager fired the `active` notification only AFTER start()
   // returned, the working frame would arrive at the server before the
   // active row existed and the composite would stay `ready`. This test
   // pins the fixed order: the `active` notification fires before the
-  // handler returns (so before any setRuntimeState the handler does).
+  // handler returns.
   it("emits onStateChange('active') BEFORE handler.start (so handler runtime reports land on an active row)", async () => {
     const emissions: Array<{ kind: "state" | "runtime"; value: string }> = [];
     let observedActiveBeforeHandlerCompletion = false;
 
     const handler = createMockHandler({
-      // Codex-style handler: awaits the entire turn. Synchronously reports
-      // working at the top, then idle on the way out, all before start()
-      // returns. The pre-fix SessionManager would have queued both frames
-      // ahead of the `active` notification.
-      start: vi.fn(async (_msg, ctx: SessionContext) => {
+      // Codex-style handler: awaits the entire turn before start() returns.
+      start: vi.fn(async (msg, ctx: SessionContext) => {
         // Snapshot the state emissions seen so far — if the `active`
         // notification fired before invoking start, it must already be in
         // `emissions`.
         observedActiveBeforeHandlerCompletion = emissions.some((e) => e.kind === "state" && e.value === "active");
-        ctx.setRuntimeState("working");
-        ctx.setRuntimeState("idle");
+        ctx.markMessagesConsumed(msg);
+        await ctx.finishTurn(msg, { status: "success" });
         return "session-id-mock";
       }),
     });

--- a/packages/client/src/__tests__/test-helpers.ts
+++ b/packages/client/src/__tests__/test-helpers.ts
@@ -22,10 +22,13 @@ export function mockCtxPlumbing(
   chatId: string,
 ): {
   forwardResult: (text: string) => Promise<void>;
-  markCompleted: () => void;
+  recordProviderActivity: () => void;
   markMessagesConsumed: (messages: SessionMessage | readonly SessionMessage[]) => void;
-  markMessagesCompleted: (messages: SessionMessage | readonly SessionMessage[]) => void;
-  markMessagesRetryable: (messages: SessionMessage | readonly SessionMessage[], reason: string) => void;
+  finishTurn: (
+    messages: SessionMessage | readonly SessionMessage[],
+    outcome: { status: "success" | "error"; terminal?: boolean },
+  ) => Promise<void>;
+  retryTurn: (messages: SessionMessage | readonly SessionMessage[], reason: string) => void;
   buildAgentEnv: (env: NodeJS.ProcessEnv) => NodeJS.ProcessEnv;
   formatInboundContent: (msg: SessionMessage) => Promise<string>;
   resolveSenderLabel: (senderId: string) => Promise<string>;
@@ -35,10 +38,10 @@ export function mockCtxPlumbing(
       await sdk.sendMessage(chatId, { source: "api", format: "text", content: text });
     },
     // Default stub: tests that care about ack timing override via spies.
-    markCompleted: () => {},
+    recordProviderActivity: () => {},
     markMessagesConsumed: () => {},
-    markMessagesCompleted: () => {},
-    markMessagesRetryable: () => {},
+    finishTurn: async () => {},
+    retryTurn: () => {},
     buildAgentEnv: (env) => env,
     formatInboundContent: async (msg) => {
       const raw = typeof msg.content === "string" ? msg.content : JSON.stringify(msg.content);

--- a/packages/client/src/__tests__/tui-turn-disposition.test.ts
+++ b/packages/client/src/__tests__/tui-turn-disposition.test.ts
@@ -4,12 +4,12 @@ import { resolveTurnDisposition } from "../handlers/claude-code-tui/turn-disposi
 const CLEAN = { aborted: false, timedOut: false, turnFailed: false, forwardFailed: false };
 
 describe("resolveTurnDisposition", () => {
-  it("a clean turn reports success, acks, forwards, and goes idle", () => {
+  it("a clean turn reports success, acks, forwards, and has no terminal marker", () => {
     expect(resolveTurnDisposition(CLEAN)).toEqual({
       status: "success",
       ack: true,
       forward: true,
-      runtimeState: "idle",
+      terminalRuntimeError: false,
     });
   });
 
@@ -21,32 +21,32 @@ describe("resolveTurnDisposition", () => {
    * the no-ack decision — so the chat got a partial message while the entry
    * stayed un-acked and re-ran on reconnect, double-posting. A timeout must
    * report error, must NOT ack AND must NOT forward (so the redelivered retry
-   * is the single source of output), and must surface an error runtime state.
+   * is the single source of output), and must surface a terminal error marker.
    */
-  it("a timed-out turn reports error, does NOT ack, does NOT forward, and surfaces error state", () => {
+  it("a timed-out turn reports error, does NOT ack, does NOT forward, and surfaces terminal error", () => {
     expect(resolveTurnDisposition({ ...CLEAN, timedOut: true })).toEqual({
       status: "error",
       ack: false,
       forward: false,
-      runtimeState: "error",
+      terminalRuntimeError: true,
     });
   });
 
-  it("a body failure reports error, acks + forwards (clean close, avoid storm), and surfaces error state", () => {
+  it("a body failure reports error, acks + forwards (clean close, avoid storm), and surfaces terminal error", () => {
     expect(resolveTurnDisposition({ ...CLEAN, turnFailed: true })).toEqual({
       status: "error",
       ack: true,
       forward: true,
-      runtimeState: "error",
+      terminalRuntimeError: true,
     });
   });
 
-  it("a forward-only failure reports error and acks but keeps the session idle", () => {
+  it("a forward-only failure reports error and acks without a terminal marker", () => {
     expect(resolveTurnDisposition({ ...CLEAN, forwardFailed: true })).toEqual({
       status: "error",
       ack: true,
       forward: true,
-      runtimeState: "idle",
+      terminalRuntimeError: false,
     });
   });
 
@@ -55,7 +55,7 @@ describe("resolveTurnDisposition", () => {
       status: "success",
       ack: false,
       forward: false,
-      runtimeState: "idle",
+      terminalRuntimeError: false,
     });
   });
 
@@ -64,7 +64,7 @@ describe("resolveTurnDisposition", () => {
       status: "error",
       ack: false,
       forward: false,
-      runtimeState: "error",
+      terminalRuntimeError: true,
     });
   });
 

--- a/packages/client/src/handlers/claude-code-tui/index.ts
+++ b/packages/client/src/handlers/claude-code-tui/index.ts
@@ -2,21 +2,13 @@ import { randomUUID } from "node:crypto";
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { type AgentRuntimeConfigPayload, DEFAULT_CLAUDE_CODE_TUI_RUNTIME_CONFIG_PAYLOAD } from "@first-tree/shared";
-import { ensureAgentBootstrap } from "../../runtime/agent-bootstrap.js";
-import { buildAgentBriefing } from "../../runtime/agent-briefing.js";
 import type { AgentConfigCache } from "../../runtime/agent-config-cache.js";
-import type { PredeclaredSourceRepo } from "../../runtime/bootstrap.js";
-import { type ChatContext, fetchChatContext } from "../../runtime/chat-context.js";
 import type { GitMirrorManager } from "../../runtime/git-mirror-manager.js";
 import type { AgentHandler, HandlerFactory, SessionContext, SessionMessage } from "../../runtime/handler.js";
-import {
-  currentSourceRepoNamesFromPayload,
-  prepareSourceRepos,
-  releaseSourceReposForSession,
-} from "../../runtime/source-repos.js";
-import { acquireAgentHome, markWorkspaceInitComplete } from "../../runtime/workspace.js";
+import { releaseSourceReposForSession } from "../../runtime/source-repos.js";
 import { createToolCallProcessor, mapMcpServers } from "../claude-code.js";
 import { resolveClaudeCodeExecutable } from "../claude-executable.js";
+import { prepareProviderBootstrap } from "../provider-bootstrap.js";
 import {
   capturePane,
   deriveSessionName,
@@ -110,54 +102,6 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
   let configTempDir: string | null = null;
   const queuedMessages: SessionMessage[] = [];
   const ownedWorktrees: Worktree[] = [];
-  // Per-chat state captured at session start — feeds the unified briefing
-  // (AGENTS.md / CLAUDE.md symlink) that claude reads at startup via
-  // `--setting-sources user,project`. The TUI handler can't update the
-  // briefing mid-thread (claude is a persistent process holding the file
-  // contents in memory), so we snapshot once per startClaude().
-  let chatContextForPrompt: ChatContext | undefined;
-  let sourceReposForPrompt: PredeclaredSourceRepo[] = [];
-
-  function buildEnv(sessionCtx: SessionContext, payload: AgentRuntimeConfigPayload): Record<string, string> {
-    const env: Record<string, string> = {};
-    for (const [k, v] of Object.entries(process.env)) {
-      if (typeof v === "string") env[k] = v;
-    }
-    for (const e of payload.env) env[e.key] = e.value;
-    const merged = sessionCtx.buildAgentEnv(env);
-    const out: Record<string, string> = {};
-    for (const [k, v] of Object.entries(merged)) {
-      if (typeof v === "string") out[k] = v;
-    }
-    return out;
-  }
-
-  /**
-   * Build the unified briefing for the current session — agent identity,
-   * payload.prompt.append, source-repo list, chat context, and the Context
-   * Tree / runtime sections. Materialised by {@link ensureAgentBootstrap} as
-   * `<cwd>/AGENTS.md` (with `<cwd>/CLAUDE.md` symlinked to it) before claude
-   * spawns; the CLI then loads CLAUDE.md via `--setting-sources user,project`.
-   */
-  function buildBriefing(sessionCtx: SessionContext, payload: AgentRuntimeConfigPayload, workspaceCwd: string): string {
-    return buildAgentBriefing({
-      identity: sessionCtx.agent,
-      payload,
-      chatContext: chatContextForPrompt,
-      workspacePath: workspaceCwd,
-      sourceRepos: sourceReposForPrompt,
-      contextTreePath,
-    });
-  }
-
-  async function fetchChatContextOrLog(sessionCtx: SessionContext): Promise<ChatContext | undefined> {
-    try {
-      return await fetchChatContext(sessionCtx.sdk, sessionCtx.chatId, sessionCtx.agent);
-    } catch (err) {
-      sessionCtx.log(`fetchChatContext failed: ${err instanceof Error ? err.message : String(err)}`);
-      return undefined;
-    }
-  }
 
   function ensureConfigTempDir(workspaceCwd: string, sessionId: string): string {
     const dir = join(workspaceCwd, ".claude-code-tui", sessionId);
@@ -214,19 +158,14 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
     return args.join(" ");
   }
 
-  async function loadPayload(sessionCtx: SessionContext): Promise<AgentRuntimeConfigPayload | null> {
-    if (!agentConfigCache) return null;
-    const cached = agentConfigCache.get(sessionCtx.agent.agentId);
-    if (cached) return cached.payload;
-    const refreshed = await agentConfigCache.refresh(sessionCtx.agent.agentId);
-    return refreshed.payload;
-  }
-
-  async function startClaude(input: { sessionCtx: SessionContext; resumeSessionId: string | null }): Promise<string> {
-    const { sessionCtx, resumeSessionId } = input;
+  async function startClaude(input: {
+    sessionCtx: SessionContext;
+    resumeSessionId: string | null;
+    payload: AgentRuntimeConfigPayload;
+    env: Record<string, string>;
+  }): Promise<string> {
+    const { sessionCtx, resumeSessionId, payload, env } = input;
     if (!cwd) throw new Error("startClaude called before cwd was acquired");
-
-    const payload = (await loadPayload(sessionCtx)) ?? defaultPayload();
 
     const sessionId = resumeSessionId ?? randomUUID();
     const sessionName = deriveSessionName(clientId, sessionCtx.agent.agentId, sessionCtx.chatId);
@@ -246,7 +185,7 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
       name: sessionName,
       cwd,
       command,
-      env: buildEnv(sessionCtx, payload),
+      env,
     });
     // Track the session name immediately so a waitForReady failure still has a
     // teardown path — otherwise the detached tmux session (and its claude
@@ -537,45 +476,22 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
       try {
         await orphanSweep(clientId);
         ctx = sessionCtx;
-        cwd = acquireAgentHome(workspaceRoot);
-
-        const resolvedPayload = await loadPayload(sessionCtx);
-        const payload = resolvedPayload ?? defaultPayload();
-
-        // Per-chat material flows through the unified briefing
-        // (`<cwd>/AGENTS.md`, with `<cwd>/CLAUDE.md` symlinked to it). Resolve
-        // chat-context and source repos BEFORE bootstrap so the briefing the
-        // shared `ensureAgentBootstrap` materialises is fully populated; claude
-        // then reads CLAUDE.md once on spawn via `--setting-sources project`.
-        chatContextForPrompt = await fetchChatContextOrLog(sessionCtx);
-        sourceReposForPrompt = await prepareSourceRepos({
-          workspace: cwd,
-          payload,
-          sessionCtx,
-          gitMirrorManager,
-          agentName,
-          // `payloadResolved: false` when we fell back to `defaultPayload()` —
-          // the empty `gitRepos: []` is then NOT authoritative and state-based
-          // cleanup is suppressed for this session (see PR #869 P0-2).
-          payloadResolved: resolvedPayload !== null && resolvedPayload !== undefined,
-        });
-        ensureAgentBootstrap({
-          workspace: cwd,
+        const bootstrap = await prepareProviderBootstrap({
+          workspaceRoot,
           sessionCtx,
           contextTreePath,
-          briefing: buildBriefing(sessionCtx, payload, cwd),
-          // Forward the authoritative current source-repo set to migrations
-          // (PR #869 baixiaohang round-3 P0). Same `payloadResolved` signal as
-          // above — null when defaultPayload was used, so v1-orphan-ft-clones
-          // defers until a future resolved start.
-          currentSourceRepoNames: currentSourceRepoNamesFromPayload(
-            payload,
-            resolvedPayload !== null && resolvedPayload !== undefined,
-          ),
+          agentConfigCache,
+          gitMirrorManager,
+          agentName,
+          payloadStrategy: "cached-or-refresh",
+          defaultPayload,
+          envOptions: { trimUndefined: true },
         });
-        markWorkspaceInitComplete(cwd);
+        cwd = bootstrap.cwd;
+        const payload = bootstrap.payload;
+        const env = bootstrap.env as Record<string, string>;
 
-        const sessionId = await startClaude({ sessionCtx, resumeSessionId: null });
+        const sessionId = await startClaude({ sessionCtx, resumeSessionId: null, payload, env });
 
         const inputText = await sessionCtx.formatInboundContent(message);
         currentTurnPromise = runTurn(inputText, sessionCtx, [message]);
@@ -597,38 +513,22 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
       try {
         await orphanSweep(clientId);
         ctx = sessionCtx;
-        cwd = acquireAgentHome(workspaceRoot);
-
-        const resumePayloadResolved = await loadPayload(sessionCtx);
-        const payload = resumePayloadResolved ?? defaultPayload();
-
-        chatContextForPrompt = await fetchChatContextOrLog(sessionCtx);
-        sourceReposForPrompt = await prepareSourceRepos({
-          workspace: cwd,
-          payload,
-          sessionCtx,
-          gitMirrorManager,
-          agentName,
-          // See PR #869 P0-2: same gate as the start() path.
-          payloadResolved: resumePayloadResolved !== null && resumePayloadResolved !== undefined,
-        });
-        // Same shared bootstrap as start(): ensureAgentBootstrap handles the
-        // sentinel + Context-Tree/CLI drift internally, so a stale or failed
-        // integration is re-run on resume instead of being skipped.
-        ensureAgentBootstrap({
-          workspace: cwd,
+        const bootstrap = await prepareProviderBootstrap({
+          workspaceRoot,
           sessionCtx,
           contextTreePath,
-          briefing: buildBriefing(sessionCtx, payload, cwd),
-          // See PR #869 baixiaohang round-3 P0 — same gate as start().
-          currentSourceRepoNames: currentSourceRepoNamesFromPayload(
-            payload,
-            resumePayloadResolved !== null && resumePayloadResolved !== undefined,
-          ),
+          agentConfigCache,
+          gitMirrorManager,
+          agentName,
+          payloadStrategy: "cached-or-refresh",
+          defaultPayload,
+          envOptions: { trimUndefined: true },
         });
-        markWorkspaceInitComplete(cwd);
+        cwd = bootstrap.cwd;
+        const payload = bootstrap.payload;
+        const env = bootstrap.env as Record<string, string>;
 
-        await startClaude({ sessionCtx, resumeSessionId: sessionId });
+        await startClaude({ sessionCtx, resumeSessionId: sessionId, payload, env });
 
         if (message) {
           const inputText = await sessionCtx.formatInboundContent(message);

--- a/packages/client/src/handlers/claude-code-tui/index.ts
+++ b/packages/client/src/handlers/claude-code-tui/index.ts
@@ -326,7 +326,7 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
       throw new Error("runTurn called before session was prepared");
     }
     sessionCtx.markMessagesConsumed(messages);
-    sessionCtx.setRuntimeState("working");
+    sessionCtx.recordProviderActivity();
     turnAborted = false;
 
     const state: TurnState = { finalTexts: [] };
@@ -341,12 +341,12 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
       transcriptTailer.drainEntries();
 
       await pasteText(tmuxSessionName, text);
-      sessionCtx.touch();
+      sessionCtx.recordProviderActivity();
 
       const startTs = Date.now();
       while (Date.now() - startTs < TURN_TIMEOUT_MS) {
         if (turnAborted) break;
-        sessionCtx.touch();
+        sessionCtx.recordProviderActivity();
 
         await drainAndConsume(sessionCtx, state);
 
@@ -443,14 +443,15 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
     // ackTurnClose, avoiding redelivery storms); an abort or a timeout
     // withholds the ack so the message gets a real retry.
     const disposition = resolveTurnDisposition({ aborted: turnAborted, timedOut, turnFailed, forwardFailed });
-    sessionCtx.emitEvent({ kind: "turn_end", payload: { status: disposition.status } });
     if (disposition.ack) {
-      sessionCtx.markMessagesCompleted(messages);
+      await sessionCtx.finishTurn(messages, {
+        status: disposition.status,
+        terminal: disposition.terminalRuntimeError,
+      });
     } else {
       const reason = timedOut ? "turn_timeout" : turnAborted ? "turn_aborted" : "turn_retryable";
-      sessionCtx.markMessagesRetryable(messages, reason);
+      sessionCtx.retryTurn(messages, reason);
     }
-    sessionCtx.setRuntimeState(disposition.runtimeState);
     resetProcessor();
   }
 
@@ -478,7 +479,7 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
         }
       }
       if (inputs.length === 0) {
-        sessionCtx.markMessagesCompleted(drained);
+        await sessionCtx.finishTurn(drained, { status: "error", terminal: true });
         return;
       }
       await runTurn(inputs.join("\n\n"), sessionCtx, drained);
@@ -627,7 +628,7 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
         });
         markWorkspaceInitComplete(cwd);
 
-        const restartedId = await startClaude({ sessionCtx, resumeSessionId: sessionId });
+        await startClaude({ sessionCtx, resumeSessionId: sessionId });
 
         if (message) {
           const inputText = await sessionCtx.formatInboundContent(message);
@@ -638,7 +639,7 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
             currentTurnPromise = null;
           }
         }
-        return restartedId;
+        return sessionId;
       } finally {
         turnRunning = false;
         setImmediate(pump);

--- a/packages/client/src/handlers/claude-code-tui/index.ts
+++ b/packages/client/src/handlers/claude-code-tui/index.ts
@@ -389,7 +389,10 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
       });
     } else {
       const reason = timedOut ? "turn_timeout" : turnAborted ? "turn_aborted" : "turn_retryable";
-      sessionCtx.retryTurn(messages, reason);
+      sessionCtx.retryTurn(messages, reason, {
+        status: disposition.status,
+        terminal: disposition.terminalRuntimeError,
+      });
     }
     resetProcessor();
   }

--- a/packages/client/src/handlers/claude-code-tui/turn-disposition.ts
+++ b/packages/client/src/handlers/claude-code-tui/turn-disposition.ts
@@ -22,7 +22,7 @@ export type TurnDisposition = {
   /** Status reported on the `turn_end` event. */
   status: "success" | "error";
   /**
-   * Whether to `markCompleted` (ack the triggering inbox entries). The runtime
+   * Whether to `finishTurn` (ack the triggering inbox entries). The runtime
    * never auto-acks on turn_end, so a false here leaves the entries in-flight
    * for at-least-once redelivery.
    */
@@ -34,8 +34,8 @@ export type TurnDisposition = {
    * double-posts once the replay produces the real answer.
    */
   forward: boolean;
-  /** Runtime state to settle into after the turn. */
-  runtimeState: "idle" | "error";
+  /** Whether SessionManager should retain a fatal runtime error marker. */
+  terminalRuntimeError: boolean;
 };
 
 /**
@@ -69,7 +69,7 @@ export function resolveTurnDisposition(outcome: TurnOutcome): TurnDisposition {
     ack: consume,
     forward: consume,
     // A broken (turnFailed) or interrupted (timedOut) session is advertised as
-    // error; a forward-only failure leaves the session healthy, so it stays idle.
-    runtimeState: turnFailed || timedOut ? "error" : "idle",
+    // error; a forward-only failure leaves the session healthy.
+    terminalRuntimeError: turnFailed || timedOut,
   };
 }

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -17,7 +17,6 @@ import {
   isImageRefContent,
   SUPPORTED_IMAGE_MIMES as SHARED_SUPPORTED_IMAGE_MIMES,
 } from "@first-tree/shared";
-import { ensureAgentBootstrap as ensureAgentBootstrapShared } from "../runtime/agent-bootstrap.js";
 import { buildAgentBriefing } from "../runtime/agent-briefing.js";
 import type { AgentConfigCache } from "../runtime/agent-config-cache.js";
 import { type PredeclaredSourceRepo, writeAgentBriefing } from "../runtime/bootstrap.js";
@@ -29,15 +28,10 @@ import type { AgentHandler, HandlerFactory, SessionContext, SessionMessage } fro
 import { ResumeUnavailableError } from "../runtime/handler.js";
 import { findImagePath } from "../runtime/image-store.js";
 import { InputController } from "../runtime/input-controller.js";
-import { materializeResourceSkills } from "../runtime/resource-skills.js";
-import {
-  currentSourceRepoNamesFromPayload,
-  prepareSourceRepos as prepareSourceReposShared,
-  releaseSourceReposForSession,
-} from "../runtime/source-repos.js";
-import { acquireAgentHome, markWorkspaceInitComplete } from "../runtime/workspace.js";
+import { releaseSourceReposForSession } from "../runtime/source-repos.js";
 import { formatAuthHint, isClaudeAuthError } from "./auth-error-hint.js";
 import { resolveClaudeCodeExecutable } from "./claude-executable.js";
+import { buildProviderEnv, prepareProviderBootstrap } from "./provider-bootstrap.js";
 
 const MAX_RETRIES = 2;
 
@@ -795,28 +789,8 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
    * `ctx.buildAgentEnv` so all handlers expose the same vars uniformly.
    */
   function buildEnv(sessionCtx: SessionContext): Record<string, string | undefined> {
-    const env: Record<string, string | undefined> = { ...process.env };
-
-    // Parent session markers — not needed by the child
-    delete env.CLAUDECODE;
-    delete env.CLAUDE_CODE_ENTRYPOINT;
-    delete env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS;
-    delete env.npm_lifecycle_script;
-
-    // Step 6: layer in user-configured env (sensitive already decrypted at
-    // service level; see config-service.getDecrypted()). User vars come
-    // BEFORE First Tree-internal vars so the latter wins on collision.
     const payload = agentConfigCache?.get(sessionCtx.agent.agentId)?.payload;
-    if (payload) {
-      for (const e of payload.env) env[e.key] = e.value;
-    }
-
-    // Child processes receive the member access JWT as FIRST_TREE_ACCESS_TOKEN
-    // and pair it with X-Agent-Id (sent by the SDK automatically) to act as
-    // the current agent. Obtaining the token at buildEnv-time means the child
-    // sees the JWT valid at its spawn moment; long-lived runtimes should
-    // re-spawn after refresh, or re-read the env on their own cadence.
-    return sessionCtx.buildAgentEnv(env);
+    return buildProviderEnv(sessionCtx, payload, { stripClaudeCodeParentEnv: true });
   }
 
   /** Create query and input controller, then start consumer loop. */
@@ -1365,55 +1339,6 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
   // instead of churning a new id per chat.
   const agentName = (config.agentName as string | undefined) ?? null;
 
-  /**
-   * Materialise the runtime config's `gitRepos` as **predeclared source
-   * repos** at the **top level** of the agent home (`<cwd>/<localPath>/`),
-   * NOT under `<cwd>/worktrees/`. Per the 2026-05-22 redesign, the
-   * `worktrees/` subdirectory is reserved entirely for agent-on-demand
-   * worktrees the LLM creates per task — the runtime never pre-creates any.
-   *
-   * Idempotent across sessions: with the per-agent-home model the checkout
-   * is **shared** across every chat for this agent. First call clones the
-   * repo as a standalone clone; subsequent calls fetch and — when the
-   * checkout is clean and not in use by another live session — bring it to
-   * the latest default branch. A dirty or in-use checkout is left at its
-   * current commit, so pending state the LLM left behind survives.
-   *
-   * Concurrency: the manager serialises per clone path so two sessions
-   * starting at the same time don't race a clone / update for the same path.
-   * See proposals/agent-session-cwd-redesign.20260519.md §⑧ R1.
-   *
-   * Side effect: refreshes `sourceReposForPrompt` so the unified briefing
-   * builder (`runtime/agent-briefing.ts` → `## Source Repositories`) can
-   * list absolute paths + upstream coordinates for the LLM.
-   *
-   * Fail-fast semantics per PRD D10/D13/D14: any failure aborts the session
-   * and the error bubbles up to the caller (SessionManager).
-   */
-  async function prepareSourceRepos(
-    workspace: string,
-    payload: AgentRuntimeConfigPayload | undefined,
-    sessionCtx: SessionContext,
-  ): Promise<void> {
-    // Delegates to the shared helper (runtime/source-repos.ts) so the SDK and
-    // TUI handlers share one worktree-lock / Hub-marker implementation rather
-    // than each carrying its own source-repo invariant.
-    //
-    // `payloadResolved` distinguishes "agent config truly says zero repos"
-    // from "we couldn't reach the cache/server and `payload` is undefined".
-    // Without this gate, a cache miss would compute an empty current-repo
-    // set and the state-reconcile path would `rm` every previously-managed
-    // clone. See `PrepareSourceReposParams.payloadResolved`.
-    sourceReposForPrompt = await prepareSourceReposShared({
-      workspace,
-      payload,
-      sessionCtx,
-      gitMirrorManager,
-      agentName,
-      payloadResolved: payload !== undefined,
-    });
-  }
-
   /** Tear down all worktrees this session owns; best-effort. */
   async function cleanupGitWorktrees(sessionCtx: SessionContext): Promise<void> {
     // Drop this session's live-use references on shared source-repo checkouts so
@@ -1506,76 +1431,23 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
     });
   }
 
-  /**
-   * Run the expensive first-time bootstrap (full stable layout + `first-tree
-   * tree skill install` shell-out). Gated by the stage-2 sentinel + Context-Tree
-   * HEAD drift detection (proposals/agent-session-cwd-redesign §⑤.3):
-   *
-   *   - Sentinel absent → full bootstrap.
-   *   - Sentinel present + Tree HEAD unchanged → cheap identity refresh only.
-   *   - Sentinel present + Tree HEAD drifted → full bootstrap re-runs so the
-   *     stable `.first-tree-workspace/` layout and first-tree skill pick up
-   *     the new tree state.
-   *
-   * The unified briefing is rewritten on every call regardless of the drift
-   * decision — chat context and the agent payload may have changed between
-   * sessions for the same agent home.
-   *
-   * `workspaceId` for the integrate shell-out is the agent name — the home
-   * directory is per-agent, so the skill identity stays stable across chats.
-   */
-  function ensureAgentBootstrap(
-    workspace: string,
-    sessionCtx: SessionContext,
-    briefing: string,
-    payload: AgentRuntimeConfigPayload | undefined,
-  ): void {
-    // Delegates to the shared helper (runtime/agent-bootstrap.ts) so the SDK
-    // and TUI handlers share one briefing / core-skill / drift-pin contract
-    // rather than each maintaining a partial copy.
-    //
-    // `currentSourceRepoNames` is threaded through to the migration applier
-    // so `v1-orphan-ft-clones` can defer when the live config is unresolved
-    // (cache miss). See PR #869 baixiaohang round-3 P0.
-    ensureAgentBootstrapShared({
-      workspace,
-      sessionCtx,
-      contextTreePath,
-      briefing,
-      currentSourceRepoNames: currentSourceRepoNamesFromPayload(payload, payload !== undefined),
-    });
-  }
-
   const handler: AgentHandler = {
     async start(message, sessionCtx) {
       ctx = sessionCtx;
       claudeSessionId = randomUUID();
-      // Per agent-session-cwd-redesign: cwd is per-agent, shared by every
-      // chat session. acquireAgentHome creates the directory and writes the
-      // boundary marker on first call; afterwards it is a no-op.
-      cwd = acquireAgentHome(workspaceRoot);
-
-      // Resolve the per-chat inputs that drive the unified briefing BEFORE
-      // bootstrap: the briefing is the single channel that materialises agent
-      // identity, payload.prompt.append, source-repo list, and Current Chat
-      // Context for the Claude Code SDK (read via `settingSources:
-      // ["project"]` from CLAUDE.md → AGENTS.md). Bootstrap must therefore
-      // see fully-resolved inputs.
-      const payload = agentConfigCache?.get(sessionCtx.agent.agentId)?.payload;
-      const chatContext = await fetchChatContextOrLog(sessionCtx);
-      chatContextForPrompt = chatContext;
-      // Materialise gitRepos under `<cwd>/<localPath>/` before computing the
-      // briefing so the source-repo list reflects what the agent will see on
-      // disk. Failures here abort session creation (D10/D13).
-      await prepareSourceRepos(cwd, payload, sessionCtx);
-      await materializeResourceSkills(cwd, payload, sessionCtx);
-
-      const briefing = currentBriefing(sessionCtx, cwd, payload);
-      ensureAgentBootstrap(cwd, sessionCtx, briefing, payload);
-
-      // Stage-2 sentinel: written once per agent home. Future starts short-
-      // circuit the expensive integrate path on its presence.
-      markWorkspaceInitComplete(cwd);
+      const bootstrap = await prepareProviderBootstrap({
+        workspaceRoot,
+        sessionCtx,
+        contextTreePath,
+        agentConfigCache,
+        gitMirrorManager,
+        agentName,
+        payloadStrategy: "cached",
+        envOptions: { stripClaudeCodeParentEnv: true },
+      });
+      cwd = bootstrap.cwd;
+      chatContextForPrompt = bootstrap.chatContext;
+      sourceReposForPrompt = bootstrap.sourceRepos;
 
       sessionCtx.log(
         `Starting session (${claudeSessionId}), cwd=${cwd}, permissionMode=${config.permissionMode ?? "bypassPermissions"}`,
@@ -1661,22 +1533,19 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       }
 
       // Normal new-design resume path: cwd is the agent home.
-      cwd = acquireAgentHome(workspaceRoot);
-
-      // Identical control flow to start(): bootstrap is idempotent and the
-      // sentinel gates the expensive integrate. The cheap stable-identity
-      // hash check runs every time so agent rename / inboxId changes
-      // propagate even after the sentinel is set (R5 in the proposal).
-      const payload = agentConfigCache?.get(sessionCtx.agent.agentId)?.payload;
-      const chatContext = await fetchChatContextOrLog(sessionCtx);
-      chatContextForPrompt = chatContext;
-      await prepareSourceRepos(cwd, payload, sessionCtx);
-      await materializeResourceSkills(cwd, payload, sessionCtx);
-
-      const briefing = currentBriefing(sessionCtx, cwd, payload);
-      ensureAgentBootstrap(cwd, sessionCtx, briefing, payload);
-
-      markWorkspaceInitComplete(cwd);
+      const bootstrap = await prepareProviderBootstrap({
+        workspaceRoot,
+        sessionCtx,
+        contextTreePath,
+        agentConfigCache,
+        gitMirrorManager,
+        agentName,
+        payloadStrategy: "cached",
+        envOptions: { stripClaudeCodeParentEnv: true },
+      });
+      cwd = bootstrap.cwd;
+      chatContextForPrompt = bootstrap.chatContext;
+      sourceReposForPrompt = bootstrap.sourceRepos;
 
       // Defensive fallback: sessionId isn't recognised at EITHER cwd (likely
       // a stale registry entry from machine swap / fs cleanup / tampering).

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -26,6 +26,7 @@ import { toolFileRefsFromShellCommand } from "../runtime/context-tree-file-refs.
 import { classify } from "../runtime/error-taxonomy.js";
 import type { GitMirrorManager } from "../runtime/git-mirror-manager.js";
 import type { AgentHandler, HandlerFactory, SessionContext, SessionMessage } from "../runtime/handler.js";
+import { ResumeUnavailableError } from "../runtime/handler.js";
 import { findImagePath } from "../runtime/image-store.js";
 import { InputController } from "../runtime/input-controller.js";
 import { materializeResourceSkills } from "../runtime/resource-skills.js";
@@ -637,7 +638,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
    * the next turn). We stash the already-converted SDK form (rather
    * than the raw `SessionMessage`) so the retry path stays synchronous
    * and timing-compatible with the existing consumer-loop catch block.
-   * Cleared once `ackTurnClose()` acks the entry — turn fully processed,
+   * Cleared once `finishTurnClose()` finishes the entry — turn fully processed,
    * no further replay needed.
    *
    * Invariant — single-consumer loop: this stash is safe ONLY because
@@ -831,23 +832,22 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
   }
 
   /**
-   * Single helper for "turn closed → ack the pending inbox message AND
+   * Single helper for "turn closed → finish the pending inbox message AND
    * drop the replay stash". The two operations are paired everywhere a
    * turn finishes (success / sniff-permanent / forward-error / no-result /
    * non-success subtype / MAX_RETRIES / respawn-fail) — folding them into
    * one call keeps the invariant "stash lives only as long as the turn
    * still might need a replay" enforced in one place. Use the raw
-   * `markMessagesCompleted(message)` directly for per-message terminal
+   * `finishTurn(message, outcome)` directly for per-message terminal
    * failures (e.g. inject's `toSDKUserMessage` catch) where the semantics is
    * "commit this single inbox message, NOT close the active SDK turn".
    */
-  function ackTurnClose(sessionCtx: SessionContext): void {
+  async function finishTurnClose(
+    sessionCtx: SessionContext,
+    outcome: { status: "success" | "error"; terminal?: boolean },
+  ): Promise<void> {
     const message = pendingAckMessages.shift();
-    if (message) {
-      sessionCtx.markMessagesCompleted(message);
-    } else {
-      sessionCtx.markCompleted();
-    }
+    await sessionCtx.finishTurn(message ? [message] : [], outcome);
     markCurrentPendingMessageConsumed(sessionCtx);
     stashedSdkMessage = null;
   }
@@ -886,7 +886,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       // entry with an SDK result. Ack here — re-handling on
       // redelivery would re-hit the same conversion error
       // (permanent failure semantics, design §4).
-      sessionCtx.markMessagesCompleted(message);
+      await sessionCtx.finishTurn(message, { status: "error", terminal: true });
     }
   }
 
@@ -1094,11 +1094,11 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
         if (!currentQuery) return;
 
         try {
-          sessionCtx.setRuntimeState("working");
+          sessionCtx.recordProviderActivity();
 
           for await (const message of currentQuery) {
             // Every message refreshes lastActivity to prevent idle timeout
-            sessionCtx.touch();
+            sessionCtx.recordProviderActivity();
 
             toolCallProcessor.onMessage(message);
 
@@ -1172,11 +1172,10 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
                         message: `Claude API error (${classification.reasonCode}): ${sniff.message}`,
                       },
                     });
-                    sessionCtx.emitEvent({ kind: "turn_end", payload: { status: "error" } });
                     // Permanent stream API failure — ack so the server
                     // doesn't redeliver a message that would just produce
                     // the same error. Retry was exhausted upstream.
-                    ackTurnClose(sessionCtx);
+                    await finishTurnClose(sessionCtx, { status: "error" });
                   } else {
                     // Genuine success — reset retry budget for the next turn.
                     // Do NOT reset on the sniff-hit branches above: a wrapped
@@ -1191,9 +1190,8 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
                       // handler shares one code path — see runtime/result-sink.ts.
                       await sessionCtx.forwardResult(resultText);
                       sessionCtx.log("Result forwarded to chat");
-                      sessionCtx.emitEvent({ kind: "turn_end", payload: { status: "success" } });
                       // Turn closed cleanly — drain in-flight inbox entries.
-                      ackTurnClose(sessionCtx);
+                      await finishTurnClose(sessionCtx, { status: "success" });
                     } catch (err) {
                       const reason = err instanceof Error ? err.message : String(err);
                       sessionCtx.log(`Failed to forward result: ${reason}`);
@@ -1203,7 +1201,6 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
                         kind: "error",
                         payload: { source: "runtime", message: forwardErrMessage },
                       });
-                      sessionCtx.emitEvent({ kind: "turn_end", payload: { status: "error" } });
                       // forwardResult failure is treated as terminal for
                       // this turn — ack so we don't loop on redelivery.
                       // Long-lived sdk.sendMessage failures are rare; if
@@ -1218,15 +1215,14 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
                       // counter when an unrelated future stream error
                       // fires.
                       retryCount = 0;
-                      ackTurnClose(sessionCtx);
+                      await finishTurnClose(sessionCtx, { status: "error" });
                     }
                   }
                 } else {
                   // No result text to forward (edge case) — still close the turn.
                   // Same reset rationale as the forward-success branch above.
                   retryCount = 0;
-                  sessionCtx.emitEvent({ kind: "turn_end", payload: { status: "success" } });
-                  ackTurnClose(sessionCtx);
+                  await finishTurnClose(sessionCtx, { status: "success" });
                 }
               } else {
                 const errors = message.errors ? message.errors.join("; ") : message.subtype;
@@ -1240,12 +1236,10 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
                 if (!authHintEmitted) {
                   sessionCtx.emitEvent({ kind: "error", payload: { source: "sdk", message: errors } });
                 }
-                sessionCtx.emitEvent({ kind: "turn_end", payload: { status: "error" } });
                 // SDK reported a turn-level error (non-success subtype):
                 // redelivery would just hit the same error — ack.
-                ackTurnClose(sessionCtx);
+                await finishTurnClose(sessionCtx, { status: "error" });
               }
-              sessionCtx.setRuntimeState("idle");
               // Reset the auth-hint flag only on a SUCCESSFUL result. This
               // gives a clean slate for the next turn once auth is clearly
               // working, while suppressing a duplicate hint when the next
@@ -1257,7 +1251,6 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
               }
             }
           }
-          sessionCtx.setRuntimeState("idle");
           return;
         } catch (err) {
           // Process crash, OOM, or unexpected termination
@@ -1283,7 +1276,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
             // would just go quiet.
             //
             // Wrap the emits so a broken `onSessionEvent` callback can't
-            // short-circuit the `setRuntimeState("error")` call below —
+            // short-circuit the terminal `finishTurn` call below —
             // if that one is skipped the SessionManager keeps the slot
             // counted as `working` and never reclaims it.
             try {
@@ -1292,19 +1285,17 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
                 ? `Query failed after ${MAX_RETRIES} retries: ${preview}`
                 : `Query failed and no resume id available: ${preview}`;
               sessionCtx.emitEvent({ kind: "error", payload: { source: "runtime", message: reason } });
-              sessionCtx.emitEvent({ kind: "turn_end", payload: { status: "error" } });
             } catch (emitErr) {
               sessionCtx.log(
                 `Failed to emit retry-exhaustion error event: ${emitErr instanceof Error ? emitErr.message : String(emitErr)}`,
               );
             }
-            sessionCtx.setRuntimeState("error");
             // Ack the in-flight entry for this turn. Without this the row
             // stays `delivered` server-side forever: the in-process
             // Deduplicator collapses every bind-reset replay so the entry
             // never re-dispatches and never gets acked. Per design §4
             // "permanent → ack".
-            ackTurnClose(sessionCtx);
+            await finishTurnClose(sessionCtx, { status: "error", terminal: true });
             return;
           }
 
@@ -1337,27 +1328,23 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
           } catch (resumeErr) {
             const resumeMsg = resumeErr instanceof Error ? resumeErr.message : String(resumeErr);
             sessionCtx.log(`Auto-resume failed: ${resumeMsg}`);
-            // Mirror the MAX_RETRIES branch above: leaving runtimeState at
-            // `working` would block the SessionManager's idle-suspend grace
-            // window from ever firing on this session, so the slot would
-            // never be reclaimed. Wrap the emits defensively so the
-            // setRuntimeState call still runs if the callback throws.
+            // Mirror the MAX_RETRIES branch above: finish the turn with a
+            // terminal error marker so the SessionManager can reclaim/report
+            // the session even if event callbacks fail.
             try {
               sessionCtx.emitEvent({
                 kind: "error",
                 payload: { source: "runtime", message: `Auto-resume failed: ${resumeMsg.slice(0, 800)}` },
               });
-              sessionCtx.emitEvent({ kind: "turn_end", payload: { status: "error" } });
             } catch (emitErr) {
               sessionCtx.log(
                 `Failed to emit auto-resume error event: ${emitErr instanceof Error ? emitErr.message : String(emitErr)}`,
               );
             }
-            sessionCtx.setRuntimeState("error");
             // Same reasoning as the MAX_RETRIES branch above — without this
             // ack the row would loop in `delivered` forever, deduped on every
             // bind-reset replay. Per design §4 "permanent → ack".
-            ackTurnClose(sessionCtx);
+            await finishTurnClose(sessionCtx, { status: "error", terminal: true });
             return;
           }
         }
@@ -1693,28 +1680,14 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
 
       // Defensive fallback: sessionId isn't recognised at EITHER cwd (likely
       // a stale registry entry from machine swap / fs cleanup / tampering).
-      // Mint a fresh id and start cold — First Tree message history survives.
+      // Report typed resume-unavailable to SessionManager. The manager owns
+      // explicit provider session replacement; tree/CLI/bootstrap drift must
+      // not silently mint a fresh id inside handler.resume().
       if (!claudeSessionFileExists(cwd, sessionId)) {
-        const freshSessionId = randomUUID();
-        sessionCtx.log(
-          `Resume: SDK transcript for ${sessionId} not found at legacy (${legacyCwd}) ` +
-            `or agent home (${cwd}); starting fresh session ${freshSessionId} — ` +
-            "First Tree message history is preserved.",
+        throw new ResumeUnavailableError(
+          "transcript_missing",
+          `SDK transcript for ${sessionId} not found at legacy cwd (${legacyCwd}) or agent home (${cwd})`,
         );
-        claudeSessionId = freshSessionId;
-        let freshSdkMsg: SDKUserMessage | null = null;
-        if (message) {
-          freshSdkMsg = await toSDKUserMessage(message, sessionCtx, freshSessionId);
-          stashedSdkMessage = freshSdkMsg;
-        }
-        spawnQuery(freshSessionId, sessionCtx);
-        if (freshSdkMsg) {
-          inputController?.push(freshSdkMsg);
-          if (message) pushPendingAckMessage(message, sessionCtx);
-        }
-        scheduleInjectedMessagesDrain(sessionCtx, freshSessionId);
-        sessionCtx.log(`Session started (${freshSessionId}, replacing ${sessionId})`);
-        return freshSessionId;
       }
 
       sessionCtx.log(`Resuming session (${sessionId}), cwd=${cwd}`);

--- a/packages/client/src/handlers/codex.ts
+++ b/packages/client/src/handlers/codex.ts
@@ -6,11 +6,10 @@ import {
   type ToolFileRef,
 } from "@first-tree/shared";
 import { Codex, type Input, type Thread, type ThreadItem, type ThreadOptions, type Usage } from "@openai/codex-sdk";
-import { ensureAgentBootstrap as ensureAgentBootstrapShared } from "../runtime/agent-bootstrap.js";
 import { buildAgentBriefing } from "../runtime/agent-briefing.js";
 import type { AgentConfigCache } from "../runtime/agent-config-cache.js";
 import { FIRST_TREE_WORKSPACE_MARKER, type PredeclaredSourceRepo } from "../runtime/bootstrap.js";
-import { type ChatContext, fetchChatContext } from "../runtime/chat-context.js";
+import type { ChatContext } from "../runtime/chat-context.js";
 import { toolFileRefsFromShellCommand } from "../runtime/context-tree-file-refs.js";
 import { resolveGitRepoTargetPath } from "../runtime/git-local-path.js";
 import type { GitMirrorManager } from "../runtime/git-mirror-manager.js";
@@ -22,14 +21,9 @@ import type {
   SessionMessage,
 } from "../runtime/handler.js";
 import { ResumeUnavailableError } from "../runtime/handler.js";
-import { materializeResourceSkills } from "../runtime/resource-skills.js";
-import {
-  currentSourceRepoNamesFromPayload,
-  prepareSourceRepos as prepareSourceReposShared,
-  releaseSourceReposForSession,
-} from "../runtime/source-repos.js";
-import { acquireAgentHome, markWorkspaceInitComplete } from "../runtime/workspace.js";
+import { releaseSourceReposForSession } from "../runtime/source-repos.js";
 import { formatAuthHint, isCodexAuthError } from "./auth-error-hint.js";
+import { prepareProviderBootstrap } from "./provider-bootstrap.js";
 
 /**
  * Codex SDK does not export its `CodexConfigObject` type, so reproduce the
@@ -329,9 +323,8 @@ export function buildCodexThreadOptions(payload: AgentRuntimeConfigPayload, work
 }
 
 /**
- * Thin wrapper over the unified {@link buildAgentBriefing} kept for the
- * codex-bootstrap test suite. Production paths call `buildAgentBriefing`
- * directly via the inner `buildBriefing` helper inside the handler closure.
+ * Thin wrapper over the unified {@link buildAgentBriefing} kept for tests.
+ * Production start/resume paths call the shared ProviderBootstrap helper.
  */
 export function buildCodexAgentBriefing(
   identity: AgentIdentity,
@@ -471,33 +464,6 @@ export const createCodexHandler: HandlerFactory = (config) => {
   let drainInProgress = false;
   const queuedMessages: SessionMessage[] = [];
   const ownedWorktrees: Worktree[] = [];
-  /**
-   * Predeclared source repos materialised by `prepareSourceRepos`. Surfaced
-   * in the per-session AGENTS.md so the LLM knows the absolute paths.
-   */
-  let sourceReposForPrompt: PredeclaredSourceRepo[] = [];
-
-  function buildEnv(sessionCtx: SessionContext): Record<string, string> {
-    // Footgun F1: when `CodexOptions.env` is provided the SDK does NOT
-    // inherit `process.env`, so HOME/PATH/etc. would be missing. Start by
-    // explicitly cloning every defined parent var.
-    const env: Record<string, string> = {};
-    for (const [k, v] of Object.entries(process.env)) {
-      if (typeof v === "string") env[k] = v;
-    }
-    const payload = agentConfigCache?.get(sessionCtx.agent.agentId)?.payload;
-    if (payload) {
-      for (const e of payload.env) env[e.key] = e.value;
-    }
-    const merged = sessionCtx.buildAgentEnv(env);
-    // The First Tree envelope returns `Record<string, string | undefined>`; trim out
-    // undefined values so the SDK doesn't see them.
-    const out: Record<string, string> = {};
-    for (const [k, v] of Object.entries(merged)) {
-      if (typeof v === "string") out[k] = v;
-    }
-    return out;
-  }
 
   function buildCodexConfig(payload: AgentRuntimeConfigPayload): CodexConfigObject {
     const cfg: CodexConfigObject = {
@@ -523,62 +489,21 @@ export const createCodexHandler: HandlerFactory = (config) => {
     return cfg;
   }
 
-  function buildBriefing(
-    sessionCtx: SessionContext,
-    payload: AgentRuntimeConfigPayload,
-    chatContext: ChatContext | undefined,
-    workspaceCwd: string,
-  ): string {
-    return buildAgentBriefing({
-      identity: sessionCtx.agent,
-      payload,
-      chatContext,
-      workspacePath: workspaceCwd,
-      sourceRepos: sourceReposForPrompt,
-      contextTreePath,
-    });
-  }
-
-  /**
-   * Best-effort chat-context fetch for the identity-injection path. Failures
-   * are logged but never bubble — bootstrap continues with `undefined`.
-   */
-  async function fetchChatContextOrLog(sessionCtx: SessionContext): Promise<ChatContext | undefined> {
-    try {
-      return await fetchChatContext(sessionCtx.sdk, sessionCtx.chatId, sessionCtx.agent);
-    } catch (err) {
-      sessionCtx.log(`fetchChatContext failed: ${err instanceof Error ? err.message : String(err)}`);
-      return undefined;
-    }
+  function defaultCodexPayload(): AgentRuntimeConfigPayload {
+    return {
+      kind: "codex",
+      prompt: { append: "" },
+      model: "",
+      mcpServers: [],
+      env: [],
+      gitRepos: [],
+      resourceSkills: [],
+      reasoningEffort: "high",
+    };
   }
 
   function toCodexInput(message: SessionMessage, sessionCtx: SessionContext): Promise<Input> {
     return sessionCtx.formatInboundContent(message).then((text) => text);
-  }
-
-  async function prepareSourceRepos(
-    payload: AgentRuntimeConfigPayload,
-    workspaceCwd: string,
-    sessionCtx: SessionContext,
-    payloadResolved: boolean,
-  ): Promise<void> {
-    // Delegate to the shared helper (runtime/source-repos.ts) so the
-    // standalone-clone materialisation + per-clone lock + decision-B in-use
-    // refcount stay in one place across the SDK, TUI, and codex handlers. The
-    // returned list feeds the per-session AGENTS.md "Source Repositories" block
-    // on the next `buildAgentBriefing` call.
-    //
-    // `payloadResolved` is forwarded so the shared helper can decide whether
-    // its empty `gitRepos: []` is authoritative — see
-    // `PrepareSourceReposParams.payloadResolved` and PR #869 P0-2.
-    sourceReposForPrompt = await prepareSourceReposShared({
-      workspace: workspaceCwd,
-      payload,
-      sessionCtx,
-      gitMirrorManager,
-      agentName,
-      payloadResolved,
-    });
   }
 
   function emitToolCall(
@@ -1049,79 +974,27 @@ export const createCodexHandler: HandlerFactory = (config) => {
     await runTurn(inputs.join("\n\n"), sessionCtx, drained);
   }
 
-  /**
-   * Bootstrap wrapper around the shared {@link ensureAgentBootstrapShared}
-   * helper that adds codex's AGENTS.md concurrent-write detector.
-   *
-   * 🔥 RACE WINDOW (proposal §⓪.3 accepted): the codex CLI reads AGENTS.md
-   * once at thread startup, so two writers landing inside the race window
-   * mean the second writer likely clobbered the first briefing before codex
-   * read it. Claude Code has the same property now that the briefing is the
-   * single channel, but Codex still hits this most visibly because there is
-   * no per-turn prompt API to update mid-thread — debug "wrong chat context
-   * surfaces in codex" symptoms by looking here first.
-   */
-  function ensureCodexBootstrap(
-    workspace: string,
-    sessionCtx: SessionContext,
-    briefing: string,
-    payload: AgentRuntimeConfigPayload,
-    payloadResolved: boolean,
-  ): void {
-    detectAgentsMdConcurrentWrite(workspace, Date.now(), (m) => sessionCtx.log(m));
-    ensureAgentBootstrapShared({
-      workspace,
-      sessionCtx,
-      contextTreePath,
-      briefing,
-      // PR #869 baixiaohang round-3 P0: thread the authoritative current
-      // source-repo set into migrations so `v1-orphan-ft-clones` can defer
-      // when the live config is unresolved.
-      currentSourceRepoNames: currentSourceRepoNamesFromPayload(payload, payloadResolved),
-    });
-  }
-
   return {
     async start(message, sessionCtx) {
       ctx = sessionCtx;
-      // Per agent-session-cwd-redesign: cwd is the per-agent home, shared
-      // by every chat session for this agent.
-      cwd = acquireAgentHome(workspaceRoot);
+      const bootstrap = await prepareProviderBootstrap({
+        workspaceRoot,
+        sessionCtx,
+        contextTreePath,
+        agentConfigCache,
+        gitMirrorManager,
+        agentName,
+        payloadStrategy: "refresh",
+        defaultPayload: defaultCodexPayload,
+        envOptions: { trimUndefined: true },
+        beforeBootstrap: ({ cwd: workspace, sessionCtx }) =>
+          detectAgentsMdConcurrentWrite(workspace, Date.now(), (message) => sessionCtx.log(message)),
+      });
+      cwd = bootstrap.cwd;
+      const payload = bootstrap.payload;
+      const env = bootstrap.env as Record<string, string>;
 
-      let payload: AgentRuntimeConfigPayload | null = null;
-      if (agentConfigCache) {
-        payload = (await agentConfigCache.refresh(sessionCtx.agent.agentId)).payload;
-      }
-      // Track whether the payload reflects a real config — used by the source-
-      // repo state reconcile to distinguish "config has zero repos" from "we
-      // couldn't reach the cache". A `false` here suppresses cleanup of
-      // previously-managed clones; see PR #869 P0-2.
-      const payloadResolved = payload !== null;
-      if (!payload) {
-        payload = {
-          kind: "codex",
-          prompt: { append: "" },
-          model: "",
-          mcpServers: [],
-          env: [],
-          gitRepos: [],
-          resourceSkills: [],
-          reasoningEffort: "high",
-        };
-      }
-
-      const chatContext = await fetchChatContextOrLog(sessionCtx);
-
-      // gitRepos first so the per-chat briefing can list the predeclared
-      // worktree paths the agent should know about.
-      await prepareSourceRepos(payload, cwd, sessionCtx, payloadResolved);
-      await materializeResourceSkills(cwd, payload, sessionCtx);
-
-      const briefing = buildBriefing(sessionCtx, payload, chatContext, cwd);
-      ensureCodexBootstrap(cwd, sessionCtx, briefing, payload, payloadResolved);
-      markWorkspaceInitComplete(cwd);
-
-      codex = new Codex({ env: buildEnv(sessionCtx), config: buildCodexConfig(payload) });
+      codex = new Codex({ env, config: buildCodexConfig(payload) });
       thread = codex.startThread(buildCodexThreadOptions(payload, cwd));
       currentModel = payload.model || "";
       // Brand-new thread: the first `turn.completed` cumulative IS turn 1, so
@@ -1147,39 +1020,24 @@ export const createCodexHandler: HandlerFactory = (config) => {
 
     async resume(message, sessionId, sessionCtx) {
       ctx = sessionCtx;
-      cwd = acquireAgentHome(workspaceRoot);
+      const bootstrap = await prepareProviderBootstrap({
+        workspaceRoot,
+        sessionCtx,
+        contextTreePath,
+        agentConfigCache,
+        gitMirrorManager,
+        agentName,
+        payloadStrategy: "refresh",
+        defaultPayload: defaultCodexPayload,
+        envOptions: { trimUndefined: true },
+        beforeBootstrap: ({ cwd: workspace, sessionCtx }) =>
+          detectAgentsMdConcurrentWrite(workspace, Date.now(), (message) => sessionCtx.log(message)),
+      });
+      cwd = bootstrap.cwd;
+      const payload = bootstrap.payload;
+      const env = bootstrap.env as Record<string, string>;
 
-      let payload: AgentRuntimeConfigPayload | null = null;
-      if (agentConfigCache) {
-        payload = (await agentConfigCache.refresh(sessionCtx.agent.agentId)).payload;
-      }
-      const resumePayloadResolved = payload !== null;
-      if (!payload) {
-        payload = {
-          kind: "codex",
-          prompt: { append: "" },
-          model: "",
-          mcpServers: [],
-          env: [],
-          gitRepos: [],
-          resourceSkills: [],
-          reasoningEffort: "high",
-        };
-      }
-
-      // Re-fetch chat-context every resume so newly-joined participants
-      // surface in AGENTS.md. The sentinel still gates the expensive
-      // `<binName> tree skill install` shell-out.
-      const chatContext = await fetchChatContextOrLog(sessionCtx);
-
-      await prepareSourceRepos(payload, cwd, sessionCtx, resumePayloadResolved);
-      await materializeResourceSkills(cwd, payload, sessionCtx);
-
-      const briefing = buildBriefing(sessionCtx, payload, chatContext, cwd);
-      ensureCodexBootstrap(cwd, sessionCtx, briefing, payload, resumePayloadResolved);
-      markWorkspaceInitComplete(cwd);
-
-      codex = new Codex({ env: buildEnv(sessionCtx), config: buildCodexConfig(payload) });
+      codex = new Codex({ env, config: buildCodexConfig(payload) });
       // Footgun F2: resumeThread does NOT inherit first-call ThreadOptions —
       // re-pass them every time.
       try {

--- a/packages/client/src/handlers/codex.ts
+++ b/packages/client/src/handlers/codex.ts
@@ -21,6 +21,7 @@ import type {
   SessionContext,
   SessionMessage,
 } from "../runtime/handler.js";
+import { ResumeUnavailableError } from "../runtime/handler.js";
 import { materializeResourceSkills } from "../runtime/resource-skills.js";
 import {
   currentSourceRepoNamesFromPayload,
@@ -185,6 +186,14 @@ export function isTransientCodexErrorMessage(message: string): boolean {
     m.includes("econnrefused") ||
     m.includes("etimedout") ||
     m.includes("epipe")
+  );
+}
+
+function isCodexResumeUnavailableMessage(message: string): boolean {
+  const m = message.toLowerCase();
+  return (
+    m.includes("thread") &&
+    (m.includes("not found") || m.includes("does not exist") || m.includes("missing") || m.includes("resume"))
   );
 }
 
@@ -744,7 +753,7 @@ export const createCodexHandler: HandlerFactory = (config) => {
     sessionCtx.markMessagesConsumed(messages);
     const abort = new AbortController();
     currentAbort = abort;
-    sessionCtx.setRuntimeState("working");
+    sessionCtx.recordProviderActivity();
 
     // Emit exactly one `turn_end` per turn, after `forwardResult` resolves —
     // mirrors claude-code so admin events + completion bookkeeping reflect
@@ -788,7 +797,7 @@ export const createCodexHandler: HandlerFactory = (config) => {
             const streamed = await activeThread.runStreamed(input, { signal: attemptAbort.signal });
             for await (const event of streamed.events) {
               if (attemptAbort.signal.aborted) break;
-              sessionCtx.touch();
+              sessionCtx.recordProviderActivity();
               if (event.type === "thread.started") {
                 threadId = event.thread_id;
               } else if (event.type === "turn.started") {
@@ -806,6 +815,9 @@ export const createCodexHandler: HandlerFactory = (config) => {
                 // still emitted after forwardResult below.
                 usageBox.value = event.usage;
               } else if (event.type === "turn.failed") {
+                if (isCodexResumeUnavailableMessage(event.error.message)) {
+                  throw new ResumeUnavailableError("provider_resume_rejected", event.error.message);
+                }
                 if (
                   !userVisibleEmitted &&
                   attempt < MAX_TURN_RETRIES &&
@@ -825,6 +837,9 @@ export const createCodexHandler: HandlerFactory = (config) => {
                   payload: { source: "sdk", message },
                 });
               } else if (event.type === "error") {
+                if (isCodexResumeUnavailableMessage(event.message)) {
+                  throw new ResumeUnavailableError("provider_resume_rejected", event.message);
+                }
                 if (!userVisibleEmitted && attempt < MAX_TURN_RETRIES && isTransientCodexErrorMessage(event.message)) {
                   retryRequested = true;
                   retryDelay = RETRY_BASE_MS * RETRY_MULTIPLIER ** attempt;
@@ -844,6 +859,10 @@ export const createCodexHandler: HandlerFactory = (config) => {
           } catch (err) {
             if (abort.signal.aborted) return;
             const msg = err instanceof Error ? err.message : String(err);
+            if (err instanceof ResumeUnavailableError) throw err;
+            if (isCodexResumeUnavailableMessage(msg)) {
+              throw new ResumeUnavailableError("provider_resume_rejected", msg);
+            }
             if (!userVisibleEmitted && attempt < MAX_TURN_RETRIES && isTransientCodexErrorMessage(msg)) {
               retryRequested = true;
               retryDelay = RETRY_BASE_MS * RETRY_MULTIPLIER ** attempt;
@@ -962,16 +981,11 @@ export const createCodexHandler: HandlerFactory = (config) => {
         sessionCtx.log(`Failed to emit token_usage: ${err instanceof Error ? err.message : String(err)}`);
       }
     }
-    sessionCtx.emitEvent({
-      kind: "turn_end",
-      payload: { status: succeeded ? "success" : "error" },
-    });
-    sessionCtx.setRuntimeState("idle");
     // Ack the entries this turn consumed. All four turn outcomes (success,
     // silent / no-text, SDK turn.failed, forwardResult failure) are
     // terminal for this turn — redelivery would either replay an already-
     // delivered reply or re-hit the same failure.
-    sessionCtx.markMessagesCompleted(messages);
+    await sessionCtx.finishTurn(messages, { status: succeeded ? "success" : "error" });
 
     // Structured usage / timing log — emitted via `sessionCtx.log` rather
     // than a new SessionEvent kind so we stay inside the codex handler
@@ -1029,7 +1043,7 @@ export const createCodexHandler: HandlerFactory = (config) => {
       // permanent failure for this batch (redelivery would re-hit the same
       // format errors). Ack the entries so they don't leak in
       // `inFlightEntries` and pile up server-side as `delivered` rows.
-      sessionCtx.markMessagesCompleted(drained);
+      await sessionCtx.finishTurn(drained, { status: "error", terminal: true });
       return;
     }
     await runTurn(inputs.join("\n\n"), sessionCtx, drained);
@@ -1168,7 +1182,12 @@ export const createCodexHandler: HandlerFactory = (config) => {
       codex = new Codex({ env: buildEnv(sessionCtx), config: buildCodexConfig(payload) });
       // Footgun F2: resumeThread does NOT inherit first-call ThreadOptions —
       // re-pass them every time.
-      thread = codex.resumeThread(sessionId, buildCodexThreadOptions(payload, cwd));
+      try {
+        thread = codex.resumeThread(sessionId, buildCodexThreadOptions(payload, cwd));
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        throw new ResumeUnavailableError("provider_resume_rejected", message);
+      }
       threadId = sessionId;
       currentModel = payload.model || "";
 

--- a/packages/client/src/handlers/provider-bootstrap.ts
+++ b/packages/client/src/handlers/provider-bootstrap.ts
@@ -1,0 +1,209 @@
+import type { AgentRuntimeConfigPayload } from "@first-tree/shared";
+import { type AgentBootstrapResult, ensureAgentBootstrap } from "../runtime/agent-bootstrap.js";
+import { buildAgentBriefing } from "../runtime/agent-briefing.js";
+import type { AgentConfigCache } from "../runtime/agent-config-cache.js";
+import type { PredeclaredSourceRepo } from "../runtime/bootstrap.js";
+import { type ChatContext, fetchChatContext } from "../runtime/chat-context.js";
+import type { GitMirrorManager } from "../runtime/git-mirror-manager.js";
+import type { SessionContext } from "../runtime/handler.js";
+import { materializeResourceSkills } from "../runtime/resource-skills.js";
+import { currentSourceRepoNamesFromPayload, prepareSourceRepos } from "../runtime/source-repos.js";
+import { acquireAgentHome, markWorkspaceInitComplete } from "../runtime/workspace.js";
+
+export type ProviderPayloadStrategy = "cached" | "refresh" | "cached-or-refresh";
+
+export type ProviderEnvOptions = {
+  stripClaudeCodeParentEnv?: boolean;
+  trimUndefined?: boolean;
+};
+
+export type ProviderBootstrapResult<TPayload extends AgentRuntimeConfigPayload | undefined> = {
+  cwd: string;
+  payload: TPayload;
+  payloadResolved: boolean;
+  chatContext: ChatContext | undefined;
+  sourceRepos: PredeclaredSourceRepo[];
+  briefing: string;
+  env: Record<string, string | undefined>;
+  bootstrap: AgentBootstrapResult;
+};
+
+export type ProviderBootstrapDeps = {
+  acquireAgentHome: (workspaceRoot: string) => string;
+  fetchChatContext: typeof fetchChatContext;
+  prepareSourceRepos: typeof prepareSourceRepos;
+  materializeResourceSkills: typeof materializeResourceSkills;
+  buildAgentBriefing: typeof buildAgentBriefing;
+  ensureAgentBootstrap: typeof ensureAgentBootstrap;
+  markWorkspaceInitComplete: typeof markWorkspaceInitComplete;
+};
+
+const defaultDeps: ProviderBootstrapDeps = {
+  acquireAgentHome,
+  fetchChatContext,
+  prepareSourceRepos,
+  materializeResourceSkills,
+  buildAgentBriefing,
+  ensureAgentBootstrap,
+  markWorkspaceInitComplete,
+};
+
+type ProviderBootstrapOptionsBase = {
+  workspaceRoot: string;
+  sessionCtx: SessionContext;
+  contextTreePath: string | null;
+  agentConfigCache: AgentConfigCache | null;
+  gitMirrorManager: GitMirrorManager | null;
+  agentName: string | null;
+  payloadStrategy: ProviderPayloadStrategy;
+  envOptions?: ProviderEnvOptions;
+  beforeBootstrap?: (input: { cwd: string; sessionCtx: SessionContext }) => void;
+  deps?: Partial<ProviderBootstrapDeps>;
+};
+
+type ProviderBootstrapOptionsWithDefault = ProviderBootstrapOptionsBase & {
+  defaultPayload: () => AgentRuntimeConfigPayload;
+};
+
+type ProviderBootstrapOptionsWithoutDefault = ProviderBootstrapOptionsBase & {
+  defaultPayload?: undefined;
+};
+
+export function buildProviderEnv(
+  sessionCtx: SessionContext,
+  payload: AgentRuntimeConfigPayload | null | undefined,
+  options: ProviderEnvOptions & { trimUndefined: true },
+): Record<string, string>;
+export function buildProviderEnv(
+  sessionCtx: SessionContext,
+  payload: AgentRuntimeConfigPayload | null | undefined,
+  options?: ProviderEnvOptions,
+): Record<string, string | undefined>;
+export function buildProviderEnv(
+  sessionCtx: SessionContext,
+  payload: AgentRuntimeConfigPayload | null | undefined,
+  options: ProviderEnvOptions = {},
+): Record<string, string | undefined> {
+  const env: Record<string, string | undefined> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (typeof value === "string" || !options.trimUndefined) env[key] = value;
+  }
+
+  if (options.stripClaudeCodeParentEnv) {
+    delete env.CLAUDECODE;
+    delete env.CLAUDE_CODE_ENTRYPOINT;
+    delete env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS;
+    delete env.npm_lifecycle_script;
+  }
+
+  for (const entry of payload?.env ?? []) {
+    env[entry.key] = entry.value;
+  }
+
+  const merged = sessionCtx.buildAgentEnv(env);
+  if (!options.trimUndefined) return merged;
+
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(merged)) {
+    if (typeof value === "string") out[key] = value;
+  }
+  return out;
+}
+
+export async function prepareProviderBootstrap(
+  options: ProviderBootstrapOptionsWithDefault,
+): Promise<ProviderBootstrapResult<AgentRuntimeConfigPayload>>;
+export async function prepareProviderBootstrap(
+  options: ProviderBootstrapOptionsWithoutDefault,
+): Promise<ProviderBootstrapResult<AgentRuntimeConfigPayload | undefined>>;
+export async function prepareProviderBootstrap(
+  options: ProviderBootstrapOptionsWithDefault | ProviderBootstrapOptionsWithoutDefault,
+): Promise<ProviderBootstrapResult<AgentRuntimeConfigPayload | undefined>> {
+  const deps = { ...defaultDeps, ...options.deps };
+  const cwd = deps.acquireAgentHome(options.workspaceRoot);
+  const { payload, payloadResolved } = await resolvePayload(options);
+  const chatContext = await fetchChatContextOrLog(deps, options.sessionCtx);
+  const sourceRepos = await deps.prepareSourceRepos({
+    workspace: cwd,
+    payload,
+    sessionCtx: options.sessionCtx,
+    gitMirrorManager: options.gitMirrorManager,
+    agentName: options.agentName,
+    payloadResolved,
+  });
+  await deps.materializeResourceSkills(cwd, payload, options.sessionCtx);
+
+  const briefing = deps.buildAgentBriefing({
+    identity: options.sessionCtx.agent,
+    payload: payload ?? null,
+    chatContext,
+    workspacePath: cwd,
+    sourceRepos,
+    contextTreePath: options.contextTreePath,
+  });
+  options.beforeBootstrap?.({ cwd, sessionCtx: options.sessionCtx });
+  const bootstrap = deps.ensureAgentBootstrap({
+    workspace: cwd,
+    sessionCtx: options.sessionCtx,
+    contextTreePath: options.contextTreePath,
+    briefing,
+    currentSourceRepoNames: currentSourceRepoNamesFromPayload(payload, payloadResolved),
+  });
+  deps.markWorkspaceInitComplete(cwd);
+
+  return {
+    cwd,
+    payload,
+    payloadResolved,
+    chatContext,
+    sourceRepos,
+    briefing,
+    env: buildProviderEnv(options.sessionCtx, payload, options.envOptions),
+    bootstrap,
+  };
+}
+
+async function resolvePayload(
+  options: ProviderBootstrapOptionsWithDefault | ProviderBootstrapOptionsWithoutDefault,
+): Promise<{ payload: AgentRuntimeConfigPayload | undefined; payloadResolved: boolean }> {
+  const agentId = options.sessionCtx.agent.agentId;
+  let payload: AgentRuntimeConfigPayload | undefined;
+  let payloadResolved = false;
+
+  if (options.agentConfigCache) {
+    if (options.payloadStrategy === "cached") {
+      const cached = options.agentConfigCache.get(agentId);
+      payload = cached?.payload;
+      payloadResolved = cached !== undefined;
+    } else if (options.payloadStrategy === "refresh") {
+      payload = (await options.agentConfigCache.refresh(agentId)).payload;
+      payloadResolved = true;
+    } else {
+      const cached = options.agentConfigCache.get(agentId);
+      if (cached) {
+        payload = cached.payload;
+        payloadResolved = true;
+      } else {
+        payload = (await options.agentConfigCache.refresh(agentId)).payload;
+        payloadResolved = true;
+      }
+    }
+  }
+
+  if (!payload && options.defaultPayload) {
+    payload = options.defaultPayload();
+  }
+  return { payload, payloadResolved };
+}
+
+async function fetchChatContextOrLog(
+  deps: ProviderBootstrapDeps,
+  sessionCtx: SessionContext,
+): Promise<ChatContext | undefined> {
+  try {
+    return await deps.fetchChatContext(sessionCtx.sdk, sessionCtx.chatId, sessionCtx.agent);
+  } catch (err) {
+    sessionCtx.log(`fetchChatContext failed: ${err instanceof Error ? err.message : String(err)}`);
+    return undefined;
+  }
+}

--- a/packages/client/src/runtime/agent-bootstrap.ts
+++ b/packages/client/src/runtime/agent-bootstrap.ts
@@ -43,6 +43,12 @@ export type AgentBootstrapParams = {
   currentSourceRepoNames: ReadonlySet<string> | null;
 };
 
+export type AgentBootstrapResult = {
+  treeDrifted: boolean;
+  cliDrifted: boolean;
+  bootstrapped: boolean;
+};
+
 /**
  * Hash-check the existing identity.json against current agent metadata and
  * rewrite the stable `.first-tree-workspace/` section only when something
@@ -100,7 +106,7 @@ function ensureStableIdentity(workspace: string, sessionCtx: SessionContext, con
  * list, current payload prompt.append) that changes between sessions for the
  * same agent home. See proposal §⓪.3 for the race window this accepts.
  */
-export function ensureAgentBootstrap(params: AgentBootstrapParams): void {
+export function ensureAgentBootstrap(params: AgentBootstrapParams): AgentBootstrapResult {
   const { workspace, sessionCtx, contextTreePath, briefing, currentSourceRepoNames } = params;
 
   // One-shot workspace migrations: sweep legacy directory-structure residue
@@ -152,7 +158,7 @@ export function ensureAgentBootstrap(params: AgentBootstrapParams): void {
   if (sentinelPresent && !treeDrifted && !cliDrifted && !integrationNeverPinned) {
     ensureStableIdentity(workspace, sessionCtx, contextTreePath);
     writeAgentBriefing(workspace, briefing);
-    return;
+    return { treeDrifted, cliDrifted, bootstrapped: false };
   }
 
   if (sentinelPresent && treeDrifted) {
@@ -198,4 +204,5 @@ export function ensureAgentBootstrap(params: AgentBootstrapParams): void {
   if (integrationOk) {
     writeBundledCliVersion(workspace, currentCliVersion);
   }
+  return { treeDrifted, cliDrifted, bootstrapped: true };
 }

--- a/packages/client/src/runtime/agent-slot.ts
+++ b/packages/client/src/runtime/agent-slot.ts
@@ -405,7 +405,7 @@ export class AgentSlot {
    * Ack happens INSIDE the SessionManager via the `ackEntry` callback we
    * pinned at construction time — `clientConnection.sendInboxAck`. Post
    * inflight-message-recovery the ack is deferred until the handler closes
-   * the turn via `ctx.markCompleted()`. Sending an additional ack here
+   * the turn via `ctx.finishTurn(...)`. Sending an additional ack here
    * would double-ack: a WS frame the server cannot match against any
    * `delivered` row, which leaks the server's per-agent in-flight counter
    * and stalls push after `inboxMaxInFlightPerAgent` messages.

--- a/packages/client/src/runtime/deduplicator.ts
+++ b/packages/client/src/runtime/deduplicator.ts
@@ -34,7 +34,7 @@ export class Deduplicator {
   /**
    * Drop every recorded id that starts with `prefix`. Used by the runtime
    * when a chat is LRU-evicted: the in-flight entries for that chat won't
-   * be acked (no handler will run `markCompleted`), and the server will
+   * be acked (no handler will run `finishTurn`), and the server will
    * resend the same `(chatId, messageId)` pairs against a fresh session.
    * Leaving the keys in the dedup set would cause the resend to be
    * mis-classified as a duplicate — and (post-#1-fix) re-acked, which

--- a/packages/client/src/runtime/handler.ts
+++ b/packages/client/src/runtime/handler.ts
@@ -44,6 +44,8 @@ export type HandlerContext = {
   log: (msg: string) => void;
 };
 
+export type SessionTurnOutcome = { status: "success" | "error"; terminal?: boolean };
+
 /** Extended context for session-oriented handlers. */
 export type SessionContext = HandlerContext & {
   /** The server-side chat this session belongs to. */
@@ -76,17 +78,19 @@ export type SessionContext = HandlerContext & {
    * completed inbox prefix, clears local in-flight tracking on ACK success,
    * and recomputes effective runtime state.
    */
-  finishTurn: (
-    messages: SessionMessage | readonly SessionMessage[],
-    outcome: { status: "success" | "error"; terminal?: boolean },
-  ) => Promise<void>;
+  finishTurn: (messages: SessionMessage | readonly SessionMessage[], outcome: SessionTurnOutcome) => Promise<void>;
 
   /**
    * Mark a concrete message or batch as abandoned by a retryable path
-   * (abort, timeout, unknown failure). The runtime leaves the server-side
-   * entries unacked; a later chat recovery or bind reset redelivers them.
+   * (abort, timeout, unknown failure) while still reporting the provider turn
+   * boundary. The runtime leaves the server-side entries unacked; a later chat
+   * recovery or bind reset redelivers them.
    */
-  retryTurn: (messages: SessionMessage | readonly SessionMessage[], reason: string) => void;
+  retryTurn: (
+    messages: SessionMessage | readonly SessionMessage[],
+    reason: string,
+    outcome?: SessionTurnOutcome,
+  ) => void;
 
   /**
    * Build env for CLI sub-processes that shell out to the First Tree CLI.

--- a/packages/client/src/runtime/handler.ts
+++ b/packages/client/src/runtime/handler.ts
@@ -48,10 +48,8 @@ export type HandlerContext = {
 export type SessionContext = HandlerContext & {
   /** The server-side chat this session belongs to. */
   chatId: string;
-  /** Refresh `lastActivity` timestamp to prevent idle timeout. */
-  touch: () => void;
-  /** Report per-session runtime state (working/idle/blocked/error). */
-  setRuntimeState: (state: "idle" | "working" | "blocked" | "error") => void;
+  /** Report provider activity without directly changing effective runtime state. */
+  recordProviderActivity: () => void;
   /**
    * Persist a structured session event (tool_call / error) to the server.
    * Assistant text does NOT go through here — it flows via `forwardResult`.
@@ -66,13 +64,6 @@ export type SessionContext = HandlerContext & {
   forwardResult: (text: string) => Promise<void>;
 
   /**
-   * Mark a single-message turn complete. Built-in handlers should prefer
-   * `markMessagesCompleted(messageOrBatch)` so the runtime can ack-through
-   * the exact inbox entry the handler actually consumed.
-   */
-  markCompleted: () => void;
-
-  /**
    * Mark the concrete message or fused batch as entered into the current
    * provider turn. This is an in-memory boundary used by suspend: consumed
    * entries can be ACKed when the turn is paused, while handler queues that
@@ -81,21 +72,21 @@ export type SessionContext = HandlerContext & {
   markMessagesConsumed: (messages: SessionMessage | readonly SessionMessage[]) => void;
 
   /**
-   * Mark the concrete message or fused message batch a handler has actually
-   * consumed. The runtime sends one `inbox:ack` for the last message's
-   * `inboxEntryId`; the server interprets it as ack-through for the chat's
-   * delivered prefix. This replaces the old `markCompleted(count)` FIFO
-   * pairing, which could ack an older queued entry while the completed entry
-   * remained unacked.
+   * Finish a concrete provider turn. The runtime emits turn_end, ACKs the
+   * completed inbox prefix, clears local in-flight tracking on ACK success,
+   * and recomputes effective runtime state.
    */
-  markMessagesCompleted: (messages: SessionMessage | readonly SessionMessage[]) => void;
+  finishTurn: (
+    messages: SessionMessage | readonly SessionMessage[],
+    outcome: { status: "success" | "error"; terminal?: boolean },
+  ) => Promise<void>;
 
   /**
    * Mark a concrete message or batch as abandoned by a retryable path
    * (abort, timeout, unknown failure). The runtime leaves the server-side
    * entries unacked; a later chat recovery or bind reset redelivers them.
    */
-  markMessagesRetryable: (messages: SessionMessage | readonly SessionMessage[], reason: string) => void;
+  retryTurn: (messages: SessionMessage | readonly SessionMessage[], reason: string) => void;
 
   /**
    * Build env for CLI sub-processes that shell out to the First Tree CLI.
@@ -124,6 +115,25 @@ export type SessionContext = HandlerContext & {
    */
   resolveSenderLabel: (senderId: string) => Promise<string>;
 };
+
+export type ResumeUnavailableReason =
+  | "transcript_missing"
+  | "provider_resume_rejected"
+  | "local_session_artifact_missing";
+
+export class ResumeUnavailableError extends Error {
+  readonly reason: ResumeUnavailableReason;
+
+  constructor(reason: ResumeUnavailableReason, message: string) {
+    super(message);
+    this.name = "ResumeUnavailableError";
+    this.reason = reason;
+  }
+}
+
+export function isResumeUnavailableError(err: unknown): err is ResumeUnavailableError {
+  return err instanceof ResumeUnavailableError;
+}
 
 /** Message content extracted from an inbox entry (no entry metadata). */
 export type SessionMessage = {

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -25,6 +25,7 @@ import type {
   SessionContext,
   SessionMessage,
 } from "./handler.js";
+import { isResumeUnavailableError } from "./handler.js";
 import { findImagePath, writeImage } from "./image-store.js";
 import { createResultSink, type Trigger } from "./result-sink.js";
 import { SessionRegistry } from "./session-registry.js";
@@ -67,6 +68,8 @@ type PendingMessage = {
   message: SessionMessage;
   chatId: string;
 };
+
+type RuntimeMarker = "blocked" | "error";
 
 /**
  * Resolve the directory the runtime reads markdown doc snapshots against —
@@ -306,12 +309,12 @@ export class SessionManager {
    * Kept here (not on `SessionEntry`) because dispatch may push an entryId
    * before any session record exists for the chat (`startNewSession` runs
    * `routeMessage` first), and the queue must survive a session being
-   * suspended / evicted between dispatch and markCompleted.
+   * suspended / evicted between dispatch and finishTurn.
    *
    * Sized small in practice: usually 1, briefly up to N when several
    * messages land while a turn is mid-flight. Entries that were delivered
    * but only queued inside a handler remain tracked until the handler's
-   * actual consuming turn calls `markMessagesCompleted`.
+   * actual consuming turn calls `finishTurn`.
    * See
    * docs/inflight-message-recovery-design.md §4.
    */
@@ -331,6 +334,7 @@ export class SessionManager {
   private readonly pendingQueue: PendingMessage[] = [];
   private readonly lastReportedStates = new Map<string, SessionState>();
   private readonly sessionRuntimeStates = new Map<string, RuntimeState>();
+  private readonly sessionRuntimeMarkers = new Map<string, RuntimeMarker>();
   private lastReportedRuntimeState: RuntimeState | null = null;
   private idleTimer: ReturnType<typeof setInterval> | null = null;
   private runtimeReaffirmTimer: ReturnType<typeof setTimeout> | null = null;
@@ -361,7 +365,7 @@ export class SessionManager {
 
   /**
    * Dispatch an inbox entry. ACK is deferred until the handler reports a
-   * completed turn via `ctx.markMessagesCompleted(...)`.
+   * completed turn via `ctx.finishTurn(...)`.
    *
    * Delayed ACK semantics (post inflight-message-recovery): the entry stays
    * `delivered` server-side until forwardResult succeeds (or the handler
@@ -394,7 +398,10 @@ export class SessionManager {
       const queue = this.inFlightEntries.get(chatId);
       const stillInFlight = queue ? queue.some((tracked) => tracked.entryId === entry.id) : false;
       this.config.log.debug({ chatId, messageId, entryId: entry.id, stillInFlight }, "duplicate message observed");
-      if (stillInFlight) return;
+      if (stillInFlight) {
+        this.recomputeSessionRuntimeState(chatId);
+        return;
+      }
       this.config.log.debug(
         { chatId, messageId, entryId: entry.id },
         "duplicate key is not tied to an active entry; reprocessing redelivery",
@@ -407,6 +414,7 @@ export class SessionManager {
     const tracked = { entryId: entry.id, messageId, dedupKey, accepted: false, consumed: false };
     if (queue) queue.push(tracked);
     else this.inFlightEntries.set(chatId, [tracked]);
+    this.recomputeSessionRuntimeState(chatId);
 
     let routePromise: Promise<void> | undefined;
     await this.withAdmissionBarrier(chatId, async () => {
@@ -538,6 +546,7 @@ export class SessionManager {
       this.sessions.delete(chatId);
       this.evictedMappings.delete(chatId);
       this.sessionRuntimeStates.delete(chatId);
+      this.sessionRuntimeMarkers.delete(chatId);
       this.lastReportedStates.delete(chatId);
       this.currentTrigger.delete(chatId);
 
@@ -617,6 +626,7 @@ export class SessionManager {
     this.evictedMappings.clear();
     this.lastReportedStates.clear();
     this.sessionRuntimeStates.clear();
+    this.sessionRuntimeMarkers.clear();
     this.lastReportedRuntimeState = null;
     this._activeCount = 0;
   }
@@ -684,7 +694,10 @@ export class SessionManager {
     const next = prev.then(op, op);
     this.admissionQueues.set(chatId, next);
     const cleanup = () => {
-      if (this.admissionQueues.get(chatId) === next) this.admissionQueues.delete(chatId);
+      if (this.admissionQueues.get(chatId) === next) {
+        this.admissionQueues.delete(chatId);
+        this.recomputeSessionRuntimeState(chatId);
+      }
     };
     void next.then(cleanup, cleanup);
     await next;
@@ -736,14 +749,20 @@ export class SessionManager {
         this.requiresInboxRecovery.delete(chatId);
         this.recoveryActivationReady.add(chatId);
         this.config.log.debug({ chatId, entryId, messageId }, "chat inbox recovery accepted before dispatch");
+        this.recomputeSessionRuntimeState(chatId);
       })
       .catch((err) => {
         this.config.log.warn({ chatId, entryId, messageId, err }, "chat inbox recovery failed before dispatch");
+        this.recomputeSessionRuntimeState(chatId);
       })
       .finally(() => {
-        if (this.recoveringChats.get(chatId) === recovery) this.recoveringChats.delete(chatId);
+        if (this.recoveringChats.get(chatId) === recovery) {
+          this.recoveringChats.delete(chatId);
+          this.recomputeSessionRuntimeState(chatId);
+        }
       });
     this.recoveringChats.set(chatId, recovery);
+    this.recomputeSessionRuntimeState(chatId);
     await recovery;
   }
 
@@ -777,16 +796,7 @@ export class SessionManager {
         case "active":
           existing.handler.inject(message);
           existing.lastActivity = Date.now();
-          // Re-arm the working-grace guard in `evictIdle`. Without this, a
-          // turn that ends with `setRuntimeState("idle")` (claude-code.ts on
-          // every result message) leaves the next inject-triggered turn
-          // observable as `idle` — and a long-thinking turn that produces
-          // no SDK messages for `idle_timeout` (300s default) trips
-          // evictIdle's suspend path even though the agent is actively
-          // working. Setting `working` here puts the session under the
-          // `idle_timeout + working_grace_seconds` umbrella until the next
-          // result flips it back.
-          this.setSessionRuntimeState(chatId, "working");
+          this.recomputeSessionRuntimeState(chatId);
           this.config.log.debug({ chatId }, "message injected");
           return;
 
@@ -838,23 +848,15 @@ export class SessionManager {
     this._activeCount++;
     if (evicted) this.evictedMappings.delete(chatId);
 
-    // Report `active` BEFORE invoking handler.start / handler.resume. Handlers
-    // can call `ctx.setRuntimeState("working")` synchronously inside start()
-    // (claude-code does; codex always does — its handler awaits the whole
-    // turn before returning, so the initial working AND final idle reports
-    // both fire from inside start()). Those `session:runtime` frames are
-    // active-gated on the server, so they would be dropped if the
-    // `session:state active` write hadn't landed yet — leaving the composite
-    // stuck at `ready` until a reaffirm (or never, for short turns). The
-    // server's `upsertSessionState` short-circuits same-state reports, and
-    // `notifySessionState` here additionally dedupes against the last
-    // reported value, so doing it before AND after is harmless if a future
-    // refactor adds a second site. Failure path replaces this `active` with
-    // `errored` in the catch below (different state → goes through).
+    // Report `active` before invoking handler.start / handler.resume, then
+    // compute runtime state from manager-owned delivery facts. The server
+    // active-gates `session:runtime`, so this order keeps the first working
+    // projection from being dropped.
     this.notifySessionState(chatId, "active");
+    this.recomputeSessionRuntimeState(chatId);
     try {
       if (evicted) {
-        const sessionId = await handler.resume(message, evicted.claudeSessionId, ctx);
+        const sessionId = await this.resumeProviderSession(entry, message, evicted.claudeSessionId, ctx);
         entry.claudeSessionId = sessionId;
         this.config.log.info({ chatId, sessionId }, "session resumed from eviction");
       } else {
@@ -880,6 +882,7 @@ export class SessionManager {
         this.drainAllInFlightEntries(chatId);
         this.sessions.delete(chatId);
         this.sessionRuntimeStates.delete(chatId);
+        this.sessionRuntimeMarkers.delete(chatId);
         this.recomputeRuntimeState();
         this._activeCount--;
       }
@@ -910,22 +913,18 @@ export class SessionManager {
     this._activeCount++;
     entry.lastActivity = Date.now();
 
-    // Same rationale as `startNewSession`: report `active` BEFORE invoking
-    // the handler so any synchronous `ctx.setRuntimeState("working")` inside
-    // handler.resume() lands on a server row that is already active-gated.
+    // Same rationale as `startNewSession`: report `active` before invoking the
+    // handler so the manager-owned runtime projection lands on an active row.
     // Failure path overrides with `errored` in the catch below.
     this.notifySessionState(entry.chatId, "active");
+    this.recomputeSessionRuntimeState(entry.chatId);
     try {
-      // Mirror the pattern in `startNewSession` (line 449): the handler may
-      // return a DIFFERENT sessionId than the one passed in — e.g. when the
-      // claude-code handler detects a stale SDK transcript and falls
-      // through to fresh-start semantics — and `entry.claudeSessionId` has
-      // to track the handler's truth or future resume cycles will keep
-      // calling the stale id. PR #530 nit baixiaohang flagged: without the
-      // assignment back, a fresh-start fallback would persist the OLD id,
-      // and the next suspend→resume cycle would re-trigger the same
-      // missing-transcript fallback ad infinitum.
-      const resumedSessionId = await entry.handler.resume(message ?? undefined, entry.claudeSessionId, ctx);
+      const resumedSessionId = await this.resumeProviderSession(
+        entry,
+        message ?? undefined,
+        entry.claudeSessionId,
+        ctx,
+      );
       entry.claudeSessionId = resumedSessionId;
       this.config.log.info({ chatId: entry.chatId, sessionId: entry.claudeSessionId }, "session resumed");
       this.persistRegistry();
@@ -942,10 +941,75 @@ export class SessionManager {
         this.drainAllInFlightEntries(entry.chatId);
         this.sessions.delete(entry.chatId);
         this.sessionRuntimeStates.delete(entry.chatId);
+        this.sessionRuntimeMarkers.delete(entry.chatId);
         this.recomputeRuntimeState();
         this._activeCount--;
       }
     }
+  }
+
+  private async resumeProviderSession(
+    entry: SessionEntry,
+    message: SessionMessage | undefined,
+    previousSessionId: string,
+    ctx: SessionContext,
+  ): Promise<string> {
+    try {
+      const resumedSessionId = await entry.handler.resume(message, previousSessionId, ctx);
+      if (resumedSessionId !== previousSessionId) {
+        throw new Error(
+          `handler.resume returned a different provider session id (${resumedSessionId}) than requested (${previousSessionId}) without typed resume-unavailable`,
+        );
+      }
+      return resumedSessionId;
+    } catch (err) {
+      if (!isResumeUnavailableError(err)) throw err;
+      return this.replaceProviderSession(entry, message, previousSessionId, err.reason, err.message, ctx);
+    }
+  }
+
+  private async replaceProviderSession(
+    entry: SessionEntry,
+    message: SessionMessage | undefined,
+    previousSessionId: string,
+    reason: string,
+    detail: string,
+    ctx: SessionContext,
+  ): Promise<string> {
+    if (!message) {
+      this.config.log.warn(
+        { chatId: entry.chatId, previousSessionId, reason, detail },
+        "provider resume unavailable during no-input resume; replacement deferred until concrete input",
+      );
+      throw new Error(`Provider resume unavailable during no-input resume (${reason}): ${detail}`);
+    }
+
+    this.config.log.warn(
+      { chatId: entry.chatId, previousSessionId, reason, detail },
+      "provider resume unavailable; explicitly replacing provider session",
+    );
+    try {
+      ctx.emitEvent({
+        kind: "error",
+        payload: {
+          source: "runtime",
+          message: encodeResilienceMessage("resilience.session.provider_replaced", {
+            reason,
+            previousSessionId,
+          }),
+        },
+      });
+    } catch (emitErr) {
+      this.config.log.warn({ chatId: entry.chatId, emitErr }, "provider replacement event emit failed");
+    }
+
+    const replacementSessionId = await entry.handler.start(message, ctx);
+    this.sessionRuntimeMarkers.delete(entry.chatId);
+    this.config.log.info(
+      { chatId: entry.chatId, previousSessionId, sessionId: replacementSessionId, reason },
+      "provider session replacement started",
+    );
+    return replacementSessionId;
   }
 
   /**
@@ -995,6 +1059,7 @@ export class SessionManager {
       this._activeCount--;
       entry.status = "suspended";
       this.sessionRuntimeStates.delete(chatId);
+      this.sessionRuntimeMarkers.delete(chatId);
       this.recomputeRuntimeState();
 
       this.config.log.info(
@@ -1128,7 +1193,7 @@ export class SessionManager {
       const resumeMessage = entry.startMessage ?? null;
       const previousSessionId = entry.claudeSessionId || entry.retryFromEvicted?.claudeSessionId || "";
       if (previousSessionId) {
-        const sid = await newHandler.resume(resumeMessage ?? undefined, previousSessionId, ctx);
+        const sid = await this.resumeProviderSession(entry, resumeMessage ?? undefined, previousSessionId, ctx);
         entry.claudeSessionId = sid;
       } else {
         // No resume key yet — fall back to fresh start.
@@ -1175,6 +1240,7 @@ export class SessionManager {
         this.drainAllInFlightEntries(chatId);
         this.sessions.delete(chatId);
         this.sessionRuntimeStates.delete(chatId);
+        this.sessionRuntimeMarkers.delete(chatId);
         this.recomputeRuntimeState();
         this._activeCount--;
       }
@@ -1229,6 +1295,7 @@ export class SessionManager {
     // `inFlightEntries[chatId]` until the eventual turn finishes.
     this.config.log.info({ chatId }, "concurrency limit reached, queuing");
     this.pendingQueue.push({ message, chatId });
+    this.recomputeSessionRuntimeState(chatId);
     return false;
   }
 
@@ -1239,6 +1306,7 @@ export class SessionManager {
     this._activeCount--;
     // Clear per-session runtime state on suspend
     this.sessionRuntimeStates.delete(entry.chatId);
+    this.sessionRuntimeMarkers.delete(entry.chatId);
     this.recomputeRuntimeState();
     entry.suspending = entry.handler
       .suspend()
@@ -1261,6 +1329,7 @@ export class SessionManager {
 
     const next = this.pendingQueue.shift();
     if (!next) return;
+    this.recomputeSessionRuntimeState(next.chatId);
     // Route asynchronously — the in-flight entryId for this message is
     // already in `inFlightEntries[chatId]` from the original `dispatch`.
     this.routeMessage(next.chatId, next.message).catch((err) => {
@@ -1307,6 +1376,7 @@ export class SessionManager {
       // every eviction.
       this.sessions.delete(candidate.key);
       this.sessionRuntimeStates.delete(candidate.key);
+      this.sessionRuntimeMarkers.delete(candidate.key);
       // Drop the trigger alongside the session — the next message routed to
       // this chat will set a fresh one. Leaving stale entries here would
       // only burn memory (wrong replies are not a risk since `routeMessage`
@@ -1314,7 +1384,7 @@ export class SessionManager {
       // cleans the same maps we keep the two paths symmetric.
       this.currentTrigger.delete(candidate.key);
       // Drop local in-flight tracking too — the handler is gone, so no
-      // markCompleted will ever fire. The server-side entries stay
+      // finishTurn will ever fire. The server-side entries stay
       // `delivered`; a later chat recovery or bind reset redelivers them
       // against a fresh session.
       this.clearInFlightForRecovery(candidate.key, "session_evicted");
@@ -1329,7 +1399,7 @@ export class SessionManager {
    * Invariants this routine relies on:
    *   1. `lastActivity` is monotonic per session and is bumped by every
    *      inbound activity — `dispatch` (new chat / resume), `inject`
-   *      (mid-turn message), and the handler's `touch()` on each SDK event.
+   *      (mid-turn message), and the handler's provider activity reports.
    *   2. `runtimeState` reflects what the agent is currently doing as best
    *      the runtime can tell:
    *        - `working` — a turn is in flight. Set by the handler at the top
@@ -1346,7 +1416,7 @@ export class SessionManager {
    *          (e.g. if/when the SDK transport exposes a real stuck signal).
    *        - `idle` — no work in flight.
    *      If you add a new way to wake the session up, you MUST also set
-   *      `runtimeState` to `working` from that path, or this guard will
+   *      manager-owned delivery facts from that path, or this guard will
    *      treat the chat as idle and reap it.
    *   3. `working_grace_seconds` is an UPPER bound on how long a `working`
    *      / `blocked` chat can hold a slot past `idle_timeout` — defends
@@ -1371,7 +1441,7 @@ export class SessionManager {
       const pastHardCap = inactiveMs >= timeoutMs + workingGraceMs;
 
       // `lastActivity` is bumped per inbound SDK message/event (handler
-      // `touch()`), so a long thinking turn or a single very large message
+      // provider activity), so a long thinking turn or a single very large message
       // looks identical to "session has been idle" here. Without this
       // exemption the runtime suspends the SDK transport mid-thinking and
       // the work is lost. The hard cap above bounds the worst case.
@@ -1440,11 +1510,6 @@ export class SessionManager {
     });
   }
 
-  private ackOldestTrackedEntry(chatId: string): void {
-    const entryId = this.inFlightEntries.get(chatId)?.[0]?.entryId;
-    if (entryId !== undefined) this.ackThroughTrackedEntry(chatId, entryId);
-  }
-
   private clearInFlightForRecovery(chatId: string, reason: string): void {
     const queue = this.inFlightEntries.get(chatId);
     if (!queue || queue.length === 0) return;
@@ -1455,6 +1520,7 @@ export class SessionManager {
       { chatId, reason, entryIds: queue.map((entry) => entry.entryId) },
       "cleared local in-flight inbox entries; waiting for recovery redelivery",
     );
+    this.recomputeSessionRuntimeState(chatId);
   }
 
   private ackConsumedInFlightForSuspend(chatId: string): void {
@@ -1484,9 +1550,21 @@ export class SessionManager {
     for (const tracked of queue) {
       if (consumedIds.has(tracked.entryId)) tracked.consumed = true;
     }
+    this.recomputeSessionRuntimeState(chatId);
   }
 
-  private markMessagesCompleted(chatId: string, messages: SessionMessage | readonly SessionMessage[]): void {
+  private async finishTurn(
+    chatId: string,
+    messages: SessionMessage | readonly SessionMessage[],
+    outcome: { status: "success" | "error"; terminal?: boolean },
+  ): Promise<void> {
+    this.config.onSessionEvent?.(chatId, { kind: "turn_end", payload: { status: outcome.status } });
+    if (outcome.status === "success") {
+      this.sessionRuntimeMarkers.delete(chatId);
+    } else if (outcome.terminal) {
+      this.sessionRuntimeMarkers.set(chatId, "error");
+    }
+
     const batch = Array.isArray(messages) ? messages : [messages];
     let throughEntryId: number | undefined;
     for (const message of batch) {
@@ -1494,17 +1572,46 @@ export class SessionManager {
       if (message.inboxEntryId !== undefined) throughEntryId = message.inboxEntryId;
     }
     if (throughEntryId === undefined) {
-      this.config.log.warn({ chatId }, "attempt completion ignored because no inboxEntryId was provided");
+      if (batch.length > 0) {
+        this.config.log.warn({ chatId }, "attempt completion ignored because no inboxEntryId was provided");
+      }
+      this.recomputeSessionRuntimeState(chatId);
       return;
     }
-    this.ackThroughTrackedEntry(chatId, throughEntryId);
+
+    try {
+      await this.ackThroughTrackedEntryAfterServerAck(chatId, throughEntryId);
+    } finally {
+      this.recomputeSessionRuntimeState(chatId);
+    }
   }
 
-  private markMessagesRetryable(
-    chatId: string,
-    messages: SessionMessage | readonly SessionMessage[],
-    reason: string,
-  ): void {
+  private async ackThroughTrackedEntryAfterServerAck(chatId: string, throughEntryId: number): Promise<void> {
+    const queue = this.inFlightEntries.get(chatId);
+    if (!queue || queue.length === 0) return;
+    const index = queue.findIndex((tracked) => tracked.entryId === throughEntryId);
+    if (index < 0) {
+      this.config.log.warn({ chatId, throughEntryId }, "attempt completion ignored for untracked inbox entry");
+      return;
+    }
+
+    try {
+      await this.config.ackEntry(throughEntryId);
+    } catch (err) {
+      this.config.log.warn({ chatId, entryId: throughEntryId, err }, "ACK-through failed; leaving entry for recovery");
+      this.clearInFlightForRecovery(chatId, "ack_failed");
+      return;
+    }
+
+    const committed = queue.splice(0, index + 1);
+    for (const tracked of committed) {
+      this.deduplicator.drop(tracked.dedupKey);
+    }
+    if (queue.length === 0) this.inFlightEntries.delete(chatId);
+  }
+
+  private retryTurn(chatId: string, messages: SessionMessage | readonly SessionMessage[], reason: string): void {
+    this.config.onSessionEvent?.(chatId, { kind: "turn_end", payload: { status: "error" } });
     const batch = Array.isArray(messages) ? messages : [messages];
     const hasTrackedMessage = batch.some(
       (message) =>
@@ -1512,8 +1619,8 @@ export class SessionManager {
         message.inboxEntryId !== undefined &&
         (this.inFlightEntries.get(chatId) ?? []).some((entry) => entry.entryId === message.inboxEntryId),
     );
-    if (!hasTrackedMessage) return;
-    this.clearInFlightForRecovery(chatId, reason);
+    if (hasTrackedMessage) this.clearInFlightForRecovery(chatId, reason);
+    this.recomputeSessionRuntimeState(chatId);
   }
 
   /**
@@ -1522,7 +1629,7 @@ export class SessionManager {
    * entry is doomed) and on permanent `handler.start` / `handler.resume`
    * failure (re-handling on redelivery would re-hit the same permanent
    * error, so acking avoids a loop). NOT to be called from handlers — the
-   * per-turn pairing path is `markMessagesCompleted(messageOrBatch)`.
+   * per-turn pairing path is `finishTurn(messageOrBatch, outcome)`.
    */
   private drainAllInFlightEntries(chatId: string): void {
     const queue = this.inFlightEntries.get(chatId);
@@ -1608,30 +1715,25 @@ export class SessionManager {
       sdk: this.config.sdk,
       log,
       chatId,
-      touch: () => {
+      recordProviderActivity: () => {
         const entry = this.sessions.get(chatId);
         if (entry && entry.status === "active") {
           entry.lastActivity = Date.now();
+          this.recomputeSessionRuntimeState(chatId);
         }
-      },
-      setRuntimeState: (state) => {
-        this.setSessionRuntimeState(chatId, state);
       },
       emitEvent: (event) => {
         this.config.onSessionEvent?.(chatId, event);
       },
       forwardResult,
-      markCompleted: () => {
-        this.ackOldestTrackedEntry(chatId);
-      },
       markMessagesConsumed: (messages) => {
         this.markMessagesConsumed(chatId, messages);
       },
-      markMessagesCompleted: (messages) => {
-        this.markMessagesCompleted(chatId, messages);
+      finishTurn: (messages, outcome) => {
+        return this.finishTurn(chatId, messages, outcome);
       },
-      markMessagesRetryable: (messages, reason) => {
-        this.markMessagesRetryable(chatId, messages, reason);
+      retryTurn: (messages, reason) => {
+        this.retryTurn(chatId, messages, reason);
       },
       buildAgentEnv: (parentEnv) => buildAgentEnv(parentEnv, envCtx),
       formatInboundContent: (message) => formatInboundContent(message, participants),
@@ -1657,8 +1759,42 @@ export class SessionManager {
     }
   }
 
+  private hasDeliveryWork(chatId: string): boolean {
+    if ((this.inFlightEntries.get(chatId)?.length ?? 0) > 0) return true;
+    if (this.admissionQueues.has(chatId)) return true;
+    if (this.pendingQueue.some((entry) => entry.chatId === chatId)) return true;
+    if (this.requiresInboxRecovery.has(chatId)) return true;
+    if (this.recoveringChats.has(chatId)) return true;
+    const session = this.sessions.get(chatId);
+    if (session?.retryAttempt && session.retryAttempt > 0) return true;
+    if (session?.retryTimer || session?.retryNextAt) return true;
+    return false;
+  }
+
+  private isSessionQuiescent(chatId: string): boolean {
+    const session = this.sessions.get(chatId);
+    return Boolean(session && session.status === "active" && !session.suspending && !this.hasDeliveryWork(chatId));
+  }
+
+  private recomputeSessionRuntimeState(chatId: string): void {
+    const session = this.sessions.get(chatId);
+    if (!session || session.status !== "active") {
+      this.sessionRuntimeMarkers.delete(chatId);
+      if (this.sessionRuntimeStates.delete(chatId)) this.recomputeRuntimeState();
+      return;
+    }
+
+    const marker = this.sessionRuntimeMarkers.get(chatId);
+    const nextState: RuntimeState = marker ?? (this.hasDeliveryWork(chatId) ? "working" : "idle");
+    if (nextState === "idle" && !this.isSessionQuiescent(chatId)) {
+      this.reportSessionRuntimeState(chatId, "working");
+      return;
+    }
+    this.reportSessionRuntimeState(chatId, nextState);
+  }
+
   /** Update per-session runtime state and recompute aggregate. Only active sessions may update. */
-  private setSessionRuntimeState(chatId: string, state: RuntimeState): void {
+  private reportSessionRuntimeState(chatId: string, state: RuntimeState): void {
     const session = this.sessions.get(chatId);
     if (!session || session.status !== "active") return;
     this.sessionRuntimeStates.set(chatId, state);

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -895,6 +895,10 @@ export class SessionManager {
     if (entry.suspending) {
       await entry.suspending;
     }
+    if (this.requiresInboxRecovery.has(entry.chatId)) {
+      this.recomputeSessionRuntimeState(entry.chatId);
+      return;
+    }
 
     // For admin-triggered resume (no message), synthesize a minimal stub for slot acquisition only
     const slotMessage: SessionMessage = message ?? {
@@ -1301,7 +1305,7 @@ export class SessionManager {
   }
 
   private suspendSession(entry: SessionEntry): void {
-    this.ackConsumedInFlightForSuspend(entry.chatId);
+    const consumedAck = this.ackConsumedInFlightForSuspend(entry.chatId);
     this.clearUnconsumedInFlightForSuspend(entry.chatId);
     entry.status = "suspended";
     this._activeCount--;
@@ -1309,11 +1313,11 @@ export class SessionManager {
     this.sessionRuntimeStates.delete(entry.chatId);
     this.sessionRuntimeMarkers.delete(entry.chatId);
     this.recomputeRuntimeState();
-    entry.suspending = entry.handler
-      .suspend()
-      .catch((err) => {
-        this.config.log.warn({ chatId: entry.chatId, err }, "suspend error");
-      })
+    const handlerSuspend = entry.handler.suspend().catch((err) => {
+      this.config.log.warn({ chatId: entry.chatId, err }, "suspend error");
+    });
+    entry.suspending = Promise.all([handlerSuspend, consumedAck ?? Promise.resolve()])
+      .then(() => undefined)
       .finally(() => {
         entry.suspending = null;
       });
@@ -1535,19 +1539,19 @@ export class SessionManager {
     this.recomputeSessionRuntimeState(chatId);
   }
 
-  private ackConsumedInFlightForSuspend(chatId: string): void {
+  private ackConsumedInFlightForSuspend(chatId: string): Promise<void> | null {
     const queue = this.inFlightEntries.get(chatId);
-    if (!queue || queue.length === 0) return;
+    if (!queue || queue.length === 0) return null;
 
     let consumedPrefixCount = 0;
     for (const tracked of queue) {
       if (!tracked.consumed) break;
       consumedPrefixCount++;
     }
-    if (consumedPrefixCount === 0) return;
+    if (consumedPrefixCount === 0) return null;
 
     const lastConsumed = queue[consumedPrefixCount - 1];
-    if (lastConsumed) void this.ackThroughTrackedEntryAfterServerAck(chatId, lastConsumed.entryId);
+    return lastConsumed ? this.ackThroughTrackedEntryAfterServerAck(chatId, lastConsumed.entryId) : null;
   }
 
   private clearUnconsumedInFlightForSuspend(chatId: string): void {

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -1302,7 +1302,7 @@ export class SessionManager {
 
   private suspendSession(entry: SessionEntry): void {
     this.ackConsumedInFlightForSuspend(entry.chatId);
-    this.clearInFlightForRecovery(entry.chatId, "session_suspended_unconsumed_tail");
+    this.clearUnconsumedInFlightForSuspend(entry.chatId);
     entry.status = "suspended";
     this._activeCount--;
     // Clear per-session runtime state on suspend
@@ -1515,10 +1515,21 @@ export class SessionManager {
     const queue = this.inFlightEntries.get(chatId);
     if (!queue || queue.length === 0) return;
     this.inFlightEntries.delete(chatId);
-    this.deduplicator.dropByPrefix(`${chatId}:`);
+    this.markTrackedEntriesForRecovery(chatId, reason, queue);
+  }
+
+  private markTrackedEntriesForRecovery(
+    chatId: string,
+    reason: string,
+    entries: readonly { entryId: number; dedupKey: string }[],
+  ): void {
+    if (entries.length === 0) return;
+    for (const entry of entries) {
+      this.deduplicator.drop(entry.dedupKey);
+    }
     this.requiresInboxRecovery.add(chatId);
     this.config.log.warn(
-      { chatId, reason, entryIds: queue.map((entry) => entry.entryId) },
+      { chatId, reason, entryIds: entries.map((entry) => entry.entryId) },
       "cleared local in-flight inbox entries; waiting for recovery redelivery",
     );
     this.recomputeSessionRuntimeState(chatId);
@@ -1536,7 +1547,27 @@ export class SessionManager {
     if (consumedPrefixCount === 0) return;
 
     const lastConsumed = queue[consumedPrefixCount - 1];
-    if (lastConsumed) this.ackThroughTrackedEntry(chatId, lastConsumed.entryId);
+    if (lastConsumed) void this.ackThroughTrackedEntryAfterServerAck(chatId, lastConsumed.entryId);
+  }
+
+  private clearUnconsumedInFlightForSuspend(chatId: string): void {
+    const queue = this.inFlightEntries.get(chatId);
+    if (!queue || queue.length === 0) return;
+
+    let consumedPrefixCount = 0;
+    for (const tracked of queue) {
+      if (!tracked.consumed) break;
+      consumedPrefixCount++;
+    }
+
+    if (consumedPrefixCount === 0) {
+      this.clearInFlightForRecovery(chatId, "session_suspended_unconsumed_tail");
+      return;
+    }
+    if (consumedPrefixCount >= queue.length) return;
+
+    const unconsumedTail = queue.splice(consumedPrefixCount);
+    this.markTrackedEntriesForRecovery(chatId, "session_suspended_unconsumed_tail", unconsumedTail);
   }
 
   private markMessagesConsumed(chatId: string, messages: SessionMessage | readonly SessionMessage[]): void {

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -895,6 +895,10 @@ export class SessionManager {
     if (entry.suspending) {
       await entry.suspending;
     }
+    const currentEntry = this.sessions.get(entry.chatId);
+    if (currentEntry !== entry || (entry.status !== "suspended" && entry.status !== "evicted")) {
+      return;
+    }
     if (this.requiresInboxRecovery.has(entry.chatId)) {
       this.recomputeSessionRuntimeState(entry.chatId);
       return;

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -24,6 +24,7 @@ import type {
   HandlerFactory,
   SessionContext,
   SessionMessage,
+  SessionTurnOutcome,
 } from "./handler.js";
 import { isResumeUnavailableError } from "./handler.js";
 import { findImagePath, writeImage } from "./image-store.js";
@@ -1556,14 +1557,9 @@ export class SessionManager {
   private async finishTurn(
     chatId: string,
     messages: SessionMessage | readonly SessionMessage[],
-    outcome: { status: "success" | "error"; terminal?: boolean },
+    outcome: SessionTurnOutcome,
   ): Promise<void> {
-    this.config.onSessionEvent?.(chatId, { kind: "turn_end", payload: { status: outcome.status } });
-    if (outcome.status === "success") {
-      this.sessionRuntimeMarkers.delete(chatId);
-    } else if (outcome.terminal) {
-      this.sessionRuntimeMarkers.set(chatId, "error");
-    }
+    this.reportTurnOutcome(chatId, outcome);
 
     const batch = Array.isArray(messages) ? messages : [messages];
     let throughEntryId: number | undefined;
@@ -1610,8 +1606,22 @@ export class SessionManager {
     if (queue.length === 0) this.inFlightEntries.delete(chatId);
   }
 
-  private retryTurn(chatId: string, messages: SessionMessage | readonly SessionMessage[], reason: string): void {
-    this.config.onSessionEvent?.(chatId, { kind: "turn_end", payload: { status: "error" } });
+  private reportTurnOutcome(chatId: string, outcome: SessionTurnOutcome): void {
+    this.config.onSessionEvent?.(chatId, { kind: "turn_end", payload: { status: outcome.status } });
+    if (outcome.status === "success") {
+      this.sessionRuntimeMarkers.delete(chatId);
+    } else if (outcome.terminal) {
+      this.sessionRuntimeMarkers.set(chatId, "error");
+    }
+  }
+
+  private retryTurn(
+    chatId: string,
+    messages: SessionMessage | readonly SessionMessage[],
+    reason: string,
+    outcome: SessionTurnOutcome = { status: "error" },
+  ): void {
+    this.reportTurnOutcome(chatId, outcome);
     const batch = Array.isArray(messages) ? messages : [messages];
     const hasTrackedMessage = batch.some(
       (message) =>
@@ -1732,8 +1742,8 @@ export class SessionManager {
       finishTurn: (messages, outcome) => {
         return this.finishTurn(chatId, messages, outcome);
       },
-      retryTurn: (messages, reason) => {
-        this.retryTurn(chatId, messages, reason);
+      retryTurn: (messages, reason, outcome) => {
+        this.retryTurn(chatId, messages, reason, outcome);
       },
       buildAgentEnv: (parentEnv) => buildAgentEnv(parentEnv, envCtx),
       formatInboundContent: (message) => formatInboundContent(message, participants),

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -795,10 +795,7 @@ export class SessionManager {
     if (existing) {
       switch (existing.status) {
         case "active":
-          existing.handler.inject(message);
-          existing.lastActivity = Date.now();
-          this.recomputeSessionRuntimeState(chatId);
-          this.config.log.debug({ chatId }, "message injected");
+          this.injectIntoActiveSession(existing, message);
           return;
 
         case "suspended":
@@ -896,7 +893,14 @@ export class SessionManager {
       await entry.suspending;
     }
     const currentEntry = this.sessions.get(entry.chatId);
-    if (currentEntry !== entry || (entry.status !== "suspended" && entry.status !== "evicted")) {
+    if (currentEntry !== entry) {
+      return;
+    }
+    if (entry.status === "active") {
+      if (message) this.injectIntoActiveSession(entry, message);
+      return;
+    }
+    if (entry.status !== "suspended" && entry.status !== "evicted") {
       return;
     }
     if (this.requiresInboxRecovery.has(entry.chatId)) {
@@ -975,6 +979,13 @@ export class SessionManager {
       if (!isResumeUnavailableError(err)) throw err;
       return this.replaceProviderSession(entry, message, previousSessionId, err.reason, err.message, ctx);
     }
+  }
+
+  private injectIntoActiveSession(entry: SessionEntry, message: SessionMessage): void {
+    entry.handler.inject(message);
+    entry.lastActivity = Date.now();
+    this.recomputeSessionRuntimeState(entry.chatId);
+    this.config.log.debug({ chatId: entry.chatId }, "message injected");
   }
 
   private async replaceProviderSession(


### PR DESCRIPTION
## Summary
- Move session turn completion, ACK-through, in-flight cleanup, runtime recompute, and resume replacement decisions behind `SessionManager` APIs.
- Migrate Claude Code, Codex, and Claude TUI handlers off direct runtime state setters / no-arg completion into concrete `recordProviderActivity`, `finishTurn`, and `retryTurn` lifecycle reporting.
- Preserve provider-session continuity across daemon restart + Context Tree HEAD drift by routing persisted/evicted mappings through `resume(oldProviderSessionId)`; typed resume-unavailable reasons are the only path to explicit replacement.
- Add handler-side `ProviderBootstrap` shared prep for agent home/cwd, chat context, source repos, resource skills, briefing, provider payload/env, and diagnostic drift facts without ACK/state/recovery/turn_end/session replacement side effects.
- Preserve no-ACK TUI turn outcomes: timeout reports terminal runtime error while staying unacked for recovery; suspend/abort reports `turn_end:success` instead of being forced to error.
- Make suspend consumed-prefix ACK recovery-safe: consumed entries stay locally tracked until the ACK result; ACK reject marks the chat for recovery instead of forgetting delivered work; resume/new input waits for pending suspend ACK to settle before entering the handler.
- Guard post-suspend resume against stale session entries after terminate/evict races, while later same-chat waiters that see the same session already active are injected instead of dropped.
- Record explicit `transcript_missing`, `provider_resume_rejected`, and `local_session_artifact_missing` replacement reasons without treating tree/CLI drift as replacement.

## Context Tree
- Contract update PR: https://github.com/agent-team-foundation/first-tree-context/pull/467

Fixes #919.

## Validation
- `pnpm --filter @first-tree/client typecheck`
- `pnpm --filter @first-tree/client exec vitest run --maxWorkers=2 --minWorkers=1 src/__tests__/session-manager.test.ts` (1 file / 38 tests)
- `pnpm --filter @first-tree/client exec vitest run --maxWorkers=2 --minWorkers=1 src/__tests__/agent-cwd-redesign.e2e.test.ts src/__tests__/claude-code-inject-startup-race.test.ts src/__tests__/claude-code-result-forward-fail.test.ts src/__tests__/claude-code-sdk-options.test.ts src/__tests__/claude-code-stream-error-retry-replay.test.ts src/__tests__/claude-code-turn-end-auto-resume-fail.test.ts src/__tests__/claude-code-turn-end-retry-exhausted.test.ts src/__tests__/claude-code-turn-end-sdk-error.test.ts src/__tests__/claude-code-turn-end-serialization.test.ts src/__tests__/claude-code-turn-end.test.ts src/__tests__/codex-inject-startup-race.test.ts src/__tests__/codex-retry-abort.test.ts src/__tests__/gitrepos-session-integration.test.ts src/__tests__/provider-bootstrap.test.ts src/__tests__/session-manager-edge-coverage.test.ts src/__tests__/session-manager.test.ts src/__tests__/session-runtime-state.test.ts src/__tests__/session-state-notifications.test.ts src/__tests__/tui-turn-disposition.test.ts` (19 files / 137 tests)
- `pnpm check` (passes with existing unrelated info/warning in `prompt-tab.tsx` and `workspace-migrations.ts`)
- `pnpm typecheck` (11 successful)
- `rg -n "setRuntimeState|markCompleted|markMessagesCompleted|markMessagesRetryable|touch\(\)|\.touch\b" packages/client/src -g '*.ts'` (no matches)
- `git diff --check`
