### PR TITLE
feat(web): add GA4 tag with region-scoped consent to the app shell

### DIFF
--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -16,6 +16,55 @@
         if (t === "dark" || (!t && m)) document.documentElement.classList.add("dark");
       })();
     </script>
+    <!--
+      ── Google Analytics 4 with Consent Mode v2 (region-scoped) ──
+      Same property as first-tree.ai (G-BHG918MZ02). The cookie lives on
+      .first-tree.ai, so sessions continue from the marketing site into the
+      app and README/site UTM campaigns (top-cta-app, awesome-loops-app,
+      nav-app, getstarted-app) attribute the login page. Outside the
+      EEA/UK/CH analytics_storage defaults to granted; inside those regions
+      it stays denied — the app has no consent banner, EEA users simply
+      stay cookieless. A stored choice on this origin (localStorage
+      ft_consent) is honored before gtag.js loads. Ad signals are denied
+      everywhere. Privacy policy at first-tree.ai/privacy covers subdomains.
+      Mirrors the snippet in first-tree-website (index.html / BaseLayout).
+    -->
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        // biome-ignore lint/complexity/noArguments: gtag.js processes its queue by Arguments object; pushing a real array (rest params) silently drops the commands
+        dataLayer.push(arguments);
+      }
+      gtag("consent", "default", {
+        ad_storage: "denied",
+        ad_user_data: "denied",
+        ad_personalization: "denied",
+        analytics_storage: "granted",
+      });
+      gtag("consent", "default", {
+        ad_storage: "denied",
+        ad_user_data: "denied",
+        ad_personalization: "denied",
+        analytics_storage: "denied",
+        wait_for_update: 500,
+        region: ["AT","BE","BG","HR","CY","CZ","DK","EE","FI","FR","DE","GR",
+                 "HU","IE","IT","LV","LT","LU","MT","NL","PL","PT","RO","SK",
+                 "SI","ES","SE","IS","LI","NO","GB","CH"],
+      });
+      try {
+        const prior = localStorage.getItem("ft_consent");
+        if (prior === "granted") {
+          gtag("consent", "update", { analytics_storage: "granted" });
+        } else if (prior === "denied") {
+          gtag("consent", "update", { analytics_storage: "denied" });
+        }
+      } catch {
+        /* storage unavailable (private mode) — region defaults apply */
+      }
+      gtag("js", new Date());
+      gtag("config", "G-BHG918MZ02");
+    </script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-BHG918MZ02"></script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## What

Adds the first-tree.ai GA4 tag (`G-BHG918MZ02`) to `packages/web/index.html` so clicks on the README CTAs' primary link (`cloud.first-tree.ai/login?utm_campaign=top-cta-app / awesome-loops-app` and the nav/getstarted links) finally show up in analytics — until now the funnel's most important link was unmeasured (#961).

- **Same property, shared subdomain cookie** (`.first-tree.ai`): sessions continue from the marketing site into the app; UTM campaigns attribute the login page; no cross-domain config needed.
- **Consent mirrors the marketing site** (first-tree-website#70): region-scoped Consent Mode v2 — granted outside EEA/UK/CH, denied inside (the app ships no banner; EEA users simply stay cookieless), ad signals denied everywhere, stored `ft_consent` honored before gtag.js loads. The privacy policy at first-tree.ai/privacy explicitly covers subdomains.
- **SPA routes**: GA4 Enhanced Measurement (history changes) covers route views; no router instrumentation added.
- The gtag stub keeps the `Arguments` object with a documented biome-ignore — gtag.js processes its queue by Arguments; rest params push a real array and silently drop commands.

## Verification

- `pnpm check`: the edited file is clean (repo-wide warnings unchanged from baseline); `pnpm typecheck`: 12/12 tasks pass.
- `pnpm --filter @first-tree/web build`: ✓, `dist/index.html` carries the tag.
- Snippet logic is byte-equivalent to the four verified copies on first-tree.ai (consent defaults / region list / prior-choice handling were browser-E2E'd there on 2026-06-10).

## After merge (owner, GA admin — 1 minute)

Admin → Data streams → first-tree.ai → Configure tag settings → **List unwanted referrals** → add `first-tree.ai` (prevents subdomain self-referrals from polluting source data).

Refs #961

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — agent-authored PR on behalf of @serenakeyitan; leaving merge to a human reviewer.