### PR TITLE
fix: surface Codex usage-limit empty turns

### DIFF
--- a/packages/client/src/__tests__/codex-usage-limit.test.ts
+++ b/packages/client/src/__tests__/codex-usage-limit.test.ts
@@ -1,0 +1,289 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { SessionEvent } from "@first-tree/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChatContext } from "../runtime/chat-context.js";
+import type { SessionContext, SessionMessage } from "../runtime/handler.js";
+import { mockCtxPlumbing } from "./test-helpers.js";
+
+/**
+ * Issue #971 — codex usage-limit silent failure.
+ *
+ * When the codex account usage limit is exhausted the SDK emits
+ * `turn.completed` almost instantly with NO agent_message and ZERO token
+ * consumption (the model is never invoked). Before the fix that looked
+ * identical to the legitimate "silent turn" protocol, so the runtime acked
+ * the message as a phantom success: no chat reply, no error, no log.
+ *
+ * The handler now discriminates on the per-turn token delta:
+ *   - zero delta + empty reply + turn.completed  => usage-limit empty turn
+ *     => emit an `error` event, log a warn line, and post a chat notice.
+ *   - non-zero delta + empty reply               => a chosen silence (the
+ *     model ran), left untouched (no false positive).
+ *
+ * These drive the real `runTurn` state machine through a mock Codex SDK whose
+ * per-turn event script is set by each test.
+ */
+
+type MockState = {
+  runInputs: unknown[];
+  turns: unknown[][];
+};
+
+const state = vi.hoisted<MockState>(() => ({
+  runInputs: [],
+  turns: [],
+}));
+
+vi.mock("@openai/codex-sdk", () => {
+  const thread = {
+    id: "thread-usage-limit",
+    async runStreamed(input: unknown) {
+      state.runInputs.push(input);
+      const idx = state.runInputs.length - 1;
+      const events = state.turns[idx] ?? [];
+      return {
+        events: (async function* () {
+          yield { type: "thread.started", thread_id: "thread-usage-limit" };
+          for (const event of events) yield event;
+        })(),
+      };
+    },
+  };
+
+  return {
+    Codex: class {
+      startThread() {
+        return thread;
+      }
+      resumeThread() {
+        return thread;
+      }
+    },
+  };
+});
+
+vi.mock("../runtime/bootstrap.js", () => ({
+  FIRST_TREE_RUNTIME_DIR: ".first-tree-workspace",
+  FIRST_TREE_WORKSPACE_MARKER: ".first-tree-workspace",
+  bootstrapWorkspace: vi.fn(),
+  deepEqualIdentity: vi.fn(() => true),
+  ensureWorkspaceRuntimeDir: vi.fn((workspacePath: string) => {
+    const dir = join(workspacePath, ".first-tree-workspace");
+    mkdirSync(dir, { recursive: true });
+    return dir;
+  }),
+  installCoreSkills: vi.fn(),
+  installFirstTreeIntegration: vi.fn(() => true),
+  isHubWorktreeMarker: vi.fn(() => false),
+  readCachedBundledCliVersion: vi.fn(() => null),
+  readCachedContextTreeHead: vi.fn(() => null),
+  readContextTreeHead: vi.fn(() => null),
+  resolveBundledCliVersion: vi.fn(() => "0.0.0-test"),
+  writeAgentBriefing: vi.fn(),
+  writeBundledCliVersion: vi.fn(),
+  writeContextTreeHead: vi.fn(),
+}));
+
+vi.mock("../runtime/chat-context.js", () => ({
+  fetchChatContext: vi.fn(async (): Promise<ChatContext> => {
+    return {
+      chatId: "chat-usage-limit",
+      title: "usage limit",
+      topic: null,
+      description: null,
+      participants: [],
+    };
+  }),
+}));
+
+import { createCodexHandler } from "../handlers/codex.js";
+
+const AGENT_ID = "019e71c9-88d2-70be-be67-fdb033b2ef0b";
+
+let workspaceRoot: string;
+
+type SendMessageMock = ReturnType<typeof vi.fn<(chatId: string, body: Record<string, unknown>) => Promise<unknown>>>;
+
+function makeMessage(id: string, content: string): SessionMessage {
+  return {
+    id,
+    chatId: "chat-usage-limit",
+    senderId: "sender-1",
+    format: "text",
+    content,
+    metadata: {},
+  };
+}
+
+function makeContext(
+  markCompleted: (count?: number) => void,
+  opts: {
+    sendMessage?: SendMessageMock;
+    emitEvent?: SessionContext["emitEvent"];
+    log?: SessionContext["log"];
+  } = {},
+): SessionContext {
+  const sendMessage =
+    opts.sendMessage ??
+    vi.fn<(chatId: string, body: Record<string, unknown>) => Promise<unknown>>().mockResolvedValue(undefined);
+  return {
+    agent: {
+      agentId: AGENT_ID,
+      inboxId: `inbox_${AGENT_ID}`,
+      displayName: "codex-assistant",
+      type: "agent",
+      visibility: "organization",
+      delegateMention: null,
+      metadata: {},
+    },
+    sdk: { serverUrl: "http://test", sendMessage } as unknown as SessionContext["sdk"],
+    chatId: "chat-usage-limit",
+    log: opts.log ?? (() => {}),
+    touch: () => {},
+    setRuntimeState: () => {},
+    emitEvent: opts.emitEvent ?? (() => {}),
+    ...mockCtxPlumbing({ sendMessage }, "chat-usage-limit"),
+    markCompleted,
+    markMessagesCompleted: (messages) => markCompleted(Array.isArray(messages) ? messages.length : 1),
+  };
+}
+
+const zeroUsage = { input_tokens: 0, cached_input_tokens: 0, output_tokens: 0, reasoning_output_tokens: 0 };
+
+beforeEach(() => {
+  workspaceRoot = mkdtempSync(join(tmpdir(), "ft-codex-usage-limit-"));
+  state.runInputs.length = 0;
+  state.turns = [];
+});
+
+afterEach(() => {
+  rmSync(workspaceRoot, { recursive: true, force: true });
+});
+
+describe("codex usage-limit empty-turn (issue #971)", () => {
+  it("surfaces a chat notice + error event when the turn completes with no reply and zero token delta", async () => {
+    // turn.completed with zero usage and NO agent_message — the model was
+    // never invoked (account usage limit exhausted).
+    state.turns = [[{ type: "turn.completed", usage: zeroUsage }]];
+
+    const completedCounts: Array<number | undefined> = [];
+    const logs: string[] = [];
+    const sendMessage = vi
+      .fn<(chatId: string, body: Record<string, unknown>) => Promise<unknown>>()
+      .mockResolvedValue(undefined);
+    const emitEvent = vi.fn<(event: SessionEvent) => void>();
+    const handler = createCodexHandler({ workspaceRoot });
+    const ctx = makeContext((count) => completedCounts.push(count), {
+      sendMessage,
+      emitEvent,
+      log: (message) => logs.push(message),
+    });
+
+    await handler.start(makeMessage("m1", "hello"), ctx);
+
+    const events = emitEvent.mock.calls.map(([event]) => event);
+
+    // Layer 1-A: a chat-visible notice is posted (via the forwardResult /
+    // agent-final-text path → sendMessage in this harness).
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(String(sendMessage.mock.calls[0]?.[1].content)).toContain("usage limit");
+
+    // Layer 2: an `error` event is emitted (daemon log + admin stream), and a
+    // warn-style log line is recorded — not a phantom success.
+    const errorEvents = events.filter((event) => event.kind === "error");
+    expect(
+      errorEvents.some(
+        (event) => event.kind === "error" && event.payload.message.includes("codex usage limit reached"),
+      ),
+    ).toBe(true);
+    expect(logs.some((line) => line.includes("codex usage limit reached"))).toBe(true);
+
+    // turn_end is reported as an error, never as success.
+    expect(events.some((event) => event.kind === "turn_end" && event.payload.status === "error")).toBe(true);
+    expect(events.some((event) => event.kind === "turn_end" && event.payload.status === "success")).toBe(false);
+
+    // MVP scope: the message is still acked (no auto-redelivery). The user
+    // resends manually once the limit resets.
+    expect(completedCounts).toEqual([1]);
+
+    await handler.shutdown();
+  });
+
+  it("does NOT flag a legitimate silent turn (model ran, burned tokens, chose to stay silent)", async () => {
+    // turn.completed with NON-zero usage and NO agent_message — the model ran
+    // and the agent deliberately produced no reply (silent-turn protocol).
+    state.turns = [
+      [
+        {
+          type: "turn.completed",
+          usage: { input_tokens: 120, cached_input_tokens: 10, output_tokens: 0, reasoning_output_tokens: 4 },
+        },
+      ],
+    ];
+
+    const completedCounts: Array<number | undefined> = [];
+    const logs: string[] = [];
+    const sendMessage = vi
+      .fn<(chatId: string, body: Record<string, unknown>) => Promise<unknown>>()
+      .mockResolvedValue(undefined);
+    const emitEvent = vi.fn<(event: SessionEvent) => void>();
+    const handler = createCodexHandler({ workspaceRoot });
+    const ctx = makeContext((count) => completedCounts.push(count), {
+      sendMessage,
+      emitEvent,
+      log: (message) => logs.push(message),
+    });
+
+    await handler.start(makeMessage("m1", "hello"), ctx);
+
+    const events = emitEvent.mock.calls.map(([event]) => event);
+
+    // No notice, no usage-limit error/log — a chosen silence is left alone.
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(
+      events.some((event) => event.kind === "error" && event.payload.message.includes("codex usage limit reached")),
+    ).toBe(false);
+    expect(logs.some((line) => line.includes("codex usage limit reached"))).toBe(false);
+
+    // A silent turn is a success (the agent's explicit signal of "nothing to add").
+    expect(events.some((event) => event.kind === "turn_end" && event.payload.status === "success")).toBe(true);
+    expect(completedCounts).toEqual([1]);
+
+    await handler.shutdown();
+  });
+
+  it("forwards a normal reply unchanged and reports success (no false trigger when text is produced)", async () => {
+    state.turns = [
+      [
+        { type: "item.completed", item: { type: "agent_message", text: "here is your answer" } },
+        {
+          type: "turn.completed",
+          usage: { input_tokens: 200, cached_input_tokens: 0, output_tokens: 40, reasoning_output_tokens: 0 },
+        },
+      ],
+    ];
+
+    const completedCounts: Array<number | undefined> = [];
+    const sendMessage = vi
+      .fn<(chatId: string, body: Record<string, unknown>) => Promise<unknown>>()
+      .mockResolvedValue(undefined);
+    const emitEvent = vi.fn<(event: SessionEvent) => void>();
+    const handler = createCodexHandler({ workspaceRoot });
+    const ctx = makeContext((count) => completedCounts.push(count), { sendMessage, emitEvent });
+
+    await handler.start(makeMessage("m1", "hello"), ctx);
+
+    const events = emitEvent.mock.calls.map(([event]) => event);
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage.mock.calls[0]?.[1].content).toBe("here is your answer");
+    expect(
+      events.some((event) => event.kind === "error" && event.payload.message.includes("codex usage limit reached")),
+    ).toBe(false);
+    expect(events.some((event) => event.kind === "turn_end" && event.payload.status === "success")).toBe(true);
+    expect(completedCounts).toEqual([1]);
+
+    await handler.shutdown();
+  });
+});

--- a/packages/client/src/handlers/codex.ts
+++ b/packages/client/src/handlers/codex.ts
@@ -72,6 +72,19 @@ const RETRY_BASE_MS = 500;
 const RETRY_MULTIPLIER = 3;
 
 /**
+ * Chat-visible notice posted when a turn is detected as a usage-limit empty
+ * turn (issue #971 — codex account usage limit exhausted: the SDK reports
+ * `turn.completed` with no reply and zero token consumption, i.e. the model
+ * was never invoked). Delivered via the agent-final-text path, so it is
+ * authored as the agent itself — hence first person. We deliberately do NOT
+ * include an ETA: codex-sdk@0.134 does not expose `rate_limits.resets_at`,
+ * so there is no reliable recovery time to quote.
+ */
+const USAGE_LIMIT_NOTICE =
+  "⚠️ My runtime has reached its usage limit, so I couldn't process the message you just sent. " +
+  "Please resend it once the limit resets.";
+
+/**
  * Concurrent-write detection window for the per-chat AGENTS.md briefing.
  *
  * Codex CLI reads AGENTS.md once at thread startup; the handler rewrites it
@@ -905,26 +918,13 @@ export const createCodexHandler: HandlerFactory = (config) => {
     // chat message.
     const accumulated = finalResponse;
 
-    let forwardFailed = false;
-    if (!turnFailed && accumulated.trim()) {
-      try {
-        await sessionCtx.forwardResult(accumulated);
-      } catch (err) {
-        forwardFailed = true;
-        const msg = err instanceof Error ? err.message : String(err);
-        sessionCtx.emitEvent({
-          kind: "error",
-          payload: { source: "runtime", message: `forwardResult failed: ${msg}` },
-        });
-      }
-    }
-
-    const succeeded = !turnFailed && !forwardFailed;
     // Codex reports CUMULATIVE thread usage on `turn.completed`; convert it to
-    // the per-turn delta the `token_usage` schema documents before emitting.
-    // `usageBox.value` is null when the turn never reached `turn.completed`
-    // (abort / unrecoverable failure) — no totals to diff, so leave the
-    // baseline untouched and skip both the emit and the log below.
+    // the per-turn delta the `token_usage` schema documents. Computed here
+    // (before the forward decision) because the usage-limit empty-turn check
+    // below reads the delta. `usageBox.value` is null when the turn never
+    // reached `turn.completed` (abort / unrecoverable failure) — no totals to
+    // diff, so leave the baseline untouched and skip both the emit and the log
+    // below.
     const cumulativeUsage = usageBox.value;
     const perTurnUsage = cumulativeUsage
       ? computePerTurnUsageDelta(cumulativeUsage, prevCumulativeUsage, threadIsFresh)
@@ -937,6 +937,78 @@ export const createCodexHandler: HandlerFactory = (config) => {
       prevCumulativeUsage = cumulativeUsage;
       threadIsFresh = false;
     }
+
+    // Issue #971 — usage-limit empty-turn detection. When the codex account
+    // usage limit is exhausted, the SDK emits `turn.completed` almost instantly
+    // with NO agent_message item and ZERO token consumption: the model was
+    // never invoked. On the surface that is identical to the legitimate
+    // "silent turn" protocol (the agent chose to stay silent — see
+    // result-sink.ts forwardResult), with ONE discriminator: a chosen silence
+    // still ran the model and so burned input tokens, whereas a usage-limit
+    // turn burns zero. So `empty finalResponse + turn.completed fired + zero
+    // per-turn delta` means the model never ran (quota / credits exhausted),
+    // and we surface it rather than ack it away as a phantom success.
+    //
+    // `perTurnUsage === null` is the cold-resume first turn (no baseline to
+    // diff) — we cannot decide there, so we do NOT flag it (avoids false
+    // positives) and let it fall through to the normal path.
+    const zeroTokenDelta =
+      perTurnUsage !== null &&
+      perTurnUsage.input_tokens === 0 &&
+      perTurnUsage.cached_input_tokens === 0 &&
+      perTurnUsage.output_tokens === 0 &&
+      perTurnUsage.reasoning_output_tokens === 0;
+    const usageLimitEmptyTurn = !turnFailed && accumulated.trim().length === 0 && zeroTokenDelta;
+
+    let forwardFailed = false;
+    if (usageLimitEmptyTurn) {
+      // Layer 2 (observability): emit an error event + warn-level log so the
+      // daemon log and admin event stream record a real failure instead of a
+      // phantom `turn_end: success`. Mirrors the existing `turnFailed`
+      // treatment — runtime state still goes `idle` below so a later message
+      // can retry once the limit resets. We do NOT auto-redeliver THIS message
+      // (markMessagesCompleted still runs below); auto-redelivery is tracked
+      // separately (see #971 discussion) because it needs a reset-aware
+      // trigger + loop guard that the SDK's missing `rate_limits` can't supply.
+      sessionCtx.emitEvent({
+        kind: "error",
+        payload: {
+          source: "runtime",
+          message:
+            "codex usage limit reached: turn completed with no model invocation (empty reply, zero token delta); message not processed",
+        },
+      });
+      sessionCtx.log(
+        `codex usage limit reached chatId=${sessionCtx.chatId}: empty turn, model not invoked (zero token delta); ` +
+          "posting a chat notice instead of silently acking the message",
+      );
+      // Layer 1-A (visibility): post a chat-visible notice via the
+      // agent-final-text path (forwardResult → notify=false, bypasses the
+      // group @mention guard) so a human observer sees WHY their message got
+      // no reply, rather than having to dig through codex rollout files.
+      try {
+        await sessionCtx.forwardResult(USAGE_LIMIT_NOTICE);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        sessionCtx.emitEvent({
+          kind: "error",
+          payload: { source: "runtime", message: `usage-limit notice delivery failed: ${msg}` },
+        });
+      }
+    } else if (!turnFailed && accumulated.trim()) {
+      try {
+        await sessionCtx.forwardResult(accumulated);
+      } catch (err) {
+        forwardFailed = true;
+        const msg = err instanceof Error ? err.message : String(err);
+        sessionCtx.emitEvent({
+          kind: "error",
+          payload: { source: "runtime", message: `forwardResult failed: ${msg}` },
+        });
+      }
+    }
+
+    const succeeded = !turnFailed && !forwardFailed && !usageLimitEmptyTurn;
 
     // Emit `token_usage` just before `turn_end` so the wire-order matches the
     // claude-code handler (consumers can group all usage events for a turn


### PR DESCRIPTION
## Summary

Fixes #971.

When Codex hits a usage limit, the SDK can return a completed turn with no agent message and no token delta. The client runtime previously treated that as a legitimate silent turn, ACKed the message, and produced no user-visible signal.

This PR detects that zero-token empty-turn case in the Codex handler and surfaces it instead of silently succeeding:

- emits a runtime error and warning log
- closes the turn with `turn_end:error`
- writes a chat-visible system-style notice through the existing final-text path
- still ACKs the consumed message, preserving the MVP behavior agreed in the issue thread

It also guards against false positives for legitimate silent turns with non-zero usage and cold resume turns without a usage baseline.

## Verification

Local pre-PR check in `/Users/yuezengwu/.first-tree-staging/data/workspaces/yzw-codex/worktrees/fix-971-codex-usage-limit`:

- `pnpm --dir packages/client exec vitest run src/__tests__/codex-usage-limit.test.ts src/__tests__/codex-resilience.test.ts src/__tests__/codex-retry-abort.test.ts src/__tests__/codex-inject-startup-race.test.ts` → 4 files / 29 tests passed
- `pnpm exec biome check packages/client/src/handlers/codex.ts packages/client/src/__tests__/codex-usage-limit.test.ts` → passed
- `git diff --check origin/main...HEAD` → passed

Formal QA regression was also completed by @qa with PASS: focused Codex tests, full `@first-tree/client` suite, client typecheck, monorepo typecheck, touched-file Biome, and diff whitespace checks all passed. Report: `/Users/yuezengwu/.first-tree-staging/data/workspaces/qa/qa-reports/issue-971-codex-usage-limit-regression-20260611.md`