### PR TITLE
docs: drop stale re-bind rationale from config kind re-stamp comment

### DIFF
--- a/packages/server/src/services/config-service.ts
+++ b/packages/server/src/services/config-service.ts
@@ -195,9 +195,11 @@ export function createConfigService(opts: ConfigServiceOptions): ConfigService {
         `Agent config "${agentId}" version mismatch: expected ${expectedVersion}, got ${current.version}`,
       );
     }
-    // Re-sync `kind` with the authoritative agents.runtime_provider on
-    // every commit so a re-bind to a different provider lands on the
-    // correct discriminator next read.
+    // Re-stamp `kind` from the authoritative agents.runtime_provider on every
+    // commit so the discriminator stays in lockstep with the provider and any
+    // legacy row that predates `kind` is backfilled on its next write. The
+    // provider is fixed for an agent's lifetime (no re-bind), so this can only
+    // ever re-affirm or backfill the value, never switch it.
     const provider = await readRuntimeProviderFor(agentId);
     const merged = applyPatch(current.payload, patch);
     const synced = { ...merged, kind: provider } as AgentRuntimeConfigPayload;


### PR DESCRIPTION
Follow-up cleanup after the agent re-bind removal (first-tree#1080).

`config-service.ts` re-stamps `agent_configs.payload.kind` from the authoritative `agents.runtime_provider` on every config commit. The comment justified this with *"so a re-bind to a different provider lands on the correct discriminator"* — but re-bind is removed and the provider is now fixed for an agent's lifetime, so the re-stamp can only re-affirm or backfill `kind`, never switch it.

**Comment-only change — no behavior change.** The re-stamp is kept (it still backfills legacy rows that predate `kind`); only the stale rationale is corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)