### PR TITLE
fix(chat): unify participant avatar resolution

### DIFF
--- a/packages/server/src/__tests__/chat-detail-avatar-fields.test.ts
+++ b/packages/server/src/__tests__/chat-detail-avatar-fields.test.ts
@@ -1,8 +1,9 @@
 import { eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 import { agents } from "../db/schema/agents.js";
+import { users } from "../db/schema/users.js";
 import { createChat } from "../services/chat.js";
-import { createTestAgent, useTestApp } from "./helpers.js";
+import { createTestAdmin, createTestAgent, useTestApp } from "./helpers.js";
 
 /**
  * Regression: the chat-detail surface used to drop the manager-configured
@@ -51,6 +52,75 @@ describe("chat-detail wire shape — participant avatar fields", () => {
     expect(callerRow?.avatarColorToken).toBeNull();
   });
 
+  it("admin GET /chats/:chatId falls back to a human user's external avatar", async () => {
+    const app = getApp();
+    const caller = await createTestAdmin(app);
+    const teammate = await createTestAdmin(app);
+    const teammateAvatar = "https://avatars.githubusercontent.com/u/24680?v=4";
+    await app.db.update(users).set({ avatarUrl: teammateAvatar }).where(eq(users.id, teammate.userId));
+
+    const chat = await createChat(app.db, caller.humanAgentUuid, {
+      type: "group",
+      participantIds: [teammate.humanAgentUuid],
+    });
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/chats/${chat.id}`,
+      headers: { authorization: `Bearer ${caller.accessToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as {
+      participants: Array<{
+        agentId: string;
+        avatarImageUrl: string | null;
+      }>;
+    };
+
+    expect(body.participants.find((p) => p.agentId === teammate.humanAgentUuid)?.avatarImageUrl).toBe(teammateAvatar);
+  });
+
+  it("admin GET /chats/:chatId prefers uploaded human avatars over external avatars", async () => {
+    const app = getApp();
+    const caller = await createTestAdmin(app);
+    const teammate = await createTestAdmin(app);
+    const uploadedAt = new Date("2026-06-15T12:00:00.000Z");
+    await app.db
+      .update(users)
+      .set({ avatarUrl: "https://avatars.githubusercontent.com/u/13579?v=4" })
+      .where(eq(users.id, teammate.userId));
+    await app.db
+      .update(agents)
+      .set({
+        avatarImageData: Buffer.from("avatar"),
+        avatarImageMime: "image/webp",
+        avatarImageUpdatedAt: uploadedAt,
+      })
+      .where(eq(agents.uuid, teammate.humanAgentUuid));
+
+    const chat = await createChat(app.db, caller.humanAgentUuid, {
+      type: "group",
+      participantIds: [teammate.humanAgentUuid],
+    });
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/chats/${chat.id}`,
+      headers: { authorization: `Bearer ${caller.accessToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as {
+      participants: Array<{
+        agentId: string;
+        avatarImageUrl: string | null;
+      }>;
+    };
+
+    expect(body.participants.find((p) => p.agentId === teammate.humanAgentUuid)?.avatarImageUrl).toBe(
+      `/api/v1/agents/${teammate.humanAgentUuid}/avatar?v=${uploadedAt.getTime()}`,
+    );
+  });
+
   it("agent GET /agent/chats/:chatId returns avatarColorToken + avatarImageUrl", async () => {
     const app = getApp();
     const caller = await createTestAgent(app, { type: "agent", displayName: "Caller Bot" });
@@ -77,6 +147,31 @@ describe("chat-detail wire shape — participant avatar fields", () => {
     expect(peerRow?.avatarImageUrl).toBeNull();
   });
 
+  it("agent GET /agent/chats/:chatId falls back to a human user's external avatar", async () => {
+    const app = getApp();
+    const caller = await createTestAgent(app, { type: "human", displayName: "Caller Human" });
+    const teammate = await createTestAdmin(app);
+    const teammateAvatar = "https://avatars.githubusercontent.com/u/97531?v=4";
+    await app.db.update(users).set({ avatarUrl: teammateAvatar }).where(eq(users.id, teammate.userId));
+
+    const chatRes = await caller.request("POST", "/api/v1/agent/chats", {
+      type: "group",
+      participantIds: [teammate.humanAgentUuid],
+    });
+    const chatId = chatRes.json().id as string;
+
+    const res = await caller.request("GET", `/api/v1/agent/chats/${chatId}`);
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as {
+      participants: Array<{
+        agentId: string;
+        avatarImageUrl: string | null;
+      }>;
+    };
+
+    expect(body.participants.find((p) => p.agentId === teammate.humanAgentUuid)?.avatarImageUrl).toBe(teammateAvatar);
+  });
+
   it("agent GET /agent/chats/:chatId/participants returns avatarColorToken + avatarImageUrl", async () => {
     const app = getApp();
     const caller = await createTestAgent(app, { type: "agent", displayName: "Caller Bot" });
@@ -99,5 +194,28 @@ describe("chat-detail wire shape — participant avatar fields", () => {
     const peerRow = body.find((p) => p.agentId === peer.agent.uuid);
     expect(peerRow?.avatarColorToken).toBe("hue-1");
     expect(peerRow?.avatarImageUrl).toBeNull();
+  });
+
+  it("agent GET /agent/chats/:chatId/participants falls back to a human user's external avatar", async () => {
+    const app = getApp();
+    const caller = await createTestAgent(app, { type: "human", displayName: "Caller Human" });
+    const teammate = await createTestAdmin(app);
+    const teammateAvatar = "https://avatars.githubusercontent.com/u/86420?v=4";
+    await app.db.update(users).set({ avatarUrl: teammateAvatar }).where(eq(users.id, teammate.userId));
+
+    const chatRes = await caller.request("POST", "/api/v1/agent/chats", {
+      type: "group",
+      participantIds: [teammate.humanAgentUuid],
+    });
+    const chatId = chatRes.json().id as string;
+
+    const res = await caller.request("GET", `/api/v1/agent/chats/${chatId}/participants`);
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as Array<{
+      agentId: string;
+      avatarImageUrl: string | null;
+    }>;
+
+    expect(body.find((p) => p.agentId === teammate.humanAgentUuid)?.avatarImageUrl).toBe(teammateAvatar);
   });
 });

--- a/packages/server/src/__tests__/me-chat-service.test.ts
+++ b/packages/server/src/__tests__/me-chat-service.test.ts
@@ -23,8 +23,9 @@
  * See first-tree-context:agent-hub/web-console.md for the contract under test.
  */
 
-import { sql } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
+import { users } from "../db/schema/users.js";
 import { applyAfterFanOut } from "../services/chat-projection.js";
 import {
   addMeChatParticipants,
@@ -68,6 +69,31 @@ describe("chat-first workspace service layer", () => {
       participantIds: [peer.agent.uuid],
     });
     expect(a.chatId).not.toBe(b.chatId);
+  });
+
+  it("listMeChats: resolves human external avatars while leaving agent avatars null without an upload", async () => {
+    const app = getApp();
+    const owner = await createTestAdmin(app);
+    const teammate = await createTestAdmin(app);
+    const bot = await createTestAgent(app, { name: "avatar-list-bot", displayName: "Avatar List Bot" });
+    const teammateAvatar = "https://avatars.githubusercontent.com/u/12345?v=4";
+    await app.db.update(users).set({ avatarUrl: teammateAvatar }).where(eq(users.id, teammate.userId));
+
+    const { chatId } = await createMeChat(app.db, owner.humanAgentUuid, owner.organizationId, {
+      participantIds: [teammate.humanAgentUuid, bot.agent.uuid],
+    });
+
+    const list = await listMeChats(app.db, owner.humanAgentUuid, owner.memberId, owner.organizationId, {
+      limit: 50,
+      filter: "all",
+      engagement: "all",
+    });
+    const row = list.rows.find((r) => r.chatId === chatId);
+    expect(row).toBeDefined();
+    const participantsById = new Map((row?.participants ?? []).map((p) => [p.agentId, p]));
+
+    expect(participantsById.get(teammate.humanAgentUuid)?.avatarImageUrl).toBe(teammateAvatar);
+    expect(participantsById.get(bot.agent.uuid)?.avatarImageUrl).toBeNull();
   });
 
   it("watcher rows: managed agent's chat creates a subscription, not a participant", async () => {

--- a/packages/server/src/api/agent/chats.ts
+++ b/packages/server/src/api/agent/chats.ts
@@ -12,7 +12,6 @@ import { chats } from "../../db/schema/chats.js";
 import { BadRequestError } from "../../errors.js";
 import { requireAgent } from "../../middleware/require-identity.js";
 import { createLogger } from "../../observability/index.js";
-import { agentAvatarImageUrl } from "../../services/agent.js";
 import * as chatService from "../../services/chat.js";
 import { resolveBindingPair } from "../../services/github-entity-chat.js";
 import {
@@ -129,7 +128,7 @@ export async function agentChatRoutes(app: FastifyInstance): Promise<void> {
       type: r.type,
       joinedAt: r.joinedAt.toISOString(),
       avatarColorToken: r.avatarColorToken ?? null,
-      avatarImageUrl: agentAvatarImageUrl(r.agentId, r.avatarImageUpdatedAt ?? null),
+      avatarImageUrl: r.avatarImageUrl,
     }));
   });
 

--- a/packages/server/src/api/chats.ts
+++ b/packages/server/src/api/chats.ts
@@ -12,10 +12,12 @@ import { agents } from "../db/schema/agents.js";
 import { chatMembership } from "../db/schema/chat-membership.js";
 import { chats } from "../db/schema/chats.js";
 import { inboxEntries } from "../db/schema/inbox-entries.js";
+import { members } from "../db/schema/members.js";
 import { messages } from "../db/schema/messages.js";
+import { users } from "../db/schema/users.js";
 import { BadRequestError } from "../errors.js";
 import { assertAllAgentsVisibleInOrg, requireChatAccess } from "../scope/require-resource.js";
-import { agentAvatarImageUrl } from "../services/agent.js";
+import { resolveAvatarImageUrl } from "../services/agent.js";
 import { getChatAgentStatuses } from "../services/agent-chat-status.js";
 import { ensureParticipant, leaveChat } from "../services/chat.js";
 import { declareEntityFollow, listChatGithubEntities, removeEntityFollow } from "../services/github-entity-follow.js";
@@ -67,9 +69,12 @@ export async function chatRoutes(app: FastifyInstance): Promise<void> {
         type: agents.type,
         avatarColorToken: agents.avatarColorToken,
         avatarImageUpdatedAt: agents.avatarImageUpdatedAt,
+        userAvatarUrl: users.avatarUrl,
       })
       .from(chatMembership)
       .innerJoin(agents, eq(chatMembership.agentId, agents.uuid))
+      .leftJoin(members, eq(members.agentId, agents.uuid))
+      .leftJoin(users, eq(users.id, members.userId))
       .where(and(eq(chatMembership.chatId, chat.id), eq(chatMembership.accessMode, "speaker")));
 
     const firstMsgRows = (await app.db.execute<{ content: unknown }>(sql`
@@ -85,7 +90,12 @@ export async function chatRoutes(app: FastifyInstance): Promise<void> {
       displayName: p.displayName,
       type: p.type,
       avatarColorToken: p.avatarColorToken ?? null,
-      avatarImageUrl: agentAvatarImageUrl(p.agentId, p.avatarImageUpdatedAt ?? null),
+      avatarImageUrl: resolveAvatarImageUrl({
+        uuid: p.agentId,
+        type: p.type,
+        avatarImageUpdatedAt: p.avatarImageUpdatedAt,
+        userAvatarUrl: p.userAvatarUrl,
+      }),
     }));
     const title = resolveChatTitle(chat.topic, firstMessagePreview, participantsForTitle, scope.humanAgentId);
 
@@ -125,7 +135,12 @@ export async function chatRoutes(app: FastifyInstance): Promise<void> {
         type: p.type,
         joinedAt: p.joinedAt.toISOString(),
         avatarColorToken: p.avatarColorToken ?? null,
-        avatarImageUrl: agentAvatarImageUrl(p.agentId, p.avatarImageUpdatedAt ?? null),
+        avatarImageUrl: resolveAvatarImageUrl({
+          uuid: p.agentId,
+          type: p.type,
+          avatarImageUpdatedAt: p.avatarImageUpdatedAt,
+          userAvatarUrl: p.userAvatarUrl,
+        }),
       })),
     };
   });

--- a/packages/server/src/services/chat.ts
+++ b/packages/server/src/services/chat.ts
@@ -13,8 +13,9 @@ import { chatMembership } from "../db/schema/chat-membership.js";
 import { chats } from "../db/schema/chats.js";
 import { members } from "../db/schema/members.js";
 import { messages } from "../db/schema/messages.js";
+import { users } from "../db/schema/users.js";
 import { BadRequestError, ForbiddenError, NotFoundError } from "../errors.js";
-import { agentAvatarImageUrl } from "./agent.js";
+import { resolveAvatarImageUrl } from "./agent.js";
 import { invalidateChatAudience } from "./chat-audience-cache.js";
 import { resolveChatTitle } from "./me-chat.js";
 import { preflightMessageSendIntent, type SendIntentParticipant, sendMessage } from "./message.js";
@@ -514,9 +515,12 @@ export async function getChatDetail(db: Database, chatId: string, selfAgentId: s
       type: agents.type,
       avatarColorToken: agents.avatarColorToken,
       avatarImageUpdatedAt: agents.avatarImageUpdatedAt,
+      userAvatarUrl: users.avatarUrl,
     })
     .from(chatMembership)
     .innerJoin(agents, eq(chatMembership.agentId, agents.uuid))
+    .leftJoin(members, eq(members.agentId, agents.uuid))
+    .leftJoin(users, eq(users.id, members.userId))
     .where(and(eq(chatMembership.chatId, chatId), eq(chatMembership.accessMode, "speaker")));
 
   // Compute server-resolved `title` + `firstMessagePreview` so the agent
@@ -549,7 +553,12 @@ export async function getChatDetail(db: Database, chatId: string, selfAgentId: s
     displayName: p.displayName,
     type: p.type,
     avatarColorToken: p.avatarColorToken ?? null,
-    avatarImageUrl: agentAvatarImageUrl(p.agentId, p.avatarImageUpdatedAt ?? null),
+    avatarImageUrl: resolveAvatarImageUrl({
+      uuid: p.agentId,
+      type: p.type,
+      avatarImageUpdatedAt: p.avatarImageUpdatedAt,
+      userAvatarUrl: p.userAvatarUrl,
+    }),
   }));
 
   // Match the chatDetailSchema wire contract — the chat-first workspace
@@ -633,11 +642,28 @@ export async function listChatParticipantsWithNames(db: Database, chatId: string
       type: agents.type,
       avatarColorToken: agents.avatarColorToken,
       avatarImageUpdatedAt: agents.avatarImageUpdatedAt,
+      userAvatarUrl: users.avatarUrl,
     })
     .from(chatMembership)
     .innerJoin(agents, eq(chatMembership.agentId, agents.uuid))
+    .leftJoin(members, eq(members.agentId, agents.uuid))
+    .leftJoin(users, eq(users.id, members.userId))
     .where(and(eq(chatMembership.chatId, chatId), eq(chatMembership.accessMode, "speaker")));
-  return rows;
+  return rows.map((r) => ({
+    agentId: r.agentId,
+    role: r.role,
+    joinedAt: r.joinedAt,
+    name: r.name,
+    displayName: r.displayName,
+    type: r.type,
+    avatarColorToken: r.avatarColorToken,
+    avatarImageUrl: resolveAvatarImageUrl({
+      uuid: r.agentId,
+      type: r.type,
+      avatarImageUpdatedAt: r.avatarImageUpdatedAt,
+      userAvatarUrl: r.userAvatarUrl,
+    }),
+  }));
 }
 
 export async function assertParticipant(db: Database, chatId: string, agentId: string): Promise<void> {

--- a/packages/server/src/services/me-chat.ts
+++ b/packages/server/src/services/me-chat.ts
@@ -39,9 +39,11 @@ import type { Database } from "../db/connection.js";
 import { agents } from "../db/schema/agents.js";
 import { chatMembership } from "../db/schema/chat-membership.js";
 import { chatUserState } from "../db/schema/chat-user-state.js";
+import { members } from "../db/schema/members.js";
 import { messages } from "../db/schema/messages.js";
+import { users } from "../db/schema/users.js";
 import { BadRequestError, CallerNotSpeakerError, NotFoundError } from "../errors.js";
-import { agentAvatarImageUrl } from "./agent.js";
+import { resolveAvatarImageUrl } from "./agent.js";
 import { resolveAgentChatStatuses } from "./agent-chat-status.js";
 import { createChat } from "./chat.js";
 import { invalidateChatAudience } from "./chat-audience-cache.js";
@@ -415,9 +417,12 @@ export async function listMeChats(
       type: agents.type,
       avatarColorToken: agents.avatarColorToken,
       avatarImageUpdatedAt: agents.avatarImageUpdatedAt,
+      userAvatarUrl: users.avatarUrl,
     })
     .from(chatMembership)
     .innerJoin(agents, eq(chatMembership.agentId, agents.uuid))
+    .leftJoin(members, eq(members.agentId, agents.uuid))
+    .leftJoin(users, eq(users.id, members.userId))
     .where(and(inArray(chatMembership.chatId, chatIds), eq(chatMembership.accessMode, "speaker")));
 
   const participantsByChat = new Map<string, MeChatRow["participants"]>();
@@ -431,14 +436,12 @@ export async function listMeChats(
       displayName: p.displayName,
       type: p.type,
       avatarColorToken: p.avatarColorToken,
-      // Chat list intentionally retains the agent-only avatar path — it
-      // does NOT fall back to `users.avatar_url` for human participants.
-      // The detail-view surfaces (message bubbles, ParticipantsHeader)
-      // use `resolveAvatarImageUrl` via `/agents` / `/me/managed-agents`
-      // and DO honor the human → GitHub fallback. Keep the chat row
-      // unchanged so the existing visual contract (first-letter / hue
-      // for humans without an upload) stays stable.
-      avatarImageUrl: agentAvatarImageUrl(p.agentId, p.avatarImageUpdatedAt),
+      avatarImageUrl: resolveAvatarImageUrl({
+        uuid: p.agentId,
+        type: p.type,
+        avatarImageUpdatedAt: p.avatarImageUpdatedAt,
+        userAvatarUrl: p.userAvatarUrl,
+      }),
     });
     participantsByChat.set(p.chatId, list);
     if (p.type !== "human") {


### PR DESCRIPTION
## Summary
- Resolve chat participant avatars through the canonical server avatar resolver.
- Add human backing-user avatar joins for chat list, chat detail, and participant projections.
- Keep non-human agents without uploads on the initials fallback while preserving uploaded-avatar precedence.

## Verification
- pnpm --filter @first-tree/server test -- --run src/__tests__/chat-detail-avatar-fields.test.ts
- pnpm --filter @first-tree/server test -- --run src/__tests__/me-chat-service.test.ts
- pnpm check && pnpm typecheck

Note: the two focused server test commands currently run the full server test suite via the package script; both runs passed (161 files, 1426 tests).
