### PR TITLE
fix(web): enter onboarding after team create or join

### DIFF
--- a/packages/web/src/components/__tests__/team-setup-modal-dom.test.tsx
+++ b/packages/web/src/components/__tests__/team-setup-modal-dom.test.tsx
@@ -88,7 +88,7 @@ afterEach(() => {
 });
 
 describe("TeamSetupModal", () => {
-  it("creates a team with a slugified name, selects it, navigates home, and closes", async () => {
+  it("creates a team with a slugified name, selects it, enters onboarding, and closes", async () => {
     const onClose = vi.fn();
     clientMocks.post.mockResolvedValue({
       organization: { id: "org-new", name: "acme-robotics", displayName: "ACME Robotics!!!", role: "admin" },
@@ -108,7 +108,7 @@ describe("TeamSetupModal", () => {
     });
     expect(authMock.value.selectOrganization).toHaveBeenCalledWith("org-new");
     expect(onClose).toHaveBeenCalledTimes(1);
-    expect(routerMocks.navigate).toHaveBeenCalledWith("/", { replace: true });
+    expect(routerMocks.navigate).toHaveBeenCalledWith("/onboarding", { replace: true });
 
     await act(async () => root.unmount());
   });
@@ -127,7 +127,7 @@ describe("TeamSetupModal", () => {
     expect(clientMocks.post).toHaveBeenCalledWith("/me/organizations/join", { token: "token-123" });
     expect(authMock.value.selectOrganization).toHaveBeenCalledWith("org-joined");
     expect(onClose).toHaveBeenCalledTimes(1);
-    expect(routerMocks.navigate).toHaveBeenCalledWith("/", { replace: true });
+    expect(routerMocks.navigate).toHaveBeenCalledWith("/onboarding", { replace: true });
 
     await act(async () => root.unmount());
   });

--- a/packages/web/src/components/team-setup-modal.tsx
+++ b/packages/web/src/components/team-setup-modal.tsx
@@ -82,7 +82,10 @@ function CreateForm({ onDone }: { onDone: () => void }) {
       // freshly created org so the user lands in it.
       await selectOrganization(res.organization.id);
       onDone();
-      navigate("/", { replace: true });
+      // A newly created team starts a fresh setup lifecycle. Enter the
+      // onboarding route directly so account-level dismissals from another
+      // team cannot strand the user on an empty workspace.
+      navigate("/onboarding", { replace: true });
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to create team");
     } finally {
@@ -143,7 +146,10 @@ function JoinForm({ onDone }: { onDone: () => void }) {
       // a stale one (and so we never write `undefined` into the token store).
       await selectOrganization(res.organizationId);
       onDone();
-      navigate("/", { replace: true });
+      // A joined team may still need this member's computer/agent setup.
+      // `/onboarding` bounces back to the workspace when the selected org is
+      // already ready, so mature teams are not held in the flow.
+      navigate("/onboarding", { replace: true });
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to join team");
     } finally {

--- a/packages/web/src/pages/__tests__/invite-accept-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/invite-accept-dom.test.tsx
@@ -183,7 +183,7 @@ describe("InviteAcceptPage", () => {
     expect(clientMocks.post).toHaveBeenCalledWith("/me/organizations/join", { token: "token-1" });
     expect(authMock.value.selectOrganization).toHaveBeenCalledWith("org-new");
     expect(onboardingMocks.markOnboardingResume).toHaveBeenCalledWith("invite");
-    expect(navigateMock).toHaveBeenCalledWith("/", { replace: true });
+    expect(navigateMock).toHaveBeenCalledWith("/onboarding", { replace: true });
   });
 
   it("renders public OAuth and invalid invitation states", async () => {

--- a/packages/web/src/pages/invite-accept.tsx
+++ b/packages/web/src/pages/invite-accept.tsx
@@ -91,7 +91,7 @@ export function InviteAcceptPage() {
       }>("/me/organizations/join", { token });
       await selectOrganization(res.organizationId);
       markOnboardingResume("invite");
-      navigate("/", { replace: true });
+      navigate("/onboarding", { replace: true });
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to join team");
     } finally {


### PR DESCRIPTION
## Summary

- Route successful Create team and Join team flows directly to `/onboarding` after selecting the new org.
- Keep mature teams safe: `/onboarding` already bounces back to `/` when the selected org is ready.
- Update the modal DOM tests to pin the new destination.

## Root Cause

Create/join currently returns to `/`, where the workspace enter gate can be blocked by account-level `users.onboarding_dismissed_at` from another team. That can strand a freshly created or joined unready org in an empty workspace instead of letting the onboarding route evaluate the selected org.

## Validation

- `pnpm --filter @first-tree/web test -- src/components/__tests__/team-setup-modal-dom.test.tsx` (runs full web suite: 105 files / 794 tests passed; existing stderr warnings only)
- `pnpm --filter @first-tree/web typecheck`
- `pnpm biome check packages/web/src/components/team-setup-modal.tsx packages/web/src/components/__tests__/team-setup-modal-dom.test.tsx`