### PR TITLE
[codex] Use active token totals in usage UI

### DIFF
--- a/packages/web/src/pages/__tests__/team-preview-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/team-preview-dom.test.tsx
@@ -156,7 +156,7 @@ describe("team preview page", () => {
 
     await click(buttonByText(container, "All"));
     await click(buttonByText(container, "7d"));
-    expect(container.textContent).toContain("4.5M");
+    expect(container.textContent).toContain("1.4M");
 
     const search = container.querySelector<HTMLInputElement>('input[placeholder="Search name or @handle"]');
     if (!search) throw new Error("Search input missing");

--- a/packages/web/src/pages/agent-detail/__tests__/usage-tab.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/usage-tab.test.tsx
@@ -269,13 +269,13 @@ describe("UsageTab", () => {
     expect(container.textContent).toContain("Active days");
     expect(container.textContent).toContain("Peak day");
     expect(container.textContent).toContain("Recent turns");
-    expect(container.textContent).toContain("Daily total tokens. Darker cells mean more usage.");
-    expect(activityCells.find((cell) => cell.getAttribute("aria-label")?.includes("10.5K total tokens"))).toBeDefined();
+    expect(container.textContent).toContain("Daily active tokens. Darker cells mean more usage.");
+    expect(activityCells.find((cell) => cell.getAttribute("aria-label")?.includes("9.5K active tokens"))).toBeDefined();
     expect(container.textContent).toContain("Your most recent turns from the last 30 days.");
     expect(container.textContent).toContain("Launch planning");
     expect(container.textContent).toContain("private chat");
     expect(container.textContent).toContain("claude-code/sonnet");
-    expect(container.textContent).toContain("46.2K");
+    expect(container.textContent).toContain("16.2K");
     expect(usageMocks.getAgentUsageSummary).toHaveBeenCalledWith("agent-1", "30d");
     expect(usageMocks.getAgentUsageTurns).toHaveBeenCalledWith("agent-1", {
       window: "30d",

--- a/packages/web/src/pages/agent-detail/usage-tab.tsx
+++ b/packages/web/src/pages/agent-detail/usage-tab.tsx
@@ -94,7 +94,16 @@ export function UsageTab(): ReactElement {
    Activity
    ========================================================================== */
 
-type DayBucket = { date: string; weekday: number; month: number; day: number; year: number; tokens: number };
+type DayBucket = {
+  date: string;
+  weekday: number;
+  month: number;
+  day: number;
+  year: number;
+  activeTokens: number;
+  cacheReadTokens: number;
+  processedTokens: number;
+};
 
 function ActivityBlock({
   data,
@@ -115,7 +124,7 @@ function ActivityBlock({
           </span>
         </>
       }
-      description="Daily total tokens. Darker cells mean more usage."
+      description="Daily active tokens. Darker cells mean more usage."
       action={<DensityLegend />}
     >
       {isError ? (
@@ -146,7 +155,7 @@ function DensityLegend(): ReactElement {
 function ActivityBody({ summary }: { summary: UsageAgentSummary | undefined }): ReactElement {
   const days = useMemo(() => buildDays(summary?.daily), [summary?.daily]);
   const columns = useMemo(() => buildColumns(days), [days]);
-  const max = Math.max(1, ...days.map((d) => d.tokens));
+  const max = Math.max(1, ...days.map((d) => d.activeTokens));
   const stats = useMemo(() => computeStats(days), [days]);
   const [hover, setHover] = useState<{ d: DayBucket; x: number; y: number } | null>(null);
 
@@ -229,13 +238,13 @@ function Cell({
   if (!day) {
     return <span aria-hidden="true" className="usage-cal-cell usage-cal-cell-empty" />;
   }
-  const b = bucket(day.tokens, max);
+  const b = bucket(day.activeTokens, max);
   const colors = ["var(--lvl0)", "var(--lvl1)", "var(--lvl2)", "var(--lvl3)", "var(--lvl4)"];
   return (
     <span
       role="img"
       aria-label={`${WEEKDAYS[day.weekday]} ${MONTHS[day.month]} ${day.day}: ${
-        day.tokens > 0 ? `${formatCompactCount(day.tokens)} total tokens` : "no activity"
+        day.activeTokens > 0 ? `${formatCompactCount(day.activeTokens)} active tokens` : "no activity"
       }`}
       onMouseEnter={onEnter}
       onMouseLeave={onLeave}
@@ -247,13 +256,18 @@ function Cell({
 
 function CellTooltip({ day, anchorX, anchorY }: { day: DayBucket; anchorX: number; anchorY: number }): ReactElement {
   const label = `${WEEKDAYS[day.weekday]} · ${MONTHS[day.month]} ${day.day}, ${day.year}`;
-  const value = day.tokens > 0 ? `${formatCompactCount(day.tokens)} total tokens` : "No activity";
+  const value = day.activeTokens > 0 ? `${formatCompactCount(day.activeTokens)} active tokens` : "No activity";
   return (
     <div role="tooltip" className="usage-cal-tooltip" style={{ left: anchorX, top: anchorY }}>
       <div className="text-eyebrow mono" style={{ color: "var(--fg-3)" }}>
         {label}
       </div>
       <div className="usage-cal-tooltip-value text-body mono font-semibold">{value}</div>
+      {day.cacheReadTokens > 0 ? (
+        <div className="text-caption mono" style={{ color: "var(--fg-3)" }}>
+          {formatCompactCount(day.cacheReadTokens)} cache read · {formatCompactCount(day.processedTokens)} processed
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -264,8 +278,8 @@ function ActivityStatsPanel({
   stats: { activeDays: number; avgPerDay: number; peak: DayBucket | null; streak: number };
 }): ReactElement {
   const peakLabel =
-    stats.peak && stats.peak.tokens > 0
-      ? `${MONTHS[stats.peak.month]} ${stats.peak.day} · ${formatCompactCount(stats.peak.tokens)}`
+    stats.peak && stats.peak.activeTokens > 0
+      ? `${MONTHS[stats.peak.month]} ${stats.peak.day} · ${formatCompactCount(stats.peak.activeTokens)}`
       : "—";
   return (
     <div className="usage-stats-panel">
@@ -280,7 +294,7 @@ function ActivityStatsPanel({
           </>
         }
       />
-      <StatTile label="Avg tokens / day" value={formatCompactCount(stats.avgPerDay)} mono />
+      <StatTile label="Avg active / day" value={formatCompactCount(stats.avgPerDay)} mono />
       <StatTile label="Peak day" value={peakLabel} mono />
       <StatTile
         label="Current streak"
@@ -359,8 +373,8 @@ function TurnsTable({
   rows: UsageTurnRow[];
   onOpenChat: (chatId: string) => void;
 }): ReactElement {
-  const totalFor = (r: UsageTurnRow) => r.inputTokens + r.cachedInputTokens + r.outputTokens;
-  const max = Math.max(1, ...rows.map(totalFor));
+  const activeFor = (r: UsageTurnRow) => r.inputTokens + r.outputTokens;
+  const max = Math.max(1, ...rows.map(activeFor));
   return (
     <div className="usage-turn-scroll">
       <table className="usage-turn-table w-full" style={{ borderCollapse: "collapse", marginTop: "var(--sp-1)" }}>
@@ -372,12 +386,12 @@ function TurnsTable({
             <th style={thStyle("right")}>Input</th>
             <th style={thStyle("right")}>Cached</th>
             <th style={thStyle("right")}>Output</th>
-            <th style={{ ...thStyle("left"), width: "var(--sp-20)" }}>Total</th>
+            <th style={{ ...thStyle("left"), width: "var(--sp-20)" }}>Active</th>
           </tr>
         </thead>
         <tbody>
           {rows.map((r) => {
-            const total = totalFor(r);
+            const active = activeFor(r);
             return (
               <tr key={`${r.chatId}:${r.seq}`} className="usage-turn-row">
                 <td className="text-body" style={{ color: "var(--fg-3)", whiteSpace: "nowrap" }}>
@@ -420,13 +434,13 @@ function TurnsTable({
                 </td>
                 <td>
                   <div className="usage-turn-total-cell">
-                    <span className="mono text-body">{formatCompactCount(total)}</span>
+                    <span className="mono text-body">{formatCompactCount(active)}</span>
                     <div
                       role="img"
                       className="usage-turn-volbar"
-                      aria-label={`${formatCompactCount(total)} tokens this turn`}
+                      aria-label={`${formatCompactCount(active)} active tokens this usage event`}
                     >
-                      <span style={{ width: `${(total / max) * 100}%` }} />
+                      <span style={{ width: `${(active / max) * 100}%` }} />
                     </div>
                   </div>
                 </td>
@@ -461,7 +475,13 @@ function buildDays(daily: UsageAgentSummary["daily"] | undefined): DayBucket[] {
   // half the day in non-UTC zones and silently miss the join key.
   const byDate = new Map<string, number>();
   for (const d of daily ?? []) {
-    byDate.set(d.date, d.inputTokens + d.cachedInputTokens + d.outputTokens);
+    byDate.set(d.date, d.inputTokens + d.outputTokens);
+  }
+  const byCacheRead = new Map<string, number>();
+  const byProcessed = new Map<string, number>();
+  for (const d of daily ?? []) {
+    byCacheRead.set(d.date, d.cachedInputTokens);
+    byProcessed.set(d.date, d.inputTokens + d.cachedInputTokens + d.outputTokens);
   }
   const today = new Date();
   today.setUTCHours(0, 0, 0, 0);
@@ -469,13 +489,17 @@ function buildDays(daily: UsageAgentSummary["daily"] | undefined): DayBucket[] {
   for (let i = ACTIVITY_GRID_DAYS - 1; i >= 0; i--) {
     const dt = new Date(today.getTime() - i * 24 * 60 * 60 * 1000);
     const iso = dt.toISOString().slice(0, 10);
+    const activeTokens = byDate.get(iso) ?? 0;
+    const cacheReadTokens = byCacheRead.get(iso) ?? 0;
     days.push({
       date: iso,
       weekday: dt.getUTCDay(),
       month: dt.getUTCMonth(),
       day: dt.getUTCDate(),
       year: dt.getUTCFullYear(),
-      tokens: byDate.get(iso) ?? 0,
+      activeTokens,
+      cacheReadTokens,
+      processedTokens: byProcessed.get(iso) ?? activeTokens + cacheReadTokens,
     });
   }
   return days;
@@ -516,15 +540,15 @@ function computeStats(days: DayBucket[]): {
   peak: DayBucket | null;
   streak: number;
 } {
-  const activeDays = days.filter((d) => d.tokens > 0).length;
-  const total = days.reduce((acc, d) => acc + d.tokens, 0);
+  const activeDays = days.filter((d) => d.activeTokens > 0).length;
+  const total = days.reduce((acc, d) => acc + d.activeTokens, 0);
   const avgPerDay = days.length > 0 ? Math.round(total / days.length) : 0;
   const seed = days[0];
-  const peak = seed ? days.reduce((a, d) => (d.tokens > a.tokens ? d : a), seed) : null;
+  const peak = seed ? days.reduce((a, d) => (d.activeTokens > a.activeTokens ? d : a), seed) : null;
   let streak = 0;
   for (let i = days.length - 1; i >= 0; i--) {
     const d = days[i];
-    if (d && d.tokens > 0) streak++;
+    if (d && d.activeTokens > 0) streak++;
     else break;
   }
   return { activeDays, avgPerDay, peak, streak };

--- a/packages/web/src/pages/team-preview.tsx
+++ b/packages/web/src/pages/team-preview.tsx
@@ -611,14 +611,15 @@ function UsageCell({ usage }: { usage: PreviewUsage | null }) {
       </span>
     );
   }
-  const totalTokens = usage.inputTokens + usage.cachedInputTokens + usage.outputTokens;
+  const activeTokens = usage.inputTokens + usage.outputTokens;
+  const processedTokens = activeTokens + usage.cachedInputTokens;
   return (
     <span
       className="text-caption mono truncate"
       style={{ color: "var(--fg-2)" }}
-      title={`Input ${usage.inputTokens.toLocaleString()} · Cached ${usage.cachedInputTokens.toLocaleString()} · Output ${usage.outputTokens.toLocaleString()} · ${usage.turns} turns`}
+      title={`Active ${activeTokens.toLocaleString()} · Input ${usage.inputTokens.toLocaleString()} · Cached ${usage.cachedInputTokens.toLocaleString()} · Output ${usage.outputTokens.toLocaleString()} · Processed ${processedTokens.toLocaleString()} · ${usage.turns} usage events`}
     >
-      {formatCompactCount(totalTokens)}
+      {formatCompactCount(activeTokens)}
       <span style={{ color: "var(--fg-4)" }}>{` · ${formatCompactCount(usage.turns)}t`}</span>
     </span>
   );
@@ -1093,7 +1094,7 @@ function agentMetaLine(agent: PreviewAgent, isMine: boolean, usage: PreviewUsage
   const owner = isMine ? "You" : (MEMBERS[agent.managerId]?.displayName ?? "—");
   const usageStr =
     usage && usage.turns > 0
-      ? `${formatCompactCount(usage.inputTokens + usage.cachedInputTokens + usage.outputTokens)} · ${formatCompactCount(usage.turns)}t`
+      ? `${formatCompactCount(usage.inputTokens + usage.outputTokens)} · ${formatCompactCount(usage.turns)}t`
       : "—";
   return `${owner} · ${agent.runtimeProvider} · ${usageStr}`;
 }

--- a/packages/web/src/pages/team/__tests__/team-table-dom.test.tsx
+++ b/packages/web/src/pages/team/__tests__/team-table-dom.test.tsx
@@ -214,7 +214,7 @@ describe("TeamTable", () => {
     expect(container.textContent).toContain("Human teammates");
     expect(container.textContent).toContain("Nova");
     expect(container.textContent).toContain("Design");
-    expect(container.textContent).toContain("3.5K");
+    expect(container.textContent).toContain("1.5K");
     expect(container.textContent).toContain("Online");
     expect(container.textContent).toContain("Gandy");
     expect(container.textContent).toContain("Admin");

--- a/packages/web/src/pages/team/team-table.tsx
+++ b/packages/web/src/pages/team/team-table.tsx
@@ -547,17 +547,18 @@ function UsageCell({ usage, loading }: { usage: UsageByAgentRow | null; loading:
       </div>
     );
   }
-  const totalTokens = usage.inputTokens + usage.cachedInputTokens + usage.outputTokens;
+  const activeTokens = usage.inputTokens + usage.outputTokens;
+  const processedTokens = activeTokens + usage.cachedInputTokens;
   // Show only the token magnitude — the turn count was dropped from the cell (it
-  // crowded the column and truncated); turns remain in the hover title for the
-  // rare case someone wants the breakdown.
+  // crowded the column and truncated); usage events remain in the hover title
+  // for the rare case someone wants the breakdown.
   return (
     <div
       className="text-caption mono truncate"
       style={{ color: "var(--fg-2)", textAlign: "right" }}
-      title={`Input ${usage.inputTokens.toLocaleString()} · Cached ${usage.cachedInputTokens.toLocaleString()} · Output ${usage.outputTokens.toLocaleString()} · ${usage.turns} turns`}
+      title={`Active ${activeTokens.toLocaleString()} · Input ${usage.inputTokens.toLocaleString()} · Cached ${usage.cachedInputTokens.toLocaleString()} · Output ${usage.outputTokens.toLocaleString()} · Processed ${processedTokens.toLocaleString()} · ${usage.turns} usage events`}
     >
-      {formatCompactCount(totalTokens)}
+      {formatCompactCount(activeTokens)}
     </div>
   );
 }
@@ -1068,10 +1069,7 @@ function agentMetaLine(
   usage: UsageByAgentRow | null,
 ): string {
   const owner = isSelf ? "You" : (managerLabel ?? "—");
-  // Token magnitude only — turns were dropped from the Usage display.
-  const usageStr =
-    usage && usage.turns > 0
-      ? formatCompactCount(usage.inputTokens + usage.cachedInputTokens + usage.outputTokens)
-      : "—";
+  // Token magnitude only — usage events were dropped from the Usage display.
+  const usageStr = usage && usage.turns > 0 ? formatCompactCount(usage.inputTokens + usage.outputTokens) : "—";
   return `${owner} · ${provider} · ${usageStr}`;
 }

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -1357,6 +1357,8 @@ export function ChatView({
     enabled: !!chatId,
     refetchInterval: 5_000,
   });
+  const chatActiveTokens = chatTokenUsage ? chatTokenUsage.inputTokens + chatTokenUsage.outputTokens : 0;
+  const chatProcessedTokens = chatTokenUsage ? chatActiveTokens + chatTokenUsage.cachedInputTokens : 0;
 
   /** Org-wide agent list, consumed by `managedByMeMap` for picker
    *  grouping and by the identity-map hooks (`useAgentIdentityMap` etc.)
@@ -3328,13 +3330,13 @@ export function ChatView({
                   </div>
                 ) : (
                   <>
-                    {chatTokenUsage && chatTokenUsage.totalTokens > 0 ? (
+                    {chatTokenUsage && chatProcessedTokens > 0 ? (
                       <div
                         className="mono text-caption"
                         style={{ color: "var(--fg-4)", padding: "0 var(--sp-0_5) var(--sp-1)" }}
-                        title={`input ${chatTokenUsage.inputTokens.toLocaleString()} · cached ${chatTokenUsage.cachedInputTokens.toLocaleString()} · output ${chatTokenUsage.outputTokens.toLocaleString()}`}
+                        title={`active ${chatActiveTokens.toLocaleString()} · input ${chatTokenUsage.inputTokens.toLocaleString()} · cached ${chatTokenUsage.cachedInputTokens.toLocaleString()} · output ${chatTokenUsage.outputTokens.toLocaleString()} · processed ${chatProcessedTokens.toLocaleString()}`}
                       >
-                        {formatTokenCount(chatTokenUsage.totalTokens)} tokens used in this chat
+                        {formatTokenCount(chatActiveTokens)} active tokens in this chat
                       </div>
                     ) : null}
                     <ComposeStatusBar


### PR DESCRIPTION
## Summary

- Switch primary token usage displays from cache-inclusive processed tokens to active tokens (`inputTokens + outputTokens`).
- Keep cached input visible as secondary detail in titles/tooltips, and label cache-inclusive totals as processed diagnostics rather than the primary usage number.
- Update affected DOM expectations for Team, Team preview, and Agent Usage surfaces.

## Root Cause

Usage surfaces were presenting `inputTokens + cachedInputTokens + outputTokens` as the single main number. High cache-read volume made usage look exaggerated even though `cachedInputTokens` is already stored separately from non-cached input.

## Scope

Display-only P0 fix. This does not change reporting, DB schema, or shared DTO/schema contracts.

Updated surfaces:

- Chat footer
- Team Usage column
- Team preview usage display
- Agent Usage activity heatmap/stats
- Agent Usage recent turns active column

## QA

Local QA completed: PASS with scope caveat.

- Real browser Agent Usage evidence with high-cache sample: `input=1.4K`, `cached=150K`, `output=2.6K`; primary UI shows active `4K`, cached remains separate.
- Desktop and 390px mobile verified for Agent Usage.
- Team Usage, Team preview, and Chat footer covered by focused DOM tests and full web test suite.
- Local QA report: `/Users/yuezengwu/.first-tree-staging/data/workspaces/qa/qa-reports/usage-p0-active-tokens-regression-20260616.md`

## Validation

- `pnpm --filter @first-tree/web exec vitest run src/pages/agent-detail/__tests__/usage-tab.test.tsx src/pages/team/__tests__/team-table-dom.test.tsx src/pages/__tests__/team-preview-dom.test.tsx --passWithNoTests`
- `pnpm --filter @first-tree/web typecheck`
- `pnpm exec biome check packages/web/src/pages/agent-detail/usage-tab.tsx packages/web/src/pages/agent-detail/__tests__/usage-tab.test.tsx packages/web/src/pages/team/team-table.tsx packages/web/src/pages/team/__tests__/team-table-dom.test.tsx packages/web/src/pages/team-preview.tsx packages/web/src/pages/__tests__/team-preview-dom.test.tsx packages/web/src/pages/workspace/center/chat-view.tsx`
- `pnpm --filter @first-tree/web test`

QA also ran root `pnpm check` successfully; it retained existing unrelated Biome warnings/info noted in the QA report.