### PR TITLE
fix(chat ask): skip-as-answer + instant-in-chat takeover hardening

### DIFF
--- a/packages/server/src/__tests__/activity.test.ts
+++ b/packages/server/src/__tests__/activity.test.ts
@@ -19,6 +19,7 @@ function makeNotifier(): Notifier {
     notifyRuntimeStateChange: vi.fn(async () => {}),
     notifySessionRuntime: vi.fn(async () => {}),
     notifyChatMessage: vi.fn(async () => {}),
+    notifyChatAudience: vi.fn(async () => {}),
     notifySessionEvent: vi.fn(async () => {}),
     pushFrameToInbox: vi.fn(async () => 0),
     onConfigChange: vi.fn(),
@@ -27,6 +28,7 @@ function makeNotifier(): Notifier {
     onRuntimeStateChange: vi.fn(),
     onSessionRuntime: vi.fn(),
     onChatMessage: vi.fn(),
+    onChatAudience: vi.fn(),
     start: vi.fn(async () => {}),
     stop: vi.fn(async () => {}),
   } satisfies Notifier;
@@ -142,6 +144,7 @@ describe("upsertSessionState — touchPresenceLastSeen option", () => {
       notifyRuntimeStateChange: vi.fn(async () => {}),
       notifySessionRuntime: vi.fn(async () => {}),
       notifyChatMessage: vi.fn(async () => {}),
+      notifyChatAudience: vi.fn(async () => {}),
       notifySessionEvent: vi.fn(async () => {}),
       pushFrameToInbox: vi.fn(async () => 0),
       onConfigChange: vi.fn(),
@@ -150,6 +153,7 @@ describe("upsertSessionState — touchPresenceLastSeen option", () => {
       onRuntimeStateChange: vi.fn(),
       onSessionRuntime: vi.fn(),
       onChatMessage: vi.fn(),
+      onChatAudience: vi.fn(),
       start: vi.fn(async () => {}),
       stop: vi.fn(async () => {}),
     } satisfies Notifier;
@@ -180,6 +184,7 @@ describe("upsertSessionState — touchPresenceLastSeen option", () => {
       notifyRuntimeStateChange: vi.fn(async () => {}),
       notifySessionRuntime: vi.fn(async () => {}),
       notifyChatMessage: vi.fn(async () => {}),
+      notifyChatAudience: vi.fn(async () => {}),
       notifySessionEvent: vi.fn(async () => {}),
       pushFrameToInbox: vi.fn(async () => 0),
       onConfigChange: vi.fn(),
@@ -188,6 +193,7 @@ describe("upsertSessionState — touchPresenceLastSeen option", () => {
       onRuntimeStateChange: vi.fn(),
       onSessionRuntime: vi.fn(),
       onChatMessage: vi.fn(),
+      onChatAudience: vi.fn(),
       start: vi.fn(async () => {}),
       stop: vi.fn(async () => {}),
     } satisfies Notifier;

--- a/packages/server/src/__tests__/chat-audience-cache.test.ts
+++ b/packages/server/src/__tests__/chat-audience-cache.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  invalidateChatAudience,
+  invalidateChatAudienceLocal,
+  registerChatAudienceDispatcher,
+  resetChatAudienceDispatcher,
+} from "../services/chat-audience-cache.js";
+
+describe("chat-audience-cache cross-replica invalidation", () => {
+  afterEach(() => resetChatAudienceDispatcher());
+
+  it("invalidateChatAudience fans the invalidation out to the registered dispatcher", () => {
+    const dispatched: string[] = [];
+    registerChatAudienceDispatcher((chatId) => dispatched.push(chatId));
+    invalidateChatAudience("chat-1");
+    expect(dispatched).toEqual(["chat-1"]);
+  });
+
+  it("invalidateChatAudienceLocal drops locally WITHOUT fanning out (prevents NOTIFY loops)", () => {
+    const dispatched: string[] = [];
+    registerChatAudienceDispatcher((chatId) => dispatched.push(chatId));
+    invalidateChatAudienceLocal("chat-1");
+    expect(dispatched).toEqual([]);
+  });
+
+  it("a throwing dispatcher does not propagate (fan-out is best-effort)", () => {
+    registerChatAudienceDispatcher(() => {
+      throw new Error("notify failed");
+    });
+    expect(() => invalidateChatAudience("chat-1")).not.toThrow();
+  });
+
+  it("is a no-op when no dispatcher is registered (single-process / tests)", () => {
+    resetChatAudienceDispatcher();
+    expect(() => invalidateChatAudience("chat-1")).not.toThrow();
+  });
+});

--- a/packages/server/src/__tests__/chat-open-requests-route.test.ts
+++ b/packages/server/src/__tests__/chat-open-requests-route.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { createAgent } from "../services/agent.js";
+import { createMeChat } from "../services/me-chat.js";
+import { sendMessage } from "../services/message.js";
+import { createTestAdmin, useTestApp } from "./helpers.js";
+
+/**
+ * `GET /api/v1/chats/:chatId/open-requests` must be served on the USER-scope
+ * chat router — the route the web actually calls (the same scope as
+ * `/chats/:chatId/messages`).
+ *
+ * Regression guard: the window-independent open-requests source was first
+ * wired only onto the agent-scope router, so the web's member-JWT call 404'd
+ * and an open ask that had scrolled past the latest message page never
+ * surfaced in the blocking takeover. This pins the route to the web scope and
+ * the open/resolved semantics it returns.
+ */
+describe("GET /chats/:chatId/open-requests — user-scope route", () => {
+  const getApp = useTestApp();
+
+  it("returns the viewer's open asks and drops them once resolved", async () => {
+    const app = getApp();
+    const alice = await createTestAdmin(app);
+    const peer = await createAgent(app.db, {
+      name: `open-req-peer-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "Open Req Peer",
+      managerId: alice.memberId,
+      organizationId: alice.organizationId,
+    });
+    const { chatId } = await createMeChat(app.db, alice.humanAgentUuid, alice.organizationId, {
+      participantIds: [peer.uuid],
+    });
+
+    // The agent raises an open question directed at the human.
+    const ask = await sendMessage(app.db, chatId, peer.uuid, {
+      format: "request",
+      content: "Approve the migration?",
+      metadata: {
+        mentions: [alice.humanAgentUuid],
+        request: {
+          options: [
+            { label: "Approve", description: "go" },
+            { label: "Hold", description: "wait" },
+          ],
+        },
+      },
+      source: "api",
+    });
+
+    // The web (member JWT) reads the open-requests source on the user scope.
+    const open = await app.inject({
+      method: "GET",
+      url: `/api/v1/chats/${encodeURIComponent(chatId)}/open-requests`,
+      headers: { authorization: `Bearer ${alice.accessToken}` },
+    });
+    expect(open.statusCode).toBe(200);
+    const body = open.json<{ items: { id: string; content: string }[] }>();
+    expect(body.items.map((m) => m.id)).toEqual([ask.message.id]);
+    expect(body.items[0]?.content).toBe("Approve the migration?");
+
+    // The target human answers → the ask is no longer open.
+    await sendMessage(app.db, chatId, alice.humanAgentUuid, {
+      format: "text",
+      content: "Approve",
+      metadata: { mentions: [peer.uuid], resolves: { request: ask.message.id, kind: "answered" } },
+      inReplyTo: ask.message.id,
+      source: "api",
+    });
+
+    const after = await app.inject({
+      method: "GET",
+      url: `/api/v1/chats/${encodeURIComponent(chatId)}/open-requests`,
+      headers: { authorization: `Bearer ${alice.accessToken}` },
+    });
+    expect(after.statusCode).toBe(200);
+    expect(after.json<{ items: unknown[] }>().items).toEqual([]);
+  });
+});

--- a/packages/server/src/__tests__/pulse-aggregator.test.ts
+++ b/packages/server/src/__tests__/pulse-aggregator.test.ts
@@ -29,6 +29,7 @@ function makeMockNotifier(): {
     notifyRuntimeStateChange: vi.fn(async () => {}),
     notifySessionRuntime: vi.fn(async () => {}),
     notifyChatMessage: vi.fn(async () => {}),
+    notifyChatAudience: vi.fn(async () => {}),
     notifySessionEvent: vi.fn(async () => {}),
     pushFrameToInbox: vi.fn(async () => 0),
     onConfigChange: vi.fn(),
@@ -39,6 +40,7 @@ function makeMockNotifier(): {
     }),
     onSessionRuntime: vi.fn(),
     onChatMessage: vi.fn(),
+    onChatAudience: vi.fn(),
     start: vi.fn(async () => {}),
     stop: vi.fn(async () => {}),
   } satisfies Notifier;

--- a/packages/server/src/api/agent/messages.ts
+++ b/packages/server/src/api/agent/messages.ts
@@ -90,4 +90,16 @@ export async function agentMessageRoutes(app: FastifyInstance): Promise<void> {
       nextCursor: result.nextCursor,
     };
   });
+
+  // The caller's currently-open questions in this chat, window-independent —
+  // the blocking answer UI reads this so an open ask that scrolled past the
+  // (capped, unpaginated) message page still surfaces.
+  app.get<{ Params: { chatId: string } }>("/:chatId/open-requests", async (request) => {
+    const identity = requireAgent(request);
+    await chatService.assertParticipant(app.db, request.params.chatId, identity.uuid);
+    const items = await messageService.listOpenRequestsForViewer(app.db, request.params.chatId, identity.uuid);
+    return {
+      items: items.map((m) => ({ ...m, createdAt: m.createdAt.toISOString() })),
+    };
+  });
 }

--- a/packages/server/src/api/agent/messages.ts
+++ b/packages/server/src/api/agent/messages.ts
@@ -90,16 +90,4 @@ export async function agentMessageRoutes(app: FastifyInstance): Promise<void> {
       nextCursor: result.nextCursor,
     };
   });
-
-  // The caller's currently-open questions in this chat, window-independent —
-  // the blocking answer UI reads this so an open ask that scrolled past the
-  // (capped, unpaginated) message page still surfaces.
-  app.get<{ Params: { chatId: string } }>("/:chatId/open-requests", async (request) => {
-    const identity = requireAgent(request);
-    await chatService.assertParticipant(app.db, request.params.chatId, identity.uuid);
-    const items = await messageService.listOpenRequestsForViewer(app.db, request.params.chatId, identity.uuid);
-    return {
-      items: items.map((m) => ({ ...m, createdAt: m.createdAt.toISOString() })),
-    };
-  });
 }

--- a/packages/server/src/api/chats.ts
+++ b/packages/server/src/api/chats.ts
@@ -33,7 +33,7 @@ import {
   resolveChatTitle,
   setChatEngagement,
 } from "../services/me-chat.js";
-import { sendMessage } from "../services/message.js";
+import { listOpenRequestsForViewer, sendMessage } from "../services/message.js";
 import { WIRE_RECIPIENT_MODE } from "../services/message-dispatcher.js";
 import { notifyRecipients } from "../services/notifier.js";
 import { extractSummary } from "../services/session.js";
@@ -366,6 +366,18 @@ export async function chatRoutes(app: FastifyInstance): Promise<void> {
         createdAt: m.createdAt.toISOString(),
       })),
       nextCursor,
+    };
+  });
+
+  // The caller's currently-open questions in this chat, window-independent —
+  // the blocking takeover UI reads this so an open ask that has scrolled past
+  // the (capped, unpaginated) message page above still surfaces. Scoped to the
+  // member's own human-agent uuid, the same id carried in `metadata.mentions`.
+  app.get<{ Params: { chatId: string } }>("/:chatId/open-requests", async (request) => {
+    const { scope } = await requireChatAccess(request, app.db);
+    const items = await listOpenRequestsForViewer(app.db, request.params.chatId, scope.humanAgentId);
+    return {
+      items: items.map((m) => ({ ...m, createdAt: m.createdAt.toISOString() })),
     };
   });
 

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -79,6 +79,7 @@ import {
 import { broadcastToAdmins } from "./services/admin-broadcast.js";
 import { expiryToSeconds } from "./services/auth.js";
 import { type BackgroundTasks, createBackgroundTasks } from "./services/background-tasks.js";
+import { invalidateChatAudienceLocal, registerChatAudienceDispatcher } from "./services/chat-audience-cache.js";
 import { registerChatMessageDispatcher } from "./services/chat-projection.js";
 import { createCommandVersionPoller } from "./services/command-version-poller.js";
 import { createConfigService } from "./services/config-service.js";
@@ -657,6 +658,17 @@ export async function buildApp(config: Config) {
       .notifyChatMessage(chatId, messageId)
       .catch((err) => createLogger("chat-message-kick").warn({ err, chatId, messageId }, "chat:message kick failed"));
   });
+  // Cross-replica chat-audience invalidation. Membership-mutation paths call
+  // `invalidateChatAudience`, which fans out through this dispatcher; every
+  // replica's listener (below) drops its local audience cache so none keeps
+  // serving a stale audience that would drop `chat:message` pushes to a
+  // just-added member for up to the cache TTL.
+  registerChatAudienceDispatcher((chatId) => {
+    notifier
+      .notifyChatAudience(chatId)
+      .catch((err) => createLogger("chat-audience-kick").warn({ err, chatId }, "chat:audience kick failed"));
+  });
+  notifier.onChatAudience(({ chatId }) => invalidateChatAudienceLocal(chatId));
   // Start notifier and background tasks on server start.
   app.addHook("onReady", async () => {
     // Ensure the default organization exists (idempotent)

--- a/packages/server/src/services/chat-audience-cache.ts
+++ b/packages/server/src/services/chat-audience-cache.ts
@@ -19,14 +19,15 @@
  * of `addChatParticipants`, `recomputeChatWatchers`, or any other ad-hoc
  * speaker-row write are still responsible.
  *
- * Cross-instance correctness: not handled here. The PG NOTIFY layer
- * already broadcasts message events to every replica; each replica's
- * audience cache is independently invalidated by its own
- * service-layer mutations on chats it routes traffic for. For
- * cross-replica participant changes to invalidate this cache, route
- * the mutation through the same replica that hosts the WS connection
- * (sticky routing) or add a dedicated `chat:audience` PG NOTIFY in
- * a follow-up.
+ * Cross-instance correctness: handled via a fan-out dispatcher.
+ * `invalidateChatAudience` drops the LOCAL replica's entry AND fires a
+ * registered dispatcher (wired at boot to a `chat_audience_events` PG
+ * NOTIFY) so every other replica drops its entry too. Each replica's
+ * NOTIFY listener calls `invalidateChatAudienceLocal` — the local-only
+ * variant — so the fan-out cannot loop. Without this, a membership change
+ * made on replica A would leave replica B (hosting a viewer's admin WS)
+ * serving a stale audience — and silently dropping that member's
+ * `chat:message` pushes — until the entry aged out after TTL_MS.
  */
 
 import { sql } from "drizzle-orm";
@@ -34,6 +35,22 @@ import type { Database } from "../db/connection.js";
 import { createLogger } from "../observability/index.js";
 
 const log = createLogger("ChatAudienceCache");
+
+// Cross-replica fan-out hook. Registered once at boot (see app.ts) with a
+// function that issues the `chat_audience_events` PG NOTIFY. Left null in
+// unit tests and single-process contexts, where the local drop is enough.
+type AudienceInvalidationDispatcher = (chatId: string) => void;
+let dispatcher: AudienceInvalidationDispatcher | null = null;
+
+/** Wire the cross-replica fan-out (the PG NOTIFY publisher). Call once at boot. */
+export function registerChatAudienceDispatcher(fn: AudienceInvalidationDispatcher): void {
+  dispatcher = fn;
+}
+
+/** Drop the cross-replica fan-out hook (test teardown). */
+export function resetChatAudienceDispatcher(): void {
+  dispatcher = null;
+}
 
 const TTL_MS = 5_000;
 const MAX_ENTRIES = 1024;
@@ -75,7 +92,24 @@ export async function getCachedAudience(db: Database, chatId: string): Promise<S
 /** Drop the cached audience for a chat. Called from participant-
  *  mutation paths after their transaction commits, so the next
  *  `chat:message` dispatch hits the DB and reflects the new
- *  membership instead of serving a stale TTL window. */
+ *  membership instead of serving a stale TTL window. Also fans the
+ *  invalidation to every other replica via the registered dispatcher so
+ *  the replica hosting a viewer's admin WS doesn't keep a stale audience. */
 export function invalidateChatAudience(chatId: string): void {
+  cache.delete(chatId);
+  if (dispatcher) {
+    try {
+      dispatcher(chatId);
+    } catch {
+      // best-effort fan-out — a miss just means the remote replica's entry
+      // ages out after TTL_MS instead of being dropped immediately.
+    }
+  }
+}
+
+/** Drop the cached audience for a chat on THIS replica only — no cross-replica
+ *  fan-out. Used by the `chat_audience_events` NOTIFY listener so a fanned
+ *  invalidation cannot re-broadcast and loop. */
+export function invalidateChatAudienceLocal(chatId: string): void {
   cache.delete(chatId);
 }

--- a/packages/server/src/services/message.ts
+++ b/packages/server/src/services/message.ts
@@ -9,7 +9,7 @@ import {
   scanMentionTokens,
 } from "@first-tree/shared";
 import { getServerCliBinding } from "@first-tree/shared/channel";
-import { and, desc, eq, inArray, lt, ne, sql } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, lt, ne, sql } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 import { agents } from "../db/schema/agents.js";
 import { chatMembership } from "../db/schema/chat-membership.js";
@@ -794,4 +794,45 @@ export async function listMessages(db: Database, chatId: string, limit: number, 
   const nextCursor = hasMore && last ? last.createdAt.toISOString() : null;
 
   return { items, nextCursor };
+}
+
+/**
+ * Every `format=request` message in `chatId` directed at `viewerAgentId` (its
+ * single human target) that has NO authorized resolution yet — i.e. the
+ * viewer's currently-open questions, oldest-first.
+ *
+ * "Open" mirrors the `open_request_count` decrement rule in `sendMessage`:
+ * resolution is human-only, so a request is resolved iff a later message in the
+ * chat carries `metadata.resolves.request = <this id>` with a valid kind from an
+ * authorized resolver — the target (the viewer) or the asker. Anything else
+ * (a bare threaded reply, a stray `resolves` from a third party) leaves it open.
+ *
+ * This is deliberately WINDOW-INDEPENDENT: it is the source the blocking
+ * answer UI uses so an open ask that has scrolled past the latest message page
+ * still surfaces (the timeline fetch is capped + unpaginated). Oldest-first so
+ * the caller's FIFO blocking pick matches the client's `findBlockingRequest`.
+ */
+export async function listOpenRequestsForViewer(
+  db: Database,
+  chatId: string,
+  viewerAgentId: string,
+): Promise<(typeof messages.$inferSelect)[]> {
+  return db
+    .select()
+    .from(messages)
+    .where(
+      and(
+        eq(messages.chatId, chatId),
+        eq(messages.format, MESSAGE_FORMATS.REQUEST),
+        sql`${messages.metadata} -> 'mentions' @> jsonb_build_array(${viewerAgentId}::text)`,
+        sql`NOT EXISTS (
+          SELECT 1 FROM ${messages} AS resolver
+          WHERE resolver.chat_id = ${messages.chatId}
+            AND resolver.metadata -> 'resolves' ->> 'request' = ${messages.id}::text
+            AND (resolver.metadata -> 'resolves' ->> 'kind') IN ('answered', 'closed')
+            AND resolver.sender_id IN (${messages.senderId}, ${viewerAgentId})
+        )`,
+      ),
+    )
+    .orderBy(asc(messages.createdAt));
 }

--- a/packages/server/src/services/notifier.ts
+++ b/packages/server/src/services/notifier.ts
@@ -20,6 +20,15 @@ const SESSION_RUNTIME_CHANNEL = "session_runtime_changes";
  * inbox NOTIFY path that only reaches speakers.
  */
 const CHAT_MESSAGE_CHANNEL = "chat_message_events";
+/**
+ * Cross-replica chat-audience invalidation. Carries the bare `<chatId>`.
+ * The push-audience cache (`chat-audience-cache.ts`) is process-local, so a
+ * membership change on one replica only drops THAT replica's cache. This
+ * channel fans the invalidation to every replica so the one hosting a viewer's
+ * admin WS doesn't keep serving a stale audience (and dropping `chat:message`
+ * pushes to a just-added member) for up to the cache TTL.
+ */
+const CHAT_AUDIENCE_CHANNEL = "chat_audience_events";
 
 export type ConfigChangeHandler = (channel: string) => void;
 export type SessionStateChangeHandler = (payload: {
@@ -57,6 +66,7 @@ export type SessionRuntimeChangeHandler = (payload: {
   organizationId: string;
 }) => void;
 export type ChatMessageChangeHandler = (payload: { chatId: string; messageId: string }) => void;
+export type ChatAudienceChangeHandler = (payload: { chatId: string }) => void;
 
 /**
  * Per-socket push handler for the WS data plane. When a NOTIFY arrives on
@@ -92,6 +102,8 @@ export type Notifier = {
   notifySessionRuntime(agentId: string, chatId: string, state: string, organizationId: string): Promise<void>;
   /** Chat-first workspace: kick admin WS sockets to invalidate ["me","chats"] and the timeline of `chatId`. */
   notifyChatMessage(chatId: string, messageId: string): Promise<void>;
+  /** Fan a chat-audience-cache invalidation for `chatId` to every replica. */
+  notifyChatAudience(chatId: string): Promise<void>;
   /**
    * Push a raw JSON frame to every socket currently subscribed to `inboxId`
    * on **this server instance only**. Unlike `notify`, does not fan out
@@ -112,6 +124,8 @@ export type Notifier = {
   onSessionRuntime(handler: SessionRuntimeChangeHandler): void;
   /** Register a handler for chat:message change notifications. */
   onChatMessage(handler: ChatMessageChangeHandler): void;
+  /** Register a handler for cross-replica chat-audience invalidations. */
+  onChatAudience(handler: ChatAudienceChangeHandler): void;
   /** Start listening for PG notifications */
   start(): Promise<void>;
   /** Stop listening */
@@ -126,6 +140,7 @@ export function createNotifier(listenClient: postgres.Sql): Notifier {
   const runtimeStateChangeHandlers: RuntimeStateChangeHandler[] = [];
   const sessionRuntimeHandlers: SessionRuntimeChangeHandler[] = [];
   const chatMessageHandlers: ChatMessageChangeHandler[] = [];
+  const chatAudienceHandlers: ChatAudienceChangeHandler[] = [];
   let unlistenInboxFn: (() => Promise<void>) | null = null;
   let unlistenConfigFn: (() => Promise<void>) | null = null;
   let unlistenSessionStateFn: (() => Promise<void>) | null = null;
@@ -133,6 +148,7 @@ export function createNotifier(listenClient: postgres.Sql): Notifier {
   let unlistenRuntimeStateFn: (() => Promise<void>) | null = null;
   let unlistenSessionRuntimeFn: (() => Promise<void>) | null = null;
   let unlistenChatMessageFn: (() => Promise<void>) | null = null;
+  let unlistenChatAudienceFn: (() => Promise<void>) | null = null;
 
   function handleNotification(payload: string) {
     // payload format: "inboxId:messageId"
@@ -240,6 +256,15 @@ export function createNotifier(listenClient: postgres.Sql): Notifier {
       }
     },
 
+    async notifyChatAudience(chatId: string) {
+      try {
+        await listenClient`SELECT pg_notify(${CHAT_AUDIENCE_CHANNEL}, ${chatId})`;
+      } catch {
+        // fire-and-forget — a missed fan-out just means the stale replica
+        // serves its cached audience until the TTL ages it out (≤ cache TTL).
+      }
+    },
+
     async pushFrameToInbox(inboxId: string, frame: string): Promise<number> {
       const map = subscriptions.get(inboxId);
       if (!map) return 0;
@@ -282,6 +307,10 @@ export function createNotifier(listenClient: postgres.Sql): Notifier {
 
     onChatMessage(handler: ChatMessageChangeHandler) {
       chatMessageHandlers.push(handler);
+    },
+
+    onChatAudience(handler: ChatAudienceChangeHandler) {
+      chatAudienceHandlers.push(handler);
     },
 
     async start() {
@@ -400,6 +429,20 @@ export function createNotifier(listenClient: postgres.Sql): Notifier {
         }
       });
       unlistenChatMessageFn = chatMessageResult.unlisten;
+
+      const chatAudienceResult = await listenClient.listen(CHAT_AUDIENCE_CHANNEL, (payload) => {
+        if (!payload) return;
+        // payload is the bare chatId (a UUID).
+        const chatId = payload;
+        for (const handler of chatAudienceHandlers) {
+          try {
+            handler({ chatId });
+          } catch {
+            // swallow — handler errors must not poison fan-out
+          }
+        }
+      });
+      unlistenChatAudienceFn = chatAudienceResult.unlisten;
     },
 
     async stop() {
@@ -430,6 +473,10 @@ export function createNotifier(listenClient: postgres.Sql): Notifier {
       if (unlistenChatMessageFn) {
         await unlistenChatMessageFn();
         unlistenChatMessageFn = null;
+      }
+      if (unlistenChatAudienceFn) {
+        await unlistenChatAudienceFn();
+        unlistenChatAudienceFn = null;
       }
     },
   };

--- a/packages/web/src/api/chats.ts
+++ b/packages/web/src/api/chats.ts
@@ -222,3 +222,12 @@ export function listChatMessages(
   const query = qs.toString();
   return api.get<PaginatedMessages>(`/chats/${encodeURIComponent(chatId)}/messages${query ? `?${query}` : ""}`);
 }
+
+/**
+ * The viewer's currently-open questions (`format=request` directed at them, not
+ * yet resolved) in a chat — window-independent, so the blocking answer UI can
+ * surface an open ask that has scrolled past the latest message page.
+ */
+export function listChatOpenRequests(chatId: string): Promise<{ items: Message[] }> {
+  return api.get<{ items: Message[] }>(`/chats/${encodeURIComponent(chatId)}/open-requests`);
+}

--- a/packages/web/src/components/chat/ask-takeover.tsx
+++ b/packages/web/src/components/chat/ask-takeover.tsx
@@ -10,8 +10,11 @@
  *     multi = checkbox; each shows label + description, and `preview` when
  *     selected) plus an always-present free-text "Other" input — or, when the ask
  *     carries no options, a single free-text box;
- *   - the Skip / Reply actions follow the answer content (Skip dismisses for now,
- *     the open-request persists; Reply resolves with the composed answer).
+ *   - the Skip / Reply actions follow the answer content. Both RESOLVE the
+ *     question: Reply sends the composed answer; Skip sends a "skipped" answer
+ *     (the caller's `onSkip` writes the resolving reply) so the asking agent
+ *     unblocks rather than waiting on a never-answered question. There is no
+ *     "dismiss but keep it open" path — skip is an answer, not a deferral.
  *
  * The answer is plain text: selected option labels join on one line, any typed
  * note follows — `buildResolveAnswer` owns the format. This is the ONLY way to
@@ -38,7 +41,7 @@ export function AskTakeover({
   sending?: boolean;
   /** Resolve the question with the composed answer content. */
   onReply: (content: string) => void;
-  /** Dismiss the takeover without answering (the open-request persists). */
+  /** Resolve the question with a "skipped" answer (caller sends the reply). */
   onSkip: () => void;
 }) {
   const options = payload.options;

--- a/packages/web/src/hooks/use-admin-ws.ts
+++ b/packages/web/src/hooks/use-admin-ws.ts
@@ -255,6 +255,10 @@ function broadcast(msg: WsMessage) {
       if (chatId) {
         latestQc.invalidateQueries({ queryKey: ["chat-messages", chatId] });
         latestQc.invalidateQueries({ queryKey: ["chat-detail", chatId] });
+        // The blocking answer UI reads open requests window-independently;
+        // refresh them on the same kick so a new (or just-resolved) ask flips
+        // the takeover without waiting for its own 5s poll.
+        latestQc.invalidateQueries({ queryKey: ["chat-open-requests", chatId] });
       }
     } else if (msg.type === "pulse:tick") {
       // Per-org runtime-state aggregate (pulse-aggregator broadcasts every 5s).
@@ -329,6 +333,9 @@ function connect() {
       // refetchInterval in ChatView; now that the poll is gone, reconnect
       // must explicitly catch up the open chat's message timeline.
       latestQc.invalidateQueries({ queryKey: ["chat-messages"] });
+      // Same reasoning for the window-independent open-requests source that
+      // backs the blocking takeover — catch it up after a WS gap too.
+      latestQc.invalidateQueries({ queryKey: ["chat-open-requests"] });
       // The chat-first workspace reads `viewerMembershipKind` (and other
       // viewer-scoped fields) off `["chat-detail", chatId]`. Without this,
       // a frame that fired while the WS was down (e.g. the caller was

--- a/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
@@ -39,6 +39,7 @@ const attachmentMocks = vi.hoisted(() => ({
 const chatMocks = vi.hoisted(() => ({
   getChat: vi.fn(),
   listChatMessages: vi.fn(),
+  listChatOpenRequests: vi.fn(),
   patchChatEngagement: vi.fn(),
   readFileAsBase64: vi.fn(),
   renameChat: vi.fn(),
@@ -666,6 +667,7 @@ beforeEach(() => {
   attachmentMocks.uploadImageAttachment.mockResolvedValue({ id: "uploaded-image", mimeType: "image/png", size: 42 });
   chatMocks.getChat.mockResolvedValue(chatDetail());
   chatMocks.listChatMessages.mockResolvedValue(BASE_MESSAGES);
+  chatMocks.listChatOpenRequests.mockResolvedValue({ items: [] });
   chatMocks.patchChatEngagement.mockResolvedValue({ chatId: "chat-1", engagementStatus: "active" });
   chatMocks.readFileAsBase64.mockResolvedValue("image-base64");
   chatMocks.renameChat.mockResolvedValue({ id: "chat-1", topic: "Renamed launch" });
@@ -1039,6 +1041,48 @@ describe("ChatView", () => {
       inReplyTo: "req-enter",
       resolves: { request: "req-enter", kind: "answered" },
     });
+
+    await act(async () => root.unmount());
+  });
+
+  it("surfaces a buried open ask (outside the message window) via the open-requests source", async () => {
+    const { ChatView } = await import("../chat-view.js");
+    // An open ask that is NOT in the loaded 50-message timeline — only the
+    // window-independent open-requests source knows about it.
+    const buriedAsk = message({
+      id: "req-buried",
+      senderId: "agent-1",
+      format: "request",
+      content: "Approve the migration?",
+      metadata: {
+        mentions: ["human-agent-self"],
+        request: {
+          options: [
+            { label: "Approve", description: "go" },
+            { label: "Hold", description: "wait" },
+          ],
+        },
+      },
+      createdAt: "2026-05-28T11:00:00.000Z",
+    });
+    chatMocks.listChatOpenRequests.mockResolvedValue({ items: [buriedAsk] });
+
+    const { container, queryClient, root } = await renderDom(
+      <ChatView agentId="agent-1" chatId="chat-1" />,
+      // Timeline seeded WITHOUT the request — it is past the loaded window.
+      (client) => seedChat(client, chatDetail(), messages([])),
+      "/",
+    );
+
+    await act(async () => {
+      queryClient.setQueryData(["chat-open-requests", "chat-1"], { items: [buriedAsk] });
+    });
+    await flush();
+
+    // The blocking takeover still appears, driven by the open-requests source.
+    await waitForText(container, "Approve the migration?");
+    expect(buttonByText(container, "Reply")).toBeTruthy();
+    expect(buttonByText(container, "Skip")).toBeTruthy();
 
     await act(async () => root.unmount());
   });

--- a/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
@@ -1087,6 +1087,54 @@ describe("ChatView", () => {
     await act(async () => root.unmount());
   });
 
+  it("Skip resolves the question with a skipped answer (no temporary dismiss)", async () => {
+    const { ChatView } = await import("../chat-view.js");
+    const dockMessages = messages([
+      message({
+        id: "req-skip",
+        senderId: "agent-1",
+        format: "request",
+        content: "Pick the deploy color.",
+        metadata: {
+          mentions: ["human-agent-self"],
+          request: {
+            options: [
+              { label: "Blue-green", description: "blue-green deploy" },
+              { label: "Rolling update", description: "rolling deploy" },
+            ],
+          },
+        },
+        createdAt: "2026-05-28T12:00:00.000Z",
+      }),
+    ]);
+    const { container, queryClient, root } = await renderDom(
+      <ChatView agentId="agent-1" chatId="chat-1" />,
+      (client) => seedChat(client, chatDetail(), messages([])),
+      "/",
+    );
+
+    await act(async () => {
+      queryClient.setQueryData(["chat-messages", "chat-1"], dockMessages);
+    });
+    await flush();
+    await waitForText(container, "Skip");
+
+    // Skip is always enabled and resolves the question with a skipped answer —
+    // it does NOT just dismiss the overlay (the open request would persist).
+    expect(buttonByText(container, "Skip")?.disabled).toBe(false);
+    await click(buttonByText(container, "Skip"));
+    await waitForCondition(
+      () => chatMocks.sendChatMessage.mock.calls.length > 0,
+      "Expected Skip to resolve the question",
+    );
+    expect(chatMocks.sendChatMessage).toHaveBeenCalledWith("chat-1", "(Skipped — no answer provided.)", ["agent-1"], {
+      inReplyTo: "req-skip",
+      resolves: { request: "req-skip", kind: "answered" },
+    });
+
+    await act(async () => root.unmount());
+  });
+
   it("enables Send and resolves when an option question is answered with free text (no option picked)", async () => {
     const { ChatView } = await import("../chat-view.js");
     const dockMessages = messages([

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -1801,13 +1801,11 @@ export function ChatView({
     [readOnly, blockingMessages, myAgentId],
   );
   const dockPayload = useMemo(() => (dockRequest ? readRequestPayload(dockRequest.metadata) : null), [dockRequest]);
-  // Requests the viewer chose to Skip this session — the AskTakeover dismisses,
-  // but the open-request / red dot persists and it reappears on next visit.
-  const [skippedRequestIds, setSkippedRequestIds] = useState<ReadonlySet<string>>(() => new Set<string>());
   // The full-coverage ask card is active (and owns answering) iff a question
-  // blocks me and I haven't skipped it. While active it drives the timeline
-  // truncation below; on Skip it clears so the timeline becomes legible again.
-  const askOverlayActive = dockRequest != null && dockPayload != null && !skippedRequestIds.has(dockRequest.id);
+  // blocks me. Both Reply and Skip resolve the question (Skip sends a "skipped"
+  // answer — see the `onSkip` handler), so the overlay clears the moment the
+  // resolving reply lands; there is no "dismiss but keep it open" path.
+  const askOverlayActive = dockRequest != null && dockPayload != null;
   const dockRequestId = askOverlayActive ? dockRequest.id : undefined;
   useEffect(() => {
     if (!dockRequestId || draft !== "@" || !autoPrimedDraftRef.current) return;
@@ -2806,9 +2804,11 @@ export function ChatView({
         >
           {/* The ask pops up as a card INSIDE the workspace body — offset below
               the (stable, single-row) topic header so the header and the
-              right rail stay visible. Owns answering: Reply resolves; Skip
-              dismisses for this session (the red dot persists). Keyed by request
-              id so its answer state resets when the blocking question changes. */}
+              right rail stay visible. Owns answering: Reply resolves with the
+              composed answer; Skip ALSO resolves, sending a "skipped" answer so
+              the asking agent unblocks and the red dot clears (skip is an answer,
+              not a temporary dismiss). Keyed by request id so its answer state
+              resets when the blocking question changes. */}
           {askOverlayActive && dockRequest && dockPayload ? (
             <div style={{ position: "absolute", top: 52, left: 0, right: 0, bottom: 0, zIndex: 30 }}>
               <AskTakeover
@@ -2825,7 +2825,18 @@ export function ChatView({
                     resolves: { request: dockRequest.id, kind: "answered" },
                   })
                 }
-                onSkip={() => setSkippedRequestIds((prev) => new Set(prev).add(dockRequest.id))}
+                onSkip={() =>
+                  // Skip is an answer, not a dismiss: send a resolving reply
+                  // (kind="answered") carrying a "skipped" body so the open
+                  // request resolves, the red dot clears, and the asking agent
+                  // unblocks and proceeds with its own judgment.
+                  sendMut.mutate({
+                    content: "(Skipped — no answer provided.)",
+                    mentions: [dockRequest.senderId],
+                    inReplyTo: dockRequest.id,
+                    resolves: { request: dockRequest.id, kind: "answered" },
+                  })
+                }
               />
             </div>
           ) : null}

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -38,6 +38,7 @@ import {
   type ImageBatchRefContent,
   type ImageRefContent,
   listChatMessages,
+  listChatOpenRequests,
   type MessageWithDelivery,
   type PaginatedMessages,
   patchChatEngagement,
@@ -1221,6 +1222,17 @@ export function ChatView({
     refetchInterval: 5_000,
   });
 
+  // The viewer's open questions in this chat, fetched independently of the
+  // capped 50-message timeline window above. The blocking answer UI unions
+  // these into its derivation (`blockingMessages`) so an open ask that has
+  // scrolled past the latest page still surfaces. Same 5s poll + WS
+  // invalidation as the timeline; the query usually returns 0–1 rows.
+  const { data: openRequestsData } = useQuery({
+    queryKey: ["chat-open-requests", chatId],
+    queryFn: () => listChatOpenRequests(chatId),
+    refetchInterval: 5_000,
+  });
+
   // Fetch newest events first so the turn-grouping filter always sees the
   // latest `turn_end` even in chats with thousands of total events. The
   // timeline renderer later sorts by timestamp, so the fetch order is moot
@@ -1771,9 +1783,22 @@ export function ChatView({
   // `dockPayload` is non-null whenever `dockRequest` is set: every open request —
   // including ones written under the retired schema — stays answerable and its
   // red dot can be cleared.
+  // Union the server's window-independent open requests with the loaded
+  // timeline before deriving the block, so an open ask that scrolled past the
+  // latest 50 messages still blocks. Dedup by id; the loaded message WINS over
+  // the open-requests row (it may carry an optimistic resolving reply, or the
+  // resolving reply itself, that lifts the block the instant the viewer answers).
+  const blockingMessages = useMemo<MessageWithDelivery[]>(() => {
+    const open = openRequestsData?.items ?? [];
+    if (open.length === 0) return mergedMessages;
+    const byId = new Map<string, MessageWithDelivery>();
+    for (const r of open) byId.set(r.id, r);
+    for (const m of mergedMessages) byId.set(m.id, m);
+    return Array.from(byId.values()).sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+  }, [openRequestsData, mergedMessages]);
   const dockRequest = useMemo(
-    () => (readOnly ? null : findBlockingRequest(mergedMessages, myAgentId)),
-    [readOnly, mergedMessages, myAgentId],
+    () => (readOnly ? null : findBlockingRequest(blockingMessages, myAgentId)),
+    [readOnly, blockingMessages, myAgentId],
   );
   const dockPayload = useMemo(() => (dockRequest ? readRequestPayload(dockRequest.metadata) : null), [dockRequest]);
   // Requests the viewer chose to Skip this session — the AskTakeover dismisses,


### PR DESCRIPTION
Fixes the `chat ask` takeover interaction reported by @yuezengwu, plus two latent realtime hazards found while auditing why the takeover sometimes didn't pop instantly. Three independent fixes, landed together as one reviewed change (QA validated as a unit).

## #2 — Skip is an answer, not a deferral (web)
Previously the takeover's **Skip** only dismissed the overlay for the session via a local `skippedRequestIds` set: no message was sent, so the open request, the red dot, and the asking agent's block all persisted. Skip now sends a resolving reply (`metadata.resolves` `kind="answered"`, body `"(Skipped — no answer provided.)"`) → the question resolves, the red dot clears, the asking agent unblocks, and the overlay closes. Removed the dead session state.

## H1 — Cross-replica chat-audience invalidation (server)
The push-audience cache is process-local, so a membership change on one replica left other replicas serving a stale audience — silently dropping `chat:message` pushes to a just-added member until the TTL aged out (intermittent "takeover didn't pop instantly", self-healing in ≤5s). Adds a `chat_audience_events` PG NOTIFY: `invalidateChatAudience` now drops the local entry **and** fans out so every replica invalidates; `invalidateChatAudienceLocal` (used by the listener) avoids a NOTIFY loop. No schema change.

## H2 — Open asks beyond the message window still block (server + web)
The blocking takeover derived only from the latest 50 loaded messages, so an open ask that scrolled past that window never blocked (and refresh didn't help). Adds a window-independent source: `listOpenRequestsForViewer` + `GET /:chatId/open-requests` on the **user-scope** chat router (same scope the web's `/messages` uses), scoped to the caller's own human-agent uuid; the web unions open requests into the blocking derivation, with WS + reconnect invalidation wired.

## Tests
- web DOM: Skip resolves (no dismiss); a buried open ask surfaces via the open-requests source.
- server: cross-audience fan-out unit test; user-scope `open-requests` HTTP e2e (route + open/resolved semantics).
- `pnpm typecheck` (server + web), `biome`, and the full server suite green.

## QA
Validated end-to-end on a real two-replica server + browser suite (skip resolve, cross-replica WS push, buried-ask takeover via user-scope `/open-requests`, mobile) — full server suite 1472 tests pass. A first QA pass caught an H2 404 (the `open-requests` route was initially on the agent scope, not the user scope the web calls); fixed and re-validated PASS.

No DB migration. No `version` bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)