### PR TITLE
fix(web): restore pointer events on composer footer toolbar

### DIFF
--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -3087,6 +3087,16 @@ export function ChatView({
                           left: 10,
                           right: 10,
                           color: "var(--fg-4)",
+                          // This toolbar sits inside the textarea's bottom-padding
+                          // strip (`--sp-7_5`). The textarea above carries
+                          // `zIndex: 1` (caret-over-overlay fix), which would
+                          // otherwise hit-test ABOVE this z-auto row — the
+                          // buttons stay visible through the textarea's
+                          // transparent background but every click lands on the
+                          // textarea instead (send/@/attach appear dead; only
+                          // Enter works). Stack the toolbar higher so it gets
+                          // pointer events back.
+                          zIndex: 2,
                         }}
                       >
                         <span className="mono flex items-center" style={{ gap: 10 }}>


### PR DESCRIPTION
## Summary

- Fixes the chat composer bug where the send button (and the `@` / attach buttons) cannot be clicked — only Enter sends.
- Root cause: #597 gave the composer textarea `position: relative; zIndex: 1` to lift its caret above the new `MentionHighlightOverlay`. The footer toolbar is absolutely positioned inside the textarea's bottom-padding strip with `z-auto`, so the textarea now hit-tests above it: the buttons remain visible through the textarea's transparent background, but every click lands on the textarea. The Enter key bypasses pointer hit-testing, which is why it still worked.
- Fix: stack the toolbar row at `zIndex: 2` so it receives pointer events again, restoring the pre-#597 stacking order. The `new-chat-draft` composer is unaffected (its toolbar is in normal flow).

## Test plan

- [x] `pnpm check` — clean
- [x] `pnpm typecheck` — 11/11 packages pass
- [x] `pnpm --filter @first-tree/web test` — 726 tests pass
- [ ] Manual: in a chat, type text and click the send arrow — message sends; `@` and attach buttons respond to clicks; caret still visible over mention highlights

🤖 Generated with [Claude Code](https://claude.com/claude-code)