### PR TITLE
[codex] Fix Claude TUI suspend during resume prepare

### DIFF
--- a/packages/client/src/__tests__/tui-lifecycle-fence.test.ts
+++ b/packages/client/src/__tests__/tui-lifecycle-fence.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { TuiLifecycleFence } from "../handlers/claude-code-tui/index.js";
+
+describe("TuiLifecycleFence", () => {
+  it("makes a stop request visible to an in-flight lifecycle", async () => {
+    const fence = new TuiLifecycleFence();
+    let release!: () => void;
+    const prepared = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    const lifecycle = fence.run(async () => {
+      await prepared;
+      return fence.stopRequested ? "stopped-before-turn" : "run-turn";
+    });
+
+    expect(fence.active).toBe(lifecycle);
+    fence.requestStop();
+    expect(fence.stopRequested).toBe(true);
+
+    release();
+    await expect(lifecycle).resolves.toBe("stopped-before-turn");
+    expect(fence.active).toBeNull();
+  });
+
+  it("clears a previous stop request when the next lifecycle begins", async () => {
+    const fence = new TuiLifecycleFence();
+
+    fence.requestStop();
+    expect(fence.stopRequested).toBe(true);
+
+    await expect(fence.run(async () => fence.stopRequested)).resolves.toBe(false);
+    expect(fence.stopRequested).toBe(false);
+    expect(fence.active).toBeNull();
+  });
+});

--- a/packages/client/src/__tests__/tui-suspend-queued-recovery.test.ts
+++ b/packages/client/src/__tests__/tui-suspend-queued-recovery.test.ts
@@ -1,0 +1,223 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChatContext } from "../runtime/chat-context.js";
+import type { SessionContext, SessionMessage } from "../runtime/handler.js";
+import { mockCtxPlumbing } from "./test-helpers.js";
+
+const state = vi.hoisted(() => ({
+  workspaceRoot: "",
+  pasteTexts: [] as string[],
+  lastPasteOrdinal: 0,
+  emittedOrdinals: new Set<number>(),
+  chatContext: {
+    chatId: "chat-tui-suspend-queued-recovery",
+    title: "queued recovery",
+    topic: null,
+    description: null,
+    participants: [],
+  } satisfies ChatContext,
+}));
+
+vi.mock("../runtime/agent-bootstrap.js", () => ({
+  ensureAgentBootstrap: vi.fn(),
+}));
+
+vi.mock("../runtime/agent-briefing.js", () => ({
+  buildAgentBriefing: vi.fn(() => ""),
+}));
+
+vi.mock("../runtime/chat-context.js", () => ({
+  fetchChatContext: vi.fn(async () => state.chatContext),
+}));
+
+vi.mock("../runtime/context-tree-git-status.js", () => ({
+  createContextTreeGitWriteTracker: vi.fn(() => ({})),
+}));
+
+vi.mock("../runtime/source-repos.js", () => ({
+  currentSourceRepoNamesFromPayload: vi.fn(() => null),
+  declaredSourceRepos: vi.fn(() => []),
+}));
+
+vi.mock("../runtime/workspace.js", () => ({
+  acquireAgentHome: vi.fn(() => state.workspaceRoot),
+  markWorkspaceInitComplete: vi.fn(),
+}));
+
+vi.mock("../handlers/claude-code.js", () => ({
+  createToolCallProcessor: vi.fn(() => ({
+    flush: vi.fn(),
+    onMessage: vi.fn(),
+  })),
+  mapMcpServers: vi.fn(() => []),
+}));
+
+vi.mock("../handlers/claude-executable.js", () => ({
+  resolveClaudeCodeExecutable: vi.fn(() => ({ path: "/bin/claude-fake" })),
+}));
+
+vi.mock("../handlers/claude-code-tui/tmux-session.js", () => ({
+  capturePane: vi.fn(async () => (state.lastPasteOrdinal === 1 ? "esc to interrupt" : "")),
+  deriveSessionName: vi.fn(() => "ftth-test-session"),
+  killSession: vi.fn(async () => undefined),
+  listOwnedSessions: vi.fn(async () => []),
+  newSession: vi.fn(async () => undefined),
+  ownedSessionPrefix: vi.fn(() => "ftth-test-"),
+  pasteText: vi.fn(async (_sessionName: string, text: string) => {
+    state.pasteTexts.push(text);
+    state.lastPasteOrdinal = state.pasteTexts.length;
+  }),
+  sendKey: vi.fn(async () => undefined),
+  sessionExists: vi.fn(async () => false),
+  waitForReady: vi.fn(async () => undefined),
+}));
+
+vi.mock("../handlers/claude-code-tui/transcript-tail.js", () => ({
+  transcriptPathFor: vi.fn(() => "/tmp/fake-transcript.jsonl"),
+  TranscriptTailer: class {
+    drainEntries() {
+      const ordinal = state.lastPasteOrdinal;
+      if (ordinal < 2 || state.emittedOrdinals.has(ordinal)) return [];
+      state.emittedOrdinals.add(ordinal);
+      return [
+        {
+          type: "assistant",
+          message: {
+            content: [{ type: "text", text: `reply ${ordinal}` }],
+          },
+        },
+      ];
+    }
+  },
+}));
+
+import { createClaudeCodeTuiHandler } from "../handlers/claude-code-tui/index.js";
+
+const AGENT_ID = "019eca71-0000-7000-8000-000000000001";
+const CHAT_ID = "chat-tui-suspend-queued-recovery";
+
+function makeMessage(id: string, content: string): SessionMessage {
+  return {
+    id,
+    chatId: CHAT_ID,
+    senderId: "sender-1",
+    format: "text",
+    content,
+    metadata: {},
+    inboxEntryId: Number(id.replace(/\D/g, "")),
+  };
+}
+
+function makeContext(opts: { formatInboundContent?: SessionContext["formatInboundContent"] } = {}): SessionContext {
+  const sendMessage = vi.fn().mockResolvedValue(undefined);
+  const plumbing = mockCtxPlumbing({ sendMessage }, CHAT_ID);
+  return {
+    agent: {
+      agentId: AGENT_ID,
+      inboxId: `inbox_${AGENT_ID}`,
+      displayName: "tui-agent",
+      type: "agent",
+      visibility: "organization",
+      delegateMention: null,
+      metadata: {},
+    },
+    sdk: { serverUrl: "http://test", sendMessage } as unknown as SessionContext["sdk"],
+    chatId: CHAT_ID,
+    log: () => {},
+    recordProviderActivity: () => {},
+    emitEvent: () => {},
+    ...plumbing,
+    ...(opts.formatInboundContent ? { formatInboundContent: opts.formatInboundContent } : {}),
+    finishTurn: vi.fn(plumbing.finishTurn),
+    retryTurn: vi.fn(plumbing.retryTurn),
+  };
+}
+
+async function waitFor(assertion: () => boolean): Promise<void> {
+  const deadline = Date.now() + 2_000;
+  while (!assertion()) {
+    if (Date.now() > deadline) throw new Error("timed out waiting for assertion");
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+beforeEach(() => {
+  state.workspaceRoot = mkdtempSync(join(tmpdir(), "ft-tui-suspend-queue-"));
+  state.pasteTexts.length = 0;
+  state.lastPasteOrdinal = 0;
+  state.emittedOrdinals.clear();
+});
+
+afterEach(() => {
+  rmSync(state.workspaceRoot, { recursive: true, force: true });
+});
+
+describe("claude-code-tui suspend queued recovery", () => {
+  it("drops handler-local queued injects on suspend so recovered messages are not pasted twice", async () => {
+    const handler = createClaudeCodeTuiHandler({ workspaceRoot: state.workspaceRoot, clientId: "client-test" });
+    const ctx = makeContext();
+    const first = makeMessage("m1", "active turn");
+    const recovered = makeMessage("m2", "queued recovered turn");
+
+    const start = handler.start(first, ctx);
+    await waitFor(() => state.pasteTexts.some((text) => text.includes("active turn")));
+
+    handler.inject(recovered);
+    await handler.suspend();
+    const sessionId = await start;
+
+    await handler.resume(recovered, sessionId, ctx);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const recoveredPastes = state.pasteTexts.filter((text) => text.includes("queued recovered turn"));
+    expect(recoveredPastes).toHaveLength(1);
+
+    const finishTurn = vi.mocked(ctx.finishTurn);
+    const recoveredFinishes = finishTurn.mock.calls.filter((call) => {
+      const messages = Array.isArray(call[0]) ? call[0] : [call[0]];
+      return messages.some((message) => message.id === recovered.id);
+    });
+    expect(recoveredFinishes).toHaveLength(1);
+
+    await handler.shutdown();
+  });
+
+  it("does not paste a drained queued batch when suspend arrives during formatting", async () => {
+    const handler = createClaudeCodeTuiHandler({ workspaceRoot: state.workspaceRoot, clientId: "client-test" });
+    const queued = makeMessage("m2", "format-held queued turn");
+    let formattingStarted = false;
+    let releaseFormat!: () => void;
+    const formatGate = new Promise<void>((resolve) => {
+      releaseFormat = resolve;
+    });
+    const ctx = makeContext({
+      formatInboundContent: async (message) => {
+        if (message.id === queued.id) {
+          formattingStarted = true;
+          await formatGate;
+        }
+        const raw = typeof message.content === "string" ? message.content : JSON.stringify(message.content);
+        return `[From: ${message.senderId}]\n\n${raw}`;
+      },
+    });
+
+    await handler.resume(undefined, "existing-session", ctx);
+
+    handler.inject(queued);
+    await waitFor(() => formattingStarted);
+
+    const suspend = handler.suspend();
+    await Promise.resolve();
+    releaseFormat();
+    await suspend;
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(state.pasteTexts.some((text) => text.includes("format-held queued turn"))).toBe(false);
+    expect(ctx.finishTurn).not.toHaveBeenCalled();
+    expect(ctx.retryTurn).toHaveBeenCalledWith([queued], "queued_turn_stopped_before_paste");
+
+    await handler.shutdown();
+  });
+});

--- a/packages/client/src/handlers/claude-code-tui/index.ts
+++ b/packages/client/src/handlers/claude-code-tui/index.ts
@@ -56,6 +56,33 @@ function shellQuote(value: string): string {
   return `'${value.replace(/'/g, "'\\''")}'`;
 }
 
+export class TuiLifecycleFence {
+  private activePromise: Promise<unknown> | null = null;
+  private requestedStop = false;
+
+  get active(): Promise<unknown> | null {
+    return this.activePromise;
+  }
+
+  get stopRequested(): boolean {
+    return this.requestedStop;
+  }
+
+  requestStop(): void {
+    this.requestedStop = true;
+  }
+
+  run<T>(body: () => Promise<T>): Promise<T> {
+    this.requestedStop = false;
+    const promise = (async () => body())();
+    const tracked = promise.finally(() => {
+      if (this.activePromise === tracked) this.activePromise = null;
+    });
+    this.activePromise = tracked;
+    return tracked;
+  }
+}
+
 /**
  * Module-level lazy sweep: on first handler instantiation in this process, kill
  * tmux sessions left over from a prior crashed run of THIS client.
@@ -113,6 +140,7 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
   let tmuxSessionName: string | null = null;
   let transcriptTailer: TranscriptTailer | null = null;
   let currentTurnPromise: Promise<void> | null = null;
+  const lifecycleFence = new TuiLifecycleFence();
   let turnAborted = false;
   // True for the whole span a turn is being prepared/run — start/resume
   // bootstrap through turn completion, or a queued-message turn. This is the
@@ -480,7 +508,7 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
    * so a concurrent `suspend()` awaits the turn instead of tearing it down.
    */
   function pump(): void {
-    if (turnRunning || queuedMessages.length === 0) return;
+    if (turnRunning || lifecycleFence.stopRequested || queuedMessages.length === 0) return;
     const sessionCtx = ctx;
     if (!sessionCtx || !tmuxSessionName) return;
     const drained = queuedMessages.splice(0);
@@ -493,6 +521,14 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
         } catch (err) {
           sessionCtx.log(`tui inject formatInboundContent failed: ${err instanceof Error ? err.message : String(err)}`);
         }
+        if (lifecycleFence.stopRequested) {
+          retryQueuedMessagesForRecovery(sessionCtx, drained, "queued_turn_stopped_before_paste");
+          return;
+        }
+      }
+      if (lifecycleFence.stopRequested) {
+        retryQueuedMessagesForRecovery(sessionCtx, drained, "queued_turn_stopped_before_paste");
+        return;
       }
       if (inputs.length === 0) {
         await sessionCtx.finishTurn(drained, { status: "error", terminal: true, errorKind: "deterministic" });
@@ -512,6 +548,23 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
         // recursion off the stack and lets the just-cleared flags settle.
         setImmediate(pump);
       });
+  }
+
+  function retryQueuedMessagesForRecovery(
+    sessionCtx: SessionContext,
+    messages: readonly SessionMessage[],
+    reason: string,
+  ): void {
+    if (messages.length === 0) return;
+    sessionCtx.log(`tui ${reason}: retrying ${messages.length} queued message(s) through inbox recovery`);
+    sessionCtx.retryTurn(messages, reason);
+  }
+
+  function dropQueuedMessagesForRecovery(reason: string): void {
+    if (queuedMessages.length > 0) {
+      ctx?.log(`tui ${reason}: dropping ${queuedMessages.length} queued message(s) for inbox recovery`);
+      queuedMessages.length = 0;
+    }
   }
 
   function sleep(ms: number): Promise<void> {
@@ -538,108 +591,134 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
     configTempDir = null;
   }
 
+  async function waitForStopFence(): Promise<void> {
+    const activeLifecycle = lifecycleFence.active;
+    const activeTurn = currentTurnPromise;
+    if ((activeTurn || !activeLifecycle) && tmuxSessionName) {
+      try {
+        await sendKey(tmuxSessionName, "Escape");
+      } catch {
+        /* best-effort */
+      }
+    }
+    try {
+      await (activeLifecycle ?? activeTurn);
+    } catch {
+      /* swallow */
+    }
+    currentTurnPromise = null;
+  }
+
   return {
     async start(message, sessionCtx) {
-      // Hold turnRunning across the whole bootstrap so an inject arriving while
-      // the session is still being prepared queues instead of racing pump()
-      // into a second turn the instant startClaude sets tmuxSessionName.
-      turnRunning = true;
-      try {
-        await orphanSweep(clientId);
-        ctx = sessionCtx;
-        cwd = acquireAgentHome(workspaceRoot);
-
-        const resolvedPayload = await loadPayload(sessionCtx);
-        const payload = resolvedPayload ?? defaultPayload();
-
-        // Per-chat material flows through the unified briefing
-        // (`<cwd>/AGENTS.md`, with `<cwd>/CLAUDE.md` symlinked to it). Resolve
-        // chat-context and source repos BEFORE bootstrap so the briefing the
-        // shared `ensureAgentBootstrap` materialises is fully populated; claude
-        // then reads CLAUDE.md once on spawn via `--setting-sources project`.
-        chatContextForPrompt = await fetchChatContextOrLog(sessionCtx);
-        // Pure declaration — the agent itself clones/refreshes the repos per
-        // its briefing protocol; the listed paths may not exist yet.
-        sourceReposForPrompt = declaredSourceRepos(cwd, payload);
-        await materializeResourceSkills(cwd, payload, sessionCtx);
-        ensureAgentBootstrap({
-          workspace: cwd,
-          sessionCtx,
-          contextTreePath,
-          briefing: buildBriefing(sessionCtx, payload, cwd),
-          // `null` when we fell back to `defaultPayload()` — the empty
-          // `gitRepos: []` is then NOT authoritative, and the workspace
-          // manifest write is deferred for this session.
-          currentSourceRepoNames: currentSourceRepoNamesFromPayload(
-            payload,
-            resolvedPayload !== null && resolvedPayload !== undefined,
-          ),
-        });
-        markWorkspaceInitComplete(cwd);
-
-        const sessionId = await startClaude({ sessionCtx, resumeSessionId: null });
-
-        const inputText = await sessionCtx.formatInboundContent(message);
-        currentTurnPromise = runTurn(inputText, sessionCtx, [message]);
+      return lifecycleFence.run(async () => {
+        // Hold turnRunning across the whole bootstrap so an inject arriving while
+        // the session is still being prepared queues instead of racing pump()
+        // into a second turn the instant startClaude sets tmuxSessionName.
+        turnRunning = true;
         try {
-          await currentTurnPromise;
-        } finally {
-          currentTurnPromise = null;
-        }
-        return sessionId;
-      } finally {
-        turnRunning = false;
-        // Drain any messages injected during bootstrap / the first turn.
-        setImmediate(pump);
-      }
-    },
+          await orphanSweep(clientId);
+          ctx = sessionCtx;
+          cwd = acquireAgentHome(workspaceRoot);
 
-    async resume(message, sessionId, sessionCtx) {
-      turnRunning = true;
-      try {
-        await orphanSweep(clientId);
-        ctx = sessionCtx;
-        cwd = acquireAgentHome(workspaceRoot);
+          const resolvedPayload = await loadPayload(sessionCtx);
+          const payload = resolvedPayload ?? defaultPayload();
 
-        const resumePayloadResolved = await loadPayload(sessionCtx);
-        const payload = resumePayloadResolved ?? defaultPayload();
+          // Per-chat material flows through the unified briefing
+          // (`<cwd>/AGENTS.md`, with `<cwd>/CLAUDE.md` symlinked to it). Resolve
+          // chat-context and source repos BEFORE bootstrap so the briefing the
+          // shared `ensureAgentBootstrap` materialises is fully populated; claude
+          // then reads CLAUDE.md once on spawn via `--setting-sources project`.
+          chatContextForPrompt = await fetchChatContextOrLog(sessionCtx);
+          // Pure declaration — the agent itself clones/refreshes the repos per
+          // its briefing protocol; the listed paths may not exist yet.
+          sourceReposForPrompt = declaredSourceRepos(cwd, payload);
+          await materializeResourceSkills(cwd, payload, sessionCtx);
+          ensureAgentBootstrap({
+            workspace: cwd,
+            sessionCtx,
+            contextTreePath,
+            briefing: buildBriefing(sessionCtx, payload, cwd),
+            // `null` when we fell back to `defaultPayload()` — the empty
+            // `gitRepos: []` is then NOT authoritative, and the workspace
+            // manifest write is deferred for this session.
+            currentSourceRepoNames: currentSourceRepoNamesFromPayload(
+              payload,
+              resolvedPayload !== null && resolvedPayload !== undefined,
+            ),
+          });
+          markWorkspaceInitComplete(cwd);
 
-        chatContextForPrompt = await fetchChatContextOrLog(sessionCtx);
-        // Pure declaration — same as the start() path.
-        sourceReposForPrompt = declaredSourceRepos(cwd, payload);
-        await materializeResourceSkills(cwd, payload, sessionCtx);
-        // Same shared bootstrap as start(): ensureAgentBootstrap handles the
-        // sentinel + CLI-version drift internally, so a stale or failed
-        // integration is re-run on resume instead of being skipped.
-        ensureAgentBootstrap({
-          workspace: cwd,
-          sessionCtx,
-          contextTreePath,
-          briefing: buildBriefing(sessionCtx, payload, cwd),
-          // See PR #869 baixiaohang round-3 P0 — same gate as start().
-          currentSourceRepoNames: currentSourceRepoNamesFromPayload(
-            payload,
-            resumePayloadResolved !== null && resumePayloadResolved !== undefined,
-          ),
-        });
-        markWorkspaceInitComplete(cwd);
+          const sessionId = await startClaude({ sessionCtx, resumeSessionId: null });
+          if (lifecycleFence.stopRequested) return sessionId;
 
-        const restartedId = await startClaude({ sessionCtx, resumeSessionId: sessionId });
-
-        if (message) {
           const inputText = await sessionCtx.formatInboundContent(message);
+          if (lifecycleFence.stopRequested) return sessionId;
           currentTurnPromise = runTurn(inputText, sessionCtx, [message]);
           try {
             await currentTurnPromise;
           } finally {
             currentTurnPromise = null;
           }
+          return sessionId;
+        } finally {
+          turnRunning = false;
+          // Drain any messages injected during bootstrap / the first turn.
+          setImmediate(pump);
         }
-        return restartedId;
-      } finally {
-        turnRunning = false;
-        setImmediate(pump);
-      }
+      });
+    },
+
+    async resume(message, sessionId, sessionCtx) {
+      return lifecycleFence.run(async () => {
+        turnRunning = true;
+        try {
+          await orphanSweep(clientId);
+          ctx = sessionCtx;
+          cwd = acquireAgentHome(workspaceRoot);
+
+          const resumePayloadResolved = await loadPayload(sessionCtx);
+          const payload = resumePayloadResolved ?? defaultPayload();
+
+          chatContextForPrompt = await fetchChatContextOrLog(sessionCtx);
+          // Pure declaration — same as the start() path.
+          sourceReposForPrompt = declaredSourceRepos(cwd, payload);
+          await materializeResourceSkills(cwd, payload, sessionCtx);
+          // Same shared bootstrap as start(): ensureAgentBootstrap handles the
+          // sentinel + CLI-version drift internally, so a stale or failed
+          // integration is re-run on resume instead of being skipped.
+          ensureAgentBootstrap({
+            workspace: cwd,
+            sessionCtx,
+            contextTreePath,
+            briefing: buildBriefing(sessionCtx, payload, cwd),
+            // See PR #869 baixiaohang round-3 P0 — same gate as start().
+            currentSourceRepoNames: currentSourceRepoNamesFromPayload(
+              payload,
+              resumePayloadResolved !== null && resumePayloadResolved !== undefined,
+            ),
+          });
+          markWorkspaceInitComplete(cwd);
+
+          const restartedId = await startClaude({ sessionCtx, resumeSessionId: sessionId });
+
+          if (message) {
+            if (lifecycleFence.stopRequested) return restartedId;
+            const inputText = await sessionCtx.formatInboundContent(message);
+            if (lifecycleFence.stopRequested) return restartedId;
+            currentTurnPromise = runTurn(inputText, sessionCtx, [message]);
+            try {
+              await currentTurnPromise;
+            } finally {
+              currentTurnPromise = null;
+            }
+          }
+          return restartedId;
+        } finally {
+          turnRunning = false;
+          setImmediate(pump);
+        }
+      });
     },
 
     inject(message) {
@@ -652,38 +731,20 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
     },
 
     async suspend() {
+      lifecycleFence.requestStop();
       turnAborted = true;
-      if (tmuxSessionName) {
-        try {
-          await sendKey(tmuxSessionName, "Escape");
-        } catch {
-          /* best-effort */
-        }
-      }
-      try {
-        await currentTurnPromise;
-      } catch {
-        /* swallow */
-      }
-      currentTurnPromise = null;
+      dropQueuedMessagesForRecovery("suspend");
+      await waitForStopFence();
+      dropQueuedMessagesForRecovery("suspend");
       await teardownTmux();
     },
 
     async shutdown() {
+      lifecycleFence.requestStop();
       turnAborted = true;
-      if (tmuxSessionName) {
-        try {
-          await sendKey(tmuxSessionName, "Escape");
-        } catch {
-          /* best-effort */
-        }
-      }
-      try {
-        await currentTurnPromise;
-      } catch {
-        /* swallow */
-      }
-      currentTurnPromise = null;
+      dropQueuedMessagesForRecovery("shutdown");
+      await waitForStopFence();
+      dropQueuedMessagesForRecovery("shutdown");
       await teardownTmux();
 
       // Per agent-session-cwd-redesign: cwd is the per-agent home — shared

--- a/packages/e2e/src/framework/runtime-tui-fixture.ts
+++ b/packages/e2e/src/framework/runtime-tui-fixture.ts
@@ -29,6 +29,8 @@ export const FAKE_CLAUDE_TUI_EXECUTABLE = resolve(PACKAGE_E2E_ROOT, "src/mocks/f
 export type FakeTuiAgentKnobs = {
   /** Canned reply override (FAKE_TUI_REPLY). */
   reply?: string;
+  /** Delay before advertising ready (FAKE_TUI_READY_DELAY_MS). */
+  readyDelayMs?: number;
   /** Pre-emit delay (FAKE_TUI_DELAY_MS). */
   delayMs?: number;
   /** Never paint the ready marker (FAKE_TUI_FAIL_READY=1). */
@@ -48,6 +50,12 @@ export type CreateTuiAgentInput = {
   displayName?: string;
   /** Behaviour knobs forwarded to the fake-tui binary via per-agent env. */
   knobs?: FakeTuiAgentKnobs;
+  /**
+   * Real-provider parity uses the product path: create the agent already bound
+   * to the client. Fake TUI tests can opt into patching env first so the first
+   * pinned-frame config load cannot miss fake-only knobs like readyDelayMs.
+   */
+  bindMode?: "at-create" | "after-env-patch";
   /** Optional override of where the fake-tui side-channel log lands. */
   logPath?: string;
 };
@@ -87,6 +95,7 @@ function knobsToEnvEntries(knobs: FakeTuiAgentKnobs, logPath: string): Array<{ k
   const env: Array<{ key: string; value: string }> = [];
   env.push({ key: "FAKE_TUI_LOG_PATH", value: logPath });
   if (knobs.reply !== undefined) env.push({ key: "FAKE_TUI_REPLY", value: knobs.reply });
+  if (knobs.readyDelayMs !== undefined) env.push({ key: "FAKE_TUI_READY_DELAY_MS", value: String(knobs.readyDelayMs) });
   if (knobs.delayMs !== undefined) env.push({ key: "FAKE_TUI_DELAY_MS", value: String(knobs.delayMs) });
   if (knobs.failReady) env.push({ key: "FAKE_TUI_FAIL_READY", value: "1" });
   if (knobs.hang) env.push({ key: "FAKE_TUI_HANG", value: "1" });
@@ -105,6 +114,7 @@ function knobsToEnvEntries(knobs: FakeTuiAgentKnobs, logPath: string): Array<{ k
 export async function createTuiAgent(input: CreateTuiAgentInput): Promise<TuiAgentFixture> {
   const creds = readCredentialsOrThrow(input.handle);
   const knobs = input.knobs ?? {};
+  const bindMode = input.bindMode ?? "at-create";
   const agentName = `tui-${randomBytes(3).toString("hex")}`;
   const logPath = input.logPath ?? defaultLogPath(input.handle, agentName);
   mkdirSync(dirname(logPath), { recursive: true });
@@ -117,7 +127,7 @@ export async function createTuiAgent(input: CreateTuiAgentInput): Promise<TuiAge
     name: agentName,
     type: "agent",
     displayName: input.displayName ?? `TUI fixture ${agentName}`,
-    clientId: creds.clientId,
+    ...(bindMode === "at-create" ? { clientId: creds.clientId } : {}),
     runtimeProvider: "claude-code-tui",
   });
   let created: { uuid: string } | null = null;
@@ -155,6 +165,14 @@ export async function createTuiAgent(input: CreateTuiAgentInput): Promise<TuiAge
     agentId: created.uuid,
     envEntries: knobsToEnvEntries(knobs, logPath),
   });
+  if (bindMode === "after-env-patch") {
+    await bindAgentToClient({
+      handle: input.handle,
+      accessToken: creds.accessToken,
+      agentId: created.uuid,
+      clientId: creds.clientId,
+    });
+  }
 
   const chatRes = await fetch(`${input.handle.serverBaseUrl}/api/v1/orgs/${creds.organizationId}/chats`, {
     method: "POST",
@@ -291,6 +309,22 @@ async function patchAgentRuntimeEnv(input: {
   });
   if (patchRes.status !== 200) {
     throw new Error(`patch runtime env failed: ${patchRes.status} ${await patchRes.text()}`);
+  }
+}
+
+async function bindAgentToClient(input: {
+  handle: CurrentRunHandle;
+  accessToken: string;
+  agentId: string;
+  clientId: string;
+}): Promise<void> {
+  const res = await fetch(`${input.handle.serverBaseUrl}/api/v1/agents/${input.agentId}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${input.accessToken}` },
+    body: JSON.stringify({ clientId: input.clientId }),
+  });
+  if (res.status !== 200) {
+    throw new Error(`bind tui agent to client failed: ${res.status} ${await res.text()}`);
   }
 }
 

--- a/packages/e2e/src/mocks/fake-claude-tui.mjs
+++ b/packages/e2e/src/mocks/fake-claude-tui.mjs
@@ -28,6 +28,8 @@
 // per agent via FIRST_TREE_HOME-scoped env):
 //
 //   FAKE_TUI_REPLY                — canned reply text (default: echoes input)
+//   FAKE_TUI_READY_DELAY_MS       — pre-ready delay; useful for suspend /
+//                                   resume preparation race tests
 //   FAKE_TUI_DELAY_MS             — pre-emit delay; useful for timeout tests
 //   FAKE_TUI_FAIL_READY=1         — never print the ready marker (probe a
 //                                   waitForReady timeout)
@@ -71,6 +73,7 @@ const resumeId = readFlag("--resume") ?? null;
 const sessionId = readFlag("--session-id") ?? resumeId ?? randomUUID();
 
 const REPLY = process.env.FAKE_TUI_REPLY ?? null;
+const READY_DELAY_MS = Number(process.env.FAKE_TUI_READY_DELAY_MS ?? "0");
 const DELAY_MS = Number(process.env.FAKE_TUI_DELAY_MS ?? "0");
 const FAIL_READY = process.env.FAKE_TUI_FAIL_READY === "1";
 const HANG = process.env.FAKE_TUI_HANG === "1";
@@ -385,6 +388,7 @@ async function main() {
   process.stdout.write("\x1b[?2004h");
   // Paint the ready surface: bypass-permissions marker + the `❯ ` prompt
   // line. waitForReady requires both.
+  await sleep(READY_DELAY_MS);
   paint(READY_MARKER);
   paint("❯ "); // NBSP: tmux capture-pane trims trailing ASCII space, NBSP survives — handler's USER_RE matches either
   logEvent("ready");

--- a/packages/e2e/src/tests/tui-askuser-disallowed.e2e.test.ts
+++ b/packages/e2e/src/tests/tui-askuser-disallowed.e2e.test.ts
@@ -28,6 +28,7 @@ beforeAll(async () => {
   fixture = await createTuiAgent({
     handle,
     displayName: "tui-askuser-disallowed agent",
+    bindMode: "after-env-patch",
   });
 });
 

--- a/packages/e2e/src/tests/tui-crash-recovery.e2e.test.ts
+++ b/packages/e2e/src/tests/tui-crash-recovery.e2e.test.ts
@@ -33,6 +33,7 @@ beforeAll(async () => {
   fixture = await createTuiAgent({
     handle,
     displayName: "tui-crash-recovery agent",
+    bindMode: "after-env-patch",
     knobs: { crashAfterTurns: 1 },
   });
 });

--- a/packages/e2e/src/tests/tui-orphan-sweep.e2e.test.ts
+++ b/packages/e2e/src/tests/tui-orphan-sweep.e2e.test.ts
@@ -39,7 +39,11 @@ let foreignSessionName: string;
 beforeAll(async () => {
   handle = await setupOwnTuiWorld();
   const creds = readCredentialsOrThrow(handle);
-  fixture = await createTuiAgent({ handle, displayName: "tui-orphan-sweep agent" });
+  fixture = await createTuiAgent({
+    handle,
+    displayName: "tui-orphan-sweep agent",
+    bindMode: "after-env-patch",
+  });
 
   // Plant two stale sessions:
   //   - one with the daemon's own prefix (should be swept)

--- a/packages/e2e/src/tests/tui-restart-resume.e2e.test.ts
+++ b/packages/e2e/src/tests/tui-restart-resume.e2e.test.ts
@@ -37,6 +37,7 @@ beforeAll(async () => {
   hangFixture = await createTuiAgent({
     handle,
     displayName: "tui-restart-resume hanging agent",
+    bindMode: "after-env-patch",
     knobs: { hang: true },
   });
 }, 120_000);

--- a/packages/e2e/src/tests/tui-runtime-basic.e2e.test.ts
+++ b/packages/e2e/src/tests/tui-runtime-basic.e2e.test.ts
@@ -23,7 +23,11 @@ let fixture: TuiAgentFixture;
 
 beforeAll(async () => {
   const handle = readCurrentHandle();
-  fixture = await createTuiAgent({ handle, displayName: "tui-runtime-basic agent" });
+  fixture = await createTuiAgent({
+    handle,
+    displayName: "tui-runtime-basic agent",
+    bindMode: "after-env-patch",
+  });
 });
 
 afterAll(async () => {

--- a/packages/e2e/src/tests/tui-runtime-resume.e2e.test.ts
+++ b/packages/e2e/src/tests/tui-runtime-resume.e2e.test.ts
@@ -24,7 +24,11 @@ let fixture: TuiAgentFixture;
 
 beforeAll(async () => {
   const handle = readCurrentHandle();
-  fixture = await createTuiAgent({ handle, displayName: "tui-runtime-resume agent" });
+  fixture = await createTuiAgent({
+    handle,
+    displayName: "tui-runtime-resume agent",
+    bindMode: "after-env-patch",
+  });
 });
 
 describe("tui-runtime-resume — suspended session resumes and forwards output", () => {

--- a/packages/e2e/src/tests/tui-runtime-suspend-race.e2e.test.ts
+++ b/packages/e2e/src/tests/tui-runtime-suspend-race.e2e.test.ts
@@ -1,0 +1,86 @@
+import { Client as PgClient } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { execCli } from "../framework/cli-driver/exec.js";
+import { type CurrentRunHandle, readCurrentHandle } from "../framework/current-handle.js";
+import {
+  createTuiAgent,
+  sendUserMessageToTuiAgent,
+  type TuiAgentFixture,
+  waitForAgentReply,
+} from "../framework/runtime-tui-fixture.js";
+
+let handle: CurrentRunHandle;
+let fixture: TuiAgentFixture;
+let pg: PgClient;
+
+beforeAll(async () => {
+  handle = readCurrentHandle();
+  pg = new PgClient({ connectionString: handle.databaseUrl });
+  await pg.connect();
+  fixture = await createTuiAgent({
+    handle,
+    displayName: "tui-runtime-suspend-race agent",
+    bindMode: "after-env-patch",
+    knobs: { readyDelayMs: 2_500 },
+  });
+});
+
+afterAll(async () => {
+  await pg.end().catch(() => undefined);
+});
+
+async function suspendFixtureSession(): Promise<void> {
+  const suspend = await execCli({
+    home: handle.clientHome,
+    serverBaseUrl: handle.serverBaseUrl,
+    args: ["agent", "session", "suspend", fixture.agentName, fixture.chatId],
+    timeoutMs: 30_000,
+  });
+  expect(suspend.exitCode).toBe(0);
+}
+
+describe("tui-runtime-suspend-race — suspend while resume is preparing", () => {
+  it("does not tear down a preparing tmux session and then call runTurn", { timeout: 120_000 }, async () => {
+    const firstExpected = "FT_E2E_TUI_SUSPEND_RACE_FIRST";
+    const first = await sendUserMessageToTuiAgent({
+      handle,
+      chatId: fixture.chatId,
+      mentionAgentId: fixture.agentId,
+      text: `first turn, include ${firstExpected}`,
+    });
+    const firstReplies = await waitForAgentReply({
+      handle,
+      chatId: fixture.chatId,
+      afterMessageId: first.id,
+      predicate: (m) => m.content.includes(firstExpected),
+      timeoutMs: 60_000,
+    });
+    expect(firstReplies.length).toBeGreaterThan(0);
+
+    await suspendFixtureSession();
+
+    await sendUserMessageToTuiAgent({
+      handle,
+      chatId: fixture.chatId,
+      mentionAgentId: fixture.agentId,
+      text: "resume while a second suspend arrives",
+    });
+
+    await fixture.fakeLog.waitUntil((events) => events.some((e) => e.kind === "start" && e.resumeId), {
+      timeoutMs: 45_000,
+      label: "resume fake started",
+    });
+    await suspendFixtureSession();
+
+    await new Promise((r) => setTimeout(r, 3_000));
+
+    const rows = await pg.query<{ payload: { message?: string } }>(
+      "SELECT payload FROM session_events WHERE chat_id = $1 AND kind = 'error' ORDER BY seq",
+      [fixture.chatId],
+    );
+    const errorText = rows.rows.map((row) => row.payload.message ?? "").join("\n");
+    expect(errorText).not.toContain("runTurn called before session was prepared");
+    expect(errorText).not.toContain("paste-buffer");
+    expect(errorText).not.toContain("resilience.session.retry_scheduled");
+  });
+});

--- a/packages/e2e/src/tests/tui-runtime-tool-call.e2e.test.ts
+++ b/packages/e2e/src/tests/tui-runtime-tool-call.e2e.test.ts
@@ -34,6 +34,7 @@ beforeAll(async () => {
   fixture = await createTuiAgent({
     handle,
     displayName: "tui-runtime-tool-call agent",
+    bindMode: "after-env-patch",
     knobs: { emitToolCall: true },
   });
 });

--- a/packages/e2e/src/tests/tui-tmux-lifecycle.e2e.test.ts
+++ b/packages/e2e/src/tests/tui-tmux-lifecycle.e2e.test.ts
@@ -36,7 +36,11 @@ let fixture: TuiAgentFixture;
 
 beforeAll(async () => {
   handle = await setupOwnTuiWorld();
-  fixture = await createTuiAgent({ handle, displayName: "tui-tmux-lifecycle agent" });
+  fixture = await createTuiAgent({
+    handle,
+    displayName: "tui-tmux-lifecycle agent",
+    bindMode: "after-env-patch",
+  });
 }, 120_000);
 
 afterAll(async () => {


### PR DESCRIPTION
## Summary

Fixes a follow-up Claude Code TUI race after #1056: a second suspend can arrive while a resumed TUI session is still preparing, before the first resumed turn has installed `currentTurnPromise`. The old suspend path could tear down tmux during that preparation window, then resume would continue into `runTurn` and hit `runTurn called before session was prepared` / tmux `paste-buffer ... no server running` retry symptoms.

This PR adds a lifecycle fence around TUI start/resume preparation through the first turn, so suspend/shutdown waits for the active lifecycle before tearing down tmux. It also fences queued inject recovery: messages still in the handler-local queue are dropped on suspend/shutdown, and queued batches already drained by `pump()` but still awaiting async formatting are retried through inbox recovery before any paste/finish path.

## Changes

- Add `TuiLifecycleFence` to serialize TUI start/resume preparation against suspend/shutdown teardown.
- Make suspend/shutdown request stop, wait for the active lifecycle/turn, then tear down tmux.
- Stop queued pumps once a stop is requested.
- Drop handler-local `queuedMessages` on suspend/shutdown so unconsumed inbox entries are recovered by the server instead of replayed locally.
- Recheck the stop fence after queued-batch formatting and before `runTurn`; stopped drained batches call `retryTurn(..., "queued_turn_stopped_before_paste")` instead of pasting.
- Keep #1056 resume argv behavior intact: fresh sessions use `--session-id`; resume uses only `--resume`.
- Add focused lifecycle and queued-recovery unit coverage.
- Add a TUI e2e regression for suspend arriving while resume is still preparing.
- Keep `createTuiAgent` default behavior aligned with the real product path (`clientId` bound at create), while fake TUI tests explicitly opt into `after-env-patch` binding so fake-only env knobs cannot race `agent:pinned` config loading.

## Validation

Self-check after updating onto latest `origin/main`:

- `pnpm --filter @first-tree/client exec vitest run src/__tests__/tui-lifecycle-fence.test.ts src/__tests__/tui-claude-command.test.ts src/__tests__/tui-tmux-session.test.ts src/__tests__/tui-transcript-tail.test.ts src/__tests__/tui-turn-disposition.test.ts`
- `pnpm --filter @first-tree/client typecheck`
- `pnpm --filter @first-tree/e2e typecheck`
- `pnpm exec biome check packages/client/src/handlers/claude-code-tui/index.ts packages/client/src/__tests__/tui-lifecycle-fence.test.ts packages/e2e/src/framework/runtime-tui-fixture.ts packages/e2e/src/mocks/fake-claude-tui.mjs packages/e2e/src/tests/tui-runtime-suspend-race.e2e.test.ts`
- `pnpm --filter @first-tree/shared --filter @first-tree/client --filter first-tree-dev --filter @first-tree/server build`
- `TMPDIR=/tmp/ftqa-prrace03 E2E_TUI=1 E2E_WITH_CLIENT=1 E2E_RUN_ID=prrace03 E2E_PORT_MIN=35500 E2E_PORT_MAX=35599 pnpm --filter @first-tree/e2e exec vitest run --config vitest.tui.config.ts src/tests/tui-runtime-basic.e2e.test.ts src/tests/tui-runtime-resume.e2e.test.ts src/tests/tui-runtime-suspend-race.e2e.test.ts`

Additional validation after QA found the real-provider fixture gap:

- `pnpm --filter @first-tree/e2e typecheck`
- `pnpm exec biome check packages/e2e/src/framework/runtime-tui-fixture.ts packages/e2e/src/tests/tui-runtime-basic.e2e.test.ts packages/e2e/src/tests/tui-runtime-resume.e2e.test.ts packages/e2e/src/tests/tui-runtime-suspend-race.e2e.test.ts packages/e2e/src/tests/tui-runtime-tool-call.e2e.test.ts packages/e2e/src/tests/tui-crash-recovery.e2e.test.ts packages/e2e/src/tests/tui-tmux-lifecycle.e2e.test.ts packages/e2e/src/tests/tui-orphan-sweep.e2e.test.ts packages/e2e/src/tests/tui-askuser-disallowed.e2e.test.ts packages/e2e/src/tests/tui-restart-resume.e2e.test.ts`
- `TMPDIR=/tmp/ftqa-pr1061fix01 E2E_TUI=1 E2E_WITH_CLIENT=1 E2E_RUN_ID=fixqa01 E2E_PORT_MIN=35600 E2E_PORT_MAX=35699 pnpm --filter @first-tree/e2e exec vitest run --config vitest.tui.config.ts src/tests/tui-runtime-basic.e2e.test.ts src/tests/tui-runtime-resume.e2e.test.ts src/tests/tui-runtime-suspend-race.e2e.test.ts`
- Real Claude fixture runner against updated head: `FTQA_WORKTREE=/Users/yuezengwu/.first-tree-staging/data/workspaces/yzw-codex/worktrees/fix-tui-suspend-prepare-race FTQA_LABEL=codex-real-fixture-fix ... real-tui-resume-runner.ts` passed first start and resume replies with no fatal log matches.

Additional validation after queued-recovery review fixes on current head `974026ae`:

- `pnpm --filter @first-tree/client exec vitest run src/__tests__/tui-claude-command.test.ts src/__tests__/tui-lifecycle-fence.test.ts src/__tests__/tui-suspend-queued-recovery.test.ts src/__tests__/tui-transcript-tail.test.ts src/__tests__/tui-tmux-session.test.ts src/__tests__/tui-turn-disposition.test.ts` — 6 files / 31 tests passed.
- `pnpm --filter @first-tree/client typecheck`
- `pnpm --filter @first-tree/e2e typecheck`
- `pnpm exec biome check packages/client/src/handlers/claude-code-tui/index.ts packages/client/src/__tests__/tui-suspend-queued-recovery.test.ts`
- `pnpm --filter @first-tree/client build`
- `TMPDIR=/tmp/ftqa-pr1061-review2-fix-rerun E2E_TUI=1 E2E_WITH_CLIENT=1 E2E_RUN_ID=rvfix03 E2E_PORT_MIN=36100 E2E_PORT_MAX=36199 pnpm --filter @first-tree/e2e exec vitest run --config vitest.tui.config.ts src/tests/tui-runtime-basic.e2e.test.ts src/tests/tui-runtime-resume.e2e.test.ts src/tests/tui-runtime-suspend-race.e2e.test.ts` — 3 files / 3 tests passed.

QA real local regression on current head `974026ae`: PASS.

- focused TUI client tests: 6 files / 31 tests passed, including queued recovery no-duplicate regressions.
- client/e2e typecheck, Biome changed files, and client build passed.
- fake TUI basic/resume/suspend-race e2e passed after a clean rerun; fake argv strict check confirmed fresh starts use `--session-id`, resumes use only `--resume`, `badResume=0`.
- Real Claude default bound-at-create path passed: first reply once, suspend, resumed reply once, no fatal log matches.
- Real Claude suspend-race/recovery passed for 25/150/500ms race suspends, recovery reply once, no fatal log matches.
- No target signatures observed: `runTurn called before session was prepared`, tmux no-server paste/capture errors, `resilience.session.retry_*`, Claude `--session-id` + `--resume` conflict, `Not logged in`, or readiness timeout.

QA report: `/Users/yuezengwu/.first-tree-staging/data/workspaces/qa/qa-reports/claude-tui-suspend-queue-pr1061-rerun-qa-20260615.md`.
