### PR TITLE
fix(server): use persisted GitHub entity state

### DIFF
--- a/apps/cli/src/commands/github/following.ts
+++ b/apps/cli/src/commands/github/following.ts
@@ -12,7 +12,7 @@ export function registerGithubFollowingCommand(github: Command): void {
   github
     .command("following")
     .description(
-      "List the GitHub entities whose events route into the current chat (live title/state included). " +
+      "List the GitHub entities whose events route into the current chat. " +
         "Run this before following when unsure — re-following an already-wired entity is a no-op.",
     )
     .option("--chat <chatId>", "Target chat (default: the session's FIRST_TREE_CHAT_ID)")

--- a/packages/client/src/sdk.ts
+++ b/packages/client/src/sdk.ts
@@ -389,7 +389,7 @@ export class FirstTreeHubSDK {
     );
   }
 
-  /** List the GitHub entities currently wired into a chat (live title/state included). */
+  /** List the GitHub entities currently wired into a chat. */
   async listChatGithubEntities(chatId: string): Promise<ChatGithubEntityListResponse> {
     return this.requestJson<ChatGithubEntityListResponse>(`/api/v1/agent/chats/${chatId}/github-entities`);
   }

--- a/packages/server/src/__tests__/github-app-webhook-route.test.ts
+++ b/packages/server/src/__tests__/github-app-webhook-route.test.ts
@@ -451,6 +451,422 @@ describe("POST /webhooks/github-app", () => {
     expect(mappingRow?.entityState).toBe("open");
   });
 
+  it("late opened webhooks do not overwrite newer persisted entity_state", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const installationId = 100036;
+    await seedInstallation(app, { installationId, orgId: admin.organizationId });
+
+    const delegate = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-${randomUUID().slice(0, 6)}`,
+    });
+    const human = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `human-${randomUUID().slice(0, 6)}`,
+      delegateMention: delegate,
+    });
+    const chatId = `chat_${randomUUID()}`;
+    await app.db.insert(chats).values({ id: chatId, organizationId: admin.organizationId, type: "direct" });
+    await app.db.insert(githubEntityChatMappings).values([
+      {
+        organizationId: admin.organizationId,
+        humanAgentId: human,
+        delegateAgentId: delegate,
+        entityType: "pull_request",
+        entityKey: "owner/repo#825",
+        chatId,
+        boundVia: "direct",
+        entityState: "draft",
+      },
+      {
+        organizationId: admin.organizationId,
+        humanAgentId: human,
+        delegateAgentId: delegate,
+        entityType: "pull_request",
+        entityKey: "owner/repo#826",
+        chatId,
+        boundVia: "direct",
+        entityState: "merged",
+      },
+      {
+        organizationId: admin.organizationId,
+        humanAgentId: human,
+        delegateAgentId: delegate,
+        entityType: "issue",
+        entityKey: "owner/repo#827",
+        chatId,
+        boundVia: "direct",
+        entityState: "closed",
+      },
+    ]);
+
+    for (const number of [825, 826]) {
+      const res = await postWebhook(app, "pull_request", {
+        action: "opened",
+        pull_request: {
+          number,
+          title: "Late opened",
+          html_url: `https://github.com/owner/repo/pull/${number}`,
+          body: "",
+          state: "open",
+          draft: false,
+          merged: false,
+        },
+        repository: { full_name: "owner/repo" },
+        sender: { login: "author", type: "User" },
+        installation: { id: installationId },
+      });
+      expect(res.statusCode).toBe(200);
+    }
+
+    const issueRes = await postWebhook(app, "issues", {
+      action: "opened",
+      issue: {
+        number: 827,
+        title: "Late issue opened",
+        html_url: "https://github.com/owner/repo/issues/827",
+        body: "",
+        state: "open",
+      },
+      repository: { full_name: "owner/repo" },
+      sender: { login: "author", type: "User" },
+      installation: { id: installationId },
+    });
+    expect(issueRes.statusCode).toBe(200);
+
+    const rows = await app.db
+      .select({ entityKey: githubEntityChatMappings.entityKey, entityState: githubEntityChatMappings.entityState })
+      .from(githubEntityChatMappings)
+      .where(eq(githubEntityChatMappings.chatId, chatId));
+    const stateByKey = new Map(rows.map((row) => [row.entityKey, row.entityState]));
+    expect(stateByKey.get("owner/repo#825")).toBe("draft");
+    expect(stateByKey.get("owner/repo#826")).toBe("merged");
+    expect(stateByKey.get("owner/repo#827")).toBe("closed");
+  });
+
+  it("pull_request.converted_to_draft → syncs entity_state to 'draft'", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const installationId = 100034;
+    await seedInstallation(app, { installationId, orgId: admin.organizationId });
+
+    const delegate = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-${randomUUID().slice(0, 6)}`,
+    });
+    const human = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `human-${randomUUID().slice(0, 6)}`,
+      delegateMention: delegate,
+    });
+    const chatId = `chat_${randomUUID()}`;
+    await app.db.insert(chats).values({ id: chatId, organizationId: admin.organizationId, type: "direct" });
+    await app.db.insert(githubEntityChatMappings).values({
+      organizationId: admin.organizationId,
+      humanAgentId: human,
+      delegateAgentId: delegate,
+      entityType: "pull_request",
+      entityKey: "owner/repo#823",
+      chatId,
+      boundVia: "direct",
+      entityState: "open",
+    });
+
+    const res = await postWebhook(app, "pull_request", {
+      action: "converted_to_draft",
+      pull_request: {
+        number: 823,
+        title: "Draft again",
+        html_url: "https://github.com/owner/repo/pull/823",
+        body: "",
+        draft: true,
+      },
+      repository: { full_name: "owner/repo" },
+      sender: { login: "author", type: "User" },
+      installation: { id: installationId },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().handled).toBe(false);
+
+    const [mappingRow] = await app.db
+      .select({ entityState: githubEntityChatMappings.entityState })
+      .from(githubEntityChatMappings)
+      .where(and(eq(githubEntityChatMappings.chatId, chatId), eq(githubEntityChatMappings.entityKey, "owner/repo#823")))
+      .limit(1);
+    expect(mappingRow?.entityState).toBe("draft");
+  });
+
+  it("pull_request.ready_for_review → syncs entity_state to 'open' even when normalize drops the event", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const installationId = 100035;
+    await seedInstallation(app, { installationId, orgId: admin.organizationId });
+
+    const delegate = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-${randomUUID().slice(0, 6)}`,
+    });
+    const human = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `human-${randomUUID().slice(0, 6)}`,
+      delegateMention: delegate,
+    });
+    const chatId = `chat_${randomUUID()}`;
+    await app.db.insert(chats).values({ id: chatId, organizationId: admin.organizationId, type: "direct" });
+    await app.db.insert(githubEntityChatMappings).values({
+      organizationId: admin.organizationId,
+      humanAgentId: human,
+      delegateAgentId: delegate,
+      entityType: "pull_request",
+      entityKey: "owner/repo#824",
+      chatId,
+      boundVia: "direct",
+      entityState: "draft",
+    });
+
+    const res = await postWebhook(app, "pull_request", {
+      action: "ready_for_review",
+      pull_request: {
+        number: 824,
+        title: "Ready",
+        html_url: "https://github.com/owner/repo/pull/824",
+        body: "",
+        draft: false,
+        requested_reviewers: [],
+      },
+      repository: { full_name: "owner/repo" },
+      sender: { login: "author", type: "User" },
+      installation: { id: installationId },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().handled).toBe(false);
+
+    const [mappingRow] = await app.db
+      .select({ entityState: githubEntityChatMappings.entityState })
+      .from(githubEntityChatMappings)
+      .where(and(eq(githubEntityChatMappings.chatId, chatId), eq(githubEntityChatMappings.entityKey, "owner/repo#824")))
+      .limit(1);
+    expect(mappingRow?.entityState).toBe("open");
+  });
+
+  it("pull_request.review_requested seeds a new draft PR mapping from the payload state", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const installationId = 100037;
+    await seedInstallation(app, { installationId, orgId: admin.organizationId });
+
+    const delegate = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-${randomUUID().slice(0, 6)}`,
+    });
+    const humanName = `reviewer-${randomUUID().slice(0, 6)}`;
+    const human = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: humanName,
+      delegateMention: delegate,
+    });
+
+    const res = await postWebhook(app, "pull_request", {
+      action: "review_requested",
+      pull_request: {
+        number: 828,
+        title: "Draft review",
+        html_url: "https://github.com/owner/repo/pull/828",
+        body: "",
+        state: "open",
+        draft: true,
+        merged: false,
+      },
+      requested_reviewer: { login: humanName, type: "User" },
+      repository: { full_name: "owner/repo" },
+      sender: { login: "author", type: "User" },
+      installation: { id: installationId },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ delivered: 1, newChats: 1, failed: 0 });
+
+    const [mappingRow] = await app.db
+      .select({
+        humanAgentId: githubEntityChatMappings.humanAgentId,
+        entityState: githubEntityChatMappings.entityState,
+      })
+      .from(githubEntityChatMappings)
+      .where(eq(githubEntityChatMappings.entityKey, "owner/repo#828"))
+      .limit(1);
+    expect(mappingRow).toMatchObject({ humanAgentId: human, entityState: "draft" });
+  });
+
+  it("issue_comment.created seeds a new closed issue mapping from the issue payload state", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const installationId = 100038;
+    await seedInstallation(app, { installationId, orgId: admin.organizationId });
+
+    const delegate = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-${randomUUID().slice(0, 6)}`,
+    });
+    const humanName = `issue-${randomUUID().slice(0, 6)}`;
+    const human = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: humanName,
+      delegateMention: delegate,
+    });
+
+    const res = await postWebhook(app, "issue_comment", {
+      action: "created",
+      issue: {
+        number: 829,
+        title: "Closed issue",
+        html_url: "https://github.com/owner/repo/issues/829",
+        body: "",
+        state: "closed",
+      },
+      comment: {
+        body: `@${humanName} please verify`,
+        html_url: "https://github.com/owner/repo/issues/829#issuecomment-1",
+      },
+      repository: { full_name: "owner/repo" },
+      sender: { login: "author", type: "User" },
+      installation: { id: installationId },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ delivered: 1, newChats: 1, failed: 0 });
+
+    const [mappingRow] = await app.db
+      .select({
+        humanAgentId: githubEntityChatMappings.humanAgentId,
+        entityType: githubEntityChatMappings.entityType,
+        entityState: githubEntityChatMappings.entityState,
+      })
+      .from(githubEntityChatMappings)
+      .where(eq(githubEntityChatMappings.entityKey, "owner/repo#829"))
+      .limit(1);
+    expect(mappingRow).toMatchObject({ humanAgentId: human, entityType: "issue", entityState: "closed" });
+  });
+
+  it("issue_comment.created on a PR seeds a new closed PR mapping from the issue payload state", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const installationId = 100040;
+    await seedInstallation(app, { installationId, orgId: admin.organizationId });
+
+    const delegate = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-${randomUUID().slice(0, 6)}`,
+    });
+    const humanName = `pr-issue-${randomUUID().slice(0, 6)}`;
+    const human = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: humanName,
+      delegateMention: delegate,
+    });
+
+    const res = await postWebhook(app, "issue_comment", {
+      action: "created",
+      issue: {
+        number: 831,
+        title: "Closed PR thread",
+        html_url: "https://github.com/owner/repo/pull/831",
+        body: "",
+        state: "closed",
+        pull_request: { html_url: "https://github.com/owner/repo/pull/831", merged_at: null },
+      },
+      comment: {
+        body: `@${humanName} please verify`,
+        html_url: "https://github.com/owner/repo/pull/831#issuecomment-1",
+      },
+      repository: { full_name: "owner/repo" },
+      sender: { login: "author", type: "User" },
+      installation: { id: installationId },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ delivered: 1, newChats: 1, failed: 0 });
+
+    const [mappingRow] = await app.db
+      .select({
+        humanAgentId: githubEntityChatMappings.humanAgentId,
+        entityType: githubEntityChatMappings.entityType,
+        entityState: githubEntityChatMappings.entityState,
+      })
+      .from(githubEntityChatMappings)
+      .where(eq(githubEntityChatMappings.entityKey, "owner/repo#831"))
+      .limit(1);
+    expect(mappingRow).toMatchObject({ humanAgentId: human, entityType: "pull_request", entityState: "closed" });
+  });
+
+  it("pull_request_review_comment.created seeds a new draft PR mapping from the PR payload state", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const installationId = 100039;
+    await seedInstallation(app, { installationId, orgId: admin.organizationId });
+
+    const delegate = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-${randomUUID().slice(0, 6)}`,
+    });
+    const humanName = `pr-${randomUUID().slice(0, 6)}`;
+    const human = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: humanName,
+      delegateMention: delegate,
+    });
+
+    const res = await postWebhook(app, "pull_request_review_comment", {
+      action: "created",
+      pull_request: {
+        number: 830,
+        title: "Draft PR review comment",
+        html_url: "https://github.com/owner/repo/pull/830",
+        body: "",
+        state: "open",
+        draft: true,
+        merged: false,
+      },
+      comment: {
+        body: `@${humanName} please review`,
+        html_url: "https://github.com/owner/repo/pull/830#discussion_r1",
+      },
+      repository: { full_name: "owner/repo" },
+      sender: { login: "author", type: "User" },
+      installation: { id: installationId },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ delivered: 1, newChats: 1, failed: 0 });
+
+    const [mappingRow] = await app.db
+      .select({
+        humanAgentId: githubEntityChatMappings.humanAgentId,
+        entityType: githubEntityChatMappings.entityType,
+        entityState: githubEntityChatMappings.entityState,
+      })
+      .from(githubEntityChatMappings)
+      .where(eq(githubEntityChatMappings.entityKey, "owner/repo#830"))
+      .limit(1);
+    expect(mappingRow).toMatchObject({ humanAgentId: human, entityType: "pull_request", entityState: "draft" });
+  });
+
   it("issues.closed → syncs entity_state to 'closed' on the issue mapping", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);

--- a/packages/server/src/__tests__/github-entity-follow.test.ts
+++ b/packages/server/src/__tests__/github-entity-follow.test.ts
@@ -125,6 +125,15 @@ describe("github-entity-follow", () => {
           pull_request: { merged_at: null },
           draft: false,
         }),
+      "/repos/acme/api/pulls/42": () =>
+        json({
+          number: 42,
+          state: "open",
+          title: "Add follow command",
+          html_url: "https://github.com/Acme/Api/pull/42",
+          merged: false,
+          draft: false,
+        }),
       "/repos/acme/api": () => json({ full_name: "Acme/Api" }),
       ...overrides,
     });
@@ -327,6 +336,15 @@ describe("github-entity-follow", () => {
           html_url: "https://github.com/Acme/Api/pull/42",
           pull_request: { merged_at: "2026-06-01T00:00:00Z" },
         }),
+      "/repos/acme/api/pulls/42": () =>
+        json({
+          number: 42,
+          state: "closed",
+          title: "Add follow command",
+          html_url: "https://github.com/Acme/Api/pull/42",
+          merged: true,
+          draft: false,
+        }),
     });
 
     const result = await declareEntityFollow(app.db, deps(fetcher), followParams(s, "acme/api#42"));
@@ -339,6 +357,41 @@ describe("github-entity-follow", () => {
       .from(githubEntityChatMappings)
       .where(eq(githubEntityChatMappings.chatId, s.chatId));
     expect(row?.entityState).toBe("merged");
+  });
+
+  it("records draft PR state on follow", async () => {
+    const app = getApp();
+    const s = await setup(app);
+    const fetcher = prFetcher({
+      "/repos/acme/api/issues/42": () =>
+        json({
+          number: 42,
+          state: "open",
+          title: "Draft follow command",
+          html_url: "https://github.com/Acme/Api/pull/42",
+          pull_request: { merged_at: null },
+        }),
+      "/repos/acme/api/pulls/42": () =>
+        json({
+          number: 42,
+          state: "open",
+          title: "Draft follow command",
+          html_url: "https://github.com/Acme/Api/pull/42",
+          merged: false,
+          draft: true,
+        }),
+    });
+
+    const result = await declareEntityFollow(app.db, deps(fetcher), followParams(s, "acme/api#42"));
+    expect(result.outcome).toBe("created");
+    if (result.outcome !== "created") throw new Error("unreachable");
+    expect(result.entity.state).toBe("draft");
+
+    const [row] = await app.db
+      .select({ entityState: githubEntityChatMappings.entityState })
+      .from(githubEntityChatMappings)
+      .where(eq(githubEntityChatMappings.chatId, s.chatId));
+    expect(row?.entityState).toBe("draft");
   });
 
   it("an issue without a pull_request block resolves to entityType issue", async () => {
@@ -628,12 +681,35 @@ describe("github-entity-follow", () => {
       boundVia: "agent_created",
     });
 
-    const list = await listChatGithubEntities(app.db, deps(prFetcher()), {
-      chatId: s.chatId,
-      organizationId: s.admin.organizationId,
-    });
+    const list = await listChatGithubEntities(app.db, { chatId: s.chatId });
     expect(list.items).toHaveLength(1);
-    expect(list.items[0]).toMatchObject({ entityKey: "Acme/Api#7", boundVia: "agent_declared" });
+    expect(list.items[0]).toMatchObject({ entityKey: "Acme/Api#7", boundVia: "agent_declared", state: "open" });
+  });
+
+  it("following reads lifecycle state from the DB projection", async () => {
+    const app = getApp();
+    const s = await setup(app);
+    await app.db.insert(githubEntityChatMappings).values({
+      organizationId: s.admin.organizationId,
+      humanAgentId: s.human,
+      delegateAgentId: s.delegate,
+      entityType: "pull_request",
+      entityKey: "Acme/Api#8",
+      chatId: s.chatId,
+      boundVia: "agent_declared",
+      entityState: "draft",
+    });
+
+    const list = await listChatGithubEntities(app.db, { chatId: s.chatId });
+    expect(list.items).toHaveLength(1);
+    expect(list.items[0]).toMatchObject({
+      entityType: "pull_request",
+      entityKey: "Acme/Api#8",
+      htmlUrl: "https://github.com/Acme/Api/pull/8",
+      title: null,
+      state: "draft",
+      number: 8,
+    });
   });
 
   it("following lists legacy discussion mappings under the canonical numeric key", async () => {
@@ -649,10 +725,7 @@ describe("github-entity-follow", () => {
       boundVia: "agent_declared",
     });
 
-    const list = await listChatGithubEntities(app.db, deps(prFetcher()), {
-      chatId: s.chatId,
-      organizationId: s.admin.organizationId,
-    });
+    const list = await listChatGithubEntities(app.db, { chatId: s.chatId });
 
     expect(list.items).toHaveLength(1);
     expect(list.items[0]).toMatchObject({

--- a/packages/server/src/__tests__/github-entity-live.test.ts
+++ b/packages/server/src/__tests__/github-entity-live.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { GITHUB_API_BASE } from "../services/github-api-base.js";
-import { __testing, resolveChatGithubEntity } from "../services/github-entity-live.js";
+import { __testing, materializeChatGithubEntity, resolveChatGithubEntity } from "../services/github-entity-live.js";
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), { status });
@@ -142,6 +142,36 @@ describe("fetchEntityLiveFields", () => {
 });
 
 describe("resolveChatGithubEntity", () => {
+  it("materializes persisted PR and issue lifecycle state without live fetches", () => {
+    expect(
+      materializeChatGithubEntity({
+        entityType: "pull_request",
+        entityKey: "owner/repo#12",
+        boundVia: "direct",
+        entityState: "draft",
+      }),
+    ).toMatchObject({
+      entityType: "pull_request",
+      entityKey: "owner/repo#12",
+      state: "draft",
+      title: null,
+      number: 12,
+    });
+    expect(
+      materializeChatGithubEntity({
+        entityType: "issue",
+        entityKey: "owner/repo#13",
+        boundVia: "direct",
+        entityState: "merged",
+      }),
+    ).toMatchObject({
+      entityType: "issue",
+      entityKey: "owner/repo#13",
+      state: null,
+      number: 13,
+    });
+  });
+
   it("materializes wire entities with optional live fields", async () => {
     const fetcher = vi.fn<typeof fetch>().mockResolvedValueOnce(jsonResponse({ title: "Bug", state: "open" }));
 

--- a/packages/server/src/__tests__/resolve-target-chat.test.ts
+++ b/packages/server/src/__tests__/resolve-target-chat.test.ts
@@ -110,6 +110,64 @@ describe("resolveTargetChat", () => {
     });
   });
 
+  it("seeds state when the current webhook creates a matching mapping", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const delegate = await seedDelegate(app, admin.organizationId, admin.memberId, `dlg-${randomUUID().slice(0, 6)}`);
+
+    const result = await resolveTargetChat(app.db, {
+      organizationId: admin.organizationId,
+      humanAgentId: admin.humanAgentUuid,
+      delegateAgentId: delegate,
+      entity: pr50,
+      relatedEntities: [],
+      eventType: "pull_request",
+      action: "opened",
+      entityStateSeed: { entityType: "pull_request", entityKey: "owner/repo#50", state: "draft" },
+    });
+
+    const [mapping] = await app.db
+      .select({ entityState: githubEntityChatMappings.entityState })
+      .from(githubEntityChatMappings)
+      .where(eq(githubEntityChatMappings.chatId, result.chatId))
+      .limit(1);
+    expect(mapping?.entityState).toBe("draft");
+  });
+
+  it("does not apply a related entity's state seed to the new mapping", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const delegate = await seedDelegate(app, admin.organizationId, admin.memberId, `dlg-${randomUUID().slice(0, 6)}`);
+
+    const issueResolved = await resolveTargetChat(app.db, {
+      organizationId: admin.organizationId,
+      humanAgentId: admin.humanAgentUuid,
+      delegateAgentId: delegate,
+      entity: issue42,
+      relatedEntities: [],
+      eventType: "issues",
+      action: "opened",
+    });
+    const prResolved = await resolveTargetChat(app.db, {
+      organizationId: admin.organizationId,
+      humanAgentId: admin.humanAgentUuid,
+      delegateAgentId: delegate,
+      entity: pr50,
+      relatedEntities: [issue42],
+      eventType: "pull_request",
+      action: "opened",
+      entityStateSeed: { entityType: "issue", entityKey: "owner/repo#42", state: "closed" },
+    });
+
+    expect(prResolved.chatId).toBe(issueResolved.chatId);
+    const [prMapping] = await app.db
+      .select({ entityState: githubEntityChatMappings.entityState })
+      .from(githubEntityChatMappings)
+      .where(eq(githubEntityChatMappings.entityKey, "owner/repo#50"))
+      .limit(1);
+    expect(prMapping?.entityState).toBe("open");
+  });
+
   it("reuses the existing chat on a direct re-hit", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);

--- a/packages/server/src/api/agent/chats.ts
+++ b/packages/server/src/api/agent/chats.ts
@@ -209,17 +209,7 @@ export async function agentChatRoutes(app: FastifyInstance): Promise<void> {
   app.get<{ Params: { chatId: string } }>("/:chatId/github-entities", async (request) => {
     const identity = requireAgent(request);
     await chatService.assertParticipant(app.db, request.params.chatId, identity.uuid);
-    const [chat] = await app.db
-      .select({ organizationId: chats.organizationId })
-      .from(chats)
-      .where(eq(chats.id, request.params.chatId))
-      .limit(1);
-    if (!chat) throw new BadRequestError("Chat not found");
-    return listChatGithubEntities(
-      app.db,
-      { appCredentials: app.config.oauth?.githubApp },
-      { chatId: request.params.chatId, organizationId: chat.organizationId },
-    );
+    return listChatGithubEntities(app.db, { chatId: request.params.chatId });
   });
 
   app.post<{ Params: { chatId: string } }>(

--- a/packages/server/src/api/chats.ts
+++ b/packages/server/src/api/chats.ts
@@ -171,23 +171,16 @@ export async function chatRoutes(app: FastifyInstance): Promise<void> {
 
   /**
    * List GitHub entities bound to this chat. Reads the binding rows from
-   * `github_entity_chat_mappings`, then fetches the live `title` / `state`
-   * for each from the GitHub REST API at request time — nothing is
-   * persisted. Per the right-sidebar plan, we deliberately did NOT add
-   * cached columns; freshness wins over a low-cost cache.
+   * `github_entity_chat_mappings` and projects lifecycle state from the
+   * webhook-synced `entity_state` column. The route deliberately does not
+   * mint GitHub tokens or call GitHub; `title` remains nullable because the
+   * mapping table does not persist titles.
    *
-   * Returns an empty list when the chat has no bindings. When the org
-   * has no GitHub App installation (or token mint fails), rows are
-   * still returned with `title: null` and `state: null` so the row
-   * remains a working link to GitHub.
+   * Returns an empty list when the chat has no bindings.
    */
   app.get<{ Params: { chatId: string } }>("/:chatId/github-entities", async (request) => {
-    const { chat, scope } = await requireChatAccess(request, app.db);
-    return listChatGithubEntities(
-      app.db,
-      { appCredentials: app.config.oauth?.githubApp },
-      { chatId: chat.id, organizationId: scope.organizationId },
-    );
+    const { chat } = await requireChatAccess(request, app.db);
+    return listChatGithubEntities(app.db, { chatId: chat.id });
   });
 
   /**

--- a/packages/server/src/api/webhooks/github-app.ts
+++ b/packages/server/src/api/webhooks/github-app.ts
@@ -14,7 +14,7 @@ import {
 } from "../../services/github-app-installations.js";
 import { resolveAudience } from "../../services/github-audience.js";
 import { deliverNormalizedEvent } from "../../services/github-delivery.js";
-import { setEntityState } from "../../services/github-entity-state.js";
+import { type EntityStateSeed, setEntityState } from "../../services/github-entity-state.js";
 import { normalizeGithubEvent } from "../../services/github-normalize.js";
 import { isRecord, readNumber, readString } from "./github-entity.js";
 
@@ -63,34 +63,97 @@ function parseInstallationMetadata(installation: Record<string, unknown>): AppIn
   };
 }
 
-type EntityStateUpdate = {
-  entityType: "pull_request" | "issue";
-  entityKey: string;
-  state: "open" | "closed" | "merged";
-};
+function pullRequestStateFromPayload(pr: Record<string, unknown>, action: string): EntityStateSeed["state"] {
+  const state = readString(pr.state);
+  if (action === "closed" || state === "closed") {
+    return pr.merged === true ? "merged" : "closed";
+  }
+  return pr.draft === true ? "draft" : "open";
+}
+
+function issueStateFromPayload(issue: Record<string, unknown>, action: string): EntityStateSeed["state"] {
+  const state = readString(issue.state);
+  return action === "closed" || state === "closed" ? "closed" : "open";
+}
+
+function pullRequestStateFromIssuePayload(issue: Record<string, unknown>, action: string): EntityStateSeed["state"] {
+  const state = readString(issue.state);
+  if (action === "closed" || state === "closed") {
+    const pr = isRecord(issue.pull_request) ? issue.pull_request : null;
+    return readString(pr?.merged_at) ? "merged" : "closed";
+  }
+  return issue.draft === true ? "draft" : "open";
+}
 
 /**
- * Map a PR/Issue lifecycle action to the persisted `entity_state` column.
- * Returns `null` for events that don't change lifecycle (e.g. comment, label).
+ * Derive the current PR/Issue state from any payload that carries the entity.
+ * This is used only as an INSERT seed for mappings created by the same
+ * webhook delivery; it must not update existing rows for non-transition
+ * events such as late `opened` deliveries.
+ */
+function resolveEntityStateSeed(
+  eventType: string,
+  action: string,
+  payload: Record<string, unknown>,
+  repoFullName: string,
+): EntityStateSeed | null {
+  if (
+    eventType === "pull_request" ||
+    eventType === "pull_request_review" ||
+    eventType === "pull_request_review_comment"
+  ) {
+    const pr = isRecord(payload.pull_request) ? payload.pull_request : null;
+    const number = readNumber(pr?.number);
+    if (!pr || number === null) return null;
+    return {
+      entityType: "pull_request",
+      entityKey: `${repoFullName}#${number}`,
+      state: pullRequestStateFromPayload(pr, action),
+    };
+  }
+  if (eventType === "issues" || eventType === "issue_comment") {
+    const issue = isRecord(payload.issue) ? payload.issue : null;
+    const number = readNumber(issue?.number);
+    if (!issue || number === null) return null;
+    if (isRecord(issue.pull_request)) {
+      return {
+        entityType: "pull_request",
+        entityKey: `${repoFullName}#${number}`,
+        state: pullRequestStateFromIssuePayload(issue, action),
+      };
+    }
+    return { entityType: "issue", entityKey: `${repoFullName}#${number}`, state: issueStateFromPayload(issue, action) };
+  }
+  return null;
+}
+
+/**
+ * Map lifecycle transitions to persisted `entity_state` updates for rows
+ * that already exist. Initial `opened` events are excluded on purpose: a
+ * retry or delayed opened delivery must not overwrite a newer draft/closed/
+ * merged state.
  */
 function resolveEntityStateUpdate(
   eventType: string,
   action: string,
   payload: Record<string, unknown>,
   repoFullName: string,
-): EntityStateUpdate | null {
+): EntityStateSeed | null {
   if (eventType === "pull_request") {
     const pr = isRecord(payload.pull_request) ? payload.pull_request : null;
     const number = readNumber(pr?.number);
-    if (number === null) return null;
-    if (action === "closed") {
+    if (!pr || number === null) return null;
+    if (action === "closed" || action === "reopened") {
       return {
         entityType: "pull_request",
         entityKey: `${repoFullName}#${number}`,
-        state: pr?.merged === true ? "merged" : "closed",
+        state: pullRequestStateFromPayload(pr, action),
       };
     }
-    if (action === "reopened") {
+    if (action === "converted_to_draft") {
+      return { entityType: "pull_request", entityKey: `${repoFullName}#${number}`, state: "draft" };
+    }
+    if (action === "ready_for_review") {
       return { entityType: "pull_request", entityKey: `${repoFullName}#${number}`, state: "open" };
     }
     return null;
@@ -98,14 +161,9 @@ function resolveEntityStateUpdate(
   if (eventType === "issues") {
     const issue = isRecord(payload.issue) ? payload.issue : null;
     const number = readNumber(issue?.number);
-    if (number === null) return null;
-    if (action === "closed") {
-      return { entityType: "issue", entityKey: `${repoFullName}#${number}`, state: "closed" };
-    }
-    if (action === "reopened") {
-      return { entityType: "issue", entityKey: `${repoFullName}#${number}`, state: "open" };
-    }
-    return null;
+    if (!issue || number === null) return null;
+    if (action !== "closed" && action !== "reopened") return null;
+    return { entityType: "issue", entityKey: `${repoFullName}#${number}`, state: issueStateFromPayload(issue, action) };
   }
   return null;
 }
@@ -253,11 +311,13 @@ export async function githubAppWebhookRoutes(app: FastifyInstance): Promise<void
     // archive. Idempotent under retries — sits before claimEvent on
     // purpose so a retry whose normalized event was already claimed
     // still gets its state column updated.
+    let entityStateSeed: EntityStateSeed | null = null;
     if (isRecord(payload)) {
       const repo = isRecord(payload.repository) ? payload.repository : null;
       const repoFullName = readString(repo?.full_name);
       const action = typeof payload.action === "string" ? payload.action : null;
       if (repoFullName && action) {
+        entityStateSeed = resolveEntityStateSeed(eventType, action, payload, repoFullName);
         const stateUpdate = resolveEntityStateUpdate(eventType, action, payload, repoFullName);
         if (stateUpdate) {
           try {
@@ -321,7 +381,7 @@ export async function githubAppWebhookRoutes(app: FastifyInstance): Promise<void
         );
         return reply.status(200).send({ ok: true, event: eventType, audience: 0, reason });
       }
-      const stats = await deliverNormalizedEvent(app, event, audience);
+      const stats = await deliverNormalizedEvent(app, event, audience, { entityStateSeed });
       return reply.status(200).send({ ok: true, event: eventType, ...stats });
     } catch (err) {
       if (deliveryId) {

--- a/packages/server/src/db/schema/github-entity-chat-mappings.ts
+++ b/packages/server/src/db/schema/github-entity-chat-mappings.ts
@@ -19,11 +19,10 @@ import { organizations } from "./organizations.js";
  * `services/github-audience.ts`. Canonical value docs: `BoundVia` in
  * `services/github-entity-chat.ts`.
  *
- * `entity_state` (added 0048) tracks the upstream PR/Issue lifecycle so the
- * auto-archive sweeper can decide whether a chat's bound entities are all
- * terminal (closed/merged) without making GitHub API calls. Updated by the
- * webhook handler on `pull_request.closed/merged/reopened` and
- * `issues.closed/reopened`. New rows default to `'open'`.
+ * `entity_state` (added 0048) tracks the upstream PR/Issue lifecycle so
+ * sidebar reads and the auto-archive sweeper can avoid GitHub API calls.
+ * Updated by the webhook handler on PR/Issue lifecycle actions, including
+ * PR draft transitions. New rows default to `'open'`.
  */
 export const githubEntityChatMappings = pgTable(
   "github_entity_chat_mappings",
@@ -47,7 +46,7 @@ export const githubEntityChatMappings = pgTable(
     boundAt: timestamp("bound_at", { withTimezone: true }).notNull().defaultNow(),
     /** See file header — canonical value list lives on `BoundVia`. */
     boundVia: text("bound_via").notNull(),
-    /** "open" (default) | "closed" | "merged". See file header. */
+    /** "open" (default) | "draft" | "closed" | "merged". See file header. */
     entityState: text("entity_state").notNull().default("open"),
     entityStateUpdatedAt: timestamp("entity_state_updated_at", { withTimezone: true }),
   },

--- a/packages/server/src/services/github-delivery.ts
+++ b/packages/server/src/services/github-delivery.ts
@@ -4,6 +4,7 @@ import type { GithubEntity } from "../api/webhooks/github-entity.js";
 import { createLogger } from "../observability/index.js";
 import type { AudienceTarget } from "./github-audience.js";
 import { refreshGithubChatTopic, resolveTargetChat } from "./github-entity-chat.js";
+import type { EntityStateSeed } from "./github-entity-state.js";
 import { sendMessage } from "./message.js";
 import { notifyRecipients } from "./notifier.js";
 
@@ -24,6 +25,10 @@ export type DeliveryStats = {
   failed: number;
 };
 
+type DeliveryOptions = {
+  entityStateSeed?: EntityStateSeed | null;
+};
+
 /**
  * Stage 3 — actually emit one card per audience target.
  *
@@ -42,12 +47,13 @@ export async function deliverNormalizedEvent(
   app: FastifyInstance,
   event: NormalizedEvent,
   audience: AudienceTarget[],
+  options: DeliveryOptions = {},
 ): Promise<DeliveryStats> {
   const stats: DeliveryStats = { delivered: 0, newChats: 0, failed: 0 };
 
   for (const target of audience) {
     try {
-      const resolved = await resolveChatFor(app, event, target);
+      const resolved = await resolveChatFor(app, event, target, options);
       if (!resolved) {
         // Creation-event guard fired: opened webhook had no existing mapping
         // and no explicit mention for this target, so we drop the event for
@@ -188,6 +194,7 @@ async function resolveChatFor(
   app: FastifyInstance,
   event: NormalizedEvent,
   target: AudienceTarget,
+  options: DeliveryOptions,
 ): Promise<ResolvedChat | null> {
   if (target.kind === "existing") {
     if (!target.chatId) {
@@ -213,6 +220,7 @@ async function resolveChatFor(
     relatedEntities,
     eventType: event.rawEventType,
     action: event.rawAction ?? "",
+    entityStateSeed: options.entityStateSeed ?? null,
     // `kind: "new"` audience targets come from explicit mentions / involves
     // in the event payload — these are the only path allowed to mint a fresh
     // chat for an opened creation event. Subscription targets never reach

--- a/packages/server/src/services/github-entity-chat.ts
+++ b/packages/server/src/services/github-entity-chat.ts
@@ -14,6 +14,7 @@ import {
   githubEntityKeyCandidates,
   githubEntityKeysEquivalent,
 } from "./github-entity-key.js";
+import type { EntityState, EntityStateSeed } from "./github-entity-state.js";
 
 const log = createLogger("GithubEntityChat");
 
@@ -106,6 +107,12 @@ export async function resolveTargetChat(
      * chat-proliferation behaviour.
      */
     isMentionMatched: boolean;
+    /**
+     * State derived from the current webhook payload. Used only when this
+     * resolution writes a new mapping for the same entity; existing rows are
+     * updated by the pre-delivery state-sync path.
+     */
+    entityStateSeed?: EntityStateSeed | null;
   },
 ): Promise<{ chatId: string; created: boolean; boundVia: BoundVia } | null> {
   const {
@@ -120,6 +127,7 @@ export async function resolveTargetChat(
   } = params;
   const entity = normalizeGithubEntity(rawEntity);
   const relatedEntities = rawRelatedEntities.map(normalizeGithubEntity);
+  const entityState = stateSeedForEntity(params.entityStateSeed ?? null, entity);
 
   // (a) Direct hit.
   const direct = await lookupMapping(db, organizationId, humanAgentId, delegateAgentId, entity);
@@ -143,6 +151,7 @@ export async function resolveTargetChat(
       entity,
       chatId: humanScoped.chatId,
       boundVia: "human_fallback",
+      entityState,
     });
     return { chatId: inserted.chatId, created: false, boundVia: inserted.boundVia };
   }
@@ -158,6 +167,7 @@ export async function resolveTargetChat(
       entity,
       chatId: linked.chatId,
       boundVia: "fixes_link",
+      entityState,
     });
     // If the insert lost a race, our re-read returns the winner's row.
     return { chatId: inserted.chatId, created: false, boundVia: inserted.boundVia };
@@ -189,6 +199,7 @@ export async function resolveTargetChat(
     entity,
     chatId: chat.id,
     boundVia: "direct",
+    entityState,
   });
   return { chatId: inserted.chatId, created: inserted.chatId === chat.id, boundVia: inserted.boundVia };
 }
@@ -226,7 +237,7 @@ async function lookupMapping(
  * Multiple rows can legitimately exist when the same human created the entity
  * via one delegate and later got fanned out via another delegate's
  * `delegateMention` configuration. Pick deterministically:
- *   1. `entity_state = 'open'` rows first (active conversation).
+ *   1. `entity_state IN ('open', 'draft')` rows first (active conversation).
  *   2. Then earliest `bound_at` — the original chat is the canonical thread.
  */
 async function lookupMappingByHuman(
@@ -250,7 +261,7 @@ async function lookupMappingByHuman(
     )
     .orderBy(
       desc(sql`${githubEntityChatMappings.entityKey} = ${canonicalKey}`),
-      desc(sql`${githubEntityChatMappings.entityState} = 'open'`),
+      desc(sql`${githubEntityChatMappings.entityState} IN ('open', 'draft')`),
       asc(githubEntityChatMappings.boundAt),
     )
     .limit(1);
@@ -268,7 +279,7 @@ export async function insertMappingIfAbsent(
     chatId: string;
     boundVia: BoundVia;
     /** Upstream lifecycle state to seed the row with; defaults to "open". */
-    entityState?: "open" | "closed" | "merged";
+    entityState?: EntityState;
   },
 ): Promise<{ chatId: string; boundVia: BoundVia; inserted: boolean }> {
   const entity = normalizeGithubEntity(params.entity);
@@ -510,4 +521,11 @@ export async function refreshGithubChatTopic(db: Database, chatId: string, entit
 function normalizeGithubEntity(entity: GithubEntity): GithubEntity {
   const key = canonicalizeGithubEntityKey(entity.type, entity.key);
   return key === entity.key ? entity : { ...entity, key };
+}
+
+function stateSeedForEntity(seed: EntityStateSeed | null, entity: GithubEntity): EntityState | undefined {
+  if (!seed) return undefined;
+  if (seed.entityType !== entity.type) return undefined;
+  if (!githubEntityKeysEquivalent(entity.type, seed.entityKey, entity.key)) return undefined;
+  return seed.state;
 }

--- a/packages/server/src/services/github-entity-follow.ts
+++ b/packages/server/src/services/github-entity-follow.ts
@@ -17,7 +17,8 @@ import { findInstallationByOrg } from "./github-app-installations.js";
 import { mintContextTreeInstallationToken } from "./github-app-token.js";
 import { insertMappingIfAbsent } from "./github-entity-chat.js";
 import { githubEntityDedupKey, githubEntityKeyCandidates, legacyDiscussionEntityKey } from "./github-entity-key.js";
-import { resolveChatGithubEntity } from "./github-entity-live.js";
+import { materializeChatGithubEntity } from "./github-entity-live.js";
+import type { EntityState } from "./github-entity-state.js";
 
 const log = createLogger("GithubEntityFollow");
 
@@ -133,9 +134,6 @@ function parseEntityReferenceOrThrow(raw: string): EntityReference {
 function escapeLikeLiteral(value: string): string {
   return value.replaceAll("\\", "\\\\").replaceAll("%", "\\%").replaceAll("_", "\\_");
 }
-
-/** Mapping-row lifecycle state (`entity_state` column). */
-type EntityState = "open" | "closed" | "merged";
 
 type ResolvedEntity = {
   entityType: GithubEntityType;
@@ -274,23 +272,28 @@ async function resolveEntityOnGithub(
   const htmlUrl = readStr(res.body.html_url);
 
   if (prInfo) {
-    const merged = readStr(prInfo.merged_at) !== null;
-    const draft = res.body.draft === true;
-    const entityState: EntityState = merged ? "merged" : rawState === "closed" ? "closed" : "open";
+    const pullRes = await ghGet(`/repos/${fullName}/pulls/${number}`, token, fetcher);
+    if (pullRes.kind === "unavailable") return { ok: false, reason: "github-unavailable" };
+    if (pullRes.kind === "forbidden") return { ok: false, reason: "repo-not-accessible" };
+    if (pullRes.kind !== "ok") return { ok: false, reason: "entity-not-found" };
+    const pullState = readStr(pullRes.body.state) ?? rawState;
+    const merged = pullRes.body.merged === true || readStr(pullRes.body.merged_at) !== null;
+    const draft = pullRes.body.draft === true;
+    const entityState: EntityState = merged ? "merged" : pullState === "closed" ? "closed" : draft ? "draft" : "open";
     const liveState: GithubEntityLiveState | null = merged
       ? "merged"
-      : draft && rawState === "open"
+      : draft && pullState === "open"
         ? "draft"
-        : rawState === "open" || rawState === "closed"
-          ? rawState
+        : pullState === "open" || pullState === "closed"
+          ? pullState
           : null;
     return {
       ok: true,
       entity: {
         entityType: "pull_request",
         entityKey: `${fullName}#${number}`,
-        htmlUrl: htmlUrl ?? `https://github.com/${fullName}/pull/${number}`,
-        title,
+        htmlUrl: readStr(pullRes.body.html_url) ?? htmlUrl ?? `https://github.com/${fullName}/pull/${number}`,
+        title: readStr(pullRes.body.title) ?? title,
         liveState,
         entityState,
         number,
@@ -583,20 +586,21 @@ export async function removeEntityFollow(
 
 /**
  * List the entities wired into a chat — shared by the user-scoped sidebar
- * route and the agent-scoped `github following` CLI. Reads the mapping
- * rows, dedups by entity (the pair axes are an audit detail), then fetches
- * live title/state per entity from the GitHub API; nothing is persisted.
+ * route and the agent-scoped `github following` CLI. Reads only the mapping
+ * rows, dedups by entity (the pair axes are an audit detail), and projects
+ * lifecycle state from the webhook-synced `entity_state` column. This hot
+ * read path deliberately does not mint GitHub tokens or call GitHub.
  */
 export async function listChatGithubEntities(
   db: Database,
-  deps: FollowDeps,
-  params: { chatId: string; organizationId: string },
+  params: { chatId: string },
 ): Promise<ChatGithubEntityListResponse> {
   const rows = await db
     .select({
       entityType: githubEntityChatMappings.entityType,
       entityKey: githubEntityChatMappings.entityKey,
       boundVia: githubEntityChatMappings.boundVia,
+      entityState: githubEntityChatMappings.entityState,
       boundAt: githubEntityChatMappings.boundAt,
     })
     .from(githubEntityChatMappings)
@@ -613,21 +617,6 @@ export async function listChatGithubEntities(
     if (!dedup.has(key)) dedup.set(key, r);
   }
 
-  // Mint one installation token and reuse it for every entity fetch — the
-  // ~1h TTL is well outside the request window.
-  const fetcher = deps.fetcher ?? fetch;
-  const installation = await findInstallationByOrg(db, params.organizationId);
-  const mintResult = await mintContextTreeInstallationToken(installation, deps.appCredentials, { fetcher });
-  const token = mintResult.ok ? mintResult.token : null;
-
-  const items = await Promise.all(
-    Array.from(dedup.values()).map((r) =>
-      resolveChatGithubEntity(
-        { entityType: r.entityType, entityKey: r.entityKey, boundVia: r.boundVia },
-        token,
-        fetcher,
-      ),
-    ),
-  );
+  const items = Array.from(dedup.values()).map((r) => materializeChatGithubEntity(r));
   return { items: items.filter((x): x is NonNullable<typeof x> => x !== null) };
 }

--- a/packages/server/src/services/github-entity-live.ts
+++ b/packages/server/src/services/github-entity-live.ts
@@ -163,21 +163,36 @@ export type MappingRow = {
   entityType: string;
   entityKey: string;
   boundVia: string;
+  entityState?: string | null;
 };
+
+function stateFromPersistedEntityState(
+  entityType: GithubEntityType,
+  entityState: string | null | undefined,
+): GithubEntityLiveState | null {
+  if (entityType === "pull_request") {
+    if (entityState === "open" || entityState === "draft" || entityState === "closed" || entityState === "merged") {
+      return entityState;
+    }
+    return null;
+  }
+  if (entityType === "issue") {
+    if (entityState === "open" || entityState === "closed") return entityState;
+    return null;
+  }
+  return null;
+}
 
 /**
  * Materialise the wire-shape `ChatGithubEntity` for a single mapping row.
  *
  * `parsed` may be null when `entityKey` doesn't match the expected
- * `owner/repo#N` or `owner/repo@<sha>` shape; in that case the
- * `htmlUrl` falls back to a search URL keyed on the raw `entityKey`
- * (still better than dropping the row silently). Live fields are null.
+ * `owner/repo#N` or `owner/repo@<sha>` shape; in that case the row is
+ * dropped because the right rail cannot build a trustworthy GitHub link.
+ * The title remains null because mappings do not persist titles; lifecycle
+ * state comes from the webhook-synced `entity_state` projection.
  */
-export async function resolveChatGithubEntity(
-  row: MappingRow,
-  token: string | null,
-  fetcher: typeof fetch = fetch,
-): Promise<ChatGithubEntity | null> {
+export function materializeChatGithubEntity(row: MappingRow): ChatGithubEntity | null {
   // Defend against unknown enum values landing here — schema drift between
   // shared and server would otherwise propagate to the wire. Both axes are
   // narrowed via the canonical Zod schema (boundVia) and the exported
@@ -191,15 +206,36 @@ export async function resolveChatGithubEntity(
   const boundVia: GithubEntityBoundVia = boundViaParsed.data;
   const parsed = parseEntityKey(entityType, row.entityKey);
   if (!parsed) return null;
-  const live = token ? await fetchEntityLiveFields(entityType, parsed, token, fetcher) : { title: null, state: null };
   return {
     entityType,
     entityKey,
     boundVia,
     htmlUrl: buildHtmlUrl(entityType, parsed),
-    title: live.title,
-    state: live.state,
+    title: null,
+    state: stateFromPersistedEntityState(entityType, row.entityState),
     number: parsed.kind === "numeric" ? parsed.number : null,
+  };
+}
+
+/**
+ * Legacy live resolver kept for follow/list unit coverage and future
+ * call sites that explicitly want a best-effort GitHub REST overlay. The
+ * hot right-sidebar list path uses `materializeChatGithubEntity` directly.
+ */
+export async function resolveChatGithubEntity(
+  row: MappingRow,
+  token: string | null,
+  fetcher: typeof fetch = fetch,
+): Promise<ChatGithubEntity | null> {
+  const base = materializeChatGithubEntity(row);
+  if (!base || !token) return base;
+  const parsed = parseEntityKey(base.entityType, row.entityKey);
+  if (!parsed) return base;
+  const live = await fetchEntityLiveFields(base.entityType, parsed, token, fetcher);
+  return {
+    ...base,
+    title: live.title,
+    state: live.state ?? base.state,
   };
 }
 
@@ -207,4 +243,5 @@ export const __testing = {
   parseEntityKey,
   buildHtmlUrl,
   fetchEntityLiveFields,
+  stateFromPersistedEntityState,
 };

--- a/packages/server/src/services/github-entity-state.ts
+++ b/packages/server/src/services/github-entity-state.ts
@@ -9,11 +9,14 @@
  *
  * Behaviour:
  *
- *   - PR `closed` + merged   → `entity_state = 'merged'`
- *   - PR `closed` + un-merged → `entity_state = 'closed'`
- *   - PR `reopened`          → `entity_state = 'open'`
- *   - Issue `closed`         → `entity_state = 'closed'`
- *   - Issue `reopened`       → `entity_state = 'open'`
+ *   - PR `opened/reopened` while draft → `entity_state = 'draft'`
+ *   - PR `opened/reopened` otherwise   → `entity_state = 'open'`
+ *   - PR `converted_to_draft`          → `entity_state = 'draft'`
+ *   - PR `ready_for_review`            → `entity_state = 'open'`
+ *   - PR `closed` + merged             → `entity_state = 'merged'`
+ *   - PR `closed` + un-merged          → `entity_state = 'closed'`
+ *   - Issue `opened/reopened`          → `entity_state = 'open'`
+ *   - Issue `closed`                   → `entity_state = 'closed'`
  *
  * Idempotent under webhook retries: writes are scoped to
  * `(organization_id, entity_type, entity_key)`, the mapping table's natural
@@ -24,7 +27,13 @@ import { and, eq, sql } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 import { githubEntityChatMappings } from "../db/schema/github-entity-chat-mappings.js";
 
-export type EntityState = "open" | "closed" | "merged";
+export type EntityState = "open" | "draft" | "closed" | "merged";
+
+export type EntityStateSeed = {
+  entityType: "pull_request" | "issue";
+  entityKey: string;
+  state: EntityState;
+};
 
 export type SetEntityStateInput = {
   organizationId: string;

--- a/packages/shared/src/schemas/chat-github-entities.ts
+++ b/packages/shared/src/schemas/chat-github-entities.ts
@@ -5,14 +5,13 @@ import { githubEntityTypeSchema } from "./chat-metadata.js";
  * Schema for `GET /api/v1/chats/:chatId/github-entities`.
  *
  * Each item describes one entity bound to the chat via
- * `github_entity_chat_mappings`. Live state (`title`, `state`) is fetched
- * per-request from the GitHub REST API at request time and NEVER
- * persisted to the database — the user explicitly opted for the
- * fresh-on-every-open model rather than a webhook-synced column.
+ * `github_entity_chat_mappings`. The server projects state from the
+ * webhook-synced `entity_state` column rather than calling GitHub on the
+ * read path.
  *
- * Live fields may be `null` when the GitHub call failed (token unavailable,
- * rate-limited, 404 on a deleted entity, etc.). The client falls back to
- * rendering `entityKey + htmlUrl` so the row is still a working link.
+ * Title may be `null` because mapping rows do not persist titles. The client
+ * falls back to rendering `entityKey + htmlUrl` so the row is still a
+ * working link.
  */
 
 /**
@@ -47,11 +46,10 @@ export function isDeclaredBoundVia(value: string): value is DeclaredBoundVia {
 }
 
 /**
- * Coarse live state. PR-specific values (`merged`, `draft`) are folded
+ * Coarse entity state. PR-specific values (`merged`, `draft`) are folded
  * into the same enum as the issue's `open` / `closed` so the UI can
- * switch on a single field. `null` means we couldn't reach GitHub for
- * this entity in this request — the row still renders, just without
- * the state badge.
+ * switch on a single field. `null` means the state is not meaningful for
+ * this entity type, or the persisted value was unknown.
  */
 export const githubEntityLiveStateSchema = z.enum(["open", "closed", "merged", "draft"]);
 export type GithubEntityLiveState = z.infer<typeof githubEntityLiveStateSchema>;
@@ -68,9 +66,9 @@ export const chatGithubEntitySchema = z.object({
    * unreachable for the live fields.
    */
   htmlUrl: z.string().url(),
-  /** Live title from GitHub. `null` when the fetch failed / no token. */
+  /** Persisted title projection when available; currently null for mapping-only rows. */
   title: z.string().nullable(),
-  /** Live state from GitHub. `null` when the fetch failed / no token. */
+  /** Webhook-synced state projection. `null` for commits/discussions. */
   state: githubEntityLiveStateSchema.nullable(),
   /** Issue / PR / Discussion number when applicable. */
   number: z.number().int().nullable(),

--- a/packages/web/src/api/chats.ts
+++ b/packages/web/src/api/chats.ts
@@ -44,9 +44,8 @@ export function getChatTokenUsage(chatId: string): Promise<ChatTokenUsage> {
 }
 
 /**
- * List the GitHub entities bound to this chat. Server fetches live state
- * from GitHub on every request — nothing is cached server-side — so the
- * client should rely on React Query's `staleTime` to keep this gentle.
+ * List the GitHub entities bound to this chat. The server reads its local
+ * mapping projection only; state freshness comes from GitHub webhooks.
  */
 export function listChatGithubEntities(chatId: string): Promise<ChatGithubEntityListResponse> {
   return api.get<ChatGithubEntityListResponse>(`/chats/${encodeURIComponent(chatId)}/github-entities`);

--- a/packages/web/src/hooks/use-admin-ws.ts
+++ b/packages/web/src/hooks/use-admin-ws.ts
@@ -116,8 +116,8 @@ const chatAgentStatusInvalidator = createThrottledInvalidator(["chat-agent-statu
 //
 // `["chat-right-sidebar", "session", ...]` is targeted explicitly to keep
 // the sibling `["chat-right-sidebar", "github-entities", chatId]` query
-// (github-section.tsx) — a 60s GitHub REST poll — out of the invalidation
-// path on every `session:state` burst.
+// (github-section.tsx) — a periodic GitHub-entity DB projection — out of
+// the invalidation path on every `session:state` burst.
 type SessionPairThrottleState = {
   lastAt: number;
   trailingTimer: ReturnType<typeof setTimeout> | null;

--- a/packages/web/src/pages/workspace/right-sidebar/github-section.tsx
+++ b/packages/web/src/pages/workspace/right-sidebar/github-section.tsx
@@ -6,10 +6,9 @@ import { DenseBadge, type DenseBadgeTone } from "../../../components/ui/dense-ba
 
 /**
  * GitHub section — lists every PR / Issue / Discussion / Commit bound to
- * the current chat via `github_entity_chat_mappings`. Live title + state
- * are fetched per-request by the server from the GitHub REST API and are
- * NOT persisted; rows degrade gracefully (link only) when the GitHub
- * round-trip fails or the org has no installation.
+ * the current chat via `github_entity_chat_mappings`. State comes from the
+ * server's webhook-synced projection; title may be null because the mapping
+ * table does not persist titles, so rows degrade gracefully to link-only.
  *
  * Hidden entirely when the chat has no bindings — empty rails would
  * waste vertical space on chats that aren't sourced from GitHub.
@@ -18,9 +17,8 @@ export function GitHubSection({ chatId }: { chatId: string }) {
   const query = useQuery({
     queryKey: ["chat-right-sidebar", "github-entities", chatId],
     queryFn: () => listChatGithubEntities(chatId),
-    // GitHub live state can drift between sessions; refresh every 60s when
-    // the panel is open, and treat the data as fresh for ~30s so quick
-    // panel toggles do not refetch.
+    // Webhook-synced state can drift while the panel is open; refresh the
+    // cheap DB projection periodically and keep quick panel toggles warm.
     staleTime: 30_000,
     refetchInterval: 60_000,
   });


### PR DESCRIPTION
## Summary
- Make chat GitHub entity list endpoints read local mapping projections instead of resolving an installation token and calling GitHub REST.
- Persist PR/Issue lifecycle state from follow resolution and webhook insert seeds/transitions, including draft PR support.
- Update shared/client/web/CLI contract comments and route tests for DB-only list behavior and webhook seed edge cases.

## Context Tree
- Companion context PR: https://github.com/agent-team-foundation/first-tree-context/pull/553

## Verification
- `pnpm exec biome check --write packages/server/src/api/webhooks/github-app.ts packages/server/src/__tests__/github-app-webhook-route.test.ts`
- `pnpm exec vitest run --maxWorkers=2 src/__tests__/github-app-webhook-route.test.ts`
- `pnpm exec vitest run --maxWorkers=2 src/__tests__/github-entity-follow.test.ts src/__tests__/github-entity-live.test.ts src/__tests__/resolve-target-chat.test.ts src/__tests__/github-app-webhook-route.test.ts src/__tests__/github-entities-agent-route.test.ts`
- `pnpm check`
  - exits 0; existing unrelated Biome warnings remain in `packages/web/src/pages/agent-detail/prompt-tab.tsx`, `apps/cli/src/__tests__/agent-shared-helpers-extra.test.ts`, and `packages/client/src/runtime/workspace-migrations.ts`
- `pnpm typecheck`