### PR TITLE
fix(runtime): align session guardrails and idle yield events

### DIFF
--- a/packages/client/src/__tests__/config.test.ts
+++ b/packages/client/src/__tests__/config.test.ts
@@ -1,6 +1,7 @@
 import { writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { DEFAULT_AGENT_CONCURRENCY, DEFAULT_AGENT_MAX_SESSIONS } from "@first-tree/shared/config";
 import { describe, expect, it } from "vitest";
 import { loadRuntimeConfig } from "../runtime/config.js";
 
@@ -29,9 +30,9 @@ agents:
     // Defaults are kept in lock-step with `@first-tree/shared`
     // `agentConfigSchema` — see runtime/config.ts. The shipped CLI goes
     // through that schema; this YAML loader is the legacy back-door.
-    expect(nova?.concurrency).toBe(5);
+    expect(nova?.concurrency).toBe(DEFAULT_AGENT_CONCURRENCY);
     expect(nova?.session.idle_timeout).toBe(300);
-    expect(nova?.session.max_sessions).toBe(10);
+    expect(nova?.session.max_sessions).toBe(DEFAULT_AGENT_MAX_SESSIONS);
     expect(nova?.session.working_grace_seconds).toBe(3600);
   });
 

--- a/packages/client/src/__tests__/session-manager.test.ts
+++ b/packages/client/src/__tests__/session-manager.test.ts
@@ -1,4 +1,4 @@
-import type { AgentRuntimeConfig } from "@first-tree/shared";
+import type { AgentRuntimeConfig, SessionEvent } from "@first-tree/shared";
 import type pino from "pino";
 import { describe, expect, it, vi } from "vitest";
 import type { AgentConfigCache } from "../runtime/agent-config-cache.js";
@@ -107,6 +107,7 @@ function createSessionManager(opts: {
   log?: pino.Logger;
   agentConfigCache?: AgentConfigCache;
   recoverChat?: (chatId: string) => Promise<void>;
+  onSessionEvent?: (chatId: string, event: SessionEvent) => void;
 }) {
   const handler = opts.handler ?? createMockHandler();
   const factory: HandlerFactory = opts.handlerFactory ?? (() => handler);
@@ -139,6 +140,7 @@ function createSessionManager(opts: {
     ackEntry: opts.ackEntry ?? mockAckEntry(),
     recoverChat: opts.recoverChat,
     agentConfigCache: opts.agentConfigCache,
+    onSessionEvent: opts.onSessionEvent,
   });
 }
 
@@ -962,6 +964,7 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
 
   it("uses an idle active session before preempting a working session for concurrency", async () => {
     const ackEntry = vi.fn().mockResolvedValue(undefined);
+    const events: Array<{ chatId: string; event: SessionEvent }> = [];
     const handlers = new Map<string, AgentHandler>();
     const contexts = new Map<string, SessionContext>();
     const messages = new Map<string, SessionMessage>();
@@ -981,6 +984,7 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     const sm = createSessionManager({
       ackEntry,
       handlerFactory: factory,
+      onSessionEvent: (chatId, event) => events.push({ chatId, event }),
       concurrency: 2,
       session: { idle_timeout: 300, max_sessions: 10, working_grace_seconds: 3600, reconcile_interval_seconds: 300 },
     });
@@ -998,6 +1002,16 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     expect(handlers.get("chat-working")?.suspend).not.toHaveBeenCalled();
     expect(handlers.has("chat-new")).toBe(true);
     expect(ackEntry).toHaveBeenCalledWith(2);
+    expect(
+      events.some(
+        ({ chatId, event }) =>
+          chatId === "chat-idle" &&
+          event.kind === "error" &&
+          event.payload.source === "runtime" &&
+          event.payload.message.includes("resilience.session.preempted:") &&
+          event.payload.message.includes("concurrency_idle_yield"),
+      ),
+    ).toBe(false);
 
     await sm.shutdown();
   });

--- a/packages/client/src/runtime/config.ts
+++ b/packages/client/src/runtime/config.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from "node:fs";
+import { DEFAULT_AGENT_CONCURRENCY, DEFAULT_AGENT_MAX_SESSIONS } from "@first-tree/shared/config";
 import { parse as parseYaml } from "yaml";
 import { z } from "zod";
 
@@ -18,7 +19,7 @@ import { z } from "zod";
 const sessionConfigSchema = z
   .object({
     idle_timeout: z.number().int().positive().default(300),
-    max_sessions: z.number().int().positive().default(10),
+    max_sessions: z.number().int().positive().default(DEFAULT_AGENT_MAX_SESSIONS),
     /**
      * Upper bound on how long `working` / `blocked` may keep a session
      * alive past `idle_timeout` before force-suspend. See `evictIdle` in
@@ -35,7 +36,7 @@ const agentSlotConfigSchema = z
     agentId: z.string().min(1),
     type: z.string().min(1),
     session: sessionConfigSchema.prefault({}),
-    concurrency: z.number().int().positive().default(5),
+    concurrency: z.number().int().positive().default(DEFAULT_AGENT_CONCURRENCY),
   })
   .passthrough();
 

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -1475,10 +1475,6 @@ export class SessionManager {
         { chatId: idleVictim.chatId, requesterChatId: chatId },
         "idle session yielded for concurrency",
       );
-      this.emitResilienceEvent(idleVictim.chatId, "resilience.session.preempted", {
-        reason: "concurrency_idle_yield",
-        requesterChatId: chatId,
-      });
       this.suspendSession(idleVictim, { reason: "concurrency_idle_yield", ackConsumedPrefix: true, drainQueue: false });
       return true;
     }

--- a/packages/shared/src/config/__tests__/agent-config.test.ts
+++ b/packages/shared/src/config/__tests__/agent-config.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { agentConfigSchema, DEFAULT_AGENT_CONCURRENCY, DEFAULT_AGENT_MAX_SESSIONS } from "../agent-config.js";
+import { buildZodSchema } from "../resolver.js";
+
+describe("agentConfigSchema", () => {
+  it("defaults session guardrails to effectively unbounded product values", () => {
+    expect(DEFAULT_AGENT_CONCURRENCY).toBe(99);
+    expect(DEFAULT_AGENT_MAX_SESSIONS).toBe(99);
+
+    const parsed = buildZodSchema(agentConfigSchema).parse({ agentId: "agent-1" });
+
+    expect(parsed).toMatchObject({
+      concurrency: DEFAULT_AGENT_CONCURRENCY,
+      session: {
+        max_sessions: DEFAULT_AGENT_MAX_SESSIONS,
+      },
+    });
+  });
+});

--- a/packages/shared/src/config/__tests__/index.test.ts
+++ b/packages/shared/src/config/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { agentConfigSchema } from "../agent-config.js";
+import { agentConfigSchema, DEFAULT_AGENT_CONCURRENCY, DEFAULT_AGENT_MAX_SESSIONS } from "../agent-config.js";
 import { clientConfigSchema, getClientConfig, updatePolicySchema } from "../client-config.js";
 import * as config from "../index.js";
 import { loadAgents } from "../loader.js";
@@ -25,6 +25,8 @@ import { getConfig, resetConfig } from "../singleton.js";
 describe("config barrel", () => {
   it("re-exports config schemas and helpers from the public entry point", () => {
     expect(config.agentConfigSchema).toBe(agentConfigSchema);
+    expect(config.DEFAULT_AGENT_CONCURRENCY).toBe(DEFAULT_AGENT_CONCURRENCY);
+    expect(config.DEFAULT_AGENT_MAX_SESSIONS).toBe(DEFAULT_AGENT_MAX_SESSIONS);
     expect(config.clientConfigSchema).toBe(clientConfigSchema);
     expect(config.getClientConfig).toBe(getClientConfig);
     expect(config.updatePolicySchema).toBe(updatePolicySchema);

--- a/packages/shared/src/config/agent-config.ts
+++ b/packages/shared/src/config/agent-config.ts
@@ -2,6 +2,9 @@ import { z } from "zod";
 import { defineConfig, field } from "./schema.js";
 import type { InferConfig } from "./types.js";
 
+export const DEFAULT_AGENT_CONCURRENCY = 99;
+export const DEFAULT_AGENT_MAX_SESSIONS = 99;
+
 /**
  * Agent config layout on disk: `$FIRST_TREE_HOME/config/agents/<name>/agent.yaml`.
  *
@@ -16,10 +19,10 @@ export const agentConfigSchema = defineConfig({
   agentId: field(z.string().min(1)),
   /** Runtime handler type (e.g. "claude-code"). NOT the agent business type. */
   runtime: field(z.string().default("claude-code")),
-  concurrency: field(z.number().int().positive().default(5)),
+  concurrency: field(z.number().int().positive().default(DEFAULT_AGENT_CONCURRENCY)),
   session: {
     idle_timeout: field(z.number().int().positive().default(300)),
-    max_sessions: field(z.number().int().positive().default(10)),
+    max_sessions: field(z.number().int().positive().default(DEFAULT_AGENT_MAX_SESSIONS)),
     // Upper bound on how long a session may stay `working`/`blocked` past
     // `idle_timeout` before the runtime force-suspends it. Protects long
     // thinking / large message generation from idle eviction while still

--- a/packages/shared/src/config/index.ts
+++ b/packages/shared/src/config/index.ts
@@ -1,7 +1,7 @@
 // Schema declaration utilities
 
 export type { AgentConfig } from "./agent-config.js";
-export { agentConfigSchema } from "./agent-config.js";
+export { agentConfigSchema, DEFAULT_AGENT_CONCURRENCY, DEFAULT_AGENT_MAX_SESSIONS } from "./agent-config.js";
 export type { ClientConfig } from "./client-config.js";
 export { clientConfigSchema, getClientConfig, updatePolicySchema } from "./client-config.js";
 // Agent loader


### PR DESCRIPTION
## Summary

- align agent session guardrail defaults to `concurrency = 99` and `session.max_sessions = 99`
- share those defaults between the shared agent config schema and the legacy client runtime loader
- stop emitting a tagged `kind: \"error\"` session event for idle `concurrency_idle_yield` while preserving the suspend/yield behavior

## Validation

- [x] `pnpm check`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- focused: `pnpm --dir packages/shared exec vitest run --passWithNoTests --maxWorkers=2 src/config/__tests__/agent-config.test.ts src/config/__tests__/index.test.ts`
- focused: `pnpm --dir packages/client exec vitest run --passWithNoTests --maxWorkers=2 src/__tests__/config.test.ts src/__tests__/session-manager.test.ts`

## Change Surface

- [ ] `apps/cli` public CLI or help output
- [ ] tree onboarding / binding / inspection behavior
- [ ] shipped or planned skill topology
- [ ] docs or contributor-facing repository metadata
- [ ] CI / packaging / release plumbing

## Notes

- package or install behavior changes: none
- docs or tests updated to match: tests updated for shared defaults, legacy loader defaults, and idle yield event behavior
- follow-up work: none for this scoped fix