### PR TITLE
fix: scope org session metadata visibility

### DIFF
--- a/packages/server/src/__tests__/org-sessions-list.test.ts
+++ b/packages/server/src/__tests__/org-sessions-list.test.ts
@@ -1,19 +1,24 @@
 import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { describe, expect, it } from "vitest";
 import { agentChatSessions } from "../db/schema/agent-chat-sessions.js";
 import { agents } from "../db/schema/agents.js";
+import { chatMembership } from "../db/schema/chat-membership.js";
 import { chats } from "../db/schema/chats.js";
+import { members } from "../db/schema/members.js";
+import { messages } from "../db/schema/messages.js";
 import { organizations } from "../db/schema/organizations.js";
 import { createAgent } from "../services/agent.js";
-import { createAdminContext, useTestApp } from "./helpers.js";
+import { createAdminContext, seedClient, useTestApp } from "./helpers.js";
 
 /**
  * Filter integrity for `GET /orgs/:orgId/sessions` (listAllSessions).
  *
- * Visibility policy: any active org member may read every org session's
- * topic/summary — that is accepted product behavior. What these tests pin
- * down is that every query filter actually takes effect:
+ * Visibility policy: org session rows are chat-access aware. Ordinary members
+ * see only sessions in chats they can open. Admins can keep the org-wide
+ * operational row list, but chat self-description and first-message summary
+ * are masked unless the admin also has chat access. These tests also pin:
  *
  *   - the organization boundary cannot be crossed (neither via the URL's
  *     :orgId nor via rows leaking into another org's listing);
@@ -25,7 +30,7 @@ import { createAdminContext, useTestApp } from "./helpers.js";
 describe("GET /orgs/:orgId/sessions — filter integrity", () => {
   const getApp = useTestApp();
 
-  type SessionItem = { agentId: string; chatId: string; state: string; topic: string | null };
+  type SessionItem = { agentId: string; chatId: string; state: string; topic: string | null; summary: string | null };
   type ListResponse = { items: SessionItem[]; nextCursor: string | null };
 
   async function seedChat(app: FastifyInstance, organizationId: string, topic?: string): Promise<string> {
@@ -46,6 +51,49 @@ describe("GET /orgs/:orgId/sessions — filter integrity", () => {
       state: opts.state ?? "active",
       ...(opts.updatedAt ? { updatedAt: opts.updatedAt } : {}),
     });
+  }
+
+  async function seedSpeaker(app: FastifyInstance, chatId: string, agentId: string): Promise<void> {
+    await app.db
+      .insert(chatMembership)
+      .values({ chatId, agentId, role: "member", accessMode: "speaker" })
+      .onConflictDoNothing();
+  }
+
+  async function seedFirstMessage(app: FastifyInstance, chatId: string, senderId: string, text: string): Promise<void> {
+    await app.db.insert(messages).values({
+      id: `msg-${randomUUID().slice(0, 8)}`,
+      chatId,
+      senderId,
+      format: "text",
+      content: { text },
+      source: "api",
+    });
+  }
+
+  async function createMember(app: FastifyInstance, admin: Awaited<ReturnType<typeof createAdminContext>>) {
+    const username = `member-${randomUUID().slice(0, 8)}`;
+    const createRes = await app.inject({
+      method: "POST",
+      url: `/api/v1/orgs/${admin.organizationId}/members`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+      payload: { username, displayName: "Session Member", role: "member" },
+    });
+    const created = createRes.json<{ id: string; password: string; agentId: string }>();
+    const loginRes = await app.inject({
+      method: "POST",
+      url: "/api/v1/auth/login",
+      payload: { username, password: created.password },
+    });
+    const { accessToken } = loginRes.json<{ accessToken: string }>();
+    const [member] = await app.db
+      .select({ userId: members.userId, organizationId: members.organizationId })
+      .from(members)
+      .where(eq(members.id, created.id))
+      .limit(1);
+    if (!member) throw new Error("member missing after creation");
+    const clientId = await seedClient(app, member.userId, member.organizationId);
+    return { memberId: created.id, humanAgentId: created.agentId, accessToken, clientId };
   }
 
   async function listSessions(
@@ -95,6 +143,7 @@ describe("GET /orgs/:orgId/sessions — filter integrity", () => {
       clientId: admin.clientId,
     });
     const ownChatId = await seedChat(app, admin.organizationId, "own topic");
+    await seedSpeaker(app, ownChatId, ownAgent.uuid);
     await seedSession(app, ownAgent.uuid, ownChatId);
 
     const own = await listSessions(app, admin.accessToken, admin.organizationId, "?limit=100");
@@ -105,6 +154,113 @@ describe("GET /orgs/:orgId/sessions — filter integrity", () => {
 
     const foreign = await listSessions(app, admin.accessToken, foreignOrgId);
     expect(foreign.statusCode).toBe(403);
+  });
+
+  it("ordinary members see participant and managed-agent sessions, but not outsider chat topics or summaries", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app);
+    const viewer = await createMember(app, admin);
+    const otherMember = await createMember(app, admin);
+
+    const participantAgent = await createAgent(app.db, {
+      name: `part-${randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "Participant Agent",
+      managerId: admin.memberId,
+      clientId: admin.clientId,
+    });
+    const managedAgent = await createAgent(app.db, {
+      name: `mgr-${randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "Managed Agent",
+      managerId: viewer.memberId,
+      clientId: viewer.clientId,
+    });
+    const hiddenAgent = await createAgent(app.db, {
+      name: `hidden-${randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "Hidden Agent",
+      managerId: admin.memberId,
+      clientId: admin.clientId,
+    });
+
+    const participantChatId = await seedChat(app, admin.organizationId, "participant topic");
+    await seedSpeaker(app, participantChatId, viewer.humanAgentId);
+    await seedSpeaker(app, participantChatId, participantAgent.uuid);
+    await seedFirstMessage(app, participantChatId, viewer.humanAgentId, "participant first message");
+    await seedSession(app, participantAgent.uuid, participantChatId);
+
+    const managedChatId = await seedChat(app, admin.organizationId, "managed topic");
+    await seedSpeaker(app, managedChatId, otherMember.humanAgentId);
+    await seedSpeaker(app, managedChatId, managedAgent.uuid);
+    await seedFirstMessage(app, managedChatId, otherMember.humanAgentId, "managed first message");
+    await seedSession(app, managedAgent.uuid, managedChatId);
+
+    const hiddenChatId = await seedChat(app, admin.organizationId, "hidden topic");
+    await seedSpeaker(app, hiddenChatId, otherMember.humanAgentId);
+    await seedSpeaker(app, hiddenChatId, hiddenAgent.uuid);
+    await seedFirstMessage(app, hiddenChatId, otherMember.humanAgentId, "hidden first message");
+    await seedSession(app, hiddenAgent.uuid, hiddenChatId);
+
+    const res = await listSessions(app, viewer.accessToken, admin.organizationId, "?limit=100");
+    expect(res.statusCode).toBe(200);
+    const visibleChatIds = new Set(res.body.items.map((i) => i.chatId));
+    expect(visibleChatIds.has(participantChatId)).toBe(true);
+    expect(visibleChatIds.has(managedChatId)).toBe(true);
+    expect(visibleChatIds.has(hiddenChatId)).toBe(false);
+    expect(res.body.items.find((i) => i.chatId === participantChatId)).toMatchObject({
+      topic: "participant topic",
+      summary: "participant first message",
+    });
+    expect(res.body.items.find((i) => i.chatId === managedChatId)).toMatchObject({
+      topic: "managed topic",
+      summary: "managed first message",
+    });
+  });
+
+  it("admins keep the org-wide session list but topic and summary are masked without chat access", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app);
+    const otherMember = await createMember(app, admin);
+
+    const accessibleAgent = await createAgent(app.db, {
+      name: `adm-visible-${randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "Admin Visible Agent",
+      managerId: admin.memberId,
+      clientId: admin.clientId,
+    });
+    const hiddenAgent = await createAgent(app.db, {
+      name: `adm-hidden-${randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "Admin Hidden Agent",
+      managerId: otherMember.memberId,
+      clientId: otherMember.clientId,
+    });
+
+    const accessibleChatId = await seedChat(app, admin.organizationId, "admin visible topic");
+    await seedSpeaker(app, accessibleChatId, accessibleAgent.uuid);
+    await seedFirstMessage(app, accessibleChatId, accessibleAgent.uuid, "admin visible first");
+    await seedSession(app, accessibleAgent.uuid, accessibleChatId);
+
+    const hiddenChatId = await seedChat(app, admin.organizationId, "admin hidden topic");
+    await seedSpeaker(app, hiddenChatId, otherMember.humanAgentId);
+    await seedSpeaker(app, hiddenChatId, hiddenAgent.uuid);
+    await seedFirstMessage(app, hiddenChatId, otherMember.humanAgentId, "admin hidden first");
+    await seedSession(app, hiddenAgent.uuid, hiddenChatId);
+
+    const res = await listSessions(app, admin.accessToken, admin.organizationId, "?limit=100");
+    expect(res.statusCode).toBe(200);
+    expect(res.body.items.some((i) => i.chatId === accessibleChatId)).toBe(true);
+    expect(res.body.items.some((i) => i.chatId === hiddenChatId)).toBe(true);
+    expect(res.body.items.find((i) => i.chatId === accessibleChatId)).toMatchObject({
+      topic: "admin visible topic",
+      summary: "admin visible first",
+    });
+    expect(res.body.items.find((i) => i.chatId === hiddenChatId)).toMatchObject({
+      topic: null,
+      summary: null,
+    });
   });
 
   it("excludes a session row that points an own-org agent at a foreign-org chat", async () => {

--- a/packages/server/src/api/orgs/sessions.ts
+++ b/packages/server/src/api/orgs/sessions.ts
@@ -14,9 +14,20 @@ export async function orgSessionRoutes(app: FastifyInstance): Promise<void> {
   app.get<{ Params: { orgId: string } }>("/", async (request) => {
     const scope = await requireOrgMembership(request, app.db);
     const query = sessionListFilter.parse(request.query);
-    return sessionService.listAllSessions(app.db, scope.organizationId, query.limit, query.cursor, {
-      state: query.state,
-      agentId: query.agentId,
-    });
+    return sessionService.listAllSessions(
+      app.db,
+      scope.organizationId,
+      {
+        role: scope.role,
+        memberId: scope.memberId,
+        humanAgentId: scope.humanAgentId,
+      },
+      query.limit,
+      query.cursor,
+      {
+        state: query.state,
+        agentId: query.agentId,
+      },
+    );
   });
 }

--- a/packages/server/src/services/session.ts
+++ b/packages/server/src/services/session.ts
@@ -67,6 +67,61 @@ export type SessionListItem = {
   topic: string | null;
 };
 
+export type OrgSessionListViewer = {
+  role: "admin" | "member";
+  memberId: string;
+  humanAgentId: string;
+};
+
+function chatAccessPredicate(viewer: OrgSessionListViewer) {
+  return sql`(
+    EXISTS (
+      SELECT 1
+      FROM chat_membership direct_cm
+      WHERE direct_cm.chat_id = ${chats.id}
+        AND direct_cm.agent_id = ${viewer.humanAgentId}
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM chat_membership managed_cm
+      INNER JOIN agents managed_agent ON managed_agent.uuid = managed_cm.agent_id
+      WHERE managed_cm.chat_id = ${chats.id}
+        AND managed_cm.access_mode = 'speaker'
+        AND managed_agent.manager_id = ${viewer.memberId}
+    )
+  )`;
+}
+
+async function accessibleChatIdSet(
+  db: Database,
+  viewer: OrgSessionListViewer,
+  chatIds: string[],
+): Promise<Set<string>> {
+  const accessible = new Set<string>();
+  if (chatIds.length === 0) return accessible;
+
+  const directRows = await db
+    .select({ chatId: chatMembership.chatId })
+    .from(chatMembership)
+    .where(and(inArray(chatMembership.chatId, chatIds), eq(chatMembership.agentId, viewer.humanAgentId)));
+  for (const row of directRows) accessible.add(row.chatId);
+
+  const supervisedRows = await db
+    .select({ chatId: chatMembership.chatId })
+    .from(chatMembership)
+    .innerJoin(agents, eq(agents.uuid, chatMembership.agentId))
+    .where(
+      and(
+        inArray(chatMembership.chatId, chatIds),
+        eq(chatMembership.accessMode, "speaker"),
+        eq(agents.managerId, viewer.memberId),
+      ),
+    );
+  for (const row of supervisedRows) accessible.add(row.chatId);
+
+  return accessible;
+}
+
 /** List sessions for a specific agent, with optional state filters. */
 export async function listAgentSessions(
   db: Database,
@@ -226,6 +281,7 @@ export async function getSession(db: Database, agentId: string, chatId: string):
 export async function listAllSessions(
   db: Database,
   organizationId: string,
+  viewer: OrgSessionListViewer,
   limit: number,
   cursor?: string,
   filters?: { state?: string; agentId?: string },
@@ -236,6 +292,9 @@ export async function listAllSessions(
   // reporting session:state for a foreign chatId could otherwise leak that
   // chat's topic/summary through the unconstrained chats join.
   const conditions = [eq(agents.organizationId, organizationId), eq(chats.organizationId, organizationId)];
+  if (viewer.role !== "admin") {
+    conditions.push(chatAccessPredicate(viewer));
+  }
   if (filters?.state) {
     conditions.push(eq(agentChatSessions.state, filters.state));
   } else {
@@ -289,12 +348,14 @@ export async function listAllSessions(
 
   // Batch-fetch first message per chat for summary (parity with listAgentSessions)
   const chatIds = [...new Set(items.map((r) => r.chatId))];
+  const accessibleChatIds = await accessibleChatIdSet(db, viewer, chatIds);
+  const visibleSummaryChatIds = chatIds.filter((chatId) => accessibleChatIds.has(chatId));
   const firstMessages =
-    chatIds.length > 0
+    visibleSummaryChatIds.length > 0
       ? await db
           .selectDistinctOn([messages.chatId], { chatId: messages.chatId, content: messages.content })
           .from(messages)
-          .where(inArray(messages.chatId, chatIds))
+          .where(inArray(messages.chatId, visibleSummaryChatIds))
           .orderBy(messages.chatId, messages.createdAt)
       : [];
   const summaryMap = new Map<string, string>();
@@ -307,17 +368,20 @@ export async function listAllSessions(
   const nextCursor = hasMore && last ? last.updatedAt.toISOString() : null;
 
   return {
-    items: items.map((r) => ({
-      agentId: r.agentId,
-      chatId: r.chatId,
-      state: r.state,
-      runtimeState: runtimeMap.get(r.agentId) ?? null,
-      startedAt: r.chatCreatedAt.toISOString(),
-      lastActivityAt: r.updatedAt.toISOString(),
-      messageCount: 0, // Omit per-session message count in global list for performance
-      summary: summaryMap.get(r.chatId) ?? null,
-      topic: r.chatTopic ?? null,
-    })),
+    items: items.map((r) => {
+      const canSeeChat = accessibleChatIds.has(r.chatId);
+      return {
+        agentId: r.agentId,
+        chatId: r.chatId,
+        state: r.state,
+        runtimeState: runtimeMap.get(r.agentId) ?? null,
+        startedAt: r.chatCreatedAt.toISOString(),
+        lastActivityAt: r.updatedAt.toISOString(),
+        messageCount: 0, // Omit per-session message count in global list for performance
+        summary: canSeeChat ? (summaryMap.get(r.chatId) ?? null) : null,
+        topic: canSeeChat ? (r.chatTopic ?? null) : null,
+      };
+    }),
     nextCursor,
   };
 }


### PR DESCRIPTION
## Summary
- Make `GET /api/v1/orgs/:orgId/sessions` chat-access aware by passing the caller's org-scope viewer into `listAllSessions`.
- Filter ordinary members before pagination so invisible session rows cannot consume page slots.
- Keep admin org-wide session rows, but mask `topic` and first-message `summary` unless the admin also has chat access; only fetch first messages for visible chats.
- Flip org-session list regression coverage to assert participant/managed-agent visibility, outsider exclusion, and admin masking.

## Validation
- `pnpm --filter @first-tree/server typecheck`
- `pnpm exec biome check packages/server/src/services/session.ts packages/server/src/api/orgs/sessions.ts packages/server/src/__tests__/org-sessions-list.test.ts`
- `pnpm --filter @first-tree/server exec vitest run src/__tests__/org-sessions-list.test.ts --maxWorkers=1 --minWorkers=1`

## Review
- Reviewed in First Tree by `codex-reviewer`; no blocking findings.
