### PR TITLE
Preserve human member mirrors on removal

### DIFF
--- a/packages/server/src/__tests__/admin-agents.test.ts
+++ b/packages/server/src/__tests__/admin-agents.test.ts
@@ -1,5 +1,7 @@
+import { eq } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { describe, expect, it } from "vitest";
+import { agents } from "../db/schema/agents.js";
 import { members } from "../db/schema/members.js";
 import { organizations } from "../db/schema/organizations.js";
 import { createAgent } from "../services/agent.js";
@@ -164,6 +166,19 @@ describe("Admin Agents API", () => {
     expect(body.metadata.role).toBe("testing");
   });
 
+  it("rejects public creation of standalone human agents", async () => {
+    const app = getApp();
+    const { req, ctx } = await authedRequest(app);
+
+    const res = await req("POST", `/api/v1/orgs/${ctx.organizationId}/agents`, {
+      name: `api-human-${crypto.randomUUID().slice(0, 6)}`,
+      type: "human",
+      displayName: "API Human",
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
   it("updates an agent via PATCH", async () => {
     const app = getApp();
     const { req } = await authedRequest(app);
@@ -195,6 +210,59 @@ describe("Admin Agents API", () => {
     const reactivateRes = await req("POST", `/api/v1/agents/${agent.uuid}/reactivate`);
     expect(reactivateRes.statusCode).toBe(200);
     expect(reactivateRes.json().status).toBe("active");
+  });
+
+  it("rejects direct lifecycle changes for human agents", async () => {
+    const app = getApp();
+    const { req } = await authedRequest(app);
+    const human = await createAgent(app.db, {
+      name: `human-lifecycle-${Date.now()}`,
+      type: "human",
+      displayName: "Human Lifecycle",
+    });
+
+    const suspendRes = await req("POST", `/api/v1/agents/${human.uuid}/suspend`);
+    expect(suspendRes.statusCode).toBe(400);
+
+    await app.db.update(agents).set({ status: "suspended" }).where(eq(agents.uuid, human.uuid));
+
+    const reactivateRes = await req("POST", `/api/v1/agents/${human.uuid}/reactivate`);
+    expect(reactivateRes.statusCode).toBe(400);
+
+    const deleteRes = await req("DELETE", `/api/v1/agents/${human.uuid}`);
+    expect(deleteRes.statusCode).toBe(400);
+
+    const [row] = await app.db
+      .select({ status: agents.status, name: agents.name })
+      .from(agents)
+      .where(eq(agents.uuid, human.uuid))
+      .limit(1);
+    expect(row).toEqual({ status: "suspended", name: human.name });
+  });
+
+  it("keeps human mirrors human when PATCH tries to type-flip before lifecycle calls", async () => {
+    const app = getApp();
+    const { req, ctx } = await authedRequest(app);
+
+    const patchRes = await req("PATCH", `/api/v1/agents/${ctx.humanAgentUuid}`, {
+      type: "agent",
+      delegateMention: null,
+    });
+    expect(patchRes.statusCode).toBe(400);
+
+    const suspendRes = await req("POST", `/api/v1/agents/${ctx.humanAgentUuid}/suspend`);
+    expect(suspendRes.statusCode).toBe(400);
+
+    const deleteRes = await req("DELETE", `/api/v1/agents/${ctx.humanAgentUuid}`);
+    expect(deleteRes.statusCode).toBe(400);
+
+    const [row] = await app.db
+      .select({ type: agents.type, status: agents.status, name: agents.name })
+      .from(agents)
+      .where(eq(agents.uuid, ctx.humanAgentUuid))
+      .limit(1);
+    expect(row).toMatchObject({ type: "human", status: "active" });
+    expect(row?.name).not.toBeNull();
   });
 
   it("deletes only suspended agents", async () => {

--- a/packages/server/src/__tests__/admin-delete-agent.test.ts
+++ b/packages/server/src/__tests__/admin-delete-agent.test.ts
@@ -84,9 +84,14 @@ describe("Admin DELETE Agent API", () => {
 
   it("returns 404 for already deleted agent", async () => {
     const app = getApp();
-    const { req } = await authedRequest(app);
+    const { req, ctx } = await authedRequest(app);
 
-    const agent = await createAgent(app.db, { name: "double-del", type: "human" });
+    const agent = await createAgent(app.db, {
+      name: "double-del",
+      type: "agent",
+      managerId: ctx.memberId,
+      clientId: ctx.clientId,
+    });
     await suspendAgent(app.db, agent.uuid);
     await req("DELETE", `/api/v1/agents/${agent.uuid}`);
 

--- a/packages/server/src/__tests__/agent-delegate-mention-source-type.test.ts
+++ b/packages/server/src/__tests__/agent-delegate-mention-source-type.test.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 import { agents } from "../db/schema/agents.js";
 import { BadRequestError } from "../errors.js";
@@ -40,6 +41,7 @@ async function seedTargetHuman(
 
 describe("agent service — delegateMention source-type guard", () => {
   const getApp = useTestApp();
+  const unsafeUpdate = (data: unknown): Parameters<typeof updateAgent>[2] => data as Parameters<typeof updateAgent>[2];
 
   it("createAgent rejects delegateMention on a non-human (agent) source", async () => {
     const app = getApp();
@@ -111,10 +113,10 @@ describe("agent service — delegateMention source-type guard", () => {
     expect(updated.delegateMention).toBeNull();
   });
 
-  it("updateAgent honors a same-patch type → human flip alongside delegateMention", async () => {
-    // Same-patch type change must apply before the guard reads it, otherwise
-    // an admin promoting a row to human and setting its delegate in one
-    // PATCH would 400 even though the post-patch state is valid.
+  it("updateAgent rejects promoting a non-human row to human alongside delegateMention", async () => {
+    // `type` is immutable after create; human mirrors are owned by member
+    // lifecycle, not by the generic agent patch path. Cast through the service
+    // type to simulate an internal caller that bypasses the public schema.
     const app = getApp();
     const admin = await createTestAdmin(app);
     const target = await seedTargetHuman(app, admin.organizationId, admin.memberId);
@@ -129,55 +131,79 @@ describe("agent service — delegateMention source-type guard", () => {
       managerId: admin.memberId,
     });
 
-    const updated = await updateAgent(app.db, sourceUuid, {
+    await expect(
+      updateAgent(
+        app.db,
+        sourceUuid,
+        unsafeUpdate({
+          type: "human",
+          delegateMention: target,
+        }),
+      ),
+    ).rejects.toBeInstanceOf(BadRequestError);
+  });
+
+  it("updateAgent rejects demoting a human row even when the same patch clears delegateMention", async () => {
+    // This is the human-mirror lifecycle guard: allowing `{ type: "agent" }`
+    // would let a caller bypass direct human suspend/delete protection.
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const target = await seedTargetHuman(app, admin.organizationId, admin.memberId);
+    await updateAgent(app.db, admin.humanAgentUuid, { delegateMention: target });
+
+    await expect(
+      updateAgent(
+        app.db,
+        admin.humanAgentUuid,
+        unsafeUpdate({
+          type: "agent",
+          delegateMention: null,
+        }),
+      ),
+    ).rejects.toBeInstanceOf(BadRequestError);
+
+    const [row] = await app.db
+      .select({ type: agents.type, delegateMention: agents.delegateMention })
+      .from(agents)
+      .where(eq(agents.uuid, admin.humanAgentUuid))
+      .limit(1);
+    expect(row).toEqual({
       type: "human",
       delegateMention: target,
     });
-    expect(updated.type).toBe("human");
-    expect(updated.delegateMention).toBe(target);
   });
 
-  it("updateAgent rejects when a same-patch type flip targets a non-human type alongside delegateMention", async () => {
+  it("updateAgent rejects demoting a human row without a same-patch delegate clear", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const target = await seedTargetHuman(app, admin.organizationId, admin.memberId);
+    await updateAgent(app.db, admin.humanAgentUuid, { delegateMention: target });
+
+    await expect(
+      updateAgent(
+        app.db,
+        admin.humanAgentUuid,
+        unsafeUpdate({
+          type: "agent",
+        }),
+      ),
+    ).rejects.toBeInstanceOf(BadRequestError);
+  });
+
+  it("updateAgent rejects demoting a human row alongside a new delegateMention", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
     const target = await seedTargetHuman(app, admin.organizationId, admin.memberId);
 
     await expect(
-      updateAgent(app.db, admin.humanAgentUuid, {
-        type: "agent",
-        delegateMention: target,
-      }),
+      updateAgent(
+        app.db,
+        admin.humanAgentUuid,
+        unsafeUpdate({
+          type: "agent",
+          delegateMention: target,
+        }),
+      ),
     ).rejects.toBeInstanceOf(BadRequestError);
-  });
-
-  it("updateAgent rejects flipping type away from human when delegateMention is set (no same-patch clear)", async () => {
-    // The type-flip leak: without a guard on the `type` write itself,
-    // `{type: "agent"}` alone (no delegateMention field) would
-    // silently leave behind a non-human row carrying a delegate uuid —
-    // violating the invariant the source-type guard is meant to enforce.
-    const app = getApp();
-    const admin = await createTestAdmin(app);
-    const target = await seedTargetHuman(app, admin.organizationId, admin.memberId);
-    // Seed a human source with delegateMention set.
-    await updateAgent(app.db, admin.humanAgentUuid, { delegateMention: target });
-
-    await expect(updateAgent(app.db, admin.humanAgentUuid, { type: "agent" })).rejects.toBeInstanceOf(BadRequestError);
-  });
-
-  it("updateAgent accepts flipping type away from human when the same patch clears delegateMention", async () => {
-    // Companion to the leak guard above: the patch is well-formed when it
-    // clears the field in the same write. This is the ops-side recovery
-    // path — change the agent's role and scrub the delegate together.
-    const app = getApp();
-    const admin = await createTestAdmin(app);
-    const target = await seedTargetHuman(app, admin.organizationId, admin.memberId);
-    await updateAgent(app.db, admin.humanAgentUuid, { delegateMention: target });
-
-    const updated = await updateAgent(app.db, admin.humanAgentUuid, {
-      type: "agent",
-      delegateMention: null,
-    });
-    expect(updated.type).toBe("agent");
-    expect(updated.delegateMention).toBeNull();
   });
 });

--- a/packages/server/src/__tests__/agent-identity.test.ts
+++ b/packages/server/src/__tests__/agent-identity.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { createAgent, deleteAgent, getAgent, getAgentByName, listAgents, suspendAgent } from "../services/agent.js";
+import { createMember } from "../services/member.js";
 import { createOrganization } from "../services/organization.js";
 import { createAdminContext, createTestAdmin, useTestApp } from "./helpers.js";
 import { DEFAULT_ORG_ID } from "./setup.js";
@@ -23,7 +24,12 @@ describe("Agent Identity (UUID + Name)", () => {
       const app = getApp();
       const ctx = await createAdminContext(app, { username: `recycle-${Date.now()}` });
 
-      const original = await createAgent(app.db, { name: "recycle-me", type: "human" });
+      const original = await createAgent(app.db, {
+        name: "recycle-me",
+        type: "agent",
+        managerId: ctx.memberId,
+        clientId: ctx.clientId,
+      });
       await suspendAgent(app.db, original.uuid);
       await deleteAgent(app.db, original.uuid);
 
@@ -42,8 +48,14 @@ describe("Agent Identity (UUID + Name)", () => {
 
     it("deleted agent retains uuid but loses name", async () => {
       const app = getApp();
+      const ctx = await createAdminContext(app, { username: `will-delete-${Date.now()}` });
 
-      const agent = await createAgent(app.db, { name: "will-delete", type: "human" });
+      const agent = await createAgent(app.db, {
+        name: "will-delete",
+        type: "agent",
+        managerId: ctx.memberId,
+        clientId: ctx.clientId,
+      });
       const savedUuid = agent.uuid;
 
       await suspendAgent(app.db, agent.uuid);
@@ -56,20 +68,39 @@ describe("Agent Identity (UUID + Name)", () => {
 
     it("multiple deleted agents can have name=NULL in the same org", async () => {
       const app = getApp();
+      const ctx = await createAdminContext(app, { username: `multi-del-${Date.now()}` });
 
-      const a1 = await createAgent(app.db, { name: "multi-del-1", type: "human" });
-      const a2 = await createAgent(app.db, { name: "multi-del-2", type: "human" });
+      const a1 = await createAgent(app.db, {
+        name: "multi-del-1",
+        type: "agent",
+        managerId: ctx.memberId,
+        clientId: ctx.clientId,
+      });
+      const a2 = await createAgent(app.db, {
+        name: "multi-del-2",
+        type: "agent",
+        managerId: ctx.memberId,
+        clientId: ctx.clientId,
+      });
 
       await suspendAgent(app.db, a1.uuid);
       await deleteAgent(app.db, a1.uuid);
       await suspendAgent(app.db, a2.uuid);
       await deleteAgent(app.db, a2.uuid);
 
-      // Both deleted — no unique constraint violation (NULL != NULL in PG)
-      // Verify by creating new agents with those names. Use human type to
-      // avoid needing a client — this test is about name recycling, not run-pinning.
-      const r1 = await createAgent(app.db, { name: "multi-del-1", type: "human" });
-      const r2 = await createAgent(app.db, { name: "multi-del-2", type: "human" });
+      // Both deleted — no unique constraint violation (NULL != NULL in PG).
+      const r1 = await createAgent(app.db, {
+        name: "multi-del-1",
+        type: "agent",
+        managerId: ctx.memberId,
+        clientId: ctx.clientId,
+      });
+      const r2 = await createAgent(app.db, {
+        name: "multi-del-2",
+        type: "agent",
+        managerId: ctx.memberId,
+        clientId: ctx.clientId,
+      });
       expect(r1.uuid).not.toBe(a1.uuid);
       expect(r2.uuid).not.toBe(a2.uuid);
     });
@@ -96,8 +127,14 @@ describe("Agent Identity (UUID + Name)", () => {
 
     it("returns 404 for deleted agent name", async () => {
       const app = getApp();
+      const ctx = await createAdminContext(app, { username: `deleted-lookup-${Date.now()}` });
 
-      const agent = await createAgent(app.db, { name: "deleted-lookup", type: "human" });
+      const agent = await createAgent(app.db, {
+        name: "deleted-lookup",
+        type: "agent",
+        managerId: ctx.memberId,
+        clientId: ctx.clientId,
+      });
       await suspendAgent(app.db, agent.uuid);
       await deleteAgent(app.db, agent.uuid);
 
@@ -107,14 +144,18 @@ describe("Agent Identity (UUID + Name)", () => {
     it("returns 404 when name exists in a different org", async () => {
       const app = getApp();
 
-      const ctx = await createAdminContext(app, { username: `scoped-${Date.now()}` });
       const orgAlpha = await createOrganization(app.db, { name: "org-alpha", displayName: "Alpha" });
       const orgBeta = await createOrganization(app.db, { name: "org-beta", displayName: "Beta" });
+      const owner = await createMember(app.db, orgAlpha.id, {
+        username: `scoped-owner-${Date.now()}`,
+        displayName: "Scoped Owner",
+        role: "admin",
+      });
       await createAgent(app.db, {
         name: "org-scoped",
-        type: "human",
+        type: "agent",
         organizationId: orgAlpha.id,
-        managerId: ctx.memberId,
+        managerId: owner.id,
       });
 
       // Same name, different org → not found
@@ -131,21 +172,29 @@ describe("Agent Identity (UUID + Name)", () => {
   describe("listAgents org filtering", () => {
     it("only returns agents in the requested org", async () => {
       const app = getApp();
-      const ctx = await createAdminContext(app, { username: `filter-${Date.now()}` });
-
       const orgList = await createOrganization(app.db, { name: "org-list-test", displayName: "List Test" });
       const orgOther = await createOrganization(app.db, { name: "org-other", displayName: "Other" });
+      const listOwner = await createMember(app.db, orgList.id, {
+        username: `list-owner-${Date.now()}`,
+        displayName: "List Owner",
+        role: "admin",
+      });
+      const otherOwner = await createMember(app.db, orgOther.id, {
+        username: `other-owner-${Date.now()}`,
+        displayName: "Other Owner",
+        role: "admin",
+      });
       const a1 = await createAgent(app.db, {
         name: "list-org-a",
-        type: "human",
+        type: "agent",
         organizationId: orgList.id,
-        managerId: ctx.memberId,
+        managerId: listOwner.id,
       });
       await createAgent(app.db, {
         name: "list-org-b",
-        type: "human",
+        type: "agent",
         organizationId: orgOther.id,
-        managerId: ctx.memberId,
+        managerId: otherOwner.id,
       });
 
       const result = await listAgents(app.db, orgList.id, 50);
@@ -193,21 +242,29 @@ describe("Agent Identity (UUID + Name)", () => {
 
     it("allows same name in different orgs", async () => {
       const app = getApp();
-      const ctx = await createAdminContext(app, { username: `cross-${Date.now()}` });
-
       const orgX = await createOrganization(app.db, { name: "org-x", displayName: "Org X" });
       const orgY = await createOrganization(app.db, { name: "org-y", displayName: "Org Y" });
+      const ownerX = await createMember(app.db, orgX.id, {
+        username: `cross-x-${Date.now()}`,
+        displayName: "Cross X",
+        role: "admin",
+      });
+      const ownerY = await createMember(app.db, orgY.id, {
+        username: `cross-y-${Date.now()}`,
+        displayName: "Cross Y",
+        role: "admin",
+      });
       const a1 = await createAgent(app.db, {
         name: "cross-org-name",
-        type: "human",
+        type: "agent",
         organizationId: orgX.id,
-        managerId: ctx.memberId,
+        managerId: ownerX.id,
       });
       const a2 = await createAgent(app.db, {
         name: "cross-org-name",
-        type: "human",
+        type: "agent",
         organizationId: orgY.id,
-        managerId: ctx.memberId,
+        managerId: ownerY.id,
       });
 
       expect(a1.uuid).not.toBe(a2.uuid);

--- a/packages/server/src/__tests__/agent-quota.test.ts
+++ b/packages/server/src/__tests__/agent-quota.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { createAgent } from "../services/agent.js";
+import { createMember } from "../services/member.js";
 import { createOrganization } from "../services/organization.js";
 import { createAdminContext, useTestApp } from "./helpers.js";
 
@@ -23,29 +24,34 @@ describe("Agent Quota Enforcement", () => {
 
   it("enforces agent limit when maxAgents > 0", async () => {
     const app = getApp();
-    const ctx = await createAdminContext(app, { username: `quota-l-${Date.now()}` });
+    await createAdminContext(app, { username: `quota-l-${Date.now()}` });
 
-    const org = await createOrganization(app.db, { name: "limited-org", displayName: "Limited", maxAgents: 2 });
+    const org = await createOrganization(app.db, { name: "limited-org", displayName: "Limited", maxAgents: 3 });
+    const owner = await createMember(app.db, org.id, {
+      username: `quota-owner-${Date.now()}`,
+      displayName: "Quota Owner",
+      role: "admin",
+    });
 
     await createAgent(app.db, {
       name: "slot-1",
-      type: "human",
+      type: "agent",
       organizationId: org.id,
-      managerId: ctx.memberId,
+      managerId: owner.id,
     });
     await createAgent(app.db, {
       name: "slot-2",
-      type: "human",
+      type: "agent",
       organizationId: org.id,
-      managerId: ctx.memberId,
+      managerId: owner.id,
     });
 
     await expect(
       createAgent(app.db, {
         name: "slot-3",
-        type: "human",
+        type: "agent",
         organizationId: org.id,
-        managerId: ctx.memberId,
+        managerId: owner.id,
       }),
     ).rejects.toThrow(/agent limit/i);
   });
@@ -53,24 +59,29 @@ describe("Agent Quota Enforcement", () => {
   it("does not count deleted agents toward quota", async () => {
     const app = getApp();
     const { suspendAgent, deleteAgent } = await import("../services/agent.js");
-    const ctx = await createAdminContext(app, { username: `quota-d-${Date.now()}` });
+    await createAdminContext(app, { username: `quota-d-${Date.now()}` });
 
-    const org = await createOrganization(app.db, { name: "quota-del-org", displayName: "Quota Del", maxAgents: 1 });
+    const org = await createOrganization(app.db, { name: "quota-del-org", displayName: "Quota Del", maxAgents: 2 });
+    const owner = await createMember(app.db, org.id, {
+      username: `quota-del-owner-${Date.now()}`,
+      displayName: "Quota Del Owner",
+      role: "admin",
+    });
 
     const agent = await createAgent(app.db, {
       name: "temp",
-      type: "human",
+      type: "agent",
       organizationId: org.id,
-      managerId: ctx.memberId,
+      managerId: owner.id,
     });
     await suspendAgent(app.db, agent.uuid);
     await deleteAgent(app.db, agent.uuid);
 
     const newAgent = await createAgent(app.db, {
       name: "replacement",
-      type: "human",
+      type: "agent",
       organizationId: org.id,
-      managerId: ctx.memberId,
+      managerId: owner.id,
     });
     expect(newAgent.name).toBe("replacement");
   });

--- a/packages/server/src/__tests__/agent-visibility.test.ts
+++ b/packages/server/src/__tests__/agent-visibility.test.ts
@@ -299,6 +299,37 @@ describe("Agent Visibility", () => {
       expect(names).toContain("qhuman-needle");
     });
 
+    it("addressableOnly hides removed human mirrors while the regular roster can still resolve them", async () => {
+      const app = getApp();
+      const { req: adminReq, admin } = await authedRequest(app);
+      const username = `removed-picker-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+      const createRes = await adminReq("POST", `/api/v1/orgs/${admin.organizationId}/members`, {
+        username,
+        displayName: "Removed Picker",
+        role: "member",
+      });
+      const created = createRes.json<{ id: string; agentId: string }>();
+      const deleteRes = await adminReq("DELETE", `/api/v1/orgs/${admin.organizationId}/members/${created.id}`);
+      expect(deleteRes.statusCode).toBe(204);
+
+      const regular = await adminReq(
+        "GET",
+        `/api/v1/orgs/${admin.organizationId}/agents?query=${encodeURIComponent(username)}`,
+      );
+      expect(regular.statusCode).toBe(200);
+      expect(regular.json<{ items: Array<{ uuid: string; status: string }> }>().items).toContainEqual(
+        expect.objectContaining({ uuid: created.agentId, status: "suspended" }),
+      );
+
+      const picker = await adminReq(
+        "GET",
+        `/api/v1/orgs/${admin.organizationId}/agents?query=${encodeURIComponent(username)}&addressableOnly=true`,
+      );
+      expect(picker.statusCode).toBe(200);
+      const pickerIds = picker.json<{ items: Array<{ uuid: string }> }>().items.map((agent) => agent.uuid);
+      expect(pickerIds).not.toContain(created.agentId);
+    });
+
     it("treats ILIKE wildcards in user input as literals", async () => {
       const app = getApp();
       const { req: adminReq, admin } = await authedRequest(app);
@@ -559,6 +590,33 @@ describe("Agent Visibility", () => {
 
       const res = await memberB.req("POST", `/api/v1/orgs/${adminBundle.admin.organizationId}/chats`, {
         participantIds: [privateAgent.uuid],
+      });
+      expect(res.statusCode).toBe(404);
+    });
+
+    it("rejects removed human mirrors before web task chat creation writes participants", async () => {
+      const app = getApp();
+      const adminBundle = await authedRequest(app);
+      const username = `removed-task-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+      const createRes = await adminBundle.req("POST", `/api/v1/orgs/${adminBundle.admin.organizationId}/members`, {
+        username,
+        displayName: "Removed Task Target",
+        role: "member",
+      });
+      const created = createRes.json<{ id: string; agentId: string }>();
+      const deleteRes = await adminBundle.req(
+        "DELETE",
+        `/api/v1/orgs/${adminBundle.admin.organizationId}/members/${created.id}`,
+      );
+      expect(deleteRes.statusCode).toBe(204);
+
+      const res = await adminBundle.req("POST", `/api/v1/orgs/${adminBundle.admin.organizationId}/chats`, {
+        mode: "task",
+        initialRecipientAgentIds: [created.agentId],
+        initialRecipientNames: [],
+        contextParticipantAgentIds: [],
+        contextParticipantNames: [],
+        initialMessage: { source: "web", format: "text", content: "hello" },
       });
       expect(res.statusCode).toBe(404);
     });

--- a/packages/server/src/__tests__/attachments-route.test.ts
+++ b/packages/server/src/__tests__/attachments-route.test.ts
@@ -1,9 +1,8 @@
 import { ATTACHMENT_FILENAME_HEADER, ATTACHMENT_MIME_HEADER, MAX_ATTACHMENT_BYTES } from "@first-tree/shared";
 import type { FastifyInstance } from "fastify";
 import { describe, expect, it } from "vitest";
-import { members } from "../db/schema/members.js";
 import { organizations } from "../db/schema/organizations.js";
-import { createAgent } from "../services/agent.js";
+import { ensureMembership } from "../services/membership.js";
 import { uuidv7 } from "../uuid.js";
 import { createAdminContext, createTestAdmin, useTestApp } from "./helpers.js";
 
@@ -176,19 +175,12 @@ describe("attachments route — upload + capability download", () => {
     await app.db
       .insert(organizations)
       .values({ id: otherOrgId, name: otherOrgId.slice(0, 30), displayName: "Other Org" });
-    const otherAgent = await createAgent(app.db, {
-      name: `mo-agent-${crypto.randomUUID().slice(0, 6)}`,
-      type: "human",
-      displayName: "Other Org Agent",
-      managerId: admin.memberId,
-      organizationId: otherOrgId,
-    });
-    await app.db.insert(members).values({
-      id: uuidv7(),
+    const otherMember = await ensureMembership(app.db, {
       userId: admin.userId,
       organizationId: otherOrgId,
-      agentId: otherAgent.uuid,
       role: "member",
+      displayName: "Other Org Agent",
+      username: admin.username,
     });
 
     // Upload via the first org → uploaded_by = first org's humanAgent.
@@ -199,6 +191,6 @@ describe("attachments route — upload + capability download", () => {
     // Upload via the second org → uploaded_by = second org's humanAgent.
     const second = await postAttachment(app, admin, Buffer.from("second"), { orgId: otherOrgId });
     expect(second.statusCode).toBe(201);
-    expect((second.json() as { uploadedBy: string }).uploadedBy).toBe(otherAgent.uuid);
+    expect((second.json() as { uploadedBy: string }).uploadedBy).toBe(otherMember.agentId);
   });
 });

--- a/packages/server/src/__tests__/github-entities-agent-route.test.ts
+++ b/packages/server/src/__tests__/github-entities-agent-route.test.ts
@@ -16,22 +16,20 @@ type App = ReturnType<ReturnType<typeof useTestApp>>;
 describe("agent github-entities routes", () => {
   const getApp = useTestApp();
 
-  async function seedOrgAgent(app: App, orgId: string, memberId: string, type: "human" | "agent"): Promise<string> {
+  async function seedOrgAgent(app: App, orgId: string, memberId: string): Promise<string> {
     const uuid = randomUUID();
     await app.db.insert(agents).values({
       uuid,
-      name: `${type}-${uuid.slice(0, 8)}`,
+      name: `agent-${uuid.slice(0, 8)}`,
       organizationId: orgId,
-      type,
-      displayName: type,
+      type: "agent",
+      displayName: "agent",
       inboxId: `inbox_${uuid}`,
       managerId: memberId,
       status: "active",
     });
     return uuid;
   }
-
-  const seedHuman = (app: App, orgId: string, memberId: string) => seedOrgAgent(app, orgId, memberId, "human");
 
   async function createChatWith(a: Awaited<ReturnType<typeof createTestAgent>>, participantIds: string[]) {
     const res = await a.request("POST", "/api/v1/agent/chats", { type: "group", participantIds });
@@ -42,7 +40,7 @@ describe("agent github-entities routes", () => {
   it("follow without an App installation is 422 with operator guidance", async () => {
     const app = getApp();
     const a = await createTestAgent(app, { name: `gh-a-${randomUUID().slice(0, 6)}` });
-    const human = await seedHuman(app, a.organizationId, a.memberId);
+    const human = a.humanAgentUuid;
     const chatId = await createChatWith(a, [human]);
 
     const res = await a.request("POST", `/api/v1/agent/chats/${chatId}/github-entities`, {
@@ -55,7 +53,7 @@ describe("agent github-entities routes", () => {
   it("follow in an agents-only chat still resolves a pair via the supervising human watcher", async () => {
     const app = getApp();
     const a = await createTestAgent(app, { name: `gh-b-${randomUUID().slice(0, 6)}` });
-    const peerAgent = await seedOrgAgent(app, a.organizationId, a.memberId, "agent");
+    const peerAgent = await seedOrgAgent(app, a.organizationId, a.memberId);
     const chatId = await createChatWith(a, [peerAgent]);
 
     const res = await a.request("POST", `/api/v1/agent/chats/${chatId}/github-entities`, {
@@ -73,7 +71,7 @@ describe("agent github-entities routes", () => {
   it("a non-participant is rejected", async () => {
     const app = getApp();
     const a = await createTestAgent(app, { name: `gh-d-${randomUUID().slice(0, 6)}` });
-    const human = await seedHuman(app, a.organizationId, a.memberId);
+    const human = a.humanAgentUuid;
     const chatId = await createChatWith(a, [human]);
 
     const stranger = await createTestAgent(app, { name: `gh-e-${randomUUID().slice(0, 6)}` });
@@ -86,7 +84,7 @@ describe("agent github-entities routes", () => {
   it("following lists the chat's wired entities; unfollow is idempotent over HTTP", async () => {
     const app = getApp();
     const a = await createTestAgent(app, { name: `gh-f-${randomUUID().slice(0, 6)}` });
-    const human = await seedHuman(app, a.organizationId, a.memberId);
+    const human = a.humanAgentUuid;
     const chatId = await createChatWith(a, [human]);
 
     await app.db.insert(githubEntityChatMappings).values({

--- a/packages/server/src/__tests__/helpers.ts
+++ b/packages/server/src/__tests__/helpers.ts
@@ -6,6 +6,7 @@ import type { FastifyInstance } from "fastify";
 import { afterAll, beforeAll } from "vitest";
 import { buildApp } from "../app.js";
 import type { Config } from "../config.js";
+import { agents } from "../db/schema/agents.js";
 import { clients } from "../db/schema/clients.js";
 import { members } from "../db/schema/members.js";
 import { users } from "../db/schema/users.js";
@@ -205,13 +206,27 @@ export async function createTestAgent(
   });
 
   const type = opts.type ?? "agent";
-  const agent = await createAgent(app.db, {
-    name: opts.name ?? `test-agent-${crypto.randomUUID().slice(0, 8)}`,
-    type,
-    displayName: opts.displayName ?? "Test Agent",
-    managerId: admin.memberId,
-    ...(type === "human" ? {} : { clientId }),
-  });
+  const agent =
+    type === "human"
+      ? (
+          await app.db
+            .update(agents)
+            .set({
+              name: opts.name ?? `test-human-${crypto.randomUUID().slice(0, 8)}`,
+              displayName: opts.displayName ?? "Test Human",
+              updatedAt: new Date(),
+            })
+            .where(eq(agents.uuid, admin.humanAgentUuid))
+            .returning()
+        )[0]
+      : await createAgent(app.db, {
+          name: opts.name ?? `test-agent-${crypto.randomUUID().slice(0, 8)}`,
+          type,
+          displayName: opts.displayName ?? "Test Agent",
+          managerId: admin.memberId,
+          clientId,
+        });
+  if (!agent) throw new Error("test agent setup failed");
 
   // `token` is kept as an alias for the user's JWT so the large body of
   // pre-unified-token tests still compiles; those tests will additionally
@@ -223,6 +238,7 @@ export async function createTestAgent(
     token: admin.accessToken,
     clientId,
     memberId: admin.memberId,
+    humanAgentUuid: admin.humanAgentUuid,
     userId: member.userId,
     organizationId: member.organizationId,
     /** Agent-scoped request — adds `Authorization` + `x-agent-id` headers. */

--- a/packages/server/src/__tests__/inbox-ws-push.test.ts
+++ b/packages/server/src/__tests__/inbox-ws-push.test.ts
@@ -3,7 +3,7 @@ import type { FastifyInstance } from "fastify";
 import { describe, expect, it } from "vitest";
 import { chatMembership } from "../db/schema/chat-membership.js";
 import { inboxEntries } from "../db/schema/inbox-entries.js";
-import { createAgent } from "../services/agent.js";
+import { createAgent, getAgent } from "../services/agent.js";
 import { createChat } from "../services/chat.js";
 import * as inboxService from "../services/inbox.js";
 import { sendMessage } from "../services/message.js";
@@ -161,11 +161,8 @@ describe("inbox WS data-plane claim helpers", () => {
     const app = getApp();
     const uid = crypto.randomUUID().slice(0, 6);
     const ctx = await createAdminContext(app, { username: `wsp-si-${uid}` });
-    const human = await createAgent(app.db, {
-      name: `wsp-si-h-${uid}`,
-      type: "human",
-      managerId: ctx.memberId,
-    });
+    const human = await getAgent(app.db, ctx.humanAgentUuid);
+    if (!human) throw new Error("expected admin human mirror");
     const observer = await createAgent(app.db, {
       name: `wsp-si-obs-${uid}`,
       type: "agent",

--- a/packages/server/src/__tests__/me-onboarding.test.ts
+++ b/packages/server/src/__tests__/me-onboarding.test.ts
@@ -155,6 +155,7 @@ describe("PATCH /me/onboarding", () => {
         status: "left",
       })
       .where(eq(members.id, admin.memberId));
+    await app.db.update(agents).set({ status: "suspended" }).where(eq(agents.uuid, admin.humanAgentUuid));
 
     // Rejoin (the invite-join / OAuth-invite path funnels through
     // ensureMembership): the row is reactivated, not recreated…
@@ -183,6 +184,31 @@ describe("PATCH /me/onboarding", () => {
       .from(members)
       .where(eq(members.id, admin.memberId));
     expect(row).toEqual({ suppressedAt: null, suppressedReason: null, completedAt: null, status: "active" });
+
+    const [mirror] = await app.db
+      .select({ status: agents.status, name: agents.name })
+      .from(agents)
+      .where(eq(agents.uuid, admin.humanAgentUuid));
+    expect(mirror?.status).toBe("active");
+    expect(mirror?.name).not.toBeNull();
+  });
+
+  it("ordinary membership rejoin does not restore an admin-removed member", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const { ensureMembership } = await import("../services/membership.js");
+
+    await app.db.update(members).set({ status: "removed" }).where(eq(members.id, admin.memberId));
+
+    await expect(
+      ensureMembership(app.db, {
+        userId: admin.userId,
+        organizationId: admin.organizationId,
+        role: "member",
+        displayName: "Test Admin",
+        username: admin.username,
+      }),
+    ).rejects.toThrow(/removed by an admin/);
   });
 
   it("rejects a suppress timestamp without a suppress reason at the database boundary", async () => {

--- a/packages/server/src/__tests__/members.test.ts
+++ b/packages/server/src/__tests__/members.test.ts
@@ -1,10 +1,12 @@
 import { randomUUID } from "node:crypto";
-import { eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { describe, expect, it } from "vitest";
 import { agents as agentsTable } from "../db/schema/agents.js";
 import { members as membersTable } from "../db/schema/members.js";
+import { createAgent } from "../services/agent.js";
 import * as memberService from "../services/member.js";
+import { repairMembershipHumanMirrors } from "../services/membership.js";
 import { createOrganization } from "../services/organization.js";
 import { createTestAdmin, useTestApp } from "./helpers.js";
 
@@ -135,7 +137,7 @@ describe("Members API", () => {
   });
 
   describe("DELETE /api/v1/members/:id", () => {
-    it("deletes member and deactivates their agent", async () => {
+    it("removes member, suspends their human mirror, and transfers managed agents", async () => {
       const app = getApp();
       const req = await authedRequest(app);
       const createRes = await req("POST", "/api/v1/members", {
@@ -143,15 +145,204 @@ describe("Members API", () => {
         displayName: "Deletable",
         role: "member",
       });
-      const { id } = createRes.json<{ id: string }>();
+      const { id, agentId } = createRes.json<{ id: string; agentId: string }>();
+
+      const managed = await createAgent(app.db, {
+        name: `member-owned-${randomUUID().slice(0, 8)}`,
+        type: "agent",
+        managerId: id,
+      });
 
       const deleteRes = await req("DELETE", `/api/v1/members/${id}`);
       expect(deleteRes.statusCode).toBe(204);
 
-      // Verify member is gone from list
       const listRes = await req("GET", "/api/v1/members");
       const members = listRes.json<Array<{ id: string }>>();
       expect(members.find((m: { id: string }) => m.id === id)).toBeUndefined();
+
+      const [memberRow] = await app.db
+        .select({ status: membersTable.status })
+        .from(membersTable)
+        .where(eq(membersTable.id, id))
+        .limit(1);
+      expect(memberRow?.status).toBe("removed");
+
+      const [humanMirror] = await app.db
+        .select({ status: agentsTable.status, name: agentsTable.name })
+        .from(agentsTable)
+        .where(eq(agentsTable.uuid, agentId))
+        .limit(1);
+      expect(humanMirror?.status).toBe("suspended");
+      expect(humanMirror?.name).not.toBeNull();
+
+      const [managedRow] = await app.db
+        .select({ managerId: agentsTable.managerId, clientId: agentsTable.clientId })
+        .from(agentsTable)
+        .where(eq(agentsTable.uuid, managed.uuid))
+        .limit(1);
+      expect(managedRow?.managerId).not.toBe(id);
+      expect(managedRow?.clientId).toBeNull();
+    });
+
+    it("serializes concurrent admin removals so one active admin remains", async () => {
+      const app = getApp();
+      const admin = await createTestAdmin(app, { username: `race-admin-a-${randomUUID().slice(0, 8)}` });
+      const createSecond = await app.inject({
+        method: "POST",
+        url: `/api/v1/orgs/${admin.organizationId}/members`,
+        headers: { authorization: `Bearer ${admin.accessToken}` },
+        payload: {
+          username: `race-admin-b-${randomUUID().slice(0, 8)}`,
+          displayName: "Race Admin B",
+          role: "admin",
+        },
+      });
+      expect(createSecond.statusCode).toBe(201);
+      const second = createSecond.json<{ id: string; username: string; password: string }>();
+      const secondLogin = await app.inject({
+        method: "POST",
+        url: "/api/v1/auth/login",
+        payload: { username: second.username, password: second.password },
+      });
+      const secondAccessToken = secondLogin.json<{ accessToken: string }>().accessToken;
+
+      const [deleteSecond, deleteFirst] = await Promise.all([
+        app.inject({
+          method: "DELETE",
+          url: `/api/v1/orgs/${admin.organizationId}/members/${second.id}`,
+          headers: { authorization: `Bearer ${admin.accessToken}` },
+        }),
+        app.inject({
+          method: "DELETE",
+          url: `/api/v1/orgs/${admin.organizationId}/members/${admin.memberId}`,
+          headers: { authorization: `Bearer ${secondAccessToken}` },
+        }),
+      ]);
+
+      const statusCodes = [deleteSecond.statusCode, deleteFirst.statusCode];
+      expect(statusCodes.filter((status) => status === 204)).toHaveLength(1);
+
+      const activeAdmins = await app.db
+        .select({ id: membersTable.id })
+        .from(membersTable)
+        .where(
+          and(
+            eq(membersTable.organizationId, admin.organizationId),
+            eq(membersTable.role, "admin"),
+            eq(membersTable.status, "active"),
+          ),
+        );
+      expect(activeAdmins).toHaveLength(1);
+    });
+
+    it("admin create restores a removed membership and the same human mirror", async () => {
+      const app = getApp();
+      const req = await authedRequest(app);
+      const username = `restore-${Date.now()}`;
+      const createRes = await req("POST", "/api/v1/members", {
+        username,
+        displayName: "Removable",
+        role: "member",
+      });
+      const created = createRes.json<{ id: string; agentId: string }>();
+      await req("DELETE", `/api/v1/members/${created.id}`);
+
+      const restoreRes = await req("POST", "/api/v1/members", {
+        username,
+        displayName: "Restored",
+        role: "admin",
+      });
+      expect(restoreRes.statusCode).toBe(201);
+      const restored = restoreRes.json<{ id: string; agentId: string; role: string; notice: string }>();
+      expect(restored.id).toBe(created.id);
+      expect(restored.agentId).toBe(created.agentId);
+      expect(restored.role).toBe("admin");
+      expect(restored.notice).toMatch(/Existing user/);
+
+      const [row] = await app.db
+        .select({ status: membersTable.status, role: membersTable.role })
+        .from(membersTable)
+        .where(eq(membersTable.id, created.id))
+        .limit(1);
+      expect(row).toEqual({ status: "active", role: "admin" });
+
+      const [mirror] = await app.db
+        .select({ status: agentsTable.status, displayName: agentsTable.displayName, name: agentsTable.name })
+        .from(agentsTable)
+        .where(eq(agentsTable.uuid, created.agentId))
+        .limit(1);
+      expect(mirror?.status).toBe("active");
+      expect(mirror?.displayName).toBe("Restored");
+      expect(mirror?.name).not.toBeNull();
+    });
+
+    it("repairs pre-existing corrupted human mirrors for active and inactive memberships", async () => {
+      const app = getApp();
+      const admin = await createTestAdmin(app, { username: `repair-active-${randomUUID().slice(0, 8)}` });
+      const req = (method: string, url: string, payload?: Record<string, unknown>) =>
+        app.inject({
+          method: method as "GET" | "POST" | "PATCH" | "DELETE",
+          url: url.replace("/api/v1/members", `/api/v1/orgs/${admin.organizationId}/members`),
+          headers: { authorization: `Bearer ${admin.accessToken}` },
+          payload,
+        });
+
+      const leftRes = await req("POST", "/api/v1/members", {
+        username: `repair-left-${randomUUID().slice(0, 8)}`,
+        displayName: "Repair Left",
+        role: "member",
+      });
+      const left = leftRes.json<{ id: string; agentId: string }>();
+      const removedRes = await req("POST", "/api/v1/members", {
+        username: `repair-removed-${randomUUID().slice(0, 8)}`,
+        displayName: "Repair Removed",
+        role: "member",
+      });
+      const removed = removedRes.json<{ id: string; agentId: string }>();
+      await app.db.update(membersTable).set({ status: "left" }).where(eq(membersTable.id, left.id));
+      await req("DELETE", `/api/v1/members/${removed.id}`);
+
+      const [leftBefore] = await app.db
+        .select({ name: agentsTable.name })
+        .from(agentsTable)
+        .where(eq(agentsTable.uuid, left.agentId))
+        .limit(1);
+      expect(leftBefore?.name).not.toBeNull();
+
+      await app.db
+        .update(agentsTable)
+        .set({ type: "agent", status: "deleted", name: null, clientId: null })
+        .where(eq(agentsTable.uuid, admin.humanAgentUuid));
+      await app.db.update(agentsTable).set({ status: "active" }).where(eq(agentsTable.uuid, left.agentId));
+      await app.db
+        .update(agentsTable)
+        .set({ type: "agent", status: "active", name: null, clientId: null })
+        .where(eq(agentsTable.uuid, removed.agentId));
+
+      const result = await repairMembershipHumanMirrors(app.db);
+      expect(result).toEqual({ activeMirrorsRepaired: 1, inactiveMirrorsRepaired: 2 });
+
+      const repairedRows = await app.db
+        .select({
+          uuid: agentsTable.uuid,
+          type: agentsTable.type,
+          status: agentsTable.status,
+          name: agentsTable.name,
+          clientId: agentsTable.clientId,
+        })
+        .from(agentsTable)
+        .where(inArray(agentsTable.uuid, [admin.humanAgentUuid, left.agentId, removed.agentId]));
+      const byId = new Map(repairedRows.map((row) => [row.uuid, row]));
+      expect(byId.get(admin.humanAgentUuid)).toMatchObject({ type: "human", status: "active", clientId: null });
+      expect(byId.get(admin.humanAgentUuid)?.name).not.toBeNull();
+      expect(byId.get(left.agentId)).toMatchObject({
+        type: "human",
+        status: "suspended",
+        name: leftBefore?.name,
+        clientId: null,
+      });
+      expect(byId.get(removed.agentId)).toMatchObject({ type: "human", status: "suspended", clientId: null });
+      expect(byId.get(removed.agentId)?.name).not.toBeNull();
     });
 
     it("returns 404 and leaves the target intact when deleting a member from another org", async () => {

--- a/packages/server/src/__tests__/message-dispatcher.test.ts
+++ b/packages/server/src/__tests__/message-dispatcher.test.ts
@@ -1,12 +1,12 @@
 import type { FastifyInstance } from "fastify";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { createAgent } from "../services/agent.js";
+import { createAgent, getAgent } from "../services/agent.js";
 import { addParticipant, createChat } from "../services/chat.js";
 import { buildClientMessagePayload, buildClientMessagePayloadsForInbox } from "../services/message-dispatcher.js";
 import { createAdminContext, createTestApp } from "./helpers.js";
 
 let app: FastifyInstance;
-let ctx: { memberId: string; clientId: string };
+let ctx: { memberId: string; clientId: string; humanAgentUuid: string };
 
 beforeAll(async () => {
   app = await createTestApp();
@@ -154,11 +154,8 @@ describe("buildClientMessagePayload — recipientMode (v2 constant)", () => {
   });
 
   it("human↔agent two-speaker chat → 'mention_only' wire value (no v1 'full' derivation)", async () => {
-    const human = await createAgent(app.db, {
-      name: `rmode-hum-${Date.now()}`,
-      type: "human",
-      managerId: ctx.memberId,
-    });
+    const human = await getAgent(app.db, ctx.humanAgentUuid);
+    if (!human) throw new Error("expected admin human mirror");
     const agent = await createAgent(app.db, {
       name: `rmode-agt-${Date.now()}`,
       type: "agent",

--- a/packages/server/src/__tests__/messaging-e2e.test.ts
+++ b/packages/server/src/__tests__/messaging-e2e.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { createAgent } from "../services/agent.js";
+import { createAgent, getAgent } from "../services/agent.js";
 import { createChat } from "../services/chat.js";
 import { ackEntryByIdForBoundAgents, pollInbox } from "../services/inbox.js";
 import { listMessages, sendMessage } from "../services/message.js";
@@ -37,11 +37,7 @@ describe("messaging E2E — group-chat mention scenarios", () => {
   it("Case C: group @mention activates only the targeted agent (Mention-filter invariant)", async () => {
     const app = getApp();
     const ctx = await createAdminContext(app, { username: `e2ec-${Date.now()}` });
-    const a1 = await createAgent(app.db, {
-      name: `e2ec-a1-${Date.now()}`,
-      type: "human",
-      managerId: ctx.memberId,
-    });
+    const a1 = await getAgent(app.db, ctx.humanAgentUuid);
     const b1 = await createAgent(app.db, {
       name: `e2ec-b1-${Date.now()}`,
       type: "agent",
@@ -95,11 +91,7 @@ describe("messaging E2E — group-chat mention scenarios", () => {
   it("Case D: b1's reply with explicit @b3 activates b3 (not b2)", async () => {
     const app = getApp();
     const ctx = await createAdminContext(app, { username: `e2ed-${Date.now()}` });
-    const a1 = await createAgent(app.db, {
-      name: `e2ed-a1-${Date.now()}`,
-      type: "human",
-      managerId: ctx.memberId,
-    });
+    const a1 = await getAgent(app.db, ctx.humanAgentUuid);
     const b1 = await createAgent(app.db, {
       name: `e2ed-b1-${Date.now()}`,
       type: "agent",

--- a/packages/server/src/__tests__/participant-invite.test.ts
+++ b/packages/server/src/__tests__/participant-invite.test.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { AGENT_VISIBILITY } from "@first-tree/shared";
 import { and, eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
@@ -6,9 +7,10 @@ import { chatMembership } from "../db/schema/chat-membership.js";
 import { inboxEntries } from "../db/schema/inbox-entries.js";
 import { BadRequestError, ConflictError, ForbiddenError, NotFoundError } from "../errors.js";
 import { createChat } from "../services/chat.js";
+import * as memberService from "../services/member.js";
 import { sendMessage } from "../services/message.js";
 import { assertChatVisibleInOrgOrNotFound, inviteParticipantsToChat } from "../services/participant-invite.js";
-import { createTestAgent, useTestApp } from "./helpers.js";
+import { createTestAdmin, createTestAgent, useTestApp } from "./helpers.js";
 
 /**
  * Layer-2 invite service contract. Both the agent-JWT path
@@ -82,6 +84,42 @@ describe("inviteParticipantsToChat", () => {
         errorOnAlreadySpeaker: true,
       }),
     ).rejects.toThrow(/Agents not found/);
+  });
+
+  it("rejects removed human mirrors as explicit invite targets", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `invite-admin-${randomUUID().slice(0, 8)}` });
+    const target = await memberService.createMember(app.db, admin.organizationId, {
+      username: `invite-removed-${randomUUID().slice(0, 8)}`,
+      displayName: "Invite Removed",
+      role: "member",
+    });
+    await memberService.deleteMember(app.db, target.id, admin.organizationId);
+
+    const chat = await createChat(app.db, admin.humanAgentUuid, { type: "group", participantIds: [] });
+    await expect(
+      inviteParticipantsToChat(app.db, {
+        chatId: chat.id,
+        callerAgentId: admin.humanAgentUuid,
+        targetAgentIds: [target.agentId],
+        errorOnAlreadySpeaker: true,
+      }),
+    ).rejects.toThrow(/Inactive participant/);
+  });
+
+  it("rejects removed human mirrors during legacy chat creation", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `legacy-admin-${randomUUID().slice(0, 8)}` });
+    const target = await memberService.createMember(app.db, admin.organizationId, {
+      username: `legacy-removed-${randomUUID().slice(0, 8)}`,
+      displayName: "Legacy Removed",
+      role: "member",
+    });
+    await memberService.deleteMember(app.db, target.id, admin.organizationId);
+
+    await expect(
+      createChat(app.db, admin.humanAgentUuid, { type: "group", participantIds: [target.agentId] }),
+    ).rejects.toThrow(/inactive participant/);
   });
 
   it("rejects cross-org targets with BadRequestError", async () => {
@@ -216,11 +254,11 @@ describe("inviteParticipantsToChat", () => {
     // here we pin it on the underlying invite service so any future Layer-3
     // shell that delegates to invite inherits the assertion for free.
     const app = getApp();
-    const owner = await createTestAgent(app, { type: "human" });
+    const owner = await createTestAdmin(app, { username: `backfill-owner-${randomUUID().slice(0, 8)}` });
     const peer = await createTestAgent(app, { type: "agent" });
     const newcomer = await createTestAgent(app, { type: "agent" });
 
-    const chat = await createChat(app.db, owner.agent.uuid, {
+    const chat = await createChat(app.db, owner.humanAgentUuid, {
       type: "group",
       participantIds: [peer.agent.uuid],
     });
@@ -228,7 +266,7 @@ describe("inviteParticipantsToChat", () => {
       await sendMessage(
         app.db,
         chat.id,
-        owner.agent.uuid,
+        owner.humanAgentUuid,
         {
           source: "api",
           format: "text",
@@ -240,7 +278,7 @@ describe("inviteParticipantsToChat", () => {
 
     await inviteParticipantsToChat(app.db, {
       chatId: chat.id,
-      callerAgentId: owner.agent.uuid,
+      callerAgentId: owner.humanAgentUuid,
       targetAgentIds: [newcomer.agent.uuid],
       errorOnAlreadySpeaker: true,
     });
@@ -293,7 +331,7 @@ describe("assertChatVisibleInOrgOrNotFound", () => {
 
   it("404s when the chat does not exist", async () => {
     const app = getApp();
-    const caller = await createTestAgent(app, { type: "human" });
+    const caller = await createTestAdmin(app, { username: `visible-missing-${randomUUID().slice(0, 8)}` });
     await expect(
       assertChatVisibleInOrgOrNotFound(app.db, "00000000-0000-0000-0000-000000000000", caller.organizationId),
     ).rejects.toThrow(NotFoundError);
@@ -301,7 +339,7 @@ describe("assertChatVisibleInOrgOrNotFound", () => {
 
   it("404s when the chat is in a different org from the caller (probing protection)", async () => {
     const app = getApp();
-    const caller = await createTestAgent(app, { type: "human" });
+    const caller = await createTestAdmin(app, { username: `visible-cross-${randomUUID().slice(0, 8)}` });
     const chatOwner = await createTestAgent(app, { type: "agent" });
     const chat = await createChat(app.db, chatOwner.agent.uuid, { type: "group", participantIds: [] });
 
@@ -323,8 +361,8 @@ describe("assertChatVisibleInOrgOrNotFound", () => {
 
   it("passes when chat exists and is in the caller's org", async () => {
     const app = getApp();
-    const caller = await createTestAgent(app, { type: "human" });
-    const chat = await createChat(app.db, caller.agent.uuid, { type: "group", participantIds: [] });
+    const caller = await createTestAdmin(app, { username: `visible-pass-${randomUUID().slice(0, 8)}` });
+    const chat = await createChat(app.db, caller.humanAgentUuid, { type: "group", participantIds: [] });
     await expect(assertChatVisibleInOrgOrNotFound(app.db, chat.id, caller.organizationId)).resolves.toBeUndefined();
   });
 });

--- a/packages/server/src/api/orgs/agents.ts
+++ b/packages/server/src/api/orgs/agents.ts
@@ -1,11 +1,12 @@
 import {
+  AGENT_TYPES,
   agentPinnedMessageSchema,
   createAgentSchema,
   listAgentsQuerySchema,
   paginationQuerySchema,
 } from "@first-tree/shared";
 import type { FastifyInstance } from "fastify";
-import { ForbiddenError } from "../../errors.js";
+import { BadRequestError, ForbiddenError } from "../../errors.js";
 import { requireOrgMembership } from "../../scope/require-org.js";
 import * as agentService from "../../services/agent.js";
 import { resolveAvatarImageUrl } from "../../services/agent.js";
@@ -49,8 +50,8 @@ export async function orgAgentRoutes(app: FastifyInstance): Promise<void> {
 
   app.get<{ Params: { orgId: string } }>("/", async (request) => {
     const scope = await requireOrgMembership(request, app.db);
-    const { limit, cursor, type, query } = listAgentsQuerySchema.parse(request.query);
-    const result = await agentService.listAgentsForMember(app.db, scope, limit, cursor, type, query);
+    const { limit, cursor, type, query, addressableOnly } = listAgentsQuerySchema.parse(request.query);
+    const result = await agentService.listAgentsForMember(app.db, scope, limit, cursor, type, query, addressableOnly);
     return {
       items: result.items.map(({ avatarImageUpdatedAt, userAvatarUrl, ...a }) => ({
         ...a,
@@ -121,6 +122,9 @@ export async function orgAgentRoutes(app: FastifyInstance): Promise<void> {
   app.post<{ Params: { orgId: string } }>("/", { config: { otelRecordBody: true } }, async (request, reply) => {
     const scope = await requireOrgMembership(request, app.db);
     const body = createAgentSchema.parse(request.body);
+    if (body.type === AGENT_TYPES.HUMAN) {
+      throw new BadRequestError("Human agents are created through the member lifecycle");
+    }
     // member role: managerId forced to caller's member; admin role may
     // specify any managerId in the same org.
     const managerId = scope.role === "admin" ? (body.managerId ?? scope.memberId) : scope.memberId;

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -82,6 +82,7 @@ import { type BackgroundTasks, createBackgroundTasks } from "./services/backgrou
 import { registerChatMessageDispatcher } from "./services/chat-projection.js";
 import { createCommandVersionPoller } from "./services/command-version-poller.js";
 import { createConfigService } from "./services/config-service.js";
+import { repairMembershipHumanMirrors } from "./services/membership.js";
 import { createNotifier, type Notifier } from "./services/notifier.js";
 import { ensureDefaultOrganization } from "./services/organization.js";
 import { createPulseAggregator } from "./services/pulse-aggregator.js";
@@ -661,6 +662,11 @@ export async function buildApp(config: Config) {
   app.addHook("onReady", async () => {
     // Ensure the default organization exists (idempotent)
     await ensureDefaultOrganization(db);
+    const mirrorRepair = await repairMembershipHumanMirrors(db);
+    const repaired = mirrorRepair.activeMirrorsRepaired + mirrorRepair.inactiveMirrorsRepaired;
+    if (repaired > 0) {
+      app.log.info({ ...mirrorRepair }, "membership human mirrors repaired");
+    }
     await backfillResourcesPhase1(db).catch((err) => {
       app.log.warn({ err }, "resources phase1 backfill failed");
     });

--- a/packages/server/src/db/schema/members.ts
+++ b/packages/server/src/db/schema/members.ts
@@ -31,11 +31,11 @@ export const members = pgTable(
     /** Audit stamp for completing this membership's onboarding journey. */
     onboardingCompletedAt: timestamp("onboarding_completed_at", { withTimezone: true }),
     /**
-     * "active" | "left". Soft-delete marker. Members who leave a team have
-     * their row flipped to "left" rather than deleted, so historical chats /
-     * agent ownership references stay intact. The auth middleware refuses
-     * tokens that resolve to a "left" member; the join-by-invite flow flips
-     * a previously-"left" row back to "active".
+     * "active" | "left" | "removed". Soft-delete marker. Members who leave
+     * or are removed from a team keep their row so historical chats / agent
+     * ownership references stay intact. Auth only accepts "active" rows.
+     * Invite rejoin restores "left"; admin restore can restore "left" or
+     * "removed".
      */
     status: text("status").notNull().default("active"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),

--- a/packages/server/src/scope/require-resource.ts
+++ b/packages/server/src/scope/require-resource.ts
@@ -1,4 +1,4 @@
-import { AGENT_STATUSES, AGENT_VISIBILITY } from "@first-tree/shared";
+import { AGENT_STATUSES, AGENT_TYPES, AGENT_VISIBILITY } from "@first-tree/shared";
 import { and, eq, inArray } from "drizzle-orm";
 import type { FastifyRequest } from "fastify";
 import type { Database } from "../db/connection.js";
@@ -281,9 +281,10 @@ export async function assertAgentManageableByUser(db: Database, userId: string, 
 }
 
 /**
- * Assert every agent in `agentIds` is visible to `scope` and lives in
- * `scope.organizationId`. Used by chat-create to keep visibility rules out of
- * the service layer's signature.
+ * Assert every agent in `agentIds` is visible to `scope`, lives in
+ * `scope.organizationId`, and is eligible to become a new chat participant.
+ * Used by chat-create to keep visibility rules out of the service layer's
+ * signature.
  */
 export async function assertAllAgentsVisibleInOrg(db: Database, scope: OrgScope, agentIds: string[]): Promise<void> {
   if (agentIds.length === 0) return;
@@ -295,14 +296,18 @@ export async function assertAllAgentsVisibleInOrg(db: Database, scope: OrgScope,
       visibility: agents.visibility,
       managerId: agents.managerId,
       status: agents.status,
+      type: agents.type,
+      memberStatus: members.status,
     })
     .from(agents)
+    .leftJoin(members, eq(members.agentId, agents.uuid))
     .where(inArray(agents.uuid, agentIds));
 
   const byId = new Map(rows.map((r) => [r.uuid, r]));
   for (const id of agentIds) {
     const row = byId.get(id);
-    if (!row || row.status === AGENT_STATUSES.DELETED) {
+    const inactiveHumanMirror = row?.type === AGENT_TYPES.HUMAN && row.memberStatus !== "active";
+    if (!row || row.status !== AGENT_STATUSES.ACTIVE || inactiveHumanMirror) {
       throw new NotFoundError(`Agent "${id}" not found`);
     }
     if (row.organizationId !== scope.organizationId) {

--- a/packages/server/src/services/access-control.ts
+++ b/packages/server/src/services/access-control.ts
@@ -14,7 +14,7 @@
  * (`requireAgentAccess(..., "manage")`), not visibility.
  */
 
-import { AGENT_STATUSES, AGENT_VISIBILITY } from "@first-tree/shared";
+import { AGENT_STATUSES, AGENT_TYPES, AGENT_VISIBILITY } from "@first-tree/shared";
 import { and, eq, inArray, ne, or, type SQL } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 import { agents } from "../db/schema/agents.js";
@@ -30,6 +30,18 @@ export function agentVisibilityCondition(orgId: string, memberId: string): SQL {
     eq(agents.organizationId, orgId),
     ne(agents.status, AGENT_STATUSES.DELETED),
     or(eq(agents.visibility, AGENT_VISIBILITY.ORGANIZATION), eq(agents.managerId, memberId)),
+  ) as SQL;
+}
+
+/**
+ * SQL WHERE condition for identities that may be selected as new chat
+ * participants. Callers must join `members` as `members.agentId = agents.uuid`
+ * before composing this predicate.
+ */
+export function agentAddressableCondition(): SQL {
+  return and(
+    eq(agents.status, AGENT_STATUSES.ACTIVE),
+    or(ne(agents.type, AGENT_TYPES.HUMAN), eq(members.status, "active")),
   ) as SQL;
 }
 

--- a/packages/server/src/services/agent.ts
+++ b/packages/server/src/services/agent.ts
@@ -29,7 +29,7 @@ import { users } from "../db/schema/users.js";
 import { BadRequestError, ConflictError, ForbiddenError, NotFoundError } from "../errors.js";
 import type { OrgScope } from "../scope/types.js";
 import { uuidv7 } from "../uuid.js";
-import { agentVisibilityCondition } from "./access-control.js";
+import { agentAddressableCondition, agentVisibilityCondition } from "./access-control.js";
 import { resolveDefaultOrgId } from "./organization.js";
 import { recomputeWatchersForAgent } from "./watcher.js";
 
@@ -259,7 +259,7 @@ async function resolveAgentClient(
   const [manager] = await db
     .select({ userId: members.userId })
     .from(members)
-    .where(eq(members.id, data.managerId))
+    .where(and(eq(members.id, data.managerId), eq(members.status, "active")))
     .limit(1);
   if (!manager) {
     throw new BadRequestError(`Manager "${data.managerId}" not found`);
@@ -339,6 +339,12 @@ function assertDelegateMentionAllowed(sourceType: string): void {
   }
 }
 
+function assertNonHumanLifecycleTarget(agent: { type: string }): void {
+  if (agent.type === AGENT_TYPES.HUMAN) {
+    throw new BadRequestError("Human agent lifecycle is managed by member leave/remove/restore.");
+  }
+}
+
 /**
  * Pick the first admin member in the org for internal system agents. Throws
  * if the org has no admin — the caller should surface the error so an admin
@@ -348,7 +354,7 @@ async function resolveFallbackManagerId(db: Database, orgId: string): Promise<st
   const [row] = await db
     .select({ id: members.id })
     .from(members)
-    .where(and(eq(members.organizationId, orgId), eq(members.role, "admin")))
+    .where(and(eq(members.organizationId, orgId), eq(members.role, "admin"), eq(members.status, "active")))
     .orderBy(members.createdAt)
     .limit(1);
   if (!row) {
@@ -402,7 +408,26 @@ export async function createAgent(
   let managerId: string;
 
   if (data.managerId && data.organizationId) {
-    // Branch 2: trust explicit pair (bootstrap / tests).
+    // Branch 2: explicit pair. If the manager row already exists, validate it
+    // like the public API path; if it does not, this is the member bootstrap
+    // path that inserts the human agent before inserting the member row in the
+    // same transaction, so the deferred FK validates it at commit time.
+    const [manager] = await db
+      .select({ id: members.id, organizationId: members.organizationId, status: members.status })
+      .from(members)
+      .where(eq(members.id, data.managerId))
+      .limit(1);
+    if (!manager && data.type !== AGENT_TYPES.HUMAN) {
+      throw new BadRequestError(`Manager "${data.managerId}" not found`);
+    }
+    if (manager) {
+      if (manager.status !== "active") {
+        throw new BadRequestError(`Manager "${data.managerId}" not found`);
+      }
+      if (manager.organizationId !== data.organizationId) {
+        throw new BadRequestError("Manager must belong to the same organization as the agent");
+      }
+    }
     orgId = data.organizationId;
     managerId = data.managerId;
   } else if (data.managerId) {
@@ -410,7 +435,7 @@ export async function createAgent(
     const [manager] = await db
       .select({ id: members.id, organizationId: members.organizationId })
       .from(members)
-      .where(eq(members.id, data.managerId))
+      .where(and(eq(members.id, data.managerId), eq(members.status, "active")))
       .limit(1);
     if (!manager) {
       throw new BadRequestError(`Manager "${data.managerId}" not found`);
@@ -732,9 +757,11 @@ export async function listAgentsForMember(
   cursor?: string,
   type?: string,
   query?: string,
+  addressableOnly = false,
 ) {
   // agentVisibilityCondition already includes org + status + visibility filtering
   const conditions = [agentVisibilityCondition(scope.organizationId, scope.memberId)];
+  if (addressableOnly) conditions.push(agentAddressableCondition());
   if (cursor) conditions.push(lt(agents.createdAt, new Date(cursor)));
   if (type) conditions.push(eq(agents.type, type));
   if (query) {
@@ -832,26 +859,12 @@ export async function updateAgent(db: Database, uuid: string, data: UpdateAgent)
 
   const updates: Partial<typeof agents.$inferInsert> = { updatedAt: new Date() };
   if (data.type !== undefined) {
-    // Closes the type-flip leak: without this guard a PATCH like
-    // `{type: "agent"}` on a human row with a non-null delegateMention
-    // would leave behind `type=agent + delegateMention=<uuid>`, violating
-    // the invariant that only humans carry a delegate. The caller must
-    // either clear delegateMention in the same patch or flip type to human
-    // (no-op for the invariant).
-    if (data.type !== AGENT_TYPES.HUMAN && agent.delegateMention !== null && data.delegateMention !== null) {
-      throw new BadRequestError(
-        "Cannot change type away from `human` while delegateMention is set — clear delegateMention in the same patch.",
-      );
-    }
-    updates.type = data.type;
+    throw new BadRequestError("Agent type is immutable");
   }
   if (data.displayName !== undefined) updates.displayName = data.displayName;
   if (data.delegateMention !== undefined) {
     if (data.delegateMention !== null) {
-      // Effective type honors a same-patch `type` update; without this the
-      // guard would read the stale pre-update value when the caller flips
-      // type → "human" and sets delegateMention in one PATCH.
-      assertDelegateMentionAllowed(data.type ?? agent.type);
+      assertDelegateMentionAllowed(agent.type);
       await validateDelegateMentionTarget(db, data.delegateMention, agent.organizationId);
     }
     updates.delegateMention = data.delegateMention;
@@ -869,7 +882,7 @@ export async function updateAgent(db: Database, uuid: string, data: UpdateAgent)
     const [manager] = await db
       .select({ id: members.id, organizationId: members.organizationId })
       .from(members)
-      .where(eq(members.id, data.managerId))
+      .where(and(eq(members.id, data.managerId), eq(members.status, "active")))
       .limit(1);
     if (!manager) {
       throw new BadRequestError(`Manager "${data.managerId}" not found`);
@@ -964,13 +977,14 @@ export async function rebindAgent(db: Database, uuid: string, data: RebindAgent)
  */
 export async function reactivateAgent(db: Database, uuid: string) {
   const [existing] = await db
-    .select({ uuid: agents.uuid, status: agents.status })
+    .select({ uuid: agents.uuid, status: agents.status, type: agents.type })
     .from(agents)
     .where(eq(agents.uuid, uuid))
     .limit(1);
   if (!existing || existing.status === AGENT_STATUSES.DELETED) {
     throw new NotFoundError(`Agent "${uuid}" not found`);
   }
+  assertNonHumanLifecycleTarget(existing);
   if (existing.status !== AGENT_STATUSES.SUSPENDED) {
     throw new BadRequestError("Only suspended agents can be reactivated.");
   }
@@ -992,15 +1006,18 @@ export async function reactivateAgent(db: Database, uuid: string) {
  * and every agent-selector-authorised HTTP call.
  */
 export async function suspendAgent(db: Database, uuid: string) {
-  const [agent] = await db
-    .update(agents)
-    .set({ status: AGENT_STATUSES.SUSPENDED, updatedAt: new Date() })
-    .where(and(eq(agents.uuid, uuid), ne(agents.status, AGENT_STATUSES.DELETED)))
-    .returning();
+  const [existing] = await db
+    .select({ uuid: agents.uuid, status: agents.status, type: agents.type })
+    .from(agents)
+    .where(eq(agents.uuid, uuid))
+    .limit(1);
 
-  if (!agent) {
+  if (!existing || existing.status === AGENT_STATUSES.DELETED) {
     throw new NotFoundError(`Agent "${uuid}" not found`);
   }
+  assertNonHumanLifecycleTarget(existing);
+
+  await db.update(agents).set({ status: AGENT_STATUSES.SUSPENDED, updatedAt: new Date() }).where(eq(agents.uuid, uuid));
 
   const refreshed = await selectAgentRowWithRuntime(db, uuid);
   if (!refreshed) throw new Error("Unexpected: agent disappeared after UPDATE");
@@ -1013,13 +1030,14 @@ export async function suspendAgent(db: Database, uuid: string) {
  */
 export async function deleteAgent(db: Database, uuid: string) {
   const [existing] = await db
-    .select({ uuid: agents.uuid, status: agents.status })
+    .select({ uuid: agents.uuid, status: agents.status, type: agents.type })
     .from(agents)
     .where(eq(agents.uuid, uuid))
     .limit(1);
   if (!existing || existing.status === AGENT_STATUSES.DELETED) {
     throw new NotFoundError(`Agent "${uuid}" not found`);
   }
+  assertNonHumanLifecycleTarget(existing);
   if (existing.status !== AGENT_STATUSES.SUSPENDED) {
     throw new BadRequestError("Only suspended agents can be deleted. Suspend the agent first.");
   }

--- a/packages/server/src/services/chat.ts
+++ b/packages/server/src/services/chat.ts
@@ -1,5 +1,11 @@
 import { randomUUID } from "node:crypto";
-import type { AddParticipant, LegacyCreateChat, SendMessage } from "@first-tree/shared";
+import {
+  type AddParticipant,
+  AGENT_STATUSES,
+  AGENT_TYPES,
+  type LegacyCreateChat,
+  type SendMessage,
+} from "@first-tree/shared";
 import { and, desc, eq, inArray, lt, sql } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 import { agents } from "../db/schema/agents.js";
@@ -71,6 +77,7 @@ type AgentIdentityForCreate = {
   organizationId: string;
   type: string;
   status: string;
+  memberStatus: string | null;
   visibility: string;
   managerId: string;
 };
@@ -128,10 +135,13 @@ async function createLegacyEmptyChat(
       id: agents.uuid,
       organizationId: agents.organizationId,
       type: agents.type,
+      status: agents.status,
+      memberStatus: members.status,
       visibility: agents.visibility,
       managerId: agents.managerId,
     })
     .from(agents)
+    .leftJoin(members, eq(members.agentId, agents.uuid))
     .where(inArray(agents.uuid, [...allParticipantIds]));
 
   if (existingAgents.length !== allParticipantIds.size) {
@@ -150,6 +160,12 @@ async function createLegacyEmptyChat(
   const crossOrg = existingAgents.filter((a) => a.organizationId !== orgId);
   if (crossOrg.length > 0) {
     throw new BadRequestError(`Cross-organization chat not allowed: ${crossOrg.map((a) => a.id).join(", ")}`);
+  }
+  const inactive = existingAgents.filter(
+    (a) => a.status !== AGENT_STATUSES.ACTIVE || (a.type === AGENT_TYPES.HUMAN && a.memberStatus !== "active"),
+  );
+  if (inactive.length > 0) {
+    throw new BadRequestError(`Cannot create chat with inactive participant "${inactive[0]?.id}".`);
   }
 
   // Owner-exclusive rule for private targets (RFC §4.5, shared-owner
@@ -361,10 +377,12 @@ async function loadAgentsForCreate(db: Database, agentIds: readonly string[]): P
       organizationId: agents.organizationId,
       type: agents.type,
       status: agents.status,
+      memberStatus: members.status,
       visibility: agents.visibility,
       managerId: agents.managerId,
     })
     .from(agents)
+    .leftJoin(members, eq(members.agentId, agents.uuid))
     .where(inArray(agents.uuid, distinct));
   if (rows.length !== distinct.length) {
     const found = new Set(rows.map((a) => a.id));
@@ -419,11 +437,15 @@ function validateCreateParticipants(input: {
     throw new BadRequestError(`Creator agent "${input.caller.id}" is not in organization "${input.organizationId}"`);
   }
   if (input.requireActive) {
-    const inactive = input.participants.filter((a) => a.status !== "active");
+    const inactive = input.participants.filter(
+      (a) => a.status !== AGENT_STATUSES.ACTIVE || (a.type === AGENT_TYPES.HUMAN && a.memberStatus !== "active"),
+    );
     if (inactive.length > 0) {
       const first = inactive[0];
+      if (!first) throw new Error("Unexpected: inactive participant list is empty");
+      const status = first.type === AGENT_TYPES.HUMAN && first.memberStatus !== "active" ? "removed" : first.status;
       throw new BadRequestError(
-        `Cannot create task chat with inactive participant "${first?.displayName ?? first?.id}" (${first?.status}).`,
+        `Cannot create task chat with inactive participant "${first.displayName ?? first.id}" (${status}).`,
       );
     }
   }

--- a/packages/server/src/services/member.ts
+++ b/packages/server/src/services/member.ts
@@ -1,7 +1,7 @@
 import { randomBytes } from "node:crypto";
-import type { CreateMember, UpdateMember } from "@first-tree/shared";
+import { AGENT_STATUSES, AGENT_TYPES, type CreateMember, type UpdateMember } from "@first-tree/shared";
 import bcrypt from "bcrypt";
-import { and, desc, eq, inArray, max, ne } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, max, ne } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 import { agents } from "../db/schema/agents.js";
 import { members } from "../db/schema/members.js";
@@ -10,6 +10,10 @@ import { users } from "../db/schema/users.js";
 import { BadRequestError, ConflictError, NotFoundError } from "../errors.js";
 import { uuidv7 } from "../uuid.js";
 import { createAgent } from "./agent.js";
+import { forceDisconnect } from "./connection-manager.js";
+import { MEMBER_STATUSES, reactivateMembership } from "./membership.js";
+import * as presenceService from "./presence.js";
+import { recomputeWatchersForAgent, recomputeWatchersForMember } from "./watcher.js";
 
 const SALT_ROUNDS = 10;
 
@@ -54,7 +58,30 @@ export async function createMember(db: Database, orgId: string, data: CreateMemb
       .where(and(eq(members.userId, existingUser.id), eq(members.organizationId, orgId)))
       .limit(1);
     if (existingMember) {
-      throw new ConflictError(`User "${data.username}" is already a member of this organization`);
+      if (existingMember.status === MEMBER_STATUSES.ACTIVE) {
+        throw new ConflictError(`User "${data.username}" is already a member of this organization`);
+      }
+      if (existingMember.status !== MEMBER_STATUSES.LEFT && existingMember.status !== MEMBER_STATUSES.REMOVED) {
+        throw new ConflictError(`User "${data.username}" has an unsupported membership status`);
+      }
+
+      await db.transaction(async (tx) => {
+        await tx.update(users).set({ displayName: data.displayName }).where(eq(users.id, existingUser.id));
+        await reactivateMembership(tx, existingMember, {
+          displayName: data.displayName,
+          username: data.username,
+          role: data.role ?? "member",
+          resetOnboarding: true,
+        });
+      });
+
+      const member = await getMember(db, existingMember.id);
+      return {
+        ...member,
+        username: data.username,
+        displayName: data.displayName,
+        notice: "Existing user — use their current password to log in",
+      };
     }
   }
 
@@ -127,13 +154,14 @@ export async function listMembers(db: Database, orgId: string) {
       organizationId: members.organizationId,
       agentId: members.agentId,
       role: members.role,
+      status: members.status,
       createdAt: members.createdAt,
       username: users.username,
       displayName: users.displayName,
     })
     .from(members)
     .innerJoin(users, eq(members.userId, users.id))
-    .where(eq(members.organizationId, orgId))
+    .where(and(eq(members.organizationId, orgId), eq(members.status, MEMBER_STATUSES.ACTIVE)))
     .orderBy(desc(members.createdAt));
 
   const lastActive = await lastActiveByAgent(
@@ -155,6 +183,7 @@ export async function getMember(db: Database, id: string) {
       organizationId: members.organizationId,
       agentId: members.agentId,
       role: members.role,
+      status: members.status,
       createdAt: members.createdAt,
       username: users.username,
       displayName: users.displayName,
@@ -175,6 +204,9 @@ export async function updateMember(db: Database, id: string, data: UpdateMember,
   // tenant. The route layer supplies its own org id; without a match we
   // 404 to avoid leaking that the member exists.
   if (callerOrgId && current.organizationId !== callerOrgId) {
+    throw new NotFoundError(`Member "${id}" not found`);
+  }
+  if (current.status !== MEMBER_STATUSES.ACTIVE) {
     throw new NotFoundError(`Member "${id}" not found`);
   }
 
@@ -225,41 +257,97 @@ export async function updateOwnProfile(db: Database, userId: string, displayName
 }
 
 export async function deleteMember(db: Database, id: string, callerOrgId: string) {
-  const member = await getMember(db, id);
-  // A cross-org admin should never be able to delete a member in another
-  // tenant. Return 404 to avoid leaking that the member exists.
-  if (member.organizationId !== callerOrgId) {
-    throw new NotFoundError(`Member "${id}" not found`);
+  const transferredAgentIds = await db.transaction(async (tx) => {
+    const [targetRef] = await tx
+      .select({ organizationId: members.organizationId })
+      .from(members)
+      .where(eq(members.id, id))
+      .limit(1);
+    // A cross-org admin should never be able to delete a member in another
+    // tenant. Return 404 to avoid leaking that the member exists.
+    if (!targetRef || targetRef.organizationId !== callerOrgId) {
+      throw new NotFoundError(`Member "${id}" not found`);
+    }
+
+    const activeAdmins = await tx
+      .select({ id: members.id })
+      .from(members)
+      .where(
+        and(
+          eq(members.organizationId, callerOrgId),
+          eq(members.role, "admin"),
+          eq(members.status, MEMBER_STATUSES.ACTIVE),
+        ),
+      )
+      .orderBy(asc(members.id))
+      .for("update");
+
+    const [member] = await tx
+      .select({
+        id: members.id,
+        organizationId: members.organizationId,
+        role: members.role,
+        status: members.status,
+        agentId: members.agentId,
+      })
+      .from(members)
+      .where(eq(members.id, id))
+      .for("update")
+      .limit(1);
+    if (!member || member.organizationId !== callerOrgId || member.status !== MEMBER_STATUSES.ACTIVE) {
+      throw new NotFoundError(`Member "${id}" not found`);
+    }
+
+    // Prevent deleting the last admin. The active-admin rows are locked in a
+    // deterministic order above, so concurrent admin removals serialize before
+    // this check and fallback selection.
+    const fallback = activeAdmins.find((admin) => admin.id !== id);
+    if (member.role === "admin" && !fallback) {
+      throw new BadRequestError("Cannot remove the last admin from the organization");
+    }
+    if (!fallback) {
+      throw new ConflictError(
+        `Cannot delete member "${id}" — another admin must exist in the organization to inherit their agents.`,
+      );
+    }
+
+    // Reassign every non-human agent managed by this member to another active
+    // admin in the org. The member's human mirror stays attached to the member
+    // row and is suspended by the membership lifecycle update below.
+    // managerId is NOT NULL after the unified-user-token milestone, so we can
+    // never clear it — a sibling admin takes over.
+    const transferred = await tx
+      .update(agents)
+      .set({ managerId: fallback.id, clientId: null, updatedAt: new Date() })
+      .where(and(eq(agents.managerId, id), ne(agents.type, AGENT_TYPES.HUMAN)))
+      .returning({ uuid: agents.uuid });
+
+    for (const { uuid } of transferred) {
+      await recomputeWatchersForAgent(tx, uuid);
+    }
+
+    const [deactivated] = await tx
+      .update(members)
+      .set({ status: MEMBER_STATUSES.REMOVED })
+      .where(and(eq(members.id, id), eq(members.status, MEMBER_STATUSES.ACTIVE)))
+      .returning({ id: members.id });
+    if (!deactivated) {
+      throw new ConflictError(`Membership "${id}" is not active`);
+    }
+    await tx
+      .update(agents)
+      .set({ status: AGENT_STATUSES.SUSPENDED, clientId: null, updatedAt: new Date() })
+      .where(eq(agents.uuid, member.agentId));
+    await recomputeWatchersForMember(tx, id);
+    return transferred.map((agent) => agent.uuid);
+  });
+
+  for (const agentId of transferredAgentIds) {
+    forceDisconnect(agentId, "member_removed");
+    await presenceService.unbindAgent(db, agentId);
   }
 
-  // Prevent deleting the last admin
-  if (member.role === "admin") {
-    await assertNotLastAdmin(db, member.organizationId, id);
-  }
-
-  // Reassign every agent managed by this member to another admin in the org.
-  // managerId is NOT NULL after the unified-user-token milestone, so we can
-  // never clear it — a sibling admin takes over (assertNotLastAdmin above
-  // guarantees at least one remains).
-  const [fallback] = await db
-    .select({ id: members.id })
-    .from(members)
-    .where(and(eq(members.organizationId, member.organizationId), eq(members.role, "admin"), ne(members.id, id)))
-    .limit(1);
-  if (!fallback) {
-    throw new ConflictError(
-      `Cannot delete member "${id}" — another admin must exist in the organization to inherit their agents.`,
-    );
-  }
-  await db.update(agents).set({ managerId: fallback.id }).where(eq(agents.managerId, id));
-
-  // Mark the member's human agent as deleted
-  await db.update(agents).set({ status: "deleted", name: null }).where(eq(agents.uuid, member.agentId));
-
-  // Delete member record
-  await db.delete(members).where(eq(members.id, id));
-
-  // Note: user record is kept (for multi-org future — user may belong to other orgs)
+  // Note: user record is kept (for multi-org future — user may belong to other orgs).
 }
 
 /** Throw if this is the last admin in the organization. */
@@ -267,7 +355,14 @@ async function assertNotLastAdmin(db: Database, orgId: string, excludeMemberId: 
   const [otherAdmin] = await db
     .select({ id: members.id })
     .from(members)
-    .where(and(eq(members.organizationId, orgId), eq(members.role, "admin"), ne(members.id, excludeMemberId)))
+    .where(
+      and(
+        eq(members.organizationId, orgId),
+        eq(members.role, "admin"),
+        eq(members.status, MEMBER_STATUSES.ACTIVE),
+        ne(members.id, excludeMemberId),
+      ),
+    )
     .limit(1);
 
   if (!otherAdmin) {

--- a/packages/server/src/services/membership.ts
+++ b/packages/server/src/services/membership.ts
@@ -1,9 +1,12 @@
 import { randomBytes } from "node:crypto";
-import { and, desc, eq, inArray, sql } from "drizzle-orm";
+import { AGENT_STATUSES, AGENT_TYPES } from "@first-tree/shared";
+import { and, desc, eq, inArray, ne, sql } from "drizzle-orm";
+import type { PgDatabase, PgQueryResultHKT } from "drizzle-orm/pg-core";
 import type { Database } from "../db/connection.js";
 import { agents } from "../db/schema/agents.js";
 import { members } from "../db/schema/members.js";
 import { organizations } from "../db/schema/organizations.js";
+import { users } from "../db/schema/users.js";
 import { BadRequestError, ConflictError, NotFoundError } from "../errors.js";
 import { uuidv7 } from "../uuid.js";
 import { recomputeWatchersForMember } from "./watcher.js";
@@ -15,6 +18,17 @@ import { recomputeWatchersForMember } from "./watcher.js";
  * self-service and don't share its admin invariants (e.g. "last admin can't
  * be demoted" doesn't apply to "last admin leaves").
  */
+
+export const MEMBER_STATUSES = {
+  ACTIVE: "active",
+  LEFT: "left",
+  REMOVED: "removed",
+} as const;
+
+export type MemberStatus = (typeof MEMBER_STATUSES)[keyof typeof MEMBER_STATUSES];
+
+// biome-ignore lint/suspicious/noExplicitAny: needed for cross-schema compatibility with transaction clients.
+type DbLike = PgDatabase<PgQueryResultHKT, any, any>;
 
 type CreateMembershipForUser = {
   userId: string;
@@ -35,10 +49,8 @@ export async function ensureMembership(db: Database, data: CreateMembershipForUs
     .limit(1);
 
   if (existing) {
-    if (existing.status === "left") {
-      // Re-activate the prior soft-deleted row. The human agent associated
-      // with it may be in any state — leave it alone; it gets refreshed
-      // implicitly when the member starts using the team again.
+    if (existing.status === MEMBER_STATUSES.LEFT) {
+      // Re-activate the prior soft-deleted row and its human-agent mirror.
       //
       // Rejoin starts a FRESH onboarding lifecycle for this membership: clear
       // the prior suppress/completion stamps so the auto-entry gate treats
@@ -46,26 +58,25 @@ export async function ensureMembership(db: Database, data: CreateMembershipForUs
       // would otherwise hide setup for what is effectively a newly joined
       // team — the exact failure mode the membership-scoped gate exists to
       // prevent.
-      await db
-        .update(members)
-        .set({
-          status: "active",
-          onboardingSuppressedAt: null,
-          onboardingSuppressedReason: null,
-          onboardingCompletedAt: null,
-        })
-        .where(eq(members.id, existing.id));
-      // Watcher rows: re-activated member regains visibility into chats
-      // where their managed non-human agents speak. recompute restores
-      // the rows that were dropped on the prior `left` flip.
-      await recomputeWatchersForMember(db, existing.id);
+      await db.transaction(async (tx) => {
+        await reactivateMembership(tx, existing, {
+          displayName: data.displayName,
+          username: data.username,
+          resetOnboarding: true,
+        });
+      });
       return {
         ...existing,
-        status: "active" as const,
+        status: MEMBER_STATUSES.ACTIVE,
         onboardingSuppressedAt: null,
         onboardingSuppressedReason: null,
         onboardingCompletedAt: null,
       };
+    }
+    if (existing.status === MEMBER_STATUSES.REMOVED) {
+      throw new ConflictError(
+        `Membership for user "${data.userId}" was removed by an admin and must be restored by an admin.`,
+      );
     }
     return existing;
   }
@@ -96,7 +107,7 @@ export async function ensureMembership(db: Database, data: CreateMembershipForUs
         organizationId: data.organizationId,
         agentId: agentUuid,
         role: data.role,
-        status: "active",
+        status: MEMBER_STATUSES.ACTIVE,
       })
       .returning();
     if (!row) throw new Error("Unexpected: INSERT RETURNING produced no row");
@@ -112,6 +123,197 @@ function sanitizeAgentName(login: string): string {
       .replace(/^-+|-+$/g, "")
       .slice(0, 60) || "user"
   );
+}
+
+type ExistingMembershipForLifecycle = {
+  id: string;
+  agentId: string;
+  organizationId: string;
+  status: string;
+};
+
+type ReactivateMembershipOptions = {
+  displayName: string;
+  username: string;
+  role?: "admin" | "member";
+  resetOnboarding?: boolean;
+};
+
+/**
+ * Restore an inactive member and its 1:1 human-agent mirror. The member row is
+ * preserved so historical chats, authorship, and ownership references keep the
+ * same stable ids across leave/rejoin and admin restore.
+ */
+export async function reactivateMembership(
+  db: DbLike,
+  existing: ExistingMembershipForLifecycle,
+  options: ReactivateMembershipOptions,
+): Promise<void> {
+  const memberUpdate = {
+    ...(options.role ? { role: options.role } : {}),
+    status: MEMBER_STATUSES.ACTIVE,
+    ...(options.resetOnboarding
+      ? {
+          onboardingSuppressedAt: null,
+          onboardingSuppressedReason: null,
+          onboardingCompletedAt: null,
+        }
+      : {}),
+  };
+  await db.update(members).set(memberUpdate).where(eq(members.id, existing.id));
+
+  const [mirror] = await db
+    .select({ name: agents.name })
+    .from(agents)
+    .where(eq(agents.uuid, existing.agentId))
+    .limit(1);
+  if (mirror?.name === null) {
+    const restoredName = await resolveRestoredAgentName(db, existing, options.username);
+    await db
+      .update(agents)
+      .set({
+        status: AGENT_STATUSES.ACTIVE,
+        displayName: options.displayName,
+        name: restoredName,
+        clientId: null,
+        updatedAt: new Date(),
+      })
+      .where(eq(agents.uuid, existing.agentId));
+  } else {
+    await db
+      .update(agents)
+      .set({
+        status: AGENT_STATUSES.ACTIVE,
+        displayName: options.displayName,
+        clientId: null,
+        updatedAt: new Date(),
+      })
+      .where(eq(agents.uuid, existing.agentId));
+  }
+
+  await recomputeWatchersForMember(db, existing.id);
+}
+
+async function resolveRestoredAgentName(
+  db: DbLike,
+  existing: Pick<ExistingMembershipForLifecycle, "agentId" | "organizationId">,
+  username: string,
+): Promise<string> {
+  const base = sanitizeAgentName(username);
+  const suffixes = ["", existing.agentId.slice(0, 8), randomBytes(2).toString("hex")];
+  for (const suffix of suffixes) {
+    const candidate = suffix ? appendAgentNameSuffix(base, suffix) : base;
+    const [collision] = await db
+      .select({ uuid: agents.uuid })
+      .from(agents)
+      .where(
+        and(
+          eq(agents.organizationId, existing.organizationId),
+          eq(agents.name, candidate),
+          ne(agents.uuid, existing.agentId),
+        ),
+      )
+      .limit(1);
+    if (!collision) return candidate;
+  }
+  return appendAgentNameSuffix(base, randomBytes(4).toString("hex"));
+}
+
+function appendAgentNameSuffix(base: string, suffix: string): string {
+  const maxNameLength = 64;
+  const roomForBase = maxNameLength - suffix.length - 1;
+  return `${base.slice(0, Math.max(1, roomForBase))}-${suffix}`;
+}
+
+/**
+ * Move a membership out of the active roster while preserving its identity.
+ * The human mirror becomes suspended, not deleted, so names and historical
+ * attribution remain intact and a future explicit restore can reactivate the
+ * same member+agent pair.
+ */
+export async function deactivateMembership(
+  db: DbLike,
+  memberId: string,
+  status: typeof MEMBER_STATUSES.LEFT | typeof MEMBER_STATUSES.REMOVED,
+) {
+  const [existing] = await db.select().from(members).where(eq(members.id, memberId)).limit(1);
+  if (!existing) throw new NotFoundError(`Membership "${memberId}" not found`);
+  if (existing.status !== MEMBER_STATUSES.ACTIVE && existing.status !== status) {
+    throw new ConflictError(`Membership "${memberId}" is not active`);
+  }
+
+  if (existing.status !== status) {
+    await db.update(members).set({ status }).where(eq(members.id, memberId));
+  }
+  await db
+    .update(agents)
+    .set({ status: AGENT_STATUSES.SUSPENDED, clientId: null, updatedAt: new Date() })
+    .where(eq(agents.uuid, existing.agentId));
+  await recomputeWatchersForMember(db, memberId);
+  return { ...existing, status };
+}
+
+export type MembershipMirrorRepairResult = {
+  activeMirrorsRepaired: number;
+  inactiveMirrorsRepaired: number;
+};
+
+/**
+ * Idempotent startup repair for rows produced before membership removal used
+ * the suspended-mirror model. Active members must have an active, named human
+ * mirror; inactive memberships keep the mirror named but suspended.
+ */
+export async function repairMembershipHumanMirrors(db: Database): Promise<MembershipMirrorRepairResult> {
+  return db.transaction(async (tx) => {
+    const rows = await tx
+      .select({
+        memberId: members.id,
+        memberStatus: members.status,
+        agentId: members.agentId,
+        organizationId: members.organizationId,
+        username: users.username,
+        mirrorType: agents.type,
+        mirrorStatus: agents.status,
+        mirrorName: agents.name,
+      })
+      .from(members)
+      .innerJoin(users, eq(users.id, members.userId))
+      .innerJoin(agents, eq(agents.uuid, members.agentId))
+      .for("update");
+
+    let activeMirrorsRepaired = 0;
+    let inactiveMirrorsRepaired = 0;
+    for (const row of rows) {
+      const desiredStatus =
+        row.memberStatus === MEMBER_STATUSES.ACTIVE ? AGENT_STATUSES.ACTIVE : AGENT_STATUSES.SUSPENDED;
+      const needsRepair =
+        row.mirrorType !== AGENT_TYPES.HUMAN || row.mirrorStatus !== desiredStatus || row.mirrorName === null;
+      if (!needsRepair) continue;
+
+      const restoredName =
+        row.mirrorName ??
+        (await resolveRestoredAgentName(
+          tx,
+          { agentId: row.agentId, organizationId: row.organizationId },
+          row.username,
+        ));
+      await tx
+        .update(agents)
+        .set({
+          type: AGENT_TYPES.HUMAN,
+          status: desiredStatus,
+          name: restoredName,
+          clientId: null,
+          updatedAt: new Date(),
+        })
+        .where(eq(agents.uuid, row.agentId));
+
+      if (row.memberStatus === MEMBER_STATUSES.ACTIVE) activeMirrorsRepaired += 1;
+      else inactiveMirrorsRepaired += 1;
+    }
+
+    return { activeMirrorsRepaired, inactiveMirrorsRepaired };
+  });
 }
 
 type CreatePersonalTeamInput = {
@@ -202,7 +404,7 @@ async function insertOrgWithSlugRetry(db: Database, orgId: string, base: string,
   return candidate;
 }
 
-/** List ACTIVE memberships (omit soft-deleted "left") for a user. */
+/** List ACTIVE memberships (omit soft-deleted "left"/"removed") for a user. */
 export async function listActiveMemberships(db: Database, userId: string) {
   const rows = await db
     .select({
@@ -219,7 +421,7 @@ export async function listActiveMemberships(db: Database, userId: string) {
     })
     .from(members)
     .innerJoin(organizations, eq(members.organizationId, organizations.id))
-    .where(and(eq(members.userId, userId), eq(members.status, "active")))
+    .where(and(eq(members.userId, userId), eq(members.status, MEMBER_STATUSES.ACTIVE)))
     .orderBy(desc(members.createdAt));
   return rows;
 }
@@ -240,7 +442,7 @@ export async function countActiveMembersByOrgs(db: Database, organizationIds: st
       count: sql<number>`count(*)::int`,
     })
     .from(members)
-    .where(and(inArray(members.organizationId, organizationIds), eq(members.status, "active")))
+    .where(and(inArray(members.organizationId, organizationIds), eq(members.status, MEMBER_STATUSES.ACTIVE)))
     .groupBy(members.organizationId);
   return new Map(rows.map((r) => [r.organizationId, r.count]));
 }
@@ -256,7 +458,7 @@ export async function pickPrimaryMembership(db: Database, userId: string) {
 
 /**
  * Look up a user's ACTIVE membership in a specific org. Returns null when
- * the user isn't a member there (or their row is soft-deleted `left`).
+ * the user isn't a member there (or their row is inactive).
  *
  * Used by the OAuth callback to re-check that a `targetOrganizationId`
  * carried in the signed state still names an org the user can administer
@@ -267,7 +469,13 @@ export async function findActiveMembership(db: Database, userId: string, organiz
   const [row] = await db
     .select({ memberId: members.id, role: members.role })
     .from(members)
-    .where(and(eq(members.userId, userId), eq(members.organizationId, organizationId), eq(members.status, "active")))
+    .where(
+      and(
+        eq(members.userId, userId),
+        eq(members.organizationId, organizationId),
+        eq(members.status, MEMBER_STATUSES.ACTIVE),
+      ),
+    )
     .limit(1);
   return row ?? null;
 }
@@ -285,15 +493,7 @@ export async function findActiveMembership(db: Database, userId: string, organiz
  * the chats from their `/me/chats` watching list.
  */
 export async function leaveOrganization(db: Database, memberId: string) {
-  const [existing] = await db.select().from(members).where(eq(members.id, memberId)).limit(1);
-  if (!existing) throw new NotFoundError(`Membership "${memberId}" not found`);
-  if (existing.status === "left") return existing;
-  await db.update(members).set({ status: "left" }).where(eq(members.id, memberId));
-  // Watcher rows anchored to this member's managed non-human agents drop
-  // off — they pivot through the now-inactive member, so the active-member
-  // predicate filters them out on the next recompute.
-  await recomputeWatchersForMember(db, memberId);
-  return { ...existing, status: "left" as const };
+  return deactivateMembership(db, memberId, MEMBER_STATUSES.LEFT);
 }
 
 /**

--- a/packages/server/src/services/participant-invite.ts
+++ b/packages/server/src/services/participant-invite.ts
@@ -60,12 +60,13 @@
  *     post-commit audience-cache invalidation.
  */
 
-import { AGENT_VISIBILITY } from "@first-tree/shared";
+import { AGENT_STATUSES, AGENT_TYPES, AGENT_VISIBILITY } from "@first-tree/shared";
 import { and, eq, inArray } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 import { agents } from "../db/schema/agents.js";
 import { chatMembership } from "../db/schema/chat-membership.js";
 import { chats } from "../db/schema/chats.js";
+import { members } from "../db/schema/members.js";
 import { BadRequestError, CallerNotSpeakerError, ConflictError, ForbiddenError, NotFoundError } from "../errors.js";
 import { applyMembershipWrite } from "./participant-mode.js";
 
@@ -206,8 +207,12 @@ export async function inviteParticipantsToChat(db: Database, args: InvitePartici
       organizationId: agents.organizationId,
       visibility: agents.visibility,
       managerId: agents.managerId,
+      status: agents.status,
+      type: agents.type,
+      memberStatus: members.status,
     })
     .from(agents)
+    .leftJoin(members, eq(members.agentId, agents.uuid))
     .where(inArray(agents.uuid, distinctTargets));
   if (targetRows.length !== distinctTargets.length) {
     const foundSet = new Set(targetRows.map((r) => r.uuid));
@@ -217,6 +222,12 @@ export async function inviteParticipantsToChat(db: Database, args: InvitePartici
   const crossOrg = targetRows.filter((t) => t.organizationId !== chat.organizationId);
   if (crossOrg.length > 0) {
     throw new BadRequestError(`Cross-organization participant rejected: ${crossOrg.map((t) => t.uuid).join(", ")}`);
+  }
+  const inactiveTargets = targetRows.filter(
+    (t) => t.status !== AGENT_STATUSES.ACTIVE || (t.type === AGENT_TYPES.HUMAN && t.memberStatus !== "active"),
+  );
+  if (inactiveTargets.length > 0) {
+    throw new BadRequestError(`Inactive participant rejected: ${inactiveTargets.map((t) => t.uuid).join(", ")}`);
   }
 
   // 4. Owner-exclusive for private targets. The caller's owning member

--- a/packages/shared/src/__tests__/agent-name-schema.test.ts
+++ b/packages/shared/src/__tests__/agent-name-schema.test.ts
@@ -129,6 +129,11 @@ describe("Phase 2: displayName is non-null on the wire", () => {
     expect(res.success).toBe(true);
   });
 
+  it("updateAgentSchema rejects type updates", () => {
+    expect(updateAgentSchema.safeParse({ type: "agent" }).success).toBe(false);
+    expect(updateAgentSchema.safeParse({ type: "human" }).success).toBe(false);
+  });
+
   it("updateAgentSchema accepts omitted displayName (leaves row untouched)", () => {
     const res = updateAgentSchema.safeParse({});
     expect(res.success).toBe(true);

--- a/packages/shared/src/schemas/agent.ts
+++ b/packages/shared/src/schemas/agent.ts
@@ -148,7 +148,9 @@ export const createAgentSchema = z.object({
 export type CreateAgent = z.infer<typeof createAgentSchema>;
 
 export const updateAgentSchema = z.object({
-  type: agentTypeSchema.optional(),
+  // Agent kind is established at creation. Human mirrors are owned by the
+  // member lifecycle, so generic PATCH must not support human <-> agent flips.
+  type: z.never().optional(),
   /**
    * Phase 2 of the agent-naming refactor promoted `displayName` to NOT NULL
    * at the DB level, so null is no longer an accepted update — clearing the
@@ -311,5 +313,13 @@ export type AgentPinnedMessage = z.infer<typeof agentPinnedMessageSchema>;
 export const listAgentsQuerySchema = paginationQuerySchema.extend({
   type: agentTypeSchema.optional(),
   query: z.string().trim().max(60).optional(),
+  addressableOnly: z
+    .preprocess((value) => {
+      if (value === undefined || value === "") return undefined;
+      if (value === true || value === "true" || value === "1") return true;
+      if (value === false || value === "false" || value === "0") return false;
+      return value;
+    }, z.boolean().optional())
+    .default(false),
 });
 export type ListAgentsQuery = z.infer<typeof listAgentsQuerySchema>;

--- a/packages/web/src/api/__tests__/api-wrappers.test.ts
+++ b/packages/web/src/api/__tests__/api-wrappers.test.ts
@@ -169,7 +169,7 @@ describe("api wrapper paths", () => {
     await agentConfig.getAgentClientStatus("agent/id");
     await agentStatus.fetchChatAgentStatuses("chat/id");
 
-    await agents.listAgents({ limit: 10, cursor: "next", type: "agent", query: "nova" });
+    await agents.listAgents({ limit: 10, cursor: "next", type: "agent", query: "nova", addressableOnly: true });
     await agents.listAllAgents({ limit: 5, cursor: "older" });
     await agents.listManagedAgents();
     await agents.getAgent("agent/id");
@@ -264,7 +264,9 @@ describe("api wrapper paths", () => {
     expect(apiMock.get).toHaveBeenCalledWith("/agents/agent/id/config");
     expect(apiMock.post).toHaveBeenCalledWith("/agents/agent/id/config/dry-run", { payload: { gitRepos: [] } });
     expect(apiMock.get).toHaveBeenCalledWith("/chats/chat/id/agent-status");
-    expect(apiMock.get).toHaveBeenCalledWith("/orgs/current/agents?limit=10&cursor=next&type=agent&query=nova");
+    expect(apiMock.get).toHaveBeenCalledWith(
+      "/orgs/current/agents?limit=10&cursor=next&type=agent&query=nova&addressableOnly=true",
+    );
     expect(apiMock.get).toHaveBeenCalledWith("/orgs/current/agents/all?limit=5&cursor=older");
     expect(apiMock.get).toHaveBeenCalledWith("/agents/agent%2Fid/skills");
     expect(apiMock.get).toHaveBeenCalledWith("/orgs/current/agents/names/name%20with%20spaces/availability");

--- a/packages/web/src/api/agents.ts
+++ b/packages/web/src/api/agents.ts
@@ -13,12 +13,15 @@ export function listAgents(params?: {
   /** Case-insensitive substring match against `name` + `displayName`.
    *  Whitespace is trimmed server-side; pass a non-empty string. */
   query?: string;
+  /** Restrict to identities that can be added to a new chat participant set. */
+  addressableOnly?: boolean;
 }): Promise<PaginatedAgents> {
   const qs = new URLSearchParams();
   if (params?.limit) qs.set("limit", String(params.limit));
   if (params?.cursor) qs.set("cursor", params.cursor);
   if (params?.type) qs.set("type", params.type);
   if (params?.query) qs.set("query", params.query);
+  if (params?.addressableOnly) qs.set("addressableOnly", "true");
   const query = qs.toString();
   return api.get<PaginatedAgents>(withOrg(`/agents${query ? `?${query}` : ""}`));
 }

--- a/packages/web/src/components/add-participant-dropdown.tsx
+++ b/packages/web/src/components/add-participant-dropdown.tsx
@@ -49,7 +49,9 @@ export function AddParticipantDropdown({
   const inputRef = useRef<HTMLInputElement | null>(null);
 
   const { agentId: myAgentId, memberId: myMemberId } = useAuth();
-  const { data: agentsPage, isFetching: searchFetching } = useOrgAgentsSearch(debouncedSearch);
+  const { data: agentsPage, isFetching: searchFetching } = useOrgAgentsSearch(debouncedSearch, {
+    addressableOnly: true,
+  });
 
   const candidates = useMemo<MentionCandidate[]>(() => {
     const out: MentionCandidate[] = [];

--- a/packages/web/src/lib/use-org-agents.ts
+++ b/packages/web/src/lib/use-org-agents.ts
@@ -5,10 +5,10 @@ type PaginatedAgents = Awaited<ReturnType<typeof listAgents>>;
 
 /**
  * Shared cache for `GET /orgs/:orgId/agents?limit=100` — the org-wide agent
- * roster used by the participant picker, the `[+]` add-member dropdown, the
- * identity-map hooks (UUID → name / slug / chip), and the bindings page.
+ * roster used by identity-map hooks (UUID → name / slug / chip), navigation,
+ * and picker surfaces that do not request the active-only addressable view.
  *
- * Centralising on a single `queryKey` (`["agents", "org-list"]`) is the
+ * Centralising under the `["agents", "org-list"]` prefix is the
  * point: prior to this hook the picker used `["org-agents"]` while the
  * identity-map hooks used `["agents", "name-map"]`, so React Query held two
  * independent caches for the same HTTP request — two GETs on mount and two
@@ -32,10 +32,14 @@ type PaginatedAgents = Awaited<ReturnType<typeof listAgents>>;
  * above that threshold reach agents past the first page via
  * {@link useOrgAgentsSearch} (issue 494).
  */
-export function useOrgAgents(options?: { enabled?: boolean }): UseQueryResult<PaginatedAgents> {
+export function useOrgAgents(options?: {
+  enabled?: boolean;
+  addressableOnly?: boolean;
+}): UseQueryResult<PaginatedAgents> {
+  const addressableOnly = options?.addressableOnly ?? false;
   return useQuery({
-    queryKey: ["agents", "org-list"],
-    queryFn: () => listAgents({ limit: 100 }),
+    queryKey: ["agents", "org-list", { addressableOnly }],
+    queryFn: () => listAgents({ limit: 100, addressableOnly }),
     refetchInterval: 30_000,
     staleTime: 30_000,
     enabled: options?.enabled ?? true,
@@ -58,12 +62,16 @@ export function useOrgAgents(options?: { enabled?: boolean }): UseQueryResult<Pa
  * Caller is responsible for debouncing the input — wiring this directly to
  * an onChange handler would issue one fetch per keystroke.
  */
-export function useOrgAgentsSearch(query: string): UseQueryResult<PaginatedAgents> {
+export function useOrgAgentsSearch(
+  query: string,
+  options?: { addressableOnly?: boolean },
+): UseQueryResult<PaginatedAgents> {
   const trimmed = query.trim();
-  const unfiltered = useOrgAgents();
+  const addressableOnly = options?.addressableOnly ?? false;
+  const unfiltered = useOrgAgents({ addressableOnly });
   const search = useQuery({
-    queryKey: ["agents", "org-list", "search", trimmed],
-    queryFn: () => listAgents({ limit: 100, query: trimmed }),
+    queryKey: ["agents", "org-list", { addressableOnly }, "search", trimmed],
+    queryFn: () => listAgents({ limit: 100, query: trimmed, addressableOnly }),
     // Search results stay fresh briefly so re-opening the picker with the
     // same term doesn't re-hit the server; expire fast enough that a newly
     // added agent shows up under search within a reasonable window.

--- a/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
@@ -1032,4 +1032,17 @@ describe("AgentDetailPage", () => {
 
     await act(async () => toDelete.root.unmount());
   });
+
+  it("does not render agent lifecycle danger controls for human agents", async () => {
+    const { ProfileTab } = await import("../profile-tab.js");
+
+    agentMocks.getAgent.mockResolvedValueOnce(agent({ type: "human" }));
+    const view = await renderDom("/agents/agent-1/profile", <ProfileTab />);
+    await waitForText(view.container, "Identity");
+    expect(view.container.textContent).not.toContain("Agent lifecycle");
+    expect(view.container.textContent).not.toContain("Deletion");
+    expect(view.container.querySelector('button[aria-label="Suspend"]')).toBeNull();
+
+    await act(async () => view.root.unmount());
+  });
 });

--- a/packages/web/src/pages/agent-detail/profile-tab.tsx
+++ b/packages/web/src/pages/agent-detail/profile-tab.tsx
@@ -27,7 +27,7 @@ export function ProfileTab() {
       />
       {/* Agent lifecycle is identity-level, so destructive controls stay at the
           end of Profile instead of mixing with runtime configuration. */}
-      {ctx.canManageAgent && (
+      {ctx.canManageAgent && ctx.agent.type !== "human" && (
         <DangerZone
           agent={ctx.agent}
           suspendPending={ctx.suspendPending}

--- a/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
+++ b/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
@@ -114,7 +114,7 @@ export function NewChatDraft({
    *  `@`-autocomplete results come from the server-search hook below so
    *  orgs above the 100-row cap can still reach every addable agent
    *  (issue 494). */
-  const { data: orgAgentsPage } = useOrgAgents();
+  const { data: orgAgentsPage } = useOrgAgents({ addressableOnly: true });
 
   /** Map of every uuid we have ever shown to the user this session —
    *  seeded from the first page and grown with each search round-trip
@@ -187,7 +187,7 @@ export function NewChatDraft({
   const trigger = useMemo(() => detectMentionTrigger(draft, cursor), [draft, cursor]);
   const triggerQuery = trigger?.query ?? "";
   const debouncedTriggerQuery = useDebouncedValue(triggerQuery, 100);
-  const { data: triggerSearchPage } = useOrgAgentsSearch(debouncedTriggerQuery);
+  const { data: triggerSearchPage } = useOrgAgentsSearch(debouncedTriggerQuery, { addressableOnly: true });
   useEffect(() => {
     if (!triggerSearchPage?.items) return;
     mergeKnown(triggerSearchPage.items);
@@ -200,7 +200,9 @@ export function NewChatDraft({
    *  hook dedupes by query key, so if both surfaces happen to search
    *  the same term React Query coalesces them into one fetch. */
   const debouncedPickerSearch = useDebouncedValue(pickerSearch, 200);
-  const { data: pickerSearchPage, isFetching: pickerFetching } = useOrgAgentsSearch(debouncedPickerSearch);
+  const { data: pickerSearchPage, isFetching: pickerFetching } = useOrgAgentsSearch(debouncedPickerSearch, {
+    addressableOnly: true,
+  });
   useEffect(() => {
     if (!pickerSearchPage?.items) return;
     mergeKnown(pickerSearchPage.items);


### PR DESCRIPTION
## Summary

- Preserve human member mirrors with a suspended mirror lifecycle instead of deleting the backing human agent identity.
- Add startup repair for active and inactive memberships whose human mirrors were previously left corrupt.
- Split visible versus addressable agent semantics so participant pickers, chat creation, and participant invites only target active agents, and human targets require an active backing membership.
- Make generic agent type updates immutable and reject public standalone human agent creation.
- Make admin member removal atomic around last-admin checks, fallback manager selection, transfer, and member deactivation.

## Validation

- [x] `pnpm --dir packages/shared exec vitest run --maxWorkers=2 src/__tests__/agent-name-schema.test.ts` - 18 passed
- [x] `pnpm --dir packages/server exec vitest run --maxWorkers=2 src/__tests__/members.test.ts src/__tests__/participant-invite.test.ts src/__tests__/agent-visibility.test.ts src/__tests__/me-onboarding.test.ts src/__tests__/admin-agents.test.ts src/__tests__/agent-identity.test.ts src/__tests__/agent-quota.test.ts src/__tests__/attachments-route.test.ts src/__tests__/agent-delegate-mention-source-type.test.ts` - 142 passed
- [x] `pnpm --dir packages/server exec vitest run --maxWorkers=2 src/__tests__/message-system-sender-strip.test.ts src/__tests__/messaging-e2e.test.ts src/__tests__/open-question.test.ts src/__tests__/participant-mode-backfill.test.ts src/__tests__/participant-mode-invariant.test.ts` - 37 passed
- [x] `pnpm --dir packages/server exec vitest run --maxWorkers=2 src/__tests__/inbox-ws-push.test.ts src/__tests__/message-dispatcher.test.ts` - 35 passed
- [x] `pnpm --dir packages/server exec vitest run --maxWorkers=2 src/__tests__/github-entities-agent-route.test.ts` - 4 passed
- [x] `pnpm --dir packages/server exec vitest run --maxWorkers=2` - 161 files / 1412 tests passed
- [x] `pnpm --dir packages/web exec vitest run --maxWorkers=2 src/api/__tests__/api-wrappers.test.ts src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx` - 18 passed, with existing ECONNREFUSED stderr in load-failure tests
- [x] `pnpm check` - exit 0, existing Biome info/warnings only
- [x] `pnpm typecheck`
- [x] `git diff --check`
- [x] Context Tree: `first-tree-staging tree verify`

## Change Surface

- [ ] `apps/cli` public CLI or help output
- [ ] tree onboarding / binding / inspection behavior
- [ ] shipped or planned skill topology
- [ ] docs or contributor-facing repository metadata
- [ ] CI / packaging / release plumbing

## Notes

- package or install behavior changes: none
- docs or tests updated to match: Context Tree PR https://github.com/agent-team-foundation/first-tree-context/pull/517 records the lifecycle decision
- follow-up work: `createAgent()` still supports internal human mirror creation for member bootstrap; a later cleanup can split that into a dedicated internal helper.
