### PR TITLE
feat(web): drop Pages group from jump-to palette, rename Agents to Teammates

### DIFF
--- a/packages/web/src/__tests__/app-routes.test.tsx
+++ b/packages/web/src/__tests__/app-routes.test.tsx
@@ -72,6 +72,9 @@ vi.mock("../pages/agent-detail/profile-tab.js", () => ({ ProfileTab: () => <div>
 vi.mock("../pages/agent-detail/runtime-tab.js", () => ({ RuntimeTab: () => <div>runtime tab</div> }));
 vi.mock("../pages/agent-detail/prompt-tab.js", () => ({ PromptTab: () => <div>prompt tab</div> }));
 vi.mock("../pages/agent-detail/resources-tab.js", () => ({ ResourcesTab: () => <div>resources tab</div> }));
+vi.mock("../pages/command-palette-preview.js", () => ({
+  CommandPalettePreviewPage: () => <div>command palette preview</div>,
+}));
 vi.mock("../pages/styleguide-preview.js", () => ({ StyleguidePreviewPage: () => <div>styleguide preview</div> }));
 
 let root: Root | null = null;
@@ -139,5 +142,9 @@ describe("App routes", () => {
     document.body.innerHTML = "";
 
     expect(await renderAppAt("/preview/styleguide")).toContain("styleguide preview");
+    await act(async () => root?.unmount());
+    document.body.innerHTML = "";
+
+    expect(await renderAppAt("/preview/command-palette")).toContain("command palette preview");
   });
 });

--- a/packages/web/src/app.tsx
+++ b/packages/web/src/app.tsx
@@ -96,6 +96,12 @@ const AgentDetailPreviewPage = import.meta.env.DEV
   ? lazy(() => import("./pages/agent-detail-preview.js").then((module) => ({ default: module.AgentDetailPreviewPage })))
   : null;
 
+const CommandPalettePreviewPage = import.meta.env.DEV
+  ? lazy(() =>
+      import("./pages/command-palette-preview.js").then((module) => ({ default: module.CommandPalettePreviewPage })),
+    )
+  : null;
+
 // Living design-system reference (companion to DESIGN.md). Unlike the previews
 // above this ships in prod too, so it can be opened on a deployed URL — it has
 // no auth-gated data, only tokens and `components/ui` primitives.
@@ -174,6 +180,16 @@ export function App() {
                   element={
                     <Suspense fallback={null}>
                       <RequestDockPreviewPage />
+                    </Suspense>
+                  }
+                />
+              ) : null}
+              {CommandPalettePreviewPage ? (
+                <Route
+                  path="/preview/command-palette"
+                  element={
+                    <Suspense fallback={null}>
+                      <CommandPalettePreviewPage />
                     </Suspense>
                   }
                 />

--- a/packages/web/src/components/ui/command.tsx
+++ b/packages/web/src/components/ui/command.tsx
@@ -97,7 +97,12 @@ const CommandItem = forwardRef<HTMLDivElement, ComponentPropsWithoutRef<typeof C
     <CommandPrimitive.Item
       ref={ref}
       className={cn(
-        "relative flex cursor-default select-none items-center rounded-[var(--radius-input)] px-2 py-1.5 text-body outline-none aria-selected:bg-accent aria-selected:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+        // `data-[disabled=true]`, NOT `data-[disabled]`: cmdk ≥1.0 sets
+        // `data-disabled="false"` on every enabled item (the attribute is
+        // always present), so the presence-matching selector dimmed the
+        // whole list to 50% opacity. Value-matching is the upstream
+        // shadcn/ui fix for the same bug.
+        "relative flex cursor-default select-none items-center rounded-[var(--radius-input)] px-2 py-1.5 text-body outline-none aria-selected:bg-accent aria-selected:text-accent-foreground data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50",
         className,
       )}
       {...props}

--- a/packages/web/src/lib/use-org-agents.ts
+++ b/packages/web/src/lib/use-org-agents.ts
@@ -32,12 +32,13 @@ type PaginatedAgents = Awaited<ReturnType<typeof listAgents>>;
  * above that threshold reach agents past the first page via
  * {@link useOrgAgentsSearch} (issue 494).
  */
-export function useOrgAgents(): UseQueryResult<PaginatedAgents> {
+export function useOrgAgents(options?: { enabled?: boolean }): UseQueryResult<PaginatedAgents> {
   return useQuery({
     queryKey: ["agents", "org-list"],
     queryFn: () => listAgents({ limit: 100 }),
     refetchInterval: 30_000,
     staleTime: 30_000,
+    enabled: options?.enabled ?? true,
   });
 }
 

--- a/packages/web/src/pages/command-palette-preview.tsx
+++ b/packages/web/src/pages/command-palette-preview.tsx
@@ -1,0 +1,223 @@
+import type { Agent, MeChatRow } from "@first-tree/shared";
+import { useState } from "react";
+import { CommandPalette } from "./workspace/palette/command-palette.js";
+
+/**
+ * DEV-only visual review for the Workspace topbar CommandPalette.
+ *
+ * This preview injects fixed data into the production palette component so UI
+ * review does not depend on staging having enough chats or teammates. It is
+ * registered only behind `import.meta.env.DEV` in `app.tsx`.
+ */
+
+const SELF_ID = "preview-human";
+
+function minutesAgo(minutes: number): string {
+  return new Date(Date.now() - minutes * 60_000).toISOString();
+}
+
+function teammate(overrides: Partial<Agent>): Agent {
+  return {
+    uuid: overrides.uuid ?? "preview-agent",
+    name: overrides.name ?? "preview",
+    displayName: overrides.displayName ?? "Preview Agent",
+    type: overrides.type ?? "agent",
+    managerId: overrides.managerId ?? "preview-member",
+    visibility: overrides.visibility ?? "organization",
+    avatarColorToken: overrides.avatarColorToken ?? null,
+    avatarImageUrl: overrides.avatarImageUrl ?? null,
+    status: overrides.status ?? "active",
+    organizationId: overrides.organizationId ?? "preview-org",
+    delegateMention: overrides.delegateMention ?? null,
+    inboxId: overrides.inboxId ?? `${overrides.uuid ?? "preview-agent"}-inbox`,
+    metadata: overrides.metadata ?? {},
+    source: overrides.source ?? "portal",
+    clientId: overrides.clientId ?? null,
+    runtimeProvider: overrides.runtimeProvider ?? "claude-code",
+    runtimeState: overrides.runtimeState ?? "idle",
+    createdAt: overrides.createdAt ?? minutesAgo(10_000),
+    updatedAt: overrides.updatedAt ?? minutesAgo(12),
+  };
+}
+
+const TEAMMATES: Agent[] = [
+  teammate({ uuid: SELF_ID, name: "gandy", displayName: "Gandy", type: "human" }),
+  teammate({ uuid: "agent-codex", name: "gandy-coder", displayName: "gandy-coder", runtimeProvider: "codex" }),
+  teammate({ uuid: "agent-claude", name: "gandy-assistant", displayName: "gandy-assistant" }),
+  teammate({ uuid: "agent-design", name: "design-review", displayName: "Design Review" }),
+  teammate({ uuid: "agent-release", name: "release-captain", displayName: "Release Captain" }),
+  teammate({ uuid: "agent-docs", name: "docs-writer", displayName: "Docs Writer" }),
+  teammate({ uuid: "agent-qa", name: "qa-runner", displayName: "QA Runner" }),
+  teammate({ uuid: "agent-research", name: "research", displayName: "Research" }),
+];
+
+function participant(agent: Agent): MeChatRow["participants"][number] {
+  return {
+    agentId: agent.uuid,
+    displayName: agent.displayName,
+    type: agent.type === "human" ? "human" : "agent",
+    avatarColorToken: agent.avatarColorToken,
+    avatarImageUrl: agent.avatarImageUrl,
+  };
+}
+
+const SELF = participant(TEAMMATES[0] ?? teammate({ uuid: SELF_ID }));
+const CODER = participant(TEAMMATES[1] ?? teammate({ uuid: "agent-codex" }));
+const ASSISTANT = participant(TEAMMATES[2] ?? teammate({ uuid: "agent-claude" }));
+const DESIGN = participant(TEAMMATES[3] ?? teammate({ uuid: "agent-design" }));
+const RELEASE = participant(TEAMMATES[4] ?? teammate({ uuid: "agent-release" }));
+const DOCS = participant(TEAMMATES[5] ?? teammate({ uuid: "agent-docs" }));
+const QA = participant(TEAMMATES[6] ?? teammate({ uuid: "agent-qa" }));
+const RESEARCH = participant(TEAMMATES[7] ?? teammate({ uuid: "agent-research" }));
+
+function chat(overrides: Partial<MeChatRow>): MeChatRow {
+  const participants = overrides.participants ?? [SELF, CODER];
+  return {
+    chatId: overrides.chatId ?? "preview-chat",
+    type: overrides.type ?? (participants.length > 2 ? "group" : "direct"),
+    membershipKind: overrides.membershipKind ?? "participant",
+    createdByMe: overrides.createdByMe ?? false,
+    source: overrides.source ?? "manual",
+    entityType: overrides.entityType ?? null,
+    title: overrides.title ?? "Preview chat",
+    topic: overrides.topic ?? null,
+    description: overrides.description ?? null,
+    participants,
+    participantCount: overrides.participantCount ?? participants.length,
+    lastMessageAt: "lastMessageAt" in overrides ? (overrides.lastMessageAt ?? null) : minutesAgo(5),
+    lastMessagePreview: overrides.lastMessagePreview ?? null,
+    unreadMentionCount: overrides.unreadMentionCount ?? 0,
+    openRequestCount: overrides.openRequestCount ?? 0,
+    canReply: overrides.canReply ?? true,
+    engagementStatus: overrides.engagementStatus ?? "active",
+    liveActivity: overrides.liveActivity ?? null,
+    failedAgentIds: overrides.failedAgentIds ?? [],
+    busyAgentIds: overrides.busyAgentIds ?? [],
+    chatHasExplicitMentionToMe: overrides.chatHasExplicitMentionToMe ?? false,
+  };
+}
+
+const CHATS: MeChatRow[] = [
+  chat({
+    chatId: "preview-jump-palette",
+    title: "Jump to palette polish",
+    topic: "Jump to palette polish",
+    description: "semantic fixture search target: palette density, teammate roster, archived chip, and recents",
+    participants: [SELF, CODER, DESIGN],
+    lastMessageAt: minutesAgo(2),
+  }),
+  chat({
+    chatId: "preview-ask-user",
+    title: "Ask-user dialog review",
+    participants: [SELF, ASSISTANT],
+    lastMessageAt: minutesAgo(7),
+  }),
+  chat({
+    chatId: "preview-release",
+    title: "Release train",
+    participants: [SELF, RELEASE, QA],
+    lastMessageAt: minutesAgo(18),
+  }),
+  chat({
+    chatId: "preview-docs",
+    title: "Docs and tree sync",
+    participants: [SELF, DOCS, RESEARCH],
+    lastMessageAt: minutesAgo(41),
+  }),
+  chat({
+    chatId: "preview-archived",
+    title: "Archived onboarding audit",
+    engagementStatus: "archived",
+    participants: [SELF, ASSISTANT],
+    lastMessageAt: minutesAgo(83),
+  }),
+  chat({
+    chatId: "preview-long-title",
+    title: "A very long workspace topic that should truncate cleanly inside a compact command row",
+    participants: [SELF, DESIGN],
+    lastMessageAt: minutesAgo(110),
+  }),
+  chat({
+    chatId: "preview-untitled",
+    title: "",
+    topic: null,
+    participants: [SELF, QA],
+    lastMessageAt: minutesAgo(160),
+  }),
+  chat({
+    chatId: "preview-github",
+    title: "Command palette follow-up review",
+    source: "github",
+    entityType: "pull_request",
+    participants: [SELF, CODER],
+    lastMessageAt: minutesAgo(230),
+  }),
+  chat({
+    chatId: "preview-cap-rover",
+    title: "CapRover feedback route",
+    participants: [SELF, RESEARCH],
+    lastMessageAt: minutesAgo(300),
+  }),
+  chat({
+    chatId: "preview-runtime",
+    title: "Runtime status cards",
+    participants: [SELF, ASSISTANT],
+    lastMessageAt: minutesAgo(390),
+  }),
+  chat({
+    chatId: "preview-agent-copy",
+    title: "Agent profile copy pass",
+    participants: [SELF, DOCS],
+    lastMessageAt: minutesAgo(520),
+  }),
+  chat({
+    chatId: "preview-context-feed",
+    title: "Context feed skip reasons",
+    participants: [SELF, RESEARCH],
+    lastMessageAt: minutesAgo(720),
+  }),
+  chat({
+    chatId: "preview-old-1",
+    title: "Old branch cleanup",
+    participants: [SELF, RELEASE],
+    lastMessageAt: minutesAgo(1_020),
+  }),
+  chat({
+    chatId: "preview-old-2",
+    title: "Design token audit",
+    participants: [SELF, DESIGN],
+    lastMessageAt: minutesAgo(1_600),
+  }),
+  chat({
+    chatId: "preview-old-3",
+    title: "Search backend backlog",
+    participants: [SELF, CODER],
+    lastMessageAt: minutesAgo(2_400),
+  }),
+  chat({ chatId: "preview-never", title: "Never messaged seed", participants: [SELF, QA], lastMessageAt: null }),
+];
+
+export function CommandPalettePreviewPage() {
+  const [open, setOpen] = useState(true);
+
+  return (
+    <div className="min-h-screen bg-background p-8 text-foreground">
+      <div className="mx-auto flex max-w-3xl flex-col gap-4">
+        <div>
+          <h1 className="text-title font-semibold">Command palette preview</h1>
+          <p className="text-body text-muted-foreground mt-2">
+            DEV fixture route. The palette uses fixed local chats and teammates, not staging data.
+          </p>
+        </div>
+        <button
+          type="button"
+          className="w-fit rounded-[var(--radius-input)] bg-primary px-3 py-2 text-body text-primary-foreground"
+          onClick={() => setOpen(true)}
+        >
+          Open palette
+        </button>
+      </div>
+      <CommandPalette open={open} onOpenChange={setOpen} demoData={{ chats: CHATS, agents: TEAMMATES }} />
+    </div>
+  );
+}

--- a/packages/web/src/pages/workspace/palette/__tests__/command-palette-dom.test.tsx
+++ b/packages/web/src/pages/workspace/palette/__tests__/command-palette-dom.test.tsx
@@ -359,4 +359,43 @@ describe("CommandPalette", () => {
 
     await act(async () => root.unmount());
   });
+
+  it("renders injected demo data without fetching live chats", async () => {
+    orgAgentsMock.value = { items: [], nextCursor: null };
+
+    const { CommandPalette } = await import("../command-palette.js");
+    const { root } = await renderDom(
+      <CommandPalette
+        open
+        onOpenChange={vi.fn()}
+        demoData={{
+          chats: [
+            chatRow({ chatId: "demo-new", title: "Demo newest", lastMessageAt: "2026-05-28T12:00:00.000Z" }),
+            chatRow({
+              chatId: "demo-archived",
+              title: "Archived audit trail",
+              engagementStatus: "archived",
+              lastMessageAt: "2026-05-27T12:00:00.000Z",
+            }),
+          ],
+          agents: [
+            agent({ uuid: "demo-agent-a", name: "maya", displayName: "Maya Chen" }),
+            agent({ uuid: "demo-agent-b", name: "ops", displayName: "Ops Reviewer" }),
+          ],
+        }}
+      />,
+    );
+
+    await waitForText(document.body, "Demo newest");
+
+    expect(meChatMocks.listMeChats).not.toHaveBeenCalled();
+    expect(document.body.textContent).toContain("Recent");
+    expect(document.body.textContent).toContain("Archived audit trail");
+    expect(document.body.textContent).toContain("Archived");
+    expect(document.body.textContent).toContain("Teammates");
+    expect(document.body.textContent).toContain("Maya Chen");
+    expect(document.body.textContent).toContain("Ops Reviewer");
+
+    await act(async () => root.unmount());
+  });
 });

--- a/packages/web/src/pages/workspace/palette/__tests__/command-palette-dom.test.tsx
+++ b/packages/web/src/pages/workspace/palette/__tests__/command-palette-dom.test.tsx
@@ -211,6 +211,14 @@ describe("CommandPalette", () => {
     expect(document.body.textContent).not.toContain("Pages");
     expect(document.body.textContent).not.toContain("Workspace");
 
+    // Regression: cmdk ≥1.0 puts `data-disabled="false"` on every enabled
+    // item, so the disabled dim must use the value-matching selector — the
+    // presence-matching form (`data-[disabled]:`) grayed out the whole list.
+    const anyItem = commandItemByText(document.body, "Launch planning");
+    expect(anyItem?.getAttribute("data-disabled")).toBe("false");
+    expect(anyItem?.className).toContain("data-[disabled=true]:opacity-50");
+    expect(anyItem?.className).not.toMatch(/data-\[disabled\]:/);
+
     await click(commandItemByText(document.body, "Launch planning"));
     expect(onOpenChange).toHaveBeenLastCalledWith(false);
     expect(routerMocks.navigate).toHaveBeenLastCalledWith("/?c=chat-123456789");

--- a/packages/web/src/pages/workspace/palette/__tests__/command-palette-dom.test.tsx
+++ b/packages/web/src/pages/workspace/palette/__tests__/command-palette-dom.test.tsx
@@ -19,6 +19,7 @@ const routerMocks = vi.hoisted(() => ({
 
 const orgAgentsMock = vi.hoisted(() => ({
   value: { items: [] as Agent[], nextCursor: null as string | null },
+  isLoading: false,
 }));
 
 vi.mock("../../../../api/me-chats.js", () => meChatMocks);
@@ -32,7 +33,7 @@ vi.mock("../../../../lib/use-agent-name-map.js", () => ({
 }));
 
 vi.mock("../../../../lib/use-org-agents.js", () => ({
-  useOrgAgents: () => ({ data: orgAgentsMock.value }),
+  useOrgAgents: () => ({ data: orgAgentsMock.value, isLoading: orgAgentsMock.isLoading }),
 }));
 
 vi.mock("react-router", async (importOriginal) => ({
@@ -174,6 +175,7 @@ beforeEach(() => {
     items: [agent(), agent({ uuid: "agent-2", name: null, displayName: "No Handle" })],
     nextCursor: null,
   };
+  orgAgentsMock.isLoading = false;
   meChatMocks.listMeChats.mockResolvedValue({
     rows: [chatRow(), chatRow({ chatId: "chat-untitled", title: "", topic: null })],
     nextCursor: null,
@@ -328,6 +330,32 @@ describe("CommandPalette", () => {
 
     expect(document.body.querySelectorAll("[cmdk-item]")).toHaveLength(0);
     expect(meChatMocks.listMeChats).not.toHaveBeenCalled();
+
+    await act(async () => root.unmount());
+  });
+
+  it("does not show the empty state while chat results are still loading", async () => {
+    orgAgentsMock.value = { items: [], nextCursor: null };
+    meChatMocks.listMeChats.mockReturnValue(new Promise(() => undefined));
+
+    const { CommandPalette } = await import("../command-palette.js");
+    const { root } = await renderDom(<CommandPalette open onOpenChange={vi.fn()} />);
+
+    expect(document.body.textContent).not.toContain("No results");
+    expect(document.body.querySelector(".animate-pulse")).not.toBeNull();
+
+    await act(async () => root.unmount());
+  });
+
+  it("does not show the empty state while teammates are still loading", async () => {
+    orgAgentsMock.value = { items: [], nextCursor: null };
+    orgAgentsMock.isLoading = true;
+    meChatMocks.listMeChats.mockResolvedValue({ rows: [], nextCursor: null });
+
+    const { CommandPalette } = await import("../command-palette.js");
+    const { root } = await renderDom(<CommandPalette open onOpenChange={vi.fn()} />);
+
+    expect(document.body.textContent).not.toContain("No results");
 
     await act(async () => root.unmount());
   });

--- a/packages/web/src/pages/workspace/palette/__tests__/command-palette-dom.test.tsx
+++ b/packages/web/src/pages/workspace/palette/__tests__/command-palette-dom.test.tsx
@@ -186,7 +186,7 @@ afterEach(() => {
 });
 
 describe("CommandPalette", () => {
-  it("fetches open-only data while visible and navigates from chat, agent, and page items", async () => {
+  it("fetches open-only data while visible and navigates from chat and teammate items", async () => {
     const onOpenChange = vi.fn();
     const { CommandPalette } = await import("../command-palette.js");
     const { root } = await renderDom(<CommandPalette open onOpenChange={onOpenChange} />);
@@ -195,7 +195,6 @@ describe("CommandPalette", () => {
     await waitForText(document.body, "(untitled)");
     await waitForText(document.body, "Nova");
     await waitForText(document.body, "No Handle");
-    await waitForText(document.body, "Workspace");
 
     expect(meChatMocks.listMeChats).toHaveBeenCalledWith({ limit: 100, engagement: "all" });
 
@@ -205,15 +204,19 @@ describe("CommandPalette", () => {
     expect(document.body.textContent).not.toContain("Release train");
     expect(document.body.textContent).not.toContain("chat-123");
 
+    // The roster group is "Teammates" (humans + agents), and the static
+    // "Pages" group is gone — both by design.
+    expect(document.body.textContent).toContain("Teammates");
+    expect(document.body.textContent).not.toContain("Agents");
+    expect(document.body.textContent).not.toContain("Pages");
+    expect(document.body.textContent).not.toContain("Workspace");
+
     await click(commandItemByText(document.body, "Launch planning"));
     expect(onOpenChange).toHaveBeenLastCalledWith(false);
     expect(routerMocks.navigate).toHaveBeenLastCalledWith("/?c=chat-123456789");
 
     await click(commandItemByText(document.body, "Nova"));
     expect(routerMocks.navigate).toHaveBeenLastCalledWith("/agents/agent-1/profile");
-
-    await click(commandItemByText(document.body, "Settings"));
-    expect(routerMocks.navigate).toHaveBeenLastCalledWith("/settings");
 
     await act(async () => root.unmount());
   });
@@ -308,14 +311,14 @@ describe("CommandPalette", () => {
     await act(async () => root.unmount());
   });
 
-  it("keeps async palette queries disabled while closed and still renders static pages", async () => {
+  it("keeps async palette queries disabled while closed and renders nothing", async () => {
     orgAgentsMock.value = { items: [], nextCursor: null };
     meChatMocks.listMeChats.mockResolvedValue({ rows: [], nextCursor: null });
 
     const { CommandPalette } = await import("../command-palette.js");
     const { root } = await renderDom(<CommandPalette open={false} onOpenChange={vi.fn()} />);
 
-    expect(document.body.textContent).not.toContain("Workspace");
+    expect(document.body.querySelectorAll("[cmdk-item]")).toHaveLength(0);
     expect(meChatMocks.listMeChats).not.toHaveBeenCalled();
 
     await act(async () => root.unmount());

--- a/packages/web/src/pages/workspace/palette/command-palette.tsx
+++ b/packages/web/src/pages/workspace/palette/command-palette.tsx
@@ -1,4 +1,4 @@
-import type { MeChatRow } from "@first-tree/shared";
+import type { Agent, MeChatRow } from "@first-tree/shared";
 import { useQuery } from "@tanstack/react-query";
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router";
@@ -32,6 +32,11 @@ const RECENT_CHAT_LIMIT = 12;
  *  conversation rail's default disc. */
 const ROW_AVATAR_SIZE = 24;
 
+type CommandPaletteDemoData = {
+  chats: MeChatRow[];
+  agents: Agent[];
+};
+
 /**
  * Topbar "Jump to…" palette.
  *
@@ -51,7 +56,16 @@ const ROW_AVATAR_SIZE = 24;
  * above `keywords` matches, so a title hit ranks ahead of a
  * participant-name hit without any custom filter.
  */
-export function CommandPalette({ open, onOpenChange }: { open: boolean; onOpenChange: (open: boolean) => void }) {
+export function CommandPalette({
+  open,
+  onOpenChange,
+  demoData,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** DEV preview injection. Production callers leave this undefined. */
+  demoData?: CommandPaletteDemoData;
+}) {
   const navigate = useNavigate();
   const { agentId: selfAgentId } = useAuth();
 
@@ -63,10 +77,10 @@ export function CommandPalette({ open, onOpenChange }: { open: boolean; onOpenCh
     if (!open) setSearch("");
   }, [open]);
 
-  const { data: orgAgents, isLoading: agentsLoading } = useOrgAgents();
-  const agents = orgAgents?.items ?? [];
+  const { data: orgAgents, isLoading: orgAgentsLoading } = useOrgAgents({ enabled: demoData === undefined });
+  const agents = demoData?.agents ?? orgAgents?.items ?? [];
 
-  const { data: chatsResp, isLoading: chatsLoading } = useQuery({
+  const { data: chatsResp, isLoading: queryChatsLoading } = useQuery({
     // Prefix-aligned with conversations-page invalidations
     // (`["me", "chats"]` is the family every chat mutation invalidates —
     // new-chat-draft, row-engagement-menu, etc.) so creating / archiving
@@ -78,22 +92,24 @@ export function CommandPalette({ open, onOpenChange }: { open: boolean; onOpenCh
     // an old conversation is a common reason to open the palette.
     queryKey: ["me", "chats", "palette"],
     queryFn: () => listMeChats({ limit: 100, engagement: "all" }),
-    enabled: open,
+    enabled: open && demoData === undefined,
     staleTime: 30_000,
   });
+  const chatsLoading = demoData === undefined && queryChatsLoading;
+  const agentsLoading = demoData === undefined && orgAgentsLoading;
 
   // Most-recently-active first, regardless of the API's order — recency
   // is the palette's organizing principle (jump back to live work).
   // Never-messaged chats (null lastMessageAt) sink to the end.
   const chats = useMemo(() => {
-    const rows = chatsResp?.rows ?? [];
+    const rows = demoData?.chats ?? chatsResp?.rows ?? [];
     return [...rows].sort((a, b) => {
       if (a.lastMessageAt === b.lastMessageAt) return 0;
       if (a.lastMessageAt === null) return 1;
       if (b.lastMessageAt === null) return -1;
       return a.lastMessageAt < b.lastMessageAt ? 1 : -1;
     });
-  }, [chatsResp]);
+  }, [chatsResp, demoData]);
 
   const browsing = search.trim().length === 0;
   const visibleChats = browsing ? chats.slice(0, RECENT_CHAT_LIMIT) : chats;

--- a/packages/web/src/pages/workspace/palette/command-palette.tsx
+++ b/packages/web/src/pages/workspace/palette/command-palette.tsx
@@ -63,7 +63,7 @@ export function CommandPalette({ open, onOpenChange }: { open: boolean; onOpenCh
     if (!open) setSearch("");
   }, [open]);
 
-  const { data: orgAgents } = useOrgAgents();
+  const { data: orgAgents, isLoading: agentsLoading } = useOrgAgents();
   const agents = orgAgents?.items ?? [];
 
   const { data: chatsResp, isLoading: chatsLoading } = useQuery({
@@ -97,6 +97,7 @@ export function CommandPalette({ open, onOpenChange }: { open: boolean; onOpenCh
 
   const browsing = search.trim().length === 0;
   const visibleChats = browsing ? chats.slice(0, RECENT_CHAT_LIMIT) : chats;
+  const paletteLoading = chatsLoading || agentsLoading;
 
   const go = (url: string) => {
     onOpenChange(false);
@@ -107,7 +108,7 @@ export function CommandPalette({ open, onOpenChange }: { open: boolean; onOpenCh
     <CommandDialog open={open} onOpenChange={onOpenChange}>
       <CommandInput placeholder="Jump to chat or teammate…" value={search} onValueChange={setSearch} />
       <CommandList>
-        <CommandEmpty>No results</CommandEmpty>
+        {!paletteLoading && <CommandEmpty>No results</CommandEmpty>}
 
         {chatsLoading && (
           <CommandLoading>

--- a/packages/web/src/pages/workspace/palette/command-palette.tsx
+++ b/packages/web/src/pages/workspace/palette/command-palette.tsx
@@ -1,6 +1,5 @@
 import type { MeChatRow } from "@first-tree/shared";
 import { useQuery } from "@tanstack/react-query";
-import { LayoutDashboard } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router";
 import { listMeChats } from "../../../api/me-chats.js";
@@ -19,13 +18,6 @@ import {
 } from "../../../components/ui/command.js";
 import { useOrgAgents } from "../../../lib/use-org-agents.js";
 import { formatRowTime } from "../../../lib/utils.js";
-
-const STATIC_ROUTES = [
-  { path: "/", label: "Workspace" },
-  { path: "/context", label: "Context" },
-  { path: "/team", label: "Team" },
-  { path: "/settings", label: "Settings" },
-];
 
 /**
  * Empty-query chat count. With no query the palette is a "go back to
@@ -48,8 +40,9 @@ const ROW_AVATAR_SIZE = 24;
  *   - Chats: `/me/chats` (default engagement, server-paged). Replaces the
  *     prior per-agent `/agents/:uuid/sessions` fan-out, which issued one
  *     request per managed agent.
- *   - Agents: `useOrgAgents` (`/agents?limit=100`), the same cache used by
- *     the participant picker and identity maps.
+ *   - Teammates: `useOrgAgents` (`/agents?limit=100`, no type filter — the
+ *     roster carries human members and agents alike), the same cache used
+ *     by the participant picker and identity maps.
  *
  * Filtering is handled by `cmdk`. Each item splits its searchable text
  * between `value` (primary identity: visible title + a uniquifying id —
@@ -112,7 +105,7 @@ export function CommandPalette({ open, onOpenChange }: { open: boolean; onOpenCh
 
   return (
     <CommandDialog open={open} onOpenChange={onOpenChange}>
-      <CommandInput placeholder="Jump to chat or agent…" value={search} onValueChange={setSearch} />
+      <CommandInput placeholder="Jump to chat or teammate…" value={search} onValueChange={setSearch} />
       <CommandList>
         <CommandEmpty>No results</CommandEmpty>
 
@@ -139,8 +132,10 @@ export function CommandPalette({ open, onOpenChange }: { open: boolean; onOpenCh
 
         {agents.length > 0 && (
           <>
-            <CommandSeparator />
-            <CommandGroup heading="Agents">
+            {visibleChats.length > 0 && <CommandSeparator />}
+            {/* "Teammates", not "Agents" — the unfiltered roster carries
+                human members and agents alike, and both are jumpable. */}
+            <CommandGroup heading="Teammates">
               {agents.map((a) => (
                 <CommandItem
                   key={a.uuid}
@@ -163,16 +158,6 @@ export function CommandPalette({ open, onOpenChange }: { open: boolean; onOpenCh
             </CommandGroup>
           </>
         )}
-
-        <CommandSeparator />
-        <CommandGroup heading="Pages">
-          {STATIC_ROUTES.map((r) => (
-            <CommandItem key={r.path} value={r.label} onSelect={() => go(r.path)}>
-              <LayoutDashboard className="mr-2 h-4 w-4 shrink-0 opacity-70" />
-              <span>{r.label}</span>
-            </CommandItem>
-          ))}
-        </CommandGroup>
       </CommandList>
       <div className="text-caption text-muted-foreground flex items-center gap-3 border-t px-3 py-1.5">
         <KeyHint keys="↑↓" label="navigate" />


### PR DESCRIPTION
Follow-up to #1005 from user feedback.

## Changes

- **Pages group removed.** The static four rows (Workspace / Context / Team / Settings) duplicated the topbar tabs that are always visible one click away — they earned their palette rows in no real jump.
- **Agents → Teammates.** `/agents` without a type filter returns human members and agents alike (humans are first-class rows in the agents table), so the "Agents" heading mislabeled half its content. Clicking a human row already works — `/agents/:uuid/profile` handles humans (agent-only tabs redirect to profile).
- Input placeholder follows: "Jump to chat or teammate…".
- The chats/teammates separator now renders only when both groups are visible (no leading separator when the chat list is empty).

## Tests

Updated palette DOM tests: Teammates heading asserted, Pages/Workspace absence asserted, page-navigation case removed. Web suite 103 files / 783 tests green; check + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)