### PR TITLE
release: bump apps/cli to v0.5.5

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "first-tree-dev",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "type": "module",
   "description": "First Tree — unified CLI for Context Tree onboarding, agent management, and team messaging. (Source-tree dev build; CI rewrites `name` and `bin` for prod / staging publishes — see docs/local-dev-isolation.md.)",
   "keywords": [


### PR DESCRIPTION
## Summary

- Bumps `apps/cli/package.json` from `0.5.4` to `0.5.5` for the next stable release.
- Keeps the source package identity as `first-tree-dev`; CI will rewrite the publish workspace for the production `first-tree` package.
- Includes the post-`v0.5.4` onboarding redirect fix now merged on `main`.

## Draft GitHub Release

Title: `v0.5.5 — Onboarding redirect fix`

Body:

```markdown
## Notable fixes

- Fixes the onboarding flow so users are not bounced away when their organization gains a usable agent mid-flow; the leave-bounce decision is made at entry instead of on every render.
```

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm check`
  - Passed with existing Biome info/warning in `packages/web/src/pages/agent-detail/prompt-tab.tsx` and `packages/client/src/runtime/workspace-migrations.ts`.
- `pnpm typecheck`
  - Passed with existing web CSS/chunk-size warnings and tsdown dependency option warnings.

## Post-Merge Release Steps

1. Wait for CI on `main` to pass for the release bump merge commit.
2. Create GitHub Release `v0.5.5` targeting the release bump merge commit.
3. Let the tag-triggered `npm Publish` workflow publish `first-tree@0.5.5` with dist-tag `latest`.
4. Verify `npm view first-tree version` returns `0.5.5`.
