### PR TITLE
fix: harden ack recovery scheduling

### DIFF
--- a/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
+++ b/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
@@ -508,6 +508,107 @@ describe("SessionManager edge coverage", () => {
     await sm.shutdown();
   });
 
+  it("queues recovery redelivery instead of preempting a working session", async () => {
+    const working = handler();
+    const recovered = handler();
+    const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
+    const sm = makeManager({
+      concurrency: 1,
+      handlers: [working, recovered],
+      recoverChat,
+    });
+
+    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-working", messageId: "msg-working" }));
+    internals(sm).evictedMappings.set("chat-recovery", { claudeSessionId: "old-recovery", lastActivity: 1 });
+
+    await sm.dispatch(mockEntry({ id: 2, chatId: "chat-recovery", messageId: "msg-recovery" }));
+    expect(recoverChat).toHaveBeenCalledWith("chat-recovery");
+
+    await sm.dispatch(mockEntry({ id: 2, chatId: "chat-recovery", messageId: "msg-recovery" }));
+
+    expect(working.suspend).not.toHaveBeenCalled();
+    expect(recovered.start).not.toHaveBeenCalled();
+    expect(internals(sm).pendingQueue.some((item) => item.chatId === "chat-recovery")).toBe(true);
+
+    await sm.shutdown();
+  });
+
+  it("does not let a queued recovery steal a slot released for fresh preemption", async () => {
+    const lifecycles: Array<{ chatId: string; phase: "start" | "resume" }> = [];
+    const makeTrackedHandler = () =>
+      handler({
+        async start(message) {
+          lifecycles.push({ chatId: message.chatId, phase: "start" });
+          return `session-${message.chatId}`;
+        },
+        async resume(message) {
+          lifecycles.push({ chatId: message?.chatId ?? "", phase: "resume" });
+          return `session-${message?.chatId ?? "unknown"}`;
+        },
+      });
+    const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
+    const sm = makeManager({
+      concurrency: 1,
+      handlers: [makeTrackedHandler(), makeTrackedHandler(), makeTrackedHandler()],
+      recoverChat,
+    });
+
+    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-working", messageId: "msg-working" }));
+    internals(sm).evictedMappings.set("chat-recovery", { claudeSessionId: "old-recovery", lastActivity: 1 });
+    await sm.dispatch(mockEntry({ id: 2, chatId: "chat-recovery", messageId: "msg-recovery" }));
+    await sm.dispatch(mockEntry({ id: 2, chatId: "chat-recovery", messageId: "msg-recovery" }));
+    expect(internals(sm).pendingQueue.some((item) => item.chatId === "chat-recovery")).toBe(true);
+
+    await sm.dispatch(mockEntry({ id: 3, chatId: "chat-fresh", messageId: "msg-fresh" }));
+
+    expect(sm.activeCount).toBe(1);
+    expect(lifecycles).toEqual([
+      { chatId: "chat-working", phase: "start" },
+      { chatId: "chat-fresh", phase: "start" },
+    ]);
+    expect(internals(sm).pendingQueue.some((item) => item.chatId === "chat-recovery")).toBe(true);
+
+    await sm.shutdown();
+  });
+
+  it("marks queued inbox work for recovery when pending drain routing fails", async () => {
+    const ackEntry = vi.fn<(entryId: number) => Promise<void>>().mockResolvedValue(undefined);
+    const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
+    let firstContext: SessionContext | undefined;
+    let firstMessage: SessionMessage | undefined;
+    let factoryCalls = 0;
+    const sm = makeManager({
+      ackEntry,
+      recoverChat,
+      concurrency: 1,
+      maxSessions: 1,
+      handlerFactory: () => {
+        factoryCalls++;
+        if (factoryCalls > 1) throw new Error("handler factory unavailable");
+        return handler({
+          async start(message, ctx) {
+            firstMessage = message;
+            firstContext = ctx;
+            return "session-chat-working";
+          },
+        });
+      },
+    });
+
+    await sm.dispatch(mockEntry({ id: 10, chatId: "chat-working", messageId: "msg-working" }));
+    await sm.dispatch(mockEntry({ id: 11, chatId: "chat-queued", messageId: "msg-queued" }));
+    expect(internals(sm).pendingQueue.some((item) => item.chatId === "chat-queued")).toBe(true);
+    if (!firstContext || !firstMessage) throw new Error("first context missing");
+
+    await firstContext.finishTurn(firstMessage, { status: "success", terminal: true });
+
+    await vi.waitFor(() => expect(recoverChat).toHaveBeenCalledWith("chat-queued"));
+    expect(ackEntry).toHaveBeenCalledWith(10);
+    expect(internals(sm).pendingQueue.some((item) => item.chatId === "chat-queued")).toBe(false);
+
+    await sm.shutdown();
+  });
+
   it("covers retry early returns, retry re-queue, empty-message start, resume fallback, and emit failures", async () => {
     const events: SessionEvent[] = [];
     const sm = makeManager({

--- a/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
+++ b/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
@@ -533,6 +533,32 @@ describe("SessionManager edge coverage", () => {
     await sm.shutdown();
   });
 
+  it("keeps the recovery window open across multiple queued recovered frames", async () => {
+    const working = handler();
+    const recovered = handler();
+    const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
+    const sm = makeManager({
+      concurrency: 1,
+      handlers: [working, recovered],
+      recoverChat,
+    });
+
+    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-working", messageId: "msg-working" }));
+    internals(sm).evictedMappings.set("chat-recovery", { claudeSessionId: "old-recovery", lastActivity: 1 });
+
+    await sm.dispatch(mockEntry({ id: 2, chatId: "chat-recovery", messageId: "msg-recovery-1" }));
+    expect(recoverChat).toHaveBeenCalledTimes(1);
+
+    await sm.dispatch(mockEntry({ id: 2, chatId: "chat-recovery", messageId: "msg-recovery-1" }));
+    await sm.dispatch(mockEntry({ id: 3, chatId: "chat-recovery", messageId: "msg-recovery-2" }));
+
+    expect(recoverChat).toHaveBeenCalledTimes(1);
+    expect(recovered.start).not.toHaveBeenCalled();
+    expect(internals(sm).pendingQueue.filter((item) => item.chatId === "chat-recovery")).toHaveLength(2);
+
+    await sm.shutdown();
+  });
+
   it("does not let a queued recovery steal a slot released for fresh preemption", async () => {
     const lifecycles: Array<{ chatId: string; phase: "start" | "resume" }> = [];
     const makeTrackedHandler = () =>

--- a/packages/client/src/__tests__/session-manager.test.ts
+++ b/packages/client/src/__tests__/session-manager.test.ts
@@ -269,67 +269,67 @@ describe("SessionManager", () => {
     await sm.shutdown();
   });
 
-  it("does NOT re-ack a dedup-hit whose chat was LRU-evicted — the bind-reset recovery path must stay open", async () => {
-    // R5 boundary: LRU eviction moves the entry to recovery debt WITHOUT
-    // acking it (no handler will ever call finishTurn). The
-    // recovery contract documented in `evictIfNeeded` is "server's
-    // bind-reset redelivers against a fresh session." Pre-this-PR the
-    // dispatch dedup short-circuit silently returned, the evicted chat's
-    // dedup key kept the redelivery from being mis-classified as a fresh
-    // message at process restart, and recovery worked. After adding the
-    // dedup-hit re-ack the path would have been broken: dedup-hit + entry
-    // not in-flight → re-ack → server marks acked → no redelivery → loss.
-    // The fix synchronously drops the evicted chat's dedup keys, so the
-    // redelivery is no longer a dedup hit at all and goes through the
-    // normal `startNewSession` (with evictedMappings → handler.resume)
-    // path. Verifies (1) ack is NOT called for the evicted entry on
-    // redelivery, and (2) the handler runs again (fresh session pickup).
+  it("queues a new chat instead of evicting working sessions at max_sessions", async () => {
     const ackEntry = mockAckEntry();
-    const startSpy = vi.fn(async (_msg: unknown, _ctx: SessionContext) => "session-id-mock");
-    const resumeSpy = vi.fn(async (_msg: unknown, _sid: string, _ctx: SessionContext) => "session-id-mock");
-    const handler = createMockHandler({ start: startSpy, resume: resumeSpy });
     const recoverChat = vi.fn().mockResolvedValue(undefined);
+    const handlers: AgentHandler[] = [];
+    const factory: HandlerFactory = () => {
+      const h = createMockHandler();
+      handlers.push(h);
+      return h;
+    };
     const sm = createSessionManager({
       ackEntry,
-      handler,
+      handlerFactory: factory,
       session: { idle_timeout: 300, max_sessions: 2, working_grace_seconds: 3600, reconcile_interval_seconds: 300 },
       recoverChat,
     });
 
-    // Fill the session pool: chat-a then chat-b. chat-a becomes LRU.
-    const chatA = mockEntry({ id: 70, chatId: "chat-a", messageId: "msg-a" });
-    const chatB = mockEntry({ id: 71, chatId: "chat-b", messageId: "msg-b" });
-    await sm.dispatch(chatA);
-    await sm.dispatch(chatA);
-    await sm.dispatch(chatB);
-    await sm.dispatch(chatB);
-    expect(startSpy).toHaveBeenCalledTimes(2);
+    await sm.dispatch(mockEntry({ id: 70, chatId: "chat-a", messageId: "msg-a" }));
+    await sm.dispatch(mockEntry({ id: 71, chatId: "chat-b", messageId: "msg-b" }));
+    expect(sm.totalCount).toBe(2);
 
-    // chat-c trips evictIfNeeded — sessions.size (2) >= max_sessions (2),
-    // chat-a is the LRU candidate and gets evicted (chat-a:msg-a should
-    // come out of the dedup set as part of eviction), then proactively
-    // requests chat-scoped recovery for its unacked work.
-    const chatC = mockEntry({ id: 72, chatId: "chat-c", messageId: "msg-c" });
-    await sm.dispatch(chatC);
-    await sm.dispatch(chatC);
-    expect(startSpy).toHaveBeenCalledTimes(3);
-    expect(recoverChat).toHaveBeenCalledTimes(1);
-    expect(recoverChat).toHaveBeenCalledWith("chat-a");
-    // Nothing has been acked yet — none of the mock handlers call finishTurn.
+    await sm.dispatch(mockEntry({ id: 72, chatId: "chat-c", messageId: "msg-c" }));
+
+    expect(sm.totalCount).toBe(2);
+    expect(handlers).toHaveLength(2);
+    expect(recoverChat).not.toHaveBeenCalled();
     expect(ackEntry).not.toHaveBeenCalled();
 
-    // Simulate redelivery of the SAME entry for the LRU-evicted chat after
-    // proactive recovery. The first dispatch resumes from evictedMappings;
-    // the second is a duplicate-in-flight redelivery and is ignored.
-    await sm.dispatch(chatA);
-    await sm.dispatch(chatA);
+    await sm.shutdown();
+  });
 
-    // Recovery path: handler.resume invoked once for chat-a (it was
-    // evicted, so the new dispatch resumes from evictedMappings).
-    expect(resumeSpy).toHaveBeenCalledTimes(1);
-    // Critically: NO ack for the evicted entry. The fresh session will
-    // ack it when its handler calls finishTurn at turn end.
-    expect(ackEntry).not.toHaveBeenCalled();
+  it("drains max_sessions queue after a working session becomes idle", async () => {
+    const ackEntry = mockAckEntry();
+    const contexts = new Map<string, SessionContext>();
+    const messages = new Map<string, SessionMessage>();
+    const started: string[] = [];
+    const factory: HandlerFactory = () =>
+      createMockHandler({
+        async start(message, ctx) {
+          contexts.set(message.chatId, ctx);
+          messages.set(message.chatId, message);
+          started.push(message.chatId);
+          return `session-${message.chatId}`;
+        },
+      });
+    const sm = createSessionManager({
+      ackEntry,
+      handlerFactory: factory,
+      concurrency: 1,
+      session: { idle_timeout: 300, max_sessions: 1, working_grace_seconds: 3600, reconcile_interval_seconds: 300 },
+    });
+
+    await sm.dispatch(mockEntry({ id: 80, chatId: "chat-a", messageId: "msg-a" }));
+    await sm.dispatch(mockEntry({ id: 81, chatId: "chat-b", messageId: "msg-b" }));
+    expect(started).toEqual(["chat-a"]);
+
+    const ctx = contexts.get("chat-a");
+    const message = messages.get("chat-a");
+    if (!ctx || !message) throw new Error("chat-a context missing");
+    await ctx.finishTurn(message, { status: "success", terminal: true });
+
+    await vi.waitFor(() => expect(started).toEqual(["chat-a", "chat-b"]));
 
     await sm.shutdown();
   });
@@ -468,8 +468,16 @@ describe("SessionManager", () => {
 
   it("evicts LRU session when max_sessions is reached", async () => {
     const handlers: AgentHandler[] = [];
+    const contexts = new Map<string, SessionContext>();
+    const messages = new Map<string, SessionMessage>();
     const factory: HandlerFactory = () => {
-      const h = createMockHandler();
+      const h = createMockHandler({
+        async start(msg, ctx) {
+          contexts.set(msg.chatId, ctx);
+          messages.set(msg.chatId, msg);
+          return `session-${msg.chatId}`;
+        },
+      });
       handlers.push(h);
       return h;
     };
@@ -497,8 +505,12 @@ describe("SessionManager", () => {
     await sm.dispatch(mockEntry({ id: 1, chatId: "chat-1" }));
     await sm.dispatch(mockEntry({ id: 2, chatId: "chat-2" }));
     expect(sm.totalCount).toBe(2);
+    const firstCtx = contexts.get("chat-1");
+    const firstMessage = messages.get("chat-1");
+    if (!firstCtx || !firstMessage) throw new Error("chat-1 context missing");
+    await firstCtx.finishTurn(firstMessage, { status: "success", terminal: true });
 
-    // Third chat should evict the oldest
+    // Third chat should evict the oldest idle session.
     await sm.dispatch(mockEntry({ id: 3, chatId: "chat-3" }));
     expect(sm.totalCount).toBe(2);
 
@@ -507,14 +519,22 @@ describe("SessionManager", () => {
 
   it("resumes evicted session when new message arrives for same chat", async () => {
     const lifecycleCalls: Array<{ type: string; chatId: string; sessionId?: string }> = [];
+    const contexts = new Map<string, SessionContext>();
+    const messages = new Map<string, SessionMessage>();
     const factory: HandlerFactory = () =>
       createMockHandler({
-        async start(msg) {
+        async start(msg, ctx) {
           const sid = `session-${msg.chatId}`;
+          contexts.set(msg.chatId, ctx);
+          messages.set(msg.chatId, msg);
           lifecycleCalls.push({ type: "start", chatId: msg.chatId });
           return sid;
         },
-        async resume(msg, sessionId) {
+        async resume(msg, sessionId, ctx) {
+          if (msg) {
+            contexts.set(msg.chatId, ctx);
+            messages.set(msg.chatId, msg);
+          }
           lifecycleCalls.push({ type: "resume", chatId: msg?.chatId ?? "", sessionId });
           return sessionId;
         },
@@ -552,6 +572,13 @@ describe("SessionManager", () => {
     await sm.dispatch(chat2);
     await sm.dispatch(chat2);
     expect(sm.totalCount).toBe(2);
+    const chat1Ctx = contexts.get("chat-1");
+    const chat1Msg = messages.get("chat-1");
+    const chat2Ctx = contexts.get("chat-2");
+    const chat2Msg = messages.get("chat-2");
+    if (!chat1Ctx || !chat1Msg || !chat2Ctx || !chat2Msg) throw new Error("initial contexts missing");
+    await chat1Ctx.finishTurn(chat1Msg, { status: "success", terminal: true });
+    await chat2Ctx.finishTurn(chat2Msg, { status: "success", terminal: true });
 
     // Third chat evicts chat-1 (LRU)
     await sm.dispatch(chat3);
@@ -562,6 +589,10 @@ describe("SessionManager", () => {
     await sm.dispatch(chat4);
     await sm.dispatch(chat4);
     expect(sm.totalCount).toBe(2);
+    const chat3Ctx = contexts.get("chat-3");
+    const chat3Msg = messages.get("chat-3");
+    if (!chat3Ctx || !chat3Msg) throw new Error("chat-3 context missing");
+    await chat3Ctx.finishTurn(chat3Msg, { status: "success", terminal: true });
 
     // Send a message to evicted chat-1: first dispatch triggers recovery,
     // second dispatch represents redelivery and should resume, not start.
@@ -774,6 +805,47 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     expect(recoverChat).toHaveBeenCalledTimes(1);
     expect(recoverChat).toHaveBeenCalledWith("chat-preempted");
     expect(ackEntry).not.toHaveBeenCalled();
+
+    await sm.shutdown();
+  });
+
+  it("uses an idle active session before preempting a working session for concurrency", async () => {
+    const ackEntry = vi.fn().mockResolvedValue(undefined);
+    const handlers = new Map<string, AgentHandler>();
+    const contexts = new Map<string, SessionContext>();
+    const messages = new Map<string, SessionMessage>();
+    const factory: HandlerFactory = () => {
+      let current: AgentHandler;
+      current = createMockHandler({
+        async start(message, ctx) {
+          handlers.set(message.chatId, current);
+          contexts.set(message.chatId, ctx);
+          messages.set(message.chatId, message);
+          return `session-${message.chatId}`;
+        },
+      });
+      return current;
+    };
+    const sm = createSessionManager({
+      ackEntry,
+      handlerFactory: factory,
+      concurrency: 2,
+      session: { idle_timeout: 300, max_sessions: 10, working_grace_seconds: 3600, reconcile_interval_seconds: 300 },
+    });
+
+    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-working", messageId: "msg-working" }));
+    await sm.dispatch(mockEntry({ id: 2, chatId: "chat-idle", messageId: "msg-idle" }));
+    const idleCtx = contexts.get("chat-idle");
+    const idleMessage = messages.get("chat-idle");
+    if (!idleCtx || !idleMessage) throw new Error("idle context missing");
+    await idleCtx.finishTurn(idleMessage, { status: "success", terminal: true });
+
+    await sm.dispatch(mockEntry({ id: 3, chatId: "chat-new", messageId: "msg-new" }));
+
+    await vi.waitFor(() => expect(handlers.get("chat-idle")?.suspend).toHaveBeenCalledTimes(1));
+    expect(handlers.get("chat-working")?.suspend).not.toHaveBeenCalled();
+    expect(handlers.has("chat-new")).toBe(true);
+    expect(ackEntry).toHaveBeenCalledWith(2);
 
     await sm.shutdown();
   });
@@ -1240,11 +1312,11 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     const chatB = mockEntry({ id: 2, chatId: "chat-b" });
     await sm.dispatch(chatA);
     await sm.dispatch(chatA);
+    await finishEntry(capturedCtxs[0], 1, "chat-a");
     await sm.dispatch(chatB);
     await sm.dispatch(chatB);
     // Close chat-a and chat-b's start turns so their entries don't pollute
     // the resume-branch ack assertion.
-    await finishEntry(capturedCtxs[0], 1, "chat-a");
     await finishEntry(capturedCtxs[1], 2, "chat-b");
     ackEntry.mockClear();
 

--- a/packages/client/src/__tests__/session-start-error-signaling.test.ts
+++ b/packages/client/src/__tests__/session-start-error-signaling.test.ts
@@ -1,6 +1,6 @@
 import type { SessionEvent, SessionState } from "@first-tree/shared";
 import { describe, expect, it, vi } from "vitest";
-import type { AgentHandler, HandlerFactory } from "../runtime/handler.js";
+import type { AgentHandler, HandlerFactory, SessionContext, SessionMessage } from "../runtime/handler.js";
 import { SessionManager } from "../runtime/session-manager.js";
 import type { FirstTreeHubSDK } from "../sdk.js";
 import { silentLogger } from "./_logger-helpers.js";
@@ -292,6 +292,8 @@ describe("SessionManager: session-resume failure signalling (F2, resume path)", 
     const events: Array<{ chatId: string; event: SessionEvent }> = [];
     const { sdk, sendMessage } = mockSdk();
     const recoverChat = vi.fn().mockResolvedValue(undefined);
+    let chatBContext: SessionContext | undefined;
+    let chatBMessage: SessionMessage | undefined;
     const handlerA: AgentHandler = {
       start: vi.fn().mockResolvedValue("session-A"),
       resume: vi.fn().mockRejectedValue(new FakeClientUserMismatchError("git mirror fetch failed: connection refused")),
@@ -299,8 +301,14 @@ describe("SessionManager: session-resume failure signalling (F2, resume path)", 
       suspend: vi.fn().mockResolvedValue(undefined),
       shutdown: vi.fn().mockResolvedValue(undefined),
     };
+    const handlerB = workingHandler("session-B");
+    handlerB.start = vi.fn(async (message, ctx) => {
+      chatBMessage = message;
+      chatBContext = ctx;
+      return "session-B";
+    });
     const sm = makeSerializedManager({
-      handlerQueue: [handlerA, workingHandler("session-B")],
+      handlerQueue: [handlerA, handlerB],
       sdk,
       onStateChange: (chatId, state) => stateChanges.push({ chatId, state }),
       onSessionEvent: (chatId, event) => events.push({ chatId, event }),
@@ -309,12 +317,14 @@ describe("SessionManager: session-resume failure signalling (F2, resume path)", 
 
     const chatAStart = mockEntry({ id: 1, chatId: "chat-A" });
     const chatBStart = mockEntry({ id: 2, chatId: "chat-B" });
-    const chatAResume = mockEntry({ id: 3, chatId: "chat-A" });
     await sm.dispatch(chatAStart); // starts chat-A
     await sm.dispatch(chatBStart); // starts chat-B and preempts chat-A
     await vi.waitFor(() => expect(recoverChat).toHaveBeenCalledWith("chat-A"));
     await new Promise((resolve) => setImmediate(resolve));
-    await sm.dispatch(chatAResume); // recovery redelivery resumes chat-A -> throws
+    await sm.dispatch(chatAStart); // recovery redelivery queues behind working chat-B
+    if (!chatBContext || !chatBMessage) throw new Error("chat-B context missing");
+    await chatBContext.finishTurn(chatBMessage, { status: "success", terminal: true });
+    await vi.waitFor(() => expect(handlerA.resume).toHaveBeenCalledTimes(1));
 
     const chatAStates = stateChanges.filter((c) => c.chatId === "chat-A").map((c) => c.state);
     expect(chatAStates.at(-1)).toBe("errored");
@@ -345,6 +355,8 @@ describe("SessionManager: session-resume failure signalling (F2, resume path)", 
   it("allows the next inbound message for the same chat to start a fresh session after a resume failure", async () => {
     const stateChanges: Array<{ chatId: string; state: SessionState }> = [];
     const recoverChat = vi.fn().mockResolvedValue(undefined);
+    let chatBContext: SessionContext | undefined;
+    let chatBMessage: SessionMessage | undefined;
     const handlerA: AgentHandler = {
       start: vi.fn().mockResolvedValue("session-A"),
       resume: vi.fn().mockRejectedValue(new FakeClientUserMismatchError("resume blew up")),
@@ -352,22 +364,31 @@ describe("SessionManager: session-resume failure signalling (F2, resume path)", 
       suspend: vi.fn().mockResolvedValue(undefined),
       shutdown: vi.fn().mockResolvedValue(undefined),
     };
+    const handlerB = workingHandler("session-B");
+    handlerB.start = vi.fn(async (message, ctx) => {
+      chatBMessage = message;
+      chatBContext = ctx;
+      return "session-B";
+    });
     const handlerARecovery = workingHandler("session-A-fresh");
     const sm = makeSerializedManager({
-      handlerQueue: [handlerA, workingHandler("session-B"), handlerARecovery],
+      handlerQueue: [handlerA, handlerB, handlerARecovery],
       onStateChange: (chatId, state) => stateChanges.push({ chatId, state }),
       recoverChat,
     });
 
     const chatAStart = mockEntry({ id: 1, chatId: "chat-A" });
     const chatBStart = mockEntry({ id: 2, chatId: "chat-B" });
-    const chatAResume = mockEntry({ id: 3, chatId: "chat-A" });
     const chatARecovery = mockEntry({ id: 4, chatId: "chat-A" });
     await sm.dispatch(chatAStart);
     await sm.dispatch(chatBStart);
     await vi.waitFor(() => expect(recoverChat).toHaveBeenCalledWith("chat-A"));
     await new Promise((resolve) => setImmediate(resolve));
-    await sm.dispatch(chatAResume); // resume → errored
+    await sm.dispatch(chatAStart); // recovery redelivery queues behind working chat-B
+    if (!chatBContext || !chatBMessage) throw new Error("chat-B context missing");
+    await chatBContext.finishTurn(chatBMessage, { status: "success", terminal: true });
+    await vi.waitFor(() => expect(handlerA.resume).toHaveBeenCalledTimes(1)); // resume → errored
+    await vi.waitFor(() => expect(sm.getSessionStates().some((session) => session.chatId === "chat-A")).toBe(false));
 
     // A fresh inbound for chat-A should route as start (entry was dropped
     // on resume failure — the resume catch tears down the same way the

--- a/packages/client/src/__tests__/session-state-notifications.test.ts
+++ b/packages/client/src/__tests__/session-state-notifications.test.ts
@@ -1,7 +1,7 @@
 import type { RuntimeState, SessionState } from "@first-tree/shared";
 import type pino from "pino";
 import { describe, expect, it, vi } from "vitest";
-import type { AgentHandler, HandlerFactory } from "../runtime/handler.js";
+import type { AgentHandler, HandlerFactory, SessionContext, SessionMessage } from "../runtime/handler.js";
 import { SessionManager } from "../runtime/session-manager.js";
 import type { FirstTreeHubSDK } from "../sdk.js";
 import { silentLogger } from "./_logger-helpers.js";
@@ -29,6 +29,34 @@ function createMockHandler(overrides?: Partial<AgentHandler>): AgentHandler {
     shutdown: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   };
+}
+
+function createCapturingFactory() {
+  const contexts = new Map<string, SessionContext>();
+  const messages = new Map<string, SessionMessage>();
+  const factory: HandlerFactory = () => {
+    return createMockHandler({
+      async start(message, ctx) {
+        contexts.set(message.chatId, ctx);
+        messages.set(message.chatId, message);
+        return `session-${message.chatId}`;
+      },
+      async resume(message, _sessionId, ctx) {
+        if (message) {
+          contexts.set(message.chatId, ctx);
+          messages.set(message.chatId, message);
+        }
+        return `session-${message?.chatId ?? "unknown"}`;
+      },
+    });
+  };
+  const finish = async (chatId: string) => {
+    const ctx = contexts.get(chatId);
+    const message = messages.get(chatId);
+    if (!ctx || !message) throw new Error(`${chatId} context missing`);
+    await ctx.finishTurn(message, { status: "success", terminal: true });
+  };
+  return { factory, finish };
 }
 
 function createSessionManager(opts: {
@@ -123,20 +151,17 @@ describe("SessionManager: state notifications", () => {
     // or conflict with the server-authoritative `evicted` terminal. The row
     // stays as last reported; local `evictedMappings` handles resume.
     const stateChanges: Array<{ chatId: string; state: SessionState }> = [];
-    const handlers: AgentHandler[] = [];
+    const capturing = createCapturingFactory();
     const sm = createSessionManager({
       session: { idle_timeout: 300, max_sessions: 2, working_grace_seconds: 3600, reconcile_interval_seconds: 300 },
-      handlerFactory: () => {
-        const h = createMockHandler();
-        handlers.push(h);
-        return h;
-      },
+      handlerFactory: capturing.factory,
       onStateChange: (chatId, state) => stateChanges.push({ chatId, state }),
     });
 
     await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
+    await capturing.finish("chat-a");
     await sm.dispatch(mockEntry({ id: 2, chatId: "chat-b" }));
-    // Third chat triggers eviction of chat-a (LRU)
+    // Third chat triggers eviction of idle chat-a (LRU)
     await sm.dispatch(mockEntry({ id: 3, chatId: "chat-c" }));
 
     const chatAChanges = stateChanges.filter((c) => c.chatId === "chat-a");
@@ -149,24 +174,39 @@ describe("SessionManager: state notifications", () => {
   it("fires onStateChange('active') on resume after suspension", async () => {
     const stateChanges: Array<{ chatId: string; state: SessionState }> = [];
     const recoverChat = vi.fn().mockResolvedValue(undefined);
+    let chatBContext: SessionContext | undefined;
+    let chatBMessage: SessionMessage | undefined;
+    const handlerA = createMockHandler({
+      start: vi.fn().mockResolvedValue("session-chat-a"),
+      resume: vi.fn().mockResolvedValue("session-chat-a"),
+    });
+    const handlerB = createMockHandler({
+      async start(message, ctx) {
+        chatBMessage = message;
+        chatBContext = ctx;
+        return "session-chat-b";
+      },
+    });
+    const handlers = [handlerA, handlerB];
     const sm = createSessionManager({
       concurrency: 1,
+      handlerFactory: () => handlers.shift() ?? createMockHandler(),
       onStateChange: (chatId, state) => stateChanges.push({ chatId, state }),
       recoverChat,
     });
 
-    // chat-a starts (active), chat-b preempts chat-a (suspended → active)
+    // chat-a starts, chat-b preempts it, then the redelivered chat-a frame
+    // waits until chat-b finishes and yields the only active slot.
     const chatA = mockEntry({ id: 1, chatId: "chat-a" });
     const chatB = mockEntry({ id: 2, chatId: "chat-b" });
-    const chatAResume = mockEntry({ id: 3, chatId: "chat-a" });
-    await sm.dispatch(chatA);
     await sm.dispatch(chatA);
     await sm.dispatch(chatB);
-    await sm.dispatch(chatB);
-    // Resume now goes through chat-scoped recovery first; the second dispatch
-    // represents the redelivered frame that can enter the resume branch.
-    await sm.dispatch(chatAResume);
-    await sm.dispatch(chatAResume);
+    await vi.waitFor(() => expect(recoverChat).toHaveBeenCalledWith("chat-a"));
+    await new Promise((resolve) => setImmediate(resolve));
+    await sm.dispatch(chatA);
+    if (!chatBContext || !chatBMessage) throw new Error("chat-b context missing");
+    await chatBContext.finishTurn(chatBMessage, { status: "success", terminal: true });
+    await vi.waitFor(() => expect(handlerA.resume).toHaveBeenCalledTimes(1));
 
     const chatAChanges = stateChanges.filter((c) => c.chatId === "chat-a");
     expect(chatAChanges).toEqual([
@@ -294,13 +334,16 @@ describe("SessionManager: getEvictedChatIds()", () => {
   // them as "suspended" on the wire so the server's
   // `agent_chat_sessions.state` isn't stuck on a pre-restart snapshot.
   it("returns evictedMappings keys (LRU-evicted chats included)", async () => {
+    const capturing = createCapturingFactory();
     const sm = createSessionManager({
       session: { idle_timeout: 300, max_sessions: 2, working_grace_seconds: 3600, reconcile_interval_seconds: 300 },
+      handlerFactory: capturing.factory,
     });
 
     await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
+    await capturing.finish("chat-a");
     await sm.dispatch(mockEntry({ id: 2, chatId: "chat-b" }));
-    // chat-c forces LRU eviction of the older chat (chat-a is suspended-then-evicted
+    // chat-c forces LRU eviction of the older idle chat (chat-a is evicted
     // out of `sessions` into `evictedMappings`).
     await sm.dispatch(mockEntry({ id: 3, chatId: "chat-c" }));
 
@@ -400,12 +443,15 @@ describe("SessionManager: terminate + reconcile", () => {
 
   it("applyStaleChatIds() cleans up both live sessions and evicted mappings", async () => {
     const stateChanges: Array<{ chatId: string; state: SessionState }> = [];
+    const capturing = createCapturingFactory();
     const sm = createSessionManager({
       session: { idle_timeout: 300, max_sessions: 2, working_grace_seconds: 3600, reconcile_interval_seconds: 300 },
+      handlerFactory: capturing.factory,
       onStateChange: (chatId, state) => stateChanges.push({ chatId, state }),
     });
 
     await sm.dispatch(mockEntry({ id: 1, chatId: "chat-a" }));
+    await capturing.finish("chat-a");
     await sm.dispatch(mockEntry({ id: 2, chatId: "chat-b" }));
     await sm.dispatch(mockEntry({ id: 3, chatId: "chat-c" })); // chat-a → evictedMappings
 

--- a/packages/client/src/runtime/inbox-delivery-coordinator.ts
+++ b/packages/client/src/runtime/inbox-delivery-coordinator.ts
@@ -87,13 +87,17 @@ export class InboxDeliveryCoordinator {
 
   shouldRecoverBeforeDispatch(chatId: string, hasHealthyLiveHandler: boolean, hasLocalSessionRecord: boolean): boolean {
     const ledger = this.ledgers.get(chatId);
-    if (ledger?.recoveryActivationReady) {
-      ledger.recoveryActivationReady = false;
-      this.cleanupLedger(chatId);
-      return false;
-    }
+    if (ledger?.recoveryActivationReady) return false;
     if (ledger?.recoveryDebt === "required" || ledger?.recoveryDebt === "running") return true;
     return Boolean(this.config.recoverChat) && hasLocalSessionRecord && !hasHealthyLiveHandler;
+  }
+
+  takeRecoveryActivationReady(chatId: string): boolean {
+    const ledger = this.ledgers.get(chatId);
+    if (!ledger?.recoveryActivationReady) return false;
+    ledger.recoveryActivationReady = false;
+    this.cleanupLedger(chatId);
+    return true;
   }
 
   async recoverIfNeeded(chatId: string, reason: string): Promise<void> {

--- a/packages/client/src/runtime/inbox-delivery-coordinator.ts
+++ b/packages/client/src/runtime/inbox-delivery-coordinator.ts
@@ -38,6 +38,9 @@ type ChatInboxLedger = {
   entries: TrackedDelivery[];
   recoveryDebt: RecoveryDebt;
   recoveryActivationReady: boolean;
+  // Server recovery can redeliver several frames after one accepted request;
+  // keep classifying that burst as recovery while any redelivered work is unsettled.
+  recoveryWindowOpen: boolean;
   admissionQueue: Promise<void> | null;
   ackQueue: Promise<void> | null;
 };
@@ -94,10 +97,13 @@ export class InboxDeliveryCoordinator {
 
   takeRecoveryActivationReady(chatId: string): boolean {
     const ledger = this.ledgers.get(chatId);
-    if (!ledger?.recoveryActivationReady) return false;
-    ledger.recoveryActivationReady = false;
-    this.cleanupLedger(chatId);
-    return true;
+    if (!ledger) return false;
+    if (ledger.recoveryActivationReady) {
+      ledger.recoveryActivationReady = false;
+      ledger.recoveryWindowOpen = true;
+      return true;
+    }
+    return ledger.recoveryWindowOpen && this.hasUnsettledWork(chatId);
   }
 
   async recoverIfNeeded(chatId: string, reason: string): Promise<void> {
@@ -133,6 +139,7 @@ export class InboxDeliveryCoordinator {
         const current = this.ledger(chatId);
         current.recoveryDebt = "none";
         current.recoveryActivationReady = true;
+        current.recoveryWindowOpen = false;
         this.config.log.debug({ chatId, reason }, "chat inbox recovery accepted before dispatch");
       })
       .catch((err) => {
@@ -444,6 +451,7 @@ export class InboxDeliveryCoordinator {
       entries: [],
       recoveryDebt: "none",
       recoveryActivationReady: false,
+      recoveryWindowOpen: false,
       admissionQueue: null,
       ackQueue: null,
     };
@@ -455,9 +463,19 @@ export class InboxDeliveryCoordinator {
     const ledger = this.ledgers.get(chatId);
     if (!ledger) return;
     if (
+      ledger.recoveryWindowOpen &&
+      ledger.entries.length === 0 &&
+      ledger.recoveryDebt === "none" &&
+      ledger.admissionQueue === null &&
+      ledger.ackQueue === null
+    ) {
+      ledger.recoveryWindowOpen = false;
+    }
+    if (
       ledger.entries.length === 0 &&
       ledger.recoveryDebt === "none" &&
       !ledger.recoveryActivationReady &&
+      !ledger.recoveryWindowOpen &&
       ledger.admissionQueue === null &&
       ledger.ackQueue === null
     ) {

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -84,7 +84,10 @@ type SessionEntry = {
 type PendingMessage = {
   message: SessionMessage;
   chatId: string;
+  deliveryKind: SlotDeliveryKind;
 };
+
+type SlotDeliveryKind = "fresh" | "recovery";
 
 /**
  * Resolve the directory the runtime reads markdown doc snapshots against —
@@ -381,8 +384,10 @@ export class SessionManager {
   async dispatch(entry: InboxEntryWithMessage): Promise<void> {
     const chatId = entry.chatId ?? entry.message.chatId;
     const messageId = entry.message.id;
+    const isRecoveryRedelivery = this.inboxDelivery.takeRecoveryActivationReady(chatId);
 
     if (
+      !isRecoveryRedelivery &&
       this.inboxDelivery.shouldRecoverBeforeDispatch(
         chatId,
         this.hasHealthyLiveHandler(chatId) || this.hasPendingTransientRetry(chatId),
@@ -463,7 +468,8 @@ export class SessionManager {
       // admission barrier: for Codex/TUI, route promises can span the whole
       // turn, but same-chat later messages must still be able to append once
       // this entry has reached handler membership.
-      routePromise = this.routeMessage(chatId, message).catch((err) => {
+      const deliveryKind: SlotDeliveryKind = isRecoveryRedelivery ? "recovery" : "fresh";
+      routePromise = this.routeMessage(chatId, message, deliveryKind).catch((err) => {
         if (this.inboxDelivery.hasEntry(work)) {
           this.inboxDelivery.retryTurn(chatId, message, "route_message_failed");
         }
@@ -692,7 +698,11 @@ export class SessionManager {
     return this.sessions.has(chatId) || this.evictedMappings.has(chatId);
   }
 
-  private async routeMessage(chatId: string, message: SessionMessage): Promise<void> {
+  private async routeMessage(
+    chatId: string,
+    message: SessionMessage,
+    deliveryKind: SlotDeliveryKind = "fresh",
+  ): Promise<void> {
     const existing = this.sessions.get(chatId);
 
     // Transient retry path: keep the original start/resume message at the head
@@ -716,13 +726,13 @@ export class SessionManager {
 
         case "suspended":
         case "evicted":
-          await this.resumeSession(existing, message);
+          await this.resumeSession(existing, message, deliveryKind);
           return;
       }
     }
 
     // No existing session — create new
-    await this.startNewSession(chatId, message);
+    await this.startNewSession(chatId, message, deliveryKind);
   }
 
   /**
@@ -762,12 +772,17 @@ export class SessionManager {
     );
   }
 
-  private async startNewSession(chatId: string, message: SessionMessage): Promise<void> {
-    // Enforce concurrency limit
-    if (!this.acquireActiveSlot(chatId, message)) return;
+  private async startNewSession(
+    chatId: string,
+    message: SessionMessage,
+    deliveryKind: SlotDeliveryKind,
+  ): Promise<void> {
+    // Enforce max_sessions before active-slot preemption so a full pool of
+    // working sessions queues instead of first suspending a working victim.
+    if (!this.evictIfNeeded(chatId, message, deliveryKind)) return;
 
-    // Enforce max_sessions (evict LRU)
-    this.evictIfNeeded();
+    // Enforce concurrency limit
+    if (!this.acquireActiveSlot(chatId, message, deliveryKind)) return;
 
     // Check for prior evicted session mapping
     const evicted = this.evictedMappings.get(chatId);
@@ -841,7 +856,11 @@ export class SessionManager {
     }
   }
 
-  private async resumeSession(entry: SessionEntry, message: SessionMessage | null | undefined): Promise<void> {
+  private async resumeSession(
+    entry: SessionEntry,
+    message: SessionMessage | null | undefined,
+    deliveryKind: SlotDeliveryKind = "fresh",
+  ): Promise<void> {
     // Wait for in-flight suspension to complete before resuming
     if (entry.suspending) {
       await entry.suspending;
@@ -858,7 +877,7 @@ export class SessionManager {
     };
 
     // Enforce concurrency limit
-    if (!this.acquireActiveSlot(entry.chatId, slotMessage)) return;
+    if (!this.acquireActiveSlot(entry.chatId, slotMessage, deliveryKind)) return;
 
     const ctx = this.buildSessionContext(entry.chatId);
     entry.status = "active";
@@ -1071,7 +1090,7 @@ export class SessionManager {
     // Enforce concurrency limit before claiming the slot. If we cannot, the
     // entry stays in transient-retry state and a future retry / message will
     // try again.
-    if (!this.acquireActiveSlot(chatId, entry.startMessage ?? buildEmptySessionMessage(chatId))) {
+    if (!this.acquireActiveSlot(chatId, entry.startMessage ?? buildEmptySessionMessage(chatId), "recovery")) {
       // Couldn't get a slot — re-arm the timer with a short delay.
       const nextDelay = 5_000;
       entry.retryNextAt = Date.now() + nextDelay;
@@ -1199,44 +1218,102 @@ export class SessionManager {
 
   /**
    * Try to acquire an active slot. If at concurrency limit:
-   * 1. Suspend the least-recently-active session to free a slot
-   * 2. If no candidates, queue the message
+   * 1. Suspend the least-recently-active idle session to free a slot.
+   * 2. For fresh external input only, preempt the least-recently-active
+   *    working session as a last resort and force recovery for its work.
+   * 3. Queue recovery/internal traffic instead of displacing working sessions.
    *
    * Returns true if slot acquired, false if queued. The in-flight entryId
    * is tracked separately in `InboxDeliveryCoordinator` (populated at dispatch),
    * so the queue doesn't carry inbox metadata.
    */
-  private acquireActiveSlot(chatId: string, message: SessionMessage): boolean {
+  private acquireActiveSlot(
+    chatId: string,
+    message: SessionMessage,
+    deliveryKind: SlotDeliveryKind = "fresh",
+  ): boolean {
     if (this._activeCount < this.config.concurrency) return true;
 
-    // Find least-recently-active session (excluding the target chat)
-    let oldestActive: SessionEntry | null = null;
-    for (const session of this.sessions.values()) {
-      if (session.status !== "active") continue;
-      if (session.chatId === chatId) continue;
-      if (!oldestActive || session.lastActivity < oldestActive.lastActivity) {
-        oldestActive = session;
-      }
-    }
-
-    if (oldestActive) {
-      this.config.log.info({ chatId: oldestActive.chatId }, "session preempted for concurrency");
-      this.suspendSession(oldestActive, { reason: "concurrency_preempted", ackConsumedPrefix: false });
+    const idleVictim = this.findOldestActiveSession(
+      (session) => session.chatId !== chatId && !this.inboxDelivery.hasUnsettledWork(session.chatId),
+    );
+    if (idleVictim) {
+      this.config.log.info(
+        { chatId: idleVictim.chatId, requesterChatId: chatId },
+        "idle session yielded for concurrency",
+      );
+      this.emitResilienceEvent(idleVictim.chatId, "resilience.session.preempted", {
+        reason: "concurrency_idle_yield",
+        requesterChatId: chatId,
+      });
+      this.suspendSession(idleVictim, { reason: "concurrency_idle_yield", ackConsumedPrefix: true, drainQueue: false });
       return true;
     }
 
-    // All active sessions are busy — queue. The inbox entry stays in
-    // the coordinator ledger until the eventual turn finishes.
-    this.config.log.info({ chatId }, "concurrency limit reached, queuing");
-    this.pendingQueue.push({ message, chatId });
+    const workingVictim =
+      deliveryKind === "fresh" ? this.findOldestActiveSession((session) => session.chatId !== chatId) : null;
+    if (workingVictim) {
+      this.config.log.info(
+        { chatId: workingVictim.chatId, requesterChatId: chatId },
+        "working session preempted for fresh input",
+      );
+      this.emitResilienceEvent(workingVictim.chatId, "resilience.session.preempted", {
+        reason: "concurrency_preempted",
+        requesterChatId: chatId,
+      });
+      this.suspendSession(workingVictim, {
+        reason: "concurrency_preempted",
+        ackConsumedPrefix: false,
+        drainQueue: false,
+      });
+      return true;
+    }
+
+    this.queueForSlot(chatId, message, deliveryKind, "concurrency_limit");
     return false;
+  }
+
+  private findOldestActiveSession(eligible: (session: SessionEntry) => boolean): SessionEntry | null {
+    let oldest: SessionEntry | null = null;
+    for (const session of this.sessions.values()) {
+      if (session.status !== "active") continue;
+      if (!eligible(session)) continue;
+      if (!oldest || session.lastActivity < oldest.lastActivity) oldest = session;
+    }
+    return oldest;
+  }
+
+  private queueForSlot(
+    chatId: string,
+    message: SessionMessage,
+    deliveryKind: SlotDeliveryKind,
+    reason: "concurrency_limit" | "max_sessions_all_working",
+  ): void {
+    this.config.log.info({ chatId, deliveryKind, reason }, "session slot unavailable, queuing");
+    this.emitResilienceEvent(chatId, "resilience.session.queued", { reason, deliveryKind });
+    this.pendingQueue.push({ message, chatId, deliveryKind });
+  }
+
+  private emitResilienceEvent(chatId: string, eventName: string, payload: Record<string, unknown>): void {
+    try {
+      this.config.onSessionEvent?.(chatId, {
+        kind: "error",
+        payload: {
+          source: "runtime",
+          message: encodeResilienceMessage(eventName, payload),
+        },
+      });
+    } catch (err) {
+      this.config.log.warn({ chatId, eventName, err }, "resilience event emit failed");
+    }
   }
 
   private suspendSession(
     entry: SessionEntry,
-    opts: { reason: string; ackConsumedPrefix: boolean } = {
+    opts: { reason: string; ackConsumedPrefix: boolean; drainQueue?: boolean } = {
       reason: "session_suspended",
       ackConsumedPrefix: true,
+      drainQueue: true,
     },
   ): void {
     const prepare = opts.ackConsumedPrefix
@@ -1262,39 +1339,67 @@ export class SessionManager {
     this.persistRegistry();
     this.notifySessionState(entry.chatId, "suspended");
 
-    // Drain pending queue
-    this.drainPendingQueue();
+    if (opts.drainQueue !== false) this.drainPendingQueue();
   }
 
   private drainPendingQueue(): void {
     if (this.pendingQueue.length === 0) return;
-    if (this._activeCount >= this.config.concurrency) return;
-
-    const next = this.pendingQueue.shift();
+    const next = this.pendingQueue[0];
     if (!next) return;
+    if (
+      this._activeCount >= this.config.concurrency &&
+      !this.findOldestActiveSession(
+        (session) => session.chatId !== next.chatId && !this.inboxDelivery.hasUnsettledWork(session.chatId),
+      )
+    ) {
+      return;
+    }
+
+    this.pendingQueue.shift();
     // Route asynchronously — the delivery work is already tracked by the
     // coordinator from the original `dispatch`.
-    this.routeMessage(next.chatId, next.message).catch((err) => {
-      this.config.log.warn({ chatId: next.chatId, err }, "pending drain error");
+    this.routeMessage(next.chatId, next.message, next.deliveryKind).catch((err) => {
+      const hasInboxEntryId = next.message.inboxEntryId !== undefined;
+      this.config.log.warn({ chatId: next.chatId, hasInboxEntryId, err }, "pending drain error");
+      if (hasInboxEntryId) {
+        this.inboxDelivery.retryTurn(next.chatId, next.message, "pending_drain_failed");
+      } else {
+        this.pendingQueue.unshift(next);
+      }
     });
   }
 
-  private evictIfNeeded(): void {
+  private evictIfNeeded(chatId?: string, message?: SessionMessage, deliveryKind: SlotDeliveryKind = "fresh"): boolean {
     const { max_sessions } = this.config.session;
-    if (this.sessions.size < max_sessions) return;
+    if (this.sessions.size < max_sessions) return true;
 
-    // Single pass: find LRU session, preferring non-active over active
-    let candidate: { key: string; session: SessionEntry } | null = null;
+    // Prefer non-active sessions, then idle active sessions. Working active
+    // sessions are not memory-management victims: dropping them silently loses
+    // replies/tool side effects unless their work is explicitly recovered.
+    let nonActiveCandidate: { key: string; session: SessionEntry } | null = null;
+    let idleActiveCandidate: { key: string; session: SessionEntry } | null = null;
     for (const [key, session] of this.sessions) {
-      if (!candidate) {
-        candidate = { key, session };
+      if (session.status !== "active") {
+        if (!nonActiveCandidate || session.lastActivity < nonActiveCandidate.session.lastActivity) {
+          nonActiveCandidate = { key, session };
+        }
         continue;
       }
-      const preferNonActive = session.status !== "active" && candidate.session.status === "active";
-      const sameCategory = (session.status === "active") === (candidate.session.status === "active");
-      if (preferNonActive || (sameCategory && session.lastActivity < candidate.session.lastActivity)) {
-        candidate = { key, session };
+      if (!this.inboxDelivery.hasUnsettledWork(key)) {
+        if (!idleActiveCandidate || session.lastActivity < idleActiveCandidate.session.lastActivity) {
+          idleActiveCandidate = { key, session };
+        }
       }
+    }
+
+    const candidate = nonActiveCandidate ?? idleActiveCandidate;
+    if (!candidate) {
+      if (chatId && message) {
+        this.queueForSlot(chatId, message, deliveryKind, "max_sessions_all_working");
+      } else {
+        this.config.log.info({ maxSessions: max_sessions }, "max_sessions reached with no idle eviction candidate");
+      }
+      return false;
     }
 
     if (candidate) {
@@ -1328,6 +1433,7 @@ export class SessionManager {
       this.recomputeRuntimeState();
       this.persistRegistry();
     }
+    return true;
   }
 
   /**
@@ -1523,10 +1629,12 @@ export class SessionManager {
       if (this.sessionRuntimeStates.delete(chatId)) this.recomputeRuntimeState();
       return;
     }
-    if (this.sessionRuntimeStates.get(chatId) === state) return;
+    const previous = this.sessionRuntimeStates.get(chatId);
+    if (previous === state) return;
     this.sessionRuntimeStates.set(chatId, state);
     this.config.onSessionRuntimeChange?.(chatId, state);
     this.recomputeRuntimeState();
+    if (state === "idle" && this.pendingQueue.length > 0) this.drainPendingQueue();
   }
 
   private projectedRuntimeState(chatId: string, session: SessionEntry | null): RuntimeState | null {

--- a/packages/server/src/__tests__/inbox-ws-push.test.ts
+++ b/packages/server/src/__tests__/inbox-ws-push.test.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq } from "drizzle-orm";
+import { and, asc, eq, inArray } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { describe, expect, it } from "vitest";
 import { chatMembership } from "../db/schema/chat-membership.js";
@@ -492,6 +492,38 @@ describe("inbox WS data-plane claim helpers", () => {
     expect(accepted.ackedCount).toBe(2);
     expect(accepted.ackedEntryIds).toEqual([first.id, second.id]);
     expect(accepted.throughEntry.id).toBe(second.id);
+
+    const after = await app.db
+      .select({ id: inboxEntries.id, status: inboxEntries.status })
+      .from(inboxEntries)
+      .where(and(eq(inboxEntries.inboxId, a2.agent.inboxId), eq(inboxEntries.notify, true)))
+      .orderBy(asc(inboxEntries.id));
+    expect(after.map((row) => [row.id, row.status])).toEqual([
+      [first.id, "acked"],
+      [second.id, "acked"],
+    ]);
+  });
+
+  it("ackEntryByIdForBoundAgents accepts delivered rows reset to pending by recovery", async () => {
+    const app = getApp();
+    const { a2, messageIds, rows } = await seedDeliverables(app, 2);
+    const first = rows[0];
+    const second = rows[1];
+    if (!first || !second) throw new Error("expected two inbox rows");
+
+    await inboxService.claimAndBuildForPush(app.db, a2.agent.inboxId, messageIds[0] ?? "");
+    await inboxService.claimAndBuildForPush(app.db, a2.agent.inboxId, messageIds[1] ?? "");
+    await app.db
+      .update(inboxEntries)
+      .set({ status: "pending" })
+      .where(inArray(inboxEntries.id, [first.id, second.id]));
+
+    const accepted = await inboxService.ackEntryByIdForBoundAgents(app.db, second.id, [a2.agent.inboxId]);
+    expect(accepted.ok).toBe(true);
+    if (!accepted.ok) throw new Error("ack-through unexpectedly rejected");
+    expect(accepted.disposition).toBe("accepted_from_pending");
+    expect(accepted.ackedCount).toBe(2);
+    expect(accepted.ackedEntryIds).toEqual([first.id, second.id]);
 
     const after = await app.db
       .select({ id: inboxEntries.id, status: inboxEntries.status })

--- a/packages/server/src/services/inbox.ts
+++ b/packages/server/src/services/inbox.ts
@@ -17,7 +17,7 @@ export type AckEntryResult =
   | {
       ok: true;
       throughEntry: typeof inboxEntries.$inferSelect;
-      disposition: "acked" | "already_acked";
+      disposition: "acked" | "already_acked" | "accepted_from_pending";
       ackedCount: number;
       ackedEntryIds: number[];
     }
@@ -512,11 +512,14 @@ export async function ackThroughEntryIdForBoundAgents(
         .orderBy(asc(inboxEntries.id))
         .for("update");
 
-      if (prefixRows.some((row) => row.status !== "acked" && row.status !== "delivered")) {
+      const isResetDeliveredRow = (row: ClaimedEntry): boolean => row.status === "pending" && row.deliveredAt !== null;
+      if (prefixRows.some((row) => row.status !== "acked" && row.status !== "delivered" && !isResetDeliveredRow(row))) {
         return { ok: false, reason: "prefix_gap" };
       }
 
       const deliveredIds = prefixRows.filter((row) => row.status === "delivered").map((row) => row.id);
+      const resetPendingIds = prefixRows.filter(isResetDeliveredRow).map((row) => row.id);
+      const committableIds = [...deliveredIds, ...resetPendingIds];
       const ackedAt = new Date();
       const drainPendingSilentRows = async (): Promise<void> => {
         await tx
@@ -533,7 +536,7 @@ export async function ackThroughEntryIdForBoundAgents(
           );
       };
 
-      if (deliveredIds.length === 0) {
+      if (committableIds.length === 0) {
         await drainPendingSilentRows();
         return {
           ok: true,
@@ -547,14 +550,14 @@ export async function ackThroughEntryIdForBoundAgents(
       const updated = await tx
         .update(inboxEntries)
         .set({ status: "acked", ackedAt })
-        .where(and(inArray(inboxEntries.id, deliveredIds), eq(inboxEntries.status, "delivered")))
+        .where(and(inArray(inboxEntries.id, committableIds), inArray(inboxEntries.status, ["delivered", "pending"])))
         .returning();
       await drainPendingSilentRows();
       const updatedThroughEntry = updated.find((row) => row.id === entryId) ?? entry;
       return {
         ok: true,
         throughEntry: updatedThroughEntry,
-        disposition: "acked",
+        disposition: resetPendingIds.length > 0 ? "accepted_from_pending" : "acked",
         ackedCount: updated.length,
         ackedEntryIds: updated.map((row) => row.id),
       };


### PR DESCRIPTION
## Summary

- Accept ACK-through for notify rows that were delivered and then reset back to pending during recovery, returning `accepted_from_pending` while still rejecting never-delivered pending prefix gaps.
- Teach session scheduling to distinguish fresh external input from recovery/internal traffic: idle active sessions yield first, fresh input can preempt working sessions only as a last resort, and recovery traffic queues instead of preempting working sessions.
- Keep queued work recoverable by preventing queue-drain slot stealing and marking queued inbox work for recovery if pending drain routing fails.

## Tests

- `pnpm --filter @first-tree/client exec vitest run --maxWorkers=2 src/__tests__/session-manager.test.ts src/__tests__/session-manager-edge-coverage.test.ts`
- `pnpm --filter @first-tree/server exec vitest run --maxWorkers=2 src/__tests__/inbox-ws-push.test.ts`
- `pnpm exec biome check packages/client/src/runtime/session-manager.ts packages/client/src/runtime/inbox-delivery-coordinator.ts packages/client/src/__tests__/session-manager.test.ts packages/client/src/__tests__/session-manager-edge-coverage.test.ts packages/server/src/services/inbox.ts packages/server/src/__tests__/inbox-ws-push.test.ts`
- `pnpm check`
- `pnpm typecheck`
- `git diff --check`

## Notes

`pnpm check` exits successfully, with existing warnings outside this change in:

- `packages/web/src/pages/agent-detail/prompt-tab.tsx`
- `apps/cli/src/__tests__/agent-shared-helpers-extra.test.ts`
- `packages/client/src/runtime/workspace-migrations.ts`
