### PR TITLE
fix(server): move github echo-suppression to the notification layer (#942)

### DIFF
--- a/packages/server/src/__tests__/github-audience.test.ts
+++ b/packages/server/src/__tests__/github-audience.test.ts
@@ -248,6 +248,7 @@ describe("resolveAudience", () => {
         chatId,
         involveReason: null,
         involveLogin: null,
+        actorAgentId: null,
       },
     ]);
   });
@@ -289,6 +290,7 @@ describe("resolveAudience", () => {
         chatId: null,
         involveReason: "review_requested",
         involveLogin: humanName.toLowerCase(),
+        actorAgentId: null,
       },
     ]);
   });
@@ -540,7 +542,7 @@ describe("resolveAudience", () => {
     expect(audience).toEqual([]);
   });
 
-  it("echo: drops mappings where actor is the human side OR delegate side", async () => {
+  it("echo (#942): keeps mappings where actor is the human side, annotating actorAgentId for notification suppression", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
     const delegate = await seedAgent(app, {
@@ -584,7 +586,11 @@ describe("resolveAudience", () => {
       chatId: chatOther,
     });
 
-    // Actor is the human-side agent → only the other-human row survives.
+    // Actor is the human-side agent of the first mapping. Pre-#942 the
+    // whole row was dropped, which silently killed card delivery to that
+    // chat. Now BOTH rows survive (every mapped chat keeps the public
+    // record); each carries actorAgentId so Stage 3 suppresses only the
+    // actor's own notification.
     const [humanRow] = await app.db.select({ name: agents.name }).from(agents).where(eq(agents.uuid, human)).limit(1);
     const audience = await resolveAudience(
       app.db,
@@ -597,8 +603,73 @@ describe("resolveAudience", () => {
       }),
       "first-tree",
     );
-    expect(audience).toHaveLength(1);
-    expect(audience[0]?.humanAgentId).toBe(otherHuman);
+    expect(audience).toHaveLength(2);
+    const byHuman = new Map(audience.map((a) => [a.humanAgentId, a]));
+    expect(byHuman.get(human)).toMatchObject({
+      delegateAgentId: delegate,
+      kind: "existing",
+      chatId: chatHuman,
+      actorAgentId: human,
+    });
+    expect(byHuman.get(otherHuman)).toMatchObject({
+      delegateAgentId: otherDelegate,
+      kind: "existing",
+      chatId: chatOther,
+      actorAgentId: human,
+    });
+  });
+
+  it("echo (#942): keeps a mapping where actor is the delegate side, annotating actorAgentId", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const delegateName = `dlg-${randomUUID().slice(0, 6)}`;
+    const delegate = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: delegateName,
+    });
+    const human = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `human-${randomUUID().slice(0, 6)}`,
+      delegateMention: delegate,
+    });
+    const chatId = await seedChat(app, admin.organizationId, human);
+    await seedMapping(app, {
+      orgId: admin.organizationId,
+      humanId: human,
+      delegateId: delegate,
+      entityType: "pull_request",
+      entityKey: "owner/repo#105",
+      chatId,
+    });
+
+    // Actor resolves to the delegate agent (e.g. the squash-merge run by the
+    // delegate's GitHub identity — the staging case of #942). The mapping
+    // survives with actorAgentId set; Stage 3 then empties the addressing
+    // and the card lands as a recipientless public-record row.
+    const audience = await resolveAudience(
+      app.db,
+      makeEvent({
+        orgId: admin.organizationId,
+        entityType: "pull_request",
+        entityKey: "owner/repo#105",
+        actorLogin: delegateName,
+        kind: "merged",
+      }),
+      "first-tree",
+    );
+    expect(audience).toEqual([
+      {
+        humanAgentId: human,
+        delegateAgentId: delegate,
+        kind: "existing",
+        chatId,
+        involveReason: null,
+        involveLogin: null,
+        actorAgentId: delegate,
+      },
+    ]);
   });
 
   it("keeps an involved-new row when actor self-mentions (explicit intent, not echo)", async () => {
@@ -645,17 +716,18 @@ describe("resolveAudience", () => {
     });
   });
 
-  it("self-mention in an already-subscribed entity stays silent (existing dropped, new skipped by subscribedKeys)", async () => {
+  it("self-mention in an already-subscribed entity keeps the existing row (no duplicate new row)", async () => {
     // Documents the interaction between two filters when actor self-targets
     // an entity they already subscribe to:
     //   - the `subscribedKeys` short-circuit (resolveAudience) skips adding a
     //     `kind: "new"` row because (human, delegate) is already subscribed
-    //   - the actor-agent echo filter then drops the surviving `kind: "existing"`
-    //     row because the actor is on the human side
-    // Net result: audience is empty. This is *not* the explicit-intent path the
-    // sibling test covers — there's no new row to keep. Locking the behavior
-    // here so a future change that wants to nudge a subscribed delegate via
-    // self-mention has a clear anchor.
+    //   - the actor-agent echo annotation (#942) keeps the surviving
+    //     `kind: "existing"` row, tagging it with actorAgentId
+    // Net result: exactly one target — the card lands in the bound chat and
+    // the subscribed delegate is nudged (it is not the actor), while the
+    // actor's own notification is suppressed downstream. Pre-#942 this
+    // audience was empty (the echo filter dropped the existing row), which
+    // also meant a self-mention could not nudge the subscribed delegate.
     const app = getApp();
     const admin = await createTestAdmin(app);
     const delegate = await seedAgent(app, {
@@ -693,7 +765,17 @@ describe("resolveAudience", () => {
       "first-tree",
     );
 
-    expect(audience).toEqual([]);
+    expect(audience).toEqual([
+      {
+        humanAgentId: human,
+        delegateAgentId: delegate,
+        kind: "existing",
+        chatId,
+        involveReason: null,
+        involveLogin: null,
+        actorAgentId: human,
+      },
+    ]);
   });
 
   it("skips an involve whose delegate target is inactive (suspended/deleted)", async () => {

--- a/packages/server/src/__tests__/github-delivery.test.ts
+++ b/packages/server/src/__tests__/github-delivery.test.ts
@@ -8,7 +8,7 @@ import { chats } from "../db/schema/chats.js";
 import { githubEntityChatMappings } from "../db/schema/github-entity-chat-mappings.js";
 import { inboxEntries } from "../db/schema/inbox-entries.js";
 import { messages } from "../db/schema/messages.js";
-import type { AudienceTarget } from "../services/github-audience.js";
+import { type AudienceTarget, resolveAudience } from "../services/github-audience.js";
 import { deliverNormalizedEvent } from "../services/github-delivery.js";
 import { createTestAdmin, useTestApp } from "./helpers.js";
 
@@ -117,6 +117,7 @@ describe("deliverNormalizedEvent", () => {
       chatId,
       involveReason: null,
       involveLogin: null,
+      actorAgentId: null,
     };
     const event = makeEvent({
       orgId: admin.organizationId,
@@ -186,6 +187,7 @@ describe("deliverNormalizedEvent", () => {
       chatId,
       involveReason: null,
       involveLogin: null,
+      actorAgentId: null,
     };
     const event = makeEvent({
       orgId: admin.organizationId,
@@ -250,6 +252,7 @@ describe("deliverNormalizedEvent", () => {
       chatId,
       involveReason: null,
       involveLogin: null,
+      actorAgentId: null,
     };
     const event = makeEvent({
       orgId: admin.organizationId,
@@ -304,6 +307,7 @@ describe("deliverNormalizedEvent", () => {
       chatId,
       involveReason: null,
       involveLogin: null,
+      actorAgentId: null,
     };
     const event = makeEvent({
       orgId: admin.organizationId,
@@ -372,6 +376,7 @@ describe("deliverNormalizedEvent", () => {
       chatId,
       involveReason: null,
       involveLogin: null,
+      actorAgentId: null,
     };
     const event = makeEvent({
       orgId: admin.organizationId,
@@ -416,6 +421,7 @@ describe("deliverNormalizedEvent", () => {
       chatId,
       involveReason: null,
       involveLogin: null,
+      actorAgentId: null,
     };
     const event = makeEvent({
       orgId: admin.organizationId,
@@ -451,6 +457,7 @@ describe("deliverNormalizedEvent", () => {
       chatId: null,
       involveReason: "review_requested",
       involveLogin: humanName.toLowerCase(),
+      actorAgentId: null,
     };
     const event = makeEvent({
       orgId: admin.organizationId,
@@ -525,6 +532,7 @@ describe("deliverNormalizedEvent", () => {
       chatId: null, // forces the runtime guard to throw
       involveReason: null,
       involveLogin: null,
+      actorAgentId: null,
     };
     const ok: AudienceTarget = {
       humanAgentId: goodHuman,
@@ -533,6 +541,7 @@ describe("deliverNormalizedEvent", () => {
       chatId: goodChatId,
       involveReason: null,
       involveLogin: null,
+      actorAgentId: null,
     };
     const event = makeEvent({
       orgId: admin.organizationId,
@@ -600,6 +609,7 @@ describe("deliverNormalizedEvent", () => {
       chatId,
       involveReason: null,
       involveLogin: null,
+      actorAgentId: null,
     };
     const event = makeEvent({
       orgId: admin.organizationId,
@@ -629,5 +639,225 @@ describe("deliverNormalizedEvent", () => {
     // Other group speakers stay silent (history-only) — exactly the
     // mention-only behaviour for unaddressed participants.
     expect(watcherRow?.notify).toBe(false);
+  });
+
+  // #942 — echo suppression moved from the chat-delivery layer to the
+  // notification layer. The card is always written to the mapped chat (the
+  // public record); only the actor's own notification is suppressed.
+  describe("echo suppression (#942)", () => {
+    type Seeded = {
+      orgId: string;
+      human: string;
+      delegate: string;
+      others: string[];
+      chatId: string;
+      entityKey: string;
+      inboxOf: (agentId: string) => Promise<string | undefined>;
+    };
+
+    async function seedBoundGroupChat(app: App, otherCount: number): Promise<Seeded> {
+      const admin = await createTestAdmin(app);
+      const delegate = await seedAgent(app, {
+        orgId: admin.organizationId,
+        memberId: admin.memberId,
+        name: `dlg-${randomUUID().slice(0, 6)}`,
+      });
+      const human = await seedAgent(app, {
+        orgId: admin.organizationId,
+        memberId: admin.memberId,
+        name: `human-${randomUUID().slice(0, 6)}`,
+        delegateMention: delegate,
+      });
+      const others: string[] = [];
+      for (let i = 0; i < otherCount; i++) {
+        others.push(
+          await seedAgent(app, {
+            orgId: admin.organizationId,
+            memberId: admin.memberId,
+            name: `member-${i}-${randomUUID().slice(0, 6)}`,
+          }),
+        );
+      }
+      const chatId = `chat_${randomUUID()}`;
+      const entityKey = `owner/repo#${Math.floor(Math.random() * 100000)}`;
+      await app.db.insert(chats).values({ id: chatId, organizationId: admin.organizationId, type: "group" });
+      await app.db.insert(chatMembership).values([
+        { chatId, agentId: human, role: "owner" as const, accessMode: "speaker" as const },
+        { chatId, agentId: delegate, role: "member" as const, accessMode: "speaker" as const },
+        ...others.map((agentId) => ({
+          chatId,
+          agentId,
+          role: "member" as const,
+          accessMode: "speaker" as const,
+        })),
+      ]);
+      await app.db.insert(githubEntityChatMappings).values({
+        organizationId: admin.organizationId,
+        humanAgentId: human,
+        delegateAgentId: delegate,
+        entityType: "pull_request",
+        entityKey,
+        chatId,
+        boundVia: "agent_created",
+      });
+      const inboxOf = async (agentId: string): Promise<string | undefined> => {
+        const [row] = await app.db
+          .select({ inboxId: agents.inboxId })
+          .from(agents)
+          .where(eq(agents.uuid, agentId))
+          .limit(1);
+        return row?.inboxId;
+      };
+      return { orgId: admin.organizationId, human, delegate, others, chatId, entityKey, inboxOf };
+    }
+
+    it("actor on the human side: card written, delegate still woken, actor (sender) gets no inbox row", async () => {
+      const app = getApp();
+      const s = await seedBoundGroupChat(app, 2);
+
+      const target: AudienceTarget = {
+        humanAgentId: s.human,
+        delegateAgentId: s.delegate,
+        kind: "existing",
+        chatId: s.chatId,
+        involveReason: null,
+        involveLogin: null,
+        actorAgentId: s.human,
+      };
+      const event = makeEvent({
+        orgId: s.orgId,
+        entityType: "pull_request",
+        entityKey: s.entityKey,
+        rawEventType: "pull_request_review",
+        rawAction: "submitted",
+      });
+      const stats = await deliverNormalizedEvent(app, event, [target]);
+      expect(stats).toEqual({ delivered: 1, newChats: 0, failed: 0 });
+
+      // Card is the public record — it must land in the chat.
+      const sent = await app.db.select().from(messages).where(eq(messages.chatId, s.chatId));
+      expect(sent).toHaveLength(1);
+      expect(sent[0]?.format).toBe("card");
+
+      const rows = await app.db.select().from(inboxEntries).where(eq(inboxEntries.chatId, s.chatId));
+      // Actor (= card sender) is never self-delivered: no inbox row at all.
+      const humanInbox = await s.inboxOf(s.human);
+      expect(rows.filter((r) => r.inboxId === humanInbox)).toHaveLength(0);
+      // The other side of the actor's own audience pair is notified normally.
+      const delegateInbox = await s.inboxOf(s.delegate);
+      expect(rows.find((r) => r.inboxId === delegateInbox)?.notify).toBe(true);
+      // Remaining participants receive the card as silent context.
+      for (const other of s.others) {
+        const otherInbox = await s.inboxOf(other);
+        expect(rows.find((r) => r.inboxId === otherInbox)?.notify).toBe(false);
+      }
+    });
+
+    it("actor on the delegate side: card written recipientless, nobody woken (the staging merge case)", async () => {
+      const app = getApp();
+      const s = await seedBoundGroupChat(app, 2);
+
+      const target: AudienceTarget = {
+        humanAgentId: s.human,
+        delegateAgentId: s.delegate,
+        kind: "existing",
+        chatId: s.chatId,
+        involveReason: null,
+        involveLogin: null,
+        actorAgentId: s.delegate,
+      };
+      const event = makeEvent({
+        orgId: s.orgId,
+        entityType: "pull_request",
+        entityKey: s.entityKey,
+        rawEventType: "pull_request",
+        rawAction: "closed",
+      });
+      const stats = await deliverNormalizedEvent(app, event, [target]);
+      expect(stats).toEqual({ delivered: 1, newChats: 0, failed: 0 });
+
+      // Card still lands — pre-#942 this entire delivery was suppressed and
+      // the multi-participant chat silently lost the event.
+      const sent = await app.db.select().from(messages).where(eq(messages.chatId, s.chatId));
+      expect(sent).toHaveLength(1);
+
+      // The actor's addressing was emptied → recipientless trusted send:
+      // every fan-out row (including the actor's) is silent context.
+      const notified = await app.db
+        .select()
+        .from(inboxEntries)
+        .where(and(eq(inboxEntries.chatId, s.chatId), eq(inboxEntries.notify, true)));
+      expect(notified).toHaveLength(0);
+      const actorInbox = await s.inboxOf(s.delegate);
+      const rows = await app.db.select().from(inboxEntries).where(eq(inboxEntries.chatId, s.chatId));
+      expect(rows.find((r) => r.inboxId === actorInbox)?.notify).toBe(false);
+    });
+
+    it("actor not in any participant pair (external actor): behaviour unchanged, delegate woken", async () => {
+      const app = getApp();
+      const s = await seedBoundGroupChat(app, 1);
+
+      const target: AudienceTarget = {
+        humanAgentId: s.human,
+        delegateAgentId: s.delegate,
+        kind: "existing",
+        chatId: s.chatId,
+        involveReason: null,
+        involveLogin: null,
+        actorAgentId: null,
+      };
+      const event = makeEvent({
+        orgId: s.orgId,
+        entityType: "pull_request",
+        entityKey: s.entityKey,
+        rawEventType: "pull_request",
+        rawAction: "synchronize",
+      });
+      const stats = await deliverNormalizedEvent(app, event, [target]);
+      expect(stats).toEqual({ delivered: 1, newChats: 0, failed: 0 });
+
+      const delegateInbox = await s.inboxOf(s.delegate);
+      const rows = await app.db.select().from(inboxEntries).where(eq(inboxEntries.chatId, s.chatId));
+      expect(rows.find((r) => r.inboxId === delegateInbox)?.notify).toBe(true);
+    });
+
+    it("end-to-end (resolveAudience → deliver): actor-on-pair event still reaches the multi-participant chat", async () => {
+      // Replays the #942 staging topology: a 4+-member chat whose ONLY
+      // routing entry is (human, delegate), and the event actor resolves to
+      // one side of that pair. Pre-#942 resolveAudience returned [] and the
+      // chat lost the card entirely.
+      const app = getApp();
+      const s = await seedBoundGroupChat(app, 2);
+      const [delegateRow] = await app.db
+        .select({ name: agents.name })
+        .from(agents)
+        .where(eq(agents.uuid, s.delegate))
+        .limit(1);
+
+      const event: NormalizedEvent = {
+        ...makeEvent({
+          orgId: s.orgId,
+          entityType: "pull_request",
+          entityKey: s.entityKey,
+          rawEventType: "pull_request",
+          rawAction: "closed",
+        }),
+        actor: { githubLogin: delegateRow?.name ?? "", isBot: false },
+        kind: "merged",
+      };
+      const audience = await resolveAudience(app.db, event, "first-tree");
+      expect(audience).toHaveLength(1);
+      expect(audience[0]?.actorAgentId).toBe(s.delegate);
+
+      const stats = await deliverNormalizedEvent(app, event, audience);
+      expect(stats).toEqual({ delivered: 1, newChats: 0, failed: 0 });
+      const sent = await app.db.select().from(messages).where(eq(messages.chatId, s.chatId));
+      expect(sent).toHaveLength(1);
+      const notified = await app.db
+        .select()
+        .from(inboxEntries)
+        .where(and(eq(inboxEntries.chatId, s.chatId), eq(inboxEntries.notify, true)));
+      expect(notified).toHaveLength(0);
+    });
   });
 });

--- a/packages/server/src/services/github-audience.ts
+++ b/packages/server/src/services/github-audience.ts
@@ -34,8 +34,11 @@ export function evaluateDelegateTarget(
  * event). Three buckets:
  *
  *   - `agent`         — actor.login maps to one of this org's agents. Used
- *                       for echo suppression: the agent's own actions don't
- *                       fan back into their own chat.
+ *                       for echo suppression at the notification layer: the
+ *                       card still lands in every mapped chat (the public
+ *                       record of what happened), but the actor is excluded
+ *                       from the notify/addressing fan-out so agents aren't
+ *                       woken by their own actions. See #942.
  *   - `our-app-bot`   — actor is `<app-slug>[bot]`. The event is a downstream
  *                       effect of First Tree's own outbound write. `kind: "existing"`
  *                       targets are kept (so PRs the agent opens via First Tree's
@@ -90,6 +93,15 @@ export type AudienceTarget = {
    * mentioned" because two involves shared the same reason.
    */
   involveLogin: string | null;
+  /**
+   * Set when the event's actor resolves to an org agent (`identifyActor`
+   * returned `kind: "agent"`). Stage 3 excludes this id from the card's
+   * notification addressing (`addressedToAgentIds`) so the actor is never
+   * woken / red-dotted by their own action, while the card itself still
+   * lands in the chat as the public record (#942). `null` for our-app-bot
+   * and external actors.
+   */
+  actorAgentId: string | null;
 };
 
 /**
@@ -104,9 +116,14 @@ export type AudienceTarget = {
  * already subscribed, appends a `new` row.
  *
  * Echo filtering runs after the union:
- *   - actor = `agent`: rows where the actor sits on either the human or
- *     delegate side of an `existing` mapping are dropped. `kind: "new"`
- *     mention rows are kept (explicit involves are intentional routing).
+ *   - actor = `agent`: no row is dropped — every mapped chat keeps the card
+ *     as the public record of what happened. Instead, each row is annotated
+ *     with `actorAgentId` so Stage 3 excludes the actor from notification
+ *     addressing (the actor isn't woken / red-dotted by their own action,
+ *     other recipients are notified normally). Dropping rows here used to
+ *     conflate "should this chat get the card" with "should this recipient
+ *     be notified" and silently killed delivery to multi-participant chats
+ *     whose only routing entry had the actor on one side (#942).
  *   - actor = `our-app-bot`: `kind: "existing"` rows are kept so follow-up
  *     events on entities the agent opened still reach the chat through the
  *     subscription path; `kind: "new"` rows are dropped to avoid forking a
@@ -185,6 +202,7 @@ export async function resolveAudience(
     chatId: row.chatId,
     involveReason: null,
     involveLogin: null,
+    actorAgentId: null,
   }));
 
   // Dedup involved candidates by `humanAgentId` only — once any (human, *,
@@ -253,6 +271,7 @@ export async function resolveAudience(
         chatId: null,
         involveReason: reason,
         involveLogin: candidateLogin,
+        actorAgentId: null,
       });
     }
   }
@@ -271,17 +290,23 @@ export async function resolveAudience(
     return audience.filter((a) => a.kind === "existing");
   }
   if (actor.kind === "agent") {
-    // Echo suppression applies to subscribed rows only: a row where the
-    // actor is on either side of an existing mapping shouldn't fan back
-    // into their chat (they already know about the action they just took).
-    // `kind: "new"` rows come from explicit involves in the event payload
-    // (mention / review_request / assign) — the actor deliberately named
-    // that login, so even a self-target is intentional routing, not echo.
-    // Dropping them would regress the human-self-mention pattern that used
-    // to work under the pre-#345 mention-driven webhook.
-    return audience.filter(
-      (a) => a.kind === "new" || (a.humanAgentId !== actor.agentId && a.delegateAgentId !== actor.agentId),
-    );
+    // Echo suppression is a *notification* concern, not a delivery one
+    // (#942). Every mapped chat keeps its card — the chat row is the public
+    // record of what happened, and other participants of a multi-member
+    // chat legitimately want to see it. The actor's id is annotated onto
+    // every target so Stage 3 (`deliverNormalizedEvent`) excludes it from
+    // `addressedToAgentIds`: the actor is never woken / red-dotted by their
+    // own action, while everyone else (including the other side of the
+    // actor's own audience pair) is notified normally. A 1:1 chat where the
+    // actor is the sole addressable recipient reduces naturally to "card
+    // visible, nobody woken" via the existing `allowRecipientlessSend`
+    // trusted opt-out.
+    //
+    // The previous implementation dropped `kind: "existing"` rows whose
+    // human or delegate side matched the actor. When such a row was the
+    // chat's only routing entry, that silently killed delivery to the
+    // entire chat — multi-participant chats lost the event altogether.
+    return audience.map((a) => ({ ...a, actorAgentId: actor.agentId }));
   }
   return audience;
 }

--- a/packages/server/src/services/github-delivery.ts
+++ b/packages/server/src/services/github-delivery.ts
@@ -94,6 +94,15 @@ export async function deliverNormalizedEvent(
       // and the multi-speaker fan-out collapses to notify=false for
       // everyone. Same pattern as any system-routed delivery (see
       // SendMessageOptions `addressedToAgentIds`).
+      //
+      // Echo suppression (#942): when the event's actor resolved to an org
+      // agent, exclude it from the addressing — nobody is woken /
+      // red-dotted by their own action. The card itself is still written
+      // (public record); when the exclusion empties the addressing this
+      // reduces to the recipientless trusted send below. The actor on the
+      // *human* side needs no exclusion here: it is the card's senderId and
+      // the message fan-out never self-delivers.
+      const addressedToAgentIds = [target.delegateAgentId].filter((id) => id !== target.actorAgentId);
       const { message, recipients } = await sendMessage(
         app.db,
         resolved.chatId,
@@ -121,7 +130,7 @@ export async function deliverNormalizedEvent(
           },
         },
         {
-          addressedToAgentIds: [target.delegateAgentId],
+          addressedToAgentIds,
           // Opt in to writing `metadata.systemSender` — the message service
           // strips that key from every other caller (web / agent SDK POST)
           // so HTTP boundaries cannot impersonate the GitHub sender in the
@@ -130,8 +139,10 @@ export async function deliverNormalizedEvent(
           // Opt out of the default explicit-recipient guard. This trusted
           // system delivery owns and validates its own addressing
           // (`addressedToAgentIds` derived from the resolved audience row),
-          // but the delegate may not be a speaker of the bound chat on some
-          // events, so the addressing resolves to no live recipient. Such a
+          // but on some events the addressing resolves to no live recipient:
+          // the delegate may not be a speaker of the bound chat, or the
+          // delegate IS the event's actor and was excluded by echo
+          // suppression (#942, the empty-filter case above). Such a
           // card is still a valid history/context row for human observers;
           // without this opt-out the default guard would make this trusted path
           // start throwing. (A delegate that IS a speaker but suspended/deleted


### PR DESCRIPTION
Closes #942.

## Goal

GitHub event cards stopped appearing in a multi-participant chat after a
certain event. Root cause (per #942): the audience filter in
`github-audience.ts` dropped any `(human, delegate) → chat` audience entry
where the event's **actor** equalled either side of the pair. When that
entry was a chat's *only* routing key, the whole chat silently lost the
card — even though other participants legitimately wanted to see it.

The filter's intent ("don't notify yourself about your own action") is
correct; the **layer** was wrong. It answered a publication question
("should this chat get the card?") as a proxy for a notification question
("should this recipient be woken?").

## Core change

Move echo-suppression from the **delivery** layer to the **notification**
layer:

- **`github-audience.ts`** — `resolveAudience` no longer drops rows for an
  `agent` actor. Every mapped chat keeps its card (the public record).
  Each surviving row is annotated with a new `actorAgentId` field on
  `AudienceTarget` (additive, in-memory only — no DB/schema change).
- **`github-delivery.ts`** — Stage 3 derives
  `addressedToAgentIds = [delegateAgentId].filter(id => id !== actorAgentId)`.
  The actor is excluded from the card's notification addressing, so it is
  never woken / red-dotted by its own action; everyone else is notified
  normally. When the actor *is* the sole addressable delegate, the
  addressing empties and the send reduces to the existing
  `allowRecipientlessSend` trusted path — card visible, nobody woken.
  The actor on the *human* side needs no exclusion: it is the card's
  `senderId` and the message fan-out never self-delivers.

Behaviour for `our-app-bot` and external actors is unchanged.

## Tests

Regression coverage added for all three #942 scenarios plus an
end-to-end `resolveAudience → deliver` replay of the staging topology
(4+-member chat whose only routing entry has the actor on one side):

- actor on the human side → card written, delegate woken, actor (sender) gets no inbox row
- actor on the delegate side → card written recipientless, nobody woken
- external actor → behaviour unchanged, delegate woken

Existing audience tests updated to assert the keep-and-annotate behaviour
that replaced the drop behaviour.

## Verification

Local regression run by the QA agent on this diff replayed onto current
`origin/main`: focused suite (35 cases), server typecheck, full server
suite (1363 tests), `pnpm build`, and CLI post-bundle unit rerun — all
green. (Final PASS/FAIL authority is the PR's own CI.)

## Notes for reviewers

- No DB / schema migration. The only data-structure change is the additive
  `actorAgentId: string | null` field on the in-memory `AudienceTarget`.
- A companion Context-Tree update to
  `system/cloud/github/github-entity-chat-binding.md` (a new decision row
  alongside B3) is being raised separately with the node owners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)