### PR TITLE
fix(client): redact URL userinfo in empty-username + bare-token forms

### DIFF
--- a/packages/client/src/__tests__/redact-error-preview.test.ts
+++ b/packages/client/src/__tests__/redact-error-preview.test.ts
@@ -57,6 +57,45 @@ describe("redactErrorPreview — secret patterns are sanitised", () => {
     expect(redactErrorPreview("redis://default:redis_pwd_99@cache:6379/0")).not.toContain("redis_pwd_99");
   });
 
+  it("scrubs URL userinfo in the empty-username and bare-token forms (PR #975 follow-up gap)", () => {
+    // Codex's round-3 probe on PR #975 d30e8926 caught the previous
+    // `([^\s:@/]+):([^\s@/]+)@` regex requiring BOTH username and password
+    // to be non-empty with a colon between them. Two real-world userinfo
+    // shapes slipped through:
+    //
+    //  (a) Empty username — common in DB connection strings, e.g.
+    //      `redis://:redis_pwd_99@cache:6379/0`
+    //      `postgres://:secret_pg_99@db:5432/main`
+    //  (b) Single-component bare token — common for OAuth-token-in-URL:
+    //      `https://oauth-token-AbCd1234@github.com/owner/repo`
+    //
+    // Both must be redacted. `.not.toContain(<actual credential>)` is the
+    // load-bearing assertion — substring checks on `[REDACTED]` alone
+    // would pass through a "scheme + [REDACTED] + leftover credential"
+    // partial redaction (the same false-confidence mode that hid the
+    // round-2 Authorization Basic leak).
+    const emptyUserRedis = redactErrorPreview("redis connect failed: redis://:redis_pwd_99@cache:6379/0");
+    expect(emptyUserRedis).not.toContain("redis_pwd_99");
+    expect(emptyUserRedis).toContain("redis://[REDACTED]@cache:6379/0");
+
+    const emptyUserPg = redactErrorPreview("dial timeout postgres://:secret_pg_99@db:5432/main");
+    expect(emptyUserPg).not.toContain("secret_pg_99");
+    expect(emptyUserPg).toContain("postgres://[REDACTED]@db:5432/main");
+
+    const bareTokenGitHub = redactErrorPreview(
+      "git fetch failed: https://oauth-token-AbCd1234@github.com/owner/repo.git",
+    );
+    expect(bareTokenGitHub).not.toContain("oauth-token-AbCd1234");
+    expect(bareTokenGitHub).toContain("https://[REDACTED]@github.com/owner/repo.git");
+
+    // Regression guard: the standard `user:pass` form (the round-1 case)
+    // still works through the collapsed single-blob userinfo regex.
+    const standard = redactErrorPreview("https://liu:ghp_AbCdEf0123456789abcdef0123456789abcd@github.com/x.git");
+    expect(standard).not.toContain("ghp_AbCdEf0123456789abcdef0123456789abcd");
+    expect(standard).not.toContain("liu:ghp_");
+    expect(standard).toContain("https://[REDACTED]@github.com/x.git");
+  });
+
   it("scrubs vendor-prefixed tokens that appear bare (not inside a URL)", () => {
     expect(redactErrorPreview("X-GitHub-Token: ghp_AbCdEf0123456789abcdef0123456789abcd")).toMatch(/\[REDACTED:ghp\]/);
     expect(redactErrorPreview("hint: server-to-server token ghs_AbCdEf0123456789abcdef0123456789abcd")).toMatch(

--- a/packages/client/src/runtime/redact-error-preview.ts
+++ b/packages/client/src/runtime/redact-error-preview.ts
@@ -34,12 +34,15 @@ const DEFAULT_MAX_LEN = 256;
  *
  * Pattern coverage (all checked independently):
  *
- *  1. URL-embedded basic auth — `<scheme>://user:pass@host/...` for ANY
+ *  1. URL-embedded userinfo — `<scheme>://<userinfo>@host/...` for ANY
  *     RFC-3986 scheme (https / ssh / git / postgres / mysql / mongodb+srv /
- *     redis / amqp / …). `git clone <url>` echoes the configured URL into
- *     the resulting `GitMirrorError` message, so a PAT-bearing
- *     `remote.origin.url` lands here verbatim — but so does any database
- *     connection string an SDK happens to log on failure.
+ *     redis / amqp / …). Userinfo is redacted as a single blob (`user:pass`,
+ *     `:pass` empty-username form common to redis / postgres, and the bare
+ *     `<token>` single-component form like `https://oauth-token@github.com/x`
+ *     all collapse to `<scheme>://[REDACTED]@host`). `git clone <url>` echoes
+ *     the configured URL into the resulting `GitMirrorError` message, so a
+ *     PAT-bearing `remote.origin.url` lands here verbatim — but so does any
+ *     database connection string an SDK happens to log on failure.
  *  2. Standard token prefixes that are unambiguously credentials:
  *       - GitHub: `ghp_*`, `ghs_*`, `gho_*`, `ghu_*`, `ghr_*` (refresh
  *         token), `github_pat_*`
@@ -64,11 +67,21 @@ export function redactErrorPreview(input: string, maxLen: number = DEFAULT_MAX_L
   if (!input) return input;
   let s = input;
 
-  // 1. URL-embedded basic auth — any RFC-3986 scheme. Keeps host + path so
+  // 1. URL-embedded userinfo — any RFC-3986 scheme. Keeps host + path so
   //    the operator can still tell which resource failed. Bounded scheme
   //    length (1–31 chars after the leading letter) keeps the match cheap
   //    and unambiguous: an arbitrary `word://` is rare outside actual URIs.
-  s = s.replace(/\b([a-z][a-z0-9+.\-]{0,30}:\/\/)([^\s:@/]+):([^\s@/]+)@/gi, "$1[REDACTED]@");
+  //
+  //    Userinfo is matched as a single blob (`[^\s@/]+`) rather than a
+  //    `user:pass` pair so the three real-world forms collapse uniformly:
+  //      a. `user:pass`                — standard
+  //      b. `:pass`                    — empty-username (redis / postgres)
+  //      c. `<token>` (no colon)      — single-component (`https://<PAT>@…`)
+  //    The previous `([^\s:@/]+):([^\s@/]+)` required both halves to be
+  //    non-empty and a colon between them, which let (b) and (c) slip
+  //    through with credentials intact — caught by Codex on PR #975's
+  //    `d30e8926` and now pinned by negative-toContain regression tests.
+  s = s.replace(/\b([a-z][a-z0-9+.\-]{0,30}:\/\/)[^\s@/]+@/gi, "$1[REDACTED]@");
 
   // 2. Vendor-prefixed token shapes. Order matters: longest / most-specific
   //    first so we don't half-redact a `github_pat_…` to a `gh…` shape.
@@ -84,6 +97,14 @@ export function redactErrorPreview(input: string, maxLen: number = DEFAULT_MAX_L
   // OpenAI / Anthropic `sk-…` family. The vendor segment (`-ant-`, `-proj-`,
   // a service codename) is OPTIONAL: the older bare `sk-<longstring>` shape
   // is still in the wild and the new helper should catch it.
+  //
+  // Widening trade-off (intentional, per the over-redact bias): with the
+  // vendor segment optional, prose like `task-sk-something-that-is-long-
+  // enough-prose` ALSO matches and collapses to `task-[REDACTED:sk]`. That
+  // false-positive shape (a `sk-` followed by 20+ chars of `[A-Za-z0-9_-]`
+  // with no whitespace / punctuation) is genuinely rare in ordinary error
+  // logs, so the recall on legacy bare-`sk-` tokens wins. Flagged by
+  // code-reviewer on PR #975 round-2 for documentation purposes.
   s = s.replace(/\bsk-(?:(?:ant|proj|[a-z]{2,12})-)?[A-Za-z0-9_-]{20,}/g, "[REDACTED:sk]");
   s = s.replace(/\bxox[abprs]-[A-Za-z0-9-]{10,}/g, "[REDACTED:xox]");
 


### PR DESCRIPTION
## Summary

Follow-up to #975. Codex's round-3 probe on `d30e8926` caught the previous URL basic-auth regex (`([^\s:@/]+):([^\s@/]+)@`) requiring BOTH username and password to be non-empty with a colon between them. Two real-world userinfo shapes slipped through and could ride into chat-visible session events on any handler that logs a connection string or a tokenised remote URL — defeating the boundary helper that #975 introduced for exactly these shapes.

**Forms that previously slipped through:**

- **(a) Empty username** — standard for DB / queue connection strings:
  ```
  redis://:redis_pwd_99@cache:6379/0     ← UNCHANGED, leaked
  postgres://:secret_pg_99@db:5432/main  ← UNCHANGED, leaked
  ```
- **(b) Single-component bare token** — common OAuth-token-in-URL form:
  ```
  https://oauth-token-AbCd1234@github.com/owner/repo  ← UNCHANGED, leaked
  ```

## Fix

Collapse to a single-blob userinfo match — `[^\s@/]+@` — so the three userinfo forms all redact uniformly to `<scheme>://[REDACTED]@host`. The greedy match is bounded by `@` (excluded from the class), so a real URL with `@` later in the query (e.g. `?q=foo@bar`) won't over-match; the path's first `/` also terminates the userinfo class, so a `@` in path / query is safe.

Also folds in the **`sk-` widening doc note** from code-reviewer's round-2 review on #975 — the legacy bare-`sk-` recall is intentional, and the trade-off (`task-sk-<long-dashed-word>` prose may over-match) is now called out in the helper header so a future contributor doesn't "tighten" it away unintentionally.

## Test plan

- [x] `pnpm --filter @first-tree/client test` — **1194/1194 passed** (+1 over the post-merge baseline of 1193).
- [x] New dedicated case `scrubs URL userinfo in the empty-username and bare-token forms (PR #975 follow-up gap)` in `redact-error-preview.test.ts`, asserting all three userinfo shapes redact + a regression guard that the standard `user:pass` form still works under the collapsed pattern. `.not.toContain(<actual credential>)` is the load-bearing form (same as the round-2 Authorization-Basic guard).
- [x] `pnpm check` / `pnpm typecheck`: clean (only the pre-existing `MigrationOutcome` warning, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)