### PR TITLE
fix: enforce org scope for member mutations

### DIFF
--- a/packages/server/src/__tests__/members.test.ts
+++ b/packages/server/src/__tests__/members.test.ts
@@ -1,5 +1,11 @@
+import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { describe, expect, it } from "vitest";
+import { agents as agentsTable } from "../db/schema/agents.js";
+import { members as membersTable } from "../db/schema/members.js";
+import * as memberService from "../services/member.js";
+import { createOrganization } from "../services/organization.js";
 import { createTestAdmin, useTestApp } from "./helpers.js";
 
 describe("Members API", () => {
@@ -16,6 +22,24 @@ describe("Members API", () => {
         payload,
       });
     return req;
+  }
+
+  async function createOtherOrgTargetMember(app: FastifyInstance, prefix: string) {
+    const otherOrg = await createOrganization(app.db, {
+      name: `${prefix}-${randomUUID().slice(0, 8)}`,
+      displayName: "IDOR Target",
+    });
+    await memberService.createMember(app.db, otherOrg.id, {
+      username: `${prefix}-owner-${randomUUID().slice(0, 8)}`,
+      displayName: "Other Org Admin",
+      role: "admin",
+    });
+    const target = await memberService.createMember(app.db, otherOrg.id, {
+      username: `${prefix}-target-${randomUUID().slice(0, 8)}`,
+      displayName: "Other Org Member",
+      role: "member",
+    });
+    return { otherOrg, target };
   }
 
   describe("GET /api/v1/members", () => {
@@ -94,6 +118,20 @@ describe("Members API", () => {
       expect(patchRes.statusCode).toBe(200);
       expect(patchRes.json<{ role: string }>().role).toBe("admin");
     });
+
+    it("returns 404 for an empty patch against a member from another org", async () => {
+      const app = getApp();
+      const admin = await createTestAdmin(app, { username: `patch-idor-admin-${randomUUID().slice(0, 8)}` });
+      const { target } = await createOtherOrgTargetMember(app, "patch-idor");
+
+      const patchRes = await app.inject({
+        method: "PATCH",
+        url: `/api/v1/orgs/${admin.organizationId}/members/${target.id}`,
+        headers: { authorization: `Bearer ${admin.accessToken}` },
+        payload: {},
+      });
+      expect(patchRes.statusCode).toBe(404);
+    });
   });
 
   describe("DELETE /api/v1/members/:id", () => {
@@ -114,6 +152,34 @@ describe("Members API", () => {
       const listRes = await req("GET", "/api/v1/members");
       const members = listRes.json<Array<{ id: string }>>();
       expect(members.find((m: { id: string }) => m.id === id)).toBeUndefined();
+    });
+
+    it("returns 404 and leaves the target intact when deleting a member from another org", async () => {
+      const app = getApp();
+      const admin = await createTestAdmin(app, { username: `delete-idor-admin-${randomUUID().slice(0, 8)}` });
+      const { otherOrg, target } = await createOtherOrgTargetMember(app, "delete-idor");
+
+      const deleteRes = await app.inject({
+        method: "DELETE",
+        url: `/api/v1/orgs/${admin.organizationId}/members/${target.id}`,
+        headers: { authorization: `Bearer ${admin.accessToken}` },
+      });
+      expect(deleteRes.statusCode).toBe(404);
+
+      const [memberRow] = await app.db
+        .select({ id: membersTable.id, organizationId: membersTable.organizationId })
+        .from(membersTable)
+        .where(eq(membersTable.id, target.id))
+        .limit(1);
+      expect(memberRow).toEqual({ id: target.id, organizationId: otherOrg.id });
+
+      const [agentRow] = await app.db
+        .select({ status: agentsTable.status, name: agentsTable.name })
+        .from(agentsTable)
+        .where(eq(agentsTable.uuid, target.agentId))
+        .limit(1);
+      expect(agentRow?.status).toBe("active");
+      expect(agentRow?.name).not.toBeNull();
     });
   });
 

--- a/packages/server/src/api/orgs/members.ts
+++ b/packages/server/src/api/orgs/members.ts
@@ -24,8 +24,8 @@ export async function orgMemberRoutes(app: FastifyInstance): Promise<void> {
   });
 
   app.delete<{ Params: { orgId: string; id: string } }>("/:id", async (request, reply) => {
-    await requireOrgAdmin(request, app.db);
-    await memberService.deleteMember(app.db, request.params.id);
+    const scope = await requireOrgAdmin(request, app.db);
+    await memberService.deleteMember(app.db, request.params.id, scope.organizationId);
     return reply.status(204).send();
   });
 }

--- a/packages/server/src/services/member.ts
+++ b/packages/server/src/services/member.ts
@@ -170,16 +170,16 @@ export async function getMember(db: Database, id: string) {
 }
 
 export async function updateMember(db: Database, id: string, data: UpdateMember, callerOrgId?: string) {
-  if (data.role === undefined && data.displayName === undefined) {
-    return getMember(db, id);
-  }
-
   const current = await getMember(db, id);
   // A cross-org admin should never be able to mutate a member in another
   // tenant. The route layer supplies its own org id; without a match we
   // 404 to avoid leaking that the member exists.
   if (callerOrgId && current.organizationId !== callerOrgId) {
     throw new NotFoundError(`Member "${id}" not found`);
+  }
+
+  if (data.role === undefined && data.displayName === undefined) {
+    return current;
   }
 
   // Prevent demoting the last admin — if the caller is turning the final
@@ -224,8 +224,13 @@ export async function updateOwnProfile(db: Database, userId: string, displayName
   return { id: userId, displayName };
 }
 
-export async function deleteMember(db: Database, id: string) {
+export async function deleteMember(db: Database, id: string, callerOrgId: string) {
   const member = await getMember(db, id);
+  // A cross-org admin should never be able to delete a member in another
+  // tenant. Return 404 to avoid leaking that the member exists.
+  if (member.organizationId !== callerOrgId) {
+    throw new NotFoundError(`Member "${id}" not found`);
+  }
 
   // Prevent deleting the last admin
   if (member.role === "admin") {


### PR DESCRIPTION
## Summary
- Pass the resolved org admin scope into member deletion and reject cross-org targets before any delete-side effects run.
- Move member update target lookup/org validation ahead of the empty-patch early return so `PATCH /orgs/:orgId/members/:id` cannot leak another org's member details.
- Add cross-org regression coverage for empty PATCH and DELETE member mutations.

## Tests
- `pnpm --filter @first-tree/server exec vitest run src/__tests__/members.test.ts --maxWorkers=2`
- `pnpm check` (passes; existing Biome warnings are outside this change)
- `pnpm typecheck`
- `git diff --check`