### PR TITLE
feat(web): restructure chat right sidebar as an inspection panel

### DIFF
--- a/packages/web/src/components/chat/agent-status-panel.tsx
+++ b/packages/web/src/components/chat/agent-status-panel.tsx
@@ -30,6 +30,7 @@ export function AgentStatusPanel({
   agents,
   canManage,
   order = "fixed",
+  compact = false,
 }: {
   chatId: string;
   /** Non-human agent participants, in display order. */
@@ -39,6 +40,9 @@ export function AgentStatusPanel({
   /** `fixed` keeps `agents` order (sidebar); `priority` sorts by attention
    *  (compose) so the most urgent agent is on top. */
   order?: "fixed" | "priority";
+  /** Tighter row padding for the dense sidebar roster. The compose-bar usage
+   *  keeps the roomier default. */
+  compact?: boolean;
 }) {
   const { data: statuses } = useQuery({
     queryKey: chatAgentStatusQueryKey(chatId),
@@ -71,6 +75,7 @@ export function AgentStatusPanel({
           status={byAgent.get(agent.agentId) ?? null}
           canManage={canManage(agent.agentId)}
           mounted={mounted}
+          compact={compact}
         />
       ))}
     </div>
@@ -98,12 +103,14 @@ function AgentStatusRow({
   status,
   canManage,
   mounted,
+  compact,
 }: {
   chatId: string;
   agent: ChatParticipantDetail;
   status: AgentChatStatus | null;
   canManage: boolean;
   mounted: ReadonlySet<string>;
+  compact: boolean;
 }) {
   const queryClient = useQueryClient();
   const suspendMut = useMutation({
@@ -130,7 +137,11 @@ function AgentStatusRow({
   return (
     <div
       className="flex items-center transition-colors hover:bg-[var(--bg-hover)]"
-      style={{ gap: "var(--sp-2_5)", padding: "var(--sp-1_75) var(--sp-2)", borderRadius: "var(--radius-input)" }}
+      style={{
+        gap: "var(--sp-2_5)",
+        padding: compact ? "var(--sp-1_25) var(--sp-2)" : "var(--sp-1_75) var(--sp-2)",
+        borderRadius: "var(--radius-input)",
+      }}
     >
       <AgentHovercard
         agentId={agent.agentId}

--- a/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
@@ -1290,8 +1290,8 @@ describe("ChatView", () => {
       await waitForCondition(() => sidebarOpen(container), "Expected rail to auto-open for a chat with a description");
       const aside = container.querySelector('aside[aria-label="Chat details"]');
       if (!aside) throw new Error("Sidebar aside missing");
-      // DescriptionSection eyebrow + markdown body (bold renders as <strong>).
-      expect(aside.textContent).toContain("Description");
+      // Summary section eyebrow (was "Description") + markdown body (bold renders as <strong>).
+      expect(aside.textContent).toContain("Summary");
       expect(aside.textContent).toContain("shipping");
       expect([...aside.querySelectorAll("strong")].some((el) => el.textContent === "DescBody")).toBe(true);
 
@@ -1452,7 +1452,7 @@ describe("ChatView", () => {
         "Expected the described chat's rail to auto-open after the doc-preview closed (regression: mark-before-docPreview-guard)",
       );
       const aside = container.querySelector('aside[aria-label="Chat details"]');
-      expect(aside?.textContent).toContain("Description");
+      expect(aside?.textContent).toContain("Summary");
       expect([...(aside?.querySelectorAll("strong") ?? [])].some((el) => el.textContent === "DescBody")).toBe(true);
 
       await act(async () => root.unmount());

--- a/packages/web/src/pages/workspace/right-sidebar/__tests__/github-sort.test.ts
+++ b/packages/web/src/pages/workspace/right-sidebar/__tests__/github-sort.test.ts
@@ -1,0 +1,50 @@
+import type { ChatGithubEntity, GithubEntityType } from "@first-tree/shared";
+import { describe, expect, it } from "vitest";
+import { sortEntitiesByType } from "../github-section.js";
+
+function entity(entityType: GithubEntityType, key: string): ChatGithubEntity {
+  return {
+    entityType,
+    entityKey: key,
+    boundVia: "direct",
+    htmlUrl: `https://github.com/o/r/${key}`,
+    title: null,
+    state: null,
+    number: null,
+  };
+}
+
+describe("sortEntitiesByType", () => {
+  it("clusters by type in PR → issue → discussion → commit order", () => {
+    const items = [
+      entity("issue", "i1"),
+      entity("commit", "c1"),
+      entity("pull_request", "p1"),
+      entity("discussion", "d1"),
+    ];
+    expect(sortEntitiesByType(items).map((e) => e.entityType)).toEqual([
+      "pull_request",
+      "issue",
+      "discussion",
+      "commit",
+    ]);
+  });
+
+  it("preserves server order within a type group (stable)", () => {
+    const items = [
+      entity("pull_request", "p1"),
+      entity("issue", "i1"),
+      entity("pull_request", "p2"),
+      entity("issue", "i2"),
+      entity("pull_request", "p3"),
+    ];
+    expect(sortEntitiesByType(items).map((e) => e.entityKey)).toEqual(["p1", "p2", "p3", "i1", "i2"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const items = [entity("issue", "i1"), entity("pull_request", "p1")];
+    const before = items.map((e) => e.entityKey);
+    sortEntitiesByType(items);
+    expect(items.map((e) => e.entityKey)).toEqual(before);
+  });
+});

--- a/packages/web/src/pages/workspace/right-sidebar/__tests__/participants-roster.test.ts
+++ b/packages/web/src/pages/workspace/right-sidebar/__tests__/participants-roster.test.ts
@@ -1,0 +1,65 @@
+import type { ChatParticipantDetail } from "@first-tree/shared";
+import { describe, expect, it } from "vitest";
+import { partitionRoster, VISIBLE_LIMIT } from "../participants-section.js";
+
+function participant(id: string, type: "human" | "agent"): ChatParticipantDetail {
+  return {
+    agentId: id,
+    role: "member",
+    mode: "default",
+    joinedAt: "2026-06-16T00:00:00.000Z",
+    name: id,
+    displayName: id,
+    type,
+    avatarColorToken: null,
+    avatarImageUrl: null,
+  };
+}
+
+describe("partitionRoster", () => {
+  it("orders agents before humans, preserving server order within each group", () => {
+    const roster = [
+      participant("human-1", "human"),
+      participant("agent-1", "agent"),
+      participant("human-2", "human"),
+      participant("agent-2", "agent"),
+    ];
+    const { visibleAgents, visibleHumans } = partitionRoster(roster, true);
+    expect(visibleAgents.map((p) => p.agentId)).toEqual(["agent-1", "agent-2"]);
+    expect(visibleHumans.map((p) => p.agentId)).toEqual(["human-1", "human-2"]);
+  });
+
+  it("caps the visible roster at the limit and reports the hidden remainder", () => {
+    const roster = Array.from({ length: 8 }, (_, i) => participant(`agent-${i}`, "agent"));
+    const { total, visibleAgents, visibleHumans, hiddenCount } = partitionRoster(roster, false);
+    expect(total).toBe(8);
+    expect(visibleAgents).toHaveLength(VISIBLE_LIMIT);
+    expect(visibleHumans).toHaveLength(0);
+    expect(hiddenCount).toBe(3);
+  });
+
+  it("fills the visible slice with agents first, then humans, when over the cap", () => {
+    const roster = [
+      ...Array.from({ length: 3 }, (_, i) => participant(`agent-${i}`, "agent")),
+      ...Array.from({ length: 4 }, (_, i) => participant(`human-${i}`, "human")),
+    ];
+    const { visibleAgents, visibleHumans, hiddenCount } = partitionRoster(roster, false);
+    // 3 agents + first 2 humans = 5 visible; 2 humans hidden.
+    expect(visibleAgents.map((p) => p.agentId)).toEqual(["agent-0", "agent-1", "agent-2"]);
+    expect(visibleHumans.map((p) => p.agentId)).toEqual(["human-0", "human-1"]);
+    expect(hiddenCount).toBe(2);
+  });
+
+  it("reveals everyone when showAll is set", () => {
+    const roster = Array.from({ length: 8 }, (_, i) => participant(`agent-${i}`, "agent"));
+    const { visibleAgents, hiddenCount } = partitionRoster(roster, true);
+    expect(visibleAgents).toHaveLength(8);
+    expect(hiddenCount).toBe(0);
+  });
+
+  it("does not hide anything at or under the cap", () => {
+    const roster = Array.from({ length: 5 }, (_, i) => participant(`agent-${i}`, "agent"));
+    const { hiddenCount } = partitionRoster(roster, false);
+    expect(hiddenCount).toBe(0);
+  });
+});

--- a/packages/web/src/pages/workspace/right-sidebar/description-section.tsx
+++ b/packages/web/src/pages/workspace/right-sidebar/description-section.tsx
@@ -1,29 +1,132 @@
 import type { ReactNode } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Markdown } from "../../../components/ui/markdown.js";
 
+/** Collapsed cap for the markdown body (~26 lines) — applied ONLY when a
+ *  section sits below Summary (GitHub). Sized so a typical summary renders
+ *  fully without a click; this section is the catch-up surface someone reads to
+ *  reconstruct the work, so forcing "Show more" on a normal-length summary would
+ *  defeat its purpose. Only long bodies (approaching the ~1500 char description
+ *  budget) clamp here with a bottom fade + "Show more". When Summary is the last
+ *  section the cap is dropped entirely (see `capped`). */
+const COLLAPSED_MAX_HEIGHT_REM = 30;
+
 /**
- * Description section — the chat's work summary + status report (set by the
- * owning agent via `chat update --description`), rendered as markdown at the
- * TOP of the right rail, above Participants. Read-only on the web.
+ * Summary section — the chat's running work summary + status (set by the
+ * owning agent via `chat update --description`), rendered as markdown in the
+ * right rail (below Participants). Read-only on the web.
+ *
+ * Labelled "Summary" rather than "Description": this is a live, continuously
+ * re-written account read by whoever is reconstructing context (a returning
+ * human, a teammate or agent just joining / waking), not a static blurb. The
+ * underlying field is still `chat.description`; only the surface label differs.
+ *
+ * Height is dynamic via `capped` (owned by ChatRightSidebar):
+ *   - capped (GitHub section present below): clamp long bodies to ~30rem with a
+ *     fade-to-background mask + "Show more". Overflow is measured against the
+ *     cap and re-measured on width changes (the rail is resizable), so the
+ *     toggle only appears when content actually exceeds the cap. A height cap +
+ *     fade is used rather than `line-clamp`, which is unreliable across markdown
+ *     block elements (headings / lists / code).
+ *   - uncapped (Summary is the last visible section — the common no-GitHub
+ *     case): render the whole body, no fade, no toggle. Nothing sits below it,
+ *     so there is nothing to protect; the rail just scrolls.
  *
  * Hidden entirely when the chat has no description — an empty eyebrow would
- * just waste vertical space on chats that never set one. The trailing
- * hairline mirrors the Participants section so the rail's sections read as a
- * consistent stack.
+ * just waste vertical space. The trailing hairline mirrors the other sections.
  */
-export function DescriptionSection({ description }: { description: string | null }): ReactNode {
+export function DescriptionSection({
+  description,
+  capped = true,
+}: {
+  description: string | null;
+  /** Apply the ~30rem cap + fade + "Show more". False when Summary is the last
+   *  visible section (no GitHub below), in which case the full body renders. */
+  capped?: boolean;
+}): ReactNode {
   const trimmed = description?.trim();
+  const bodyRef = useRef<HTMLDivElement>(null);
+  const [expanded, setExpanded] = useState(false);
+  const [overflowing, setOverflowing] = useState(false);
+
+  const measure = useCallback(() => {
+    const el = bodyRef.current;
+    if (!el) return;
+    const rootPx = Number.parseFloat(getComputedStyle(document.documentElement).fontSize) || 16;
+    const capPx = COLLAPSED_MAX_HEIGHT_REM * rootPx;
+    // scrollHeight is the full content height regardless of the maxHeight cap,
+    // so this holds whether or not we're currently expanded.
+    setOverflowing(el.scrollHeight > capPx + 1);
+  }, []);
+
+  useEffect(() => {
+    // Overflow only matters while capped; an uncapped body always renders fully.
+    if (!trimmed || !capped) {
+      setOverflowing(false);
+      return;
+    }
+    measure();
+    const el = bodyRef.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    // Width changes (sidebar resize) reflow markdown → re-measure overflow.
+    const ro = new ResizeObserver(() => measure());
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [trimmed, capped, measure]);
+
   if (!trimmed) return null;
+
+  const clamp = capped && !expanded;
+  const showToggle = capped && overflowing;
+  const showFade = clamp && overflowing;
 
   return (
     <section style={{ borderBottom: "var(--hairline) solid var(--border-faint)" }}>
       <div className="text-eyebrow" style={{ padding: "var(--sp-2_5) var(--sp-3) var(--sp-1)", color: "var(--fg-4)" }}>
-        Description
+        Summary
       </div>
 
-      <div className="text-body" style={{ padding: "0 var(--sp-3) var(--sp-2_5)", color: "var(--fg)" }}>
-        <Markdown>{trimmed}</Markdown>
+      <div style={{ position: "relative" }}>
+        <div
+          ref={bodyRef}
+          className="text-body"
+          style={{
+            padding: "0 var(--sp-3) var(--sp-2_5)",
+            color: "var(--fg)",
+            maxHeight: clamp ? `${COLLAPSED_MAX_HEIGHT_REM}rem` : undefined,
+            overflow: "hidden",
+          }}
+        >
+          <Markdown>{trimmed}</Markdown>
+        </div>
+        {showFade ? (
+          <div
+            aria-hidden="true"
+            style={{
+              position: "absolute",
+              left: 0,
+              right: 0,
+              bottom: 0,
+              height: "2.5rem",
+              background: "linear-gradient(to bottom, transparent, var(--bg-raised))",
+              pointerEvents: "none",
+            }}
+          />
+        ) : null}
       </div>
+
+      {showToggle ? (
+        <div style={{ padding: "0 var(--sp-2) var(--sp-2)" }}>
+          <button
+            type="button"
+            onClick={() => setExpanded((v) => !v)}
+            className="text-caption transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--fg)]"
+            style={{ padding: "var(--sp-1) var(--sp-1_5)", color: "var(--fg-3)", borderRadius: "var(--radius-input)" }}
+          >
+            {expanded ? "Show less" : "Show more"}
+          </button>
+        </div>
+      ) : null}
     </section>
   );
 }

--- a/packages/web/src/pages/workspace/right-sidebar/github-section.tsx
+++ b/packages/web/src/pages/workspace/right-sidebar/github-section.tsx
@@ -5,6 +5,24 @@ import { listChatGithubEntities } from "../../../api/chats.js";
 import { DenseBadge, type DenseBadgeTone } from "../../../components/ui/dense-badge.js";
 
 /**
+ * Shared query for a chat's bound GitHub entities. Used by GitHubSection to
+ * render the list AND by ChatRightSidebar to decide whether Summary is the last
+ * visible section (and therefore uncapped). Same query key → React Query
+ * dedupes the two call sites to a single request.
+ */
+export function useChatGithubEntities(chatId: string): { items: ChatGithubEntity[]; isLoading: boolean } {
+  const query = useQuery({
+    queryKey: ["chat-right-sidebar", "github-entities", chatId],
+    queryFn: () => listChatGithubEntities(chatId),
+    // Webhook-synced state can drift while the panel is open; refresh the
+    // cheap DB projection periodically and keep quick panel toggles warm.
+    staleTime: 30_000,
+    refetchInterval: 60_000,
+  });
+  return { items: query.data?.items ?? [], isLoading: query.isLoading };
+}
+
+/**
  * GitHub section — lists every PR / Issue / Discussion / Commit bound to
  * the current chat via `github_entity_chat_mappings`. State comes from the
  * server's webhook-synced projection; title may be null because the mapping
@@ -14,23 +32,19 @@ import { DenseBadge, type DenseBadgeTone } from "../../../components/ui/dense-ba
  * waste vertical space on chats that aren't sourced from GitHub.
  */
 export function GitHubSection({ chatId }: { chatId: string }) {
-  const query = useQuery({
-    queryKey: ["chat-right-sidebar", "github-entities", chatId],
-    queryFn: () => listChatGithubEntities(chatId),
-    // Webhook-synced state can drift while the panel is open; refresh the
-    // cheap DB projection periodically and keep quick panel toggles warm.
-    staleTime: 30_000,
-    refetchInterval: 60_000,
-  });
+  const { items, isLoading } = useChatGithubEntities(chatId);
 
-  const items = query.data?.items ?? [];
-
-  if (query.isLoading || items.length === 0) {
+  if (isLoading || items.length === 0) {
     // Loading / empty: render nothing. The Agents section already covered
     // the "right rail has content" cue; an extra spinner would just churn
     // the layout.
     return null;
   }
+
+  // Group by type so same-kind entities cluster — PRs (the primary work
+  // artifact) first, then issues, discussions, commits. Type is conveyed by
+  // the per-row icon alone (no subheaders).
+  const sorted = sortEntitiesByType(items);
 
   return (
     <section>
@@ -39,12 +53,34 @@ export function GitHubSection({ chatId }: { chatId: string }) {
       </div>
 
       <div className="flex flex-col" style={{ padding: "0 var(--sp-2) var(--sp-2)", gap: 2 }}>
-        {items.map((entity) => (
+        {sorted.map((entity) => (
           <GitHubRow key={`${entity.entityType}::${entity.entityKey}`} entity={entity} />
         ))}
       </div>
     </section>
   );
+}
+
+/** Group order for the GitHub list: PR → Issue → Discussion → Commit. */
+const TYPE_ORDER: Record<string, number> = {
+  pull_request: 0,
+  issue: 1,
+  discussion: 2,
+  commit: 3,
+};
+
+function typeRank(type: GithubEntityType): number {
+  return TYPE_ORDER[type] ?? 9;
+}
+
+/**
+ * Cluster entities by type (PR → Issue → Discussion → Commit) without
+ * subheaders — the per-row icon carries the type. `Array.prototype.sort` is
+ * stable, so server order is preserved within each type group. Pure + exported
+ * for unit testing (the panel itself needs live bindings to render).
+ */
+export function sortEntitiesByType(items: ChatGithubEntity[]): ChatGithubEntity[] {
+  return [...items].sort((a, b) => typeRank(a.entityType) - typeRank(b.entityType));
 }
 
 function GitHubRow({ entity }: { entity: ChatGithubEntity }) {
@@ -59,7 +95,7 @@ function GitHubRow({ entity }: { entity: ChatGithubEntity }) {
       className="group flex items-start transition-colors hover:bg-[var(--bg-hover)]"
       style={{
         gap: "var(--sp-2)",
-        padding: "var(--sp-2)",
+        padding: "var(--sp-1_5) var(--sp-2)",
         borderRadius: "var(--radius-input)",
         color: "inherit",
         textDecoration: "none",
@@ -91,9 +127,6 @@ function GitHubRow({ entity }: { entity: ChatGithubEntity }) {
             {entity.title}
           </div>
         ) : null}
-        <div className="text-caption" style={{ color: "var(--fg-4)" }}>
-          {humanizeBoundVia(entity.boundVia)}
-        </div>
       </div>
       <ExternalLink
         aria-hidden="true"
@@ -124,31 +157,6 @@ function iconColor(state: GithubEntityLiveState | null): string {
       return "var(--fg-success-strong)";
     default:
       return "var(--fg-3)";
-  }
-}
-
-/**
- * Map the wire-level `bound_via` enum (`direct` / `fixes_link` /
- * `human_fallback` / `agent_declared` / `human_declared`) to a
- * self-contained sentence — the row doesn't prepend "via " anymore, so
- * each label has to read as a complete provenance hint on its own.
- * Falling back to the raw key preserves forward-compatibility for any
- * new boundVia value the server might emit before this map catches up.
- */
-function humanizeBoundVia(boundVia: string): string {
-  switch (boundVia) {
-    case "direct":
-      return "Mentioned in chat";
-    case "fixes_link":
-      return 'Auto-linked from "Fixes #…"';
-    case "human_fallback":
-      return "Routed to your existing chat";
-    case "agent_declared":
-      return "Followed by an agent";
-    case "human_declared":
-      return "Followed by you";
-    default:
-      return boundVia;
   }
 }
 

--- a/packages/web/src/pages/workspace/right-sidebar/index.tsx
+++ b/packages/web/src/pages/workspace/right-sidebar/index.tsx
@@ -135,8 +135,14 @@ export function ChatRightSidebar({
           onReset={handleReset}
         />
       )}
+      {/* Key the sections that hold local fold state (Participants' "Show all",
+          Summary's "Show more") by chatId. ChatView is NOT remounted on chat
+          switch — it refetches by chatId — so without this the expanded/showAll
+          UI state would leak from one chat into the next. The rail shell itself
+          is intentionally NOT keyed: its width is a global preference. */}
       <div className="flex-1 overflow-y-auto">
         <ParticipantsSection
+          key={chatId}
           chatId={chatId}
           participants={participants}
           participantsLoading={participantsLoading}
@@ -144,7 +150,7 @@ export function ChatRightSidebar({
           onAdded={onAdded}
           readOnly={readOnly}
         />
-        <DescriptionSection description={description} capped={summaryCapped} />
+        <DescriptionSection key={chatId} description={description} capped={summaryCapped} />
         <GitHubSection chatId={chatId} />
       </div>
     </aside>

--- a/packages/web/src/pages/workspace/right-sidebar/index.tsx
+++ b/packages/web/src/pages/workspace/right-sidebar/index.tsx
@@ -1,27 +1,76 @@
 import type { ChatParticipantDetail } from "@first-tree/shared";
+import { useCallback, useState } from "react";
 import { DescriptionSection } from "./description-section.js";
-import { GitHubSection } from "./github-section.js";
+import { GitHubSection, useChatGithubEntities } from "./github-section.js";
 import { ParticipantsSection } from "./participants-section.js";
+import { SidebarResizeHandle } from "./resize-handle.js";
+
+/** Resizable inline-rail width (px). Default is a touch wider than the legacy
+ *  320 so markdown descriptions breathe; the user can drag wider for long
+ *  content. Persisted globally (a reading preference, not per-chat). */
+const WIDTH_STORAGE_KEY = "first-tree:chat-right-sidebar:width:v1";
+const DEFAULT_WIDTH = 360;
+const MIN_WIDTH = 300;
+const MAX_WIDTH = 600;
+
+/** Clamp to the fixed [MIN, MAX] band. A single source of clamping shared with
+ *  the drag handle (which is handed the same MIN/MAX), so the live drag value,
+ *  the committed value, and the persisted value never disagree. The center
+ *  conversation stays usable because the shell switches to the overlay variant
+ *  below the narrow breakpoint; in inline mode the user owns the trade and can
+ *  double-click the handle to reset. */
+function clampWidth(width: number): number {
+  return Math.min(Math.max(Math.round(width), MIN_WIDTH), MAX_WIDTH);
+}
+
+function loadWidth(): number {
+  if (typeof window === "undefined") return DEFAULT_WIDTH;
+  try {
+    const raw = window.localStorage.getItem(WIDTH_STORAGE_KEY);
+    if (raw === null) return DEFAULT_WIDTH;
+    const parsed = Number.parseInt(raw, 10);
+    return Number.isFinite(parsed) ? clampWidth(parsed) : DEFAULT_WIDTH;
+  } catch {
+    return DEFAULT_WIDTH;
+  }
+}
+
+function saveWidth(width: number): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(WIDTH_STORAGE_KEY, String(width));
+  } catch {
+    // localStorage may be unavailable (private mode); ignore.
+  }
+}
 
 /**
  * ChatRightSidebar — chat-scoped detail + management panel mounted inside
  * ChatView. No internal header bar and no in-panel close button: the
  * chat header already owns a "Hide chat details" toggle, so a duplicate
- * × inside the panel was just redundant clutter. Sections kick off
- * straight from the first eyebrow.
+ * × inside the panel was just redundant clutter.
  *
- * Sections, top-to-bottom:
- *   1. Description — the chat's running work summary, rendered as markdown.
- *      Hidden entirely when no description is set.
- *   2. Participants — humans + agents with per-agent Suspend (matches the
- *      legacy AgentRow capability).
- *   3. GitHub bindings — read-only list of PRs / Issues bound to this
- *      chat. Hidden entirely when there are no bindings.
+ * Sections, top-to-bottom — ordered by what the user most wants to scan when
+ * inspecting selected work (the rail is a calm inspection surface; attention
+ * routing lives in the left nav + composer RequestDock, not here):
+ *   1. Participants — humans + agents (agents first, since their live status
+ *      is the glanceable pulse). Caps the visible roster; rest behind
+ *      "Show all".
+ *   2. Summary — the chat's running work summary + status (the `description`
+ *      field, labelled "Summary"), rendered as markdown. Height is dynamic:
+ *      capped (fade + "Show more") only when GitHub renders below it; uncapped
+ *      when Summary is the last section. Hidden when unset.
+ *   3. GitHub bindings — read-only PRs / Issues bound to this chat. As the
+ *      last section nothing sits below it, so it is NOT height-capped. Hidden
+ *      when there are no bindings.
+ *
+ * Width: the inline rail is drag-resizable (left-edge handle) and remembers
+ * its width globally. The narrow-viewport overlay passes a fixed `width` and
+ * gets no handle.
  *
  * Archive / Delete are intentionally NOT in this rail — the
  * conversation-list row kebab (row-engagement-menu.tsx) is the single
- * canonical entry, so the sidebar copy that used to live here was just
- * duplication.
+ * canonical entry.
  */
 export function ChatRightSidebar({
   chatId,
@@ -31,10 +80,10 @@ export function ChatRightSidebar({
   managedByMe,
   onAdded,
   readOnly,
-  width = 320,
+  width,
 }: {
   chatId: string;
-  /** The chat's running work summary, rendered as markdown in the top
+  /** The chat's running work summary, rendered as markdown in the
    *  DescriptionSection. Null / empty hides that section. */
   description: string | null;
   participants: ChatParticipantDetail[];
@@ -44,23 +93,49 @@ export function ChatRightSidebar({
   /** Watcher mode: hide write surfaces. Currently gates the inline
    *  "Add participant" affordance inside ParticipantsSection. */
   readOnly: boolean;
-  /** Override the default 20rem width. Used by the narrow-viewport
-   *  overlay branch in `ChatView` to cap to `min(88vw, 20rem)` so
-   *  the rail doesn't overflow a ~23rem logical viewport. */
+  /** When set, pins the rail to a fixed width and disables resize. Used by the
+   *  narrow-viewport overlay branch in `ChatView` (`min(88vw, 20rem)`). When
+   *  omitted, the rail is drag-resizable and restores its persisted width. */
   width?: number | string;
 }) {
+  const isFixed = width !== undefined;
+  const [resizableWidth, setResizableWidth] = useState<number>(loadWidth);
+
+  const handleWidthChange = useCallback((next: number) => setResizableWidth(clampWidth(next)), []);
+  const handleCommit = useCallback((next: number) => saveWidth(clampWidth(next)), []);
+  const handleReset = useCallback(() => {
+    setResizableWidth(DEFAULT_WIDTH);
+    saveWidth(DEFAULT_WIDTH);
+  }, []);
+
+  // Summary caps its height only when a section (GitHub) sits below it. GitHub
+  // is hidden when the chat has no bindings — the common case — so Summary is
+  // then the last section and renders uncapped. While the bindings query is in
+  // flight, stay capped to avoid a tall-then-shrink reflow if bindings load.
+  const { items: githubItems, isLoading: githubLoading } = useChatGithubEntities(chatId);
+  const summaryCapped = githubLoading || githubItems.length > 0;
+
   return (
     <aside
       aria-label="Chat details"
       className="relative flex shrink-0 flex-col overflow-hidden animate-in fade-in slide-in-from-right-4 duration-150"
       style={{
-        width,
+        width: isFixed ? width : resizableWidth,
         background: "var(--bg-raised)",
         borderLeft: "var(--hairline) solid var(--border)",
       }}
     >
+      {isFixed ? null : (
+        <SidebarResizeHandle
+          width={resizableWidth}
+          min={MIN_WIDTH}
+          max={MAX_WIDTH}
+          onWidthChange={handleWidthChange}
+          onCommit={handleCommit}
+          onReset={handleReset}
+        />
+      )}
       <div className="flex-1 overflow-y-auto">
-        <DescriptionSection description={description} />
         <ParticipantsSection
           chatId={chatId}
           participants={participants}
@@ -69,6 +144,7 @@ export function ChatRightSidebar({
           onAdded={onAdded}
           readOnly={readOnly}
         />
+        <DescriptionSection description={description} capped={summaryCapped} />
         <GitHubSection chatId={chatId} />
       </div>
     </aside>

--- a/packages/web/src/pages/workspace/right-sidebar/participants-section.tsx
+++ b/packages/web/src/pages/workspace/right-sidebar/participants-section.tsx
@@ -1,25 +1,64 @@
 import type { ChatParticipantDetail } from "@first-tree/shared";
-import { useMemo } from "react";
+import type { ReactNode } from "react";
+import { useMemo, useState } from "react";
 import { useAuth } from "../../../auth/auth-context.js";
 import { AddParticipantDropdown } from "../../../components/add-participant-dropdown.js";
 import { Avatar as RealAvatar } from "../../../components/avatar.js";
 import { AgentStatusPanel } from "../../../components/chat/agent-status-panel.js";
 
+/** Roster rows shown before the "Show all" fold. The rail is a calm
+ *  inspection surface, not a member-management screen — a long roster
+ *  shouldn't push Description / GitHub off-screen, so we cap the visible
+ *  rows and tuck the rest behind a toggle. */
+export const VISIBLE_LIMIT = 5;
+
 /**
- * Participants section — full chat membership (humans + agents). Agent rows
- * render through <AgentStatusPanel> (one /chats/:id/agent-status call drives
- * every agent's composite status + per-row Pause when the caller can manage).
- * Humans render a simplified row (no session state, no actions in v1 —
- * Remove / Change role are deferred to a future iteration alongside the
- * missing backend routes for member-side participant removal).
+ * Order the roster agents-first (their live status is the glanceable pulse),
+ * then humans, preserving server order within each group; cap to `limit`
+ * unless `showAll`. Pure so the ordering / fold math is unit-testable without
+ * rendering the query-backed AgentStatusPanel.
+ */
+export function partitionRoster(
+  participants: ChatParticipantDetail[],
+  showAll: boolean,
+  limit: number = VISIBLE_LIMIT,
+): {
+  total: number;
+  visibleAgents: ChatParticipantDetail[];
+  visibleHumans: ChatParticipantDetail[];
+  hiddenCount: number;
+} {
+  const agents = participants.filter((p) => p.type !== "human");
+  const humans = participants.filter((p) => p.type === "human");
+  const ordered = [...agents, ...humans];
+  const total = ordered.length;
+  const visible = showAll ? ordered : ordered.slice(0, limit);
+  return {
+    total,
+    visibleAgents: visible.filter((p) => p.type !== "human"),
+    visibleHumans: visible.filter((p) => p.type === "human"),
+    hiddenCount: total - visible.length,
+  };
+}
+
+/**
+ * Participants section — full chat membership (humans + agents), the top
+ * section of the rail. Agents render first (their live status is the
+ * glanceable pulse of the work) through <AgentStatusPanel> (one
+ * /chats/:id/agent-status call drives every agent's composite status +
+ * per-row Pause when the caller can manage). Humans follow as a simplified
+ * roster (no session state, no actions in v1 — Remove / Change role are
+ * deferred alongside the missing backend routes for member-side removal).
+ *
+ * The roster is capped at VISIBLE_LIMIT; the remainder collapses behind a
+ * "Show all" toggle so a crowded chat can't dominate the rail.
  *
  * The bottom "Add" affordance shares <AddParticipantDropdown> with the
  * header quick-add icon — both go through the same `addMeChatParticipants`
  * mutation and the same grouped, avatar'd picker.
  *
  * Membership data (`participants` / `managedByMe`) is passed down from
- * ChatView, which already holds the `chat-detail` + `activity` queries —
- * this section no longer re-declares them.
+ * ChatView, which already holds the `chat-detail` + `activity` queries.
  */
 export function ParticipantsSection({
   chatId,
@@ -37,24 +76,18 @@ export function ParticipantsSection({
   readOnly: boolean;
 }) {
   const { role } = useAuth();
-
-  // Humans first (the people in the room), then agents (the tools and
-  // teammates). Within each group, server order is preserved.
-  const sorted = useMemo(() => {
-    const humans = participants.filter((p) => p.type === "human");
-    const agents = participants.filter((p) => p.type !== "human");
-    return [...humans, ...agents];
-  }, [participants]);
+  const [showAll, setShowAll] = useState(false);
 
   const isAdmin = role === "admin";
+  const { total, visibleAgents, visibleHumans, hiddenCount } = useMemo(
+    () => partitionRoster(participants, showAll),
+    [participants, showAll],
+  );
 
   return (
     <section style={{ borderBottom: "var(--hairline) solid var(--border-faint)" }}>
-      {/* Count is rendered inline ("Participants · N") rather than as a
-          right-aligned separate field; the right edge of this eyebrow
-          row is reserved for the floating X close button on the rail. */}
       <div className="text-eyebrow" style={{ padding: "var(--sp-2_5) var(--sp-3) var(--sp-1)", color: "var(--fg-4)" }}>
-        Participants <span className="mono">· {sorted.length}</span>
+        Participants <span className="mono">· {total}</span>
       </div>
 
       <div className="flex flex-col" style={{ padding: "0 var(--sp-2) var(--sp-1)", gap: 2 }}>
@@ -62,22 +95,28 @@ export function ParticipantsSection({
           <div className="text-body" style={{ padding: "var(--sp-2)", color: "var(--fg-3)" }}>
             Loading…
           </div>
-        ) : sorted.length === 0 ? (
+        ) : total === 0 ? (
           <div className="text-body" style={{ padding: "var(--sp-2)", color: "var(--fg-3)" }}>
             No participants yet.
           </div>
         ) : (
           <>
-            {sorted
-              .filter((p) => p.type === "human")
-              .map((p) => (
-                <HumanRow key={p.agentId} participant={p} />
-              ))}
-            <AgentStatusPanel
-              chatId={chatId}
-              agents={sorted.filter((p) => p.type !== "human")}
-              canManage={(id) => isAdmin || (managedByMe.get(id) ?? false)}
-            />
+            {visibleAgents.length > 0 ? (
+              <AgentStatusPanel
+                chatId={chatId}
+                agents={visibleAgents}
+                canManage={(id) => isAdmin || (managedByMe.get(id) ?? false)}
+                compact
+              />
+            ) : null}
+            {visibleHumans.map((p) => (
+              <HumanRow key={p.agentId} participant={p} />
+            ))}
+            {hiddenCount > 0 ? (
+              <RosterToggle onClick={() => setShowAll(true)}>Show all · {total}</RosterToggle>
+            ) : showAll && total > VISIBLE_LIMIT ? (
+              <RosterToggle onClick={() => setShowAll(false)}>Show less</RosterToggle>
+            ) : null}
           </>
         )}
       </div>
@@ -96,13 +135,26 @@ export function ParticipantsSection({
   );
 }
 
+function RosterToggle({ onClick, children }: { onClick: () => void; children: ReactNode }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="text-caption w-full text-left transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--fg)]"
+      style={{ padding: "var(--sp-1_5) var(--sp-2)", color: "var(--fg-3)", borderRadius: "var(--radius-input)" }}
+    >
+      {children}
+    </button>
+  );
+}
+
 function HumanRow({ participant }: { participant: ChatParticipantDetail }) {
   return (
     <div
       className="flex items-center"
       style={{
         gap: "var(--sp-2_5)",
-        padding: "var(--sp-1_75) var(--sp-2)",
+        padding: "var(--sp-1_25) var(--sp-2)",
         borderRadius: "var(--radius-input)",
       }}
     >

--- a/packages/web/src/pages/workspace/right-sidebar/resize-handle.tsx
+++ b/packages/web/src/pages/workspace/right-sidebar/resize-handle.tsx
@@ -1,0 +1,102 @@
+import type { KeyboardEvent as ReactKeyboardEvent, MouseEvent as ReactMouseEvent } from "react";
+import { useCallback, useRef } from "react";
+
+/** Keyboard nudge step (px) for ArrowLeft / ArrowRight on the focused handle. */
+const KEY_STEP = 16;
+
+/**
+ * Left-edge drag handle for the right sidebar. Mirrors the proven pattern in
+ * `doc-preview-drawer.tsx`: the rail sits on the right, so dragging the handle
+ * LEFT widens it (`startWidth + (startX - clientX)`).
+ *
+ * Width changes stream live via `onWidthChange` during the drag; persistence
+ * is deferred to `onCommit` (fired once on mouse-up / per keypress) so we don't
+ * thrash localStorage on every pointer move. Double-click resets to default.
+ *
+ * Rendered only in the inline (non-overlay) rail — the narrow-viewport overlay
+ * is a fixed `min(88vw, 20rem)` and not resizable.
+ */
+export function SidebarResizeHandle({
+  width,
+  min,
+  max,
+  onWidthChange,
+  onCommit,
+  onReset,
+}: {
+  width: number;
+  min: number;
+  max: number;
+  /** Live width while dragging / nudging — caller updates state, no persist. */
+  onWidthChange: (next: number) => void;
+  /** Settle: persist the final width (mouse-up, each keypress). */
+  onCommit: (next: number) => void;
+  /** Double-click: reset to the default width (and persist). */
+  onReset: () => void;
+}) {
+  // Track the latest width without re-binding the drag listeners each render.
+  const widthRef = useRef(width);
+  widthRef.current = width;
+
+  const clamp = useCallback((w: number) => Math.min(Math.max(Math.round(w), min), max), [min, max]);
+
+  const startResize = useCallback(
+    (event: ReactMouseEvent<HTMLButtonElement>) => {
+      if (event.button !== 0) return;
+      event.preventDefault();
+      const startX = event.clientX;
+      const startWidth = widthRef.current;
+      let latest = startWidth;
+      const previousUserSelect = document.body.style.userSelect;
+      const previousCursor = document.body.style.cursor;
+      document.body.style.userSelect = "none";
+      document.body.style.cursor = "col-resize";
+
+      const onMouseMove = (moveEvent: MouseEvent) => {
+        latest = clamp(startWidth + (startX - moveEvent.clientX));
+        onWidthChange(latest);
+      };
+      const onMouseUp = () => {
+        document.body.style.userSelect = previousUserSelect;
+        document.body.style.cursor = previousCursor;
+        window.removeEventListener("mousemove", onMouseMove);
+        window.removeEventListener("mouseup", onMouseUp);
+        onCommit(latest);
+      };
+      window.addEventListener("mousemove", onMouseMove);
+      window.addEventListener("mouseup", onMouseUp);
+    },
+    [clamp, onWidthChange, onCommit],
+  );
+
+  const resizeWithKeyboard = useCallback(
+    (event: ReactKeyboardEvent<HTMLButtonElement>) => {
+      if (event.key === "ArrowLeft") {
+        event.preventDefault();
+        const next = clamp(widthRef.current + KEY_STEP);
+        onWidthChange(next);
+        onCommit(next);
+      } else if (event.key === "ArrowRight") {
+        event.preventDefault();
+        const next = clamp(widthRef.current - KEY_STEP);
+        onWidthChange(next);
+        onCommit(next);
+      }
+    },
+    [clamp, onWidthChange, onCommit],
+  );
+
+  return (
+    <button
+      aria-label="Resize chat details"
+      className="group absolute top-0 left-0 z-10 h-full w-3 -translate-x-1/2 cursor-col-resize"
+      onDoubleClick={onReset}
+      onKeyDown={resizeWithKeyboard}
+      onMouseDown={startResize}
+      title="Drag to resize · double-click to reset"
+      type="button"
+    >
+      <div className="mx-auto h-full w-px bg-border-faint opacity-60 transition-all group-hover:w-1 group-hover:bg-accent group-hover:opacity-100" />
+    </button>
+  );
+}


### PR DESCRIPTION
## What

Restructures the chat right sidebar (`ChatRightSidebar`) around the
workspace-detail product model — an inspection + light-control surface for the
selected work — **without adding modules or backend**. Same three modules
(Participants / Summary / GitHub), reorganized and re-presented.

## Changes

- **Section order**: Participants → Summary → GitHub (the live roster first; the
  read-only summary no longer occupies the most valuable top slot).
- **Participants**: agents-first; show the first 5 with a "Show all" fold;
  tighter row padding via a new `compact` prop on `AgentStatusPanel` (the
  compose status bar keeps the roomier default).
- **Summary** (renamed from "Description" — it's a live, continuously-rewritten
  summary read by whoever is reconstructing context, human or agent):
  **dynamic height** — capped at 30rem with a fade + "Show more" only when the
  GitHub section renders below it; uncapped (full body) when Summary is the last
  visible section (the common no-bindings case).
- **GitHub**: cluster rows by type (icon only: PR → Issue → Discussion →
  Commit); drop the bound-via provenance caption.
- **Width**: the inline rail is drag-resizable (left-edge handle + keyboard +
  double-click reset), default 360px, persisted globally, clamped to
  `[300, 600]`; the narrow-viewport overlay is unchanged.

## Scope / safety

Pure `packages/web`; no backend or shared-type changes.

## Tests

- New unit tests: roster partition (`partitionRoster`), GitHub type sort
  (`sortEntitiesByType`).
- Updated the right-rail DOM test for the Summary rename.
- `biome` + `typecheck` + design-token guardrail + affected suites green (33).

## Review

Self-reviewed with a high-effort multi-finder pass. One real bug found and
fixed in-branch: a self-added viewport-half width clamp diverged from the drag
handle's clamp, causing a mid-drag freeze and width-preference loss on smaller
windows — removed it, so the handle and parent now share one `[300, 600]`
clamp.

## Follow-up (not in this PR)

The resize handle mirrors the proven pattern in `doc-preview-drawer.tsx`
(~120 lines). Extracting a shared `useResizableWidth` hook would touch that
shipped component; left as a separate cleanup.

## Note

`main` advanced with unrelated server/CLI work after this branch's base; a
rebase may be needed before merge if `agent-status-panel.tsx` / `chat-view.tsx`
conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
