### PR TITLE
feat(web): redesign onboarding kickoff finale + repo-connect friction + humanized errors

### DIFF
--- a/packages/web/src/api/client.ts
+++ b/packages/web/src/api/client.ts
@@ -88,6 +88,8 @@ export class ApiError extends Error {
     message: string,
     /** Zod validation issues when `status === 400` and the server returned `details`. */
     public readonly issues?: ValidationIssue[],
+    /** Machine-readable code from the error body (`{ code }`), when the server sent one. */
+    public readonly code?: string,
   ) {
     super(message);
     this.name = "ApiError";
@@ -183,9 +185,11 @@ async function request<T>(path: string, options?: { method?: string; body?: unkn
     const text = await res.text();
     let message: string;
     let issues: ValidationIssue[] | undefined;
+    let code: string | undefined;
     try {
-      const json = JSON.parse(text) as { error?: string; details?: unknown };
+      const json = JSON.parse(text) as { error?: string; code?: string; details?: unknown };
       message = json.error ?? text;
+      code = typeof json.code === "string" ? json.code : undefined;
       if (Array.isArray(json.details)) {
         issues = json.details.filter(
           (d): d is ValidationIssue =>
@@ -195,7 +199,7 @@ async function request<T>(path: string, options?: { method?: string; body?: unkn
     } catch {
       message = text;
     }
-    throw new ApiError(res.status, message, issues);
+    throw new ApiError(res.status, message, issues, code);
   }
 
   if (res.status === 204) return undefined as T;

--- a/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
+++ b/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
@@ -1249,7 +1249,7 @@ describe("page SSR smoke coverage", () => {
     ).toContain("online yet");
     expect(await renderOnboardingStep(<StepConnectCode />, { activeStep: "connect-code" })).toContain("Pick repos");
     expect(await renderOnboardingStep(<StepKickoff />, { activeStep: "kickoff" })).toContain(
-      "Use your team&#x27;s Context Tree",
+      "Your agent&#x27;s ready to get to work",
     );
     expect(
       await renderOnboardingStep(<StepKickoff />, {
@@ -1258,14 +1258,14 @@ describe("page SSR smoke coverage", () => {
         treeMode: "new",
         treeUrl: "",
       }),
-    ).toContain("Start your agent");
+    ).toContain("No repo connected");
     expect(
       await renderOnboardingStep(<StepKickoff />, {
         path: "invitee",
         activeStep: "kickoff",
         selectedRepoUrls: [],
       }),
-    ).toContain("Your team is ready");
+    ).toContain("Your agent&#x27;s ready to go");
   });
 
   it("renders invite, GitHub App, settings, and layout surfaces", async () => {

--- a/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
+++ b/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
@@ -1616,7 +1616,13 @@ describe("web DOM interaction coverage", () => {
     const inviteeReady = await renderOnboardingDom(<StepKickoff />, { path: "invitee", activeStep: "kickoff" });
     await waitForText("Your agent's ready to go", inviteeReady.container);
     await click(findButton(inviteeReady.container, "Start working"));
-    expect(chatApiMocks.sendChatMessage).toHaveBeenCalledWith("chat-onboarding", expect.any(String), ["agent-1"]);
+    // Pin the invitee bootstrap (a swap back to buildBindBootstrap would still
+    // send a string — assert the joining-teammate voice).
+    expect(chatApiMocks.sendChatMessage).toHaveBeenCalledWith(
+      "chat-onboarding",
+      expect.stringContaining("just joined the team"),
+      ["agent-1"],
+    );
     expect(onboardingEventMocks.reportOnboardingEvent).toHaveBeenCalledWith(
       "tree_chat_started",
       expect.objectContaining({ joinPath: "invite" }),

--- a/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
+++ b/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
@@ -1514,9 +1514,13 @@ describe("web DOM interaction coverage", () => {
   });
 
   it("drives StepKickoff admin and invitee start flows", async () => {
-    const { ApiError } = await import("../../api/client.js");
     const { StepKickoff } = await import("../onboarding/steps/step-kickoff.js");
+    const findButton = (container: ParentNode, text: string): HTMLButtonElement | null =>
+      ([...container.querySelectorAll("button")].find((button) => button.textContent?.includes(text)) ??
+        null) as HTMLButtonElement | null;
 
+    // Admin · silently detects an existing team tree → switches the first task to
+    // "read it" (no fork, no URL input). The heading is agent + outcome.
     const setTreeMode = vi.fn();
     const setTreeUrl = vi.fn();
     const markTreeAutoInitDone = vi.fn();
@@ -1530,23 +1534,23 @@ describe("web DOM interaction coverage", () => {
       setTreeUrl,
       markTreeAutoInitDone,
     });
-    await waitForText("Start your Context Tree", adminAutoDetect.container);
+    await waitForText("Your agent's ready to get to work", adminAutoDetect.container);
     expect(markTreeAutoInitDone).toHaveBeenCalled();
     expect(setTreeMode).toHaveBeenCalledWith("existing");
     expect(setTreeUrl).toHaveBeenCalledWith("https://github.com/acme/context-tree");
     await unmountRoot(adminAutoDetect.root);
 
+    // Admin · existing tree → Start reads it: bind bootstrap (names the tree),
+    // caches the repo + tree setting, enters the chat. (New-tree provisioning is
+    // covered by provision-tree.test.ts.)
     const adminExisting = await renderOnboardingDom(<StepKickoff />, {
       activeStep: "kickoff",
       selectedRepoUrls: ["https://github.com/acme/web.git"],
       treeMode: "existing",
       treeUrl: "https://github.com/acme/context-tree",
     });
-    await waitForText("Use your team's Context Tree", adminExisting.container);
-    await click(
-      [...adminExisting.container.querySelectorAll("button")].find((button) => button.textContent?.includes("Start")) ??
-        null,
-    );
+    await waitForText("Your agent's ready to get to work", adminExisting.container);
+    await click(findButton(adminExisting.container, "Start"));
     await waitForText("Starting your agent", adminExisting.container);
     expect(agentApiMocks.listManagedAgents).toHaveBeenCalled();
     expect(chatApiMocks.createAgentChat).toHaveBeenCalledWith("agent-1");
@@ -1567,30 +1571,7 @@ describe("web DOM interaction coverage", () => {
     expect(adminExisting.flow.completeAndEnterChat).toHaveBeenCalledWith("chat-onboarding");
     await unmountRoot(adminExisting.root);
 
-    const setTreeModeNew = vi.fn();
-    const setTreeUrlNew = vi.fn();
-    const adminNew = await renderOnboardingDom(<StepKickoff />, {
-      activeStep: "kickoff",
-      selectedRepoUrls: ["https://github.com/acme/web.git"],
-      treeMode: "existing",
-      treeUrl: "git@github.com:acme/context-tree.git",
-      setTreeMode: setTreeModeNew,
-      setTreeUrl: setTreeUrlNew,
-    });
-    await waitForText("That doesn't look like a web link", adminNew.container);
-    const startButton = [...adminNew.container.querySelectorAll("button")].find((button) =>
-      button.textContent?.includes("Start"),
-    );
-    expect(startButton?.hasAttribute("disabled")).toBe(true);
-    await click(
-      [...adminNew.container.querySelectorAll("button")].find((button) =>
-        button.textContent?.includes("Create new instead"),
-      ) ?? null,
-    );
-    expect(setTreeUrlNew).toHaveBeenCalledWith("");
-    expect(setTreeModeNew).toHaveBeenCalledWith("new");
-    await unmountRoot(adminNew.root);
-
+    // Admin · no repo → honestly just "meet your agent" (intro), no provisioning.
     chatApiMocks.sendChatMessage.mockRejectedValueOnce(new Error("message failed"));
     const adminNoProject = await renderOnboardingDom(<StepKickoff />, {
       activeStep: "kickoff",
@@ -1598,77 +1579,43 @@ describe("web DOM interaction coverage", () => {
       treeMode: "new",
       treeUrl: "",
     });
-    await waitForText("Start your agent", adminNoProject.container);
-    await click(
-      [...adminNoProject.container.querySelectorAll("button")].find((button) =>
-        button.textContent?.includes("Meet your agent"),
-      ) ?? null,
-    );
+    await waitForText("No repo connected", adminNoProject.container);
+    await click(findButton(adminNoProject.container, "Meet your agent"));
     expect(chatApiMocks.createAgentChat).toHaveBeenLastCalledWith("agent-1");
     expect(adminNoProject.flow.completeAndEnterChat).toHaveBeenCalledWith("chat-onboarding");
     await unmountRoot(adminNoProject.root);
 
+    // Invitee · waiting (no team tree yet) → "Meet your agent" now lands in a real
+    // chat (runKickoff → completeAndEnterChat), not finishLater.
     orgSettingsMocks.getContextTreeSetting.mockResolvedValueOnce({ repo: "", branch: null });
-    const inviteeWaiting = await renderOnboardingDom(<StepKickoff />, {
-      path: "invitee",
-      activeStep: "kickoff",
-    });
+    const inviteeWaiting = await renderOnboardingDom(<StepKickoff />, { path: "invitee", activeStep: "kickoff" });
     await waitForText("Waiting for your team to set up", inviteeWaiting.container);
-    await click(
-      [...inviteeWaiting.container.querySelectorAll("button")].find((button) =>
-        button.textContent?.includes("Meet your agent"),
-      ) ?? null,
-    );
-    expect(inviteeWaiting.flow.finishLater).toHaveBeenCalled();
+    await click(findButton(inviteeWaiting.container, "Meet your agent"));
+    await waitForText("Starting your agent", inviteeWaiting.container);
+    expect(inviteeWaiting.flow.completeAndEnterChat).toHaveBeenCalled();
     await unmountRoot(inviteeWaiting.root);
 
+    // Invitee · no installation (tree set, GitHub not connected) → hold + the same
+    // "meet your agent" bailout. No share-link/Copy affordance anymore.
     githubAppMocks.getGithubAppInstallationExists.mockResolvedValueOnce(false);
-    const inviteeNoInstall = await renderOnboardingDom(<StepKickoff />, {
-      path: "invitee",
-      activeStep: "kickoff",
-    });
+    const inviteeNoInstall = await renderOnboardingDom(<StepKickoff />, { path: "invitee", activeStep: "kickoff" });
     await waitForText("your team's repo isn't connected yet", inviteeNoInstall.container);
-    await click(
-      [...inviteeNoInstall.container.querySelectorAll("button")].find((button) =>
-        button.textContent?.includes("Copy"),
-      ) ?? null,
-    );
-    expect(navigator.clipboard.writeText).toHaveBeenCalled();
+    await click(findButton(inviteeNoInstall.container, "Meet your agent"));
+    expect(inviteeNoInstall.flow.completeAndEnterChat).toHaveBeenCalled();
     await unmountRoot(inviteeNoInstall.root);
 
-    const inviteeConfirm = await renderOnboardingDom(<StepKickoff />, {
-      path: "invitee",
-      activeStep: "kickoff",
-    });
-    await waitForText("Your team is ready", inviteeConfirm.container);
-    await click(
-      [...inviteeConfirm.container.querySelectorAll("button")].find((button) =>
-        button.textContent?.includes("Continue without a repo"),
-      ) ?? null,
-    );
+    // Invitee · ready (tree + install) → a single launch, no repo selection. The
+    // agent already inherits the team's recommended repos.
+    const inviteeReady = await renderOnboardingDom(<StepKickoff />, { path: "invitee", activeStep: "kickoff" });
+    await waitForText("Your agent's ready to go", inviteeReady.container);
+    await click(findButton(inviteeReady.container, "Start working"));
     expect(chatApiMocks.sendChatMessage).toHaveBeenCalledWith("chat-onboarding", expect.any(String), ["agent-1"]);
     expect(onboardingEventMocks.reportOnboardingEvent).toHaveBeenCalledWith(
       "tree_chat_started",
       expect.objectContaining({ joinPath: "invite" }),
     );
-    await unmountRoot(inviteeConfirm.root);
-
-    resourceMocks.listTeamResourcesForOrg.mockResolvedValueOnce([]);
-    githubMocks.listGithubRepos.mockRejectedValueOnce(new ApiError(403, "scope missing"));
-    const inviteePickerScope = await renderOnboardingDom(<StepKickoff />, {
-      path: "invitee",
-      activeStep: "kickoff",
-    });
-    await waitForText("Reconnect GitHub with repo access", inviteePickerScope.container);
-    await unmountRoot(inviteePickerScope.root);
-
-    resourceMocks.listTeamResourcesForOrg.mockResolvedValueOnce([]);
-    githubMocks.listGithubRepos.mockRejectedValueOnce(new Error("network"));
-    const inviteePickerNetwork = await renderOnboardingDom(<StepKickoff />, {
-      path: "invitee",
-      activeStep: "kickoff",
-    });
-    await waitForText("Couldn't load your repos", inviteePickerNetwork.container);
+    expect(inviteeReady.flow.completeAndEnterChat).toHaveBeenCalled();
+    await unmountRoot(inviteeReady.root);
   });
 
   it("edits MCP server rows through validation, stdio, and HTTP submissions", async () => {

--- a/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
+++ b/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
@@ -1382,6 +1382,13 @@ describe("web DOM interaction coverage", () => {
     });
     await waitForText("Which repos should your agent work on?", connected.container);
     await waitForText("acme/web", connected.container);
+    // 0 repos picked but the list is pickable → friction: the consequence line
+    // shows and the strong primary "Continue" is absent (only the quiet
+    // "Continue without a repo" link remains; never disabled).
+    await waitForText("Pick a repo so your agent can build your team's Context Tree", connected.container);
+    expect([...connected.container.querySelectorAll("button")].some((b) => b.textContent?.trim() === "Continue")).toBe(
+      false,
+    );
     await click(
       [...connected.container.querySelectorAll("label")].find((label) => label.textContent?.includes("acme/web")) ??
         null,

--- a/packages/web/src/pages/onboarding-preview.tsx
+++ b/packages/web/src/pages/onboarding-preview.tsx
@@ -203,8 +203,8 @@ type NetProfile = {
    * Team-recommended repos the invitee inherits. Served as ResourceRow[] from
    * GET /orgs/:id/resources (what listTeamResourcesForOrg actually calls since
    * the Resources Phase 1 refactor); InviteeKickoff filters to
-   * type==="repo" && defaultEnabled==="recommended" — non-empty names them in
-   * the ready launch body, empty falls back to the intro copy.
+   * type==="repo" && defaultEnabled==="recommended" — non-empty picks the
+   * "works with your team's repos" ready copy, empty the intro copy.
    */
   sourceRepos?: string[];
   /**

--- a/packages/web/src/pages/onboarding-preview.tsx
+++ b/packages/web/src/pages/onboarding-preview.tsx
@@ -1,4 +1,4 @@
-import type { AgentVisibility } from "@first-tree/shared";
+import type { AgentVisibility, ResourceRow } from "@first-tree/shared";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { type ReactNode, useMemo, useState } from "react";
 import type { HubClient } from "../api/activity.js";
@@ -199,7 +199,12 @@ type NetProfile = {
   installExists?: boolean;
   /** GET /orgs/:id/settings/context_tree → { repo } */
   contextTree?: string | null | "pending";
-  /** GET /orgs/:id/settings/source_repos → { repos: [{ url }] } */
+  /**
+   * Team-recommended repos the invitee inherits. Served as ResourceRow[] from
+   * GET /orgs/:id/resources (what listTeamResourcesForOrg actually calls since
+   * the Resources Phase 1 refactor); InviteeKickoff filters to
+   * type==="repo" && defaultEnabled==="recommended" to decide confirm vs picker.
+   */
   sourceRepos?: string[];
   /**
    * GET /orgs/:id/github-app-installation/install-url — when set, the install
@@ -228,6 +233,26 @@ function reposResponse(outcome: RepoOutcome | undefined): Promise<Response> | Re
   if (outcome === "scope") return statusResponse(403, JSON.stringify({ error: "missing project read permission" }));
   if (outcome === "neterror") return Promise.reject(new TypeError("Failed to fetch"));
   return jsonResponse({ repos: outcome ?? [] });
+}
+
+/** A team-recommended repo resource, matching what GET /orgs/:id/resources returns. */
+function teamRepoResource(url: string, i: number): ResourceRow {
+  return {
+    id: `res-${i}`,
+    organizationId: ORG_ID,
+    type: "repo",
+    scope: "team",
+    ownerAgentId: null,
+    name: url.replace(/^https?:\/\/[^/]+\//, "").replace(/\.git$/, ""),
+    repoCanonicalKey: null,
+    defaultEnabled: "recommended",
+    status: "active",
+    payload: { url },
+    createdBy: "preview",
+    updatedBy: "preview",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
 }
 
 /** Map a request path (with `/api/v1` prefix) to a canned response, or null to fall through. */
@@ -262,8 +287,8 @@ function handleNet(rawUrl: string): Promise<Response> | Response | null {
     if (activeNet.contextTree === "pending") return new Promise<Response>(() => {});
     return jsonResponse({ repo: activeNet.contextTree ?? null });
   }
-  if (p === `/orgs/${ORG_ID}/settings/source_repos`) {
-    return jsonResponse({ repos: (activeNet.sourceRepos ?? []).map((url) => ({ url })) });
+  if (p === `/orgs/${ORG_ID}/resources`) {
+    return jsonResponse((activeNet.sourceRepos ?? []).map((url, i) => teamRepoResource(url, i)));
   }
   return null;
 }
@@ -519,17 +544,6 @@ const SCENARIOS: Scenario[] = [
     wizard: { step: "kickoff", flow: { selectedRepoUrls: [REPO_WEB] }, net: { contextTree: TREE_URL } },
   },
   {
-    id: "admin-ko-invalid",
-    label: "Existing · invalid URL",
-    group: "5 · Kickoff",
-    role: "admin",
-    wizard: {
-      step: "kickoff",
-      flow: { selectedRepoUrls: [REPO_WEB], treeMode: "existing", treeUrl: "ftp://not-a-link", treeAutoInitDone: true },
-      net: { contextTree: null },
-    },
-  },
-  {
     id: "admin-ko-checking",
     label: "Checking team setup",
     group: "5 · Kickoff",
@@ -756,49 +770,18 @@ const SCENARIOS: Scenario[] = [
     wizard: { step: "kickoff", net: { contextTree: TREE_URL, installExists: false } },
   },
   {
-    id: "inv-ko-confirm",
-    label: "Confirm team repos",
+    id: "inv-ko-ready",
+    label: "Ready · team has repos",
     group: "4 · Kickoff (start work)",
     role: "invitee",
     wizard: { step: "kickoff", net: { contextTree: TREE_URL, installExists: true, sourceRepos: [REPO_WEB, REPO_API] } },
   },
   {
-    id: "inv-ko-picker",
-    label: "Picker · pick own",
+    id: "inv-ko-ready-norepos",
+    label: "Ready · no team repos (intro)",
     group: "4 · Kickoff (start work)",
     role: "invitee",
-    wizard: { step: "kickoff", net: { contextTree: TREE_URL, installExists: true, sourceRepos: [], repos: REPOS } },
-  },
-  {
-    id: "inv-ko-picker-empty",
-    label: "Picker · no repos",
-    group: "4 · Kickoff (start work)",
-    role: "invitee",
-    wizard: { step: "kickoff", net: { contextTree: TREE_URL, installExists: true, sourceRepos: [], repos: [] } },
-  },
-  {
-    id: "inv-ko-picker-loading",
-    label: "Picker · loading",
-    group: "4 · Kickoff (start work)",
-    role: "invitee",
-    wizard: { step: "kickoff", net: { contextTree: TREE_URL, installExists: true, sourceRepos: [], repos: "pending" } },
-  },
-  {
-    id: "inv-ko-picker-scope",
-    label: "Picker · scope missing",
-    group: "4 · Kickoff (start work)",
-    role: "invitee",
-    wizard: { step: "kickoff", net: { contextTree: TREE_URL, installExists: true, sourceRepos: [], repos: "scope" } },
-  },
-  {
-    id: "inv-ko-picker-neterr",
-    label: "Picker · network error",
-    group: "4 · Kickoff (start work)",
-    role: "invitee",
-    wizard: {
-      step: "kickoff",
-      net: { contextTree: TREE_URL, installExists: true, sourceRepos: [], repos: "neterror" },
-    },
+    wizard: { step: "kickoff", net: { contextTree: TREE_URL, installExists: true, sourceRepos: [] } },
   },
   {
     id: "inv-ko-starting",

--- a/packages/web/src/pages/onboarding-preview.tsx
+++ b/packages/web/src/pages/onboarding-preview.tsx
@@ -203,7 +203,8 @@ type NetProfile = {
    * Team-recommended repos the invitee inherits. Served as ResourceRow[] from
    * GET /orgs/:id/resources (what listTeamResourcesForOrg actually calls since
    * the Resources Phase 1 refactor); InviteeKickoff filters to
-   * type==="repo" && defaultEnabled==="recommended" to decide confirm vs picker.
+   * type==="repo" && defaultEnabled==="recommended" — non-empty names them in
+   * the ready launch body, empty falls back to the intro copy.
    */
   sourceRepos?: string[];
   /**

--- a/packages/web/src/pages/onboarding/__tests__/provision-tree.test.ts
+++ b/packages/web/src/pages/onboarding/__tests__/provision-tree.test.ts
@@ -14,7 +14,7 @@ vi.mock("../../../api/resources.js", () => ({
 }));
 
 import { ApiError } from "../../../api/client.js";
-import { ensureSourceReposRegistered, provisionNewTree, repoLabel } from "../provision-tree.js";
+import { ensureSourceReposRegistered, kickoffErrorMessage, provisionNewTree, repoLabel } from "../provision-tree.js";
 
 const CREATED = {
   repo: "https://github.com/acme/acme-context-tree",
@@ -128,5 +128,28 @@ describe("repoLabel", () => {
   it("reduces a repo URL to its owner/name path", () => {
     expect(repoLabel("https://github.com/acme/app.git")).toBe("acme/app");
     expect(repoLabel("git@github.com:acme/api.git")).toBe("acme/api");
+  });
+});
+
+describe("kickoffErrorMessage", () => {
+  it("maps a known provisioning code to a plain message (not the raw server string)", () => {
+    const msg = kickoffErrorMessage(
+      new ApiError(409, "administration: write and contents: write", undefined, "organization_installation_required"),
+      "fallback",
+    );
+    expect(msg).toMatch(/GitHub organization/);
+    expect(msg).not.toMatch(/administration: write/);
+  });
+  it("falls back for an ApiError with an unknown / missing code (never leaks the server string)", () => {
+    expect(kickoffErrorMessage(new ApiError(500, "internal detail"), "fallback")).toBe("fallback");
+    expect(kickoffErrorMessage(new ApiError(409, "weird", undefined, "totally_unknown"), "fallback")).toBe("fallback");
+  });
+  it("surfaces a plain Error's message (our own friendly errors carry good copy)", () => {
+    expect(kickoffErrorMessage(new Error("Couldn't register 2 source repos"), "fallback")).toBe(
+      "Couldn't register 2 source repos",
+    );
+  });
+  it("uses the fallback for a non-Error throw", () => {
+    expect(kickoffErrorMessage("nope", "fallback")).toBe("fallback");
   });
 });

--- a/packages/web/src/pages/onboarding/__tests__/provision-tree.test.ts
+++ b/packages/web/src/pages/onboarding/__tests__/provision-tree.test.ts
@@ -139,6 +139,10 @@ describe("kickoffErrorMessage", () => {
     );
     expect(msg).toMatch(/GitHub organization/);
     expect(msg).not.toMatch(/administration: write/);
+    // repo_unavailable (repo name collision the App can't access) is mapped too.
+    expect(kickoffErrorMessage(new ApiError(409, "not accessible", undefined, "repo_unavailable"), "fallback")).toMatch(
+      /can't access it/,
+    );
   });
   it("falls back for an ApiError with an unknown / missing code (never leaks the server string)", () => {
     expect(kickoffErrorMessage(new ApiError(500, "internal detail"), "fallback")).toBe("fallback");

--- a/packages/web/src/pages/onboarding/__tests__/steps.test.ts
+++ b/packages/web/src/pages/onboarding/__tests__/steps.test.ts
@@ -137,29 +137,17 @@ describe("shouldEnterOnboarding", () => {
 
 describe("resolveInviteeKickoffState", () => {
   it("waits when the team has no knowledge link yet (admin not done)", () => {
-    expect(resolveInviteeKickoffState({ treeUrl: "", hasInstallation: false, teamRepoCount: 0 })).toBe("waiting");
-    expect(resolveInviteeKickoffState({ treeUrl: "", hasInstallation: true, teamRepoCount: 3 })).toBe("waiting");
+    expect(resolveInviteeKickoffState({ treeUrl: "", hasInstallation: false })).toBe("waiting");
+    expect(resolveInviteeKickoffState({ treeUrl: "", hasInstallation: true })).toBe("waiting");
   });
   it("waiting wins over no-installation when the tree is also missing (fix the bigger blocker first)", () => {
-    expect(resolveInviteeKickoffState({ treeUrl: "", hasInstallation: false, teamRepoCount: 3 })).toBe("waiting");
+    expect(resolveInviteeKickoffState({ treeUrl: "", hasInstallation: false })).toBe("waiting");
   });
-  it("stops at no-installation when the tree is set but the App was never installed (would 403 in picker)", () => {
-    expect(resolveInviteeKickoffState({ treeUrl: "https://x/y", hasInstallation: false, teamRepoCount: 0 })).toBe(
-      "no-installation",
-    );
-    expect(resolveInviteeKickoffState({ treeUrl: "https://x/y", hasInstallation: false, teamRepoCount: 3 })).toBe(
-      "no-installation",
-    );
+  it("stops at no-installation when the tree is set but the App was never installed (agent would 403)", () => {
+    expect(resolveInviteeKickoffState({ treeUrl: "https://x/y", hasInstallation: false })).toBe("no-installation");
   });
-  it("confirms from the team's projects when link + install + projects all exist", () => {
-    expect(resolveInviteeKickoffState({ treeUrl: "https://x/y", hasInstallation: true, teamRepoCount: 2 })).toBe(
-      "confirm",
-    );
-  });
-  it("lets the invitee pick when the team has link + install but listed no projects", () => {
-    expect(resolveInviteeKickoffState({ treeUrl: "https://x/y", hasInstallation: true, teamRepoCount: 0 })).toBe(
-      "picker",
-    );
+  it("is ready to launch once the tree is set and the App is installed (no repo selection)", () => {
+    expect(resolveInviteeKickoffState({ treeUrl: "https://x/y", hasInstallation: true })).toBe("ready");
   });
 });
 

--- a/packages/web/src/pages/onboarding/copy.ts
+++ b/packages/web/src/pages/onboarding/copy.ts
@@ -366,6 +366,8 @@ export const COPY = {
     no_installation: "GitHub isn't connected for your team yet. Connect it first, then try again.",
     suspended: "Your team's GitHub App installation is suspended. Re-enable it on GitHub, then try again.",
     not_configured: "GitHub isn't set up on this First Tree server yet. Ask your First Tree admin to finish the setup.",
+    repo_unavailable:
+      "A GitHub repo for your team's Context Tree already exists but First Tree can't access it. Give the GitHub App access to it (or remove it), then try again.",
     upstream: "Couldn't reach GitHub just now. Try again in a moment.",
   },
 } as const;

--- a/packages/web/src/pages/onboarding/copy.ts
+++ b/packages/web/src/pages/onboarding/copy.ts
@@ -161,7 +161,12 @@ export const COPY = {
     cantConnect: "Couldn't connect a repo here right now — continue now and add one later from Settings.",
     continueWithout: "Continue without a repo",
     continueNoProject: "Continue without a repo",
-    pickHint: "Pick one or more repos for your agent — or continue without any for now.",
+    // Shown when the picker has repos but none are selected. Connecting one is
+    // the whole point of this step — it's what gives the team a Context Tree —
+    // so we add friction (state the consequence + a quieter skip button), but
+    // never block: a beginner should still be able to move on.
+    noRepoConsequence:
+      "Pick a repo so your agent can build your team's Context Tree. Without one, teammates who join will be left waiting until you connect one.",
     /**
      * Shown under the CTA/Skip row: the install caveat (who can install) merged
      * with the skip reassurance into one muted line. `emphasis` renders bold so
@@ -178,7 +183,7 @@ export const COPY = {
         auto-unlocked button) because a fresh install URL overwrites the
         `oauth_state_nonce` cookie — re-minting while the first install tab is
         mid-flow would fail its callback. */
-    restartInstall: "Start over",
+    restartInstall: "Didn't work? Start over",
     /**
      * Troubleshooting shown inside the "Need help?" disclosure (alongside the
      * InstallGuide how-to), mirroring connect-computer. The disclosure
@@ -288,7 +293,7 @@ export const COPY = {
     newTitle: "Your agent's ready to get to work",
     newWhy: (repoCount: number): string =>
       `It'll start by reading your ${repoCount === 1 ? "repo" : `${repoCount} repos`} and drafting your team's Context Tree — the shared memory that lets every agent work like it already knows your project.`,
-    startBuilding: "Create tree & start",
+    startBuilding: "Build tree & start",
 
     // admin · the team already has a Context Tree (re-run / second admin /
     // CLI-bound). Detected silently — no fork, no paste — the agent reads it
@@ -343,5 +348,24 @@ export const COPY = {
     chatFailed: "Couldn't start the first task. Try again.",
     agentFailed: "Couldn't create your agent — please try again.",
     noAgent: "We couldn't find your agent. Go back a step and create one.",
+  },
+  /**
+   * Human-readable messages for Context Tree provisioning failures at kickoff.
+   * The server returns a machine `code` from POST /context-tree/initialize; we
+   * map it to plain language + a way forward, rather than leaking the raw
+   * server string (e.g. "administration: write and contents: write"). Keyed by
+   * that code; an unmapped code falls back to the generic chat-failed message.
+   */
+  provisionErrors: {
+    organization_installation_required:
+      "First Tree is connected to a personal GitHub account, but a team Context Tree needs a GitHub organization. Connect First Tree to an org, then try again.",
+    selected_repositories_unsupported:
+      "First Tree's GitHub App can only see selected repositories. Give it access to all repositories on GitHub, then try again.",
+    installation_permissions_insufficient:
+      "First Tree's GitHub App is missing permissions it needs to create your team's tree. Update its access on GitHub, then try again.",
+    no_installation: "GitHub isn't connected for your team yet. Connect it first, then try again.",
+    suspended: "Your team's GitHub App installation is suspended. Re-enable it on GitHub, then try again.",
+    not_configured: "GitHub isn't set up on this First Tree server yet. Ask your First Tree admin to finish the setup.",
+    upstream: "Couldn't reach GitHub just now. Try again in a moment.",
   },
 } as const;

--- a/packages/web/src/pages/onboarding/copy.ts
+++ b/packages/web/src/pages/onboarding/copy.ts
@@ -317,8 +317,11 @@ export const COPY = {
     // automatically (recommended team resources are enabled for every org
     // agent), so there is nothing to select.
     inviteeReadyTitle: "Your agent's ready to go",
-    inviteeReadyWithRepos: (repos: string): string =>
-      `Your team's all set up — your agent can already work on ${repos} and your shared Context Tree.`,
+    // Deliberately does NOT name specific repos or claim guaranteed access: an
+    // agent clones a team repo with the host machine's git credentials (no org
+    // token is injected), so a joining member without access to a private team
+    // repo can't reach it. "works with your team's repos" stays true regardless.
+    inviteeReadyWithRepos: "Your team's all set up — your agent works with your team's repos and shared Context Tree.",
     inviteeReadyNoRepos:
       "Your team's all set up — your agent will start with a quick intro. Repos can be added anytime from Settings.",
     startWorking: "Start working",

--- a/packages/web/src/pages/onboarding/copy.ts
+++ b/packages/web/src/pages/onboarding/copy.ts
@@ -278,73 +278,63 @@ export const COPY = {
       post: " to create your agent.",
     },
   },
-  /** kickoff / "Start" states (title/why are per-state, rendered by the step) */
+  /** kickoff — one unified "launch" finale across every path. Titles/bodies are
+      rendered per-state by the step; the shell leaves STEP_COPY.kickoff empty
+      for this bookend. */
   kickoff: {
-    // admin — new Context Tree (default when the team has none yet). This is
-    // the first time the user meets "Context Tree", so lead with a plain
-    // one-line gloss of what it is + why it helps before saying what happens.
-    // Approval is phrased concretely ("nothing's saved unless you say yes")
-    // instead of "walking you through each change to approve" — the latter
-    // reads vague about what is actually being approved (per issue-834 copy review).
-    newTitle: "Start your Context Tree",
-    newWhy:
-      "Your Context Tree is your team's shared memory — what agents need to work like they already know your project. Your agent drafts the first pieces with you in the chat, and nothing's saved unless you say yes.",
-    haveExisting: "I already have a Context Tree",
-    // admin — existing Context Tree (auto-detected from team settings, or pasted).
-    // Same gloss as newWhy so both kickoff paths teach the concept identically.
-    existingTitle: "Use your team's Context Tree",
-    existingWhy:
-      "Your Context Tree is your team's shared memory — what agents need to work like they already know your project. Your team already has one; your agent builds on it with you in the chat, and nothing's saved unless you say yes.",
-    existingUrlLabel: "Context Tree link",
-    autoDetectedNote: "Your team already has one — your agent will build on it. Edit the link or create a new one.",
-    createInstead: "Create new instead",
-    // admin — no project connected
-    noProjectTitle: "Start your agent",
-    noProjectBody:
-      "No repo connected, so your agent will start with a quick intro. Connect a repo later from Settings to give it real context.",
-    // invitee — team's tree is ready, pick a repo
-    inviteePickerTitle: "Pick a repo to work on",
-    inviteePickerWhy: "Your team's set up — pick which of your own repos your agent should help with.",
-    inviteePickerLoading: "Loading your repos…",
-    inviteePickerEmpty:
-      "No repos found on your GitHub account yet. You can continue without one and add later from Settings.",
-    inviteePickerScopeMissing: "Couldn't see your repos — First Tree needs permission to read them.",
-    inviteePickerNetworkError: "Couldn't load your repos. Try again in a moment.",
-    inviteeContinueNoProject: "Continue without a repo",
-    /** Shown atop confirm / picker so invitee knows where the work lands. */
-    treeLabel: "Context Tree",
-    // Launch CTA — per-substate so it names what's actually starting:
-    //   admin + tree → building the Context Tree; admin no-project → meeting
-    //   the agent (no project yet, so it's an intro — framed around the agent
-    //   as a teammate, not "chatting", which reads as a chatbot); invitee →
-    //   getting to work. (Green `cta` everywhere.)
-    startBuilding: "Start building",
+    // admin · new tree (the default — the team has none yet). Lead with the
+    // agent + the outcome (it seeds your team's memory from your code), not a
+    // Context-Tree lecture; the term is named once, lightly.
+    newTitle: "Your agent's ready to get to work",
+    newWhy: (repoCount: number): string =>
+      `It'll start by reading your ${repoCount === 1 ? "repo" : `${repoCount} repos`} and drafting your team's Context Tree — the shared memory that lets every agent work like it already knows your project.`,
+    startBuilding: "Create tree & start",
+
+    // admin · the team already has a Context Tree (re-run / second admin /
+    // CLI-bound). Detected silently — no fork, no paste — the agent reads it
+    // instead of seeding.
+    existingTitle: "Your agent's ready to get to work",
+    existingWhy: (repoCount: number): string =>
+      `Your team already has a Context Tree — your agent will get oriented and start working on your ${repoCount === 1 ? "repo" : `${repoCount} repos`}.`,
+    startExisting: "Start",
+
+    // admin · no repo connected (connect-code skipped / 0 picked). Nothing to
+    // seed from, so this is honestly "meet your agent" — not a tree moment. The
+    // affordance points back to connecting a repo (the only way to give the team
+    // a Context Tree), not a silent "do it later in Settings".
+    noProjectTitle: "Your agent's ready",
+    noProjectBody: "No repo connected, so your agent will start with a quick intro.",
+    connectRepoAffordance: "Want a team Context Tree? Connect a repo",
     startChatting: "Meet your agent",
+
+    // invitee · ready (team has a tree + a GitHub connection). Replaces the old
+    // confirm/picker screens — the agent already inherits the team's repos
+    // automatically (recommended team resources are enabled for every org
+    // agent), so there is nothing to select.
+    inviteeReadyTitle: "Your agent's ready to go",
+    inviteeReadyWithRepos: (repos: string): string =>
+      `Your team's all set up — your agent can already work on ${repos} and your shared Context Tree.`,
+    inviteeReadyNoRepos:
+      "Your team's all set up — your agent will start with a quick intro. Repos can be added anytime from Settings.",
     startWorking: "Start working",
+
+    // shared launch transition
     starting: "Starting your agent…",
-    invalidUrl:
-      "That doesn't look like a web link — paste the full address, e.g. https://github.com/your-team/context-tree",
   },
-  /** invitee states */
+  /** invitee blocked states — the team isn't ready yet (no tree, or no GitHub) */
   invitee: {
     waitingTitle: "Waiting for your team to set up",
     waitingBody:
       "Your team's admin is still setting up repos and a Context Tree. This page updates on its own as soon as they're done.",
     waitingStatus: "Watching for updates…",
-    // NEW: admin set up tree but never connected the GitHub App. Without
-    // an installation, every git op the agent runs will 403, so we hard-stop
-    // the invitee here rather than letting them sail into the picker.
+    // admin set up a tree but never connected the GitHub App; without an
+    // installation every git op the agent runs would 403, so we hold here.
     noInstallTitle: "Almost there — your team's repo isn't connected yet",
     noInstallBody:
       "Your team's admin set up the Context Tree but hasn't connected a repo on GitHub yet. Your agent needs that connection to do real work.",
     noInstallStatus: "Watching for the connection…",
-    noInstallShareIntro: "Send this link so your admin can connect your team's repo:",
-    confirmTitle: "Your team is ready",
-    confirmBody: "Your team set up its repos and Context Tree. Pick what your agent should work on.",
-    // Bailout on the waiting / no-installation screens — proceed with your
-    // own agent now instead of waiting on the team. Framed positively around
-    // the agent (was "Start chatting anyway"; "anyway" read as defiant/
-    // discouraging, and "chatting" as a chatbot).
+    // Bailout on the blocked screens — meet your agent now (an intro chat)
+    // instead of waiting on the team.
     startAnyway: "Meet your agent",
   },
   /** failure recovery, shared */

--- a/packages/web/src/pages/onboarding/flow-ui.tsx
+++ b/packages/web/src/pages/onboarding/flow-ui.tsx
@@ -77,15 +77,23 @@ export function FlowHint({
       role={role}
       style={{ gap: "var(--sp-1_5)", margin: 0, color: "var(--fg-3)" }}
     >
-      <Icon
-        className="h-3.5 w-3.5"
+      {/* Box the icon to the text's line-height and center it, so the glyph
+          lines up with the FIRST line of the hint — keeps single- AND
+          multi-line hints aligned (a fixed marginTop only worked for one). */}
+      <span
         style={{
+          display: "inline-flex",
+          alignItems: "center",
+          height: "calc(var(--text-label) * var(--text-label--line-height))",
           flexShrink: 0,
-          marginTop: "var(--sp-0_5)",
-          color: tone === "error" ? "var(--fg-error-strong)" : "var(--fg-4)",
         }}
-        aria-hidden="true"
-      />
+      >
+        <Icon
+          className="h-3.5 w-3.5"
+          style={{ color: tone === "error" ? "var(--fg-error-strong)" : "var(--fg-4)" }}
+          aria-hidden="true"
+        />
+      </span>
       <span style={{ minWidth: 0 }}>{children}</span>
     </p>
   );

--- a/packages/web/src/pages/onboarding/provision-tree.ts
+++ b/packages/web/src/pages/onboarding/provision-tree.ts
@@ -3,6 +3,25 @@ import { ApiError } from "../../api/client.js";
 import { initializeContextTree } from "../../api/context-tree.js";
 import { getContextTreeSetting } from "../../api/org-settings.js";
 import { createTeamResourceForOrg, listTeamResourcesForOrg } from "../../api/resources.js";
+import { COPY } from "./copy.js";
+
+/**
+ * Turn a kickoff failure into a message worth showing the user. Context Tree
+ * provisioning errors arrive as an `ApiError` carrying the server's machine
+ * `code` (organization_installation_required, installation_permissions_insufficient,
+ * …); map those to plain language with a way forward rather than leaking the raw
+ * server string. Our own thrown Errors (e.g. `ensureSourceReposRegistered`)
+ * already carry a friendly message, so surface those as-is; an unmapped ApiError
+ * falls back to `fallback` rather than exposing a technical string.
+ */
+export function kickoffErrorMessage(err: unknown, fallback: string): string {
+  if (err instanceof ApiError) {
+    const messages: Record<string, string> = COPY.provisionErrors;
+    const mapped = err.code ? messages[err.code] : undefined;
+    return mapped ?? fallback;
+  }
+  return err instanceof Error ? err.message : fallback;
+}
 
 /** Reduce a repo URL to its `owner/name` path (protocol/host/.git stripped) —
  *  for the human-readable resource name and error text. */

--- a/packages/web/src/pages/onboarding/steps.ts
+++ b/packages/web/src/pages/onboarding/steps.ts
@@ -208,27 +208,27 @@ export function shouldLeaveOnboarding(facts: OnboardingGateFacts): boolean {
 /**
  * Which invitee kickoff sub-state to show, given what the team has set up.
  * Pure so it's unit-testable (the React component just maps the result to a
- * body). Ordered upstream-first — fix the biggest blocker before the next:
- *   - no Context Tree link yet              → "waiting"          (admin isn't done at all)
- *   - link but no GitHub App installation   → "no-installation"  (admin skipped code; agent would 403)
- *   - link + install + team listed projects → "confirm"          (pick from them)
- *   - link + install but no team projects   → "picker"           (invitee picks own)
+ * body). Ordered upstream-first — fix the biggest blocker before launch:
+ *   - no Context Tree link yet            → "waiting"          (admin isn't done at all)
+ *   - link but no GitHub App installation → "no-installation"  (admin skipped code; agent would 403)
+ *   - link + install                      → "ready"            (just launch)
  *
- * The "no-installation" state was added because the previous flow silently
- * advanced invitees into the picker, where they'd successfully select repos
- * and only discover the missing install when the agent's first git op
- * failed with 403. We hard-stop here instead, with a "remind admin"
- * affordance and a "Meet your agent" bailout so the invitee is never
- * truly blocked.
+ * There is deliberately no repo-selection sub-state. The invitee's agent
+ * inherits the team's `recommended` repo resources automatically (they're
+ * enabled for every org agent), so picking repos here changed nothing about
+ * what the agent could access — it only flavoured the kickoff message. The
+ * "ready" state is a pure launch; the body names the team's repos when there
+ * are any, otherwise frames it as an intro.
+ *
+ * The "no-installation" state exists because the previous flow silently
+ * advanced invitees past it, where the agent's first git op would 403. We
+ * hold there instead, with a "Meet your agent" bailout so the invitee is
+ * never truly blocked.
  */
-export type InviteeKickoffState = "waiting" | "no-installation" | "confirm" | "picker";
+export type InviteeKickoffState = "waiting" | "no-installation" | "ready";
 
-export function resolveInviteeKickoffState(args: {
-  treeUrl: string;
-  hasInstallation: boolean;
-  teamRepoCount: number;
-}): InviteeKickoffState {
+export function resolveInviteeKickoffState(args: { treeUrl: string; hasInstallation: boolean }): InviteeKickoffState {
   if (!args.treeUrl) return "waiting";
   if (!args.hasInstallation) return "no-installation";
-  return args.teamRepoCount > 0 ? "confirm" : "picker";
+  return "ready";
 }

--- a/packages/web/src/pages/onboarding/steps/step-connect-code.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-connect-code.tsx
@@ -215,14 +215,12 @@ export function StepConnectCode() {
                 if the GitHub tab didn't work, "Start over" re-mints (the only
                 safe way to retry — see the CTA-lock note above). */}
             {attempted ? (
-              <div className="flex flex-col" style={{ gap: "var(--sp-1)" }}>
+              // One row: the live "waiting" status plus the re-mint retry as a
+              // quiet inline link (the GitHub tab can fail silently; re-minting
+              // is the only safe retry — see the CTA-lock note above).
+              <div className="flex items-center" style={{ gap: "var(--sp-2_5)", flexWrap: "wrap" }}>
                 <StatusRow state="waiting" label={COPY.connectCode.waiting} />
-                <Button
-                  type="button"
-                  variant="link"
-                  className="h-auto self-start p-0 text-label"
-                  onClick={handleStartOver}
-                >
+                <Button type="button" variant="link" className="h-auto p-0 text-label" onClick={handleStartOver}>
                   {COPY.connectCode.restartInstall}
                 </Button>
               </div>
@@ -268,18 +266,35 @@ export function StepConnectCode() {
         )}
       </div>
 
-      <div className="flex flex-col" style={{ gap: "var(--sp-2)" }}>
-        {hasPickableRepos && selectedRepoUrls.length === 0 && (
-          <p className="text-label" style={{ margin: 0, color: "var(--fg-4)" }}>
-            {COPY.connectCode.pickHint}
-          </p>
+      <div className="flex flex-col" style={{ gap: "var(--sp-2_5)" }}>
+        {selectedRepoUrls.length > 0 ? (
+          // Happy path: a repo is picked → bind it. Strong primary.
+          <Button type="button" onClick={goNext} className="self-start">
+            <span>{COPY.continue}</span>
+            <ArrowRight className="h-4 w-4" />
+          </Button>
+        ) : (
+          // No repo (didn't pick / couldn't load / none exist): continuing
+          // without one is never the desired path, so it's always a very weak
+          // muted micro-link — never a strong button. When there ARE repos to
+          // pick, add the consequence line so the skip is an informed, deliberate
+          // choice (friction, not a block). When the list failed/empty, the
+          // picker area already explains why, so no extra line.
+          <>
+            {hasPickableRepos && <FlowHint>{COPY.connectCode.noRepoConsequence}</FlowHint>}
+            {/* A quiet text link: clearly clickable (persistent underline, no
+                button chrome) but never the prominent path, so picking a repo
+                stays obvious. Never disabled. */}
+            <Button
+              type="button"
+              variant="link"
+              className="h-auto self-start p-0 text-label underline underline-offset-2"
+              onClick={goNext}
+            >
+              {COPY.connectCode.continueNoProject}
+            </Button>
+          </>
         )}
-        {/* Primary is never disabled: with a project it binds, without one it
-            continues anyway — a beginner should never face a dead button. */}
-        <Button type="button" onClick={goNext} className="self-start">
-          <span>{selectedRepoUrls.length > 0 ? COPY.continue : COPY.connectCode.continueNoProject}</span>
-          <ArrowRight className="h-4 w-4" />
-        </Button>
       </div>
     </div>
   );

--- a/packages/web/src/pages/onboarding/steps/step-kickoff.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-kickoff.tsx
@@ -7,7 +7,11 @@ import { reportOnboardingEvent } from "../../../api/onboarding-events.js";
 import { getContextTreeSetting, putContextTreeSetting } from "../../../api/org-settings.js";
 import { createTeamResourceForOrg, listTeamResourcesForOrg } from "../../../api/resources.js";
 import { Button } from "../../../components/ui/button.js";
-import { buildBindBootstrap, buildCreateBootstrap } from "../../workspace/center/onboarding/bootstrap-prose.js";
+import {
+  buildBindBootstrap,
+  buildCreateBootstrap,
+  buildInviteeBootstrap,
+} from "../../workspace/center/onboarding/bootstrap-prose.js";
 import { COPY } from "../copy.js";
 import { FlowHint, StatusRow, StepHeading, WorkingState } from "../flow-ui.js";
 import { useOnboardingFlow } from "../onboarding-flow.js";
@@ -364,9 +368,11 @@ function InviteeReady({ treeUrl, teamRepoUrls }: { treeUrl: string; teamRepoUrls
     setError(null);
     setPhase("starting");
     try {
-      const bootstrap = hasRepos ? buildBindBootstrap(teamRepoUrls, treeUrl) : NO_REPO_BOOTSTRAP;
+      // The agent already inherits the team's repos; a joining teammate's first
+      // message is "read the tree to get oriented, then introduce yourself" —
+      // not the admin's "reflect these repos into the tree".
       await runKickoff({
-        bootstrap,
+        bootstrap: buildInviteeBootstrap(treeUrl),
         gitRepoUrls: [],
         orgWrites: null,
         treeMode: "existing",

--- a/packages/web/src/pages/onboarding/steps/step-kickoff.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-kickoff.tsx
@@ -35,7 +35,6 @@ function teamRecommendedRepoUrls(resources: Awaited<ReturnType<typeof listTeamRe
 /** Shared "create the chat + send the first task + finish" sequence. */
 async function runKickoff(args: {
   bootstrap: string;
-  gitRepoUrls: string[];
   orgWrites: { organizationId: string; sourceRepos: string[]; contextTreeUrl: string | null } | null;
   treeMode: "new" | "existing";
   joinPath?: "invite";
@@ -164,7 +163,6 @@ function AdminKickoff() {
       if (!hasRepos) {
         await runKickoff({
           bootstrap: NO_REPO_BOOTSTRAP,
-          gitRepoUrls: [],
           orgWrites: null,
           treeMode: "new",
           complete: completeAndEnterChat,
@@ -178,7 +176,6 @@ function AdminKickoff() {
         : buildCreateBootstrap(selectedRepoUrls);
       await runKickoff({
         bootstrap,
-        gitRepoUrls: selectedRepoUrls,
         orgWrites: organizationId
           ? {
               organizationId,
@@ -373,7 +370,6 @@ function InviteeReady({ treeUrl, teamRepoUrls }: { treeUrl: string; teamRepoUrls
       // not the admin's "reflect these repos into the tree".
       await runKickoff({
         bootstrap: buildInviteeBootstrap(treeUrl),
-        gitRepoUrls: [],
         orgWrites: null,
         treeMode: "existing",
         joinPath: "invite",
@@ -439,7 +435,6 @@ function InviteeBlocked({ title, why, status }: { title: string; why: string; st
     try {
       await runKickoff({
         bootstrap: NO_REPO_BOOTSTRAP,
-        gitRepoUrls: [],
         orgWrites: null, // never mutate team config as an invitee
         treeMode: "existing",
         joinPath: "invite",

--- a/packages/web/src/pages/onboarding/steps/step-kickoff.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-kickoff.tsx
@@ -387,11 +387,7 @@ function InviteeReady({ treeUrl, teamRepoUrls }: { treeUrl: string; teamRepoUrls
     <div className="flex flex-col" style={{ gap: "var(--sp-6)" }}>
       <StepHeading
         title={COPY.kickoff.inviteeReadyTitle}
-        why={
-          hasRepos
-            ? COPY.kickoff.inviteeReadyWithRepos(teamRepoUrls.map(repoLabel).join(", "))
-            : COPY.kickoff.inviteeReadyNoRepos
-        }
+        why={hasRepos ? COPY.kickoff.inviteeReadyWithRepos : COPY.kickoff.inviteeReadyNoRepos}
       />
       <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
         {error && (

--- a/packages/web/src/pages/onboarding/steps/step-kickoff.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-kickoff.tsx
@@ -11,7 +11,7 @@ import { buildBindBootstrap, buildCreateBootstrap } from "../../workspace/center
 import { COPY } from "../copy.js";
 import { FlowHint, StatusRow, StepHeading, WorkingState } from "../flow-ui.js";
 import { useOnboardingFlow } from "../onboarding-flow.js";
-import { ensureSourceReposRegistered, provisionNewTree, repoLabel } from "../provision-tree.js";
+import { ensureSourceReposRegistered, kickoffErrorMessage, provisionNewTree, repoLabel } from "../provision-tree.js";
 import { resolveOnboardingAgent } from "../resolve-agent.js";
 import { resolveInviteeKickoffState } from "../steps.js";
 
@@ -186,7 +186,7 @@ function AdminKickoff() {
         complete: completeAndEnterChat,
       });
     } catch (err) {
-      setError(err instanceof Error ? err.message : COPY.errors.chatFailed);
+      setError(kickoffErrorMessage(err, COPY.errors.chatFailed));
       setPhase("form");
     }
   };
@@ -212,10 +212,13 @@ function AdminKickoff() {
               <ArrowRight className="h-4 w-4" />
             </Button>
           </div>
+          {/* Standalone affordance back to connect-code (where they can pick a
+              repo, then Continue returns here with one). A persistent underline
+              makes it read as a clickable link, not a heading. */}
           <Button
             type="button"
             variant="link"
-            className="h-auto p-0 text-label self-start"
+            className="h-auto self-start p-0 text-label underline underline-offset-2"
             onClick={() => goTo(sequence.indexOf("connect-code"))}
           >
             {COPY.kickoff.connectRepoAffordance}
@@ -371,7 +374,7 @@ function InviteeReady({ treeUrl, teamRepoUrls }: { treeUrl: string; teamRepoUrls
         complete: completeAndEnterChat,
       });
     } catch (err) {
-      setError(err instanceof Error ? err.message : COPY.errors.chatFailed);
+      setError(kickoffErrorMessage(err, COPY.errors.chatFailed));
       setPhase("idle");
     }
   };
@@ -438,7 +441,7 @@ function InviteeBlocked({ title, why, status }: { title: string; why: string; st
         complete: completeAndEnterChat,
       });
     } catch (err) {
-      setError(err instanceof Error ? err.message : COPY.errors.chatFailed);
+      setError(kickoffErrorMessage(err, COPY.errors.chatFailed));
       setPhase("idle");
     }
   };

--- a/packages/web/src/pages/onboarding/steps/step-kickoff.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-kickoff.tsx
@@ -2,17 +2,14 @@ import { useQuery } from "@tanstack/react-query";
 import { ArrowRight } from "lucide-react";
 import { useEffect, useState } from "react";
 import { createAgentChat, sendChatMessage } from "../../../api/chats.js";
-import { ApiError } from "../../../api/client.js";
-import { listGithubRepos } from "../../../api/github.js";
 import { getGithubAppInstallationExists } from "../../../api/github-app.js";
 import { reportOnboardingEvent } from "../../../api/onboarding-events.js";
 import { getContextTreeSetting, putContextTreeSetting } from "../../../api/org-settings.js";
 import { createTeamResourceForOrg, listTeamResourcesForOrg } from "../../../api/resources.js";
 import { Button } from "../../../components/ui/button.js";
-import { Input } from "../../../components/ui/input.js";
 import { buildBindBootstrap, buildCreateBootstrap } from "../../workspace/center/onboarding/bootstrap-prose.js";
 import { COPY } from "../copy.js";
-import { CommandBox, FlowHint, RepoPicker, SelectableRow, StatusRow, StepHeading, WorkingState } from "../flow-ui.js";
+import { FlowHint, StatusRow, StepHeading, WorkingState } from "../flow-ui.js";
 import { useOnboardingFlow } from "../onboarding-flow.js";
 import { ensureSourceReposRegistered, provisionNewTree, repoLabel } from "../provision-tree.js";
 import { resolveOnboardingAgent } from "../resolve-agent.js";
@@ -123,15 +120,20 @@ function AdminKickoff() {
     treeAutoInitDone,
     markTreeAutoInitDone,
     completeAndEnterChat,
+    goTo,
+    sequence,
   } = useOnboardingFlow();
   const [phase, setPhase] = useState<"form" | "starting">("form");
   const [error, setError] = useState<string | null>(null);
 
   const hasRepos = selectedRepoUrls.length > 0;
+  const repoCount = selectedRepoUrls.length;
 
-  // Auto-detect an existing team Context Tree so a re-run / second admin /
-  // CLI-bound tree doesn't default to creating a duplicate. retry:false so a
-  // "no tree yet" miss falls through to the new-tree path fast.
+  // Silently detect an existing team Context Tree (a re-run / second admin /
+  // CLI-bound tree). There is no "paste your tree URL" path anymore — a team's
+  // tree is always one we provision — so detection only switches the agent's
+  // first task from "seed a new tree" to "read the existing one"; it never asks
+  // the user to choose. retry:false so a "no tree yet" miss falls through fast.
   const treeSettingQuery = useQuery({
     queryKey: ["onboarding", "context-tree", organizationId],
     queryFn: () => getContextTreeSetting(organizationId ?? ""),
@@ -140,20 +142,16 @@ function AdminKickoff() {
   });
   const detectedTreeUrl = treeSettingQuery.data?.repo ?? null;
   useEffect(() => {
-    // One-shot: when an existing tree first arrives, default to "use existing"
-    // with the URL pre-filled. After that the user can toggle freely — the
-    // done-flag lives in the provider, so re-entering this step (e.g. via the
-    // rail) won't re-fire and clobber a "Create new instead" choice.
+    // One-shot: when an existing tree is detected, switch to the "read it"
+    // bootstrap silently. The done-flag lives in the provider so re-entering
+    // this step won't re-fire.
     if (treeAutoInitDone || !detectedTreeUrl) return;
     markTreeAutoInitDone();
     setTreeUrl(detectedTreeUrl);
     setTreeMode("existing");
   }, [detectedTreeUrl, setTreeUrl, setTreeMode, treeAutoInitDone, markTreeAutoInitDone]);
-  const autoDetected = treeMode === "existing" && !!detectedTreeUrl && treeUrl === detectedTreeUrl;
 
-  const trimmedTreeUrl = treeUrl.trim();
-  const urlInvalid = treeMode === "existing" && trimmedTreeUrl.length > 0 && !/^https:\/\//.test(trimmedTreeUrl);
-  const canStart = phase === "form" && (!hasRepos || treeMode === "new" || (trimmedTreeUrl.length > 0 && !urlInvalid));
+  const canStart = phase === "form";
 
   const handleStart = async (): Promise<void> => {
     setError(null);
@@ -170,8 +168,9 @@ function AdminKickoff() {
         return;
       }
       const useExisting = treeMode === "existing";
+      const detectedUrl = treeUrl.trim();
       const bootstrap = useExisting
-        ? buildBindBootstrap(selectedRepoUrls, trimmedTreeUrl)
+        ? buildBindBootstrap(selectedRepoUrls, detectedUrl)
         : buildCreateBootstrap(selectedRepoUrls);
       await runKickoff({
         bootstrap,
@@ -180,7 +179,7 @@ function AdminKickoff() {
           ? {
               organizationId,
               sourceRepos: selectedRepoUrls,
-              contextTreeUrl: useExisting ? trimmedTreeUrl : null,
+              contextTreeUrl: useExisting ? detectedUrl : null,
             }
           : null,
         treeMode: useExisting ? "existing" : "new",
@@ -194,13 +193,14 @@ function AdminKickoff() {
 
   if (phase === "starting") return <StartingState />;
 
-  // C — no project connected: agent just introduces itself.
+  // No repo connected — nothing to seed a tree from, so this is honestly just
+  // "meet your agent". A quiet affordance points back to connect-code (the only
+  // way to give the team a Context Tree), not a silent "do it later in Settings".
   if (!hasRepos) {
     return (
       <div className="flex flex-col" style={{ gap: "var(--sp-6)" }}>
-        <StepHeading title={COPY.kickoff.noProjectTitle} />
-        <div className="flex flex-col" style={{ gap: "var(--sp-5)" }}>
-          <FlowHint>{COPY.kickoff.noProjectBody}</FlowHint>
+        <StepHeading title={COPY.kickoff.noProjectTitle} why={COPY.kickoff.noProjectBody} />
+        <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
           {error && (
             <FlowHint tone="error" role="alert">
               {error}
@@ -212,18 +212,22 @@ function AdminKickoff() {
               <ArrowRight className="h-4 w-4" />
             </Button>
           </div>
+          <Button
+            type="button"
+            variant="link"
+            className="h-auto p-0 text-label self-start"
+            onClick={() => goTo(sequence.indexOf("connect-code"))}
+          >
+            {COPY.kickoff.connectRepoAffordance}
+          </Button>
         </div>
       </div>
     );
   }
 
-  // Wait for the existing-tree probe so we don't flash "new" then jump to A.
+  // Wait for the existing-tree probe so we don't flash "new" then flip to "read".
   if (treeSettingQuery.isLoading) {
-    return (
-      <p className="text-label" style={{ color: "var(--fg-4)" }}>
-        Checking your team's setup…
-      </p>
-    );
+    return <StatusRow state="waiting" label="Checking your team's setup…" />;
   }
 
   const isExisting = treeMode === "existing";
@@ -231,55 +235,9 @@ function AdminKickoff() {
     <div className="flex flex-col" style={{ gap: "var(--sp-6)" }}>
       <StepHeading
         title={isExisting ? COPY.kickoff.existingTitle : COPY.kickoff.newTitle}
-        why={isExisting ? COPY.kickoff.existingWhy : COPY.kickoff.newWhy}
+        why={isExisting ? COPY.kickoff.existingWhy(repoCount) : COPY.kickoff.newWhy(repoCount)}
       />
       <div className="flex flex-col" style={{ gap: "var(--sp-5)" }}>
-        {isExisting ? (
-          // A (auto-detected, pre-filled) or B′ (manually "I already have one").
-          <div className="flex flex-col" style={{ gap: "var(--sp-1_5)" }}>
-            <label htmlFor="onboarding-tree-url" className="text-label" style={{ color: "var(--fg-3)" }}>
-              {COPY.kickoff.existingUrlLabel}
-            </label>
-            <Input
-              id="onboarding-tree-url"
-              value={treeUrl}
-              onChange={(e) => setTreeUrl(e.target.value)}
-              placeholder="https://github.com/your-team/context-tree"
-              className="mono"
-            />
-            {autoDetected ? (
-              <p className="text-label" style={{ margin: 0, color: "var(--fg-4)" }}>
-                {COPY.kickoff.autoDetectedNote}
-              </p>
-            ) : null}
-            {urlInvalid && (
-              <FlowHint tone="error" role="alert">
-                {COPY.kickoff.invalidUrl}
-              </FlowHint>
-            )}
-            <Button
-              type="button"
-              variant="link"
-              className="h-auto p-0 text-label self-start"
-              onClick={() => {
-                setTreeUrl("");
-                setTreeMode("new");
-              }}
-            >
-              {COPY.kickoff.createInstead}
-            </Button>
-          </div>
-        ) : (
-          // B (new tree, default): quiet secondary link to the existing path.
-          <Button
-            type="button"
-            variant="link"
-            className="h-auto p-0 text-label self-start"
-            onClick={() => setTreeMode("existing")}
-          >
-            {COPY.kickoff.haveExisting}
-          </Button>
-        )}
         {error && (
           <FlowHint tone="error" role="alert">
             {error}
@@ -287,7 +245,7 @@ function AdminKickoff() {
         )}
         <div className="flex">
           <Button type="button" variant="cta" onClick={() => void handleStart()} disabled={!canStart}>
-            <span>{COPY.kickoff.startBuilding}</span>
+            <span>{isExisting ? COPY.kickoff.startExisting : COPY.kickoff.startBuilding}</span>
             <ArrowRight className="h-4 w-4" />
           </Button>
         </div>
@@ -361,11 +319,7 @@ function InviteeKickoff() {
   });
 
   if (teamQuery.isLoading) {
-    return (
-      <p className="text-label" style={{ color: "var(--fg-4)" }}>
-        Checking what your team has set up…
-      </p>
-    );
+    return <StatusRow state="waiting" label="Checking what your team has set up…" />;
   }
 
   // Read failure → waiting; the query keeps polling so a transient blip
@@ -375,136 +329,42 @@ function InviteeKickoff() {
   }
 
   const { treeUrl, teamRepoUrls, hasInstallation } = teamQuery.data;
-  const state = resolveInviteeKickoffState({
-    treeUrl,
-    hasInstallation,
-    teamRepoCount: teamRepoUrls.length,
-  });
+  const state = resolveInviteeKickoffState({ treeUrl, hasInstallation });
 
   switch (state) {
     case "waiting":
       return <InviteeWaiting />;
     case "no-installation":
       return <InviteeNoInstallation />;
-    case "confirm":
-      return <InviteeConfirm treeUrl={treeUrl} teamRepoUrls={teamRepoUrls} />;
-    case "picker":
-      return <InviteePicker treeUrl={treeUrl} />;
+    case "ready":
+      return <InviteeReady treeUrl={treeUrl} teamRepoUrls={teamRepoUrls} />;
   }
 }
 
 /**
- * Read-only display of the team's Context Tree URL, shown at the top of
- * the invitee's confirm/picker sub-states so they know where their agent's
- * work will land. Info transparency — invitee inherits this, can't change it.
+ * Invitee · ready to launch. The team has a Context Tree and a GitHub
+ * connection, so there's nothing left to set up — and nothing to pick: the
+ * agent already inherits the team's `recommended` repo resources automatically
+ * (they're enabled for every org agent). This mirrors the admin finale as a
+ * pure launch. The kickoff message names the team's repos when there are any,
+ * otherwise it's an intro; either way the agent enters a real chat. `orgWrites`
+ * stays null — an invitee never mutates team config.
  */
-function TreeUrlDisplay({ treeUrl }: { treeUrl: string }) {
-  return (
-    <div className="flex flex-col" style={{ gap: "var(--sp-0_5)" }}>
-      <p className="text-label" style={{ margin: 0, color: "var(--fg-4)" }}>
-        {COPY.kickoff.treeLabel}
-      </p>
-      <p
-        className="text-label mono"
-        title={treeUrl}
-        style={{
-          margin: 0,
-          color: "var(--fg-2)",
-          whiteSpace: "nowrap",
-          overflow: "hidden",
-          textOverflow: "ellipsis",
-        }}
-      >
-        {repoLabel(treeUrl)}
-      </p>
-    </div>
-  );
-}
-
-function InviteeConfirm({ treeUrl, teamRepoUrls }: { treeUrl: string; teamRepoUrls: string[] }) {
+function InviteeReady({ treeUrl, teamRepoUrls }: { treeUrl: string; teamRepoUrls: string[] }) {
   const { completeAndEnterChat } = useOnboardingFlow();
-  const [chosen, setChosen] = useState<string[]>(teamRepoUrls);
-  const [phase, setPhase] = useState<"form" | "starting">("form");
+  const [phase, setPhase] = useState<"idle" | "starting">("idle");
   const [error, setError] = useState<string | null>(null);
 
-  const toggle = (url: string): void =>
-    setChosen((prev) => (prev.includes(url) ? prev.filter((u) => u !== url) : [...prev, url]));
+  const hasRepos = teamRepoUrls.length > 0;
 
-  const handleStart = async (selectedRepos: string[]): Promise<void> => {
+  const handleStart = async (): Promise<void> => {
     setError(null);
     setPhase("starting");
     try {
-      // Empty selection ⇒ intro-only bootstrap (matches admin's no-project
-      // path), so deselecting all isn't a dead end.
-      const bootstrap = selectedRepos.length > 0 ? buildBindBootstrap(selectedRepos, treeUrl) : NO_REPO_BOOTSTRAP;
+      const bootstrap = hasRepos ? buildBindBootstrap(teamRepoUrls, treeUrl) : NO_REPO_BOOTSTRAP;
       await runKickoff({
         bootstrap,
-        gitRepoUrls: selectedRepos,
-        orgWrites: null, // never mutate team config as an invitee
-        treeMode: "existing",
-        joinPath: "invite",
-        complete: completeAndEnterChat,
-      });
-    } catch (err) {
-      setError(err instanceof Error ? err.message : COPY.errors.chatFailed);
-      setPhase("form");
-    }
-  };
-
-  if (phase === "starting") return <StartingState />;
-
-  return (
-    <div className="flex flex-col" style={{ gap: "var(--sp-6)" }}>
-      <StepHeading title={COPY.invitee.confirmTitle} why={COPY.invitee.confirmBody} />
-      <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
-        <TreeUrlDisplay treeUrl={treeUrl} />
-        <div className="flex flex-col" style={{ gap: "var(--sp-1)" }}>
-          {teamRepoUrls.map((url) => (
-            <SelectableRow key={url} checked={chosen.includes(url)} onToggle={() => toggle(url)}>
-              <span className="font-medium">{repoLabel(url)}</span>
-            </SelectableRow>
-          ))}
-        </div>
-        {error && (
-          <FlowHint tone="error" role="alert">
-            {error}
-          </FlowHint>
-        )}
-        {/* Primary is never disabled by deselect-all; the bailout link
-            preserves the "continue with intro only" path so users can't
-            soft-lock themselves. */}
-        <div className="flex items-center" style={{ gap: "var(--sp-4)", flexWrap: "wrap" }}>
-          <Button type="button" variant="cta" onClick={() => void handleStart(chosen)} disabled={chosen.length === 0}>
-            <span>{COPY.kickoff.startWorking}</span>
-            <ArrowRight className="h-4 w-4" />
-          </Button>
-          <Button type="button" variant="link" className="h-auto p-0 text-label" onClick={() => void handleStart([])}>
-            {COPY.kickoff.inviteeContinueNoProject}
-          </Button>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function InviteePicker({ treeUrl }: { treeUrl: string }) {
-  const { completeAndEnterChat } = useOnboardingFlow();
-  const [selected, setSelected] = useState<string[]>([]);
-  const [phase, setPhase] = useState<"form" | "starting">("form");
-  const [error, setError] = useState<string | null>(null);
-  const reposQuery = useQuery({ queryKey: ["onboarding", "github-repos"], queryFn: listGithubRepos });
-
-  const toggle = (url: string): void =>
-    setSelected((prev) => (prev.includes(url) ? prev.filter((u) => u !== url) : [...prev, url]));
-
-  const handleStart = async (selectedRepos: string[]): Promise<void> => {
-    setError(null);
-    setPhase("starting");
-    try {
-      const bootstrap = selectedRepos.length > 0 ? buildBindBootstrap(selectedRepos, treeUrl) : NO_REPO_BOOTSTRAP;
-      await runKickoff({
-        bootstrap,
-        gitRepoUrls: selectedRepos,
+        gitRepoUrls: [],
         orgWrites: null,
         treeMode: "existing",
         joinPath: "invite",
@@ -512,68 +372,94 @@ function InviteePicker({ treeUrl }: { treeUrl: string }) {
       });
     } catch (err) {
       setError(err instanceof Error ? err.message : COPY.errors.chatFailed);
-      setPhase("form");
+      setPhase("idle");
     }
   };
 
   if (phase === "starting") return <StartingState />;
 
-  // Three failure shapes are folded into one "no list" branch in the
-  // legacy code; split them so the recovery action matches the cause.
-  const scopeMissing = reposQuery.error instanceof ApiError && reposQuery.error.status === 403;
-  const networkErr = !!reposQuery.error && !scopeMissing;
-  const empty = !reposQuery.error && (reposQuery.data?.length ?? 0) === 0;
-  const hasRepos = !reposQuery.error && (reposQuery.data?.length ?? 0) > 0;
-
   return (
     <div className="flex flex-col" style={{ gap: "var(--sp-6)" }}>
-      <StepHeading title={COPY.kickoff.inviteePickerTitle} why={COPY.kickoff.inviteePickerWhy} />
+      <StepHeading
+        title={COPY.kickoff.inviteeReadyTitle}
+        why={
+          hasRepos
+            ? COPY.kickoff.inviteeReadyWithRepos(teamRepoUrls.map(repoLabel).join(", "))
+            : COPY.kickoff.inviteeReadyNoRepos
+        }
+      />
       <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
-        <TreeUrlDisplay treeUrl={treeUrl} />
-        {reposQuery.isLoading ? (
-          <p className="text-label" style={{ color: "var(--fg-4)" }}>
-            {COPY.kickoff.inviteePickerLoading}
-          </p>
-        ) : scopeMissing ? (
-          <FlowHint>
-            {COPY.kickoff.inviteePickerScopeMissing}{" "}
-            <a
-              href="/api/v1/auth/github/start?next=/onboarding"
-              className="font-medium"
-              style={{ color: "var(--primary)" }}
-            >
-              {COPY.connectCode.reconnect}
-            </a>
-          </FlowHint>
-        ) : networkErr ? (
-          <FlowHint tone="error" role="alert">
-            {COPY.kickoff.inviteePickerNetworkError}
-          </FlowHint>
-        ) : empty ? (
-          <FlowHint>{COPY.kickoff.inviteePickerEmpty}</FlowHint>
-        ) : (
-          <RepoPicker repos={reposQuery.data ?? []} selected={selected} onToggle={toggle} fill />
-        )}
         {error && (
           <FlowHint tone="error" role="alert">
             {error}
           </FlowHint>
         )}
-        <div className="flex items-center" style={{ gap: "var(--sp-4)", flexWrap: "wrap" }}>
-          <Button
-            type="button"
-            variant="cta"
-            onClick={() => void handleStart(selected)}
-            disabled={!hasRepos || selected.length === 0}
-          >
+        <div className="flex">
+          <Button type="button" variant="cta" onClick={() => void handleStart()}>
             <span>{COPY.kickoff.startWorking}</span>
             <ArrowRight className="h-4 w-4" />
           </Button>
-          {/* Always visible — covers empty, scope-missing, network, AND
-              "I just don't want to pick one right now". No path is a
-              dead end. */}
-          <Button type="button" variant="link" className="h-auto p-0 text-label" onClick={() => void handleStart([])}>
-            {COPY.kickoff.inviteeContinueNoProject}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Shared body for the two "team isn't ready yet" sub-states: `waiting` (admin
+ * hasn't created the Context Tree) and `no-installation` (tree exists but no
+ * GitHub App is connected). Both are blocked on the admin and both poll +
+ * advance on their own the moment the admin finishes — so the only thing the
+ * invitee can DO here is not wait: meet their agent now.
+ *
+ * "Meet your agent" runs the same intro-only kickoff as the confirm/picker
+ * "Continue without a repo" bailout (`runKickoff` with no repo → an agent that
+ * introduces itself, repos connectable later from Settings). Routing it through
+ * `completeAndEnterChat` — not `finishLater` — means the button lands the user
+ * in a real chat WITH the agent everywhere it appears, instead of dropping them
+ * into an empty workspace. The two states differ only in copy, so they share
+ * this body; split them again if their actions ever diverge.
+ */
+function InviteeBlocked({ title, why, status }: { title: string; why: string; status: string }) {
+  const { completeAndEnterChat } = useOnboardingFlow();
+  const [phase, setPhase] = useState<"idle" | "starting">("idle");
+  const [error, setError] = useState<string | null>(null);
+
+  const handleMeet = async (): Promise<void> => {
+    setError(null);
+    setPhase("starting");
+    try {
+      await runKickoff({
+        bootstrap: NO_REPO_BOOTSTRAP,
+        gitRepoUrls: [],
+        orgWrites: null, // never mutate team config as an invitee
+        treeMode: "existing",
+        joinPath: "invite",
+        complete: completeAndEnterChat,
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : COPY.errors.chatFailed);
+      setPhase("idle");
+    }
+  };
+
+  if (phase === "starting") return <StartingState />;
+
+  return (
+    <div className="flex flex-col" style={{ gap: "var(--sp-6)" }}>
+      {/* Heading carries the screen; the pulsing StatusRow is the "still
+          watching, will advance on its own" signal. */}
+      <StepHeading title={title} why={why} />
+      <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
+        <StatusRow state="waiting" label={status} />
+        {error && (
+          <FlowHint tone="error" role="alert">
+            {error}
+          </FlowHint>
+        )}
+        <div className="flex">
+          <Button type="button" variant="outline" onClick={() => void handleMeet()}>
+            {COPY.invitee.startAnyway}
           </Button>
         </div>
       </div>
@@ -582,73 +468,22 @@ function InviteePicker({ treeUrl }: { treeUrl: string }) {
 }
 
 function InviteeWaiting() {
-  const { finishLater } = useOnboardingFlow();
   return (
-    <div className="flex flex-col" style={{ gap: "var(--sp-6)" }}>
-      {/* The heading (title + why) carries this blocked screen; the body text
-          moved into the why so it's properly weighted, not a lone light line.
-          The pulsing StatusRow carries the "still alive / watching" signal. */}
-      <StepHeading title={COPY.invitee.waitingTitle} why={COPY.invitee.waitingBody} />
-      <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
-        {/* Visible polling so the user trusts the page is alive — the
-            previous "no status" state had users wondering if it was
-            stuck. */}
-        <StatusRow state="waiting" label={COPY.invitee.waitingStatus} />
-        <div className="flex">
-          <Button type="button" variant="outline" onClick={() => void finishLater()}>
-            {COPY.invitee.startAnyway}
-          </Button>
-        </div>
-      </div>
-    </div>
+    <InviteeBlocked
+      title={COPY.invitee.waitingTitle}
+      why={COPY.invitee.waitingBody}
+      status={COPY.invitee.waitingStatus}
+    />
   );
 }
 
-/**
- * NEW sub-state: admin set a tree URL but never connected the GitHub App,
- * so the org has no installation row. Without one, the agent's first git
- * operation will 403 with no useful signal. We surface that here and offer
- * a "remind your admin" copy-link + a bailout to keep the user moving.
- *
- * Why this link IS safe to share (unlike connect-code's install URL): we
- * copy `window.location.href`, the onboarding page URL itself, with no
- * cookie-bound state JWT. Whoever opens it just lands on first-tree as
- * themselves; if they're the admin, they see their own onboarding /
- * Settings → GitHub and can finish the install. It's a reminder URL, not
- * an authorization handoff.
- */
 function InviteeNoInstallation() {
-  const { finishLater } = useOnboardingFlow();
-  const [pageUrl, setPageUrl] = useState<string>("");
-
-  useEffect(() => {
-    if (typeof window !== "undefined") setPageUrl(window.location.href);
-  }, []);
-
   return (
-    <div className="flex flex-col" style={{ gap: "var(--sp-6)" }}>
-      {/* Heading (title + why) carries the screen; the body moved into the why.
-          Pulse = liveness; the share-link block below is the real action. */}
-      <StepHeading title={COPY.invitee.noInstallTitle} why={COPY.invitee.noInstallBody} />
-      <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
-        <StatusRow state="waiting" label={COPY.invitee.noInstallStatus} />
-
-        <div className="flex flex-col" style={{ gap: "var(--sp-2)" }}>
-          <p className="text-label" style={{ margin: 0, color: "var(--fg-2)" }}>
-            {COPY.invitee.noInstallShareIntro}
-          </p>
-          {/* Reuses the connect-computer CommandBox so the copy affordance is
-              identical everywhere; here the "command" is the shareable page URL. */}
-          <CommandBox command={pageUrl || null} placeholder="…" />
-        </div>
-
-        <div className="flex">
-          <Button type="button" variant="outline" onClick={() => void finishLater()}>
-            {COPY.invitee.startAnyway}
-          </Button>
-        </div>
-      </div>
-    </div>
+    <InviteeBlocked
+      title={COPY.invitee.noInstallTitle}
+      why={COPY.invitee.noInstallBody}
+      status={COPY.invitee.noInstallStatus}
+    />
   );
 }
 

--- a/packages/web/src/pages/onboarding/steps/step-kickoff.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-kickoff.tsx
@@ -261,10 +261,10 @@ function AdminKickoff() {
 
 function InviteeKickoff() {
   const { organizationId } = useOnboardingFlow();
-  // Fetch tree config, source repos, and installation existence together.
-  // The installation bit drives the new "no-installation" sub-state, which
-  // catches "admin set up the tree but never connected GitHub" before the
-  // invitee sails into the picker and hits a 403 on the first git op.
+  // Fetch tree config, team repos, and installation existence together.
+  // The installation bit drives the "no-installation" sub-state, which catches
+  // "admin set up the tree but never connected GitHub" before the invitee
+  // launches and the agent hits a 403 on its first git op.
   //
   // We use the dedicated /github-app-installation/exists endpoint here
   // (returns `{ exists: boolean }`, member-readable) rather than the full
@@ -415,13 +415,12 @@ function InviteeReady({ treeUrl, teamRepoUrls }: { treeUrl: string; teamRepoUrls
  * advance on their own the moment the admin finishes — so the only thing the
  * invitee can DO here is not wait: meet their agent now.
  *
- * "Meet your agent" runs the same intro-only kickoff as the confirm/picker
- * "Continue without a repo" bailout (`runKickoff` with no repo → an agent that
- * introduces itself, repos connectable later from Settings). Routing it through
- * `completeAndEnterChat` — not `finishLater` — means the button lands the user
- * in a real chat WITH the agent everywhere it appears, instead of dropping them
- * into an empty workspace. The two states differ only in copy, so they share
- * this body; split them again if their actions ever diverge.
+ * "Meet your agent" runs an intro-only kickoff (`runKickoff` with no repo → an
+ * agent that introduces itself, repos connectable later from Settings), the same
+ * launch the `ready` state uses. Routing it through `completeAndEnterChat` — not
+ * `finishLater` — means the button lands the user in a real chat WITH the agent,
+ * instead of dropping them into an empty workspace. The two states differ only
+ * in copy, so they share this body; split them again if their actions diverge.
  */
 function InviteeBlocked({ title, why, status }: { title: string; why: string; status: string }) {
   const { completeAndEnterChat } = useOnboardingFlow();

--- a/packages/web/src/pages/onboarding/steps/step-welcome.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-welcome.tsx
@@ -18,7 +18,7 @@ export function StepWelcome() {
         <span className="font-semibold" style={{ color: "var(--fg)" }}>
           {teamDisplayName ?? "your team"}
         </span>
-        . It's all set up — you just need your own agent.
+        . To get started, let's create your own agent.
       </p>
       <div className="flex">
         <Button type="button" onClick={goNext}>

--- a/packages/web/src/pages/workspace/center/onboarding/__tests__/bootstrap-prose.test.ts
+++ b/packages/web/src/pages/workspace/center/onboarding/__tests__/bootstrap-prose.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { buildBindBootstrap, buildCreateBootstrap, FIRST_TREE_REFERENCE_URL } from "../bootstrap-prose.js";
+import {
+  buildBindBootstrap,
+  buildCreateBootstrap,
+  buildInviteeBootstrap,
+  FIRST_TREE_REFERENCE_URL,
+} from "../bootstrap-prose.js";
 
 describe("kickoff bootstrap prose", () => {
   it("builds singular existing-tree instructions", () => {
@@ -72,5 +77,20 @@ describe("kickoff bootstrap prose", () => {
     expect(message).not.toContain("record its URL");
     // Cloud names + creates the repo, so the agent is never asked which owner.
     expect(message).not.toContain("ask me which owner");
+  });
+
+  it("builds a joining-teammate invitee message (orient + introduce, not tree writes)", () => {
+    const message = buildInviteeBootstrap("https://github.com/acme/context");
+
+    expect(message).toContain("just joined the team");
+    expect(message).toContain("Team Context Tree: https://github.com/acme/context");
+    expect(message).toContain("Read the tree first to get oriented");
+    expect(message).toContain("introduce yourself");
+    expect(message).toContain(FIRST_TREE_REFERENCE_URL);
+    // A brand-new teammate is NOT asked to write to the tree or seed it, and the
+    // admin's "my repos are now connected" voice must not leak in.
+    expect(message).not.toContain("first-tree-seed");
+    expect(message).not.toContain("reflect them into the tree");
+    expect(message).not.toContain("are now connected");
   });
 });

--- a/packages/web/src/pages/workspace/center/onboarding/bootstrap-prose.ts
+++ b/packages/web/src/pages/workspace/center/onboarding/bootstrap-prose.ts
@@ -15,12 +15,13 @@
  * session resolves the binding. That precondition is what lets the prose name
  * skills directly instead of asking the agent to self-provision.
  *
- * Two paths:
+ * Three paths:
  *   - existing tree (buildBindBootstrap): the team's tree already exists and is
  *     populated, and the binding (workspace.json) is written automatically by
  *     the runtime — so the agent is NOT asked to bind or open a PR back to the
  *     source. `first-tree-seed` does not apply to a populated tree; the agent
- *     reads the tree and uses `first-tree-context` for any further writes.
+ *     reads the tree and uses `first-tree-context` for any further writes. Sent
+ *     for the admin who just connected repos to an already-existing team tree.
  *   - new tree (buildCreateBootstrap): Cloud has already created the empty tree
  *     repo, written `context_tree`, and (on this session) the runtime writes
  *     `workspace.json`, so the new-tree self-check preconditions for
@@ -28,6 +29,12 @@
  *     asks the agent to seed the already-bound, still-empty tree with real
  *     content drawn from the source repos — it no longer asks the agent to
  *     create the GitHub repo or record its URL (Cloud owns both).
+ *   - invitee joining a set-up team (buildInviteeBootstrap): the team's tree and
+ *     repos already exist and the agent inherits them automatically (recommended
+ *     team resources), so the invitee never connected anything. The prose is in a
+ *     joining-teammate voice — get oriented by reading the tree, then introduce
+ *     yourself — NOT the admin's "my repos are now connected, reflect them into
+ *     the tree" (a brand-new teammate shouldn't open with tree writes).
  *
  * Single source of truth: only the kickoff step sends these. If a future surface
  * needs the same prompts, hoist these builders to `packages/shared`.
@@ -83,6 +90,26 @@ export function buildCreateBootstrap(sourceUrls: readonly string[]): string {
     skillLine,
     "",
     walkthrough,
+    "",
+    `Reference: ${FIRST_TREE_REFERENCE_URL}`,
+  ].join("\n");
+}
+
+/**
+ * Invitee joining a team that's already set up. The agent already inherits the
+ * team's repos + Context Tree (recommended team resources + the runtime's
+ * workspace.json), so the invitee never connected anything and is NOT asked to
+ * reflect decisions into the tree on its first message. Instead: read the tree
+ * to get oriented, then introduce yourself — the right tone for a brand-new
+ * teammate's first hello.
+ */
+export function buildInviteeBootstrap(treeUrl: string): string {
+  return [
+    "I've just joined the team and you're my agent. The team already has its repos connected and a shared Context Tree.",
+    "",
+    `Team Context Tree: ${treeUrl}`,
+    "",
+    "Read the tree first to get oriented — start at its root NODE.md — so you understand how the team works and what it's building. Then introduce yourself to me: what can you help with, and what's a good first thing for us to try?",
     "",
     `Reference: ${FIRST_TREE_REFERENCE_URL}`,
   ].join("\n");


### PR DESCRIPTION
## What

Redesign the onboarding **kickoff** finale into one unified "launch" moment, consistent with the welcome/team opening bookends, and tighten the surrounding repo-connect step.

**Admin**
- Delete the new/existing Context Tree fork (URL input + links). A team's tree is always one we provision; a pre-existing tree (re-run / 2nd admin / CLI-bound) is detected silently and switches the agent's first task to "read" instead of "seed" — no user choice.
- Lead the heading with the agent + outcome, not a Context-Tree gloss. CTA: "Build tree & start".
- No-repo finale: an honest "meet your agent" + a quiet "connect a repo" link back to connect-code; the title no longer duplicates the CTA.

**Invitee**
- Merge the confirm/picker repo-selection screens into a single "ready" launch. The agent already inherits the team's `recommended` repo resources automatically, so there was nothing to pick (the old selection only flavoured the message). `resolveInviteeKickoffState` → waiting / no-installation / ready.
- Send a joining-teammate bootstrap (`buildInviteeBootstrap`: read the tree to get oriented, then introduce yourself) instead of the admin's "reflect these repos into the tree" voice.
- The waiting / no-installation bailouts now enter a real chat instead of dropping to an empty workspace.

**connect-code**
- "Friction, not a block" when 0 repos are picked: a consequence line + a quiet underlined "continue without a repo" link (never the strong primary, never disabled). The strong "Continue" is reserved for when a repo is selected.
- "Start over" moves inline with the "Waiting for GitHub…" status and reads "Didn't work? Start over".

**Errors**
- Map provisioning failure codes (personal-account / missing-permissions / no-installation / repo-unavailable / …) to plain language with a way forward, instead of leaking the raw server string. `ApiError` carries the server `code`; `kickoffErrorMessage` does the mapping.

**Layout**: the kickoff finale matches the welcome/team bookends (top-anchored, left-aligned). `FlowHint`'s icon is boxed to the text line-height so it lines up on single- and multi-line hints.

## Context Tree

This changes a durable onboarding contract (invitee kickoff goes from four confirm/picker states to three `waiting / no-installation / ready`; admin always provisions, no manual tree-URL entry). The matching Context Tree update is **agent-team-foundation/first-tree-context#473** — land it first / together so agents don't keep acting on the old four-state model.

## Reviews

Reviewed by **codex** (diff review, gate pass), **gandy-developer** (independent adversarial pass, code merge-ready), **codex-assistant**, and **yzw-assistant**. Between them they verified the 8 `provisionError` keys match real server codes, the dropped `gitRepoUrls` was a no-op on main, `finishLater` isn't orphaned, and invitee resource-inheritance holds at the resolver layer. CI green (lint/type/test/CodeQL/migrations). All code findings addressed.

**Outstanding gate (not a code issue):** codex-assistant + yzw-assistant require the Context Tree onboarding contract to be synced before this lands — that is first-tree-context#473 above (`tree verify` passes).

## Before merge

- **Context Tree #473** lands first / together (the gate above).
- **Invitee E2E (not test-coverable):** resource inheritance holds at the resolver layer, but the runtime clones repos with the **host machine's git credentials** (no org token injected — `client/runtime/git-mirror-manager.ts`; per-agent tokens retired in migration `0020`). So public team repos always clone; a private team repo the joining member can't personally access fails fast. The ready copy was softened to not name repos or claim guaranteed access, so it no longer over-promises — but one live invitee walkthrough is still worth a run.
- **Known narrow edge (left as-is by design):** if new-tree provisioning succeeds but a later step fails *and* the user reloads, the silent auto-detect treats the just-created empty tree as "existing" and reads it instead of seeding. The old "Create new instead" control was the escape hatch; it was intentionally removed. A same-session retry (no reload) self-heals.

Tests: full web suite green (typecheck + lint:tokens + biome + vitest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
