### PR TITLE
docs: add measurable CTA to README + UTM-tag existing site links

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   English | <a href="README_zh-CN.md">中文</a>
 </p>
 
-> Use this [link](https://cloud.first-tree.ai/login?utm_source=github&utm_medium=readme&utm_campaign=top-cta-app) to use [first-tree](https://first-tree.ai/?utm_source=github&utm_medium=readme&utm_campaign=top-cta-site) for **free!!!** — the most efficient way to **loopmaxx your engineering work**.
+> Use this [link](https://cloud.first-tree.ai/login?utm_source=github&utm_medium=readme&utm_campaign=top-cta-app) to use [first-tree 🌳](https://first-tree.ai/?utm_source=github&utm_medium=readme&utm_campaign=top-cta-site) for **free!!!** — the most efficient way to **loopmaxx your engineering work**.
 
 # First-Tree
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </p>
 
 <p align="center">
-  <a href="https://cloud.first-tree.ai"><strong>Open App</strong></a> &middot;
+  <a href="https://cloud.first-tree.ai/?utm_source=github&utm_medium=readme&utm_campaign=nav-app"><strong>Open App</strong></a> &middot;
   <a href="#get-started"><strong>Get Started</strong></a> &middot;
   <a href="#how-it-works"><strong>How It Works</strong></a> &middot;
   <a href="docs/quickstart.md"><strong>Quickstart</strong></a> &middot;
@@ -24,6 +24,8 @@
 <p align="center">
   English | <a href="README_zh-CN.md">中文</a>
 </p>
+
+> Use this [link](https://cloud.first-tree.ai/login?utm_source=github&utm_medium=readme&utm_campaign=top-cta-app) to use [first-tree](https://first-tree.ai/?utm_source=github&utm_medium=readme&utm_campaign=top-cta-site) for **free** — the most efficient way to **loopmaxx your engineering work**.
 
 # First-Tree
 
@@ -114,10 +116,11 @@ during, and after execution.
 
 ## Get Started
 
-Open the app at **<https://cloud.first-tree.ai>** (or your own deployment) and
-sign in. Learn more at <https://first-tree.ai>. The guided setup walks you
-through the first run: name your team, connect a computer, create your first
-agent, connect code, and start work.
+Open the app at **[cloud.first-tree.ai](https://cloud.first-tree.ai/?utm_source=github&utm_medium=readme&utm_campaign=getstarted-app)**
+(or your own deployment) and sign in. Learn more at
+[first-tree.ai](https://first-tree.ai/?utm_source=github&utm_medium=readme&utm_campaign=getstarted-home).
+The guided setup walks you through the first run: name your team, connect a
+computer, create your first agent, connect code, and start work.
 
 See the [Quickstart](docs/quickstart.md) for the full walkthrough.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   English | <a href="README_zh-CN.md">中文</a>
 </p>
 
-> Use this [link](https://cloud.first-tree.ai/login?utm_source=github&utm_medium=readme&utm_campaign=top-cta-app) to use [first-tree](https://first-tree.ai/?utm_source=github&utm_medium=readme&utm_campaign=top-cta-site) for **free** — the most efficient way to **loopmaxx your engineering work**.
+> Use this [link](https://cloud.first-tree.ai/login?utm_source=github&utm_medium=readme&utm_campaign=top-cta-app) to use [first-tree](https://first-tree.ai/?utm_source=github&utm_medium=readme&utm_campaign=top-cta-site) for **free!!!** — the most efficient way to **loopmaxx your engineering work**.
 
 # First-Tree
 


### PR DESCRIPTION
## What

One conversion hook at the top of the README (under the badges), owner-approved copy — the same CTA now live on [awesome-agent-loops](https://github.com/serenakeyitan/awesome-agent-loops):

> Use this [link](https://cloud.first-tree.ai/login?utm_source=github&utm_medium=readme&utm_campaign=top-cta-app) to use [first-tree](https://first-tree.ai/?utm_source=github&utm_medium=readme&utm_campaign=top-cta-site) for **free** — the most efficient way to **loopmaxx your engineering work**.

Campaigns are per-placement (`top-cta-*` here vs `awesome-loops-*` there) so GA can compare the two READMEs. Also adds silent UTM campaigns to the three pre-existing site links (nav "Open App" → `nav-app`; Get Started links → `getstarted-app` / `getstarted-home`) with zero visible copy changes. `README_zh-CN.md` untouched per owner.

Content is identical to #959, which was closed during a placement decision and reinstated by the owner (see #958).

## Verification

- All tagged URLs resolve 200 (cloud login page + site with UTM variants).
- Diff: README.md only, +8/−5; renders as a standard blockquote.

Refs #958

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — agent-authored PR on behalf of @serenakeyitan; leaving merge to a human reviewer.