### PR TITLE
release: bump apps/cli to v0.5.6

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "first-tree-dev",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "type": "module",
   "description": "First Tree — unified CLI for Context Tree onboarding, agent management, and team messaging. (Source-tree dev build; CI rewrites `name` and `bin` for prod / staging publishes — see docs/local-dev-isolation.md.)",
   "keywords": [


### PR DESCRIPTION
## Summary

- Bump `apps/cli` from `0.5.5` to `0.5.6` for the next stable release.
- Keep the source package identity as `first-tree-dev`; production package identity is still rewritten only by CI trusted publishing.

## Draft GitHub Release

Title: `v0.5.6 — Chat requests, Context Tree read skill, release hardening`

## Draft Release Notes

### Highlights

- Chat requests now have explicit open-question resolution, chat descriptions paired with topics, and Needs attention keeps open requests pinned.
- Agents now operate on the chat-send-only contract and include the new `first-tree-read` skill for scoped Context Tree reads.
- Onboarding and Context Tree setup recover better when admins skipped connecting code, with clearer invitee and team copy.

### Notable fixes

- Require explicit production server secrets and remove the retired Feishu/Kael adapter subsystem.
- Lower the published Node engine floor to `>=22.13.0` to match resolver-enforced dependencies.
- Degrade GitMirrorAuthError as a source-repo checkout condition, restore composer footer toolbar clicks, and guard prompt edits from pasted assembled briefings.

## Preflight

- `npm view first-tree version` -> `0.5.5`
- `npm view first-tree-staging version` -> `0.5.6-staging.330.1`
- `git ls-remote --tags origin refs/tags/v0.5.6` -> no tag
- `gh release view v0.5.6` -> release not found
- `npm view first-tree@0.5.6 version` -> 404 / not published
- Latest `origin/main` before branching: `d21cee12edc393ed1a681c5e799e3d815b714608`

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm check` (passes; Biome reported existing info/warning only)
- `pnpm typecheck`

## Post-Merge Release Steps

1. Wait for the merge commit's main-branch GitHub Actions to finish. At minimum, `CI` must pass; also check `npm Publish` and `Docker` for the same SHA when they run.
2. Confirm the final release coordinates before tagging: version `0.5.6`, tag `v0.5.6`, target merge commit SHA, release title, and release body.
3. Create the GitHub Release `v0.5.6` targeting the confirmed merge commit so trusted publishing publishes `first-tree@0.5.6`.
4. Verify the tag-triggered `npm Publish` run, `npm view first-tree version`, GitHub Release, and Docker image tag `ghcr.io/agent-team-foundation/first-tree:0.5.6`.
