### PR TITLE
fix(web): restore single-line conversation list rows

### DIFF
--- a/packages/web/src/pages/workspace/conversations/__tests__/conversation-list-dom.test.tsx
+++ b/packages/web/src/pages/workspace/conversations/__tests__/conversation-list-dom.test.tsx
@@ -407,7 +407,7 @@ describe("ConversationList", () => {
     expect(container.textContent).not.toContain("Start with New chat.");
   });
 
-  it("renders the description second line with a last-message fallback, and a skeleton only when neither exists", async () => {
+  it("renders single-line rows: no description / preview second line, no skeleton", async () => {
     const rows = [
       row({ chatId: "chat-desc", title: "Has summary", description: "reviewing PR 916; CI green; awaiting approval" }),
       row({ chatId: "chat-nodesc", title: "No summary", description: null, lastMessagePreview: "ack — looking now" }),
@@ -415,21 +415,17 @@ describe("ConversationList", () => {
     ];
     const container = await renderDom(<StatefulList rows={rows} nextCursor={null} />, createClient(rows, null));
 
-    // The description text is rendered for the row that has one — it wins
-    // over the last-message preview.
-    expect(container.textContent).toContain("reviewing PR 916; CI green; awaiting approval");
-
-    // No description → the second line falls back to the last-message
-    // preview (default display, mirroring the title's fallback chain).
+    // Rows are title-only: neither the chat description nor the last-message
+    // preview renders in the list (the chat header is the surface that shows
+    // the description in full).
+    expect(container.textContent).not.toContain("reviewing PR 916; CI green; awaiting approval");
     const withFallback = rowButton(container, "No summary");
-    expect(withFallback.textContent).toContain("ack — looking now");
-    expect(withFallback.querySelector('[data-testid="row-description-skeleton"]')).toBeNull();
+    expect(withFallback.textContent).not.toContain("ack — looking now");
 
-    // Only a row with neither description nor preview shows the skeleton
-    // placeholder (an aria-hidden bar) — keeps every card equal height.
-    const withDesc = rowButton(container, "Has summary");
-    const empty = rowButton(container, "Empty chat");
-    expect(withDesc.querySelector('[data-testid="row-description-skeleton"]')).toBeNull();
-    expect(empty.querySelector('[data-testid="row-description-skeleton"]')).not.toBeNull();
+    // No skeleton placeholder either — single-line rows need no second-line
+    // height keeper.
+    for (const title of ["Has summary", "No summary", "Empty chat"]) {
+      expect(rowButton(container, title).querySelector('[data-testid="row-description-skeleton"]')).toBeNull();
+    }
   });
 });

--- a/packages/web/src/pages/workspace/conversations/index.tsx
+++ b/packages/web/src/pages/workspace/conversations/index.tsx
@@ -531,20 +531,14 @@ export function ConversationList({
                         type="button"
                         onClick={() => onSelectChat(row.chatId)}
                         className={cn(
-                          "w-full text-left transition-colors flex items-start",
+                          "w-full text-left transition-colors flex items-center",
                           "hover:bg-[var(--bg-hover)]",
                         )}
                         style={{
-                          // Fixed-height two-line cards: title line + a
-                          // description line (the chat's running work summary).
-                          // Height is pinned so every card is equal regardless
-                          // of whether a description is set — the list keeps a
-                          // steady rhythm, scrolling never reflows, and the
-                          // per-screen chat count stays predictable. Rows with
-                          // no description render a skeleton in the second line
-                          // rather than collapsing.
-                          height: 52,
-                          overflow: "hidden",
+                          // Single-line rows tuned for desktop-inbox density:
+                          // tightened vertical padding (--sp-2) now that the
+                          // preview subtitle line is gone, so more conversations
+                          // fit per screen without reading as a dense wall.
                           padding: "var(--sp-2) var(--sp-3)",
                           gap: "var(--sp-2)",
                           background: isSelected ? "var(--brand-bg)" : "transparent",
@@ -554,87 +548,46 @@ export function ConversationList({
                           borderLeft: `var(--hairline-bold) solid ${isSelected ? "var(--brand)" : "transparent"}`,
                         }}
                       >
-                        <span className="shrink-0" style={{ marginTop: 1 }}>
-                          <ChatRowAvatar
-                            title={row.title}
-                            type={row.type}
-                            participants={row.participants}
-                            selfAgentId={selfAgentId ?? ""}
-                            unreadCount={row.unreadMentionCount}
-                            failed={failed}
-                            needsYou={row.openRequestCount > 0}
-                            size={26}
-                            muted
-                            badge={false}
-                            statusDot
-                          />
+                        <ChatRowAvatar
+                          title={row.title}
+                          type={row.type}
+                          participants={row.participants}
+                          selfAgentId={selfAgentId ?? ""}
+                          unreadCount={row.unreadMentionCount}
+                          failed={failed}
+                          needsYou={row.openRequestCount > 0}
+                          size={26}
+                          muted
+                          badge={false}
+                          statusDot
+                        />
+                        <span
+                          className="truncate text-subtitle"
+                          style={{
+                            color: hasUnread || isSelected ? "var(--fg)" : "var(--fg-2)",
+                            fontWeight: hasUnread ? 700 : 500,
+                            flex: 1,
+                            minWidth: 0,
+                          }}
+                        >
+                          {row.title}
                         </span>
-                        <span className="flex flex-col min-w-0" style={{ flex: 1, minWidth: 0 }}>
-                          {/* Line 1 — title + right meta cluster. */}
-                          <span className="flex items-center" style={{ gap: 6 }}>
-                            <span
-                              className="truncate text-subtitle"
-                              style={{
-                                color: hasUnread || isSelected ? "var(--fg)" : "var(--fg-2)",
-                                fontWeight: hasUnread ? 700 : 500,
-                                flex: 1,
-                                minWidth: 0,
-                              }}
-                            >
-                              {row.title}
-                            </span>
-                            {/* Right meta cluster. Hidden on hover so the row's
-                                engagement menu can take the corner. */}
-                            <span
-                              className="shrink-0 inline-flex items-center transition-opacity group-hover:opacity-0 group-has-aria-expanded:opacity-0"
-                              style={{ gap: 6 }}
-                            >
-                              {isWatching && (
-                                <Eye
-                                  size={12}
-                                  strokeWidth={1.75}
-                                  style={{ color: "var(--fg-4)" }}
-                                  aria-label="watching"
-                                />
-                              )}
-                              {row.busyAgentIds.length > 0 ? (
-                                <ActivityDots />
-                              ) : row.lastMessageAt ? (
-                                <span className="mono text-caption" style={{ color: "var(--fg-4)" }}>
-                                  {formatRowTime(row.lastMessageAt)}
-                                </span>
-                              ) : null}
-                            </span>
-                          </span>
-                          {/* Line 2 — description (running work summary). Single
-                              line, truncated when long: the list is the density
-                              surface, so it stays equal-height and tidy. Like the
-                              title (topic → first-message → participants), the
-                              line has a default: when no description is set it
-                              falls back to the last-message preview, so the
-                              second line is informative by default instead of an
-                              empty placeholder. Only when neither exists does the
-                              skeleton bar keep the card's height. */}
-                          {(row.description ?? row.lastMessagePreview) ? (
-                            <span className="truncate text-label" style={{ color: "var(--fg-3)", marginTop: 2 }}>
-                              {row.description ?? row.lastMessagePreview}
-                            </span>
-                          ) : (
-                            <span
-                              aria-hidden
-                              data-testid="row-description-skeleton"
-                              style={{
-                                display: "block",
-                                height: 7,
-                                width: 128,
-                                maxWidth: "70%",
-                                marginTop: 5,
-                                borderRadius: 3,
-                                background: "linear-gradient(90deg, var(--bg-active), var(--bg-sunken))",
-                                opacity: 0.85,
-                              }}
-                            />
+                        {/* Right meta cluster — single line. Hidden on hover so
+                            the row's engagement menu can take the corner. */}
+                        <span
+                          className="shrink-0 inline-flex items-center transition-opacity group-hover:opacity-0 group-has-aria-expanded:opacity-0"
+                          style={{ gap: 6 }}
+                        >
+                          {isWatching && (
+                            <Eye size={12} strokeWidth={1.75} style={{ color: "var(--fg-4)" }} aria-label="watching" />
                           )}
+                          {row.busyAgentIds.length > 0 ? (
+                            <ActivityDots />
+                          ) : row.lastMessageAt ? (
+                            <span className="mono text-caption" style={{ color: "var(--fg-4)" }}>
+                              {formatRowTime(row.lastMessageAt)}
+                            </span>
+                          ) : null}
                         </span>
                       </button>
                       <div


### PR DESCRIPTION
## Summary

Restores the left conversation list to the pre-#916 **single-line row design**, per product feedback that the two-line cards make the rail too tall and the list should stay the density surface.

- Row layout back to: avatar + title + right meta cluster, vertically centered (`items-center`)
- Drops the fixed 52px two-line card, the description second line, the lastMessagePreview fallback (#980), and the skeleton placeholder
- **Scope is the list only** — the `description` data model, `MeChatRow.description` projection, CLI/agent write paths, and the chat header's inline topic+description display are all untouched

## Test plan

- Updated `conversation-list-dom.test.tsx`: rows render title-only (no description text, no preview fallback, no skeleton) — 4/4 pass
- Full web suite: 101 files / 742 tests pass
- `pnpm check && pnpm typecheck` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)