### PR TITLE
fix(server): enforce filter integrity on org session listing

### DIFF
--- a/packages/server/src/__tests__/org-sessions-list.test.ts
+++ b/packages/server/src/__tests__/org-sessions-list.test.ts
@@ -107,6 +107,35 @@ describe("GET /orgs/:orgId/sessions — filter integrity", () => {
     expect(foreign.statusCode).toBe(403);
   });
 
+  it("excludes a session row that points an own-org agent at a foreign-org chat", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app);
+
+    // agent_chat_sessions has independent FKs to agents and chats; nothing at
+    // the DB layer ties their orgs together. Simulate a stale/malicious
+    // client having reported session:state for a foreign chatId.
+    const foreignOrgId = `org-${randomUUID().slice(0, 6)}`;
+    await app.db.insert(organizations).values({
+      id: foreignOrgId,
+      name: foreignOrgId.slice(0, 30),
+      displayName: "Foreign Org",
+    });
+    const foreignChatId = await seedChat(app, foreignOrgId, "foreign secret topic");
+
+    const ownAgent = await createAgent(app.db, {
+      name: `xchat-${randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "Cross-chat Agent",
+      managerId: admin.memberId,
+      clientId: admin.clientId,
+    });
+    await seedSession(app, ownAgent.uuid, foreignChatId);
+
+    const res = await listSessions(app, admin.accessToken, admin.organizationId, `?agentId=${ownAgent.uuid}&limit=100`);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.items).toEqual([]);
+  });
+
   it("agentId filter returns only that agent's sessions", async () => {
     const app = getApp();
     const admin = await createAdminContext(app);

--- a/packages/server/src/__tests__/org-sessions-list.test.ts
+++ b/packages/server/src/__tests__/org-sessions-list.test.ts
@@ -1,0 +1,204 @@
+import { randomUUID } from "node:crypto";
+import type { FastifyInstance } from "fastify";
+import { describe, expect, it } from "vitest";
+import { agentChatSessions } from "../db/schema/agent-chat-sessions.js";
+import { agents } from "../db/schema/agents.js";
+import { chats } from "../db/schema/chats.js";
+import { organizations } from "../db/schema/organizations.js";
+import { createAgent } from "../services/agent.js";
+import { createAdminContext, useTestApp } from "./helpers.js";
+
+/**
+ * Filter integrity for `GET /orgs/:orgId/sessions` (listAllSessions).
+ *
+ * Visibility policy: any active org member may read every org session's
+ * topic/summary — that is accepted product behavior. What these tests pin
+ * down is that every query filter actually takes effect:
+ *
+ *   - the organization boundary cannot be crossed (neither via the URL's
+ *     :orgId nor via rows leaking into another org's listing);
+ *   - `agentId` and `state` narrow the result set;
+ *   - evicted sessions stay hidden unless explicitly requested;
+ *   - cursor pagination advances without overlap, and a malformed cursor
+ *     is a 400, not a Postgres error surfaced as a 500.
+ */
+describe("GET /orgs/:orgId/sessions — filter integrity", () => {
+  const getApp = useTestApp();
+
+  type SessionItem = { agentId: string; chatId: string; state: string; topic: string | null };
+  type ListResponse = { items: SessionItem[]; nextCursor: string | null };
+
+  async function seedChat(app: FastifyInstance, organizationId: string, topic?: string): Promise<string> {
+    const id = `chat-${randomUUID().slice(0, 8)}`;
+    await app.db.insert(chats).values({ id, organizationId, type: "group", topic });
+    return id;
+  }
+
+  async function seedSession(
+    app: FastifyInstance,
+    agentId: string,
+    chatId: string,
+    opts: { state?: string; updatedAt?: Date } = {},
+  ): Promise<void> {
+    await app.db.insert(agentChatSessions).values({
+      agentId,
+      chatId,
+      state: opts.state ?? "active",
+      ...(opts.updatedAt ? { updatedAt: opts.updatedAt } : {}),
+    });
+  }
+
+  async function listSessions(
+    app: FastifyInstance,
+    accessToken: string,
+    orgId: string,
+    query = "",
+  ): Promise<{ statusCode: number; body: ListResponse }> {
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/orgs/${orgId}/sessions${query}`,
+      headers: { authorization: `Bearer ${accessToken}` },
+    });
+    return { statusCode: res.statusCode, body: res.json<ListResponse>() };
+  }
+
+  it("never returns another organization's sessions, and rejects a foreign :orgId with 403", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app);
+
+    // Foreign org with its own agent + chat + active session, seeded directly.
+    const foreignOrgId = `org-${randomUUID().slice(0, 6)}`;
+    await app.db.insert(organizations).values({
+      id: foreignOrgId,
+      name: foreignOrgId.slice(0, 30),
+      displayName: "Foreign Org",
+    });
+    const foreignAgentUuid = randomUUID();
+    await app.db.insert(agents).values({
+      uuid: foreignAgentUuid,
+      name: `foreign-${randomUUID().slice(0, 6)}`,
+      organizationId: foreignOrgId,
+      type: "agent",
+      displayName: "Foreign Agent",
+      inboxId: `inbox_${foreignAgentUuid}`,
+      managerId: admin.memberId,
+    });
+    const foreignChatId = await seedChat(app, foreignOrgId, "foreign topic");
+    await seedSession(app, foreignAgentUuid, foreignChatId);
+
+    // Own-org session for contrast.
+    const ownAgent = await createAgent(app.db, {
+      name: `own-${randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "Own Agent",
+      managerId: admin.memberId,
+      clientId: admin.clientId,
+    });
+    const ownChatId = await seedChat(app, admin.organizationId, "own topic");
+    await seedSession(app, ownAgent.uuid, ownChatId);
+
+    const own = await listSessions(app, admin.accessToken, admin.organizationId, "?limit=100");
+    expect(own.statusCode).toBe(200);
+    expect(own.body.items.some((i) => i.chatId === ownChatId)).toBe(true);
+    expect(own.body.items.some((i) => i.chatId === foreignChatId)).toBe(false);
+    expect(own.body.items.find((i) => i.chatId === ownChatId)?.topic).toBe("own topic");
+
+    const foreign = await listSessions(app, admin.accessToken, foreignOrgId);
+    expect(foreign.statusCode).toBe(403);
+  });
+
+  it("agentId filter returns only that agent's sessions", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app);
+
+    const agentA = await createAgent(app.db, {
+      name: `flt-a-${randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "Filter A",
+      managerId: admin.memberId,
+      clientId: admin.clientId,
+    });
+    const agentB = await createAgent(app.db, {
+      name: `flt-b-${randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "Filter B",
+      managerId: admin.memberId,
+      clientId: admin.clientId,
+    });
+    await seedSession(app, agentA.uuid, await seedChat(app, admin.organizationId));
+    await seedSession(app, agentB.uuid, await seedChat(app, admin.organizationId));
+
+    const res = await listSessions(app, admin.accessToken, admin.organizationId, `?agentId=${agentA.uuid}&limit=100`);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.items.length).toBeGreaterThan(0);
+    expect(res.body.items.every((i) => i.agentId === agentA.uuid)).toBe(true);
+  });
+
+  it("state filter takes effect, and evicted sessions are hidden by default", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app);
+
+    const agent = await createAgent(app.db, {
+      name: `st-${randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "State Agent",
+      managerId: admin.memberId,
+      clientId: admin.clientId,
+    });
+    const activeChatId = await seedChat(app, admin.organizationId);
+    const evictedChatId = await seedChat(app, admin.organizationId);
+    await seedSession(app, agent.uuid, activeChatId, { state: "active" });
+    await seedSession(app, agent.uuid, evictedChatId, { state: "evicted" });
+
+    const byAgent = `agentId=${agent.uuid}&limit=100`;
+
+    const defaults = await listSessions(app, admin.accessToken, admin.organizationId, `?${byAgent}`);
+    expect(defaults.body.items.map((i) => i.chatId)).toEqual([activeChatId]);
+
+    const evicted = await listSessions(app, admin.accessToken, admin.organizationId, `?${byAgent}&state=evicted`);
+    expect(evicted.body.items.map((i) => i.chatId)).toEqual([evictedChatId]);
+
+    const active = await listSessions(app, admin.accessToken, admin.organizationId, `?${byAgent}&state=active`);
+    expect(active.body.items.map((i) => i.chatId)).toEqual([activeChatId]);
+  });
+
+  it("cursor pagination advances without overlap; malformed cursor and state are 400", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app);
+
+    const agent = await createAgent(app.db, {
+      name: `pg-${randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "Page Agent",
+      managerId: admin.memberId,
+      clientId: admin.clientId,
+    });
+    const newerChatId = await seedChat(app, admin.organizationId);
+    const olderChatId = await seedChat(app, admin.organizationId);
+    await seedSession(app, agent.uuid, newerChatId, { updatedAt: new Date("2026-01-02T00:00:00Z") });
+    await seedSession(app, agent.uuid, olderChatId, { updatedAt: new Date("2026-01-01T00:00:00Z") });
+
+    const byAgent = `agentId=${agent.uuid}&limit=1`;
+
+    const page1 = await listSessions(app, admin.accessToken, admin.organizationId, `?${byAgent}`);
+    expect(page1.statusCode).toBe(200);
+    expect(page1.body.items.map((i) => i.chatId)).toEqual([newerChatId]);
+    expect(page1.body.nextCursor).not.toBeNull();
+
+    const page2 = await listSessions(
+      app,
+      admin.accessToken,
+      admin.organizationId,
+      `?${byAgent}&cursor=${encodeURIComponent(page1.body.nextCursor ?? "")}`,
+    );
+    expect(page2.statusCode).toBe(200);
+    expect(page2.body.items.map((i) => i.chatId)).toEqual([olderChatId]);
+    expect(page2.body.nextCursor).toBeNull();
+
+    const badCursor = await listSessions(app, admin.accessToken, admin.organizationId, "?cursor=not-a-date");
+    expect(badCursor.statusCode).toBe(400);
+
+    const badState = await listSessions(app, admin.accessToken, admin.organizationId, "?state=bogus");
+    expect(badState.statusCode).toBe(400);
+  });
+});

--- a/packages/server/src/api/orgs/sessions.ts
+++ b/packages/server/src/api/orgs/sessions.ts
@@ -14,10 +14,9 @@ export async function orgSessionRoutes(app: FastifyInstance): Promise<void> {
   app.get<{ Params: { orgId: string } }>("/", async (request) => {
     const scope = await requireOrgMembership(request, app.db);
     const query = sessionListFilter.parse(request.query);
-    return sessionService.listAllSessions(app.db, query.limit, query.cursor, {
+    return sessionService.listAllSessions(app.db, scope.organizationId, query.limit, query.cursor, {
       state: query.state,
       agentId: query.agentId,
-      organizationId: scope.organizationId,
     });
   });
 }

--- a/packages/server/src/services/session.ts
+++ b/packages/server/src/services/session.ts
@@ -1,5 +1,5 @@
 import { MENTION_REGEX, type SessionState, stripCode } from "@first-tree/shared";
-import { and, desc, eq, inArray, ne, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, lt, ne, sql } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 import { agentChatSessions } from "../db/schema/agent-chat-sessions.js";
 import { agentPresence } from "../db/schema/agent-presence.js";
@@ -8,7 +8,7 @@ import { chatMembership } from "../db/schema/chat-membership.js";
 import { chats } from "../db/schema/chats.js";
 import { inboxEntries } from "../db/schema/inbox-entries.js";
 import { messages } from "../db/schema/messages.js";
-import { NotFoundError } from "../errors.js";
+import { BadRequestError, NotFoundError } from "../errors.js";
 import type { Notifier } from "./notifier.js";
 
 export const SUMMARY_MAX_LENGTH = 50;
@@ -216,14 +216,21 @@ export async function getSession(db: Database, agentId: string, chatId: string):
   };
 }
 
-/** List all sessions across all agents, with pagination. Scoped to organization. */
+/**
+ * List all sessions across all agents in one organization, with pagination.
+ *
+ * `organizationId` is a required positional parameter, not an optional
+ * filter: it is the tenant boundary, and an omitted boundary must be a
+ * compile error rather than a silently unscoped query.
+ */
 export async function listAllSessions(
   db: Database,
+  organizationId: string,
   limit: number,
   cursor?: string,
-  filters?: { state?: string; agentId?: string; organizationId?: string },
+  filters?: { state?: string; agentId?: string },
 ): Promise<{ items: SessionListItem[]; nextCursor: string | null }> {
-  const conditions = [];
+  const conditions = [eq(agents.organizationId, organizationId)];
   if (filters?.state) {
     conditions.push(eq(agentChatSessions.state, filters.state));
   } else {
@@ -233,11 +240,16 @@ export async function listAllSessions(
   if (filters?.agentId) {
     conditions.push(eq(agentChatSessions.agentId, filters.agentId));
   }
-  if (filters?.organizationId) {
-    conditions.push(eq(agents.organizationId, filters.organizationId));
-  }
   if (cursor) {
-    conditions.push(sql`${agentChatSessions.updatedAt} < ${new Date(cursor)}`);
+    const cursorDate = new Date(cursor);
+    if (Number.isNaN(cursorDate.getTime())) {
+      // An Invalid Date would otherwise reach Postgres as a malformed
+      // timestamp parameter and surface as a 500.
+      throw new BadRequestError(`Invalid cursor: ${cursor}`);
+    }
+    // `lt()` (not a raw sql`` fragment) so the Date goes through the
+    // column's driver mapping — postgres-js rejects raw Date parameters.
+    conditions.push(lt(agentChatSessions.updatedAt, cursorDate));
   }
 
   const rows = await db
@@ -252,7 +264,7 @@ export async function listAllSessions(
     .from(agentChatSessions)
     .innerJoin(chats, eq(agentChatSessions.chatId, chats.id))
     .innerJoin(agents, eq(agentChatSessions.agentId, agents.uuid))
-    .where(conditions.length > 0 ? and(...conditions) : undefined)
+    .where(and(...conditions))
     .orderBy(desc(agentChatSessions.updatedAt))
     .limit(limit + 1);
 

--- a/packages/server/src/services/session.ts
+++ b/packages/server/src/services/session.ts
@@ -230,7 +230,12 @@ export async function listAllSessions(
   cursor?: string,
   filters?: { state?: string; agentId?: string },
 ): Promise<{ items: SessionListItem[]; nextCursor: string | null }> {
-  const conditions = [eq(agents.organizationId, organizationId)];
+  // The boundary applies to BOTH tenant-owned tables this query exposes:
+  // agent_chat_sessions has independent FKs to agents and chats with no DB
+  // constraint tying their orgs together, so a stale or malicious client
+  // reporting session:state for a foreign chatId could otherwise leak that
+  // chat's topic/summary through the unconstrained chats join.
+  const conditions = [eq(agents.organizationId, organizationId), eq(chats.organizationId, organizationId)];
   if (filters?.state) {
     conditions.push(eq(agentChatSessions.state, filters.state));
   } else {


### PR DESCRIPTION
## Context

Follow-up from the security audit walkthrough (same review batch as #983). The audit flagged that `GET /orgs/:orgId/sessions` exposes every org session's chat topic and first-message summary to any active member.

**Decision: visibility stays as-is.** Org members are mutually trusted; topic/summary of org sessions is information the membership permission is allowed to read. What must be guaranteed instead is that every query filter on this listing actually takes effect. Auditing that filter chain found three real defects, fixed here.

## Defects found and fixed

### 1. The tenant boundary was an optional filter

`listAllSessions(db, limit, cursor?, filters?)` carried `organizationId` inside the optional `filters` object. A caller that forgot to pass it got a silently unscoped, cross-tenant query. The only current caller did pass it, but a tenant boundary must not depend on caller discipline.

**Fix:** `organizationId` is now a required positional parameter — omitting it is a compile error.

### 2. Cursor pagination never worked (pre-existing 500)

The cursor condition was built as a raw fragment: ``sql`${agentChatSessions.updatedAt} < ${new Date(cursor)}` ``. Parameters inside a raw `sql` fragment bypass the column's driver mapping, and postgres-js rejects native `Date` instances (`TypeError: The "string" argument must be of type string...`). Every page-2 request on this endpoint returned 500 — the new pagination test reproduced this faithfully before the fix.

**Fix:** use the `lt()` comparator so the Date goes through the column type's driver mapping. Swept the repo for the same pattern; this was the only raw-fragment comparison passing a `Date` (the `inbox.ts` fragments pass strings/numbers, which are safe).

### 3. Malformed cursor surfaced as 500

`new Date("garbage")` produces an Invalid Date that previously went straight into the query. Now validated: a malformed cursor returns `400 BadRequestError`.

`agentId` and `state` filters were verified correct as-is (ANDed with the org condition; a foreign agentId yields an empty set, not a leak).

## Tests

New `org-sessions-list.test.ts` (this route previously had zero coverage):

- org isolation: foreign org's sessions never appear in the listing; requesting a foreign `:orgId` is 403
- `agentId` filter narrows to that agent's sessions
- `state` filter takes effect; evicted sessions hidden by default, visible only via `state=evicted`
- cursor pagination advances without overlap and terminates; malformed cursor and invalid state enum return 400

`pnpm check`, `pnpm typecheck`, and the full server suite (161 files / 1382 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)