### PR TITLE
feat(web): dock the open question's answer surface onto the composer

### DIFF
--- a/packages/server/src/__tests__/chat-message-post-shape.test.ts
+++ b/packages/server/src/__tests__/chat-message-post-shape.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { createAgent } from "../services/agent.js";
+import { createMeChat } from "../services/me-chat.js";
+import { sendMessage } from "../services/message.js";
+import { createTestAdmin, useTestApp } from "./helpers.js";
+
+/**
+ * Wire-level shape of `POST /api/v1/chats/:chatId/messages` (the web
+ * composer's send route).
+ *
+ * The 201 body must carry the STORED row's `metadata` and `inReplyTo`,
+ * mirroring the GET list shape: the web composer swaps its optimistic cache
+ * row for this response (`replaceOptimisticMessage`), so a body that omits
+ * them strips `metadata.resolves` / `metadata.mentions` / threading from the
+ * cache during the POST-success → refetch window — a just-answered docked
+ * request flips back to open and a threaded reply unthreads (PR 981 review).
+ */
+describe("POST /chats/:chatId/messages — response carries metadata + inReplyTo", () => {
+  const getApp = useTestApp();
+
+  it("echoes resolves metadata, mentions, and inReplyTo on a clean dock answer", async () => {
+    const app = getApp();
+    const alice = await createTestAdmin(app);
+    const peer = await createAgent(app.db, {
+      name: `post-shape-peer-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "Post Shape Peer",
+      managerId: alice.memberId,
+      organizationId: alice.organizationId,
+    });
+    const { chatId } = await createMeChat(app.db, alice.humanAgentUuid, alice.organizationId, {
+      participantIds: [peer.uuid],
+    });
+
+    // The agent raises an open question at the human (service layer — the
+    // HTTP surface under test is the human's answer below).
+    const ask = await sendMessage(app.db, chatId, peer.uuid, {
+      format: "request",
+      content: "Ship it?",
+      metadata: {
+        mentions: [alice.humanAgentUuid],
+        request: { questions: [{ id: "q1", prompt: "Ship it?", kind: "single", options: ["yes", "no"] }] },
+      },
+      source: "api",
+    });
+
+    // The human's clean dock answer: threads under the request and carries
+    // the explicit resolution signal.
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/chats/${encodeURIComponent(chatId)}/messages`,
+      headers: { authorization: `Bearer ${alice.accessToken}` },
+      payload: {
+        format: "text",
+        content: "yes",
+        metadata: {
+          mentions: [peer.uuid],
+          resolves: { request: ask.message.id, kind: "answered" },
+        },
+        inReplyTo: ask.message.id,
+      },
+    });
+    expect(res.statusCode).toBe(201);
+    const body = res.json<Record<string, unknown>>();
+
+    // The fields the web cache swap depends on — must mirror the stored row.
+    expect(body.inReplyTo).toBe(ask.message.id);
+    expect(body.metadata).toMatchObject({
+      mentions: [peer.uuid],
+      resolves: { request: ask.message.id, kind: "answered" },
+    });
+  });
+});

--- a/packages/server/src/api/chats.ts
+++ b/packages/server/src/api/chats.ts
@@ -352,6 +352,14 @@ export async function chatRoutes(app: FastifyInstance): Promise<void> {
       senderId: result.message.senderId,
       format: result.message.format,
       content: result.message.content,
+      // Return the STORED row's metadata + inReplyTo (mirrors the GET list
+      // shape above). The web composer swaps its optimistic row for this
+      // response; omitting these fields stripped `metadata.resolves` /
+      // `metadata.mentions` / threading from the cache row during the
+      // POST-success → refetch window, flipping a just-answered request back
+      // to open and unthreading docked replies.
+      metadata: result.message.metadata,
+      inReplyTo: result.message.inReplyTo,
       source: result.message.source,
       createdAt: result.message.createdAt.toISOString(),
     });

--- a/packages/web/src/api/chats.ts
+++ b/packages/web/src/api/chats.ts
@@ -172,6 +172,7 @@ export function sendFileMessageBatch(
   chatId: string,
   content: SendFileMessageBatchBody,
   metadata?: SendFileMessageMetadata,
+  opts?: { inReplyTo?: string },
 ): Promise<Message> {
   // Project explicit fields rather than spreading `metadata` whole so future
   // additions to SendFileMessageMetadata don't ride out on the `mentions`
@@ -182,6 +183,10 @@ export function sendFileMessageBatch(
     format: "file",
     content,
     ...(hasMentions ? { metadata: { mentions } } : {}),
+    // `inReplyTo` is format-agnostic threading (`sendMessageSchema`) — a
+    // captioned image answering a docked question threads under it just like
+    // a text reply.
+    ...(opts?.inReplyTo ? { inReplyTo: opts.inReplyTo } : {}),
   });
 }
 

--- a/packages/web/src/app.tsx
+++ b/packages/web/src/app.tsx
@@ -64,6 +64,14 @@ const ComposeStatusBarPreviewPage = import.meta.env.DEV
     )
   : null;
 
+const RequestDockPreviewPage = import.meta.env.DEV
+  ? lazy(() =>
+      import("./pages/request-dock-preview.js").then((module) => ({
+        default: module.RequestDockPreviewPage,
+      })),
+    )
+  : null;
+
 const OnboardingPreviewPage = import.meta.env.DEV
   ? lazy(() => import("./pages/onboarding-preview.js").then((module) => ({ default: module.OnboardingPreviewPage })))
   : null;
@@ -138,6 +146,16 @@ export function App() {
                   element={
                     <Suspense fallback={null}>
                       <ComposeStatusBarPreviewPage />
+                    </Suspense>
+                  }
+                />
+              ) : null}
+              {RequestDockPreviewPage ? (
+                <Route
+                  path="/preview/request-dock"
+                  element={
+                    <Suspense fallback={null}>
+                      <RequestDockPreviewPage />
                     </Suspense>
                   }
                 />

--- a/packages/web/src/components/chat/__tests__/request-state.test.ts
+++ b/packages/web/src/components/chat/__tests__/request-state.test.ts
@@ -1,15 +1,19 @@
 import type { Message } from "@first-tree/shared";
 import { describe, expect, it } from "vitest";
 import {
+  allRequiredSelected,
+  buildAnswerDraft,
   contentStartsWithMention,
   defaultExpanded,
   deriveRequestState,
+  findDockableRequest,
   findThreadableRequestId,
   isRelatedViewer,
   parseAnswerSelections,
   readCloseReason,
   readRequestPayload,
   readResolution,
+  recoverAnswerSelections,
 } from "../request-state.js";
 
 const ASKER = "agent-asker";
@@ -179,6 +183,17 @@ describe("parseAnswerSelections", () => {
   it("ignores lines whose prompt is unknown", () => {
     expect(parseAnswerSelections("Other? → x", ["Ship?"])).toEqual({});
   });
+  it("handles a prompt that itself contains ' → ' — prefix matching, not first-separator split", () => {
+    const prompt = "Migrate v1 → v2 now?";
+    expect(parseAnswerSelections(`${prompt} → yes`, [prompt])).toEqual({ [prompt]: "yes" });
+  });
+
+  it("prefers the longest matching prompt when one prompt prefixes another", () => {
+    const short = "Deploy?";
+    const long = "Deploy? → to prod too?";
+    expect(parseAnswerSelections(`${long} → yes`, [short, long])).toEqual({ [long]: "yes" });
+  });
+
   it("returns {} for free-form (non-matching) content", () => {
     expect(parseAnswerSelections("let's just do 5%", ["Ship?"])).toEqual({});
     expect(parseAnswerSelections(42, ["Ship?"])).toEqual({});
@@ -211,5 +226,120 @@ describe("contentStartsWithMention", () => {
   it("is false for non-string content or empty names", () => {
     expect(contentStartsWithMention(42, ["gandy"])).toBe(false);
     expect(contentStartsWithMention("@gandy hi", [])).toBe(false);
+  });
+});
+
+describe("findDockableRequest", () => {
+  it("returns the newest live request directed at the viewer", () => {
+    const older = msg({
+      id: "req-old",
+      format: "request",
+      metadata: { mentions: [TARGET], request: { questions: [{ id: "q1", prompt: "Old?", options: ["a"] }] } },
+    });
+    const thread = [older, request];
+    expect(findDockableRequest(thread, TARGET)?.id).toBe("req");
+  });
+
+  it("skips resolved/closed requests and falls back to an older live one", () => {
+    const resolvedNewer = msg({
+      id: "req-new",
+      format: "request",
+      createdAt: "2026-06-02T01:00:00.000Z",
+      metadata: { mentions: [TARGET], request: { questions: [{ id: "q1", prompt: "New?", options: ["a"] }] } },
+    });
+    const answer = msg({
+      id: "ans",
+      senderId: TARGET,
+      inReplyTo: "req-new",
+      content: "a",
+      metadata: { resolves: { request: "req-new", kind: "answered" } },
+    });
+    expect(findDockableRequest([request, resolvedNewer, answer], TARGET)?.id).toBe("req");
+  });
+
+  it("still docks a DISCUSSING request — threading does not unpin it", () => {
+    const discuss = msg({ id: "d1", senderId: TARGET, inReplyTo: "req", content: "why?" });
+    expect(findDockableRequest([request, discuss], TARGET)?.id).toBe("req");
+  });
+
+  it("returns null for non-target viewers and signed-out viewers", () => {
+    expect(findDockableRequest([request], OTHER)).toBeNull();
+    expect(findDockableRequest([request], null)).toBeNull();
+  });
+});
+
+describe("buildAnswerDraft / allRequiredSelected", () => {
+  const single = {
+    subject: "Deploy",
+    questions: [{ id: "q1", prompt: "Ship?", kind: "single" as const, options: ["yes", "no"], required: true }],
+    allowExtra: false,
+  };
+  const multi = {
+    subject: "Release",
+    questions: [
+      { id: "q1", prompt: "Strategy?", kind: "single" as const, options: ["blue-green", "rolling"], required: true },
+      { id: "q2", prompt: "Window?", kind: "single" as const, options: ["friday", "monday"], required: true },
+    ],
+    allowExtra: false,
+  };
+  const withFree = {
+    subject: "Risk",
+    questions: [{ id: "q1", prompt: "Concerns?", kind: "free" as const, options: [], required: true }],
+    allowExtra: false,
+  };
+
+  it("single question fills just the option text — what you click is what you send", () => {
+    expect(buildAnswerDraft(single, { "Ship?": "yes" })).toBe("yes");
+    expect(buildAnswerDraft(single, {})).toBe("");
+  });
+
+  it("multi question fills canonical prompt → answer lines that parseAnswerSelections reads back", () => {
+    const draft = buildAnswerDraft(multi, { "Strategy?": "blue-green", "Window?": "friday" });
+    expect(draft).toBe("Strategy? → blue-green\nWindow? → friday");
+    expect(parseAnswerSelections(draft, ["Strategy?", "Window?"])).toEqual({
+      "Strategy?": "blue-green",
+      "Window?": "friday",
+    });
+  });
+
+  it("round-trips through recoverAnswerSelections — the derived-selection model's invariant", () => {
+    // chat-view derives selections FROM the draft; a clean draft must
+    // recover the same selections it was built from.
+    const sel = { "Strategy?": "blue-green", "Window?": "friday" };
+    const draft = buildAnswerDraft(multi, sel);
+    expect(recoverAnswerSelections(draft, multi.questions)).toEqual(sel);
+    expect(buildAnswerDraft(multi, recoverAnswerSelections(draft, multi.questions))).toBe(draft);
+  });
+
+  it("allRequiredSelected requires every required single answered; free-text never satisfies it", () => {
+    expect(allRequiredSelected(multi, { "Strategy?": "blue-green" })).toBe(false);
+    expect(allRequiredSelected(multi, { "Strategy?": "blue-green", "Window?": "friday" })).toBe(true);
+    // A required free-text question always routes through agent judgment.
+    expect(allRequiredSelected(withFree, {})).toBe(false);
+  });
+});
+
+describe("recoverAnswerSelections", () => {
+  const questions = [{ id: "q1", prompt: "Ship?", kind: "single" as const, options: ["yes", "no"], required: true }];
+
+  it("parses canonical prompt → answer lines first", () => {
+    expect(recoverAnswerSelections("Ship? → yes", questions)).toEqual({ "Ship?": "yes" });
+  });
+
+  it("accepts the bare option text the dock sends for a one-question request", () => {
+    expect(recoverAnswerSelections("yes", questions)).toEqual({ "Ship?": "yes" });
+  });
+
+  it("returns {} for free-form replies that match nothing", () => {
+    expect(recoverAnswerSelections("let me think about it", questions)).toEqual({});
+    expect(recoverAnswerSelections(42, questions)).toEqual({});
+  });
+
+  it("does not bare-option-match multi-question requests — ambiguous", () => {
+    const multiQ = [
+      { id: "q1", prompt: "A?", kind: "single" as const, options: ["x"], required: true },
+      { id: "q2", prompt: "B?", kind: "single" as const, options: ["x"], required: true },
+    ];
+    expect(recoverAnswerSelections("x", multiQ)).toEqual({});
   });
 });

--- a/packages/web/src/components/chat/request-card.tsx
+++ b/packages/web/src/components/chat/request-card.tsx
@@ -31,11 +31,11 @@ import {
   defaultExpanded,
   deriveRequestState,
   isRelatedViewer,
-  parseAnswerSelections,
   type RequestState,
   readCloseReason,
   readMentions,
   readRequestPayload,
+  recoverAnswerSelections,
 } from "./request-state.js";
 
 type ChipSpec = { label: string; Icon: ComponentType<{ size?: number }>; bg: string; fg: string };
@@ -93,6 +93,7 @@ export function RequestCard({
   bodyShowsTarget = false,
   resolveAgentName,
   onSent,
+  suppressAnswerBlock = false,
 }: {
   message: Message;
   thread: readonly Message[];
@@ -110,6 +111,13 @@ export function RequestCard({
   resolveAgentName: (agentId: string) => string;
   /** Called after a successful answer send so the parent can refresh. */
   onSent?: () => void;
+  /**
+   * True when this request is the one pinned in the composer dock
+   * (`RequestDock`) — the dock owns the answering surface, so the timeline
+   * card drops its inline answer block to keep that surface unique. Header,
+   * body, and the resolved/closed read-only states render unchanged.
+   */
+  suppressAnswerBlock?: boolean;
 }) {
   const state = useMemo(() => deriveRequestState(message, thread), [message, thread]);
   const payload = useMemo(() => readRequestPayload(message.metadata), [message.metadata]);
@@ -145,12 +153,7 @@ export function RequestCard({
         (raw as { kind?: unknown }).kind === "answered"
       );
     });
-    return reply
-      ? parseAnswerSelections(
-          reply.content,
-          payload.questions.map((q) => q.prompt),
-        )
-      : {};
+    return reply ? recoverAnswerSelections(reply.content, payload.questions) : {};
   }, [state, payload, thread, message.id]);
 
   const mut = useMutation({
@@ -270,8 +273,10 @@ export function RequestCard({
 
       {/* state-specific block: `open` keeps interactive card chrome; `resolved`
           / `closed` are read-only and render as plain labeled content — no
-          filled/bordered card (DESIGN.md pillar 5). */}
-      {answerable && payload ? (
+          filled/bordered card (DESIGN.md pillar 5). When the composer dock owns
+          this request (`suppressAnswerBlock`), the inline block is dropped so
+          the answering surface exists exactly once. */}
+      {answerable && payload && !suppressAnswerBlock ? (
         <div
           style={{
             marginTop: "var(--sp-3)",

--- a/packages/web/src/components/chat/request-dock.tsx
+++ b/packages/web/src/components/chat/request-dock.tsx
@@ -1,0 +1,149 @@
+/**
+ * RequestDock — the live open question pinned directly above the composer.
+ *
+ * The `format="request"` message in the timeline carries the long narrative
+ * body; this dock carries ONLY the structured ask (questions + options) so the
+ * thing awaiting the viewer's action stays attached to where they act: the
+ * input box. One send button, one box, one rule:
+ *
+ *   - clicking an option REPLACES the composer draft with the canonical
+ *     answer text (single question → the option itself; several → one
+ *     `"<prompt> → <answer>"` line each);
+ *   - the selection state is DERIVED from the draft (`recoverAnswerSelections`
+ *     in chat-view), so editing the text away from a clean answer drops the
+ *     highlight — and typing the exact option text by hand counts as a clean
+ *     answer (accepted semantics: the draft is the single source of truth);
+ *   - sending a clean answer direct-resolves via `metadata.resolves`
+ *     (`kind="answered"`) — instant red-dot clear;
+ *   - sending any other text is a plain reply routed to the asking agent to
+ *     judge (answer / discuss / close) — the question stays open. While the
+ *     dock is live the asker is the default recipient, so this works without
+ *     a typed @mention even in a group chat.
+ *
+ * The dock pins the single most recent live request directed at the viewer
+ * (see `findDockableRequest`); that request's timeline card suppresses its
+ * inline answer block so the answering surface exists exactly once.
+ *
+ * Design (DESIGN.md): the dock is interactive, so it keeps card chrome
+ * (pillar 5) with the needs-you amber tint the inline answer block already
+ * uses; options reuse `OptionCard` (neutral dot + tint selection — §7); the
+ * helper line states what send will do, in mono caption like the rest of the
+ * composer chrome.
+ */
+import type { OpenQuestionRequest } from "@first-tree/shared";
+import { MessageCircleQuestion } from "lucide-react";
+import { OptionCard } from "../ui/option-card.js";
+
+export function RequestDock({
+  requestId,
+  payload,
+  selections,
+  directResolve,
+  draftEmpty,
+  askerName,
+  onPick,
+}: {
+  requestId: string;
+  payload: OpenQuestionRequest;
+  /** Keyed by prompt — the shape `recoverAnswerSelections` derives from the draft. */
+  selections: Record<string, string>;
+  /** Whether sending right now direct-resolves (clean untouched answer). */
+  directResolve: boolean;
+  /** Whether the composer draft is empty (drives the neutral helper line). */
+  draftEmpty: boolean;
+  askerName: string;
+  onPick: (prompt: string, option: string) => void;
+}) {
+  const questionCount = payload.questions.length;
+  const subject = payload.subject ?? "Request";
+  const hasFree = payload.questions.some((q) => q.kind === "free");
+  const sendKind = directResolve ? "resolve" : draftEmpty ? "empty" : "judge";
+
+  return (
+    <div
+      style={{
+        marginBottom: "var(--sp-1_5)",
+        border: "var(--hairline) solid var(--border)",
+        borderRadius: "var(--radius-panel)",
+        background: "color-mix(in oklch, var(--state-needs-you) 4%, var(--bg-raised))",
+        padding: "var(--sp-2_5) var(--sp-3)",
+      }}
+    >
+      <div
+        className="mono text-caption font-semibold"
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "var(--sp-1)",
+          color: "var(--fg-needs-you-strong)",
+          textTransform: "uppercase",
+          marginBottom: "var(--sp-2)",
+        }}
+      >
+        <MessageCircleQuestion size={12} className="shrink-0" />
+        {`Awaiting your answer · ${subject} · ${questionCount} question${questionCount === 1 ? "" : "s"}`}
+      </div>
+
+      {payload.questions.map((q, i) => (
+        <div key={q.id} style={{ marginTop: i === 0 ? 0 : "var(--sp-3)" }}>
+          <div className="text-body font-medium" style={{ color: "var(--fg)" }}>
+            <span className="mono text-caption" style={{ color: "var(--fg-4)", marginRight: "var(--sp-1_5)" }}>
+              {`Q${i + 1}`}
+            </span>
+            {q.prompt}
+          </div>
+          {q.kind === "single" ? (
+            <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--sp-1_5)", marginTop: "var(--sp-1_5)" }}>
+              {q.options.map((opt) => (
+                <OptionCard
+                  key={opt}
+                  layout="pill"
+                  // Namespace by message id — question ids are request-local
+                  // (`q1`, …) and the suppressed timeline card may still render
+                  // for other viewers; a distinct group keeps DOM radio state
+                  // from crossing surfaces.
+                  name={`dock:${requestId}:${q.id}`}
+                  checked={selections[q.prompt] === opt}
+                  onSelect={() => onPick(q.prompt, opt)}
+                >
+                  <span className="text-body">{opt}</span>
+                </OptionCard>
+              ))}
+            </div>
+          ) : (
+            <div className="mono text-caption" style={{ color: "var(--fg-4)", marginTop: "var(--sp-1)" }}>
+              (free-text — type your answer in the composer below)
+            </div>
+          )}
+        </div>
+      ))}
+
+      {payload.allowExtra && !hasFree ? (
+        <div className="mono text-caption" style={{ color: "var(--fg-4)", marginTop: "var(--sp-2)" }}>
+          (you can add a note — an edited reply goes to {askerName} to judge)
+        </div>
+      ) : null}
+
+      <div
+        className="mono text-caption"
+        style={{
+          marginTop: "var(--sp-2_5)",
+          paddingTop: "var(--sp-2)",
+          borderTop: "var(--hairline) solid var(--border-faint)",
+          color:
+            sendKind === "resolve"
+              ? "var(--fg-success-strong)"
+              : sendKind === "judge"
+                ? "var(--fg-info-strong)"
+                : "var(--fg-4)",
+        }}
+      >
+        {sendKind === "resolve"
+          ? "↵ Send answers and resolves this question"
+          : sendKind === "judge"
+            ? `↵ Send replies for ${askerName} to judge — the question stays open`
+            : "Pick an option to fill the composer, or type to discuss"}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/chat/request-state.ts
+++ b/packages/web/src/components/chat/request-state.ts
@@ -1,4 +1,4 @@
-import type { Message, OpenQuestionRequest, RequestResolution } from "@first-tree/shared";
+import type { Message, OpenQuestionItem, OpenQuestionRequest, RequestResolution } from "@first-tree/shared";
 import { MENTION_REGEX, openQuestionRequestSchema, requestResolutionSchema } from "@first-tree/shared";
 
 /**
@@ -127,6 +127,31 @@ export function defaultExpanded(state: RequestState, related: boolean): boolean 
 }
 
 /**
+ * Core scan shared by `findThreadableRequestId` and `findDockableRequest`:
+ * the most recent OPEN or DISCUSSING `format="request"` directed at the
+ * viewer, optionally restricted to requests raised by `fromSenders`. One
+ * definition of "the live question" keeps the composer's thread-on-reply
+ * behavior and the dock's pin choice agreeing by construction.
+ */
+function findLiveRequest(
+  thread: readonly Message[],
+  viewerAgentId: string | null,
+  fromSenders?: ReadonlySet<string>,
+): Message | null {
+  if (!viewerAgentId) return null;
+  // `thread` is oldest-first; walk from the newest so the latest live question wins.
+  for (let i = thread.length - 1; i >= 0; i--) {
+    const m = thread[i];
+    if (!m || m.format !== "request") continue;
+    if (fromSenders && !fromSenders.has(m.senderId)) continue;
+    if (!readMentions(m.metadata).includes(viewerAgentId)) continue;
+    const st = deriveRequestState(m, thread);
+    if (st === "open" || st === "discussing") return m;
+  }
+  return null;
+}
+
+/**
  * When `viewer` is about to send a message mentioning `mentionedIds`, find the
  * most recent OPEN or DISCUSSING request directed at them and raised by one of
  * the mentioned agents — so a plain composer reply that @-mentions the asking
@@ -141,17 +166,74 @@ export function findThreadableRequestId(
   viewerAgentId: string | null,
   mentionedIds: readonly string[],
 ): string | null {
-  if (!viewerAgentId || mentionedIds.length === 0) return null;
-  const mentioned = new Set(mentionedIds);
-  // `thread` is oldest-first; walk from the newest so the latest live question wins.
-  for (let i = thread.length - 1; i >= 0; i--) {
-    const m = thread[i];
-    if (!m || m.format !== "request" || !mentioned.has(m.senderId)) continue;
-    if (!readMentions(m.metadata).includes(viewerAgentId)) continue;
-    const st = deriveRequestState(m, thread);
-    if (st === "open" || st === "discussing") return m.id;
+  if (mentionedIds.length === 0) return null;
+  return findLiveRequest(thread, viewerAgentId, new Set(mentionedIds))?.id ?? null;
+}
+
+/**
+ * The request the composer dock pins: the most recent OPEN or DISCUSSING
+ * `format="request"` directed at the viewer. The dock owns answering for
+ * exactly this one (the timeline card suppresses its inline answer block via
+ * `suppressAnswerBlock`); any older live request keeps its inline block as
+ * the fallback. Returns `null` when nothing needs the viewer's answer.
+ */
+export function findDockableRequest(thread: readonly Message[], viewerAgentId: string | null): Message | null {
+  return findLiveRequest(thread, viewerAgentId);
+}
+
+/**
+ * The composer text a clean option selection produces. `selections` is keyed
+ * by PROMPT (the same shape `recoverAnswerSelections` returns, so draft ⇄
+ * selection round-trips losslessly). A single single-select question fills
+ * just the option text (what you click is exactly what you send); several
+ * questions fill one canonical `"<prompt> → <answer>"` line per answered
+ * single-select question so the sent content parses back via
+ * `parseAnswerSelections` for the resolved card's echo. Free-text questions
+ * never contribute — they are answered by typing, which goes through the
+ * agent-judgment path.
+ */
+export function buildAnswerDraft(payload: OpenQuestionRequest, selections: Record<string, string>): string {
+  const qs = payload.questions;
+  const only = qs.length === 1 ? qs[0] : undefined;
+  if (only && only.kind === "single") return selections[only.prompt] ?? "";
+  return qs
+    .filter((q) => q.kind === "single" && selections[q.prompt])
+    .map((q) => `${q.prompt} → ${selections[q.prompt]}`)
+    .join("\n");
+}
+
+/**
+ * Every required question is answered by an option selection (`selections`
+ * keyed by prompt). A required free-text question can never satisfy this — a
+ * typed answer is judged by the asking agent, not direct-resolved by the
+ * composer.
+ */
+export function allRequiredSelected(payload: OpenQuestionRequest, selections: Record<string, string>): boolean {
+  return payload.questions.every((q) => !q.required || (q.kind === "single" && Boolean(selections[q.prompt])));
+}
+
+/**
+ * Recover the chosen answers from a resolving message's content, keyed by
+ * prompt. Canonical `"<prompt> → <answer>"` lines parse first; the fallback
+ * accepts the bare option text the composer dock sends for a one-question
+ * request (the box shows exactly the clicked option, so that is what lands in
+ * history). Returns `{}` when nothing matches — callers render "answered".
+ */
+export function recoverAnswerSelections(
+  replyContent: unknown,
+  questions: readonly OpenQuestionItem[],
+): Record<string, string> {
+  const parsed = parseAnswerSelections(
+    replyContent,
+    questions.map((q) => q.prompt),
+  );
+  if (Object.keys(parsed).length > 0) return parsed;
+  const only = questions.length === 1 ? questions[0] : undefined;
+  if (only && only.kind === "single" && typeof replyContent === "string") {
+    const text = replyContent.trim();
+    if (only.options.includes(text)) return { [only.prompt]: text };
   }
-  return null;
+  return {};
 }
 
 /**
@@ -163,14 +245,23 @@ export function findThreadableRequestId(
  */
 export function parseAnswerSelections(replyContent: unknown, prompts: readonly string[]): Record<string, string> {
   if (typeof replyContent !== "string") return {};
-  const known = new Set(prompts);
+  // Match each line against the known prompts as PREFIXES (longest first),
+  // not by splitting on the first " → " — a prompt that itself contains
+  // " → " (e.g. "Migrate v1 → v2 now?") would otherwise break the
+  // buildAnswerDraft round-trip. The separator tolerates extra whitespace
+  // around the arrow, matching historical hand-formatted replies.
+  const byLength = [...prompts].sort((a, b) => b.length - a.length);
   const out: Record<string, string> = {};
-  for (const line of replyContent.split("\n")) {
-    const sep = line.indexOf(" → ");
-    if (sep < 0) continue;
-    const prompt = line.slice(0, sep).trim();
-    const answer = line.slice(sep + 3).trim();
-    if (known.has(prompt)) out[prompt] = answer;
+  for (const rawLine of replyContent.split("\n")) {
+    const line = rawLine.trim();
+    for (const prompt of byLength) {
+      if (!line.startsWith(prompt)) continue;
+      const sep = /^\s+→\s+(.*)$/.exec(line.slice(prompt.length));
+      if (sep?.[1] !== undefined) {
+        out[prompt] = sep[1].trim();
+        break;
+      }
+    }
   }
   return out;
 }

--- a/packages/web/src/pages/request-dock-preview.tsx
+++ b/packages/web/src/pages/request-dock-preview.tsx
@@ -1,0 +1,183 @@
+import type { OpenQuestionRequest } from "@first-tree/shared";
+import { useState } from "react";
+import { RequestDock } from "../components/chat/request-dock.js";
+import { allRequiredSelected, buildAnswerDraft, recoverAnswerSelections } from "../components/chat/request-state.js";
+
+/**
+ * DEV-only visual review for `RequestDock` — the open question pinned above
+ * the composer. No backend / no auth — same gating as the other `/preview/*`
+ * routes (DEV-only in `app.tsx`).
+ *
+ * Each mode renders the production dock against a mock composer that mirrors
+ * chat-view's wiring contract — including the derived-selection model: the
+ * draft is the single source of truth and the selection highlight is derived
+ * from it via `recoverAnswerSelections`, so clicking an option REPLACES the
+ * draft, editing the text away from a clean answer drops the highlight, and
+ * the helper line flips between resolve / judge / empty. The "send" button
+ * just echoes which path the real composer would take.
+ */
+
+const MODES: Record<string, { label: string; payload: OpenQuestionRequest }> = {
+  single: {
+    label: "single",
+    payload: {
+      subject: "Deploy strategy",
+      questions: [
+        {
+          id: "q1",
+          prompt: "Blue-green or rolling update?",
+          kind: "single",
+          options: ["Blue-green", "Rolling update", "Keep as-is"],
+          required: true,
+        },
+      ],
+      allowExtra: false,
+    },
+  },
+  free: {
+    label: "free-text",
+    payload: {
+      subject: "Launch concerns",
+      questions: [
+        { id: "q1", prompt: "Any remaining concerns before launch?", kind: "free", options: [], required: true },
+      ],
+      allowExtra: false,
+    },
+  },
+  multi: {
+    label: "multi-question",
+    payload: {
+      subject: "Release plan",
+      questions: [
+        { id: "q1", prompt: "Strategy?", kind: "single", options: ["Blue-green", "Rolling"], required: true },
+        { id: "q2", prompt: "Window?", kind: "single", options: ["Friday", "Monday"], required: true },
+      ],
+      allowExtra: false,
+    },
+  },
+  extra: {
+    label: "option + note",
+    payload: {
+      subject: "Canary ratio",
+      questions: [
+        { id: "q1", prompt: "First canary batch?", kind: "single", options: ["5%", "20%", "50%"], required: true },
+      ],
+      allowExtra: true,
+    },
+  },
+};
+
+function ModeBlock({ modeKey, payload }: { modeKey: string; payload: OpenQuestionRequest }) {
+  const [draft, setDraft] = useState("");
+  const [sentAs, setSentAs] = useState<string | null>(null);
+
+  // Mirrors chat-view's derived-selection model: no stored selection state.
+  const selections = recoverAnswerSelections(draft, payload.questions);
+  const directResolve =
+    draft.trim().length > 0 &&
+    draft.trim() === buildAnswerDraft(payload, selections) &&
+    allRequiredSelected(payload, selections);
+
+  const pick = (prompt: string, option: string) => {
+    setDraft(buildAnswerDraft(payload, { ...selections, [prompt]: option }));
+    setSentAs(null);
+  };
+
+  const edit = (value: string) => {
+    setDraft(value);
+    setSentAs(null);
+  };
+
+  return (
+    <section style={{ marginBottom: "var(--sp-6)" }}>
+      <h2 className="mono text-caption font-semibold" style={{ color: "var(--fg-3)", textTransform: "uppercase" }}>
+        {MODES[modeKey]?.label}
+      </h2>
+      <div
+        style={{
+          marginTop: "var(--sp-2)",
+          maxWidth: 720,
+          padding: "var(--sp-3)",
+          background: "var(--bg)",
+          border: "var(--hairline) solid var(--border)",
+          borderRadius: "var(--radius-panel)",
+        }}
+      >
+        <RequestDock
+          requestId={`req-${modeKey}`}
+          payload={payload}
+          selections={selections}
+          directResolve={directResolve}
+          draftEmpty={draft.trim().length === 0}
+          askerName="deploy-agent"
+          onPick={pick}
+        />
+        {/* mock composer — mirrors the wiring contract, not the real chrome */}
+        <div style={{ display: "flex", gap: "var(--sp-2)", alignItems: "flex-end" }}>
+          <textarea
+            value={draft}
+            onChange={(e) => edit(e.target.value)}
+            placeholder="Pick an option above, or type to discuss…"
+            className="text-body"
+            style={{
+              flex: 1,
+              border: "var(--hairline) solid var(--border-strong)",
+              borderRadius: "var(--radius-input)",
+              background: "var(--bg-raised)",
+              padding: "var(--sp-1_5) var(--sp-2)",
+              color: "var(--fg)",
+              minHeight: "var(--sp-10)",
+              resize: "vertical",
+            }}
+          />
+          <button
+            type="button"
+            className="text-body"
+            disabled={draft.trim().length === 0}
+            onClick={() => {
+              setSentAs(
+                directResolve
+                  ? "→ resolves.answered (direct resolve, red dot cleared)"
+                  : "→ plain reply (agent judges; question stays open)",
+              );
+              setDraft("");
+            }}
+            style={{
+              border: "none",
+              borderRadius: "var(--radius-input)",
+              background: "var(--primary)",
+              color: "var(--primary-on)",
+              padding: "var(--sp-1_5) var(--sp-3)",
+              cursor: draft.trim().length === 0 ? "not-allowed" : "pointer",
+              opacity: draft.trim().length === 0 ? 0.4 : 1,
+            }}
+          >
+            Send
+          </button>
+        </div>
+        {sentAs ? (
+          <div className="mono text-caption" style={{ color: "var(--fg-3)", marginTop: "var(--sp-1_5)" }}>
+            sent {sentAs}
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+}
+
+export function RequestDockPreviewPage() {
+  return (
+    <div style={{ padding: "var(--sp-6)", background: "var(--bg-sunken)", minHeight: "100vh" }}>
+      <h1 className="text-subtitle font-semibold" style={{ marginBottom: "var(--sp-1)" }}>
+        RequestDock preview
+      </h1>
+      <p className="text-body" style={{ color: "var(--fg-3)", marginBottom: "var(--sp-4)" }}>
+        Click an option → it fills the box (replace, not append). The highlight derives from the draft: text that is a
+        clean answer (clicked or hand-typed) resolves on send; anything else goes to the agent to judge.
+      </p>
+      {Object.entries(MODES).map(([key, m]) => (
+        <ModeBlock key={key} modeKey={key} payload={m.payload} />
+      ))}
+    </div>
+  );
+}

--- a/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
@@ -812,6 +812,53 @@ describe("ChatView", () => {
     await act(async () => root.unmount());
   });
 
+  it("does not clear a user-typed @ after an earlier focus auto-prime", async () => {
+    const { ChatView } = await import("../chat-view.js");
+    const dockMessages = messages([
+      message({
+        id: "req-manual-mention",
+        senderId: "agent-1",
+        format: "request",
+        content: "Discuss the deploy.",
+        metadata: {
+          mentions: ["human-agent-self"],
+          request: {
+            subject: "Deploy",
+            questions: [{ id: "q1", prompt: "Concerns?", kind: "free", required: true }],
+          },
+        },
+        createdAt: "2026-05-28T12:00:00.000Z",
+      }),
+    ]);
+    const { container, queryClient, root } = await renderDom(
+      <ChatView agentId="agent-1" chatId="chat-1" />,
+      (client) => seedChat(client, chatDetail(), messages([])),
+      "/",
+    );
+
+    const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
+    if (!textarea) throw new Error("Composer textarea missing");
+    await act(async () => {
+      textarea.dispatchEvent(new FocusEvent("focusin", { bubbles: true, cancelable: true }));
+    });
+    await flush();
+    await waitForCondition(() => textarea.value === "@", "Expected initial group focus to auto-prime @");
+
+    await setValue(textarea, "");
+    await act(async () => {
+      queryClient.setQueryData(["chat-messages", "chat-1"], dockMessages);
+    });
+    await flush();
+    await waitForText(container, "Awaiting your answer");
+    expect(textarea.value).toBe("");
+
+    await setValue(textarea, "@");
+    await flush();
+    expect(textarea.value).toBe("@");
+
+    await act(async () => root.unmount());
+  });
+
   it("threads docked attachment replies under the live request without a visible @mention", async () => {
     const { ChatView } = await import("../chat-view.js");
     const dockMessages = messages([

--- a/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
@@ -470,7 +470,7 @@ async function renderDom(
   element: ReactElement,
   seed?: (queryClient: QueryClient) => void,
   route = "/?docChat=chat-1&docAgent=agent-1&docPath=docs/plan.md",
-): Promise<{ container: HTMLElement; root: Root }> {
+): Promise<{ container: HTMLElement; queryClient: QueryClient; root: Root }> {
   const container = document.createElement("div");
   document.body.appendChild(container);
   const root = createRoot(container);
@@ -487,7 +487,7 @@ async function renderDom(
     );
   });
   await flush();
-  return { container, root };
+  return { container, queryClient, root };
 }
 
 async function flush(): Promise<void> {
@@ -549,6 +549,10 @@ function buttonByTitle(container: ParentNode, title: string): HTMLButtonElement 
 
 function buttonByText(container: ParentNode, text: string): HTMLButtonElement | null {
   return [...container.querySelectorAll("button")].find((button) => button.textContent?.trim() === text) ?? null;
+}
+
+function optionByText(container: ParentNode, text: string): HTMLLabelElement | null {
+  return [...container.querySelectorAll("label")].find((label) => label.textContent?.includes(text)) ?? null;
 }
 
 beforeEach(() => {
@@ -744,6 +748,112 @@ describe("ChatView", () => {
       { mentions: ["agent-2"] },
       // No live request in this chat → nothing to thread under.
       undefined,
+    );
+
+    await act(async () => root.unmount());
+  });
+
+  it("clears a stale auto-primed @ when a request dock arrives late and clean-resolves option answers", async () => {
+    const { ChatView } = await import("../chat-view.js");
+    const dockMessages = messages([
+      message({
+        id: "req-1",
+        senderId: "agent-1",
+        format: "request",
+        content: "Pick the deploy color.",
+        metadata: {
+          mentions: ["human-agent-self"],
+          request: {
+            subject: "Deploy",
+            questions: [
+              {
+                id: "q1",
+                prompt: "Deploy color?",
+                kind: "single",
+                options: ["Blue-green", "Rolling update"],
+                required: true,
+              },
+            ],
+          },
+        },
+        createdAt: "2026-05-28T12:00:00.000Z",
+      }),
+    ]);
+    const { container, queryClient, root } = await renderDom(
+      <ChatView agentId="agent-1" chatId="chat-1" />,
+      (client) => seedChat(client, chatDetail(), messages([])),
+      "/",
+    );
+
+    const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
+    if (!textarea) throw new Error("Composer textarea missing");
+    await act(async () => {
+      textarea.dispatchEvent(new FocusEvent("focusin", { bubbles: true, cancelable: true }));
+    });
+    await flush();
+    await waitForCondition(() => textarea.value === "@", "Expected group focus to prime @ before dock data arrives");
+
+    await act(async () => {
+      queryClient.setQueryData(["chat-messages", "chat-1"], dockMessages);
+    });
+    await flush();
+    await waitForText(container, "Awaiting your answer");
+    await waitForCondition(() => textarea.value === "", "Expected late request dock to clear auto-primed @");
+
+    await click(optionByText(container, "Blue-green"));
+    expect(textarea.value).toBe("Blue-green");
+    await click(container.querySelector('button[aria-label="Send"]'));
+    await waitForCondition(() => chatMocks.sendChatMessage.mock.calls.length > 0, "Expected clean option send");
+    expect(chatMocks.sendChatMessage).toHaveBeenCalledWith("chat-1", "Blue-green", ["agent-1"], {
+      inReplyTo: "req-1",
+      resolves: { request: "req-1", kind: "answered" },
+    });
+
+    await act(async () => root.unmount());
+  });
+
+  it("threads docked attachment replies under the live request without a visible @mention", async () => {
+    const { ChatView } = await import("../chat-view.js");
+    const dockMessages = messages([
+      message({
+        id: "req-file",
+        senderId: "agent-1",
+        format: "request",
+        content: "Attach the rollout screenshot.",
+        metadata: {
+          mentions: ["human-agent-self"],
+          request: {
+            subject: "Evidence",
+            questions: [{ id: "q1", prompt: "Evidence?", kind: "free", required: true }],
+          },
+        },
+        createdAt: "2026-05-28T12:00:00.000Z",
+      }),
+    ]);
+    const { container, root } = await renderDom(
+      <ChatView agentId="agent-1" chatId="chat-1" />,
+      (client) => seedChat(client, chatDetail(), dockMessages),
+      "/",
+    );
+
+    await waitForText(container, "Awaiting your answer");
+    const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
+    if (!textarea) throw new Error("Composer textarea missing");
+    await setValue(textarea, "Screenshot evidence attached");
+    const file = new File(["abc"], "evidence.png", { type: "image/png" });
+    const fileInput = container.querySelector<HTMLInputElement>('input[type="file"]');
+    if (!fileInput) throw new Error("File input missing");
+    await changeFiles(fileInput, [file]);
+    await click(container.querySelector('button[aria-label="Send"]'));
+    await waitForCondition(() => chatMocks.sendFileMessageBatch.mock.calls.length > 0, "Expected image send");
+    expect(chatMocks.sendFileMessageBatch).toHaveBeenCalledWith(
+      "chat-1",
+      {
+        caption: "Screenshot evidence attached",
+        attachments: [{ imageId: "uploaded-image", mimeType: "image/png", filename: "evidence.png", size: 3 }],
+      },
+      { mentions: ["agent-1"] },
+      { inReplyTo: "req-file" },
     );
 
     await act(async () => root.unmount());

--- a/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
@@ -742,6 +742,8 @@ describe("ChatView", () => {
         attachments: [{ imageId: "uploaded-image", mimeType: "image/png", filename: "preview.png", size: 3 }],
       },
       { mentions: ["agent-2"] },
+      // No live request in this chat → nothing to thread under.
+      undefined,
     );
 
     await act(async () => root.unmount());

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -972,6 +972,11 @@ export function ChatView({
    * focused the input even once, we don't keep slapping `@` back into an
    * empty draft. Reset when switching chats. */
   const focusPrimedRef = useRef(false);
+  // Current-draft provenance for the single `@` inserted by focus auto-prime.
+  // This is intentionally narrower than `focusPrimedRef`: the latter only
+  // means auto-prime has ever happened in this chat, while this flag means the
+  // current draft is still the untouched auto-prime token.
+  const autoPrimedDraftRef = useRef(false);
   /** Once-per-session set of chatIds we've pre-filled. Set semantics
    * (not a single ref) so revisiting an empty chat we already touched
    * doesn't re-stamp the greeting on top of the user's cleared draft.
@@ -980,6 +985,7 @@ export function ChatView({
   // biome-ignore lint/correctness/useExhaustiveDependencies: reset is intentionally chatId-scoped.
   useEffect(() => {
     focusPrimedRef.current = false;
+    autoPrimedDraftRef.current = false;
   }, [chatId]);
 
   // Hydrate timeline from local IndexedDB cache so chat-switches feel
@@ -1578,6 +1584,7 @@ export function ChatView({
   const pickDockOption = (prompt: string, option: string) => {
     if (!dockPayload) return;
     const nextDraft = buildAnswerDraft(dockPayload, { ...dockSelections, [prompt]: option });
+    autoPrimedDraftRef.current = false;
     setDraft(nextDraft);
     setCursor(nextDraft.length);
     requestAnimationFrame(() => {
@@ -1588,9 +1595,10 @@ export function ChatView({
     });
   };
   useEffect(() => {
-    if (!dockRequestId || draft !== "@" || !focusPrimedRef.current) return;
+    if (!dockRequestId || draft !== "@" || !autoPrimedDraftRef.current) return;
     // Real message data can arrive after an empty group composer already
     // focus-primed `@`; once the dock appears, the asker is the default route.
+    autoPrimedDraftRef.current = false;
     focusPrimedRef.current = false;
     setDraft("");
     setCursor(0);
@@ -2455,6 +2463,7 @@ export function ChatView({
     candidates: mentionCandidates,
     disabled: sendMut.isPending || uploading,
     onSelect: (update) => {
+      autoPrimedDraftRef.current = false;
       setDraft(update.text);
       setCursor(update.cursor);
       // Defer so React has committed the new value before we move the
@@ -2526,6 +2535,7 @@ export function ChatView({
     mentionedAgent: slashMentionContext,
     disabled: sendMut.isPending || uploading,
     onSelect: (update, picked) => {
+      autoPrimedDraftRef.current = false;
       setDraft(update.text);
       setCursor(update.cursor);
       requestAnimationFrame(() => {
@@ -3173,6 +3183,7 @@ export function ChatView({
                           ref={textareaRef}
                           value={draft}
                           onChange={(e) => {
+                            autoPrimedDraftRef.current = false;
                             setDraft(e.target.value);
                             setCursor(e.target.selectionStart ?? e.target.value.length);
                             // Dismiss a stale upload error (e.g. the "no @mention"
@@ -3210,6 +3221,7 @@ export function ChatView({
                               return;
                             }
                             focusPrimedRef.current = true;
+                            autoPrimedDraftRef.current = true;
                             setDraft("@");
                             setCursor(1);
                             requestAnimationFrame(() => {
@@ -3326,6 +3338,7 @@ export function ChatView({
                               const start = el.selectionStart ?? draft.length;
                               const end = el.selectionEnd ?? start;
                               const next = `${draft.slice(0, start)}@${draft.slice(end)}`;
+                              autoPrimedDraftRef.current = false;
                               setDraft(next);
                               setCursor(start + 1);
                               requestAnimationFrame(() => {

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -1587,6 +1587,19 @@ export function ChatView({
       el.setSelectionRange(el.value.length, el.value.length);
     });
   };
+  useEffect(() => {
+    if (!dockRequestId || draft !== "@" || !focusPrimedRef.current) return;
+    // Real message data can arrive after an empty group composer already
+    // focus-primed `@`; once the dock appears, the asker is the default route.
+    focusPrimedRef.current = false;
+    setDraft("");
+    setCursor(0);
+    requestAnimationFrame(() => {
+      const el = textareaRef.current;
+      if (!el || el.value !== "") return;
+      el.setSelectionRange(0, 0);
+    });
+  }, [dockRequestId, draft]);
   // When the dock re-pins to a DIFFERENT request (a newer question arrived,
   // or the current one resolved under us), drop a draft the old dock
   // authored — otherwise a staged clean answer silently retargets and would

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -7,7 +7,9 @@ import {
   isImageBatchRefContent,
   isImageRefContent,
   type MentionParticipant,
+  type OpenQuestionRequest,
   parseWorkspaceDocKey,
+  type RequestResolution,
 } from "@first-tree/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
@@ -74,10 +76,16 @@ import {
   isTrustedGithubDispatcherMessage,
 } from "../../../components/chat/github-event-card.js";
 import { RequestCard } from "../../../components/chat/request-card.js";
+import { RequestDock } from "../../../components/chat/request-dock.js";
 import {
+  allRequiredSelected,
+  buildAnswerDraft,
   contentStartsWithMention,
+  findDockableRequest,
   findThreadableRequestId,
   readMentions,
+  readRequestPayload,
+  recoverAnswerSelections,
 } from "../../../components/chat/request-state.js";
 import { WorkingTurn } from "../../../components/chat/working-turn.js";
 import { HistoryGapBanner } from "../../../components/history-gap-banner.js";
@@ -265,6 +273,7 @@ function TextRow({
   agentColorTokenFn,
   mentionParticipants,
   messages,
+  suppressAnswerBlock = false,
 }: {
   msg: MessageWithDelivery;
   myAgentId: string | null;
@@ -274,6 +283,13 @@ function TextRow({
   mentionParticipants: MentionParticipant[];
   /** Full visible thread — RequestCard derives a request's lifecycle from it. */
   messages: readonly MessageWithDelivery[];
+  /**
+   * True when this message is the request currently pinned in the composer
+   * dock — its timeline card suppresses the inline answer block (the dock
+   * owns answering). Passed as a per-row boolean (not the docked id) so a
+   * future memo() on TextRow invalidates only the affected row.
+   */
+  suppressAnswerBlock?: boolean;
 }) {
   const [searchParams, setSearchParams] = useSearchParams();
   const queryClient = useQueryClient();
@@ -574,6 +590,7 @@ function TextRow({
               }
               resolveAgentName={agentNameFn}
               onSent={() => queryClient.invalidateQueries({ queryKey: ["chat-messages", msg.chatId] })}
+              suppressAnswerBlock={suppressAnswerBlock}
             />
           ) : (
             <pre
@@ -1089,7 +1106,10 @@ export function ChatView({
     [queryClient, messagesQueryKey],
   );
   const buildOptimisticTextMessage = useCallback(
-    (text: string): MessageWithDelivery | null => {
+    (
+      text: string,
+      route?: { mentions?: string[]; inReplyTo?: string; resolves?: RequestResolution },
+    ): MessageWithDelivery | null => {
       if (!myAgentId) return null;
       return {
         id: `optimistic-${crypto.randomUUID()}`,
@@ -1097,8 +1117,16 @@ export function ChatView({
         senderId: myAgentId,
         format: "text",
         content: text,
-        metadata: {},
-        inReplyTo: null,
+        // Stamp the routing/lifecycle metadata on the optimistic row so
+        // `deriveRequestState` flips a just-answered request immediately —
+        // the dock unpins and the card resolves without waiting for the
+        // POST + refetch round-trip (otherwise the still-"open" question
+        // invites a second resolve send on a slow link).
+        metadata: {
+          ...(route?.mentions && route.mentions.length > 0 ? { mentions: route.mentions } : {}),
+          ...(route?.resolves ? { resolves: route.resolves } : {}),
+        },
+        inReplyTo: route?.inReplyTo ?? null,
         source: "web",
         createdAt: new Date().toISOString(),
         deliveryStatus: "pending",
@@ -1147,20 +1175,32 @@ export function ChatView({
   );
 
   const sendMut = useMutation({
-    mutationFn: ({ content, mentions, inReplyTo }: { content: string; mentions: string[]; inReplyTo?: string }) => {
-      return inReplyTo
-        ? sendChatMessage(chatId, content, mentions, { inReplyTo })
-        : sendChatMessage(chatId, content, mentions);
-    },
+    mutationFn: ({
+      content,
+      mentions,
+      inReplyTo,
+      resolves,
+    }: {
+      content: string;
+      mentions: string[];
+      inReplyTo?: string;
+      resolves?: RequestResolution;
+    }) =>
+      // `resolves` rides only the composer dock's direct-resolve send (the
+      // untouched option selection) — see `dockDirectResolve` in handleSend.
+      // Plain sends keep the 3-arg shape (no opts object on the wire path).
+      inReplyTo || resolves
+        ? sendChatMessage(chatId, content, mentions, { inReplyTo, resolves })
+        : sendChatMessage(chatId, content, mentions),
     // Optimistic insert: render the user's row above the composer immediately
     // and clear the draft so the input feels responsive even when the POST
     // round-trip + follow-up GET take 1–2s. The ctx returned here is threaded
     // to onError / onSuccess so we can reconcile with the server row.
-    onMutate: async ({ content }) => {
+    onMutate: async ({ content, mentions, inReplyTo, resolves }) => {
       await queryClient.cancelQueries({ queryKey: messagesQueryKey });
       const previousDraft = draft;
       setDraft("");
-      const optimistic = buildOptimisticTextMessage(content);
+      const optimistic = buildOptimisticTextMessage(content, { mentions, inReplyTo, resolves });
       if (!optimistic) return { tempId: null, previousDraft };
       insertOwnOptimisticMessage(optimistic);
       return { tempId: optimistic.id, previousDraft };
@@ -1233,6 +1273,23 @@ export function ChatView({
     if (!text && images.length === 0) return;
     if (uploading) return;
 
+    // Direct resolve: the draft is exactly the dock's untouched option
+    // selection — send it as the clean answer. It threads under the request
+    // (`inReplyTo`) and carries the explicit `resolves` signal that drives the
+    // server's red-dot −1. Mentions route to the asker automatically, so this
+    // path needs no typed @mention even in a group chat. Any edit, free text,
+    // or attached image fails `dockDirectResolve` and falls through to the
+    // normal send below (a plain reply the asking agent judges).
+    if (dockDirectResolve && dockRequest) {
+      sendMut.mutate({
+        content: text,
+        mentions: [dockRequest.senderId],
+        inReplyTo: dockRequest.id,
+        resolves: { request: dockRequest.id, kind: "answered" },
+      });
+      return;
+    }
+
     // No client-side unresolved-`@`-token pre-flight: a `@<token>` that
     // doesn't resolve to a chat member is treated as plain text, matching
     // Slack/Discord. This avoids false positives like npm scoped
@@ -1246,13 +1303,14 @@ export function ChatView({
 
     // Group-chat send guard: a multi-speaker chat has no no-recipient send
     // path — every message must @mention at least one member. The send button
-    // is already disabled in this state (see the `disabled` prop below), so
+    // is already disabled in this state (see `sendBlockedByMentionGate`), so
     // this is the Enter-key / programmatic backstop. Applies to image-only
     // sends too: the server's mention check runs per message regardless of
     // format, so an un-addressed image would 400 just like un-addressed text.
     // Surface a hint when the user has only attached images so the
-    // silent-return doesn't look like a stuck send.
-    if (requiresMention && draftMentions.length === 0) {
+    // silent-return doesn't look like a stuck send. A live dock lifts the
+    // gate — `routedMentions` below defaults the recipient to the asker.
+    if (sendBlockedByMentionGate) {
       if (images.length > 0) {
         // English matches the other uploadError strings in this file
         // (Failed to send image / Failed to add participants / Image too large).
@@ -1261,15 +1319,24 @@ export function ChatView({
       return;
     }
 
+    // Routing mentions for this send. While a dock is live, its asker is the
+    // default recipient when no explicit @mention resolved — a typed/edited
+    // reply is "for the asker to judge" (exactly what the dock's helper line
+    // promises), and it then threads under the question via
+    // `findThreadableRequestId` below. Explicit @mentions always win.
+    const routedMentions =
+      effectiveSendMentions.length === 0 && dockRequest ? [dockRequest.senderId] : effectiveSendMentions;
+
     if (images.length > 0) {
       setUploading(true);
       setUploadError(null);
       // Carry the routing mentions onto each image message so the
       // server's explicit-recipient enforcement check accepts file-format sends.
-      // `effectiveSendMentions` already includes the 1:1 peer (per the
-      // explicit-only contract), so the file path works in both DM and
-      // group chats — without this every image POST would 400.
-      const imageMetadata = effectiveSendMentions.length > 0 ? { mentions: effectiveSendMentions } : undefined;
+      // `routedMentions` already includes the 1:1 peer (per the
+      // explicit-only contract) or the dock-asker fallback, so the file path
+      // works in DM, group, and docked-question chats — without this every
+      // image POST would 400.
+      const imageMetadata = routedMentions.length > 0 ? { mentions: routedMentions } : undefined;
       // Snapshot draft + clear inputs up front so the composer feels instant.
       // Optimistic rows render into the cache below; rollback restores both
       // the textarea draft and any not-yet-acked optimistic tempIds on error.
@@ -1394,16 +1461,17 @@ export function ChatView({
       return;
     }
 
-    // "Chat about this": a plain reply that @-mentions the agent which asked an
-    // open question directed at me threads under that question (`inReplyTo`) so
-    // the back-and-forth stays scoped to it. This does NOT resolve the question
-    // — `inReplyTo` is pure threading now; resolution needs an explicit
-    // `metadata.resolves`, written by the request card's answer block (a clean
-    // answer) or the asking agent's `chat send --answer`/`--close`.
-    const threadedRequestId = findThreadableRequestId(mergedMessages, myAgentId, effectiveSendMentions) ?? undefined;
+    // "Chat about this": a plain reply that addresses the agent which asked an
+    // open question directed at me (explicit @mention, or the dock-asker
+    // fallback in `routedMentions`) threads under that question (`inReplyTo`)
+    // so the back-and-forth stays scoped to it. This does NOT resolve the
+    // question — `inReplyTo` is pure threading now; resolution needs an
+    // explicit `metadata.resolves`, written by the dock's clean answer or the
+    // asking agent's `chat send --answer`/`--close`.
+    const threadedRequestId = findThreadableRequestId(mergedMessages, myAgentId, routedMentions) ?? undefined;
     sendMut.mutate({
       content: text,
-      mentions: effectiveSendMentions,
+      mentions: routedMentions,
       inReplyTo: threadedRequestId,
     });
   };
@@ -1467,6 +1535,71 @@ export function ChatView({
     () => findGapAfterMessageId(cachedMessages ?? [], messagesData?.items ?? []),
     [cachedMessages, messagesData],
   );
+
+  // ── Request dock: the most recent live open question directed at me pins
+  // its questions + options directly above the composer (the timeline card
+  // suppresses its inline answer block — the answering surface exists once).
+  // Single send button, one contract: clicking an option REPLACES the draft
+  // with the canonical answer text; sending a clean answer direct-resolves
+  // via `metadata.resolves`; sending any other text is a plain reply routed
+  // to the asking agent to judge — the question stays open.
+  //
+  // The selection state is DERIVED from the draft (`recoverAnswerSelections`),
+  // never stored: the draft is the single source of truth, so the send
+  // mutation's own draft lifecycle (onMutate clears, onError restores) keeps
+  // resolve semantics across a failed-send retry for free, and hand-typing
+  // the exact option text counts as a clean answer (accepted semantics).
+  // Watchers never dock — the read-only branch renders no composer, and
+  // suppressing the timeline card without a dock would leave zero answering
+  // surfaces.
+  const dockRequest = useMemo(
+    () => (readOnly ? null : findDockableRequest(mergedMessages, myAgentId)),
+    [readOnly, mergedMessages, myAgentId],
+  );
+  const dockPayload = useMemo(() => (dockRequest ? readRequestPayload(dockRequest.metadata) : null), [dockRequest]);
+  const dockRequestId = dockRequest?.id;
+  const dockSelections = useMemo<Record<string, string>>(
+    () => (dockPayload ? recoverAnswerSelections(draft, dockPayload.questions) : {}),
+    [dockPayload, draft],
+  );
+  const dockDirectResolve =
+    dockRequest != null &&
+    dockPayload != null &&
+    pendingImages.length === 0 &&
+    draft.trim().length > 0 &&
+    draft.trim() === buildAnswerDraft(dockPayload, dockSelections) &&
+    allRequiredSelected(dockPayload, dockSelections);
+  const pickDockOption = (prompt: string, option: string) => {
+    if (!dockPayload) return;
+    const nextDraft = buildAnswerDraft(dockPayload, { ...dockSelections, [prompt]: option });
+    setDraft(nextDraft);
+    setCursor(nextDraft.length);
+    requestAnimationFrame(() => {
+      const el = textareaRef.current;
+      if (!el) return;
+      el.focus();
+      el.setSelectionRange(el.value.length, el.value.length);
+    });
+  };
+  // When the dock re-pins to a DIFFERENT request (a newer question arrived,
+  // or the current one resolved under us), drop a draft the old dock
+  // authored — otherwise a staged clean answer silently retargets and would
+  // thread under the new question as a confusing bare reply. Typed
+  // discussion text never matches the old request's canonical answer shape
+  // and is kept. Functional setDraft returns the same string in the keep
+  // case, so React bails out of the no-op update.
+  const prevDockRef = useRef<{ id: string; payload: OpenQuestionRequest } | null>(null);
+  useEffect(() => {
+    const prev = prevDockRef.current;
+    prevDockRef.current = dockRequest && dockPayload ? { id: dockRequest.id, payload: dockPayload } : null;
+    if (!prev || prev.id === dockRequest?.id) return;
+    setDraft((current) => {
+      const trimmed = current.trim();
+      if (trimmed.length === 0) return current;
+      const derived = recoverAnswerSelections(trimmed, prev.payload.questions);
+      return Object.keys(derived).length > 0 && trimmed === buildAnswerDraft(prev.payload, derived) ? "" : current;
+    });
+  }, [dockRequest, dockPayload]);
 
   const items: TimelineItem[] = useMemo(() => {
     const rawEvents = eventsData?.items ?? [];
@@ -2289,6 +2422,14 @@ export function ChatView({
     [draftMentions, peerAgentId],
   );
 
+  // Group-chat mention gate, shared by the send button (disabled / title /
+  // dimming) and handleSend's Enter-key backstop. A live dock lifts the gate:
+  // the pinned question makes its asker the default recipient (a clean answer
+  // direct-resolves; an edited/typed reply routes to the asker to judge —
+  // exactly what the dock's helper line promises), so no typed @mention is
+  // required while a question is docked.
+  const sendBlockedByMentionGate = requiresMention && draftMentions.length === 0 && dockRequest == null;
+
   const mention = useMentionAutocomplete({
     value: draft,
     cursor,
@@ -2774,6 +2915,7 @@ export function ChatView({
                           agentColorTokenFn={agentColorToken}
                           mentionParticipants={renderMentionParticipants}
                           messages={mergedMessages}
+                          suppressAnswerBlock={dockRequestId != null && msg.id === dockRequestId}
                         />
                       );
                     }
@@ -2889,6 +3031,20 @@ export function ChatView({
                       chatId={chatId}
                       agents={(chatDetail?.participants ?? []).filter((p) => p.type !== "human")}
                     />
+                    {/* The live open question directed at me — questions +
+                        options pinned where the answer happens. See the dock
+                        state block above `handleSend` for the send contract. */}
+                    {dockRequest && dockPayload ? (
+                      <RequestDock
+                        requestId={dockRequest.id}
+                        payload={dockPayload}
+                        selections={dockSelections}
+                        directResolve={dockDirectResolve}
+                        draftEmpty={draft.trim().length === 0}
+                        askerName={chatScopedAgentName(dockRequest.senderId)}
+                        onPick={pickDockOption}
+                      />
+                    ) : null}
                     {/* biome-ignore lint/a11y/noStaticElementInteractions: drop target for image upload */}
                     <div
                       style={{
@@ -3202,10 +3358,10 @@ export function ChatView({
                               sendMut.isPending ||
                               uploading ||
                               (!draft.trim() && pendingImages.length === 0) ||
-                              (requiresMention && draftMentions.length === 0)
+                              sendBlockedByMentionGate
                             }
                             title={
-                              requiresMention && draftMentions.length === 0
+                              sendBlockedByMentionGate
                                 ? "@mention a member to send — a group message must address someone"
                                 : "Send (Enter)"
                             }
@@ -3215,7 +3371,7 @@ export function ChatView({
                               (sendMut.isPending ||
                                 uploading ||
                                 (!draft.trim() && pendingImages.length === 0) ||
-                                (requiresMention && draftMentions.length === 0)) &&
+                                sendBlockedByMentionGate) &&
                                 "opacity-40 cursor-not-allowed",
                             )}
                             style={{

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -123,7 +123,7 @@ import { useOrgAgents } from "../../../lib/use-org-agents.js";
 import { usePendingImages } from "../../../lib/use-pending-images.js";
 import { cn } from "../../../lib/utils.js";
 import { findGapAfterMessageId } from "../../../utils/chat-gap.js";
-import { computeRequiresMention } from "../../../utils/requires-mention.js";
+import { computeRequiresMention, shouldPrimeMentionOnFocus } from "../../../utils/requires-mention.js";
 import { filterEventsForTimeline } from "../../../utils/session-timeline.js";
 import { ChatRightSidebar } from "../right-sidebar/index.js";
 
@@ -1327,6 +1327,17 @@ export function ChatView({
     const routedMentions =
       effectiveSendMentions.length === 0 && dockRequest ? [dockRequest.senderId] : effectiveSendMentions;
 
+    // "Chat about this": a plain reply that addresses the agent which asked an
+    // open question directed at me (explicit @mention, or the dock-asker
+    // fallback above) threads under that question (`inReplyTo`) so the
+    // back-and-forth stays scoped to it. Computed BEFORE the image branch —
+    // a captioned image answering a docked question must thread exactly like
+    // a text reply. This does NOT resolve the question — `inReplyTo` is pure
+    // threading; resolution needs an explicit `metadata.resolves`, written by
+    // the dock's clean answer or the asking agent's `chat send
+    // --answer`/`--close`.
+    const threadedRequestId = findThreadableRequestId(mergedMessages, myAgentId, routedMentions) ?? undefined;
+
     if (images.length > 0) {
       setUploading(true);
       setUploadError(null);
@@ -1391,7 +1402,9 @@ export function ChatView({
             format: "file",
             content: optimisticContent,
             metadata: imageMetadata ?? {},
-            inReplyTo: null,
+            // Mirror the POST below: a captioned image answering a docked
+            // question threads under it, optimistically too.
+            inReplyTo: threadedRequestId ?? null,
             source: "web",
             createdAt: new Date().toISOString(),
             deliveryStatus: "pending",
@@ -1411,6 +1424,7 @@ export function ChatView({
             attachments: optimisticRefs,
           },
           imageMetadata,
+          threadedRequestId ? { inReplyTo: threadedRequestId } : undefined,
         );
         if (batchTempId) {
           replaceOptimisticMessage(batchTempId, saved);
@@ -1461,14 +1475,6 @@ export function ChatView({
       return;
     }
 
-    // "Chat about this": a plain reply that addresses the agent which asked an
-    // open question directed at me (explicit @mention, or the dock-asker
-    // fallback in `routedMentions`) threads under that question (`inReplyTo`)
-    // so the back-and-forth stays scoped to it. This does NOT resolve the
-    // question — `inReplyTo` is pure threading now; resolution needs an
-    // explicit `metadata.resolves`, written by the dock's clean answer or the
-    // asking agent's `chat send --answer`/`--close`.
-    const threadedRequestId = findThreadableRequestId(mergedMessages, myAgentId, routedMentions) ?? undefined;
     sendMut.mutate({
       content: text,
       mentions: routedMentions,
@@ -3175,9 +3181,21 @@ export function ChatView({
                             // their draft and tabbed away/back; that would constantly
                             // fight the user when they're trying to write a fresh
                             // empty message without addressing anyone (e.g. paste over).
-                            if (!requiresMention) return;
-                            if (focusPrimedRef.current) return;
-                            if (draft.length > 0 || mentionCandidates.length === 0) return;
+                            // While a question is docked, priming is skipped — the
+                            // asker is the default recipient (same gate that lifts
+                            // `sendBlockedByMentionGate`), so stamping `@` would fight
+                            // the dock contract as the user starts a free-text answer.
+                            if (
+                              !shouldPrimeMentionOnFocus({
+                                requiresMention,
+                                dockActive: dockRequest != null,
+                                alreadyPrimed: focusPrimedRef.current,
+                                draftLength: draft.length,
+                                mentionCandidateCount: mentionCandidates.length,
+                              })
+                            ) {
+                              return;
+                            }
                             focusPrimedRef.current = true;
                             setDraft("@");
                             setCursor(1);

--- a/packages/web/src/utils/__tests__/requires-mention.test.ts
+++ b/packages/web/src/utils/__tests__/requires-mention.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { computeRequiresMention } from "../requires-mention.js";
+import { computeRequiresMention, shouldPrimeMentionOnFocus } from "../requires-mention.js";
 
 const ME = "me-agent";
 const A = "agent-a";
@@ -51,5 +51,42 @@ describe("computeRequiresMention", () => {
 
   it("handles an empty participant list", () => {
     expect(computeRequiresMention([], ME)).toBe(false);
+  });
+});
+
+describe("shouldPrimeMentionOnFocus", () => {
+  const base = {
+    requiresMention: true,
+    dockActive: false,
+    alreadyPrimed: false,
+    draftLength: 0,
+    mentionCandidateCount: 2,
+  };
+
+  it("primes in a plain group chat with an empty draft", () => {
+    expect(shouldPrimeMentionOnFocus(base)).toBe(true);
+  });
+
+  it("does NOT prime while a question is docked — the asker is the default recipient", () => {
+    // The dock contract: answering or discussing the pinned question needs no
+    // typed @mention (the group-chat/free-text dock case from PR 981's review).
+    // Stamping `@` on focus would fight the user starting a free-text answer.
+    expect(shouldPrimeMentionOnFocus({ ...base, dockActive: true })).toBe(false);
+  });
+
+  it("does NOT prime in a 1-on-1 (no mention required)", () => {
+    expect(shouldPrimeMentionOnFocus({ ...base, requiresMention: false })).toBe(false);
+  });
+
+  it("primes once per chat visit", () => {
+    expect(shouldPrimeMentionOnFocus({ ...base, alreadyPrimed: true })).toBe(false);
+  });
+
+  it("never primes over an existing draft", () => {
+    expect(shouldPrimeMentionOnFocus({ ...base, draftLength: 5 })).toBe(false);
+  });
+
+  it("does not prime with no mention candidates to pick", () => {
+    expect(shouldPrimeMentionOnFocus({ ...base, mentionCandidateCount: 0 })).toBe(false);
   });
 });

--- a/packages/web/src/utils/requires-mention.ts
+++ b/packages/web/src/utils/requires-mention.ts
@@ -29,3 +29,33 @@ export function computeRequiresMention(
   const speakersAfterSend = participantAgentIds.length + (meIn ? 0 : 1);
   return speakersAfterSend >= 3;
 }
+
+/**
+ * Whether composer focus should auto-insert `@` to pop the recipient picker.
+ *
+ * Primes only when an explicit @mention is genuinely required for this send:
+ * a real group chat (`requiresMention`) with NO live docked question. While a
+ * question is docked, its asker is the default recipient (the mention gate is
+ * lifted — see chat-view's `sendBlockedByMentionGate` / `routedMentions`), so
+ * stamping `@` on focus would fight the dock contract ("no typed @mention
+ * needed") exactly as the user clicks an option or starts a free-text answer.
+ *
+ * The remaining guards mirror the composer's long-standing rules: prime once
+ * per chat visit, never over an existing draft, and only when there is at
+ * least one mention candidate to pick.
+ */
+export function shouldPrimeMentionOnFocus(args: {
+  requiresMention: boolean;
+  dockActive: boolean;
+  alreadyPrimed: boolean;
+  draftLength: number;
+  mentionCandidateCount: number;
+}): boolean {
+  return (
+    args.requiresMention &&
+    !args.dockActive &&
+    !args.alreadyPrimed &&
+    args.draftLength === 0 &&
+    args.mentionCandidateCount > 0
+  );
+}


### PR DESCRIPTION
## What

The most recent live `format="request"` directed at the viewer now pins its **questions + options directly above the composer** (`RequestDock`); that request's timeline card suppresses its inline answer block, so the answering surface exists exactly once. The long narrative body stays in the timeline message.

Try it at `/preview/request-dock` (DEV-only, covers single / free-text / multi-question / option+note).

## The contract (single button, draft text decides)

| You do | Send does |
|---|---|
| Click an option | Option text REPLACES the draft (multi-question → canonical `prompt → answer` lines) |
| Send an untouched clean answer | Direct resolve: `metadata.resolves kind="answered"`, threads under the request, red dot clears |
| Edit / type anything else | Plain reply threaded for the asker to judge — question stays open |
| Type the exact option text by hand | Same as clicking it (selection highlight is **derived** from the draft) |

- **Derived selection state** — no stored selections; `recoverAnswerSelections(draft)` drives the highlight. The send mutation's draft restore (onError) therefore keeps resolve semantics across a failed-send retry for free.
- **Dock-asker default recipient** — while a question is docked, an un-addressed group-chat send routes to the asker (matches the dock helper line; no typed @mention needed, like the old inline answer block).
- **Free-text answers always go to the asker to judge** (resolution via `chat send --answer/--close`) — per the v4 design, confirmed by @yuezengwu 2026-06-11.
- **Optimistic resolve** — the optimistic row carries `resolves`/`mentions`/`inReplyTo`, so the dock unpins and the card flips to RESOLVED instantly (no double-answer window on slow links).
- Watchers never dock (read-only view keeps the inline card); `findLiveRequest` unifies the dock's pin choice with reply threading; `parseAnswerSelections` matches prompts as prefixes so a prompt containing " → " round-trips.

## Review

Self-reviewed with a 7-angle finder + per-candidate verify pass; all CONFIRMED findings (failed-retry downgrade, group-chat judge-path dead end, optimistic-row dock persistence, dock-retarget on new request, watcher suppression gap, arrow-in-prompt parsing) are fixed in this PR.

## Context Tree

Companion tree PR (decision record, opened first): agent-team-foundation/first-tree-context#487

## QA

- 756 web tests green (17 new: dock helpers, derived-model round-trip invariant, prefix parsing)
- `pnpm check` + `pnpm typecheck` clean
- Interaction contract verified in a headless browser against the v4 prototype (click-fills-replace, edit-clears-highlight, hand-typed clean answer, multi-question canonical lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
