### PR TITLE
fix: name chat completion undici spans by route

### DIFF
--- a/packages/server/src/observability/__tests__/otel-init.test.ts
+++ b/packages/server/src/observability/__tests__/otel-init.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { initTelemetry, isTelemetryEnabled, parseHeaderString, shutdownTelemetry } from "../logfire-init.js";
+import {
+  initTelemetry,
+  isTelemetryEnabled,
+  parseHeaderString,
+  shutdownTelemetry,
+  undiciSpanNameForRequest,
+  updateKnownUndiciSpanName,
+} from "../logfire-init.js";
 import { normalizeAttrs } from "../otel-helpers.js";
 
 describe("normalizeAttrs", () => {
@@ -121,6 +128,71 @@ describe("parseHeaderString", () => {
   it("handles realistic Logfire-style token header", () => {
     const out = parseHeaderString("Authorization=Bearer pylf_v1_us_xyzABC123==");
     expect(out).toEqual({ Authorization: "Bearer pylf_v1_us_xyzABC123==" });
+  });
+});
+
+describe("undici span naming", () => {
+  it("names OpenRouter chat completions by method and path without host or query", () => {
+    const name = undiciSpanNameForRequest({
+      method: "POST",
+      origin: "https://openrouter.ai",
+      path: "/api/v1/chat/completions?ignored=true",
+    });
+
+    expect(name).toBe("POST /api/v1/chat/completions");
+  });
+
+  it("keeps provider-specific API prefixes while normalizing trailing slash", () => {
+    const name = undiciSpanNameForRequest({
+      method: "post",
+      origin: "https://api.openai.com",
+      path: "/v1/chat/completions/",
+    });
+
+    expect(name).toBe("POST /v1/chat/completions");
+  });
+
+  it("does not rename unrelated outbound requests", () => {
+    const name = undiciSpanNameForRequest({
+      method: "POST",
+      origin: "https://api.github.com",
+      path: "/repos/agent-team-foundation/first-tree/issues",
+    });
+
+    expect(name).toBeUndefined();
+  });
+
+  it("does not put arbitrary dynamic path prefixes into span names", () => {
+    const name = undiciSpanNameForRequest({
+      method: "POST",
+      origin: "https://example.test",
+      path: "/openai/deployments/prod-main/chat/completions",
+    });
+
+    expect(name).toBeUndefined();
+  });
+
+  it("does not rename malformed undici request data", () => {
+    expect(undiciSpanNameForRequest({ method: "POST", origin: "not a url", path: "://bad" })).toBeUndefined();
+    expect(undiciSpanNameForRequest({ method: "POST", origin: "https://openrouter.ai" })).toBeUndefined();
+  });
+
+  it("updates only known undici span names", () => {
+    const calls: string[] = [];
+    const span = { updateName: (name: string) => calls.push(name) };
+
+    updateKnownUndiciSpanName(span, {
+      method: "POST",
+      origin: "https://openrouter.ai",
+      path: "/api/v1/chat/completions",
+    });
+    updateKnownUndiciSpanName(span, {
+      method: "GET",
+      origin: "https://openrouter.ai",
+      path: "/api/v1/models",
+    });
+
+    expect(calls).toEqual(["POST /api/v1/chat/completions"]);
   });
 });
 

--- a/packages/server/src/observability/logfire-init.ts
+++ b/packages/server/src/observability/logfire-init.ts
@@ -30,6 +30,18 @@ const log = createLogger("Telemetry");
 
 const TRACER_VERSION = "0.1.0";
 
+const CHAT_COMPLETIONS_PATH_RE = /^\/(?:(?:api\/)?v\d+\/)?chat\/completions$/;
+
+type UndiciRequestLike = {
+  origin?: unknown;
+  path?: unknown;
+  method?: unknown;
+};
+
+type SpanNameUpdater = {
+  updateName(name: string): void;
+};
+
 export type TracingConfig = {
   endpoint: string;
   headers: string;
@@ -75,6 +87,39 @@ function deriveBaseUrl(endpoint: string): string | undefined {
   } catch {
     return undefined;
   }
+}
+
+function normalizeRequestMethod(method: unknown): string | undefined {
+  if (typeof method !== "string") return undefined;
+  const normalized = method.trim().toUpperCase();
+  return normalized || undefined;
+}
+
+function normalizePathname(pathname: string): string {
+  if (pathname.length > 1 && pathname.endsWith("/")) return pathname.slice(0, -1);
+  return pathname;
+}
+
+export function undiciSpanNameForRequest(request: UndiciRequestLike): string | undefined {
+  const method = normalizeRequestMethod(request.method);
+  if (!method || typeof request.origin !== "string" || typeof request.path !== "string") return undefined;
+
+  let url: URL;
+  try {
+    url = new URL(request.path, request.origin);
+  } catch {
+    return undefined;
+  }
+
+  const pathname = normalizePathname(url.pathname);
+  if (!CHAT_COMPLETIONS_PATH_RE.test(pathname)) return undefined;
+
+  return `${method} ${pathname}`;
+}
+
+export function updateKnownUndiciSpanName(span: SpanNameUpdater, request: UndiciRequestLike): void {
+  const spanName = undiciSpanNameForRequest(request);
+  if (spanName) span.updateName(spanName);
 }
 
 /**
@@ -175,6 +220,9 @@ export async function initTelemetry(config: TracingConfig | undefined, instanceI
       "@opentelemetry/instrumentation-http": { enabled: false },
       "@opentelemetry/instrumentation-net": { enabled: false },
       "@opentelemetry/instrumentation-dns": { enabled: false },
+      "@opentelemetry/instrumentation-undici": {
+        requestHook: updateKnownUndiciSpanName,
+      },
     },
   });
 


### PR DESCRIPTION
## Summary
- add an undici request hook that renames known OpenAI-compatible chat completions client spans to `METHOD path`
- keep host, full URL, and query data in span attributes rather than span names
- cover OpenRouter `/api/v1/chat/completions`, OpenAI-style `/v1/chat/completions`, malformed requests, unrelated requests, and arbitrary dynamic path prefixes

## Verification
- `pnpm exec vitest run src/observability/__tests__/otel-init.test.ts --maxWorkers=2 --minWorkers=1`
- `pnpm exec biome check packages/server/src/observability/logfire-init.ts packages/server/src/observability/__tests__/otel-init.test.ts`
- `pnpm --filter @first-tree/server typecheck`
- `git diff --check`
