### PR TITLE
fix: guard chat description against literal \n escapes

### DIFF
--- a/apps/cli/src/__tests__/chat-attention-commands-extra.test.ts
+++ b/apps/cli/src/__tests__/chat-attention-commands-extra.test.ts
@@ -452,6 +452,46 @@ describe("chat command behavior", () => {
     });
   });
 
+  it("guards --description against literal \\n escapes on update and create, with a stdin escape hatch", async () => {
+    const sdk = localAgentMocks.createSdk();
+
+    // update: a one-line description whose newlines are literal `\n` escapes is
+    // rejected before any write, with a copyable heredoc hint on stderr.
+    await expect(
+      runChat(["update", "--description", "line1\\n\\n**title**\\nline3", "--chat", "chat-1"]),
+    ).rejects.toMatchObject({ code: "ESCAPED_NEWLINES", exitCode: 2 });
+    expect(sdk.updateChat).not.toHaveBeenCalled();
+    const updateHint = printLineMock.mock.calls.map((call) => String(call[0])).join("");
+    expect(updateHint).toContain("chat update --description -");
+
+    // Narrow by design: a single escaped `\n` in prose stays writable.
+    await runChat(["update", "--description", "see `\\n` in the logs", "--chat", "chat-1"]);
+    expect(sdk.updateChat).toHaveBeenLastCalledWith("chat-1", { description: "see `\\n` in the logs" });
+
+    // `--description -` reads the description from stdin (real newlines) and
+    // skips the guard — the escape hatch for an intentional literal `\n` body.
+    ioMocks.readStdin.mockResolvedValueOnce("first line\n\n**second** line");
+    await runChat(["update", "--description", "-", "--chat", "chat-1"]);
+    expect(sdk.updateChat).toHaveBeenLastCalledWith("chat-1", { description: "first line\n\n**second** line" });
+
+    // `--description -` with no piped stdin (TTY) is a usage error, not a write.
+    ioMocks.readStdin.mockResolvedValueOnce(null);
+    await expect(runChat(["update", "--description", "-", "--chat", "chat-1"])).rejects.toMatchObject({
+      code: "NO_STDIN",
+      exitCode: 2,
+    });
+
+    // create: the same inline guard fires before the chat is created; its hint
+    // points at ANSI-C `$'...'` quoting (stdin is taken by the first message).
+    printLineMock.mockClear();
+    await expect(
+      runChat(["create", "--to", "nova", "hello", "--description", "alpha\\nbeta\\ngamma"]),
+    ).rejects.toMatchObject({ code: "ESCAPED_NEWLINES", exitCode: 2 });
+    expect(sdk.createTaskChat).not.toHaveBeenCalled();
+    const createHint = printLineMock.mock.calls.map((call) => String(call[0])).join("");
+    expect(createHint).toContain("$'first line");
+  });
+
   it("opens an interactive chat, polls, sends input, handles send failures, and closes cleanly", async () => {
     const emitter = new EventEmitter() as EventEmitter & { prompt: () => void };
     emitter.prompt = vi.fn();

--- a/apps/cli/src/__tests__/chat-attention-commands-extra.test.ts
+++ b/apps/cli/src/__tests__/chat-attention-commands-extra.test.ts
@@ -481,6 +481,19 @@ describe("chat command behavior", () => {
       exitCode: 2,
     });
 
+    // The deprecated `set-topic` / `rename` alias is also a description write
+    // entry point, so it inherits the same guard and `--description -` hatch.
+    await expect(runChat(["set-topic", "--description", "x\\ny\\nz", "--chat", "chat-1"])).rejects.toMatchObject({
+      code: "ESCAPED_NEWLINES",
+      exitCode: 2,
+    });
+    await expect(runChat(["rename", "Launch", "--description", "x\\ny\\nz", "--chat", "chat-1"])).rejects.toMatchObject(
+      { code: "ESCAPED_NEWLINES", exitCode: 2 },
+    );
+    ioMocks.readStdin.mockResolvedValueOnce("alpha\n\nbeta");
+    await runChat(["set-topic", "--description", "-", "--chat", "chat-1"]);
+    expect(sdk.updateChat).toHaveBeenLastCalledWith("chat-1", { description: "alpha\n\nbeta" });
+
     // create: the same inline guard fires before the chat is created; its hint
     // points at ANSI-C `$'...'` quoting (stdin is taken by the first message).
     printLineMock.mockClear();

--- a/apps/cli/src/commands/chat/_shared/io.ts
+++ b/apps/cli/src/commands/chat/_shared/io.ts
@@ -1,4 +1,6 @@
 import { fail } from "../../../cli/output.js";
+import { channelConfig } from "../../../core/channel.js";
+import { print } from "../../../core/output.js";
 
 const MAX_STDIN_BYTES = 5 * 1024 * 1024;
 
@@ -45,6 +47,64 @@ export function looksLikeEscapedNewlineBody(body: string): boolean {
   if (body.includes("\n")) return false;
   const escapes = body.match(/\\n/g);
   return (escapes?.length ?? 0) >= 2;
+}
+
+/**
+ * Guard an inline `--description` (chat update / create) exactly the way
+ * `chat send` guards a message body. A chat description is authored markdown,
+ * surfaced verbatim in the chat sidebar and in every agent's prompt. When its
+ * newlines arrive as literal `\n` escapes — a one-line
+ * `chat update --description "line1\n\nline2"` whose shell quotes never expand
+ * `\n` — the stored value differs from the intended markdown structure and
+ * renders as one long line with visible `\n` tokens. The correction belongs
+ * before the write, not in UI rendering, so reject the malformed value here
+ * with a copyable fix instead of persisting it.
+ *
+ * `supportsStdin` selects the escape hatch the hint offers: `chat update` has
+ * no message body, so it can take the description from stdin via
+ * `--description -`; `chat create` already consumes stdin for its initial
+ * message, so it points to ANSI-C `$'...\n...'` quoting instead. Detection is
+ * shared with the send-body guard (`looksLikeEscapedNewlineBody`): narrow by
+ * design, so prose that merely mentions `\n` once stays writable.
+ */
+export function guardInlineDescription(value: string, opts: { supportsStdin: boolean }): void {
+  if (!looksLikeEscapedNewlineBody(value)) return;
+  const bin = channelConfig.binName;
+  // The copyable retry form goes through `print.line` — plain multi-line
+  // stderr text (silenced in --json mode). The fail envelope below stays a
+  // single-line JSON object per the Print-layer contract; embedding the
+  // heredoc example there would itself arrive `\n`-escaped, the exact bug.
+  if (opts.supportsStdin) {
+    print.line(
+      "chat update: --description arrived with literal \\n escapes — shell quotes do not expand \\n, " +
+        "so it would render as one long unformatted line in the chat sidebar. Resend with real newlines " +
+        "via stdin:\n\n" +
+        `  cat <<'EOF' | ${bin} chat update --description -\n` +
+        "  first line\n" +
+        "\n" +
+        "  **second** line\n" +
+        "  EOF\n\n" +
+        "(or pass an ANSI-C quoted string: --description $'first line\\n\\n**second** line'. " +
+        "stdin is not checked — pipe the body if literal \\n text is intentional.)\n\n",
+    );
+  } else {
+    print.line(
+      "chat create: --description arrived with literal \\n escapes — shell quotes do not expand \\n, " +
+        "so it would render as one long unformatted line in the chat sidebar. Pass real newlines via an " +
+        "ANSI-C quoted string instead:\n\n" +
+        "  --description $'first line\\n\\n**second** line'\n\n",
+    );
+  }
+  fail(
+    "ESCAPED_NEWLINES",
+    'Inline --description contains literal "\\n" escapes and no real newlines — it would render as one ' +
+      "long unformatted line in the chat sidebar. " +
+      (opts.supportsStdin
+        ? "Resend the description via stdin (`--description -`) with real newlines, or use an ANSI-C $'...' " +
+          "string (copyable forms printed above)."
+        : "Use an ANSI-C $'...\\n...' string with real newlines (copyable form printed above)."),
+    2,
+  );
 }
 
 export function parseLimit(value: string, max: number): number {

--- a/apps/cli/src/commands/chat/create.ts
+++ b/apps/cli/src/commands/chat/create.ts
@@ -4,7 +4,7 @@ import type { Command } from "commander";
 import { fail, success } from "../../cli/output.js";
 import { captureOutboundDocs } from "../../core/doc-capture.js";
 import { createSdk, handleSdkError } from "../_shared/local-agent.js";
-import { readStdin } from "./_shared/io.js";
+import { guardInlineDescription, readStdin } from "./_shared/io.js";
 import { buildRequestMetadata } from "./_shared/request.js";
 
 interface CreateOptions {
@@ -109,6 +109,13 @@ export function registerChatCreateCommand(chat: Command): void {
         const content = message ?? (await readStdin());
         if (!content || content.trim().length === 0) {
           fail("NO_MESSAGE", "No message provided. Pass as argument or pipe via stdin.", 2);
+        }
+
+        // The initial message already consumes stdin, so `--description` is
+        // inline-only here: reject a literal `\n`-escaped value before the
+        // chat is created (the hint points to ANSI-C `$'...'` quoting).
+        if (options.description !== undefined) {
+          guardInlineDescription(options.description, { supportsStdin: false });
         }
 
         let metadata: Record<string, unknown> | undefined;

--- a/apps/cli/src/commands/chat/set-topic.ts
+++ b/apps/cli/src/commands/chat/set-topic.ts
@@ -1,5 +1,6 @@
 import type { Command } from "commander";
 import { fail } from "../../cli/output.js";
+import { guardInlineDescription, readStdin } from "./_shared/io.js";
 import { applyChatUpdate } from "./update.js";
 
 type Options = {
@@ -67,7 +68,26 @@ async function run(topicArg: string | undefined, options: Options): Promise<void
   if (options.clearDescription === true) {
     body.description = null;
   } else if (options.description !== undefined) {
-    const trimmed = options.description.trim();
+    // Same authoring-surface guard as `chat update`: `--description -` reads
+    // real newlines from stdin (guard skipped — the escape hatch), any other
+    // value is guarded against the literal `\n` shape before the write.
+    let resolved: string;
+    if (options.description === "-") {
+      const piped = await readStdin();
+      if (piped === null) {
+        fail(
+          "NO_STDIN",
+          "`--description -` reads the description from stdin, but stdin is a TTY (nothing piped). " +
+            "Pipe it: `cat <<'EOF' | … chat update --description -` … `EOF`.",
+          2,
+        );
+      }
+      resolved = piped;
+    } else {
+      guardInlineDescription(options.description, { supportsStdin: true });
+      resolved = options.description;
+    }
+    const trimmed = resolved.trim();
     if (trimmed.length === 0) {
       fail("EMPTY_DESCRIPTION", "Description cannot be empty. Use --clear-description to unset.", 2);
     }

--- a/apps/cli/src/commands/chat/update.ts
+++ b/apps/cli/src/commands/chat/update.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 import { fail, success } from "../../cli/output.js";
 import { createSdk, handleSdkError } from "../_shared/local-agent.js";
+import { guardInlineDescription, readStdin } from "./_shared/io.js";
 
 type Options = {
   chat?: string;
@@ -91,7 +92,28 @@ async function run(options: Options): Promise<void> {
   if (options.clearDescription === true) {
     body.description = null;
   } else if (options.description !== undefined) {
-    const trimmed = options.description.trim();
+    // `--description -` reads the description from stdin (heredoc): real
+    // newlines survive and the escaped-newline guard is intentionally skipped,
+    // so it doubles as the escape hatch for an intentional literal `\n` body.
+    // Any other value is an inline string the shell did not expand, so guard
+    // it against the literal `\n` shape before persisting.
+    let resolved: string;
+    if (options.description === "-") {
+      const piped = await readStdin();
+      if (piped === null) {
+        fail(
+          "NO_STDIN",
+          "`--description -` reads the description from stdin, but stdin is a TTY (nothing piped). " +
+            "Pipe it: `cat <<'EOF' | … chat update --description -` … `EOF`.",
+          2,
+        );
+      }
+      resolved = piped;
+    } else {
+      guardInlineDescription(options.description, { supportsStdin: true });
+      resolved = options.description;
+    }
+    const trimmed = resolved.trim();
     if (trimmed.length === 0) {
       fail("EMPTY_DESCRIPTION", "Description cannot be empty. Use --clear-description to unset.", 2);
     }
@@ -108,7 +130,11 @@ export function registerChatUpdateCommand(chat: Command): void {
     .option("--chat <chatId>", "Target chat id (default: FIRST_TREE_CHAT_ID)")
     .option("--topic <text>", "Set the chat's short display label")
     .option("--clear-topic", "Clear the topic (falls back to auto-derived title)")
-    .option("--description <text>", "Set the chat's work summary + status report (Markdown supported)")
+    .option(
+      "--description <text>",
+      "Set the chat's work summary + status report (Markdown supported). Pass `-` to read it from stdin/heredoc " +
+        "when the body has real newlines (avoids literal \\n escapes).",
+    )
     .option("--clear-description", "Clear the description (sets it to null)")
     .option("--agent <name>", "Agent name on the First Tree server (default: first configured on this client)")
     .action(async (options: Options) => {

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -267,7 +267,7 @@ first-tree chat
 ├── history <chatId>
 ├── update                                           # update topic and/or description (each independently)
 │     --topic <text> / --clear-topic                 #   set/clear the short display label
-│     --description <text> / --clear-description      #   set/clear the work summary + status report (Markdown)
+│     --description <text> / --clear-description      #   set/clear the work summary + status report (Markdown; `-` = read from stdin/heredoc)
 │     --chat <chatId> / --agent <name>               #   target another chat / the named agent
 ├── set-topic [topic]                                # [DEPRECATED — use `update`] hidden alias
 └── open <agent-name>                                # interactive REPL
@@ -355,6 +355,17 @@ first-tree chat update --topic "review PR #916"
 first-tree chat update --description "Reviewing PR #916. **Plan:** address review findings, re-verify. **Progress:** 2/3 findings fixed."
 first-tree chat update --topic "ship plan" --description "Drafting; next: hand to QA."
 first-tree chat update --clear-description
+# A one-line --description whose newlines are written as literal `\n` is rejected
+# before the write: shell quotes do not expand `\n`, so it would persist and
+# render as one long line with visible `\n` tokens. For a multi-line description
+# pass real newlines — either an ANSI-C $'...' string, or `--description -` to
+# read it from stdin/heredoc:
+cat <<'EOF' | first-tree chat update --description -
+Reviewing PR #916.
+
+**Plan:** address review findings, re-verify.
+**Progress:** 2/3 findings fixed.
+EOF
 # `chat set-topic` still works as a deprecated alias.
 
 # Interactive


### PR DESCRIPTION
## Problem

A chat `description` whose Markdown does not render — the sidebar shows one long line with visible `\n` tokens instead of line breaks. Reported as recurring.

**Root cause:** `chat update --description` and `chat create --description` persisted the inline value verbatim. POSIX shells do not expand `\n` inside quotes, so a one-line `chat update --description "line1\n\nline2"` stores a literal backslash-n body, and the renderer faithfully shows it as one unformatted line. `chat send` already rejects this exact shape for message bodies (`looksLikeEscapedNewlineBody`), but the description authoring surface had no equivalent guard — which is why it kept happening.

## Fix

- Extract a shared `guardInlineDescription(value, { supportsStdin })` helper next to the send-body detector. It rejects an evidently multi-line escaped-newline `--description` **before** the write, with a copyable fix on stderr and a single-line JSON error envelope (`ESCAPED_NEWLINES`, exit 2) — same contract as the send guard.
- `chat update` gains a `--description -` stdin/heredoc escape hatch: real newlines survive and the guard is intentionally skipped, so it also covers an intentional literal `\n` body.
- `chat create` points to ANSI-C `$'...\n...'` quoting instead, since its stdin is already consumed by the initial message.
- Detection is the narrow existing rule (≥2 escaped `\n`, zero real newlines), so prose that merely mentions `\n` once still saves.
- Docs: `docs/cli-reference.md` documents `--description -` and the heredoc form.

## Tests

Added to `chat-attention-commands-extra.test.ts`: update inline rejection (no write, heredoc hint), narrow-guard pass-through, `--description -` stdin acceptance, `--description -` TTY error, and create inline rejection (no chat created, `$'...'` hint). Full CLI suite green (477 passing), typecheck + biome clean.

## Companion tree PR

Records the constraint on the description contract: agent-team-foundation/first-tree-context#547

🤖 Generated with [Claude Code](https://claude.com/claude-code)