### PR TITLE
fix(web): free text alone answers/resolves an option question

### DIFF
--- a/packages/web/src/components/chat/__tests__/request-state.test.ts
+++ b/packages/web/src/components/chat/__tests__/request-state.test.ts
@@ -400,9 +400,12 @@ describe("allRequiredAnswered / buildResolveAnswer (blocking surface — both ch
     allowExtra: false,
   };
 
-  it("a required single needs a selection; free text does not satisfy it", () => {
+  it("free text satisfies a required option question — no option pick needed (the reported bug)", () => {
     expect(allRequiredAnswered(single, {}, "")).toBe(false);
-    expect(allRequiredAnswered(single, {}, "just typing")).toBe(false);
+    // Free text alone enables send for an option question (was incorrectly false).
+    expect(allRequiredAnswered(single, {}, "let's hold off")).toBe(true);
+    expect(buildResolveAnswer(single, {}, "let's hold off")).toBe("Ship? → let's hold off");
+    // An option pick alone still works.
     expect(allRequiredAnswered(single, { "Ship?": "yes" }, "")).toBe(true);
   });
 
@@ -411,9 +414,9 @@ describe("allRequiredAnswered / buildResolveAnswer (blocking surface — both ch
     expect(allRequiredAnswered(withFree, {}, "looks risky")).toBe(true);
   });
 
-  it("a mixed request needs both channels", () => {
+  it("mixed request: free text alone enables send; option-only without free text does not (free question unanswered)", () => {
     expect(allRequiredAnswered(mixed, { "Strategy?": "blue-green" }, "")).toBe(false);
-    expect(allRequiredAnswered(mixed, {}, "some notes")).toBe(false);
+    expect(allRequiredAnswered(mixed, {}, "some notes")).toBe(true);
     expect(allRequiredAnswered(mixed, { "Strategy?": "blue-green" }, "some notes")).toBe(true);
   });
 

--- a/packages/web/src/components/chat/request-state.ts
+++ b/packages/web/src/components/chat/request-state.ts
@@ -242,22 +242,24 @@ export function findBlockingRequest(thread: readonly Message[], viewerAgentId: s
 }
 
 /**
- * Whether every REQUIRED question is answered, treating the blocking surface's
- * two answer channels as equals: a single-select question is answered by an
- * option `selection` (keyed by prompt), a free-text question by the composer's
- * `freeText`. Drives the send button's enabled state. Unlike
- * `allRequiredSelected`, a required free-text question CAN be satisfied here —
- * a typed answer now resolves rather than going to the asking agent to judge.
+ * Whether the viewer has answered enough to send, treating the blocking
+ * surface's two answer channels as equals. Free text alone is a complete answer
+ * to the whole request — typing an answer resolves the question even for an
+ * option (single-select) question, so the human is never forced to pick a
+ * listed option. Absent free text, every required question must be answered by
+ * its own option selection. Drives the send button's enabled state.
  */
 export function allRequiredAnswered(
   payload: OpenQuestionRequest,
   selections: Record<string, string>,
   freeText: string,
 ): boolean {
-  const hasFree = freeText.trim().length > 0;
-  return payload.questions.every((q) =>
-    !q.required ? true : q.kind === "single" ? Boolean(selections[q.prompt]) : hasFree,
-  );
+  // Any free text is itself the answer — enable send (it stands in as the
+  // answer for every question via `buildResolveAnswer`).
+  if (freeText.trim().length > 0) return true;
+  // No free text: each required question needs an option pick. A required
+  // free-text question is unsatisfied here, since it has no free text.
+  return payload.questions.every((q) => !q.required || (q.kind === "single" && Boolean(selections[q.prompt])));
 }
 
 /**
@@ -279,15 +281,25 @@ export function buildResolveAnswer(
 ): string {
   const note = freeText.trim();
   const lines = payload.questions
-    .map((q) => ({ q, answer: q.kind === "single" ? (selections[q.prompt] ?? "") : note }))
-    // Drop optional questions the viewer left unanswered — otherwise the
-    // resolving content carries `"<prompt> → —"` placeholder lines that the
-    // resolved card would echo as the "answer". Required questions are always
-    // answered by the send gate, so they always survive.
+    .map((q) => ({
+      q,
+      // An option question is answered by its selection; if none was picked the
+      // free text stands in as the answer (so free-text-only answers an option
+      // question too). A free-text question is answered by the free text.
+      answer: q.kind === "single" ? (selections[q.prompt] ?? note) : note,
+    }))
+    // Drop optional questions the viewer left unanswered through both channels —
+    // otherwise the resolving content carries `"<prompt> → —"` placeholder lines
+    // the resolved card would echo as the "answer". Required questions are
+    // always answered by the send gate, so they survive.
     .filter(({ q, answer }) => q.required || answer.length > 0)
     .map(({ q, answer }) => `${q.prompt} → ${answer || "—"}`);
-  const hasFree = payload.questions.some((q) => q.kind === "free");
-  if (!hasFree && note) lines.push(note);
+  // The note is used as an answer for any question lacking an option selection
+  // (a free-text question, or an option question answered by free text), so only
+  // append it as a standalone trailing note when every question was answered by
+  // its own selection.
+  const noteConsumed = payload.questions.some((q) => !selections[q.prompt]);
+  if (note && !noteConsumed) lines.push(note);
   return lines.join("\n");
 }
 

--- a/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
@@ -861,6 +861,63 @@ describe("ChatView", () => {
     await act(async () => root.unmount());
   });
 
+  it("enables Send and resolves when an option question is answered with free text (no option picked)", async () => {
+    const { ChatView } = await import("../chat-view.js");
+    const dockMessages = messages([
+      message({
+        id: "req-opt",
+        senderId: "agent-1",
+        format: "request",
+        content: "Pick the deploy color.",
+        metadata: {
+          mentions: ["human-agent-self"],
+          request: {
+            subject: "Deploy",
+            questions: [
+              {
+                id: "q1",
+                prompt: "Deploy color?",
+                kind: "single",
+                options: ["Blue-green", "Rolling update"],
+                required: true,
+              },
+            ],
+          },
+        },
+        createdAt: "2026-05-28T12:00:00.000Z",
+      }),
+    ]);
+    const { container, root } = await renderDom(
+      <ChatView agentId="agent-1" chatId="chat-1" />,
+      (client) => seedChat(client, chatDetail(), dockMessages),
+      "/",
+    );
+
+    await waitForText(container, "Awaiting your answer");
+    const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
+    if (!textarea) throw new Error("Composer textarea missing");
+
+    // No option picked + empty composer → Send disabled.
+    expect(container.querySelector<HTMLButtonElement>('button[aria-label="Send"]')?.disabled).toBe(true);
+
+    // Typing a free-text answer (without picking an option) must enable Send —
+    // this was the reported bug.
+    await setValue(textarea, "Neither — let's hold the deploy");
+    expect(container.querySelector<HTMLButtonElement>('button[aria-label="Send"]')?.disabled).toBe(false);
+
+    // ...and sending resolves the question with the free text as the answer.
+    await click(container.querySelector('button[aria-label="Send"]'));
+    await waitForCondition(() => chatMocks.sendChatMessage.mock.calls.length > 0, "Expected free-text answer send");
+    expect(chatMocks.sendChatMessage).toHaveBeenCalledWith(
+      "chat-1",
+      "Deploy color? → Neither — let's hold the deploy",
+      ["agent-1"],
+      { inReplyTo: "req-opt", resolves: { request: "req-opt", kind: "answered" } },
+    );
+
+    await act(async () => root.unmount());
+  });
+
   it("does not clear a user-typed @ after an earlier focus auto-prime", async () => {
     const { ChatView } = await import("../chat-view.js");
     const dockMessages = messages([


### PR DESCRIPTION
## Bug
Reported by yuezengwu: when answering an open question **with free text instead of picking an option**, the **Send button stays disabled** — so an option-type question couldn't be answered by typing.

## Cause
The blocking-answer send gate `allRequiredAnswered` required an option *selection* for option (`single`) questions; free text didn't satisfy it. This contradicts the shipped "option **or** free text both resolve" contract (#1072).

## Fix
- `allRequiredAnswered`: free text alone is a complete answer — it enables Send (an option pick alone still works too).
- `buildResolveAnswer`: free text stands in as the answer for any question with no option selection, so an option question answered by free text resolves as `"<prompt> → <free text>"` (no `→ —` placeholder).

## Tests
- Unit: `allRequiredAnswered` / `buildResolveAnswer` for free-text-on-option-question, plus updated mixed-request expectations.
- DOM: typing free text into an option-question dock enables Send and resolves with the free-text answer.
- Full web suite green (806); typecheck / biome / design-token clean.

Follow-up to #1072 (open-question blocking reply).