### PR TITLE
fix: add fair inbox delivery windows

### DIFF
--- a/packages/server/src/__tests__/helpers.ts
+++ b/packages/server/src/__tests__/helpers.ts
@@ -59,6 +59,7 @@ export type CreateTestAppOptions = {
   channel?: Config["channel"];
   commandVersion?: string;
   rateLimit?: Partial<NonNullable<Config["rateLimit"]>>;
+  inbox?: Partial<NonNullable<Config["inbox"]>>;
   allowedOrganizationId?: string;
   /**
    * Drop `oauth.githubApp.slug` from the test config. Used by the
@@ -128,6 +129,9 @@ export async function createTestApp(opts: CreateTestAppOptions = {}): Promise<Fa
     },
     trustProxy: false,
     rateLimit: { ...baseRateLimit, ...opts.rateLimit },
+    ...(opts.inbox !== undefined
+      ? { inbox: { maxInFlightPerAgent: 8192, maxInFlightPerAgentChat: 8, ...opts.inbox } }
+      : {}),
     observability: {
       logging: { level: "error", format: "json", bridgeToSpanLevel: "off" },
     },

--- a/packages/server/src/__tests__/inbox-ws-push.test.ts
+++ b/packages/server/src/__tests__/inbox-ws-push.test.ts
@@ -66,6 +66,29 @@ describe("inbox WS data-plane claim helpers", () => {
     return { a2, chatId, messageIds, rows };
   }
 
+  async function seedDeliverablesAcrossChats(app: FastifyInstance, messagesPerChat: number[]) {
+    const uid = crypto.randomUUID().slice(0, 6);
+    const a1 = await createTestAgent(app, { name: `wspf-a1-${uid}` });
+    const a2 = await createTestAgent(app, { name: `wspf-a2-${uid}` });
+    const chatIds: string[] = [];
+    for (const [chatIndex, count] of messagesPerChat.entries()) {
+      const chatRes = await a1.request("POST", "/api/v1/agent/chats", {
+        type: "group",
+        participantIds: [a2.agent.uuid],
+      });
+      const chatId = chatRes.json().id;
+      chatIds.push(chatId);
+      for (let i = 0; i < count; i++) {
+        await a1.request("POST", `/api/v1/agent/chats/${chatId}/messages`, {
+          format: "text",
+          content: `chat ${chatIndex} msg ${i}`,
+          receiverNames: [a2.agent.name],
+        });
+      }
+    }
+    return { a2, chatIds };
+  }
+
   async function loadSilentRows(app: FastifyInstance, inboxId: string, chatId: string) {
     return app.db
       .select({ id: inboxEntries.id, status: inboxEntries.status })
@@ -433,6 +456,131 @@ describe("inbox WS data-plane claim helpers", () => {
     // ever regresses to raw SQL, every push frame would be dropped client-
     // side as malformed. See issue #194.
     for (const e of drained) expect(typeof e.id).toBe("number");
+  });
+
+  it("claimBacklogForPushFair limits a single chat to its per-chat budget", async () => {
+    const app = getApp();
+    const { a2, chatId } = await seedDeliverables(app, 12);
+
+    const drained = await inboxService.claimBacklogForPushFair(app.db, a2.agent.inboxId, {
+      limit: 50,
+      defaultPerChatLimit: 8,
+      chatBudgets: [],
+    });
+
+    expect(drained).toHaveLength(8);
+    expect(drained.every((entry) => entry.chatId === chatId)).toBe(true);
+    expect(drained.map((entry) => entry.id)).toEqual([...drained].map((entry) => entry.id).sort((a, b) => a - b));
+
+    const rows = await app.db
+      .select({ id: inboxEntries.id, status: inboxEntries.status })
+      .from(inboxEntries)
+      .where(
+        and(eq(inboxEntries.inboxId, a2.agent.inboxId), eq(inboxEntries.chatId, chatId), eq(inboxEntries.notify, true)),
+      )
+      .orderBy(asc(inboxEntries.id));
+    expect(rows.filter((row) => row.status === "delivered")).toHaveLength(8);
+    expect(rows.filter((row) => row.status === "pending")).toHaveLength(4);
+  });
+
+  it("claimBacklogForPushFair skips a capped chat while claiming another eligible chat", async () => {
+    const app = getApp();
+    const { a2, chatIds } = await seedDeliverablesAcrossChats(app, [3, 2]);
+    const cappedChatId = chatIds[0];
+    const eligibleChatId = chatIds[1];
+    if (!cappedChatId || !eligibleChatId) throw new Error("expected two chats");
+
+    const drained = await inboxService.claimBacklogForPushFair(app.db, a2.agent.inboxId, {
+      limit: 10,
+      defaultPerChatLimit: 2,
+      chatBudgets: [{ chatId: cappedChatId, remaining: 0 }],
+    });
+
+    expect(drained).toHaveLength(2);
+    expect(drained.every((entry) => entry.chatId === eligibleChatId)).toBe(true);
+
+    const cappedRows = await app.db
+      .select({ status: inboxEntries.status })
+      .from(inboxEntries)
+      .where(
+        and(
+          eq(inboxEntries.inboxId, a2.agent.inboxId),
+          eq(inboxEntries.chatId, cappedChatId),
+          eq(inboxEntries.notify, true),
+        ),
+      );
+    expect(cappedRows.every((row) => row.status === "pending")).toBe(true);
+  });
+
+  it("claimBacklogForPushFair fills post-ack budget across eligible chats", async () => {
+    const app = getApp();
+    const { a2, chatIds } = await seedDeliverablesAcrossChats(app, [3, 3]);
+    const ackedChatId = chatIds[0];
+    const otherChatId = chatIds[1];
+    if (!ackedChatId || !otherChatId) throw new Error("expected two chats");
+
+    const drained = await inboxService.claimBacklogForPushFair(app.db, a2.agent.inboxId, {
+      limit: 3,
+      defaultPerChatLimit: 2,
+      chatBudgets: [{ chatId: ackedChatId, remaining: 1 }],
+    });
+
+    expect(drained).toHaveLength(3);
+    expect(drained.filter((entry) => entry.chatId === ackedChatId)).toHaveLength(1);
+    expect(drained.filter((entry) => entry.chatId === otherChatId)).toHaveLength(2);
+  });
+
+  it("claimBacklogForPushFair bundles silent context without spending extra per-chat slots", async () => {
+    const app = getApp();
+    const uid = crypto.randomUUID().slice(0, 6);
+    const human = await createTestAgent(app, { type: "human", name: `fairctx-h-${uid}` });
+    const observer = await createTestAgent(app, { type: "agent", name: `fairctx-a-${uid}` });
+    const chat = await createChat(app.db, human.agent.uuid, {
+      type: "group",
+      participantIds: [observer.agent.uuid],
+    });
+
+    await sendMessage(
+      app.db,
+      chat.id,
+      human.agent.uuid,
+      { source: "api", format: "text", content: "silent one" },
+      { allowRecipientlessSend: true },
+    );
+    await sendMessage(
+      app.db,
+      chat.id,
+      human.agent.uuid,
+      { source: "api", format: "text", content: "silent two" },
+      { allowRecipientlessSend: true },
+    );
+    await sendMessage(app.db, chat.id, human.agent.uuid, {
+      source: "api",
+      format: "text",
+      content: "notify one",
+      metadata: { mentions: [observer.agent.uuid] },
+    });
+    await sendMessage(app.db, chat.id, human.agent.uuid, {
+      source: "api",
+      format: "text",
+      content: "notify two",
+      metadata: { mentions: [observer.agent.uuid] },
+    });
+
+    const drained = await inboxService.claimBacklogForPushFair(app.db, observer.agent.inboxId, {
+      limit: 50,
+      defaultPerChatLimit: 1,
+      chatBudgets: [],
+    });
+
+    expect(drained).toHaveLength(1);
+    const entry = drained[0];
+    if (!entry) throw new Error("expected fair delivery");
+    expect(entry.message.content).toBe("notify one");
+    expect(entry.message.precedingMessages.map((p) => p.content)).toEqual(["silent one", "silent two"]);
+
+    const silentRows = await loadSilentRows(app, observer.agent.inboxId, chat.id);
+    expect(silentRows.every((row) => row.status === "pending")).toBe(true);
   });
 
   it("uses inbox id cursor order even when createdAt is reversed", async () => {

--- a/packages/server/src/__tests__/ws-inbox-delivery-order.test.ts
+++ b/packages/server/src/__tests__/ws-inbox-delivery-order.test.ts
@@ -146,4 +146,88 @@ describe("Agent WS — inbox delivery ordering", () => {
       await new Promise<void>((resolve) => ws.once("close", () => resolve()));
     }
   }, 15000);
+
+  it("keeps other chats moving when one chat fills its per-chat in-flight window", async () => {
+    const admin = await createAdminContext(app, { username: `ws-fair-${crypto.randomUUID().slice(0, 6)}` });
+    const agent = await createAgent(app.db, {
+      name: `ws-fair-agent-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      managerId: admin.memberId,
+      clientId: admin.clientId,
+      organizationId: admin.organizationId,
+    });
+    const chatA = await createChat(app.db, admin.humanAgentUuid, {
+      type: "group",
+      participantIds: [agent.uuid],
+    });
+    const chatB = await createChat(app.db, admin.humanAgentUuid, {
+      type: "group",
+      participantIds: [agent.uuid],
+    });
+    const ws = await openBoundSocket({
+      accessToken: admin.accessToken,
+      clientId: admin.clientId,
+      agentId: agent.uuid,
+      runtimeProvider: agent.runtimeProvider,
+    });
+
+    try {
+      const chatAMessageIds: string[] = [];
+      for (let i = 0; i < 9; i++) {
+        const sent = await sendMessage(app.db, chatA.id, admin.humanAgentUuid, {
+          source: "api",
+          format: "text",
+          content: `A${i + 1}`,
+          metadata: { mentions: [agent.uuid] },
+        });
+        chatAMessageIds.push(sent.message.id);
+      }
+
+      const initialFramesPromise = collectDeliverFrames(ws, 8);
+      const lastChatAMessageId = chatAMessageIds.at(-1);
+      if (!lastChatAMessageId) throw new Error("expected chat A messages");
+      await app.notifier.notify(agent.inboxId, lastChatAMessageId);
+      const initialFrames = await initialFramesPromise;
+      expect(initialFrames.map((frame) => frame.message.content)).toEqual([
+        "A1",
+        "A2",
+        "A3",
+        "A4",
+        "A5",
+        "A6",
+        "A7",
+        "A8",
+      ]);
+
+      const b1 = await sendMessage(app.db, chatB.id, admin.humanAgentUuid, {
+        source: "api",
+        format: "text",
+        content: "B1",
+        metadata: { mentions: [agent.uuid] },
+      });
+      const b1FramePromise = collectDeliverFrames(ws, 1);
+      await app.notifier.notify(agent.inboxId, b1.message.id);
+      const [b1Frame] = await b1FramePromise;
+      expect(b1Frame?.message.content).toBe("B1");
+
+      const b2 = await sendMessage(app.db, chatB.id, admin.humanAgentUuid, {
+        source: "api",
+        format: "text",
+        content: "B2",
+        metadata: { mentions: [agent.uuid] },
+      });
+
+      const postAckFramesPromise = collectDeliverFrames(ws, 2);
+      const firstChatAFrame = initialFrames[0];
+      if (!firstChatAFrame) throw new Error("expected initial chat A delivery");
+      ws.send(JSON.stringify({ type: "inbox:ack", entryId: firstChatAFrame.entryId, ref: "ack-a1" }));
+      const postAckFrames = await postAckFramesPromise;
+
+      expect(postAckFrames.map((frame) => frame.message.id).sort()).toEqual([lastChatAMessageId, b2.message.id].sort());
+      expect(postAckFrames.map((frame) => frame.message.content).sort()).toEqual(["A9", "B2"]);
+    } finally {
+      ws.close();
+      await new Promise<void>((resolve) => ws.once("close", () => resolve()));
+    }
+  }, 15000);
 });

--- a/packages/server/src/api/agent/ws-client.ts
+++ b/packages/server/src/api/agent/ws-client.ts
@@ -53,11 +53,17 @@ import * as presenceService from "../../services/presence.js";
 import * as sessionEventService from "../../services/session-event.js";
 
 /**
- * Default per-agent in-flight cap when `server.inbox.maxInFlightPerAgent` is
- * unset. Mirrors the schema default so a server running without an explicit
- * `inbox` block still gets reasonable backpressure.
+ * Default per-agent in-flight fuse when `server.inbox.maxInFlightPerAgent` is
+ * unset. Normal delivery fairness is per `(agent, chat)`; this high-water
+ * value bounds pathological recovery storms and badly stalled clients.
  */
-const DEFAULT_INBOX_MAX_IN_FLIGHT_PER_AGENT = 32;
+const DEFAULT_INBOX_MAX_IN_FLIGHT_PER_AGENT = 8192;
+/**
+ * Default per-(agent, chat) fairness window. A long turn may fill its own
+ * chat-local window, but it should not block delivery to the same agent's
+ * other chats.
+ */
+const DEFAULT_INBOX_MAX_IN_FLIGHT_PER_AGENT_CHAT = 8;
 /**
  * Hard cap on entries scanned in a single backlog drain so a recovering
  * client doesn't trigger an arbitrarily large transaction or burst of
@@ -65,9 +71,6 @@ const DEFAULT_INBOX_MAX_IN_FLIGHT_PER_AGENT = 32;
  * subsequent post-ack drains. Same constant covers both the agent:bound
  * recovery path and the post-ack top-up.
  *
- * Lower than proposal §3.3's 500 on purpose: the actual limit per drain is
- * `min(remainingInFlightBudget, INBOX_BACKLOG_BATCH_LIMIT)`, so with a
- * default cap of 32 the drain SQL never asks for more than ~32 anyway.
  * Subsequent NOTIFYs and post-ack top-ups continue draining without a
  * single-transaction megabatch.
  */
@@ -254,6 +257,8 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
     const jwtSecretBytes = new TextEncoder().encode(app.config.secrets.jwtSecret);
 
     const inboxMaxInFlightPerAgent = app.config.inbox?.maxInFlightPerAgent ?? DEFAULT_INBOX_MAX_IN_FLIGHT_PER_AGENT;
+    const inboxMaxInFlightPerAgentChat =
+      app.config.inbox?.maxInFlightPerAgentChat ?? DEFAULT_INBOX_MAX_IN_FLIGHT_PER_AGENT_CHAT;
 
     // WS upgrade is excluded from HTTP tracing in app.ts via the autotelic
     // plugin's `ignoreRoutes` — fastify hijacks the reply on upgrade, so a
@@ -284,13 +289,23 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
         { agentId: string; inboxId: string; organizationId: string; runtimeProvider: string }
       >();
 
+      type InboxInFlightChatBucket = {
+        chatId: string | null;
+        entryIds: Set<number>;
+      };
+      type InboxInFlightOwner = {
+        agentId: string;
+        chatKey: string;
+      };
+
       /**
-       * Per-agent in-flight `inbox:deliver` ids for backpressure. Tracking ids
-       * instead of a scalar counter lets same-socket recovery remove exactly
-       * the reset rows before redelivery, so the cap cannot leak when an entry
-       * is delivered twice on the same connection.
+       * Per-socket in-flight `inbox:deliver` ids for backpressure. Tracking ids
+       * instead of scalar counters lets ACK and same-socket recovery remove
+       * exactly the reset rows before redelivery, so the cap cannot leak when
+       * an entry is delivered twice on the same connection.
        */
-      const inboxInFlightEntryIds = new Map<string, Set<number>>();
+      const inboxInFlightByAgent = new Map<string, Map<string, InboxInFlightChatBucket>>();
+      const inboxInFlightOwnersByEntryId = new Map<number, InboxInFlightOwner>();
       /**
        * Socket-wide inbox operation queue. This is intentionally stronger than
        * per-agent delivery serialization: `inbox:ack` does not carry an
@@ -307,22 +322,81 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
       }
 
       function inboxInFlightCount(agentId: string): number {
-        return inboxInFlightEntryIds.get(agentId)?.size ?? 0;
+        const byChat = inboxInFlightByAgent.get(agentId);
+        if (!byChat) return 0;
+        let total = 0;
+        for (const bucket of byChat.values()) total += bucket.entryIds.size;
+        return total;
       }
 
-      function addInboxInFlight(agentId: string, entryId: number): void {
-        const current = inboxInFlightEntryIds.get(agentId) ?? new Set<number>();
-        current.add(entryId);
-        inboxInFlightEntryIds.set(agentId, current);
+      function inboxChatKey(chatId: string | null): string {
+        return chatId === null ? "null" : `chat:${chatId}`;
       }
 
-      function removeInboxInFlight(agentId: string, entryIds: readonly number[]): void {
-        const current = inboxInFlightEntryIds.get(agentId);
-        if (!current) return;
-        for (const entryId of entryIds) {
-          current.delete(entryId);
+      function inboxInFlightCountForChat(agentId: string, chatId: string | null): number {
+        return inboxInFlightByAgent.get(agentId)?.get(inboxChatKey(chatId))?.entryIds.size ?? 0;
+      }
+
+      function inboxInFlightChatBudgets(agentId: string): Array<{ chatId: string | null; remaining: number }> {
+        const byChat = inboxInFlightByAgent.get(agentId);
+        if (!byChat) return [];
+        return [...byChat.values()].map((bucket) => ({
+          chatId: bucket.chatId,
+          remaining: Math.max(0, inboxMaxInFlightPerAgentChat - bucket.entryIds.size),
+        }));
+      }
+
+      function logPerChatCaps(agentId: string, inboxId: string, inFlightCount: number): void {
+        const byChat = inboxInFlightByAgent.get(agentId);
+        if (!byChat) return;
+        for (const bucket of byChat.values()) {
+          if (bucket.entryIds.size < inboxMaxInFlightPerAgentChat) continue;
+          app.log.debug(
+            {
+              agentId,
+              inboxId,
+              chatId: bucket.chatId,
+              inFlightCount,
+              chatInFlightCount: bucket.entryIds.size,
+              globalCap: inboxMaxInFlightPerAgent,
+              chatCap: inboxMaxInFlightPerAgentChat,
+            },
+            "inbox push: per-chat cap active, skipping capped chat backlog",
+          );
         }
-        if (current.size === 0) inboxInFlightEntryIds.delete(agentId);
+      }
+
+      function removeInboxInFlight(entryIds: readonly number[]): void {
+        for (const entryId of entryIds) {
+          const owner = inboxInFlightOwnersByEntryId.get(entryId);
+          if (!owner) continue;
+          const byChat = inboxInFlightByAgent.get(owner.agentId);
+          const bucket = byChat?.get(owner.chatKey);
+          bucket?.entryIds.delete(entryId);
+          inboxInFlightOwnersByEntryId.delete(entryId);
+          if (bucket && bucket.entryIds.size === 0) byChat?.delete(owner.chatKey);
+          if (byChat && byChat.size === 0) inboxInFlightByAgent.delete(owner.agentId);
+        }
+      }
+
+      function addInboxInFlight(agentId: string, chatId: string | null, entryId: number): void {
+        removeInboxInFlight([entryId]);
+        const chatKey = inboxChatKey(chatId);
+        const byChat = inboxInFlightByAgent.get(agentId) ?? new Map<string, InboxInFlightChatBucket>();
+        const bucket = byChat.get(chatKey) ?? { chatId, entryIds: new Set<number>() };
+        bucket.entryIds.add(entryId);
+        byChat.set(chatKey, bucket);
+        inboxInFlightByAgent.set(agentId, byChat);
+        inboxInFlightOwnersByEntryId.set(entryId, { agentId, chatKey });
+      }
+
+      function clearInboxInFlightForAgent(agentId: string): void {
+        const byChat = inboxInFlightByAgent.get(agentId);
+        if (!byChat) return;
+        for (const bucket of byChat.values()) {
+          for (const entryId of bucket.entryIds) inboxInFlightOwnersByEntryId.delete(entryId);
+        }
+        inboxInFlightByAgent.delete(agentId);
       }
 
       function chainInboxDelivery(_agentId: string, op: () => Promise<void>): Promise<void> {
@@ -394,8 +468,8 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
 
       /**
        * Drain up to `INBOX_BACKLOG_BATCH_LIMIT` pending entries for an agent
-       * over the current WS, capped by the remaining in-flight budget so a
-       * full drain stays within the per-agent backpressure cap (§3.3, §3.5).
+       * over the current WS. Normal scheduling is capped by the per-chat
+       * fairness window; the agent-wide cap is only a high-water fuse.
        *
        * Used in two places:
        *   1. Right after `agent:bound` — covers reconnects where NOTIFYs
@@ -403,7 +477,7 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
        *   2. Right after an `inbox:ack` — top up the in-flight slot just
        *      freed, in case the previous NOTIFY was dropped at-cap.
        *
-       * Delivery operations are serialized per agent, so `slotsFree` and the
+       * Delivery operations are serialized on the socket, so budget checks and the
        * subsequent claim/send loop observe one consistent per-socket in-flight
        * counter. That ordering is part of the ack-through safety contract.
        */
@@ -418,39 +492,72 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
         if (socket.readyState !== socket.OPEN) return;
         if (!isAgentStillRoutedHere(agentId)) return;
         const inFlight = inboxInFlightCount(agentId);
-        const slotsFree = inboxMaxInFlightPerAgent - inFlight;
-        if (slotsFree <= 0) {
-          if (trigger?.source === "notify") {
+        const globalSlotsFree = inboxMaxInFlightPerAgent - inFlight;
+        if (globalSlotsFree <= 0) {
+          app.log.warn(
+            {
+              agentId,
+              inboxId,
+              chatId: trigger?.source === "recover" ? trigger.chatId : null,
+              messageId: trigger?.source === "notify" ? trigger.messageId : undefined,
+              inFlightCount: inFlight,
+              chatInFlightCount:
+                trigger?.source === "recover" ? inboxInFlightCountForChat(agentId, trigger.chatId) : undefined,
+              globalCap: inboxMaxInFlightPerAgent,
+              chatCap: inboxMaxInFlightPerAgentChat,
+            },
+            "inbox push: global in-flight fuse reached, leaving backlog pending",
+          );
+          return;
+        }
+        logPerChatCaps(agentId, inboxId, inFlight);
+
+        const recoverChatId = trigger?.source === "recover" ? trigger.chatId : undefined;
+        const limit =
+          recoverChatId === undefined
+            ? Math.min(globalSlotsFree, INBOX_BACKLOG_BATCH_LIMIT)
+            : Math.min(
+                globalSlotsFree,
+                Math.max(0, inboxMaxInFlightPerAgentChat - inboxInFlightCountForChat(agentId, recoverChatId)),
+                INBOX_BACKLOG_BATCH_LIMIT,
+              );
+        if (limit <= 0) {
+          if (recoverChatId !== undefined) {
             app.log.debug(
               {
                 agentId,
                 inboxId,
-                messageId: trigger.messageId,
+                chatId: recoverChatId,
                 inFlightCount: inFlight,
-                cap: inboxMaxInFlightPerAgent,
+                chatInFlightCount: inboxInFlightCountForChat(agentId, recoverChatId),
+                globalCap: inboxMaxInFlightPerAgent,
+                chatCap: inboxMaxInFlightPerAgentChat,
               },
-              "inbox push: at cap, dropping NOTIFY (will replay via post-ack drain)",
+              "inbox push: recovery chat at per-chat cap, leaving backlog pending",
             );
           }
           return;
         }
-        const limit = Math.min(slotsFree, INBOX_BACKLOG_BATCH_LIMIT);
 
         let entries: InboxEntryWithMessage[];
         try {
           entries =
             trigger?.source === "recover"
               ? await inboxService.claimBacklogForPushForChat(app.db, inboxId, trigger.chatId, limit)
-              : await inboxService.claimBacklogForPush(app.db, inboxId, limit);
+              : await inboxService.claimBacklogForPushFair(app.db, inboxId, {
+                  limit,
+                  defaultPerChatLimit: inboxMaxInFlightPerAgentChat,
+                  chatBudgets: inboxInFlightChatBudgets(agentId),
+                });
         } catch (err) {
-          app.log.error({ err, agentId, inboxId, limit }, "claimBacklogForPush failed");
+          app.log.error({ err, agentId, inboxId, limit }, "claim backlog for WS push failed");
           return;
         }
 
         for (const entry of entries) {
-          addInboxInFlight(agentId, entry.id);
+          addInboxInFlight(agentId, entry.chatId, entry.id);
           if (!sendInboxDeliverFrame(entry)) {
-            removeInboxInFlight(agentId, [entry.id]);
+            removeInboxInFlight([entry.id]);
             // Socket gone mid-drain — stop pushing. Remaining entries stay
             // 'delivered'; the next bind from this client resets them and
             // re-drains.
@@ -978,7 +1085,7 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
               await presenceService.unbindAgent(app.db, agentId);
               connectionManager.unbindAgentFromClient(agentId);
               boundAgents.delete(agentId);
-              inboxInFlightEntryIds.delete(agentId);
+              clearInboxInFlightForAgent(agentId);
 
               socket.send(JSON.stringify({ type: "agent:unbound", agentId }));
             } else if (type === "session:state") {
@@ -1269,7 +1376,7 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
                     "inbox:ack accepted",
                   );
                   if (owner && ackResult.ackedEntryIds.length > 0) {
-                    removeInboxInFlight(owner.agentId, ackResult.ackedEntryIds);
+                    removeInboxInFlight(ackResult.ackedEntryIds);
                     // Slot freed → top up. Cheap when no backlog (single SQL
                     // statement returning 0 rows). Critical when the cap was
                     // hit and queued NOTIFYs got dropped (proposal §3.5).
@@ -1317,7 +1424,7 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
                     inboxId: info.inboxId,
                     chatId,
                   });
-                  removeInboxInFlight(agentId, recovered.resetEntryIds);
+                  removeInboxInFlight(recovered.resetEntryIds);
                   socket.send(
                     JSON.stringify({
                       type: "inbox:recover:accepted",
@@ -1368,7 +1475,8 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
           notifier.unsubscribe(info.inboxId, socket);
         }
         boundAgents.clear();
-        inboxInFlightEntryIds.clear();
+        inboxInFlightByAgent.clear();
+        inboxInFlightOwnersByEntryId.clear();
 
         if (clientId) {
           // Reconnect-race guard. A typical `systemctl restart` produces this

--- a/packages/server/src/services/inbox.ts
+++ b/packages/server/src/services/inbox.ts
@@ -247,10 +247,9 @@ export async function bundleDeliveryWithSilentContext(
  * that target.
  *
  * Production WS delivery no longer exact-claims NOTIFY message ids; it treats
- * NOTIFY as a wake-up hint and drains backlog by inbox-id cursor through
- * `claimBacklogForPush()`. This helper remains for direct tests and any
- * explicit exact-message claim callers that need the same ack-through prefix
- * safety.
+ * NOTIFY as a wake-up hint and drains backlog through `claimBacklogForPushFair`.
+ * This helper remains for direct tests and any explicit exact-message claim
+ * callers that need the same ack-through prefix safety.
  *
  * Returns `[]` if no row matches — benign race with another server instance
  * (or the debug `GET /inbox` endpoint) that already claimed the entry.
@@ -313,11 +312,9 @@ export async function claimAndBuildForPush(
 }
 
 /**
- * WS-push backlog path: on agent rebind (or once an in-flight slot frees up
- * after an ack), drain up to `limit` pending `notify=true` entries oldest-
- * first and assemble wire payloads. Identical claim shape to `pollInbox` —
- * they are intentionally interchangeable so a hot-path bug fixed in one
- * shows up in the other (proposal §3.3 / §3.5).
+ * Oldest-first backlog path. Kept for debug parity with `pollInbox` and
+ * direct service tests; normal WS delivery uses `claimBacklogForPushFair` so a
+ * single chat cannot consume the agent's whole in-flight window.
  */
 export async function claimBacklogForPush(
   db: Database,
@@ -344,6 +341,110 @@ export async function claimBacklogForPushForChat(
     "inbox.deliver.backlog.chat",
     { "inbox.id": inboxId, "chat.id": chatId, "inbox.backlog.limit": limit },
     () => pollInboxInner(db, inboxId, limit, chatId),
+  );
+}
+
+export type ClaimBacklogForPushFairChatBudget = {
+  chatId: string | null;
+  remaining: number;
+};
+
+function fairBudgetKey(chatId: string | null): string {
+  return chatId === null ? "null" : `chat:${chatId}`;
+}
+
+/**
+ * Fair WS backlog path for normal agent drains. It keeps the old backlog
+ * helper's same-chat id order, but chooses across chats by chat-local rank so
+ * one noisy/stuck chat cannot consume every delivered-but-unacked slot.
+ *
+ * `chatBudgets` only needs entries for chats whose current in-flight count
+ * reduces their remaining budget. Chats absent from the list receive
+ * `defaultPerChatLimit`.
+ */
+export async function claimBacklogForPushFair(
+  db: Database,
+  inboxId: string,
+  opts: {
+    limit: number;
+    defaultPerChatLimit: number;
+    chatBudgets: readonly ClaimBacklogForPushFairChatBudget[];
+  },
+): Promise<InboxEntryWithMessage[]> {
+  if (opts.limit <= 0 || opts.defaultPerChatLimit <= 0) return [];
+
+  const normalizedBudgets = new Map<string, { chat_id: string | null; remaining: number }>();
+  for (const budget of opts.chatBudgets) {
+    normalizedBudgets.set(fairBudgetKey(budget.chatId), {
+      chat_id: budget.chatId,
+      remaining: Math.max(0, Math.floor(budget.remaining)),
+    });
+  }
+  const budgetJson = JSON.stringify([...normalizedBudgets.values()]);
+
+  return withSpan(
+    "inbox.deliver.backlog.fair",
+    {
+      "inbox.id": inboxId,
+      "inbox.backlog.limit": opts.limit,
+      "inbox.backlog.per_chat_limit": opts.defaultPerChatLimit,
+    },
+    () =>
+      db.transaction(async (tx) => {
+        const selected = await tx.execute<{ id: number | string }>(sql`
+          WITH chat_budget AS (
+            SELECT budget.chat_id, budget.remaining
+              FROM jsonb_to_recordset(${budgetJson}::jsonb) AS budget(chat_id text, remaining integer)
+          ),
+          ranked AS (
+            SELECT
+              e.id,
+              e.chat_id,
+              row_number() OVER (PARTITION BY e.chat_id ORDER BY e.id) AS chat_rank
+            FROM inbox_entries e
+            WHERE e.inbox_id = ${inboxId}
+              AND e.status = 'pending'
+              AND e.notify = true
+          ),
+          eligible AS (
+            SELECT ranked.id, ranked.chat_rank
+              FROM ranked
+              LEFT JOIN chat_budget
+                ON ranked.chat_id IS NOT DISTINCT FROM chat_budget.chat_id
+             WHERE ranked.chat_rank <= COALESCE(chat_budget.remaining, ${opts.defaultPerChatLimit})
+             ORDER BY ranked.chat_rank, ranked.id
+             LIMIT ${opts.limit}
+          ),
+          locked AS (
+            SELECT e.id, eligible.chat_rank
+              FROM inbox_entries e
+              INNER JOIN eligible ON eligible.id = e.id
+             WHERE e.inbox_id = ${inboxId}
+               AND e.status = 'pending'
+               AND e.notify = true
+             ORDER BY eligible.chat_rank, e.id
+             FOR UPDATE OF e SKIP LOCKED
+          )
+          SELECT locked.id
+            FROM locked
+           ORDER BY locked.chat_rank, locked.id
+        `);
+
+        const targetIds = selected.map((row) => {
+          const id = typeof row.id === "number" ? row.id : Number(row.id);
+          if (!Number.isSafeInteger(id)) throw new Error(`Unexpected inbox entry id from fair claim: ${row.id}`);
+          return id;
+        });
+        if (targetIds.length === 0) return [];
+
+        const claimed = await tx
+          .update(inboxEntries)
+          .set({ status: "delivered", deliveredAt: new Date() })
+          .where(inArray(inboxEntries.id, targetIds))
+          .returning();
+
+        return bundleDeliveryWithSilentContext(tx, inboxId, claimed);
+      }),
   );
 }
 

--- a/packages/shared/src/config/__tests__/server-config.test.ts
+++ b/packages/shared/src/config/__tests__/server-config.test.ts
@@ -108,6 +108,29 @@ describe("server config", () => {
     expect(config.rateLimit).toEqual({ max: 1234 });
   });
 
+  it("uses inbox delivery fairness defaults when the inbox group is active", () => {
+    expect(serverConfigSchema.inbox.shape.maxInFlightPerAgent.schema.parse(undefined)).toBe(8192);
+    expect(serverConfigSchema.inbox.shape.maxInFlightPerAgentChat.schema.parse(undefined)).toBe(8);
+  });
+
+  it("resolves inbox delivery fairness env overrides", async () => {
+    const configDir = makeTempConfigDir();
+    stubRequiredProductionConfig();
+    vi.stubEnv("FIRST_TREE_INBOX_MAX_IN_FLIGHT_PER_AGENT", "4096");
+    vi.stubEnv("FIRST_TREE_INBOX_MAX_IN_FLIGHT_PER_AGENT_CHAT", "12");
+
+    const config = await initConfig({
+      schema: createServerConfigSchema({ autoGenerateSecrets: false }),
+      role: "server",
+      configDir,
+    });
+
+    expect(config.inbox).toEqual({
+      maxInFlightPerAgent: 4096,
+      maxInFlightPerAgentChat: 12,
+    });
+  });
+
   it("ignores removed per-route rate-limit env vars", async () => {
     const configDir = makeTempConfigDir();
     vi.stubEnv("FIRST_TREE_DATABASE_URL", "postgres://first-tree:test@localhost:5432/firsttree");

--- a/packages/shared/src/config/server-config.ts
+++ b/packages/shared/src/config/server-config.ts
@@ -207,10 +207,12 @@ export const serverConfigSchema = defineConfig({
   }),
   inbox: optional({
     /**
-     * Backpressure cap on per-agent in-flight (un-acked) `inbox:deliver`
-     * frames. Once reached the server stops pushing for that agent until an
-     * ack arrives — leftover entries stay `pending` in the DB and get
-     * replayed via the post-ack backlog scan. See proposal §3.5.
+     * High-water fuse on per-agent in-flight (un-acked) `inbox:deliver`
+     * frames. Normal fairness is enforced per `(agent, chat)` below; this
+     * agent-wide value exists only to bound pathological recovery storms or a
+     * badly stalled client. Once reached the server stops pushing for that
+     * agent until an ack arrives — leftover entries stay `pending` in the DB
+     * and get replayed via later backlog scans.
      *
      * The WS data plane is the only delivery path on this server build. The
      * legacy `new_message` doorbell + HTTP poll fallback was removed in
@@ -220,8 +222,16 @@ export const serverConfigSchema = defineConfig({
      * read `server:welcome.capabilities.wsInboxDeliver` to skip their own
      * poll path on bootstrap.
      */
-    maxInFlightPerAgent: field(z.number().int().min(1).max(1024).default(32), {
+    maxInFlightPerAgent: field(z.number().int().min(1).max(65_536).default(8192), {
       env: "FIRST_TREE_INBOX_MAX_IN_FLIGHT_PER_AGENT",
+    }),
+    /**
+     * Fairness window for one agent in one chat. A stuck or very long turn may
+     * fill this chat-local window, but it must not consume delivery capacity
+     * for the same agent's other chats.
+     */
+    maxInFlightPerAgentChat: field(z.number().int().min(1).max(1024).default(8), {
+      env: "FIRST_TREE_INBOX_MAX_IN_FLIGHT_PER_AGENT_CHAT",
     }),
   }),
   feedback: optional(


### PR DESCRIPTION
## Summary
- Add per-(agent, chat) inbox delivery fairness with a default window of 8 delivered-but-unacked notify entries
- Raise the agent-wide in-flight cap to a high-water fuse and keep backlog drains bounded per batch
- Track WS in-flight entries by agent/chat and use fair backlog claim for normal bind/notify/ack drains while keeping recovery chat-scoped
- Preserve silent-context ACK-through behavior and legacy oldest-first backlog helper semantics for debug/poll paths

## Context Tree
- https://github.com/agent-team-foundation/first-tree-context/pull/502

## Verification
- pnpm --filter @first-tree/shared test -- server-config
- pnpm --filter @first-tree/server test -- inbox-ws-push ws-inbox-delivery-order inbox-bind-recovery
- pnpm --filter @first-tree/shared typecheck
- pnpm --filter @first-tree/server typecheck
- pnpm check
- pnpm typecheck
- first-tree-staging tree verify