### PR TITLE
fix(web): render human teammate avatars

### DIFF
--- a/packages/server/src/__tests__/members.test.ts
+++ b/packages/server/src/__tests__/members.test.ts
@@ -4,6 +4,7 @@ import type { FastifyInstance } from "fastify";
 import { describe, expect, it } from "vitest";
 import { agents as agentsTable } from "../db/schema/agents.js";
 import { members as membersTable } from "../db/schema/members.js";
+import { users as usersTable } from "../db/schema/users.js";
 import { createAgent } from "../services/agent.js";
 import * as memberService from "../services/member.js";
 import { repairMembershipHumanMirrors } from "../services/membership.js";
@@ -50,11 +51,31 @@ describe("Members API", () => {
       const req = await authedRequest(app);
       const res = await req("GET", "/api/v1/members");
       expect(res.statusCode).toBe(200);
-      const body = res.json<Array<{ id: string; username: string; role: string }>>();
+      const body = res.json<Array<{ id: string; username: string; role: string; avatarUrl: string | null }>>();
       expect(body.length).toBeGreaterThanOrEqual(1);
       expect(body[0]).toHaveProperty("username");
       expect(body[0]).toHaveProperty("role");
       expect(body[0]).toHaveProperty("agentId");
+      expect(body[0]).toHaveProperty("avatarUrl");
+    });
+
+    it("returns a member's user avatar URL when present", async () => {
+      const app = getApp();
+      const req = await authedRequest(app);
+      const createRes = await req("POST", "/api/v1/members", {
+        username: `avatar-member-${Date.now()}`,
+        displayName: "Avatar Member",
+        role: "member",
+      });
+      expect(createRes.statusCode).toBe(201);
+      const created = createRes.json<{ userId: string }>();
+      const avatarUrl = "https://avatars.example.test/u/avatar-member.png";
+      await app.db.update(usersTable).set({ avatarUrl }).where(eq(usersTable.id, created.userId));
+
+      const res = await req("GET", "/api/v1/members");
+      expect(res.statusCode).toBe(200);
+      const body = res.json<Array<{ userId: string; avatarUrl: string | null }>>();
+      expect(body.find((member) => member.userId === created.userId)?.avatarUrl).toBe(avatarUrl);
     });
   });
 
@@ -68,11 +89,19 @@ describe("Members API", () => {
         role: "member",
       });
       expect(res.statusCode).toBe(201);
-      const body = res.json<{ id: string; username: string; password: string; role: string; agentId: string }>();
+      const body = res.json<{
+        id: string;
+        username: string;
+        password: string;
+        role: string;
+        agentId: string;
+        avatarUrl: string | null;
+      }>();
       expect(body.password).toBeDefined();
       expect(body.password.length).toBeGreaterThan(0);
       expect(body.role).toBe("member");
       expect(body.agentId).toBeDefined();
+      expect(body.avatarUrl).toBeNull();
     });
 
     it("rejects duplicate username in same org", async () => {

--- a/packages/server/src/services/member.ts
+++ b/packages/server/src/services/member.ts
@@ -140,6 +140,7 @@ export async function createMember(db: Database, orgId: string, data: CreateMemb
       lastActiveAt: null,
       username: data.username,
       displayName: data.displayName,
+      avatarUrl: existingUser?.avatarUrl ?? null,
       // Only return password for new users
       ...(password ? { password } : { notice: "Existing user — use their current password to log in" }),
     };
@@ -158,6 +159,7 @@ export async function listMembers(db: Database, orgId: string) {
       createdAt: members.createdAt,
       username: users.username,
       displayName: users.displayName,
+      avatarUrl: users.avatarUrl,
     })
     .from(members)
     .innerJoin(users, eq(members.userId, users.id))
@@ -187,6 +189,7 @@ export async function getMember(db: Database, id: string) {
       createdAt: members.createdAt,
       username: users.username,
       displayName: users.displayName,
+      avatarUrl: users.avatarUrl,
     })
     .from(members)
     .innerJoin(users, eq(members.userId, users.id))

--- a/packages/shared/src/schemas/member.ts
+++ b/packages/shared/src/schemas/member.ts
@@ -15,6 +15,7 @@ export const memberSchema = z.object({
   agentId: z.string(),
   role: memberRoleSchema,
   createdAt: z.string(),
+  avatarUrl: z.string().nullable(),
   /**
    * ISO timestamp the member was last active, *derived* from the most recent
    * message sent by their human agent (no dedicated column — read-time

--- a/packages/web/src/api/members.ts
+++ b/packages/web/src/api/members.ts
@@ -10,6 +10,7 @@ type MemberListItem = {
   createdAt: string;
   username: string;
   displayName: string;
+  avatarUrl: string | null;
   /** Derived from the member's most recent message (口径 B); null = never active. */
   lastActiveAt: string | null;
 };

--- a/packages/web/src/pages/team/__tests__/team-groups.test.ts
+++ b/packages/web/src/pages/team/__tests__/team-groups.test.ts
@@ -39,6 +39,7 @@ const member = (id: string, agentId: string, displayName: string, role = "member
   agentId,
   username: displayName.toLowerCase(),
   displayName,
+  avatarUrl: null,
   role,
   createdAt: "2026-01-01T00:00:00.000Z",
   lastActiveAt: null,
@@ -109,6 +110,17 @@ describe("buildTeamData", () => {
     const never = humans.find((h) => h.id === "member-2");
     expect(active?.lastActiveLabel).toBeTruthy();
     expect(never?.lastActiveLabel).toBeNull();
+  });
+
+  it("passes member avatarUrl through to the human row", () => {
+    const avatarUrl = "https://avatars.example.test/u/ada.png";
+    const { humans } = buildTeamData({
+      ...base,
+      members: [{ ...member("member-1", "human-1", "Ada"), avatarUrl }],
+      agents: [],
+      agentByUuid: new Map(),
+    });
+    expect(humans[0]?.avatarUrl).toBe(avatarUrl);
   });
 
   it("partitions agents into Public/Private with own agents pinned first", () => {

--- a/packages/web/src/pages/team/__tests__/team-page-dom.test.tsx
+++ b/packages/web/src/pages/team/__tests__/team-page-dom.test.tsx
@@ -180,6 +180,8 @@ type MemberListItem = {
   createdAt: string;
   username: string;
   displayName: string;
+  avatarUrl: string | null;
+  lastActiveAt: string | null;
 };
 
 function agent(overrides: Partial<Agent> = {}): Agent {
@@ -216,6 +218,8 @@ function member(overrides: Partial<MemberListItem> = {}): MemberListItem {
     createdAt: overrides.createdAt ?? NOW,
     username: overrides.username ?? "gandy",
     displayName: overrides.displayName ?? "Gandy",
+    avatarUrl: overrides.avatarUrl ?? null,
+    lastActiveAt: overrides.lastActiveAt ?? null,
   };
 }
 
@@ -322,6 +326,7 @@ const MEMBERS = [
     role: "member",
     username: "alice",
     displayName: "Alice",
+    avatarUrl: "https://avatars.example.test/u/alice.png",
   }),
 ];
 
@@ -498,6 +503,9 @@ describe("TeamPage", () => {
     expect(container.textContent).toContain("Invite link");
     expect(container.textContent).toContain("Design Critique");
     expect(container.querySelector('[title="claude-code @ gandy-macbook"]')).not.toBeNull();
+    expect(container.querySelector('img[alt="Alice"]')?.getAttribute("src")).toBe(
+      "https://avatars.example.test/u/alice.png",
+    );
 
     await click(exactButton(container, "New agent"));
     await waitForText(document.body, "Mock New Agent");

--- a/packages/web/src/pages/team/__tests__/team-table-dom.test.tsx
+++ b/packages/web/src/pages/team/__tests__/team-table-dom.test.tsx
@@ -109,6 +109,7 @@ function createProps(overrides: Partial<TeamTableProps> = {}): TeamTableProps {
       agentId: "human-self",
       username: "gandy",
       displayName: "Gandy",
+      avatarUrl: "https://avatars.example.test/u/gandy.png",
       role: "admin",
       isSelf: true,
       delegate: { uuid: "agent-1", name: "nova", displayName: "Nova", colorToken: null, avatarImageUrl: null },
@@ -121,6 +122,7 @@ function createProps(overrides: Partial<TeamTableProps> = {}): TeamTableProps {
       agentId: "human-alice",
       username: "alice",
       displayName: "Alice",
+      avatarUrl: null,
       role: "member",
       isSelf: false,
       delegate: null,
@@ -219,6 +221,9 @@ describe("TeamTable", () => {
     expect(container.textContent).toContain("Gandy");
     expect(container.textContent).toContain("Admin");
     expect(container.textContent).toContain("—");
+    expect(container.querySelector('img[alt="Gandy"]')?.getAttribute("src")).toBe(
+      "https://avatars.example.test/u/gandy.png",
+    );
 
     await click(container.querySelector('[aria-label="Open Nova"]'));
     expect(props.onAgentDetails).toHaveBeenCalledWith("agent-1");
@@ -254,6 +259,7 @@ describe("TeamTable", () => {
           agentId: "human-self",
           username: "gandy",
           displayName: "Gandy",
+          avatarUrl: "https://avatars.example.test/u/gandy-compact.png",
           role: "member",
           isSelf: true,
           delegate: null,
@@ -272,6 +278,9 @@ describe("TeamTable", () => {
     const { container, root } = await renderDom(<TeamTable {...props} />);
     expect(container.textContent).toContain("No agents match this search.");
     expect(container.textContent).toContain("Set delegate");
+    expect(container.querySelector('img[alt="Gandy"]')?.getAttribute("src")).toBe(
+      "https://avatars.example.test/u/gandy-compact.png",
+    );
 
     const selfRow = container.querySelector('[aria-label="Open Gandy"]');
     await act(async () => {

--- a/packages/web/src/pages/team/index.tsx
+++ b/packages/web/src/pages/team/index.tsx
@@ -59,6 +59,7 @@ type MemberListItem = {
   displayName: string;
   role: string;
   createdAt: string;
+  avatarUrl: string | null;
   /** Derived from the member's most recent message; null = never active. */
   lastActiveAt: string | null;
 };
@@ -516,6 +517,7 @@ export function buildTeamData(args: {
         agentId: m.agentId,
         username: m.username,
         displayName: m.displayName,
+        avatarUrl: m.avatarUrl,
         role: m.role,
         isSelf,
         delegate: resolveDelegate(m.agentId),

--- a/packages/web/src/pages/team/team-table.tsx
+++ b/packages/web/src/pages/team/team-table.tsx
@@ -34,6 +34,7 @@ export type HumanRow = {
   agentId: string;
   username: string;
   displayName: string;
+  avatarUrl: string | null;
   role: string;
   isSelf: boolean;
   delegate: {
@@ -692,7 +693,7 @@ function HumanRowView(props: TeamTableProps & { compact: boolean; row: HumanRow 
         displayName={row.displayName}
         handle={row.username}
         handleTone="neutral"
-        avatarUrl={null}
+        avatarUrl={row.avatarUrl}
         seed={row.id}
         selfTag={row.isSelf}
         adminBadge={row.role === "admin"}
@@ -719,7 +720,7 @@ function HumanRowView(props: TeamTableProps & { compact: boolean; row: HumanRow 
         displayName={row.displayName}
         handle={row.username}
         handleTone="neutral"
-        avatarUrl={null}
+        avatarUrl={row.avatarUrl}
         seed={row.id}
         selfTag={row.isSelf}
         adminBadge={row.role === "admin"}


### PR DESCRIPTION
## Root Cause

The Team page's Human teammates rows always passed `avatarUrl={null}`. The org members API also did not expose `users.avatar_url`, so real user avatars could not reach the Team table and every human row fell back to an identicon.

## Changes

- Return `avatarUrl` from member create/list/get service results.
- Add `avatarUrl` to the shared member schema and web members API type.
- Thread member avatars through `TeamPage.buildTeamData` into `HumanRow`.
- Render human teammate avatars in both desktop and compact Team table rows.
- Add server and web regression coverage for non-null member avatar URLs.

## Verification

- `pnpm --filter @first-tree/server exec vitest run 'src/__tests__/members.test.ts'`
- `pnpm --filter @first-tree/web exec vitest run 'src/pages/team/__tests__/team-table-dom.test.tsx' 'src/pages/team/__tests__/team-page-dom.test.tsx' 'src/pages/team/__tests__/team-groups.test.ts'`
- `pnpm check && pnpm typecheck`

Note: `pnpm --filter @first-tree/web test -- team-table-dom.test.tsx team-page-dom.test.tsx` runs the broader web suite under the package script; the targeted Team tests passed there, but unrelated localStorage mock tests failed (`window.localStorage.clear is not a function`). Direct file-targeted Vitest commands above passed.
