### PR TITLE
fix(server): stop dropping followed chats from GitHub event audience

### DIFF
--- a/packages/server/src/__tests__/github-audience.test.ts
+++ b/packages/server/src/__tests__/github-audience.test.ts
@@ -248,6 +248,7 @@ describe("resolveAudience", () => {
         chatId,
         involveReason: null,
         involveLogin: null,
+        actorAgentId: null,
       },
     ]);
   });
@@ -297,6 +298,7 @@ describe("resolveAudience", () => {
         chatId,
         involveReason: null,
         involveLogin: null,
+        actorAgentId: null,
       },
     ]);
   });
@@ -338,6 +340,7 @@ describe("resolveAudience", () => {
         chatId: null,
         involveReason: "review_requested",
         involveLogin: humanName.toLowerCase(),
+        actorAgentId: null,
       },
     ]);
   });
@@ -449,6 +452,67 @@ describe("resolveAudience", () => {
     expect(audience[0]?.kind).toBe("existing");
     expect(audience[0]?.humanAgentId).toBe(human);
     expect(audience[0]?.chatId).toBe(chatId);
+  });
+
+  it("M2: does NOT collapse subscribed rows across different chats for the same human", async () => {
+    // Regression for the multi-human-not-pushed bug: the same human can be
+    // bound to one entity from two different chats (e.g. a webhook
+    // `human_fallback` row in chat A under delegateA plus an explicit follow
+    // row in chat B under delegateB). Deduping by `humanAgentId` alone kept
+    // only the earliest chat and silently dropped the *other* followed chat
+    // from the audience. Dedup is keyed by `(human, chat)`, so BOTH chats
+    // receive the event.
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const delegateA = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-a-${randomUUID().slice(0, 6)}`,
+    });
+    const delegateB = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-b-${randomUUID().slice(0, 6)}`,
+    });
+    const human = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `frank-${randomUUID().slice(0, 6)}`,
+    });
+    const chatA = await seedChat(app, admin.organizationId, human);
+    const chatB = await seedChat(app, admin.organizationId, human);
+    await seedMapping(app, {
+      orgId: admin.organizationId,
+      humanId: human,
+      delegateId: delegateA,
+      entityType: "issue",
+      entityKey: "owner/repo#303",
+      chatId: chatA,
+    });
+    await seedMapping(app, {
+      orgId: admin.organizationId,
+      humanId: human,
+      delegateId: delegateB,
+      entityType: "issue",
+      entityKey: "owner/repo#303",
+      chatId: chatB,
+    });
+
+    const audience = await resolveAudience(
+      app.db,
+      makeEvent({
+        orgId: admin.organizationId,
+        entityType: "issue",
+        entityKey: "owner/repo#303",
+        actorLogin: "outsider",
+        kind: "commented",
+      }),
+      "first-tree",
+    );
+
+    expect(audience).toHaveLength(2);
+    expect(audience.every((a) => a.kind === "existing")).toBe(true);
+    expect(new Set(audience.map((a) => a.chatId))).toEqual(new Set([chatA, chatB]));
   });
 
   it("dedups involves by human even when the existing mapping uses a different delegate", async () => {
@@ -589,7 +653,7 @@ describe("resolveAudience", () => {
     expect(audience).toEqual([]);
   });
 
-  it("echo: drops mappings where actor is the human side OR delegate side", async () => {
+  it("echo (#942): keeps every mapping but annotates actorAgentId (notification-layer suppression)", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
     const delegate = await seedAgent(app, {
@@ -633,7 +697,11 @@ describe("resolveAudience", () => {
       chatId: chatOther,
     });
 
-    // Actor is the human-side agent → only the other-human row survives.
+    // Actor is the human-side agent. The previous behaviour DROPPED the
+    // actor's own row, which silently killed delivery to that chat (the
+    // multi-human-not-pushed bug). Now no row is dropped — every target is
+    // annotated with `actorAgentId` so Stage 3 excludes the actor from the
+    // notification addressing while the card still lands in every chat.
     const [humanRow] = await app.db.select({ name: agents.name }).from(agents).where(eq(agents.uuid, human)).limit(1);
     const audience = await resolveAudience(
       app.db,
@@ -646,8 +714,11 @@ describe("resolveAudience", () => {
       }),
       "first-tree",
     );
-    expect(audience).toHaveLength(1);
-    expect(audience[0]?.humanAgentId).toBe(otherHuman);
+    expect(audience).toHaveLength(2);
+    expect(new Set(audience.map((a) => a.humanAgentId))).toEqual(new Set([human, otherHuman]));
+    for (const target of audience) {
+      expect(target.actorAgentId).toBe(human);
+    }
   });
 
   it("keeps an involved-new row when actor self-mentions (explicit intent, not echo)", async () => {
@@ -694,17 +765,16 @@ describe("resolveAudience", () => {
     });
   });
 
-  it("self-mention in an already-subscribed entity stays silent (existing dropped, new skipped by subscribedKeys)", async () => {
-    // Documents the interaction between two filters when actor self-targets
-    // an entity they already subscribe to:
+  it("self-mention in an already-subscribed entity keeps the existing row, annotated (no fork, #942)", async () => {
+    // Actor self-targets an entity they already subscribe to:
     //   - the `subscribedKeys` short-circuit (resolveAudience) skips adding a
     //     `kind: "new"` row because (human, delegate) is already subscribed
-    //   - the actor-agent echo filter then drops the surviving `kind: "existing"`
-    //     row because the actor is on the human side
-    // Net result: audience is empty. This is *not* the explicit-intent path the
-    // sibling test covers — there's no new row to keep. Locking the behavior
-    // here so a future change that wants to nudge a subscribed delegate via
-    // self-mention has a clear anchor.
+    //   - the surviving `kind: "existing"` row is NOT dropped (#942): it is
+    //     annotated with `actorAgentId` so Stage 3 excludes the actor from
+    //     addressing. The card still lands; the delegate (≠ actor) is woken
+    //     normally — activity on a subscribed entity is real signal.
+    // Previously the actor-agent echo filter dropped this row, leaving an
+    // empty audience and silently swallowing the event.
     const app = getApp();
     const admin = await createTestAdmin(app);
     const delegate = await seedAgent(app, {
@@ -742,7 +812,14 @@ describe("resolveAudience", () => {
       "first-tree",
     );
 
-    expect(audience).toEqual([]);
+    expect(audience).toHaveLength(1);
+    expect(audience[0]).toMatchObject({
+      humanAgentId: human,
+      delegateAgentId: delegate,
+      kind: "existing",
+      chatId,
+      actorAgentId: human,
+    });
   });
 
   it("skips an involve whose delegate target is inactive (suspended/deleted)", async () => {

--- a/packages/server/src/__tests__/github-delivery.test.ts
+++ b/packages/server/src/__tests__/github-delivery.test.ts
@@ -117,6 +117,7 @@ describe("deliverNormalizedEvent", () => {
       chatId,
       involveReason: null,
       involveLogin: null,
+      actorAgentId: null,
     };
     const event = makeEvent({
       orgId: admin.organizationId,
@@ -186,6 +187,7 @@ describe("deliverNormalizedEvent", () => {
       chatId,
       involveReason: null,
       involveLogin: null,
+      actorAgentId: null,
     };
     const event = makeEvent({
       orgId: admin.organizationId,
@@ -207,6 +209,74 @@ describe("deliverNormalizedEvent", () => {
       .from(inboxEntries)
       .where(and(eq(inboxEntries.chatId, chatId), eq(inboxEntries.notify, true)));
     expect(delegateEntries).toHaveLength(0);
+  });
+
+  it("echo (#942): excludes the actor from addressing — card still written, actor not woken", async () => {
+    // The delegate is a live speaker of the bound chat, so it would normally
+    // be woken. When the delegate is ALSO the event's actor (its own GitHub
+    // action, surfaced as `target.actorAgentId`), #942 excludes it from
+    // `addressedToAgentIds`: the card still lands (public record) but the
+    // actor is not woken / red-dotted. With `actorAgentId = null` the same
+    // speaker-delegate IS woken — the two deliveries below pin both sides.
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const delegate = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-${randomUUID().slice(0, 6)}`,
+    });
+    const human = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `human-${randomUUID().slice(0, 6)}`,
+      delegateMention: delegate,
+    });
+    const chatId = `chat_${randomUUID()}`;
+    await app.db.insert(chats).values({ id: chatId, organizationId: admin.organizationId, type: "group" });
+    await app.db.insert(chatMembership).values([
+      { chatId, agentId: human, role: "owner", accessMode: "speaker", mode: "full", source: "manual" },
+      { chatId, agentId: delegate, role: "member", accessMode: "speaker", mode: "full", source: "manual" },
+    ]);
+    await app.db.insert(githubEntityChatMappings).values({
+      organizationId: admin.organizationId,
+      humanAgentId: human,
+      delegateAgentId: delegate,
+      entityType: "pull_request",
+      entityKey: "owner/repo#205",
+      chatId,
+      boundVia: "direct",
+    });
+    const baseTarget = {
+      humanAgentId: human,
+      delegateAgentId: delegate,
+      kind: "existing",
+      chatId,
+      involveReason: null,
+      involveLogin: null,
+    } satisfies Omit<AudienceTarget, "actorAgentId">;
+    const event = makeEvent({
+      orgId: admin.organizationId,
+      entityType: "pull_request",
+      entityKey: "owner/repo#205",
+    });
+
+    // (1) actor === delegate: excluded from addressing → card written, no wake.
+    const echoStats = await deliverNormalizedEvent(app, event, [{ ...baseTarget, actorAgentId: delegate }]);
+    expect(echoStats.delivered).toBe(1);
+    const afterEcho = await app.db
+      .select()
+      .from(inboxEntries)
+      .where(and(eq(inboxEntries.chatId, chatId), eq(inboxEntries.notify, true)));
+    expect(afterEcho).toHaveLength(0);
+
+    // (2) actor !== delegate (null): the speaker-delegate IS woken.
+    const okStats = await deliverNormalizedEvent(app, event, [{ ...baseTarget, actorAgentId: null }]);
+    expect(okStats.delivered).toBe(1);
+    const afterOk = await app.db
+      .select()
+      .from(inboxEntries)
+      .where(and(eq(inboxEntries.chatId, chatId), eq(inboxEntries.notify, true)));
+    expect(afterOk.length).toBeGreaterThan(0);
   });
 
   it("refreshes chats.topic to match the current entity title on each subsequent event for a github-bound chat", async () => {
@@ -250,6 +320,7 @@ describe("deliverNormalizedEvent", () => {
       chatId,
       involveReason: null,
       involveLogin: null,
+      actorAgentId: null,
     };
     const event = makeEvent({
       orgId: admin.organizationId,
@@ -304,6 +375,7 @@ describe("deliverNormalizedEvent", () => {
       chatId,
       involveReason: null,
       involveLogin: null,
+      actorAgentId: null,
     };
     const event = makeEvent({
       orgId: admin.organizationId,
@@ -372,6 +444,7 @@ describe("deliverNormalizedEvent", () => {
       chatId,
       involveReason: null,
       involveLogin: null,
+      actorAgentId: null,
     };
     const event = makeEvent({
       orgId: admin.organizationId,
@@ -416,6 +489,7 @@ describe("deliverNormalizedEvent", () => {
       chatId,
       involveReason: null,
       involveLogin: null,
+      actorAgentId: null,
     };
     const event = makeEvent({
       orgId: admin.organizationId,
@@ -451,6 +525,7 @@ describe("deliverNormalizedEvent", () => {
       chatId: null,
       involveReason: "review_requested",
       involveLogin: humanName.toLowerCase(),
+      actorAgentId: null,
     };
     const event = makeEvent({
       orgId: admin.organizationId,
@@ -525,6 +600,7 @@ describe("deliverNormalizedEvent", () => {
       chatId: null, // forces the runtime guard to throw
       involveReason: null,
       involveLogin: null,
+      actorAgentId: null,
     };
     const ok: AudienceTarget = {
       humanAgentId: goodHuman,
@@ -533,6 +609,7 @@ describe("deliverNormalizedEvent", () => {
       chatId: goodChatId,
       involveReason: null,
       involveLogin: null,
+      actorAgentId: null,
     };
     const event = makeEvent({
       orgId: admin.organizationId,
@@ -600,6 +677,7 @@ describe("deliverNormalizedEvent", () => {
       chatId,
       involveReason: null,
       involveLogin: null,
+      actorAgentId: null,
     };
     const event = makeEvent({
       orgId: admin.organizationId,

--- a/packages/server/src/services/github-audience.ts
+++ b/packages/server/src/services/github-audience.ts
@@ -35,8 +35,11 @@ export function evaluateDelegateTarget(
  * event). Three buckets:
  *
  *   - `agent`         — actor.login maps to one of this org's agents. Used
- *                       for echo suppression: the agent's own actions don't
- *                       fan back into their own chat.
+ *                       for echo suppression at the notification layer: the
+ *                       card still lands in every mapped chat (the public
+ *                       record of what happened), but the actor is excluded
+ *                       from the notify/addressing fan-out so agents aren't
+ *                       woken by their own actions. See #942.
  *   - `our-app-bot`   — actor is `<app-slug>[bot]`. The event is a downstream
  *                       effect of First Tree's own outbound write. `kind: "existing"`
  *                       targets are kept (so PRs the agent opens via First Tree's
@@ -91,6 +94,15 @@ export type AudienceTarget = {
    * mentioned" because two involves shared the same reason.
    */
   involveLogin: string | null;
+  /**
+   * Set when the event's actor resolves to an org agent (`identifyActor`
+   * returned `kind: "agent"`). Stage 3 excludes this id from the card's
+   * notification addressing (`addressedToAgentIds`) so the actor is never
+   * woken / red-dotted by their own action, while the card itself still
+   * lands in the chat as the public record (#942). `null` for our-app-bot
+   * and external actors.
+   */
+  actorAgentId: string | null;
 };
 
 /**
@@ -105,9 +117,14 @@ export type AudienceTarget = {
  * already subscribed, appends a `new` row.
  *
  * Echo filtering runs after the union:
- *   - actor = `agent`: rows where the actor sits on either the human or
- *     delegate side of an `existing` mapping are dropped. `kind: "new"`
- *     mention rows are kept (explicit involves are intentional routing).
+ *   - actor = `agent`: no row is dropped — every mapped chat keeps the card
+ *     as the public record of what happened. Instead, each row is annotated
+ *     with `actorAgentId` so Stage 3 excludes the actor from notification
+ *     addressing (the actor isn't woken / red-dotted by their own action,
+ *     other recipients are notified normally). Dropping rows here used to
+ *     conflate "should this chat get the card" with "should this recipient
+ *     be notified" and silently killed delivery to multi-participant chats
+ *     whose only routing entry had the actor on one side (#942).
  *   - actor = `our-app-bot`: `kind: "existing"` rows are kept so follow-up
  *     events on entities the agent opened still reach the chat through the
  *     subscription path; `kind: "new"` rows are dropped to avoid forking a
@@ -140,19 +157,28 @@ export async function resolveAudience(
       ),
     );
 
-  // Dedup subscribed rows by `humanAgentId` (keep earliest `bound_at`).
-  // After `resolveTargetChat` step (a.5) lands, the same `(human, entity)`
-  // pair can have multiple mapping rows pointing at the *same* chat (one
-  // per delegate that ever drove an event for this entity under this
-  // human). Without this dedup the audience loops the same chatId N times
-  // and `deliverNormalizedEvent` posts N identical cards. Sibling rows are
-  // guaranteed to share `chatId` because (a.5) always inserts using the
-  // human-scoped lookup's `chatId`, so collapsing them is loss-free.
-  const earliestByHuman = new Map<string, (typeof subscribedRows)[number]>();
+  // Dedup subscribed rows by `(humanAgentId, chatId)` (keep earliest
+  // `bound_at`). A single `(human, entity)` pair can carry multiple mapping
+  // rows pointing at the *same* chat (one per delegate that ever drove an
+  // event for this entity under this human); collapsing those to one row is
+  // loss-free and stops `deliverNormalizedEvent` posting N identical cards
+  // to that chat.
+  //
+  // The key MUST include `chatId`. Deduping by `humanAgentId` alone assumed
+  // every row for a human shared one chat — false once the same human is
+  // bound to the entity from more than one chat (e.g. a webhook
+  // `human_fallback` row in one chat plus an explicit `follow` row in
+  // another, each under a different delegate). Collapsing across chats kept
+  // only the earliest chat's row and silently dropped every *other* followed
+  // chat from the audience — that chat never received the entity's events at
+  // all. "The chat follows, not the person", so the surviving unit is one
+  // row per (human, chat), never one per human.
+  const earliestByHumanChat = new Map<string, (typeof subscribedRows)[number]>();
   for (const row of subscribedRows) {
-    const current = earliestByHuman.get(row.humanAgentId);
+    const key = `${row.humanAgentId}:${row.chatId}`;
+    const current = earliestByHumanChat.get(key);
     if (!current || row.boundAt < current.boundAt) {
-      earliestByHuman.set(row.humanAgentId, row);
+      earliestByHumanChat.set(key, row);
     }
   }
   // #766: A `pull_request.opened` delivery reaching a reviewer purely through
@@ -182,13 +208,14 @@ export async function resolveAudience(
     return row.humanAgentName !== null && involvedLogins.has(row.humanAgentName.toLowerCase());
   };
 
-  const subscribed: AudienceTarget[] = [...earliestByHuman.values()].filter(keepSubscribedOpened).map((row) => ({
+  const subscribed: AudienceTarget[] = [...earliestByHumanChat.values()].filter(keepSubscribedOpened).map((row) => ({
     humanAgentId: row.humanAgentId,
     delegateAgentId: row.delegateAgentId,
     kind: "existing",
     chatId: row.chatId,
     involveReason: null,
     involveLogin: null,
+    actorAgentId: null,
   }));
 
   // Dedup involved candidates by `humanAgentId` only — once any (human, *,
@@ -257,6 +284,7 @@ export async function resolveAudience(
         chatId: null,
         involveReason: reason,
         involveLogin: candidateLogin,
+        actorAgentId: null,
       });
     }
   }
@@ -275,17 +303,27 @@ export async function resolveAudience(
     return audience.filter((a) => a.kind === "existing");
   }
   if (actor.kind === "agent") {
-    // Echo suppression applies to subscribed rows only: a row where the
-    // actor is on either side of an existing mapping shouldn't fan back
-    // into their chat (they already know about the action they just took).
-    // `kind: "new"` rows come from explicit involves in the event payload
-    // (mention / review_request / assign) — the actor deliberately named
-    // that login, so even a self-target is intentional routing, not echo.
-    // Dropping them would regress the human-self-mention pattern that used
-    // to work under the pre-#345 mention-driven webhook.
-    return audience.filter(
-      (a) => a.kind === "new" || (a.humanAgentId !== actor.agentId && a.delegateAgentId !== actor.agentId),
-    );
+    // Echo suppression is a *notification* concern, not a delivery one
+    // (#942). Every mapped chat keeps its card — the chat row is the public
+    // record of what happened, and other participants of a multi-member
+    // chat legitimately want to see it. The actor's id is annotated onto
+    // every target so Stage 3 (`deliverNormalizedEvent`) excludes it from
+    // `addressedToAgentIds`: the actor is never woken / red-dotted by their
+    // own action, while everyone else is notified normally. A 1:1 chat where
+    // the actor is the sole addressable recipient reduces naturally to "card
+    // visible, nobody woken" via the existing `allowRecipientlessSend`
+    // trusted opt-out.
+    //
+    // The previous implementation dropped `kind: "existing"` rows whose
+    // human or delegate side matched the actor. When such a row was the
+    // chat's only routing entry, that silently killed delivery to the entire
+    // chat — multi-participant chats lost the event altogether. It also
+    // assumed `actor.login` identifies a single acting agent, which is
+    // unsound: agents act on GitHub under a human's GitHub identity, so
+    // identity-based echo cannot reliably tell an agent's own write from a
+    // human's. Notification-layer exclusion is best-effort — at worst it
+    // re-wakes the actor once; it never drops an event.
+    return audience.map((a) => ({ ...a, actorAgentId: actor.agentId }));
   }
   return audience;
 }

--- a/packages/server/src/services/github-delivery.ts
+++ b/packages/server/src/services/github-delivery.ts
@@ -94,6 +94,15 @@ export async function deliverNormalizedEvent(
       // and the multi-speaker fan-out collapses to notify=false for
       // everyone. Same pattern as any system-routed delivery (see
       // SendMessageOptions `addressedToAgentIds`).
+      //
+      // Echo suppression (#942): when the event's actor resolved to an org
+      // agent, exclude it from the addressing — nobody is woken / red-dotted
+      // by their own action. The card itself is still written (public
+      // record); when the exclusion empties the addressing this reduces to
+      // the recipientless trusted send below. The actor on the *human* side
+      // needs no exclusion here: it is the card's senderId and the message
+      // fan-out never self-delivers.
+      const addressedToAgentIds = [target.delegateAgentId].filter((id) => id !== target.actorAgentId);
       const { message, recipients } = await sendMessage(
         app.db,
         resolved.chatId,
@@ -121,7 +130,7 @@ export async function deliverNormalizedEvent(
           },
         },
         {
-          addressedToAgentIds: [target.delegateAgentId],
+          addressedToAgentIds,
           // Opt in to writing `metadata.systemSender` — the message service
           // strips that key from every other caller (web / agent SDK POST)
           // so HTTP boundaries cannot impersonate the GitHub sender in the
@@ -130,8 +139,10 @@ export async function deliverNormalizedEvent(
           // Opt out of the default explicit-recipient guard. This trusted
           // system delivery owns and validates its own addressing
           // (`addressedToAgentIds` derived from the resolved audience row),
-          // but the delegate may not be a speaker of the bound chat on some
-          // events, so the addressing resolves to no live recipient. Such a
+          // but on some events the addressing resolves to no live recipient:
+          // the delegate may not be a speaker of the bound chat, or the
+          // delegate IS the event's actor and was excluded by echo
+          // suppression (#942, the empty-filter case above). Such a
           // card is still a valid history/context row for human observers;
           // without this opt-out the default guard would make this trusted path
           // start throwing. (A delegate that IS a speaker but suspended/deleted


### PR DESCRIPTION
## Summary
Fixes the "followed chat never receives GitHub events" bug — a refactor chat that `github follow`-ed a PR never got woken by reviewers' comments. Two **decoupled** fixes in the webhook → chat audience/delivery path:

- **M2 — audience dedup by `(human, chat)`, not `human`** (`github-audience.ts`). `resolveAudience` collapsed subscribed rows by `humanAgentId` alone, assuming all of a human's rows share one chat. When the same human is bound to an entity from two chats (a webhook `human_fallback` row in one chat + an explicit `follow` row in another, under different delegates), the dedup kept only the earliest chat and **silently dropped every other followed chat** from the audience. This is the confirmed root cause of the reported bug.
- **B — echo suppression moved to the notification layer, decoupled from delegate** (reuses unmerged `origin/fix/issue-942-audience-echo-suppression`). The old `kind:"agent"` filter dropped whole audience rows whose human/delegate matched the actor; when that was a chat's only routing row, the chat lost the event entirely. It also relied on `actor.login` identifying a single acting agent — unsound, since agents act on GitHub under a human's GitHub identity. Now every target is annotated with `actorAgentId` and `deliverNormalizedEvent` excludes the actor from `addressedToAgentIds`: the card always lands (public record), the actor is never woken by its own action, everyone else is notified normally.

**Safety invariant** established by this change: *echo & dedup may never drop a followed chat or a card; echo's strongest action is removing the acting agent from one card's wake-set.*

## Follow-ups (separate PRs)
- **M3** — delivery must fall back to the chat's live speakers instead of silently recipientless when the stored delegate is not a live speaker (renegotiates the `e20f0dec` recipientless test).
- **D** (optional) — de-fabricate the `(human, delegate)` pair; the representative-human becomes cosmetic only.

## Test plan
- [x] `pnpm --filter @first-tree/server typecheck`
- [x] `biome check` on changed files
- [x] `vitest run github-audience github-delivery` — all pass (32 + new)
- [x] New tests: M2 cross-chat non-collapse; echo annotates instead of dropping (audience); echo excludes actor from addressing while card still lands (delivery)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)