### PR TITLE
fix(client): fail closed on source repo repoint blockers

### DIFF
--- a/packages/client/src/__tests__/git-mirror-manager.test.ts
+++ b/packages/client/src/__tests__/git-mirror-manager.test.ts
@@ -164,6 +164,66 @@ function seedBareRepo(branch = "main"): { url: string; tip: string; prev: string
   return { url: bare, tip, prev };
 }
 
+function seedRepointReposWithSharedBase(): {
+  a: { url: string; tip: string };
+  b: { url: string; tip: string };
+} {
+  const dir = mkdtempSync(join(tmpdir(), "ftt-repoint-"));
+  const base = join(dir, "base");
+  mkdirSync(base, { recursive: true });
+  execSync("git init -q -b main", { cwd: base });
+  execSync("git config user.email t@e.com && git config user.name t", { cwd: base });
+  writeFileSync(join(base, "README.md"), "base");
+  execSync("git add . && git commit -q -m base", {
+    cwd: base,
+    env: {
+      ...process.env,
+      GIT_AUTHOR_DATE: "2020-01-01T00:00:00Z",
+      GIT_COMMITTER_DATE: "2020-01-01T00:00:00Z",
+    },
+  });
+
+  const aSeed = join(dir, "a-seed");
+  execSync(`git clone -q ${base} ${aSeed}`);
+  execSync("git config user.email t@e.com && git config user.name t", { cwd: aSeed });
+  writeFileSync(join(aSeed, "repo-a.txt"), "a");
+  execSync("git add . && git commit -q -m a-tip", {
+    cwd: aSeed,
+    env: {
+      ...process.env,
+      GIT_AUTHOR_DATE: "2020-01-01T00:00:01Z",
+      GIT_COMMITTER_DATE: "2020-01-01T00:00:01Z",
+    },
+  });
+  const aTip = execSync("git rev-parse HEAD", { cwd: aSeed }).toString().trim();
+  const aBare = join(dir, "a.git");
+  execSync(`git init -q --bare ${aBare}`);
+  execSync(`git push -q ${aBare} main`, { cwd: aSeed });
+  execSync("git symbolic-ref HEAD refs/heads/main", { cwd: aBare });
+
+  const bSeed = join(dir, "b-seed");
+  execSync(`git clone -q ${base} ${bSeed}`);
+  execSync("git config user.email t@e.com && git config user.name t", { cwd: bSeed });
+  execSync("git checkout -q -b trunk", { cwd: bSeed });
+  execSync("git branch -D main", { cwd: bSeed });
+  writeFileSync(join(bSeed, "repo-b.txt"), "b");
+  execSync("git add . && git commit -q -m b-tip", {
+    cwd: bSeed,
+    env: {
+      ...process.env,
+      GIT_AUTHOR_DATE: "2020-01-01T00:00:02Z",
+      GIT_COMMITTER_DATE: "2020-01-01T00:00:02Z",
+    },
+  });
+  const bTip = execSync("git rev-parse HEAD", { cwd: bSeed }).toString().trim();
+  const bBare = join(dir, "b.git");
+  execSync(`git init -q --bare ${bBare}`);
+  execSync(`git push -q ${bBare} trunk`, { cwd: bSeed });
+  execSync("git symbolic-ref HEAD refs/heads/trunk", { cwd: bBare });
+
+  return { a: { url: aBare, tip: aTip }, b: { url: bBare, tip: bTip } };
+}
+
 /** Push one new commit to `main` of a bare upstream; returns the new tip sha. */
 function pushCommit(url: string, marker: string): string {
   const tmp = mkdtempSync(join(tmpdir(), "ftt-push-"));
@@ -250,11 +310,14 @@ describe("GitMirrorManager — source repo lifecycle (per-agent clone)", () => {
   });
 
   it("reconciles origin url + default branch when the configured url repoints to a different repo", async () => {
-    const a = seedBareRepo("main");
+    const { a, b } = seedRepointReposWithSharedBase();
     // Repo B has a DIFFERENT default branch name — exercises the origin/HEAD
     // refresh in reconcileOrigin (a plain fetch would leave origin/HEAD on
-    // "main", which doesn't exist in B).
-    const b = seedBareRepo("trunk");
+    // "main", which doesn't exist in B). A and B intentionally share a base
+    // commit but diverge at their tips, matching the flaky failure shape: the
+    // local-commits guard must not treat repo A's old HEAD as same-repo work
+    // after the origin URL repoints to repo B.
+    expect(a.tip).not.toBe(b.tip);
     const m = makeManager();
     const clonePath = join(newDataDir(), "repo");
     // First materialise against repo A.
@@ -266,7 +329,34 @@ describe("GitMirrorManager — source repo lifecycle (per-agent clone)", () => {
     const r2 = await m.ensureSourceRepo({ url: b.url, clonePath });
     expect(gitIn(clonePath, "config --get remote.origin.url")).toBe(b.url);
     expect(gitIn(clonePath, "rev-parse HEAD")).toBe(b.tip);
+    expect(r2.outcome).toBe("updated");
+    expect(r2.headCommit).toBe(b.tip);
     expect(r2.branch).toBe("trunk");
+  });
+
+  it("fails closed before repointing origin when the configured url changes and the checkout is dirty", async () => {
+    const { a, b } = seedRepointReposWithSharedBase();
+    const m = makeManager();
+    const clonePath = join(newDataDir(), "repo");
+    await m.ensureSourceRepo({ url: a.url, clonePath });
+    writeFileSync(join(clonePath, "README.md"), "dirty local edit");
+
+    await expect(m.ensureSourceRepo({ url: b.url, clonePath })).rejects.toBeInstanceOf(GitMirrorError);
+    expect(gitIn(clonePath, "config --get remote.origin.url")).toBe(a.url);
+    expect(gitIn(clonePath, "rev-parse HEAD")).toBe(a.tip);
+  });
+
+  it("fails closed before repointing origin when the configured url changes and the checkout is in use", async () => {
+    const { a, b } = seedRepointReposWithSharedBase();
+    const m = makeManager();
+    const clonePath = join(newDataDir(), "repo");
+    await m.ensureSourceRepo({ url: a.url, clonePath });
+
+    await expect(m.ensureSourceRepo({ url: b.url, clonePath, activelyInUse: true })).rejects.toBeInstanceOf(
+      GitMirrorError,
+    );
+    expect(gitIn(clonePath, "config --get remote.origin.url")).toBe(a.url);
+    expect(gitIn(clonePath, "rev-parse HEAD")).toBe(a.tip);
   });
 
   it("preserves local commits ahead of upstream instead of resetting (skipped-local-commits)", async () => {

--- a/packages/client/src/__tests__/git-mirror-manager.test.ts
+++ b/packages/client/src/__tests__/git-mirror-manager.test.ts
@@ -379,6 +379,25 @@ describe("GitMirrorManager — source repo lifecycle (per-agent clone)", () => {
     expect(upstream).not.toBe(localHead);
   });
 
+  it("keeps local commits protected when origin is missing before fetch", async () => {
+    const { url, tip } = seedBareRepo();
+    const m = makeManager();
+    const clonePath = join(newDataDir(), "repo");
+    await m.ensureSourceRepo({ url, clonePath });
+    execSync("git config user.email t@e.com && git config user.name t", { cwd: clonePath });
+    writeFileSync(join(clonePath, "local.txt"), "agent work");
+    execSync("git add . && git commit -q -m local-work", { cwd: clonePath });
+    const localHead = gitIn(clonePath, "rev-parse HEAD");
+    execSync("git remote remove origin", { cwd: clonePath });
+
+    const r = await m.ensureSourceRepo({ url, clonePath });
+    expect(r.outcome).toBe("skipped-local-commits");
+    expect(gitIn(clonePath, "config --get remote.origin.url")).toBe(url);
+    expect(gitIn(clonePath, "rev-parse HEAD")).toBe(localHead);
+    expect(existsSync(join(clonePath, "local.txt"))).toBe(true);
+    expect(localHead).not.toBe(tip);
+  });
+
   it("degrades to the existing checkout when a SAME-repo fetch fails transiently (stale-offline)", async () => {
     // Issue #865: an existing, usable clone of the SAME repo + a transient
     // network fetch failure must NOT abort — leave the checkout at its current

--- a/packages/client/src/__tests__/git-mirror-manager.test.ts
+++ b/packages/client/src/__tests__/git-mirror-manager.test.ts
@@ -436,9 +436,17 @@ describe("GitMirrorManager — source repo lifecycle (per-agent clone)", () => {
     const clonePath = join(newDataDir(), "repo");
     const first = await m.ensureSourceRepo({ url, clonePath });
     expect(first.headCommit).toBe(tip);
-    await expect(m.ensureSourceRepo({ url: "https://127.0.0.1:1/different.git", clonePath })).rejects.toBeInstanceOf(
-      GitMirrorError,
-    );
+    const unreachable = "https://127.0.0.1:1/different.git";
+    await expect(m.ensureSourceRepo({ url: unreachable, clonePath })).rejects.toBeInstanceOf(GitMirrorError);
+    expect(gitIn(clonePath, "config --get remote.origin.url")).toBe(url);
+    expect(gitIn(clonePath, "rev-parse HEAD")).toBe(tip);
+
+    // Regression: the failed confirmation fetch must not leave origin pointing
+    // at the unconfirmed URL. Otherwise the retry looks like a same-repo outage
+    // and degrades to stale-offline while serving the old checkout.
+    await expect(m.ensureSourceRepo({ url: unreachable, clonePath })).rejects.toBeInstanceOf(GitMirrorError);
+    expect(gitIn(clonePath, "config --get remote.origin.url")).toBe(url);
+    expect(gitIn(clonePath, "rev-parse HEAD")).toBe(tip);
   }, 30_000);
 
   it("still degrades when the configured ref already matches the checked-out HEAD", async () => {

--- a/packages/client/src/runtime/git-mirror-manager.ts
+++ b/packages/client/src/runtime/git-mirror-manager.ts
@@ -407,21 +407,21 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
    * so the subsequent fetch + `checkout -B` track the configured upstream
    * instead of silently serving the old one.
    */
+  type OriginUrlState = "matched" | "different" | "missing-or-unreadable";
+
   /**
-   * True when `absTarget`'s current `remote.origin.url` already canonically
-   * matches the configured `url` — i.e. reconcileOrigin would NOT repoint origin
-   * to a different repo. Mirrors reconcileOrigin's own canonical comparison.
-   * Gates the transient `stale-offline` degrade: serving the local checkout is
-   * only safe when it is the SAME repo. Treats an unreadable / missing origin as
-   * "not matching" (fail closed).
+   * Classify the current `remote.origin.url` before reconciling it. A confirmed
+   * canonical difference means a real URL repoint; a missing / unreadable origin
+   * is ambiguous and must keep same-repo local-commit protection.
    */
-  async function originCanonicallyMatches(absTarget: string, url: string): Promise<boolean> {
+  async function originUrlState(absTarget: string, url: string): Promise<OriginUrlState> {
     try {
       const { stdout } = await git(["config", "--get", "remote.origin.url"], absTarget, 10_000);
       const current = stdout.trim();
-      return current.length > 0 && canonicalizeRepoUrl(current) === canonicalizeRepoUrl(url);
+      if (!current) return "missing-or-unreadable";
+      return canonicalizeRepoUrl(current) === canonicalizeRepoUrl(url) ? "matched" : "different";
     } catch {
-      return false;
+      return "missing-or-unreadable";
     }
   }
 
@@ -706,13 +706,13 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
 
         // (4) Managed standalone clone → reconcile origin, fetch, then update when safe.
         //
-        // Capture whether origin ALREADY canonically matched the configured
-        // upstream *before* reconcileOrigin can repoint it. The transient
-        // degrade below is only safe for the SAME repo: if this call is
-        // repointing origin to a different repo and the confirming fetch then
-        // fails, the local checkout is the OLD repo's content and must NOT be
-        // served as the newly-configured source.
-        const originMatchedBeforeFetch = await originCanonicallyMatches(absTarget, url);
+        // Capture origin state *before* reconcileOrigin can mutate it. Only a
+        // confirmed canonical difference is a real URL repoint. A missing /
+        // unreadable origin is ambiguous: fetch failures must fail closed, but a
+        // successful fetch must still protect same-repo local commits.
+        const originStateBeforeFetch = await originUrlState(absTarget, url);
+        const originMatchedBeforeFetch = originStateBeforeFetch === "matched";
+        const originDiffersBeforeFetch = originStateBeforeFetch === "different";
         if (!originMatchedBeforeFetch) {
           if (activelyInUse) {
             throw repointBlockedError(absTarget, url, "another live session is using the checkout");
@@ -809,7 +809,7 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
         }
 
         const before = await headCommit(absTarget);
-        const update = await updateToLatest(absTarget, ref, { protectLocalCommits: originMatchedBeforeFetch });
+        const update = await updateToLatest(absTarget, ref, { protectLocalCommits: !originDiffersBeforeFetch });
         if (update === "skipped-local-commits") {
           log?.warn(
             { clonePath: absTarget },

--- a/packages/client/src/runtime/git-mirror-manager.ts
+++ b/packages/client/src/runtime/git-mirror-manager.ts
@@ -596,13 +596,16 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
    * current HEAD is strictly ahead of the resolved branch tip on the *same*
    * lineage — i.e. someone committed local work on top of the tracked branch.
    * `checkout -B` would orphan those commits, so we refuse and leave the
-   * checkout as-is. A diverged/unrelated HEAD (e.g. after an origin repoint) is
-   * NOT ahead-on-the-same-lineage, so it still resets cleanly. A pinned SHA
-   * `ref` is explicit operator intent and is always applied.
+   * checkout as-is. Disable that guard after an origin URL repoint: the current
+   * HEAD belongs to the previously configured source, and distinct repos can
+   * still share history (forks/templates), so serving it as the new source would
+   * be wrong. A pinned SHA `ref` is explicit operator intent and is always
+   * applied.
    */
   async function updateToLatest(
     absTarget: string,
     ref: string | undefined,
+    opts: { protectLocalCommits?: boolean } = {},
   ): Promise<"applied" | "skipped-local-commits"> {
     if (ref && looksLikeCommitSha(ref)) {
       if (await gitOk(["cat-file", "-e", ref], absTarget, 10_000)) {
@@ -623,24 +626,31 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
         `Cannot update "${absTarget}": remote-tracking ref "${remoteRef}" not found after fetch.`,
       );
     }
-    // Data-loss guard: skip the destructive reset when HEAD carries commits the
-    // remote tip does NOT contain, on a *shared* history — i.e. local work
-    // committed on top of (or diverged from) the tracked branch. `checkout -B`
-    // would orphan those commits.
-    //   - related (common ancestor exists) AND HEAD not an ancestor of remote
-    //     → HEAD has its own commits → SKIP.
-    //   - HEAD is an ancestor of remote (fast-forward, incl. equal)        → reset.
-    //   - unrelated history (no common ancestor, e.g. origin repointed at a
-    //     different repo)                                                  → reset.
-    const related = await gitOk(["merge-base", remoteRef, "HEAD"], absTarget, 10_000);
-    const headIsAncestorOfRemote = await gitOk(["merge-base", "--is-ancestor", "HEAD", remoteRef], absTarget, 10_000);
-    if (related && !headIsAncestorOfRemote) {
-      return "skipped-local-commits";
+    if (opts.protectLocalCommits !== false) {
+      // Data-loss guard: skip the destructive reset when HEAD carries commits
+      // the remote tip does NOT contain, on a *shared* history — i.e. local
+      // work committed on top of (or diverged from) the tracked branch.
+      // `checkout -B` would orphan those commits.
+      //   - related (common ancestor exists) AND HEAD not an ancestor of remote
+      //     → HEAD has its own commits → SKIP.
+      //   - HEAD is an ancestor of remote (fast-forward, incl. equal) → reset.
+      //   - unrelated history (no common ancestor) → reset.
+      const related = await gitOk(["merge-base", remoteRef, "HEAD"], absTarget, 10_000);
+      const headIsAncestorOfRemote = await gitOk(["merge-base", "--is-ancestor", "HEAD", remoteRef], absTarget, 10_000);
+      if (related && !headIsAncestorOfRemote) {
+        return "skipped-local-commits";
+      }
     }
     // `checkout -B` with a clean tree moves the local branch to the remote tip
     // and updates the working tree. Force-guards against a transient index lock.
     await git(["checkout", "-B", branch, remoteRef], absTarget, cloneTimeoutMs);
     return "applied";
+  }
+
+  function repointBlockedError(absTarget: string, url: string, reason: string): GitMirrorError {
+    return new GitMirrorError(
+      `Cannot repoint source-repo target "${absTarget}" to "${url}" because ${reason}; refusing to serve the previous source as the configured source.`,
+    );
   }
 
   return {
@@ -703,6 +713,14 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
         // fails, the local checkout is the OLD repo's content and must NOT be
         // served as the newly-configured source.
         const originMatchedBeforeFetch = await originCanonicallyMatches(absTarget, url);
+        if (!originMatchedBeforeFetch) {
+          if (activelyInUse) {
+            throw repointBlockedError(absTarget, url, "another live session is using the checkout");
+          }
+          if (await isDirty(absTarget)) {
+            throw repointBlockedError(absTarget, url, "the checkout has local changes");
+          }
+        }
         try {
           await reconcileOrigin(absTarget, url);
           await fetchClone(absTarget, url);
@@ -773,10 +791,16 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
         }
 
         if (activelyInUse) {
+          if (!originMatchedBeforeFetch) {
+            throw repointBlockedError(absTarget, url, "another live session is using the checkout");
+          }
           log?.debug({ clonePath: absTarget }, "source-repo update skipped — another live session is using it");
           return finish("skipped-in-use");
         }
         if (await isDirty(absTarget)) {
+          if (!originMatchedBeforeFetch) {
+            throw repointBlockedError(absTarget, url, "the checkout has local changes");
+          }
           log?.warn(
             { clonePath: absTarget },
             "source-repo has local changes — leaving at current commit, not updating to latest",
@@ -785,7 +809,7 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
         }
 
         const before = await headCommit(absTarget);
-        const update = await updateToLatest(absTarget, ref);
+        const update = await updateToLatest(absTarget, ref, { protectLocalCommits: originMatchedBeforeFetch });
         if (update === "skipped-local-commits") {
           log?.warn(
             { clonePath: absTarget },

--- a/packages/client/src/runtime/git-mirror-manager.ts
+++ b/packages/client/src/runtime/git-mirror-manager.ts
@@ -407,7 +407,10 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
    * so the subsequent fetch + `checkout -B` track the configured upstream
    * instead of silently serving the old one.
    */
-  type OriginUrlState = "matched" | "different" | "missing-or-unreadable";
+  type OriginUrlState =
+    | { kind: "matched"; currentUrl: string }
+    | { kind: "different"; currentUrl: string }
+    | { kind: "missing-or-unreadable" };
 
   /**
    * Classify the current `remote.origin.url` before reconciling it. A confirmed
@@ -418,10 +421,12 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
     try {
       const { stdout } = await git(["config", "--get", "remote.origin.url"], absTarget, 10_000);
       const current = stdout.trim();
-      if (!current) return "missing-or-unreadable";
-      return canonicalizeRepoUrl(current) === canonicalizeRepoUrl(url) ? "matched" : "different";
+      if (!current) return { kind: "missing-or-unreadable" };
+      return canonicalizeRepoUrl(current) === canonicalizeRepoUrl(url)
+        ? { kind: "matched", currentUrl: current }
+        : { kind: "different", currentUrl: current };
     } catch {
-      return "missing-or-unreadable";
+      return { kind: "missing-or-unreadable" };
     }
   }
 
@@ -653,6 +658,21 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
     );
   }
 
+  async function rollbackUnconfirmedOrigin(absTarget: string, previousOriginUrl: string | undefined): Promise<void> {
+    try {
+      if (previousOriginUrl) {
+        await git(["remote", "set-url", "origin", previousOriginUrl], absTarget, 10_000);
+      } else {
+        await git(["remote", "remove", "origin"], absTarget, 10_000);
+      }
+    } catch (err) {
+      log?.warn(
+        { clonePath: absTarget, previousOriginUrl, err: err instanceof Error ? err.message : String(err) },
+        "failed to roll back unconfirmed source-repo origin after fetch failure",
+      );
+    }
+  }
+
   return {
     get legacyMirrorsRoot() {
       return legacyMirrorsRoot;
@@ -711,8 +731,10 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
         // unreadable origin is ambiguous: fetch failures must fail closed, but a
         // successful fetch must still protect same-repo local commits.
         const originStateBeforeFetch = await originUrlState(absTarget, url);
-        const originMatchedBeforeFetch = originStateBeforeFetch === "matched";
-        const originDiffersBeforeFetch = originStateBeforeFetch === "different";
+        const originMatchedBeforeFetch = originStateBeforeFetch.kind === "matched";
+        const originDiffersBeforeFetch = originStateBeforeFetch.kind === "different";
+        const previousOriginUrl =
+          originStateBeforeFetch.kind === "missing-or-unreadable" ? undefined : originStateBeforeFetch.currentUrl;
         if (!originMatchedBeforeFetch) {
           if (activelyInUse) {
             throw repointBlockedError(absTarget, url, "another live session is using the checkout");
@@ -726,6 +748,9 @@ export function createGitMirrorManager(opts: GitMirrorManagerOptions): GitMirror
           await fetchClone(absTarget, url);
         } catch (err) {
           const stderr = err instanceof Error ? err.message : String(err);
+          if (!originMatchedBeforeFetch) {
+            await rollbackUnconfirmedOrigin(absTarget, previousOriginUrl);
+          }
 
           // Degrade-on-transient-fetch-failure: when GitHub is briefly
           // unreachable (a network blip, not an auth/corrupt/TLS-trust fault)


### PR DESCRIPTION
## Summary

- fail closed before repointing a source repo origin when the checkout is dirty or actively in use
- keep same-repo local-commit protection, but disable that guard only after a confirmed URL repoint so a clean checkout can move to the new upstream
- distinguish matched, different, and missing/unreadable origin states so missing origin still preserves clean local commits
- roll back unconfirmed origin URL writes when a repoint fetch fails, so retries continue to fail closed instead of degrading to `stale-offline` on the old checkout
- add deterministic regression coverage for clean shared-base repoint, dirty/in-use repoint blockers, missing-origin local commits, and failed-repoint retry rollback

## Testing

- `pnpm --filter @first-tree/client build`
- `pnpm --filter @first-tree/client exec vitest run src/__tests__/git-mirror-manager.test.ts -t "origin is being repointed" --maxWorkers 1 --minWorkers 1`
- `pnpm --filter @first-tree/client exec vitest run src/__tests__/git-mirror-manager.test.ts --maxWorkers 1 --minWorkers 1`
- `pnpm check` (exits 0; existing unrelated Biome hints still print)
- `pnpm typecheck`
