### PR TITLE
[codex] Fix Claude TUI resume handling

### DIFF
--- a/packages/client/src/__tests__/tui-claude-command.test.ts
+++ b/packages/client/src/__tests__/tui-claude-command.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { buildClaudeSessionFlags } from "../handlers/claude-code-tui/index.js";
+
+describe("buildClaudeSessionFlags", () => {
+  it("pins new TUI sessions to the generated Claude session id", () => {
+    expect(
+      buildClaudeSessionFlags({ sessionId: "11111111-1111-4111-8111-111111111111", resumeSessionId: null }),
+    ).toEqual(["--session-id", "11111111-1111-4111-8111-111111111111"]);
+  });
+
+  it("resumes existing sessions without passing a conflicting --session-id", () => {
+    const flags = buildClaudeSessionFlags({
+      sessionId: "22222222-2222-4222-8222-222222222222",
+      resumeSessionId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    });
+
+    expect(flags).toEqual(["--resume", "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"]);
+    expect(flags).not.toContain("--session-id");
+  });
+});

--- a/packages/client/src/__tests__/tui-tmux-session.test.ts
+++ b/packages/client/src/__tests__/tui-tmux-session.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { deriveSessionName, ownedSessionPrefix } from "../handlers/claude-code-tui/tmux-session.js";
+import {
+  deriveSessionName,
+  isWorkspaceTrustPrompt,
+  ownedSessionPrefix,
+} from "../handlers/claude-code-tui/tmux-session.js";
 
 const CID = "client_abcd1234";
 
@@ -63,5 +67,29 @@ describe("ownedSessionPrefix", () => {
 
   it("falls back to a placeholder tag when clientId is empty", () => {
     expect(ownedSessionPrefix("")).toBe("ftth-nocid-");
+  });
+});
+
+describe("isWorkspaceTrustPrompt", () => {
+  it("detects Claude Code's first-run workspace trust dialog", () => {
+    const pane = `
+ Quick safety check: Is this a project you created or one you trust?
+
+ ❯ 1. Yes, I trust this folder
+   2. No, exit
+
+ Enter to confirm · Esc to cancel
+`;
+
+    expect(isWorkspaceTrustPrompt(pane)).toBe(true);
+  });
+
+  it("does not treat the normal ready surface as a trust prompt", () => {
+    const pane = `
+❯ Try "edit <filepath> to..."
+⏵⏵ bypass permissions on (shift+tab to cycle)
+`;
+
+    expect(isWorkspaceTrustPrompt(pane)).toBe(false);
   });
 });

--- a/packages/client/src/handlers/claude-code-tui/index.ts
+++ b/packages/client/src/handlers/claude-code-tui/index.ts
@@ -42,6 +42,27 @@ const READY_TIMEOUT_MS = 30_000;
 type Worktree = { clonePath: string };
 
 /**
+ * Claude Code 2.1.170 rejects `--session-id <id> --resume <id>` unless
+ * `--fork-session` is also present. Resume should continue the existing
+ * conversation, so only new sessions get an explicit `--session-id`.
+ *
+ * Exported for tests because this flag contract is enforced by the external
+ * Claude CLI rather than TypeScript types.
+ */
+export function buildClaudeSessionFlags(input: { sessionId: string; resumeSessionId: string | null }): string[] {
+  if (input.resumeSessionId) {
+    return ["--resume", shellQuote(input.resumeSessionId)];
+  }
+  return ["--session-id", shellQuote(input.sessionId)];
+}
+
+function shellQuote(value: string): string {
+  if (!value) return "''";
+  if (/^[A-Za-z0-9_@%+=:,./-]+$/.test(value)) return value;
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+/**
  * Module-level lazy sweep: on first handler instantiation in this process, kill
  * tmux sessions left over from a prior crashed run of THIS client.
  *
@@ -187,12 +208,8 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
       // `--disallowed-tools` removes the tool from the model's context entirely instead.
       "--disallowed-tools",
       "AskUserQuestion",
-      "--session-id",
-      shellQuote(sessionId),
+      ...buildClaudeSessionFlags({ sessionId, resumeSessionId }),
     ];
-    if (resumeSessionId) {
-      args.push("--resume", shellQuote(resumeSessionId));
-    }
     if (payload.model) {
       args.push("--model", shellQuote(payload.model));
     }
@@ -506,12 +523,6 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
 
   function sleep(ms: number): Promise<void> {
     return new Promise((r) => setTimeout(r, ms));
-  }
-
-  function shellQuote(value: string): string {
-    if (!value) return "''";
-    if (/^[A-Za-z0-9_@%+=:,./-]+$/.test(value)) return value;
-    return `'${value.replace(/'/g, "'\\''")}'`;
   }
 
   async function teardownTmux(): Promise<void> {

--- a/packages/client/src/handlers/claude-code-tui/tmux-session.ts
+++ b/packages/client/src/handlers/claude-code-tui/tmux-session.ts
@@ -172,15 +172,38 @@ export type WaitForReadyInput = {
 };
 
 /**
+ * Claude Code 2.1.170 may show a one-time workspace trust dialog before the
+ * normal TUI surface when a fresh agent workspace has never been opened by the
+ * local user. First Tree creates and owns these agent workspaces; without
+ * acknowledging this dialog the handler never reaches the ready marker.
+ */
+export function isWorkspaceTrustPrompt(pane: string): boolean {
+  return (
+    pane.includes("Quick safety check:") &&
+    pane.includes("Yes, I trust this folder") &&
+    pane.includes("Enter to confirm")
+  );
+}
+
+/**
  * Poll capture-pane until both the bypass-permissions marker and a `❯`
  * input prompt line are visible. Resolves on success, throws on timeout.
+ * If Claude shows its workspace trust prompt first, acknowledge it once and
+ * keep waiting for the actual ready surface.
  */
 export async function waitForReady(input: WaitForReadyInput): Promise<void> {
   const timeoutMs = input.timeoutMs ?? 30_000;
   const pollIntervalMs = input.pollIntervalMs ?? 250;
   const started = Date.now();
+  let acceptedWorkspaceTrust = false;
   while (Date.now() - started < timeoutMs) {
     const pane = await capturePane(input.name);
+    if (!acceptedWorkspaceTrust && isWorkspaceTrustPrompt(pane)) {
+      acceptedWorkspaceTrust = true;
+      await sendKey(input.name, "Enter");
+      await new Promise((r) => setTimeout(r, pollIntervalMs));
+      continue;
+    }
     if (pane.includes(READY_MARKER) && pane.split("\n").some((line) => USER_RE.test(line))) {
       return;
     }

--- a/packages/e2e/src/mocks/fake-claude-tui.mjs
+++ b/packages/e2e/src/mocks/fake-claude-tui.mjs
@@ -4,9 +4,10 @@
 // (packages/client/src/handlers/claude-code-tui/), NOT the SDK path.
 //
 // The handler drives this binary by:
-//   1. Spawning it inside `tmux new-session -d -s <name> ... <cmd>`. The cmd
-//      includes `--session-id <uuid>` so we know which transcript file to
-//      write to (per real Claude's behaviour — see transcript-tail.ts).
+//   1. Spawning it inside `tmux new-session -d -s <name> ... <cmd>`. Fresh
+//      starts include `--session-id <uuid>`; resumes include `--resume <uuid>`.
+//      Both identify the transcript file to write to (per real Claude's
+//      behaviour — see transcript-tail.ts).
 //   2. Polling `tmux capture-pane` for the `bypass permissions on` ready
 //      marker, the `❯ ` prompt, and the `esc to interrupt` working marker.
 //   3. Sending user text via `paste-buffer -p` + `send-keys Enter`.
@@ -66,8 +67,8 @@ if (args.includes("--version") || args.includes("-v")) {
   process.exit(0);
 }
 
-const sessionId = readFlag("--session-id") ?? randomUUID();
 const resumeId = readFlag("--resume") ?? null;
+const sessionId = readFlag("--session-id") ?? resumeId ?? randomUUID();
 
 const REPLY = process.env.FAKE_TUI_REPLY ?? null;
 const DELAY_MS = Number(process.env.FAKE_TUI_DELAY_MS ?? "0");

--- a/packages/e2e/src/tests/tui-runtime-resume.e2e.test.ts
+++ b/packages/e2e/src/tests/tui-runtime-resume.e2e.test.ts
@@ -1,0 +1,82 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { execCli } from "../framework/cli-driver/exec.js";
+import { readCurrentHandle } from "../framework/current-handle.js";
+import {
+  createTuiAgent,
+  sendUserMessageToTuiAgent,
+  type TuiAgentFixture,
+  waitForAgentReply,
+} from "../framework/runtime-tui-fixture.js";
+
+/**
+ * tui-runtime-resume — happy path for a suspended TUI session:
+ *   1. First turn starts a fresh fake TUI and forwards a reply.
+ *   2. Operator suspend tears down the tmux process but preserves the session id.
+ *   3. A later message resumes with `--resume <oldId>` and forwards that reply too.
+ *
+ * Regression coverage for the e2e fake's resume transcript contract: when the
+ * handler no longer passes `--session-id` on resume, the fake must still append
+ * to the resumed session's transcript file, because that is what the handler
+ * tails for user-visible output.
+ */
+
+let fixture: TuiAgentFixture;
+
+beforeAll(async () => {
+  const handle = readCurrentHandle();
+  fixture = await createTuiAgent({ handle, displayName: "tui-runtime-resume agent" });
+});
+
+describe("tui-runtime-resume — suspended session resumes and forwards output", () => {
+  it("fresh turn forwards, suspend closes tmux, resumed turn also forwards", { timeout: 120_000 }, async () => {
+    const handle = readCurrentHandle();
+
+    const firstExpected = "FT_E2E_TUI_RESUME_FIRST";
+    const first = await sendUserMessageToTuiAgent({
+      handle,
+      chatId: fixture.chatId,
+      mentionAgentId: fixture.agentId,
+      text: `first turn, include ${firstExpected}`,
+    });
+    const firstReplies = await waitForAgentReply({
+      handle,
+      chatId: fixture.chatId,
+      afterMessageId: first.id,
+      predicate: (m) => m.senderId !== handle.credentials?.humanAgentId && m.content.includes(firstExpected),
+      timeoutMs: 45_000,
+    });
+    expect(firstReplies.length).toBeGreaterThan(0);
+
+    const suspend = await execCli({
+      home: handle.clientHome,
+      serverBaseUrl: handle.serverBaseUrl,
+      args: ["agent", "session", "suspend", fixture.agentName, fixture.chatId],
+      timeoutMs: 30_000,
+    });
+    expect(suspend.exitCode).toBe(0);
+
+    await new Promise((r) => setTimeout(r, 1_500));
+
+    const secondExpected = "FT_E2E_TUI_RESUME_SECOND";
+    const second = await sendUserMessageToTuiAgent({
+      handle,
+      chatId: fixture.chatId,
+      mentionAgentId: fixture.agentId,
+      text: `resume turn, include ${secondExpected}`,
+    });
+    const secondReplies = await waitForAgentReply({
+      handle,
+      chatId: fixture.chatId,
+      afterMessageId: second.id,
+      predicate: (m) => m.senderId !== handle.credentials?.humanAgentId && m.content.includes(secondExpected),
+      timeoutMs: 90_000,
+    });
+    expect(secondReplies.length).toBeGreaterThan(0);
+
+    const events = fixture.fakeLog.readAll();
+    const resumeStart = events.find((e) => e.kind === "start" && e.resumeId);
+    expect(resumeStart).toBeDefined();
+    expect(resumeStart?.sessionId).toBe(resumeStart?.resumeId);
+    expect(events.some((e) => e.kind === "turn:end" && String(e.replyText).includes(secondExpected))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Fix Claude TUI resume command construction so resumed sessions pass only `--resume <sessionId>` instead of combining `--session-id` and `--resume`.
- Teach the fake TUI resume path to write resumed output to the resumed transcript session id, so e2e resume replies are forwarded back to chat.
- Auto-acknowledge Claude Code's one-time workspace trust prompt during TUI readiness polling, then continue waiting for the normal ready surface.
- Add focused unit coverage and an end-to-end suspend/resume TUI regression test.

## Root Cause

Claude Code 2.1.170 rejects `--session-id <id> --resume <id>` unless `--fork-session` is also provided. First Tree's TUI handler was constructing that invalid combination on resume, causing Claude to exit immediately. The client then observed the terminated tmux process as a secondary `tmux capture-pane ... no server running` failure and entered the resume retry loop.

The earlier fake TUI regression also missed resumed output because the mock generated a new random transcript id when invoked with only `--resume`; the handler correctly tailed the old session transcript, so the second fake reply was written somewhere else. Real Claude first-run validation additionally exposed a workspace trust prompt that could block readiness polling in a fresh workspace.

## Validation

- `pnpm --filter @first-tree/client exec vitest run src/__tests__/tui-claude-command.test.ts src/__tests__/tui-tmux-session.test.ts src/__tests__/tui-transcript-tail.test.ts src/__tests__/tui-turn-disposition.test.ts`
- `pnpm exec biome check packages/client/src/handlers/claude-code-tui/index.ts packages/client/src/handlers/claude-code-tui/tmux-session.ts packages/client/src/__tests__/tui-claude-command.test.ts packages/client/src/__tests__/tui-tmux-session.test.ts packages/e2e/src/mocks/fake-claude-tui.mjs packages/e2e/src/tests/tui-runtime-resume.e2e.test.ts`
- `pnpm --filter @first-tree/client typecheck`
- `pnpm --filter @first-tree/e2e typecheck`
- `TMPDIR=/tmp/ftqa-yzw-codex-pr-tui E2E_TUI=1 E2E_WITH_CLIENT=1 E2E_RUN_ID=yzwcodexprtui E2E_PORT_MIN=34900 E2E_PORT_MAX=34999 pnpm --filter @first-tree/e2e exec vitest run --config vitest.tui.config.ts src/tests/tui-runtime-basic.e2e.test.ts src/tests/tui-runtime-resume.e2e.test.ts`
- `pnpm --filter @first-tree/shared --filter @first-tree/client --filter first-tree-dev --filter @first-tree/server build`

QA also ran a full local regression before PR creation, including strict adversarial reproduction and a real Claude TUI start → suspend → resume path.