### PR TITLE
feat(chat): converge doc-preview onto generic attachment refs (zero-DB)

### DIFF
--- a/apps/cli/src/__tests__/chat-attention-commands-extra.test.ts
+++ b/apps/cli/src/__tests__/chat-attention-commands-extra.test.ts
@@ -254,7 +254,10 @@ describe("chat command behavior", () => {
       "markdown",
     ]);
 
-    expect(docCaptureMock.captureOutboundDocs).toHaveBeenCalledWith("see docs/plan.md");
+    expect(docCaptureMock.captureOutboundDocs).toHaveBeenCalledWith(
+      "see docs/plan.md",
+      expect.objectContaining({ sdk }),
+    );
     expect(sdk.createTaskChat).toHaveBeenCalledWith({
       mode: "task",
       initialRecipientAgentIds: [],

--- a/apps/cli/src/__tests__/doc-capture-failure.test.ts
+++ b/apps/cli/src/__tests__/doc-capture-failure.test.ts
@@ -1,29 +1,46 @@
+import type { FirstTreeHubSDK } from "@first-tree/client";
 import { describe, expect, it, vi } from "vitest";
 
 /**
- * Mirror of the result-sink dead-link guard for the `chat send` path: when
- * snapshot validation throws, `captureOutboundDocs` must return the ORIGINAL
- * content and no documentContext (its catch already does this — pinned here so
- * a future refactor can't regress it into shipping rewritten links without
- * snapshots).
+ * Mirror of the result-sink dead-link guard for the `chat send` path: when doc
+ * capture throws, `captureOutboundDocs` must return the ORIGINAL content and no
+ * attachment metadata (its catch already does this — pinned here so a future
+ * refactor can't regress it into shipping rewritten attachment links without
+ * the matching refs).
  *
- * Force the failure by mocking the snapshot builder to return a doc that fails
- * the shared schema (`sha256` not 64 hex).
+ * Force the failure by mocking the capture builder to throw.
  */
 vi.mock("@first-tree/client", () => ({
-  buildMessageDocumentSnapshots: vi.fn(async () => ({
-    docs: [{ path: "design.md", sha256: "not-64-hex", size: 1, content: "x" }],
-    skipped: 0,
-    rewrittenText: "see [design.md](design.md) please",
-  })),
+  buildMessageDocumentSnapshots: vi.fn(async () => {
+    throw new Error("capture exploded");
+  }),
 }));
 
 import { captureOutboundDocs } from "../core/doc-capture.js";
 
+const CHAT_ID = "11111111-1111-4111-8111-111111111111";
+
+function stubSdk(): FirstTreeHubSDK {
+  return {
+    serverUrl: "http://test",
+    async getChatDetail() {
+      return { id: CHAT_ID, organizationId: "org-1", participants: [] };
+    },
+    async uploadAttachment() {
+      return { id: "x", mimeType: "text/markdown", filename: "x.md", sizeBytes: 1 };
+    },
+  } as unknown as FirstTreeHubSDK;
+}
+
 describe("captureOutboundDocs — failure preserves the original body", () => {
-  it("returns the original content and no documentContext when validation throws", async () => {
-    const out = await captureOutboundDocs("see design.md please", { FIRST_TREE_DOC_BASE: "/ws/coder/chat-1" });
+  it("returns the original content and no attachment metadata when capture throws", async () => {
+    const out = await captureOutboundDocs(
+      "see design.md please",
+      { sdk: stubSdk(), chatId: CHAT_ID },
+      { FIRST_TREE_DOC_BASE: "/ws/coder/chat-1" },
+    );
     expect(out.content).toBe("see design.md please");
+    expect(out.attachments).toBeUndefined();
     expect(out.documentContext).toBeUndefined();
   });
 });

--- a/apps/cli/src/__tests__/doc-capture.test.ts
+++ b/apps/cli/src/__tests__/doc-capture.test.ts
@@ -1,15 +1,43 @@
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { FirstTreeHubSDK } from "@first-tree/client";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { captureOutboundDocs } from "../core/doc-capture.js";
 
 /**
- * `chat send` doc capture (L3 阶段1): the CLI snapshots referenced `.md` the
- * same way result-sink does, driven by the runtime-injected env. These tests
- * exercise the env contract + pass-through behaviour; the snapshot/rewrite
- * mechanics themselves are covered by client `doc-snapshots.test.ts`.
+ * `chat send` doc capture (L3): the CLI captures referenced `.md` the same way
+ * result-sink does, driven by the runtime-injected env. After the
+ * attachment-ref convergence it uploads bytes to the org store (org resolved
+ * from the chat) and attaches generic refs. The snapshot/rewrite mechanics
+ * themselves are covered by client `doc-snapshots.test.ts`; these tests pin the
+ * env contract + the metadata shape this layer produces.
  */
+
+const CHAT_ID = "11111111-1111-4111-8111-111111111111";
+const ORG_ID = "22222222-2222-4222-8222-222222222222";
+
+function stubSdk(): { sdk: FirstTreeHubSDK } {
+  let seq = 0;
+  const sdk = {
+    serverUrl: "http://test",
+    async getChatDetail() {
+      return { id: CHAT_ID, organizationId: ORG_ID, participants: [] };
+    },
+    async uploadAttachment(o: { bytes: Uint8Array | Buffer; mimeType: string; filename: string; orgId: string }) {
+      seq += 1;
+      const bytes = Buffer.from(o.bytes);
+      return {
+        id: `00000000-0000-4000-8000-${seq.toString(16).padStart(12, "0")}`,
+        mimeType: o.mimeType,
+        filename: o.filename,
+        sizeBytes: bytes.byteLength,
+      };
+    },
+  } as unknown as FirstTreeHubSDK;
+  return { sdk };
+}
+
 describe("captureOutboundDocs (chat send L3 capture)", () => {
   let base: string;
 
@@ -23,46 +51,57 @@ describe("captureOutboundDocs (chat send L3 capture)", () => {
   });
 
   it("pass-through when no doc base in env (not in an agent session)", async () => {
-    const out = await captureOutboundDocs("see design.md please", {});
+    const { sdk } = stubSdk();
+    const out = await captureOutboundDocs("see design.md please", { sdk, chatId: CHAT_ID }, {});
     expect(out.content).toBe("see design.md please");
-    expect(out.documentContext).toBeUndefined();
+    expect(out.attachments).toBeUndefined();
   });
 
-  it("snapshots a referenced workspace .md and attaches documentContext (explicit link)", async () => {
-    const out = await captureOutboundDocs("see design.md please", { FIRST_TREE_DOC_BASE: base });
-    expect(out.content).toBe("see [design.md](design.md) please");
-    const ctx = out.documentContext as { kind?: string; docs?: Array<{ path: string }> } | undefined;
-    expect(ctx?.kind).toBe("snapshot");
-    expect(ctx?.docs?.map((d) => d.path)).toEqual(["design.md"]);
+  it("pass-through when no chatId is supplied (org unresolvable, e.g. chat create)", async () => {
+    const { sdk } = stubSdk();
+    const out = await captureOutboundDocs("see design.md please", { sdk }, { FIRST_TREE_DOC_BASE: base });
+    expect(out.content).toBe("see design.md please");
+    expect(out.attachments).toBeUndefined();
   });
 
-  it("rewrites an absolute-in-base path into an explicit relative link + snapshots it", async () => {
-    const abs = join(base, "design.md");
-    const out = await captureOutboundDocs(`wrote ${abs} now`, { FIRST_TREE_DOC_BASE: base });
-    expect(out.content).toBe("wrote [design.md](design.md) now");
-    const ctx = out.documentContext as { docs?: Array<{ path: string }> } | undefined;
-    expect(ctx?.docs?.map((d) => d.path)).toEqual(["design.md"]);
+  it("captures a referenced workspace .md as an attachment ref + rewrites the link", async () => {
+    const { sdk } = stubSdk();
+    const out = await captureOutboundDocs(
+      "see design.md please",
+      { sdk, chatId: CHAT_ID },
+      { FIRST_TREE_DOC_BASE: base },
+    );
+    expect(out.content).toBe("see [design.md](attachment:00000000-0000-4000-8000-000000000001) please");
+    expect(out.attachments?.map((a) => a.source?.path)).toEqual(["design.md"]);
+    expect(out.attachments?.[0]?.kind).toBe("document");
   });
 
-  it("no documentContext when the referenced path is not in the workspace", async () => {
-    const out = await captureOutboundDocs("see /etc/nope/missing.md", { FIRST_TREE_DOC_BASE: base });
+  it("no attachments when the referenced path is not in the workspace", async () => {
+    const { sdk } = stubSdk();
+    const out = await captureOutboundDocs(
+      "see /etc/nope/missing.md",
+      { sdk, chatId: CHAT_ID },
+      { FIRST_TREE_DOC_BASE: base },
+    );
     expect(out.content).toBe("see /etc/nope/missing.md");
-    expect(out.documentContext).toBeUndefined();
+    expect(out.attachments).toBeUndefined();
   });
 
-  it("no documentContext when the message references no .md", async () => {
-    const out = await captureOutboundDocs("just a plain message", { FIRST_TREE_DOC_BASE: base });
+  it("no attachments when the message references no .md", async () => {
+    const { sdk } = stubSdk();
+    const out = await captureOutboundDocs(
+      "just a plain message",
+      { sdk, chatId: CHAT_ID },
+      { FIRST_TREE_DOC_BASE: base },
+    );
     expect(out.content).toBe("just a plain message");
-    expect(out.documentContext).toBeUndefined();
+    expect(out.attachments).toBeUndefined();
   });
 
   describe("wide-fence env (FIRST_TREE_DOC_AGENT_HOME + optional FIRST_TREE_DOC_REPO_LOCAL_PATH)", () => {
     let agentHome: string;
 
     beforeAll(async () => {
-      // Layout mirrors the post-#506 production tree:
-      //   <agentHome>/<localPath>/         predeclared source repo
-      //   <agentHome>/worktrees/<task>/    on-demand worktree the LLM `git worktree add`s
       agentHome = await mkdtemp(join(tmpdir(), "cli-doc-capture-agent-home-"));
       await mkdir(join(agentHome, "first-tree", "docs"), { recursive: true });
       await writeFile(join(agentHome, "first-tree", "docs", "intro.md"), "# intro\n", "utf8");
@@ -74,43 +113,39 @@ describe("captureOutboundDocs (chat send L3 capture)", () => {
       await rm(agentHome, { recursive: true, force: true });
     });
 
-    it("snapshots a worktree-scoped absolute path when AGENT_HOME widens the fence", async () => {
-      // The pre-fix narrow fence (source-repo top only) would have dropped this
-      // mention to plain text; the wide fence now produces an agent-home-relative
-      // snapshot key.
+    it("captures a worktree-scoped absolute path when AGENT_HOME widens the fence", async () => {
+      const { sdk } = stubSdk();
       const abs = join(agentHome, "worktrees", "task-x", "docs", "design.md");
-      const out = await captureOutboundDocs(`wrote ${abs} now`, {
-        FIRST_TREE_DOC_AGENT_HOME: agentHome,
-        FIRST_TREE_DOC_REPO_LOCAL_PATH: "first-tree",
-      });
-      expect(out.content).toBe(`wrote [worktrees/task-x/docs/design.md](worktrees/task-x/docs/design.md) now`);
-      const ctx = out.documentContext as { docs?: Array<{ path: string }> } | undefined;
-      expect(ctx?.docs?.map((d) => d.path)).toEqual(["worktrees/task-x/docs/design.md"]);
+      const out = await captureOutboundDocs(
+        `wrote ${abs} now`,
+        { sdk, chatId: CHAT_ID },
+        { FIRST_TREE_DOC_AGENT_HOME: agentHome, FIRST_TREE_DOC_REPO_LOCAL_PATH: "first-tree" },
+      );
+      expect(out.attachments?.map((a) => a.source?.path)).toEqual(["worktrees/task-x/docs/design.md"]);
+      expect(out.content).toBe(
+        "wrote [worktrees/task-x/docs/design.md](attachment:00000000-0000-4000-8000-000000000001) now",
+      );
     });
 
-    it("promotes a relative source-repo mention to a shared agent-home-relative key", async () => {
-      // `docs/intro.md` written relatively must share its canonical key with the
-      // absolute form `<agentHome>/<localPath>/docs/intro.md` — otherwise the same
-      // file produces two snapshot entries and web cache lookup splits.
-      const out = await captureOutboundDocs("see docs/intro.md please", {
-        FIRST_TREE_DOC_AGENT_HOME: agentHome,
-        FIRST_TREE_DOC_REPO_LOCAL_PATH: "first-tree",
-      });
-      const ctx = out.documentContext as { docs?: Array<{ path: string }> } | undefined;
-      expect(ctx?.docs?.map((d) => d.path)).toEqual(["first-tree/docs/intro.md"]);
-      expect(out.content).toBe("see [first-tree/docs/intro.md](first-tree/docs/intro.md) please");
+    it("promotes a relative source-repo mention to a shared agent-home-relative source path", async () => {
+      const { sdk } = stubSdk();
+      const out = await captureOutboundDocs(
+        "see docs/intro.md please",
+        { sdk, chatId: CHAT_ID },
+        { FIRST_TREE_DOC_AGENT_HOME: agentHome, FIRST_TREE_DOC_REPO_LOCAL_PATH: "first-tree" },
+      );
+      expect(out.attachments?.map((a) => a.source?.path)).toEqual(["first-tree/docs/intro.md"]);
     });
 
     it("ignores the legacy FIRST_TREE_DOC_BASE when FIRST_TREE_DOC_AGENT_HOME is present", async () => {
-      // The wide-fence env takes precedence so a runtime that emits BOTH (during
-      // upgrade) routes through the new path.
+      const { sdk } = stubSdk();
       const abs = join(agentHome, "worktrees", "task-x", "docs", "design.md");
-      const out = await captureOutboundDocs(`wrote ${abs} now`, {
-        FIRST_TREE_DOC_AGENT_HOME: agentHome,
-        FIRST_TREE_DOC_BASE: join(agentHome, "first-tree"),
-      });
-      const ctx = out.documentContext as { docs?: Array<{ path: string }> } | undefined;
-      expect(ctx?.docs?.map((d) => d.path)).toEqual(["worktrees/task-x/docs/design.md"]);
+      const out = await captureOutboundDocs(
+        `wrote ${abs} now`,
+        { sdk, chatId: CHAT_ID },
+        { FIRST_TREE_DOC_AGENT_HOME: agentHome, FIRST_TREE_DOC_BASE: join(agentHome, "first-tree") },
+      );
+      expect(out.attachments?.map((a) => a.source?.path)).toEqual(["worktrees/task-x/docs/design.md"]);
     });
   });
 });

--- a/apps/cli/src/__tests__/doc-capture.test.ts
+++ b/apps/cli/src/__tests__/doc-capture.test.ts
@@ -57,7 +57,11 @@ describe("captureOutboundDocs (chat send L3 capture)", () => {
     expect(out.attachments).toBeUndefined();
   });
 
-  it("pass-through when no chatId is supplied (org unresolvable, e.g. chat create)", async () => {
+  // KNOWN GAP (tracked in #1069), not an endorsed final behavior: `chat create`'s
+  // initial message can't resolve an upload org without a chatId, so doc capture is
+  // a pass-through there and mentions degrade to plain text. `chat send` captures
+  // normally. Closing this gap (org resolution without a chatId) is follow-up #1069.
+  it("pass-through when no chatId is supplied (org unresolvable, e.g. chat create — see #1069)", async () => {
     const { sdk } = stubSdk();
     const out = await captureOutboundDocs("see design.md please", { sdk }, { FIRST_TREE_DOC_BASE: base });
     expect(out.content).toBe("see design.md please");

--- a/apps/cli/src/commands/chat/create.ts
+++ b/apps/cli/src/commands/chat/create.ts
@@ -130,9 +130,10 @@ export function registerChatCreateCommand(chat: Command): void {
         }
 
         const sdk = createSdk(options.agent);
-        // No chat exists yet, so org can't be resolved from a chat — doc
-        // capture is a pass-through for `chat create`'s initial message (doc
-        // mentions render as plain text). Subsequent `chat send` captures.
+        // KNOWN GAP (follow-up #1069), out of scope for this PR: no chat exists
+        // yet, so the upload org can't be resolved from a chat — doc capture is a
+        // pass-through for `chat create`'s initial message (doc mentions render as
+        // plain text). Subsequent `chat send` captures normally.
         const captured = await captureOutboundDocs(content, { sdk });
         const outboundMetadata =
           captured.attachments || captured.documentContext

--- a/apps/cli/src/commands/chat/create.ts
+++ b/apps/cli/src/commands/chat/create.ts
@@ -130,10 +130,18 @@ export function registerChatCreateCommand(chat: Command): void {
         }
 
         const sdk = createSdk(options.agent);
-        const captured = await captureOutboundDocs(content);
-        const outboundMetadata = captured.documentContext
-          ? { ...(metadata ?? {}), documentContext: captured.documentContext }
-          : metadata;
+        // No chat exists yet, so org can't be resolved from a chat — doc
+        // capture is a pass-through for `chat create`'s initial message (doc
+        // mentions render as plain text). Subsequent `chat send` captures.
+        const captured = await captureOutboundDocs(content, { sdk });
+        const outboundMetadata =
+          captured.attachments || captured.documentContext
+            ? {
+                ...(metadata ?? {}),
+                ...(captured.attachments ? { attachments: captured.attachments } : {}),
+                ...(captured.documentContext ? { documentContext: captured.documentContext } : {}),
+              }
+            : metadata;
         const result = await sdk.createTaskChat({
           mode: "task",
           initialRecipientAgentIds: [],

--- a/apps/cli/src/commands/chat/send.ts
+++ b/apps/cli/src/commands/chat/send.ts
@@ -176,13 +176,19 @@ export function registerChatSendCommand(chat: Command): void {
 
         const sdk = createSdk(options.agent);
 
-        // L3: snapshot any `.md` this message references, exactly like the
-        // runtime's result-sink does for final-text — closing the biggest
-        // doc-preview gap. Pure pass-through outside an agent session.
-        const captured = await captureOutboundDocs(content ?? "");
-        const outboundMetadata = captured.documentContext
-          ? { ...(metadata ?? {}), documentContext: captured.documentContext }
-          : metadata;
+        // L3: capture any `.md` this message references, exactly like the
+        // runtime's result-sink does for final-text — uploading to the org
+        // attachment store and attaching generic refs. Pure pass-through
+        // outside an agent session.
+        const captured = await captureOutboundDocs(content ?? "", { sdk, chatId });
+        const outboundMetadata =
+          captured.attachments || captured.documentContext
+            ? {
+                ...(metadata ?? {}),
+                ...(captured.attachments ? { attachments: captured.attachments } : {}),
+                ...(captured.documentContext ? { documentContext: captured.documentContext } : {}),
+              }
+            : metadata;
 
         // `--reply-to` threads explicitly; `--answer`/`--close` thread under the
         // question they resolve. Either way `inReplyTo` is pure threading.

--- a/apps/cli/src/core/doc-capture.ts
+++ b/apps/cli/src/core/doc-capture.ts
@@ -21,7 +21,8 @@ import { type AttachmentRef, documentContextSchema } from "@first-tree/shared";
  * exact same fence as the runtime — no config reconstruction. Uploads need an
  * org: it is resolved from the target chat (`getChatDetail`), so capture only
  * runs when a `chatId` is supplied (i.e. `chat send`; `chat create` has no chat
- * yet, so its initial message degrades doc mentions to plain text).
+ * yet, so its initial message degrades doc mentions to plain text — KNOWN GAP,
+ * out of scope for this PR, tracked as follow-up #1069).
  *
  * Returns the (possibly rewritten) content + the metadata to merge (an
  * `attachments` array and/or a `documentContext` failedMentions roster). When

--- a/apps/cli/src/core/doc-capture.ts
+++ b/apps/cli/src/core/doc-capture.ts
@@ -1,60 +1,75 @@
-import { buildMessageDocumentSnapshots, type SelfFence, type WorkspaceFence } from "@first-tree/client";
-import { documentContextSchema } from "@first-tree/shared";
+import {
+  buildMessageDocumentSnapshots,
+  type FirstTreeHubSDK,
+  type SelfFence,
+  type WorkspaceFence,
+} from "@first-tree/client";
+import { type AttachmentRef, documentContextSchema } from "@first-tree/shared";
 
 /**
- * Snapshot the `.md` documents an outbound `chat send` message references, the
+ * Capture the `.md` documents an outbound `chat send` message references, the
  * same way the runtime's `result-sink` does for an agent's final-text reply
  * (L3: unify doc-preview capture across ALL send paths, not just final-text).
  *
+ * Capture now uploads each resolved doc's bytes to the org attachment store and
+ * stores a generic `AttachmentRef` (kind: "document") in `metadata.attachments[]`,
+ * rewriting the mention into an `[display](attachment:<id>)` link — identical to
+ * result-sink. The bytes never travel inside the message.
+ *
  * The runtime injects the resolved doc context into the agent's environment
- * (`buildAgentEnv`); we read it here so the CLI sub-process resolves against
- * the exact same fence as the runtime — no config reconstruction, no server
- * round-trip.
+ * (`buildAgentEnv`); we read it here so the CLI sub-process resolves against the
+ * exact same fence as the runtime — no config reconstruction. Uploads need an
+ * org: it is resolved from the target chat (`getChatDetail`), so capture only
+ * runs when a `chatId` is supplied (i.e. `chat send`; `chat create` has no chat
+ * yet, so its initial message degrades doc mentions to plain text).
  *
- * Two wire forms, in priority order:
- *
- *  1. `FIRST_TREE_DOC_AGENT_HOME` (+ optional `_DOC_REPO_LOCAL_PATH`) — the
- *     wide self-fence introduced alongside the worktrees-fence widening. The
- *     full {@link SelfFence} is rebuilt so absolute `.md` paths in the agent's
- *     on-demand `worktrees/<task>/` checkouts also snapshot.
- *
- *  2. `FIRST_TREE_DOC_BASE` (legacy) — set by pre-fix runtimes. We treat it
- *     as `agentHome` so the snapshot pipeline still produces relative-key
- *     output, but no `singleRepoLocalPath` is available so the wider
- *     containment that #498's worktrees idiom relies on is not active. This
- *     branch keeps an old runtime + new chat-send combo working at pre-fix
- *     fidelity (no worktree preview, source-repo paths still resolve).
- *
- * Returns the (possibly rewritten) content + a validated `documentContext` to
- * merge into message metadata. When no doc base is present (not in an agent
- * session) it is a pure pass-through, so `chat send` keeps working unchanged.
- *
- * Capture failure NEVER blocks the send: any error degrades to passing the
- * original content through with no `documentContext`.
+ * Returns the (possibly rewritten) content + the metadata to merge (an
+ * `attachments` array and/or a `documentContext` failedMentions roster). When
+ * no doc base is present (not in an agent session), or the org can't be
+ * resolved, it is a pure pass-through. Capture failure NEVER blocks the send.
  */
 export async function captureOutboundDocs(
   content: string,
+  ctx: { sdk: FirstTreeHubSDK; chatId?: string },
   env: NodeJS.ProcessEnv = process.env,
-): Promise<{ content: string; documentContext?: unknown }> {
+): Promise<{ content: string; attachments?: AttachmentRef[]; documentContext?: unknown }> {
   const self = resolveSelfFenceFromEnv(env);
-  if (!self) return { content };
+  if (!self || !ctx.chatId) return { content };
 
-  const chatId = env.FIRST_TREE_CHAT_ID;
+  const chatId = ctx.chatId;
   const workspacesRoot = env.FIRST_TREE_WORKSPACES_ROOT;
   const selfSlug = env.FIRST_TREE_AGENT_SLUG;
   const fence: WorkspaceFence | undefined =
-    workspacesRoot && selfSlug && chatId ? { workspacesRoot, chatId, selfSlug } : undefined;
+    workspacesRoot && selfSlug ? { workspacesRoot, chatId, selfSlug } : undefined;
 
   try {
-    const { docs, rewrittenText } = await buildMessageDocumentSnapshots(content, self, fence);
-    if (docs.length === 0) return { content: rewrittenText };
-    // Validate through the shared schema (same as result-sink) so a malformed
-    // doc can never be lodged into immutable message history; on a parse error
-    // fall back to sending the content with no documentContext.
-    const documentContext = documentContextSchema.parse({ kind: "snapshot", docs });
-    return { content: rewrittenText, documentContext };
+    const orgId = await resolveChatOrgId(ctx.sdk, chatId);
+    if (!orgId) return { content };
+    const { refs, rewrittenText, failedMentions } = await buildMessageDocumentSnapshots(
+      content,
+      self,
+      { uploader: ctx.sdk, orgId },
+      fence,
+    );
+    const result: { content: string; attachments?: AttachmentRef[]; documentContext?: unknown } = {
+      content: rewrittenText,
+    };
+    if (refs.length > 0) result.attachments = refs;
+    if (failedMentions.length > 0) {
+      result.documentContext = documentContextSchema.parse({ kind: "snapshot", failedMentions });
+    }
+    return result;
   } catch {
     return { content };
+  }
+}
+
+async function resolveChatOrgId(sdk: FirstTreeHubSDK, chatId: string): Promise<string | null> {
+  try {
+    const detail = await sdk.getChatDetail(chatId);
+    return typeof detail.organizationId === "string" && detail.organizationId.length > 0 ? detail.organizationId : null;
+  } catch {
+    return null;
   }
 }
 

--- a/packages/client/src/__tests__/doc-snapshots.fs-mocks.test.ts
+++ b/packages/client/src/__tests__/doc-snapshots.fs-mocks.test.ts
@@ -1,13 +1,31 @@
-import { mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AttachmentUploader, BuildDocAttachmentsOptions } from "../runtime/doc-snapshots.js";
+
+const ORG_ID = "11111111-1111-4111-8111-111111111111";
+
+function noopUploader(): BuildDocAttachmentsOptions {
+  let seq = 0;
+  const uploader: AttachmentUploader = {
+    async uploadAttachment(o) {
+      seq += 1;
+      const bytes = Buffer.from(o.bytes);
+      return {
+        id: `00000000-0000-4000-8000-${seq.toString(16).padStart(12, "0")}`,
+        mimeType: o.mimeType,
+        filename: o.filename,
+        sizeBytes: bytes.byteLength,
+      };
+    },
+  };
+  return { uploader, orgId: ORG_ID };
+}
 
 describe("buildMessageDocumentSnapshots — filesystem failure edges", () => {
   afterEach(() => {
-    vi.doUnmock("@first-tree/shared");
     vi.doUnmock("node:fs/promises");
-    vi.doUnmock("node:path");
     vi.resetModules();
   });
 
@@ -31,9 +49,13 @@ describe("buildMessageDocumentSnapshots — filesystem failure edges", () => {
 
     try {
       const { buildMessageDocumentSnapshots } = await import("../runtime/doc-snapshots.js");
-      const { docs, failedMentions, skipped } = await buildMessageDocumentSnapshots("see unreadable.md", root);
+      const { refs, failedMentions, skipped } = await buildMessageDocumentSnapshots(
+        "see unreadable.md",
+        root,
+        noopUploader(),
+      );
 
-      expect(docs).toEqual([]);
+      expect(refs).toEqual([]);
       expect(skipped).toBe(1);
       expect(failedMentions).toEqual([{ raw: "unreadable.md", reason: "unreadable" }]);
     } finally {
@@ -41,7 +63,7 @@ describe("buildMessageDocumentSnapshots — filesystem failure edges", () => {
     }
   });
 
-  it("treats a self stat failure during read-time resolution as missing", async () => {
+  it("treats a self stat failure during resolution as missing", async () => {
     const root = await mkdtemp(join(tmpdir(), "doc-snap-stat-fail-"));
     const target = join(root, "stat-fail.md");
     await writeFile(target, "# stat fail\n", "utf8");
@@ -61,307 +83,12 @@ describe("buildMessageDocumentSnapshots — filesystem failure edges", () => {
 
     try {
       const { buildMessageDocumentSnapshots } = await import("../runtime/doc-snapshots.js");
-      const { docs, failedMentions, skipped } = await buildMessageDocumentSnapshots("see stat-fail.md", root);
+      const { refs, failedMentions } = await buildMessageDocumentSnapshots("see stat-fail.md", root, noopUploader());
 
-      expect(docs).toEqual([]);
-      expect(skipped).toBe(1);
+      expect(refs).toEqual([]);
       expect(failedMentions).toEqual([{ raw: "stat-fail.md", reason: "missing" }]);
     } finally {
       await rm(root, { recursive: true, force: true });
-    }
-  });
-
-  it("classifies cross-workspace stat failures as missing", async () => {
-    const workspacesRoot = await mkdtemp(join(tmpdir(), "doc-snap-cross-stat-"));
-    const chatId = "chat-stat";
-    const selfSlug = "coder";
-    const selfRoot = join(workspacesRoot, selfSlug, chatId);
-    const target = join(workspacesRoot, "assistant", chatId, "cross-stat.md");
-    await mkdir(selfRoot, { recursive: true });
-    await mkdir(join(workspacesRoot, "assistant", chatId), { recursive: true });
-    await writeFile(target, "# cross stat\n", "utf8");
-    const targetReal = await realpath(target);
-
-    vi.resetModules();
-    vi.doMock("node:fs/promises", async () => {
-      const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
-      return {
-        ...actual,
-        stat: (path: string) => {
-          if (path === targetReal) throw new Error("blocked stat");
-          return actual.stat(path);
-        },
-      };
-    });
-
-    try {
-      const { buildMessageDocumentSnapshots } = await import("../runtime/doc-snapshots.js");
-      const { docs, failedMentions } = await buildMessageDocumentSnapshots(`see ${target}`, selfRoot, {
-        workspacesRoot,
-        chatId,
-        selfSlug,
-      });
-
-      expect(docs).toEqual([]);
-      expect(failedMentions).toEqual([{ raw: target, reason: "missing" }]);
-    } finally {
-      await rm(workspacesRoot, { recursive: true, force: true });
-    }
-  });
-
-  it("classifies inside-home stat failures after canonical-key rejection as missing", async () => {
-    const root = await mkdtemp(join(tmpdir(), "doc-snap-classify-stat-"));
-    const target = join(root, "query?segment", "note.md");
-    await mkdir(join(root, "query?segment"), { recursive: true });
-    await writeFile(target, "# query segment\n", "utf8");
-    const targetReal = await realpath(target);
-
-    vi.resetModules();
-    vi.doMock("node:fs/promises", async () => {
-      const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
-      return {
-        ...actual,
-        stat: (path: string) => {
-          if (path === targetReal) throw new Error("blocked stat");
-          return actual.stat(path);
-        },
-      };
-    });
-
-    try {
-      const { buildMessageDocumentSnapshots } = await import("../runtime/doc-snapshots.js");
-      const { docs, failedMentions } = await buildMessageDocumentSnapshots(`see [note](${target})`, root);
-
-      expect(docs).toEqual([]);
-      expect(failedMentions).toEqual([]);
-    } finally {
-      await rm(root, { recursive: true, force: true });
-    }
-  });
-
-  it("marks a normalized key that does not end in .md as missing", async () => {
-    const root = await mkdtemp(join(tmpdir(), "doc-snap-normalize-non-md-"));
-    await writeFile(join(root, "design.md"), "# design\n", "utf8");
-
-    vi.resetModules();
-    vi.doMock("@first-tree/shared", async () => {
-      const actual = await vi.importActual<typeof import("@first-tree/shared")>("@first-tree/shared");
-      return {
-        ...actual,
-        normalizeDocLinkPath: (raw: string) => {
-          if (raw === "design.md") return "design.txt";
-          return actual.normalizeDocLinkPath(raw);
-        },
-      };
-    });
-
-    try {
-      const { buildMessageDocumentSnapshots } = await import("../runtime/doc-snapshots.js");
-      const { docs, failedMentions } = await buildMessageDocumentSnapshots("see design.md", root);
-
-      expect(docs).toEqual([]);
-      expect(failedMentions).toEqual([{ raw: "design.md", reason: "missing" }]);
-    } finally {
-      await rm(root, { recursive: true, force: true });
-    }
-  });
-
-  it("treats an absolute normalized key as missing at read-time resolution", async () => {
-    const root = await mkdtemp(join(tmpdir(), "doc-snap-normalize-abs-"));
-
-    vi.resetModules();
-    vi.doMock("@first-tree/shared", async () => {
-      const actual = await vi.importActual<typeof import("@first-tree/shared")>("@first-tree/shared");
-      return {
-        ...actual,
-        normalizeDocLinkPath: (raw: string) => {
-          if (raw === "absolute-key.md") return "/absolute-key.md";
-          return actual.normalizeDocLinkPath(raw);
-        },
-      };
-    });
-
-    try {
-      const { buildMessageDocumentSnapshots } = await import("../runtime/doc-snapshots.js");
-      const { docs, failedMentions } = await buildMessageDocumentSnapshots("see absolute-key.md", root);
-
-      expect(docs).toEqual([]);
-      expect(failedMentions).toEqual([{ raw: "absolute-key.md", reason: "missing" }]);
-    } finally {
-      await rm(root, { recursive: true, force: true });
-    }
-  });
-
-  it("drops a read-time path that starts resolving outside the workspace", async () => {
-    const root = await mkdtemp(join(tmpdir(), "doc-snap-toctou-outside-"));
-    const outside = await mkdtemp(join(tmpdir(), "doc-snap-toctou-outside-target-"));
-    const target = join(root, "flip.md");
-    const outsideTarget = join(outside, "external.md");
-    await writeFile(target, "# flip\n", "utf8");
-    await writeFile(outsideTarget, "# external\n", "utf8");
-    const targetReal = await realpath(target);
-    const outsideReal = await realpath(outsideTarget);
-    let targetRealpathCalls = 0;
-
-    vi.resetModules();
-    vi.doMock("node:fs/promises", async () => {
-      const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
-      return {
-        ...actual,
-        realpath: async (path: string) => {
-          if (path === targetReal) {
-            targetRealpathCalls += 1;
-            if (targetRealpathCalls === 2) return outsideReal;
-          }
-          return actual.realpath(path);
-        },
-      };
-    });
-
-    try {
-      const { buildMessageDocumentSnapshots } = await import("../runtime/doc-snapshots.js");
-      const { docs, failedMentions } = await buildMessageDocumentSnapshots("see flip.md", root);
-
-      expect(docs).toEqual([]);
-      expect(failedMentions).toEqual([{ raw: "flip.md", reason: "missing" }]);
-    } finally {
-      await rm(root, { recursive: true, force: true });
-      await rm(outside, { recursive: true, force: true });
-    }
-  });
-
-  it("drops a read-time path that starts resolving into a hidden segment", async () => {
-    const root = await mkdtemp(join(tmpdir(), "doc-snap-toctou-hidden-"));
-    const target = join(root, "flip-hidden.md");
-    const hiddenTarget = join(root, ".agent", "secret.md");
-    await mkdir(join(root, ".agent"), { recursive: true });
-    await writeFile(target, "# flip\n", "utf8");
-    await writeFile(hiddenTarget, "# secret\n", "utf8");
-    const targetReal = await realpath(target);
-    const hiddenReal = await realpath(hiddenTarget);
-    let targetRealpathCalls = 0;
-
-    vi.resetModules();
-    vi.doMock("node:fs/promises", async () => {
-      const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
-      return {
-        ...actual,
-        realpath: async (path: string) => {
-          if (path === targetReal) {
-            targetRealpathCalls += 1;
-            if (targetRealpathCalls === 2) return hiddenReal;
-          }
-          return actual.realpath(path);
-        },
-      };
-    });
-
-    try {
-      const { buildMessageDocumentSnapshots } = await import("../runtime/doc-snapshots.js");
-      const { docs, failedMentions } = await buildMessageDocumentSnapshots("see flip-hidden.md", root);
-
-      expect(docs).toEqual([]);
-      expect(failedMentions).toEqual([{ raw: "flip-hidden.md", reason: "missing" }]);
-    } finally {
-      await rm(root, { recursive: true, force: true });
-    }
-  });
-
-  it("classifies a cross hidden segment after the home-relative hidden check clears", async () => {
-    const workspacesRoot = await mkdtemp(join(tmpdir(), "doc-snap-path-hidden-ws-"));
-    const home = await mkdtemp(join(tmpdir(), "doc-snap-path-hidden-home-"));
-    const chatId = "chat-path";
-    const target = join(workspacesRoot, "assistant", chatId, "notes.md");
-    await mkdir(join(workspacesRoot, "assistant", chatId), { recursive: true });
-    await writeFile(target, "# path mock\n", "utf8");
-    const workspacesRootReal = await realpath(workspacesRoot);
-    const homeReal = await realpath(home);
-    const targetReal = await realpath(target);
-
-    vi.resetModules();
-    vi.doMock("node:path", async () => {
-      const actual = await vi.importActual<typeof import("node:path")>("node:path");
-      return {
-        ...actual,
-        relative: (from: string, to: string) => {
-          if (from === homeReal && to === targetReal) return "safe/notes.md";
-          if (from === workspacesRootReal && to === targetReal) return `assistant/${chatId}/.hidden/notes.md`;
-          return actual.relative(from, to);
-        },
-      };
-    });
-
-    try {
-      const { buildMessageDocumentSnapshots } = await import("../runtime/doc-snapshots.js");
-      const { docs, failedMentions } = await buildMessageDocumentSnapshots(`see ${target}`, home, {
-        workspacesRoot,
-        chatId,
-        selfSlug: "coder",
-      });
-
-      expect(docs).toEqual([]);
-      expect(failedMentions).toEqual([{ raw: target, reason: "hidden-segment" }]);
-    } finally {
-      await rm(workspacesRoot, { recursive: true, force: true });
-      await rm(home, { recursive: true, force: true });
-    }
-  });
-
-  it("drops a cross path whose relative owner segment is empty", async () => {
-    const nativeFilter = Array.prototype.filter;
-    const workspacesRoot = await mkdtemp(join(tmpdir(), "doc-snap-empty-owner-ws-"));
-    const home = await mkdtemp(join(tmpdir(), "doc-snap-empty-owner-home-"));
-    const chatId = "chat-empty";
-    const target = join(workspacesRoot, "assistant", chatId, "file.md");
-    await mkdir(join(workspacesRoot, "assistant", chatId), { recursive: true });
-    await writeFile(target, "# empty owner\n", "utf8");
-    const workspacesRootReal = await realpath(workspacesRoot);
-    const targetReal = await realpath(target);
-
-    function patchedFilter(this: unknown[], callback: unknown, thisArg?: unknown): unknown[] {
-      if (this.length === 3 && this[0] === "" && this[1] === chatId && this[2] === "file.md") {
-        return Array.from(this);
-      }
-      const result = Reflect.apply(nativeFilter, this, [callback, thisArg]);
-      if (Array.isArray(result)) return result;
-      return [];
-    }
-
-    Object.defineProperty(Array.prototype, "filter", {
-      configurable: true,
-      value: patchedFilter,
-      writable: true,
-    });
-    vi.resetModules();
-    vi.doMock("node:path", async () => {
-      const actual = await vi.importActual<typeof import("node:path")>("node:path");
-      return {
-        ...actual,
-        relative: (from: string, to: string) => {
-          if (from === workspacesRootReal && to === targetReal) return `/${chatId}/file.md`;
-          return actual.relative(from, to);
-        },
-      };
-    });
-
-    try {
-      const { buildMessageDocumentSnapshots } = await import("../runtime/doc-snapshots.js");
-      const { docs, failedMentions } = await buildMessageDocumentSnapshots(`see ${target}`, home, {
-        workspacesRoot,
-        chatId,
-        selfSlug: "coder",
-      });
-
-      expect(docs).toEqual([]);
-      expect(failedMentions).toEqual([{ raw: target, reason: "unreadable" }]);
-    } finally {
-      Object.defineProperty(Array.prototype, "filter", {
-        configurable: true,
-        value: nativeFilter,
-        writable: true,
-      });
-      await rm(workspacesRoot, { recursive: true, force: true });
-      await rm(home, { recursive: true, force: true });
     }
   });
 });

--- a/packages/client/src/__tests__/doc-snapshots.test.ts
+++ b/packages/client/src/__tests__/doc-snapshots.test.ts
@@ -178,6 +178,35 @@ describe("buildMessageDocumentSnapshots — capture + attachment-link rewrite", 
     expect(rewrittenText).toBe("just chatting");
     expect(uploads).toEqual([]);
   });
+
+  // R4: the capture cap was raised from 256KB to the 10MB upload cap. A doc
+  // larger than the OLD 256KB ceiling but well under the upload cap must now be
+  // captured (it used to fail `too-large`). Would fail before the fix.
+  it("captures a doc larger than the legacy 256KB cap (capture cap = upload cap)", async () => {
+    const big = `# big\n${"x".repeat(400 * 1024)}\n`;
+    await writeFile(join(root, "big.md"), big, "utf8");
+    const { refs, failedMentions } = await buildMessageDocumentSnapshots("see big.md", root, opts(uploader));
+    expect(refs).toHaveLength(1);
+    expect(refs[0]?.source?.path).toBe("big.md");
+    expect(failedMentions).toEqual([]);
+    expect(uploads).toHaveLength(1);
+  });
+
+  // R4: a doc above the 10MB upload cap still degrades to `too-large` (the blob
+  // store would reject the upload anyway), so the new ceiling is the upload cap.
+  it("fails a doc above the 10MB upload cap as too-large", async () => {
+    const huge = `# huge\n${"y".repeat(11 * 1024 * 1024)}\n`;
+    await writeFile(join(root, "huge.md"), huge, "utf8");
+    const { refs, failedMentions, rewrittenText } = await buildMessageDocumentSnapshots(
+      "see huge.md",
+      root,
+      opts(uploader),
+    );
+    expect(refs).toEqual([]);
+    expect(failedMentions).toEqual([{ raw: "huge.md", reason: "too-large" }]);
+    expect(rewrittenText).toBe("see huge.md");
+    expect(uploads).toEqual([]);
+  });
 });
 
 describe("buildMessageDocumentSnapshots — cross-agent workspace fence", () => {

--- a/packages/client/src/__tests__/doc-snapshots.test.ts
+++ b/packages/client/src/__tests__/doc-snapshots.test.ts
@@ -1,37 +1,76 @@
+import { createHash } from "node:crypto";
 import { mkdir, mkdtemp, realpath, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  MAX_DOC_SNAPSHOT_BYTES,
-  MAX_DOC_SNAPSHOTS_PER_MESSAGE,
-  MAX_TOTAL_DOC_SNAPSHOT_BYTES,
-} from "@first-tree/shared";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { buildMessageDocumentSnapshots } from "../runtime/doc-snapshots.js";
+  type AttachmentUploader,
+  type BuildDocAttachmentsOptions,
+  buildMessageDocumentSnapshots,
+} from "../runtime/doc-snapshots.js";
 
 /**
- * Unit tests for the runtime snapshot builder. Every resolved+snapshotted `.md`
- * reference is rewritten into an EXPLICIT markdown link whose href is the
- * canonical snapshot key (bare → `[display](key)`; inline target → key), so web
- * resolves a click by direct href→snapshot lookup without re-scanning. Out-of-
- * root / hidden / escaping paths get no snapshot and are left verbatim.
+ * Unit tests for the runtime doc-capture builder after the attachment-ref
+ * convergence. A resolved `.md` reference is now uploaded to the org blob store
+ * and rewritten into an explicit `[display](attachment:<id>)` link; the bytes
+ * are no longer inlined. We use a deterministic stub uploader that mints
+ * uuid-shaped ids so the rewrite output is assertable.
  */
-describe("buildMessageDocumentSnapshots — explicit-link rewrite (self / Case A)", () => {
+
+const ORG_ID = "11111111-1111-4111-8111-111111111111";
+
+function fakeUploadId(seq: number): string {
+  const hex = seq.toString(16).padStart(12, "0");
+  return `00000000-0000-4000-8000-${hex}`;
+}
+
+type RecordedUpload = { bytes: Buffer; mimeType: string; filename: string; orgId: string };
+
+function stubUploader(): { uploader: AttachmentUploader; uploads: RecordedUpload[] } {
+  const uploads: RecordedUpload[] = [];
+  let seq = 0;
+  const uploader: AttachmentUploader = {
+    async uploadAttachment(opts) {
+      seq += 1;
+      const bytes = Buffer.from(opts.bytes);
+      uploads.push({ bytes, mimeType: opts.mimeType, filename: opts.filename, orgId: opts.orgId });
+      return { id: fakeUploadId(seq), mimeType: opts.mimeType, filename: opts.filename, sizeBytes: bytes.byteLength };
+    },
+  };
+  return { uploader, uploads };
+}
+
+function failingUploader(): AttachmentUploader {
+  return {
+    async uploadAttachment() {
+      throw new Error("upload boom");
+    },
+  };
+}
+
+function opts(uploader: AttachmentUploader): BuildDocAttachmentsOptions {
+  return { uploader, orgId: ORG_ID };
+}
+
+function sha256(content: string): string {
+  return createHash("sha256").update(content, "utf8").digest("hex");
+}
+
+describe("buildMessageDocumentSnapshots — capture + attachment-link rewrite", () => {
   let root: string;
   let outside: string;
+  let uploads: RecordedUpload[];
+  let uploader: AttachmentUploader;
 
   beforeAll(async () => {
     root = await mkdtemp(join(tmpdir(), "doc-snap-root-"));
     await writeFile(join(root, "design.md"), "# design\n", "utf8");
     await mkdir(join(root, "docs"), { recursive: true });
     await writeFile(join(root, "docs", "intro.md"), "# intro\n", "utf8");
-    // Symlink escape fixture: public.md → .agent/secret.md (hidden segment).
     await mkdir(join(root, ".agent"), { recursive: true });
     await writeFile(join(root, ".agent", "secret.md"), "# secret\n", "utf8");
     await symlink(join(root, ".agent", "secret.md"), join(root, "public.md"));
 
-    // A real .md file that EXISTS but lives OUTSIDE the workspace root, so the
-    // rejection is proven by containment, not a missing-file shortcut.
     outside = await mkdtemp(join(tmpdir(), "doc-snap-outside-"));
     await writeFile(join(outside, "external.md"), "# external\n", "utf8");
   });
@@ -41,864 +80,164 @@ describe("buildMessageDocumentSnapshots — explicit-link rewrite (self / Case A
     await rm(outside, { recursive: true, force: true });
   });
 
-  it("rewrites a bare absolute-in-root token to its relative path + snapshots it", async () => {
+  beforeEach(() => {
+    const stub = stubUploader();
+    uploader = stub.uploader;
+    uploads = stub.uploads;
+  });
+
+  it("uploads a bare absolute-in-root token and rewrites it to an attachment link", async () => {
     const abs = join(root, "design.md");
-    const { docs, rewrittenText } = await buildMessageDocumentSnapshots(`wrote ${abs} just now`, root);
+    const { refs, rewrittenText } = await buildMessageDocumentSnapshots(`wrote ${abs} just now`, root, opts(uploader));
 
-    expect(docs.map((d) => d.path)).toEqual(["design.md"]);
-    expect(docs[0]?.content).toBe("# design\n");
-    expect(rewrittenText).toBe("wrote [design.md](design.md) just now");
+    expect(refs).toHaveLength(1);
+    expect(refs[0]?.kind).toBe("document");
+    expect(refs[0]?.source?.path).toBe("design.md");
+    expect(refs[0]?.mimeType).toBe("text/markdown");
+    expect(refs[0]?.sha256).toBe(sha256("# design\n"));
+    expect(refs[0]?.filename).toBe("design.md");
+    expect(rewrittenText).toBe(`wrote [design.md](attachment:${fakeUploadId(1)}) just now`);
+    expect(uploads).toHaveLength(1);
+    expect(uploads[0]?.orgId).toBe(ORG_ID);
   });
 
-  it("rewrites an absolute target inside an inline markdown link in place", async () => {
+  it("retargets an inline markdown link's target at the attachment", async () => {
     const abs = join(root, "docs", "intro.md");
-    const { docs, rewrittenText } = await buildMessageDocumentSnapshots(`see [intro](${abs}) for setup`, root);
-
-    expect(docs.map((d) => d.path)).toEqual(["docs/intro.md"]);
-    expect(rewrittenText).toBe("see [intro](docs/intro.md) for setup");
+    const { refs, rewrittenText } = await buildMessageDocumentSnapshots(
+      `see [intro](${abs}) for setup`,
+      root,
+      opts(uploader),
+    );
+    expect(refs[0]?.source?.path).toBe("docs/intro.md");
+    expect(rewrittenText).toBe(`see [intro](attachment:${fakeUploadId(1)}) for setup`);
   });
 
-  it("preserves the :line[:col] suffix when rewriting an absolute token, keys the snapshot de-suffixed", async () => {
+  it("keeps the :line[:col] suffix on the display, points href at the attachment", async () => {
     const abs = join(root, "docs", "intro.md");
-    const { docs, rewrittenText } = await buildMessageDocumentSnapshots(`open ${abs}:42:7 here`, root);
-
-    expect(docs.map((d) => d.path)).toEqual(["docs/intro.md"]);
-    // Explicit link: `:line` kept on the display, stripped from the key href.
-    expect(rewrittenText).toBe("open [docs/intro.md:42:7](docs/intro.md) here");
+    const { refs, rewrittenText } = await buildMessageDocumentSnapshots(`open ${abs}:42:7 here`, root, opts(uploader));
+    expect(refs[0]?.source?.path).toBe("docs/intro.md");
+    expect(rewrittenText).toBe(`open [docs/intro.md:42:7](attachment:${fakeUploadId(1)}) here`);
   });
 
-  it("leaves an out-of-root absolute path untouched — no snapshot, no rewrite", async () => {
+  it("leaves an out-of-root absolute path untouched — no upload, no rewrite", async () => {
     const abs = join(outside, "external.md");
     const text = `external doc at ${abs} here`;
-    const { docs, rewrittenText } = await buildMessageDocumentSnapshots(text, root);
-
-    expect(docs).toEqual([]);
+    const { refs, rewrittenText } = await buildMessageDocumentSnapshots(text, root, opts(uploader));
+    expect(refs).toEqual([]);
     expect(rewrittenText).toBe(text);
+    expect(uploads).toEqual([]);
   });
 
-  it("wraps a bare relative mention into an explicit link; an already-canonical inline href is left as-is", async () => {
-    const text = "see docs/intro.md and [d](design.md)";
-    const { docs, rewrittenText } = await buildMessageDocumentSnapshots(text, root);
-
-    expect(docs.map((d) => d.path).sort()).toEqual(["design.md", "docs/intro.md"]);
-    // Bare `docs/intro.md` → explicit link; inline `[d](design.md)` href is
-    // already the canonical key, so it stays byte-identical.
-    expect(rewrittenText).toBe("see [docs/intro.md](docs/intro.md) and [d](design.md)");
+  it("links a bare relative mention; dedupes the same file mentioned twice to one upload", async () => {
+    const { refs, rewrittenText } = await buildMessageDocumentSnapshots(
+      "see docs/intro.md and again docs/intro.md",
+      root,
+      opts(uploader),
+    );
+    expect(refs).toHaveLength(1);
+    expect(uploads).toHaveLength(1);
+    expect(rewrittenText).toBe(
+      `see [docs/intro.md](attachment:${fakeUploadId(1)}) and again [docs/intro.md](attachment:${fakeUploadId(1)})`,
+    );
   });
 
-  it("canonicalises a non-canonical inline target (`./docs/intro.md` → `docs/intro.md`)", async () => {
-    const text = "see [d](./docs/intro.md)";
-    const { docs, rewrittenText } = await buildMessageDocumentSnapshots(text, root);
-
-    expect(docs.map((d) => d.path)).toEqual(["docs/intro.md"]);
-    // Web no longer canonicalises on re-scan; the runtime points the target
-    // straight at the snapshot key so the click is a direct lookup.
-    expect(rewrittenText).toBe("see [d](docs/intro.md)");
-  });
-
-  it("scans an inline markdown link at the start of the message", async () => {
-    const { docs, rewrittenText } = await buildMessageDocumentSnapshots("[d](design.md) starts here", root);
-
-    expect(docs.map((d) => d.path)).toEqual(["design.md"]);
-    expect(rewrittenText).toBe("[d](design.md) starts here");
-  });
-
-  it("rejects a symlink whose realpath crosses into a hidden dir — relative AND absolute forms", async () => {
-    const rel = "see [p](public.md)";
-    const relOut = await buildMessageDocumentSnapshots(rel, root);
-    expect(relOut.docs).toEqual([]);
-    expect(relOut.rewrittenText).toBe(rel);
-
+  it("rejects a symlink whose realpath crosses into a hidden dir (relative + absolute)", async () => {
+    const relOut = await buildMessageDocumentSnapshots("see [p](public.md)", root, opts(uploader));
+    expect(relOut.refs).toEqual([]);
     const abs = join(root, "public.md");
-    const absText = `see ${abs}`;
-    const absOut = await buildMessageDocumentSnapshots(absText, root);
-    expect(absOut.docs).toEqual([]);
-    expect(absOut.rewrittenText).toBe(absText);
+    const absOut = await buildMessageDocumentSnapshots(`see ${abs}`, root, opts(uploader));
+    expect(absOut.refs).toEqual([]);
   });
 
-  it("rejects a hidden-segment mention and leaves the text verbatim", async () => {
-    const text = "secret [s](.agent/secret.md)";
-    const { docs, rewrittenText } = await buildMessageDocumentSnapshots(text, root);
-
-    expect(docs).toEqual([]);
-    expect(rewrittenText).toBe(text);
-  });
-
-  it("rewrites every occurrence of the same absolute path, snapshotting it once", async () => {
-    const abs = join(root, "design.md");
-    const text = `first ${abs} then again ${abs}`;
-    const { docs, rewrittenText } = await buildMessageDocumentSnapshots(text, root);
-
-    expect(docs.map((d) => d.path)).toEqual(["design.md"]);
-    expect(rewrittenText).toBe("first [design.md](design.md) then again [design.md](design.md)");
-  });
-
-  it("invariant: every rewritten explicit-link href is a real snapshot key", async () => {
-    // The core "two ends agree by construction" guarantee — web resolves a
-    // click by direct href→snapshot lookup, so every href the rewrite emits
-    // MUST be one of the snapshot keys (else a dead link). Mixes bare +
-    // inline + absolute + relative + :line in one message.
-    const absDesign = join(root, "design.md");
-    const text = `a ${absDesign} b docs/intro.md c [x](${join(root, "docs", "intro.md")}) d ${absDesign}:9`;
-    const { docs, rewrittenText } = await buildMessageDocumentSnapshots(text, root);
-
-    const keys = new Set(docs.map((d) => d.path));
-    const hrefs = [...rewrittenText.matchAll(/\]\(([^)]+)\)/g)].map((m) => m[1]);
-    expect(hrefs.length).toBeGreaterThan(0);
-    for (const href of hrefs) expect(keys.has(href ?? "")).toBe(true);
-  });
-
-  it("widens the rewrite over a single-backtick code span — code-styled clickable link", async () => {
-    // Phase-1 fix: previously inline code was a hard skip and `` `docs/intro.md` ``
-    // stayed dead. Now the rewrite encloses the whole tick-wrapped span so the
-    // mono-spaced visual survives and the link points at the snapshot key.
-    const { docs, rewrittenText } = await buildMessageDocumentSnapshots("see `docs/intro.md` for setup", root);
-
-    expect(docs.map((d) => d.path)).toEqual(["docs/intro.md"]);
-    expect(rewrittenText).toBe("see [`docs/intro.md`](docs/intro.md) for setup");
-  });
-
-  it("preserves multi-backtick code-span wrappers verbatim in the link text", async () => {
-    // Multi-tick spans are commonmark-legal too and the rewrite preserves the
-    // exact tick count + surrounding text so embedded backticks aren't lost.
-    const { docs, rewrittenText } = await buildMessageDocumentSnapshots(
-      "see ``the ` token in docs/intro.md`` is escaped",
+  it("reports a bare missing mention as a failedMention and leaves it plain text", async () => {
+    const { refs, failedMentions, rewrittenText } = await buildMessageDocumentSnapshots(
+      "read directory-or-missing.md",
       root,
+      opts(uploader),
     );
-
-    expect(docs.map((d) => d.path)).toEqual(["docs/intro.md"]);
-    expect(rewrittenText).toBe("see [``the ` token in docs/intro.md``](docs/intro.md) is escaped");
+    expect(refs).toEqual([]);
+    expect(failedMentions).toEqual([{ raw: "directory-or-missing.md", reason: "missing" }]);
+    expect(rewrittenText).toBe("read directory-or-missing.md");
   });
 
-  it("preserves the :line suffix when the path is wrapped in a code span", async () => {
-    // `:line` inside the span survives via the verbatim slice; the href is
-    // still the canonical de-suffixed key.
-    const { docs, rewrittenText } = await buildMessageDocumentSnapshots("open `docs/intro.md:42:7` here", root);
-
-    expect(docs.map((d) => d.path)).toEqual(["docs/intro.md"]);
-    expect(rewrittenText).toBe("open [`docs/intro.md:42:7`](docs/intro.md) here");
-  });
-
-  it("snapshots an absolute code-span path and links it with the canonical key", async () => {
-    const abs = join(root, "docs", "intro.md");
-    const { docs, rewrittenText } = await buildMessageDocumentSnapshots(`see \`${abs}\` please`, root);
-
-    expect(docs.map((d) => d.path)).toEqual(["docs/intro.md"]);
-    // Display kept verbatim (long absolute path inside ticks), href is the
-    // canonical workspace-relative key.
-    expect(rewrittenText).toBe(`see [\`${abs}\`](docs/intro.md) please`);
-  });
-
-  it("leaves a fenced (triple-backtick) code block as plain text — fenced stays a hard skip", async () => {
-    const text = ["before", "```", "docs/intro.md", "```", "after"].join("\n");
-    const { docs, rewrittenText } = await buildMessageDocumentSnapshots(text, root);
-
-    expect(docs).toEqual([]);
-    expect(rewrittenText).toBe(text);
-  });
-
-  it("reports a missing relative mention via failedMentions[missing]", async () => {
-    // Phase-2: a bare mention whose canonical path can't be resolved to a
-    // real file lands in failedMentions with reason "missing". The rewrite
-    // leaves the token untouched (no dead link), and the snapshot list stays
-    // empty — the agent's text reaches the wire as authored.
-    const { docs, rewrittenText, failedMentions } = await buildMessageDocumentSnapshots(
-      "see docs/nope.md please",
+  it("degrades to plain text (no rewrite) when the upload fails after retries", async () => {
+    const { refs, failedMentions, rewrittenText } = await buildMessageDocumentSnapshots(
+      "see design.md please",
       root,
+      opts(failingUploader()),
     );
-
-    expect(docs).toEqual([]);
-    expect(rewrittenText).toBe("see docs/nope.md please");
-    expect(failedMentions).toEqual([{ raw: "docs/nope.md", reason: "missing" }]);
+    expect(refs).toEqual([]);
+    expect(rewrittenText).toBe("see design.md please");
+    // A bare mention whose upload failed surfaces an inert-chip reason.
+    expect(failedMentions).toEqual([{ raw: "design.md", reason: "unreadable" }]);
   });
 
-  it("reports a code-span-wrapped missing mention with raw stripped of line suffix", async () => {
-    // The code-span wrapper doesn't change failure reporting: the agent's
-    // written path (suffix-stripped) is what lands in failedMentions, so the
-    // web wrap pass can match every variant of the token in one entry.
-    const { docs, rewrittenText, failedMentions } = await buildMessageDocumentSnapshots(
-      "see `docs/missing.md:42` together",
-      root,
-    );
-
-    expect(docs).toEqual([]);
-    expect(rewrittenText).toBe("see `docs/missing.md:42` together");
-    expect(failedMentions).toEqual([{ raw: "docs/missing.md", reason: "missing" }]);
-  });
-
-  it("reports an out-of-root absolute mention as out-of-fence", async () => {
-    // Out-of-root absolute paths fall through self resolution and fail
-    // classification — bucket them as out-of-fence so the chip tooltip can
-    // tell the agent the file is outside the workspace.
-    const abs = join(outside, "external.md");
-    const { docs, failedMentions } = await buildMessageDocumentSnapshots(`see ${abs} now`, root);
-
-    expect(docs).toEqual([]);
-    expect(failedMentions).toEqual([{ raw: abs, reason: "out-of-fence" }]);
-  });
-
-  it("reports a hidden-segment mention via failedMentions[hidden-segment]", async () => {
-    const { docs, failedMentions } = await buildMessageDocumentSnapshots("read .agent/secret.md", root);
-
-    expect(docs).toEqual([]);
-    expect(failedMentions).toEqual([{ raw: ".agent/secret.md", reason: "hidden-segment" }]);
-  });
-
-  it("treats an in-workspace .md directory as missing", async () => {
-    await mkdir(join(root, "directory.md"), { recursive: true });
-
-    const { docs, failedMentions } = await buildMessageDocumentSnapshots("read directory.md", root);
-
-    expect(docs).toEqual([]);
-    expect(failedMentions).toEqual([{ raw: "directory.md", reason: "missing" }]);
-  });
-
-  it("classifies a relative `..` escape as out-of-fence, not hidden-segment", async () => {
-    // Parent-traversal mentions (`../outside.md`) cannot snapshot — but the
-    // failure reason is "outside the workspace", not "hidden directory". The
-    // chip tooltip would otherwise mis-attribute the cause and confuse the
-    // agent (Codex review round 1 P3).
-    const { docs, failedMentions } = await buildMessageDocumentSnapshots("see ../outside.md please", root);
-
-    expect(docs).toEqual([]);
-    expect(failedMentions).toEqual([{ raw: "../outside.md", reason: "out-of-fence" }]);
-  });
-
-  it("dedupes failedMentions by writtenPath across multiple raw variants", async () => {
-    // Two occurrences of the same canonical path under different `:line`
-    // suffixes collapse to ONE failedMentions entry on the wire. Web's wrap
-    // pass canonicalises each scan match before lookup so all occurrences
-    // still render as chips.
-    const { failedMentions } = await buildMessageDocumentSnapshots(
-      "compare docs/nope.md to docs/nope.md:5 together",
-      root,
-    );
-
-    expect(failedMentions).toEqual([{ raw: "docs/nope.md", reason: "missing" }]);
-  });
-
-  it("drops failed mentions whose raw token would exceed the wire cap", async () => {
-    const tooLongRaw = `${"a".repeat(513)}.md`;
-
-    const { docs, failedMentions } = await buildMessageDocumentSnapshots(`see ${tooLongRaw}`, root);
-
-    expect(docs).toEqual([]);
-    expect(failedMentions).toEqual([]);
-  });
-
-  it("caps the number of failed mentions reported per message", async () => {
-    const names = Array.from({ length: 18 }, (_, i) => `missing-${i}.md`);
-
-    const { docs, failedMentions } = await buildMessageDocumentSnapshots(names.join(" "), root);
-
-    expect(docs).toEqual([]);
-    expect(failedMentions).toHaveLength(16);
-    expect(failedMentions.at(-1)).toEqual({ raw: "missing-15.md", reason: "missing" });
-  });
-
-  it("mixes successful snapshots and failed mentions in one message", async () => {
-    // Mixed message: a real path snapshots, an unreachable one fails. Both
-    // are reported so chat-view can render a real link + an inert chip side
-    // by side.
-    const { docs, rewrittenText, failedMentions } = await buildMessageDocumentSnapshots(
-      "wrote docs/intro.md but docs/nope.md is missing",
-      root,
-    );
-
-    expect(docs.map((d) => d.path)).toEqual(["docs/intro.md"]);
-    expect(rewrittenText).toBe("wrote [docs/intro.md](docs/intro.md) but docs/nope.md is missing");
-    expect(failedMentions).toEqual([{ raw: "docs/nope.md", reason: "missing" }]);
-  });
-
-  it("marks duplicate failed snapshot attempts with the original failure reason", async () => {
-    await writeFile(join(root, "too-big.md"), Buffer.alloc(MAX_DOC_SNAPSHOT_BYTES + 1, 0x61));
-
-    const { docs, failedMentions, skipped } = await buildMessageDocumentSnapshots(
-      "first too-big.md then too-big.md again",
-      root,
-    );
-
-    expect(docs).toEqual([]);
-    expect(skipped).toBe(1);
-    expect(failedMentions).toEqual([{ raw: "too-big.md", reason: "too-large" }]);
-  });
-
-  it("falls back to missing for a duplicate attempted key with no prior failure reason", async () => {
-    const NativeSet = globalThis.Set;
-    let createdSets = 0;
-    class SnapshotBlindSet<T> extends NativeSet<T> {
-      private readonly blindHas: boolean;
-
-      constructor(values?: Iterable<T> | null) {
-        super(values ?? undefined);
-        createdSets += 1;
-        this.blindHas = createdSets === 2;
-      }
-
-      override has(value: T): boolean {
-        if (this.blindHas) return false;
-        return super.has(value);
-      }
-    }
-
-    Object.defineProperty(globalThis, "Set", {
-      configurable: true,
-      value: SnapshotBlindSet,
-      writable: true,
-    });
-    try {
-      const { docs, failedMentions } = await buildMessageDocumentSnapshots("design.md design.md", root);
-
-      expect(docs.map((d) => d.path)).toEqual(["design.md"]);
-      expect(failedMentions).toEqual([{ raw: "design.md", reason: "missing" }]);
-    } finally {
-      Object.defineProperty(globalThis, "Set", {
-        configurable: true,
-        value: NativeSet,
-        writable: true,
-      });
-    }
-  });
-
-  it("enforces the per-message snapshot count budget", async () => {
-    const names = Array.from({ length: MAX_DOC_SNAPSHOTS_PER_MESSAGE + 1 }, (_, i) => `budget-${i}.md`);
-    const overflowName = names[MAX_DOC_SNAPSHOTS_PER_MESSAGE] ?? "budget-overflow.md";
-    await Promise.all(names.map((name) => writeFile(join(root, name), `# ${name}\n`, "utf8")));
-
-    const { docs, failedMentions, skipped } = await buildMessageDocumentSnapshots(names.join(" "), root);
-
-    expect(docs).toHaveLength(MAX_DOC_SNAPSHOTS_PER_MESSAGE);
-    expect(skipped).toBe(1);
-    expect(failedMentions).toEqual([{ raw: overflowName, reason: "budget-exceeded" }]);
-  });
-
-  it("skips files over the raw-byte snapshot cap", async () => {
-    await writeFile(join(root, "raw-too-large.md"), Buffer.alloc(MAX_DOC_SNAPSHOT_BYTES + 1, 0x61));
-
-    const { docs, failedMentions, skipped } = await buildMessageDocumentSnapshots("read raw-too-large.md", root);
-
-    expect(docs).toEqual([]);
-    expect(skipped).toBe(1);
-    expect(failedMentions).toEqual([{ raw: "raw-too-large.md", reason: "too-large" }]);
-  });
-
-  it("skips files whose UTF-8 replacement content exceeds the per-file cap", async () => {
-    await writeFile(join(root, "utf8-too-large.md"), Buffer.alloc(Math.floor(MAX_DOC_SNAPSHOT_BYTES / 2), 0xff));
-
-    const { docs, failedMentions, skipped } = await buildMessageDocumentSnapshots("read utf8-too-large.md", root);
-
-    expect(docs).toEqual([]);
-    expect(skipped).toBe(1);
-    expect(failedMentions).toEqual([{ raw: "utf8-too-large.md", reason: "too-large" }]);
-  });
-
-  it("enforces the aggregate snapshot byte budget after successful reads", async () => {
-    const chunkSize = Math.floor(MAX_TOTAL_DOC_SNAPSHOT_BYTES / 3);
-    const names = ["total-a.md", "total-b.md", "total-c.md", "total-d.md"];
-    await Promise.all(names.map((name) => writeFile(join(root, name), "a".repeat(chunkSize), "utf8")));
-
-    const { docs, failedMentions, skipped } = await buildMessageDocumentSnapshots(names.join(" "), root);
-
-    expect(docs.map((d) => d.path)).toEqual(["total-a.md", "total-b.md", "total-c.md"]);
-    expect(skipped).toBe(1);
-    expect(failedMentions).toEqual([{ raw: "total-d.md", reason: "budget-exceeded" }]);
-  });
-
-  it("inline-link failures stay silent — no failedMentions entry", async () => {
-    // The agent's explicit `[label](target.md)` already shows their intent
-    // to link. A failed snapshot for that target leaves the link as-is in
-    // the text; web's click handler no-ops on the missing snapshot. We
-    // deliberately do NOT add an inert chip — the proposal scopes the chip
-    // UI to scanner-bare-token positions.
-    const { docs, failedMentions } = await buildMessageDocumentSnapshots("click [docs](docs/nope.md) please", root);
-
-    expect(docs).toEqual([]);
-    expect(failedMentions).toEqual([]);
-  });
-
-  it("multi-path-in-one-code-span: first wins, second left inside the link text", async () => {
-    // Degenerate case: the agent crams two paths into one code span. The
-    // overlap-defensive applyRewrites picks the first match's widened span;
-    // the second match's rewrite is dropped. The second path's snapshot is
-    // still emitted so metadata stays self-consistent — it just isn't its
-    // own clickable target.
-    const { docs, rewrittenText } = await buildMessageDocumentSnapshots(
-      "see `docs/intro.md and design.md` together",
-      root,
-    );
-
-    const paths = docs.map((d) => d.path).sort();
-    expect(paths).toEqual(["design.md", "docs/intro.md"]);
-    expect(rewrittenText).toBe("see [`docs/intro.md and design.md`](docs/intro.md) together");
+  it("does not capture when no .md mention is present", async () => {
+    const { refs, rewrittenText } = await buildMessageDocumentSnapshots("just chatting", root, opts(uploader));
+    expect(refs).toEqual([]);
+    expect(rewrittenText).toBe("just chatting");
+    expect(uploads).toEqual([]);
   });
 });
 
-/**
- * Cross-agent doc preview: with a workspace fence, an absolute `.md` path that
- * realpaths into ANOTHER agent's workspace (same chat) under the shared
- * `workspaces/` common root is snapshotted with a global
- * `<ownerSlug>/<chatId>/<rel>` key and rewritten into an explicit link with a
- * short `<ownerSlug>/<rel>` display and the FULL global key as href. Self paths
- * get an explicit relative link; out-of-scope paths (other chat, other root,
- * hidden) stay verbatim.
- */
 describe("buildMessageDocumentSnapshots — cross-agent workspace fence", () => {
   let workspacesRoot: string;
   let selfRoot: string;
-  const chatId = "chat-xyz";
-  const selfSlug = "coder";
-  const otherSlug = "assistant";
+  let crossRoot: string;
+  const CHAT = "22222222-2222-4222-8222-222222222222";
 
   beforeAll(async () => {
     workspacesRoot = await mkdtemp(join(tmpdir(), "doc-snap-ws-"));
-    // self workspace: workspaces/coder/chat-xyz
-    selfRoot = join(workspacesRoot, selfSlug, chatId);
+    selfRoot = join(workspacesRoot, "coder", CHAT);
+    crossRoot = join(workspacesRoot, "assistant", CHAT);
     await mkdir(selfRoot, { recursive: true });
-    await writeFile(join(selfRoot, "mine.md"), "# mine\n", "utf8");
-    // Self file whose relative path collides with a cross short form
-    // (`assistant/design.md`) — used to prove the collision → full-key rewrite.
-    await mkdir(join(selfRoot, otherSlug), { recursive: true });
-    await writeFile(join(selfRoot, otherSlug, "design.md"), "# my own assistant notes\n", "utf8");
-    // sibling agent workspace (same chat): workspaces/assistant/chat-xyz
-    const otherRoot = join(workspacesRoot, otherSlug, chatId);
-    await mkdir(join(otherRoot, "docs"), { recursive: true });
-    await writeFile(join(otherRoot, "design.md"), "# their design\n", "utf8");
-    await writeFile(join(otherRoot, "docs", "intro.md"), "# their intro\n", "utf8");
-    await mkdir(join(otherRoot, ".agent"), { recursive: true });
-    await writeFile(join(otherRoot, ".agent", "secret.md"), "# their secret\n", "utf8");
-    await symlink(join(otherRoot, ".agent", "secret.md"), join(otherRoot, "leak.md"));
-    // sibling agent in a DIFFERENT chat: workspaces/assistant/other-chat
-    const otherChatRoot = join(workspacesRoot, otherSlug, "other-chat");
-    await mkdir(otherChatRoot, { recursive: true });
-    await writeFile(join(otherChatRoot, "private.md"), "# other chat\n", "utf8");
+    await mkdir(crossRoot, { recursive: true });
+    await writeFile(join(crossRoot, "plan.md"), "# their plan\n", "utf8");
   });
 
   afterAll(async () => {
     await rm(workspacesRoot, { recursive: true, force: true });
   });
 
-  const fence = () => ({ workspacesRoot, chatId, selfSlug });
+  function fence() {
+    return { workspacesRoot, chatId: CHAT, selfSlug: "coder" };
+  }
 
-  it("snapshots a sibling agent's doc with a global key + short rewrite", async () => {
-    const abs = join(workspacesRoot, otherSlug, chatId, "design.md");
-    const { docs, rewrittenText } = await buildMessageDocumentSnapshots(`see ${abs} please`, selfRoot, fence());
-
-    expect(docs.map((d) => d.path)).toEqual([`${otherSlug}/${chatId}/design.md`]);
-    expect(docs[0]?.content).toBe("# their design\n");
-    // Explicit link: short `<slug>/<rel>` display, FULL global key href so web
-    // direct-matches without chatId re-expansion.
-    expect(rewrittenText).toBe(`see [${otherSlug}/design.md](${otherSlug}/${chatId}/design.md) please`);
-  });
-
-  it("preserves subdir + :line suffix in the cross rewrite", async () => {
-    const abs = join(workspacesRoot, otherSlug, chatId, "docs", "intro.md");
-    const { docs, rewrittenText } = await buildMessageDocumentSnapshots(`open ${abs}:10 now`, selfRoot, fence());
-
-    expect(docs.map((d) => d.path)).toEqual([`${otherSlug}/${chatId}/docs/intro.md`]);
-    expect(rewrittenText).toBe(`open [${otherSlug}/docs/intro.md:10](${otherSlug}/${chatId}/docs/intro.md) now`);
-  });
-
-  it("rewrites a self path into an explicit relative link even with a fence", async () => {
-    const abs = join(selfRoot, "mine.md");
-    const { docs, rewrittenText } = await buildMessageDocumentSnapshots(`my ${abs} file`, selfRoot, fence());
-
-    expect(docs.map((d) => d.path)).toEqual(["mine.md"]);
-    expect(rewrittenText).toBe("my [mine.md](mine.md) file");
-  });
-
-  it("rejects a sibling doc from a DIFFERENT chat (chat-scope fence)", async () => {
-    const abs = join(workspacesRoot, otherSlug, "other-chat", "private.md");
-    const text = `cross-chat ${abs} nope`;
-    const { docs, rewrittenText } = await buildMessageDocumentSnapshots(text, selfRoot, fence());
-
-    expect(docs).toEqual([]);
-    expect(rewrittenText).toBe(text);
-  });
-
-  it("classifies a missing cross-workspace path as missing", async () => {
-    const abs = join(workspacesRoot, otherSlug, chatId, "missing-cross.md");
-
-    const { docs, failedMentions } = await buildMessageDocumentSnapshots(`see ${abs}`, selfRoot, fence());
-
-    expect(docs).toEqual([]);
-    expect(failedMentions).toEqual([{ raw: abs, reason: "missing" }]);
-  });
-
-  it("classifies a shallow path under the workspace common root as out-of-fence", async () => {
-    const abs = join(workspacesRoot, "loose.md");
-    await writeFile(abs, "# loose\n", "utf8");
-
-    const { docs, failedMentions } = await buildMessageDocumentSnapshots(`see ${abs}`, selfRoot, fence());
-
-    expect(docs).toEqual([]);
-    expect(failedMentions).toEqual([{ raw: abs, reason: "out-of-fence" }]);
-  });
-
-  it("classifies an absolute path outside the workspace common root as out-of-fence with a fence present", async () => {
-    const outside = await mkdtemp(join(tmpdir(), "doc-snap-cross-outside-"));
-    try {
-      const abs = join(outside, "outside.md");
-      await writeFile(abs, "# outside\n", "utf8");
-
-      const { docs, failedMentions } = await buildMessageDocumentSnapshots(`see ${abs}`, selfRoot, fence());
-
-      expect(docs).toEqual([]);
-      expect(failedMentions).toEqual([{ raw: abs, reason: "out-of-fence" }]);
-    } finally {
-      await rm(outside, { recursive: true, force: true });
-    }
-  });
-
-  it("handles a workspace common root whose realpath is the filesystem root", async () => {
-    const detachedHome = await mkdtemp(join(tmpdir(), "doc-snap-root-ws-home-"));
-    const rootWorkspace = await mkdtemp(join(tmpdir(), "doc-snap-root-ws-"));
-    try {
-      const abs = join(rootWorkspace, "assistant", chatId, "notes.md");
-      await mkdir(join(rootWorkspace, "assistant", chatId), { recursive: true });
-      await writeFile(abs, "# root workspace\n", "utf8");
-
-      const { docs, failedMentions } = await buildMessageDocumentSnapshots(`see ${abs}`, detachedHome, {
-        workspacesRoot: "/",
-        chatId,
-        selfSlug,
-      });
-
-      expect(docs).toEqual([]);
-      expect(failedMentions).toEqual([{ raw: abs, reason: "out-of-fence" }]);
-    } finally {
-      await rm(detachedHome, { recursive: true, force: true });
-      await rm(rootWorkspace, { recursive: true, force: true });
-    }
-  });
-
-  it("rejects a sibling symlink whose realpath crosses into a hidden dir", async () => {
-    const abs = join(workspacesRoot, otherSlug, chatId, "leak.md");
-    const text = `leak ${abs}`;
-    const { docs, rewrittenText } = await buildMessageDocumentSnapshots(text, selfRoot, fence());
-
-    expect(docs).toEqual([]);
-    expect(rewrittenText).toBe(text);
-  });
-
-  it("classifies a cross path with a hidden real segment as hidden", async () => {
-    const abs = join(workspacesRoot, otherSlug, chatId, ".hidden", "notes.md");
-    await mkdir(join(workspacesRoot, otherSlug, chatId, ".hidden"), { recursive: true });
-    await writeFile(abs, "# hidden\n", "utf8");
-
-    const { docs, failedMentions } = await buildMessageDocumentSnapshots(`see ${abs}`, selfRoot, fence());
-
-    expect(docs).toEqual([]);
-    expect(failedMentions).toEqual([{ raw: abs, reason: "hidden-segment" }]);
-  });
-
-  it("classifies an absolute path under the self slug but outside this agent home as missing", async () => {
-    const abs = join(workspacesRoot, selfSlug, chatId, "foreign-self.md");
-    const detachedHome = await mkdtemp(join(tmpdir(), "doc-snap-detached-home-"));
-    await writeFile(abs, "# other self checkout\n", "utf8");
-
-    try {
-      const { docs, failedMentions } = await buildMessageDocumentSnapshots(`see ${abs}`, detachedHome, fence());
-
-      expect(docs).toEqual([]);
-      expect(failedMentions).toEqual([{ raw: abs, reason: "missing" }]);
-    } finally {
-      await rm(detachedHome, { recursive: true, force: true });
-    }
-  });
-
-  it("classifies a sibling .md directory as missing", async () => {
-    const abs = join(workspacesRoot, otherSlug, chatId, "folder.md");
-    await mkdir(abs, { recursive: true });
-
-    const { docs, failedMentions } = await buildMessageDocumentSnapshots(`see ${abs}`, selfRoot, fence());
-
-    expect(docs).toEqual([]);
-    expect(failedMentions).toEqual([{ raw: abs, reason: "missing" }]);
-  });
-
-  it("classifies a cross path rejected by canonical key validation as unreadable", async () => {
-    const unusualSlug = "assistant?debug=true";
-    const abs = join(workspacesRoot, unusualSlug, chatId, "notes.md");
-    await mkdir(join(workspacesRoot, unusualSlug, chatId), { recursive: true });
-    await writeFile(abs, "# unusual slug\n", "utf8");
-
-    const { docs, failedMentions } = await buildMessageDocumentSnapshots(`see [notes](${abs})`, selfRoot, fence());
-
-    expect(docs).toEqual([]);
-    expect(failedMentions).toEqual([]);
-  });
-
-  it("does NOT cross-resolve when no fence is supplied (opt-in)", async () => {
-    const abs = join(workspacesRoot, otherSlug, chatId, "design.md");
-    const text = `see ${abs} please`;
-    const { docs, rewrittenText } = await buildMessageDocumentSnapshots(text, selfRoot);
-
-    expect(docs).toEqual([]);
-    expect(rewrittenText).toBe(text);
-  });
-
-  it("a self ref and a cross ref that share a short form get DISTINCT hrefs (no collision)", async () => {
-    // Self file `assistant/design.md` (relative) AND the sibling agent's
-    // `assistant/<chat>/design.md` are both referenced — both display as
-    // `assistant/design.md`. With explicit links the hrefs are the canonical
-    // keys (self relative vs cross GLOBAL), so they can never collide and web
-    // direct-matches each to the right snapshot — no collision handling needed.
-    const crossAbs = join(workspacesRoot, otherSlug, chatId, "design.md");
-    const text = `self ${otherSlug}/design.md and cross ${crossAbs}`;
-    const { docs, rewrittenText } = await buildMessageDocumentSnapshots(text, selfRoot, fence());
-
-    expect(docs.map((d) => d.path).sort()).toEqual([`${otherSlug}/${chatId}/design.md`, `${otherSlug}/design.md`]);
-    expect(rewrittenText).toBe(
-      `self [${otherSlug}/design.md](${otherSlug}/design.md) and ` +
-        `cross [${otherSlug}/design.md](${otherSlug}/${chatId}/design.md)`,
+  it("captures a cross-agent doc under the shared root and uses the short source path", async () => {
+    const stub = stubUploader();
+    const abs = join(crossRoot, "plan.md");
+    const { refs, rewrittenText } = await buildMessageDocumentSnapshots(
+      `see ${abs} please`,
+      selfRoot,
+      opts(stub.uploader),
+      fence(),
     );
+    expect(refs).toHaveLength(1);
+    expect(refs[0]?.source?.path).toBe("assistant/plan.md");
+    expect(rewrittenText).toBe(`see [assistant/plan.md](attachment:${fakeUploadId(1)}) please`);
+  });
+
+  it("does not capture a cross-agent doc when no fence is supplied", async () => {
+    const stub = stubUploader();
+    const abs = join(crossRoot, "plan.md");
+    const { refs } = await buildMessageDocumentSnapshots(`see ${abs}`, selfRoot, opts(stub.uploader));
+    expect(refs).toEqual([]);
   });
 });
 
-/**
- * Worktree-fence widening (this PR): the self fence now extends to the FULL
- * agent home, not just the source-repo top, so absolute paths into the
- * agent's on-demand `<agentHome>/worktrees/<task>/` checkouts also snapshot
- * (PR #498's workflow). Relative mentions in a single-repo workspace are
- * promoted to `<localPath>/<rel>` so the abs + rel forms of a source-repo
- * file share one canonical key.
- */
-describe("buildMessageDocumentSnapshots — wide self-fence over agent home", () => {
-  let agentHome: string;
-
-  beforeAll(async () => {
-    // Layout mirrors the post-#506 production tree:
-    //   <agentHome>/first-tree/          predeclared source repo (top level)
-    //   <agentHome>/worktrees/<task>/    agent-on-demand worktree
-    //   <agentHome>/docs/                agent-home-scoped notes
-    //   <agentHome>/.agent/              MUST stay rejected via hidden-segment check
-    agentHome = await mkdtemp(join(tmpdir(), "doc-snap-agenthome-"));
-    await mkdir(join(agentHome, "first-tree", "docs"), { recursive: true });
-    await writeFile(join(agentHome, "first-tree", "docs", "intro.md"), "# intro\n", "utf8");
-    await mkdir(join(agentHome, "worktrees", "task-x", "docs"), { recursive: true });
-    await writeFile(join(agentHome, "worktrees", "task-x", "docs", "design.md"), "# design\n", "utf8");
-    await mkdir(join(agentHome, "docs"), { recursive: true });
-    await writeFile(join(agentHome, "docs", "note.md"), "# note\n", "utf8");
-    await mkdir(join(agentHome, ".agent"), { recursive: true });
-    await writeFile(join(agentHome, ".agent", "secret.md"), "# secret\n", "utf8");
-  });
-
-  afterAll(async () => {
-    await rm(agentHome, { recursive: true, force: true });
-  });
-
-  it("snapshots a worktree-scoped absolute .md (#506+#498 idiom — the bug this PR fixes)", async () => {
-    // Pre-fix the snapshot scanner gated absolute paths on the source-repo top
-    // and dropped this mention back to plain text. Wide fence + agent-home-
-    // relative key restores the preview.
-    const abs = join(agentHome, "worktrees", "task-x", "docs", "design.md");
-    const { docs, rewrittenText } = await buildMessageDocumentSnapshots(`wrote ${abs} just now`, {
-      agentHome,
-      singleRepoLocalPath: "first-tree",
-    });
-
-    expect(docs.map((d) => d.path)).toEqual(["worktrees/task-x/docs/design.md"]);
-    expect(docs[0]?.content).toBe("# design\n");
-    expect(rewrittenText).toBe("wrote [worktrees/task-x/docs/design.md](worktrees/task-x/docs/design.md) just now");
-  });
-
-  it("promotes a relative source-repo mention to `<localPath>/<rel>` so abs + rel share one key", async () => {
-    // `docs/intro.md` written relatively was the pre-#506 idiom; we keep it
-    // resolving against the source-repo top so the agent's old habits still
-    // work. The snapshot key is PROMOTED so the absolute form
-    // `<agentHome>/first-tree/docs/intro.md` produces the same canonical key —
-    // web cache stays single-keyed per file.
-    const abs = join(agentHome, "first-tree", "docs", "intro.md");
-    const text = `relative docs/intro.md and absolute ${abs}`;
-    const { docs, rewrittenText } = await buildMessageDocumentSnapshots(text, {
-      agentHome,
-      singleRepoLocalPath: "first-tree",
-    });
-
-    expect(docs.map((d) => d.path)).toEqual(["first-tree/docs/intro.md"]);
-    expect(rewrittenText).toBe(
-      "relative [first-tree/docs/intro.md](first-tree/docs/intro.md) and " +
-        "absolute [first-tree/docs/intro.md](first-tree/docs/intro.md)",
-    );
-  });
-
-  it("snapshots an agent-home-scoped absolute .md (sibling of the source repo)", async () => {
-    // `<agentHome>/docs/note.md` is in neither the source repo nor a worktree;
-    // it's an agent-home note (CLAUDE.md, README, scratch). The wide fence
-    // accepts it as a valid snapshot target.
-    const abs = join(agentHome, "docs", "note.md");
-    const { docs, rewrittenText } = await buildMessageDocumentSnapshots(`see ${abs}`, {
-      agentHome,
-      singleRepoLocalPath: "first-tree",
-    });
-
-    expect(docs.map((d) => d.path)).toEqual(["docs/note.md"]);
-    expect(rewrittenText).toBe("see [docs/note.md](docs/note.md)");
-  });
-
-  it("rejects an absolute path outside the agent home — wide fence is not a free-for-all", async () => {
-    const outside = await mkdtemp(join(tmpdir(), "doc-snap-outside-wide-"));
+describe("buildMessageDocumentSnapshots — orgId plumbing", () => {
+  it("passes the orgId through to every upload", async () => {
+    const root = await mkdtemp(join(tmpdir(), "doc-snap-org-"));
     try {
-      await writeFile(join(outside, "external.md"), "# external\n", "utf8");
-      const abs = join(outside, "external.md");
-      const text = `out-of-home ${abs}`;
-      const { docs, rewrittenText } = await buildMessageDocumentSnapshots(text, {
-        agentHome,
-        singleRepoLocalPath: "first-tree",
-      });
-
-      expect(docs).toEqual([]);
-      expect(rewrittenText).toBe(text);
+      await writeFile(join(root, "a.md"), "# a\n", "utf8");
+      const realRoot = await realpath(root);
+      const stub = stubUploader();
+      await buildMessageDocumentSnapshots("see a.md", realRoot, { uploader: stub.uploader, orgId: "org-xyz" });
+      expect(stub.uploads.map((u) => u.orgId)).toEqual(["org-xyz"]);
+      // Spies stay quiet — no global mocks here.
+      vi.clearAllMocks();
     } finally {
-      await rm(outside, { recursive: true, force: true });
-    }
-  });
-
-  it("still rejects a hidden-segment mention inside the agent home (.agent/secret.md)", async () => {
-    const abs = join(agentHome, ".agent", "secret.md");
-    const text = `secret ${abs}`;
-    const { docs, rewrittenText } = await buildMessageDocumentSnapshots(text, {
-      agentHome,
-      singleRepoLocalPath: "first-tree",
-    });
-
-    expect(docs).toEqual([]);
-    expect(rewrittenText).toBe(text);
-  });
-
-  it("falls back to agent-home resolution when singleRepoLocalPath is absent (zero/multi-repo)", async () => {
-    // No promotion: relative `first-tree/docs/intro.md` is interpreted directly
-    // against the agent home and resolves cleanly without prefixing.
-    const { docs, rewrittenText } = await buildMessageDocumentSnapshots("see first-tree/docs/intro.md please", {
-      agentHome,
-    });
-
-    expect(docs.map((d) => d.path)).toEqual(["first-tree/docs/intro.md"]);
-    expect(rewrittenText).toBe("see [first-tree/docs/intro.md](first-tree/docs/intro.md) please");
-  });
-
-  it("gracefully degrades when singleRepoLocalPath points outside the agent home (no promotion)", async () => {
-    // Defence in depth: a misconfigured `localPath: "../escape"` must not let
-    // docBase wander outside the fence. The resolver silently drops the
-    // promotion and falls back to agent-home resolution.
-    const abs = join(agentHome, "docs", "note.md");
-    const { docs, rewrittenText } = await buildMessageDocumentSnapshots(`see ${abs}`, {
-      agentHome,
-      singleRepoLocalPath: "../escape",
-    });
-
-    expect(docs.map((d) => d.path)).toEqual(["docs/note.md"]);
-    expect(rewrittenText).toBe("see [docs/note.md](docs/note.md)");
-  });
-
-  it("drops promotion when singleRepoLocalPath resolves to the agent home itself", async () => {
-    const { docs, rewrittenText } = await buildMessageDocumentSnapshots("see docs/note.md", {
-      agentHome,
-      singleRepoLocalPath: ".",
-    });
-
-    expect(docs.map((d) => d.path)).toEqual(["docs/note.md"]);
-    expect(rewrittenText).toBe("see [docs/note.md](docs/note.md)");
-  });
-
-  it("gracefully degrades when singleRepoLocalPath resolves outside the agent home", async () => {
-    const outside = await mkdtemp(join(tmpdir(), "doc-snap-localpath-outside-"));
-    try {
-      await symlink(outside, join(agentHome, "outside-source"));
-
-      const { docs, rewrittenText } = await buildMessageDocumentSnapshots("see docs/note.md", {
-        agentHome,
-        singleRepoLocalPath: "outside-source",
-      });
-
-      expect(docs.map((d) => d.path)).toEqual(["docs/note.md"]);
-      expect(rewrittenText).toBe("see [docs/note.md](docs/note.md)");
-    } finally {
-      await rm(outside, { recursive: true, force: true });
-      await rm(join(agentHome, "outside-source"), { force: true });
-    }
-  });
-
-  it("promotes a missing relative source-repo mention before the read-time miss", async () => {
-    const { docs, failedMentions, skipped } = await buildMessageDocumentSnapshots("see docs/missing-promoted.md", {
-      agentHome,
-      singleRepoLocalPath: "first-tree",
-    });
-
-    expect(docs).toEqual([]);
-    expect(skipped).toBe(1);
-    expect(failedMentions).toEqual([{ raw: "docs/missing-promoted.md", reason: "missing" }]);
-  });
-
-  it("classifies an inside-home path rejected by canonical key validation as unreadable", async () => {
-    const abs = join(agentHome, "query?segment", "note.md");
-    await mkdir(join(agentHome, "query?segment"), { recursive: true });
-    await writeFile(abs, "# query segment\n", "utf8");
-
-    const { docs, failedMentions } = await buildMessageDocumentSnapshots(`see [note](${abs})`, {
-      agentHome,
-      singleRepoLocalPath: "first-tree",
-    });
-
-    expect(docs).toEqual([]);
-    expect(failedMentions).toEqual([]);
-  });
-
-  it("classifies an inside-home directory rejected by canonical key validation as missing", async () => {
-    const abs = join(agentHome, "dir?segment", "folder.md");
-    await mkdir(abs, { recursive: true });
-
-    const { docs, failedMentions } = await buildMessageDocumentSnapshots(`see [folder](${abs})`, {
-      agentHome,
-      singleRepoLocalPath: "first-tree",
-    });
-
-    expect(docs).toEqual([]);
-    expect(failedMentions).toEqual([]);
-  });
-
-  it("rejects a relative symlink that resolves outside the agent home", async () => {
-    const outside = await mkdtemp(join(tmpdir(), "doc-snap-rel-outside-"));
-    try {
-      await writeFile(join(outside, "external.md"), "# external\n", "utf8");
-      await symlink(join(outside, "external.md"), join(agentHome, "external-link.md"));
-
-      const { docs, failedMentions } = await buildMessageDocumentSnapshots("see external-link.md", {
-        agentHome,
-      });
-
-      expect(docs).toEqual([]);
-      expect(failedMentions).toEqual([{ raw: "external-link.md", reason: "out-of-fence" }]);
-    } finally {
-      await rm(outside, { recursive: true, force: true });
-      await rm(join(agentHome, "external-link.md"), { force: true });
-    }
-  });
-
-  it("handles an agent home whose realpath is the filesystem root", async () => {
-    const rootScoped = await mkdtemp(join(tmpdir(), "doc-snap-root-home-"));
-    try {
-      const abs = join(rootScoped, "root-branch.md");
-      await writeFile(abs, "# root branch\n", "utf8");
-      const rejected = join(rootScoped, "query?x", "note.md");
-      await mkdir(join(rootScoped, "query?x"), { recursive: true });
-      await writeFile(rejected, "# rejected\n", "utf8");
-      const relativeToRoot = (await realpath(abs)).replace(/^\/+/, "");
-
-      const absoluteOut = await buildMessageDocumentSnapshots(`see ${abs}`, "/");
-      const relativeOut = await buildMessageDocumentSnapshots(`see ${relativeToRoot}`, "/");
-      const promotedOut = await buildMessageDocumentSnapshots("see root-branch.md", {
-        agentHome: "/",
-        singleRepoLocalPath: relativeToRoot.replace(/\/root-branch\.md$/, ""),
-      });
-      const rejectedOut = await buildMessageDocumentSnapshots(`see [root](${rejected})`, "/");
-
-      expect(absoluteOut.docs.map((d) => d.path)).toEqual([relativeToRoot]);
-      expect(relativeOut.docs.map((d) => d.path)).toEqual([relativeToRoot]);
-      expect(promotedOut.docs.map((d) => d.path)).toEqual([relativeToRoot]);
-      expect(rejectedOut.docs).toEqual([]);
-    } finally {
-      await rm(rootScoped, { recursive: true, force: true });
+      await rm(root, { recursive: true, force: true });
     }
   });
 });

--- a/packages/client/src/__tests__/result-sink-capture-failure.test.ts
+++ b/packages/client/src/__tests__/result-sink-capture-failure.test.ts
@@ -1,28 +1,24 @@
 import { describe, expect, it, vi } from "vitest";
 
 /**
- * Regression for the codex review finding: when snapshot validation throws,
- * result-sink must send the ORIGINAL body — never the rewritten explicit-link
- * text — so it can't ship `[display](key)` links with no matching snapshot
- * (dead links). Keeps the "rewritten ⇔ snapshotted" invariant atomic.
+ * When doc capture throws, result-sink must send the ORIGINAL body — never the
+ * rewritten explicit-link text — and attach no attachment metadata, so it can't
+ * ship `attachment:<id>` links with no matching ref (dead links). Keeps the
+ * "rewritten ⇔ has-ref" invariant atomic.
  *
- * We force the failure by mocking the snapshot builder to return a doc that
- * fails the shared schema (`sha256` not 64 hex), which makes
- * `documentContextSchema.parse` throw inside result-sink.
+ * We force the failure by mocking the capture builder to throw.
  */
 vi.mock("../runtime/doc-snapshots.js", () => ({
-  buildMessageDocumentSnapshots: vi.fn(async () => ({
-    docs: [{ path: "design.md", sha256: "not-64-hex", size: 1, content: "x" }],
-    skipped: 0,
-    rewrittenText: "see [design.md](design.md) please",
-  })),
+  buildMessageDocumentSnapshots: vi.fn(async () => {
+    throw new Error("capture exploded");
+  }),
 }));
 
 import { createResultSink } from "../runtime/result-sink.js";
 import type { FirstTreeHubSDK } from "../sdk.js";
 
-describe("createResultSink — capture/parse failure preserves the original body", () => {
-  it("sends the ORIGINAL text and no documentContext when snapshot validation throws", async () => {
+describe("createResultSink — capture failure preserves the original body", () => {
+  it("sends the ORIGINAL text and no attachment metadata when capture throws", async () => {
     const sendMessage = vi.fn().mockResolvedValue(undefined);
     const sdk = { serverUrl: "http://test", sendMessage } as unknown as FirstTreeHubSDK;
     const sink = createResultSink({
@@ -41,6 +37,7 @@ describe("createResultSink — capture/parse failure preserves the original body
       clearTrigger: () => {},
       log: () => {},
       getSelfFence: vi.fn().mockResolvedValue({ agentHome: "/ws/coder/chat-1" }),
+      getOrgId: vi.fn().mockResolvedValue("org-1"),
       workspacesRoot: "/ws",
       selfSlug: "coder",
     });
@@ -48,9 +45,10 @@ describe("createResultSink — capture/parse failure preserves the original body
     await sink("see design.md please");
 
     const [, body] = sendMessage.mock.calls[0] ?? [];
-    const sent = body as { content?: string; metadata?: { documentContext?: unknown } };
-    // Body restored to the original — NOT the rewritten explicit-link form.
+    const sent = body as { content?: string; metadata?: { attachments?: unknown; documentContext?: unknown } };
+    // Body restored to the original — NOT a rewritten explicit-link form.
     expect(sent.content).toBe("see design.md please");
+    expect(sent.metadata?.attachments).toBeUndefined();
     expect(sent.metadata?.documentContext).toBeUndefined();
   });
 });

--- a/packages/client/src/__tests__/result-sink.test.ts
+++ b/packages/client/src/__tests__/result-sink.test.ts
@@ -26,17 +26,39 @@ type SinkFixtures = {
   trigger: Trigger | null;
   sendMessage?: ReturnType<typeof vi.fn>;
   getSelfFence?: () => Promise<SelfFence | null>;
+  /** Defaults to a real org id so doc capture is enabled when a self-fence is
+   *  also provided. Pass `null` to disable capture. */
+  orgId?: string | null;
 };
+
+const FAKE_ORG_ID = "11111111-1111-4111-8111-111111111111";
+
+function fakeUploadId(seq: number): string {
+  return `00000000-0000-4000-8000-${seq.toString(16).padStart(12, "0")}`;
+}
 
 function buildSink(fx: SinkFixtures) {
   const sendMessage = fx.sendMessage ?? vi.fn().mockResolvedValue(undefined);
   const logs: string[] = [];
 
   let trigger = fx.trigger;
+  let seq = 0;
+  // Stub the SDK upload the sink calls during doc capture; mints deterministic
+  // uuid-shaped ids so the rewritten `attachment:<id>` links are assertable.
+  const uploadAttachment = vi.fn(
+    async (o: { bytes: Uint8Array | Buffer; mimeType: string; filename: string; orgId: string }) => {
+      seq += 1;
+      const bytes = Buffer.from(o.bytes);
+      return { id: fakeUploadId(seq), mimeType: o.mimeType, filename: o.filename, sizeBytes: bytes.byteLength };
+    },
+  );
   const sdk = {
     serverUrl: "http://test",
     sendMessage,
+    uploadAttachment,
   } as unknown as FirstTreeHubSDK;
+
+  const orgId = fx.orgId === undefined ? FAKE_ORG_ID : fx.orgId;
 
   const sink = createResultSink({
     sdk,
@@ -56,9 +78,10 @@ function buildSink(fx: SinkFixtures) {
     },
     log: (msg) => logs.push(msg),
     getSelfFence: fx.getSelfFence,
+    getOrgId: async () => orgId,
   });
 
-  return { sink, sendMessage, logs };
+  return { sink, sendMessage, uploadAttachment, logs };
 }
 
 describe("createResultSink — forwardResult enrichment", () => {
@@ -116,7 +139,7 @@ describe("createResultSink — forwardResult enrichment", () => {
     expect(body.metadata?.mentions).toBeUndefined();
   });
 
-  describe("inline snapshot variant", () => {
+  describe("attachment-ref capture variant", () => {
     let worktree: string;
 
     beforeAll(async () => {
@@ -125,8 +148,6 @@ describe("createResultSink — forwardResult enrichment", () => {
       await writeFile(join(worktree, "api.md"), "# api\n", "utf8");
       await mkdir(join(worktree, "docs"), { recursive: true });
       await writeFile(join(worktree, "docs", "intro.md"), "# intro\n", "utf8");
-      // For symlink escape test: a "public" link whose realpath actually lives
-      // inside `.agent/`.
       await mkdir(join(worktree, ".agent"), { recursive: true });
       await writeFile(join(worktree, ".agent", "secret.md"), "# secret\n", "utf8");
       await symlink(join(worktree, ".agent", "secret.md"), join(worktree, "public.md"));
@@ -136,8 +157,8 @@ describe("createResultSink — forwardResult enrichment", () => {
       await rm(worktree, { recursive: true, force: true });
     });
 
-    it("emits kind=snapshot when basePath resolves and the text references a real .md", async () => {
-      const { sink, sendMessage } = buildSink({
+    it("attaches an AttachmentRef and rewrites to an attachment link when a real .md is referenced", async () => {
+      const { sink, sendMessage, uploadAttachment } = buildSink({
         trigger: { messageId: "m1", senderId: "agent-peer" },
         getSelfFence: vi.fn().mockResolvedValue({ agentHome: worktree } satisfies SelfFence),
       });
@@ -145,26 +166,20 @@ describe("createResultSink — forwardResult enrichment", () => {
       await sink("see [design](design.md)");
 
       const body = sendMessage.mock.calls[0]?.[1] as {
-        metadata?: {
-          documentContext?: {
-            kind?: string;
-            docs?: Array<{ path: string; content: string; size: number; sha256: string }>;
-          };
-        };
+        content?: string;
+        metadata?: { attachments?: Array<{ kind: string; source?: { path: string }; sha256?: string; size: number }> };
       };
-      expect(body.metadata?.documentContext?.kind).toBe("snapshot");
-      expect(body.metadata?.documentContext?.docs).toHaveLength(1);
-      const [doc] = body.metadata?.documentContext?.docs ?? [];
-      expect(doc?.path).toBe("design.md");
-      expect(doc?.content).toBe("# design\n\nbody.\n");
-      expect(doc?.size).toBe(16);
-      expect(doc?.sha256).toMatch(/^[0-9a-f]{64}$/);
+      expect(body.metadata?.attachments).toHaveLength(1);
+      const [ref] = body.metadata?.attachments ?? [];
+      expect(ref?.kind).toBe("document");
+      expect(ref?.source?.path).toBe("design.md");
+      expect(ref?.size).toBe(16);
+      expect(ref?.sha256).toMatch(/^[0-9a-f]{64}$/);
+      expect(body.content).toBe(`see [design](attachment:${fakeUploadId(1)})`);
+      expect(uploadAttachment).toHaveBeenCalledTimes(1);
     });
 
-    it("emits kind=snapshot for a bare `.md` mention (no inline markdown link wrapping)", async () => {
-      // Web-side `linkifyMarkdownDocPaths` wraps the same bare token as
-      // `[design.md](design.md)` before rendering — both sides must produce
-      // the same canonical key so the click hits the snapshot in cache.
+    it("captures a bare `.md` mention and rewrites it to an explicit attachment link", async () => {
       const { sink, sendMessage } = buildSink({
         trigger: { messageId: "m1", senderId: "agent-peer" },
         getSelfFence: vi.fn().mockResolvedValue({ agentHome: worktree } satisfies SelfFence),
@@ -173,27 +188,30 @@ describe("createResultSink — forwardResult enrichment", () => {
       await sink("created design.md just now");
 
       const body = sendMessage.mock.calls[0]?.[1] as {
-        metadata?: { documentContext?: { kind?: string; docs?: Array<{ path: string }> } };
+        content?: string;
+        metadata?: { attachments?: Array<{ source?: { path: string } }> };
       };
-      expect(body.metadata?.documentContext?.kind).toBe("snapshot");
-      expect(body.metadata?.documentContext?.docs?.map((d) => d.path)).toEqual(["design.md"]);
+      expect(body.metadata?.attachments?.map((a) => a.source?.path)).toEqual(["design.md"]);
+      expect(body.content).toBe(`created [design.md](attachment:${fakeUploadId(1)}) just now`);
     });
 
-    it("strips :line[:col] from bare paths so snapshot keys match what the click handler resolves", async () => {
-      const { sink, sendMessage } = buildSink({
+    it("disables capture (no attachments) when the org id is unresolvable", async () => {
+      const { sink, sendMessage, uploadAttachment } = buildSink({
         trigger: { messageId: "m1", senderId: "agent-peer" },
         getSelfFence: vi.fn().mockResolvedValue({ agentHome: worktree } satisfies SelfFence),
+        orgId: null,
       });
 
-      await sink("see docs/intro.md:42:1 for details");
+      await sink("see [design](design.md)");
 
-      const body = sendMessage.mock.calls[0]?.[1] as {
-        metadata?: { documentContext?: { kind?: string; docs?: Array<{ path: string }> } };
-      };
-      expect(body.metadata?.documentContext?.docs?.map((d) => d.path)).toEqual(["docs/intro.md"]);
+      const body = sendMessage.mock.calls[0]?.[1] as { content?: string; metadata?: unknown };
+      expect(body.metadata).toBeUndefined();
+      // Body untouched — the mention stays plain text.
+      expect(body.content).toBe("see [design](design.md)");
+      expect(uploadAttachment).not.toHaveBeenCalled();
     });
 
-    it("rejects dotfiles / hidden dirs and attaches NO documentContext when no docs survive", async () => {
+    it("rejects dotfiles / hidden dirs and attaches no metadata when nothing survives", async () => {
       const { sink, sendMessage } = buildSink({
         trigger: { messageId: "m1", senderId: "agent-peer" },
         getSelfFence: vi.fn().mockResolvedValue({ agentHome: worktree } satisfies SelfFence),
@@ -201,13 +219,8 @@ describe("createResultSink — forwardResult enrichment", () => {
 
       await sink("hidden: [secret](.agent/secret.md)");
 
-      const body = sendMessage.mock.calls[0]?.[1] as {
-        metadata?: { documentContext?: unknown };
-      };
-      // The hidden path is rejected, leaving zero snapshots — and we no longer
-      // emit the legacy `kind:"path"` fallback (which would leak the worktree
-      // absolute path into history), so there is no documentContext at all.
-      expect(body.metadata?.documentContext).toBeUndefined();
+      const body = sendMessage.mock.calls[0]?.[1] as { metadata?: { attachments?: unknown } };
+      expect(body.metadata?.attachments).toBeUndefined();
     });
 
     it("emits failedMentions for unresolved bare doc mentions", async () => {
@@ -224,9 +237,7 @@ describe("createResultSink — forwardResult enrichment", () => {
       expect(body.metadata?.documentContext?.failedMentions).toEqual([{ raw: "docs/missing.md", reason: "missing" }]);
     });
 
-    it("stores canonical workspace-relative paths so web cache lookup matches", async () => {
-      // `./docs/intro.md` and `docs/intro.md` should both store as `docs/intro.md`,
-      // matching what `docPreviewPathFromHref` produces for a click.
+    it("stores canonical workspace-relative source paths", async () => {
       const { sink, sendMessage } = buildSink({
         trigger: { messageId: "m1", senderId: "agent-peer" },
         getSelfFence: vi.fn().mockResolvedValue({ agentHome: worktree } satisfies SelfFence),
@@ -235,19 +246,12 @@ describe("createResultSink — forwardResult enrichment", () => {
       await sink("see [a](./docs/intro.md) and [b](./other/../docs/intro.md)");
 
       const body = sendMessage.mock.calls[0]?.[1] as {
-        metadata?: {
-          documentContext?: {
-            docs?: Array<{ path: string }>;
-          };
-        };
+        metadata?: { attachments?: Array<{ source?: { path: string } }> };
       };
-      const paths = body.metadata?.documentContext?.docs?.map((d) => d.path) ?? [];
-      expect(paths).toEqual(["docs/intro.md"]);
+      expect(body.metadata?.attachments?.map((a) => a.source?.path)).toEqual(["docs/intro.md"]);
     });
 
     it("rejects symlinks whose realpath crosses into a hidden directory", async () => {
-      // public.md is a symlink → .agent/secret.md. Link-path segments alone
-      // would pass; realpath-relative segments must fail.
       const { sink, sendMessage } = buildSink({
         trigger: { messageId: "m1", senderId: "agent-peer" },
         getSelfFence: vi.fn().mockResolvedValue({ agentHome: worktree } satisfies SelfFence),
@@ -255,28 +259,14 @@ describe("createResultSink — forwardResult enrichment", () => {
 
       await sink("see [public](public.md)");
 
-      const body = sendMessage.mock.calls[0]?.[1] as {
-        metadata?: { documentContext?: unknown };
-      };
-      // Symlink target is rejected → zero snapshots → no documentContext (the
-      // legacy kind:"path" fallback that leaked the worktree path is gone).
-      expect(body.metadata?.documentContext).toBeUndefined();
+      const body = sendMessage.mock.calls[0]?.[1] as { metadata?: { attachments?: unknown } };
+      expect(body.metadata?.attachments).toBeUndefined();
     });
 
-    it("stores size that matches Buffer.byteLength(content, utf8) so server validation never rejects a malformed-UTF-8 file", async () => {
-      // Reviewer-flagged regression: when a `.md` file contains invalid
-      // UTF-8 bytes, `buf.toString("utf8")` substitutes U+FFFD, so the raw
-      // byte length drifts from the re-encoded byte length. If runtime
-      // ships raw bytes as `size` but server recomputes from `content`,
-      // sendMessage fails with BadRequestError("size does not match
-      // content"). Pin runtime + server to the SAME algorithm so a
-      // broken-encoding markdown file degrades to a preview-with-FFFD
-      // rather than a hard send failure.
-      const malformed = Buffer.concat([
-        Buffer.from("# title\n", "utf8"),
-        Buffer.from([0xff, 0xfe, 0xfd]), // invalid UTF-8 bytes
-      ]);
+    it("ref size matches Buffer.byteLength(content, utf8) for a malformed-UTF-8 file (server size check)", async () => {
+      const malformed = Buffer.concat([Buffer.from("# title\n", "utf8"), Buffer.from([0xff, 0xfe, 0xfd])]);
       await writeFile(join(worktree, "broken.md"), malformed);
+      const expectedSize = Buffer.byteLength(Buffer.from(malformed).toString("utf8"), "utf8");
 
       const { sink, sendMessage } = buildSink({
         trigger: { messageId: "m1", senderId: "agent-peer" },
@@ -286,25 +276,14 @@ describe("createResultSink — forwardResult enrichment", () => {
       await sink("see [broken](broken.md)");
 
       const body = sendMessage.mock.calls[0]?.[1] as {
-        metadata?: {
-          documentContext?: {
-            docs?: Array<{ path: string; content: string; size: number }>;
-          };
-        };
+        metadata?: { attachments?: Array<{ source?: { path: string }; size: number }> };
       };
-      const [doc] = body.metadata?.documentContext?.docs ?? [];
-      expect(doc?.path).toBe("broken.md");
-      // The cardinal invariant: declared size MUST equal the server's
-      // recomputation of Buffer.byteLength(content, "utf8").
-      expect(doc?.size).toBe(Buffer.byteLength(doc?.content ?? "", "utf8"));
+      const [ref] = body.metadata?.attachments ?? [];
+      expect(ref?.source?.path).toBe("broken.md");
+      expect(ref?.size).toBe(expectedSize);
     });
 
-    it("ignores external-link hrefs (https / mailto / scheme-relative) even when a matching file exists on disk", async () => {
-      // Defence in depth: if an agent emits `[doc](https://x.com/api.md)` and
-      // the workspace happens to contain `https:/x.com/api.md`, the runtime
-      // must NOT canonicalise the URL into a workspace path. We pre-create
-      // that exact path to prove the guard is structural and not just
-      // accidentally-by-missing-file.
+    it("ignores external-link hrefs even when a matching file exists on disk", async () => {
       await mkdir(join(worktree, "https:", "x.com"), { recursive: true });
       await writeFile(join(worktree, "https:", "x.com", "api.md"), "# evil\n", "utf8");
 
@@ -315,12 +294,8 @@ describe("createResultSink — forwardResult enrichment", () => {
 
       await sink("see [evil](https://x.com/api.md) and [also](//x.com/a.md) and [mail](mailto:a@b.md)");
 
-      const body = sendMessage.mock.calls[0]?.[1] as {
-        metadata?: { documentContext?: unknown };
-      };
-      // None of the three hrefs is a workspace path → zero snapshots → no
-      // documentContext (no legacy kind:"path" fallback).
-      expect(body.metadata?.documentContext).toBeUndefined();
+      const body = sendMessage.mock.calls[0]?.[1] as { metadata?: { attachments?: unknown } };
+      expect(body.metadata?.attachments).toBeUndefined();
     });
 
     it("ignores escaped link `\\[...](path.md)` and image link `![alt](path.md)`", async () => {
@@ -331,17 +306,11 @@ describe("createResultSink — forwardResult enrichment", () => {
 
       await sink("escaped: \\[design](design.md) and image: ![diagram](api.md)");
 
-      const body = sendMessage.mock.calls[0]?.[1] as {
-        metadata?: { documentContext?: unknown };
-      };
-      // Neither escaped nor image triggers snapshot emission → zero snapshots
-      // → no documentContext (no legacy kind:"path" fallback).
-      expect(body.metadata?.documentContext).toBeUndefined();
+      const body = sendMessage.mock.calls[0]?.[1] as { metadata?: { attachments?: unknown } };
+      expect(body.metadata?.attachments).toBeUndefined();
     });
 
-    it("sends content with referenced docs rewritten to explicit links (Option R wiring)", async () => {
-      // The sink must forward `rewrittenText`, not the agent's original body, so
-      // web renders a native link whose href is the snapshot key.
+    it("forwards the rewritten body (not the original) so web renders the attachment link", async () => {
       const { sink, sendMessage } = buildSink({
         trigger: { messageId: "m1", senderId: "agent-peer" },
         getSelfFence: vi.fn().mockResolvedValue({ agentHome: worktree } satisfies SelfFence),
@@ -351,12 +320,9 @@ describe("createResultSink — forwardResult enrichment", () => {
       await sink(`done — wrote ${abs} for review`);
 
       const [, body] = sendMessage.mock.calls[0] ?? [];
-      const sent = body as {
-        content?: string;
-        metadata?: { documentContext?: { docs?: Array<{ path: string }> } };
-      };
-      expect(sent.content).toBe("done — wrote [design.md](design.md) for review");
-      expect(sent.metadata?.documentContext?.docs?.map((d) => d.path)).toEqual(["design.md"]);
+      const sent = body as { content?: string; metadata?: { attachments?: Array<{ source?: { path: string } }> } };
+      expect(sent.content).toBe(`done — wrote [design.md](attachment:${fakeUploadId(1)}) for review`);
+      expect(sent.metadata?.attachments?.map((a) => a.source?.path)).toEqual(["design.md"]);
     });
   });
 

--- a/packages/client/src/runtime/doc-snapshots.ts
+++ b/packages/client/src/runtime/doc-snapshots.ts
@@ -2,62 +2,75 @@ import { createHash } from "node:crypto";
 import { readFile, realpath, stat } from "node:fs/promises";
 import { isAbsolute, relative, resolve, sep } from "node:path";
 import {
+  type AttachmentRef,
   buildWorkspaceDocKey,
   type DocSnapshotFailReason,
   type FailedDocMention,
-  MAX_DOC_SNAPSHOT_BYTES,
-  MAX_DOC_SNAPSHOTS_PER_MESSAGE,
   MAX_FAILED_DOC_MENTION_RAW_LEN,
   MAX_FAILED_DOC_MENTIONS_PER_MESSAGE,
-  MAX_TOTAL_DOC_SNAPSHOT_BYTES,
+  MAX_MESSAGE_ATTACHMENT_REFS,
   normalizeDocLinkPath,
-  type SnapshotDoc,
   scanBareDocPathTokens,
   stripDocPathLineSuffix,
 } from "@first-tree/shared";
 
 /**
- * Scan an outbound agent message for `.md` path mentions (inline markdown
- * links `[text](path.md)` AND bare `path.md` tokens) and turn each
- * safely-resolvable target into a snapshot of the file's contents at send
- * time.
- *
- * Resolution is constrained to `root` (+ the optional cross-agent fence). A
- * path resolves when its real target is a regular `.md` file physically inside
- * an allowed root with no hidden segment. Relative (`docs/foo.md`,
- * `./docs/foo.md`) and absolute-inside-root (`<root>/docs/foo.md`) forms both
- * resolve.
- *
- * For every resolved+snapshotted reference we **rewrite its span in the
- * outbound text into an EXPLICIT markdown link** whose href is the canonical
- * snapshot key — a bare mention becomes `[display](key)`, an inline
- * `[label](target)` keeps its label and points the target at the key. The
- * caller sends `rewrittenText`. Web then renders a native markdown link and
- * resolves a click by a direct href→snapshot lookup: it does NOT re-scan free
- * text, re-derive keys, or expand cross short-forms. That removes the whole
- * "the runtime scanner and the web scanner must agree" failure class (and the
- * cross-agent web-version skew it caused), and is immune to server-side body
- * rewrites (e.g. `@mention` prepend) since a `[..](..)` link survives wherever
- * it lands. Only snapshotted refs are rewritten, so "rewritten ⇔ has a
- * snapshot ⇔ web can render it" holds. (Web keeps a legacy bare-token re-scan
- * for messages authored before this — it is simply inert here because the
- * scanner skips inline links.)
- *
- * Anything that escapes the worktree (absolute path resolving OUTSIDE root,
- * `..` traversal, symlink pointing to a hidden segment inside or outside
- * root), hides (`.dotfile` / `.dotdir`, `.agent/`), or is missing is dropped
- * — the caller's message still goes through, the offending mention simply
- * stays plain text in the UI (and is left untouched in `rewrittenText`).
- *
- * The shared schema enforces canonical path form and the server re-validates
- * byte budgets + sha256 so a misbehaving runtime cannot lodge mismatched
- * data.
+ * Per-file raw byte cap for a doc capture. The attachments blob store caps a
+ * single upload at 10MB, but a markdown doc that big would render to a multi-MB
+ * string and choke the preview drawer, so the capture side keeps the original
+ * conservative ceiling. Files above this are dropped (the mention stays plain
+ * text) rather than uploaded.
  */
+const MAX_DOC_CAPTURE_BYTES = 256 * 1024;
+/** MIME the runtime assigns to markdown doc captures. */
+const DOC_CAPTURE_MIME = "text/markdown";
+/** Bounded retries for a single doc upload before giving up and degrading the
+ *  mention to plain text. */
+const DOC_UPLOAD_MAX_ATTEMPTS = 3;
+
 /**
- * Fence that widens snapshotting from "the sender's own workspace root" to
- * "any agent's workspace under the shared `workspaces/` common root, scoped to
- * the current chat". Passed by the runtime; absent in legacy/unit call sites,
- * in which case behaviour is exactly the pre-existing self-only path.
+ * Minimal upload surface this module needs — a slice of the SDK so unit tests
+ * can stub it without constructing a full SDK. Mirrors `sdk.uploadAttachment`.
+ */
+export type AttachmentUploader = {
+  uploadAttachment(opts: {
+    bytes: Uint8Array | Buffer;
+    mimeType: string;
+    filename: string;
+    orgId: string;
+  }): Promise<{ id: string; mimeType: string; filename: string; sizeBytes: number }>;
+};
+
+/**
+ * Scan an outbound agent message for `.md` path mentions (inline markdown
+ * links `[text](path.md)` AND bare `path.md` tokens), upload each
+ * safely-resolvable target's bytes to the org attachment store, and turn the
+ * mention into a clickable preview link that points at the stored blob.
+ *
+ * Resolution is constrained to `root` (+ the optional cross-agent fence) — the
+ * same provenance fence as before: a path resolves when its real target is a
+ * regular `.md` file physically inside an allowed root with no hidden segment.
+ * Relative (`docs/foo.md`, `./docs/foo.md`) and absolute-inside-root forms both
+ * resolve. The fence is the send-side authz: the sender can only capture docs
+ * it can legitimately read.
+ *
+ * For every resolved file we:
+ *  1. read the bytes and compute `sha256` (stored in the ref for renderer-side
+ *     end-to-end integrity verification),
+ *  2. upload to `POST /orgs/:orgId/attachments` (bounded retry) to get an
+ *     `attachmentId`,
+ *  3. build a generic `AttachmentRef{ kind: "document", attachmentId, ... }`
+ *     mounted at `metadata.attachments[]`, and
+ *  4. rewrite the mention's span into an explicit `[display](attachment:<id>)`
+ *     markdown link.
+ *
+ * The rewrite happens **only after a successful upload**, so the invariant
+ * "rewritten ⇔ has a ref ⇔ web can fetch+render it" holds. A failed upload
+ * (after the bounded retry) leaves the mention as plain text and does NOT
+ * block message delivery. Bare-source resolution failures are reported via
+ * `failedMentions[]` so web can render an inert chip; inline `[label](target)`
+ * failures stay silent (the agent's link still renders, the click handler
+ * no-ops on a missing ref).
  */
 export type WorkspaceFence = {
   /** Shared `workspaces/` common root (parent of every `<agentSlug>/<chatId>`). */
@@ -70,87 +83,54 @@ export type WorkspaceFence = {
 
 /**
  * Self-fence config: the agent's own workspace root + an optional source-repo
- * `localPath` for relative-path promotion.
- *
- * Why two roots: after #506 the agent's cwd is the per-agent home and the
- * `git worktree add` workflow (#498) puts task-scoped checkouts at
- * `<agentHome>/worktrees/<task>/`. Those are **siblings** of the predeclared
- * source repo at `<agentHome>/<localPath>/`. Containment-checking absolute
- * paths against the source repo alone (the pre-#535 behaviour, restored by
- * #535 to the right root but not widened) drops every worktree mention back to
- * plain text. The fix is to gate absolute paths on the wider `agentHome`
- * boundary while keeping relative paths resolving against the source repo top
- * (where "docs/foo.md" has always meant "in the source repo").
- *
- * `singleRepoLocalPath`, when set, is used both to RESOLVE relative mentions
- * (against `<agentHome>/<localPath>`) AND to **promote** the resulting snapshot
- * key to `<localPath>/<rel>` so a file written two ways (relative
- * `docs/foo.md` and absolute `<agentHome>/<localPath>/docs/foo.md`) ends up
- * with one shared canonical key. Zero / multi-repo agents skip the promotion;
- * relative mentions resolve against `agentHome` directly.
+ * `localPath` for relative-path promotion. See git history / proposal §5.1 for
+ * the two-root rationale (agent home vs source-repo top).
  */
 export type SelfFence = {
-  /** Per-agent home (`acquireAgentHome` return value) or legacy per-chat dir
-   *  for pre-#506 chats. Absolute paths must realpath inside this; snapshot
-   *  keys are emitted relative to this root. */
   agentHome: string;
-  /** Single declared source-repo `localPath` — e.g. `"first-tree"`. Set when
-   *  `payload.gitRepos.length === 1` and its localPath is non-empty. */
   singleRepoLocalPath?: string;
 };
 
 type ResolvedRoots = {
   agentHomeReal: string;
-  /** Where relative paths resolve. Equals `agentHomeReal` when no singleRepo
-   *  localPath; equals `<agentHomeReal>/<localPath>` realpath'd otherwise. May
-   *  fall back to `agentHomeReal` when the localPath dir doesn't yet exist. */
   docBaseReal: string;
-  /** `<localPath>` as a POSIX-canonical key prefix (or null when no promotion).
-   *  Used to promote a relative `docs/foo.md` into agent-home-relative form
-   *  `<localPath>/docs/foo.md`. */
   promotePrefix: string | null;
 };
 
 type ResolvedOccurrence = DocPathOccurrence & {
   kind: "self" | "cross" | null;
-  /** Snapshot key: agent-home-relative for self (key collisions with cross
-   *  ruled out because cross keys are global `<slug>/<chatId>/<rel>`). */
-  key: string | null;
-  /** Realpath of the file to read (cross only; self resolves against
-   *  `agentHomeReal`). */
+  /** Canonical workspace-relative source path: agent-home-relative for self,
+   *  short `<ownerSlug>/<rel>` for cross. Stored in `ref.source.path`. */
+  sourcePath: string | null;
+  /** Realpath of the file to read. */
   file: string | null;
-  /** Rewrite replacement for a cross mention: short `<ownerSlug>/<rel>`. */
-  shortForm: string;
-  /** Reason this occurrence failed to snapshot, set when Pass 1 (key
-   *  resolution) OR Pass 2 (read / byte budget) drops the mention. Null /
-   *  undefined when the snapshot succeeded. Bare-source failures populate
-   *  `failedMentions[]` on the wire (inline-source failures stay silent —
-   *  the agent's existing `[label](target)` syntax already implies they
-   *  meant a link, so the click handler just no-ops on a missing snapshot). */
   failReason?: DocSnapshotFailReason;
+};
+
+export type BuildDocAttachmentsOptions = {
+  uploader: AttachmentUploader;
+  orgId: string;
 };
 
 export async function buildMessageDocumentSnapshots(
   text: string,
   self: string | SelfFence,
+  opts: BuildDocAttachmentsOptions,
   fence?: WorkspaceFence,
 ): Promise<{
-  docs: SnapshotDoc[];
+  refs: AttachmentRef[];
   skipped: number;
   rewrittenText: string;
   /**
    * Per-mention failures (BARE-source tokens only, deduped by writtenPath).
-   * Caller embeds this list as `metadata.documentContext.failedMentions` so
-   * web can render an inert "doc chip" at the original token position with a
-   * reason-mapped tooltip. Empty array when every mention either resolved or
-   * was an inline `[label](target)` link (those failures stay silent — the
-   * link still renders, the click handler just no-ops on a missing snapshot).
+   * Caller embeds this as `metadata.documentContext.failedMentions` so web can
+   * render an inert "doc chip" at the original token position.
    */
   failedMentions: FailedDocMention[];
 }> {
   const occurrences = collectDocPathOccurrences(text);
   const empty = {
-    docs: [] as SnapshotDoc[],
+    refs: [] as AttachmentRef[],
     skipped: 0,
     rewrittenText: text,
     failedMentions: [] as FailedDocMention[],
@@ -163,187 +143,96 @@ export async function buildMessageDocumentSnapshots(
 
   const workspacesRootReal = fence ? await safeRealpath(fence.workspacesRoot) : null;
 
-  // Pass 1 — resolve every occurrence to a snapshot plan:
-  //   self  → key relative to `agentHomeReal`; relative mentions in single-
-  //           repo workspaces are PROMOTED to `<localPath>/<rel>` so the abs
-  //           and rel forms of the same source-repo file share one canonical
-  //           key.
-  //   cross → global key `<ownerSlug>/<chatId>/<rel>` for a file that realpaths
-  //           into ANOTHER agent's workspace under the shared common root.
-  //
-  // When BOTH self and cross attempts fail, `classifyOccurrenceFailure`
-  // re-runs the discrimination checks (hidden segment / out-of-fence /
-  // missing) to attach a reason — that reason is what surfaces as the
-  // inert-chip tooltip on web. The classifier is best-effort; a path that
-  // doesn't fit any clean bucket falls back to `missing` (the most common
-  // and user-actionable reason).
+  // Pass 1 — resolve every occurrence to a readable file + canonical source
+  // path, or attach a failure reason. Same provenance fence as before.
   const resolved: ResolvedOccurrence[] = await Promise.all(
     occurrences.map(async (occ): Promise<ResolvedOccurrence> => {
       const selfKey = await canonicalizeWorkspacePath(roots, occ.writtenPath);
-      if (selfKey) return { ...occ, kind: "self", key: selfKey, file: null, shortForm: "" };
-      // Only an ABSOLUTE path can escape the sender's own home into a sibling
-      // workspace; a relative mention always resolves under the self roots.
+      if (selfKey) {
+        const file = await resolveWorkspaceFile(roots.agentHomeReal, selfKey);
+        if (file) return { ...occ, kind: "self", sourcePath: selfKey, file };
+        // Canonicalised but unreadable (race / non-file) — classify below.
+      }
       if (workspacesRootReal && fence && isAbsolute(occ.writtenPath)) {
         const cross = await resolveCrossWorkspaceDoc(workspacesRootReal, fence, occ.writtenPath);
-        if (cross) return { ...occ, kind: "cross", key: cross.key, file: cross.file, shortForm: cross.shortForm };
+        if (cross) return { ...occ, kind: "cross", sourcePath: cross.shortForm, file: cross.file };
       }
       const failReason = await classifyOccurrenceFailure(occ, roots, fence, workspacesRootReal);
-      return { ...occ, kind: null, key: null, file: null, shortForm: "", failReason };
+      return { ...occ, kind: null, sourcePath: null, file: null, failReason };
     }),
   );
 
-  // Pass 2 — build snapshots. De-dupe by snapshot key so the same file
-  // mentioned twice is read once; the on-wire key is what the web cache lookup
-  // produces from a clicked href.
-  const docs: SnapshotDoc[] = [];
-  let totalBytes = 0;
+  // Pass 2 — read + upload. De-dupe by source path so the same file mentioned
+  // twice is uploaded once; both occurrences then rewrite to the same ref.
+  const refsByPath = new Map<string, AttachmentRef>();
   let skipped = 0;
-  const seen = new Set<string>();
-  const snapshotted = new Set<string>();
+  const attempted = new Set<string>();
 
+  // Upload eligible files in parallel.
+  const uploadTasks: Array<Promise<void>> = [];
   for (const occ of resolved) {
-    const key = occ.key;
-    if (!key || !key.toLowerCase().endsWith(".md")) {
-      skipped += 1;
-      // failReason was set in Pass 1 already (or this is the rare "key but
-      // not .md" case — treat as missing for the chip tooltip).
-      if (!occ.failReason) occ.failReason = "missing";
+    const sourcePath = occ.sourcePath;
+    const file = occ.file;
+    if (!sourcePath || !file || !sourcePath.toLowerCase().endsWith(".md")) {
+      if (occ.failReason === undefined && occ.kind === null) occ.failReason = "missing";
       continue;
     }
-    if (seen.has(key)) {
-      // Already attempted for an earlier occurrence of the same key. If that
-      // earlier attempt failed, propagate the same reason so every occurrence
-      // of the path shows the same chip status.
-      if (!snapshotted.has(key)) {
-        // Find the prior occurrence's failReason (if any) and adopt it.
-        const prior = resolved.find((o) => o.key === key && o.failReason !== undefined);
-        if (prior?.failReason) occ.failReason = prior.failReason;
-        else if (!occ.failReason) occ.failReason = "missing";
-      }
-      continue;
-    }
-    seen.add(key);
+    if (attempted.has(sourcePath)) continue;
+    attempted.add(sourcePath);
 
-    if (docs.length >= MAX_DOC_SNAPSHOTS_PER_MESSAGE) {
-      skipped += 1;
+    if (refsByPath.size + uploadTasks.length >= MAX_MESSAGE_ATTACHMENT_REFS) {
       occ.failReason = "budget-exceeded";
+      skipped += 1;
       continue;
     }
 
-    // Self keys resolve back against `agentHomeReal`; cross keys already
-    // carry the realpath'd file from the fenced lookup.
-    const file = occ.kind === "cross" ? occ.file : await resolveWorkspaceFile(roots.agentHomeReal, key);
-    if (!file) {
-      skipped += 1;
-      // A successfully canonicalised key whose file disappears at read time
-      // (TOCTOU / race) is effectively missing.
-      occ.failReason = "missing";
-      continue;
-    }
-
-    try {
-      const buf = await readFile(file);
-      // Pre-flight raw-byte cap so a multi-MB file doesn't waste a full UTF-8
-      // round-trip just to be rejected below.
-      if (buf.byteLength > MAX_DOC_SNAPSHOT_BYTES) {
-        skipped += 1;
-        occ.failReason = "too-large";
-        continue;
-      }
-      const content = buf.toString("utf8");
-      // `size` MUST match the byte length the server recomputes from
-      // `content` (see `services/doc-snapshots.ts validateDocumentContext`).
-      // Files that contain invalid UTF-8 sequences have `buf.toString("utf8")`
-      // substitute U+FFFD for each malformed byte, so `buf.byteLength` (raw)
-      // drifts from `Buffer.byteLength(content, "utf8")` (re-encoded) and the
-      // server rejects the message with "size does not match content".
-      // Compute size from the round-tripped content so both sides agree.
-      const size = Buffer.byteLength(content, "utf8");
-      // After substitution `size` may grow (a single invalid byte → 3 bytes
-      // for U+FFFD) and overshoot the per-file cap even if raw bytes were
-      // under. Catch that and skip.
-      if (size > MAX_DOC_SNAPSHOT_BYTES) {
-        skipped += 1;
-        occ.failReason = "too-large";
-        continue;
-      }
-      if (totalBytes + size > MAX_TOTAL_DOC_SNAPSHOT_BYTES) {
-        skipped += 1;
-        occ.failReason = "budget-exceeded";
-        continue;
-      }
-      const sha256 = createHash("sha256").update(content, "utf8").digest("hex");
-      docs.push({ path: key, sha256, size, content });
-      totalBytes += size;
-      snapshotted.add(key);
-    } catch {
-      skipped += 1;
-      occ.failReason = "unreadable";
-    }
+    uploadTasks.push(
+      (async () => {
+        const captured = await captureAndUpload(file, sourcePath, opts);
+        if (captured.ref) {
+          refsByPath.set(sourcePath, captured.ref);
+        } else {
+          skipped += 1;
+          // Attach the reason to every occurrence of this path (Pass 3 reads it).
+          for (const o of resolved) {
+            if (o.sourcePath === sourcePath) o.failReason = captured.reason;
+          }
+        }
+      })(),
+    );
   }
+  await Promise.all(uploadTasks);
 
-  // Pass 3 — rewrite every resolved+snapshotted reference into an EXPLICIT
-  // markdown link whose href is the canonical snapshot key. Web then renders a
-  // native link and resolves a click by a direct href→snapshot lookup; it no
-  // longer re-scans free text or re-derives/expands keys. That removes the
-  // "two scanners must agree" fragility — and, because the href carries the
-  // FULL key (relative for self, global `<slug>/<chatId>/<rel>` for cross),
-  // the cross-agent web-version skew is gone too (no chatId re-expansion on
-  // the web side). The href being explicit also makes short-form/self-key
-  // collisions impossible, so no collision handling is needed.
-  //   - bare mention   → `[display](key)` (display = canonical relative for
-  //                       self, short `<slug>/<rel>` for cross; `:line` kept on
-  //                       the display, stripped from the key href).
-  //   - inline `[label](target)` → target replaced with the key; the agent's
-  //                       label is preserved.
-  // Only tokens that actually produced a snapshot are rewritten, so the
-  // invariant "rewritten ⇔ has a snapshot ⇔ web can render it" holds.
+  // Pass 3 — rewrite every occurrence whose path produced a ref into an
+  // explicit `[display](attachment:<id>)` link (bare) or retarget the inline
+  // link's `(target)` (inline). Only refs that uploaded successfully rewrite.
   const rewrites: Array<{ start: number; end: number; replacement: string }> = [];
   for (const occ of resolved) {
-    if (!occ.key || !snapshotted.has(occ.key)) continue;
+    const sourcePath = occ.sourcePath;
+    if (!sourcePath) continue;
+    const ref = refsByPath.get(sourcePath);
+    if (!ref) continue;
+    const href = attachmentHref(ref.attachmentId);
     if (occ.source === "inline") {
-      // Point the agent's existing link at the canonical key (no-op when it
-      // already is); the label between `[` and `]` is left untouched.
-      rewrites.push({ start: occ.start, end: occ.end, replacement: occ.key });
+      rewrites.push({ start: occ.start, end: occ.end, replacement: href });
     } else if (occ.enclosingCodeSpan) {
-      // Code-span-wrapped bare mention: widen the rewrite to the outer ticks
-      // and slice the original code span verbatim into the link text. The
-      // result `[`anything-incl-path`](key)` renders as a code-styled
-      // clickable link (commonmark allows inline code inside link text), so
-      // the agent's mono-spaced visual intent survives while the click target
-      // points at the snapshot. Verbatim slice (instead of synthesising a
-      // canonical display) is what keeps surrounding text inside the same
-      // span — e.g. `` `agent-hub/messaging.md` §218-229 `` — intact when the
-      // §-suffix sits outside the ticks, or when the span itself contains
-      // descriptive prose around the path. Multi-path-in-one-span is a
-      // degenerate case handled defensively below by `applyRewrites`'s
-      // overlap-skip (first match wins; others are dropped silently — their
-      // snapshots are still emitted so metadata stays self-consistent).
       const visibleText = text.slice(occ.enclosingCodeSpan.start, occ.enclosingCodeSpan.end);
       rewrites.push({
         start: occ.enclosingCodeSpan.start,
         end: occ.enclosingCodeSpan.end,
-        replacement: `[${visibleText}](${occ.key})`,
+        replacement: `[${visibleText}](${href})`,
       });
     } else {
-      const display = occ.kind === "cross" ? occ.shortForm : occ.key;
-      rewrites.push({ start: occ.start, end: occ.end, replacement: `[${display}${occ.lineSuffix}](${occ.key})` });
+      const display = `${sourcePath}${occ.lineSuffix}`;
+      rewrites.push({ start: occ.start, end: occ.end, replacement: `[${display}](${href})` });
     }
   }
 
-  // Collect per-mention failures for inert-chip rendering. Only BARE-source
-  // occurrences are surfaced (inline `[label](target)` failures stay silent
-  // — the existing link already shows the agent's intent; the click handler
-  // simply no-ops on a missing snapshot). Dedupe by writtenPath so two
-  // mentions of the same path under `:line` variants collapse to one entry;
-  // the web wrap pass canonicalises each scanned occurrence's raw via
-  // `stripDocPathLineSuffix` before lookup, so a single entry covers all
-  // matching occurrences in the text.
+  // Collect per-mention failures (bare-source only), deduped by writtenPath.
   const failuresByRaw = new Map<string, DocSnapshotFailReason>();
   for (const occ of resolved) {
     if (occ.source !== "bare") continue;
     if (!occ.failReason) continue;
-    // Drop the line-suffix from the wire key so suffixed variants dedupe.
     const raw = occ.writtenPath;
     if (!raw || raw.length > MAX_FAILED_DOC_MENTION_RAW_LEN) continue;
     if (failuresByRaw.has(raw)) continue;
@@ -352,31 +241,84 @@ export async function buildMessageDocumentSnapshots(
   }
   const failedMentions: FailedDocMention[] = [...failuresByRaw.entries()].map(([raw, reason]) => ({ raw, reason }));
 
-  return { docs, skipped, rewrittenText: applyRewrites(text, rewrites), failedMentions };
+  return {
+    refs: [...refsByPath.values()],
+    skipped,
+    rewrittenText: applyRewrites(text, rewrites),
+    failedMentions,
+  };
+}
+
+/** Scheme used to point a rewritten doc mention at its stored attachment. The
+ *  web link layer parses this back into the attachmentId. */
+const ATTACHMENT_HREF_SCHEME = "attachment:";
+
+export function attachmentHref(attachmentId: string): string {
+  return `${ATTACHMENT_HREF_SCHEME}${attachmentId}`;
+}
+
+/**
+ * Read a file, enforce the capture byte cap, compute sha256, and upload to the
+ * attachment store with a bounded retry. Returns the built `AttachmentRef` or a
+ * failure reason. Never throws — upload/IO failures degrade to plain text.
+ */
+async function captureAndUpload(
+  file: string,
+  sourcePath: string,
+  opts: BuildDocAttachmentsOptions,
+): Promise<{ ref: AttachmentRef; reason?: undefined } | { ref: null; reason: DocSnapshotFailReason }> {
+  let content: string;
+  let size: number;
+  try {
+    const buf = await readFile(file);
+    if (buf.byteLength > MAX_DOC_CAPTURE_BYTES) return { ref: null, reason: "too-large" };
+    content = buf.toString("utf8");
+    // Re-encode so `size` matches what the server measures from the uploaded
+    // bytes (invalid UTF-8 → U+FFFD substitution can change byte length).
+    size = Buffer.byteLength(content, "utf8");
+    if (size > MAX_DOC_CAPTURE_BYTES) return { ref: null, reason: "too-large" };
+  } catch {
+    return { ref: null, reason: "unreadable" };
+  }
+
+  const sha256 = createHash("sha256").update(content, "utf8").digest("hex");
+  const filename = sourcePath.split("/").filter(Boolean).at(-1) ?? "document.md";
+  // Upload the re-encoded bytes (not the raw buffer) so the stored byte length
+  // matches `size` and `sha256` exactly.
+  const bytes = Buffer.from(content, "utf8");
+
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= DOC_UPLOAD_MAX_ATTEMPTS; attempt += 1) {
+    try {
+      const uploaded = await opts.uploader.uploadAttachment({
+        bytes,
+        mimeType: DOC_CAPTURE_MIME,
+        filename,
+        orgId: opts.orgId,
+      });
+      const ref: AttachmentRef = {
+        attachmentId: uploaded.id,
+        kind: "document",
+        mimeType: DOC_CAPTURE_MIME,
+        filename,
+        size,
+        sha256,
+        source: { path: sourcePath },
+      };
+      return { ref };
+    } catch (err) {
+      lastError = err;
+    }
+  }
+  void lastError;
+  // Bounded retry exhausted — degrade to plain text. `unreadable` is the
+  // closest existing inert-chip bucket for "couldn't materialise the preview".
+  return { ref: null, reason: "unreadable" };
 }
 
 /**
  * Best-effort classification of why a doc mention failed to resolve to a
- * canonical workspace key. Runs ONLY on occurrences that fell through Pass 1
- * (both self and cross attempts returned null), so the input has already been
- * rejected by the structural fence — the job here is to bucket the reason
- * cleanly enough for the user-facing tooltip.
- *
- * Buckets are deliberately coarse and ordered by user actionability:
- *   - hidden-segment: a path segment starts with `.` (`.agent/...`, `.git/...`).
- *   - out-of-fence:   absolute path realpaths outside agent home AND outside
- *                     the cross-fence workspaces common root (or under it but
- *                     in another chat's scope).
- *   - missing:        the file doesn't exist / isn't a regular `.md` /
- *                     realpath returned null. Most common case; the most
- *                     actionable tooltip ("文档不存在" — agent typo'd, file
- *                     was deleted, etc.).
- *   - unreadable:     used as a last-resort fallback when realpath succeeded
- *                     and the path is inside the fence but a later stat
- *                     somehow threw — the rare permission / I/O failure case.
- *
- * `too-large` / `budget-exceeded` / `unreadable` from readFile are NOT
- * classified here — those are set inline in Pass 2 where they're detected.
+ * readable workspace file. Runs ONLY on occurrences that fell through Pass 1.
  */
 async function classifyOccurrenceFailure(
   occ: DocPathOccurrence,
@@ -384,39 +326,19 @@ async function classifyOccurrenceFailure(
   fence: WorkspaceFence | undefined,
   workspacesRootReal: string | null,
 ): Promise<DocSnapshotFailReason> {
-  // 1. Static hidden-segment check on the raw written path. Catches the
-  //    common `.agent/secret.md` / `docs/.git/HEAD.md` pattern before any
-  //    filesystem syscall. `.` and `..` segments are filesystem references,
-  //    not hidden dirs — they're escape attempts handled by the out-of-fence
-  //    bucket later, not hidden segments here.
   const writtenSegs = occ.writtenPath.split(/[\\/]+/).filter((s) => s.length > 0 && s !== "." && s !== "..");
   if (writtenSegs.some((s) => s.startsWith("."))) return "hidden-segment";
 
-  // 2. Try to realpath the target so the rest of the buckets can lean on a
-  //    concrete inode. Absolute paths go directly; relative paths route
-  //    through `normalizeDocLinkPath` (rejects `.`-segments, `..`-escape)
-  //    then resolve against `docBaseReal`.
   let real: string | null = null;
   if (isAbsolute(occ.writtenPath)) {
     real = await safeRealpath(occ.writtenPath);
   } else {
     const normalized = normalizeDocLinkPath(occ.writtenPath);
-    if (!normalized) {
-      // Step 1 already cleared hidden segments; a null here is the parent-
-      // traversal escape (`../outside.md`) — bucket as out-of-fence so the
-      // chip tooltip says "not in the workspace" instead of mis-attributing
-      // to a hidden directory. (Codex review P3.)
-      return "out-of-fence";
-    }
+    if (!normalized) return "out-of-fence";
     real = await safeRealpath(resolve(roots.docBaseReal, normalized));
   }
   if (!real) return "missing";
 
-  // 3. Hidden segment exposed by the realpath (symlink dropping into
-  //    `.agent/`, `.git/`, etc.). Mirrors the rejection in `resolveWorkspaceFile`.
-  //    Strip both `.` AND `..` — realpath canonicalises away `.`, but
-  //    `relative()` emits leading `..` when the target sits OUTSIDE the home
-  //    (handled by step 4 below). Those aren't hidden dirs, they're escapes.
   const homeRel = relative(roots.agentHomeReal, real)
     .split(sep)
     .filter((s) => s.length > 0 && s !== "." && s !== "..");
@@ -425,7 +347,6 @@ async function classifyOccurrenceFailure(
   const homePrefix = roots.agentHomeReal.endsWith(sep) ? roots.agentHomeReal : roots.agentHomeReal + sep;
   const insideHome = real === roots.agentHomeReal || real.startsWith(homePrefix);
   if (!insideHome) {
-    // 4. Outside agent home — check the cross fence next.
     if (workspacesRootReal && fence) {
       const wsPrefix = workspacesRootReal.endsWith(sep) ? workspacesRootReal : workspacesRootReal + sep;
       if (real.startsWith(wsPrefix)) {
@@ -436,8 +357,6 @@ async function classifyOccurrenceFailure(
         if (wsRel.length < 3) return "out-of-fence";
         const [ownerSlug, segChatId] = wsRel;
         if (segChatId !== fence.chatId) return "out-of-fence";
-        // Self workspace via the cross root is treated as self elsewhere; if
-        // we got here, self resolution already failed — treat as missing.
         if (ownerSlug === fence.selfSlug) return "missing";
         try {
           const st = await stat(real);
@@ -445,15 +364,12 @@ async function classifyOccurrenceFailure(
         } catch {
           return "missing";
         }
-        // Cross fence accepted the realpath but the resolver still dropped it
-        // — something I/O-shaped is amiss. `unreadable` is the closest bucket.
         return "unreadable";
       }
     }
     return "out-of-fence";
   }
 
-  // 5. Inside agent home — the file either doesn't exist or isn't a regular file.
   try {
     const st = await stat(real);
     if (!st.isFile()) return "missing";
@@ -463,36 +379,12 @@ async function classifyOccurrenceFailure(
   return "unreadable";
 }
 
-/**
- * One `.md` path mention found in the outbound text, with the exact text span
- * to replace if the path resolves to a workspace file.
- *
- * - `writtenPath` is the path as authored, minus any `:line[:col]` suffix.
- * - `lineSuffix` is that suffix verbatim ("" when absent) so a rewrite can
- *   preserve `foo.md:12`.
- * - `[start, end)` is the slice to replace: the whole bare token (incl. the
- *   line suffix) for bare mentions, or just the `(target)` for inline links.
- */
 type DocPathOccurrence = {
   writtenPath: string;
   lineSuffix: string;
   start: number;
   end: number;
-  /**
-   * `bare` — a plain `path.md` mention; rewritten into an explicit
-   * `[display](key)` markdown link so web renders a native link (no re-scan).
-   * `inline` — the `(target)` of an agent-authored `[label](target.md)`; only
-   * the target is rewritten to the canonical key (the agent's label is kept).
-   */
   source: "bare" | "inline";
-  /**
-   * Outer span (opening tick → closing tick, inclusive) of the inline code
-   * wrapper around a bare token, when the token sits inside one. Pass 3
-   * widens the rewrite to this span so `` `docs/foo.md` `` becomes the
-   * commonmark-legal `` [`docs/foo.md`](docs/foo.md) `` — a code-styled
-   * clickable link instead of dead inline code. Absent for `source: "inline"`
-   * and for unwrapped bare tokens.
-   */
   enclosingCodeSpan?: { start: number; end: number };
 };
 
@@ -534,20 +426,6 @@ function applyRewrites(text: string, rewrites: Array<{ start: number; end: numbe
 
 type InlineLinkMatch = { target: string; start: number; end: number };
 
-/**
- * Inline markdown link scanner. Conservative: requires a literal `[ ... ](path.md)`
- * pair (with optional title segment ignored) where the path captures up to the
- * first whitespace or `)`. Reference-style / autolink / HTML / escaped /
- * image forms are deliberately not matched (proposal §非目标).
- *
- * The leading `[ ... ](` is captured as group 1 so the target's start offset
- * is `match.index + group1.length` — used to rewrite an absolute-in-root
- * target in place without re-searching the string.
- *
- * Two forms are excluded by inspecting the byte preceding the opening `[`:
- *   - `\[text](path.md)` — markdown-escaped bracket
- *   - `![alt](path.md)` — image, not a click target
- */
 function scanInlineMarkdownLinks(text: string): InlineLinkMatch[] {
   const out: InlineLinkMatch[] = [];
   const re = /(\[(?:[^\]\\]|\\.)*\]\()(\S+?\.md)(?:\s+"[^"]*")?\)/g;
@@ -566,19 +444,6 @@ function scanInlineMarkdownLinks(text: string): InlineLinkMatch[] {
   return out;
 }
 
-/**
- * Realpath the two self roots up-front so every occurrence in `Pass 1` shares
- * the same containment-check fixtures. Returns null when `agentHome` itself is
- * unrealpath'able — there is no workspace to snapshot against, so every
- * occurrence is "skipped" by the caller.
- *
- * `docBaseReal` falls back to `agentHomeReal` when `singleRepoLocalPath` is
- * unset OR points to a directory that doesn't physically exist yet (e.g. the
- * source repo hasn't been materialised when the very first message goes out).
- * In both cases the promotion is silently dropped — relative mentions still
- * resolve, just against the agent home directly, matching the legacy
- * zero/multi-repo path.
- */
 async function resolveSelfRoots(self: SelfFence): Promise<ResolvedRoots | null> {
   const agentHomeReal = await safeRealpath(self.agentHome);
   if (!agentHomeReal) return null;
@@ -590,17 +455,10 @@ async function resolveSelfRoots(self: SelfFence): Promise<ResolvedRoots | null> 
   if (!docBaseReal) {
     return { agentHomeReal, docBaseReal: agentHomeReal, promotePrefix: null };
   }
-  // Defence in depth: the localPath dir must still be inside the agent home.
-  // A misconfigured `localPath: "../escape"` would otherwise let the docBase
-  // wander outside the fence and accept files we don't intend to snapshot.
   const prefix = agentHomeReal.endsWith(sep) ? agentHomeReal : agentHomeReal + sep;
   if (docBaseReal !== agentHomeReal && !docBaseReal.startsWith(prefix)) {
     return { agentHomeReal, docBaseReal: agentHomeReal, promotePrefix: null };
   }
-  // Promote relative keys to `<localPath>/<rel>` so abs + rel forms of the
-  // same source-repo file share one canonical key. `normalizeDocLinkPath`
-  // canonicalises here too, so a stray leading "/" or "./" in the operator's
-  // config doesn't leak through into snapshot keys.
   const promote = normalizeDocLinkPath(relative(agentHomeReal, docBaseReal));
   return {
     agentHomeReal,
@@ -609,30 +467,6 @@ async function resolveSelfRoots(self: SelfFence): Promise<ResolvedRoots | null> 
   };
 }
 
-/**
- * Resolve the canonical agent-home-relative snapshot key for a written `.md`
- * path. Accepts BOTH relative paths (resolved against `docBaseReal` — the
- * source repo top for single-repo agents, the agent home otherwise) and
- * absolute paths (containment-checked against the wider `agentHomeReal` so
- * `<agentHome>/worktrees/<task>/foo.md` and `<agentHome>/<localPath>/docs/foo.md`
- * both land inside the fence).
- *
- * Absolute paths are `realpath`'d FIRST, then checked for containment — so an
- * ancestor symlink cannot be used to claim a path is "inside" the home when
- * its real target is not. The result is run back through `normalizeDocLinkPath`
- * so the key is POSIX-canonical and any hidden segment exposed by the realpath
- * (`<agentHome>/.agent/x.md` reached via a symlink) is rejected — matching
- * what web's re-scan derives from the rewritten token. Returns null when the
- * path escapes the home, hides, or cannot be realpath'd; the caller then leaves
- * the text untouched and embeds no snapshot.
- *
- * Relative paths get a second pass: `<docBaseReal>/<rel>` is realpath'd to
- * confirm the file physically exists inside the fence (so the snapshot key
- * agrees with what `resolveWorkspaceFile` will read) and to derive the
- * agent-home-relative form. A relative mention that points at a non-existent
- * file falls back to the un-promoted `normalizeDocLinkPath` so we don't change
- * pre-#535 behaviour for tokens that were always dropped anyway.
- */
 async function canonicalizeWorkspacePath(roots: ResolvedRoots, writtenPath: string): Promise<string | null> {
   if (isAbsolute(writtenPath)) {
     const real = await safeRealpath(writtenPath);
@@ -642,18 +476,10 @@ async function canonicalizeWorkspacePath(roots: ResolvedRoots, writtenPath: stri
     return normalizeDocLinkPath(relative(roots.agentHomeReal, real));
   }
 
-  // Relative path. Try to land it inside the fence so abs and rel forms agree
-  // on the same key; if it can't be realpath'd, fall back to the bare
-  // normalized form (legacy: caller's resolveWorkspaceFile will still drop it).
   const normalized = normalizeDocLinkPath(writtenPath);
   if (!normalized) return null;
   const real = await safeRealpath(resolve(roots.docBaseReal, normalized));
   if (!real) {
-    // The file may not exist yet (or the path leaves the fence via `..`); the
-    // pre-promotion key remains valid for the legacy single-root resolve in
-    // resolveWorkspaceFile, where promotePrefix is null. With a promotePrefix
-    // we still need agent-home-relative output, so synthesise it from the
-    // normalized rel form.
     if (roots.promotePrefix) {
       return normalizeDocLinkPath(`${roots.promotePrefix}/${normalized}`);
     }
@@ -664,23 +490,11 @@ async function canonicalizeWorkspacePath(roots: ResolvedRoots, writtenPath: stri
   return normalizeDocLinkPath(relative(roots.agentHomeReal, real));
 }
 
-/**
- * Resolve an ABSOLUTE `.md` path that points into a DIFFERENT agent's
- * workspace under the shared common root. Returns the global snapshot key
- * `<ownerSlug>/<chatId>/<rel>`, the realpath'd file to read, and the short
- * `<ownerSlug>/<rel>` form to rewrite into the outbound text — or null when
- * the path is outside the common root, belongs to another chat, hides, is the
- * sender's own workspace (handled as a self path), is not a regular `.md`
- * file, or cannot be realpath'd.
- *
- * realpath runs BEFORE the containment check so an ancestor symlink cannot
- * fake "inside the common root" — same discipline as the self-path resolver.
- */
 async function resolveCrossWorkspaceDoc(
   workspacesRootReal: string,
   fence: WorkspaceFence,
   absPath: string,
-): Promise<{ key: string; file: string; shortForm: string } | null> {
+): Promise<{ file: string; shortForm: string } | null> {
   const real = await safeRealpath(absPath);
   if (!real) return null;
 
@@ -690,22 +504,16 @@ async function resolveCrossWorkspaceDoc(
   const segments = relative(workspacesRootReal, real)
     .split(sep)
     .filter((s) => s.length > 0 && s !== ".");
-  // Need at least <ownerSlug>/<chatId>/<file>.
   if (segments.length < 3) return null;
-  // Reject any hidden segment (`.agent/`, `.git/`, dotfiles) anywhere in the
-  // realpath — closes the symlink-into-hidden-dir escape after realpath.
   if (segments.some((s) => s.startsWith("."))) return null;
 
   const [ownerSlug, segChatId, ...rest] = segments;
   if (!ownerSlug || !segChatId) return null;
-  // Chat-scope fence: only the current chat's workspaces are in range, so one
-  // chat can never preview another chat's private workspace docs.
   if (segChatId !== fence.chatId) return null;
-  // The sender's own workspace is handled by the self-path resolver (bare key,
-  // #480 rewrite). Keep cross strictly cross-agent.
   if (ownerSlug === fence.selfSlug) return null;
 
   const rel = rest.join("/");
+  // Validate the rel forms a canonical `.md` key (defence in depth).
   const key = buildWorkspaceDocKey(ownerSlug, segChatId, rel);
   if (!key || !key.toLowerCase().endsWith(".md")) return null;
 
@@ -716,22 +524,9 @@ async function resolveCrossWorkspaceDoc(
     return null;
   }
 
-  return { key, file: real, shortForm: `${ownerSlug}/${rel}` };
+  return { file: real, shortForm: `${ownerSlug}/${rel}` };
 }
 
-/**
- * Resolve a canonical workspace-relative link target against `rootReal`.
- * Returns the real path of a regular `.md` file that is **physically** inside
- * the worktree AND whose real path contains no hidden segments. The second
- * check is the bit that closes the symlink-into-`.agent` / -`.git` /
- * -dotfile escape: a link like `docs/public.md` could be a symlink whose
- * realpath is `<root>/.agent/secret.md` — link-level segment check would
- * allow it (no dot in `docs/public.md`), so we re-check after realpath.
- *
- * Callers must pass a canonical path (no leading "/", no "./", no "..", no
- * dot segments) — `buildMessageDocumentSnapshots` runs `normalizeDocLinkPath`
- * before invoking this function.
- */
 async function resolveWorkspaceFile(rootReal: string, canonicalPath: string): Promise<string | null> {
   if (!canonicalPath || isAbsolute(canonicalPath)) return null;
 
@@ -739,13 +534,9 @@ async function resolveWorkspaceFile(rootReal: string, canonicalPath: string): Pr
   const candidateReal = await safeRealpath(candidate);
   if (!candidateReal) return null;
 
-  // 1. Real target must still be inside (or equal to) the workspace root.
   const prefix = rootReal.endsWith(sep) ? rootReal : rootReal + sep;
   if (candidateReal !== rootReal && !candidateReal.startsWith(prefix)) return null;
 
-  // 2. Real target's path relative to root must not include any hidden
-  //    segment. Catches the case where a non-hidden link path points at a
-  //    symlink whose realpath drops into `.agent/`, `.git/`, dotfiles, etc.
   const rel = relative(rootReal, candidateReal);
   const realSegments = rel.split(sep).filter((s) => s.length > 0 && s !== ".");
   if (realSegments.some((s) => s.startsWith("."))) return null;

--- a/packages/client/src/runtime/doc-snapshots.ts
+++ b/packages/client/src/runtime/doc-snapshots.ts
@@ -6,6 +6,7 @@ import {
   buildWorkspaceDocKey,
   type DocSnapshotFailReason,
   type FailedDocMention,
+  MAX_ATTACHMENT_BYTES,
   MAX_FAILED_DOC_MENTION_RAW_LEN,
   MAX_FAILED_DOC_MENTIONS_PER_MESSAGE,
   MAX_MESSAGE_ATTACHMENT_REFS,
@@ -15,13 +16,15 @@ import {
 } from "@first-tree/shared";
 
 /**
- * Per-file raw byte cap for a doc capture. The attachments blob store caps a
- * single upload at 10MB, but a markdown doc that big would render to a multi-MB
- * string and choke the preview drawer, so the capture side keeps the original
- * conservative ceiling. Files above this are dropped (the mention stays plain
- * text) rather than uploaded.
+ * Per-file raw byte cap for a doc capture, aligned with the attachment UPLOAD
+ * cap (10MB) rather than a separate, smaller capture ceiling. A doc up to the
+ * upload limit is captured and uploaded; the preview drawer enforces its own
+ * far-smaller render cap (~1MB) and falls back to an authenticated download for
+ * anything larger, so a huge markdown never chokes the UI. Files above the
+ * upload cap hit `too-large` and stay plain text (the blob store would reject
+ * the upload anyway).
  */
-const MAX_DOC_CAPTURE_BYTES = 256 * 1024;
+const MAX_DOC_CAPTURE_BYTES = MAX_ATTACHMENT_BYTES;
 /** MIME the runtime assigns to markdown doc captures. */
 const DOC_CAPTURE_MIME = "text/markdown";
 /** Bounded retries for a single doc upload before giving up and degrading the

--- a/packages/client/src/runtime/result-sink.ts
+++ b/packages/client/src/runtime/result-sink.ts
@@ -1,4 +1,4 @@
-import { documentContextSchema } from "@first-tree/shared";
+import { type AttachmentRef, documentContextSchema } from "@first-tree/shared";
 import type { FirstTreeHubSDK } from "../sdk.js";
 import { buildMessageDocumentSnapshots, type SelfFence } from "./doc-snapshots.js";
 import type { AgentIdentity } from "./handler.js";
@@ -68,6 +68,15 @@ export type ResultSinkDeps = {
    */
   getSelfFence?: () => Promise<SelfFence | null>;
   /**
+   * Resolve the organization id the doc captures upload under. Uploads are
+   * org-scoped (`POST /orgs/:orgId/attachments`); the chat lives in exactly one
+   * org, so the sink resolves it from the chat (cached). Returning `null` (org
+   * unresolvable) disables doc capture for the turn — the message still goes
+   * out, mentions just stay plain text. Returned via a callback so the lookup
+   * (and its cache) lives with the runtime, not the sink.
+   */
+  getOrgId?: () => Promise<string | null>;
+  /**
    * Shared `workspaces/` common root (parent of every `<agentSlug>/<chatId>`).
    * Set alongside `selfSlug` to enable cross-agent doc snapshots: an absolute
    * `.md` path that realpaths into ANOTHER agent's workspace under this root
@@ -91,20 +100,17 @@ export function createResultSink(deps: ResultSinkDeps): ResultSink {
     const metadata: Record<string, unknown> = {};
     let content = text;
     const selfFence = await deps.getSelfFence?.();
-    if (selfFence) {
-      // Embed the inline-snapshot variant only. This is the cloud-friendly
-      // form: web gets the bytes straight from the message, no second server
-      // round-trip and no dependency on the server having access to the
-      // agent's local workspace filesystem (see proposal §核心设计).
-      //
-      // We deliberately do NOT fall back to the legacy `kind:"path"` variant.
-      // It carries the agent host's local absolute workspace path into
-      // immutable chat history (a cloud-topology leak), and is dead in the
-      // cloud anyway since the server can't read the agent's disk. Any real,
-      // referenced `.md` is already captured as a snapshot above; a message
-      // with no resolvable doc simply carries no documentContext. (Historical
-      // messages may still hold `kind:"path"`; the web reader keeps handling
-      // them for back-compat — this only stops emitting new ones.)
+    // Doc capture needs both the resolvable self-fence AND an org to upload the
+    // bytes under. With either missing we skip capture entirely — the message
+    // still goes out, doc mentions just stay plain text.
+    const orgId = selfFence ? await deps.getOrgId?.() : null;
+    if (selfFence && orgId) {
+      // Capture referenced docs as generic attachment refs: upload the bytes to
+      // the org blob store, store an `AttachmentRef` in `metadata.attachments[]`,
+      // and rewrite each resolved mention into `[display](attachment:<id>)`.
+      // Web fetches the bytes on demand from `GET /attachments/:id`. Bytes never
+      // travel in the message (cloud-friendly; the server can't read the agent's
+      // disk). See proposal §5.
       try {
         // Enable cross-agent resolution only when the runtime supplied the
         // shared common root + this agent's slug; otherwise fall back to the
@@ -113,39 +119,34 @@ export function createResultSink(deps: ResultSinkDeps): ResultSink {
           deps.workspacesRoot && deps.selfSlug
             ? { workspacesRoot: deps.workspacesRoot, chatId: deps.chatId, selfSlug: deps.selfSlug }
             : undefined;
-        const { docs, skipped, rewrittenText, failedMentions } = await buildMessageDocumentSnapshots(
+        const { refs, skipped, rewrittenText, failedMentions } = await buildMessageDocumentSnapshots(
           text,
           selfFence,
+          { uploader: deps.sdk, orgId },
           fence,
         );
-        // Validate BEFORE committing the rewritten body: `rewrittenText`
-        // contains explicit `[display](key)` links that only make sense paired
-        // with their snapshots. If schema validation throws, the catch must
-        // leave `content` as the ORIGINAL text — otherwise we'd ship explicit
-        // links with no matching snapshot (dead links), breaking the
-        // "rewritten ⇔ snapshotted" invariant (codex review finding).
-        //
-        // failedMentions enables the inert-chip UI on web: with ZERO
-        // snapshots but ≥1 failure we still attach the documentContext so the
-        // chat-view can render disabled chips + reason tooltips. Schema's
-        // refinement rejects empty docs + empty failedMentions, so we only
-        // attach when at least one is populated.
-        if (docs.length > 0 || failedMentions.length > 0) {
-          const payload: { kind: "snapshot"; docs: typeof docs; failedMentions?: typeof failedMentions } = {
-            kind: "snapshot",
-            docs,
-          };
-          if (failedMentions.length > 0) payload.failedMentions = failedMentions;
-          metadata.documentContext = documentContextSchema.parse(payload);
+        // The rewritten body's `attachment:<id>` links only make sense paired
+        // with their refs. `buildMessageDocumentSnapshots` only rewrites spans
+        // whose upload succeeded, so `rewrittenText` and `refs` are always
+        // consistent here.
+        if (refs.length > 0) {
+          const attachments: AttachmentRef[] = refs;
+          metadata.attachments = attachments;
+        }
+        // failedMentions enables the inert-chip UI on web: attach the
+        // documentContext snapshot roster only when ≥1 failure is present (the
+        // schema rejects an empty roster).
+        if (failedMentions.length > 0) {
+          metadata.documentContext = documentContextSchema.parse({ kind: "snapshot", failedMentions });
         }
         content = rewrittenText;
         if (skipped > 0) {
-          deps.log(`doc snapshot: skipped ${skipped} unresolvable link(s)`);
+          deps.log(`doc capture: skipped ${skipped} unresolvable / failed link(s)`);
         }
       } catch (err) {
-        // Snapshot build failure must never block message delivery — log and
-        // attach no documentContext so the message still goes out (verbatim).
-        deps.log(`doc snapshot: build failed, no documentContext attached: ${(err as Error).message}`);
+        // Capture failure must never block message delivery — log and attach no
+        // attachment metadata so the message still goes out (verbatim).
+        deps.log(`doc capture: build failed, no attachments attached: ${(err as Error).message}`);
       }
     }
 

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -331,6 +331,10 @@ export class SessionManager {
   private readonly pendingQueue: PendingMessage[] = [];
   private readonly lastReportedStates = new Map<string, SessionState>();
   private readonly sessionRuntimeStates = new Map<string, RuntimeState>();
+  /** Cache of chatId → organizationId, resolved via `getChatDetail`. A chat's
+   *  org is immutable, so this is a cheap permanent memo that keeps doc-capture
+   *  uploads off the hot path after the first lookup. */
+  private readonly chatOrgIds = new Map<string, string>();
   private lastReportedRuntimeState: RuntimeState | null = null;
   private idleTimer: ReturnType<typeof setInterval> | null = null;
   private runtimeReaffirmTimer: ReturnType<typeof setTimeout> | null = null;
@@ -1560,6 +1564,7 @@ export class SessionManager {
       },
       log,
       getSelfFence: () => this.resolveSelfFence(log, chatId),
+      getOrgId: () => this.resolveChatOrgId(log, chatId),
       workspacesRoot,
       selfSlug,
     });
@@ -1622,6 +1627,31 @@ export class SessionManager {
         `document preview self-fence: config unavailable, using agent home only: ${err instanceof Error ? err.message : String(err)}`,
       );
       return { agentHome: sessionRoot };
+    }
+  }
+
+  /**
+   * Resolve the organization id a chat belongs to, for doc-capture uploads
+   * (`POST /orgs/:orgId/attachments`). Cached permanently (a chat's org never
+   * changes). Returns `null` when the lookup fails so the sink degrades doc
+   * mentions to plain text instead of blocking the message.
+   */
+  private async resolveChatOrgId(log: (msg: string) => void, chatId: string): Promise<string | null> {
+    const cached = this.chatOrgIds.get(chatId);
+    if (cached) return cached;
+    try {
+      const detail = await this.config.sdk.getChatDetail(chatId);
+      const orgId = detail.organizationId;
+      if (typeof orgId === "string" && orgId.length > 0) {
+        this.chatOrgIds.set(chatId, orgId);
+        return orgId;
+      }
+      return null;
+    } catch (err) {
+      log(
+        `doc capture: org lookup failed, doc mentions stay plain text: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return null;
     }
   }
 

--- a/packages/server/src/__tests__/doc-snapshots.test.ts
+++ b/packages/server/src/__tests__/doc-snapshots.test.ts
@@ -150,6 +150,26 @@ describe("validateMessageAttachmentRefs", () => {
     ).rejects.toThrow(BadRequestError);
   });
 
+  // R5: the strict reader now full-schema-parses each ref, so a ref with a
+  // schema-invalid sha256 (wrong length) is rejected before any DB lookup —
+  // not just the uuid-shape check the hand-rolled guard performed.
+  it("rejects a ref whose sha256 is the wrong length (full schema parse)", async () => {
+    await expect(
+      validateMessageAttachmentRefs(readerWith({ mimeType: "text/markdown", sizeBytes: 12 }), {
+        attachments: [baseRef({ sha256: "abc" })],
+      }),
+    ).rejects.toThrow(BadRequestError);
+  });
+
+  // R5: schema parse attributes the failing index for diagnostics.
+  it("reports the failing ref index in the BadRequestError attributes", async () => {
+    await expect(
+      validateMessageAttachmentRefs(readerWith({ mimeType: "text/markdown", sizeBytes: 12 }), {
+        attachments: [baseRef(), baseRef({ size: -1 })],
+      }),
+    ).rejects.toMatchObject({ attrs: { "attachment_ref.index": 1 } });
+  });
+
   it("rejects a non-array attachments field", async () => {
     await expect(validateMessageAttachmentRefs(readerWith(null), { attachments: "nope" })).rejects.toThrow(
       BadRequestError,

--- a/packages/server/src/__tests__/doc-snapshots.test.ts
+++ b/packages/server/src/__tests__/doc-snapshots.test.ts
@@ -1,21 +1,8 @@
-import { createHash } from "node:crypto";
-import { MAX_DOC_SNAPSHOT_BYTES, MAX_TOTAL_DOC_SNAPSHOT_BYTES } from "@first-tree/shared";
+import { randomUUID } from "node:crypto";
 import { describe, expect, it } from "vitest";
 import { BadRequestError } from "../errors.js";
-import { validateDocumentContext } from "../services/doc-snapshots.js";
-
-function sha256(content: string): string {
-  return createHash("sha256").update(content, "utf8").digest("hex");
-}
-
-function snapshotDoc(path: string, content: string) {
-  return {
-    path,
-    content,
-    sha256: sha256(content),
-    size: Buffer.byteLength(content, "utf8"),
-  };
-}
+import type { AttachmentReader } from "../services/attachment.js";
+import { validateDocumentContext, validateMessageAttachmentRefs } from "../services/doc-snapshots.js";
 
 describe("validateDocumentContext", () => {
   it("accepts metadata without documentContext", () => {
@@ -24,254 +11,158 @@ describe("validateDocumentContext", () => {
     expect(() => validateDocumentContext({ mentions: ["x"] })).not.toThrow();
   });
 
-  it("accepts a well-formed snapshot variant", () => {
+  it("accepts a snapshot variant carrying a failedMentions roster", () => {
     expect(() =>
       validateDocumentContext({
         documentContext: {
           kind: "snapshot",
-          docs: [snapshotDoc("docs/design.md", "# design\n\nbody.\n")],
+          failedMentions: [{ raw: "docs/missing.md", reason: "missing" }],
         },
       }),
     ).not.toThrow();
+  });
+
+  it("rejects a snapshot variant with an empty failedMentions roster", () => {
+    expect(() =>
+      validateDocumentContext({
+        documentContext: { kind: "snapshot", failedMentions: [] },
+      }),
+    ).toThrow(BadRequestError);
+  });
+
+  it("rejects a snapshot variant with no failedMentions field", () => {
+    // The inline `docs[]` shape is gone, so a bare `{ kind: "snapshot" }` is
+    // no longer valid — the roster is now required.
+    expect(() =>
+      validateDocumentContext({
+        documentContext: { kind: "snapshot" },
+      }),
+    ).toThrow(BadRequestError);
+  });
+
+  it("rejects an unknown failure reason", () => {
+    expect(() =>
+      validateDocumentContext({
+        documentContext: {
+          kind: "snapshot",
+          failedMentions: [{ raw: "docs/x.md", reason: "nonsense" }],
+        },
+      }),
+    ).toThrow(BadRequestError);
   });
 
   it("normalises legacy `{ basePath }` to kind=path via the shared preprocessor", () => {
     expect(() => validateDocumentContext({ documentContext: { basePath: "first-tree" } })).not.toThrow();
   });
 
-  it("rejects a sha256 that disagrees with the content", () => {
+  it("rejects the legacy inline snapshot shape (cutover — graceful degrade is reader-side)", () => {
+    // A pre-cutover message's inline `docs[].content` shape no longer matches
+    // the schema. On the SEND path that's a client bug worth surfacing; readers
+    // (web) tolerate the old shape by falling back to no-preview.
     expect(() =>
       validateDocumentContext({
         documentContext: {
           kind: "snapshot",
-          docs: [{ ...snapshotDoc("a.md", "hello"), sha256: "0".repeat(64) }],
+          docs: [{ path: "docs/design.md", content: "# design", sha256: "a".repeat(64), size: 8 }],
         },
       }),
     ).toThrow(BadRequestError);
   });
+});
 
-  it("rejects a size that disagrees with the content", () => {
-    expect(() =>
-      validateDocumentContext({
-        documentContext: {
-          kind: "snapshot",
-          docs: [{ ...snapshotDoc("a.md", "hello"), size: 9999 }],
-        },
+describe("validateMessageAttachmentRefs", () => {
+  const id = randomUUID();
+  const baseRef = (overrides: Record<string, unknown> = {}) => ({
+    attachmentId: id,
+    kind: "document",
+    mimeType: "text/markdown",
+    filename: "design.md",
+    size: 12,
+    sha256: "a".repeat(64),
+    source: { path: "docs/design.md" },
+    ...overrides,
+  });
+
+  // The fake reader can't decode drizzle's `eq()` predicate, so we give it a
+  // single-row store keyed by the only id we reference and read by ignoring the
+  // predicate — every `select` returns that row. Tests that need "missing" use
+  // an empty store.
+  // Minimal stand-in for the `select().from().where().limit()` chain
+  // `loadAttachmentMeta` uses. Drizzle's real builder types are far richer than
+  // this test needs, so the whole stub is cast through `unknown` to
+  // `AttachmentReader` — the only contract we exercise is that `limit()`
+  // resolves to the seeded row (or none).
+  function readerWith(row: { mimeType: string; sizeBytes: number } | null): AttachmentReader {
+    const chain = {
+      from() {
+        return chain;
+      },
+      where() {
+        return chain;
+      },
+      async limit() {
+        return row ? [{ id, ...row }] : [];
+      },
+    };
+    return { select: () => chain } as unknown as AttachmentReader;
+  }
+
+  it("no-ops when there is no attachments field", async () => {
+    await expect(validateMessageAttachmentRefs(readerWith(null), {})).resolves.toBeUndefined();
+    await expect(validateMessageAttachmentRefs(readerWith(null), undefined)).resolves.toBeUndefined();
+  });
+
+  it("accepts a ref whose mime + size match the stored row", async () => {
+    await expect(
+      validateMessageAttachmentRefs(readerWith({ mimeType: "text/markdown", sizeBytes: 12 }), {
+        attachments: [baseRef()],
       }),
-    ).toThrow(BadRequestError);
+    ).resolves.toBeUndefined();
   });
 
-  it("rejects a snapshot that exceeds the per-file byte budget", () => {
-    const oversize = "a".repeat(MAX_DOC_SNAPSHOT_BYTES + 1);
-    expect(() =>
-      validateDocumentContext({
-        documentContext: {
-          kind: "snapshot",
-          docs: [snapshotDoc("big.md", oversize)],
-        },
+  it("rejects a ref pointing at a non-existent attachment", async () => {
+    await expect(validateMessageAttachmentRefs(readerWith(null), { attachments: [baseRef()] })).rejects.toThrow(
+      BadRequestError,
+    );
+  });
+
+  it("rejects a mime mismatch", async () => {
+    await expect(
+      validateMessageAttachmentRefs(readerWith({ mimeType: "image/png", sizeBytes: 12 }), {
+        attachments: [baseRef()],
       }),
-    ).toThrow(BadRequestError);
+    ).rejects.toThrow(BadRequestError);
   });
 
-  it("rejects when the aggregate byte total exceeds the per-message budget", () => {
-    // Three docs each just under the per-file budget — individually OK,
-    // collectively over the per-message cap.
-    const chunk = "a".repeat(Math.floor(MAX_TOTAL_DOC_SNAPSHOT_BYTES / 2 + 1));
-    expect(() =>
-      validateDocumentContext({
-        documentContext: {
-          kind: "snapshot",
-          docs: [snapshotDoc("a.md", chunk), snapshotDoc("b.md", chunk)],
-        },
+  it("rejects a size mismatch", async () => {
+    await expect(
+      validateMessageAttachmentRefs(readerWith({ mimeType: "text/markdown", sizeBytes: 99 }), {
+        attachments: [baseRef()],
       }),
-    ).toThrow(BadRequestError);
+    ).rejects.toThrow(BadRequestError);
   });
 
-  it("rejects entirely-invalid documentContext shape with a parse error", () => {
-    expect(() =>
-      validateDocumentContext({
-        documentContext: { kind: "snapshot", docs: [] },
+  it("rejects a present-but-malformed attachments entry (strict on send)", async () => {
+    await expect(
+      validateMessageAttachmentRefs(readerWith({ mimeType: "text/markdown", sizeBytes: 12 }), {
+        attachments: [{ attachmentId: "not-a-uuid" }],
       }),
-    ).toThrow(BadRequestError);
+    ).rejects.toThrow(BadRequestError);
   });
 
-  it("rejects non-canonical paths so the wire format matches web cache lookup", () => {
-    // Any path the web `docPreviewPathFromHref` would NOT produce must be
-    // rejected — leading `/`, `./`, `..`, and hidden segments all fall here.
-    for (const badPath of ["/docs/a.md", "./docs/a.md", "docs/../a.md", ".agent/secret.md", "docs/.hidden.md"]) {
-      expect(
-        () =>
-          validateDocumentContext({
-            documentContext: {
-              kind: "snapshot",
-              docs: [snapshotDoc(badPath, "x")],
-            },
-          }),
-        `expected to reject path: ${badPath}`,
-      ).toThrow(BadRequestError);
-    }
+  it("rejects a non-array attachments field", async () => {
+    await expect(validateMessageAttachmentRefs(readerWith(null), { attachments: "nope" })).rejects.toThrow(
+      BadRequestError,
+    );
   });
 
-  it("rejects non-`.md` paths even when canonical (trust boundary tightening)", () => {
-    expect(() =>
-      validateDocumentContext({
-        documentContext: {
-          kind: "snapshot",
-          docs: [snapshotDoc("docs/secret.env", "leak")],
-        },
+  it("does not check uploader == sender (uploaded_by is the managing human)", async () => {
+    // The stored row carries no uploadedBy in the fake, and the validator never
+    // reads it — a normal send (agent sender ≠ human uploader) must pass.
+    await expect(
+      validateMessageAttachmentRefs(readerWith({ mimeType: "text/markdown", sizeBytes: 12 }), {
+        attachments: [baseRef()],
       }),
-    ).toThrow(BadRequestError);
-  });
-
-  it("rejects query / fragment embedded in path", () => {
-    for (const badPath of ["docs/a.md?leak=1", "docs/a.md#section"]) {
-      expect(
-        () =>
-          validateDocumentContext({
-            documentContext: {
-              kind: "snapshot",
-              docs: [snapshotDoc(badPath, "x")],
-            },
-          }),
-        `expected to reject path: ${badPath}`,
-      ).toThrow(BadRequestError);
-    }
-  });
-
-  describe("cross-agent provenance (chatScope)", () => {
-    // Real chat ids are UUIDs (services/chat.ts uses `randomUUID()`). Tests use
-    // canonical UUID-shaped strings so the cross-chat fence (which gates on
-    // `looksLikeChatId`) discriminates correctly — a non-UUID second segment
-    // is treated as a deep self path, NOT a cross-chat attempt.
-    const CHAT_ID = "11111111-1111-4111-8111-111111111111";
-    const OTHER_CHAT_ID = "22222222-2222-4222-8222-222222222222";
-    const scope = (slugs: string[]) => ({ chatId: CHAT_ID, participantSlugs: new Set(slugs) });
-
-    it("accepts a cross-agent global key when the owner is a chat participant", () => {
-      expect(() =>
-        validateDocumentContext(
-          {
-            documentContext: {
-              kind: "snapshot",
-              docs: [snapshotDoc(`assistant/${CHAT_ID}/design.md`, "# theirs\n")],
-            },
-          },
-          scope(["coder", "assistant"]),
-        ),
-      ).not.toThrow();
-    });
-
-    it("rejects a cross-agent global key when the owner is NOT a chat participant", () => {
-      expect(() =>
-        validateDocumentContext(
-          {
-            documentContext: {
-              kind: "snapshot",
-              docs: [snapshotDoc(`intruder/${CHAT_ID}/secret.md`, "# leak\n")],
-            },
-          },
-          scope(["coder", "assistant"]),
-        ),
-      ).toThrow(BadRequestError);
-    });
-
-    it("leaves bare self keys unaffected by the participant check", () => {
-      expect(() =>
-        validateDocumentContext(
-          {
-            documentContext: {
-              kind: "snapshot",
-              docs: [snapshotDoc("docs/design.md", "# mine\n")],
-            },
-          },
-          scope(["coder"]),
-        ),
-      ).not.toThrow();
-    });
-
-    it("rejects a participant-owned global key that names a DIFFERENT chat (chatId fence — P1)", () => {
-      // `assistant` is a participant, the second segment is a uuid-shaped
-      // chatId different from `scope.chatId` — this is a cross key shape
-      // pointing at another chat's workspace and must not slip past the
-      // `workspaces/*/<currentChatId>/` fence.
-      expect(() =>
-        validateDocumentContext(
-          {
-            documentContext: {
-              kind: "snapshot",
-              docs: [snapshotDoc(`assistant/${OTHER_CHAT_ID}/design.md`, "# x\n")],
-            },
-          },
-          scope(["coder", "assistant"]),
-        ),
-      ).toThrow(BadRequestError);
-    });
-
-    it("allows a deep SELF path whose first segment is not a participant slug", () => {
-      // `docs/api/design.md` is a legitimate nested self path; `docs` is not a
-      // participant, so the chatId-fence rule must not over-reject it.
-      expect(() =>
-        validateDocumentContext(
-          {
-            documentContext: {
-              kind: "snapshot",
-              docs: [snapshotDoc("docs/api/design.md", "# nested\n")],
-            },
-          },
-          scope(["coder", "assistant"]),
-        ),
-      ).not.toThrow();
-    });
-
-    it("treats a participant-named first segment as SELF when the second segment is not uuid-shaped", () => {
-      // Worktree-fence regression guard: a single-repo agent whose source-repo
-      // `localPath` happens to coincide with another participant's slug emits
-      // promoted self keys like `assistant/docs/intro.md` for relative
-      // mentions. Without the `looksLikeChatId` discriminator, the
-      // participant-owned-different-chat branch would reject these as a
-      // cross-chat leak — but `docs` is not a uuid, so no real chat can be
-      // named `docs` and the leak path is structurally impossible. Treat the
-      // key as a deep self path and let it through.
-      expect(() =>
-        validateDocumentContext(
-          {
-            documentContext: {
-              kind: "snapshot",
-              docs: [snapshotDoc("assistant/docs/intro.md", "# self with colliding prefix\n")],
-            },
-          },
-          scope(["coder", "assistant"]),
-        ),
-      ).not.toThrow();
-    });
-
-    it("allows a worktree self key whose first segment is not a participant slug", () => {
-      // The wide self-fence emits agent-home-relative keys for files outside
-      // the source repo (e.g. on-demand `git worktree add`). When the first
-      // segment is `worktrees` and no participant is named `worktrees`, the
-      // path is straightforward self — never trips the cross check.
-      expect(() =>
-        validateDocumentContext(
-          {
-            documentContext: {
-              kind: "snapshot",
-              docs: [snapshotDoc("worktrees/553-fix/docs/design.md", "# worktree doc\n")],
-            },
-          },
-          scope(["coder", "assistant"]),
-        ),
-      ).not.toThrow();
-    });
-
-    it("skips the provenance check entirely when no chatScope is supplied (back-compat)", () => {
-      expect(() =>
-        validateDocumentContext({
-          documentContext: {
-            kind: "snapshot",
-            docs: [snapshotDoc(`intruder/${CHAT_ID}/secret.md`, "# leak\n")],
-          },
-        }),
-      ).not.toThrow();
-    });
+    ).resolves.toBeUndefined();
   });
 });

--- a/packages/server/src/services/attachment.ts
+++ b/packages/server/src/services/attachment.ts
@@ -74,7 +74,11 @@ export async function createAttachment(db: Database, input: CreateAttachmentInpu
 /** Everything in `AttachmentRow` except the `bytea` payload. */
 export type AttachmentMeta = Omit<AttachmentRow, "data">;
 
-export async function loadAttachmentMeta(db: Database, id: string): Promise<AttachmentMeta | null> {
+/** A select-capable executor — `Database` or a transaction both satisfy it, so
+ *  read helpers can run inside a caller's open transaction. */
+export type AttachmentReader = Pick<Database, "select">;
+
+export async function loadAttachmentMeta(db: AttachmentReader, id: string): Promise<AttachmentMeta | null> {
   const [row] = await db
     .select({
       id: attachments.id,

--- a/packages/server/src/services/doc-snapshots.ts
+++ b/packages/server/src/services/doc-snapshots.ts
@@ -1,43 +1,32 @@
-import { createHash } from "node:crypto";
 import {
+  type AttachmentRef,
+  attachmentRefsFromMetadata,
   documentContextSchema,
-  looksLikeChatId,
-  MAX_DOC_SNAPSHOT_BYTES,
-  MAX_TOTAL_DOC_SNAPSHOT_BYTES,
-  parseWorkspaceDocKey,
+  MAX_MESSAGE_ATTACHMENT_REFS,
 } from "@first-tree/shared";
 import { BadRequestError } from "../errors.js";
+import { type AttachmentReader, loadAttachmentMeta } from "./attachment.js";
 
 /**
- * Server-side bottom-line validation for `metadata.documentContext`.
+ * Server-side shape validation for `metadata.documentContext`.
  *
- * Runtime is the snapshot author, but content arrives over the wire — server
- * still has to verify byte budgets and recompute sha256 so a buggy or
- * malicious client cannot lodge a doc whose declared hash drifts from its
- * actual content. Shape validation (path / docs[] cap / kind discriminator)
- * lives in the shared schema; this file owns the byte-counted and
- * cryptographic checks that schemas cannot express.
+ * After the attachment-ref convergence the only thing left in
+ * `documentContext` is the inert-chip `failedMentions` roster (the successful
+ * captures are now generic `AttachmentRef`s in `metadata.attachments[]`, byte
+ * validated by {@link validateMessageAttachmentRefs}). This function only
+ * enforces the discriminated-union shape so a malformed roster is rejected
+ * loudly rather than silently stored.
  *
- * Returns the validated DocumentContext for the caller to store, or
- * `undefined` if no `documentContext` was provided.
+ * Graceful degradation: a pre-cutover message carrying the legacy inline
+ * `kind: "snapshot"` shape (`docs[].content`) no longer matches the schema, so
+ * the parse fails. This validator runs only on the SEND path (new messages),
+ * so a parse failure here is a genuine client bug worth surfacing; readers
+ * (web) tolerate the legacy shape by falling back to no-preview.
  *
- * Why throw BadRequestError instead of silently stripping: snapshot data
- * comes from a trusted runtime; a schema mismatch typically signals a
- * client bug, and surfacing it loudly is more useful than hiding it.
- *
- * `chatScope` (optional) enables cross-agent provenance authz: a snapshot key
- * shaped like a global cross key `<ownerSlug>/<chatId>/<rel>` whose chatId
- * segment matches the message's chat must name an owner that is a participant
- * of that chat. This is defense-in-depth on top of the runtime's structural
- * fence — a compromised runtime cannot embed (and broadcast) a non-participant
- * agent's workspace doc. Self / legacy bare keys carry no owner segment for
- * this chat and are unaffected. When omitted (other callers / tests), the
- * provenance check is skipped.
+ * Throws `BadRequestError` on a malformed `documentContext`; a no-op when the
+ * field is absent.
  */
-export function validateDocumentContext(
-  metadata: Record<string, unknown> | undefined,
-  chatScope?: { chatId: string; participantSlugs: ReadonlySet<string> },
-): void {
+export function validateDocumentContext(metadata: Record<string, unknown> | undefined): void {
   if (!metadata) return;
   const raw = metadata.documentContext;
   if (raw === undefined || raw === null) return;
@@ -48,77 +37,89 @@ export function validateDocumentContext(
       "doc_snapshot.parse_error": parsed.error.message.slice(0, 200),
     });
   }
-  const ctx = parsed.data;
-  if (ctx.kind !== "snapshot") return;
+}
 
-  let totalBytes = 0;
-  for (const doc of ctx.docs) {
-    if (chatScope) {
-      const key = parseWorkspaceDocKey(doc.path);
-      if (key) {
-        const ownerIsParticipant = chatScope.participantSlugs.has(key.agentSlug.toLowerCase());
-        if (key.chatId === chatScope.chatId) {
-          // Cross-agent global key for THIS chat — the owner must be a speaker
-          // participant, else a doc from a non-member's workspace would be
-          // broadcast into the chat.
-          if (!ownerIsParticipant) {
-            throw new BadRequestError("Document snapshot references a non-participant agent workspace", {
-              "doc_snapshot.path": doc.path,
-              "doc_snapshot.owner_slug": key.agentSlug,
-            });
-          }
-        } else if (ownerIsParticipant && looksLikeChatId(key.chatId)) {
-          // Owner-shaped global key naming a DIFFERENT chat. A participant-owned
-          // key whose chat segment isn't this chat would pull another chat's
-          // private workspace doc past the `workspaces/*/<currentChatId>/` fence
-          // — reject it (review P1).
-          //
-          // The `looksLikeChatId` gate disambiguates a real cross-chat attempt
-          // (`<participant>/<some-uuid>/<rel>`) from a deep SELF path whose
-          // first segment HAPPENS to be a participant slug. After the
-          // worktree-fence widening (this PR), a single-repo agent emits
-          // promoted self keys shaped `<localPath>/<rel>` (e.g.
-          // `assistant/docs/intro.md`); without the uuid check, those would be
-          // rejected here whenever `<localPath>` collides with a participant
-          // name, breaking otherwise valid sends. chatIds are minted by
-          // `createChat` as canonical UUIDs (services/chat.ts), so any
-          // non-uuid second segment cannot reference a real chat — the leak
-          // protection is meaningless in that branch.
-          throw new BadRequestError("Document snapshot references another chat's agent workspace", {
-            "doc_snapshot.path": doc.path,
-            "doc_snapshot.owner_slug": key.agentSlug,
-            "doc_snapshot.key_chat_id": key.chatId,
-          });
-        }
-      }
-    }
-    const actualBytes = Buffer.byteLength(doc.content, "utf8");
-    if (actualBytes > MAX_DOC_SNAPSHOT_BYTES) {
-      throw new BadRequestError("Document snapshot exceeds per-file byte budget", {
-        "doc_snapshot.path": doc.path,
-        "doc_snapshot.actual_bytes": actualBytes,
-        "doc_snapshot.limit_bytes": MAX_DOC_SNAPSHOT_BYTES,
-      });
-    }
-    if (doc.size !== actualBytes) {
-      throw new BadRequestError("Document snapshot size does not match content", {
-        "doc_snapshot.path": doc.path,
-        "doc_snapshot.declared_size": doc.size,
-        "doc_snapshot.actual_size": actualBytes,
-      });
-    }
-    const actualSha = createHash("sha256").update(doc.content, "utf8").digest("hex");
-    if (actualSha !== doc.sha256) {
-      throw new BadRequestError("Document snapshot sha256 does not match content", {
-        "doc_snapshot.path": doc.path,
-      });
-    }
-    totalBytes += actualBytes;
-  }
-  if (totalBytes > MAX_TOTAL_DOC_SNAPSHOT_BYTES) {
-    throw new BadRequestError("Total document snapshot bytes exceed per-message budget", {
-      "doc_snapshot.total_bytes": totalBytes,
-      "doc_snapshot.limit_bytes": MAX_TOTAL_DOC_SNAPSHOT_BYTES,
+/**
+ * Server-side bottom-line validation for `metadata.attachments[]` — the generic
+ * attachment-ref roster (doc-preview is the first consumer; kind: "document").
+ *
+ * Runtime is the ref author, but the wire is untrusted: server confirms each
+ * referenced blob actually exists and that the ref's declared `mimeType` /
+ * `size` agree with the stored `attachments` row. This is the trust boundary
+ * that keeps a buggy or malicious client from lodging a ref whose declared
+ * metadata drifts from reality (which would mislead every reader / integrity
+ * check). Integrity of the BYTES is verified client-side at render via
+ * `ref.sha256`, so the server does not re-hash (zero DB change, no bytea read
+ * on the hot send path).
+ *
+ * Deliberately does NOT check `uploaded_by == sender`: uploads record the
+ * managing human's `humanAgentId`, while the message sender is the agent uuid —
+ * the two are never equal, so that check would reject every normal send (see
+ * proposal §5.3, verified against api/orgs/attachments.ts).
+ *
+ * Throws `BadRequestError` when the ref count exceeds the cap, or any ref's
+ * attachment is missing / mime-mismatched / size-mismatched. A no-op when no
+ * `attachments` field is present (the common case — most messages carry none).
+ */
+export async function validateMessageAttachmentRefs(
+  db: AttachmentReader,
+  metadata: Record<string, unknown> | undefined,
+): Promise<void> {
+  const refs = readAttachmentRefsStrict(metadata);
+  if (refs.length === 0) return;
+
+  if (refs.length > MAX_MESSAGE_ATTACHMENT_REFS) {
+    throw new BadRequestError("Too many attachment references on a single message", {
+      "attachment_ref.count": refs.length,
+      "attachment_ref.limit": MAX_MESSAGE_ATTACHMENT_REFS,
     });
   }
+
+  // Look up every referenced row in parallel (metadata only — no bytea).
+  const rows = await Promise.all(refs.map((ref) => loadAttachmentMeta(db, ref.attachmentId)));
+
+  for (let i = 0; i < refs.length; i += 1) {
+    const ref = refs[i];
+    const row = rows[i];
+    if (!ref) continue;
+    if (!row) {
+      throw new BadRequestError("Attachment reference points at a non-existent attachment", {
+        "attachment_ref.id": ref.attachmentId,
+      });
+    }
+    if (row.mimeType !== ref.mimeType) {
+      throw new BadRequestError("Attachment reference mimeType does not match the stored attachment", {
+        "attachment_ref.id": ref.attachmentId,
+        "attachment_ref.declared_mime": ref.mimeType,
+        "attachment_ref.actual_mime": row.mimeType,
+      });
+    }
+    if (row.sizeBytes !== ref.size) {
+      throw new BadRequestError("Attachment reference size does not match the stored attachment", {
+        "attachment_ref.id": ref.attachmentId,
+        "attachment_ref.declared_size": ref.size,
+        "attachment_ref.actual_size": row.sizeBytes,
+      });
+    }
+  }
+}
+
+/**
+ * Read `metadata.attachments[]`, rejecting a present-but-malformed array as a
+ * client bug. `attachmentRefsFromMetadata` (the lenient reader used on render)
+ * silently drops bad entries; on the send path we want a loud failure instead
+ * so a misbehaving runtime can't ship a half-broken roster.
+ */
+function readAttachmentRefsStrict(metadata: Record<string, unknown> | undefined): AttachmentRef[] {
+  if (!metadata) return [];
+  const raw = metadata.attachments;
+  if (raw === undefined || raw === null) return [];
+  if (!Array.isArray(raw)) {
+    throw new BadRequestError("metadata.attachments must be an array of attachment references");
+  }
+  const refs = attachmentRefsFromMetadata(metadata);
+  if (refs.length !== raw.length) {
+    throw new BadRequestError("metadata.attachments contains a malformed attachment reference");
+  }
+  return refs;
 }

--- a/packages/server/src/services/doc-snapshots.ts
+++ b/packages/server/src/services/doc-snapshots.ts
@@ -1,6 +1,6 @@
 import {
   type AttachmentRef,
-  attachmentRefsFromMetadata,
+  attachmentRefSchema,
   documentContextSchema,
   MAX_MESSAGE_ATTACHMENT_REFS,
 } from "@first-tree/shared";
@@ -106,9 +106,12 @@ export async function validateMessageAttachmentRefs(
 
 /**
  * Read `metadata.attachments[]`, rejecting a present-but-malformed array as a
- * client bug. `attachmentRefsFromMetadata` (the lenient reader used on render)
- * silently drops bad entries; on the send path we want a loud failure instead
- * so a misbehaving runtime can't ship a half-broken roster.
+ * client bug. The render-side `attachmentRefsFromMetadata` reader silently drops
+ * bad entries; on the send path we want a loud failure instead so a misbehaving
+ * runtime can't ship a half-broken roster. Each entry is validated with the full
+ * `attachmentRefSchema` (uuid id + sha256 length + field types), not just the
+ * hand-rolled `isAttachmentRef` guard, so any schema-invalid ref is rejected
+ * with a clean 400 rather than slipping through.
  */
 function readAttachmentRefsStrict(metadata: Record<string, unknown> | undefined): AttachmentRef[] {
   if (!metadata) return [];
@@ -117,9 +120,16 @@ function readAttachmentRefsStrict(metadata: Record<string, unknown> | undefined)
   if (!Array.isArray(raw)) {
     throw new BadRequestError("metadata.attachments must be an array of attachment references");
   }
-  const refs = attachmentRefsFromMetadata(metadata);
-  if (refs.length !== raw.length) {
-    throw new BadRequestError("metadata.attachments contains a malformed attachment reference");
+  const refs: AttachmentRef[] = [];
+  for (let i = 0; i < raw.length; i += 1) {
+    const parsed = attachmentRefSchema.safeParse(raw[i]);
+    if (!parsed.success) {
+      throw new BadRequestError("metadata.attachments contains a malformed attachment reference", {
+        "attachment_ref.index": i,
+        "attachment_ref.parse_error": parsed.error.message.slice(0, 200),
+      });
+    }
+    refs.push(parsed.data);
   }
   return refs;
 }

--- a/packages/server/src/services/message.ts
+++ b/packages/server/src/services/message.ts
@@ -21,7 +21,7 @@ import { createLogger, messageAttrs, withSpan } from "../observability/index.js"
 import { uuidv7 } from "../uuid.js";
 import { upsertSessionState } from "./activity.js";
 import { applyAfterFanOut, fireChatMessageKick } from "./chat-projection.js";
-import { validateDocumentContext } from "./doc-snapshots.js";
+import { validateDocumentContext, validateMessageAttachmentRefs } from "./doc-snapshots.js";
 
 const log = createLogger("message");
 
@@ -185,10 +185,7 @@ export function preflightMessageSendIntent(input: {
   }
 
   const incomingMeta = stripUntrustedMetadataKeys((data.metadata ?? {}) as Record<string, unknown>, options);
-  validateDocumentContext(incomingMeta, {
-    chatId,
-    participantSlugs: new Set(participants.map((p) => p.name?.toLowerCase()).filter((n): n is string => Boolean(n))),
-  });
+  validateDocumentContext(incomingMeta);
   if (incomingMeta.resolves !== undefined && !requestResolutionSchema.safeParse(incomingMeta.resolves).success) {
     throw new BadRequestError(
       'Malformed "metadata.resolves": expected {request: <messageId>, kind: "answered"|"closed", reason?}.',
@@ -413,6 +410,14 @@ async function sendMessageInner(
       participants,
     });
     const { content: outboundContent, metadata: metadataToStore, mentionedAgentIds: mergedMentions } = prepared;
+
+    // 2b. Validate generic attachment refs (`metadata.attachments[]`) against
+    //     the blob store: each referenced attachment must exist and its
+    //     declared mime/size must match the stored row. Async (DB lookup), so
+    //     it runs here rather than in the sync preflight. Byte integrity is
+    //     checked client-side at render via `ref.sha256`; uploader != sender by
+    //     design (see validateMessageAttachmentRefs).
+    await validateMessageAttachmentRefs(tx, metadataToStore);
 
     // 3. Store the message (with merged metadata + normalised content).
     // UUID v7 per the "UUID v7 as Message ID" architecture rule in

--- a/packages/shared/src/__tests__/me-doc-schema.test.ts
+++ b/packages/shared/src/__tests__/me-doc-schema.test.ts
@@ -16,35 +16,29 @@ describe("documentContextSchema", () => {
     });
   });
 
-  it("accepts snapshot context with canonical markdown docs", () => {
+  it("accepts a snapshot context carrying a failedMentions roster", () => {
+    // Post-convergence the snapshot variant is the inert-chip roster ONLY —
+    // successful captures live in metadata.attachments[] as AttachmentRefs.
     const context = {
       kind: "snapshot",
-      docs: [
-        {
-          path: "docs/readme.md",
-          sha256: "a".repeat(64),
-          size: 12,
-          content: "# Readme",
-        },
-      ],
-    };
-
-    expect(documentContextSchema.parse(context)).toEqual(context);
-  });
-
-  it("accepts snapshot context with failed mentions and no docs", () => {
-    const context = {
-      kind: "snapshot",
-      docs: [],
       failedMentions: [{ raw: "docs/missing.md", reason: "missing" }],
     };
 
     expect(documentContextSchema.parse(context)).toEqual(context);
   });
 
-  it("rejects snapshot context without docs or failed mentions", () => {
-    expect(() => documentContextSchema.parse({ kind: "snapshot", docs: [] })).toThrow(
-      "snapshot documentContext must include at least one snapshot or one failedMention",
-    );
+  it("rejects a snapshot context with an empty failedMentions roster", () => {
+    expect(() => documentContextSchema.parse({ kind: "snapshot", failedMentions: [] })).toThrow();
+  });
+
+  it("rejects the legacy inline `docs[].content` snapshot shape (cutover)", () => {
+    // Old messages with this shape no longer parse; readers degrade gracefully
+    // to no-preview rather than throwing.
+    expect(() =>
+      documentContextSchema.parse({
+        kind: "snapshot",
+        docs: [{ path: "docs/readme.md", sha256: "a".repeat(64), size: 12, content: "# Readme" }],
+      }),
+    ).toThrow();
   });
 });

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -135,6 +135,16 @@ export {
   uploadAttachmentResponseSchema,
 } from "./schemas/attachment.js";
 export {
+  ATTACHMENT_KINDS,
+  type AttachmentKind,
+  type AttachmentRef,
+  attachmentKindSchema,
+  attachmentRefSchema,
+  attachmentRefsFromMetadata,
+  isAttachmentRef,
+  MAX_MESSAGE_ATTACHMENT_REFS,
+} from "./schemas/attachment-ref.js";
+export {
   type ConnectTokenExchange,
   type ConnectTokenResponse,
   connectTokenExchangeSchema,
@@ -443,13 +453,8 @@ export {
   type GetMeDocResponse,
   getMeDocResponseSchema,
   getMeDocSchema,
-  MAX_DOC_SNAPSHOT_BYTES,
-  MAX_DOC_SNAPSHOTS_PER_MESSAGE,
   MAX_FAILED_DOC_MENTION_RAW_LEN,
   MAX_FAILED_DOC_MENTIONS_PER_MESSAGE,
-  MAX_TOTAL_DOC_SNAPSHOT_BYTES,
-  type SnapshotDoc,
-  snapshotDocSchema,
   type WorkspaceDocRef,
   workspaceDocRefSchema,
 } from "./schemas/me-doc.js";

--- a/packages/shared/src/schemas/attachment-ref.ts
+++ b/packages/shared/src/schemas/attachment-ref.ts
@@ -37,6 +37,13 @@ export const attachmentRefSchema = z.object({
   filename: z.string().min(1),
   size: z.number().int().nonnegative(),
   sha256: z.string().length(64).optional(),
+  // SECURITY: `source.path` (and `sourcePath`) is UNTRUSTED, DISPLAY-ONLY
+  // metadata. A ref's bytes are self-supplied by the sender and downloads are
+  // capability-based (valid session + unguessable attachmentId), so a malicious
+  // runtime can fabricate bytes and pair them with an arbitrary `source.path`.
+  // The server cannot meaningfully validate a free-form display string, so it
+  // does not — this is display-spoofing only, NOT access escalation. NEVER use
+  // `source.path` for authorization, routing, or filesystem access.
   source: z
     .object({
       path: z.string(),
@@ -57,6 +64,13 @@ export const MAX_MESSAGE_ATTACHMENT_REFS = 10;
 const ATTACHMENT_KINDS_SET = new Set<string>(ATTACHMENT_KINDS);
 
 /**
+ * UUID shape check matching `z.string().uuid()` — kept in the hand-rolled guard
+ * so a non-uuid `attachmentId` cannot slip past `isAttachmentRef` (and thus the
+ * count-matched server reader) when the schema requires a uuid.
+ */
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
  * Hand-rolled guard for {@link AttachmentRef} — kept cheap (instead of
  * `schema.safeParse`) because every inbound message in chat-view / runtime
  * passes through it on render. Mirrors the contract of `attachmentRefSchema`;
@@ -66,7 +80,7 @@ const ATTACHMENT_KINDS_SET = new Set<string>(ATTACHMENT_KINDS);
 export function isAttachmentRef(value: unknown): value is AttachmentRef {
   if (!value || typeof value !== "object") return false;
   const v = value as Record<string, unknown>;
-  if (typeof v.attachmentId !== "string") return false;
+  if (typeof v.attachmentId !== "string" || !UUID_RE.test(v.attachmentId)) return false;
   if (typeof v.kind !== "string" || !ATTACHMENT_KINDS_SET.has(v.kind)) return false;
   if (typeof v.mimeType !== "string" || v.mimeType.length === 0) return false;
   if (typeof v.filename !== "string" || v.filename.length === 0) return false;

--- a/packages/shared/src/schemas/attachment-ref.ts
+++ b/packages/shared/src/schemas/attachment-ref.ts
@@ -1,0 +1,98 @@
+import { z } from "zod";
+
+/**
+ * Attachment kinds carried by an {@link AttachmentRef}. `kind` is derived from
+ * the mime type at capture time and stored explicitly so render/delivery code
+ * can branch without re-sniffing the mime on every read:
+ *  - `image`    — a picture (rendered inline / lightbox). NOTE: images today
+ *                 still travel as `imageRefContent` in `messages.content`; this
+ *                 kind exists for the future convergence onto the generic ref.
+ *  - `document` — a text document previewed in the doc drawer (markdown today).
+ *  - `file`     — any other blob; rendered as a download card.
+ */
+export const ATTACHMENT_KINDS = ["image", "document", "file"] as const;
+export const attachmentKindSchema = z.enum(ATTACHMENT_KINDS);
+export type AttachmentKind = z.infer<typeof attachmentKindSchema>;
+
+/**
+ * Generic "this message references a stored blob" model — the single shape
+ * every consumer (image / document / arbitrary file) hangs off, mounted at
+ * `messages.metadata.attachments[]`. Mirrors the live image-ref convergence
+ * onto the `attachments` blob substrate: the sender uploads bytes to
+ * `POST /orgs/:orgId/attachments`, then sends a message carrying only this
+ * reference. Every reader fetches the bytes on demand from
+ * `GET /attachments/:attachmentId` — bytes never travel inside the message.
+ *
+ * `sha256` is computed client-side at capture and verified by the renderer for
+ * end-to-end integrity (and is the hook a future "show latest" comparison
+ * would use). `source` is present only for refs captured from an agent's
+ * workspace filesystem; `path` is the workspace-relative path (display / in-doc
+ * cross-navigation) and `sourcePath` is a forward hook for "show latest" that
+ * is written but not consumed this phase.
+ */
+export const attachmentRefSchema = z.object({
+  attachmentId: z.string().uuid(),
+  kind: attachmentKindSchema,
+  mimeType: z.string().min(1),
+  filename: z.string().min(1),
+  size: z.number().int().nonnegative(),
+  sha256: z.string().length(64).optional(),
+  source: z
+    .object({
+      path: z.string(),
+      sourcePath: z.string().optional(),
+    })
+    .optional(),
+});
+export type AttachmentRef = z.infer<typeof attachmentRefSchema>;
+
+/**
+ * Hard cap on attachment refs a single message may carry. Bounds the
+ * per-render fetch fan-out and the size of the metadata blob; doc-preview's
+ * original "snapshot N docs" UX needed ~5, so this stays generous-but-finite.
+ * Bump only with product sign-off.
+ */
+export const MAX_MESSAGE_ATTACHMENT_REFS = 10;
+
+const ATTACHMENT_KINDS_SET = new Set<string>(ATTACHMENT_KINDS);
+
+/**
+ * Hand-rolled guard for {@link AttachmentRef} — kept cheap (instead of
+ * `schema.safeParse`) because every inbound message in chat-view / runtime
+ * passes through it on render. Mirrors the contract of `attachmentRefSchema`;
+ * if the schema gains a required field this guard must match. Style follows
+ * `isImageRefContent` in `image-payload.ts` so the family stays consistent.
+ */
+export function isAttachmentRef(value: unknown): value is AttachmentRef {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  if (typeof v.attachmentId !== "string") return false;
+  if (typeof v.kind !== "string" || !ATTACHMENT_KINDS_SET.has(v.kind)) return false;
+  if (typeof v.mimeType !== "string" || v.mimeType.length === 0) return false;
+  if (typeof v.filename !== "string" || v.filename.length === 0) return false;
+  if (typeof v.size !== "number" || !Number.isInteger(v.size) || v.size < 0) return false;
+  if (v.sha256 !== undefined && (typeof v.sha256 !== "string" || v.sha256.length !== 64)) return false;
+  if (v.source !== undefined) {
+    if (!v.source || typeof v.source !== "object") return false;
+    const s = v.source as Record<string, unknown>;
+    if (typeof s.path !== "string") return false;
+    if (s.sourcePath !== undefined && typeof s.sourcePath !== "string") return false;
+  }
+  return true;
+}
+
+/**
+ * Read the validated `AttachmentRef[]` from a message's free-form metadata.
+ * Returns an empty array when the field is absent or malformed — readers must
+ * degrade gracefully (old messages have no `attachments` key), never throw.
+ */
+export function attachmentRefsFromMetadata(metadata: Record<string, unknown> | undefined): AttachmentRef[] {
+  if (!metadata) return [];
+  const raw = metadata.attachments;
+  if (!Array.isArray(raw)) return [];
+  const out: AttachmentRef[] = [];
+  for (const entry of raw) {
+    if (isAttachmentRef(entry)) out.push(entry);
+  }
+  return out;
+}

--- a/packages/shared/src/schemas/attachment-ref.ts
+++ b/packages/shared/src/schemas/attachment-ref.ts
@@ -36,7 +36,10 @@ export const attachmentRefSchema = z.object({
   mimeType: z.string().min(1),
   filename: z.string().min(1),
   size: z.number().int().nonnegative(),
-  sha256: z.string().length(64).optional(),
+  sha256: z
+    .string()
+    .regex(/^[0-9a-f]{64}$/, "sha256 must be 64 lowercase hex chars")
+    .optional(),
   // SECURITY: `source.path` (and `sourcePath`) is UNTRUSTED, DISPLAY-ONLY
   // metadata. A ref's bytes are self-supplied by the sender and downloads are
   // capability-based (valid session + unguessable attachmentId), so a malicious
@@ -70,6 +73,9 @@ const ATTACHMENT_KINDS_SET = new Set<string>(ATTACHMENT_KINDS);
  */
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
+/** Lowercase-hex sha256 shape, mirroring `attachmentRefSchema.sha256`. */
+const SHA256_RE = /^[0-9a-f]{64}$/;
+
 /**
  * Hand-rolled guard for {@link AttachmentRef} — kept cheap (instead of
  * `schema.safeParse`) because every inbound message in chat-view / runtime
@@ -85,7 +91,7 @@ export function isAttachmentRef(value: unknown): value is AttachmentRef {
   if (typeof v.mimeType !== "string" || v.mimeType.length === 0) return false;
   if (typeof v.filename !== "string" || v.filename.length === 0) return false;
   if (typeof v.size !== "number" || !Number.isInteger(v.size) || v.size < 0) return false;
-  if (v.sha256 !== undefined && (typeof v.sha256 !== "string" || v.sha256.length !== 64)) return false;
+  if (v.sha256 !== undefined && (typeof v.sha256 !== "string" || !SHA256_RE.test(v.sha256))) return false;
   if (v.source !== undefined) {
     if (!v.source || typeof v.source !== "object") return false;
     const s = v.source as Record<string, unknown>;

--- a/packages/shared/src/schemas/me-doc.ts
+++ b/packages/shared/src/schemas/me-doc.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import { isCanonicalDocLinkPath } from "../lib/doc-path.js";
 
 export const workspaceDocRefSchema = z.object({
   type: z.literal("workspace"),
@@ -10,54 +9,19 @@ export const workspaceDocRefSchema = z.object({
 });
 export type WorkspaceDocRef = z.infer<typeof workspaceDocRefSchema>;
 
-/** Per-message snapshot caps. Server-side byte counting + sha256 calibration
- *  happen in `services/message.ts sendMessage` (these schemas only enforce
- *  shape and `string.length`-based ceilings; cf. proposal §安全与限制). */
-export const MAX_DOC_SNAPSHOT_BYTES = 256 * 1024;
-export const MAX_DOC_SNAPSHOTS_PER_MESSAGE = 5;
-export const MAX_TOTAL_DOC_SNAPSHOT_BYTES = 512 * 1024;
-
-/** Cap on the inert-chip failedMentions list. Existing scanner already caps
- *  per-message mention count via the BARE_PATH regex on a single text body;
- *  this is a hard ceiling against pathological inputs. */
+/**
+ * Cap on the inert-chip failedMentions list. The runtime scanner already caps
+ * per-message mention count via the BARE_PATH regex on a single text body;
+ * this is a hard ceiling against pathological inputs.
+ */
 export const MAX_FAILED_DOC_MENTIONS_PER_MESSAGE = 16;
 /** Schema-side raw-token length cap. Generous because absolute paths can be
  *  long, but bounded so a misbehaving runtime cannot lodge giant strings. */
 export const MAX_FAILED_DOC_MENTION_RAW_LEN = 512;
 
-export const snapshotDocSchema = z.object({
-  /**
-   * Canonical workspace-relative path — must already be in the form produced
-   * by `normalizeDocLinkPath` (POSIX "/" separators, no leading slash, no
-   * "./" / ".." segments, no hidden segments). Web link click handlers
-   * normalise hrefs through the same helper before cache lookup, so the
-   * canonical form is the only one that produces deterministic snapshot
-   * hits and a non-canonical value would silently miss.
-   *
-   * The schema is the trust boundary: even though runtime + web reject
-   * non-`.md` paths upstream, server enforces the `.md` suffix here too so
-   * a misbehaving (or compromised) runtime cannot lodge arbitrary file
-   * paths in immutable message history.
-   */
-  path: z
-    .string()
-    .trim()
-    .min(1)
-    .refine(isCanonicalDocLinkPath, {
-      message: "path must be a canonical workspace-relative doc path (no leading /, no ./, no ..)",
-    })
-    .refine((p) => p.toLowerCase().endsWith(".md"), {
-      message: "path must have a .md extension",
-    }),
-  sha256: z.string().regex(/^[0-9a-f]{64}$/, "sha256 must be 64 lowercase hex chars"),
-  size: z.number().int().nonnegative(),
-  content: z.string(),
-});
-export type SnapshotDoc = z.infer<typeof snapshotDocSchema>;
-
 /**
  * Why a `.md` mention that LOOKED like a workspace path didn't end up as an
- * inline snapshot. The web renders a disabled "doc chip" in place of the raw
+ * attachment ref. The web renders a disabled "doc chip" in place of the raw
  * token + a reason-mapped tooltip so the failure is visible instead of
  * silently degrading to plain text (and the agent — re-reading its own
  * message — can see WHY the preview didn't materialise).
@@ -65,7 +29,8 @@ export type SnapshotDoc = z.infer<typeof snapshotDocSchema>;
  * Scanner-static rejections (domain-shaped, fenced code blocks, HTML tag
  * bodies, reference link definitions) do NOT produce failedMentions — those
  * tokens are by design not workspace paths. Only mentions that made it to the
- * runtime resolver AND failed to snapshot are reported.
+ * runtime resolver AND failed to capture (resolve / read / upload) are
+ * reported.
  */
 export const docSnapshotFailReasonSchema = z.enum([
   "missing",
@@ -86,19 +51,14 @@ export const failedDocMentionSchema = z.object({
 });
 export type FailedDocMention = z.infer<typeof failedDocMentionSchema>;
 
-const snapshotDocumentContextSchema = z
-  .object({
-    kind: z.literal("snapshot"),
-    /** Successful snapshots embedded inline. May be empty when ALL mentions
-     *  failed — see the refinement below. */
-    docs: z.array(snapshotDocSchema).max(MAX_DOC_SNAPSHOTS_PER_MESSAGE).default([]),
-    /** Failure roster for inert chip rendering. Optional for backward
-     *  compatibility with the pre-Phase-2 schema where only `docs` existed. */
-    failedMentions: z.array(failedDocMentionSchema).max(MAX_FAILED_DOC_MENTIONS_PER_MESSAGE).optional(),
-  })
-  .refine((d) => d.docs.length > 0 || (d.failedMentions?.length ?? 0) > 0, {
-    message: "snapshot documentContext must include at least one snapshot or one failedMention",
-  });
+const snapshotDocumentContextSchema = z.object({
+  kind: z.literal("snapshot"),
+  /** Failure roster for inert chip rendering. The successful captures now live
+   *  in `metadata.attachments[]` as generic `AttachmentRef`s; this context only
+   *  carries the failures so the chat-view can render disabled chips + reason
+   *  tooltips at the original token positions. */
+  failedMentions: z.array(failedDocMentionSchema).max(MAX_FAILED_DOC_MENTIONS_PER_MESSAGE).min(1),
+});
 
 const pathDocumentContextSchema = z.object({
   kind: z.literal("path"),
@@ -108,17 +68,18 @@ const pathDocumentContextSchema = z.object({
 /**
  * `messages.metadata.documentContext` discriminated union.
  *
- * - `kind: "snapshot"` — inline preview content. Each snapshot carries the
- *   markdown body verbatim at the moment the message was sent. Used by
- *   First Tree Cloud server + local agent runtime topology where the server
- *   cannot read the runtime's workspace filesystem.
- * - `kind: "path"` — PR #356 path-based fallback, only meaningful when
- *   server and runtime share a filesystem (local dev / single-host).
+ * - `kind: "snapshot"` — failure roster ONLY (inert chips). Successful doc
+ *   captures are stored as generic `AttachmentRef`s in `metadata.attachments[]`
+ *   (kind: "document"), fetched on demand from the attachments blob store.
+ * - `kind: "path"` — PR #356 path-based fallback, only meaningful when server
+ *   and runtime share a filesystem (local dev / single-host).
  *
- * Legacy compat: messages written before this schema landed have a bare
- * `{ basePath: string }` (no `kind` field). The preprocessor below
- * normalises that to `{ kind: "path", basePath }` so legacy messages stay
- * parseable without a DB backfill.
+ * Legacy compat: messages written before the `kind` field had a bare
+ * `{ basePath: string }`. The preprocessor normalises that to
+ * `{ kind: "path", basePath }`. Pre-cutover messages that carried the inline
+ * `kind: "snapshot"` shape with `docs[].content` no longer match this schema
+ * (the `docs` field is gone); `safeParse` fails and readers fall back to
+ * no-preview / plain text — the intended graceful degradation for old rows.
  */
 export const documentContextSchema = z.preprocess(
   (val) => {

--- a/packages/web/src/api/attachments.ts
+++ b/packages/web/src/api/attachments.ts
@@ -74,6 +74,31 @@ export async function fetchAttachmentText(id: string): Promise<{ text: string; m
 }
 
 /**
+ * Download attachment bytes through the authed api helper and trigger a browser
+ * save dialog. The `<a href="/api/v1/attachments/:id">` shortcut cannot be used
+ * for a real download: that navigation carries no `Authorization` header (the
+ * token lives in localStorage, only `apiFetchRaw` injects it) → 401, and a
+ * page-relative `/api/v1/...` points at the wrong origin when web and API are
+ * deployed separately → 404. Fetch the blob authenticated, hand it to the
+ * browser via an object URL, then revoke the URL once the click is dispatched.
+ */
+export async function downloadAttachment(id: string, filename: string): Promise<void> {
+  const res = await apiFetchRaw(`/attachments/${encodeURIComponent(id)}`);
+  const blob = await res.blob();
+  const objectUrl = URL.createObjectURL(blob);
+  try {
+    const anchor = document.createElement("a");
+    anchor.href = objectUrl;
+    anchor.download = filename;
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+  } finally {
+    URL.revokeObjectURL(objectUrl);
+  }
+}
+
+/**
  * Compute the lowercase hex SHA-256 of a UTF-8 string via the Web Crypto API —
  * used by the doc-preview drawer to verify fetched bytes against the captured
  * `ref.sha256`. Throws when `crypto.subtle` is unavailable (insecure context);

--- a/packages/web/src/api/attachments.ts
+++ b/packages/web/src/api/attachments.ts
@@ -59,3 +59,32 @@ export async function fetchAttachmentBase64(id: string): Promise<{ base64: strin
   const mimeType = res.headers.get("content-type") ?? blob.type ?? "application/octet-stream";
   return { base64: await blobToBase64(blob), mimeType };
 }
+
+/**
+ * Download attachment bytes as decoded text — the doc-preview drawer's data
+ * source. Returns the UTF-8 text, the served MIME, and the raw byte length so
+ * callers can verify integrity (sha256) and enforce a render size cap.
+ */
+export async function fetchAttachmentText(id: string): Promise<{ text: string; mimeType: string; sizeBytes: number }> {
+  const res = await apiFetchRaw(`/attachments/${encodeURIComponent(id)}`);
+  const buffer = await res.arrayBuffer();
+  const mimeType = res.headers.get("content-type") ?? "application/octet-stream";
+  const text = new TextDecoder("utf-8").decode(buffer);
+  return { text, mimeType, sizeBytes: buffer.byteLength };
+}
+
+/**
+ * Compute the lowercase hex SHA-256 of a UTF-8 string via the Web Crypto API —
+ * used by the doc-preview drawer to verify fetched bytes against the captured
+ * `ref.sha256`. Throws when `crypto.subtle` is unavailable (insecure context);
+ * callers treat that as "skip verification".
+ */
+export async function sha256Hex(text: string): Promise<string> {
+  const subtle = globalThis.crypto?.subtle;
+  if (!subtle) throw new Error("Web Crypto subtle digest is unavailable");
+  const bytes = new TextEncoder().encode(text);
+  const digest = await subtle.digest("SHA-256", bytes);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}

--- a/packages/web/src/components/__tests__/doc-preview-drawer.test.tsx
+++ b/packages/web/src/components/__tests__/doc-preview-drawer.test.tsx
@@ -5,7 +5,7 @@ import { act, type ReactElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { MemoryRouter, Route, Routes, useLocation } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { docAttachmentRefQueryKey } from "../../pages/workspace/center/chat-view.js";
+import { docAttachmentRefQueryKey, docMessageAttachmentRefsQueryKey } from "../../pages/workspace/center/chat-view.js";
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -133,6 +133,19 @@ const docRef = {
   source: { path: "docs/plan.md" },
 };
 
+const SIBLING_ID = "00000000-0000-4000-8000-000000000002";
+// `details.md` relative to the current doc's `docs/plan.md` resolves to
+// `docs/details.md` — the sibling's source.path.
+const siblingRef = {
+  attachmentId: SIBLING_ID,
+  kind: "document" as const,
+  mimeType: "text/markdown",
+  filename: "details.md",
+  size: 10,
+  sha256: "c".repeat(64),
+  source: { path: "docs/details.md" },
+};
+
 beforeEach(() => {
   vi.resetModules();
   setupDom();
@@ -236,6 +249,56 @@ describe("DocPreviewDrawer", () => {
     });
     await flush();
     expect(dom.textContent).toContain("Unable to load");
+  });
+
+  // R1: a relative in-doc link to a sibling doc in the SAME message resolves on
+  // the seeded (normal click) path — the click handler seeds the full per-message
+  // ref list, so the drawer maps `details.md` → the sibling attachment without
+  // fetching the messages window. Would no-op before the fix (recovery is
+  // disabled when a seeded ref exists, so the sibling map was empty).
+  it("resolves a same-message sibling link on the seeded path (no recovery fetch)", async () => {
+    const { DocPreviewDrawer } = await import("../doc-preview-drawer.js");
+    const route = `/?docChat=chat-1&docMsg=msg-1&docAttachment=${ATT_ID}`;
+    const dom = await renderAt(route, <DocPreviewDrawer />, (client) => {
+      client.setQueryData(docAttachmentRefQueryKey(ATT_ID), docRef);
+      client.setQueryData(docAttachmentRefQueryKey(SIBLING_ID), siblingRef);
+      // Seed the FULL per-message ref list — the seeded enumeration path.
+      client.setQueryData(docMessageAttachmentRefsQueryKey("msg-1"), [docRef, siblingRef]);
+    });
+    await flush();
+
+    // Recovery is disabled on the seeded path — the messages window is never read.
+    expect(chatsMocks.listChatMessages).not.toHaveBeenCalled();
+
+    const siblingLink = [...dom.querySelectorAll("a")].find((a) => a.textContent === "details");
+    expect(siblingLink).toBeTruthy();
+    await click(siblingLink ?? null);
+    expect(latestSearch).toContain(`docAttachment=${SIBLING_ID}`);
+  });
+
+  // R2: on a cold deep-link (no seeded ref) the fetch must WAIT for the ref to
+  // be recovered, then verify the bytes against the recovered ref's sha256.
+  // Here the recovered ref's sha256 mismatches the fetched bytes, so the
+  // integrity warning can only appear if verification ran against the recovered
+  // ref — proving the fetch did not race ahead of recovery. Would not warn
+  // before the fix (fetch ran with an undefined ref → verification skipped, and
+  // the attachmentId-only key never recomputed when the ref later resolved).
+  it("verifies bytes against the recovered ref on a cold deep-link", async () => {
+    chatsMocks.listChatMessages.mockResolvedValue({
+      items: [{ id: "msg-1", metadata: { attachments: [docRef] } }],
+      nextCursor: null,
+    });
+    // Fetched bytes hash to something other than docRef.sha256 ("aaaa...").
+    attachmentsMocks.sha256Hex.mockResolvedValue("d".repeat(64));
+    const { DocPreviewDrawer } = await import("../doc-preview-drawer.js");
+    const route = `/?docChat=chat-1&docMsg=msg-1&docAttachment=${ATT_ID}`;
+    const dom = await renderAt(route, <DocPreviewDrawer />);
+    await flush();
+
+    expect(chatsMocks.listChatMessages).toHaveBeenCalledWith("chat-1", { limit: 50 });
+    // Verification ran against the recovered ref (the fetch waited for it).
+    expect(attachmentsMocks.sha256Hex).toHaveBeenCalled();
+    expect(dom.textContent).toContain("Integrity check failed");
   });
 
   it("uses mobile focus handling and escape close", async () => {

--- a/packages/web/src/components/__tests__/doc-preview-drawer.test.tsx
+++ b/packages/web/src/components/__tests__/doc-preview-drawer.test.tsx
@@ -254,8 +254,9 @@ describe("DocPreviewDrawer", () => {
 
     expect(chatsMocks.listChatMessages).toHaveBeenCalledWith("chat-1", { limit: 50 });
     expect(attachmentsMocks.fetchAttachmentText).toHaveBeenCalledWith(ATT_ID);
+    expect(attachmentsMocks.sha256Hex).not.toHaveBeenCalled();
     expect(dom.textContent).toContain("Plan");
-    expect(dom.textContent).toContain("Couldn't verify integrity");
+    expect(dom.textContent).toContain("This preview was not checksum verified");
   });
 
   it("renders a fetch error inline rather than throwing", async () => {

--- a/packages/web/src/components/__tests__/doc-preview-drawer.test.tsx
+++ b/packages/web/src/components/__tests__/doc-preview-drawer.test.tsx
@@ -14,6 +14,7 @@ const ATT_ID = "00000000-0000-4000-8000-000000000001";
 const attachmentsMocks = vi.hoisted(() => ({
   fetchAttachmentText: vi.fn(),
   sha256Hex: vi.fn(),
+  downloadAttachment: vi.fn(),
 }));
 const chatsMocks = vi.hoisted(() => ({
   listChatMessages: vi.fn(),
@@ -202,7 +203,13 @@ describe("DocPreviewDrawer", () => {
     });
     await flush();
     expect(dom.textContent).toContain("too large to preview");
-    expect(dom.querySelector(`a[href*="${ATT_ID}"]`)).toBeTruthy();
+    // The over-cap fallback is an authenticated download button (not a dead
+    // page-relative `/api/v1/...` anchor that would 401/404). Clicking it routes
+    // through the authed `downloadAttachment` helper.
+    const downloadButton = [...dom.querySelectorAll("button")].find((b) => b.textContent === "Download to view");
+    expect(downloadButton).toBeTruthy();
+    await click(downloadButton ?? null);
+    expect(attachmentsMocks.downloadAttachment).toHaveBeenCalledWith(ATT_ID, docRef.filename);
   });
 
   it("recovers the ref from the messages window after a cold reload", async () => {

--- a/packages/web/src/components/__tests__/doc-preview-drawer.test.tsx
+++ b/packages/web/src/components/__tests__/doc-preview-drawer.test.tsx
@@ -240,6 +240,24 @@ describe("DocPreviewDrawer", () => {
     expect(dom.textContent).toContain("Plan");
   });
 
+  // R4 follow-up (codex-assistant #2): a cold deep-link whose `docMsg` is OLDER
+  // than the recovery window (message not returned by listChatMessages) misses
+  // recovery. It must still fetch (capability-authed by attachmentId) and render,
+  // flagged "unverified" — NOT sit at a silent blank drawer. Would render blank
+  // before the fix (enabled gate stayed false forever on a recovery miss).
+  it("fetches unverified instead of going blank when the ref can't be recovered", async () => {
+    chatsMocks.listChatMessages.mockResolvedValue({ items: [], nextCursor: null });
+    const { DocPreviewDrawer } = await import("../doc-preview-drawer.js");
+    const route = `/?docChat=chat-1&docMsg=msg-out-of-window&docAttachment=${ATT_ID}`;
+    const dom = await renderAt(route, <DocPreviewDrawer />);
+    await flush();
+
+    expect(chatsMocks.listChatMessages).toHaveBeenCalledWith("chat-1", { limit: 50 });
+    expect(attachmentsMocks.fetchAttachmentText).toHaveBeenCalledWith(ATT_ID);
+    expect(dom.textContent).toContain("Plan");
+    expect(dom.textContent).toContain("Couldn't verify integrity");
+  });
+
   it("renders a fetch error inline rather than throwing", async () => {
     attachmentsMocks.fetchAttachmentText.mockRejectedValueOnce(new Error("Unable to load"));
     const { DocPreviewDrawer } = await import("../doc-preview-drawer.js");

--- a/packages/web/src/components/__tests__/doc-preview-drawer.test.tsx
+++ b/packages/web/src/components/__tests__/doc-preview-drawer.test.tsx
@@ -5,22 +5,22 @@ import { act, type ReactElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { MemoryRouter, Route, Routes, useLocation } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { docSnapshotQueryKey } from "../../pages/workspace/center/chat-view.js";
+import { docAttachmentRefQueryKey } from "../../pages/workspace/center/chat-view.js";
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
-const meDocsMocks = vi.hoisted(() => ({
-  getMeDoc: vi.fn(),
+const ATT_ID = "00000000-0000-4000-8000-000000000001";
+
+const attachmentsMocks = vi.hoisted(() => ({
+  fetchAttachmentText: vi.fn(),
+  sha256Hex: vi.fn(),
 }));
 const chatsMocks = vi.hoisted(() => ({
   listChatMessages: vi.fn(),
 }));
 
-vi.mock("../../api/me-docs.js", () => meDocsMocks);
+vi.mock("../../api/attachments.js", () => attachmentsMocks);
 vi.mock("../../api/chats.js", () => chatsMocks);
-vi.mock("../../lib/use-agent-name-map.js", () => ({
-  useAgentSlugToIdMap: () => (slug: string | null | undefined) => (slug === "nova" ? "agent-owner" : null),
-}));
 
 let root: Root | null = null;
 let container: HTMLElement | null = null;
@@ -122,6 +122,16 @@ async function click(el: Element | null): Promise<void> {
   await flush();
 }
 
+const docRef = {
+  attachmentId: ATT_ID,
+  kind: "document" as const,
+  mimeType: "text/markdown",
+  filename: "plan.md",
+  size: 28,
+  sha256: "a".repeat(64),
+  source: { path: "docs/plan.md" },
+};
+
 beforeEach(() => {
   vi.resetModules();
   setupDom();
@@ -129,28 +139,17 @@ beforeEach(() => {
   latestSearch = "";
   root = null;
   container = null;
-  meDocsMocks.getMeDoc.mockReset();
-  meDocsMocks.getMeDoc.mockResolvedValue({
-    path: "docs/guide.md",
-    content: "# Guide\nSee [next](next.md).",
-    ref: { path: "docs/guide.md" },
+  attachmentsMocks.fetchAttachmentText.mockReset();
+  attachmentsMocks.fetchAttachmentText.mockResolvedValue({
+    text: "# Plan\nSee [details](details.md).",
+    mimeType: "text/markdown",
+    sizeBytes: 30,
   });
+  attachmentsMocks.sha256Hex.mockReset();
+  attachmentsMocks.sha256Hex.mockResolvedValue("a".repeat(64));
   chatsMocks.listChatMessages.mockReset();
   chatsMocks.listChatMessages.mockResolvedValue({ items: [], nextCursor: null });
 });
-
-// A snapshot-variant message whose metadata still carries the doc bytes —
-// the immutable source recovery re-derives from. sha256 must be 64 hex chars
-// because the recovery path schema-validates metadata.
-const recoveryMessage = {
-  id: "msg-1",
-  metadata: {
-    documentContext: {
-      kind: "snapshot",
-      docs: [{ path: "docs/plan.md", content: "# Recovered Plan", sha256: "a".repeat(64), size: 16 }],
-    },
-  },
-};
 
 afterEach(async () => {
   if (root) await act(async () => root?.unmount());
@@ -158,20 +157,15 @@ afterEach(async () => {
 });
 
 describe("DocPreviewDrawer", () => {
-  it("renders inline snapshots, follows markdown links, closes, and resizes", async () => {
+  it("fetches + renders the attachment from a seeded ref, closes, and resizes", async () => {
     const { DocPreviewDrawer } = await import("../doc-preview-drawer.js");
-    const route = "/?docChat=chat-1&docAgent=agent-1&docPath=docs%2Fplan.md&docMsg=msg-1";
+    const route = `/?docChat=chat-1&docMsg=msg-1&docAttachment=${ATT_ID}`;
     const dom = await renderAt(route, <DocPreviewDrawer />, (client) => {
-      client.setQueryData(docSnapshotQueryKey("chat-1", "msg-1", "docs/plan.md"), {
-        path: "docs/plan.md",
-        content: "# Plan\nSee [details](details.md).",
-        sha256: "sha",
-        size: 28,
-      });
+      client.setQueryData(docAttachmentRefQueryKey(ATT_ID), docRef);
     });
 
+    expect(attachmentsMocks.fetchAttachmentText).toHaveBeenCalledWith(ATT_ID);
     expect(dom.textContent).toContain("Plan");
-    expect(meDocsMocks.getMeDoc).not.toHaveBeenCalled();
 
     const resize = dom.querySelector<HTMLButtonElement>('button[aria-label="Resize document preview"]');
     await act(async () => {
@@ -180,93 +174,61 @@ describe("DocPreviewDrawer", () => {
     });
     expect(localStorage.getItem("first-tree:doc-preview-drawer:width:v1")).toBeTruthy();
 
-    await click(dom.querySelector<HTMLAnchorElement>('a[href="details.md"]'));
-    expect(latestSearch).toContain("docPath=docs%2Fdetails.md");
-
     await click(dom.querySelector('button[aria-label="Close document preview"]'));
-    expect(latestSearch).not.toContain("docPath=");
+    expect(latestSearch).not.toContain("docAttachment=");
   });
 
-  it("recovers from the warm messages cache when the seeded entry was GC'd (chat open)", async () => {
-    // Reproduces the GC bug: the URL still carries docMsg, but the seeded
-    // `docSnapshotQueryKey` entry was garbage-collected (no observer). While
-    // the chat is open, ChatView keeps `chat-messages` warm — model that with
-    // a pre-seeded cache entry. The drawer must re-derive the snapshot from
-    // the message's `metadata.documentContext` instead of falling through to
-    // the path endpoint (which 404s on the cloud topology).
-    chatsMocks.listChatMessages.mockResolvedValue({ items: [recoveryMessage], nextCursor: null });
+  it("shows an integrity warning when the fetched bytes do not match ref.sha256", async () => {
+    attachmentsMocks.sha256Hex.mockResolvedValue("b".repeat(64));
     const { DocPreviewDrawer } = await import("../doc-preview-drawer.js");
-    const route = "/?docChat=chat-1&docAgent=agent-1&docPath=docs%2Fplan.md&docMsg=msg-1";
+    const route = `/?docChat=chat-1&docMsg=msg-1&docAttachment=${ATT_ID}`;
     const dom = await renderAt(route, <DocPreviewDrawer />, (client) => {
-      // No docSnapshotQueryKey seed — simulate the post-GC state.
-      client.setQueryData(["chat-messages", "chat-1"], { items: [recoveryMessage], nextCursor: null });
+      client.setQueryData(docAttachmentRefQueryKey(ATT_ID), docRef);
     });
     await flush();
-
-    expect(dom.textContent).toContain("Recovered Plan");
-    expect(meDocsMocks.getMeDoc).not.toHaveBeenCalled();
+    expect(dom.textContent).toContain("Integrity check failed");
   });
 
-  it("recovers by fetching the messages window after a cold reload", async () => {
-    // Reproduces the reload P2 codex flagged: no seeded snapshot AND no warm
-    // messages cache on first render. A non-reactive cache peek would memoise
-    // `undefined` and never recompute. The drawer must observe the messages
-    // query, fetch the window, and recover — never hitting the path endpoint.
-    chatsMocks.listChatMessages.mockResolvedValue({ items: [recoveryMessage], nextCursor: null });
+  it("shows a download fallback when the doc exceeds the preview render cap", async () => {
+    attachmentsMocks.fetchAttachmentText.mockResolvedValue({
+      text: "x",
+      mimeType: "text/markdown",
+      sizeBytes: 2 * 1024 * 1024,
+    });
     const { DocPreviewDrawer } = await import("../doc-preview-drawer.js");
-    const route = "/?docChat=chat-1&docAgent=agent-1&docPath=docs%2Fplan.md&docMsg=msg-1";
+    const route = `/?docChat=chat-1&docMsg=msg-1&docAttachment=${ATT_ID}`;
+    const dom = await renderAt(route, <DocPreviewDrawer />, (client) => {
+      client.setQueryData(docAttachmentRefQueryKey(ATT_ID), docRef);
+    });
+    await flush();
+    expect(dom.textContent).toContain("too large to preview");
+    expect(dom.querySelector(`a[href*="${ATT_ID}"]`)).toBeTruthy();
+  });
+
+  it("recovers the ref from the messages window after a cold reload", async () => {
+    chatsMocks.listChatMessages.mockResolvedValue({
+      items: [{ id: "msg-1", metadata: { attachments: [docRef] } }],
+      nextCursor: null,
+    });
+    const { DocPreviewDrawer } = await import("../doc-preview-drawer.js");
+    const route = `/?docChat=chat-1&docMsg=msg-1&docAttachment=${ATT_ID}`;
     const dom = await renderAt(route, <DocPreviewDrawer />);
     await flush();
 
     expect(chatsMocks.listChatMessages).toHaveBeenCalledWith("chat-1", { limit: 50 });
-    expect(dom.textContent).toContain("Recovered Plan");
-    expect(meDocsMocks.getMeDoc).not.toHaveBeenCalled();
+    expect(attachmentsMocks.fetchAttachmentText).toHaveBeenCalledWith(ATT_ID);
+    expect(dom.textContent).toContain("Plan");
   });
 
-  it("still uses the path endpoint for an in-preview link to a non-snapshotted doc", async () => {
-    // Guards the second regression: a snapshot-origin preview keeps `docMsg` in
-    // the URL when navigating to an in-doc link. If that target was never one
-    // of the message's snapshots, recovery comes up empty and the drawer must
-    // still fall through to the legacy path endpoint (single-host) rather than
-    // being gated out wholesale by `docMsg`.
-    chatsMocks.listChatMessages.mockResolvedValue({ items: [recoveryMessage], nextCursor: null });
+  it("renders a fetch error inline rather than throwing", async () => {
+    attachmentsMocks.fetchAttachmentText.mockRejectedValueOnce(new Error("Unable to load"));
     const { DocPreviewDrawer } = await import("../doc-preview-drawer.js");
-    // docPath is docs/design.md — present in neither the seed nor the message's
-    // docs[] (which only has docs/plan.md), but docMsg is still msg-1.
-    const route = "/?docChat=chat-1&docAgent=agent-1&docPath=docs%2Fdesign.md&docMsg=msg-1";
+    const route = `/?docChat=chat-1&docMsg=msg-1&docAttachment=${ATT_ID}`;
     const dom = await renderAt(route, <DocPreviewDrawer />, (client) => {
-      client.setQueryData(["chat-messages", "chat-1"], { items: [recoveryMessage], nextCursor: null });
+      client.setQueryData(docAttachmentRefQueryKey(ATT_ID), docRef);
     });
     await flush();
-
-    expect(meDocsMocks.getMeDoc).toHaveBeenCalledWith("chat-1", {
-      agentId: "agent-1",
-      basePath: undefined,
-      path: "docs/design.md",
-    });
-    expect(dom.textContent).toContain("Guide");
-  });
-
-  it("loads fallback previews for cross-agent paths and renders API errors", async () => {
-    const { DocPreviewDrawer } = await import("../doc-preview-drawer.js");
-    const dom = await renderAt(
-      "/?docChat=chat-1&docAgent=sender&docPath=nova%2Fchat-1%2Fdocs%2Fguide.md",
-      <DocPreviewDrawer />,
-    );
-
-    await flush();
-    expect(meDocsMocks.getMeDoc).toHaveBeenCalledWith("chat-1", {
-      agentId: "agent-owner",
-      basePath: undefined,
-      path: "docs/guide.md",
-    });
-    expect(dom.textContent).toContain("Guide");
-
-    await act(async () => root?.unmount());
-    meDocsMocks.getMeDoc.mockRejectedValueOnce(new Error("Unable to load"));
-    const errored = await renderAt("/?docChat=chat-1&docAgent=sender&docPath=docs%2Fmissing.md", <DocPreviewDrawer />);
-    await flush();
-    expect(errored.textContent).toContain("Unable to load");
+    expect(dom.textContent).toContain("Unable to load");
   });
 
   it("uses mobile focus handling and escape close", async () => {
@@ -276,7 +238,13 @@ describe("DocPreviewDrawer", () => {
     document.body.appendChild(previous);
     previous.focus();
     const { DocPreviewDrawer } = await import("../doc-preview-drawer.js");
-    const dom = await renderAt("/?docChat=chat-1&docAgent=agent-1&docPath=docs%2Fguide.md", <DocPreviewDrawer />);
+    const dom = await renderAt(
+      `/?docChat=chat-1&docMsg=msg-1&docAttachment=${ATT_ID}`,
+      <DocPreviewDrawer />,
+      (client) => {
+        client.setQueryData(docAttachmentRefQueryKey(ATT_ID), docRef);
+      },
+    );
     await flush();
 
     expect(dom.querySelector('[aria-modal="true"]')).toBeTruthy();
@@ -284,6 +252,6 @@ describe("DocPreviewDrawer", () => {
       dom.querySelector("aside")?.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab", bubbles: true }));
       document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
     });
-    expect(latestSearch).not.toContain("docPath=");
+    expect(latestSearch).not.toContain("docAttachment=");
   });
 });

--- a/packages/web/src/components/__tests__/markdown-attachment-link.test.tsx
+++ b/packages/web/src/components/__tests__/markdown-attachment-link.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment happy-dom
+
+import { act, type ReactElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import type { Components } from "react-markdown";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { attachmentIdFromHref } from "../../lib/doc-preview-links.js";
+import { isNavigableWebHref } from "../../lib/safe-href.js";
+import { Markdown } from "../ui/markdown.js";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+/**
+ * Mirror of chat-view's `a` override at the seam relevant to this regression:
+ * an `attachment:<uuid>` href must reach the override intact so it renders as a
+ * live anchor (the click handler then opens the drawer). Anything that is not a
+ * doc-preview attachment nor a navigable web URL is dropped to plain text.
+ */
+const attachmentLinkComponents: Components = {
+  a({ href, children, ...props }) {
+    const attachmentId = typeof href === "string" ? attachmentIdFromHref(href) : null;
+    if (!attachmentId && !isNavigableWebHref(href)) {
+      return <>{children}</>;
+    }
+    return (
+      <a {...props} href={href} data-attachment-id={attachmentId ?? undefined}>
+        {children}
+      </a>
+    );
+  },
+};
+
+function renderMarkdown(markdown: string): void {
+  act(() => root.render((<Markdown components={attachmentLinkComponents}>{markdown}</Markdown>) as ReactElement));
+}
+
+/**
+ * Render-seam regression: react-markdown's `defaultUrlTransform` strips the
+ * unknown `attachment:` scheme to `href=""` BEFORE the `a` component override
+ * runs. Without the `urlTransform` passthrough in `markdown.tsx`, the override
+ * sees an empty href, `attachmentIdFromHref` returns null, and the doc-preview
+ * link renders as dead plain text. This test exercises the real `<Markdown>`
+ * wrapper (not a helper / deep-link shortcut), so it fails without that fix.
+ */
+describe("Markdown attachment link render seam", () => {
+  const uuid = "11111111-2222-4333-8444-555555555555";
+
+  it("preserves an attachment:<uuid> href through the real Markdown wrapper", () => {
+    renderMarkdown(`See [the doc](attachment:${uuid})`);
+    const anchor = container.querySelector("a");
+    expect(anchor).not.toBeNull();
+    // The load-bearing assertion: NOT stripped to "".
+    expect(anchor?.getAttribute("href")).toBe(`attachment:${uuid}`);
+    expect(anchor?.getAttribute("data-attachment-id")).toBe(uuid);
+  });
+
+  it("still strips unknown/unsafe schemes via the default transform", () => {
+    renderMarkdown("[evil](javascript:alert(1))");
+    // The default transform neutralizes the href; the override then drops the
+    // non-navigable anchor to plain text.
+    expect(container.querySelector("a")).toBeNull();
+    expect(container.textContent).toContain("evil");
+  });
+
+  it("still renders normal external links as anchors", () => {
+    renderMarkdown("[site](https://cloud.first-tree.ai/docs)");
+    expect(container.querySelector("a")?.getAttribute("href")).toBe("https://cloud.first-tree.ai/docs");
+  });
+});

--- a/packages/web/src/components/doc-preview-drawer.tsx
+++ b/packages/web/src/components/doc-preview-drawer.tsx
@@ -1,4 +1,4 @@
-import { parseWorkspaceDocKey } from "@first-tree/shared";
+import { type AttachmentRef, attachmentRefsFromMetadata, normalizeDocLinkPath } from "@first-tree/shared";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Loader2, X } from "lucide-react";
 import {
@@ -12,17 +12,12 @@ import {
 } from "react";
 import type { Components } from "react-markdown";
 import { useSearchParams } from "react-router";
+import { fetchAttachmentText, sha256Hex } from "../api/attachments.js";
 import { listChatMessages } from "../api/chats.js";
-import { getMeDoc } from "../api/me-docs.js";
-import { docPreviewPathFromHref } from "../lib/doc-preview-links.js";
+import { attachmentIdFromHref } from "../lib/doc-preview-links.js";
 import { isNavigableWebHref } from "../lib/safe-href.js";
-import { useAgentSlugToIdMap } from "../lib/use-agent-name-map.js";
 import { cn } from "../lib/utils.js";
-import {
-  type DocSnapshotEntry,
-  docSnapshotQueryKey,
-  documentSnapshotMapFromMetadata,
-} from "../pages/workspace/center/chat-view.js";
+import { docAttachmentRefQueryKey } from "../pages/workspace/center/chat-view.js";
 import { Button } from "./ui/button.js";
 import { Markdown } from "./ui/markdown.js";
 
@@ -30,16 +25,19 @@ const DEFAULT_MAX_WIDTH = 1200;
 const DEFAULT_VIEWPORT_RATIO = 0.55;
 const MIN_DRAWER_WIDTH = 360;
 /**
- * Reserved layout width the drawer must NOT eat into when it expands.
- * Covers the fixed left conversation rail (320 wide, see
- * `packages/web/src/pages/workspace/conversations/index.tsx`) plus the
- * minimum readable chat column (about 320). Without this the drawer can
- * drag itself wide enough to squash the chat composer / reading column
- * into a few characters per line on common laptop viewports.
+ * Reserved layout width the drawer must NOT eat into when it expands. Covers the
+ * fixed left conversation rail plus a minimum readable chat column.
  */
 const RESERVED_MAIN_WIDTH = 640;
 const RESIZE_KEY_STEP = 24;
 const WIDTH_STORAGE_KEY = "first-tree:doc-preview-drawer:width:v1";
+
+/**
+ * Preview render size cap — separate from (and far below) the 10MB upload cap.
+ * A multi-MB markdown string would choke react-markdown / the DOM, so above
+ * this we show a "too large" download fallback instead of rendering.
+ */
+const MAX_PREVIEW_RENDER_BYTES = 1024 * 1024;
 
 function defaultDrawerWidth(): number {
   if (typeof window === "undefined") return DEFAULT_MAX_WIDTH;
@@ -92,101 +90,57 @@ function useIsMobileDocPreview(): boolean {
   return isMobile;
 }
 
+type PreviewState =
+  | { kind: "text"; text: string; integrityWarning: boolean }
+  | { kind: "too-large"; sizeBytes: number };
+
 /**
- * Markdown preview rail that sits to the right of the chat reading column.
+ * Markdown preview rail to the right of the chat reading column.
  *
- * Layout:
- *   - Desktop: a `relative shrink-0` flex sibling inside chat-view's flex
- *     container. The chat main column flexes around it, so the drawer
- *     coexists with the chat instead of overlaying it. The left edge is
- *     a draggable col-resize handle (mouse + keyboard via Arrow Left /
- *     Right) so the user can widen or shrink the rail toward the chat
- *     main column.
- *   - Mobile (`max-width: 47.999rem`): full-screen fixed inset-0 modal
- *     with focus trap, so the same component covers both surfaces
- *     without rendering two competing rails on a narrow viewport.
+ * Data source: a doc is referenced by `metadata.attachments[]` as a generic
+ * `AttachmentRef` (kind: "document"). The drawer reads the ref (seeded into the
+ * React Query cache by the chat-view click handler, or recovered from the
+ * message metadata on a cold deep-link / reload), then fetches the bytes from
+ * `GET /attachments/:id`, verifies them against `ref.sha256` (best-effort
+ * integrity warning on mismatch), enforces a render size cap, and renders the
+ * markdown. Bytes are cached by attachmentId, so re-opens and in-doc cross
+ * links to sibling docs in the same message are network-free after first load.
  *
- * Data source priority:
- *   - Seeded inline snapshot via React Query cache (PR 415). chat-view seeds
- *     the whole message's `docs[]` when the user clicks any `.md` link, so
- *     opening the drawer is a synchronous cache read with no network
- *     round-trip — load-bearing on the cloud topology where the server
- *     cannot read the local agent workspace.
- *   - Recovery from the message's own `metadata.documentContext` when the
- *     seeded entry is gone. That seeded entry has NO observer (read via
- *     `getQueryData`, never `useQuery`), so React Query garbage-collects it
- *     after the default gcTime (~5 min). The next re-render — e.g. the
- *     messages refetch `sendMut.onSettled` triggers when the user sends a new
- *     message — would otherwise drop straight to the path endpoint below and,
- *     on the cloud topology, 404 with "Document not found". The snapshot bytes
- *     are immutable and still live in the message row, so re-derive them from
- *     the messages cache. This also makes the preview survive a full page
- *     reload (the messages refetch restores the metadata).
- *     Recovery is deferred-to, not gated-around: the path endpoint still runs
- *     once recovery settles without a hit, so it is held off only during the
- *     brief recovery window, never disabled for `docMsg`-tagged messages.
- *   - Falls back to `GET /me/docs/preview` (path variant) for legacy
- *     `kind: "path"` messages AND for in-preview links to docs that were never
- *     snapshotted — both only resolve on single-host deployments where the
- *     server can read workspace files directly.
- *
- * Slot semantics — the drawer is rendered by chat-view in the same right
- * slot as `<ChatRightSidebar>`. chat-view enforces mutual exclusion so the
- * two rails never compete for space; see `chat-view.tsx` for the slot
- * decision and the auto-restore behaviour that re-opens the sidebar when
- * the drawer closes.
+ * Graceful degradation: an OLD message whose metadata still has the legacy
+ * inline shape carries no `attachments` ref, so clicking such a (legacy bare)
+ * link never reaches this drawer; if a stale URL points at an attachment that
+ * no longer resolves, the fetch error path renders an inline error rather than
+ * throwing.
  */
 export function DocPreviewDrawer() {
   const [searchParams, setSearchParams] = useSearchParams();
   const queryClient = useQueryClient();
   const docChatId = searchParams.get("docChat");
-  const docAgentId = searchParams.get("docAgent");
-  const docPath = searchParams.get("docPath");
-  const docBasePath = searchParams.get("docBase") ?? undefined;
   const docMsgId = searchParams.get("docMsg");
-  const hasDocRef = Boolean(docChatId && docAgentId && docPath);
-  // Inline snapshot takes precedence over the path-based endpoint. Two layers:
-  //   1. Seeded cache: the chat-view click handler stashes the whole message's
-  //      docs[] under `docSnapshotQueryKey`, so the first open is a
-  //      synchronous, network-free read.
-  //   2. Recovery from the message's `metadata.documentContext`: the seeded
-  //      entry has no observer and is GC'd after ~5 min, after which a
-  //      re-render (e.g. the post-send messages refetch) would otherwise fall
-  //      through to a path endpoint that 404s on the cloud topology. The bytes
-  //      are immutable and still in the message row, so re-derive them. See
-  //      the component docblock for the full failure trace.
-  const seededSnapshot =
-    docMsgId && docChatId && docPath
-      ? queryClient.getQueryData<DocSnapshotEntry>(docSnapshotQueryKey(docChatId, docMsgId, docPath))
-      : undefined;
-  // Reactively observe the chat's messages so recovery re-runs when they
-  // hydrate. A plain `getQueryData` peek is non-reactive: on a cold deep-link
-  // reload the messages cache is empty on first render, so a peek would
-  // memoise `undefined` and never recompute once ChatView's fetch lands —
-  // re-introducing the cloud 404 this path exists to prevent. Sharing
-  // ChatView's exact query key makes this a free cache read whenever the chat
-  // is already open; on a reload it fetches the window once.
-  const recoveryEnabled = Boolean(docChatId && docMsgId && docPath && !seededSnapshot);
+  const docAttachmentId = searchParams.get("docAttachment");
+  const hasDocRef = Boolean(docAttachmentId);
+
+  // The ref carries filename / sha256 / source.path. Prefer the seeded cache
+  // (synchronous, network-free after a click); recover from the message
+  // metadata on a cold reload by re-reading the chat's messages window.
+  const seededRef = docAttachmentId
+    ? queryClient.getQueryData<AttachmentRef>(docAttachmentRefQueryKey(docAttachmentId))
+    : undefined;
+  const recoveryEnabled = Boolean(docChatId && docMsgId && docAttachmentId && !seededRef);
   const recoveryMessages = useQuery({
     queryKey: ["chat-messages", docChatId],
     queryFn: () => listChatMessages(docChatId ?? "", { limit: 50 }),
     enabled: recoveryEnabled,
   });
-  const recoveredSnapshot = useMemo<DocSnapshotEntry | undefined>(() => {
-    if (seededSnapshot || !docMsgId || !docPath) return undefined;
+  const recoveredRef = useMemo<AttachmentRef | undefined>(() => {
+    if (seededRef || !docMsgId || !docAttachmentId) return undefined;
     const message = recoveryMessages.data?.items.find((item) => item.id === docMsgId);
     if (!message) return undefined;
-    return documentSnapshotMapFromMetadata(message.metadata)?.get(docPath);
-  }, [seededSnapshot, docMsgId, docPath, recoveryMessages.data]);
-  const inlineSnapshot = seededSnapshot ?? recoveredSnapshot;
-  // Only DEFER the path endpoint while the messages window is still loading for
-  // a snapshot-origin doc — long enough for the common GC / reload recovery to
-  // land without a wasted, soon-to-404 round-trip. Once recovery settles
-  // without a hit (e.g. an in-preview link to a doc that was never one of this
-  // message's snapshots), the path endpoint runs as the legacy single-host
-  // fallback exactly as before. We do NOT gate it out wholesale on `docMsg`:
-  // that would strand in-preview links to non-snapshotted docs on single-host.
-  const awaitingRecovery = recoveryEnabled && !recoveredSnapshot && recoveryMessages.isLoading;
+    return attachmentRefsFromMetadata(message.metadata).find((r) => r.attachmentId === docAttachmentId);
+  }, [seededRef, docMsgId, docAttachmentId, recoveryMessages.data]);
+  const docRef = seededRef ?? recoveredRef;
+  const awaitingRecovery = recoveryEnabled && !recoveredRef && recoveryMessages.isLoading;
+
   const isMobile = useIsMobileDocPreview();
   const [drawerWidth, setDrawerWidth] = useState<number>(() =>
     clampDrawerWidth(loadPersistedWidth() ?? defaultDrawerWidth()),
@@ -195,18 +149,11 @@ export function DocPreviewDrawer() {
   const closeButtonRef = useRef<HTMLButtonElement | null>(null);
   const previousFocusRef = useRef<HTMLElement | null>(null);
 
-  // Persist width changes (skip mobile — width has no meaning when the
-  // drawer is a fullscreen modal and we don't want a portrait-mode
-  // session to overwrite the user's desktop width preference).
   useEffect(() => {
     if (isMobile) return;
     savePersistedWidth(drawerWidth);
   }, [isMobile, drawerWidth]);
 
-  // Re-clamp when the viewport shrinks below the saved width (e.g. window
-  // resize, devtools open). Without this the drawer could end up wider
-  // than the viewport - RESERVED_MAIN_WIDTH and squeeze the chat column
-  // below usable size.
   useEffect(() => {
     if (isMobile) return;
     const onResize = () => setDrawerWidth((current) => clampDrawerWidth(current));
@@ -217,10 +164,8 @@ export function DocPreviewDrawer() {
   const close = useCallback(() => {
     const next = new URLSearchParams(searchParams);
     next.delete("docChat");
-    next.delete("docAgent");
-    next.delete("docPath");
-    next.delete("docBase");
     next.delete("docMsg");
+    next.delete("docAttachment");
     setSearchParams(next, { replace: true });
   }, [searchParams, setSearchParams]);
 
@@ -237,7 +182,6 @@ export function DocPreviewDrawer() {
     if (!hasDocRef || !isMobile) return;
     previousFocusRef.current = document.activeElement instanceof HTMLElement ? document.activeElement : null;
     const focusTimer = window.setTimeout(() => closeButtonRef.current?.focus(), 0);
-
     return () => {
       window.clearTimeout(focusTimer);
       const previous = previousFocusRef.current;
@@ -246,53 +190,62 @@ export function DocPreviewDrawer() {
     };
   }, [hasDocRef, isMobile]);
 
-  // A cross-agent docPath is a global key `<ownerSlug>/<chatId>/<rel>`; the
-  // path-based fallback endpoint is keyed by (owner agentId, rel) under
-  // `workspaces/<ownerName>/<chatId>/`, so strip the owner+chatId prefix and
-  // send just `rel`. Self / legacy bare keys (or a deep self path whose chatId
-  // segment doesn't match this chat) pass through unchanged.
-  const slugToId = useAgentSlugToIdMap();
-  const parsedKey = docPath ? parseWorkspaceDocKey(docPath) : null;
-  const isCrossKey = parsedKey !== null && parsedKey.chatId === docChatId;
-  // For a cross key the OWNER is named in the key itself — resolve the owner
-  // agent id from that slug rather than trusting `docAgent` (the click handler
-  // may have stored the sender as a hasDocRef placeholder when the owner slug
-  // couldn't be resolved). This keeps the fallback pointed at the owner's
-  // workspace even after a reload / cache miss; if the owner can't be resolved
-  // we DISABLE the fallback rather than query the sender, which could surface a
-  // same-named file from the WRONG workspace (review P2-a).
-  const crossOwnerId = isCrossKey && parsedKey ? slugToId(parsedKey.agentSlug) : null;
-  const fallbackAgentId = isCrossKey ? crossOwnerId : docAgentId;
-  const apiPath = isCrossKey && parsedKey ? parsedKey.rel : (docPath ?? "");
-  const apiBasePath = isCrossKey ? undefined : docBasePath;
-  const previewQuery = useQuery({
-    queryKey: ["me", "docs", "preview", docChatId, fallbackAgentId, apiBasePath, apiPath],
-    queryFn: () =>
-      getMeDoc(docChatId ?? "", {
-        agentId: fallbackAgentId ?? "",
-        basePath: apiBasePath,
-        path: apiPath,
-      }),
-    // Skip the network round-trip when we already have an inline snapshot
-    // (seeded or recovered), when a cross key's owner couldn't be resolved
-    // (fail closed), or while metadata recovery is still in flight — see
-    // `awaitingRecovery`, which holds this off just long enough for the common
-    // GC / reload recovery to win instead of racing a doomed cloud 404.
-    enabled: hasDocRef && !inlineSnapshot && Boolean(fallbackAgentId) && !awaitingRecovery,
+  // Fetch + verify the doc bytes. React Query caches by attachmentId (immutable
+  // blob), so re-opens / in-doc cross-links are network-free.
+  const previewQuery = useQuery<PreviewState>({
+    queryKey: ["doc-attachment-preview", docAttachmentId],
+    queryFn: async (): Promise<PreviewState> => {
+      const id = docAttachmentId ?? "";
+      const fetched = await fetchAttachmentText(id);
+      if (fetched.sizeBytes > MAX_PREVIEW_RENDER_BYTES) {
+        return { kind: "too-large", sizeBytes: fetched.sizeBytes };
+      }
+      let integrityWarning = false;
+      const expected = docRef?.sha256;
+      if (expected) {
+        try {
+          const actual = await sha256Hex(fetched.text);
+          integrityWarning = actual !== expected;
+        } catch {
+          // Web Crypto unavailable (e.g. insecure context) — skip verification.
+          integrityWarning = false;
+        }
+      }
+      return { kind: "text", text: fetched.text, integrityWarning };
+    },
+    enabled: hasDocRef && Boolean(docAttachmentId),
   });
-  const resolvedDocPath = inlineSnapshot?.path ?? previewQuery.data?.ref.path ?? docPath;
-  const displayDocPath = inlineSnapshot?.path ?? previewQuery.data?.path ?? docPath;
 
   const title = useMemo(() => {
-    const path = displayDocPath ?? "";
+    const path = docRef?.source?.path ?? docRef?.filename ?? "";
     return path.split("/").filter(Boolean).at(-1) ?? path;
-  }, [displayDocPath]);
-  const subtitle = displayDocPath && displayDocPath !== title ? displayDocPath : null;
+  }, [docRef]);
+  const docSourcePath = docRef?.source?.path ?? docRef?.filename ?? null;
+  const subtitle = docSourcePath && docSourcePath !== title ? docSourcePath : null;
 
-  const openDocPath = useCallback(
-    (path: string) => {
+  // Map a click on an in-doc markdown link to a sibling doc ref in the SAME
+  // message (matched by `source.path`) so cross-navigation stays inside the
+  // attachment model. Falls back to no-op when the target isn't a sibling doc.
+  const siblingRefsByPath = useMemo(() => {
+    const map = new Map<string, AttachmentRef>();
+    if (!docMsgId) return map;
+    // Seeded siblings: the click handler stashes every ref of the message under
+    // its own attachmentId key. We can only enumerate via the messages cache,
+    // so read recovery/messages data when present.
+    const message = recoveryMessages.data?.items.find((item) => item.id === docMsgId);
+    const refs = message ? attachmentRefsFromMetadata(message.metadata) : [];
+    for (const r of refs) {
+      if (r.kind === "document" && r.source?.path) map.set(r.source.path, r);
+    }
+    // Always include the current ref so a self-link resolves.
+    if (docRef?.source?.path) map.set(docRef.source.path, docRef);
+    return map;
+  }, [docMsgId, recoveryMessages.data, docRef]);
+
+  const openSiblingAttachment = useCallback(
+    (attachmentId: string) => {
       const next = new URLSearchParams(searchParams);
-      next.set("docPath", path);
+      next.set("docAttachment", attachmentId);
       setSearchParams(next);
     },
     [searchParams, setSearchParams],
@@ -301,11 +254,14 @@ export function DocPreviewDrawer() {
   const markdownComponents = useMemo<Components>(
     () => ({
       a({ href, children, ...props }) {
-        // issue 831: neutralise dead links (local filesystem paths / unknown
-        // schemes) that would 404 against the cloud origin. Doc-preview `.md`
-        // paths resolve first so in-doc cross-links keep their click handler.
-        const docPreviewPath = typeof href === "string" ? docPreviewPathFromHref(href, resolvedDocPath) : null;
-        if (!docPreviewPath && !isNavigableWebHref(href)) {
+        // An `attachment:<id>` link inside the doc → open that sibling doc.
+        const inDocAttachmentId = typeof href === "string" ? attachmentIdFromHref(href) : null;
+        // A relative `.md` link resolved against the current doc's source path,
+        // matched to a sibling ref's source.path.
+        const siblingId =
+          typeof href === "string" ? resolveSiblingByPath(href, docSourcePath, siblingRefsByPath) : null;
+        const targetId = inDocAttachmentId ?? siblingId;
+        if (!targetId && !isNavigableWebHref(href)) {
           return <>{children}</>;
         }
         const onClick = (event: ReactMouseEvent<HTMLAnchorElement>) => {
@@ -320,10 +276,9 @@ export function DocPreviewDrawer() {
           ) {
             return;
           }
-          const nextDocPath = docPreviewPathFromHref(href, resolvedDocPath);
-          if (!nextDocPath) return;
+          if (!targetId) return;
           event.preventDefault();
-          openDocPath(nextDocPath);
+          openSiblingAttachment(targetId);
         };
 
         return (
@@ -333,13 +288,9 @@ export function DocPreviewDrawer() {
         );
       },
     }),
-    [openDocPath, resolvedDocPath],
+    [docSourcePath, siblingRefsByPath, openSiblingAttachment],
   );
 
-  // Resize via the left edge. The drawer lives on the right of the chat
-  // main column, so growing left = wider drawer (= narrower chat). Track
-  // the starting width at mousedown and apply (startX - clientX) to the
-  // delta so cumulative drags stay stable across React state updates.
   const startResize = useCallback((event: ReactMouseEvent<HTMLButtonElement>) => {
     if (event.button !== 0) return;
     event.preventDefault();
@@ -366,9 +317,6 @@ export function DocPreviewDrawer() {
     window.addEventListener("mouseup", onMouseUp);
   }, []);
 
-  // Keyboard a11y for the resize handle. Arrow Left widens the drawer
-  // (it lives on the right, so "left" means "push the resize edge
-  // leftward into the chat column"); Arrow Right narrows it.
   const resizeWithKeyboard = useCallback((event: ReactKeyboardEvent<HTMLButtonElement>) => {
     if (event.key === "ArrowLeft") {
       event.preventDefault();
@@ -433,18 +381,11 @@ export function DocPreviewDrawer() {
           onKeyDown={resizeWithKeyboard}
           type="button"
         >
-          {/* Always-on hairline so the user can see the rail is draggable.
-              Hover bumps to full opacity for affirmative feedback. */}
           <div className="mx-auto h-full w-px bg-border-faint opacity-60 transition-all group-hover:w-1 group-hover:bg-accent group-hover:opacity-100" />
         </button>
       )}
 
-      <header
-        className="flex shrink-0 items-center gap-3 px-4"
-        // Match chat-view's header sizing + raised background so the two
-        // headers share one continuous chrome row across the panel split.
-        style={{ height: 52, background: "var(--bg-raised)" }}
-      >
+      <header className="flex shrink-0 items-center gap-3 px-4" style={{ height: 52, background: "var(--bg-raised)" }}>
         <div className="min-w-0 flex-1">
           <div className="truncate text-body font-medium">{title}</div>
           {subtitle ? <div className="truncate text-caption text-fg-3">{subtitle}</div> : null}
@@ -462,34 +403,63 @@ export function DocPreviewDrawer() {
       </header>
 
       <div className="flex-1 overflow-y-auto px-4 py-3">
-        {inlineSnapshot ? (
-          <Markdown components={markdownComponents}>{inlineSnapshot.content}</Markdown>
-        ) : awaitingRecovery ? (
+        {awaitingRecovery || previewQuery.isLoading ? (
           <div className="flex h-full items-center justify-center text-body text-fg-2">
             <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
             Loading preview
           </div>
-        ) : (
+        ) : previewQuery.isError ? (
+          <div className="rounded-[var(--radius-panel)] border border-error bg-error-soft p-4 text-body text-error">
+            {previewQuery.error instanceof Error ? previewQuery.error.message : "Unable to load document"}
+          </div>
+        ) : previewQuery.data?.kind === "too-large" ? (
+          <div className="rounded-[var(--radius-panel)] border border-border bg-bg-sunken p-4 text-body text-fg-2">
+            This document is too large to preview ({Math.round(previewQuery.data.sizeBytes / 1024)} KB).{" "}
+            {docAttachmentId ? (
+              <a
+                href={`/api/v1/attachments/${encodeURIComponent(docAttachmentId)}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline"
+              >
+                Download to view
+              </a>
+            ) : null}
+          </div>
+        ) : previewQuery.data?.kind === "text" ? (
           <>
-            {previewQuery.isLoading ? (
-              <div className="flex h-full items-center justify-center text-body text-fg-2">
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
-                Loading preview
+            {previewQuery.data.integrityWarning ? (
+              <div className="mb-3 rounded-[var(--radius-panel)] border border-warn bg-warn-soft p-2 text-caption text-warn">
+                Integrity check failed — the fetched content does not match the captured checksum.
               </div>
             ) : null}
-
-            {previewQuery.isError ? (
-              <div className="rounded-[var(--radius-panel)] border border-error bg-error-soft p-4 text-body text-error">
-                {previewQuery.error instanceof Error ? previewQuery.error.message : "Unable to load document"}
-              </div>
-            ) : null}
-
-            {previewQuery.data ? (
-              <Markdown components={markdownComponents}>{previewQuery.data.content}</Markdown>
-            ) : null}
+            <Markdown components={markdownComponents}>{previewQuery.data.text}</Markdown>
           </>
-        )}
+        ) : null}
       </div>
     </aside>
   );
+}
+
+/**
+ * Resolve a relative in-doc markdown link (`../api.md`, `design.md`) against the
+ * currently-open doc's `source.path`, then match it to a sibling ref's
+ * `source.path`. Returns the sibling's attachmentId or null.
+ */
+function resolveSiblingByPath(
+  href: string,
+  currentDocPath: string | null,
+  siblingRefsByPath: ReadonlyMap<string, AttachmentRef>,
+): string | null {
+  const pathPart = href.trim().split(/[?#]/, 1).at(0) ?? "";
+  if (!pathPart.toLowerCase().endsWith(".md")) return null;
+  let candidate = pathPart;
+  if (currentDocPath && !pathPart.startsWith("/")) {
+    const slash = currentDocPath.lastIndexOf("/");
+    const base = slash >= 0 ? currentDocPath.slice(0, slash + 1) : "";
+    candidate = `${base}${pathPart}`;
+  }
+  const normalized = normalizeDocLinkPath(candidate);
+  if (!normalized) return null;
+  return siblingRefsByPath.get(normalized)?.attachmentId ?? null;
 }

--- a/packages/web/src/components/doc-preview-drawer.tsx
+++ b/packages/web/src/components/doc-preview-drawer.tsx
@@ -91,7 +91,11 @@ function useIsMobileDocPreview(): boolean {
 }
 
 type PreviewState =
-  | { kind: "text"; text: string; integrityWarning: boolean }
+  // `integrityWarning`: had an expected sha256 and it did NOT match (tamper/corruption).
+  // `unverified`: a ref was expected (deep-link with a docMsg) but could not be recovered
+  // (e.g. the message is older than the recovery window), so the fetched bytes could not be
+  // checked against a checksum — shown to the user rather than left as a silent blank drawer.
+  | { kind: "text"; text: string; integrityWarning: boolean; unverified: boolean }
   | { kind: "too-large"; sizeBytes: number };
 
 /**
@@ -219,12 +223,18 @@ export function DocPreviewDrawer() {
           integrityWarning = false;
         }
       }
-      return { kind: "text", text: fetched.text, integrityWarning };
+      // A ref was expected (deep-link carried a docMsg) but couldn't be recovered →
+      // we fetch anyway (capability-authed by attachmentId) but flag it unverified
+      // rather than render a silent blank drawer.
+      const unverified = !expected && Boolean(docMsgId);
+      return { kind: "text", text: fetched.text, integrityWarning, unverified };
     },
-    // Don't fetch while a ref is still being recovered: a seeded ref is
-    // present, or there's nothing to recover (`!recoveryEnabled` — orphan or
-    // already-resolved), or recovery has produced the ref.
-    enabled: Boolean(docAttachmentId) && (Boolean(seededRef) || !recoveryEnabled || Boolean(recoveredRef)),
+    // Hold the fetch only while recovery is still in flight (`awaitingRecovery`).
+    // Once recovery SETTLES — whether it produced the ref or missed (e.g. the
+    // message is older than the recovery window) — we fetch: with the ref it
+    // verifies (sha256 in the key); on a miss it fetches unverified (flagged
+    // above) instead of leaving the drawer stuck idle/blank.
+    enabled: Boolean(docAttachmentId) && !awaitingRecovery,
   });
 
   // SECURITY: `docRef.source.path` is UNTRUSTED, DISPLAY-ONLY metadata supplied
@@ -464,6 +474,10 @@ export function DocPreviewDrawer() {
             {previewQuery.data.integrityWarning ? (
               <div className="mb-3 rounded-[var(--radius-panel)] border border-warn bg-warn-soft p-2 text-caption text-warn">
                 Integrity check failed — the fetched content does not match the captured checksum.
+              </div>
+            ) : previewQuery.data.unverified ? (
+              <div className="mb-3 rounded-[var(--radius-panel)] border border-warn bg-warn-soft p-2 text-caption text-warn">
+                Couldn't verify integrity — the document reference is unavailable (showing fetched content).
               </div>
             ) : null}
             <Markdown components={markdownComponents}>{previewQuery.data.text}</Markdown>

--- a/packages/web/src/components/doc-preview-drawer.tsx
+++ b/packages/web/src/components/doc-preview-drawer.tsx
@@ -91,11 +91,7 @@ function useIsMobileDocPreview(): boolean {
 }
 
 type PreviewState =
-  // `integrityWarning`: had an expected sha256 and it did NOT match (tamper/corruption).
-  // `unverified`: a ref was expected (deep-link with a docMsg) but could not be recovered
-  // (e.g. the message is older than the recovery window), so the fetched bytes could not be
-  // checked against a checksum — shown to the user rather than left as a silent blank drawer.
-  | { kind: "text"; text: string; integrityWarning: boolean; unverified: boolean }
+  | { kind: "text"; text: string; integrityWarning: boolean }
   | { kind: "too-large"; sizeBytes: number };
 
 /**
@@ -144,6 +140,8 @@ export function DocPreviewDrawer() {
   }, [seededRef, docMsgId, docAttachmentId, recoveryMessages.data]);
   const docRef = seededRef ?? recoveredRef;
   const awaitingRecovery = recoveryEnabled && !recoveredRef && recoveryMessages.isLoading;
+  const recoveryMiss = recoveryEnabled && !recoveredRef && !recoveryMessages.isLoading && !recoveryMessages.isFetching;
+  const previewWillBeUnverifiedAfterRecoveryMiss = recoveryMiss && !docRef;
 
   const isMobile = useIsMobileDocPreview();
   const [drawerWidth, setDrawerWidth] = useState<number>(() =>
@@ -203,7 +201,9 @@ export function DocPreviewDrawer() {
   // fetch until recovery settles whenever a ref is recoverable — this enforces
   // the invariant: whenever a ref with a sha256 is available, the rendered
   // preview was verified against it. A truly ref-less orphan (no msgId to
-  // recover from) still fetches unverified, which is acceptable.
+  // recover from) still fetches unverified, which is acceptable. A stale deep
+  // link with msgId outside the recovery window also fetches unverified after
+  // recovery misses, but renders a visible warning instead of a blank drawer.
   const previewQuery = useQuery<PreviewState>({
     queryKey: ["doc-attachment-preview", docAttachmentId, docRef?.sha256 ?? null],
     queryFn: async (): Promise<PreviewState> => {
@@ -223,17 +223,13 @@ export function DocPreviewDrawer() {
           integrityWarning = false;
         }
       }
-      // A ref was expected (deep-link carried a docMsg) but couldn't be recovered →
-      // we fetch anyway (capability-authed by attachmentId) but flag it unverified
-      // rather than render a silent blank drawer.
-      const unverified = !expected && Boolean(docMsgId);
-      return { kind: "text", text: fetched.text, integrityWarning, unverified };
+      return { kind: "text", text: fetched.text, integrityWarning };
     },
     // Hold the fetch only while recovery is still in flight (`awaitingRecovery`).
     // Once recovery SETTLES — whether it produced the ref or missed (e.g. the
     // message is older than the recovery window) — we fetch: with the ref it
-    // verifies (sha256 in the key); on a miss it fetches unverified (flagged
-    // above) instead of leaving the drawer stuck idle/blank.
+    // verifies (sha256 in the key); on a miss it fetches unverified with a
+    // visible warning instead of leaving the drawer stuck idle/blank.
     enabled: Boolean(docAttachmentId) && !awaitingRecovery,
   });
 
@@ -461,6 +457,12 @@ export function DocPreviewDrawer() {
           </div>
         ) : previewQuery.data?.kind === "too-large" ? (
           <div className="rounded-[var(--radius-panel)] border border-border bg-bg-sunken p-4 text-body text-fg-2">
+            {previewWillBeUnverifiedAfterRecoveryMiss ? (
+              <div className="mb-3 rounded-[var(--radius-panel)] border border-warn bg-warn-soft p-2 text-caption text-warn">
+                Unable to recover document metadata from the recent message window. This preview was not checksum
+                verified.
+              </div>
+            ) : null}
             This document is too large to preview ({Math.round(previewQuery.data.sizeBytes / 1024)} KB).{" "}
             {docAttachmentId ? (
               <button type="button" onClick={handleDownload} className="underline">
@@ -471,13 +473,15 @@ export function DocPreviewDrawer() {
           </div>
         ) : previewQuery.data?.kind === "text" ? (
           <>
+            {previewWillBeUnverifiedAfterRecoveryMiss ? (
+              <div className="mb-3 rounded-[var(--radius-panel)] border border-warn bg-warn-soft p-2 text-caption text-warn">
+                Unable to recover document metadata from the recent message window. This preview was not checksum
+                verified.
+              </div>
+            ) : null}
             {previewQuery.data.integrityWarning ? (
               <div className="mb-3 rounded-[var(--radius-panel)] border border-warn bg-warn-soft p-2 text-caption text-warn">
                 Integrity check failed — the fetched content does not match the captured checksum.
-              </div>
-            ) : previewQuery.data.unverified ? (
-              <div className="mb-3 rounded-[var(--radius-panel)] border border-warn bg-warn-soft p-2 text-caption text-warn">
-                Couldn't verify integrity — the document reference is unavailable (showing fetched content).
               </div>
             ) : null}
             <Markdown components={markdownComponents}>{previewQuery.data.text}</Markdown>

--- a/packages/web/src/components/doc-preview-drawer.tsx
+++ b/packages/web/src/components/doc-preview-drawer.tsx
@@ -12,7 +12,7 @@ import {
 } from "react";
 import type { Components } from "react-markdown";
 import { useSearchParams } from "react-router";
-import { fetchAttachmentText, sha256Hex } from "../api/attachments.js";
+import { downloadAttachment, fetchAttachmentText, sha256Hex } from "../api/attachments.js";
 import { listChatMessages } from "../api/chats.js";
 import { attachmentIdFromHref } from "../lib/doc-preview-links.js";
 import { isNavigableWebHref } from "../lib/safe-href.js";
@@ -216,6 +216,11 @@ export function DocPreviewDrawer() {
     enabled: hasDocRef && Boolean(docAttachmentId),
   });
 
+  // SECURITY: `docRef.source.path` is UNTRUSTED, DISPLAY-ONLY metadata supplied
+  // by the sending runtime (see `AttachmentRef.source` in attachment-ref.ts). It
+  // is rendered purely as the drawer title/subtitle here — it must NEVER be used
+  // for authorization, routing, or filesystem access. The doc bytes are fetched
+  // by the capability-based attachmentId, not by this path.
   const title = useMemo(() => {
     const path = docRef?.source?.path ?? docRef?.filename ?? "";
     return path.split("/").filter(Boolean).at(-1) ?? path;
@@ -250,6 +255,20 @@ export function DocPreviewDrawer() {
     },
     [searchParams, setSearchParams],
   );
+
+  // Over-cap fallback: download the bytes through the authed api helper rather
+  // than navigating to a page-relative `/api/v1/...` (no auth header → 401,
+  // wrong origin → 404). The download filename prefers the captured filename.
+  const [downloadError, setDownloadError] = useState<string | null>(null);
+  const handleDownload = useCallback(async () => {
+    if (!docAttachmentId) return;
+    setDownloadError(null);
+    try {
+      await downloadAttachment(docAttachmentId, docRef?.filename ?? "document.md");
+    } catch (error) {
+      setDownloadError(error instanceof Error ? error.message : "Download failed");
+    }
+  }, [docAttachmentId, docRef]);
 
   const markdownComponents = useMemo<Components>(
     () => ({
@@ -416,15 +435,11 @@ export function DocPreviewDrawer() {
           <div className="rounded-[var(--radius-panel)] border border-border bg-bg-sunken p-4 text-body text-fg-2">
             This document is too large to preview ({Math.round(previewQuery.data.sizeBytes / 1024)} KB).{" "}
             {docAttachmentId ? (
-              <a
-                href={`/api/v1/attachments/${encodeURIComponent(docAttachmentId)}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="underline"
-              >
+              <button type="button" onClick={handleDownload} className="underline">
                 Download to view
-              </a>
+              </button>
             ) : null}
+            {downloadError ? <div className="mt-2 text-caption text-error">{downloadError}</div> : null}
           </div>
         ) : previewQuery.data?.kind === "text" ? (
           <>

--- a/packages/web/src/components/doc-preview-drawer.tsx
+++ b/packages/web/src/components/doc-preview-drawer.tsx
@@ -17,7 +17,7 @@ import { listChatMessages } from "../api/chats.js";
 import { attachmentIdFromHref } from "../lib/doc-preview-links.js";
 import { isNavigableWebHref } from "../lib/safe-href.js";
 import { cn } from "../lib/utils.js";
-import { docAttachmentRefQueryKey } from "../pages/workspace/center/chat-view.js";
+import { docAttachmentRefQueryKey, docMessageAttachmentRefsQueryKey } from "../pages/workspace/center/chat-view.js";
 import { Button } from "./ui/button.js";
 import { Markdown } from "./ui/markdown.js";
 
@@ -190,10 +190,18 @@ export function DocPreviewDrawer() {
     };
   }, [hasDocRef, isMobile]);
 
-  // Fetch + verify the doc bytes. React Query caches by attachmentId (immutable
-  // blob), so re-opens / in-doc cross-links are network-free.
+  // Fetch + verify the doc bytes.
+  //
+  // The query key includes the expected sha256 so a late-arriving ref (cold
+  // deep-link, where the ref is recovered AFTER first render) forces a
+  // refetch+reverify rather than serving a previously-fetched-but-unverified
+  // cached state. Combined with the `enabled` gate below — which holds the
+  // fetch until recovery settles whenever a ref is recoverable — this enforces
+  // the invariant: whenever a ref with a sha256 is available, the rendered
+  // preview was verified against it. A truly ref-less orphan (no msgId to
+  // recover from) still fetches unverified, which is acceptable.
   const previewQuery = useQuery<PreviewState>({
-    queryKey: ["doc-attachment-preview", docAttachmentId],
+    queryKey: ["doc-attachment-preview", docAttachmentId, docRef?.sha256 ?? null],
     queryFn: async (): Promise<PreviewState> => {
       const id = docAttachmentId ?? "";
       const fetched = await fetchAttachmentText(id);
@@ -213,7 +221,10 @@ export function DocPreviewDrawer() {
       }
       return { kind: "text", text: fetched.text, integrityWarning };
     },
-    enabled: hasDocRef && Boolean(docAttachmentId),
+    // Don't fetch while a ref is still being recovered: a seeded ref is
+    // present, or there's nothing to recover (`!recoveryEnabled` — orphan or
+    // already-resolved), or recovery has produced the ref.
+    enabled: Boolean(docAttachmentId) && (Boolean(seededRef) || !recoveryEnabled || Boolean(recoveredRef)),
   });
 
   // SECURITY: `docRef.source.path` is UNTRUSTED, DISPLAY-ONLY metadata supplied
@@ -234,18 +245,25 @@ export function DocPreviewDrawer() {
   const siblingRefsByPath = useMemo(() => {
     const map = new Map<string, AttachmentRef>();
     if (!docMsgId) return map;
-    // Seeded siblings: the click handler stashes every ref of the message under
-    // its own attachmentId key. We can only enumerate via the messages cache,
-    // so read recovery/messages data when present.
+    // Seeded siblings (common click path): the chat-view click handler stashes
+    // the message's FULL ref list under a per-message key. Read it so relative
+    // `other.md` links resolve without re-fetching the messages window.
+    const seededMessageRefs =
+      queryClient.getQueryData<AttachmentRef[]>(docMessageAttachmentRefsQueryKey(docMsgId)) ?? [];
+    for (const r of seededMessageRefs) {
+      if (r.kind === "document" && r.source?.path) map.set(r.source.path, r);
+    }
+    // Recovered siblings (cold load / deep link): the click cache is empty, so
+    // enumerate from the recovered messages window instead.
     const message = recoveryMessages.data?.items.find((item) => item.id === docMsgId);
-    const refs = message ? attachmentRefsFromMetadata(message.metadata) : [];
-    for (const r of refs) {
+    const recoveredRefs = message ? attachmentRefsFromMetadata(message.metadata) : [];
+    for (const r of recoveredRefs) {
       if (r.kind === "document" && r.source?.path) map.set(r.source.path, r);
     }
     // Always include the current ref so a self-link resolves.
     if (docRef?.source?.path) map.set(docRef.source.path, docRef);
     return map;
-  }, [docMsgId, recoveryMessages.data, docRef]);
+  }, [docMsgId, queryClient, recoveryMessages.data, docRef]);
 
   const openSiblingAttachment = useCallback(
     (attachmentId: string) => {

--- a/packages/web/src/components/ui/markdown.tsx
+++ b/packages/web/src/components/ui/markdown.tsx
@@ -1,11 +1,25 @@
 import type { ComponentProps } from "react";
-import ReactMarkdown, { type Components } from "react-markdown";
+import ReactMarkdown, { type Components, defaultUrlTransform } from "react-markdown";
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 import { isNavigableWebHref } from "../../lib/safe-href.js";
 import { cn } from "../../lib/utils.js";
 
 type RehypePlugins = ComponentProps<typeof ReactMarkdown>["rehypePlugins"];
+
+/**
+ * react-markdown's `defaultUrlTransform` sanitizes hrefs and STRIPS any
+ * unrecognized scheme to an empty string before our `a` component override
+ * runs — so a doc-preview `attachment:<uuid>` link (and the `#doc-failed`
+ * failure-chip fragment) would otherwise arrive at the override as `href=""`
+ * and render as dead text. Preserve exactly our two internal href shapes and
+ * delegate everything else to the default transform, so normal external links
+ * keep their full XSS-safety scrubbing (no weakening for `javascript:` etc.).
+ */
+function previewSafeUrlTransform(url: string): string {
+  if (url.startsWith("attachment:") || url.startsWith("#doc-failed")) return url;
+  return defaultUrlTransform(url);
+}
 
 export type MarkdownProps = {
   children: string;
@@ -48,6 +62,7 @@ export function Markdown({ children, className, components, rehypePlugins }: Mar
       <ReactMarkdown
         remarkPlugins={[remarkGfm, remarkBreaks]}
         rehypePlugins={rehypePlugins}
+        urlTransform={previewSafeUrlTransform}
         components={{
           a: ({ node, href, children, ...props }) => {
             void node;

--- a/packages/web/src/lib/__tests__/doc-preview-links.test.ts
+++ b/packages/web/src/lib/__tests__/doc-preview-links.test.ts
@@ -1,168 +1,32 @@
 import { describe, expect, it } from "vitest";
 import {
+  attachmentIdFromHref,
   buildFailedDocHref,
-  docPreviewPathFromHref,
-  linkifyMarkdownDocPaths,
   parseFailedDocHref,
   wrapFailedDocMentions,
 } from "../doc-preview-links.js";
 
-describe("docPreviewPathFromHref", () => {
-  it("accepts markdown paths with `:line[:col]` suffix and strips them", () => {
-    expect(docPreviewPathFromHref("docs/intro.md:12")).toBe("docs/intro.md");
-    expect(docPreviewPathFromHref("docs/api.md:42:13")).toBe("docs/api.md");
+describe("attachmentIdFromHref", () => {
+  const UUID = "00000000-0000-4000-8000-000000000001";
+
+  it("extracts a uuid attachment id from an `attachment:<uuid>` href", () => {
+    expect(attachmentIdFromHref(`attachment:${UUID}`)).toBe(UUID);
   });
 
-  it("accepts markdown paths and strips query/hash fragments", () => {
-    expect(docPreviewPathFromHref("docs/design.md?plain=1#section")).toBe("docs/design.md");
+  it("strips any query/hash suffix defensively", () => {
+    expect(attachmentIdFromHref(`attachment:${UUID}?x=1`)).toBe(UUID);
+    expect(attachmentIdFromHref(`attachment:${UUID}#frag`)).toBe(UUID);
   });
 
-  it("resolves relative links against the current document path", () => {
-    expect(docPreviewPathFromHref("../api.md", "docs/design/overview.md")).toBe("docs/api.md");
+  it("returns null for a non-attachment href", () => {
+    expect(attachmentIdFromHref("docs/intro.md")).toBeNull();
+    expect(attachmentIdFromHref("https://example.com/x.md")).toBeNull();
+    expect(attachmentIdFromHref("#heading")).toBeNull();
   });
 
-  it("normalizes root-relative markdown paths inside the preview root", () => {
-    expect(docPreviewPathFromHref("/docs/intro.md")).toBe("docs/intro.md");
-  });
-
-  it("rejects paths that escape above the preview root", () => {
-    expect(docPreviewPathFromHref("../../../secret.md", "docs/design/overview.md")).toBeNull();
-    expect(docPreviewPathFromHref("../secret.md")).toBeNull();
-  });
-
-  it("rejects schemes, scheme-relative links, fragments, and non-markdown links", () => {
-    expect(docPreviewPathFromHref("https://example.com/readme.md")).toBeNull();
-    expect(docPreviewPathFromHref("mailto:hello@example.com")).toBeNull();
-    expect(docPreviewPathFromHref("//example.com/readme.md")).toBeNull();
-    expect(docPreviewPathFromHref("#heading")).toBeNull();
-    expect(docPreviewPathFromHref("docs/readme.txt")).toBeNull();
-  });
-
-  it("rejects hidden segments (.dotfile / .agent / .git) so a click never resolves into them", () => {
-    expect(docPreviewPathFromHref(".agent/secret.md")).toBeNull();
-    expect(docPreviewPathFromHref("docs/.hidden.md")).toBeNull();
-    expect(docPreviewPathFromHref("docs/.git/HEAD.md")).toBeNull();
-  });
-});
-
-describe("linkifyMarkdownDocPaths", () => {
-  it("wraps only snapshotted paths, linking to the canonical (de-suffixed) target", () => {
-    // `README.md:12` keeps its `:12` in the visible text but links to the
-    // canonical `README.md` — an href with a `:` before any `/` would be
-    // stripped to "" by react-markdown's defaultUrlTransform and reload the page.
-    expect(
-      linkifyMarkdownDocPaths("Created docs/intro.md and README.md:12.", new Set(["docs/intro.md", "README.md"])),
-    ).toBe("Created [docs/intro.md](docs/intro.md) and [README.md:12](README.md).");
-  });
-
-  it("leaves a mentioned-but-not-snapshotted path as plain text (no dead links)", () => {
-    // The agent only *talks about* README.md:12 (e.g. describing a bug); there
-    // is no snapshot for it, so it must NOT become a clickable (dead) link.
-    expect(linkifyMarkdownDocPaths("the README.md:12 bug is annoying", new Set())).toBe(
-      "the README.md:12 bug is annoying",
-    );
-    expect(linkifyMarkdownDocPaths("see docs/intro.md for details", new Set(["docs/other.md"]))).toBe(
-      "see docs/intro.md for details",
-    );
-  });
-
-  it("does not touch already-linked paths, fenced code, HTML tags, or external URLs", () => {
-    // Phase 1: inline code is NOT in this list anymore — see the dedicated
-    // code-span test below. Fenced / HTML / inline-link / domain-shaped are
-    // still hard skips.
-    const input = [
-      "Already [intro](docs/intro.md)",
-      'HTML <a href="docs/html.md">link</a>',
-      "```",
-      "docs/fenced.md",
-      "```",
-      "External https://example.com/readme.md",
-      "Text docs/readme.txt",
-    ].join("\n");
-    // Even when the snapshot set contains these paths, the scanner skips
-    // links / code / HTML, so the source is returned unchanged.
-    expect(linkifyMarkdownDocPaths(input, new Set(["docs/intro.md", "docs/fenced.md", "docs/html.md"]))).toBe(input);
-  });
-
-  it("widens the rewrite to a code-span-wrapped path, preserving the mono-spaced visual", () => {
-    // Legacy (pre-runtime-rewrite) message where the agent wrapped the path
-    // in single backticks. Web's fallback now mirrors the runtime: enclose
-    // the whole `` `…` `` span as the link text so the chip renders as
-    // code-styled monospace AND becomes clickable.
-    expect(linkifyMarkdownDocPaths("see `docs/intro.md` please", new Set(["docs/intro.md"]))).toBe(
-      "see [`docs/intro.md`](docs/intro.md) please",
-    );
-  });
-
-  it("preserves multi-backtick code-span wrappers verbatim in the legacy fallback", () => {
-    expect(linkifyMarkdownDocPaths("see ``the ` token in docs/intro.md`` after", new Set(["docs/intro.md"]))).toBe(
-      "see [``the ` token in docs/intro.md``](docs/intro.md) after",
-    );
-  });
-
-  it("leaves a code-span-wrapped path without a snapshot as plain text", () => {
-    // Same invariant as bare tokens — no dead links. If the path isn't in
-    // `snapshotPaths` the code span stays untouched.
-    expect(linkifyMarkdownDocPaths("see `docs/intro.md` please", new Set())).toBe("see `docs/intro.md` please");
-  });
-
-  it("returns the source unchanged when no plain markdown paths are present", () => {
-    const text = "hello world";
-    expect(linkifyMarkdownDocPaths(text, new Set(["docs/intro.md"]))).toBe(text);
-  });
-
-  it("leaves tokens that would canonicalise to null as plain text (hidden segments, escapes)", () => {
-    // These match the surface-level regex but `normalizeDocLinkPath` rejects
-    // them, so they can never be in the snapshot set and stay plain text.
-    const input = "see .agent/secret.md and ../outside.md and docs/.git/HEAD.md";
-    expect(linkifyMarkdownDocPaths(input, new Set([".agent/secret.md", "outside.md"]))).toBe(input);
-  });
-
-  it("linkifies the snapshotted token in a line that also contains an unresolvable one", () => {
-    expect(linkifyMarkdownDocPaths("ok docs/intro.md but not .agent/secret.md", new Set(["docs/intro.md"]))).toBe(
-      "ok [docs/intro.md](docs/intro.md) but not .agent/secret.md",
-    );
-  });
-
-  it("expands a short cross-agent token to the global key when a chatId is given", () => {
-    // Runtime rewrote a sibling-workspace mention to `assistant/design.md` and
-    // embedded the snapshot under the global key `assistant/<chatId>/design.md`.
-    // Web re-expands the token with the current chat id and links to that key.
-    expect(linkifyMarkdownDocPaths("see assistant/design.md", new Set(["assistant/chat-1/design.md"]), "chat-1")).toBe(
-      "see [assistant/design.md](assistant/chat-1/design.md)",
-    );
-  });
-
-  it("prefers a direct (self/legacy) bare key over the cross expansion", () => {
-    // A literal self subdir named like another agent still matches its bare key
-    // first, so self previews never get hijacked by cross expansion.
-    expect(linkifyMarkdownDocPaths("see assistant/design.md", new Set(["assistant/design.md"]), "chat-1")).toBe(
-      "see [assistant/design.md](assistant/design.md)",
-    );
-  });
-
-  it("does not cross-expand without a chatId (self-only matching)", () => {
-    expect(linkifyMarkdownDocPaths("see assistant/design.md", new Set(["assistant/chat-1/design.md"]))).toBe(
-      "see assistant/design.md",
-    );
-  });
-
-  it("leaves a cross token plain when its expanded global key isn't snapshotted", () => {
-    expect(linkifyMarkdownDocPaths("see assistant/design.md", new Set(["assistant/chat-1/other.md"]), "chat-1")).toBe(
-      "see assistant/design.md",
-    );
-  });
-
-  it("disambiguates a self/cross collision: self short token vs full cross key (P2-b)", () => {
-    // Runtime emits the FULL global key for the colliding cross mention, so the
-    // bare `assistant/design.md` token is unambiguously the SELF snapshot and
-    // the full-key token resolves to the cross snapshot — distinct targets.
-    const set = new Set(["assistant/design.md", "assistant/chat-1/design.md"]);
-    expect(
-      linkifyMarkdownDocPaths("self assistant/design.md and cross assistant/chat-1/design.md", set, "chat-1"),
-    ).toBe(
-      "self [assistant/design.md](assistant/design.md) and cross [assistant/chat-1/design.md](assistant/chat-1/design.md)",
-    );
+  it("returns null when the id isn't uuid-shaped", () => {
+    expect(attachmentIdFromHref("attachment:not-a-uuid")).toBeNull();
+    expect(attachmentIdFromHref("attachment:")).toBeNull();
   });
 });
 

--- a/packages/web/src/lib/doc-preview-links.ts
+++ b/packages/web/src/lib/doc-preview-links.ts
@@ -1,136 +1,33 @@
 import {
-  buildWorkspaceDocKey,
   type DocSnapshotFailReason,
   docSnapshotFailReasonSchema,
-  normalizeDocLinkPath,
   scanBareDocPathTokens,
   stripDocPathLineSuffix,
 } from "@first-tree/shared";
 
 /**
- * Map an `<a href>` from a chat / drawer markdown render to the canonical
- * workspace-relative path used as the doc-snapshot cache key.
- *
- * External-link guards (scheme / scheme-relative / fragment-only) and
- * canonicalisation live in the shared `normalizeDocLinkPath` so runtime,
- * server, and web all reject and canonicalise identically. This wrapper
- * only contributes the href-specific concerns: strip query/hash, accept
- * the `:line[:col]` suffix agents often append, apply the relative-resolve
- * against `currentDocPath`, and require the `.md` suffix.
+ * URL scheme the runtime rewrites a captured doc mention into:
+ * `[display](attachment:<attachmentId>)`. The chat-view / drawer `a` override
+ * parses it back into the attachment id and opens the doc-preview drawer, which
+ * fetches the bytes from `GET /attachments/:id`. Kept as an internal magic
+ * string so the wire format has a single definition.
  */
-export function docPreviewPathFromHref(href: string, currentDocPath?: string | null): string | null {
+const ATTACHMENT_HREF_SCHEME = "attachment:";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Map an `<a href>` to the attachment id of the doc it previews, or null when
+ * the href is not an `attachment:<uuid>` link. Strips any `?query`/`#fragment`
+ * defensively; requires a uuid-shaped id so a malformed href can never address
+ * a non-attachment route.
+ */
+export function attachmentIdFromHref(href: string): string | null {
   const trimmed = href.trim();
-  if (!trimmed) return null;
-
-  const pathPart = trimmed.split(/[?#]/, 1).at(0) ?? "";
-  // Accept and discard a `:line[:col]` suffix so a link the chat linkified
-  // from `docs/api.md:42` still resolves to `docs/api.md`. Preview-time
-  // scrolling to the line is out of scope; the suffix is purely informational
-  // for the reader.
-  const pathOnly = stripDocPathLineSuffix(pathPart);
-  if (!pathOnly.toLowerCase().endsWith(".md")) return null;
-
-  // Relative-resolve against the currently-open doc path BEFORE handing off
-  // to the shared canonicaliser so a click on `../api.md` from inside
-  // `docs/design.md` resolves to `api.md`.
-  let candidate = pathOnly;
-  if (currentDocPath && !pathOnly.startsWith("/")) {
-    const slash = currentDocPath.lastIndexOf("/");
-    const base = slash >= 0 ? currentDocPath.slice(0, slash + 1) : "";
-    candidate = `${base}${pathOnly}`;
-  }
-
-  return normalizeDocLinkPath(candidate);
-}
-
-/**
- * Rewrite plain `.md` path mentions in chat text into inline markdown links
- * so react-markdown renders them as clickable previews.
- *
- * A token is linkified ONLY when its canonical path is present in
- * `snapshotPaths` — the set of `.md` docs the runtime actually embedded as
- * snapshots in this message's `metadata.documentContext`. This is the single
- * invariant that keeps the feature honest:
- *
- *   - No dead / false-positive links. A path the agent merely *mentions*
- *     conversationally (an example like `README.md:12`, a file that doesn't
- *     exist, or a doc that was too large to snapshot) has no snapshot, so it
- *     stays plain text instead of rendering a link that opens an empty preview
- *     or — worse — an unrelated workspace file that happens to share the name.
- *   - Every rendered link is guaranteed to open from the React Query cache
- *     with no server round-trip (load-bearing on the cloud topology).
- *
- * The link target is the CANONICAL (de-suffixed) path, while the visible text
- * keeps the raw token. So `README.md:12` renders `[README.md:12](README.md)`:
- * the user still sees the line number, but the href has no `:` before a `/`,
- * so react-markdown's `defaultUrlTransform` keeps it instead of stripping it
- * to `""` (an empty href made the anchor reload the whole page on click).
- *
- * Cross-agent (`chatId` provided): a snapshot of a file in ANOTHER agent's
- * workspace is keyed globally as `<ownerSlug>/<chatId>/<rel>`, and the runtime
- * rewrites the visible mention to the short `<ownerSlug>/<rel>` form. So when
- * a bare canonical token isn't itself a snapshot key, we also try expanding it
- * with the current chat id (`<firstSeg>/<chatId>/<rest>`) and link to that
- * global key if it matches. Self/legacy bare keys still match directly and
- * win (tried first), so self previews are unchanged.
- */
-export function linkifyMarkdownDocPaths(markdown: string, snapshotPaths: ReadonlySet<string>, chatId?: string): string {
-  if (snapshotPaths.size === 0) return markdown;
-  const matches = scanBareDocPathTokens(markdown);
-  if (matches.length === 0) return markdown;
-
-  // Walk matches in order and stitch the new string in O(n). Reversing and
-  // splicing would also work but is harder to read and offers no speed-up
-  // here since the source string is read sequentially anyway.
-  let out = "";
-  let cursor = 0;
-  for (const match of matches) {
-    // The cursor jumps past any code-span widening from a previous match, so
-    // a same-span sibling token here would land below `cursor` and skip — the
-    // multi-path-in-one-code-span degenerate case (first wins, rest dropped).
-    if (match.start < cursor) continue;
-    // Canonicalise BEFORE wrapping, then require a matching snapshot. Tokens
-    // like `.agent/secret.md` / `../outside.md` canonicalise to null; tokens
-    // with no embedded snapshot are conversational mentions, not previews.
-    const canonical = normalizeDocLinkPath(stripDocPathLineSuffix(match.raw));
-    if (!canonical) continue;
-    const target = resolveSnapshotKey(canonical, snapshotPaths, chatId);
-    if (!target) continue;
-    if (match.enclosingCodeSpan && match.enclosingCodeSpan.start >= cursor) {
-      // Code-span-wrapped path in a legacy (pre-runtime-rewrite) message:
-      // widen the linkification to the whole `` `…` `` span and slice it
-      // verbatim into the link text. Same shape as the runtime emits for
-      // fresh messages, so render output is consistent across vintages.
-      out += markdown.slice(cursor, match.enclosingCodeSpan.start);
-      const visibleText = markdown.slice(match.enclosingCodeSpan.start, match.enclosingCodeSpan.end);
-      out += `[${visibleText}](${target})`;
-      cursor = match.enclosingCodeSpan.end;
-    } else {
-      out += markdown.slice(cursor, match.start);
-      out += `[${match.raw}](${target})`;
-      cursor = match.end;
-    }
-  }
-  out += markdown.slice(cursor);
-  return out;
-}
-
-/**
- * Map a canonical bare token to the snapshot key it should link to, or null if
- * none. Self/legacy bare keys are tried first (so self previews are unchanged);
- * otherwise, with a chat id, the token is treated as the short cross form
- * `<ownerSlug>/<rest>` and expanded to the global `<ownerSlug>/<chatId>/<rest>`
- * key.
- */
-function resolveSnapshotKey(canonical: string, snapshotPaths: ReadonlySet<string>, chatId?: string): string | null {
-  if (snapshotPaths.has(canonical)) return canonical;
-  if (!chatId) return null;
-  const slash = canonical.indexOf("/");
-  if (slash <= 0) return null;
-  const ownerSlug = canonical.slice(0, slash);
-  const rest = canonical.slice(slash + 1);
-  const global = buildWorkspaceDocKey(ownerSlug, chatId, rest);
-  return global && snapshotPaths.has(global) ? global : null;
+  if (!trimmed.toLowerCase().startsWith(ATTACHMENT_HREF_SCHEME)) return null;
+  const rest = trimmed.slice(ATTACHMENT_HREF_SCHEME.length);
+  const id = rest.split(/[?#]/, 1).at(0) ?? "";
+  return UUID_RE.test(id) ? id : null;
 }
 
 /**
@@ -164,11 +61,10 @@ export function parseFailedDocHref(href: string): DocSnapshotFailReason | null {
 }
 
 /**
- * Wrap bare `.md` mentions that the runtime marked as snapshot failures into
- * the inert-chip placeholder link form. Same scanner as `linkifyMarkdownDocPaths`
- * so positioning + code-span widening are identical to the success path; the
- * difference is only the link's href — a magic `#doc-failed?reason=…` string
- * that the chat-view's `a` override picks up to render a disabled chip.
+ * Wrap bare `.md` mentions that the runtime marked as capture failures into the
+ * inert-chip placeholder link form. The runtime no longer linkifies successful
+ * captures on the web side (it rewrites them to explicit `attachment:` links
+ * itself), so this is the only scanner-driven rewrite left.
  *
  * `failedReasonsByRaw` maps the agent's WRITTEN path (suffix-stripped — the
  * wire stores `raw` without `:line[:col]`) to the bucketed reason. The scanner
@@ -195,8 +91,6 @@ export function wrapFailedDocMentions(
     if (!reason) continue;
     const href = buildFailedDocHref(reason);
     if (match.enclosingCodeSpan && match.enclosingCodeSpan.start >= cursor) {
-      // Code-span-wrapped failure: widen to the whole `` `…` `` span so the
-      // disabled chip carries the mono-spaced visual the agent intended.
       out += markdown.slice(cursor, match.enclosingCodeSpan.start);
       const visibleText = markdown.slice(match.enclosingCodeSpan.start, match.enclosingCodeSpan.end);
       out += `[${visibleText}](${href})`;

--- a/packages/web/src/pages/workspace/__tests__/url-transitions.test.ts
+++ b/packages/web/src/pages/workspace/__tests__/url-transitions.test.ts
@@ -31,12 +31,17 @@ describe("nextParamsForEngagement", () => {
     expect(result.has("c")).toBe(false);
   });
 
-  it("clears any doc-preview overlay", () => {
+  it("clears any doc-preview overlay (current attachment-ref params + legacy)", () => {
     const result = nextParamsForEngagement(
-      paramsOf("c=abc&engagement=active&docChat=a&docAgent=b&docPath=p&docBase=base"),
+      paramsOf("c=abc&engagement=active&docChat=a&docMsg=m&docAttachment=att&docAgent=b&docPath=p&docBase=base"),
       "all",
     );
+    // Current attachment-ref params — switching engagement must not leave a
+    // stale preview behind (R3).
     expect(result.has("docChat")).toBe(false);
+    expect(result.has("docMsg")).toBe(false);
+    expect(result.has("docAttachment")).toBe(false);
+    // Legacy params still cleared for in-flight URLs minted pre-migration.
     expect(result.has("docAgent")).toBe(false);
     expect(result.has("docPath")).toBe(false);
     expect(result.has("docBase")).toBe(false);

--- a/packages/web/src/pages/workspace/__tests__/workspace-page-dom.test.tsx
+++ b/packages/web/src/pages/workspace/__tests__/workspace-page-dom.test.tsx
@@ -242,7 +242,7 @@ describe("WorkspacePage DOM behavior", () => {
   it("normalizes legacy URL params and exposes list-driven URL transitions", async () => {
     const { WorkspacePage } = await import("../index.js");
     const { container, root } = await renderDom(
-      "/?a=agent-1&c=chat-1&source=manual&docChat=old&docAgent=agent-1&docPath=readme",
+      "/?a=agent-1&c=chat-1&source=manual&docChat=old&docMsg=m&docAttachment=att&docAgent=agent-1&docPath=readme",
       <WorkspacePage />,
     );
 
@@ -250,13 +250,20 @@ describe("WorkspacePage DOM behavior", () => {
     expect(locationParams(container).get("c")).toBe("chat-1");
     expect(locationParams(container).get("origin")).toBe("manual");
     expect(locationParams(container).get("docChat")).toBe("old");
+    // Current attachment-ref params survive the initial normalize.
+    expect(locationParams(container).get("docAttachment")).toBe("att");
+    expect(locationParams(container).get("docMsg")).toBe("m");
     expect(locationParams(container).get("docAgent")).toBe("agent-1");
     expect(locationParams(container).get("docPath")).toBe("readme");
     expect(container.textContent).toContain("list:chat-1:active");
     expect(container.textContent).toContain("center:chat-1:wide:no-with");
 
+    // R3: switching chat clears the doc-preview overlay — both the current
+    // attachment-ref params and the legacy ones — so no stale preview lingers.
     await click(buttonByText(container, "Select chat"));
     expect(container.querySelector('[data-testid="location"]')?.textContent).toBe("/?c=chat-picked&origin=manual");
+    expect(locationParams(container).get("docAttachment")).toBeNull();
+    expect(locationParams(container).get("docMsg")).toBeNull();
 
     await click(buttonByText(container, "New chat"));
     expect(container.querySelector('[data-testid="location"]')?.textContent).toBe("/?c=draft&origin=manual");

--- a/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
@@ -249,9 +249,19 @@ const BASE_MESSAGES = messages([
     createdAt: "2026-05-28T11:55:00.000Z",
     metadata: {
       mentions: ["agent-1"],
+      attachments: [
+        {
+          attachmentId: "00000000-0000-4000-8000-000000000001",
+          kind: "document",
+          mimeType: "text/markdown",
+          filename: "plan.md",
+          size: 21,
+          sha256: "a".repeat(64),
+          source: { path: "docs/plan.md" },
+        },
+      ],
       documentContext: {
         kind: "snapshot",
-        docs: [{ path: "docs/plan.md", content: "# Plan\nShip carefully.", sha256: "sha", size: 21 }],
         failedMentions: [{ raw: "secrets.env", reason: "hidden-segment" }],
       },
     },
@@ -264,9 +274,19 @@ const BASE_MESSAGES = messages([
     createdAt: "2026-05-28T11:56:00.000Z",
     deliveryStatus: "acked",
     metadata: {
+      attachments: [
+        {
+          attachmentId: "00000000-0000-4000-8000-000000000001",
+          kind: "document",
+          mimeType: "text/markdown",
+          filename: "plan.md",
+          size: 21,
+          sha256: "a".repeat(64),
+          source: { path: "docs/plan.md" },
+        },
+      ],
       documentContext: {
         kind: "snapshot",
-        docs: [{ path: "docs/plan.md", content: "# Plan\nShip carefully.", sha256: "sha", size: 21 }],
         failedMentions: [{ raw: "secrets.env", reason: "hidden-segment" }],
       },
     },
@@ -469,7 +489,7 @@ function seedChat(
 async function renderDom(
   element: ReactElement,
   seed?: (queryClient: QueryClient) => void,
-  route = "/?docChat=chat-1&docAgent=agent-1&docPath=docs/plan.md",
+  route = "/?docChat=chat-1&docMsg=msg-1&docAttachment=00000000-0000-4000-8000-000000000001",
 ): Promise<{ container: HTMLElement; queryClient: QueryClient; root: Root }> {
   const container = document.createElement("div");
   document.body.appendChild(container);

--- a/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
@@ -731,6 +731,32 @@ describe("ChatView", () => {
     await act(async () => root.unmount());
   });
 
+  // R3: opening an attachment preview (new `docChat` + `docAttachment` params)
+  // collapses the right sidebar so the preview rail gets the slot, then restores
+  // it when the preview params clear. Keys on the new params — before the fix
+  // `hasDocPreview` still read the legacy `docPath`, so the collapse never fired.
+  it("collapses the right sidebar while an attachment preview is open, restores after", async () => {
+    const { ChatView } = await import("../chat-view.js");
+    localStorage.setItem("first-tree:chat-right-sidebar:open:v1", "1");
+
+    // With no doc-preview params the sidebar is open → Participants visible.
+    const open = await renderDom(<ChatView agentId="agent-1" chatId="chat-1" />, undefined, "/");
+    await waitForText(open.container, "Participants");
+    await act(async () => open.root.unmount());
+
+    // With the attachment-preview params present the sidebar collapses →
+    // Participants no longer rendered even though localStorage says "open".
+    const preview = await renderDom(
+      <ChatView agentId="agent-1" chatId="chat-1" />,
+      undefined,
+      "/?docChat=chat-1&docMsg=msg-1&docAttachment=00000000-0000-4000-8000-000000000001",
+    );
+    await waitForText(preview.container, "Launch planning");
+    await flush();
+    expect(preview.container.textContent).not.toContain("Participants");
+    await act(async () => preview.root.unmount());
+  });
+
   it("sends text, blocks unaddressed image sends, then sends uploaded image batches", async () => {
     const { ChatView } = await import("../chat-view.js");
     const { container, root } = await renderDom(<ChatView agentId="agent-1" chatId="chat-1" />, undefined, "/");

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -1,4 +1,6 @@
 import {
+  type AttachmentRef,
+  attachmentRefsFromMetadata,
   CHAT_ENGAGEMENT_STATUSES,
   type ChatParticipantDetail,
   type DocSnapshotFailReason,
@@ -8,7 +10,6 @@ import {
   isImageRefContent,
   type MentionParticipant,
   type OpenQuestionRequest,
-  parseWorkspaceDocKey,
   type RequestResolution,
 } from "@first-tree/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -100,14 +101,9 @@ import { UnreadDivider } from "../../../components/unread-divider.js";
 import { useChatScroll } from "../../../hooks/use-chat-scroll.js";
 import { useReadTracker } from "../../../hooks/use-read-tracker.js";
 import { viewOf } from "../../../lib/agent-status-view.js";
-import {
-  docPreviewPathFromHref,
-  linkifyMarkdownDocPaths,
-  parseFailedDocHref,
-  wrapFailedDocMentions,
-} from "../../../lib/doc-preview-links.js";
+import { attachmentIdFromHref, parseFailedDocHref, wrapFailedDocMentions } from "../../../lib/doc-preview-links.js";
 import { isNavigableWebHref } from "../../../lib/safe-href.js";
-import { useAgentIdentityMap, useAgentNameMap, useAgentSlugToIdMap } from "../../../lib/use-agent-name-map.js";
+import { useAgentIdentityMap, useAgentNameMap } from "../../../lib/use-agent-name-map.js";
 import { useAutoResizeTextarea } from "../../../lib/use-autoresize-textarea.js";
 import { useOrgAgents } from "../../../lib/use-org-agents.js";
 import { usePendingImages } from "../../../lib/use-pending-images.js";
@@ -283,7 +279,6 @@ function TextRow({
 }) {
   const [searchParams, setSearchParams] = useSearchParams();
   const queryClient = useQueryClient();
-  const slugToId = useAgentSlugToIdMap();
   // GitHub-dispatcher cards keep the human-agent uuid in `senderId` so
   // routing / read-receipts / mention-resolution stay consistent, but we
   // re-attribute the row to a synthetic "GitHub" sender in the UI. The
@@ -296,8 +291,17 @@ function TextRow({
   const isGithubSystem = isTrustedGithubDispatcherMessage(msg);
   const senderName = isGithubSystem ? GITHUB_SYSTEM_SENDER_NAME : agentNameFn(msg.senderId);
   const isSelf = !isGithubSystem && myAgentId === msg.senderId;
-  const docBasePath = documentBasePathFromMetadata(msg.metadata);
-  const docSnapshots = useMemo(() => documentSnapshotMapFromMetadata(msg.metadata), [msg.metadata]);
+  // Generic attachment refs (doc-preview is the first consumer; kind:
+  // "document"). Keyed by attachmentId so the `attachment:<id>` link click can
+  // look the ref up and seed the drawer's cache. Old messages (legacy inline
+  // shape) have no `metadata.attachments` → empty map → no preview, plain text.
+  const docAttachmentRefs = useMemo(() => {
+    const map = new Map<string, AttachmentRef>();
+    for (const ref of attachmentRefsFromMetadata(msg.metadata)) {
+      if (ref.kind === "document") map.set(ref.attachmentId, ref);
+    }
+    return map;
+  }, [msg.metadata]);
   const failedDocMentions = useMemo(() => failedDocMentionsFromMetadata(msg.metadata), [msg.metadata]);
   // Does the request body *lead* with its target mention — the server-
   // normalised `@target …` shape that the renderer always chips? Resolved
@@ -312,38 +316,26 @@ function TextRow({
       .filter((name): name is string => typeof name === "string");
     return contentStartsWithMention(msg.content, targetNames);
   }, [msg.format, msg.content, msg.metadata, mentionParticipants]);
-  // Linkify plain `.md` mentions only on agent-sourced messages. Anything the
-  // user typed in the web composer (`source === "web"`) is left untouched
-  // so paths that humans write — code-fence walkthroughs, quoted snippets,
-  // intentional bare references — render exactly as authored. Only paths that
-  // this message actually carries a snapshot for get linkified, so a filename
-  // the agent only *mentions* in prose stays plain text instead of becoming a
-  // dead link — and every link that does render opens from cache without a
-  // server round-trip.
-  //
-  // Failed mentions go through `wrapFailedDocMentions` AFTER linkify so any
-  // tokens still bare in the text get the inert-chip placeholder href
-  // (`#doc-failed?reason=…`). The `a` override below renders that placeholder
-  // as a disabled chip with a reason-mapped tooltip instead of a clickable
-  // link. Order matters: linkify first so a path that snapshotted is wrapped
-  // into a markdown link (and therefore hard-skipped by the scanner the
-  // failed-mention wrapper uses), and only the genuinely-failed remainder
-  // becomes chips.
+  // Successful doc captures are already explicit `[display](attachment:<id>)`
+  // links the runtime rewrote into the message body — web does NOT re-linkify
+  // bare tokens any more. The only scanner-driven rewrite left is wrapping the
+  // runtime-reported FAILED mentions into inert-chip placeholder hrefs
+  // (`#doc-failed?reason=…`); the `a` override renders those as disabled chips.
+  // Web-composed messages (`source === "web"`) are left untouched so paths a
+  // human types render exactly as authored.
   const textContent = useMemo<string | null>(() => {
     // `request` is included so RequestCard's `body` (the long narrative /
-    // decision context) renders through the same markdown + doc-link path as
+    // decision context) renders through the same markdown path as
     // text/markdown — without this it falls back to "" and the card shows
     // only the chip + answer block (QA: missing body on expanded requests).
     if (msg.format !== "text" && msg.format !== "markdown" && msg.format !== "request") return null;
     if (typeof msg.content !== "string") return JSON.stringify(msg.content);
     if (msg.source === "web") return msg.content;
-    const snapshotPaths = new Set(docSnapshots?.keys() ?? []);
-    let body = linkifyMarkdownDocPaths(msg.content, snapshotPaths, msg.chatId);
     if (failedDocMentions && failedDocMentions.size > 0) {
-      body = wrapFailedDocMentions(body, failedDocMentions);
+      return wrapFailedDocMentions(msg.content, failedDocMentions);
     }
-    return body;
-  }, [msg.format, msg.content, msg.source, msg.chatId, docSnapshots, failedDocMentions]);
+    return msg.content;
+  }, [msg.format, msg.content, msg.source, failedDocMentions]);
   // Highlight `@<participant>` tokens in sent messages with the same
   // chip styling the composer's mirror overlay uses. Code blocks and
   // link text are skipped by the plugin itself, so a message containing
@@ -392,14 +384,13 @@ function TextRow({
             );
           }
         }
-        // issue 831: a markdown link whose href is neither a workspace doc-preview
-        // path nor a navigable web URL (e.g. an agent-written worktree path
-        // like `/Users/…/worktrees/<task>`) has no route on the cloud origin
-        // and 404s when clicked. Render the link text as plain text instead of
-        // a dead link. Doc-preview paths are checked first so snapshot-backed
-        // `.md` mentions keep their click-to-preview anchor.
-        const docPreviewPath = typeof href === "string" ? docPreviewPathFromHref(href) : null;
-        if (!docPreviewPath && !isNavigableWebHref(href)) {
+        // Doc-preview links are `attachment:<id>` (the runtime rewrites a
+        // captured mention into one). issue 831: a link whose href is neither a
+        // doc-preview attachment nor a navigable web URL (e.g. an agent-written
+        // worktree path) has no route on the cloud origin and 404s when
+        // clicked — render its text as plain text instead of a dead link.
+        const attachmentId = typeof href === "string" ? attachmentIdFromHref(href) : null;
+        if (!attachmentId && !isNavigableWebHref(href)) {
           return <>{children}</>;
         }
         const onClick = (event: ReactMouseEvent<HTMLAnchorElement>) => {
@@ -415,53 +406,22 @@ function TextRow({
             return;
           }
 
-          const docPath = docPreviewPathFromHref(href);
-          if (!docPath) return;
+          const clickedAttachmentId = attachmentIdFromHref(href);
+          if (!clickedAttachmentId) return;
 
           event.preventDefault();
+          // Seed the drawer's React Query ref cache (keyed by attachmentId) with
+          // EVERY doc ref this message carries — so the drawer opens
+          // synchronously and an in-doc cross-link to a sibling doc in the same
+          // message hits cache too. The drawer fetches the bytes on demand from
+          // `GET /attachments/:id`.
+          for (const ref of docAttachmentRefs.values()) {
+            queryClient.setQueryData(docAttachmentRefQueryKey(ref.attachmentId), ref);
+          }
           const next = new URLSearchParams(searchParams);
           next.set("docChat", msg.chatId);
-          // Owner attribution for `docAgent`: a global cross-agent key
-          // `<ownerSlug>/<chatId>/…` (chatId segment === this chat) belongs to
-          // the OWNER, not the sender; self / legacy bare keys stay the sender.
-          // `docAgent` is only a hint here — the drawer authoritatively
-          // re-resolves the owner from the key's own slug for the path-based
-          // fallback (review P2-a), so an unresolved owner does NOT mis-query
-          // the sender's workspace; it just leaves this placeholder in the URL
-          // for `hasDocRef`. The inline snapshot path renders from cache
-          // regardless of `docAgent`.
-          const parsedKey = parseWorkspaceDocKey(docPath);
-          const ownerId =
-            parsedKey && parsedKey.chatId === msg.chatId
-              ? (slugToId(parsedKey.agentSlug) ?? msg.senderId)
-              : msg.senderId;
-          next.set("docAgent", ownerId);
-          next.set("docPath", docPath);
-
-          // Prefer the inline snapshot variant: hand the drawer the bytes via
-          // React Query cache (keyed by chat+message+path) and tag the URL
-          // with the source message id. Falls back to path-based legacy
-          // preview when the agent emitted only a `kind: "path"` context.
-          //
-          // Seed the ENTIRE message's docs[] in one shot — not just the
-          // clicked one — so when the drawer's internal markdown links jump
-          // between snapshots in the same message they still hit cache and
-          // avoid the legacy network round-trip.
-          const snapshot = docSnapshots?.get(docPath);
-          if (snapshot && docSnapshots) {
-            for (const entry of docSnapshots.values()) {
-              queryClient.setQueryData(docSnapshotQueryKey(msg.chatId, msg.id, entry.path), entry);
-            }
-            next.set("docMsg", msg.id);
-            next.delete("docBase");
-          } else {
-            next.delete("docMsg");
-            if (docBasePath) {
-              next.set("docBase", docBasePath);
-            } else {
-              next.delete("docBase");
-            }
-          }
+          next.set("docMsg", msg.id);
+          next.set("docAttachment", clickedAttachmentId);
           setSearchParams(next);
         };
 
@@ -472,18 +432,7 @@ function TextRow({
         );
       },
     }),
-    [
-      docBasePath,
-      docSnapshots,
-      failedDocMentions,
-      msg.chatId,
-      msg.id,
-      msg.senderId,
-      queryClient,
-      searchParams,
-      setSearchParams,
-      slugToId,
-    ],
+    [docAttachmentRefs, failedDocMentions, msg.chatId, msg.id, queryClient, searchParams, setSearchParams],
   );
 
   return (
@@ -602,34 +551,6 @@ function TextRow({
   );
 }
 
-function documentBasePathFromMetadata(metadata: Record<string, unknown> | undefined): string | undefined {
-  const parsed = documentContextSchema.safeParse(metadata?.documentContext);
-  if (!parsed.success) return undefined;
-  // Only the path-based legacy variant exposes basePath; snapshot variants
-  // carry inline content rendered through a separate path.
-  return parsed.data.kind === "path" ? parsed.data.basePath : undefined;
-}
-
-export type DocSnapshotEntry = { path: string; content: string; sha256: string; size: number };
-
-/**
- * For snapshot-variant `documentContext`, return a map from `docs[].path` to
- * the snapshot record. Path-based or absent variants return `undefined`.
- * The map keys match the raw href that the agent emitted, so the chat link
- * click handler can use the clicked href directly as a lookup key.
- */
-export function documentSnapshotMapFromMetadata(
-  metadata: Record<string, unknown> | undefined,
-): Map<string, DocSnapshotEntry> | undefined {
-  const parsed = documentContextSchema.safeParse(metadata?.documentContext);
-  if (!parsed.success || parsed.data.kind !== "snapshot") return undefined;
-  const map = new Map<string, DocSnapshotEntry>();
-  for (const doc of parsed.data.docs) {
-    map.set(doc.path, { path: doc.path, content: doc.content, sha256: doc.sha256, size: doc.size });
-  }
-  return map;
-}
-
 /**
  * For snapshot-variant `documentContext`, return a map from the agent's
  * written raw token (suffix-stripped — wire format) to the failure reason.
@@ -669,8 +590,14 @@ function failedDocReasonTooltip(reason: DocSnapshotFailReason): string {
   }
 }
 
-export function docSnapshotQueryKey(chatId: string, messageId: string, path: string): readonly unknown[] {
-  return ["chat-doc-snapshot", chatId, messageId, path] as const;
+/**
+ * React Query key for a doc `AttachmentRef`, keyed solely by attachmentId (the
+ * blob is immutable, so the id is a stable cache key independent of which
+ * message referenced it). The chat-view click handler seeds the ref here so the
+ * drawer can read filename / sha256 / source.path without re-deriving them.
+ */
+export function docAttachmentRefQueryKey(attachmentId: string): readonly unknown[] {
+  return ["chat-doc-attachment-ref", attachmentId] as const;
 }
 
 function isInlineImageContent(content: unknown): content is FileMessageContent {

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -415,9 +415,14 @@ function TextRow({
           // synchronously and an in-doc cross-link to a sibling doc in the same
           // message hits cache too. The drawer fetches the bytes on demand from
           // `GET /attachments/:id`.
-          for (const ref of docAttachmentRefs.values()) {
+          const messageRefs = [...docAttachmentRefs.values()];
+          for (const ref of messageRefs) {
             queryClient.setQueryData(docAttachmentRefQueryKey(ref.attachmentId), ref);
           }
+          // Also seed the FULL per-message ref list under its own key so the
+          // drawer can enumerate same-message siblings on the seeded path
+          // (relative `other.md` links) without re-fetching the messages window.
+          queryClient.setQueryData(docMessageAttachmentRefsQueryKey(msg.id), messageRefs);
           const next = new URLSearchParams(searchParams);
           next.set("docChat", msg.chatId);
           next.set("docMsg", msg.id);
@@ -598,6 +603,18 @@ function failedDocReasonTooltip(reason: DocSnapshotFailReason): string {
  */
 export function docAttachmentRefQueryKey(attachmentId: string): readonly unknown[] {
   return ["chat-doc-attachment-ref", attachmentId] as const;
+}
+
+/**
+ * React Query key for the FULL list of doc `AttachmentRef`s a single message
+ * carries, keyed by messageId. The chat-view click handler seeds this so the
+ * drawer can enumerate same-message sibling docs (relative `other.md` links)
+ * on the seeded (no-fetch) path — `docAttachmentRefQueryKey` alone is keyed by
+ * attachmentId and can't be enumerated. The cold-load / deep-link path falls
+ * back to recovering the list from the chat's messages window.
+ */
+export function docMessageAttachmentRefsQueryKey(msgId: string): readonly unknown[] {
+  return ["chat-doc-message-attachment-refs", msgId] as const;
 }
 
 function isInlineImageContent(content: unknown): content is FileMessageContent {
@@ -812,7 +829,7 @@ export function ChatView({
   // expects. Stash whether the sidebar was visible at the moment doc-preview
   // opened so we can auto-restore it when the preview closes — the user did
   // not ask to dismiss the sidebar, they only opened a doc.
-  const hasDocPreview = Boolean(searchParams.get("docChat") && searchParams.get("docPath"));
+  const hasDocPreview = Boolean(searchParams.get("docChat") && searchParams.get("docAttachment"));
   const sidebarBeforeDocPreviewRef = useRef<boolean | null>(null);
   useEffect(() => {
     if (hasDocPreview) {
@@ -835,10 +852,14 @@ export function ChatView({
     if (hasDocPreview) {
       const next = new URLSearchParams(searchParams);
       next.delete("docChat");
+      next.delete("docMsg");
+      // Current owner of which doc is open (attachment-ref model).
+      next.delete("docAttachment");
+      // Legacy params from the pre-convergence `docPath` model — still cleared
+      // so a stale URL minted before the migration also clears cleanly.
       next.delete("docAgent");
       next.delete("docPath");
       next.delete("docBase");
-      next.delete("docMsg");
       setSearchParams(next, { replace: true });
       sidebarBeforeDocPreviewRef.current = true;
       return;

--- a/packages/web/src/pages/workspace/index.tsx
+++ b/packages/web/src/pages/workspace/index.tsx
@@ -363,10 +363,14 @@ export function WorkspacePage() {
 
 function clearDocPreviewParams(params: URLSearchParams): void {
   params.delete("docChat");
+  params.delete("docMsg");
+  // Current owner of which doc is open (attachment-ref model).
+  params.delete("docAttachment");
+  // Legacy params from the pre-convergence `docPath` model — still cleared so
+  // an in-flight URL minted before the migration also clears cleanly.
   params.delete("docAgent");
   params.delete("docPath");
   params.delete("docBase");
-  params.delete("docMsg");
 }
 
 /**


### PR DESCRIPTION
Converges the workspace `.md` doc-preview feature off the inline-snapshot model onto a **generic message attachment-reference model**, reusing the already-live `attachments` blob substrate. Doc-preview is the first consumer.

Design (converged across gandy2025 / yuezengwu / yzw): context-tree proposal PR → agent-team-foundation/first-tree-context#521.

## What changed
- **shared** — new generic `attachmentRefSchema` (`kind: image|document|file`) on `metadata.attachments[]`; removed the inline `content` field + per-message byte caps; `isAttachmentRef` guard.
- **client runtime** — `buildMessageDocumentSnapshots` uploads bytes via `sdk.uploadAttachment({orgId,...})` at send time and emits `AttachmentRef`; rewrites the text span to `[display](attachment:<id>)` **only on successful upload**; bounded retry then plain-text degrade; `orgId` resolved from the chat. Removed inline-write path + `looksLikeChatId` key resolution.
- **server** — validate refs (attachment exists + mime + `size`) instead of re-hashing inline content; **no** `uploaded_by==sender` check (it's the managing human's id); **no DB / schema change**.
- **web** — drawer fetches `GET /attachments/:id`, verifies client `sha256`, ~1MB preview-render cap with download fallback; linkify to `attachment:<id>`; **legacy inline-shape messages degrade gracefully** (no throw).
- **cli** — `chat send` capture mirrors the runtime. **`chat create`'s initial message does NOT capture docs** (no `chatId` yet → can't resolve the upload org; mentions degrade gracefully to plain text). Scoped out of this PR and tracked in #1069.

## Scope (acceptance)
- **In scope:** doc capture on `chat send` and on the agent runtime's final-text replies.
- **Deferred → #1069:** `chat create`'s first-message doc capture (no `chatId` yet → upload org can't be resolved). Mentions there degrade gracefully to plain text; `chat send` captures normally.

## Properties
- **Single phase, zero DB / schema change, no dedup** (design decision: dedup needs a DB index + shared rows are a cross-tenant metadata-leak vector → accept duplicate blobs at internal scale).
- **Cutover**: no backward-compat for new sends; old messages still render (graceful degrade).

## Verification
- `pnpm typecheck`: 12/12 ✅
- `pnpm check`: ✅ (2 pre-existing warnings, untouched)
- Tests: shared 442 · server 1415 · client 913 · web 784 · cli 456 — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

