### PR TITLE
refactor(chat): drop the watcher-mention red-dot branch

### DIFF
--- a/packages/server/src/__tests__/me-chat-service.test.ts
+++ b/packages/server/src/__tests__/me-chat-service.test.ts
@@ -7,9 +7,12 @@
  *      appear in `inbox_entries` even when a chat is messaged.
  *   2. Mention candidates resolve from speaker rows only
  *      (`access_mode = 'speaker'`) — watchers cannot be `@`-mentioned.
- *   3. Mention propagation increments the watcher's
- *      `chat_user_state.unread_mention_count` when the watched managed
- *      agent is mentioned.
+ *   3. Mention propagation increments `chat_user_state.unread_mention_count`
+ *      ONLY for a directly-mentioned human speaker. Mentioning a watched
+ *      managed (non-human) agent wakes it but does NOT bump its
+ *      manager-watcher's count — red dots are a direct-human signal. (The
+ *      watcher count still bumps via an `agent-final-text` send by the
+ *      managed agent; that path is unchanged.)
  *   4. `chats.last_message_at` / `last_message_preview` advance on each send.
  *   5. `joinAsParticipant` preserves `chat_user_state` (last_read_at +
  *      unread_mention_count survive the watcher → speaker flip).
@@ -655,8 +658,8 @@ describe("chat-first workspace service layer", () => {
     // chat_membership.access_mode = 'speaker', so a watcher's name resolves
     // to nothing even when typed verbatim. We pin this in a group chat
     // (≥3 speakers) so the direct-chat auto-mention path is not exercised
-    // here; admin watches no one in this chat, so the manager-of-mentioned
-    // branch can't fire either, isolating the name-resolution invariant.
+    // here, isolating the name-resolution invariant: a watcher's name simply
+    // does not resolve to a mention candidate.
     const app = getApp();
     const admin = await createTestAdmin(app);
     const peer = await createTestAgent(app, { name: `peer-mc-${crypto.randomUUID().slice(0, 6)}` });
@@ -698,6 +701,43 @@ describe("chat-first workspace service layer", () => {
     // Either the row was never created (lazy materialisation, no event
     // touched it) or its count stayed at zero — the @-name path cannot
     // reach a watcher, by design.
+    expect(adminStateRow?.unread_mention_count ?? 0).toBe(0);
+  });
+
+  it("mentioning a managed non-human agent does NOT bump its manager-watcher's red dot", async () => {
+    // Negative regression for the removed watcher-of-mentioned-agent branch.
+    // A human (admin) manages `managed`; another participant @-mentions
+    // `managed`. The managed agent is woken, but red dots are a direct-human
+    // signal, so admin's manager-watcher `unread_mention_count` stays 0.
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const { createAgent } = await import("../services/agent.js");
+    const managed = await createAgent(app.db, {
+      name: `mng-neg-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "MngNeg",
+      managerId: admin.memberId,
+      organizationId: admin.organizationId,
+      clientId: undefined,
+    });
+    const peer = await createTestAgent(app, { name: `peer-neg-${crypto.randomUUID().slice(0, 6)}` });
+    const { chatId } = await createMeChat(app.db, peer.agent.uuid, peer.organizationId, {
+      participantIds: [managed.uuid],
+    });
+
+    // peer @-mentions the managed agent (which is a speaker of this chat).
+    await sendMessage(app.db, chatId, peer.agent.uuid, {
+      source: "api",
+      format: "text",
+      content: `@${managed.name} please review`,
+      metadata: { mentions: [managed.uuid] },
+    });
+
+    // admin (manager-watcher of `managed`) gets NO red dot.
+    const [adminStateRow] = await app.db.execute<{ unread_mention_count: number | null }>(sql`
+      SELECT unread_mention_count FROM chat_user_state
+       WHERE chat_id = ${chatId} AND agent_id = ${admin.humanAgentUuid}
+    `);
     expect(adminStateRow?.unread_mention_count ?? 0).toBe(0);
   });
 

--- a/packages/server/src/__tests__/me-chat-service.test.ts
+++ b/packages/server/src/__tests__/me-chat-service.test.ts
@@ -280,13 +280,14 @@ describe("chat-first workspace service layer", () => {
       participantIds: [managed.uuid],
     });
 
-    // Direct send via sendMessage (which itself calls applyAfterFanOut), with
-    // an explicit mention of `managed` to trigger watcher propagation.
-    await sendMessage(app.db, chatId, peer.agent.uuid, {
+    // The watcher (admin, manager of `managed`) red dot now bumps only via an
+    // agent-final-text send by the managed agent — a non-human mention no
+    // longer raises a watcher red dot. applyAfterFanOut still runs.
+    await sendMessage(app.db, chatId, managed.uuid, {
       source: "api",
       format: "text",
-      content: `@${managed.name} Please review`,
-      metadata: { mentions: [managed.uuid] },
+      content: "Please review",
+      purpose: "agent-final-text",
     });
 
     // chats projection updated. Raw `db.execute` returns timestamptz as
@@ -327,11 +328,11 @@ describe("chat-first workspace service layer", () => {
     const { chatId } = await createMeChat(app.db, peer.agent.uuid, peer.organizationId, {
       participantIds: [managed.uuid],
     });
-    await sendMessage(app.db, chatId, peer.agent.uuid, {
+    await sendMessage(app.db, chatId, managed.uuid, {
       source: "api",
       format: "text",
-      content: `@${managed.name} hi`,
-      metadata: { mentions: [managed.uuid] },
+      content: "hi",
+      purpose: "agent-final-text",
     });
 
     // Pre: counter is 1+
@@ -483,13 +484,13 @@ describe("chat-first workspace service layer", () => {
     const { chatId } = await createMeChat(app.db, peer.agent.uuid, peer.organizationId, {
       participantIds: [managed.uuid],
     });
-    // Bump the watcher's unread counter via an explicit mention of the
-    // managed agent.
-    await sendMessage(app.db, chatId, peer.agent.uuid, {
+    // Bump the watcher's unread counter via an agent-final-text send by the
+    // managed agent (mentioning a managed agent no longer bumps the watcher).
+    await sendMessage(app.db, chatId, managed.uuid, {
       source: "api",
       format: "text",
-      content: `@${managed.name} ping`,
-      metadata: { mentions: [managed.uuid] },
+      content: "ping",
+      purpose: "agent-final-text",
     });
 
     // Pre-state: admin's chat_user_state row has unread_mention_count >= 1.

--- a/packages/server/src/services/chat-projection.ts
+++ b/packages/server/src/services/chat-projection.ts
@@ -14,9 +14,8 @@
  *      rows are sticky and intentionally untouched.
  *
  *   3. Unread counter propagation: increment `unread_mention_count` via a
- *      single UNION'd UPSERT. Branches: mentioned speakers (≠ sender),
- *      watchers whose managed non-human agent was mentioned, plus —
- *      when `bumpForAgentFinalText` is set — human speakers (≠ sender)
+ *      single UNION'd UPSERT. Branches: mentioned HUMAN speakers (≠ sender),
+ *      plus — when `bumpForAgentFinalText` is set — human speakers (≠ sender)
  *      and watchers whose managed agent IS the sender. UNION dedupes any
  *      target row that satisfies more than one branch so the counter
  *      advances by exactly +1 per message. The final-text branch
@@ -155,12 +154,12 @@ export async function applyAfterFanOut(tx: DbLike, input: ApplyAfterFanOutInput)
   // the UPSERT to keep `+1 per message` semantics intact:
   //
   //   A. Mention propagation (always on when the message has explicit
-  //      mentions). Speaker branch: mentioned ∩ chat speakers, sender
-  //      excluded, HUMAN targets only — the unread-mention red dot is a
-  //      human-attention signal, so mentioning a non-human agent (a delegate,
-  //      a routed GitHub card target) wakes it via the inbox notify path but
-  //      raises no red dot. Watcher branch: watchers whose managed non-human
-  //      agent was mentioned.
+  //      mentions). Single branch: mentioned ∩ chat speakers, sender excluded,
+  //      HUMAN targets only — the unread-mention red dot is a human-attention
+  //      signal, so mentioning a non-human agent (a delegate, a routed GitHub
+  //      card target) wakes it via the inbox notify path but raises no red dot,
+  //      and neither does the agent's human manager-watcher. Red dots are
+  //      reserved for a human called directly by name.
   //
   //   B. Agent-final-text bump (only when `bumpForAgentFinalText`).
   //      `purpose === "agent-final-text"` carries empty mentions by
@@ -192,6 +191,12 @@ export async function applyAfterFanOut(tx: DbLike, input: ApplyAfterFanOutInput)
       mentionedAgentIds.map((id) => sql`${id}`),
       sql`, `,
     );
+    // Unread-mention red dots fire ONLY for a directly-@-mentioned human
+    // speaker. Mentioning a non-human agent (a delegate, a routed card target)
+    // wakes that agent via the inbox notify path but raises no red dot — and
+    // neither does the agent's human manager-watcher. Red dots are reserved
+    // for a human being called by name; a managed agent being mentioned is not
+    // that signal.
     branches.push(sql`
       SELECT cm.chat_id, cm.agent_id
         FROM chat_membership cm
@@ -201,17 +206,6 @@ export async function applyAfterFanOut(tx: DbLike, input: ApplyAfterFanOutInput)
          AND cm.agent_id    IN (${mentionedList})
          AND cm.agent_id   <> ${senderId}
          AND a.type         = 'human'
-    `);
-    branches.push(sql`
-      SELECT cm.chat_id, cm.agent_id
-        FROM chat_membership cm
-        JOIN members m  ON m.agent_id    = cm.agent_id
-        JOIN agents  a  ON a.manager_id  = m.id
-       WHERE cm.chat_id     = ${chatId}
-         AND cm.access_mode = 'watcher'
-         AND a.uuid         IN (${mentionedList})
-         AND a.type        <> 'human'
-         AND m.status       = 'active'
     `);
   }
 

--- a/packages/server/src/services/message.ts
+++ b/packages/server/src/services/message.ts
@@ -517,8 +517,8 @@ async function sendMessageInner(
     if (!msg) throw new Error("Unexpected: INSERT RETURNING produced no row");
 
     // 6. Chat-first workspace projection (append-only, post-fan-out).
-    //    Updates chats.last_message_*, increments speaker + watcher mention
-    //    counters. New code; no existing path is modified — see
+    //    Updates chats.last_message_*, increments the directly-mentioned human
+    //    speaker's unread-mention counter (plus the agent-final-text bump). See
     //    first-tree-context:agent-hub/web-console.md "Risk Constraints".
     // Chat-list preview: prefer string content (text/markdown) verbatim;
     // fall back to the caption of a batched image send (`format: "file"`


### PR DESCRIPTION
## What
Completes the "unread red dot = a human called directly by name" rule (started in #1102, owner-directed). Removes the projection branch that bumped a **human watcher's** red dot when their **managed non-human agent** was @-mentioned.

- `chat-projection.ts` — the mention propagation now has a **single branch**: directly-mentioned **human speakers** (≠ sender). The watcher-of-mentioned-agent branch is gone.
- The **agent-final-text** watcher bump (agent finished → manager red dot) is **unchanged** — that's a distinct signal, not a mention.
- The 3 `me-chat-service` tests that seeded the watcher counter via a mention now seed it via an agent-final-text send (the remaining bump path).

## Why
A managed agent being @-mentioned is not a "human attention" event. With native-mention GitHub delivery (#1104) now waking delegates via `metadata.mentions`, the old branch would raise the delegate-manager's red dot on **every** routed card. Cutting it fully realizes the human-only red-dot rule (owner direction).

## Tests
Full server suite green: **1458 passed**.

## Note
This finishes the red-dot rule: red dots now fire **only** for a direct human @-mention (plus the unchanged agent-final-text bump). If we want this captured in the tree (`system/cloud/chat/messaging.md`), I can open a companion tree note — flag me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)