### PR TITLE
feat(onboarding): seed Context Tree from source repos at kickoff

### DIFF
--- a/docs/development/onboarding-context-tree-seed-design.md
+++ b/docs/development/onboarding-context-tree-seed-design.md
@@ -1,0 +1,246 @@
+# Onboarding → build Context Tree from source repos (design)
+
+Status: proposed · Date: 2026-06-10 · Depends on: PR #923 (`feat/context-tree-initializer`), enabled-by PR #925 (W1 tree verify on clean checkouts)
+
+## 1. Goal
+
+After a user creates their first agent during onboarding, the **new-tree**
+path should actually result in a Context Tree that is **seeded from the bound
+source repos** by that agent, using the `first-tree-seed` skill — asynchronously,
+without blocking the agent from handling other chats, and as a natural part of
+onboarding (the user does not babysit it).
+
+## 2. Current state (verified in code)
+
+The onboarding kickoff already *intends* this, but the new-tree path is broken
+end to end. Three concrete gaps:
+
+- **断点1 — WITHDRAWN after implementation review.** The original concern
+  ("`runKickoff` drops `gitRepoUrls`, so sources never materialize") was based on
+  the stale "gitRepos lives in agent config" model. In the current code: (a) the
+  config PATCH endpoint **rejects** writing `gitRepos`
+  (`config-service.ts` → `legacy_resource_config_disabled`); (b) the runtime
+  `gitRepos` is **derived** from the agent's *effective resources*
+  (`resources.ts` `resolveRuntimeConfig`), and a `recommended` **team** repo
+  resource is `mode:"enabled"` for every org runtime agent by default; (c)
+  `runKickoff` **already** creates the admin's selected repos as `recommended`
+  team resources (the `orgWrites` block). So the admin new-tree agent's sources
+  already flow → `prepareSourceRepos` materializes them, and creating those
+  resources bumps the config version so the kickoff message refreshes the client
+  config. **No gitRepos wiring is needed.** Residual gap: the invitee *picker*
+  sub-state (invitee's own repos, never turned into resources) — an edge path,
+  unrelated to new-tree seed; **deferred**, noted in the PR.
+
+- **断点2 — on the new-tree path the seed skill is neither installed, surfaced,
+  nor allowed.** The First-Tree family skills (incl. `first-tree-seed`) install
+  and appear in the briefing **only when `contextTreePath !== null`**
+  (`agent-briefing.ts:503`, `agent-bootstrap.ts:187`). A brand-new tree has no
+  `org.context_tree` setting yet → `contextTreePath` is null → the agent is told
+  *"binding a tree is an operator action, surface to a human"*
+  (`agent-briefing.ts:475`). The kickoff prose also names a non-existent
+  "first-tree onboarding skill" (`bootstrap-prose.ts`).
+
+- **断点3 — seed assumes Cloud provisioned first; cloud layout doesn't match
+  W1.** `first-tree-seed` refuses unless `.first-tree/workspace.json`
+  (`{ tree, sources }`) exists, the tree is empty, and all sources are on disk
+  (`skills/first-tree-seed/SKILL.md` self-check). In cloud the tree is cloned to
+  a **separate** dir (`context-tree-repos/<hash>/`, not a workspace sibling),
+  sources live under the agent home, and **no `.first-tree/workspace.json` is
+  ever written** (only the local CLI `migrate-workspace` writes it).
+
+Async note: a single agent already runs up to **5 concurrent sessions**
+(`runtime/config.ts`), per-chat isolated, with "working" state protected up to
+65 min. The seed task runs in the kickoff chat's own session; other chats stay
+responsive. Onboarding itself does not block — kickoff stamps `completed`
+right after sending the message. **No new background-task system is needed.**
+
+## 3. Dependency: PR #923 (Cloud provisioning primitive)
+
+`POST /api/v1/orgs/:orgId/context-tree/initialize` (admin-only) creates a
+private GitHub repo via the **GitHub App ORG installation token**
+(`POST /orgs/{org}/repos` — `createOrganizationRepo`), writes a **title-only
+root `NODE.md`** (deliberately within `first-tree-seed`'s "placeholder root
+counts as empty" carve-out), and persists `org.context_tree = { repo,
+branch:"main" }`. Surfaced today only in Settings and `/context` unavailable
+state — **not** wired into onboarding.
+
+> Correction (verified against the *merged* #923, which changed after the
+> initial review): the repo is created through the **org installation token**,
+> not the signed-in user's OAuth token. The endpoint hard-requires an
+> **Organization** installation with `repositorySelection: "all"` and the App's
+> `Administration: write` + `Contents: write` repository permissions, and
+> returns distinct status codes when those aren't met:
+> - `409 organization_installation_required` — installation is a personal/User
+>   account (so **personal-account users cannot use one-click new-tree** — a
+>   real constraint of the Cloud-provision choice);
+> - `409 selected_repositories_unsupported` — installed on selected repos only;
+> - `403 installation_permissions_insufficient` — missing admin/contents write;
+> - `503 no_installation` — no installation connected;
+> - `409 ConflictError` — `org.context_tree` already set.
+
+This resolves the architecture fork: **Cloud provisions the empty tree repo +
+org binding; the agent seeds content.** This task builds on #923; it does not
+add agent-driven repo creation.
+
+## 4. Decisions (confirmed with owner)
+
+1. **Cloud-provisions, single path** (build on #923). Agent-driven repo
+   creation (the "variant G" host-`gh` fallback) is **dropped** — onboarding
+   always provisions via `POST …/context-tree/initialize`. Owner accepted the
+   external-customer trade-off this implies (see O3 below): the shared GitHub
+   App must hold repo **Administration: write**, which every customer authorizes.
+2. **Gap④ = Option A:** the cloud runtime makes the agent home a real W1
+   workspace and writes `.first-tree/workspace.json`, so the skills stay
+   layout-agnostic (no per-skill cloud branch, seed's self-check stays a real
+   guard). The tree is exposed as a **sibling symlink** under the agent home
+   pointing at the shared external clone, preserving the cross-agent dedup
+   sharing.
+3. **Timing = lazy re-resolution**, implemented at a single point in
+   `SessionManager` (not the kickoff-UX reordering alternative). See §5.3.
+
+## 5. Design
+
+### 5.1 Web / onboarding
+
+- **No gitRepos write (断点1 withdrawn).** Sources already flow to the admin
+  agent via the `recommended` team repo resources `runKickoff` creates; the
+  config PATCH would reject a `gitRepos` write anyway. See §2.
+- **Provision the tree for new-tree mode.** Call `provisionNewTree(orgId)` in
+  `runKickoff`, gated on `treeMode === "new" && orgWrites?.organizationId`,
+  BEFORE the chat is created. The helper calls `initializeContextTree` and, on a
+  409, **discriminates by actual binding state** — not the status code, since
+  the "already configured" `ConflictError` carries no discriminating `code`: if
+  a tree now exists (`getContextTreeSetting().repo`), provisioning effectively
+  succeeded → proceed; otherwise re-throw. This correctly handles BOTH the
+  genuinely-already-provisioned case (detect→create race, or a retry after a
+  later kickoff step failed — no confusing dead-end) AND the merged endpoint's
+  other 409s (`organization_installation_required` /
+  `selected_repositories_unsupported` mean *no tree was created* → re-throw the
+  actionable error). Every non-409 error (e.g. `403`) propagates unchanged;
+  nothing is half-created on failure (no chat yet). `AdminKickoff` also
+  auto-detects an existing `context_tree` at form time and switches to the bind
+  path, so this only fires when no tree was detected. *(Review-evolved: the
+  initial draft swallowed all 409s, then re-threw all 409s; the state-check is
+  the correct middle ground.)*
+- **Fix BOTH kickoff prose builders (`bootstrap-prose.ts`).**
+  - *New-tree* (`buildCreateBootstrap`): point the agent at `first-tree-seed`,
+    framed as *"the tree repo is already provisioned — read your tree, then seed
+    it from the bound source repos"* (drop "create the GitHub repo yourself /
+    record the URL on the Hub").
+  - *Bind / existing-tree* (`buildBindBootstrap`, O1): the W1 binding
+    (`workspace.json`) is now written automatically by the runtime, so the agent
+    no longer "binds the repo + opens a PR back to source." Its task reduces to
+    *read the tree (`first-tree-context`) and, if warranted, reflect the new
+    source into it.* Remove the manual-bind framing and the non-existent
+    "first-tree onboarding skill" name.
+  - 409 from `initialize` (tree already exists) is treated as success (O4);
+    `AdminKickoff` already auto-detects an existing tree and switches to the
+    bind path, so `initialize` only fires in new-mode with no existing tree.
+
+### 5.2 Client runtime (Option A: W1 conformance + workspace.json)
+
+Centralize in `ensureAgentBootstrap` (already per-session, already holds
+`contextTreePath` + `currentSourceRepoNames`):
+
+- When `contextTreePath !== null`:
+  1. Ensure a stable sibling symlink `<workspace>/<TREE_DIR>` → `contextTreePath`
+     (`TREE_DIR` = a fixed reserved name, e.g. `context-tree`; guard against
+     collision with a source `localPath` of the same name).
+  2. Write `<workspace>/.first-tree/workspace.json` =
+     `{ tree: TREE_DIR, sources: [...currentSourceRepoNames] }`, validated with
+     `workspaceManifestSchema` from `@first-tree/shared`. Idempotent — rewrite
+     when tree/sources change.
+- Reuse the shared schema + `WORKSPACE_MANIFEST_FILENAME` /
+  `WORKSPACE_STATE_DIRNAME` constants; the client writes the file itself (it
+  can't import the CLI's `writeWorkspaceManifest`).
+- This is consistent with the codebase already treating `<agentHome>/.first-tree/`
+  as active W1 state (see the withdrawn `v1-legacy-dot-first-tree` migration
+  note in `workspace-migrations.ts`).
+
+### 5.3 Timing — lazy re-resolution of an unbound tree
+
+`contextTreeBinding` is resolved **once** at `AgentSlot.start()` and frozen into
+`handlerConfig.contextTreePath`. A new tree set *after* the slot starts (the
+onboarding case) is otherwise never picked up until a daemon restart.
+
+Fix (corrected after review): **re-resolve at a single point in
+`SessionManager.startNewSession`, before building `handlerCfg`** — not in each
+handler (E1: `contextTreePath` is a per-handler const read at construction
+[claude-code.ts:1372], and handlers are built per session, so patching
+`this.config.handlerConfig` upgrades all three handlers for free). When
+`handlerConfig.contextTreePath` is null, call `syncAgentContextTree(sdk)` (cheap:
+dedup lock + clone cache) and **patch all three fields together**
+(`contextTreePath` + `contextTreeRepoUrl` + `contextTreeBranch`, E2 — the
+tree-write path uses `repoUrl`). Gate on "currently null" so the steady-state
+path is untouched; the upgrade is monotonic and sticky for the slot's life.
+
+The null→bound upgrade then **automatically** drives skill install + manifest
+write: `ensureAgentBootstrap`'s existing `integrationNeverPinned` trigger
+([agent-bootstrap.ts:150], G1) forces the full bootstrap whenever a
+previously-tree-less agent first sees a non-null `contextTreePath` — no new
+trigger condition needed.
+
+Result for new-tree onboarding: kickoff sets `gitRepos` + provisions the tree +
+sends the seed message → the kickoff message starts a session → config refresh
+materializes sources, the now-non-null tree binding is resolved, family skills
+install, briefing lists `first-tree-seed`, workspace.json is written → seed's
+self-check (workspace.json present, tree empty placeholder, sources on disk)
+passes → seed runs.
+
+### 5.4 Async / non-blocking
+
+No new machinery. Seed runs in the kickoff chat's session; the existing
+5-concurrency + per-chat isolation keeps the agent responsive in other chats;
+per-chat runtime state already lets the UI show "working" on that chat.
+
+## 6. Out of scope (explicit)
+
+- Server-side GitHub-App repo creation (Option B heavy path) — #923's user-OAuth
+  approach supersedes it.
+- A tree-destination picker UI (choose repo owner/name in onboarding) — future
+  polish; #923 names the repo after the team.
+- Rewriting `first-tree-seed`'s phased workflow — only the trigger preconditions
+  are now satisfiable; the skill body is unchanged.
+
+## 7. Testing
+
+- **Web:** unit tests that `runKickoff` (new-tree) calls `updateAgentConfig`
+  with the selected repos and `initialize` before sending the bootstrap; prose
+  builder snapshot updates. UI test of the kickoff step states via the
+  onboarding preview gallery.
+- **Client runtime:** unit tests for the workspace.json writer + tree symlink
+  (idempotent, collision guard, schema-valid) and for lazy re-resolution
+  (null → bound upgrade installs skills + writes manifest; already-bound path
+  unchanged). Cross-check the family-skill list test still passes.
+- **Server:** rely on #923's initialize tests; add coverage only if we touch the
+  endpoint.
+- `pnpm check && pnpm typecheck && pnpm test`.
+
+## 8. Open items / risks
+
+- **O3 — GitHub App ORG-installation prerequisites (deployment-gated).** Because
+  the merged endpoint creates the repo with the **org installation token** (see
+  §3 correction), the prerequisites are on the installation, not a user OAuth
+  token:
+  - the App's repository permissions must include **`Administration: write`**
+    (governs repo creation) **and `Contents: write`** (to write the root
+    `NODE.md`) — owner reports Administration was set to write ✅; **verify
+    `Contents: write` too**;
+  - the team must install the App on a GitHub **Organization** with
+    **all repositories** (not a personal account, not selected repos);
+  - existing installations are re-prompted to accept new permissions; the change
+    applies to future installs.
+  #923's unit tests inject a mock `fetcher`, so green CI does NOT prove the live
+  App can create repos — **smoke-test the real flow** (org install, all repos)
+  and confirm a 201 + real private repo before relying on it. **Known
+  constraint:** personal-account users get `409 organization_installation_required`
+  and cannot use one-click new-tree — the kickoff now surfaces that actionable
+  error (re-throw) instead of silently sending a broken seed message.
+- **O2 — provider:** `first-tree-seed` is a Claude-Code-shaped skill; onboarding
+  picks `runtimeProvider` (claude-code preferred, else codex). This PR validates
+  the claude-code path; codex seeding is out of scope / flagged, not assumed.
+- **Dependency #923 must merge (or base on its head).** Branch strategy: base on
+  #923's head so the full flow is locally testable; rebase onto main when #923
+  merges.
+- **TREE_DIR naming / symlink portability** across the handlers' cwd
+  conventions — covered by tests.

--- a/packages/client/src/__tests__/agent-bootstrap.test.ts
+++ b/packages/client/src/__tests__/agent-bootstrap.test.ts
@@ -106,6 +106,46 @@ describe("ensureAgentBootstrap — integration retry gate", () => {
     expect(installFirstTreeIntegration).toHaveBeenCalledTimes(2);
   });
 
+  it("a tree-less session leaves the CLI pin unset so a later tree-bound session still installs skills", () => {
+    // Regression: a tree-less session used to pin the CLI version (because
+    // `integrationOk` defaults to true even when integration is skipped),
+    // which defeated `integrationNeverPinned` and made the eventual tree-bound
+    // upgrade (new-tree onboarding) take the fast path and never install
+    // `first-tree-seed`.
+    vi.mocked(installFirstTreeIntegration).mockReturnValue(true);
+    const sentinel = join(workspace, INIT_COMPLETE_SENTINEL_REL);
+    rmSync(sentinel, { force: true }); // start sentinel-absent → slow path
+
+    // Session 1: tree-less slow path. Integration is skipped (no tree) and —
+    // post-fix — the CLI version must NOT be pinned.
+    ensureAgentBootstrap({
+      workspace,
+      sessionCtx: fakeSessionCtx(),
+      contextTreePath: null,
+      briefing: "# Agent Identity\n\nstub briefing\n",
+      currentSourceRepoNames: null,
+    });
+    expect(installFirstTreeIntegration).not.toHaveBeenCalled();
+    expect(state.cachedCli).toBeNull();
+
+    // Simulate the completed session having written the init-complete sentinel.
+    mkdirSync(dirname(sentinel), { recursive: true });
+    writeFileSync(sentinel, "1", "utf-8");
+
+    // Session 2: the org tree now exists → tree-bound. Sentinel is present, but
+    // because the tree-less session never pinned the CLI version,
+    // `integrationNeverPinned` fires and the slow path installs the skills.
+    ensureAgentBootstrap({
+      workspace,
+      sessionCtx: fakeSessionCtx(),
+      contextTreePath: "/tree",
+      briefing: "# Agent Identity\n\nstub briefing\n",
+      currentSourceRepoNames: null,
+    });
+    expect(installFirstTreeIntegration).toHaveBeenCalledTimes(1);
+    expect(state.cachedCli).toBe("1.0.0");
+  });
+
   it("non-tree agents take the fast path on the sentinel (no integration gate)", () => {
     const params = {
       workspace,

--- a/packages/client/src/__tests__/context-tree-rebind.test.ts
+++ b/packages/client/src/__tests__/context-tree-rebind.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from "vitest";
+import { reresolveUnboundTree } from "../runtime/context-tree-rebind.js";
+
+const BINDING = { path: "/clones/abc", repoUrl: "https://github.com/acme/ct", branch: "main" };
+
+describe("reresolveUnboundTree", () => {
+  it("re-resolves when currently unbound (undefined path)", async () => {
+    expect(await reresolveUnboundTree(undefined, async () => BINDING)).toEqual(BINDING);
+  });
+
+  it("treats an empty-string path as unbound and re-resolves", async () => {
+    expect(await reresolveUnboundTree("", async () => BINDING)).toEqual(BINDING);
+  });
+
+  it("does NOT re-resolve when already bound (steady state untouched)", async () => {
+    const resolve = vi.fn();
+    expect(await reresolveUnboundTree("/already/bound", resolve)).toBeNull();
+    expect(resolve).not.toHaveBeenCalled();
+  });
+
+  it("returns null when the org has no tree configured yet", async () => {
+    expect(await reresolveUnboundTree(undefined, async () => null)).toBeNull();
+  });
+
+  it("swallows a resolver failure and returns null (session starts unbound)", async () => {
+    expect(
+      await reresolveUnboundTree(undefined, async () => {
+        throw new Error("network down");
+      }),
+    ).toBeNull();
+  });
+});

--- a/packages/client/src/__tests__/session-manager.test.ts
+++ b/packages/client/src/__tests__/session-manager.test.ts
@@ -2,7 +2,8 @@ import type { AgentRuntimeConfig } from "@first-tree/shared";
 import type pino from "pino";
 import { describe, expect, it, vi } from "vitest";
 import type { AgentConfigCache } from "../runtime/agent-config-cache.js";
-import type { AgentHandler, HandlerFactory, SessionContext } from "../runtime/handler.js";
+import type { ContextTreeBinding } from "../runtime/bootstrap.js";
+import type { AgentHandler, HandlerConfig, HandlerFactory, SessionContext } from "../runtime/handler.js";
 import { SessionManager } from "../runtime/session-manager.js";
 import type { FirstTreeHubSDK } from "../sdk.js";
 import { recordingLogger, silentLogger } from "./_logger-helpers.js";
@@ -45,6 +46,9 @@ function createMockHandler(overrides?: Partial<AgentHandler>): AgentHandler {
 function createSessionManager(opts: {
   sdk?: FirstTreeHubSDK;
   handler?: AgentHandler;
+  handlerConfig?: HandlerConfig;
+  handlerFactory?: HandlerFactory;
+  resolveContextTreeBinding?: () => Promise<ContextTreeBinding | null>;
   ackEntry?: (entryId: number) => Promise<void>;
   session?: {
     idle_timeout: number;
@@ -58,7 +62,7 @@ function createSessionManager(opts: {
   recoverChat?: (chatId: string) => Promise<void>;
 }) {
   const handler = opts.handler ?? createMockHandler();
-  const factory: HandlerFactory = () => handler;
+  const factory: HandlerFactory = opts.handlerFactory ?? (() => handler);
   const sdk = opts.sdk ?? mockSdk();
 
   return new SessionManager({
@@ -70,7 +74,10 @@ function createSessionManager(opts: {
     },
     concurrency: opts.concurrency ?? 5,
     handlerFactory: factory,
-    handlerConfig: { workspaceRoot: "/tmp/test" },
+    handlerConfig: opts.handlerConfig ?? { workspaceRoot: "/tmp/test" },
+    // Tests never want the live git-backed resolver — default to a no-op so a
+    // tree-less handlerConfig stays tree-less unless a test opts in.
+    resolveContextTreeBinding: opts.resolveContextTreeBinding ?? (async () => null),
     agentIdentity: {
       agentId: "agent-1",
       inboxId: "inbox-agent-1",
@@ -1191,6 +1198,64 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     await sm.handleCommand("chat-term", "session:terminate");
     await Promise.resolve();
     expect(ackEntry).toHaveBeenCalledWith(11);
+
+    await sm.shutdown();
+  });
+});
+
+describe("SessionManager lazy Context Tree binding", () => {
+  const BINDING: ContextTreeBinding = {
+    path: "/clones/abc",
+    repoUrl: "https://github.com/acme/context-tree",
+    branch: "main",
+  };
+
+  it("upgrades a tree-less handler config to tree-bound on a new session", async () => {
+    const handlerConfig: HandlerConfig = { workspaceRoot: "/tmp/test" };
+    let builtWith: HandlerConfig | undefined;
+    const sm = createSessionManager({
+      handlerConfig,
+      handlerFactory: (cfg) => {
+        builtWith = cfg;
+        return createMockHandler();
+      },
+      resolveContextTreeBinding: async () => BINDING,
+    });
+
+    await sm.dispatch(mockEntry({ id: 1, chatId: "c-bind", messageId: "m1" }));
+
+    // Patched in place...
+    expect(handlerConfig.contextTreePath).toBe("/clones/abc");
+    expect(handlerConfig.contextTreeRepoUrl).toBe("https://github.com/acme/context-tree");
+    expect(handlerConfig.contextTreeBranch).toBe("main");
+    // ...so the handler for the new session is built tree-bound.
+    expect(builtWith?.contextTreePath).toBe("/clones/abc");
+
+    await sm.shutdown();
+  });
+
+  it("does not re-resolve when already bound (steady state pays nothing)", async () => {
+    const resolve = vi.fn(async () => BINDING);
+    const handlerConfig: HandlerConfig = { workspaceRoot: "/tmp/test", contextTreePath: "/already/bound" };
+    const sm = createSessionManager({ handlerConfig, resolveContextTreeBinding: resolve });
+
+    await sm.dispatch(mockEntry({ id: 1, chatId: "c-bound", messageId: "m1" }));
+
+    expect(resolve).not.toHaveBeenCalled();
+    expect(handlerConfig.contextTreePath).toBe("/already/bound");
+
+    await sm.shutdown();
+  });
+
+  it("re-resolves once for the new session, not again for a same-chat inject", async () => {
+    const resolve = vi.fn(async () => null);
+    const handlerConfig: HandlerConfig = { workspaceRoot: "/tmp/test" };
+    const sm = createSessionManager({ handlerConfig, resolveContextTreeBinding: resolve });
+
+    await sm.dispatch(mockEntry({ id: 1, chatId: "c-once", messageId: "m1" }));
+    await sm.dispatch(mockEntry({ id: 2, chatId: "c-once", messageId: "m2" }));
+
+    expect(resolve).toHaveBeenCalledTimes(1);
 
     await sm.shutdown();
   });

--- a/packages/client/src/__tests__/workspace-manifest.test.ts
+++ b/packages/client/src/__tests__/workspace-manifest.test.ts
@@ -1,0 +1,101 @@
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readlinkSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { CONTEXT_TREE_LINK_DIRNAME, ensureWorkspaceManifest } from "../runtime/workspace-manifest.js";
+
+describe("ensureWorkspaceManifest", () => {
+  let ws: string;
+  let tree: string;
+
+  beforeEach(() => {
+    ws = mkdtempSync(join(tmpdir(), "ft-ws-"));
+    tree = mkdtempSync(join(tmpdir(), "ft-tree-"));
+  });
+  afterEach(() => {
+    rmSync(ws, { recursive: true, force: true });
+    rmSync(tree, { recursive: true, force: true });
+  });
+
+  const manifestPath = () => join(ws, ".first-tree", "workspace.json");
+  const linkPath = () => join(ws, CONTEXT_TREE_LINK_DIRNAME);
+
+  it("writes .first-tree/workspace.json naming the tree link + sources", () => {
+    ensureWorkspaceManifest(ws, tree, ["app", "api"]);
+    expect(existsSync(manifestPath())).toBe(true);
+    expect(JSON.parse(readFileSync(manifestPath(), "utf-8"))).toEqual({
+      tree: CONTEXT_TREE_LINK_DIRNAME,
+      sources: ["app", "api"],
+    });
+  });
+
+  it("exposes the external tree clone as a sibling symlink", () => {
+    ensureWorkspaceManifest(ws, tree, ["app"]);
+    expect(lstatSync(linkPath()).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(linkPath())).toBe(tree);
+  });
+
+  it("is idempotent across repeated calls", () => {
+    ensureWorkspaceManifest(ws, tree, ["app"]);
+    expect(() => ensureWorkspaceManifest(ws, tree, ["app"])).not.toThrow();
+    expect(readlinkSync(linkPath())).toBe(tree);
+    expect(JSON.parse(readFileSync(manifestPath(), "utf-8")).tree).toBe(CONTEXT_TREE_LINK_DIRNAME);
+  });
+
+  it("repoints the symlink when the tree clone path changes (rebind)", () => {
+    ensureWorkspaceManifest(ws, tree, ["app"]);
+    const tree2 = mkdtempSync(join(tmpdir(), "ft-tree2-"));
+    try {
+      ensureWorkspaceManifest(ws, tree2, ["app"]);
+      expect(readlinkSync(linkPath())).toBe(tree2);
+    } finally {
+      rmSync(tree2, { recursive: true, force: true });
+    }
+  });
+
+  it("never clobbers a real source dir colliding with the link name, and writes no manifest", () => {
+    // A source repo literally named `context-tree` is already checked out.
+    mkdirSync(linkPath());
+    writeFileSync(join(linkPath(), "code.ts"), "x", "utf-8");
+    ensureWorkspaceManifest(ws, tree, [CONTEXT_TREE_LINK_DIRNAME]);
+    expect(lstatSync(linkPath()).isDirectory()).toBe(true);
+    expect(existsSync(join(linkPath(), "code.ts"))).toBe(true);
+    // Refused to write a manifest that would put the tree name into `sources`.
+    expect(existsSync(manifestPath())).toBe(false);
+  });
+
+  it("writes a valid manifest with no sources (tree-bound agent, no repos)", () => {
+    ensureWorkspaceManifest(ws, tree, []);
+    expect(JSON.parse(readFileSync(manifestPath(), "utf-8"))).toEqual({
+      tree: CONTEXT_TREE_LINK_DIRNAME,
+      sources: [],
+    });
+  });
+
+  it("drops a source with a nested localPath instead of dropping the whole manifest", () => {
+    ensureWorkspaceManifest(ws, tree, ["app", "nested/path", "api"]);
+    // The valid sources still bind; the nested one is omitted (still on disk).
+    expect(JSON.parse(readFileSync(manifestPath(), "utf-8"))).toEqual({
+      tree: CONTEXT_TREE_LINK_DIRNAME,
+      sources: ["app", "api"],
+    });
+    expect(lstatSync(linkPath()).isSymbolicLink()).toBe(true);
+  });
+
+  it("refuses to write a manifest when a real (non-symlink) dir occupies the link path", () => {
+    // A leftover real dir at the link path (not a declared source).
+    mkdirSync(linkPath());
+    ensureWorkspaceManifest(ws, tree, ["app"]);
+    expect(lstatSync(linkPath()).isDirectory()).toBe(true); // not clobbered
+    expect(existsSync(manifestPath())).toBe(false); // tree not linked → no manifest
+  });
+});

--- a/packages/client/src/runtime/agent-bootstrap.ts
+++ b/packages/client/src/runtime/agent-bootstrap.ts
@@ -16,6 +16,7 @@ import {
 } from "./bootstrap.js";
 import type { SessionContext } from "./handler.js";
 import { INIT_COMPLETE_SENTINEL_REL } from "./workspace.js";
+import { ensureWorkspaceManifest } from "./workspace-manifest.js";
 import { applyPendingMigrations } from "./workspace-migrations.js";
 
 export type AgentBootstrapParams = {
@@ -118,6 +119,17 @@ export function ensureAgentBootstrap(params: AgentBootstrapParams): void {
   // (PR #869 baixiaohang round-3 P0).
   applyPendingMigrations(workspace, sessionCtx.log, { currentSourceRepoNames });
 
+  // Make this a valid W1 workspace for the shipped First Tree skills: expose the
+  // (external, cross-agent-shared) Context Tree clone as a sibling symlink and
+  // write `<workspace>/.first-tree/workspace.json` naming the tree + bound
+  // sources. Runs every session (cheap + idempotent) so the manifest tracks
+  // source-repo changes. Gated on BOTH a resolved tree binding and a resolved
+  // source set — a null source set (cache miss) would write a manifest that
+  // falsely claims zero sources, which `first-tree-seed`'s self-check reads.
+  if (contextTreePath !== null && currentSourceRepoNames !== null) {
+    ensureWorkspaceManifest(workspace, contextTreePath, [...currentSourceRepoNames], sessionCtx.log);
+  }
+
   const sentinelPresent = existsSync(join(workspace, INIT_COMPLETE_SENTINEL_REL));
   const currentTreeHead = readContextTreeHead(contextTreePath);
   const cachedTreeHead = readCachedContextTreeHead(workspace);
@@ -193,9 +205,15 @@ export function ensureAgentBootstrap(params: AgentBootstrapParams): void {
 
   // Pin the current HEAD so the next start can detect drift.
   writeContextTreeHead(workspace, currentTreeHead);
-  // Only pin the CLI version when integrate actually succeeded — pinning on a
-  // failed run would mask the gap and skip the retry this trigger exists for.
-  if (integrationOk) {
+  // Only pin the CLI version when integration ACTUALLY RAN and succeeded —
+  // i.e. the agent is tree-bound. A tree-less session skips
+  // `installFirstTreeIntegration` (so no skills land) but `integrationOk` stays
+  // `true`; pinning here would set `cachedCliVersion` non-null, which then
+  // defeats the `integrationNeverPinned` trigger when the agent later becomes
+  // tree-bound (new-tree onboarding) — `ensureAgentBootstrap` would take the
+  // fast path and never install `first-tree-seed`. Gating on `contextTreePath`
+  // keeps the upgrade path's slow-bootstrap trigger intact.
+  if (contextTreePath !== null && integrationOk) {
     writeBundledCliVersion(workspace, currentCliVersion);
   }
 }

--- a/packages/client/src/runtime/context-tree-rebind.ts
+++ b/packages/client/src/runtime/context-tree-rebind.ts
@@ -1,0 +1,33 @@
+import type { ContextTreeBinding } from "./bootstrap.js";
+
+/**
+ * Lazily re-resolve an agent's Context Tree binding when it started its slot
+ * tree-LESS.
+ *
+ * The binding is resolved once at `AgentSlot.start()` and frozen into the
+ * handler config for the slot's lifetime. That's wrong for the new-tree
+ * onboarding flow: the agent's slot comes up before the org's `context_tree`
+ * setting exists (the kickoff step provisions it moments later), so the slot is
+ * frozen tree-less and would never pick up the tree until a daemon restart.
+ *
+ * This decides whether a fresh re-resolution is warranted at session start:
+ *   - already bound (`currentPath` is a non-empty string) → returns null and
+ *     does NOT call `resolve`, so the steady-state path pays nothing;
+ *   - unbound → calls `resolve` once and returns whatever it produced (a
+ *     binding, or null when the org still has no tree).
+ *
+ * Never throws — a failed re-resolution just leaves the session unbound for
+ * this turn (the next new session retries). The caller owns applying the
+ * returned binding to its (mutable) handler config.
+ */
+export async function reresolveUnboundTree(
+  currentPath: unknown,
+  resolve: () => Promise<ContextTreeBinding | null>,
+): Promise<ContextTreeBinding | null> {
+  if (typeof currentPath === "string" && currentPath.length > 0) return null;
+  try {
+    return await resolve();
+  } catch {
+    return null;
+  }
+}

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -13,7 +13,9 @@ import type { pino } from "../observability/logger.js";
 import type { FirstTreeHubSDK } from "../sdk.js";
 import type { AgentConfigCache } from "./agent-config-cache.js";
 import { buildAgentEnv, createParticipantCache, formatInboundContent, resolveSenderLabel } from "./agent-io.js";
+import { type ContextTreeBinding, syncAgentContextTree } from "./bootstrap.js";
 import type { SessionConfig } from "./config.js";
+import { reresolveUnboundTree } from "./context-tree-rebind.js";
 import { Deduplicator } from "./deduplicator.js";
 import type { SelfFence } from "./doc-snapshots.js";
 import { type Classification, clampRetryAttempt, classify, ERROR_KINDS, nextRetryDelayMs } from "./error-taxonomy.js";
@@ -207,6 +209,14 @@ type SessionManagerConfig = {
    * chat back to pending and redeliver them on this connection.
    */
   recoverChat?: (chatId: string) => Promise<void>;
+  /**
+   * Resolver for the agent's Context Tree binding, used to lazily upgrade a
+   * tree-LESS slot to tree-bound at session start (new-tree onboarding sets the
+   * org `context_tree` only after the slot starts). Defaults to a live
+   * `syncAgentContextTree(sdk)`; injected as a stub in tests to avoid spawning
+   * real git.
+   */
+  resolveContextTreeBinding?: () => Promise<ContextTreeBinding | null>;
   /** Callback when a session state changes (per-session granularity). */
   onStateChange?: (chatId: string, state: SessionState) => void;
   /** Callback when aggregated runtime state changes. */
@@ -237,6 +247,15 @@ type SessionManagerConfig = {
  */
 /** Maximum number of evicted session mappings to retain for resume recovery. */
 const MAX_EVICTED_MAPPINGS = 500;
+
+/**
+ * Minimum spacing between lazy Context-Tree re-resolutions for a slot that is
+ * currently tree-LESS. Caps the per-new-session git + HTTP probe for a
+ * permanently-tree-less agent at once per minute, while still picking up a tree
+ * configured later within this window. Tree-BOUND slots never reach this gate
+ * (they exit on the cheap already-bound check).
+ */
+const TREE_RERESOLVE_INTERVAL_MS = 60_000;
 
 /**
  * Base interval for re-affirming per-(agent,chat) runtime so the server-side
@@ -286,6 +305,8 @@ export class SessionManager {
   private readonly sessions = new Map<string, SessionEntry>();
   private readonly evictedMappings = new Map<string, { claudeSessionId: string; lastActivity: number }>();
   private readonly config: SessionManagerConfig;
+  /** Last lazy Context-Tree re-resolution attempt (epoch ms); see `TREE_RERESOLVE_INTERVAL_MS`. */
+  private lastTreeResolveAttemptAt = 0;
   private readonly deduplicator = new Deduplicator(1000);
   /**
    * Current trigger (messageId + senderId) per chat — the message that kicked
@@ -454,6 +475,19 @@ export class SessionManager {
       await this.ensureImagesLocal(message);
 
       if (!this.markTrackedEntryAccepted(chatId, entry.id)) return;
+
+      // 4c. Lazily resolve a tree-LESS Context Tree binding before routing this
+      // message to a (possibly new) session. The binding is frozen at
+      // `AgentSlot.start()`, but the new-tree onboarding flow sets the org
+      // `context_tree` only afterwards — without this the fresh agent would
+      // never pick up its tree until a daemon restart. Done INSIDE the
+      // admission barrier so the `handlerConfig` patch lands before routing and
+      // a same-chat follow-up can't race a half-resolved binding, and only when
+      // no live session exists for this chat (a start / resume, never an inject
+      // into an active turn). No-op + no network once bound.
+      if (!this.hasHealthyLiveHandler(chatId)) {
+        await this.ensureContextTreeBinding();
+      }
 
       // 5. Route by session state. ACK no longer happens inside route — the
       // entry sits in `inFlightEntries` until the handler completes the
@@ -799,6 +833,43 @@ export class SessionManager {
 
     // No existing session — create new
     await this.startNewSession(chatId, message);
+  }
+
+  /**
+   * Lazily resolve the agent's Context Tree binding when its slot came up
+   * tree-less. The binding is resolved once at `AgentSlot.start()` and frozen
+   * into `handlerConfig`; the new-tree onboarding flow sets the org
+   * `context_tree` only AFTER that, so a fresh agent would otherwise stay
+   * unbound until a daemon restart. Re-resolving at each new session is cheap
+   * once bound (`reresolveUnboundTree` short-circuits without a network call)
+   * and patches `handlerConfig` in place — so the handler built in
+   * `startNewSession`, and every later session on this slot, sees the tree,
+   * installs the First Tree skills, and writes the W1 workspace manifest.
+   */
+  private async ensureContextTreeBinding(): Promise<void> {
+    const cfg = this.config.handlerConfig;
+    // Already bound — cheapest exit (no clock read, no resolver, no network).
+    if (typeof cfg.contextTreePath === "string" && cfg.contextTreePath.length > 0) return;
+    // Tree-less: rate-limit re-resolution so a permanently-tree-less agent (the
+    // common case) doesn't spawn git + an HTTP GET on EVERY new session for the
+    // slot's whole life. A tree configured later is still picked up within
+    // TREE_RERESOLVE_INTERVAL_MS on the next new session.
+    const now = Date.now();
+    if (now - this.lastTreeResolveAttemptAt < TREE_RERESOLVE_INTERVAL_MS) return;
+    this.lastTreeResolveAttemptAt = now;
+
+    const resolve =
+      this.config.resolveContextTreeBinding ??
+      (() => syncAgentContextTree(this.config.sdk, (msg) => this.config.log.info(msg)));
+    const binding = await reresolveUnboundTree(cfg.contextTreePath, resolve);
+    if (!binding) return;
+    cfg.contextTreePath = binding.path;
+    cfg.contextTreeRepoUrl = binding.repoUrl;
+    cfg.contextTreeBranch = binding.branch;
+    this.config.log.info(
+      { path: binding.path, repoUrl: binding.repoUrl },
+      "context tree binding resolved lazily (agent was unbound at slot start)",
+    );
   }
 
   private async startNewSession(chatId: string, message: SessionMessage): Promise<void> {

--- a/packages/client/src/runtime/workspace-manifest.ts
+++ b/packages/client/src/runtime/workspace-manifest.ts
@@ -1,0 +1,160 @@
+// Make a cloud agent home a valid W1 workspace so the shipped First Tree
+// skills find the binding they expect.
+//
+// The shipped skills (pre-task hygiene in `first-tree`, and `first-tree-seed`'s
+// self-check) locate their binding by walking up from cwd for
+// `.first-tree/workspace.json` — a manifest that names the tree subdir and the
+// bound source subdirs, ALL as immediate children of one workspace root (the
+// "W1" layout, see `@first-tree/shared` `workspaceManifestSchema`). A
+// cloud-hosted agent doesn't naturally have that shape: its source repos sit at
+// the agent-home top level (good), but the Context Tree is cloned to a SHARED
+// external directory (dedup'd across every agent in the org) — not a sibling.
+//
+// To satisfy the W1 contract without giving up that cross-agent clone sharing,
+// we expose the external clone inside the agent home as a symlink named
+// `context-tree`, then write `.first-tree/workspace.json` naming that link as
+// `tree`. The skills stay completely layout-agnostic; all the cloud-specific
+// adaptation lives here, at the runtime boundary.
+
+import { lstatSync, mkdirSync, readlinkSync, symlinkSync, unlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { WORKSPACE_MANIFEST_FILENAME, WORKSPACE_STATE_DIRNAME, workspaceManifestSchema } from "@first-tree/shared";
+
+/**
+ * Immediate-subdirectory name under the agent home that the Context Tree clone
+ * is symlinked to, and the value written as the manifest's `tree`. A reserved,
+ * fixed name (not derived from the repo) so the manifest is stable across tree
+ * rebinds and re-clones.
+ */
+export const CONTEXT_TREE_LINK_DIRNAME = "context-tree";
+
+/**
+ * Ensure `<workspace>/context-tree` symlinks the external tree clone and
+ * `<workspace>/.first-tree/workspace.json` records `{ tree, sources }`.
+ *
+ * A best-effort, idempotent, **never-throws-out** session-bootstrap step. The
+ * agent home is shared across the agent's concurrent sessions, so every
+ * filesystem step tolerates a racing peer, and the whole filesystem block is
+ * wrapped — it must never fail the session it runs in. Defensive rules:
+ *   - Validates the manifest BEFORE touching the filesystem, so a bad input
+ *     never leaves a half-applied state (a symlink with no manifest).
+ *   - Drops source names that can't be immediate-subdir manifest entries
+ *     (a nested `localPath` like `a/b`) rather than dropping the whole manifest;
+ *     such a source is still materialised on disk, it just can't be expressed
+ *     in `sources`.
+ *   - Skips entirely when a declared source is named `context-tree` (the schema
+ *     also forbids `tree` ∈ `sources`) or when a real (non-symlink) entry
+ *     occupies the link path — never clobbers checked-out code.
+ *   - Re-points the symlink when the clone path changes (tree rebind / re-clone
+ *     to a new digest dir), tolerating concurrent create/remove races.
+ *
+ * @param sourceNames immediate-subdir names of the bound source repos (the
+ *   agent's resolved `gitRepos` localPaths). Pass the resolved set only — never
+ *   call this with an unresolved/empty-as-unknown source set.
+ */
+export function ensureWorkspaceManifest(
+  workspace: string,
+  contextTreePath: string,
+  sourceNames: readonly string[],
+  log?: (msg: string) => void,
+): void {
+  // Drop names that can't be immediate-subdir manifest entries (nested
+  // `localPath`). Better than failing the whole manifest write.
+  const usable = [...sourceNames].filter((name) => {
+    if (isImmediateSubdirName(name)) return true;
+    log?.(`workspace manifest: dropping source "${name}" — not an immediate subdirectory name`);
+    return false;
+  });
+
+  if (usable.includes(CONTEXT_TREE_LINK_DIRNAME)) {
+    log?.(`workspace manifest skipped: a source repo is named "${CONTEXT_TREE_LINK_DIRNAME}"`);
+    return;
+  }
+
+  // Validate (and pre-serialize) BEFORE any filesystem mutation so an invalid
+  // input never leaves a symlink without a manifest.
+  let serialized: string;
+  try {
+    const manifest = workspaceManifestSchema.parse({ tree: CONTEXT_TREE_LINK_DIRNAME, sources: usable });
+    serialized = `${JSON.stringify(manifest, null, 2)}\n`;
+  } catch (err) {
+    log?.(`workspace manifest skipped: ${err instanceof Error ? err.message : String(err)}`);
+    return;
+  }
+
+  try {
+    if (!ensureTreeSymlink(join(workspace, CONTEXT_TREE_LINK_DIRNAME), contextTreePath, log)) return;
+    const stateDir = join(workspace, WORKSPACE_STATE_DIRNAME);
+    mkdirSync(stateDir, { recursive: true });
+    writeFileSync(join(stateDir, WORKSPACE_MANIFEST_FILENAME), serialized, "utf-8");
+  } catch (err) {
+    log?.(`workspace manifest write failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+/** Mirrors `workspaceManifestSchema`'s `subdirectoryNameSchema` rules. */
+function isImmediateSubdirName(name: string): boolean {
+  return (
+    name.length > 0 &&
+    !name.includes("/") &&
+    !name.includes("\\") &&
+    name !== "." &&
+    name !== ".." &&
+    !name.startsWith(".")
+  );
+}
+
+/**
+ * Create / repair the `<workspace>/context-tree` → clone symlink, tolerating a
+ * racing peer (the agent home is shared across concurrent sessions). Returns
+ * `false` when a real file/dir occupies the path (so the caller writes no
+ * manifest, which would otherwise name a tree that isn't actually linked).
+ */
+function ensureTreeSymlink(linkPath: string, target: string, log?: (msg: string) => void): boolean {
+  // Already correct — the steady state and the concurrent-winner case.
+  if (readlinkOrNull(linkPath) === target) return true;
+
+  const stat = lstatOrNull(linkPath);
+  if (stat && !stat.isSymbolicLink()) {
+    log?.(`workspace manifest skipped: "${CONTEXT_TREE_LINK_DIRNAME}" exists and is not a symlink — not clobbering`);
+    return false;
+  }
+  // Missing, or a stale symlink (tree re-cloned to a new digest dir). Remove a
+  // stale link if present, then (re)create — tolerating a peer that created or
+  // removed it underneath us.
+  if (stat) {
+    try {
+      unlinkSync(linkPath);
+    } catch (err) {
+      if (nodeErrCode(err) !== "ENOENT") throw err;
+    }
+  }
+  try {
+    symlinkSync(target, linkPath);
+  } catch (err) {
+    // A concurrent session created it first. Accept iff it points where we want.
+    if (nodeErrCode(err) === "EEXIST") return readlinkOrNull(linkPath) === target;
+    throw err;
+  }
+  return true;
+}
+
+function readlinkOrNull(path: string): string | null {
+  try {
+    return readlinkSync(path);
+  } catch {
+    return null;
+  }
+}
+
+function lstatOrNull(path: string): ReturnType<typeof lstatSync> | null {
+  try {
+    return lstatSync(path);
+  } catch {
+    return null;
+  }
+}
+
+function nodeErrCode(err: unknown): string | undefined {
+  return typeof err === "object" && err !== null ? (err as { code?: string }).code : undefined;
+}

--- a/packages/web/src/pages/onboarding/__tests__/provision-tree.test.ts
+++ b/packages/web/src/pages/onboarding/__tests__/provision-tree.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  initializeContextTree: vi.fn(),
+  getContextTreeSetting: vi.fn(),
+}));
+vi.mock("../../../api/context-tree.js", () => ({ initializeContextTree: mocks.initializeContextTree }));
+vi.mock("../../../api/org-settings.js", () => ({ getContextTreeSetting: mocks.getContextTreeSetting }));
+
+import { ApiError } from "../../../api/client.js";
+import { provisionNewTree } from "../provision-tree.js";
+
+const CREATED = {
+  repo: "https://github.com/acme/acme-context-tree",
+  htmlUrl: "https://github.com/acme/acme-context-tree",
+  branch: "main",
+  nodePath: "NODE.md",
+};
+
+describe("provisionNewTree", () => {
+  beforeEach(() => {
+    mocks.initializeContextTree.mockReset();
+    mocks.getContextTreeSetting.mockReset();
+  });
+
+  it("initializes and does not probe binding state on success", async () => {
+    mocks.initializeContextTree.mockResolvedValue(CREATED);
+    await provisionNewTree("org-1");
+    expect(mocks.initializeContextTree).toHaveBeenCalledWith("org-1");
+    expect(mocks.getContextTreeSetting).not.toHaveBeenCalled();
+  });
+
+  it("treats a 409 as success when a tree binding now exists (detect→create race / retry)", async () => {
+    mocks.initializeContextTree.mockRejectedValue(
+      new ApiError(409, "Context Tree repo is already configured for this team"),
+    );
+    mocks.getContextTreeSetting.mockResolvedValue({
+      repo: "https://github.com/acme/acme-context-tree",
+      branch: "main",
+    });
+    await expect(provisionNewTree("org-1")).resolves.toBeUndefined();
+  });
+
+  it("re-throws a 409 when no tree was created (e.g. org installation required)", async () => {
+    mocks.initializeContextTree.mockRejectedValue(new ApiError(409, "requires a GitHub organization installation"));
+    mocks.getContextTreeSetting.mockResolvedValue({ repo: null, branch: null });
+    await expect(provisionNewTree("org-1")).rejects.toBeInstanceOf(ApiError);
+  });
+
+  it("re-throws a non-409 error without probing binding state", async () => {
+    mocks.initializeContextTree.mockRejectedValue(new ApiError(403, "installation permissions insufficient"));
+    await expect(provisionNewTree("org-1")).rejects.toBeInstanceOf(ApiError);
+    expect(mocks.getContextTreeSetting).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/pages/onboarding/provision-tree.ts
+++ b/packages/web/src/pages/onboarding/provision-tree.ts
@@ -1,0 +1,32 @@
+import { ApiError } from "../../api/client.js";
+import { initializeContextTree } from "../../api/context-tree.js";
+import { getContextTreeSetting } from "../../api/org-settings.js";
+
+/**
+ * Provision a fresh Context Tree for the new-tree onboarding path: create the
+ * repo + write the org `context_tree` binding via the admin initializer. Runs
+ * before the kickoff message is sent so the agent's session resolves the
+ * binding and `first-tree-seed`'s preconditions hold.
+ *
+ * A `409` from the initializer is ambiguous — it can mean the tree is **already
+ * provisioned** (a detect→create race, or a retry after a later kickoff step
+ * failed) OR that **no tree could be created** (the merged initializer also
+ * returns 409 for `organization_installation_required` /
+ * `selected_repositories_unsupported`). We distinguish by the **actual binding
+ * state** rather than the status code (the "already configured" conflict
+ * carries no discriminating `code`): if a tree now exists, provisioning
+ * effectively succeeded and we proceed; otherwise we re-throw so the user sees
+ * the actionable error and can fix their GitHub setup. Every non-409 error
+ * (e.g. `403 installation_permissions_insufficient`) propagates unchanged.
+ */
+export async function provisionNewTree(organizationId: string): Promise<void> {
+  try {
+    await initializeContextTree(organizationId);
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 409) {
+      const setting = await getContextTreeSetting(organizationId).catch(() => null);
+      if (setting?.repo) return; // a tree binding exists — treat as provisioned
+    }
+    throw err;
+  }
+}

--- a/packages/web/src/pages/onboarding/steps/step-kickoff.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-kickoff.tsx
@@ -14,6 +14,7 @@ import { buildBindBootstrap, buildCreateBootstrap } from "../../workspace/center
 import { COPY } from "../copy.js";
 import { CommandBox, FlowHint, RepoPicker, SelectableRow, StatusRow, StepHeading, WorkingState } from "../flow-ui.js";
 import { useOnboardingFlow } from "../onboarding-flow.js";
+import { provisionNewTree } from "../provision-tree.js";
 import { resolveOnboardingAgent } from "../resolve-agent.js";
 import { resolveInviteeKickoffState } from "../steps.js";
 
@@ -47,6 +48,19 @@ async function runKickoff(args: {
   complete: (chatId: string) => Promise<void>;
 }): Promise<void> {
   const agent = await resolveOnboardingAgent();
+
+  // New-tree mode: provision the team's Context Tree repo + org binding BEFORE
+  // sending the kickoff message, so the agent's session resolves the binding
+  // (contextTreePath becomes non-null) and `first-tree-seed`'s preconditions
+  // hold. Only fires when there are repos to seed from — the no-project path
+  // has no `orgWrites` and nothing to seed. `provisionNewTree` treats an
+  // already-provisioned tree (a retry after a later step failed, or a
+  // detect→create race) as success and re-throws every real failure (e.g. the
+  // GitHub App installation isn't an org with repo-admin) so the user sees an
+  // actionable error and can retry — nothing is half-created (no chat yet).
+  if (args.treeMode === "new" && args.orgWrites?.organizationId) {
+    await provisionNewTree(args.orgWrites.organizationId);
+  }
 
   // Org-level writes are a convenience cache for future teammates — never
   // let them block the user's first chat.

--- a/packages/web/src/pages/workspace/center/onboarding/__tests__/bootstrap-prose.test.ts
+++ b/packages/web/src/pages/workspace/center/onboarding/__tests__/bootstrap-prose.test.ts
@@ -8,7 +8,15 @@ describe("kickoff bootstrap prose", () => {
     expect(message).toContain("source repo");
     expect(message).toContain("Source repo: https://github.com/acme/app");
     expect(message).toContain("Existing tree: https://github.com/acme/context");
-    expect(message).toContain("bind the repo to that existing tree");
+    // Binding is now written automatically by the runtime (workspace.json), so
+    // the agent is told the repo is already connected and pointed at reading /
+    // reflecting — never at performing a manual bind + PR-back.
+    expect(message).toContain("connected");
+    expect(message).toContain("first-tree-context");
+    expect(message).not.toContain("bind the repo to that existing tree");
+    expect(message).not.toContain("PR back to the source");
+    // A populated team tree must never invoke the one-shot seed skill.
+    expect(message).not.toContain("first-tree-seed");
     expect(message).toContain(FIRST_TREE_REFERENCE_URL);
   });
 
@@ -22,41 +30,47 @@ describe("kickoff bootstrap prose", () => {
     expect(message).toContain("Source repos:");
     expect(message).toContain("- https://github.com/acme/web");
     expect(message).toContain("- https://github.com/acme/api");
-    expect(message).toContain("bind every repo to that existing tree");
+    expect(message).toContain("Existing tree: https://github.com/acme/context");
+    expect(message).toContain("connected");
+    expect(message).toContain("first-tree-context");
+    expect(message).not.toContain("bind every repo to that existing tree");
   });
 
   it("builds singular new-tree instructions", () => {
     const message = buildCreateBootstrap(["https://github.com/acme/app"]);
 
-    expect(message).toContain("create a brand-new Context Tree");
     expect(message).toContain("Source repo: https://github.com/acme/app");
-    expect(message).toContain("Host the new tree as its own GitHub repo under the same owner as the source");
-    expect(message).toContain("record its URL in First Tree");
+    // Cloud now provisions the tree repo + org binding and the runtime writes
+    // workspace.json before this message is sent, so the new-tree prose names
+    // `first-tree-seed` directly and tells the agent to seed an already-bound,
+    // already-empty tree from the source — it no longer asks the agent to
+    // create the GitHub repo or record its URL.
+    expect(message).toContain("first-tree-seed");
+    expect(message).toContain("not placeholders");
 
-    // Pin out the retired-skill name so the prose can never silently
-    // regress to advertising a skill that does not exist on disk.
+    // Retired skill name must never reappear.
     expect(message).not.toContain("first-tree onboarding flow");
+    // The agent no longer self-provisions the tree: Cloud already did.
+    expect(message).not.toContain("Host the new tree");
+    expect(message).not.toContain("record its URL");
+    expect(message).not.toContain("create a brand-new Context Tree");
 
-    // Pin out `$first-tree-seed` naming until the Cloud-side new-tree
-    // provisioning step lands. Naming the skill while Cloud still passes
-    // `contextTreeUrl: null` would send the kickoff agent to a self-check
-    // that hard-refuses on the missing workspace.json tree binding. See
-    // the JSDoc on `buildCreateBootstrap` for the full rationale.
-    expect(message).not.toContain("$first-tree-seed");
-    expect(message).not.toContain("first-tree-seed");
+    expect(message).toContain(FIRST_TREE_REFERENCE_URL);
   });
 
   it("builds plural new-tree instructions", () => {
     const message = buildCreateBootstrap(["https://github.com/acme/web", "https://github.com/acme/api"]);
 
-    expect(message).toContain("one shared Context Tree");
     expect(message).toContain("Source repos:");
-    expect(message).toContain("ask me which owner if they don't share one");
-    expect(message).toContain("each PR");
+    expect(message).toContain("- https://github.com/acme/web");
+    expect(message).toContain("- https://github.com/acme/api");
+    expect(message).toContain("first-tree-seed");
+    expect(message).toContain("not placeholders");
 
-    // Same retired / not-yet-wired skill-name pins as the singular case.
     expect(message).not.toContain("first-tree onboarding flow");
-    expect(message).not.toContain("$first-tree-seed");
-    expect(message).not.toContain("first-tree-seed");
+    expect(message).not.toContain("Host the new tree");
+    expect(message).not.toContain("record its URL");
+    // Cloud names + creates the repo, so the agent is never asked which owner.
+    expect(message).not.toContain("ask me which owner");
   });
 });

--- a/packages/web/src/pages/workspace/center/onboarding/bootstrap-prose.ts
+++ b/packages/web/src/pages/workspace/center/onboarding/bootstrap-prose.ts
@@ -8,25 +8,26 @@
  * tree URL) and defer the mechanics, so they don't drift as the CLI / skills
  * evolve.
  *
+ * Both paths now assume Cloud has provisioned + bound the tree BEFORE the
+ * kickoff message is sent: `runKickoff` creates the tree repo + writes the
+ * org's `context_tree` setting (new-tree, via the initializer), and the
+ * runtime writes `<workspace>/.first-tree/workspace.json` once the agent's
+ * session resolves the binding. That precondition is what lets the prose name
+ * skills directly instead of asking the agent to self-provision.
+ *
  * Two paths:
- *   - existing tree (buildBindBootstrap): the frontend has already best-effort
- *     PUT the URL into the org's `context_tree` settings before sending, so the
- *     message doesn't ask the agent to record it in First Tree again. The
- *     tree is already populated, so `first-tree-seed` does not apply — the
- *     agent uses `first-tree-context` for any further writes.
- *   - new tree (buildCreateBootstrap): today, the Cloud-side `runKickoff` path
- *     does NOT provision the tree repo, write the org's `context_tree`
- *     setting, or bind the workspace before sending the kickoff message
- *     (`step-kickoff.tsx` passes `contextTreeUrl: null`). The message
- *     therefore must NOT name `$first-tree-seed`: that skill's self-check
- *     hard-requires those preconditions and would refuse on every new-tree
- *     onboarding. Instead, the prose states the user's goal in plain
- *     language; the agent uses its full skill set (`first-tree-context` for
- *     writes, plus general tooling) to bind + host + record + draft. When
- *     Cloud gains a real provisioning step (creates the tree repo, writes
- *     `context_tree`, writes `workspace.json`) BEFORE sending kickoff, a
- *     future PR will switch this prose to name `$first-tree-seed` and drop
- *     the bind/host/record-URL instructions. See PR 899 (baixiaohang's r3 review).
+ *   - existing tree (buildBindBootstrap): the team's tree already exists and is
+ *     populated, and the binding (workspace.json) is written automatically by
+ *     the runtime — so the agent is NOT asked to bind or open a PR back to the
+ *     source. `first-tree-seed` does not apply to a populated tree; the agent
+ *     reads the tree and uses `first-tree-context` for any further writes.
+ *   - new tree (buildCreateBootstrap): Cloud has already created the empty tree
+ *     repo, written `context_tree`, and (on this session) the runtime writes
+ *     `workspace.json`, so the new-tree self-check preconditions for
+ *     `first-tree-seed` hold. The prose names `first-tree-seed` directly and
+ *     asks the agent to seed the already-bound, still-empty tree with real
+ *     content drawn from the source repos — it no longer asks the agent to
+ *     create the GitHub repo or record its URL (Cloud owns both).
  *
  * Single source of truth: only the kickoff step sends these. If a future surface
  * needs the same prompts, hoist these builders to `packages/shared`.
@@ -45,11 +46,11 @@ export function buildBindBootstrap(sourceUrls: readonly string[], treeUrl: strin
   const sourceLines = formatSourceList(sourceUrls);
   const single = sourceUrls.length === 1;
   const opener = single
-    ? "Set up First Tree for my source repo, binding it to our team's existing Context Tree."
-    : "Set up First Tree for my source repos, binding them to our team's existing Context Tree.";
+    ? "My source repo is now connected to our team's existing Context Tree."
+    : "My source repos are now connected to our team's existing Context Tree.";
   const skillLine = single
-    ? "Use your First Tree skills to bind the repo to that existing tree, then open a PR back to the source with the binding. Show me the diff before it's pushed, and walk me through the PR."
-    : "Use your First Tree skills to bind every repo to that existing tree, then open a PR back to each source with its binding. Show me the diffs before they're pushed, and walk me through each PR.";
+    ? "Read the tree first to get oriented — start at its root NODE.md. If this repo introduces decisions, ownership, or context worth recording, use the first-tree-context skill to reflect them into the tree — show me the diff and walk me through any PR before it's pushed."
+    : "Read the tree first to get oriented — start at its root NODE.md. If these repos introduce decisions, ownership, or context worth recording, use the first-tree-context skill to reflect them into the tree — show me the diffs and walk me through any PRs before they're pushed.";
   return [
     opener,
     "",
@@ -66,22 +67,20 @@ export function buildCreateBootstrap(sourceUrls: readonly string[]): string {
   const sourceLines = formatSourceList(sourceUrls);
   const single = sourceUrls.length === 1;
   const opener = single
-    ? "Set up First Tree for my source repo and create a brand-new Context Tree for it."
-    : "Set up First Tree for my source repos and create one shared Context Tree they all bind to.";
-  const goalLine = single
-    ? "Bind the repo to the new Context Tree, and — this part matters most — draft real starting content for the tree from what's actually in the repo, not placeholders. Host the new tree as its own GitHub repo under the same owner as the source."
-    : "Bind every repo to the one new shared Context Tree, and — this part matters most — draft real starting content for the tree from what's actually in the repos, not placeholders. Host the new tree as its own GitHub repo under the owner the sources share (ask me which owner if they don't share one).";
+    ? "My team's Context Tree is set up and bound to my source repo — now seed it with real starting content."
+    : "My team's Context Tree is set up and bound to my source repos — now seed it with real starting content.";
+  const skillLine = single
+    ? "Use the first-tree-seed skill: read the bound source repo, then draft the tree's initial structure and starting content from what's actually in it — not placeholders."
+    : "Use the first-tree-seed skill: read every bound source repo, then draft the tree's initial structure and starting content from what's actually in them — not placeholders.";
   const walkthrough = single
-    ? "Show me the diffs before anything is pushed, and walk me through what got created — the tree repo, its content, and the PR."
-    : "Show me the diffs before anything is pushed, and walk me through what got created — the tree repo, its content, and each PR.";
+    ? "Show me the diff before anything is pushed, and walk me through each PR as it opens."
+    : "Show me the diffs before anything is pushed, and walk me through each PR as it opens.";
   return [
     opener,
     "",
     ...sourceLines,
     "",
-    goalLine,
-    "",
-    "Once the tree repo is up on GitHub, record its URL in First Tree with the First Tree CLI so future teammates' agents can find it.",
+    skillLine,
     "",
     walkthrough,
     "",


### PR DESCRIPTION
## What

After onboarding's "create agent" step, the **new-tree** kickoff path now
provisions a Context Tree (Cloud) and the cloud agent **seeds it from the bound
source repos** with `first-tree-seed` — asynchronously, in its kickoff chat,
without blocking onboarding. Completes the "build context tree during
onboarding" flow that was previously stubbed out.

Builds on #923 (merged). Design + the verified gaps it closes, plus open
prerequisites:
[`docs/development/onboarding-context-tree-seed-design.md`](docs/development/onboarding-context-tree-seed-design.md).

## Changes

**Web (onboarding)**
- `steps/step-kickoff.tsx` + new `provision-tree.ts` — new-tree mode provisions
  the tree before sending the kickoff message; a `409` is resolved by the
  **actual binding state** (already-provisioned → proceed; no-tree-created →
  re-throw the actionable error), not blindly swallowed/re-thrown.
- `bootstrap-prose.ts` — new-tree message names `first-tree-seed` and drops the
  self-provision / record-URL framing; the bind message no longer self-binds
  (the runtime writes `workspace.json`) and reads/reflects via
  `first-tree-context`.

**Client (runtime)**
- `workspace-manifest.ts` (new) + `agent-bootstrap.ts` — make the cloud agent
  home a valid **W1 workspace**: sibling symlink to the shared tree clone +
  `.first-tree/workspace.json`, so the shipped skills (incl. `first-tree-seed`'s
  self-check) stay layout-agnostic. Validates before touching disk, tolerates
  concurrent-session races, never clobbers checked-out code, never throws out.
- `context-tree-rebind.ts` (new) + `session-manager.ts` — lazily re-resolve a
  tree-LESS binding at session start (rate-limited) so a tree provisioned *after*
  the slot started is picked up without a daemon restart.
- `agent-bootstrap.ts` — only pin the bundled CLI version when integration
  actually ran, so the tree-less → tree-bound upgrade installs the skills.

Source repos already reach the agent via `recommended` team resources — no
`gitRepos` wiring needed.

## Prerequisites / known limits (design §O3)
- New-tree provisioning needs the GitHub App **org installation** with
  `Administration: write` + `Contents: write` on **all** repos. Personal-account
  installs get `409 organization_installation_required` (surfaced as an
  actionable error) and cannot use one-click new-tree.

## Testing
- `pnpm typecheck` (11/11 packages) · `biome check` clean
- client `vitest` green; web `vitest` green (1 pre-existing unrelated
  `localhost:3000` file artifact)
- New unit/regression tests: prose, `provisionNewTree`, `ensureWorkspaceManifest`,
  `reresolveUnboundTree`, SessionManager lazy-binding, the CLI-pin upgrade.
- 3 independent review rounds; all findings fixed. Onboarding kickoff UI verified
  via the DEV preview gallery (renders clean, no console errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
