### PR TITLE
fix(server): repair missed inbox notify delivery

### DIFF
--- a/packages/server/src/__tests__/ws-inbox-delivery-order.test.ts
+++ b/packages/server/src/__tests__/ws-inbox-delivery-order.test.ts
@@ -1,7 +1,9 @@
 import type { InboxDeliverFrame } from "@first-tree/shared";
+import { and, eq } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import WebSocket from "ws";
+import { inboxEntries } from "../db/schema/inbox-entries.js";
 import { createAgent } from "../services/agent.js";
 import { createChat } from "../services/chat.js";
 import { sendMessage } from "../services/message.js";
@@ -31,6 +33,48 @@ describe("Agent WS — inbox delivery ordering", () => {
       };
       ws.on("message", onMessage);
     });
+  }
+
+  async function sendHeartbeat(ws: WebSocket): Promise<void> {
+    const ackPromise = waitForFrame(ws, (m) => (m as { type?: string }).type === "heartbeat:ack");
+    ws.send(JSON.stringify({ type: "heartbeat" }));
+    await ackPromise;
+  }
+
+  function expectNoDeliverFrame(ws: WebSocket, timeoutMs = 250): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        ws.off("message", onMessage);
+        resolve();
+      }, timeoutMs);
+      const onMessage = (raw: WebSocket.RawData) => {
+        try {
+          const msg = JSON.parse(raw.toString()) as Partial<InboxDeliverFrame> & { type?: string };
+          if (msg.type !== "inbox:deliver") return;
+          clearTimeout(timer);
+          ws.off("message", onMessage);
+          reject(new Error(`unexpected duplicate inbox:deliver frame for entry ${msg.entryId ?? "unknown"}`));
+        } catch {
+          // ignore non-JSON frames
+        }
+      };
+      ws.on("message", onMessage);
+    });
+  }
+
+  async function loadNotifyRow(inboxId: string, messageId: string) {
+    const [row] = await app.db
+      .select({
+        id: inboxEntries.id,
+        status: inboxEntries.status,
+        deliveredAt: inboxEntries.deliveredAt,
+      })
+      .from(inboxEntries)
+      .where(
+        and(eq(inboxEntries.inboxId, inboxId), eq(inboxEntries.messageId, messageId), eq(inboxEntries.notify, true)),
+      )
+      .limit(1);
+    return row;
   }
 
   function collectDeliverFrames(ws: WebSocket, count: number, timeoutMs = 5000): Promise<InboxDeliverFrame[]> {
@@ -141,6 +185,163 @@ describe("Agent WS — inbox delivery ordering", () => {
 
       expect(frames.map((frame) => frame.message.id)).toEqual([first.message.id, second.message.id]);
       expect(frames.map((frame) => frame.message.content)).toEqual(["A1", "A2"]);
+    } finally {
+      ws.close();
+      await new Promise<void>((resolve) => ws.once("close", () => resolve()));
+    }
+  }, 15000);
+
+  it("repairs a pending notify row on heartbeat when PG NOTIFY was missed", async () => {
+    const admin = await createAdminContext(app, { username: `ws-repair-${crypto.randomUUID().slice(0, 6)}` });
+    const agent = await createAgent(app.db, {
+      name: `ws-repair-agent-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      managerId: admin.memberId,
+      clientId: admin.clientId,
+      organizationId: admin.organizationId,
+    });
+    const chat = await createChat(app.db, admin.humanAgentUuid, {
+      type: "group",
+      participantIds: [agent.uuid],
+    });
+    const ws = await openBoundSocket({
+      accessToken: admin.accessToken,
+      clientId: admin.clientId,
+      agentId: agent.uuid,
+      runtimeProvider: agent.runtimeProvider,
+    });
+
+    try {
+      const sent = await sendMessage(app.db, chat.id, admin.humanAgentUuid, {
+        source: "api",
+        format: "text",
+        content: "lost notify repair",
+        metadata: { mentions: [agent.uuid] },
+      });
+      expect((await loadNotifyRow(agent.inboxId, sent.message.id))?.status).toBe("pending");
+
+      const framesPromise = collectDeliverFrames(ws, 1);
+      await sendHeartbeat(ws);
+      const [frame] = await framesPromise;
+
+      expect(frame?.message.id).toBe(sent.message.id);
+      const row = await loadNotifyRow(agent.inboxId, sent.message.id);
+      expect(row?.id).toBe(frame?.entryId);
+      expect(row?.status).toBe("delivered");
+      expect(row?.deliveredAt).toBeInstanceOf(Date);
+    } finally {
+      ws.close();
+      await new Promise<void>((resolve) => ws.once("close", () => resolve()));
+    }
+  }, 15000);
+
+  it("does not duplicate delivery when NOTIFY drain races heartbeat repair", async () => {
+    const admin = await createAdminContext(app, { username: `ws-repair-dupe-${crypto.randomUUID().slice(0, 6)}` });
+    const agent = await createAgent(app.db, {
+      name: `ws-repair-dupe-agent-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      managerId: admin.memberId,
+      clientId: admin.clientId,
+      organizationId: admin.organizationId,
+    });
+    const chat = await createChat(app.db, admin.humanAgentUuid, {
+      type: "group",
+      participantIds: [agent.uuid],
+    });
+    const ws = await openBoundSocket({
+      accessToken: admin.accessToken,
+      clientId: admin.clientId,
+      agentId: agent.uuid,
+      runtimeProvider: agent.runtimeProvider,
+    });
+
+    try {
+      const sent = await sendMessage(app.db, chat.id, admin.humanAgentUuid, {
+        source: "api",
+        format: "text",
+        content: "notify repair race",
+        metadata: { mentions: [agent.uuid] },
+      });
+
+      const framesPromise = collectDeliverFrames(ws, 1);
+      await Promise.all([app.notifier.notify(agent.inboxId, sent.message.id), sendHeartbeat(ws)]);
+      const [frame] = await framesPromise;
+      expect(frame?.message.id).toBe(sent.message.id);
+      await expectNoDeliverFrame(ws);
+
+      const row = await loadNotifyRow(agent.inboxId, sent.message.id);
+      expect(row?.id).toBe(frame?.entryId);
+      expect(row?.status).toBe("delivered");
+    } finally {
+      ws.close();
+      await new Promise<void>((resolve) => ws.once("close", () => resolve()));
+    }
+  }, 15000);
+
+  it("uses repair drains without letting one full chat block other chats", async () => {
+    const admin = await createAdminContext(app, { username: `ws-repair-fair-${crypto.randomUUID().slice(0, 6)}` });
+    const agent = await createAgent(app.db, {
+      name: `ws-repair-fair-agent-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      managerId: admin.memberId,
+      clientId: admin.clientId,
+      organizationId: admin.organizationId,
+    });
+    const chatA = await createChat(app.db, admin.humanAgentUuid, {
+      type: "group",
+      participantIds: [agent.uuid],
+    });
+    const chatB = await createChat(app.db, admin.humanAgentUuid, {
+      type: "group",
+      participantIds: [agent.uuid],
+    });
+    const ws = await openBoundSocket({
+      accessToken: admin.accessToken,
+      clientId: admin.clientId,
+      agentId: agent.uuid,
+      runtimeProvider: agent.runtimeProvider,
+    });
+
+    try {
+      const chatAMessageIds: string[] = [];
+      for (let i = 0; i < 9; i++) {
+        const sent = await sendMessage(app.db, chatA.id, admin.humanAgentUuid, {
+          source: "api",
+          format: "text",
+          content: `repair A${i + 1}`,
+          metadata: { mentions: [agent.uuid] },
+        });
+        chatAMessageIds.push(sent.message.id);
+      }
+      const chatBMessage = await sendMessage(app.db, chatB.id, admin.humanAgentUuid, {
+        source: "api",
+        format: "text",
+        content: "repair B1",
+        metadata: { mentions: [agent.uuid] },
+      });
+
+      const framesPromise = collectDeliverFrames(ws, 9);
+      await sendHeartbeat(ws);
+      const frames = await framesPromise;
+      const contents = frames.map((frame) => String(frame.message.content));
+
+      expect(contents.filter((content) => content.startsWith("repair A"))).toHaveLength(8);
+      expect(contents).toContain("repair B1");
+      expect(contents).not.toContain("repair A9");
+      expect((await loadNotifyRow(agent.inboxId, chatBMessage.message.id))?.status).toBe("delivered");
+
+      const lastChatAMessageId = chatAMessageIds.at(-1);
+      if (!lastChatAMessageId) throw new Error("expected chat A messages");
+      expect((await loadNotifyRow(agent.inboxId, lastChatAMessageId))?.status).toBe("pending");
+
+      const topUpPromise = collectDeliverFrames(ws, 1);
+      const firstChatAFrame = frames.find((frame) => frame.message.content === "repair A1");
+      if (!firstChatAFrame) throw new Error("expected repair A1 delivery");
+      ws.send(JSON.stringify({ type: "inbox:ack", entryId: firstChatAFrame.entryId, ref: "ack-repair-a1" }));
+      const [topUp] = await topUpPromise;
+
+      expect(topUp?.message.id).toBe(lastChatAMessageId);
+      expect(topUp?.message.content).toBe("repair A9");
     } finally {
       ws.close();
       await new Promise<void>((resolve) => ws.once("close", () => resolve()));

--- a/packages/server/src/api/agent/ws-client.ts
+++ b/packages/server/src/api/agent/ws-client.ts
@@ -75,6 +75,12 @@ const DEFAULT_INBOX_MAX_IN_FLIGHT_PER_AGENT_CHAT = 8;
  * single-transaction megabatch.
  */
 const INBOX_BACKLOG_BATCH_LIMIT = 50;
+/**
+ * Low-frequency safety net for missed PG NOTIFY events while the WebSocket
+ * remains online. The durable queue is still `inbox_entries`; this only adds a
+ * bounded extra trigger for sockets this server instance already owns.
+ */
+const INBOX_BACKLOG_REPAIR_INTERVAL_MS = 30_000;
 
 const wsMessageSchema = z.object({
   type: z.string(),
@@ -314,6 +320,7 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
        * the ACK/recover race.
        */
       let inboxOperationQueue: Promise<void> = Promise.resolve();
+      const lastInboxRepairDrainAtByAgent = new Map<string, number>();
 
       function isAgentStillRoutedHere(agentId: string): boolean {
         return (
@@ -466,16 +473,34 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
           chainInboxDelivery(agentId, () => drainBacklogForAgent(agentId, inboxId, { source: "notify", messageId }));
       }
 
+      function maybeRepairInboxBacklog(agentId: string, inboxId: string): void {
+        if (socket.readyState !== socket.OPEN) return;
+        if (!isAgentStillRoutedHere(agentId)) return;
+
+        const now = Date.now();
+        const lastRepairAt = lastInboxRepairDrainAtByAgent.get(agentId) ?? 0;
+        if (now - lastRepairAt < INBOX_BACKLOG_REPAIR_INTERVAL_MS) return;
+        lastInboxRepairDrainAtByAgent.set(agentId, now);
+
+        chainInboxDelivery(agentId, () => drainBacklogForAgent(agentId, inboxId, { source: "repair" })).catch((err) => {
+          app.log.error({ err, agentId, inboxId }, "inbox backlog repair crashed");
+        });
+      }
+
       /**
        * Drain up to `INBOX_BACKLOG_BATCH_LIMIT` pending entries for an agent
        * over the current WS. Normal scheduling is capped by the per-chat
        * fairness window; the agent-wide cap is only a high-water fuse.
        *
-       * Used in two places:
+       * Used in four places:
        *   1. Right after `agent:bound` — covers reconnects where NOTIFYs
        *      were dropped while the socket was offline.
        *   2. Right after an `inbox:ack` — top up the in-flight slot just
        *      freed, in case the previous NOTIFY was dropped at-cap.
+       *   3. On `inbox:recover` — reset and redeliver one chat's unacked
+       *      recovery debt.
+       *   4. Low-frequency bound-socket repair — drains durable pending
+       *      notify rows when PG NOTIFY was missed but the socket stayed up.
        *
        * Delivery operations are serialized on the socket, so budget checks and the
        * subsequent claim/send loop observe one consistent per-socket in-flight
@@ -486,7 +511,7 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
         inboxId: string,
         trigger?:
           | { source: "notify"; messageId: string }
-          | { source: "bind" | "ack" }
+          | { source: "bind" | "ack" | "repair" }
           | { source: "recover"; chatId: string },
       ): Promise<void> {
         if (socket.readyState !== socket.OPEN) return;
@@ -552,6 +577,21 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
         } catch (err) {
           app.log.error({ err, agentId, inboxId, limit }, "claim backlog for WS push failed");
           return;
+        }
+
+        if (trigger?.source === "repair" && entries.length > 0) {
+          app.log.info(
+            {
+              source: "repair",
+              agentId,
+              inboxId,
+              drained: entries.length,
+              inFlightCount: inFlight,
+              globalCap: inboxMaxInFlightPerAgent,
+              chatCap: inboxMaxInFlightPerAgentChat,
+            },
+            "inbox backlog repair drained pending notify rows",
+          );
         }
 
         for (const entry of entries) {
@@ -1094,6 +1134,7 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
                 app.log.info({ clientId, agentId }, "stale agent:unbind ignored for global binding");
               }
               boundAgents.delete(agentId);
+              lastInboxRepairDrainAtByAgent.delete(agentId);
               clearInboxInFlightForAgent(agentId);
 
               socket.send(JSON.stringify({ type: "agent:unbound", agentId }));
@@ -1468,6 +1509,11 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
                     .filter((id) => isAgentStillRoutedHere(id))
                     .map((id) => presenceService.touchAgent(app.db, id)),
                 );
+                for (const info of boundAgents.values()) {
+                  if (isAgentStillRoutedHere(info.agentId)) {
+                    maybeRepairInboxBacklog(info.agentId, info.inboxId);
+                  }
+                }
               }
               socket.send(JSON.stringify({ type: "heartbeat:ack" }));
             }
@@ -1487,6 +1533,7 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
           notifier.unsubscribe(info.inboxId, socket);
         }
         boundAgents.clear();
+        lastInboxRepairDrainAtByAgent.clear();
         inboxInFlightByAgent.clear();
         inboxInFlightOwnersByEntryId.clear();
 

--- a/packages/server/src/services/notifier.ts
+++ b/packages/server/src/services/notifier.ts
@@ -181,7 +181,8 @@ export function createNotifier(listenClient: postgres.Sql): Notifier {
       try {
         await listenClient`SELECT pg_notify(${INBOX_CHANNEL}, ${`${inboxId}:${messageId}`})`;
       } catch {
-        // fire-and-forget: notification loss is acceptable, polling covers it
+        // Fire-and-forget: durable inbox rows are repaired by bound WS backlog
+        // drains if this volatile NOTIFY hint is missed.
       }
     },
 


### PR DESCRIPTION
## Summary
- add a low-frequency heartbeat-triggered backlog repair for agents bound on the active client WebSocket
- route repair through the existing inbox delivery queue and fair backlog claim path, preserving in-flight caps and delivered-row recovery semantics
- replace the stale notifier comment that claimed polling covered inbox NOTIFY loss
- add WS integration coverage for lost NOTIFY repair, NOTIFY/repair duplicate resistance, and repair fairness with ACK top-up

## Validation
- `VITEST_MAX_FORKS=2 pnpm --filter @first-tree/server exec vitest run src/__tests__/ws-inbox-delivery-order.test.ts`
- `VITEST_MAX_FORKS=2 pnpm --filter @first-tree/server test -- src/__tests__/ws-inbox-delivery-order.test.ts` (ran the full server suite: 162 files / 1448 tests passed)
- `pnpm typecheck`
- `pnpm check` (exit 0; existing unrelated Biome warnings remain in web/client/cli files)

## Context
- Context Tree update is in a separate PR for `agent-team-foundation/first-tree-context`.
