### PR TITLE
feat(web): rework jump-to palette rows, recents, and search quality

### DIFF
--- a/packages/web/src/components/ui/command.tsx
+++ b/packages/web/src/components/ui/command.tsx
@@ -106,4 +106,24 @@ const CommandItem = forwardRef<HTMLDivElement, ComponentPropsWithoutRef<typeof C
 );
 CommandItem.displayName = CommandPrimitive.Item.displayName;
 
-export { Command, CommandDialog, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList, CommandSeparator };
+/**
+ * Async-source pending state. cmdk renders this only while
+ * `<Command.Loading>` is mounted AND keeps it outside filtering, so it
+ * never competes with real items for selection.
+ */
+const CommandLoading = forwardRef<HTMLDivElement, ComponentPropsWithoutRef<typeof CommandPrimitive.Loading>>(
+  ({ className, ...props }, ref) => <CommandPrimitive.Loading ref={ref} className={cn("py-2", className)} {...props} />,
+);
+CommandLoading.displayName = CommandPrimitive.Loading.displayName;
+
+export {
+  Command,
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandLoading,
+  CommandSeparator,
+};

--- a/packages/web/src/lib/utils.ts
+++ b/packages/web/src/lib/utils.ts
@@ -129,3 +129,31 @@ export function formatRelative(iso: string | null | undefined): string {
   }
   return RELATIVE_FORMATTER.format(Math.round(diffMs / unitMs), unit);
 }
+
+/**
+ * Ultra-compact row timestamp for dense chat lists ("now", "5m", "3h",
+ * then "MM/DD"). Shared by the conversation rail and the jump-to
+ * palette so a chat reads the same age in both surfaces. Returns ""
+ * for null/invalid input — these rows simply omit the time slot rather
+ * than render a placeholder dash.
+ *
+ * ≥ 24h renders `MM/DD` only. Hour:minute is dropped — once a chat
+ * slips out of "today", knowing the exact minute is rarely useful and
+ * the extra " HH:mm" squeezes the title column for every older row.
+ */
+export function formatRowTime(iso: string | null | undefined): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  const t = d.getTime();
+  if (Number.isNaN(t)) return "";
+  const ageMs = Date.now() - t;
+  if (ageMs < MINUTE_MS) return "now";
+  if (ageMs < HOUR_MS) return `${Math.round(ageMs / MINUTE_MS)}m`;
+  if (ageMs < DAY_MS) return `${Math.round(ageMs / HOUR_MS)}h`;
+  const parts = new Intl.DateTimeFormat("en-GB", {
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(d);
+  const get = (type: Intl.DateTimeFormatPartTypes) => parts.find((p) => p.type === type)?.value ?? "";
+  return `${get("month")}/${get("day")}`;
+}

--- a/packages/web/src/pages/workspace/conversations/index.tsx
+++ b/packages/web/src/pages/workspace/conversations/index.tsx
@@ -9,7 +9,7 @@ import { ChatRowAvatar } from "../../../components/chat/chat-row-avatar.js";
 import { Button } from "../../../components/ui/button.js";
 import { Popover } from "../../../components/ui/popover.js";
 import { useAgentNameMap } from "../../../lib/use-agent-name-map.js";
-import { cn } from "../../../lib/utils.js";
+import { cn, formatRowTime } from "../../../lib/utils.js";
 import { FilterPopover, GROUP_OPTIONS, originLabel } from "./filter-popover.js";
 import { type GroupMode, groupRows, rowIsFailed, splitAttentionRows } from "./group-rows.js";
 import { RowEngagementMenu } from "./row-engagement-menu.js";
@@ -43,31 +43,6 @@ export const DRAFT_CHAT_ID = "draft" as const;
  * atomic URL write — see `nextParamsForRailFilter` in `workspace/index.tsx`).
  */
 export type RailFilter = "all" | "unread" | "watching";
-
-function formatRowTime(iso: string | null): string {
-  if (!iso) return "";
-  const d = new Date(iso);
-  const now = Date.now();
-  const ageMs = now - d.getTime();
-  if (ageMs < 60_000) return "now";
-  if (ageMs < 60 * 60_000) {
-    const m = Math.round(ageMs / 60_000);
-    return `${m}m`;
-  }
-  if (ageMs < 24 * 60 * 60_000) {
-    const h = Math.round(ageMs / (60 * 60_000));
-    return `${h}h`;
-  }
-  // ≥ 24h: render `MM/DD` only. Hour:minute is dropped — once a chat
-  // slips out of "today", knowing the exact minute is rarely useful and
-  // the extra " HH:mm" squeezes the title column for every older row.
-  const parts = new Intl.DateTimeFormat("en-GB", {
-    month: "2-digit",
-    day: "2-digit",
-  }).formatToParts(d);
-  const get = (type: Intl.DateTimeFormatPartTypes) => parts.find((p) => p.type === type)?.value ?? "";
-  return `${get("month")}/${get("day")}`;
-}
 
 export function ConversationList({
   selectedChatId,

--- a/packages/web/src/pages/workspace/palette/__tests__/command-palette-dom.test.tsx
+++ b/packages/web/src/pages/workspace/palette/__tests__/command-palette-dom.test.tsx
@@ -23,6 +23,10 @@ const orgAgentsMock = vi.hoisted(() => ({
 
 vi.mock("../../../../api/me-chats.js", () => meChatMocks);
 
+vi.mock("../../../../auth/auth-context.js", () => ({
+  useAuth: () => ({ agentId: "human-agent-self" }),
+}));
+
 vi.mock("../../../../lib/use-agent-name-map.js", () => ({
   useAgentNameMap: () => (id: string | null | undefined) => (id === "agent-1" ? "Nova" : (id ?? "unknown")),
 }));
@@ -93,7 +97,9 @@ function chatRow(overrides: Partial<MeChatRow> = {}): MeChatRow {
     description: overrides.description ?? null,
     participants: overrides.participants ?? participants,
     participantCount: overrides.participantCount ?? participants.length,
-    lastMessageAt: overrides.lastMessageAt ?? NOW,
+    // `??` would swallow an explicit `null` (a never-messaged chat) — use
+    // an `in` check so tests can express that state.
+    lastMessageAt: "lastMessageAt" in overrides ? (overrides.lastMessageAt ?? null) : NOW,
     lastMessagePreview: overrides.lastMessagePreview ?? "Ship it.",
     unreadMentionCount: overrides.unreadMentionCount ?? 0,
     openRequestCount: overrides.openRequestCount ?? 0,
@@ -187,12 +193,17 @@ describe("CommandPalette", () => {
 
     await waitForText(document.body, "Launch planning");
     await waitForText(document.body, "(untitled)");
-    await waitForText(document.body, "Release train");
     await waitForText(document.body, "Nova");
     await waitForText(document.body, "No Handle");
     await waitForText(document.body, "Workspace");
 
     expect(meChatMocks.listMeChats).toHaveBeenCalledWith({ limit: 100, engagement: "all" });
+
+    // Row noise is gone: the topic is no longer repeated next to the
+    // title (title already derives from it), and the chat-id hash is
+    // searchable but never rendered.
+    expect(document.body.textContent).not.toContain("Release train");
+    expect(document.body.textContent).not.toContain("chat-123");
 
     await click(commandItemByText(document.body, "Launch planning"));
     expect(onOpenChange).toHaveBeenLastCalledWith(false);
@@ -203,6 +214,96 @@ describe("CommandPalette", () => {
 
     await click(commandItemByText(document.body, "Settings"));
     expect(routerMocks.navigate).toHaveBeenLastCalledWith("/settings");
+
+    await act(async () => root.unmount());
+  });
+
+  it("shows a recency-sorted, capped Recent view while the query is empty", async () => {
+    const rows = [
+      chatRow({ chatId: "chat-old", title: "Oldest", lastMessageAt: "2026-05-01T00:00:00.000Z" }),
+      chatRow({ chatId: "chat-new", title: "Newest", lastMessageAt: "2026-05-28T00:00:00.000Z" }),
+      chatRow({ chatId: "chat-mid", title: "Middle", lastMessageAt: "2026-05-14T00:00:00.000Z" }),
+      chatRow({ chatId: "chat-never", title: "Never messaged", lastMessageAt: null }),
+      // Filler so the total (16) exceeds the 12-row empty-query cap.
+      ...Array.from({ length: 12 }, (_, i) =>
+        chatRow({ chatId: `chat-filler-${i}`, title: `Filler ${i}`, lastMessageAt: "2026-05-20T00:00:00.000Z" }),
+      ),
+    ];
+    meChatMocks.listMeChats.mockResolvedValue({ rows, nextCursor: null });
+
+    const { CommandPalette } = await import("../command-palette.js");
+    const { root } = await renderDom(<CommandPalette open onOpenChange={vi.fn()} />);
+    await waitForText(document.body, "Newest");
+
+    expect(document.body.textContent).toContain("Recent");
+
+    const chatItems = [...document.body.querySelectorAll<HTMLElement>("[cmdk-item]")].filter((el) =>
+      el.getAttribute("data-value")?.includes("chat-"),
+    );
+    expect(chatItems).toHaveLength(12);
+    // Most recent first; null lastMessageAt sinks past the cap entirely.
+    expect(chatItems[0]?.textContent).toContain("Newest");
+    expect(chatItems[1]?.textContent).toContain("Filler");
+    expect(document.body.textContent).not.toContain("Never messaged");
+    expect(document.body.textContent).not.toContain("Oldest");
+
+    await act(async () => root.unmount());
+  });
+
+  it("marks archived chats and renders the compact age in the time slot", async () => {
+    meChatMocks.listMeChats.mockResolvedValue({
+      rows: [
+        chatRow({
+          chatId: "chat-archived",
+          title: "Old initiative",
+          engagementStatus: "archived",
+          lastMessageAt: "2026-01-05T00:00:00.000Z",
+        }),
+      ],
+      nextCursor: null,
+    });
+
+    const { CommandPalette } = await import("../command-palette.js");
+    const { root } = await renderDom(<CommandPalette open onOpenChange={vi.fn()} />);
+    await waitForText(document.body, "Old initiative");
+
+    const item = commandItemByText(document.body, "Old initiative");
+    expect(item?.textContent).toContain("Archived");
+    expect(item?.textContent).toContain("01/05");
+
+    await act(async () => root.unmount());
+  });
+
+  it("searches topic, description, and participant names via keywords and lifts the Recent cap", async () => {
+    meChatMocks.listMeChats.mockResolvedValue({
+      rows: [
+        chatRow({ chatId: "chat-a", title: "Launch planning", description: "reviewing PR #42", topic: null }),
+        chatRow({ chatId: "chat-b", title: "Random other", description: null, topic: null }),
+      ],
+      nextCursor: null,
+    });
+
+    const { CommandPalette } = await import("../command-palette.js");
+    const { root } = await renderDom(<CommandPalette open onOpenChange={vi.fn()} />);
+    await waitForText(document.body, "Launch planning");
+
+    const input = document.body.querySelector<HTMLInputElement>("[cmdk-input]");
+    if (!input) throw new Error("Expected cmdk input");
+    await act(async () => {
+      // Native prototype setter so React's value tracker sees the change
+      // (assigning `input.value` directly is swallowed as a duplicate).
+      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+      setter?.call(input, "reviewing");
+      input.dispatchEvent(new InputEvent("input", { bubbles: true, inputType: "insertText", data: "reviewing" }));
+    });
+    await flush();
+
+    // Searching switches the group heading from Recent to Chats and
+    // matches on the description keyword.
+    expect(document.body.textContent).toContain("Chats");
+    expect(document.body.textContent).not.toContain("Recent");
+    expect(commandItemByText(document.body, "Launch planning")).not.toBeNull();
+    expect(commandItemByText(document.body, "Random other")).toBeNull();
 
     await act(async () => root.unmount());
   });

--- a/packages/web/src/pages/workspace/palette/command-palette.tsx
+++ b/packages/web/src/pages/workspace/palette/command-palette.tsx
@@ -1,7 +1,12 @@
+import type { MeChatRow } from "@first-tree/shared";
 import { useQuery } from "@tanstack/react-query";
-import { Bot, LayoutDashboard, MessageSquare } from "lucide-react";
+import { LayoutDashboard } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router";
 import { listMeChats } from "../../../api/me-chats.js";
+import { useAuth } from "../../../auth/auth-context.js";
+import { Avatar } from "../../../components/avatar.js";
+import { ChatRowAvatar } from "../../../components/chat/chat-row-avatar.js";
 import {
   CommandDialog,
   CommandEmpty,
@@ -9,9 +14,11 @@ import {
   CommandInput,
   CommandItem,
   CommandList,
+  CommandLoading,
   CommandSeparator,
 } from "../../../components/ui/command.js";
 import { useOrgAgents } from "../../../lib/use-org-agents.js";
+import { formatRowTime } from "../../../lib/utils.js";
 
 const STATIC_ROUTES = [
   { path: "/", label: "Workspace" },
@@ -19,6 +26,19 @@ const STATIC_ROUTES = [
   { path: "/team", label: "Team" },
   { path: "/settings", label: "Settings" },
 ];
+
+/**
+ * Empty-query chat count. With no query the palette is a "go back to
+ * what I was just doing" surface (Slack/Linear-style recents), not a
+ * browser — a screenful of the most recently active chats beats 100
+ * rows in API order. Typing anything lifts the cap and searches the
+ * full fetched window.
+ */
+const RECENT_CHAT_LIMIT = 12;
+
+/** Avatar disc diameter inside palette rows — compact, denser than the
+ *  conversation rail's default disc. */
+const ROW_AVATAR_SIZE = 24;
 
 /**
  * Topbar "Jump to…" palette.
@@ -31,16 +51,29 @@ const STATIC_ROUTES = [
  *   - Agents: `useOrgAgents` (`/agents?limit=100`), the same cache used by
  *     the participant picker and identity maps.
  *
- * Filtering is handled by `cmdk` — each item's `value` is a space-joined
- * string of every searchable token, and cmdk fuzzy-matches against it.
+ * Filtering is handled by `cmdk`. Each item splits its searchable text
+ * between `value` (primary identity: visible title + a uniquifying id —
+ * two chats may share a title) and `keywords` (secondary tokens: topic,
+ * description, participant names). cmdk's scorer weights `value` matches
+ * above `keywords` matches, so a title hit ranks ahead of a
+ * participant-name hit without any custom filter.
  */
 export function CommandPalette({ open, onOpenChange }: { open: boolean; onOpenChange: (open: boolean) => void }) {
   const navigate = useNavigate();
+  const { agentId: selfAgentId } = useAuth();
+
+  // Controlled query so the empty-query "Recent" view and the searching
+  // view can differ. Cleared on close — reopening the palette is always
+  // a new jump, not a continuation of the last search.
+  const [search, setSearch] = useState("");
+  useEffect(() => {
+    if (!open) setSearch("");
+  }, [open]);
 
   const { data: orgAgents } = useOrgAgents();
   const agents = orgAgents?.items ?? [];
 
-  const { data: chatsResp } = useQuery({
+  const { data: chatsResp, isLoading: chatsLoading } = useQuery({
     // Prefix-aligned with conversations-page invalidations
     // (`["me", "chats"]` is the family every chat mutation invalidates —
     // new-chat-draft, row-engagement-menu, etc.) so creating / archiving
@@ -55,7 +88,22 @@ export function CommandPalette({ open, onOpenChange }: { open: boolean; onOpenCh
     enabled: open,
     staleTime: 30_000,
   });
-  const chats = chatsResp?.rows ?? [];
+
+  // Most-recently-active first, regardless of the API's order — recency
+  // is the palette's organizing principle (jump back to live work).
+  // Never-messaged chats (null lastMessageAt) sink to the end.
+  const chats = useMemo(() => {
+    const rows = chatsResp?.rows ?? [];
+    return [...rows].sort((a, b) => {
+      if (a.lastMessageAt === b.lastMessageAt) return 0;
+      if (a.lastMessageAt === null) return 1;
+      if (b.lastMessageAt === null) return -1;
+      return a.lastMessageAt < b.lastMessageAt ? 1 : -1;
+    });
+  }, [chatsResp]);
+
+  const browsing = search.trim().length === 0;
+  const visibleChats = browsing ? chats.slice(0, RECENT_CHAT_LIMIT) : chats;
 
   const go = (url: string) => {
     onOpenChange(false);
@@ -64,32 +112,28 @@ export function CommandPalette({ open, onOpenChange }: { open: boolean; onOpenCh
 
   return (
     <CommandDialog open={open} onOpenChange={onOpenChange}>
-      <CommandInput placeholder="Jump to chat or agent…" />
+      <CommandInput placeholder="Jump to chat or agent…" value={search} onValueChange={setSearch} />
       <CommandList>
         <CommandEmpty>No results</CommandEmpty>
 
-        {chats.length > 0 && (
-          <CommandGroup heading="Chats">
-            {chats.map((c) => {
-              // Participant names give cmdk extra search tokens — typing a
-              // teammate's name surfaces the 1:1 chats and group chats that
-              // include them, even when the chat's own title doesn't.
-              const participantNames = c.participants.map((p) => p.displayName).join(" ");
-              return (
-                <CommandItem
-                  key={c.chatId}
-                  value={`chat ${c.title} ${c.topic ?? ""} ${participantNames} ${c.chatId}`}
-                  onSelect={() => go(`/?c=${encodeURIComponent(c.chatId)}`)}
-                >
-                  <MessageSquare className="mr-2 h-4 w-4 shrink-0 opacity-70" />
-                  <span className="flex-1 truncate">{c.title || "(untitled)"}</span>
-                  {c.topic ? (
-                    <span className="text-caption text-muted-foreground ml-2 truncate max-w-[40%]">{c.topic}</span>
-                  ) : null}
-                  <span className="text-caption text-muted-foreground font-mono ml-2">{c.chatId.slice(0, 8)}</span>
-                </CommandItem>
-              );
-            })}
+        {chatsLoading && (
+          <CommandLoading>
+            <div aria-hidden className="space-y-1 px-3 py-1">
+              {[0, 1, 2].map((i) => (
+                <div key={i} className="flex animate-pulse items-center gap-2 py-2">
+                  <div className="h-6 w-6 shrink-0 rounded-full bg-muted" />
+                  <div className="h-3 rounded bg-muted" style={{ width: `${52 - i * 9}%` }} />
+                </div>
+              ))}
+            </div>
+          </CommandLoading>
+        )}
+
+        {visibleChats.length > 0 && (
+          <CommandGroup heading={browsing ? "Recent" : "Chats"}>
+            {visibleChats.map((c) => (
+              <ChatItem key={c.chatId} chat={c} selfAgentId={selfAgentId ?? ""} onGo={go} />
+            ))}
           </CommandGroup>
         )}
 
@@ -100,12 +144,20 @@ export function CommandPalette({ open, onOpenChange }: { open: boolean; onOpenCh
               {agents.map((a) => (
                 <CommandItem
                   key={a.uuid}
-                  value={`agent ${a.displayName} ${a.name ?? ""} ${a.uuid}`}
+                  value={`${a.displayName} ${a.uuid}`}
+                  keywords={a.name ? [a.name] : undefined}
                   onSelect={() => go(`/agents/${encodeURIComponent(a.uuid)}/profile`)}
                 >
-                  <Bot className="mr-2 h-4 w-4 shrink-0 opacity-70" />
+                  <Avatar
+                    name={a.displayName}
+                    src={a.avatarImageUrl}
+                    colorToken={a.avatarColorToken}
+                    seed={a.uuid}
+                    size={ROW_AVATAR_SIZE}
+                    className="mr-2 shrink-0 [&>span]:text-caption"
+                  />
                   <span className="flex-1 truncate">{a.displayName}</span>
-                  {a.name ? <span className="text-caption text-muted-foreground ml-2">@{a.name}</span> : null}
+                  {a.name ? <span className="text-caption text-muted-foreground ml-2 shrink-0">@{a.name}</span> : null}
                 </CommandItem>
               ))}
             </CommandGroup>
@@ -115,13 +167,75 @@ export function CommandPalette({ open, onOpenChange }: { open: boolean; onOpenCh
         <CommandSeparator />
         <CommandGroup heading="Pages">
           {STATIC_ROUTES.map((r) => (
-            <CommandItem key={r.path} value={`page ${r.label}`} onSelect={() => go(r.path)}>
+            <CommandItem key={r.path} value={r.label} onSelect={() => go(r.path)}>
               <LayoutDashboard className="mr-2 h-4 w-4 shrink-0 opacity-70" />
               <span>{r.label}</span>
             </CommandItem>
           ))}
         </CommandGroup>
       </CommandList>
+      <div className="text-caption text-muted-foreground flex items-center gap-3 border-t px-3 py-1.5">
+        <KeyHint keys="↑↓" label="navigate" />
+        <KeyHint keys="↵" label="open" />
+        <KeyHint keys="esc" label="close" />
+      </div>
     </CommandDialog>
+  );
+}
+
+/**
+ * One chat row. Identity on the left (the rail's avatar disc + title),
+ * state on the right (Archived chip when applicable, then the rail's
+ * compact age — "now" / "5m" / "3h" / "MM/DD"). The chat id stays
+ * searchable via `value` but is never rendered: it means nothing to a
+ * human eye, and the topic is not repeated either — `title` already
+ * derives from the topic whenever one is set.
+ */
+function ChatItem({ chat, selfAgentId, onGo }: { chat: MeChatRow; selfAgentId: string; onGo: (url: string) => void }) {
+  const title = chat.title || "(untitled)";
+  // Participant names give cmdk extra search tokens — typing a teammate's
+  // name surfaces the 1:1 chats and group chats that include them, even
+  // when the chat's own title doesn't. `description` makes the chat's
+  // running work summary searchable the same way.
+  const keywords = [chat.topic ?? "", chat.description ?? "", ...chat.participants.map((p) => p.displayName)].filter(
+    (k) => k.length > 0,
+  );
+  return (
+    <CommandItem
+      value={`${title} ${chat.chatId}`}
+      keywords={keywords}
+      onSelect={() => onGo(`/?c=${encodeURIComponent(chat.chatId)}`)}
+    >
+      <ChatRowAvatar
+        title={title}
+        type={chat.type}
+        participants={chat.participants}
+        selfAgentId={selfAgentId}
+        unreadCount={0}
+        size={ROW_AVATAR_SIZE}
+        badge={false}
+        muted
+      />
+      <span className="ml-2 flex-1 truncate">{title}</span>
+      {chat.engagementStatus === "archived" && (
+        <span className="text-caption text-muted-foreground ml-2 shrink-0 rounded-[var(--radius-chip)] border px-1.5">
+          Archived
+        </span>
+      )}
+      {chat.lastMessageAt ? (
+        <span className="text-caption text-muted-foreground ml-2 shrink-0 tabular-nums">
+          {formatRowTime(chat.lastMessageAt)}
+        </span>
+      ) : null}
+    </CommandItem>
+  );
+}
+
+function KeyHint({ keys, label }: { keys: string; label: string }) {
+  return (
+    <span className="inline-flex items-center gap-1">
+      <kbd className="text-caption rounded border bg-muted px-1 font-mono leading-4">{keys}</kbd>
+      {label}
+    </span>
   );
 }


### PR DESCRIPTION
## Problem

The ⌘K jump-to palette's chat rows were structurally noisy and the list had no recency semantics:

1. **Same text twice per row** — `title` derives from `topic` whenever one is set, yet the row rendered both, so most rows read "X … X".
2. **Chat-id hash rendered** — the 8-char mono hash means nothing to a human eye.
3. **No useful metadata** — no age, and `engagement: "all"` mixes archived chats in with no way to tell them apart.
4. **Uniform icon** — every row carried the same small MessageSquare, reading like a column of checkboxes.
5. **No recents** — empty query showed 100 rows in API order; the most common jump ("back to what I was just doing") wasn't served.
6. **No loading state** — the list flashed empty then popped in.
7. **Search gaps** — `description` (the chat's running work summary) wasn't searchable, and every item's value began with a literal `chat `/`agent `/`page ` token that polluted fuzzy scoring.

## Changes

**Row structure** — avatar disc (same `ChatRowAvatar` as the conversation rail, muted, 24px) + title, with an `Archived` chip and the rail's compact age (`now`/`5m`/`3h`/`MM/DD`) on the right. Topic and chat-id are no longer rendered; the id stays searchable. Agent rows render the real agent avatar (image / color token / hash fallback).

**Recent view** — chats sort most-recently-active first; with an empty query the list caps at 12 under a `Recent` heading. Typing lifts the cap and switches the heading to `Chats`. Query resets on close.

**Search quality** — each item splits searchable text between cmdk `value` (title + uniquifying id) and `keywords` (topic, description, participant names), so title hits outrank secondary-field hits with no custom filter. Literal type-prefix tokens are gone.

**Loading** — skeleton rows via a new `CommandLoading` wrapper (cmdk `Command.Loading`) while the chat fetch is pending.

**Footer** — ↑↓ / ↵ / esc keyboard hints.

**Shared util** — `formatRowTime` moved from the conversations rail into `lib/utils.ts` so both surfaces render the same age format.

## Tests

- Updated palette DOM tests for the new row shape (topic not repeated, hash not rendered).
- New: recency sort + 12-row cap + null `lastMessageAt` sinking; Archived chip + compact age; keyword search over description with cap lift and heading switch.
- `pnpm check` ✓, `pnpm typecheck` (incl. design-token lint) ✓, web suite 103 files / 781 tests ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)