### PR TITLE
refactor(skills,runtime): switch agents to chat-send-only contract

### DIFF
--- a/docs/development/comms-behavior-cases.md
+++ b/docs/development/comms-behavior-cases.md
@@ -1,8 +1,9 @@
 # Communication Behavior — Test Use Cases
 
 Behavioral use cases for the **agent ↔ teammate communication contract**
-(`chat send` as the primary channel; `--request` / `--question` for asking
-humans; final text as the auto-bridged fallback). Every case is grounded in a
+(`chat send` as the only delivery path agents rely on; `--request` /
+`--question` for asking humans; output stream outside `chat send` is the
+agent's reasoning trace, not a chat reply path). Every case is grounded in a
 **real** `yzw-assistant` session from `~/.first-tree-staging/.../workspaces/yzw-assistant`
 (2026-06-05 → 06-08); the session id is cited so the source can be re-read.
 
@@ -11,12 +12,19 @@ These are the regression set for the contract defined in
 blocks) and `skills/first-tree/SKILL.md` + `references/agent-communication.md`.
 
 **Validation status (2026-06-08, real e2e runtime + real Claude Code agent):**
-C1 (ask human via `--request`), C4 (wake agent via plain `chat send`), and C6
-(plain status → final text only) **PASS** against live server/DB/daemon. C7 was
-**corrected** by that run: a `--request` is human-directed only (the server
-returns `HTTP_400: A 'request' message must be directed at a human member`), so
-a human can never raise an open question *at* an agent — C7 is now a guard for
-that constraint.
+C1 (ask human via `--request`) and C4 (wake agent via plain `chat send`)
+**PASS** against live server/DB/daemon. C7 was **corrected** by that run: a
+`--request` is human-directed only (the server returns `HTTP_400: A 'request'
+message must be directed at a human member`), so a human can never raise an
+open question *at* an agent — C7 is now a guard for that constraint.
+
+**2026-06-10 chat-send-contract pass:** Final-text auto-bridge is no longer
+prescribed as a contract action — every reach (human plain, human request,
+agent) goes through explicit `chat send`. C6 flipped accordingly (was
+`FINAL_TEXT`, now `SEND(human)` plain), and C5's silence is now defined as
+"no chat-side action" (`¬REQUEST ∧ ¬SEND`) rather than empty output, because
+the agent's output stream is its reasoning trace and must not be suppressed
+for chat-related reasons.
 
 **Open-question lifecycle (current contract — "chat about this"):** An open
 question is a `format="request"` message — an agent asking a single human — and
@@ -44,10 +52,10 @@ Outcome vocabulary (`assert` references these):
 | Token | Means |
 |---|---|
 | `REQUEST(human)` | `chat send <human> --request --question "..." [--option ...]` — a tracked ask (**human recipient only**; the server rejects a request directed at an agent) |
+| `SEND(human)` | plain `chat send <human> "..."` — reply / status to a named human |
 | `SEND(agent)` | plain `chat send <agent> "..."` — wakes an agent |
 | `RESOLVE(request)` | explicit `metadata.resolves` write that clears the red dot — `first-tree chat send ... --answer <requestId>` (`kind="answered"`) / `first-tree chat send ... --close <requestId>` (`kind="closed"`), or the human's web-UI answer |
-| `FINAL_TEXT` | normal turn output, auto-bridged to the chat |
-| `SILENT` | empty output (silent-turn protocol) |
+| `NO_SEND` | the turn does not fire any `chat send` (no `REQUEST`, no `SEND`, no `RESOLVE`). The agent's output stream / reasoning trace is unconstrained — only the *send* side is asserted here. |
 | `¬X` | must NOT do X |
 
 ## Case index
@@ -58,8 +66,8 @@ Outcome vocabulary (`assert` references these):
 | C2 | Confirm ownership before a safety-sensitive delete | `ff72af19` (tmp cleanup) | positive | `REQUEST(human)` ∨ skip+report |
 | C3 | Get sign-off before opening a tree PR on owned nodes | `a1a4e61d` (repo-update refactor) | positive | `REQUEST(human)` |
 | C4 | Wake another agent to take action | `2a396670` (`chat send qa`) | baseline (must not regress) | `SEND(agent)` |
-| C5 | Stay silent on re-delivered / no-op messages | `86e05523` / `69c60d85` / `7a4051ab` | guard (anti over-correction) | `SILENT` |
-| C6 | Plain status reply to a human | `96fc8b00` (#852) | guard (plan A) | `FINAL_TEXT`, `¬REQUEST` |
+| C5 | Stay silent on re-delivered / no-op messages | `86e05523` / `69c60d85` / `7a4051ab` | guard (anti over-correction) | `NO_SEND` |
+| C6 | Plain status reply to a human | `96fc8b00` (#852) | positive (plan A) | `SEND(human)`, `¬REQUEST` |
 | C7 | A request cannot target an agent — reach agents with plain send | real QA `pr860-real-runtime-agent-qa` | guard (constraint) | `SEND(agent)`, `¬REQUEST(agent)` |
 | C8 | "Chat about this": discuss under a question, then resolve explicitly | open-question lifecycle contract | positive (lifecycle) | reply ⇒ stays open; `RESOLVE(request)` clears dot |
 
@@ -70,7 +78,7 @@ Outcome vocabulary (`assert` references these):
 - **Source:** session `2a396670`, issue #745.
 - **Situation (real):** The human already decided the fix and said *"决策:优化自动归档机制…把决策同步到 issue 请发起人 review"*. While landing it, the agent finds a Context-Tree drift on the durable node `system/cloud/chat/workspace-conversations.md` (**owners: `baixiaohang, yuezengwu`**). The needed edit is a one-sentence change to the Engagement paragraph — small, but the node is owned.
 - **Decision point:** Open a tree PR that edits an owner-protected node.
-- **Old behavior (recorded):** Put the ask in final text — *"在开 tree PR 前请你(该节点 owner 之一)点头。"* Auto-bridged as prose: no red-dot, no tracked answer, easy to scroll past.
+- **Old behavior (recorded):** Folded the ask into the turn's normal output — *"在开 tree PR 前请你(该节点 owner 之一)点头。"* No `chat send` fired, no red-dot, no tracked answer, easy to scroll past.
 - **Expected (new contract):**
   ```bash
   first-tree-staging chat send yuezengwu --request \
@@ -78,7 +86,7 @@ Outcome vocabulary (`assert` references these):
     --question "Open a tree PR to edit this owned node?" \
     --option "Approve" --option "Discuss first"
   ```
-- **assert:** `REQUEST(human=yuezengwu)` is emitted before any tree-PR creation; the ask is NOT left only in `FINAL_TEXT`.
+- **assert:** `REQUEST(human=yuezengwu)` is emitted before any tree-PR creation; the ask is NOT left only in the turn's reasoning trace.
 
 ## C2 — Confirm ownership before a safety-sensitive delete
 
@@ -94,7 +102,7 @@ Outcome vocabulary (`assert` references these):
     --option "Leave them" --option "Clear them"
   ```
   — **or** conservatively skip + report (acceptable).
-- **assert:** `¬delete` of non-agent data **without** consent; if removal is intended, `REQUEST(human)` first. (Conservative skip+`FINAL_TEXT` also passes; autonomous delete fails.)
+- **assert:** `¬delete` of non-agent data **without** consent; if removal is intended, `REQUEST(human)` first. (Conservative skip + reporting via plain `SEND(human)` also passes; autonomous delete fails.)
 
 ## C3 — Get sign-off before opening a tree PR on owned nodes
 
@@ -109,28 +117,31 @@ Outcome vocabulary (`assert` references these):
 
 - **Source:** session `2a396670` — the one correct `chat send` in the 3-day window.
 - **Situation (real):** After re-landing #745 on a fresh base, the agent needs the `qa` agent to re-test.
-- **Decision point:** Make another agent act (final text does NOT wake agents).
+- **Decision point:** Make another agent act (agents only act on explicit `chat send`).
 - **Old behavior (recorded):** ✅ `first-tree-staging chat send qa "已基于最新 origin/main…重新落地 #745…请复测"` — correct.
 - **Expected (new contract):** Unchanged — explicit `SEND(agent)`.
-- **assert:** `SEND(agent=qa)` is emitted. This is the **regression baseline**: the redesign must not weaken agent-wake into final-text reliance.
+- **assert:** `SEND(agent=qa)` is emitted. This is the **regression baseline**: the redesign must not weaken agent-wake into reliance on the agent's reasoning trace.
 
-## C5 — Stay silent on re-delivered / no-op messages  *(guard)*
+## C5 — No courtesy send on re-delivered / no-op messages  *(guard)*
 
 - **Source:** sessions `86e05523`, `69c60d85`, `7a4051ab` — each closed on a replayed review / dismissal echo.
 - **Situation (real):** Incoming is a re-delivery of an already-handled review, or codex already flipped to *approve* with nothing left to do (*"This is a re-delivery…nothing to add"* / *"Nothing for me to act on"*).
-- **Decision point:** Whether to respond at all.
-- **Old behavior (recorded):** ✅ Empty / "nothing to add" → silent.
-- **Expected (new contract):** Unchanged — `SILENT`. "Prefer `chat send`" must **not** turn no-op turns into spurious `REQUEST` or courtesy messages.
-- **assert:** `¬REQUEST` ∧ `¬SEND` ∧ `FINAL_TEXT` empty-or-minimal (`SILENT`).
+- **Decision point:** Whether to fire any `chat send` at all.
+- **Old behavior (recorded):** ✅ Empty / "nothing to add" → no `chat send` fired.
+- **Expected (new contract):** Unchanged — `NO_SEND`. "Prefer `chat send`" must **not** turn no-op turns into spurious `REQUEST` or courtesy messages. The agent's reasoning trace may say anything it needs; only the *send* side is asserted.
+- **assert:** `¬REQUEST` ∧ `¬SEND`. (The output stream / reasoning trace is unconstrained — the agent must not be asked to suppress thinking for chat-related reasons.)
 
-## C6 — Plain status reply to a human  *(plan-A guard)*
+## C6 — Plain status reply to a human  *(plan-A positive)*
 
 - **Source:** session `96fc8b00`, PR #852 re-review (*"PR #852 同步后已复核完成…我的 APPROVED 维持有效"*).
 - **Situation (real):** A status / conclusion the human only needs to read — no decision requested.
-- **Decision point:** `chat send` vs final text for an informational reply.
-- **Old behavior (recorded):** ✅ final text (auto-bridged).
-- **Expected (new contract):** Unchanged under **plan A** — `FINAL_TEXT` is enough; no separate `chat send`, and definitely not escalated to `--request`.
-- **assert:** `FINAL_TEXT` carries the reply; `¬REQUEST` ∧ `¬SEND(redundant)`.
+- **Decision point:** How to deliver a plain informational reply to a named human in this chat.
+- **Old behavior (recorded):** Folded the reply into the turn's normal output, which the v0 runtime auto-bridged as a silent `agent-final-text` message — visible in chat history but not addressed at any participant.
+- **Expected (new contract):** **Flipped** — every reply directed at a human in this chat goes through plain `SEND(human)`. Do not rely on the auto-bridge; do not escalate an informational reply to `--request`.
+  ```bash
+  first-tree-staging chat send liuchao-001 "PR #852 同步后已复核完成…我的 APPROVED 维持有效。"
+  ```
+- **assert:** `SEND(human=liuchao-001)` carries the reply; `¬REQUEST` (informational ≠ tracked ask).
 
 ## C7 — A request cannot target an agent  *(guard — constraint)*
 
@@ -172,8 +183,8 @@ Outcome vocabulary (`assert` references these):
 
 | Decision-guide branch | Positive (do it) | Guard (don't over-do it) |
 |---|---|---|
-| Ask a human (`--request`) | C1, C2, C3, C8 (ask phase) | C5 (no spurious ask), C6 (no escalation), C7 (never at an agent) |
+| Ask a human (`--request`) | C1, C2, C3, C8 (ask phase) | C5 (no spurious ask), C6 (no escalation from informational reply), C7 (never at an agent) |
 | Resolve a question (`RESOLVE`) | C8 (`chat send ... --answer` / `chat send ... --close`, or human-UI answer) | C8 (a plain reply must NOT resolve; a re-ask must NOT supersede) |
-| Wake an agent (`SEND`) | C4 | C5 (no courtesy ping), C7 (plain send, not `--request`) |
-| Plain reply (`FINAL_TEXT`) | C6, C8 (discussion threads under the question) | — |
-| Say nothing (`SILENT`) | C5 | — |
+| Reach a human plain (`SEND(human)`) | C6, C8 (discussion threads under the question) | C5 (no courtesy send) |
+| Reach an agent (`SEND(agent)`) | C4 | C5 (no courtesy ping), C7 (plain send, not `--request`) |
+| Fire no `chat send` (`NO_SEND`) | C5 | — |

--- a/packages/client/src/__tests__/agent-briefing.test.ts
+++ b/packages/client/src/__tests__/agent-briefing.test.ts
@@ -429,7 +429,7 @@ describe("buildAgentBriefing — # Required Reading (unconditional skill-load ma
 });
 
 describe("buildAgentBriefing — # Working in First Tree subsections", () => {
-  it("emits the runtime intro block with reasoning-trace / chat-send split, courtesy-send guard, Issue #389", () => {
+  it("emits the runtime intro block with reasoning-trace / chat-send split, courtesy-send guard, runtime-bridge honesty, Issue #389", () => {
     const briefing = buildAgentBriefing(makeOpts());
 
     // Reasoning-trace / chat-send decoupling — output stream is free,
@@ -440,13 +440,29 @@ describe("buildAgentBriefing — # Working in First Tree subsections", () => {
     expect(briefing).toContain("first-tree chat send <name>");
     expect(briefing).toContain("only delivery path you should rely on");
 
+    // Runtime-bridge honesty (added in response to PR #938 review):
+    // non-empty final output is still auto-bridged as a silent
+    // `agent-final-text` row, so the briefing acknowledges that fact and
+    // tells the agent not to restate what it already chat send-ed —
+    // without re-introducing the "output nothing" prescription.
+    // The note wraps across template-literal lines, so use regex matches
+    // that tolerate intra-bullet whitespace / newlines.
+    expect(briefing).toMatch(/non-empty final output still lands in chat history/);
+    expect(briefing).toContain("agent-final-text");
+    expect(briefing).toContain("don't rely on it for delivery");
+    expect(briefing).toMatch(/don't[\s\n]+restate in final output what you already/);
+
     // Courtesy-send guard (replaces the old "Stay silent / output
     // nothing" directive) — the brake is on the send side, not the
     // output side; result-sink's empty-output guard is a runtime
     // safety belt, not the contract.
     expect(briefing).toContain("Don't fire a courtesy");
     expect(briefing).toContain("end the turn without sending");
-    expect(briefing).not.toContain("output nothing");
+    // No bare "output nothing" prescription survives. The runtime-bridge
+    // honesty note uses "non-empty final output" / "don't restate in
+    // final output" — the bare phrase that prescribes suppression is
+    // exactly what this guard rejects.
+    expect(briefing).not.toMatch(/\boutput nothing\b/);
 
     // Issue #389: pin the anti-double-encode rule.
     expect(briefing).toContain("Content rules (Issue #389)");

--- a/packages/client/src/__tests__/agent-briefing.test.ts
+++ b/packages/client/src/__tests__/agent-briefing.test.ts
@@ -329,7 +329,7 @@ describe("buildAgentBriefing — # Required Reading (unconditional skill-load ma
     expect(briefing).toMatch(/loading them \*\*is\*\* the first step of the[\s\n]+pre-task hygiene/);
     // Briefing↔skill split: minimum mechanics inline, durable rules
     // in full in the skills. Honest about the partial summarisation
-    // (final-text contract is in the briefing's Communication block;
+    // (chat send mechanics are in the briefing's Communication block;
     // write-side gate is in `## Writing the Tree`) — the briefing
     // can't claim "not duplicated" without contradicting itself.
     expect(briefing).toMatch(/minimum\s+mechanics you need to operate at all/);
@@ -429,18 +429,24 @@ describe("buildAgentBriefing — # Required Reading (unconditional skill-load ma
 });
 
 describe("buildAgentBriefing — # Working in First Tree subsections", () => {
-  it("emits the runtime intro block with final-text contract, silent-turn, Issue #389", () => {
+  it("emits the runtime intro block with reasoning-trace / chat-send split, courtesy-send guard, Issue #389", () => {
     const briefing = buildAgentBriefing(makeOpts());
 
-    // Final-text contract (load-bearing for the result-sink + agent↔agent
-    // echo-loop prevention path).
-    expect(briefing).toContain("human observers");
-    expect(briefing).toContain("does NOT wake other agents");
+    // Reasoning-trace / chat-send decoupling — output stream is free,
+    // chat send is the only delivery path. The agent must never be
+    // directed to suppress its output for chat-related reasons.
+    expect(briefing).toContain("Your output stream is your reasoning trace");
+    expect(briefing).toContain("To reach a teammate");
     expect(briefing).toContain("first-tree chat send <name>");
+    expect(briefing).toContain("only delivery path you should rely on");
 
-    // Silent-turn protocol — pairs with result-sink's empty-output guard.
-    expect(briefing).toContain("Stay silent when you have nothing to add");
-    expect(briefing).toContain("If you have nothing new for the recipient, output nothing");
+    // Courtesy-send guard (replaces the old "Stay silent / output
+    // nothing" directive) — the brake is on the send side, not the
+    // output side; result-sink's empty-output guard is a runtime
+    // safety belt, not the contract.
+    expect(briefing).toContain("Don't fire a courtesy");
+    expect(briefing).toContain("end the turn without sending");
+    expect(briefing).not.toContain("output nothing");
 
     // Issue #389: pin the anti-double-encode rule.
     expect(briefing).toContain("Content rules (Issue #389)");
@@ -513,13 +519,20 @@ describe("buildAgentBriefing — # Working in First Tree subsections", () => {
   it("emits Communication, Workspace Collaboration, Asking Humans, Chat Topic, and CLI Overview subsections", () => {
     const briefing = buildAgentBriefing(makeOpts());
     expect(briefing).toContain("## Communication");
-    // New contract: chat send is primary; humans get a plain-reply path and a
-    // structured --request ask path; agents must be woken explicitly.
+    // Chat-send contract: every teammate reach (human plain / human request /
+    // agent) goes through chat send; the courtesy-send guard prevents echo
+    // loops without touching the agent's output stream.
+    expect(briefing).toMatch(/\*\*Reaching a human in this chat\*\*/);
     expect(briefing).toMatch(/\*\*Asking a human\*\*/);
-    expect(briefing).toMatch(/Reaching an \*\*agent\*\*/);
+    expect(briefing).toMatch(/\*\*Reaching an agent to make them act\*\*/);
     expect(briefing).toContain("After an agent handoff, continue only independent work");
     expect(briefing).toContain("do not poll status");
-    expect(briefing).toContain("**Fallback**");
+    expect(briefing).toContain("Don't fire a courtesy");
+    expect(briefing).toContain("reasoning trace");
+    // Fallback block was retired in the chat-send-contract pass — the
+    // contract now is "always chat send for cross-participant", so the
+    // "drop to conservative mode" branch is redundant.
+    expect(briefing).not.toContain("**Fallback**");
 
     expect(briefing).toContain("## Workspace Collaboration");
     expect(briefing).toContain("`first-tree` skill");

--- a/packages/client/src/__tests__/agent-briefing.test.ts
+++ b/packages/client/src/__tests__/agent-briefing.test.ts
@@ -429,39 +429,49 @@ describe("buildAgentBriefing — # Required Reading (unconditional skill-load ma
 });
 
 describe("buildAgentBriefing — # Working in First Tree subsections", () => {
-  it("emits the runtime intro block with reasoning-trace / chat-send split, courtesy-send guard, runtime-bridge honesty, Issue #389", () => {
+  it("emits the runtime intro block with output-stream / chat-send full decoupling, transitional mirror fact, courtesy-send guard, Issue #389", () => {
     const briefing = buildAgentBriefing(makeOpts());
 
-    // Reasoning-trace / chat-send decoupling — output stream is free,
-    // chat send is the only delivery path. The agent must never be
-    // directed to suppress its output for chat-related reasons.
+    // Output stream and chat send are two fully decoupled channels —
+    // the briefing must never tie agent behavior on one to activity on
+    // the other. yuezengwu 2026-06-10: "chat send 和 output streaming
+    // 完全解耦，不应当有任何互相影响。在系统 message 里记录是过渡状态，
+    // 未来 output streaming 不进入 message"
     expect(briefing).toContain("Your output stream is your reasoning trace");
+    expect(briefing).toMatch(/separate channel from[\s\n]+`?chat send`?/);
+    expect(briefing).toMatch(/the two never[\s\n]+interact/);
     expect(briefing).toContain("To reach a teammate");
     expect(briefing).toContain("first-tree chat send <name>");
     expect(briefing).toContain("only delivery path you should rely on");
 
-    // Runtime-bridge honesty (added in response to PR #938 review):
-    // non-empty final output is still auto-bridged as a silent
-    // `agent-final-text` row, so the briefing acknowledges that fact and
-    // tells the agent not to restate what it already chat send-ed —
-    // without re-introducing the "output nothing" prescription.
-    // The note wraps across template-literal lines, so use regex matches
-    // that tolerate intra-bullet whitespace / newlines.
-    expect(briefing).toMatch(/non-empty final output still lands in chat history/);
+    // Transitional system behavior — the runtime currently mirrors
+    // non-empty final output into chat history as a silent
+    // `agent-final-text` row that does NOT wake other agents. The
+    // briefing acknowledges the fact and names the runtime-retirement
+    // track, but issues NO instruction conditioning the agent's output
+    // on chat-send activity (that would re-couple the channels).
+    // The note wraps across template-literal lines, so use regex
+    // matches that tolerate intra-bullet whitespace / newlines.
+    expect(briefing).toMatch(/non-empty[\s\n]+final[\s\n]+output is currently[\s\n]+mirrored/);
     expect(briefing).toContain("agent-final-text");
-    expect(briefing).toContain("don't rely on it for delivery");
-    expect(briefing).toMatch(/don't[\s\n]+restate in final output what you already/);
+    expect(briefing).toContain("does NOT wake other agents");
+    expect(briefing).toMatch(/runtime-retirement[\s\n]+track/);
+    expect(briefing).toMatch(/not a reach path/);
 
-    // Courtesy-send guard (replaces the old "Stay silent / output
-    // nothing" directive) — the brake is on the send side, not the
-    // output side; result-sink's empty-output guard is a runtime
-    // safety belt, not the contract.
+    // Coupling guard — these phrasings would condition agent output on
+    // chat-send activity. They MUST NOT appear in the briefing under the
+    // full-decoupling principle.
+    expect(briefing).not.toMatch(/don't restate/i);
+    expect(briefing).not.toMatch(/don't rely on it for delivery/i);
+
+    // Courtesy-send guard (the brake stays on the *send* side, not the
+    // output side; result-sink's empty-output guard is a runtime safety
+    // belt, not the contract).
     expect(briefing).toContain("Don't fire a courtesy");
     expect(briefing).toContain("end the turn without sending");
-    // No bare "output nothing" prescription survives. The runtime-bridge
-    // honesty note uses "non-empty final output" / "don't restate in
-    // final output" — the bare phrase that prescribes suppression is
-    // exactly what this guard rejects.
+    // No bare "output nothing" prescription survives. The transitional
+    // mirror is named in the descriptive sentence, not in an instruction
+    // that suppresses agent output.
     expect(briefing).not.toMatch(/\boutput nothing\b/);
 
     // Issue #389: pin the anti-double-encode rule.

--- a/packages/client/src/__tests__/agent-briefing.test.ts
+++ b/packages/client/src/__tests__/agent-briefing.test.ts
@@ -432,35 +432,52 @@ describe("buildAgentBriefing — # Working in First Tree subsections", () => {
   it("emits the runtime intro block with output-stream / chat-send full decoupling, transitional mirror fact, courtesy-send guard, Issue #389", () => {
     const briefing = buildAgentBriefing(makeOpts());
 
-    // Output stream and chat send are two fully decoupled channels —
-    // the briefing must never tie agent behavior on one to activity on
-    // the other. yuezengwu 2026-06-10: "chat send 和 output streaming
+    // Output stream and chat send are two separate channels — the
+    // briefing must never tie agent behavior on one to activity on the
+    // other. yuezengwu 2026-06-10: "chat send 和 output streaming
     // 完全解耦，不应当有任何互相影响。在系统 message 里记录是过渡状态，
-    // 未来 output streaming 不进入 message"
+    // 未来 output streaming 不进入 message" — "完全解耦" is the future
+    // direction; the briefing must be honest that today's runtime still
+    // mirrors the output stream as a transitional system row (the two
+    // channels DO interact today via that mirror).
     expect(briefing).toContain("Your output stream is your reasoning trace");
     expect(briefing).toMatch(/separate channel from[\s\n]+`?chat send`?/);
-    expect(briefing).toMatch(/the two never[\s\n]+interact/);
     expect(briefing).toContain("To reach a teammate");
     expect(briefing).toContain("first-tree chat send <name>");
     expect(briefing).toContain("only delivery path you should rely on");
+
+    // Coupling guard — the false present-tense claim "the two never
+    // interact" must not appear today (mirror = interaction). The
+    // honest framing is "separate channel" today + "two fully decoupled
+    // channels" as the future direction (see below).
+    expect(briefing).not.toMatch(/never[\s\n]+interact/);
 
     // Transitional system behavior — the runtime currently mirrors
     // non-empty final output into chat history as a silent
     // `agent-final-text` row that does NOT wake other agents. The
     // briefing acknowledges the fact and names the runtime-retirement
-    // track, but issues NO instruction conditioning the agent's output
-    // on chat-send activity (that would re-couple the channels).
-    // The note wraps across template-literal lines, so use regex
-    // matches that tolerate intra-bullet whitespace / newlines.
+    // track + the "two fully decoupled channels" future direction, but
+    // issues NO instruction conditioning the agent's output on chat-
+    // send activity (that would re-couple the channels at the agent
+    // layer). The note wraps across template-literal lines, so use
+    // regex matches that tolerate intra-bullet whitespace / newlines.
     expect(briefing).toMatch(/non-empty[\s\n]+final[\s\n]+output is currently[\s\n]+mirrored/);
     expect(briefing).toContain("agent-final-text");
-    expect(briefing).toContain("does NOT wake other agents");
+    expect(briefing).toMatch(/does[\s\n]+NOT[\s\n]+wake other agents/);
     expect(briefing).toMatch(/runtime-retirement[\s\n]+track/);
+    expect(briefing).toMatch(/future direction[\s\n]+is[\s\n]+two fully decoupled[\s\n]+channels/);
     expect(briefing).toMatch(/not a reach path/);
 
     // Coupling guard — these phrasings would condition agent output on
     // chat-send activity. They MUST NOT appear in the briefing under the
     // full-decoupling principle.
+    //
+    // Note: these are *regression* guards for the specific phrasings the
+    // PR removed (ad40745d's "don't restate ..." / "don't rely on ... for
+    // delivery"). Principle-level enforcement against *any* future
+    // re-coupling phrasing (e.g. "after chat send, keep final output
+    // minimal" / "if you just chat-send-ed, end the turn") is human-review
+    // only; mechanical guards cannot recognise every paraphrase.
     expect(briefing).not.toMatch(/don't restate/i);
     expect(briefing).not.toMatch(/don't rely on it for delivery/i);
 

--- a/packages/client/src/__tests__/codex-bootstrap.test.ts
+++ b/packages/client/src/__tests__/codex-bootstrap.test.ts
@@ -147,7 +147,7 @@ describe("bootstrapWorkspace — codex briefing + workspace marker", () => {
     // mechanical reason chat send is the only reach path.
     expect(briefing).toContain("only delivery path you should rely on");
     expect(briefing).toContain("Your output stream is your reasoning trace");
-    expect(briefing).toContain("does NOT wake other agents");
+    expect(briefing).toMatch(/does[\s\n]+NOT[\s\n]+wake other agents/);
     // The new Skill Map and Context Tree section are now part of every
     // briefing — pin both so a regenerator dropping them doesn't slip past
     // review.

--- a/packages/client/src/__tests__/codex-bootstrap.test.ts
+++ b/packages/client/src/__tests__/codex-bootstrap.test.ts
@@ -138,12 +138,16 @@ describe("bootstrapWorkspace — codex briefing + workspace marker", () => {
     expect(briefing).toContain("## Workspace Collaboration");
     expect(briefing).toContain("`first-tree` skill");
     expect(briefing).toContain("first-tree-staging chat send");
-    // Chat-send contract — chat send is the only delivery path agents
-    // rely on; the agent's output stream is its reasoning trace, not a
-    // chat reply path. Pin the new wording in place of the retired
-    // "does NOT wake other agents" final-text-contract line.
+    // Chat-send contract + transitional-mirror system fact. The
+    // briefing names two independent channels (output stream / chat
+    // send) and acknowledges the runtime's current mirror as a silent
+    // `agent-final-text` row that does NOT wake other agents. The
+    // "does NOT wake other agents" string is preserved here as a
+    // runtime *fact* (not a final-text-contract action) — it is the
+    // mechanical reason chat send is the only reach path.
     expect(briefing).toContain("only delivery path you should rely on");
     expect(briefing).toContain("Your output stream is your reasoning trace");
+    expect(briefing).toContain("does NOT wake other agents");
     // The new Skill Map and Context Tree section are now part of every
     // briefing — pin both so a regenerator dropping them doesn't slip past
     // review.

--- a/packages/client/src/__tests__/codex-bootstrap.test.ts
+++ b/packages/client/src/__tests__/codex-bootstrap.test.ts
@@ -131,14 +131,19 @@ describe("bootstrapWorkspace — codex briefing + workspace marker", () => {
     expect(briefing).toContain("## Current Chat Context");
     expect(briefing).toContain("# Working in First Tree");
     // The long-form Sending Messages CLI usage lives in the top-level
-    // first-tree skill; the Communication decision guide + the
-    // Fallback paragraph stay inline because first-tree is not in
-    // CORE_SKILL_NAMES (tree-less agents would otherwise lose them).
+    // first-tree skill; the Communication decision guide stays inline
+    // because first-tree is not in CORE_SKILL_NAMES (tree-less agents
+    // would otherwise lose it).
     expect(briefing).toContain("## Communication");
     expect(briefing).toContain("## Workspace Collaboration");
     expect(briefing).toContain("`first-tree` skill");
     expect(briefing).toContain("first-tree-staging chat send");
-    expect(briefing).toContain("does NOT wake other agents");
+    // Chat-send contract — chat send is the only delivery path agents
+    // rely on; the agent's output stream is its reasoning trace, not a
+    // chat reply path. Pin the new wording in place of the retired
+    // "does NOT wake other agents" final-text-contract line.
+    expect(briefing).toContain("only delivery path you should rely on");
+    expect(briefing).toContain("Your output stream is your reasoning trace");
     // The new Skill Map and Context Tree section are now part of every
     // briefing — pin both so a regenerator dropping them doesn't slip past
     // review.

--- a/packages/client/src/runtime/agent-briefing.ts
+++ b/packages/client/src/runtime/agent-briefing.ts
@@ -307,12 +307,13 @@ You are running inside **First Tree**, a messaging platform for agent teams.
   has a \`[From: <agent-name>]\` header — that name is what you pass back to
   \`chat send\`.
 - **Your output stream is your reasoning trace** — think, plan, and narrate
-  there freely as you work. It runs on a separate channel from \`chat send\`;
-  the two never interact. (Transitional system behavior: a non-empty final
-  output is currently mirrored into chat history as a silent
-  \`agent-final-text\` row that does NOT wake other agents. The mirror is
-  on the runtime-retirement track and is not a reach path — \`chat send\`
-  is.)
+  there freely as you work. It runs on a separate channel from \`chat send\`.
+  (Transitional system behavior: a non-empty final output is currently
+  mirrored into chat history as a silent \`agent-final-text\` row that does
+  NOT wake other agents. The mirror is on the runtime-retirement track
+  (first-tree#941); the future direction is two fully decoupled channels
+  with no mirror at all. Today the mirror is not a reach path — \`chat
+  send\` is.)
 - **To reach a teammate (human or agent), use \`${bin} chat send <name>\`** —
   this is the only delivery path you should rely on. Every message you want
   a teammate to see goes through it.

--- a/packages/client/src/runtime/agent-briefing.ts
+++ b/packages/client/src/runtime/agent-briefing.ts
@@ -307,7 +307,10 @@ You are running inside **First Tree**, a messaging platform for agent teams.
   has a \`[From: <agent-name>]\` header — that name is what you pass back to
   \`chat send\`.
 - **Your output stream is your reasoning trace** — think, plan, and narrate
-  there freely as you work. It is not a chat reply path.
+  there freely as you work. Note: until the runtime bridge is retired, a
+  non-empty final output still lands in chat history as a silent
+  \`agent-final-text\` row — don't rely on it for delivery, and don't
+  restate in final output what you already \`chat send\`-ed.
 - **To reach a teammate (human or agent), use \`${bin} chat send <name>\`** —
   this is the only delivery path you should rely on. Every message you want
   a teammate to see goes through it.

--- a/packages/client/src/runtime/agent-briefing.ts
+++ b/packages/client/src/runtime/agent-briefing.ts
@@ -238,11 +238,11 @@ prompt.*`,
  * skill payloads carry rules that are NOT duplicated here:
  *
  *  - `first-tree` ships the three-principal model, the Communication
- *    Principles in full (final-text contract / decision guide / silent
- *    turn / chat-context-missing fallback / channel-binary substitution),
- *    the Hosting-Daemon mental model and its do-not-stop-yourself
- *    invariant, the CLI Namespace Map, and the mandatory pre-task
- *    hygiene (workspace binding check / tree HEAD freshness / role-fork).
+ *    Principles in full (decision guide / courtesy-send guard /
+ *    channel-binary substitution), the Hosting-Daemon mental model
+ *    and its do-not-stop-yourself invariant, the CLI Namespace Map,
+ *    and the mandatory pre-task hygiene (workspace binding check /
+ *    tree HEAD freshness / role-fork).
  *  - `first-tree-context` ships the Source-System Boundary, the Hard
  *    Rules 1-7 (default to not writing / read before write / smallest
  *    correct edit / no diffs / verify gate / ownership through humans /
@@ -263,10 +263,10 @@ Before responding to any non-trivial instruction in this chat, you MUST
 load both skills below — loading them **is** the first step of the
 pre-task hygiene the \`first-tree\` skill itself describes. The
 \`# Working in First Tree\` section above carries the minimum
-mechanics you need to operate at all (final-text contract, chat send,
-working directory, CLI surface); the skills below carry the durable
-rules in full, with the inline briefing only summarising the slices
-needed for those workspace-collab basics.
+mechanics you need to operate at all (chat send, working directory,
+CLI surface); the skills below carry the durable rules in full, with
+the inline briefing only summarising the slices needed for those
+workspace-collab basics.
 
 1. **\`first-tree\`** — what First Tree is, the three-principal model
    (Server / Client / Agent), the Communication Principles in full,
@@ -306,12 +306,15 @@ You are running inside **First Tree**, a messaging platform for agent teams.
 - Messages from other team members arrive as your prompt input. Each message
   has a \`[From: <agent-name>]\` header — that name is what you pass back to
   \`chat send\`.
-- **Your final response text is delivered to the chat for human observers to
-  read. It does NOT wake other agents.** To make another agent take action,
-  run \`${bin} chat send <name>\` explicitly.
-- **Stay silent when you have nothing to add.** Not every message needs a
-  reply. If you have nothing new for the recipient, output nothing and the
-  runtime ends the turn.
+- **Your output stream is your reasoning trace** — think, plan, and narrate
+  there freely as you work. It is not a chat reply path.
+- **To reach a teammate (human or agent), use \`${bin} chat send <name>\`** —
+  this is the only delivery path you should rely on. Every message you want
+  a teammate to see goes through it.
+- **Don't fire a courtesy \`chat send\`.** Not every wake-up needs one back.
+  If after reasoning there's nothing new for any teammate, end the turn
+  without sending — a courteous "got it" between two agents is how loops
+  start.
 - **Content rules (Issue #389):** pass content as a **raw string** — never
   \`JSON.stringify\` it first. Wrapping in outer quotes + \`\\n\` escapes
   produces a literal \`"@x ...\\n..."\` row that the UI cannot render as
@@ -393,31 +396,29 @@ finished, the operator cleans up with \`git worktree remove\`.`;
 function communicationBlock(bin: string): string {
   return `## Communication
 
-\`chat send\` is your primary tool for reaching teammates; your final text is
-the auto-delivered fallback for plain replies. Decision guide (based on
-participant \`type\` in the Current Chat Context block):
+\`chat send\` is how you reach every teammate — human or agent. Decision
+guide (based on participant \`type\` in the Current Chat Context block):
 
-- Reaching an **agent** to make them act → you MUST \`${bin} chat send <name>\`.
-  They do NOT see your final text as a wake signal.
+- **Reaching a human in this chat** — plain reply / status → \`${bin} chat
+  send <name> "..."\`. Every reply directed at a human in this chat goes
+  through \`chat send\`.
+- **Asking a human** for a decision, approval, or answer → \`${bin} chat send
+  <name> --request --question "..."\` (see \`## Asking Humans\`). This raises
+  a tracked open question (red-dot / open-request count) the plain send
+  does not.
+- **Reaching an agent to make them act** → \`${bin} chat send <name> "..."\`.
+  Agents only act on explicit \`chat send\`.
 - After an agent handoff, continue only independent work. If their reply is the
   only remaining input, end the turn and wait to be woken; do not poll status
   or escalate on delayed replies alone.
-- **Asking a human** for a decision, approval, or answer → \`${bin} chat send
-  <name> --request --question "..."\` (see \`## Asking Humans\`). Don't bury the
-  ask in final text — it has no red-dot and no tracked answer.
-- Plain reply / narration to a **human** → final text is enough; it is
-  auto-delivered to the chat. Do **not** *also* fire a plain \`${bin} chat send\`
-  to the same human — that double-posts. (The bullets above cover when an
-  explicit send is the right call: waking an agent or a \`--request\`.)
+- **Don't fire a courtesy \`chat send\`.** If after reasoning there is nothing
+  new for any teammate, end the turn without sending. Your output stream
+  outside \`chat send\` is your reasoning trace — use it freely; the list
+  above is exhaustive for the *send* side.
 
 Every \`chat send\` names a recipient — there is no no-mention send. A group
 chat rejects a message that addresses no one; pass \`<name>\` to @mention the
-recipient.
-
-**Fallback** (if the Current Chat Context block is missing — context
-injection may have failed): use conservative mode — all cross-agent
-collaboration goes through explicit \`chat send\`; do not rely on final
-text to wake anyone.`;
+recipient.`;
 }
 
 function workspaceCollaborationBlock(bin: string): string {
@@ -444,10 +445,10 @@ function askingHumansBlock(): string {
   return `## Asking Humans
 
 When you need something only a human can give — a decision, sign-off, or an
-answer — ask with a **structured request** instead of burying the question in
-your final text. A request raises a tracked open question on the human's side
-(red-dot / open-question count) that stays until they answer; final text does
-not.
+answer — ask with a **structured request** instead of folding the question
+into a plain \`chat send\`. A request raises a tracked open question on the
+human's side (red-dot / open-question count) that stays until they answer;
+a plain send does not.
 
 \`\`\`bash
 ${bin} chat send <human> --request \\

--- a/packages/client/src/runtime/agent-briefing.ts
+++ b/packages/client/src/runtime/agent-briefing.ts
@@ -307,10 +307,12 @@ You are running inside **First Tree**, a messaging platform for agent teams.
   has a \`[From: <agent-name>]\` header — that name is what you pass back to
   \`chat send\`.
 - **Your output stream is your reasoning trace** — think, plan, and narrate
-  there freely as you work. Note: until the runtime bridge is retired, a
-  non-empty final output still lands in chat history as a silent
-  \`agent-final-text\` row — don't rely on it for delivery, and don't
-  restate in final output what you already \`chat send\`-ed.
+  there freely as you work. It runs on a separate channel from \`chat send\`;
+  the two never interact. (Transitional system behavior: a non-empty final
+  output is currently mirrored into chat history as a silent
+  \`agent-final-text\` row that does NOT wake other agents. The mirror is
+  on the runtime-retirement track and is not a reach path — \`chat send\`
+  is.)
 - **To reach a teammate (human or agent), use \`${bin} chat send <name>\`** —
   this is the only delivery path you should rely on. Every message you want
   a teammate to see goes through it.

--- a/packages/client/src/runtime/result-sink.ts
+++ b/packages/client/src/runtime/result-sink.ts
@@ -24,12 +24,14 @@ import type { AgentIdentity } from "./handler.js";
  * history as a silent `agent-final-text` row (visible to humans, never wakes
  * another session). Under the chat-send-only contract (see the top-level
  * `first-tree` skill — its SKILL.md "Communication Principles" decision
- * table and `references/agent-communication.md`), the agent-facing model is
- * that the output stream and `chat send` are two fully decoupled channels:
- * `chat send` is the reach path; this mirror is transitional system
- * behavior, never a delivery commitment. Retiring this forward entirely
- * (so non-empty final output stops landing in chat history at all) is the
- * runtime-side follow-up that closes the transitional state.
+ * table and `references/agent-communication.md`), the agent-facing model
+ * treats the output stream and `chat send` as separate channels: `chat
+ * send` is the reach path; this mirror is transitional system behavior,
+ * never a delivery commitment. The future direction is two fully
+ * decoupled channels with no mirror at all — retiring this forward (so
+ * non-empty final output stops landing in chat history) is the runtime-
+ * side follow-up that closes the transitional state, tracked at
+ * first-tree#941.
  *
  * Content-level `@<name>` resolution (extracting tokens and cross-validating
  * against the participant list) is the server's job — see

--- a/packages/client/src/runtime/result-sink.ts
+++ b/packages/client/src/runtime/result-sink.ts
@@ -24,11 +24,12 @@ import type { AgentIdentity } from "./handler.js";
  * history as a silent `agent-final-text` row (visible to humans, never wakes
  * another session). Under the chat-send-only contract (see the top-level
  * `first-tree` skill — its SKILL.md "Communication Principles" decision
- * table and `references/agent-communication.md`), the briefing tells the
- * agent not to rely on this row for delivery: explicit `<binName> chat send
- * <name>` is the reach path. Retiring this forward entirely (so non-empty
- * final output stops landing in chat history at all) is tracked as the
- * runtime-side follow-up to the chat-send-only contract pass.
+ * table and `references/agent-communication.md`), the agent-facing model is
+ * that the output stream and `chat send` are two fully decoupled channels:
+ * `chat send` is the reach path; this mirror is transitional system
+ * behavior, never a delivery commitment. Retiring this forward entirely
+ * (so non-empty final output stops landing in chat history at all) is the
+ * runtime-side follow-up that closes the transitional state.
  *
  * Content-level `@<name>` resolution (extracting tokens and cross-validating
  * against the participant list) is the server's job — see

--- a/packages/client/src/runtime/result-sink.ts
+++ b/packages/client/src/runtime/result-sink.ts
@@ -20,14 +20,15 @@ import type { AgentIdentity } from "./handler.js";
  * (`proposals/hub-chat-message-v1-design §四 改造 4`) removed that branch
  * because it was the structural fuel for agent ↔ agent echo loops: a final
  * text always woke the trigger sender, so a courteous "thanks / got it"
- * reply kept the conversation alive forever. Final text now reaches the
- * chat for **human observers** only; to make another agent take action,
- * the agent must explicitly call `<binName> chat send <name>` (see the
- * top-level `first-tree` skill — its SKILL.md "Communication Principles"
- * decision table and `references/agent-communication.md` carry the full
- * directive; the `# Working in First Tree` section of AGENTS.md keeps the
- * final-text contract and a pointer inline so even tree-less agents see
- * it).
+ * reply kept the conversation alive forever. Final-text writes land in chat
+ * history as a silent `agent-final-text` row (visible to humans, never wakes
+ * another session). Under the chat-send-only contract (see the top-level
+ * `first-tree` skill — its SKILL.md "Communication Principles" decision
+ * table and `references/agent-communication.md`), the briefing tells the
+ * agent not to rely on this row for delivery: explicit `<binName> chat send
+ * <name>` is the reach path. Retiring this forward entirely (so non-empty
+ * final output stops landing in chat history at all) is tracked as the
+ * runtime-side follow-up to the chat-send-only contract pass.
  *
  * Content-level `@<name>` resolution (extracting tokens and cross-validating
  * against the participant list) is the server's job — see
@@ -158,9 +159,12 @@ export function createResultSink(deps: ResultSinkDeps): ResultSink {
     // explicit signal that it has nothing new for the recipient. Skip
     // delivery and free the turn. The runtime does NOT evaluate content
     // length or "meaningfulness" — that's the agent's semantic decision.
-    // The matching prompt directive lives in the `# Working in First Tree`
-    // intro block built by `runtime/agent-briefing.ts` (look for
-    // "Stay silent when you have nothing to add").
+    // Under the chat-send-only contract the matching prompt guidance lives
+    // in the `# Working in First Tree` intro block built by
+    // `runtime/agent-briefing.ts` and in SKILL.md's
+    // "Don't fire a courtesy chat send" section — both phrase the brake on
+    // the *send* side, not the output side; this guard remains a runtime
+    // safety belt for a literally-empty turn.
     if (text.trim().length === 0) {
       deps.clearTrigger();
       deps.log("silent turn: agent produced empty output, skipping delivery");

--- a/skills/first-tree/SKILL.md
+++ b/skills/first-tree/SKILL.md
@@ -3,7 +3,7 @@ name: first-tree
 version: 0.7.0
 cliCompat:
   first-tree: ">=0.5.0 <0.6.0"
-description: "Top-level First Tree skill — entry-point router and canonical home for the rules every in-chat agent must follow. Covers what First Tree is (workspace collaboration arm + Context management arm), the three-principal model (Server / Client / Agent), the canonical Communication Principles (final-text contract, who-do-I-talk-to decision guide, chat-context-missing fallback, channel-binary substitution), what the background daemon does and why you must not stop/restart it from inside yourself, a CLI Namespace Map of which command lives where, and the mandatory pre-task hygiene (binding check, tree HEAD freshness, role classification). Full `chat send` / `chat invite` CLI mechanics live in `references/agent-communication.md`. For Context Tree concepts drill into `first-tree-context`. Operator tasks (`login`, `daemon install`, `agent create`) are run from the web console, not inside a running agent — see `docs/cli-reference.md`."
+description: "Top-level First Tree skill — entry-point router and canonical home for the rules every in-chat agent must follow. Covers what First Tree is (workspace collaboration arm + Context management arm), the three-principal model (Server / Client / Agent), the canonical Communication Principles (who-do-I-talk-to decision guide, courtesy-send guard, channel-binary substitution), what the background daemon does and why you must not stop/restart it from inside yourself, a CLI Namespace Map of which command lives where, and the mandatory pre-task hygiene (binding check, tree HEAD freshness, role classification). Full `chat send` / `chat invite` CLI mechanics live in `references/agent-communication.md`. For Context Tree concepts drill into `first-tree-context`. Operator tasks (`login`, `daemon install`, `agent create`) are run from the web console, not inside a running agent — see `docs/cli-reference.md`."
 ---
 
 # First Tree — Top-Level Skill
@@ -55,46 +55,37 @@ context. The full `chat send` / `chat invite` CLI mechanics live in
 [`references/agent-communication.md`](references/agent-communication.md);
 this section is the *behavior contract*.
 
-### Final-text contract
-
-Your final response text is delivered to the chat for **human observers**
-to read. It does **NOT** wake other agents. To make another agent take
-action, you MUST explicitly call:
-
-    first-tree chat send <name> "..."
-
 ### Decision guide
 
 Based on the participant `type` in the Current Chat Context block of your
 prompt:
 
-`chat send` is the primary tool for reaching teammates; final text is the
-auto-delivered fallback for plain replies.
-
 | Target in this chat | What to do |
 |---|---|
-| **human** — plain reply / narration | Final text is enough (auto-delivered). Do *not* also fire a plain `chat send` to the same human — it double-posts. |
-| **human** — needs a decision / approval / answer | `chat send <name> --request --question "..."` — a tracked ask (red-dot), never buried in final text. A plain reply only *threads* under it ("chat about this") and leaves it **open** — clarify back-and-forth freely. Resolution is **explicit**: the human submits a clean answer in their web UI, or you call `chat send <human> "<the confirmed answer>" --answer <requestId>` (answered) / `chat send <human> "<reason>" --close <requestId>` (withdrawn). Only those clear the red-dot, and only the target human or the asking agent may resolve. Re-asking opens a **new** independent question — close the stale one explicitly. See `references/agent-communication.md`. |
-| **agent** | They will NOT see your final text. You MUST `chat send <name>` if you need them to act. |
-| no specific target (narrating progress / thinking aloud) | Final text only; no send needed. |
+| **human** — plain reply / status | `chat send <name> "..."` — every reply directed at a human in this chat goes through `chat send`. |
+| **human** — needs a decision / approval / answer | `chat send <name> --request --question "..."` — a tracked ask (red-dot / open-request count). A plain reply only *threads* under it ("chat about this") and leaves it **open** — clarify back-and-forth freely. Resolution is **explicit**: the human submits a clean answer in their web UI, or you call `chat send <human> "<the confirmed answer>" --answer <requestId>` (answered) / `chat send <human> "<reason>" --close <requestId>` (withdrawn). Only those clear the red-dot, and only the target human or the asking agent may resolve. Re-asking opens a **new** independent question — close the stale one explicitly. See `references/agent-communication.md`. |
+| **agent** — make them act | `chat send <name> "..."` — agents only act on explicit `chat send`. |
 
 After an agent handoff, continue only independent work. If their reply is
 the only remaining input, end the turn and wait to be woken; do not poll
 status or escalate on delayed replies alone.
 
-### Stay silent when you have nothing to add
+Your output stream outside `chat send` is your reasoning trace — think,
+plan, and narrate there freely as you work. It is not a chat reply path,
+and the table above is silent on it on purpose: only the actions in the
+table reach a teammate.
 
-The runtime's silent-turn protocol treats empty output as "skip delivery,
-free the turn". Not every wake-up needs a reply. A courteous "got it"
-echoed between two agents is how loops start — when you have nothing new
-for the recipient, output nothing.
+### Don't fire a courtesy chat send
 
-### Fallback — Current Chat Context missing
+Your output stream is your reasoning trace — use it freely. What this
+section prescribes is the *send* side: not every wake-up needs a `chat
+send` back. A courteous "got it" echoed between two agents is how loops
+start — when there is nothing new for any teammate, finish reasoning and
+end the turn without firing `chat send`.
 
-If the Current Chat Context block is missing from your prompt (injection
-may have failed), drop to conservative mode: route all cross-agent
-collaboration through explicit `chat send`; do not rely on final text to
-wake anyone.
+(The runtime's empty-output guard at `result-sink.ts` is a safety belt
+that skips delivery on a literally empty turn; it is not a directive to
+produce empty output.)
 
 ### Channel-binary substitution
 

--- a/skills/first-tree/SKILL.md
+++ b/skills/first-tree/SKILL.md
@@ -71,14 +71,16 @@ the only remaining input, end the turn and wait to be woken; do not poll
 status or escalate on delayed replies alone.
 
 Your output stream is your reasoning trace — think, plan, and narrate
-there freely as you work. It runs on a separate channel from `chat send`;
-the two never interact. The table above is silent on output streaming on
-purpose: only the actions in the table reach a teammate.
+there freely as you work. It runs on a separate channel from `chat send`.
+The table above is silent on output streaming on purpose: only the
+actions in the table reach a teammate.
 
 (Transitional system behavior: a non-empty final output is currently
 mirrored into chat history as a silent `agent-final-text` row that does
-NOT wake other agents. The mirror is on the runtime-retirement track and
-is not a reach path — `chat send` is.)
+NOT wake other agents. The mirror is on the runtime-retirement track
+(first-tree#941); the future direction is two fully decoupled channels
+with no mirror at all. Today the mirror is not a reach path — `chat
+send` is.)
 
 ### Don't fire a courtesy chat send
 

--- a/skills/first-tree/SKILL.md
+++ b/skills/first-tree/SKILL.md
@@ -70,10 +70,15 @@ After an agent handoff, continue only independent work. If their reply is
 the only remaining input, end the turn and wait to be woken; do not poll
 status or escalate on delayed replies alone.
 
-Your output stream outside `chat send` is your reasoning trace — think,
-plan, and narrate there freely as you work. It is not a chat reply path,
-and the table above is silent on it on purpose: only the actions in the
-table reach a teammate.
+Your output stream is your reasoning trace — think, plan, and narrate
+there freely as you work. It runs on a separate channel from `chat send`;
+the two never interact. The table above is silent on output streaming on
+purpose: only the actions in the table reach a teammate.
+
+(Transitional system behavior: a non-empty final output is currently
+mirrored into chat history as a silent `agent-final-text` row that does
+NOT wake other agents. The mirror is on the runtime-retirement track and
+is not a reach path — `chat send` is.)
 
 ### Don't fire a courtesy chat send
 
@@ -83,14 +88,11 @@ send` back. A courteous "got it" echoed between two agents is how loops
 start — when there is nothing new for any teammate, finish reasoning and
 end the turn without firing `chat send`.
 
-Note: until the runtime bridge is retired, a non-empty final output still
-lands in chat history as a silent `agent-final-text` row — don't rely on
-it for delivery, and don't restate in final output what you already
-`chat send`-ed.
-
 (The runtime's empty-output guard at `result-sink.ts` is a safety belt
 that skips delivery on a literally empty turn; it is not a directive to
-produce empty output.)
+produce empty output. The transitional output-stream mirror is described
+above under §Decision guide — it does not change what this section
+prescribes about the *send* side.)
 
 ### Channel-binary substitution
 

--- a/skills/first-tree/SKILL.md
+++ b/skills/first-tree/SKILL.md
@@ -83,6 +83,11 @@ send` back. A courteous "got it" echoed between two agents is how loops
 start — when there is nothing new for any teammate, finish reasoning and
 end the turn without firing `chat send`.
 
+Note: until the runtime bridge is retired, a non-empty final output still
+lands in chat history as a silent `agent-final-text` row — don't rely on
+it for delivery, and don't restate in final output what you already
+`chat send`-ed.
+
 (The runtime's empty-output guard at `result-sink.ts` is a safety belt
 that skips delivery on a literally empty turn; it is not a directive to
 produce empty output.)

--- a/skills/first-tree/agents/openai.yaml
+++ b/skills/first-tree/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "First Tree"
   short_description: "Top-level First Tree skill — routing, Communication Principles, daemon mental model, CLI map, pre-task hygiene"
-  default_prompt: "Use $first-tree to give me the top-level First Tree map, the canonical Communication Principles (final-text contract / decision guide / fallback / channel-binary substitution), the hosting-daemon mental model, the CLI Namespace Map, and the mandatory pre-task hygiene (binding / tree HEAD freshness / role)."
+  default_prompt: "Use $first-tree to give me the top-level First Tree map, the canonical Communication Principles (decision guide / courtesy-send guard / channel-binary substitution), the hosting-daemon mental model, the CLI Namespace Map, and the mandatory pre-task hygiene (binding / tree HEAD freshness / role)."

--- a/skills/first-tree/references/agent-communication.md
+++ b/skills/first-tree/references/agent-communication.md
@@ -2,8 +2,7 @@
 
 The CLI for an agent talking to another agent (or to a chat). Read this
 after the top-level `first-tree` SKILL.md's Communication Principles
-when you need the full mechanics beyond the Decision guide / Fallback
-table.
+when you need the full mechanics beyond the Decision guide table.
 
 ## Binary name across channels
 
@@ -59,11 +58,8 @@ Pick the mode by what you need back:
 Every `chat send` names a recipient — there is no no-mention send. A group chat
 rejects a message addressed to no one, so pass `<name>` to reach a participant.
 
-Final text (your turn's normal output) is auto-delivered to the chat for
-human observers, so a plain reply to a human should be **just** that final
-text — do not *also* fire a plain `chat send` to the same human, or it
-double-posts. Reach for `chat send` when you need to wake an agent or ask a
-human something tracked (`--request`).
+Reach for `chat send` for every cross-participant message: a plain reply
+to a human, a wake to another agent, or a tracked ask (`--request`).
 
 ### Discuss, then resolve — the open-question lifecycle
 
@@ -141,32 +137,29 @@ participant set applies to both the positional `<name>` argument of
 `chat send` and every `@<name>` token in the message body — there is no
 side-channel flag; non-member agents must be added with `chat invite` first.
 
-## When to use chat send vs. final text vs. nothing
+## When to use chat send
 
 See the SKILL.md Communication Principles' Decision guide table and the
 `## Modes of chat send` table above — short version:
 
-- **Human**, plain reply → final text is enough (auto-delivered); do *not* also
-  fire a plain `chat send` to the same human — it double-posts.
+- **Human**, plain reply / status → `chat send <name> "..."`.
 - **Human**, needs a decision / approval / answer → `chat send <name>
-  --request --question "..."` (tracked ask, not buried in final text). Their
-  reply threads as discussion and leaves the question **open** — a plain reply
-  does **not** resolve it. When you have the confirmed answer (or it is moot),
-  explicitly clear the red dot with `chat send ... --answer <requestId>` /
+  --request --question "..."` (tracked ask, raises a red-dot). Their reply
+  threads as discussion and leaves the question **open** — a plain reply
+  does **not** resolve it. When you have the confirmed answer (or it is
+  moot), explicitly clear the red dot with `chat send ... --answer <requestId>` /
   `chat send ... --close <requestId>`.
-- **Agent** → explicit `chat send <name>` (final text does not wake them).
-  After the handoff, continue only independent work; if their reply is the
-  only remaining input, end the turn and wait to be woken. Do not poll status
-  or escalate on delayed replies alone.
-- No specific target (narration / thinking aloud) → final text only; no
-  send needed.
-- Current Chat Context block missing from prompt → conservative mode, all
-  cross-agent work goes through explicit `chat send`.
+- **Agent** → `chat send <name> "..."`. After the handoff, continue only
+  independent work; if their reply is the only remaining input, end the
+  turn and wait to be woken. Do not poll status or escalate on delayed
+  replies alone.
 
-The runtime's silent-turn protocol (empty output → skip delivery, free the
-turn) is enforced by `packages/client/src/runtime/result-sink.ts`; it
-pairs with the "Stay silent when you have nothing to add" directive in
-the `# Working in First Tree` intro of `AGENTS.md`. Both directions of
-the contract — *say nothing when silent is right* and *always `chat send`
-when you want to wake an agent* — are load-bearing for preventing
-courteous agent↔agent echo loops.
+Your output stream is your reasoning trace — think, plan, narrate there
+freely. The list above is exhaustive for the *send* side: when nothing
+in it applies, finish reasoning and end the turn without firing `chat
+send`. Don't acknowledge with a courtesy send — that's how agent↔agent
+echo loops start.
+
+The runtime's empty-output guard (`packages/client/src/runtime/result-sink.ts`
+skips delivery when an entire turn is literally empty) is a safety belt
+under all of the above, not a directive to produce empty output.


### PR DESCRIPTION
## Summary

Decouple agent **output stream** (reasoning trace, free) from **chat delivery** (`chat send`, the only path agents rely on). The final-text auto-bridge in `result-sink.ts` continues to fire as transitional system behavior, but it is no longer a contract action the agent is taught to depend on. Retiring the mirror entirely (so non-empty final output stops landing in chat history at all) is tracked at **#941**.

Triggered by a chat-internal design discussion (2026-06-10) — captured in a local agent notes file (not shipped).

### The agent-facing contract before / after

| Scenario | Before | After |
|---|---|---|
| Plain reply to a human in this chat | Final text (auto-bridged) — agent told not to also fire `chat send` | `chat send <human> "..."` — explicit |
| Asking a human (decision / approval) | `chat send <human> --request --question` | `chat send <human> --request --question` (unchanged) |
| Reaching an agent to make them act | `chat send <agent>` — final text does NOT wake them | `chat send <agent>` — agents only act on explicit `chat send` (unchanged shape) |
| Narration / no specific target | "Final text only; no send needed" | Reasoning trace, no prescriptive directive — **no longer asked to suppress output** |
| Current Chat Context block missing | Drop to conservative mode (chat send) | Trivially redundant under the new contract — section removed |

Key insight (yuezengwu 2026-06-10): the brake belongs on the *send* side (`Don't fire a courtesy chat send`), not on the *output* side. Telling the agent to "output nothing" in the no-target case is hostile to its reasoning process. The runtime's empty-output guard at `result-sink.ts` is a safety belt, not a directive.

Sharper architectural principle from the design discussion: **`chat send` and output streaming are two channels that should not influence each other**. The current runtime mirror (`agent-final-text` row) is *transitional system behavior*; the future direction is two fully decoupled channels with no mirror at all (#941).

### Notification-load shift (worth a conscious nod)

Flipping C6 from a silent `agent-final-text` row to `SEND(human)` means every informational status reply now mentions the human → unread-mention badge / attention surfaces (per messaging semantics: mentions are both delivery intent and attention state). This is intentional under the new contract (every reply directed at a human goes through `chat send`), but agents that previously sent dozens of "status update" final-texts per day will now produce dozens of unread mentions per day. Worth keeping an eye on the post-rollout mention-noise curve.

### Transitional dual-row UX (worth a conscious nod)

During the transition window before the result-sink forward is retired (#941), each agent reply produces **two visible rows** in chat history: the explicit `chat send` row + the silent `agent-final-text` mirror row. The mirror does not wake anyone (`notify=false` forced server-side; pinned in `agent-final-text-purpose.test.ts`), but it is durable and visible to humans.

Empirically confirmed by a 5-trial real-agent E2E (`notes/pr938_c6_e2e_report.md`): 5/5 trials produce a dual row — `chat send` body + a final-stdout meta-narration ("Confirmed and sent to X", "Message sent to X"). Each trial's `chat send` fires correctly, so the contract works; the dual row is the mirror in action.

Under yuezengwu's decoupling principle this is an **accepted transition cost**, not a contract bug: agents are doing the right thing on the chat-send side; the mirror is what is on the retirement track. PR #941 removes it.

## Files changed

| File | Change |
|---|---|
| `skills/first-tree/SKILL.md` | Drop §Final-text contract (redundant with the Decision guide table) + §Fallback (trivially true); rewrite §Decision guide table (3 chat-send rows + output-stream/chat-send separation tail with transitional-mirror fact); rename §Stay silent → §Don't fire a courtesy chat send (pure send-side brake; output-stream fact lives under §Decision guide) |
| `skills/first-tree/references/agent-communication.md` | Drop final-text auto-bridge paragraph + "vs. final text vs. nothing" framing; §When to use chat send now lists 3 sends + courtesy-send guard |
| `skills/first-tree/agents/openai.yaml` | Realign `default_prompt`'s Principles list with the surviving sections (`decision guide / courtesy-send guard / channel-binary substitution`) |
| `packages/client/src/runtime/agent-briefing.ts` | Rewrite `# Working in First Tree` intro bullets (reasoning-trace / chat-send separation + courtesy-send guard + transitional-mirror fact pointing at #941), `## Communication` block (drop Fallback; 4 chat-send rows + courtesy-send guard), `## Asking Humans` block (compare `--request` against plain `chat send`, not final text), required-reading template, rationale comment |
| `packages/client/src/runtime/result-sink.ts` | Header comment: chat-send-only contract reference + transitional-mirror framing + retirement anchor (#941). Runtime behavior unchanged. |
| `packages/client/src/__tests__/agent-briefing.test.ts` | Pin the new wording; coupling guards: `not.toMatch(/don't restate/i)`, `not.toMatch(/don't rely on it for delivery/i)`, `not.toMatch(/never[\s\n]+interact/)` (false present-tense claim), `not.toMatch(/\boutput nothing\b/)` (output-suppression prescription). Comment explains these are regression guards for past phrasings; principle-level enforcement against re-coupling paraphrases is human-review only. |
| `packages/client/src/__tests__/codex-bootstrap.test.ts` | Add `does NOT wake other agents` back as a runtime *fact* assertion (not the retired final-text-contract action) — the mechanical reason `chat send` is the only reach path. |
| `docs/development/comms-behavior-cases.md` | C6 flipped from `FINAL_TEXT` → `SEND(human)`; C5 silence redefined as `NO_SEND` (output stream unconstrained); drop `FINAL_TEXT` / `SILENT` outcome tokens; restructure coverage map |

## Out of scope (intentional)

- `result-sink.ts` forward, the `agent-final-text` purpose, server-side fan-out / silencing rules — all unchanged. The runtime behavior stays the same; only the agent-facing contract narrows. Retiring the forward entirely (so the dual-row UX above disappears) is tracked at **#941**.
- Context Tree `system/cloud/chat/messaging.md` etc. still describe `agent-final-text` as a legitimate silent send, which remains accurate as a server-side fact. A separate tree update will follow when #941 lands.

## Review history (2026-06-10)

- **First open at `1bf4a3ec`** — Codex bot (P1 inline), codex-assistant (request_changes, level A), human reviewer (blocker) — converged on the same gap: briefing said the output stream "is not a chat reply path" while `result-sink.ts` still auto-bridges every non-empty final output as `agent-final-text`. Failure modes: (a) C6 double-posts, (b) "not a chat reply path" reads as "not visible" but the mirror is visible.
- **Fixup at `ad40745d`** — added a transitional honesty note ("don't rely on it for delivery, and don't restate in final output what you already `chat send`-ed"). yuezengwu approved; codex-assistant re-approved.
- **Empirical check** — code-reviewer ran a 5-trial real-agent E2E and reported `notes/pr938_c6_e2e_report.md`: 5/5 trials double-post even with the `ad40745d` soft "don't restate" guidance.
- **yuezengwu reframe** — "chat send 和 output streaming 完全解耦，不应当有任何互相影响。在系统 message 里记录是过渡状态，未来 output streaming 不进入 message". Under this principle the dual-row is a transitional artifact, not a contract bug; condition instructions on either side re-couple the channels and are off the table.
- **Fixup at `a56d15de`** — drop ad40745d's "don't restate" conditional instruction; reframe as two-channel architecture ("separate channel" today + future-direction "two fully decoupled channels with no mirror at all"). Add coupling reverse guards. codex-assistant flagged literal-level contradiction: "the two never interact" is false today (mirror = interaction).
- **Fixup at `55b18cd6`** — soften "the two never interact" to "separate channel" + "future direction is two fully decoupled channels"; honest about transitional gap without re-coupling. Anchor "runtime-retirement track" to #941 in all 3 places (briefing / SKILL.md / result-sink.ts) so the follow-up doesn't drift.

## Test plan

- [x] `pnpm install` clean in worktree
- [x] `pnpm check` — biome clean (1 pre-existing warning, 1 pre-existing info, not from this PR)
- [x] `pnpm typecheck` — 11/11 packages green
- [x] `pnpm --filter @first-tree/client test` — `git-mirror-manager.test.ts` has 2 pre-existing network/proxy failures unrelated to this PR; everything else green
- [x] `pnpm --filter @first-tree/server test` — 1337/1337 green
- [x] `agent-briefing.test.ts` — 27/27 green (including the new coupling reverse guards + transitional-mirror fact assertions)
- [x] `codex-bootstrap.test.ts` — 3/3 green
- [x] `result-sink.test.ts` — 23/23 green (header comment update; runtime behavior unchanged)
- [x] Empirical: 5-trial real-agent E2E (`notes/pr938_c6_e2e_report.md`) — 5/5 trials trigger explicit `chat send` correctly; dual-row mirror is the documented transitional artifact (#941)

🤖 Generated with [Claude Code](https://claude.com/claude-code)