### PR TITLE
fix(server): preserve literal unicode escapes in session events

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,7 +127,7 @@ SDK methods live in `sdk.ts`, handlers register in `handlers/`, runtime changes 
 ### Git Conventions
 
 - **Branching**: trunk-based; feature branch → PR → squash merge → main
-- **Branch naming**: `feat/xxx`, `fix/xxx`, `refactor/xxx`, `test/xxx`, `docs/xxx`, `chore/xxx`
+- **Branch naming**: CI accepts only `feat/xxx`, `fix/xxx`, `refactor/xxx`, `test/xxx`, `docs/xxx`, `chore/xxx`, or `merge/xxx`. Do not use agent/person prefixes such as `codex/xxx`.
 - **Commit messages**: Conventional Commits — `feat: xxx`, `fix: xxx`, `refactor: xxx`, `test: xxx`, `docs: xxx`
 - **Releases**: tag + GitHub Release
 - **Do not edit `version` fields in any `package.json`.** Version bumps are handled by CI on tag push, or manually by a maintainer cutting a tag. Coding agents must not touch `version` as part of a feature/fix PR.

--- a/packages/server/src/__tests__/session-event.test.ts
+++ b/packages/server/src/__tests__/session-event.test.ts
@@ -148,6 +148,33 @@ describe("sessionEventService", () => {
     expect(payload.args.command).toBe("echo ");
   });
 
+  it("preserves literal unicode escape text in tool_call payload strings", async () => {
+    const app = getApp();
+    const a = agentId();
+    const c = chatId();
+    const sourcePreview = 'if (s.includes("\\u0000")) return true;';
+
+    const persisted = await sessionEventService.appendEvent(app.db, a, c, {
+      kind: "tool_call",
+      payload: {
+        toolUseId: "tu-source-preview",
+        name: "Bash",
+        args: { command: `git show file.ts | grep '${sourcePreview}'` },
+        status: "ok",
+        durationMs: 5,
+        resultPreview: sourcePreview,
+      },
+    });
+
+    expect(persisted.seq).toBe(1);
+    const payload = persisted.payload as {
+      resultPreview?: string;
+      args: { command: string };
+    };
+    expect(payload.resultPreview).toBe(sourcePreview);
+    expect(payload.args.command).toContain(sourcePreview);
+  });
+
   it("listEvents paginates by seq asc", async () => {
     const app = getApp();
     const a = agentId();

--- a/packages/server/src/services/session-event.ts
+++ b/packages/server/src/services/session-event.ts
@@ -46,6 +46,28 @@ type AppendEventOptions = {
   deferSideEffects?: boolean;
 };
 
+const NUL_CHAR = "\u0000";
+
+function stripNulFromJsonbValue(value: unknown): unknown {
+  if (typeof value === "string") return value.replaceAll(NUL_CHAR, "");
+  if (Array.isArray(value)) return value.map(stripNulFromJsonbValue);
+  if (value === null || typeof value !== "object") return value;
+
+  const sanitized: Record<string, unknown> = {};
+  for (const [key, nested] of Object.entries(value)) {
+    sanitized[key.replaceAll(NUL_CHAR, "")] = stripNulFromJsonbValue(nested);
+  }
+  return sanitized;
+}
+
+function stringifyJsonbPayload(payload: SessionEvent["payload"]): string {
+  const json = JSON.stringify(stripNulFromJsonbValue(payload));
+  if (json === undefined) {
+    throw new Error("session event payload could not be serialized");
+  }
+  return json;
+}
+
 function rowToEvent(row: {
   id: string;
   agentId: string;
@@ -97,14 +119,10 @@ export async function appendEvent(
       await new Promise((r) => setTimeout(r, Math.random() * RETRY_JITTER_MS));
     }
     const id = uuidv7();
-    // PG JSONB rejects U+0000 outright. Strip the escaped sequence from the
-    // serialized JSON so a binary preview (e.g. ZIP bytes from
-    // `gh api .../actions/runs/<id>/logs` reaching us through a tool stdout)
-    // does not nuke the whole event. The client already replaces obvious
-    // binary previews with a placeholder; this is the last-mile gate for any
-    // path the client sanitizer does not cover (future handlers, other
-    // free-form string fields).
-    const payloadJson = JSON.stringify(validated.payload).replaceAll("\\u0000", "");
+    // PG JSONB rejects U+0000 outright. Strip the actual NUL characters before
+    // serializing so ordinary text containing the literal sequence `\u0000`
+    // (for example source code previews) remains valid and unchanged.
+    const payloadJson = stringifyJsonbPayload(validated.payload);
     const result = await db.execute<{
       id: string;
       agent_id: string;


### PR DESCRIPTION
## Summary
- sanitize actual NUL characters in session event payloads before JSON serialization
- preserve literal `\\u0000` text in tool result previews, such as source-code snippets
- add regression coverage for literal unicode escape text in `tool_call` payload strings
- clarify the agent branch naming rule in `AGENTS.md` so agent-created branches use CI-accepted prefixes

## Testing
- `pnpm --filter @first-tree/server exec vitest run --maxWorkers=2 src/__tests__/session-event.test.ts`
- `pnpm --filter @first-tree/server typecheck`
- `pnpm check` (exit 0; reports existing unrelated Biome hints)
- `pnpm typecheck`
- `git diff --check origin/main...HEAD`