### PR TITLE
fix(shared): unwrap login-shell wrappers in shell IO classifier

### DIFF
--- a/packages/client/src/__tests__/codex-context-tree-io.test.ts
+++ b/packages/client/src/__tests__/codex-context-tree-io.test.ts
@@ -71,6 +71,55 @@ describe("Codex Context Tree file refs", () => {
     ]);
   });
 
+  // Codex CLI does not surface raw `sed` / `cat` — every command_execution
+  // lands as `/bin/<login-shell> -lc '<inner>'` (zsh on macOS, bash on Linux).
+  // This is the real wire shape pulled from a session_events row during the
+  // fix investigation. Without the shared `classifyShellCommandIo` wrapper
+  // unwrap, the outer `zsh` / `bash` falls into MUTATING_OR_AMBIGUOUS_TOOLS
+  // and the client never attaches file refs, so the Context tab dashboard
+  // records nothing for codex agents. Lock the wrapped form down end-to-end.
+  it("emits shell read refs for Codex's /bin/zsh -lc 'sed ...' wrapper (macOS form)", () => {
+    const refs = toolFileRefsFromShellCommand({
+      command: "/bin/zsh -lc \"sed -n '1,7p' /home/op/context-tree/NODE.md\"",
+      cwd: "/home/op/source",
+      contextTreePath: "/home/op/context-tree",
+      contextTreeRepoUrl: "https://github.com/acme/first-tree-context.git",
+      contextTreeBranch: "main",
+    });
+
+    expect(refs).toEqual([
+      {
+        origin: "tool_arg",
+        localPath: "/home/op/context-tree/NODE.md",
+        repoUrl: "https://github.com/acme/first-tree-context.git",
+        repoBranch: "main",
+        repoRelativePath: "NODE.md",
+        pathKind: "file",
+      },
+    ]);
+  });
+
+  it("emits shell read refs for Codex's /bin/bash -lc 'cat ...' wrapper (Linux form)", () => {
+    const refs = toolFileRefsFromShellCommand({
+      command: "/bin/bash -lc 'cat /home/op/context-tree/NODE.md'",
+      cwd: "/home/op/source",
+      contextTreePath: "/home/op/context-tree",
+      contextTreeRepoUrl: "https://github.com/acme/first-tree-context.git",
+      contextTreeBranch: "main",
+    });
+
+    expect(refs).toEqual([
+      {
+        origin: "tool_arg",
+        localPath: "/home/op/context-tree/NODE.md",
+        repoUrl: "https://github.com/acme/first-tree-context.git",
+        repoBranch: "main",
+        repoRelativePath: "NODE.md",
+        pathKind: "file",
+      },
+    ]);
+  });
+
   it("rejects Codex shell read candidates outside the Context Tree checkout or using write syntax", () => {
     const base = {
       cwd: "/home/op/source",

--- a/packages/shared/src/__tests__/shell-command-io.test.ts
+++ b/packages/shared/src/__tests__/shell-command-io.test.ts
@@ -132,4 +132,120 @@ describe("classifyShellCommandIo", () => {
       commandName: "cat",
     });
   });
+
+  // Codex CLI wraps every command in `/bin/<login-shell> -lc '<inner>'` before
+  // it surfaces in the `command_execution` thread item — bash on Linux daemons,
+  // zsh on macOS daemons, sh on minimal images. Without unwrapping these
+  // wrappers, codex's only file-read signal lands in MUTATING_OR_AMBIGUOUS_TOOLS
+  // and the Context tab dashboard sees zero codex usage (see PR description for
+  // the empirical event-payload that drove this fix).
+  describe("unwraps login-shell wrappers (codex /bin/<shell> -lc form)", () => {
+    it("unwraps /bin/zsh -lc 'sed ...' (codex macOS form) to a read", () => {
+      // Real payload pulled from a codex session_events row on macOS.
+      expect(classifyShellCommandIo("/bin/zsh -lc \"sed -n '1,7p' /Users/op/.first-tree/tree/NODE.md\"")).toEqual({
+        supported: true,
+        action: "read",
+        commandName: "sed",
+        pathArgs: [{ raw: "/Users/op/.first-tree/tree/NODE.md", pathKindHint: "file" }],
+      });
+    });
+
+    it("unwraps /bin/bash -lc 'cat ...' (codex Linux form) to a read", () => {
+      expect(classifyShellCommandIo("/bin/bash -lc 'cat /home/op/.first-tree/tree/NODE.md'")).toEqual({
+        supported: true,
+        action: "read",
+        commandName: "cat",
+        pathArgs: [{ raw: "/home/op/.first-tree/tree/NODE.md", pathKindHint: "file" }],
+      });
+    });
+
+    it("unwraps sh -c 'rg --files ...' (minimal image form) to a read", () => {
+      expect(classifyShellCommandIo("sh -c 'rg --files /tree/practices'")).toEqual({
+        supported: true,
+        action: "read",
+        commandName: "rg",
+        pathArgs: [{ raw: "/tree/practices", pathKindHint: "directory" }],
+      });
+    });
+
+    it("preserves the inner-command rejection — wrapped mutating tool still rejected", () => {
+      // The whole point of the wrapper unwrap is that whatever the inner tool
+      // is decides the verdict — not the outer shell. A wrapped `tee` (write)
+      // must remain rejected as a mutation, not silently classified as read.
+      expect(classifyShellCommandIo("/bin/zsh -lc 'tee /tree/NODE.md'")).toEqual({
+        supported: false,
+        reason: "write_or_mutation",
+        commandName: "tee",
+      });
+    });
+
+    it("preserves the inner-command rejection — wrapped pipeline still complex_shell", () => {
+      expect(classifyShellCommandIo("/bin/bash -lc 'cat /tree/NODE.md | head'")).toEqual({
+        supported: false,
+        reason: "complex_shell",
+      });
+    });
+
+    it("preserves the inner-command rejection — wrapped sed -i still mutation", () => {
+      expect(classifyShellCommandIo("/bin/bash -lc \"sed -i 's/a/b/' /tree/NODE.md\"")).toEqual({
+        supported: false,
+        reason: "write_or_mutation",
+        commandName: "sed",
+      });
+    });
+
+    it("rejects a wrapper with no inner command as write_or_mutation (not a read)", () => {
+      // `zsh -lc` with nothing after isn't a "read of a tree file" — fall
+      // through to the standard mutating-shell rejection so we don't silently
+      // promote a malformed wrapper into a phony read.
+      expect(classifyShellCommandIo("/bin/zsh -lc")).toEqual({
+        supported: false,
+        reason: "write_or_mutation",
+        commandName: "zsh",
+      });
+    });
+
+    it("rejects a wrapper whose flag is not -c / -lc", () => {
+      // `bash -x cat foo` is NOT the wrapper pattern — must NOT unwrap and
+      // re-classify; the outer bash invocation can do arbitrary things, so
+      // it stays in the mutating rejection.
+      expect(classifyShellCommandIo("/bin/bash -x cat /tree/NODE.md")).toEqual({
+        supported: false,
+        reason: "write_or_mutation",
+        commandName: "bash",
+      });
+    });
+
+    it("does not unwrap when the inner script is dynamic ($VAR / backticks)", () => {
+      // The inner token came from a double-quoted shell string that included
+      // `$VAR`, so the tokenizer flagged it dynamic. We can't statically know
+      // what the inner command resolves to — fall through to mutation
+      // rejection rather than analyze a string the agent's shell would
+      // re-expand at runtime.
+      expect(classifyShellCommandIo('/bin/zsh -lc "cat $TREE/NODE.md"')).toEqual({
+        supported: false,
+        reason: "write_or_mutation",
+        commandName: "zsh",
+      });
+    });
+
+    it("unwraps a doubly-nested wrapper (bash -lc \"sh -c 'cat ...'\") within the depth budget", () => {
+      expect(classifyShellCommandIo("/bin/bash -lc \"sh -c 'cat /tree/NODE.md'\"")).toEqual({
+        supported: true,
+        action: "read",
+        commandName: "cat",
+        pathArgs: [{ raw: "/tree/NODE.md", pathKindHint: "file" }],
+      });
+    });
+
+    it("stops unwrapping past the depth budget (no infinite recursion)", () => {
+      // Three nested wrappers — the budget allows two unwraps, so the third
+      // outer `bash` is treated as a bare mutating shell. The path stops at a
+      // safe rejection rather than recursing forever or unwrapping a
+      // pathological chain.
+      expect(classifyShellCommandIo('/bin/bash -lc "bash -lc \\"bash -lc \'cat /tree/NODE.md\'\\""')).toMatchObject({
+        supported: false,
+      });
+    });
+  });
 });

--- a/packages/shared/src/shell-command-io.ts
+++ b/packages/shared/src/shell-command-io.ts
@@ -68,6 +68,26 @@ const MUTATING_OR_AMBIGUOUS_TOOLS = new Set([
   "zsh",
 ]);
 
+/**
+ * Codex CLI (and any other runtime that shells out via the user's login shell)
+ * wraps every command it emits as `/bin/<shell> -lc '<inner>'` — observed shells
+ * include `bash` (Linux daemons), `zsh` (macOS daemons), and `sh`. Without
+ * unwrapping, the outer shell basename hits {@link MUTATING_OR_AMBIGUOUS_TOOLS}
+ * below and every codex read of a Context Tree file falls through to
+ * `unsupported_shell_command`, breaking the Context tab's usage dashboard.
+ * Both the client (file-ref extraction at emit time) and the server
+ * (`shellToolCanRead` at record time) call into the same classifier, so this
+ * one shared unwrap fixes both ends with no per-runtime adapter.
+ */
+const SHELL_WRAPPER_BASENAMES = new Set(["sh", "bash", "zsh"]);
+const SHELL_WRAPPER_FLAGS = new Set(["-c", "-lc"]);
+/**
+ * Bound recursion so a pathological `bash -lc 'bash -lc "bash -lc ..."'`
+ * chain (real or adversarial) can't loop. Two levels covers the codex case
+ * with margin and matches the depth a human operator would reasonably write.
+ */
+const MAX_WRAPPER_UNWRAPS = 2;
+
 const SIMPLE_FILE_READ_TOOLS = new Set(["cat", "head", "nl", "tail", "wc"]);
 const HEAD_TAIL_VALUE_OPTIONS = new Set(["-c", "--bytes", "-n", "--lines"]);
 const SED_SCRIPT_OPTIONS = new Set(["-e", "--expression", "-f", "--file"]);
@@ -502,6 +522,10 @@ function classifyLs(tokens: ShellToken[]): ShellIoClassification {
 }
 
 export function classifyShellCommandIo(command: string): ShellIoClassification {
+  return classifyShellCommandIoInternal(command, 0);
+}
+
+function classifyShellCommandIoInternal(command: string, wrapperDepth: number): ShellIoClassification {
   const tokenized = tokenizeSimpleShell(command);
   if (!tokenized.ok) return { supported: false, reason: tokenized.reason };
 
@@ -510,6 +534,26 @@ export function classifyShellCommandIo(command: string): ShellIoClassification {
   if (commandToken.dynamic) return { supported: false, reason: "dynamic_path" };
 
   const commandName = commandBasename(commandToken.value);
+
+  // Unwrap `/bin/<shell> -lc '<inner>'` before the mutating-shell rejection
+  // below — see `SHELL_WRAPPER_BASENAMES`. Two-step shape check: the second
+  // token must be `-c` or `-lc` and the third token must be a non-empty,
+  // statically-known inner command. If any condition fails we fall through to
+  // the normal rejection path (which still safely returns `write_or_mutation`).
+  if (wrapperDepth < MAX_WRAPPER_UNWRAPS && SHELL_WRAPPER_BASENAMES.has(commandName)) {
+    const flagToken = tokenized.tokens[1];
+    const innerToken = tokenized.tokens[2];
+    if (
+      flagToken &&
+      innerToken &&
+      SHELL_WRAPPER_FLAGS.has(flagToken.value) &&
+      innerToken.value.length > 0 &&
+      !innerToken.dynamic
+    ) {
+      return classifyShellCommandIoInternal(innerToken.value, wrapperDepth + 1);
+    }
+  }
+
   if (MUTATING_OR_AMBIGUOUS_TOOLS.has(commandName)) {
     return { supported: false, reason: "write_or_mutation", commandName };
   }


### PR DESCRIPTION
## Summary

- The Web Console Context tab dashboard never shows any codex runtime activity because every codex shell command lands as `/bin/<login-shell> -lc '<inner>'` (bash on Linux daemons, zsh on macOS daemons), and `classifyShellCommandIo` treats the outer shell as a mutating tool and rejects the whole event before the inner read is ever inspected.
- The rejection happens in **both** the client (file-ref extraction at emit time) and the server (`shellToolCanRead` at record time) because both call into the same shared classifier — so events reach the DB with no `toolFileRefs`, and no `context_tree_io_events` row ever gets derived.
- This PR adds a shell-wrapper unwrap step to `classifyShellCommandIo` so `/bin/zsh -lc "sed -n '1,7p' .../NODE.md"` re-classifies through the same function as `sed -n '1,7p' .../NODE.md` would, while every other rejection (wrapped `tee`, wrapped pipeline, wrapped `sed -i`, wrapped `$VAR`) still surfaces correctly.

## Empirical evidence

Pulled live from a codex `session_events` row:

```
payload.args.command = '/bin/zsh -lc "sed -n \'1,7p\' /Users/op/.../NODE.md"'
classifyShellCommandIo(...) →
  { supported: false, reason: "write_or_mutation", commandName: "zsh" }
payload.toolFileRefs = undefined   // ← client refused to attach refs
```

After this fix the same input becomes:

```
{ supported: true, action: "read", commandName: "sed",
  pathArgs: [{ raw: "/Users/op/.../NODE.md", pathKindHint: "file" }] }
```

## Why one shared change, not split client/server

- Client `toolFileRefsFromShellCommand()` calls `classifyShellCommandIo` directly — without the unwrap the emitted event has no `toolFileRefs`.
- Server `recordFromSessionEvent` / `shellToolCanRead` also calls `classifyShellCommandIo` — even if it could otherwise infer the inner command, the event payload it sees has no refs to attach.
- Fixing only one side leaves the other one broken. Fixing the shared classifier fixes both ends in one place, and is automatically provider-neutral.

## What this PR does NOT do

- **Does not backfill historical events.** Past `session_events` rows already landed without `toolFileRefs`; the server has no agent-local tree checkout to reconstruct repo-relative paths from. The Context tab catches up as new codex activity accumulates after this lands.
- Does not change the codex handler. The wire format stays exactly the same; only the classifier's interpretation of it changes.
- Does not relax the rejection envelope. Wrapped `tee`, wrapped `sed -i`, wrapped `cat … | head`, and wrapped `cat \$VAR/NODE.md` all still reject (with the inner reason now surfaced as the rejection reason).

## Implementation notes

- Wrapper basename set: `{sh, bash, zsh}` — the three shells that show up as the daemon login shell in this codebase's runtime surface.
- Wrapper flag set: `{-c, -lc}`. `-lc` is what codex / login-shell daemons emit; `-c` is the POSIX form so we accept both.
- `MAX_WRAPPER_UNWRAPS = 2` bounds recursion. One level covers codex; two leaves headroom for a script-wrapped command. Anything deeper falls through to the standard mutating-shell rejection — covered by a regression test.
- The unwrap is placed *before* `MUTATING_OR_AMBIGUOUS_TOOLS` so a wrapped read survives the mutating-shell check; the inner command then goes through the full classify pipeline so its own rejection rules still apply.

## Test plan

- [x] `pnpm --filter @first-tree/shared test src/__tests__/shell-command-io.test.ts` — 23 tests pass (11 new wrapper cases + 12 pre-existing)
- [x] `pnpm --filter @first-tree/client test src/__tests__/codex-context-tree-io.test.ts` — 6 tests pass (2 new wrapped-command end-to-end fixtures + 4 pre-existing)
- [x] `pnpm --filter @first-tree/server test` — full 1350-test server suite green (covers `recordFromSessionEvent` end-to-end)
- [x] `pnpm check` and `pnpm typecheck` clean
- [ ] After merge: liuchao-codex agent runs a fresh `sed -n` against its tree checkout; the resulting `session_events` row should now carry `toolFileRefs`, and the Context tab Recent Events feed should pick it up within one snapshot-refresh cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)