### PR TITLE
[codex] Keep existing chat topics stable

### DIFF
--- a/packages/client/src/__tests__/agent-briefing.test.ts
+++ b/packages/client/src/__tests__/agent-briefing.test.ts
@@ -758,6 +758,10 @@ describe("buildAgentBriefing — # Working in First Tree subsections", () => {
     expect(briefing).toMatch(/status report/);
     expect(briefing).toMatch(/deprecated alias/);
     expect(briefing).toMatch(/Self-locate/);
+    expect(briefing).toContain("Once set, leave the topic unchanged");
+    expect(briefing).toContain("stable topic helps humans find the chat");
+    expect(briefing).not.toContain("Rename only");
+    expect(briefing).not.toContain("subject itself changed");
     // The Chat Topic block points at the Current Chat Context block at the
     // BOTTOM of the briefing (not "above" as in the pre-restructure
     // copy).

--- a/packages/client/src/runtime/agent-briefing.ts
+++ b/packages/client/src/runtime/agent-briefing.ts
@@ -829,12 +829,11 @@ everyone (reading a description to self-locate needs no ownership).
    fallback ("first 50 chars of the first message" / "alice, bob-bot")
    is rarely distinctive — naming the chat is a cheap win.
 
-   **Once set, treat the topic as a stable anchor — do not rename it
-   casually.** Users and agents locate a specific chat by its topic, so a
-   chat that keeps changing names becomes hard to find again. Rename only
-   when the topic is genuinely wrong or misleading because the chat's
-   subject itself changed — never to track progress or reflect a passing
-   focus. Progress belongs in the description, not the topic.
+   **Once set, leave the topic unchanged.** Users and agents locate a
+   specific chat by its topic, so a stable topic helps humans find the chat
+   again quickly. Do not rename an existing topic to track progress, reflect
+   a passing focus, or restate a changed subject. Progress and current scope
+   belong in the description, not the topic.
 
 2. **(Owner) Description → keep it current as a status report.** The
    description is **meant to move with the work**, but refresh it only on


### PR DESCRIPTION
## Summary
- Tighten the injected Chat Topic & Description briefing so owners only set a topic when it is unset/null.
- Tell agents to leave existing topics unchanged and put progress/current-scope changes in the description.
- Add briefing test coverage so the old subject-changed rename exception does not come back.

## Why
Stable chat topics help humans find the same task chat quickly. The previous briefing allowed topic changes when the subject changed, which could still make chat list anchors drift over time.

## Validation
- `pnpm --filter @first-tree/client test -- src/__tests__/agent-briefing.test.ts` (ran client full suite: 100 files / 1026 tests)
- `pnpm check && pnpm typecheck`

Note: `pnpm check` reported existing lint warnings outside the changed files.