### PR TITLE
fix(server): allowlist /build-tree as a post-install next

### DIFF
--- a/packages/server/src/api/orgs/__tests__/post-install-next.test.ts
+++ b/packages/server/src/api/orgs/__tests__/post-install-next.test.ts
@@ -11,6 +11,10 @@ describe("resolvePostInstallNext", () => {
     expect(resolvePostInstallNext("/onboarding")).toBe("/onboarding");
     expect(resolvePostInstallNext("/onboarding/connected")).toBe("/onboarding/connected");
     expect(resolvePostInstallNext("/settings/github")).toBe("/settings/github");
+    // The build-tree recovery surface passes itself as `next` when the install
+    // popup is blocked — rewriting it to Settings would strand the recovery
+    // admin outside the flow they were in.
+    expect(resolvePostInstallNext("/build-tree")).toBe("/build-tree");
   });
 
   it("falls back to Settings for an absent value", () => {
@@ -26,6 +30,11 @@ describe("resolvePostInstallNext", () => {
   });
 
   it("only allows the known internal destinations", () => {
-    expect([...ALLOWED_POST_INSTALL_NEXT].sort()).toEqual(["/onboarding", "/onboarding/connected", "/settings/github"]);
+    expect([...ALLOWED_POST_INSTALL_NEXT].sort()).toEqual([
+      "/build-tree",
+      "/onboarding",
+      "/onboarding/connected",
+      "/settings/github",
+    ]);
   });
 });

--- a/packages/server/src/api/orgs/github-app.ts
+++ b/packages/server/src/api/orgs/github-app.ts
@@ -47,6 +47,10 @@ export const ALLOWED_POST_INSTALL_NEXT: ReadonlySet<string> = new Set([
   // installs in a popup and lands the popup here so it can auto-close while the
   // original tab keeps polling.
   "/onboarding/connected",
+  // Build-tree recovery surface: its connect-code step passes itself as `next`
+  // when the install popup is blocked (the full-page redirect must return to
+  // the recovery flow, not Settings — see step-connect-code.tsx).
+  "/build-tree",
 ]);
 
 /**


### PR DESCRIPTION
## Problem

The `/build-tree` recovery surface's connect-code step passes `next=/build-tree` when the GitHub App install popup is blocked (it falls back to a full-page redirect and must return to the recovery flow — see `step-connect-code.tsx`):

```ts
const postInstallNext = installTab ? "/onboarding/connected" : recovery ? "/build-tree" : "/onboarding";
```

But `ALLOWED_POST_INSTALL_NEXT` never included `/build-tree`, so `resolvePostInstallNext` silently rewrote the destination to `/settings/github`. A recovery admin whose popup was blocked completed the install and landed on Settings, outside the flow they were in.

## Fix

Add `/build-tree` to the allowlist (an internal SPA path, same trust class as `/onboarding`), and pin it in `post-install-next.test.ts` alongside the exact-allowlist assertion.

## Context

Found while working on the install-callback dead-end UX; the rest of that work was superseded by #988 (which lands the bind on the kickoff session and routes all browser-facing callback errors to `/auth/github/complete#error=<code>`). This allowlist gap is the one piece #988 didn't cover.

## Test plan

- `pnpm --filter @first-tree/server exec vitest run src/api/orgs/__tests__/post-install-next.test.ts src/__tests__/github-app-install-url.test.ts src/__tests__/github-app-callback-target-org.test.ts` — 18/18 green
- `pnpm check` + `pnpm --filter @first-tree/server typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)