### PR TITLE
fix(client,server): canonicalize Context Tree ref paths, cover notebook and search tools

### DIFF
--- a/packages/client/src/__tests__/claude-code-tool-events.test.ts
+++ b/packages/client/src/__tests__/claude-code-tool-events.test.ts
@@ -1,5 +1,8 @@
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { SessionEvent } from "@first-tree/shared";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createToolCallProcessor, treeNodePathOf } from "../handlers/claude-code.js";
 
 /**
@@ -557,6 +560,182 @@ describe("createToolCallProcessor — Context Tree file refs", () => {
       },
     ]);
     expect(usageEventCount(emit)).toBe(0);
+  });
+});
+
+/**
+ * W1 cloud layout: the shared external tree clone is exposed inside the agent
+ * home as a `<workspace>/context-tree` symlink (runtime/workspace-manifest.ts),
+ * while the binding carries the external clone's real path. Refs must map
+ * regardless of which spelling the tool call used.
+ */
+describe("createToolCallProcessor — symlinked Context Tree (W1 cloud layout)", () => {
+  let root: string;
+  let realTree: string;
+  let link: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "first-tree-symlink-refs-"));
+    realTree = join(root, "context-tree-repos", "abc123");
+    mkdirSync(join(realTree, "members"), { recursive: true });
+    writeFileSync(join(realTree, "NODE.md"), "root");
+    writeFileSync(join(realTree, "members", "NODE.md"), "members");
+    const workspace = join(root, "workspaces", "agent-home");
+    mkdirSync(workspace, { recursive: true });
+    link = join(workspace, "context-tree");
+    symlinkSync(realTree, link);
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  function bindingFor(path: string) {
+    return { path, repoUrl: "https://github.com/example/tree", branch: "main" } as const;
+  }
+
+  function finalRefs(emit: ReturnType<typeof vi.fn<(event: SessionEvent) => void>>, id: string) {
+    const final = emit.mock.calls
+      .map((c) => c[0])
+      .filter((ev) => ev.kind === "tool_call")
+      .find((event) => event.payload.toolUseId === id && event.payload.status === "ok");
+    return final?.payload.toolFileRefs;
+  }
+
+  it("maps a Read through the workspace symlink to the real-clone binding", () => {
+    const emit = vi.fn<(event: SessionEvent) => void>();
+    const processor = createToolCallProcessor(emit, bindingFor(realTree));
+
+    processor.onMessage(assistantToolUse("s1", "Read", { file_path: join(link, "members", "NODE.md") }));
+    processor.onMessage(userToolResult("s1", "contents"));
+
+    expect(finalRefs(emit, "s1")).toEqual([
+      {
+        origin: "tool_arg",
+        localPath: join(link, "members", "NODE.md"),
+        repoUrl: "https://github.com/example/tree",
+        repoBranch: "main",
+        repoRelativePath: "members/NODE.md",
+        pathKind: "file",
+      },
+    ]);
+  });
+
+  it("maps a Write creating a NEW file through the symlink (no existing path to realpath)", () => {
+    const emit = vi.fn<(event: SessionEvent) => void>();
+    const processor = createToolCallProcessor(emit, bindingFor(realTree));
+
+    processor.onMessage(
+      assistantToolUse("s2", "Write", { file_path: join(link, "domains", "new-leaf.md"), content: "x" }),
+    );
+    processor.onMessage(userToolResult("s2", "created"));
+
+    expect(finalRefs(emit, "s2")?.[0]).toMatchObject({
+      repoUrl: "https://github.com/example/tree",
+      repoRelativePath: "domains/new-leaf.md",
+    });
+  });
+
+  it("maps a Read of the real clone path when the binding is spelled as the symlink", () => {
+    const emit = vi.fn<(event: SessionEvent) => void>();
+    const processor = createToolCallProcessor(emit, bindingFor(link));
+
+    processor.onMessage(assistantToolUse("s3", "Read", { file_path: join(realTree, "NODE.md") }));
+    processor.onMessage(userToolResult("s3", "contents"));
+
+    expect(finalRefs(emit, "s3")?.[0]).toMatchObject({
+      repoUrl: "https://github.com/example/tree",
+      repoRelativePath: "NODE.md",
+    });
+  });
+
+  it("attaches a write ref for NotebookEdit via its notebook_path argument", () => {
+    const emit = vi.fn<(event: SessionEvent) => void>();
+    const processor = createToolCallProcessor(emit, bindingFor(realTree));
+
+    processor.onMessage(
+      assistantToolUse("s4", "NotebookEdit", { notebook_path: join(realTree, "members", "NODE.md") }),
+    );
+    processor.onMessage(userToolResult("s4", "edited"));
+
+    expect(finalRefs(emit, "s4")?.[0]).toMatchObject({
+      repoUrl: "https://github.com/example/tree",
+      repoRelativePath: "members/NODE.md",
+      pathKind: "file",
+    });
+  });
+
+  it("attaches a directory-level ref for Grep with an explicit tree path", () => {
+    const emit = vi.fn<(event: SessionEvent) => void>();
+    const processor = createToolCallProcessor(emit, bindingFor(realTree));
+
+    processor.onMessage(assistantToolUse("s5", "Grep", { pattern: "owners", path: join(link, "members") }));
+    processor.onMessage(userToolResult("s5", "matches"));
+
+    expect(finalRefs(emit, "s5")).toEqual([
+      {
+        origin: "tool_arg",
+        localPath: join(link, "members"),
+        repoUrl: "https://github.com/example/tree",
+        repoBranch: "main",
+        repoRelativePath: "members",
+        pathKind: "directory",
+      },
+    ]);
+  });
+
+  it("attaches a repo-level ref for Glob rooted at the tree itself", () => {
+    const emit = vi.fn<(event: SessionEvent) => void>();
+    const processor = createToolCallProcessor(emit, bindingFor(realTree));
+
+    processor.onMessage(assistantToolUse("s6", "Glob", { pattern: "**/*.md", path: realTree }));
+    processor.onMessage(userToolResult("s6", "files"));
+
+    expect(finalRefs(emit, "s6")?.[0]).toMatchObject({
+      repoRelativePath: "/",
+      pathKind: "repo",
+    });
+  });
+
+  it("does NOT attach refs for Grep without an explicit path argument", () => {
+    const emit = vi.fn<(event: SessionEvent) => void>();
+    const processor = createToolCallProcessor(emit, bindingFor(realTree), { cwd: realTree });
+
+    processor.onMessage(assistantToolUse("s7", "Grep", { pattern: "owners" }));
+    processor.onMessage(userToolResult("s7", "matches"));
+
+    expect(finalRefs(emit, "s7")).toBeUndefined();
+  });
+
+  it("attaches a local-only ref for Grep over a non-tree directory", () => {
+    const emit = vi.fn<(event: SessionEvent) => void>();
+    const processor = createToolCallProcessor(emit, bindingFor(realTree));
+    const outside = join(root, "workspaces", "agent-home");
+
+    processor.onMessage(assistantToolUse("s8", "Grep", { pattern: "x", path: outside }));
+    processor.onMessage(userToolResult("s8", "matches"));
+
+    expect(finalRefs(emit, "s8")).toEqual([
+      {
+        origin: "tool_arg",
+        localPath: outside,
+        pathKind: "directory",
+      },
+    ]);
+  });
+
+  it("maps a Bash read through the workspace symlink", () => {
+    const emit = vi.fn<(event: SessionEvent) => void>();
+    const processor = createToolCallProcessor(emit, bindingFor(realTree), { cwd: root });
+
+    processor.onMessage(assistantToolUse("s9", "Bash", { command: `cat ${join(link, "NODE.md")}` }));
+    processor.onMessage(userToolResult("s9", "contents"));
+
+    expect(finalRefs(emit, "s9")?.[0]).toMatchObject({
+      repoUrl: "https://github.com/example/tree",
+      repoRelativePath: "NODE.md",
+      pathKind: "file",
+    });
   });
 });
 

--- a/packages/client/src/__tests__/codex-context-tree-io.test.ts
+++ b/packages/client/src/__tests__/codex-context-tree-io.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { collectCodexFileChangePaths, toolFileRefsFromCodexFileChange } from "../handlers/codex.js";
 import { toolFileRefsFromShellCommand } from "../runtime/context-tree-file-refs.js";
 
@@ -130,5 +133,47 @@ describe("Codex Context Tree file refs", () => {
     expect(toolFileRefsFromShellCommand({ ...base, command: "cat /home/op/context-tree-sibling/NODE.md" })).toEqual([]);
     expect(toolFileRefsFromShellCommand({ ...base, command: "cat /home/op/context-tree/NODE.md | head" })).toEqual([]);
     expect(toolFileRefsFromShellCommand({ ...base, command: "echo x > /home/op/context-tree/NODE.md" })).toEqual([]);
+  });
+});
+
+describe("Codex file refs through the W1 workspace symlink", () => {
+  let root: string;
+  let realTree: string;
+  let link: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "first-tree-codex-symlink-"));
+    realTree = join(root, "context-tree-repos", "abc123");
+    mkdirSync(realTree, { recursive: true });
+    writeFileSync(join(realTree, "NODE.md"), "root");
+    const workspace = join(root, "workspace");
+    mkdirSync(workspace, { recursive: true });
+    link = join(workspace, "context-tree");
+    symlinkSync(realTree, link);
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("maps file_change paths that travel through the symlink to the real-clone binding", () => {
+    const refs = toolFileRefsFromCodexFileChange({
+      changes: [{ path: join(link, "NODE.md") }],
+      workspaceCwd: join(root, "workspace"),
+      contextTreePath: realTree,
+      contextTreeRepoUrl: "https://github.com/acme/first-tree-context.git",
+      contextTreeBranch: "main",
+    });
+
+    expect(refs).toEqual([
+      {
+        origin: "file_change",
+        localPath: join(link, "NODE.md"),
+        repoUrl: "https://github.com/acme/first-tree-context.git",
+        repoBranch: "main",
+        repoRelativePath: "NODE.md",
+        pathKind: "file",
+      },
+    ]);
   });
 });

--- a/packages/client/src/__tests__/context-tree-file-refs.test.ts
+++ b/packages/client/src/__tests__/context-tree-file-refs.test.ts
@@ -1,8 +1,12 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { toolFileRefsFromShellCommand } from "../runtime/context-tree-file-refs.js";
+import {
+  canonicalizeFsPath,
+  contextTreeRelativePathOf,
+  toolFileRefsFromShellCommand,
+} from "../runtime/context-tree-file-refs.js";
 
 describe("toolFileRefsFromShellCommand", () => {
   let root: string;
@@ -133,5 +137,67 @@ describe("toolFileRefsFromShellCommand", () => {
         contextTreeRepoUrl: null,
       }),
     ).toEqual([]);
+  });
+});
+
+describe("canonicalizeFsPath / contextTreeRelativePathOf", () => {
+  let root: string;
+  let realTree: string;
+  let link: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "first-tree-canonical-"));
+    realTree = join(root, "context-tree-repos", "abc123");
+    mkdirSync(join(realTree, "members"), { recursive: true });
+    writeFileSync(join(realTree, "NODE.md"), "root");
+    const workspace = join(root, "workspace");
+    mkdirSync(workspace, { recursive: true });
+    link = join(workspace, "context-tree");
+    symlinkSync(realTree, link);
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("resolves a symlinked path to its real form", () => {
+    expect(canonicalizeFsPath(join(link, "NODE.md"))).toBe(canonicalizeFsPath(join(realTree, "NODE.md")));
+  });
+
+  it("canonicalizes the deepest existing ancestor of a not-yet-existing path", () => {
+    expect(canonicalizeFsPath(join(link, "domains", "new-leaf.md"))).toBe(
+      canonicalizeFsPath(join(realTree, "domains", "new-leaf.md")),
+    );
+  });
+
+  it("relativizes across symlink aliases in both directions", () => {
+    expect(contextTreeRelativePathOf(join(link, "members"), realTree)).toBe("members");
+    expect(contextTreeRelativePathOf(join(realTree, "members"), link)).toBe("members");
+    expect(contextTreeRelativePathOf(link, realTree)).toBe("/");
+  });
+
+  it("still rejects paths outside the tree", () => {
+    expect(contextTreeRelativePathOf(join(root, "workspace"), realTree)).toBeNull();
+  });
+
+  it("maps shell reads that travel through the workspace symlink", () => {
+    const refs = toolFileRefsFromShellCommand({
+      command: `cat ${join(link, "NODE.md")}`,
+      cwd: root,
+      contextTreePath: realTree,
+      contextTreeRepoUrl: "https://github.com/acme/first-tree-context.git",
+      contextTreeBranch: "main",
+    });
+
+    expect(refs).toEqual([
+      {
+        origin: "tool_arg",
+        localPath: join(link, "NODE.md"),
+        repoUrl: "https://github.com/acme/first-tree-context.git",
+        repoBranch: "main",
+        repoRelativePath: "NODE.md",
+        pathKind: "file",
+      },
+    ]);
   });
 });

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -1,8 +1,8 @@
 import { randomUUID } from "node:crypto";
-import { existsSync } from "node:fs";
+import { existsSync, statSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
-import { join } from "node:path";
+import { isAbsolute, join, resolve } from "node:path";
 import type {
   EffortLevel,
   McpServerConfig,
@@ -22,7 +22,11 @@ import { buildAgentBriefing } from "../runtime/agent-briefing.js";
 import type { AgentConfigCache } from "../runtime/agent-config-cache.js";
 import { type PredeclaredSourceRepo, writeAgentBriefing } from "../runtime/bootstrap.js";
 import { type ChatContext, fetchChatContext } from "../runtime/chat-context.js";
-import { toolFileRefsFromShellCommand } from "../runtime/context-tree-file-refs.js";
+import {
+  canonicalizeFsPath,
+  contextTreeRelativePathOf,
+  toolFileRefsFromShellCommand,
+} from "../runtime/context-tree-file-refs.js";
 import { classify } from "../runtime/error-taxonomy.js";
 import type { GitMirrorManager } from "../runtime/git-mirror-manager.js";
 import type { AgentHandler, HandlerFactory, SessionContext, SessionMessage } from "../runtime/handler.js";
@@ -312,18 +316,26 @@ function extractToolResultText(content: unknown): string {
   return parts.join("\n");
 }
 
-/**
- * Tools whose `file_path` argument names a single file. Search tools
- * (Grep/Glob) are excluded because they need server-side command/query
- * semantics before they can be treated as an explicit file IO fact.
- */
+/** Tools whose `file_path` / `notebook_path` argument names a single file. */
 const TREE_READ_TOOL_NAMES: ReadonlySet<string> = new Set(["Read", "NotebookRead"]);
-const TREE_WRITE_TOOL_NAMES: ReadonlySet<string> = new Set(["Write", "Edit", "MultiEdit"]);
+const TREE_WRITE_TOOL_NAMES: ReadonlySet<string> = new Set(["Write", "Edit", "MultiEdit", "NotebookEdit"]);
+/**
+ * Search/discovery tools scan a search root rather than open one file. They
+ * carry directory-level evidence (the explicit `path` argument), deliberately
+ * NOT one ref per matched file — a recursive search "touching" every node
+ * would drown the Context tab feed in noise.
+ */
+const TREE_SEARCH_TOOL_NAMES: ReadonlySet<string> = new Set(["Grep", "Glob"]);
 
-/** Extract a string `file_path` argument from a tool_use input, if present. */
+/**
+ * Extract a string `file_path` argument from a tool_use input, if present.
+ * Notebook tools (NotebookRead / NotebookEdit) spell the same argument
+ * `notebook_path`; accept either so notebook IO carries refs too.
+ */
 function readFilePathArg(input: unknown): string | null {
   if (!input || typeof input !== "object") return null;
-  const fp = (input as { file_path?: unknown }).file_path;
+  const record = input as { file_path?: unknown; notebook_path?: unknown };
+  const fp = record.file_path ?? record.notebook_path;
   return typeof fp === "string" ? fp : null;
 }
 
@@ -337,6 +349,11 @@ function readFilePathArg(input: unknown): string | null {
  * Invariant: both `filePath` and `contextTreePath` are expected to be
  * absolute. A relative `filePath` will not match the absolute root and returns
  * null — i.e. it silently under-counts (fails safe) rather than mis-attributing.
+ *
+ * Callers that may receive symlink aliases of the tree (the W1 cloud layout
+ * exposes the shared clone as a `<workspace>/context-tree` link) must pass
+ * both arguments through `canonicalizeFsPath` first — this function compares
+ * strings only.
  */
 export function treeNodePathOf(filePath: string, contextTreePath: string): string | null {
   if (!filePath || !contextTreePath) return null;
@@ -353,11 +370,65 @@ function toolFileRef(toolName: string, input: unknown, contextTree?: ContextTree
   if (!TREE_READ_TOOL_NAMES.has(toolName) && !TREE_WRITE_TOOL_NAMES.has(toolName)) return null;
   const filePath = readFilePathArg(input);
   if (filePath === null) return null;
-  const repoRelativePath = contextTree?.path ? treeNodePathOf(filePath, contextTree.path) : null;
+  // Canonicalize both sides so a symlinked tree path (W1 cloud layout) still
+  // maps. Relative paths keep the fail-safe null mapping — canonicalizing
+  // them would resolve against the daemon's cwd and risk mis-attribution.
+  const repoRelativePath =
+    contextTree?.path && isAbsolute(filePath)
+      ? treeNodePathOf(canonicalizeFsPath(filePath), canonicalizeFsPath(contextTree.path))
+      : null;
   return {
     origin: "tool_arg",
     localPath: filePath,
     pathKind: "file",
+    ...(contextTree?.repoUrl && repoRelativePath !== null
+      ? {
+          repoUrl: contextTree.repoUrl,
+          ...(contextTree.branch ? { repoBranch: contextTree.branch } : {}),
+          repoRelativePath,
+        }
+      : {}),
+  };
+}
+
+function statIsFile(absolutePath: string): boolean {
+  try {
+    return statSync(absolutePath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+/** Extract a string `path` argument from a search tool_use input, if present. */
+function searchPathArg(input: unknown): string | null {
+  if (!input || typeof input !== "object") return null;
+  const p = (input as { path?: unknown }).path;
+  return typeof p === "string" ? p : null;
+}
+
+/**
+ * Directory-level ref for a Grep/Glob call whose explicit `path` argument
+ * targets the Context Tree. Calls without a `path` argument default to the
+ * session cwd (the workspace root, not the tree) and carry no ref — fail-safe
+ * under-counting over mis-attribution, same stance as `toolFileRef`.
+ */
+function searchToolFileRef(
+  toolName: string,
+  input: unknown,
+  contextTree: ContextTreeBinding | undefined,
+  cwd: string | null | undefined,
+): ToolFileRef | null {
+  if (!TREE_SEARCH_TOOL_NAMES.has(toolName)) return null;
+  const rawPath = searchPathArg(input);
+  if (rawPath === null) return null;
+  if (!isAbsolute(rawPath) && !cwd) return null;
+  const absolutePath = isAbsolute(rawPath) ? resolve(rawPath) : resolve(cwd ?? "", rawPath);
+  const repoRelativePath = contextTree?.path ? contextTreeRelativePathOf(absolutePath, contextTree.path) : null;
+  return {
+    origin: "tool_arg",
+    localPath: absolutePath,
+    // Grep accepts a file as its search root; everything else is a directory.
+    pathKind: repoRelativePath === "/" ? "repo" : statIsFile(absolutePath) ? "file" : "directory",
     ...(contextTree?.repoUrl && repoRelativePath !== null
       ? {
           repoUrl: contextTree.repoUrl,
@@ -382,6 +453,8 @@ function toolFileRefs(
 ): ToolFileRef[] {
   const directRef = toolFileRef(toolName, input, contextTree);
   if (directRef) return [directRef];
+  const searchRef = searchToolFileRef(toolName, input, contextTree, cwd);
+  if (searchRef) return [searchRef];
   if (toolName !== "Bash" || !cwd) return [];
   const command = readCommandArg(input);
   if (command === null) return [];

--- a/packages/client/src/handlers/codex.ts
+++ b/packages/client/src/handlers/codex.ts
@@ -1,4 +1,4 @@
-import { isAbsolute, relative, resolve } from "node:path";
+import { isAbsolute, resolve } from "node:path";
 import {
   type AgentRuntimeConfigPayload,
   deriveRepoLocalPath,
@@ -11,7 +11,7 @@ import { buildAgentBriefing } from "../runtime/agent-briefing.js";
 import type { AgentConfigCache } from "../runtime/agent-config-cache.js";
 import { FIRST_TREE_WORKSPACE_MARKER, type PredeclaredSourceRepo } from "../runtime/bootstrap.js";
 import { type ChatContext, fetchChatContext } from "../runtime/chat-context.js";
-import { toolFileRefsFromShellCommand } from "../runtime/context-tree-file-refs.js";
+import { contextTreeRelativePathOf, toolFileRefsFromShellCommand } from "../runtime/context-tree-file-refs.js";
 import { resolveGitRepoTargetPath } from "../runtime/git-local-path.js";
 import type { GitMirrorManager } from "../runtime/git-mirror-manager.js";
 import type {
@@ -362,10 +362,10 @@ function contextTreeTargetPathOf(
 ): string | null {
   if (!contextTreePath) return null;
   const absolutePath = isAbsolute(filePath) ? resolve(filePath) : resolve(workspaceCwd, filePath);
-  const root = resolve(contextTreePath);
-  const rel = relative(root, absolutePath);
-  if (!rel || rel === "." || rel.startsWith("..") || isAbsolute(rel)) return null;
-  return rel.replaceAll("\\", "/");
+  // Canonical comparison so a symlink alias of the tree (W1 cloud layout's
+  // `<workspace>/context-tree` link) maps the same as the real clone path.
+  const rel = contextTreeRelativePathOf(absolutePath, contextTreePath);
+  return rel === null || rel === "/" ? null : rel;
 }
 
 export function collectCodexFileChangePaths(changes: unknown): string[] {

--- a/packages/client/src/runtime/context-tree-file-refs.ts
+++ b/packages/client/src/runtime/context-tree-file-refs.ts
@@ -1,5 +1,5 @@
-import { statSync } from "node:fs";
-import { isAbsolute, relative, resolve } from "node:path";
+import { realpathSync, statSync } from "node:fs";
+import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { classifyShellCommandIo, type ShellIoPathKindHint, type ToolFileRef } from "@first-tree/shared";
 
 export type ShellCommandFileRefsInput = {
@@ -14,8 +14,44 @@ function toPosixPath(path: string): string {
   return path.replaceAll("\\", "/");
 }
 
-function pathInsideContextTree(absolutePath: string, contextTreePath: string): string | null {
-  const relativePath = relative(contextTreePath, absolutePath);
+/**
+ * Resolve `path` to its canonical filesystem form (symlinks resolved),
+ * falling back lexically for segments that do not exist (yet).
+ *
+ * Cloud agent homes expose the shared Context Tree clone through a
+ * `<workspace>/context-tree` symlink (see `runtime/workspace-manifest.ts`),
+ * while the runtime config carries the external clone's real path. A pure
+ * string prefix match between the two spellings never agrees, so every ref
+ * that travels through the symlinked path silently loses its repo evidence.
+ * Canonicalizing both sides of the containment check makes the spellings
+ * equivalent.
+ *
+ * A not-yet-existing path (e.g. a Write creating a new file) canonicalizes
+ * its deepest existing ancestor and re-appends the remaining segments, so
+ * brand-new files under a symlinked root still map correctly.
+ */
+export function canonicalizeFsPath(path: string): string {
+  let current = resolve(path);
+  const pendingSegments: string[] = [];
+  for (;;) {
+    try {
+      return pendingSegments.length === 0 ? realpathSync(current) : join(realpathSync(current), ...pendingSegments);
+    } catch {
+      const parent = dirname(current);
+      if (parent === current) return resolve(path);
+      pendingSegments.unshift(basename(current));
+      current = parent;
+    }
+  }
+}
+
+/**
+ * Tree-root-relative posix path of `absolutePath` when it lives under
+ * `contextTreeRoot`, `"/"` when it IS the root, null otherwise. Both sides
+ * are compared in canonical form, so symlink aliases of the same tree agree.
+ */
+export function contextTreeRelativePathOf(absolutePath: string, contextTreeRoot: string): string | null {
+  const relativePath = relative(canonicalizeFsPath(contextTreeRoot), canonicalizeFsPath(absolutePath));
   if (relativePath === "") return "/";
   if (relativePath.startsWith("..") || isAbsolute(relativePath)) return null;
   return toPosixPath(relativePath);
@@ -44,13 +80,12 @@ export function toolFileRefsFromShellCommand(input: ShellCommandFileRefsInput): 
 
   const refs: ToolFileRef[] = [];
   const seen = new Set<string>();
-  const contextTreeRoot = resolve(input.contextTreePath);
   for (const pathArg of classification.pathArgs) {
     const absolutePath = isAbsolute(pathArg.raw) ? resolve(pathArg.raw) : resolve(input.cwd, pathArg.raw);
     if (seen.has(absolutePath)) continue;
     seen.add(absolutePath);
 
-    const repoRelativePath = pathInsideContextTree(absolutePath, contextTreeRoot);
+    const repoRelativePath = contextTreeRelativePathOf(absolutePath, input.contextTreePath);
     if (repoRelativePath === null) continue;
 
     refs.push({

--- a/packages/server/src/__tests__/context-tree-io.test.ts
+++ b/packages/server/src/__tests__/context-tree-io.test.ts
@@ -468,4 +468,115 @@ describe("context-tree IO service", () => {
       }),
     ).toEqual({ recordable: false, reason: "unsupported_shell_command" });
   });
+
+  it("derives Claude search and notebook IO at the granularity the refs carry", async () => {
+    const app = getApp();
+    const seed = await seedContextTreeChat();
+
+    const grep = await appendEvent(app.db, seed.agent.uuid, seed.chatId, {
+      kind: "tool_call",
+      payload: {
+        toolUseId: "tu-grep",
+        name: "Grep",
+        args: { pattern: "owners", path: "/tmp/context-tree/members" },
+        status: "ok",
+        toolFileRefs: [
+          {
+            origin: "tool_arg",
+            repoUrl: TREE_REPO,
+            repoBranch: "main",
+            repoRelativePath: "members",
+            pathKind: "directory",
+          },
+        ],
+      },
+    });
+    const glob = await appendEvent(app.db, seed.agent.uuid, seed.chatId, {
+      kind: "tool_call",
+      payload: {
+        toolUseId: "tu-glob",
+        name: "Glob",
+        args: { pattern: "**/*.md", path: "/tmp/context-tree" },
+        status: "ok",
+        toolFileRefs: [
+          {
+            origin: "tool_arg",
+            repoUrl: TREE_REPO,
+            repoBranch: "main",
+            repoRelativePath: "/",
+            pathKind: "repo",
+          },
+        ],
+      },
+    });
+    const notebookEdit = await appendEvent(app.db, seed.agent.uuid, seed.chatId, {
+      kind: "tool_call",
+      payload: {
+        toolUseId: "tu-notebook-edit",
+        name: "NotebookEdit",
+        args: { notebook_path: "/tmp/context-tree/designs/spike.ipynb" },
+        status: "ok",
+        toolFileRefs: [
+          {
+            origin: "tool_arg",
+            repoUrl: TREE_REPO,
+            repoBranch: "main",
+            repoRelativePath: "designs/spike.ipynb",
+            pathKind: "file",
+          },
+        ],
+      },
+    });
+
+    for (const sessionEvent of [grep, glob, notebookEdit]) {
+      await recordFromSessionEvent(app.db, {
+        organizationId: seed.organizationId,
+        agentId: seed.agent.uuid,
+        chatId: seed.chatId,
+        runtimeProvider: "claude-code",
+        sessionEvent,
+      });
+    }
+
+    const grepRows = await app.db
+      .select()
+      .from(contextTreeIoEvents)
+      .where(eq(contextTreeIoEvents.sourceSessionEventId, grep.id));
+    expect(grepRows).toHaveLength(1);
+    expect(grepRows[0]).toMatchObject({
+      action: "read",
+      source: "claude_read_tool",
+      targetKind: "directory",
+      targetPath: "members",
+    });
+
+    const globRows = await app.db
+      .select()
+      .from(contextTreeIoEvents)
+      .where(eq(contextTreeIoEvents.sourceSessionEventId, glob.id));
+    expect(globRows[0]).toMatchObject({ action: "read", targetKind: "repo", targetPath: "/" });
+
+    const notebookRows = await app.db
+      .select()
+      .from(contextTreeIoEvents)
+      .where(eq(contextTreeIoEvents.sourceSessionEventId, notebookEdit.id));
+    expect(notebookRows[0]).toMatchObject({
+      action: "write",
+      source: "claude_write_tool",
+      targetPath: "designs/spike.ipynb",
+    });
+
+    // A search call whose client attached no refs (no explicit path argument)
+    // stays unrecordable — fail-safe under-counting, not cwd guessing.
+    expect(
+      explainContextTreeIoDecision({
+        runtimeProvider: "claude-code",
+        sessionEvent: {
+          kind: "tool_call",
+          payload: { toolUseId: "tu-grep-norefs", name: "Grep", args: { pattern: "owners" }, status: "ok" },
+        },
+        bindingRepo: TREE_REPO,
+      }),
+    ).toEqual({ recordable: false, reason: "no_tool_file_refs" });
+  });
 });

--- a/packages/server/src/services/context-tree-io.ts
+++ b/packages/server/src/services/context-tree-io.ts
@@ -24,8 +24,11 @@ import { createLogger } from "../observability/index.js";
 import { getOrgContextTree } from "./org-settings.js";
 
 const CONTEXT_TREE_IO_FEED_LIMIT = 50;
-const CLAUDE_READ_TOOLS = new Set(["Read", "NotebookRead"]);
-const CLAUDE_WRITE_TOOLS = new Set(["Write", "Edit", "MultiEdit"]);
+// Grep/Glob count as reads at the granularity their refs carry: the client
+// emits one directory-level ref for the explicit search root, never one ref
+// per matched file (see the client's TREE_SEARCH_TOOL_NAMES).
+const CLAUDE_READ_TOOLS = new Set(["Read", "NotebookRead", "Grep", "Glob"]);
+const CLAUDE_WRITE_TOOLS = new Set(["Write", "Edit", "MultiEdit", "NotebookEdit"]);
 const log = createLogger("ContextTreeIo");
 
 export type ContextTreeIoViewer = {


### PR DESCRIPTION
## Summary

Two systematic under-counting gaps in Context Tree IO attribution (the data behind the Context tab's read/write feed):

### 1. Symlink alias mismatch — the biggest silent miss

The W1 cloud layout exposes the shared external tree clone inside each agent home as a `<workspace>/context-tree` **symlink** (`runtime/workspace-manifest.ts`), while the runtime binding carries the external clone's **real path** (`context-tree-repos/<digest>`). Ref attribution was a pure string prefix match between the two spellings, which never agrees — so every read/write that traveled through the symlinked path (the path the shipped `first-tree` skill's pre-task hygiene points agents at) silently lost its repo evidence and never reached the feed.

Fix: a `canonicalizeFsPath` helper (realpath with lexical fallback for not-yet-existing segments) applied to **both sides** of the containment check, in all three ref extractors:
- Claude single-file tools (`treeNodePathOf` call site)
- shell command refs (`toolFileRefsFromShellCommand`)
- Codex `file_change` (`contextTreeTargetPathOf`)

`localPath` keeps the tool's original spelling for evidence fidelity; relative tool paths keep the fail-safe null mapping (canonicalizing them against the daemon cwd would risk mis-attribution).

### 2. Tool coverage gaps

- `NotebookEdit` joins `CLAUDE_WRITE_TOOLS` (client + server), and notebook tools' `notebook_path` argument is recognized alongside `file_path` — previously `NotebookRead` was in the read set but could never produce a ref.
- `Grep` / `Glob` count as reads at **directory granularity**: the client emits one ref for the explicit `path` argument (search root), never one ref per matched file, so a recursive search cannot flood the feed. Calls without an explicit `path` carry no ref (fail-safe). This also removes the inconsistency where shell `grep`/`rg` counted as tree reads but the equivalent Grep tool did not.

## Validation

- `pnpm check` / `pnpm typecheck` clean
- client 1216/1216, server 1382/1382, shared 422/422
- New tests: symlinked-tree mapping in both directions (incl. Write of a not-yet-existing node), NotebookEdit via `notebook_path`, Grep/Glob directory- and repo-level refs, no-path fail-safe, Bash read through the symlink, server-side derivation for Grep/Glob/NotebookEdit

🤖 Generated with [Claude Code](https://claude.com/claude-code)