### PR TITLE
[codex] Guard disabled feedback fallback

### DIFF
--- a/packages/server/src/__tests__/build-app-validation.test.ts
+++ b/packages/server/src/__tests__/build-app-validation.test.ts
@@ -1,3 +1,6 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { FastifyInstance } from "fastify";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildApp } from "../app.js";
@@ -151,6 +154,30 @@ describe("buildApp — server secret validation", () => {
       }).rejects.toThrow(/FIRST_TREE_ENCRYPTION_KEY must be 32 bytes/);
     } finally {
       await safeClose(app);
+    }
+  });
+});
+
+describe("buildApp — feedback static fallback boundary", () => {
+  it("does not serve the SPA shell for feedback routes when feedback is not configured", async () => {
+    const webRoot = await mkdtemp(join(tmpdir(), "first-tree-web-"));
+    await writeFile(join(webRoot, "index.html"), "<!doctype html><html><body>App shell</body></html>", "utf8");
+
+    let app: FastifyInstance | undefined;
+    try {
+      app = await buildApp({ ...baseConfig, webDistPath: webRoot });
+
+      const spa = await app.inject({ method: "GET", url: "/workspace/deep-link" });
+      expect(spa.statusCode).toBe(200);
+      expect(spa.body).toContain("App shell");
+
+      const feedback = await app.inject({ method: "POST", url: "/feedback/chat" });
+      expect(feedback.statusCode).toBe(501);
+      expect(feedback.headers["content-type"]).toContain("application/json");
+      expect(feedback.json()).toEqual({ error: "Feedback is not configured" });
+    } finally {
+      await safeClose(app);
+      await rm(webRoot, { recursive: true, force: true });
     }
   });
 });

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -623,6 +623,9 @@ export async function buildApp(config: Config) {
           return reply.status(404).send({ error: "Not found" });
         }
         const requestPath = request.url.split("?")[0] ?? request.url;
+        if (requestPath.startsWith("/feedback/")) {
+          return reply.status(501).send({ error: "Feedback is not configured" });
+        }
         if (requestPath.startsWith("/assets/") || extname(requestPath).length > 0) {
           return reply.status(404).send({ error: "Not found" });
         }


### PR DESCRIPTION
## Summary

- Return JSON 501 for `/feedback/*` when the feedback plugin is not configured instead of serving the Web SPA shell.
- Keep ordinary SPA deep-link fallback behavior unchanged.
- Add a server regression test covering the disabled-feedback boundary.

## Root Cause

Production currently serves the hearback widget script, but `/feedback/chat` falls through to `index.html` when `config.feedback` is absent. That produces a 200 `text/html` response for a feedback API route, which can be mistaken for an available chat endpoint.

## Validation

- `pnpm check`
- `pnpm --filter @first-tree/server exec vitest run src/__tests__/build-app-validation.test.ts -t "feedback static fallback"`
- `pnpm --filter @first-tree/server typecheck`

Note: this makes the disabled feedback state explicit. Production still needs the feedback/LLM environment configured to actually accept hearback reports.