### PR TITLE
fix: gate client websocket data frames

### DIFF
--- a/packages/client/src/__tests__/client-connection-websocket-coverage.test.ts
+++ b/packages/client/src/__tests__/client-connection-websocket-coverage.test.ts
@@ -233,6 +233,106 @@ describe("ClientConnection — WebSocket edge coverage", () => {
     expect(plainSocket.closeCalls.length).toBe(1);
   });
 
+  it("does not send post-auth frames before the auth frame during open", async () => {
+    let resolveToken!: (token: string) => void;
+    const tokenPromise = new Promise<string>((resolve) => {
+      resolveToken = resolve;
+    });
+    const connection = await makeConnection({
+      getAccessToken: async () => tokenPromise,
+    });
+    const internal = priv(connection);
+
+    const openPromise = internal.openWebSocket();
+    const socket = FakeWebSocket.instances[0];
+    if (!socket) throw new Error("missing fake socket");
+
+    socket.emitOpen();
+    await flushMicrotasks();
+
+    connection.reportSessionState("agent-1", "chat-1", "active");
+    connection.reportRuntimeState("agent-1", "working");
+    connection.reportSessionRuntime("agent-1", "chat-1", "working");
+    connection.reportSessionEvent("agent-1", "chat-1", {
+      kind: "error",
+      payload: { source: "runtime", message: "still handshaking" },
+    });
+    connection.sendSessionReconcile("agent-1", ["chat-1"]);
+    await connection.unbindAgent("agent-1");
+    await expect(connection.sendInboxAck(50, "agent-1")).resolves.toBeUndefined();
+
+    expect(socket.sent).toEqual([]);
+
+    resolveToken(makeJwt({ exp: Math.floor(Date.now() / 1000) + 3600 }));
+    await flushMicrotasks();
+    expect(parseSent(socket, 0)).toMatchObject({ type: "auth" });
+
+    socket.emitMessage({ type: "auth:ok" });
+    socket.emitMessage({ type: "client:registered" });
+    await openPromise;
+
+    internal.clearTimers();
+  });
+
+  it("does not send agent data-plane frames before the agent is bound on the current socket", async () => {
+    const connection = await makeConnection();
+    const socket = await openRegisteredConnection(connection);
+    const start = socket.sent.length;
+
+    connection.reportSessionState("agent-1", "chat-1", "active");
+    connection.reportRuntimeState("agent-1", "working");
+    connection.reportSessionRuntime("agent-1", "chat-1", "working");
+    connection.reportSessionEvent("agent-1", "chat-1", {
+      kind: "error",
+      payload: { source: "runtime", message: "before bind" },
+    });
+    connection.sendSessionReconcile("agent-1", ["chat-1"]);
+    await connection.unbindAgent("agent-1");
+    await expect(connection.sendInboxAck(50, "agent-1")).resolves.toBeUndefined();
+
+    expect(socket.sent.slice(start)).toEqual([]);
+
+    priv(connection).clearTimers();
+  });
+
+  it("sends agent data-plane frames after the agent is bound on the current socket", async () => {
+    const connection = await makeConnection();
+    const internal = priv(connection);
+    const socket = await openRegisteredConnection(connection, { wsInboxAckConfirm: true });
+
+    const bindPromise = internal.sendBind("agent-1", "codex");
+    const bindFrame = parseSent(socket, socket.sent.length - 1);
+    socket.emitMessage({
+      type: "agent:bound",
+      ref: bindFrame.ref,
+      agentId: "agent-1",
+      displayName: "Agent One",
+      agentType: "agent",
+    });
+    await bindPromise;
+
+    const start = socket.sent.length;
+    connection.reportSessionState("agent-1", "chat-1", "active");
+    connection.reportRuntimeState("agent-1", "working");
+    connection.reportSessionRuntime("agent-1", "chat-1", "working");
+    connection.reportSessionEvent("agent-1", "chat-1", {
+      kind: "error",
+      payload: { source: "runtime", message: "after bind" },
+    });
+    connection.sendSessionReconcile("agent-1", ["chat-1"]);
+    await connection.unbindAgent("agent-1");
+
+    const sentTypes = socket.sent.slice(start).map((raw) => (JSON.parse(raw) as { type?: string }).type);
+    expect(sentTypes).toEqual([
+      "session:state",
+      "runtime:state",
+      "session:runtime",
+      "session:event",
+      "session:reconcile",
+      "agent:unbind",
+    ]);
+  });
+
   it("covers non-Error initial connect failures and paused-after-backoff exit", async () => {
     vi.useFakeTimers();
     const connection = await makeConnection();

--- a/packages/client/src/client-connection.ts
+++ b/packages/client/src/client-connection.ts
@@ -530,7 +530,7 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
    */
   sendInboxAck(entryId: number, agentId?: string): Promise<void> {
     if (!this.serverSupportsInboxAckConfirm) {
-      this.sendLegacyInboxAck(entryId);
+      this.sendLegacyInboxAck(entryId, agentId);
       return Promise.resolve();
     }
 
@@ -591,15 +591,24 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
     return pending.promise;
   }
 
-  private sendLegacyInboxAck(entryId: number): void {
-    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+  private canSendClientFrame(): boolean {
+    return this.ws !== null && this.ws.readyState === WebSocket.OPEN && this.registered;
+  }
+
+  private canSendAgentFrame(agentId?: string): boolean {
+    return this.canSendClientFrame() && (agentId === undefined || this.socketBoundAgentIds.has(agentId));
+  }
+
+  private sendLegacyInboxAck(entryId: number, agentId?: string): void {
+    const ws = this.ws;
+    if (!this.canSendAgentFrame(agentId) || !ws) {
       this.wsLogger.warn(
-        { entryId, connectionState: this.inboxAckConnectionState() },
-        "inbox:ack dropped — socket not OPEN",
+        { entryId, agentId, connectionState: this.inboxAckConnectionState() },
+        "inbox:ack dropped — socket not ready",
       );
       return;
     }
-    this.ws.send(JSON.stringify({ type: "inbox:ack", entryId }));
+    ws.send(JSON.stringify({ type: "inbox:ack", entryId }));
     this.wsLogger.debug(
       {
         entryId,
@@ -652,7 +661,7 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
     }
 
     if (!this.serverSupportsInboxAckConfirm) {
-      this.sendLegacyInboxAck(pending.entryId);
+      this.sendLegacyInboxAck(pending.entryId, pending.agentId);
       this.resolvePendingInboxAck(pending, "legacy_fallback");
       return;
     }
@@ -856,22 +865,23 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
   }
 
   async unbindAgent(agentId: string): Promise<void> {
+    const shouldNotifyServer = this.canSendAgentFrame(agentId);
     this.desiredBindings.delete(agentId);
     this.boundAgents.delete(agentId);
     this.socketBoundAgentIds.delete(agentId);
     this.rejectPendingInboxAcksForAgent(agentId, "agent_unbound");
     this.rejectPendingInboxRecoversForAgent(agentId, "agent_unbound");
-    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+    if (!shouldNotifyServer || !this.ws) return;
     this.ws.send(JSON.stringify({ type: "agent:unbind", agentId }));
   }
 
   reportSessionState(agentId: string, chatId: string, state: SessionState): void {
-    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+    if (!this.canSendAgentFrame(agentId) || !this.ws) return;
     this.ws.send(JSON.stringify({ type: "session:state", agentId, chatId, state }));
   }
 
   reportRuntimeState(agentId: string, runtimeState: RuntimeState): void {
-    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+    if (!this.canSendAgentFrame(agentId) || !this.ws) return;
     this.ws.send(JSON.stringify({ type: "runtime:state", agentId, runtimeState }));
   }
 
@@ -884,19 +894,19 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
    * admin overview / fault notification path until that consumer migrates.
    */
   reportSessionRuntime(agentId: string, chatId: string, runtimeState: RuntimeState): void {
-    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+    if (!this.canSendAgentFrame(agentId) || !this.ws) return;
     this.ws.send(JSON.stringify({ type: "session:runtime", agentId, chatId, runtimeState }));
   }
 
   reportSessionEvent(agentId: string, chatId: string, event: SessionEvent): void {
-    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+    if (!this.canSendAgentFrame(agentId) || !this.ws) return;
     const sanitized = sanitizeSessionEventForTransport(event);
     this.ws.send(JSON.stringify({ type: "session:event", agentId, chatId, event: sanitized }));
   }
 
   /** Ask the server which of the supplied chatIds the client should drop. */
   sendSessionReconcile(agentId: string, chatIds: string[]): void {
-    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+    if (!this.canSendAgentFrame(agentId) || !this.ws) return;
     this.ws.send(JSON.stringify({ type: "session:reconcile", agentId, chatIds }));
   }
 


### PR DESCRIPTION
## Summary
- Gate client WebSocket frames until the socket is open and the server has confirmed `client:registered`.
- Gate agent-scoped frames until the current socket has received `agent:bound` for that agent.
- Apply the gate to session/runtime reports, session reconcile, `agent:unbind`, and legacy inbox ACKs so reconnect handshakes cannot send data-plane frames before auth.
- Add WebSocket coverage for the auth-before-data and bind-before-agent-data ordering windows.

## Testing
- `pnpm check`
- `pnpm --filter @first-tree/client exec vitest run --passWithNoTests --maxWorkers=2`
- `pnpm exec turbo run typecheck --concurrency=2`

Reviewed in First Tree chat by `codex-reviewer`: approved, no blocking findings.