### PR TITLE
feat(context-tree): initialize validate workflow

### DIFF
--- a/docs/development/onboarding-context-tree-seed-design.md
+++ b/docs/development/onboarding-context-tree-seed-design.md
@@ -68,13 +68,13 @@ state — **not** wired into onboarding.
 > initial review): the repo is created through the **org installation token**,
 > not the signed-in user's OAuth token. The endpoint hard-requires an
 > **Organization** installation with `repositorySelection: "all"` and the App's
-> `Administration: write` + `Contents: write` repository permissions, and
-> returns distinct status codes when those aren't met:
+> `Administration: write` + `Contents: write` + `Workflows: write` repository
+> permissions, and returns distinct status codes when those aren't met:
 > - `409 organization_installation_required` — installation is a personal/User
 >   account (so **personal-account users cannot use one-click new-tree** — a
 >   real constraint of the Cloud-provision choice);
 > - `409 selected_repositories_unsupported` — installed on selected repos only;
-> - `403 installation_permissions_insufficient` — missing admin/contents write;
+> - `403 installation_permissions_insufficient` — missing admin/contents/workflows write;
 > - `503 no_installation` — no installation connected;
 > - `409 ConflictError` — `org.context_tree` already set.
 
@@ -88,7 +88,8 @@ add agent-driven repo creation.
    creation (the "variant G" host-`gh` fallback) is **dropped** — onboarding
    always provisions via `POST …/context-tree/initialize`. Owner accepted the
    external-customer trade-off this implies (see O3 below): the shared GitHub
-   App must hold repo **Administration: write**, which every customer authorizes.
+   App must hold repo **Administration: write** and **Workflows: write**, which
+   every customer authorizes.
 2. **Gap④ = Option A:** the cloud runtime makes the agent home a real W1
    workspace and writes `.first-tree/workspace.json`, so the skills stay
    layout-agnostic (no per-skill cloud branch, seed's self-check stays a real
@@ -223,9 +224,8 @@ per-chat runtime state already lets the UI show "working" on that chat.
   §3 correction), the prerequisites are on the installation, not a user OAuth
   token:
   - the App's repository permissions must include **`Administration: write`**
-    (governs repo creation) **and `Contents: write`** (to write the root
-    `NODE.md`) — owner reports Administration was set to write ✅; **verify
-    `Contents: write` too**;
+    (governs repo creation), **`Contents: write`** (to write the root
+    `NODE.md`), and **`Workflows: write`** (to write the validation workflow);
   - the team must install the App on a GitHub **Organization** with
     **all repositories** (not a personal account, not selected repos);
   - existing installations are re-prompted to accept new permissions; the change

--- a/docs/github-app-design-zh.md
+++ b/docs/github-app-design-zh.md
@@ -25,6 +25,7 @@ Repository permissions:
 
 - `Administration`: Read and write
 - `Contents`: Read and write
+- `Workflows`: Read and write
 - `Pull requests`: Read and write
 - `Issues`: Read-only
 - `Metadata`: Read-only
@@ -47,7 +48,7 @@ Subscribed events:
 Operator rollout note:
 
 - Operators must update the GitHub App settings to request
-  `Administration: Read and write`.
+  `Administration: Read and write` and `Workflows: Read and write`.
 - Existing installations must re-approve the permission upgrade in GitHub
   before relying on one-click Context Tree initialization.
 - Until an installation is re-approved, initializer calls return

--- a/packages/server/src/__tests__/context-tree-initialize.test.ts
+++ b/packages/server/src/__tests__/context-tree-initialize.test.ts
@@ -21,6 +21,25 @@ const ACCOUNT_LOGIN = "acme-github";
 const REPO_NAME = "acme-labs-context-tree";
 const CLONE_URL = `https://github.com/${ACCOUNT_LOGIN}/${REPO_NAME}.git`;
 const HTML_URL = `https://github.com/${ACCOUNT_LOGIN}/${REPO_NAME}`;
+const ROOT_NODE_PATH = "NODE.md";
+const VALIDATE_TREE_WORKFLOW_PATH = ".github/workflows/validate-tree.yml";
+const VALIDATE_TREE_WORKFLOW_CONTENT = `name: Validate Context Tree
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Validate Context Tree
+        run: npx -p first-tree first-tree tree verify
+`;
 
 const { privateKey: githubAppPrivateKeyPem } = generateKeyPairSync("rsa", {
   modulusLength: 2048,
@@ -43,14 +62,15 @@ describe("POST /orgs/:orgId/context-tree/initialize", () => {
     vi.restoreAllMocks();
   });
 
-  it("creates an organization repo with the bound installation token, writes NODE.md, and persists context_tree", async () => {
+  it("creates an organization repo with the bound installation token, writes NODE.md and the validation workflow, and persists context_tree", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
     const installationId = await seedInstallation(app, admin.organizationId);
     await renameOrg(app, admin.organizationId, "Acme Labs");
 
     let createRepoPayload: unknown;
-    let createFilePayload: unknown;
+    let createRootNodePayload: unknown;
+    let createWorkflowPayload: unknown;
     const fetchSpy = mockFetch(async (url, init) => {
       if (url === installationTokenUrl(installationId)) {
         expectAuth(init, "Bearer");
@@ -65,14 +85,23 @@ describe("POST /orgs/:orgId/context-tree/initialize", () => {
         expectAuth(init, `Bearer ${INSTALLATION_TOKEN}`);
         return githubRepoResponse(200);
       }
-      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, "NODE.md", "main")) {
+      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, ROOT_NODE_PATH, "main")) {
         expectAuth(init, `Bearer ${INSTALLATION_TOKEN}`);
         return jsonResponse({ message: "Not Found" }, 404);
       }
-      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, "NODE.md")) {
+      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, ROOT_NODE_PATH)) {
         expectAuth(init, `Bearer ${INSTALLATION_TOKEN}`);
-        createFilePayload = parseJsonBody(init);
-        return jsonResponse({ content: { path: "NODE.md" } }, 201);
+        createRootNodePayload = parseJsonBody(init);
+        return jsonResponse({ content: { path: ROOT_NODE_PATH } }, 201);
+      }
+      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, VALIDATE_TREE_WORKFLOW_PATH, "main")) {
+        expectAuth(init, `Bearer ${INSTALLATION_TOKEN}`);
+        return jsonResponse({ message: "Not Found" }, 404);
+      }
+      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, VALIDATE_TREE_WORKFLOW_PATH)) {
+        expectAuth(init, `Bearer ${INSTALLATION_TOKEN}`);
+        createWorkflowPayload = parseJsonBody(init);
+        return jsonResponse({ content: { path: VALIDATE_TREE_WORKFLOW_PATH } }, 201);
       }
       return new Response(`unexpected fetch ${url}`, { status: 500 });
     });
@@ -92,11 +121,11 @@ describe("POST /orgs/:orgId/context-tree/initialize", () => {
       auto_init: false,
       description: "Acme Labs Context Tree",
     });
-    expect(createFilePayload).toMatchObject({
+    expect(createRootNodePayload).toMatchObject({
       branch: "main",
       message: "Initialize Context Tree root node",
     });
-    const nodeContent = readBase64Content(createFilePayload);
+    const nodeContent = readBase64Content(createRootNodePayload);
     expect(nodeContent).toBe(`---
 title: "Acme Labs Context Tree"
 description: "Shared context, decisions, ownership, and operating knowledge for Acme Labs."
@@ -105,7 +134,12 @@ owners: [${ACCOUNT_LOGIN}]
 
 # Acme Labs's Context Tree
 `);
-    expect(fetchSpy).toHaveBeenCalledTimes(5);
+    expect(createWorkflowPayload).toMatchObject({
+      branch: "main",
+      message: "Initialize Context Tree validation workflow",
+    });
+    expect(readBase64Content(createWorkflowPayload)).toBe(VALIDATE_TREE_WORKFLOW_CONTENT);
+    expect(fetchSpy).toHaveBeenCalledTimes(7);
 
     const setting = await getOrgContextTree(app.db, admin.organizationId);
     expect(setting).toEqual({ repo: CLONE_URL, branch: "main" });
@@ -246,8 +280,9 @@ owners: [${ACCOUNT_LOGIN}]
   });
 
   const permissionCases: Array<[string, Record<string, "read" | "write" | "admin">]> = [
-    ["administration", { administration: "read", contents: "write" }],
-    ["contents", { administration: "write", contents: "read" }],
+    ["administration", { administration: "read", contents: "write", workflows: "write" }],
+    ["contents", { administration: "write", contents: "read", workflows: "write" }],
+    ["workflows", { administration: "write", contents: "write", workflows: "read" }],
   ];
   for (const [missingPermission, permissions] of permissionCases) {
     it(`returns 403 installation_permissions_insufficient when ${missingPermission} is not write`, async () => {
@@ -274,17 +309,25 @@ owners: [${ACCOUNT_LOGIN}]
     const admin = await createTestAdmin(app);
     const installationId = await seedInstallation(app, admin.organizationId);
     await renameOrg(app, admin.organizationId, "Acme Labs");
-    let fileWrites = 0;
+    let rootNodeWrites = 0;
+    let workflowWrites = 0;
     const fetchSpy = mockFetch(async (url) => {
       if (url === installationTokenUrl(installationId)) return installationTokenResponse();
       if (url === orgReposUrl(ACCOUNT_LOGIN)) return jsonResponse({ message: "Repository creation failed." }, 422);
       if (url === repoUrl(ACCOUNT_LOGIN, REPO_NAME)) return githubRepoResponse(200);
-      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, "NODE.md", "main")) {
+      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, ROOT_NODE_PATH, "main")) {
         return jsonResponse({ message: "Not Found" }, 404);
       }
-      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, "NODE.md")) {
-        fileWrites += 1;
-        return jsonResponse({ content: { path: "NODE.md" } }, 201);
+      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, ROOT_NODE_PATH)) {
+        rootNodeWrites += 1;
+        return jsonResponse({ content: { path: ROOT_NODE_PATH } }, 201);
+      }
+      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, VALIDATE_TREE_WORKFLOW_PATH, "main")) {
+        return jsonResponse({ message: "Not Found" }, 404);
+      }
+      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, VALIDATE_TREE_WORKFLOW_PATH)) {
+        workflowWrites += 1;
+        return jsonResponse({ content: { path: VALIDATE_TREE_WORKFLOW_PATH } }, 201);
       }
       return new Response(`unexpected fetch ${url}`, { status: 500 });
     });
@@ -292,8 +335,9 @@ owners: [${ACCOUNT_LOGIN}]
     const res = await initialize(app, admin);
 
     expect(res.statusCode).toBe(201);
-    expect(fileWrites).toBe(1);
-    expect(fetchSpy).toHaveBeenCalledTimes(5);
+    expect(rootNodeWrites).toBe(1);
+    expect(workflowWrites).toBe(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(7);
     expect(await getOrgContextTree(app.db, admin.organizationId)).toEqual({ repo: CLONE_URL, branch: "main" });
   });
 
@@ -317,7 +361,44 @@ owners: [${ACCOUNT_LOGIN}]
     expect((await getOrgContextTree(app.db, admin.organizationId)).repo).toBeUndefined();
   });
 
-  it("adopts an existing repo with an existing NODE.md without rewriting the file", async () => {
+  it("adopts an existing repo with an existing NODE.md without rewriting it and writes the missing workflow", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const installationId = await seedInstallation(app, admin.organizationId);
+    await renameOrg(app, admin.organizationId, "Acme Labs");
+    let rootNodeWrites = 0;
+    let workflowWrites = 0;
+    const fetchSpy = mockFetch(async (url) => {
+      if (url === installationTokenUrl(installationId)) return installationTokenResponse();
+      if (url === orgReposUrl(ACCOUNT_LOGIN)) return jsonResponse({ message: "Repository creation failed." }, 422);
+      if (url === repoUrl(ACCOUNT_LOGIN, REPO_NAME)) return githubRepoResponse(200);
+      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, ROOT_NODE_PATH, "main")) {
+        return jsonResponse({ path: ROOT_NODE_PATH }, 200);
+      }
+      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, ROOT_NODE_PATH)) {
+        rootNodeWrites += 1;
+        return jsonResponse({ content: { path: ROOT_NODE_PATH } }, 201);
+      }
+      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, VALIDATE_TREE_WORKFLOW_PATH, "main")) {
+        return jsonResponse({ message: "Not Found" }, 404);
+      }
+      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, VALIDATE_TREE_WORKFLOW_PATH)) {
+        workflowWrites += 1;
+        return jsonResponse({ content: { path: VALIDATE_TREE_WORKFLOW_PATH } }, 201);
+      }
+      return new Response(`unexpected fetch ${url}`, { status: 500 });
+    });
+
+    const res = await initialize(app, admin);
+
+    expect(res.statusCode).toBe(201);
+    expect(rootNodeWrites).toBe(0);
+    expect(workflowWrites).toBe(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(6);
+    expect(await getOrgContextTree(app.db, admin.organizationId)).toEqual({ repo: CLONE_URL, branch: "main" });
+  });
+
+  it("adopts an existing repo with an existing validation workflow without rewriting it", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
     const installationId = await seedInstallation(app, admin.organizationId);
@@ -327,12 +408,18 @@ owners: [${ACCOUNT_LOGIN}]
       if (url === installationTokenUrl(installationId)) return installationTokenResponse();
       if (url === orgReposUrl(ACCOUNT_LOGIN)) return jsonResponse({ message: "Repository creation failed." }, 422);
       if (url === repoUrl(ACCOUNT_LOGIN, REPO_NAME)) return githubRepoResponse(200);
-      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, "NODE.md", "main")) {
-        return jsonResponse({ path: "NODE.md" }, 200);
+      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, ROOT_NODE_PATH, "main")) {
+        return jsonResponse({ path: ROOT_NODE_PATH }, 200);
       }
-      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, "NODE.md")) {
+      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, VALIDATE_TREE_WORKFLOW_PATH, "main")) {
+        return jsonResponse({ path: VALIDATE_TREE_WORKFLOW_PATH }, 200);
+      }
+      if (
+        url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, ROOT_NODE_PATH) ||
+        url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, VALIDATE_TREE_WORKFLOW_PATH)
+      ) {
         fileWrites += 1;
-        return jsonResponse({ content: { path: "NODE.md" } }, 201);
+        return jsonResponse({ content: { path: ROOT_NODE_PATH } }, 201);
       }
       return new Response(`unexpected fetch ${url}`, { status: 500 });
     });
@@ -341,9 +428,82 @@ owners: [${ACCOUNT_LOGIN}]
 
     expect(res.statusCode).toBe(201);
     expect(fileWrites).toBe(0);
-    expect(fetchSpy).toHaveBeenCalledTimes(4);
+    expect(fetchSpy).toHaveBeenCalledTimes(5);
     expect(await getOrgContextTree(app.db, admin.organizationId)).toEqual({ repo: CLONE_URL, branch: "main" });
   });
+
+  it("returns 502 and does not persist context_tree when the validation workflow write fails", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const installationId = await seedInstallation(app, admin.organizationId);
+    await renameOrg(app, admin.organizationId, "Acme Labs");
+    const fetchSpy = mockFetch(async (url) => {
+      if (url === installationTokenUrl(installationId)) return installationTokenResponse();
+      if (url === orgReposUrl(ACCOUNT_LOGIN)) return githubRepoResponse(201);
+      if (url === repoUrl(ACCOUNT_LOGIN, REPO_NAME)) return githubRepoResponse(200);
+      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, ROOT_NODE_PATH, "main")) {
+        return jsonResponse({ message: "Not Found" }, 404);
+      }
+      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, ROOT_NODE_PATH)) {
+        return jsonResponse({ content: { path: ROOT_NODE_PATH } }, 201);
+      }
+      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, VALIDATE_TREE_WORKFLOW_PATH, "main")) {
+        return jsonResponse({ message: "Not Found" }, 404);
+      }
+      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, VALIDATE_TREE_WORKFLOW_PATH)) {
+        return jsonResponse({ message: "GitHub unavailable" }, 500);
+      }
+      return new Response(`unexpected fetch ${url}`, { status: 500 });
+    });
+
+    const res = await initialize(app, admin);
+
+    expect(res.statusCode).toBe(502);
+    expect(res.json()).toMatchObject({ code: "upstream" });
+    expect(fetchSpy).toHaveBeenCalledTimes(7);
+    expect((await getOrgContextTree(app.db, admin.organizationId)).repo).toBeUndefined();
+  });
+
+  for (const createConflictStatus of [409, 422]) {
+    it(`initializes successfully when validation workflow create returns ${createConflictStatus} and the file now exists`, async () => {
+      const app = getApp();
+      const admin = await createTestAdmin(app);
+      const installationId = await seedInstallation(app, admin.organizationId);
+      await renameOrg(app, admin.organizationId, "Acme Labs");
+      let workflowReadCalls = 0;
+      let workflowCreateCalls = 0;
+      const fetchSpy = mockFetch(async (url) => {
+        if (url === installationTokenUrl(installationId)) return installationTokenResponse();
+        if (url === orgReposUrl(ACCOUNT_LOGIN)) return githubRepoResponse(201);
+        if (url === repoUrl(ACCOUNT_LOGIN, REPO_NAME)) return githubRepoResponse(200);
+        if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, ROOT_NODE_PATH, "main")) {
+          return jsonResponse({ message: "Not Found" }, 404);
+        }
+        if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, ROOT_NODE_PATH)) {
+          return jsonResponse({ content: { path: ROOT_NODE_PATH } }, 201);
+        }
+        if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, VALIDATE_TREE_WORKFLOW_PATH, "main")) {
+          workflowReadCalls += 1;
+          return workflowReadCalls === 1
+            ? jsonResponse({ message: "Not Found" }, 404)
+            : jsonResponse({ path: VALIDATE_TREE_WORKFLOW_PATH }, 200);
+        }
+        if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, VALIDATE_TREE_WORKFLOW_PATH)) {
+          workflowCreateCalls += 1;
+          return jsonResponse({ message: "File already exists" }, createConflictStatus);
+        }
+        return new Response(`unexpected fetch ${url}`, { status: 500 });
+      });
+
+      const res = await initialize(app, admin);
+
+      expect(res.statusCode).toBe(201);
+      expect(workflowReadCalls).toBe(2);
+      expect(workflowCreateCalls).toBe(1);
+      expect(fetchSpy).toHaveBeenCalledTimes(8);
+      expect(await getOrgContextTree(app.db, admin.organizationId)).toEqual({ repo: CLONE_URL, branch: "main" });
+    });
+  }
 
   it("can retry successfully when the root-node write failed after repo creation", async () => {
     const app = getApp();
@@ -351,7 +511,8 @@ owners: [${ACCOUNT_LOGIN}]
     const installationId = await seedInstallation(app, admin.organizationId);
     await renameOrg(app, admin.organizationId, "Acme Labs");
     let repoCreateCalls = 0;
-    let fileWriteCalls = 0;
+    let rootNodeWriteCalls = 0;
+    let workflowWriteCalls = 0;
     mockFetch(async (url) => {
       if (url === installationTokenUrl(installationId)) return installationTokenResponse();
       if (url === orgReposUrl(ACCOUNT_LOGIN)) {
@@ -361,14 +522,21 @@ owners: [${ACCOUNT_LOGIN}]
           : jsonResponse({ message: "Repository creation failed." }, 422);
       }
       if (url === repoUrl(ACCOUNT_LOGIN, REPO_NAME)) return githubRepoResponse(200);
-      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, "NODE.md", "main")) {
+      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, ROOT_NODE_PATH, "main")) {
         return jsonResponse({ message: "Not Found" }, 404);
       }
-      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, "NODE.md")) {
-        fileWriteCalls += 1;
-        return fileWriteCalls === 1
+      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, ROOT_NODE_PATH)) {
+        rootNodeWriteCalls += 1;
+        return rootNodeWriteCalls === 1
           ? jsonResponse({ message: "GitHub unavailable" }, 500)
-          : jsonResponse({ content: { path: "NODE.md" } }, 201);
+          : jsonResponse({ content: { path: ROOT_NODE_PATH } }, 201);
+      }
+      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, VALIDATE_TREE_WORKFLOW_PATH, "main")) {
+        return jsonResponse({ message: "Not Found" }, 404);
+      }
+      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, VALIDATE_TREE_WORKFLOW_PATH)) {
+        workflowWriteCalls += 1;
+        return jsonResponse({ content: { path: VALIDATE_TREE_WORKFLOW_PATH } }, 201);
       }
       return new Response(`unexpected fetch ${url}`, { status: 500 });
     });
@@ -381,17 +549,19 @@ owners: [${ACCOUNT_LOGIN}]
     const second = await initialize(app, admin);
     expect(second.statusCode).toBe(201);
     expect(repoCreateCalls).toBe(2);
-    expect(fileWriteCalls).toBe(2);
+    expect(rootNodeWriteCalls).toBe(2);
+    expect(workflowWriteCalls).toBe(1);
     expect(await getOrgContextTree(app.db, admin.organizationId)).toEqual({ repo: CLONE_URL, branch: "main" });
   });
 
-  it("can retry successfully when DB save failed after repo creation and root-node write", async () => {
+  it("can retry successfully when DB save failed after repo creation, root-node write, and workflow write", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
     const installationId = await seedInstallation(app, admin.organizationId);
     await renameOrg(app, admin.organizationId, "Acme Labs");
     let repoCreateCalls = 0;
     let rootNodeExists = false;
+    let workflowExists = false;
     vi.spyOn(app.db, "transaction").mockRejectedValueOnce(new Error("db down"));
     mockFetch(async (url) => {
       if (url === installationTokenUrl(installationId)) return installationTokenResponse();
@@ -402,12 +572,23 @@ owners: [${ACCOUNT_LOGIN}]
           : jsonResponse({ message: "Repository creation failed." }, 422);
       }
       if (url === repoUrl(ACCOUNT_LOGIN, REPO_NAME)) return githubRepoResponse(200);
-      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, "NODE.md", "main")) {
-        return rootNodeExists ? jsonResponse({ path: "NODE.md" }, 200) : jsonResponse({ message: "Not Found" }, 404);
+      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, ROOT_NODE_PATH, "main")) {
+        return rootNodeExists
+          ? jsonResponse({ path: ROOT_NODE_PATH }, 200)
+          : jsonResponse({ message: "Not Found" }, 404);
       }
-      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, "NODE.md")) {
+      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, ROOT_NODE_PATH)) {
         rootNodeExists = true;
-        return jsonResponse({ content: { path: "NODE.md" } }, 201);
+        return jsonResponse({ content: { path: ROOT_NODE_PATH } }, 201);
+      }
+      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, VALIDATE_TREE_WORKFLOW_PATH, "main")) {
+        return workflowExists
+          ? jsonResponse({ path: VALIDATE_TREE_WORKFLOW_PATH }, 200)
+          : jsonResponse({ message: "Not Found" }, 404);
+      }
+      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, VALIDATE_TREE_WORKFLOW_PATH)) {
+        workflowExists = true;
+        return jsonResponse({ content: { path: VALIDATE_TREE_WORKFLOW_PATH } }, 201);
       }
       return new Response(`unexpected fetch ${url}`, { status: 500 });
     });
@@ -415,6 +596,7 @@ owners: [${ACCOUNT_LOGIN}]
     const first = await initialize(app, admin);
     expect(first.statusCode).toBe(500);
     expect(rootNodeExists).toBe(true);
+    expect(workflowExists).toBe(true);
     expect((await getOrgContextTree(app.db, admin.organizationId)).repo).toBeUndefined();
 
     const second = await initialize(app, admin);
@@ -462,7 +644,7 @@ async function seedInstallation(
       accountType: opts.accountType ?? "Organization",
       accountLogin: opts.accountLogin ?? ACCOUNT_LOGIN,
       accountGithubId: installationId + 1_000_000,
-      permissions: opts.permissions ?? { administration: "write", contents: "write" },
+      permissions: opts.permissions ?? { administration: "write", contents: "write", workflows: "write" },
       events: opts.repositoryEvents ?? ["push"],
       suspendedAt: opts.suspendedAt ?? null,
     },
@@ -512,7 +694,7 @@ function installationTokenResponse(
     {
       token: INSTALLATION_TOKEN,
       expires_at: "2026-05-15T01:00:00Z",
-      permissions: overrides.permissions ?? { administration: "write", contents: "write" },
+      permissions: overrides.permissions ?? { administration: "write", contents: "write", workflows: "write" },
       repository_selection: overrides.repository_selection ?? "all",
     },
     201,

--- a/packages/server/src/__tests__/oauth-flow.test.ts
+++ b/packages/server/src/__tests__/oauth-flow.test.ts
@@ -399,7 +399,12 @@ describe("OAuth callback rejects malformed state", () => {
     expect(row?.hubOrganizationId).not.toBeNull();
     // App-declared permissions mirror D0b — the dev stub looks like a real
     // install for downstream QA.
-    expect(row?.permissions).toMatchObject({ administration: "write", contents: "write", members: "read" });
+    expect(row?.permissions).toMatchObject({
+      administration: "write",
+      contents: "write",
+      workflows: "write",
+      members: "read",
+    });
   });
 
   it("dev-callback without installationId leaves github_app_installations untouched (legacy OAuth-only dev flow)", async () => {

--- a/packages/server/src/api/auth/github.ts
+++ b/packages/server/src/api/auth/github.ts
@@ -280,6 +280,7 @@ export async function githubOauthRoutes(app: FastifyInstance): Promise<void> {
             permissions: {
               administration: "write",
               contents: "write",
+              workflows: "write",
               pull_requests: "write",
               issues: "read",
               metadata: "read",

--- a/packages/server/src/api/orgs/context-tree.ts
+++ b/packages/server/src/api/orgs/context-tree.ts
@@ -17,6 +17,24 @@ import { getOrganization } from "../../services/organization.js";
 
 const BRANCH = "main";
 const ROOT_NODE_PATH = "NODE.md";
+const VALIDATE_TREE_WORKFLOW_PATH = ".github/workflows/validate-tree.yml";
+const VALIDATE_TREE_WORKFLOW_CONTENT = `name: Validate Context Tree
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Validate Context Tree
+        run: npx -p first-tree first-tree tree verify
+`;
 const REPO_SUFFIX = "-context-tree";
 const GITHUB_REPO_NAME_MAX_LENGTH = 100;
 
@@ -57,7 +75,7 @@ export async function orgContextTreeRoutes(app: FastifyInstance): Promise<void> 
     if (!hasInitializationPermissions(mint.permissions)) {
       return reply.status(403).send({
         error:
-          "The GitHub App installation needs administration: write and contents: write permissions to initialize a Context Tree repo.",
+          "The GitHub App installation needs administration: write, contents: write, and workflows: write permissions to initialize a Context Tree repo.",
         code: "installation_permissions_insufficient",
       });
     }
@@ -115,7 +133,14 @@ export async function orgContextTreeRoutes(app: FastifyInstance): Promise<void> 
 
     const nodeContent = initialRootNode(teamName, installation.accountLogin);
     try {
-      await ensureRootNode(mint.token, repo, nodeContent);
+      await ensureRepoFile(mint.token, repo, {
+        path: ROOT_NODE_PATH,
+        content: nodeContent,
+        commitMessage: "Initialize Context Tree root node",
+        verifyErrorMessage: "Couldn't verify the Context Tree root node. Try again in a moment.",
+        createErrorMessage: "Couldn't initialize the Context Tree root node. Try again in a moment.",
+        verifyExistingErrorMessage: "Couldn't verify the existing Context Tree root node. Try again in a moment.",
+      });
     } catch (err) {
       if (err instanceof ContextTreeInitializeError) {
         app.log.warn(
@@ -125,6 +150,7 @@ export async function orgContextTreeRoutes(app: FastifyInstance): Promise<void> 
             userId: scope.userId,
             repo: repo.fullName,
             nodePath: ROOT_NODE_PATH,
+            filePath: ROOT_NODE_PATH,
             code: err.code,
           },
           "context tree initialize: create root node failed",
@@ -138,8 +164,49 @@ export async function orgContextTreeRoutes(app: FastifyInstance): Promise<void> 
           userId: scope.userId,
           repo: repo.fullName,
           nodePath: ROOT_NODE_PATH,
+          filePath: ROOT_NODE_PATH,
         },
         "context tree initialize: create root node failed",
+      );
+      throw err;
+    }
+
+    try {
+      await ensureRepoFile(mint.token, repo, {
+        path: VALIDATE_TREE_WORKFLOW_PATH,
+        content: VALIDATE_TREE_WORKFLOW_CONTENT,
+        commitMessage: "Initialize Context Tree validation workflow",
+        verifyErrorMessage: "Couldn't verify the Context Tree validation workflow. Try again in a moment.",
+        createErrorMessage: "Couldn't initialize the Context Tree validation workflow. Try again in a moment.",
+        verifyExistingErrorMessage:
+          "Couldn't verify the existing Context Tree validation workflow. Try again in a moment.",
+      });
+    } catch (err) {
+      if (err instanceof ContextTreeInitializeError) {
+        app.log.warn(
+          {
+            err,
+            organizationId: scope.organizationId,
+            userId: scope.userId,
+            repo: repo.fullName,
+            workflowPath: VALIDATE_TREE_WORKFLOW_PATH,
+            filePath: VALIDATE_TREE_WORKFLOW_PATH,
+            code: err.code,
+          },
+          "context tree initialize: create validation workflow failed",
+        );
+        return reply.status(err.statusCode).send({ error: err.message, code: err.code });
+      }
+      app.log.warn(
+        {
+          err,
+          organizationId: scope.organizationId,
+          userId: scope.userId,
+          repo: repo.fullName,
+          workflowPath: VALIDATE_TREE_WORKFLOW_PATH,
+          filePath: VALIDATE_TREE_WORKFLOW_PATH,
+        },
+        "context tree initialize: create validation workflow failed",
       );
       throw err;
     }
@@ -159,6 +226,7 @@ export async function orgContextTreeRoutes(app: FastifyInstance): Promise<void> 
         userId: scope.userId,
         repo: repo.fullName,
         nodePath: ROOT_NODE_PATH,
+        workflowPath: VALIDATE_TREE_WORKFLOW_PATH,
       },
       "context tree initialize: saved organization setting",
     );
@@ -207,7 +275,9 @@ function sendMintFailure(
 }
 
 function hasInitializationPermissions(permissions: Record<string, "read" | "write" | "admin">): boolean {
-  return permissions.administration === "write" && permissions.contents === "write";
+  return (
+    permissions.administration === "write" && permissions.contents === "write" && permissions.workflows === "write"
+  );
 }
 
 async function createOrAdoptContextTreeRepo(input: {
@@ -263,18 +333,29 @@ async function adoptExistingRepository(
   }
 }
 
-async function ensureRootNode(installationToken: string, repo: GithubCreatedRepo, nodeContent: string): Promise<void> {
+async function ensureRepoFile(
+  installationToken: string,
+  repo: GithubCreatedRepo,
+  input: {
+    path: string;
+    content: string;
+    commitMessage: string;
+    verifyErrorMessage: string;
+    createErrorMessage: string;
+    verifyExistingErrorMessage: string;
+  },
+): Promise<void> {
   try {
     await getRepoFileWithToken(installationToken, {
       owner: repo.ownerLogin,
       repo: repo.name,
-      path: ROOT_NODE_PATH,
+      path: input.path,
       branch: BRANCH,
     });
     return;
   } catch (err) {
     if (!(err instanceof GithubAppApiError) || err.status !== 404) {
-      throw mapUpstreamError(err, "Couldn't verify the Context Tree root node. Try again in a moment.");
+      throw mapUpstreamError(err, input.verifyErrorMessage);
     }
   }
 
@@ -282,30 +363,35 @@ async function ensureRootNode(installationToken: string, repo: GithubCreatedRepo
     await createRepoFileWithToken(installationToken, {
       owner: repo.ownerLogin,
       repo: repo.name,
-      path: ROOT_NODE_PATH,
+      path: input.path,
       branch: BRANCH,
-      message: "Initialize Context Tree root node",
-      contentBase64: Buffer.from(nodeContent, "utf8").toString("base64"),
+      message: input.commitMessage,
+      contentBase64: Buffer.from(input.content, "utf8").toString("base64"),
     });
   } catch (err) {
     if (err instanceof GithubAppApiError && (err.status === 409 || err.status === 422)) {
-      await verifyExistingRootNode(installationToken, repo);
+      await verifyExistingRepoFile(installationToken, repo, input.path, input.verifyExistingErrorMessage);
       return;
     }
-    throw mapUpstreamError(err, "Couldn't initialize the Context Tree root node. Try again in a moment.");
+    throw mapUpstreamError(err, input.createErrorMessage);
   }
 }
 
-async function verifyExistingRootNode(installationToken: string, repo: GithubCreatedRepo): Promise<void> {
+async function verifyExistingRepoFile(
+  installationToken: string,
+  repo: GithubCreatedRepo,
+  path: string,
+  errorMessage: string,
+): Promise<void> {
   try {
     await getRepoFileWithToken(installationToken, {
       owner: repo.ownerLogin,
       repo: repo.name,
-      path: ROOT_NODE_PATH,
+      path,
       branch: BRANCH,
     });
   } catch (err) {
-    throw mapUpstreamError(err, "Couldn't verify the existing Context Tree root node. Try again in a moment.");
+    throw mapUpstreamError(err, errorMessage);
   }
 }
 


### PR DESCRIPTION
## Summary
- Ensure Context Tree initialization creates `.github/workflows/validate-tree.yml` after `NODE.md` and before persisting the org `context_tree` setting.
- Generalize repo file initialization so existing files are preserved and 409/422 create races are verified by re-reading the file.
- Require `workflows: write` alongside `administration: write` and `contents: write`, and update the dev GitHub App stub/docs to match.

## Tests
- `pnpm exec biome check packages/server/src/api/orgs/context-tree.ts packages/server/src/api/auth/github.ts packages/server/src/__tests__/context-tree-initialize.test.ts packages/server/src/__tests__/oauth-flow.test.ts docs/github-app-design-zh.md docs/development/onboarding-context-tree-seed-design.md`
- `pnpm --filter @first-tree/server test -- context-tree-initialize oauth-flow`
- `pnpm typecheck`

## Notes
- `pnpm check` was run and still fails on pre-existing unrelated diagnostics in `packages/client/src/runtime/workspace-migrations.ts` and untracked `packages/skill-evals/.runs/**` JSON formatting output.
