### PR TITLE
fix(web): invitee no-repo copy must not imply members can add team repos

### DIFF
--- a/packages/web/src/pages/onboarding/copy.ts
+++ b/packages/web/src/pages/onboarding/copy.ts
@@ -322,8 +322,10 @@ export const COPY = {
     // token is injected), so a joining member without access to a private team
     // repo can't reach it. "works with your team's repos" stays true regardless.
     inviteeReadyWithRepos: "Your team's all set up — your agent works with your team's repos and shared Context Tree.",
+    // No "add from Settings": connecting team repos is admin-only, and this is
+    // shown to a joining member, so it must not imply they can do it themselves.
     inviteeReadyNoRepos:
-      "Your team's all set up — your agent will start with a quick intro. Repos can be added anytime from Settings.",
+      "Your team's all set up — your agent will start with a quick intro. An admin can connect team repos anytime.",
     startWorking: "Start working",
 
     // shared launch transition


### PR DESCRIPTION
Follow-up to #943. The invitee `ready` launch's no-repo copy said "Repos can be added anytime from **Settings**", but adding team repos is **admin-only** (`settings/resources.tsx`: only admins see add/edit/retire). That line is shown to a joining member, so it implied something they can't do. Point at the admin instead: "An admin can connect team repos anytime."

One-line copy change. typecheck + lint:tokens + onboarding tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)