### PR TITLE
fix(web): use PanelRight glyph for the chat details rail toggle

### DIFF
--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -12,18 +12,7 @@ import {
   type RequestResolution,
 } from "@first-tree/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import {
-  ArrowUp,
-  AtSign,
-  Check,
-  ExternalLink,
-  Eye,
-  Menu,
-  MessageSquare,
-  MoreHorizontal,
-  Paperclip,
-  X,
-} from "lucide-react";
+import { ArrowUp, AtSign, Check, ExternalLink, Eye, Menu, MessageSquare, PanelRight, Paperclip, X } from "lucide-react";
 import {
   type MouseEvent as ReactMouseEvent,
   type ReactNode,
@@ -2575,7 +2564,7 @@ export function ChatView({
           {/* Chat header — content centred in a reading column that's now
           measured against the left column rather than the full panel.
           Title + EntityLink + ParticipantsStats live in the reading
-          column; the chat-level icon strip (UserPlus / MoreHorizontal)
+          column; the chat-level icon strip (UserPlus / PanelRight)
           rides along at the column's right edge so it sits flush with
           the composer's right edge below. */}
           <div
@@ -2818,8 +2807,12 @@ export function ChatView({
               )}
               {/* Chat details toggle — opens the right rail (Participants /
               GitHub / Chat actions). Sits at the panel's far right,
-              mirroring the rail's position. The "..." glyph follows the
-              collaboration-product convention referenced in the design discussion. */}
+              mirroring the rail's position. The PanelRight glyph is the
+              panel-toggle convention (Linear / Notion / VS Code); the same
+              glyph renders in both states — pressed styling (sunken
+              background + darker foreground) carries the open/closed state.
+              An ellipsis is reserved for overflow-action menus (see
+              row-actions-menu.tsx), so it would mislead here. */}
               <button
                 type="button"
                 onClick={toggleSidebar}
@@ -2838,7 +2831,7 @@ export function ChatView({
                   cursor: "pointer",
                 }}
               >
-                <MoreHorizontal size={16} strokeWidth={2.25} />
+                <PanelRight size={16} strokeWidth={2.25} />
               </button>
             </div>
           </div>


### PR DESCRIPTION
## What

Swaps the chat header's details-rail toggle glyph from `MoreHorizontal` ("...") to `PanelRight` (lucide). One glyph swap + comment updates in `chat-view.tsx`; size (16px), stroke width (2.25), 28×28 hit area, pressed styling, and behavior are all unchanged.

## Why

- `...` conventionally signals an overflow-action menu — and already means exactly that in `row-actions-menu.tsx`. The same glyph carrying two interactions in one product misleads: users expect a dropdown, get a sidebar.
- `PanelRight` is the panel-toggle convention (Linear / Notion / VS Code): a window outline with the right rail highlighted — what you see is what it toggles.
- The same glyph renders in both states; the existing pressed treatment (`bg-sunken` + foreground deepened from `fg-3` to `fg`) carries open/closed, so the icon stays stable across clicks.
- Frees the `...` slot for a future real chat-actions overflow menu.

Mockup (closed / open / three-way comparison) was reviewed and approved in chat before implementation.

## Checks

- `pnpm check` clean
- `@first-tree/web` typecheck + design-token guardrails clean
- `@first-tree/web` tests: 102 files / 773 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)