### PR TITLE
fix(client): keep claude-code-tui startup from deadlocking on unanswerable prompts

### DIFF
--- a/packages/client/src/__tests__/error-taxonomy.test.ts
+++ b/packages/client/src/__tests__/error-taxonomy.test.ts
@@ -106,6 +106,15 @@ describe("error-taxonomy.classify", () => {
       expect(c.reasonCode).toBe("auth_refresh_failed");
     });
 
+    it("ClaudeTuiLoginRequiredError (session source) → permanent, no retry", () => {
+      const err = new Error("claude TUI requires re-authentication (run /login) — session=ftth-x");
+      err.name = "ClaudeTuiLoginRequiredError";
+      const c = classify(err, { source: "session" });
+      expect(c.kind).toBe(ERROR_KINDS.PERMANENT);
+      expect(c.reasonCode).toBe("claude_login_required");
+      expect(c.strategy.kind).toBe("none");
+    });
+
     it("ClientOrgMismatchError → permanent with default message", () => {
       const c = classify(noMessageShape({ name: "ClientOrgMismatchError" }));
       expect(c.kind).toBe(ERROR_KINDS.PERMANENT);

--- a/packages/client/src/__tests__/tui-tmux-session.test.ts
+++ b/packages/client/src/__tests__/tui-tmux-session.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
   deriveSessionName,
+  isBypassPermissionsWarning,
+  isClaudeLoginWall,
   isResumeSummaryPrompt,
   isWorkspaceTrustPrompt,
   ownedSessionPrefix,
@@ -131,5 +133,59 @@ Resuming the full session will consume a substantial portion of your usage limit
 `;
 
     expect(isResumeSummaryPrompt(pane)).toBe(false);
+  });
+});
+
+describe("isBypassPermissionsWarning", () => {
+  it("detects the one-time bypass-permissions acceptance modal", () => {
+    const pane = `
+ WARNING: Claude Code running in Bypass Permissions mode
+
+ In Bypass Permissions mode, Claude Code will not ask for your approval
+ before running potentially dangerous commands.
+
+ ❯ 1. Yes, I accept
+   2. No, exit
+
+ Enter to confirm · Esc to cancel
+`;
+
+    expect(isBypassPermissionsWarning(pane)).toBe(true);
+  });
+
+  it("does not treat the normal ready surface ('bypass permissions on') as the modal", () => {
+    const pane = `
+❯ Try "edit <filepath> to..."
+⏵⏵ bypass permissions on (shift+tab to cycle)
+`;
+
+    expect(isBypassPermissionsWarning(pane)).toBe(false);
+  });
+});
+
+describe("isClaudeLoginWall", () => {
+  it("detects the interactive login-method selector", () => {
+    const pane = `
+ Select login method:
+
+ ❯ 1. Login with Claude account
+   2. Login with Claude Console (API)
+`;
+
+    expect(isClaudeLoginWall(pane)).toBe(true);
+  });
+
+  it("detects a 'run /login' re-auth prompt", () => {
+    expect(isClaudeLoginWall("OAuth refresh token is no longer valid; run /login to re-authenticate")).toBe(true);
+    expect(isClaudeLoginWall("Not authenticated. Please run /login and try again.")).toBe(true);
+  });
+
+  it("does not fire on the normal ready surface", () => {
+    const pane = `
+❯ Try "edit <filepath> to..."
+⏵⏵ bypass permissions on (shift+tab to cycle)
+`;
+
+    expect(isClaudeLoginWall(pane)).toBe(false);
   });
 });

--- a/packages/client/src/__tests__/tui-tmux-session.test.ts
+++ b/packages/client/src/__tests__/tui-tmux-session.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   deriveSessionName,
+  isResumeSummaryPrompt,
   isWorkspaceTrustPrompt,
   ownedSessionPrefix,
 } from "../handlers/claude-code-tui/tmux-session.js";
@@ -91,5 +92,44 @@ describe("isWorkspaceTrustPrompt", () => {
 `;
 
     expect(isWorkspaceTrustPrompt(pane)).toBe(false);
+  });
+});
+
+describe("isResumeSummaryPrompt", () => {
+  it("detects Claude Code's large-session resume strategy menu", () => {
+    const pane = `
+This session is 2h 41m old and 119.5k tokens.
+Resuming the full session will consume a substantial portion of your usage limits. We recommend resuming from a summary.
+
+ ❯ 1. Resume from summary (recommended)
+   2. Resume full session as-is
+   3. Don't ask me again
+
+ Enter to confirm · Esc to cancel
+`;
+
+    expect(isResumeSummaryPrompt(pane)).toBe(true);
+  });
+
+  it("does not treat the normal ready surface as a resume menu", () => {
+    const pane = `
+❯ Try "edit <filepath> to..."
+⏵⏵ bypass permissions on (shift+tab to cycle)
+`;
+
+    expect(isResumeSummaryPrompt(pane)).toBe(false);
+  });
+
+  it("does not trip on the trust prompt (disjoint option labels)", () => {
+    const pane = `
+ Quick safety check: Is this a project you created or one you trust?
+
+ ❯ 1. Yes, I trust this folder
+   2. No, exit
+
+ Enter to confirm · Esc to cancel
+`;
+
+    expect(isResumeSummaryPrompt(pane)).toBe(false);
   });
 });

--- a/packages/client/src/__tests__/tui-tmux-session.test.ts
+++ b/packages/client/src/__tests__/tui-tmux-session.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from "vitest";
 import {
+  ClaudeTuiLoginRequiredError,
   deriveSessionName,
   isBypassPermissionsWarning,
   isClaudeLoginWall,
   isResumeSummaryPrompt,
   isWorkspaceTrustPrompt,
   ownedSessionPrefix,
+  waitForReady,
 } from "../handlers/claude-code-tui/tmux-session.js";
 
 const CID = "client_abcd1234";
@@ -161,6 +163,13 @@ describe("isBypassPermissionsWarning", () => {
 
     expect(isBypassPermissionsWarning(pane)).toBe(false);
   });
+
+  it("does not fire on transcript text that merely mentions bypass mode", () => {
+    // Lacks the full warning title + both option labels of the live modal.
+    expect(isBypassPermissionsWarning('we discussed Bypass Permissions mode and the "Yes, I accept" option')).toBe(
+      false,
+    );
+  });
 });
 
 describe("isClaudeLoginWall", () => {
@@ -175,9 +184,11 @@ describe("isClaudeLoginWall", () => {
     expect(isClaudeLoginWall(pane)).toBe(true);
   });
 
-  it("detects a 'run /login' re-auth prompt", () => {
-    expect(isClaudeLoginWall("OAuth refresh token is no longer valid; run /login to re-authenticate")).toBe(true);
-    expect(isClaudeLoginWall("Not authenticated. Please run /login and try again.")).toBe(true);
+  it("does NOT fire on loose 'run /login' / OAuth transcript text (no live selector)", () => {
+    // These strings routinely appear in ordinary conversation; a false positive
+    // here marks a healthy session permanent. Only the live selector counts.
+    expect(isClaudeLoginWall("OAuth refresh token is no longer valid; run /login to re-authenticate")).toBe(false);
+    expect(isClaudeLoginWall("Not authenticated. Please run /login and try again.")).toBe(false);
   });
 
   it("does not fire on the normal ready surface", () => {
@@ -187,5 +198,80 @@ describe("isClaudeLoginWall", () => {
 `;
 
     expect(isClaudeLoginWall(pane)).toBe(false);
+  });
+});
+
+describe("waitForReady ordering (transcript safety)", () => {
+  // A ready pane whose visible transcript quotes EVERY modal/login string.
+  const readyPaneQuotingPrompts = [
+    "⏺ Recap of this chat: it mentions run /login and Select login method,",
+    "  the option Login with Claude account, plus the modal title",
+    "  WARNING: Claude Code running in Bypass Permissions mode with options",
+    '  "Yes, I accept" / "No, exit".',
+    '❯ Try "edit <filepath> to..."',
+    "⏵⏵ bypass permissions on (shift+tab to cycle)",
+  ].join("\n");
+
+  it("the detectors WOULD fire on that transcript, so ready-first ordering is load-bearing", () => {
+    expect(isClaudeLoginWall(readyPaneQuotingPrompts)).toBe(true);
+    expect(isBypassPermissionsWarning(readyPaneQuotingPrompts)).toBe(true);
+  });
+
+  it("returns ready with no keystroke and no throw despite the quoted prompts", async () => {
+    const sent: string[] = [];
+    await expect(
+      waitForReady({
+        name: "ftth-test",
+        timeoutMs: 1_000,
+        pollIntervalMs: 1,
+        capture: async () => readyPaneQuotingPrompts,
+        send: async (_name, key) => {
+          sent.push(key);
+        },
+      }),
+    ).resolves.toBeUndefined();
+    expect(sent).toEqual([]);
+  });
+
+  it("throws ClaudeTuiLoginRequiredError on a live (non-ready) login selector", async () => {
+    const loginPane =
+      "\n Select login method:\n\n ❯ 1. Login with Claude account\n   2. Login with Claude Console (API)\n";
+    const sent: string[] = [];
+    await expect(
+      waitForReady({
+        name: "ftth-test",
+        timeoutMs: 1_000,
+        pollIntervalMs: 1,
+        capture: async () => loginPane,
+        send: async (_name, key) => {
+          sent.push(key);
+        },
+      }),
+    ).rejects.toBeInstanceOf(ClaudeTuiLoginRequiredError);
+    expect(sent).toEqual([]);
+  });
+
+  it("accepts a live bypass modal by sending '1' then Enter, then reaches ready", async () => {
+    const modalPane = [
+      " WARNING: Claude Code running in Bypass Permissions mode",
+      " ❯ 1. Yes, I accept",
+      "   2. No, exit",
+      " Enter to confirm · Esc to cancel",
+    ].join("\n");
+    const readyPane = "❯ ready\n⏵⏵ bypass permissions on (shift+tab to cycle)";
+    let polls = 0;
+    const sent: string[] = [];
+    await expect(
+      waitForReady({
+        name: "ftth-test",
+        timeoutMs: 2_000,
+        pollIntervalMs: 1,
+        capture: async () => (polls++ === 0 ? modalPane : readyPane),
+        send: async (_name, key) => {
+          sent.push(key);
+        },
+      }),
+    ).resolves.toBeUndefined();
+    expect(sent).toEqual(["1", "Enter"]);
   });
 });

--- a/packages/client/src/handlers/claude-code-tui/tmux-session.ts
+++ b/packages/client/src/handlers/claude-code-tui/tmux-session.ts
@@ -177,6 +177,9 @@ export type WaitForReadyInput = {
    * the menu and still time out, re-deadlocking on the next resume attempt.
    */
   summaryReadyTimeoutMs?: number;
+  /** Test seams; default to the real tmux helpers (capturePane / sendKey). */
+  capture?: (sessionName: string) => Promise<string>;
+  send?: (sessionName: string, key: string) => Promise<void>;
 };
 
 /**
@@ -211,34 +214,45 @@ export function isResumeSummaryPrompt(pane: string): boolean {
 }
 
 /**
- * `--dangerously-skip-permissions` makes Claude Code show a one-time "Bypass
- * Permissions mode" warning ("Yes, I accept" / "No, exit") before the ready
- * surface unless the HOME has already accepted it (a settings flag or a prior
- * interactive accept). First Tree never sets that flag, so a fresh HOME (new
- * machine / cloud agent) hits this modal and deadlocks exactly like the trust
- * dialog. Distinct from the READY_MARKER ("bypass permissions on") by the
- * "mode" wording plus the accept option.
+ * `--dangerously-skip-permissions` makes Claude Code show a one-time
+ * Bypass-Permissions warning ("Yes, I accept" / "No, exit") before the ready
+ * surface unless the HOME already accepted it (a settings flag or a prior
+ * interactive accept). First Tree sets that flag nowhere, so a fresh HOME (new
+ * machine / cloud agent) hits this modal and deadlocks like the trust dialog.
+ *
+ * Match the full warning title AND both option labels: the captured pane also
+ * contains prior transcript on resume, so a loose "Bypass Permissions mode"
+ * match could fire on conversation text and inject a stray keystroke. The full
+ * title + both options is a live-modal shape that ordinary prose won't satisfy
+ * (and `waitForReady` checks the ready surface first regardless).
  */
 export function isBypassPermissionsWarning(pane: string): boolean {
-  return pane.includes("Bypass Permissions mode") && pane.includes("Yes, I accept");
+  return (
+    pane.includes("WARNING: Claude Code running in Bypass Permissions mode") &&
+    pane.includes("Yes, I accept") &&
+    pane.includes("No, exit")
+  );
 }
 
 /**
- * Claude Code drops into an interactive login / re-auth wall when credentials
- * are missing or expired (OAuth refresh token revoked, API key invalid, …) —
- * a login-method selector or a "run /login" prompt. Unlike the trust / resume
- * / bypass modals this is NOT answerable by keystroke (it needs a human to
- * re-authenticate in a browser), so waitForReady throws
- * {@link ClaudeTuiLoginRequiredError} on sight; the error taxonomy classifies
- * it `permanent` so the session stops the otherwise-infinite transient retry
- * loop and surfaces to an operator instead of silently spamming retries.
+ * Claude Code drops into an interactive login wall when credentials are missing
+ * or expired — a login-method selector the detached runtime cannot answer (a
+ * human must re-authenticate in a browser). waitForReady throws
+ * {@link ClaudeTuiLoginRequiredError} on sight; the taxonomy classifies it
+ * `permanent` so the session stops the otherwise-infinite retry loop and
+ * surfaces to an operator instead of silently spamming retries.
+ *
+ * Match ONLY the live selector (its title AND an option label), never loose
+ * "run /login" / OAuth phrasing: that text routinely appears in ordinary
+ * transcript content (a resumed pane re-renders prior conversation), and a
+ * false positive here is irreversible — it marks a healthy session permanent.
+ * Under-detecting (a non-selector auth failure falls back to the normal
+ * retry + ready-timeout path) is the safe direction.
  */
 export function isClaudeLoginWall(pane: string): boolean {
   return (
-    pane.includes("Select login method") ||
-    pane.includes("Login with Claude account") ||
-    pane.includes("OAuth refresh token is no longer valid") ||
-    /\brun \/login\b/i.test(pane)
+    pane.includes("Select login method") &&
+    (pane.includes("Login with Claude account") || pane.includes("Sign in with your Anthropic account"))
   );
 }
 
@@ -255,16 +269,29 @@ export class ClaudeTuiLoginRequiredError extends Error {
   }
 }
 
+/** True iff the pane shows the loaded ready surface (marker + `❯` input line). */
+function isReadySurface(pane: string): boolean {
+  return pane.includes(READY_MARKER) && pane.split("\n").some((line) => USER_RE.test(line));
+}
+
 /**
- * Poll capture-pane until both the bypass-permissions marker and a `❯`
- * input prompt line are visible. Resolves on success, throws on timeout.
- * One-time interactive prompts can precede the ready surface; the detached
- * runtime handles each instead of deadlocking on it:
+ * Poll capture-pane until the bypass-permissions marker and a `❯` input prompt
+ * line are visible. Resolves on success, throws on timeout.
+ *
+ * The ready surface is checked FIRST every poll. A loaded TUI always shows the
+ * marker + input prompt, and on resume the captured pane ALSO re-renders prior
+ * transcript -- which can quote modal/login strings. Checking ready first means
+ * a healthy session is never mistaken for a modal (no stray keystroke) or for
+ * the login wall (no false permanent failure) just because its visible history
+ * mentions those words.
+ *
+ * Only before the ready surface exists do we handle the one-time interactive
+ * prompts instead of deadlocking on them:
  * - the workspace trust prompt (acknowledged with Enter);
  * - the bypass-permissions warning (accept option 1, "Yes, I accept");
  * - the large-session "resume strategy" menu (select option 1, "Resume from
  *   summary", so over-threshold sessions resume from a summary).
- * The login / re-auth wall is NOT keystroke-answerable, so it throws
+ * The login wall is NOT keystroke-answerable, so it throws
  * {@link ClaudeTuiLoginRequiredError} (classified `permanent`) to stop the
  * retry loop and surface to an operator rather than time out forever.
  */
@@ -272,6 +299,8 @@ export async function waitForReady(input: WaitForReadyInput): Promise<void> {
   const timeoutMs = input.timeoutMs ?? 30_000;
   const pollIntervalMs = input.pollIntervalMs ?? 250;
   const summaryReadyTimeoutMs = input.summaryReadyTimeoutMs ?? 120_000;
+  const capture = input.capture ?? capturePane;
+  const send = input.send ?? sendKey;
   const started = Date.now();
   let deadline = started + timeoutMs;
   let acceptedWorkspaceTrust = false;
@@ -281,15 +310,20 @@ export async function waitForReady(input: WaitForReadyInput): Promise<void> {
     // The TUI prints U+00A0 (NBSP) inside its chrome (see tui-markers.ts);
     // normalize to ASCII space once so every substring match below is robust
     // to that, regardless of which gaps Claude renders as NBSP.
-    const pane = (await capturePane(input.name)).replace(/\u00A0/g, " ");
-    // An unanswerable login / re-auth wall can't be keystroked away; fail fast
-    // and let the taxonomy mark it permanent so we stop retrying forever.
+    const pane = (await capture(input.name)).replace(/\u00A0/g, " ");
+    // Ready wins over every modal/login check below -- see the function doc:
+    // a ready pane can also show prior transcript that quotes those strings.
+    if (isReadySurface(pane)) {
+      return;
+    }
+    // Not ready yet. An unanswerable login wall can't be keystroked away; fail
+    // fast and let the taxonomy mark it permanent so we stop retrying forever.
     if (isClaudeLoginWall(pane)) {
       throw new ClaudeTuiLoginRequiredError(input.name);
     }
     if (!acceptedWorkspaceTrust && isWorkspaceTrustPrompt(pane)) {
       acceptedWorkspaceTrust = true;
-      await sendKey(input.name, "Enter");
+      await send(input.name, "Enter");
       await new Promise((r) => setTimeout(r, pollIntervalMs));
       continue;
     }
@@ -301,9 +335,9 @@ export async function waitForReady(input: WaitForReadyInput): Promise<void> {
       // "1" pins the affirmative option; if number-select is unsupported it is
       // ignored and Enter falls on the default (the affirmative option 1, as
       // with the trust dialog).
-      await sendKey(input.name, "1");
+      await send(input.name, "1");
       await new Promise((r) => setTimeout(r, 100));
-      await sendKey(input.name, "Enter");
+      await send(input.name, "Enter");
       await new Promise((r) => setTimeout(r, pollIntervalMs));
       continue;
     }
@@ -313,18 +347,15 @@ export async function waitForReady(input: WaitForReadyInput): Promise<void> {
       // than relying on Enter hitting the default highlight: it pins the
       // over-threshold path to a summary even if a future build reorders or
       // re-highlights the menu. (If number-select is unsupported, the "1" is
-      // ignored and Enter still falls on the recommended default — option 1.)
-      await sendKey(input.name, "1");
+      // ignored and Enter still falls on the recommended default -- option 1.)
+      await send(input.name, "1");
       await new Promise((r) => setTimeout(r, 100));
-      await sendKey(input.name, "Enter");
+      await send(input.name, "Enter");
       // Summary generation needs a fresh, longer window than a normal start,
       // or a large session answers the menu and still times out.
       deadline = Date.now() + summaryReadyTimeoutMs;
       await new Promise((r) => setTimeout(r, pollIntervalMs));
       continue;
-    }
-    if (pane.includes(READY_MARKER) && pane.split("\n").some((line) => USER_RE.test(line))) {
-      return;
     }
     await new Promise((r) => setTimeout(r, pollIntervalMs));
   }

--- a/packages/client/src/handlers/claude-code-tui/tmux-session.ts
+++ b/packages/client/src/handlers/claude-code-tui/tmux-session.ts
@@ -169,6 +169,14 @@ export type WaitForReadyInput = {
   name: string;
   timeoutMs?: number;
   pollIntervalMs?: number;
+  /**
+   * Deadline granted *after* we auto-select "Resume from summary". Claude then
+   * generates the summary (an LLM round-trip over the whole session) before it
+   * reaches the ready surface, which routinely exceeds the normal `timeoutMs`
+   * start window. Without a fresh, longer deadline a large session would answer
+   * the menu and still time out, re-deadlocking on the next resume attempt.
+   */
+  summaryReadyTimeoutMs?: number;
 };
 
 /**
@@ -186,21 +194,56 @@ export function isWorkspaceTrustPrompt(pane: string): boolean {
 }
 
 /**
+ * Claude Code shows a one-time "resume strategy" menu before the normal TUI
+ * surface when resuming a large / old session — e.g. "This session is 2h 41m
+ * old and 119.5k tokens. … We recommend resuming from a summary." with options
+ * `1. Resume from summary (recommended)` / `2. Resume full session as-is` /
+ * `3. Don't ask me again`. The detached runtime has no human to answer it, so
+ * without acknowledging this menu the handler never reaches the ready marker
+ * and the session start times out, looping forever on every resume attempt.
+ * We match on the two stable option labels plus the confirm footer so the
+ * normal ready surface never trips it.
+ */
+export function isResumeSummaryPrompt(pane: string): boolean {
+  return (
+    pane.includes("Resume from summary") && pane.includes("Resume full session") && pane.includes("Enter to confirm")
+  );
+}
+
+/**
  * Poll capture-pane until both the bypass-permissions marker and a `❯`
  * input prompt line are visible. Resolves on success, throws on timeout.
- * If Claude shows its workspace trust prompt first, acknowledge it once and
- * keep waiting for the actual ready surface.
+ * Two one-time interactive prompts can precede the ready surface; we
+ * auto-acknowledge each and keep waiting:
+ * - the workspace trust prompt (acknowledged with Enter); and
+ * - the large-session "resume strategy" menu, where we accept the default
+ *   "Resume from summary (recommended)" so over-threshold sessions resume from
+ *   a summary instead of deadlocking on an unanswerable menu.
  */
 export async function waitForReady(input: WaitForReadyInput): Promise<void> {
   const timeoutMs = input.timeoutMs ?? 30_000;
   const pollIntervalMs = input.pollIntervalMs ?? 250;
+  const summaryReadyTimeoutMs = input.summaryReadyTimeoutMs ?? 120_000;
   const started = Date.now();
+  let deadline = started + timeoutMs;
   let acceptedWorkspaceTrust = false;
-  while (Date.now() - started < timeoutMs) {
+  let acceptedResumeSummary = false;
+  while (Date.now() < deadline) {
     const pane = await capturePane(input.name);
     if (!acceptedWorkspaceTrust && isWorkspaceTrustPrompt(pane)) {
       acceptedWorkspaceTrust = true;
       await sendKey(input.name, "Enter");
+      await new Promise((r) => setTimeout(r, pollIntervalMs));
+      continue;
+    }
+    if (!acceptedResumeSummary && isResumeSummaryPrompt(pane)) {
+      // Enter selects the default-highlighted "1. Resume from summary
+      // (recommended)" — the over-threshold path the menu itself recommends.
+      acceptedResumeSummary = true;
+      await sendKey(input.name, "Enter");
+      // Summary generation needs a fresh, longer window than a normal start,
+      // or a large session answers the menu and still times out.
+      deadline = Date.now() + summaryReadyTimeoutMs;
       await new Promise((r) => setTimeout(r, pollIntervalMs));
       continue;
     }
@@ -209,7 +252,8 @@ export async function waitForReady(input: WaitForReadyInput): Promise<void> {
     }
     await new Promise((r) => setTimeout(r, pollIntervalMs));
   }
-  throw new Error(`claude TUI did not become ready within ${timeoutMs}ms (session=${input.name})`);
+  const waitedMs = Date.now() - started;
+  throw new Error(`claude TUI did not become ready within ${waitedMs}ms (session=${input.name})`);
 }
 
 /**

--- a/packages/client/src/handlers/claude-code-tui/tmux-session.ts
+++ b/packages/client/src/handlers/claude-code-tui/tmux-session.ts
@@ -229,7 +229,10 @@ export async function waitForReady(input: WaitForReadyInput): Promise<void> {
   let acceptedWorkspaceTrust = false;
   let acceptedResumeSummary = false;
   while (Date.now() < deadline) {
-    const pane = await capturePane(input.name);
+    // The TUI prints U+00A0 (NBSP) inside its chrome (see tui-markers.ts);
+    // normalize to ASCII space once so every substring match below is robust
+    // to that, regardless of which gaps Claude renders as NBSP.
+    const pane = (await capturePane(input.name)).replace(/\u00A0/g, " ");
     if (!acceptedWorkspaceTrust && isWorkspaceTrustPrompt(pane)) {
       acceptedWorkspaceTrust = true;
       await sendKey(input.name, "Enter");
@@ -237,9 +240,14 @@ export async function waitForReady(input: WaitForReadyInput): Promise<void> {
       continue;
     }
     if (!acceptedResumeSummary && isResumeSummaryPrompt(pane)) {
-      // Enter selects the default-highlighted "1. Resume from summary
-      // (recommended)" — the over-threshold path the menu itself recommends.
       acceptedResumeSummary = true;
+      // Select option 1 ("Resume from summary") explicitly by its number rather
+      // than relying on Enter hitting the default highlight: it pins the
+      // over-threshold path to a summary even if a future build reorders or
+      // re-highlights the menu. (If number-select is unsupported, the "1" is
+      // ignored and Enter still falls on the recommended default — option 1.)
+      await sendKey(input.name, "1");
+      await new Promise((r) => setTimeout(r, 100));
       await sendKey(input.name, "Enter");
       // Summary generation needs a fresh, longer window than a normal start,
       // or a large session answers the menu and still times out.

--- a/packages/client/src/handlers/claude-code-tui/tmux-session.ts
+++ b/packages/client/src/handlers/claude-code-tui/tmux-session.ts
@@ -211,14 +211,62 @@ export function isResumeSummaryPrompt(pane: string): boolean {
 }
 
 /**
+ * `--dangerously-skip-permissions` makes Claude Code show a one-time "Bypass
+ * Permissions mode" warning ("Yes, I accept" / "No, exit") before the ready
+ * surface unless the HOME has already accepted it (a settings flag or a prior
+ * interactive accept). First Tree never sets that flag, so a fresh HOME (new
+ * machine / cloud agent) hits this modal and deadlocks exactly like the trust
+ * dialog. Distinct from the READY_MARKER ("bypass permissions on") by the
+ * "mode" wording plus the accept option.
+ */
+export function isBypassPermissionsWarning(pane: string): boolean {
+  return pane.includes("Bypass Permissions mode") && pane.includes("Yes, I accept");
+}
+
+/**
+ * Claude Code drops into an interactive login / re-auth wall when credentials
+ * are missing or expired (OAuth refresh token revoked, API key invalid, …) —
+ * a login-method selector or a "run /login" prompt. Unlike the trust / resume
+ * / bypass modals this is NOT answerable by keystroke (it needs a human to
+ * re-authenticate in a browser), so waitForReady throws
+ * {@link ClaudeTuiLoginRequiredError} on sight; the error taxonomy classifies
+ * it `permanent` so the session stops the otherwise-infinite transient retry
+ * loop and surfaces to an operator instead of silently spamming retries.
+ */
+export function isClaudeLoginWall(pane: string): boolean {
+  return (
+    pane.includes("Select login method") ||
+    pane.includes("Login with Claude account") ||
+    pane.includes("OAuth refresh token is no longer valid") ||
+    /\brun \/login\b/i.test(pane)
+  );
+}
+
+/**
+ * Thrown by {@link waitForReady} when the TUI is parked on an unanswerable
+ * login / re-auth wall. The `name` is the classification contract: the error
+ * taxonomy maps it to a `permanent` `claude_login_required` so SessionManager
+ * stops retrying and surfaces the session as errored.
+ */
+export class ClaudeTuiLoginRequiredError extends Error {
+  constructor(sessionName: string) {
+    super(`claude TUI requires re-authentication (run /login) — session=${sessionName}`);
+    this.name = "ClaudeTuiLoginRequiredError";
+  }
+}
+
+/**
  * Poll capture-pane until both the bypass-permissions marker and a `❯`
  * input prompt line are visible. Resolves on success, throws on timeout.
- * Two one-time interactive prompts can precede the ready surface; we
- * auto-acknowledge each and keep waiting:
- * - the workspace trust prompt (acknowledged with Enter); and
- * - the large-session "resume strategy" menu, where we accept the default
- *   "Resume from summary (recommended)" so over-threshold sessions resume from
- *   a summary instead of deadlocking on an unanswerable menu.
+ * One-time interactive prompts can precede the ready surface; the detached
+ * runtime handles each instead of deadlocking on it:
+ * - the workspace trust prompt (acknowledged with Enter);
+ * - the bypass-permissions warning (accept option 1, "Yes, I accept");
+ * - the large-session "resume strategy" menu (select option 1, "Resume from
+ *   summary", so over-threshold sessions resume from a summary).
+ * The login / re-auth wall is NOT keystroke-answerable, so it throws
+ * {@link ClaudeTuiLoginRequiredError} (classified `permanent`) to stop the
+ * retry loop and surface to an operator rather than time out forever.
  */
 export async function waitForReady(input: WaitForReadyInput): Promise<void> {
   const timeoutMs = input.timeoutMs ?? 30_000;
@@ -227,14 +275,34 @@ export async function waitForReady(input: WaitForReadyInput): Promise<void> {
   const started = Date.now();
   let deadline = started + timeoutMs;
   let acceptedWorkspaceTrust = false;
+  let acceptedBypassWarning = false;
   let acceptedResumeSummary = false;
   while (Date.now() < deadline) {
     // The TUI prints U+00A0 (NBSP) inside its chrome (see tui-markers.ts);
     // normalize to ASCII space once so every substring match below is robust
     // to that, regardless of which gaps Claude renders as NBSP.
     const pane = (await capturePane(input.name)).replace(/\u00A0/g, " ");
+    // An unanswerable login / re-auth wall can't be keystroked away; fail fast
+    // and let the taxonomy mark it permanent so we stop retrying forever.
+    if (isClaudeLoginWall(pane)) {
+      throw new ClaudeTuiLoginRequiredError(input.name);
+    }
     if (!acceptedWorkspaceTrust && isWorkspaceTrustPrompt(pane)) {
       acceptedWorkspaceTrust = true;
+      await sendKey(input.name, "Enter");
+      await new Promise((r) => setTimeout(r, pollIntervalMs));
+      continue;
+    }
+    if (!acceptedBypassWarning && isBypassPermissionsWarning(pane)) {
+      acceptedBypassWarning = true;
+      // Accept by selecting option 1 ("Yes, I accept") explicitly by number.
+      // We must NOT rely on Enter hitting the default highlight here: if the
+      // modal ever defaulted to "No, exit", a bare Enter would QUIT claude.
+      // "1" pins the affirmative option; if number-select is unsupported it is
+      // ignored and Enter falls on the default (the affirmative option 1, as
+      // with the trust dialog).
+      await sendKey(input.name, "1");
+      await new Promise((r) => setTimeout(r, 100));
       await sendKey(input.name, "Enter");
       await new Promise((r) => setTimeout(r, pollIntervalMs));
       continue;

--- a/packages/client/src/runtime/error-taxonomy.ts
+++ b/packages/client/src/runtime/error-taxonomy.ts
@@ -234,6 +234,19 @@ export function classify(err: unknown, context?: { source?: ErrorSource }): Clas
       message: shape.message ?? "Refresh token rejected",
     };
   }
+  // The claude-code-tui runtime throws this when its detached `claude` start
+  // parks on an interactive login / re-auth wall it cannot keystroke past. No
+  // amount of retrying fixes it — a human must re-authenticate — so it's
+  // permanent (stops the otherwise-infinite transient retry loop and surfaces
+  // the session as errored).
+  if (shape.name === "ClaudeTuiLoginRequiredError") {
+    return {
+      kind: ERROR_KINDS.PERMANENT,
+      strategy: NONE,
+      reasonCode: "claude_login_required",
+      message: shape.message ?? "Claude TUI requires re-authentication (run /login)",
+    };
+  }
   if (isCodexBinaryMissingError(err)) {
     return {
       kind: ERROR_KINDS.PERMANENT,


### PR DESCRIPTION
## Problem

The `claude-code-tui` runtime launches `claude --resume <id>` inside a **detached tmux session** and polls `waitForReady` for the ready surface (`bypass permissions on` marker + `❯` prompt). If Claude Code shows **any interactive prompt that needs a keystroke** before that surface, the detached runtime can't answer it → `waitForReady` times out (30s) → `SessionManager` retries forever as `reasonCode:"unknown"` (transient). Observed live: a 119.5k-token / 2h41m session deadlocked on the resume-strategy menu and spammed `resilience.session.retry_*` every ~60s, recurring across chats.

This PR makes the runtime handle the known startup prompts instead of deadlocking, and stops the *infinite* retry when the prompt is genuinely unanswerable.

## Changes (all in `waitForReady` + the error taxonomy)

1. **Resume-strategy menu** (large/old session): detect it and select option 1 **"Resume from summary"** via `"1"`+Enter; grant a fresh longer deadline (`summaryReadyTimeoutMs`, default 120s) since summary generation is an LLM round-trip that exceeds the normal 30s start window.
2. **Bypass-Permissions warning** (`--dangerously-skip-permissions` → "WARNING: …Bypass Permissions mode" / "Yes, I accept" / "No, exit"): same deadlock class as the existing trust dialog, only masked today by HOMEs that carry `skipDangerousModePermissionPrompt` (First Tree sets it nowhere → fresh HOMEs deadlock). Accept option 1 **"Yes, I accept"** via `"1"`+Enter — explicit by number because a bare Enter on a "No, exit" default would *quit* claude.
3. **Login / re-auth wall** (interactive login-method selector): **not** keystroke-answerable — a human must re-authenticate. `waitForReady` throws `ClaudeTuiLoginRequiredError`, which the taxonomy classifies **permanent** (`claude_login_required`) → `SessionManager` stops retrying and surfaces the session as `errored` instead of spamming "did not become ready" forever.
4. **Robustness**: normalize U+00A0 (NBSP) → ASCII space on the captured pane before matching (the TUI prints NBSP in its chrome; `tui-markers.ts` documents this).
5. **Transcript safety (the key correctness guard)**: on resume the captured pane re-renders prior transcript, which can quote any of these prompt strings. So `waitForReady` checks the **ready surface FIRST every poll** — a loaded session (marker + `❯`) returns before any modal/login detection, so visible history mentioning `run /login` or `Bypass Permissions mode` can never inject a keystroke or trigger a false permanent failure. The detectors are also tightened to live-modal-only shapes (login = the selector title + an option label, not loose `run /login`; bypass = full warning title + both option labels), so even the pre-ready window can't be tripped by prose. Under-detecting (fall back to the normal retry/timeout) is the safe direction.

Already closed by existing launch flags and out of scope: the project-`.mcp.json` trust modal (`--strict-mcp-config`) and the in-turn AskUserQuestion picker (`--disallowed-tools AskUserQuestion`).

## Verification

- `pnpm --dir packages/client exec vitest run src/__tests__/tui-tmux-session.test.ts src/__tests__/error-taxonomy.test.ts src/__tests__/tui-suspend-queued-recovery.test.ts` — **75 passed**. Includes a `waitForReady ordering (transcript safety)` group driven through a `capture`/`send` injection seam: a ready pane quoting **every** modal/login string resolves with no keystroke and no throw (and asserts the detectors *would* fire on it, proving ready-first is load-bearing); a live login selector rejects with `ClaudeTuiLoginRequiredError`; a live bypass modal is accepted via `"1"`+Enter.
- `pnpm --filter @first-tree/client typecheck` — clean. Biome — clean.
- Independent QA: full client suite 1015/1015, typecheck, `pnpm check` clean; a real-tmux probe reproduced the transcript false-positive on the pre-fix head and the ready-first commit resolves it. The package TUI resume e2e is inconclusive but fails identically on `origin/main` (pre-existing harness issue, not introduced here).

Note: the bypass-modal and login-wall paths are masked on the dev machine (HOME already onboarded / authed), so they're covered by unit tests + a real-tmux probe + the live `claude.exe` strings, not a live daemon repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)