### PR TITLE
feat(chat): explicit open-question resolution with fail-loud validation

### DIFF
--- a/apps/cli/src/commands/chat/send.ts
+++ b/apps/cli/src/commands/chat/send.ts
@@ -13,6 +13,8 @@ interface SendOptions {
   question?: string;
   option?: string[];
   replyTo?: string;
+  answer?: string;
+  close?: string;
 }
 
 /** Commander collector for a repeatable flag (`--option a --option b`). */
@@ -27,7 +29,7 @@ export function registerChatSendCommand(chat: Command): void {
       "Send a message into the caller's current chat (FIRST_TREE_CHAT_ID). <name> is any participant — agent or " +
         "human; the recipient is @mentioned and woken (must already be a participant — `chat invite` an agent " +
         "first). A message must name a recipient — there is no no-mention send. Use --request to ask a human an " +
-        "open question, --reply-to to answer one.",
+        "open question, and --answer/--close to resolve a question you asked.",
     )
     .option("-f, --format <format>", "Message format (text|markdown|card)", "text")
     .option("-m, --metadata <json>", "JSON metadata to attach")
@@ -39,7 +41,20 @@ export function registerChatSendCommand(chat: Command): void {
     )
     .option("--question <text>", "The question prompt — just the ask, no background (with --request)")
     .option("--option <opt>", "An answer option for the question; repeatable (with --request)", collectOption, [])
-    .option("--reply-to <messageId>", "Answer/thread this message — sets inReplyTo (clears the asker's red dot)")
+    .option(
+      "--answer <requestId>",
+      "Resolve an open question you asked: mark it answered and clear the human's red dot. The message body is " +
+        "the confirmed answer. Threads under the question.",
+    )
+    .option(
+      "--close <requestId>",
+      "Withdraw an open question you asked: mark it closed and clear the human's red dot. The message body is the " +
+        "reason. Re-asking opens a NEW question — it never auto-supersedes, so close the stale one explicitly.",
+    )
+    .option(
+      "--reply-to <messageId>",
+      "Thread a reply under a message — sets inReplyTo (pure threading; does NOT resolve a question)",
+    )
     .action(async (name: string | undefined, message: string | undefined, options: SendOptions) => {
       try {
         const chatId = process.env.FIRST_TREE_CHAT_ID;
@@ -119,6 +134,26 @@ export function registerChatSendCommand(chat: Command): void {
           };
         }
 
+        // --answer / --close fold open-question resolution into `send`: they
+        // attach `metadata.resolves` (the explicit signal the server's red-dot
+        // −1 keys off) and thread the reply under the question. `inReplyTo`
+        // alone never resolves anything — it is pure threading now.
+        const resolveId = options.answer ?? options.close;
+        if (resolveId !== undefined) {
+          if (isRequest) {
+            fail("RESOLVE_WITH_REQUEST", "--answer/--close cannot be combined with --request.", 2);
+          }
+          if (options.answer && options.close) {
+            fail("RESOLVE_AMBIGUOUS", "Pass only one of --answer / --close.", 2);
+          }
+          const kind = options.answer ? "answered" : "closed";
+          metadata = {
+            ...(metadata ?? {}),
+            // For a withdrawal the body doubles as the human-readable reason.
+            resolves: { request: resolveId, kind, ...(kind === "closed" && content ? { reason: content } : {}) },
+          };
+        }
+
         const sdk = createSdk(options.agent);
 
         // L3: snapshot any `.md` this message references, exactly like the
@@ -129,6 +164,10 @@ export function registerChatSendCommand(chat: Command): void {
           ? { ...(metadata ?? {}), documentContext: captured.documentContext }
           : metadata;
 
+        // `--reply-to` threads explicitly; `--answer`/`--close` thread under the
+        // question they resolve. Either way `inReplyTo` is pure threading.
+        const inReplyTo = options.replyTo ?? resolveId;
+
         const result = await sdk.sendMessage(chatId, {
           format,
           content: captured.content,
@@ -138,9 +177,7 @@ export function registerChatSendCommand(chat: Command): void {
           // adds it to mentions; an unknown name fails with a `chat invite`
           // hint.
           ...(target ? { receiverNames: [target] } : {}),
-          // Answer/thread a prior message; the server's open-question counter
-          // decrements off exactly this when the target answers a request.
-          ...(options.replyTo ? { inReplyTo: options.replyTo } : {}),
+          ...(inReplyTo ? { inReplyTo } : {}),
         });
         success(result);
       } catch (error) {

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -248,7 +248,9 @@ Day-to-day messaging.
 first-tree chat
 ├── send <name> [message]                            # recipient is any participant (agent or human)
 │     --request / --question / --option              #   structured ask directed at a human
-│     --reply-to <messageId>                         #   answer/thread a question; clears red-dot
+│     --answer <requestId>                           #   resolve a question you asked: body = the answer, clears their red-dot
+│     --close <requestId>                            #   withdraw a question you asked: body = the reason (re-asking opens a NEW question)
+│     --reply-to <messageId>                         #   thread a reply under a message (pure threading; does not resolve a question)
 ├── invite <agentName>                               # add to FIRST_TREE_CHAT_ID before send
 ├── list
 ├── history <chatId>
@@ -269,8 +271,14 @@ first-tree chat send alice --request \
   --question "Ship the destructive migration?" \
   --option "Ship" --option "Hold"
 
-# Answer / thread a question (clears the asker's red-dot)
+# Thread a reply under a message (pure threading; does NOT resolve a question)
 first-tree chat send alice --reply-to <messageId> "Holding — will split the migration."
+
+# Resolve an open question you asked the human (marks answered, clears their red-dot; body = the answer)
+first-tree chat send alice "Ship it — go ahead with migration 0021." --answer <requestId>
+
+# Withdraw an open question you asked (body = the reason; re-asking opens a NEW question, never auto-supersedes)
+first-tree chat send alice "Superseded — splitting the migration first." --close <requestId>
 
 # Pull a non-member into the current chat first, then send normally.
 first-tree chat invite code-agent

--- a/docs/development/comms-behavior-cases.md
+++ b/docs/development/comms-behavior-cases.md
@@ -15,8 +15,19 @@ C1 (ask human via `--request`), C4 (wake agent via plain `chat send`), and C6
 (plain status → final text only) **PASS** against live server/DB/daemon. C7 was
 **corrected** by that run: a `--request` is human-directed only (the server
 returns `HTTP_400: A 'request' message must be directed at a human member`), so
-the "agent answers an open question" path does not exist — C7 is now a guard for
+a human can never raise an open question *at* an agent — C7 is now a guard for
 that constraint.
+
+**Open-question lifecycle (current contract — "chat about this"):** An open
+question is a `format="request"` message — an agent asking a single human — and
+it raises a tracked red dot (`open_request_count`) on the human target.
+`inReplyTo` is now **pure threading**: a plain reply threads under the question
+(a "chat about this" discussion) and leaves it **OPEN**. Resolution is
+**explicit**, carried by `metadata.resolves = {request: <requestId>, kind:
+"answered" | "closed", reason?}`, and **only** that field drives the red-dot −1.
+It is written by the human's web UI on a clean answer (`kind="answered"`), or by
+the asking agent via `first-tree chat send ... --answer <requestId>` / `first-tree chat send ... --close <requestId>`. Authz:
+only the target human or the asking agent may resolve. See C8 for the full flow.
 
 ## How to run
 
@@ -34,6 +45,7 @@ Outcome vocabulary (`assert` references these):
 |---|---|
 | `REQUEST(human)` | `chat send <human> --request --question "..." [--option ...]` — a tracked ask (**human recipient only**; the server rejects a request directed at an agent) |
 | `SEND(agent)` | plain `chat send <agent> "..."` — wakes an agent |
+| `RESOLVE(request)` | explicit `metadata.resolves` write that clears the red dot — `first-tree chat send ... --answer <requestId>` (`kind="answered"`) / `first-tree chat send ... --close <requestId>` (`kind="closed"`), or the human's web-UI answer |
 | `FINAL_TEXT` | normal turn output, auto-bridged to the chat |
 | `SILENT` | empty output (silent-turn protocol) |
 | `¬X` | must NOT do X |
@@ -49,6 +61,7 @@ Outcome vocabulary (`assert` references these):
 | C5 | Stay silent on re-delivered / no-op messages | `86e05523` / `69c60d85` / `7a4051ab` | guard (anti over-correction) | `SILENT` |
 | C6 | Plain status reply to a human | `96fc8b00` (#852) | guard (plan A) | `FINAL_TEXT`, `¬REQUEST` |
 | C7 | A request cannot target an agent — reach agents with plain send | real QA `pr860-real-runtime-agent-qa` | guard (constraint) | `SEND(agent)`, `¬REQUEST(agent)` |
+| C8 | "Chat about this": discuss under a question, then resolve explicitly | open-question lifecycle contract | positive (lifecycle) | reply ⇒ stays open; `RESOLVE(request)` clears dot |
 
 ---
 
@@ -121,16 +134,37 @@ Outcome vocabulary (`assert` references these):
 
 ## C7 — A request cannot target an agent  *(guard — constraint)*
 
-- **Source:** real runtime QA `pr860-real-runtime-agent-qa-20260608`. An earlier draft of this case wrongly assumed a human could raise an open question *at an agent* and the agent would answer with `--reply-to`; the live CLI/API disproved it.
+- **Source:** real runtime QA `pr860-real-runtime-agent-qa-20260608`. An earlier draft of this case wrongly assumed a human could raise an open question *at an agent* and the agent would answer it; the live CLI/API disproved the direction.
 - **Situation:** the agent wants another agent to act on (or weigh in on) something and reaches for a tracked open question.
 - **Decision point:** can you direct a `--request` open question at an agent?
 - **Constraint (by design):** **No.** `--request` (`format=request`) is **human-directed only** — the server rejects any other recipient:
   ```
   HTTP_400: A 'request' message must be directed at a human member.
   ```
-  Agents therefore never receive a `format=request` message and never run an `--reply-to` answer step. When an agent *does* ask a human (C1–C3), the human's answer returns as an ordinary message and the runtime threads the agent's final text automatically (`inReplyTo`); there is no agent-side red-dot to clear.
+  Agents therefore never *receive* a `format=request` message, and the red dot (`open_request_count`) is only ever raised on a human target. Note this is about the **ask direction**, not resolution: when an agent asks a human (C1–C3), that agent *is* allowed to resolve its own question explicitly via `first-tree chat send ... --answer <requestId>` / `first-tree chat send ... --close <requestId>` (see C8) — what it cannot do is open a tracked question *at* another agent.
 - **Expected (new contract):** to reach an agent, use plain `SEND(agent)` — `chat send <agent> "..."`. Reserve `--request`/`--question` for the agent→human direction.
 - **assert:** `¬REQUEST(agent)` (a `--request` aimed at an agent is a contract violation, not just suboptimal) ∧ `SEND(agent)` for agent-to-agent work. Complements C4.
+
+## C8 — "Chat about this": discuss under a question, then resolve explicitly  *(positive — lifecycle)*
+
+- **Source:** "chat about this" feature contract (open-question lifecycle). Generalizes the C1–C3 ask path through its full life: ask → discuss → resolve.
+- **Situation:** The agent asked a human a tracked question via `--request` (e.g. C1's "Open a tree PR to edit this owned node?"), so a red dot (`open_request_count`) is live on the human. The human, instead of picking an option, **replies under the question** — *"先别开 PR,这个 Engagement 段落的措辞我想再讨论一下"* — threading a "chat about this" discussion. More turns may follow on either side.
+- **Decision point:** Does a plain reply on the thread clear the question, and how does it finally get resolved?
+- **Behavior (current contract):**
+  - A plain reply only **threads** (`inReplyTo` = pure threading). The question stays **OPEN** and the red dot does **not** clear — discussion, by either party, never resolves. (Changed from the old model, where any reply by the asker to its own request closed it.)
+  - Resolution is **explicit**, via `metadata.resolves = {request: <requestId>, kind: "answered" | "closed", reason?}`, and **only** that field drives the red-dot −1:
+    - Human's web UI writes it on a clean answer (`kind="answered"`).
+    - The **asking agent** resolves it from the discussion via the new CLI:
+      ```bash
+      # agreement reached in the thread → resolve as answered
+      first-tree chat send yuezengwu "Reworded the Engagement paragraph as discussed; opening the tree PR now." --answer <requestId>
+      # decided not to proceed → withdraw the question
+      first-tree chat send yuezengwu "Dropping the edit — handling it in the separate archive-policy PR instead." --close <requestId>
+      ```
+  - **Authz:** only the target human or the asking agent may resolve.
+  - **Invalid resolves fail loud (no silent write).** The server rejects the whole send — message included, via tx rollback — when `resolves.request` does not exist in this chat (stale/bogus id), points at a non-`request` message, or the sender is neither the target nor the asker. No "answered"/"closed" message with a dangling `metadata.resolves`/`inReplyTo` ever lands in history. Re-resolving an already-resolved question stays a **soft success** (threads as confirmation, idempotent counter), so the human-answers-while-agent-closes race never errors either side.
+  - **Re-asking opens a NEW, independent question** — it never auto-supersedes the old one. (Changed from the old model, where a request-shaped reply replaced the parent.) If after closing one question the agent needs a fresh decision, it fires another `--request`, raising a new red dot; the closed one stays closed.
+- **assert:** a plain reply under the question is `¬RESOLVE` and the dot stays up; the dot clears **only** on an explicit `resolves` write — human-UI `answered`, or asking-agent `first-tree chat send ... --answer <requestId>` / `first-tree chat send ... --close <requestId>`; a re-ask is a new `REQUEST(human)`, `¬supersede` of the prior question.
 
 ---
 
@@ -138,7 +172,8 @@ Outcome vocabulary (`assert` references these):
 
 | Decision-guide branch | Positive (do it) | Guard (don't over-do it) |
 |---|---|---|
-| Ask a human (`--request`) | C1, C2, C3 | C5 (no spurious ask), C6 (no escalation), C7 (never at an agent) |
+| Ask a human (`--request`) | C1, C2, C3, C8 (ask phase) | C5 (no spurious ask), C6 (no escalation), C7 (never at an agent) |
+| Resolve a question (`RESOLVE`) | C8 (`chat send ... --answer` / `chat send ... --close`, or human-UI answer) | C8 (a plain reply must NOT resolve; a re-ask must NOT supersede) |
 | Wake an agent (`SEND`) | C4 | C5 (no courtesy ping), C7 (plain send, not `--request`) |
-| Plain reply (`FINAL_TEXT`) | C6 | — |
+| Plain reply (`FINAL_TEXT`) | C6, C8 (discussion threads under the question) | — |
 | Say nothing (`SILENT`) | C5 | — |

--- a/packages/client/src/runtime/agent-briefing.ts
+++ b/packages/client/src/runtime/agent-briefing.ts
@@ -320,10 +320,32 @@ The body carries the context; \`--question\` is **only** the ask; \`--option\`
 (repeatable) offers explicit choices. A request is **human-directed only** — the
 server rejects \`--request\` unless the recipient is a human member, so you cannot
 open a tracked question against another agent (reach agents with a plain \`chat
-send <name>\`). The human's answer comes back to you as an ordinary message; you
-do not clear their red-dot yourself.
+send <name>\`).
 
-Reach for this on any real fork: needs approval, ambiguous requirements, a
+### When the human replies — discuss, then resolve
+
+The human's reply comes back as an ordinary message. It does **not** clear the
+red dot on its own, and neither does any plain reply you send back: replying
+threads onto the question (a focused "chat about this" exchange) but leaves it
+**open** so you can clarify back-and-forth without prematurely marking it
+answered. The open question stays tracked until you **explicitly resolve** it.
+
+Once you've got what you need, judge the reply and close the loop with one of:
+
+\`\`\`bash
+# You have the answer — resolve it and clear their red dot (body = the answer):
+${bin} chat send <human> "<the confirmed answer>" --answer <requestId>
+
+# The question no longer applies — withdraw it (body = the reason). Re-asking
+# opens a NEW question; it never auto-supersedes the old one:
+${bin} chat send <human> "<reason>" --close <requestId>
+\`\`\`
+
+\`<requestId>\` is the id of your original \`--request\` message. Only you (the
+asker) or the human you asked may resolve it; if they answer cleanly in the web
+UI, it's already cleared — no action needed.
+
+Reach for a request on any real fork: needs approval, ambiguous requirements, a
 safety-sensitive action, or any change to core data structures or the database.`;
 }
 

--- a/packages/server/src/__tests__/open-question.test.ts
+++ b/packages/server/src/__tests__/open-question.test.ts
@@ -1,6 +1,7 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 import { chatUserState } from "../db/schema/chat-user-state.js";
+import { messages } from "../db/schema/messages.js";
 import { createAgent } from "../services/agent.js";
 import { createChat } from "../services/chat.js";
 import { listMeChats } from "../services/me-chat.js";
@@ -14,11 +15,20 @@ import { createTestAdmin, createTestAgent, useTestApp } from "./helpers.js";
  *     `metadata.mentions` entry) — enforced at the service layer.
  *   - `chat_user_state.open_request_count` is the answer-cleared counter
  *     behind the `needs_you` red-dot:
- *       +1  a FRESH request (format=request, no inReplyTo) → target human.
- *       -1  the target's FIRST reply (a message with inReplyTo=question);
- *           idempotent and floored at zero.
- *   - A reply that is itself a new request takes NEITHER path (has inReplyTo
- *     ⇒ no +1; sender is the asking agent, not the human target ⇒ no -1).
+ *       +1  a FRESH request (format=request) → target human.
+ *       -1  an EXPLICIT resolution: a message carrying
+ *           `metadata.resolves = {request, kind}` pointed at the question,
+ *           from the target (answered) or the asking agent (answered/closed).
+ *           Idempotent and floored at zero.
+ *   - `inReplyTo` is pure threading and NEVER resolves: a "chat about this"
+ *     discussion reply leaves the question open. Re-asking (a new
+ *     `format=request`) opens a second independent question (+1) — it does
+ *     not auto-supersede the one it threads under.
+ *   - An invalid `resolves` target FAILS LOUD: the whole send is rejected
+ *     (tx rollback, no message row) when the request id is missing from this
+ *     chat, points at a non-request message, or the sender is neither the
+ *     target nor the asker. Re-resolving an already-resolved question stays
+ *     a soft success (idempotent counter).
  *
  * No lifecycle state is stored on the message — these tests pin the counter,
  * which is the only persisted signal.
@@ -100,7 +110,7 @@ describe("open-question (format=request) + open_request_count", () => {
     ).rejects.toThrow(/human/i);
   });
 
-  it("the target's first reply (inReplyTo=question) decrements the count; further replies are no-ops", async () => {
+  it("an explicit answer resolution decrements the count; further resolutions are no-ops", async () => {
     const app = getApp();
     const uid = crypto.randomUUID().slice(0, 6);
     const { asker, human, chat } = await setup(app, uid);
@@ -113,7 +123,8 @@ describe("open-question (format=request) + open_request_count", () => {
     });
     expect(await openReqCount(app, chat.id, human.uuid)).toBe(1);
 
-    // First answer from the target → -1.
+    // The target answers explicitly (metadata.resolves) → -1. `inReplyTo` is
+    // set for threading but is NOT what drives the decrement.
     await sendMessage(
       app.db,
       chat.id,
@@ -121,15 +132,16 @@ describe("open-question (format=request) + open_request_count", () => {
       {
         source: "web",
         format: "text",
-        content: "Let's do 5%.",
+        content: "5% or 20%? → 5%",
         inReplyTo: question.id,
+        metadata: { resolves: { request: question.id, kind: "answered" } },
       },
       { allowRecipientlessSend: true },
     );
     expect(await openReqCount(app, chat.id, human.uuid)).toBe(0);
 
-    // A second reply to the SAME question must NOT decrement again (idempotent,
-    // floored at zero).
+    // A second resolution of the SAME question must NOT decrement again
+    // (idempotent, floored at zero).
     await sendMessage(
       app.db,
       chat.id,
@@ -137,15 +149,51 @@ describe("open-question (format=request) + open_request_count", () => {
       {
         source: "web",
         format: "text",
-        content: "...actually still 5%.",
-        inReplyTo: question.id,
+        content: "5% or 20%? → still 5%",
+        metadata: { resolves: { request: question.id, kind: "answered" } },
       },
       { allowRecipientlessSend: true },
     );
     expect(await openReqCount(app, chat.id, human.uuid)).toBe(0);
   });
 
-  it("a normal reply NOT pointing at the question does not change the count", async () => {
+  it("a threaded discussion reply (inReplyTo set, no resolves) does NOT change the count", async () => {
+    // The core "chat about this" guarantee: the human and asking agent can go
+    // back and forth threaded under the question without resolving it.
+    const app = getApp();
+    const uid = crypto.randomUUID().slice(0, 6);
+    const { asker, human, chat } = await setup(app, uid);
+
+    const { message: question } = await sendMessage(app.db, chat.id, asker.agent.uuid, {
+      source: "api",
+      format: "request",
+      content: "ratio?",
+      metadata: { mentions: [human.uuid], request: { question: "5% or 20%?" } },
+    });
+    expect(await openReqCount(app, chat.id, human.uuid)).toBe(1);
+
+    // Human threads a clarifying question onto the request — no resolves.
+    const { message: disc } = await sendMessage(
+      app.db,
+      chat.id,
+      human.uuid,
+      { source: "web", format: "text", content: "what's the rollback window?", inReplyTo: question.id },
+      { allowRecipientlessSend: true },
+    );
+    expect(await openReqCount(app, chat.id, human.uuid)).toBe(1);
+
+    // Asking agent replies into the discussion line — still no resolves.
+    await sendMessage(
+      app.db,
+      chat.id,
+      asker.agent.uuid,
+      { source: "api", format: "text", content: "seconds — old env stays warm", inReplyTo: disc.id },
+      { allowRecipientlessSend: true },
+    );
+    expect(await openReqCount(app, chat.id, human.uuid)).toBe(1);
+  });
+
+  it("a plain reply with neither inReplyTo nor resolves does not change the count", async () => {
     const app = getApp();
     const uid = crypto.randomUUID().slice(0, 6);
     const { asker, human, chat } = await setup(app, uid);
@@ -158,26 +206,19 @@ describe("open-question (format=request) + open_request_count", () => {
     });
     expect(await openReqCount(app, chat.id, human.uuid)).toBe(1);
 
-    // Human chats without inReplyTo — not an answer to the question.
     await sendMessage(
       app.db,
       chat.id,
       human.uuid,
-      {
-        source: "web",
-        format: "text",
-        content: "give me a sec",
-      },
+      { source: "web", format: "text", content: "give me a sec" },
       { allowRecipientlessSend: true },
     );
     expect(await openReqCount(app, chat.id, human.uuid)).toBe(1);
   });
 
-  it("a replacement request (asker re-asks) nets zero — supersede old, open new", async () => {
-    // The asking agent re-asks by replying to its own question with a new
-    // request. The new request +1s the target AND supersedes (resolves) the
-    // parent it replies to (-1), so for the same target the count nets zero —
-    // staying at one open question (now the new one).
+  it("re-asking (a new format=request) opens a SECOND independent question (+1, no auto-supersede)", async () => {
+    // Under the explicit-resolution model a new request never auto-closes the
+    // one it threads under — superseding is now an explicit `chat send --close`.
     const app = getApp();
     const uid = crypto.randomUUID().slice(0, 6);
     const { asker, human, chat } = await setup(app, uid);
@@ -198,11 +239,11 @@ describe("open-question (format=request) + open_request_count", () => {
       metadata: { mentions: [human.uuid], request: { question: "5%, 10%, or 20%?" } },
     });
 
-    // Still exactly 1 — new request +1, parent superseded -1, net zero.
-    expect(await openReqCount(app, chat.id, human.uuid)).toBe(1);
+    // Two independent open questions now.
+    expect(await openReqCount(app, chat.id, human.uuid)).toBe(2);
   });
 
-  it("the asker's plain-text reply to its own request actively closes it (clears the target's count)", async () => {
+  it("the asking agent closes via an explicit resolves(closed) (clears the target's count)", async () => {
     const app = getApp();
     const uid = crypto.randomUUID().slice(0, 6);
     const { asker, human, chat } = await setup(app, uid);
@@ -215,8 +256,7 @@ describe("open-question (format=request) + open_request_count", () => {
     });
     expect(await openReqCount(app, chat.id, human.uuid)).toBe(1);
 
-    // The ASKER (not the target) replies to its own request with a plain text
-    // message → active close/withdraw → the target's count clears.
+    // The ASKER explicitly closes (chat send --close) → resolves(closed) → -1.
     await sendMessage(
       app.db,
       chat.id,
@@ -224,14 +264,14 @@ describe("open-question (format=request) + open_request_count", () => {
       {
         source: "api",
         format: "text",
-        content: "Never mind — resolved this offline, closing.",
-        inReplyTo: question.id,
+        content: "Never mind — resolved this offline.",
+        metadata: { resolves: { request: question.id, kind: "closed", reason: "resolved offline" } },
       },
       { allowRecipientlessSend: true },
     );
     expect(await openReqCount(app, chat.id, human.uuid)).toBe(0);
 
-    // A second close (or any later reply) is a no-op — floored at zero.
+    // A second close is a no-op — floored at zero.
     await sendMessage(
       app.db,
       chat.id,
@@ -240,19 +280,199 @@ describe("open-question (format=request) + open_request_count", () => {
         source: "api",
         format: "text",
         content: "(still closed)",
-        inReplyTo: question.id,
+        metadata: { resolves: { request: question.id, kind: "closed" } },
       },
       { allowRecipientlessSend: true },
     );
     expect(await openReqCount(app, chat.id, human.uuid)).toBe(0);
   });
 
-  it("a request-shaped reply to an already-resolved request opens a fresh count (+1)", async () => {
-    // Review #3: a threaded follow-up question must be independently countable.
-    // Raise → target answers (count 0) → asker asks a NEW request replying to
-    // the resolved one → it's a new open question, so count must be 1 again
-    // (the new request +1; the supersede of the already-resolved parent is a
-    // no-op, not a double -1).
+  it("a resolves from neither the target nor the asker is REJECTED (unauthorized, fail loud)", async () => {
+    const app = getApp();
+    const uid = crypto.randomUUID().slice(0, 6);
+    const { asker, human, other, chat } = await setup(app, uid);
+
+    const { message: question } = await sendMessage(app.db, chat.id, asker.agent.uuid, {
+      source: "api",
+      format: "request",
+      content: "ratio?",
+      metadata: { mentions: [human.uuid], request: { question: "5% or 20%?" } },
+    });
+    expect(await openReqCount(app, chat.id, human.uuid)).toBe(1);
+
+    // `other` (an unrelated participant) tries to resolve — must fail loud.
+    await expect(
+      sendMessage(
+        app.db,
+        chat.id,
+        other.uuid,
+        {
+          source: "api",
+          format: "text",
+          content: "I'll close this",
+          metadata: { resolves: { request: question.id, kind: "closed" } },
+        },
+        { allowRecipientlessSend: true },
+      ),
+    ).rejects.toThrow(/target or the asking agent/i);
+    expect(await openReqCount(app, chat.id, human.uuid)).toBe(1);
+
+    // The rejected send must not leave a message in history (tx rollback).
+    const stray = await app.db
+      .select({ id: messages.id })
+      .from(messages)
+      .where(and(eq(messages.chatId, chat.id), eq(messages.senderId, other.uuid)));
+    expect(stray).toHaveLength(0);
+  });
+
+  it("a resolves pointed at a nonexistent message id is REJECTED and writes nothing", async () => {
+    const app = getApp();
+    const uid = crypto.randomUUID().slice(0, 6);
+    const { asker, human, chat } = await setup(app, uid);
+
+    await sendMessage(app.db, chat.id, asker.agent.uuid, {
+      source: "api",
+      format: "request",
+      content: "ratio?",
+      metadata: { mentions: [human.uuid], request: { question: "5% or 20%?" } },
+    });
+    expect(await openReqCount(app, chat.id, human.uuid)).toBe(1);
+
+    // Stale/bogus id (the QA `--answer <missing id>` shape) — fail loud.
+    await expect(
+      sendMessage(
+        app.db,
+        chat.id,
+        asker.agent.uuid,
+        {
+          source: "api",
+          format: "text",
+          content: "STALE_ANSWER_SHOULD_FAIL",
+          inReplyTo: "00000000-0000-0000-0000-000000000000",
+          metadata: { resolves: { request: "00000000-0000-0000-0000-000000000000", kind: "answered" } },
+        },
+        { allowRecipientlessSend: true },
+      ),
+    ).rejects.toThrow(/no such message/i);
+    expect(await openReqCount(app, chat.id, human.uuid)).toBe(1);
+
+    // Rollback: no dangling resolution message in history.
+    const stale = await app.db
+      .select({ id: messages.id })
+      .from(messages)
+      .where(and(eq(messages.chatId, chat.id), sql`${messages.metadata} -> 'resolves' ->> 'kind' IS NOT NULL`));
+    expect(stale).toHaveLength(0);
+  });
+
+  it("a resolves pointed at a message in ANOTHER chat is REJECTED", async () => {
+    const app = getApp();
+    const uid = crypto.randomUUID().slice(0, 6);
+    const { asker, human, chat } = await setup(app, uid);
+    const otherChat = await createChat(app.db, asker.agent.uuid, {
+      type: "group",
+      participantIds: [human.uuid],
+    });
+
+    const { message: question } = await sendMessage(app.db, otherChat.id, asker.agent.uuid, {
+      source: "api",
+      format: "request",
+      content: "ratio?",
+      metadata: { mentions: [human.uuid], request: { question: "5% or 20%?" } },
+    });
+
+    // Real request id, wrong chat — must not resolve across chats.
+    await expect(
+      sendMessage(
+        app.db,
+        chat.id,
+        asker.agent.uuid,
+        {
+          source: "api",
+          format: "text",
+          content: "cross-chat resolve",
+          metadata: { resolves: { request: question.id, kind: "answered" } },
+        },
+        { allowRecipientlessSend: true },
+      ),
+    ).rejects.toThrow(/no such message/i);
+    expect(await openReqCount(app, otherChat.id, human.uuid)).toBe(1);
+  });
+
+  it("a resolves pointed at a non-request message is REJECTED", async () => {
+    const app = getApp();
+    const uid = crypto.randomUUID().slice(0, 6);
+    const { asker, human, chat } = await setup(app, uid);
+
+    const { message: plain } = await sendMessage(
+      app.db,
+      chat.id,
+      asker.agent.uuid,
+      { source: "api", format: "text", content: "just a remark" },
+      { allowRecipientlessSend: true },
+    );
+
+    await expect(
+      sendMessage(
+        app.db,
+        chat.id,
+        asker.agent.uuid,
+        {
+          source: "api",
+          format: "text",
+          content: "closing a non-question",
+          metadata: { resolves: { request: plain.id, kind: "closed" } },
+        },
+        { allowRecipientlessSend: true },
+      ),
+    ).rejects.toThrow(/not a tracked request/i);
+    expect(await openReqCount(app, chat.id, human.uuid)).toBe(0);
+  });
+
+  it("a stray unauthorized resolves row (legacy, pre-gate) does NOT block a later legitimate resolution", async () => {
+    const app = getApp();
+    const uid = crypto.randomUUID().slice(0, 6);
+    const { asker, human, other, chat } = await setup(app, uid);
+
+    const { message: question } = await sendMessage(app.db, chat.id, asker.agent.uuid, {
+      source: "api",
+      format: "request",
+      content: "ratio?",
+      metadata: { mentions: [human.uuid], request: { question: "5% or 20%?" } },
+    });
+    expect(await openReqCount(app, chat.id, human.uuid)).toBe(1);
+
+    // Unauthorized resolves are rejected at send nowadays, but rows written
+    // before that gate existed can still be present. Simulate one with a
+    // direct insert: it must not count as a "prior" that blocks the real
+    // resolution — otherwise the red dot could never clear.
+    await app.db.insert(messages).values({
+      id: crypto.randomUUID(),
+      chatId: chat.id,
+      senderId: other.uuid,
+      format: "text",
+      content: "not my question, but here",
+      metadata: { resolves: { request: question.id, kind: "answered" } },
+      source: "api",
+    });
+    expect(await openReqCount(app, chat.id, human.uuid)).toBe(1);
+
+    // The target's legitimate answer still decrements to 0.
+    await sendMessage(
+      app.db,
+      chat.id,
+      human.uuid,
+      {
+        source: "api",
+        format: "text",
+        content: "5% → yes",
+        metadata: { resolves: { request: question.id, kind: "answered" } },
+      },
+      { allowRecipientlessSend: true },
+    );
+    expect(await openReqCount(app, chat.id, human.uuid)).toBe(0);
+  });
+
+  it("a NEW request after an answered one opens a fresh count (+1)", async () => {
     const app = getApp();
     const uid = crypto.randomUUID().slice(0, 6);
     const { asker, human, chat } = await setup(app, uid);
@@ -267,7 +487,13 @@ describe("open-question (format=request) + open_request_count", () => {
       app.db,
       chat.id,
       human.uuid,
-      { source: "web", format: "text", content: "5%", inReplyTo: q1.id },
+      {
+        source: "web",
+        format: "text",
+        content: "5%",
+        inReplyTo: q1.id,
+        metadata: { resolves: { request: q1.id, kind: "answered" } },
+      },
       { allowRecipientlessSend: true },
     );
     expect(await openReqCount(app, chat.id, human.uuid)).toBe(0);
@@ -350,7 +576,7 @@ describe("open_request_count surfaces in the listMeChats projection (needs_you r
     });
     expect(listAfterRaise.rows.find((r) => r.chatId === chat.id)?.openRequestCount).toBe(1);
 
-    // Human answers (reply threaded to the question) → counter clears.
+    // Human answers explicitly (metadata.resolves) → counter clears.
     await sendMessage(
       app.db,
       chat.id,
@@ -358,8 +584,9 @@ describe("open_request_count surfaces in the listMeChats projection (needs_you r
       {
         source: "web",
         format: "text",
-        content: "yes, ship it",
+        content: "ship today? → yes, ship it",
         inReplyTo: question.id,
+        metadata: { resolves: { request: question.id, kind: "answered" } },
       },
       { allowRecipientlessSend: true },
     );

--- a/packages/server/src/__tests__/open-question.test.ts
+++ b/packages/server/src/__tests__/open-question.test.ts
@@ -428,6 +428,116 @@ describe("open-question (format=request) + open_request_count", () => {
     expect(await openReqCount(app, chat.id, human.uuid)).toBe(0);
   });
 
+  it("a MALFORMED metadata.resolves is REJECTED outright (never stored as inert metadata)", async () => {
+    const app = getApp();
+    const uid = crypto.randomUUID().slice(0, 6);
+    const { asker, human, chat } = await setup(app, uid);
+
+    const { message: question } = await sendMessage(app.db, chat.id, asker.agent.uuid, {
+      source: "api",
+      format: "request",
+      content: "ratio?",
+      metadata: { mentions: [human.uuid], request: { question: "5% or 20%?" } },
+    });
+    expect(await openReqCount(app, chat.id, human.uuid)).toBe(1);
+
+    // Authorized sender, valid request id, but bogus `kind` — must fail loud,
+    // not land as ordinary metadata (which would poison the priors scan).
+    await expect(
+      sendMessage(
+        app.db,
+        chat.id,
+        asker.agent.uuid,
+        {
+          source: "api",
+          format: "text",
+          content: "resolving with a typo'd kind",
+          metadata: { resolves: { request: question.id, kind: "anwsered" } },
+        },
+        { allowRecipientlessSend: true },
+      ),
+    ).rejects.toThrow(/malformed "metadata.resolves"/i);
+    // Missing `kind` entirely — same rejection.
+    await expect(
+      sendMessage(
+        app.db,
+        chat.id,
+        asker.agent.uuid,
+        {
+          source: "api",
+          format: "text",
+          content: "resolving with no kind",
+          metadata: { resolves: { request: question.id } },
+        },
+        { allowRecipientlessSend: true },
+      ),
+    ).rejects.toThrow(/malformed "metadata.resolves"/i);
+    expect(await openReqCount(app, chat.id, human.uuid)).toBe(1);
+
+    // Rollback: neither malformed send left a message row.
+    const stray = await app.db
+      .select({ id: messages.id })
+      .from(messages)
+      .where(and(eq(messages.chatId, chat.id), sql`${messages.metadata} ? 'resolves'`));
+    expect(stray).toHaveLength(0);
+
+    // The legitimate resolution still works and clears the count.
+    await sendMessage(
+      app.db,
+      chat.id,
+      asker.agent.uuid,
+      {
+        source: "api",
+        format: "text",
+        content: "confirmed: 5%",
+        metadata: { resolves: { request: question.id, kind: "answered" } },
+      },
+      { allowRecipientlessSend: true },
+    );
+    expect(await openReqCount(app, chat.id, human.uuid)).toBe(0);
+  });
+
+  it("a malformed legacy resolves row (pre-validation) does NOT block a later legitimate resolution", async () => {
+    const app = getApp();
+    const uid = crypto.randomUUID().slice(0, 6);
+    const { asker, human, chat } = await setup(app, uid);
+
+    const { message: question } = await sendMessage(app.db, chat.id, asker.agent.uuid, {
+      source: "api",
+      format: "request",
+      content: "ratio?",
+      metadata: { mentions: [human.uuid], request: { question: "5% or 20%?" } },
+    });
+    expect(await openReqCount(app, chat.id, human.uuid)).toBe(1);
+
+    // A pre-validation row from an AUTHORIZED sender with a malformed kind:
+    // matches the priors scan on `resolves ->> 'request'` + sender, but is
+    // not a schema-valid resolution — it must not count as a "prior".
+    await app.db.insert(messages).values({
+      id: crypto.randomUUID(),
+      chatId: chat.id,
+      senderId: asker.agent.uuid,
+      format: "text",
+      content: "legacy malformed resolve",
+      metadata: { resolves: { request: question.id, kind: "anwsered" } },
+      source: "api",
+    });
+
+    await sendMessage(
+      app.db,
+      chat.id,
+      asker.agent.uuid,
+      {
+        source: "api",
+        format: "text",
+        content: "confirmed: 5%",
+        metadata: { resolves: { request: question.id, kind: "answered" } },
+      },
+      { allowRecipientlessSend: true },
+    );
+    expect(await openReqCount(app, chat.id, human.uuid)).toBe(0);
+  });
+
   it("a stray unauthorized resolves row (legacy, pre-gate) does NOT block a later legitimate resolution", async () => {
     const app = getApp();
     const uid = crypto.randomUUID().slice(0, 6);

--- a/packages/server/src/db/schema/chat-user-state.ts
+++ b/packages/server/src/db/schema/chat-user-state.ts
@@ -40,9 +40,12 @@ export const chatUserState = pgTable(
     unreadMentionCount: integer("unread_mention_count").notNull().default(0),
     /**
      * Count of open questions (`messages.format = 'request'`) directed at
-     * this (chat, human) — incremented on RAISE, decremented when the human
-     * answers (replies with `inReplyTo` pointing at the question). Drives the
-     * re-introduced `needs_you` red-dot.
+     * this (chat, human) — incremented on RAISE, decremented by an EXPLICIT
+     * resolution (a message carrying `metadata.resolves` pointed at the
+     * question — the human's clean answer, or the asking agent's
+     * `chat send --answer`/`--close`). NOT decremented by plain threaded replies
+     * (`inReplyTo` is pure threading now), so a "chat about this" discussion
+     * keeps the question open. Drives the re-introduced `needs_you` red-dot.
      *
      * Mirrors `unread_mention_count`'s storage shape, but with the OPPOSITE
      * clear semantics: this is **answer-cleared, NOT read-cleared** — it is

--- a/packages/server/src/db/schema/messages.ts
+++ b/packages/server/src/db/schema/messages.ts
@@ -38,11 +38,14 @@ export const messages = pgTable(
      * Original message ID; threads replies in the same chat. Maintained
      * field (NOT decision-inert — unlike `replyToInbox`/`replyToChat`).
      * Consumers: loop-detector reply-chain guard C4, client dispatcher /
-     * inbox / chat-list projections, and — as of the open-question feature —
-     * the "answer" signal: a reply whose `inReplyTo` points at a
-     * `format='request'` message directed at the replier decrements that
-     * human's `chat_user_state.open_request_count`. (Keep decision per
-     * issue #754: do NOT remove this column.)
+     * inbox / chat-list projections, and conversation threading for the
+     * open-question "chat about this" discussion line.
+     *
+     * Pure threading: `inReplyTo` does NOT change a `format='request'`
+     * question's lifecycle. A question is answered/closed only by an
+     * explicit `metadata.resolves` signal (see shared `requestResolutionSchema`),
+     * which is what decrements `chat_user_state.open_request_count`. (Keep
+     * decision per issue #754: do NOT remove this column.)
      */
     inReplyTo: text("in_reply_to"),
     /**

--- a/packages/server/src/services/message.ts
+++ b/packages/server/src/services/message.ts
@@ -4,11 +4,12 @@ import {
   imageRefContentSchema,
   MAX_BATCH_ATTACHMENTS,
   MESSAGE_FORMATS,
+  requestResolutionSchema,
   type SendMessage,
   scanMentionTokens,
 } from "@first-tree/shared";
 import { getServerCliBinding } from "@first-tree/shared/channel";
-import { and, desc, eq, lt, ne, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, lt, ne, sql } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 import { agents } from "../db/schema/agents.js";
 import { chatMembership } from "../db/schema/chat-membership.js";
@@ -520,19 +521,18 @@ async function sendMessageInner(
     });
 
     // 7. Open-question counter (`chat_user_state.open_request_count`) — see
-    //    proposals/group-chat-unified-send §D1. TWO INDEPENDENT effects (a
-    //    single message can trigger both):
+    //    proposals/group-chat-unified-send §D1. TWO INDEPENDENT effects:
     //      +1 — ANY `format=request` opens a question for its single human
-    //           target, including a request-shaped reply (the new request
-    //           stands on its own and is independently answerable).
-    //      -1 — a reply that RESOLVES the parent request: the target answers
-    //           it, OR the asking agent replies to its own request (a
-    //           non-request reply withdraws it; a request-shaped reply
-    //           supersedes it). Idempotent — only the first resolving reply
-    //           decrements; `GREATEST(0, …)` floors at zero.
-    //    A request-shaped reply by the author thus does both: +1 the new
-    //    question and -1 (supersede) the parent → nets zero when both target
-    //    the same human; +1 only when the parent was already resolved/closed.
+    //           target. (A request-shaped reply also +1's — it is a new,
+    //           independently-answerable question; it does NOT auto-close the
+    //           one it replies to. Superseding is now an explicit close.)
+    //      -1 — an EXPLICIT resolution: a message carrying `metadata.resolves`
+    //           pointed at a prior open question (the human's clean answer, or
+    //           the asking agent's `chat send --answer`/`--close`). `inReplyTo`
+    //           no longer resolves anything — it is pure threading, so a
+    //           "chat about this" discussion can thread under the question
+    //           without clearing the red dot. Idempotent — only the first
+    //           resolution decrements; `GREATEST(0, …)` floors at zero.
     const requestTarget = mergedMentions[0];
     if (data.format === MESSAGE_FORMATS.REQUEST && requestTarget) {
       await tx.execute(sql`
@@ -542,44 +542,71 @@ async function sendMessageInner(
         DO UPDATE SET open_request_count = chat_user_state.open_request_count + 1
       `);
     }
-    if (data.inReplyTo) {
-      // Lock the parent request row FIRST so concurrent resolving replies to
-      // the SAME request serialise — otherwise two answers/closes could both
-      // observe `alreadyResolved=false` under READ COMMITTED and each
-      // decrement the same row (double-decrement).
+    const resolution = requestResolutionSchema.safeParse(data.metadata?.resolves);
+    if (resolution.success) {
+      const requestId = resolution.data.request;
+      // Lock the target request row FIRST so concurrent resolutions of the
+      // SAME question serialise — otherwise two could both observe no prior
+      // resolution under READ COMMITTED and each decrement (double-decrement).
       const [parent] = await tx
         .select({ format: messages.format, metadata: messages.metadata, senderId: messages.senderId })
         .from(messages)
-        .where(and(eq(messages.id, data.inReplyTo), eq(messages.chatId, chatId)))
+        .where(and(eq(messages.id, requestId), eq(messages.chatId, chatId)))
         .for("update")
         .limit(1);
-      const parentMentions = Array.isArray(parent?.metadata?.mentions) ? parent.metadata.mentions : [];
+      // FAIL LOUD on an invalid resolution target. Throwing here rolls back
+      // the whole transaction (including the message INSERT above), so no
+      // misleading "answered"/"closed" message with a dangling
+      // `metadata.resolves.request` / `inReplyTo` ever lands in history.
+      if (!parent) {
+        throw new BadRequestError(
+          `Cannot resolve "${requestId}": no such message in this chat. Pass the id of the open question you asked.`,
+        );
+      }
+      const parentMentions = Array.isArray(parent.metadata?.mentions) ? parent.metadata.mentions : [];
       const target =
-        parent?.format === MESSAGE_FORMATS.REQUEST && parentMentions.length === 1 ? parentMentions[0] : undefined;
-      if (typeof target === "string") {
-        // Resolving = the target answers (sender === target) OR the asking
-        // agent replies to its own request (any format — withdraw or supersede).
-        const isAnswer = senderId === target;
-        const isAuthorReply = senderId === parent?.senderId;
-        if (isAnswer || isAuthorReply) {
-          // Idempotency: only the FIRST resolving reply decrements (exclude the
-          // row we just inserted). Serialised by the parent FOR UPDATE lock; a
-          // prior resolving reply is one from the target or the asking author.
-          const priors = await tx
-            .select({ senderId: messages.senderId })
-            .from(messages)
-            .where(
-              and(eq(messages.chatId, chatId), eq(messages.inReplyTo, data.inReplyTo), ne(messages.id, messageId)),
-            );
-          const alreadyResolved = priors.some((p) => p.senderId === target || p.senderId === parent?.senderId);
-          if (!alreadyResolved) {
-            await tx.execute(sql`
-              UPDATE chat_user_state
-                 SET open_request_count = GREATEST(0, open_request_count - 1)
-               WHERE chat_id = ${chatId} AND agent_id = ${target}
-            `);
-          }
-        }
+        parent.format === MESSAGE_FORMATS.REQUEST && parentMentions.length === 1 ? parentMentions[0] : undefined;
+      if (typeof target !== "string") {
+        throw new BadRequestError(
+          `Cannot resolve "${requestId}": it is not a tracked request. Only messages sent with --request can be answered or closed.`,
+        );
+      }
+      // Only the target (a direct answer) or the asking agent (answer/close
+      // after judging the discussion) may resolve a question.
+      if (senderId !== target && senderId !== parent.senderId) {
+        throw new ForbiddenError("Only the question's target or the asking agent may resolve it.");
+      }
+      // Idempotency: only the FIRST resolution decrements (exclude the row we
+      // just inserted). A prior resolution is any other message in this chat
+      // whose `metadata.resolves.request` points at the same question — but
+      // ONLY from an authorized resolver (the target or the asker). Without
+      // the sender scope, any participant could pre-write a stray
+      // `metadata.resolves` for this question (which itself never decrements,
+      // being unauthorized) and have it count as a "prior", permanently
+      // blocking the legitimate resolution from clearing the red dot.
+      // (Unauthorized resolves are rejected above nowadays, but rows written
+      // before that gate existed may still be present — keep the scope.)
+      // A re-resolve of an already-resolved question stays a soft success:
+      // it threads as a confirmation and simply skips the decrement, so the
+      // human-answers-while-agent-closes race never errors either side.
+      const resolvers = [target, parent.senderId];
+      const priors = await tx
+        .select({ id: messages.id })
+        .from(messages)
+        .where(
+          and(
+            eq(messages.chatId, chatId),
+            ne(messages.id, messageId),
+            sql`${messages.metadata} -> 'resolves' ->> 'request' = ${requestId}`,
+            inArray(messages.senderId, resolvers),
+          ),
+        );
+      if (priors.length === 0) {
+        await tx.execute(sql`
+          UPDATE chat_user_state
+             SET open_request_count = GREATEST(0, open_request_count - 1)
+           WHERE chat_id = ${chatId} AND agent_id = ${target}
+        `);
       }
     }
 

--- a/packages/server/src/services/message.ts
+++ b/packages/server/src/services/message.ts
@@ -542,6 +542,16 @@ async function sendMessageInner(
         DO UPDATE SET open_request_count = chat_user_state.open_request_count + 1
       `);
     }
+    // ANY presence of the reserved `resolves` key must parse — a malformed
+    // shape (e.g. bogus `kind`) is rejected, not stored as inert metadata.
+    // Storing it would both mislead readers and poison the prior-resolution
+    // idempotency scan below (which matches on `resolves ->> 'request'`),
+    // permanently blocking the legitimate decrement.
+    if (data.metadata?.resolves !== undefined && !requestResolutionSchema.safeParse(data.metadata.resolves).success) {
+      throw new BadRequestError(
+        'Malformed "metadata.resolves": expected {request: <messageId>, kind: "answered"|"closed", reason?}.',
+      );
+    }
     const resolution = requestResolutionSchema.safeParse(data.metadata?.resolves);
     if (resolution.success) {
       const requestId = resolution.data.request;
@@ -598,6 +608,10 @@ async function sendMessageInner(
             eq(messages.chatId, chatId),
             ne(messages.id, messageId),
             sql`${messages.metadata} -> 'resolves' ->> 'request' = ${requestId}`,
+            // Only schema-valid resolution rows count as a "prior" — a
+            // malformed legacy row (pre-validation `kind`) must not block
+            // the legitimate resolution from clearing the red dot.
+            sql`${messages.metadata} -> 'resolves' ->> 'kind' IN ('answered', 'closed')`,
             inArray(messages.senderId, resolvers),
           ),
         );

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -478,6 +478,8 @@ export {
   type PrecedingMessage,
   participantModeSchema,
   precedingMessageSchema,
+  type RequestResolution,
+  requestResolutionSchema,
   type SendMessage,
   sendMessageSchema,
 } from "./schemas/message.js";

--- a/packages/shared/src/schemas/message.ts
+++ b/packages/shared/src/schemas/message.ts
@@ -41,9 +41,15 @@ export const MESSAGE_FORMATS = {
    * Open question — an "ask" directed at a single human (the sole entry in
    * `metadata.mentions`). The narrative/context lives in the message body
    * (`content`); the specific question + optional subject live in
-   * `metadata.request`. No lifecycle state is stored on the message: it is
-   * "answered" when the target replies with `inReplyTo` pointing back at it
-   * (which drives `chat_user_state.open_request_count` down). See
+   * `metadata.request`. No lifecycle state is stored on the message.
+   *
+   * Lifecycle is driven by an EXPLICIT resolution signal, not by threading:
+   * a question is answered/closed only by a later message carrying
+   * `metadata.resolves` (see `requestResolutionSchema`) — which drives
+   * `chat_user_state.open_request_count` down. `inReplyTo` is pure
+   * conversation threading and never changes a question's lifecycle, so a
+   * human ↔ asking-agent back-and-forth ("chat about this") can thread under
+   * the question without prematurely resolving it. See
    * proposals/group-chat-unified-send §D1.
    */
   REQUEST: "request",
@@ -82,6 +88,34 @@ export const openQuestionRequestSchema = z.object({
   allowExtra: z.boolean().default(false),
 });
 export type OpenQuestionRequest = z.infer<typeof openQuestionRequestSchema>;
+
+/**
+ * Explicit lifecycle signal carried in `metadata.resolves` on a reply to a
+ * `format="request"` message. This is the ONLY thing that answers or closes
+ * an open question — `inReplyTo` no longer does (it is pure threading now).
+ *
+ * Written by:
+ *   - the human's web UI when they pick an option cleanly and send it as-is
+ *     (a direct answer), or
+ *   - the asking agent via `chat send --answer`/`--close` after judging an
+ *     incoming human reply.
+ * A plain reply with no `resolves` is a discussion turn and leaves the
+ * question open.
+ *
+ *   - kind="answered" — the question is answered. The readable
+ *     `"<prompt> → <answer>"` lines stay in the message `content`.
+ *   - kind="closed"   — the question is withdrawn / superseded; `reason`
+ *     optionally explains why.
+ *
+ * Server-opaque except for the `open_request_count` counter, whose −1 keys
+ * off `resolves.request`. The web parses it with `safeParse`.
+ */
+export const requestResolutionSchema = z.object({
+  request: z.string().min(1),
+  kind: z.enum(["answered", "closed"]),
+  reason: z.string().optional(),
+});
+export type RequestResolution = z.infer<typeof requestResolutionSchema>;
 
 /**
  * Optional intent tag set by the client when posting through

--- a/packages/web/src/api/chats.ts
+++ b/packages/web/src/api/chats.ts
@@ -5,6 +5,7 @@ import type {
   ChatGithubEntityListResponse,
   ChatTokenUsage,
   Message,
+  RequestResolution,
 } from "@first-tree/shared";
 import { api, withOrg } from "./client.js";
 
@@ -85,12 +86,23 @@ export function sendChatMessage(
   chatId: string,
   content: string,
   mentions: string[],
-  opts?: { inReplyTo?: string },
+  opts?: { inReplyTo?: string; resolves?: RequestResolution },
 ): Promise<Message> {
+  // `resolves` is the explicit lifecycle signal — present only when the human
+  // submits a clean answer from the request card (it drives the server's
+  // `open_request_count` −1 / red-dot clear). A plain "chat about this" reply
+  // omits it and threads under the question without resolving it.
+  const metadata =
+    mentions.length > 0 || opts?.resolves
+      ? {
+          ...(mentions.length > 0 ? { mentions } : {}),
+          ...(opts?.resolves ? { resolves: opts.resolves } : {}),
+        }
+      : undefined;
   return api.post<Message>(`/chats/${encodeURIComponent(chatId)}/messages`, {
     format: "text",
     content,
-    ...(mentions.length > 0 ? { metadata: { mentions } } : {}),
+    ...(metadata ? { metadata } : {}),
     ...(opts?.inReplyTo ? { inReplyTo: opts.inReplyTo } : {}),
   });
 }

--- a/packages/web/src/components/chat/__tests__/request-state.test.ts
+++ b/packages/web/src/components/chat/__tests__/request-state.test.ts
@@ -4,11 +4,12 @@ import {
   contentStartsWithMention,
   defaultExpanded,
   deriveRequestState,
-  findAnswerableRequestId,
+  findThreadableRequestId,
   isRelatedViewer,
-  isReplacedByNewRequest,
   parseAnswerSelections,
+  readCloseReason,
   readRequestPayload,
+  readResolution,
 } from "../request-state.js";
 
 const ASKER = "agent-asker";
@@ -38,42 +39,54 @@ const request = msg({
   },
 });
 
+/** A reply carrying the explicit `metadata.resolves` lifecycle signal. */
+function resolveMsg(id: string, senderId: string, kind: "answered" | "closed", reason?: string): Message {
+  return msg({
+    id,
+    senderId,
+    inReplyTo: "req",
+    content: kind === "answered" ? "Ship? → yes" : "withdrawing",
+    metadata: { resolves: { request: "req", kind, ...(reason ? { reason } : {}) } },
+  });
+}
+
 describe("deriveRequestState", () => {
   it("is open with no follow-ups", () => {
     expect(deriveRequestState(request, [request])).toBe("open");
   });
 
-  it("is resolved when the target replies with inReplyTo", () => {
-    const reply = msg({ id: "r1", senderId: TARGET, inReplyTo: "req", content: "yes" });
-    expect(deriveRequestState(request, [request, reply])).toBe("resolved");
+  it("is discussing when a plain threaded reply exists but nothing resolves it", () => {
+    // The core "chat about this" guarantee: a discussion turn threaded under the
+    // question does NOT prematurely resolve it (inReplyTo is pure threading now).
+    const discuss = msg({ id: "d1", senderId: TARGET, inReplyTo: "req", content: "why are you asking?" });
+    expect(deriveRequestState(request, [request, discuss])).toBe("discussing");
+    const reply = msg({ id: "d2", senderId: ASKER, inReplyTo: "req", content: "because X" });
+    expect(deriveRequestState(request, [request, discuss, reply])).toBe("discussing");
   });
 
-  it("is closed when the asker sends a plain text reply (active close / withdraw)", () => {
-    const close = msg({ id: "c1", senderId: ASKER, inReplyTo: "req", content: "Closing this — resolved offline." });
-    expect(deriveRequestState(request, [request, close])).toBe("closed");
+  it("is resolved on an explicit answered resolution (from the target)", () => {
+    expect(deriveRequestState(request, [request, resolveMsg("r1", TARGET, "answered")])).toBe("resolved");
   });
 
-  it("is closed when the asker supersedes with a new request reply", () => {
-    const newQ = msg({
-      id: "r2",
-      senderId: ASKER,
-      format: "request",
-      inReplyTo: "req",
-      metadata: { mentions: [TARGET] },
-    });
-    expect(deriveRequestState(request, [request, newQ])).toBe("closed");
+  it("is resolved when the asking agent answers (chat send --answer)", () => {
+    expect(deriveRequestState(request, [request, resolveMsg("r1", ASKER, "answered")])).toBe("resolved");
   });
 
-  it("resolved outranks closed", () => {
-    const newQ = msg({
-      id: "r2",
-      senderId: ASKER,
-      format: "request",
-      inReplyTo: "req",
-      metadata: { mentions: [TARGET] },
-    });
-    const reply = msg({ id: "r1", senderId: TARGET, inReplyTo: "req" });
-    expect(deriveRequestState(request, [request, newQ, reply])).toBe("resolved");
+  it("is closed on an explicit closed resolution (from the asking agent)", () => {
+    expect(deriveRequestState(request, [request, resolveMsg("c1", ASKER, "closed", "no longer needed")])).toBe(
+      "closed",
+    );
+  });
+
+  it("resolution survives a prior discussion turn", () => {
+    const discuss = msg({ id: "d1", senderId: TARGET, inReplyTo: "req", content: "let me think" });
+    expect(deriveRequestState(request, [request, discuss, resolveMsg("r1", TARGET, "answered")])).toBe("resolved");
+  });
+
+  it("ignores a `resolves` written by an unauthorized sender (not target/asker)", () => {
+    const stray = resolveMsg("s1", OTHER, "answered");
+    // The stray still threads under the request → discussing, never resolved.
+    expect(deriveRequestState(request, [request, stray])).toBe("discussing");
   });
 
   it("an unrelated reply (wrong inReplyTo) leaves it open", () => {
@@ -82,20 +95,23 @@ describe("deriveRequestState", () => {
   });
 });
 
-describe("isReplacedByNewRequest", () => {
-  it("true when the asker superseded with a new request reply", () => {
-    const newQ = msg({
-      id: "r2",
-      senderId: ASKER,
-      format: "request",
-      inReplyTo: "req",
-      metadata: { mentions: [TARGET] },
+describe("readResolution / readCloseReason", () => {
+  it("readResolution parses a valid resolves signal", () => {
+    expect(readResolution({ resolves: { request: "req", kind: "answered" } })).toEqual({
+      request: "req",
+      kind: "answered",
     });
-    expect(isReplacedByNewRequest(request, [request, newQ])).toBe(true);
+    expect(readResolution({ mentions: [TARGET] })).toBeNull();
   });
-  it("false for a plain-text active close (withdraw)", () => {
-    const close = msg({ id: "c1", senderId: ASKER, inReplyTo: "req", content: "closing" });
-    expect(isReplacedByNewRequest(request, [request, close])).toBe(false);
+  it("readCloseReason returns the asker's reason from the closing message", () => {
+    const close = resolveMsg("c1", ASKER, "closed", "decided offline");
+    expect(readCloseReason(request, [request, close])).toBe("decided offline");
+  });
+  it("readCloseReason is null when the close carried no reason", () => {
+    expect(readCloseReason(request, [request, resolveMsg("c1", ASKER, "closed")])).toBeNull();
+  });
+  it("readCloseReason is null when the request is not closed", () => {
+    expect(readCloseReason(request, [request, resolveMsg("r1", TARGET, "answered")])).toBeNull();
   });
 });
 
@@ -109,8 +125,9 @@ describe("isRelatedViewer", () => {
 });
 
 describe("defaultExpanded", () => {
-  it("related: open/resolved expanded, closed collapsed", () => {
+  it("related: open/discussing/resolved expanded, closed collapsed", () => {
     expect(defaultExpanded("open", true)).toBe(true);
+    expect(defaultExpanded("discussing", true)).toBe(true);
     expect(defaultExpanded("resolved", true)).toBe(true);
     expect(defaultExpanded("closed", true)).toBe(false);
   });
@@ -132,23 +149,25 @@ describe("readRequestPayload", () => {
   });
 });
 
-describe("findAnswerableRequestId", () => {
+describe("findThreadableRequestId", () => {
   it("returns the open request id when the reply mentions the asking agent", () => {
-    expect(findAnswerableRequestId([request], TARGET, [ASKER])).toBe("req");
+    expect(findThreadableRequestId([request], TARGET, [ASKER])).toBe("req");
+  });
+  it("still threads onto a DISCUSSING request (the chat-about-this back-and-forth)", () => {
+    const discuss = msg({ id: "d1", senderId: TARGET, inReplyTo: "req", content: "why?" });
+    expect(findThreadableRequestId([request, discuss], TARGET, [ASKER])).toBe("req");
   });
   it("returns null when the asking agent is not mentioned", () => {
-    expect(findAnswerableRequestId([request], TARGET, [OTHER])).toBeNull();
+    expect(findThreadableRequestId([request], TARGET, [OTHER])).toBeNull();
   });
   it("returns null when the viewer is not the target", () => {
-    expect(findAnswerableRequestId([request], OTHER, [ASKER])).toBeNull();
+    expect(findThreadableRequestId([request], OTHER, [ASKER])).toBeNull();
   });
-  it("returns null once the request is already resolved", () => {
-    const reply = msg({ id: "r1", senderId: TARGET, inReplyTo: "req" });
-    expect(findAnswerableRequestId([request, reply], TARGET, [ASKER])).toBeNull();
+  it("returns null once the request is explicitly resolved", () => {
+    expect(findThreadableRequestId([request, resolveMsg("r1", TARGET, "answered")], TARGET, [ASKER])).toBeNull();
   });
-  it("returns null once the asker has actively closed the request", () => {
-    const close = msg({ id: "c1", senderId: ASKER, inReplyTo: "req", content: "closing" });
-    expect(findAnswerableRequestId([request, close], TARGET, [ASKER])).toBeNull();
+  it("returns null once the asker has closed the request", () => {
+    expect(findThreadableRequestId([request, resolveMsg("c1", ASKER, "closed")], TARGET, [ASKER])).toBeNull();
   });
 });
 

--- a/packages/web/src/components/chat/request-card.tsx
+++ b/packages/web/src/components/chat/request-card.tsx
@@ -4,12 +4,14 @@
  * markdown body + interactive answer block) plus its collapse/expand state,
  * because collapsing must hide body AND answer block together.
  *
- * Lifecycle (open / resolved / closed) is derived from the thread, not stored
- * (see request-state.ts). The answer block is interactive only for the target
- * while the request is `open`; everyone else sees it read-only, and unrelated
- * viewers get it collapsed by default. Answering sends a normal reply message
- * with `inReplyTo` pointing at the request (the server's −1 / red-dot clear
- * keys off exactly that) — no new endpoint. See proposals/group-chat-unified-send §D1.
+ * Lifecycle (open / discussing / resolved / closed) is derived from the
+ * thread, not stored (see request-state.ts). The answer block is interactive
+ * only for the target while the request is unresolved (`open` or `discussing`);
+ * everyone else sees it read-only, and unrelated viewers get it collapsed by
+ * default. A clean answer sends a reply that threads under the request
+ * (`inReplyTo`) AND carries the explicit `metadata.resolves` signal the
+ * server's −1 / red-dot clear keys off — a plain "chat about this" reply omits
+ * `resolves` and leaves the question open. See proposals/group-chat-unified-send §D1.
  *
  * Design (DESIGN.md): `open` keeps card chrome because it is *interactive*
  * (pillar 5). `resolved` / `closed` are read-only and render as plain labeled
@@ -29,9 +31,9 @@ import {
   defaultExpanded,
   deriveRequestState,
   isRelatedViewer,
-  isReplacedByNewRequest,
   parseAnswerSelections,
   type RequestState,
+  readCloseReason,
   readMentions,
   readRequestPayload,
 } from "./request-state.js";
@@ -46,9 +48,17 @@ const CHIP: Record<RequestState, ChipSpec> = {
     bg: "var(--state-needs-you-soft)",
     fg: "var(--fg-needs-you-strong)",
   },
+  // amber needs-you — a "chat about this" exchange is in flight but the
+  // question is not answered yet, so it still needs the human's action.
+  discussing: {
+    label: "DISCUSSING",
+    Icon: MessageCircleQuestion,
+    bg: "var(--state-needs-you-soft)",
+    fg: "var(--fg-needs-you-strong)",
+  },
   // success green — answered.
   resolved: { label: "RESOLVED", Icon: CircleCheck, bg: "var(--bg-success-soft)", fg: "var(--fg-success-strong)" },
-  // neutral sunken — withdrawn / superseded.
+  // neutral sunken — withdrawn by the asker.
   closed: { label: "CLOSED", Icon: Ban, bg: "var(--bg-sunken)", fg: "var(--fg-3)" },
 };
 
@@ -106,7 +116,10 @@ export function RequestCard({
   const targets = useMemo(() => readMentions(message.metadata), [message.metadata]);
   const related = isRelatedViewer(message, viewerAgentId);
   const isTarget = viewerAgentId != null && targets.includes(viewerAgentId);
-  const canAnswer = state === "open" && isTarget;
+  // The card stays interactive while the question is unresolved — `open` or
+  // `discussing` (a "chat about this" exchange doesn't lock the answer block).
+  const answerable = state === "open" || state === "discussing";
+  const canAnswer = answerable && isTarget;
 
   const targetLabel = targets[0] ? resolveAgentName(targets[0]) : undefined;
   const subject = payload?.subject ?? "Request";
@@ -117,22 +130,39 @@ export function RequestCard({
   const [free, setFree] = useState<Record<string, string>>({});
 
   // For a resolved request, recover the chosen answers from the resolving
-  // reply so the card can echo them (keyed by prompt). Empty when the answer
-  // was a free-form composer reply that doesn't match the format.
+  // message so the card can echo them (keyed by prompt). The resolving message
+  // is the one carrying `metadata.resolves` (kind="answered") for this request;
+  // its body holds the `"prompt → answer"` lines. Empty when the answer was a
+  // free-form reply that doesn't match the format.
   const selections = useMemo<Record<string, string>>(() => {
     if (state !== "resolved" || !payload) return {};
-    const reply = thread.find((m) => m.inReplyTo === message.id && targets.includes(m.senderId));
+    const reply = thread.find((m) => {
+      const raw = m.metadata?.resolves;
+      return (
+        raw != null &&
+        typeof raw === "object" &&
+        (raw as { request?: unknown }).request === message.id &&
+        (raw as { kind?: unknown }).kind === "answered"
+      );
+    });
     return reply
       ? parseAnswerSelections(
           reply.content,
           payload.questions.map((q) => q.prompt),
         )
       : {};
-  }, [state, payload, thread, message.id, targets]);
+  }, [state, payload, thread, message.id]);
 
   const mut = useMutation({
+    // A clean answer from the target resolves the question: it threads under
+    // the request (`inReplyTo`) AND carries the explicit `resolves` signal that
+    // drives the server's red-dot −1. (A plain "chat about this" reply, sent
+    // from the composer, omits `resolves` and only threads.)
     mutationFn: (content: string) =>
-      sendChatMessage(message.chatId, content, [message.senderId], { inReplyTo: message.id }),
+      sendChatMessage(message.chatId, content, [message.senderId], {
+        inReplyTo: message.id,
+        resolves: { request: message.id, kind: "answered" },
+      }),
     onSuccess: () => onSent?.(),
   });
 
@@ -153,18 +183,17 @@ export function RequestCard({
     }
   }
 
-  // A `closed` request is either superseded by a replacement question or
-  // actively withdrawn by the asker — copy differs so a plain close doesn't
-  // read as "superseded by an updated question" (QA).
-  const superseded = state === "closed" && isReplacedByNewRequest(message, thread);
+  // Closing is explicit now (the asker calls `chat send --close`; re-asking never
+  // auto-supersedes) — show the reason they gave, when any.
+  const closeReason = state === "closed" ? readCloseReason(message, thread) : null;
   const summary =
-    state === "open"
-      ? `${questionCount} question${questionCount === 1 ? "" : "s"}`
-      : state === "resolved"
-        ? "answered"
-        : superseded
-          ? "superseded"
-          : "withdrawn";
+    state === "resolved"
+      ? "answered"
+      : state === "closed"
+        ? "withdrawn"
+        : state === "discussing"
+          ? "discussing"
+          : `${questionCount} question${questionCount === 1 ? "" : "s"}`;
 
   // ── Collapsed: one row, body + answer block hidden. Click anywhere to expand.
   if (!expanded) {
@@ -242,7 +271,7 @@ export function RequestCard({
       {/* state-specific block: `open` keeps interactive card chrome; `resolved`
           / `closed` are read-only and render as plain labeled content — no
           filled/bordered card (DESIGN.md pillar 5). */}
-      {state === "open" && payload ? (
+      {answerable && payload ? (
         <div
           style={{
             marginTop: "var(--sp-3)",
@@ -384,7 +413,7 @@ export function RequestCard({
       {/* closed — read-only one-line status, no card chrome */}
       {state === "closed" ? (
         <div className="text-body" style={{ marginTop: "var(--sp-1_5)", color: "var(--fg-3)" }}>
-          {superseded ? "Superseded by an updated question." : "Withdrawn by the asker."}
+          {closeReason ? `Withdrawn — ${closeReason}` : "Withdrawn by the asker."}
           {questionCount > 0 ? (
             <span style={{ color: "var(--fg-4)" }}>
               {` · ${questionCount} question${questionCount === 1 ? "" : "s"} unanswered`}

--- a/packages/web/src/components/chat/request-state.ts
+++ b/packages/web/src/components/chat/request-state.ts
@@ -1,21 +1,26 @@
-import type { Message, OpenQuestionRequest } from "@first-tree/shared";
-import { MENTION_REGEX, openQuestionRequestSchema } from "@first-tree/shared";
+import type { Message, OpenQuestionRequest, RequestResolution } from "@first-tree/shared";
+import { MENTION_REGEX, openQuestionRequestSchema, requestResolutionSchema } from "@first-tree/shared";
 
 /**
  * Lifecycle of a `format="request"` message. Derived from the message thread —
- * NOT stored on the message (the server keeps no lifecycle state). See
- * proposals/group-chat-unified-send §D1.
- *   - `open`     — no qualifying follow-up. Counts toward the needs_you dot.
- *   - `resolved` — the target (a member in `metadata.mentions`) replied with
- *                  `inReplyTo` pointing at this request.
- *   - `closed`   — the asking agent (the request's own sender) replied to its
- *                  own request: a non-request reply actively closes/withdraws
- *                  it; a request-shaped reply replaces it (this card closes,
- *                  the new request stands separately). Either way the count
- *                  for the open question is released (replacement re-opens via
- *                  the new request).
+ * NOT stored on the message (the server keeps no lifecycle state). Resolution
+ * is driven by an EXPLICIT `metadata.resolves` signal (see
+ * `requestResolutionSchema`), never by `inReplyTo` — which is now pure
+ * threading, so a "chat about this" back-and-forth can thread under the
+ * question without resolving it. See proposals/group-chat-unified-send §D1.
+ *   - `open`       — no reply yet. Counts toward the needs_you dot.
+ *   - `discussing` — threaded replies exist (a "chat about this" exchange) but
+ *                    no explicit resolution yet. Still counts toward the dot —
+ *                    the question is being clarified, not answered.
+ *   - `resolved`   — a message carries `metadata.resolves` with
+ *                    `kind="answered"` pointing at this request (the target's
+ *                    clean answer, or the asking agent's `chat send --answer`).
+ *   - `closed`     — same, with `kind="closed"` (the asking agent withdrew it
+ *                    via `chat send --close`). Closing is explicit; re-asking opens a
+ *                    new independent question and never auto-supersedes.
+ * Only the target or the asking agent can resolve (mirrors the server's authz).
  */
-export type RequestState = "open" | "resolved" | "closed";
+export type RequestState = "open" | "discussing" | "resolved" | "closed";
 
 /** Read the resolved `@`-mention uuids from a message's metadata. */
 export function readMentions(metadata: Record<string, unknown> | null | undefined): string[] {
@@ -54,33 +59,55 @@ export function readRequestPayload(metadata: Record<string, unknown> | null | un
   return parsed.success ? parsed.data : null;
 }
 
-/**
- * Derive the request's lifecycle from the surrounding messages. `resolved`
- * outranks `closed` (an answer is more meaningful than a supersede if both
- * somehow exist).
- */
-export function deriveRequestState(request: Message, thread: readonly Message[]): RequestState {
-  const targets = readMentions(request.metadata);
-  let closed = false;
-  for (const m of thread) {
-    if (m.inReplyTo !== request.id) continue;
-    if (targets.includes(m.senderId)) return "resolved";
-    // Any reply BY THE ASKER to its own request closes it: a non-request reply
-    // is an active close/withdraw; a request-shaped reply is a replacement
-    // (this old card closes, the new request stands on its own).
-    if (m.senderId === request.senderId) closed = true;
-  }
-  return closed ? "closed" : "open";
+/** Parse `metadata.resolves` into the explicit resolution signal; `null` when absent/malformed. */
+export function readResolution(metadata: Record<string, unknown> | null | undefined): RequestResolution | null {
+  const parsed = requestResolutionSchema.safeParse(metadata?.resolves);
+  return parsed.success ? parsed.data : null;
 }
 
 /**
- * Distinguishes the two `closed` sub-cases for copy: `true` when the asker
- * closed by posting a NEW request replying to this one (supersede/replacement),
- * `false` when it was an active close/withdraw (a non-request reply). Only
- * meaningful when the request already derives `closed`.
+ * Derive the request's lifecycle from the surrounding messages. An explicit
+ * `metadata.resolves` wins; absent that, threaded replies mean `discussing`,
+ * and a bare request means `open`. Resolution counts only from the target (a
+ * direct answer) or the asking agent (answer/close after the discussion) —
+ * mirrors the server's authz, so a stray `resolves` from anyone else can't flip
+ * the card.
  */
-export function isReplacedByNewRequest(request: Message, thread: readonly Message[]): boolean {
-  return thread.some((m) => m.inReplyTo === request.id && m.senderId === request.senderId && m.format === "request");
+export function deriveRequestState(request: Message, thread: readonly Message[]): RequestState {
+  const targets = readMentions(request.metadata);
+  const canResolve = (senderId: string): boolean => senderId === request.senderId || targets.includes(senderId);
+  let discussing = false;
+  for (const m of thread) {
+    const res = readResolution(m.metadata);
+    if (res && res.request === request.id && canResolve(m.senderId)) {
+      return res.kind === "answered" ? "resolved" : "closed";
+    }
+    // A threaded reply that is NOT a resolution is a "chat about this"
+    // discussion turn — the question is being clarified, not answered.
+    if (m.id !== request.id && m.inReplyTo === request.id) discussing = true;
+  }
+  return discussing ? "discussing" : "open";
+}
+
+/**
+ * The optional human-readable reason from the message that CLOSED this request
+ * (`metadata.resolves.kind="closed"`). `null` when the request isn't closed or
+ * the close carried no reason. Used for the closed card's copy.
+ */
+export function readCloseReason(request: Message, thread: readonly Message[]): string | null {
+  const targets = readMentions(request.metadata);
+  for (const m of thread) {
+    const res = readResolution(m.metadata);
+    if (
+      res &&
+      res.request === request.id &&
+      res.kind === "closed" &&
+      (m.senderId === request.senderId || targets.includes(m.senderId))
+    ) {
+      return res.reason ?? null;
+    }
+  }
+  return null;
 }
 
 /** Viewer is "related" to a request iff they are the asker or the single target. */
@@ -101,24 +128,28 @@ export function defaultExpanded(state: RequestState, related: boolean): boolean 
 
 /**
  * When `viewer` is about to send a message mentioning `mentionedIds`, find the
- * most recent OPEN request directed at them and raised by one of the mentioned
- * agents — so a plain composer reply that @-mentions the asking agent threads
- * onto the question (sets `inReplyTo`) and counts as the answer. Returns the
- * request's message id, or `null` when there's no such open question.
+ * most recent OPEN or DISCUSSING request directed at them and raised by one of
+ * the mentioned agents — so a plain composer reply that @-mentions the asking
+ * agent threads onto the question (sets `inReplyTo`). This is the "chat about
+ * this" path: the reply threads under the question for context but does NOT
+ * resolve it — resolution needs an explicit `metadata.resolves` (written by the
+ * card's answer block, or the agent's `chat send --answer`/`--close`). Returns
+ * the request's message id, or `null` when there's no such live question.
  */
-export function findAnswerableRequestId(
+export function findThreadableRequestId(
   thread: readonly Message[],
   viewerAgentId: string | null,
   mentionedIds: readonly string[],
 ): string | null {
   if (!viewerAgentId || mentionedIds.length === 0) return null;
   const mentioned = new Set(mentionedIds);
-  // `thread` is oldest-first; walk from the newest so the latest open question wins.
+  // `thread` is oldest-first; walk from the newest so the latest live question wins.
   for (let i = thread.length - 1; i >= 0; i--) {
     const m = thread[i];
     if (!m || m.format !== "request" || !mentioned.has(m.senderId)) continue;
     if (!readMentions(m.metadata).includes(viewerAgentId)) continue;
-    if (deriveRequestState(m, thread) === "open") return m.id;
+    const st = deriveRequestState(m, thread);
+    if (st === "open" || st === "discussing") return m.id;
   }
   return null;
 }

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -76,7 +76,7 @@ import {
 import { RequestCard } from "../../../components/chat/request-card.js";
 import {
   contentStartsWithMention,
-  findAnswerableRequestId,
+  findThreadableRequestId,
   readMentions,
 } from "../../../components/chat/request-state.js";
 import { WorkingTurn } from "../../../components/chat/working-turn.js";
@@ -1394,14 +1394,17 @@ export function ChatView({
       return;
     }
 
-    // Auto-thread an answer: a plain reply that @-mentions the agent which
-    // asked an open question directed at me counts as the answer (proposal
-    // §D2) — attach `inReplyTo` so the server clears the red dot.
-    const answeredRequestId = findAnswerableRequestId(mergedMessages, myAgentId, effectiveSendMentions) ?? undefined;
+    // "Chat about this": a plain reply that @-mentions the agent which asked an
+    // open question directed at me threads under that question (`inReplyTo`) so
+    // the back-and-forth stays scoped to it. This does NOT resolve the question
+    // — `inReplyTo` is pure threading now; resolution needs an explicit
+    // `metadata.resolves`, written by the request card's answer block (a clean
+    // answer) or the asking agent's `chat send --answer`/`--close`.
+    const threadedRequestId = findThreadableRequestId(mergedMessages, myAgentId, effectiveSendMentions) ?? undefined;
     sendMut.mutate({
       content: text,
       mentions: effectiveSendMentions,
-      inReplyTo: answeredRequestId,
+      inReplyTo: threadedRequestId,
     });
   };
 

--- a/skills/first-tree/SKILL.md
+++ b/skills/first-tree/SKILL.md
@@ -74,7 +74,7 @@ auto-delivered fallback for plain replies.
 | Target in this chat | What to do |
 |---|---|
 | **human** — plain reply / narration | Final text is enough (auto-delivered). Do *not* also fire a plain `chat send` to the same human — it double-posts. |
-| **human** — needs a decision / approval / answer | `chat send <name> --request --question "..."` — a tracked ask (red-dot), never buried in final text. See `references/agent-communication.md`. |
+| **human** — needs a decision / approval / answer | `chat send <name> --request --question "..."` — a tracked ask (red-dot), never buried in final text. A plain reply only *threads* under it ("chat about this") and leaves it **open** — clarify back-and-forth freely. Resolution is **explicit**: the human submits a clean answer in their web UI, or you call `chat send <human> "<the confirmed answer>" --answer <requestId>` (answered) / `chat send <human> "<reason>" --close <requestId>` (withdrawn). Only those clear the red-dot, and only the target human or the asking agent may resolve. Re-asking opens a **new** independent question — close the stale one explicitly. See `references/agent-communication.md`. |
 | **agent** | They will NOT see your final text. You MUST `chat send <name>` if you need them to act. |
 | no specific target (narrating progress / thinking aloud) | Final text only; no send needed. |
 

--- a/skills/first-tree/references/agent-communication.md
+++ b/skills/first-tree/references/agent-communication.md
@@ -52,7 +52,9 @@ Pick the mode by what you need back:
 |---|---|---|
 | Plain | `chat send <name> "..."` | Wake / answer a specific participant in this chat. |
 | Markdown / multiline | `chat send <name> -f markdown` (or pipe via stdin) | Formatted or multi-line bodies (see Content rules below). |
-| **Ask a human** | `chat send <human> --request "<context>" --question "<the ask>" [--option "<A>" --option "<B>"]` | A decision / approval / answer you need back. Raises a tracked open question (red-dot / open-request count). `--request` is **human-directed only** — the server rejects it unless the recipient is a human member, so you cannot open one against another agent. It needs both a body (context) and `--question` (the bare ask). |
+| **Ask a human** | `chat send <human> --request "<context>" --question "<the ask>" [--option "<A>" --option "<B>"]` | Open a question — a single human, a decision / approval / answer you need back. Raises a tracked red dot (`open_request_count`) on the human. `--request` is **human-directed only** — the server rejects it unless the recipient is a human member, so you cannot open one against another agent. It needs both a body (context) and `--question` (the bare ask). |
+| **Resolve your own open question (answered)** | `chat send <human> "<the confirmed answer>" --answer <requestId>` | Explicitly **resolve** a question you asked (`kind="answered"`): the body carries the confirmed answer, `--answer` writes the explicit `metadata.resolves`, notifies the human, and clears their red dot. Only the target human or the asking agent may resolve. |
+| **Close your own open question (withdraw)** | `chat send <human> "<reason>" --close <requestId>` | Explicitly **withdraw** a question you asked (`kind="closed"`) — e.g. it became moot. The body carries the reason, `--close` writes the explicit `metadata.resolves`, clears the red dot. Same authorization. |
 
 Every `chat send` names a recipient — there is no no-mention send. A group chat
 rejects a message addressed to no one, so pass `<name>` to reach a participant.
@@ -63,10 +65,40 @@ text — do not *also* fire a plain `chat send` to the same human, or it
 double-posts. Reach for `chat send` when you need to wake an agent or ask a
 human something tracked (`--request`).
 
-You never answer an open question yourself: a request can only be directed at a
-human, so when you ask one, the human's answer arrives back as an ordinary
-message — there is no agent-side `--reply-to` step, and the runtime already
-threads your final text under whatever woke the turn.
+### Discuss, then resolve — the open-question lifecycle
+
+An open question is a `format="request"` message: one agent asking one human,
+raising a tracked red dot (`open_request_count`) on the human. It clears in
+exactly one way.
+
+- **Plain reply = discussion, not resolution.** `inReplyTo` is now **pure
+  threading**: a plain reply (from either side) threads under the question — a
+  focused "chat about this" discussion — and leaves it **OPEN**. Threading lets
+  the human and the asking agent clarify back and forth without prematurely
+  clearing the red dot. Replying to your own question (e.g. to add context or
+  ask a follow-up) does **not** resolve it.
+- **Explicit resolution clears the dot.** Resolution is carried by
+  `metadata.resolves = {request: <requestId>, kind: "answered"|"closed", reason?}`,
+  and **only** this clears the red dot. It is written either by:
+  - the human's web UI when they submit a clean answer (`kind="answered"`), or
+  - the asking agent, via `chat send <human> "<answer>" --answer <requestId>`
+    (resolve, `kind="answered"` — the body carries the answer; notifies the
+    human and clears the dot) or `chat send <human> "<reason>" --close
+    <requestId>` (withdraw, `kind="closed"` — the body carries the reason).
+- **Authorization:** only the target human or the asking agent may resolve.
+- **Invalid targets fail loud.** `--answer`/`--close` is rejected (nothing is
+  written) when `<requestId>` does not exist in this chat, is not a tracked
+  request, or you are neither the target nor the asker. Re-resolving an
+  already-resolved question is a soft success: it threads as a confirmation
+  and changes no counter.
+- **Closing is explicit** (`chat send ... --close <requestId>`); and **re-asking opens a NEW,
+  independent question** — it never auto-supersedes the old one, so close the
+  old one yourself if it is now moot.
+
+So when you ask, the human's reply arrives as an ordinary threaded message;
+keep discussing as needed, and once you have the confirmed answer (or the
+question is moot), explicitly resolve it with `chat send ... --answer <requestId>` /
+`chat send ... --close <requestId>`.
 
 ## Reaching another agent
 
@@ -117,7 +149,11 @@ See the SKILL.md Communication Principles' Decision guide table and the
 - **Human**, plain reply → final text is enough (auto-delivered); do *not* also
   fire a plain `chat send` to the same human — it double-posts.
 - **Human**, needs a decision / approval / answer → `chat send <name>
-  --request --question "..."` (tracked ask, not buried in final text).
+  --request --question "..."` (tracked ask, not buried in final text). Their
+  reply threads as discussion and leaves the question **open** — a plain reply
+  does **not** resolve it. When you have the confirmed answer (or it is moot),
+  explicitly clear the red dot with `chat send ... --answer <requestId>` /
+  `chat send ... --close <requestId>`.
 - **Agent** → explicit `chat send <name>` (final text does not wake them).
   After the handoff, continue only independent work; if their reply is the
   only remaining input, end the turn and wait to be woken. Do not poll status


### PR DESCRIPTION
## Summary

Implements the "chat about this" open-question lifecycle contract (comms-behavior-cases C8):

- **`inReplyTo` is pure threading.** A reply under a `format=request` question no longer resolves it — a threaded discussion keeps the question open and the red dot (`open_request_count`) up.
- **Resolution is explicit** via `metadata.resolves = {request, kind: "answered"|"closed", reason?}`, written by the human's web answer or the asking agent's new `chat send --answer <requestId>` / `chat send --close <requestId>`.
- **Invalid resolution targets fail loud.** The server rejects the whole send — tx rollback, no message row — when the request id does not exist in the chat, points at a non-request message, or the sender is neither the question's target nor the asker. No message with a dangling `metadata.resolves` / `inReplyTo` can land in history.
- **Re-resolving an already-resolved question stays a soft success** (idempotent counter), keeping the human-answers-while-agent-closes race benign on both sides.
- **Re-asking opens a NEW independent question** — no auto-supersede; close the stale one explicitly.
- Web request card renders the answered/closed lifecycle states; CLI reference, behavior-cases doc, and the first-tree skill are updated to the new contract.

No DB migration — the two `db/schema` diffs are doc-comment updates only.

## Testing

- `packages/server/src/__tests__/open-question.test.ts`: 16 tests incl. new negative cases (stale id, cross-chat id, non-request target, unauthorized resolver, rollback assertions)
- Full server suite: 159 files / 1348 tests green; `pnpm check` + `pnpm typecheck` clean
- QA real-agent regressions: complex chat-ops matrix + stale-resolve negative rerun both PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)