### PR TITLE
feat(web): pin current team first and collapse long team list in user menu

### DIFF
--- a/packages/web/src/app.tsx
+++ b/packages/web/src/app.tsx
@@ -102,6 +102,10 @@ const CommandPalettePreviewPage = import.meta.env.DEV
     )
   : null;
 
+const UserMenuPreviewPage = import.meta.env.DEV
+  ? lazy(() => import("./pages/user-menu-preview.js").then((module) => ({ default: module.UserMenuPreviewPage })))
+  : null;
+
 // Living design-system reference (companion to DESIGN.md). Unlike the previews
 // above this ships in prod too, so it can be opened on a deployed URL — it has
 // no auth-gated data, only tokens and `components/ui` primitives.
@@ -190,6 +194,16 @@ export function App() {
                   element={
                     <Suspense fallback={null}>
                       <CommandPalettePreviewPage />
+                    </Suspense>
+                  }
+                />
+              ) : null}
+              {UserMenuPreviewPage ? (
+                <Route
+                  path="/preview/user-menu"
+                  element={
+                    <Suspense fallback={null}>
+                      <UserMenuPreviewPage />
                     </Suspense>
                   }
                 />

--- a/packages/web/src/components/user-menu.tsx
+++ b/packages/web/src/components/user-menu.tsx
@@ -1,5 +1,5 @@
 import type { OrgBrief } from "@first-tree/shared";
-import { Check, Link2, LogOut, Plus, UserPlus } from "lucide-react";
+import { Check, ChevronDown, ChevronUp, Link2, LogOut, Plus, UserPlus } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router";
 import { api } from "../api/client.js";
@@ -7,6 +7,8 @@ import { useAuth } from "../auth/auth-context.js";
 import { Avatar } from "./avatar.js";
 import { InviteDialog } from "./invite-dialog.js";
 import { TeamSetupModal } from "./team-setup-modal.js";
+
+const COLLAPSED_TEAM_LIMIT = 5;
 
 /**
  * Right-side user menu. Avatar trigger; dropdown nests team switching,
@@ -22,6 +24,7 @@ export function UserMenu() {
   const navigate = useNavigate();
   const [orgs, setOrgs] = useState<OrgBrief[]>([]);
   const [open, setOpen] = useState(false);
+  const [teamsExpanded, setTeamsExpanded] = useState(false);
   const [inviteOpen, setInviteOpen] = useState(false);
   const [setupAction, setSetupAction] = useState<"create" | "join" | null>(null);
   const ref = useRef<HTMLDivElement>(null);
@@ -54,11 +57,19 @@ export function UserMenu() {
     };
   }, [open]);
 
+  useEffect(() => {
+    if (!open) setTeamsExpanded(false);
+  }, [open]);
+
   const displayName = user?.displayName ?? "User";
   const username = user?.username ?? "";
   const avatarSrc = user?.avatarUrl ?? null;
   const currentOrg = orgs.find((o) => o.id === organizationId) ?? null;
   const currentRole = currentOrg?.role ?? (role === "admin" || role === "member" ? role : null);
+  const orderedOrgs = currentOrg ? [currentOrg, ...orgs.filter((o) => o.id !== currentOrg.id)] : orgs;
+  const hasHiddenTeams = orderedOrgs.length > COLLAPSED_TEAM_LIMIT;
+  const visibleOrgs = teamsExpanded ? orderedOrgs : orderedOrgs.slice(0, COLLAPSED_TEAM_LIMIT);
+  const hiddenTeamCount = Math.max(0, orderedOrgs.length - COLLAPSED_TEAM_LIMIT);
 
   const switchOrg = async (id: string) => {
     if (id === organizationId) {
@@ -144,27 +155,45 @@ export function UserMenu() {
                     <span style={{ width: 14, display: "inline-flex" }}>
                       <Check className="h-3.5 w-3.5" />
                     </span>
-                    <span className="min-w-0 flex-1 truncate">{orgs[0]?.displayName}</span>
-                    <RoleBadge role={orgs[0]?.role ?? currentRole} />
+                    <span className="min-w-0 flex-1 truncate">{orderedOrgs[0]?.displayName}</span>
+                    <RoleBadge role={orderedOrgs[0]?.role ?? currentRole} />
                   </div>
                 ) : (
                   <div>
-                    {orgs.map((o) => (
+                    <div style={teamsExpanded ? { maxHeight: "var(--sp-75)", overflowY: "auto" } : undefined}>
+                      {visibleOrgs.map((o) => (
+                        <button
+                          type="button"
+                          role="menuitem"
+                          key={o.id}
+                          onClick={() => void switchOrg(o.id)}
+                          className="flex w-full items-center gap-2 px-4 py-1.5 text-left text-body hover:bg-accent transition-colors"
+                          style={{ color: "var(--fg)" }}
+                        >
+                          <span style={{ width: 14, display: "inline-flex" }}>
+                            {o.id === organizationId ? <Check className="h-3.5 w-3.5" /> : null}
+                          </span>
+                          <span className="min-w-0 flex-1 truncate">{o.displayName}</span>
+                          <RoleBadge role={o.role} />
+                        </button>
+                      ))}
+                    </div>
+                    {hasHiddenTeams && (
                       <button
                         type="button"
                         role="menuitem"
-                        key={o.id}
-                        onClick={() => void switchOrg(o.id)}
-                        className="flex w-full items-center gap-2 px-4 py-1.5 text-left text-body hover:bg-accent transition-colors"
-                        style={{ color: "var(--fg)" }}
+                        onClick={() => setTeamsExpanded((value) => !value)}
+                        className="flex w-full items-center gap-2 px-4 py-1.5 text-left text-label hover:bg-accent transition-colors"
+                        style={{ color: "var(--fg-2)" }}
                       >
-                        <span style={{ width: 14, display: "inline-flex" }}>
-                          {o.id === organizationId ? <Check className="h-3.5 w-3.5" /> : null}
-                        </span>
-                        <span className="min-w-0 flex-1 truncate">{o.displayName}</span>
-                        <RoleBadge role={o.role} />
+                        {teamsExpanded ? (
+                          <ChevronUp className="h-3.5 w-3.5" />
+                        ) : (
+                          <ChevronDown className="h-3.5 w-3.5" />
+                        )}
+                        <span>{teamsExpanded ? "Show fewer teams" : `View ${hiddenTeamCount} more teams`}</span>
                       </button>
-                    ))}
+                    )}
                   </div>
                 )}
               </div>

--- a/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
+++ b/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
@@ -1345,6 +1345,58 @@ describe("web DOM interaction coverage", () => {
     api.get = originalGet;
   });
 
+  it("keeps the selected team first and collapses long team lists", async () => {
+    const { UserMenu } = await import("../../components/user-menu.js");
+    authMock.value = {
+      ...authMock.value,
+      organizationId: "org-current",
+      role: "admin",
+      selectOrganization: vi.fn(async () => undefined),
+    };
+    const getMock = async <T,>(): Promise<T> =>
+      [
+        { id: "org-1", displayName: "Alpha", role: "member" },
+        { id: "org-2", displayName: "Beta", role: "member" },
+        { id: "org-3", displayName: "Gamma", role: "admin" },
+        { id: "org-4", displayName: "Delta", role: "member" },
+        { id: "org-5", displayName: "Epsilon", role: "member" },
+        { id: "org-6", displayName: "Zeta", role: "member" },
+        { id: "org-current", displayName: "Current Team", role: "admin" },
+      ] as T;
+    const { api } = await import("../../api/client.js");
+    const originalGet = api.get;
+    api.get = getMock;
+
+    const menu = await renderDom(<UserMenu />);
+    await click(menu.container.querySelector('button[aria-haspopup="menu"]'));
+    await waitForText("Current Team", menu.container);
+
+    const visibleTeamButtons = [...menu.container.querySelectorAll("button[role='menuitem']")].filter((button) =>
+      ["Current Team", "Alpha", "Beta", "Gamma", "Delta", "Epsilon", "Zeta"].some((name) =>
+        button.textContent?.includes(name),
+      ),
+    );
+    expect(
+      visibleTeamButtons.map(
+        (button) =>
+          ["Current Team", "Alpha", "Beta", "Gamma", "Delta", "Epsilon", "Zeta"].find((name) =>
+            button.textContent?.includes(name),
+          ) ?? "",
+      ),
+    ).toEqual(["Current Team", "Alpha", "Beta", "Gamma", "Delta"]);
+    expect(menu.container.textContent).not.toContain("Epsilon");
+    expect(menu.container.textContent).toContain("View 2 more teams");
+
+    await click(
+      [...menu.container.querySelectorAll("button")].find((button) =>
+        button.textContent?.includes("View 2 more teams"),
+      ) ?? null,
+    );
+    await waitForText("Zeta", menu.container);
+    expect(menu.container.textContent).toContain("Show fewer teams");
+    api.get = originalGet;
+  });
+
   it("loads, copies, rotates, and errors InviteLinkPanel", async () => {
     const { InviteLinkPanel } = await import("../invite-link-panel.js");
     const { api } = await import("../../api/client.js");

--- a/packages/web/src/pages/user-menu-preview.tsx
+++ b/packages/web/src/pages/user-menu-preview.tsx
@@ -1,0 +1,114 @@
+import type { OrgBrief } from "@first-tree/shared";
+import { useMemo, useState } from "react";
+import { api } from "../api/client.js";
+import { AuthContext } from "../auth/auth-context.js";
+import { UserMenu } from "../components/user-menu.js";
+
+/**
+ * DEV-only visual preview of the user menu's team list, mounted at
+ * `/preview/user-menu` (gated by `import.meta.env.DEV` in app.tsx).
+ *
+ * Renders the REAL `UserMenu` against a 8-org fixture so the two behaviours
+ * under review are demoable without a backend or login:
+ *   - the current team is always pinned as the first row, and
+ *   - lists longer than 5 collapse behind "View N more teams".
+ *
+ * Switching teams in the preview updates the faked auth `organizationId`
+ * in-place and then REJECTS — `switchOrg`'s catch branch keeps the menu
+ * open and skips its `navigate("/")` (react-router forbids nesting a
+ * MemoryRouter here), so the re-pinned order is visible immediately.
+ *
+ * `api.get` is patched for `/me/organizations` only — every other path
+ * falls through to the real client (same approach as the DOM tests).
+ */
+
+const MOCK_ORGS: OrgBrief[] = [
+  { id: "org-1", name: "antgroup", displayName: "antgroup", role: "member" },
+  { id: "org-2", name: "gandy2025s-team", displayName: "gandy2025's team", role: "admin" },
+  { id: "org-3", name: "agent-team-foundation", displayName: "agent-team-foundation", role: "admin" },
+  { id: "org-4", name: "first-tree-qa", displayName: "first-tree-qa", role: "member" },
+  { id: "org-5", name: "hearback", displayName: "hearback", role: "admin" },
+  { id: "org-6", name: "kael-labs", displayName: "kael-labs", role: "member" },
+  { id: "org-7", name: "weekend-hacks", displayName: "weekend-hacks", role: "member" },
+  { id: "org-8", name: "design-playground", displayName: "design-playground", role: "member" },
+];
+
+const originalGet = api.get.bind(api);
+api.get = (async (path: string, ...rest: never[]) => {
+  if (path === "/me/organizations") return MOCK_ORGS;
+  return (originalGet as (path: string, ...rest: never[]) => Promise<unknown>)(path, ...rest);
+}) as typeof api.get;
+
+export function UserMenuPreviewPage() {
+  // Default to a mid-list org so the pin-to-top behaviour is visible
+  // immediately (org-5 sits 5th in the raw /me/organizations order).
+  const [organizationId, setOrganizationId] = useState("org-5");
+  const currentRole = MOCK_ORGS.find((o) => o.id === organizationId)?.role ?? "member";
+
+  const auth = useMemo(
+    () =>
+      ({
+        isAuthenticated: true,
+        meLoaded: true,
+        organizationId,
+        role: currentRole,
+        user: { displayName: "Gandy", username: "gandy2025", avatarUrl: null },
+        selectOrganization: async (id: string) => {
+          setOrganizationId(id);
+          // Reject on purpose: switchOrg's catch keeps the dropdown open and
+          // skips navigate("/"), so the preview stays on this page with the
+          // newly pinned order visible in place.
+          throw new Error("preview: stay on page");
+        },
+        logout: () => undefined,
+        // The remaining ~15 fields are irrelevant to UserMenu — same
+        // unavoidable-cast pattern as /preview/resources.
+      }) as unknown as Parameters<typeof AuthContext.Provider>[0]["value"],
+    [organizationId, currentRole],
+  );
+
+  return (
+    <AuthContext.Provider value={auth}>
+      <div style={{ minHeight: "100vh", background: "var(--bg)" }}>
+        <header
+          className="flex items-center justify-between"
+          style={{
+            padding: "var(--sp-2) var(--sp-4)",
+            borderBottom: "var(--hairline) solid var(--border)",
+            background: "var(--bg-raised)",
+          }}
+        >
+          <span className="text-label" style={{ color: "var(--fg-2)" }}>
+            /preview/user-menu — click the avatar; current team is pinned first, 8 mock teams collapse at 5
+          </span>
+          <UserMenu />
+        </header>
+        <div className="text-caption" style={{ padding: "var(--sp-4)", color: "var(--fg-3)" }}>
+          <p>
+            Current team:{" "}
+            <strong style={{ color: "var(--fg)" }}>
+              {MOCK_ORGS.find((o) => o.id === organizationId)?.displayName}
+            </strong>{" "}
+            (switching a team re-pins it to the top — reopen the menu to see).
+          </p>
+          <button
+            type="button"
+            className="text-caption mono"
+            onClick={() => document.documentElement.classList.toggle("dark")}
+            style={{
+              marginTop: "var(--sp-2)",
+              padding: "var(--sp-1) var(--sp-2_5)",
+              border: "var(--hairline) solid var(--border)",
+              borderRadius: "var(--radius-input)",
+              background: "var(--bg-raised)",
+              color: "var(--fg-2)",
+              cursor: "pointer",
+            }}
+          >
+            theme
+          </button>
+        </div>
+      </div>
+    </AuthContext.Provider>
+  );
+}


### PR DESCRIPTION
## Summary

User-menu team list improvements for accounts with many orgs (requested by @gandy2025):

- **Current team pinned first** — the active team always renders as the first row; the remaining teams keep their original `/me/organizations` order.
- **Long lists collapse** — more than 5 teams collapses behind a `View N more teams` row. Expanding caps the list at `var(--sp-75)` with internal scroll and shows `Show fewer teams` to collapse back.
- Collapse state resets when the menu closes, so reopening always starts compact.

## Tests

- New DOM tests cover current-team pinning and the collapse/expand flow (`web-dom-interactions.test.tsx`, 21 passed).
- `pnpm --filter @first-tree/web typecheck` — clean, design-token guardrails clean.
- `pnpm exec biome check` on changed files — clean.

## Notes

- Implementation authored by gandy-coder in worktree `org-list-menu`; committed and PR'd by gandy-s-assistant after user sign-off.
- Known low-priority follow-up from review: on very short viewports the dropdown itself (header/actions/sign-out) can still exceed the screen — only the team list area is height-capped. Can be made viewport-aware in a follow-up if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)