### PR TITLE
refactor(web): consolidate popover chrome, copy feedback, and DOM test harness

### DIFF
--- a/packages/web/src/components/chat/__tests__/agent-hovercard.test.tsx
+++ b/packages/web/src/components/chat/__tests__/agent-hovercard.test.tsx
@@ -2,9 +2,9 @@
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, type ReactElement } from "react";
-import { createRoot, type Root } from "react-dom/client";
 import { MemoryRouter, Route, Routes, useLocation } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDomHarness, type DomHarness } from "../../../test-utils/dom-harness.js";
 
 const mocks = vi.hoisted(() => ({
   getChat: vi.fn(),
@@ -30,10 +30,7 @@ vi.mock("../../../lib/use-client-map.js", () => ({
 // Imported after the mocks are registered.
 import { AgentHovercard } from "../agent-hovercard.js";
 
-globalThis.IS_REACT_ACT_ENVIRONMENT = true;
-
-let root: Root | null = null;
-let container: HTMLElement | null = null;
+let h: DomHarness;
 let queryClient: QueryClient;
 let latestPath = "";
 
@@ -43,40 +40,20 @@ function LocationProbe(): null {
 }
 
 function render(ui: ReactElement): void {
-  act(() => {
-    root?.render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter initialEntries={["/start"]}>
-          <LocationProbe />
-          <Routes>
-            <Route path="*" element={ui} />
-          </Routes>
-        </MemoryRouter>
-      </QueryClientProvider>,
-    );
-  });
+  h.render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={["/start"]}>
+        <LocationProbe />
+        <Routes>
+          <Route path="*" element={ui} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
 }
 
-function flush(): Promise<void> {
-  return act(async () => {
-    await Promise.resolve();
-    await Promise.resolve();
-  });
-}
-
-async function waitFor(assertion: () => void): Promise<void> {
-  let lastErr: unknown;
-  for (let i = 0; i < 25; i++) {
-    try {
-      assertion();
-      return;
-    } catch (err) {
-      lastErr = err;
-    }
-    await flush();
-  }
-  throw lastErr;
-}
+const flush = (): Promise<void> => h.flush();
+const waitFor = (assertion: () => void): Promise<void> => h.waitFor(assertion);
 
 // Pass A is read from the warm React Query cache (ChatView keeps it hot in the
 // real app). Seed it directly so the test mirrors that warm-cache open.
@@ -86,26 +63,18 @@ function seedPassA(chatId: string, participants: unknown, statuses: unknown): vo
 }
 
 beforeEach(() => {
-  container = document.createElement("div");
-  document.body.appendChild(container);
-  root = createRoot(container);
+  h = createDomHarness();
   // staleTime: Infinity so the seeded Pass A cache (chat-detail / agent-status)
   // is never background-refetched; Pass B (getAgent) has no seed, so it still
   // fetches on open.
   queryClient = new QueryClient({ defaultOptions: { queries: { retry: false, staleTime: Number.POSITIVE_INFINITY } } });
-  Object.defineProperty(window, "innerWidth", { configurable: true, value: 1400 });
-  Object.defineProperty(window, "innerHeight", { configurable: true, value: 900 });
   mocks.getChat.mockReset();
   mocks.fetchChatAgentStatuses.mockReset();
   mocks.getAgent.mockReset();
 });
 
 afterEach(() => {
-  act(() => root?.unmount());
-  container?.remove();
-  container = null;
-  root = null;
-  document.body.innerHTML = "";
+  h.cleanup();
 });
 
 const AGENT_PARTICIPANT = {
@@ -145,7 +114,7 @@ const AGENT_DTO = {
 };
 
 async function openCard(): Promise<HTMLElement> {
-  const trigger = container?.querySelector<HTMLButtonElement>("button");
+  const trigger = h.container.querySelector<HTMLButtonElement>("button");
   if (!trigger) throw new Error("trigger not found");
   await act(async () => {
     trigger.click();

--- a/packages/web/src/components/chat/__tests__/chat-description-info.test.tsx
+++ b/packages/web/src/components/chat/__tests__/chat-description-info.test.tsx
@@ -1,46 +1,20 @@
 // @vitest-environment happy-dom
 
 import { act, type ReactElement } from "react";
-import { createRoot, type Root } from "react-dom/client";
 import { MemoryRouter } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDomHarness, type DomHarness } from "../../../test-utils/dom-harness.js";
 import { ChatDescriptionInfo } from "../chat-description-info.js";
 
-globalThis.IS_REACT_ACT_ENVIRONMENT = true;
-
-let root: Root | null = null;
-let container: HTMLElement | null = null;
+let h: DomHarness;
 const writeText = vi.fn<(text: string) => Promise<void>>();
 
 function render(ui: ReactElement): void {
-  act(() => {
-    root?.render(<MemoryRouter initialEntries={["/start"]}>{ui}</MemoryRouter>);
-  });
-}
-
-function flush(): Promise<void> {
-  return act(async () => {
-    await Promise.resolve();
-    await Promise.resolve();
-  });
-}
-
-async function waitFor(assertion: () => void): Promise<void> {
-  let lastErr: unknown;
-  for (let i = 0; i < 25; i++) {
-    try {
-      assertion();
-      return;
-    } catch (err) {
-      lastErr = err;
-    }
-    await flush();
-  }
-  throw lastErr;
+  h.render(<MemoryRouter initialEntries={["/start"]}>{ui}</MemoryRouter>);
 }
 
 function trigger(): HTMLButtonElement {
-  const btn = container?.querySelector<HTMLButtonElement>("button");
+  const btn = h.container.querySelector<HTMLButtonElement>("button");
   if (!btn) throw new Error("trigger not found");
   return btn;
 }
@@ -54,29 +28,21 @@ async function openCard(): Promise<HTMLElement> {
     trigger().click();
     await Promise.resolve();
   });
-  await flush();
+  await h.flush();
   const el = card();
   if (!el) throw new Error("card did not open");
   return el;
 }
 
 beforeEach(() => {
-  container = document.createElement("div");
-  document.body.appendChild(container);
-  root = createRoot(container);
-  Object.defineProperty(window, "innerWidth", { configurable: true, value: 1400 });
-  Object.defineProperty(window, "innerHeight", { configurable: true, value: 900 });
+  h = createDomHarness();
   writeText.mockReset();
   writeText.mockResolvedValue(undefined);
   Object.defineProperty(navigator, "clipboard", { configurable: true, value: { writeText } });
 });
 
 afterEach(() => {
-  act(() => root?.unmount());
-  container?.remove();
-  container = null;
-  root = null;
-  document.body.innerHTML = "";
+  h.cleanup();
 });
 
 const DESCRIPTION = "Reviewing PR 987 — chat header description popover, gates green, awaiting review.";
@@ -84,16 +50,16 @@ const DESCRIPTION = "Reviewing PR 987 — chat header description popover, gates
 describe("ChatDescriptionInfo", () => {
   it("renders a labelled trigger and stays closed until activated", async () => {
     render(<ChatDescriptionInfo description={DESCRIPTION} />);
-    await flush();
+    await h.flush();
     expect(trigger().getAttribute("aria-label")).toBe("View chat description");
     expect(card()).toBeNull();
   });
 
   it("opens a Description card with the full text on click", async () => {
     render(<ChatDescriptionInfo description={DESCRIPTION} />);
-    await flush();
+    await h.flush();
     const el = await openCard();
-    await waitFor(() => {
+    await h.waitFor(() => {
       expect(el.textContent).toContain("Description");
       expect(el.textContent).toContain(DESCRIPTION);
     });
@@ -101,7 +67,7 @@ describe("ChatDescriptionInfo", () => {
 
   it("copies the description and flips the button to Copied", async () => {
     render(<ChatDescriptionInfo description={DESCRIPTION} />);
-    await flush();
+    await h.flush();
     const el = await openCard();
     const copyBtn = [...el.querySelectorAll("button")].find((b) => b.textContent?.includes("Copy"));
     if (!copyBtn) throw new Error("copy button not found");
@@ -110,20 +76,20 @@ describe("ChatDescriptionInfo", () => {
       await Promise.resolve();
     });
     expect(writeText).toHaveBeenCalledWith(DESCRIPTION);
-    await waitFor(() => {
+    await h.waitFor(() => {
       expect(el.textContent).toContain("Copied");
     });
   });
 
   it("closes on Escape", async () => {
     render(<ChatDescriptionInfo description={DESCRIPTION} />);
-    await flush();
+    await h.flush();
     await openCard();
     await act(async () => {
       document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
       await Promise.resolve();
     });
-    await flush();
+    await h.flush();
     expect(card()).toBeNull();
   });
 });

--- a/packages/web/src/components/chat/agent-hovercard.tsx
+++ b/packages/web/src/components/chat/agent-hovercard.tsx
@@ -53,14 +53,11 @@ export function AgentHovercard({
       placement={placement}
       ariaLabel={`${name} — view details`}
       triggerClassName={triggerClassName}
+      // Card chrome (background / border / shadow / padding) comes from the
+      // HoverCard primitive; only the width is this consumer's call.
       contentStyle={{
         width: "var(--sp-70)",
         maxWidth: "calc(100vw - var(--sp-4))",
-        background: "var(--bg-raised)",
-        border: "var(--hairline) solid var(--border)",
-        borderRadius: "var(--radius-panel)",
-        boxShadow: "var(--shadow-md)",
-        padding: "var(--sp-3)",
       }}
       content={({ close }) => <AgentHovercardBody agentId={agentId} chatId={chatId} onAction={close} />}
     >

--- a/packages/web/src/components/chat/chat-description-info.tsx
+++ b/packages/web/src/components/chat/chat-description-info.tsx
@@ -1,5 +1,5 @@
 import { Check, Copy, Info } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useCopyFeedback } from "../../lib/use-copy-feedback.js";
 import { Button } from "../ui/button.js";
 import { HoverCard } from "../ui/hover-card.js";
 
@@ -19,8 +19,6 @@ import { HoverCard } from "../ui/hover-card.js";
  * being renamed, so there is no empty / dead entry point.
  */
 
-const COPY_FEEDBACK_MS = 1500;
-
 export function ChatDescriptionInfo({ description }: { description: string }) {
   return (
     <HoverCard
@@ -30,14 +28,11 @@ export function ChatDescriptionInfo({ description }: { description: string }) {
       // rounded backplate. Mirrors the header's other ghost icons (the
       // hamburger / GitHub link) for a consistent control language.
       triggerClassName="inline-flex shrink-0 cursor-pointer items-center justify-center rounded-[var(--radius-input)] p-[var(--sp-1)] text-[var(--fg-3)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--fg-2)] focus-visible:bg-[var(--bg-hover)] focus-visible:text-[var(--fg-2)] focus-visible:outline-none"
+      // Card chrome (background / border / shadow / padding) comes from the
+      // HoverCard primitive; only the readable-measure width is set here.
       contentStyle={{
         width: "var(--sp-95)",
         maxWidth: "calc(100vw - var(--sp-8))",
-        background: "var(--bg-raised)",
-        border: "var(--hairline) solid var(--border)",
-        borderRadius: "var(--radius-panel)",
-        boxShadow: "var(--shadow-md)",
-        padding: "var(--sp-3)",
       }}
       content={() => <DescriptionCard description={description} />}
     >
@@ -46,37 +41,11 @@ export function ChatDescriptionInfo({ description }: { description: string }) {
   );
 }
 
-type CopyStatus = "idle" | "copied" | "failed";
-
 function DescriptionCard({ description }: { description: string }) {
-  const [status, setStatus] = useState<CopyStatus>("idle");
-  // One timer for the transient feedback: clear-before-set so a rapid second
-  // click restarts the full window (not a ~0ms flash), and clear on unmount.
-  const resetTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  useEffect(
-    () => () => {
-      if (resetTimer.current) clearTimeout(resetTimer.current);
-    },
-    [],
-  );
-
-  const flash = (next: CopyStatus): void => {
-    setStatus(next);
-    if (resetTimer.current) clearTimeout(resetTimer.current);
-    resetTimer.current = setTimeout(() => setStatus("idle"), COPY_FEEDBACK_MS);
-  };
-
-  const handleCopy = async (): Promise<void> => {
-    try {
-      await navigator.clipboard.writeText(description);
-      flash("copied");
-    } catch {
-      // `navigator.clipboard.writeText` rejects in non-secure contexts and when
-      // the user denies clipboard permission. The text is selectable above, so
-      // flip to a transient "Copy failed" state rather than fail silently.
-      flash("failed");
-    }
-  };
+  // Shared copy → transient-feedback machine. The text is selectable above,
+  // so a clipboard failure surfaces as a transient "Copy failed" rather than
+  // failing silently.
+  const { status, copy } = useCopyFeedback();
 
   return (
     <div className="flex flex-col" style={{ gap: "var(--sp-2)" }}>
@@ -99,7 +68,7 @@ function DescriptionCard({ description }: { description: string }) {
         {description}
       </div>
       <div className="flex justify-end">
-        <Button size="sm" variant="ghost" onClick={handleCopy}>
+        <Button size="sm" variant="ghost" onClick={() => void copy(description)}>
           {status === "copied" ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
           {status === "copied" ? "Copied" : status === "failed" ? "Copy failed" : "Copy"}
         </Button>

--- a/packages/web/src/components/connect-command-panel.tsx
+++ b/packages/web/src/components/connect-command-panel.tsx
@@ -1,5 +1,6 @@
 import { Check, Copy } from "lucide-react";
-import { type ReactNode, useState } from "react";
+import type { ReactNode } from "react";
+import { useCopyFeedback } from "../lib/use-copy-feedback.js";
 import { Button } from "./ui/button.js";
 
 export type ConnectPhase = "loading" | "waiting" | "success" | "error";
@@ -31,8 +32,6 @@ type ConnectCommandPanelProps = {
   copyButtonPlacement?: "right" | "bottom";
 };
 
-const COPY_FEEDBACK_MS = 1_500;
-
 /**
  * Shared panel for "run this CLI command on the machine you want to pair"
  * surfaces. Used by the onboarding flow's connect step and the
@@ -59,13 +58,14 @@ export function ConnectCommandPanel({
   caption = "Single-use · regenerates the previous one.",
   copyButtonPlacement = "right",
 }: ConnectCommandPanelProps) {
-  const [copied, setCopied] = useState(false);
+  // Shared copy → transient-feedback machine. This panel only surfaces the
+  // success label (`copyLabel.done`); a clipboard failure quietly stays on
+  // the idle label — the command text is selectable above.
+  const { status, copy } = useCopyFeedback();
 
-  const handleCopy = async (): Promise<void> => {
+  const handleCopy = (): void => {
     if (!command) return;
-    await navigator.clipboard.writeText(command);
-    setCopied(true);
-    setTimeout(() => setCopied(false), COPY_FEEDBACK_MS);
+    void copy(command);
   };
 
   const expiryMinutes = expiresInSeconds !== undefined ? Math.max(1, Math.round(expiresInSeconds / 60)) : null;
@@ -108,8 +108,8 @@ export function ConnectCommandPanel({
       disabled={!command}
       style={{ alignSelf: "flex-start" }}
     >
-      {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
-      {copied ? copyLabel.done : copyLabel.idle}
+      {status === "copied" ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+      {status === "copied" ? copyLabel.done : copyLabel.idle}
     </Button>
   );
 

--- a/packages/web/src/components/last-step-modal.tsx
+++ b/packages/web/src/components/last-step-modal.tsx
@@ -1,9 +1,10 @@
 import type { Agent } from "@first-tree/shared";
 import { useQuery } from "@tanstack/react-query";
 import { Check, Copy } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { generateConnectToken } from "../api/activity.js";
 import { getAgent } from "../api/agents.js";
+import { useCopyFeedback } from "../lib/use-copy-feedback.js";
 import { Button } from "./ui/button.js";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "./ui/dialog.js";
 import { StateDot } from "./ui/state-dot.js";
@@ -37,7 +38,10 @@ function shellQuote(value: string): string {
 }
 
 export function LastStepModal({ agent, open, onClose, onBound }: Props) {
-  const [copied, setCopied] = useState(false);
+  // Shared copy → transient-feedback machine. This modal historically used a
+  // slightly longer 2s window than the 1.5s default — kept as-is.
+  const { status: copyStatus, copy } = useCopyFeedback({ feedbackMs: 2_000 });
+  const copied = copyStatus === "copied";
 
   const tokenQuery = useQuery({
     queryKey: ["connect-token", agent.uuid],
@@ -100,9 +104,7 @@ export function LastStepModal({ agent, open, onClose, onBound }: Props) {
 
   function handleCopy() {
     if (!command) return;
-    navigator.clipboard.writeText(command);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    void copy(command);
   }
 
   return (

--- a/packages/web/src/components/new-agent-dialog.tsx
+++ b/packages/web/src/components/new-agent-dialog.tsx
@@ -13,6 +13,7 @@ import { getClientCapabilities, type HubClient, listClients } from "../api/activ
 import { checkAgentNameAvailability, createAgent } from "../api/agents.js";
 import { ApiError, api, type ValidationIssue } from "../api/client.js";
 import { useAuth } from "../auth/auth-context.js";
+import { useCopyFeedback } from "../lib/use-copy-feedback.js";
 import { runVisibilityAwareInterval } from "../lib/visibility-interval.js";
 import { slugify } from "../utils/agent-naming.js";
 import { Button } from "./ui/button.js";
@@ -232,7 +233,9 @@ export function NewAgentDialog({ open, onOpenChange, onCreated }: Props) {
   const [connectToken, setConnectToken] = useState<string | null>(null);
   const [connectCommand, setConnectCommand] = useState<string | null>(null);
   const [connectTokenExpiresAt, setConnectTokenExpiresAt] = useState<number | null>(null);
-  const [tokenCopied, setTokenCopied] = useState(false);
+  // Shared copy → transient-feedback machine for the zero-computer block's
+  // connect command (success label only here).
+  const { status: tokenCopyStatus, copy: copyToken, reset: resetTokenCopy } = useCopyFeedback();
 
   const [clientErrors, setClientErrors] = useState<FieldErrors>({});
 
@@ -253,10 +256,10 @@ export function NewAgentDialog({ open, onOpenChange, onCreated }: Props) {
       setConnectToken(null);
       setConnectCommand(null);
       setConnectTokenExpiresAt(null);
-      setTokenCopied(false);
+      resetTokenCopy();
       setClientErrors({});
     }
-  }, [open]);
+  }, [open, resetTokenCopy]);
 
   const baseSlug = useMemo(() => slugify(displayName), [displayName]);
   const hasDisplay = displayName.trim().length > 0;
@@ -754,12 +757,10 @@ export function NewAgentDialog({ open, onOpenChange, onCreated }: Props) {
             ) : connectedClients.length === 0 ? (
               <ZeroComputerBlock
                 command={connectCommand}
-                copied={tokenCopied}
-                onCopy={async () => {
+                copied={tokenCopyStatus === "copied"}
+                onCopy={() => {
                   if (!connectCommand) return;
-                  await navigator.clipboard.writeText(connectCommand);
-                  setTokenCopied(true);
-                  window.setTimeout(() => setTokenCopied(false), 1500);
+                  void copyToken(connectCommand);
                 }}
               />
             ) : connectedClients.length === 1 ? (

--- a/packages/web/src/components/ui/hover-card.tsx
+++ b/packages/web/src/components/ui/hover-card.tsx
@@ -44,6 +44,11 @@ export function HoverCard({
   content: (api: { close: () => void }) => ReactNode;
   placement?: HoverCardPlacement;
   contentClassName?: string;
+  /**
+   * Consumer-specific card styles (typically just `width` / `maxWidth`).
+   * The primitive already provides the shared card chrome (background,
+   * border, radius, shadow, padding); anything passed here overrides it.
+   */
   contentStyle?: React.CSSProperties;
   triggerClassName?: string;
   ariaLabel?: string;
@@ -226,6 +231,16 @@ export function HoverCard({
                 zIndex: 60,
                 // Hidden until positioned, so it never flashes at the origin.
                 visibility: coords ? "visible" : "hidden",
+                // Default card chrome — the primitive owns the shared popover
+                // surface so every hover-card looks the same (consumers used
+                // to re-declare these identically; issue 998). Sizing stays
+                // with the consumer via `contentStyle`, which also overrides
+                // any of these when a card genuinely needs to diverge.
+                background: "var(--bg-raised)",
+                border: "var(--hairline) solid var(--border)",
+                borderRadius: "var(--radius-panel)",
+                boxShadow: "var(--shadow-md)",
+                padding: "var(--sp-3)",
                 ...contentStyle,
               }}
               onPointerEnter={cancelClose}

--- a/packages/web/src/lib/__tests__/use-copy-feedback.test.tsx
+++ b/packages/web/src/lib/__tests__/use-copy-feedback.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDomHarness, type DomHarness } from "../../test-utils/dom-harness.js";
+import { type CopyFeedbackStatus, useCopyFeedback } from "../use-copy-feedback.js";
+
+let h: DomHarness;
+const writeText = vi.fn<(text: string) => Promise<void>>();
+
+/** Tiny probe component: exposes the hook's status as text + a copy button. */
+function Probe({ text }: { text: string }) {
+  const { status, copy } = useCopyFeedback();
+  return (
+    <button type="button" data-status={status satisfies CopyFeedbackStatus} onClick={() => void copy(text)}>
+      {status}
+    </button>
+  );
+}
+
+function probeButton(): HTMLButtonElement {
+  const btn = h.container.querySelector<HTMLButtonElement>("button");
+  if (!btn) throw new Error("probe button not found");
+  return btn;
+}
+
+async function clickCopy(): Promise<void> {
+  await act(async () => {
+    probeButton().click();
+    await Promise.resolve();
+  });
+  await h.flush();
+}
+
+beforeEach(() => {
+  h = createDomHarness();
+  writeText.mockReset();
+  Object.defineProperty(navigator, "clipboard", { configurable: true, value: { writeText } });
+});
+
+afterEach(() => {
+  h.cleanup();
+});
+
+describe("useCopyFeedback", () => {
+  it("flips to copied on success and back to idle after the window", async () => {
+    vi.useFakeTimers();
+    try {
+      writeText.mockResolvedValue(undefined);
+      h.render(<Probe text="hello" />);
+      await clickCopy();
+      expect(writeText).toHaveBeenCalledWith("hello");
+      expect(probeButton().textContent).toBe("copied");
+      await act(async () => {
+        vi.advanceTimersByTime(1_500);
+      });
+      expect(probeButton().textContent).toBe("idle");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("flips to failed when the clipboard write rejects", async () => {
+    writeText.mockRejectedValue(new Error("denied"));
+    h.render(<Probe text="nope" />);
+    await clickCopy();
+    expect(probeButton().textContent).toBe("failed");
+  });
+
+  it("restarts the full feedback window on a rapid second copy", async () => {
+    vi.useFakeTimers();
+    try {
+      writeText.mockResolvedValue(undefined);
+      h.render(<Probe text="again" />);
+      await clickCopy();
+      // 1.4s in: still within the first window; copy again.
+      await act(async () => {
+        vi.advanceTimersByTime(1_400);
+      });
+      await clickCopy();
+      // 0.2s after the second copy the first timer's deadline has passed —
+      // clear-before-set means the status must still be "copied".
+      await act(async () => {
+        vi.advanceTimersByTime(200);
+      });
+      expect(probeButton().textContent).toBe("copied");
+      await act(async () => {
+        vi.advanceTimersByTime(1_300);
+      });
+      expect(probeButton().textContent).toBe("idle");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/packages/web/src/lib/use-copy-feedback.ts
+++ b/packages/web/src/lib/use-copy-feedback.ts
@@ -1,0 +1,67 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * Default duration of the transient "Copied" / "Copy failed" feedback window.
+ * Sites that need a different window pass `feedbackMs` instead of redefining
+ * their own constant.
+ */
+export const COPY_FEEDBACK_MS = 1_500;
+
+export type CopyFeedbackStatus = "idle" | "copied" | "failed";
+
+/**
+ * Copy-to-clipboard with transient button feedback — the single source of
+ * truth for the copy → "Copied" pattern that used to be hand-rolled per
+ * call site (issue 999).
+ *
+ * Contract (modeled on the most robust of the previous copies):
+ *  - `copy(text)` writes to the clipboard and flips `status` to `"copied"`,
+ *    or to `"failed"` when `navigator.clipboard.writeText` rejects (non-secure
+ *    context, or the user denied the clipboard permission) — callers decide
+ *    whether to surface the failed state or treat it as idle.
+ *  - One reset timer, clear-before-set: a rapid second copy restarts the full
+ *    feedback window instead of being cut short by the first timer.
+ *  - The timer is cleared on unmount, so no state update fires after the
+ *    owning component is gone.
+ */
+export function useCopyFeedback(options?: { feedbackMs?: number }): {
+  status: CopyFeedbackStatus;
+  copy: (text: string) => Promise<void>;
+  /** Snap back to idle immediately (e.g. when a host dialog reopens). */
+  reset: () => void;
+} {
+  const feedbackMs = options?.feedbackMs ?? COPY_FEEDBACK_MS;
+  const [status, setStatus] = useState<CopyFeedbackStatus>("idle");
+  const resetTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (resetTimer.current) clearTimeout(resetTimer.current);
+    },
+    [],
+  );
+
+  const copy = useCallback(
+    async (text: string): Promise<void> => {
+      let next: CopyFeedbackStatus;
+      try {
+        await navigator.clipboard.writeText(text);
+        next = "copied";
+      } catch {
+        next = "failed";
+      }
+      setStatus(next);
+      if (resetTimer.current) clearTimeout(resetTimer.current);
+      resetTimer.current = setTimeout(() => setStatus("idle"), feedbackMs);
+    },
+    [feedbackMs],
+  );
+
+  const reset = useCallback((): void => {
+    if (resetTimer.current) clearTimeout(resetTimer.current);
+    resetTimer.current = null;
+    setStatus("idle");
+  }, []);
+
+  return { status, copy, reset };
+}

--- a/packages/web/src/pages/clients/cards/shared/inline-command.tsx
+++ b/packages/web/src/pages/clients/cards/shared/inline-command.tsx
@@ -1,8 +1,7 @@
 import { Check, Copy } from "lucide-react";
-import { useId, useState } from "react";
+import { useId } from "react";
 import { Button } from "../../../../components/ui/button.js";
-
-const COPY_FEEDBACK_MS = 1_500;
+import { useCopyFeedback } from "../../../../lib/use-copy-feedback.js";
 
 type InlineCommandProps = {
   command: string;
@@ -36,29 +35,13 @@ type InlineCommandProps = {
  * the command text for screen readers.
  */
 export function InlineCommand({ command, caption, ariaLabel = "Command" }: InlineCommandProps) {
-  const [copied, setCopied] = useState(false);
-  const [copyError, setCopyError] = useState(false);
+  // Shared copy → transient-feedback machine. A clipboard failure (non-secure
+  // context / denied permission) surfaces as a transient "Copy failed" — the
+  // command text is still visible above for manual select-copy.
+  const { status, copy } = useCopyFeedback();
   const reactId = useId();
   const preId = `${reactId}-cmd`;
   const captionId = `${reactId}-cap`;
-
-  const handleCopy = async (): Promise<void> => {
-    try {
-      await navigator.clipboard.writeText(command);
-      setCopyError(false);
-      setCopied(true);
-      setTimeout(() => setCopied(false), COPY_FEEDBACK_MS);
-    } catch {
-      // `navigator.clipboard.writeText` rejects in non-secure contexts
-      // and when the user denies the clipboard permission. Silent failure
-      // would leave the operator wondering why nothing landed, so flip
-      // the button to a transient "Copy failed" state. The command text
-      // is still visible above for manual select-copy.
-      setCopied(false);
-      setCopyError(true);
-      setTimeout(() => setCopyError(false), COPY_FEEDBACK_MS);
-    }
-  };
 
   return (
     <figure className="flex flex-col" style={{ margin: 0, gap: "var(--sp-2)" }} aria-labelledby={captionId}>
@@ -88,12 +71,12 @@ export function InlineCommand({ command, caption, ariaLabel = "Command" }: Inlin
           type="button"
           variant="outline"
           size="sm"
-          onClick={handleCopy}
+          onClick={() => void copy(command)}
           aria-describedby={preId}
           style={{ alignSelf: "flex-start" }}
         >
-          {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
-          {copyError ? "Copy failed" : copied ? "Copied" : "Copy"}
+          {status === "copied" ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+          {status === "failed" ? "Copy failed" : status === "copied" ? "Copied" : "Copy"}
         </Button>
         {caption && (
           <span className="text-label" style={{ color: "var(--fg-4)" }}>

--- a/packages/web/src/pages/invite-link-panel.tsx
+++ b/packages/web/src/pages/invite-link-panel.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { api, withOrgAt } from "../api/client.js";
 import { useAuth } from "../auth/auth-context.js";
 import { Button } from "../components/ui/button.js";
+import { useCopyFeedback } from "../lib/use-copy-feedback.js";
 
 /** Render the expiry timestamp as "in N days · 2026/5/6" — both relative
  *  and absolute, so the admin doesn't have to do arithmetic. */
@@ -33,7 +34,8 @@ export function InviteLinkPanel() {
   const [invite, setInvite] = useState<InvitationView | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
-  const [copied, setCopied] = useState(false);
+  const { status: copyStatus, copy } = useCopyFeedback();
+  const copied = copyStatus === "copied";
 
   useEffect(() => {
     if (!organizationId) return;
@@ -86,15 +88,7 @@ export function InviteLinkPanel() {
               className="flex-1 rounded-[var(--radius-panel)] border bg-muted px-2 py-1 text-label font-mono"
               value={invite.inviteUrl}
             />
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={() => {
-                void navigator.clipboard.writeText(invite.inviteUrl);
-                setCopied(true);
-                setTimeout(() => setCopied(false), 1500);
-              }}
-            >
+            <Button size="sm" variant="outline" onClick={() => void copy(invite.inviteUrl)}>
               {copied ? "Copied!" : "Copy"}
             </Button>
             {isAdmin && (

--- a/packages/web/src/pages/onboarding/flow-ui.tsx
+++ b/packages/web/src/pages/onboarding/flow-ui.tsx
@@ -1,8 +1,8 @@
 import { Check, CircleAlert, Copy, ExternalLink, Info, Lock } from "lucide-react";
 import type { ReactNode } from "react";
-import { useState } from "react";
 import type { GithubRepo } from "../../api/github.js";
 import { Button } from "../../components/ui/button.js";
+import { useCopyFeedback } from "../../lib/use-copy-feedback.js";
 import { cn } from "../../lib/utils.js";
 
 /**
@@ -206,14 +206,14 @@ export function CommandBox({
   /** Shown when `command` is null (e.g. "Generating command…" or "…"). */
   placeholder?: string;
 }) {
-  const [copied, setCopied] = useState(false);
+  // Shared copy → transient-feedback machine (success label only here).
+  const { status: copyStatus, copy } = useCopyFeedback();
+  const copied = copyStatus === "copied";
   const lines = command ? command.split("\n").filter((l) => l.trim().length > 0) : [];
 
-  const handleCopy = async (): Promise<void> => {
+  const handleCopy = (): void => {
     if (!command) return;
-    await navigator.clipboard.writeText(command);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 1500);
+    void copy(command);
   };
 
   return (

--- a/packages/web/src/test-utils/dom-harness.tsx
+++ b/packages/web/src/test-utils/dom-harness.tsx
@@ -1,0 +1,96 @@
+import { act, type ReactElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+/**
+ * Shared DOM test harness for happy-dom component tests (issue 1000).
+ *
+ * Several DOM test files used to hand-roll the same ~25 lines: a `createRoot`
+ * render-into-act helper, a double-microtask `flush`, and a retrying
+ * `waitFor`. When React batching / act timing changes, every private copy has
+ * to be updated — this module is the single shared copy.
+ *
+ * Usage:
+ *   let h: DomHarness;
+ *   beforeEach(() => { h = createDomHarness(); });
+ *   afterEach(() => h.cleanup());
+ *   ...
+ *   h.render(<MemoryRouter>{ui}</MemoryRouter>);  // caller owns providers
+ *   await h.waitFor(() => expect(...));
+ *
+ * The harness deliberately does NOT bake in providers (router, react-query):
+ * each test composes its own wrapper, since provider needs differ per suite.
+ */
+
+declare global {
+  // eslint-style global used by React to silence act() warnings in tests.
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+export type DomHarness = {
+  /** Render (or re-render) the element into this harness's container. */
+  render: (ui: ReactElement) => void;
+  /** Flush pending microtasks twice inside act() — settles most effects. */
+  flush: () => Promise<void>;
+  /** Retry `assertion` across up to 25 flushes until it stops throwing. */
+  waitFor: (assertion: () => void) => Promise<void>;
+  /** The detached container element the harness rendered into. */
+  container: HTMLElement;
+  /** Unmount the root, remove the container, and clear document.body. */
+  cleanup: () => void;
+};
+
+/**
+ * Create a fresh harness (one per test via `beforeEach`). Also normalizes the
+ * happy-dom viewport to a desktop-ish size so positioning code (portals,
+ * popovers) sees sane dimensions; override per-test with `setViewportSize`.
+ */
+export function createDomHarness(): DomHarness {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root: Root = createRoot(container);
+  setViewportSize(1400, 900);
+
+  const render = (ui: ReactElement): void => {
+    act(() => {
+      root.render(ui);
+    });
+  };
+
+  const flush = (): Promise<void> =>
+    act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+  const waitFor = async (assertion: () => void): Promise<void> => {
+    let lastErr: unknown;
+    for (let i = 0; i < 25; i++) {
+      try {
+        assertion();
+        return;
+      } catch (err) {
+        lastErr = err;
+      }
+      await flush();
+    }
+    throw lastErr;
+  };
+
+  const cleanup = (): void => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    document.body.innerHTML = "";
+  };
+
+  return { render, flush, waitFor, container, cleanup };
+}
+
+/** Set the happy-dom window dimensions (configurable, test-only). */
+export function setViewportSize(width: number, height: number): void {
+  Object.defineProperty(window, "innerWidth", { configurable: true, value: width });
+  Object.defineProperty(window, "innerHeight", { configurable: true, value: height });
+}


### PR DESCRIPTION
Closes #998, closes #999, closes #1000 — the three primitive-level follow-ups from the #991 review, batched into one refactor PR per gandy2025's request. **No behavior change intended.**

## #998 — HoverCard owns the default card chrome

The primitive now applies the shared popover surface (`--bg-raised` background, hairline `--border`, `--radius-panel`, `--shadow-md`, `--sp-3` padding) by default; `contentStyle` still overrides any of it. `AgentHovercard` and `ChatDescriptionInfo` drop their identical 7-property inline copies and keep only their widths. The next consumer (@mention chips) gets the chrome for free.

## #999 — `useCopyFeedback` hook

`lib/use-copy-feedback.ts` is the single copy → transient-feedback machine, modeled on the most robust prior copy (#991's): status enum (`idle | copied | failed`), one clear-before-set timer (a rapid second copy restarts the full window), unmount cleanup, `failed` on clipboard rejection, optional `feedbackMs`, and `reset()` for reopening dialogs.

The survey found **seven** hand-rolled call sites, not the four the issue estimated — all migrated: `chat-description-info`, `inline-command`, `connect-command-panel`, `last-step-modal` (keeps its historical 2s window via `feedbackMs`), `invite-link-panel`, onboarding `flow-ui` CommandBox, and `new-agent-dialog`. Sites that only surfaced the success label still do; the previously-unhandled rejection paths now settle quietly to `failed` instead of leaving an unhandled promise rejection.

## #1000 — shared DOM test harness

`test-utils/dom-harness.tsx` extracts the duplicated createRoot / double-microtask `flush` / retrying `waitFor` helpers (providers stay with each suite — needs differ). The two hover-card suites migrate now; the other ~8 DOM test files with private copies can adopt incrementally.

## Verification

- web suite **776/776** (includes 3 new `useCopyFeedback` tests: success flip, rejection → failed, rapid-second-copy restarts the window), `tsc` clean, `lint:tokens` clean, `biome check` exit 0
- Verified on `/preview/chat-description` that the card's computed chrome (width/background/border/radius/padding/shadow) is byte-identical to the #991-approved look now that it comes from the primitive
- Amusing trap for posterity: `lint:tokens`' hex-color regex flags `#998`-style issue references in comments — they're written as `issue 998` in code comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)