### PR TITLE
feat(client,shared): attribute Context Tree refs by git repo identity

### DIFF
--- a/packages/client/src/__tests__/claude-code-tool-events.test.ts
+++ b/packages/client/src/__tests__/claude-code-tool-events.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -5,6 +6,7 @@ import type { SessionEvent } from "@first-tree/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createToolCallProcessor, treeNodePathOf } from "../handlers/claude-code.js";
 import type { ContextTreeGitWriteTracker } from "../runtime/context-tree-git-status.js";
+import { clearGitRepoIdentityCacheForTests } from "../runtime/git-repo-identity.js";
 
 /**
  * S11 (NC2 client handler) — tool-call processor fixtures.
@@ -834,5 +836,76 @@ describe("treeNodePathOf", () => {
   it("returns null on empty inputs", () => {
     expect(treeNodePathOf("", TREE)).toBeNull();
     expect(treeNodePathOf(`${TREE}/NODE.md`, "")).toBeNull();
+  });
+});
+
+/**
+ * Repo-identity attribution: tree PRs are authored in `worktrees/<task>`
+ * checkouts of the Context Tree repo, not in the bound shared clone. A Write
+ * there must still carry repo evidence — this is where real tree writes live.
+ */
+describe("createToolCallProcessor — tree PR worktree attribution", () => {
+  let root: string;
+  let sharedClone: string;
+  let treeWorktree: string;
+
+  function git(cwd: string, ...args: string[]): string {
+    return execFileSync("git", ["-C", cwd, ...args])
+      .toString("utf8")
+      .trim();
+  }
+
+  beforeEach(() => {
+    clearGitRepoIdentityCacheForTests();
+    root = mkdtempSync(join(tmpdir(), "first-tree-worktree-refs-"));
+    sharedClone = join(root, "context-tree-repos", "abc123");
+    mkdirSync(sharedClone, { recursive: true });
+    git(join(root, "context-tree-repos"), "init", "abc123");
+    git(sharedClone, "config", "user.email", "agent@example.com");
+    git(sharedClone, "config", "user.name", "Agent");
+    git(sharedClone, "remote", "add", "origin", "git@github.com:example/tree.git");
+    writeFileSync(join(sharedClone, "NODE.md"), "root");
+    git(sharedClone, "add", ".");
+    git(sharedClone, "commit", "-m", "initial");
+    treeWorktree = join(root, "worktrees", "task-tree");
+    mkdirSync(join(root, "worktrees"), { recursive: true });
+    git(sharedClone, "worktree", "add", treeWorktree, "-b", "task-branch");
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+    clearGitRepoIdentityCacheForTests();
+  });
+
+  it("attaches repo evidence when Write targets a tree PR worktree file", () => {
+    const emit = vi.fn<(event: SessionEvent) => void>();
+    const processor = createToolCallProcessor(emit, {
+      path: sharedClone,
+      repoUrl: "https://github.com/example/tree",
+      branch: "main",
+    });
+
+    processor.onMessage(
+      assistantToolUse("wt1", "Write", {
+        file_path: join(treeWorktree, "system", "new-node.md"),
+        content: "x",
+      }),
+    );
+    processor.onMessage(userToolResult("wt1", "created"));
+
+    const final = emit.mock.calls
+      .map((c) => c[0])
+      .filter((ev) => ev.kind === "tool_call")
+      .find((event) => event.payload.toolUseId === "wt1" && event.payload.status === "ok");
+    expect(final?.payload.toolFileRefs).toEqual([
+      {
+        origin: "tool_arg",
+        localPath: join(treeWorktree, "system", "new-node.md"),
+        repoUrl: "https://github.com/example/tree",
+        repoBranch: "main",
+        repoRelativePath: "system/new-node.md",
+        pathKind: "file",
+      },
+    ]);
   });
 });

--- a/packages/client/src/__tests__/codex-context-tree-io.test.ts
+++ b/packages/client/src/__tests__/codex-context-tree-io.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -9,6 +10,7 @@ import {
   toolFileRefsFromCodexFileChange,
 } from "../handlers/codex.js";
 import { toolFileRefsFromShellCommand } from "../runtime/context-tree-file-refs.js";
+import { clearGitRepoIdentityCacheForTests } from "../runtime/git-repo-identity.js";
 
 describe("Codex Context Tree file refs", () => {
   it("collects explicit path fields and object keys from file_change payloads", () => {
@@ -245,6 +247,61 @@ describe("Codex file refs through the W1 workspace symlink", () => {
         repoUrl: "https://github.com/acme/first-tree-context.git",
         repoBranch: "main",
         repoRelativePath: "NODE.md",
+        pathKind: "file",
+      },
+    ]);
+  });
+});
+
+describe("Codex file refs in a tree PR worktree (repo identity)", () => {
+  let root: string;
+  let sharedClone: string;
+  let treeWorktree: string;
+
+  function git(cwd: string, ...args: string[]): string {
+    return execFileSync("git", ["-C", cwd, ...args])
+      .toString("utf8")
+      .trim();
+  }
+
+  beforeEach(() => {
+    clearGitRepoIdentityCacheForTests();
+    root = mkdtempSync(join(tmpdir(), "first-tree-codex-worktree-"));
+    sharedClone = join(root, "context-tree-repos", "abc123");
+    mkdirSync(sharedClone, { recursive: true });
+    git(join(root, "context-tree-repos"), "init", "abc123");
+    git(sharedClone, "config", "user.email", "agent@example.com");
+    git(sharedClone, "config", "user.name", "Agent");
+    git(sharedClone, "remote", "add", "origin", "git@github.com:acme/first-tree-context.git");
+    writeFileSync(join(sharedClone, "NODE.md"), "root");
+    git(sharedClone, "add", ".");
+    git(sharedClone, "commit", "-m", "initial");
+    treeWorktree = join(root, "worktrees", "task-tree");
+    mkdirSync(join(root, "worktrees"), { recursive: true });
+    git(sharedClone, "worktree", "add", treeWorktree, "-b", "task-branch");
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+    clearGitRepoIdentityCacheForTests();
+  });
+
+  it("maps file_change paths inside the tree PR worktree to the binding repo", () => {
+    const refs = toolFileRefsFromCodexFileChange({
+      changes: [{ path: join(treeWorktree, "system", "new-node.md") }],
+      workspaceCwd: root,
+      contextTreePath: sharedClone,
+      contextTreeRepoUrl: "https://github.com/acme/first-tree-context.git",
+      contextTreeBranch: "main",
+    });
+
+    expect(refs).toEqual([
+      {
+        origin: "file_change",
+        localPath: join(treeWorktree, "system", "new-node.md"),
+        repoUrl: "https://github.com/acme/first-tree-context.git",
+        repoBranch: "main",
+        repoRelativePath: "system/new-node.md",
         pathKind: "file",
       },
     ]);

--- a/packages/client/src/__tests__/context-tree-file-refs.test.ts
+++ b/packages/client/src/__tests__/context-tree-file-refs.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -5,8 +6,10 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   canonicalizeFsPath,
   contextTreeRelativePathOf,
+  resolveContextTreeRelativePath,
   toolFileRefsFromShellCommand,
 } from "../runtime/context-tree-file-refs.js";
+import { clearGitRepoIdentityCacheForTests } from "../runtime/git-repo-identity.js";
 
 describe("toolFileRefsFromShellCommand", () => {
   let root: string;
@@ -193,6 +196,100 @@ describe("canonicalizeFsPath / contextTreeRelativePathOf", () => {
       {
         origin: "tool_arg",
         localPath: join(link, "NODE.md"),
+        repoUrl: "https://github.com/acme/first-tree-context.git",
+        repoBranch: "main",
+        repoRelativePath: "NODE.md",
+        pathKind: "file",
+      },
+    ]);
+  });
+});
+
+/**
+ * Repo-identity attribution: tree writes are authored in per-task worktrees
+ * (sibling checkouts of the same repo), not in the bound shared clone. Refs
+ * must attribute by git remote identity, not just path containment.
+ */
+describe("resolveContextTreeRelativePath — tree PR worktree (repo identity)", () => {
+  let root: string;
+  let sharedClone: string;
+  let treeWorktree: string;
+  let sourceRepo: string;
+
+  function git(cwd: string, ...args: string[]): string {
+    return execFileSync("git", ["-C", cwd, ...args])
+      .toString("utf8")
+      .trim();
+  }
+
+  beforeEach(() => {
+    clearGitRepoIdentityCacheForTests();
+    root = mkdtempSync(join(tmpdir(), "first-tree-repo-identity-refs-"));
+    sharedClone = join(root, "context-tree-repos", "abc123");
+    mkdirSync(sharedClone, { recursive: true });
+    git(join(root, "context-tree-repos"), "init", "abc123");
+    git(sharedClone, "config", "user.email", "agent@example.com");
+    git(sharedClone, "config", "user.name", "Agent");
+    git(sharedClone, "remote", "add", "origin", "git@github.com:acme/first-tree-context.git");
+    writeFileSync(join(sharedClone, "NODE.md"), "root");
+    git(sharedClone, "add", ".");
+    git(sharedClone, "commit", "-m", "initial");
+
+    treeWorktree = join(root, "worktrees", "task-tree");
+    mkdirSync(join(root, "worktrees"), { recursive: true });
+    git(sharedClone, "worktree", "add", treeWorktree, "-b", "task-branch");
+
+    sourceRepo = join(root, "worktrees", "task-code");
+    mkdirSync(sourceRepo, { recursive: true });
+    git(join(root, "worktrees"), "init", "task-code");
+    git(sourceRepo, "remote", "add", "origin", "https://github.com/acme/first-tree.git");
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+    clearGitRepoIdentityCacheForTests();
+  });
+
+  it("attributes a path inside a tree PR worktree via the worktree's remote", () => {
+    expect(
+      resolveContextTreeRelativePath(join(treeWorktree, "system", "new-node.md"), {
+        contextTreePath: sharedClone,
+        contextTreeRepoUrl: "https://github.com/acme/first-tree-context.git",
+      }),
+    ).toBe("system/new-node.md");
+  });
+
+  it("does not attribute paths in a checkout of a different repo", () => {
+    expect(
+      resolveContextTreeRelativePath(join(sourceRepo, "docs", "guide.md"), {
+        contextTreePath: sharedClone,
+        contextTreeRepoUrl: "https://github.com/acme/first-tree-context.git",
+      }),
+    ).toBeNull();
+  });
+
+  it("still resolves containment without spawning git (fast path)", () => {
+    expect(
+      resolveContextTreeRelativePath(join(sharedClone, "NODE.md"), {
+        contextTreePath: sharedClone,
+        contextTreeRepoUrl: null,
+      }),
+    ).toBe("NODE.md");
+  });
+
+  it("emits shell read refs for tree files read inside the tree PR worktree", () => {
+    const refs = toolFileRefsFromShellCommand({
+      command: `cat ${join(treeWorktree, "NODE.md")}`,
+      cwd: root,
+      contextTreePath: sharedClone,
+      contextTreeRepoUrl: "https://github.com/acme/first-tree-context.git",
+      contextTreeBranch: "main",
+    });
+
+    expect(refs).toEqual([
+      {
+        origin: "tool_arg",
+        localPath: join(treeWorktree, "NODE.md"),
         repoUrl: "https://github.com/acme/first-tree-context.git",
         repoBranch: "main",
         repoRelativePath: "NODE.md",

--- a/packages/client/src/__tests__/git-repo-identity.test.ts
+++ b/packages/client/src/__tests__/git-repo-identity.test.ts
@@ -1,0 +1,83 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  clearGitRepoIdentityCacheForTests,
+  findGitRepoRoot,
+  gitRemoteOriginUrl,
+  gitRepoRootMatchingRemote,
+} from "../runtime/git-repo-identity.js";
+
+const TREE_URL_HTTPS = "https://github.com/acme/first-tree-context.git";
+const TREE_URL_SSH = "git@github.com:acme/first-tree-context.git";
+const SOURCE_URL = "https://github.com/acme/first-tree.git";
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync("git", ["-C", cwd, ...args])
+    .toString("utf8")
+    .trim();
+}
+
+describe("git-repo-identity", () => {
+  let root: string;
+  let treeClone: string;
+
+  beforeEach(() => {
+    clearGitRepoIdentityCacheForTests();
+    root = mkdtempSync(join(tmpdir(), "first-tree-repo-identity-"));
+    treeClone = join(root, "tree-clone");
+    mkdirSync(treeClone, { recursive: true });
+    git(root, "init", "tree-clone");
+    git(treeClone, "config", "user.email", "agent@example.com");
+    git(treeClone, "config", "user.name", "Agent");
+    git(treeClone, "remote", "add", "origin", TREE_URL_SSH);
+    writeFileSync(join(treeClone, "NODE.md"), "root");
+    git(treeClone, "add", ".");
+    git(treeClone, "commit", "-m", "initial");
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+    clearGitRepoIdentityCacheForTests();
+  });
+
+  it("finds the repo root from a nested path and reads the origin remote", () => {
+    mkdirSync(join(treeClone, "members", "alice"), { recursive: true });
+    expect(findGitRepoRoot(join(treeClone, "members", "alice"))).toBe(treeClone);
+    expect(gitRemoteOriginUrl(treeClone)).toBe(TREE_URL_SSH);
+  });
+
+  it("returns null for paths outside any git repo and repos without origin", () => {
+    const plain = join(root, "no-repo");
+    mkdirSync(plain, { recursive: true });
+    expect(findGitRepoRoot(plain)).toBeNull();
+
+    const orphan = join(root, "orphan-repo");
+    mkdirSync(orphan, { recursive: true });
+    git(root, "init", "orphan-repo");
+    expect(gitRemoteOriginUrl(orphan)).toBeNull();
+    expect(gitRepoRootMatchingRemote(join(orphan, "x"), TREE_URL_HTTPS)).toBeNull();
+  });
+
+  it("matches a checkout whose ssh remote equals the https binding URL", () => {
+    expect(gitRepoRootMatchingRemote(join(treeClone, "NODE.md"), TREE_URL_HTTPS)).toBe(treeClone);
+  });
+
+  it("matches a linked git worktree (.git file) of the tree repo", () => {
+    const linked = join(root, "worktrees", "task-tree");
+    mkdirSync(join(root, "worktrees"), { recursive: true });
+    git(treeClone, "worktree", "add", linked, "-b", "task-branch");
+    expect(findGitRepoRoot(join(linked, "members"))).toBe(linked);
+    expect(gitRepoRootMatchingRemote(join(linked, "NODE.md"), TREE_URL_HTTPS)).toBe(linked);
+  });
+
+  it("rejects a checkout of a different repo", () => {
+    const source = join(root, "source-repo");
+    mkdirSync(source, { recursive: true });
+    git(root, "init", "source-repo");
+    git(source, "remote", "add", "origin", SOURCE_URL);
+    expect(gitRepoRootMatchingRemote(join(source, "src", "index.ts"), TREE_URL_HTTPS)).toBeNull();
+  });
+});

--- a/packages/client/src/__tests__/git-repo-identity.test.ts
+++ b/packages/client/src/__tests__/git-repo-identity.test.ts
@@ -81,3 +81,44 @@ describe("git-repo-identity", () => {
     expect(gitRepoRootMatchingRemote(join(source, "src", "index.ts"), TREE_URL_HTTPS)).toBeNull();
   });
 });
+
+describe("git-repo-identity — recycled checkout paths", () => {
+  it("re-resolves the remote after the same path is recreated as a different repo", () => {
+    const root = mkdtempSync(join(tmpdir(), "first-tree-repo-recycle-"));
+    try {
+      const checkout = join(root, "worktrees", "task");
+      mkdirSync(checkout, { recursive: true });
+      execFileSync("git", ["-C", root, "init", join("worktrees", "task")]);
+      execFileSync("git", ["-C", checkout, "remote", "add", "origin", "git@github.com:acme/first-tree-context.git"]);
+
+      // Warm the cache with the tree remote.
+      expect(
+        gitRepoRootMatchingRemote(join(checkout, "NODE.md"), "https://github.com/acme/first-tree-context.git"),
+      ).toBe(checkout);
+
+      // Operator cleans the worktree; a later task recreates the SAME path
+      // as a checkout of a DIFFERENT repo — without a daemon restart.
+      rmSync(checkout, { recursive: true, force: true });
+      mkdirSync(checkout, { recursive: true });
+      execFileSync("git", ["-C", root, "init", join("worktrees", "task")]);
+      execFileSync("git", ["-C", checkout, "remote", "add", "origin", "https://github.com/acme/other-repo.git"]);
+
+      // A stale path-keyed cache would still claim the tree remote here.
+      expect(
+        gitRepoRootMatchingRemote(join(checkout, "NODE.md"), "https://github.com/acme/first-tree-context.git"),
+      ).toBeNull();
+
+      // And the reverse direction: recycled path gains tree identity.
+      rmSync(checkout, { recursive: true, force: true });
+      mkdirSync(checkout, { recursive: true });
+      execFileSync("git", ["-C", root, "init", join("worktrees", "task")]);
+      execFileSync("git", ["-C", checkout, "remote", "add", "origin", "git@github.com:acme/first-tree-context.git"]);
+      expect(
+        gitRepoRootMatchingRemote(join(checkout, "NODE.md"), "https://github.com/acme/first-tree-context.git"),
+      ).toBe(checkout);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+      clearGitRepoIdentityCacheForTests();
+    }
+  });
+});

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -22,11 +22,7 @@ import { buildAgentBriefing } from "../runtime/agent-briefing.js";
 import type { AgentConfigCache } from "../runtime/agent-config-cache.js";
 import { type PredeclaredSourceRepo, writeAgentBriefing } from "../runtime/bootstrap.js";
 import { type ChatContext, fetchChatContext } from "../runtime/chat-context.js";
-import {
-  canonicalizeFsPath,
-  contextTreeRelativePathOf,
-  toolFileRefsFromShellCommand,
-} from "../runtime/context-tree-file-refs.js";
+import { resolveContextTreeRelativePath, toolFileRefsFromShellCommand } from "../runtime/context-tree-file-refs.js";
 import {
   type ContextTreeGitWriteTracker,
   createContextTreeGitWriteTracker,
@@ -374,12 +370,16 @@ function toolFileRef(toolName: string, input: unknown, contextTree?: ContextTree
   if (!TREE_READ_TOOL_NAMES.has(toolName) && !TREE_WRITE_TOOL_NAMES.has(toolName)) return null;
   const filePath = readFilePathArg(input);
   if (filePath === null) return null;
-  // Canonicalize both sides so a symlinked tree path (W1 cloud layout) still
-  // maps. Relative paths keep the fail-safe null mapping — canonicalizing
-  // them would resolve against the daemon's cwd and risk mis-attribution.
+  // Containment (canonical, symlink-safe) or repo identity (tree PR
+  // worktrees — any checkout whose origin remote IS the Context Tree repo).
+  // Relative paths keep the fail-safe null mapping — canonicalizing them
+  // would resolve against the daemon's cwd and risk mis-attribution.
   const repoRelativePath =
-    contextTree?.path && isAbsolute(filePath)
-      ? treeNodePathOf(canonicalizeFsPath(filePath), canonicalizeFsPath(contextTree.path))
+    contextTree && isAbsolute(filePath)
+      ? resolveContextTreeRelativePath(filePath, {
+          contextTreePath: contextTree.path,
+          contextTreeRepoUrl: contextTree.repoUrl,
+        })
       : null;
   return {
     origin: "tool_arg",
@@ -427,7 +427,12 @@ function searchToolFileRef(
   if (rawPath === null) return null;
   if (!isAbsolute(rawPath) && !cwd) return null;
   const absolutePath = isAbsolute(rawPath) ? resolve(rawPath) : resolve(cwd ?? "", rawPath);
-  const repoRelativePath = contextTree?.path ? contextTreeRelativePathOf(absolutePath, contextTree.path) : null;
+  const repoRelativePath = contextTree
+    ? resolveContextTreeRelativePath(absolutePath, {
+        contextTreePath: contextTree.path,
+        contextTreeRepoUrl: contextTree.repoUrl,
+      })
+    : null;
   return {
     origin: "tool_arg",
     localPath: absolutePath,

--- a/packages/client/src/handlers/codex.ts
+++ b/packages/client/src/handlers/codex.ts
@@ -24,7 +24,11 @@ import {
   formatCodexBinaryMissingMessage,
   isCodexBinaryMissingError,
 } from "../runtime/codex-binary.js";
-import { contextTreeRelativePathOf, toolFileRefsFromShellCommand } from "../runtime/context-tree-file-refs.js";
+import {
+  type ContextTreeAttribution,
+  resolveContextTreeRelativePath,
+  toolFileRefsFromShellCommand,
+} from "../runtime/context-tree-file-refs.js";
 import {
   type ContextTreeGitWriteTracker,
   createContextTreeGitWriteTracker,
@@ -374,14 +378,13 @@ export function buildCodexAgentBriefing(
 
 function contextTreeTargetPathOf(
   filePath: string,
-  contextTreePath: string | null,
+  attribution: ContextTreeAttribution,
   workspaceCwd: string,
 ): string | null {
-  if (!contextTreePath) return null;
   const absolutePath = isAbsolute(filePath) ? resolve(filePath) : resolve(workspaceCwd, filePath);
-  // Canonical comparison so a symlink alias of the tree (W1 cloud layout's
-  // `<workspace>/context-tree` link) maps the same as the real clone path.
-  const rel = contextTreeRelativePathOf(absolutePath, contextTreePath);
+  // Containment (canonical, symlink-safe) or repo identity (tree PR
+  // worktrees — any checkout whose origin remote IS the Context Tree repo).
+  const rel = resolveContextTreeRelativePath(absolutePath, attribution);
   return rel === null || rel === "/" ? null : rel;
 }
 
@@ -423,7 +426,11 @@ export function toolFileRefsFromCodexFileChange(input: {
     const fileKey = isAbsolute(filePath) ? filePath : resolve(input.workspaceCwd, filePath);
     if (seen.has(fileKey)) continue;
     seen.add(fileKey);
-    const repoRelativePath = contextTreeTargetPathOf(filePath, input.contextTreePath, input.workspaceCwd);
+    const repoRelativePath = contextTreeTargetPathOf(
+      filePath,
+      { contextTreePath: input.contextTreePath, contextTreeRepoUrl: input.contextTreeRepoUrl },
+      input.workspaceCwd,
+    );
     refs.push({
       origin: "file_change",
       localPath: filePath,

--- a/packages/client/src/runtime/context-tree-file-refs.ts
+++ b/packages/client/src/runtime/context-tree-file-refs.ts
@@ -1,6 +1,7 @@
 import { realpathSync, statSync } from "node:fs";
 import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { classifyShellCommandIo, type ShellIoPathKindHint, type ToolFileRef } from "@first-tree/shared";
+import { gitRepoRootMatchingRemote } from "./git-repo-identity.js";
 
 export type ShellCommandFileRefsInput = {
   command: string;
@@ -8,6 +9,12 @@ export type ShellCommandFileRefsInput = {
   contextTreePath: string | null;
   contextTreeRepoUrl: string | null;
   contextTreeBranch?: string | null;
+};
+
+/** The slice of the Context Tree binding that attribution decisions need. */
+export type ContextTreeAttribution = {
+  contextTreePath: string | null;
+  contextTreeRepoUrl: string | null;
 };
 
 function toPosixPath(path: string): string {
@@ -57,6 +64,42 @@ export function contextTreeRelativePathOf(absolutePath: string, contextTreeRoot:
   return toPosixPath(relativePath);
 }
 
+/**
+ * Tree-root-relative posix path of `absolutePath` when it belongs to the
+ * bound Context Tree repo, null otherwise. Two recognition layers:
+ *
+ * 1. Containment (fast, pure fs): the path lives under the bound shared
+ *    clone (`contextTreePath`), via canonical comparison so the workspace
+ *    `context-tree` symlink matches.
+ * 2. Repo identity: the path lives in ANY OTHER checkout of the same repo —
+ *    above all the per-task tree PR worktree where tree writes are actually
+ *    authored. The nearest enclosing git root's `origin` remote is compared,
+ *    canonically, against the binding's repo URL; the relative path is then
+ *    computed against THAT root.
+ *
+ * Layer 2 is what makes the feed recognize the real tree-write workflow:
+ * agents read the shared clone but author tree PRs in `worktrees/<task>`,
+ * a sibling checkout the containment check can never see.
+ */
+export function resolveContextTreeRelativePath(
+  absolutePath: string,
+  attribution: ContextTreeAttribution,
+): string | null {
+  if (attribution.contextTreePath) {
+    const contained = contextTreeRelativePathOf(absolutePath, attribution.contextTreePath);
+    if (contained !== null) return contained;
+  }
+  if (!attribution.contextTreeRepoUrl) return null;
+
+  const canonicalPath = canonicalizeFsPath(absolutePath);
+  const root = gitRepoRootMatchingRemote(canonicalPath, attribution.contextTreeRepoUrl);
+  if (!root) return null;
+  const relativePath = relative(root, canonicalPath);
+  if (relativePath === "") return "/";
+  if (relativePath.startsWith("..") || isAbsolute(relativePath)) return null;
+  return toPosixPath(relativePath);
+}
+
 function pathKindOf(
   absolutePath: string,
   repoRelativePath: string,
@@ -85,7 +128,10 @@ export function toolFileRefsFromShellCommand(input: ShellCommandFileRefsInput): 
     if (seen.has(absolutePath)) continue;
     seen.add(absolutePath);
 
-    const repoRelativePath = contextTreeRelativePathOf(absolutePath, input.contextTreePath);
+    const repoRelativePath = resolveContextTreeRelativePath(absolutePath, {
+      contextTreePath: input.contextTreePath,
+      contextTreeRepoUrl: input.contextTreeRepoUrl,
+    });
     if (repoRelativePath === null) continue;
 
     refs.push({

--- a/packages/client/src/runtime/git-repo-identity.ts
+++ b/packages/client/src/runtime/git-repo-identity.ts
@@ -1,0 +1,83 @@
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { canonicalGitRepoUrl } from "@first-tree/shared";
+
+/**
+ * Repo-identity resolution for Context Tree attribution.
+ *
+ * The agent workflow keeps TWO kinds of local checkouts of the Context Tree
+ * repo: the shared read clone the runtime binds as `contextTreePath`, and
+ * per-task worktrees under `worktrees/<task>` where tree PRs are actually
+ * authored. Path containment against `contextTreePath` only recognizes the
+ * first kind, so every write made in a tree PR worktree was invisible to the
+ * Context tab feed. These helpers answer the question containment cannot:
+ * "does this path live in ANY checkout of the bound Context Tree repo?" —
+ * by walking up to the nearest git root and comparing its `origin` remote,
+ * in canonical form, against the binding's repo URL.
+ */
+
+/**
+ * Nearest ancestor (including `path` itself) containing a `.git` entry.
+ * Works for clones (`.git` directory) and linked worktrees (`.git` file).
+ * Pure filesystem walk — no git process. Returns null when no repo
+ * encloses the path.
+ */
+export function findGitRepoRoot(path: string): string | null {
+  let current = path;
+  for (;;) {
+    if (existsSync(join(current, ".git"))) return current;
+    const parent = dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+
+/**
+ * `origin` remote URL of the repo at `gitRoot`, cached per root for the
+ * process lifetime (a checkout's remote does not change mid-session, and
+ * the daemon calls this on the tool-call hot path). Negative results are
+ * cached too — a repo with no `origin` stays a non-tree repo. The git
+ * invocation is bounded so a wedged process cannot stall the daemon
+ * event loop (same stance as the git-status write tracker).
+ */
+const remoteUrlCache = new Map<string, string | null>();
+
+export function gitRemoteOriginUrl(gitRoot: string): string | null {
+  const cached = remoteUrlCache.get(gitRoot);
+  if (cached !== undefined) return cached;
+  let remote: string | null = null;
+  try {
+    const raw = execFileSync("git", ["-C", gitRoot, "remote", "get-url", "origin"], {
+      timeout: 2000,
+      maxBuffer: 1024 * 1024,
+    })
+      .toString("utf8")
+      .trim();
+    remote = raw.length > 0 ? raw : null;
+  } catch {
+    remote = null;
+  }
+  remoteUrlCache.set(gitRoot, remote);
+  return remote;
+}
+
+/** Test seam: the cache is process-global and tests create throwaway repos. */
+export function clearGitRepoIdentityCacheForTests(): void {
+  remoteUrlCache.clear();
+}
+
+/**
+ * Root of the checkout enclosing `canonicalPath` IF that checkout is of the
+ * repo identified by `repoUrl` (canonical URL comparison — https and
+ * scp-like ssh spellings of the same repo match). Null otherwise.
+ */
+export function gitRepoRootMatchingRemote(canonicalPath: string, repoUrl: string): string | null {
+  const expected = canonicalGitRepoUrl(repoUrl);
+  if (!expected) return null;
+  const root = findGitRepoRoot(canonicalPath);
+  if (!root) return null;
+  const remote = gitRemoteOriginUrl(root);
+  if (!remote || canonicalGitRepoUrl(remote) !== expected) return null;
+  return root;
+}

--- a/packages/client/src/runtime/git-repo-identity.ts
+++ b/packages/client/src/runtime/git-repo-identity.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, statSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { canonicalGitRepoUrl } from "@first-tree/shared";
 
@@ -34,18 +34,41 @@ export function findGitRepoRoot(path: string): string | null {
 }
 
 /**
- * `origin` remote URL of the repo at `gitRoot`, cached per root for the
- * process lifetime (a checkout's remote does not change mid-session, and
- * the daemon calls this on the tool-call hot path). Negative results are
- * cached too — a repo with no `origin` stays a non-tree repo. The git
- * invocation is bounded so a wedged process cannot stall the daemon
- * event loop (same stance as the git-status write tracker).
+ * `origin` remote URL of the repo at `gitRoot`, cached per root and
+ * validated against the identity of the `.git` entry (inode + mtime).
+ *
+ * A plain path-keyed process-lifetime cache would be wrong here:
+ * `worktrees/<task>` paths are an on-demand namespace — a worktree can be
+ * removed and the same path recreated as a checkout of a DIFFERENT repo
+ * without the daemon restarting. Re-stating `.git` on every lookup makes
+ * recycling self-invalidating (a recreated `.git` has a new inode), at the
+ * cost of one stat per lookup. A churned-but-same repo (e.g. the clone's
+ * `.git` dir mtime moving with normal git activity) merely re-reads the
+ * remote — correctness never depends on the cache being warm. Negative
+ * results are cached the same way. The git invocation is bounded so a
+ * wedged process cannot stall the daemon event loop (same stance as the
+ * git-status write tracker).
  */
-const remoteUrlCache = new Map<string, string | null>();
+type RemoteCacheEntry = { ino: number; mtimeMs: number; remote: string | null };
+const remoteUrlCache = new Map<string, RemoteCacheEntry>();
+const REMOTE_CACHE_MAX_ENTRIES = 256;
 
 export function gitRemoteOriginUrl(gitRoot: string): string | null {
+  let gitEntryStat: { ino: number; mtimeMs: number };
+  try {
+    const stat = statSync(join(gitRoot, ".git"));
+    gitEntryStat = { ino: stat.ino, mtimeMs: stat.mtimeMs };
+  } catch {
+    // The root vanished between discovery and lookup (worktree cleanup).
+    remoteUrlCache.delete(gitRoot);
+    return null;
+  }
+
   const cached = remoteUrlCache.get(gitRoot);
-  if (cached !== undefined) return cached;
+  if (cached && cached.ino === gitEntryStat.ino && cached.mtimeMs === gitEntryStat.mtimeMs) {
+    return cached.remote;
+  }
+
   let remote: string | null = null;
   try {
     const raw = execFileSync("git", ["-C", gitRoot, "remote", "get-url", "origin"], {
@@ -58,7 +81,10 @@ export function gitRemoteOriginUrl(gitRoot: string): string | null {
   } catch {
     remote = null;
   }
-  remoteUrlCache.set(gitRoot, remote);
+  // Crude growth bound: the working set is a handful of checkouts; if the
+  // map ever balloons (pathological path churn), start over rather than LRU.
+  if (remoteUrlCache.size >= REMOTE_CACHE_MAX_ENTRIES) remoteUrlCache.clear();
+  remoteUrlCache.set(gitRoot, { ...gitEntryStat, remote });
   return remote;
 }
 

--- a/packages/server/src/services/context-tree-io.ts
+++ b/packages/server/src/services/context-tree-io.ts
@@ -9,6 +9,7 @@ import {
   type ContextTreeIoSource,
   type ContextTreeIoSummary,
   type ContextTreeIoTargetKind,
+  canonicalGitRepoUrl,
   classifyShellCommandIo,
   contextTreeIoSourceSchema,
   type SessionEvent,
@@ -109,34 +110,6 @@ type InternalContextTreeIoDecision =
       reason: ContextTreeIoSkipReason;
     };
 
-function canonicalRepoUrl(value: string | null | undefined): string | null {
-  const trimmed = value?.trim();
-  if (!trimmed) return null;
-
-  const scpLike = /^(?:[^@/\s]+@)?([^:]+):(.+)$/.exec(trimmed);
-  if (scpLike && !trimmed.includes("://")) {
-    const host = scpLike[1];
-    const rawPath = scpLike[2];
-    if (!host || !rawPath) return null;
-    const path = normalizeRepoPath(rawPath);
-    return path ? `${host.toLowerCase()}/${path}` : null;
-  }
-
-  try {
-    const url = new URL(trimmed);
-    const path = normalizeRepoPath(url.pathname);
-    return path ? `${url.hostname.toLowerCase()}/${path}` : null;
-  } catch {
-    return null;
-  }
-}
-
-function normalizeRepoPath(rawPath: string): string | null {
-  let path = rawPath.replace(/^\/+/, "").replace(/\/+$/, "");
-  if (path.endsWith(".git")) path = path.slice(0, -4);
-  return path.length > 0 ? path : null;
-}
-
 function normalizeTargetPath(rawPath: string, targetKind: ContextTreeIoTargetKind): string | null {
   const trimmed = rawPath.trim().replaceAll("\\", "/");
   if (trimmed.length === 0 || trimmed.includes("\0")) return null;
@@ -230,8 +203,8 @@ function normalizeFileRef(
   const parsed = toolFileRefSchema.safeParse(ref);
   if (!parsed.success) return { ok: false, reason: "ref_schema_invalid" };
 
-  const expectedRepo = canonicalRepoUrl(bindingRepo);
-  const reportedRepo = canonicalRepoUrl(parsed.data.repoUrl);
+  const expectedRepo = canonicalGitRepoUrl(bindingRepo);
+  const reportedRepo = canonicalGitRepoUrl(parsed.data.repoUrl);
   if (!expectedRepo || !reportedRepo || expectedRepo !== reportedRepo) {
     return { ok: false, reason: "ref_repo_mismatch" };
   }

--- a/packages/shared/src/__tests__/canonical-git-repo-url.test.ts
+++ b/packages/shared/src/__tests__/canonical-git-repo-url.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { canonicalGitRepoUrl } from "../canonical-git-repo-url.js";
+
+describe("canonicalGitRepoUrl", () => {
+  it("canonicalizes https URLs to host/owner/repo", () => {
+    expect(canonicalGitRepoUrl("https://github.com/acme/first-tree-context.git")).toBe(
+      "github.com/acme/first-tree-context",
+    );
+    expect(canonicalGitRepoUrl("https://GitHub.com/acme/first-tree-context/")).toBe(
+      "github.com/acme/first-tree-context",
+    );
+  });
+
+  it("canonicalizes scp-like ssh URLs to the same identity as https", () => {
+    expect(canonicalGitRepoUrl("git@github.com:acme/first-tree-context.git")).toBe(
+      canonicalGitRepoUrl("https://github.com/acme/first-tree-context"),
+    );
+  });
+
+  it("treats different repos as different identities", () => {
+    expect(canonicalGitRepoUrl("https://github.com/acme/first-tree")).not.toBe(
+      canonicalGitRepoUrl("https://github.com/acme/first-tree-context"),
+    );
+  });
+
+  it("returns null for empty or unparseable values", () => {
+    expect(canonicalGitRepoUrl(null)).toBeNull();
+    expect(canonicalGitRepoUrl(undefined)).toBeNull();
+    expect(canonicalGitRepoUrl("   ")).toBeNull();
+    expect(canonicalGitRepoUrl("not a url")).toBeNull();
+    expect(canonicalGitRepoUrl("https://github.com/")).toBeNull();
+  });
+});

--- a/packages/shared/src/canonical-git-repo-url.ts
+++ b/packages/shared/src/canonical-git-repo-url.ts
@@ -31,7 +31,13 @@ export function canonicalGitRepoUrl(value: string | null | undefined): string | 
 }
 
 function normalizeGitRepoPath(rawPath: string): string | null {
-  let path = rawPath.replace(/^\/+/, "").replace(/\/+$/, "");
+  // Trim slashes without regex: CodeQL flags `/\/+$/`-style patterns as
+  // polynomial on adversarial many-slash inputs (js/polynomial-redos).
+  let start = 0;
+  let end = rawPath.length;
+  while (start < end && rawPath[start] === "/") start++;
+  while (end > start && rawPath[end - 1] === "/") end--;
+  let path = rawPath.slice(start, end);
   if (path.endsWith(".git")) path = path.slice(0, -4);
   return path.length > 0 ? path : null;
 }

--- a/packages/shared/src/canonical-git-repo-url.ts
+++ b/packages/shared/src/canonical-git-repo-url.ts
@@ -1,0 +1,37 @@
+/**
+ * Canonical identity form of a git repo URL: `host/owner/repo` — lowercase
+ * host, no scheme, no credentials, no trailing `.git` / slashes. Two local
+ * checkouts belong to the same repo iff their remotes canonicalize equal,
+ * regardless of https vs scp-like ssh spelling.
+ *
+ * Single source of truth shared by the server (Context Tree IO ref
+ * validation) and the client (repo-identity attribution of local paths).
+ * Returns null for values that don't parse as a repo URL.
+ */
+export function canonicalGitRepoUrl(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+
+  const scpLike = /^(?:[^@/\s]+@)?([^:]+):(.+)$/.exec(trimmed);
+  if (scpLike && !trimmed.includes("://")) {
+    const host = scpLike[1];
+    const rawPath = scpLike[2];
+    if (!host || !rawPath) return null;
+    const path = normalizeGitRepoPath(rawPath);
+    return path ? `${host.toLowerCase()}/${path}` : null;
+  }
+
+  try {
+    const url = new URL(trimmed);
+    const path = normalizeGitRepoPath(url.pathname);
+    return path ? `${url.hostname.toLowerCase()}/${path}` : null;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeGitRepoPath(rawPath: string): string | null {
+  let path = rawPath.replace(/^\/+/, "").replace(/\/+$/, "");
+  if (path.endsWith(".git")) path = path.slice(0, -4);
+  return path.length > 0 ? path : null;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -6,6 +6,7 @@ export {
   type BriefingFingerprint,
   findAssembledBriefingFingerprint,
 } from "./agent-briefing-guard.js";
+export { canonicalGitRepoUrl } from "./canonical-git-repo-url.js";
 // -- Mention extraction (shared by server fan-out resolver and client auto-forward) --
 export { type BarePathMatch, scanBareDocPathTokens, stripDocPathLineSuffix } from "./lib/doc-link-scan.js";
 export {


### PR DESCRIPTION
## Problem

The Context tab feed rarely shows writes. Root cause (discussed in chat): the agent workflow keeps **two kinds of Context Tree checkouts** —

- the **shared read clone** the runtime binds as `contextTreePath` (exposed as the `<workspace>/context-tree` symlink), used for reading;
- **per-task worktrees** under `worktrees/<task>`, where tree PRs are actually authored.

Ref attribution only did path containment against the shared clone, so every read/write made in a tree PR worktree — the place real tree writes happen — was invisible to the feed. #1007 (symlink canonicalization) and #1024 (git-status write detection) both still watch only the shared clone.

## Change

Attribution now asks "does this path live in **any checkout of the bound Context Tree repo**?", in two layers:

1. **Containment** (fast path, unchanged): canonical, symlink-safe prefix check against `contextTreePath`. No git process.
2. **Repo identity** (new): walk up to the nearest enclosing git root (`.git` dir **or** linked-worktree `.git` file — pure fs walk), read its `origin` remote via a **bounded** `execFileSync` (`timeout: 2000`, `maxBuffer: 1 MiB`); the per-root cache is validated against the `.git` entry’s inode + mtime on every lookup, so a recycled `worktrees/<task>` path recreated as a different repo self-invalidates, compare in canonical form against the binding's repo URL, and relativize against **that** root. https and scp-like ssh spellings of the same repo match.

Wired through every ref extractor:
- Claude single-file tools (`Write`/`Edit`/`Read`/Notebook…) — `claude-code.ts` `toolFileRef`
- `Grep`/`Glob` search refs — `searchToolFileRef`
- shell command refs — `toolFileRefsFromShellCommand`
- Codex `file_change` — `contextTreeTargetPathOf`

`canonicalGitRepoUrl` moves to `@first-tree/shared` as the single source of truth; the server's private `canonicalRepoUrl` in `context-tree-io.ts` now imports it (zero behavior change server-side — the server already accepted any ref whose `repoUrl` canonically matches the binding, so **no server changes are needed** for these refs to record).

## Not in this PR (follow-up, PR 2)

The #1024 git-status write tracker still watches only the bound shared clone. Making it repo-root-aware (baseline/delta per matching worktree) is the next PR — this one makes all *direct* tool refs (Write/Edit/file_change, the dominant tree-write path) attribute correctly first.

Design notes:
- Refs keep carrying the **binding's** `repoUrl`/`repoBranch` (not the worktree's spelling/branch) — the server compares canonically either way, and the feed groups by the bound repo.
- Relative tool paths keep the fail-safe null mapping, unchanged.
- Negative remote lookups are cached the same way, so non-tree repos (e.g. source-repo worktrees) cost one git spawn per root until their `.git` identity changes.

## Validation

- `pnpm check` / `pnpm typecheck` clean
- shared 434/434, client 1227/1227, server 1392/1392
- New tests: shared URL canonicalization; git-root/remote discovery incl. linked worktree (`.git` file) and no-origin repos; ssh↔https equivalence; tree-PR-worktree attribution through shell refs, Claude `Write`, and Codex `file_change`; different-repo checkout rejection; containment fast path with no git spawn

🤖 Generated with [Claude Code](https://claude.com/claude-code)
