### PR TITLE
Fix agent rebind runtime detachment

### DIFF
--- a/packages/server/src/__tests__/activity.test.ts
+++ b/packages/server/src/__tests__/activity.test.ts
@@ -19,6 +19,7 @@ function makeNotifier(): Notifier {
     notifyRuntimeStateChange: vi.fn(async () => {}),
     notifySessionRuntime: vi.fn(async () => {}),
     notifyChatMessage: vi.fn(async () => {}),
+    notifyAgentDetach: vi.fn(async () => {}),
     notifySessionEvent: vi.fn(async () => {}),
     pushFrameToInbox: vi.fn(async () => 0),
     onConfigChange: vi.fn(),
@@ -27,6 +28,7 @@ function makeNotifier(): Notifier {
     onRuntimeStateChange: vi.fn(),
     onSessionRuntime: vi.fn(),
     onChatMessage: vi.fn(),
+    onAgentDetach: vi.fn(),
     start: vi.fn(async () => {}),
     stop: vi.fn(async () => {}),
   } satisfies Notifier;
@@ -142,6 +144,7 @@ describe("upsertSessionState — touchPresenceLastSeen option", () => {
       notifyRuntimeStateChange: vi.fn(async () => {}),
       notifySessionRuntime: vi.fn(async () => {}),
       notifyChatMessage: vi.fn(async () => {}),
+      notifyAgentDetach: vi.fn(async () => {}),
       notifySessionEvent: vi.fn(async () => {}),
       pushFrameToInbox: vi.fn(async () => 0),
       onConfigChange: vi.fn(),
@@ -150,6 +153,7 @@ describe("upsertSessionState — touchPresenceLastSeen option", () => {
       onRuntimeStateChange: vi.fn(),
       onSessionRuntime: vi.fn(),
       onChatMessage: vi.fn(),
+      onAgentDetach: vi.fn(),
       start: vi.fn(async () => {}),
       stop: vi.fn(async () => {}),
     } satisfies Notifier;
@@ -180,6 +184,7 @@ describe("upsertSessionState — touchPresenceLastSeen option", () => {
       notifyRuntimeStateChange: vi.fn(async () => {}),
       notifySessionRuntime: vi.fn(async () => {}),
       notifyChatMessage: vi.fn(async () => {}),
+      notifyAgentDetach: vi.fn(async () => {}),
       notifySessionEvent: vi.fn(async () => {}),
       pushFrameToInbox: vi.fn(async () => 0),
       onConfigChange: vi.fn(),
@@ -188,6 +193,7 @@ describe("upsertSessionState — touchPresenceLastSeen option", () => {
       onRuntimeStateChange: vi.fn(),
       onSessionRuntime: vi.fn(),
       onChatMessage: vi.fn(),
+      onAgentDetach: vi.fn(),
       start: vi.fn(async () => {}),
       stop: vi.fn(async () => {}),
     } satisfies Notifier;

--- a/packages/server/src/__tests__/agent-capability-gate.test.ts
+++ b/packages/server/src/__tests__/agent-capability-gate.test.ts
@@ -3,7 +3,7 @@ import { eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 import { clients } from "../db/schema/clients.js";
 import { createAgent, rebindAgent } from "../services/agent.js";
-import { createAdminContext, useTestApp } from "./helpers.js";
+import { createAdminContext, seedClient, useTestApp } from "./helpers.js";
 
 /**
  * Coverage for the post-0026 capability gate in `services/agent.ts`:
@@ -201,6 +201,35 @@ describe("Agent capability gate (services/agent.ts)", () => {
       clientId: ctx.clientId,
       runtimeProvider: "codex",
     });
-    expect(rebound.runtimeProvider).toBe("codex");
+    expect(rebound.agent.runtimeProvider).toBe("codex");
+    expect(rebound.previousClientId).toBe(ctx.clientId);
+  });
+
+  it("rebindAgent returns the actual previous client for each committed move", async () => {
+    const app = getApp();
+    const ctx = await createAdminContext(app);
+    const secondClientId = await seedClient(app, ctx.userId, ctx.organizationId);
+    const thirdClientId = await seedClient(app, ctx.userId, ctx.organizationId);
+    const agent = await createAgent(app.db, {
+      name: `cap-gate-prev-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      managerId: ctx.memberId,
+      clientId: ctx.clientId,
+      runtimeProvider: "claude-code",
+    });
+
+    const first = await rebindAgent(app.db, agent.uuid, {
+      clientId: secondClientId,
+      runtimeProvider: "claude-code",
+    });
+    expect(first.previousClientId).toBe(ctx.clientId);
+    expect(first.agent.clientId).toBe(secondClientId);
+
+    const second = await rebindAgent(app.db, agent.uuid, {
+      clientId: thirdClientId,
+      runtimeProvider: "claude-code",
+    });
+    expect(second.previousClientId).toBe(secondClientId);
+    expect(second.agent.clientId).toBe(thirdClientId);
   });
 });

--- a/packages/server/src/__tests__/agent-pinned-notification.test.ts
+++ b/packages/server/src/__tests__/agent-pinned-notification.test.ts
@@ -7,7 +7,7 @@ import { agentPresence } from "../db/schema/agent-presence.js";
 import { clients } from "../db/schema/clients.js";
 import { members } from "../db/schema/members.js";
 import { users } from "../db/schema/users.js";
-import { createAgent, suspendAgent } from "../services/agent.js";
+import { createAgent, rebindAgent, suspendAgent } from "../services/agent.js";
 import { getAgentClientId } from "../services/connection-manager.js";
 import { resolveDefaultOrgId } from "../services/organization.js";
 import { uuidv7 } from "../uuid.js";
@@ -504,6 +504,47 @@ describe("Agent WS — agent:pinned push on create/bind", () => {
     } finally {
       ws.close();
       await new Promise<void>((r) => ws.once("close", () => r()));
+    }
+  }, 15000);
+
+  it("rebind transaction detach notifications force-disconnect a matching local runtime route", async () => {
+    const seed = await seedConnectedClient("detach-notify");
+    const secondSeed = await seedAdditionalClient(seed, "detach-notify-second");
+    const agent = await createAgent(app.db, {
+      name: `pin-detach-notify-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "Detach Notify",
+      source: "admin-api",
+      managerId: seed.memberId,
+      organizationId: seed.organizationId,
+      clientId: seed.clientId,
+    });
+    const ws = await openRegisteredSocket(seed);
+
+    try {
+      await bindRuntimeSlot(ws, agent.uuid, "bind-detach-notify");
+      expect(getAgentClientId(agent.uuid)).toBe(seed.clientId);
+
+      const forcePromise = waitForFrame(
+        ws,
+        (m) =>
+          (m as { type?: string; agentId?: string }).type === "agent:force_disconnect" &&
+          (m as { agentId?: string }).agentId === agent.uuid,
+      );
+      const rebound = await rebindAgent(app.db, agent.uuid, {
+        clientId: secondSeed.clientId,
+        runtimeProvider: "claude-code",
+      });
+      expect(rebound.previousClientId).toBe(seed.clientId);
+
+      await expect(forcePromise).resolves.toMatchObject({
+        type: "agent:force_disconnect",
+        agentId: agent.uuid,
+        reason: "agent_rebound",
+      });
+      expect(getAgentClientId(agent.uuid)).toBeUndefined();
+    } finally {
+      await closeSockets(ws);
     }
   }, 15000);
 

--- a/packages/server/src/__tests__/agent-pinned-notification.test.ts
+++ b/packages/server/src/__tests__/agent-pinned-notification.test.ts
@@ -1,11 +1,14 @@
+import { eq } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { SignJWT } from "jose";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import WebSocket from "ws";
+import { agentPresence } from "../db/schema/agent-presence.js";
 import { clients } from "../db/schema/clients.js";
 import { members } from "../db/schema/members.js";
 import { users } from "../db/schema/users.js";
 import { createAgent, suspendAgent } from "../services/agent.js";
+import { getAgentClientId } from "../services/connection-manager.js";
 import { resolveDefaultOrgId } from "../services/organization.js";
 import { uuidv7 } from "../uuid.js";
 import { createTestApp } from "./helpers.js";
@@ -126,6 +129,54 @@ describe("Agent WS — agent:pinned push on create/bind", () => {
     await waitForFrame(ws, (m) => (m as { type?: string }).type === "client:registered");
 
     return ws;
+  }
+
+  async function seedAdditionalClient(
+    seed: Awaited<ReturnType<typeof seedConnectedClient>>,
+    suffix: string,
+  ): Promise<Awaited<ReturnType<typeof seedConnectedClient>>> {
+    const clientId = `cli-pin-${suffix}-${crypto.randomUUID().slice(0, 6)}`;
+    await app.db.insert(clients).values({
+      id: clientId,
+      userId: seed.userId,
+      organizationId: seed.organizationId,
+      status: "connected",
+    });
+    return { ...seed, clientId };
+  }
+
+  async function bindRuntimeSlot(ws: WebSocket, agentId: string, ref: string): Promise<void> {
+    ws.send(
+      JSON.stringify({
+        type: "agent:bind",
+        ref,
+        agentId,
+        runtimeType: "claude-code",
+        runtimeVersion: "test",
+      }),
+    );
+    await waitForFrame(
+      ws,
+      (m) =>
+        (m as { type?: string; agentId?: string }).type === "agent:bound" &&
+        (m as { agentId?: string }).agentId === agentId,
+    );
+  }
+
+  async function closeSockets(...sockets: WebSocket[]): Promise<void> {
+    await Promise.all(
+      sockets.map(
+        (ws) =>
+          new Promise<void>((resolve) => {
+            if (ws.readyState === WebSocket.CLOSED) {
+              resolve();
+              return;
+            }
+            ws.once("close", () => resolve());
+            ws.close();
+          }),
+      ),
+    );
   }
 
   beforeAll(async () => {
@@ -453,6 +504,128 @@ describe("Agent WS — agent:pinned push on create/bind", () => {
     } finally {
       ws.close();
       await new Promise<void>((r) => ws.once("close", () => r()));
+    }
+  }, 15000);
+
+  it("rebind force-disconnects the previous client and ignores stale unbinds", async () => {
+    const firstSeed = await seedConnectedClient("rebind-first");
+    const secondSeed = await seedAdditionalClient(firstSeed, "rebind-second");
+    const thirdSeed = await seedAdditionalClient(firstSeed, "rebind-third");
+    const firstWs = await openRegisteredSocket(firstSeed);
+    const secondWs = await openRegisteredSocket(secondSeed);
+    const thirdWs = await openRegisteredSocket(thirdSeed);
+
+    try {
+      const agent = await createAgent(app.db, {
+        name: `pin-rebind-${crypto.randomUUID().slice(0, 6)}`,
+        type: "agent",
+        displayName: "Rebind Agent",
+        source: "admin-api",
+        managerId: firstSeed.memberId,
+        organizationId: firstSeed.organizationId,
+        clientId: firstSeed.clientId,
+      });
+
+      await bindRuntimeSlot(firstWs, agent.uuid, "bind-first");
+      expect(getAgentClientId(agent.uuid)).toBe(firstSeed.clientId);
+
+      const firstForcePromise = waitForFrame(
+        firstWs,
+        (m) =>
+          (m as { type?: string; agentId?: string }).type === "agent:force_disconnect" &&
+          (m as { agentId?: string }).agentId === agent.uuid,
+      );
+      const secondPinnedPromise = waitForFrame(
+        secondWs,
+        (m) =>
+          (m as { type?: string; agentId?: string }).type === "agent:pinned" &&
+          (m as { agentId?: string }).agentId === agent.uuid,
+      );
+
+      const res = await app.inject({
+        method: "PATCH",
+        url: `/api/v1/agents/${agent.uuid}/rebind`,
+        headers: { authorization: `Bearer ${firstSeed.token}` },
+        payload: { clientId: secondSeed.clientId, runtimeProvider: "claude-code" },
+      });
+      expect(res.statusCode).toBe(200);
+
+      await expect(firstForcePromise).resolves.toMatchObject({
+        type: "agent:force_disconnect",
+        agentId: agent.uuid,
+        reason: "agent_rebound",
+      });
+      await expect(secondPinnedPromise).resolves.toMatchObject({
+        type: "agent:pinned",
+        agentId: agent.uuid,
+      });
+      expect(getAgentClientId(agent.uuid)).toBeUndefined();
+
+      await bindRuntimeSlot(secondWs, agent.uuid, "bind-second");
+      expect(getAgentClientId(agent.uuid)).toBe(secondSeed.clientId);
+
+      firstWs.send(JSON.stringify({ type: "agent:unbind", agentId: agent.uuid }));
+      await waitForFrame(
+        firstWs,
+        (m) =>
+          (m as { type?: string; agentId?: string }).type === "agent:unbound" &&
+          (m as { agentId?: string }).agentId === agent.uuid,
+      );
+
+      expect(getAgentClientId(agent.uuid)).toBe(secondSeed.clientId);
+      let [presence] = await app.db.select().from(agentPresence).where(eq(agentPresence.agentId, agent.uuid));
+      expect(presence?.status).toBe("online");
+      expect(presence?.clientId).toBe(secondSeed.clientId);
+
+      const secondForcePromise = waitForFrame(
+        secondWs,
+        (m) =>
+          (m as { type?: string; agentId?: string }).type === "agent:force_disconnect" &&
+          (m as { agentId?: string }).agentId === agent.uuid,
+      );
+      const thirdPinnedPromise = waitForFrame(
+        thirdWs,
+        (m) =>
+          (m as { type?: string; agentId?: string }).type === "agent:pinned" &&
+          (m as { agentId?: string }).agentId === agent.uuid,
+      );
+
+      const secondRes = await app.inject({
+        method: "PATCH",
+        url: `/api/v1/agents/${agent.uuid}/rebind`,
+        headers: { authorization: `Bearer ${firstSeed.token}` },
+        payload: { clientId: thirdSeed.clientId, runtimeProvider: "claude-code" },
+      });
+      expect(secondRes.statusCode).toBe(200);
+
+      await expect(secondForcePromise).resolves.toMatchObject({
+        type: "agent:force_disconnect",
+        agentId: agent.uuid,
+        reason: "agent_rebound",
+      });
+      await expect(thirdPinnedPromise).resolves.toMatchObject({
+        type: "agent:pinned",
+        agentId: agent.uuid,
+      });
+      expect(getAgentClientId(agent.uuid)).toBeUndefined();
+
+      await bindRuntimeSlot(thirdWs, agent.uuid, "bind-third");
+      expect(getAgentClientId(agent.uuid)).toBe(thirdSeed.clientId);
+
+      secondWs.send(JSON.stringify({ type: "agent:unbind", agentId: agent.uuid }));
+      await waitForFrame(
+        secondWs,
+        (m) =>
+          (m as { type?: string; agentId?: string }).type === "agent:unbound" &&
+          (m as { agentId?: string }).agentId === agent.uuid,
+      );
+
+      expect(getAgentClientId(agent.uuid)).toBe(thirdSeed.clientId);
+      [presence] = await app.db.select().from(agentPresence).where(eq(agentPresence.agentId, agent.uuid));
+      expect(presence?.status).toBe("online");
+      expect(presence?.clientId).toBe(thirdSeed.clientId);
+    } finally {
+      await closeSockets(firstWs, secondWs, thirdWs);
     }
   }, 15000);
 

--- a/packages/server/src/__tests__/connection-manager.test.ts
+++ b/packages/server/src/__tests__/connection-manager.test.ts
@@ -89,6 +89,16 @@ describe("connection-manager: bindAgentToClient", () => {
     expect(getAgentClientId(agent1)).toBe(clientA);
     expect(getClientAgentIds(clientA)).toEqual([agent1]);
   });
+
+  it("does not unbind when expected client does not own the agent", () => {
+    bindAgentToClient(clientB, agent1);
+
+    const removed = unbindAgentFromClient(agent1, clientA);
+
+    expect(removed).toBe(false);
+    expect(getAgentClientId(agent1)).toBe(clientB);
+    expect(getClientAgentIds(clientB)).toContain(agent1);
+  });
 });
 
 describe("connection-manager: removeClientConnection", () => {
@@ -226,5 +236,30 @@ describe("connection-manager: forceDisconnect M1 mode", () => {
 
     // Cleanup
     forceDisconnectClient(clientId);
+  });
+
+  it("does not force-disconnect when expected client is stale", () => {
+    const currentClientId = "client-m1-current";
+    const staleClientId = "client-m1-stale";
+    const agent1 = "agent-m1-stale-1";
+    const sentMessages: string[] = [];
+    const ws = {
+      readyState: WebSocket.OPEN,
+      close: () => {},
+      send: (data: string) => {
+        sentMessages.push(data);
+      },
+    } as unknown as WebSocket;
+
+    setClientConnection(currentClientId, ws);
+    bindAgentToClient(currentClientId, agent1);
+
+    const result = forceDisconnect(agent1, "agent_rebound", staleClientId);
+
+    expect(result).toBe(false);
+    expect(sentMessages).toHaveLength(0);
+    expect(getAgentClientId(agent1)).toBe(currentClientId);
+
+    forceDisconnectClient(currentClientId);
   });
 });

--- a/packages/server/src/__tests__/pulse-aggregator.test.ts
+++ b/packages/server/src/__tests__/pulse-aggregator.test.ts
@@ -29,6 +29,7 @@ function makeMockNotifier(): {
     notifyRuntimeStateChange: vi.fn(async () => {}),
     notifySessionRuntime: vi.fn(async () => {}),
     notifyChatMessage: vi.fn(async () => {}),
+    notifyAgentDetach: vi.fn(async () => {}),
     notifySessionEvent: vi.fn(async () => {}),
     pushFrameToInbox: vi.fn(async () => 0),
     onConfigChange: vi.fn(),
@@ -39,6 +40,7 @@ function makeMockNotifier(): {
     }),
     onSessionRuntime: vi.fn(),
     onChatMessage: vi.fn(),
+    onAgentDetach: vi.fn(),
     start: vi.fn(async () => {}),
     stop: vi.fn(async () => {}),
   } satisfies Notifier;

--- a/packages/server/src/api/agent/ws-client.ts
+++ b/packages/server/src/api/agent/ws-client.ts
@@ -1078,12 +1078,17 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
               }
 
               const info = boundAgents.get(agentId);
+              const stillRoutedHere = isAgentStillRoutedHere(agentId);
               if (info) {
                 notifier.unsubscribe(info.inboxId, socket);
               }
 
-              await presenceService.unbindAgent(app.db, agentId);
-              connectionManager.unbindAgentFromClient(agentId);
+              if (stillRoutedHere && clientId) {
+                await presenceService.unbindAgent(app.db, agentId, { expectedClientId: clientId });
+                connectionManager.unbindAgentFromClient(agentId, clientId);
+              } else {
+                app.log.info({ clientId, agentId }, "stale agent:unbind ignored for global binding");
+              }
               boundAgents.delete(agentId);
               clearInboxInFlightForAgent(agentId);
 
@@ -1318,10 +1323,13 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
 
               await chainInboxDelivery("__socket", async () => {
                 try {
+                  const routedBoundAgents = [...boundAgents.values()].filter((agent) =>
+                    isAgentStillRoutedHere(agent.agentId),
+                  );
                   const ackResult = await inboxService.ackEntryByIdForBoundAgents(
                     app.db,
                     entryId,
-                    [...boundAgents.values()].map((a) => a.inboxId),
+                    routedBoundAgents.map((a) => a.inboxId),
                   );
                   if (!ackResult.ok) {
                     if (ref) {
@@ -1340,7 +1348,7 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
                         entryId,
                         ref,
                         agentId: null,
-                        boundInboxes: boundAgents.size,
+                        boundInboxes: routedBoundAgents.length,
                         reason: ackResult.reason,
                         ackEvent: "inbox_ack_rejected",
                       },
@@ -1350,7 +1358,7 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
                   }
                   // Find the agentId that owns this inbox to decrement the
                   // counter and trigger backlog drain.
-                  const owner = [...boundAgents.values()].find((a) => a.inboxId === ackResult.throughEntry.inboxId);
+                  const owner = routedBoundAgents.find((a) => a.inboxId === ackResult.throughEntry.inboxId);
                   if (ref) {
                     socket.send(
                       JSON.stringify({

--- a/packages/server/src/api/agents.ts
+++ b/packages/server/src/api/agents.ts
@@ -129,7 +129,23 @@ export async function agentRoutes(app: FastifyInstance): Promise<void> {
   app.patch<{ Params: { uuid: string } }>("/:uuid/rebind", { config: { otelRecordBody: true } }, async (request) => {
     await requireAgentAccess(request, app.db, "manage");
     const body = rebindAgentSchema.parse(request.body);
-    const agent = await agentService.rebindAgent(app.db, request.params.uuid, body);
+    const { agent, previousClientId } = await agentService.rebindAgent(app.db, request.params.uuid, body);
+    if (previousClientId && previousClientId !== agent.clientId) {
+      const disconnected = forceDisconnect(request.params.uuid, "agent_rebound", previousClientId);
+      const clearedPresence = await presenceService.unbindAgent(app.db, request.params.uuid, {
+        expectedClientId: previousClientId,
+      });
+      app.log.info(
+        {
+          agentId: request.params.uuid,
+          oldClientId: previousClientId,
+          newClientId: agent.clientId,
+          disconnected,
+          clearedPresence,
+        },
+        "agent rebind detached previous client",
+      );
+    }
     notifyClientAgentPinned(agent);
     const userAvatarUrl = await fetchUserAvatarForHumanAgent(app.db, agent);
     return serializeAgent(agent, userAvatarUrl);

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -82,6 +82,7 @@ import { type BackgroundTasks, createBackgroundTasks } from "./services/backgrou
 import { registerChatMessageDispatcher } from "./services/chat-projection.js";
 import { createCommandVersionPoller } from "./services/command-version-poller.js";
 import { createConfigService } from "./services/config-service.js";
+import { forceDisconnect } from "./services/connection-manager.js";
 import { createNotifier, type Notifier } from "./services/notifier.js";
 import { ensureDefaultOrganization } from "./services/organization.js";
 import { createPulseAggregator } from "./services/pulse-aggregator.js";
@@ -655,6 +656,15 @@ export async function buildApp(config: Config) {
     notifier
       .notifyChatMessage(chatId, messageId)
       .catch((err) => createLogger("chat-message-kick").warn({ err, chatId, messageId }, "chat:message kick failed"));
+  });
+  notifier.onAgentDetach(({ agentId, clientId, reason }) => {
+    const disconnected = forceDisconnect(agentId, reason, clientId);
+    if (disconnected) {
+      app.log.info(
+        { agentId, clientId, reason, instanceId: config.instanceId },
+        "agent detach notification disconnected local runtime",
+      );
+    }
   });
 
   // Start notifier and background tasks on server start.

--- a/packages/server/src/services/agent.ts
+++ b/packages/server/src/services/agent.ts
@@ -17,7 +17,7 @@ import {
   isReservedAgentName,
 } from "@first-tree/shared";
 import { getServerCliBinding } from "@first-tree/shared/channel";
-import { and, count, desc, eq, getTableColumns, ilike, lt, ne, or } from "drizzle-orm";
+import { and, count, desc, eq, getTableColumns, ilike, lt, ne, or, sql } from "drizzle-orm";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import type { Database } from "../db/connection.js";
 import { agentConfigs } from "../db/schema/agent-configs.js";
@@ -31,6 +31,7 @@ import { BadRequestError, ConflictError, ForbiddenError, NotFoundError } from ".
 import type { OrgScope } from "../scope/types.js";
 import { uuidv7 } from "../uuid.js";
 import { agentVisibilityCondition } from "./access-control.js";
+import { AGENT_DETACH_CHANNEL } from "./notifier.js";
 import { resolveDefaultOrgId } from "./organization.js";
 import { recomputeWatchersForAgent } from "./watcher.js";
 
@@ -961,6 +962,15 @@ export async function rebindAgent(db: Database, uuid: string, data: RebindAgent)
       .returning();
 
     if (!updated) throw new Error("Unexpected: UPDATE RETURNING produced no row");
+    if (previousClientId && previousClientId !== newClientId) {
+      await tx.execute(
+        sql`SELECT pg_notify(${AGENT_DETACH_CHANNEL}, ${JSON.stringify({
+          agentId: uuid,
+          clientId: previousClientId,
+          reason: "agent_rebound",
+        })})`,
+      );
+    }
     const refreshed = await selectAgentRowWithRuntime(tx, uuid);
     if (!refreshed) throw new Error("Unexpected: agent disappeared after UPDATE");
     return { agent: refreshed, previousClientId };

--- a/packages/server/src/services/agent.ts
+++ b/packages/server/src/services/agent.ts
@@ -18,6 +18,7 @@ import {
 } from "@first-tree/shared";
 import { getServerCliBinding } from "@first-tree/shared/channel";
 import { and, count, desc, eq, getTableColumns, ilike, lt, ne, or } from "drizzle-orm";
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import type { Database } from "../db/connection.js";
 import { agentConfigs } from "../db/schema/agent-configs.js";
 import { agentPresence } from "../db/schema/agent-presence.js";
@@ -39,6 +40,7 @@ import { recomputeWatchersForAgent } from "./watcher.js";
  * internal traffic could be routed through a real account.
  */
 const RESERVED_AGENT_NAME_PREFIX = "__";
+type SelectDbLike = Pick<PostgresJsDatabase<Record<string, never>>, "select">;
 
 /**
  * Derive the relative URL clients should use to fetch a manager-uploaded
@@ -213,7 +215,7 @@ export function legacyWireAgentType(type: string): "human" | "personal_assistant
  * (e.g. operator overrides for an offline client).
  */
 async function ensureClientSupportsRuntimeProvider(
-  db: Database,
+  db: SelectDbLike,
   clientId: string | null,
   runtimeProvider: RuntimeProvider,
   options: { force?: boolean } = {},
@@ -242,7 +244,7 @@ async function ensureClientSupportsRuntimeProvider(
 }
 
 async function resolveAgentClient(
-  db: Database,
+  db: SelectDbLike,
   data: { clientId?: string; managerId: string; type: string },
 ): Promise<string | null> {
   if (data.type === "human") {
@@ -570,7 +572,7 @@ export async function checkAgentNameAvailability(
  * Returns `null` when no row exists (the caller decides whether that's a
  * 404 or an internal invariant violation post-update).
  */
-export async function selectAgentRowWithRuntime(db: Database, uuid: string): Promise<AgentRowWithRuntime | null> {
+export async function selectAgentRowWithRuntime(db: SelectDbLike, uuid: string): Promise<AgentRowWithRuntime | null> {
   const [row] = await db
     .select({
       ...getTableColumns(agents),
@@ -922,41 +924,47 @@ export async function updateAgent(db: Database, uuid: string, data: UpdateAgent)
  * dialog routes both same-client runtime-only switches and cross-client
  * moves through this single entry.
  *
- * NOTE: active sessions on the previous client are not auto-suspended in P1.
- * P3 will wire in cross-service coordination (inbox + presence + session)
- * so the destination client can resume cleanly.
+ * Returns the agent row plus the previous client captured under the same row
+ * lock as the update, so callers detach the runtime slot that this rebind
+ * actually replaced.
  */
 export async function rebindAgent(db: Database, uuid: string, data: RebindAgent) {
-  const agent = await getAgent(db, uuid);
-  if (agent.type === "human") {
-    throw new BadRequestError("Human agents have no runtime — they cannot be re-bound to a client.");
-  }
+  return db.transaction(async (tx) => {
+    const [agent] = await tx.select().from(agents).where(eq(agents.uuid, uuid)).for("update").limit(1);
+    if (!agent || agent.status === AGENT_STATUSES.DELETED) {
+      throw new NotFoundError(`Agent "${uuid}" not found`);
+    }
+    if (agent.type === "human") {
+      throw new BadRequestError("Human agents have no runtime — they cannot be re-bound to a client.");
+    }
+    const previousClientId = agent.clientId;
 
-  const newClientId = await resolveAgentClient(db, {
-    clientId: data.clientId,
-    managerId: agent.managerId,
-    type: agent.type,
+    const newClientId = await resolveAgentClient(tx, {
+      clientId: data.clientId,
+      managerId: agent.managerId,
+      type: agent.type,
+    });
+    if (newClientId === null) {
+      throw new BadRequestError("Rebind requires a non-null clientId.");
+    }
+
+    await ensureClientSupportsRuntimeProvider(tx, newClientId, data.runtimeProvider, { force: data.force });
+
+    const [updated] = await tx
+      .update(agents)
+      .set({
+        clientId: newClientId,
+        runtimeProvider: data.runtimeProvider,
+        updatedAt: new Date(),
+      })
+      .where(eq(agents.uuid, uuid))
+      .returning();
+
+    if (!updated) throw new Error("Unexpected: UPDATE RETURNING produced no row");
+    const refreshed = await selectAgentRowWithRuntime(tx, uuid);
+    if (!refreshed) throw new Error("Unexpected: agent disappeared after UPDATE");
+    return { agent: refreshed, previousClientId };
   });
-  if (newClientId === null) {
-    throw new BadRequestError("Rebind requires a non-null clientId.");
-  }
-
-  await ensureClientSupportsRuntimeProvider(db, newClientId, data.runtimeProvider, { force: data.force });
-
-  const [updated] = await db
-    .update(agents)
-    .set({
-      clientId: newClientId,
-      runtimeProvider: data.runtimeProvider,
-      updatedAt: new Date(),
-    })
-    .where(eq(agents.uuid, uuid))
-    .returning();
-
-  if (!updated) throw new Error("Unexpected: UPDATE RETURNING produced no row");
-  const refreshed = await selectAgentRowWithRuntime(db, uuid);
-  if (!refreshed) throw new Error("Unexpected: agent disappeared after UPDATE");
-  return refreshed;
 }
 
 /**

--- a/packages/server/src/services/connection-manager.ts
+++ b/packages/server/src/services/connection-manager.ts
@@ -27,15 +27,16 @@ export function removeConnection(agentId: string, ws: WebSocket): boolean {
 }
 
 /** Force-disconnect an agent's active WS connection. Returns true if a connection was closed. */
-export function forceDisconnect(agentId: string, reason?: string): boolean {
+export function forceDisconnect(agentId: string, reason?: string, expectedClientId?: string): boolean {
   const clientId = agentToClient.get(agentId);
+  if (expectedClientId !== undefined && clientId !== expectedClientId) return false;
   if (clientId) {
     // M1 mode: unbind the single agent without closing the shared client WS
     const entry = clientConnections.get(clientId);
     if (entry && entry.ws.readyState <= 1) {
       entry.ws.send(JSON.stringify({ type: "agent:force_disconnect", agentId, ...(reason ? { reason } : {}) }));
     }
-    unbindAgentFromClient(agentId);
+    unbindAgentFromClient(agentId, clientId);
     return true;
   }
 
@@ -99,8 +100,9 @@ export function bindAgentToClient(clientId: string, agentId: string): void {
   agentToClient.set(agentId, clientId);
 }
 
-export function unbindAgentFromClient(agentId: string): void {
+export function unbindAgentFromClient(agentId: string, expectedClientId?: string): boolean {
   const clientId = agentToClient.get(agentId);
+  if (expectedClientId !== undefined && clientId !== expectedClientId) return false;
   if (clientId) {
     const entry = clientConnections.get(clientId);
     if (entry) {
@@ -109,6 +111,7 @@ export function unbindAgentFromClient(agentId: string): void {
     agentToClient.delete(agentId);
   }
   activeConnections.delete(agentId);
+  return clientId !== undefined;
 }
 
 export function getClientAgentIds(clientId: string): string[] {

--- a/packages/server/src/services/notifier.ts
+++ b/packages/server/src/services/notifier.ts
@@ -20,6 +20,12 @@ const SESSION_RUNTIME_CHANNEL = "session_runtime_changes";
  * inbox NOTIFY path that only reaches speakers.
  */
 const CHAT_MESSAGE_CHANNEL = "chat_message_events";
+/**
+ * Runtime binding cross-process invalidation. Carries a small JSON payload
+ * `{ agentId, clientId, reason }`; each server instance conditionally detaches
+ * its local route only when `clientId` still owns `agentId` on that instance.
+ */
+export const AGENT_DETACH_CHANNEL = "agent_detach_requests";
 
 export type ConfigChangeHandler = (channel: string) => void;
 export type SessionStateChangeHandler = (payload: {
@@ -57,6 +63,7 @@ export type SessionRuntimeChangeHandler = (payload: {
   organizationId: string;
 }) => void;
 export type ChatMessageChangeHandler = (payload: { chatId: string; messageId: string }) => void;
+export type AgentDetachHandler = (payload: { agentId: string; clientId: string; reason?: string }) => void;
 
 /**
  * Per-socket push handler for the WS data plane. When a NOTIFY arrives on
@@ -92,6 +99,8 @@ export type Notifier = {
   notifySessionRuntime(agentId: string, chatId: string, state: string, organizationId: string): Promise<void>;
   /** Chat-first workspace: kick admin WS sockets to invalidate ["me","chats"] and the timeline of `chatId`. */
   notifyChatMessage(chatId: string, messageId: string): Promise<void>;
+  /** Cross-process runtime route invalidation for an agent/client binding. */
+  notifyAgentDetach(agentId: string, clientId: string, reason?: string): Promise<void>;
   /**
    * Push a raw JSON frame to every socket currently subscribed to `inboxId`
    * on **this server instance only**. Unlike `notify`, does not fan out
@@ -112,6 +121,8 @@ export type Notifier = {
   onSessionRuntime(handler: SessionRuntimeChangeHandler): void;
   /** Register a handler for chat:message change notifications. */
   onChatMessage(handler: ChatMessageChangeHandler): void;
+  /** Register a handler for agent detach requests. */
+  onAgentDetach(handler: AgentDetachHandler): void;
   /** Start listening for PG notifications */
   start(): Promise<void>;
   /** Stop listening */
@@ -126,6 +137,7 @@ export function createNotifier(listenClient: postgres.Sql): Notifier {
   const runtimeStateChangeHandlers: RuntimeStateChangeHandler[] = [];
   const sessionRuntimeHandlers: SessionRuntimeChangeHandler[] = [];
   const chatMessageHandlers: ChatMessageChangeHandler[] = [];
+  const agentDetachHandlers: AgentDetachHandler[] = [];
   let unlistenInboxFn: (() => Promise<void>) | null = null;
   let unlistenConfigFn: (() => Promise<void>) | null = null;
   let unlistenSessionStateFn: (() => Promise<void>) | null = null;
@@ -133,6 +145,7 @@ export function createNotifier(listenClient: postgres.Sql): Notifier {
   let unlistenRuntimeStateFn: (() => Promise<void>) | null = null;
   let unlistenSessionRuntimeFn: (() => Promise<void>) | null = null;
   let unlistenChatMessageFn: (() => Promise<void>) | null = null;
+  let unlistenAgentDetachFn: (() => Promise<void>) | null = null;
 
   function handleNotification(payload: string) {
     // payload format: "inboxId:messageId"
@@ -239,6 +252,10 @@ export function createNotifier(listenClient: postgres.Sql): Notifier {
       }
     },
 
+    async notifyAgentDetach(agentId: string, clientId: string, reason?: string) {
+      await listenClient`SELECT pg_notify(${AGENT_DETACH_CHANNEL}, ${JSON.stringify({ agentId, clientId, reason })})`;
+    },
+
     async pushFrameToInbox(inboxId: string, frame: string): Promise<number> {
       const map = subscriptions.get(inboxId);
       if (!map) return 0;
@@ -281,6 +298,10 @@ export function createNotifier(listenClient: postgres.Sql): Notifier {
 
     onChatMessage(handler: ChatMessageChangeHandler) {
       chatMessageHandlers.push(handler);
+    },
+
+    onAgentDetach(handler: AgentDetachHandler) {
+      agentDetachHandlers.push(handler);
     },
 
     async start() {
@@ -399,6 +420,32 @@ export function createNotifier(listenClient: postgres.Sql): Notifier {
         }
       });
       unlistenChatMessageFn = chatMessageResult.unlisten;
+
+      const agentDetachResult = await listenClient.listen(AGENT_DETACH_CHANNEL, (payload) => {
+        if (!payload) return;
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(payload);
+        } catch {
+          return;
+        }
+        if (!parsed || typeof parsed !== "object") return;
+        const data = parsed as { agentId?: unknown; clientId?: unknown; reason?: unknown };
+        if (typeof data.agentId !== "string" || typeof data.clientId !== "string") return;
+        const event = {
+          agentId: data.agentId,
+          clientId: data.clientId,
+          reason: typeof data.reason === "string" ? data.reason : undefined,
+        };
+        for (const handler of agentDetachHandlers) {
+          try {
+            handler(event);
+          } catch {
+            // swallow — handler errors must not poison fan-out
+          }
+        }
+      });
+      unlistenAgentDetachFn = agentDetachResult.unlisten;
     },
 
     async stop() {
@@ -429,6 +476,10 @@ export function createNotifier(listenClient: postgres.Sql): Notifier {
       if (unlistenChatMessageFn) {
         await unlistenChatMessageFn();
         unlistenChatMessageFn = null;
+      }
+      if (unlistenAgentDetachFn) {
+        await unlistenAgentDetachFn();
+        unlistenAgentDetachFn = null;
       }
     },
   };

--- a/packages/server/src/services/presence.ts
+++ b/packages/server/src/services/presence.ts
@@ -1,5 +1,5 @@
 import type { RuntimeState } from "@first-tree/shared";
-import { eq, sql } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 import { agentPresence } from "../db/schema/agent-presence.js";
 import { serverInstances } from "../db/schema/server-instances.js";
@@ -110,16 +110,26 @@ export async function bindAgent(
     });
 }
 
-export async function unbindAgent(db: Database, agentId: string) {
+export async function unbindAgent(
+  db: Database,
+  agentId: string,
+  opts: { expectedClientId?: string } = {},
+): Promise<number> {
   const now = new Date();
-  await db
+  const where =
+    opts.expectedClientId === undefined
+      ? eq(agentPresence.agentId, agentId)
+      : and(eq(agentPresence.agentId, agentId), eq(agentPresence.clientId, opts.expectedClientId));
+  const updated = await db
     .update(agentPresence)
     .set({
       status: "offline",
       clientId: null,
       ...runtimeFieldsReset(now),
     })
-    .where(eq(agentPresence.agentId, agentId));
+    .where(where)
+    .returning({ agentId: agentPresence.agentId });
+  return updated.length;
 }
 
 /** Set runtime state directly from client-reported value.


### PR DESCRIPTION
## Summary
- make cross-client agent rebind an exclusive runtime move by capturing the actual previous client inside the locked `rebindAgent` mutation
- enqueue a PostgreSQL `agent_detach_requests` notification in the same rebind transaction so every stateless server instance can invalidate the replaced runtime route
- have each instance conditionally `agent:force_disconnect` only the local route that still maps the agent to the expected previous client
- ignore stale socket `agent:unbind` and `inbox:ack` frames unless the socket is still the current agent route
- add expected-client guards to connection-manager and presence unbind paths

## Context Tree
- Companion tree PR: https://github.com/agent-team-foundation/first-tree-context/pull/516

## Verification
- `pnpm exec biome check --write packages/server/src/services/notifier.ts packages/server/src/services/agent.ts packages/server/src/app.ts packages/server/src/api/agents.ts packages/server/src/__tests__/agent-pinned-notification.test.ts packages/server/src/__tests__/activity.test.ts packages/server/src/__tests__/pulse-aggregator.test.ts`
- `pnpm exec vitest run src/__tests__/connection-manager.test.ts src/__tests__/agent-pinned-notification.test.ts src/__tests__/agent-capability-gate.test.ts src/__tests__/pulse-aggregator.test.ts src/__tests__/activity.test.ts --maxWorkers=2 --maxConcurrency=2` (46 passed)
- `pnpm check` (exit 0; existing unrelated warnings/info remain)
- `TURBO_CONCURRENCY=2 pnpm typecheck` (12 successful)

Reviewed in First Tree chat by codex-reviewer before PR creation; updated after human review requested cross-instance route invalidation.