### PR TITLE
Limit chat auto-archive to GitHub-sourced chats

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -660,10 +660,10 @@ Old per-route rate-limit env vars are no longer read.
 | `FIRST_TREE_WS_MAX_PAYLOAD` | `262144` (256 KiB) |
 | `FIRST_TREE_ARCHIVE_SWEEP_INTERVAL_SECONDS` | `300` (set `0` to disable) |
 | `FIRST_TREE_ARCHIVE_MAPPED_IDLE_SECONDS` | `3600` |
-| `FIRST_TREE_ARCHIVE_UNMAPPED_IDLE_SECONDS` | `43200` |
 
-`FIRST_TREE_ARCHIVE_UNMAPPED_IDLE_SECONDS` applies only to chats with no
-GitHub mapping and no human owner.
+`FIRST_TREE_ARCHIVE_MAPPED_IDLE_SECONDS` is the GitHub-source archive idle
+threshold. Mapped chats also require all bound entities to be closed/merged;
+source=github chats with no mapping use the same idle threshold.
 
 **Observability:**
 

--- a/packages/server/src/__tests__/bootstrap.test.ts
+++ b/packages/server/src/__tests__/bootstrap.test.ts
@@ -46,7 +46,6 @@ const baseServerConfig: ServerConfig = {
     presenceCleanupSeconds: 60,
     archiveSweepIntervalSeconds: 0,
     archiveMappedIdleSeconds: 60 * 60,
-    archiveUnmappedIdleSeconds: 12 * 60 * 60,
     notificationWebhookUrl: undefined,
   },
   update: {

--- a/packages/server/src/__tests__/build-app-validation.test.ts
+++ b/packages/server/src/__tests__/build-app-validation.test.ts
@@ -31,7 +31,6 @@ const baseConfig: Config = {
     presenceCleanupSeconds: 60,
     archiveSweepIntervalSeconds: 0,
     archiveMappedIdleSeconds: 60 * 60,
-    archiveUnmappedIdleSeconds: 12 * 60 * 60,
     notificationWebhookUrl: undefined,
   },
   update: {

--- a/packages/server/src/__tests__/chat-archive.test.ts
+++ b/packages/server/src/__tests__/chat-archive.test.ts
@@ -1,13 +1,13 @@
 /**
  * Unit tests for the chat auto-archive sweeper (`sweepChatArchive`). Covers
- * the two routes the sweeper owns:
+ * the two GitHub-source branches the sweeper owns:
  *
- *   Route A — chats with GitHub mappings: archive when every mapped entity
- *             is terminal AND `last_message_at` is older than the mapped
- *             idle threshold.
- *   Route B — chats with no GitHub mapping and no human owner: archive
- *             (chat, user) pairs with no unread mentions AND
- *             `last_message_at` older than the unmapped idle threshold.
+ *   Mapped branch — source=github chats with GitHub mappings: archive when
+ *                   every mapped entity is terminal AND `last_message_at` is
+ *                   older than the GitHub idle threshold.
+ *   No-mapping branch — source=github chats with no GitHub mapping: archive
+ *                       acknowledged (chat, user) pairs after the same idle
+ *                       threshold.
  *
  * Also asserts the shared per-user safety guards: deleted-sticky and
  * already-archived rows are never touched; sweeps are idempotent.
@@ -26,6 +26,11 @@ import { createMeChat } from "../services/me-chat.js";
 import { createTestAdmin, useTestApp } from "./helpers.js";
 
 type App = ReturnType<ReturnType<typeof useTestApp>>;
+type ChatMetadata = Record<string, unknown>;
+
+function githubMetadata(key = `owner/repo#${randomUUID().slice(0, 8)}`): ChatMetadata {
+  return { source: "github", entityType: "pull_request", entityKey: key };
+}
 
 async function seedHumanAgent(app: App, orgId: string, memberId: string): Promise<string> {
   const uuid = randomUUID();
@@ -55,13 +60,19 @@ async function seedDelegateAgent(app: App, orgId: string, memberId: string): Pro
   return uuid;
 }
 
-async function seedChat(app: App, orgId: string, lastMessageAt: Date | null): Promise<string> {
+async function seedChat(
+  app: App,
+  orgId: string,
+  lastMessageAt: Date | null,
+  metadata: ChatMetadata = githubMetadata(),
+): Promise<string> {
   const chatId = `chat_${randomUUID()}`;
   await app.db.insert(chats).values({
     id: chatId,
     organizationId: orgId,
     type: "direct",
     lastMessageAt,
+    metadata,
   });
   return chatId;
 }
@@ -89,7 +100,7 @@ const HOURS = 60 * 60;
 const longAgo = () => new Date(Date.now() - 48 * HOURS * 1000);
 const recent = () => new Date(Date.now() - 5 * 60 * 1000);
 
-describe("sweepChatArchive — Route A (chats with GitHub mappings)", () => {
+describe("sweepChatArchive — mapped source=github branch", () => {
   const getApp = useTestApp();
 
   it("archives a chat when every mapped entity is terminal and idle > threshold", async () => {
@@ -112,6 +123,78 @@ describe("sweepChatArchive — Route A (chats with GitHub mappings)", () => {
     const result = await sweepChatArchive(app.db);
 
     expect(result.mappedRowsArchived).toBe(1);
+    expect(await getEngagement(app, chatId, human)).toBe("archived");
+  });
+
+  it("does not archive mapped chats unless their source is github", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const human = await seedHumanAgent(app, admin.organizationId, admin.memberId);
+    const delegate = await seedDelegateAgent(app, admin.organizationId, admin.memberId);
+    const manualChatId = await seedChat(app, admin.organizationId, longAgo(), {});
+    const agentChatId = await seedChat(app, admin.organizationId, longAgo(), { source: "agent" });
+    await app.db.insert(githubEntityChatMappings).values([
+      {
+        organizationId: admin.organizationId,
+        humanAgentId: human,
+        delegateAgentId: delegate,
+        entityType: "pull_request",
+        entityKey: "owner/repo#manual",
+        chatId: manualChatId,
+        boundVia: "human_declared",
+        entityState: "merged",
+      },
+      {
+        organizationId: admin.organizationId,
+        humanAgentId: human,
+        delegateAgentId: delegate,
+        entityType: "pull_request",
+        entityKey: "owner/repo#agent",
+        chatId: agentChatId,
+        boundVia: "agent_declared",
+        entityState: "merged",
+      },
+    ]);
+
+    const result = await sweepChatArchive(app.db);
+
+    expect(result.mappedRowsArchived).toBe(0);
+    expect(await getEngagement(app, manualChatId, human)).toBeNull();
+    expect(await getEngagement(app, agentChatId, human)).toBeNull();
+  });
+
+  it("does not archive mapped chats while any request in the chat is still open", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const human = await seedHumanAgent(app, admin.organizationId, admin.memberId);
+    const delegate = await seedDelegateAgent(app, admin.organizationId, admin.memberId);
+    const chatId = await seedChat(app, admin.organizationId, longAgo());
+    await app.db.insert(githubEntityChatMappings).values({
+      organizationId: admin.organizationId,
+      humanAgentId: human,
+      delegateAgentId: delegate,
+      entityType: "pull_request",
+      entityKey: "owner/repo#open-request",
+      chatId,
+      boundVia: "direct",
+      entityState: "merged",
+    });
+    await app.db.insert(chatUserState).values({
+      chatId,
+      agentId: human,
+      engagementStatus: "active",
+      unreadMentionCount: 0,
+      openRequestCount: 1,
+    });
+
+    const blocked = await sweepChatArchive(app.db);
+    expect(blocked.mappedRowsArchived).toBe(0);
+    expect(await getEngagement(app, chatId, human)).toBe("active");
+
+    await app.db.update(chatUserState).set({ openRequestCount: 0 }).where(eq(chatUserState.chatId, chatId));
+
+    const unblocked = await sweepChatArchive(app.db);
+    expect(unblocked.mappedRowsArchived).toBe(1);
     expect(await getEngagement(app, chatId, human)).toBe("archived");
   });
 
@@ -249,6 +332,7 @@ describe("sweepChatArchive — Route A (chats with GitHub mappings)", () => {
       organizationId: admin.organizationId,
       type: "direct",
       lastMessageAt: longAgo(),
+      metadata: githubMetadata("owner/repo#parent"),
     });
     // Sub-chat: same shape, but parent_chat_id set. Matches the schema's
     // historical-only scaffolding scenario.
@@ -259,6 +343,7 @@ describe("sweepChatArchive — Route A (chats with GitHub mappings)", () => {
       type: "direct",
       parentChatId,
       lastMessageAt: longAgo(),
+      metadata: githubMetadata("owner/repo#11"),
     });
     await app.db.insert(githubEntityChatMappings).values({
       organizationId: admin.organizationId,
@@ -353,7 +438,7 @@ describe("sweepChatArchive — Route A (chats with GitHub mappings)", () => {
   });
 });
 
-describe("sweepChatArchive — Route B (chats with no GitHub mapping)", () => {
+describe("sweepChatArchive — no-mapping source=github branch", () => {
   const getApp = useTestApp();
 
   async function seedReadAcknowledgement(app: App, chatId: string, agentId: string): Promise<void> {
@@ -366,7 +451,7 @@ describe("sweepChatArchive — Route B (chats with no GitHub mapping)", () => {
     });
   }
 
-  it("archives a chat once it has been idle past the unmapped threshold and user has acknowledged read", async () => {
+  it("archives a source=github chat with no mappings once it is idle and the user has acknowledged read", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
     const human = await seedHumanAgent(app, admin.organizationId, admin.memberId);
@@ -378,6 +463,24 @@ describe("sweepChatArchive — Route B (chats with no GitHub mapping)", () => {
 
     expect(result.unmappedRowsArchived).toBeGreaterThanOrEqual(1);
     expect(await getEngagement(app, chatId, human)).toBe("archived");
+  });
+
+  it("does not archive no-mapping chats unless their source is github", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const human = await seedHumanAgent(app, admin.organizationId, admin.memberId);
+    const manualChatId = await seedChat(app, admin.organizationId, longAgo(), {});
+    const agentChatId = await seedChat(app, admin.organizationId, longAgo(), { source: "agent" });
+    await addHumanMember(app, manualChatId, human);
+    await addHumanMember(app, agentChatId, human);
+    await seedReadAcknowledgement(app, manualChatId, human);
+    await seedReadAcknowledgement(app, agentChatId, human);
+
+    const result = await sweepChatArchive(app.db);
+
+    expect(result.unmappedRowsArchived).toBe(0);
+    expect(await getEngagement(app, manualChatId, human)).toBe("active");
+    expect(await getEngagement(app, agentChatId, human)).toBe("active");
   });
 
   it("does not archive a user who has never opened the chat (last_read_at IS NULL)", async () => {
@@ -416,6 +519,32 @@ describe("sweepChatArchive — Route B (chats with no GitHub mapping)", () => {
     expect(await getEngagement(app, chatId, human)).toBe("active");
   });
 
+  it("does not archive no-mapping source=github chats while any request in the chat is still open", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const human = await seedHumanAgent(app, admin.organizationId, admin.memberId);
+    const chatId = await seedChat(app, admin.organizationId, longAgo());
+    await addHumanMember(app, chatId, human);
+    await app.db.insert(chatUserState).values({
+      chatId,
+      agentId: human,
+      engagementStatus: "active",
+      unreadMentionCount: 0,
+      openRequestCount: 1,
+      lastReadAt: new Date(Date.now() - 24 * 60 * 60 * 1000),
+    });
+
+    const blocked = await sweepChatArchive(app.db);
+    expect(blocked.unmappedRowsArchived).toBe(0);
+    expect(await getEngagement(app, chatId, human)).toBe("active");
+
+    await app.db.update(chatUserState).set({ openRequestCount: 0 }).where(eq(chatUserState.chatId, chatId));
+
+    const unblocked = await sweepChatArchive(app.db);
+    expect(unblocked.unmappedRowsArchived).toBe(1);
+    expect(await getEngagement(app, chatId, human)).toBe("archived");
+  });
+
   it("does not archive a recently active chat", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
@@ -445,18 +574,18 @@ describe("sweepChatArchive — Route B (chats with no GitHub mapping)", () => {
     expect(await getEngagement(app, chatId, admin.humanAgentUuid)).toBe("active");
   });
 
-  it("does not archive chats that have GitHub mappings (Route A's responsibility)", async () => {
+  it("does not archive chats that have GitHub mappings (mapped branch responsibility)", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
     const human = await seedHumanAgent(app, admin.organizationId, admin.memberId);
     const delegate = await seedDelegateAgent(app, admin.organizationId, admin.memberId);
     const chatId = await seedChat(app, admin.organizationId, longAgo());
     await addHumanMember(app, chatId, human);
-    // Make the user a Route-B-eligible candidate so the assertion only
-    // succeeds because the mapping presence excludes the chat from Route B.
+    // Make the user a no-mapping-branch eligible candidate so the assertion
+    // only succeeds because mapping presence excludes the chat from this branch.
     await seedReadAcknowledgement(app, chatId, human);
-    // Mapping with an open entity → Route A should NOT fire either, and
-    // Route B must skip this chat entirely.
+    // Mapping with an open entity -> mapped branch should NOT fire either, and
+    // the no-mapping branch must skip this chat entirely.
     await app.db.insert(githubEntityChatMappings).values({
       organizationId: admin.organizationId,
       humanAgentId: human,
@@ -514,5 +643,26 @@ describe("sweepChatArchive — thresholds", () => {
 
     const after = await sweepChatArchive(app.db, { mappedIdleSeconds: 10 * 60 });
     expect(after.mappedRowsArchived).toBe(1);
+  });
+
+  it("uses mappedIdleSeconds for the no-mapping source=github branch too", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const human = await seedHumanAgent(app, admin.organizationId, admin.memberId);
+    const chatId = await seedChat(app, admin.organizationId, new Date(Date.now() - 30 * 60 * 1000));
+    await addHumanMember(app, chatId, human);
+    await app.db.insert(chatUserState).values({
+      chatId,
+      agentId: human,
+      engagementStatus: "active",
+      unreadMentionCount: 0,
+      lastReadAt: new Date(Date.now() - 24 * 60 * 60 * 1000),
+    });
+
+    const before = await sweepChatArchive(app.db);
+    expect(before.unmappedRowsArchived).toBe(0);
+
+    const after = await sweepChatArchive(app.db, { mappedIdleSeconds: 10 * 60 });
+    expect(after.unmappedRowsArchived).toBe(1);
   });
 });

--- a/packages/server/src/__tests__/helpers.ts
+++ b/packages/server/src/__tests__/helpers.ts
@@ -144,7 +144,6 @@ export async function createTestApp(opts: CreateTestAppOptions = {}): Promise<Fa
       // timer would only add nondeterminism.
       archiveSweepIntervalSeconds: 0,
       archiveMappedIdleSeconds: 60 * 60,
-      archiveUnmappedIdleSeconds: 12 * 60 * 60,
       notificationWebhookUrl: undefined,
     },
     update: {

--- a/packages/server/src/services/background-tasks.ts
+++ b/packages/server/src/services/background-tasks.ts
@@ -65,16 +65,14 @@ export function createBackgroundTasks(app: FastifyInstance, instanceId: string):
 
       // Chat auto-archive sweeper — cadence comes from runtime config so
       // ops can tune (or zero-disable) without touching code. See
-      // services/chat-archive.ts for the two routes and their idle
-      // thresholds (defaults: 1h for chats with GitHub mappings, 12h
-      // otherwise).
+      // services/chat-archive.ts for the GitHub-source archive policy and
+      // idle threshold (default: 1h).
       const archiveSweepSeconds = app.config.runtime.archiveSweepIntervalSeconds;
       if (archiveSweepSeconds > 0) {
         archiveSweepTimer = setInterval(async () => {
           try {
             const stats = await chatArchiveService.sweepChatArchive(app.db, {
               mappedIdleSeconds: app.config.runtime.archiveMappedIdleSeconds,
-              unmappedIdleSeconds: app.config.runtime.archiveUnmappedIdleSeconds,
             });
             if (stats.mappedRowsArchived > 0 || stats.unmappedRowsArchived > 0) {
               log.info(stats, "chat auto-archive sweep flipped rows to archived");

--- a/packages/server/src/services/chat-archive.ts
+++ b/packages/server/src/services/chat-archive.ts
@@ -5,20 +5,23 @@
  * lived in the GitHub App webhook. Run from `background-tasks.ts` on a
  * configurable interval.
  *
- * Two routes share the sweep, both keyed off `chats.last_message_at` as the
- * idleness anchor:
+ * Only GitHub-originated chats (`chats.metadata.source = 'github'`) are
+ * eligible for automatic archive. The sweep has two GitHub-source branches,
+ * both keyed off `chats.last_message_at` as the idleness anchor:
  *
- *   Route A — chats with at least one `github_entity_chat_mappings` row.
+ *   Mapped branch — chats with at least one `github_entity_chat_mappings` row.
  *     Archive (for every mapped human) once *all* bound entities are
  *     terminal (`entity_state` in `('closed','merged')`) AND the chat has
- *     been silent for `mappedIdleSeconds` (default 1h). Additionally:
- *     skip individual users whose `unread_mention_count > 0`.
+ *     been silent for `mappedIdleSeconds` (default 1h).
  *
- *   Route B — chats with no GitHub mapping and no human owner. Archive only
- *     the (chat, user) pairs where the user has no unread mentions AND the
- *     chat has been silent for `unmappedIdleSeconds` (default 12h). Human-
- *     owned chats are user-created workspace conversations and must stay
- *     active until explicitly archived.
+ *   No-mapping branch — GitHub-originated chats with no mapping rows. Archive
+ *     only acknowledged human views once the chat has been silent for the same
+ *     idle threshold. This is an explicit GitHub orphan/no-binding cleanup,
+ *     not the old generic operational-chat idle sweep.
+ *
+ * A chat with any open structured request (`open_request_count > 0`) is never
+ * auto-archived. Per-user unread guards still apply, and user-`deleted` /
+ * already-`archived` rows are left alone.
  *
  * Per-user safety: writes use the same UPSERT + setWhere guard as the
  * removed `archiveChatsForMergedPr` — only implicit-active or
@@ -34,14 +37,11 @@ import { sql } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 
 export const DEFAULT_MAPPED_IDLE_SECONDS = 60 * 60; // 1 hour
-export const DEFAULT_UNMAPPED_IDLE_SECONDS = 12 * 60 * 60; // 12 hours
 export const DEFAULT_SWEEP_BATCH_SIZE = 1000;
 
 export type SweepChatArchiveOptions = {
-  /** Idle threshold for Route A (chats with GitHub mappings). Default 1h. */
+  /** Idle threshold for GitHub-originated archive branches. Default 1h. */
   mappedIdleSeconds?: number;
-  /** Idle threshold for Route B (chats without GitHub mappings). Default 12h. */
-  unmappedIdleSeconds?: number;
   /** Max candidate rows per route per tick. Default 1000. */
   batchSize?: number;
 };
@@ -56,23 +56,23 @@ export async function sweepChatArchive(
   opts: SweepChatArchiveOptions = {},
 ): Promise<SweepChatArchiveResult> {
   const mappedIdle = opts.mappedIdleSeconds ?? DEFAULT_MAPPED_IDLE_SECONDS;
-  const unmappedIdle = opts.unmappedIdleSeconds ?? DEFAULT_UNMAPPED_IDLE_SECONDS;
   const batchSize = opts.batchSize ?? DEFAULT_SWEEP_BATCH_SIZE;
 
   const mappedRowsArchived = await sweepMapped(db, mappedIdle, batchSize);
-  const unmappedRowsArchived = await sweepUnmapped(db, unmappedIdle, batchSize);
+  const unmappedRowsArchived = await sweepUnmapped(db, mappedIdle, batchSize);
   return { mappedRowsArchived, unmappedRowsArchived };
 }
 
 /**
- * Route A: chats whose every GitHub-mapped entity is terminal AND have been
- * silent for at least `idleSeconds`. Archives every (chat, human) pair from
- * the mapping table — matches the legacy `archiveChatsForMergedPr` reach,
- * minus the per-user unread carve-out added here.
+ * Mapped branch: GitHub-originated chats whose every GitHub-mapped entity is
+ * terminal AND have been silent for at least `idleSeconds`. Archives every
+ * (chat, human) pair from the mapping table, minus per-user unread and
+ * chat-level open-request guards.
  *
  * Implemented as a single `INSERT … SELECT … ON CONFLICT` round-trip:
  *  - The inner CTE picks chats whose `BOOL_AND(entity_state IN
- *    ('closed','merged'))` and idle timestamp both hold.
+ *    ('closed','merged'))`, GitHub source, open-request, and idle timestamp
+ *    conditions all hold.
  *  - The outer SELECT joins back to the mapping table for the (chat,
  *    human) pairs. A second per-user guard excludes humans whose
  *    `unread_mention_count > 0` — the schema column is semantically
@@ -93,8 +93,15 @@ async function sweepMapped(db: Database, idleSeconds: number, batchSize: number)
         FROM github_entity_chat_mappings m
         JOIN chats c ON c.id = m.chat_id
        WHERE c.parent_chat_id IS NULL
+         AND c.metadata->>'source' = 'github'
          AND c.last_message_at IS NOT NULL
          AND c.last_message_at < NOW() - make_interval(secs => ${idleSeconds})
+         AND NOT EXISTS (
+           SELECT 1
+             FROM chat_user_state req
+            WHERE req.chat_id = c.id
+              AND req.open_request_count > 0
+         )
        GROUP BY m.chat_id
       HAVING bool_and(m.entity_state IN ('closed', 'merged'))
        LIMIT ${batchSize}
@@ -117,12 +124,10 @@ async function sweepMapped(db: Database, idleSeconds: number, batchSize: number)
 }
 
 /**
- * Route B: chats with no GitHub mapping and no human owner that have been
- * silent past `idleSeconds`, restricted to per-(chat, user) rows that all of:
+ * No-mapping branch: GitHub-originated chats with no mapping rows that have
+ * been silent past `idleSeconds`, restricted to per-(chat, user) rows that all
+ * of:
  *
- *   - the chat is not owned by a human speaker — human-owned chats are
- *     manually created workspace conversations and should not disappear from
- *     Active merely because they are quiet,
  *   - the user has acknowledged the chat at least once (`last_read_at IS
  *     NOT NULL`) — never auto-archive a view the user has never even
  *     opened; without this guard a never-clicked watcher would find the
@@ -130,6 +135,10 @@ async function sweepMapped(db: Database, idleSeconds: number, batchSize: number)
  *   - the user has no unread mentions,
  *   - the user's engagement is currently `active` (either an explicit
  *     row or the implicit default via missing row).
+ *
+ * Like the mapped branch, any open request in the chat blocks archive for the
+ * entire chat. Unlike the retired generic Route B, this branch does not require
+ * "no human owner": GitHub-originated chats are normally human-owned.
  *
  * The `last_read_at IS NOT NULL` condition implies `cus` is materialised,
  * so the `COALESCE(cus.engagement_status, 'active') = 'active'` clause
@@ -152,19 +161,21 @@ async function sweepUnmapped(db: Database, idleSeconds: number, batchSize: numbe
       JOIN agents a ON a.uuid = cm.agent_id
       JOIN chat_user_state cus
              ON cus.chat_id = cm.chat_id AND cus.agent_id = cm.agent_id
-      LEFT JOIN github_entity_chat_mappings m ON m.chat_id = cm.chat_id
-     WHERE m.chat_id IS NULL
+     WHERE c.metadata->>'source' = 'github'
+       AND NOT EXISTS (
+         SELECT 1
+           FROM github_entity_chat_mappings m
+          WHERE m.chat_id = c.id
+       )
        AND a.type = 'human'
        AND c.parent_chat_id IS NULL
        AND c.last_message_at IS NOT NULL
        AND c.last_message_at < NOW() - make_interval(secs => ${idleSeconds})
        AND NOT EXISTS (
          SELECT 1
-           FROM chat_membership owner_cm
-           JOIN agents owner_a ON owner_a.uuid = owner_cm.agent_id
-          WHERE owner_cm.chat_id = c.id
-            AND owner_cm.role = 'owner'
-            AND owner_a.type = 'human'
+           FROM chat_user_state req
+          WHERE req.chat_id = c.id
+            AND req.open_request_count > 0
        )
        AND cus.last_read_at IS NOT NULL
        AND cus.unread_mention_count = 0

--- a/packages/shared/src/config/server-config.ts
+++ b/packages/shared/src/config/server-config.ts
@@ -371,9 +371,9 @@ export const serverConfigSchema = defineConfig({
       env: "FIRST_TREE_ARCHIVE_SWEEP_INTERVAL_SECONDS",
     }),
     /**
-     * Idle threshold for chats bound to GitHub PRs/Issues. Once every
-     * bound entity is closed/merged AND the chat has been silent this
-     * long, the sweeper flips every mapped human's view to `archived`.
+     * Idle threshold for source=github chats. Mapped chats require every bound
+     * entity to be closed/merged; no-mapping source=github chats use this same
+     * threshold as an orphan/no-binding cleanup.
      */
     archiveMappedIdleSeconds: field(
       z.coerce
@@ -383,21 +383,6 @@ export const serverConfigSchema = defineConfig({
         .default(60 * 60),
       {
         env: "FIRST_TREE_ARCHIVE_MAPPED_IDLE_SECONDS",
-      },
-    ),
-    /**
-     * Idle threshold for chats with no GitHub mapping and no human owner.
-     * Per (chat, user) — users with unread mentions are skipped; users
-     * without an unread stay archived after this much silence.
-     */
-    archiveUnmappedIdleSeconds: field(
-      z.coerce
-        .number()
-        .int()
-        .positive()
-        .default(12 * 60 * 60),
-      {
-        env: "FIRST_TREE_ARCHIVE_UNMAPPED_IDLE_SECONDS",
       },
     ),
     /**


### PR DESCRIPTION
## Summary
- limit automatic chat archive eligibility to `metadata.source = "github"`
- keep mapped GitHub archive behavior on terminal entities plus idle, and add a chat-level unresolved request guard
- replace the old generic unmapped cleanup with GitHub-source no-mapping cleanup gated by idle, acknowledgement, active status, and no unread mentions
- remove the separate unmapped archive idle config and document the unified GitHub idle threshold

## Context Tree
- https://github.com/agent-team-foundation/first-tree-context/pull/525

## Verification
- `VITEST_PG_MAX_WORKERS=2 pnpm --dir packages/server exec vitest run src/__tests__/chat-archive.test.ts --maxWorkers=2`
- `pnpm check`
- `pnpm typecheck`
- `git diff --check`

Internal review: passed by codex-reviewer.
