### PR TITLE
fix: reserve pixel avatars for non-human agents

### DIFF
--- a/packages/web/src/pages/agent-detail/__tests__/appearance-identity-options-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/appearance-identity-options-dom.test.tsx
@@ -362,6 +362,35 @@ describe("ProfileEditDialog (merged identity + appearance)", () => {
     await act(async () => root.unmount());
   });
 
+  it("offers the pixel-avatar generator only for non-human agents (humans use their GitHub avatar)", async () => {
+    const { ProfileEditDialog } = await import("../profile-edit-dialog.js");
+
+    // Non-human agent: pixel avatar is its identity, so the generator shows.
+    const nonHuman = await renderDom(
+      <ProfileEditDialog agent={agent({ type: "agent" })} open onOpenChange={vi.fn()} onSave={vi.fn()} />,
+    );
+    expect(document.body.textContent).toContain("Pixel avatar");
+    expect(buttonByText(document.body, "Generate")).not.toBeNull();
+    await act(async () => nonHuman.root.unmount());
+
+    // Human agent: pixel avatars are reserved for non-human agents, so the
+    // generator is hidden — humans fall back to their GitHub avatar.
+    document.body.innerHTML = "";
+    const human = await renderDom(
+      <ProfileEditDialog
+        agent={agent({ uuid: "human-1", name: "bestony", displayName: "Bestony", type: "human" })}
+        open
+        onOpenChange={vi.fn()}
+        onSave={vi.fn()}
+      />,
+    );
+    expect(document.body.textContent).not.toContain("Pixel avatar");
+    expect(buttonByText(document.body, "Generate")).toBeNull();
+    // The custom-image upload path stays available to humans.
+    expect(buttonByText(document.body, "Upload image")).not.toBeNull();
+    await act(async () => human.root.unmount());
+  });
+
   it("edits human visibility + delegate, and disables visibility for non-owners", async () => {
     const { ProfileEditDialog } = await import("../profile-edit-dialog.js");
     const human = agent({

--- a/packages/web/src/pages/agent-detail/profile-edit-dialog.tsx
+++ b/packages/web/src/pages/agent-detail/profile-edit-dialog.tsx
@@ -287,7 +287,9 @@ export function ProfileEditDialog({ agent, open, onOpenChange, onSave, onRefresh
         <DialogHeader>
           <DialogTitle>Edit profile</DialogTitle>
           <DialogDescription>
-            Avatar changes (image or pixel avatar) save immediately. Other details save when you click Save.
+            {isHuman
+              ? "Avatar changes (image) save immediately. Other details save when you click Save."
+              : "Avatar changes (image or pixel avatar) save immediately. Other details save when you click Save."}
           </DialogDescription>
         </DialogHeader>
         <form onSubmit={submit} className="space-y-5">
@@ -393,43 +395,50 @@ export function ProfileEditDialog({ agent, open, onOpenChange, onSave, onRefresh
             </p>
             {imageError && <p className="text-body text-destructive">{imageError}</p>}
           </div>
-          <div className="space-y-2">
-            <Label>Pixel avatar</Label>
-            <div className="flex flex-wrap items-center gap-2">
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={rollPixelCandidates}
-                disabled={uploading || saving}
-              >
-                {pixelCandidates.length ? "Shuffle" : "Generate"}
-              </Button>
-              {pixelCandidates.map((candidate, index) => (
-                <button
-                  key={candidate.seed}
+          {/* Pixel avatars are a non-human-agent identity. Human agents
+              represent real people and use their GitHub avatar (resolved
+              server-side via the backing user's avatar URL), so the
+              pixel-avatar generator is hidden for them — offering it would let
+              a baked identicon override the GitHub avatar. */}
+          {!isHuman && (
+            <div className="space-y-2">
+              <Label>Pixel avatar</Label>
+              <div className="flex flex-wrap items-center gap-2">
+                <Button
                   type="button"
-                  onClick={() => applyPixelAvatar(candidate)}
+                  variant="outline"
+                  size="sm"
+                  onClick={rollPixelCandidates}
                   disabled={uploading || saving}
-                  aria-label={`Use pixel avatar ${index + 1}`}
-                  title="Use this pixel avatar"
-                  className="rounded-full focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1"
-                  style={{
-                    display: "inline-flex",
-                    padding: 0,
-                    border: "none",
-                    background: "transparent",
-                    cursor: "pointer",
-                  }}
                 >
-                  <Identicon seed={candidate.seed} size={40} color={`var(--avatar-hue-${candidate.hueIdx})`} />
-                </button>
-              ))}
+                  {pixelCandidates.length ? "Shuffle" : "Generate"}
+                </Button>
+                {pixelCandidates.map((candidate, index) => (
+                  <button
+                    key={candidate.seed}
+                    type="button"
+                    onClick={() => applyPixelAvatar(candidate)}
+                    disabled={uploading || saving}
+                    aria-label={`Use pixel avatar ${index + 1}`}
+                    title="Use this pixel avatar"
+                    className="rounded-full focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1"
+                    style={{
+                      display: "inline-flex",
+                      padding: 0,
+                      border: "none",
+                      background: "transparent",
+                      cursor: "pointer",
+                    }}
+                  >
+                    <Identicon seed={candidate.seed} size={40} color={`var(--avatar-hue-${candidate.hueIdx})`} />
+                  </button>
+                ))}
+              </div>
+              <p className="text-caption text-muted-foreground">
+                Generate five random pixel avatars and click one to use it. It saves as the avatar image immediately.
+              </p>
             </div>
-            <p className="text-caption text-muted-foreground">
-              Generate five random pixel avatars and click one to use it. It saves as the avatar image immediately.
-            </p>
-          </div>
+          )}
           <div className="space-y-2">
             <Label>Color</Label>
             <div className="flex flex-wrap gap-2">


### PR DESCRIPTION
## What

Human agents now keep their GitHub avatar; pixel (identicon) avatars are reserved for non-human agents.

## Why

Avatar resolution (`resolveAvatarImageUrl`) already prefers a human agent's GitHub avatar (priority: uploaded image → human's GitHub `users.avatar_url` → null/identicon fallback). But the profile-edit dialog's **Pixel avatar** generator was offered to *all* agents. A human could bake an identicon and upload it, which then overrode their GitHub avatar (uploaded images win). That defeats "human agents use their GitHub avatar."

## Changes

- `profile-edit-dialog.tsx`: gate the "Pixel avatar" generator behind `!isHuman`. Humans keep the custom-image upload path and otherwise fall back to their GitHub avatar.
- Dialog description copy now varies by agent type.
- New DOM test asserting the generator shows for non-human agents and is hidden for humans (upload still available).

## Verification

- `@first-tree/web` vitest: 10/10 pass
- biome check, `tsc --noEmit`, design-token guardrails: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)