### PR TITLE
fix(cli): reject chat send inline bodies with escaped newlines

### DIFF
--- a/apps/cli/src/__tests__/chat-attention-commands-extra.test.ts
+++ b/apps/cli/src/__tests__/chat-attention-commands-extra.test.ts
@@ -46,7 +46,10 @@ vi.mock("../core/cli-fetch.js", () => ({ cliFetch: cliFetchMock }));
 vi.mock("../commands/_shared/resolve-agent.js", () => ({ resolveAgent: resolveAgentMock }));
 vi.mock("../commands/_shared/local-agent.js", () => localAgentMocks);
 vi.mock("../core/doc-capture.js", () => docCaptureMock);
-vi.mock("../commands/chat/_shared/io.js", () => ioMocks);
+vi.mock("../commands/chat/_shared/io.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../commands/chat/_shared/io.js")>()),
+  readStdin: ioMocks.readStdin,
+}));
 vi.mock("../cli/output.js", () => outputMocks);
 vi.mock("../core/output.js", () => ({
   print: { line: printLineMock, result: outputMocks.success, fail: outputMocks.fail },

--- a/apps/cli/src/__tests__/chat-send-escaped-newline-guard.test.ts
+++ b/apps/cli/src/__tests__/chat-send-escaped-newline-guard.test.ts
@@ -22,9 +22,15 @@ const outputMocks = vi.hoisted(() => ({
   success: vi.fn(),
 }));
 
+const printLineMock = vi.hoisted(() => vi.fn());
+
 vi.mock("../commands/_shared/local-agent.js", () => localAgentMocks);
 vi.mock("../core/doc-capture.js", () => docCaptureMock);
 vi.mock("../cli/output.js", () => outputMocks);
+vi.mock("../core/output.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../core/output.js")>();
+  return { ...actual, print: { ...actual.print, line: printLineMock } };
+});
 
 /**
  * Pins the `chat send` escaped-newline guard. Shell-composing models
@@ -145,13 +151,20 @@ describe("chat send escaped-newline guard — intercept then self-correct", () =
     expect(outputMocks.success).not.toHaveBeenCalled();
   });
 
-  it("tells the agent exactly how to retry — copyable heredoc + stdin escape hatch", async () => {
+  it("tells the agent exactly how to retry — copyable heredoc hint + single-line envelope", async () => {
     await expect(runChatSend(["nova", escapedBody])).rejects.toThrow();
 
+    // The copyable form rides `print.line` (plain stderr text with REAL
+    // newlines); the fail envelope stays single-line and points at it.
+    const hint = printLineMock.mock.calls[0]?.[0] ?? "";
+    expect(hint).toContain("cat <<'EOF'");
+    expect(hint).toContain("chat send <name> -f markdown");
+    expect(hint).toContain("\n  EOF\n");
+    expect(hint).toContain("stdin is not checked");
+
     const message = outputMocks.fail.mock.calls[0]?.[1] ?? "";
-    expect(message).toContain("cat <<'EOF'");
-    expect(message).toContain("chat send <name> -f markdown");
-    expect(message).toContain("stdin is not checked");
+    expect(message).toContain("stdin/heredoc");
+    expect(message).not.toContain("\n");
   });
 
   it("retry via stdin with real newlines succeeds and preserves markdown formatting", async () => {

--- a/apps/cli/src/__tests__/chat-send-escaped-newline-guard.test.ts
+++ b/apps/cli/src/__tests__/chat-send-escaped-newline-guard.test.ts
@@ -1,0 +1,186 @@
+import { EventEmitter } from "node:events";
+
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { looksLikeEscapedNewlineBody } from "../commands/chat/_shared/io.js";
+
+const localAgentMocks = vi.hoisted(() => ({
+  createSdk: vi.fn(),
+  handleSdkError: vi.fn((error: unknown) => {
+    throw error;
+  }),
+}));
+
+const docCaptureMock = vi.hoisted(() => ({
+  captureOutboundDocs: vi.fn(),
+}));
+
+const outputMocks = vi.hoisted(() => ({
+  fail: vi.fn((code: string, message: string, exitCode = 1) => {
+    throw Object.assign(new Error(message), { code, exitCode });
+  }),
+  success: vi.fn(),
+}));
+
+vi.mock("../commands/_shared/local-agent.js", () => localAgentMocks);
+vi.mock("../core/doc-capture.js", () => docCaptureMock);
+vi.mock("../cli/output.js", () => outputMocks);
+
+/**
+ * Pins the `chat send` escaped-newline guard. Shell-composing models
+ * routinely write the whole multi-line body as ONE quoted argument with
+ * `\n` escapes — POSIX shells do not expand `\n` inside quotes, so the
+ * literal two-character sequence reaches the server and the web UI renders
+ * one long unformatted line. The guard rejects exactly that shape BEFORE
+ * anything is sent, with a stderr hint actionable enough that the agent can
+ * retry via stdin/heredoc and succeed in the same session.
+ */
+describe("looksLikeEscapedNewlineBody", () => {
+  it("matches the observed failure shape — many escaped \\n, zero real newlines", () => {
+    // Verbatim prefix of an incident message (codex agent, one-line send).
+    const body = "更通俗地说：现在有两套文件夹。\\n\\n**第一套：公共阅读本**\\n就是 workspace 里的：\\n`context-tree`";
+    expect(looksLikeEscapedNewlineBody(body)).toBe(true);
+  });
+
+  it("matches a minimal two-paragraph escaped body", () => {
+    expect(looksLikeEscapedNewlineBody("para one\\n\\npara two")).toBe(true);
+  });
+
+  it("leaves bodies with real newlines alone — heredoc / stdin / ANSI-C $'...' shapes", () => {
+    expect(looksLikeEscapedNewlineBody("para one\n\npara two")).toBe(false);
+    // Mixed: discusses the escape sequence inside an otherwise real-newline body.
+    expect(looksLikeEscapedNewlineBody("the bug: `\\n` vs `\\r\\n`\nsecond line")).toBe(false);
+  });
+
+  it("leaves a single \\n mention in one-line prose alone", () => {
+    expect(looksLikeEscapedNewlineBody("split the value on \\n before parsing")).toBe(false);
+  });
+
+  it("leaves plain one-line bodies alone", () => {
+    expect(looksLikeEscapedNewlineBody("done — PR #123 is green, merging now")).toBe(false);
+    expect(looksLikeEscapedNewlineBody("")).toBe(false);
+  });
+});
+
+const originalChatId = process.env.FIRST_TREE_CHAT_ID;
+const originalStdinDescriptor = Object.getOwnPropertyDescriptor(process, "stdin");
+
+/**
+ * Stdin stand-in that replays its body once `readStdin` attaches the `end`
+ * listener — the command action runs asynchronously, so emitting eagerly
+ * would race the listener registration.
+ */
+class MockStdin extends EventEmitter {
+  isTTY = false;
+  destroy = vi.fn();
+
+  constructor(private readonly body: string) {
+    super();
+  }
+
+  override on(event: string, listener: (...args: unknown[]) => void): this {
+    super.on(event, listener);
+    if (event === "end") {
+      queueMicrotask(() => {
+        this.emit("data", Buffer.from(this.body, "utf-8"));
+        this.emit("end");
+      });
+    }
+    return this;
+  }
+}
+
+function setProcessStdin(stdin: unknown): void {
+  Object.defineProperty(process, "stdin", {
+    configurable: true,
+    value: stdin,
+  });
+}
+
+async function runChatSend(args: string[]): Promise<void> {
+  const { registerChatCommands } = await import("../commands/chat/index.js");
+  const program = new Command();
+  program.exitOverride();
+  program.configureOutput({ writeErr: () => undefined, writeOut: () => undefined });
+  registerChatCommands(program);
+  await program.parseAsync(["node", "test", "chat", "send", ...args]);
+}
+
+describe("chat send escaped-newline guard — intercept then self-correct", () => {
+  // The exact body shape from the incident: what the shell hands the CLI
+  // after `chat send nova "line1\n\n**title**\nline3"` — backslash-n stays
+  // two literal characters.
+  const escapedBody = "line1\\n\\n**title**\\nline3";
+  const realBody = "line1\n\n**title**\nline3";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.FIRST_TREE_CHAT_ID = "chat-env";
+    docCaptureMock.captureOutboundDocs.mockImplementation(async (content: string) => ({ content }));
+    localAgentMocks.createSdk.mockReturnValue({
+      sendMessage: vi.fn(async () => ({ id: "msg-1" })),
+    });
+  });
+
+  afterEach(() => {
+    if (originalChatId === undefined) {
+      delete process.env.FIRST_TREE_CHAT_ID;
+    } else {
+      process.env.FIRST_TREE_CHAT_ID = originalChatId;
+    }
+    if (originalStdinDescriptor) {
+      Object.defineProperty(process, "stdin", originalStdinDescriptor);
+    }
+  });
+
+  it("rejects the inline escaped body before anything is sent (non-zero exit, no row written)", async () => {
+    await expect(runChatSend(["nova", escapedBody])).rejects.toMatchObject({
+      code: "ESCAPED_NEWLINES",
+      exitCode: 2,
+    });
+
+    // Nothing reached the server — no half-written or broken-format message.
+    const sdk = localAgentMocks.createSdk.mock.results[0]?.value;
+    expect(sdk?.sendMessage ?? localAgentMocks.createSdk).not.toHaveBeenCalled();
+    expect(outputMocks.success).not.toHaveBeenCalled();
+  });
+
+  it("tells the agent exactly how to retry — copyable heredoc + stdin escape hatch", async () => {
+    await expect(runChatSend(["nova", escapedBody])).rejects.toThrow();
+
+    const message = outputMocks.fail.mock.calls[0]?.[1] ?? "";
+    expect(message).toContain("cat <<'EOF'");
+    expect(message).toContain("chat send <name> -f markdown");
+    expect(message).toContain("stdin is not checked");
+  });
+
+  it("retry via stdin with real newlines succeeds and preserves markdown formatting", async () => {
+    // First attempt: intercepted.
+    await expect(runChatSend(["nova", escapedBody])).rejects.toMatchObject({ code: "ESCAPED_NEWLINES" });
+
+    // Second attempt — the agent follows the hint and pipes the same content
+    // through stdin with real newlines (heredoc shape).
+    setProcessStdin(new MockStdin(realBody));
+    await runChatSend(["nova", "-f", "markdown"]);
+
+    const sdk = localAgentMocks.createSdk.mock.results.at(-1)?.value;
+    expect(sdk.sendMessage).toHaveBeenCalledWith(
+      "chat-env",
+      expect.objectContaining({ content: realBody, format: "markdown" }),
+    );
+    // The stored body carries REAL newlines (markdown renders) and no
+    // literal backslash-n leftovers.
+    const sentContent = sdk.sendMessage.mock.calls[0][1].content;
+    expect(sentContent).toContain("\n\n**title**");
+    expect(sentContent).not.toContain("\\n");
+    expect(outputMocks.success).toHaveBeenCalledWith({ id: "msg-1" });
+  });
+
+  it("does not intercept a literal-\\n body piped via stdin (escape hatch)", async () => {
+    setProcessStdin(new MockStdin(escapedBody));
+    await runChatSend(["nova"]);
+
+    const sdk = localAgentMocks.createSdk.mock.results.at(-1)?.value;
+    expect(sdk.sendMessage).toHaveBeenCalledWith("chat-env", expect.objectContaining({ content: escapedBody }));
+  });
+});

--- a/apps/cli/src/__tests__/chat-send-escaped-newline-stderr.test.ts
+++ b/apps/cli/src/__tests__/chat-send-escaped-newline-stderr.test.ts
@@ -1,0 +1,96 @@
+import { Command } from "commander";
+import type { MockInstance } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Pins the escaped-newline guard at the REAL process-output boundary — no
+ * mocks on the Print layer (`core/output.js`) or its `cli/output.js`
+ * wrapper. The point of the guard is agent self-correction, and the agent
+ * reads raw stderr: the copyable heredoc retry form must arrive as plain
+ * multi-line text, while the failure envelope stays one machine-readable
+ * JSON line. Mock-level tests cannot see this; this file asserts the actual
+ * bytes written to stderr and the actual exit code.
+ */
+
+const localAgentMocks = vi.hoisted(() => ({
+  createSdk: vi.fn(),
+  handleSdkError: vi.fn((error: unknown) => {
+    throw error;
+  }),
+}));
+
+const docCaptureMock = vi.hoisted(() => ({
+  captureOutboundDocs: vi.fn(),
+}));
+
+vi.mock("../commands/_shared/local-agent.js", () => localAgentMocks);
+vi.mock("../core/doc-capture.js", () => docCaptureMock);
+
+const originalChatId = process.env.FIRST_TREE_CHAT_ID;
+const originalExit = process.exit;
+
+async function runChatSend(args: string[]): Promise<void> {
+  const { registerChatCommands } = await import("../commands/chat/index.js");
+  const program = new Command();
+  program.exitOverride();
+  program.configureOutput({ writeErr: () => undefined, writeOut: () => undefined });
+  registerChatCommands(program);
+  await program.parseAsync(["node", "test", "chat", "send", ...args]);
+}
+
+describe("chat send escaped-newline guard — real stderr boundary", () => {
+  let stderrChunks: string[];
+  let stderrSpy: MockInstance<typeof process.stderr.write>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.FIRST_TREE_CHAT_ID = "chat-env";
+    docCaptureMock.captureOutboundDocs.mockImplementation(async (content: string) => ({ content }));
+    localAgentMocks.createSdk.mockReturnValue({
+      sendMessage: vi.fn(async () => ({ id: "msg-1" })),
+    });
+    stderrChunks = [];
+    stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(((chunk: string | Uint8Array) => {
+      stderrChunks.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf-8"));
+      return true;
+    }) as typeof process.stderr.write);
+    process.exit = vi.fn(((code?: number) => {
+      throw Object.assign(new Error("process.exit"), { exitCode: code });
+    }) as never);
+  });
+
+  afterEach(() => {
+    stderrSpy.mockRestore();
+    process.exit = originalExit;
+    if (originalChatId === undefined) {
+      delete process.env.FIRST_TREE_CHAT_ID;
+    } else {
+      process.env.FIRST_TREE_CHAT_ID = originalChatId;
+    }
+  });
+
+  it("writes a copyable multi-line heredoc hint plus a single-line JSON envelope, exits 2, sends nothing", async () => {
+    await expect(runChatSend(["nova", "line1\\n\\n**title**\\nline3"])).rejects.toMatchObject({ exitCode: 2 });
+
+    const stderr = stderrChunks.join("");
+
+    // The retry form is pasteable as-is: real newlines, heredoc opener and
+    // terminator on their own lines, no JSON escaping.
+    expect(stderr).toContain("cat <<'EOF' | ");
+    expect(stderr).toContain("chat send <name> -f markdown\n");
+    expect(stderr).toContain("\n  EOF\n");
+    expect(stderr).toContain("stdin is not checked");
+
+    // The machine-readable envelope is exactly one line of valid JSON with
+    // the stable error code, so scripted consumers keep parsing.
+    const envelopeLine = stderrChunks.find((chunk) => chunk.startsWith('{"ok":false'));
+    expect(envelopeLine).toBeDefined();
+    expect(envelopeLine).not.toContain("\n".repeat(2));
+    const envelope = JSON.parse(envelopeLine ?? "");
+    expect(envelope).toMatchObject({ ok: false, error: { code: "ESCAPED_NEWLINES" } });
+
+    // exit 2, and nothing reached the send path — no broken row written.
+    expect(process.exit).toHaveBeenCalledWith(2);
+    expect(localAgentMocks.createSdk).not.toHaveBeenCalled();
+  });
+});

--- a/apps/cli/src/commands/chat/_shared/io.ts
+++ b/apps/cli/src/commands/chat/_shared/io.ts
@@ -23,6 +23,30 @@ export function readStdin(): Promise<string | null> {
   });
 }
 
+/**
+ * Detect an inline message body whose newlines arrived as the two-character
+ * escape sequence `\n` instead of real newlines. POSIX shells do not expand
+ * `\n` inside single or double quotes, so a one-line
+ * `chat send <name> "line1\n\n**line2**"` stores a literal backslash-n body
+ * that the web UI renders as one long unformatted line — the markdown
+ * structure never starts at a line beginning. Models that compose one-line
+ * shell commands hit this shape often (and self-imitate it for the rest of
+ * the session), so `chat send` rejects it with a how-to-fix hint instead of
+ * persisting a broken row.
+ *
+ * Deliberately narrow, to keep prose that *mentions* the token sendable:
+ * - at least two escaped `\n` occurrences (a multi-line intent), and
+ * - zero real newlines (any real newline proves the formatting arrived
+ *   intact — e.g. ANSI-C `$'...\n...'` quoting expands before we see it).
+ * Bodies piped via stdin are never checked: stdin/heredoc is both the fix
+ * and the escape hatch for intentionally sending literal `\n` text.
+ */
+export function looksLikeEscapedNewlineBody(body: string): boolean {
+  if (body.includes("\n")) return false;
+  const escapes = body.match(/\\n/g);
+  return (escapes?.length ?? 0) >= 2;
+}
+
 export function parseLimit(value: string, max: number): number {
   const limit = Number.parseInt(value, 10);
   if (Number.isNaN(limit) || limit < 1 || limit > max) {

--- a/apps/cli/src/commands/chat/send.ts
+++ b/apps/cli/src/commands/chat/send.ts
@@ -3,6 +3,7 @@ import type { Command } from "commander";
 import { fail, success } from "../../cli/output.js";
 import { channelConfig } from "../../core/channel.js";
 import { captureOutboundDocs } from "../../core/doc-capture.js";
+import { print } from "../../core/output.js";
 import { createSdk, handleSdkError } from "../_shared/local-agent.js";
 import { looksLikeEscapedNewlineBody, readStdin } from "./_shared/io.js";
 import { buildRequestMetadata } from "./_shared/request.js";
@@ -93,14 +94,26 @@ export function registerChatSendCommand(chat: Command): void {
         // one long unformatted line. Stdin bodies are never checked: piping
         // is both the fix and the escape hatch for intentional literal `\n`.
         if (inlineBody !== undefined && looksLikeEscapedNewlineBody(inlineBody)) {
+          // The copyable retry form goes through `print.line` — plain
+          // multi-line stderr text (silenced in --json mode). The fail
+          // envelope below stays a single-line JSON object per the
+          // Print-layer contract; embedding the heredoc example there would
+          // itself arrive `\n`-escaped, which is exactly this bug.
+          print.line(
+            "chat send: the message body arrived with literal \\n escapes — shell quotes do not expand \\n, " +
+              "so it would render as one long unformatted line. Resend with real newlines via stdin:\n\n" +
+              `  cat <<'EOF' | ${channelConfig.binName} chat send <name> -f markdown\n` +
+              "  first line\n" +
+              "\n" +
+              "  **second** line\n" +
+              "  EOF\n\n" +
+              "(stdin is not checked — pipe the body if the literal \\n text is intentional.)\n\n",
+          );
           fail(
             "ESCAPED_NEWLINES",
-            'Message body contains literal "\\n" escapes and no real newlines — shell quotes do not expand \\n, ' +
-              "so the message would render as one long unformatted line instead of markdown. " +
-              "Pipe the body with real newlines via stdin instead:\n\n" +
-              `  cat <<'EOF' | ${channelConfig.binName} chat send <name> -f markdown\n` +
-              "  first line\n\n  **second** line\n  EOF\n\n" +
-              "(stdin is not checked — pipe the body if the literal \\n text is intentional.)",
+            'Inline message body contains literal "\\n" escapes and no real newlines — it would render as one ' +
+              "long unformatted line. Resend the body via stdin/heredoc with real newlines (copyable form " +
+              "printed above; stdin is not checked, so it also sends intentional literal \\n text).",
             2,
           );
         }

--- a/apps/cli/src/commands/chat/send.ts
+++ b/apps/cli/src/commands/chat/send.ts
@@ -1,9 +1,10 @@
 import type { MessageFormat } from "@first-tree/shared";
 import type { Command } from "commander";
 import { fail, success } from "../../cli/output.js";
+import { channelConfig } from "../../core/channel.js";
 import { captureOutboundDocs } from "../../core/doc-capture.js";
 import { createSdk, handleSdkError } from "../_shared/local-agent.js";
-import { readStdin } from "./_shared/io.js";
+import { looksLikeEscapedNewlineBody, readStdin } from "./_shared/io.js";
 import { buildRequestMetadata } from "./_shared/request.js";
 
 interface SendOptions {
@@ -83,6 +84,23 @@ export function registerChatSendCommand(chat: Command): void {
           fail(
             "NO_TARGET",
             "Pass <name> to @mention a recipient — a message must name a recipient (there is no no-mention send).",
+            2,
+          );
+        }
+
+        // Reject an inline body whose newlines are the two-character escape
+        // `\n` — shell quotes do not expand it, so the row would render as
+        // one long unformatted line. Stdin bodies are never checked: piping
+        // is both the fix and the escape hatch for intentional literal `\n`.
+        if (inlineBody !== undefined && looksLikeEscapedNewlineBody(inlineBody)) {
+          fail(
+            "ESCAPED_NEWLINES",
+            'Message body contains literal "\\n" escapes and no real newlines — shell quotes do not expand \\n, ' +
+              "so the message would render as one long unformatted line instead of markdown. " +
+              "Pipe the body with real newlines via stdin instead:\n\n" +
+              `  cat <<'EOF' | ${channelConfig.binName} chat send <name> -f markdown\n` +
+              "  first line\n\n  **second** line\n  EOF\n\n" +
+              "(stdin is not checked — pipe the body if the literal \\n text is intentional.)",
             2,
           );
         }

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -296,6 +296,20 @@ first-tree chat send code-agent "ship the PR"
 # Stdin (multiline, markdown, special chars)
 echo "long body" | first-tree chat send code-agent -f markdown
 
+# Inline bodies must carry REAL newlines. A one-line quoted body written with
+# `\n` escapes — chat send code-agent "line1\n\n**title**" — is rejected
+# BEFORE anything is sent (ESCAPED_NEWLINES, exit 2): shells do not expand
+# `\n` inside quotes, so the literal backslash-n would be stored and the
+# message would render as one long unformatted line. The error prints a
+# copyable heredoc retry form on stderr; resend via stdin:
+cat <<'EOF' | first-tree chat send code-agent -f markdown
+first line
+
+**second** line
+EOF
+# Stdin bodies are never checked — piping is also the escape hatch for
+# intentionally sending literal `\n` text.
+
 # Ask a human a tracked question (red-dot until answered). --request must
 # target a single human; the body carries context, --subject is the headline
 # (≤80 chars), and --question carries only the ask (≤200 chars).

--- a/skills/first-tree/references/agent-communication.md
+++ b/skills/first-tree/references/agent-communication.md
@@ -172,6 +172,13 @@ break markdown rendering downstream.
 - Pass content as a **raw string** — never `JSON.stringify` it first.
   Wrapping in outer quotes + `\n` escapes produces a literal
   `"@x ...\n..."` row that the UI cannot render as markdown.
+- Never write the body as a one-line quoted argument with `\n` escapes
+  (`chat send <name> "line1\n\n**line2**"`) — POSIX shells do not expand
+  `\n` inside quotes, so the literal backslash-n reaches the server and
+  the row renders as one long unformatted line. The CLI **rejects** this
+  shape (`ESCAPED_NEWLINES`, exit 2) before anything is sent; retry via
+  the stdin form below. Stdin bodies are not checked — pipe the body if
+  literal `\n` text is intentional.
 - For multi-line / markdown / special chars (quotes, `$`, backticks,
   newlines), use **stdin** with real newlines, plus `-f markdown`:
 


### PR DESCRIPTION
## Problem

Shell-composing agents (observed with codex/gpt-5.5 across two machines) often write the whole multi-line `chat send` body as **one quoted argument with `\n` escapes**:

```bash
first-tree chat send alice "line1\n\n**title**\nline3"
```

POSIX shells do not expand `\n` inside single or double quotes, so the literal two-character sequence reaches the server and the web UI renders one long unformatted line — markdown never renders. The habit is **session-sticky**: rollout analysis shows each session picks a serialization style at its first multi-line send and repeats it for every subsequent send (3 of 4 sessions on one machine locked onto the escaped style; 21 of 72 chat-send sessions on another).

Two factors make this urgent:
- #938 (chat-send-only contract) routed all agent replies through `chat send`, turning a latent occasional failure into a daily one (literal-\n messages went from 0 to 45 on one machine the day #938 landed).
- The #389 server guard (`maybeUnwrapDoubleEncoded`) deliberately only unwraps fully JSON-encoded bodies; this bare shape has no outer quotes and passes through.

## Fix

Reject the shape at the CLI boundary, **before anything is sent**: an inline body with ≥2 literal `\n` escapes and zero real newlines fails with `ESCAPED_NEWLINES` (exit 2) and a copyable heredoc example. Because style is session-sticky, one rejection at the first bad send flips the rest of the agent's session onto the correct form.

Deliberately narrow:
- ≥2 escaped `\n` — one-line prose *mentioning* the token once still sends
- zero real newlines — any real newline proves formatting arrived intact (ANSI-C `$'...\n...'` expands before the CLI sees it, so it passes)
- stdin/heredoc bodies are never checked — piping is both the fix and the escape hatch for intentionally sending literal `\n` text

## Acceptance criteria covered (per review thread)

- ✅ Bad inline body fails before any message is written (non-zero exit, no broken row)
- ✅ stderr is actionable: copyable heredoc form with the channel-correct binary name
- ✅ Automated retry-path test: inline send intercepted → same content piped via stdin succeeds → asserted stored body has real newlines, no `\n` leftovers
- ✅ `$'...'` ANSI-C quoting and real-newline bodies pass
- ✅ stdin escape hatch for intentional literal `\n`

## Context Tree

- Paired tree PR: agent-team-foundation/first-tree-context#511

## Testing

- New: `chat-send-escaped-newline-guard.test.ts` (9 tests — helper matrix + command-level intercept/retry/escape-hatch)
- New: `chat-send-escaped-newline-stderr.test.ts` — real process-output boundary, no Print-layer mocks (pasteable heredoc on raw stderr + single-line JSON envelope + exit 2)
- Updated: `chat-attention-commands-extra.test.ts` io mock now passes through the real guard
- `pnpm check` / `pnpm typecheck` green; apps/cli suite 453/453

🤖 Generated with [Claude Code](https://claude.com/claude-code)