### PR TITLE
Refactor inbox ACK runtime state

### DIFF
--- a/packages/client/src/__tests__/agent-cwd-redesign.e2e.test.ts
+++ b/packages/client/src/__tests__/agent-cwd-redesign.e2e.test.ts
@@ -117,8 +117,7 @@ function buildSessionCtx(chatId: string): SessionContext {
     sdk: { serverUrl: "http://test", sendMessage } as unknown as SessionContext["sdk"],
     chatId,
     log: () => {},
-    touch: () => {},
-    setRuntimeState: () => {},
+    recordProviderActivity: () => {},
     emitEvent: () => {},
     ...mockCtxPlumbing({ sendMessage }, chatId),
   };

--- a/packages/client/src/__tests__/claude-code-inject-startup-race.test.ts
+++ b/packages/client/src/__tests__/claude-code-inject-startup-race.test.ts
@@ -114,7 +114,7 @@ function makeMessage(id: string, content: string): SessionMessage {
 }
 
 function makeContext(
-  markCompleted: (count?: number) => void,
+  onFinishTurn: (count?: number) => void,
   opts: { formatInboundContent?: SessionContext["formatInboundContent"] } = {},
 ): SessionContext {
   const sendMessage = vi.fn().mockResolvedValue(undefined);
@@ -131,13 +131,13 @@ function makeContext(
     sdk: { serverUrl: "http://test", sendMessage } as unknown as SessionContext["sdk"],
     chatId: "chat-claude-startup-race",
     log: () => {},
-    touch: () => {},
-    setRuntimeState: () => {},
+    recordProviderActivity: () => {},
     emitEvent: () => {},
     ...mockCtxPlumbing({ sendMessage }, "chat-claude-startup-race"),
     ...(opts.formatInboundContent ? { formatInboundContent: opts.formatInboundContent } : {}),
-    markCompleted,
-    markMessagesCompleted: () => markCompleted(),
+    finishTurn: async () => {
+      onFinishTurn();
+    },
   };
 }
 

--- a/packages/client/src/__tests__/claude-code-result-forward-fail.test.ts
+++ b/packages/client/src/__tests__/claude-code-result-forward-fail.test.ts
@@ -89,8 +89,7 @@ describe("claude-code handler — sendMessage failure surfaces lost result", () 
       sdk: { serverUrl: "http://test", sendMessage } as unknown as SessionContext["sdk"],
       chatId: "chat-1",
       log: () => {},
-      touch: () => {},
-      setRuntimeState: () => {},
+      recordProviderActivity: () => {},
       emitEvent: (e) => {
         emitted.push(e);
       },

--- a/packages/client/src/__tests__/claude-code-sdk-options.test.ts
+++ b/packages/client/src/__tests__/claude-code-sdk-options.test.ts
@@ -86,8 +86,7 @@ function buildSessionCtx(chatId: string): SessionContext {
     sdk: { serverUrl: "http://test", sendMessage } as unknown as SessionContext["sdk"],
     chatId,
     log: () => {},
-    touch: () => {},
-    setRuntimeState: () => {},
+    recordProviderActivity: () => {},
     emitEvent: () => {},
     ...mockCtxPlumbing({ sendMessage }, chatId),
   };

--- a/packages/client/src/__tests__/claude-code-stream-error-retry-replay.test.ts
+++ b/packages/client/src/__tests__/claude-code-stream-error-retry-replay.test.ts
@@ -130,8 +130,7 @@ describe("claude-code handler — transient stream-error retry replays user mess
     const sendMessage = vi.fn().mockResolvedValue(undefined);
     const emitted: SessionEvent[] = [];
     const logs: string[] = [];
-    const runtimeStates: string[] = [];
-    const markCompleted = vi.fn();
+    const finishTurnCalled = vi.fn();
 
     const cache = buildCache();
     await cache.refresh(AGENT_ID);
@@ -150,12 +149,12 @@ describe("claude-code handler — transient stream-error retry replays user mess
       sdk: { serverUrl: "http://test", sendMessage } as unknown as SessionContext["sdk"],
       chatId: "chat-stream-retry",
       log: (m) => logs.push(m),
-      touch: () => {},
-      setRuntimeState: (state) => runtimeStates.push(state),
+      recordProviderActivity: () => {},
       emitEvent: (e) => emitted.push(e),
       ...mockCtxPlumbing({ sendMessage }, "chat-stream-retry"),
-      markCompleted,
-      markMessagesCompleted: () => markCompleted(),
+      finishTurn: async () => {
+        finishTurnCalled();
+      },
     };
 
     await handler.start(
@@ -193,7 +192,7 @@ describe("claude-code handler — transient stream-error retry replays user mess
     // After both retries fail transient (same wrapped API error every
     // time), the handler must end in the retry-exhausted / permanent
     // branch and ack — per PR #612 § "permanent → ack".
-    expect(markCompleted).toHaveBeenCalledTimes(1);
+    expect(finishTurnCalled).toHaveBeenCalledTimes(1);
 
     // A user-visible error must be surfaced on retry-exhaustion (so the
     // chat timeline shows what happened), AND the turn must be closed

--- a/packages/client/src/__tests__/claude-code-turn-end-auto-resume-fail.test.ts
+++ b/packages/client/src/__tests__/claude-code-turn-end-auto-resume-fail.test.ts
@@ -80,12 +80,11 @@ function buildCache() {
 }
 
 describe("claude-code handler — auto-resume failure surfacing", () => {
-  it("emits error + turn_end:error, flips runtimeState, AND acks the in-flight entry when respawnQuery throws", async () => {
+  it("emits error + turn_end:error and finishes the in-flight entry when respawnQuery throws", async () => {
     queryCallCount = 0;
     const sendMessage = vi.fn().mockResolvedValue(undefined);
     const emitted: SessionEvent[] = [];
-    const runtimeStates: string[] = [];
-    const markCompleted = vi.fn();
+    const finishTurnCalled = vi.fn();
 
     const cache = buildCache();
     await cache.refresh(AGENT_ID);
@@ -104,12 +103,12 @@ describe("claude-code handler — auto-resume failure surfacing", () => {
       sdk: { serverUrl: "http://test", sendMessage } as unknown as SessionContext["sdk"],
       chatId: "chat-resume-fail",
       log: () => {},
-      touch: () => {},
-      setRuntimeState: (state) => runtimeStates.push(state),
+      recordProviderActivity: () => {},
       emitEvent: (e) => emitted.push(e),
       ...mockCtxPlumbing({ sendMessage }, "chat-resume-fail"),
-      markCompleted,
-      markMessagesCompleted: () => markCompleted(),
+      finishTurn: async () => {
+        finishTurnCalled();
+      },
     };
 
     await handler.start(
@@ -139,14 +138,10 @@ describe("claude-code handler — auto-resume failure surfacing", () => {
     const turnEndIdx = emitted.findIndex((e) => e.kind === "turn_end");
     expect(errIdx).toBeLessThan(turnEndIdx);
 
-    // setRuntimeState("error") MUST run so the SessionManager can reclaim
-    // the slot even though respawnQuery never produced a working session.
-    expect(runtimeStates).toContain("error");
-
     // Reviewer Blocking 2 regression: the auto-resume-failure return MUST
     // ack the entry. Without this the row stays `delivered` server-side
     // and the in-process Deduplicator collapses every bind-reset replay
     // (entry → server → push → dispatch dedup skip → never re-acked).
-    expect(markCompleted).toHaveBeenCalledTimes(1);
+    expect(finishTurnCalled).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/client/src/__tests__/claude-code-turn-end-retry-exhausted.test.ts
+++ b/packages/client/src/__tests__/claude-code-turn-end-retry-exhausted.test.ts
@@ -67,11 +67,10 @@ function buildCache() {
 }
 
 describe("claude-code handler — retry-exhausted surfacing", () => {
-  it("emits error + turn_end:error, flips runtimeState to error, AND acks the in-flight entry after MAX_RETRIES", async () => {
+  it("emits error + turn_end:error and finishes the in-flight entry after MAX_RETRIES", async () => {
     const sendMessage = vi.fn().mockResolvedValue(undefined);
     const emitted: SessionEvent[] = [];
-    const runtimeStates: string[] = [];
-    const markCompleted = vi.fn();
+    const finishTurnCalled = vi.fn();
 
     const cache = buildCache();
     await cache.refresh(AGENT_ID);
@@ -90,12 +89,12 @@ describe("claude-code handler — retry-exhausted surfacing", () => {
       sdk: { serverUrl: "http://test", sendMessage } as unknown as SessionContext["sdk"],
       chatId: "chat-retry",
       log: () => {},
-      touch: () => {},
-      setRuntimeState: (state) => runtimeStates.push(state),
+      recordProviderActivity: () => {},
       emitEvent: (e) => emitted.push(e),
       ...mockCtxPlumbing({ sendMessage }, "chat-retry"),
-      markCompleted,
-      markMessagesCompleted: () => markCompleted(),
+      finishTurn: async () => {
+        finishTurnCalled();
+      },
     };
 
     await handler.start(
@@ -111,7 +110,7 @@ describe("claude-code handler — retry-exhausted surfacing", () => {
     // Reviewer Blocking 2 regression: the retry-exhausted return MUST ack
     // the entry. Without this the row sits `delivered` forever and the
     // in-process Deduplicator collapses every bind-reset replay.
-    expect(markCompleted).toHaveBeenCalledTimes(1);
+    expect(finishTurnCalled).toHaveBeenCalledTimes(1);
 
     const errors = emitted.filter((e) => e.kind === "error");
     expect(errors).toHaveLength(1);
@@ -134,18 +133,10 @@ describe("claude-code handler — retry-exhausted surfacing", () => {
     const turnEndIdx = emitted.findIndex((e) => e.kind === "turn_end");
     expect(errIdx).toBeLessThan(turnEndIdx);
 
-    // setRuntimeState("error") MUST run so the SessionManager's idle path
-    // can reclaim the slot. (Pre-fix this was the only signal of failure.)
-    expect(runtimeStates).toContain("error");
   });
 
-  it("still flips runtimeState to error even when emitEvent throws", async () => {
-    // Defensive contract: if the onSessionEvent callback throws (e.g. the
-    // agent-slot reporting hits a dead WS), the handler must still run
-    // setRuntimeState("error") so the SessionManager can reclaim the slot.
-    // Without this, the session stays counted as `working` forever.
+  it("still returns when emitEvent throws", async () => {
     const sendMessage = vi.fn().mockResolvedValue(undefined);
-    const runtimeStates: string[] = [];
 
     const cache = buildCache();
     await cache.refresh(AGENT_ID);
@@ -164,8 +155,7 @@ describe("claude-code handler — retry-exhausted surfacing", () => {
       sdk: { serverUrl: "http://test", sendMessage } as unknown as SessionContext["sdk"],
       chatId: "chat-retry-emit-throw",
       log: () => {},
-      touch: () => {},
-      setRuntimeState: (state) => runtimeStates.push(state),
+      recordProviderActivity: () => {},
       emitEvent: () => {
         throw new Error("event sink down");
       },
@@ -178,7 +168,5 @@ describe("claude-code handler — retry-exhausted surfacing", () => {
     );
     await handler.suspend();
     await new Promise((r) => setImmediate(r));
-
-    expect(runtimeStates).toContain("error");
   });
 });

--- a/packages/client/src/__tests__/claude-code-turn-end-retry-exhausted.test.ts
+++ b/packages/client/src/__tests__/claude-code-turn-end-retry-exhausted.test.ts
@@ -132,7 +132,6 @@ describe("claude-code handler — retry-exhausted surfacing", () => {
     const errIdx = emitted.findIndex((e) => e.kind === "error");
     const turnEndIdx = emitted.findIndex((e) => e.kind === "turn_end");
     expect(errIdx).toBeLessThan(turnEndIdx);
-
   });
 
   it("still returns when emitEvent throws", async () => {

--- a/packages/client/src/__tests__/claude-code-turn-end-sdk-error.test.ts
+++ b/packages/client/src/__tests__/claude-code-turn-end-sdk-error.test.ts
@@ -93,8 +93,7 @@ describe("claude-code handler — turn_end on SDK-reported subtype error", () =>
       sdk: { serverUrl: "http://test", sendMessage } as unknown as SessionContext["sdk"],
       chatId: "chat-1",
       log: () => {},
-      touch: () => {},
-      setRuntimeState: () => {},
+      recordProviderActivity: () => {},
       emitEvent: (e) => emitted.push(e),
       ...mockCtxPlumbing({ sendMessage }, "chat-1"),
     };

--- a/packages/client/src/__tests__/claude-code-turn-end-serialization.test.ts
+++ b/packages/client/src/__tests__/claude-code-turn-end-serialization.test.ts
@@ -120,8 +120,7 @@ describe("claude-code handler — turn_end serialization (race guard)", () => {
       sdk: { serverUrl: "http://test", sendMessage } as unknown as SessionContext["sdk"],
       chatId: "chat-1",
       log: () => {},
-      touch: () => {},
-      setRuntimeState: () => {},
+      recordProviderActivity: () => {},
       emitEvent: (e: SessionEvent) => {
         emitted.push({ kind: e.kind, at: Date.now() - start });
       },

--- a/packages/client/src/__tests__/claude-code-turn-end.test.ts
+++ b/packages/client/src/__tests__/claude-code-turn-end.test.ts
@@ -91,8 +91,7 @@ describe("claude-code handler — turn_end emission", () => {
       sdk: { serverUrl: "http://test", sendMessage } as unknown as SessionContext["sdk"],
       chatId: "chat-1",
       log: () => {},
-      touch: () => {},
-      setRuntimeState: () => {},
+      recordProviderActivity: () => {},
       ...mockCtxPlumbing({ sendMessage }, "chat-1"),
       emitEvent: (e) => emitted.push(e),
     };
@@ -132,8 +131,7 @@ describe("claude-code handler — turn_end emission", () => {
       sdk: { serverUrl: "http://test", sendMessage } as unknown as SessionContext["sdk"],
       chatId: "chat-1",
       log: () => {},
-      touch: () => {},
-      setRuntimeState: () => {},
+      recordProviderActivity: () => {},
       ...mockCtxPlumbing({ sendMessage }, "chat-1"),
       emitEvent: (e) => {
         if (e.kind === "turn_end") order.push(`turn_end:${e.payload.status}`);

--- a/packages/client/src/__tests__/codex-inject-startup-race.test.ts
+++ b/packages/client/src/__tests__/codex-inject-startup-race.test.ts
@@ -113,7 +113,7 @@ function makeMessage(id: string, content: string): SessionMessage {
 type SendMessageMock = ReturnType<typeof vi.fn<(chatId: string, body: Record<string, unknown>) => Promise<unknown>>>;
 
 function makeContext(
-  markCompleted: (count?: number) => void,
+  onFinishTurn: (count?: number) => void,
   opts: { sendMessage?: SendMessageMock; emitEvent?: SessionContext["emitEvent"] } = {},
 ): SessionContext {
   const sendMessage =
@@ -132,12 +132,12 @@ function makeContext(
     sdk: { serverUrl: "http://test", sendMessage } as unknown as SessionContext["sdk"],
     chatId: "chat-startup-race",
     log: () => {},
-    touch: () => {},
-    setRuntimeState: () => {},
+    recordProviderActivity: () => {},
     emitEvent: opts.emitEvent ?? (() => {}),
     ...mockCtxPlumbing({ sendMessage }, "chat-startup-race"),
-    markCompleted,
-    markMessagesCompleted: (messages) => markCompleted(Array.isArray(messages) ? messages.length : 1),
+    finishTurn: async (messages) => {
+      onFinishTurn(Array.isArray(messages) ? messages.length : 1);
+    },
   };
 }
 

--- a/packages/client/src/__tests__/codex-retry-abort.test.ts
+++ b/packages/client/src/__tests__/codex-retry-abort.test.ts
@@ -130,7 +130,7 @@ function makeMessage(id: string, content: string): SessionMessage {
 }
 
 function makeContext(
-  markCompleted: (count?: number) => void,
+  onFinishTurn: (count?: number) => void,
   opts: {
     sendMessage?: SendMessageMock;
     emitEvent?: SessionContext["emitEvent"];
@@ -153,12 +153,12 @@ function makeContext(
     sdk: { serverUrl: "http://test", sendMessage } as unknown as SessionContext["sdk"],
     chatId: "chat-retry-abort",
     log: opts.log ?? (() => {}),
-    touch: () => {},
-    setRuntimeState: () => {},
+    recordProviderActivity: () => {},
     emitEvent: opts.emitEvent ?? (() => {}),
     ...mockCtxPlumbing({ sendMessage }, "chat-retry-abort"),
-    markCompleted,
-    markMessagesCompleted: (messages) => markCompleted(Array.isArray(messages) ? messages.length : 1),
+    finishTurn: async (messages) => {
+      onFinishTurn(Array.isArray(messages) ? messages.length : 1);
+    },
   };
 }
 

--- a/packages/client/src/__tests__/codex-usage-limit.test.ts
+++ b/packages/client/src/__tests__/codex-usage-limit.test.ts
@@ -118,7 +118,7 @@ function makeMessage(id: string, content: string): SessionMessage {
 }
 
 function makeContext(
-  markCompleted: (count?: number) => void,
+  onFinishTurn: (count?: number) => void,
   opts: {
     sendMessage?: SendMessageMock;
     emitEvent?: SessionContext["emitEvent"];
@@ -141,12 +141,12 @@ function makeContext(
     sdk: { serverUrl: "http://test", sendMessage } as unknown as SessionContext["sdk"],
     chatId: "chat-usage-limit",
     log: opts.log ?? (() => {}),
-    touch: () => {},
-    setRuntimeState: () => {},
+    recordProviderActivity: () => {},
     emitEvent: opts.emitEvent ?? (() => {}),
     ...mockCtxPlumbing({ sendMessage }, "chat-usage-limit"),
-    markCompleted,
-    markMessagesCompleted: (messages) => markCompleted(Array.isArray(messages) ? messages.length : 1),
+    finishTurn: async (messages) => {
+      onFinishTurn(Array.isArray(messages) ? messages.length : 1);
+    },
   };
 }
 

--- a/packages/client/src/__tests__/gitrepos-session-integration.test.ts
+++ b/packages/client/src/__tests__/gitrepos-session-integration.test.ts
@@ -97,8 +97,7 @@ function buildSessionCtx(chatId: string, log: (msg: string) => void): SessionCon
     sdk: { serverUrl: "http://test", sendMessage } as unknown as SessionContext["sdk"],
     chatId,
     log,
-    touch: () => {},
-    setRuntimeState: () => {},
+    recordProviderActivity: () => {},
     emitEvent: () => {},
     ...mockCtxPlumbing({ sendMessage }, chatId),
   };

--- a/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
+++ b/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
@@ -33,10 +33,7 @@ type SessionRecord = {
 type SessionManagerInternals = {
   sessions: Map<string, SessionRecord>;
   evictedMappings: Map<string, { claudeSessionId: string; lastActivity: number }>;
-  // entryId tracking moved out of PendingMessage and into a per-chat
-  // FIFO (`inFlightEntries`) per the in-flight message recovery PR.
   pendingQueue: Array<{ message: SessionMessage; chatId: string }>;
-  inFlightEntries: Map<string, Array<{ entryId: number; messageId: string; dedupKey: string }>>;
   _activeCount: number;
   acquireActiveSlot(chatId: string, message: SessionMessage): boolean;
   routeMessage(chatId: string, message: SessionMessage): Promise<void>;
@@ -48,7 +45,6 @@ type SessionManagerInternals = {
   notifySessionState(chatId: string, state: SessionState): void;
   reaffirmRuntimeStates(): void;
   persistRegistry(): void;
-  drainAllInFlightEntries(chatId: string): void;
 };
 
 type TestRuntimeState = RuntimeState;
@@ -248,7 +244,11 @@ describe("SessionManager edge coverage", () => {
   });
 
   it("handles suspend, terminate, pending-queue cleanup, ack failures, and quiet-gate snapshots", async () => {
-    const first = handler();
+    const first = handler({
+      async start() {
+        return "idle-log-session";
+      },
+    });
     const ackEntry = vi
       .fn<(entryId: number) => Promise<void>>()
       .mockResolvedValueOnce(undefined)
@@ -277,8 +277,7 @@ describe("SessionManager edge coverage", () => {
     // Same-socket recovery fail-closed: suspending clears unfinished local
     // entries and newer same-chat input asks the server to reset/redeliver
     // before the handler resumes.
-    expect(internals(sm).inFlightEntries.has("chat-active")).toBe(false);
-    expect(recoverChat).toHaveBeenCalledTimes(2);
+    expect(recoverChat).toHaveBeenCalledTimes(1);
     expect(ackEntry).not.toHaveBeenCalledWith(2);
 
     internals(sm).pendingQueue.push({ chatId: "chat-queued", message: makeMessage("chat-queued") });
@@ -368,7 +367,7 @@ describe("SessionManager edge coverage", () => {
       async start(_message, ctx) {
         captured = ctx;
         ctx.log("started");
-        ctx.touch();
+        ctx.recordProviderActivity();
         return "session-context";
       },
     });
@@ -909,7 +908,7 @@ describe("SessionManager edge coverage", () => {
     await stringFailure.shutdown();
   });
 
-  it("reports runtime snapshots only for active sessions and ignores inactive runtime writes", async () => {
+  it("reports runtime snapshots only for active sessions and ignores inactive provider activity", async () => {
     const runtimeChanges: RuntimeState[] = [];
     let captured: SessionContext | undefined;
     const sm = makeManager({
@@ -926,10 +925,11 @@ describe("SessionManager edge coverage", () => {
     });
 
     await sm.dispatch(mockEntry({ id: 1, chatId: "chat-runtime" }));
-    expect(sm.getSessionRuntimeStates()).toEqual([{ chatId: "chat-runtime", runtimeState: "idle" }]);
+    expect(sm.getSessionRuntimeStates()).toEqual([{ chatId: "chat-runtime", runtimeState: "working" }]);
     if (!captured) throw new Error("context was not captured");
+    runtimeChanges.length = 0;
     await sm.handleCommand("chat-runtime", "session:suspend");
-    captured.setRuntimeState("working");
+    captured.recordProviderActivity();
     expect(runtimeChanges).not.toContain("working");
 
     internals(sm).reaffirmRuntimeStates();
@@ -939,7 +939,15 @@ describe("SessionManager edge coverage", () => {
   it("uses idle fallback in evictIdle logging when no runtime state was recorded", async () => {
     vi.useFakeTimers({ now: 100_000 });
     const log = recordingLogger();
-    const first = handler();
+    let captured: SessionContext | undefined;
+    let capturedMessage: SessionMessage | undefined;
+    const first = handler({
+      async start(message, ctx) {
+        capturedMessage = message;
+        captured = ctx;
+        return "idle-log-session";
+      },
+    });
     const sm = new SessionManager({
       session: { idle_timeout: 1, max_sessions: 10, working_grace_seconds: 1, reconcile_interval_seconds: 300 },
       concurrency: 5,
@@ -960,6 +968,8 @@ describe("SessionManager edge coverage", () => {
     });
 
     await sm.dispatch(mockEntry({ id: 1, chatId: "chat-idle-log" }));
+    if (!capturedMessage) throw new Error("message was not captured");
+    await captured?.finishTurn(capturedMessage, { status: "success", terminal: true });
     vi.advanceTimersByTime(2_000);
 
     vi.advanceTimersByTime(10_000);

--- a/packages/client/src/__tests__/session-manager-retry.test.ts
+++ b/packages/client/src/__tests__/session-manager-retry.test.ts
@@ -1,6 +1,6 @@
 import type { SessionEvent, SessionState } from "@first-tree/shared";
 import { describe, expect, it, vi } from "vitest";
-import type { AgentHandler, HandlerFactory } from "../runtime/handler.js";
+import type { AgentHandler, HandlerFactory, SessionContext, SessionMessage } from "../runtime/handler.js";
 import { SessionManager } from "../runtime/session-manager.js";
 import type { FirstTreeHubSDK } from "../sdk.js";
 import { silentLogger } from "./_logger-helpers.js";
@@ -29,6 +29,8 @@ function mockSdk(): { sdk: FirstTreeHubSDK; sendMessage: ReturnType<typeof vi.fn
 
 function makeManager(opts: {
   handlers: AgentHandler[];
+  ackEntry?: (entryId: number) => Promise<void>;
+  recoverChat?: (chatId: string) => Promise<void>;
   onStateChange?: (chatId: string, state: SessionState) => void;
   onSessionEvent?: (chatId: string, event: SessionEvent) => void;
 }): SessionManager {
@@ -53,7 +55,8 @@ function makeManager(opts: {
     },
     sdk: mockSdk().sdk,
     log: silentLogger(),
-    ackEntry: vi.fn<(entryId: number) => Promise<void>>().mockResolvedValue(undefined),
+    ackEntry: opts.ackEntry ?? vi.fn<(entryId: number) => Promise<void>>().mockResolvedValue(undefined),
+    recoverChat: opts.recoverChat,
     onStateChange: opts.onStateChange,
     onSessionEvent: opts.onSessionEvent,
   });
@@ -240,6 +243,51 @@ describe("SessionManager: transient retry on session start", () => {
     // First handler.start rejected (transient), so no claudeSessionId was
     // captured. The retry path falls back to start() on the new handler.
     expect(recovered.start).toHaveBeenCalled();
+
+    await sm.shutdown();
+  });
+
+  it("queues newer retry-window messages behind the original unconsumed prefix", async () => {
+    const ackEntry = vi.fn<(entryId: number) => Promise<void>>().mockResolvedValue(undefined);
+    const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
+    const capturedCtx: SessionContext[] = [];
+    const startedMessages: SessionMessage[] = [];
+    const injected: SessionMessage[] = [];
+    const failing: AgentHandler = {
+      start: vi.fn().mockRejectedValue(new FakeRateLimit("rate limited")),
+      resume: vi.fn(),
+      inject: vi.fn(),
+      suspend: vi.fn().mockResolvedValue(undefined),
+      shutdown: vi.fn().mockResolvedValue(undefined),
+    };
+    const recovered: AgentHandler = {
+      start: vi.fn(async (message, ctx) => {
+        startedMessages.push(message);
+        capturedCtx.push(ctx);
+        return "session-after-retry";
+      }),
+      resume: vi.fn().mockResolvedValue("session-after-retry"),
+      inject: vi.fn((message) => {
+        injected.push(message);
+      }),
+      suspend: vi.fn().mockResolvedValue(undefined),
+      shutdown: vi.fn().mockResolvedValue(undefined),
+    };
+    const sm = makeManager({ handlers: [failing, recovered], ackEntry, recoverChat });
+
+    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-prefix", messageId: "msg-1" }));
+    await sm.dispatch(mockEntry({ id: 2, chatId: "chat-prefix", messageId: "msg-2" }));
+    await vi.waitFor(() => expect(recovered.start).toHaveBeenCalledTimes(1));
+
+    expect(startedMessages[0]?.id).toBe("msg-1");
+    expect(injected.map((message) => message.id)).toEqual(["msg-2"]);
+
+    await capturedCtx[0]?.finishTurn(startedMessages[0] as SessionMessage, { status: "success", terminal: true });
+    await capturedCtx[0]?.finishTurn(injected[0] as SessionMessage, { status: "success", terminal: true });
+
+    expect(ackEntry).toHaveBeenNthCalledWith(1, 1);
+    expect(ackEntry).toHaveBeenNthCalledWith(2, 2);
+    expect(recoverChat).not.toHaveBeenCalled();
 
     await sm.shutdown();
   });

--- a/packages/client/src/__tests__/session-manager.test.ts
+++ b/packages/client/src/__tests__/session-manager.test.ts
@@ -3,7 +3,7 @@ import type pino from "pino";
 import { describe, expect, it, vi } from "vitest";
 import type { AgentConfigCache } from "../runtime/agent-config-cache.js";
 import type { ContextTreeBinding } from "../runtime/bootstrap.js";
-import type { AgentHandler, HandlerConfig, HandlerFactory, SessionContext } from "../runtime/handler.js";
+import type { AgentHandler, HandlerConfig, HandlerFactory, SessionContext, SessionMessage } from "../runtime/handler.js";
 import { SessionManager } from "../runtime/session-manager.js";
 import type { FirstTreeHubSDK } from "../sdk.js";
 import { recordingLogger, silentLogger } from "./_logger-helpers.js";
@@ -41,6 +41,26 @@ function createMockHandler(overrides?: Partial<AgentHandler>): AgentHandler {
     shutdown: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   };
+}
+
+async function finishEntry(
+  ctx: SessionContext | undefined,
+  entryId: number,
+  chatId: string,
+  messageId = `msg-${entryId}`,
+): Promise<void> {
+  await ctx?.finishTurn(
+    {
+      inboxEntryId: entryId,
+      id: messageId,
+      chatId,
+      senderId: "sender-1",
+      format: "text",
+      content: "",
+      metadata: {},
+    },
+    { status: "success", terminal: true },
+  );
 }
 
 function createSessionManager(opts: {
@@ -110,11 +130,11 @@ describe("SessionManager", () => {
     await sm.shutdown();
   });
 
-  it("does NOT ack on dispatch — entry is held until the handler calls markCompleted (in-flight recovery)", async () => {
+  it("does NOT ack on dispatch — entry is held until the handler finishes the turn (in-flight recovery)", async () => {
     // Post-inflight-message-recovery: dispatch only enqueues the entry into
-    // `inFlightEntries`. The ack waits for the handler to signal turn
-    // completion via `ctx.markCompleted()`. A bare-mocked handler never
-    // closes the turn, so no ack is fired.
+    // the delivery coordinator. The ack waits for the handler to signal turn
+    // completion via `ctx.finishTurn(...)`. A bare-mocked handler never closes
+    // the turn, so no ack is fired.
     const ackEntry = mockAckEntry();
     const sm = createSessionManager({ ackEntry });
 
@@ -125,7 +145,7 @@ describe("SessionManager", () => {
     await sm.shutdown();
   });
 
-  it("acks via the callback when the handler calls ctx.markCompleted()", async () => {
+  it("acks via the callback when the handler calls ctx.finishTurn(...)", async () => {
     // A handler that completes its turn cleanly drains the in-flight queue.
     const ackEntry = mockAckEntry();
     let capturedCtx: SessionContext | undefined;
@@ -143,9 +163,7 @@ describe("SessionManager", () => {
     // Handler closes the turn — this is what claude-code / codex do after
     // forwardResult success.
     expect(capturedCtx).not.toBeNull();
-    capturedCtx?.markCompleted();
-    // Drain is fire-and-forget — yield once so the ackEntry promise settles.
-    await Promise.resolve();
+    await finishEntry(capturedCtx, 42, "chat-1");
     expect(ackEntry).toHaveBeenCalledWith(42);
 
     await sm.shutdown();
@@ -222,12 +240,12 @@ describe("SessionManager", () => {
     await sm.shutdown();
   });
 
-  it("does NOT re-ack a dedup-hit while the entry is still in-flight (handler hasn't markCompleted yet)", async () => {
+  it("does NOT re-ack a dedup-hit while the entry is still in-flight (handler has not finished the turn yet)", async () => {
     // The first dispatch creates the in-flight slot; the second dispatch
     // (same chatId+messageId, same entryId — what `agent:bind` reset +
     // drainBacklog produces while a turn is still mid-flight) must NOT
     // ack — that would defuse inflight-message-recovery if this process
-    // crashed mid-turn. The eventual `markCompleted` is the only thing
+    // crashed mid-turn. The eventual `finishTurn` is the only thing
     // that should ack while the turn is open.
     const ackEntry = mockAckEntry();
     const handler = createMockHandler();
@@ -236,8 +254,9 @@ describe("SessionManager", () => {
     await sm.dispatch(mockEntry({ id: 50, chatId: "chat-mid", messageId: "msg-mid" }));
     await sm.dispatch(mockEntry({ id: 50, chatId: "chat-mid", messageId: "msg-mid" }));
 
-    // Second dispatch is a dedup-hit, but the entry is still in inFlightEntries
-    // (handler never called markCompleted in this test), so re-ack must be skipped.
+    // Second dispatch is a dedup-hit, but the entry is still tracked by the
+    // coordinator (handler never called finishTurn in this test), so re-ack
+    // must be skipped.
     expect(ackEntry).not.toHaveBeenCalled();
     expect(handler.start).toHaveBeenCalledTimes(1);
 
@@ -245,8 +264,8 @@ describe("SessionManager", () => {
   });
 
   it("does NOT re-ack a dedup-hit whose chat was LRU-evicted — the bind-reset recovery path must stay open", async () => {
-    // R5 boundary: LRU eviction removes the entry from `inFlightEntries`
-    // WITHOUT acking it (no handler will ever fire markCompleted). The
+    // R5 boundary: LRU eviction moves the entry to recovery debt WITHOUT
+    // acking it (no handler will ever call finishTurn). The
     // recovery contract documented in `evictIfNeeded` is "server's
     // bind-reset redelivers against a fresh session." Pre-this-PR the
     // dispatch dedup short-circuit silently returned, the evicted chat's
@@ -282,17 +301,20 @@ describe("SessionManager", () => {
 
     // chat-c trips evictIfNeeded — sessions.size (2) >= max_sessions (2),
     // chat-a is the LRU candidate and gets evicted (chat-a:msg-a should
-    // come out of the dedup set as part of eviction).
+    // come out of the dedup set as part of eviction), then proactively
+    // requests chat-scoped recovery for its unacked work.
     const chatC = mockEntry({ id: 72, chatId: "chat-c", messageId: "msg-c" });
     await sm.dispatch(chatC);
     await sm.dispatch(chatC);
     expect(startSpy).toHaveBeenCalledTimes(3);
-    // Nothing has been acked yet — none of the mock handlers call markCompleted.
+    expect(recoverChat).toHaveBeenCalledTimes(1);
+    expect(recoverChat).toHaveBeenCalledWith("chat-a");
+    // Nothing has been acked yet — none of the mock handlers call finishTurn.
     expect(ackEntry).not.toHaveBeenCalled();
 
-    // Simulate chat-scoped recovery and redelivery of the SAME entry for
-    // the LRU-evicted chat. The first dispatch asks the server to recover;
-    // the second represents the redelivered frame.
+    // Simulate redelivery of the SAME entry for the LRU-evicted chat after
+    // proactive recovery. The first dispatch resumes from evictedMappings;
+    // the second is a duplicate-in-flight redelivery and is ignored.
     await sm.dispatch(chatA);
     await sm.dispatch(chatA);
 
@@ -300,7 +322,7 @@ describe("SessionManager", () => {
     // evicted, so the new dispatch resumes from evictedMappings).
     expect(resumeSpy).toHaveBeenCalledTimes(1);
     // Critically: NO ack for the evicted entry. The fresh session will
-    // ack it when its handler calls markCompleted at turn end.
+    // ack it when its handler calls finishTurn at turn end.
     expect(ackEntry).not.toHaveBeenCalled();
 
     await sm.shutdown();
@@ -319,8 +341,7 @@ describe("SessionManager", () => {
 
     // Turn 1: original delivery.
     await sm.dispatch(mockEntry({ id: 60, chatId: "chat-redeliver", messageId: "msg-redeliver" }));
-    capturedCtx?.markCompleted();
-    await Promise.resolve();
+    await finishEntry(capturedCtx, 60, "chat-redeliver", "msg-redeliver");
     expect(ackEntry).toHaveBeenCalledTimes(1);
     expect(ackEntry).toHaveBeenLastCalledWith(60);
 
@@ -399,7 +420,7 @@ describe("SessionManager", () => {
     expect(handler.shutdown).toHaveBeenCalledTimes(1);
   });
 
-  it("passes SessionContext with chatId and touch()", async () => {
+  it("passes SessionContext with chatId and provider activity callback", async () => {
     let capturedCtx: SessionContext | undefined;
     const handler = createMockHandler({
       async start(_msg, ctx) {
@@ -416,7 +437,7 @@ describe("SessionManager", () => {
     expect(capturedCtx).toBeDefined();
     expect(capturedCtx?.chatId).toBe("chat-1");
     expect(capturedCtx?.agent.agentId).toBe("agent-1");
-    expect(typeof capturedCtx?.touch).toBe("function");
+    expect(typeof capturedCtx?.recordProviderActivity).toBe("function");
     expect(typeof capturedCtx?.log).toBe("function");
     expect(capturedCtx?.sdk).toBe(sdk);
 
@@ -610,8 +631,8 @@ describe("SessionManager dispatch integration", () => {
     //
     // Post-inflight-message-recovery: dispatch starts the handler but does
     // NOT ack immediately; ack happens once the handler calls
-    // `ctx.markCompleted()`. We close the turn here to exercise both
-    // halves of the contract.
+    // `ctx.finishTurn(...)`. We close the turn here to exercise both halves
+    // of the contract.
     let capturedCtx: SessionContext | undefined;
     const handler = createMockHandler();
     const startSpy = handler.start as ReturnType<typeof vi.fn>;
@@ -633,8 +654,7 @@ describe("SessionManager dispatch integration", () => {
     expect(handler.start).toHaveBeenCalledTimes(1);
     expect(ackEntry).not.toHaveBeenCalled();
 
-    capturedCtx?.markCompleted();
-    await Promise.resolve();
+    await finishEntry(capturedCtx, 101, "grp-2");
     expect(ackEntry).toHaveBeenCalledWith(101);
 
     await sm.shutdown();
@@ -644,8 +664,8 @@ describe("SessionManager dispatch integration", () => {
 /**
  * `ackEntry` is the WS data-plane ack callback wired from AgentSlot to
  * `clientConnection.sendInboxAck`. Post-inflight-message-recovery the
- * runtime defers acks: every entry sits in `inFlightEntries[chatId]` until
- * the handler calls `ctx.markCompleted()`, the runtime drains the queue
+ * runtime defers acks: every entry sits in the delivery coordinator until
+ * the handler calls `ctx.finishTurn(...)`, the runtime drains the queue
  * during a permanent failure / terminate teardown, or the next
  * `agent:bind` resets it server-side. Tests below pin the deferred-ack
  * contract for each entry-point dispatch can hit.
@@ -680,7 +700,79 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     return { sm, handler: h };
   }
 
-  it("ack waits for markCompleted when starting a new session", async () => {
+  it("starts a fresh chat without same-socket recovery even when recoverChat is configured", async () => {
+    const ackEntry = vi.fn().mockResolvedValue(undefined);
+    const recoverChat = vi.fn().mockResolvedValue(undefined);
+    const startSpy = vi.fn(async () => "session-id-mock");
+    const handler = createMockHandler({ start: startSpy });
+    const { sm } = buildSm(ackEntry, handler, recoverChat);
+
+    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-fresh", messageId: "msg-fresh" }));
+
+    expect(recoverChat).not.toHaveBeenCalled();
+    expect(startSpy).toHaveBeenCalledTimes(1);
+
+    await sm.shutdown();
+  });
+
+  it("does not duplicate ACK-through when suspend races an ACK-pending finishTurn", async () => {
+    const ack = deferred<void>();
+    const ackEntry = vi.fn().mockReturnValue(ack.promise);
+    let capturedCtx: SessionContext | undefined;
+    let capturedMessage: SessionMessage | undefined;
+    const handler = createMockHandler({
+      async start(message, ctx) {
+        capturedMessage = message;
+        capturedCtx = ctx;
+        return "session-id-mock";
+      },
+    });
+    const { sm } = buildSm(ackEntry, handler);
+
+    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-ack-pending", messageId: "msg-ack-pending" }));
+    if (!capturedCtx || !capturedMessage) throw new Error("message was not captured");
+
+    const finish = capturedCtx.finishTurn(capturedMessage, { status: "success", terminal: true });
+    await vi.waitFor(() => expect(ackEntry).toHaveBeenCalledTimes(1));
+
+    await sm.handleCommand("chat-ack-pending", "session:suspend");
+    await Promise.resolve();
+    expect(ackEntry).toHaveBeenCalledTimes(1);
+
+    ack.resolve(undefined);
+    await finish;
+    await Promise.resolve();
+    expect(ackEntry).toHaveBeenCalledTimes(1);
+
+    await sm.shutdown();
+  });
+
+  it("requests chat recovery when concurrency preemption interrupts owed work", async () => {
+    const ackEntry = vi.fn().mockResolvedValue(undefined);
+    const recoverChat = vi.fn().mockResolvedValue(undefined);
+    const startSpy = vi.fn(async () => "session-id-mock");
+    const handler = createMockHandler({ start: startSpy });
+    const sm = createSessionManager({
+      ackEntry,
+      handler,
+      recoverChat,
+      concurrency: 1,
+      session: { idle_timeout: 300, max_sessions: 10, working_grace_seconds: 3600, reconcile_interval_seconds: 300 },
+    });
+
+    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-preempted", messageId: "msg-preempted" }));
+    expect(recoverChat).not.toHaveBeenCalled();
+
+    await sm.dispatch(mockEntry({ id: 2, chatId: "chat-new-slot", messageId: "msg-new-slot" }));
+
+    expect(recoverChat).toHaveBeenCalledTimes(1);
+    expect(recoverChat).toHaveBeenCalledWith("chat-preempted");
+    expect(ackEntry).not.toHaveBeenCalled();
+
+    await sm.shutdown();
+  });
+
+  it("ack waits for finishTurn when starting a new session", async () => {
     const ackEntry = vi.fn().mockResolvedValue(undefined);
     let capturedCtx: SessionContext | undefined;
     const handler = createMockHandler({
@@ -694,15 +786,14 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     await sm.dispatch(mockEntry({ id: 1, chatId: "chat-1" }));
     expect(ackEntry).not.toHaveBeenCalled();
 
-    capturedCtx?.markCompleted();
-    await Promise.resolve();
+    await finishEntry(capturedCtx, 1, "chat-1");
     expect(ackEntry).toHaveBeenCalledTimes(1);
     expect(ackEntry).toHaveBeenCalledWith(1);
 
     await sm.shutdown();
   });
 
-  it("markMessagesCompleted(message) acks through the concrete consumed entry only", async () => {
+  it("finishTurn(message) acks through the concrete consumed entry only", async () => {
     const ackEntry = vi.fn().mockResolvedValue(undefined);
     let capturedCtx: SessionContext | undefined;
     let firstMessage: Parameters<AgentHandler["start"]>[0] | undefined;
@@ -725,21 +816,19 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     expect(ackEntry).not.toHaveBeenCalled();
 
     // First turn closes — ack entry #1 only.
-    if (firstMessage) capturedCtx?.markMessagesCompleted(firstMessage);
-    await Promise.resolve();
+    if (firstMessage) await capturedCtx?.finishTurn(firstMessage, { status: "success", terminal: true });
     expect(ackEntry).toHaveBeenCalledTimes(1);
     expect(ackEntry).toHaveBeenCalledWith(1);
 
     // Second turn closes — ack entry #2.
-    if (injected[0]) capturedCtx?.markMessagesCompleted(injected[0]);
-    await Promise.resolve();
+    if (injected[0]) await capturedCtx?.finishTurn(injected[0], { status: "success", terminal: true });
     expect(ackEntry).toHaveBeenCalledTimes(2);
     expect(ackEntry).toHaveBeenNthCalledWith(2, 2);
 
     await sm.shutdown();
   });
 
-  it("markMessagesCompleted(batch) sends one ack-through for the batch tail", async () => {
+  it("finishTurn(batch) sends one ack-through for the batch tail", async () => {
     const ackEntry = vi.fn().mockResolvedValue(undefined);
     let capturedCtx: SessionContext | undefined;
     let firstMessage: Parameters<AgentHandler["start"]>[0] | undefined;
@@ -762,21 +851,19 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     expect(ackEntry).not.toHaveBeenCalled();
 
     // First turn (just message 10).
-    if (firstMessage) capturedCtx?.markMessagesCompleted(firstMessage);
-    await Promise.resolve();
+    if (firstMessage) await capturedCtx?.finishTurn(firstMessage, { status: "success", terminal: true });
     expect(ackEntry).toHaveBeenCalledTimes(1);
     expect(ackEntry).toHaveBeenCalledWith(10);
 
     // Fused turn (messages 11 + 12 batched into one runTurn).
-    capturedCtx?.markMessagesCompleted(injected);
-    await Promise.resolve();
+    await capturedCtx?.finishTurn(injected, { status: "success", terminal: true });
     expect(ackEntry).toHaveBeenCalledTimes(2);
     expect(ackEntry).toHaveBeenNthCalledWith(2, 12);
 
     await sm.shutdown();
   });
 
-  it("markMessagesCompleted ignores stale messages that are no longer tracked", async () => {
+  it("finishTurn ignores stale messages that are no longer tracked", async () => {
     const ackEntry = vi.fn().mockResolvedValue(undefined);
     let capturedCtx: SessionContext | undefined;
     let capturedMessage: Parameters<AgentHandler["start"]>[0] | undefined;
@@ -790,13 +877,11 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     const { sm } = buildSm(ackEntry, handler);
 
     await sm.dispatch(mockEntry({ id: 20, chatId: "chat-clamp" }));
-    if (capturedMessage) capturedCtx?.markMessagesCompleted(capturedMessage);
-    await Promise.resolve();
+    if (capturedMessage) await capturedCtx?.finishTurn(capturedMessage, { status: "success", terminal: true });
     expect(ackEntry).toHaveBeenCalledTimes(1);
     expect(ackEntry).toHaveBeenCalledWith(20);
 
-    if (capturedMessage) capturedCtx?.markMessagesCompleted(capturedMessage);
-    await Promise.resolve();
+    if (capturedMessage) await capturedCtx?.finishTurn(capturedMessage, { status: "success", terminal: true });
     expect(ackEntry).toHaveBeenCalledTimes(1);
 
     await sm.shutdown();
@@ -820,10 +905,12 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     const routed: string[] = [];
     const injected: Parameters<AgentHandler["inject"]>[0][] = [];
     let capturedCtx: SessionContext | undefined;
+    let startedMessage: SessionMessage | undefined;
     const handler = createMockHandler({
       async start(m, ctx) {
         routed.push(`start:${m.id}`);
         capturedCtx = ctx;
+        startedMessage = m;
         return "session-id-mock";
       },
       inject: vi.fn((m) => {
@@ -851,15 +938,15 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     expect(routed).toEqual(["start:msg-a1", "inject:msg-a2"]);
     expect(agentConfigCache.refreshIfNewer).toHaveBeenCalledTimes(2);
 
-    if (injected[0]) capturedCtx?.markMessagesCompleted(injected[0]);
-    await Promise.resolve();
+    if (!startedMessage || !injected[0] || !capturedCtx) throw new Error("messages were not captured");
+    await capturedCtx.finishTurn([startedMessage, injected[0]], { status: "success", terminal: true });
     expect(ackEntry).toHaveBeenCalledTimes(1);
     expect(ackEntry).toHaveBeenCalledWith(2);
 
     await sm.shutdown();
   });
 
-  it("clears local tracking when routeMessage fails and lets later input trigger chat recovery", async () => {
+  it("requests chat recovery when routeMessage fails and lets later redelivery route", async () => {
     const ackEntry = vi.fn().mockResolvedValue(undefined);
     const recoverChat = vi.fn().mockResolvedValue(undefined);
     const recoveryStart = vi.fn(async () => "session-id-recovery");
@@ -890,16 +977,14 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     });
 
     const first = mockEntry({ id: 1, chatId: "chat-route-fail", messageId: "msg-a1" });
-    await sm.dispatch(first);
-    expect(recoverChat).toHaveBeenCalledTimes(1);
-    expect(factory).not.toHaveBeenCalled();
-
     await expect(sm.dispatch(first)).rejects.toThrow("handler factory offline");
     expect(factory).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(recoverChat).toHaveBeenCalledTimes(1));
+    await new Promise((resolve) => setImmediate(resolve));
 
     await sm.dispatch(mockEntry({ id: 2, chatId: "chat-route-fail", messageId: "msg-a2" }));
-    expect(recoverChat).toHaveBeenCalledTimes(2);
-    expect(recoveryStart).not.toHaveBeenCalled();
+    expect(recoverChat).toHaveBeenCalledTimes(1);
+    expect(recoveryStart).toHaveBeenCalledTimes(1);
     expect(ackEntry).not.toHaveBeenCalled();
 
     await sm.shutdown();
@@ -924,8 +1009,7 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
 
     const first = mockEntry({ id: 30, chatId: "chat-suspend", messageId: "msg-a1" });
     await sm.dispatch(first);
-    expect(recoverChat).toHaveBeenCalledTimes(1);
-    await sm.dispatch(first);
+    expect(recoverChat).not.toHaveBeenCalled();
     expect(startSpy).toHaveBeenCalledTimes(1);
 
     if (firstMessage) capturedCtx?.markMessagesConsumed(firstMessage);
@@ -935,7 +1019,7 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     expect(ackEntry).toHaveBeenCalledWith(30);
 
     await sm.dispatch(mockEntry({ id: 31, chatId: "chat-suspend", messageId: "msg-a2" }));
-    expect(recoverChat).toHaveBeenCalledTimes(2);
+    expect(recoverChat).toHaveBeenCalledTimes(1);
     expect(resumeSpy).not.toHaveBeenCalled();
 
     await sm.dispatch(mockEntry({ id: 31, chatId: "chat-suspend", messageId: "msg-a2" }));
@@ -965,7 +1049,6 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
 
     const first = mockEntry({ id: 32, chatId: "chat-suspend-queue", messageId: "msg-q1" });
     await sm.dispatch(first);
-    await sm.dispatch(first);
     if (firstMessage) capturedCtx?.markMessagesConsumed(firstMessage);
 
     await sm.dispatch(mockEntry({ id: 33, chatId: "chat-suspend-queue", messageId: "msg-q2" }));
@@ -975,9 +1058,10 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     await Promise.resolve();
     expect(ackEntry).toHaveBeenCalledTimes(1);
     expect(ackEntry).toHaveBeenCalledWith(32);
+    await vi.waitFor(() => expect(recoverChat).toHaveBeenCalledTimes(1));
 
     await sm.dispatch(mockEntry({ id: 34, chatId: "chat-suspend-queue", messageId: "msg-q3" }));
-    expect(recoverChat).toHaveBeenCalledTimes(2);
+    expect(recoverChat).toHaveBeenCalledTimes(1);
     expect(ackEntry).toHaveBeenCalledTimes(1);
 
     await sm.shutdown();
@@ -1003,8 +1087,8 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     await sm.dispatch(mockEntry({ id: 40, chatId: "chat-retryable", messageId: "msg-a1" }));
     await sm.dispatch(mockEntry({ id: 41, chatId: "chat-retryable", messageId: "msg-a2" }));
 
-    if (firstMessage) capturedCtx?.markMessagesRetryable(firstMessage, "turn_timeout");
-    if (injected[0]) capturedCtx?.markMessagesCompleted(injected[0]);
+    if (firstMessage) capturedCtx?.retryTurn(firstMessage, "turn_timeout");
+    if (injected[0]) capturedCtx?.finishTurn(injected[0], { status: "success", terminal: true });
     await Promise.resolve();
 
     expect(ackEntry).not.toHaveBeenCalled();
@@ -1012,9 +1096,10 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     await sm.shutdown();
   });
 
-  it("retryable no-ack while active requires chat recovery before newer input reaches the handler", async () => {
+  it("retryable no-ack requests recovery and blocks newer input until recovery settles", async () => {
     const ackEntry = vi.fn().mockResolvedValue(undefined);
-    const recoverChat = vi.fn().mockResolvedValue(undefined);
+    const recovery = deferred<void>();
+    const recoverChat = vi.fn().mockReturnValue(recovery.promise);
     let capturedCtx: SessionContext | undefined;
     let firstMessage: Parameters<AgentHandler["start"]>[0] | undefined;
     const injectSpy = vi.fn();
@@ -1031,16 +1116,56 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
 
     const first = mockEntry({ id: 42, chatId: "chat-retryable-recover", messageId: "msg-r1" });
     await sm.dispatch(first);
-    await sm.dispatch(first);
-    expect(recoverChat).toHaveBeenCalledTimes(1);
+    expect(recoverChat).not.toHaveBeenCalled();
     expect(startSpy).toHaveBeenCalledTimes(1);
 
-    if (firstMessage) capturedCtx?.markMessagesRetryable(firstMessage, "turn_timeout");
+    if (firstMessage) capturedCtx?.retryTurn(firstMessage, "turn_timeout");
+    await vi.waitFor(() => expect(recoverChat).toHaveBeenCalledTimes(1));
 
-    await sm.dispatch(mockEntry({ id: 43, chatId: "chat-retryable-recover", messageId: "msg-r2" }));
-    expect(recoverChat).toHaveBeenCalledTimes(2);
+    const newer = sm.dispatch(mockEntry({ id: 43, chatId: "chat-retryable-recover", messageId: "msg-r2" }));
+    await Promise.resolve();
+    expect(recoverChat).toHaveBeenCalledTimes(1);
     expect(injectSpy).not.toHaveBeenCalled();
     expect(ackEntry).not.toHaveBeenCalled();
+    recovery.resolve(undefined);
+    await newer;
+
+    await sm.dispatch(mockEntry({ id: 43, chatId: "chat-retryable-recover", messageId: "msg-r2" }));
+    expect(injectSpy).toHaveBeenCalledTimes(1);
+
+    await sm.shutdown();
+  });
+
+  it("keeps recovery debt after recovery failure and retries on later dispatch", async () => {
+    const ackEntry = vi.fn().mockResolvedValue(undefined);
+    const recoverChat = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("recover offline"))
+      .mockResolvedValue(undefined);
+    let capturedCtx: SessionContext | undefined;
+    let firstMessage: Parameters<AgentHandler["start"]>[0] | undefined;
+    const injectSpy = vi.fn();
+    const handler = createMockHandler({
+      async start(m, ctx) {
+        firstMessage = m;
+        capturedCtx = ctx;
+        return "session-id-mock";
+      },
+      inject: injectSpy,
+    });
+    const { sm } = buildSm(ackEntry, handler, recoverChat);
+
+    await sm.dispatch(mockEntry({ id: 50, chatId: "chat-recover-fail", messageId: "msg-fail-1" }));
+    if (firstMessage) capturedCtx?.retryTurn(firstMessage, "turn_timeout");
+    await vi.waitFor(() => expect(recoverChat).toHaveBeenCalledTimes(1));
+    await new Promise((resolve) => setImmediate(resolve));
+
+    await sm.dispatch(mockEntry({ id: 51, chatId: "chat-recover-fail", messageId: "msg-fail-2" }));
+    expect(recoverChat).toHaveBeenCalledTimes(2);
+    expect(injectSpy).not.toHaveBeenCalled();
+
+    await sm.dispatch(mockEntry({ id: 51, chatId: "chat-recover-fail", messageId: "msg-fail-2" }));
+    expect(injectSpy).toHaveBeenCalledTimes(1);
 
     await sm.shutdown();
   });
@@ -1061,7 +1186,7 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     const { sm } = buildSm(ackEntry, handler);
 
     await sm.dispatch(mockEntry({ id: 44, chatId: "chat-retryable-no-recover", messageId: "msg-nr1" }));
-    if (firstMessage) capturedCtx?.markMessagesRetryable(firstMessage, "turn_timeout");
+    if (firstMessage) capturedCtx?.retryTurn(firstMessage, "turn_timeout");
 
     await sm.dispatch(mockEntry({ id: 45, chatId: "chat-retryable-no-recover", messageId: "msg-nr2" }));
     expect(injectSpy).not.toHaveBeenCalled();
@@ -1070,7 +1195,7 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     await sm.shutdown();
   });
 
-  it("ack waits for markCompleted when resuming an evicted session", async () => {
+  it("ack waits for finishTurn when resuming an evicted session", async () => {
     // Seed an evicted session by exceeding concurrency=1, then dispatch into
     // the evicted chat to trigger the resume branch.
     const ackEntry = vi.fn().mockResolvedValue(undefined);
@@ -1116,9 +1241,8 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     await sm.dispatch(chatB);
     // Close chat-a and chat-b's start turns so their entries don't pollute
     // the resume-branch ack assertion.
-    capturedCtxs[0]?.markCompleted();
-    capturedCtxs[1]?.markCompleted();
-    await Promise.resolve();
+    await finishEntry(capturedCtxs[0], 1, "chat-a");
+    await finishEntry(capturedCtxs[1], 2, "chat-b");
     ackEntry.mockClear();
 
     // Dispatching back into chat-a first triggers chat-scoped recovery; the
@@ -1128,8 +1252,7 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     await sm.dispatch(chatAResume);
     expect(ackEntry).not.toHaveBeenCalled();
 
-    capturedCtxs[2]?.markCompleted();
-    await Promise.resolve();
+    await finishEntry(capturedCtxs[2], 3, "chat-a", "msg-resume");
     expect(ackEntry).toHaveBeenCalledWith(3);
 
     await sm.shutdown();
@@ -1165,7 +1288,7 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
   it("does NOT ack on transient handler.start failure — retry path keeps the entry queued for forwardResult", async () => {
     // A 429-ish error is classified as transient; the runtime schedules a
     // retry inside `handleSessionFailure` and leaves the entry queued so
-    // the eventual successful retry can ack it via markCompleted.
+    // the eventual successful retry can ack it via finishTurn.
     const ackEntry = vi.fn().mockResolvedValue(undefined);
     const transientErr = Object.assign(new Error("rate limited"), { status: 429 });
     const handler = createMockHandler({
@@ -1185,9 +1308,9 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
   it("acks queued in-flight entries on session:terminate", async () => {
     const ackEntry = vi.fn().mockResolvedValue(undefined);
     // Handler whose `start` resolves quickly (matching production: start
-    // returns the sessionId; the turn closes later via markCompleted).
-    // markCompleted is NEVER called by this mock, so the entry sits in
-    // `inFlightEntries` past the turn — exactly what terminate needs to
+    // returns the sessionId; the turn closes later via finishTurn).
+    // finishTurn is NEVER called by this mock, so the entry stays tracked
+    // past the turn — exactly what terminate needs to
     // ack so the next bind doesn't redeliver.
     const handler = createMockHandler();
     const { sm } = buildSm(ackEntry, handler);

--- a/packages/client/src/__tests__/session-manager.test.ts
+++ b/packages/client/src/__tests__/session-manager.test.ts
@@ -3,7 +3,13 @@ import type pino from "pino";
 import { describe, expect, it, vi } from "vitest";
 import type { AgentConfigCache } from "../runtime/agent-config-cache.js";
 import type { ContextTreeBinding } from "../runtime/bootstrap.js";
-import type { AgentHandler, HandlerConfig, HandlerFactory, SessionContext, SessionMessage } from "../runtime/handler.js";
+import type {
+  AgentHandler,
+  HandlerConfig,
+  HandlerFactory,
+  SessionContext,
+  SessionMessage,
+} from "../runtime/handler.js";
 import { SessionManager } from "../runtime/session-manager.js";
 import type { FirstTreeHubSDK } from "../sdk.js";
 import { recordingLogger, silentLogger } from "./_logger-helpers.js";
@@ -1138,10 +1144,7 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
 
   it("keeps recovery debt after recovery failure and retries on later dispatch", async () => {
     const ackEntry = vi.fn().mockResolvedValue(undefined);
-    const recoverChat = vi
-      .fn()
-      .mockRejectedValueOnce(new Error("recover offline"))
-      .mockResolvedValue(undefined);
+    const recoverChat = vi.fn().mockRejectedValueOnce(new Error("recover offline")).mockResolvedValue(undefined);
     let capturedCtx: SessionContext | undefined;
     let firstMessage: Parameters<AgentHandler["start"]>[0] | undefined;
     const injectSpy = vi.fn();

--- a/packages/client/src/__tests__/session-runtime-state.test.ts
+++ b/packages/client/src/__tests__/session-runtime-state.test.ts
@@ -1,26 +1,10 @@
 import type pino from "pino";
 import { describe, expect, it, vi } from "vitest";
-import type { AgentHandler, HandlerFactory, SessionContext } from "../runtime/handler.js";
+import type { AgentHandler, HandlerFactory, SessionContext, SessionMessage } from "../runtime/handler.js";
 import { SessionManager } from "../runtime/session-manager.js";
 import type { FirstTreeHubSDK } from "../sdk.js";
 import { silentLogger } from "./_logger-helpers.js";
 import { mockEntry } from "./test-helpers.js";
-
-/** Assert value is defined and return it (avoids non-null assertions). */
-function defined<T>(value: T | undefined, label = "value"): T {
-  expect(value, `${label} should be defined`).toBeDefined();
-  return value as T;
-}
-
-/**
- * Tests for per-session runtime state aggregation and cleanup.
- *
- * Covers:
- * - Aggregate runtime state recomputation (idle → working → blocked → error priority)
- * - Runtime state cleanup on terminate command
- * - Runtime state cleanup on eviction
- * - Runtime state cleanup on start/resume failure
- */
 
 function mockSdk(): FirstTreeHubSDK {
   return {
@@ -28,10 +12,6 @@ function mockSdk(): FirstTreeHubSDK {
     sendMessage: vi.fn().mockResolvedValue({ id: "msg-reply" }),
     sendToAgent: vi.fn().mockResolvedValue({ id: "msg-dm" }),
   } as unknown as FirstTreeHubSDK;
-}
-
-function mockAckEntry() {
-  return vi.fn<(entryId: number) => Promise<void>>().mockResolvedValue(undefined);
 }
 
 function createMockHandler(overrides?: Partial<AgentHandler>): AgentHandler {
@@ -50,6 +30,7 @@ function createSessionManager(opts: {
   handler?: AgentHandler;
   handlerFactory?: HandlerFactory;
   ackEntry?: (entryId: number) => Promise<void>;
+  recoverChat?: (chatId: string) => Promise<void>;
   session?: {
     idle_timeout: number;
     max_sessions: number;
@@ -60,7 +41,7 @@ function createSessionManager(opts: {
   log?: pino.Logger;
   onRuntimeStateChange?: (state: "idle" | "working" | "blocked" | "error") => void;
   onSessionRuntimeChange?: (chatId: string, state: "idle" | "working" | "blocked" | "error") => void;
-}) {
+}): SessionManager {
   const handler = opts.handler ?? createMockHandler();
   const factory: HandlerFactory = opts.handlerFactory ?? (() => handler);
   const sdk = opts.sdk ?? mockSdk();
@@ -86,428 +67,127 @@ function createSessionManager(opts: {
     },
     sdk,
     log: opts.log ?? silentLogger(),
-    ackEntry: opts.ackEntry ?? mockAckEntry(),
+    ackEntry: opts.ackEntry ?? vi.fn<(entryId: number) => Promise<void>>().mockResolvedValue(undefined),
+    recoverChat: opts.recoverChat,
     onRuntimeStateChange: opts.onRuntimeStateChange,
     onSessionRuntimeChange: opts.onSessionRuntimeChange,
   });
 }
 
-describe("SessionManager: runtime state aggregation", () => {
-  it("fires onRuntimeStateChange when a session sets working state", async () => {
-    const runtimeChanges: Array<"idle" | "working" | "blocked" | "error"> = [];
-    let capturedCtx: SessionContext | undefined;
+function deferred(): { promise: Promise<void>; resolve: () => void; reject: (err: unknown) => void } {
+  let resolve: () => void = () => {};
+  let reject: (err: unknown) => void = () => {};
+  const promise = new Promise<void>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
 
+describe("SessionManager runtime projection from inbox coordinator work", () => {
+  it("projects active unsettled work as working and settles to idle only after ACK confirms", async () => {
+    const events: Array<{ chatId: string; state: string }> = [];
+    let capturedCtx: SessionContext | undefined;
+    let capturedMessage: SessionMessage | undefined;
+    const ack = deferred();
     const handler = createMockHandler({
-      async start(_msg, ctx) {
+      async start(msg, ctx) {
         capturedCtx = ctx;
+        capturedMessage = msg;
         return "session-1";
       },
     });
-
     const sm = createSessionManager({
       handler,
-      onRuntimeStateChange: (state) => runtimeChanges.push(state),
-    });
-
-    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
-    expect(capturedCtx).toBeDefined();
-
-    // Handler sets working state
-    const ctx = defined(capturedCtx, "capturedCtx");
-    ctx.setRuntimeState("working");
-    expect(runtimeChanges).toContain("working");
-
-    // Handler sets back to idle
-    ctx.setRuntimeState("idle");
-    expect(runtimeChanges[runtimeChanges.length - 1]).toBe("idle");
-
-    await sm.shutdown();
-  });
-
-  it("aggregates to highest priority: error > blocked > working > idle", async () => {
-    const runtimeChanges: Array<"idle" | "working" | "blocked" | "error"> = [];
-    const contexts: SessionContext[] = [];
-
-    const factory: HandlerFactory = () =>
-      createMockHandler({
-        async start(_msg, ctx) {
-          contexts.push(ctx);
-          return `session-${contexts.length}`;
-        },
-      });
-
-    const sm = createSessionManager({
-      handlerFactory: factory,
-      onRuntimeStateChange: (state) => runtimeChanges.push(state),
-    });
-
-    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
-    await sm.dispatch(mockEntry({ id: 2, chatId: "chat-b" }));
-    expect(contexts).toHaveLength(2);
-
-    // Both idle → aggregate stays idle (initial state, no explicit report yet)
-    runtimeChanges.length = 0;
-
-    const ctx0 = defined(contexts[0], "contexts[0]");
-    const ctx1 = defined(contexts[1], "contexts[1]");
-
-    // One working → aggregate = working
-    ctx0.setRuntimeState("working");
-    expect(runtimeChanges[runtimeChanges.length - 1]).toBe("working");
-
-    // Second also working → still working
-    ctx1.setRuntimeState("working");
-    expect(runtimeChanges[runtimeChanges.length - 1]).toBe("working");
-
-    // One error → aggregate = error (highest priority)
-    ctx0.setRuntimeState("error");
-    expect(runtimeChanges[runtimeChanges.length - 1]).toBe("error");
-
-    // Clear error, set blocked → aggregate = blocked
-    ctx0.setRuntimeState("blocked");
-    expect(runtimeChanges[runtimeChanges.length - 1]).toBe("blocked");
-
-    await sm.shutdown();
-  });
-
-  it("deduplicates aggregate state — no callback if state unchanged", async () => {
-    const runtimeChanges: Array<"idle" | "working" | "blocked" | "error"> = [];
-    let capturedCtx: SessionContext | undefined;
-
-    const handler = createMockHandler({
-      async start(_msg, ctx) {
-        capturedCtx = ctx;
-        return "s1";
-      },
-    });
-
-    const sm = createSessionManager({
-      handler,
-      onRuntimeStateChange: (state) => runtimeChanges.push(state),
-    });
-
-    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
-    runtimeChanges.length = 0;
-
-    const dedupCtx = defined(capturedCtx, "capturedCtx");
-    dedupCtx.setRuntimeState("working");
-    dedupCtx.setRuntimeState("working"); // duplicate — should not fire
-    dedupCtx.setRuntimeState("working"); // duplicate — should not fire
-    expect(runtimeChanges).toHaveLength(1);
-
-    await sm.shutdown();
-  });
-});
-
-describe("SessionManager: runtime state cleanup on terminate", () => {
-  it("clears session runtime state and recomputes aggregate on terminate", async () => {
-    const runtimeChanges: Array<"idle" | "working" | "blocked" | "error"> = [];
-    const contexts: SessionContext[] = [];
-
-    const factory: HandlerFactory = () =>
-      createMockHandler({
-        async start(_msg, ctx) {
-          contexts.push(ctx);
-          return `s-${contexts.length}`;
-        },
-      });
-
-    const sm = createSessionManager({
-      handlerFactory: factory,
-      onRuntimeStateChange: (state) => runtimeChanges.push(state),
-    });
-
-    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
-    await sm.dispatch(mockEntry({ id: 2, chatId: "chat-b" }));
-
-    // chat-a = working, chat-b = idle → aggregate = working
-    defined(contexts[0], "contexts[0]").setRuntimeState("working");
-    runtimeChanges.length = 0;
-
-    // Terminate chat-a → its "working" state should be cleaned up → aggregate = idle
-    await sm.handleCommand("chat-a", "session:terminate");
-
-    expect(runtimeChanges[runtimeChanges.length - 1]).toBe("idle");
-
-    await sm.shutdown();
-  });
-});
-
-describe("SessionManager: runtime state cleanup on eviction", () => {
-  it("clears session runtime state when evicted by max_sessions", async () => {
-    const runtimeChanges: Array<"idle" | "working" | "blocked" | "error"> = [];
-    const contexts: SessionContext[] = [];
-
-    const factory: HandlerFactory = () =>
-      createMockHandler({
-        async start(_msg, ctx) {
-          contexts.push(ctx);
-          return `s-${contexts.length}`;
-        },
-      });
-
-    const sm = createSessionManager({
-      session: { idle_timeout: 300, max_sessions: 2, working_grace_seconds: 3600, reconcile_interval_seconds: 300 },
-      handlerFactory: factory,
-      onRuntimeStateChange: (state) => runtimeChanges.push(state),
-    });
-
-    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
-    await sm.dispatch(mockEntry({ id: 2, chatId: "chat-b" }));
-
-    // chat-a = error → aggregate = error
-    defined(contexts[0], "contexts[0]").setRuntimeState("error");
-    runtimeChanges.length = 0;
-
-    // Third chat triggers eviction of LRU (chat-a with error) → aggregate should drop from error
-    await sm.dispatch(mockEntry({ id: 3, chatId: "chat-c" }));
-
-    // After chat-a evicted, its "error" state is gone, aggregate should not be "error"
-    const lastState = runtimeChanges[runtimeChanges.length - 1];
-    expect(lastState).not.toBe("error");
-
-    await sm.shutdown();
-  });
-});
-
-describe("SessionManager: runtime state cleanup on start failure", () => {
-  it("clears session runtime state when handler.start throws permanent error", async () => {
-    const runtimeChanges: Array<"idle" | "working" | "blocked" | "error"> = [];
-    let callCount = 0;
-
-    // After Task 3 (transient retry): transient errors keep the entry alive
-    // for retry; only permanent errors run the legacy teardown that this
-    // test guards. Use a permanent-classified error class.
-    class FakePermanentError extends Error {
-      override name = "ClientUserMismatchError";
-    }
-
-    const factory: HandlerFactory = () => {
-      callCount++;
-      if (callCount === 2) {
-        // Second handler throws on start with a permanent classification.
-        return createMockHandler({
-          async start() {
-            throw new FakePermanentError("start boom");
-          },
-        });
-      }
-      return createMockHandler();
-    };
-
-    const sm = createSessionManager({
-      handlerFactory: factory,
-      onRuntimeStateChange: (state) => runtimeChanges.push(state),
-      log: silentLogger(),
-    });
-
-    // First session starts fine
-    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
-    // Second session fails to start — should not leave orphaned runtime state
-    await sm.dispatch(mockEntry({ id: 2, chatId: "chat-b" }));
-
-    // Only chat-a should be tracked
-    expect(sm.totalCount).toBe(1);
-
-    // Aggregate should not be affected by the failed session
-    // If there was a leak, the failed session's state would pollute the aggregate
-    const lastState = runtimeChanges.length > 0 ? runtimeChanges[runtimeChanges.length - 1] : null;
-    // Should be null (no runtime state set) or "idle" — never "error" or "working"
-    expect(lastState === null || lastState === "idle").toBe(true);
-
-    await sm.shutdown();
-  });
-});
-
-describe("SessionManager: getAggregateRuntimeState()", () => {
-  it("returns null when no sessions have reported state", async () => {
-    const sm = createSessionManager({});
-    expect(sm.getAggregateRuntimeState()).toBeNull();
-    await sm.shutdown();
-  });
-
-  it("returns current aggregate after session reports", async () => {
-    let capturedCtx: SessionContext | undefined;
-    const handler = createMockHandler({
-      async start(_msg, ctx) {
-        capturedCtx = ctx;
-        return "s1";
-      },
-    });
-
-    const sm = createSessionManager({
-      handler,
-      onRuntimeStateChange: () => {},
-    });
-
-    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
-    defined(capturedCtx, "ctx").setRuntimeState("working");
-    expect(sm.getAggregateRuntimeState()).toBe("working");
-
-    defined(capturedCtx, "ctx").setRuntimeState("idle");
-    expect(sm.getAggregateRuntimeState()).toBe("idle");
-
-    await sm.shutdown();
-  });
-});
-
-describe("SessionManager: per-(agent,chat) runtime callback (#553 rebase)", () => {
-  it("fires onSessionRuntimeChange with the chatId whenever a session reports runtime", async () => {
-    const events: Array<{ chatId: string; state: string }> = [];
-    let capturedCtx: SessionContext | undefined;
-    const handler = createMockHandler({
-      async start(_msg, ctx) {
-        capturedCtx = ctx;
-        return "s1";
-      },
-    });
-
-    const sm = createSessionManager({
-      handler,
+      ackEntry: vi.fn().mockReturnValue(ack.promise),
+      onRuntimeStateChange: vi.fn(),
       onSessionRuntimeChange: (chatId, state) => events.push({ chatId, state }),
     });
 
     await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
-    defined(capturedCtx, "ctx").setRuntimeState("working");
-    defined(capturedCtx, "ctx").setRuntimeState("idle");
+    expect(events).toContainEqual({ chatId: "chat-a", state: "working" });
+    expect(sm.getAggregateRuntimeState()).toBe("working");
 
-    // dispatch flow itself sets working before handler.start (the inject→working
-    // grace-window fix). We only care that the explicit setRuntimeState calls
-    // emitted with the right chatId.
-    const forChatA = events.filter((e) => e.chatId === "chat-a").map((e) => e.state);
-    expect(forChatA).toContain("working");
-    expect(forChatA).toContain("idle");
+    if (!capturedMessage) throw new Error("expected captured message");
+    const finish = capturedCtx?.finishTurn(capturedMessage, { status: "success", terminal: true });
+    await Promise.resolve();
+    expect(events[events.length - 1]).toEqual({ chatId: "chat-a", state: "working" });
+
+    ack.resolve();
+    await finish;
+    expect(events[events.length - 1]).toEqual({ chatId: "chat-a", state: "idle" });
+    expect(sm.getAggregateRuntimeState()).toBe("idle");
 
     await sm.shutdown();
   });
 
-  it("getSessionRuntimeStates returns ACTIVE sessions only, defaulting to idle when unrecorded", async () => {
+  it("keeps ACK failure unsettled and recovers before routing later delivery", async () => {
+    const events: Array<{ chatId: string; state: string }> = [];
+    const recovery = deferred();
+    const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockReturnValue(recovery.promise);
+    const handler = createMockHandler();
     let capturedCtx: SessionContext | undefined;
-    const handler = createMockHandler({
-      async start(_msg, ctx) {
-        capturedCtx = ctx;
-        return "s-a";
-      },
+    let capturedMessage: SessionMessage | undefined;
+    handler.start = vi.fn(async (msg, ctx) => {
+      capturedCtx = ctx;
+      capturedMessage = msg;
+      return "session-1";
+    });
+    const sm = createSessionManager({
+      handler,
+      recoverChat,
+      ackEntry: vi.fn().mockRejectedValue(new Error("prefix_gap")),
+      onRuntimeStateChange: vi.fn(),
+      onSessionRuntimeChange: (chatId, state) => events.push({ chatId, state }),
     });
 
-    const sm = createSessionManager({ handler, onSessionRuntimeChange: () => {} });
-    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
-    defined(capturedCtx, "ctx").setRuntimeState("working");
+    const first = mockEntry({ id: 1, chatId: "chat-a" });
+    await sm.dispatch(first);
+    if (!capturedMessage) throw new Error("expected captured message");
+    await capturedCtx?.finishTurn(capturedMessage, { status: "success", terminal: true });
 
-    const snap = sm.getSessionRuntimeStates();
-    expect(snap).toEqual([{ chatId: "chat-a", runtimeState: "working" }]);
+    expect(events[events.length - 1]).toEqual({ chatId: "chat-a", state: "working" });
+    expect(sm.getAggregateRuntimeState()).toBe("working");
+    expect(recoverChat).toHaveBeenCalledWith("chat-a");
+
+    const later = sm.dispatch(mockEntry({ id: 2, chatId: "chat-a" }));
+    await Promise.resolve();
+    expect(handler.inject).not.toHaveBeenCalledWith(expect.objectContaining({ id: "msg-2" }));
+    recovery.resolve();
+    await later;
+
+    await sm.dispatch(mockEntry({ id: 2, chatId: "chat-a" }));
+    expect(handler.inject).toHaveBeenCalledWith(expect.objectContaining({ id: "msg-2" }));
 
     await sm.shutdown();
   });
 
-  it("re-affirm timer re-emits working / blocked / error, skips idle", async () => {
-    vi.useFakeTimers();
-    try {
-      const seen: Array<{ chatId: string; state: string }> = [];
-      const contexts: SessionContext[] = [];
-      const factory: HandlerFactory = () =>
-        createMockHandler({
-          async start(_msg, ctx) {
-            contexts.push(ctx);
-            return `s-${contexts.length}`;
-          },
-        });
+  it("does not route or ACK duplicate-in-flight redelivery", async () => {
+    const ackEntry = vi.fn<(entryId: number) => Promise<void>>().mockResolvedValue(undefined);
+    const handler = createMockHandler();
+    const sm = createSessionManager({ handler, ackEntry });
+    const entry = mockEntry({ id: 1, chatId: "chat-a", messageId: "same-message" });
 
-      const sm = createSessionManager({
-        handlerFactory: factory,
-        onSessionRuntimeChange: (chatId, state) => seen.push({ chatId, state }),
-        session: { idle_timeout: 3600, max_sessions: 10, working_grace_seconds: 3600, reconcile_interval_seconds: 300 },
-      });
+    await sm.dispatch(entry);
+    await sm.dispatch(entry);
 
-      await sm.dispatch(mockEntry({ id: 1, chatId: "chat-w" }));
-      await sm.dispatch(mockEntry({ id: 2, chatId: "chat-i" }));
-      defined(contexts[0], "ctx0").setRuntimeState("working");
-      defined(contexts[1], "ctx1").setRuntimeState("idle");
-
-      // Drain the initial callback noise so the assertion below targets
-      // only re-affirm output.
-      seen.length = 0;
-
-      // Reaffirm base = 20s + ±20% jitter — 60s straddles the upper bound
-      // (24s) twice so at least one fire is guaranteed even at max jitter.
-      await vi.advanceTimersByTimeAsync(60_000);
-
-      const reaffirms = seen.filter((e) => e.chatId === "chat-w" || e.chatId === "chat-i");
-      const workingReaffirms = reaffirms.filter((e) => e.chatId === "chat-w" && e.state === "working");
-      const idleReaffirms = reaffirms.filter((e) => e.chatId === "chat-i");
-      expect(workingReaffirms.length).toBeGreaterThanOrEqual(1);
-      // idle sessions must NEVER show up on the reaffirm channel — that's
-      // pure wire noise (server's fail-closed default already handles it).
-      expect(idleReaffirms).toHaveLength(0);
-
-      await sm.shutdown();
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-});
-
-describe("SessionManager: ack-through guard under concurrency preemption", () => {
-  it("abandons a preempted unfinished entry and only acks the newly completed chat", async () => {
-    // Ack-through fail-closed: preempting chat-a means its unfinished
-    // delivered entry must not be committed by a stale completion. chat-b
-    // can complete its own attempt and ack only its through cursor.
-    const ackEntry = mockAckEntry();
-    const ctxs: Record<string, SessionContext> = {};
-    const handler = createMockHandler({
-      async start(msg, ctx) {
-        ctxs[msg.chatId] = ctx;
-        return "session-id-mock";
-      },
-    });
-    const sm = createSessionManager({ ackEntry, handler, concurrency: 1 });
-
-    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
-    // chat-b's dispatch causes chat-a to be suspended (preempted for slot)
-    // and chat-b's handler.start to run.
-    await sm.dispatch(mockEntry({ id: 2, chatId: "chat-b" }));
+    expect(handler.start).toHaveBeenCalledTimes(1);
+    expect(handler.inject).not.toHaveBeenCalled();
     expect(ackEntry).not.toHaveBeenCalled();
 
-    // chat-a's stale completion is ignored; chat-b completes normally.
-    ctxs["chat-a"]?.markCompleted();
-    ctxs["chat-b"]?.markCompleted();
-    await Promise.resolve();
-    expect(ackEntry).toHaveBeenCalledTimes(1);
-    expect(ackEntry).not.toHaveBeenCalledWith(1);
-    expect(ackEntry).toHaveBeenCalledWith(2);
-
     await sm.shutdown();
   });
-});
 
-describe("SessionManager.evictIdle — working-state grace window", () => {
-  // A long thinking turn or one giant SDK message produces no inbound events
-  // for minutes at a time, so `lastActivity` (refreshed only by handler
-  // `touch()`) drifts past `idle_timeout` even though the handler is still
-  // working. Without this grace window the runtime suspends the SDK
-  // mid-thought; with it, the slot survives until either work resumes or the
-  // upper bound `idle_timeout + working_grace_seconds` is exceeded.
-  it("does NOT suspend a session whose runtimeState is 'working' inside the grace window", async () => {
+  it("keeps idle reaper from suspending unsettled work before hard cap", async () => {
     vi.useFakeTimers();
     try {
-      let capturedCtx: SessionContext | undefined;
-      const handler = createMockHandler({
-        async start(_msg, ctx) {
-          capturedCtx = ctx;
-          return "s-working";
-        },
-      });
+      const handler = createMockHandler();
       const sm = createSessionManager({
         handler,
-        // 1s idle window + 60s grace — picked so a single 20s tick lands
-        // inside the grace window.
         session: { idle_timeout: 1, max_sessions: 10, working_grace_seconds: 60, reconcile_interval_seconds: 300 },
       });
 
       await sm.dispatch(mockEntry({ id: 1, chatId: "chat-thinking" }));
-      defined(capturedCtx, "ctx").setRuntimeState("working");
-
-      // 20s ≫ idle_timeout (1s) but ≪ idle_timeout + grace (61s).
       await vi.advanceTimersByTimeAsync(20_000);
 
       expect(handler.suspend).not.toHaveBeenCalled();
@@ -517,178 +197,40 @@ describe("SessionManager.evictIdle — working-state grace window", () => {
     }
   });
 
-  it("DOES suspend once inactiveMs exceeds idle_timeout + working_grace_seconds", async () => {
+  it("hard cap suspends and ACKs only the consumed prefix", async () => {
     vi.useFakeTimers();
     try {
+      const ackEntry = vi.fn<(entryId: number) => Promise<void>>().mockResolvedValue(undefined);
+      const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
       let capturedCtx: SessionContext | undefined;
+      let firstMessage: SessionMessage | undefined;
       const handler = createMockHandler({
-        async start(_msg, ctx) {
+        async start(msg, ctx) {
           capturedCtx = ctx;
-          return "s-stuck";
+          firstMessage = msg;
+          return "session-1";
         },
       });
       const sm = createSessionManager({
         handler,
-        // 1s idle + 5s grace — the timer below blows past the 6s cap so
-        // the runtime should give up and reclaim the slot.
+        ackEntry,
+        recoverChat,
         session: { idle_timeout: 1, max_sessions: 10, working_grace_seconds: 5, reconcile_interval_seconds: 300 },
       });
 
       await sm.dispatch(mockEntry({ id: 1, chatId: "chat-stuck" }));
-      defined(capturedCtx, "ctx").setRuntimeState("working");
+      if (!firstMessage) throw new Error("expected first message");
+      capturedCtx?.markMessagesConsumed(firstMessage);
+      await sm.dispatch(mockEntry({ id: 2, chatId: "chat-stuck" }));
 
-      // 30s ≫ idle_timeout + grace (6s). evictIdle ticks every 10s.
       await vi.advanceTimersByTimeAsync(30_000);
 
       expect(handler.suspend).toHaveBeenCalledTimes(1);
-      await sm.shutdown();
-    } finally {
-      vi.useRealTimers();
-    }
-  });
+      expect(ackEntry).toHaveBeenCalledTimes(1);
+      expect(ackEntry).toHaveBeenCalledWith(1);
+      expect(ackEntry).not.toHaveBeenCalledWith(2);
+      expect(recoverChat).toHaveBeenCalledWith("chat-stuck");
 
-  // `blocked` is no longer auto-set by evictIdle (the 120s auto-migration
-  // was removed because reasoning-model thinking turns commonly exceed 2
-  // minutes between SDK events, producing false-positive UI warnings).
-  // The grace-window exemption still covers `blocked` so any handler that
-  // sets it explicitly — present or future — is treated like `working`.
-  it("also exempts 'blocked' from idle suspend inside the grace window", async () => {
-    vi.useFakeTimers();
-    try {
-      let capturedCtx: SessionContext | undefined;
-      const handler = createMockHandler({
-        async start(_msg, ctx) {
-          capturedCtx = ctx;
-          return "s-blocked";
-        },
-      });
-      const sm = createSessionManager({
-        handler,
-        session: { idle_timeout: 1, max_sessions: 10, working_grace_seconds: 60, reconcile_interval_seconds: 300 },
-      });
-
-      await sm.dispatch(mockEntry({ id: 1, chatId: "chat-blocked" }));
-      defined(capturedCtx, "ctx").setRuntimeState("blocked");
-
-      await vi.advanceTimersByTimeAsync(20_000);
-
-      expect(handler.suspend).not.toHaveBeenCalled();
-      await sm.shutdown();
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it("'idle' runtimeState still suspends at idle_timeout (regression)", async () => {
-    vi.useFakeTimers();
-    try {
-      let capturedCtx: SessionContext | undefined;
-      const handler = createMockHandler({
-        async start(_msg, ctx) {
-          capturedCtx = ctx;
-          return "s-idle";
-        },
-      });
-      const sm = createSessionManager({
-        handler,
-        session: { idle_timeout: 1, max_sessions: 10, working_grace_seconds: 60, reconcile_interval_seconds: 300 },
-      });
-
-      await sm.dispatch(mockEntry({ id: 1, chatId: "chat-idle" }));
-      defined(capturedCtx, "ctx").setRuntimeState("idle");
-
-      await vi.advanceTimersByTimeAsync(20_000);
-
-      expect(handler.suspend).toHaveBeenCalledTimes(1);
-      await sm.shutdown();
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  // Regression for the removed 120s working→blocked auto-migration.
-  // Before this change evictIdle would flip a `working` session to
-  // `blocked` after 2 minutes of SDK silence, surfacing as a yellow UI
-  // warning even when the agent was just deep-thinking. The grace
-  // window above proved that's never a real problem (we don't actually
-  // suspend), so the auto-migration was pure UX noise — removed.
-  it("does NOT auto-migrate 'working' → 'blocked' on inactivity (no false alarms during long reasoning)", async () => {
-    vi.useFakeTimers();
-    try {
-      const runtimeChanges: Array<"idle" | "working" | "blocked" | "error"> = [];
-      let capturedCtx: SessionContext | undefined;
-      const handler = createMockHandler({
-        async start(_msg, ctx) {
-          capturedCtx = ctx;
-          return "s-no-auto-blocked";
-        },
-      });
-      const sm = createSessionManager({
-        handler,
-        // Big idle_timeout so we don't trip the suspend path while we're
-        // proving the *non*-transition.
-        session: { idle_timeout: 3600, max_sessions: 10, working_grace_seconds: 60, reconcile_interval_seconds: 300 },
-        onRuntimeStateChange: (state) => runtimeChanges.push(state),
-      });
-
-      await sm.dispatch(mockEntry({ id: 1, chatId: "chat-thinking" }));
-      defined(capturedCtx, "ctx").setRuntimeState("working");
-      runtimeChanges.length = 0;
-
-      // Past the old 120s threshold; the runtime would previously have
-      // flipped the state to `blocked` here.
-      await vi.advanceTimersByTimeAsync(180_000);
-
-      expect(runtimeChanges).not.toContain("blocked");
-      expect(handler.suspend).not.toHaveBeenCalled();
-      await sm.shutdown();
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  // Reproduces the post-#477 regression observed in production: a turn that
-  // ends with `setRuntimeState("idle")` (handler claude-code does this on
-  // every result message) left the next inject-triggered turn observable
-  // as `idle`, so a long thinking turn that produced no SDK output for
-  // `idle_timeout` (300s) tripped evictIdle's suspend path even though the
-  // agent was still working. `dispatch` for an active chat must put the
-  // session back into `working` BEFORE the handler starts its next turn
-  // so the grace-window guard above kicks in.
-  it("'idle' → inject restores 'working' so the grace window protects long thinking turns", async () => {
-    vi.useFakeTimers();
-    try {
-      let capturedCtx: SessionContext | undefined;
-      const handler = createMockHandler({
-        async start(_msg, ctx) {
-          capturedCtx = ctx;
-          return "s-inject-grace";
-        },
-      });
-      const sm = createSessionManager({
-        handler,
-        session: { idle_timeout: 1, max_sessions: 10, working_grace_seconds: 60, reconcile_interval_seconds: 300 },
-      });
-
-      await sm.dispatch(mockEntry({ id: 1, chatId: "chat-inject" }));
-      // Handler completed its first turn — back to idle, mirroring
-      // claude-code.ts on every result message.
-      defined(capturedCtx, "ctx").setRuntimeState("idle");
-
-      // User sends a follow-up. Without the inject→working fix, this
-      // refreshes lastActivity but leaves runtimeState=idle, so the next
-      // evictIdle tick past idle_timeout would suspend the chat
-      // mid-thinking.
-      await sm.dispatch(mockEntry({ id: 2, chatId: "chat-inject" }));
-      expect(handler.inject).toHaveBeenCalledTimes(1);
-
-      // 20s ≫ idle_timeout (1s) but ≪ idle_timeout + grace (61s). The
-      // handler is "thinking" — no touch() calls — so lastActivity stays
-      // pinned at the inject moment. The grace window must keep the slot
-      // alive.
-      await vi.advanceTimersByTimeAsync(20_000);
-
-      expect(handler.suspend).not.toHaveBeenCalled();
       await sm.shutdown();
     } finally {
       vi.useRealTimers();

--- a/packages/client/src/__tests__/session-start-error-signaling.test.ts
+++ b/packages/client/src/__tests__/session-start-error-signaling.test.ts
@@ -310,12 +310,11 @@ describe("SessionManager: session-resume failure signalling (F2, resume path)", 
     const chatAStart = mockEntry({ id: 1, chatId: "chat-A" });
     const chatBStart = mockEntry({ id: 2, chatId: "chat-B" });
     const chatAResume = mockEntry({ id: 3, chatId: "chat-A" });
-    await sm.dispatch(chatAStart); // asks for recovery
-    await sm.dispatch(chatAStart); // redelivery starts chat-A
-    await sm.dispatch(chatBStart); // asks for recovery
-    await sm.dispatch(chatBStart); // redelivery starts chat-B and preempts chat-A
-    await sm.dispatch(chatAResume); // asks for recovery of chat-A's unacked tail
-    await sm.dispatch(chatAResume); // redelivery resumes chat-A → throws
+    await sm.dispatch(chatAStart); // starts chat-A
+    await sm.dispatch(chatBStart); // starts chat-B and preempts chat-A
+    await vi.waitFor(() => expect(recoverChat).toHaveBeenCalledWith("chat-A"));
+    await new Promise((resolve) => setImmediate(resolve));
+    await sm.dispatch(chatAResume); // recovery redelivery resumes chat-A -> throws
 
     const chatAStates = stateChanges.filter((c) => c.chatId === "chat-A").map((c) => c.state);
     expect(chatAStates.at(-1)).toBe("errored");
@@ -365,16 +364,14 @@ describe("SessionManager: session-resume failure signalling (F2, resume path)", 
     const chatAResume = mockEntry({ id: 3, chatId: "chat-A" });
     const chatARecovery = mockEntry({ id: 4, chatId: "chat-A" });
     await sm.dispatch(chatAStart);
-    await sm.dispatch(chatAStart);
     await sm.dispatch(chatBStart);
-    await sm.dispatch(chatBStart);
-    await sm.dispatch(chatAResume);
+    await vi.waitFor(() => expect(recoverChat).toHaveBeenCalledWith("chat-A"));
+    await new Promise((resolve) => setImmediate(resolve));
     await sm.dispatch(chatAResume); // resume → errored
 
     // A fresh inbound for chat-A should route as start (entry was dropped
     // on resume failure — the resume catch tears down the same way the
     // start catch does, so there's no "stuck suspended" entry blocking it).
-    await sm.dispatch(chatARecovery);
     await sm.dispatch(chatARecovery);
     expect(handlerARecovery.start).toHaveBeenCalledTimes(1);
     expect(stateChanges.filter((c) => c.chatId === "chat-A").at(-1)?.state).toBe("active");

--- a/packages/client/src/__tests__/session-state-notifications.test.ts
+++ b/packages/client/src/__tests__/session-state-notifications.test.ts
@@ -1,7 +1,7 @@
 import type { RuntimeState, SessionState } from "@first-tree/shared";
 import type pino from "pino";
 import { describe, expect, it, vi } from "vitest";
-import type { AgentHandler, HandlerFactory, SessionContext } from "../runtime/handler.js";
+import type { AgentHandler, HandlerFactory } from "../runtime/handler.js";
 import { SessionManager } from "../runtime/session-manager.js";
 import type { FirstTreeHubSDK } from "../sdk.js";
 import { silentLogger } from "./_logger-helpers.js";
@@ -189,30 +189,19 @@ describe("SessionManager: state notifications", () => {
 describe("SessionManager: state-before-runtime ordering (codex review P2)", () => {
   // The server's `setSessionRuntime` is active-gated — if `session:state
   // active` hasn't landed yet, any `session:runtime` for the same
-  // (agent, chat) is dropped. Handlers (codex especially) emit
-  // `setRuntimeState("working")` synchronously from inside handler.start(),
-  // and codex's start() awaits the WHOLE turn before returning. If
-  // SessionManager fired the `active` notification only AFTER start()
-  // returned, the working frame would arrive at the server before the
-  // active row existed and the composite would stay `ready`. This test
-  // pins the fixed order: the `active` notification fires before the
-  // handler returns (so before any setRuntimeState the handler does).
-  it("emits onStateChange('active') BEFORE handler.start (so handler runtime reports land on an active row)", async () => {
+  // (agent, chat) is dropped. Runtime projection is now coordinator-derived,
+  // so SessionManager must emit `active` before it projects the fresh
+  // delivery to `working`, and both must happen before handler.start().
+  it("emits active before coordinator-derived working runtime and before handler.start", async () => {
     const emissions: Array<{ kind: "state" | "runtime"; value: string }> = [];
     let observedActiveBeforeHandlerCompletion = false;
 
     const handler = createMockHandler({
-      // Codex-style handler: awaits the entire turn. Synchronously reports
-      // working at the top, then idle on the way out, all before start()
-      // returns. The pre-fix SessionManager would have queued both frames
-      // ahead of the `active` notification.
-      start: vi.fn(async (_msg, ctx: SessionContext) => {
+      start: vi.fn(async () => {
         // Snapshot the state emissions seen so far — if the `active`
         // notification fired before invoking start, it must already be in
         // `emissions`.
         observedActiveBeforeHandlerCompletion = emissions.some((e) => e.kind === "state" && e.value === "active");
-        ctx.setRuntimeState("working");
-        ctx.setRuntimeState("idle");
         return "session-id-mock";
       }),
     });
@@ -233,6 +222,7 @@ describe("SessionManager: state-before-runtime ordering (codex review P2)", () =
     // Belt-and-braces: the first emission overall must be the active state
     // notification (no runtime frame slipped in before it).
     expect(emissions[0]).toEqual({ kind: "state", value: "active" });
+    expect(emissions[1]).toEqual({ kind: "runtime", value: "working" });
 
     await sm.shutdown();
   });

--- a/packages/client/src/__tests__/test-helpers.ts
+++ b/packages/client/src/__tests__/test-helpers.ts
@@ -22,10 +22,12 @@ export function mockCtxPlumbing(
   chatId: string,
 ): {
   forwardResult: (text: string) => Promise<void>;
-  markCompleted: () => void;
   markMessagesConsumed: (messages: SessionMessage | readonly SessionMessage[]) => void;
-  markMessagesCompleted: (messages: SessionMessage | readonly SessionMessage[]) => void;
-  markMessagesRetryable: (messages: SessionMessage | readonly SessionMessage[], reason: string) => void;
+  finishTurn: (
+    messages: SessionMessage | readonly SessionMessage[],
+    outcome: { status: "success" | "error"; terminal?: boolean },
+  ) => Promise<void>;
+  retryTurn: (messages: SessionMessage | readonly SessionMessage[], reason: string) => void;
   buildAgentEnv: (env: NodeJS.ProcessEnv) => NodeJS.ProcessEnv;
   formatInboundContent: (msg: SessionMessage) => Promise<string>;
   resolveSenderLabel: (senderId: string) => Promise<string>;
@@ -35,10 +37,9 @@ export function mockCtxPlumbing(
       await sdk.sendMessage(chatId, { source: "api", format: "text", content: text });
     },
     // Default stub: tests that care about ack timing override via spies.
-    markCompleted: () => {},
     markMessagesConsumed: () => {},
-    markMessagesCompleted: () => {},
-    markMessagesRetryable: () => {},
+    finishTurn: async () => {},
+    retryTurn: () => {},
     buildAgentEnv: (env) => env,
     formatInboundContent: async (msg) => {
       const raw = typeof msg.content === "string" ? msg.content : JSON.stringify(msg.content);

--- a/packages/client/src/__tests__/tui-turn-disposition.test.ts
+++ b/packages/client/src/__tests__/tui-turn-disposition.test.ts
@@ -4,12 +4,11 @@ import { resolveTurnDisposition } from "../handlers/claude-code-tui/turn-disposi
 const CLEAN = { aborted: false, timedOut: false, turnFailed: false, forwardFailed: false };
 
 describe("resolveTurnDisposition", () => {
-  it("a clean turn reports success, acks, forwards, and goes idle", () => {
+  it("a clean turn reports success, acks, and forwards", () => {
     expect(resolveTurnDisposition(CLEAN)).toEqual({
       status: "success",
       ack: true,
       forward: true,
-      runtimeState: "idle",
     });
   });
 
@@ -21,32 +20,29 @@ describe("resolveTurnDisposition", () => {
    * the no-ack decision — so the chat got a partial message while the entry
    * stayed un-acked and re-ran on reconnect, double-posting. A timeout must
    * report error, must NOT ack AND must NOT forward (so the redelivered retry
-   * is the single source of output), and must surface an error runtime state.
+   * is the single source of output).
    */
-  it("a timed-out turn reports error, does NOT ack, does NOT forward, and surfaces error state", () => {
+  it("a timed-out turn reports error and does NOT ack or forward", () => {
     expect(resolveTurnDisposition({ ...CLEAN, timedOut: true })).toEqual({
       status: "error",
       ack: false,
       forward: false,
-      runtimeState: "error",
     });
   });
 
-  it("a body failure reports error, acks + forwards (clean close, avoid storm), and surfaces error state", () => {
+  it("a body failure reports error, acks, and forwards (clean close, avoid storm)", () => {
     expect(resolveTurnDisposition({ ...CLEAN, turnFailed: true })).toEqual({
       status: "error",
       ack: true,
       forward: true,
-      runtimeState: "error",
     });
   });
 
-  it("a forward-only failure reports error and acks but keeps the session idle", () => {
+  it("a forward-only failure reports error but still consumes the turn", () => {
     expect(resolveTurnDisposition({ ...CLEAN, forwardFailed: true })).toEqual({
       status: "error",
       ack: true,
       forward: true,
-      runtimeState: "idle",
     });
   });
 
@@ -55,7 +51,6 @@ describe("resolveTurnDisposition", () => {
       status: "success",
       ack: false,
       forward: false,
-      runtimeState: "idle",
     });
   });
 
@@ -64,7 +59,6 @@ describe("resolveTurnDisposition", () => {
       status: "error",
       ack: false,
       forward: false,
-      runtimeState: "error",
     });
   });
 

--- a/packages/client/src/handlers/claude-code-tui/index.ts
+++ b/packages/client/src/handlers/claude-code-tui/index.ts
@@ -326,7 +326,6 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
       throw new Error("runTurn called before session was prepared");
     }
     sessionCtx.markMessagesConsumed(messages);
-    sessionCtx.setRuntimeState("working");
     turnAborted = false;
 
     const state: TurnState = { finalTexts: [] };
@@ -341,12 +340,12 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
       transcriptTailer.drainEntries();
 
       await pasteText(tmuxSessionName, text);
-      sessionCtx.touch();
+      sessionCtx.recordProviderActivity();
 
       const startTs = Date.now();
       while (Date.now() - startTs < TURN_TIMEOUT_MS) {
         if (turnAborted) break;
-        sessionCtx.touch();
+        sessionCtx.recordProviderActivity();
 
         await drainAndConsume(sessionCtx, state);
 
@@ -445,12 +444,11 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
     const disposition = resolveTurnDisposition({ aborted: turnAborted, timedOut, turnFailed, forwardFailed });
     sessionCtx.emitEvent({ kind: "turn_end", payload: { status: disposition.status } });
     if (disposition.ack) {
-      sessionCtx.markMessagesCompleted(messages);
+      await sessionCtx.finishTurn(messages, { status: disposition.status, terminal: true });
     } else {
       const reason = timedOut ? "turn_timeout" : turnAborted ? "turn_aborted" : "turn_retryable";
-      sessionCtx.markMessagesRetryable(messages, reason);
+      sessionCtx.retryTurn(messages, reason);
     }
-    sessionCtx.setRuntimeState(disposition.runtimeState);
     resetProcessor();
   }
 
@@ -478,7 +476,7 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
         }
       }
       if (inputs.length === 0) {
-        sessionCtx.markMessagesCompleted(drained);
+        await sessionCtx.finishTurn(drained, { status: "error", terminal: true, errorKind: "deterministic" });
         return;
       }
       await runTurn(inputs.join("\n\n"), sessionCtx, drained);

--- a/packages/client/src/handlers/claude-code-tui/turn-disposition.ts
+++ b/packages/client/src/handlers/claude-code-tui/turn-disposition.ts
@@ -22,9 +22,9 @@ export type TurnDisposition = {
   /** Status reported on the `turn_end` event. */
   status: "success" | "error";
   /**
-   * Whether to `markCompleted` (ack the triggering inbox entries). The runtime
-   * never auto-acks on turn_end, so a false here leaves the entries in-flight
-   * for at-least-once redelivery.
+   * Whether to finish the triggering inbox entries. The runtime never
+   * auto-acks on turn_end, so a false here leaves the entries in-flight for
+   * at-least-once redelivery.
    */
   ack: boolean;
   /**
@@ -34,8 +34,6 @@ export type TurnDisposition = {
    * double-posts once the replay produces the real answer.
    */
   forward: boolean;
-  /** Runtime state to settle into after the turn. */
-  runtimeState: "idle" | "error";
 };
 
 /**
@@ -45,9 +43,8 @@ export type TurnDisposition = {
  * is NOT a success. claude was interrupted before reaching idle, so we cannot
  * confirm the work completed. Acking it would silently consume the user's
  * message with no replay path — exactly the bug this function guards. So a
- * timeout reports `turn_end: error`, leaves the inbox entries un-acked (the
- * server redelivers them on reconnect/restart for a genuine retry), and surfaces
- * an `error` runtime state.
+ * timeout reports `turn_end: error` and leaves the inbox entries un-acked (the
+ * server redelivers them on reconnect/restart for a genuine retry).
  *
  * Ack policy otherwise mirrors the SDK handler's `ackTurnClose`: a clean close
  * acks even on a plain forward failure (claude finished; re-running yields the
@@ -68,8 +65,5 @@ export function resolveTurnDisposition(outcome: TurnOutcome): TurnDisposition {
     status: turnFailed || forwardFailed || timedOut ? "error" : "success",
     ack: consume,
     forward: consume,
-    // A broken (turnFailed) or interrupted (timedOut) session is advertised as
-    // error; a forward-only failure leaves the session healthy, so it stays idle.
-    runtimeState: turnFailed || timedOut ? "error" : "idle",
   };
 }

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -904,22 +904,20 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
   }
 
   /**
-   * Single helper for "turn closed → ack the pending inbox message AND
+   * Single helper for "turn closed → finish the pending inbox message AND
    * drop the replay stash". The two operations are paired everywhere a
    * turn finishes (success / sniff-permanent / forward-error / no-result /
    * non-success subtype / MAX_RETRIES / respawn-fail) — folding them into
    * one call keeps the invariant "stash lives only as long as the turn
    * still might need a replay" enforced in one place. Use the raw
-   * `markMessagesCompleted(message)` directly for per-message terminal
+   * `finishTurn(message, ...)` directly for per-message terminal
    * failures (e.g. inject's `toSDKUserMessage` catch) where the semantics is
    * "commit this single inbox message, NOT close the active SDK turn".
    */
-  function ackTurnClose(sessionCtx: SessionContext): void {
+  async function ackTurnClose(sessionCtx: SessionContext, status: "success" | "error"): Promise<void> {
     const message = pendingAckMessages.shift();
     if (message) {
-      sessionCtx.markMessagesCompleted(message);
-    } else {
-      sessionCtx.markCompleted();
+      await sessionCtx.finishTurn(message, { status, terminal: true });
     }
     markCurrentPendingMessageConsumed(sessionCtx);
     stashedSdkMessage = null;
@@ -959,7 +957,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       // entry with an SDK result. Ack here — re-handling on
       // redelivery would re-hit the same conversion error
       // (permanent failure semantics, design §4).
-      sessionCtx.markMessagesCompleted(message);
+      await sessionCtx.finishTurn(message, { status: "error", terminal: true, errorKind: "deterministic" });
     }
   }
 
@@ -1167,11 +1165,9 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
         if (!currentQuery) return;
 
         try {
-          sessionCtx.setRuntimeState("working");
-
           for await (const message of currentQuery) {
             // Every message refreshes lastActivity to prevent idle timeout
-            sessionCtx.touch();
+            sessionCtx.recordProviderActivity();
 
             toolCallProcessor.onMessage(message);
 
@@ -1249,7 +1245,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
                     // Permanent stream API failure — ack so the server
                     // doesn't redeliver a message that would just produce
                     // the same error. Retry was exhausted upstream.
-                    ackTurnClose(sessionCtx);
+                    await ackTurnClose(sessionCtx, "error");
                   } else {
                     // Genuine success — reset retry budget for the next turn.
                     // Do NOT reset on the sniff-hit branches above: a wrapped
@@ -1266,7 +1262,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
                       sessionCtx.log("Result forwarded to chat");
                       sessionCtx.emitEvent({ kind: "turn_end", payload: { status: "success" } });
                       // Turn closed cleanly — drain in-flight inbox entries.
-                      ackTurnClose(sessionCtx);
+                      await ackTurnClose(sessionCtx, "success");
                     } catch (err) {
                       const reason = err instanceof Error ? err.message : String(err);
                       sessionCtx.log(`Failed to forward result: ${reason}`);
@@ -1291,7 +1287,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
                       // counter when an unrelated future stream error
                       // fires.
                       retryCount = 0;
-                      ackTurnClose(sessionCtx);
+                      await ackTurnClose(sessionCtx, "error");
                     }
                   }
                 } else {
@@ -1299,7 +1295,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
                   // Same reset rationale as the forward-success branch above.
                   retryCount = 0;
                   sessionCtx.emitEvent({ kind: "turn_end", payload: { status: "success" } });
-                  ackTurnClose(sessionCtx);
+                  await ackTurnClose(sessionCtx, "success");
                 }
               } else {
                 const errors = message.errors ? message.errors.join("; ") : message.subtype;
@@ -1316,9 +1312,8 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
                 sessionCtx.emitEvent({ kind: "turn_end", payload: { status: "error" } });
                 // SDK reported a turn-level error (non-success subtype):
                 // redelivery would just hit the same error — ack.
-                ackTurnClose(sessionCtx);
+                await ackTurnClose(sessionCtx, "error");
               }
-              sessionCtx.setRuntimeState("idle");
               // Reset the auth-hint flag only on a SUCCESSFUL result. This
               // gives a clean slate for the next turn once auth is clearly
               // working, while suppressing a duplicate hint when the next
@@ -1330,7 +1325,6 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
               }
             }
           }
-          sessionCtx.setRuntimeState("idle");
           return;
         } catch (err) {
           // Process crash, OOM, or unexpected termination
@@ -1356,9 +1350,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
             // would just go quiet.
             //
             // Wrap the emits so a broken `onSessionEvent` callback can't
-            // short-circuit the `setRuntimeState("error")` call below —
-            // if that one is skipped the SessionManager keeps the slot
-            // counted as `working` and never reclaims it.
+            // short-circuit turn cleanup below.
             try {
               const preview = errMsg.slice(0, 800);
               const reason = claudeSessionId
@@ -1371,13 +1363,12 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
                 `Failed to emit retry-exhaustion error event: ${emitErr instanceof Error ? emitErr.message : String(emitErr)}`,
               );
             }
-            sessionCtx.setRuntimeState("error");
             // Ack the in-flight entry for this turn. Without this the row
             // stays `delivered` server-side forever: the in-process
             // Deduplicator collapses every bind-reset replay so the entry
             // never re-dispatches and never gets acked. Per design §4
             // "permanent → ack".
-            ackTurnClose(sessionCtx);
+            await ackTurnClose(sessionCtx, "error");
             return;
           }
 
@@ -1410,11 +1401,8 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
           } catch (resumeErr) {
             const resumeMsg = resumeErr instanceof Error ? resumeErr.message : String(resumeErr);
             sessionCtx.log(`Auto-resume failed: ${resumeMsg}`);
-            // Mirror the MAX_RETRIES branch above: leaving runtimeState at
-            // `working` would block the SessionManager's idle-suspend grace
-            // window from ever firing on this session, so the slot would
-            // never be reclaimed. Wrap the emits defensively so the
-            // setRuntimeState call still runs if the callback throws.
+            // Mirror the MAX_RETRIES branch above and close the turn
+            // deterministically so the slot can be reclaimed.
             try {
               sessionCtx.emitEvent({
                 kind: "error",
@@ -1426,11 +1414,10 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
                 `Failed to emit auto-resume error event: ${emitErr instanceof Error ? emitErr.message : String(emitErr)}`,
               );
             }
-            sessionCtx.setRuntimeState("error");
             // Same reasoning as the MAX_RETRIES branch above — without this
             // ack the row would loop in `delivered` forever, deduped on every
             // bind-reset replay. Per design §4 "permanent → ack".
-            ackTurnClose(sessionCtx);
+            await ackTurnClose(sessionCtx, "error");
             return;
           }
         }

--- a/packages/client/src/handlers/codex.ts
+++ b/packages/client/src/handlers/codex.ts
@@ -757,7 +757,6 @@ export const createCodexHandler: HandlerFactory = (config) => {
     sessionCtx.markMessagesConsumed(messages);
     const abort = new AbortController();
     currentAbort = abort;
-    sessionCtx.setRuntimeState("working");
 
     // Emit exactly one `turn_end` per turn, after `forwardResult` resolves —
     // mirrors claude-code so admin events + completion bookkeeping reflect
@@ -801,7 +800,7 @@ export const createCodexHandler: HandlerFactory = (config) => {
             const streamed = await activeThread.runStreamed(input, { signal: attemptAbort.signal });
             for await (const event of streamed.events) {
               if (attemptAbort.signal.aborted) break;
-              sessionCtx.touch();
+              sessionCtx.recordProviderActivity();
               if (event.type === "thread.started") {
                 threadId = event.thread_id;
               } else if (event.type === "turn.started") {
@@ -967,7 +966,7 @@ export const createCodexHandler: HandlerFactory = (config) => {
       // phantom `turn_end: success`. Mirrors the existing `turnFailed`
       // treatment — runtime state still goes `idle` below so a later message
       // can retry once the limit resets. We do NOT auto-redeliver THIS message
-      // (markMessagesCompleted still runs below); auto-redelivery is tracked
+      // (finishTurn still runs below); auto-redelivery is tracked
       // separately (see #971 discussion) because it needs a reset-aware
       // trigger + loop guard that the SDK's missing `rate_limits` can't supply.
       sessionCtx.emitEvent({
@@ -1038,12 +1037,11 @@ export const createCodexHandler: HandlerFactory = (config) => {
       kind: "turn_end",
       payload: { status: succeeded ? "success" : "error" },
     });
-    sessionCtx.setRuntimeState("idle");
     // Ack the entries this turn consumed. All four turn outcomes (success,
     // silent / no-text, SDK turn.failed, forwardResult failure) are
     // terminal for this turn — redelivery would either replay an already-
     // delivered reply or re-hit the same failure.
-    sessionCtx.markMessagesCompleted(messages);
+    await sessionCtx.finishTurn(messages, { status: succeeded ? "success" : "error", terminal: true });
 
     // Structured usage / timing log — emitted via `sessionCtx.log` rather
     // than a new SessionEvent kind so we stay inside the codex handler
@@ -1100,8 +1098,8 @@ export const createCodexHandler: HandlerFactory = (config) => {
       // Every fused message failed `formatInboundContent` — semantically a
       // permanent failure for this batch (redelivery would re-hit the same
       // format errors). Ack the entries so they don't leak in
-      // `inFlightEntries` and pile up server-side as `delivered` rows.
-      sessionCtx.markMessagesCompleted(drained);
+      // the coordinator ledger and pile up server-side as `delivered` rows.
+      await sessionCtx.finishTurn(drained, { status: "error", terminal: true, errorKind: "deterministic" });
       return;
     }
     await runTurn(inputs.join("\n\n"), sessionCtx, drained);

--- a/packages/client/src/runtime/agent-slot.ts
+++ b/packages/client/src/runtime/agent-slot.ts
@@ -418,7 +418,7 @@ export class AgentSlot {
    * Ack happens INSIDE the SessionManager via the `ackEntry` callback we
    * pinned at construction time — `clientConnection.sendInboxAck`. Post
    * inflight-message-recovery the ack is deferred until the handler closes
-   * the turn via `ctx.markCompleted()`. Sending an additional ack here
+   * the turn via `ctx.finishTurn(...)`. Sending an additional ack here
    * would double-ack: a WS frame the server cannot match against any
    * `delivered` row, which leaks the server's per-agent in-flight counter
    * and stalls push after `inboxMaxInFlightPerAgent` messages.

--- a/packages/client/src/runtime/deduplicator.ts
+++ b/packages/client/src/runtime/deduplicator.ts
@@ -34,7 +34,7 @@ export class Deduplicator {
   /**
    * Drop every recorded id that starts with `prefix`. Used by the runtime
    * when a chat is LRU-evicted: the in-flight entries for that chat won't
-   * be acked (no handler will run `markCompleted`), and the server will
+   * be acked (no handler will run `finishTurn`), and the server will
    * resend the same `(chatId, messageId)` pairs against a fresh session.
    * Leaving the keys in the dedup set would cause the resend to be
    * mis-classified as a duplicate — and (post-#1-fix) re-acked, which

--- a/packages/client/src/runtime/handler.ts
+++ b/packages/client/src/runtime/handler.ts
@@ -44,14 +44,18 @@ export type HandlerContext = {
   log: (msg: string) => void;
 };
 
+export type TurnOutcome = {
+  status: "success" | "error";
+  terminal?: boolean;
+  errorKind?: "deterministic" | "transient" | "unknown";
+};
+
 /** Extended context for session-oriented handlers. */
 export type SessionContext = HandlerContext & {
   /** The server-side chat this session belongs to. */
   chatId: string;
-  /** Refresh `lastActivity` timestamp to prevent idle timeout. */
-  touch: () => void;
-  /** Report per-session runtime state (working/idle/blocked/error). */
-  setRuntimeState: (state: "idle" | "working" | "blocked" | "error") => void;
+  /** Refresh `lastActivity` timestamp when the provider produces activity. */
+  recordProviderActivity: () => void;
   /**
    * Persist a structured session event (tool_call / error) to the server.
    * Assistant text does NOT go through here — it flows via `forwardResult`.
@@ -66,13 +70,6 @@ export type SessionContext = HandlerContext & {
   forwardResult: (text: string) => Promise<void>;
 
   /**
-   * Mark a single-message turn complete. Built-in handlers should prefer
-   * `markMessagesCompleted(messageOrBatch)` so the runtime can ack-through
-   * the exact inbox entry the handler actually consumed.
-   */
-  markCompleted: () => void;
-
-  /**
    * Mark the concrete message or fused batch as entered into the current
    * provider turn. This is an in-memory boundary used by suspend: consumed
    * entries can be ACKed when the turn is paused, while handler queues that
@@ -81,21 +78,18 @@ export type SessionContext = HandlerContext & {
   markMessagesConsumed: (messages: SessionMessage | readonly SessionMessage[]) => void;
 
   /**
-   * Mark the concrete message or fused message batch a handler has actually
-   * consumed. The runtime sends one `inbox:ack` for the last message's
-   * `inboxEntryId`; the server interprets it as ack-through for the chat's
-   * delivered prefix. This replaces the old `markCompleted(count)` FIFO
-   * pairing, which could ack an older queued entry while the completed entry
-   * remained unacked.
+   * Mark the concrete message or fused message batch's provider turn finished.
+   * The coordinator sends one ACK-through for the last message's
+   * `inboxEntryId` and settles local ledger only after server confirmation.
    */
-  markMessagesCompleted: (messages: SessionMessage | readonly SessionMessage[]) => void;
+  finishTurn: (messages: SessionMessage | readonly SessionMessage[], outcome: TurnOutcome) => Promise<void>;
 
   /**
    * Mark a concrete message or batch as abandoned by a retryable path
    * (abort, timeout, unknown failure). The runtime leaves the server-side
    * entries unacked; a later chat recovery or bind reset redelivers them.
    */
-  markMessagesRetryable: (messages: SessionMessage | readonly SessionMessage[], reason: string) => void;
+  retryTurn: (messages: SessionMessage | readonly SessionMessage[], reason: string) => void;
 
   /**
    * Build env for CLI sub-processes that shell out to the First Tree CLI.

--- a/packages/client/src/runtime/inbox-delivery-coordinator.ts
+++ b/packages/client/src/runtime/inbox-delivery-coordinator.ts
@@ -112,7 +112,10 @@ export class InboxDeliveryCoordinator {
     if (!recoverChat) {
       ledger.recoveryDebt = "required";
       this.emitWorkChanged(chatId);
-      this.config.log.error({ chatId, reason }, "chat requires inbox recovery but no recoverChat callback is configured");
+      this.config.log.error(
+        { chatId, reason },
+        "chat requires inbox recovery but no recoverChat callback is configured",
+      );
       return;
     }
 
@@ -317,7 +320,10 @@ export class InboxDeliveryCoordinator {
     const ledger = this.ledgers.get(chatId);
     if (!ledger || ledger.entries.length === 0) return;
     if (ledger.recoveryDebt !== "none") {
-      this.config.log.debug({ chatId, throughEntryId, reason }, "ACK-through deferred because chat recovery is required");
+      this.config.log.debug(
+        { chatId, throughEntryId, reason },
+        "ACK-through deferred because chat recovery is required",
+      );
       return;
     }
     const index = ledger.entries.findIndex((tracked) => tracked.entryId === throughEntryId);

--- a/packages/client/src/runtime/inbox-delivery-coordinator.ts
+++ b/packages/client/src/runtime/inbox-delivery-coordinator.ts
@@ -1,0 +1,465 @@
+import type { InboxEntryWithMessage } from "@first-tree/shared";
+import type { pino } from "../observability/logger.js";
+import { Deduplicator } from "./deduplicator.js";
+import type { SessionMessage, TurnOutcome } from "./handler.js";
+
+export type DeliveryWork = {
+  chatId: string;
+  entryId: number;
+  messageId: string;
+};
+
+export type DeliveryDecision =
+  | { kind: "deliver"; work: DeliveryWork }
+  | { kind: "duplicate-in-flight" }
+  | { kind: "recovering" };
+
+export type WorkSnapshot = {
+  entries: Array<{
+    entryId: number;
+    messageId: string;
+    phase: DeliveryPhase;
+  }>;
+  recoveryDebt: RecoveryDebt;
+  admissionPending: boolean;
+};
+
+type DeliveryPhase = "tracked" | "accepted" | "consumed" | "ackPending";
+type RecoveryDebt = "none" | "required" | "running";
+
+type TrackedDelivery = {
+  entryId: number;
+  messageId: string;
+  dedupKey: string;
+  phase: DeliveryPhase;
+};
+
+type ChatInboxLedger = {
+  entries: TrackedDelivery[];
+  recoveryDebt: RecoveryDebt;
+  recoveryActivationReady: boolean;
+  admissionQueue: Promise<void> | null;
+  ackQueue: Promise<void> | null;
+};
+
+type InboxDeliveryCoordinatorConfig = {
+  ackEntry: (entryId: number) => Promise<void>;
+  recoverChat?: (chatId: string) => Promise<void>;
+  onWorkChanged: (chatId: string) => void;
+  log: pino.Logger;
+};
+
+export class InboxDeliveryCoordinator {
+  private readonly config: InboxDeliveryCoordinatorConfig;
+  private readonly deduplicator = new Deduplicator(1000);
+  private readonly ledgers = new Map<string, ChatInboxLedger>();
+  private readonly recoveringChats = new Map<string, Promise<void>>();
+
+  constructor(config: InboxDeliveryCoordinatorConfig) {
+    this.config = config;
+  }
+
+  receive(entry: InboxEntryWithMessage): DeliveryDecision {
+    const chatId = entry.chatId ?? entry.message.chatId;
+    const messageId = entry.message.id;
+    const ledger = this.ledger(chatId);
+
+    if (ledger.recoveryDebt !== "none") {
+      return { kind: "recovering" };
+    }
+
+    const dedupKey = this.dedupKey(chatId, messageId);
+    if (this.deduplicator.isDuplicate(dedupKey)) {
+      const stillInFlight = ledger.entries.some((tracked) => tracked.entryId === entry.id);
+      this.config.log.debug({ chatId, messageId, entryId: entry.id, stillInFlight }, "duplicate message observed");
+      if (stillInFlight) return { kind: "duplicate-in-flight" };
+      this.config.log.debug(
+        { chatId, messageId, entryId: entry.id },
+        "duplicate key is not tied to an active entry; reprocessing redelivery",
+      );
+    }
+
+    ledger.entries.push({ entryId: entry.id, messageId, dedupKey, phase: "tracked" });
+    ledger.entries.sort((a, b) => a.entryId - b.entryId);
+    this.emitWorkChanged(chatId);
+    return { kind: "deliver", work: { chatId, entryId: entry.id, messageId } };
+  }
+
+  shouldRecoverBeforeDispatch(chatId: string, hasHealthyLiveHandler: boolean, hasLocalSessionRecord: boolean): boolean {
+    const ledger = this.ledgers.get(chatId);
+    if (ledger?.recoveryActivationReady) {
+      ledger.recoveryActivationReady = false;
+      this.cleanupLedger(chatId);
+      return false;
+    }
+    if (ledger?.recoveryDebt === "required" || ledger?.recoveryDebt === "running") return true;
+    return Boolean(this.config.recoverChat) && hasLocalSessionRecord && !hasHealthyLiveHandler;
+  }
+
+  async recoverIfNeeded(chatId: string, reason: string): Promise<void> {
+    await this.requestRecovery(chatId, reason);
+  }
+
+  private async requestRecovery(chatId: string, reason: string): Promise<void> {
+    const existing = this.recoveringChats.get(chatId);
+    if (existing) {
+      await existing;
+      return;
+    }
+
+    const recoverChat = this.config.recoverChat;
+    const ledger = this.ledger(chatId);
+    if (!recoverChat) {
+      ledger.recoveryDebt = "required";
+      this.emitWorkChanged(chatId);
+      this.config.log.error({ chatId, reason }, "chat requires inbox recovery but no recoverChat callback is configured");
+      return;
+    }
+
+    ledger.recoveryDebt = "running";
+    this.emitWorkChanged(chatId);
+
+    let recovery: Promise<void>;
+    recovery = recoverChat(chatId)
+      .then(() => {
+        this.clearEntriesForRecoverySuccess(chatId);
+        const current = this.ledger(chatId);
+        current.recoveryDebt = "none";
+        current.recoveryActivationReady = true;
+        this.config.log.debug({ chatId, reason }, "chat inbox recovery accepted before dispatch");
+      })
+      .catch((err) => {
+        const current = this.ledger(chatId);
+        current.recoveryDebt = "required";
+        this.config.log.warn({ chatId, reason, err }, "chat inbox recovery failed before dispatch");
+      })
+      .finally(() => {
+        if (this.recoveringChats.get(chatId) === recovery) this.recoveringChats.delete(chatId);
+        this.emitWorkChanged(chatId);
+      });
+
+    this.recoveringChats.set(chatId, recovery);
+    await recovery;
+  }
+
+  async runAdmission<T>(work: DeliveryWork, op: () => Promise<T>): Promise<T> {
+    const ledger = this.ledger(work.chatId);
+    const prev = ledger.admissionQueue ?? Promise.resolve();
+    const next = prev.then(op, op);
+    const queueMarker = next.then(
+      () => {},
+      () => {},
+    );
+    ledger.admissionQueue = queueMarker;
+    this.emitWorkChanged(work.chatId);
+    const cleanup = () => {
+      if (ledger.admissionQueue === queueMarker) {
+        ledger.admissionQueue = null;
+        this.cleanupLedger(work.chatId);
+        this.emitWorkChanged(work.chatId);
+      }
+    };
+    void next.then(cleanup, cleanup);
+    return next;
+  }
+
+  markAccepted(work: DeliveryWork): boolean {
+    const tracked = this.findEntry(work.chatId, work.entryId);
+    if (!tracked) return false;
+    if (tracked.phase === "tracked") {
+      tracked.phase = "accepted";
+      this.emitWorkChanged(work.chatId);
+    }
+    return true;
+  }
+
+  hasEntry(work: DeliveryWork): boolean {
+    return this.findEntry(work.chatId, work.entryId) !== null;
+  }
+
+  markConsumed(chatId: string, messages: SessionMessage | readonly SessionMessage[]): void {
+    const ledger = this.ledgers.get(chatId);
+    if (!ledger || ledger.entries.length === 0) return;
+    const consumedIds = this.messageEntryIds(chatId, messages);
+    if (consumedIds.size === 0) return;
+    let changed = false;
+    for (const tracked of ledger.entries) {
+      if (!consumedIds.has(tracked.entryId)) continue;
+      if (tracked.phase === "tracked" || tracked.phase === "accepted") {
+        tracked.phase = "consumed";
+        changed = true;
+      }
+    }
+    if (changed) this.emitWorkChanged(chatId);
+  }
+
+  async finishTurn(
+    chatId: string,
+    messages: SessionMessage | readonly SessionMessage[],
+    _outcome: TurnOutcome,
+  ): Promise<void> {
+    this.markConsumed(chatId, messages);
+    const throughEntryId = this.lastMessageEntryId(chatId, messages);
+    if (throughEntryId === undefined) {
+      this.config.log.warn({ chatId }, "turn completion ignored because no inboxEntryId was provided");
+      return;
+    }
+    await this.ackThrough(chatId, throughEntryId, "finish_turn", { requireConsumedPrefix: true });
+  }
+
+  retryTurn(chatId: string, messages: SessionMessage | readonly SessionMessage[], reason: string): void {
+    const entryIds = this.messageEntryIds(chatId, messages);
+    if (entryIds.size === 0) return;
+    const ledger = this.ledgers.get(chatId);
+    if (!ledger?.entries.some((entry) => entryIds.has(entry.entryId))) return;
+    void this.markRecoveryDebt(chatId, reason);
+  }
+
+  async prepareSuspend(chatId: string, reason: string): Promise<void> {
+    const ledger = this.ledgers.get(chatId);
+    if (!ledger || ledger.entries.length === 0) return;
+
+    let consumedPrefixCount = 0;
+    for (const tracked of ledger.entries) {
+      if (tracked.phase !== "consumed" && tracked.phase !== "ackPending") break;
+      consumedPrefixCount++;
+    }
+
+    if (consumedPrefixCount > 0) {
+      const lastConsumed = ledger.entries[consumedPrefixCount - 1];
+      if (lastConsumed) {
+        await this.ackThrough(chatId, lastConsumed.entryId, `${reason}:consumed_prefix`, {
+          requireConsumedPrefix: true,
+        });
+      }
+    }
+
+    const remaining = this.ledgers.get(chatId)?.entries ?? [];
+    if (remaining.length > 0) await this.markRecoveryDebt(chatId, reason);
+  }
+
+  prepareEvict(chatId: string, reason: string): void {
+    const ledger = this.ledgers.get(chatId);
+    if (!ledger || ledger.entries.length === 0) return;
+    void this.markRecoveryDebt(chatId, reason);
+  }
+
+  async drainForTerminate(chatId: string): Promise<void> {
+    const ledger = this.ledgers.get(chatId);
+    if (!ledger || ledger.entries.length === 0) return;
+
+    let acceptedPrefixCount = 0;
+    for (const tracked of ledger.entries) {
+      if (tracked.phase === "tracked") break;
+      acceptedPrefixCount++;
+    }
+    if (acceptedPrefixCount > 0) {
+      const lastAccepted = ledger.entries[acceptedPrefixCount - 1];
+      if (lastAccepted) await this.ackThrough(chatId, lastAccepted.entryId, "terminate");
+    }
+
+    const remaining = this.ledgers.get(chatId)?.entries ?? [];
+    if (remaining.length > 0) await this.markRecoveryDebt(chatId, "terminate_unaccepted_remainder");
+  }
+
+  hasUnsettledWork(chatId: string): boolean {
+    const ledger = this.ledgers.get(chatId);
+    if (!ledger) return false;
+    return ledger.entries.length > 0 || ledger.recoveryDebt !== "none" || ledger.admissionQueue !== null;
+  }
+
+  snapshot(chatId: string): WorkSnapshot {
+    const ledger = this.ledgers.get(chatId);
+    return {
+      entries: (ledger?.entries ?? []).map((entry) => ({
+        entryId: entry.entryId,
+        messageId: entry.messageId,
+        phase: entry.phase,
+      })),
+      recoveryDebt: ledger?.recoveryDebt ?? "none",
+      admissionPending: ledger?.admissionQueue !== null,
+    };
+  }
+
+  private async ackThrough(
+    chatId: string,
+    throughEntryId: number,
+    reason: string,
+    opts: { requireConsumedPrefix?: boolean } = {},
+  ): Promise<void> {
+    const ledger = this.ledgers.get(chatId);
+    if (!ledger) return;
+    const prev = ledger.ackQueue ?? Promise.resolve();
+    const next = prev.catch(() => undefined).then(() => this.ackThroughNow(chatId, throughEntryId, reason, opts));
+    const queueMarker = next.then(
+      () => {},
+      () => {},
+    );
+    ledger.ackQueue = queueMarker;
+    this.emitWorkChanged(chatId);
+    try {
+      await next;
+    } finally {
+      if (ledger.ackQueue === queueMarker) {
+        ledger.ackQueue = null;
+        this.cleanupLedger(chatId);
+        this.emitWorkChanged(chatId);
+      }
+    }
+  }
+
+  private async ackThroughNow(
+    chatId: string,
+    throughEntryId: number,
+    reason: string,
+    opts: { requireConsumedPrefix?: boolean },
+  ): Promise<void> {
+    const ledger = this.ledgers.get(chatId);
+    if (!ledger || ledger.entries.length === 0) return;
+    if (ledger.recoveryDebt !== "none") {
+      this.config.log.debug({ chatId, throughEntryId, reason }, "ACK-through deferred because chat recovery is required");
+      return;
+    }
+    const index = ledger.entries.findIndex((tracked) => tracked.entryId === throughEntryId);
+    if (index < 0) {
+      this.config.log.warn({ chatId, throughEntryId, reason }, "attempt completion ignored for untracked inbox entry");
+      return;
+    }
+
+    const ackPrefix = ledger.entries.slice(0, index + 1);
+    if (
+      opts.requireConsumedPrefix &&
+      ackPrefix.some((tracked) => tracked.phase === "tracked" || tracked.phase === "accepted")
+    ) {
+      this.config.log.warn(
+        {
+          chatId,
+          throughEntryId,
+          reason,
+          prefix: ackPrefix.map((entry) => ({ entryId: entry.entryId, phase: entry.phase })),
+        },
+        "ACK-through blocked because delivery prefix has unconsumed entries",
+      );
+      await this.markRecoveryDebt(chatId, `${reason}:unconsumed_prefix_gap`);
+      return;
+    }
+    let changed = false;
+    for (const tracked of ackPrefix) {
+      if (tracked.phase !== "ackPending") {
+        tracked.phase = "ackPending";
+        changed = true;
+      }
+    }
+    if (changed) this.emitWorkChanged(chatId);
+
+    try {
+      await this.config.ackEntry(throughEntryId);
+    } catch (err) {
+      this.config.log.warn({ chatId, entryId: throughEntryId, reason, err }, "ACK-through failed; retaining ledger");
+      const current = this.ledgers.get(chatId);
+      if (current) {
+        for (const tracked of current.entries) {
+          if (tracked.entryId <= throughEntryId && tracked.phase === "ackPending") {
+            tracked.phase = "consumed";
+          }
+        }
+      }
+      this.emitWorkChanged(chatId);
+      void this.markRecoveryDebt(chatId, `${reason}:ack_failed`);
+      return;
+    }
+
+    const current = this.ledgers.get(chatId);
+    if (!current) return;
+    const committed = current.entries.filter((tracked) => tracked.entryId <= throughEntryId);
+    current.entries = current.entries.filter((tracked) => tracked.entryId > throughEntryId);
+    for (const tracked of committed) {
+      this.deduplicator.drop(tracked.dedupKey);
+    }
+    if (current.entries.length === 0 && current.recoveryDebt === "required") {
+      current.recoveryDebt = "none";
+    }
+    this.cleanupLedger(chatId);
+    this.emitWorkChanged(chatId);
+  }
+
+  private async markRecoveryDebt(chatId: string, reason: string): Promise<void> {
+    const ledger = this.ledger(chatId);
+    if (ledger.recoveryDebt !== "required") {
+      ledger.recoveryDebt = "required";
+      this.emitWorkChanged(chatId);
+    }
+    this.config.log.warn(
+      { chatId, reason, entryIds: ledger.entries.map((entry) => entry.entryId) },
+      "chat has unsettled inbox work; waiting for recovery redelivery",
+    );
+    await this.requestRecovery(chatId, reason);
+  }
+
+  private clearEntriesForRecoverySuccess(chatId: string): void {
+    const ledger = this.ledger(chatId);
+    for (const tracked of ledger.entries) {
+      this.deduplicator.drop(tracked.dedupKey);
+    }
+    ledger.entries = [];
+  }
+
+  private findEntry(chatId: string, entryId: number): TrackedDelivery | null {
+    return this.ledgers.get(chatId)?.entries.find((entry) => entry.entryId === entryId) ?? null;
+  }
+
+  private messageEntryIds(chatId: string, messages: SessionMessage | readonly SessionMessage[]): Set<number> {
+    const batch = Array.isArray(messages) ? messages : [messages];
+    const entryIds = new Set<number>();
+    for (const message of batch) {
+      if (message.chatId === chatId && message.inboxEntryId !== undefined) entryIds.add(message.inboxEntryId);
+    }
+    return entryIds;
+  }
+
+  private lastMessageEntryId(chatId: string, messages: SessionMessage | readonly SessionMessage[]): number | undefined {
+    const batch = Array.isArray(messages) ? messages : [messages];
+    let throughEntryId: number | undefined;
+    for (const message of batch) {
+      if (message.chatId !== chatId) continue;
+      if (message.inboxEntryId !== undefined) throughEntryId = message.inboxEntryId;
+    }
+    return throughEntryId;
+  }
+
+  private ledger(chatId: string): ChatInboxLedger {
+    const existing = this.ledgers.get(chatId);
+    if (existing) return existing;
+    const ledger: ChatInboxLedger = {
+      entries: [],
+      recoveryDebt: "none",
+      recoveryActivationReady: false,
+      admissionQueue: null,
+      ackQueue: null,
+    };
+    this.ledgers.set(chatId, ledger);
+    return ledger;
+  }
+
+  private cleanupLedger(chatId: string): void {
+    const ledger = this.ledgers.get(chatId);
+    if (!ledger) return;
+    if (
+      ledger.entries.length === 0 &&
+      ledger.recoveryDebt === "none" &&
+      !ledger.recoveryActivationReady &&
+      ledger.admissionQueue === null &&
+      ledger.ackQueue === null
+    ) {
+      this.ledgers.delete(chatId);
+    }
+  }
+
+  private emitWorkChanged(chatId: string): void {
+    this.config.onWorkChanged(chatId);
+  }
+
+  private dedupKey(chatId: string, messageId: string): string {
+    return `${chatId}:${messageId}`;
+  }
+}

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -67,6 +67,13 @@ type SessionEntry = {
   /** Original message used to bootstrap this session, replayed on retry. */
   startMessage: SessionMessage | null;
   /**
+   * Messages that arrived while start/resume is in transient retry. They must
+   * not replace `startMessage`: the older accepted inbox entry is still ahead
+   * of them in the ACK prefix, so retry consumes the original trigger first and
+   * injects these only after the handler is live again.
+   */
+  retryQueuedMessages: SessionMessage[];
+  /**
    * When we entered transient-retry mode this is set to the evicted mapping
    * captured at startNewSession time. Lets a retry re-use the same resume
    * path (handler.resume) instead of regressing to handler.start.
@@ -378,7 +385,7 @@ export class SessionManager {
     if (
       this.inboxDelivery.shouldRecoverBeforeDispatch(
         chatId,
-        this.hasHealthyLiveHandler(chatId),
+        this.hasHealthyLiveHandler(chatId) || this.hasPendingTransientRetry(chatId),
         this.hasLocalSessionRecord(chatId),
       )
     ) {
@@ -676,31 +683,23 @@ export class SessionManager {
     return entry?.status === "active" && entry.suspending === null;
   }
 
+  private hasPendingTransientRetry(chatId: string): boolean {
+    const entry = this.sessions.get(chatId);
+    return Boolean(entry && entry.retryAttempt > 0);
+  }
+
   private hasLocalSessionRecord(chatId: string): boolean {
     return this.sessions.has(chatId) || this.evictedMappings.has(chatId);
   }
 
   private async routeMessage(chatId: string, message: SessionMessage): Promise<void> {
-    // Record the trigger BEFORE dispatching to any handler path (start /
-    // resume / inject) so the resultSink constructed in buildSessionContext
-    // sees the right messageId+senderId when this turn eventually produces a
-    // reply. The sink clears it on forward so an intervening inject() can
-    // overwrite it without the in-flight reply stealing the new trigger.
-    if (message.id) {
-      this.currentTrigger.set(chatId, { messageId: message.id, senderId: message.senderId });
-    }
-
     const existing = this.sessions.get(chatId);
 
-    // Transient retry path: an earlier handler.start / handler.resume failed
-    // with a classified-transient error and we kept the entry around. A new
-    // user message is a strong signal the user is waiting — replace the
-    // stored startMessage so the retry uses the fresher content, then fire
-    // an immediate retry. The new entry sits alongside any prior entries in
-    // the coordinator ledger; the retry's eventual finishTurn commits the
-    // concrete message/batch it consumed.
+    // Transient retry path: keep the original start/resume message at the head
+    // of the provider retry. Newer messages sit later in the inbox ACK prefix,
+    // so they are queued and injected only after retry succeeds.
     if (existing && existing.retryAttempt > 0) {
-      existing.startMessage = message;
+      existing.retryQueuedMessages.push(message);
       this.triggerImmediateRetry(chatId);
       return;
     }
@@ -708,6 +707,7 @@ export class SessionManager {
     if (existing) {
       switch (existing.status) {
         case "active":
+          this.setCurrentTrigger(chatId, message);
           existing.handler.inject(message);
           existing.lastActivity = Date.now();
           this.projectSessionRuntime(chatId);
@@ -793,6 +793,7 @@ export class SessionManager {
       lastRetryReason: null,
       lastRetryRawError: null,
       startMessage: message,
+      retryQueuedMessages: [],
       retryFromEvicted: evicted ?? null,
     };
 
@@ -806,6 +807,7 @@ export class SessionManager {
     this.notifySessionState(chatId, "active");
     this.projectSessionRuntime(chatId);
     try {
+      this.setCurrentTrigger(chatId, message);
       if (evicted) {
         const sessionId = await handler.resume(message, evicted.claudeSessionId, ctx);
         entry.claudeSessionId = sessionId;
@@ -866,6 +868,7 @@ export class SessionManager {
     this.notifySessionState(entry.chatId, "active");
     this.projectSessionRuntime(entry.chatId);
     try {
+      if (message) this.setCurrentTrigger(entry.chatId, message);
       // Mirror the pattern in `startNewSession` (line 449): the handler may
       // return a DIFFERENT sessionId than the one passed in — e.g. when the
       // claude-code handler detects a stale SDK transcript and falls
@@ -1098,6 +1101,7 @@ export class SessionManager {
     try {
       const resumeMessage = entry.startMessage ?? null;
       const previousSessionId = entry.claudeSessionId || entry.retryFromEvicted?.claudeSessionId || "";
+      if (resumeMessage) this.setCurrentTrigger(chatId, resumeMessage);
       if (previousSessionId) {
         const sid = await newHandler.resume(resumeMessage ?? undefined, previousSessionId, ctx);
         entry.claudeSessionId = sid;
@@ -1133,6 +1137,7 @@ export class SessionManager {
       } catch (emitErr) {
         this.config.log.warn({ chatId, emitErr }, "resilience retry_succeeded emit failed");
       }
+      this.drainRetryQueuedMessages(entry);
       this.persistRegistry();
     } catch (err) {
       const classification = classify(err, { source: "session" });
@@ -1167,6 +1172,29 @@ export class SessionManager {
       entry.retryTimer = null;
     }
     void this.runRetry(chatId);
+  }
+
+  private drainRetryQueuedMessages(entry: SessionEntry): void {
+    if (entry.retryQueuedMessages.length === 0) return;
+
+    const queued = entry.retryQueuedMessages.splice(0);
+    for (const message of queued) {
+      this.setCurrentTrigger(entry.chatId, message);
+      try {
+        entry.handler.inject(message);
+        entry.lastActivity = Date.now();
+      } catch (err) {
+        this.config.log.warn({ chatId: entry.chatId, messageId: message.id, err }, "retry queued inject failed");
+        this.inboxDelivery.retryTurn(entry.chatId, message, "retry_queued_inject_failed");
+        break;
+      }
+    }
+    this.projectSessionRuntime(entry.chatId);
+  }
+
+  private setCurrentTrigger(chatId: string, message: SessionMessage): void {
+    if (!message.id) return;
+    this.currentTrigger.set(chatId, { messageId: message.id, senderId: message.senderId });
   }
 
   /**

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -16,7 +16,6 @@ import { buildAgentEnv, createParticipantCache, formatInboundContent, resolveSen
 import { type ContextTreeBinding, syncAgentContextTree } from "./bootstrap.js";
 import type { SessionConfig } from "./config.js";
 import { reresolveUnboundTree } from "./context-tree-rebind.js";
-import { Deduplicator } from "./deduplicator.js";
 import type { SelfFence } from "./doc-snapshots.js";
 import { type Classification, clampRetryAttempt, classify, ERROR_KINDS, nextRetryDelayMs } from "./error-taxonomy.js";
 import type {
@@ -28,6 +27,7 @@ import type {
   SessionMessage,
 } from "./handler.js";
 import { findImagePath, writeImage } from "./image-store.js";
+import { InboxDeliveryCoordinator } from "./inbox-delivery-coordinator.js";
 import { redactErrorPreview } from "./redact-error-preview.js";
 import { createResultSink, type Trigger } from "./result-sink.js";
 import { SessionRegistry } from "./session-registry.js";
@@ -291,14 +291,6 @@ function previousAvailable(entry: SessionEntry): boolean {
   return Boolean(entry.claudeSessionId) || Boolean(entry.retryFromEvicted?.claudeSessionId);
 }
 
-type TrackedInFlightEntry = {
-  entryId: number;
-  messageId: string;
-  dedupKey: string;
-  accepted: boolean;
-  consumed: boolean;
-};
-
 /**
  * Encode a resilience event into the closed `error` event payload by
  * prefixing the message with the event name. Future server-side consumers
@@ -314,9 +306,9 @@ export class SessionManager {
   private readonly sessions = new Map<string, SessionEntry>();
   private readonly evictedMappings = new Map<string, { claudeSessionId: string; lastActivity: number }>();
   private readonly config: SessionManagerConfig;
+  private readonly inboxDelivery: InboxDeliveryCoordinator;
   /** Last lazy Context-Tree re-resolution attempt (epoch ms); see `TREE_RERESOLVE_INTERVAL_MS`. */
   private lastTreeResolveAttemptAt = 0;
-  private readonly deduplicator = new Deduplicator(1000);
   /**
    * Current trigger (messageId + senderId) per chat — the message that kicked
    * off the current or most-recent turn. Read by `forwardResult` (via the
@@ -326,38 +318,6 @@ export class SessionManager {
    */
   private readonly currentTrigger = new Map<string, Trigger>();
   private readonly registry: SessionRegistry | null;
-  /**
-   * In-flight inbox entries per chat — delivered entries that this process
-   * has handed toward a handler and has not yet committed. Completion is
-   * identity based: handlers report the concrete SessionMessage or fused
-   * batch they actually consumed, and the runtime sends one ack-through for
-   * that batch's last inbox entry.
-   *
-   * Kept here (not on `SessionEntry`) because dispatch may push an entryId
-   * before any session record exists for the chat (`startNewSession` runs
-   * `routeMessage` first), and the queue must survive a session being
-   * suspended / evicted between dispatch and markCompleted.
-   *
-   * Sized small in practice: usually 1, briefly up to N when several
-   * messages land while a turn is mid-flight. Entries that were delivered
-   * but only queued inside a handler remain tracked until the handler's
-   * actual consuming turn calls `markMessagesCompleted`.
-   * See
-   * docs/inflight-message-recovery-design.md §4.
-   */
-  private readonly inFlightEntries = new Map<string, TrackedInFlightEntry[]>();
-  /**
-   * Per-chat admission barrier. It serializes the pre-handler admission phase
-   * only: config refresh, eager asset fetch, marking the entry accepted, and
-   * invoking `routeMessage()`. It deliberately does NOT wait for the handler's
-   * turn promise to settle, so A2 can still be appended/injected while A1's
-   * attempt is running; it just cannot overtake A1 before A1 reaches handler
-   * membership.
-   */
-  private readonly admissionQueues = new Map<string, Promise<void>>();
-  private readonly recoveringChats = new Map<string, Promise<void>>();
-  private readonly recoveryActivationReady = new Set<string>();
-  private readonly requiresInboxRecovery = new Set<string>();
   private readonly pendingQueue: PendingMessage[] = [];
   private readonly lastReportedStates = new Map<string, SessionState>();
   private readonly sessionRuntimeStates = new Map<string, RuntimeState>();
@@ -368,10 +328,16 @@ export class SessionManager {
 
   constructor(config: SessionManagerConfig) {
     this.config = config;
+    this.inboxDelivery = new InboxDeliveryCoordinator({
+      ackEntry: config.ackEntry,
+      recoverChat: config.recoverChat,
+      onWorkChanged: (chatId) => this.projectSessionRuntime(chatId),
+      log: config.log,
+    });
     this.registry = config.registryPath ? new SessionRegistry(config.registryPath) : null;
     this.idleTimer = setInterval(() => this.evictIdle(), 10_000);
     // Independent of `evictIdle` (which early-continues on freshly-active
-    // sessions): re-affirm working / blocked / error sessions so the
+    // sessions): re-affirm working / error sessions so the
     // server-side `runtime_state_at` stays inside the freshness window.
     // Jittered setTimeout (rearmed each tick) instead of setInterval so
     // many clients don't align on the same instant.
@@ -391,7 +357,7 @@ export class SessionManager {
 
   /**
    * Dispatch an inbox entry. ACK is deferred until the handler reports a
-   * completed turn via `ctx.markMessagesCompleted(...)`.
+   * completed turn via `ctx.finishTurn(...)`.
    *
    * Delayed ACK semantics (post inflight-message-recovery): the entry stays
    * `delivered` server-side until forwardResult succeeds (or the handler
@@ -409,38 +375,24 @@ export class SessionManager {
     const chatId = entry.chatId ?? entry.message.chatId;
     const messageId = entry.message.id;
 
-    if (this.shouldRecoverBeforeDispatch(chatId)) {
-      await this.recoverChatBeforeDispatch(chatId, entry.id, messageId);
+    if (
+      this.inboxDelivery.shouldRecoverBeforeDispatch(
+        chatId,
+        this.hasHealthyLiveHandler(chatId),
+        this.hasLocalSessionRecord(chatId),
+      )
+    ) {
+      await this.inboxDelivery.recoverIfNeeded(chatId, `before_dispatch:${entry.id}:${messageId}`);
       return;
     }
 
-    // 1. Deduplication — key by (chatId, messageId). Dedup is now only an
-    // in-process duplicate-injection guard for entries still tracked by the
-    // active local turn/batch. It must not independently re-ack: ack-through
-    // can commit older delivered prefix rows, so only a concrete successful
-    // turn completion may send the cursor.
-    const dedupKey = `${chatId}:${messageId}`;
-    if (this.deduplicator.isDuplicate(dedupKey)) {
-      const queue = this.inFlightEntries.get(chatId);
-      const stillInFlight = queue ? queue.some((tracked) => tracked.entryId === entry.id) : false;
-      this.config.log.debug({ chatId, messageId, entryId: entry.id, stillInFlight }, "duplicate message observed");
-      if (stillInFlight) return;
-      this.config.log.debug(
-        { chatId, messageId, entryId: entry.id },
-        "duplicate key is not tied to an active entry; reprocessing redelivery",
-      );
-    }
-
-    // Track before routing. The handler (or teardown path) commits by
-    // message identity once work is complete; nothing acks until then.
-    const queue = this.inFlightEntries.get(chatId);
-    const tracked = { entryId: entry.id, messageId, dedupKey, accepted: false, consumed: false };
-    if (queue) queue.push(tracked);
-    else this.inFlightEntries.set(chatId, [tracked]);
+    const decision = this.inboxDelivery.receive(entry);
+    if (decision.kind !== "deliver") return;
+    const { work } = decision;
 
     let routePromise: Promise<void> | undefined;
-    await this.withAdmissionBarrier(chatId, async () => {
-      if (!this.isTrackedEntry(chatId, entry.id)) return;
+    await this.inboxDelivery.runAdmission(work, async () => {
+      if (!this.inboxDelivery.hasEntry(work)) return;
 
       // 2. Step 4: refresh runtime config if the message brought a newer
       // version. This is the *only* trigger for active-session re-config —
@@ -466,7 +418,7 @@ export class SessionManager {
         }
       }
 
-      if (!this.isTrackedEntry(chatId, entry.id)) return;
+      if (!this.inboxDelivery.hasEntry(work)) return;
 
       // Note: the "mention_only" filter now lives on the server (see
       // services/message.ts sendMessage fan-out). If an entry reaches dispatch
@@ -483,7 +435,7 @@ export class SessionManager {
       // "not available on this device" placeholder for that ref.
       await this.ensureImagesLocal(message);
 
-      if (!this.markTrackedEntryAccepted(chatId, entry.id)) return;
+      if (!this.inboxDelivery.markAccepted(work)) return;
 
       // 4c. Lazily resolve a tree-LESS Context Tree binding before routing this
       // message to a (possibly new) session. The binding is frozen at
@@ -499,14 +451,14 @@ export class SessionManager {
       }
 
       // 5. Route by session state. ACK no longer happens inside route — the
-      // entry sits in `inFlightEntries` until the handler completes the
+      // entry sits in the coordinator ledger until the handler completes the
       // concrete message/batch it actually consumed. Do not await inside the
       // admission barrier: for Codex/TUI, route promises can span the whole
       // turn, but same-chat later messages must still be able to append once
       // this entry has reached handler membership.
       routePromise = this.routeMessage(chatId, message).catch((err) => {
-        if (this.isTrackedEntry(chatId, entry.id)) {
-          this.clearInFlightForRecovery(chatId, "route_message_failed");
+        if (this.inboxDelivery.hasEntry(work)) {
+          this.inboxDelivery.retryTurn(chatId, message, "route_message_failed");
         }
         throw err;
       });
@@ -588,12 +540,9 @@ export class SessionManager {
         if (this.pendingQueue[i]?.chatId === chatId) this.pendingQueue.splice(i, 1);
       }
 
-      // Terminate is operator-intent — ack every queued in-flight entry
-      // so the server doesn't redeliver them on the next bind. Server-side
-      // pushed messages get silently dropped here; this is the documented
-      // terminate semantics (operator chose to wipe this chat's session,
-      // anything mid-flight is collateral).
-      this.drainAllInFlightEntries(chatId);
+      // Terminate is operator intent: accepted delivery work can be drained,
+      // but coordinator keeps any uncommitted tail as recovery debt.
+      await this.inboxDelivery.drainForTerminate(chatId);
 
       this.recomputeRuntimeState();
       this.persistRegistry();
@@ -714,7 +663,7 @@ export class SessionManager {
   /**
    * Compatibility hook for AgentSlot's bind listener. Bind-time recovery is
    * now server-driven; chat-scoped same-socket recovery is requested lazily
-   * by `dispatch` when no healthy live handler exists.
+   * by `dispatch` when a locally held chat has no healthy live handler.
    */
   noteBindRecoveryComplete(): void {
     // Intentionally no-op.
@@ -722,72 +671,13 @@ export class SessionManager {
 
   // ---- Internal -----------------------------------------------------------
 
-  private async withAdmissionBarrier(chatId: string, op: () => Promise<void>): Promise<void> {
-    const prev = this.admissionQueues.get(chatId) ?? Promise.resolve();
-    const next = prev.then(op, op);
-    this.admissionQueues.set(chatId, next);
-    const cleanup = () => {
-      if (this.admissionQueues.get(chatId) === next) this.admissionQueues.delete(chatId);
-    };
-    void next.then(cleanup, cleanup);
-    await next;
-  }
-
-  private isTrackedEntry(chatId: string, entryId: number): boolean {
-    return this.inFlightEntries.get(chatId)?.some((tracked) => tracked.entryId === entryId) ?? false;
-  }
-
-  private markTrackedEntryAccepted(chatId: string, entryId: number): boolean {
-    const tracked = this.inFlightEntries.get(chatId)?.find((entry) => entry.entryId === entryId);
-    if (!tracked) return false;
-    tracked.accepted = true;
-    return true;
-  }
-
   private hasHealthyLiveHandler(chatId: string): boolean {
     const entry = this.sessions.get(chatId);
     return entry?.status === "active" && entry.suspending === null;
   }
 
-  private shouldRecoverBeforeDispatch(chatId: string): boolean {
-    if (this.recoveryActivationReady.has(chatId)) {
-      this.recoveryActivationReady.delete(chatId);
-      return false;
-    }
-    if (this.requiresInboxRecovery.has(chatId)) return true;
-    return Boolean(this.config.recoverChat) && !this.hasHealthyLiveHandler(chatId);
-  }
-
-  private async recoverChatBeforeDispatch(chatId: string, entryId: number, messageId: string): Promise<void> {
-    const existing = this.recoveringChats.get(chatId);
-    if (existing) {
-      await existing;
-      return;
-    }
-    const recoverChat = this.config.recoverChat;
-    if (!recoverChat) {
-      this.config.log.error(
-        { chatId, entryId, messageId },
-        "chat requires inbox recovery but no recoverChat callback is configured; deferring dispatch",
-      );
-      return;
-    }
-
-    let recovery: Promise<void>;
-    recovery = recoverChat(chatId)
-      .then(() => {
-        this.requiresInboxRecovery.delete(chatId);
-        this.recoveryActivationReady.add(chatId);
-        this.config.log.debug({ chatId, entryId, messageId }, "chat inbox recovery accepted before dispatch");
-      })
-      .catch((err) => {
-        this.config.log.warn({ chatId, entryId, messageId, err }, "chat inbox recovery failed before dispatch");
-      })
-      .finally(() => {
-        if (this.recoveringChats.get(chatId) === recovery) this.recoveringChats.delete(chatId);
-      });
-    this.recoveringChats.set(chatId, recovery);
-    await recovery;
+  private hasLocalSessionRecord(chatId: string): boolean {
+    return this.sessions.has(chatId) || this.evictedMappings.has(chatId);
   }
 
   private async routeMessage(chatId: string, message: SessionMessage): Promise<void> {
@@ -807,8 +697,8 @@ export class SessionManager {
     // user message is a strong signal the user is waiting — replace the
     // stored startMessage so the retry uses the fresher content, then fire
     // an immediate retry. The new entry sits alongside any prior entries in
-    // `inFlightEntries[chatId]`; the retry's eventual forwardResult commits
-    // the concrete message/batch it consumed.
+    // the coordinator ledger; the retry's eventual finishTurn commits the
+    // concrete message/batch it consumed.
     if (existing && existing.retryAttempt > 0) {
       existing.startMessage = message;
       this.triggerImmediateRetry(chatId);
@@ -820,16 +710,7 @@ export class SessionManager {
         case "active":
           existing.handler.inject(message);
           existing.lastActivity = Date.now();
-          // Re-arm the working-grace guard in `evictIdle`. Without this, a
-          // turn that ends with `setRuntimeState("idle")` (claude-code.ts on
-          // every result message) leaves the next inject-triggered turn
-          // observable as `idle` — and a long-thinking turn that produces
-          // no SDK messages for `idle_timeout` (300s default) trips
-          // evictIdle's suspend path even though the agent is actively
-          // working. Setting `working` here puts the session under the
-          // `idle_timeout + working_grace_seconds` umbrella until the next
-          // result flips it back.
-          this.setSessionRuntimeState(chatId, "working");
+          this.projectSessionRuntime(chatId);
           this.config.log.debug({ chatId }, "message injected");
           return;
 
@@ -919,20 +800,11 @@ export class SessionManager {
     this._activeCount++;
     if (evicted) this.evictedMappings.delete(chatId);
 
-    // Report `active` BEFORE invoking handler.start / handler.resume. Handlers
-    // can call `ctx.setRuntimeState("working")` synchronously inside start()
-    // (claude-code does; codex always does — its handler awaits the whole
-    // turn before returning, so the initial working AND final idle reports
-    // both fire from inside start()). Those `session:runtime` frames are
-    // active-gated on the server, so they would be dropped if the
-    // `session:state active` write hadn't landed yet — leaving the composite
-    // stuck at `ready` until a reaffirm (or never, for short turns). The
-    // server's `upsertSessionState` short-circuits same-state reports, and
-    // `notifySessionState` here additionally dedupes against the last
-    // reported value, so doing it before AND after is harmless if a future
-    // refactor adds a second site. Failure path replaces this `active` with
-    // `errored` in the catch below (different state → goes through).
+    // Report `active` before runtime projection. `session:runtime` frames are
+    // active-gated on the server, so the state row must exist before a fresh
+    // delivery projects this chat to working.
     this.notifySessionState(chatId, "active");
+    this.projectSessionRuntime(chatId);
     try {
       if (evicted) {
         const sessionId = await handler.resume(message, evicted.claudeSessionId, ctx);
@@ -958,7 +830,7 @@ export class SessionManager {
         // Permanent / degraded failure: tear down (legacy F2 path) and ack
         // every in-flight entry so the server doesn't redeliver a message
         // that would just re-hit the same permanent failure.
-        this.drainAllInFlightEntries(chatId);
+        await this.inboxDelivery.drainForTerminate(chatId);
         this.sessions.delete(chatId);
         this.sessionRuntimeStates.delete(chatId);
         this.recomputeRuntimeState();
@@ -991,11 +863,8 @@ export class SessionManager {
     this._activeCount++;
     entry.lastActivity = Date.now();
 
-    // Same rationale as `startNewSession`: report `active` BEFORE invoking
-    // the handler so any synchronous `ctx.setRuntimeState("working")` inside
-    // handler.resume() lands on a server row that is already active-gated.
-    // Failure path overrides with `errored` in the catch below.
     this.notifySessionState(entry.chatId, "active");
+    this.projectSessionRuntime(entry.chatId);
     try {
       // Mirror the pattern in `startNewSession` (line 449): the handler may
       // return a DIFFERENT sessionId than the one passed in — e.g. when the
@@ -1020,7 +889,7 @@ export class SessionManager {
         classification,
       });
       if (!handled) {
-        this.drainAllInFlightEntries(entry.chatId);
+        await this.inboxDelivery.drainForTerminate(entry.chatId);
         this.sessions.delete(entry.chatId);
         this.sessionRuntimeStates.delete(entry.chatId);
         this.recomputeRuntimeState();
@@ -1086,6 +955,7 @@ export class SessionManager {
       this._activeCount--;
       entry.status = "suspended";
       this.sessionRuntimeStates.delete(chatId);
+      this.projectSessionRuntime(chatId);
       this.recomputeRuntimeState();
 
       this.config.log.info(
@@ -1134,7 +1004,9 @@ export class SessionManager {
 
     // Permanent / degraded — legacy F2 signalling (server state + structured
     // error event), then let caller tear down.
+    entry.status = "errored";
     this.notifySessionState(chatId, "errored");
+    this.projectSessionRuntime(chatId);
     try {
       // Same `safe in logs but NOT chat` boundary as the transient `rawError`
       // path above: the error message can legitimately echo back a git remote
@@ -1222,6 +1094,7 @@ export class SessionManager {
     const ctx = this.buildSessionContext(chatId);
 
     this.notifySessionState(chatId, "active");
+    this.projectSessionRuntime(chatId);
     try {
       const resumeMessage = entry.startMessage ?? null;
       const previousSessionId = entry.claudeSessionId || entry.retryFromEvicted?.claudeSessionId || "";
@@ -1271,7 +1144,7 @@ export class SessionManager {
         classification,
       });
       if (!handled) {
-        this.drainAllInFlightEntries(chatId);
+        await this.inboxDelivery.drainForTerminate(chatId);
         this.sessions.delete(chatId);
         this.sessionRuntimeStates.delete(chatId);
         this.recomputeRuntimeState();
@@ -1302,7 +1175,7 @@ export class SessionManager {
    * 2. If no candidates, queue the message
    *
    * Returns true if slot acquired, false if queued. The in-flight entryId
-   * is tracked separately in `inFlightEntries` (populated at dispatch),
+   * is tracked separately in `InboxDeliveryCoordinator` (populated at dispatch),
    * so the queue doesn't carry inbox metadata.
    */
   private acquireActiveSlot(chatId: string, message: SessionMessage): boolean {
@@ -1320,27 +1193,38 @@ export class SessionManager {
 
     if (oldestActive) {
       this.config.log.info({ chatId: oldestActive.chatId }, "session preempted for concurrency");
-      this.suspendSession(oldestActive);
+      this.suspendSession(oldestActive, { reason: "concurrency_preempted", ackConsumedPrefix: false });
       return true;
     }
 
     // All active sessions are busy — queue. The inbox entry stays in
-    // `inFlightEntries[chatId]` until the eventual turn finishes.
+    // the coordinator ledger until the eventual turn finishes.
     this.config.log.info({ chatId }, "concurrency limit reached, queuing");
     this.pendingQueue.push({ message, chatId });
     return false;
   }
 
-  private suspendSession(entry: SessionEntry): void {
-    this.ackConsumedInFlightForSuspend(entry.chatId);
-    this.clearInFlightForRecovery(entry.chatId, "session_suspended_unconsumed_tail");
+  private suspendSession(
+    entry: SessionEntry,
+    opts: { reason: string; ackConsumedPrefix: boolean } = {
+      reason: "session_suspended",
+      ackConsumedPrefix: true,
+    },
+  ): void {
+    const prepare = opts.ackConsumedPrefix
+      ? this.inboxDelivery.prepareSuspend(entry.chatId, opts.reason)
+      : Promise.resolve(this.inboxDelivery.prepareEvict(entry.chatId, opts.reason));
     entry.status = "suspended";
     this._activeCount--;
     // Clear per-session runtime state on suspend
     this.sessionRuntimeStates.delete(entry.chatId);
     this.recomputeRuntimeState();
-    entry.suspending = entry.handler
-      .suspend()
+    entry.suspending = prepare
+      .then(() => entry.handler.suspend())
+      .catch((err) => {
+        this.config.log.warn({ chatId: entry.chatId, err }, "suspend preparation error");
+      })
+      .then(() => undefined)
       .catch((err) => {
         this.config.log.warn({ chatId: entry.chatId, err }, "suspend error");
       })
@@ -1360,8 +1244,8 @@ export class SessionManager {
 
     const next = this.pendingQueue.shift();
     if (!next) return;
-    // Route asynchronously — the in-flight entryId for this message is
-    // already in `inFlightEntries[chatId]` from the original `dispatch`.
+    // Route asynchronously — the delivery work is already tracked by the
+    // coordinator from the original `dispatch`.
     this.routeMessage(next.chatId, next.message).catch((err) => {
       this.config.log.warn({ chatId: next.chatId, err }, "pending drain error");
     });
@@ -1412,11 +1296,7 @@ export class SessionManager {
       // overwrites before the handler runs), but since `terminate` already
       // cleans the same maps we keep the two paths symmetric.
       this.currentTrigger.delete(candidate.key);
-      // Drop local in-flight tracking too — the handler is gone, so no
-      // markCompleted will ever fire. The server-side entries stay
-      // `delivered`; a later chat recovery or bind reset redelivers them
-      // against a fresh session.
-      this.clearInFlightForRecovery(candidate.key, "session_evicted");
+      this.inboxDelivery.prepareEvict(candidate.key, "session_evicted");
       this.recomputeRuntimeState();
       this.persistRegistry();
     }
@@ -1428,28 +1308,12 @@ export class SessionManager {
    * Invariants this routine relies on:
    *   1. `lastActivity` is monotonic per session and is bumped by every
    *      inbound activity — `dispatch` (new chat / resume), `inject`
-   *      (mid-turn message), and the handler's `touch()` on each SDK event.
-   *   2. `runtimeState` reflects what the agent is currently doing as best
-   *      the runtime can tell:
-   *        - `working` — a turn is in flight. Set by the handler at the top
-   *          of its consume loop AND by `SessionManager` on every `inject`
-   *          (because the handler can't observe inject from inside the SDK
-   *          for-await — see #536). Cleared back to `idle` on each
-   *          `result` message from the SDK.
-   *        - `blocked` — only reachable if a handler chooses to set it
-   *          explicitly. The runtime no longer auto-migrates `working` →
-   *          `blocked` on inactivity: with reasoning models a 2-minute
-   *          quiet stretch is normal deep-thinking, not a stuck process,
-   *          and the auto-migration was producing false-positive UI
-   *          warnings. State kept as a semantic slot for future use
-   *          (e.g. if/when the SDK transport exposes a real stuck signal).
-   *        - `idle` — no work in flight.
-   *      If you add a new way to wake the session up, you MUST also set
-   *      `runtimeState` to `working` from that path, or this guard will
-   *      treat the chat as idle and reap it.
-   *   3. `working_grace_seconds` is an UPPER bound on how long a `working`
-   *      / `blocked` chat can hold a slot past `idle_timeout` — defends
-   *      against a stuck handler that never flips back to `idle`.
+   *      (mid-turn message), and the handler's provider-activity callback.
+   *   2. The coordinator is the source of truth for unsettled delivery work.
+   *      If a chat has tracked / consumed / ACK-pending entries or recovery
+   *      debt, the reaper must not treat it as idle before the hard cap.
+   *   3. `working_grace_seconds` is an UPPER bound on how long unsettled work
+   *      can hold a slot past `idle_timeout`.
    */
   private evictIdle(): void {
     const timeoutMs = this.config.session.idle_timeout * 1000;
@@ -1462,20 +1326,15 @@ export class SessionManager {
       if (inactiveMs <= timeoutMs) continue;
 
       const currentState = this.sessionRuntimeStates.get(session.chatId);
+      const hasUnsettledWork = this.inboxDelivery.hasUnsettledWork(session.chatId);
 
-      // Hard cap: regardless of `runtimeState`, once we are past
+      // Hard cap: regardless of unsettled work, once we are past
       // `idle_timeout + working_grace_seconds` the slot MUST be reclaimed.
       // Anything else means a stuck handler can hold a slot forever just
-      // by never flipping `runtimeState` back to `idle`.
+      // by never closing the delivery work.
       const pastHardCap = inactiveMs >= timeoutMs + workingGraceMs;
 
-      // `lastActivity` is bumped per inbound SDK message/event (handler
-      // `touch()`), so a long thinking turn or a single very large message
-      // looks identical to "session has been idle" here. Without this
-      // exemption the runtime suspends the SDK transport mid-thinking and
-      // the work is lost. The hard cap above bounds the worst case.
-      const stillProgressing = currentState === "working" || currentState === "blocked";
-      if (stillProgressing && !pastHardCap) {
+      if (hasUnsettledWork && !pastHardCap) {
         this.config.log.info(
           {
             chatId: session.chatId,
@@ -1483,7 +1342,7 @@ export class SessionManager {
             inactiveSec: Math.round(inactiveMs / 1000),
             graceSec: this.config.session.working_grace_seconds,
           },
-          "session idle threshold reached but still working — skipping suspend",
+          "session idle threshold reached but inbox work is unsettled — skipping suspend",
         );
         continue;
       }
@@ -1517,127 +1376,6 @@ export class SessionManager {
     if (this.lastReportedStates.get(chatId) === state) return;
     this.lastReportedStates.set(chatId, state);
     this.config.onStateChange(chatId, state);
-  }
-
-  private ackThroughTrackedEntry(chatId: string, throughEntryId: number): void {
-    const queue = this.inFlightEntries.get(chatId);
-    if (!queue || queue.length === 0) return;
-    const index = queue.findIndex((tracked) => tracked.entryId === throughEntryId);
-    if (index < 0) {
-      this.config.log.warn({ chatId, throughEntryId }, "attempt completion ignored for untracked inbox entry");
-      return;
-    }
-
-    const committed = queue.splice(0, index + 1);
-    for (const tracked of committed) {
-      this.deduplicator.drop(tracked.dedupKey);
-    }
-    if (queue.length === 0) this.inFlightEntries.delete(chatId);
-
-    this.config.ackEntry(throughEntryId).catch((err) => {
-      this.config.log.warn({ chatId, entryId: throughEntryId, err }, "ACK-through failed, continuing");
-    });
-  }
-
-  private ackOldestTrackedEntry(chatId: string): void {
-    const entryId = this.inFlightEntries.get(chatId)?.[0]?.entryId;
-    if (entryId !== undefined) this.ackThroughTrackedEntry(chatId, entryId);
-  }
-
-  private clearInFlightForRecovery(chatId: string, reason: string): void {
-    const queue = this.inFlightEntries.get(chatId);
-    if (!queue || queue.length === 0) return;
-    this.inFlightEntries.delete(chatId);
-    this.deduplicator.dropByPrefix(`${chatId}:`);
-    this.requiresInboxRecovery.add(chatId);
-    this.config.log.warn(
-      { chatId, reason, entryIds: queue.map((entry) => entry.entryId) },
-      "cleared local in-flight inbox entries; waiting for recovery redelivery",
-    );
-  }
-
-  private ackConsumedInFlightForSuspend(chatId: string): void {
-    const queue = this.inFlightEntries.get(chatId);
-    if (!queue || queue.length === 0) return;
-
-    let consumedPrefixCount = 0;
-    for (const tracked of queue) {
-      if (!tracked.consumed) break;
-      consumedPrefixCount++;
-    }
-    if (consumedPrefixCount === 0) return;
-
-    const lastConsumed = queue[consumedPrefixCount - 1];
-    if (lastConsumed) this.ackThroughTrackedEntry(chatId, lastConsumed.entryId);
-  }
-
-  private markMessagesConsumed(chatId: string, messages: SessionMessage | readonly SessionMessage[]): void {
-    const queue = this.inFlightEntries.get(chatId);
-    if (!queue || queue.length === 0) return;
-    const batch = Array.isArray(messages) ? messages : [messages];
-    const consumedIds = new Set<number>();
-    for (const message of batch) {
-      if (message.chatId === chatId && message.inboxEntryId !== undefined) consumedIds.add(message.inboxEntryId);
-    }
-    if (consumedIds.size === 0) return;
-    for (const tracked of queue) {
-      if (consumedIds.has(tracked.entryId)) tracked.consumed = true;
-    }
-  }
-
-  private markMessagesCompleted(chatId: string, messages: SessionMessage | readonly SessionMessage[]): void {
-    const batch = Array.isArray(messages) ? messages : [messages];
-    let throughEntryId: number | undefined;
-    for (const message of batch) {
-      if (message.chatId !== chatId) continue;
-      if (message.inboxEntryId !== undefined) throughEntryId = message.inboxEntryId;
-    }
-    if (throughEntryId === undefined) {
-      this.config.log.warn({ chatId }, "attempt completion ignored because no inboxEntryId was provided");
-      return;
-    }
-    this.ackThroughTrackedEntry(chatId, throughEntryId);
-  }
-
-  private markMessagesRetryable(
-    chatId: string,
-    messages: SessionMessage | readonly SessionMessage[],
-    reason: string,
-  ): void {
-    const batch = Array.isArray(messages) ? messages : [messages];
-    const hasTrackedMessage = batch.some(
-      (message) =>
-        message.chatId === chatId &&
-        message.inboxEntryId !== undefined &&
-        (this.inFlightEntries.get(chatId) ?? []).some((entry) => entry.entryId === message.inboxEntryId),
-    );
-    if (!hasTrackedMessage) return;
-    this.clearInFlightForRecovery(chatId, reason);
-  }
-
-  /**
-   * Drain every in-flight entry for this chat and ack them all. Used by
-   * the runtime on `session:terminate` (operator intent — every queued
-   * entry is doomed) and on permanent `handler.start` / `handler.resume`
-   * failure (re-handling on redelivery would re-hit the same permanent
-   * error, so acking avoids a loop). NOT to be called from handlers — the
-   * per-turn pairing path is `markMessagesCompleted(messageOrBatch)`.
-   */
-  private drainAllInFlightEntries(chatId: string): void {
-    const queue = this.inFlightEntries.get(chatId);
-    if (!queue || queue.length === 0) return;
-    let acceptedPrefixCount = 0;
-    for (const tracked of queue) {
-      if (!tracked.accepted) break;
-      acceptedPrefixCount++;
-    }
-    if (acceptedPrefixCount > 0) {
-      const lastAccepted = queue[acceptedPrefixCount - 1];
-      if (lastAccepted) this.ackThroughTrackedEntry(chatId, lastAccepted.entryId);
-    }
-    if (this.inFlightEntries.has(chatId)) {
-      this.clearInFlightForRecovery(chatId, "drain_unaccepted_remainder");
-    }
   }
 
   private buildSessionContext(chatId: string): SessionContext {
@@ -1707,30 +1445,24 @@ export class SessionManager {
       sdk: this.config.sdk,
       log,
       chatId,
-      touch: () => {
+      recordProviderActivity: () => {
         const entry = this.sessions.get(chatId);
         if (entry && entry.status === "active") {
           entry.lastActivity = Date.now();
         }
       },
-      setRuntimeState: (state) => {
-        this.setSessionRuntimeState(chatId, state);
-      },
       emitEvent: (event) => {
         this.config.onSessionEvent?.(chatId, event);
       },
       forwardResult,
-      markCompleted: () => {
-        this.ackOldestTrackedEntry(chatId);
-      },
       markMessagesConsumed: (messages) => {
-        this.markMessagesConsumed(chatId, messages);
+        this.inboxDelivery.markConsumed(chatId, messages);
       },
-      markMessagesCompleted: (messages) => {
-        this.markMessagesCompleted(chatId, messages);
+      finishTurn: (messages, outcome) => {
+        return this.inboxDelivery.finishTurn(chatId, messages, outcome);
       },
-      markMessagesRetryable: (messages, reason) => {
-        this.markMessagesRetryable(chatId, messages, reason);
+      retryTurn: (messages, reason) => {
+        this.inboxDelivery.retryTurn(chatId, messages, reason);
       },
       buildAgentEnv: (parentEnv) => buildAgentEnv(parentEnv, envCtx),
       formatInboundContent: (message) => formatInboundContent(message, participants),
@@ -1756,18 +1488,24 @@ export class SessionManager {
     }
   }
 
-  /** Update per-session runtime state and recompute aggregate. Only active sessions may update. */
-  private setSessionRuntimeState(chatId: string, state: RuntimeState): void {
+  private projectSessionRuntime(chatId: string): void {
     const session = this.sessions.get(chatId);
-    if (!session || session.status !== "active") return;
+    const state = this.projectedRuntimeState(chatId, session ?? null);
+    if (!state) {
+      if (this.sessionRuntimeStates.delete(chatId)) this.recomputeRuntimeState();
+      return;
+    }
+    if (this.sessionRuntimeStates.get(chatId) === state) return;
     this.sessionRuntimeStates.set(chatId, state);
-    // Per-chat D-axis report: the authoritative source the server-side
-    // composite reads. Fire before recomputing the agent-global aggregate
-    // so a single state change drops one frame on each wire (the per-chat
-    // and the agent-global one), in that order — making it harmless if
-    // either consumer races the other.
     this.config.onSessionRuntimeChange?.(chatId, state);
     this.recomputeRuntimeState();
+  }
+
+  private projectedRuntimeState(chatId: string, session: SessionEntry | null): RuntimeState | null {
+    if (!session) return null;
+    if (session.status === "errored") return "error";
+    if (session.status !== "active") return null;
+    return this.inboxDelivery.hasUnsettledWork(chatId) ? "working" : "idle";
   }
 
   /**
@@ -1781,9 +1519,9 @@ export class SessionManager {
   private reaffirmRuntimeStates(): void {
     if (!this.config.onSessionRuntimeChange) return;
     for (const [chatId, session] of this.sessions) {
-      if (session.status !== "active") continue;
+      if (session.status !== "active" && session.status !== "errored") continue;
       const state = this.sessionRuntimeStates.get(chatId);
-      if (state === "working" || state === "blocked" || state === "error") {
+      if (state === "working" || state === "error") {
         this.config.onSessionRuntimeChange(chatId, state);
       }
     }
@@ -1799,8 +1537,9 @@ export class SessionManager {
   getSessionRuntimeStates(): Array<{ chatId: string; runtimeState: RuntimeState }> {
     const out: Array<{ chatId: string; runtimeState: RuntimeState }> = [];
     for (const [chatId, session] of this.sessions) {
-      if (session.status !== "active") continue;
-      out.push({ chatId, runtimeState: this.sessionRuntimeStates.get(chatId) ?? "idle" });
+      const runtimeState = this.projectedRuntimeState(chatId, session);
+      if (!runtimeState) continue;
+      out.push({ chatId, runtimeState });
     }
     return out;
   }

--- a/packages/server/src/__tests__/inbox-ws-push.test.ts
+++ b/packages/server/src/__tests__/inbox-ws-push.test.ts
@@ -402,7 +402,7 @@ describe("inbox WS data-plane claim helpers", () => {
     expect(afterAck.every((row) => row.status === "acked")).toBe(true);
   });
 
-  it("claimBacklogForPush drains pending entries oldest-first up to the limit", async () => {
+  it("claimBacklogForPush drains pending entries by inbox id up to the limit", async () => {
     const app = getApp();
     const uid = crypto.randomUUID().slice(0, 6);
     const a1 = await createTestAgent(app, { name: `wspb-a1-${uid}` });
@@ -425,15 +425,7 @@ describe("inbox WS data-plane claim helpers", () => {
 
     const drained = await inboxService.claimBacklogForPush(app.db, a2.agent.inboxId, 10);
     expect(drained.length).toBe(3);
-    // FIFO invariant — proposal §3.3: reply chains and silent-context windows
-    // depend on chronological order; reordering here would silently break
-    // mention semantics in group chats.
-    for (let i = 1; i < drained.length; i++) {
-      const prev = drained[i - 1];
-      const curr = drained[i];
-      if (!prev || !curr) throw new Error("unreachable: drained array bounds");
-      expect(prev.createdAt <= curr.createdAt).toBe(true);
-    }
+    expect(drained.map((entry) => entry.id)).toEqual([...drained].map((entry) => entry.id).sort((a, b) => a - b));
     // Every drained entry must be marked delivered atomically with the claim.
     for (const e of drained) expect(e.status).toBe("delivered");
     // Pin the bigserial → number conversion on the backlog path too. The WS
@@ -441,6 +433,46 @@ describe("inbox WS data-plane claim helpers", () => {
     // ever regresses to raw SQL, every push frame would be dropped client-
     // side as malformed. See issue #194.
     for (const e of drained) expect(typeof e.id).toBe("number");
+  });
+
+  it("uses inbox id cursor order even when createdAt is reversed", async () => {
+    const app = getApp();
+    const { a2, rows } = await seedDeliverables(app, 2);
+    const first = rows[0];
+    const second = rows[1];
+    if (!first || !second) throw new Error("expected two inbox rows");
+
+    await app.db
+      .update(inboxEntries)
+      .set({ createdAt: new Date("2030-01-01T00:00:00.000Z") })
+      .where(eq(inboxEntries.id, first.id));
+    await app.db
+      .update(inboxEntries)
+      .set({ createdAt: new Date("2020-01-01T00:00:00.000Z") })
+      .where(eq(inboxEntries.id, second.id));
+
+    const drained = await inboxService.claimBacklogForPush(app.db, a2.agent.inboxId, 10);
+    expect(drained.map((entry) => entry.id)).toEqual([first.id, second.id]);
+
+    const firstAck = await inboxService.ackEntryByIdForBoundAgents(app.db, first.id, [a2.agent.inboxId]);
+    expect(firstAck.ok).toBe(true);
+    if (!firstAck.ok) throw new Error("ack-through unexpectedly rejected");
+    expect(firstAck.ackedEntryIds).toEqual([first.id]);
+
+    const afterFirstAck = await app.db
+      .select({ id: inboxEntries.id, status: inboxEntries.status })
+      .from(inboxEntries)
+      .where(and(eq(inboxEntries.inboxId, a2.agent.inboxId), eq(inboxEntries.notify, true)))
+      .orderBy(asc(inboxEntries.id));
+    expect(afterFirstAck.map((row) => [row.id, row.status])).toEqual([
+      [first.id, "acked"],
+      [second.id, "delivered"],
+    ]);
+
+    const secondAck = await inboxService.ackEntryByIdForBoundAgents(app.db, second.id, [a2.agent.inboxId]);
+    expect(secondAck.ok).toBe(true);
+    if (!secondAck.ok) throw new Error("ack-through unexpectedly rejected");
+    expect(secondAck.ackedEntryIds).toEqual([second.id]);
   });
 
   it("ackEntryByIdForBoundAgents commits delivered notify=true prefix through the target entry", async () => {

--- a/packages/server/src/services/inbox.ts
+++ b/packages/server/src/services/inbox.ts
@@ -131,7 +131,7 @@ async function pollInboxInner(db: Database, inboxId: string, limit: number, chat
             .where(
               and(eq(inboxEntries.inboxId, inboxId), eq(inboxEntries.status, "pending"), eq(inboxEntries.notify, true)),
             )
-            .orderBy(asc(inboxEntries.createdAt), asc(inboxEntries.id))
+            .orderBy(asc(inboxEntries.id))
             .limit(limit)
             .for("update", { skipLocked: true })
         : tx
@@ -145,7 +145,7 @@ async function pollInboxInner(db: Database, inboxId: string, limit: number, chat
                 eq(inboxEntries.notify, true),
               ),
             )
-            .orderBy(asc(inboxEntries.createdAt), asc(inboxEntries.id))
+            .orderBy(asc(inboxEntries.id))
             .limit(limit)
             .for("update", { skipLocked: true });
 
@@ -169,7 +169,7 @@ async function pollInboxInner(db: Database, inboxId: string, limit: number, chat
  * hub-inbox-ws-data-plane §3.2 risk #1).
  *
  * Steps:
- *   1. Sort by `createdAt` ASC (PG `RETURNING` does not guarantee order).
+ *   1. Sort by inbox `id` ASC (PG `RETURNING` does not guarantee order).
  *   2. For each trigger, collect silent context without consuming silent rows.
  *   3. Fetch the trigger messages.
  *   4. Build wire payloads via the single dispatcher.
@@ -183,11 +183,10 @@ export async function bundleDeliveryWithSilentContext(
 ): Promise<InboxEntryWithMessage[]> {
   if (claimed.length === 0) return [];
 
-  // PostgreSQL's UPDATE...RETURNING does not guarantee row order, so we sort
-  // by createdAt/id (ascending) before assembling the response. Downstream
-  // consumers — and silent-context bundling in particular — depend on
-  // chronological order to split context windows correctly.
-  claimed.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime() || a.id - b.id);
+  // PostgreSQL's UPDATE...RETURNING does not guarantee row order, so sort by
+  // the delivery cursor. ACK-through uses `id <= cursor`; delivery cannot use
+  // `createdAt` as a separate prefix order without making that cursor unsafe.
+  claimed.sort((a, b) => a.id - b.id);
 
   const precedingByEntryId = await collectPrecedingContext(tx, inboxId, claimed);
 
@@ -248,7 +247,7 @@ export async function bundleDeliveryWithSilentContext(
  * that target.
  *
  * Production WS delivery no longer exact-claims NOTIFY message ids; it treats
- * NOTIFY as a wake-up hint and drains backlog oldest-first through
+ * NOTIFY as a wake-up hint and drains backlog by inbox-id cursor through
  * `claimBacklogForPush()`. This helper remains for direct tests and any
  * explicit exact-message claim callers that need the same ack-through prefix
  * safety.
@@ -257,10 +256,10 @@ export async function bundleDeliveryWithSilentContext(
  * (or the debug `GET /inbox` endpoint) that already claimed the entry.
  * NOTIFY is fire-and-forget (proposal §3.2).
  *
- * Ack-through safety depends on this prefix behavior: a newer entry must not
- * be claimed/sent while an older same-chat pending entry remains invisible to
- * the client attempt. Callers that send the returned frames must preserve the
- * returned oldest-first order.
+ * Ack-through safety depends on this prefix behavior: a higher-id entry must
+ * not be claimed/sent while a lower-id same-chat pending entry remains
+ * invisible to the client attempt. Callers that send the returned frames must
+ * preserve the returned id order.
  */
 export async function claimAndBuildForPush(
   db: Database,
@@ -280,7 +279,7 @@ export async function claimAndBuildForPush(
             eq(inboxEntries.notify, true),
           ),
         )
-        .orderBy(asc(inboxEntries.createdAt), asc(inboxEntries.id))
+        .orderBy(asc(inboxEntries.id))
         .for("update")
         .limit(1);
       if (!target) return [];
@@ -376,7 +375,7 @@ async function collectPrecedingContext(
   }
 
   for (const [chatId, chatTriggers] of byChat) {
-    chatTriggers.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime() || a.id - b.id);
+    chatTriggers.sort((a, b) => a.id - b.id);
 
     const firstTrigger = chatTriggers[0];
     if (!firstTrigger) continue;


### PR DESCRIPTION
## Summary
- unify server inbox delivery and ACK-through cursor semantics on inbox `id`
- add `InboxDeliveryCoordinator` to own per-chat delivery ledger, ACK commit/failure, dedup, recovery debt, and work-change projection
- shrink `SessionManager` to lifecycle/scheduling/projection and migrate Codex/Claude handlers to turn lifecycle APIs

## Tests
- `pnpm --filter @first-tree/client typecheck`
- `pnpm --filter @first-tree/server typecheck`
- `pnpm --filter @first-tree/client exec vitest run --passWithNoTests`
- `pnpm --filter @first-tree/client exec vitest run --passWithNoTests src/__tests__/session-start-error-signaling.test.ts src/__tests__/session-manager.test.ts src/__tests__/session-runtime-state.test.ts src/__tests__/session-manager-edge-coverage.test.ts`
- `pnpm --filter @first-tree/server exec vitest run src/__tests__/inbox-ws-push.test.ts src/__tests__/ws-inbox-delivery-order.test.ts src/__tests__/inbox-bind-recovery.test.ts`
- `git diff --check`
