### PR TITLE
refactor(chat): unread-mention red dot only for human mention targets

### DIFF
--- a/packages/server/src/__tests__/direct-chat-auto-mention.test.ts
+++ b/packages/server/src/__tests__/direct-chat-auto-mention.test.ts
@@ -20,15 +20,17 @@ import { createTestAdmin, createTestAgent, useTestApp } from "./helpers.js";
  * Both mechanisms have been retired. In the new world, clients (the
  * web composer is the main one) inject the peer's uuid into
  * `metadata.mentions` for 2-speaker chats, and the server treats that
- * exactly like any other explicit mention — notify=true for the peer,
- * unread badge +1 for the peer.
+ * exactly like any other explicit mention — notify=true for the peer.
+ * The unread badge (`unread_mention_count`) is a human-attention signal:
+ * it bumps only when the mention target is a HUMAN, so a mentioned agent
+ * is woken via the inbox but raises no red dot.
  *
  * Invariants this file pins:
- *   1. Human → agent DM with explicit mentions wakes the agent and
- *      bumps the agent's unread counter.
+ *   1. Human → agent DM with explicit mentions wakes the agent but
+ *      raises NO unread red dot (the agent is a non-human target).
  *   2. Agent → human DM with explicit mentions wakes the human and
  *      bumps the human's unread counter.
- *   3. Agent ↔ agent DM with explicit mentions wakes the peer.
+ *   3. Agent ↔ agent DM with explicit mentions wakes the peer (no red dot).
  *   4. A DM send WITHOUT explicit mentions (would only happen via a
  *      pre-explicit-contract caller) does NOT wake the peer and does
  *      NOT bump the badge — this is the regression guard for the

--- a/packages/server/src/__tests__/direct-chat-auto-mention.test.ts
+++ b/packages/server/src/__tests__/direct-chat-auto-mention.test.ts
@@ -81,7 +81,7 @@ describe("1:1 chat wake-up + unread badge (explicit-mention contract)", () => {
     return typeof row?.content === "string" ? row.content : "";
   }
 
-  it("human → agent DM with explicit mentions wakes the agent and bumps the unread counter", async () => {
+  it("human → agent DM with explicit mentions wakes the agent but raises no unread red dot (non-human mention)", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
     const peer = await createTestAgent(app, { name: `dmh2a-${crypto.randomUUID().slice(0, 6)}` });
@@ -98,8 +98,11 @@ describe("1:1 chat wake-up + unread badge (explicit-mention contract)", () => {
       metadata: { mentions: [peer.agent.uuid] },
     });
 
+    // The agent is still woken via the inbox notify path…
     expect(await notifyInboxRows(chatId, peer.agent.uuid)).toHaveLength(1);
-    expect(await loadUnread(chatId, peer.agent.uuid, peer.memberId, peer.organizationId)).toBeGreaterThanOrEqual(1);
+    // …but the unread-mention red dot is a human-attention signal, so
+    // mentioning a non-human agent raises no red dot for that agent.
+    expect(await loadUnread(chatId, peer.agent.uuid, peer.memberId, peer.organizationId)).toBe(0);
   });
 
   it("agent → human DM with explicit mentions wakes the human and bumps the unread counter", async () => {
@@ -140,8 +143,10 @@ describe("1:1 chat wake-up + unread badge (explicit-mention contract)", () => {
       metadata: { mentions: [a2.uuid] },
     });
 
+    // a2 is woken via the inbox, but as a non-human mention target it gets
+    // no unread red dot — red dots are a human-attention signal.
     expect(await notifyInboxRows(chat.id, a2.uuid)).toHaveLength(1);
-    expect(await loadUnread(chat.id, a2.uuid, a1.memberId, a1.organizationId)).toBeGreaterThanOrEqual(1);
+    expect(await loadUnread(chat.id, a2.uuid, a1.memberId, a1.organizationId)).toBe(0);
   });
 
   it("DM without explicit mentions does NOT wake the peer (the retired 1:1 implicit-wake regression guard)", async () => {
@@ -214,7 +219,8 @@ describe("1:1 chat wake-up + unread badge (explicit-mention contract)", () => {
 
     expect(await notifyInboxRows(chat.id, a2.uuid)).toHaveLength(1);
     expect(await notifyInboxRows(chat.id, a3.uuid)).toHaveLength(0);
-    expect(await loadUnread(chat.id, a2.uuid, a1.memberId, a1.organizationId)).toBeGreaterThanOrEqual(1);
+    // a2 is woken but, as a non-human mention target, gets no unread red dot.
+    expect(await loadUnread(chat.id, a2.uuid, a1.memberId, a1.organizationId)).toBe(0);
     expect(await loadUnread(chat.id, a3.uuid, a1.memberId, a1.organizationId)).toBe(0);
   });
 });

--- a/packages/server/src/services/chat-projection.ts
+++ b/packages/server/src/services/chat-projection.ts
@@ -156,7 +156,10 @@ export async function applyAfterFanOut(tx: DbLike, input: ApplyAfterFanOutInput)
   //
   //   A. Mention propagation (always on when the message has explicit
   //      mentions). Speaker branch: mentioned ∩ chat speakers, sender
-  //      excluded. Watcher branch: watchers whose managed non-human
+  //      excluded, HUMAN targets only — the unread-mention red dot is a
+  //      human-attention signal, so mentioning a non-human agent (a delegate,
+  //      a routed GitHub card target) wakes it via the inbox notify path but
+  //      raises no red dot. Watcher branch: watchers whose managed non-human
   //      agent was mentioned.
   //
   //   B. Agent-final-text bump (only when `bumpForAgentFinalText`).
@@ -192,10 +195,12 @@ export async function applyAfterFanOut(tx: DbLike, input: ApplyAfterFanOutInput)
     branches.push(sql`
       SELECT cm.chat_id, cm.agent_id
         FROM chat_membership cm
+        JOIN agents a ON a.uuid = cm.agent_id
        WHERE cm.chat_id     = ${chatId}
          AND cm.access_mode = 'speaker'
          AND cm.agent_id    IN (${mentionedList})
          AND cm.agent_id   <> ${senderId}
+         AND a.type         = 'human'
     `);
     branches.push(sql`
       SELECT cm.chat_id, cm.agent_id


### PR DESCRIPTION
## What
Restrict the unread-mention red dot (`chat_user_state.unread_mention_count`) so it only fires for **human** mention targets. Mentioning a **non-human agent** (a delegate, a routed GitHub card target) still wakes that agent via the inbox notify path, but raises **no red dot**.

- `chat-projection.ts` — the mention **speaker branch** now joins `agents` and filters `a.type = 'human'`.
- The **watcher branch** (a human watcher whose managed non-human agent was @-mentioned) is **unchanged**; the agent-final-text bump is unchanged.
- Tests updated: `agent↔agent` and `human→agent` mention cases assert wake **without** a red-dot bump.

## Why
The red dot is a human-attention signal. Per owner direction (@yuezengwu), agent mentions are routing/wake signals, not human red-dot signals — and this is the prerequisite that lets GitHub event cards wake their delegate via native `metadata.mentions` (next PR) without the delegate flooding anyone's badge on every comment/CI card.

This is a **global** behavior change (also affects e.g. human↔agent DM unread), confirmed with the owner.

## Tests
Full server suite green: **1456 passed**.

## Note / open question
I deliberately **kept the watcher branch** (human watcher alerted when their managed agent is mentioned) — removing it is a separate, more invasive change. If GitHub cards should also not raise a watcher-manager's red dot, that's a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)