### PR TITLE
fix: lower engines.node floor from >=22.16.0 to >=22.13.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ What first-tree is NOT:
 - **Shared:** Zod schemas + TypeScript types + config system
 - **Web:** React 19 / Vite
 - **Tooling:** pnpm (workspace) / Turborepo / Biome / Vitest / tsdown
-- **Node.js:** minimum 22, recommended 24
+- **Node.js:** minimum 22.13, recommended 24
 
 ## Common Commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ What first-tree is NOT:
 - **Shared:** Zod schemas + TypeScript types + config system
 - **Web:** React 19 / Vite
 - **Tooling:** pnpm (workspace) / Turborepo / Biome / Vitest / tsdown
-- **Node.js:** minimum 22.16, recommended 24
+- **Node.js:** minimum 22, recommended 24
 
 ## Common Commands
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -50,7 +50,7 @@
     "directory": "apps/cli"
   },
   "engines": {
-    "node": ">=22.16.0"
+    "node": ">=22.0.0"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.84",

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -50,7 +50,7 @@
     "directory": "apps/cli"
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.13.0"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.84",

--- a/apps/cli/src/core/doctor.ts
+++ b/apps/cli/src/core/doctor.ts
@@ -49,7 +49,7 @@ export function checkNodeVersion(): CheckResult {
   return {
     label: "Node.js",
     ok,
-    detail: ok ? `v${version}` : `v${version} (requires >= 22.16)`,
+    detail: ok ? `v${version}` : `v${version} (requires >= 22)`,
   };
 }
 

--- a/apps/cli/src/core/doctor.ts
+++ b/apps/cli/src/core/doctor.ts
@@ -44,12 +44,18 @@ function get(obj: Record<string, unknown>, dotPath: string): unknown {
 
 export function checkNodeVersion(): CheckResult {
   const version = process.versions.node;
-  const [major] = version.split(".").map(Number);
-  const ok = major !== undefined && major >= 22;
+  const [major, minor] = version.split(".").map(Number);
+  // Floor of `>=22.13.0` matches engines.node on the published packages
+  // and reflects the real strict-resolver floor — `@inquirer/prompts`
+  // (a direct dep of apps/cli) is the tightest constraint at `^22.13.0`,
+  // so under pnpm / yarn / `engine-strict=true` installs on 22.0-22.12
+  // hard-fail despite engines saying otherwise. Mirror that here so the
+  // doctor is honest about the supported range, not just the major.
+  const ok = major !== undefined && (major >= 23 || (major === 22 && minor !== undefined && minor >= 13));
   return {
     label: "Node.js",
     ok,
-    detail: ok ? `v${version}` : `v${version} (requires >= 22)`,
+    detail: ok ? `v${version}` : `v${version} (requires >= 22.13)`,
   };
 }
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -20,7 +20,7 @@ first-tree --version
 ```
 
 The binary lives at `first-tree`; the short alias `ft` is also installed.
-Requirements: Node.js ≥ 22.16 (24 recommended).
+Requirements: Node.js ≥ 22 (24 recommended).
 
 ## Global flags
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -20,7 +20,7 @@ first-tree --version
 ```
 
 The binary lives at `first-tree`; the short alias `ft` is also installed.
-Requirements: Node.js ≥ 22 (24 recommended).
+Requirements: Node.js ≥ 22.13 (24 recommended).
 
 ## Global flags
 

--- a/docs/onboarding-guide.md
+++ b/docs/onboarding-guide.md
@@ -15,7 +15,7 @@ everything online.
 
 ## Prerequisites
 
-- **Node.js** ≥ 22.16 (24 recommended).
+- **Node.js** ≥ 22 (24 recommended).
 - **The CLI** — `npm install -g first-tree && first-tree --version`.
 - **A connect token** — generated from the web console's *Computers → New
   Connection* dialog. The token's `iss` claim carries the server URL, so

--- a/docs/onboarding-guide.md
+++ b/docs/onboarding-guide.md
@@ -15,7 +15,7 @@ everything online.
 
 ## Prerequisites
 
-- **Node.js** ≥ 22 (24 recommended).
+- **Node.js** ≥ 22.13 (24 recommended).
 - **The CLI** — `npm install -g first-tree && first-tree --version`.
 - **A connect token** — generated from the web console's *Computers → New
   Connection* dialog. The token's `iss` claim carries the server URL, so

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -17,7 +17,7 @@ page mirrors that flow.
 ## Before you start
 
 - A **GitHub account** to sign in with.
-- **Node.js ≥ 22.16** (24 recommended) on the computer your agent will run
+- **Node.js ≥ 22** (24 recommended) on the computer your agent will run
   on. Setup installs the CLI for you, but Node must already be present.
 
 ## 1. Sign in and name your team

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -17,7 +17,7 @@ page mirrors that flow.
 ## Before you start
 
 - A **GitHub account** to sign in with.
-- **Node.js ≥ 22** (24 recommended) on the computer your agent will run
+- **Node.js ≥ 22.13** (24 recommended) on the computer your agent will run
   on. Setup installs the CLI for you, but Node must already be present.
 
 ## 1. Sign in and name your team

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": ">=22.16.0"
+    "node": ">=22.0.0"
   },
   "packageManager": "pnpm@10.12.1",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.13.0"
   },
   "packageManager": "pnpm@10.12.1",
   "scripts": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -25,7 +25,7 @@
     "smoke:codex-sandbox": "node scripts/codex-sandbox-smoke.mjs"
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.13.0"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.84",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -25,7 +25,7 @@
     "smoke:codex-sandbox": "node scripts/codex-sandbox-smoke.mjs"
   },
   "engines": {
-    "node": ">=22.16.0"
+    "node": ">=22.0.0"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.84",

--- a/packages/e2e/README.md
+++ b/packages/e2e/README.md
@@ -60,7 +60,7 @@ real-world runs the CI wiring (proposal §九 M3) will land separately.
 
 ## Local prerequisites
 
-- Node ≥ 22.16
+- Node ≥ 22
 - pnpm 10.x
 - Docker (with `docker compose` v2 preferred; v1 `docker-compose` is the
   fallback)

--- a/packages/e2e/README.md
+++ b/packages/e2e/README.md
@@ -60,7 +60,7 @@ real-world runs the CI wiring (proposal §九 M3) will land separately.
 
 ## Local prerequisites
 
-- Node ≥ 22
+- Node ≥ 22.13
 - pnpm 10.x
 - Docker (with `docker compose` v2 preferred; v1 `docker-compose` is the
   fallback)

--- a/packages/e2e/src/framework/doctor.ts
+++ b/packages/e2e/src/framework/doctor.ts
@@ -54,7 +54,7 @@ export function runDoctor(repoRoot: string): DoctorResult {
     });
   }
 
-  const nodeIssue = checkNodeVersion([22, 16, 0]);
+  const nodeIssue = checkNodeVersion([22, 13, 0]);
   if (nodeIssue) issues.push(nodeIssue);
 
   const serverDist = resolve(repoRoot, "packages/server/dist/index.mjs");


### PR DESCRIPTION
## Summary

- New users on Node 22.0-22.15 (e.g. nvm/brew default Node 22 minor) running the onboarding flow's `npm install -g first-tree` end up with **0.4.5** instead of the current **0.5.5** — confirmed in production by a real user on `v22.15.1`.
- Root cause: every 0.5.x bumped `engines.node` from `>=22` to `>=22.16.0`. With pnpm/yarn or `engine-strict=true` set, the resolver walks back through the prerelease ladder until 0.4.5 (the last version with `>=22` engines) wins. Plain npm prints `EBADENGINE` but still installs the requested version — users who treat the warning as a hard error fall back manually to the same place.
- This PR lowers the floor to `>=22.13.0` on every published / workspace-root `package.json` and updates the docs that quoted the old floor.

## Why `>=22.13.0` and not `>=22.0.0`

`apps/cli` has a direct dep on `@inquirer/prompts@8.3.2`, whose own engines is `>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0`. Confirmed via pnpm-lock that this is the tightest Node 22.x constraint in the resolved graph. Under pnpm / yarn / `engine-strict=true`, installs on Node 22.0–22.12 would still hard-fail on this transitive constraint even if the published engines said `>=22.0.0`. Aligning the advertised floor with the resolver-enforced floor keeps the engines field truthful and lets a future maintainer see that lowering the floor further requires repinning `@inquirer/prompts`. The confirmed real reporting user (v22.15.1) and the common nvm/brew-recent 22.x bracket (22.13–22.15) are fully covered.

## What changed
| File | Change |
|---|---|
| `apps/cli/package.json` | `engines.node`: `>=22.16.0` → `>=22.13.0` (the published tarball) |
| `packages/client/package.json` | `engines.node`: `>=22.16.0` → `>=22.13.0` — private bundled package; the file is never read by `npm install` on the user side, so the only effect is keeping the workspace floor consistent for `engine-strict=true` contributors |
| `package.json` (root) | `engines.node`: `>=22.16.0` → `>=22.13.0` (workspace floor) |
| `apps/cli/src/core/doctor.ts` | `checkNodeVersion()` gate strengthened from major-only (`major >= 22`) to major + minor (`>= 22.13`); detail string mirrors the new floor. The previous string `requires >= 22.16` was inconsistent with both old and new engines. |
| `AGENTS.md`, `docs/quickstart.md`, `docs/cli-reference.md`, `docs/onboarding-guide.md`, `packages/e2e/README.md` | "Node.js ≥ 22.16" → "Node.js ≥ 22.13" |

### Intentionally left alone
- `packages/skill-evals/package.json` — `engines.node` stays at `>=22.16.0`. This is private dev-only tooling whose devDeps (`@types/node@^22.16.0`) genuinely depend on the newer minor. The exception is explicitly documented in [first-tree-context#482](https://github.com/agent-team-foundation/first-tree-context/pull/482).
- `@types/node@^22.16.0` devDep pins across the workspace — devDeps don't gate runtime `engines`, so these are not part of the floor.

## Why this is safe
- No runtime code uses a 22.16-only Node API. The original bump came in as a side-effect of pinning `@types/node@^22.16.0` in skill-evals devDeps; that pin never gated runtime behavior.
- `pnpm check` and `pnpm typecheck` pass clean (the single pre-existing biome warning on `MigrationOutcome` is unrelated).
- All 436 `apps/cli` Vitest tests pass locally including the doctor-core suite.

## Companion tree PR

[first-tree-context#482](https://github.com/agent-team-foundation/first-tree-context/pull/482) updates `system/distribution/cicd.md` to record the new floor + the `@inquirer/prompts` rationale as the contributor / CI baseline. Ideal merge order: tree PR first, then this code PR.

## Test plan
- [x] `pnpm install --frozen-lockfile` succeeds (no dep resolution churn — engines is a soft floor for direct deps)
- [x] `pnpm check` clean (the 1 pre-existing warning is unrelated to this PR)
- [x] `pnpm typecheck` clean across all 12 workspace tasks
- [x] `pnpm --filter first-tree-dev test` — 436/436 pass after the new doctor gate
- [ ] After merge + next release: confirm a Node 22.15.1 host running `npm install -g first-tree` resolves to the new latest (not 0.4.5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)