### PR TITLE
feat(web): default chat-list grouping to Time, remember the choice, clarify source labels

### DIFF
--- a/packages/web/src/components/chat/source-icon.tsx
+++ b/packages/web/src/components/chat/source-icon.tsx
@@ -45,7 +45,7 @@ const GITHUB_ENTITY_ICON_MAP: Record<GithubEntityType, LucideIcon> = {
 };
 
 const SOURCE_LABEL_MAP: Record<ChatSource, string> = {
-  manual: "Manual chat",
+  manual: "Human-created chat",
   github: "GitHub",
   agent: "Agent-created task",
 };

--- a/packages/web/src/pages/workspace/__tests__/group-rows.test.ts
+++ b/packages/web/src/pages/workspace/__tests__/group-rows.test.ts
@@ -1,11 +1,14 @@
 import type { MeChatRow } from "@first-tree/shared";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
+  DEFAULT_GROUP_MODE,
   groupRows,
   parseGroupMode,
+  readStoredGroupMode,
   rowAttentionReason,
   rowIsFailed,
   splitAttentionRows,
+  storeGroupMode,
 } from "../conversations/group-rows.js";
 
 // Fixed reference "now" — picked to be mid-week so the
@@ -48,12 +51,40 @@ function offsetIso(hours: number): string {
 }
 
 describe("parseGroupMode", () => {
-  it("supports only source and recency", () => {
+  it("supports only source and recency; unknown values yield null", () => {
     expect(parseGroupMode("source")).toBe("source");
     expect(parseGroupMode("recency")).toBe("recency");
-    expect(parseGroupMode("type")).toBe("source");
-    expect(parseGroupMode("none")).toBe("source");
-    expect(parseGroupMode(null)).toBe("source");
+    expect(parseGroupMode("type")).toBeNull();
+    expect(parseGroupMode("none")).toBeNull();
+    expect(parseGroupMode(null)).toBeNull();
+  });
+
+  it("round-trips the stored preference and defaults to recency", () => {
+    const store = new Map<string, string>();
+    vi.stubGlobal("window", {
+      localStorage: {
+        getItem: (key: string) => store.get(key) ?? null,
+        setItem: (key: string, value: string) => void store.set(key, value),
+      },
+    });
+    try {
+      expect(readStoredGroupMode()).toBe(DEFAULT_GROUP_MODE);
+      storeGroupMode("source");
+      expect(readStoredGroupMode()).toBe("source");
+      storeGroupMode("recency");
+      expect(readStoredGroupMode()).toBe("recency");
+      // Corrupt / legacy values fall back to the default.
+      store.set("first-tree:chat-list-group", "bogus");
+      expect(readStoredGroupMode()).toBe(DEFAULT_GROUP_MODE);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("falls back to the default when localStorage is unavailable", () => {
+    // Node test env has no `window` at all — the helpers must not throw.
+    expect(readStoredGroupMode()).toBe(DEFAULT_GROUP_MODE);
+    expect(() => storeGroupMode("source")).not.toThrow();
   });
 
   it("returns an empty single bucket when there are no rows", () => {
@@ -140,7 +171,7 @@ describe("groupRows — source", () => {
     // Canonical order is the one declared inside `group-rows.ts`:
     // created-by-me → manual → github.
     expect(buckets.map((b) => b.key)).toEqual(["created-by-me", "manual", "github"]);
-    expect(buckets.map((b) => b.label)).toEqual(["MINE", "MANUAL", "GITHUB"]);
+    expect(buckets.map((b) => b.label)).toEqual(["Started by me", "Started by teammates", "From GitHub"]);
     // Both github rows land in the single `github` bucket regardless
     // of inner entityType — the popover collapse is a per-origin axis,
     // not a per-entity one.

--- a/packages/web/src/pages/workspace/__tests__/url-transitions.test.ts
+++ b/packages/web/src/pages/workspace/__tests__/url-transitions.test.ts
@@ -219,18 +219,18 @@ describe("nextParamsForClearFilters", () => {
 });
 
 describe("nextParamsForGroup", () => {
-  it("drops the param for the default `source` mode", () => {
+  it("drops the param for the default `recency` mode", () => {
     // Default omitted from URL so the canonical home page stays `/`.
-    const result = nextParamsForGroup(paramsOf("group=recency"), "source");
+    const result = nextParamsForGroup(paramsOf("group=source"), "recency");
     expect(result.has("group")).toBe(false);
   });
 
   it("sets non-default modes", () => {
-    expect(nextParamsForGroup(paramsOf(""), "recency").get("group")).toBe("recency");
+    expect(nextParamsForGroup(paramsOf(""), "source").get("group")).toBe("source");
   });
 
   it("preserves the chat selection (grouping is purely visual)", () => {
-    const result = nextParamsForGroup(paramsOf("c=abc"), "recency");
+    const result = nextParamsForGroup(paramsOf("c=abc"), "source");
     expect(result.get("c")).toBe("abc");
   });
 });

--- a/packages/web/src/pages/workspace/__tests__/workspace-page-dom.test.tsx
+++ b/packages/web/src/pages/workspace/__tests__/workspace-page-dom.test.tsx
@@ -99,7 +99,7 @@ vi.mock("../conversations/index.js", () => ({
       <button type="button" onClick={() => onParticipantsChange(["agent-2"])}>
         Set participants
       </button>
-      <button type="button" onClick={() => onGroupChange("recency")}>
+      <button type="button" onClick={() => onGroupChange("source")}>
         Set group
       </button>
       <button type="button" onClick={onClearFilters}>
@@ -220,6 +220,9 @@ function lastConversationList(container: ParentNode): HTMLElement | null {
 
 beforeEach(() => {
   document.body.innerHTML = "";
+  // The group-by preference persists in localStorage; clear it so each
+  // test starts from the default rather than a previous test's choice.
+  window.localStorage.clear();
   viewportMock.value = "xl";
   authMock.value = {
     meLoaded: true,
@@ -275,10 +278,10 @@ describe("WorkspacePage DOM behavior", () => {
     expect(filtered.get("watching")).toBe("1");
     expect(filtered.get("origin")).toBe("manual,github");
     expect(filtered.get("with")).toBe("agent-2");
-    expect(filtered.get("group")).toBe("recency");
+    expect(filtered.get("group")).toBe("source");
 
     await click(buttonByText(container, "Clear filters"));
-    expect(container.querySelector('[data-testid="location"]')?.textContent).toBe("/?group=recency");
+    expect(container.querySelector('[data-testid="location"]')?.textContent).toBe("/?group=source");
 
     await act(async () => root.unmount());
   });
@@ -293,7 +296,9 @@ describe("WorkspacePage DOM behavior", () => {
 
     const list = container.querySelector<HTMLElement>('[data-testid="conversation-list"]');
     expect(list?.dataset.width).toBe("100%");
-    expect(container.textContent).toContain("list:none:active:read:not-watching:manual:agent-1:source");
+    // `group=bad` is unrecognized → falls back to the (empty) stored
+    // preference → the `recency` default.
+    expect(container.textContent).toContain("list:none:active:read:not-watching:manual:agent-1:recency");
     expect(container.querySelector('[data-testid="center-panel"]')).toBeNull();
     expect(container.querySelector('[data-testid="doc-preview"]')).toBeTruthy();
 

--- a/packages/web/src/pages/workspace/conversations/__tests__/conversation-list-dom.test.tsx
+++ b/packages/web/src/pages/workspace/conversations/__tests__/conversation-list-dom.test.tsx
@@ -273,7 +273,7 @@ describe("ConversationList", () => {
     expect(container.textContent).toContain("Broken deploy");
     expect(container.textContent).toContain("Waiting approval");
     expect(container.textContent).toContain("Manual");
-    expect(container.textContent).toContain("GITHUB");
+    expect(container.textContent).toContain("From GitHub");
     expect(container.querySelector('[aria-label="watching"]')).toBeTruthy();
     expect(container.querySelector('[aria-label="failed, 3 unread"]')).toBeTruthy();
     expect(container.querySelector('[aria-label="1 unread"]')).toBeTruthy();
@@ -307,13 +307,13 @@ describe("ConversationList", () => {
 
     await click(container.querySelector('button[aria-label="Filter"]'));
     await click(
-      [...document.body.querySelectorAll("label")].find((label) => label.textContent?.includes("Manual")) ?? null,
+      [...document.body.querySelectorAll("label")].find((label) => label.textContent?.includes("Human")) ?? null,
     );
     await click(
       [...document.body.querySelectorAll("label")].find((label) => label.textContent?.includes("GitHub")) ?? null,
     );
     expect(container.textContent).toContain("Filters");
-    expect(container.textContent).toContain("Manual");
+    expect(container.textContent).toContain("Human");
     expect(container.textContent).toContain("GitHub");
 
     await click(buttonByText(container, "Unread"));

--- a/packages/web/src/pages/workspace/conversations/__tests__/filter-popover-dom.test.tsx
+++ b/packages/web/src/pages/workspace/conversations/__tests__/filter-popover-dom.test.tsx
@@ -119,9 +119,9 @@ describe("FilterPopover", () => {
     expect(checkboxByLabel("Archived").checked).toBe(true);
     expect(checkboxByLabel("GitHub").checked).toBe(true);
     expect(checkboxByLabel("Agent").checked).toBe(true);
-    expect(checkboxByLabel("Manual").checked).toBe(false);
+    expect(checkboxByLabel("Human").checked).toBe(false);
 
-    await click(checkboxByLabel("Manual"));
+    await click(checkboxByLabel("Human"));
     expect(onOriginChange).toHaveBeenLastCalledWith(["manual", "github", "agent"]);
     expect(trigger?.textContent).toContain("4");
 
@@ -135,7 +135,7 @@ describe("FilterPopover", () => {
 
     await click([...document.body.querySelectorAll("button")].find((button) => button.textContent === "Reset") ?? null);
     expect(onOriginChange).toHaveBeenLastCalledWith([]);
-    expect(checkboxByLabel("Manual").checked).toBe(false);
+    expect(checkboxByLabel("Human").checked).toBe(false);
 
     await click(checkboxByLabel("Active"));
     expect(onEngagementChange).toHaveBeenLastCalledWith("all");

--- a/packages/web/src/pages/workspace/conversations/filter-popover.tsx
+++ b/packages/web/src/pages/workspace/conversations/filter-popover.tsx
@@ -15,7 +15,10 @@ import type { GroupMode } from "./group-rows.js";
  * mapping.
  */
 export const ORIGIN_OPTIONS: ReadonlyArray<{ value: ChatSource; label: string }> = [
-  { value: "manual", label: "Manual" },
+  // "Human" (not "Manual") — users don't think of themselves as creating
+  // chats "manually"; the dimension is who started the work stream, matching
+  // the Source group-by buckets ("Started by me/teammates").
+  { value: "manual", label: "Human" },
   { value: "github", label: "GitHub" },
   { value: "agent", label: "Agent" },
 ];

--- a/packages/web/src/pages/workspace/conversations/group-rows.ts
+++ b/packages/web/src/pages/workspace/conversations/group-rows.ts
@@ -2,15 +2,45 @@ import type { MeChatRow } from "@first-tree/shared";
 
 export type GroupMode = "recency" | "source";
 
+/** Default grouping when neither the URL nor the stored preference says otherwise. */
+export const DEFAULT_GROUP_MODE: GroupMode = "recency";
+
+const GROUP_MODE_STORAGE_KEY = "first-tree:chat-list-group";
+
 /**
- * Parse a `?group=` URL value into a `GroupMode`. Unknown / missing
- * values fall back to `source` (the default). Exported so both the
- * URL-state side (`WorkspacePage`) and the headless dropdown
- * (`ConversationList`) share one canonical parser.
+ * Parse a raw `?group=` URL (or storage) value into a `GroupMode`.
+ * Returns `null` for unknown / missing values so the caller can fall
+ * back to the remembered preference (`readStoredGroupMode`). Exported
+ * so the URL-state side (`WorkspacePage`) and tests share one
+ * canonical parser.
  */
-export function parseGroupMode(raw: string | null): GroupMode {
-  if (raw === "recency") return raw;
-  return "source";
+export function parseGroupMode(raw: string | null): GroupMode | null {
+  if (raw === "recency" || raw === "source") return raw;
+  return null;
+}
+
+/**
+ * Read the remembered `Group by` choice. The selection is a per-device
+ * view preference, so it lives in `localStorage` (same pattern as the
+ * doc-preview drawer width) rather than in server-side user settings.
+ */
+export function readStoredGroupMode(): GroupMode {
+  try {
+    return parseGroupMode(window.localStorage.getItem(GROUP_MODE_STORAGE_KEY)) ?? DEFAULT_GROUP_MODE;
+  } catch {
+    // localStorage may be unavailable (private mode, sandboxed iframe);
+    // fall back to the default rather than breaking the rail.
+    return DEFAULT_GROUP_MODE;
+  }
+}
+
+/** Persist the `Group by` choice so the next visit restores it. */
+export function storeGroupMode(mode: GroupMode): void {
+  try {
+    window.localStorage.setItem(GROUP_MODE_STORAGE_KEY, mode);
+  } catch {
+    // Best-effort persistence — losing the preference is acceptable.
+  }
 }
 
 export type GroupBucket = {
@@ -112,15 +142,23 @@ function groupByRecency(rows: ReadonlyArray<MeChatRow>, now: Date): ReadonlyArra
 // Source
 // ---------------------------------------------------------------------------
 
+// Labels are phrased around "who started this work stream" — the user's
+// mental model for this grouping — rather than the creation mechanism
+// (the old MINE/MANUAL/GITHUB/AGENT set read as two mixed dimensions).
+// Header rendering uppercases via CSS, so labels stay normal case here.
 const SOURCE_BUCKETS: ReadonlyArray<{ key: string; label: string; match: (row: MeChatRow) => boolean }> = [
   {
     key: "created-by-me",
-    label: "MINE",
+    label: "Started by me",
     match: (row) => row.createdByMe === true && (row.source ?? "manual") === "manual",
   },
-  { key: "manual", label: "MANUAL", match: (row) => row.createdByMe !== true && (row.source ?? "manual") === "manual" },
-  { key: "github", label: "GITHUB", match: (row) => row.source === "github" },
-  { key: "agent", label: "AGENT", match: (row) => row.source === "agent" },
+  {
+    key: "manual",
+    label: "Started by teammates",
+    match: (row) => row.createdByMe !== true && (row.source ?? "manual") === "manual",
+  },
+  { key: "github", label: "From GitHub", match: (row) => row.source === "github" },
+  { key: "agent", label: "Started by agents", match: (row) => row.source === "agent" },
 ];
 
 function groupBySource(rows: ReadonlyArray<MeChatRow>): ReadonlyArray<GroupBucket> {

--- a/packages/web/src/pages/workspace/index.tsx
+++ b/packages/web/src/pages/workspace/index.tsx
@@ -7,7 +7,13 @@ import { useAdminWs } from "../../hooks/use-admin-ws.js";
 import { useWorkspaceViewport } from "../../hooks/use-viewport.js";
 import { shouldEnterOnboarding } from "../onboarding/steps.js";
 import { CenterPanel } from "./center/index.js";
-import { type GroupMode, parseGroupMode } from "./conversations/group-rows.js";
+import {
+  DEFAULT_GROUP_MODE,
+  type GroupMode,
+  parseGroupMode,
+  readStoredGroupMode,
+  storeGroupMode,
+} from "./conversations/group-rows.js";
 import { ConversationList, DRAFT_CHAT_ID, type RailFilter } from "./conversations/index.js";
 
 /**
@@ -20,7 +26,8 @@ import { ConversationList, DRAFT_CHAT_ID, type RailFilter } from "./conversation
  *   - `?watching=1` (default off) — chats where the caller is a watcher
  *   - `?origin=manual,pr,issue,…` (default empty = unfiltered) — multi-select
  *   - `?with=agent-x,agent-y` (default empty = unfiltered) — participants
- *   - `?group=recency|source` (default `source`) — list grouping
+ *   - `?group=recency|source` — list grouping; when absent, falls back to
+ *     the remembered per-device choice (`localStorage`), then `recency`
  *
  * Phase B replaces the Phase A single-value `?source=` with the multi-select
  * `?origin=`; the legacy key is still accepted on first load and upgraded
@@ -109,7 +116,9 @@ export function WorkspacePage() {
   const { unread, watching } = parseUnreadWatching(searchParams);
   const origin = parseOriginList(searchParams);
   const participants = parseParticipantList(searchParams);
-  const group = parseGroupMode(searchParams.get("group"));
+  // Explicit URL value wins (shareable links); otherwise restore the
+  // remembered per-device choice, which itself defaults to `recency`.
+  const group = parseGroupMode(searchParams.get("group")) ?? readStoredGroupMode();
 
   useAdminWs();
 
@@ -226,6 +235,8 @@ export function WorkspacePage() {
 
   const setGroup = useCallback(
     (next: GroupMode) => {
+      // Remember the choice for future visits, then mirror it in the URL.
+      storeGroupMode(next);
       setSearchParams(nextParamsForGroup(searchParams, next), { replace: true });
     },
     [searchParams, setSearchParams],
@@ -443,7 +454,7 @@ export function nextParamsForParticipants(current: URLSearchParams, agents: Read
  */
 export function nextParamsForGroup(current: URLSearchParams, mode: GroupMode): URLSearchParams {
   const next = new URLSearchParams(current);
-  if (mode === "source") next.delete("group");
+  if (mode === DEFAULT_GROUP_MODE) next.delete("group");
   else next.set("group", mode);
   return next;
 }


### PR DESCRIPTION
## What

Three related chat-list (left rail) improvements:

1. **Default grouping is now Time (recency)** — `parseGroupMode` previously fell back to `source`; new users now land on the more familiar Today / Yesterday / Earlier this week view.
2. **The group-by choice is remembered per device** — stored in `localStorage` (`first-tree:chat-list-group`, same pattern as the doc-preview drawer width). An explicit `?group=` URL value still wins, so shared links render the same view for the recipient. Private-mode / storage-denied environments safely fall back to the default.
3. **Source labels now answer 'who started this work stream?'** — the old set mixed two dimensions (creator vs mechanism), and 'MANUAL' could not be read as 'started by someone else':

| Before | After |
|---|---|
| MINE | Started by me |
| MANUAL | Started by teammates |
| GITHUB | From GitHub |
| AGENT | Started by agents |

Synchronized renames on the same dimension: filter popover origin option **Manual → Human**, row icon tooltip **Manual chat → Human-created chat**. Bucket labels also drop the hardcoded uppercase — the header already uppercases via CSS (matches the 'Needs attention' bucket style).

## Not changed

- URL params (`?group=`, `?origin=`), internal bucket keys, `ChatSource` wire values, DB — label-only renames per the product language model (no implementation churn for product language).
- Bucket order, empty-bucket hiding, unknown-source → manual fallback.

## Tests

- `parseGroupMode` now returns `null` for unknown values (caller falls back to stored preference); new round-trip + storage-unavailable cases
- Updated URL-transition default (drop `?group` for `recency`, set for `source`), DOM tests for new labels, localStorage isolation in `beforeEach`
- Web suite: 103 files / 780 tests green; `pnpm check` + `typecheck` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)