### PR TITLE
fix(web): cap RequestDock height so long asks stay scrollable

### DIFF
--- a/packages/web/src/components/chat/request-dock.tsx
+++ b/packages/web/src/components/chat/request-dock.tsx
@@ -75,6 +75,15 @@ export function RequestDock({
         borderRadius: "var(--radius-panel)",
         background: "color-mix(in oklch, var(--state-needs-you) 4%, var(--bg-raised))",
         padding: "var(--sp-2_5) var(--sp-3)",
+        // The dock lives in the `shrink-0` composer footer, which has no scroll
+        // of its own. A long ask — many questions, or a legacy wall-of-text
+        // prompt the user expanded via "Show all" — would otherwise grow the
+        // dock past the viewport and push its own option list AND the composer
+        // off-screen with no way to reach them. Cap the height and scroll the
+        // dock internally so the options stay reachable and the composer below
+        // stays visible.
+        maxHeight: "min(40vh, 32rem)",
+        overflowY: "auto",
       }}
     >
       <div


### PR DESCRIPTION
## Problem

The **RequestDock** (the "Awaiting your answer" card pinned directly above the composer) lives in the `shrink-0` composer footer, which has no scroll of its own. The dock had no height constraint, so a long ask would grow it past the viewport and push its **own option list AND the composer off-screen**, with no way to reach them.

This bit a real request where a whole meeting-notes summary had been crammed into a single question's `prompt`; after the user clicked "Show all" to expand it, the option pills and the input box were unreachable.

## Fix

One file, two effective lines on the dock's root container:

```ts
maxHeight: "min(40vh, 32rem)",
overflowY: "auto",
```

- `min(40vh, 32rem)` — caps the card at 40% of viewport height (scales down on short screens, leaving room for the composer + timeline), with a 32rem absolute ceiling for very tall screens.
- `overflowY: auto` — long content scrolls **inside** the card; short asks never hit the cap, so their appearance is unchanged.

Pure CSS constraint — no logic touched (option pick / draft-derived selection / resolve-vs-judge send / "View context" jump all unchanged). The inline `RequestCard` in the timeline is unaffected (it already lives in the scrollable message area, and its answer block is suppressed while the dock is live).

## Verification

- `tsc --noEmit` clean
- 5/5 `request-dock-dom` tests pass
- biome clean
- `/preview/request-dock` legacy wall-of-text scenario (matches the reported case): after "Show all", card capped at 240px (40vh of a 900×600 viewport), `scrollHeight 357 > clientHeight 238` → scrolls internally; scrolling to the bottom reveals the option pills + composer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)