### PR TITLE
feat(daemon): refresh runtime capabilities while connected

### DIFF
--- a/apps/cli/src/__tests__/capability-refresh.test.ts
+++ b/apps/cli/src/__tests__/capability-refresh.test.ts
@@ -158,23 +158,55 @@ describe("CapabilityRefresher", () => {
     refresher.stop();
   });
 
-  it("does not run a reconnect re-probe while a poll is already in flight", async () => {
+  it("defers a reconnect that lands mid-poll and drains it afterward (reconnect re-probe never dropped)", async () => {
     const gate = deferred<ClientCapabilities>();
     const { refresher, reprobe, revalidate } = makeRefresher({ initial: codexMissing() });
-    revalidate.mockReturnValueOnce(gate.promise);
+    revalidate.mockReturnValueOnce(gate.promise); // poll #1 hangs in flight
 
     await refresher.start();
-    // Kick the poll; revalidate is now pending (in-flight).
     await vi.advanceTimersByTimeAsync(BASE);
     expect(revalidate).toHaveBeenCalledTimes(1);
 
-    // A reconnect arriving mid-poll must be dropped, not run concurrently.
+    // A reconnect arriving mid-poll must NOT run concurrently with it...
     refresher.onReconnect();
     await vi.advanceTimersByTimeAsync(0);
     expect(reprobe).not.toHaveBeenCalled();
 
-    gate.resolve(allOk());
+    // ...but once the poll resolves, the held reconnect is drained in reconnect
+    // mode so its TTL/full re-probe still runs (the codex-assistant finding).
+    gate.resolve(codexMissing());
     await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(reprobe).toHaveBeenCalledTimes(1);
+    expect(reprobe).toHaveBeenLastCalledWith(codexMissing());
+    refresher.stop();
+  });
+
+  it("keeps polling when a recovery is probed but its upload fails, then stops once the server is in sync", async () => {
+    const { refresher, upload, revalidate } = makeRefresher({ initial: codexMissing() });
+    // Default revalidate already returns all-ok, so poll #1 recovers locally.
+    upload.mockReset();
+    upload.mockResolvedValue(undefined);
+    upload.mockResolvedValueOnce(undefined); // start: degraded snapshot uploads ok
+    upload.mockRejectedValueOnce(new Error("PATCH 503")); // poll #1 recovery upload FAILS
+
+    await refresher.start();
+    expect(upload).toHaveBeenCalledTimes(1);
+
+    // Poll #1 recovers to all-ok locally, but the upload fails: the poll must
+    // NOT stop — the server is still on the stale degraded snapshot (yuezengwu).
+    await vi.advanceTimersByTimeAsync(BASE);
+    expect(revalidate).toHaveBeenCalledTimes(1);
+    expect(upload).toHaveBeenCalledTimes(2);
+
+    // The failed upload resets the backoff, so the retry fires at BASE again and
+    // succeeds → server now in sync → poll stops.
+    await vi.advanceTimersByTimeAsync(BASE);
+    expect(revalidate).toHaveBeenCalledTimes(2);
+    expect(upload).toHaveBeenCalledTimes(3);
+
+    await vi.advanceTimersByTimeAsync(MAX * 4);
+    expect(revalidate).toHaveBeenCalledTimes(2); // healthy + synced → no more polls
     refresher.stop();
   });
 

--- a/apps/cli/src/__tests__/capability-refresh.test.ts
+++ b/apps/cli/src/__tests__/capability-refresh.test.ts
@@ -1,0 +1,228 @@
+import type { CapabilityEntry, ClientCapabilities } from "@first-tree/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CapabilityRefresher, type CapabilityRefresherDeps } from "../core/capability-refresh.js";
+
+/**
+ * The refresher unifies the daemon's two capability-refresh triggers — the WS
+ * reconnect re-probe and a bounded, backoff-scheduled background poll that runs
+ * while the daemon stays connected (the gap fixed for the "no runtime ready
+ * after install" issue). These tests cover the poll lifecycle, the upload
+ * dedupe, the backoff, the shared in-flight guard, and the reconnect path with
+ * the probe helpers injected (no real provider launches).
+ */
+
+const ok = (over: Partial<CapabilityEntry> = {}): CapabilityEntry => ({
+  state: "ok",
+  available: true,
+  authenticated: true,
+  authMethod: "oauth",
+  sdkVersion: "1.0.0",
+  detectedAt: "2026-06-17T00:00:00.000Z",
+  ...over,
+});
+
+const missing = (over: Partial<CapabilityEntry> = {}): CapabilityEntry => ({
+  state: "missing",
+  available: false,
+  authenticated: false,
+  authMethod: "none",
+  detectedAt: "2026-06-17T00:00:00.000Z",
+  ...over,
+});
+
+const allOk = (): ClientCapabilities => ({
+  "claude-code": ok(),
+  "claude-code-tui": ok(),
+  codex: ok(),
+});
+
+const codexMissing = (): ClientCapabilities => ({
+  "claude-code": ok(),
+  "claude-code-tui": ok(),
+  codex: missing(),
+});
+
+const BASE = 100;
+const MAX = 400;
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+function makeRefresher(overrides: Partial<CapabilityRefresherDeps> = {}): {
+  refresher: CapabilityRefresher;
+  upload: ReturnType<typeof vi.fn>;
+  log: ReturnType<typeof vi.fn>;
+  reprobe: ReturnType<typeof vi.fn>;
+  revalidate: ReturnType<typeof vi.fn>;
+} {
+  const upload = vi.fn(async () => undefined);
+  const log = vi.fn();
+  const reprobe = vi.fn(async () => ({ capabilities: allOk(), mode: "full" as const }));
+  const revalidate = vi.fn(async () => allOk());
+  const refresher = new CapabilityRefresher({
+    upload,
+    log,
+    reprobe,
+    revalidate,
+    baseMs: BASE,
+    maxMs: MAX,
+    ...overrides,
+  });
+  return { refresher, upload, log, reprobe, revalidate };
+}
+
+describe("CapabilityRefresher", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("uploads the startup snapshot once and does not poll when all providers are ok", async () => {
+    const { refresher, upload, revalidate } = makeRefresher({ initial: allOk() });
+    await refresher.start();
+
+    expect(upload).toHaveBeenCalledTimes(1);
+    expect(upload).toHaveBeenCalledWith(allOk());
+
+    await vi.advanceTimersByTimeAsync(MAX * 4);
+    expect(revalidate).not.toHaveBeenCalled();
+    refresher.stop();
+  });
+
+  it("polls a degraded snapshot, uploads the recovery, then stops once everything is ok", async () => {
+    const recovered = allOk();
+    const { refresher, upload, revalidate } = makeRefresher({ initial: codexMissing() });
+    revalidate.mockResolvedValueOnce(recovered);
+
+    await refresher.start();
+    expect(upload).toHaveBeenCalledTimes(1); // initial degraded snapshot
+
+    await vi.advanceTimersByTimeAsync(BASE);
+    expect(revalidate).toHaveBeenCalledTimes(1);
+    expect(revalidate).toHaveBeenCalledWith(codexMissing());
+    expect(upload).toHaveBeenCalledTimes(2); // recovery uploaded
+    expect(upload).toHaveBeenLastCalledWith(recovered);
+
+    // Now healthy → the poll is disarmed.
+    await vi.advanceTimersByTimeAsync(MAX * 4);
+    expect(revalidate).toHaveBeenCalledTimes(1);
+    refresher.stop();
+  });
+
+  it("skips the upload when a poll produces an unchanged snapshot, and backs off", async () => {
+    const { refresher, upload, revalidate } = makeRefresher({ initial: codexMissing() });
+    revalidate.mockResolvedValue(codexMissing()); // never changes
+
+    await refresher.start();
+    expect(upload).toHaveBeenCalledTimes(1);
+
+    // First poll at BASE: unchanged → no upload, backoff grows to 2×BASE.
+    await vi.advanceTimersByTimeAsync(BASE);
+    expect(revalidate).toHaveBeenCalledTimes(1);
+    expect(upload).toHaveBeenCalledTimes(1);
+
+    // Nothing fires before the backed-off interval elapses.
+    await vi.advanceTimersByTimeAsync(BASE);
+    expect(revalidate).toHaveBeenCalledTimes(1);
+
+    // Second poll at 2×BASE.
+    await vi.advanceTimersByTimeAsync(BASE);
+    expect(revalidate).toHaveBeenCalledTimes(2);
+    expect(upload).toHaveBeenCalledTimes(1);
+    refresher.stop();
+  });
+
+  it("resets the backoff when a poll observes a state change", async () => {
+    const { refresher, revalidate } = makeRefresher({ initial: codexMissing() });
+    // Each poll yields a different (still-degraded) snapshot → always "changed".
+    revalidate
+      .mockResolvedValueOnce({ ...codexMissing(), codex: missing({ error: "v1" }) })
+      .mockResolvedValueOnce({ ...codexMissing(), codex: missing({ error: "v2" }) });
+
+    await refresher.start();
+
+    await vi.advanceTimersByTimeAsync(BASE);
+    expect(revalidate).toHaveBeenCalledTimes(1);
+
+    // Changed → backoff stays at BASE (not 2×BASE), so the next poll fires after BASE again.
+    await vi.advanceTimersByTimeAsync(BASE);
+    expect(revalidate).toHaveBeenCalledTimes(2);
+    refresher.stop();
+  });
+
+  it("does not run a reconnect re-probe while a poll is already in flight", async () => {
+    const gate = deferred<ClientCapabilities>();
+    const { refresher, reprobe, revalidate } = makeRefresher({ initial: codexMissing() });
+    revalidate.mockReturnValueOnce(gate.promise);
+
+    await refresher.start();
+    // Kick the poll; revalidate is now pending (in-flight).
+    await vi.advanceTimersByTimeAsync(BASE);
+    expect(revalidate).toHaveBeenCalledTimes(1);
+
+    // A reconnect arriving mid-poll must be dropped, not run concurrently.
+    refresher.onReconnect();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(reprobe).not.toHaveBeenCalled();
+
+    gate.resolve(allOk());
+    await vi.advanceTimersByTimeAsync(0);
+    refresher.stop();
+  });
+
+  it("re-probes via reprobeOnReconnect on a reconnect and re-arms based on the result", async () => {
+    const { refresher, upload, reprobe } = makeRefresher({ initial: codexMissing() });
+    reprobe.mockResolvedValueOnce({ capabilities: allOk(), mode: "revalidate" as const });
+
+    refresher.onReconnect();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(reprobe).toHaveBeenCalledTimes(1);
+    expect(reprobe).toHaveBeenCalledWith(codexMissing());
+    expect(upload).toHaveBeenCalledWith(allOk());
+    refresher.stop();
+  });
+
+  it("arms the poll even when the startup upload fails (a later poll retries)", async () => {
+    const { refresher, upload, log, revalidate } = makeRefresher({ initial: codexMissing() });
+    upload.mockRejectedValueOnce(new Error("clients row not ready"));
+
+    await refresher.start();
+    expect(log).toHaveBeenCalledWith("⚠️", expect.stringContaining("capabilities upload skipped"));
+
+    await vi.advanceTimersByTimeAsync(BASE);
+    expect(revalidate).toHaveBeenCalledTimes(1);
+    refresher.stop();
+  });
+
+  it("stop() cancels a pending poll", async () => {
+    const { refresher, revalidate } = makeRefresher({ initial: codexMissing() });
+    await refresher.start();
+    refresher.stop();
+
+    await vi.advanceTimersByTimeAsync(MAX * 4);
+    expect(revalidate).not.toHaveBeenCalled();
+  });
+
+  it("treats a null startup snapshot as degraded and recovers via the poll", async () => {
+    const { refresher, upload, revalidate } = makeRefresher({ initial: null });
+    revalidate.mockResolvedValueOnce(allOk());
+
+    await refresher.start();
+    expect(upload).not.toHaveBeenCalled(); // nothing to upload yet
+
+    await vi.advanceTimersByTimeAsync(BASE);
+    expect(revalidate).toHaveBeenCalledTimes(1);
+    expect(revalidate).toHaveBeenCalledWith({}); // empty previous
+    expect(upload).toHaveBeenCalledWith(allOk());
+    refresher.stop();
+  });
+});

--- a/apps/cli/src/__tests__/daemon-start-command.test.ts
+++ b/apps/cli/src/__tests__/daemon-start-command.test.ts
@@ -13,6 +13,7 @@ const clientMocks = vi.hoisted(() => ({
 }));
 
 const coreMocks = vi.hoisted(() => ({
+  CapabilityRefresher: vi.fn(),
   ClientRuntime: vi.fn(),
   createApiNameResolver: vi.fn(),
   createExecuteUpdate: vi.fn(),
@@ -82,6 +83,11 @@ let runtimeInstance: {
   watchAgentsDir: ReturnType<typeof vi.fn>;
   onReconnect: ReturnType<typeof vi.fn>;
 };
+let refresherInstance: {
+  start: ReturnType<typeof vi.fn>;
+  onReconnect: ReturnType<typeof vi.fn>;
+  stop: ReturnType<typeof vi.fn>;
+};
 
 beforeEach(() => {
   home = mkdtempSync(join(tmpdir(), "ft-daemon-start-"));
@@ -136,6 +142,13 @@ beforeEach(() => {
     onReconnect: vi.fn(),
   };
   coreMocks.ClientRuntime.mockImplementation(() => runtimeInstance);
+
+  refresherInstance = {
+    start: vi.fn(async () => undefined),
+    onReconnect: vi.fn(),
+    stop: vi.fn(),
+  };
+  coreMocks.CapabilityRefresher.mockImplementation(() => refresherInstance);
 });
 
 afterEach(() => {
@@ -262,9 +275,14 @@ describe("daemon start command", () => {
     );
     expect(runtimeInstance.addAgent).toHaveBeenCalledWith("nova", expect.objectContaining({ agentId: "agent-1" }));
     expect(runtimeInstance.start).toHaveBeenCalled();
-    expect(coreMocks.uploadClientCapabilities).toHaveBeenCalledWith(
-      expect.objectContaining({ clientId: "client_1234abcd", capabilities: { "claude-code": { state: "ok" } } }),
+    // Capability refresh is owned by the refresher: it is seeded with the
+    // startup probe snapshot, wired to reconnect, and started (which uploads
+    // the snapshot and arms the background poll).
+    expect(coreMocks.CapabilityRefresher).toHaveBeenCalledWith(
+      expect.objectContaining({ initial: { "claude-code": { state: "ok" } } }),
     );
+    expect(runtimeInstance.onReconnect).toHaveBeenCalledWith(expect.any(Function));
+    expect(refresherInstance.start).toHaveBeenCalled();
     expect(coreMocks.listPinnedAgents).toHaveBeenCalledWith({
       serverUrl: "https://first-tree.example",
       accessToken: "access-token",
@@ -276,29 +294,18 @@ describe("daemon start command", () => {
     expect(output()).toContain("Error: stop after watch");
   });
 
-  it("re-probes on reconnect but skips uploading unchanged capabilities", async () => {
+  it("routes the runtime's reconnect callback into the capability refresher", async () => {
     await expect(runStart(["--foreground"])).rejects.toMatchObject({ exitCode: 1 });
-    expect(coreMocks.uploadClientCapabilities).toHaveBeenCalledTimes(1);
 
+    // start.ts no longer re-probes inline; it hands the runtime's reconnect
+    // signal to the refresher (whose probe/upload/dedup behavior is covered by
+    // capability-refresh.test.ts).
     const reconnect = runtimeInstance.onReconnect.mock.calls[0]?.[0];
     if (typeof reconnect !== "function") throw new Error("Reconnect callback was not registered");
 
+    expect(refresherInstance.onReconnect).not.toHaveBeenCalled();
     reconnect();
-    await flushAsync();
-    expect(clientMocks.reprobeOnReconnect).toHaveBeenCalledTimes(1);
-    expect(coreMocks.uploadClientCapabilities).toHaveBeenCalledTimes(1);
-
-    clientMocks.reprobeOnReconnect.mockResolvedValueOnce({
-      capabilities: { codex: { state: "missing" } },
-      mode: "full",
-    });
-    reconnect();
-    await flushAsync();
-    expect(clientMocks.reprobeOnReconnect).toHaveBeenCalledTimes(2);
-    expect(coreMocks.uploadClientCapabilities).toHaveBeenCalledTimes(2);
-    expect(coreMocks.uploadClientCapabilities).toHaveBeenLastCalledWith(
-      expect.objectContaining({ clientId: "client_1234abcd", capabilities: { codex: { state: "missing" } } }),
-    );
+    expect(refresherInstance.onReconnect).toHaveBeenCalledTimes(1);
   });
 
   it("skips skill upload for stale local aliases that are not pinned to this client", async () => {
@@ -347,7 +354,6 @@ describe("daemon start command", () => {
   it("continues when best-effort reconciliation and uploads fail", async () => {
     coreMocks.migrateLocalAgentDirs.mockRejectedValueOnce(new Error("rename failed"));
     coreMocks.reconcileLocalRuntimeProviders.mockRejectedValueOnce(new Error("runtime probe failed"));
-    coreMocks.uploadClientCapabilities.mockRejectedValueOnce(new Error("capabilities failed"));
     clientMocks.discoverClaudeCodeSkills.mockRejectedValueOnce(new Error("skill scan failed"));
 
     await expect(runStart(["--foreground"])).rejects.toMatchObject({ exitCode: 1 });
@@ -355,7 +361,6 @@ describe("daemon start command", () => {
     const text = output();
     expect(text).toContain("agent-dir migration skipped: rename failed");
     expect(text).toContain("runtime-provider reconcile skipped: runtime probe failed");
-    expect(text).toContain("capabilities upload skipped: capabilities failed");
     expect(text).toContain("skills upload skipped: skill scan failed");
   });
 

--- a/apps/cli/src/commands/daemon/probe.ts
+++ b/apps/cli/src/commands/daemon/probe.ts
@@ -15,11 +15,14 @@ import { isJsonMode, print } from "../../core/output.js";
 /**
  * `daemon probe` — run the launch-verified capability probes on demand.
  *
- * The daemon only probes at startup, so this is how an operator refreshes a
- * client's advertised capabilities after installing / logging into a provider
- * without restarting the daemon — and sees the real, verbatim probe result
- * locally. Each probe really launches its provider (a 1-turn haiku query / a
- * `codex doctor` handshake), so this is not free.
+ * The daemon refreshes capabilities automatically (at startup, on every WS
+ * reconnect, and via a bounded background poll while any provider is non-`ok`),
+ * so installing / logging into a provider is normally noticed without operator
+ * action. This command is the immediate, on-demand path — it forces a full
+ * re-probe + upload right now (instead of waiting for the next backed-off poll)
+ * and surfaces the real, verbatim probe result locally. Each probe really
+ * launches its provider (a 1-turn haiku query / a `codex doctor` handshake), so
+ * this is not free.
  *
  * Probing is purely local and needs no First Tree credentials; only the
  * (default) upload step requires a logged-in client. So `--no-upload` runs as

--- a/apps/cli/src/commands/daemon/start.ts
+++ b/apps/cli/src/commands/daemon/start.ts
@@ -6,7 +6,6 @@ import {
   configureClientLoggerForService,
   discoverClaudeCodeSkills,
   probeCapabilities,
-  reprobeOnReconnect,
 } from "@first-tree/client";
 import {
   agentConfigSchema,
@@ -23,6 +22,7 @@ import type { Command } from "commander";
 import { fail } from "../../cli/output.js";
 import { channelConfig } from "../../core/channel.js";
 import {
+  CapabilityRefresher,
   ClientRuntime,
   COMMAND_VERSION,
   createApiNameResolver,
@@ -45,15 +45,6 @@ import {
 } from "../../core/index.js";
 import { print } from "../../core/output.js";
 import { isWslDbusOvermount } from "./_shared/wsl-dbus.js";
-
-function stableJson(value: unknown): string {
-  if (value === null || typeof value !== "object") return JSON.stringify(value) ?? "null";
-  if (Array.isArray(value)) return `[${value.map((item) => stableJson(item)).join(",")}]`;
-  return `{${Object.entries(value)
-    .sort(([a], [b]) => a.localeCompare(b))
-    .map(([key, item]) => `${JSON.stringify(key)}:${stableJson(item)}`)
-    .join(",")}}`;
-}
 
 export function registerDaemonStartCommand(daemon: Command): void {
   daemon
@@ -253,64 +244,38 @@ export function registerDaemonStartCommand(daemon: Command): void {
           runtime.addAgent(name, agentConfig);
         }
 
-        let lastUploadedCapabilitiesJson: string | null = null;
-        const uploadCapabilitiesIfChanged = async (capabilities: Awaited<ReturnType<typeof probeCapabilities>>) => {
-          const nextJson = stableJson(capabilities);
-          if (lastUploadedCapabilitiesJson === nextJson) return false;
-          const accessToken = await ensureFreshAccessToken();
-          await uploadClientCapabilities({
-            serverUrl: config.server.url,
-            accessToken,
-            clientId: config.client.id,
-            capabilities,
-          });
-          lastUploadedCapabilitiesJson = nextJson;
-          return true;
-        };
-
-        // Re-probe runtime-provider capabilities on each WS reconnect. The
-        // startup probe goes stale while the daemon runs (a provider gets
-        // installed / logged in / removed), and there is otherwise no refresh
-        // until a restart. On reconnect we conditionally re-probe — a full real
-        // smoke only when the last result was non-ok or older than the TTL,
-        // else a free resolve+auth re-validate — then re-upload. Guarded against
-        // overlap; never throws into the connection.
-        let reprobeInFlight = false;
-        runtime.onReconnect(() => {
-          void (async () => {
-            if (reprobeInFlight) return;
-            reprobeInFlight = true;
-            try {
-              const { capabilities, mode } = await reprobeOnReconnect(probedCapabilities ?? {});
-              probedCapabilities = capabilities;
-              const uploaded = await uploadCapabilitiesIfChanged(capabilities);
-              print.status(
-                "•",
-                `runtime capabilities re-probed on reconnect (${mode})${uploaded ? " and uploaded" : "; unchanged, upload skipped"}`,
-              );
-            } catch (err) {
-              const msg = err instanceof Error ? err.message : String(err);
-              print.status("⚠️", `reconnect capability re-probe skipped: ${msg}`);
-            } finally {
-              reprobeInFlight = false;
-            }
-          })();
+        // Runtime-capability refresh as a single probing model. The refresher
+        // owns BOTH the WS-reconnect re-probe AND a bounded, backoff-scheduled
+        // background poll that runs while the daemon stays connected — the gap
+        // this fixes: the startup snapshot goes stale the instant the operator
+        // installs / logs into a provider, and with no reconnect there was
+        // otherwise no refresh until a restart or a manual `daemon probe`. The
+        // poll re-probes only while a provider is non-`ok` and stops once every
+        // provider is `ok`; reconnect and poll share one in-flight guard so
+        // providers are never launched concurrently. Uploads are deduped.
+        const capabilityRefresher = new CapabilityRefresher({
+          initial: probedCapabilities,
+          upload: async (capabilities) => {
+            const accessToken = await ensureFreshAccessToken();
+            await uploadClientCapabilities({
+              serverUrl: config.server.url,
+              accessToken,
+              clientId: config.client.id,
+              capabilities,
+            });
+          },
+          log: (symbol, msg) => print.status(symbol, msg),
         });
+        runtime.onReconnect(() => capabilityRefresher.onReconnect());
 
         await runtime.start();
 
-        // Post-register capabilities upload — the `clients` row only exists
-        // after the `client:register` WS handshake, so we run the PATCH here
-        // instead of pre-flight. Best-effort: a transient failure logs and
-        // moves on; agents still bind, and a subsequent restart retries.
-        if (probedCapabilities) {
-          try {
-            await uploadCapabilitiesIfChanged(probedCapabilities);
-          } catch (err) {
-            const msg = err instanceof Error ? err.message : String(err);
-            print.status("⚠️", `capabilities upload skipped: ${msg}`);
-          }
-        }
+        // Post-register capabilities upload + arm the background poll — the
+        // `clients` row only exists after the `client:register` WS handshake,
+        // so the first PATCH runs here rather than pre-flight. Best-effort: a
+        // transient failure logs and moves on; agents still bind, and the poll
+        // (or a later restart) retries.
+        await capabilityRefresher.start();
 
         // Post-register slash-command skill upload. Phase 1B scope is
         // user-global Claude Code skills — every claude-code agent on this
@@ -375,6 +340,7 @@ export function registerDaemonStartCommand(daemon: Command): void {
         // Graceful shutdown
         const shutdown = async () => {
           print.line("\n  Shutting down...\n");
+          capabilityRefresher.stop();
           runtime.unwatchAgentsDir();
           await runtime.stop();
           process.exit(0);

--- a/apps/cli/src/core/capability-refresh.ts
+++ b/apps/cli/src/core/capability-refresh.ts
@@ -69,6 +69,10 @@ export class CapabilityRefresher {
   private snapshot: ClientCapabilities | null;
   private lastUploadedJson: string | null = null;
   private inFlight = false;
+  /** A reconnect that landed while a refresh was in flight, to be drained (in
+   * reconnect mode) once the current refresh finishes — never dropped, so the
+   * reconnect TTL/full re-probe path is always honored. */
+  private pendingReconnect = false;
   private timer: ReturnType<typeof setTimeout> | null = null;
   /** Consecutive polls with no observed state change — drives the backoff. */
   private idleAttempts = 0;
@@ -84,9 +88,10 @@ export class CapabilityRefresher {
   }
 
   /**
-   * Push the startup snapshot to the server (deduped) and, if any provider is
-   * not yet `ok`, arm the background poll. Best-effort: an upload failure is
-   * logged and the poll is still armed (a later poll re-tries the upload).
+   * Push the startup snapshot to the server (deduped) and arm the background
+   * poll if a refresh is still warranted (a non-`ok` provider, or a snapshot
+   * the server has not confirmed). Best-effort: an upload failure is logged and
+   * the poll is still armed (a later poll re-tries the upload).
    */
   async start(): Promise<void> {
     if (this.snapshot) {
@@ -103,9 +108,15 @@ export class CapabilityRefresher {
   /**
    * Re-probe after a WS reconnect (full or revalidate per the TTL policy), then
    * re-arm or stop the poll based on the fresh snapshot. Fire-and-forget; never
-   * throws into the connection. No-op if a refresh is already in flight.
+   * throws into the connection.
+   *
+   * If a refresh is already in flight (e.g. a degraded-state poll), the
+   * reconnect is recorded as pending and drained in reconnect mode once that
+   * refresh finishes — it is never dropped, so the reconnect's TTL/full
+   * re-probe always runs even when it coincides with a poll.
    */
   onReconnect(): void {
+    this.pendingReconnect = true;
     void this.runRefresh("reconnect");
   }
 
@@ -131,52 +142,80 @@ export class CapabilityRefresher {
   }
 
   private async runRefresh(trigger: "reconnect" | "poll"): Promise<void> {
-    if (this.inFlight || this.stopped) return;
+    if (this.stopped) return;
+    if (this.inFlight) return; // a coincident reconnect is held in pendingReconnect
+
     this.inFlight = true;
     try {
+      // A reconnect that arrived (now, or while a prior refresh ran) wins over a
+      // poll: it carries the stricter TTL/full re-probe semantics. Drain the
+      // intent into this run so it is honored rather than dropped.
+      const effective: "reconnect" | "poll" = this.pendingReconnect ? "reconnect" : trigger;
+      this.pendingReconnect = false;
+
       const previous = this.snapshot ?? {};
-      let next: ClientCapabilities;
-      let modeLabel: string;
-      if (trigger === "reconnect") {
-        const { capabilities, mode } = await this.reprobe(previous);
-        next = capabilities;
-        modeLabel = `reconnect, ${mode}`;
-      } else {
-        next = await this.revalidate(previous);
-        modeLabel = "poll";
+      let probed = false;
+      try {
+        let next: ClientCapabilities;
+        let modeLabel: string;
+        if (effective === "reconnect") {
+          const { capabilities, mode } = await this.reprobe(previous);
+          next = capabilities;
+          modeLabel = `reconnect, ${mode}`;
+        } else {
+          next = await this.revalidate(previous);
+          modeLabel = "poll";
+        }
+        probed = true;
+        const changed = stableCapabilitiesJson(next) !== stableCapabilitiesJson(previous);
+        this.snapshot = next;
+        // Upload is tracked separately from the probe: a probe that recovered a
+        // provider to `ok` but whose PATCH failed must NOT let the poll stop —
+        // the server would otherwise stay on the stale degraded snapshot. The
+        // upload failure resets the backoff so the retry is prompt.
+        let uploadFailed = false;
+        try {
+          const uploaded = await this.uploadIfChanged(next);
+          this.deps.log(
+            "•",
+            `runtime capabilities re-probed (${modeLabel})${uploaded ? " and uploaded" : "; unchanged, upload skipped"}`,
+          );
+        } catch (uploadErr) {
+          uploadFailed = true;
+          this.deps.log("⚠️", `capabilities upload skipped: ${message(uploadErr)}`);
+        }
+        // A reconnect, an observed state change, or a failed upload all warrant
+        // a prompt next attempt; only an unchanged, fully-synced poll backs off.
+        this.idleAttempts = effective === "reconnect" || changed || uploadFailed ? 0 : this.idleAttempts + 1;
+      } catch (probeErr) {
+        this.deps.log("⚠️", `${effective} capability re-probe skipped: ${message(probeErr)}`);
+        // Keep polling on a transient probe failure so the daemon still converges.
       }
-      const changed = stableCapabilitiesJson(next) !== stableCapabilitiesJson(previous);
-      this.snapshot = next;
-      const uploaded = await this.uploadIfChanged(next);
-      this.deps.log(
-        "•",
-        `runtime capabilities re-probed (${modeLabel})${uploaded ? " and uploaded" : "; unchanged, upload skipped"}`,
-      );
-      // A reconnect is a fresh external trigger, so reset the backoff; for a
-      // poll, a state change means the operator is actively setting up (poll
-      // again quickly), while an unchanged poll lets the interval grow toward
-      // the ceiling.
-      this.idleAttempts = trigger === "reconnect" || changed ? 0 : this.idleAttempts + 1;
-      this.scheduleNext();
-    } catch (err) {
-      this.deps.log("⚠️", `${trigger} capability re-probe skipped: ${message(err)}`);
-      // Keep polling on a transient failure so the daemon still converges.
+      if (!probed) this.idleAttempts += 1;
       this.scheduleNext();
     } finally {
       this.inFlight = false;
     }
+
+    // A reconnect that landed while this refresh ran is drained now (in
+    // reconnect mode), so its TTL/full re-probe is never skipped.
+    if (this.pendingReconnect && !this.stopped) {
+      void this.runRefresh("reconnect");
+    }
   }
 
   /**
-   * Arm the next poll when the snapshot still has a non-`ok` provider (a null
-   * snapshot — the startup probe failed — also counts as degraded), else cancel
-   * it. The interval is read from `idleAttempts`, which the callers advance.
+   * Arm the next poll while a refresh is still warranted, else cancel it. A
+   * refresh is warranted when the snapshot is missing (startup probe failed),
+   * still has a non-`ok` provider, OR is healthy but not yet confirmed uploaded
+   * to the server (a prior PATCH failed) — the poll must keep going until the
+   * server actually reflects readiness. The interval is read from
+   * `idleAttempts`, which the callers advance.
    */
   private scheduleNext(): void {
     this.clearPending();
     if (this.stopped) return;
-    const degraded = !this.snapshot || hasNonOkProvider(this.snapshot);
-    if (!degraded) {
+    if (!this.needsRefresh()) {
       this.idleAttempts = 0;
       return;
     }
@@ -188,6 +227,16 @@ export class CapabilityRefresher {
       this.timer = null;
       void this.runRefresh("poll");
     }, delay);
+  }
+
+  /** True while the daemon should keep re-probing: no snapshot yet, a provider
+   * is still non-`ok`, or the current healthy snapshot has not been confirmed
+   * uploaded (so the server may still show stale "no runtime ready"). */
+  private needsRefresh(): boolean {
+    const snap = this.snapshot;
+    if (!snap) return true;
+    if (hasNonOkProvider(snap)) return true;
+    return stableCapabilitiesJson(snap) !== this.lastUploadedJson;
   }
 }
 

--- a/apps/cli/src/core/capability-refresh.ts
+++ b/apps/cli/src/core/capability-refresh.ts
@@ -1,0 +1,196 @@
+import {
+  hasNonOkProvider,
+  nextCapabilityRefreshDelayMs,
+  reprobeOnReconnect,
+  revalidateCapabilities,
+} from "@first-tree/client";
+import type { ClientCapabilities } from "@first-tree/shared";
+
+/**
+ * Stable JSON stringify — sorts object keys so two capability snapshots that
+ * differ only in key order serialize identically. Used to dedupe uploads: a
+ * re-probe that produced the same snapshot must not re-PATCH the server.
+ */
+export function stableCapabilitiesJson(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value) ?? "null";
+  if (Array.isArray(value)) return `[${value.map((item) => stableCapabilitiesJson(item)).join(",")}]`;
+  return `{${Object.entries(value)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, item]) => `${JSON.stringify(key)}:${stableCapabilitiesJson(item)}`)
+    .join(",")}}`;
+}
+
+export type CapabilityRefresherDeps = {
+  /** PATCH the snapshot to the server. The caller owns access-token + clientId
+   * wiring; the refresher only decides *when* and *whether changed*. */
+  upload: (capabilities: ClientCapabilities) => Promise<void>;
+  /** Status logger (symbol + message), e.g. `print.status`. */
+  log: (symbol: string, message: string) => void;
+  /** Initial snapshot from the daemon's startup probe (null if it failed). */
+  initial?: ClientCapabilities | null;
+  /** Override the backoff base (test seam). */
+  baseMs?: number;
+  /** Override the backoff ceiling (test seam). */
+  maxMs?: number;
+  /** Timer seam — defaults to global setTimeout/clearTimeout. */
+  setTimer?: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>;
+  clearTimer?: (handle: ReturnType<typeof setTimeout>) => void;
+  /** Injected probe helpers (test seam). */
+  reprobe?: typeof reprobeOnReconnect;
+  revalidate?: typeof revalidateCapabilities;
+};
+
+/**
+ * Owns the daemon's post-registration runtime-capability refresh as a SINGLE
+ * probing model, so the two refresh triggers never overlap or fight:
+ *
+ *   1. WS reconnect (`onReconnect`) — TTL-aware full-or-revalidate via
+ *      {@link reprobeOnReconnect}, preserving the existing reconnect behavior.
+ *   2. A bounded, backoff-scheduled background poll (`start`) that fires *while
+ *      the daemon stays connected* — the gap this fixes. A capability snapshot
+ *      goes stale the moment the operator installs / logs into a provider; with
+ *      no reconnect there was previously no refresh until a restart or a manual
+ *      `daemon probe`. The poll re-probes with {@link revalidateCapabilities}
+ *      (a real smoke for each non-`ok` provider so a freshly-installed one can
+ *      flip to `ok`; already-`ok` providers stay on the free cached path), and
+ *      stops itself once every built-in provider is `ok`.
+ *
+ * Both triggers share one in-flight guard, so a reconnect re-probe and a poll
+ * can never launch providers concurrently, and uploads are deduped against the
+ * last snapshot actually sent.
+ */
+export class CapabilityRefresher {
+  private readonly deps: CapabilityRefresherDeps;
+  private readonly setTimer: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>;
+  private readonly clearTimer: (handle: ReturnType<typeof setTimeout>) => void;
+  private readonly reprobe: typeof reprobeOnReconnect;
+  private readonly revalidate: typeof revalidateCapabilities;
+
+  private snapshot: ClientCapabilities | null;
+  private lastUploadedJson: string | null = null;
+  private inFlight = false;
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  /** Consecutive polls with no observed state change — drives the backoff. */
+  private idleAttempts = 0;
+  private stopped = false;
+
+  constructor(deps: CapabilityRefresherDeps) {
+    this.deps = deps;
+    this.snapshot = deps.initial ?? null;
+    this.setTimer = deps.setTimer ?? ((fn, ms) => setTimeout(fn, ms));
+    this.clearTimer = deps.clearTimer ?? ((handle) => clearTimeout(handle));
+    this.reprobe = deps.reprobe ?? reprobeOnReconnect;
+    this.revalidate = deps.revalidate ?? revalidateCapabilities;
+  }
+
+  /**
+   * Push the startup snapshot to the server (deduped) and, if any provider is
+   * not yet `ok`, arm the background poll. Best-effort: an upload failure is
+   * logged and the poll is still armed (a later poll re-tries the upload).
+   */
+  async start(): Promise<void> {
+    if (this.snapshot) {
+      try {
+        await this.uploadIfChanged(this.snapshot);
+      } catch (err) {
+        this.deps.log("⚠️", `capabilities upload skipped: ${message(err)}`);
+      }
+    }
+    this.idleAttempts = 0;
+    this.scheduleNext();
+  }
+
+  /**
+   * Re-probe after a WS reconnect (full or revalidate per the TTL policy), then
+   * re-arm or stop the poll based on the fresh snapshot. Fire-and-forget; never
+   * throws into the connection. No-op if a refresh is already in flight.
+   */
+  onReconnect(): void {
+    void this.runRefresh("reconnect");
+  }
+
+  /** Tear down the poll timer. Call on daemon shutdown. */
+  stop(): void {
+    this.stopped = true;
+    this.clearPending();
+  }
+
+  private clearPending(): void {
+    if (this.timer !== null) {
+      this.clearTimer(this.timer);
+      this.timer = null;
+    }
+  }
+
+  private async uploadIfChanged(capabilities: ClientCapabilities): Promise<boolean> {
+    const nextJson = stableCapabilitiesJson(capabilities);
+    if (this.lastUploadedJson === nextJson) return false;
+    await this.deps.upload(capabilities);
+    this.lastUploadedJson = nextJson;
+    return true;
+  }
+
+  private async runRefresh(trigger: "reconnect" | "poll"): Promise<void> {
+    if (this.inFlight || this.stopped) return;
+    this.inFlight = true;
+    try {
+      const previous = this.snapshot ?? {};
+      let next: ClientCapabilities;
+      let modeLabel: string;
+      if (trigger === "reconnect") {
+        const { capabilities, mode } = await this.reprobe(previous);
+        next = capabilities;
+        modeLabel = `reconnect, ${mode}`;
+      } else {
+        next = await this.revalidate(previous);
+        modeLabel = "poll";
+      }
+      const changed = stableCapabilitiesJson(next) !== stableCapabilitiesJson(previous);
+      this.snapshot = next;
+      const uploaded = await this.uploadIfChanged(next);
+      this.deps.log(
+        "•",
+        `runtime capabilities re-probed (${modeLabel})${uploaded ? " and uploaded" : "; unchanged, upload skipped"}`,
+      );
+      // A reconnect is a fresh external trigger, so reset the backoff; for a
+      // poll, a state change means the operator is actively setting up (poll
+      // again quickly), while an unchanged poll lets the interval grow toward
+      // the ceiling.
+      this.idleAttempts = trigger === "reconnect" || changed ? 0 : this.idleAttempts + 1;
+      this.scheduleNext();
+    } catch (err) {
+      this.deps.log("⚠️", `${trigger} capability re-probe skipped: ${message(err)}`);
+      // Keep polling on a transient failure so the daemon still converges.
+      this.scheduleNext();
+    } finally {
+      this.inFlight = false;
+    }
+  }
+
+  /**
+   * Arm the next poll when the snapshot still has a non-`ok` provider (a null
+   * snapshot — the startup probe failed — also counts as degraded), else cancel
+   * it. The interval is read from `idleAttempts`, which the callers advance.
+   */
+  private scheduleNext(): void {
+    this.clearPending();
+    if (this.stopped) return;
+    const degraded = !this.snapshot || hasNonOkProvider(this.snapshot);
+    if (!degraded) {
+      this.idleAttempts = 0;
+      return;
+    }
+    const delay = nextCapabilityRefreshDelayMs(this.idleAttempts, {
+      baseMs: this.deps.baseMs,
+      maxMs: this.deps.maxMs,
+    });
+    this.timer = this.setTimer(() => {
+      this.timer = null;
+      void this.runRefresh("poll");
+    }, delay);
+  }
+}
+
+function message(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/apps/cli/src/core/index.ts
+++ b/apps/cli/src/core/index.ts
@@ -14,6 +14,9 @@ export {
   saveAgentConfig,
   saveCredentials,
 } from "./bootstrap.js";
+export type { CapabilityRefresherDeps } from "./capability-refresh.js";
+// Runtime-capability refresh (reconnect re-probe + bounded background poll)
+export { CapabilityRefresher, stableCapabilitiesJson } from "./capability-refresh.js";
 export { cliFetch } from "./cli-fetch.js";
 // Local client identity rotation (on CLIENT_ORG_MISMATCH)
 export { handleClientOrgMismatch, rotateClientIdWithBackup } from "./client-reidentify.js";

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -476,7 +476,15 @@ still-launchable, still-logged-in provider keeps its prior `ok` for free
 binary or login downgrades, and a non-ok provider is fully re-probed so it can
 recover. So a machine missing an optional provider (e.g. no tmux for
 `claude-code-tui`) does not re-smoke its healthy providers on every reconnect.
-`daemon probe` is the manual, on-demand path between those automatic refreshes.
+
+**While the daemon stays connected**, it also runs a bounded background
+re-probe whenever any provider is not yet `ok` — so installing or logging into
+a provider is noticed within a bounded time without a restart or reconnect. The
+poll starts ~15s after the degraded state is seen and backs off to a 5-minute
+ceiling, re-probes only the non-`ok` providers (already-`ok` ones stay on the
+free cached path), uploads only when the snapshot actually changes, and stops
+once every provider is `ok`. `daemon probe` remains the manual, on-demand path
+to force an immediate full re-probe + upload.
 
 The top-level `first-tree status` is the cross-subsystem overview that
 calls `daemon status` internally and adds server/auth/agent rows.

--- a/packages/client/src/__tests__/capability-reprobe.test.ts
+++ b/packages/client/src/__tests__/capability-reprobe.test.ts
@@ -1,6 +1,13 @@
 import type { CapabilityEntry, ClientCapabilities } from "@first-tree/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { REPROBE_MAX_AGE_MS, shouldFullReprobe } from "../runtime/capabilities/index.js";
+import {
+  CAPABILITY_REFRESH_BASE_MS,
+  CAPABILITY_REFRESH_MAX_MS,
+  hasNonOkProvider,
+  nextCapabilityRefreshDelayMs,
+  REPROBE_MAX_AGE_MS,
+  shouldFullReprobe,
+} from "../runtime/capabilities/index.js";
 
 /**
  * Reconnect re-probe policy (PR-2b): on a WS reconnect the daemon either runs
@@ -55,6 +62,63 @@ describe("shouldFullReprobe", () => {
 
   it("unparseable detectedAt → full (treat as unknown age)", () => {
     expect(shouldFullReprobe({ codex: okEntry({ detectedAt: "not-a-date" }) }, now)).toBe(true);
+  });
+});
+
+describe("hasNonOkProvider", () => {
+  it("empty snapshot is degraded (no provider has reached ok yet)", () => {
+    expect(hasNonOkProvider({})).toBe(true);
+  });
+
+  it("a partial snapshot missing a built-in provider is degraded", () => {
+    // claude-code-tui + codex are absent → still degraded.
+    expect(hasNonOkProvider({ "claude-code": okEntry() })).toBe(true);
+  });
+
+  it("all built-in providers ok → not degraded (stops the poll)", () => {
+    expect(
+      hasNonOkProvider({
+        "claude-code": okEntry(),
+        "claude-code-tui": okEntry(),
+        codex: okEntry(),
+      }),
+    ).toBe(false);
+  });
+
+  it("any non-ok built-in provider keeps it degraded", () => {
+    expect(
+      hasNonOkProvider({
+        "claude-code": okEntry(),
+        "claude-code-tui": okEntry(),
+        codex: okEntry({ state: "unauthenticated", authenticated: false }),
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("nextCapabilityRefreshDelayMs", () => {
+  it("first poll uses the base delay", () => {
+    expect(nextCapabilityRefreshDelayMs(0)).toBe(CAPABILITY_REFRESH_BASE_MS);
+  });
+
+  it("doubles per attempt", () => {
+    expect(nextCapabilityRefreshDelayMs(1)).toBe(CAPABILITY_REFRESH_BASE_MS * 2);
+    expect(nextCapabilityRefreshDelayMs(2)).toBe(CAPABILITY_REFRESH_BASE_MS * 4);
+  });
+
+  it("clamps to the ceiling and never overflows", () => {
+    expect(nextCapabilityRefreshDelayMs(100)).toBe(CAPABILITY_REFRESH_MAX_MS);
+    expect(Number.isFinite(nextCapabilityRefreshDelayMs(1000))).toBe(true);
+  });
+
+  it("treats negative / non-finite attempts as the first poll", () => {
+    expect(nextCapabilityRefreshDelayMs(-5)).toBe(CAPABILITY_REFRESH_BASE_MS);
+    expect(nextCapabilityRefreshDelayMs(Number.NaN)).toBe(CAPABILITY_REFRESH_BASE_MS);
+  });
+
+  it("honors injected base/max overrides", () => {
+    expect(nextCapabilityRefreshDelayMs(3, { baseMs: 1000, maxMs: 4000 })).toBe(4000);
+    expect(nextCapabilityRefreshDelayMs(1, { baseMs: 1000, maxMs: 8000 })).toBe(2000);
   });
 });
 

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -27,6 +27,11 @@ export {
 export { probeClaudeCodeCapability } from "./runtime/capabilities/claude-code.js";
 export { probeCodexCapability } from "./runtime/capabilities/codex.js";
 export {
+  CAPABILITY_REFRESH_BASE_MS,
+  CAPABILITY_REFRESH_MAX_MS,
+  hasNonOkProvider,
+  nextCapabilityRefreshDelayMs,
+  PROBED_RUNTIME_PROVIDERS,
   probeCapabilities,
   REPROBE_MAX_AGE_MS,
   reprobeOnReconnect,

--- a/packages/client/src/runtime/capabilities/index.ts
+++ b/packages/client/src/runtime/capabilities/index.ts
@@ -8,6 +8,48 @@ import type { SmokeOutcome } from "./launch-probe.js";
  * real smoke at most this often on reconnect, to catch silent drift. */
 export const REPROBE_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 
+/** The runtime providers a built-in probe exists for. Used by
+ * {@link hasNonOkProvider} to decide whether a daemon's advertised capability
+ * snapshot still has a provider worth re-probing for. */
+export const PROBED_RUNTIME_PROVIDERS: readonly RuntimeProvider[] = ["claude-code", "claude-code-tui", "codex"];
+
+/** First delay before the daemon-side degraded-capability re-probe fires. Short
+ * enough that a freshly-installed provider is noticed quickly during setup. */
+export const CAPABILITY_REFRESH_BASE_MS = 15 * 1000;
+
+/** Upper bound on the backoff between degraded-capability re-probes. Once the
+ * interval reaches this ceiling it stays there, so a permanently-missing
+ * provider (e.g. `claude-code-tui` on a no-tmux box) settles into a cheap,
+ * low-frequency poll rather than hammering the host. */
+export const CAPABILITY_REFRESH_MAX_MS = 5 * 60 * 1000;
+
+/**
+ * True when the snapshot still has a built-in provider that is not `ok` — i.e.
+ * a provider that could still become usable if the operator installs / logs in.
+ * An empty or partial snapshot counts as degraded (a provider that was never
+ * probed is not yet `ok`). Drives whether the daemon keeps a background
+ * re-probe scheduled while it stays connected.
+ */
+export function hasNonOkProvider(caps: ClientCapabilities): boolean {
+  return PROBED_RUNTIME_PROVIDERS.some((provider) => caps[provider]?.state !== "ok");
+}
+
+/**
+ * Exponential backoff for the degraded-capability re-probe loop:
+ * `base * 2^attempt`, clamped to `max`. `attempt` is 0 for the first poll after
+ * a state change and increments while nothing changes, so an actively-setting-up
+ * machine is polled quickly and an idle degraded machine slows to the ceiling.
+ */
+export function nextCapabilityRefreshDelayMs(attempt: number, opts: { baseMs?: number; maxMs?: number } = {}): number {
+  const baseMs = opts.baseMs ?? CAPABILITY_REFRESH_BASE_MS;
+  const maxMs = opts.maxMs ?? CAPABILITY_REFRESH_MAX_MS;
+  const safeAttempt = Number.isFinite(attempt) && attempt > 0 ? Math.floor(attempt) : 0;
+  // Cap the exponent so `2 ** attempt` cannot overflow to Infinity before the
+  // Math.min clamp runs.
+  const exponent = Math.min(safeAttempt, 30);
+  return Math.min(maxMs, baseMs * 2 ** exponent);
+}
+
 function errorEntry(err: unknown): CapabilityEntry {
   return {
     state: "error",


### PR DESCRIPTION
## Problem

Closes #1118.

Runtime-provider readiness could stay stale after a user installs or logs into a provider while the daemon is already connected. The daemon only refreshed its capability snapshot at **startup** and on **WS reconnect**. With a connected daemon, installing/logging into Claude Code or Codex went unnoticed, so the server/web UI could keep showing **"no runtime ready"** until the user ran `daemon probe`, restarted, or happened to reconnect.

## Fix

Unify the refresh triggers behind a single `CapabilityRefresher` (`apps/cli/src/core/capability-refresh.ts`) with **one shared in-flight guard**, so a reconnect re-probe and the new background poll never launch providers concurrently:

- **Reconnect re-probe** reuses `reprobeOnReconnect` — behavior unchanged (TTL-aware full-vs-revalidate). A reconnect that lands while a refresh is already running is **held and drained in reconnect mode** afterward (never dropped); when it coincides with a poll, the stricter reconnect TTL/full path wins.
- **New bounded background poll** runs *while the daemon stays connected* whenever a refresh is still warranted:
  - starts ~15s after the degraded state is observed, exponential backoff to a **5-min ceiling**;
  - re-probes **only the non-`ok` providers** via `revalidateCapabilities` (already-`ok` providers stay on the free cached resolve+auth path — no repeated full smokes);
  - uploads **only when the snapshot changes** (deduped);
  - **stops only once every provider is `ok` AND that healthy snapshot is confirmed uploaded** — a recovery whose PATCH failed keeps the poll alive (and resets the backoff) so the server can't be left on the stale degraded snapshot;
  - a permanently-missing provider (e.g. `claude-code-tui` on a no-tmux box) settles into the cheap 5-min poll, where its resolve stage short-circuits without a launch.

No server/web changes — the web "no runtime ready" gate clears automatically once the next changed snapshot uploads. The optional explicit web "refresh runtimes" button is deferred (the issue lists it as a maybe; the bounded auto-poll satisfies the default-path acceptance criteria).

## Acceptance criteria

- [x] Install/login while connected refreshes within a bounded time (no restart/reconnect needed).
- [x] Server/web stops showing stale "no runtime ready" once the provider is usable (poll only stops after the healthy snapshot is confirmed uploaded).
- [x] No overlapping probes (shared in-flight guard); no expensive full smoke on every interval for healthy providers (revalidate keeps `ok` cached).
- [x] Existing reconnect re-probe behavior preserved (a reconnect coinciding with a poll is deferred, then run in reconnect mode — never dropped).
- [x] Docs/setup copy updated (`cli-reference.md`, `daemon probe` help).

## Tests

New pure-helper tests (`hasNonOkProvider`, `nextCapabilityRefreshDelayMs`) and a behavioral `capability-refresh.test.ts` covering: poll → recover → stop, upload dedupe, backoff growth/reset, a reconnect deferred-then-drained mid-poll, recovery-but-upload-fails → keeps polling → stops once synced, the reconnect path, and null-snapshot recovery. Existing `daemon-start-command.test.ts` updated for the refactor.

Verified locally: `pnpm typecheck` clean, CLI 491/491 + client 1036/1036 green, `pnpm check` clean.

## Context Tree

Paired tree PR updates the Capabilities Probe refresh-timing note in `system/cloud/runtime/client-runtime.md`: agent-team-foundation/first-tree-context#568 (https://github.com/agent-team-foundation/first-tree-context/pull/568).
