### PR TITLE
docs: relax tree/code PR sequencing to co-open + cross-link

### DIFF
--- a/packages/client/src/__tests__/agent-briefing.test.ts
+++ b/packages/client/src/__tests__/agent-briefing.test.ts
@@ -757,12 +757,13 @@ describe("buildAgentBriefing — # Context Tree", () => {
     expect(briefing).toContain("eagerly, not lazily");
 
     // Writing discipline anchors — fresh vs persistent context framing and
-    // the tree-PR-before-code-PR ordering rule. The prose wraps the
-    // emphasised phrases across lines, so allow either single-line or
-    // wrapped forms.
+    // the co-open + cross-link PR coordination rule (the tree PR need not
+    // merge before the code PR). The prose wraps the emphasised phrases
+    // across lines, so allow either single-line or wrapped forms.
     expect(briefing).toContain("fresh context");
     expect(briefing).toMatch(/\*\*persistent[\s\n]+context\*\*/);
-    expect(briefing).toMatch(/tree PR opens first, then the code[\s\n]+PR/);
+    expect(briefing).toMatch(/open the tree PR and the code[\s\n]+PR[\s\n]+together and cross-link them/);
+    expect(briefing).toMatch(/with[\s\n]+the code PR or shortly after/);
     expect(briefing).toContain("Implementation-only changes skip the tree");
 
     // Tree path interpolated under Tree Location.

--- a/packages/client/src/runtime/agent-briefing.ts
+++ b/packages/client/src/runtime/agent-briefing.ts
@@ -699,8 +699,12 @@ picks up where you left off.
 
 The write trigger is **task completion** — the moment you're ready to
 open the code PR. If the task touched decisions, constraints, ownership,
-or cross-domain relationships, the **tree PR opens first, then the code
-PR** — otherwise other agents keep acting on the old tree.
+or cross-domain relationships, **open the tree PR and the code PR
+together and cross-link them**, so a reviewer on the code PR can reach
+the decision and its rationale from the linked tree PR; when review
+reshapes the design, update both PRs together. The tree PR lands **with
+the code PR or shortly after** — it need not merge first, but keep it
+close so the tree never trails the merged code for long.
 Implementation-only changes skip the tree write — not the read.
 
 Before writing, you MUST load the relevant skill first and follow its


### PR DESCRIPTION
## Summary

Updates the `## Writing the Tree` block of the agent briefing (`packages/client/src/runtime/agent-briefing.ts`) so the injected guidance no longer says the tree PR must open first.

New guidance: when a task touches durable decisions / constraints / ownership / cross-domain relationships, **open the tree PR and the code PR together and cross-link them** so a reviewer on the code PR can reach the decision and its rationale; update both PRs together when review reshapes the design; and land the tree **with the code PR or shortly after** — it need not merge first, just don't let it trail the merged code for long.

- `agent-briefing.ts` — rewrite the ordering paragraph in the Writing the Tree section.
- `agent-briefing.test.ts` — update the writing-discipline anchors (the old test hard-asserted `tree PR opens first, then the code PR`).

## Context

Decided with liuchao-001 — relaxes the previously rigid "tree first" rule because the brief stale-tree window is acceptable and the rigidity costs more than it's worth; cross-linking + co-changing recovers the consistency the old rule protected, and gives the code reviewer direct access to the rationale.

Paired tree PR (the durable record of this convention, in `team-practice/tree-maintenance.md`): https://github.com/agent-team-foundation/first-tree-context/pull/508

This pair dogfoods the very convention it introduces: co-opened and cross-linked.

## Test plan

- [x] `vitest run src/__tests__/agent-briefing.test.ts` — 34 passed
- [x] `tsc --noEmit` (client) clean
- [x] `biome check` on both changed files clean