### PR TITLE
Fix silent backfill context ACK semantics

### DIFF
--- a/packages/server/src/__tests__/inbox-bind-recovery.test.ts
+++ b/packages/server/src/__tests__/inbox-bind-recovery.test.ts
@@ -1,7 +1,9 @@
 import { and, eq, inArray } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 import { inboxEntries } from "../db/schema/inbox-entries.js";
+import { createChat } from "../services/chat.js";
 import * as inboxService from "../services/inbox.js";
+import { sendMessage } from "../services/message.js";
 import { createTestAgent, useTestApp } from "./helpers.js";
 
 /**
@@ -51,8 +53,8 @@ describe("inbox bind-time recovery (resetDeliveredForInboxes)", () => {
     // the third as `pending`, and force-set one row to `acked` to confirm
     // the WHERE filter actually short-circuits on status. Filter to
     // notify=true so the silent fan-out row (from the @a3 message) doesn't
-    // skew the assertion — silent rows are bulk-acked by the trigger's
-    // bundling pass and are not part of the recovery contract.
+    // skew the assertion — silent rows are context-only and are not part of
+    // the bind-time notify recovery contract.
     const rows = await app.db
       .select({ id: inboxEntries.id, messageId: inboxEntries.messageId })
       .from(inboxEntries)
@@ -232,5 +234,94 @@ describe("inbox same-socket chat recovery", () => {
     expect(chat2Rows).toHaveLength(1);
     expect(chat2Rows[0]?.messageId).toBe(msg2Res.json().id);
     expect(chat2Rows[0]?.status).toBe("pending");
+  });
+
+  it("redelivers the same silent preceding context after chat-scoped recovery", async () => {
+    const app = getApp();
+    const uid = crypto.randomUUID().slice(0, 6);
+    const human = await createTestAgent(app, { type: "human", name: `recoverctx-h-${uid}` });
+    const observer = await createTestAgent(app, { type: "agent", name: `recoverctx-a-${uid}` });
+    const chat = await createChat(app.db, human.agent.uuid, {
+      type: "group",
+      participantIds: [observer.agent.uuid],
+    });
+
+    await sendMessage(
+      app.db,
+      chat.id,
+      human.agent.uuid,
+      { source: "api", format: "text", content: "first recovered context" },
+      { allowRecipientlessSend: true },
+    );
+    await sendMessage(
+      app.db,
+      chat.id,
+      human.agent.uuid,
+      { source: "api", format: "text", content: "second recovered context" },
+      { allowRecipientlessSend: true },
+    );
+    const trigger = await sendMessage(app.db, chat.id, human.agent.uuid, {
+      source: "api",
+      format: "text",
+      content: "please recover this",
+      metadata: { mentions: [observer.agent.uuid] },
+    });
+
+    const triggerEntryRows = await app.db
+      .select({ id: inboxEntries.id })
+      .from(inboxEntries)
+      .where(
+        and(
+          eq(inboxEntries.inboxId, observer.agent.inboxId),
+          eq(inboxEntries.messageId, trigger.message.id),
+          eq(inboxEntries.notify, true),
+        ),
+      );
+    const triggerEntry = triggerEntryRows[0];
+    if (!triggerEntry) throw new Error("expected trigger inbox row");
+
+    const staleTriggerTime = new Date(Date.now() - (inboxService.PRECEDING_CONTEXT_WINDOW_SECONDS + 60) * 1000);
+    const staleContextTime = new Date(staleTriggerTime.getTime() - 60 * 1000);
+    await app.db
+      .update(inboxEntries)
+      .set({ createdAt: staleContextTime })
+      .where(
+        and(
+          eq(inboxEntries.inboxId, observer.agent.inboxId),
+          eq(inboxEntries.chatId, chat.id),
+          eq(inboxEntries.notify, false),
+        ),
+      );
+    await app.db.update(inboxEntries).set({ createdAt: staleTriggerTime }).where(eq(inboxEntries.id, triggerEntry.id));
+
+    const claimed = await inboxService.claimAndBuildForPush(app.db, observer.agent.inboxId, trigger.message.id);
+    const firstDelivery = claimed[0];
+    if (!firstDelivery) throw new Error("expected first delivery");
+    const firstPreceding = firstDelivery.message.precedingMessages.map((p) => p.content);
+    expect(firstPreceding).toEqual(["first recovered context", "second recovered context"]);
+
+    const silentAfterClaim = await app.db
+      .select({ status: inboxEntries.status })
+      .from(inboxEntries)
+      .where(
+        and(
+          eq(inboxEntries.inboxId, observer.agent.inboxId),
+          eq(inboxEntries.chatId, chat.id),
+          eq(inboxEntries.notify, false),
+        ),
+      );
+    expect(silentAfterClaim.every((row) => row.status === "pending")).toBe(true);
+
+    const recovered = await inboxService.recoverUnackedForScope(app.db, {
+      inboxId: observer.agent.inboxId,
+      chatId: chat.id,
+    });
+    expect(recovered.resetEntryIds).toEqual([firstDelivery.id]);
+
+    const redelivered = await inboxService.claimBacklogForPushForChat(app.db, observer.agent.inboxId, chat.id, 10);
+    const secondDelivery = redelivered[0];
+    if (!secondDelivery) throw new Error("expected redelivery");
+    expect(secondDelivery.id).toBe(firstDelivery.id);
+    expect(secondDelivery.message.precedingMessages.map((p) => p.content)).toEqual(firstPreceding);
   });
 });

--- a/packages/server/src/__tests__/inbox-ws-push.test.ts
+++ b/packages/server/src/__tests__/inbox-ws-push.test.ts
@@ -66,6 +66,14 @@ describe("inbox WS data-plane claim helpers", () => {
     return { a2, chatId, messageIds, rows };
   }
 
+  async function loadSilentRows(app: FastifyInstance, inboxId: string, chatId: string) {
+    return app.db
+      .select({ id: inboxEntries.id, status: inboxEntries.status })
+      .from(inboxEntries)
+      .where(and(eq(inboxEntries.inboxId, inboxId), eq(inboxEntries.chatId, chatId), eq(inboxEntries.notify, false)))
+      .orderBy(asc(inboxEntries.id));
+  }
+
   it("claimAndBuildForPush atomically claims a pending entry and bundles it", async () => {
     const app = getApp();
     const { a2, messageId } = await seedDeliverable(app);
@@ -122,7 +130,7 @@ describe("inbox WS data-plane claim helpers", () => {
     ]);
   });
 
-  it("claimAndBuildForPush bundles silent context for a mention_only trigger", async () => {
+  it("claimAndBuildForPush bundles silent context, then ACK-through drains it", async () => {
     // Mirror the silent-inbox-context test but on the push path. This is the
     // riskiest piece of the refactor — `bundleDeliveryWithSilentContext` was
     // extracted from `pollInboxInner` to be shared, so a divergence between
@@ -197,20 +205,201 @@ describe("inbox WS data-plane claim helpers", () => {
       "third silent",
     ]);
 
-    // Same side effect as the poll path: silent rows bulk-acked so they don't
-    // re-attach to a future trigger.
-    const silentRemaining = await app.db
-      .select({ status: inboxEntries.status })
-      .from(inboxEntries)
-      .where(
-        and(
-          eq(inboxEntries.inboxId, observer.inboxId),
-          eq(inboxEntries.chatId, chat.id),
-          eq(inboxEntries.notify, false),
-        ),
+    // Bundling is not consumption: same-socket recovery can still rebuild
+    // the preceding block until the notify trigger is ACKed.
+    const silentBeforeAck = await loadSilentRows(app, observer.inboxId, chat.id);
+    expect(silentBeforeAck.length).toBeGreaterThan(0);
+    expect(silentBeforeAck.every((r) => r.status === "pending")).toBe(true);
+
+    const acked = await inboxService.ackEntryByIdForBoundAgents(app.db, entry.id, [observer.inboxId]);
+    expect(acked.ok).toBe(true);
+    if (!acked.ok) throw new Error("ack-through unexpectedly rejected");
+    expect(acked.ackedCount).toBe(1);
+    expect(acked.ackedEntryIds).toEqual([entry.id]);
+
+    const silentAfterAck = await loadSilentRows(app, observer.inboxId, chat.id);
+    expect(silentAfterAck.every((r) => r.status === "acked")).toBe(true);
+  });
+
+  it("ack-through drains silent rows only in the same inbox/chat up to the notify cursor", async () => {
+    const app = getApp();
+    const uid = crypto.randomUUID().slice(0, 6);
+    const human = await createTestAgent(app, { type: "human", name: `scope-h-${uid}` });
+    const observer = await createTestAgent(app, { type: "agent", name: `scope-obs-${uid}` });
+    const peer = await createTestAgent(app, { type: "agent", name: `scope-peer-${uid}` });
+
+    const chat1 = await createChat(app.db, human.agent.uuid, {
+      type: "group",
+      participantIds: [observer.agent.uuid, peer.agent.uuid],
+    });
+    const chat2 = await createChat(app.db, human.agent.uuid, {
+      type: "group",
+      participantIds: [observer.agent.uuid, peer.agent.uuid],
+    });
+
+    await sendMessage(
+      app.db,
+      chat1.id,
+      human.agent.uuid,
+      { source: "api", format: "text", content: "old chat1 context" },
+      { allowRecipientlessSend: true },
+    );
+    await sendMessage(
+      app.db,
+      chat2.id,
+      human.agent.uuid,
+      { source: "api", format: "text", content: "old chat2 context" },
+      { allowRecipientlessSend: true },
+    );
+    const trigger = await sendMessage(app.db, chat1.id, human.agent.uuid, {
+      source: "api",
+      format: "text",
+      content: "observer trigger",
+      metadata: { mentions: [observer.agent.uuid] },
+    });
+
+    const claimed = await inboxService.claimAndBuildForPush(app.db, observer.agent.inboxId, trigger.message.id);
+    const entry = claimed[0];
+    if (!entry) throw new Error("expected trigger claim");
+
+    await sendMessage(
+      app.db,
+      chat1.id,
+      human.agent.uuid,
+      { source: "api", format: "text", content: "later chat1 context" },
+      { allowRecipientlessSend: true },
+    );
+
+    const accepted = await inboxService.ackEntryByIdForBoundAgents(app.db, entry.id, [observer.agent.inboxId]);
+    expect(accepted.ok).toBe(true);
+    if (!accepted.ok) throw new Error("ack-through unexpectedly rejected");
+    expect(accepted.ackedEntryIds).toEqual([entry.id]);
+
+    const observerChat1 = await loadSilentRows(app, observer.agent.inboxId, chat1.id);
+    expect(observerChat1.some((row) => row.id < entry.id && row.status === "acked")).toBe(true);
+    expect(observerChat1.some((row) => row.id > entry.id && row.status === "pending")).toBe(true);
+
+    const observerChat2 = await loadSilentRows(app, observer.agent.inboxId, chat2.id);
+    expect(observerChat2.length).toBeGreaterThan(0);
+    expect(observerChat2.every((row) => row.status === "pending")).toBe(true);
+
+    const peerChat1 = await loadSilentRows(app, peer.agent.inboxId, chat1.id);
+    expect(peerChat1.length).toBeGreaterThan(0);
+    expect(peerChat1.every((row) => row.status === "pending")).toBe(true);
+  });
+
+  it("does not reuse silent context that belongs before an earlier unacked notify trigger", async () => {
+    const app = getApp();
+    const uid = crypto.randomUUID().slice(0, 6);
+    const human = await createTestAgent(app, { type: "human", name: `part-h-${uid}` });
+    const observer = await createTestAgent(app, { type: "agent", name: `part-obs-${uid}` });
+    const chat = await createChat(app.db, human.agent.uuid, {
+      type: "group",
+      participantIds: [observer.agent.uuid],
+    });
+
+    await sendMessage(
+      app.db,
+      chat.id,
+      human.agent.uuid,
+      { source: "api", format: "text", content: "before first trigger" },
+      { allowRecipientlessSend: true },
+    );
+    await sendMessage(app.db, chat.id, human.agent.uuid, {
+      source: "api",
+      format: "text",
+      content: "first trigger",
+      metadata: { mentions: [observer.agent.uuid] },
+    });
+
+    const firstClaim = await inboxService.claimBacklogForPush(app.db, observer.agent.inboxId, 1);
+    const firstDelivery = firstClaim[0];
+    if (!firstDelivery) throw new Error("expected first delivery");
+    expect(firstDelivery.message.precedingMessages.map((p) => p.content)).toEqual(["before first trigger"]);
+
+    await sendMessage(
+      app.db,
+      chat.id,
+      human.agent.uuid,
+      { source: "api", format: "text", content: "between triggers" },
+      { allowRecipientlessSend: true },
+    );
+    await sendMessage(app.db, chat.id, human.agent.uuid, {
+      source: "api",
+      format: "text",
+      content: "second trigger",
+      metadata: { mentions: [observer.agent.uuid] },
+    });
+
+    const secondClaim = await inboxService.claimBacklogForPush(app.db, observer.agent.inboxId, 1);
+    const secondDelivery = secondClaim[0];
+    if (!secondDelivery) throw new Error("expected second delivery");
+    expect(secondDelivery.message.precedingMessages.map((p) => p.content)).toEqual(["between triggers"]);
+
+    const accepted = await inboxService.ackEntryByIdForBoundAgents(app.db, secondDelivery.id, [observer.agent.inboxId]);
+    expect(accepted.ok).toBe(true);
+    if (!accepted.ok) throw new Error("ack-through unexpectedly rejected");
+    expect(accepted.ackedEntryIds).toEqual([firstDelivery.id, secondDelivery.id]);
+
+    const afterAck = await loadSilentRows(app, observer.agent.inboxId, chat.id);
+    expect(afterAck.map((row) => row.status)).toEqual(["acked", "acked"]);
+  });
+
+  it("ack-through drains silent rows excluded from preceding context by cap or trigger-relative window", async () => {
+    const app = getApp();
+    const uid = crypto.randomUUID().slice(0, 6);
+    const human = await createTestAgent(app, { type: "human", name: `cap-h-${uid}` });
+    const observer = await createTestAgent(app, { type: "agent", name: `cap-obs-${uid}` });
+    const chat = await createChat(app.db, human.agent.uuid, {
+      type: "group",
+      participantIds: [observer.agent.uuid],
+    });
+
+    const total = inboxService.PRECEDING_CONTEXT_MAX_ENTRIES + 2;
+    for (let i = 0; i < total; i++) {
+      await sendMessage(
+        app.db,
+        chat.id,
+        human.agent.uuid,
+        { source: "api", format: "text", content: `silent-${i}` },
+        { allowRecipientlessSend: true },
       );
-    expect(silentRemaining.length).toBeGreaterThan(0);
-    expect(silentRemaining.every((r) => r.status === "acked")).toBe(true);
+    }
+
+    const silentRows = await loadSilentRows(app, observer.agent.inboxId, chat.id);
+    expect(silentRows).toHaveLength(total);
+    const oldExcluded = silentRows[0];
+    if (!oldExcluded) throw new Error("expected silent rows");
+    await app.db
+      .update(inboxEntries)
+      .set({ createdAt: new Date(Date.now() - (inboxService.PRECEDING_CONTEXT_WINDOW_SECONDS + 60) * 1000) })
+      .where(eq(inboxEntries.id, oldExcluded.id));
+
+    const trigger = await sendMessage(app.db, chat.id, human.agent.uuid, {
+      source: "api",
+      format: "text",
+      content: "cap trigger",
+      metadata: { mentions: [observer.agent.uuid] },
+    });
+
+    const claimed = await inboxService.claimAndBuildForPush(app.db, observer.agent.inboxId, trigger.message.id);
+    const entry = claimed[0];
+    if (!entry) throw new Error("expected trigger claim");
+    expect(entry.message.precedingMessages).toHaveLength(inboxService.PRECEDING_CONTEXT_MAX_ENTRIES);
+    const precedingContents = entry.message.precedingMessages.map((p) => p.content);
+    expect(precedingContents).not.toContain("silent-0");
+    expect(precedingContents).not.toContain("silent-1");
+    expect(precedingContents).toContain(`silent-${total - 1}`);
+
+    const accepted = await inboxService.ackEntryByIdForBoundAgents(app.db, entry.id, [observer.agent.inboxId]);
+    expect(accepted.ok).toBe(true);
+    if (!accepted.ok) throw new Error("ack-through unexpectedly rejected");
+    expect(accepted.ackedCount).toBe(1);
+    expect(accepted.ackedEntryIds).toEqual([entry.id]);
+
+    const afterAck = await loadSilentRows(app, observer.agent.inboxId, chat.id);
+    expect(afterAck).toHaveLength(total);
+    expect(afterAck.every((row) => row.status === "acked")).toBe(true);
   });
 
   it("claimBacklogForPush drains pending entries oldest-first up to the limit", async () => {

--- a/packages/server/src/services/inbox.ts
+++ b/packages/server/src/services/inbox.ts
@@ -37,8 +37,8 @@ type WideTxLike = PgDatabase<PgQueryResultHKT, any, any>;
  * Caps for the silent-context replay attached to an active delivery (proposal
  * §1). The window keeps stale chatter out of the prompt; the cap protects
  * against runaway batches if a chat is very chatty between two mentions of
- * the same agent. Older / overflow silent rows are still bulk-acked so they
- * don't accumulate forever.
+ * the same agent. Older / overflow silent rows are excluded from the prompt
+ * window but drained later when ACK-through commits the notify delivery.
  *
  * Exported (test-only) so the cap-overflow test doesn't have to spam 50+
  * silent messages — it pins the invariant by reading the constant.
@@ -170,7 +170,7 @@ async function pollInboxInner(db: Database, inboxId: string, limit: number, chat
  *
  * Steps:
  *   1. Sort by `createdAt` ASC (PG `RETURNING` does not guarantee order).
- *   2. For each trigger, collect silent context & bulk-ack stale silent rows.
+ *   2. For each trigger, collect silent context without consuming silent rows.
  *   3. Fetch the trigger messages.
  *   4. Build wire payloads via the single dispatcher.
  *
@@ -354,10 +354,10 @@ export async function claimBacklogForPushForChat(
  * of time) and this trigger, capped by `PRECEDING_CONTEXT_MAX_ENTRIES` and
  * `PRECEDING_CONTEXT_WINDOW_SECONDS`. Returned messages are oldest-first.
  *
- * Side effect: bulk-ack ALL silent pending rows in each chat with
- * createdAt < latest_trigger.createdAt — including ones that fell outside
- * the window/cap. Otherwise stale silent rows would accumulate and re-load
- * on every poll.
+ * This function intentionally does not ACK silent rows. Bundling is not
+ * consumption: recovery must be able to reset the notify trigger and rebuild
+ * the same trigger-relative context window. Silent rows are drained only when
+ * the client ACKs the consumed notify entry.
  */
 async function collectPrecedingContext(
   tx: TxLike,
@@ -378,16 +378,33 @@ async function collectPrecedingContext(
   for (const [chatId, chatTriggers] of byChat) {
     chatTriggers.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime() || a.id - b.id);
 
+    const firstTrigger = chatTriggers[0];
+    if (!firstTrigger) continue;
+    const [previousNotify] = await tx
+      .select({ id: inboxEntries.id })
+      .from(inboxEntries)
+      .where(
+        and(
+          eq(inboxEntries.inboxId, inboxId),
+          eq(inboxEntries.chatId, chatId),
+          eq(inboxEntries.notify, true),
+          lt(inboxEntries.id, firstTrigger.id),
+        ),
+      )
+      .orderBy(desc(inboxEntries.id))
+      .limit(1);
+
     // For each trigger, fetch silent context strictly before it (and after
-    // the previous trigger in this batch). Window: 24h before the trigger.
+    // the previous notify trigger cursor, even if that trigger was delivered
+    // in an earlier unacked batch). Window: 24h before the trigger.
     //
     // Order matters: when there are MORE than `PRECEDING_CONTEXT_MAX_ENTRIES`
     // candidates, we want to keep the rows CLOSEST to the trigger (most
     // contextually relevant) and drop the oldest. So select DESC + LIMIT,
     // then reverse in JS to get chronological prompt-ready output. Selecting
-    // ASC + LIMIT would drop the recent rows — and the bulk-ack below would
-    // mark them acked anyway, so the agent would silently lose the messages
-    // that mattered most.
+    // ASC + LIMIT would drop the recent rows; ACK-through later drains every
+    // silent row behind the consumed notify cursor, including rows excluded by
+    // this cap, so this delivery must choose the most relevant window now.
     //
     // We sort by `messages.createdAt` rather than `inboxEntries.createdAt`
     // because `addParticipant`'s backfill writes 50 inbox rows in one
@@ -403,8 +420,9 @@ async function collectPrecedingContext(
     // (T2 > T1) would both include silent rows < T1 in their preceding
     // context. With SKIP LOCKED, the second poll skips the rows the first
     // has reserved.
-    let prevCreatedAt: Date | null = null;
+    let previousNotifyId: number | null = previousNotify?.id ?? null;
     for (const trigger of chatTriggers) {
+      const windowStart = new Date(trigger.createdAt.getTime() - PRECEDING_CONTEXT_WINDOW_SECONDS * 1000);
       const rows = await tx
         .select({
           messageId: messages.id,
@@ -422,9 +440,9 @@ async function collectPrecedingContext(
             eq(inboxEntries.chatId, chatId),
             eq(inboxEntries.status, "pending"),
             eq(inboxEntries.notify, false),
-            lt(inboxEntries.createdAt, trigger.createdAt),
-            prevCreatedAt === null ? undefined : gt(inboxEntries.createdAt, prevCreatedAt),
-            sql`${inboxEntries.createdAt} > NOW() - make_interval(secs => ${PRECEDING_CONTEXT_WINDOW_SECONDS})`,
+            lt(inboxEntries.id, trigger.id),
+            previousNotifyId === null ? undefined : gt(inboxEntries.id, previousNotifyId),
+            gt(inboxEntries.createdAt, windowStart),
           ),
         )
         .orderBy(desc(messages.createdAt))
@@ -443,27 +461,7 @@ async function collectPrecedingContext(
         }))
         .reverse();
       result.set(trigger.id, preceding);
-      prevCreatedAt = trigger.createdAt;
-    }
-
-    // Bulk-ack ALL silent pending rows in this chat strictly before the
-    // latest trigger — covers both "included in preceding" and "dropped due
-    // to cap/window". Without this the cap-overflow rows would re-attach to
-    // the next trigger and grow forever.
-    const latestTrigger = chatTriggers[chatTriggers.length - 1];
-    if (latestTrigger) {
-      await tx
-        .update(inboxEntries)
-        .set({ status: "acked", ackedAt: new Date() })
-        .where(
-          and(
-            eq(inboxEntries.inboxId, inboxId),
-            eq(inboxEntries.chatId, chatId),
-            eq(inboxEntries.status, "pending"),
-            eq(inboxEntries.notify, false),
-            lt(inboxEntries.createdAt, latestTrigger.createdAt),
-          ),
-        );
+      previousNotifyId = trigger.id;
     }
   }
 
@@ -520,7 +518,24 @@ export async function ackThroughEntryIdForBoundAgents(
       }
 
       const deliveredIds = prefixRows.filter((row) => row.status === "delivered").map((row) => row.id);
+      const ackedAt = new Date();
+      const drainPendingSilentRows = async (): Promise<void> => {
+        await tx
+          .update(inboxEntries)
+          .set({ status: "acked", ackedAt })
+          .where(
+            and(
+              eq(inboxEntries.inboxId, entry.inboxId),
+              chatPredicate,
+              eq(inboxEntries.status, "pending"),
+              eq(inboxEntries.notify, false),
+              sql`${inboxEntries.id} <= ${entryId}`,
+            ),
+          );
+      };
+
       if (deliveredIds.length === 0) {
+        await drainPendingSilentRows();
         return {
           ok: true,
           throughEntry: entry,
@@ -532,9 +547,10 @@ export async function ackThroughEntryIdForBoundAgents(
 
       const updated = await tx
         .update(inboxEntries)
-        .set({ status: "acked", ackedAt: new Date() })
+        .set({ status: "acked", ackedAt })
         .where(and(inArray(inboxEntries.id, deliveredIds), eq(inboxEntries.status, "delivered")))
         .returning();
+      await drainPendingSilentRows();
       const updatedThroughEntry = updated.find((row) => row.id === entryId) ?? entry;
       return {
         ok: true,
@@ -619,8 +635,7 @@ export const SILENT_ROW_GC_MAX_AGE_SECONDS = 30 * 24 * 60 * 60;
  * Two cleanup paths:
  *
  *   1. `notify=false AND status='acked'` of any age — these are fully
- *      consumed (either bundled into a previous trigger or aged out via the
- *      bulk-ack in `collectPrecedingContext`); keep them only as long as
+ *      consumed by ACK-through after a notify trigger commits); keep them only as long as
  *      the corresponding message rows we link to. The unique constraint
  *      `(inbox_id, message_id, chat_id)` means leaving them around blocks
  *      legitimate retries with the same key.


### PR DESCRIPTION
## Summary

- Keep silent inbox rows pending when they are bundled as `precedingMessages`, so chat-scoped recovery can rebuild the same context before the notify turn is ACKed.
- Drain scoped pending silent rows during notify ACK-through for the same inbox/chat up to the acknowledged delivery cursor.
- Partition silent context by the previous notify cursor across delivery batches, preventing a later unacked trigger from reusing silent context that belonged to an earlier trigger.

## Context

- Fixes #939.
- Durable Context Tree update landed first in agent-team-foundation/first-tree-context#472.

## Validation

- `pnpm --filter @first-tree/server exec vitest run --maxWorkers=2 inbox-ws-push`
- `pnpm --filter @first-tree/server exec vitest run --maxWorkers=2 inbox-bind-recovery`
- `pnpm check`
- `pnpm typecheck`