### PR TITLE
fix(server,web): rest the GitHub App install bind on the kickoff session, not the callback OAuth identity

### DIFF
--- a/packages/server/src/__tests__/github-app-callback-target-org.test.ts
+++ b/packages/server/src/__tests__/github-app-callback-target-org.test.ts
@@ -186,7 +186,7 @@ describe("/auth/github/callback honors targetOrganizationId in the state (codex 
     expect(row?.hubOrganizationId).not.toBe(admin.organizationId);
   });
 
-  it("403s when the user is not an admin of the target org", async () => {
+  it("refuses the bind (via the SPA error surface) when the user is not an admin of the target org", async () => {
     const app = getApp();
     const githubId = 770_002;
     const login = `targetorg-member-${uuidv7().slice(0, 6)}`;
@@ -227,12 +227,15 @@ describe("/auth/github/callback honors targetOrganizationId in the state (codex 
         url: `/api/v1/auth/github/callback?code=devcode&state=${token}&installation_id=${installationId}`,
         headers: { cookie: `${OAUTH_STATE_COOKIE}=${nonce}` },
       });
-      expect(res.statusCode).toBe(403);
+      // Browser-facing refusal: friendly SPA error page, not raw JSON.
+      expect(res.statusCode).toBe(302);
+      expect(res.headers.location).toContain("/auth/github/complete#");
+      expect(res.headers.location).toContain("error=install-not-admin");
     } finally {
       restore();
     }
 
-    // The install stays unbound — the 403 short-circuits before the bind.
+    // The install stays unbound — the refusal short-circuits before the bind.
     const row = await findInstallationByGithubId(app.db, installationId);
     expect(row?.hubOrganizationId).toBeNull();
   });
@@ -282,6 +285,92 @@ describe("/auth/github/callback honors targetOrganizationId in the state (codex 
     expect(row).toBeNull();
   });
 
+  it("binds via the kickoff session's authority when the callback GitHub identity differs", async () => {
+    // The incident class behind this test: an org admin kicks off the
+    // install (admin-gated, so their authority is proven at mint time),
+    // but the browser's github.com session belongs to a DIFFERENT GitHub
+    // identity (second account, recreated account, someone else's First Tree
+    // session in the same browser). GitHub completes the install either
+    // way; the bind must rest on the kickoff session signed into the
+    // state, not on whoever the OAuth code resolves to.
+    const app = getApp();
+    const kickoffGithubId = 770_005;
+    const strangerGithubId = 770_006;
+    const login = `targetorg-kickoff-${uuidv7().slice(0, 6)}`;
+    const installationId = 8_822_005;
+
+    // Kickoff admin: admin of their own org, linked to kickoffGithubId.
+    const admin = await createTestAdmin(app, { username: `${login}-u` });
+    await seedGithubIdentity(app, admin.userId, kickoffGithubId, login);
+
+    const { token, nonce } = await signOAuthState(TEST_JWT_SECRET, "/onboarding/connected", {
+      targetOrganizationId: admin.organizationId,
+      kickoffUserId: admin.userId,
+    });
+    // The OAuth exchange resolves a stranger identity (never seen before).
+    const restore = stubGithub({
+      githubId: strangerGithubId,
+      login: `${login}-stranger`,
+      installationIds: [installationId],
+    });
+    try {
+      const res = await app.inject({
+        method: "GET",
+        url: `/api/v1/auth/github/callback?code=devcode&state=${token}&installation_id=${installationId}`,
+        headers: { cookie: `${OAUTH_STATE_COOKIE}=${nonce}` },
+      });
+      // Install completes: redirect straight to `next` — and WITHOUT a
+      // token fragment, so the stranger identity must not replace the
+      // kickoff admin's browser session.
+      expect(res.statusCode).toBe(302);
+      expect(res.headers.location).toBe("/onboarding/connected");
+      expect(res.headers.location).not.toContain("access=");
+    } finally {
+      restore();
+    }
+
+    const row = await findInstallationByGithubId(app.db, installationId);
+    expect(row?.hubOrganizationId).toBe(admin.organizationId);
+  });
+
+  it("redirects to a friendly error page when the kickoff admin's membership was revoked mid-flight", async () => {
+    const app = getApp();
+    const githubId = 770_007;
+    const login = `targetorg-revoked-${uuidv7().slice(0, 6)}`;
+    const installationId = 8_822_006;
+
+    const admin = await createTestAdmin(app, { username: `${login}-u` });
+    await seedGithubIdentity(app, admin.userId, githubId, login);
+
+    const { token, nonce } = await signOAuthState(TEST_JWT_SECRET, "/settings/github", {
+      targetOrganizationId: admin.organizationId,
+      kickoffUserId: admin.userId,
+    });
+    // Membership revoked between mint and callback: flip role to member.
+    await app.db.update(members).set({ role: "member" }).where(eq(members.userId, admin.userId));
+
+    const restore = stubGithub({ githubId, login, installationIds: [installationId] });
+    try {
+      const res = await app.inject({
+        method: "GET",
+        url: `/api/v1/auth/github/callback?code=devcode&state=${token}&installation_id=${installationId}`,
+        headers: { cookie: `${OAUTH_STATE_COOKIE}=${nonce}` },
+      });
+      // Refusal is correct — but it must land on the SPA's friendly error
+      // surface, not a raw JSON body at the API URL.
+      expect(res.statusCode).toBe(302);
+      expect(res.headers.location).toContain("/auth/github/complete#");
+      expect(res.headers.location).toContain("error=install-not-admin");
+      expect(res.headers.location).not.toContain("access=");
+    } finally {
+      restore();
+    }
+
+    // The install stays unbound — the refusal short-circuits the bind.
+    const row = await findInstallationByGithubId(app.db, installationId);
+    expect(row?.hubOrganizationId).toBeNull();
+  });
+
   it("ignores a targetOrganizationId naming an org the user isn't a member of", async () => {
     const app = getApp();
     const githubId = 770_003;
@@ -289,7 +378,9 @@ describe("/auth/github/callback honors targetOrganizationId in the state (codex 
     const installationId = 8_822_003;
 
     // Brand-new GitHub user; the callback mints them with no membership in
-    // the default org → `findActiveMembership` returns null → 403.
+    // the default org → `findActiveMembership` returns null → refusal via
+    // the SPA error surface (no kickoffUserId in this legacy-shape state,
+    // so the OAuth identity is the bind authority).
     const defaultOrgId = await resolveDefaultOrgId(app.db);
     await upsertInstallationFromMetadata(app.db, {
       installation: {
@@ -312,7 +403,9 @@ describe("/auth/github/callback honors targetOrganizationId in the state (codex 
         url: `/api/v1/auth/github/callback?code=devcode&state=${token}&installation_id=${installationId}`,
         headers: { cookie: `${OAUTH_STATE_COOKIE}=${nonce}` },
       });
-      expect(res.statusCode).toBe(403);
+      expect(res.statusCode).toBe(302);
+      expect(res.headers.location).toContain("/auth/github/complete#");
+      expect(res.headers.location).toContain("error=install-not-admin");
     } finally {
       restore();
     }

--- a/packages/server/src/__tests__/github-app-callback-target-org.test.ts
+++ b/packages/server/src/__tests__/github-app-callback-target-org.test.ts
@@ -333,6 +333,98 @@ describe("/auth/github/callback honors targetOrganizationId in the state (codex 
     expect(row?.hubOrganizationId).toBe(admin.organizationId);
   });
 
+  it("surfaces an error (not success) when the identities mismatch and there is no verified installation to bind", async () => {
+    // Review finding (yuezengwu + codex): with no `installation_id` (or one
+    // cleared by the fail-closed GitHub-side admin proof), the mismatch
+    // branch must NOT bounce to the success `next` — in onboarding that
+    // page auto-closes as "connected" while nothing was bound.
+    const app = getApp();
+    const kickoffGithubId = 770_008;
+    const strangerGithubId = 770_009;
+    const login = `targetorg-noinstall-${uuidv7().slice(0, 6)}`;
+
+    const admin = await createTestAdmin(app, { username: `${login}-u` });
+    await seedGithubIdentity(app, admin.userId, kickoffGithubId, login);
+
+    const { token, nonce } = await signOAuthState(TEST_JWT_SECRET, "/onboarding/connected", {
+      targetOrganizationId: admin.organizationId,
+      kickoffUserId: admin.userId,
+    });
+    const restore = stubGithub({ githubId: strangerGithubId, login: `${login}-stranger`, installationIds: [] });
+    try {
+      // No installation_id on the callback at all.
+      const res = await app.inject({
+        method: "GET",
+        url: `/api/v1/auth/github/callback?code=devcode&state=${token}`,
+        headers: { cookie: `${OAUTH_STATE_COOKIE}=${nonce}` },
+      });
+      expect(res.statusCode).toBe(302);
+      expect(res.headers.location).toContain("/auth/github/complete#");
+      expect(res.headers.location).toContain("error=install-not-verified");
+      expect(res.headers.location).not.toContain("access=");
+    } finally {
+      restore();
+    }
+  });
+
+  it("surfaces an error (not success) when the identities mismatch and the bind itself fails", async () => {
+    // Same review finding, bind-failure leg: the installation is already
+    // bound to a DIFFERENT org (D2 1:1), so `bindInstallationToOrg` throws.
+    // The user must land on the error surface, not the success `next`.
+    const app = getApp();
+    const kickoffGithubId = 770_010;
+    const strangerGithubId = 770_011;
+    const login = `targetorg-bindfail-${uuidv7().slice(0, 6)}`;
+    const installationId = 8_822_007;
+
+    const admin = await createTestAdmin(app, { username: `${login}-u` });
+    await seedGithubIdentity(app, admin.userId, kickoffGithubId, login);
+
+    // Pre-bind the installation to another org so the bind is refused.
+    const otherOrgId = uuidv7();
+    await app.db.insert(organizations).values({ id: otherOrgId, name: `other-${otherOrgId}`, displayName: "Other" });
+    await upsertInstallationFromMetadata(app.db, {
+      installation: {
+        id: installationId,
+        accountType: "Organization",
+        accountLogin: "acme",
+        accountGithubId: 990_001,
+        permissions: {},
+        events: [],
+        suspendedAt: null,
+      },
+    });
+    const { bindInstallationToOrg } = await import("../services/github-app-installations.js");
+    await bindInstallationToOrg(app.db, installationId, otherOrgId);
+
+    const { token, nonce } = await signOAuthState(TEST_JWT_SECRET, "/settings/github", {
+      targetOrganizationId: admin.organizationId,
+      kickoffUserId: admin.userId,
+    });
+    const restore = stubGithub({
+      githubId: strangerGithubId,
+      login: `${login}-stranger`,
+      installationIds: [installationId],
+    });
+    try {
+      const res = await app.inject({
+        method: "GET",
+        url: `/api/v1/auth/github/callback?code=devcode&state=${token}&installation_id=${installationId}`,
+        headers: { cookie: `${OAUTH_STATE_COOKIE}=${nonce}` },
+      });
+      expect(res.statusCode).toBe(302);
+      expect(res.headers.location).toContain("/auth/github/complete#");
+      expect(res.headers.location).toContain("error=install-bind-failed");
+      expect(res.headers.location).not.toContain("access=");
+    } finally {
+      restore();
+    }
+
+    // The pre-existing binding is untouched.
+    const row = await findInstallationByGithubId(app.db, installationId);
+    expect(row?.hubOrganizationId).toBe(otherOrgId);
+  });
+
   it("redirects to a friendly error page when the kickoff admin's membership was revoked mid-flight", async () => {
     const app = getApp();
     const githubId = 770_007;

--- a/packages/server/src/__tests__/github-app-callback-target-org.test.ts
+++ b/packages/server/src/__tests__/github-app-callback-target-org.test.ts
@@ -362,6 +362,12 @@ describe("/auth/github/callback honors targetOrganizationId in the state (codex 
       expect(res.headers.location).toContain("/auth/github/complete#");
       expect(res.headers.location).toContain("error=install-not-verified");
       expect(res.headers.location).not.toContain("access=");
+      // Review finding round 2: the error page renders `next` as its "Back
+      // to First Tree" link — it must NOT point at the auto-close
+      // "Connected" sentinel, or the error page offers a false-success
+      // escape hatch. The onboarding popup path normalizes to /onboarding.
+      const fragment = new URLSearchParams(res.headers.location?.split("#")[1] ?? "");
+      expect(fragment.get("next")).toBe("/onboarding");
     } finally {
       restore();
     }
@@ -416,6 +422,9 @@ describe("/auth/github/callback honors targetOrganizationId in the state (codex 
       expect(res.headers.location).toContain("/auth/github/complete#");
       expect(res.headers.location).toContain("error=install-bind-failed");
       expect(res.headers.location).not.toContain("access=");
+      // Settings-flow `next` is a real recovery surface — preserved as-is.
+      const fragment = new URLSearchParams(res.headers.location?.split("#")[1] ?? "");
+      expect(fragment.get("next")).toBe("/settings/github");
     } finally {
       restore();
     }

--- a/packages/server/src/__tests__/github-app-install-url.test.ts
+++ b/packages/server/src/__tests__/github-app-install-url.test.ts
@@ -47,6 +47,11 @@ describe("GET /api/v1/orgs/:orgId/github-app-installation/install-url", () => {
     expect(cookieNonce).toBeTruthy();
     const verified = await verifyOAuthState(TEST_JWT_SECRET, state ?? "", cookieNonce);
     expect(verified.next).toBe("/settings/github");
+    // The signed state pins both the org the install binds to AND the
+    // kickoff admin whose (re-checked) authority the callback bind rests
+    // on — the browser's github.com identity at callback time may differ.
+    expect(verified.targetOrganizationId).toBe(admin.organizationId);
+    expect(verified.kickoffUserId).toBe(admin.userId);
   });
 
   it("bakes an allowlisted ?next= into the signed state (onboarding flow)", async () => {

--- a/packages/server/src/__tests__/oauth-flow.test.ts
+++ b/packages/server/src/__tests__/oauth-flow.test.ts
@@ -330,16 +330,28 @@ describe("GitHub OAuth invite-only single-org entry gate", () => {
 describe("OAuth callback rejects malformed state", () => {
   const getApp = useTestApp();
 
-  it("returns 401 when state JWT is gibberish", async () => {
+  // The /callback route is a full-page browser navigation, so state
+  // rejections redirect to the SPA's friendly error surface (the most
+  // common trigger is a user spending >10min on GitHub's repo picker,
+  // expiring the 10-minute state JWT) instead of stranding the browser
+  // on a raw JSON 401.
+  function expectStateRejectedRedirect(res: { statusCode: number; headers: { location?: string } }) {
+    expect(res.statusCode).toBe(302);
+    expect(res.headers.location).toContain("/auth/github/complete#");
+    expect(res.headers.location).toContain("error=state-expired");
+    expect(res.headers.location).not.toContain("access=");
+  }
+
+  it("redirects to the SPA error surface when state JWT is gibberish", async () => {
     const app = getApp();
     const res = await app.inject({
       method: "GET",
       url: "/api/v1/auth/github/callback?code=abc&state=not-a-jwt",
     });
-    expect(res.statusCode).toBe(401);
+    expectStateRejectedRedirect(res);
   });
 
-  it("returns 401 when state cookie is absent", async () => {
+  it("redirects to the SPA error surface when state cookie is absent", async () => {
     const app = getApp();
     // Sign a real state token but omit the cookie — should fail nonce check.
     const { signOAuthState } = await import("../services/oauth-state.js");
@@ -348,10 +360,10 @@ describe("OAuth callback rejects malformed state", () => {
       method: "GET",
       url: `/api/v1/auth/github/callback?code=abc&state=${token}`,
     });
-    expect(res.statusCode).toBe(401);
+    expectStateRejectedRedirect(res);
   });
 
-  it("returns 401 when cookie nonce mismatches", async () => {
+  it("redirects to the SPA error surface when cookie nonce mismatches", async () => {
     const app = getApp();
     const { signOAuthState } = await import("../services/oauth-state.js");
     const { token } = await signOAuthState(app.config.secrets.jwtSecret, "/welcome");
@@ -360,7 +372,7 @@ describe("OAuth callback rejects malformed state", () => {
       url: `/api/v1/auth/github/callback?code=abc&state=${token}`,
       headers: { cookie: "oauth_state_nonce=wrong" },
     });
-    expect(res.statusCode).toBe(401);
+    expectStateRejectedRedirect(res);
   });
 
   it("dev-callback ignores open-redirect bypasses in `next`", async () => {

--- a/packages/server/src/api/auth/github.ts
+++ b/packages/server/src/api/auth/github.ts
@@ -336,6 +336,8 @@ type CallbackErrorCode =
   | "state-expired"
   | "github-exchange-failed"
   | "install-not-admin"
+  | "install-not-verified"
+  | "install-bind-failed"
   | "invite-invalid"
   | "invite-not-allowed"
   | "invite-required"
@@ -483,6 +485,12 @@ async function completeOauthFlow(
       // unchanged: `installationId` is non-null only when the OAuth user
       // proved they administer the installed account, and the nonce cookie
       // pins this request to the same browser that minted the kickoff.
+      //
+      // The no-token success redirect is earned ONLY by an actual bind
+      // (review finding on the first cut of this branch): with no verified
+      // installation, or a bind refusal, `next` may be the onboarding
+      // auto-close page — bouncing there would present a silent failure as
+      // "connected". Surface the error instead.
       app.log.warn(
         {
           event: "github_app.install_callback_identity_mismatch",
@@ -495,15 +503,19 @@ async function completeOauthFlow(
         },
         "install callback: OAuth identity differs from the kickoff session — binding on kickoff authority, skipping sign-in",
       );
-      if (installationId !== null) {
-        try {
-          await bindInstallationToOrg(app.db, installationId, targetOrganizationId);
-        } catch (err) {
-          app.log.warn(
-            { err, installationId, hubOrganizationId: targetOrganizationId, kickoffUserId: bindAuthorityUserId },
-            "github app install bind-to-org failed on identity-mismatch path — reconcile in Settings",
-          );
-        }
+      if (installationId === null) {
+        // Either GitHub never sent an installation_id, or the GitHub-side
+        // admin proof / fetch / upsert failed closed and cleared it.
+        return redirectCallbackError(reply, "install-not-verified", next);
+      }
+      try {
+        await bindInstallationToOrg(app.db, installationId, targetOrganizationId);
+      } catch (err) {
+        app.log.warn(
+          { err, installationId, hubOrganizationId: targetOrganizationId, kickoffUserId: bindAuthorityUserId },
+          "github app install bind-to-org failed on identity-mismatch path — reconcile in Settings",
+        );
+        return redirectCallbackError(reply, "install-bind-failed", next);
       }
       return reply.redirect(next, 302);
     }

--- a/packages/server/src/api/auth/github.ts
+++ b/packages/server/src/api/auth/github.ts
@@ -53,7 +53,15 @@ import { buildCookie, parseCookieHeader } from "./oauth-cookie.js";
  * `GET /orgs/:orgId/github-app-installation/install-url` and surfaced both
  * in onboarding's "Connect your code" step and Settings → GitHub. After
  * that dialog GitHub redirects back here with `code + state +
- * installation_id`, which the callback verifies and binds.
+ * installation_id`, which the callback verifies and binds. The install
+ * BIND rests on the kickoff session signed into the state
+ * (`kickoffUserId`, re-checked live), not on the identity the OAuth code
+ * resolves to — the browser's github.com session is independent of the
+ * First Tree session, and a mismatch must not strand the install unbound.
+ *
+ * The live `/callback` is a full-page browser navigation, so its error
+ * replies redirect to the SPA error surface
+ * (`/auth/github/complete#error=<code>`) instead of raw JSON.
  *
  * `dev-callback` bypasses GitHub entirely; gated to non-production.
  *
@@ -107,13 +115,21 @@ export async function githubOauthRoutes(app: FastifyInstance): Promise<void> {
 
     let next: string;
     let targetOrganizationId: string | null = null;
+    let kickoffUserId: string | null = null;
     try {
       const verified = await verifyOAuthState(app.config.secrets.jwtSecret, state, cookieNonce);
       next = verified.next;
       targetOrganizationId = verified.targetOrganizationId ?? null;
+      kickoffUserId = verified.kickoffUserId ?? null;
     } catch (err) {
-      const msg = err instanceof Error ? err.message : "OAuth state rejected";
-      return reply.status(401).send({ error: msg });
+      // Browser-facing: the user just navigated here from github.com. A raw
+      // JSON body would strand them on the API URL — most commonly after
+      // taking >10min on GitHub's repo picker (state JWT expiry).
+      app.log.warn(
+        { err, event: "github_oauth.state_rejected" },
+        "github callback state rejected — redirecting to SPA error surface",
+      );
+      return redirectCallbackError(reply, "state-expired");
     }
 
     // Clear the state cookie even on success — it's single-use.
@@ -150,9 +166,8 @@ export async function githubOauthRoutes(app: FastifyInstance): Promise<void> {
       };
       installationId = result.installationId;
     } catch (err) {
-      const msg = err instanceof Error ? err.message : "GitHub exchange failed";
       app.log.warn({ err }, "github sign-in code exchange failed");
-      return reply.status(401).send({ error: msg });
+      return redirectCallbackError(reply, "github-exchange-failed", next);
     }
 
     // SECURITY: `installation_id` rides the browser address bar — not a
@@ -206,7 +221,10 @@ export async function githubOauthRoutes(app: FastifyInstance): Promise<void> {
       }
     }
 
-    return completeOauthFlow(app, request, reply, profile, next, tokens, installationId, targetOrganizationId);
+    return completeOauthFlow(app, request, reply, profile, next, tokens, installationId, targetOrganizationId, {
+      kickoffUserId,
+      browserFacing: true,
+    });
   });
 
   app.get("/dev-callback", async (request, reply) => {
@@ -310,6 +328,31 @@ export async function githubOauthRoutes(app: FastifyInstance): Promise<void> {
   });
 }
 
+/**
+ * Error codes the SPA's `/auth/github/complete` page renders friendly copy
+ * for. Keep in sync with `packages/web/src/pages/oauth-complete.tsx`.
+ */
+type CallbackErrorCode =
+  | "state-expired"
+  | "github-exchange-failed"
+  | "install-not-admin"
+  | "invite-invalid"
+  | "invite-not-allowed"
+  | "invite-required"
+  | "membership-unresolved";
+
+/**
+ * The live `/callback` route is a full-page browser navigation (GitHub
+ * redirects the user's browser here), so error replies must land the user
+ * back on the SPA — a raw JSON body strands them on the API URL with no
+ * way forward. The error code rides in the fragment like the success
+ * tokens do (never enters Referer headers or server logs).
+ */
+function redirectCallbackError(reply: FastifyReply, code: CallbackErrorCode, next?: string) {
+  const fragment = new URLSearchParams({ error: code, ...(next ? { next } : {}) }).toString();
+  return reply.redirect(`/auth/github/complete#${fragment}`, 302);
+}
+
 async function completeOauthFlow(
   app: FastifyInstance,
   request: FastifyRequest,
@@ -340,7 +383,23 @@ async function completeOauthFlow(
    * path, that org wins regardless. Null on the plain sign-in flow.
    */
   targetOrganizationId: string | null,
+  opts: {
+    /**
+     * First Tree user who kicked off the App-install flow, carried in the
+     * signed state (see `StatePayload.kickoffUserId`). Null on the plain
+     * sign-in flow, legacy states, and `dev-callback`.
+     */
+    kickoffUserId?: string | null;
+    /**
+     * True when the caller is the live browser-navigated `/callback`
+     * route: error replies redirect to the SPA error surface instead of
+     * raw JSON. `dev-callback` keeps JSON errors (curl-able, and the
+     * dev/test suites assert on status codes).
+     */
+    browserFacing?: boolean;
+  } = {},
 ) {
+  const { kickoffUserId = null, browserFacing = false } = opts;
   const { userId } = await findOrCreateUserFromGithub(app.db, profile, oauthTokens);
   const allowedOrganizationId = app.config.access?.allowedOrganizationId ?? null;
 
@@ -361,9 +420,11 @@ async function completeOauthFlow(
     const token = inviteMatch[1];
     const inv = await findActiveByToken(app.db, token);
     if (!inv) {
+      if (browserFacing) return redirectCallbackError(reply, "invite-invalid");
       return reply.status(404).send({ error: "Invitation not found or no longer valid" });
     }
     if (allowedOrganizationId && inv.organizationId !== allowedOrganizationId) {
+      if (browserFacing) return redirectCallbackError(reply, "invite-not-allowed");
       return reply.status(403).send({ error: "Invitation is not allowed on this server" });
     }
     await ensureMembership(app.db, {
@@ -386,14 +447,65 @@ async function completeOauthFlow(
     // onboarding modal can layer on top.
     next = "/";
   } else if (targetOrganizationId) {
-    // App-install flow: the org was chosen on a Settings page and rode in
-    // the signed state (codex P1-3). Re-check the user is still an active
-    // admin of it — the state JWT outlives a membership revoke, so a stale
-    // token must not bind another team's install to an org the user no
-    // longer administers.
-    const membership = await findActiveMembership(app.db, userId, targetOrganizationId);
-    if (!membership || membership.role !== "admin") {
-      return reply.status(403).send({ error: "Not an admin of the organization this installation targets" });
+    // App-install flow: the org rode in the signed state minted by the
+    // admin-gated `/install-url` (codex P1-3). The bind rests on the
+    // KICKOFF user's authority — re-checked live against `members`,
+    // because the state JWT outlives a membership revoke — and NOT on the
+    // identity the OAuth code resolved to: the browser's github.com
+    // session is independent of the First Tree session, and a mismatch
+    // (second GitHub account, deleted-and-recreated account, someone
+    // else's First Tree session in the same browser) must not strand a
+    // completed install unbound. States minted before `kickoffUserId`
+    // existed (≤10min old at deploy time) fall back to the OAuth identity.
+    const bindAuthorityUserId = kickoffUserId ?? userId;
+    const authority = await findActiveMembership(app.db, bindAuthorityUserId, targetOrganizationId);
+    if (!authority || authority.role !== "admin") {
+      app.log.warn(
+        {
+          event: "github_app.install_callback_admin_check_failed",
+          targetOrganizationId,
+          kickoffUserId,
+          oauthUserId: userId,
+          githubId: profile.githubId,
+          githubLogin: profile.login,
+          installationId,
+        },
+        "install callback: bind authority is not an active admin of the target org — refusing to bind",
+      );
+      if (browserFacing) return redirectCallbackError(reply, "install-not-admin", next);
+      return reply.status(403).send({ error: "Not an admin of the First Tree organization this installation targets" });
+    }
+    if (bindAuthorityUserId !== userId) {
+      // Identity mismatch: complete the install on the kickoff admin's
+      // authority, then bounce straight to `next` WITHOUT issuing tokens —
+      // signing the browser in as the OAuth identity would replace the
+      // kickoff admin's session across every tab. GitHub-side authority is
+      // unchanged: `installationId` is non-null only when the OAuth user
+      // proved they administer the installed account, and the nonce cookie
+      // pins this request to the same browser that minted the kickoff.
+      app.log.warn(
+        {
+          event: "github_app.install_callback_identity_mismatch",
+          targetOrganizationId,
+          kickoffUserId: bindAuthorityUserId,
+          oauthUserId: userId,
+          githubId: profile.githubId,
+          githubLogin: profile.login,
+          installationId,
+        },
+        "install callback: OAuth identity differs from the kickoff session — binding on kickoff authority, skipping sign-in",
+      );
+      if (installationId !== null) {
+        try {
+          await bindInstallationToOrg(app.db, installationId, targetOrganizationId);
+        } catch (err) {
+          app.log.warn(
+            { err, installationId, hubOrganizationId: targetOrganizationId, kickoffUserId: bindAuthorityUserId },
+            "github app install bind-to-org failed on identity-mismatch path — reconcile in Settings",
+          );
+        }
+      }
+      return reply.redirect(next, 302);
     }
     resolved = true;
     resolvedOrganizationId = targetOrganizationId;
@@ -407,6 +519,7 @@ async function completeOauthFlow(
       // joinPath stays "returning"; preserve caller's original `next` intent.
     } else {
       if (allowedOrganizationId) {
+        if (browserFacing) return redirectCallbackError(reply, "invite-required");
         return reply.status(403).send({ error: "This server requires an invitation link to join" });
       }
       const personal = await createPersonalTeam(app.db, {
@@ -494,6 +607,7 @@ async function completeOauthFlow(
   }
 
   if (!resolved) {
+    if (browserFacing) return redirectCallbackError(reply, "membership-unresolved");
     return reply.status(500).send({ error: "Failed to resolve membership" });
   }
 

--- a/packages/server/src/api/auth/github.ts
+++ b/packages/server/src/api/auth/github.ts
@@ -349,9 +349,16 @@ type CallbackErrorCode =
  * back on the SPA — a raw JSON body strands them on the API URL with no
  * way forward. The error code rides in the fragment like the success
  * tokens do (never enters Referer headers or server logs).
+ *
+ * `next` becomes the error page's visible "Back to First Tree" link, so it
+ * must be a real recovery surface: the onboarding popup's auto-close
+ * "Connected" sentinel (`/onboarding/connected`) would present a
+ * false-success escape hatch right on the failure page — normalize it to
+ * the onboarding flow itself.
  */
 function redirectCallbackError(reply: FastifyReply, code: CallbackErrorCode, next?: string) {
-  const fragment = new URLSearchParams({ error: code, ...(next ? { next } : {}) }).toString();
+  const recoveryNext = next === "/onboarding/connected" ? "/onboarding" : next;
+  const fragment = new URLSearchParams({ error: code, ...(recoveryNext ? { next: recoveryNext } : {}) }).toString();
   return reply.redirect(`/auth/github/complete#${fragment}`, 302);
 }
 

--- a/packages/server/src/api/orgs/github-app.ts
+++ b/packages/server/src/api/orgs/github-app.ts
@@ -231,13 +231,17 @@ export async function orgGithubAppRoutes(app: FastifyInstance): Promise<void> {
     // `targetOrganizationId` rides inside the signed state so the OAuth
     // callback binds the install to *this* org rather than the caller's
     // primary org (codex P1-3) — an admin in org B installing the App must
-    // end up bound to org B. The callback re-checks the caller is still an
-    // admin of that org before honoring it.
+    // end up bound to org B. `kickoffUserId` rides alongside it so the
+    // callback can rest the bind on THIS admin's (re-checked) authority
+    // even when the browser's github.com session resolves to a different
+    // GitHub identity — the github.com session and the First Tree session
+    // are independent, and a mismatch must not strand the install unbound.
     const { token, nonce } = await signOAuthState(
       app.config.secrets.jwtSecret,
       resolvePostInstallNext(request.query.next),
       {
         targetOrganizationId: scope.organizationId,
+        kickoffUserId: scope.userId,
       },
     );
     reply.header(

--- a/packages/server/src/services/oauth-state.ts
+++ b/packages/server/src/services/oauth-state.ts
@@ -36,11 +36,24 @@ type StatePayload = {
    * the plain `/auth/github/start` sign-in flow.
    */
   targetOrganizationId?: string;
+  /**
+   * First Tree user who kicked off the App-install flow (the admin
+   * authenticated by `GET /orgs/:orgId/github-app-installation/install-url`).
+   * The callback rests the install *bind* on this identity — re-checked
+   * live against `members` — instead of whoever the OAuth code resolves
+   * to, because the browser's github.com session can legitimately differ
+   * from the GitHub account linked to the kickoff user (second account,
+   * deleted-and-recreated account, someone else's session in the same
+   * browser). Absent on the plain `/auth/github/start` sign-in flow.
+   */
+  kickoffUserId?: string;
 };
 
 export type SignOAuthStateOptions = {
   /** See `StatePayload.targetOrganizationId`. */
   targetOrganizationId?: string;
+  /** See `StatePayload.kickoffUserId`. */
+  kickoffUserId?: string;
 };
 
 /**
@@ -57,6 +70,9 @@ export async function signOAuthState(
   const claims: StatePayload = { nonce, next };
   if (opts.targetOrganizationId) {
     claims.targetOrganizationId = opts.targetOrganizationId;
+  }
+  if (opts.kickoffUserId) {
+    claims.kickoffUserId = opts.kickoffUserId;
   }
   const token = await new SignJWT({ ...claims })
     .setProtectedHeader({ alg: "HS256" })
@@ -80,7 +96,7 @@ export async function verifyOAuthState(
   jwtSecret: string,
   token: string,
   cookieNonce: string | null,
-): Promise<{ next: string; targetOrganizationId?: string }> {
+): Promise<{ next: string; targetOrganizationId?: string; kickoffUserId?: string }> {
   const secret = new TextEncoder().encode(jwtSecret);
   let payload: StatePayload;
   try {
@@ -96,6 +112,9 @@ export async function verifyOAuthState(
   if (payload.targetOrganizationId !== undefined && typeof payload.targetOrganizationId !== "string") {
     throw new Error("OAuth state payload malformed");
   }
+  if (payload.kickoffUserId !== undefined && typeof payload.kickoffUserId !== "string") {
+    throw new Error("OAuth state payload malformed");
+  }
 
   if (!cookieNonce || cookieNonce !== payload.nonce) {
     throw new Error("OAuth state nonce / cookie mismatch");
@@ -104,5 +123,6 @@ export async function verifyOAuthState(
   return {
     next: payload.next,
     ...(payload.targetOrganizationId ? { targetOrganizationId: payload.targetOrganizationId } : {}),
+    ...(payload.kickoffUserId ? { kickoffUserId: payload.kickoffUserId } : {}),
   };
 }

--- a/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
+++ b/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
@@ -1117,6 +1117,39 @@ describe("web DOM interaction coverage", () => {
     await waitForText("Sign-in did not complete", failure.container);
   });
 
+  it("renders friendly copy for callback error fragments", async () => {
+    const { OAuthCompletePage } = await import("../oauth-complete.js");
+    const replaceState = vi.fn();
+    Object.defineProperty(window, "history", { configurable: true, value: { replaceState } });
+
+    // Expired/consumed state — the most common real-world trigger is the
+    // user spending >10min on GitHub's repo picker.
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        ...window.location,
+        hash: "#error=state-expired&next=/settings/github",
+        pathname: "/auth/github/complete",
+      },
+    });
+    const expired = await renderDom(<OAuthCompletePage />, "/auth/github/complete");
+    await waitForText("took too long or was already used", expired.container);
+    const back = expired.container.querySelector<HTMLAnchorElement>("a");
+    expect(back?.getAttribute("href")).toBe("/settings/github");
+    await unmountRoot(expired.root);
+
+    // Install refused: kickoff admin's authority no longer holds.
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...window.location, hash: "#error=install-not-admin", pathname: "/auth/github/complete" },
+    });
+    const notAdmin = await renderDom(<OAuthCompletePage />, "/auth/github/complete");
+    await waitForText("admin of the First Tree team", notAdmin.container);
+    // No `next` in the fragment → the way out defaults to the app root.
+    expect(notAdmin.container.querySelector<HTMLAnchorElement>("a")?.getAttribute("href")).toBe("/");
+    await unmountRoot(notAdmin.root);
+  });
+
   it("renders SettingsOnboardingPage resume, hide, disabled, and completed states", async () => {
     const { SettingsOnboardingPage } = await import("../settings/onboarding.js");
 

--- a/packages/web/src/pages/oauth-complete.tsx
+++ b/packages/web/src/pages/oauth-complete.tsx
@@ -16,6 +16,10 @@ const CALLBACK_ERROR_COPY: Record<string, string> = {
   "github-exchange-failed": "GitHub didn't accept the sign-in handshake. Head back and try again in a moment.",
   "install-not-admin":
     "The GitHub App was installed, but connecting it needs an admin of the First Tree team it was started from. Ask a team admin to finish the connection from Settings → GitHub.",
+  "install-not-verified":
+    "The GitHub App install couldn't be verified, so nothing was connected to your team. Start the install again from the app.",
+  "install-bind-failed":
+    "The GitHub App was installed, but it couldn't be connected to your team — it may already be connected to a different team. Try again from Settings → GitHub.",
   "invite-invalid": "This invitation link is no longer valid. Ask your team for a fresh invite.",
   "invite-not-allowed": "This invitation isn't allowed on this server.",
   "invite-required": "This server requires an invitation link to join. Ask your team for an invite.",

--- a/packages/web/src/pages/oauth-complete.tsx
+++ b/packages/web/src/pages/oauth-complete.tsx
@@ -5,8 +5,27 @@ import { useAuth } from "../auth/auth-context.js";
 import { markOnboardingResume } from "../utils/onboarding-flags.js";
 
 /**
+ * Friendly copy for the `#error=<code>` fragment the server's GitHub
+ * callback redirects to on failure (it is a full-page browser navigation,
+ * so a raw JSON error would strand the user on the API URL). Codes are
+ * minted in `packages/server/src/api/auth/github.ts` — keep in sync.
+ */
+const CALLBACK_ERROR_COPY: Record<string, string> = {
+  "state-expired":
+    "This GitHub connection took too long or was already used. Head back and start the connection again.",
+  "github-exchange-failed": "GitHub didn't accept the sign-in handshake. Head back and try again in a moment.",
+  "install-not-admin":
+    "The GitHub App was installed, but connecting it needs an admin of the First Tree team it was started from. Ask a team admin to finish the connection from Settings → GitHub.",
+  "invite-invalid": "This invitation link is no longer valid. Ask your team for a fresh invite.",
+  "invite-not-allowed": "This invitation isn't allowed on this server.",
+  "invite-required": "This server requires an invitation link to join. Ask your team for an invite.",
+  "membership-unresolved": "Sign-in did not complete. Please try again.",
+};
+
+/**
  * Consumes the `#access=…&refresh=…&next=…` fragment that the server
- * appends after a successful GitHub callback. The fragment is ideal here:
+ * appends after a successful GitHub callback — or the `#error=<code>`
+ * fragment it appends on failure. The fragment is ideal here:
  *   - browsers do NOT include it in the Referer header
  *   - it never enters server-side request logs
  *   - SPA can `replaceState` to wipe it from the URL bar
@@ -18,6 +37,7 @@ export function OAuthCompletePage() {
   const navigate = useNavigate();
   const { adoptTokens, selectOrganization } = useAuth();
   const [error, setError] = useState<string | null>(null);
+  const [errorNext, setErrorNext] = useState<string>("/");
 
   useEffect(() => {
     const hash = window.location.hash.startsWith("#") ? window.location.hash.slice(1) : window.location.hash;
@@ -31,6 +51,13 @@ export function OAuthCompletePage() {
     // localStorage so an invitee lands in the org they just joined, not a
     // previously-used one.
     const org = params.get("org");
+    const errorCode = params.get("error");
+
+    if (errorCode) {
+      setError(CALLBACK_ERROR_COPY[errorCode] ?? "Sign-in did not complete. Please try again.");
+      setErrorNext(next);
+      return;
+    }
 
     if (!accessToken || !refreshToken) {
       setError("Sign-in did not complete. Please try again.");
@@ -57,9 +84,22 @@ export function OAuthCompletePage() {
     })();
   }, [adoptTokens, selectOrganization, navigate]);
 
+  if (error) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-background">
+        <div className="flex max-w-md flex-col items-center gap-4 px-6 text-center">
+          <p className="text-body text-muted-foreground">{error}</p>
+          <a className="text-body text-primary underline underline-offset-4" href={errorNext}>
+            Back to First Tree
+          </a>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="flex min-h-screen items-center justify-center bg-background text-body text-muted-foreground">
-      {error ?? "Signing you in…"}
+      Signing you in…
     </div>
   );
 }


### PR DESCRIPTION
## Incident

Prod onboarding: a user completed the GitHub App install (installation `139563599`, GitHub org `ShibaOrg`), but the OAuth callback refused with a raw-JSON 403 **"Not an admin of the organization this installation targets"** and the installation row sat unbound (`hub_organization_id = NULL`, confirmed in prod).

## Root cause

The callback re-resolved the acting user **from the OAuth code** (`findOrCreateUserFromGithub`) and ran the target-org admin re-check against that identity. But the browser's github.com session is independent of the First Tree session — a second GitHub account, a deleted-and-recreated account (numeric ID changes), or another person's First Tree session in the same browser all make the two identities legitimately diverge. The kickoff (`GET /orgs/:orgId/github-app-installation/install-url`) is admin-gated, so the kickoff user's authority was already proven — the callback just wasn't using it.

## Fix (4 defects)

1. **Bind authority = kickoff session.** `/install-url` signs `kickoffUserId` into the state alongside `targetOrganizationId`; the callback re-checks **that** admin live against `members` and binds on their authority. On identity mismatch it completes the bind and redirects to `next` **without issuing tokens** — signing the browser in as the foreign identity would replace the kickoff admin's session in every tab. GitHub-side authority is unchanged: `installationId` is only non-null when the OAuth user proved they administer the installed account (#423), and the nonce cookie pins the callback to the kickoff browser. Legacy states without `kickoffUserId` (≤10 min old at deploy time) keep the old behavior.
2. **No more raw-JSON dead ends.** Every browser-facing `/callback` error 302s to `/auth/github/complete#error=<code>` where the SPA renders friendly copy + a way back (codes: `state-expired`, `github-exchange-failed`, `install-not-admin`, `invite-invalid`, `invite-not-allowed`, `invite-required`, `membership-unresolved`). The most common real-world trigger — spending >10 min on GitHub's repo picker and expiring the 10-minute state JWT — now lands on a readable page. `dev-callback` keeps JSON errors (curl-able, asserted by dev tests).
3. **Observability.** The refusal path logs structured warns with both identities (`github_app.install_callback_admin_check_failed` / `github_app.install_callback_identity_mismatch`) — this incident was undiagnosable from logs (the 403 path logged nothing).
4. **Copy.** The refusal names the First Tree team; "organization" read as the GitHub org to everyone who saw it.

## Tests (red → green)

- `binds via the kickoff session's authority when the callback GitHub identity differs` — the incident class; failed 403 before, passes with the row bound and no token fragment in the redirect.
- `redirects to a friendly error page when the kickoff admin's membership was revoked mid-flight` — the legitimate refusal keeps refusing, now on the SPA surface.
- Updated: legacy-state refusals + state-rejection tests assert the redirect contract; `install-url` test pins `kickoffUserId` + `targetOrganizationId` in the signed state; web test covers the `#error=` fragment rendering.
- Full suite green: server 1352, web 743, cli 436, client 1197, shared 408. `pnpm check` + `pnpm typecheck` clean.

## Recovery for the affected user

After deploy, re-running "Install on GitHub" from Settings/onboarding completes and binds installation `139563599` (GitHub redirects straight back with the existing install). No manual DB surgery needed.

Tree PR (merged): agent-team-foundation/first-tree-context#492

🤖 Generated with [Claude Code](https://claude.com/claude-code)