### PR TITLE
fix(web): don't eject onboarding users when their org gains a usable agent mid-flow

### DIFF
--- a/packages/web/src/pages/onboarding/__tests__/onboarding-page-dom.test.tsx
+++ b/packages/web/src/pages/onboarding/__tests__/onboarding-page-dom.test.tsx
@@ -130,6 +130,43 @@ describe("OnboardingPage", () => {
     expect(container.textContent).toContain("Workspace Home");
   });
 
+  it("does NOT eject a user whose org gains a usable agent mid-flow (created at create-agent)", async () => {
+    // Entry: actively onboarding, no usable agent yet → on the create-agent step.
+    authMock.value = { ...authMock.value, onboardingStep: "create_agent", currentOrgHasUsableAgent: false };
+    flowMock.activeStep = "create-agent";
+
+    // Fresh element each render so React actually reconciles on the flip
+    // (re-rendering the same element object bails out). OnboardingPage stays
+    // the same instance across renders, so its entry-time decision persists.
+    const renderTree = () => (
+      <MemoryRouter initialEntries={["/onboarding"]}>
+        <Routes>
+          <Route path="/" element={<div>Workspace Home</div>} />
+          <Route path="/onboarding" element={<OnboardingPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => root?.render(renderTree()));
+    await flush();
+    expect(container.textContent).toContain("Create Agent Step");
+
+    // Mid-flow: the just-created agent comes online → currentOrgHasUsableAgent
+    // flips true and the flow advances to connect-code. The route must NOT
+    // bounce to the workspace — connect-code + kickoff are still ahead of
+    // create-agent in the admin sequence. (Regression: the leave-gate used to
+    // re-evaluate every render and eject here.)
+    authMock.value = { ...authMock.value, onboardingStep: "completed", currentOrgHasUsableAgent: true };
+    flowMock.activeStep = "connect-code";
+    await act(async () => root?.render(renderTree()));
+    await flush();
+
+    expect(container.textContent).not.toContain("Workspace Home");
+    expect(container.textContent).toContain("Connect Code Step");
+  });
+
   it("renders every step from the active onboarding flow", async () => {
     const cases: Array<[step: string, label: string, role: string, path: string]> = [
       ["team", "Team Step", "admin", "admin"],

--- a/packages/web/src/pages/onboarding/onboarding-page.tsx
+++ b/packages/web/src/pages/onboarding/onboarding-page.tsx
@@ -1,3 +1,4 @@
+import { useRef } from "react";
 import { Navigate } from "react-router";
 import { useAuth } from "../../auth/auth-context.js";
 import { OnboardingFlowProvider, useOnboardingFlow } from "./onboarding-flow.js";
@@ -15,21 +16,33 @@ import { resolveOnboardingPath, shouldLeaveOnboarding } from "./steps.js";
  * the workspace chrome (no rail / top bar) so a brand-new user sees one
  * clear thing at a time. The workspace root (`/`) bounces incomplete users
  * here; once setup is terminally complete this route bounces back to `/`.
+ *
+ * The "bounce back" is an ENTRY-time guard, decided ONCE when `/me` first
+ * loads — not a live leash re-checked every render. Both admin and invitee
+ * have steps AFTER create-agent (admin: connect-code + kickoff; invitee:
+ * kickoff), and creating the agent flips `currentOrgHasUsableAgent` true (the
+ * flow's own `refreshMe` surfaces it the moment the agent comes online). A
+ * per-render check therefore ejected an actively-onboarding user the instant
+ * they made their agent, skipping those steps. Freezing the decision at entry
+ * lets them finish; they leave via the explicit `completeAndEnterChat`
+ * navigate at the end of kickoff (or `finishLater`).
  */
 export function OnboardingPage() {
   const { meLoaded, role, onboardingStep, onboardingDismissedAt, currentOrgHasUsableAgent } = useAuth();
+  const leaveDecision = useRef<boolean | null>(null);
 
   if (!meLoaded) {
     return <div className="min-h-screen bg-background" />;
   }
-  if (
-    shouldLeaveOnboarding({
+  if (leaveDecision.current === null) {
+    leaveDecision.current = shouldLeaveOnboarding({
       meLoaded,
       onboardingStep,
       onboardingDismissedAt,
       currentOrgReady: currentOrgHasUsableAgent,
-    })
-  ) {
+    });
+  }
+  if (leaveDecision.current) {
     return <Navigate to="/" replace />;
   }
 


### PR DESCRIPTION
## Problem

Going through `/onboarding`, the moment a user creates their agent (the **create-agent** step) they are bounced straight into the workspace — **skipping connect-code + kickoff** (admin) / **kickoff** (invitee). Found during a manual E2E of the kickoff redesign (#943); it is **pre-existing**, not introduced by that PR.

## Root cause

`OnboardingPage` re-evaluates `shouldLeaveOnboarding` **on every render**, and that returns true as soon as the org has a usable non-human agent (`currentOrgHasUsableAgent`, from `me.ts` / `listOrgsWithUsableNonHumanAgent` — active + org-visible, **no online requirement**). Creating the agent makes the org "ready", and the flow's own `onAgentOnline` → `refreshMe()` surfaces it immediately, so the route fires `<Navigate to="/">`.

Both paths have steps **after** create-agent (admin: `connect-code` + `kickoff`; invitee: `kickoff`), so they become unreachable via the forward flow. This also left `inferInitialStepIndex`'s "completed → resume at connect-code" branch effectively dead. It reproduces whenever a real runtime is connected (i.e. real users); pure-mock environments don't bring the agent online, which is likely why it slipped past prior reviews/sims.

## Fix

Decide the leave-bounce **once, at entry** (first `/me` load) via a ref, instead of re-checking every render. `shouldLeaveOnboarding` is an entry-time guard ("you landed here already done → go back"), not a live leash. An actively-onboarding user now finishes the flow and leaves via the explicit `completeAndEnterChat` navigate (or `finishLater`); a genuinely-done user who lands on `/onboarding` is still bounced.

`shouldLeaveOnboarding` itself is unchanged — it stays correct as the entry check, and **#732's per-org enter behavior is preserved**. (Deliberately did *not* switch the leave check to `onboardingCompletedAt`: that flag is account-level, so it would reintroduce the multi-org bug #732 fixed.)

## Tests

- New regression test in `onboarding-page-dom.test.tsx`: org gains a usable agent **mid-flow** → no eject, stays on connect-code (red before the fix, green after).
- Existing "terminally completed user landing on /onboarding → bounce" test still passes (entry-time guard intact).
- Full web suite green: **726/726**; typecheck + `lint:tokens` + biome clean.

## Known limitation (not addressed here)

A user who abandons mid-flow (already has an agent, never finished kickoff) and later re-opens `/onboarding` is still bounced rather than resumed at connect-code. Supporting resume-after-abandon needs a real **per-org completion** signal (server change) — out of scope for this minimal fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)