### PR TITLE
test(server): combined M2+echo regression for the multi-human-not-pushed bug

### DIFF
--- a/packages/server/src/__tests__/github-delivery.test.ts
+++ b/packages/server/src/__tests__/github-delivery.test.ts
@@ -8,7 +8,7 @@ import { chats } from "../db/schema/chats.js";
 import { githubEntityChatMappings } from "../db/schema/github-entity-chat-mappings.js";
 import { inboxEntries } from "../db/schema/inbox-entries.js";
 import { messages } from "../db/schema/messages.js";
-import type { AudienceTarget } from "../services/github-audience.js";
+import { type AudienceTarget, resolveAudience } from "../services/github-audience.js";
 import { deliverNormalizedEvent } from "../services/github-delivery.js";
 import { createTestAdmin, useTestApp } from "./helpers.js";
 
@@ -54,6 +54,7 @@ function makeEvent(opts: {
   rawEventType?: string;
   rawAction?: string;
   title?: string;
+  actorLogin?: string;
 }): NormalizedEvent {
   return {
     source: { kind: "github-app-installation", installationId: 1, organizationId: opts.orgId },
@@ -67,7 +68,7 @@ function makeEvent(opts: {
       title: opts.title ?? "Refactor inbox",
       url: `https://github.com/owner/repo/pull/1`,
     },
-    actor: { githubLogin: "alice", isBot: false },
+    actor: { githubLogin: opts.actorLogin ?? "alice", isBot: false },
     kind: "opened",
     involves: opts.involves ?? [],
     surface: {
@@ -707,5 +708,132 @@ describe("deliverNormalizedEvent", () => {
     // Other group speakers stay silent (history-only) — exactly the
     // mention-only behaviour for unaddressed participants.
     expect(watcherRow?.notify).toBe(false);
+  });
+
+  it("M2 + echo combined: actor is the represented human, entity bound from two chats — both wake their delegate (regression)", async () => {
+    // Single fixture that lights up BOTH old defects at once — the exact shape
+    // of the multi-human-not-pushed bug, which only manifests when they stack:
+    //   - old M2 (dedup by `humanAgentId`, keep earliest) dropped the LATER
+    //     chat (chatB) — bound_at order is load-bearing;
+    //   - old echo (actor on the human side → drop the whole row) then dropped
+    //     chatA too, since the actor IS chatA's represented human.
+    // Old code → empty audience → both chats silent. This pins the fix end to
+    // end: drives `resolveAudience` → `deliverNormalizedEvent` and asserts both
+    // chats not only re-enter the audience but each delegate (≠ actor) is
+    // actually woken — a pure audience-layer assertion cannot prove the wake.
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const humanName = `rep-human-${randomUUID().slice(0, 6)}`;
+    const human = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: humanName,
+    });
+    const da = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-a-${randomUUID().slice(0, 6)}`,
+    });
+    const db = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-b-${randomUUID().slice(0, 6)}`,
+    });
+
+    const chatA = `chat_${randomUUID()}`;
+    const chatB = `chat_${randomUUID()}`;
+    await app.db.insert(chats).values([
+      { id: chatA, organizationId: admin.organizationId, type: "group" },
+      { id: chatB, organizationId: admin.organizationId, type: "group" },
+    ]);
+    // H speaks in both; each chat's delegate is a speaker so it can be woken.
+    await app.db.insert(chatMembership).values([
+      { chatId: chatA, agentId: human, role: "owner", accessMode: "speaker", mode: "full", source: "manual" },
+      { chatId: chatA, agentId: da, role: "member", accessMode: "speaker", mode: "full", source: "manual" },
+      { chatId: chatB, agentId: human, role: "owner", accessMode: "speaker", mode: "full", source: "manual" },
+      { chatId: chatB, agentId: db, role: "member", accessMode: "speaker", mode: "full", source: "manual" },
+    ]);
+    // chatA bound EARLIER, chatB LATER — old dedup-by-human kept chatA, dropped chatB.
+    await app.db.insert(githubEntityChatMappings).values([
+      {
+        organizationId: admin.organizationId,
+        humanAgentId: human,
+        delegateAgentId: da,
+        entityType: "pull_request",
+        entityKey: "owner/repo#777",
+        chatId: chatA,
+        boundVia: "human_fallback",
+        boundAt: new Date(Date.now() - 60_000),
+      },
+      {
+        organizationId: admin.organizationId,
+        humanAgentId: human,
+        delegateAgentId: db,
+        entityType: "pull_request",
+        entityKey: "owner/repo#777",
+        chatId: chatB,
+        boundVia: "agent_declared",
+        boundAt: new Date(),
+      },
+    ]);
+
+    // `synchronize` (not `opened`) so the #766 opened-card carve-out cannot interfere.
+    const event = makeEvent({
+      orgId: admin.organizationId,
+      entityType: "pull_request",
+      entityKey: "owner/repo#777",
+      actorLogin: humanName,
+      rawAction: "synchronize",
+    });
+
+    // Stage 2: both chats survive. M2 keeps the (human, chat) pairs distinct;
+    // echo annotates `actorAgentId = H` on every row instead of dropping any.
+    const audience = await resolveAudience(app.db, event, "first-tree");
+    expect(audience).toHaveLength(2);
+    expect(new Set(audience.map((a) => a.chatId))).toEqual(new Set([chatA, chatB]));
+    for (const target of audience) expect(target.actorAgentId).toBe(human);
+
+    // Stage 3: both cards land AND each chat's delegate (≠ actor) is woken.
+    const stats = await deliverNormalizedEvent(app, event, audience);
+    expect(stats.delivered).toBe(2);
+
+    const [daRow] = await app.db.select({ inboxId: agents.inboxId }).from(agents).where(eq(agents.uuid, da)).limit(1);
+    const [dbRow] = await app.db.select({ inboxId: agents.inboxId }).from(agents).where(eq(agents.uuid, db)).limit(1);
+    const [hRow] = await app.db.select({ inboxId: agents.inboxId }).from(agents).where(eq(agents.uuid, human)).limit(1);
+
+    // chatA: card written + Da woken.
+    expect(await app.db.select().from(messages).where(eq(messages.chatId, chatA))).toHaveLength(1);
+    const daWoken = await app.db
+      .select()
+      .from(inboxEntries)
+      .where(
+        and(
+          eq(inboxEntries.chatId, chatA),
+          eq(inboxEntries.notify, true),
+          eq(inboxEntries.inboxId, daRow?.inboxId ?? ""),
+        ),
+      );
+    expect(daWoken.length).toBeGreaterThan(0);
+
+    // chatB: card written + Db woken — chatB is the chat the OLD dedup silently dropped.
+    expect(await app.db.select().from(messages).where(eq(messages.chatId, chatB))).toHaveLength(1);
+    const dbWoken = await app.db
+      .select()
+      .from(inboxEntries)
+      .where(
+        and(
+          eq(inboxEntries.chatId, chatB),
+          eq(inboxEntries.notify, true),
+          eq(inboxEntries.inboxId, dbRow?.inboxId ?? ""),
+        ),
+      );
+    expect(dbWoken.length).toBeGreaterThan(0);
+
+    // The actor (== represented human H) is never woken by its own action.
+    const hWoken = await app.db
+      .select()
+      .from(inboxEntries)
+      .where(and(eq(inboxEntries.notify, true), eq(inboxEntries.inboxId, hRow?.inboxId ?? "")));
+    expect(hWoken).toHaveLength(0);
   });
 });


### PR DESCRIPTION
Follow-up to #1064 (code-reviewer's suggestion ①): one fixture that ignites **both** old defects at once, locking the exact regression #1064 fixed.

## The fixture
One human **H** (`agents.name == actor login`), the same entity bound from **two chats** — chatA (`bound_at` earlier, delegate Da) and chatB (`bound_at` later, delegate Db) — and the event **actor = H**. Da/Db/H distinct; Da speaks in chatA, Db in chatB.

On the **old** code both mechanisms stacked:
- old M2 (dedup by `humanAgentId`, keep earliest) dropped **chatB**;
- old echo (actor on the human side → drop the whole row) dropped **chatA** too;
- → empty audience → both chats silent (the real `1d2f3012` shape).

## What it asserts (delivery/inbox seam, not just audience)
Drives `resolveAudience` → `deliverNormalizedEvent` and checks:
1. audience keeps **both** chats, each annotated `actorAgentId = H`;
2. both chats get a card;
3. **Da is woken in chatA, Db in chatB** (inbox `notify=true`) — the swallowed chat's delegate (≠ actor) actually wakes;
4. the actor H is never self-woken.

A pure audience-layer assertion only proves the row survives, not the wake — so the check runs at delivery/inbox.

Test-only; `typecheck` / `biome` / `vitest github-delivery` (11 passed) green locally. Durable constraint already recorded in first-tree-context#523 (S7).