### PR TITLE
refactor(github): per-chat delivery dedup + native-mention wake + reviewer reuse (S7/S8/S9)

### DIFF
--- a/packages/server/src/__tests__/github-delivery.test.ts
+++ b/packages/server/src/__tests__/github-delivery.test.ts
@@ -751,6 +751,86 @@ describe("deliverNormalizedEvent", () => {
     expect(mappings).toHaveLength(1);
   });
 
+  it("a `mentioned` involve does NOT reuse the entity chat — it mints a fresh chat (S5, reuse is review_requested-only)", async () => {
+    // S9 reuse is scoped to review_requested. An @mention of a human who is
+    // already a speaker of the entity's bound chat must still pierce into a
+    // FRESH chat (S5), never get routed back into the existing one.
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const delegateA = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlgA-${randomUUID().slice(0, 6)}`,
+    });
+    const humanA = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `humanA-${randomUUID().slice(0, 6)}`,
+      delegateMention: delegateA,
+    });
+    const delegateM = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlgM-${randomUUID().slice(0, 6)}`,
+    });
+    const humanM = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `humanM-${randomUUID().slice(0, 6)}`,
+      delegateMention: delegateM,
+    });
+
+    const chatId = `chat_${randomUUID()}`;
+    await app.db.insert(chats).values({ id: chatId, organizationId: admin.organizationId, type: "group" });
+    // The mentioned human + its delegate are BOTH already speakers of the bound chat.
+    await app.db.insert(chatMembership).values(
+      [humanA, delegateA, humanM, delegateM].map((agentId, i) => ({
+        chatId,
+        agentId,
+        role: i === 0 ? "owner" : "member",
+        accessMode: "speaker" as const,
+        mode: "full" as const,
+        source: "manual" as const,
+      })),
+    );
+    await app.db.insert(githubEntityChatMappings).values({
+      organizationId: admin.organizationId,
+      humanAgentId: humanA,
+      delegateAgentId: delegateA,
+      entityType: "pull_request",
+      entityKey: "owner/repo#211",
+      chatId,
+      boundVia: "direct",
+    });
+
+    const event = makeEvent({ orgId: admin.organizationId, entityType: "pull_request", entityKey: "owner/repo#211" });
+    const involvedMention: AudienceTarget = {
+      humanAgentId: humanM,
+      delegateAgentId: delegateM,
+      kind: "new",
+      chatId: null,
+      involveReason: "mentioned",
+      involveLogin: "humanm",
+      actorAgentId: null,
+    };
+
+    const stats = await deliverNormalizedEvent(app, event, [involvedMention]);
+
+    // A fresh chat was minted for the mention (NOT reused into the bound chat).
+    expect(stats.newChats).toBe(1);
+    const mintedMappings = await app.db
+      .select()
+      .from(githubEntityChatMappings)
+      .where(
+        and(
+          eq(githubEntityChatMappings.entityKey, "owner/repo#211"),
+          eq(githubEntityChatMappings.humanAgentId, humanM),
+        ),
+      );
+    expect(mintedMappings).toHaveLength(1);
+    expect(mintedMappings[0]?.chatId).not.toBe(chatId);
+  });
+
   // Regression: a GitHub-bound chat that has been expanded to >=3 speakers
   // (e.g. a teammate invited in) must still wake the delegate agent that
   // owns the entity. github-delivery wakes the delegate by adding it to the

--- a/packages/server/src/__tests__/github-delivery.test.ts
+++ b/packages/server/src/__tests__/github-delivery.test.ts
@@ -137,13 +137,14 @@ describe("deliverNormalizedEvent", () => {
   });
 
   it("delivers a recipientless card when the delegate is not a live speaker (trusted opt-out, wakes no one)", async () => {
-    // Empty-addressing system path: github-delivery addresses the delegate via
-    // `addressedToAgentIds`, but on some events that delegate is not an active
-    // speaker of the bound chat, so the addressing resolves to no live
-    // recipient. The default explicit-recipient guard would reject such a send;
-    // github-delivery declares `allowRecipientlessSend` so the card still lands
-    // as a history/context row for human observers. This pins that the trusted
-    // opt-out is load-bearing — the delivery must NOT throw and must wake no one.
+    // Empty-wake-set system path: github-delivery wakes the delegate via native
+    // `metadata.mentions`, but on some events that delegate is not an active
+    // speaker of the bound chat, so the mention is filtered out and the wake-set
+    // resolves to no live recipient. The default explicit-recipient guard would
+    // reject such a send; github-delivery declares `allowRecipientlessSend` so
+    // the card still lands as a history/context row for human observers. This
+    // pins that the trusted opt-out is load-bearing — the delivery must NOT
+    // throw and must wake no one.
     const app = getApp();
     const admin = await createTestAdmin(app);
     const delegate = await seedAgent(app, {
@@ -644,12 +645,118 @@ describe("deliverNormalizedEvent", () => {
     expect(sent).toHaveLength(1);
   });
 
+  it("reviewer-reuse + per-chat dedup: an involved member routes into the existing chat (one card, both delegates woken, no new chat/mapping)", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const mk = (p: string) =>
+      seedAgent(app, {
+        orgId: admin.organizationId,
+        memberId: admin.memberId,
+        name: `${p}-${randomUUID().slice(0, 6)}`,
+      });
+    const delegateA = await mk("dlgA");
+    const humanA = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `humanA-${randomUUID().slice(0, 6)}`,
+      delegateMention: delegateA,
+    });
+    const delegateR = await mk("dlgR");
+    const humanR = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `humanR-${randomUUID().slice(0, 6)}`,
+      delegateMention: delegateR,
+    });
+
+    const chatId = `chat_${randomUUID()}`;
+    await app.db.insert(chats).values({ id: chatId, organizationId: admin.organizationId, type: "group" });
+    // All four are speakers of the one chat (reviewer + its delegate are already members).
+    await app.db.insert(chatMembership).values(
+      [humanA, delegateA, humanR, delegateR].map((agentId, i) => ({
+        chatId,
+        agentId,
+        role: i === 0 ? "owner" : "member",
+        accessMode: "speaker" as const,
+        mode: "full" as const,
+        source: "manual" as const,
+      })),
+    );
+    // The entity is bound to this chat under (humanA, delegateA) only.
+    await app.db.insert(githubEntityChatMappings).values({
+      organizationId: admin.organizationId,
+      humanAgentId: humanA,
+      delegateAgentId: delegateA,
+      entityType: "pull_request",
+      entityKey: "owner/repo#210",
+      chatId,
+      boundVia: "direct",
+    });
+
+    const event = makeEvent({ orgId: admin.organizationId, entityType: "pull_request", entityKey: "owner/repo#210" });
+    const subscribed: AudienceTarget = {
+      humanAgentId: humanA,
+      delegateAgentId: delegateA,
+      kind: "existing",
+      chatId,
+      involveReason: null,
+      involveLogin: null,
+      actorAgentId: null,
+    };
+    const involved: AudienceTarget = {
+      humanAgentId: humanR,
+      delegateAgentId: delegateR,
+      kind: "new",
+      chatId: null,
+      involveReason: "review_requested",
+      involveLogin: "humanr",
+      actorAgentId: null,
+    };
+
+    const stats = await deliverNormalizedEvent(app, event, [subscribed, involved]);
+
+    // No new chat minted; exactly one card delivered to the single chat.
+    expect(stats.newChats).toBe(0);
+    expect(stats.delivered).toBe(1);
+    const sent = await app.db.select().from(messages).where(eq(messages.chatId, chatId));
+    expect(sent).toHaveLength(1);
+
+    // Union wake-set: BOTH delegates are woken via native mentions.
+    const wokenCount = async (agentUuid: string) => {
+      const [a] = await app.db
+        .select({ inboxId: agents.inboxId })
+        .from(agents)
+        .where(eq(agents.uuid, agentUuid))
+        .limit(1);
+      const rows = await app.db
+        .select({ id: inboxEntries.messageId })
+        .from(inboxEntries)
+        .where(
+          and(
+            eq(inboxEntries.inboxId, a?.inboxId ?? ""),
+            eq(inboxEntries.chatId, chatId),
+            eq(inboxEntries.notify, true),
+          ),
+        );
+      return rows.length;
+    };
+    expect(await wokenCount(delegateA)).toBe(1);
+    expect(await wokenCount(delegateR)).toBe(1);
+
+    // No reviewer mapping row was written — reuse routes by membership, not subscription.
+    const mappings = await app.db
+      .select()
+      .from(githubEntityChatMappings)
+      .where(eq(githubEntityChatMappings.entityKey, "owner/repo#210"));
+    expect(mappings).toHaveLength(1);
+  });
+
   // Regression: a GitHub-bound chat that has been expanded to >=3 speakers
   // (e.g. a teammate invited in) must still wake the delegate agent that
-  // owns the entity. Before the fix, github-delivery passed neither
-  // `addressedToAgentIds` nor `metadata.mentions`, so for card-format
-  // messages in a multi-speaker chat the fan-out collapsed to
-  // `notify=false` for everyone and the agent never woke.
+  // owns the entity. github-delivery wakes the delegate by adding it to the
+  // card's native `metadata.mentions`; before that, a card-format message in a
+  // multi-speaker chat produced no mentionSet and the fan-out collapsed to
+  // `notify=false` for everyone, so the agent never woke.
   it("wakes the delegate even in a multi-speaker bound chat (no mention required)", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);

--- a/packages/server/src/services/github-delivery.ts
+++ b/packages/server/src/services/github-delivery.ts
@@ -1,9 +1,9 @@
-import type { GithubEventCard, NormalizedEvent } from "@first-tree/shared";
+import type { GithubEventCard, InvolveReason, NormalizedEvent } from "@first-tree/shared";
 import type { FastifyInstance } from "fastify";
 import type { GithubEntity } from "../api/webhooks/github-entity.js";
 import { createLogger } from "../observability/index.js";
 import type { AudienceTarget } from "./github-audience.js";
-import { refreshGithubChatTopic, resolveTargetChat } from "./github-entity-chat.js";
+import { findReuseChatForInvolved, refreshGithubChatTopic, resolveTargetChat } from "./github-entity-chat.js";
 import type { EntityStateSeed } from "./github-entity-state.js";
 import { sendMessage } from "./message.js";
 import { notifyRecipients } from "./notifier.js";
@@ -11,16 +11,16 @@ import { notifyRecipients } from "./notifier.js";
 const log = createLogger("GithubDelivery");
 
 export type DeliveryStats = {
-  /** Number of audience targets that received a card. */
+  /** Number of chats that received a card (one card per chat). */
   delivered: number;
   /** Number of fresh chats created (involved-new path). */
   newChats: number;
   /**
-   * Number of audience targets whose delivery threw and was caught by the
-   * per-target guard. These targets did NOT receive a card; the webhook
-   * has already been claimed in `processed_events`, so GitHub will not
-   * retry. Surfaced in the response + metric so a regression in single-
-   * target reliability becomes observable instead of silent.
+   * Number of chats whose delivery threw and was caught by the per-chat
+   * guard. These chats did NOT receive a card; the webhook has already been
+   * claimed in `processed_events`, so GitHub will not retry. Surfaced in the
+   * response + metric so a regression in single-chat reliability becomes
+   * observable instead of silent.
    */
   failed: number;
 };
@@ -30,18 +30,35 @@ type DeliveryOptions = {
 };
 
 /**
- * Stage 3 — actually emit one card per audience target.
+ * Per-chat delivery accumulator. "Deliver once per chat" (S7/S9): multiple
+ * audience targets (subscribed and/or involved) that resolve to the same chat
+ * collapse into a single card whose wake-set is the union of their delegates.
+ */
+type ChatDelivery = {
+  chatId: string;
+  created: boolean;
+  /** Native mention / wake-set — the delegates to notify in this chat. */
+  delegateIds: Set<string>;
+  /** Echo suppress-set — actor agents excluded from notify (still get a silent row). */
+  actorIds: Set<string>;
+  /** Card framing: an involved target's reason/login wins over plain subscribed. */
+  involveReason: InvolveReason | null;
+  involveLogin: string | null;
+  /** Chat-local representative human used as `senderId` (rendered as the GitHub system sender). */
+  humanAgentId: string;
+};
+
+/**
+ * Stage 3 — emit exactly one card per chat.
  *
- * `existing` targets carry their chatId and short-circuit straight to the
- * send. `new` targets go through `resolveTargetChat` which performs the
- * §4.4 direct / fixes_link / fresh-chat lookup and writes the mapping row.
- * Each target's row is delivered + dispatched independently so a single
- * failure (e.g. cross-org rejection on chat creation) doesn't poison the
- * whole audience — the loop logs and continues.
- *
- * The card `reason` is `subscribed` for existing rows and the new target's
- * `involveReason` for involved rows; the surface event payload is the same
- * either way.
+ * Two phases. Phase 1 resolves every audience target to a chat (subscribed
+ * targets short-circuit; involved targets reuse the entity's existing chat
+ * when the involved human+delegate are already speakers, else mint a fresh
+ * one) and accumulates the per-chat wake-set / suppress-set / card framing.
+ * Phase 2 delivers one card per chat, waking the union of delegates via native
+ * `metadata.mentions` and suppressing the actor via `suppressNotifyAgentIds`.
+ * Each chat is delivered independently so a single failure doesn't poison the
+ * rest — the loop logs and continues.
  */
 export async function deliverNormalizedEvent(
   app: FastifyInstance,
@@ -51,132 +68,18 @@ export async function deliverNormalizedEvent(
 ): Promise<DeliveryStats> {
   const stats: DeliveryStats = { delivered: 0, newChats: 0, failed: 0 };
 
+  // Phase 1 — resolve each target to a chat and merge into per-chat deliveries.
+  const byChat = new Map<string, ChatDelivery>();
   for (const target of audience) {
+    let resolved: ResolvedChat | null;
     try {
-      const resolved = await resolveChatFor(app, event, target, options);
-      if (!resolved) {
-        // Creation-event guard fired: opened webhook had no existing mapping
-        // and no explicit mention for this target, so we drop the event for
-        // this target rather than inventing a chat. Other targets in the
-        // audience may still receive the card.
-        log.info(
-          {
-            humanAgent: target.humanAgentId,
-            delegateAgent: target.delegateAgentId,
-            entityType: event.entity.type,
-            entityKey: event.entity.key,
-            eventType: event.rawEventType,
-            action: event.rawAction,
-            reason: "creation_event_no_mapping_no_mention",
-          },
-          "webhook_dropped_creation",
-        );
-        continue;
-      }
-      if (resolved.created) stats.newChats += 1;
-
-      // Existing github-sourced chats: refresh the topic so PR / issue
-      // title edits on GitHub propagate into the workspace chat list. The
-      // helper only touches a chat whose own `direct` anchor entity matches
-      // this event (never a linked fixes_link entity), preserves the original
-      // prefix, and no-ops when the payload carries no title — keeping the
-      // refresh scoped to chats First Tree originally minted from this entity.
-      if (!resolved.created) {
-        const entity: GithubEntity = {
-          type: event.entity.type,
-          key: event.entity.key,
-          title: event.entity.title,
-          url: event.entity.url,
-        };
-        await refreshGithubChatTopic(app.db, resolved.chatId, entity);
-      }
-
-      const card = buildCard(event, target);
-      const mentionedUser = card.mentionedUser ?? undefined;
-      // The audience row resolved a specific (human, delegate) pair as the
-      // structural target of this event. Address the delegate explicitly so
-      // a bound chat that has been expanded to ≥3 speakers still wakes the
-      // agent — without this, card-format messages produce no mentionSet
-      // and the multi-speaker fan-out collapses to notify=false for
-      // everyone. Same pattern as any system-routed delivery (see
-      // SendMessageOptions `addressedToAgentIds`).
-      //
-      // Echo suppression (#942) is decoupled from addressing (S2 / D1): the
-      // delegate is always the structural addressing target; the actor (when
-      // it resolved to an org agent) is passed separately as
-      // `suppressNotifyAgentIds` so it is never *woken* by its own action
-      // while the card still lands in its inbox as a silent context row.
-      // The old `.filter(id !== actor)` conflated "who is the structural
-      // target" with "who gets woken"; keeping them separate also keeps echo
-      // off `senderId` — the actor is frequently not a speaker of this chat,
-      // so it must never become the chat-local sender. See
-      // system/cloud/github/github-entity-chat-binding.md S2.
-      const addressedToAgentIds = [target.delegateAgentId];
-      const suppressNotifyAgentIds = target.actorAgentId ? [target.actorAgentId] : [];
-      const { message, recipients } = await sendMessage(
-        app.db,
-        resolved.chatId,
-        target.humanAgentId,
-        {
-          format: "card",
-          content: card,
-          source: "github",
-          metadata: {
-            source: "github",
-            event: event.rawEventType,
-            action: event.rawAction,
-            entityType: event.entity.type,
-            entityKey: event.entity.key,
-            reason: card.reason,
-            // Tells the web UI to render this card with a synthetic
-            // "GitHub" sender (icon + name) in place of the human-agent
-            // row whose id we still store as `senderId`. Keeping the DB
-            // senderId as the human agent preserves multi-speaker
-            // fan-out / read-receipts / mention-resolution; only the
-            // visual attribution shifts. Scoped to GitHub cards so an
-            // arbitrary client cannot impersonate other sources.
-            systemSender: "github",
-            ...(mentionedUser ? { mentionedUser } : {}),
-          },
-        },
-        {
-          addressedToAgentIds,
-          // Echo suppression target (S2 / D1): the event's actor agent, when it
-          // resolved to one. Decoupled from `senderId` and from the addressing
-          // set — the actor still gets a silent inbox row, it is just not woken.
-          suppressNotifyAgentIds,
-          // Opt in to writing `metadata.systemSender` — the message service
-          // strips that key from every other caller (web / agent SDK POST)
-          // so HTTP boundaries cannot impersonate the GitHub sender in the
-          // chat UI. This is the one trusted-internal path.
-          allowSystemSender: true,
-          // Opt out of the default explicit-recipient guard. This trusted
-          // system delivery owns and validates its own addressing
-          // (`addressedToAgentIds` derived from the resolved audience row),
-          // but on some events the addressing resolves to no live recipient:
-          // the delegate may not be a speaker of the bound chat. Such a card
-          // is still a valid history/context row for human observers; without
-          // this opt-out the default guard would make this trusted path start
-          // throwing. (The echo case — delegate IS the actor — no longer
-          // empties the addressing: the delegate stays the structural target
-          // and is silenced via `suppressNotifyAgentIds`, so the card lands as
-          // a silent row rather than relying on this opt-out. A delegate that
-          // IS a speaker but suspended/deleted is rejected earlier by the
-          // addressed-recipient status check — a separate, intentional guard.)
-          // See SendMessageOptions docs.
-          allowRecipientlessSend: true,
-        },
-      );
-      notifyRecipients(app.notifier, recipients, message.id);
-      stats.delivered += 1;
+      resolved = await resolveChatFor(app, event, target, options);
     } catch (err) {
+      // A single target's chat resolution failing (e.g. cross-org rejection
+      // on mint, or a malformed audience row) must not abort the rest. Count
+      // it and move on — the webhook is already claimed, so GitHub won't
+      // retry; the metric makes the drop observable. See #507.
       stats.failed += 1;
-      // Per-target failures are isolated so one bad target doesn't poison
-      // the audience, but the webhook is already claimed in
-      // `processed_events` — GitHub will not retry. Emit a structured
-      // metric line so a regression in single-target reliability is
-      // observable in logs (and dashboardable by the operator) instead
-      // of being silently swallowed by `continue`. See #507.
       log.error(
         {
           err,
@@ -189,7 +92,147 @@ export async function deliverNormalizedEvent(
           eventType: event.rawEventType,
           action: event.rawAction,
         },
-        "failed to deliver normalized github event to target",
+        "failed to resolve chat for normalized github target",
+      );
+      continue;
+    }
+    if (!resolved) {
+      // Creation-event guard fired: opened webhook had no existing mapping
+      // and no explicit mention for this target, so we drop it rather than
+      // inventing a chat. Other targets may still resolve to a chat.
+      log.info(
+        {
+          humanAgent: target.humanAgentId,
+          delegateAgent: target.delegateAgentId,
+          entityType: event.entity.type,
+          entityKey: event.entity.key,
+          eventType: event.rawEventType,
+          action: event.rawAction,
+          reason: "creation_event_no_mapping_no_mention",
+        },
+        "webhook_dropped_creation",
+      );
+      continue;
+    }
+    let delivery = byChat.get(resolved.chatId);
+    if (!delivery) {
+      delivery = {
+        chatId: resolved.chatId,
+        created: resolved.created,
+        delegateIds: new Set(),
+        actorIds: new Set(),
+        involveReason: null,
+        involveLogin: null,
+        humanAgentId: target.humanAgentId,
+      };
+      byChat.set(resolved.chatId, delivery);
+    } else if (resolved.created) {
+      delivery.created = true;
+    }
+    delivery.delegateIds.add(target.delegateAgentId);
+    if (target.actorAgentId) delivery.actorIds.add(target.actorAgentId);
+    // Prefer an involved target's reason/login for the (single) card framing.
+    if (target.kind === "new" && target.involveReason && !delivery.involveReason) {
+      delivery.involveReason = target.involveReason;
+      delivery.involveLogin = target.involveLogin;
+    }
+  }
+
+  // Phase 2 — one card per chat.
+  for (const delivery of byChat.values()) {
+    try {
+      if (delivery.created) stats.newChats += 1;
+      else {
+        // Existing github-sourced chats: refresh the topic so PR / issue title
+        // edits propagate into the chat list. The helper only touches a chat
+        // whose own `direct` anchor entity matches this event, preserves the
+        // original prefix, and no-ops when the payload carries no title.
+        const entity: GithubEntity = {
+          type: event.entity.type,
+          key: event.entity.key,
+          title: event.entity.title,
+          url: event.entity.url,
+        };
+        await refreshGithubChatTopic(app.db, delivery.chatId, entity);
+      }
+
+      const card = buildCard(event, delivery.involveReason, delivery.involveLogin);
+      const mentionedUser = card.mentionedUser ?? undefined;
+      // Native wake-set (S8): the delegates are passed as `metadata.mentions`,
+      // so the generic fan-out wakes them — no GitHub-specific addressing
+      // override. A mention that is not a live speaker of the chat is filtered
+      // out by the message service (the card still lands as a silent row via
+      // `allowRecipientlessSend`). The unread-mention red dot stays off because
+      // delegates are non-human mention targets.
+      const mentions = [...delivery.delegateIds].sort();
+      // Echo suppression (S2 / D1): the event's actor agent(s), decoupled from
+      // `senderId` and from the wake-set. A suppressed agent still gets a
+      // silent (notify=false) inbox row — the card lands, it just doesn't wake.
+      const suppressNotifyAgentIds = [...delivery.actorIds];
+      const { message, recipients } = await sendMessage(
+        app.db,
+        delivery.chatId,
+        delivery.humanAgentId,
+        {
+          format: "card",
+          content: card,
+          source: "github",
+          metadata: {
+            source: "github",
+            event: event.rawEventType,
+            action: event.rawAction,
+            entityType: event.entity.type,
+            entityKey: event.entity.key,
+            reason: card.reason,
+            // Native mention wake-set — see above.
+            mentions,
+            // Render this card with a synthetic "GitHub" sender in place of the
+            // chat-local human row stored as `senderId`. Keeping the DB
+            // senderId chat-local preserves fan-out / read-receipts; only the
+            // visual attribution shifts. Scoped to GitHub cards so an arbitrary
+            // client cannot impersonate other sources.
+            systemSender: "github",
+            ...(mentionedUser ? { mentionedUser } : {}),
+          },
+        },
+        {
+          suppressNotifyAgentIds,
+          // Opt in to writing `metadata.systemSender` — the message service
+          // strips that key from every untrusted caller (web / agent SDK POST)
+          // so HTTP boundaries cannot impersonate the GitHub sender. This is
+          // the one trusted-internal path.
+          allowSystemSender: true,
+          // Opt out of the default explicit-recipient guard. This trusted
+          // system delivery owns its own routing, but on some events the
+          // wake-set resolves to no live speaker (every delegate is a
+          // non-speaker, or the only addressable agent is the suppressed
+          // actor). Such a card is still a valid history/context row for human
+          // observers; without this opt-out the default guard would make this
+          // trusted path start throwing.
+          allowRecipientlessSend: true,
+        },
+      );
+      notifyRecipients(app.notifier, recipients, message.id);
+      stats.delivered += 1;
+    } catch (err) {
+      stats.failed += 1;
+      // Per-chat failures are isolated so one bad chat doesn't poison the rest,
+      // but the webhook is already claimed in `processed_events` — GitHub will
+      // not retry. Emit a structured metric line so a regression in single-chat
+      // reliability is observable instead of silently swallowed. See #507.
+      log.error(
+        {
+          err,
+          metric: "github_delivery_failed_total",
+          errorClass: err instanceof Error ? err.name : "Unknown",
+          chatId: delivery.chatId,
+          delegateAgents: [...delivery.delegateIds],
+          entityType: event.entity.type,
+          entityKey: event.entity.key,
+          eventType: event.rawEventType,
+          action: event.rawAction,
+        },
+        "failed to deliver normalized github event to chat",
       );
     }
   }
@@ -217,6 +260,20 @@ async function resolveChatFor(
     title: event.entity.title,
     url: event.entity.url,
   };
+  // Reviewer-reuse (S9, deliver-once-per-chat): if the entity already has a
+  // single bound chat where this involved (human, delegate) are both speakers,
+  // route there instead of minting a sibling chat — and write NO mapping row.
+  // The pair sees the entity's events through chat membership, and Phase 2
+  // dedups so the chat gets one card whose wake-set includes this delegate.
+  const reuseChatId = await findReuseChatForInvolved(
+    app.db,
+    event.source.organizationId,
+    entity,
+    target.humanAgentId,
+    target.delegateAgentId,
+  );
+  if (reuseChatId) return { chatId: reuseChatId, created: false };
+
   const relatedEntities: GithubEntity[] = event.relatedRefs.map((ref) => ({
     type: "issue",
     key: ref.key,
@@ -230,10 +287,9 @@ async function resolveChatFor(
     eventType: event.rawEventType,
     action: event.rawAction ?? "",
     entityStateSeed: options.entityStateSeed ?? null,
-    // `kind: "new"` audience targets come from explicit mentions / involves
-    // in the event payload — these are the only path allowed to mint a fresh
-    // chat for an opened creation event. Subscription targets never reach
-    // resolveTargetChat (`kind: "existing"` short-circuits above), but the
+    // `kind: "new"` audience targets come from explicit mentions / involves in
+    // the event payload — the only path allowed to mint a fresh chat for an
+    // opened creation event. Subscription targets short-circuit above; the
     // guard is still wired so any future caller is safe by default.
     isMentionMatched: true,
   });
@@ -241,9 +297,18 @@ async function resolveChatFor(
   return { chatId: resolved.chatId, created: resolved.created };
 }
 
-function buildCard(event: NormalizedEvent, target: AudienceTarget): GithubEventCard {
-  const reason: GithubEventCard["reason"] =
-    target.kind === "existing" ? "subscribed" : (target.involveReason ?? "mentioned");
+/**
+ * Build the per-chat card. `involveReason`/`involveLogin` come from an involved
+ * target routed to this chat (review_requested / mentioned / assigned); when a
+ * chat is reached only through subscription they are null and the card reads as
+ * `subscribed`.
+ */
+function buildCard(
+  event: NormalizedEvent,
+  involveReason: InvolveReason | null,
+  involveLogin: string | null,
+): GithubEventCard {
+  const reason: GithubEventCard["reason"] = involveReason ?? "subscribed";
   const card: GithubEventCard = {
     type: "github_event",
     reason,
@@ -261,6 +326,6 @@ function buildCard(event: NormalizedEvent, target: AudienceTarget): GithubEventC
       url: event.entity.url ?? null,
     },
   };
-  if (target.involveLogin) card.mentionedUser = target.involveLogin;
+  if (involveLogin) card.mentionedUser = involveLogin;
   return card;
 }

--- a/packages/server/src/services/github-delivery.ts
+++ b/packages/server/src/services/github-delivery.ts
@@ -260,19 +260,24 @@ async function resolveChatFor(
     title: event.entity.title,
     url: event.entity.url,
   };
-  // Reviewer-reuse (S9, deliver-once-per-chat): if the entity already has a
-  // single bound chat where this involved (human, delegate) are both speakers,
-  // route there instead of minting a sibling chat — and write NO mapping row.
-  // The pair sees the entity's events through chat membership, and Phase 2
-  // dedups so the chat gets one card whose wake-set includes this delegate.
-  const reuseChatId = await findReuseChatForInvolved(
-    app.db,
-    event.source.organizationId,
-    entity,
-    target.humanAgentId,
-    target.delegateAgentId,
-  );
-  if (reuseChatId) return { chatId: reuseChatId, created: false };
+  // Reviewer-reuse (S9, deliver-once-per-chat) — scoped to `review_requested`
+  // ONLY. When the entity already has exactly one reusable bound chat (the
+  // reviewer's human + delegate both already speak there), route there instead
+  // of minting a sibling chat, writing NO mapping row; the pair sees the
+  // entity's events through chat membership and Phase 2 dedups to one card.
+  // `mentioned` / `assigned` involves are deliberately NOT reused: a mention is
+  // a directed call that must mint a fresh chat (S5 — mentions pierce into a
+  // new chat, never back into an existing/unfollowed one).
+  if (target.involveReason === "review_requested") {
+    const reuseChatId = await findReuseChatForInvolved(
+      app.db,
+      event.source.organizationId,
+      entity,
+      target.humanAgentId,
+      target.delegateAgentId,
+    );
+    if (reuseChatId) return { chatId: reuseChatId, created: false };
+  }
 
   const relatedEntities: GithubEntity[] = event.relatedRefs.map((ref) => ({
     type: "issue",

--- a/packages/server/src/services/github-entity-chat.ts
+++ b/packages/server/src/services/github-entity-chat.ts
@@ -65,6 +65,60 @@ export function isCreationEvent(eventType: string, action: string): boolean {
 }
 
 /**
+ * Reviewer-reuse routing (S9, deliver-once-per-chat). When an involved
+ * `(human, delegate)` pair is NOT yet mapped to this entity but the entity
+ * already has a **single** bound chat where BOTH the human and the delegate
+ * are already speakers, the event routes into that chat instead of minting a
+ * sibling one — and **no mapping row is written**. The pair sees the entity's
+ * events through chat membership, and `deliverNormalizedEvent` dedups so the
+ * chat receives one card whose wake-set includes this delegate.
+ *
+ * Returns the chat id when exactly one such chat exists; null when there is
+ * none, or when the candidate is ambiguous (≥2 bound chats both speak in),
+ * in which case the caller mints a fresh chat via `resolveTargetChat` (the
+ * strict per-`(human, delegate)` path — we never guess). Preserves S1 (the
+ * chat follows, not the person) and S7 (no followed chat is dropped).
+ */
+export async function findReuseChatForInvolved(
+  db: Database,
+  organizationId: string,
+  entity: GithubEntity,
+  humanAgentId: string,
+  delegateAgentId: string,
+): Promise<string | null> {
+  const candidateKeys = githubEntityKeyCandidates(entity.type, entity.key);
+  const boundChats = await db
+    .selectDistinct({ chatId: githubEntityChatMappings.chatId })
+    .from(githubEntityChatMappings)
+    .where(
+      and(
+        eq(githubEntityChatMappings.organizationId, organizationId),
+        eq(githubEntityChatMappings.entityType, entity.type),
+        inArray(githubEntityChatMappings.entityKey, candidateKeys),
+      ),
+    );
+  if (boundChats.length === 0) return null;
+
+  const reusable: string[] = [];
+  for (const { chatId } of boundChats) {
+    const speakerRows = await db
+      .select({ agentId: chatMembership.agentId })
+      .from(chatMembership)
+      .where(
+        and(
+          eq(chatMembership.chatId, chatId),
+          eq(chatMembership.accessMode, "speaker"),
+          inArray(chatMembership.agentId, [humanAgentId, delegateAgentId]),
+        ),
+      );
+    const ids = new Set(speakerRows.map((r) => r.agentId));
+    if (ids.has(humanAgentId) && ids.has(delegateAgentId)) reusable.push(chatId);
+    if (reusable.length > 1) break;
+  }
+  return reusable.length === 1 ? (reusable[0] ?? null) : null;
+}
+
+/**
  * Resolve which chat a GitHub event for (human, delegate, entity) belongs to.
  *
  * Three-step strategy from docs/webhook-routing-design.md §4.4:


### PR DESCRIPTION
## What
The routing/wake half of the GitHub delivery-boundary refactor (echo-decouple #1100 and human-only red dot #1102 already merged). Per `system/cloud/github/github-entity-chat-binding.md` **S7 / S8 / S9**.

- **`github-delivery.ts` — deliver ONE card per chat.** Phase 1 resolves every audience target to a chat and **unions their delegates** into a per-chat wake-set; phase 2 sends one card per chat, waking the delegates via native **`metadata.mentions`** (S8) and suppressing the actor via `suppressNotifyAgentIds` (S2). Subscribed + involved targets that land in the same chat collapse to **one card** (no more N cards to a shared chat). Per-target resolution failures stay isolated (#507).
- **`github-entity-chat.ts` — `findReuseChatForInvolved`.** When an involved `(human, delegate)` is not yet mapped but the entity already has a **single** bound chat where **both are speakers**, the event routes into that chat with **no new chat and no mapping row** (S9, deliver-once-per-chat — per owner direction, not a `bound_via` special-case). Ambiguous (≥2 candidates) / none → mint via `resolveTargetChat` (strict path, no guessing). Preserves S1 + S7.
- GitHub no longer passes `addressedToAgentIds`; the wake-set is native mentions. The generic `addressedToAgentIds` option stays for other callers (it is independently tested).

## Why
"Deliver once per chat" (owner direction): a reviewer who is already a member of the entity's chat gets the event **there** — no duplicate sibling chat, no extra mapping. The card wakes the union of relevant delegates. With native mentions + the human-only red-dot rule (#1102), delegates are woken without flooding anyone's badge.

## Tests
Full server suite green: **1457 passed**. New test pins reviewer-reuse + per-chat dedup (one card, both delegates woken, no new chat/mapping).

## Companion tree PR
Updates the locked node S9 (reuse-by-membership, **no mapping**) and S7 (per-chat dedup framing) to match — opening alongside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)