### PR TITLE
feat(chat): readable open-question prompts — markdown + clamp, --subject, question caps, clearer selection

### DIFF
--- a/apps/cli/src/__tests__/chat-attention-commands-extra.test.ts
+++ b/apps/cli/src/__tests__/chat-attention-commands-extra.test.ts
@@ -282,6 +282,8 @@ describe("chat command behavior", () => {
       "--agent",
       "worker",
       "--request",
+      "--subject",
+      "Rollout gate",
       "--question",
       "Ship to 20%?",
       "--option",
@@ -299,6 +301,7 @@ describe("chat command behavior", () => {
           content: "stdin message",
           metadata: {
             request: {
+              subject: "Rollout gate",
               questions: [
                 {
                   id: "q1",
@@ -322,6 +325,12 @@ describe("chat command behavior", () => {
       code: "REQUEST_NEEDS_QUESTION",
       exitCode: 2,
     });
+    await expect(
+      runChat(["create", "body", "--request", "--to", "nova", "--question", "x".repeat(201)]),
+    ).rejects.toMatchObject({ code: "QUESTION_TOO_LONG", exitCode: 2 });
+    await expect(
+      runChat(["create", "body", "--request", "--to", "nova", "--subject", "s".repeat(81), "--question", "Ship?"]),
+    ).rejects.toMatchObject({ code: "SUBJECT_TOO_LONG", exitCode: 2 });
   });
 
   it("validates chat create input and treats uncertain create outcomes as non-retryable", async () => {

--- a/apps/cli/src/__tests__/chat-attention-commands-extra.test.ts
+++ b/apps/cli/src/__tests__/chat-attention-commands-extra.test.ts
@@ -188,6 +188,44 @@ describe("chat command behavior", () => {
     });
   });
 
+  it("passes --subject through as the request's dock/card headline", async () => {
+    const sdk = localAgentMocks.createSdk();
+    await runChat([
+      "send",
+      "nova",
+      "Rollout is at 5% and error rate is flat for 24h.",
+      "--request",
+      "--subject",
+      "Rollout gate",
+      "--question",
+      "Ship to 20%?",
+      "--option",
+      "yes",
+    ]);
+
+    expect(sdk.sendMessage).toHaveBeenCalledWith(
+      "chat-env",
+      expect.objectContaining({
+        format: "request",
+        metadata: expect.objectContaining({
+          request: expect.objectContaining({ subject: "Rollout gate" }),
+        }),
+      }),
+    );
+  });
+
+  it("rejects an over-long --question — the wall of text belongs in the body", async () => {
+    await expect(
+      runChat(["send", "nova", "body context", "--request", "--question", "x".repeat(201)]),
+    ).rejects.toMatchObject({ code: "QUESTION_TOO_LONG", exitCode: 2 });
+  });
+
+  it("rejects an over-long --subject — it is a headline, not a summary", async () => {
+    await expect(
+      runChat(["send", "nova", "body context", "--request", "--subject", "s".repeat(81), "--question", "Ship?"]),
+    ).rejects.toMatchObject({ code: "SUBJECT_TOO_LONG", exitCode: 2 });
+  });
+
   it("creates task chats with first-message routing and silent context participants", async () => {
     docCaptureMock.captureOutboundDocs.mockResolvedValueOnce({
       content: "see docs/plan.md",

--- a/apps/cli/src/commands/chat/_shared/request.ts
+++ b/apps/cli/src/commands/chat/_shared/request.ts
@@ -1,0 +1,59 @@
+import { fail } from "../../../cli/output.js";
+
+/**
+ * Hard caps on the structured ask. `--question` is the short ask the web pins
+ * above the composer (RequestDock); `--subject` is its headline. Background
+ * and context belong in the message body, which renders as markdown in the
+ * request card.
+ */
+export const REQUEST_QUESTION_MAX_CHARS = 200;
+export const REQUEST_SUBJECT_MAX_CHARS = 80;
+
+export type RequestCliOptions = {
+  subject?: string;
+  question?: string;
+  option?: string[];
+};
+
+export function buildRequestMetadata(
+  metadata: Record<string, unknown> | undefined,
+  options: RequestCliOptions,
+): Record<string, unknown> {
+  if (!options.question) {
+    fail("REQUEST_NEEDS_QUESTION", "--request needs --question <text>.", 2);
+  }
+  if (options.question.length > REQUEST_QUESTION_MAX_CHARS) {
+    fail(
+      "QUESTION_TOO_LONG",
+      `--question must stay a short ask (≤${REQUEST_QUESTION_MAX_CHARS} chars, got ${options.question.length}). ` +
+        "Move the background/context into the message body — it renders as the request card's markdown body; " +
+        "the question is pinned verbatim above the composer.",
+      2,
+    );
+  }
+  if (options.subject && options.subject.length > REQUEST_SUBJECT_MAX_CHARS) {
+    fail(
+      "SUBJECT_TOO_LONG",
+      `--subject is a headline (≤${REQUEST_SUBJECT_MAX_CHARS} chars, got ${options.subject.length}). ` +
+        "Keep it to a few words; details belong in the body or --question.",
+      2,
+    );
+  }
+
+  const opts = options.option ?? [];
+  return {
+    ...(metadata ?? {}),
+    request: {
+      ...(options.subject ? { subject: options.subject } : {}),
+      questions: [
+        {
+          id: "q1",
+          prompt: options.question,
+          kind: opts.length > 0 ? "single" : "free",
+          options: opts,
+          required: true,
+        },
+      ],
+    },
+  };
+}

--- a/apps/cli/src/commands/chat/create.ts
+++ b/apps/cli/src/commands/chat/create.ts
@@ -5,6 +5,7 @@ import { fail, success } from "../../cli/output.js";
 import { captureOutboundDocs } from "../../core/doc-capture.js";
 import { createSdk, handleSdkError } from "../_shared/local-agent.js";
 import { readStdin } from "./_shared/io.js";
+import { buildRequestMetadata } from "./_shared/request.js";
 
 interface CreateOptions {
   to: string[];
@@ -15,6 +16,7 @@ interface CreateOptions {
   metadata?: string;
   agent?: string;
   request?: boolean;
+  subject?: string;
   question?: string;
   option?: string[];
 }
@@ -91,7 +93,11 @@ export function registerChatCreateCommand(chat: Command): void {
       "--request",
       "Create the task with an open question. Requires exactly one --to recipient; the message body is context.",
     )
-    .option("--question <text>", "The question prompt — just the ask, no background (with --request)")
+    .option(
+      "--subject <text>",
+      "Short headline for the request, shown in the answer dock/card header (with --request, ≤80 chars)",
+    )
+    .option("--question <text>", "The question prompt — just the ask, no background (with --request, ≤200 chars)")
     .option("--option <opt>", "An answer option for the question; repeatable (with --request)", collect, [])
     .action(async (message: string | undefined, options: CreateOptions) => {
       try {
@@ -119,25 +125,8 @@ export function registerChatCreateCommand(chat: Command): void {
           if (to.length !== 1) {
             fail("REQUEST_NEEDS_ONE_TARGET", "--request task creation requires exactly one --to recipient.", 2);
           }
-          if (!options.question) {
-            fail("REQUEST_NEEDS_QUESTION", "--request needs --question <text>.", 2);
-          }
-          const opts = options.option ?? [];
           format = "request";
-          metadata = {
-            ...(metadata ?? {}),
-            request: {
-              questions: [
-                {
-                  id: "q1",
-                  prompt: options.question,
-                  kind: opts.length > 0 ? "single" : "free",
-                  options: opts,
-                  required: true,
-                },
-              ],
-            },
-          };
+          metadata = buildRequestMetadata(metadata, options);
         }
 
         const sdk = createSdk(options.agent);

--- a/apps/cli/src/commands/chat/send.ts
+++ b/apps/cli/src/commands/chat/send.ts
@@ -10,12 +10,24 @@ interface SendOptions {
   metadata?: string;
   agent?: string;
   request?: boolean;
+  subject?: string;
   question?: string;
   option?: string[];
   replyTo?: string;
   answer?: string;
   close?: string;
 }
+
+/**
+ * Hard caps on the structured ask. `--question` is the ONE-LINE ask the web
+ * pins above the composer (RequestDock); `--subject` is its headline. The
+ * background/context belongs in the message body, which renders as the
+ * request card's full markdown body. The caps exist because agents otherwise
+ * cram the whole context into `--question`, producing an unreadable wall in
+ * the dock.
+ */
+const REQUEST_QUESTION_MAX_CHARS = 200;
+const REQUEST_SUBJECT_MAX_CHARS = 80;
 
 /** Commander collector for a repeatable flag (`--option a --option b`). */
 function collectOption(value: string, previous: string[]): string[] {
@@ -39,7 +51,11 @@ export function registerChatSendCommand(chat: Command): void {
       "Send as an open question (format=request) directed at a single human <name>. The message body carries the " +
         "background/context; --question carries only the ask",
     )
-    .option("--question <text>", "The question prompt — just the ask, no background (with --request)")
+    .option(
+      "--subject <text>",
+      "Short headline for the request, shown in the answer dock/card header (with --request, ≤80 chars)",
+    )
+    .option("--question <text>", "The question prompt — just the ask, no background (with --request, ≤200 chars)")
     .option("--option <opt>", "An answer option for the question; repeatable (with --request)", collectOption, [])
     .option(
       "--answer <requestId>",
@@ -116,11 +132,29 @@ export function registerChatSendCommand(chat: Command): void {
           if (!options.question) {
             fail("REQUEST_NEEDS_QUESTION", "--request needs --question <text>.", 2);
           }
+          if (options.question && options.question.length > REQUEST_QUESTION_MAX_CHARS) {
+            fail(
+              "QUESTION_TOO_LONG",
+              `--question must stay a short ask (≤${REQUEST_QUESTION_MAX_CHARS} chars, got ${options.question.length}). ` +
+                "Move the background/context into the message body — it renders as the request card's markdown body; " +
+                "the question is pinned verbatim above the composer.",
+              2,
+            );
+          }
+          if (options.subject && options.subject.length > REQUEST_SUBJECT_MAX_CHARS) {
+            fail(
+              "SUBJECT_TOO_LONG",
+              `--subject is a headline (≤${REQUEST_SUBJECT_MAX_CHARS} chars, got ${options.subject.length}). ` +
+                "Keep it to a few words; details belong in the body or --question.",
+              2,
+            );
+          }
           const opts = options.option ?? [];
           format = "request";
           metadata = {
             ...(metadata ?? {}),
             request: {
+              ...(options.subject ? { subject: options.subject } : {}),
               questions: [
                 {
                   id: "q1",

--- a/apps/cli/src/commands/chat/send.ts
+++ b/apps/cli/src/commands/chat/send.ts
@@ -4,6 +4,7 @@ import { fail, success } from "../../cli/output.js";
 import { captureOutboundDocs } from "../../core/doc-capture.js";
 import { createSdk, handleSdkError } from "../_shared/local-agent.js";
 import { readStdin } from "./_shared/io.js";
+import { buildRequestMetadata } from "./_shared/request.js";
 
 interface SendOptions {
   format: MessageFormat;
@@ -17,17 +18,6 @@ interface SendOptions {
   answer?: string;
   close?: string;
 }
-
-/**
- * Hard caps on the structured ask. `--question` is the ONE-LINE ask the web
- * pins above the composer (RequestDock); `--subject` is its headline. The
- * background/context belongs in the message body, which renders as the
- * request card's full markdown body. The caps exist because agents otherwise
- * cram the whole context into `--question`, producing an unreadable wall in
- * the dock.
- */
-const REQUEST_QUESTION_MAX_CHARS = 200;
-const REQUEST_SUBJECT_MAX_CHARS = 80;
 
 /** Commander collector for a repeatable flag (`--option a --option b`). */
 function collectOption(value: string, previous: string[]): string[] {
@@ -129,43 +119,8 @@ export function registerChatSendCommand(chat: Command): void {
           if (!target) {
             fail("REQUEST_NEEDS_TARGET", "--request must be directed at a single human member.", 2);
           }
-          if (!options.question) {
-            fail("REQUEST_NEEDS_QUESTION", "--request needs --question <text>.", 2);
-          }
-          if (options.question && options.question.length > REQUEST_QUESTION_MAX_CHARS) {
-            fail(
-              "QUESTION_TOO_LONG",
-              `--question must stay a short ask (≤${REQUEST_QUESTION_MAX_CHARS} chars, got ${options.question.length}). ` +
-                "Move the background/context into the message body — it renders as the request card's markdown body; " +
-                "the question is pinned verbatim above the composer.",
-              2,
-            );
-          }
-          if (options.subject && options.subject.length > REQUEST_SUBJECT_MAX_CHARS) {
-            fail(
-              "SUBJECT_TOO_LONG",
-              `--subject is a headline (≤${REQUEST_SUBJECT_MAX_CHARS} chars, got ${options.subject.length}). ` +
-                "Keep it to a few words; details belong in the body or --question.",
-              2,
-            );
-          }
-          const opts = options.option ?? [];
           format = "request";
-          metadata = {
-            ...(metadata ?? {}),
-            request: {
-              ...(options.subject ? { subject: options.subject } : {}),
-              questions: [
-                {
-                  id: "q1",
-                  prompt: options.question,
-                  kind: opts.length > 0 ? "single" : "free",
-                  options: opts,
-                  required: true,
-                },
-              ],
-            },
-          };
+          metadata = buildRequestMetadata(metadata, options);
         }
 
         // --answer / --close fold open-question resolution into `send`: they

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -256,9 +256,9 @@ first-tree chat
 │     --to <name>                                  #   initial recipient to mention + wake; repeatable, required
 │     --with <name>                                #   context participant; added silently, not woken by the first message
 │     --topic <text> / --description <text>        #   initial chat self-description
-│     --request / --question / --option            #   first message is a tracked ask; exactly one --to human
+│     --request / --subject / --question / --option #  first message is a tracked ask; exactly one --to human
 ├── send <name> [message]                            # recipient is any participant (agent or human)
-│     --request / --question / --option              #   structured ask directed at a human
+│     --request / --subject / --question / --option  #   structured ask directed at a human
 │     --answer <requestId>                           #   resolve a question you asked: body = the answer, clears their red-dot
 │     --close <requestId>                            #   withdraw a question you asked: body = the reason (re-asking opens a NEW question)
 │     --reply-to <messageId>                         #   thread a reply under a message (pure threading; does not resolve a question)
@@ -281,9 +281,11 @@ first-tree chat create "Please review the rollout plan." --to code-agent --with 
   --description "reviewing rollout plan; waiting on code-agent"
 
 # Start a new task chat with a tracked question. The first request must target
-# exactly one human.
+# exactly one human. The message body is the background/context; --subject is
+# the dock/card headline (≤80 chars), and --question is only the ask (≤200 chars).
 first-tree chat create --to alice --request \
   "Migration 0021 drops the legacy column — irreversible." \
+  --subject "Migration gate" \
   --question "Ship the destructive migration?" \
   --option "Ship" --option "Hold"
 
@@ -294,11 +296,16 @@ first-tree chat send code-agent "ship the PR"
 echo "long body" | first-tree chat send code-agent -f markdown
 
 # Ask a human a tracked question (red-dot until answered). --request must
-# target a single human; the body carries context, --question carries the ask.
+# target a single human; the body carries context, --subject is the headline
+# (≤80 chars), and --question carries only the ask (≤200 chars).
 first-tree chat send alice --request \
   "Migration 0021 drops the legacy column — irreversible." \
+  --subject "Migration gate" \
   --question "Ship the destructive migration?" \
   --option "Ship" --option "Hold"
+
+# If --question exceeds 200 chars, the CLI exits with QUESTION_TOO_LONG.
+# If --subject exceeds 80 chars, the CLI exits with SUBJECT_TOO_LONG.
 
 # Thread a reply under a message (pure threading; does NOT resolve a question)
 first-tree chat send alice --reply-to <messageId> "Holding — will split the migration."

--- a/packages/web/DESIGN.md
+++ b/packages/web/DESIGN.md
@@ -289,11 +289,11 @@ const buttonVariants = cva("…base classes…", {
 
 **Selection state** (`OptionCard` and any radio/option cards): selected and
 unselected share the **same faint `--border` hairline** — selection is signalled
-by a **filled neutral dot (`--fg`) plus a very light `--fg` tint (~5%)**, never a
-heavier or colored border and never a saturated dot. Both cues are
-hue-independent (filled vs hollow dot, presence of tint), so it reads without
-relying on color. The real `<input>` is `sr-only`; focus follows the §13
-bordered-control rule (deepen the card's own border on `:focus-within`).
+by a **filled neutral dot (`--fg`) plus a light `--fg` tint (~10%) plus medium
+label weight**, never a heavier or colored border and never a saturated dot.
+Both cues are hue-independent (filled vs hollow dot, presence of tint), so it
+reads without relying on color. The real `<input>` is `sr-only`; focus follows
+the §13 bordered-control rule (deepen the card's own border on `:focus-within`).
 
 ---
 

--- a/packages/web/src/components/chat/__tests__/request-dock-dom.test.tsx
+++ b/packages/web/src/components/chat/__tests__/request-dock-dom.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
 import type { OpenQuestionRequest } from "@first-tree/shared";
-import { act, type ReactElement } from "react";
+import { act, type ComponentProps, type ReactElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { RequestDock } from "../request-dock.js";
@@ -33,14 +33,18 @@ afterEach(() => {
   document.body.innerHTML = "";
 });
 
-function dock(p: OpenQuestionRequest, onJumpToOrigin?: () => void): ReactElement {
+function dock(
+  p: OpenQuestionRequest,
+  onJumpToOrigin?: () => void,
+  overrides?: Partial<ComponentProps<typeof RequestDock>>,
+): ReactElement {
   return (
     <RequestDock
       requestId="req"
       payload={p}
-      selections={{}}
-      directResolve={false}
-      draftEmpty
+      selections={overrides?.selections ?? {}}
+      directResolve={overrides?.directResolve ?? false}
+      draftEmpty={overrides?.draftEmpty ?? true}
       askerName="asker"
       onPick={() => undefined}
       onJumpToOrigin={onJumpToOrigin}
@@ -71,10 +75,13 @@ describe("RequestDock prompt rendering", () => {
     const container = await renderDom(dock(payload(wall)));
     const showAll = findButton(container, "Show all");
     expect(showAll).toBeDefined();
+    expect(showAll?.getAttribute("aria-expanded")).toBe("false");
     await act(async () => {
       showAll?.click();
     });
-    expect(findButton(container, "Show less")).toBeDefined();
+    const showLess = findButton(container, "Show less");
+    expect(showLess).toBeDefined();
+    expect(showLess?.getAttribute("aria-expanded")).toBe("true");
   });
 
   it("offers the way back to the request's timeline card when wired", async () => {
@@ -82,6 +89,7 @@ describe("RequestDock prompt rendering", () => {
     const container = await renderDom(dock(payload("Ship to 20%?"), jump));
     const view = findButton(container, "View context");
     expect(view).toBeDefined();
+    expect(view?.className).toContain("focus-visible:ring-1");
     await act(async () => {
       view?.click();
     });
@@ -89,5 +97,20 @@ describe("RequestDock prompt rendering", () => {
     // Without the wiring (e.g. preview page) the affordance is hidden.
     const bare = await renderDom(dock(payload("Ship to 20%?")));
     expect(findButton(bare, "View context")).toBeUndefined();
+  });
+
+  it("keeps pre-send helper copy neutral even when the draft will resolve", async () => {
+    const container = await renderDom(
+      dock(payload("Ship to 20%?"), undefined, {
+        selections: { "Ship to 20%?": "yes" },
+        directResolve: true,
+        draftEmpty: false,
+      }),
+    );
+    const helper = Array.from(container.querySelectorAll("div"))
+      .reverse()
+      .find((el) => el.textContent?.includes("Send answers and resolves this question"));
+    expect(helper).toBeDefined();
+    expect(helper?.getAttribute("style")).toContain("color: var(--fg-3)");
   });
 });

--- a/packages/web/src/components/chat/__tests__/request-dock-dom.test.tsx
+++ b/packages/web/src/components/chat/__tests__/request-dock-dom.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment happy-dom
+
+import type { OpenQuestionRequest } from "@first-tree/shared";
+import { act, type ReactElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { RequestDock } from "../request-dock.js";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+function payload(prompt: string): OpenQuestionRequest {
+  return {
+    subject: "Rollout",
+    questions: [{ id: "q1", prompt, kind: "single", options: ["yes", "hold"], required: true }],
+    allowExtra: false,
+  };
+}
+
+const roots: Root[] = [];
+async function renderDom(element: ReactElement): Promise<HTMLElement> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  roots.push(root);
+  await act(async () => {
+    root.render(element);
+  });
+  return container;
+}
+
+afterEach(() => {
+  for (const r of roots.splice(0)) r.unmount();
+  document.body.innerHTML = "";
+});
+
+function dock(p: OpenQuestionRequest, onJumpToOrigin?: () => void): ReactElement {
+  return (
+    <RequestDock
+      requestId="req"
+      payload={p}
+      selections={{}}
+      directResolve={false}
+      draftEmpty
+      askerName="asker"
+      onPick={() => undefined}
+      onJumpToOrigin={onJumpToOrigin}
+    />
+  );
+}
+
+function findButton(container: HTMLElement, label: string): HTMLButtonElement | undefined {
+  return Array.from(container.querySelectorAll("button")).find((b) => b.textContent?.includes(label));
+}
+
+describe("RequestDock prompt rendering", () => {
+  it("renders the prompt as markdown — no literal ### / ** markers", async () => {
+    const container = await renderDom(dock(payload("### Decision needed\n\n**Ship** to 20%?")));
+    expect(container.querySelector("h3")?.textContent).toBe("Decision needed");
+    expect(container.querySelector("strong")?.textContent).toBe("Ship");
+    expect(container.textContent).not.toContain("###");
+    expect(container.textContent).not.toContain("**");
+  });
+
+  it("keeps a short prompt unclamped — no expand affordance", async () => {
+    const container = await renderDom(dock(payload("Ship to 20%?")));
+    expect(findButton(container, "Show all")).toBeUndefined();
+  });
+
+  it("clamps a legacy wall-of-text prompt and expands on demand", async () => {
+    const wall = `## Meeting notes\n${"context line that goes on and on. ".repeat(20)}\n\nAnswer ① or ②?`;
+    const container = await renderDom(dock(payload(wall)));
+    const showAll = findButton(container, "Show all");
+    expect(showAll).toBeDefined();
+    await act(async () => {
+      showAll?.click();
+    });
+    expect(findButton(container, "Show less")).toBeDefined();
+  });
+
+  it("offers the way back to the request's timeline card when wired", async () => {
+    const jump = vi.fn();
+    const container = await renderDom(dock(payload("Ship to 20%?"), jump));
+    const view = findButton(container, "View context");
+    expect(view).toBeDefined();
+    await act(async () => {
+      view?.click();
+    });
+    expect(jump).toHaveBeenCalledTimes(1);
+    // Without the wiring (e.g. preview page) the affordance is hidden.
+    const bare = await renderDom(dock(payload("Ship to 20%?")));
+    expect(findButton(bare, "View context")).toBeUndefined();
+  });
+});

--- a/packages/web/src/components/chat/question-prompt.tsx
+++ b/packages/web/src/components/chat/question-prompt.tsx
@@ -1,0 +1,76 @@
+/**
+ * QuestionPrompt — renders an open question's prompt
+ * (`metadata.request.questions[].prompt`) as markdown, clamped when long.
+ *
+ * Prompts are supposed to be one-line asks (the CLI caps new ones at 200
+ * chars), but requests sent before the cap exist with whole markdown
+ * documents crammed into the prompt. Rendering those as a bare text node
+ * produced an unreadable wall — literal `###` / `**` markers with every
+ * newline collapsed. Markdown rendering keeps the formatting; the clamp keeps
+ * a legacy wall from swallowing the dock/card (expand on demand).
+ *
+ * `fadeColor` must match the surface the prompt sits on (the dock and the
+ * card's answer block share the needs-you 4% tint) so the clamp's fade-out
+ * blends instead of banding.
+ */
+import { useState } from "react";
+import { Markdown } from "../ui/markdown.js";
+
+/** A prompt longer than this (or spanning several lines) gets clamped. */
+const CLAMP_CHARS = 240;
+const CLAMP_NEWLINES = 2;
+/** Collapsed height — roughly six lines of body text. */
+const CLAMP_MAX_HEIGHT = "8.5em";
+
+export const QUESTION_SURFACE_BG = "color-mix(in oklch, var(--state-needs-you) 4%, var(--bg-raised))";
+
+export function QuestionPrompt({ prompt, fadeColor = QUESTION_SURFACE_BG }: { prompt: string; fadeColor?: string }) {
+  const long = prompt.length > CLAMP_CHARS || prompt.split("\n").length > CLAMP_NEWLINES + 1;
+  const [expanded, setExpanded] = useState(false);
+
+  const body = (
+    // Headings collapse to body size — a prompt is an ask, not a document;
+    // bold weight alone carries the hierarchy without a legacy wall's `##`
+    // exploding inside the dock/card.
+    <Markdown className="prose-p:my-1 prose-headings:mt-2 prose-headings:mb-1 prose-headings:text-[length:1em] first:prose-p:mt-0 last:prose-p:mb-0">
+      {prompt}
+    </Markdown>
+  );
+
+  if (!long) return body;
+
+  return (
+    <div>
+      <div style={expanded ? undefined : { maxHeight: CLAMP_MAX_HEIGHT, overflow: "hidden", position: "relative" }}>
+        {body}
+        {!expanded ? (
+          <div
+            aria-hidden
+            style={{
+              position: "absolute",
+              insetInline: 0,
+              bottom: 0,
+              height: "3em",
+              background: `linear-gradient(to bottom, transparent, ${fadeColor})`,
+            }}
+          />
+        ) : null}
+      </div>
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        className="mono text-caption"
+        style={{
+          background: "none",
+          border: "none",
+          padding: 0,
+          marginTop: "var(--sp-1)",
+          color: "var(--fg-3)",
+          cursor: "pointer",
+        }}
+      >
+        {expanded ? "Show less" : "Show all"}
+      </button>
+    </div>
+  );
+}

--- a/packages/web/src/components/chat/question-prompt.tsx
+++ b/packages/web/src/components/chat/question-prompt.tsx
@@ -58,8 +58,9 @@ export function QuestionPrompt({ prompt, fadeColor = QUESTION_SURFACE_BG }: { pr
       </div>
       <button
         type="button"
+        aria-expanded={expanded}
         onClick={() => setExpanded((v) => !v)}
-        className="mono text-caption"
+        className="mono text-caption rounded-[var(--radius-input)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
         style={{
           background: "none",
           border: "none",

--- a/packages/web/src/components/chat/request-card.tsx
+++ b/packages/web/src/components/chat/request-card.tsx
@@ -27,6 +27,7 @@ import { type ComponentType, type KeyboardEvent, type ReactNode, useMemo, useSta
 import { sendChatMessage } from "../../api/chats.js";
 import { Button } from "../ui/button.js";
 import { OptionCard } from "../ui/option-card.js";
+import { QuestionPrompt } from "./question-prompt.js";
 import {
   defaultExpanded,
   deriveRequestState,
@@ -297,11 +298,13 @@ export function RequestCard({
 
           {payload.questions.map((q, i) => (
             <div key={q.id} style={{ marginTop: i === 0 ? 0 : "var(--sp-3)" }}>
-              <div className="text-body font-medium" style={{ color: "var(--fg)" }}>
-                <span className="mono text-caption" style={{ color: "var(--fg-4)", marginRight: "var(--sp-1_5)" }}>
+              <div style={{ display: "flex", gap: "var(--sp-1_5)", alignItems: "baseline" }}>
+                <span className="mono text-caption shrink-0" style={{ color: "var(--fg-4)" }}>
                   {`Q${i + 1}`}
                 </span>
-                {q.prompt}
+                <div className="text-body font-medium" style={{ color: "var(--fg)", flex: 1, minWidth: 0 }}>
+                  <QuestionPrompt prompt={q.prompt} />
+                </div>
               </div>
               {q.kind === "single" ? (
                 <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--sp-1_5)", marginTop: "var(--sp-1_5)" }}>

--- a/packages/web/src/components/chat/request-dock.tsx
+++ b/packages/web/src/components/chat/request-dock.tsx
@@ -31,8 +31,9 @@
  * composer chrome.
  */
 import type { OpenQuestionRequest } from "@first-tree/shared";
-import { MessageCircleQuestion } from "lucide-react";
+import { ArrowUpRight, MessageCircleQuestion } from "lucide-react";
 import { OptionCard } from "../ui/option-card.js";
+import { QuestionPrompt } from "./question-prompt.js";
 
 export function RequestDock({
   requestId,
@@ -42,6 +43,7 @@ export function RequestDock({
   draftEmpty,
   askerName,
   onPick,
+  onJumpToOrigin,
 }: {
   requestId: string;
   payload: OpenQuestionRequest;
@@ -53,6 +55,12 @@ export function RequestDock({
   draftEmpty: boolean;
   askerName: string;
   onPick: (prompt: string, option: string) => void;
+  /**
+   * Scroll the timeline to the request's own card — the dock carries only the
+   * structured ask, so this is the way back to the full markdown context.
+   * Omitted (e.g. in the preview page) the affordance is hidden.
+   */
+  onJumpToOrigin?: () => void;
 }) {
   const questionCount = payload.questions.length;
   const subject = payload.subject ?? "Request";
@@ -82,15 +90,41 @@ export function RequestDock({
       >
         <MessageCircleQuestion size={12} className="shrink-0" />
         {`Awaiting your answer · ${subject} · ${questionCount} question${questionCount === 1 ? "" : "s"}`}
+        {onJumpToOrigin ? (
+          <button
+            type="button"
+            onClick={onJumpToOrigin}
+            className="mono text-caption"
+            style={{
+              marginLeft: "auto",
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 2,
+              background: "none",
+              border: "none",
+              padding: 0,
+              textTransform: "none",
+              letterSpacing: "normal",
+              fontWeight: 500,
+              color: "var(--fg-needs-you-strong)",
+              cursor: "pointer",
+            }}
+          >
+            View context
+            <ArrowUpRight size={11} className="shrink-0" />
+          </button>
+        ) : null}
       </div>
 
       {payload.questions.map((q, i) => (
         <div key={q.id} style={{ marginTop: i === 0 ? 0 : "var(--sp-3)" }}>
-          <div className="text-body font-medium" style={{ color: "var(--fg)" }}>
-            <span className="mono text-caption" style={{ color: "var(--fg-4)", marginRight: "var(--sp-1_5)" }}>
+          <div style={{ display: "flex", gap: "var(--sp-1_5)", alignItems: "baseline" }}>
+            <span className="mono text-caption shrink-0" style={{ color: "var(--fg-4)" }}>
               {`Q${i + 1}`}
             </span>
-            {q.prompt}
+            <div className="text-body font-medium" style={{ color: "var(--fg)", flex: 1, minWidth: 0 }}>
+              <QuestionPrompt prompt={q.prompt} />
+            </div>
           </div>
           {q.kind === "single" ? (
             <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--sp-1_5)", marginTop: "var(--sp-1_5)" }}>

--- a/packages/web/src/components/chat/request-dock.tsx
+++ b/packages/web/src/components/chat/request-dock.tsx
@@ -94,12 +94,12 @@ export function RequestDock({
           <button
             type="button"
             onClick={onJumpToOrigin}
-            className="mono text-caption"
+            className="mono text-caption rounded-[var(--radius-input)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
             style={{
               marginLeft: "auto",
               display: "inline-flex",
               alignItems: "center",
-              gap: 2,
+              gap: "var(--sp-0_5)",
               background: "none",
               border: "none",
               padding: 0,
@@ -164,12 +164,7 @@ export function RequestDock({
           marginTop: "var(--sp-2_5)",
           paddingTop: "var(--sp-2)",
           borderTop: "var(--hairline) solid var(--border-faint)",
-          color:
-            sendKind === "resolve"
-              ? "var(--fg-success-strong)"
-              : sendKind === "judge"
-                ? "var(--fg-info-strong)"
-                : "var(--fg-4)",
+          color: "var(--fg-3)",
         }}
       >
         {sendKind === "resolve"

--- a/packages/web/src/components/ui/option-card.tsx
+++ b/packages/web/src/components/ui/option-card.tsx
@@ -11,8 +11,8 @@ import { cn } from "../../lib/utils.js";
  *
  * Design language (DESIGN.md §2 near-monochrome, §13 a11y):
  *   - Selected and unselected share the SAME faint `border-border` hairline —
- *     selection is signalled by a *filled* neutral dot + a very light ink
- *     tint, not by a heavier/darker border.
+ *     selection is signalled by a *filled* neutral dot + a light ink tint
+ *     (~10%) + medium label weight, not by a heavier/darker border.
  *   - The real `<input>` is `sr-only`; the custom dot is the visual. Keyboard
  *     focus deepens the card's own border to `--ring` via `:focus-within`
  *     (a single line — no ringed second frame), matching `Input`.
@@ -28,7 +28,10 @@ const optionCardVariants = cva(
         pill: "items-center gap-2 px-3 py-1.5",
       },
       selected: {
-        true: "bg-foreground/5",
+        // Tint at 10% + medium label weight: clearly apart from the unselected
+        // hover wash (accent/30) at a glance, still neutral-ink per §7 — the
+        // border stays the same hairline, selection never colors it.
+        true: "bg-foreground/10 font-medium",
         false: "hover:bg-accent/30",
       },
       disabled: {
@@ -71,7 +74,7 @@ export function OptionCard({
           checked ? "border-foreground" : "border-border-strong",
         )}
       >
-        {checked && <span className="h-1.5 w-1.5 rounded-full bg-foreground" />}
+        {checked && <span className="h-2 w-2 rounded-full bg-foreground" />}
       </span>
       {children}
     </label>

--- a/packages/web/src/pages/request-dock-preview.tsx
+++ b/packages/web/src/pages/request-dock-preview.tsx
@@ -65,6 +65,33 @@ const MODES: Record<string, { label: string; payload: OpenQuestionRequest }> = {
       allowExtra: true,
     },
   },
+  legacy: {
+    label: "legacy wall-of-text prompt (pre-cap markdown crammed into --question)",
+    payload: {
+      questions: [
+        {
+          id: "q1",
+          prompt: [
+            "## Meeting records landed in the tree",
+            "",
+            "### 2026-06-02 team regular meeting — your asks",
+            "① **Workflow planning** — this week's focus is deep OpenClaw usage, wiring it into the workflow → **landed**: goal/NODE.md updated",
+            "② **Consensus capture** — move capture rules out of agent system prompts into a skill (P3)",
+            "③ **Git workflow convergence** — agents integrate via skill/prompt upgrades, not direct pushes",
+            "",
+            "### 2026-06-03 team regular meeting — follow-ups",
+            "① Planning conclusions merged into raw-context; branch notes pending",
+            "",
+            "Answer ① status quo OK / ② which section to change (explain in chat)?",
+          ].join("\n"),
+          kind: "single",
+          options: ["OK as landed", "Needs changes (explain in chat)"],
+          required: true,
+        },
+      ],
+      allowExtra: false,
+    },
+  },
 };
 
 function ModeBlock({ modeKey, payload }: { modeKey: string; payload: OpenQuestionRequest }) {

--- a/packages/web/src/pages/request-dock-preview.tsx
+++ b/packages/web/src/pages/request-dock-preview.tsx
@@ -44,6 +44,22 @@ const MODES: Record<string, { label: string; payload: OpenQuestionRequest }> = {
       allowExtra: false,
     },
   },
+  context: {
+    label: "wired context jump + long subject",
+    payload: {
+      subject: "Long request subject that checks mobile header wrapping with context jump",
+      questions: [
+        {
+          id: "q1",
+          prompt: "Approve this rollout gate after reviewing the full request context?",
+          kind: "single",
+          options: ["Approve", "Hold"],
+          required: true,
+        },
+      ],
+      allowExtra: false,
+    },
+  },
   multi: {
     label: "multi-question",
     payload: {
@@ -138,6 +154,7 @@ function ModeBlock({ modeKey, payload }: { modeKey: string; payload: OpenQuestio
           draftEmpty={draft.trim().length === 0}
           askerName="deploy-agent"
           onPick={pick}
+          onJumpToOrigin={modeKey === "context" ? () => setSentAs("→ jumped to timeline request context") : undefined}
         />
         {/* mock composer — mirrors the wiring contract, not the real chrome */}
         <div style={{ display: "flex", gap: "var(--sp-2)", alignItems: "flex-end" }}>

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -3069,6 +3069,10 @@ export function ChatView({
                         draftEmpty={draft.trim().length === 0}
                         askerName={chatScopedAgentName(dockRequest.senderId)}
                         onPick={pickDockOption}
+                        // Back to the full markdown context: the request's own
+                        // timeline card. No-op when the card is outside the
+                        // loaded message window (querySelector miss).
+                        onJumpToOrigin={() => scrollToMessage(dockRequest.id, "start", "smooth")}
                       />
                     ) : null}
                     {/* biome-ignore lint/a11y/noStaticElementInteractions: drop target for image upload */}


### PR DESCRIPTION
## Problem

The open-question answering surfaces had zero content defense and weak feedback (screenshot trigger: a pre-#790 request with a whole markdown document crammed into `--question` renders in the new RequestDock (#981) as an unreadable wall — literal `###`/`**`, every newline collapsed, filling a screen):

1. `questions[].prompt` rendered as a bare text node — no markdown, no line breaks
2. The dock headline is always a generic "REQUEST" — `subject` exists in the schema but the CLI never exposed it
3. The dock carries only the structured ask, with no way back to the request's full markdown body in the timeline
4. `OptionCard`'s selected state (5% tint + small dot) is nearly indistinguishable from hover
5. Nothing stops an agent from cramming context into `--question` again

## Changes

**Web**
- New `QuestionPrompt` (shared by `RequestDock` + `RequestCard`'s answer block): renders the prompt as markdown via the existing `Markdown` primitive; headings collapse to body size (a prompt is an ask, not a document); prompts beyond ~240 chars / 3 lines clamp at ~6 lines with a fade + `Show all` toggle
- Dock header gains **View context** (lucide `ArrowUpRight`) → `scrollToMessage(request.id)` back to the timeline card; hidden when not wired (preview)
- `OptionCard` selected state strengthened **within the DESIGN.md §7 rule**: ink tint 5%→10%, filled dot 1.5→2, medium label weight — border stays the same hairline, both cues stay hue-independent. §7 wording updated to match
- `/preview/request-dock` gains a `legacy` wall-of-text mode for visual review

**CLI**
- `chat send --request` gains `--subject <text>` (≤80 chars, `SUBJECT_TOO_LONG`) feeding the dock/card headline
- `--question` capped at 200 chars (`QUESTION_TOO_LONG`) with an error that tells the agent to move background into the body — the structural fix for the wall

## Out of scope (follow-ups per the UX review)
- Unifying the card's staged-Reply answer block with the dock's fill-composer model
- `discussing`-state copy ("awaiting your answer" after a discuss reply)
- Request age / manual resolve / stale-request lifecycle

## Tests
- `request-dock-dom.test.tsx` (new): markdown rendering (no literal `###`/`**`), no clamp for short prompts, clamp+expand for walls, jump-link wiring/hiding
- CLI: `--subject` passthrough, `QUESTION_TOO_LONG`, `SUBJECT_TOO_LONG`
- Full suites green: web 787, cli 442, `pnpm check` + `pnpm typecheck` clean (2 pre-existing biome notes in untouched files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)