### PR TITLE
feat(web): dark, brand-consistent login page + brand-home nav targets

### DIFF
--- a/packages/web/src/components/user-menu.tsx
+++ b/packages/web/src/components/user-menu.tsx
@@ -10,6 +10,12 @@ import { TeamSetupModal } from "./team-setup-modal.js";
 
 const COLLAPSED_TEAM_LIMIT = 5;
 
+// Marketing site — where an explicit sign-out lands the browser, so the user
+// leaves the app on the parent brand surface rather than an app route (which
+// would just bounce back through the login page). Mirrors `PARENT_URL` in
+// layout.tsx / footer.tsx.
+const PARENT_URL = "https://first-tree.ai";
+
 /**
  * Right-side user menu. Avatar trigger; dropdown nests team switching,
  * admin team management, Create / Join entry points, and sign-out.
@@ -247,6 +253,10 @@ export function UserMenu() {
                 onClick={() => {
                   setOpen(false);
                   logout();
+                  // Leave the app on the marketing site rather than an app
+                  // route — `logout()` clears local auth state, so staying in
+                  // the SPA would just redirect to the login page.
+                  window.location.href = PARENT_URL;
                 }}
                 className="flex w-full items-center gap-2 px-4 py-1.5 text-left text-body hover:bg-accent transition-colors"
                 style={{ color: "var(--fg)" }}

--- a/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
+++ b/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
@@ -1107,7 +1107,8 @@ describe("web DOM interaction coverage", () => {
     });
     authMock.value = { ...authMock.value, isAuthenticated: false };
     const local = await renderDom(<LoginPage />, "/login", undefined);
-    await waitForText("Sign in with GitHub", local.container);
+    await waitForText("Continue with GitHub", local.container);
+    await waitForText("only your GitHub identity", local.container);
     await waitForText("Dev: skip GitHub", local.container);
     expect(local.container.querySelector<HTMLAnchorElement>('a[href="/api/v1/auth/github/start"]')).toBeTruthy();
     await unmountRoot(local.root);

--- a/packages/web/src/pages/login.tsx
+++ b/packages/web/src/pages/login.tsx
@@ -1,10 +1,15 @@
-import { ArrowLeft, Github, Zap } from "lucide-react";
-import { Link, Navigate, useLocation } from "react-router";
+import { ArrowLeft, Github, Lock, Zap } from "lucide-react";
+import { Navigate, useLocation } from "react-router";
 import { useAuth } from "../auth/auth-context.js";
 import { readFromPath } from "../auth/redirect-from-state.js";
 import { FirstTreeLogo } from "../components/first-tree-logo.js";
 import { Button } from "../components/ui/button.js";
-import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/card.js";
+
+// Marketing site (parent brand) — the "Back to home" link points here rather
+// than the in-app landing route. Mirrors the pattern in footer.tsx / layout.tsx.
+const PARENT_URL = "https://first-tree.ai";
+// Public source repo — the trust strip's "Open source" link.
+const REPO_URL = "https://github.com/agent-team-foundation/first-tree";
 
 /**
  * Sign-in entry. Single path: GitHub OAuth. The legacy password form has
@@ -18,6 +23,10 @@ import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/card.
  * jumps to `/auth/github/dev-callback` which mints a stub identity in
  * one round-trip without needing a real OAuth client. Production responds
  * 404 on that route, so the button is harmless even if shipped.
+ *
+ * The surface is wrapped in `.landing-marketing` (same class the in-app
+ * landing page uses) so every token utility resolves to the first-tree.ai
+ * dark palette — a single centered card on the near-black brand canvas.
  */
 export function LoginPage() {
   const { isAuthenticated } = useAuth();
@@ -47,36 +56,62 @@ export function LoginPage() {
   }
 
   return (
-    <div className="flex min-h-screen flex-col bg-background">
+    // `landing-marketing` swaps the local --bg/--fg/--border tokens to the
+    // first-tree.ai palette (near-black + cool-light), shared with the parent
+    // brand. Scoping it here means the dashboard chrome stays unaffected.
+    <div className="landing-marketing flex min-h-screen flex-col bg-background text-foreground">
       <header className="px-4 py-3">
-        <Link
-          to="/"
-          className="inline-flex items-center gap-1.5 rounded-[var(--radius-input)] px-2 py-1 text-body text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+        <a
+          href={PARENT_URL}
+          className="inline-flex items-center gap-1.5 rounded-[var(--radius-input)] px-2 py-1 text-body text-fg-3 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
         >
           <ArrowLeft className="h-3.5 w-3.5" />
           Back to home
-        </Link>
+        </a>
       </header>
 
       <div className="flex flex-1 items-center justify-center px-4 pb-16">
-        <Card className="w-full max-w-sm">
-          <CardHeader className="text-center">
+        <div className="w-full max-w-sm rounded-[var(--radius-panel)] border border-border bg-card p-6 text-card-foreground shadow-[var(--shadow-sm)]">
+          <div className="flex flex-col items-center space-y-1.5 text-center">
             <div className="mb-2 flex justify-center text-foreground">
               <FirstTreeLogo width={28} height={32} />
             </div>
-            <CardTitle className="text-title">First Tree</CardTitle>
-            <p className="text-label text-muted-foreground" style={{ marginTop: "var(--sp-1)" }}>
-              Sign in to set up your team and your first AI agent.
+            <div className="text-title">First Tree</div>
+            <p className="text-label text-fg-2" style={{ marginTop: "var(--sp-1)" }}>
+              Set up your team and your first AI agent.
             </p>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <Button asChild className="w-full">
+          </div>
+
+          <div className="mt-6 space-y-4">
+            <Button asChild className="w-full bg-foreground text-background hover:bg-foreground/90">
               <a href={githubHref}>
                 <Github className="h-4 w-4" />
-                Sign in with GitHub
+                Continue with GitHub
               </a>
             </Button>
-            <p className="text-center text-label text-muted-foreground">
+
+            <p className="text-center text-label text-fg-3">
+              <span className="font-medium text-fg-2">Sign in uses only your GitHub identity.</span> You authorize a
+              repo later, only when an agent needs to work in it.
+            </p>
+
+            <div className="flex items-center justify-center gap-4 border-t border-border pt-4 text-caption text-fg-3">
+              <span className="inline-flex items-center gap-1.5">
+                <Lock className="h-3 w-3" />
+                No repo access yet
+              </span>
+              <a
+                href={REPO_URL}
+                target="_blank"
+                rel="noreferrer noopener"
+                className="inline-flex items-center gap-1.5 rounded-[var(--radius-input)] transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+              >
+                <Github className="h-3 w-3" />
+                Open source
+              </a>
+            </div>
+
+            <p className="text-center text-label text-fg-3">
               By continuing you agree to our{" "}
               <a href="/terms" className="underline underline-offset-2 transition-colors hover:text-foreground">
                 Terms
@@ -86,9 +121,10 @@ export function LoginPage() {
                 Privacy
               </a>
             </p>
+
             {isLocalhost && (
               <>
-                <div className="relative my-2 text-center text-label text-muted-foreground">
+                <div className="relative my-2 text-center text-label text-fg-3">
                   <span className="relative z-10 bg-card px-2">localhost only</span>
                   <div className="absolute inset-x-0 top-1/2 h-px bg-border" />
                 </div>
@@ -100,8 +136,8 @@ export function LoginPage() {
                 </Button>
               </>
             )}
-          </CardContent>
-        </Card>
+          </div>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## What & why
Optimizes the `/login` experience to **reduce sign-in resistance** and **fix a jarring transition**. Coming from the dark marketing homepage, users currently hit a stark empty white login page; this makes login feel continuous with the brand and addresses the real friction (GitHub-only login is a fixed identity-foundation constraint, so we reduce the *fear*, not the method).

Decision trail: we evaluated modal-vs-page and **kept the dedicated page** (B2B convention + trust + it's the redirect/deep-link landing). The resistance lives *before* the click, so the highest-leverage fix is the identity-reassurance copy, not the container.

## Changes
- **Dark, brand-consistent surface** — wrap `/login` in `.landing-marketing` (same class the in-app landing uses) so it inherits the first-tree.ai dark palette via tokens. No hand-rolled hex; dashboard chrome unaffected.
- **Button copy** `Sign in with GitHub` → **`Continue with GitHub`** (first run is really sign-up), white-on-dark via tokens.
- **Identity-reassurance microcopy**: "Sign in uses only your GitHub identity. You authorize a repo later, only when an agent needs to work in it." — the highest-leverage resistance reducer.
- **Trust strip**: "No repo access yet" · "Open source" (links to this repo).
- **"Back to home"** now → `https://first-tree.ai` (was `/`, which bounced logged-out users back to login).
- **Explicit Sign out** (UserMenu) now lands on `https://first-tree.ai`. Deliberately scoped to the sign-out click — NOT `auth-context.logout()`, which also fires on token-expiry/401 where a redirect would break the deep-link re-login flow.

All auth logic (OAuth start, `?next=` deep-link passthrough, localhost dev-callback) is unchanged.

## Test plan
- `pnpm --filter @first-tree/web typecheck` ✓ (incl. design-token guardrails)
- biome check ✓
- web vitest suite: **813 passed**
- Updated the login DOM test (button copy + new microcopy assertion); SSR smoke ("Back to home") still passes.

## Notes / follow-ups
- Theme: login is dark for continuity with the homepage + in-app landing (which already uses the near-black first-tree.ai palette). There's a login(dark)→dashboard(light) transition, accepted as a momentary pass-through.
- The onboarding shells also call `logout()` directly (abandon-onboarding); left untouched — say the word if those should also land on first-tree.ai.

🤖 Generated with [Claude Code](https://claude.com/claude-code)