### PR TITLE
fix: resolve a pinned question on Enter for options-only answers

### DIFF
--- a/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
@@ -861,6 +861,91 @@ describe("ChatView", () => {
     await act(async () => root.unmount());
   });
 
+  it("resolves an options-only answer via Enter while focus is off the composer", async () => {
+    const { ChatView } = await import("../chat-view.js");
+    const dockMessages = messages([
+      message({
+        id: "req-enter",
+        senderId: "agent-1",
+        format: "request",
+        content: "Pick the deploy color.",
+        metadata: {
+          mentions: ["human-agent-self"],
+          request: {
+            subject: "Deploy",
+            questions: [
+              {
+                id: "q1",
+                prompt: "Deploy color?",
+                kind: "single",
+                options: ["Blue-green", "Rolling update"],
+                required: true,
+              },
+            ],
+          },
+        },
+        createdAt: "2026-05-28T12:00:00.000Z",
+      }),
+    ]);
+    const { container, queryClient, root } = await renderDom(
+      <ChatView agentId="agent-1" chatId="chat-1" />,
+      (client) => seedChat(client, chatDetail(), messages([])),
+      "/",
+    );
+
+    await act(async () => {
+      queryClient.setQueryData(["chat-messages", "chat-1"], dockMessages);
+    });
+    await flush();
+    await waitForText(container, "Awaiting your answer");
+
+    const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
+    if (!textarea) throw new Error("Composer textarea missing");
+
+    // Enter is dispatched on the focused option radio (a composer-footer
+    // descendant) and bubbles to the footer-scoped backstop — mirroring the
+    // real focus path after a pill click, and proving the listener is scoped to
+    // the composer subtree rather than `window`.
+    const optionRadio = () => {
+      const radio = optionByText(container, "Blue-green")?.querySelector<HTMLInputElement>('input[type="radio"]');
+      if (!radio) throw new Error("Option radio missing");
+      return radio;
+    };
+    const pressEnterOnRadio = async () => {
+      await act(async () => {
+        const radio = optionRadio();
+        radio.focus();
+        radio.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true }));
+      });
+    };
+
+    // No answer yet → Enter must be a no-op (the backstop isn't bound while the
+    // question is unresolvable, so a focused-but-unselected radio sends nothing).
+    await pressEnterOnRadio();
+    await flush();
+    expect(chatMocks.sendChatMessage).not.toHaveBeenCalled();
+
+    // Pick an option and type nothing — focus stays on the radio, off the
+    // composer. This is the exact path that previously left Enter dead: the
+    // composer's own keydown never fired, so the dock's "↵ Send" promise was
+    // broken for the no-typing answer.
+    await click(optionByText(container, "Blue-green"));
+    expect(textarea.value).toBe("");
+    expect(document.activeElement).not.toBe(textarea);
+
+    await pressEnterOnRadio();
+    await waitForCondition(
+      () => chatMocks.sendChatMessage.mock.calls.length > 0,
+      "Expected Enter to resolve the options-only answer",
+    );
+    expect(chatMocks.sendChatMessage).toHaveBeenCalledWith("chat-1", "Deploy color? → Blue-green", ["agent-1"], {
+      inReplyTo: "req-enter",
+      resolves: { request: "req-enter", kind: "answered" },
+    });
+
+    await act(async () => root.unmount());
+  });
+
   it("enables Send and resolves when an option question is answered with free text (no option picked)", async () => {
     const { ChatView } = await import("../chat-view.js");
     const dockMessages = messages([

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -912,6 +912,13 @@ export function ChatView({
   }, [hasDocPreview, showSidebar, setSidebarByUser]);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  // The composer footer band — wraps BOTH the request dock (with its option
+  // radios) and the composer. The Enter-to-resolve backstop binds its keydown
+  // listener here, not on `window`, so it only sees keys from inside the
+  // composer/dock subtree: a portaled dialog (custom Select listbox, Radix
+  // dialog) rendered over a still-mounted chat can't bubble Enter into it and
+  // silently resolve the pinned question in the background.
+  const composerFooterRef = useRef<HTMLDivElement | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   // Scrollable container that holds the message timeline. Ref is wired
   // up on the corresponding <div> below; consumed by useChatScroll (for
@@ -1580,6 +1587,41 @@ export function ChatView({
   const pickDockOption = (prompt: string, option: string) => {
     setAnswerSelections((prev) => ({ ...prev, [prompt]: option }));
   };
+  // Enter-to-resolve backstop while a question is pinned. The composer textarea
+  // already sends on Enter when it's focused — but an options-only answer never
+  // touches the composer: the viewer clicks a pill, focus lands on the (sr-only)
+  // radio, and Enter never reaches the composer's handler, so the dock's "↵ Send
+  // answers and resolves this question" promise was broken for the no-typing
+  // path. Bind on the composer-footer subtree (not `window`) so only keys from
+  // inside the composer/dock reach it — a portaled dialog over the chat can't
+  // resolve the pinned question from the background. Fire from anywhere in that
+  // subtree EXCEPT a control that owns Enter itself (the composer textarea / any
+  // other text input / a button / a link); radios and checkboxes do not, so
+  // Enter on a selected option pill resolves. Only bound while the answer is
+  // actually resolvable (`dockCanResolve`), so Enter is a no-op on a still-
+  // unanswered required question. `handleSend` is read through a ref so the
+  // listener never goes stale or re-subscribes per render.
+  const handleSendRef = useRef(handleSend);
+  handleSendRef.current = handleSend;
+  useEffect(() => {
+    const footer = composerFooterRef.current;
+    if (!footer || !dockRequest || !dockCanResolve) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Enter" || event.shiftKey || event.isComposing) return;
+      const active = document.activeElement;
+      const ownsEnter =
+        active instanceof HTMLTextAreaElement ||
+        active instanceof HTMLButtonElement ||
+        active instanceof HTMLAnchorElement ||
+        (active instanceof HTMLInputElement && active.type !== "radio" && active.type !== "checkbox") ||
+        (active instanceof HTMLElement && active.isContentEditable);
+      if (ownsEnter) return;
+      event.preventDefault();
+      void handleSendRef.current();
+    };
+    footer.addEventListener("keydown", onKeyDown);
+    return () => footer.removeEventListener("keydown", onKeyDown);
+  }, [dockRequest, dockCanResolve]);
   useEffect(() => {
     if (!dockRequestId || draft !== "@" || !autoPrimedDraftRef.current) return;
     // Real message data can arrive after an empty group composer already
@@ -3022,6 +3064,7 @@ export function ChatView({
           the home-indicator doesn't overlap the send button. */}
           {
             <div
+              ref={composerFooterRef}
               className="shrink-0"
               style={{
                 padding: "var(--sp-2_5) var(--sp-6) calc(var(--sp-3) + env(safe-area-inset-bottom, 0))",


### PR DESCRIPTION
## Problem

Answering a blocking structured-request question has two channels: clicking an option pill (stored in `answerSelections`) and typing free text in the composer. Enter-to-send was wired **only** on the composer textarea's own `onKeyDown`, so it fired only while the textarea was focused.

An **options-only** answer never touches the composer — clicking a pill moves focus to the (sr-only) radio — so **Enter never reached the handler**, even though the dock's helper line promises *"↵ Send answers and resolves this question"*. Typing text worked (composer focused); picking an option alone did not.

Reported via blocking-reply regression testing:
- ✅ with composer text → Enter sends
- ❌ option selected, composer empty → Enter does nothing (Send button still worked)

## Fix

Add an Enter-to-resolve backstop bound on the **composer-footer subtree** (which wraps both the dock and the composer), active only while the pinned question is resolvable (`dockCanResolve`). It resolves on Enter from anywhere in that subtree **except** a control that owns Enter itself (the composer textarea, another text input, a button, a link); radios/checkboxes do not, so Enter on a selected option pill resolves.

- **Scoped to the footer, not `window`** — a portaled dialog (custom `Select` listbox, Radix dialog) rendered over a still-mounted chat can't bubble Enter into the listener and silently resolve the pinned question in the background.
- **No double-send** — the composer-focused path is unchanged (its own handler still fires; the backstop early-returns on a focused textarea).
- **No-op when unresolvable** — the listener isn't bound until every required question is answered.

## Adversarial review + similar-bug sweep

This change was adversarially reviewed (double-send, IME, event ordering, ref-during-render under StrictMode, cleanup, global-hijack) — the one real finding (a `window`-global listener could resolve from a portaled dialog over the chat) is addressed by the footer-scoping above. A sweep of all keyboard affordances in `packages/web` for the same "promise vs. focus-gated handler" pattern found no other instances.

## Test

Adds a regression test: options-only answer + Enter (dispatched on the focused option radio, bubbling to the footer-scoped backstop) resolves the question; Enter before any answer is a no-op. `pnpm --filter @first-tree/web vitest` (chat-view + request-card/dock DOM suites), `tsc --noEmit`, and biome all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)