### PR TITLE
fix(web): duplicate Participants in chat right sidebar (unique section keys)

### DIFF
--- a/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
@@ -1475,5 +1475,38 @@ describe("ChatView", () => {
 
       await act(async () => root.unmount());
     });
+
+    // Regression: the rail keys its stateful sections (Participants, Summary) by
+    // chatId to reset fold state on switch. Those keys MUST be per-section unique
+    // — keying both with the bare chatId made them collide, and React duplicated
+    // the sections (two "Participants" stacked). Guard by asserting React emits no
+    // "two children with the same key" console error while the rail renders.
+    it("renders the rail's keyed sections without a duplicate-key collision", async () => {
+      const { ChatView } = await import("../chat-view.js");
+      const withDescription = chatDetail({ description: DESCRIPTION_MD });
+      chatMocks.getChat.mockResolvedValue(withDescription);
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const { container, root } = await renderDom(
+        <ChatView agentId="agent-1" chatId="chat-1" />,
+        (queryClient) => seedChat(queryClient, withDescription),
+        "/",
+      );
+      await waitForCondition(() => sidebarOpen(container), "Expected rail to auto-open for a chat with a description");
+
+      const dupKeyWarnings = errorSpy.mock.calls.filter((args) =>
+        args.some((a) => typeof a === "string" && a.includes("two children with the same key")),
+      );
+      expect(dupKeyWarnings).toEqual([]);
+
+      // And exactly one of each keyed section is in the DOM.
+      const eyebrows = [...container.querySelectorAll('aside[aria-label="Chat details"] .text-eyebrow')].map((e) =>
+        (e.textContent ?? "").trim(),
+      );
+      expect(eyebrows.filter((t) => t.startsWith("Participants"))).toHaveLength(1);
+      expect(eyebrows.filter((t) => t.startsWith("Summary"))).toHaveLength(1);
+
+      errorSpy.mockRestore();
+      await act(async () => root.unmount());
+    });
   });
 });

--- a/packages/web/src/pages/workspace/right-sidebar/index.tsx
+++ b/packages/web/src/pages/workspace/right-sidebar/index.tsx
@@ -136,13 +136,14 @@ export function ChatRightSidebar({
         />
       )}
       {/* Key the sections that hold local fold state (Participants' "Show all",
-          Summary's "Show more") by chatId. ChatView is NOT remounted on chat
-          switch — it refetches by chatId — so without this the expanded/showAll
-          UI state would leak from one chat into the next. The rail shell itself
-          is intentionally NOT keyed: its width is a global preference. */}
+          Summary's "Show more") by chatId so it resets on chat switch — ChatView
+          is NOT remounted on switch, it refetches by chatId. The keys MUST be
+          per-section-unique (not the bare chatId on both), or the two siblings
+          collide on the same key and React duplicates/omits them. The rail shell
+          itself is intentionally NOT keyed: its width is a global preference. */}
       <div className="flex-1 overflow-y-auto">
         <ParticipantsSection
-          key={chatId}
+          key={`participants:${chatId}`}
           chatId={chatId}
           participants={participants}
           participantsLoading={participantsLoading}
@@ -150,7 +151,7 @@ export function ChatRightSidebar({
           onAdded={onAdded}
           readOnly={readOnly}
         />
-        <DescriptionSection key={chatId} description={description} capped={summaryCapped} />
+        <DescriptionSection key={`summary:${chatId}`} description={description} capped={summaryCapped} />
         <GitHubSection chatId={chatId} />
       </div>
     </aside>


### PR DESCRIPTION
## Bug

The chat right sidebar intermittently rendered **two `Participants` sections**
stacked (one mid-load without agent status, one with), reported with a
screenshot. Introduced by the keying added in #1105 (`9d0dc07a`).

## Root cause

`9d0dc07a` keyed the fold-stateful sections by chatId so their `Show all` /
`Show more` state resets on chat switch. But it keyed **both** siblings with the
**bare `chatId`**:

```tsx
<ParticipantsSection key={chatId} ... />
<DescriptionSection  key={chatId} ... />
```

Two siblings with the same key violate React's unique-key rule. React's child
reconciliation collides on the duplicate key and **duplicates/omits** the
sections. Confirmed in a dev build — React logs, repeatedly:

> `Encountered two children with the same key, a22dbff1-…. … Non-unique keys may cause children to be duplicated and/or omitted.`

(Staging is a production build, so the warning is stripped — which is why it
wasn't visible there.)

## Fix

Make the keys per-section unique, preserving the per-chat reset they were added
for:

```tsx
<ParticipantsSection key={`participants:${chatId}`} ... />
<DescriptionSection  key={`summary:${chatId}`} ... />
```

## Verification

- Dev build (proxied to staging): the `two children with the same key` console
  error is **gone**; exactly **1 Participants + 1 Summary** render.
- Added a DOM regression test that spies on `console.error` and asserts no
  duplicate-key warning while the rail renders. **Verified it fails on the buggy
  keys and passes on the fix.**
- `biome` + `typecheck` + affected suites green (35).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
