### PR TITLE
fix(client): stop scheduler from silently dropping preempted in-progress turns

### DIFF
--- a/packages/client/src/__tests__/config.test.ts
+++ b/packages/client/src/__tests__/config.test.ts
@@ -29,9 +29,9 @@ agents:
     // Defaults are kept in lock-step with `@first-tree/shared`
     // `agentConfigSchema` — see runtime/config.ts. The shipped CLI goes
     // through that schema; this YAML loader is the legacy back-door.
-    expect(nova?.concurrency).toBe(5);
+    expect(nova?.concurrency).toBe(99);
     expect(nova?.session.idle_timeout).toBe(300);
-    expect(nova?.session.max_sessions).toBe(10);
+    expect(nova?.session.max_sessions).toBe(99);
     expect(nova?.session.working_grace_seconds).toBe(3600);
   });
 

--- a/packages/client/src/__tests__/session-manager.test.ts
+++ b/packages/client/src/__tests__/session-manager.test.ts
@@ -1,4 +1,4 @@
-import type { AgentRuntimeConfig } from "@first-tree/shared";
+import type { AgentRuntimeConfig, SessionEvent } from "@first-tree/shared";
 import type pino from "pino";
 import { describe, expect, it, vi } from "vitest";
 import type { AgentConfigCache } from "../runtime/agent-config-cache.js";
@@ -60,6 +60,7 @@ function createSessionManager(opts: {
   log?: pino.Logger;
   agentConfigCache?: AgentConfigCache;
   recoverChat?: (chatId: string) => Promise<void>;
+  onSessionEvent?: (chatId: string, event: SessionEvent) => void;
 }) {
   const handler = opts.handler ?? createMockHandler();
   const factory: HandlerFactory = opts.handlerFactory ?? (() => handler);
@@ -91,6 +92,7 @@ function createSessionManager(opts: {
     log: opts.log ?? silentLogger(),
     ackEntry: opts.ackEntry ?? mockAckEntry(),
     recoverChat: opts.recoverChat,
+    onSessionEvent: opts.onSessionEvent,
     agentConfigCache: opts.agentConfigCache,
   });
 }
@@ -1256,6 +1258,240 @@ describe("SessionManager lazy Context Tree binding", () => {
     await sm.dispatch(mockEntry({ id: 2, chatId: "c-once", messageId: "m2" }));
 
     expect(resolve).toHaveBeenCalledTimes(1);
+
+    await sm.shutdown();
+  });
+});
+
+/**
+ * #973 — Concurrency preemption must not silently drop in-progress turns.
+ *
+ * The dangerous path before the fix: `acquireActiveSlot` picked any LRU
+ * active session as the preemption victim and routed it through the same
+ * suspend path as a normal idle pause — which ACKed the consumed in-flight
+ * prefix. For a victim mid-turn the provider turn had not committed, so the
+ * ACK destroyed the only durable redelivery cursor; `evictIfNeeded` later
+ * discarded the suspended session and a quiet chat never produced the
+ * bind/recovery trigger to get its task back.
+ */
+describe("SessionManager preemption of working sessions (#973)", () => {
+  type ChatHarness = {
+    handlers: Map<string, AgentHandler>;
+    ctxs: Map<string, SessionContext>;
+    resumes: Array<{ chatId: string; sessionId: string }>;
+    factory: HandlerFactory;
+  };
+
+  /** Per-chat handler factory that records each chat's handler + ctx. */
+  function chatHarness(): ChatHarness {
+    const handlers = new Map<string, AgentHandler>();
+    const ctxs = new Map<string, SessionContext>();
+    const resumes: Array<{ chatId: string; sessionId: string }> = [];
+    const factory: HandlerFactory = () => {
+      const handler: AgentHandler = createMockHandler({
+        start: vi.fn(async (msg: { chatId: string }, ctx: SessionContext) => {
+          handlers.set(msg.chatId, handler);
+          ctxs.set(msg.chatId, ctx);
+          return `session-${msg.chatId}`;
+        }),
+        resume: vi.fn(async (msg: { chatId: string } | undefined, sessionId: string, ctx: SessionContext) => {
+          const chatId = msg?.chatId ?? ctx.chatId;
+          handlers.set(chatId, handler);
+          ctxs.set(chatId, ctx);
+          resumes.push({ chatId, sessionId });
+          return sessionId || `session-${chatId}`;
+        }),
+      });
+      return handler;
+    };
+    return { handlers, ctxs, resumes, factory };
+  }
+
+  function flushDeferred(): Promise<void> {
+    return new Promise((resolve) => setImmediate(() => setImmediate(resolve)));
+  }
+
+  /**
+   * With a `recoverChat` callback configured, the FIRST dispatch for a chat
+   * with no healthy live handler is consumed by the recovery gate (it asks
+   * the server to reset + redeliver); the second dispatch models the
+   * redelivered frame. Same double-dispatch idiom as the LRU-eviction
+   * recovery test above.
+   */
+  async function deliver(sm: SessionManager, entry: ReturnType<typeof mockEntry>): Promise<void> {
+    await sm.dispatch(entry);
+    await sm.dispatch(entry);
+  }
+
+  it("concurrency=1: preempting a working session does NOT ack its in-flight entry and proactively requests chat recovery", async () => {
+    const ackEntry = mockAckEntry();
+    const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
+    const h = chatHarness();
+    const sm = createSessionManager({ ackEntry, handlerFactory: h.factory, concurrency: 1, recoverChat });
+
+    // chat-a starts a turn and reports working — its entry is consumed by
+    // the provider turn but the turn has NOT completed.
+    await deliver(sm, mockEntry({ id: 1, chatId: "chat-a", messageId: "msg-a" }));
+    const ctxA = h.ctxs.get("chat-a");
+    expect(ctxA).toBeDefined();
+    ctxA?.setRuntimeState("working");
+    ctxA?.markMessagesConsumed({
+      inboxEntryId: 1,
+      id: "msg-a",
+      chatId: "chat-a",
+      senderId: "sender-1",
+      format: "text",
+      content: "x",
+      metadata: {},
+    });
+    recoverChat.mockClear();
+
+    // chat-b's fresh message preempts chat-a (last resort — no idle victim).
+    await deliver(sm, mockEntry({ id: 2, chatId: "chat-b", messageId: "msg-b" }));
+    await flushDeferred();
+
+    expect(h.handlers.get("chat-a")?.suspend).toHaveBeenCalledTimes(1);
+    expect(h.handlers.get("chat-b")?.start).toHaveBeenCalledTimes(1);
+    // The interrupted turn's entry must NOT be acked — it is the only
+    // durable redelivery handle.
+    expect(ackEntry).not.toHaveBeenCalled();
+    // And redelivery must be requested proactively — no new inbound input
+    // on quiet chat-a will ever arrive to trigger it lazily.
+    expect(recoverChat).toHaveBeenCalledWith("chat-a");
+
+    await sm.shutdown();
+  });
+
+  it("recovery-resume traffic queues instead of preempting another working session, and resumes when the slot frees (no livelock)", async () => {
+    const ackEntry = mockAckEntry();
+    const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
+    const h = chatHarness();
+    const sm = createSessionManager({ ackEntry, handlerFactory: h.factory, concurrency: 1, recoverChat });
+
+    // chat-a working → preempted by chat-b (which then also works).
+    await deliver(sm, mockEntry({ id: 1, chatId: "chat-a", messageId: "msg-a" }));
+    h.ctxs.get("chat-a")?.setRuntimeState("working");
+    recoverChat.mockClear();
+    await deliver(sm, mockEntry({ id: 2, chatId: "chat-b", messageId: "msg-b" }));
+    h.ctxs.get("chat-b")?.setRuntimeState("working");
+    await flushDeferred();
+    expect(recoverChat).toHaveBeenCalledWith("chat-a");
+
+    // The server redelivers chat-a's entry (same id). chat-a is owed a
+    // recovery resume — it must NOT abort chat-b's working turn; it queues.
+    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a", messageId: "msg-a" }));
+    expect(h.handlers.get("chat-b")?.suspend).not.toHaveBeenCalled();
+    expect(h.resumes.filter((r) => r.chatId === "chat-a")).toHaveLength(0);
+
+    // chat-b's turn closes → its slot is yielded to the queue and chat-a
+    // resumes its interrupted turn — with no new inbound input for chat-a.
+    const ctxB = h.ctxs.get("chat-b");
+    ctxB?.markCompleted();
+    ctxB?.setRuntimeState("idle");
+    await vi.waitFor(() => {
+      expect(h.resumes.filter((r) => r.chatId === "chat-a")).toHaveLength(1);
+    });
+    expect(h.resumes[0]?.sessionId).toBe("session-chat-a");
+
+    await sm.shutdown();
+  });
+
+  it("prefers an idle-active victim over an older working session", async () => {
+    const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
+    const h = chatHarness();
+    const sm = createSessionManager({ handlerFactory: h.factory, concurrency: 2, recoverChat });
+
+    // chat-a is OLDER (LRU) and working; chat-b is newer and idle.
+    await deliver(sm, mockEntry({ id: 1, chatId: "chat-a", messageId: "msg-a" }));
+    h.ctxs.get("chat-a")?.setRuntimeState("working");
+    await deliver(sm, mockEntry({ id: 2, chatId: "chat-b", messageId: "msg-b" }));
+    h.ctxs.get("chat-b")?.markCompleted();
+    h.ctxs.get("chat-b")?.setRuntimeState("idle");
+    await flushDeferred();
+    recoverChat.mockClear();
+
+    // chat-c needs a slot: the idle chat-b must be the victim even though
+    // chat-a is least-recently-active.
+    await deliver(sm, mockEntry({ id: 3, chatId: "chat-c", messageId: "msg-c" }));
+    expect(h.handlers.get("chat-b")?.suspend).toHaveBeenCalledTimes(1);
+    expect(h.handlers.get("chat-a")?.suspend).not.toHaveBeenCalled();
+    // Idle victim ⇒ normal suspend semantics ⇒ no recovery needed for it.
+    expect(recoverChat).not.toHaveBeenCalledWith("chat-b");
+
+    await sm.shutdown();
+  });
+
+  it("max_sessions eviction of a suspended session with an unfinished turn proactively requests recovery and leaves no entry stranded", async () => {
+    const ackEntry = mockAckEntry();
+    const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
+    const h = chatHarness();
+    const sm = createSessionManager({
+      ackEntry,
+      handlerFactory: h.factory,
+      concurrency: 1,
+      recoverChat,
+      session: { idle_timeout: 300, max_sessions: 2, working_grace_seconds: 3600, reconcile_interval_seconds: 300 },
+    });
+
+    // chat-a working → preempt-aborted by chat-b. Its proactive recovery is
+    // requested but the redelivery has not arrived yet.
+    await deliver(sm, mockEntry({ id: 1, chatId: "chat-a", messageId: "msg-a" }));
+    h.ctxs.get("chat-a")?.setRuntimeState("working");
+    recoverChat.mockClear();
+    await deliver(sm, mockEntry({ id: 2, chatId: "chat-b", messageId: "msg-b" }));
+    h.ctxs.get("chat-b")?.setRuntimeState("working");
+    await flushDeferred();
+    expect(recoverChat.mock.calls.filter(([chatId]) => chatId === "chat-a")).toHaveLength(1);
+
+    // chat-c trips max_sessions (2) — suspended chat-a is the eviction
+    // candidate while still owed its recovery resume. Eviction must
+    // re-request recovery rather than waiting for a bind reset that a
+    // quiet chat never triggers.
+    await deliver(sm, mockEntry({ id: 3, chatId: "chat-c", messageId: "msg-c" }));
+    await flushDeferred();
+    expect(recoverChat.mock.calls.filter(([chatId]) => chatId === "chat-a").length).toBeGreaterThanOrEqual(2);
+    // Nothing got acked along the way — the interrupted turn's entry stays
+    // durable on the server.
+    expect(ackEntry).not.toHaveBeenCalled();
+
+    await sm.shutdown();
+  });
+
+  it("emits explicit limit events when a chat is preempted, queued, or evicted with pending recovery", async () => {
+    const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
+    const events: Array<{ chatId: string; message: string }> = [];
+    const h = chatHarness();
+    const sm = createSessionManager({
+      handlerFactory: h.factory,
+      concurrency: 1,
+      recoverChat,
+      session: { idle_timeout: 300, max_sessions: 2, working_grace_seconds: 3600, reconcile_interval_seconds: 300 },
+      onSessionEvent: (chatId, event) => {
+        if (event.kind === "error") events.push({ chatId, message: String(event.payload.message) });
+      },
+    });
+    const eventsFor = (chatId: string, prefix: string) =>
+      events.filter((e) => e.chatId === chatId && e.message.startsWith(prefix));
+
+    // chat-a working → preempted mid-turn by chat-b: the victim chat gets an
+    // explicit "preempted, will auto-resume" event instead of going silent.
+    await deliver(sm, mockEntry({ id: 1, chatId: "chat-a", messageId: "msg-a" }));
+    h.ctxs.get("chat-a")?.setRuntimeState("working");
+    await deliver(sm, mockEntry({ id: 2, chatId: "chat-b", messageId: "msg-b" }));
+    h.ctxs.get("chat-b")?.setRuntimeState("working");
+    await flushDeferred();
+    expect(eventsFor("chat-a", "resilience.session.preempted")).toHaveLength(1);
+
+    // chat-a's recovery redelivery cannot take a slot (chat-b is working and
+    // recovery traffic never aborts working turns) — explicit queued event.
+    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a", messageId: "msg-a" }));
+    expect(eventsFor("chat-a", "resilience.session.slot_queued")).toHaveLength(1);
+
+    // chat-c trips max_sessions while chat-a is still owed its resume — the
+    // eviction is announced rather than silent.
+    await deliver(sm, mockEntry({ id: 3, chatId: "chat-c", messageId: "msg-c" }));
+    await flushDeferred();
+    expect(eventsFor("chat-a", "resilience.session.evicted_pending_recovery")).toHaveLength(1);
 
     await sm.shutdown();
   });

--- a/packages/client/src/__tests__/session-manager.test.ts
+++ b/packages/client/src/__tests__/session-manager.test.ts
@@ -1495,4 +1495,47 @@ describe("SessionManager preemption of working sessions (#973)", () => {
 
     await sm.shutdown();
   });
+
+  it("waits for the evicted handler's teardown before resuming the chat on a fresh handler (no two live handlers per chat)", async () => {
+    // PR #982 review finding: eviction fires `handler.shutdown()` without
+    // awaiting it, then proactive recovery redelivers — a fresh handler
+    // must NOT start for that chat until the old one has actually stopped.
+    const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
+    const h = chatHarness();
+    const sm = createSessionManager({
+      handlerFactory: h.factory,
+      concurrency: 5,
+      recoverChat,
+      session: { idle_timeout: 300, max_sessions: 2, working_grace_seconds: 3600, reconcile_interval_seconds: 300 },
+    });
+
+    // chat-a active with an unfinished turn; its handler's shutdown blocks
+    // until we release the gate.
+    await deliver(sm, mockEntry({ id: 1, chatId: "chat-a", messageId: "msg-a" }));
+    const shutdownGate = deferred<void>();
+    const handlerA = h.handlers.get("chat-a");
+    expect(handlerA).toBeDefined();
+    (handlerA?.shutdown as ReturnType<typeof vi.fn>).mockReturnValue(shutdownGate.promise);
+
+    await deliver(sm, mockEntry({ id: 2, chatId: "chat-b", messageId: "msg-b" }));
+    // chat-c trips max_sessions — chat-a (LRU) is evicted while active; its
+    // shutdown is now in flight, and proactive recovery is scheduled.
+    await deliver(sm, mockEntry({ id: 3, chatId: "chat-c", messageId: "msg-c" }));
+    await flushDeferred();
+    expect(recoverChat).toHaveBeenCalledWith("chat-a");
+
+    // The recovery redelivery arrives while the old handler is still
+    // shutting down — the resume must block on the teardown.
+    const redelivery = sm.dispatch(mockEntry({ id: 1, chatId: "chat-a", messageId: "msg-a" }));
+    await flushDeferred();
+    expect(h.resumes.filter((r) => r.chatId === "chat-a")).toHaveLength(0);
+
+    // Old handler finishes stopping → the fresh handler may now resume.
+    shutdownGate.resolve(undefined);
+    await redelivery;
+    expect(h.resumes.filter((r) => r.chatId === "chat-a")).toHaveLength(1);
+    expect(h.resumes[0]?.sessionId).toBe("session-chat-a");
+
+    await sm.shutdown();
+  });
 });

--- a/packages/client/src/runtime/config.ts
+++ b/packages/client/src/runtime/config.ts
@@ -18,7 +18,9 @@ import { z } from "zod";
 const sessionConfigSchema = z
   .object({
     idle_timeout: z.number().int().positive().default(300),
-    max_sessions: z.number().int().positive().default(10),
+    // Effectively-unbounded default (#973) — see the rationale comment in
+    // `packages/shared/src/config/agent-config.ts`; keep in lock-step.
+    max_sessions: z.number().int().positive().default(99),
     /**
      * Upper bound on how long `working` / `blocked` may keep a session
      * alive past `idle_timeout` before force-suspend. See `evictIdle` in
@@ -35,7 +37,8 @@ const agentSlotConfigSchema = z
     agentId: z.string().min(1),
     type: z.string().min(1),
     session: sessionConfigSchema.prefault({}),
-    concurrency: z.number().int().positive().default(5),
+    // Effectively-unbounded default (#973) — see agent-config.ts rationale.
+    concurrency: z.number().int().positive().default(99),
   })
   .passthrough();
 

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -80,6 +80,23 @@ type PendingMessage = {
 };
 
 /**
+ * Why a session is being suspended. The reason decides what happens to the
+ * chat's in-flight inbox entries (#973):
+ *
+ * - `idle` / `command` / `yield` — the provider turn has closed (or the
+ *   operator explicitly paused the chat). ACK the consumed prefix, clear the
+ *   unconsumed tail for recovery. This is the historical suspend semantics.
+ * - `preempt` — another chat is forcibly taking this session's active slot
+ *   while its provider turn may NOT have committed. ACKing the consumed
+ *   prefix here would discard the only durable redelivery handle for the
+ *   interrupted turn, silently dropping the task (issue #973). Instead the
+ *   whole in-flight queue is cleared for recovery and a proactive
+ *   chat-scoped recovery is scheduled so the turn re-runs without waiting
+ *   for new inbound input.
+ */
+type SuspendReason = "idle" | "command" | "preempt" | "yield";
+
+/**
  * Resolve the directory the runtime reads markdown doc snapshots against —
  * the same dir the handler actually hands the agent as cwd for this chat.
  *
@@ -358,6 +375,15 @@ export class SessionManager {
   private readonly recoveringChats = new Map<string, Promise<void>>();
   private readonly recoveryActivationReady = new Set<string>();
   private readonly requiresInboxRecovery = new Set<string>();
+  /**
+   * Chats whose interrupted turn is owed a recovery resume (preempt-abort or
+   * eviction with unfinished in-flight entries — #973). While a chat is in
+   * this set, its slot acquisition must NOT preempt another chat's working
+   * session: recovery traffic preempting working turns would let two
+   * oversubscribed chats abort each other forever (livelock). The flag is
+   * cleared the moment the chat successfully acquires a slot.
+   */
+  private readonly recoveryResumePending = new Set<string>();
   private readonly pendingQueue: PendingMessage[] = [];
   private readonly lastReportedStates = new Map<string, SessionState>();
   private readonly sessionRuntimeStates = new Map<string, RuntimeState>();
@@ -558,7 +584,7 @@ export class SessionManager {
       const session = this.sessions.get(chatId);
       if (session?.status === "active") {
         this.config.log.info({ chatId }, "suspend command received");
-        this.suspendSession(session);
+        this.suspendSession(session, "command");
       }
       return;
     }
@@ -583,6 +609,7 @@ export class SessionManager {
       this.sessionRuntimeStates.delete(chatId);
       this.lastReportedStates.delete(chatId);
       this.currentTrigger.delete(chatId);
+      this.recoveryResumePending.delete(chatId);
 
       for (let i = this.pendingQueue.length - 1; i >= 0; i--) {
         if (this.pendingQueue[i]?.chatId === chatId) this.pendingQueue.splice(i, 1);
@@ -660,6 +687,7 @@ export class SessionManager {
     this.evictedMappings.clear();
     this.lastReportedStates.clear();
     this.sessionRuntimeStates.clear();
+    this.recoveryResumePending.clear();
     this.lastReportedRuntimeState = null;
     this._activeCount = 0;
   }
@@ -759,35 +787,63 @@ export class SessionManager {
   }
 
   private async recoverChatBeforeDispatch(chatId: string, entryId: number, messageId: string): Promise<void> {
-    const existing = this.recoveringChats.get(chatId);
-    if (existing) {
-      await existing;
-      return;
-    }
-    const recoverChat = this.config.recoverChat;
-    if (!recoverChat) {
+    if (!this.config.recoverChat) {
       this.config.log.error(
         { chatId, entryId, messageId },
         "chat requires inbox recovery but no recoverChat callback is configured; deferring dispatch",
       );
       return;
     }
+    await this.beginChatRecovery(chatId, { entryId, messageId });
+  }
+
+  /**
+   * Start (or join) a chat-scoped inbox recovery: ask the server to reset
+   * this chat's delivered-but-unacked rows back to pending and redeliver
+   * them on this connection. Deduplicated per chat — concurrent callers
+   * share one in-flight recovery promise.
+   */
+  private beginChatRecovery(chatId: string, logCtx: Record<string, unknown>): Promise<void> {
+    const existing = this.recoveringChats.get(chatId);
+    if (existing) return existing;
+    const recoverChat = this.config.recoverChat;
+    if (!recoverChat) return Promise.resolve();
 
     let recovery: Promise<void>;
     recovery = recoverChat(chatId)
       .then(() => {
         this.requiresInboxRecovery.delete(chatId);
         this.recoveryActivationReady.add(chatId);
-        this.config.log.debug({ chatId, entryId, messageId }, "chat inbox recovery accepted before dispatch");
+        this.config.log.debug({ chatId, ...logCtx }, "chat inbox recovery accepted");
       })
       .catch((err) => {
-        this.config.log.warn({ chatId, entryId, messageId, err }, "chat inbox recovery failed before dispatch");
+        this.config.log.warn({ chatId, ...logCtx, err }, "chat inbox recovery failed");
       })
       .finally(() => {
         if (this.recoveringChats.get(chatId) === recovery) this.recoveringChats.delete(chatId);
       });
     this.recoveringChats.set(chatId, recovery);
-    await recovery;
+    return recovery;
+  }
+
+  /**
+   * Proactively schedule a chat-scoped recovery for a chat whose in-flight
+   * turn was interrupted (preempt-abort or eviction with unfinished
+   * entries — #973). Unlike `recoverChatBeforeDispatch` this is NOT driven
+   * by inbound input: a quiet chat would otherwise never produce the
+   * trigger and the interrupted task would stay silently dropped. Failure
+   * is non-fatal — the `requiresInboxRecovery` marker stays set, so the
+   * next inbound message or bind reset retries the redelivery.
+   */
+  private scheduleProactiveRecovery(chatId: string, reason: string): void {
+    if (!this.config.recoverChat) {
+      this.config.log.warn(
+        { chatId, reason },
+        "interrupted turn needs proactive inbox recovery but no recoverChat callback is configured; redelivery waits for the next inbound message or bind reset",
+      );
+      return;
+    }
+    void this.beginChatRecovery(chatId, { reason, proactive: true });
   }
 
   private async routeMessage(chatId: string, message: SessionMessage): Promise<void> {
@@ -1298,42 +1354,125 @@ export class SessionManager {
 
   /**
    * Try to acquire an active slot. If at concurrency limit:
-   * 1. Suspend the least-recently-active session to free a slot
-   * 2. If no candidates, queue the message
+   * 1. Suspend a victim session to free a slot — idle-active sessions first
+   *    (their turn has closed; suspending them loses nothing), then
+   *    working / blocked sessions as a last resort (#973: their interrupted
+   *    turn is preserved via the preempt-abort suspend path).
+   * 2. If no eligible victim, queue the message.
+   *
+   * A chat in `recoveryResumePending` (resuming an interrupted turn via
+   * recovery redelivery) may only take an idle victim — never abort another
+   * chat's working turn — otherwise two oversubscribed chats preempt each
+   * other's turns forever. Its message queues instead and drains when a
+   * slot frees up.
    *
    * Returns true if slot acquired, false if queued. The in-flight entryId
    * is tracked separately in `inFlightEntries` (populated at dispatch),
    * so the queue doesn't carry inbox metadata.
    */
   private acquireActiveSlot(chatId: string, message: SessionMessage): boolean {
-    if (this._activeCount < this.config.concurrency) return true;
-
-    // Find least-recently-active session (excluding the target chat)
-    let oldestActive: SessionEntry | null = null;
-    for (const session of this.sessions.values()) {
-      if (session.status !== "active") continue;
-      if (session.chatId === chatId) continue;
-      if (!oldestActive || session.lastActivity < oldestActive.lastActivity) {
-        oldestActive = session;
-      }
-    }
-
-    if (oldestActive) {
-      this.config.log.info({ chatId: oldestActive.chatId }, "session preempted for concurrency");
-      this.suspendSession(oldestActive);
+    if (this._activeCount < this.config.concurrency) {
+      this.recoveryResumePending.delete(chatId);
       return true;
     }
 
-    // All active sessions are busy — queue. The inbox entry stays in
+    const victim = this.findPreemptionVictim(chatId);
+    if (victim && (!victim.working || !this.recoveryResumePending.has(chatId))) {
+      this.config.log.info(
+        { chatId: victim.entry.chatId, victimWorking: victim.working, forChatId: chatId },
+        "session preempted for concurrency",
+      );
+      this.suspendSession(victim.entry, "preempt");
+      this.recoveryResumePending.delete(chatId);
+      return true;
+    }
+
+    // No eligible victim — queue. The inbox entry stays in
     // `inFlightEntries[chatId]` until the eventual turn finishes.
     this.config.log.info({ chatId }, "concurrency limit reached, queuing");
+    // #973: being limited must be visible, not silent — tell the chat why
+    // nothing is happening yet.
+    this.emitLimitEvent(chatId, "resilience.session.slot_queued", {
+      activeCount: this._activeCount,
+      concurrency: this.config.concurrency,
+      queuedAhead: this.pendingQueue.length,
+    });
     this.pendingQueue.push({ message, chatId });
     return false;
   }
 
-  private suspendSession(entry: SessionEntry): void {
-    this.ackConsumedInFlightForSuspend(entry.chatId);
-    this.clearInFlightForRecovery(entry.chatId, "session_suspended_unconsumed_tail");
+  /**
+   * Surface a concurrency / max_sessions limit event into the chat's
+   * timeline (#973: "being limited must come with an explicit signal").
+   * Uses the same closed-union `error`-kind + tagged-message bridge as the
+   * `resilience.session.retry_*` events — see {@link encodeResilienceMessage}.
+   * Best-effort: a failed emit never blocks scheduling.
+   */
+  private emitLimitEvent(chatId: string, eventName: string, payload: Record<string, unknown>): void {
+    try {
+      this.config.onSessionEvent?.(chatId, {
+        kind: "error",
+        payload: {
+          source: "runtime",
+          message: encodeResilienceMessage(eventName, payload),
+        },
+      });
+    } catch (emitErr) {
+      this.config.log.warn({ chatId, eventName, emitErr }, "limit event emit failed");
+    }
+  }
+
+  /**
+   * Pick the session to suspend when the concurrency limit is hit: the
+   * least-recently-active among idle-active sessions first; among
+   * working / blocked sessions only when no idle victim exists. A session
+   * with no recorded runtime state counts as idle — it has not reported a
+   * turn in flight.
+   */
+  private findPreemptionVictim(excludeChatId: string): { entry: SessionEntry; working: boolean } | null {
+    let idleVictim: SessionEntry | null = null;
+    let workingVictim: SessionEntry | null = null;
+    for (const session of this.sessions.values()) {
+      if (session.status !== "active") continue;
+      if (session.chatId === excludeChatId) continue;
+      const state = this.sessionRuntimeStates.get(session.chatId);
+      const working = state === "working" || state === "blocked";
+      if (working) {
+        if (!workingVictim || session.lastActivity < workingVictim.lastActivity) workingVictim = session;
+      } else if (!idleVictim || session.lastActivity < idleVictim.lastActivity) {
+        idleVictim = session;
+      }
+    }
+    if (idleVictim) return { entry: idleVictim, working: false };
+    if (workingVictim) return { entry: workingVictim, working: true };
+    return null;
+  }
+
+  private suspendSession(entry: SessionEntry, reason: SuspendReason): void {
+    const chatId = entry.chatId;
+    if (reason === "preempt" && (this.inFlightEntries.get(chatId)?.length ?? 0) > 0) {
+      // Preempt-abort (#973): the provider turn for the tracked entries has
+      // not committed — ACKing the consumed prefix would remove the durable
+      // redelivery cursor and silently drop the interrupted task. Clear the
+      // WHOLE queue for recovery (server rows stay `delivered`) and
+      // proactively ask the server to reset + redeliver them, so the turn
+      // re-runs without waiting for new inbound input on this chat.
+      this.clearInFlightForRecovery(chatId, "session_preempted_mid_turn");
+      this.recoveryResumePending.add(chatId);
+      // #973: explicit signal in the victim chat's timeline — its turn was
+      // interrupted to free a slot and will auto-resume via redelivery.
+      this.emitLimitEvent(chatId, "resilience.session.preempted", {
+        concurrency: this.config.concurrency,
+        willAutoResume: true,
+      });
+      this.scheduleProactiveRecovery(chatId, "session_preempted_mid_turn");
+    } else {
+      // Turn has closed (idle / yield), or operator intent (command):
+      // historical suspend semantics — commit what the provider consumed,
+      // leave the unconsumed tail for recovery on the next inbound input.
+      this.ackConsumedInFlightForSuspend(chatId);
+      this.clearInFlightForRecovery(chatId, "session_suspended_unconsumed_tail");
+    }
     entry.status = "suspended";
     this._activeCount--;
     // Clear per-session runtime state on suspend
@@ -1350,8 +1489,28 @@ export class SessionManager {
     this.persistRegistry();
     this.notifySessionState(entry.chatId, "suspended");
 
-    // Drain pending queue
-    this.drainPendingQueue();
+    // Drain the pending queue — EXCEPT on preemption: a preempt frees the
+    // slot specifically for the chat that requested it (the caller claims it
+    // right after this returns). Draining here would hand that slot to a
+    // queued chat synchronously and over-admit past the concurrency limit.
+    if (reason !== "preempt") this.drainPendingQueue();
+  }
+
+  /**
+   * Suspend a session whose turn has closed so a queued chat can take its
+   * slot (#973). Runs deferred from `setSessionRuntimeState("idle")`;
+   * re-checks every condition because the world may have moved on since
+   * the hook fired: the queue may have drained, a new turn may have
+   * started, or new same-chat input may already be tracked in-flight.
+   */
+  private yieldSlotToPendingQueue(chatId: string): void {
+    if (this.pendingQueue.length === 0) return;
+    const session = this.sessions.get(chatId);
+    if (!session || session.status !== "active") return;
+    if (this.sessionRuntimeStates.get(chatId) !== "idle") return;
+    if ((this.inFlightEntries.get(chatId)?.length ?? 0) > 0) return;
+    this.config.log.info({ chatId }, "turn closed with chats queued for a slot — yielding active slot");
+    this.suspendSession(session, "yield");
   }
 
   private drainPendingQueue(): void {
@@ -1417,6 +1576,22 @@ export class SessionManager {
       // `delivered`; a later chat recovery or bind reset redelivers them
       // against a fresh session.
       this.clearInFlightForRecovery(candidate.key, "session_evicted");
+      // #973: an evicted chat with an unfinished turn (in-flight entries
+      // just cleared above, or a pending recovery marker from an earlier
+      // preempt-abort whose redelivery has not landed yet) must not wait
+      // for a future bind reset that a quiet chat may never trigger —
+      // proactively ask the server to redeliver now. The redelivered
+      // message resumes the chat from `evictedMappings`.
+      if (this.requiresInboxRecovery.has(candidate.key) || this.recoveryResumePending.has(candidate.key)) {
+        this.recoveryResumePending.add(candidate.key);
+        // #973: explicit signal — the chat's session was discarded by the
+        // max_sessions cap while work was still owed; recovery is scheduled.
+        this.emitLimitEvent(candidate.key, "resilience.session.evicted_pending_recovery", {
+          maxSessions: max_sessions,
+          willAutoResume: true,
+        });
+        this.scheduleProactiveRecovery(candidate.key, "session_evicted_unfinished");
+      }
       this.recomputeRuntimeState();
       this.persistRegistry();
     }
@@ -1497,7 +1672,7 @@ export class SessionManager {
         },
         "session idle, suspending",
       );
-      this.suspendSession(session);
+      this.suspendSession(session, "idle");
     }
   }
 
@@ -1761,6 +1936,14 @@ export class SessionManager {
     const session = this.sessions.get(chatId);
     if (!session || session.status !== "active") return;
     this.sessionRuntimeStates.set(chatId, state);
+    // #973: a turn just closed while other chats are queued for a slot —
+    // yield this session's slot instead of holding it idle until the
+    // `idle_timeout` reaper. Deferred so the handler's turn-close path
+    // (forwardResult / markCompleted bookkeeping) finishes first; the
+    // deferred body re-checks every condition.
+    if (state === "idle" && this.pendingQueue.length > 0) {
+      setImmediate(() => this.yieldSlotToPendingQueue(chatId));
+    }
     // Per-chat D-axis report: the authoritative source the server-side
     // composite reads. Fire before recomputing the agent-global aggregate
     // so a single state change drops one frame on each wire (the per-chat

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -327,9 +327,19 @@ export function encodeResilienceMessage(eventName: string, payload: Record<strin
   return `${eventName}: ${JSON.stringify(payload)}`;
 }
 
+/**
+ * Mapping kept for a chat whose session was LRU-evicted, so a later resume
+ * can restore the provider context. `cleanup` (runtime-only, never persisted)
+ * settles when the evicted handler's suspend/shutdown has actually finished —
+ * a fresh handler for the same chat must wait on it, otherwise a proactive
+ * recovery redelivery can overlap two live handlers for one chat (the
+ * `(agent, chat) = 1 live handler` boundary, see PR #982 review).
+ */
+type EvictedMapping = { claudeSessionId: string; lastActivity: number; cleanup?: Promise<void> };
+
 export class SessionManager {
   private readonly sessions = new Map<string, SessionEntry>();
-  private readonly evictedMappings = new Map<string, { claudeSessionId: string; lastActivity: number }>();
+  private readonly evictedMappings = new Map<string, EvictedMapping>();
   private readonly config: SessionManagerConfig;
   /** Last lazy Context-Tree re-resolution attempt (epoch ms); see `TREE_RERESOLVE_INTERVAL_MS`. */
   private lastTreeResolveAttemptAt = 0;
@@ -991,6 +1001,12 @@ export class SessionManager {
     this.notifySessionState(chatId, "active");
     try {
       if (evicted) {
+        // The evicted handler's suspend/shutdown may still be in flight
+        // (fire-and-forget at eviction). Wait for it to settle before
+        // starting a fresh handler for the same chat — at most one live
+        // handler per (agent, chat). The promise never rejects (teardown
+        // errors are caught at capture).
+        if (evicted.cleanup) await evicted.cleanup;
         const sessionId = await handler.resume(message, evicted.claudeSessionId, ctx);
         entry.claudeSessionId = sessionId;
         this.config.log.info({ chatId, sessionId }, "session resumed from eviction");
@@ -1545,17 +1561,27 @@ export class SessionManager {
     }
 
     if (candidate) {
+      this.config.log.info({ chatId: candidate.key }, "session evicted (max_sessions reached)");
+      // Capture the old handler's teardown promise so a resume for this chat
+      // (proactive recovery redelivery, or any later message) waits for the
+      // previous handler to actually stop before starting a fresh one — an
+      // active candidate's shutdown is fire-and-forget, and a just-preempted
+      // suspended candidate may still have `suspending` in flight (PR #982
+      // review finding).
+      let cleanup: Promise<void> | undefined;
+      if (candidate.session.status === "active") {
+        this._activeCount--;
+        cleanup = candidate.session.handler.shutdown().catch(() => {});
+      } else if (candidate.session.suspending) {
+        cleanup = candidate.session.suspending;
+      }
+
       // Preserve mapping for future recovery
       this.addEvictedMapping(candidate.key, {
         claudeSessionId: candidate.session.claudeSessionId,
         lastActivity: candidate.session.lastActivity,
+        cleanup,
       });
-
-      this.config.log.info({ chatId: candidate.key }, "session evicted (max_sessions reached)");
-      if (candidate.session.status === "active") {
-        this._activeCount--;
-        candidate.session.handler.shutdown().catch(() => {});
-      }
       // LRU eviction is local memory-management, not operator intent — do
       // NOT emit a wire state here. The chat now lives in `evictedMappings`
       // and the next `agent:bound` (initial bind or reconnect) will pick it
@@ -1677,7 +1703,7 @@ export class SessionManager {
   }
 
   /** Add an evicted mapping, pruning the oldest if over capacity. */
-  private addEvictedMapping(chatId: string, mapping: { claudeSessionId: string; lastActivity: number }): void {
+  private addEvictedMapping(chatId: string, mapping: EvictedMapping): void {
     this.evictedMappings.set(chatId, mapping);
     if (this.evictedMappings.size > MAX_EVICTED_MAPPINGS) {
       // Map iteration order is insertion order — first key is the oldest

--- a/packages/shared/src/config/agent-config.ts
+++ b/packages/shared/src/config/agent-config.ts
@@ -16,10 +16,17 @@ export const agentConfigSchema = defineConfig({
   agentId: field(z.string().min(1)),
   /** Runtime handler type (e.g. "claude-code"). NOT the agent business type. */
   runtime: field(z.string().default("claude-code")),
-  concurrency: field(z.number().int().positive().default(5)),
+  // Effectively-unbounded defaults (#973): hitting either limit interrupts
+  // or queues real work, so the limits exist as resource guardrails an
+  // operator opts INTO by lowering them — not as everyday scheduling. The
+  // idle reaper (`idle_timeout`, 300 s) is what actually bounds steady-state
+  // active provider processes; `concurrency` only caps simultaneous
+  // overlapping turns. When a limit IS hit, the runtime emits an explicit
+  // `resilience.session.*` event instead of limiting silently.
+  concurrency: field(z.number().int().positive().default(99)),
   session: {
     idle_timeout: field(z.number().int().positive().default(300)),
-    max_sessions: field(z.number().int().positive().default(10)),
+    max_sessions: field(z.number().int().positive().default(99)),
     // Upper bound on how long a session may stay `working`/`blocked` past
     // `idle_timeout` before the runtime force-suspends it. Protects long
     // thinking / large message generation from idle eviction while still


### PR DESCRIPTION
Fixes #973

## Problem

Concurrency preemption routed a **working** session through the same suspend path as a normal idle pause:
1. `suspendSession` ACKed the consumed in-flight prefix — for an uncommitted turn this destroys the only durable redelivery cursor
2. nothing re-queued or resumed the interrupted turn (resume was new-input-driven only)
3. `evictIfNeeded` later discarded the suspended session; a quiet chat never produced the bind/recovery trigger

Net effect (observed in production, see #973): the task was silently dropped and the chat showed `working` forever.

## Fix (follows the triage plan in #973)

1. **Suspend semantics split by reason** (`SuspendReason`): `idle`/`command`/`yield` keep the historical contract (ACK consumed prefix, clear unconsumed tail). `preempt` of an uncommitted turn ACKs **nothing** — the whole in-flight queue is cleared for recovery and the server rows stay `delivered` as the redelivery handle.
2. **Victim selection** (`findPreemptionVictim`): idle-active sessions first (turn closed — suspending loses nothing); working/blocked sessions are last-resort victims for fresh external input only.
3. **Proactive chat recovery**: preempt-abort and `max_sessions` eviction-with-owed-work immediately request `inbox:recover` (existing protocol; server side is trigger-agnostic), so a quiet chat's interrupted turn re-runs without new inbound input.
4. **Livelock guard** (`recoveryResumePending`): recovery-resume traffic never preempts a working session — it queues and drains when a slot frees. Without this, two oversubscribed chats abort each other's turns forever.
5. **Slot yield on turn close**: when chats are queued, a session whose runtime state flips to idle yields its slot immediately instead of holding it for the `idle_timeout` reaper.
6. **Effectively-unbounded defaults**: `concurrency` 5→99, `session.max_sessions` 10→99 (both schemas in lock-step; still per-agent configurable). Limits become resource guardrails an operator opts into by lowering them; the idle reaper is what bounds steady-state provider processes.
7. **Explicit limit events**: `resilience.session.preempted` / `slot_queued` / `evicted_pending_recovery` are emitted into the affected chat's timeline (same bridge as the `retry_*` events) — being limited is visible, never silent.
8. Drive-by: `suspendSession` no longer drains the pending queue on a preempt — the freed slot belongs to the preemptor; draining there over-admitted past the concurrency limit (pre-existing).

## Tests

5 new regression cases in `session-manager.test.ts` covering the triage list:
- `concurrency=1` preempt of a working session: no ACK + proactive `recoverChat`
- recovery-resume queues instead of preempting a working session; resumes via slot yield with **no new input** (anti-livelock end-to-end)
- idle victim preferred over older working session; idle victim keeps normal semantics
- `max_sessions` eviction of an unfinished suspended session: recovery re-requested, zero ACKs throughout
- all three limit events emitted

## Validation

- `pnpm check` (3 pre-existing hints in untouched files)
- `pnpm typecheck` (12 packages)
- client 1202 tests, shared 406 tests; scheduler-related files stress-run 3× stable

## Notes

- Known race: a handler completing its turn exactly as preemption lands → redelivery re-runs that turn once (at-least-once, same class as existing crash recovery).
- `session:suspend` operator command on a working session keeps the historical semantics (operator intent; out of scope).
- Tree contract update: agent-team-foundation/first-tree-context#488 (opened first per tree-write discipline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)