### PR TITLE
fix: sync runtime provider switches to bound agents without daemon re…

### DIFF
--- a/apps/cli/src/__tests__/client-runtime-context-tree.test.ts
+++ b/apps/cli/src/__tests__/client-runtime-context-tree.test.ts
@@ -97,6 +97,7 @@ vi.mock("@first-tree/client", () => {
   }
   return {
     AgentSlot: FakeAgentSlot,
+    agentSessionRegistryPath: (name: string) => `${process.env.FIRST_TREE_HOME ?? "/tmp"}/data/sessions/${name}.json`,
     ClientConnection: class {
       clientId = connectionMock.clientId;
       on = connectionMock.on;

--- a/apps/cli/src/__tests__/client-runtime-context-tree.test.ts
+++ b/apps/cli/src/__tests__/client-runtime-context-tree.test.ts
@@ -125,6 +125,9 @@ vi.mock("@first-tree/client", () => {
       fatal: vi.fn(),
       child: vi.fn().mockReturnThis(),
     })),
+    decideRepairForBindReject: vi.fn((reason: string) =>
+      reason === "runtime_provider_mismatch" ? { kind: "restart" } : { kind: "ignore" },
+    ),
     getChildProcessRegistry: vi.fn(() => ({ killAll: killAllMock })),
     getHandlerFactory: vi.fn(() => vi.fn()),
     // Mirror the real registry: only the built-in providers have a handler.

--- a/apps/cli/src/__tests__/client-runtime-provider-switch.test.ts
+++ b/apps/cli/src/__tests__/client-runtime-provider-switch.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -77,6 +77,7 @@ vi.mock("@first-tree/client", () => {
   }
   return {
     AgentSlot: FakeAgentSlot,
+    agentSessionRegistryPath: (name: string) => `${process.env.FIRST_TREE_HOME ?? "/tmp"}/data/sessions/${name}.json`,
     ClientConnection: class {
       clientId = connectionMock.clientId;
       on = connectionMock.on;
@@ -388,6 +389,60 @@ describe("ClientRuntime runtime-provider switching (issue #552)", () => {
     );
     expect(slotInstances).toHaveLength(1);
     expect(slotInstances[0]?.stop).not.toHaveBeenCalled();
+    await rt.stop();
+  });
+
+  it("clears the persisted session registry on a provider switch", async () => {
+    // Provider session ids are not portable: a Claude session id hydrated by
+    // the rebuilt slot and fed to Codex resumeThread wedges resume in every
+    // existing chat (review finding R3 on PR #1043).
+    writeAgentYaml("alpha", "agentId: agent-1\nruntime: claude-code\n");
+    const registryPath = join(home, "data", "sessions", "alpha.json");
+    mkdirSync(join(home, "data", "sessions"), { recursive: true });
+    writeFileSync(registryPath, JSON.stringify({ version: 1, entries: { "chat-1": { claudeSessionId: "sess-1" } } }));
+    const rt = await makeRuntime();
+    addAgent(rt, "alpha", "agent-1", "claude-code");
+    await rt.start();
+
+    firePinned("agent-1", "alpha", "codex");
+
+    await vi.waitFor(() => expect(slotInstances).toHaveLength(2));
+    expect(slotInstances[1]?.type).toBe("codex");
+    expect(existsSync(registryPath)).toBe(false);
+    await rt.stop();
+  });
+
+  it("applies the latest provider queued while a switch is in flight", async () => {
+    // A pin landing mid-swap must not be dropped: it can arrive after the
+    // rebuilt slot already bound, in which case no runtime_provider_mismatch
+    // rejection would ever repair the miss (review finding R4 on PR #1043).
+    const yamlPath = writeAgentYaml("alpha", "agentId: agent-1\nruntime: claude-code\n");
+    const rt = await makeRuntime();
+    addAgent(rt, "alpha", "agent-1", "claude-code");
+    await rt.start();
+    const oldSlot = slotInstances[0];
+    if (!oldSlot) throw new Error("initial slot missing");
+    let releaseStop: () => void = () => undefined;
+    oldSlot.stop.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseStop = resolve;
+        }),
+    );
+
+    firePinned("agent-1", "alpha", "claude-code-tui");
+    await vi.waitFor(() => expect(oldSlot.stop).toHaveBeenCalled());
+    // Second switch arrives while the first is still stopping the old slot.
+    firePinned("agent-1", "alpha", "codex");
+    releaseStop();
+
+    await vi.waitFor(() =>
+      expect(slotInstances.map((slot) => slot.type)).toEqual(["claude-code", "claude-code-tui", "codex"]),
+    );
+    const finalSlot = slotInstances[2];
+    if (!finalSlot) throw new Error("final slot missing");
+    await vi.waitFor(() => expect(finalSlot.start).toHaveBeenCalled());
+    expect(readFileSync(yamlPath, "utf8")).toContain("runtime: codex");
     await rt.stop();
   });
 

--- a/apps/cli/src/__tests__/client-runtime-provider-switch.test.ts
+++ b/apps/cli/src/__tests__/client-runtime-provider-switch.test.ts
@@ -446,6 +446,48 @@ describe("ClientRuntime runtime-provider switching (issue #552)", () => {
     await rt.stop();
   });
 
+  it("defers a switch until an in-flight slot start settles", async () => {
+    // The server pushes the agent:pinned backfill right after
+    // client:registered, so a switch can land while the initial slot.start()
+    // is still in flight. Stopping a slot does not cancel its in-flight
+    // start(), so the switch must await it first or it orphans a half-started
+    // slot (review finding: Defer slot switches while startup is in flight).
+    const yamlPath = writeAgentYaml("alpha", "agentId: agent-1\nruntime: claude-code\n");
+    const rt = await makeRuntime();
+    addAgent(rt, "alpha", "agent-1", "claude-code");
+    const slot0 = slotInstances[0];
+    if (!slot0) throw new Error("initial slot missing");
+    let releaseStart: () => void = () => undefined;
+    slot0.start.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          releaseStart = () => resolve({ displayName: "alpha", agentId: "agent-1" });
+        }),
+    );
+
+    const startAll = rt.start();
+    await vi.waitFor(() => expect(slot0.start).toHaveBeenCalled());
+
+    // Switch lands while slot0.start() is still pending.
+    firePinned("agent-1", "alpha", "codex");
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    // The switch must NOT have torn down the half-started slot yet.
+    expect(slot0.stop).not.toHaveBeenCalled();
+    expect(slotInstances).toHaveLength(1);
+
+    // Start settles → the deferred switch now proceeds cleanly.
+    releaseStart();
+    await startAll;
+    await vi.waitFor(() => expect(slot0.stop).toHaveBeenCalled());
+    await vi.waitFor(() => expect(slotInstances).toHaveLength(2));
+    const newSlot = slotInstances[1];
+    if (!newSlot) throw new Error("switched slot missing");
+    expect(newSlot.type).toBe("codex");
+    await vi.waitFor(() => expect(newSlot.start).toHaveBeenCalled());
+    expect(readFileSync(yamlPath, "utf8")).toContain("runtime: codex");
+    await rt.stop();
+  });
+
   it("ignores bind rejections that are not runtime_provider_mismatch", async () => {
     const reconcile = await import("../core/runtime-provider-reconcile.js");
     writeAgentYaml("alpha", "agentId: agent-1\nruntime: claude-code\n");

--- a/apps/cli/src/__tests__/client-runtime-provider-switch.test.ts
+++ b/apps/cli/src/__tests__/client-runtime-provider-switch.test.ts
@@ -1,0 +1,408 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Issue #552 — switching an agent's runtime provider must reach an already
+ * bound agent without a daemon restart:
+ *
+ *   Fix A: an `agent:pinned` push whose `runtimeProvider` differs from the
+ *     running slot hot-swaps it (rewrite agent.yaml → stop old slot → rebuild
+ *     with the new handler factory → restart).
+ *   Fix B: a bind rejected with `runtime_provider_mismatch` re-fetches the
+ *     authoritative provider from /me/pinned-agents and runs the same swap,
+ *     instead of leaving the bind permanently disabled.
+ */
+
+type FakeSlot = {
+  agentId: string;
+  name: string;
+  type: string;
+  start: ReturnType<typeof vi.fn>;
+  stop: ReturnType<typeof vi.fn>;
+  getQuietGateSnapshot: ReturnType<typeof vi.fn>;
+};
+
+const slotInstances: FakeSlot[] = [];
+const connectionListeners = new Map<string, (...args: unknown[]) => void>();
+const killAllMock = vi.fn(async () => undefined);
+const sweepMock = vi.fn(async () => ({ removed: [] as string[] }));
+// Default: every built-in provider has a handler. Individual tests override
+// the implementation to simulate a build that predates a provider.
+const hasHandlerMock = vi.fn((type: string) => ["claude-code", "claude-code-tui", "codex"].includes(type));
+let connectionMaxListeners = 10;
+const connectionMock = {
+  clientId: "client-test",
+  on: vi.fn((event: string, fn: (...args: unknown[]) => void) => {
+    connectionListeners.set(event, fn);
+  }),
+  connect: vi.fn(async () => undefined),
+  disconnect: vi.fn(async () => undefined),
+  emit: vi.fn(),
+  isPaused: vi.fn(() => false),
+  getPausedReason: vi.fn(() => null),
+  clearPaused: vi.fn(),
+  getMaxListeners: vi.fn(() => connectionMaxListeners),
+  setMaxListeners: vi.fn((n: number) => {
+    connectionMaxListeners = n;
+  }),
+};
+
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  return {
+    ...actual,
+    default: actual,
+    // No-op watcher: these tests drive handleAgentPinned directly; the real
+    // recursive watcher would only add debounce noise.
+    watch: vi.fn(() => ({ close: vi.fn(), on: vi.fn() })),
+  };
+});
+
+vi.mock("@first-tree/client", () => {
+  class FakeAgentSlot {
+    public readonly agentId: string;
+    public readonly name: string;
+    public readonly type: string;
+    public start = vi.fn(async () => ({ displayName: this.name, agentId: this.agentId }));
+    public stop = vi.fn(async () => undefined);
+    public getQuietGateSnapshot = vi.fn(() => ({ activeCount: 0, lastActivityMs: 0 }));
+    constructor(opts: { agentId: string; name: string; type: string }) {
+      this.agentId = opts.agentId;
+      this.name = opts.name;
+      this.type = opts.type;
+      slotInstances.push(this);
+    }
+  }
+  return {
+    AgentSlot: FakeAgentSlot,
+    ClientConnection: class {
+      clientId = connectionMock.clientId;
+      on = connectionMock.on;
+      connect = connectionMock.connect;
+      disconnect = connectionMock.disconnect;
+      emit = connectionMock.emit;
+      isPaused = connectionMock.isPaused;
+      getPausedReason = connectionMock.getPausedReason;
+      clearPaused = connectionMock.clearPaused;
+      getMaxListeners = connectionMock.getMaxListeners;
+      setMaxListeners = connectionMock.setMaxListeners;
+    },
+    UpdateManager: { attach: vi.fn(() => ({ dispose: vi.fn() })) },
+    createGitMirrorManager: vi.fn(() => ({
+      ensureSourceRepo: vi.fn(),
+      removeSourceRepo: vi.fn(),
+      sweepLegacyMirrors: sweepMock,
+      legacyMirrorsRoot: "/tmp/fake-mirrors",
+    })),
+    createLogger: vi.fn(() => ({
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+      trace: vi.fn(),
+      fatal: vi.fn(),
+      child: vi.fn().mockReturnThis(),
+    })),
+    decideRepairForBindReject: vi.fn((reason: string) =>
+      reason === "runtime_provider_mismatch" ? { kind: "restart" } : { kind: "ignore" },
+    ),
+    getChildProcessRegistry: vi.fn(() => ({ killAll: killAllMock })),
+    getHandlerFactory: vi.fn(() => vi.fn()),
+    hasHandler: hasHandlerMock,
+    registerBuiltinHandlers: vi.fn(),
+  };
+});
+
+vi.mock("../core/bootstrap.js", () => ({
+  ensureFreshAccessToken: vi.fn(async () => "tok-test"),
+}));
+
+vi.mock("../core/runtime-provider-reconcile.js", () => ({
+  listPinnedAgents: vi.fn(async () => []),
+}));
+
+vi.mock("../core/output.js", () => ({
+  print: {
+    status: vi.fn(),
+    check: vi.fn(),
+    blank: vi.fn(),
+    line: vi.fn(),
+    result: vi.fn(),
+    fail: vi.fn(),
+  },
+  setJsonMode: vi.fn(),
+  isJsonMode: vi.fn(() => false),
+}));
+
+vi.mock("../core/version.js", () => ({
+  CLI_USER_AGENT: "first-tree-test/0.0.0",
+}));
+
+type RuntimeCtor = typeof import("../core/client-runtime.js").ClientRuntime;
+type Runtime = InstanceType<RuntimeCtor>;
+
+const AGENT_CONFIG_BASE = {
+  session: { idle_timeout: 300, max_sessions: 4, working_grace_seconds: 3600 },
+  concurrency: 1,
+};
+
+describe("ClientRuntime runtime-provider switching (issue #552)", () => {
+  const originalHome = process.env.FIRST_TREE_HOME;
+  let home: string;
+  let agentsDir: string;
+
+  beforeEach(() => {
+    vi.resetModules();
+    home = mkdtempSync(join(tmpdir(), "ft-provider-switch-"));
+    process.env.FIRST_TREE_HOME = home;
+    agentsDir = join(home, "config", "agents");
+    mkdirSync(agentsDir, { recursive: true });
+    slotInstances.length = 0;
+    connectionListeners.clear();
+    connectionMaxListeners = 10;
+    killAllMock.mockClear();
+    sweepMock.mockReset();
+    sweepMock.mockResolvedValue({ removed: [] });
+    hasHandlerMock.mockReset();
+    hasHandlerMock.mockImplementation((type: string) => ["claude-code", "claude-code-tui", "codex"].includes(type));
+    connectionMock.on.mockClear();
+    connectionMock.connect.mockClear();
+    connectionMock.disconnect.mockClear();
+    connectionMock.emit.mockClear();
+    connectionMock.clearPaused.mockClear();
+    connectionMock.isPaused.mockReset();
+    connectionMock.isPaused.mockReturnValue(false);
+    connectionMock.getPausedReason.mockReset();
+    connectionMock.getPausedReason.mockReturnValue(null);
+    connectionMock.getMaxListeners.mockClear();
+    connectionMock.setMaxListeners.mockClear();
+  });
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+    if (originalHome === undefined) delete process.env.FIRST_TREE_HOME;
+    else process.env.FIRST_TREE_HOME = originalHome;
+    vi.clearAllMocks();
+  });
+
+  function writeAgentYaml(name: string, body: string): string {
+    const dir = join(agentsDir, name);
+    mkdirSync(dir, { recursive: true });
+    const yamlPath = join(dir, "agent.yaml");
+    writeFileSync(yamlPath, body);
+    return yamlPath;
+  }
+
+  async function makeRuntime(): Promise<Runtime> {
+    const { ClientRuntime } = await import("../core/client-runtime.js");
+    const rt = new ClientRuntime("https://first-tree.test", "client-test");
+    rt.watchAgentsDir(agentsDir);
+    return rt;
+  }
+
+  function addAgent(rt: Runtime, name: string, agentId: string, runtime: string): void {
+    rt.addAgent(name, {
+      agentId,
+      runtime,
+      ...AGENT_CONFIG_BASE,
+    } as unknown as Parameters<Runtime["addAgent"]>[1]);
+  }
+
+  function firePinned(agentId: string, name: string, runtimeProvider: string): void {
+    const pinned = connectionListeners.get("agent:pinned");
+    if (!pinned) throw new Error("agent:pinned listener missing");
+    pinned({ agentId, name, runtimeProvider });
+  }
+
+  function fireBindRejected(reason: string, agentId: string): void {
+    const rejected = connectionListeners.get("agent:bind:rejected");
+    if (!rejected) throw new Error("agent:bind:rejected listener missing");
+    rejected(reason, agentId);
+  }
+
+  it("hot-swaps the slot when agent:pinned carries a different runtime provider", async () => {
+    const yamlPath = writeAgentYaml("alpha", "agentId: agent-1\nruntime: claude-code\nconcurrency: 2\n");
+    const rt = await makeRuntime();
+    addAgent(rt, "alpha", "agent-1", "claude-code");
+    await rt.start();
+    const oldSlot = slotInstances[0];
+    if (!oldSlot) throw new Error("initial slot missing");
+    expect(oldSlot.type).toBe("claude-code");
+
+    firePinned("agent-1", "alpha", "claude-code-tui");
+
+    await vi.waitFor(() => expect(slotInstances).toHaveLength(2));
+    const newSlot = slotInstances[1];
+    if (!newSlot) throw new Error("swapped slot missing");
+    expect(oldSlot.stop).toHaveBeenCalled();
+    expect(newSlot.type).toBe("claude-code-tui");
+    expect(newSlot.agentId).toBe("agent-1");
+    await vi.waitFor(() => expect(newSlot.start).toHaveBeenCalled());
+
+    // agent.yaml is rewritten to the authoritative provider, preserving the
+    // other fields the operator may have set locally.
+    const text = readFileSync(yamlPath, "utf8");
+    expect(text).toContain("runtime: claude-code-tui");
+    expect(text).toContain("concurrency: 2");
+    await rt.stop();
+  });
+
+  it("does not swap when agent:pinned carries the provider already running", async () => {
+    writeAgentYaml("alpha", "agentId: agent-1\nruntime: claude-code\n");
+    const rt = await makeRuntime();
+    addAgent(rt, "alpha", "agent-1", "claude-code");
+    await rt.start();
+
+    firePinned("agent-1", "alpha", "claude-code");
+
+    // Allow any (incorrect) async swap to surface before asserting.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(slotInstances).toHaveLength(1);
+    expect(slotInstances[0]?.stop).not.toHaveBeenCalled();
+    await rt.stop();
+  });
+
+  it("stops the agent with a warning when switched to a provider this build lacks", async () => {
+    const { print } = await import("../core/output.js");
+    const yamlPath = writeAgentYaml("alpha", "agentId: agent-1\nruntime: claude-code\n");
+    hasHandlerMock.mockImplementation((type: string) => type === "claude-code");
+    const rt = await makeRuntime();
+    addAgent(rt, "alpha", "agent-1", "claude-code");
+    await rt.start();
+    const oldSlot = slotInstances[0];
+    if (!oldSlot) throw new Error("initial slot missing");
+
+    firePinned("agent-1", "alpha", "claude-code-tui");
+
+    await vi.waitFor(() => expect(oldSlot.stop).toHaveBeenCalled());
+    expect(slotInstances).toHaveLength(1);
+    expect(print.status).toHaveBeenCalledWith(
+      "⚠️",
+      expect.stringContaining('agent "alpha" now uses runtime "claude-code-tui"'),
+    );
+    // The yaml still records the server's authoritative value so a client
+    // upgrade + restart picks the agent up with the right provider.
+    expect(readFileSync(yamlPath, "utf8")).toContain("runtime: claude-code-tui");
+    await rt.stop();
+  });
+
+  it("promotes a previously unsupported agent when re-pinned to a supported provider", async () => {
+    const yamlPath = writeAgentYaml("tui-agent", "agentId: agent-tui\nruntime: claude-code-tui\n");
+    hasHandlerMock.mockImplementation((type: string) => type === "claude-code");
+    const rt = await makeRuntime();
+    addAgent(rt, "tui-agent", "agent-tui", "claude-code-tui");
+    await rt.start();
+    expect(slotInstances).toHaveLength(0); // skipped: no handler for the provider
+
+    firePinned("agent-tui", "tui-agent", "claude-code");
+
+    await vi.waitFor(() => expect(slotInstances).toHaveLength(1));
+    const slot = slotInstances[0];
+    if (!slot) throw new Error("promoted slot missing");
+    expect(slot.name).toBe("tui-agent");
+    expect(slot.type).toBe("claude-code");
+    await vi.waitFor(() => expect(slot.start).toHaveBeenCalled());
+    expect(readFileSync(yamlPath, "utf8")).toContain("runtime: claude-code");
+    await rt.stop();
+  });
+
+  it("repairs a runtime_provider_mismatch bind rejection from the authoritative pinned list", async () => {
+    const reconcile = await import("../core/runtime-provider-reconcile.js");
+    vi.mocked(reconcile.listPinnedAgents).mockResolvedValue([
+      { agentId: "agent-1", clientId: "client-test", runtimeProvider: "claude-code-tui" },
+    ]);
+    const yamlPath = writeAgentYaml("alpha", "agentId: agent-1\nruntime: claude-code\n");
+    const rt = await makeRuntime();
+    addAgent(rt, "alpha", "agent-1", "claude-code");
+    await rt.start();
+    const oldSlot = slotInstances[0];
+    if (!oldSlot) throw new Error("initial slot missing");
+
+    fireBindRejected("runtime_provider_mismatch", "agent-1");
+
+    await vi.waitFor(() => expect(slotInstances).toHaveLength(2));
+    const newSlot = slotInstances[1];
+    if (!newSlot) throw new Error("repaired slot missing");
+    expect(oldSlot.stop).toHaveBeenCalled();
+    expect(newSlot.type).toBe("claude-code-tui");
+    await vi.waitFor(() => expect(newSlot.start).toHaveBeenCalled());
+    expect(readFileSync(yamlPath, "utf8")).toContain("runtime: claude-code-tui");
+    await rt.stop();
+  });
+
+  it("throttles repeated mismatch repairs for the same agent", async () => {
+    const reconcile = await import("../core/runtime-provider-reconcile.js");
+    vi.mocked(reconcile.listPinnedAgents).mockResolvedValue([
+      { agentId: "agent-1", clientId: "client-test", runtimeProvider: "claude-code-tui" },
+    ]);
+    writeAgentYaml("alpha", "agentId: agent-1\nruntime: claude-code\n");
+    const rt = await makeRuntime();
+    addAgent(rt, "alpha", "agent-1", "claude-code");
+    await rt.start();
+
+    fireBindRejected("runtime_provider_mismatch", "agent-1");
+    fireBindRejected("runtime_provider_mismatch", "agent-1");
+
+    await vi.waitFor(() => expect(slotInstances).toHaveLength(2));
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(reconcile.listPinnedAgents).toHaveBeenCalledTimes(1);
+    await rt.stop();
+  });
+
+  it("skips repair when the agent is no longer in the pinned list", async () => {
+    const { print } = await import("../core/output.js");
+    const reconcile = await import("../core/runtime-provider-reconcile.js");
+    vi.mocked(reconcile.listPinnedAgents).mockResolvedValue([]);
+    writeAgentYaml("alpha", "agentId: agent-1\nruntime: claude-code\n");
+    const rt = await makeRuntime();
+    addAgent(rt, "alpha", "agent-1", "claude-code");
+    await rt.start();
+
+    fireBindRejected("runtime_provider_mismatch", "agent-1");
+
+    await vi.waitFor(() =>
+      expect(print.status).toHaveBeenCalledWith("⚠️", expect.stringContaining("not in this user's pinned-agent list")),
+    );
+    expect(slotInstances).toHaveLength(1);
+    expect(slotInstances[0]?.stop).not.toHaveBeenCalled();
+    await rt.stop();
+  });
+
+  it("skips repair when the server already agrees with the local provider", async () => {
+    const { print } = await import("../core/output.js");
+    const reconcile = await import("../core/runtime-provider-reconcile.js");
+    vi.mocked(reconcile.listPinnedAgents).mockResolvedValue([
+      { agentId: "agent-1", clientId: "client-test", runtimeProvider: "claude-code" },
+    ]);
+    writeAgentYaml("alpha", "agentId: agent-1\nruntime: claude-code\n");
+    const rt = await makeRuntime();
+    addAgent(rt, "alpha", "agent-1", "claude-code");
+    await rt.start();
+
+    fireBindRejected("runtime_provider_mismatch", "agent-1");
+
+    await vi.waitFor(() =>
+      expect(print.status).toHaveBeenCalledWith("⚠️", expect.stringContaining("matching the local config")),
+    );
+    expect(slotInstances).toHaveLength(1);
+    expect(slotInstances[0]?.stop).not.toHaveBeenCalled();
+    await rt.stop();
+  });
+
+  it("ignores bind rejections that are not runtime_provider_mismatch", async () => {
+    const reconcile = await import("../core/runtime-provider-reconcile.js");
+    writeAgentYaml("alpha", "agentId: agent-1\nruntime: claude-code\n");
+    const rt = await makeRuntime();
+    addAgent(rt, "alpha", "agent-1", "claude-code");
+    await rt.start();
+
+    fireBindRejected("agent_suspended", "agent-1");
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(reconcile.listPinnedAgents).not.toHaveBeenCalled();
+    expect(slotInstances).toHaveLength(1);
+    await rt.stop();
+  });
+});

--- a/apps/cli/src/__tests__/daemon-start-command.test.ts
+++ b/apps/cli/src/__tests__/daemon-start-command.test.ts
@@ -78,6 +78,7 @@ let home: string;
 let runtimeInstance: {
   addAgent: ReturnType<typeof vi.fn>;
   start: ReturnType<typeof vi.fn>;
+  setAgentsDir: ReturnType<typeof vi.fn>;
   watchAgentsDir: ReturnType<typeof vi.fn>;
 };
 
@@ -124,6 +125,7 @@ beforeEach(() => {
   runtimeInstance = {
     addAgent: vi.fn(),
     start: vi.fn(async () => undefined),
+    setAgentsDir: vi.fn(),
     watchAgentsDir: vi.fn(() => {
       throw new Error("stop after watch");
     }),
@@ -248,6 +250,12 @@ describe("daemon start command", () => {
       expect.objectContaining({ currentVersion: "0.0.0-test" }),
     );
     expect(runtimeInstance.addAgent).toHaveBeenCalledWith("nova", expect.objectContaining({ agentId: "agent-1" }));
+    // The agents dir must be recorded BEFORE start(), so a startup `agent:pinned`
+    // backfill can persist a runtime switch to agent.yaml.
+    expect(runtimeInstance.setAgentsDir).toHaveBeenCalledWith(join(home, "config", "agents"));
+    expect(runtimeInstance.setAgentsDir.mock.invocationCallOrder[0]).toBeLessThan(
+      runtimeInstance.start.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
     expect(runtimeInstance.start).toHaveBeenCalled();
     expect(coreMocks.uploadClientCapabilities).toHaveBeenCalledWith(
       expect.objectContaining({ clientId: "client_1234abcd", capabilities: { "claude-code": { state: "ok" } } }),

--- a/apps/cli/src/__tests__/runtime-provider-reconcile.test.ts
+++ b/apps/cli/src/__tests__/runtime-provider-reconcile.test.ts
@@ -161,6 +161,43 @@ describe("reconcileLocalRuntimeProviders", () => {
     expect(existsSync(registryPath)).toBe(true);
   });
 
+  it("materializes an omitted runtime to the server default without clearing the registry", async () => {
+    // A legacy/hand-written agent.yaml omits `runtime`; agentConfigSchema
+    // defaults it to claude-code. With the server also on claude-code, the
+    // effective provider is unchanged — materializing the field must NOT be
+    // mistaken for a provider switch and wipe valid Claude session state.
+    const yamlPath = seedAgentDir("delta", { agentId: "agent-4" });
+    const registryPath = seedSessionRegistry("delta");
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify([{ agentId: "agent-4", clientId: "cli-1", runtimeProvider: "claude-code" }]), {
+        status: 200,
+      }),
+    );
+
+    await reconcileLocalRuntimeProviders({ serverUrl: "http://first-tree.test", accessToken: "tok", agentsDir });
+
+    // Field is materialized for explicitness, but the registry is preserved.
+    expect((parseYaml(readFileSync(yamlPath, "utf-8")) as { runtime?: string }).runtime).toBe("claude-code");
+    expect(existsSync(registryPath)).toBe(true);
+  });
+
+  it("clears the registry when an omitted runtime resolves to a different server provider", async () => {
+    // Omitted runtime defaults to claude-code; server says codex → the
+    // effective provider really changes, so the stale claude-code session
+    // registry must be cleared.
+    seedAgentDir("epsilon", { agentId: "agent-5" });
+    const registryPath = seedSessionRegistry("epsilon");
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify([{ agentId: "agent-5", clientId: "cli-1", runtimeProvider: "codex" }]), {
+        status: 200,
+      }),
+    );
+
+    await reconcileLocalRuntimeProviders({ serverUrl: "http://first-tree.test", accessToken: "tok", agentsDir });
+
+    expect(existsSync(registryPath)).toBe(false);
+  });
+
   it("leaves agent.yaml untouched when runtime already matches the server", async () => {
     const yamlPath = seedAgentDir("beta", { agentId: "agent-2", runtime: "codex" });
     const before = readFileSync(yamlPath, "utf-8");

--- a/apps/cli/src/__tests__/runtime-provider-reconcile.test.ts
+++ b/apps/cli/src/__tests__/runtime-provider-reconcile.test.ts
@@ -1,6 +1,7 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { agentSessionRegistryPath } from "@first-tree/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { parse as parseYaml } from "yaml";
 import {
@@ -61,18 +62,35 @@ describe("listPinnedAgents", () => {
 
 describe("reconcileLocalRuntimeProviders", () => {
   let agentsDir: string;
+  let home: string;
   let fetchMock: ReturnType<typeof vi.fn>;
+  const originalHome = process.env.FIRST_TREE_HOME;
 
   beforeEach(() => {
     agentsDir = mkdtempSync(join(tmpdir(), "ft-first-tree-reconcile-"));
+    // Sandbox the channel home so `agentSessionRegistryPath` (used by the
+    // runtime-switch registry clear) resolves under a temp dir, never the
+    // developer's real `<home>/data/sessions`.
+    home = mkdtempSync(join(tmpdir(), "ft-first-tree-reconcile-home-"));
+    process.env.FIRST_TREE_HOME = home;
     fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
   });
 
   afterEach(() => {
     rmSync(agentsDir, { recursive: true, force: true });
+    rmSync(home, { recursive: true, force: true });
+    if (originalHome === undefined) delete process.env.FIRST_TREE_HOME;
+    else process.env.FIRST_TREE_HOME = originalHome;
     vi.unstubAllGlobals();
   });
+
+  function seedSessionRegistry(name: string): string {
+    const path = agentSessionRegistryPath(name);
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, JSON.stringify({ version: 1, entries: { "chat-1": { claudeSessionId: "sess-old" } } }));
+    return path;
+  }
 
   function seedAgentDir(name: string, yamlContent: Record<string, unknown>): string {
     const dir = join(agentsDir, name);
@@ -106,6 +124,41 @@ describe("reconcileLocalRuntimeProviders", () => {
     // Sibling keys must survive the rewrite.
     expect(after.agentId).toBe("agent-1");
     expect(after.workspaceLabel).toBe("alpha-ws");
+  });
+
+  it("clears the persisted session registry when it switches an agent's runtime", async () => {
+    // Offline-rebind path (PR #1043 review R3 follow-up): reconciliation, not
+    // an `agent:pinned` push, applies the switch before the slot first binds.
+    // The old provider's session ids in `sessions/<name>.json` would otherwise
+    // be hydrated by the new handler (a Claude session id is meaningless to
+    // Codex `resumeThread`), so the registry must be cleared here too.
+    const yamlPath = seedAgentDir("alpha", { agentId: "agent-1", runtime: "claude-code" });
+    const registryPath = seedSessionRegistry("alpha");
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify([{ agentId: "agent-1", clientId: "cli-1", runtimeProvider: "codex" }]), {
+        status: 200,
+      }),
+    );
+
+    await reconcileLocalRuntimeProviders({ serverUrl: "http://first-tree.test", accessToken: "tok", agentsDir });
+
+    expect((parseYaml(readFileSync(yamlPath, "utf-8")) as { runtime?: string }).runtime).toBe("codex");
+    expect(existsSync(registryPath)).toBe(false);
+  });
+
+  it("preserves the session registry when the runtime already matches the server", async () => {
+    seedAgentDir("beta", { agentId: "agent-2", runtime: "codex" });
+    const registryPath = seedSessionRegistry("beta");
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify([{ agentId: "agent-2", clientId: "cli-1", runtimeProvider: "codex" }]), {
+        status: 200,
+      }),
+    );
+
+    await reconcileLocalRuntimeProviders({ serverUrl: "http://first-tree.test", accessToken: "tok", agentsDir });
+
+    // No switch happened, so the live session ids must survive.
+    expect(existsSync(registryPath)).toBe(true);
   });
 
   it("leaves agent.yaml untouched when runtime already matches the server", async () => {

--- a/apps/cli/src/commands/daemon/start.ts
+++ b/apps/cli/src/commands/daemon/start.ts
@@ -243,6 +243,13 @@ export function registerDaemonStartCommand(daemon: Command): void {
           runtime.addAgent(name, agentConfig);
         }
 
+        // Record the agents dir BEFORE start(): the server pushes the
+        // `agent:pinned` backfill right after `client:registered` (inside
+        // start()), and a runtime switch it triggers must be able to persist
+        // to `agent.yaml`. `watchAgentsDir` below additionally starts the fs
+        // watcher once startup has settled.
+        runtime.setAgentsDir(agentsDir);
+
         await runtime.start();
 
         // Post-register capabilities upload — the `clients` row only exists

--- a/apps/cli/src/core/client-runtime.ts
+++ b/apps/cli/src/core/client-runtime.ts
@@ -6,6 +6,7 @@ import {
   ClientConnection,
   createGitMirrorManager,
   createLogger,
+  decideRepairForBindReject,
   type GitMirrorManager,
   getChildProcessRegistry,
   getHandlerFactory,
@@ -17,10 +18,11 @@ import {
 import type { AgentPinnedMessage, ClientPausedReason } from "@first-tree/shared";
 import type { AgentConfig } from "@first-tree/shared/config";
 import { agentConfigSchema, defaultConfigDir, defaultDataDir, loadAgents } from "@first-tree/shared/config";
-import { stringify as stringifyYaml } from "yaml";
+import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import { ensureFreshAccessToken } from "./bootstrap.js";
 import { channelConfig } from "./channel.js";
 import { print } from "./output.js";
+import { listPinnedAgents } from "./runtime-provider-reconcile.js";
 import { readUpdateState } from "./update-state.js";
 import { CLI_USER_AGENT } from "./version.js";
 
@@ -28,11 +30,26 @@ type AgentEntry = {
   name: string;
   slot: AgentSlot;
   state: AgentStartState;
+  /**
+   * The validated local config the current slot was built from. `runtime` is
+   * the provider whose handler the slot is serving — the value the
+   * `agent:pinned` hot-swap path (issue #552) compares against the server's
+   * authoritative `runtimeProvider`.
+   */
+  config: AgentConfig;
 };
 
 type AgentStartState = "idle" | "starting" | "running" | "suspended-skipped" | "failed";
 
 const CLIENT_RUNTIME_AGENT_UNBOUND_LISTENER_COUNT = 1;
+
+/**
+ * Floor between two bind-reject repair attempts for the same agent. A repair
+ * that fails to converge (server still rejects after the yaml rewrite) must
+ * not turn into a tight reject → repair → rebind loop; one attempt per window
+ * is plenty since each reconnect/pin push retriggers the path anyway.
+ */
+const MISMATCH_REPAIR_MIN_INTERVAL_MS = 30_000;
 
 export function isAgentSuspendedBindError(error: unknown): boolean {
   const msg = error instanceof Error ? error.message : String(error);
@@ -86,6 +103,18 @@ export class ClientRuntime {
   private readonly agents: AgentEntry[] = [];
   private readonly agentNames = new Set<string>();
   private readonly agentIds = new Set<string>();
+  /**
+   * Agents whose runtime provider has no handler in this client build
+   * (recorded by `addAgent`'s unsupported-runtime guard). Kept so a later
+   * `agent:pinned` push that switches them to a supported provider can
+   * promote them to a real slot instead of falling through to the
+   * auto-register path and writing a duplicate config directory.
+   */
+  private readonly unsupportedAgents = new Map<string, { name: string; config: AgentConfig }>();
+  /** Per-agent re-entrancy guard for {@link switchAgentRuntime}. */
+  private readonly runtimeSwitchesInFlight = new Set<string>();
+  /** Per-agent timestamp throttle for {@link repairRuntimeProviderMismatch}. */
+  private readonly lastMismatchRepairAt = new Map<string, number>();
   private readonly options: ClientRuntimeOptions;
   private updateManager: UpdateManager | null = null;
   private watcher: FSWatcher | null = null;
@@ -191,6 +220,20 @@ export class ClientRuntime {
       if (!entry || !reason) return;
       entry.state = reason === "agent_suspended" ? "suspended-skipped" : "idle";
     });
+
+    // Issue #552 (Fix B): a bind rejected with `runtime_provider_mismatch`
+    // means our slot bound with a provider the server no longer agrees with
+    // (missed `agent:pinned` push, or the startup reconcile hit a transient
+    // server error). Without repair the connection layer permanently disables
+    // the bind (`resilience.bind.disabled`) until an operator restarts the
+    // daemon. Re-fetch the authoritative provider and hot-swap instead.
+    this.connection.on("agent:bind:rejected", (reason, agentId) => {
+      if (decideRepairForBindReject(reason).kind !== "restart") return;
+      this.repairRuntimeProviderMismatch(agentId).catch((err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        print.status("⚠️", `agent ${agentId}: runtime mismatch repair failed: ${msg}`);
+      });
+    });
   }
 
   addAgent(name: string, config: AgentConfig): void {
@@ -209,10 +252,26 @@ export class ClientRuntime {
       );
       this.agentNames.add(name);
       this.agentIds.add(config.agentId);
+      // Remember it so a later `agent:pinned` push that switches the agent to
+      // a supported provider can promote it to a real slot (issue #552).
+      this.unsupportedAgents.set(config.agentId, { name, config });
       return;
     }
+    const slot = this.buildSlot(name, config);
+    this.agents.push({ name, slot, state: "idle", config });
+    this.agentNames.add(name);
+    this.agentIds.add(config.agentId);
+    this.refreshConnectionListenerLimit();
+  }
+
+  /**
+   * Construct an AgentSlot for a validated local config. AgentSlot pins its
+   * `type` + `handlerFactory` at construction time, so both `addAgent` and the
+   * runtime-provider hot-swap path build slots through this single helper.
+   */
+  private buildSlot(name: string, config: AgentConfig): AgentSlot {
     const handlerFactory = getHandlerFactory(config.runtime);
-    const slot = new AgentSlot({
+    return new AgentSlot({
       name,
       agentId: config.agentId,
       serverUrl: this.serverUrl,
@@ -230,10 +289,6 @@ export class ClientRuntime {
       clientConnection: this.connection,
       gitMirrorManager: this.gitMirrorManager,
     });
-    this.agents.push({ name, slot, state: "idle" });
-    this.agentNames.add(name);
-    this.agentIds.add(config.agentId);
-    this.refreshConnectionListenerLimit();
   }
 
   private refreshConnectionListenerLimit(): void {
@@ -461,14 +516,49 @@ export class ClientRuntime {
    * (same shape `agent add` produces) and scheduling the new
    * slot — so the operator doesn't have to run `agent add` manually after
    * creating an agent from the admin UI or API.
+   *
+   * For an agent we already run, the push is also the hot-swap signal for a
+   * runtime-provider change (issue #552, Fix A): the server re-pins on every
+   * `PATCH /agents/:uuid/rebind`, and `agents.runtime_provider` is
+   * authoritative — when it differs from the local slot, rewrite agent.yaml
+   * and rebuild the slot with the new handler instead of ignoring the push.
    */
   private handleAgentPinned(message: AgentPinnedMessage): void {
     const existing = this.agents.find((agent) => agent.slot.agentId === message.agentId);
     if (existing) {
+      if (existing.config.runtime !== message.runtimeProvider) {
+        this.switchAgentRuntime(existing, message.runtimeProvider, "server push").catch((err: unknown) => {
+          const msg = err instanceof Error ? err.message : String(err);
+          print.status("⚠️", `agent "${existing.name}": runtime switch failed: ${msg}`);
+        });
+        return;
+      }
       if (existing.state === "suspended-skipped") {
         print.status("", `agent reactivated: ${existing.name}`);
         this.startAgent(existing.name);
       }
+      return;
+    }
+
+    const unsupported = this.unsupportedAgents.get(message.agentId);
+    if (unsupported) {
+      if (unsupported.config.runtime !== message.runtimeProvider) {
+        this.rewriteAgentYamlRuntime(unsupported.name, message.runtimeProvider);
+        unsupported.config = { ...unsupported.config, runtime: message.runtimeProvider };
+      }
+      if (!hasHandler(message.runtimeProvider)) return; // still unsupported — wait for a client update
+      // The operator switched the agent to a provider this build CAN run —
+      // promote it to a real slot. Release the name/id reservations so
+      // addAgent's duplicate guards let it through.
+      this.unsupportedAgents.delete(message.agentId);
+      this.agentNames.delete(unsupported.name);
+      this.agentIds.delete(unsupported.config.agentId);
+      print.status(
+        "",
+        `agent "${unsupported.name}": runtime switched to supported "${message.runtimeProvider}" — starting`,
+      );
+      this.addAgent(unsupported.name, unsupported.config);
+      this.startAgent(unsupported.name);
       return;
     }
 
@@ -555,5 +645,132 @@ export class ClientRuntime {
       print.check(false, `${entry.name}: connection failed`, msg);
       return "failed";
     }
+  }
+
+  /**
+   * Hot-swap an agent's runtime provider (issue #552, Fix A). The server is
+   * authoritative for `runtime_provider`; when an `agent:pinned` push (or a
+   * bind-reject repair) carries a provider that differs from the running
+   * slot, persist the change to `agents/<name>/agent.yaml`, stop the old
+   * slot, and rebuild + restart it with the new handler factory. AgentSlot
+   * pins `type`/`handlerFactory` at construction, so a swap always builds a
+   * fresh slot.
+   *
+   * Re-entrancy: one switch per agent at a time. A push landing mid-swap is
+   * dropped — if it carried an even newer provider, the rebuilt slot's bind
+   * fails with `runtime_provider_mismatch` and the repair path (Fix B)
+   * converges on the authoritative value.
+   */
+  private async switchAgentRuntime(entry: AgentEntry, to: string, source: string): Promise<void> {
+    const agentId = entry.slot.agentId;
+    if (this.runtimeSwitchesInFlight.has(agentId)) {
+      print.status("", `agent "${entry.name}": runtime switch already in progress — ignoring ${source}`);
+      return;
+    }
+    this.runtimeSwitchesInFlight.add(agentId);
+    try {
+      const from = entry.config.runtime;
+      print.status("", `agent "${entry.name}": runtime provider change ${from} → ${to} (${source})`);
+      this.rewriteAgentYamlRuntime(entry.name, to);
+      entry.config = { ...entry.config, runtime: to };
+      try {
+        await entry.slot.stop();
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        print.status("⚠️", `agent "${entry.name}": stop before runtime switch failed: ${msg}`);
+      }
+      if (!hasHandler(to)) {
+        entry.state = "failed";
+        print.status(
+          "⚠️",
+          `agent "${entry.name}" now uses runtime "${to}" which this client build does not support yet — stopped. Update the client to run it.`,
+        );
+        return;
+      }
+      entry.slot = this.buildSlot(entry.name, entry.config);
+      entry.state = "idle";
+      await this.startAgentEntry(entry);
+    } finally {
+      this.runtimeSwitchesInFlight.delete(agentId);
+    }
+  }
+
+  /**
+   * Best-effort rewrite of `agents/<name>/agent.yaml::runtime` to the
+   * server's authoritative provider, preserving every other field. Failure
+   * (no agents dir recorded, unreadable/unparseable yaml) only warns: the
+   * in-memory swap still applies, and the daemon-start reconcile
+   * (`reconcileLocalRuntimeProviders`) or the bind-reject repair catches the
+   * persisted drift after the next restart.
+   */
+  private rewriteAgentYamlRuntime(name: string, runtime: string): void {
+    if (!this.agentsDir) {
+      print.status("⚠️", `agent "${name}": no agents dir set — runtime change not persisted to agent.yaml.`);
+      return;
+    }
+    const yamlPath = join(this.agentsDir, name, "agent.yaml");
+    try {
+      const raw = readFileSync(yamlPath, "utf-8");
+      const parsed: Record<string, unknown> = parseYaml(raw) ?? {};
+      writeFileSync(yamlPath, stringifyYaml({ ...parsed, runtime }), { mode: 0o600 });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      print.status("⚠️", `agent "${name}": failed to rewrite agent.yaml runtime: ${msg}`);
+    }
+  }
+
+  /**
+   * Issue #552, Fix B — in-band repair for `runtime_provider_mismatch` bind
+   * rejections. Re-fetches the authoritative provider from
+   * `/me/pinned-agents` and runs the same hot-swap as the push path; the
+   * rebuilt slot's explicit `bindAgent` clears the per-agent backoff record
+   * (including the permanent `resilience.bind.disabled` state) on its own.
+   *
+   * Throttled per agent so a repair that fails to converge cannot loop.
+   */
+  private async repairRuntimeProviderMismatch(agentId: string): Promise<void> {
+    const now = Date.now();
+    const last = this.lastMismatchRepairAt.get(agentId) ?? 0;
+    if (now - last < MISMATCH_REPAIR_MIN_INTERVAL_MS) {
+      print.status(
+        "⚠️",
+        `agent ${agentId}: runtime mismatch repair attempted recently — skipping (next reconnect retries).`,
+      );
+      return;
+    }
+    this.lastMismatchRepairAt.set(agentId, now);
+
+    const entry = this.agents.find((agent) => agent.slot.agentId === agentId);
+    if (!entry) return;
+
+    print.status(
+      "",
+      `agent "${entry.name}": bind rejected (runtime_provider_mismatch) — fetching authoritative runtime provider`,
+    );
+    let authoritative: string | undefined;
+    try {
+      const accessToken = await ensureFreshAccessToken();
+      const pinned = await listPinnedAgents({ serverUrl: this.serverUrl, accessToken });
+      authoritative = pinned.find((item) => item.agentId === agentId)?.runtimeProvider;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      print.status("⚠️", `agent "${entry.name}": mismatch repair could not fetch pinned agents: ${msg}`);
+      return;
+    }
+    if (!authoritative) {
+      print.status("⚠️", `agent "${entry.name}": not in this user's pinned-agent list — mismatch repair skipped.`);
+      return;
+    }
+    if (authoritative === entry.config.runtime) {
+      // We bound with the provider the server itself reports yet still got
+      // rejected — nothing local to repair. Most likely a rebind raced this
+      // fetch; the accompanying `agent:pinned` push handles that case.
+      print.status(
+        "⚠️",
+        `agent "${entry.name}": server reports runtime "${authoritative}" matching the local config — mismatch repair skipped.`,
+      );
+      return;
+    }
+    await this.switchAgentRuntime(entry, authoritative, "bind-reject repair");
   }
 }

--- a/apps/cli/src/core/client-runtime.ts
+++ b/apps/cli/src/core/client-runtime.ts
@@ -369,10 +369,24 @@ export class ClientRuntime {
     print.status("", `${connected} agent(s) running${skippedSuffix}. Press Ctrl+C to stop.`);
   }
 
+  /**
+   * Record the agents directory WITHOUT starting the fs watcher. Must be
+   * called before {@link start} so a startup `agent:pinned` backfill — which
+   * the server pushes right after `client:registered`, before
+   * {@link watchAgentsDir} runs — can persist a runtime switch to
+   * `agent.yaml` (via {@link rewriteAgentYamlRuntime}) and auto-register new
+   * agents. Without it, a switch applied during startup updates the live slot
+   * but never reaches disk, so the agent reloads the old provider after the
+   * next restart (unless pre-flight reconcile happens to repair it).
+   */
+  setAgentsDir(agentsDir: string): void {
+    this.agentsDir = agentsDir;
+  }
+
   watchAgentsDir(agentsDir: string): void {
     // Record the directory even if the watcher bails (e.g. dir missing) so
     // the `agent:pinned` handler knows where to materialise configs.
-    this.agentsDir = agentsDir;
+    this.setAgentsDir(agentsDir);
     if (this.watcher) return;
     if (!existsSync(agentsDir)) return;
 

--- a/apps/cli/src/core/client-runtime.ts
+++ b/apps/cli/src/core/client-runtime.ts
@@ -38,6 +38,16 @@ type AgentEntry = {
    * authoritative `runtimeProvider`.
    */
   config: AgentConfig;
+  /**
+   * Set while `entry.slot.start()` is in flight (resolves — never rejects —
+   * when that start settles). A runtime switch must await this before it stops
+   * and replaces the slot: the server pushes the `agent:pinned` backfill right
+   * after `client:registered`, so a switch can land mid-startup, and stopping a
+   * slot does not cancel its in-flight `start()`. Without the await the orphaned
+   * `start()` keeps binding / scheduling timers on a slot no longer reachable
+   * through `entry.slot`.
+   */
+  startInFlight?: Promise<void>;
 };
 
 type AgentStartState = "idle" | "starting" | "running" | "suspended-skipped" | "failed";
@@ -642,8 +652,17 @@ export class ClientRuntime {
     }
 
     entry.state = "starting";
+    const startPromise = entry.slot.start();
+    // Publish the in-flight start (settled, never rejecting) so a concurrent
+    // runtime switch can await it before tearing the slot down. Set
+    // synchronously here — before yielding to the event loop — so an
+    // `agent:pinned` push that arrives the moment startup begins always sees it.
+    entry.startInFlight = startPromise.then(
+      () => undefined,
+      () => undefined,
+    );
     try {
-      const identity = await entry.slot.start();
+      const identity = await startPromise;
       entry.state = "running";
       print.check(true, `${entry.name}: connected`, `agent: ${identity.displayName ?? identity.agentId}`);
       return "connected";
@@ -657,6 +676,8 @@ export class ClientRuntime {
       entry.state = "failed";
       print.check(false, `${entry.name}: connection failed`, msg);
       return "failed";
+    } finally {
+      entry.startInFlight = undefined;
     }
   }
 
@@ -672,7 +693,9 @@ export class ClientRuntime {
    * Re-entrancy: one switch per agent at a time. A request landing mid-swap
    * is queued (latest value wins) and applied once the active swap completes
    * — see {@link queuedRuntimeSwitch} for why dropping it would strand the
-   * agent on the wrong provider.
+   * agent on the wrong provider. A switch landing mid-startup (before the
+   * initial `slot.start()` settles) first awaits that start so the teardown
+   * sees a fully-built slot — see {@link AgentEntry.startInFlight}.
    */
   private async switchAgentRuntime(entry: AgentEntry, to: string, source: string): Promise<void> {
     const agentId = entry.slot.agentId;
@@ -683,6 +706,11 @@ export class ClientRuntime {
     }
     this.runtimeSwitchesInFlight.add(agentId);
     try {
+      // If the slot is still completing its initial start, let it settle first
+      // so `performRuntimeSwitch`'s `stop()` tears down everything `start()`
+      // built instead of racing an orphaned in-flight startup.
+      const inFlight = entry.startInFlight;
+      if (inFlight) await inFlight;
       await this.performRuntimeSwitch(entry, to, source);
     } finally {
       this.runtimeSwitchesInFlight.delete(agentId);

--- a/apps/cli/src/core/client-runtime.ts
+++ b/apps/cli/src/core/client-runtime.ts
@@ -1,8 +1,9 @@
 import type { FSWatcher } from "node:fs";
-import { existsSync, mkdirSync, readFileSync, watch, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, watch, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import {
   AgentSlot,
+  agentSessionRegistryPath,
   ClientConnection,
   createGitMirrorManager,
   createLogger,
@@ -113,6 +114,15 @@ export class ClientRuntime {
   private readonly unsupportedAgents = new Map<string, { name: string; config: AgentConfig }>();
   /** Per-agent re-entrancy guard for {@link switchAgentRuntime}. */
   private readonly runtimeSwitchesInFlight = new Set<string>();
+  /**
+   * Latest provider requested while a switch for the same agent was already
+   * in flight. A push landing mid-swap cannot be dropped: it may arrive after
+   * the rebuilt slot has already bound successfully, in which case no
+   * `runtime_provider_mismatch` rejection would ever repair the miss. The
+   * map collapses bursts to the last requested value; {@link switchAgentRuntime}
+   * drains it once the active swap completes.
+   */
+  private readonly queuedRuntimeSwitch = new Map<string, string>();
   /** Per-agent timestamp throttle for {@link repairRuntimeProviderMismatch}. */
   private readonly lastMismatchRepairAt = new Map<string, number>();
   private readonly options: ClientRuntimeOptions;
@@ -544,6 +554,9 @@ export class ClientRuntime {
     if (unsupported) {
       if (unsupported.config.runtime !== message.runtimeProvider) {
         this.rewriteAgentYamlRuntime(unsupported.name, message.runtimeProvider);
+        // Same rule as performRuntimeSwitch: session ids persisted under the
+        // previous provider are not resumable by the new one.
+        this.clearAgentSessionRegistry(unsupported.name);
         unsupported.config = { ...unsupported.config, runtime: message.runtimeProvider };
       }
       if (!hasHandler(message.runtimeProvider)) return; // still unsupported — wait for a client update
@@ -656,42 +669,75 @@ export class ClientRuntime {
    * pins `type`/`handlerFactory` at construction, so a swap always builds a
    * fresh slot.
    *
-   * Re-entrancy: one switch per agent at a time. A push landing mid-swap is
-   * dropped — if it carried an even newer provider, the rebuilt slot's bind
-   * fails with `runtime_provider_mismatch` and the repair path (Fix B)
-   * converges on the authoritative value.
+   * Re-entrancy: one switch per agent at a time. A request landing mid-swap
+   * is queued (latest value wins) and applied once the active swap completes
+   * — see {@link queuedRuntimeSwitch} for why dropping it would strand the
+   * agent on the wrong provider.
    */
   private async switchAgentRuntime(entry: AgentEntry, to: string, source: string): Promise<void> {
     const agentId = entry.slot.agentId;
     if (this.runtimeSwitchesInFlight.has(agentId)) {
-      print.status("", `agent "${entry.name}": runtime switch already in progress — ignoring ${source}`);
+      this.queuedRuntimeSwitch.set(agentId, to);
+      print.status("", `agent "${entry.name}": runtime switch already in progress — queued "${to}" (${source})`);
       return;
     }
     this.runtimeSwitchesInFlight.add(agentId);
     try {
-      const from = entry.config.runtime;
-      print.status("", `agent "${entry.name}": runtime provider change ${from} → ${to} (${source})`);
-      this.rewriteAgentYamlRuntime(entry.name, to);
-      entry.config = { ...entry.config, runtime: to };
-      try {
-        await entry.slot.stop();
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        print.status("⚠️", `agent "${entry.name}": stop before runtime switch failed: ${msg}`);
-      }
-      if (!hasHandler(to)) {
-        entry.state = "failed";
-        print.status(
-          "⚠️",
-          `agent "${entry.name}" now uses runtime "${to}" which this client build does not support yet — stopped. Update the client to run it.`,
-        );
-        return;
-      }
-      entry.slot = this.buildSlot(entry.name, entry.config);
-      entry.state = "idle";
-      await this.startAgentEntry(entry);
+      await this.performRuntimeSwitch(entry, to, source);
     } finally {
       this.runtimeSwitchesInFlight.delete(agentId);
+    }
+    const queued = this.queuedRuntimeSwitch.get(agentId);
+    if (queued !== undefined) {
+      this.queuedRuntimeSwitch.delete(agentId);
+      if (queued !== entry.config.runtime) {
+        await this.switchAgentRuntime(entry, queued, "queued during previous switch");
+      }
+    }
+  }
+
+  private async performRuntimeSwitch(entry: AgentEntry, to: string, source: string): Promise<void> {
+    const from = entry.config.runtime;
+    print.status("", `agent "${entry.name}": runtime provider change ${from} → ${to} (${source})`);
+    this.rewriteAgentYamlRuntime(entry.name, to);
+    entry.config = { ...entry.config, runtime: to };
+    try {
+      await entry.slot.stop();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      print.status("⚠️", `agent "${entry.name}": stop before runtime switch failed: ${msg}`);
+    }
+    // Provider session ids are not portable across providers: the registry
+    // maps chatId → provider-native session id, and the rebuilt slot hydrates
+    // the same per-name file. A Claude session id fed to Codex `resumeThread`
+    // (or vice versa) wedges resume in every existing chat, so drop the
+    // registry and let each chat cold-start under the new provider.
+    this.clearAgentSessionRegistry(entry.name);
+    if (!hasHandler(to)) {
+      entry.state = "failed";
+      print.status(
+        "⚠️",
+        `agent "${entry.name}" now uses runtime "${to}" which this client build does not support yet — stopped. Update the client to run it.`,
+      );
+      return;
+    }
+    entry.slot = this.buildSlot(entry.name, entry.config);
+    entry.state = "idle";
+    await this.startAgentEntry(entry);
+  }
+
+  /**
+   * Remove the persisted session registry for an agent whose runtime provider
+   * just changed. Best-effort: a failure only warns — the worst case is the
+   * new handler attempting to resume a foreign session id and falling back to
+   * its own cold-start/error path.
+   */
+  private clearAgentSessionRegistry(name: string): void {
+    try {
+      rmSync(agentSessionRegistryPath(name), { force: true });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      print.status("⚠️", `agent "${name}": failed to clear session registry after provider switch: ${msg}`);
     }
   }
 

--- a/apps/cli/src/core/runtime-provider-reconcile.ts
+++ b/apps/cli/src/core/runtime-provider-reconcile.ts
@@ -1,5 +1,6 @@
-import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { agentSessionRegistryPath } from "@first-tree/client";
 import type { ClientCapabilities, RuntimeProvider, SkillDescriptor } from "@first-tree/shared";
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import { cliFetch } from "./cli-fetch.js";
@@ -75,6 +76,22 @@ export async function reconcileLocalRuntimeProviders(opts: {
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       opts.log?.("warn", `agent ${parsed.agentId}: failed to rewrite yaml — ${msg}`);
+      // Yaml unchanged → the slot still starts on the old provider, for which
+      // the persisted session registry is still valid. Leave it alone.
+      continue;
+    }
+    // The provider actually changed on disk. The persisted session registry
+    // holds the OLD provider's native session ids, which the new handler
+    // cannot resume (a Claude session id is meaningless to Codex
+    // `resumeThread` and vice versa). Clear it so every chat cold-starts under
+    // the new provider — the live `agent:pinned` hot-swap path clears the same
+    // file; this covers the offline-rebind path where reconciliation (not a
+    // pin push) applies the switch before the slot first binds.
+    try {
+      rmSync(agentSessionRegistryPath(subdir.name), { force: true });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      opts.log?.("warn", `agent ${parsed.agentId}: failed to clear session registry after runtime switch — ${msg}`);
     }
   }
 }

--- a/apps/cli/src/core/runtime-provider-reconcile.ts
+++ b/apps/cli/src/core/runtime-provider-reconcile.ts
@@ -2,6 +2,7 @@ import { existsSync, readdirSync, readFileSync, rmSync, writeFileSync } from "no
 import { join } from "node:path";
 import { agentSessionRegistryPath } from "@first-tree/client";
 import type { ClientCapabilities, RuntimeProvider, SkillDescriptor } from "@first-tree/shared";
+import { DEFAULT_RUNTIME_PROVIDER } from "@first-tree/shared";
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import { cliFetch } from "./cli-fetch.js";
 
@@ -66,6 +67,16 @@ export async function reconcileLocalRuntimeProviders(opts: {
     if (!auth) continue;
     if (parsed.runtime === auth.runtimeProvider) continue;
 
+    // The *effective* local provider is what `loadAgents()` will hand the slot:
+    // `agentConfigSchema` defaults an omitted `runtime` to DEFAULT_RUNTIME_PROVIDER.
+    // A legacy config that just omits `runtime` (effective `claude-code`) against
+    // a server `claude-code` is NOT a switch — the same handler launches either
+    // way — even though the raw YAML value (`undefined`) differs. The registry
+    // clear must key off this effective comparison, not the raw field, or it
+    // would delete valid session mappings on every startup for defaulted configs.
+    const effectiveLocal = parsed.runtime ?? DEFAULT_RUNTIME_PROVIDER;
+    const providerChanged = effectiveLocal !== auth.runtimeProvider;
+
     const next = { ...parsed, runtime: auth.runtimeProvider };
     try {
       writeFileSync(yamlPath, stringifyYaml(next), { mode: 0o600 });
@@ -80,13 +91,15 @@ export async function reconcileLocalRuntimeProviders(opts: {
       // the persisted session registry is still valid. Leave it alone.
       continue;
     }
-    // The provider actually changed on disk. The persisted session registry
-    // holds the OLD provider's native session ids, which the new handler
-    // cannot resume (a Claude session id is meaningless to Codex
-    // `resumeThread` and vice versa). Clear it so every chat cold-starts under
-    // the new provider — the live `agent:pinned` hot-swap path clears the same
-    // file; this covers the offline-rebind path where reconciliation (not a
-    // pin push) applies the switch before the slot first binds.
+    // Only a real change in the effective provider invalidates the registry.
+    // Materializing an omitted field to the same provider (above) is not a
+    // switch, so the OLD provider's native session ids stay valid and must be
+    // preserved. When the provider genuinely changed, clear them so every chat
+    // cold-starts under the new provider (a Claude session id is meaningless to
+    // Codex `resumeThread` and vice versa) — mirroring the live hot-swap path,
+    // for the offline-rebind case where reconciliation applies the switch
+    // before the slot first binds.
+    if (!providerChanged) continue;
     try {
       rmSync(agentSessionRegistryPath(subdir.name), { force: true });
     } catch (err) {

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -59,6 +59,8 @@ export type {
 } from "./runtime/handler.js";
 export { getHandlerFactory, hasHandler, registerHandler } from "./runtime/handler.js";
 export { InputController } from "./runtime/input-controller.js";
+export type { RepairAction } from "./runtime/repair.js";
+export { decideRepairForBindReject } from "./runtime/repair.js";
 export type { AgentRuntimeOptions } from "./runtime/runtime.js";
 export { AgentRuntime } from "./runtime/runtime.js";
 export { SessionManager } from "./runtime/session-manager.js";

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -16,7 +16,7 @@ export {
 } from "./observability/index.js";
 // Runtime
 export type { AgentSlotConfig } from "./runtime/agent-slot.js";
-export { AgentSlot } from "./runtime/agent-slot.js";
+export { AgentSlot, agentSessionRegistryPath } from "./runtime/agent-slot.js";
 export type { ContextTreeBinding } from "./runtime/bootstrap.js";
 export {
   contextTreeCloneDir,

--- a/packages/client/src/runtime/agent-slot.ts
+++ b/packages/client/src/runtime/agent-slot.ts
@@ -39,6 +39,18 @@ export type AgentSlotConfig = {
   runtimeVersion?: string;
 };
 
+/**
+ * Canonical on-disk location of an agent's session registry — the persisted
+ * `chatId → provider-native session id` mappings (`SessionRegistry`). Exposed
+ * so higher layers that rebuild a slot under a different runtime provider can
+ * clear the file: provider session ids are not portable across providers
+ * (a Claude session id fed to Codex `resumeThread`, or vice versa, breaks
+ * resume), so a provider switch must cold-start every chat.
+ */
+export function agentSessionRegistryPath(agentName: string): string {
+  return join(defaultDataDir(), "sessions", `${agentName}.json`);
+}
+
 type ConnectionListener =
   | { event: "inbox:deliver"; fn: (inboxId: string, frame: InboxDeliverFrame) => void }
   | { event: "agent:bound"; fn: (agent: { agentId: string }) => void }
@@ -200,7 +212,7 @@ export class AgentSlot {
         );
       }
 
-      const registryPath = join(defaultDataDir(), "sessions", `${this.config.name}.json`);
+      const registryPath = agentSessionRegistryPath(this.config.name);
 
       // The runtime owns the GitMirrorManager and injects it here — sharing one
       // manager across slots is what makes `withUrlLock` actually serialise

--- a/packages/client/src/runtime/repair.ts
+++ b/packages/client/src/runtime/repair.ts
@@ -7,14 +7,16 @@ import { AGENT_BIND_REJECT_REASONS, type AgentBindRejectReason } from "@first-tr
 export type RepairAction = { kind: "restart" } | { kind: "ignore" };
 
 /**
- * P2 minimal repair: when a bind is rejected with `runtime_provider_mismatch`,
- * the connecting client is running the wrong handler for the agent. The full
- * fix requires re-fetching the authoritative provider, rewriting the local
- * agent YAML, and respawning the slot with the right handler factory.
+ * Decide whether a bind rejection is repairable by rebuilding the slot from
+ * authoritative state. A `runtime_provider_mismatch` means the connecting
+ * client bound with a handler/provider the server no longer agrees with —
+ * `restart` asks the caller to re-fetch the authoritative provider, rewrite
+ * the local agent YAML, and respawn the slot with the right handler factory.
  *
- * For now (P2), we surface a `restart` action so the operator restarts the
- * client process. Auto-repair (yaml rewrite + slot swap) lives behind a
- * follow-up that needs handler-factory hot-swap support.
+ * The command layer implements the `restart` action in
+ * `ClientRuntime.repairRuntimeProviderMismatch` (apps/cli, issue #552); every
+ * other rejection reason is handled by the connection's own retry taxonomy
+ * and is `ignore` here.
  */
 export function decideRepairForBindReject(reason: AgentBindRejectReason): RepairAction {
   if (reason === AGENT_BIND_REJECT_REASONS.RUNTIME_PROVIDER_MISMATCH) {


### PR DESCRIPTION
…start

Switching an agent's runtime provider (e.g. claude-code -> claude-code-tui via the web Re-bind dialog) only took effect after a manual daemon restart, and a missed switch could permanently disable the agent's bind.

Fix A — hot-swap on agent:pinned: when the push carries a runtimeProvider that differs from the running slot, the daemon rewrites agent.yaml (preserving other fields), stops the old slot, and rebuilds + restarts it with the new handler factory. Agents previously skipped as unsupported-runtime are promoted to a live slot when re-pinned to a supported provider instead of leaking a duplicate config directory.

Fix B — in-band repair for runtime_provider_mismatch bind rejections: the daemon re-fetches the authoritative provider from /me/pinned-agents and runs the same hot-swap, instead of leaving the bind permanently disabled (resilience.bind.disabled) until an operator restart. Throttled per agent; decideRepairForBindReject (previously an uncalled stub) now gates the path and is exported from the client barrel.

Closes #552

## Summary

- what changed?
- why does it matter?

## Validation

- [ ] `pnpm check`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`

## Change Surface

- [ ] `apps/cli` public CLI or help output
- [ ] tree onboarding / binding / inspection behavior
- [ ] shipped or planned skill topology
- [ ] docs or contributor-facing repository metadata
- [ ] CI / packaging / release plumbing

## Notes

- package or install behavior changes:
- docs or tests updated to match:
- follow-up work:
