### PR TITLE
feat(client,server): detect Context Tree writes from git status

### DIFF
--- a/packages/client/src/__tests__/claude-code-tool-events.test.ts
+++ b/packages/client/src/__tests__/claude-code-tool-events.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import type { SessionEvent } from "@first-tree/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createToolCallProcessor, treeNodePathOf } from "../handlers/claude-code.js";
+import type { ContextTreeGitWriteTracker } from "../runtime/context-tree-git-status.js";
 
 /**
  * S11 (NC2 client handler) — tool-call processor fixtures.
@@ -438,6 +439,55 @@ describe("createToolCallProcessor — Context Tree file refs", () => {
     expect(usageEventCount(emit)).toBe(0);
   });
 
+  it("adds git status delta refs to successful tool calls", () => {
+    const emit = vi.fn<(event: SessionEvent) => void>();
+    const gitWriteTracker: ContextTreeGitWriteTracker = {
+      captureBaseline: vi.fn(),
+      refsForSuccessfulToolCall: vi.fn(() => [
+        {
+          origin: "git_status_delta" as const,
+          localPath: `${TREE}/NODE.md`,
+          repoUrl: "https://github.com/example/tree",
+          repoRelativePath: "NODE.md",
+          pathKind: "file" as const,
+          metadata: {
+            gitStatus: " M",
+            toolName: "Bash",
+            toolUseId: "r7-write",
+          },
+        },
+      ]),
+    };
+    const processor = createToolCallProcessor(emit, binding, { cwd: "/home/op/project", gitWriteTracker });
+
+    processor.onMessage(assistantToolUse("r7-write", "Bash", { command: `cat <<'EOF' > ${TREE}/NODE.md\nx\nEOF` }));
+    processor.onMessage(userToolResult("r7-write", "wrote"));
+
+    expect(gitWriteTracker.captureBaseline).toHaveBeenCalledTimes(1);
+    expect(gitWriteTracker.refsForSuccessfulToolCall).toHaveBeenCalledWith({
+      toolName: "Bash",
+      toolUseId: "r7-write",
+      existingRefs: [],
+    });
+    const final = toolCallEvents(emit).find(
+      (event) => event.payload.toolUseId === "r7-write" && event.payload.status === "ok",
+    );
+    expect(final?.payload.toolFileRefs).toEqual([
+      {
+        origin: "git_status_delta",
+        localPath: `${TREE}/NODE.md`,
+        repoUrl: "https://github.com/example/tree",
+        repoRelativePath: "NODE.md",
+        pathKind: "file",
+        metadata: {
+          gitStatus: " M",
+          toolName: "Bash",
+          toolUseId: "r7-write",
+        },
+      },
+    ]);
+  });
+
   it("does NOT attach Bash file refs when the shell command fails", () => {
     const emit = vi.fn<(event: SessionEvent) => void>();
     const processor = createToolCallProcessor(emit, binding, { cwd: "/home/op/project" });
@@ -450,6 +500,25 @@ describe("createToolCallProcessor — Context Tree file refs", () => {
     );
     expect(final?.payload.toolFileRefs).toBeUndefined();
     expect(usageEventCount(emit)).toBe(0);
+  });
+
+  it("advances git status baseline without refs when a tool call fails", () => {
+    const emit = vi.fn<(event: SessionEvent) => void>();
+    const gitWriteTracker: ContextTreeGitWriteTracker = {
+      captureBaseline: vi.fn(),
+      refsForSuccessfulToolCall: vi.fn(() => []),
+    };
+    const processor = createToolCallProcessor(emit, binding, { cwd: "/home/op/project", gitWriteTracker });
+
+    processor.onMessage(assistantToolUse("r7-failed-write", "Bash", { command: `echo x > ${TREE}/NODE.md` }));
+    processor.onMessage(userToolResult("r7-failed-write", "failed", true));
+
+    expect(gitWriteTracker.captureBaseline).toHaveBeenCalledTimes(2);
+    expect(gitWriteTracker.refsForSuccessfulToolCall).not.toHaveBeenCalled();
+    const final = toolCallEvents(emit).find(
+      (event) => event.payload.toolUseId === "r7-failed-write" && event.payload.status === "error",
+    );
+    expect(final?.payload.toolFileRefs).toBeUndefined();
   });
 
   it("does NOT attach file refs for unsupported tools even if an arg path is under the tree", () => {

--- a/packages/client/src/__tests__/codex-context-tree-io.test.ts
+++ b/packages/client/src/__tests__/codex-context-tree-io.test.ts
@@ -2,7 +2,12 @@ import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { collectCodexFileChangePaths, toolFileRefsFromCodexFileChange } from "../handlers/codex.js";
+import {
+  appendGitStatusDeltaRefs,
+  collectCodexFileChangePaths,
+  toolFileRefsForTerminalCodexTool,
+  toolFileRefsFromCodexFileChange,
+} from "../handlers/codex.js";
 import { toolFileRefsFromShellCommand } from "../runtime/context-tree-file-refs.js";
 
 describe("Codex Context Tree file refs", () => {
@@ -133,6 +138,74 @@ describe("Codex Context Tree file refs", () => {
     expect(toolFileRefsFromShellCommand({ ...base, command: "cat /home/op/context-tree-sibling/NODE.md" })).toEqual([]);
     expect(toolFileRefsFromShellCommand({ ...base, command: "cat /home/op/context-tree/NODE.md | head" })).toEqual([]);
     expect(toolFileRefsFromShellCommand({ ...base, command: "echo x > /home/op/context-tree/NODE.md" })).toEqual([]);
+  });
+
+  it("appends git status delta refs after ordinary Codex refs", () => {
+    const existingRefs = [
+      {
+        origin: "file_change" as const,
+        localPath: "/home/op/context-tree/NODE.md",
+        repoUrl: "https://github.com/acme/first-tree-context.git",
+        repoRelativePath: "NODE.md",
+        pathKind: "file" as const,
+      },
+    ];
+    const gitWriteTracker = {
+      captureBaseline() {},
+      refsForSuccessfulToolCall(input: { existingRefs?: readonly unknown[] }) {
+        expect(input.existingRefs).toEqual(existingRefs);
+        return [
+          {
+            origin: "git_status_delta" as const,
+            localPath: "/home/op/context-tree/domains/new.md",
+            repoUrl: "https://github.com/acme/first-tree-context.git",
+            repoRelativePath: "domains/new.md",
+            pathKind: "file" as const,
+          },
+        ];
+      },
+    };
+
+    expect(
+      appendGitStatusDeltaRefs({
+        existingRefs,
+        gitWriteTracker,
+        toolName: "file_change",
+        toolUseId: "fc-1",
+      }),
+    ).toEqual([
+      ...existingRefs,
+      {
+        origin: "git_status_delta",
+        localPath: "/home/op/context-tree/domains/new.md",
+        repoUrl: "https://github.com/acme/first-tree-context.git",
+        repoRelativePath: "domains/new.md",
+        pathKind: "file",
+      },
+    ]);
+  });
+
+  it("advances git status baseline without refs for failed Codex tools", () => {
+    let baselineCaptures = 0;
+    const gitWriteTracker = {
+      captureBaseline() {
+        baselineCaptures += 1;
+      },
+      refsForSuccessfulToolCall() {
+        throw new Error("failed tools must not emit git status refs");
+      },
+    };
+
+    expect(
+      toolFileRefsForTerminalCodexTool({
+        status: "error",
+        existingRefs: [],
+        gitWriteTracker,
+        toolName: "command",
+        toolUseId: "cmd-failed",
+      }),
+    ).toBeUndefined();
+    expect(baselineCaptures).toBe(1);
   });
 });
 

--- a/packages/client/src/__tests__/context-tree-git-status.test.ts
+++ b/packages/client/src/__tests__/context-tree-git-status.test.ts
@@ -1,0 +1,104 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createContextTreeGitWriteTracker } from "../runtime/context-tree-git-status.js";
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync("git", args, { cwd, encoding: "utf8" });
+}
+
+describe("createContextTreeGitWriteTracker", () => {
+  let root: string;
+  let tree: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "first-tree-git-status-"));
+    tree = join(root, "tree");
+    mkdirSync(join(tree, "domains"), { recursive: true });
+    git(root, "init", "tree");
+    git(tree, "config", "user.email", "agent@example.com");
+    git(tree, "config", "user.name", "Agent");
+    writeFileSync(join(tree, "NODE.md"), "root\n");
+    git(tree, "add", ".");
+    git(tree, "commit", "-m", "initial");
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("emits git status delta refs for newly dirty tree paths once", () => {
+    const tracker = createContextTreeGitWriteTracker({
+      contextTreePath: tree,
+      contextTreeRepoUrl: "https://github.com/acme/first-tree-context.git",
+      contextTreeBranch: "main",
+    });
+
+    writeFileSync(join(tree, "NODE.md"), "updated\n");
+    writeFileSync(join(tree, "domains", "new.md"), "new\n");
+
+    const refs = tracker.refsForSuccessfulToolCall({
+      toolName: "Bash",
+      toolUseId: "tu-shell-write",
+      existingRefs: [],
+    });
+
+    expect(refs).toEqual([
+      {
+        origin: "git_status_delta",
+        localPath: join(tree, "NODE.md"),
+        repoUrl: "https://github.com/acme/first-tree-context.git",
+        repoBranch: "main",
+        repoRelativePath: "NODE.md",
+        pathKind: "file",
+        metadata: {
+          gitStatus: " M",
+          toolName: "Bash",
+          toolUseId: "tu-shell-write",
+        },
+      },
+      {
+        origin: "git_status_delta",
+        localPath: join(tree, "domains", "new.md"),
+        repoUrl: "https://github.com/acme/first-tree-context.git",
+        repoBranch: "main",
+        repoRelativePath: "domains/new.md",
+        pathKind: "file",
+        metadata: {
+          gitStatus: "??",
+          toolName: "Bash",
+          toolUseId: "tu-shell-write",
+        },
+      },
+    ]);
+
+    expect(
+      tracker.refsForSuccessfulToolCall({
+        toolName: "Bash",
+        toolUseId: "tu-shell-write-again",
+        existingRefs: [],
+      }),
+    ).toEqual([]);
+  });
+
+  it("does not reassign paths that are absorbed into the baseline after a failed tool", () => {
+    const tracker = createContextTreeGitWriteTracker({
+      contextTreePath: tree,
+      contextTreeRepoUrl: "https://github.com/acme/first-tree-context.git",
+      contextTreeBranch: "main",
+    });
+
+    writeFileSync(join(tree, "NODE.md"), "failed write\n");
+    tracker.captureBaseline();
+
+    expect(
+      tracker.refsForSuccessfulToolCall({
+        toolName: "Bash",
+        toolUseId: "tu-next-success",
+        existingRefs: [],
+      }),
+    ).toEqual([]);
+  });
+});

--- a/packages/client/src/handlers/claude-code-tui/index.ts
+++ b/packages/client/src/handlers/claude-code-tui/index.ts
@@ -7,6 +7,7 @@ import { buildAgentBriefing } from "../../runtime/agent-briefing.js";
 import type { AgentConfigCache } from "../../runtime/agent-config-cache.js";
 import type { PredeclaredSourceRepo } from "../../runtime/bootstrap.js";
 import { type ChatContext, fetchChatContext } from "../../runtime/chat-context.js";
+import { createContextTreeGitWriteTracker } from "../../runtime/context-tree-git-status.js";
 import type { GitMirrorManager } from "../../runtime/git-mirror-manager.js";
 import type { AgentHandler, HandlerFactory, SessionContext, SessionMessage } from "../../runtime/handler.js";
 import {
@@ -304,7 +305,15 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
       turnProcessor = createToolCallProcessor(
         (event) => sessionCtx.emitEvent(event),
         contextTreePath ? { path: contextTreePath, repoUrl: contextTreeRepoUrl, branch: contextTreeBranch } : undefined,
-        { cwd },
+        {
+          cwd,
+          gitWriteTracker: createContextTreeGitWriteTracker({
+            contextTreePath,
+            contextTreeRepoUrl,
+            contextTreeBranch,
+            log: (message) => sessionCtx.log(message),
+          }),
+        },
       );
     }
     return turnProcessor;

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -27,6 +27,10 @@ import {
   contextTreeRelativePathOf,
   toolFileRefsFromShellCommand,
 } from "../runtime/context-tree-file-refs.js";
+import {
+  type ContextTreeGitWriteTracker,
+  createContextTreeGitWriteTracker,
+} from "../runtime/context-tree-git-status.js";
 import { classify } from "../runtime/error-taxonomy.js";
 import type { GitMirrorManager } from "../runtime/git-mirror-manager.js";
 import type { AgentHandler, HandlerFactory, SessionContext, SessionMessage } from "../runtime/handler.js";
@@ -484,7 +488,7 @@ export type ToolCallProcessor = {
 export function createToolCallProcessor(
   emit: (event: SessionEvent) => void,
   contextTree?: ContextTreeBinding,
-  options: { cwd?: string | null } = {},
+  options: { cwd?: string | null; gitWriteTracker?: ContextTreeGitWriteTracker } = {},
 ): ToolCallProcessor {
   type Pending = { toolUseId: string; name: string; args: unknown; startedAt: number };
   const pending = new Map<string, Pending>();
@@ -496,7 +500,17 @@ export function createToolCallProcessor(
     const durationMs = Date.now() - entry.startedAt;
     const previewRaw = extractToolResultText(block.content);
     const resultPreview = previewRaw.length > 0 ? previewRaw.slice(0, TOOL_RESULT_PREVIEW_LIMIT) : undefined;
+    if (status === "error") options.gitWriteTracker?.captureBaseline();
     const refs = status === "ok" ? toolFileRefs(entry.name, entry.args, contextTree, options.cwd) : [];
+    const gitStatusRefs =
+      status === "ok"
+        ? (options.gitWriteTracker?.refsForSuccessfulToolCall({
+            toolName: entry.name,
+            toolUseId: entry.toolUseId,
+            existingRefs: refs,
+          }) ?? [])
+        : [];
+    const allRefs = [...refs, ...gitStatusRefs];
 
     emit({
       kind: "tool_call",
@@ -507,7 +521,7 @@ export function createToolCallProcessor(
         status,
         durationMs,
         ...(resultPreview !== undefined ? { resultPreview } : {}),
-        ...(refs.length > 0 ? { toolFileRefs: refs } : {}),
+        ...(allRefs.length > 0 ? { toolFileRefs: allRefs } : {}),
       },
     });
 
@@ -521,6 +535,7 @@ export function createToolCallProcessor(
       if (type === "assistant") {
         for (const block of extractContentBlocks(message)) {
           if (isToolUseBlock(block)) {
+            options.gitWriteTracker?.captureBaseline();
             pending.set(block.id, {
               toolUseId: block.id,
               name: block.name,
@@ -1143,7 +1158,15 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
         repoUrl: contextTreeRepoUrl,
         branch: contextTreeBranch,
       },
-      { cwd },
+      {
+        cwd,
+        gitWriteTracker: createContextTreeGitWriteTracker({
+          contextTreePath,
+          contextTreeRepoUrl,
+          contextTreeBranch,
+          log: (message) => sessionCtx.log(message),
+        }),
+      },
     );
     // Auth-failure hint emission flag. Set when we detect a typed
     // `authentication_failed` on assistant / auth_status messages. Consulted

--- a/packages/client/src/handlers/codex.ts
+++ b/packages/client/src/handlers/codex.ts
@@ -12,6 +12,10 @@ import type { AgentConfigCache } from "../runtime/agent-config-cache.js";
 import { FIRST_TREE_WORKSPACE_MARKER, type PredeclaredSourceRepo } from "../runtime/bootstrap.js";
 import { type ChatContext, fetchChatContext } from "../runtime/chat-context.js";
 import { contextTreeRelativePathOf, toolFileRefsFromShellCommand } from "../runtime/context-tree-file-refs.js";
+import {
+  type ContextTreeGitWriteTracker,
+  createContextTreeGitWriteTracker,
+} from "../runtime/context-tree-git-status.js";
 import { resolveGitRepoTargetPath } from "../runtime/git-local-path.js";
 import type { GitMirrorManager } from "../runtime/git-mirror-manager.js";
 import type {
@@ -423,6 +427,37 @@ export function toolFileRefsFromCodexFileChange(input: {
   return refs;
 }
 
+export function appendGitStatusDeltaRefs(input: {
+  existingRefs?: readonly ToolFileRef[];
+  gitWriteTracker?: ContextTreeGitWriteTracker | null;
+  toolName: string;
+  toolUseId: string;
+}): ToolFileRef[] | undefined {
+  const existingRefs = [...(input.existingRefs ?? [])];
+  const gitStatusRefs =
+    input.gitWriteTracker?.refsForSuccessfulToolCall({
+      toolName: input.toolName,
+      toolUseId: input.toolUseId,
+      existingRefs,
+    }) ?? [];
+  const refs = [...existingRefs, ...gitStatusRefs];
+  return refs.length > 0 ? refs : undefined;
+}
+
+export function toolFileRefsForTerminalCodexTool(input: {
+  status: "ok" | "error" | "pending";
+  existingRefs?: readonly ToolFileRef[];
+  gitWriteTracker?: ContextTreeGitWriteTracker | null;
+  toolName: string;
+  toolUseId: string;
+}): ToolFileRef[] | undefined {
+  if (input.status !== "ok") {
+    if (input.status === "error") input.gitWriteTracker?.captureBaseline();
+    return undefined;
+  }
+  return appendGitStatusDeltaRefs(input);
+}
+
 /**
  * Codex Handler — session-oriented handler using `@openai/codex-sdk`.
  *
@@ -471,6 +506,12 @@ export const createCodexHandler: HandlerFactory = (config) => {
   let currentAbort: AbortController | null = null;
   let currentTurnPromise: Promise<void> | null = null;
   let ctx: SessionContext | null = null;
+  const gitWriteTracker = createContextTreeGitWriteTracker({
+    contextTreePath,
+    contextTreeRepoUrl,
+    contextTreeBranch,
+    log: (message) => ctx?.log(message),
+  });
   let drainScheduled = false;
   let drainInProgress = false;
   const queuedMessages: SessionMessage[] = [];
@@ -635,7 +676,7 @@ export const createCodexHandler: HandlerFactory = (config) => {
             : item.status === "failed"
               ? ("error" as const)
               : ("pending" as const);
-        const toolFileRefs =
+        const shellRefs =
           status === "ok" && cwd
             ? toolFileRefsFromShellCommand({
                 command: item.command,
@@ -645,6 +686,13 @@ export const createCodexHandler: HandlerFactory = (config) => {
                 contextTreeBranch,
               })
             : undefined;
+        const toolFileRefs = toolFileRefsForTerminalCodexTool({
+          status,
+          existingRefs: shellRefs,
+          gitWriteTracker,
+          toolName: "command",
+          toolUseId: item.id,
+        });
         emitToolCall(sessionCtx, {
           toolUseId: item.id,
           name: "command",
@@ -657,7 +705,7 @@ export const createCodexHandler: HandlerFactory = (config) => {
       }
       case "file_change": {
         const status = item.status === "completed" ? ("ok" as const) : ("error" as const);
-        const toolFileRefs =
+        const fileChangeRefs =
           status === "ok" && cwd
             ? toolFileRefsFromCodexFileChange({
                 changes: item.changes,
@@ -667,6 +715,13 @@ export const createCodexHandler: HandlerFactory = (config) => {
                 contextTreeBranch,
               })
             : undefined;
+        const toolFileRefs = toolFileRefsForTerminalCodexTool({
+          status,
+          existingRefs: fileChangeRefs,
+          gitWriteTracker,
+          toolName: "file_change",
+          toolUseId: item.id,
+        });
         emitToolCall(sessionCtx, {
           toolUseId: item.id,
           name: "file_change",
@@ -757,6 +812,7 @@ export const createCodexHandler: HandlerFactory = (config) => {
     sessionCtx.markMessagesConsumed(messages);
     const abort = new AbortController();
     currentAbort = abort;
+    gitWriteTracker.captureBaseline();
 
     // Emit exactly one `turn_end` per turn, after `forwardResult` resolves —
     // mirrors claude-code so admin events + completion bookkeeping reflect

--- a/packages/client/src/runtime/context-tree-git-status.ts
+++ b/packages/client/src/runtime/context-tree-git-status.ts
@@ -1,0 +1,114 @@
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+import type { ToolFileRef } from "@first-tree/shared";
+
+const GIT_STATUS_TIMEOUT_MS = 2_000;
+const GIT_STATUS_MAX_BUFFER_BYTES = 10 * 1024 * 1024;
+
+export type ContextTreeGitWriteTracker = {
+  captureBaseline(): void;
+  refsForSuccessfulToolCall(input: {
+    toolName: string;
+    toolUseId: string;
+    existingRefs?: readonly ToolFileRef[];
+  }): ToolFileRef[];
+};
+
+type DirtyPath = {
+  path: string;
+  status: string;
+};
+
+type TrackerOptions = {
+  contextTreePath: string | null;
+  contextTreeRepoUrl: string | null;
+  contextTreeBranch?: string | null;
+  log?: (message: string) => void;
+};
+
+function gitStatus(contextTreePath: string): DirtyPath[] | null {
+  try {
+    const raw = execFileSync(
+      "git",
+      ["-C", contextTreePath, "status", "--porcelain=v1", "-z", "--untracked-files=all"],
+      {
+        maxBuffer: GIT_STATUS_MAX_BUFFER_BYTES,
+        timeout: GIT_STATUS_TIMEOUT_MS,
+      },
+    );
+    const entries = raw.toString("utf8").split("\0");
+    const paths: DirtyPath[] = [];
+    for (let index = 0; index < entries.length; index++) {
+      const entry = entries[index];
+      if (!entry) continue;
+      const status = entry.slice(0, 2);
+      const path = entry.slice(3);
+      if (!path) continue;
+      paths.push({ path, status });
+      if (status[0] === "R" || status[0] === "C") index += 1;
+    }
+    return paths.sort((left, right) => (left.path < right.path ? -1 : left.path > right.path ? 1 : 0));
+  } catch {
+    return null;
+  }
+}
+
+function pathSet(paths: readonly DirtyPath[]): Set<string> {
+  return new Set(paths.map((path) => path.path));
+}
+
+export function createContextTreeGitWriteTracker(options: TrackerOptions): ContextTreeGitWriteTracker {
+  let baseline: DirtyPath[] | null = null;
+
+  function captureBaseline(): void {
+    baseline = options.contextTreePath ? gitStatus(options.contextTreePath) : null;
+    if (baseline === null && options.contextTreePath) {
+      options.log?.("Context Tree git write tracker disabled: git status baseline failed");
+    }
+  }
+
+  captureBaseline();
+
+  return {
+    captureBaseline,
+    refsForSuccessfulToolCall(input): ToolFileRef[] {
+      const contextTreePath = options.contextTreePath;
+      const contextTreeRepoUrl = options.contextTreeRepoUrl;
+      if (!contextTreePath || !contextTreeRepoUrl || baseline === null) return [];
+
+      const current = gitStatus(contextTreePath);
+      if (current === null) {
+        options.log?.("Context Tree git write tracker skipped: git status check failed");
+        baseline = null;
+        return [];
+      }
+
+      const baselinePaths = pathSet(baseline);
+      const existingPaths = new Set(
+        (input.existingRefs ?? [])
+          .map((ref) => ref.repoRelativePath)
+          .filter((path): path is string => typeof path === "string" && path.length > 0),
+      );
+      const refs = current
+        .filter((dirty) => !baselinePaths.has(dirty.path) && !existingPaths.has(dirty.path))
+        .map(
+          (dirty): ToolFileRef => ({
+            origin: "git_status_delta",
+            localPath: join(contextTreePath, dirty.path),
+            repoUrl: contextTreeRepoUrl,
+            ...(options.contextTreeBranch ? { repoBranch: options.contextTreeBranch } : {}),
+            repoRelativePath: dirty.path,
+            pathKind: "file",
+            metadata: {
+              gitStatus: dirty.status,
+              toolName: input.toolName,
+              toolUseId: input.toolUseId,
+            },
+          }),
+        );
+
+      baseline = current;
+      return refs;
+    },
+  };
+}

--- a/packages/server/src/__tests__/context-tree-io.test.ts
+++ b/packages/server/src/__tests__/context-tree-io.test.ts
@@ -670,4 +670,70 @@ describe("context-tree IO service", () => {
     const io = await summarizeContextTreeIo(app.db, seed.organizationId, 7);
     expect(io.skipped).toEqual(skipped);
   });
+
+  it("records git status delta refs as synthetic writes for unsupported shell commands", async () => {
+    const app = getApp();
+    const seed = await seedContextTreeChat();
+
+    const shellWrite = await appendEvent(app.db, seed.agent.uuid, seed.chatId, {
+      kind: "tool_call",
+      payload: {
+        toolUseId: "tu-shell-write",
+        name: "Bash",
+        args: { command: "cat <<'EOF' > context-tree/NODE.md\nupdated\nEOF" },
+        status: "ok",
+        toolFileRefs: [
+          {
+            origin: "git_status_delta",
+            localPath: "/context-tree/NODE.md",
+            repoUrl: TREE_REPO,
+            repoBranch: "main",
+            repoRelativePath: "NODE.md",
+            pathKind: "file",
+            metadata: {
+              origin: "spoofed_origin",
+              localPath: "/spoofed/NODE.md",
+              toolName: "Bash",
+              toolUseId: "tu-shell-write",
+              gitStatus: " M",
+            },
+          },
+        ],
+      },
+    });
+
+    await recordFromSessionEvent(app.db, {
+      organizationId: seed.organizationId,
+      agentId: seed.agent.uuid,
+      chatId: seed.chatId,
+      runtimeProvider: "claude-code",
+      sessionEvent: shellWrite,
+    });
+
+    const rows = await app.db
+      .select()
+      .from(contextTreeIoEvents)
+      .where(eq(contextTreeIoEvents.sourceSessionEventId, shellWrite.id));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      action: "write",
+      source: "git_status_delta",
+      targetKind: "file",
+      targetPath: "NODE.md",
+      metadata: {
+        origin: "git_status_delta",
+        localPath: "/context-tree/NODE.md",
+        toolName: "Bash",
+        toolUseId: "tu-shell-write",
+        gitStatus: " M",
+      },
+    });
+
+    const summary = await summarizeContextTreeIo(app.db, seed.organizationId, 7);
+    expect(summary.recentEvents[0]).toMatchObject({
+      action: "write",
+      source: "git_status_delta",
+      targetPath: "NODE.md",
+    });
+  });
 });

--- a/packages/server/src/services/context-tree-io.ts
+++ b/packages/server/src/services/context-tree-io.ts
@@ -33,6 +33,8 @@ const CONTEXT_TREE_IO_FEED_LIMIT = 50;
 const CLAUDE_READ_TOOLS = new Set(["Read", "NotebookRead", "Grep", "Glob"]);
 const CLAUDE_WRITE_TOOLS = new Set(["Write", "Edit", "MultiEdit", "NotebookEdit"]);
 const log = createLogger("ContextTreeIo");
+const GIT_STATUS_DELTA_REF_ORIGIN = "git_status_delta";
+const GIT_STATUS_DELTA_DERIVATION: EventIoDerivation = { action: "write", source: "git_status_delta" };
 
 export type ContextTreeIoViewer = {
   humanAgentId: string;
@@ -73,6 +75,7 @@ type NormalizedFileRef = {
 type NormalizedFileRefRecord = {
   normalized: NormalizedFileRef;
   sourceIndex: number;
+  derivation: EventIoDerivation;
 };
 
 export type ContextTreeIoDecision =
@@ -246,6 +249,7 @@ function normalizeFileRef(
       targetKind,
       targetPath,
       metadata: {
+        ...(parsed.data.metadata ?? {}),
         origin: parsed.data.origin,
         ...(parsed.data.localPath ? { localPath: parsed.data.localPath } : {}),
       },
@@ -262,21 +266,27 @@ function buildContextTreeIoDecision(input: {
 }): InternalContextTreeIoDecision {
   if (!input.bindingRepo) return { recordable: false, reason: "no_org_context_tree_binding" };
 
-  const derivation = deriveEventIo(input.event, input.runtimeProvider);
-  if (typeof derivation === "string") return { recordable: false, reason: derivation };
-
   const refs = extractFileRefs(input.event, input.bindingRepo, input.bindingBranch);
+  const hasGitStatusDeltaRef = refs.some(({ ref }) => ref.origin === GIT_STATUS_DELTA_REF_ORIGIN);
+  const derivation = deriveEventIo(input.event, input.runtimeProvider);
+  const baseDerivation = typeof derivation === "string" ? null : derivation;
+  const derivationSkipReason = typeof derivation === "string" ? derivation : null;
+  if (!baseDerivation && !hasGitStatusDeltaRef) {
+    return { recordable: false, reason: derivationSkipReason ?? "unsupported_tool" };
+  }
   if (refs.length === 0) return { recordable: false, reason: "no_tool_file_refs" };
 
   const normalizedRefs: NormalizedFileRefRecord[] = [];
   let firstRejectedReason: ContextTreeIoSkipReason | null = null;
   for (const { ref, sourceIndex } of refs) {
+    const refDerivation = ref.origin === GIT_STATUS_DELTA_REF_ORIGIN ? GIT_STATUS_DELTA_DERIVATION : baseDerivation;
+    if (!refDerivation) continue;
     const normalized = normalizeFileRef(ref, input.bindingRepo, input.bindingBranch);
     if (!normalized.ok) {
       firstRejectedReason ??= normalized.reason;
       continue;
     }
-    normalizedRefs.push({ normalized: normalized.normalized, sourceIndex });
+    normalizedRefs.push({ normalized: normalized.normalized, sourceIndex, derivation: refDerivation });
   }
 
   if (normalizedRefs.length === 0) {
@@ -284,7 +294,7 @@ function buildContextTreeIoDecision(input: {
   }
   if (input.chatInOrg === false) return { recordable: false, reason: "chat_not_in_org" };
 
-  return { recordable: true, derivation, refs: normalizedRefs };
+  return { recordable: true, derivation: baseDerivation ?? GIT_STATUS_DELTA_DERIVATION, refs: normalizedRefs };
 }
 
 function toolNameOf(event: SessionEvent): string | null {
@@ -467,7 +477,7 @@ export async function recordFromSessionEvent(db: Database, input: RecordContextT
 
   const createdAt = new Date(input.sessionEvent.createdAt);
   const rows = [];
-  for (const { normalized, sourceIndex } of decision.refs) {
+  for (const { normalized, sourceIndex, derivation } of decision.refs) {
     rows.push({
       id: `${input.sessionEvent.id}:${sourceIndex}`,
       organizationId: input.organizationId,
@@ -476,8 +486,8 @@ export async function recordFromSessionEvent(db: Database, input: RecordContextT
       sourceSessionEventId: input.sessionEvent.id,
       sourceIndex,
       runtimeProvider: input.runtimeProvider,
-      action: decision.derivation.action,
-      source: decision.derivation.source,
+      action: derivation.action,
+      source: derivation.source,
       treeRepoUrl: normalized.treeRepoUrl,
       treeBranch: normalized.treeBranch,
       targetKind: normalized.targetKind,

--- a/packages/shared/src/schemas/context-tree.ts
+++ b/packages/shared/src/schemas/context-tree.ts
@@ -182,6 +182,7 @@ export const contextTreeIoSourceSchema = z.enum([
   "claude_write_tool",
   "codex_file_change",
   "shell_command",
+  "git_status_delta",
 ]);
 export type ContextTreeIoSource = z.infer<typeof contextTreeIoSourceSchema>;
 

--- a/packages/shared/src/schemas/session-event.ts
+++ b/packages/shared/src/schemas/session-event.ts
@@ -14,7 +14,7 @@ export type SessionEventKind = z.infer<typeof sessionEventKind>;
 export const toolFileRefPathKindSchema = z.enum(["file", "directory", "repo"]);
 export type ToolFileRefPathKind = z.infer<typeof toolFileRefPathKindSchema>;
 
-export const toolFileRefOriginSchema = z.enum(["tool_arg", "file_change", "runtime_metadata"]);
+export const toolFileRefOriginSchema = z.enum(["tool_arg", "file_change", "runtime_metadata", "git_status_delta"]);
 export type ToolFileRefOrigin = z.infer<typeof toolFileRefOriginSchema>;
 
 export const toolFileRefSchema = z.object({
@@ -24,6 +24,7 @@ export const toolFileRefSchema = z.object({
   repoRelativePath: z.string().min(1).optional(),
   pathKind: toolFileRefPathKindSchema.optional(),
   origin: toolFileRefOriginSchema,
+  metadata: z.record(z.string(), z.unknown()).optional(),
 });
 export type ToolFileRef = z.infer<typeof toolFileRefSchema>;
 


### PR DESCRIPTION
## Summary

- Add a client-side Context Tree git-status write tracker that diffs newly dirty tree paths after successful tool calls.
- Emit synthetic `toolFileRefs` with `origin: "git_status_delta"` for Claude SDK/TUI and Codex command/file-change events.
- Teach server IO recording to persist `git_status_delta` refs as write activity even when the original shell command is otherwise unsupported.

## Notes

This implements the design from `docs/development/context-tree-git-write-detection.md`: write attribution comes from the tree clone's git status rather than expanding the shell parser. The feed remains activity evidence, not an audit log; git history and the change map remain authoritative write history.

The tracker is conservative: it records only paths newly dirty relative to the session/tool baseline and updates the baseline after recording to avoid repeated events.

## Validation

- `pnpm --filter @first-tree/client test src/__tests__/context-tree-git-status.test.ts src/__tests__/claude-code-tool-events.test.ts src/__tests__/codex-context-tree-io.test.ts`
- `pnpm --filter @first-tree/server test src/__tests__/context-tree-io.test.ts`
- `pnpm --filter @first-tree/shared typecheck`
- `pnpm --filter @first-tree/server typecheck`
- `pnpm --filter @first-tree/client typecheck`
- `pnpm exec biome check packages/client/src/runtime/context-tree-git-status.ts packages/client/src/__tests__/context-tree-git-status.test.ts packages/client/src/__tests__/claude-code-tool-events.test.ts packages/client/src/__tests__/codex-context-tree-io.test.ts packages/client/src/handlers/claude-code.ts packages/client/src/handlers/claude-code-tui/index.ts packages/client/src/handlers/codex.ts packages/server/src/__tests__/context-tree-io.test.ts packages/server/src/services/context-tree-io.ts packages/shared/src/schemas/context-tree.ts packages/shared/src/schemas/session-event.ts`