### PR TITLE
docs: add one measurable CTA to README + UTM-tag existing site links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </p>
 
 <p align="center">
-  <a href="https://cloud.first-tree.ai"><strong>Open App</strong></a> &middot;
+  <a href="https://cloud.first-tree.ai/?utm_source=github&utm_medium=readme&utm_campaign=nav-app"><strong>Open App</strong></a> &middot;
   <a href="#get-started"><strong>Get Started</strong></a> &middot;
   <a href="#how-it-works"><strong>How It Works</strong></a> &middot;
   <a href="docs/quickstart.md"><strong>Quickstart</strong></a> &middot;
@@ -24,6 +24,8 @@
 <p align="center">
   English | <a href="README_zh-CN.md">中文</a>
 </p>
+
+> Use this [link](https://first-tree.ai/?utm_source=github&utm_medium=readme&utm_campaign=top-cta) to use first-tree for **free** — the most efficient way to **loopmaxx your engineering work**.
 
 # First-Tree
 
@@ -114,10 +116,11 @@ during, and after execution.
 
 ## Get Started
 
-Open the app at **<https://cloud.first-tree.ai>** (or your own deployment) and
-sign in. Learn more at <https://first-tree.ai>. The guided setup walks you
-through the first run: name your team, connect a computer, create your first
-agent, connect code, and start work.
+Open the app at **[cloud.first-tree.ai](https://cloud.first-tree.ai/?utm_source=github&utm_medium=readme&utm_campaign=getstarted-app)**
+(or your own deployment) and sign in. Learn more at
+[first-tree.ai](https://first-tree.ai/?utm_source=github&utm_medium=readme&utm_campaign=getstarted-home).
+The guided setup walks you through the first run: name your team, connect a
+computer, create your first agent, connect code, and start work.
 
 See the [Quickstart](docs/quickstart.md) for the full walkthrough.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   English | <a href="README_zh-CN.md">中文</a>
 </p>
 
-> Use this [link](https://first-tree.ai/?utm_source=github&utm_medium=readme&utm_campaign=top-cta) to use first-tree for **free** — the most efficient way to **loopmaxx your engineering work**.
+> Use this [link](https://cloud.first-tree.ai/login?utm_source=github&utm_medium=readme&utm_campaign=top-cta-app) to use [first-tree](https://first-tree.ai/?utm_source=github&utm_medium=readme&utm_campaign=top-cta-site) for **free** — the most efficient way to **loopmaxx your engineering work**.
 
 # First-Tree
 


### PR DESCRIPTION
## What

Adds exactly **one** conversion hook to the README (top, under the badges — copy approved by @serenakeyitan):

> Use this [link](https://first-tree.ai/?utm_source=github&utm_medium=readme&utm_campaign=top-cta) to use first-tree for **free** — the most efficient way to **loopmaxx your engineering work**.

Plus silent UTM campaigns on the three pre-existing site links (nav "Open App" → `nav-app`; Get Started's app/home links → `getstarted-app` / `getstarted-home`) — zero visible copy changes there, the bare `<https://…>` autolinks become markdown links so the params stay hidden.

## Why

first-tree.ai now has full GA source attribution + conversion events (first-tree-website#70 / #78). Today every README click collapses into one `github.com / referral` row. With per-position campaigns, Traffic acquisition shows each hook as its own row, and the key-events column (click_github / click_discord / copy_command / click_x) tells us whether README-referred visitors actually convert. Decision point in ~2 weeks: keep or rewrite the CTA based on data, not vibes.

## Verification

- All 4 tagged URLs resolve 200 (incl. UTM variants; cloud.first-tree.ai unaffected by params).
- Diff is README.md only, +8/−5; README_zh-CN.md untouched per owner's call.
- Markdown renders as a standard blockquote; no structural changes.

Refs #958

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — agent-authored PR on behalf of @serenakeyitan; leaving merge to a human reviewer.