### PR TITLE
fix(web): use identicons in group composite avatars

### DIFF
--- a/packages/web/src/components/__tests__/avatar.test.tsx
+++ b/packages/web/src/components/__tests__/avatar.test.tsx
@@ -1,7 +1,14 @@
+import type { MeChatRow } from "@first-tree/shared";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 import { Avatar } from "../avatar.js";
-import { Identicon } from "../identicon.js";
+import { ChatRowAvatar } from "../chat/chat-row-avatar.js";
+import { Identicon, IdenticonBlocks } from "../identicon.js";
+
+type Participant = MeChatRow["participants"][number];
+function participant(agentId: string, over: Partial<Participant> = {}): Participant {
+  return { agentId, displayName: agentId, type: "agent", avatarColorToken: null, avatarImageUrl: null, ...over };
+}
 
 /**
  * Pin the avatar fallback contract after the identicon migration: an image
@@ -57,5 +64,42 @@ describe("Avatar — image vs identicon fallback", () => {
     const bySeed = renderToStaticMarkup(<Avatar name="Alice" seed="Alice" />);
     const byName = renderToStaticMarkup(<Avatar name="Alice" />);
     expect(byName).toBe(bySeed);
+  });
+});
+
+describe("IdenticonBlocks — fill-parent block svg", () => {
+  it("emits a 100% currentColor svg with the requested aspect handling", () => {
+    const html = renderToStaticMarkup(<IdenticonBlocks seed="x" preserveAspectRatio="xMidYMid slice" />);
+    expect(html).toContain("<svg");
+    expect(html).toContain('width="100%"');
+    expect(html).toContain('fill="currentColor"');
+    expect(html).toContain('preserveAspectRatio="xMidYMid slice"');
+    expect(html).not.toContain("border-radius"); // no own shape; the parent clips
+  });
+});
+
+describe("ChatRowAvatar — group composite uses identicons", () => {
+  const peers = [participant("self"), participant("alice"), participant("bob")];
+
+  it("renders an identicon (no initials) per peer face in a composite", () => {
+    const html = renderToStaticMarkup(
+      <ChatRowAvatar title="Team" type="group" participants={peers} selfAgentId="self" unreadCount={0} />,
+    );
+    // Two peer faces → at least two block svgs; no uploaded images here.
+    expect((html.match(/<svg/g) ?? []).length).toBeGreaterThanOrEqual(2);
+    expect(html).not.toContain("<img");
+  });
+
+  it("prefers a peer's uploaded image over the identicon in its segment", () => {
+    const withImage = [
+      participant("self"),
+      participant("alice", { avatarImageUrl: "https://example.com/a.png" }),
+      participant("bob"),
+    ];
+    const html = renderToStaticMarkup(
+      <ChatRowAvatar title="Team" type="group" participants={withImage} selfAgentId="self" unreadCount={0} />,
+    );
+    expect(html).toContain('src="https://example.com/a.png"');
+    expect(html).toContain("<svg"); // bob still falls back to an identicon
   });
 });

--- a/packages/web/src/components/chat/chat-row-avatar.tsx
+++ b/packages/web/src/components/chat/chat-row-avatar.tsx
@@ -3,9 +3,10 @@
  *
  * Renders two orthogonal signals in one 36x36 unit:
  *
- *   1. Identity. Direct chats show a single initial; group chats use a
+ *   1. Identity. Direct chats show one avatar; group chats use a
  *      Telegram-style split-disc composite (vertical bisection for 2,
- *      T-split for 3, 2x2 for exactly 4, 3 + "+N" tile for >=5).
+ *      T-split for 3, 2x2 for exactly 4, 3 + "+N" tile for >=5). Each face
+ *      is the peer's uploaded image, else a generated identicon.
  *   2. Attention. A single corner badge encodes the highest-priority
  *      "do I need to look here" signal: failed (an agent errored, red `!`)
  *      outranks an unread-mention count (red N, numeric up to 99 then "99+").
@@ -25,23 +26,19 @@
  */
 
 import type { MeChatRow } from "@first-tree/shared";
-import type { ReactNode } from "react";
-import { Identicon } from "../identicon.js";
+import type { CSSProperties, ReactNode } from "react";
+import { Identicon, IdenticonBlocks } from "../identicon.js";
 
 type Participant = MeChatRow["participants"][number];
-
-function initial(s: string): string {
-  return s.trim()[0]?.toUpperCase() ?? "?";
-}
 
 /**
  * Per-agent fill colors. References to the `--avatar-hue-0..7` tokens
  * defined in `index.css`; this file holds the *selection* logic, not
  * the colors themselves. Add or restyle hues in index.css.
  *
- * Initials are painted on top in `--fg-on-vivid` (a near-white token,
- * also in index.css) so contrast holds in both themes without relying
- * on `--bg-raised`, which inverts under `.dark`.
+ * Identicon blocks (and the `+N` overflow glyph) sit on top in
+ * `--fg-on-vivid` (a near-white token, also in index.css) so contrast holds
+ * in both themes without relying on `--bg-raised`, which inverts under `.dark`.
  */
 const AVATAR_HUE_COUNT = 8;
 
@@ -321,9 +318,6 @@ function CompositeAvatar({
   //   n5+ → 2x2 grid, first three peers + "+N" overflow tile where N = n - 3
   const n = peers.length;
   const shape = pickCompositeShape(n);
-
-  const fontSize = Math.round(size * (n === 2 ? 0.36 : 0.28));
-  const fontSizeTop = Math.round(size * 0.32);
   const fontSizeMore = Math.round(size * 0.26);
 
   const gridTemplate =
@@ -348,103 +342,30 @@ function CompositeAvatar({
     >
       {shape === "n2" && (
         <>
-          <Seg
-            name={peers[0]?.displayName ?? "?"}
-            hueSeed={peers[0]?.agentId ?? "0"}
-            colorToken={peers[0]?.avatarColorToken ?? null}
-            fontSize={fontSize}
-            muted={muted}
-          />
-          <Seg
-            name={peers[1]?.displayName ?? "?"}
-            hueSeed={peers[1]?.agentId ?? "1"}
-            colorToken={peers[1]?.avatarColorToken ?? null}
-            fontSize={fontSize}
-            muted={muted}
-          />
+          <Seg peer={peers[0]} idx={0} muted={muted} />
+          <Seg peer={peers[1]} idx={1} muted={muted} />
         </>
       )}
       {shape === "n3" && (
         <>
-          <Seg
-            name={peers[0]?.displayName ?? "?"}
-            hueSeed={peers[0]?.agentId ?? "0"}
-            colorToken={peers[0]?.avatarColorToken ?? null}
-            fontSize={fontSizeTop}
-            fullWidth
-            muted={muted}
-          />
-          <Seg
-            name={peers[1]?.displayName ?? "?"}
-            hueSeed={peers[1]?.agentId ?? "1"}
-            colorToken={peers[1]?.avatarColorToken ?? null}
-            fontSize={fontSize}
-            muted={muted}
-          />
-          <Seg
-            name={peers[2]?.displayName ?? "?"}
-            hueSeed={peers[2]?.agentId ?? "2"}
-            colorToken={peers[2]?.avatarColorToken ?? null}
-            fontSize={fontSize}
-            muted={muted}
-          />
+          <Seg peer={peers[0]} idx={0} fullWidth muted={muted} />
+          <Seg peer={peers[1]} idx={1} muted={muted} />
+          <Seg peer={peers[2]} idx={2} muted={muted} />
         </>
       )}
       {shape === "n4" && (
         <>
-          <Seg
-            name={peers[0]?.displayName ?? "?"}
-            hueSeed={peers[0]?.agentId ?? "0"}
-            colorToken={peers[0]?.avatarColorToken ?? null}
-            fontSize={fontSize}
-            muted={muted}
-          />
-          <Seg
-            name={peers[1]?.displayName ?? "?"}
-            hueSeed={peers[1]?.agentId ?? "1"}
-            colorToken={peers[1]?.avatarColorToken ?? null}
-            fontSize={fontSize}
-            muted={muted}
-          />
-          <Seg
-            name={peers[2]?.displayName ?? "?"}
-            hueSeed={peers[2]?.agentId ?? "2"}
-            colorToken={peers[2]?.avatarColorToken ?? null}
-            fontSize={fontSize}
-            muted={muted}
-          />
-          <Seg
-            name={peers[3]?.displayName ?? "?"}
-            hueSeed={peers[3]?.agentId ?? "3"}
-            colorToken={peers[3]?.avatarColorToken ?? null}
-            fontSize={fontSize}
-            muted={muted}
-          />
+          <Seg peer={peers[0]} idx={0} muted={muted} />
+          <Seg peer={peers[1]} idx={1} muted={muted} />
+          <Seg peer={peers[2]} idx={2} muted={muted} />
+          <Seg peer={peers[3]} idx={3} muted={muted} />
         </>
       )}
       {shape === "n5+" && (
         <>
-          <Seg
-            name={peers[0]?.displayName ?? "?"}
-            hueSeed={peers[0]?.agentId ?? "0"}
-            colorToken={peers[0]?.avatarColorToken ?? null}
-            fontSize={fontSize}
-            muted={muted}
-          />
-          <Seg
-            name={peers[1]?.displayName ?? "?"}
-            hueSeed={peers[1]?.agentId ?? "1"}
-            colorToken={peers[1]?.avatarColorToken ?? null}
-            fontSize={fontSize}
-            muted={muted}
-          />
-          <Seg
-            name={peers[2]?.displayName ?? "?"}
-            hueSeed={peers[2]?.agentId ?? "2"}
-            colorToken={peers[2]?.avatarColorToken ?? null}
-            fontSize={fontSize}
-            muted={muted}
-          />
+          <Seg peer={peers[0]} idx={0} muted={muted} />
+          <Seg peer={peers[1]} idx={1} muted={muted} />
+          <Seg peer={peers[2]} idx={2} muted={muted} />
           <SegMore count={n - 3} fontSize={fontSizeMore} />
         </>
       )}
@@ -453,36 +374,41 @@ function CompositeAvatar({
 }
 
 function Seg({
-  name,
-  hueSeed,
-  colorToken,
-  fontSize,
+  peer,
+  idx,
   fullWidth,
   muted = false,
 }: {
-  name: string;
-  hueSeed: string;
-  colorToken?: string | null;
-  fontSize: number;
+  /** The peer in this slot, or `undefined` for a defensive empty cell. */
+  peer: Participant | undefined;
+  /** Slot index — fallback seed so an empty cell still gets a distinct hue. */
+  idx: number;
   fullWidth?: boolean;
   muted?: boolean;
 }) {
+  const seed = peer?.agentId ?? String(idx);
+  const base: CSSProperties = {
+    display: "block",
+    width: "100%",
+    height: "100%",
+    overflow: "hidden",
+    ...(fullWidth ? { gridColumn: "1 / -1" } : null),
+  };
+  // Mirror SingleAvatar's fallback chain: uploaded image first, else the
+  // deterministic identicon. `slice` cover-crops the square grid into the
+  // (often non-square) composite cell without distorting the pixels.
+  if (peer?.avatarImageUrl) {
+    return <img src={peer.avatarImageUrl} alt="" style={{ ...base, objectFit: "cover" }} />;
+  }
   return (
     <span
       style={{
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        background: resolveAvatarHue(colorToken, hueSeed, muted),
+        ...base,
+        background: resolveAvatarHue(peer?.avatarColorToken ?? null, seed, muted),
         color: "var(--fg-on-vivid)",
-        fontSize,
-        fontWeight: 700,
-        lineHeight: 1,
-        letterSpacing: "-0.02em",
-        ...(fullWidth ? { gridColumn: "1 / -1" } : null),
       }}
     >
-      {initial(name)}
+      <IdenticonBlocks seed={seed} preserveAspectRatio="xMidYMid slice" />
     </span>
   );
 }

--- a/packages/web/src/components/identicon.tsx
+++ b/packages/web/src/components/identicon.tsx
@@ -27,6 +27,52 @@ import type { CSSProperties, ReactNode } from "react";
 
 const VIEWBOX = 100;
 
+/**
+ * Just the block pattern as a self-scaling `<svg>` filled with `currentColor`.
+ * Fills its parent (`width/height: 100%`); the parent supplies the hue
+ * background, the `color` the blocks inherit, and any clip/shape. Square group
+ * composite cells use the default `meet`; non-square cells pass `slice` to
+ * cover-crop without distorting the grid.
+ */
+export function IdenticonBlocks({
+  seed,
+  gridSize = 5,
+  preserveAspectRatio = "xMidYMid meet",
+}: {
+  seed: string;
+  gridSize?: number;
+  /** SVG aspect handling. `meet` fits (square tiles); `slice` cover-crops (non-square cells). */
+  preserveAspectRatio?: string;
+}) {
+  const cells = identiconCells(seed, gridSize);
+  const block = VIEWBOX / (gridSize + 1);
+  const margin = block / 2;
+
+  const rects: ReactNode[] = [];
+  for (let y = 0; y < gridSize; y++) {
+    const row = cells[y];
+    if (!row) continue;
+    for (let x = 0; x < gridSize; x++) {
+      if (!row[x]) continue;
+      rects.push(<rect key={`${x}-${y}`} x={margin + x * block} y={margin + y * block} width={block} height={block} />);
+    }
+  }
+
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox={`0 0 ${VIEWBOX} ${VIEWBOX}`}
+      width="100%"
+      height="100%"
+      preserveAspectRatio={preserveAspectRatio}
+      fill="currentColor"
+      style={{ display: "block" }}
+    >
+      {rects}
+    </svg>
+  );
+}
+
 export function Identicon({
   seed,
   size,
@@ -47,20 +93,6 @@ export function Identicon({
   /** When set, exposes the tile as `role="img"` with this label; otherwise `aria-hidden`. */
   label?: string;
 }) {
-  const cells = identiconCells(seed, gridSize);
-  const block = VIEWBOX / (gridSize + 1);
-  const margin = block / 2;
-
-  const rects: ReactNode[] = [];
-  for (let y = 0; y < gridSize; y++) {
-    const row = cells[y];
-    if (!row) continue;
-    for (let x = 0; x < gridSize; x++) {
-      if (!row[x]) continue;
-      rects.push(<rect key={`${x}-${y}`} x={margin + x * block} y={margin + y * block} width={block} height={block} />);
-    }
-  }
-
   const style: CSSProperties = {
     width: size,
     height: size,
@@ -76,16 +108,7 @@ export function Identicon({
 
   return (
     <span className={className} style={style} {...a11y}>
-      <svg
-        aria-hidden="true"
-        viewBox={`0 0 ${VIEWBOX} ${VIEWBOX}`}
-        width={size}
-        height={size}
-        fill="currentColor"
-        style={{ display: "block" }}
-      >
-        {rects}
-      </svg>
+      <IdenticonBlocks seed={seed} gridSize={gridSize} />
     </span>
   );
 }


### PR DESCRIPTION
## Summary

Follow-up to #1101. Group-chat **composite** avatars (the Telegram-style split disc) still rendered each peer face as a single **initial**, ignoring both the peer's identicon and any uploaded image. So a member who shows a pixel avatar everywhere else appeared as a letter inside group composites — the gap reported after #1101 landed.

### What changed
- **`IdenticonBlocks`** extracted from `<Identicon>` — a fill-parent (`width/height: 100%`) block `<svg>` painted with `currentColor`, with a configurable `preserveAspectRatio`. `<Identicon>` now composes it (square tile → default `meet`).
- **`Seg`** (composite cell) now mirrors `SingleAvatar`'s fallback chain: **uploaded image → identicon**. The square identicon cover-crops into the (often non-square) composite cell via `preserveAspectRatio="xMidYMid slice"`, so the grid never distorts. The inverted palette (hue fill + near-white blocks) makes the crop and the circular clip harmless.
- Removed the now-dead `initial` helper; refreshed the stale "shows a single initial" docstrings.

### Testing
- New render coverage: `IdenticonBlocks` (100% / currentColor / aspect), and `ChatRowAvatar` group composites (identicon per face; uploaded image preferred in its slot).
- `@first-tree/web` 830 tests pass; `tsc --noEmit` clean; Biome + design-token guard clean.

### QA focus
- [ ] Group conversation rows (2 / 3 / 4 / 5+ peers): each face shows the peer's identicon (or photo), not a letter — legible at the 36px rail size in light and dark.
- [ ] A group where one member has a custom uploaded avatar: that slot shows the photo, others show identicons.
- [ ] Composite faces match the same peer's single-avatar identicon elsewhere (same hue + pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)