### PR TITLE
fix(client): settle manual suspend before resume

### DIFF
--- a/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
+++ b/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
@@ -39,6 +39,8 @@ type SessionManagerInternals = {
     receive(entry: InboxEntryWithMessage): DeliveryDecision;
     markOwned(work: DeliveryWork): boolean;
     markProcessingStarted(chatId: string, messages: SessionMessage | readonly SessionMessage[]): void;
+    prepareOperatorSuspend(chatId: string): Promise<void>;
+    hasRecoveryDebt(chatId: string): boolean;
   };
   _activeCount: number;
   acquireActiveSlot(chatId: string, message: SessionMessage | null): boolean;
@@ -580,13 +582,12 @@ describe("SessionManager edge coverage", () => {
     await sm.shutdown();
   });
 
-  it("drains same-chat buffered delivery after explicit resume at the concurrency limit", async () => {
+  it("routes same-chat delivery after manual suspend without explicit resume", async () => {
     const resume = vi.fn().mockResolvedValue("resumed-paused");
-    const inject = vi.fn().mockReturnValue({ kind: "owned", mode: "queued" });
     const paused = makeSessionRecord("chat-paused", {
       status: "suspended",
       claudeSessionId: "old-paused-session",
-      handler: handler({ resume, inject }),
+      handler: handler({ resume }),
     });
     const sm = makeManager({ concurrency: 1 });
     internals(sm).sessions.set("chat-paused", paused);
@@ -595,14 +596,11 @@ describe("SessionManager edge coverage", () => {
 
     const entry = mockEntry({ id: 101, chatId: "chat-paused" });
     await sm.dispatch(entry);
-    expect(internals(sm).pendingQueue.some((item) => item.chatId === "chat-paused" && item.message)).toBe(true);
 
-    await sm.handleCommand("chat-paused", "session:resume");
-    await Promise.resolve();
-
-    expect(resume).toHaveBeenCalledWith(undefined, "old-paused-session", expect.anything());
-    expect(inject).toHaveBeenCalledWith(
+    expect(resume).toHaveBeenCalledWith(
       expect.objectContaining({ inboxEntryId: 101, chatId: "chat-paused" }),
+      "old-paused-session",
+      expect.anything(),
       expect.anything(),
     );
     expect(internals(sm).pendingQueue.some((item) => item.chatId === "chat-paused")).toBe(false);
@@ -803,6 +801,33 @@ describe("SessionManager edge coverage", () => {
     internals(sm).triggerImmediateRetry("missing");
     internals(sm).sessions.set("chat-no-retry", makeSessionRecord("chat-no-retry", { retryAttempt: 0 }));
     internals(sm).triggerImmediateRetry("chat-no-retry");
+    await sm.shutdown();
+  });
+
+  it("does not let runRetry bypass existing recovery debt", async () => {
+    const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
+    const recovered = handler({ start: vi.fn().mockResolvedValue("should-not-start") });
+    const sm = makeManager({ handlers: [recovered], recoverChat });
+    const chatId = "chat-retry-debt";
+    const inbox = internals(sm).inboxDelivery;
+
+    inbox.receive(mockEntry({ id: 77, chatId, messageId: "msg-retry-debt" }));
+    await inbox.prepareOperatorSuspend(chatId);
+    expect(inbox.hasRecoveryDebt(chatId)).toBe(true);
+
+    const retrying = makeSessionRecord(chatId, {
+      retryAttempt: 1,
+      status: "suspended",
+      startMessage: makeMessage(chatId),
+      lastRetryReason: "rate_limit",
+    });
+    internals(sm).sessions.set(chatId, retrying);
+
+    await internals(sm).runRetry(chatId);
+
+    expect(recoverChat).toHaveBeenCalledWith(chatId);
+    expect(recovered.start).not.toHaveBeenCalled();
+    expect(retrying.retryAttempt).toBe(0);
     await sm.shutdown();
   });
 

--- a/packages/client/src/__tests__/session-manager-retry.test.ts
+++ b/packages/client/src/__tests__/session-manager-retry.test.ts
@@ -247,6 +247,43 @@ describe("SessionManager: transient retry on session start", () => {
     await sm.shutdown();
   });
 
+  it("manual suspend during retry backoff cancels the retry and leaves work for recovery", async () => {
+    vi.useFakeTimers();
+    try {
+      const failing: AgentHandler = {
+        start: vi.fn().mockRejectedValue(new FakeRateLimit("rate limited")),
+        resume: vi.fn(),
+        inject: vi.fn(),
+        suspend: vi.fn().mockResolvedValue(undefined),
+        shutdown: vi.fn().mockResolvedValue(undefined),
+      };
+      const recovered: AgentHandler = {
+        start: vi.fn().mockResolvedValue("session-after-retry"),
+        resume: vi.fn().mockResolvedValue("session-after-retry"),
+        inject: vi.fn(),
+        suspend: vi.fn().mockResolvedValue(undefined),
+        shutdown: vi.fn().mockResolvedValue(undefined),
+      };
+      const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
+      const sm = makeManager({ handlers: [failing, recovered], recoverChat });
+
+      await sm.dispatch(mockEntry({ id: 1, chatId: "chat-suspend-retry", messageId: "msg-retry-1" }));
+      await sm.handleCommand("chat-suspend-retry", "session:suspend");
+
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(recovered.start).not.toHaveBeenCalled();
+      expect(recoverChat).not.toHaveBeenCalled();
+
+      await sm.dispatch(mockEntry({ id: 2, chatId: "chat-suspend-retry", messageId: "msg-retry-2" }));
+      expect(recoverChat).toHaveBeenCalledWith("chat-suspend-retry");
+      expect(recovered.start).not.toHaveBeenCalled();
+
+      await sm.shutdown();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("queues newer retry-window messages behind the original unconsumed prefix", async () => {
     const ackEntry = vi.fn<(entryId: number) => Promise<void>>().mockResolvedValue(undefined);
     const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);

--- a/packages/client/src/__tests__/session-manager.test.ts
+++ b/packages/client/src/__tests__/session-manager.test.ts
@@ -26,6 +26,25 @@ function mockSdk(): FirstTreeHubSDK {
   } as unknown as FirstTreeHubSDK;
 }
 
+function mockRuntimeConfig(): AgentRuntimeConfig {
+  return {
+    agentId: "agent-1",
+    version: 1,
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    updatedBy: "tester",
+    payload: {
+      kind: "claude-code",
+      prompt: { append: "" },
+      model: "",
+      mcpServers: [],
+      env: [],
+      gitRepos: [],
+      resourceSkills: [],
+      reasoningEffort: "",
+    },
+  };
+}
+
 /** Create a vi-mocked WS ack callback for SessionManager tests. */
 function mockAckEntry() {
   return vi.fn<(entryId: number) => Promise<void>>().mockResolvedValue(undefined);
@@ -267,6 +286,44 @@ describe("SessionManager", () => {
     // must be skipped.
     expect(ackEntry).not.toHaveBeenCalled();
     expect(handler.start).toHaveBeenCalledTimes(1);
+
+    await sm.shutdown();
+  });
+
+  it("does not recover while an earlier same-chat delivery is normally admitting", async () => {
+    const refresh = deferred<AgentRuntimeConfig>();
+    const agentConfigCache: AgentConfigCache = {
+      get: vi.fn(),
+      refreshIfNewer: vi.fn(() => refresh.promise),
+      refresh: vi.fn(() => Promise.resolve(mockRuntimeConfig())),
+      updateUrls: vi.fn(),
+      allReferencedUrls: vi.fn(() => new Set<string>()),
+      forget: vi.fn(),
+    };
+    const recoverChat = vi.fn().mockResolvedValue(undefined);
+    const injectSpy = vi.fn().mockReturnValue({ kind: "owned", mode: "queued" });
+    const startSpy = vi.fn(async () => "session-id-mock");
+    const handler = createMockHandler({
+      start: startSpy,
+      inject: injectSpy,
+    });
+    const sm = createSessionManager({ handler, agentConfigCache, recoverChat });
+
+    const firstDispatch = sm.dispatch(mockEntry({ id: 60, chatId: "chat-admit", messageId: "msg-admit-1" }));
+    await vi.waitFor(() => expect(agentConfigCache.refreshIfNewer).toHaveBeenCalledTimes(1));
+
+    const secondDispatch = sm.dispatch(mockEntry({ id: 61, chatId: "chat-admit", messageId: "msg-admit-2" }));
+    await Promise.resolve();
+    expect(recoverChat).not.toHaveBeenCalled();
+    expect(startSpy).not.toHaveBeenCalled();
+
+    refresh.resolve(mockRuntimeConfig());
+    await firstDispatch;
+    await secondDispatch;
+
+    expect(startSpy).toHaveBeenCalledTimes(1);
+    expect(injectSpy).toHaveBeenCalledTimes(1);
+    expect(recoverChat).not.toHaveBeenCalled();
 
     await sm.shutdown();
   });
@@ -1166,7 +1223,7 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     await sm.shutdown();
   });
 
-  it("suspend recovers processingStarted entries without ACK and waits for explicit resume", async () => {
+  it("manual suspend resolves processingStarted entries and lets later input resume", async () => {
     const ackEntry = vi.fn().mockResolvedValue(undefined);
     const recoverChat = vi.fn().mockResolvedValue(undefined);
     let capturedCtx: SessionContext | undefined;
@@ -1190,34 +1247,69 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
 
     if (firstMessage) capturedCtx?.markMessagesConsumed(firstMessage);
     await sm.handleCommand("chat-suspend", "session:suspend");
-    await Promise.resolve();
-    expect(ackEntry).not.toHaveBeenCalled();
-    await vi.waitFor(() => expect(recoverChat).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(ackEntry).toHaveBeenCalledWith(30));
+    expect(ackEntry).toHaveBeenCalledTimes(1);
+    expect(recoverChat).not.toHaveBeenCalled();
 
-    await sm.dispatch(mockEntry({ id: 31, chatId: "chat-suspend", messageId: "msg-a2" }));
-    expect(recoverChat).toHaveBeenCalledTimes(1);
-    expect(resumeSpy).not.toHaveBeenCalled();
-
-    await sm.handleCommand("chat-suspend", "session:resume");
     await sm.dispatch(mockEntry({ id: 31, chatId: "chat-suspend", messageId: "msg-a2" }));
     expect(resumeSpy).toHaveBeenCalledTimes(1);
-    expect(ackEntry).not.toHaveBeenCalled();
+    expect(recoverChat).not.toHaveBeenCalled();
+    expect(ackEntry).toHaveBeenCalledTimes(1);
 
     await sm.shutdown();
   });
 
-  it("suspend leaves injected but not consumed entries unacked for recovery", async () => {
-    const ackEntry = vi.fn().mockResolvedValue(undefined);
+  it("manual suspend settlement wins the race with immediate later input", async () => {
+    const ack = deferred<void>();
+    const ackEntry = vi.fn().mockReturnValueOnce(ack.promise).mockResolvedValue(undefined);
     const recoverChat = vi.fn().mockResolvedValue(undefined);
     let capturedCtx: SessionContext | undefined;
     let firstMessage: Parameters<AgentHandler["start"]>[0] | undefined;
-    const injected: Parameters<AgentHandler["inject"]>[0][] = [];
+    const resumeSpy = vi.fn(async () => "session-id-mock");
     const handler = createMockHandler({
       async start(m, ctx) {
         firstMessage = m;
         capturedCtx = ctx;
         return "session-id-mock";
       },
+      resume: resumeSpy,
+    });
+    const { sm } = buildSm(ackEntry, handler, recoverChat);
+
+    await sm.dispatch(mockEntry({ id: 35, chatId: "chat-suspend-race", messageId: "msg-race-1" }));
+    if (firstMessage) capturedCtx?.markMessagesConsumed(firstMessage);
+
+    await sm.handleCommand("chat-suspend-race", "session:suspend");
+    await vi.waitFor(() => expect(ackEntry).toHaveBeenCalledWith(35));
+
+    const laterDispatch = sm.dispatch(mockEntry({ id: 36, chatId: "chat-suspend-race", messageId: "msg-race-2" }));
+    await Promise.resolve();
+    expect(recoverChat).not.toHaveBeenCalled();
+    expect(resumeSpy).not.toHaveBeenCalled();
+
+    ack.resolve(undefined);
+    await laterDispatch;
+
+    expect(resumeSpy).toHaveBeenCalledTimes(1);
+    expect(recoverChat).not.toHaveBeenCalled();
+
+    await sm.shutdown();
+  });
+
+  it("manual suspend defers recovery for injected but not consumed entries", async () => {
+    const ackEntry = vi.fn().mockResolvedValue(undefined);
+    const recoverChat = vi.fn().mockResolvedValue(undefined);
+    let capturedCtx: SessionContext | undefined;
+    let firstMessage: Parameters<AgentHandler["start"]>[0] | undefined;
+    const injected: Parameters<AgentHandler["inject"]>[0][] = [];
+    const resumeSpy = vi.fn(async () => "session-id-mock");
+    const handler = createMockHandler({
+      async start(m, ctx) {
+        firstMessage = m;
+        capturedCtx = ctx;
+        return "session-id-mock";
+      },
+      resume: resumeSpy,
       inject: vi.fn((m) => {
         injected.push(m);
         return { kind: "owned", mode: "queued" } as const;
@@ -1233,13 +1325,94 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     expect(injected).toHaveLength(1);
 
     await sm.handleCommand("chat-suspend-queue", "session:suspend");
-    await Promise.resolve();
-    expect(ackEntry).not.toHaveBeenCalled();
-    await vi.waitFor(() => expect(recoverChat).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(ackEntry).toHaveBeenCalledWith(32));
+    expect(ackEntry).toHaveBeenCalledTimes(1);
+    expect(ackEntry).not.toHaveBeenCalledWith(33);
+    expect(recoverChat).not.toHaveBeenCalled();
 
     await sm.dispatch(mockEntry({ id: 34, chatId: "chat-suspend-queue", messageId: "msg-q3" }));
+    expect(recoverChat).toHaveBeenCalledWith("chat-suspend-queue");
+    expect(resumeSpy).not.toHaveBeenCalled();
+
+    await sm.dispatch(mockEntry({ id: 33, chatId: "chat-suspend-queue", messageId: "msg-q2" }));
+    expect(resumeSpy).toHaveBeenCalledTimes(1);
+    expect(ackEntry).toHaveBeenCalledTimes(1);
+
+    await sm.shutdown();
+  });
+
+  it("explicit resume requests recovery when manual suspend left deferred debt", async () => {
+    const ackEntry = vi.fn().mockResolvedValue(undefined);
+    const recoverChat = vi.fn().mockResolvedValue(undefined);
+    let capturedCtx: SessionContext | undefined;
+    let firstMessage: Parameters<AgentHandler["start"]>[0] | undefined;
+    const resumeSpy = vi.fn(async () => "session-id-mock");
+    const handler = createMockHandler({
+      async start(m, ctx) {
+        firstMessage = m;
+        capturedCtx = ctx;
+        return "session-id-mock";
+      },
+      resume: resumeSpy,
+      inject: vi.fn(() => ({ kind: "owned", mode: "queued" }) as const),
+    });
+    const { sm } = buildSm(ackEntry, handler, recoverChat);
+
+    await sm.dispatch(mockEntry({ id: 37, chatId: "chat-resume-debt", messageId: "msg-rd-1" }));
+    if (firstMessage) capturedCtx?.markMessagesConsumed(firstMessage);
+    await sm.dispatch(mockEntry({ id: 38, chatId: "chat-resume-debt", messageId: "msg-rd-2" }));
+
+    await sm.handleCommand("chat-resume-debt", "session:suspend");
+    await vi.waitFor(() => expect(ackEntry).toHaveBeenCalledWith(37));
+
+    await sm.handleCommand("chat-resume-debt", "session:resume");
+    expect(recoverChat).toHaveBeenCalledWith("chat-resume-debt");
+    expect(resumeSpy).not.toHaveBeenCalled();
+
+    await sm.dispatch(mockEntry({ id: 38, chatId: "chat-resume-debt", messageId: "msg-rd-2" }));
+    expect(resumeSpy).toHaveBeenCalledTimes(1);
+    expect(ackEntry).not.toHaveBeenCalledWith(38);
+
+    await sm.shutdown();
+  });
+
+  it("explicit resume waits for in-flight manual suspend before checking deferred debt", async () => {
+    const ack = deferred<void>();
+    const ackEntry = vi.fn().mockReturnValueOnce(ack.promise).mockResolvedValue(undefined);
+    const recoverChat = vi.fn().mockResolvedValue(undefined);
+    let capturedCtx: SessionContext | undefined;
+    let firstMessage: Parameters<AgentHandler["start"]>[0] | undefined;
+    const resumeSpy = vi.fn(async () => "session-id-mock");
+    const handler = createMockHandler({
+      async start(m, ctx) {
+        firstMessage = m;
+        capturedCtx = ctx;
+        return "session-id-mock";
+      },
+      resume: resumeSpy,
+      inject: vi.fn(() => ({ kind: "owned", mode: "queued" }) as const),
+    });
+    const { sm } = buildSm(ackEntry, handler, recoverChat);
+
+    await sm.dispatch(mockEntry({ id: 39, chatId: "chat-resume-suspend-race", messageId: "msg-rsr-1" }));
+    if (firstMessage) capturedCtx?.markMessagesConsumed(firstMessage);
+    await sm.dispatch(mockEntry({ id: 40, chatId: "chat-resume-suspend-race", messageId: "msg-rsr-2" }));
+
+    await sm.handleCommand("chat-resume-suspend-race", "session:suspend");
+    await vi.waitFor(() => expect(ackEntry).toHaveBeenCalledWith(39));
+
+    const resume = sm.handleCommand("chat-resume-suspend-race", "session:resume");
+    await Promise.resolve();
+    expect(recoverChat).not.toHaveBeenCalled();
+    expect(resumeSpy).not.toHaveBeenCalled();
+
+    ack.resolve(undefined);
+    await resume;
+
+    expect(recoverChat).toHaveBeenCalledWith("chat-resume-suspend-race");
     expect(recoverChat).toHaveBeenCalledTimes(1);
-    expect(ackEntry).not.toHaveBeenCalled();
+    expect(resumeSpy).not.toHaveBeenCalled();
+    expect(ackEntry).not.toHaveBeenCalledWith(40);
 
     await sm.shutdown();
   });

--- a/packages/client/src/runtime/inbox-delivery-coordinator.ts
+++ b/packages/client/src/runtime/inbox-delivery-coordinator.ts
@@ -114,11 +114,11 @@ export class InboxDeliveryCoordinator {
     return { kind: "deliver", work: { chatId, entryId: entry.id, messageId } };
   }
 
-  shouldRecoverBeforeDispatch(chatId: string, hasHealthyLiveHandler: boolean, hasLocalSessionRecord: boolean): boolean {
+  shouldRecoverBeforeDispatch(chatId: string, hasHealthyLiveHandler: boolean, hasLocalRecoveryRisk: boolean): boolean {
     const ledger = this.ledgers.get(chatId);
     if (ledger?.recoveryActivationReady) return false;
     if (ledger?.recoveryDebt === "required" || ledger?.recoveryDebt === "running") return true;
-    return Boolean(this.config.recoverChat) && hasLocalSessionRecord && !hasHealthyLiveHandler;
+    return Boolean(this.config.recoverChat) && hasLocalRecoveryRisk && !hasHealthyLiveHandler;
   }
 
   takeRecoveryActivationReady(chatId: string): boolean {
@@ -306,6 +306,49 @@ export class InboxDeliveryCoordinator {
     if (remaining.length > 0) await this.markRecoveryDebt(chatId, reason);
   }
 
+  async prepareOperatorSuspend(chatId: string): Promise<void> {
+    const ledger = this.ledgers.get(chatId);
+    if (!ledger || ledger.entries.length === 0) return;
+
+    let resolvablePrefixCount = 0;
+    let changed = false;
+    const handledAt = Date.now();
+    for (const tracked of ledger.entries) {
+      if (tracked.phase === "terminal") {
+        resolvablePrefixCount++;
+        continue;
+      }
+      if (tracked.phase === "owned" && tracked.processingStartedAt !== undefined) {
+        tracked.phase = "terminal";
+        tracked.terminalOutcome = {
+          status: "error",
+          errorKind: "deterministic",
+          handledAt,
+        };
+        resolvablePrefixCount++;
+        changed = true;
+        continue;
+      }
+      break;
+    }
+    if (changed) this.emitWorkChanged(chatId);
+
+    if (resolvablePrefixCount > 0) {
+      const lastResolvable = ledger.entries[resolvablePrefixCount - 1];
+      if (lastResolvable) {
+        await this.ackThrough(chatId, lastResolvable.entryId, "operator_suspended:resolved_prefix", {
+          requireTerminalPrefix: true,
+          requestRecoveryOnAckFailure: false,
+        });
+      }
+    }
+
+    const remaining = this.ledgers.get(chatId)?.entries ?? [];
+    if (remaining.length > 0) {
+      await this.markRecoveryDebt(chatId, "operator_suspended:deferred_tail", { requestNow: false });
+    }
+  }
+
   prepareEvict(chatId: string, reason: string): void {
     const ledger = this.ledgers.get(chatId);
     if (!ledger || ledger.entries.length === 0) return;
@@ -344,10 +387,9 @@ export class InboxDeliveryCoordinator {
     return ledger.entries.some((entry) => entry.phase === "owned" && entry.processingStartedAt !== undefined);
   }
 
-  latestEntryId(chatId: string): number | null {
+  hasRecoveryDebt(chatId: string): boolean {
     const ledger = this.ledgers.get(chatId);
-    if (!ledger || ledger.entries.length === 0) return null;
-    return ledger.entries[ledger.entries.length - 1]?.entryId ?? null;
+    return ledger?.recoveryDebt !== undefined && ledger.recoveryDebt !== "none";
   }
 
   snapshot(chatId: string): WorkSnapshot {
@@ -367,7 +409,7 @@ export class InboxDeliveryCoordinator {
     chatId: string,
     throughEntryId: number,
     reason: string,
-    opts: { requireTerminalPrefix?: boolean } = {},
+    opts: { requireTerminalPrefix?: boolean; requestRecoveryOnAckFailure?: boolean } = {},
   ): Promise<void> {
     const ledger = this.ledgers.get(chatId);
     if (!ledger) return;
@@ -394,7 +436,7 @@ export class InboxDeliveryCoordinator {
     chatId: string,
     throughEntryId: number,
     reason: string,
-    opts: { requireTerminalPrefix?: boolean },
+    opts: { requireTerminalPrefix?: boolean; requestRecoveryOnAckFailure?: boolean },
   ): Promise<void> {
     const ledger = this.ledgers.get(chatId);
     if (!ledger || ledger.entries.length === 0) return;
@@ -447,7 +489,9 @@ export class InboxDeliveryCoordinator {
         }
       }
       this.emitWorkChanged(chatId);
-      void this.markRecoveryDebt(chatId, `${reason}:ack_failed`);
+      void this.markRecoveryDebt(chatId, `${reason}:ack_failed`, {
+        requestNow: opts.requestRecoveryOnAckFailure ?? true,
+      });
       return;
     }
 
@@ -465,7 +509,7 @@ export class InboxDeliveryCoordinator {
     this.emitWorkChanged(chatId);
   }
 
-  private async markRecoveryDebt(chatId: string, reason: string): Promise<void> {
+  private async markRecoveryDebt(chatId: string, reason: string, opts: { requestNow?: boolean } = {}): Promise<void> {
     const ledger = this.ledger(chatId);
     if (ledger.recoveryDebt !== "required") {
       ledger.recoveryDebt = "required";
@@ -475,6 +519,7 @@ export class InboxDeliveryCoordinator {
       { chatId, reason, entryIds: ledger.entries.map((entry) => entry.entryId) },
       "chat has unsettled inbox work; waiting for recovery redelivery",
     );
+    if (opts.requestNow === false) return;
     await this.requestRecovery(chatId, reason);
   }
 

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -101,12 +101,6 @@ type SlotDeliveryKind = "fresh" | "recovery" | "control";
 
 type SessionCommandType = "session:suspend" | "session:resume" | "session:terminate";
 
-type ManualPauseGuard = {
-  generation: number;
-  pausedAfterEntryId: number | null;
-  createdAt: number;
-};
-
 /**
  * Resolve the directory the runtime reads markdown doc snapshots against —
  * the same dir the handler actually hands the agent as cwd for this chat.
@@ -397,8 +391,6 @@ export class SessionManager {
   private readonly pendingQueue: PendingMessage[] = [];
   private readonly lastReportedStates = new Map<string, SessionState>();
   private readonly sessionRuntimeStates = new Map<string, RuntimeState>();
-  private readonly manualPauseGuards = new Map<string, ManualPauseGuard>();
-  private manualPauseGeneration = 0;
   /** Cache of chatId → organizationId, resolved via `getChatDetail`. A chat's
    *  org is immutable, so this is a cheap permanent memo that keeps doc-capture
    *  uploads off the hot path after the first lookup. */
@@ -456,6 +448,8 @@ export class SessionManager {
   async dispatch(entry: InboxEntryWithMessage): Promise<void> {
     const chatId = entry.chatId ?? entry.message.chatId;
     const messageId = entry.message.id;
+    const suspending = this.sessions.get(chatId)?.suspending;
+    if (suspending) await suspending;
     const isRecoveryRedelivery = this.inboxDelivery.takeRecoveryActivationReady(chatId);
 
     if (
@@ -463,7 +457,7 @@ export class SessionManager {
       this.inboxDelivery.shouldRecoverBeforeDispatch(
         chatId,
         this.hasHealthyLiveHandler(chatId) || this.hasPendingTransientRetry(chatId),
-        this.hasLocalSessionRecord(chatId),
+        this.hasLocalRecoveryRisk(chatId),
       )
     ) {
       await this.inboxDelivery.recoverIfNeeded(chatId, `before_dispatch:${entry.id}:${messageId}`);
@@ -531,11 +525,6 @@ export class SessionManager {
           await this.ensureContextTreeBinding();
         }
 
-        if (this.shouldBufferForManualPause(chatId)) {
-          this.bufferForManualPause(chatId, message, isRecoveryRedelivery ? "recovery" : "fresh");
-          return;
-        }
-
         // 5. Route by session state. ACK no longer happens inside route — the
         // entry sits in the coordinator ledger until the handler completes the
         // concrete message/batch it actually consumed. Do not await inside the
@@ -600,22 +589,33 @@ export class SessionManager {
   /** Handle a server-issued session command. Terminate drops all local state without reporting back. */
   async handleCommand(chatId: string, command: SessionCommandType): Promise<void> {
     if (command === "session:suspend") {
-      this.setManualPauseGuard(chatId);
       const session = this.sessions.get(chatId);
+      if (session) this.clearRetryState(session);
       if (session?.status === "active") {
         this.config.log.info({ chatId }, "suspend command received");
-        this.suspendSession(session);
+        this.suspendSession(session, {
+          reason: "operator_suspended",
+          ackConsumedPrefix: true,
+          operatorResolution: true,
+        });
+      } else {
+        await this.inboxDelivery.prepareOperatorSuspend(chatId);
       }
       this.projectSessionRuntime(chatId);
       return;
     }
 
     if (command === "session:resume") {
-      this.clearManualPauseGuard(chatId);
       const session = this.sessions.get(chatId);
-      if (session && session.status !== "active") {
+      if (session?.suspending) await session.suspending;
+      if (await this.recoverDebtBeforeResume(chatId, "session_resume:recovery_debt")) {
+        this.drainPendingQueue();
+        return;
+      }
+      const current = this.sessions.get(chatId);
+      if (current && current.status !== "active") {
         this.config.log.info({ chatId }, "resume command received");
-        await this.resumeSession(session, undefined, "fresh");
+        await this.resumeSession(current, undefined, "fresh");
       }
       this.projectSessionRuntime(chatId);
       this.drainPendingQueue();
@@ -623,7 +623,6 @@ export class SessionManager {
     }
 
     if (command === "session:terminate") {
-      this.clearManualPauseGuard(chatId);
       const session = this.sessions.get(chatId);
       const hadMapping = this.evictedMappings.has(chatId);
       if (!session && !hadMapping) return;
@@ -789,40 +788,26 @@ export class SessionManager {
     return Boolean(entry && entry.retryAttempt > 0);
   }
 
-  private hasLocalSessionRecord(chatId: string): boolean {
-    return this.sessions.has(chatId) || this.evictedMappings.has(chatId);
+  private hasLocalRecoveryRisk(chatId: string): boolean {
+    return this.evictedMappings.has(chatId) || this.sessions.get(chatId)?.status === "evicted";
   }
 
-  private setManualPauseGuard(chatId: string): void {
-    this.manualPauseGuards.set(chatId, {
-      generation: ++this.manualPauseGeneration,
-      pausedAfterEntryId: this.inboxDelivery.latestEntryId(chatId),
-      createdAt: Date.now(),
-    });
+  private clearRetryState(entry: SessionEntry): void {
+    if (entry.retryTimer) clearTimeout(entry.retryTimer);
+    entry.retryAttempt = 0;
+    entry.retryNextAt = null;
+    entry.retryTimer = null;
+    entry.lastRetryReason = null;
+    entry.lastRetryRawError = null;
+    entry.retryQueuedMessages = [];
   }
 
-  private clearManualPauseGuard(chatId: string): void {
-    this.manualPauseGuards.delete(chatId);
-  }
-
-  private shouldBufferForManualPause(chatId: string): boolean {
-    return this.manualPauseGuards.has(chatId);
-  }
-
-  private bufferForManualPause(chatId: string, message: SessionMessage, deliveryKind: SlotDeliveryKind): void {
-    if (
-      message.inboxEntryId !== undefined &&
-      this.pendingQueue.some((queued) => queued.message?.inboxEntryId === message.inboxEntryId)
-    ) {
-      return;
-    }
-    const guard = this.manualPauseGuards.get(chatId);
-    this.config.log.info(
-      { chatId, entryId: message.inboxEntryId, deliveryKind, pauseGeneration: guard?.generation },
-      "manual pause guard buffered inbox delivery",
-    );
-    this.pendingQueue.push({ message, chatId, deliveryKind });
+  private async recoverDebtBeforeResume(chatId: string, reason: string): Promise<boolean> {
+    if (!this.inboxDelivery.hasRecoveryDebt(chatId)) return false;
+    this.config.log.info({ chatId, reason }, "resume deferred because chat has recovery debt");
+    await this.inboxDelivery.recoverIfNeeded(chatId, reason);
     this.projectSessionRuntime(chatId);
+    return true;
   }
 
   private errorCompletionRetryReason(outcome: TurnOutcome): string | null {
@@ -919,11 +904,6 @@ export class SessionManager {
     message: SessionMessage,
     deliveryKind: SlotDeliveryKind = "fresh",
   ): Promise<void> {
-    if (this.shouldBufferForManualPause(chatId)) {
-      this.bufferForManualPause(chatId, message, deliveryKind);
-      return;
-    }
-
     const existing = this.sessions.get(chatId);
 
     // Transient retry path: keep the original start/resume message at the head
@@ -1100,6 +1080,7 @@ export class SessionManager {
     if (entry.suspending) {
       await entry.suspending;
     }
+    if (await this.recoverDebtBeforeResume(entry.chatId, "session_resume:recovery_debt")) return;
 
     // Admin-triggered resume has no provider input. It may use idle capacity,
     // but it must not preempt unrelated working turns.
@@ -1291,15 +1272,10 @@ export class SessionManager {
     const entry = this.sessions.get(chatId);
     if (!entry) return;
     if (entry.status === "active") return; // racing inject already revived it
-    if (this.shouldBufferForManualPause(chatId)) {
-      const nextDelay = 5_000;
-      entry.retryNextAt = Date.now() + nextDelay;
-      entry.retryTimer = setTimeout(() => {
-        entry.retryTimer = null;
-        this.runRetry(chatId).catch((err) => {
-          this.config.log.warn({ chatId, err }, "paused session retry rearm failed");
-        });
-      }, nextDelay);
+    if (this.inboxDelivery.hasRecoveryDebt(chatId)) {
+      this.clearRetryState(entry);
+      await this.inboxDelivery.recoverIfNeeded(chatId, "session_retry:recovery_debt");
+      this.projectSessionRuntime(chatId);
       return;
     }
 
@@ -1435,7 +1411,6 @@ export class SessionManager {
   private triggerImmediateRetry(chatId: string): void {
     const entry = this.sessions.get(chatId);
     if (!entry || entry.retryAttempt === 0) return;
-    if (this.shouldBufferForManualPause(chatId)) return;
     if (entry.retryTimer) {
       clearTimeout(entry.retryTimer);
       entry.retryTimer = null;
@@ -1448,10 +1423,6 @@ export class SessionManager {
 
     const queued = entry.retryQueuedMessages.splice(0);
     for (const message of queued) {
-      if (this.shouldBufferForManualPause(entry.chatId)) {
-        this.bufferForManualPause(entry.chatId, message, "recovery");
-        continue;
-      }
       this.setCurrentTrigger(entry.chatId, message);
       try {
         if (
@@ -1572,15 +1543,17 @@ export class SessionManager {
 
   private suspendSession(
     entry: SessionEntry,
-    opts: { reason: string; ackConsumedPrefix: boolean; drainQueue?: boolean } = {
+    opts: { reason: string; ackConsumedPrefix: boolean; drainQueue?: boolean; operatorResolution?: boolean } = {
       reason: "session_suspended",
       ackConsumedPrefix: true,
       drainQueue: true,
     },
   ): void {
-    const prepare = opts.ackConsumedPrefix
-      ? this.inboxDelivery.prepareSuspend(entry.chatId, opts.reason)
-      : Promise.resolve(this.inboxDelivery.prepareEvict(entry.chatId, opts.reason));
+    const prepare = opts.operatorResolution
+      ? this.inboxDelivery.prepareOperatorSuspend(entry.chatId)
+      : opts.ackConsumedPrefix
+        ? this.inboxDelivery.prepareSuspend(entry.chatId, opts.reason)
+        : Promise.resolve(this.inboxDelivery.prepareEvict(entry.chatId, opts.reason));
     entry.status = "suspended";
     this._activeCount--;
     // Clear per-session runtime state on suspend
@@ -1606,7 +1579,7 @@ export class SessionManager {
 
   private drainPendingQueue(): void {
     if (this.pendingQueue.length === 0) return;
-    const nextIndex = this.pendingQueue.findIndex((queued) => !this.shouldBufferForManualPause(queued.chatId));
+    const nextIndex = this.pendingQueue.findIndex((queued) => !this.inboxDelivery.hasRecoveryDebt(queued.chatId));
     if (nextIndex < 0) return;
     const next = this.pendingQueue[nextIndex];
     if (!next) return;


### PR DESCRIPTION
## Summary
- Remove the manual pause guard and resolve manually suspended processing-started inbox work through the coordinator.
- Defer unsafe tails to recovery without immediately bouncing the suspended session.
- Ensure resume/retry paths fail closed to recovery debt after in-flight suspend settlement, including the explicit resume race.

## Tests
- `pnpm --filter @first-tree/client exec vitest run src/__tests__/session-manager.test.ts --maxWorkers=2`
- `pnpm --filter @first-tree/client exec vitest run src/__tests__/session-manager.test.ts src/__tests__/session-manager-edge-coverage.test.ts src/__tests__/session-runtime-state.test.ts src/__tests__/session-manager-retry.test.ts --maxWorkers=2`
- `pnpm check`
- `pnpm typecheck`
- `pnpm --filter @first-tree/client exec vitest run --maxWorkers=2`
- `git diff --check`
