### PR TITLE
fix: route setupDevUser's seed message to the new agent

### DIFF
--- a/packages/e2e/src/framework/setup-devuser.ts
+++ b/packages/e2e/src/framework/setup-devuser.ts
@@ -210,8 +210,12 @@ export async function setupDevUser(opts: SetupDevUserOptions): Promise<DevUserSe
     "POST",
     `/api/v1/chats/${encodeURIComponent(chatId)}/messages`,
     {
+      // Group-chat sends now require explicit routing intent; declare the new
+      // agent by name so the seed message keeps working across server-side
+      // mention/routing tightenings.
       format: "text",
       content: "Hello from the e2e environment — this message was posted via POST /chats/:id/messages.",
+      receiverNames: [agentName],
     },
     201,
   );


### PR DESCRIPTION
## Summary
- add explicit `receiverNames` routing when `setupDevUser` seeds the first dev-user chat message
- document why the e2e harness can no longer rely on implicit 1:1 delivery

## Test plan
- pnpm --filter @first-tree/e2e typecheck
- pnpm exec biome check packages/e2e/src/framework/setup-devuser.ts
- pnpm --filter @first-tree/e2e e2e:doctor
- pnpm --filter @first-tree/e2e e2e:up (verified it reaches `e2e environment ready`, creates `devAgent/devChat/devMsg`, then stopped the parked env with Ctrl-C)
