### PR TITLE
feat(web): refine agent detail header layout

### DIFF
--- a/packages/web/src/pages/agent-detail.tsx
+++ b/packages/web/src/pages/agent-detail.tsx
@@ -481,7 +481,7 @@ function AgentDetailPageView() {
 
   return (
     <div className="flex flex-col" style={{ minHeight: "calc(100vh - var(--sp-10))" }}>
-      <div style={{ padding: "var(--sp-4) 0 var(--sp-3)" }}>
+      <div style={{ padding: "var(--sp-4) 0 var(--sp-4)" }}>
         {/* Inner content sits in the same centered rail as the tabs + tab content,
             so the switcher and title row align with everything below. */}
         <div
@@ -496,14 +496,19 @@ function AgentDetailPageView() {
           {/* Agent switcher (vertical-B) replaces the breadcrumb: jump between agents
               (and back to Team) without losing the agent context. Leaving via it is
               leave-guarded. */}
-          <div style={{ marginBottom: "var(--sp-2)" }}>
+          {/* sp-3 gap to the title row: the switcher is demoted nav above the
+              page's primary identity, so it sits a touch apart rather than crowding
+              the title (part of the 16/12 top rhythm). */}
+          <div style={{ marginBottom: "var(--sp-3)" }}>
             <AgentSwitcherStrip currentAgent={agent} currentTabPath={currentTabPath} onNavigate={guardedNavigate} />
           </div>
           <div className="flex w-full items-center gap-2">
+            {/* Primary identity avatar — the largest on the page (switcher nav 28,
+                sticky context bar 20), so the title row clearly owns "which agent". */}
             <Avatar
               src={agent.avatarImageUrl}
               name={agent.displayName}
-              size={28}
+              size={36}
               colorToken={agent.avatarColorToken}
               seed={agent.uuid}
             />

--- a/packages/web/src/pages/agent-detail/agent-switcher-strip.tsx
+++ b/packages/web/src/pages/agent-detail/agent-switcher-strip.tsx
@@ -5,17 +5,18 @@ import { type ReactNode, useCallback, useEffect, useRef, useState } from "react"
 import { listAgents, listAllAgents } from "../../api/agents.js";
 import { useAuth } from "../../auth/auth-context.js";
 import { Avatar } from "../../components/avatar.js";
-import { presenceChipView, runtimeStateToPresence } from "../../components/ui/presence-chip.js";
 import { matchesAgentScope, readAgentFilterPreference } from "../team/agent-filter.js";
 import { fetchAllAgents } from "../team/index.js";
 import { resolveTabPath } from "./tabs.js";
 
 /**
  * Agent switcher (vertical-B): replaces the breadcrumb at the top of agent
- * detail. A horizontal strip of avatar-over-name items, leftmost a "‹ Team"
- * back affordance, the current agent selected. Switching agents (and Team) goes
- * through `onNavigate` = the page's `guardedNavigate`, so an unsaved config
- * draft prompts a confirm before leaving.
+ * detail. A "‹ Team" back affordance pinned at the left, then a horizontal strip
+ * of avatar-over-name items (the current agent selected). The Team anchor lives
+ * OUTSIDE the scroll container, so the only "back to the roster" exit stays put
+ * no matter how far right you scroll through a long agent list. Switching agents
+ * (and Team) goes through `onNavigate` = the page's `guardedNavigate`, so an
+ * unsaved config draft prompts a confirm before leaving.
  *
  * Scope follows the Team page's All/Mine preference (shared `agent-filter`
  * module), read once on mount — the filter can only change on the Team page,
@@ -41,7 +42,8 @@ export function AgentSwitcherStrip({
     // Same key + fetcher as the Team page, so navigating from Team is a cache hit.
     queryKey: ["agents", "team-page", isAdmin ? "admin" : "member"],
     queryFn: () => fetchAllAgents((params) => (isAdmin ? listAllAgents(params) : listAgents(params))),
-    // Mirror the Team page cadence so other agents' presence dots stay fresh.
+    // Mirror the Team page cadence so the roster (added/removed/renamed agents)
+    // stays fresh while you're parked on one agent's detail page.
     refetchInterval: 10_000,
   });
 
@@ -53,8 +55,8 @@ export function AgentSwitcherStrip({
     ? inScope
     : [currentAgent, ...inScope.filter((a) => a.uuid !== currentAgent.uuid)];
   // Render the current agent from the live (10s-polled) `currentAgent` prop, not
-  // the switcher query row, so the selected chip's name/avatar/presence never
-  // lags the header for the agent you're actually on.
+  // the switcher query row, so the selected chip's name/avatar never lags the
+  // header for the agent you're actually on.
   const items: Agent[] = base.map((a) => (a.uuid === currentAgent.uuid ? currentAgent : a));
 
   const scrollRef = useRef<HTMLDivElement | null>(null);
@@ -92,57 +94,62 @@ export function AgentSwitcherStrip({
   }, [updateEdges]);
 
   return (
-    <div style={{ position: "relative" }}>
-      <div
-        ref={scrollRef}
-        onScroll={updateEdges}
-        className="flex items-start"
-        style={{ gap: "var(--sp-2)", overflowX: "auto", paddingBottom: "var(--sp-1)" }}
-      >
-        <StripButton onClick={() => onNavigate("/team")} label="Team" ariaLabel="Back to team">
-          <span
-            className="flex items-center justify-center shrink-0"
-            style={{
-              width: 36,
-              height: 36,
-              borderRadius: "var(--radius-full)",
-              border: "var(--hairline) solid var(--border)",
-              background: "var(--bg-raised)",
-              color: "var(--fg-3)",
-            }}
-          >
-            <ChevronLeft className="h-4 w-4" />
-          </span>
-        </StripButton>
+    // Pinned Team anchor + an independently-scrolling agent strip beside it.
+    <div className="flex items-start" style={{ gap: "var(--sp-2)" }}>
+      <StripButton onClick={() => onNavigate("/team")} label="Team" ariaLabel="Back to team">
+        <span
+          className="flex items-center justify-center shrink-0"
+          style={{
+            width: 28,
+            height: 28,
+            borderRadius: "var(--radius-full)",
+            border: "var(--hairline) solid var(--border)",
+            background: "var(--bg-raised)",
+            color: "var(--fg-3)",
+          }}
+        >
+          <ChevronLeft className="h-4 w-4" />
+        </span>
+      </StripButton>
 
-        {items.map((a) => {
-          const selected = a.uuid === currentAgent.uuid;
-          const presence = presenceChipView(runtimeStateToPresence(a.runtimeState));
-          return (
-            <StripButton
-              key={a.uuid}
-              ariaCurrent={selected}
-              label={a.displayName}
-              title={a.displayName}
-              // Clicking the already-selected agent is a no-op — it isn't a
-              // "leave", so it must not trip the leave guard (which would offer to
-              // discard the draft for a navigation back to the same page).
-              onClick={
-                selected
-                  ? undefined
-                  : () => onNavigate(`/agents/${a.uuid}/${resolveTabPath(a, memberId, role, currentTabPath)}`)
-              }
-            >
-              {/* Selection is signalled by the label underline + weight below
-                  (tab-style), not a heavy/colored ring around the avatar — so the
-                  avatar size is constant (no select-time shrink/jump) and follows
-                  the OptionCard rule of never using a heavier border for selection. */}
-              <span className="relative inline-flex shrink-0" style={{ width: 36, height: 36 }}>
+      {/* min-width:0 lets this flex child shrink below its content so the inner
+          row can actually overflow and scroll instead of pushing the layout wide. */}
+      <div style={{ position: "relative", flex: "1 1 auto", minWidth: 0 }}>
+        <div
+          ref={scrollRef}
+          onScroll={updateEdges}
+          className="flex items-start"
+          style={{ gap: "var(--sp-2)", overflowX: "auto", paddingBottom: "var(--sp-1)" }}
+        >
+          {items.map((a) => {
+            const selected = a.uuid === currentAgent.uuid;
+            return (
+              <StripButton
+                key={a.uuid}
+                ariaCurrent={selected}
+                label={a.displayName}
+                title={a.displayName}
+                // Clicking the already-selected agent is a no-op — it isn't a
+                // "leave", so it must not trip the leave guard (which would offer to
+                // discard the draft for a navigation back to the same page).
+                onClick={
+                  selected
+                    ? undefined
+                    : () => onNavigate(`/agents/${a.uuid}/${resolveTabPath(a, memberId, role, currentTabPath)}`)
+                }
+              >
+                {/* Demoted switcher (the page header's title row is the primary
+                  identity, with a larger avatar): these nav avatars are deliberately
+                  smaller, and selection is a quiet bg-active disc behind the avatar
+                  plus the fg-weighted label below — NOT a tab-style underline, which
+                  would make the switcher compete with the title for "you are here".
+                  No presence dot: this strip is a switcher, not a roster — runtime
+                  status already lives in the header's PresenceChip. */}
                 <span
-                  className="inline-flex items-center justify-center"
+                  className="inline-flex items-center justify-center shrink-0"
                   style={{
-                    width: 36,
-                    height: 36,
+                    width: 28,
+                    height: 28,
                     borderRadius: "var(--radius-full)",
                     border: "var(--hairline) solid transparent",
                     background: selected ? "var(--bg-active)" : "transparent",
@@ -151,30 +158,18 @@ export function AgentSwitcherStrip({
                   <Avatar
                     src={a.avatarImageUrl}
                     name={a.displayName}
-                    size={34}
+                    size={26}
                     colorToken={a.avatarColorToken}
                     seed={a.uuid}
                   />
                 </span>
-                <span
-                  aria-hidden
-                  className="absolute inline-block rounded-full"
-                  style={{
-                    right: 0,
-                    bottom: 0,
-                    width: "var(--sp-2)",
-                    height: "var(--sp-2)",
-                    background: presence.color,
-                    boxShadow: "0 0 0 var(--hairline-bold) var(--bg-raised)",
-                  }}
-                />
-              </span>
-            </StripButton>
-          );
-        })}
+              </StripButton>
+            );
+          })}
+        </div>
+        {edges.left ? <EdgeFade side="left" /> : null}
+        {edges.right ? <EdgeFade side="right" /> : null}
       </div>
-      {edges.left ? <EdgeFade side="left" /> : null}
-      {edges.right ? <EdgeFade side="right" /> : null}
     </div>
   );
 }
@@ -202,18 +197,26 @@ function StripButton({
       aria-current={ariaCurrent ? "true" : undefined}
       title={title}
       className="flex shrink-0 cursor-pointer flex-col items-center bg-transparent border-0 transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring rounded-[var(--radius-input)]"
-      style={{ gap: "var(--sp-1)", padding: "var(--sp-1) var(--sp-0_5)", width: "var(--sp-16)" }}
+      // Width follows the name within a tight band — floor sp-16 (short names keep
+      // a stable, avatar-centered column), cap at 100 (just above sp-20) so common
+      // names like gandy-developer / gandy-assistant show in full or near-full
+      // without the column going wide and stranding the small avatar in whitespace.
+      // Past the cap the label ellipsizes. Raw 100 (no token at this step, like the
+      // avatar's raw size) — the scale jumps sp-20(80) → sp-35(140), both worse here.
+      style={{
+        gap: "var(--sp-1)",
+        padding: "var(--sp-1) var(--sp-1_5)",
+        minWidth: "var(--sp-16)",
+        maxWidth: 100,
+      }}
     >
       {children}
+      {/* Selected = label in full fg (others fg-3) + the bg-active disc behind the
+          avatar above. No underline: the switcher is demoted nav, not a tab row —
+          the page title is the primary "you are here". */}
       <span
         className="text-caption max-w-full truncate text-center"
-        style={{
-          color: ariaCurrent ? "var(--fg)" : "var(--fg-3)",
-          paddingBottom: "var(--sp-0_5)",
-          borderBottom: ariaCurrent
-            ? "var(--hairline-bold) solid var(--primary)"
-            : "var(--hairline-bold) solid transparent",
-        }}
+        style={{ color: ariaCurrent ? "var(--fg)" : "var(--fg-3)" }}
       >
         {label}
       </span>


### PR DESCRIPTION
Polishes the agent detail page header / agent-switcher strip. Pure presentational changes to two components — no behavior, routing, or data changes.

## What changed
- **Remove the presence dot** from the switcher avatars. It is a switcher, not a roster, and the same online/offline state is already shown (with a label) by the header `PresenceChip` and the sticky context bar.
- **Dynamic switcher item width** — each item now sizes to its agent name within a **64–100px** band (floor keeps short names in a stable, avatar-centered column; cap lets common names like `gandy-developer` / `gandy-assistant` show in full or near-full; longer names ellipsize). Previously every item was a fixed 64px and almost always truncated.
- **Pin the `‹ Team` back affordance** outside the horizontal scroll container, as a fixed left anchor. The back-to-roster exit (this strip replaced the breadcrumb) now stays reachable no matter how far right a long agent list is scrolled. Auto-scroll-to-selected and the edge fades now target the agent-only scroll container.
- **Avatar size hierarchy + identity de-duplication** — title-row avatar 28 → **36** (the page's single primary identity), switcher avatars 36 → **28**, sticky context bar stays 20. The switcher's selected state is demoted from a tab-style underline to a quiet `bg-active` disc + full-`fg` label, so it no longer competes with the title for "you are here".
- **Top vertical rhythm** tightened to 16/12 (switcher→title 12, header bottom padding 16).

Separation language kept as plain whitespace (the single full-bleed tab border stays the only rule) after weighing a header divider / tint-band — whitespace read cleaner.

## Verification
- `pnpm --filter @first-tree/web typecheck` ✅ (incl. design-token guardrails)
- `biome check` ✅
- `pnpm --filter @first-tree/web test` ✅ 725/725 (incl. the agent-detail layout SSR smoke test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)