### PR TITLE
feat(onboarding): confirm connected GitHub account on connect-code step

### DIFF
--- a/packages/web/src/pages/onboarding-preview.tsx
+++ b/packages/web/src/pages/onboarding-preview.tsx
@@ -1,4 +1,4 @@
-import type { AgentVisibility, ResourceRow } from "@first-tree/shared";
+import type { AgentVisibility, GithubAppInstallationOutput, ResourceRow } from "@first-tree/shared";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { type ReactNode, useMemo, useState } from "react";
 import type { HubClient } from "../api/activity.js";
@@ -97,6 +97,34 @@ const REPOS: GithubRepo[] = [
     pushedAt: NOW_ISO,
   },
 ];
+
+// GET /orgs/:id/github-app-installation — the bound installation. The connect-code
+// "connected" confirmation reads accountLogin / accountType off this; repos come
+// from the separate repositories endpoint. Installed on the `acme` org to match
+// the REPOS fixtures (acme/web, acme/api…).
+const INSTALLATION: GithubAppInstallationOutput = {
+  installationId: 139563599,
+  accountType: "Organization",
+  accountLogin: "acme",
+  accountGithubId: 4242,
+  permissions: { contents: "read", metadata: "read" },
+  events: ["push"],
+  suspended: false,
+  manageUrl: "https://github.com/organizations/acme/settings/installations/139563599",
+  createdAt: NOW_ISO,
+  updatedAt: NOW_ISO,
+};
+// Personal-account variant: the App landed on the installer's own GitHub user,
+// not the team org — the "did this go to the right place?" case the banner exists
+// to surface.
+const INSTALLATION_USER: GithubAppInstallationOutput = {
+  ...INSTALLATION,
+  installationId: 139563600,
+  accountType: "User",
+  accountLogin: "gandy",
+  accountGithubId: 4243,
+  manageUrl: "https://github.com/settings/installations/139563600",
+};
 
 const NOOP = (): void => {};
 const ASYNC_NOOP = async (): Promise<void> => {};
@@ -197,6 +225,11 @@ type NetProfile = {
   /** When true, the installation query never resolves (stays loading) — used to
       hold the post-click "Waiting for GitHub…" state without it flipping to stuck. */
   installPending?: boolean;
+  /** Which account the App is installed on, driving the connected-confirmation
+      banner: `org` (default) installs on the `acme` org; `user` installs on a
+      personal account — the case where the install account differs from the
+      team's repos, which the banner is meant to make visible. */
+  installAccount?: "org" | "user";
   /** GET /orgs/:id/github-app-installation/exists */
   installExists?: boolean;
   /** GET /orgs/:id/settings/context_tree → { repo } */
@@ -275,7 +308,7 @@ function handleNet(rawUrl: string): Promise<Response> | Response | null {
   if (p === `/orgs/${ORG_ID}/github-app-installation`) {
     if (activeNet.installPending) return new Promise<Response>(() => {});
     return activeNet.installed
-      ? jsonResponse({ installed: true })
+      ? jsonResponse(activeNet.installAccount === "user" ? INSTALLATION_USER : INSTALLATION)
       : statusResponse(404, "No GitHub App installation is bound to this team");
   }
   if (p === `/orgs/${ORG_ID}/github-app-installation/exists`) {
@@ -557,10 +590,17 @@ const SCENARIOS: Scenario[] = [
   },
   {
     id: "admin-code-repos",
-    label: "Pick repos",
+    label: "Pick repos · org install",
     group: "4 · Connect code",
     role: "admin",
-    wizard: { step: "connect-code", net: { installed: true, repos: REPOS } },
+    wizard: { step: "connect-code", net: { installed: true, repos: REPOS, installAccount: "org" } },
+  },
+  {
+    id: "admin-code-repos-user",
+    label: "Pick repos · personal-account install",
+    group: "4 · Connect code",
+    role: "admin",
+    wizard: { step: "connect-code", net: { installed: true, repos: REPOS, installAccount: "user" } },
   },
 
   {

--- a/packages/web/src/pages/onboarding/copy.ts
+++ b/packages/web/src/pages/onboarding/copy.ts
@@ -136,8 +136,17 @@ export const COPY = {
     phases: ["Connect GitHub", "Pick repos"],
     cta: "Install on GitHub",
     waiting: "Waiting for GitHub…",
-    // (connected status row removed — the PhaseNav's "✓ Connect GitHub" already
-    // signals the connection, and the repo picker shows the org + repos.)
+    /** Post-install confirmation. The account a GitHub App is installed on is
+        set by whoever's github.com session was active at install time — which
+        is NOT necessarily the account the user signed into First Tree with. So
+        name the connected account/org explicitly here, letting the user catch
+        "installed on the wrong account/org" before they pick repos (the picker
+        alone only implies it via repo names). */
+    connected: {
+      label: "Connected to",
+      /** Granted-repo count, shown once the repo list loads. */
+      repoCount: (n: number) => `${n} ${n === 1 ? "repository" : "repositories"} available`,
+    },
     pickProject: "Which repos should your agent work on?",
     /** Loading state for the repo picker (was hardcoded in the step). */
     loading: "Loading your repos…",

--- a/packages/web/src/pages/onboarding/steps/step-connect-code.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-connect-code.tsx
@@ -262,7 +262,10 @@ export function StepConnectCode({ recovery }: { recovery?: boolean } = {}) {
       {installQuery.data && (
         <ConnectedBanner
           installation={installQuery.data}
-          repoCount={hasPickableRepos ? (reposQuery.data?.length ?? null) : null}
+          // Show the granted-repo count once the list has actually resolved —
+          // including 0 (loaded-but-empty is a real, informative count). Stay
+          // null while loading or on error, where a count would be a guess.
+          repoCount={reposQuery.isSuccess ? (reposQuery.data?.length ?? 0) : null}
         />
       )}
 

--- a/packages/web/src/pages/onboarding/steps/step-connect-code.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-connect-code.tsx
@@ -1,5 +1,6 @@
+import type { GithubAppInstallationOutput } from "@first-tree/shared";
 import { useQuery } from "@tanstack/react-query";
-import { ArrowRight, Check, ChevronRight, Github } from "lucide-react";
+import { ArrowRight, Building2, Check, ChevronRight, Github, User } from "lucide-react";
 import { Fragment, useEffect, useRef, useState } from "react";
 import { ApiError } from "../../../api/client.js";
 import { listOrgGithubRepos } from "../../../api/github.js";
@@ -254,6 +255,17 @@ export function StepConnectCode({ recovery }: { recovery?: boolean } = {}) {
     <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
       <PhaseNav phase="pick" />
 
+      {/* Confirm WHICH GitHub account/org the App landed on — the install
+          account is whoever's github.com session was active at install time,
+          not necessarily the First Tree login account, so name it explicitly
+          before the repo pick. */}
+      {installQuery.data && (
+        <ConnectedBanner
+          installation={installQuery.data}
+          repoCount={hasPickableRepos ? (reposQuery.data?.length ?? null) : null}
+        />
+      )}
+
       <div className="flex flex-col" style={{ gap: "var(--sp-2)" }}>
         {/* The "which repos" prompt only makes sense when there's a list to
             pick from — in loading / load-failed / empty states it would ask
@@ -395,6 +407,62 @@ function PhaseNav({ phase }: { phase: "connect" | "pick" }) {
           </Fragment>
         );
       })}
+    </div>
+  );
+}
+
+/**
+ * Post-install confirmation banner: names the GitHub account/org the App is now
+ * connected to (plus the granted-repo count once the list loads). The install
+ * account is set by whichever github.com session was active at install time —
+ * which need not be the account the user signed into First Tree with — so
+ * surfacing it here lets the user catch a wrong-account/org install before they
+ * pick repos. Mirrors the Settings → GitHub "Connected as" idiom (account icon +
+ * login + type chip) for visual consistency.
+ */
+function ConnectedBanner({
+  installation,
+  repoCount,
+}: {
+  installation: GithubAppInstallationOutput;
+  repoCount: number | null;
+}) {
+  const AccountIcon = installation.accountType === "Organization" ? Building2 : User;
+  return (
+    <div
+      className="flex items-center"
+      style={{
+        gap: "var(--sp-2)",
+        padding: "var(--sp-2) var(--sp-3)",
+        background: "var(--bg-sunken)",
+        borderRadius: "var(--radius-input)",
+        flexWrap: "wrap",
+      }}
+    >
+      <Check className="h-4 w-4" style={{ color: "var(--primary)", flexShrink: 0 }} aria-hidden="true" />
+      <span className="text-label" style={{ color: "var(--fg-3)" }}>
+        {COPY.connectCode.connected.label}
+      </span>
+      <AccountIcon className="h-4 w-4" style={{ color: "var(--fg-2)", flexShrink: 0 }} aria-hidden="true" />
+      <span className="text-body font-medium" style={{ color: "var(--fg)" }}>
+        {installation.accountLogin}
+      </span>
+      <span
+        className="text-label"
+        style={{
+          padding: "var(--sp-0_5) var(--sp-1_5)",
+          background: "var(--bg)",
+          borderRadius: "var(--radius-input)",
+          color: "var(--fg-3)",
+        }}
+      >
+        {installation.accountType}
+      </span>
+      {repoCount !== null && (
+        <span className="text-label" style={{ color: "var(--fg-4)", marginLeft: "auto" }}>
+          {COPY.connectCode.connected.repoCount(repoCount)}
+        </span>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## What

After the GitHub App install lands, the onboarding **Connect code** step jumped straight to the repo picker without ever stating **which GitHub account/org** the App actually connected to.

This adds a post-install confirmation banner naming the connected account: account icon + login + type chip (User/Organization) + granted-repo count.

| Org install | Personal-account install |
|---|---|
| `✓ Connected to 🏢 acme [Organization] · 3 repositories available` | `✓ Connected to 👤 gandy [User] · 3 repositories available` |

## Why

The GitHub App install account is set by whichever **github.com session was active at install time** — which need not be the account the user signed into First Tree with (the system intentionally allows this mismatch; the 403 path was fixed in #988). So a **wrong-account/org install** (e.g. installing on a personal account instead of the team org) was previously only discoverable later and indirectly — the agent ends up on the wrong/empty repos.

This is a low-cost transparency/safety-net: it makes the connected account **explicit** so the user catches a wrong target at install time, before picking repos. It is **not** a "your accounts don't match" warning (that would misfire on legitimate personal/work-account splits) — it just shows what got connected and lets the user judge.

## Scope

- **Frontend only.** `accountLogin` / `accountType` are already on the installation response (`GithubAppInstallationOutput`) — no backend / schema change.
- Reuses the existing Settings → GitHub "Connected as" visual idiom.

## Changes

- `step-connect-code.tsx` — `ConnectedBanner` rendered in the connected state.
- `copy.ts` — `connectCode.connected` strings.
- `onboarding-preview.tsx` — enrich the installation mock with full account fields, add a `User`-type variant, and add org / personal-account "Pick repos" gallery scenarios.

## Verification

- `pnpm --filter @first-tree/web typecheck` ✓ (incl. design-token guard)
- Biome check on changed files ✓
- Eyeballed both variants in `/preview/onboarding` (org + personal-account scenarios).

🤖 Generated with [Claude Code](https://claude.com/claude-code)