### PR TITLE
feat(web): persist onboarding repo selection as a per-org draft

### DIFF
--- a/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
+++ b/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
@@ -761,6 +761,7 @@ function createFlowValue(overrides: Partial<OnboardingFlowValue> = {}): Onboardi
     hasAgent: true,
     selectedRepoUrls: ["https://github.com/acme/web.git"],
     setSelectedRepoUrls: () => undefined,
+    hasRepoDraft: true,
     treeMode: "existing",
     setTreeMode: () => undefined,
     treeUrl: "https://github.com/acme/context-tree",

--- a/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
+++ b/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
@@ -1870,6 +1870,31 @@ describe("web DOM interaction coverage", () => {
     await unmountRoot(view.root);
   });
 
+  it("fails closed at kickoff when the grant list can't be read (no stale write)", async () => {
+    // If the current-grant read fails we can't prove the selected repos are still
+    // accessible and nothing downstream re-checks grants, so kickoff must NOT
+    // write the (possibly stale) selection — it surfaces a retryable error and
+    // stays on the form instead.
+    const { StepKickoff } = await import("../onboarding/steps/step-kickoff.js");
+    githubMocks.listOrgGithubRepos.mockRejectedValue(new Error("github unavailable"));
+    const view = await renderOnboardingDom(<StepKickoff />, {
+      activeStep: "kickoff",
+      selectedRepoUrls: ["https://github.com/acme/web.git"],
+      treeMode: "existing",
+      treeUrl: "https://github.com/acme/context-tree",
+    });
+    await waitForText("Your agent's ready to get to work", view.container);
+    await click(
+      ([...view.container.querySelectorAll("button")].find((b) => b.textContent?.includes("Start")) ??
+        null) as HTMLButtonElement | null,
+    );
+    await waitForText("Couldn't check your repositories", view.container);
+    expect(resourceMocks.createTeamResourceForOrg).not.toHaveBeenCalled();
+    expect(chatApiMocks.createAgentChat).not.toHaveBeenCalled();
+    expect(view.flow.completeAndEnterChat).not.toHaveBeenCalled();
+    await unmountRoot(view.root);
+  });
+
   it("edits MCP server rows through validation, stdio, and HTTP submissions", async () => {
     const { McpSection } = await import("../agent-detail/mcp-section.js");
     const onAdd = vi.fn();

--- a/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
+++ b/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
@@ -484,11 +484,14 @@ function createFlowValue(overrides: Partial<OnboardingFlowValue> = {}): Onboardi
 async function renderOnboardingDom(
   element: ReactElement,
   overrides: Partial<OnboardingFlowValue> = {},
+  seed?: (queryClient: QueryClient) => void,
 ): Promise<{ container: HTMLElement; root: Root; flow: OnboardingFlowValue }> {
   const { OnboardingFlowContext } = await import("../onboarding/onboarding-flow.js");
   const flow = createFlowValue(overrides);
   const rendered = await renderDom(
     <OnboardingFlowContext.Provider value={flow}>{element}</OnboardingFlowContext.Provider>,
+    "/",
+    seed,
   );
   return { ...rendered, flow };
 }
@@ -1892,6 +1895,67 @@ describe("web DOM interaction coverage", () => {
     expect(resourceMocks.createTeamResourceForOrg).not.toHaveBeenCalled();
     expect(chatApiMocks.createAgentChat).not.toHaveBeenCalled();
     expect(view.flow.completeAndEnterChat).not.toHaveBeenCalled();
+    await unmountRoot(view.root);
+  });
+
+  it("kickoff grant check is authoritative — ignores a stale cached grant list", async () => {
+    // The QueryClient is an app-level singleton and finishLater is SPA nav, so a
+    // grant list connect-code cached earlier can still be in the cache when the
+    // user resumes at kickoff — possibly minutes stale. The write-path check
+    // must read CURRENT grants, not trust the cache (guards against re-adding a
+    // staleTime). Seed the cache with a stale list that still contains a repo
+    // that has since been removed; assert the live read prunes it anyway.
+    const { StepKickoff } = await import("../onboarding/steps/step-kickoff.js");
+    // Current grants (live) are web + api; the stale cache still has `gone`.
+    githubMocks.listOrgGithubRepos.mockResolvedValue(GITHUB_REPOS);
+    const view = await renderOnboardingDom(
+      <StepKickoff />,
+      {
+        activeStep: "kickoff",
+        selectedRepoUrls: ["https://github.com/acme/web.git", "https://github.com/acme/gone.git"],
+        treeMode: "existing",
+        treeUrl: "https://github.com/acme/context-tree",
+      },
+      (queryClient) => {
+        queryClient.setQueryData(
+          ["onboarding", "org-github-repos", "org-1"],
+          [
+            {
+              fullName: "acme/web",
+              cloneUrl: "https://github.com/acme/web.git",
+              htmlUrl: "",
+              private: false,
+              defaultBranch: "main",
+              pushedAt: NOW,
+            },
+            {
+              fullName: "acme/gone",
+              cloneUrl: "https://github.com/acme/gone.git",
+              htmlUrl: "",
+              private: false,
+              defaultBranch: "main",
+              pushedAt: NOW,
+            },
+          ],
+        );
+      },
+    );
+    await waitForText("Your agent's ready to get to work", view.container);
+    await click(
+      ([...view.container.querySelectorAll("button")].find((b) => b.textContent?.includes("Start")) ??
+        null) as HTMLButtonElement | null,
+    );
+    await waitForText("Starting your agent", view.container);
+    // Live read returned web + api → `gone` is pruned despite being in the cache.
+    expect(githubMocks.listOrgGithubRepos).toHaveBeenCalled();
+    expect(resourceMocks.createTeamResourceForOrg).toHaveBeenCalledWith(
+      "org-1",
+      expect.objectContaining({ payload: { url: "https://github.com/acme/web.git" } }),
+    );
+    expect(resourceMocks.createTeamResourceForOrg).not.toHaveBeenCalledWith(
+      "org-1",
+      expect.objectContaining({ payload: { url: "https://github.com/acme/gone.git" } }),
+    );
     await unmountRoot(view.root);
   });
 

--- a/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
+++ b/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
@@ -468,6 +468,7 @@ function createFlowValue(overrides: Partial<OnboardingFlowValue> = {}): Onboardi
     hasAgent: true,
     selectedRepoUrls: ["https://github.com/acme/web.git"],
     setSelectedRepoUrls: vi.fn(),
+    hasRepoDraft: true,
     treeMode: "existing",
     setTreeMode: vi.fn(),
     treeUrl: "https://github.com/acme/context-tree",
@@ -1586,6 +1587,83 @@ describe("web DOM interaction coverage", () => {
       ) ?? null,
     );
     expect(notConfigured.flow.goNext).toHaveBeenCalled();
+  });
+
+  it("auto-selects all granted repos with no draft, but preserves a resumed draft", async () => {
+    const { StepConnectCode } = await import("../onboarding/steps/step-connect-code.js");
+    const connectedInstall = {
+      installationId: 42,
+      accountLogin: "acme",
+      accountType: "Organization" as const,
+      accountGithubId: 123,
+      repositorySelection: "selected" as const,
+      permissions: {},
+      events: [],
+      suspended: false,
+      manageUrl: "https://github.com/organizations/acme/settings/installations/42",
+      createdAt: NOW,
+      updatedAt: NOW,
+    };
+    githubAppMocks.getGithubAppInstallation.mockResolvedValue(connectedInstall);
+
+    // No saved draft (first visit) → the picker defaults to every granted repo,
+    // so the user doesn't re-pick what they just granted on GitHub.
+    const freshSet = vi.fn();
+    const noDraft = await renderOnboardingDom(<StepConnectCode />, {
+      activeStep: "connect-code",
+      selectedRepoUrls: [],
+      hasRepoDraft: false,
+      setSelectedRepoUrls: freshSet,
+    });
+    await waitForText("acme/web", noDraft.container);
+    await waitForCondition(
+      () =>
+        freshSet.mock.calls.some(
+          ([arg]) =>
+            Array.isArray(arg) &&
+            arg.length === 2 &&
+            arg.includes("https://github.com/acme/web.git") &&
+            arg.includes("git@github.com:acme/api.git"),
+        ),
+      "auto-select all granted repos when there's no draft",
+    );
+    await unmountRoot(noDraft.root);
+
+    // Resumed draft (user narrowed to just one repo earlier, then bailed before
+    // kickoff) → no auto-select; the saved selection is left untouched instead
+    // of being clobbered back to "all granted".
+    const resumedSet = vi.fn();
+    const withDraft = await renderOnboardingDom(<StepConnectCode />, {
+      activeStep: "connect-code",
+      selectedRepoUrls: ["https://github.com/acme/web.git"],
+      hasRepoDraft: true,
+      setSelectedRepoUrls: resumedSet,
+    });
+    await waitForText("acme/web", withDraft.container);
+    await flush();
+    expect(resumedSet).not.toHaveBeenCalled();
+    await unmountRoot(withDraft.root);
+
+    // Resumed draft carrying a repo the GitHub App no longer grants (uninstall /
+    // changed grant between bailout and resume) → prune it against the current
+    // grant list so a stale URL can't ride into kickoff. acme/web is still
+    // granted; the gone repo is dropped.
+    const prunedSet = vi.fn();
+    const staleDraft = await renderOnboardingDom(<StepConnectCode />, {
+      activeStep: "connect-code",
+      selectedRepoUrls: ["https://github.com/acme/web.git", "https://github.com/acme/gone.git"],
+      hasRepoDraft: true,
+      setSelectedRepoUrls: prunedSet,
+    });
+    await waitForText("acme/web", staleDraft.container);
+    await waitForCondition(
+      () =>
+        prunedSet.mock.calls.some(
+          ([arg]) => Array.isArray(arg) && arg.length === 1 && arg[0] === "https://github.com/acme/web.git",
+        ),
+      "prune a no-longer-granted repo from a resumed draft",
+    );
+    await unmountRoot(staleDraft.root);
   });
 
   it("falls back to a full-page redirect when the install popup is blocked", async () => {

--- a/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
+++ b/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
@@ -1836,6 +1836,40 @@ describe("web DOM interaction coverage", () => {
     await unmountRoot(inviteeReady.root);
   });
 
+  it("prunes a no-longer-granted repo at kickoff before writing team resources", async () => {
+    // A flow can resume directly at kickoff (persisted step index) without ever
+    // mounting StepConnectCode, so connect-code's grant prune never runs. The
+    // kickoff handler must re-validate the (possibly stale) selection against the
+    // current grant list, so a repo removed from the installation since the user
+    // picked it is never registered as a team repo resource.
+    const { StepKickoff } = await import("../onboarding/steps/step-kickoff.js");
+    // Current grants are web + api (GITHUB_REPOS); the draft also carries a repo
+    // the app no longer grants.
+    githubMocks.listOrgGithubRepos.mockResolvedValue(GITHUB_REPOS);
+    const view = await renderOnboardingDom(<StepKickoff />, {
+      activeStep: "kickoff",
+      selectedRepoUrls: ["https://github.com/acme/web.git", "https://github.com/acme/gone.git"],
+      treeMode: "existing",
+      treeUrl: "https://github.com/acme/context-tree",
+    });
+    await waitForText("Your agent's ready to get to work", view.container);
+    await click(
+      ([...view.container.querySelectorAll("button")].find((b) => b.textContent?.includes("Start")) ??
+        null) as HTMLButtonElement | null,
+    );
+    await waitForText("Starting your agent", view.container);
+    // web is still granted → written; the stale repo is pruned → never written.
+    expect(resourceMocks.createTeamResourceForOrg).toHaveBeenCalledWith(
+      "org-1",
+      expect.objectContaining({ payload: { url: "https://github.com/acme/web.git" } }),
+    );
+    expect(resourceMocks.createTeamResourceForOrg).not.toHaveBeenCalledWith(
+      "org-1",
+      expect.objectContaining({ payload: { url: "https://github.com/acme/gone.git" } }),
+    );
+    await unmountRoot(view.root);
+  });
+
   it("edits MCP server rows through validation, stdio, and HTTP submissions", async () => {
     const { McpSection } = await import("../agent-detail/mcp-section.js");
     const onAdd = vi.fn();

--- a/packages/web/src/pages/onboarding-preview.tsx
+++ b/packages/web/src/pages/onboarding-preview.tsx
@@ -899,6 +899,7 @@ function baseFlow(path: OnboardingPath): OnboardingFlowValue {
     hasAgent: false,
     selectedRepoUrls: [],
     setSelectedRepoUrls: NOOP,
+    hasRepoDraft: false,
     treeMode: "new",
     setTreeMode: NOOP,
     treeUrl: "",

--- a/packages/web/src/pages/onboarding/onboarding-flow.tsx
+++ b/packages/web/src/pages/onboarding/onboarding-flow.tsx
@@ -1,8 +1,12 @@
 import type { AgentVisibility } from "@first-tree/shared";
-import { createContext, type ReactNode, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { createContext, type ReactNode, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router";
 import { useAuth } from "../../auth/auth-context.js";
-import { writeOnboardingAgentUuid } from "../../utils/onboarding-flags.js";
+import {
+  readOnboardingSelectedRepos,
+  writeOnboardingAgentUuid,
+  writeOnboardingSelectedRepos,
+} from "../../utils/onboarding-flags.js";
 import {
   clampStepIndex,
   getStepSequence,
@@ -52,6 +56,14 @@ export type OnboardingFlowValue = {
 
   selectedRepoUrls: string[];
   setSelectedRepoUrls: (next: string[]) => void;
+  /**
+   * True once a per-org repo-selection draft exists (the user has touched the
+   * picker, or a saved draft was restored on resume). The connect-code step
+   * reads this to decide whether to auto-select all granted repos: it only does
+   * so when there is NO draft, so a resumed narrowing — to a subset or to none —
+   * is never overwritten back to "all".
+   */
+  hasRepoDraft: boolean;
   treeMode: TreeMode;
   setTreeMode: (next: TreeMode) => void;
   treeUrl: string;
@@ -173,7 +185,41 @@ export function OnboardingFlowProvider({ path, children }: { path: OnboardingPat
     user?.username ? `${user.username}'s assistant` : "Assistant",
   );
   const [visibility, setVisibility] = useState<AgentVisibility>("organization");
-  const [selectedRepoUrls, setSelectedRepoUrls] = useState<string[]>([]);
+  // Hydrate the repo selection from this org's saved draft so a bailout before
+  // kickoff (top-bar "finish later", a refresh, a mid-flow navigation) resumes
+  // with the picked repos instead of losing them. `null` draft → empty (the
+  // connect-code step will auto-select all granted repos); a non-null draft —
+  // including `[]` — is a deliberate selection we restore verbatim.
+  const [selectedRepoUrls, setSelectedRepoUrlsState] = useState<string[]>(() =>
+    organizationId ? (readOnboardingSelectedRepos(organizationId) ?? []) : [],
+  );
+  const [hasRepoDraft, setHasRepoDraft] = useState<boolean>(() =>
+    organizationId ? readOnboardingSelectedRepos(organizationId) !== null : false,
+  );
+  // Which org's draft is loaded into state. A late-arriving organizationId (the
+  // `/me` round-trip resolves after first paint) or an org switch hydrates that
+  // org's draft exactly once — not on every render, so an in-progress edit is
+  // never clobbered back to the stored value.
+  const hydratedDraftOrgRef = useRef<string | null>(organizationId);
+  useEffect(() => {
+    if (!organizationId || hydratedDraftOrgRef.current === organizationId) return;
+    hydratedDraftOrgRef.current = organizationId;
+    const draft = readOnboardingSelectedRepos(organizationId);
+    setHasRepoDraft(draft !== null);
+    setSelectedRepoUrlsState(draft ?? []);
+  }, [organizationId]);
+
+  // Wrap the setter so every change writes through to the per-org draft and
+  // marks a draft as present. The formal team-resource write still happens only
+  // at kickoff — this is the in-flight draft that survives a bailout.
+  const setSelectedRepoUrls = useCallback(
+    (next: string[]) => {
+      setSelectedRepoUrlsState(next);
+      setHasRepoDraft(true);
+      if (organizationId) writeOnboardingSelectedRepos(organizationId, next);
+    },
+    [organizationId],
+  );
   const [treeMode, setTreeMode] = useState<TreeMode>("new");
   const [treeUrl, setTreeUrl] = useState<string>("");
   const [treeAutoInitDone, setTreeAutoInitDone] = useState(false);
@@ -195,6 +241,12 @@ export function OnboardingFlowProvider({ path, children }: { path: OnboardingPat
       // can't read a stale cross-org agent (the org filter in
       // resolveOnboardingAgent only catches that when the org id is known).
       writeOnboardingAgentUuid(null);
+      // The selection has now been consumed by kickoff (written as team repo
+      // resources), so drop the in-flight draft — a later same-tab onboarding
+      // in this org starts clean rather than resurrecting a stale pick. Only
+      // completion clears it; `finishLater` deliberately keeps it so the user
+      // resumes their selection.
+      if (organizationId) writeOnboardingSelectedRepos(organizationId, null);
       try {
         await markOnboardingCompleted();
       } catch {
@@ -205,7 +257,7 @@ export function OnboardingFlowProvider({ path, children }: { path: OnboardingPat
       }
       navigate(`/?c=${encodeURIComponent(chatId)}`);
     },
-    [path, markOnboardingCompleted, navigate],
+    [path, organizationId, markOnboardingCompleted, navigate],
   );
 
   const finishLater = useCallback(async () => {
@@ -240,6 +292,7 @@ export function OnboardingFlowProvider({ path, children }: { path: OnboardingPat
       hasAgent: orgStep === "completed" || createdAgentUuid !== null,
       selectedRepoUrls,
       setSelectedRepoUrls,
+      hasRepoDraft,
       treeMode,
       setTreeMode,
       treeUrl,
@@ -272,6 +325,8 @@ export function OnboardingFlowProvider({ path, children }: { path: OnboardingPat
       createdAgentUuid,
       orgStep,
       selectedRepoUrls,
+      setSelectedRepoUrls,
+      hasRepoDraft,
       treeMode,
       treeUrl,
       treeAutoInitDone,

--- a/packages/web/src/pages/onboarding/steps/step-connect-code.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-connect-code.tsx
@@ -38,7 +38,7 @@ const INSTALL_ATTEMPT_KEY = "onboarding:connect-code:install-attempt";
  * with no prop (friction, not a block) — unchanged.
  */
 export function StepConnectCode({ recovery }: { recovery?: boolean } = {}) {
-  const { organizationId, goNext, selectedRepoUrls, setSelectedRepoUrls } = useOnboardingFlow();
+  const { organizationId, goNext, selectedRepoUrls, setSelectedRepoUrls, hasRepoDraft } = useOnboardingFlow();
   const [installError, setInstallError] = useState<"not_configured" | "not_admin" | "generic" | null>(null);
   const [redirecting, setRedirecting] = useState(false);
   // Whether the user has actually kicked off an install (this tab). We only
@@ -92,15 +92,31 @@ export function StepConnectCode({ recovery }: { recovery?: boolean } = {}) {
 
   // Default the picker to every granted repo so the user doesn't re-pick what
   // they just granted on GitHub (they can narrow by unchecking). One-shot when
-  // repos first load — after that we never fight a deliberate "none".
+  // repos first load — and ONLY when there's no saved draft for this org, so a
+  // resumed selection (narrowed to a subset, or to none, then "finish later" /
+  // refreshed) is restored as-is instead of being re-selected back to "all".
   const preselectedRef = useRef(false);
-  // biome-ignore lint/correctness/useExhaustiveDependencies: one-shot on first repo load; reads selection at fire time
+  // biome-ignore lint/correctness/useExhaustiveDependencies: one-shot on first repo load; reads selection + draft flag at fire time
   useEffect(() => {
     if (preselectedRef.current) return;
     const loaded = reposQuery.data;
     if (!loaded || loaded.length === 0) return;
     preselectedRef.current = true;
-    if (selectedRepoUrls.length === 0) setSelectedRepoUrls(loaded.map((r) => r.cloneUrl));
+    const grantedUrls = loaded.map((r) => r.cloneUrl);
+    if (!hasRepoDraft) {
+      // First visit: default to every granted repo.
+      setSelectedRepoUrls(grantedUrls);
+      return;
+    }
+    // Resumed draft: keep the user's narrowing, but drop any repo the GitHub App
+    // no longer grants (uninstalled, or the granted set changed between bailout
+    // and resume). The pre-draft behaviour reset to "all current grants" every
+    // visit, so a restored draft is the only path a stale URL could ride into
+    // kickoff and get provisioned from a repo the app can't access. Prune only
+    // against an authoritative loaded list (this effect already returned above
+    // on an empty/missing list, so a transient load failure never wipes).
+    const pruned = selectedRepoUrls.filter((url) => grantedUrls.includes(url));
+    if (pruned.length !== selectedRepoUrls.length) setSelectedRepoUrls(pruned);
   }, [reposQuery.data]);
 
   const handleConnect = async (): Promise<void> => {

--- a/packages/web/src/pages/onboarding/steps/step-kickoff.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-kickoff.tsx
@@ -2,6 +2,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { ArrowRight } from "lucide-react";
 import { type ReactNode, useEffect, useState } from "react";
 import { createAgentChat, sendChatMessage } from "../../../api/chats.js";
+import { listOrgGithubRepos } from "../../../api/github.js";
 import { getGithubAppInstallationExists } from "../../../api/github-app.js";
 import { reportOnboardingEvent } from "../../../api/onboarding-events.js";
 import { getContextTreeSetting, putContextTreeSetting } from "../../../api/org-settings.js";
@@ -203,17 +204,52 @@ function AdminKickoff({
         });
         return;
       }
+
+      // Re-validate the selection against the CURRENT GitHub App grant list
+      // before writing any team repo resource. `selectedRepoUrls` may be a
+      // restored per-org draft, and the connect-code prune only runs when that
+      // step mounts — a flow resumed directly at kickoff (persisted step index)
+      // would otherwise register a repo removed from the installation since the
+      // user picked it. Reuses connect-code's cached repo list; on a fetch
+      // failure we don't block kickoff (downstream registration still verifies).
+      let repos = selectedRepoUrls;
+      if (organizationId) {
+        try {
+          const granted = await queryClient.fetchQuery({
+            queryKey: ["onboarding", "org-github-repos", organizationId],
+            queryFn: () => listOrgGithubRepos(organizationId),
+          });
+          const grantedUrls = new Set(granted.map((r) => r.cloneUrl));
+          repos = selectedRepoUrls.filter((url) => grantedUrls.has(url));
+        } catch {
+          // Transient GitHub read failure — proceed with the user's selection
+          // rather than block the finale on a grant-list refresh.
+        }
+      }
+
+      // Everything the user picked is gone from the installation → nothing to
+      // seed a tree from, so fall to the intro path instead of provisioning a
+      // tree from repos the app can no longer access.
+      if (repos.length === 0) {
+        await runKickoff({
+          bootstrap: NO_REPO_BOOTSTRAP,
+          orgWrites: null,
+          treeMode: "new",
+          organizationId,
+          complete: completeAndEnterChat,
+        });
+        return;
+      }
+
       const useExisting = treeMode === "existing";
       const detectedUrl = treeUrl.trim();
-      const bootstrap = useExisting
-        ? buildBindBootstrap(selectedRepoUrls, detectedUrl)
-        : buildCreateBootstrap(selectedRepoUrls);
+      const bootstrap = useExisting ? buildBindBootstrap(repos, detectedUrl) : buildCreateBootstrap(repos);
       await runKickoff({
         bootstrap,
         orgWrites: organizationId
           ? {
               organizationId,
-              sourceRepos: selectedRepoUrls,
+              sourceRepos: repos,
               contextTreeUrl: useExisting ? detectedUrl : null,
             }
           : null,

--- a/packages/web/src/pages/onboarding/steps/step-kickoff.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-kickoff.tsx
@@ -224,6 +224,14 @@ function AdminKickoff({
           .fetchQuery({
             queryKey: ["onboarding", "org-github-repos", organizationId],
             queryFn: () => listOrgGithubRepos(organizationId),
+            // Within one onboarding session grants don't change, so reuse the
+            // list connect-code just fetched instead of re-reading GitHub on
+            // every "Start". That keeps the normal connect-code → kickoff path
+            // off a live read a transient blip could fail (which fail-closed
+            // would turn into a hard block). A genuine resume-at-kickoff is a
+            // fresh page load with an empty in-memory cache, so it still fetches
+            // and validates here.
+            staleTime: 5 * 60 * 1000,
           })
           .catch(() => {
             throw new Error("Couldn't check your repositories with GitHub just now. Try again in a moment.");

--- a/packages/web/src/pages/onboarding/steps/step-kickoff.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-kickoff.tsx
@@ -210,7 +210,7 @@ function AdminKickoff({
       // restored per-org draft, and the connect-code prune only runs when that
       // step mounts — a flow resumed directly at kickoff (persisted step index)
       // would otherwise register a repo removed from the installation since the
-      // user picked it. Reuses connect-code's cached repo list.
+      // user picked it.
       //
       // Fail CLOSED: if we can't read the current grant list (no_installation,
       // suspended, not_configured, upstream 5xx) we cannot prove the selected
@@ -224,14 +224,15 @@ function AdminKickoff({
           .fetchQuery({
             queryKey: ["onboarding", "org-github-repos", organizationId],
             queryFn: () => listOrgGithubRepos(organizationId),
-            // Within one onboarding session grants don't change, so reuse the
-            // list connect-code just fetched instead of re-reading GitHub on
-            // every "Start". That keeps the normal connect-code → kickoff path
-            // off a live read a transient blip could fail (which fail-closed
-            // would turn into a hard block). A genuine resume-at-kickoff is a
-            // fresh page load with an empty in-memory cache, so it still fetches
-            // and validates here.
-            staleTime: 5 * 60 * 1000,
+            // No `staleTime`: this is the AUTHORITATIVE write-path check, so it
+            // must read the current grant list every time, never a cached one.
+            // The QueryClient is an app-level singleton and `finishLater` is SPA
+            // navigation (not a reload), so the connect-code cache stays alive —
+            // reusing it could pass a list minutes-stale relative to grants that
+            // changed in another tab / GitHub settings, and write a removed repo.
+            // A redundant read on the normal connect-code → kickoff path is the
+            // accepted cost of correctness here.
+            staleTime: 0,
           })
           .catch(() => {
             throw new Error("Couldn't check your repositories with GitHub just now. Try again in a moment.");

--- a/packages/web/src/pages/onboarding/steps/step-kickoff.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-kickoff.tsx
@@ -210,21 +210,26 @@ function AdminKickoff({
       // restored per-org draft, and the connect-code prune only runs when that
       // step mounts — a flow resumed directly at kickoff (persisted step index)
       // would otherwise register a repo removed from the installation since the
-      // user picked it. Reuses connect-code's cached repo list; on a fetch
-      // failure we don't block kickoff (downstream registration still verifies).
+      // user picked it. Reuses connect-code's cached repo list.
+      //
+      // Fail CLOSED: if we can't read the current grant list (no_installation,
+      // suspended, not_configured, upstream 5xx) we cannot prove the selected
+      // repos are still accessible, and nothing downstream re-checks grants
+      // (`createTeamResourceForOrg` only validates URL shape; existing-tree
+      // writes are best-effort). So surface a retryable error instead of
+      // registering a possibly-stale selection — clicking Start again retries.
       let repos = selectedRepoUrls;
       if (organizationId) {
-        try {
-          const granted = await queryClient.fetchQuery({
+        const granted = await queryClient
+          .fetchQuery({
             queryKey: ["onboarding", "org-github-repos", organizationId],
             queryFn: () => listOrgGithubRepos(organizationId),
+          })
+          .catch(() => {
+            throw new Error("Couldn't check your repositories with GitHub just now. Try again in a moment.");
           });
-          const grantedUrls = new Set(granted.map((r) => r.cloneUrl));
-          repos = selectedRepoUrls.filter((url) => grantedUrls.has(url));
-        } catch {
-          // Transient GitHub read failure — proceed with the user's selection
-          // rather than block the finale on a grant-list refresh.
-        }
+        const grantedUrls = new Set(granted.map((r) => r.cloneUrl));
+        repos = selectedRepoUrls.filter((url) => grantedUrls.has(url));
       }
 
       // Everything the user picked is gone from the installation → nothing to

--- a/packages/web/src/utils/__tests__/onboarding-flags.test.ts
+++ b/packages/web/src/utils/__tests__/onboarding-flags.test.ts
@@ -6,7 +6,9 @@ import {
   clearOnboardingSessionFlags,
   markOnboardingResume,
   readOnboardingAgentUuid,
+  readOnboardingSelectedRepos,
   writeOnboardingAgentUuid,
+  writeOnboardingSelectedRepos,
 } from "../onboarding-flags.js";
 
 function createStorage(): Storage {
@@ -71,5 +73,57 @@ describe("onboarding session flags", () => {
     expect(() => markOnboardingResume("solo")).not.toThrow();
     expect(() => clearOnboardingJoinPath()).not.toThrow();
     expect(() => clearOnboardingSessionFlags()).not.toThrow();
+    expect(readOnboardingSelectedRepos("org-1")).toBeNull();
+    expect(() => writeOnboardingSelectedRepos("org-1", ["x"])).not.toThrow();
+  });
+});
+
+describe("onboarding selected-repos draft", () => {
+  const WEB = "https://github.com/acme/web.git";
+  const API = "git@github.com:acme/api.git";
+  const URLS = [WEB, API];
+
+  it("round-trips a per-org draft and distinguishes absent from empty", () => {
+    // No draft yet → null (so connect-code knows to auto-select all granted).
+    expect(readOnboardingSelectedRepos("org-1")).toBeNull();
+
+    writeOnboardingSelectedRepos("org-1", URLS);
+    expect(readOnboardingSelectedRepos("org-1")).toEqual(URLS);
+
+    // A deliberate "deselect everything" is an empty array, NOT null — the
+    // distinction the connect-code preselect gate depends on.
+    writeOnboardingSelectedRepos("org-1", []);
+    expect(readOnboardingSelectedRepos("org-1")).toEqual([]);
+
+    // null clears the key back to "no draft".
+    writeOnboardingSelectedRepos("org-1", null);
+    expect(readOnboardingSelectedRepos("org-1")).toBeNull();
+  });
+
+  it("keeps drafts independent per org", () => {
+    writeOnboardingSelectedRepos("org-1", [WEB]);
+    writeOnboardingSelectedRepos("org-2", [API]);
+    expect(readOnboardingSelectedRepos("org-1")).toEqual([WEB]);
+    expect(readOnboardingSelectedRepos("org-2")).toEqual([API]);
+  });
+
+  it("is swept by clearOnboardingSessionFlags (onboarding:* namespace)", () => {
+    writeOnboardingSelectedRepos("org-1", URLS);
+    clearOnboardingSessionFlags();
+    expect(readOnboardingSelectedRepos("org-1")).toBeNull();
+  });
+
+  it("returns null for malformed or non-string-array stored values", () => {
+    sessionStorage.setItem("onboarding:selectedRepos:org-1", "not json");
+    expect(readOnboardingSelectedRepos("org-1")).toBeNull();
+    sessionStorage.setItem("onboarding:selectedRepos:org-1", JSON.stringify([1, 2]));
+    expect(readOnboardingSelectedRepos("org-1")).toBeNull();
+    sessionStorage.setItem("onboarding:selectedRepos:org-1", JSON.stringify({ url: "x" }));
+    expect(readOnboardingSelectedRepos("org-1")).toBeNull();
+  });
+
+  it("ignores a missing org id", () => {
+    expect(readOnboardingSelectedRepos("")).toBeNull();
+    expect(() => writeOnboardingSelectedRepos("", URLS)).not.toThrow();
   });
 });

--- a/packages/web/src/utils/onboarding-flags.ts
+++ b/packages/web/src/utils/onboarding-flags.ts
@@ -14,6 +14,51 @@ const JOIN_PATH_KEY = "onboarding:joinPath";
 
 const ONBOARDING_AGENT_UUID_KEY = "onboarding:agentUuid";
 
+const SELECTED_REPOS_KEY = (orgId: string) => `onboarding:selectedRepos:${orgId}`;
+
+/**
+ * Per-org draft of the repos the admin picked on the connect-code step.
+ *
+ * Persisted so leaving before kickoff — the top-bar "I'll finish later", a
+ * refresh, or a mid-flow navigation — doesn't silently discard the selection;
+ * the user resumes the wizard with the repos they chose still ticked. The
+ * formal team-resource write still happens only at kickoff ("Build tree &
+ * start"); this is purely an in-flight draft so the choice survives a bailout.
+ *
+ * Per-tab (sessionStorage), matching the other onboarding flags and the
+ * same-session continuation the flow targets. Keyed by org so a multi-org user
+ * keeps an independent draft per team.
+ *
+ * Returns `null` when no draft exists (the user hasn't touched the picker yet)
+ * — distinct from `[]`, which means they deliberately deselected everything.
+ * The connect-code step needs that distinction: it only auto-selects all
+ * granted repos when there is NO draft, so a resumed narrowing (to a subset, or
+ * to none) is never clobbered back to "all".
+ */
+export function readOnboardingSelectedRepos(orgId: string): string[] | null {
+  if (typeof window === "undefined" || !orgId) return null;
+  const raw = window.sessionStorage.getItem(SELECTED_REPOS_KEY(orgId));
+  if (raw === null) return null;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return null;
+    const urls: string[] = [];
+    for (const u of parsed) {
+      if (typeof u !== "string") return null;
+      urls.push(u);
+    }
+    return urls;
+  } catch {
+    return null;
+  }
+}
+
+export function writeOnboardingSelectedRepos(orgId: string, urls: string[] | null): void {
+  if (typeof window === "undefined" || !orgId) return;
+  if (urls === null) window.sessionStorage.removeItem(SELECTED_REPOS_KEY(orgId));
+  else window.sessionStorage.setItem(SELECTED_REPOS_KEY(orgId), JSON.stringify(urls));
+}
+
 /**
  * UUID of the agent created during onboarding. The kickoff step uses it to
  * start the first chat against the right agent on a re-visit (where


### PR DESCRIPTION
## Problem

Repos picked on the onboarding **connect-code** step lived only in React flow state. The formal team-resource write happens later, at the **kickoff** step ("Build tree & start"). So any bailout before kickoff — the top-bar "I'll finish later", a refresh, or a mid-flow navigation — silently discarded the selection. A user who carefully narrowed to one repo, then left, came back to find their choice gone (and re-defaulted to "all granted").

This is the "I selected a repo during onboarding but it didn't save" report.

## Approach

Persist the selection as a **per-org draft in `sessionStorage`**, so the user resumes the wizard with the repos they chose. The formal team-resource write is unchanged — it still happens only at kickoff. This is purely an in-flight draft that survives a bailout.

Why `sessionStorage` (not `localStorage` / server): onboarding's whole resume model is already per-tab `sessionStorage` (the step index `onboarding:stepIndex` and the created-agent stash `onboarding:agentUuid`). On tab close the flow itself resets, so a more-durable repo draft would be a half-resume that buys nothing while adding cleanup/privacy/multi-tab concerns (localStorage) or backend weight (server). The draft's durability should match the surrounding resume model. If onboarding resume ever moves server-side, the draft should move with it (noted in code).

## Changes (frontend only)

- **`onboarding-flags.ts`** — per-org `read/writeOnboardingSelectedRepos` (`onboarding:selectedRepos:<org>`). `null` = no draft yet; `[]` = deliberately selected none. The connect-code step needs that distinction. Auto-swept by the existing `onboarding:*` logout cleanup.
- **`onboarding-flow.tsx`** — hydrate the draft per org, write through on every change, expose `hasRepoDraft`, clear the draft on successful completion (`completeAndEnterChat`); `finishLater` deliberately keeps it.
- **`step-connect-code.tsx`** — auto-select all granted repos only when there's **no** draft (so a resumed narrowing isn't clobbered back to "all"); and prune a restored draft against the current grant list for picker/UI hygiene.
- **`step-kickoff.tsx`** — authoritative grant validation on the write path. `handleStart` re-validates `selectedRepoUrls` against the current GitHub App grant list (`listOrgGithubRepos`) before building `orgWrites.sourceRepos`, covering the **resume-directly-at-kickoff** path (persisted step index) where `StepConnectCode` never mounts.
  - Ungranted repos are pruned; if the selection is empty after pruning, it degrades to the no-repo intro path.
  - **Always reads current grants** (`staleTime: 0`, not a cached list): the QueryClient is an app-level singleton and `finishLater` is SPA navigation, so a cached grant list can be stale relative to grants changed in another tab / GitHub settings. The check must prove *current* grant state, so it never trusts the picker cache here. The redundant read on the normal connect-code → kickoff path is the accepted cost of correctness.
  - **Fails closed**: if the grant list can't be read (`no_installation` / `suspended` / `not_configured` / upstream 5xx), kickoff surfaces a retryable error and writes **nothing** — it never registers an unvalidated selection. There is no downstream grant check (`createTeamResourceForOrg` only validates URL shape; existing-tree writes are best-effort). Clicking Start retries.

## Review

Iterated through several `request_changes` rounds; the stale-grant invariant — a restored draft carrying a now-inaccessible repo into the team-resource write — is now closed on **every** path:
- connect-code prune (UI / picker hygiene),
- kickoff write-path revalidation against current grants (authoritative, never cached),
- fail-closed when grants can't be read.

Server-side grant enforcement at `createTeamResourceForOrg` would be additional defense-in-depth, but the onboarding client is the only writer, so the invariant is closed here (can file a follow-up issue if wanted). Implementation-only; no Context Tree change (the "formal write stays at kickoff" decision is unchanged).

## Test plan

- Unit (`onboarding-flags`): round-trip, `null` vs `[]`, per-org isolation, logout sweep, malformed-value fallback.
- DOM (`connect-code`): no-draft → auto-select all; resumed draft → not overwritten; resumed draft with a no-longer-granted repo → pruned.
- DOM (`kickoff`): stale repo in selection → pruned, never registered; grant read fails → no resource write, no navigation (fail closed); **a stale cached grant list is ignored — the live read still prunes the removed repo** (guards the authoritative check).
- `pnpm typecheck` + Biome clean; onboarding-related suites green (114 tests).

### Manual (staging)
1. Onboarding → connect GitHub → narrow the repo picker to one.
2. Top-bar "I'll finish later".
3. Re-enter onboarding → connect-code should still show your narrowed selection (not re-checked to all).
4. Refresh mid-flow → same.
5. Finish kickoff → draft cleared; the repo appears in Settings → Resources (kickoff write unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
