### PR TITLE
fix(client): classify GitMirrorAuthError as degraded instead of unknown-transient

### DIFF
--- a/packages/client/src/__tests__/error-taxonomy.test.ts
+++ b/packages/client/src/__tests__/error-taxonomy.test.ts
@@ -33,6 +33,10 @@ class FakeClientUserMismatchError extends Error {
   override name = "ClientUserMismatchError";
 }
 
+class FakeGitMirrorAuthError extends Error {
+  override name = "GitMirrorAuthError";
+}
+
 function noMessageShape(fields: Record<string, unknown> = {}): Record<string, unknown> {
   return {
     ...fields,
@@ -131,6 +135,41 @@ describe("error-taxonomy.classify", () => {
       expect(classify(new Error("fetch failed")).reasonCode).toBe("claude_socket_closed");
       expect(classify(noMessageShape({ name: "APIConnectionError" })).message).toBe("Claude API connection dropped");
       expect(classify(noMessageShape({ code: "ECONNRESET" })).message).toBe("Network error");
+    });
+  });
+
+  describe("git mirror auth failures", () => {
+    it("GitMirrorAuthError → degraded (git_clone_auth_failed), no retry", () => {
+      const c = classify(
+        new FakeGitMirrorAuthError(
+          "Could not clone https://github.com/acme/widget.git over HTTPS or SSH. " +
+            "HTTPS attempt failed: fatal: could not read Username for 'https://github.com': terminal prompts disabled " +
+            "SSH retry (git@github.com:) failed: Host key verification failed.",
+        ),
+        { source: "session" },
+      );
+      expect(c.kind).toBe(ERROR_KINDS.DEGRADED);
+      expect(c.reasonCode).toBe("git_clone_auth_failed");
+      expect(c.strategy.kind).toBe("none");
+    });
+
+    it("class name wins over transient substring heuristics embedded in git stderr", () => {
+      // Raw git stderr in the message can contain text the loose heuristics
+      // would otherwise read as transient ("server error", "fetch failed").
+      const c = classify(
+        new FakeGitMirrorAuthError(
+          "Could not fetch https://example.com/r.git over HTTPS or SSH. " +
+            "HTTPS attempt failed: remote server error SSH retry failed: fetch failed",
+        ),
+      );
+      expect(c.kind).toBe(ERROR_KINDS.DEGRADED);
+      expect(c.reasonCode).toBe("git_clone_auth_failed");
+    });
+
+    it("uses the default message when the shape has none", () => {
+      const c = classify(noMessageShape({ name: "GitMirrorAuthError" }));
+      expect(c.kind).toBe(ERROR_KINDS.DEGRADED);
+      expect(c.message).toBe("Source repo git authentication failed");
     });
   });
 

--- a/packages/client/src/__tests__/git-mirror-manager.test.ts
+++ b/packages/client/src/__tests__/git-mirror-manager.test.ts
@@ -17,6 +17,7 @@ import {
   isLikelyHttpsAuthFailure,
   isLikelySshAuthFailure,
   isLikelyTransientNetworkError,
+  protocolFallbackFailure,
   retryOnTransientNetwork,
   sshToHttpsBaseRewrite,
 } from "../runtime/git-mirror-manager.js";
@@ -557,6 +558,39 @@ describe("GitMirrorManager — SSH auth failure heuristic (isLikelySshAuthFailur
     "fatal: could not read Username for 'https://github.com'",
   ])("does NOT match: %s", (msg) => {
     expect(isLikelySshAuthFailure(msg)).toBe(false);
+  });
+});
+
+describe("GitMirrorManager — protocol-fallback failure shaping (protocolFallbackFailure)", () => {
+  const combined = "Could not clone https://github.com/x/y.git over HTTPS or SSH. …";
+
+  it.each([
+    // True double-auth failure: SSH side rejected credentials / host key.
+    "git@github.com: Permission denied (publickey).",
+    "Host key verification failed.\nfatal: Could not read from remote repository.",
+  ])("peer auth-shaped failure → GitMirrorAuthError (no session retry): %s", (peerMessage) => {
+    const err = protocolFallbackFailure(combined, peerMessage);
+    expect(err).toBeInstanceOf(GitMirrorAuthError);
+    expect(err.message).toBe(combined);
+  });
+
+  it.each([
+    // Peer died for a transient network reason (DNS / VPN / proxy outage that
+    // outlasted gitWithNetworkRetry's short budget). Only the primary side is
+    // known to be credential-shaped — keep the session-level retry alive.
+    "ssh: connect to host github.com port 22: Connection timed out\nfatal: Could not read from remote repository.",
+    "ssh: Could not resolve hostname github.com: Name or service not known",
+    "ssh: connect to host github.com port 22: Connection refused",
+  ])("peer transient-network failure → plain GitMirrorError (session retry preserved): %s", (peerMessage) => {
+    const err = protocolFallbackFailure(combined, peerMessage);
+    expect(err).toBeInstanceOf(GitMirrorError);
+    expect(err).not.toBeInstanceOf(GitMirrorAuthError);
+    expect(err.message).toBe(combined);
+  });
+
+  it("peer failure of unrecognised shape stays GitMirrorAuthError (conservative: primary was credential-shaped)", () => {
+    const err = protocolFallbackFailure(combined, "fatal: something nobody has seen before");
+    expect(err).toBeInstanceOf(GitMirrorAuthError);
   });
 });
 

--- a/packages/client/src/runtime/error-taxonomy.ts
+++ b/packages/client/src/runtime/error-taxonomy.ts
@@ -232,6 +232,26 @@ export function classify(err: unknown, context?: { source?: ErrorSource }): Clas
       message: shape.message ?? "Refresh token rejected",
     };
   }
+  // GitMirrorAuthError: the source-repo layer already tried BOTH transports
+  // (primary protocol + peer-protocol insteadOf rewrite) and git rejected
+  // each one. Waiting will not mint credentials — a human has to fix the
+  // host's git auth (credential helper, SSH key, known_hosts), so retrying
+  // is pure churn: before this branch existed the error fell through to the
+  // `unknown` transient fallback and session start retried forever without
+  // ever surfacing a readable error. Degraded rather than permanent because
+  // only THIS resource (the chat's source repo) is unusable; the process and
+  // every other agent/chat stay healthy. Matched by class name here, before
+  // the substring heuristics below, because the message embeds raw git
+  // stderr from both attempts which can contain arbitrary text ("server
+  // error", "fetch failed", …) that would misclassify it as transient.
+  if (shape.name === "GitMirrorAuthError") {
+    return {
+      kind: ERROR_KINDS.DEGRADED,
+      strategy: NONE,
+      reasonCode: "git_clone_auth_failed",
+      message: shape.message ?? "Source repo git authentication failed",
+    };
+  }
 
   // -- Anthropic SDK / stream errors ---------------------------------------
   // RateLimitError (429) — name is contributed by the SDK; substrings are

--- a/packages/client/src/runtime/git-mirror-manager.ts
+++ b/packages/client/src/runtime/git-mirror-manager.ts
@@ -369,10 +369,11 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
         return { elapsedMs, usedFallback: true };
       } catch (peerErr) {
         const peerMessage = peerErr instanceof Error ? peerErr.message : String(peerErr);
-        throw new GitMirrorAuthError(
+        throw protocolFallbackFailure(
           `Could not ${opLabel} ${url} over ${direction.fromProtocol.toUpperCase()} or ${direction.toProtocol.toUpperCase()}. ` +
             `${direction.fromProtocol.toUpperCase()} attempt failed: ${truncate(primaryMessage)} ` +
             `${direction.toProtocol.toUpperCase()} retry (${direction.peerBase}) failed: ${truncate(peerMessage)}`,
+          peerMessage,
         );
       }
     }
@@ -1016,6 +1017,28 @@ export function isLikelyTransientNetworkError(message: string): boolean {
     /fetch-pack: unexpected disconnect/i.test(message) ||
     /\bsend-pack:\s+unexpected\s+disconnect\b/i.test(message)
   );
+}
+
+/**
+ * Decide the error shape when the primary protocol failed credential-shaped
+ * AND the peer-protocol `insteadOf` fallback also failed.
+ *
+ * Only the primary side is known to be credential-shaped at this point. When
+ * the peer attempt died for a transient network reason (a DNS / VPN / proxy
+ * outage that outlasted `gitWithNetworkRetry`'s short in-process budget), the
+ * combined failure is NOT evidence that both transports' credentials are
+ * broken — `GitMirrorAuthError` here would let the error taxonomy classify
+ * the session failure as degraded/no-retry and turn a temporary outage into a
+ * terminal chat error. Keep that case a plain (session-retryable)
+ * `GitMirrorError`; reserve `GitMirrorAuthError` for peers that failed
+ * non-transiently.
+ *
+ * Exported for unit testing.
+ */
+export function protocolFallbackFailure(combinedMessage: string, peerMessage: string): GitMirrorError {
+  return isLikelyTransientNetworkError(peerMessage)
+    ? new GitMirrorError(combinedMessage)
+    : new GitMirrorAuthError(combinedMessage);
 }
 
 /**


### PR DESCRIPTION
## Summary
- `GitMirrorAuthError` (source-repo clone/fetch rejected over **both** the primary protocol and the peer-protocol `insteadOf` fallback) had no branch in `error-taxonomy.ts`, so it fell through to the `unknown` transient fallback: session start retried forever (`resilience.session.retry_scheduled`, `reasonCode: "unknown"`) and the user never saw a readable error.
- Observed in prod on 0.5.5: a host with broken git auth (no HTTPS credential helper in the daemon environment + stale `github.com` host key in `known_hosts`) had every new chat spin past attempt 20 with no surfaced error. The per-agent standalone clone layout (#854) makes a fresh clone mandatory for each agent home, so the broken host auth now blocks every new chat instead of being absorbed by a pre-existing mirror.
- Fix: classify `GitMirrorAuthError` as **degraded** (`git_clone_auth_failed`, no retry). Waiting cannot mint credentials — a human has to fix the host's git auth. Degraded (not permanent) because only this chat's source repo is unusable; the process and other agents stay healthy. The existing non-transient path in `SessionManager.handleSessionFailure` already reports `errored` and emits the readable error event to the chat, so no session-manager change is needed.
- Matched by class name **before** the substring heuristics: the message embeds raw git stderr from both attempts, which can contain text the loose heuristics would read as transient ("server error", "fetch failed").

## Test plan
- [x] New unit tests: degraded classification + no-retry strategy, class-name precedence over transient substrings embedded in git stderr, default message
- [x] `pnpm --filter @first-tree/client test` — 1113 passed (full suite; `git-mirror-manager.test.ts` requires proxy env vars unset, pre-existing)
- [x] `pnpm check && pnpm typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)