### PR TITLE
refactor(github): decouple echo suppression via suppressNotifyAgentIds (S2/D1)

### DIFF
--- a/packages/server/src/__tests__/github-delivery.test.ts
+++ b/packages/server/src/__tests__/github-delivery.test.ts
@@ -212,12 +212,13 @@ describe("deliverNormalizedEvent", () => {
     expect(delegateEntries).toHaveLength(0);
   });
 
-  it("echo (#942): excludes the actor from addressing — card still written, actor not woken", async () => {
+  it("echo (#942, S2/D1): suppresses the actor's notify but keeps it addressed — card lands as a silent row", async () => {
     // The delegate is a live speaker of the bound chat, so it would normally
     // be woken. When the delegate is ALSO the event's actor (its own GitHub
-    // action, surfaced as `target.actorAgentId`), #942 excludes it from
-    // `addressedToAgentIds`: the card still lands (public record) but the
-    // actor is not woken / red-dotted. With `actorAgentId = null` the same
+    // action, surfaced as `target.actorAgentId`), Stage 3 passes it through
+    // `suppressNotifyAgentIds` (#942, S2/D1): the delegate stays structurally
+    // addressed and the card still lands as a silent `notify=false` row, but
+    // the actor is not woken / red-dotted. With `actorAgentId = null` the same
     // speaker-delegate IS woken — the two deliveries below pin both sides.
     const app = getApp();
     const admin = await createTestAdmin(app);
@@ -261,7 +262,8 @@ describe("deliverNormalizedEvent", () => {
       entityKey: "owner/repo#205",
     });
 
-    // (1) actor === delegate: excluded from addressing → card written, no wake.
+    // (1) actor === delegate: suppressed from notify but kept addressed →
+    // card written, no wake, yet the actor still gets a silent context row.
     const echoStats = await deliverNormalizedEvent(app, event, [{ ...baseTarget, actorAgentId: delegate }]);
     expect(echoStats.delivered).toBe(1);
     const afterEcho = await app.db
@@ -269,6 +271,20 @@ describe("deliverNormalizedEvent", () => {
       .from(inboxEntries)
       .where(and(eq(inboxEntries.chatId, chatId), eq(inboxEntries.notify, true)));
     expect(afterEcho).toHaveLength(0);
+    // The suppressed actor-delegate still receives exactly one silent
+    // (notify=false) row — the card lands as context, it just doesn't wake.
+    const [delegateRow] = await app.db
+      .select({ inboxId: agents.inboxId })
+      .from(agents)
+      .where(eq(agents.uuid, delegate))
+      .limit(1);
+    const delegateInbox = delegateRow?.inboxId ?? "";
+    const delegateSilent = await app.db
+      .select({ notify: inboxEntries.notify })
+      .from(inboxEntries)
+      .where(and(eq(inboxEntries.inboxId, delegateInbox), eq(inboxEntries.chatId, chatId)));
+    expect(delegateSilent).toHaveLength(1);
+    expect(delegateSilent[0]?.notify).toBe(false);
 
     // (2) actor !== delegate (null): the speaker-delegate IS woken.
     const okStats = await deliverNormalizedEvent(app, event, [{ ...baseTarget, actorAgentId: null }]);

--- a/packages/server/src/__tests__/mention-fanout.test.ts
+++ b/packages/server/src/__tests__/mention-fanout.test.ts
@@ -99,6 +99,46 @@ describe("server routing + fan-out filter (explicit mentions only)", () => {
     expect(obsBEntries).toHaveLength(0);
   });
 
+  it("suppressNotifyAgentIds drops an agent from the wake set but still writes a silent row", async () => {
+    // Generic echo capability (S2/D1): a suppressed agent that would otherwise
+    // be woken (here via metadata.mentions) is NOT notified, yet still receives
+    // a notify=false context row so the message still lands.
+    const app = getApp();
+    const uid = crypto.randomUUID().slice(0, 6);
+    const { sender, obsA, obsB, chat } = await setupGroup(app, uid);
+
+    await sendMessage(
+      app.db,
+      chat.id,
+      sender.agent.uuid,
+      {
+        source: "api",
+        format: "text",
+        content: "review",
+        metadata: { mentions: [obsA.uuid, obsB.uuid] },
+      },
+      { suppressNotifyAgentIds: [obsB.uuid] },
+    );
+
+    // obsA mentioned and not suppressed → woken.
+    expect(await inboxEntriesFor(app, chat.id, obsA.uuid)).toHaveLength(1);
+    // obsB mentioned but suppressed → not woken (no notify=true row)…
+    expect(await inboxEntriesFor(app, chat.id, obsB.uuid)).toHaveLength(0);
+    // …yet still receives exactly one silent (notify=false) context row.
+    const [obsBRow] = await app.db
+      .select({ inboxId: agents.inboxId })
+      .from(agents)
+      .where(eq(agents.uuid, obsB.uuid))
+      .limit(1);
+    const obsBInbox = obsBRow?.inboxId ?? "";
+    const obsBAll = await app.db
+      .select({ notify: inboxEntries.notify })
+      .from(inboxEntries)
+      .where(and(eq(inboxEntries.inboxId, obsBInbox), eq(inboxEntries.chatId, chat.id)));
+    expect(obsBAll).toHaveLength(1);
+    expect(obsBAll[0]?.notify).toBe(false);
+  });
+
   it("a narrative `@<peer>` in content alone does NOT wake the peer (server does not parse content)", async () => {
     // Regression guard for the explicit-only contract.
     const app = getApp();

--- a/packages/server/src/services/github-audience.ts
+++ b/packages/server/src/services/github-audience.ts
@@ -96,11 +96,12 @@ export type AudienceTarget = {
   involveLogin: string | null;
   /**
    * Set when the event's actor resolves to an org agent (`identifyActor`
-   * returned `kind: "agent"`). Stage 3 excludes this id from the card's
-   * notification addressing (`addressedToAgentIds`) so the actor is never
-   * woken / red-dotted by their own action, while the card itself still
-   * lands in the chat as the public record (#942). `null` for our-app-bot
-   * and external actors.
+   * returned `kind: "agent"`). Stage 3 passes this id as the message's
+   * `suppressNotifyAgentIds` so the actor is never woken / red-dotted by its
+   * own action, while staying structurally addressed — the card still lands
+   * in the chat (as a silent `notify=false` row for the actor) as the public
+   * record (#942, S2/D1). The suppress target is decoupled from `senderId`.
+   * `null` for our-app-bot and external actors.
    */
   actorAgentId: string | null;
 };
@@ -119,12 +120,13 @@ export type AudienceTarget = {
  * Echo filtering runs after the union:
  *   - actor = `agent`: no row is dropped — every mapped chat keeps the card
  *     as the public record of what happened. Instead, each row is annotated
- *     with `actorAgentId` so Stage 3 excludes the actor from notification
- *     addressing (the actor isn't woken / red-dotted by their own action,
- *     other recipients are notified normally). Dropping rows here used to
- *     conflate "should this chat get the card" with "should this recipient
- *     be notified" and silently killed delivery to multi-participant chats
- *     whose only routing entry had the actor on one side (#942).
+ *     with `actorAgentId` so Stage 3 passes the actor as
+ *     `suppressNotifyAgentIds` (the actor isn't woken / red-dotted by its own
+ *     action, other recipients are notified normally; the actor still gets a
+ *     silent row). Dropping rows here used to conflate "should this chat get
+ *     the card" with "should this recipient be notified" and silently killed
+ *     delivery to multi-participant chats whose only routing entry had the
+ *     actor on one side (#942).
  *   - actor = `our-app-bot`: `kind: "existing"` rows are kept so follow-up
  *     events on entities the agent opened still reach the chat through the
  *     subscription path; `kind: "new"` rows are dropped to avoid forking a
@@ -307,12 +309,14 @@ export async function resolveAudience(
     // (#942). Every mapped chat keeps its card — the chat row is the public
     // record of what happened, and other participants of a multi-member
     // chat legitimately want to see it. The actor's id is annotated onto
-    // every target so Stage 3 (`deliverNormalizedEvent`) excludes it from
-    // `addressedToAgentIds`: the actor is never woken / red-dotted by their
-    // own action, while everyone else is notified normally. A 1:1 chat where
-    // the actor is the sole addressable recipient reduces naturally to "card
-    // visible, nobody woken" via the existing `allowRecipientlessSend`
-    // trusted opt-out.
+    // every target so Stage 3 (`deliverNormalizedEvent`) passes it as
+    // `suppressNotifyAgentIds`: the actor stays structurally addressed but is
+    // not woken / red-dotted by its own action (it still gets a silent
+    // `notify=false` row), while everyone else is notified normally.
+    // Suppression is decoupled from `senderId` (S2/D1) — the actor is
+    // frequently not a speaker of the chat, so it must not become the
+    // chat-local sender. A 1:1 chat where the actor is the sole addressable
+    // recipient reduces naturally to "card visible, nobody woken".
     //
     // The previous implementation dropped `kind: "existing"` rows whose
     // human or delegate side matched the actor. When such a row was the

--- a/packages/server/src/services/github-audience.ts
+++ b/packages/server/src/services/github-audience.ts
@@ -38,7 +38,7 @@ export function evaluateDelegateTarget(
  *                       for echo suppression at the notification layer: the
  *                       card still lands in every mapped chat (the public
  *                       record of what happened), but the actor is excluded
- *                       from the notify/addressing fan-out so agents aren't
+ *                       from notify only (Stage 3 passes its id to `suppressNotifyAgentIds` while it stays structurally addressed) so agents aren't
  *                       woken by their own actions. See #942.
  *   - `our-app-bot`   — actor is `<app-slug>[bot]`. The event is a downstream
  *                       effect of First Tree's own outbound write. `kind: "existing"`

--- a/packages/server/src/services/github-delivery.ts
+++ b/packages/server/src/services/github-delivery.ts
@@ -101,14 +101,18 @@ export async function deliverNormalizedEvent(
       // everyone. Same pattern as any system-routed delivery (see
       // SendMessageOptions `addressedToAgentIds`).
       //
-      // Echo suppression (#942): when the event's actor resolved to an org
-      // agent, exclude it from the addressing — nobody is woken / red-dotted
-      // by their own action. The card itself is still written (public
-      // record); when the exclusion empties the addressing this reduces to
-      // the recipientless trusted send below. The actor on the *human* side
-      // needs no exclusion here: it is the card's senderId and the message
-      // fan-out never self-delivers.
-      const addressedToAgentIds = [target.delegateAgentId].filter((id) => id !== target.actorAgentId);
+      // Echo suppression (#942) is decoupled from addressing (S2 / D1): the
+      // delegate is always the structural addressing target; the actor (when
+      // it resolved to an org agent) is passed separately as
+      // `suppressNotifyAgentIds` so it is never *woken* by its own action
+      // while the card still lands in its inbox as a silent context row.
+      // The old `.filter(id !== actor)` conflated "who is the structural
+      // target" with "who gets woken"; keeping them separate also keeps echo
+      // off `senderId` — the actor is frequently not a speaker of this chat,
+      // so it must never become the chat-local sender. See
+      // system/cloud/github/github-entity-chat-binding.md S2.
+      const addressedToAgentIds = [target.delegateAgentId];
+      const suppressNotifyAgentIds = target.actorAgentId ? [target.actorAgentId] : [];
       const { message, recipients } = await sendMessage(
         app.db,
         resolved.chatId,
@@ -137,6 +141,10 @@ export async function deliverNormalizedEvent(
         },
         {
           addressedToAgentIds,
+          // Echo suppression target (S2 / D1): the event's actor agent, when it
+          // resolved to one. Decoupled from `senderId` and from the addressing
+          // set — the actor still gets a silent inbox row, it is just not woken.
+          suppressNotifyAgentIds,
           // Opt in to writing `metadata.systemSender` — the message service
           // strips that key from every other caller (web / agent SDK POST)
           // so HTTP boundaries cannot impersonate the GitHub sender in the
@@ -146,14 +154,15 @@ export async function deliverNormalizedEvent(
           // system delivery owns and validates its own addressing
           // (`addressedToAgentIds` derived from the resolved audience row),
           // but on some events the addressing resolves to no live recipient:
-          // the delegate may not be a speaker of the bound chat, or the
-          // delegate IS the event's actor and was excluded by echo
-          // suppression (#942, the empty-filter case above). Such a
-          // card is still a valid history/context row for human observers;
-          // without this opt-out the default guard would make this trusted path
-          // start throwing. (A delegate that IS a speaker but suspended/deleted
-          // is rejected earlier by the addressed-recipient status check — that
-          // is a separate, intentional guard, not covered by this opt-out.)
+          // the delegate may not be a speaker of the bound chat. Such a card
+          // is still a valid history/context row for human observers; without
+          // this opt-out the default guard would make this trusted path start
+          // throwing. (The echo case — delegate IS the actor — no longer
+          // empties the addressing: the delegate stays the structural target
+          // and is silenced via `suppressNotifyAgentIds`, so the card lands as
+          // a silent row rather than relying on this opt-out. A delegate that
+          // IS a speaker but suspended/deleted is rejected earlier by the
+          // addressed-recipient status check — a separate, intentional guard.)
           // See SendMessageOptions docs.
           allowRecipientlessSend: true,
         },

--- a/packages/server/src/services/message.ts
+++ b/packages/server/src/services/message.ts
@@ -128,6 +128,22 @@ export type SendMessageOptions = {
    */
   addressedToAgentIds?: readonly string[];
   /**
+   * Agent IDs to **exclude from the notify (wake) set** even when they would
+   * otherwise be woken via `metadata.mentions` or `addressedToAgentIds`.
+   * Generic trusted-delivery capability, decoupled from `senderId`: the
+   * suppressed agent still receives a `notify=false` inbox row (the message
+   * still lands in history / replays as context), it is simply not woken.
+   *
+   * Today's caller is `github-delivery.deliverNormalizedEvent`, which passes
+   * the event's actor agent so an agent is never woken by its own GitHub
+   * action (echo suppression) — without binding that exclusion to `senderId`
+   * (the actor is frequently not a speaker of the target chat, so it must not
+   * be the chat-local sender). See `system/cloud/github/github-entity-chat-binding.md`
+   * S2. `purpose === "agent-final-text"` still forces silent for everyone;
+   * this only narrows the notify set within the non-silenced branch.
+   */
+  suppressNotifyAgentIds?: readonly string[];
+  /**
    * Trusted-internal opt-in for writing `metadata.systemSender`. The web UI
    * uses that key to re-attribute a row to a synthetic "GitHub" sender
    * (avatar + name override) instead of the row's actual `senderId`. To
@@ -458,6 +474,11 @@ async function sendMessageInner(
     //      nobody is woken.
     const mentionSet = new Set(mergedMentions);
     const addressedSet = new Set(options.addressedToAgentIds ?? []);
+    // Generic echo / wake-exclusion: agents here still get a `notify=false`
+    // inbox row (message lands), they are just not woken. Decoupled from
+    // `senderId` so a non-member actor can be excluded without being made the
+    // chat-local sender. See SendMessageOptions.suppressNotifyAgentIds.
+    const suppressNotifySet = new Set(options.suppressNotifyAgentIds ?? []);
     // Build a single fan-out structure that carries agentId alongside the
     // inbox row. agentId is needed by the post-tx session-activation step
     // (Step 1b) but is not part of the inbox_entries schema — it's stripped
@@ -468,7 +489,10 @@ async function sendMessageInner(
       .map((p) => ({
         agentId: p.agentId,
         inboxId: p.inboxId,
-        notify: !prepared.forceSilentFanOut && (addressedSet.has(p.agentId) || mentionSet.has(p.agentId)),
+        notify:
+          !prepared.forceSilentFanOut &&
+          (addressedSet.has(p.agentId) || mentionSet.has(p.agentId)) &&
+          !suppressNotifySet.has(p.agentId),
       }));
 
     if (fanout.length > 0) {


### PR DESCRIPTION
## What
First slice of the GitHub delivery-boundary refactor (per adopted decision `system/cloud/github/github-entity-chat-binding.md` **S2 / D1** in the context tree). Implements the **echo-decouple**:

- **`message.ts`** — new generic `SendMessageOptions.suppressNotifyAgentIds`. Agents in this set are excluded from the notify (wake) set but **still receive a `notify=false` inbox row** — the message still lands (S7's "card lands, nobody woken"). Generic trusted-delivery capability, not GitHub-specific.
- **`github-delivery.ts`** — the event's actor agent is now passed as `suppressNotifyAgentIds` instead of being filtered out of `addressedToAgentIds`. The delegate stays the structural addressing target; the actor is silenced **without** being made the chat-local `senderId` (the actor is frequently not a speaker of the target chat, so binding echo to `senderId` would mis-attribute the card — baixiaohang's D1 catch).
- **test** — `suppressNotifyAgentIds` drops the wake but writes the silent row.

## Why
S2 says echo suppression must be decoupled from `senderId` and expressed as a generic capability. This delivers exactly that with no behavior change to the actor-echo outcome (actor still not woken), and lays the `suppressNotifyAgentIds` foundation the rest of the refactor builds on.

## Tests
Full server suite green: **1446 passed**. New test pins the suppress-but-still-land behavior.

## Follow-ups (next PR)
- Native-mention wake + **per-chat delivery dedup** (one card per chat, union wake-set) → reviewer-already-in-group routes into the existing chat, no new chat, no new `bound_via` (per owner direction).
- Unread red-dots restricted to **human** mention targets (cancels the agent-mention badge flood) — touches general DM unread semantics, scoped with owner.
- Retire `addressedToAgentIds`; node S9/S7 update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)