### PR TITLE
docs: clarify update channel env deprecation

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -246,7 +246,7 @@ CLI user-facing / CLI internal / build) lives in the design doc:
 | `FIRST_TREE_HUB_JSON` | `FIRST_TREE_JSON` | JSON output mode (equivalent to `--json`). |
 | `FIRST_TREE_HUB_SERVER_URL` | `FIRST_TREE_SERVER_URL` | Per-call server URL override. |
 | `FIRST_TREE_HUB_LOG_LEVEL` | `FIRST_TREE_LOG_LEVEL` | Logger level. |
-| `FIRST_TREE_HUB_UPDATE_*` | `FIRST_TREE_UPDATE_*` | Self-update channel / policy / intervals. |
+| `FIRST_TREE_HUB_UPDATE_*` | `FIRST_TREE_UPDATE_*` | Phase 1A self-update settings. The historical update-channel knob is later retired by Phase 2; server channel identity is `FIRST_TREE_CHANNEL`. |
 
 ### 5. Agent runtime envs (CLI injects these; users don't set them)
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -463,9 +463,15 @@ These are mentioned for completeness; operators don't set them in shell rc.
 | Variable | Purpose |
 |---|---|
 | `FIRST_TREE_SERVICE_MODE` | Supervisor → child flag baked into the launchd plist and systemd unit templates. |
-| `FIRST_TREE_COMMAND_VERSION` | CLI build version stamped at package time. |
-| `FIRST_TREE_UPDATE_POLL_INTERVAL_MINUTES` | How often the running daemon polls npm for a newer version. |
-| `FIRST_TREE_UPDATE_REGISTRY_URL` | npm registry override for the update check. |
+
+### CLI / daemon — update behavior
+
+These are client-side update behavior tunables. They do not select a release
+channel; channel identity comes from the installed package / binary
+(`first-tree`, `first-tree-staging`, or `first-tree-dev`).
+
+| Variable | Purpose |
+|---|---|
 | `FIRST_TREE_UPDATE_RESTART_CHECK_INTERVAL_SECONDS` | Frequency of the upgrade-restart watchdog. |
 | `FIRST_TREE_UPDATE_RESTART_QUIET_SECONDS` | Quiet window the upgrade flow waits for before restarting. |
 | `FIRST_TREE_UPDATE_PROMPT_TIMEOUT_SECONDS` | Interactive upgrade prompt timeout. |
@@ -502,6 +508,18 @@ and are not used by the CLI. They are listed here for ops reference.
 | `FIRST_TREE_CORS_ORIGIN` | Allowed origin for the web console. | — |
 | `FIRST_TREE_TRUST_PROXY` | Trust the reverse-proxy `X-Forwarded-*` headers. | `false` |
 | `FIRST_TREE_WORKSPACES_ROOT` | Where agent worktrees are materialised on the host. | derived from `FIRST_TREE_HOME` |
+
+**Command update advertisement:**
+
+There is no `FIRST_TREE_UPDATE_CHANNEL`. Published channels have separate npm
+package identities, and the server polls the package selected by
+`FIRST_TREE_CHANNEL`.
+
+| Variable | Purpose | Default |
+|---|---|---|
+| `FIRST_TREE_COMMAND_VERSION` | Bootstrap CLI version advertised before the npm-registry poller succeeds. The Docker image stamps this from the Command package version at build time. | image build arg |
+| `FIRST_TREE_UPDATE_POLL_INTERVAL_MINUTES` | How often the server polls npm for the selected channel package's `latest` version. | `60` |
+| `FIRST_TREE_UPDATE_REGISTRY_URL` | npm registry override for the server-side update-version poller. | `https://registry.npmjs.org` |
 
 **Secrets:**
 


### PR DESCRIPTION
## Summary
- Clarify that `FIRST_TREE_UPDATE_CHANNEL` is not a live configuration knob.
- Split client-side update behavior envs from server-side command update advertisement envs in the CLI reference.
- Update the migration wildcard note so it does not imply the historical update-channel setting remains valid.

## Validation
- `pnpm check` (passes; reports existing unrelated lint info/warning in `prompt-tab.tsx` and `workspace-migrations.ts`)
- `pnpm typecheck`
- `git diff --check`

## Notes
- No runtime code changed.
- Repo scan confirms `FIRST_TREE_UPDATE_CHANNEL` only appears in deprecation/documentation context; source, CI, Docker, and server config have no active reference.