### PR TITLE
fix(web): use member avatar for team owner cells

### DIFF
--- a/packages/web/src/pages/team/__tests__/team-groups.test.ts
+++ b/packages/web/src/pages/team/__tests__/team-groups.test.ts
@@ -34,12 +34,18 @@ function agent(input: {
   };
 }
 
-const member = (id: string, agentId: string, displayName: string, role = "member") => ({
+const member = (
+  id: string,
+  agentId: string,
+  displayName: string,
+  role = "member",
+  avatarUrl: string | null = null,
+) => ({
   id,
   agentId,
   username: displayName.toLowerCase(),
   displayName,
-  avatarUrl: null,
+  avatarUrl,
   role,
   createdAt: "2026-01-01T00:00:00.000Z",
   lastActiveAt: null,
@@ -116,11 +122,41 @@ describe("buildTeamData", () => {
     const avatarUrl = "https://avatars.example.test/u/ada.png";
     const { humans } = buildTeamData({
       ...base,
-      members: [{ ...member("member-1", "human-1", "Ada"), avatarUrl }],
+      members: [member("member-1", "human-1", "Ada", "member", avatarUrl)],
       agents: [],
       agentByUuid: new Map(),
     });
     expect(humans[0]?.avatarUrl).toBe(avatarUrl);
+  });
+
+  it("passes the manager member avatarUrl through to agent owner rows", () => {
+    const avatarUrl = "https://avatars.example.test/u/ada.png";
+    const owned = agent({ uuid: "owned", type: "agent", displayName: "Owned", managerId: "member-1" });
+    const missingOwner = agent({
+      uuid: "missing-owner",
+      type: "agent",
+      displayName: "Missing Owner",
+      managerId: "member-missing",
+    });
+    const { publicAgents } = buildTeamData({
+      ...base,
+      members: [member("member-1", "human-1", "Ada", "member", avatarUrl)],
+      agents: [owned, missingOwner],
+      agentByUuid: new Map(),
+    });
+    expect(publicAgents.find((row) => row.agent.uuid === "owned")?.managerAvatarUrl).toBe(avatarUrl);
+    expect(publicAgents.find((row) => row.agent.uuid === "missing-owner")?.managerAvatarUrl).toBeNull();
+  });
+
+  it("keeps agent owner avatarUrl null when the manager member has no avatar", () => {
+    const owned = agent({ uuid: "owned", type: "agent", displayName: "Owned", managerId: "member-1" });
+    const { publicAgents } = buildTeamData({
+      ...base,
+      members: [member("member-1", "human-1", "Ada")],
+      agents: [owned],
+      agentByUuid: new Map(),
+    });
+    expect(publicAgents[0]?.managerAvatarUrl).toBeNull();
   });
 
   it("partitions agents into Public/Private with own agents pinned first", () => {

--- a/packages/web/src/pages/team/__tests__/team-table-dom.test.tsx
+++ b/packages/web/src/pages/team/__tests__/team-table-dom.test.tsx
@@ -85,6 +85,7 @@ function createProps(overrides: Partial<TeamTableProps> = {}): TeamTableProps {
     kind: "agent",
     agent: agent({ uuid: "agent-1", name: "nova", displayName: "Nova", runtimeState: "idle" }),
     managerLabel: "Gandy",
+    managerAvatarUrl: "https://avatars.example.test/u/gandy.png",
     isOwnedBySelf: true,
   };
   const design: AgentRow = {
@@ -100,6 +101,7 @@ function createProps(overrides: Partial<TeamTableProps> = {}): TeamTableProps {
       runtimeState: "working",
     }),
     managerLabel: "Alice",
+    managerAvatarUrl: null,
     isOwnedBySelf: false,
   };
   const humans: HumanRow[] = [
@@ -221,9 +223,10 @@ describe("TeamTable", () => {
     expect(container.textContent).toContain("Gandy");
     expect(container.textContent).toContain("Admin");
     expect(container.textContent).toContain("—");
-    expect(container.querySelector('img[alt="Gandy"]')?.getAttribute("src")).toBe(
+    expect([...container.querySelectorAll('img[alt="Gandy"]')].map((img) => img.getAttribute("src"))).toEqual([
       "https://avatars.example.test/u/gandy.png",
-    );
+      "https://avatars.example.test/u/gandy.png",
+    ]);
 
     await click(container.querySelector('[aria-label="Open Nova"]'));
     expect(props.onAgentDetails).toHaveBeenCalledWith("agent-1");

--- a/packages/web/src/pages/team/index.tsx
+++ b/packages/web/src/pages/team/index.tsx
@@ -464,6 +464,7 @@ export function buildTeamData(args: {
     !search || a.displayName.toLowerCase().includes(search) || (a.name ?? "").toLowerCase().includes(search);
   const matchHuman = (m: MemberListItem) =>
     !search || m.displayName.toLowerCase().includes(search) || m.username.toLowerCase().includes(search);
+  const memberById = new Map(members.map((m) => [m.id, m]));
 
   const visible = (a: Agent) => {
     // Members only see their own private agents; admins see all.
@@ -477,6 +478,7 @@ export function buildTeamData(args: {
     kind: "agent",
     agent: a,
     managerLabel: a.managerId ? resolveMember(a.managerId) : null,
+    managerAvatarUrl: a.managerId ? (memberById.get(a.managerId)?.avatarUrl ?? null) : null,
     isOwnedBySelf: a.managerId === selfMemberId,
   });
 

--- a/packages/web/src/pages/team/team-table.tsx
+++ b/packages/web/src/pages/team/team-table.tsx
@@ -54,6 +54,7 @@ export type AgentRow = {
   kind: "agent";
   agent: Agent;
   managerLabel: string | null;
+  managerAvatarUrl: string | null;
   isOwnedBySelf: boolean;
 };
 
@@ -423,7 +424,7 @@ function AgentRowView(props: TeamTableProps & { compact: boolean; row: AgentRow;
     onAgentDetails,
     getAgentMenuActions,
   } = props;
-  const { agent, managerLabel, isOwnedBySelf } = row;
+  const { agent, managerLabel, managerAvatarUrl, isOwnedBySelf } = row;
   const clientHost = agent.clientId ? (clientHostMap.get(agent.clientId) ?? null) : null;
   const usage = usageByAgentId ? (usageByAgentId.get(agent.uuid) ?? null) : null;
   // Row-click opens Details, so "Details" leaves the menu; the kebab holds the
@@ -472,7 +473,13 @@ function AgentRowView(props: TeamTableProps & { compact: boolean; row: AgentRow;
         hasTaglineSlot={false}
       />
       <div className="grid items-center min-w-0" style={{ gridTemplateColumns: AGENT_MIDDLE_GRID, gap: "var(--sp-4)" }}>
-        <OwnerCell managerLabel={managerLabel} managerId={agent.managerId} isSelf={isOwnedBySelf} dim={dimOwner} />
+        <OwnerCell
+          managerLabel={managerLabel}
+          managerId={agent.managerId}
+          managerAvatarUrl={managerAvatarUrl}
+          isSelf={isOwnedBySelf}
+          dim={dimOwner}
+        />
         <RunsOnCell provider={agent.runtimeProvider} host={clientHost} />
         <UsageCell usage={usage} loading={usageLoading} />
       </div>
@@ -485,11 +492,13 @@ function AgentRowView(props: TeamTableProps & { compact: boolean; row: AgentRow;
 function OwnerCell({
   managerLabel,
   managerId,
+  managerAvatarUrl,
   isSelf,
   dim,
 }: {
   managerLabel: string | null;
   managerId: string | null;
+  managerAvatarUrl: string | null;
   isSelf: boolean;
   dim: boolean;
 }) {
@@ -500,12 +509,12 @@ function OwnerCell({
       </span>
     );
   }
-  // The owner's small avatar precedes the name to make the human⇄agent
-  // ownership link legible at a glance; it's seeded by the manager's member id,
-  // so it matches that same person's avatar in the Human section.
+  // The owner's small avatar precedes the name to make the human-agent
+  // ownership link legible at a glance. Use the real member avatar when
+  // available, and keep the member-id seed as the stable fallback.
   return (
     <div className="flex items-center min-w-0" style={{ gap: "var(--sp-1_5)", opacity: dim ? 0.5 : 1 }}>
-      <Avatar name={managerLabel} seed={managerId ?? managerLabel} size={RELATION_AVATAR_SIZE} />
+      <Avatar name={managerLabel} src={managerAvatarUrl} seed={managerId ?? managerLabel} size={RELATION_AVATAR_SIZE} />
       {isSelf ? (
         <span className="text-body font-semibold truncate" style={{ color: "var(--fg)" }}>
           You


### PR DESCRIPTION
## Summary
- pass each agent owner's member avatar URL through team data rows
- render owner cells with the real member avatar before falling back to the stable identicon seed
- cover owner avatar propagation and matching owner/human avatar rendering in Team tests

## Tests
- pnpm --filter @first-tree/web exec vitest run --passWithNoTests src/pages/team/__tests__/team-groups.test.ts src/pages/team/__tests__/team-table-dom.test.tsx
- pnpm check && pnpm typecheck
