### PR TITLE
fix(client): make TUI First Tree skill loading actionable

### DIFF
--- a/packages/client/src/__tests__/agent-briefing.test.ts
+++ b/packages/client/src/__tests__/agent-briefing.test.ts
@@ -325,6 +325,12 @@ describe("buildAgentBriefing — # Required Reading (unconditional skill-load ma
     expect(briefing).toMatch(/you MUST\s+load both skills below/);
     expect(briefing).toContain("**`first-tree`**");
     expect(briefing).toContain("**`first-tree-context`**");
+    // Claude Code's transcript exposes a skill listing, but native skill-body
+    // injection is still provider-owned. The briefing must give a direct
+    // filesystem fallback so "unconditional" is actionable even when the
+    // provider only listed the skill names.
+    expect(briefing).toContain(`${AGENT_HOME}/.agents/skills/first-tree/SKILL.md`);
+    expect(briefing).toContain(`${AGENT_HOME}/.agents/skills/first-tree-context/SKILL.md`);
     // Bootstrapping framing — the mandate IS the first step of the
     // skill-described pre-task hygiene, not "even before" those
     // checks (which would be self-contradictory: you can't run the

--- a/packages/client/src/handlers/claude-code-tui/index.ts
+++ b/packages/client/src/handlers/claude-code-tui/index.ts
@@ -9,6 +9,7 @@ import type { PredeclaredSourceRepo } from "../../runtime/bootstrap.js";
 import { type ChatContext, fetchChatContext } from "../../runtime/chat-context.js";
 import { createContextTreeGitWriteTracker } from "../../runtime/context-tree-git-status.js";
 import type { AgentHandler, HandlerFactory, SessionContext, SessionMessage } from "../../runtime/handler.js";
+import { materializeResourceSkills } from "../../runtime/resource-skills.js";
 import { currentSourceRepoNamesFromPayload, declaredSourceRepos } from "../../runtime/source-repos.js";
 import { acquireAgentHome, markWorkspaceInitComplete } from "../../runtime/workspace.js";
 import { createToolCallProcessor, mapMcpServers } from "../claude-code.js";
@@ -560,6 +561,7 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
         // Pure declaration — the agent itself clones/refreshes the repos per
         // its briefing protocol; the listed paths may not exist yet.
         sourceReposForPrompt = declaredSourceRepos(cwd, payload);
+        await materializeResourceSkills(cwd, payload, sessionCtx);
         ensureAgentBootstrap({
           workspace: cwd,
           sessionCtx,
@@ -605,6 +607,7 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
         chatContextForPrompt = await fetchChatContextOrLog(sessionCtx);
         // Pure declaration — same as the start() path.
         sourceReposForPrompt = declaredSourceRepos(cwd, payload);
+        await materializeResourceSkills(cwd, payload, sessionCtx);
         // Same shared bootstrap as start(): ensureAgentBootstrap handles the
         // sentinel + CLI-version drift internally, so a stale or failed
         // integration is re-run on resume instead of being skipped.

--- a/packages/client/src/runtime/agent-briefing.ts
+++ b/packages/client/src/runtime/agent-briefing.ts
@@ -120,7 +120,7 @@ export function buildAgentBriefing(opts: BuildAgentBriefingOptions): string {
   // skill payloads installed on disk (`installFirstTreeIntegration`
   // is short-circuited in `agent-bootstrap.ts`), so mandating a load
   // would point at files that don't exist.
-  const requiredReading = requiredReadingSection(opts.contextTreePath);
+  const requiredReading = requiredReadingSection(opts.contextTreePath, opts.workspacePath);
   if (requiredReading) sections.push(requiredReading);
 
   sections.push(
@@ -285,8 +285,10 @@ prompt.*`,
  * `agent-bootstrap.ts`). Telling a tree-less agent to load them would
  * point at files that aren't there.
  */
-function requiredReadingSection(contextTreePath: string | null): string | null {
+function requiredReadingSection(contextTreePath: string | null, workspacePath: string): string | null {
   if (contextTreePath === null) return null;
+  const firstTreeSkillPath = `${workspacePath}/.agents/skills/first-tree/SKILL.md`;
+  const contextSkillPath = `${workspacePath}/.agents/skills/first-tree-context/SKILL.md`;
   return `# Required Reading (First Tree Managed)
 
 Before responding to any non-trivial instruction in this chat, you MUST
@@ -306,6 +308,13 @@ workspace-collab basics.
 2. **\`first-tree-context\`** — what a Context Tree is, the
    source-system boundary, authorship read-discipline, and the Hard
    Rules + Double Test that govern every tree write.
+
+If your runtime does not automatically inject the full skill body after
+selecting a skill from the skill listing, read the local payload files
+directly before acting:
+
+- \`${firstTreeSkillPath}\`
+- \`${contextSkillPath}\`
 
 These two are unconditional. The remaining First Tree skills
 (\`first-tree-read\`, \`first-tree-sync\`) load on demand based on the


### PR DESCRIPTION
## Summary

- Add explicit local skill-body fallback paths to the generated Required Reading section for tree-bound agents.
- Materialize resource skills during `claude-code-tui` start/resume, matching the SDK Claude handler path.
- Extend briefing tests to assert the fallback paths are present.

## Root Cause

Real Claude Code TUI transcripts showed the TUI had the correct workspace cwd, loaded project settings, and received a `skill_listing` containing the First Tree skills. The missing piece was that the generated briefing only mandated loading `first-tree` and `first-tree-context` by name; it did not provide an actionable local file path when Claude Code listed skills without injecting or reading the skill body.

## Validation

- `pnpm --filter @first-tree/client exec vitest run src/__tests__/agent-briefing.test.ts src/__tests__/resource-skills.test.ts src/__tests__/tui-claude-command.test.ts` passed: 3 files / 41 tests.
- `pnpm --filter @first-tree/client exec vitest run src/__tests__/codex-binary.test.ts` passed: 1 file / 8 tests. This reran the single unrelated timeout from the broader suite.
- `pnpm --filter @first-tree/client typecheck` passed.
- `pnpm build` passed. Existing warnings only: CSS optimizer warning for `.rounded-[var(--radius-*)]`, Vite chunk-size warning, and tsdown deprecated option warnings.
- `git diff --check` passed.

Broader client suite note: `pnpm --filter @first-tree/client test -- agent-briefing.test.ts resource-skills.test.ts tui-claude-command.test.ts` still invokes the full client suite in this repo shape. It ran 96/97 test files cleanly, then one unrelated `codex-binary.test.ts` case timed out on `codex --version`; the same file passed immediately when rerun directly.

## QA And Review Notes

- QA reproduced the pre-fix condition from a real yzw-assistant Claude TUI transcript and marked the candidate fix as scoped PASS.
- QA did not mark this as a full fresh real-candidate-runtime PASS because no fresh real Claude TUI turn was launched from a candidate daemon.
- I ran a manual self-adversarial review against bootstrap ordering, tree-less behavior, path correctness, resource skill pruning, prompt-cache behavior, and test adequacy. No blocker found.
- Attempted to run Codex CLI adversarial challenge, but local Codex CLI is currently blocked: `~/.codex/config.toml` uses unsupported `service_tier = "priority"`; with `--ignore-user-config`, the ChatGPT account rejected tested model names (`gpt-5.3-codex`, `gpt-5.1-codex`, `gpt-5-codex`, `gpt-5.2`, `gpt-5.1`, `gpt-5`).