### PR TITLE
refactor(client): drop dead managed.json sourceRepos field

### DIFF
--- a/docs/development/agent-workspace-state.md
+++ b/docs/development/agent-workspace-state.md
@@ -27,7 +27,7 @@ sit on disk forever. The state files below are that record.
 
 | Path (relative to workspace root) | Owner | What it is |
 | --- | --- | --- |
-| `.first-tree-workspace/managed.json` | `runtime/managed-state.ts` | Schema-versioned record of the CLI-managed resources currently materialised in this workspace. The live array is `skills` (skill names), diffed on every session start to discover removals. `sourceRepos` is a legacy field — no current code writes or reconciles it (source repos are agent-managed). |
+| `.first-tree-workspace/managed.json` | `runtime/managed-state.ts` | Schema-versioned record of the CLI-managed resources currently materialised in this workspace. Holds one array — `skills` (skill names) — diffed on every session start to discover removals. (Source repos and the Context Tree clone are agent-managed; the runtime never deletes a repo clone, so they carry no entry here. A legacy record that still has the retired `sourceRepos` key is read-compatible — the reader ignores unknown keys.) |
 | `.first-tree-workspace/migrations-applied.json` | `runtime/workspace-migrations.ts` | Set of one-shot directory-structure migration ids that have already run in this workspace. Each migration runs at most once even if it's later removed from the registry; the marker stays as forward protection. |
 
 Both files use atomic writes (temp + rename) so a crashed writer never
@@ -40,13 +40,10 @@ leaves a half-formed JSON record on disk.
   "schemaVersion": 1,
   "cliVersion": "0.3.2",
   "updatedAt": "2026-06-08T15:50:00.000Z",
-  "sourceRepos": ["first-tree", "first-tree-context"],
   "skills": ["first-tree", "first-tree-context", "first-tree-read", "first-tree-sync", "first-tree-seed"]
 }
 ```
 
-- **`sourceRepos`** — the `localPath` of each repo from `payload.gitRepos`
-  the CLI cloned at workspace top level.
 - **`skills`** — the names of skills installed under
   `<workspace>/.agents/skills/<name>/` (with matching `.claude/skills/<name>`
   symlinks).

--- a/packages/client/src/__tests__/managed-state.test.ts
+++ b/packages/client/src/__tests__/managed-state.test.ts
@@ -31,7 +31,6 @@ describe("managed-state", () => {
       schemaVersion: 1,
       cliVersion: "0.3.2",
       updatedAt: "2026-06-08T16:00:00.000Z",
-      sourceRepos: ["first-tree", "first-tree-context"],
       skills: ["first-tree", "first-tree-context", "first-tree-sync"],
     };
     writeManagedState(workspace, state);
@@ -44,64 +43,68 @@ describe("managed-state", () => {
   });
 
   it("returns null when schemaVersion is not 1", () => {
-    writeFileSync(
-      join(workspace, MANAGED_STATE_REL),
-      JSON.stringify({ schemaVersion: 2, sourceRepos: [], skills: [] }),
-      "utf-8",
-    );
+    writeFileSync(join(workspace, MANAGED_STATE_REL), JSON.stringify({ schemaVersion: 2, skills: [] }), "utf-8");
     expect(readManagedState(workspace)).toBeNull();
   });
 
-  it("coerces non-string array entries to empty (defensive read)", () => {
+  it("filters non-string entries out of the skills array (defensive read)", () => {
     writeFileSync(
       join(workspace, MANAGED_STATE_REL),
       JSON.stringify({
         schemaVersion: 1,
         cliVersion: null,
         updatedAt: "2026-06-08T16:00:00.000Z",
-        // Intentionally garbage values to confirm the read filter:
-        sourceRepos: ["first-tree", 42, null, "first-tree-context"],
+        // Intentionally garbage entries to confirm the read filter:
+        skills: ["first-tree", 42, null, "first-tree-context"],
+      }),
+      "utf-8",
+    );
+    expect(readManagedState(workspace)?.skills).toEqual(["first-tree", "first-tree-context"]);
+  });
+
+  it("coerces a non-array skills value to [] (defensive read)", () => {
+    writeFileSync(
+      join(workspace, MANAGED_STATE_REL),
+      JSON.stringify({
+        schemaVersion: 1,
+        cliVersion: null,
+        updatedAt: "2026-06-08T16:00:00.000Z",
         skills: "not-an-array",
       }),
       "utf-8",
     );
-    const result = readManagedState(workspace);
-    expect(result?.sourceRepos).toEqual(["first-tree", "first-tree-context"]);
-    expect(result?.skills).toEqual([]);
+    expect(readManagedState(workspace)?.skills).toEqual([]);
   });
 
   it("updateManagedState applies the mutator and persists the result", () => {
     const result = updateManagedState(workspace, "1.2.3", (current) => ({
       ...current,
-      sourceRepos: ["alpha", "beta"],
+      skills: ["alpha", "beta"],
     }));
-    expect(result.sourceRepos).toEqual(["alpha", "beta"]);
+    expect(result.skills).toEqual(["alpha", "beta"]);
     expect(result.cliVersion).toBe("1.2.3");
     expect(result.schemaVersion).toBe(1);
 
     const readBack = readManagedState(workspace);
-    expect(readBack?.sourceRepos).toEqual(["alpha", "beta"]);
+    expect(readBack?.skills).toEqual(["alpha", "beta"]);
     expect(readBack?.cliVersion).toBe("1.2.3");
   });
 
-  it("updateManagedState preserves untouched fields across calls", () => {
+  it("updateManagedState preserves skills across a later no-op update", () => {
     updateManagedState(workspace, "1.2.3", (current) => ({
       ...current,
-      sourceRepos: ["first-tree"],
+      skills: ["first-tree", "first-tree-context"],
     }));
-    updateManagedState(workspace, "1.2.3", (current) => ({
-      ...current,
-      skills: ["first-tree-context"],
-    }));
+    updateManagedState(workspace, "1.2.3", (current) => current);
     const final = readManagedState(workspace);
-    expect(final?.sourceRepos).toEqual(["first-tree"]);
-    expect(final?.skills).toEqual(["first-tree-context"]);
+    expect(final?.skills).toEqual(["first-tree", "first-tree-context"]);
+    expect(final?.cliVersion).toBe("1.2.3");
   });
 
   it("updateManagedState refreshes updatedAt on every call", async () => {
     const first = updateManagedState(workspace, null, (current) => ({
       ...current,
-      sourceRepos: ["alpha"],
+      skills: ["alpha"],
     }));
     // Sleep a hair so the ISO timestamps differ even on fast machines.
     await new Promise((resolve) => setTimeout(resolve, 5));
@@ -115,7 +118,6 @@ describe("managed-state", () => {
       schemaVersion: 1,
       cliVersion: null,
       updatedAt: new Date().toISOString(),
-      sourceRepos: [],
       skills: [],
     };
     writeManagedState(workspace, state);
@@ -131,7 +133,6 @@ describe("managed-state", () => {
       schemaVersion: 1,
       cliVersion: "x",
       updatedAt: "y",
-      sourceRepos: [],
       skills: [],
     });
     const raw = readFileSync(join(workspace, MANAGED_STATE_REL), "utf-8");

--- a/packages/client/src/__tests__/skills-state-reconcile.test.ts
+++ b/packages/client/src/__tests__/skills-state-reconcile.test.ts
@@ -70,7 +70,6 @@ describe("installFirstTreeSkills — state-based skill reconcile (PR #869 P1-3)"
       schemaVersion: 1,
       cliVersion: "test",
       updatedAt: new Date(0).toISOString(),
-      sourceRepos: [],
       skills: [...TREE_SKILL_NAMES, "legacy-foo", "legacy-bar"],
     });
 
@@ -102,7 +101,6 @@ describe("installFirstTreeSkills — state-based skill reconcile (PR #869 P1-3)"
       schemaVersion: 1,
       cliVersion: "test",
       updatedAt: new Date(0).toISOString(),
-      sourceRepos: [],
       skills: [...TREE_SKILL_NAMES], // does NOT include "my-custom"
     });
 

--- a/packages/client/src/__tests__/workspace-migrations.test.ts
+++ b/packages/client/src/__tests__/workspace-migrations.test.ts
@@ -76,8 +76,7 @@ describe("workspace-migrations registry", () => {
         schemaVersion: 1,
         cliVersion: "test",
         updatedAt: new Date().toISOString(),
-        sourceRepos: ["first-tree"],
-        skills: [],
+        skills: ["first-tree"],
       }),
     );
 
@@ -103,25 +102,20 @@ describe("workspace-migrations registry", () => {
     expect(existsSync(join(userUuidDir, "user-data.json"))).toBe(true);
   });
 
-  it("v1-uuid-snapshots leaves a UUID-named directory that's currently in source_repos config (PR #869 P0)", () => {
+  it("v1-uuid-snapshots leaves a UUID-named directory that's currently in source-repo config (PR #869 P0)", () => {
     // Edge case: agent config has a `gitRepos.localPath` shaped like a UUID.
     // The migration must NOT delete it even when it has a top-level
-    // AGENTS.md (e.g. the cloned repo happens to ship one).
+    // AGENTS.md (e.g. the cloned repo happens to ship one) — the live
+    // `currentSourceRepoNames` set spares any UUID dir still in config.
     const uuidRepo = join(workspace, "fedcba98-7654-4321-9abc-def012345678");
     mkdirSync(uuidRepo);
     writeFileSync(join(uuidRepo, "AGENTS.md"), "# this repo happens to ship AGENTS.md\n");
-    writeFileSync(
-      join(workspace, ".first-tree-workspace", "managed.json"),
-      JSON.stringify({
-        schemaVersion: 1,
-        cliVersion: "test",
-        updatedAt: new Date().toISOString(),
-        sourceRepos: ["fedcba98-7654-4321-9abc-def012345678"],
-        skills: [],
-      }),
-    );
 
-    applyPendingMigrations(workspace, () => {});
+    // Resolved config (non-null) so the migration RUNS rather than deferring;
+    // the UUID dir is spared because it's the agent's current source repo.
+    applyPendingMigrations(workspace, () => {}, {
+      currentSourceRepoNames: new Set(["fedcba98-7654-4321-9abc-def012345678"]),
+    });
 
     expect(existsSync(uuidRepo)).toBe(true);
   });

--- a/packages/client/src/runtime/managed-state.ts
+++ b/packages/client/src/runtime/managed-state.ts
@@ -2,13 +2,16 @@
 // agent workspace. Used by the next session start to detect "previously
 // managed but no longer in current config" → delete.
 //
-// Scope is deliberately narrow: a list of source-repo localPaths and a list
-// of skill names. Anything else CLI puts in the workspace (AGENTS.md,
-// .first-tree-workspace/identity.json, .claude/skills symlinks, etc.) is owned by other
-// flows and not tracked here.
+// Scope is deliberately narrow: a list of skill names. Anything else CLI
+// puts in the workspace (AGENTS.md, .first-tree-workspace/identity.json,
+// .claude/skills symlinks, etc.) is owned by other flows and not tracked
+// here. (Source repos and the Context Tree clone are agent-managed; the
+// runtime never deletes a repo clone, so they carry no managed-state entry.
+// A legacy record that still carries the retired `sourceRepos` key reads
+// fine — the reader ignores unknown keys and keeps `schemaVersion` at 1.)
 //
 // Path-level precision: the diff is "prev∖current" → delete. The flip side
-// (paths in `current` and not in `prev`) is handled by the existing
+// (names in `current` and not in `prev`) is handled by the existing
 // installer (`installFirstTreeSkills`), which already (re)materialises
 // everything it expects to be present.
 
@@ -47,9 +50,6 @@ export type ManagedState = {
   cliVersion: string | null;
   /** ISO timestamp of the last write. */
   updatedAt: string;
-  /** Source-repo `localPath` names (relative to workspace root) the CLI
-   *  cloned at workspace top level. */
-  sourceRepos: string[];
   /** Skill names currently installed under `.agents/skills/<name>/` (and
    *  symlinked at `.claude/skills/<name>`). */
   skills: string[];
@@ -73,11 +73,10 @@ export function readManagedState(workspacePath: string): ManagedState | null {
   if (typeof parsed !== "object" || parsed === null) return null;
   const record = parsed as Record<string, unknown>;
   if (record.schemaVersion !== 1) return null;
-  const sourceRepos = readStringArray(record.sourceRepos);
   const skills = readStringArray(record.skills);
   const cliVersion = typeof record.cliVersion === "string" ? record.cliVersion : null;
   const updatedAt = typeof record.updatedAt === "string" ? record.updatedAt : new Date(0).toISOString();
-  return { schemaVersion: 1, cliVersion, updatedAt, sourceRepos, skills };
+  return { schemaVersion: 1, cliVersion, updatedAt, skills };
 }
 
 function readStringArray(value: unknown): string[] {
@@ -131,7 +130,6 @@ export function updateManagedState(
     schemaVersion: 1,
     cliVersion,
     updatedAt: new Date(0).toISOString(),
-    sourceRepos: [],
     skills: [],
   };
   const next = mutator(current);

--- a/packages/client/src/runtime/workspace-migrations.ts
+++ b/packages/client/src/runtime/workspace-migrations.ts
@@ -162,7 +162,7 @@ function hasLegacySnapshotSignature(dir: string): boolean {
  * "Yes" only when the live `ctx.currentSourceRepoNames` is non-null — the
  * caller resolved a payload from the server / cache for this session. When
  * it's `null` (cache miss, default-payload fallback), callers MUST return
- * `"deferred"`: persisted `.first-tree-workspace/managed.json::sourceRepos` proves a
+ * `"deferred"`: a prior session's persisted state proves a
  * PREVIOUS config, not the current one, and falling back to it after a
  * fresh config edit (web-console add + immediate cache miss on the next
  * start) is the same "unknown config looks authoritative" deletion class


### PR DESCRIPTION
## Summary

`managed.json` (`.first-tree-workspace/managed.json`) carries a `sourceRepos` array that has been a **no-op since the agent-managed-repos refactor (#1048)**. Under the agent-managed model the runtime declares + observes but never clones / fetches / reconciles / deletes a source-repo clone, so no code writes or reads `ManagedState.sourceRepos` anymore. Only the `skills` array is still live (skill-install reconcile).

This removes the dead field and its references:

- `ManagedState` type, `readManagedState`, and the `updateManagedState` default no longer carry `sourceRepos`.
- `docs/development/agent-workspace-state.md` schema doc updated.
- Test fixtures in `managed-state.test.ts`, `skills-state-reconcile.test.ts`, `workspace-migrations.test.ts` updated.

**Read-compatible, no schema bump:** `schemaVersion` stays `1` and `readManagedState` already ignores unknown keys, so an existing `managed.json` still carrying `sourceRepos` reads fine — the stale key is simply dropped on the next write. (Bumping to `2` would make readers reject every existing v1 record as "first run" and lose `skills` tracking for a cycle — not worth it for a read-compatible change.)

**Drive-by test fix:** the `workspace-migrations` "UUID dir still in source-repo config" test was passing only via *deferral* (it called `applyPendingMigrations` with no ctx), not via config-based sparing — its fixture wrote the now-removed `sourceRepos` key but the migration spares on `ctx.currentSourceRepoNames`. It now passes a resolved `currentSourceRepoNames` set so it exercises the real spare path.

Not touched: the unrelated `sourceRepos` / `sourceReposForPrompt` fields in the briefing (`agent-briefing.ts`), handlers, and web onboarding — those are the live `PredeclaredSourceRepo` coordinates, a different concept.

Context: companion to the agent-managed-repos model recorded in first-tree-context#506. No tree change needed — this is implementation cleanup consistent with the already-recorded decision; no tree node references the field.

## Test plan

- [x] `pnpm --filter @first-tree/client typecheck` — clean
- [x] `vitest run managed-state workspace-migrations skills-state-reconcile` — 40 passed
- [x] `biome check` on changed files — exit 0 (pre-existing `noConfusingVoidType` warning at `workspace-migrations.ts:90` is on `main`, untouched)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)