### PR TITLE
fix(web): tighten right-rail Summary heading & body type scale

### DIFF
--- a/packages/web/src/app.tsx
+++ b/packages/web/src/app.tsx
@@ -98,6 +98,12 @@ const UserMenuPreviewPage = import.meta.env.DEV
   ? lazy(() => import("./pages/user-menu-preview.js").then((module) => ({ default: module.UserMenuPreviewPage })))
   : null;
 
+const SummarySectionPreviewPage = import.meta.env.DEV
+  ? lazy(() =>
+      import("./pages/summary-section-preview.js").then((module) => ({ default: module.SummarySectionPreviewPage })),
+    )
+  : null;
+
 // Living design-system reference (companion to DESIGN.md). Unlike the previews
 // above this ships in prod too, so it can be opened on a deployed URL — it has
 // no auth-gated data, only tokens and `components/ui` primitives.
@@ -186,6 +192,16 @@ export function App() {
                   element={
                     <Suspense fallback={null}>
                       <UserMenuPreviewPage />
+                    </Suspense>
+                  }
+                />
+              ) : null}
+              {SummarySectionPreviewPage ? (
+                <Route
+                  path="/preview/summary-section"
+                  element={
+                    <Suspense fallback={null}>
+                      <SummarySectionPreviewPage />
                     </Suspense>
                   }
                 />

--- a/packages/web/src/pages/summary-section-preview.tsx
+++ b/packages/web/src/pages/summary-section-preview.tsx
@@ -1,0 +1,214 @@
+import { Markdown } from "../components/ui/markdown.js";
+import { DescriptionSection } from "./workspace/right-sidebar/description-section.js";
+
+/**
+ * DEV-only visual review for the right-rail "Summary" section (chat.description).
+ * No backend / no auth — same gating as the other `/preview/*` routes (DEV-only
+ * in `app.tsx`). Covers: Before vs After (the real DescriptionSection), dark
+ * theme (the workspace adds `.dark`; these preview routes render light by
+ * default), the capped + "Show more/less" state (GitHub section present below),
+ * and markdown edge cases (table / long bare URL / deep nesting / quote / rule).
+ * Rendered at real rail width with stress-test bodies.
+ */
+
+const SAMPLE = [
+  "# 当前任务：修 Summary 标题格式",
+  "",
+  "正在收敛右栏 **Summary** 模块的标题层级方案，目标是窄栏下层次清晰、不喧宾夺主。",
+  "",
+  "## 背景",
+  "`chat.description`（≤1500 字符）由 owning agent 维护，渲染为 markdown，承载 *背景 + 计划 + 进度*。",
+  "",
+  "## 进度",
+  "- 已定位根因：`prose prose-sm` 未压标题字号、且把正文撑大",
+  "- 标题收敛为「小节标签」，靠字重 + 留白做层级",
+  "  - h1 / h2 用 subtitle 档",
+  "  - h3+ 与正文齐平",
+  "",
+  "### 风险",
+  "窄栏下表格 / 代码块可能溢出：",
+  "",
+  "```ts",
+  "const cap = 30 // rem",
+  "```",
+  "",
+  "#### 备注",
+  "详见 [PR](#)。",
+].join("\n");
+
+// Long enough to exceed the ~30rem collapse cap, so capped mode shows the
+// bottom fade + "Show more/less" toggle.
+const LONG = [
+  "# 周计划：Summary 模块体验整治",
+  "",
+  "本周聚焦右栏 Summary 的可读性，分三步推进，逐项落地并回归。",
+  "",
+  "## 背景",
+  "Summary 是返回的人 / 刚加入的 agent 重建上下文的第一落点，但此前标题过大、正文偏大、空态无引导。",
+  "",
+  "## 计划",
+  "1. 标题与正文字号收敛（本 PR）",
+  "2. 空态占位 + 引导",
+  "3. 「更新时间 / 作者」元信息",
+  "4. human owner 内联编辑",
+  "",
+  "## 进度",
+  "- 标题层级方案定稿并实现",
+  "- 正文回归 12 档，与 rail 一致",
+  "- 预览页覆盖 before/after、暗色、capped、边角",
+  "",
+  "### 风险",
+  "- 仅 GitHub section 存在时才 cap，规则不够直觉",
+  "- 30rem 为启发式数值，非布局自适应",
+  "",
+  "### 待确认",
+  "- 是否一并修「正文偷偷 14 档」属于本 PR 范围",
+  "- 元信息需要后端补字段",
+  "",
+  "#### 备注",
+  "详见关联 PR 与 issue。",
+].join("\n");
+
+const EDGE = [
+  "## 表格",
+  "| 项 | 状态 |",
+  "| --- | --- |",
+  "| 标题字号 | 已修 |",
+  "| 正文字号 | 已修 |",
+  "",
+  "## 长裸链接",
+  "https://example.com/a/very/long/path?token=abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJ",
+  "",
+  "## 多级嵌套",
+  "- 一级",
+  "  - 二级",
+  "    - 三级（窄栏缩进）",
+  "- 又一级",
+  "",
+  "> 引用：层级靠字重 + 留白，而非字号。",
+  "",
+  "---",
+  "",
+  "末尾段落，验证 `last-child` 不留多余下边距。",
+].join("\n");
+
+const RAIL: React.CSSProperties = {
+  width: 360,
+  background: "var(--bg-raised)",
+  border: "var(--hairline) solid var(--border)",
+  borderRadius: "var(--radius-panel)",
+  overflow: "hidden",
+};
+
+function Col({ label, note, children }: { label: string; note: string; children: React.ReactNode }) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "var(--sp-2)" }}>
+      <div>
+        <div className="text-caption font-semibold" style={{ color: "var(--fg)" }}>
+          {label}
+        </div>
+        <div className="text-caption" style={{ color: "var(--fg-4)" }}>
+          {note}
+        </div>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function Group({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section style={{ display: "flex", flexDirection: "column", gap: "var(--sp-3)" }}>
+      <h2 className="text-subtitle" style={{ color: "var(--fg)" }}>
+        {title}
+      </h2>
+      <div style={{ display: "flex", gap: "var(--sp-8)", alignItems: "flex-start", flexWrap: "wrap" }}>{children}</div>
+    </section>
+  );
+}
+
+/** Reproduces the section chrome WITHOUT the scoped type scale — i.e. today's
+ *  behaviour: the shared Markdown's default `prose prose-sm`. */
+function BeforeSection() {
+  return (
+    <section style={{ borderBottom: "var(--hairline) solid var(--border-faint)" }}>
+      <div className="text-eyebrow" style={{ padding: "var(--sp-2_5) var(--sp-3) var(--sp-1)", color: "var(--fg-4)" }}>
+        Summary
+      </div>
+      <div className="text-body" style={{ padding: "0 var(--sp-3) var(--sp-2_5)", color: "var(--fg)" }}>
+        <Markdown>{SAMPLE}</Markdown>
+      </div>
+    </section>
+  );
+}
+
+export function SummarySectionPreviewPage() {
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        background: "var(--bg)",
+        padding: "var(--sp-6)",
+        display: "flex",
+        flexDirection: "column",
+        gap: "var(--sp-8)",
+      }}
+    >
+      <div>
+        <h1 className="text-title" style={{ color: "var(--fg)" }}>
+          Right-rail Summary — heading & hierarchy
+        </h1>
+        <p className="text-body" style={{ color: "var(--fg-3)" }}>
+          All rails at real width. After = the real DescriptionSection. Resize the window to test the narrow column.
+        </p>
+      </div>
+
+      <Group title="1 · Light — Before vs After">
+        <Col label="Before" note="prose-sm default · oversized headings · enlarged body">
+          <div style={RAIL}>
+            <BeforeSection />
+          </div>
+        </Col>
+        <Col label="After" note="body --text-body · h1/h2 --text-subtitle · weight-led">
+          <div style={RAIL}>
+            <DescriptionSection description={SAMPLE} capped={false} />
+          </div>
+        </Col>
+      </Group>
+
+      <Group title="2 · Dark (workspace theme)">
+        <Col label="After · dark" note="wrapped in .dark — how it renders in the live rail">
+          <div className="dark" style={{ ...RAIL, background: "var(--bg-raised)" }}>
+            <DescriptionSection description={SAMPLE} capped={false} />
+          </div>
+        </Col>
+      </Group>
+
+      <Group title="3 · Capped + Show more (GitHub section present below)">
+        <Col label="After · capped" note="long body clamps to ~30rem with bottom fade + Show more/less">
+          <div style={RAIL}>
+            <DescriptionSection description={LONG} capped={true} />
+          </div>
+        </Col>
+        <Col label="After · dark · capped" note="same, dark theme">
+          <div className="dark" style={{ ...RAIL, background: "var(--bg-raised)" }}>
+            <DescriptionSection description={LONG} capped={true} />
+          </div>
+        </Col>
+      </Group>
+
+      <Group title="4 · Markdown edge cases">
+        <Col label="After · edge" note="table / long bare URL / 3-level nesting / quote / rule">
+          <div style={RAIL}>
+            <DescriptionSection description={EDGE} capped={false} />
+          </div>
+        </Col>
+        <Col label="After · dark · edge" note="same, dark theme">
+          <div className="dark" style={{ ...RAIL, background: "var(--bg-raised)" }}>
+            <DescriptionSection description={EDGE} capped={false} />
+          </div>
+        </Col>
+      </Group>
+    </div>
+  );
+}

--- a/packages/web/src/pages/workspace/right-sidebar/description-section.tsx
+++ b/packages/web/src/pages/workspace/right-sidebar/description-section.tsx
@@ -97,7 +97,39 @@ export function DescriptionSection({
             overflow: "hidden",
           }}
         >
-          <Markdown>{trimmed}</Markdown>
+          <Markdown
+            // The shared Markdown defaults to `prose prose-sm`, which (a) blows
+            // headings far past body size and (b) silently enlarges the BODY too
+            // — both wrong for this narrow rail, where the design body size is the
+            // `--text-body` token, the rest of the rail matches it, and the module
+            // already has its own "Summary" eyebrow title above. Scope a coherent
+            // type scale to the Summary surface only (chat messages keep the
+            // default):
+            //   - body (p / li) pinned to --text-body, matching the rail
+            //     (prose-sm otherwise enlarges it and leaves headings SMALLER than
+            //     body text).
+            //   - headings collapse to two compact tiers — h1/h2 at
+            //     --text-subtitle, h3–h6 at --text-body — so they read as SECTION
+            //     LABELS, not titles, and a stray deep heading can't blow up the
+            //     layout. Hierarchy is carried by weight + top-margin, not a size
+            //     jump.
+            //   - tidy-ups: first block hugs the eyebrow (mt-0), last hugs the
+            //     hairline (mb-0), list indent tightened for the column.
+            //
+            // Uses `[&_hN]` / `[&_p]` descendant variants, NOT `prose-*:` — the
+            // typography plugin's `prose-*` modifiers wrap selectors in
+            // `:where()` (zero specificity), so they only TIE prose-sm's own rules
+            // and lose on source order. `[&_h1]` emits a real `.cls h1` selector
+            // that reliably beats it.
+            //
+            // Arbitrary font-sizes need the `length:` data-type hint — a bare
+            // `text-[token]` is ambiguous (Tailwind can't tell a length from a
+            // color and silently treats it as color), so the size is a no-op
+            // unless the value is prefixed with `length:`.
+            className="[&_p]:text-[length:var(--text-body)] [&_li]:text-[length:var(--text-body)] [&_:is(h1,h2)]:text-[length:var(--text-subtitle)] [&_:is(h3,h4,h5,h6)]:text-[length:var(--text-body)] [&_:is(h1,h2,h3,h4,h5,h6)]:font-semibold [&_:is(h1,h2,h3,h4,h5,h6)]:leading-snug [&_:is(h1,h2,h3,h4,h5,h6)]:mt-3.5 [&_:is(h1,h2,h3,h4,h5,h6)]:mb-1 [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_ul]:pl-4 [&_ol]:pl-4"
+          >
+            {trimmed}
+          </Markdown>
         </div>
         {showFade ? (
           <div


### PR DESCRIPTION
## Problem
The right-rail **Summary** (`chat.description`) renders through the shared `Markdown` component's default `prose prose-sm`, which in this narrow 300–360px rail:
- blows headings up to **~30px (h1) / ~20px (h2)** — they shout over the module's own "Summary" eyebrow title;
- **silently enlarges the body to 14px**, so it's bigger than the rest of the rail (12px) and, after a naive heading fix, even *larger than the headings* (inversion).

## Fix
Scope a coherent type scale to the Summary surface only (chat messages keep the default `prose prose-sm`):

| element | before | after |
|---|---|---|
| body `p`/`li` | 14px | `--text-body` (12) |
| `h1` / `h2` | 30 / 20 | `--text-subtitle` (13) |
| `h3`–`h6` | 18 / … | `--text-body` (12) |

- Hierarchy is carried by **weight + top-margin**, not a size ramp — in-body headings read as compact **section labels**. h1/h2 collapse to one tier so a stray `#` can't blow up the layout.
- Tidy-ups: first block hugs the eyebrow (`mt-0`), last hugs the hairline (`mb-0`), list indent tightened for the column.

### Two Tailwind gotchas (documented in code)
1. The typography plugin's `prose-*` modifiers wrap selectors in `:where()` (zero specificity), so they only *tie* `prose-sm`'s own heading rules and lose on source order. Use `[&_hN]`/`[&_p]` descendant variants (real `.cls h1` specificity) instead.
2. Token font-sizes need the `length:` data-type hint — a bare `text-[token]` is ambiguous and Tailwind silently treats it as a color, making the size a no-op.

## Visual review
Adds a DEV-only route **`/preview/summary-section`** (no backend/auth, same gating as other `/preview/*`) covering: before/after, **dark theme** (the live rail), **capped + Show more/less** (GitHub section present), and **markdown edge cases** (table / long bare URL / 3-level nesting / quote / rule). Resize the window to test the narrow column.

## Scope
Frontend only; one product-code change (`description-section.tsx`) plus the preview route. No tree write (implementation-only). Body is normalized to the design's 12px token, which also aligns the summary with the rest of the rail.

## Checks
`tsc` ✓ · design-token guardrails ✓ · biome ✓ · `app-routes` test ✓