### PR TITLE
docs: clarify tree/code cross-link lives in PR descriptions

### DIFF
--- a/packages/client/src/__tests__/agent-briefing.test.ts
+++ b/packages/client/src/__tests__/agent-briefing.test.ts
@@ -762,7 +762,9 @@ describe("buildAgentBriefing — # Context Tree", () => {
     // across lines, so allow either single-line or wrapped forms.
     expect(briefing).toContain("fresh context");
     expect(briefing).toMatch(/\*\*persistent[\s\n]+context\*\*/);
-    expect(briefing).toMatch(/open the tree PR and the code[\s\n]+PR[\s\n]+together and cross-link them/);
+    expect(briefing).toMatch(
+      /open the tree PR and the code[\s\n]+PR[\s\n]+together and cross-link them in the PR descriptions/,
+    );
     expect(briefing).toMatch(/with[\s\n]+the code PR or shortly after/);
     expect(briefing).toContain("Implementation-only changes skip the tree");
 

--- a/packages/client/src/runtime/agent-briefing.ts
+++ b/packages/client/src/runtime/agent-briefing.ts
@@ -700,8 +700,9 @@ picks up where you left off.
 The write trigger is **task completion** — the moment you're ready to
 open the code PR. If the task touched decisions, constraints, ownership,
 or cross-domain relationships, **open the tree PR and the code PR
-together and cross-link them**, so a reviewer on the code PR can reach
-the decision and its rationale from the linked tree PR; when review
+together and cross-link them in the PR descriptions**, so a reviewer on
+the code PR can reach the decision and its rationale from the linked
+tree PR; when review
 reshapes the design, update both PRs together. The tree PR lands **with
 the code PR or shortly after** — it need not merge first, but keep it
 close so the tree never trails the merged code for long.


### PR DESCRIPTION
## Summary

Follow-up to first-tree#1051, adopting @code-reviewer's suggestion: the `## Writing the Tree` briefing now says to cross-link the tree and code PRs **in the PR descriptions**, so "cross-link them" can't be misread as putting a PR reference (`#1234`) inside a tree node body — which would violate first-tree-context's no-PR-references rule (Hard Rule 9).

- `agent-briefing.ts` — "cross-link them" → "cross-link them in the PR descriptions".
- `agent-briefing.test.ts` — tighten the anchor to lock the new wording.

## Context

Decided with liuchao-001; code-reviewer reviewed the prior pair HEALTHY and raised this as a non-blocking hardening.

Paired tree PR (the durable record — also restores the staleness *Why* to the node): https://github.com/agent-team-foundation/first-tree-context/pull/509

Co-opened + cross-linked, per the convention this very change documents.

## Test plan

- [x] `vitest run src/__tests__/agent-briefing.test.ts` — 34 passed
- [x] `tsc --noEmit` (client) clean
- [x] `biome check` on both changed files clean