### PR TITLE
fix(web): recover doc preview from message metadata when snapshot cache is gone

### DIFF
--- a/packages/web/src/components/__tests__/doc-preview-drawer.test.tsx
+++ b/packages/web/src/components/__tests__/doc-preview-drawer.test.tsx
@@ -12,8 +12,12 @@ globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 const meDocsMocks = vi.hoisted(() => ({
   getMeDoc: vi.fn(),
 }));
+const chatsMocks = vi.hoisted(() => ({
+  listChatMessages: vi.fn(),
+}));
 
 vi.mock("../../api/me-docs.js", () => meDocsMocks);
+vi.mock("../../api/chats.js", () => chatsMocks);
 vi.mock("../../lib/use-agent-name-map.js", () => ({
   useAgentSlugToIdMap: () => (slug: string | null | undefined) => (slug === "kael" ? "agent-owner" : null),
 }));
@@ -131,7 +135,22 @@ beforeEach(() => {
     content: "# Guide\nSee [next](next.md).",
     ref: { path: "docs/guide.md" },
   });
+  chatsMocks.listChatMessages.mockReset();
+  chatsMocks.listChatMessages.mockResolvedValue({ items: [], nextCursor: null });
 });
+
+// A snapshot-variant message whose metadata still carries the doc bytes —
+// the immutable source recovery re-derives from. sha256 must be 64 hex chars
+// because the recovery path schema-validates metadata.
+const recoveryMessage = {
+  id: "msg-1",
+  metadata: {
+    documentContext: {
+      kind: "snapshot",
+      docs: [{ path: "docs/plan.md", content: "# Recovered Plan", sha256: "a".repeat(64), size: 16 }],
+    },
+  },
+};
 
 afterEach(async () => {
   if (root) await act(async () => root?.unmount());
@@ -166,6 +185,66 @@ describe("DocPreviewDrawer", () => {
 
     await click(dom.querySelector('button[aria-label="Close document preview"]'));
     expect(latestSearch).not.toContain("docPath=");
+  });
+
+  it("recovers from the warm messages cache when the seeded entry was GC'd (chat open)", async () => {
+    // Reproduces the GC bug: the URL still carries docMsg, but the seeded
+    // `docSnapshotQueryKey` entry was garbage-collected (no observer). While
+    // the chat is open, ChatView keeps `chat-messages` warm — model that with
+    // a pre-seeded cache entry. The drawer must re-derive the snapshot from
+    // the message's `metadata.documentContext` instead of falling through to
+    // the path endpoint (which 404s on the cloud topology).
+    chatsMocks.listChatMessages.mockResolvedValue({ items: [recoveryMessage], nextCursor: null });
+    const { DocPreviewDrawer } = await import("../doc-preview-drawer.js");
+    const route = "/?docChat=chat-1&docAgent=agent-1&docPath=docs%2Fplan.md&docMsg=msg-1";
+    const dom = await renderAt(route, <DocPreviewDrawer />, (client) => {
+      // No docSnapshotQueryKey seed — simulate the post-GC state.
+      client.setQueryData(["chat-messages", "chat-1"], { items: [recoveryMessage], nextCursor: null });
+    });
+    await flush();
+
+    expect(dom.textContent).toContain("Recovered Plan");
+    expect(meDocsMocks.getMeDoc).not.toHaveBeenCalled();
+  });
+
+  it("recovers by fetching the messages window after a cold reload", async () => {
+    // Reproduces the reload P2 codex flagged: no seeded snapshot AND no warm
+    // messages cache on first render. A non-reactive cache peek would memoise
+    // `undefined` and never recompute. The drawer must observe the messages
+    // query, fetch the window, and recover — never hitting the path endpoint.
+    chatsMocks.listChatMessages.mockResolvedValue({ items: [recoveryMessage], nextCursor: null });
+    const { DocPreviewDrawer } = await import("../doc-preview-drawer.js");
+    const route = "/?docChat=chat-1&docAgent=agent-1&docPath=docs%2Fplan.md&docMsg=msg-1";
+    const dom = await renderAt(route, <DocPreviewDrawer />);
+    await flush();
+
+    expect(chatsMocks.listChatMessages).toHaveBeenCalledWith("chat-1", { limit: 50 });
+    expect(dom.textContent).toContain("Recovered Plan");
+    expect(meDocsMocks.getMeDoc).not.toHaveBeenCalled();
+  });
+
+  it("still uses the path endpoint for an in-preview link to a non-snapshotted doc", async () => {
+    // Guards the second regression: a snapshot-origin preview keeps `docMsg` in
+    // the URL when navigating to an in-doc link. If that target was never one
+    // of the message's snapshots, recovery comes up empty and the drawer must
+    // still fall through to the legacy path endpoint (single-host) rather than
+    // being gated out wholesale by `docMsg`.
+    chatsMocks.listChatMessages.mockResolvedValue({ items: [recoveryMessage], nextCursor: null });
+    const { DocPreviewDrawer } = await import("../doc-preview-drawer.js");
+    // docPath is docs/design.md — present in neither the seed nor the message's
+    // docs[] (which only has docs/plan.md), but docMsg is still msg-1.
+    const route = "/?docChat=chat-1&docAgent=agent-1&docPath=docs%2Fdesign.md&docMsg=msg-1";
+    const dom = await renderAt(route, <DocPreviewDrawer />, (client) => {
+      client.setQueryData(["chat-messages", "chat-1"], { items: [recoveryMessage], nextCursor: null });
+    });
+    await flush();
+
+    expect(meDocsMocks.getMeDoc).toHaveBeenCalledWith("chat-1", {
+      agentId: "agent-1",
+      basePath: undefined,
+      path: "docs/design.md",
+    });
+    expect(dom.textContent).toContain("Guide");
   });
 
   it("loads fallback previews for cross-agent paths and renders API errors", async () => {

--- a/packages/web/src/components/doc-preview-drawer.tsx
+++ b/packages/web/src/components/doc-preview-drawer.tsx
@@ -12,12 +12,17 @@ import {
 } from "react";
 import type { Components } from "react-markdown";
 import { useSearchParams } from "react-router";
+import { listChatMessages } from "../api/chats.js";
 import { getMeDoc } from "../api/me-docs.js";
 import { docPreviewPathFromHref } from "../lib/doc-preview-links.js";
 import { isNavigableWebHref } from "../lib/safe-href.js";
 import { useAgentSlugToIdMap } from "../lib/use-agent-name-map.js";
 import { cn } from "../lib/utils.js";
-import { type DocSnapshotEntry, docSnapshotQueryKey } from "../pages/workspace/center/chat-view.js";
+import {
+  type DocSnapshotEntry,
+  docSnapshotQueryKey,
+  documentSnapshotMapFromMetadata,
+} from "../pages/workspace/center/chat-view.js";
 import { Button } from "./ui/button.js";
 import { Markdown } from "./ui/markdown.js";
 
@@ -102,14 +107,28 @@ function useIsMobileDocPreview(): boolean {
  *     without rendering two competing rails on a narrow viewport.
  *
  * Data source priority:
- *   - Inline snapshot via React Query cache (PR 415). chat-view seeds the
- *     whole message's `docs[]` when the user clicks any `.md` link, so
+ *   - Seeded inline snapshot via React Query cache (PR 415). chat-view seeds
+ *     the whole message's `docs[]` when the user clicks any `.md` link, so
  *     opening the drawer is a synchronous cache read with no network
  *     round-trip — load-bearing on the cloud topology where the server
  *     cannot read the local agent workspace.
- *   - Falls back to `GET /me/docs/preview` (path variant) when no inline
- *     snapshot is attached. Useful for single-host deployments where the
- *     server can still read workspace files directly.
+ *   - Recovery from the message's own `metadata.documentContext` when the
+ *     seeded entry is gone. That seeded entry has NO observer (read via
+ *     `getQueryData`, never `useQuery`), so React Query garbage-collects it
+ *     after the default gcTime (~5 min). The next re-render — e.g. the
+ *     messages refetch `sendMut.onSettled` triggers when the user sends a new
+ *     message — would otherwise drop straight to the path endpoint below and,
+ *     on the cloud topology, 404 with "Document not found". The snapshot bytes
+ *     are immutable and still live in the message row, so re-derive them from
+ *     the messages cache. This also makes the preview survive a full page
+ *     reload (the messages refetch restores the metadata).
+ *     Recovery is deferred-to, not gated-around: the path endpoint still runs
+ *     once recovery settles without a hit, so it is held off only during the
+ *     brief recovery window, never disabled for `docMsg`-tagged messages.
+ *   - Falls back to `GET /me/docs/preview` (path variant) for legacy
+ *     `kind: "path"` messages AND for in-preview links to docs that were never
+ *     snapshotted — both only resolve on single-host deployments where the
+ *     server can read workspace files directly.
  *
  * Slot semantics — the drawer is rendered by chat-view in the same right
  * slot as `<ChatRightSidebar>`. chat-view enforces mutual exclusion so the
@@ -126,14 +145,48 @@ export function DocPreviewDrawer() {
   const docBasePath = searchParams.get("docBase") ?? undefined;
   const docMsgId = searchParams.get("docMsg");
   const hasDocRef = Boolean(docChatId && docAgentId && docPath);
-  // Inline snapshot takes precedence: when the chat-view click handler tagged
-  // the URL with `docMsg`, it also seeded the React Query cache under
-  // `docSnapshotQueryKey` so we can render the markdown straight from
-  // memory without hitting the legacy path-based endpoint.
-  const inlineSnapshot =
+  // Inline snapshot takes precedence over the path-based endpoint. Two layers:
+  //   1. Seeded cache: the chat-view click handler stashes the whole message's
+  //      docs[] under `docSnapshotQueryKey`, so the first open is a
+  //      synchronous, network-free read.
+  //   2. Recovery from the message's `metadata.documentContext`: the seeded
+  //      entry has no observer and is GC'd after ~5 min, after which a
+  //      re-render (e.g. the post-send messages refetch) would otherwise fall
+  //      through to a path endpoint that 404s on the cloud topology. The bytes
+  //      are immutable and still in the message row, so re-derive them. See
+  //      the component docblock for the full failure trace.
+  const seededSnapshot =
     docMsgId && docChatId && docPath
       ? queryClient.getQueryData<DocSnapshotEntry>(docSnapshotQueryKey(docChatId, docMsgId, docPath))
       : undefined;
+  // Reactively observe the chat's messages so recovery re-runs when they
+  // hydrate. A plain `getQueryData` peek is non-reactive: on a cold deep-link
+  // reload the messages cache is empty on first render, so a peek would
+  // memoise `undefined` and never recompute once ChatView's fetch lands —
+  // re-introducing the cloud 404 this path exists to prevent. Sharing
+  // ChatView's exact query key makes this a free cache read whenever the chat
+  // is already open; on a reload it fetches the window once.
+  const recoveryEnabled = Boolean(docChatId && docMsgId && docPath && !seededSnapshot);
+  const recoveryMessages = useQuery({
+    queryKey: ["chat-messages", docChatId],
+    queryFn: () => listChatMessages(docChatId ?? "", { limit: 50 }),
+    enabled: recoveryEnabled,
+  });
+  const recoveredSnapshot = useMemo<DocSnapshotEntry | undefined>(() => {
+    if (seededSnapshot || !docMsgId || !docPath) return undefined;
+    const message = recoveryMessages.data?.items.find((item) => item.id === docMsgId);
+    if (!message) return undefined;
+    return documentSnapshotMapFromMetadata(message.metadata)?.get(docPath);
+  }, [seededSnapshot, docMsgId, docPath, recoveryMessages.data]);
+  const inlineSnapshot = seededSnapshot ?? recoveredSnapshot;
+  // Only DEFER the path endpoint while the messages window is still loading for
+  // a snapshot-origin doc — long enough for the common GC / reload recovery to
+  // land without a wasted, soon-to-404 round-trip. Once recovery settles
+  // without a hit (e.g. an in-preview link to a doc that was never one of this
+  // message's snapshots), the path endpoint runs as the legacy single-host
+  // fallback exactly as before. We do NOT gate it out wholesale on `docMsg`:
+  // that would strand in-preview links to non-snapshotted docs on single-host.
+  const awaitingRecovery = recoveryEnabled && !recoveredSnapshot && recoveryMessages.isLoading;
   const isMobile = useIsMobileDocPreview();
   const [drawerWidth, setDrawerWidth] = useState<number>(() =>
     clampDrawerWidth(loadPersistedWidth() ?? defaultDrawerWidth()),
@@ -221,9 +274,11 @@ export function DocPreviewDrawer() {
         path: apiPath,
       }),
     // Skip the network round-trip when we already have an inline snapshot
-    // pre-staged in the React Query cache — see chat-view click handler. Also
-    // skip for a cross key whose owner couldn't be resolved (fail closed).
-    enabled: hasDocRef && !inlineSnapshot && Boolean(fallbackAgentId),
+    // (seeded or recovered), when a cross key's owner couldn't be resolved
+    // (fail closed), or while metadata recovery is still in flight — see
+    // `awaitingRecovery`, which holds this off just long enough for the common
+    // GC / reload recovery to win instead of racing a doomed cloud 404.
+    enabled: hasDocRef && !inlineSnapshot && Boolean(fallbackAgentId) && !awaitingRecovery,
   });
   const resolvedDocPath = inlineSnapshot?.path ?? previewQuery.data?.ref.path ?? docPath;
   const displayDocPath = inlineSnapshot?.path ?? previewQuery.data?.path ?? docPath;
@@ -409,6 +464,11 @@ export function DocPreviewDrawer() {
       <div className="flex-1 overflow-y-auto px-4 py-3">
         {inlineSnapshot ? (
           <Markdown components={markdownComponents}>{inlineSnapshot.content}</Markdown>
+        ) : awaitingRecovery ? (
+          <div className="flex h-full items-center justify-center text-body text-fg-2">
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+            Loading preview
+          </div>
         ) : (
           <>
             {previewQuery.isLoading ? (


### PR DESCRIPTION
## Problem

The doc-preview drawer rendered **"Document not found"** for a preview that was working moments earlier — typically right after the user sent a new message.

Root cause (two compounding flaws):

1. **Observer-less cache → GC'd after ~5 min.** The seeded snapshot lives in a React Query entry written by `setQueryData` and read by `getQueryData` — neither subscribes, so the entry has zero observers and React Query evicts it after the default `gcTime` (~5 min).
2. **No recovery from message metadata.** Once the seeded entry is gone, any re-render (e.g. the `chat-messages` refetch that `sendMut.onSettled` triggers on send) dropped through to `GET /me/docs/preview`. On the cloud topology the server can't read the agent's filesystem, so it 404s — even though the snapshot bytes are immutable and still sitting in the message's `metadata.documentContext`.

## Fix

Recover the snapshot from the message's own metadata instead of trusting only the transient cache:

- The drawer **reactively observes** the `chat-messages` query (sharing ChatView's exact key), so recovery is a free cache read while the chat is open and a single fetch after a cold reload. A non-reactive `getQueryData` peek would memoise `undefined` on a cold load and never recompute.
- The path endpoint is **deferred only while recovery is in flight** (`!awaitingRecovery`), not gated out wholesale on `docMsg`. This preserves the legacy single-host fallback for in-preview links to docs that were never snapshotted.

## Independent review (codex, 3 passes)

- Pass 1 — flagged the cold-reload hole (non-reactive memo). **Fixed** + regression test.
- Pass 2 — flagged that a blanket `!docMsgId` gate stranded in-preview links to non-snapshotted docs on single-host. **Fixed** (defer-not-gate) + regression test.
- Pass 3 — the pagination tail below. Tracked as fast-follow.

## Known limitation (fast-follow)

A message that has scrolled past the newest 50-message window can't be recovered (the list query only fetches the latest 50) and still falls back to the path endpoint → 404 on cloud. This is narrow (deep-link/bookmark to an aged-out doc) and strictly better than before (previously *every* post-GC case 404'd). The robust fix needs a fetch-single-message-by-id endpoint — filed as a follow-up.

## Tests

- `recovers from the warm messages cache when the seeded entry was GC'd (chat open)`
- `recovers by fetching the messages window after a cold reload`
- `still uses the path endpoint for an in-preview link to a non-snapshotted doc`

708 web tests pass · typecheck clean · biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)