### PR TITLE
fix(client): delay startup session reconcile

### DIFF
--- a/packages/client/src/__tests__/agent-slot.test.ts
+++ b/packages/client/src/__tests__/agent-slot.test.ts
@@ -123,7 +123,7 @@ function makeFrame(overrides: Record<string, unknown> = {}) {
   };
 }
 
-function installMocks(options: { syncResult?: MockState["syncResult"] } = {}): MockState {
+function installMocks(options: { syncResult?: MockState["syncResult"]; syncDelayMs?: number } = {}): MockState {
   vi.resetModules();
   const state: MockState = {
     logger: makeLogger(),
@@ -148,6 +148,9 @@ function installMocks(options: { syncResult?: MockState["syncResult"] } = {}): M
       log("sync log");
       messages.push("sync log");
       state.syncCalls.push({ sdk, messages });
+      if (options.syncDelayMs && options.syncDelayMs > 0) {
+        await new Promise((resolve) => setTimeout(resolve, options.syncDelayMs));
+      }
       return state.syncResult;
     }),
   }));
@@ -223,6 +226,7 @@ async function makeSlot(options?: {
   configError?: unknown;
   runtimeType?: string;
   syncResult?: MockState["syncResult"];
+  syncDelayMs?: number;
   omitReconcileInterval?: boolean;
 }): Promise<{
   slot: import("../runtime/agent-slot.js").AgentSlot;
@@ -230,7 +234,7 @@ async function makeSlot(options?: {
   sdk: FirstTreeHubSDK;
   state: MockState;
 }> {
-  const state = installMocks({ syncResult: options?.syncResult });
+  const state = installMocks({ syncResult: options?.syncResult, syncDelayMs: options?.syncDelayMs });
   const sdk = makeSdk({ agent: options?.agent, configError: options?.configError });
   const connection = new FakeClientConnection(sdk);
   const { AgentSlot } = await import("../runtime/agent-slot.js");
@@ -457,6 +461,32 @@ describe("AgentSlot", () => {
 
     connection.emit("inbox:deliver", "inbox-1", makeFrame({ entryId: 99 }));
     expect(session.dispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("starts the bind-time reconcile grace window after startup full state sync", async () => {
+    vi.useFakeTimers();
+    const { slot, connection, sdk } = await makeSlot({ syncDelayMs: 4_900, omitReconcileInterval: true });
+    connection.bindAgent.mockImplementationOnce(async () => {
+      connection.emit("agent:bound", { agentId: "agent-1" });
+      return { sdk };
+    });
+
+    const startPromise = slot.start();
+    await Promise.resolve();
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(4_900);
+    await expect(startPromise).resolves.toMatchObject({ agentId: "agent-1" });
+
+    expect(connection.reportSessionState).toHaveBeenCalledWith("agent-1", "chat-evicted", "suspended");
+    expect(connection.sendSessionReconcile).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(connection.sendSessionReconcile).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(4_900);
+    expect(connection.sendSessionReconcile).toHaveBeenCalledWith("agent-1", ["chat-1", "chat-2"]);
+
+    await slot.stop();
   });
 
   it("stops only the matching slot when the server force-unbounds an agent", async () => {

--- a/packages/client/src/runtime/agent-slot.ts
+++ b/packages/client/src/runtime/agent-slot.ts
@@ -52,6 +52,7 @@ export class AgentSlot {
   private logger: pino.Logger;
   private agentConfigCache: AgentConfigCache | null = null;
   private reconcileTimer: ReturnType<typeof setInterval> | null = null;
+  private postBindReconcileTimer: ReturnType<typeof setTimeout> | null = null;
   private listeners: ConnectionListener[] = [];
   private stopping: Promise<void> | null = null;
   /**
@@ -126,16 +127,19 @@ export class AgentSlot {
         if (typeof this.sessionManager?.noteBindRecoveryComplete === "function") {
           this.sessionManager.noteBindRecoveryComplete();
         }
-        // `fullStateSync` short-circuits when `sessionManager` is null,
-        // so it's safe to fire on the FIRST `agent:bound` (which now
-        // reaches this listener because we attached it pre-bind) — the
-        // explicit `fullStateSync()` after sessionManager construction
-        // covers the initial-startup case, and this listener handles
-        // reconnects.
+        // The first `agent:bound` can arrive while startup is still inside
+        // sdk.register / config load / Context Tree sync, before
+        // SessionManager exists. In that case the explicit startup
+        // fullStateSync below owns both the state report and the delayed
+        // reconcile. Reconnects with an existing SessionManager are handled
+        // here.
+        if (!this.sessionManager) return;
         this.fullStateSync();
         // One-shot post-bind reconcile catches operator-terminates that
-        // landed while this client was offline; a duplicate tick is harmless.
-        setTimeout(() => this.reconcileNow(), 5000);
+        // landed while this client was offline. It is deliberately scheduled
+        // after fullStateSync, so just-hydrated registry mappings are first
+        // advertised as suspended before the server is asked for stale rows.
+        this.schedulePostBindReconcile();
       }
     };
     const onReconcileResult = (result: SessionReconcileResult) => {
@@ -285,6 +289,7 @@ export class AgentSlot {
       // `fullStateSync()` call was a no-op. Run it explicitly now that
       // the manager exists.
       this.fullStateSync();
+      this.schedulePostBindReconcile();
 
       this.startReconcileLoop();
 
@@ -310,6 +315,10 @@ export class AgentSlot {
       clearInterval(this.reconcileTimer);
       this.reconcileTimer = null;
     }
+    if (this.postBindReconcileTimer) {
+      clearTimeout(this.postBindReconcileTimer);
+      this.postBindReconcileTimer = null;
+    }
     for (const entry of this.listeners) {
       this.clientConnection.off(entry.event, entry.fn);
     }
@@ -326,6 +335,10 @@ export class AgentSlot {
     if (this.reconcileTimer) {
       clearInterval(this.reconcileTimer);
       this.reconcileTimer = null;
+    }
+    if (this.postBindReconcileTimer) {
+      clearTimeout(this.postBindReconcileTimer);
+      this.postBindReconcileTimer = null;
     }
     for (const entry of this.listeners) {
       this.clientConnection.off(entry.event, entry.fn);
@@ -438,6 +451,14 @@ export class AgentSlot {
   private startReconcileLoop(): void {
     const intervalSec = this.config.session.reconcile_interval_seconds ?? 300;
     this.reconcileTimer = setInterval(() => this.reconcileNow(), intervalSec * 1000);
+  }
+
+  private schedulePostBindReconcile(): void {
+    if (this.postBindReconcileTimer) clearTimeout(this.postBindReconcileTimer);
+    this.postBindReconcileTimer = setTimeout(() => {
+      this.postBindReconcileTimer = null;
+      this.reconcileNow();
+    }, 5000);
   }
 
   private reconcileNow(): void {


### PR DESCRIPTION
## Summary
- delay the post-bind session reconcile timer until after startup `fullStateSync()` has advertised restored registry mappings as `suspended`
- keep reconnect behavior intact by running full-state sync and scheduling the reconcile when a live `SessionManager` already exists
- track and clear the post-bind reconcile timeout during normal stop and failed-start cleanup
- add a regression test for the near-5s Context Tree sync startup window that could previously trigger stale reconcile before restored sessions settled server-side

Fixes #919.

## Verification
- `pnpm --filter @first-tree/client exec vitest run --maxWorkers=2 --minWorkers=1 src/__tests__/agent-slot.test.ts src/__tests__/session-state-notifications.test.ts src/__tests__/session-manager-edge-coverage.test.ts`
- `pnpm --filter @first-tree/client typecheck`
- `pnpm check` (passes; existing Biome warning/info remain in `packages/web/src/pages/agent-detail/prompt-tab.tsx` and `packages/client/src/runtime/workspace-migrations.ts`)
- `pnpm typecheck`