### PR TITLE
[codex] Strip Codex shell wrapper in timeline

### DIFF
--- a/packages/server/src/__tests__/me-chat-activity.test.ts
+++ b/packages/server/src/__tests__/me-chat-activity.test.ts
@@ -218,6 +218,27 @@ describe("toLiveActivity pure helper", () => {
     expect(toLiveActivity({ ...baseRow, kind: "thinking" })?.detail).toBeUndefined();
   });
 
+  it("strips codex command shell wrappers from liveActivity detail only for codex command rows", () => {
+    const wrapped = "/bin/bash -lc \"sed -n '1,40p' /home/op/context-tree/NODE.md\"";
+    expect(
+      toLiveActivity({
+        ...baseRow,
+        kind: "tool_call",
+        runtime_provider: "codex",
+        payload: { toolUseId: "t1", name: "command", args: { command: wrapped }, status: "pending" },
+      })?.detail,
+    ).toBe("sed -n '1,40p' /home/op/context…");
+
+    expect(
+      toLiveActivity({
+        ...baseRow,
+        kind: "tool_call",
+        runtime_provider: "claude-code",
+        payload: { toolUseId: "t1", name: "command", args: { command: wrapped }, status: "pending" },
+      })?.detail,
+    ).toBe("/bin/bash -lc \"sed -n '1,40p' /…");
+  });
+
   it("assistant_text carries a collapsed reply preview; empty text → none", () => {
     const writing = toLiveActivity({
       ...baseRow,

--- a/packages/server/src/services/agent-chat-status.ts
+++ b/packages/server/src/services/agent-chat-status.ts
@@ -8,6 +8,7 @@ import {
   type LiveActivity,
   RUNTIME_STALE_MS,
   type RuntimeState,
+  stripShellCommandDisplayWrapper,
   type ToolCallEventPayload,
 } from "@first-tree/shared";
 import { and, eq, inArray, ne, sql } from "drizzle-orm";
@@ -55,7 +56,7 @@ const ARG_PREVIEW_MAX = 32;
  * truncated to {@link ARG_PREVIEW_MAX}. Returns undefined when there's nothing
  * useful to show. Exported for unit testing.
  */
-export function previewToolArgs(args: unknown): string | undefined {
+export function previewToolArgs(args: unknown, opts?: { stripShellCommandWrapper?: boolean }): string | undefined {
   let raw: string | undefined;
   if (typeof args === "string") {
     raw = args;
@@ -68,6 +69,7 @@ export function previewToolArgs(args: unknown): string | undefined {
     if (typeof pick === "string") raw = pick;
     else if (Object.keys(o).length > 0) raw = JSON.stringify(o); // empty {} → no detail
   }
+  if (raw && opts?.stripShellCommandWrapper) raw = stripShellCommandDisplayWrapper(raw);
   if (!raw) return undefined;
   const oneLine = raw.replace(/\s+/g, " ").trim();
   if (oneLine.length === 0) return undefined;
@@ -100,6 +102,7 @@ export function toLiveActivity(row: {
   kind: string;
   payload: unknown;
   created_at: Date | string;
+  runtime_provider?: string | null;
 }): LiveActivity | null {
   const startedAt = new Date(row.created_at).toISOString();
   // Expiry the client uses to self-clear a lingering chip (matches the read-time
@@ -109,7 +112,9 @@ export function toLiveActivity(row: {
     case "tool_call": {
       const payload = (row.payload ?? {}) as Partial<ToolCallEventPayload>;
       const label = typeof payload.name === "string" && payload.name.length > 0 ? payload.name : "Tool";
-      const detail = previewToolArgs(payload.args);
+      const detail = previewToolArgs(payload.args, {
+        stripShellCommandWrapper: row.runtime_provider === "codex" && payload.name === "command",
+      });
       return { agentId: row.agent_id, kind: "tool_call", label, startedAt, staleAt, ...(detail ? { detail } : {}) };
     }
     case "thinking":
@@ -212,9 +217,11 @@ async function deriveActivities(
            acs.chat_id         AS chat_id,
            e.kind              AS kind,
            e.payload           AS payload,
-           e.created_at        AS created_at
+           e.created_at        AS created_at,
+           a.runtime_provider  AS runtime_provider
            ${turnTextSelect}
       FROM agent_chat_sessions acs
+      INNER JOIN agents a ON a.uuid = acs.agent_id
       CROSS JOIN LATERAL (
         SELECT kind, payload, created_at, seq
           FROM session_events se
@@ -232,6 +239,7 @@ async function deriveActivities(
     kind: string;
     payload: unknown;
     created_at: Date | string;
+    runtime_provider: string | null;
     turn_text: string | null;
   }>;
 
@@ -244,6 +252,7 @@ async function deriveActivities(
       kind: r.kind,
       payload: r.payload,
       created_at: r.created_at,
+      runtime_provider: r.runtime_provider,
     });
     const activity = withTurnNarration(base, r.turn_text);
     if (!activity) continue;

--- a/packages/shared/src/__tests__/shell-command-io.test.ts
+++ b/packages/shared/src/__tests__/shell-command-io.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { classifyShellCommandIo } from "../shell-command-io.js";
+import { classifyShellCommandIo, stripShellCommandDisplayWrapper } from "../shell-command-io.js";
 
 describe("classifyShellCommandIo", () => {
   it("classifies sed file operands after options and script", () => {
@@ -247,5 +247,31 @@ describe("classifyShellCommandIo", () => {
         supported: false,
       });
     });
+  });
+});
+
+describe("stripShellCommandDisplayWrapper", () => {
+  it("strips one codex login-shell wrapper for display", () => {
+    expect(stripShellCommandDisplayWrapper("/bin/zsh -lc \"sed -n '1,7p' /Users/op/tree/NODE.md\"")).toBe(
+      "sed -n '1,7p' /Users/op/tree/NODE.md",
+    );
+    expect(stripShellCommandDisplayWrapper("/bin/bash -lc 'cat /home/op/tree/NODE.md'")).toBe(
+      "cat /home/op/tree/NODE.md",
+    );
+    expect(stripShellCommandDisplayWrapper("sh -c 'rg --files /tree'")).toBe("rg --files /tree");
+  });
+
+  it("leaves non-wrapper and dynamic-wrapper commands unchanged", () => {
+    expect(stripShellCommandDisplayWrapper("sed -n '1,7p' /tree/NODE.md")).toBe("sed -n '1,7p' /tree/NODE.md");
+    expect(stripShellCommandDisplayWrapper("/bin/bash -x cat /tree/NODE.md")).toBe("/bin/bash -x cat /tree/NODE.md");
+    expect(stripShellCommandDisplayWrapper('/bin/zsh -lc "cat $TREE/NODE.md"')).toBe(
+      '/bin/zsh -lc "cat $TREE/NODE.md"',
+    );
+  });
+
+  it("only strips a single display wrapper", () => {
+    expect(stripShellCommandDisplayWrapper("/bin/bash -lc \"sh -c 'cat /tree/NODE.md'\"")).toBe(
+      "sh -c 'cat /tree/NODE.md'",
+    );
   });
 });

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -764,4 +764,5 @@ export {
   type ShellIoPathArg,
   type ShellIoPathKindHint,
   type ShellIoUnsupportedReason,
+  stripShellCommandDisplayWrapper,
 } from "./shell-command-io.js";

--- a/packages/shared/src/shell-command-io.ts
+++ b/packages/shared/src/shell-command-io.ts
@@ -525,6 +525,31 @@ export function classifyShellCommandIo(command: string): ShellIoClassification {
   return classifyShellCommandIoInternal(command, 0);
 }
 
+export function stripShellCommandDisplayWrapper(command: string): string {
+  const tokenized = tokenizeSimpleShell(command);
+  if (!tokenized.ok) return command;
+
+  const commandToken = tokenized.tokens[0];
+  if (!commandToken || commandToken.dynamic) return command;
+
+  const commandName = commandBasename(commandToken.value);
+  const flagToken = tokenized.tokens[1];
+  const innerToken = tokenized.tokens[2];
+
+  if (
+    SHELL_WRAPPER_BASENAMES.has(commandName) &&
+    flagToken &&
+    innerToken &&
+    SHELL_WRAPPER_FLAGS.has(flagToken.value) &&
+    innerToken.value.length > 0 &&
+    !innerToken.dynamic
+  ) {
+    return innerToken.value;
+  }
+
+  return command;
+}
+
 function classifyShellCommandIoInternal(command: string, wrapperDepth: number): ShellIoClassification {
   const tokenized = tokenizeSimpleShell(command);
   if (!tokenized.ok) return { supported: false, reason: tokenized.reason };

--- a/packages/web/src/components/chat/__tests__/working-turn-dom.test.tsx
+++ b/packages/web/src/components/chat/__tests__/working-turn-dom.test.tsx
@@ -172,4 +172,39 @@ describe("WorkingTurn", () => {
 
     await act(async () => root.unmount());
   });
+
+  it("strips codex login-shell wrappers from command tool display", async () => {
+    const { WorkingTurn } = await import("../working-turn.js");
+    const wrapped = "/bin/zsh -lc \"sed -n '1,40p' /home/op/context-tree/NODE.md\"";
+    const { container, root } = await renderDom(
+      <WorkingTurn
+        {...props}
+        defaultOpen
+        events={[
+          event({
+            id: "codex-command",
+            seq: 1,
+            kind: "tool_call",
+            payload: {
+              toolUseId: "cmd-1",
+              name: "command",
+              args: { command: wrapped, cwd: "/home/op/repo" },
+              status: "pending",
+            },
+          }),
+        ]}
+      />,
+    );
+
+    expect(container.textContent).toContain("run");
+    expect(container.textContent).toContain("sed -n '1,40p' /home/op/context-tree/NODE.md");
+    expect(container.textContent).not.toContain("/bin/zsh");
+    expect(container.textContent).not.toContain("-lc");
+
+    const titles = Array.from(container.querySelectorAll<HTMLElement>("[title]")).map((el) => el.title);
+    expect(titles.join("\n")).toContain("sed -n '1,40p' /home/op/context-tree/NODE.md");
+    expect(titles.join("\n")).not.toContain("/bin/zsh");
+
+    await act(async () => root.unmount());
+  });
 });

--- a/packages/web/src/components/chat/working-turn.tsx
+++ b/packages/web/src/components/chat/working-turn.tsx
@@ -14,6 +14,7 @@
  * body and process lane sit still) — not by any border, fill, or card chrome.
  */
 
+import { stripShellCommandDisplayWrapper } from "@first-tree/shared";
 import { useEffect, useState } from "react";
 import {
   asAssistantTextPayload,
@@ -43,6 +44,7 @@ type WorkingTurnProps = {
 // Tool name → human action verb. Unknown tools fall back to "use <Name>".
 const TOOL_VERBS: Record<string, string> = {
   Bash: "run",
+  command: "run",
   Read: "read",
   Grep: "search",
   Glob: "find",
@@ -84,6 +86,13 @@ function readString(args: unknown, key: string): string {
   return typeof v === "string" ? v : "";
 }
 
+function displayArgs(p: ToolCallEventPayload): unknown {
+  if (p.name !== "command" || typeof p.args !== "object" || p.args === null) return p.args;
+  const command = readString(p.args, "command");
+  if (!command) return p.args;
+  return { ...(p.args as Record<string, unknown>), command: stripShellCommandDisplayWrapper(command) };
+}
+
 function basename(path: string): string {
   const tail = path.split("/").pop() ?? path;
   return tail.length > 0 ? tail : path;
@@ -98,6 +107,8 @@ function describeTool(p: ToolCallEventPayload): { verb: string; target: string }
   switch (p.name) {
     case "Bash":
       return { verb, target: readString(p.args, "command").split("\n")[0] ?? "" };
+    case "command":
+      return { verb, target: stripShellCommandDisplayWrapper(readString(p.args, "command")).split("\n")[0] ?? "" };
     case "Read":
     case "Edit":
     case "MultiEdit":
@@ -134,6 +145,7 @@ function ToolCallLine({ event }: { event: SessionEventRow }) {
   const isPending = payload.status === "pending";
   const { verb, target } = describeTool(payload);
   const result = isPending ? "" : resultPreviewLine(payload.resultPreview);
+  const argsTitle = fullArgs(displayArgs(payload));
   return (
     <div
       className="mono flex items-center text-label"
@@ -149,7 +161,7 @@ function ToolCallLine({ event }: { event: SessionEventRow }) {
           {isErr ? "⚠" : "↳"}
         </span>
       )}
-      <span className="flex items-baseline" style={{ minWidth: 0, flex: 1 }} title={fullArgs(payload.args)}>
+      <span className="flex items-baseline" style={{ minWidth: 0, flex: 1 }} title={argsTitle}>
         <span style={{ flexShrink: 0, color: "var(--fg-3)" }}>{verb}</span>
         {target ? (
           <span className="truncate" style={{ color: "var(--fg-2)", minWidth: 0, flexShrink: 1, marginLeft: 6 }}>


### PR DESCRIPTION
## Summary

- Add a shared display helper that strips one `/bin/{sh,bash,zsh} -c/-lc <inner>` wrapper using the same tokenizer and wrapper rules as shell IO classification.
- Render Codex `command` tool calls in the working timeline as the inner command, including the hover args, without modifying stored `session_events.payload.args.command`.
- Apply the same display-only strip to server-derived `liveActivity.detail`, gated to `runtime_provider = "codex"` and tool name `command`.
- Cover the shared helper, Web timeline rendering, and liveActivity preview with tests.

Closes #992.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm exec biome check packages/shared/src/shell-command-io.ts packages/shared/src/index.ts packages/shared/src/__tests__/shell-command-io.test.ts packages/web/src/components/chat/working-turn.tsx packages/web/src/components/chat/__tests__/working-turn-dom.test.tsx`
- `pnpm exec biome check packages/server/src/services/agent-chat-status.ts packages/server/src/__tests__/me-chat-activity.test.ts`
- `pnpm --filter @first-tree/shared test -- src/__tests__/shell-command-io.test.ts` (ran shared package suite: 422 tests passed)
- `pnpm --filter @first-tree/web test -- src/components/chat/__tests__/working-turn-dom.test.tsx` (ran web package suite: 743 tests passed)
- `pnpm --filter @first-tree/server test -- src/__tests__/me-chat-activity.test.ts` (ran server package suite: 1351 tests passed)
- `pnpm --filter @first-tree/shared typecheck`
- `pnpm --filter @first-tree/web typecheck`
- `pnpm --filter @first-tree/server typecheck`