### PR TITLE
[codex] Clarify GitHub unfollow guidance

### DIFF
--- a/apps/cli/src/commands/github/follow.ts
+++ b/apps/cli/src/commands/github/follow.ts
@@ -48,7 +48,7 @@ export function registerGithubFollowCommand(github: Command): void {
         const hint =
           status === "created"
             ? "Now following — every event on it will wake the wiring agent in this chat. " +
-              `Unfollow when the task's attention span closes: \`${channelConfig.binName} github unfollow ${wired.entityKey}\`.`
+              `If the human asks this chat to stop tracking it later: \`${channelConfig.binName} github unfollow ${wired.entityKey}\`.`
             : status === "rebound"
               ? "Line moved — events now route into this chat (the previous chat goes quiet)."
               : "Already following in this chat — idempotent success, do not retry.";

--- a/apps/cli/src/commands/github/index.ts
+++ b/apps/cli/src/commands/github/index.ts
@@ -8,7 +8,7 @@ export function registerGithubCommands(program: Command): void {
     .command("github")
     .description(
       "GitHub entity attention — follow / unfollow / following. Follow wires an entity's webhook events " +
-        "into the current chat; unfollow declares the task's attention span over. One line, one room: a " +
+        "into the current chat; unfollow explicitly stops this chat from tracking the entity. One line, one room: a " +
         "(human, delegate) line lives in exactly one chat (409 → --rebind moves it, never duplicates).",
     );
   registerGithubFollowCommand(github);

--- a/apps/cli/src/commands/github/unfollow.ts
+++ b/apps/cli/src/commands/github/unfollow.ts
@@ -12,7 +12,7 @@ export function registerGithubUnfollowCommand(github: Command): void {
   github
     .command("unfollow <entity>")
     .description(
-      "Unfollow a GitHub entity: the task this chat carries no longer concerns it. Severs EVERY line wired " +
+      "Unfollow a GitHub entity when the human wants this chat to stop tracking it. Severs EVERY line wired " +
         "into this chat for the entity, however it was created (follow, mention, Fixes #N). An explicit " +
         "@mention of a team member still reaches them afterwards — in a NEW chat, never back into this one.",
     )

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -388,11 +388,12 @@ effective sender so the first message can wake the agent normally.
 
 GitHub entity attention for the current chat. `follow` wires an entity's
 webhook event stream into the chat (one routing line, chat-scoped);
-`unfollow` declares the task's attention over and severs every line wired
-into the chat for that entity, however it was created. Creating a PR or
-issue never follows it automatically — declare the dependency explicitly,
-immediately after creation. Decision guidance (when to follow / not
-follow / unfollow, 409 handling) lives in the `first-tree-github` skill.
+`unfollow` explicitly stops this chat from tracking the entity and severs
+every line wired into the chat for that entity, however it was created.
+Creating a PR or issue never follows it automatically — declare the
+dependency explicitly, immediately after creation. Decision guidance
+(when to follow / not follow / unfollow, 409 handling) lives in the
+`first-tree-github` skill.
 
 ```
 first-tree github

--- a/packages/client/src/__tests__/agent-briefing.test.ts
+++ b/packages/client/src/__tests__/agent-briefing.test.ts
@@ -686,9 +686,10 @@ describe("buildAgentBriefing — # Working in First Tree subsections", () => {
     expect(briefing).toContain("first-tree github follow <url>");
     // The single exception: clearly unrelated to the chat's task.
     expect(briefing).toMatch(/clearly unrelated to this\s+chat's task/);
-    // Unfollow is human-explicit-stop or closed attention span.
+    // Unfollow is human-explicit-stop only, not a PR/Issue completion ritual.
     expect(briefing).toContain("first-tree github unfollow <entity>");
     expect(briefing).toMatch(/human explicitly asks to stop tracking/);
+    expect(briefing).toMatch(/Do not proactively unfollow\s+merely because a PR or Issue completed/);
     // Creation never auto-follows — the extractor is gone (#979).
     expect(briefing).toMatch(/there\s+is no auto-binding/);
   });

--- a/packages/client/src/runtime/agent-briefing.ts
+++ b/packages/client/src/runtime/agent-briefing.ts
@@ -636,9 +636,10 @@ and there is no auto-binding. Declaring the dependency is your job:
 
   Skip the follow only when the entity is clearly unrelated to this
   chat's task.
-- **Unfollow when the human explicitly asks to stop tracking** the entity
-  (\`${bin} github unfollow <entity>\`), or when the task's attention span
-  on it has genuinely closed.
+- **Unfollow only when the human explicitly asks to stop tracking** the
+  entity (\`${bin} github unfollow <entity>\`). Do not proactively unfollow
+  merely because a PR or Issue completed, merged, or closed; terminal
+  entities may still carry aftermath this chat should hear.
 
 ${fullGuide}`;
 }

--- a/packages/server/src/services/github-entity-follow.ts
+++ b/packages/server/src/services/github-entity-follow.ts
@@ -509,10 +509,10 @@ export async function declareEntityFollow(
 }
 
 /**
- * Unfollow: the task's attention span on the entity is over. Deletes EVERY
- * mapping row pointing at this chat for the entity — whatever pair or
- * `bound_via` wrote it (R10) — and reports the count. Never touches the
- * GitHub API; always succeeds (R4: `removed: 0` is terminal success).
+ * Unfollow: explicit stop-tracking for this chat. Deletes EVERY mapping row
+ * pointing at this chat for the entity — whatever pair or `bound_via` wrote
+ * it (R10) — and reports the count. Never touches the GitHub API; always
+ * succeeds (R4: `removed: 0` is terminal success).
  *
  * Matching is case-insensitive on the key (GitHub repo slugs are
  * case-insensitive) and prefix-based for commit shas so a short sha

--- a/skills/first-tree-github/SKILL.md
+++ b/skills/first-tree-github/SKILL.md
@@ -3,7 +3,7 @@ name: first-tree-github
 version: 0.1.1
 cliCompat:
   first-tree: ">=0.5.0 <0.6.0"
-description: "Follow / unfollow a GitHub entity (PR, Issue, Discussion, Commit) so its webhook events route into the current chat. Following your own just-created PR or issue is the DEFAULT: use IMMEDIATELY after you create one through any path (`gh pr create`, curl, GitHub MCP, the web UI) — creation never follows for you. Also use when the user asks to watch / track / follow / 关注 / 盯着 a PR or issue; when your current task is blocked on an upstream entity's progress; or to unfollow when the user explicitly asks to stop tracking (unfollow / 取消关注 / stop watching) or the task no longer concerns a followed entity."
+description: "Follow / unfollow a GitHub entity (PR, Issue, Discussion, Commit) so its webhook events route into the current chat. Following your own just-created PR or issue is the DEFAULT: use IMMEDIATELY after you create one through any path (`gh pr create`, curl, GitHub MCP, the web UI) — creation never follows for you. Also use when the user asks to watch / track / follow / 关注 / 盯着 a PR or issue; when your current task is blocked on an upstream entity's progress; or to unfollow when the user explicitly asks to stop tracking (unfollow / 取消关注 / stop watching). Do not proactively unfollow merely because a PR or Issue completed, merged, or closed."
 ---
 
 # First Tree — Follow a GitHub Entity
@@ -31,12 +31,12 @@ GitHub MCP, the web UI — wires anything for you. If the task depends on
 what you just created, declaring that dependency is YOUR job, immediately
 after creation.
 
-**Unfollowing declares the task's attention span over:** the task this
-chat carries is no longer concerned with the entity. It disconnects
-**all** lines wired into this chat for that entity, no matter how they
-were created — explicit follow, a mention, or a `Fixes #N` link. Think
-of follow/unfollow as the opening and closing bracket of the task's
-attention on the entity.
+**Unfollowing is an explicit stop-tracking action:** use it when the
+human asks this chat to stop receiving the entity's events. It
+disconnects **all** lines wired into this chat for that entity, no
+matter how they were created — explicit follow, a mention, or a
+`Fixes #N` link. It is not a completion ritual: do not proactively
+unfollow merely because a PR or Issue completed, merged, or closed.
 
 ## Commands
 
@@ -75,16 +75,16 @@ is for terminal / cross-chat use.
    event costs a wake for you and attention for the human — wire the
    stream into the chat whose task actually needs it.
 
-**Unfollow when — the task's attention span on the entity closes:**
+**Unfollow when — the human explicitly asks this chat to stop tracking:**
 
-1. The dependency is resolved: upstream merged / closed and the
-   follow-ups no longer affect this task.
-2. The task's scope has moved on and you no longer act on the entity's
-   events.
-3. The human asks to stop.
+1. The human asks to stop, unfollow, unsubscribe, cancel watching, or
+   otherwise end this chat's GitHub event stream for the entity.
 
-If you find yourself ignoring a followed entity's events turn after
-turn, that is the signal to close the bracket — unfollow.
+Do **not** proactively unfollow just because the PR or Issue is merged,
+closed, completed, or no longer the main active task. Terminal entities
+are still followable because review aftermath, reopenings, CI reruns,
+post-merge comments, and follow-up decisions can matter to the chat
+that did the work.
 
 ## Error contract
 


### PR DESCRIPTION
## Summary

- Update the generated agent briefing so `github unfollow` is taught as explicit human stop-tracking intent, not a PR/Issue completion step.
- Align the `first-tree-github` skill, CLI help, CLI reference, and service comment with that guidance.
- Extend the briefing test to assert agents are told not to proactively unfollow merely because a PR or Issue completed, merged, or closed.

## Context

The Context Tree decision already says agents should follow newly created PRs/issues by default, while unfollowing happens when the human explicitly asks to stop tracking. Some source prompt/help text had drifted into teaching agents to unfollow when a task's attention span closes, which made PR/Issue completion look like an automatic cleanup action.

## Validation

- `pnpm --filter @first-tree/client test -- src/__tests__/agent-briefing.test.ts` (ran full client suite: 100 files / 998 tests passed)
- `pnpm --filter @first-tree/client typecheck`
- `pnpm --filter first-tree-dev typecheck`
- `pnpm exec biome check packages/client/src/runtime/agent-briefing.ts packages/client/src/__tests__/agent-briefing.test.ts apps/cli/src/commands/github/follow.ts apps/cli/src/commands/github/index.ts apps/cli/src/commands/github/unfollow.ts packages/server/src/services/github-entity-follow.ts`
- `git diff --check`