### PR TITLE
fix(web): give multi-team users the full UserMenu inside onboarding

### DIFF
--- a/packages/web/src/pages/onboarding/__tests__/shell-rail-team-dom.test.tsx
+++ b/packages/web/src/pages/onboarding/__tests__/shell-rail-team-dom.test.tsx
@@ -19,6 +19,14 @@ const eventMock = vi.hoisted(() => ({
 
 const authMock = vi.hoisted(() => ({
   logout: vi.fn(),
+  // Shell only reads memberships.length; keep the shape minimal.
+  memberships: [] as Array<{ organizationId: string }>,
+}));
+
+const userMenuMock = vi.hoisted(() => ({
+  // The real UserMenu has its own DOM tests (layout-dom); here we only assert
+  // the shell's conditional mounting, so a marker stub keeps this test focused.
+  UserMenu: () => <div data-testid="user-menu-stub" />,
 }));
 
 const toastMock = vi.hoisted(() => ({
@@ -52,6 +60,8 @@ vi.mock("../../../auth/auth-context.js", () => ({
 vi.mock("../../../components/ui/toast.js", () => ({
   useToast: () => toastMock,
 }));
+
+vi.mock("../../../components/user-menu.js", () => userMenuMock);
 
 vi.mock("../onboarding-flow.js", () => ({
   useOnboardingFlow: () => flowMock.value,
@@ -114,6 +124,7 @@ async function submit(form: HTMLFormElement | null): Promise<void> {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  authMock.memberships = [];
   document.body.innerHTML = "";
   flowMock.value = {
     activeStep: "team",
@@ -181,6 +192,31 @@ describe("onboarding shell and team step", () => {
     expect(container.textContent).not.toContain("I'll finish later");
     // invitee has 2 config steps → connect-computer is step 1 of 2
     expect(container.textContent).toContain("Step 1 of 2");
+  });
+
+  it("mounts the full UserMenu for multi-team users in place of the bare sign-out link", async () => {
+    // The trapped-user scenario: routed into onboarding for a second org with
+    // no agent here (finish-later hidden) — the workspace UserMenu is the way
+    // back to their other team.
+    flowMock.value = { ...flowMock.value, activeStep: "connect-computer", hasAgent: false, organizationId: "org-2" };
+    authMock.memberships = [{ organizationId: "org-2" }, { organizationId: "org-1" }];
+    const { OnboardingShell } = await import("../onboarding-shell.js");
+
+    const container = await renderDom(<OnboardingShell>Body</OnboardingShell>);
+
+    expect(container.querySelector("[data-testid='user-menu-stub']")).not.toBeNull();
+    expect(container.textContent).not.toContain("Sign out");
+  });
+
+  it("keeps the minimal sign-out chrome for first-run single-team users", async () => {
+    flowMock.value = { ...flowMock.value, activeStep: "connect-computer", hasAgent: false };
+    authMock.memberships = [{ organizationId: "org-1" }];
+    const { OnboardingShell } = await import("../onboarding-shell.js");
+
+    const container = await renderDom(<OnboardingShell>Body</OnboardingShell>);
+
+    expect(container.querySelector("[data-testid='user-menu-stub']")).toBeNull();
+    expect(container.textContent).toContain("Sign out");
   });
 
   it("loads the team name, saves changes, and skips unchanged submissions", async () => {

--- a/packages/web/src/pages/onboarding/onboarding-shell.tsx
+++ b/packages/web/src/pages/onboarding/onboarding-shell.tsx
@@ -4,6 +4,7 @@ import { useAuth } from "../../auth/auth-context.js";
 import { FirstTreeLogo } from "../../components/first-tree-logo.js";
 import { Button } from "../../components/ui/button.js";
 import { useToast } from "../../components/ui/toast.js";
+import { UserMenu } from "../../components/user-menu.js";
 import { COPY, STEP_COPY } from "./copy.js";
 import { useOnboardingFlow } from "./onboarding-flow.js";
 import { StepProgress } from "./step-progress.js";
@@ -26,10 +27,23 @@ import { StepProgress } from "./step-progress.js";
  */
 export function OnboardingShell({ children }: { children: ReactNode }) {
   const { activeStep, finishLater, hasAgent } = useOnboardingFlow();
-  const { logout } = useAuth();
+  const { logout, memberships } = useAuth();
   const { addToast } = useToast();
   const navigate = useNavigate();
   const copy = STEP_COPY[activeStep];
+
+  // A multi-team user gets the full workspace UserMenu (team switching,
+  // create/join, invite, sign out) instead of the bare "Sign out" link. The
+  // workspace gate routes a returning user into onboarding whenever the
+  // SELECTED org has no usable agent, so a user who switches into a
+  // not-yet-set-up team lands here with no agent in THIS org ("finish later"
+  // hidden below) — without the menu they had no way back to the team they
+  // came from short of signing out. Switching teams via the menu is the same
+  // affordance they used to get here, and it carries no dismissal side effect
+  // (the account-level dismissal would suppress onboarding for every org).
+  // First-run users (single membership) keep the deliberately minimal chrome:
+  // the menu's only destinations would fork them into a second team mid-setup.
+  const isMultiTeam = memberships.length > 1;
 
   return (
     // h-screen + overflow-hidden pins the app to the viewport, so the page can
@@ -43,9 +57,8 @@ export function OnboardingShell({ children }: { children: ReactNode }) {
           <span className="text-label font-semibold">{COPY.productName}</span>
         </span>
         <div className="inline-flex items-center" style={{ gap: "var(--sp-4)" }}>
-          {/* "Finish later" only once a teammate exists — before that the
-              workspace is empty, so leaving is a dead end. Sign out is always
-              available so a user who can't finish right now isn't locked out. */}
+          {/* "Finish later" only once a teammate exists in THIS org — before
+              that the org's workspace is empty, so leaving is a dead end. */}
           {hasAgent && (
             <Button
               type="button"
@@ -66,9 +79,16 @@ export function OnboardingShell({ children }: { children: ReactNode }) {
               {COPY.finishLater}
             </Button>
           )}
-          <Button type="button" variant="link" className="h-auto p-0 text-label" onClick={logout}>
-            Sign out
-          </Button>
+          {/* Multi-team: the full workspace UserMenu (sign out lives inside it).
+              First-run: a bare Sign out link, always available so a user who
+              can't finish right now isn't locked out. */}
+          {isMultiTeam ? (
+            <UserMenu />
+          ) : (
+            <Button type="button" variant="link" className="h-auto p-0 text-label" onClick={logout}>
+              Sign out
+            </Button>
+          )}
         </div>
       </header>
 


### PR DESCRIPTION
## What

A multi-team user who switches into a not-yet-set-up team gets routed into the fullscreen `/onboarding` wizard (the org-level entry gate restored by #1027) with **no way back to the team they came from**:

- "I'll finish later" is hidden until THIS org has an agent — and would be the wrong escape anyway (it stamps the **account-level** dismissal, suppressing onboarding for every org, and lands on the new team's empty workspace, not the original team);
- the shell had no team switcher;
- the only remaining exit was Sign out.

Fix (per discussion): mount the existing workspace **`UserMenu`** (team switching with ready-state-honest routing, create/join team, invite, sign out) in the shell header for users with **more than one membership**, replacing the bare Sign out link (the menu contains sign-out). This is the same affordance the user used to switch teams in the first place, and switching carries no dismissal side effect; the wizard's persisted step survives for a later return.

First-run single-team users keep the deliberately minimal chrome (#785's light first-run is intentional, and the menu's only destinations would fork them into a second team mid-setup).

## Test plan

- `shell-rail-team-dom.test.tsx`: multi-team → UserMenu mounted, bare Sign out gone; single-team → minimal chrome unchanged (UserMenu stubbed; its own behavior is covered by layout-dom tests).
- Existing chrome tests (finish-later gating, progress counts) untouched and green.
- Gates: biome ✓, typecheck ✓, web 794/794 ✓.

Refs #1025 (the redirect-policy rework — derivation ≠ redirection — remains the long-term fix; this closes the trapped-user gap without touching gate semantics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)