### PR TITLE
fix(web): pin chats with an open request in "Needs attention"

### DIFF
--- a/packages/web/src/pages/workspace/__tests__/group-rows.test.ts
+++ b/packages/web/src/pages/workspace/__tests__/group-rows.test.ts
@@ -170,11 +170,12 @@ describe("groupRows — source", () => {
   });
 });
 
-// Phase 1 chat-granularity predicate.
-// R1 (mine-failed via failedAgentIds), R2 (explicit @<me> in unread window via
-// chatHasExplicitMentionToMe + unreadMentionCount > 0). See
-// docs/development/needs-attention-scoping.20260526.md.
-describe("splitAttentionRows — Phase 1 predicate", () => {
+// Chat-granularity predicate.
+// R1 (mine-failed via failedAgentIds), R2 (open question directed at me via
+// openRequestCount > 0 — ANSWER-cleared, so reading the chat does not unpin),
+// R3 (explicit @<me> in unread window via chatHasExplicitMentionToMe +
+// unreadMentionCount > 0). See the rule ladder in group-rows.ts.
+describe("splitAttentionRows — predicate", () => {
   it("R1: mine-failed → attention bucket, failed tier", () => {
     const rows = [row({ id: "r1", lastMessageAt: null, failedAgentIds: ["mine"] })];
     const { attention } = splitAttentionRows(rows);
@@ -182,7 +183,40 @@ describe("splitAttentionRows — Phase 1 predicate", () => {
     expect(attention[0] && rowIsFailed(attention[0])).toBe(true);
   });
 
-  it("R2: unread + explicit @<me> → attention bucket, mention tier", () => {
+  it("R2: open request, no unread → attention bucket, request tier", () => {
+    // The core scenario: a `--question` chat the human has already READ but
+    // not answered. `unreadMentionCount` is 0 (read-cleared), yet the open
+    // request keeps the row pinned — it must not leave "Needs attention"
+    // until the question is answered or closed.
+    const rows = [
+      row({
+        id: "r2-open",
+        lastMessageAt: null,
+        openRequestCount: 1,
+        unreadMentionCount: 0,
+        chatHasExplicitMentionToMe: false,
+      }),
+    ];
+    const { attention } = splitAttentionRows(rows);
+    expect(attention.map((r) => r.chatId)).toEqual(["r2-open"]);
+    expect(attention[0] && rowAttentionReason(attention[0])).toBe("request");
+  });
+
+  it("R2 cleared: request answered (count back to 0) → NOT attention", () => {
+    const rows = [
+      row({
+        id: "r2-answered",
+        lastMessageAt: null,
+        openRequestCount: 0,
+        unreadMentionCount: 0,
+      }),
+    ];
+    const { attention, rest } = splitAttentionRows(rows);
+    expect(attention).toEqual([]);
+    expect(rest.map((r) => r.chatId)).toEqual(["r2-answered"]);
+  });
+
+  it("R3: unread + explicit @<me> → attention bucket, mention tier", () => {
     const rows = [
       row({
         id: "r2",
@@ -196,7 +230,7 @@ describe("splitAttentionRows — Phase 1 predicate", () => {
     expect(attention[0] && rowAttentionReason(attention[0])).toBe("mention");
   });
 
-  it("R2 disabled by 1-on-1 implicit auto-mention: unreadMentionCount > 0 but flag false → NOT attention", () => {
+  it("R3 disabled by 1-on-1 implicit auto-mention: unreadMentionCount > 0 but flag false → NOT attention", () => {
     // The original痛点 (t7): in a 1v1, agent → human plain "ack" bumps the
     // v1 red-dot counter but `metadata.mentions` is empty, so the server
     // emits `chatHasExplicitMentionToMe: false`. The front-end must NOT
@@ -221,13 +255,31 @@ describe("splitAttentionRows — Phase 1 predicate", () => {
     expect(rest.map((r) => r.chatId)).toEqual(["quiet"]);
   });
 
-  it("priority: failed > mention across two tiers", () => {
+  it("priority: failed > request > mention across three tiers", () => {
     const rows = [
       row({ id: "m", lastMessageAt: null, unreadMentionCount: 1, chatHasExplicitMentionToMe: true }),
+      row({ id: "q", lastMessageAt: null, openRequestCount: 1 }),
       row({ id: "f", lastMessageAt: null, failedAgentIds: ["y"] }),
     ];
     const { attention } = splitAttentionRows(rows);
-    expect(attention.map((r) => r.chatId)).toEqual(["f", "m"]);
+    expect(attention.map((r) => r.chatId)).toEqual(["f", "q", "m"]);
+  });
+
+  it("priority: request beats mention on the same row", () => {
+    // A fresh `--question` is typically also an unread explicit mention —
+    // the row sorts under the request tier, and stays pinned (as `request`)
+    // after the mention half is read away.
+    const rows = [
+      row({
+        id: "qm",
+        lastMessageAt: null,
+        openRequestCount: 1,
+        unreadMentionCount: 1,
+        chatHasExplicitMentionToMe: true,
+      }),
+    ];
+    const { attention } = splitAttentionRows(rows);
+    expect(attention[0] && rowAttentionReason(attention[0])).toBe("request");
   });
 
   it("priority: failed beats mention on the same row", () => {
@@ -278,7 +330,7 @@ describe("splitAttentionRows — Phase 1 predicate", () => {
 // an old server returns "off" for that rule instead of trusting a `&&`
 // coercion of an unknown shape.
 describe("splitAttentionRows — version skew (old server, new web)", () => {
-  it("missing chatHasExplicitMentionToMe (undefined) → R2 disabled", () => {
+  it("missing chatHasExplicitMentionToMe (undefined) → R3 disabled", () => {
     const stale = {
       ...row({ id: "stale", lastMessageAt: null, unreadMentionCount: 1 }),
     };
@@ -286,6 +338,18 @@ describe("splitAttentionRows — version skew (old server, new web)", () => {
     const { attention, rest } = splitAttentionRows([stale]);
     expect(attention).toEqual([]);
     expect(rest.map((r) => r.chatId)).toEqual(["stale"]);
+  });
+
+  it("missing openRequestCount (undefined) → R2 disabled", () => {
+    // `undefined > 0` is `false` — an old server build that predates the
+    // field degrades the request rule to "off" rather than mispinning.
+    const stale = {
+      ...row({ id: "stale-r2", lastMessageAt: null }),
+    };
+    delete (stale as { openRequestCount?: number }).openRequestCount;
+    const { attention, rest } = splitAttentionRows([stale]);
+    expect(attention).toEqual([]);
+    expect(rest.map((r) => r.chatId)).toEqual(["stale-r2"]);
   });
 
   it("missing field still lets R1 (failedAgentIds) fire", () => {

--- a/packages/web/src/pages/workspace/conversations/group-rows.ts
+++ b/packages/web/src/pages/workspace/conversations/group-rows.ts
@@ -144,7 +144,7 @@ function groupBySource(rows: ReadonlyArray<MeChatRow>): ReadonlyArray<GroupBucke
 }
 
 // ---------------------------------------------------------------------------
-// attention pinning (failed + mention)
+// attention pinning (failed + request + mention)
 // ---------------------------------------------------------------------------
 //
 // Chat-granularity predicate — see docs/development/needs-attention-scoping.20260526.md.
@@ -155,7 +155,16 @@ function groupBySource(rows: ReadonlyArray<MeChatRow>): ReadonlyArray<GroupBucke
 //         narrows `failedAgentIds` to `agents.manager_id = caller` so a
 //         peer's broken agent never pins my row.
 //
-//   R2. `unreadMentionCount > 0 && chatHasExplicitMentionToMe === true`
+//   R2. `openRequestCount > 0`
+//       — An agent raised a structured question (`format=request`) at me
+//         that I have not answered/closed yet. The counter is
+//         ANSWER-cleared, not read-cleared (`chat_user_state.
+//         open_request_count` only decrements on `--answer` / `--close`
+//         or a clean web-UI answer), so merely opening the chat does NOT
+//         drop the row out of the attention bucket — the asking agent is
+//         still blocked on me until I actually resolve the question.
+//
+//   R3. `unreadMentionCount > 0 && chatHasExplicitMentionToMe === true`
 //       — I have unread, and at least one unread message explicitly
 //         `@<me>`-mentions me (server checks `messages.metadata.mentions`
 //         in the unread window). Distinguishes explicit `@<me>` from the
@@ -163,9 +172,13 @@ function groupBySource(rows: ReadonlyArray<MeChatRow>): ReadonlyArray<GroupBucke
 //         dmAutoProjection`), which still bumps `unreadMentionCount` for
 //         the red dot but never writes the recipient into
 //         `metadata.mentions` — so an agent's plain `"ack"` to me in a DM
-//         correctly stays out of attention.
+//         correctly stays out of attention. Read-cleared — which is why
+//         an open request needs its own rule (R2) instead of riding on
+//         this one.
 //
-// Sort priority: `failed > mention`.
+// Sort priority: `failed > request > mention`. An open question outranks a
+// plain mention because the asker is explicitly blocked waiting on the
+// caller; both yield to `failed` (broken agent needs recovery first).
 //
 // This ladder is INTENTIONALLY separate from the shared agent-status
 // `compareMainStatus` (`failed`, `working`, ...). `mention` is a chat-level
@@ -178,7 +191,7 @@ function groupBySource(rows: ReadonlyArray<MeChatRow>): ReadonlyArray<GroupBucke
 // silently degrade the rule to "off" under strict equality (safer
 // direction).
 
-const ATTENTION_PRIORITY = ["failed", "mention"] as const;
+const ATTENTION_PRIORITY = ["failed", "request", "mention"] as const;
 type AttentionReason = (typeof ATTENTION_PRIORITY)[number];
 
 /**
@@ -188,6 +201,11 @@ type AttentionReason = (typeof ATTENTION_PRIORITY)[number];
  */
 export function rowAttentionReason(r: MeChatRow): AttentionReason | null {
   if (r.failedAgentIds.length > 0) return "failed";
+  // `> 0` is skew-safe without an explicit guard: an older server build
+  // that predates `openRequestCount` yields `undefined`, and
+  // `undefined > 0` is `false` — the rule degrades to "off", same safe
+  // direction as the `=== true` boolean checks above.
+  if (r.openRequestCount > 0) return "request";
   if (r.unreadMentionCount > 0 && r.chatHasExplicitMentionToMe === true) {
     return "mention";
   }

--- a/packages/web/src/pages/workspace/conversations/index.tsx
+++ b/packages/web/src/pages/workspace/conversations/index.tsx
@@ -243,11 +243,11 @@ export function ConversationList({
   // (e.g. an inactive tab the browser throttles) won't see the bucket
   // shift until the next refetch lands; that's an acceptable degree
   // of staleness for a presentational concern.
-  // Hoist attention chats (failed + mention) into a pinned section at the top
-  // WITHOUT touching cursor pagination or reordering the main list: partition
-  // them out, group the rest as usual, then prepend a synthetic "Needs
-  // attention" bucket (failed pinned above mention). A chat appears in
-  // exactly one place (pinned OR its normal group), never both.
+  // Hoist attention chats (failed + open request + mention) into a pinned
+  // section at the top WITHOUT touching cursor pagination or reordering the
+  // main list: partition them out, group the rest as usual, then prepend a
+  // synthetic "Needs attention" bucket (failed > request > mention). A chat
+  // appears in exactly one place (pinned OR its normal group), never both.
   const buckets = useMemo(() => {
     const { attention, rest } = splitAttentionRows(allRows);
     if (attention.length === 0) return groupRows(allRows, group);


### PR DESCRIPTION
## 目标 / What

修复 "Needs attention" 列表中**未答的结构化提问（`--request`）在被已读后掉出 attention bucket** 的 bug。一个 `--request` 提问发给我后，只要我还没 `--answer`/`--close`，该聊天就应继续钉在 "Needs attention" —— 读一下不算解决。

之前的 attention 谓词只有两条：R1 `failedAgentIds`（mine-failed）、mention 规则（`unreadMentionCount > 0 && chatHasExplicitMentionToMe`）。mention 是 **read-cleared** 的，所以一个新 `--request` 通常也是 unread mention，被读掉后 `unreadMentionCount` 归 0，整行就静默掉出了 attention —— 而问题其实还没答。

## 核心改动 / How

在 `rowAttentionReason` 谓词中新增一条规则，复用已存在的服务端计数 `openRequestCount`（`chat_user_state.open_request_count`）：

- **新规则** `openRequestCount > 0 → "request"`
- **优先级** `failed > request > mention` —— open question 优先于普通 mention（asker 明确被我 block），但都让位于 `failed`（坏 agent 先恢复）

关键在于 `open_request_count` 是 **answer-cleared，不是 read-cleared**：服务端只在 send-path 维护它（`format=request` 时 +1，仅在显式 `metadata.resolves` answer/close 时 −1），读聊天完全不动这个计数。所以新规则下，打开/已读聊天不再让行掉出 attention，直到问题被真正解决。

## 范围与安全 / Scope & safety

- **纯前端 presentational 改动**，无数据结构 / DB 变更：`openRequestCount` 字段早已全链路打通（DB schema → `me-chat.ts` projection → shared Zod schema → web avatar `needsYou` badge 已在用），本 PR 只是把它接进 list 的 attention bucket。
- **Skew 安全**：旧 server 若不带该字段，`undefined > 0 === false`，规则退化为 off，与现有 `=== true` 布尔检查同一安全方向。新增 skew 测试覆盖。
- 与 Context Tree 中已记录的决策一致（`system/cloud/chat/workspace-conversations.md`：*"open requests … cleared by explicit resolution … never by mere discussion replies"*），属 implementation-only 落地，无需 tree 写入。

## 验证 / Verification

- `group-rows.test.ts` 26 tests PASS（新增 R2 命中、R2 answered-cleared、request>mention 同行、skew undefined 等用例）
- `tsc --noEmit` exit 0
- QA agent 已完成本地回归 PASS（桌面/移动打开并 read 后仍留在 Needs attention；显式 answer 后 `open_request_count=0` 且移出）

🤖 Generated with [Claude Code](https://claude.com/claude-code)