### PR TITLE
fix(web): wrap unbreakable long runs in chat markdown instead of overflowing

### DIFF
--- a/packages/web/src/components/__tests__/markdown-overflow-wrap.test.tsx
+++ b/packages/web/src/components/__tests__/markdown-overflow-wrap.test.tsx
@@ -1,0 +1,43 @@
+// @vitest-environment happy-dom
+
+import { act, type ReactElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Markdown } from "../ui/markdown.js";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+function renderMarkdown(markdown: string): void {
+  act(() => root.render((<Markdown>{markdown}</Markdown>) as ReactElement));
+}
+
+/**
+ * Regression: a chat message carrying one unbreakable run (a bare login URL
+ * with two embedded JWTs, ~620 chars) widened the chat timeline and put a
+ * horizontal scrollbar on the whole message stream. The prose wrapper must
+ * carry `break-words` (overflow-wrap: break-word) so such runs wrap instead
+ * of overflowing. happy-dom does no layout, so the class on the wrapper is
+ * the testable contract.
+ */
+describe("Markdown long-token wrapping", () => {
+  it("keeps break-words on the prose wrapper", () => {
+    renderMarkdown(`http://localhost:5179/auth/github/complete#access=${"eyJx".repeat(150)}`);
+    const wrapper = container.querySelector(".prose");
+    expect(wrapper).not.toBeNull();
+    expect(wrapper?.className).toContain("break-words");
+  });
+});

--- a/packages/web/src/components/ui/markdown.tsx
+++ b/packages/web/src/components/ui/markdown.tsx
@@ -27,7 +27,13 @@ export function Markdown({ children, className, components, rehypePlugins }: Mar
   return (
     <div
       className={cn(
-        "prose prose-sm max-w-none leading-[1.55] text-[color:inherit]",
+        // `break-words` lets unbreakable runs (bare URLs with embedded
+        // tokens, long file paths) wrap instead of widening the chat
+        // column — an overflowing message otherwise puts a horizontal
+        // scrollbar on the whole timeline, because the scroll container's
+        // `overflow-y: auto` makes the browser compute `overflow-x` as
+        // `auto` too.
+        "prose prose-sm max-w-none break-words leading-[1.55] text-[color:inherit]",
         "prose-headings:text-current prose-p:text-current prose-li:text-current prose-strong:text-current prose-em:text-current prose-blockquote:text-current",
         "prose-p:my-2 prose-headings:mt-3 prose-headings:mb-1.5 prose-ul:my-2 prose-ol:my-2 prose-li:my-0.5 prose-pre:my-2 prose-blockquote:my-2 prose-hr:my-3",
         "prose-a:text-[color:var(--primary)] prose-a:no-underline hover:prose-a:underline",


### PR DESCRIPTION
## Problem

A horizontal scrollbar appeared at the bottom of the chat timeline (middle livestream column).

Root cause, verified live against the affected chat:

1. One message contained a bare login URL with two embedded JWTs — a single **~620-char unbreakable run**. The `Markdown` prose wrapper sets no `overflow-wrap`, so the browser cannot break inside the run and the paragraph overflows the message column (`<p>` measured 2473px wide in an 852px column).
2. The timeline scroll container only sets `overflow-y-auto`. Per CSS, when one overflow axis is non-`visible` the other computes `visible` → `auto`, so the container's `overflow-x` is effectively `auto` and the overflow surfaces as a horizontal scrollbar on the whole stream.

The whole rendered page had exactly one overflowing chain — that paragraph; tables/`pre`/composer/token-usage rows were all measured and ruled out (typography's `pre` keeps its own internal `overflow-x: auto`, so fenced code blocks never widen the column).

## Fix

Add `break-words` to the `Markdown` prose wrapper so unbreakable runs (bare URLs, tokens, long paths) wrap within the message column. One class; applies to every `Markdown` call site.

`break-words` (`overflow-wrap: break-word`) is preferred over `overflow-wrap: anywhere`: identical wrapping behavior in width-constrained columns, but it does not change min-content intrinsic sizing, so shrink-to-fit consumers of `Markdown` (popovers, hover cards) keep their natural width.

## Verification

- Live A/B in the affected chat: scroll container `scrollWidth` 2541 → 960 (= `clientWidth`) with the rule applied; horizontal scrollbar gone. Toggling the rule reproduces/clears the bug.
- Both `break-word` and `anywhere` were measured against the real 617-char URL in an isolated repro; both fully eliminate the overflow.
- `pnpm check` / `pnpm typecheck` green; web suite 787/787 passed, including a new regression test pinning `break-words` on the prose wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)