### PR TITLE
fix(cli): retire stranded legacy github-scan launchd runner on daemon start

### DIFF
--- a/apps/cli/src/__tests__/retire-github-scan-launchd.test.ts
+++ b/apps/cli/src/__tests__/retire-github-scan-launchd.test.ts
@@ -1,0 +1,165 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { retireLegacyGithubScanLaunchd } from "../core/retire-github-scan-launchd.js";
+
+const spawnSyncMock = vi.hoisted(() => vi.fn(() => ({ status: 0, stdout: "", stderr: "" })));
+const userInfoMock = vi.hoisted(() => vi.fn(() => ({ uid: 501, username: "gandy" })));
+
+vi.mock("node:child_process", () => ({
+  spawnSync: spawnSyncMock,
+}));
+
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  return { ...actual, userInfo: userInfoMock };
+});
+
+const originalPlatform = process.platform;
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", { configurable: true, value: platform });
+}
+
+function plistBody(label: string): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTD/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${label}</string>
+  <key>KeepAlive</key>
+  <true/>
+</dict>
+</plist>
+`;
+}
+
+let home: string;
+
+function launchdDir(): string {
+  return join(home, "github-scan", "runner", "launchd");
+}
+
+function writePlist(fileName: string, label: string): string {
+  const dir = launchdDir();
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, fileName);
+  writeFileSync(path, plistBody(label));
+  return path;
+}
+
+beforeEach(() => {
+  setPlatform("darwin");
+  spawnSyncMock.mockClear();
+  spawnSyncMock.mockReturnValue({ status: 0, stdout: "", stderr: "" });
+  userInfoMock.mockReturnValue({ uid: 501, username: "gandy" });
+  home = mkdtempSync(join(tmpdir(), "ft-ghscan-"));
+});
+
+afterEach(() => {
+  Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe("retireLegacyGithubScanLaunchd", () => {
+  it("is a no-op when the legacy launchd dir is absent", () => {
+    const result = retireLegacyGithubScanLaunchd({ homeDir: home });
+    expect(result).toEqual({ bootedOut: [], removedPlists: 0 });
+    expect(spawnSyncMock).not.toHaveBeenCalled();
+  });
+
+  it("boots out the label and removes the plist", () => {
+    const label = "com.first-tree.github-scan.runner.gandy.default";
+    const plistPath = writePlist(`${label}.plist`, label);
+
+    const result = retireLegacyGithubScanLaunchd({ homeDir: home });
+
+    expect(result).toEqual({ bootedOut: [label], removedPlists: 1 });
+    expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+    expect(spawnSyncMock).toHaveBeenCalledWith(
+      "launchctl",
+      ["bootout", `gui/501/${label}`],
+      expect.objectContaining({ timeout: 15_000 }),
+    );
+    expect(existsSync(plistPath)).toBe(false);
+    // The now-empty launchd dir is pruned.
+    expect(existsSync(launchdDir())).toBe(false);
+  });
+
+  it("uses the Label inside the plist, not the filename", () => {
+    const label = "com.first-tree.github-scan.runner.gandy.default";
+    writePlist("renamed-by-hand.plist", label);
+
+    const result = retireLegacyGithubScanLaunchd({ homeDir: home });
+
+    expect(result.bootedOut).toEqual([label]);
+    expect(spawnSyncMock).toHaveBeenCalledWith("launchctl", ["bootout", `gui/501/${label}`], expect.anything());
+  });
+
+  it("falls back to the filename stem when the plist has no Label", () => {
+    const dir = launchdDir();
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "com.first-tree.github-scan.runner.x.plist"), "<plist></plist>");
+
+    const result = retireLegacyGithubScanLaunchd({ homeDir: home });
+
+    expect(result.bootedOut).toEqual(["com.first-tree.github-scan.runner.x"]);
+    expect(result.removedPlists).toBe(1);
+  });
+
+  it("swallows the benign 'no such process' bootout failure and still removes the plist", () => {
+    spawnSyncMock.mockReturnValue({ status: 1, stdout: "", stderr: "Boot-out failed: 3: No such process" });
+    const label = "com.first-tree.github-scan.runner.gandy.default";
+    const plistPath = writePlist(`${label}.plist`, label);
+    const log = vi.fn();
+
+    const result = retireLegacyGithubScanLaunchd({ homeDir: home, log });
+
+    expect(result.removedPlists).toBe(1);
+    expect(existsSync(plistPath)).toBe(false);
+    // Not-loaded is expected — it must not be logged as a problem.
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  it("retires multiple plists", () => {
+    const a = "com.first-tree.github-scan.runner.gandy.default";
+    const b = "com.first-tree.github-scan.runner.gandy.work";
+    writePlist(`${a}.plist`, a);
+    writePlist(`${b}.plist`, b);
+
+    const result = retireLegacyGithubScanLaunchd({ homeDir: home });
+
+    expect(result.removedPlists).toBe(2);
+    expect(result.bootedOut.sort()).toEqual([a, b].sort());
+    expect(spawnSyncMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("leaves a non-plist file (and its dir) untouched", () => {
+    const label = "com.first-tree.github-scan.runner.gandy.default";
+    writePlist(`${label}.plist`, label);
+    const logPath = join(launchdDir(), "runner.log");
+    writeFileSync(logPath, "old crash spam\n");
+
+    const result = retireLegacyGithubScanLaunchd({ homeDir: home });
+
+    expect(result.removedPlists).toBe(1);
+    // The stray log keeps the dir alive — we do not blow away non-plist files.
+    expect(existsSync(logPath)).toBe(true);
+    expect(existsSync(launchdDir())).toBe(true);
+  });
+
+  it("is a no-op off darwin even if a plist exists", () => {
+    setPlatform("linux");
+    const label = "com.first-tree.github-scan.runner.gandy.default";
+    const plistPath = writePlist(`${label}.plist`, label);
+
+    const result = retireLegacyGithubScanLaunchd({ homeDir: home });
+
+    expect(result).toEqual({ bootedOut: [], removedPlists: 0 });
+    expect(spawnSyncMock).not.toHaveBeenCalled();
+    // Left strictly alone on the wrong platform.
+    expect(existsSync(plistPath)).toBe(true);
+  });
+});

--- a/apps/cli/src/commands/daemon/start.ts
+++ b/apps/cli/src/commands/daemon/start.ts
@@ -38,6 +38,7 @@ import {
   promptUpdate,
   reconcileLocalRuntimeProviders,
   refreshServerUpdateTarget,
+  retireLegacyGithubScanLaunchd,
   startClientService,
   uploadAgentSkills,
   uploadClientCapabilities,
@@ -184,6 +185,23 @@ export function registerDaemonStartCommand(daemon: Command): void {
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
           print.status("⚠️", `agent-dir migration skipped: ${msg}`);
+        }
+
+        // One-shot cleanup of the stranded legacy `github-scan` launchd runner.
+        // Older builds left a KeepAlive launchd job that crash-loops after an
+        // upgrade relocates its binary and squats port 7878 while it loops.
+        // Best-effort + free on machines that never ran github-scan (the sweep
+        // short-circuits when its plist dir is absent); never blocks startup.
+        try {
+          const retired = retireLegacyGithubScanLaunchd({
+            log: (msg) => print.status("⚠️", `github-scan cleanup: ${msg}`),
+          });
+          if (retired.removedPlists > 0) {
+            print.status("•", `retired legacy github-scan launchd runner (${retired.removedPlists} plist removed)`);
+          }
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          print.status("⚠️", `github-scan cleanup skipped: ${msg}`);
         }
 
         // Pre-flight runtime-provider reconciliation: probe local runtime SDKs

--- a/apps/cli/src/core/index.ts
+++ b/apps/cli/src/core/index.ts
@@ -63,6 +63,9 @@ export {
 export { blank, status } from "./output.js";
 // Interactive prompts
 export { isInteractive, promptAddAgent, promptMissingFields } from "./prompt.js";
+// One-shot retirement of the stranded legacy github-scan launchd runner.
+export type { RetireGithubScanResult } from "./retire-github-scan-launchd.js";
+export { retireLegacyGithubScanLaunchd } from "./retire-github-scan-launchd.js";
 export type { PinnedAgentRuntimeRecord } from "./runtime-provider-reconcile.js";
 // Pre-flight runtime-provider reconciliation (P2 — capabilities + YAML rewrite)
 export {

--- a/apps/cli/src/core/retire-github-scan-launchd.ts
+++ b/apps/cli/src/core/retire-github-scan-launchd.ts
@@ -1,0 +1,133 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, readdirSync, readFileSync, rmdirSync, rmSync } from "node:fs";
+import { homedir, userInfo } from "node:os";
+import { basename, join } from "node:path";
+
+/**
+ * Retire the stranded legacy `github-scan` launchd runner.
+ *
+ * The `github-scan` subsystem was removed after v1.0, but on machines that
+ * ran an older build its launchd runner (label like
+ * `com.first-tree.github-scan.runner.<user>.default`) was installed with
+ * `KeepAlive: true` and a `ProgramArguments` path baked into the old npm
+ * layout. After a CLI upgrade relocates/removes that binary, launchd hits
+ * `MODULE_NOT_FOUND` and the service crash-loops indefinitely — and while it
+ * loops it keeps binding the legacy default `httpPort` 7878, silently
+ * squatting a port another local tool (tdoc) documents as its own.
+ *
+ * Nothing in the current upgrade path retires this service: the
+ * `v1-orphan-skills` workspace migration sweeps retired skill *payloads*, but
+ * the runner is a machine/user-level launchd job under the prod home, not a
+ * workspace artifact. This sweep closes that gap.
+ *
+ * Strategy is enumerate-from-disk rather than reconstruct-the-label: the label
+ * embeds the OS username (and a profile suffix), so we read each plist's
+ * `Label` straight from the file instead of guessing it. Bootout is keyed on
+ * the user GUI domain (`gui/<uid>`), matching how the legacy runner registered
+ * itself. Everything is best-effort — a `bootout` against an already-evicted
+ * label is a no-op, and we never throw out of here; daemon start must not be
+ * blocked by cleanup of a dead subsystem.
+ *
+ * Scope is deliberately narrow: only `*.plist` files under
+ * `<home>/github-scan/runner/launchd/` are touched (plus the now-empty dir).
+ * The rest of `<home>/github-scan/` (config.yaml, logs) is left alone — a user
+ * may have written a defensive config there, and inert files do not crash-loop.
+ */
+export type RetireGithubScanResult = {
+  /** Labels we asked launchd to bootout. */
+  bootedOut: string[];
+  /** Plist files removed from disk. */
+  removedPlists: number;
+};
+
+const EMPTY_RESULT: RetireGithubScanResult = { bootedOut: [], removedPlists: 0 };
+
+/** Parse the `Label` value out of a launchd plist body, if present. */
+function parsePlistLabel(plistBody: string): string | null {
+  const match = plistBody.match(/<key>\s*Label\s*<\/key>\s*<string>([^<]+)<\/string>/);
+  return match ? match[1].trim() : null;
+}
+
+/** `launchctl bootout gui/<uid>/<label>`, swallowing the benign not-loaded case. */
+function bootoutLabel(uid: number, label: string, log?: (msg: string) => void): void {
+  const target = `gui/${uid}/${label}`;
+  const res = spawnSync("launchctl", ["bootout", target], {
+    encoding: "utf-8",
+    timeout: 15_000,
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+  if (res.status === 0) return;
+  const stderr = (res.stderr ?? "").trim();
+  // A label that is not currently loaded is the expected happy path on a
+  // machine where the zombie was already evicted (or never ran this boot).
+  if (/not find|no such|not loaded/i.test(stderr)) return;
+  if (log) log(`launchctl bootout ${label}: ${stderr || `exit ${res.status ?? "unknown"}`}`);
+}
+
+/**
+ * Bootout + delete every legacy github-scan launchd plist found on disk.
+ *
+ * @param opts.homeDir Base home to look under. Defaults to the prod
+ *   `~/.first-tree` home where the pre-multi-channel github-scan runner lived
+ *   (it predates the per-channel home split, so it only ever existed there).
+ *   Overridable for tests.
+ * @param opts.log Optional sink for non-fatal diagnostics.
+ */
+export function retireLegacyGithubScanLaunchd(
+  opts: { homeDir?: string; log?: (msg: string) => void } = {},
+): RetireGithubScanResult {
+  // launchd is macOS-only; the legacy runner was never a launchd job anywhere
+  // else, so there is nothing to retire off-darwin.
+  if (process.platform !== "darwin") return EMPTY_RESULT;
+
+  const home = opts.homeDir ?? join(homedir(), ".first-tree");
+  const launchdDir = join(home, "github-scan", "runner", "launchd");
+  if (!existsSync(launchdDir)) return EMPTY_RESULT;
+
+  let entries: string[];
+  try {
+    entries = readdirSync(launchdDir).filter((name) => name.endsWith(".plist"));
+  } catch (err) {
+    if (opts.log) opts.log(`could not read ${launchdDir}: ${err instanceof Error ? err.message : String(err)}`);
+    return EMPTY_RESULT;
+  }
+  if (entries.length === 0) return EMPTY_RESULT;
+
+  const uid = userInfo().uid;
+  const bootedOut: string[] = [];
+  let removedPlists = 0;
+
+  for (const entry of entries) {
+    const plistPath = join(launchdDir, entry);
+    // Prefer the Label recorded inside the plist; fall back to the filename
+    // stem so an unparseable plist still gets a bootout attempt (a wrong
+    // guess is a harmless no-op against launchd).
+    let label: string | null = null;
+    try {
+      label = parsePlistLabel(readFileSync(plistPath, "utf-8"));
+    } catch {
+      // unreadable — fall through to the filename-derived label
+    }
+    label ??= basename(entry, ".plist");
+
+    bootoutLabel(uid, label, opts.log);
+    bootedOut.push(label);
+
+    try {
+      rmSync(plistPath);
+      removedPlists += 1;
+    } catch (err) {
+      if (opts.log) opts.log(`failed to remove ${plistPath}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  // Prune the now-empty launchd dir (best-effort; leave it if anything else
+  // — e.g. a stray runner log — still lives there).
+  try {
+    rmdirSync(launchdDir);
+  } catch {
+    // non-empty or already gone — nothing to do
+  }
+
+  return { bootedOut, removedPlists };
+}


### PR DESCRIPTION
## What

Closes #995 (ask #1): on machines that ran an older build, the now-removed
`github-scan` subsystem left a `KeepAlive` launchd runner
(`com.first-tree.github-scan.runner.<user>.default`). After a CLI upgrade
relocates/removes its binary, launchd hits `MODULE_NOT_FOUND` and crash-loops
the job indefinitely — and while it loops it keeps binding the legacy default
`httpPort` **7878**, silently squatting a port another local tool (tdoc)
documents as its own.

Nothing in the current upgrade path retires this job. The `v1-orphan-skills`
workspace migration only sweeps retired skill *payloads*; the runner is a
**machine/user-level launchd job under the prod home**, not a workspace artifact.

## Change

A focused, best-effort `retireLegacyGithubScanLaunchd()` sweep, wired into
`daemon start` next to the existing client-level migrations
(`migrateLocalAgentDirs`, `reconcileLocalRuntimeProviders`). Running it on
daemon start (rather than only in the `upgrade` command) means already-upgraded
machines get cleaned on their next start.

It:
- enumerates `*.plist` under `~/.first-tree/github-scan/runner/launchd/`
  (**enumerate-from-disk** — avoids reconstructing the username/profile-bearing label),
- reads each plist's recorded `Label` and `launchctl bootout gui/<uid>/<label>`s it
  (swallowing the benign "not loaded" case),
- deletes the plist and prunes the now-empty dir.

Deliberately narrow + safe:
- **darwin-only**; no-op elsewhere.
- **Free** on machines that never ran github-scan — short-circuits when the plist dir is absent.
- **Best-effort** — never throws out, never blocks daemon startup.
- Leaves the rest of `~/.first-tree/github-scan/` (config.yaml, logs) untouched — inert files don't crash-loop, and a user may have written a defensive config there.

## Tests

New `apps/cli/src/__tests__/retire-github-scan-launchd.test.ts` (8 cases): absent-dir no-op, bootout+remove+prune, Label-over-filename, filename-stem fallback, benign "no such process" swallowed, multiple plists, non-plist file keeps the dir, and off-darwin no-op.

- `pnpm --filter first-tree exec vitest run` — full CLI suite green (444 passed).
- `tsc --noEmit` — clean. `biome check` — clean on changed files.

## Scope note

This PR covers **ask #1** only. Ask #2 (harden the *active* daemon service against a bare `nvm` switch — no StartLimit backoff / re-resolve the bin at runtime) and ask #3 (move `httpPort` off 7878 *if* github-scan is ever revived) are out of scope here and can be tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)