### PR TITLE
release: bump apps/cli to v0.5.4

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "first-tree-dev",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "type": "module",
   "description": "First Tree — unified CLI for Context Tree onboarding, agent management, and team messaging. (Source-tree dev build; CI rewrites `name` and `bin` for prod / staging publishes — see docs/local-dev-isolation.md.)",
   "keywords": [


### PR DESCRIPTION
## Summary

- Bumps `apps/cli/package.json` from `0.5.3` to `0.5.4`.
- Leaves the source package identity as `first-tree-dev`; CI will rewrite the package name, binaries, and channel metadata only in the ephemeral publish workspace.
- Does not create a tag from this branch.

## Draft GitHub Release

Title: `v0.5.4 — W1 workspace, Context Tree bootstrap, onboarding polish`

Body:

```markdown
## Highlights

- Ships the W1 workspace-rooted Context Tree flow: `workspace.json`, `.first-tree-workspace` state, per-agent source repo clones, first-tree-seed, GitHub repo initialization, and W1-safe `tree verify`.
- Improves agent-team collaboration with explicit group-chat recipients, tracked human requests, channel-aware command text, clearer async handoffs, and unconditional First Tree / Context Tree reading rules in agent briefings.
- Refreshes onboarding and admin workspace UX across repo connection, Settings Resources, agent Capabilities / Instructions / Usage, Team, chat identity hovercards, and narrow viewport behavior.
- Adds the Claude Code TUI runtime path and improves agent runtime reliability around final responses, usage accounting, session mappings, source checkout fallback, and workspace cleanup retries.
- Aligns CLI upgrade behavior with the server-advertised target version and refreshes the auto-update target before install.

## Notable fixes

- Includes bundled skills and CLI README in the published npm tarball.
- Recovers inbox delivery and acknowledgement durability across suspend, redelivery, and delivered-prefix paths.
- Fixes WebSocket auth handshake classification, client presence close grace, and several onboarding access guards.
- Recovers document previews from message metadata when the snapshot cache is gone.
- Fixes web interaction issues around select options in modals, prompt editing, tab overflow, button text colors, and mention/request rendering.

## Compatibility notes

- Legacy GitHub Scan and pre-W1 Context Tree initialization paths are retired.
- Existing clients migrate workspace state forward through one-shot cleanup paths; no manual migration is expected for normal npm users.
```

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm check`
- `pnpm typecheck`

Notes:

- `pnpm check` passed with existing Biome info/warning output:
  - `packages/web/src/pages/agent-detail/prompt-tab.tsx`: unnecessary fragment info.
  - `packages/client/src/runtime/workspace-migrations.ts`: `void` union warning.
- `pnpm typecheck` passed. Web build emitted existing CSS/chunk-size warnings.

## Post-Merge Release Steps

After this PR is merged:

1. Confirm the merge commit SHA is on `origin/main`.
2. Wait for the `CI` workflow on `main` to pass; also check `npm Publish` and `Docker` runs for the same SHA if present.
3. Confirm `apps/cli/package.json` at the merge commit contains `0.5.4`.
4. Create GitHub Release `v0.5.4` targeting the merge commit, using the approved title and release notes.
5. Verify the tag-triggered `npm Publish` run publishes `first-tree@0.5.4` and skips staging/shared alpha publish jobs.
6. Verify `npm view first-tree version` reports `0.5.4` and the GitHub Release is visible.
