### PR TITLE
feat: degraded workspace start on unreachable repos

### DIFF
--- a/packages/client/src/__tests__/agent-briefing.test.ts
+++ b/packages/client/src/__tests__/agent-briefing.test.ts
@@ -801,6 +801,152 @@ describe("buildAgentBriefing — # Context Tree", () => {
   });
 });
 
+describe("buildAgentBriefing — degraded workspace warnings (repoHealth / treeHealth)", () => {
+  // These blocks carry model behavior guardrails ("Not guess or fabricate",
+  // "WITHOUT organizational context", the no-self-serve-credentials rule) —
+  // pin their rendering so the contract text cannot drift unchecked
+  // (degraded-workspace design §4.3).
+
+  it("renders the degraded source repos block: unreachable + stale flavors, ok entries filtered, behavioral constraints pinned", () => {
+    const briefing = buildAgentBriefing(
+      makeOpts({
+        sourceRepos: [
+          {
+            absolutePath: `${AGENT_HOME}/api`,
+            url: "git@github.com:example/api.git",
+          },
+        ],
+        repoHealth: [
+          { url: "git@github.com:example/api.git", status: "ok" },
+          {
+            url: "git@github.com:example/private.git",
+            status: "unreachable",
+            reasonCode: "git_repo_not_found",
+          },
+          {
+            url: "git@github.com:example/web.git",
+            localPath: "web",
+            status: "stale",
+            reasonCode: "git_clone_auth_failed",
+            headCommit: "0123456789abcdef0123456789abcdef01234567",
+          },
+        ],
+      }),
+    );
+
+    expect(briefing).toContain("### ⚠️ DEGRADED: unavailable source repositories");
+    expect(briefing).toContain("**partial workspace**");
+
+    // Unreachable flavor: not on disk, cause line from the reason taxonomy.
+    expect(briefing).toContain("- `git@github.com:example/private.git` — **NOT available on disk** (clone skipped).");
+    expect(briefing).toContain("repository not found (404)");
+
+    // Stale flavor: localPath preferred over url, frozen HEAD truncated to 12.
+    expect(briefing).toContain("- `web` — present but **FROZEN** at its last synced commit (`0123456789ab`)");
+    expect(briefing).toContain("it is NOT being updated");
+    expect(briefing).toContain("git authentication failed");
+
+    // `ok` entries never render a degraded line (the block lists only the
+    // filtered subset; the healthy repo still appears in ## Source
+    // Repositories above).
+    expect(briefing).toContain("## Source Repositories");
+    expect(briefing).not.toContain("- `git@github.com:example/api.git` —");
+
+    // The behavioral constraints are the actual payload of the block.
+    expect(briefing).toContain("**Not guess or fabricate**");
+    expect(briefing).toContain("**Tell the human about the gap**");
+    expect(briefing).toContain("**Not attempt to obtain or configure git credentials yourself**");
+    // Self-heal contract: re-checked per session, no agent action needed.
+    expect(briefing).toContain("re-checks at every session start");
+  });
+
+  it("emits the degraded block even when EVERY repo was skipped and sourceRepos is empty (git/gh-not-installed case)", () => {
+    const briefing = buildAgentBriefing(
+      makeOpts({
+        sourceRepos: [],
+        repoHealth: [
+          {
+            url: "git@github.com:example/api.git",
+            status: "unreachable",
+            reasonCode: "git_not_installed",
+          },
+        ],
+      }),
+    );
+
+    // No healthy repo list — but the warning must still appear where the
+    // list would have been.
+    expect(briefing).not.toContain("## Source Repositories");
+    expect(briefing).toContain("### ⚠️ DEGRADED: unavailable source repositories");
+    expect(briefing).toContain("git is not installed");
+  });
+
+  it("omits the degraded block when health is untracked or all-ok (legacy rendering)", () => {
+    // Untracked (repoHealth omitted) — callers that don't track health get
+    // the legacy rendering.
+    expect(buildAgentBriefing(makeOpts())).not.toContain("DEGRADED: unavailable source repositories");
+
+    // Tracked and healthy.
+    const briefing = buildAgentBriefing(
+      makeOpts({
+        repoHealth: [{ url: "git@github.com:example/api.git", status: "ok" }],
+      }),
+    );
+    expect(briefing).not.toContain("DEGRADED: unavailable source repositories");
+  });
+
+  it("appends the FROZEN staleness note to Tree Location when the bound tree checkout is stale", () => {
+    const treePath = "/var/lib/context-trees/example";
+    const briefing = buildAgentBriefing(
+      makeOpts({
+        contextTreePath: treePath,
+        treeHealth: { status: "stale", reasonCode: "git_clone_auth_failed" },
+      }),
+    );
+
+    // The tree is still on disk and still pointed at.
+    expect(briefing).toContain("## Tree Location");
+    expect(briefing).toContain(treePath);
+    // …but flagged frozen: content is possibly outdated, no self-serve
+    // credential fixing, clears automatically on repair.
+    expect(briefing).toContain("**The tree checkout is currently FROZEN**");
+    expect(briefing).toContain("possibly outdated");
+    expect(briefing).toContain("Do not attempt to fix git credentials");
+
+    // A healthy tree must NOT carry the note.
+    const healthy = buildAgentBriefing(makeOpts({ contextTreePath: treePath, treeHealth: { status: "ok" } }));
+    expect(healthy).not.toContain("FROZEN");
+  });
+
+  it("renders the bound-but-unreachable Tree Location variant — distinct from the neutral tree-less stub", () => {
+    const briefing = buildAgentBriefing(
+      makeOpts({
+        contextTreePath: null,
+        treeHealth: { status: "unreachable", reasonCode: "git_repo_not_found" },
+      }),
+    );
+
+    // The org HAS organizational context; this machine just cannot fetch
+    // it — the agent must be told it is flying blind, not that no tree
+    // exists (design §4.3).
+    expect(briefing).toContain("## Tree Location");
+    expect(briefing).toMatch(
+      /this organization HAS a Context Tree, but this machine[\s\n]+cannot reach its repository/,
+    );
+    expect(briefing).toContain("WITHOUT organizational context");
+    expect(briefing).toContain("confirm background and");
+    expect(briefing).toContain("Do not attempt to obtain or configure git credentials yourself");
+    expect(briefing).toContain("retries at every session start");
+    // The neutral tree-less stub must NOT appear.
+    expect(briefing).not.toContain("This agent has no Context Tree bound");
+
+    // `unbound` (org genuinely has no tree) keeps the neutral stub.
+    const unbound = buildAgentBriefing(makeOpts({ contextTreePath: null, treeHealth: { status: "unbound" } }));
+    expect(unbound).toContain("This agent has no Context Tree bound");
+    expect(unbound).not.toContain("HAS a Context Tree");
+  });
+});
+
 describe("buildAgentBriefing — # Skills (Skill Map)", () => {
   it("lists only the shipped First Tree family skills — drift detector against the on-disk skills/ directory", () => {
     // Compute repo root from the test file location, then enumerate

--- a/packages/client/src/__tests__/agent-slot.test.ts
+++ b/packages/client/src/__tests__/agent-slot.test.ts
@@ -143,7 +143,7 @@ function installMocks(options: { syncResult?: MockState["syncResult"]; syncDelay
     createLogger: () => state.logger,
   }));
   vi.doMock("../runtime/bootstrap.js", () => ({
-    syncAgentContextTree: vi.fn(async (sdk: unknown, log: (msg: string) => void) => {
+    syncAgentContextTreeWithHealth: vi.fn(async (sdk: unknown, log: (msg: string) => void) => {
       const messages: string[] = [];
       log("sync log");
       messages.push("sync log");
@@ -151,7 +151,12 @@ function installMocks(options: { syncResult?: MockState["syncResult"]; syncDelay
       if (options.syncDelayMs && options.syncDelayMs > 0) {
         await new Promise((resolve) => setTimeout(resolve, options.syncDelayMs));
       }
-      return state.syncResult;
+      return {
+        binding: state.syncResult,
+        health: state.syncResult
+          ? { status: "ok", repoUrl: state.syncResult.repoUrl, branch: state.syncResult.branch }
+          : null,
+      };
     }),
   }));
   vi.doMock("../runtime/session-manager.js", () => ({

--- a/packages/client/src/__tests__/bootstrap-context-sync.test.ts
+++ b/packages/client/src/__tests__/bootstrap-context-sync.test.ts
@@ -136,14 +136,21 @@ function installContextSyncMocks(overrides: Partial<MockState> = {}): MockState 
   vi.doMock("@first-tree/shared/config", () => ({
     defaultDataDir: () => "/tmp/first-tree-data",
   }));
-  vi.doMock("../runtime/git-mirror-manager.js", () => ({
-    httpsToSshBaseRewrite: vi.fn((url: string) => {
-      if (!url.startsWith("https://github.com/")) return null;
-      return state.rewriteMismatch
-        ? { httpsBase: "https://gitlab.com/", sshBase: "git@gitlab.com:" }
-        : { httpsBase: "https://github.com/", sshBase: "git@github.com:" };
-    }),
-  }));
+  // Spread the real module so bootstrap's permission-shape classifier helpers
+  // (`isLikelyRepoNotFound` / `isLikely*AuthFailure`) keep their production
+  // behavior — only the SSH-rewrite table is stubbed for URL control.
+  vi.doMock("../runtime/git-mirror-manager.js", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("../runtime/git-mirror-manager.js")>();
+    return {
+      ...actual,
+      httpsToSshBaseRewrite: vi.fn((url: string) => {
+        if (!url.startsWith("https://github.com/")) return null;
+        return state.rewriteMismatch
+          ? { httpsBase: "https://gitlab.com/", sshBase: "git@gitlab.com:" }
+          : { httpsBase: "https://github.com/", sshBase: "git@github.com:" };
+      }),
+    };
+  });
   vi.doMock("../sdk.js", () => ({
     FirstTreeHubSDK: class {
       serverUrl: string;

--- a/packages/client/src/__tests__/bootstrap.test.ts
+++ b/packages/client/src/__tests__/bootstrap.test.ts
@@ -18,6 +18,7 @@ import {
   bootstrapWorkspace,
   CONTEXT_TREE_HEAD_REL,
   type ContextTreeBinding,
+  type ContextTreeSyncResult,
   deepEqualIdentity,
   FIRST_TREE_RUNTIME_DIR,
   IDENTITY_JSON_REL,
@@ -95,10 +96,10 @@ describe("withContextTreeSyncLock", () => {
     // share that pair (the common case — one Context Tree per org), all N
     // must share one in-flight sync instead of queuing N sequential pulls.
     let invocations = 0;
-    let resolveSync: ((value: ContextTreeBinding) => void) | undefined;
-    const fn = (): Promise<ContextTreeBinding | null> => {
+    let resolveSync: ((value: ContextTreeSyncResult) => void) | undefined;
+    const fn = (): Promise<ContextTreeSyncResult> => {
       invocations++;
-      return new Promise<ContextTreeBinding>((resolve) => {
+      return new Promise<ContextTreeSyncResult>((resolve) => {
         resolveSync = resolve;
       });
     };
@@ -113,17 +114,21 @@ describe("withContextTreeSyncLock", () => {
     expect(p2).toBe(p3);
 
     const binding: ContextTreeBinding = { path: key, repoUrl: "git@example/x", branch: "main" };
-    resolveSync?.(binding);
-    await expect(p1).resolves.toBe(binding);
-    await expect(p2).resolves.toBe(binding);
-    await expect(p3).resolves.toBe(binding);
+    const result: ContextTreeSyncResult = {
+      binding,
+      health: { status: "ok", repoUrl: binding.repoUrl, branch: binding.branch },
+    };
+    resolveSync?.(result);
+    await expect(p1).resolves.toBe(result);
+    await expect(p2).resolves.toBe(result);
+    await expect(p3).resolves.toBe(result);
   });
 
   it("isolates locks across distinct keys (different repos sync in parallel)", async () => {
     let invocations = 0;
-    const fn = (): Promise<ContextTreeBinding | null> => {
+    const fn = (): Promise<ContextTreeSyncResult> => {
       invocations++;
-      return Promise.resolve(null);
+      return Promise.resolve({ binding: null, health: null });
     };
 
     await Promise.all([withContextTreeSyncLock("/tmp/clone-A", fn), withContextTreeSyncLock("/tmp/clone-B", fn)]);
@@ -133,9 +138,9 @@ describe("withContextTreeSyncLock", () => {
 
   it("clears the slot after settle so a later call triggers a fresh sync", async () => {
     let invocations = 0;
-    const fn = (): Promise<ContextTreeBinding | null> => {
+    const fn = (): Promise<ContextTreeSyncResult> => {
       invocations++;
-      return Promise.resolve(null);
+      return Promise.resolve({ binding: null, health: null });
     };
 
     await withContextTreeSyncLock("/tmp/clone-C", fn);
@@ -147,16 +152,16 @@ describe("withContextTreeSyncLock", () => {
   it("propagates rejection to all concurrent callers and clears the slot", async () => {
     let invocations = 0;
     let rejectSync: ((reason: Error) => void) | undefined;
-    const fn = (): Promise<ContextTreeBinding | null> => {
+    const fn = (): Promise<ContextTreeSyncResult> => {
       invocations++;
       if (invocations === 1) {
-        return new Promise<ContextTreeBinding>((_, reject) => {
+        return new Promise<ContextTreeSyncResult>((_, reject) => {
           rejectSync = reject;
         });
       }
       // Later retries succeed immediately so the test can observe that the
       // slot was cleared without hanging on a second pending promise.
-      return Promise.resolve(null);
+      return Promise.resolve({ binding: null, health: null });
     };
 
     const key = "/tmp/clone-D";
@@ -173,7 +178,7 @@ describe("withContextTreeSyncLock", () => {
     // After the failed sync clears the slot, a new caller is allowed to
     // retry — important so the next agent's bind isn't poisoned by an
     // earlier transient network failure.
-    await expect(withContextTreeSyncLock(key, fn)).resolves.toBeNull();
+    await expect(withContextTreeSyncLock(key, fn)).resolves.toEqual({ binding: null, health: null });
     expect(invocations).toBe(2);
   });
 });

--- a/packages/client/src/__tests__/git-mirror-manager.test.ts
+++ b/packages/client/src/__tests__/git-mirror-manager.test.ts
@@ -606,6 +606,9 @@ describe("GitMirrorManager — transient network error heuristic (isLikelyTransi
     "fatal: unable to access 'https://github.com/foo/bar/': OpenSSL SSL_read: SSL_ERROR_SYSCALL, errno 54",
     "fatal: unable to access 'https://github.com/x/y/': Recv failure: Connection reset by peer",
     "fatal: unable to access 'https://github.com/x/y/': Failed to connect to 127.0.0.1 port 6152: Connection refused",
+    // curl 56 when a local proxy (Surge / Clash) tears down the CONNECT
+    // tunnel — same bounce class as the localhost Connection-refused case.
+    "fatal: unable to access 'https://github.com/x/y/': Proxy CONNECT aborted",
     "fatal: unable to access 'https://github.com/x/y/': Operation timed out after 30000 milliseconds",
     "fatal: unable to access 'https://github.com/x/y/': Could not resolve host: github.com",
     "ssh: Could not resolve hostname github.com: Temporary failure in name resolution",

--- a/packages/client/src/__tests__/session-manager.test.ts
+++ b/packages/client/src/__tests__/session-manager.test.ts
@@ -2,7 +2,7 @@ import type { AgentRuntimeConfig } from "@first-tree/shared";
 import type pino from "pino";
 import { describe, expect, it, vi } from "vitest";
 import type { AgentConfigCache } from "../runtime/agent-config-cache.js";
-import type { ContextTreeBinding } from "../runtime/bootstrap.js";
+import type { ContextTreeBinding, ContextTreeSyncResult } from "../runtime/bootstrap.js";
 import type { AgentHandler, HandlerConfig, HandlerFactory, SessionContext } from "../runtime/handler.js";
 import { SessionManager } from "../runtime/session-manager.js";
 import type { FirstTreeHubSDK } from "../sdk.js";
@@ -48,7 +48,7 @@ function createSessionManager(opts: {
   handler?: AgentHandler;
   handlerConfig?: HandlerConfig;
   handlerFactory?: HandlerFactory;
-  resolveContextTreeBinding?: () => Promise<ContextTreeBinding | null>;
+  resolveContextTreeBinding?: () => Promise<ContextTreeSyncResult>;
   ackEntry?: (entryId: number) => Promise<void>;
   session?: {
     idle_timeout: number;
@@ -77,7 +77,7 @@ function createSessionManager(opts: {
     handlerConfig: opts.handlerConfig ?? { workspaceRoot: "/tmp/test" },
     // Tests never want the live git-backed resolver — default to a no-op so a
     // tree-less handlerConfig stays tree-less unless a test opts in.
-    resolveContextTreeBinding: opts.resolveContextTreeBinding ?? (async () => null),
+    resolveContextTreeBinding: opts.resolveContextTreeBinding ?? (async () => ({ binding: null, health: null })),
     agentIdentity: {
       agentId: "agent-1",
       inboxId: "inbox-agent-1",
@@ -1209,6 +1209,10 @@ describe("SessionManager lazy Context Tree binding", () => {
     repoUrl: "https://github.com/acme/context-tree",
     branch: "main",
   };
+  const BINDING_RESULT: ContextTreeSyncResult = {
+    binding: BINDING,
+    health: { status: "ok", repoUrl: BINDING.repoUrl, branch: BINDING.branch },
+  };
 
   it("upgrades a tree-less handler config to tree-bound on a new session", async () => {
     const handlerConfig: HandlerConfig = { workspaceRoot: "/tmp/test" };
@@ -1219,7 +1223,7 @@ describe("SessionManager lazy Context Tree binding", () => {
         builtWith = cfg;
         return createMockHandler();
       },
-      resolveContextTreeBinding: async () => BINDING,
+      resolveContextTreeBinding: async () => BINDING_RESULT,
     });
 
     await sm.dispatch(mockEntry({ id: 1, chatId: "c-bind", messageId: "m1" }));
@@ -1235,7 +1239,7 @@ describe("SessionManager lazy Context Tree binding", () => {
   });
 
   it("does not re-resolve when already bound (steady state pays nothing)", async () => {
-    const resolve = vi.fn(async () => BINDING);
+    const resolve = vi.fn(async () => BINDING_RESULT);
     const handlerConfig: HandlerConfig = { workspaceRoot: "/tmp/test", contextTreePath: "/already/bound" };
     const sm = createSessionManager({ handlerConfig, resolveContextTreeBinding: resolve });
 
@@ -1248,7 +1252,7 @@ describe("SessionManager lazy Context Tree binding", () => {
   });
 
   it("re-resolves once for the new session, not again for a same-chat inject", async () => {
-    const resolve = vi.fn(async () => null);
+    const resolve = vi.fn(async (): Promise<ContextTreeSyncResult> => ({ binding: null, health: null }));
     const handlerConfig: HandlerConfig = { workspaceRoot: "/tmp/test" };
     const sm = createSessionManager({ handlerConfig, resolveContextTreeBinding: resolve });
 

--- a/packages/client/src/client-connection.ts
+++ b/packages/client/src/client-connection.ts
@@ -22,6 +22,7 @@ import {
   type SessionState,
   serverWelcomeFrameSchema,
   type UpdateAttempt,
+  type WorkspaceHealthMessage,
 } from "@first-tree/shared";
 import WebSocket from "ws";
 import { createLogger, type pino } from "./observability/logger.js";
@@ -873,6 +874,18 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
   reportRuntimeState(agentId: string, runtimeState: RuntimeState): void {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
     this.ws.send(JSON.stringify({ type: "runtime:state", agentId, runtimeState }));
+  }
+
+  /**
+   * Report the agent's workspace health (degraded-workspace startup): the
+   * tree-side verdict plus per-repo verdicts from the latest source-repo
+   * materialisation. Latest-wins on the server (`agent_presence.workspace_health`);
+   * fire-and-forget like the other report* frames — a dropped frame is
+   * re-sent naturally at the next session start.
+   */
+  reportWorkspaceHealth(agentId: string, health: WorkspaceHealthMessage): void {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+    this.ws.send(JSON.stringify({ type: "workspace:health", agentId, ...health }));
   }
 
   /**

--- a/packages/client/src/handlers/claude-code-tui/index.ts
+++ b/packages/client/src/handlers/claude-code-tui/index.ts
@@ -1,7 +1,12 @@
 import { randomUUID } from "node:crypto";
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { type AgentRuntimeConfigPayload, DEFAULT_CLAUDE_CODE_TUI_RUNTIME_CONFIG_PAYLOAD } from "@first-tree/shared";
+import {
+  type AgentRuntimeConfigPayload,
+  DEFAULT_CLAUDE_CODE_TUI_RUNTIME_CONFIG_PAYLOAD,
+  type WorkspaceRepoHealth,
+  type WorkspaceTreeHealth,
+} from "@first-tree/shared";
 import { ensureAgentBootstrap } from "../../runtime/agent-bootstrap.js";
 import { buildAgentBriefing } from "../../runtime/agent-briefing.js";
 import type { AgentConfigCache } from "../../runtime/agent-config-cache.js";
@@ -86,6 +91,10 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
   const contextTreePath = (config.contextTreePath as string | undefined) ?? null;
   const contextTreeRepoUrl = (config.contextTreeRepoUrl as string | undefined) ?? null;
   const contextTreeBranch = (config.contextTreeBranch as string | undefined) ?? null;
+  // Tree-side workspace health from the slot's Context Tree sync (degraded-
+  // workspace startup). Drives the briefing's bound-but-unreachable / frozen
+  // tree variants and the tree row of the `workspace:health` report.
+  const contextTreeHealth = (config.contextTreeHealth as WorkspaceTreeHealth | null | undefined) ?? null;
   const agentName = (config.agentName as string | undefined) ?? null;
   // Identifies this client process; scopes tmux session ownership so the orphan
   // sweep and session names never collide with another live client / QA slot
@@ -117,6 +126,12 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
   // contents in memory), so we snapshot once per startClaude().
   let chatContextForPrompt: ChatContext | undefined;
   let sourceReposForPrompt: PredeclaredSourceRepo[] = [];
+  /**
+   * Per-repo workspace-health entries from the latest `prepareSourceRepos`
+   * run (healthy repos included). Consumed by the post-bootstrap
+   * `workspace:health` report and the briefing's degraded-workspace warning.
+   */
+  let repoHealthForReport: WorkspaceRepoHealth[] = [];
 
   function buildEnv(sessionCtx: SessionContext, payload: AgentRuntimeConfigPayload): Record<string, string> {
     const env: Record<string, string> = {};
@@ -147,6 +162,8 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
       workspacePath: workspaceCwd,
       sourceRepos: sourceReposForPrompt,
       contextTreePath,
+      repoHealth: repoHealthForReport,
+      treeHealth: contextTreeHealth,
     });
   }
 
@@ -547,7 +564,7 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
         // shared `ensureAgentBootstrap` materialises is fully populated; claude
         // then reads CLAUDE.md once on spawn via `--setting-sources project`.
         chatContextForPrompt = await fetchChatContextOrLog(sessionCtx);
-        sourceReposForPrompt = await prepareSourceRepos({
+        const preparedStart = await prepareSourceRepos({
           workspace: cwd,
           payload,
           sessionCtx,
@@ -558,6 +575,14 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
           // cleanup is suppressed for this session (see PR #869 P0-2).
           payloadResolved: resolvedPayload !== null && resolvedPayload !== undefined,
         });
+        sourceReposForPrompt = preparedStart.sourceRepos;
+        repoHealthForReport = preparedStart.repoHealth;
+        // Report workspace health only when the repo set is authoritative —
+        // a defaultPayload() fallback yields an empty repoHealth that would
+        // overwrite a real degraded report with a false green.
+        if (resolvedPayload !== null && resolvedPayload !== undefined) {
+          sessionCtx.reportRepoHealth?.(preparedStart.repoHealth);
+        }
         ensureAgentBootstrap({
           workspace: cwd,
           sessionCtx,
@@ -602,7 +627,7 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
         const payload = resumePayloadResolved ?? defaultPayload();
 
         chatContextForPrompt = await fetchChatContextOrLog(sessionCtx);
-        sourceReposForPrompt = await prepareSourceRepos({
+        const preparedResume = await prepareSourceRepos({
           workspace: cwd,
           payload,
           sessionCtx,
@@ -611,6 +636,12 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
           // See PR #869 P0-2: same gate as the start() path.
           payloadResolved: resumePayloadResolved !== null && resumePayloadResolved !== undefined,
         });
+        sourceReposForPrompt = preparedResume.sourceRepos;
+        repoHealthForReport = preparedResume.repoHealth;
+        // Same authoritative-only gate as the start() path.
+        if (resumePayloadResolved !== null && resumePayloadResolved !== undefined) {
+          sessionCtx.reportRepoHealth?.(preparedResume.repoHealth);
+        }
         // Same shared bootstrap as start(): ensureAgentBootstrap handles the
         // sentinel + Context-Tree/CLI drift internally, so a stale or failed
         // integration is re-run on resume instead of being skipped.

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -11,7 +11,14 @@ import type {
   SDKUserMessage,
 } from "@anthropic-ai/claude-agent-sdk";
 import { query as claudeQuery } from "@anthropic-ai/claude-agent-sdk";
-import type { AgentRuntimeConfigPayload, SessionEvent, SupportedImageMime, ToolFileRef } from "@first-tree/shared";
+import type {
+  AgentRuntimeConfigPayload,
+  SessionEvent,
+  SupportedImageMime,
+  ToolFileRef,
+  WorkspaceRepoHealth,
+  WorkspaceTreeHealth,
+} from "@first-tree/shared";
 import {
   isImageBatchRefContent,
   isImageRefContent,
@@ -699,6 +706,12 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
    * — those are runtime-opaque (created by the agent, not by First Tree).
    */
   let sourceReposForPrompt: PredeclaredSourceRepo[] = [];
+  /**
+   * Per-repo workspace-health entries from the latest `prepareSourceRepos`
+   * run (healthy repos included). Consumed by the post-bootstrap
+   * `workspace:health` report and the briefing's degraded-workspace warning.
+   */
+  let repoHealthForReport: WorkspaceRepoHealth[] = [];
   /**
    * The most recently pushed SDK user message, kept around as the replay
    * payload for the transient stream-API retry path. Stashed at every
@@ -1445,6 +1458,10 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
   const contextTreePath = (config.contextTreePath as string | undefined) ?? null;
   const contextTreeRepoUrl = (config.contextTreeRepoUrl as string | undefined) ?? null;
   const contextTreeBranch = (config.contextTreeBranch as string | undefined) ?? null;
+  // Tree-side workspace health from the slot's Context Tree sync (degraded-
+  // workspace startup). Drives the briefing's bound-but-unreachable / frozen
+  // tree variants and the tree row of the `workspace:health` report.
+  const contextTreeHealth = (config.contextTreeHealth as WorkspaceTreeHealth | null | undefined) ?? null;
   // `agentName` is the operator-chosen stable identifier (`config.yaml`'s
   // `agents.<name>` key). Carried through to the per-session bootstrap so a
   // single agent's multi-chat workspaces share the same workspace identity
@@ -1471,10 +1488,14 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
    *
    * Side effect: refreshes `sourceReposForPrompt` so the unified briefing
    * builder (`runtime/agent-briefing.ts` → `## Source Repositories`) can
-   * list absolute paths + upstream coordinates for the LLM.
+   * list absolute paths + upstream coordinates for the LLM, and
+   * `repoHealthForReport` for the `workspace:health` report.
    *
-   * Fail-fast semantics per PRD D10/D13/D14: any failure aborts the session
-   * and the error bubbles up to the caller (SessionManager).
+   * Fail-fast semantics per PRD D10/D13/D14, with the degraded-workspace
+   * exception: permission-shaped failures degrade per repo
+   * (`skipped-unreachable` / `stale-unreachable`, see source-repos.ts)
+   * instead of aborting; every other failure still bubbles up to the caller
+   * (SessionManager).
    */
   async function prepareSourceRepos(
     workspace: string,
@@ -1490,7 +1511,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
     // Without this gate, a cache miss would compute an empty current-repo
     // set and the state-reconcile path would `rm` every previously-managed
     // clone. See `PrepareSourceReposParams.payloadResolved`.
-    sourceReposForPrompt = await prepareSourceReposShared({
+    const prepared = await prepareSourceReposShared({
       workspace,
       payload,
       sessionCtx,
@@ -1498,6 +1519,12 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       agentName,
       payloadResolved: payload !== undefined,
     });
+    sourceReposForPrompt = prepared.sourceRepos;
+    repoHealthForReport = prepared.repoHealth;
+    // Report workspace health only when the repo set is authoritative — an
+    // unresolved payload (config cache miss) yields an empty repoHealth that
+    // would overwrite a real degraded report with a false green.
+    if (payload !== undefined) sessionCtx.reportRepoHealth?.(prepared.repoHealth);
   }
 
   /** Tear down all worktrees this session owns; best-effort. */
@@ -1589,6 +1616,8 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       workspacePath: workspace,
       sourceRepos: sourceReposForPrompt,
       contextTreePath,
+      repoHealth: repoHealthForReport,
+      treeHealth: contextTreeHealth,
     });
   }
 

--- a/packages/client/src/handlers/codex.ts
+++ b/packages/client/src/handlers/codex.ts
@@ -4,6 +4,8 @@ import {
   deriveRepoLocalPath,
   type SessionEvent,
   type ToolFileRef,
+  type WorkspaceRepoHealth,
+  type WorkspaceTreeHealth,
 } from "@first-tree/shared";
 import { Codex, type Input, type Thread, type ThreadItem, type ThreadOptions, type Usage } from "@openai/codex-sdk";
 import { ensureAgentBootstrap as ensureAgentBootstrapShared } from "../runtime/agent-bootstrap.js";
@@ -448,6 +450,10 @@ export const createCodexHandler: HandlerFactory = (config) => {
   const contextTreePath = (config.contextTreePath as string | undefined) ?? null;
   const contextTreeRepoUrl = (config.contextTreeRepoUrl as string | undefined) ?? null;
   const contextTreeBranch = (config.contextTreeBranch as string | undefined) ?? null;
+  // Tree-side workspace health from the slot's Context Tree sync (degraded-
+  // workspace startup). Drives the briefing's bound-but-unreachable / frozen
+  // tree variants and the tree row of the `workspace:health` report.
+  const contextTreeHealth = (config.contextTreeHealth as WorkspaceTreeHealth | null | undefined) ?? null;
   const agentName = (config.agentName as string | undefined) ?? null;
 
   let cwd: string | null = null;
@@ -480,6 +486,12 @@ export const createCodexHandler: HandlerFactory = (config) => {
    * in the per-session AGENTS.md so the LLM knows the absolute paths.
    */
   let sourceReposForPrompt: PredeclaredSourceRepo[] = [];
+  /**
+   * Per-repo workspace-health entries from the latest `prepareSourceRepos`
+   * run (healthy repos included). Consumed by the post-bootstrap
+   * `workspace:health` report and the briefing's degraded-workspace warning.
+   */
+  let repoHealthForReport: WorkspaceRepoHealth[] = [];
 
   function buildEnv(sessionCtx: SessionContext): Record<string, string> {
     // Footgun F1: when `CodexOptions.env` is provided the SDK does NOT
@@ -540,6 +552,8 @@ export const createCodexHandler: HandlerFactory = (config) => {
       workspacePath: workspaceCwd,
       sourceRepos: sourceReposForPrompt,
       contextTreePath,
+      repoHealth: repoHealthForReport,
+      treeHealth: contextTreeHealth,
     });
   }
 
@@ -575,7 +589,7 @@ export const createCodexHandler: HandlerFactory = (config) => {
     // `payloadResolved` is forwarded so the shared helper can decide whether
     // its empty `gitRepos: []` is authoritative — see
     // `PrepareSourceReposParams.payloadResolved` and PR #869 P0-2.
-    sourceReposForPrompt = await prepareSourceReposShared({
+    const prepared = await prepareSourceReposShared({
       workspace: workspaceCwd,
       payload,
       sessionCtx,
@@ -583,6 +597,12 @@ export const createCodexHandler: HandlerFactory = (config) => {
       agentName,
       payloadResolved,
     });
+    sourceReposForPrompt = prepared.sourceRepos;
+    repoHealthForReport = prepared.repoHealth;
+    // Report workspace health only when the repo set is authoritative — an
+    // unresolved payload yields an empty repoHealth that would overwrite a
+    // real degraded report with a false green.
+    if (payloadResolved) sessionCtx.reportRepoHealth?.(prepared.repoHealth);
   }
 
   function emitToolCall(

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -17,12 +17,13 @@ export {
 // Runtime
 export type { AgentSlotConfig } from "./runtime/agent-slot.js";
 export { AgentSlot } from "./runtime/agent-slot.js";
-export type { ContextTreeBinding } from "./runtime/bootstrap.js";
+export type { ContextTreeBinding, ContextTreeSyncResult } from "./runtime/bootstrap.js";
 export {
   contextTreeCloneDir,
   ensureWorkspaceRuntimeDir,
   migrateLegacyRuntimeLayout,
   syncAgentContextTree,
+  syncAgentContextTreeWithHealth,
   syncContextTree,
 } from "./runtime/bootstrap.js";
 // Capabilities

--- a/packages/client/src/runtime/agent-briefing.ts
+++ b/packages/client/src/runtime/agent-briefing.ts
@@ -2,6 +2,9 @@ import {
   AGENT_BRIEFING_GENERATED_MARKER,
   type AgentRuntimeConfigPayload,
   type PromptSection,
+  type WorkspaceHealthReason,
+  type WorkspaceRepoHealth,
+  type WorkspaceTreeHealth,
 } from "@first-tree/shared";
 import type { PredeclaredSourceRepo } from "./bootstrap.js";
 import type { ChatContext } from "./chat-context.js";
@@ -17,6 +20,23 @@ export type BuildAgentBriefingOptions = {
   workspacePath: string;
   sourceRepos: ReadonlyArray<PredeclaredSourceRepo>;
   contextTreePath: string | null;
+  /**
+   * Per-repo workspace-health entries from `prepareSourceRepos` (degraded
+   * startup, design docs/degraded-workspace-design.md §4.3). Entries with
+   * status `unreachable` (skipped, not on disk) or `stale` (frozen checkout)
+   * render a prominent warning block under `## Source Repositories`.
+   * Optional — callers that don't track health omit it and get the legacy
+   * rendering (warnings simply absent).
+   */
+  repoHealth?: ReadonlyArray<WorkspaceRepoHealth>;
+  /**
+   * Tree-side health from the Context Tree sync. Drives the
+   * bound-but-unreachable variant of `## Tree Location` — which MUST read
+   * differently from the neutral tree-less stub, so an agent can tell
+   * "this org has no tree" from "this machine cannot reach the tree".
+   * `null`/`undefined` = unknown or not tracked → legacy rendering.
+   */
+  treeHealth?: WorkspaceTreeHealth | null;
 };
 
 /**
@@ -84,6 +104,7 @@ export function buildAgentBriefing(opts: BuildAgentBriefingOptions): string {
       agentHome: opts.workspacePath,
       sourceRepos: opts.sourceRepos,
       contextTreePath: opts.contextTreePath,
+      repoHealth: opts.repoHealth ?? [],
     }),
   );
 
@@ -102,7 +123,7 @@ export function buildAgentBriefing(opts: BuildAgentBriefingOptions): string {
   const requiredReading = requiredReadingSection(opts.contextTreePath);
   if (requiredReading) sections.push(requiredReading);
 
-  sections.push(contextTreeSection(opts.contextTreePath));
+  sections.push(contextTreeSection(opts.contextTreePath, opts.treeHealth ?? null));
 
   const skillsBlock = skillsSection(opts.workspacePath, opts.payload, opts.contextTreePath);
   if (skillsBlock) sections.push(skillsBlock);
@@ -301,6 +322,7 @@ type WorkingInFirstTreeOpts = {
   agentHome: string;
   sourceRepos: ReadonlyArray<PredeclaredSourceRepo>;
   contextTreePath: string | null;
+  repoHealth: ReadonlyArray<WorkspaceRepoHealth>;
 };
 
 function workingInFirstTreeSection(opts: WorkingInFirstTreeOpts): string {
@@ -336,8 +358,15 @@ You are running inside **First Tree**, a messaging platform for agent teams.
 
   blocks.push(workingDirectoryBlock(opts.agentHome));
 
+  const degradedRepos = opts.repoHealth.filter((entry) => entry.status !== "ok");
   if (opts.sourceRepos.length > 0) {
     blocks.push(sourceRepositoriesBlock(opts.sourceRepos));
+  }
+  // Degraded-repo warning sits right after the repo list (or where the list
+  // would be, when EVERY configured repo got skipped and `sourceRepos` came
+  // back empty — the common "git/gh not installed or logged in" case).
+  if (degradedRepos.length > 0) {
+    blocks.push(degradedSourceReposBlock(degradedRepos));
   }
 
   blocks.push(worktreesBlock(opts.agentHome, opts.sourceRepos));
@@ -385,6 +414,78 @@ function sourceRepositoriesBlock(sourceRepos: ReadonlyArray<PredeclaredSourceRep
     if (repo.branch) coords.push(`branch=${repo.branch}`);
     lines.push(`- \`${repo.absolutePath}\`  (${coords.join(", ")})`);
   }
+  return lines.join("\n");
+}
+
+/**
+ * Human-readable cause line for a permission-shaped degrade. Keep these
+ * descriptions in sync with `workspaceHealthReasonSchema` — every enum
+ * member must have a stable rendering here (the `default` arm is a guard
+ * for forward-compat, not a license to skip new members).
+ */
+function describeWorkspaceHealthReason(reason: WorkspaceHealthReason | undefined): string {
+  switch (reason) {
+    case "git_clone_auth_failed":
+      return "git authentication failed — the credentials on this machine cannot access the repository";
+    case "git_repo_not_found":
+      return "repository not found (404) — this machine's git identity has no permission, or the repo was moved/renamed";
+    case "git_not_installed":
+      return "git is not installed (or not on PATH) on this machine";
+    default:
+      return "permission-shaped git failure";
+  }
+}
+
+/**
+ * Prominent warning block for repos the runtime could not bring up healthy
+ * at session start (degraded-workspace design §4.3). Two flavors:
+ *
+ *  - `unreachable` — clone was skipped entirely; the repo is NOT on disk.
+ *  - `stale` — an existing checkout is being served frozen at its last
+ *    synced commit; it no longer tracks `origin/<default>`.
+ *
+ * The behavioral constraints are the actual payload: an agent on a partial
+ * workspace must not guess repo contents, must surface the gap to humans
+ * when a task touches a missing repo, and must NOT try to self-serve
+ * credentials (that is the human-driven Fix flow's job).
+ */
+function degradedSourceReposBlock(degraded: ReadonlyArray<WorkspaceRepoHealth>): string {
+  const lines: string[] = [
+    "### ⚠️ DEGRADED: unavailable source repositories",
+    "",
+    "This machine's git setup could not reach the following configured",
+    "repositories at session start. The session was started anyway on a",
+    "**partial workspace**:",
+    "",
+  ];
+  for (const entry of degraded) {
+    const cause = describeWorkspaceHealthReason(entry.reasonCode);
+    if (entry.status === "unreachable") {
+      lines.push(`- \`${entry.url}\` — **NOT available on disk** (clone skipped). Cause: ${cause}.`);
+    } else {
+      const where = entry.localPath ? `\`${entry.localPath}\`` : `\`${entry.url}\``;
+      lines.push(
+        `- ${where} — present but **FROZEN** at its last synced commit${
+          entry.headCommit ? ` (\`${entry.headCommit.slice(0, 12)}\`)` : ""
+        }; it is NOT being updated. Cause: ${cause}.`,
+      );
+    }
+  }
+  lines.push(
+    "",
+    "While degraded, you MUST:",
+    "",
+    "- **Not guess or fabricate** the contents of an unavailable repository.",
+    "- **Tell the human about the gap** before proceeding whenever a task",
+    "  involves one of these repositories (frozen checkouts may be out of",
+    "  date; skipped ones are simply absent).",
+    "- **Not attempt to obtain or configure git credentials yourself** —",
+    "  fixing credentials on this machine is a human-driven action.",
+    "",
+    "The runtime re-checks at every session start; once the machine's git",
+    "access is fixed, the repositories materialise automatically and this",
+    "warning disappears.",
+  );
   return lines.join("\n");
 }
 
@@ -642,7 +743,7 @@ workspace ↔ tree binding) runs from the web console or a human terminal
 
 // --- # Context Tree ---------------------------------------------------------
 
-function contextTreeSection(contextTreePath: string | null): string {
+function contextTreeSection(contextTreePath: string | null, treeHealth: WorkspaceTreeHealth | null): string {
   const blocks: string[] = [];
 
   blocks.push(`# Context Tree (First Tree Managed)
@@ -711,13 +812,46 @@ operating guide covers staging, review routing, and ownership rules
 you will not remember by default.`);
 
   if (contextTreePath) {
+    // Bound-and-on-disk. When the latest sync failed permission-shaped, the
+    // checkout is frozen — append a staleness warning so the agent treats
+    // tree content as possibly outdated rather than current truth.
+    const staleNote =
+      treeHealth?.status === "stale"
+        ? `
+
+⚠️ **The tree checkout is currently FROZEN**: the latest sync failed
+(${describeWorkspaceHealthReason(treeHealth.reasonCode)}), so this copy
+no longer updates and may be behind the team's current state. Treat its
+content as possibly outdated; for decisions that depend on very recent
+changes, confirm with a human. Do not attempt to fix git credentials
+yourself — this clears automatically once the machine's git access is
+repaired.`
+        : "";
     blocks.push(`## Tree Location
 
 The Context Tree for this workspace is at:
 
     ${contextTreePath}
 
-Read its root \`NODE.md\` first to map the domains before you act.`);
+Read its root \`NODE.md\` first to map the domains before you act.${staleNote}`);
+  } else if (treeHealth?.status === "unreachable") {
+    // Bound-but-unreachable — MUST read differently from the neutral
+    // tree-less stub below (design §4.3): the org HAS organizational
+    // context; this machine just cannot fetch it.
+    blocks.push(`## Tree Location
+
+⚠️ **DEGRADED: this organization HAS a Context Tree, but this machine
+cannot reach its repository** (${describeWorkspaceHealthReason(treeHealth.reasonCode)}).
+You are running WITHOUT organizational context — decisions, constraints,
+and ownership recorded in the tree are invisible to you right now.
+
+- Before acting on any non-trivial instruction, confirm background and
+  constraints with a human instead of assuming the instruction is fully
+  specified.
+- Do not attempt to obtain or configure git credentials yourself —
+  fixing this machine's git access is a human-driven action.
+- The runtime retries at every session start; once access is repaired
+  the tree loads automatically and this warning disappears.`);
   } else {
     // Tree-less stub. Binding a workspace to a tree is an operator
     // action (web console / human at the terminal), not something an

--- a/packages/client/src/runtime/agent-slot.ts
+++ b/packages/client/src/runtime/agent-slot.ts
@@ -11,7 +11,7 @@ import type { ClientConnection, SessionReconcileResult } from "../client-connect
 import { createLogger, type pino } from "../observability/logger.js";
 import type { RegisterResult } from "../sdk.js";
 import { type AgentConfigCache, createAgentConfigCache } from "./agent-config-cache.js";
-import { syncAgentContextTree } from "./bootstrap.js";
+import { syncAgentContextTreeWithHealth } from "./bootstrap.js";
 import type { SessionConfig } from "./config.js";
 import type { GitMirrorManager } from "./git-mirror-manager.js";
 import type { HandlerFactory } from "./handler.js";
@@ -193,7 +193,8 @@ export class AgentSlot {
       }
 
       this.inboxId = agent.inboxId;
-      const contextTreeBinding = await syncAgentContextTree(sdk, (msg) => this.logger.info(msg));
+      const contextTreeSync = await syncAgentContextTreeWithHealth(sdk, (msg) => this.logger.info(msg));
+      const contextTreeBinding = contextTreeSync.binding;
       if (!contextTreeBinding) {
         this.logger.info(
           "context tree not configured or sync skipped — agent will start without organizational context",
@@ -220,6 +221,11 @@ export class AgentSlot {
           contextTreePath: contextTreeBinding?.path,
           contextTreeRepoUrl: contextTreeBinding?.repoUrl,
           contextTreeBranch: contextTreeBinding?.branch,
+          // Tree-side workspace health (degraded-workspace startup). Read by
+          // handlers for the briefing's degraded-tree variants and by the
+          // SessionManager when composing `workspace:health` frames; refreshed
+          // in place by the lazy tree re-resolution (`ensureContextTreeBinding`).
+          contextTreeHealth: contextTreeSync.health,
           gitMirrorManager,
           // Identifies the owning client process. The claude-code-tui handler
           // uses it to scope tmux session ownership (orphan sweep / names) so
@@ -246,6 +252,7 @@ export class AgentSlot {
         onRuntimeStateChange: (state) => this.reportRuntimeState(state),
         onSessionEvent: (chatId, event) => this.reportSessionEvent(chatId, event),
         onSessionRuntimeChange: (chatId, state) => this.reportSessionRuntime(chatId, state),
+        onWorkspaceHealth: (health) => this.clientConnection.reportWorkspaceHealth(agent.agentId, health),
       });
 
       const onCommand = (cmd: { agentId: string; chatId: string; type: string }) => {
@@ -264,7 +271,7 @@ export class AgentSlot {
       // during init. With the bind-time reset+drain path (see design §4)
       // the server pushes pending entries the instant it processes the
       // `agent:bind` frame, but the surrounding `sdk.register` +
-      // `agentConfigCache.refresh` + `syncAgentContextTree` chain above
+      // `agentConfigCache.refresh` + `syncAgentContextTreeWithHealth` chain above
       // can take anywhere from ~100ms (no Context Tree) to 15s
       // (cold-clone Context Tree). Without this flush every restart with
       // an un-acked in-flight message lost the recovery push and the

--- a/packages/client/src/runtime/bootstrap.ts
+++ b/packages/client/src/runtime/bootstrap.ts
@@ -17,13 +17,20 @@ import {
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
+import type { WorkspaceTreeHealth } from "@first-tree/shared";
 import { defaultDataDir } from "@first-tree/shared/config";
 import type { ContextTreeConfig } from "../sdk.js";
 import { type AccessTokenProvider, FirstTreeHubSDK } from "../sdk.js";
 import { getCliBinding } from "./cli-binding.js";
 import { installCoreSkills as installCoreSkillsImpl, installFirstTreeSkills } from "./first-tree-skills/installer.js";
-import { httpsToSshBaseRewrite } from "./git-mirror-manager.js";
+import {
+  httpsToSshBaseRewrite,
+  isLikelyHttpsAuthFailure,
+  isLikelyRepoNotFound,
+  isLikelySshAuthFailure,
+} from "./git-mirror-manager.js";
 import type { AgentIdentity } from "./handler.js";
+import { redactErrorPreview } from "./redact-error-preview.js";
 
 /**
  * Promisified `execFile` used by the Context Tree sync path. The sync path
@@ -61,7 +68,7 @@ function contextTreeReposDir(): string {
   return join(defaultDataDir(), "context-tree-repos");
 }
 
-const contextTreeSyncLocks = new Map<string, Promise<ContextTreeBinding | null>>();
+const contextTreeSyncLocks = new Map<string, Promise<ContextTreeSyncResult>>();
 
 /**
  * Resolved Context Tree binding the runtime threads through every layer:
@@ -74,6 +81,29 @@ export type ContextTreeBinding = {
   path: string;
   repoUrl: string;
   branch: string;
+};
+
+/**
+ * Binding + the workspace-health view of the same sync (degraded-workspace
+ * design). The two move together but answer different questions:
+ *  - `binding` — "is there a local checkout the runtime can serve?" (null =
+ *    tree-less start, exactly the silent degradation that always existed)
+ *  - `health`  — "WHY is the tree in this state?", distinguishing the four
+ *    cases the binding alone collapses: `ok` (synced, or served from an
+ *    existing clone after a transient failure — self-heals next sync),
+ *    `stale` (served from an existing clone after a PERMISSION-shaped
+ *    failure — frozen until host credentials are fixed), `unreachable`
+ *    (bound but no usable local clone), `unbound` (the org has no Context
+ *    Tree configured at all).
+ *
+ * `health: null` = unknown — the agent config could not be fetched, so bound
+ * cannot be told apart from unbound. The reporting layer skips the
+ * `workspace:health` frame entirely in that case rather than overwrite the
+ * last good report with junk (persistence is latest-wins).
+ */
+export type ContextTreeSyncResult = {
+  binding: ContextTreeBinding | null;
+  health: WorkspaceTreeHealth | null;
 };
 
 export function contextTreeCloneDir(repo: string, branch: string): string {
@@ -114,8 +144,8 @@ function toSshGitUrl(httpsRepo: string): string | null {
  */
 export function withContextTreeSyncLock(
   key: string,
-  fn: () => Promise<ContextTreeBinding | null>,
-): Promise<ContextTreeBinding | null> {
+  fn: () => Promise<ContextTreeSyncResult>,
+): Promise<ContextTreeSyncResult> {
   const inFlight = contextTreeSyncLocks.get(key);
   if (inFlight) return inFlight;
   const next = fn().finally(() => {
@@ -130,34 +160,55 @@ export function withContextTreeSyncLock(
 async function resolveContextTreeBinding(
   fetchConfig: () => Promise<ContextTreeConfig>,
   log: (msg: string) => void,
-): Promise<ContextTreeBinding | null> {
-  // 1. Check git is available
-  try {
-    await execFileAsync("git", ["--version"]);
-  } catch {
-    log("Context Tree sync skipped: git is not installed");
-    return null;
-  }
-
-  // 2. Fetch repo config from server
+): Promise<ContextTreeSyncResult> {
+  // 1. Fetch repo config from server. Runs BEFORE the git probe (it needs no
+  //    git) so a host without git can still tell `unbound` (org has no tree)
+  //    apart from `unreachable` (bound but unusable) in the health report.
   let repo: string;
   let branch: string;
   try {
     const config = await fetchConfig();
     if (!config.repo) {
       log("Context Tree sync skipped: not configured on server");
-      return null;
+      return { binding: null, health: { status: "unbound" } };
     }
     repo = config.repo;
     branch = config.branch ?? "main";
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     log(`Context Tree sync skipped: failed to fetch config from server (${msg})`);
-    return null;
+    // Server unreachable — bound vs unbound is unknowable, so health stays
+    // null and the workspace:health frame is skipped (see ContextTreeSyncResult).
+    return { binding: null, health: null };
+  }
+
+  // 2. Check git is available
+  try {
+    await execFileAsync("git", ["--version"]);
+  } catch {
+    log("Context Tree sync skipped: git is not installed");
+    return {
+      binding: null,
+      health: { status: "unreachable", repoUrl: repo, branch, reasonCode: "git_not_installed" },
+    };
   }
 
   const cloneDir = contextTreeCloneDir(repo, branch);
   return withContextTreeSyncLock(cloneDir, () => syncContextTreeRepo(repo, branch, cloneDir, log));
+}
+
+/**
+ * Permission-shaped classification for the Context Tree sync path, which works
+ * on `execFile` error strings rather than `GitMirrorError` instances (the tree
+ * path predates the manager and shells out directly). Same skippable-set
+ * semantics as `classifyPermissionShapedGitError`: 404 first (GitHub serves it
+ * for private repos the identity cannot see), then credential failures on
+ * either transport. Anything else → null (treated as transient / self-healing).
+ */
+function classifyTreeSyncFailure(message: string): "git_clone_auth_failed" | "git_repo_not_found" | null {
+  if (isLikelyRepoNotFound(message)) return "git_repo_not_found";
+  if (isLikelyHttpsAuthFailure(message) || isLikelySshAuthFailure(message)) return "git_clone_auth_failed";
+  return null;
 }
 
 async function syncContextTreeRepo(
@@ -165,7 +216,7 @@ async function syncContextTreeRepo(
   branch: string,
   cloneDir: string,
   log: (msg: string) => void,
-): Promise<ContextTreeBinding | null> {
+): Promise<ContextTreeSyncResult> {
   // 3. Clone or pull
   try {
     if (existsSync(join(cloneDir, ".git"))) {
@@ -198,7 +249,10 @@ async function syncContextTreeRepo(
       });
       log(`Context Tree cloned from ${repo} (branch: ${branch})`);
     }
-    return { path: cloneDir, repoUrl: repo, branch };
+    return {
+      binding: { path: cloneDir, repoUrl: repo, branch },
+      health: { status: "ok", repoUrl: repo, branch },
+    };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     log(`Context Tree sync failed: ${msg}`);
@@ -212,6 +266,11 @@ async function syncContextTreeRepo(
     // Pull failures (existing .git present) skip this — the existing remote
     // is whatever clone last succeeded; switching it mid-flight is messier
     // than letting the "use existing clone" fallback below take over.
+    // Accumulates every failed attempt's message for the health
+    // classification below — an HTTPS auth failure followed by an SSH
+    // `Permission denied (publickey)` should classify on EITHER line.
+    let combinedFailure = msg;
+
     const sshRepo = !existsSync(join(cloneDir, ".git")) ? toSshGitUrl(repo) : null;
     if (sshRepo) {
       log(`Retrying Context Tree clone via SSH: ${sshRepo}`);
@@ -227,10 +286,14 @@ async function syncContextTreeRepo(
         // on this checkout will be the SSH form, and downstream consumers
         // (telemetry, future tree wiring) should match the actual remote
         // rather than the configured-but-unusable HTTPS.
-        return { path: cloneDir, repoUrl: sshRepo, branch };
+        return {
+          binding: { path: cloneDir, repoUrl: sshRepo, branch },
+          health: { status: "ok", repoUrl: sshRepo, branch },
+        };
       } catch (sshErr) {
         const sshMsg = sshErr instanceof Error ? sshErr.message : String(sshErr);
         log(`Context Tree SSH fallback also failed: ${sshMsg}`);
+        combinedFailure = `${combinedFailure}\n${sshMsg}`;
       }
     }
 
@@ -250,7 +313,10 @@ async function syncContextTreeRepo(
           maxBuffer: GIT_CLONE_MAX_BUFFER,
         });
         log("Context Tree re-cloned successfully");
-        return { path: cloneDir, repoUrl: repo, branch };
+        return {
+          binding: { path: cloneDir, repoUrl: repo, branch },
+          health: { status: "ok", repoUrl: repo, branch },
+        };
       } catch {
         log("Context Tree re-clone also failed, continuing without context");
       }
@@ -259,10 +325,41 @@ async function syncContextTreeRepo(
     // Return existing clone path if available (preserves local work on transient errors)
     if (existsSync(join(cloneDir, ".git"))) {
       log("Using existing Context Tree clone despite sync failure");
-      return { path: cloneDir, repoUrl: repo, branch };
+      // Permission-shaped failure → the checkout is frozen until credentials
+      // are fixed: report "stale" so the warning surface lights up. Anything
+      // else (network blip, timeout) self-heals on the next sync, so it
+      // reports "ok" — mirroring the stale-offline → "ok" policy for source
+      // repos: the warning surface is credential-targeted, not a general
+      // connectivity monitor.
+      const reason = classifyTreeSyncFailure(msg);
+      return {
+        binding: { path: cloneDir, repoUrl: repo, branch },
+        health: reason
+          ? {
+              status: "stale",
+              repoUrl: repo,
+              branch,
+              reasonCode: reason,
+              errorPreview: redactErrorPreview(msg),
+            }
+          : { status: "ok", repoUrl: repo, branch },
+      };
     }
 
-    return null;
+    // No clone on disk and every attempt failed — the tree is bound but
+    // unreachable from this host. Classify on the combined failure text so an
+    // HTTPS auth error followed by an SSH publickey error matches on either.
+    const reason = classifyTreeSyncFailure(combinedFailure);
+    return {
+      binding: null,
+      health: {
+        status: "unreachable",
+        repoUrl: repo,
+        branch,
+        ...(reason ? { reasonCode: reason } : {}),
+        errorPreview: redactErrorPreview(combinedFailure),
+      },
+    };
   }
 }
 
@@ -281,7 +378,7 @@ export async function syncContextTree(
   userAgent?: string,
 ): Promise<ContextTreeBinding | null> {
   const sdk = new FirstTreeHubSDK({ serverUrl, getAccessToken, userAgent });
-  return resolveContextTreeBinding(() => sdk.getContextTreeConfig(), log);
+  return (await resolveContextTreeBinding(() => sdk.getContextTreeConfig(), log)).binding;
 }
 
 /**
@@ -295,6 +392,20 @@ export async function syncAgentContextTree(
   sdk: FirstTreeHubSDK,
   log: (msg: string) => void,
 ): Promise<ContextTreeBinding | null> {
+  return (await syncAgentContextTreeWithHealth(sdk, log)).binding;
+}
+
+/**
+ * Same as {@link syncAgentContextTree}, but also surfaces the tree-side
+ * workspace-health verdict (ok / stale / unreachable / unbound, or null when
+ * the server config could not be fetched). Used by the runtime to feed the
+ * `workspace:health` report alongside source-repo health; callers that only
+ * need the binding should keep using `syncAgentContextTree`.
+ */
+export async function syncAgentContextTreeWithHealth(
+  sdk: FirstTreeHubSDK,
+  log: (msg: string) => void,
+): Promise<ContextTreeSyncResult> {
   return resolveContextTreeBinding(() => sdk.getAgentContextTreeConfig(), log);
 }
 

--- a/packages/client/src/runtime/context-tree-rebind.ts
+++ b/packages/client/src/runtime/context-tree-rebind.ts
@@ -1,5 +1,3 @@
-import type { ContextTreeBinding } from "./bootstrap.js";
-
 /**
  * Lazily re-resolve an agent's Context Tree binding when it started its slot
  * tree-LESS.
@@ -19,11 +17,15 @@ import type { ContextTreeBinding } from "./bootstrap.js";
  * Never throws — a failed re-resolution just leaves the session unbound for
  * this turn (the next new session retries). The caller owns applying the
  * returned binding to its (mutable) handler config.
+ *
+ * Generic over the resolver's result so callers can thread richer shapes
+ * (e.g. `ContextTreeSyncResult` = binding + workspace-health verdict) through
+ * the same already-bound short-circuit without this helper knowing about them.
  */
-export async function reresolveUnboundTree(
+export async function reresolveUnboundTree<T>(
   currentPath: unknown,
-  resolve: () => Promise<ContextTreeBinding | null>,
-): Promise<ContextTreeBinding | null> {
+  resolve: () => Promise<T | null>,
+): Promise<T | null> {
   if (typeof currentPath === "string" && currentPath.length > 0) return null;
   try {
     return await resolve();

--- a/packages/client/src/runtime/git-mirror-manager.ts
+++ b/packages/client/src/runtime/git-mirror-manager.ts
@@ -1,8 +1,10 @@
 import { createHash } from "node:crypto";
 import { existsSync, lstatSync, mkdirSync, readdirSync, rmSync, statSync, unlinkSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
+import type { WorkspaceHealthReason } from "@first-tree/shared";
 import type { pino } from "../observability/logger.js";
 import { getChildProcessRegistry } from "./child-process-registry.js";
+import { redactErrorPreview } from "./redact-error-preview.js";
 import { isUnderManagedRoot, killProcessesHoldingPath } from "./worktree-cleanup.js";
 
 const DEFAULT_CLONE_TIMEOUT_MS = 5 * 60 * 1000;
@@ -93,6 +95,18 @@ export type GitMirrorManagerOptions = {
  *                             error on an existing usable checkout — degraded to
  *                             the last-good local source instead of aborting the
  *                             session (see step (4) in `ensureSourceRepo`)
+ *   - `stale-unreachable`     left as-is: fetch failed with a PERMISSION-shaped
+ *                             error (auth rejected on both transports, or 404)
+ *                             on an existing usable checkout. Same freeze
+ *                             contract as `stale-offline`, but it will NOT
+ *                             self-heal — the checkout stays at its last-good
+ *                             commit until credentials are fixed on the host.
+ *                             Carries `degraded` for the workspace-health report.
+ *   - `skipped-unreachable`   no usable local clone AND the clone failed with a
+ *                             permission-shaped error — the repo is skipped
+ *                             entirely (nothing materialised on disk; `cloneRepo`
+ *                             removes any partial clone) so the session can
+ *                             still start degraded. Carries `degraded`.
  */
 export type SourceRepoOutcome =
   | "cloned"
@@ -102,7 +116,20 @@ export type SourceRepoOutcome =
   | "skipped-dirty"
   | "skipped-local-commits"
   | "skipped-in-use"
-  | "stale-offline";
+  | "stale-offline"
+  | "stale-unreachable"
+  | "skipped-unreachable";
+
+/**
+ * Degradation descriptor attached to the `*-unreachable` outcomes and consumed
+ * by the `workspace:health` report (see shared/src/schemas/workspace-health.ts).
+ * `errorPreview` has ALREADY been passed through `redactErrorPreview` — safe
+ * for chat-visible / DB-persisted surfaces.
+ */
+export type SourceRepoDegradedInfo = {
+  reasonCode: WorkspaceHealthReason;
+  errorPreview: string;
+};
 
 export interface GitMirrorManager {
   /**
@@ -122,10 +149,13 @@ export interface GitMirrorManager {
     activelyInUse?: boolean;
   }): Promise<{
     clonePath: string;
-    headCommit: string;
+    /** HEAD of the local checkout. Absent only for `skipped-unreachable` (nothing on disk). */
+    headCommit?: string;
     /** Short name of the checked-out branch, or undefined when detached (pinned SHA). */
     branch?: string;
     outcome: SourceRepoOutcome;
+    /** Present only on the `*-unreachable` outcomes (permission-shaped degradation). */
+    degraded?: SourceRepoDegradedInfo;
   }>;
 
   /** Remove a standalone source-repo clone (best-effort, kills holders first). */
@@ -658,6 +688,27 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
           outcome,
         });
 
+        // Clone, or — when the failure is permission-shaped (host git identity
+        // cannot see the repo) — skip the repo so the session still starts
+        // degraded instead of aborting. `cloneRepo` already guarantees no
+        // half-written clone survives a failure, so a skip leaves nothing on
+        // disk. Every non-permission failure keeps today's fail-loud path.
+        const cloneOrSkip = async (): Promise<SourceRepoDegradedInfo | null> => {
+          try {
+            await cloneRepo(absTarget, url);
+            return null;
+          } catch (err) {
+            const degraded = classifyPermissionShapedGitError(err);
+            if (!degraded) throw err;
+            const stderr = err instanceof Error ? err.message : String(err);
+            log?.warn(
+              { gitUrl: url, clonePath: absTarget, reasonCode: degraded.reasonCode, stderr: stderr.slice(0, 1024) },
+              "source-repo clone failed (permission-shaped) — skipping repo, session starts degraded",
+            );
+            return degraded;
+          }
+        };
+
         // (0) A symlink at the target is never one of our clones — `existsSync`
         // / `statSync` follow links, so without this guard a symlink pointing at
         // some real `.git` dir would be adopted and fetched/`checkout -B`'d
@@ -677,7 +728,10 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
         // replace in place with a standalone clone.
         if (existsSync(absTarget) && isLegacyWorktreeCheckout(absTarget)) {
           await reclaimTarget(absTarget, "legacy shared-mirror worktree");
-          await cloneRepo(absTarget, url);
+          {
+            const degraded = await cloneOrSkip();
+            if (degraded) return { clonePath: absTarget, outcome: "skipped-unreachable", degraded };
+          }
           if (ref) await updateToLatest(absTarget, ref);
           return finish("migrated-recloned");
         }
@@ -689,7 +743,10 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
 
         // (3) Fresh clone.
         if (!existsSync(absTarget)) {
-          await cloneRepo(absTarget, url);
+          {
+            const degraded = await cloneOrSkip();
+            if (degraded) return { clonePath: absTarget, outcome: "skipped-unreachable", degraded };
+          }
           if (ref) await updateToLatest(absTarget, ref);
           return finish("cloned");
         }
@@ -736,20 +793,48 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
           //     closed (we cannot move to it safely without a confirmed fetch).
           // Silently serving a stale checkout otherwise would mask a real,
           // non-self-healing problem.
-          if (isLikelyTransientNetworkError(stderr) && isStandaloneClone(absTarget) && originMatchedBeforeFetch) {
+          // Shared safety gate for both stale degrades (`stale-offline` and
+          // `stale-unreachable` below): returns the frozen HEAD sha when ALL
+          // gates hold, null otherwise (fail closed → fall through to throw).
+          const frozenHeadIfSafe = async (): Promise<string | null> => {
+            if (!isStandaloneClone(absTarget) || !originMatchedBeforeFetch) return null;
             let headSha: string | null = null;
             try {
               headSha = await headCommit(absTarget);
             } catch {
               headSha = null;
             }
-            const refSatisfiedByHead = !ref || (headSha !== null && (await localRefCommit(absTarget, ref)) === headSha);
-            if (headSha !== null && refSatisfiedByHead) {
+            if (headSha === null) return null;
+            const refSatisfiedByHead = !ref || (await localRefCommit(absTarget, ref)) === headSha;
+            return refSatisfiedByHead ? headSha : null;
+          };
+
+          if (isLikelyTransientNetworkError(stderr) && (await frozenHeadIfSafe()) !== null) {
+            log?.warn(
+              { gitUrl: url, clonePath: absTarget, stderr: stderr.slice(0, 1024) },
+              "source-repo fetch failed (transient network) — using existing local checkout, left at current commit (stale)",
+            );
+            return finish("stale-offline");
+          }
+
+          // Degrade-on-permission-shaped-fetch-failure: the host's git identity
+          // cannot see the repo anymore (credentials revoked / expired, or the
+          // repo went private-invisible — GitHub serves 404 for those). Unlike
+          // the transient branch above this will NOT self-heal, so the outcome
+          // is distinct (`stale-unreachable`) and carries `degraded` for the
+          // workspace-health report: the checkout is served frozen at its
+          // last-good commit until credentials are fixed on the host. Same
+          // strict safety gates as `stale-offline`; any gate failing falls
+          // through to the fail-loud throw below (error-taxonomy fallback).
+          const degraded = classifyPermissionShapedGitError(err);
+          if (degraded) {
+            const headSha = await frozenHeadIfSafe();
+            if (headSha !== null) {
               log?.warn(
-                { gitUrl: url, clonePath: absTarget, stderr: stderr.slice(0, 1024) },
-                "source-repo fetch failed (transient network) — using existing local checkout, left at current commit (stale)",
+                { gitUrl: url, clonePath: absTarget, reasonCode: degraded.reasonCode, stderr: stderr.slice(0, 1024) },
+                "source-repo fetch failed (permission-shaped) — serving existing checkout frozen at current commit (stale-unreachable)",
               );
-              return finish("stale-offline");
+              return { ...(await finish("stale-unreachable")), degraded };
             }
           }
 
@@ -994,6 +1079,47 @@ export function isLikelyRepoNotFound(message: string): boolean {
 }
 
 /**
+ * Classify a clone/fetch failure as "permission-shaped" — the host's git
+ * identity cannot see the repo. This is the (deliberately conservative)
+ * skippable set behind the degraded-workspace start: only these two shapes
+ * degrade to `skipped-unreachable` / `stale-unreachable`; every other failure
+ * keeps today's fail-loud behaviour with the error-taxonomy as fallback.
+ *
+ *  - `GitMirrorAuthError` → `git_clone_auth_failed`. Thrown only when BOTH the
+ *    primary protocol and the peer-protocol fallback failed with credential-
+ *    shaped errors — checked FIRST since it extends `GitMirrorError`.
+ *  - plain `GitMirrorError` matching `isLikelyRepoNotFound` →
+ *    `git_repo_not_found`. GitHub deliberately serves 404 for private repos
+ *    the identity cannot see, so "no permission" usually LOOKS like not-found.
+ *    `GitMirrorTimeoutError` is excluded (a timeout is never permission-shaped,
+ *    even if its message happened to quote a 404).
+ *  - spawn-level `ENOENT` (NOT a `GitMirrorError` — the `git` binary itself is
+ *    missing from the host) → `git_not_installed`. The single most common
+ *    all-repos-unreachable cause: a fresh machine where gh/git was never
+ *    installed. Caveat: `spawn` also reports ENOENT for a missing *cwd*, but
+ *    every caller verifies the cwd exists (or passes none) before spawning.
+ *
+ * The returned `errorPreview` is already passed through `redactErrorPreview`
+ * (host-side redaction contract: credentials never reach the DB / console).
+ * Exported for unit testing.
+ */
+export function classifyPermissionShapedGitError(err: unknown): SourceRepoDegradedInfo | null {
+  if (err instanceof GitMirrorAuthError) {
+    return { reasonCode: "git_clone_auth_failed", errorPreview: redactErrorPreview(err.message) };
+  }
+  if (err instanceof GitMirrorError) {
+    if (!(err instanceof GitMirrorTimeoutError) && isLikelyRepoNotFound(err.message)) {
+      return { reasonCode: "git_repo_not_found", errorPreview: redactErrorPreview(err.message) };
+    }
+    return null;
+  }
+  if (err instanceof Error && "code" in err && err.code === "ENOENT") {
+    return { reasonCode: "git_not_installed", errorPreview: redactErrorPreview(err.message) };
+  }
+  return null;
+}
+
+/**
  * Heuristic for "the repository is reachable but the configured branch / tag /
  * commit does not exist on it". Permanent for the same reason as
  * `isLikelyRepoNotFound`: only an operator can fix the ref, retrying churns.
@@ -1112,6 +1238,10 @@ export function isLikelyTransientNetworkError(message: string): boolean {
     // `Couldn't connect to server` — a server unreachable / connect timeout.
     /Failed to connect to\s+\S+\s+port\s+\d+/i.test(message) ||
     /Couldn't connect to server/i.test(message) ||
+    // curl 56 via a local proxy (Surge / Clash): the proxy accepted the
+    // connection but tore down the CONNECT tunnel — same bounce class as
+    // the localhost ECONNREFUSED case above.
+    /Proxy CONNECT aborted/i.test(message) ||
     // HTTP/2 transport framing fault (libcurl `CURLE_HTTP2`) seen as a
     // mid-handshake `Error in the HTTP2 framing layer` against github.com.
     /Error in the HTTP[/]?2 framing layer/i.test(message) ||

--- a/packages/client/src/runtime/handler.ts
+++ b/packages/client/src/runtime/handler.ts
@@ -1,4 +1,4 @@
-import type { AgentVisibility, SessionEvent } from "@first-tree/shared";
+import type { AgentVisibility, SessionEvent, WorkspaceRepoHealth } from "@first-tree/shared";
 import type { FirstTreeHubSDK } from "../sdk.js";
 import type { GitMirrorManager } from "./git-mirror-manager.js";
 
@@ -123,6 +123,17 @@ export type SessionContext = HandlerContext & {
    * to keep `[From: ...]` attribution consistent with the text path.
    */
   resolveSenderLabel: (senderId: string) => Promise<string>;
+
+  /**
+   * Report per-repo workspace health after `prepareSourceRepos` completes
+   * (degraded-workspace startup). Include EVERY configured repo — healthy
+   * ones as `status: "ok"` — so a recovered repo flips the stored report
+   * back to green. The runtime composes the tree half and forwards the
+   * frame to the server (`workspace:health` → `agent_presence`).
+   * Optional so handler tests with minimal contexts don't have to stub it;
+   * call via `sessionCtx.reportRepoHealth?.(...)`.
+   */
+  reportRepoHealth?: (repos: WorkspaceRepoHealth[]) => void;
 };
 
 /** Message content extracted from an inbox entry (no entry metadata). */

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -7,13 +7,20 @@ import type {
   RuntimeState,
   SessionEvent,
   SessionState,
+  WorkspaceHealthMessage,
+  WorkspaceRepoHealth,
 } from "@first-tree/shared";
-import { deriveRepoLocalPath, isImageBatchRefContent, isImageRefContent } from "@first-tree/shared";
+import {
+  deriveRepoLocalPath,
+  isImageBatchRefContent,
+  isImageRefContent,
+  workspaceTreeHealthSchema,
+} from "@first-tree/shared";
 import type { pino } from "../observability/logger.js";
 import type { FirstTreeHubSDK } from "../sdk.js";
 import type { AgentConfigCache } from "./agent-config-cache.js";
 import { buildAgentEnv, createParticipantCache, formatInboundContent, resolveSenderLabel } from "./agent-io.js";
-import { type ContextTreeBinding, syncAgentContextTree } from "./bootstrap.js";
+import { type ContextTreeSyncResult, syncAgentContextTreeWithHealth } from "./bootstrap.js";
 import type { SessionConfig } from "./config.js";
 import { reresolveUnboundTree } from "./context-tree-rebind.js";
 import { Deduplicator } from "./deduplicator.js";
@@ -222,10 +229,20 @@ type SessionManagerConfig = {
    * Resolver for the agent's Context Tree binding, used to lazily upgrade a
    * tree-LESS slot to tree-bound at session start (new-tree onboarding sets the
    * org `context_tree` only after the slot starts). Defaults to a live
-   * `syncAgentContextTree(sdk)`; injected as a stub in tests to avoid spawning
-   * real git.
+   * `syncAgentContextTreeWithHealth(sdk)`; injected as a stub in tests to
+   * avoid spawning real git. The result's `health` half refreshes
+   * `handlerConfig.contextTreeHealth` so the next `workspace:health` frame
+   * carries the freshest tree verdict.
    */
-  resolveContextTreeBinding?: () => Promise<ContextTreeBinding | null>;
+  resolveContextTreeBinding?: () => Promise<ContextTreeSyncResult>;
+  /**
+   * Callback fired when a handler finishes materialising its source repos and
+   * reports per-repo workspace health (degraded-workspace startup). The
+   * SessionManager composes the frame's tree half from
+   * `handlerConfig.contextTreeHealth`; wired by AgentSlot to
+   * `clientConnection.reportWorkspaceHealth`.
+   */
+  onWorkspaceHealth?: (health: WorkspaceHealthMessage) => void;
   /** Callback when a session state changes (per-session granularity). */
   onStateChange?: (chatId: string, state: SessionState) => void;
   /** Callback when aggregated runtime state changes. */
@@ -869,8 +886,16 @@ export class SessionManager {
 
     const resolve =
       this.config.resolveContextTreeBinding ??
-      (() => syncAgentContextTree(this.config.sdk, (msg) => this.config.log.info(msg)));
-    const binding = await reresolveUnboundTree(cfg.contextTreePath, resolve);
+      (() => syncAgentContextTreeWithHealth(this.config.sdk, (msg) => this.config.log.info(msg)));
+    const result = await reresolveUnboundTree(cfg.contextTreePath, resolve);
+    if (!result) return;
+    // Record the freshest tree-side health verdict even when the slot stays
+    // tree-less — a re-resolution distinguishes "org has no tree" (unbound)
+    // from "bound but this machine can't reach it" (unreachable), and the
+    // next `workspace:health` frame should carry whichever it found.
+    // `health === null` = config fetch failed (unknown) → keep the prior value.
+    if (result.health !== null) cfg.contextTreeHealth = result.health;
+    const binding = result.binding;
     if (!binding) return;
     cfg.contextTreePath = binding.path;
     cfg.contextTreeRepoUrl = binding.repoUrl;
@@ -879,6 +904,28 @@ export class SessionManager {
       { path: binding.path, repoUrl: binding.repoUrl },
       "context tree binding resolved lazily (agent was unbound at slot start)",
     );
+  }
+
+  /**
+   * Compose and emit a `workspace:health` report: the handler's per-repo
+   * verdicts plus the tree half read from `handlerConfig.contextTreeHealth`
+   * (set by AgentSlot at bind, refreshed by `ensureContextTreeBinding`).
+   *
+   * Skipped entirely when the tree half is unknown (slot bind couldn't fetch
+   * the tree config) — the server keeps the last good latest-wins report
+   * rather than having it overwritten by a half-blind one.
+   */
+  private reportWorkspaceHealth(repos: WorkspaceRepoHealth[]): void {
+    if (!this.config.onWorkspaceHealth) return;
+    const parsed = workspaceTreeHealthSchema.safeParse(this.config.handlerConfig.contextTreeHealth);
+    if (!parsed.success) {
+      this.config.log.debug(
+        { repoCount: repos.length },
+        "workspace:health report skipped — tree health unknown (context tree config not resolved)",
+      );
+      return;
+    }
+    this.config.onWorkspaceHealth({ tree: parsed.data, repos });
   }
 
   private async startNewSession(chatId: string, message: SessionMessage): Promise<void> {
@@ -1735,6 +1782,9 @@ export class SessionManager {
       buildAgentEnv: (parentEnv) => buildAgentEnv(parentEnv, envCtx),
       formatInboundContent: (message) => formatInboundContent(message, participants),
       resolveSenderLabel: async (senderId) => resolveSenderLabel(senderId, await participants.get()),
+      reportRepoHealth: (repos) => {
+        this.reportWorkspaceHealth(repos);
+      },
     };
   }
 

--- a/packages/client/src/runtime/source-repos.ts
+++ b/packages/client/src/runtime/source-repos.ts
@@ -1,5 +1,5 @@
 import { join } from "node:path";
-import { type AgentRuntimeConfigPayload, deriveRepoLocalPath } from "@first-tree/shared";
+import { type AgentRuntimeConfigPayload, deriveRepoLocalPath, type WorkspaceRepoHealth } from "@first-tree/shared";
 import { type PredeclaredSourceRepo, resolveBundledCliVersion } from "./bootstrap.js";
 import { resolveGitRepoTargetPath } from "./git-local-path.js";
 import type { GitMirrorManager } from "./git-mirror-manager.js";
@@ -146,19 +146,40 @@ export function releaseSourceReposForSession(sessionCtx: SessionContext): void {
  * it to the latest default branch. Concurrency for the same path is serialised
  * inside the manager (`withPathLock`).
  *
- * Fail-fast, with one degrade: a transient *network* fetch failure on an
- * already-existing usable checkout does NOT abort — the manager leaves the
- * clone at its current commit (`stale-offline`) so the agent stays answerable
- * on the last-good source. Every other failure (first-clone failure, auth,
- * corrupt, wrong origin, TLS trust) still aborts the session and bubbles up.
+ * Fail-fast, with three degrades:
+ *  - transient *network* fetch failure on an already-existing usable checkout
+ *    → `stale-offline`: the manager leaves the clone at its current commit so
+ *    the agent stays answerable on the last-good source. Self-heals.
+ *  - PERMISSION-shaped fetch failure on an existing usable checkout
+ *    → `stale-unreachable`: same freeze, but reported as degraded health (it
+ *    will not self-heal until host credentials are fixed).
+ *  - PERMISSION-shaped clone failure with no usable local clone
+ *    → `skipped-unreachable`: the repo is skipped (excluded from the returned
+ *    `sourceRepos`) so the session still starts on a partial workspace.
+ * Every other failure (corrupt, wrong origin, TLS trust, ref-not-found) still
+ * aborts the session and bubbles up — see `classifyPermissionShapedGitError`.
+ *
+ * `repoHealth` carries one entry per configured repo (healthy ones included)
+ * for the post-bootstrap `workspace:health` report. Transient `stale-offline`
+ * is deliberately reported as `ok` — the warning surface is credential-
+ * targeted and a network blip heals on the next session by itself.
  */
-export async function prepareSourceRepos(params: PrepareSourceReposParams): Promise<PredeclaredSourceRepo[]> {
+export type PrepareSourceReposResult = {
+  sourceRepos: PredeclaredSourceRepo[];
+  repoHealth: WorkspaceRepoHealth[];
+};
+
+export async function prepareSourceRepos(params: PrepareSourceReposParams): Promise<PrepareSourceReposResult> {
   const { workspace, payload, sessionCtx, gitMirrorManager, payloadResolved } = params;
   const sourceRepos: PredeclaredSourceRepo[] = [];
+  const repoHealth: WorkspaceRepoHealth[] = [];
 
-  // No git capability → no source-repo prep AND no cleanup (we can't safely
-  // probe for clean state without git). Returns early before any state read.
-  if (!gitMirrorManager) return sourceRepos;
+  // No git capability handle at all (test-only construction; the production
+  // runtime always injects a manager) → no source-repo prep AND no cleanup
+  // (we can't safely probe for clean state without git). Returns early before
+  // any state read. The git-binary-missing case on a REAL host goes through
+  // the manager and is classified `git_not_installed` per repo below.
+  if (!gitMirrorManager) return { sourceRepos, repoHealth };
 
   // Build the set of `localPath`s the current config wants materialised.
   // `payload?.gitRepos` may legitimately be empty (config exists, just no
@@ -195,6 +216,24 @@ export async function prepareSourceRepos(params: PrepareSourceReposParams): Prom
         activelyInUse,
       });
 
+      // Degraded-workspace start: a permission-shaped clone failure skips the
+      // repo instead of aborting the whole loop. Nothing was materialised on
+      // disk (no `localPath` in the health entry), so the live-use
+      // registration THIS call created is released right away — a skipped
+      // repo must not pin the path into skip-update mode for other chats.
+      if (result.outcome === "skipped-unreachable") {
+        sessionCtx.log(
+          `Git: ${localPath} could not be cloned (${result.degraded?.reasonCode ?? "permission-shaped failure"}) — repo skipped, session starts on a partial workspace`,
+        );
+        repoHealth.push({
+          url: repo.url,
+          status: "unreachable",
+          ...(result.degraded ?? {}),
+        });
+        if (firstRegistration) releaseChatFromPath(sessionCtx.chatId, targetPath);
+        continue;
+      }
+
       if (result.outcome === "cloned") {
         sessionCtx.log(`Git: cloned ${repo.url}`);
       } else if (result.outcome === "migrated-recloned") {
@@ -209,7 +248,23 @@ export async function prepareSourceRepos(params: PrepareSourceReposParams): Prom
         sessionCtx.log(
           `Git: ${localPath} could not be fetched (transient network) — using existing local checkout, left at current commit (stale)`,
         );
+      } else if (result.outcome === "stale-unreachable") {
+        sessionCtx.log(
+          `Git: ${localPath} could not be fetched (${result.degraded?.reasonCode ?? "permission-shaped failure"}) — using existing local checkout FROZEN at its last-good commit until host git credentials are fixed`,
+        );
       }
+
+      repoHealth.push(
+        result.outcome === "stale-unreachable"
+          ? {
+              url: repo.url,
+              localPath,
+              status: "stale",
+              ...(result.degraded ?? {}),
+              ...(result.headCommit ? { headCommit: result.headCommit } : {}),
+            }
+          : { url: repo.url, localPath, status: "ok" },
+      );
 
       // Per agent-session-cwd-redesign: predeclared source repos are agent-scoped
       // persistent resources. They survive shutdown so the next chat finds them
@@ -251,7 +306,7 @@ export async function prepareSourceRepos(params: PrepareSourceReposParams): Prom
     throw err;
   }
 
-  return sourceRepos;
+  return { sourceRepos, repoHealth };
 }
 
 /**

--- a/packages/server/drizzle/0062_remarkable_smiling_tiger.sql
+++ b/packages/server/drizzle/0062_remarkable_smiling_tiger.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "agent_presence" ADD COLUMN "workspace_health" jsonb;

--- a/packages/server/drizzle/LATEST
+++ b/packages/server/drizzle/LATEST
@@ -1,1 +1,1 @@
-0061_backfill_legacy_discussion_entity_keys
+0062_remarkable_smiling_tiger

--- a/packages/server/drizzle/meta/0062_snapshot.json
+++ b/packages/server/drizzle/meta/0062_snapshot.json
@@ -1,0 +1,3914 @@
+{
+  "id": "6b778f07-13c5-40ce-9379-1324370dac65",
+  "prevId": "70a2c5b5-87ca-4d0c-930d-a1df7c5cc739",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_chat_sessions": {
+      "name": "agent_chat_sessions",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_state": {
+          "name": "runtime_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "runtime_state_at": {
+          "name": "runtime_state_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_chat_sessions_agent_id_agents_uuid_fk": {
+          "name": "agent_chat_sessions_agent_id_agents_uuid_fk",
+          "tableFrom": "agent_chat_sessions",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_chat_sessions_chat_id_chats_id_fk": {
+          "name": "agent_chat_sessions_chat_id_chats_id_fk",
+          "tableFrom": "agent_chat_sessions",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_chat_sessions_agent_id_chat_id_pk": {
+          "name": "agent_chat_sessions_agent_id_chat_id_pk",
+          "columns": [
+            "agent_id",
+            "chat_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_configs": {
+      "name": "agent_configs",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_presence": {
+      "name": "agent_presence",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'offline'"
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_type": {
+          "name": "runtime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_version": {
+          "name": "runtime_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_state": {
+          "name": "runtime_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_sessions": {
+          "name": "active_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_sessions": {
+          "name": "total_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_updated_at": {
+          "name": "runtime_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_health": {
+          "name": "workspace_health",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_presence_agent_id_agents_uuid_fk": {
+          "name": "agent_presence_agent_id_agents_uuid_fk",
+          "tableFrom": "agent_presence",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_presence_client_id_clients_id_fk": {
+          "name": "agent_presence_client_id_clients_id_fk",
+          "tableFrom": "agent_presence",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_resource_bindings": {
+      "name": "agent_resource_bindings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaces_resource_id": {
+          "name": "replaces_resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inline_prompt_body": {
+          "name": "inline_prompt_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo_ref": {
+          "name": "repo_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo_local_path": {
+          "name": "repo_local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_resource_bindings_agent": {
+          "name": "idx_agent_resource_bindings_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_resource_bindings_resource": {
+          "name": "idx_agent_resource_bindings_resource",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_resource_bindings_replaces": {
+          "name": "idx_agent_resource_bindings_replaces",
+          "columns": [
+            {
+              "expression": "replaces_resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_resource_bindings_organization_id_organizations_id_fk": {
+          "name": "agent_resource_bindings_organization_id_organizations_id_fk",
+          "tableFrom": "agent_resource_bindings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_resource_bindings_agent_id_agents_uuid_fk": {
+          "name": "agent_resource_bindings_agent_id_agents_uuid_fk",
+          "tableFrom": "agent_resource_bindings",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_resource_bindings_resource_id_resources_id_fk": {
+          "name": "agent_resource_bindings_resource_id_resources_id_fk",
+          "tableFrom": "agent_resource_bindings",
+          "tableTo": "resources",
+          "columnsFrom": [
+            "resource_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_resource_bindings_replaces_resource_id_resources_id_fk": {
+          "name": "agent_resource_bindings_replaces_resource_id_resources_id_fk",
+          "tableFrom": "agent_resource_bindings",
+          "tableTo": "resources",
+          "columnsFrom": [
+            "replaces_resource_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delegate_mention": {
+          "name": "delegate_mention",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inbox_id": {
+          "name": "inbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "manager_id": {
+          "name": "manager_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_provider": {
+          "name": "runtime_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claude-code'"
+        },
+        "avatar_color_token": {
+          "name": "avatar_color_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_image_data": {
+          "name": "avatar_image_data",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_image_mime": {
+          "name": "avatar_image_mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_image_updated_at": {
+          "name": "avatar_image_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skills": {
+          "name": "skills",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agents_org": {
+          "name": "idx_agents_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agents_manager": {
+          "name": "idx_agents_manager",
+          "columns": [
+            {
+              "expression": "manager_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agents_visibility_org": {
+          "name": "idx_agents_visibility_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agents_client": {
+          "name": "idx_agents_client",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_organization_id_organizations_id_fk": {
+          "name": "agents_organization_id_organizations_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agents_client_id_clients_id_fk": {
+          "name": "agents_client_id_clients_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agents_inbox_id_unique": {
+          "name": "agents_inbox_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "inbox_id"
+          ]
+        },
+        "uq_agents_org_name": {
+          "name": "uq_agents_org_name",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attachments": {
+      "name": "attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "attachments_uploaded_by_idx": {
+          "name": "attachments_uploaded_by_idx",
+          "columns": [
+            {
+              "expression": "uploaded_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attachments_created_at_idx": {
+          "name": "attachments_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attentions": {
+      "name": "attentions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "origin_agent_id": {
+          "name": "origin_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin_chat_id": {
+          "name": "origin_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_human_id": {
+          "name": "target_human_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "requires_response": {
+          "name": "requires_response",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responded_by": {
+          "name": "responded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled": {
+          "name": "cancelled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cancelled_reason": {
+          "name": "cancelled_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_attentions_target_open": {
+          "name": "idx_attentions_target_open",
+          "columns": [
+            {
+              "expression": "target_human_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_attentions_chat_open": {
+          "name": "idx_attentions_chat_open",
+          "columns": [
+            {
+              "expression": "origin_chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_attentions_origin": {
+          "name": "idx_attentions_origin",
+          "columns": [
+            {
+              "expression": "origin_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_identities": {
+      "name": "auth_identities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_type": {
+          "name": "credential_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_payload": {
+          "name": "credential_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_auth_identities_user": {
+          "name": "idx_auth_identities_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_auth_identities_email": {
+          "name": "idx_auth_identities_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_auth_identities_user_github": {
+          "name": "uq_auth_identities_user_github",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "provider = 'github'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_identities_user_id_users_id_fk": {
+          "name": "auth_identities_user_id_users_id_fk",
+          "tableFrom": "auth_identities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_auth_identities_provider_identifier": {
+          "name": "uq_auth_identities_provider_identifier",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider",
+            "identifier"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_membership": {
+      "name": "chat_membership",
+      "schema": "",
+      "columns": {
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "access_mode": {
+          "name": "access_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'full'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_membership_agent": {
+          "name": "idx_membership_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_membership_chat_role": {
+          "name": "idx_membership_chat_role",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "access_mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "chat_membership_chat_id_agent_id_pk": {
+          "name": "chat_membership_chat_id_agent_id_pk",
+          "columns": [
+            "chat_id",
+            "agent_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_user_state": {
+      "name": "chat_user_state",
+      "schema": "",
+      "columns": {
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_read_at": {
+          "name": "last_read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unread_mention_count": {
+          "name": "unread_mention_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "open_request_count": {
+          "name": "open_request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "engagement_status": {
+          "name": "engagement_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {
+        "idx_user_state_agent": {
+          "name": "idx_user_state_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_state_unread": {
+          "name": "idx_user_state_unread",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "unread_mention_count > 0",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_state_open_req": {
+          "name": "idx_user_state_open_req",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "open_request_count > 0",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "chat_user_state_chat_id_agent_id_pk": {
+          "name": "chat_user_state_chat_id_agent_id_pk",
+          "columns": [
+            "chat_id",
+            "agent_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chats": {
+      "name": "chats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'direct'"
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_policy": {
+          "name": "lifecycle_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'persistent'"
+        },
+        "parent_chat_id": {
+          "name": "parent_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_preview": {
+          "name": "last_message_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chats_org_last_message": {
+          "name": "idx_chats_org_last_message",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"last_message_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chats_organization_id_organizations_id_fk": {
+          "name": "chats_organization_id_organizations_id_fk",
+          "tableFrom": "chats",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clients": {
+      "name": "clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'disconnected'"
+        },
+        "sdk_version": {
+          "name": "sdk_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "os": {
+          "name": "os",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_clients_user": {
+          "name": "idx_clients_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_clients_org": {
+          "name": "idx_clients_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clients_user_id_users_id_fk": {
+          "name": "clients_user_id_users_id_fk",
+          "tableFrom": "clients",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "clients_organization_id_organizations_id_fk": {
+          "name": "clients_organization_id_organizations_id_fk",
+          "tableFrom": "clients",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.context_tree_io_events": {
+      "name": "context_tree_io_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_session_event_id": {
+          "name": "source_session_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_index": {
+          "name": "source_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "runtime_provider": {
+          "name": "runtime_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tree_repo_url": {
+          "name": "tree_repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tree_branch": {
+          "name": "tree_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_path": {
+          "name": "target_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_context_tree_io_source": {
+          "name": "uq_context_tree_io_source",
+          "columns": [
+            {
+              "expression": "source_session_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_context_tree_io_org_recent": {
+          "name": "idx_context_tree_io_org_recent",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_context_tree_io_org_action_recent": {
+          "name": "idx_context_tree_io_org_action_recent",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_context_tree_io_org_agent_recent": {
+          "name": "idx_context_tree_io_org_agent_recent",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_context_tree_io_org_target_recent": {
+          "name": "idx_context_tree_io_org_target_recent",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "context_tree_io_events_organization_id_organizations_id_fk": {
+          "name": "context_tree_io_events_organization_id_organizations_id_fk",
+          "tableFrom": "context_tree_io_events",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "context_tree_io_events_agent_id_agents_uuid_fk": {
+          "name": "context_tree_io_events_agent_id_agents_uuid_fk",
+          "tableFrom": "context_tree_io_events",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "context_tree_io_events_chat_id_chats_id_fk": {
+          "name": "context_tree_io_events_chat_id_chats_id_fk",
+          "tableFrom": "context_tree_io_events",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_context_tree_io_action": {
+          "name": "ck_context_tree_io_action",
+          "value": "\"context_tree_io_events\".\"action\" IN ('read', 'write')"
+        },
+        "ck_context_tree_io_target_kind": {
+          "name": "ck_context_tree_io_target_kind",
+          "value": "\"context_tree_io_events\".\"target_kind\" IN ('file', 'directory', 'repo')"
+        },
+        "ck_context_tree_io_target_path_nonempty": {
+          "name": "ck_context_tree_io_target_path_nonempty",
+          "value": "\"context_tree_io_events\".\"target_path\" <> ''"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.github_app_installations": {
+      "name": "github_app_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_github_id": {
+          "name": "account_github_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hub_organization_id": {
+          "name": "hub_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_github_app_installations_installation_id": {
+          "name": "uq_github_app_installations_installation_id",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_github_app_installations_hub_org": {
+          "name": "uq_github_app_installations_hub_org",
+          "columns": [
+            {
+              "expression": "hub_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_app_installations_account": {
+          "name": "idx_github_app_installations_account",
+          "columns": [
+            {
+              "expression": "account_github_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_app_installations_hub_organization_id_organizations_id_fk": {
+          "name": "github_app_installations_hub_organization_id_organizations_id_fk",
+          "tableFrom": "github_app_installations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "hub_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_github_app_installations_account_type": {
+          "name": "ck_github_app_installations_account_type",
+          "value": "\"github_app_installations\".\"account_type\" IN ('User', 'Organization')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.github_entity_chat_mappings": {
+      "name": "github_entity_chat_mappings",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "human_agent_id": {
+          "name": "human_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delegate_agent_id": {
+          "name": "delegate_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_key": {
+          "name": "entity_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bound_at": {
+          "name": "bound_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "bound_via": {
+          "name": "bound_via",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_state": {
+          "name": "entity_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "entity_state_updated_at": {
+          "name": "entity_state_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_github_entity_chat_mappings_chat": {
+          "name": "idx_github_entity_chat_mappings_chat",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_entity_chat_mappings_chat_state": {
+          "name": "idx_github_entity_chat_mappings_chat_state",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_entity_chat_mappings_organization_id_organizations_id_fk": {
+          "name": "github_entity_chat_mappings_organization_id_organizations_id_fk",
+          "tableFrom": "github_entity_chat_mappings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "github_entity_chat_mappings_human_agent_id_agents_uuid_fk": {
+          "name": "github_entity_chat_mappings_human_agent_id_agents_uuid_fk",
+          "tableFrom": "github_entity_chat_mappings",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "human_agent_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_entity_chat_mappings_delegate_agent_id_agents_uuid_fk": {
+          "name": "github_entity_chat_mappings_delegate_agent_id_agents_uuid_fk",
+          "tableFrom": "github_entity_chat_mappings",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "delegate_agent_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_entity_chat_mappings_chat_id_chats_id_fk": {
+          "name": "github_entity_chat_mappings_chat_id_chats_id_fk",
+          "tableFrom": "github_entity_chat_mappings",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "github_entity_chat_mappings_organization_id_human_agent_id_delegate_agent_id_entity_type_entity_key_pk": {
+          "name": "github_entity_chat_mappings_organization_id_human_agent_id_delegate_agent_id_entity_type_entity_key_pk",
+          "columns": [
+            "organization_id",
+            "human_agent_id",
+            "delegate_agent_id",
+            "entity_type",
+            "entity_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inbox_entries": {
+      "name": "inbox_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "inbox_id": {
+          "name": "inbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "notify": {
+          "name": "notify",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acked_at": {
+          "name": "acked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_inbox_pending": {
+          "name": "idx_inbox_pending",
+          "columns": [
+            {
+              "expression": "inbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inbox_pending_notify": {
+          "name": "idx_inbox_pending_notify",
+          "columns": [
+            {
+              "expression": "inbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'pending' AND notify = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inbox_chat_silent": {
+          "name": "idx_inbox_chat_silent",
+          "columns": [
+            {
+              "expression": "inbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "notify",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inbox_entries_message_id_messages_id_fk": {
+          "name": "inbox_entries_message_id_messages_id_fk",
+          "tableFrom": "inbox_entries",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_inbox_delivery": {
+          "name": "uq_inbox_delivery",
+          "nullsNotDistinct": false,
+          "columns": [
+            "inbox_id",
+            "message_id",
+            "chat_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation_redemptions": {
+      "name": "invitation_redemptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invitation_id": {
+          "name": "invitation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redeemed_at": {
+          "name": "redeemed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_invitation_redemptions_invitation": {
+          "name": "idx_invitation_redemptions_invitation",
+          "columns": [
+            {
+              "expression": "invitation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invitation_redemptions_user": {
+          "name": "idx_invitation_redemptions_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_redemptions_invitation_id_invitations_id_fk": {
+          "name": "invitation_redemptions_invitation_id_invitations_id_fk",
+          "tableFrom": "invitation_redemptions",
+          "tableTo": "invitations",
+          "columnsFrom": [
+            "invitation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_redemptions_user_id_users_id_fk": {
+          "name": "invitation_redemptions_user_id_users_id_fk",
+          "tableFrom": "invitation_redemptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_invitations_token": {
+          "name": "idx_invitations_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invitations_org": {
+          "name": "idx_invitations_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitations_organization_id_organizations_id_fk": {
+          "name": "invitations_organization_id_organizations_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitations_created_by_users_id_fk": {
+          "name": "invitations_created_by_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitations_token_unique": {
+          "name": "invitations_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.members": {
+      "name": "members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_members_user": {
+          "name": "idx_members_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_members_org": {
+          "name": "idx_members_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "members_user_id_users_id_fk": {
+          "name": "members_user_id_users_id_fk",
+          "tableFrom": "members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "members_organization_id_organizations_id_fk": {
+          "name": "members_organization_id_organizations_id_fk",
+          "tableFrom": "members",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "members_agent_id_agents_uuid_fk": {
+          "name": "members_agent_id_agents_uuid_fk",
+          "tableFrom": "members",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "members_agent_id_unique": {
+          "name": "members_agent_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "agent_id"
+          ]
+        },
+        "uq_members_user_org": {
+          "name": "uq_members_user_org",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "reply_to_inbox": {
+          "name": "reply_to_inbox",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to_chat": {
+          "name": "reply_to_chat",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "in_reply_to": {
+          "name": "in_reply_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_messages_chat_time": {
+          "name": "idx_messages_chat_time",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_messages_in_reply_to": {
+          "name": "idx_messages_in_reply_to",
+          "columns": [
+            {
+              "expression": "in_reply_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_messages_chat_source_time": {
+          "name": "idx_messages_chat_source_time",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_messages_mentions": {
+          "name": "idx_messages_mentions",
+          "columns": [
+            {
+              "expression": "((\"metadata\" -> 'mentions')) jsonb_path_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_chat_id_chats_id_fk": {
+          "name": "messages_chat_id_chats_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read": {
+          "name": "read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "dedup_key": {
+          "name": "dedup_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notifications_org_created": {
+          "name": "idx_notifications_org_created",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_agent": {
+          "name": "idx_notifications_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_org_read": {
+          "name": "idx_notifications_org_read",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_notifications_org_dedup_unread": {
+          "name": "uq_notifications_org_dedup_unread",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dedup_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "read = false AND dedup_key IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_settings": {
+      "name": "organization_settings",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_settings_namespace": {
+          "name": "idx_org_settings_namespace",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_settings_organization_id_organizations_id_fk": {
+          "name": "organization_settings_organization_id_organizations_id_fk",
+          "tableFrom": "organization_settings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_settings_updated_by_users_id_fk": {
+          "name": "organization_settings_updated_by_users_id_fk",
+          "tableFrom": "organization_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "organization_settings_organization_id_namespace_pk": {
+          "name": "organization_settings_organization_id_namespace_pk",
+          "columns": [
+            "organization_id",
+            "namespace"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_agents": {
+          "name": "max_agents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_messages_per_minute": {
+          "name": "max_messages_per_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "features": {
+          "name": "features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_name_unique": {
+          "name": "organizations_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_questions": {
+      "name": "pending_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_reason": {
+          "name": "superseded_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_pending_questions_agent_status": {
+          "name": "idx_pending_questions_agent_status",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pending_questions_chat_status": {
+          "name": "idx_pending_questions_chat_status",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resources": {
+      "name": "resources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_agent_id": {
+          "name": "owner_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_canonical_key": {
+          "name": "repo_canonical_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_enabled": {
+          "name": "default_enabled",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_resources_org_type_scope": {
+          "name": "idx_resources_org_type_scope",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_resources_owner_agent": {
+          "name": "idx_resources_owner_agent",
+          "columns": [
+            {
+              "expression": "owner_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_resources_repo_key": {
+          "name": "idx_resources_repo_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo_canonical_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_resources_team_repo_canonical_active": {
+          "name": "uq_resources_team_repo_canonical_active",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo_canonical_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"resources\".\"type\" = 'repo' AND \"resources\".\"scope\" = 'team' AND \"resources\".\"status\" IN ('active', 'stale') AND \"resources\".\"repo_canonical_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_resources_agent_repo_canonical_active": {
+          "name": "uq_resources_agent_repo_canonical_active",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo_canonical_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"resources\".\"type\" = 'repo' AND \"resources\".\"scope\" = 'agent' AND \"resources\".\"status\" IN ('active', 'stale') AND \"resources\".\"repo_canonical_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "resources_organization_id_organizations_id_fk": {
+          "name": "resources_organization_id_organizations_id_fk",
+          "tableFrom": "resources",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "resources_owner_agent_id_agents_uuid_fk": {
+          "name": "resources_owner_agent_id_agents_uuid_fk",
+          "tableFrom": "resources",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "owner_agent_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.server_instances": {
+      "name": "server_instances",
+      "schema": "",
+      "columns": {
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_heartbeat": {
+          "name": "last_heartbeat",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_events": {
+      "name": "session_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_session_events_chat_seq": {
+          "name": "uq_session_events_chat_seq",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_session_events_chat_created": {
+          "name": "idx_session_events_chat_created",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_session_events_context_tree_usage_recent": {
+          "name": "idx_session_events_context_tree_usage_recent",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"session_events\".\"kind\" = 'context_tree_usage'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_session_events_token_usage_agent_recent": {
+          "name": "idx_session_events_token_usage_agent_recent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"session_events\".\"kind\" = 'token_usage'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "onboarding_dismissed_at": {
+          "name": "onboarding_dismissed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed_at": {
+          "name": "onboarding_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -435,6 +435,13 @@
       "when": 1781162100000,
       "tag": "0061_backfill_legacy_discussion_entity_keys",
       "breakpoints": true
+    },
+    {
+      "idx": 62,
+      "version": "7",
+      "when": 1781249005244,
+      "tag": "0062_remarkable_smiling_tiger",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/api/agent/ws-client.ts
+++ b/packages/server/src/api/agent/ws-client.ts
@@ -18,6 +18,7 @@ import {
   sessionRuntimeMessageSchema,
   sessionStateMessageSchema,
   WS_AUTH_FRAME_TIMEOUT_MS,
+  workspaceHealthMessageSchema,
   wsAuthFrameSchema,
 } from "@first-tree/shared";
 import { and, desc, eq, inArray, isNull, ne } from "drizzle-orm";
@@ -1135,6 +1136,20 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
               } else if (payload.runtimeState === "idle" || payload.runtimeState === "working") {
                 notificationService.markAgentFaultsResolved(app.db, agentId).catch(() => {});
               }
+            } else if (type === "workspace:health") {
+              // Per-agent repo/tree reachability report, sent by the client
+              // after session bootstrap materialises source repos + Context
+              // Tree. Persisted latest-wins on agent_presence.workspace_health
+              // (server stamps updatedAt); read by the web console to render
+              // the degraded-workspace warning chip.
+              const agentId = parsed.data.agentId;
+              if (!agentId || !isAgentStillRoutedHere(agentId)) {
+                socket.send(JSON.stringify({ type: "error", message: "Agent not bound" }));
+                return;
+              }
+
+              const payload = workspaceHealthMessageSchema.parse(msg);
+              await presenceService.setWorkspaceHealth(app.db, agentId, payload);
             } else if (type === "session:event") {
               const agentId = parsed.data.agentId;
               if (!agentId || !isAgentStillRoutedHere(agentId)) {

--- a/packages/server/src/db/schema/agent-presence.ts
+++ b/packages/server/src/db/schema/agent-presence.ts
@@ -1,4 +1,5 @@
-import { integer, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+import type { WorkspaceHealth } from "@first-tree/shared";
+import { integer, jsonb, pgTable, text, timestamp } from "drizzle-orm/pg-core";
 import { agents } from "./agents.js";
 import { clients } from "./clients.js";
 
@@ -30,4 +31,12 @@ export const agentPresence = pgTable("agent_presence", {
   totalSessions: integer("total_sessions"),
   /** When runtime_state was last updated */
   runtimeUpdatedAt: timestamp("runtime_updated_at", { withTimezone: true }),
+
+  /**
+   * Latest `workspace:health` report (per-agent repo/tree reachability),
+   * stamped with server receive time (`updatedAt`). Latest-wins; deliberately
+   * NOT cleared on offline/unbind so the console can still explain a degraded
+   * workspace after the client disconnects ("last reported X ago").
+   */
+  workspaceHealth: jsonb("workspace_health").$type<WorkspaceHealth>(),
 });

--- a/packages/server/src/services/agent-chat-status.ts
+++ b/packages/server/src/services/agent-chat-status.ts
@@ -17,6 +17,7 @@ import { agentChatSessions } from "../db/schema/agent-chat-sessions.js";
 import { agentPresence } from "../db/schema/agent-presence.js";
 import { agents } from "../db/schema/agents.js";
 import { chatMembership } from "../db/schema/chat-membership.js";
+import { clients } from "../db/schema/clients.js";
 
 /**
  * Single source of truth for per-(agent,chat) composite status.
@@ -346,13 +347,19 @@ export async function resolveAgentChatStatuses(
   //    OR-fold for errored, for one release cycle. Matches the approved
   //    spec (proposals/hub-agent-status-working-freshness.20260525.md
   //    §6.1 §10).
+  //    Also carries the descriptive degraded-workspace fields: the latest
+  //    `workspace:health` report plus the hosting client's hostname (left
+  //    join — PK seek per row, fine on the chat-list hot path).
   const presenceRows = await db
     .select({
       agentId: agentPresence.agentId,
       clientId: agentPresence.clientId,
       runtimeState: agentPresence.runtimeState,
+      workspaceHealth: agentPresence.workspaceHealth,
+      clientHostname: clients.hostname,
     })
     .from(agentPresence)
+    .leftJoin(clients, eq(agentPresence.clientId, clients.id))
     .where(inArray(agentPresence.agentId, allAgentIds));
   const presenceById = new Map(presenceRows.map((p) => [p.agentId, p]));
 
@@ -393,6 +400,8 @@ export async function resolveAgentChatStatuses(
           // aren't in chainSessionOp) briefly emits activity=null; the next
           // runtime frame self-heals.
           activity: working ? activity : null,
+          workspaceHealth: p?.workspaceHealth ?? null,
+          clientHostname: p?.clientHostname ?? null,
         }),
       );
     }

--- a/packages/server/src/services/chat.ts
+++ b/packages/server/src/services/chat.ts
@@ -39,6 +39,9 @@ export type CreateLegacyEmptyWebChatInput = {
   participantAgentIds: readonly string[];
   topic?: string | null;
   description?: string | null;
+  // Optional purpose tag (e.g. the degraded-workspace fix chat) — written
+  // into `chats.metadata` so purpose-scoped dedup can find the chat later.
+  metadata?: Record<string, unknown>;
 };
 
 type CreateLegacyEmptyAgentChatInput = {
@@ -183,7 +186,7 @@ async function createLegacyEmptyChat(
         type: "group",
         topic: input.topic ?? null,
         description: input.description ?? null,
-        metadata: input.mode === "legacy-empty-agent" ? (input.metadata ?? {}) : {},
+        metadata: input.metadata ?? {},
       })
       .returning();
 

--- a/packages/server/src/services/me-chat.ts
+++ b/packages/server/src/services/me-chat.ts
@@ -22,6 +22,7 @@ import {
   type ChatEngagementView,
   type ChatSource,
   type CreateMeChat,
+  type CreateMeChatResponse,
   GITHUB_ENTITY_TYPES,
   type GithubEntityType,
   type ListMeChatSourceCountsQuery,
@@ -39,6 +40,7 @@ import type { Database } from "../db/connection.js";
 import { agents } from "../db/schema/agents.js";
 import { chatMembership } from "../db/schema/chat-membership.js";
 import { chatUserState } from "../db/schema/chat-user-state.js";
+import { chats } from "../db/schema/chats.js";
 import { messages } from "../db/schema/messages.js";
 import { BadRequestError, CallerNotSpeakerError, NotFoundError } from "../errors.js";
 import { agentAvatarImageUrl } from "./agent.js";
@@ -610,17 +612,43 @@ export async function createMeChat(
   humanAgentId: string,
   organizationId: string,
   body: CreateMeChat,
-): Promise<{ chatId: string }> {
+): Promise<CreateMeChatResponse> {
   const distinctIds = [...new Set(body.participantIds)].filter((id) => id !== humanAgentId);
   if (distinctIds.length === 0) {
     throw new BadRequestError("At least one non-self participant required");
   }
+  // Purpose dedup (today: the degraded-workspace fix chat). A second Fix
+  // click for the same agent must land in the existing fix chat, not mint a
+  // sibling — the chat IS the dedup unit, keyed on
+  // `chats.metadata (purpose, fixAgentId)` scoped to chats the caller
+  // participates in. Best-effort (no unique index): a true double-submit race
+  // can still create two chats, which is harmless — both work, and the next
+  // click converges on one.
+  if (body.purpose) {
+    const [existing] = await db
+      .select({ chatId: chats.id })
+      .from(chats)
+      .innerJoin(chatMembership, and(eq(chatMembership.chatId, chats.id), eq(chatMembership.agentId, humanAgentId)))
+      .where(
+        and(
+          eq(chats.organizationId, organizationId),
+          sql`${chats.metadata}->>'purpose' = ${body.purpose.kind}`,
+          sql`${chats.metadata}->>'fixAgentId' = ${body.purpose.agentId}`,
+        ),
+      )
+      .limit(1);
+    if (existing) {
+      return { chatId: existing.chatId, reused: true };
+    }
+  }
+
   const result = await createChat(db, {
     mode: "legacy-empty-web",
     creatorAgentId: humanAgentId,
     organizationId,
     participantAgentIds: distinctIds,
     topic: body.topic ?? null,
+    ...(body.purpose ? { metadata: { purpose: body.purpose.kind, fixAgentId: body.purpose.agentId } } : {}),
   });
   invalidateChatAudience(result.id);
   return { chatId: result.id };

--- a/packages/server/src/services/presence.ts
+++ b/packages/server/src/services/presence.ts
@@ -1,4 +1,4 @@
-import type { RuntimeState } from "@first-tree/shared";
+import type { RuntimeState, WorkspaceHealthMessage } from "@first-tree/shared";
 import { eq, sql } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 import { agentPresence } from "../db/schema/agent-presence.js";
@@ -142,6 +142,23 @@ export async function setRuntimeState(
   if (options?.notifier && options.organizationId) {
     options.notifier.notifyRuntimeStateChange(agentId, runtimeState, options.organizationId).catch(() => {});
   }
+}
+
+/**
+ * Persist the latest `workspace:health` report (latest-wins). The server
+ * stamps `updatedAt` here so "last reported X ago" never trusts the client
+ * clock. Deliberately not cleared on offline/unbind — the console keeps
+ * explaining a degraded workspace after the client disconnects.
+ */
+export async function setWorkspaceHealth(db: Database, agentId: string, health: WorkspaceHealthMessage): Promise<void> {
+  const now = new Date();
+  await db
+    .update(agentPresence)
+    .set({
+      workspaceHealth: { ...health, updatedAt: now.toISOString() },
+      lastSeenAt: now,
+    })
+    .where(eq(agentPresence.agentId, agentId));
 }
 
 /** Touch agent last_seen_at on heartbeat (per-agent liveness). */

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -387,6 +387,7 @@ export {
   type ChatMessageFrame,
   type ChatSourceCount,
   type CreateMeChat,
+  type CreateMeChatResponse,
   chatEngagementViewSchema,
   chatMessageFrameSchema,
   chatSourceCountSchema,
@@ -421,6 +422,7 @@ export {
   meChatRowSchema,
   meChatSourceCountsSchema,
   meChatUnreadResponseSchema,
+  WORKSPACE_FIX_CHAT_PURPOSE,
 } from "./schemas/me-chat.js";
 export {
   type DocSnapshotFailReason,
@@ -741,6 +743,24 @@ export {
   userStatusSchema,
 } from "./schemas/user.js";
 export { type WebhookSource, webhookSourceSchema } from "./schemas/webhook-source.js";
+export {
+  isWorkspaceHealthDegraded,
+  WORKSPACE_REPO_STATUSES,
+  type WorkspaceHealth,
+  type WorkspaceHealthMessage,
+  type WorkspaceHealthReason,
+  type WorkspaceRepoHealth,
+  type WorkspaceRepoStatus,
+  type WorkspaceTreeHealth,
+  type WorkspaceTreeStatus,
+  workspaceHealthMessageSchema,
+  workspaceHealthReasonSchema,
+  workspaceHealthSchema,
+  workspaceRepoHealthSchema,
+  workspaceRepoStatusSchema,
+  workspaceTreeHealthSchema,
+  workspaceTreeStatusSchema,
+} from "./schemas/workspace-health.js";
 export {
   WORKSPACE_MANIFEST_FILENAME,
   WORKSPACE_STATE_DIRNAME,

--- a/packages/shared/src/schemas/agent-status.ts
+++ b/packages/shared/src/schemas/agent-status.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { type LiveActivity, liveActivitySchema } from "./me-chat.js";
+import { type WorkspaceHealth, workspaceHealthSchema } from "./workspace-health.js";
 
 /**
  * Composite "main" status — the single value a compact surface (a status
@@ -137,6 +138,21 @@ export const agentChatStatusSchema = z
      * a second round-trip. Not an input to `main` — purely descriptive.
      */
     activity: liveActivitySchema.nullable(),
+    /**
+     * Latest `workspace:health` report for this agent (repo/tree reachability,
+     * from `agent_presence.workspace_health`), or null when the agent has
+     * never reported. Descriptive only — NOT an input to `main`; a degraded
+     * workspace renders as the topbar warning chip, not as a status token.
+     * `.nullish()` so payloads from servers predating the field still parse.
+     */
+    workspaceHealth: workspaceHealthSchema.nullish(),
+    /**
+     * Hostname of the client currently hosting this agent (from `clients.hostname`
+     * via `agent_presence.client_id`), or null when unbound/unknown. Carried for
+     * the degraded-workspace popover ("configure credentials on <hostname>") and
+     * the fix-chat template, sparing those surfaces a second round-trip.
+     */
+    clientHostname: z.string().nullish(),
   })
   .superRefine((val, ctx) => {
     const expected = deriveMainStatus(val);
@@ -151,8 +167,13 @@ export const agentChatStatusSchema = z
 export type AgentChatStatus = z.infer<typeof agentChatStatusSchema>;
 
 /** Inputs to `buildAgentChatStatus` — the axis fields plus the agent id and
- * the optional descriptive live activity. */
-export type AgentChatStatusInput = DeriveMainStatusInput & { agentId: string; activity?: LiveActivity | null };
+ * the optional descriptive fields (live activity, workspace health, hostname). */
+export type AgentChatStatusInput = DeriveMainStatusInput & {
+  agentId: string;
+  activity?: LiveActivity | null;
+  workspaceHealth?: WorkspaceHealth | null;
+  clientHostname?: string | null;
+};
 
 /**
  * Construct an `AgentChatStatus` with `main` always derived from the axes
@@ -168,5 +189,7 @@ export function buildAgentChatStatus(input: AgentChatStatusInput): AgentChatStat
     errored: input.errored,
     main: deriveMainStatus(input),
     activity: input.activity ?? null,
+    workspaceHealth: input.workspaceHealth ?? null,
+    clientHostname: input.clientHostname ?? null,
   };
 }

--- a/packages/shared/src/schemas/me-chat.ts
+++ b/packages/shared/src/schemas/me-chat.ts
@@ -334,11 +334,37 @@ export const listMeChatsResponseSchema = z.object({
 });
 export type ListMeChatsResponse = z.infer<typeof listMeChatsResponseSchema>;
 
+/**
+ * `chats.metadata.purpose` value marking a dedicated degraded-workspace fix
+ * chat (web topbar chip → Fix button). The dedup key is (purpose, fixAgentId):
+ * clicking Fix twice for the same agent reuses the existing chat instead of
+ * minting a second one.
+ */
+export const WORKSPACE_FIX_CHAT_PURPOSE = "workspace-fix";
+
 export const createMeChatSchema = z.object({
   participantIds: z.array(z.string().min(1)).min(1),
   topic: z.string().trim().max(500).optional().nullable(),
+  /**
+   * Optional structured purpose persisted to `chats.metadata` as
+   * `{ purpose, fixAgentId }`. Deliberately a closed enum-of-one rather than
+   * free-form metadata — the create route is caller-facing, so each purpose
+   * must be opted in here. When present, creation dedups: an existing chat in
+   * the org with the same (purpose, fixAgentId) that the caller participates
+   * in is returned (`reused: true`) instead of creating a new chat.
+   */
+  purpose: z
+    .object({
+      kind: z.literal(WORKSPACE_FIX_CHAT_PURPOSE),
+      /** The degraded agent this fix chat is about (dedup key with `kind`). */
+      agentId: z.string().min(1),
+    })
+    .optional(),
 });
 export type CreateMeChat = z.infer<typeof createMeChatSchema>;
+
+/** Response of `POST /orgs/:orgId/chats` — `reused` marks a purpose-dedup hit. */
+export type CreateMeChatResponse = { chatId: string; reused?: boolean };
 
 export const addMeChatParticipantsSchema = z.object({
   participantIds: z.array(z.string().min(1)).min(1),

--- a/packages/shared/src/schemas/workspace-health.ts
+++ b/packages/shared/src/schemas/workspace-health.ts
@@ -1,0 +1,99 @@
+import { z } from "zod";
+
+// -- Workspace Health (per-agent repo reachability) --
+//
+// Reported by the client after session bootstrap materialises the agent's
+// source repos and Context Tree (`workspace:health` WS frame, client → server),
+// persisted latest-wins on `agent_presence.workspace_health`, and read by the
+// web console to render the degraded-workspace warning chip.
+//
+// Reachability is an **agent × repo** fact (two agents on one machine declare
+// different gitRepos), which is why it lives on agent presence rather than on
+// `clients.metadata` next to the client × runtime capabilities probe.
+
+export const WORKSPACE_REPO_STATUSES = {
+  /** Clone present and fetched (or safely left at current commit). */
+  OK: "ok",
+  /**
+   * Existing clone served at its last-good commit because the fetch failed
+   * with a permission-shaped error. Unlike a transient network stall this
+   * will NOT self-heal — the code view stays frozen until credentials are
+   * fixed on the host.
+   */
+  STALE: "stale",
+  /** No usable local clone; the repo could not be cloned (permission-shaped failure). */
+  UNREACHABLE: "unreachable",
+} as const;
+
+export const workspaceRepoStatusSchema = z.enum(["ok", "stale", "unreachable"]);
+export type WorkspaceRepoStatus = z.infer<typeof workspaceRepoStatusSchema>;
+
+/** Tree adds `unbound` — the organization has no Context Tree configured at all. */
+export const workspaceTreeStatusSchema = z.enum(["ok", "stale", "unreachable", "unbound"]);
+export type WorkspaceTreeStatus = z.infer<typeof workspaceTreeStatusSchema>;
+
+/**
+ * Why a repo is degraded. Reuses the git error-taxonomy buckets: only the
+ * permission-shaped subset can appear here — auth rejected on both transports,
+ * or a 404 (which GitHub deliberately serves for private repos the host's git
+ * identity cannot see, so "no permission" most often *looks like* not-found).
+ *
+ * `git_not_installed` covers the host with no usable `git` binary at all — the
+ * single most common all-repos-unreachable cause (fresh machine, gh/git never
+ * installed). No clone is even attempted there, so it cannot reuse the two
+ * error-shaped buckets; the fix-chat template's first steps (install gh,
+ * `gh auth login`) are exactly its remediation.
+ */
+export const workspaceHealthReasonSchema = z.enum(["git_clone_auth_failed", "git_repo_not_found", "git_not_installed"]);
+export type WorkspaceHealthReason = z.infer<typeof workspaceHealthReasonSchema>;
+
+export const workspaceRepoHealthSchema = z.object({
+  url: z.string().min(1),
+  /** Workspace-relative checkout dir (derived localPath); absent when never materialised. */
+  localPath: z.string().min(1).optional(),
+  status: workspaceRepoStatusSchema,
+  reasonCode: workspaceHealthReasonSchema.optional(),
+  /**
+   * Short git stderr summary for the warning UI. MUST be passed through the
+   * client-side `redactErrorPreview` helper before it leaves the host —
+   * credentials never reach the DB or the console.
+   */
+  errorPreview: z.string().max(512).optional(),
+  /** HEAD commit the checkout is frozen at (stale repos only). */
+  headCommit: z.string().optional(),
+});
+export type WorkspaceRepoHealth = z.infer<typeof workspaceRepoHealthSchema>;
+
+export const workspaceTreeHealthSchema = z.object({
+  status: workspaceTreeStatusSchema,
+  repoUrl: z.string().optional(),
+  branch: z.string().optional(),
+  reasonCode: workspaceHealthReasonSchema.optional(),
+  /** Same redaction contract as `workspaceRepoHealthSchema.errorPreview`. */
+  errorPreview: z.string().max(512).optional(),
+});
+export type WorkspaceTreeHealth = z.infer<typeof workspaceTreeHealthSchema>;
+
+/**
+ * Payload of the `workspace:health` client → server frame. `agentId` rides on
+ * the WS envelope (same as `runtime:state` / `session:runtime`); the server
+ * stamps `updatedAt` on persist so "last reported X ago" never trusts the
+ * client clock.
+ */
+export const workspaceHealthMessageSchema = z.object({
+  tree: workspaceTreeHealthSchema,
+  repos: z.array(workspaceRepoHealthSchema),
+});
+export type WorkspaceHealthMessage = z.infer<typeof workspaceHealthMessageSchema>;
+
+/** Stored shape (`agent_presence.workspace_health` JSONB) — payload + server receive time. */
+export const workspaceHealthSchema = workspaceHealthMessageSchema.extend({
+  updatedAt: z.string(),
+});
+export type WorkspaceHealth = z.infer<typeof workspaceHealthSchema>;
+
+/** True when anything in the report needs the degraded-workspace warning surface. */
+export function isWorkspaceHealthDegraded(health: WorkspaceHealthMessage): boolean {
+  if (health.tree.status === "stale" || health.tree.status === "unreachable") return true;
+  return health.repos.some((repo) => repo.status !== "ok");
+}

--- a/packages/web/src/api/me-chats.ts
+++ b/packages/web/src/api/me-chats.ts
@@ -2,6 +2,7 @@ import type {
   AddMeChatParticipants,
   ChatEngagementView,
   CreateMeChat,
+  CreateMeChatResponse,
   CreateTaskChat,
   ListMeChatsQuery,
   ListMeChatsResponse,
@@ -49,8 +50,8 @@ export function listMeChatSourceCounts(params?: { engagement?: ChatEngagementVie
   return api.get<MeChatSourceCounts>(withOrg(`/chats/source-counts${query ? `?${query}` : ""}`));
 }
 
-export function createMeChat(body: CreateMeChat): Promise<{ chatId: string }> {
-  return api.post<{ chatId: string }>(withOrg("/chats"), body);
+export function createMeChat(body: CreateMeChat): Promise<CreateMeChatResponse> {
+  return api.post<CreateMeChatResponse>(withOrg("/chats"), body);
 }
 
 export function createMeTaskChat(body: CreateTaskChat): Promise<{

--- a/packages/web/src/components/degraded-workspace-chip.tsx
+++ b/packages/web/src/components/degraded-workspace-chip.tsx
@@ -1,0 +1,351 @@
+import {
+  type AgentChatStatus,
+  isWorkspaceHealthDegraded,
+  WORKSPACE_FIX_CHAT_PURPOSE,
+  type WorkspaceHealth,
+} from "@first-tree/shared";
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import { useNavigate, useSearchParams } from "react-router";
+import { chatAgentStatusQueryKey, fetchChatAgentStatuses } from "../api/agent-status.js";
+import { getChat, sendChatMessage } from "../api/chats.js";
+import { createMeChat } from "../api/me-chats.js";
+import { formatRelative } from "../lib/utils.js";
+import {
+  buildWorkspaceFixMessage,
+  buildWorkspaceFixTopic,
+  workspaceHealthReasonLabel,
+} from "../lib/workspace-fix-template.js";
+import { Popover } from "./ui/popover.js";
+
+/**
+ * Topbar warning chip for the *selected chat's* agents whose workspace is
+ * degraded (source repos / Context Tree unreachable at session start — design:
+ * docs/degraded-workspace-design.md §3.1/§3.2). Sits right beside
+ * `DisconnectChip` and borrows its visual form, but in the shared caution hue
+ * (`--state-blocked`) rather than error red: the agent is up and answering,
+ * it just can't see some team code.
+ *
+ * Yield rule: an agent whose client is disconnected is excluded
+ * (`!s.reachable`) — that situation is owned by DisconnectChip, and a stale
+ * health report would only double-bill the same outage. Renders nothing
+ * when no selected chat / nothing degraded, so the topbar stays clean.
+ */
+export function DegradedWorkspaceChip() {
+  const [searchParams] = useSearchParams();
+  const chatId = searchParams.get("c");
+  // `draft` is the new-chat composer sentinel, not a real chat id.
+  const validChatId = chatId && chatId !== "draft" ? chatId : null;
+
+  const { data: statuses } = useQuery({
+    queryKey: chatAgentStatusQueryKey(validChatId ?? ""),
+    queryFn: () => fetchChatAgentStatuses(validChatId ?? ""),
+    enabled: validChatId !== null,
+    // Same cadence as the chat surfaces; freshness mostly rides the admin-WS
+    // push (use-admin-ws upserts this exact query key).
+    refetchInterval: 30_000,
+  });
+
+  const { data: chatDetail } = useQuery({
+    queryKey: ["chat-detail", validChatId],
+    queryFn: () => getChat(validChatId ?? ""),
+    enabled: validChatId !== null,
+  });
+
+  const degraded = (statuses ?? []).filter(
+    (s): s is AgentChatStatus & { workspaceHealth: WorkspaceHealth } =>
+      s.reachable && s.workspaceHealth != null && isWorkspaceHealthDegraded(s.workspaceHealth),
+  );
+  if (validChatId === null || degraded.length === 0) return null;
+
+  const nameOf = (agentId: string): string => {
+    const p = chatDetail?.participants.find((row) => row.agentId === agentId);
+    return p?.displayName ?? p?.name ?? agentId.slice(0, 8);
+  };
+
+  const label = chipLabel(degraded, nameOf);
+  const tooltip = `${label}. Click for details.`;
+
+  return (
+    <Popover
+      align="start"
+      offset={6}
+      panelStyle={{ width: 380, maxWidth: "calc(100vw - var(--sp-6))", maxHeight: "70vh", overflowY: "auto" }}
+      trigger={({ toggle }) => (
+        <button
+          type="button"
+          onClick={toggle}
+          title={tooltip}
+          aria-label={tooltip}
+          className="inline-flex items-center cursor-pointer text-body font-medium"
+          style={{
+            gap: 8,
+            height: 26,
+            padding: "0 var(--sp-2_5) 0 var(--sp-2_25)",
+            borderRadius: 999,
+            border: 0,
+            outline: "var(--hairline) solid color-mix(in oklch, var(--state-blocked) 38%, transparent)",
+            outlineOffset: -1,
+            background: "var(--state-blocked-soft)",
+            color: "color-mix(in oklch, var(--state-blocked) 80%, var(--fg))",
+            minWidth: 0,
+          }}
+        >
+          <AmberDot />
+          <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{label}</span>
+        </button>
+      )}
+    >
+      {({ close }) => (
+        <div style={{ padding: "var(--sp-3)", display: "flex", flexDirection: "column", gap: "var(--sp-3)" }}>
+          {degraded.map((s) => (
+            <DegradedAgentSection
+              key={s.agentId}
+              status={s}
+              health={s.workspaceHealth}
+              name={nameOf(s.agentId)}
+              close={close}
+            />
+          ))}
+        </div>
+      )}
+    </Popover>
+  );
+}
+
+/** Entry counts behind the chip label / popover summary line. */
+function healthCounts(health: WorkspaceHealth): {
+  degradedCount: number;
+  total: number;
+  anyUnreachable: boolean;
+} {
+  const badRepos = health.repos.filter((r) => r.status !== "ok");
+  const treeBad = health.tree.status === "stale" || health.tree.status === "unreachable";
+  // The tree only counts toward the total when this agent has one bound at
+  // all — otherwise "all N repos" would never be reachable for tree-less
+  // agents.
+  const total = health.repos.length + (health.tree.status === "unbound" ? 0 : 1);
+  return {
+    degradedCount: badRepos.length + (treeBad ? 1 : 0),
+    total,
+    anyUnreachable: badRepos.some((r) => r.status === "unreachable") || health.tree.status === "unreachable",
+  };
+}
+
+function chipLabel(degraded: AgentChatStatus[], nameOf: (agentId: string) => string): string {
+  if (degraded.length > 1) return `${degraded.length} agents · workspace degraded`;
+  const s = degraded[0];
+  if (!s?.workspaceHealth) return "workspace degraded";
+  const { degradedCount, total, anyUnreachable } = healthCounts(s.workspaceHealth);
+  // "stale" only when nothing is outright unreachable (frozen mirrors still
+  // exist locally — softer wording for a softer failure).
+  const word = anyUnreachable ? "unreachable" : "stale";
+  const countText =
+    degradedCount === total && total > 1
+      ? `all ${total} repos ${word}`
+      : `${degradedCount} ${degradedCount === 1 ? "repo" : "repos"} ${word}`;
+  return `${nameOf(s.agentId)} · ${countText}`;
+}
+
+/** One agent's block in the popover: degraded rows + guidance + Fix button. */
+function DegradedAgentSection({
+  status,
+  health,
+  name,
+  close,
+}: {
+  status: AgentChatStatus;
+  health: WorkspaceHealth;
+  name: string;
+  close: () => void;
+}) {
+  const navigate = useNavigate();
+  const [busy, setBusy] = useState(false);
+  const hostname = status.clientHostname ?? "this machine";
+  const badRepos = health.repos.filter(
+    (r): r is (typeof health.repos)[number] & { status: "stale" | "unreachable" } => r.status !== "ok",
+  );
+  const treeBad = health.tree.status === "stale" || health.tree.status === "unreachable";
+  const has404 = badRepos.some((r) => r.reasonCode === "git_repo_not_found");
+
+  const onFix = async (): Promise<void> => {
+    setBusy(true);
+    try {
+      // Dedup lives server-side on (purpose, agentId): a second click — or a
+      // teammate's earlier click — lands in the same fix chat, and `reused`
+      // tells us not to re-send the kickoff template.
+      const res = await createMeChat({
+        participantIds: [status.agentId],
+        topic: buildWorkspaceFixTopic(hostname),
+        purpose: { kind: WORKSPACE_FIX_CHAT_PURPOSE, agentId: status.agentId },
+      });
+      if (!res.reused) {
+        await sendChatMessage(res.chatId, buildWorkspaceFixMessage({ health, hostname, locale: navigator.language }), [
+          status.agentId,
+        ]);
+      }
+      close();
+      navigate(`/?c=${encodeURIComponent(res.chatId)}`);
+    } catch (err) {
+      console.error("[degraded-workspace] failed to open fix chat", err);
+      setBusy(false);
+    }
+  };
+
+  return (
+    <section style={{ display: "flex", flexDirection: "column", gap: "var(--sp-2)" }}>
+      <div className="flex items-center" style={{ gap: 8, minWidth: 0 }}>
+        <span className="text-body font-semibold" style={{ color: "var(--fg)" }}>
+          {name}
+        </span>
+        <span className="text-label" style={{ color: "var(--fg-3)", whiteSpace: "nowrap" }}>
+          reported {formatRelative(health.updatedAt)}
+        </span>
+      </div>
+
+      <div style={{ display: "flex", flexDirection: "column", gap: "var(--sp-1_5)" }}>
+        {badRepos.map((repo) => (
+          <DegradedRow
+            key={repo.url}
+            url={repo.url}
+            status={repo.status}
+            reason={workspaceHealthReasonLabel(repo.reasonCode, false)}
+            headCommit={repo.headCommit}
+          />
+        ))}
+        {treeBad && health.tree.repoUrl ? (
+          <DegradedRow
+            url={health.tree.repoUrl}
+            status={health.tree.status === "unreachable" ? "unreachable" : "stale"}
+            reason={workspaceHealthReasonLabel(health.tree.reasonCode, false)}
+            tag="Context Tree"
+          />
+        ) : null}
+      </div>
+
+      <div className="text-label" style={{ color: "var(--fg-3)", display: "flex", flexDirection: "column", gap: 4 }}>
+        {has404 ? (
+          <span>
+            "not found (404)" can mean the repo was deleted/renamed <em>or</em> that the credentials on{" "}
+            <span className="mono">{hostname}</span> lack access — GitHub hides private repos it won't authorize.
+          </span>
+        ) : null}
+        <span>
+          1. Confirm the GitHub account used on <span className="mono">{hostname}</span> has access to the repos above
+          (a team admin can check).
+        </span>
+        <span>
+          2. Fix credentials on <span className="mono">{hostname}</span> — <span className="mono">gh auth login</span>,
+          an SSH key, or a git credential helper — then test with{" "}
+          <span className="mono">git ls-remote &lt;url&gt;</span>.
+        </span>
+        <span>3. The warning clears automatically when the agent's next session starts.</span>
+      </div>
+
+      <div>
+        <button
+          type="button"
+          onClick={() => void onFix()}
+          disabled={busy}
+          className="inline-flex items-center cursor-pointer text-body font-medium"
+          style={{
+            gap: 6,
+            height: 26,
+            padding: "0 var(--sp-2_5)",
+            borderRadius: 999,
+            border: 0,
+            outline: "var(--hairline) solid color-mix(in oklch, var(--state-blocked) 38%, transparent)",
+            outlineOffset: -1,
+            background: "var(--state-blocked-soft)",
+            color: "color-mix(in oklch, var(--state-blocked) 80%, var(--fg))",
+            opacity: busy ? 0.6 : 1,
+          }}
+        >
+          {busy ? "Opening fix chat…" : `Fix with ${name}`}
+        </button>
+      </div>
+    </section>
+  );
+}
+
+/** One degraded repo (or tree) line: mono URL + what state the local copy is in. */
+function DegradedRow({
+  url,
+  status,
+  reason,
+  headCommit,
+  tag,
+}: {
+  url: string;
+  status: "stale" | "unreachable";
+  reason: string;
+  headCommit?: string;
+  tag?: string;
+}) {
+  const detail =
+    status === "unreachable"
+      ? `no local copy — ${reason}`
+      : `frozen at ${headCommit ? headCommit.slice(0, 7) : "last sync"}, won't self-heal — ${reason}`;
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 1, minWidth: 0 }}>
+      <span className="flex items-center" style={{ gap: 6, minWidth: 0 }}>
+        <span
+          className="mono text-label"
+          style={{ color: "var(--fg)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
+        >
+          {url}
+        </span>
+        {tag ? (
+          <span
+            className="text-label"
+            style={{
+              flexShrink: 0,
+              padding: "0 var(--sp-1_5)",
+              borderRadius: 999,
+              background: "var(--state-blocked-soft)",
+              color: "color-mix(in oklch, var(--state-blocked) 80%, var(--fg))",
+            }}
+          >
+            {tag}
+          </span>
+        ) : null}
+      </span>
+      <span className="text-label" style={{ color: "color-mix(in oklch, var(--state-blocked) 70%, var(--fg))" }}>
+        {detail}
+      </span>
+    </div>
+  );
+}
+
+/**
+ * Same DOM as DisconnectChip's PulseDot (solid dot + `ring-pulse` ring),
+ * recoloured to the caution token — shared visual vocabulary, different
+ * severity.
+ */
+function AmberDot() {
+  return (
+    <span
+      aria-hidden="true"
+      style={{ position: "relative", width: 8, height: 8, flexShrink: 0, display: "inline-block" }}
+    >
+      <span
+        style={{
+          position: "absolute",
+          inset: 0,
+          borderRadius: "50%",
+          background: "var(--state-blocked)",
+        }}
+      />
+      <span
+        style={{
+          position: "absolute",
+          inset: -3,
+          borderRadius: "50%",
+          border: "var(--hairline) solid var(--state-blocked)",
+          animation: "ring-pulse 1.8s infinite",
+          opacity: 0.6,
+        }}
+      />
+    </span>
+  );
+}

--- a/packages/web/src/components/layout.tsx
+++ b/packages/web/src/components/layout.tsx
@@ -4,6 +4,7 @@ import { NavLink, Outlet, useLocation } from "react-router";
 import { useWorkspaceViewport } from "../hooks/use-viewport.js";
 import { cn } from "../lib/utils.js";
 import { CommandPalette } from "../pages/workspace/palette/command-palette.js";
+import { DegradedWorkspaceChip } from "./degraded-workspace-chip.js";
 import { DisconnectChip } from "./disconnect-chip.js";
 import { FirstTreeLogo } from "./first-tree-logo.js";
 import { ThemeToggle } from "./ui/theme-toggle.js";
@@ -118,6 +119,7 @@ export function Layout() {
               </span>
             </a>
             <DisconnectChip />
+            <DegradedWorkspaceChip />
           </div>
         )}
 

--- a/packages/web/src/lib/workspace-fix-template.ts
+++ b/packages/web/src/lib/workspace-fix-template.ts
@@ -1,0 +1,111 @@
+import type { WorkspaceHealth, WorkspaceHealthReason } from "@first-tree/shared";
+
+/**
+ * Builders for the degraded-workspace Fix flow (design:
+ * docs/degraded-workspace-design.md 附录 A). The Fix button creates a
+ * dedicated fix chat with the degraded agent and sends this template as the
+ * first message **in the user's own voice** — the agent then walks the user
+ * through repairing local gh/git credentials via the GitHub device flow.
+ *
+ * Language follows the clicking user's browser locale (zh → A.1, else A.2);
+ * the zh template string is user-facing product content, mirrored verbatim
+ * from the design appendix.
+ *
+ * Security constraints are part of the template text itself: device flow
+ * only, no PAT creation/printing/storage, no secrets in chat, no remote
+ * reconfiguration; SSH keys only as a last resort (public key only).
+ */
+
+/** True when the browser locale should get the Chinese template. */
+export function isZhLocale(locale: string): boolean {
+  return locale.toLowerCase().startsWith("zh");
+}
+
+/** Human label for a degraded repo's reason code, per template language. */
+export function workspaceHealthReasonLabel(reason: WorkspaceHealthReason | undefined, zh: boolean): string {
+  switch (reason) {
+    case "git_clone_auth_failed":
+      return zh ? "无法鉴权或凭证失效" : "authentication failed or credentials expired";
+    case "git_repo_not_found":
+      return zh ? "404 不可达" : "not found (404)";
+    case "git_not_installed":
+      return zh ? "git 未安装" : "git is not installed";
+    default:
+      return zh ? "不可达" : "unreachable";
+  }
+}
+
+/**
+ * One template line per degraded entry (`{{repos}}`), tree included as a
+ * sibling row of the source repos (§3.0 — the mechanisms are isomorphic).
+ */
+export function degradedRepoLines(health: WorkspaceHealth, zh: boolean): string[] {
+  const lines: string[] = [];
+  for (const repo of health.repos) {
+    if (repo.status === "ok") continue;
+    lines.push(
+      zh
+        ? `- ${repo.url}（${workspaceHealthReasonLabel(repo.reasonCode, zh)}）`
+        : `- ${repo.url} (${workspaceHealthReasonLabel(repo.reasonCode, zh)})`,
+    );
+  }
+  if ((health.tree.status === "stale" || health.tree.status === "unreachable") && health.tree.repoUrl) {
+    const label = workspaceHealthReasonLabel(health.tree.reasonCode, zh);
+    lines.push(
+      zh ? `- ${health.tree.repoUrl}（Context Tree，${label}）` : `- ${health.tree.repoUrl} (Context Tree, ${label})`,
+    );
+  }
+  return lines;
+}
+
+/** Topic of the dedicated fix chat. */
+export function buildWorkspaceFixTopic(hostname: string): string {
+  return `Fix GitHub access on ${hostname}`;
+}
+
+const ZH_TEMPLATE = `我的 agent 工作区提示有团队仓库在这台机器（{{hostname}}）上无法访问，原因是本地 GitHub 凭证缺失或失效。请你在这个对话里一步步帮我修好本地的 gh 和 git 凭证。涉及的仓库：
+
+{{repos}}
+
+请按下面流程做，需要我配合的地方直接在对话里告诉我：
+
+1. 先体检再动手：检查 \`gh --version\`、\`gh auth status\`、\`git config --global credential.helper\` 的现状，把发现告诉我。如果 gh 已经登录了对上述仓库有权限的账号，直接跳到第 5 步验证。
+2. 安装 gh（如缺失）：按本机操作系统选择安装方式（macOS 用 Homebrew；Debian/Ubuntu 用官方 apt 源；其他按 gh 官方文档）。如果你没有安装权限，把需要我自己执行的命令原样发给我。
+3. 用 device flow 登录（绝对不要让我在对话里粘贴任何 token 或密码）：
+   - 注意你的 shell 没有交互式 TTY，直接跑 \`gh auth login\` 会失败。用伪终端把它放到后台跑并把输出写进日志文件，例如借助 \`script\` 命令并预先用管道喂一个回车，然后从日志文件里读出一次性配对码（形如 XXXX-XXXX）。
+   - 把配对码和地址 https://github.com/login/device 发给我，提醒我用「对上述仓库有访问权限的那个 GitHub 账号」登录并输入配对码。
+   - 发完就结束这一轮，等我回复"好了"再继续，不要空转等待。配对码约 15 分钟过期，过期就重新发起一次并给我新码。
+   - 我回复后用 \`gh auth status\` 确认登录成功。
+4. 接管 git 凭证：执行 \`gh auth setup-git\`，让普通 git 命令通过 gh 走 HTTPS 凭证。
+5. 逐个验证：对上面每个仓库跑 \`git ls-remote <HTTPS 形式的 url>\`，告诉我哪些通了。仍不通的，帮我区分两种情况：我的账号没有权限（我需要找团队管理员开权限），还是仓库已被删除/改名（我需要去改 agent 的仓库配置）。
+6. 收尾：全部通过后告诉我修复完成，工作区的警告会在下一个会话开始时自动消失。
+
+约束：全程优先 device flow；不要创建、打印或保存任何 personal access token；任何密钥不得出现在这个对话里；不要改动工作区里任何仓库的 remote 配置。只有当 HTTPS 在这台机器上确实走不通时，才退而求其次引导我配置 SSH key（用 ssh-keygen 生成，把公钥加到我的 GitHub 账号——只有公钥可以出现在对话里）。`;
+
+const EN_TEMPLATE = `My agent workspace reports that some team repositories are unreachable from this machine ({{hostname}}) because local GitHub credentials are missing or no longer valid. Please fix the local gh and git credentials with me, step by step, right here in this chat. Affected repositories:
+
+{{repos}}
+
+Follow this flow, and tell me directly in chat whenever you need me to act:
+
+1. Diagnose before changing anything: check \`gh --version\`, \`gh auth status\`, and \`git config --global credential.helper\`, and report what you find. If gh is already logged in to an account that can access the repos above, skip straight to step 5.
+2. Install gh if missing, using the right method for this OS (Homebrew on macOS; the official apt repo on Debian/Ubuntu; otherwise per the official gh docs). If you lack permission to install, send me the exact commands to run myself.
+3. Log in via the device flow (never ask me to paste a token or password into this chat):
+   - Note your shell has no interactive TTY, so a bare \`gh auth login\` will fail. Run it in the background under a pseudo-TTY (e.g. via the \`script\` command, piping a newline in advance) with output redirected to a log file, then extract the one-time code (XXXX-XXXX) from the log.
+   - Send me the code and https://github.com/login/device, reminding me to sign in with the GitHub account that actually has access to the repos above.
+   - Then end your turn and wait for me to reply "done" — do not busy-wait. The code expires in ~15 minutes; if it does, start a fresh attempt and send me the new code.
+   - After I reply, confirm with \`gh auth status\`.
+4. Take over git credentials: run \`gh auth setup-git\` so plain git uses gh over HTTPS.
+5. Verify each repository above with \`git ls-remote <HTTPS url>\` and tell me which are now reachable. For any that still fail, help me distinguish: my account lacks access (I need to ask a team admin) vs. the repo was deleted/renamed (I need to fix the agent's repo config).
+6. Wrap up: once everything passes, tell me the fix is complete and that the workspace warning will clear automatically when the next session starts.
+
+Constraints: prefer the device flow throughout; do not create, print, or store any personal access token; no secret may ever appear in this chat; do not modify any repository's remote configuration in the workspace. Only if HTTPS genuinely cannot work on this machine, fall back to guiding me through SSH key setup (ssh-keygen, then add the public key to my GitHub account — only the public key may appear in chat).`;
+
+/** First message of the fix chat, in the clicking user's voice and locale. */
+export function buildWorkspaceFixMessage(opts: { health: WorkspaceHealth; hostname: string; locale: string }): string {
+  const zh = isZhLocale(opts.locale);
+  const template = zh ? ZH_TEMPLATE : EN_TEMPLATE;
+  return template
+    .replace("{{hostname}}", opts.hostname)
+    .replace("{{repos}}", degradedRepoLines(opts.health, zh).join("\n"));
+}


### PR DESCRIPTION
## Summary
- **Client**: when session-start preparation of a predeclared source repo or the Context Tree hits a permission-shaped failure (`git_clone_auth_failed`, `git_repo_not_found`, `git_not_installed`), the runtime skips that checkout and starts the session anyway instead of failing the agent. Per-checkout outcomes are graded `ok` / `stale` (existing clone frozen at its commit) / `unreachable` (no local copy); the tree adds `unbound`. Degradation surfaces as warning blocks in the agent briefing, and the slot sends a `workspace:health` WS frame after bootstrap. Transient network failures keep the existing retry/fail behavior (`Proxy CONNECT aborted` added to the transient set). Error previews pass through client-side redaction before leaving the host.
- **Server**: handles the `workspace:health` frame into a new `agent_presence.workspace_health` JSONB column (latest-wins, server-stamped `updatedAt`, kept readable while offline — migration 0062). The value is descriptive only: it is exposed on chat agent statuses (`workspaceHealth` + `clientHostname`) but never feeds `main`-status derivation. `createMeChat` gains an optional `purpose` tag with purpose-scoped dedup so repeated Fix clicks reuse the existing fix chat.
- **Web**: amber "degraded workspace" topbar chip (sibling of the disconnect chip, yields to it for unreachable agents) with a per-agent popover breakdown, repair guidance, and a one-click **Fix** that opens a dedicated repair chat seeded with a zh/en `gh` device-flow template (no tokens minted, printed, or stored; remotes untouched).

Design doc: `docs/degraded-workspace-design.md` (workspace docs, v5 + implementation addenda). Context Tree PR: agent-team-foundation/first-tree-context#496.

## Test plan
- [x] `pnpm check` (2 pre-existing warnings only) and `pnpm typecheck` green across all packages
- [x] `pnpm test` green: client 1219/1219, server 1386/1386
- [ ] Staging e2e (both runtimes, claude-code + codex): break host git credentials → agent still starts, briefing carries the warning, chip + popover render, Fix opens the deduplicated fix chat, device-flow repair works, next session self-heals

🤖 Generated with [Claude Code](https://claude.com/claude-code)