### PR TITLE
feat(onboarding): ceremonial welcome for admin + invitee openers

### DIFF
--- a/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
+++ b/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
@@ -1229,7 +1229,9 @@ describe("page SSR smoke coverage", () => {
     expect(connectedHtml).toContain("close this tab");
     expect(connectedHtml).toContain('role="status"');
 
-    expect(await renderOnboardingStep(<StepTeam />, { activeStep: "team" })).toContain("Name your team");
+    expect(await renderOnboardingStep(<StepTeam />, { activeStep: "team" })).toContain(
+      "What should we call your team?",
+    );
     expect(await renderOnboardingStep(<StepWelcome />, { path: "invitee", activeStep: "welcome" })).toContain("Acme");
     expect(await renderOnboardingStep(<StepConnectComputer />, { activeStep: "connect-computer" })).toContain(
       "gandy-macbook",

--- a/packages/web/src/pages/onboarding/copy.ts
+++ b/packages/web/src/pages/onboarding/copy.ts
@@ -115,13 +115,16 @@ export const COPY = {
   hideSetup: "Hide setup",
   /** team (opening / welcome) states */
   team: {
-    // Concise imperative label, consistent with create-agent's "Name your agent".
-    nameLabel: "Name your team",
-    // A brief one-line "what's next" preview above Get started (the two-column
-    // split was dropped) — orients the admin without weight. The steps are the
-    // admin journey after team: install → create agent → connect GitHub.
-    nextPrefix: "Next: ",
+    // The ceremonial admin opening. This bookend renders no progress bar, so the
+    // single-line roadmap below the hero (StepRoadmap, which derives the "N
+    // steps" count from this list) is the only orientation. The admin journey
+    // after team: install → create agent → connect GitHub.
     nextSteps: ["Install First Tree", "Create your first agent", "Connect to GitHub"],
+    // A warm question that doubles as the field's label, sitting on its own line
+    // above the input — so the pre-filled value is unmistakably the team's name
+    // (a bare box with only a "rename" hint left the field's purpose ambiguous).
+    // The question framing also implies the pre-filled name is editable.
+    nameLead: "What should we call your team?",
   },
   /** connect-code states */
   connectCode: {
@@ -368,12 +371,22 @@ export const COPY = {
     // shared launch transition
     starting: "Starting your agent…",
   },
-  /** invitee blocked states — the team isn't ready yet (no tree, or no GitHub) */
+  /** invitee welcome + blocked states */
   invitee: {
-    // Brief "what's next" one-liner above the welcome step's Get started, mirroring
-    // the admin team step. Invitee journey has no connect-code (they inherit team
-    // repos): install → create agent → start working.
-    nextPrefix: "Next: ",
+    // The invitee's ceremonial welcome (mirrors the admin opening). `welcomeBody`
+    // brackets the team name (rendered bold in StepWelcome); the one-line
+    // roadmap (StepRoadmap) derives its "N steps" count from `nextSteps`. The
+    // invitee journey has no connect-code (they inherit the team's repos):
+    // install → create agent → start working.
+    welcomeBody: {
+      pre: "You're now part of ",
+      // A single warm value line that names the coding agent (Claude Code,
+      // Codex) — symmetric with the admin opening's subtitle, and true to the
+      // "connect your existing coding agent" framing. Deliberately does NOT
+      // restate the roadmap's "Create your first agent" or echo the Get started
+      // CTA — the roadmap + button carry the action; this carries the welcome.
+      post: " — let's bring your coding agent (Claude Code, Codex) onto the team.",
+    },
     nextSteps: ["Install First Tree", "Create your first agent", "Start working"],
     waitingTitle: "Waiting for your team to set up",
     waitingBody:

--- a/packages/web/src/pages/onboarding/flow-ui.tsx
+++ b/packages/web/src/pages/onboarding/flow-ui.tsx
@@ -1,6 +1,7 @@
 import { Check, CircleAlert, Copy, ExternalLink, Info, Lock, Search, X } from "lucide-react";
 import { type ReactNode, useMemo, useState } from "react";
 import type { GithubRepo } from "../../api/github.js";
+import { FirstTreeLogo } from "../../components/first-tree-logo.js";
 import { Button } from "../../components/ui/button.js";
 import { useCopyFeedback } from "../../lib/use-copy-feedback.js";
 import { cn } from "../../lib/utils.js";
@@ -27,6 +28,49 @@ export function StepHeading({ title, why }: { title: string; why?: string | null
         </p>
       ) : null}
     </div>
+  );
+}
+
+/**
+ * The shared "ceremonial welcome" hero used by the journey's two openers — the
+ * admin opening (StepTeam) and the invitee landing (StepWelcome): a centered
+ * brand mark, the greeting, and a one-line value subtitle. `subtitle` is a
+ * ReactNode so the invitee can emphasize the just-joined team name inline. The
+ * 35rem cap keeps the subtitle on a comfortable measure (≈ one line on desktop)
+ * while still wrapping freely on narrow widths (no nowrap).
+ */
+export function WelcomeHero({ title, subtitle }: { title: string; subtitle: ReactNode }) {
+  return (
+    <div className="flex flex-col items-center" style={{ gap: "var(--sp-2_5)" }}>
+      <FirstTreeLogo width={42} height={47} style={{ color: "var(--brand-dim)" }} />
+      <h1
+        className="text-headline font-semibold"
+        style={{ margin: "var(--sp-3) 0 0", color: "var(--fg)", textAlign: "center" }}
+      >
+        {title}
+      </h1>
+      <p className="text-body" style={{ margin: 0, color: "var(--fg-3)", textAlign: "center", maxWidth: "35rem" }}>
+        {subtitle}
+      </p>
+    </div>
+  );
+}
+
+/**
+ * One quiet line of orientation under a welcome hero: a bold count leads, then
+ * the steps in sequence. Used on the journey bookends (team / welcome), which
+ * render no progress bar — so this is the only "what's next". The count is
+ * derived from `steps` so it can never drift out of sync with the list.
+ */
+export function StepRoadmap({ steps }: { steps: readonly string[] }) {
+  return (
+    <p className="text-label" style={{ margin: 0, color: "var(--fg-4)", textAlign: "center" }}>
+      <span className="font-semibold" style={{ color: "var(--brand-dim)" }}>
+        {steps.length} steps
+      </span>
+      {"  ·  "}
+      {steps.join("  →  ")}
+    </p>
   );
 }
 

--- a/packages/web/src/pages/onboarding/onboarding-shell.tsx
+++ b/packages/web/src/pages/onboarding/onboarding-shell.tsx
@@ -25,12 +25,20 @@ import { StepProgress } from "./step-progress.js";
  * Outcomes (the old "What you'll have" footer) were folded into each step's
  * `why` copy — one place for the user to read, less repetition, less density.
  */
+// Hero steps render a centered "this is a moment" layout (brand mark + greeting
+// own the column) instead of the standard left-aligned config column: a wider
+// column, anchored higher, with the shell's title/why suppressed because the
+// step renders its own hero. The journey's two welcomes: the admin opening
+// (`team`) and the invitee landing (`welcome`).
+const HERO_STEPS = new Set<string>(["team", "welcome"]);
+
 export function OnboardingShell({ children }: { children: ReactNode }) {
   const { activeStep, finishLater, hasAgent } = useOnboardingFlow();
   const { logout, memberships } = useAuth();
   const { addToast } = useToast();
   const navigate = useNavigate();
   const copy = STEP_COPY[activeStep];
+  const isHero = HERO_STEPS.has(activeStep);
 
   // A multi-team user gets the full workspace UserMenu (team switching,
   // create/join, invite, sign out) instead of the bare "Sign out" link. The
@@ -103,8 +111,10 @@ export function OnboardingShell({ children }: { children: ReactNode }) {
           overflowY: "auto",
           // Fixed top-anchor offset for the content column. COUPLED: the repo
           // picker's fill cap in flow-ui.tsx (`calc(100vh - 33rem)`) is tuned to
-          // this value — if you change it, re-tune that cap too.
-          paddingTop: "6rem",
+          // this value — if you change it, re-tune that cap too. Hero steps sit a
+          // touch higher (upper third) for a "moment" feel; that path has no repo
+          // picker, so the cap coupling is unaffected.
+          paddingTop: isHero ? "clamp(var(--sp-12), 13vh, var(--sp-20))" : "6rem",
           paddingBottom: "var(--sp-8)",
           paddingInline: "var(--sp-5)",
         }}
@@ -116,7 +126,9 @@ export function OnboardingShell({ children }: { children: ReactNode }) {
         <main
           className="min-w-0"
           style={{
-            width: "34rem",
+            // Hero steps get a wider column so the centered greeting + subtitle
+            // breathe; config steps keep the tighter 34rem reading column.
+            width: isHero ? "46rem" : "34rem",
             maxWidth: "100%",
             flexShrink: 0,
             // The repo picker carries its own viewport-relative max-height, so a
@@ -127,16 +139,24 @@ export function OnboardingShell({ children }: { children: ReactNode }) {
             minHeight: 0,
           }}
         >
-          <div key={activeStep} className="onboarding-shell-step fade-in">
+          <div
+            key={activeStep}
+            className="onboarding-shell-step fade-in"
+            style={
+              isHero ? { display: "flex", flexDirection: "column", alignItems: "center", width: "100%" } : undefined
+            }
+          >
             {/* Progress at the top of the column — renders nothing on bookend
                 steps (team / welcome / kickoff). */}
             <StepProgress />
-            {copy.title ? (
+            {/* Hero steps render their own greeting inside the step, so the
+                shell suppresses its title/why for them. */}
+            {!isHero && copy.title ? (
               <h1 className="text-title font-semibold" style={{ margin: "0 0 var(--sp-2_5)", color: "var(--fg)" }}>
                 {copy.title}
               </h1>
             ) : null}
-            {copy.why ? (
+            {!isHero && copy.why ? (
               <p className="text-body" style={{ margin: "0 0 var(--sp-6)", color: "var(--fg-3)" }}>
                 {copy.why}
               </p>

--- a/packages/web/src/pages/onboarding/steps/step-team.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-team.tsx
@@ -5,15 +5,22 @@ import { api } from "../../../api/client.js";
 import { reportOnboardingEvent } from "../../../api/onboarding-events.js";
 import { Button } from "../../../components/ui/button.js";
 import { Input } from "../../../components/ui/input.js";
-import { COPY } from "../copy.js";
-import { FlowHint } from "../flow-ui.js";
+import { COPY, STEP_COPY } from "../copy.js";
+import { FlowHint, StepRoadmap, WelcomeHero } from "../flow-ui.js";
 import { useOnboardingFlow } from "../onboarding-flow.js";
 
 /**
- * Admin step 1: confirm or rename the team. The team row already exists
- * (auto-created at sign-in); this just lets the user own its name. One
- * field, pre-filled, Enter or Continue advances. If the name is unchanged
- * we skip the PATCH entirely.
+ * Admin step 1 — the ceremonial welcome (the highest-leverage frame in
+ * onboarding). A centered "this is a moment" hero: brand mark, greeting, a
+ * one-line value subtitle, a light "what's next" roadmap (this bookend has no
+ * progress bar, so it's the only orientation), then the single first action —
+ * confirm or rename the team. The team row already exists (auto-created at
+ * sign-in); the name is pre-filled with a trailing "rename it freely" hint, so
+ * naming reads as optional, not a cold required field. Enter or Get started
+ * advances; an unchanged name skips the PATCH entirely.
+ *
+ * The shell renders this step in its hero layout (wider, centered, its own
+ * title/why suppressed) — see HERO_STEPS in onboarding-shell.tsx.
  */
 export function StepTeam() {
   const { organizationId, goNext } = useOnboardingFlow();
@@ -77,39 +84,45 @@ export function StepTeam() {
   );
 
   return (
-    <form onSubmit={handleSubmit} className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
-      {/* The welcome's first action: name the team. A visible label now names
-          the field (the step title is the greeting, not the field label), with
-          the "shared space" reassurance as a hint underneath. */}
-      <div className="flex flex-col" style={{ gap: "var(--sp-2)" }}>
-        <label htmlFor="onboarding-team-name" className="text-label font-medium" style={{ color: "var(--fg-2)" }}>
-          {COPY.team.nameLabel}
-        </label>
-        <Input
-          ref={inputRef}
-          id="onboarding-team-name"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          maxLength={200}
-          disabled={saving}
-        />
-      </div>
+    <form onSubmit={handleSubmit} className="flex flex-col items-center" style={{ width: "100%", gap: "var(--sp-7)" }}>
+      {/* Hero + roadmap are shared with the invitee opening (StepWelcome); the
+          greeting reuses the team STEP_COPY strings (the shell suppresses its
+          own copy for this hero step). */}
+      <WelcomeHero title={STEP_COPY.team.title} subtitle={STEP_COPY.team.why} />
+      <StepRoadmap steps={COPY.team.nextSteps} />
 
-      {(saveError || loadError) && (
-        <FlowHint tone="error" role="alert">
-          {saveError ?? `Couldn't load your team — ${loadError}. Refresh and try again.`}
-        </FlowHint>
-      )}
+      {/* ── Action ── name the field explicitly with a warm question on its own
+          line above the input (a bare box left the field's purpose ambiguous),
+          then the single primary CTA. */}
+      <div className="flex flex-col items-center" style={{ gap: "var(--sp-5)", width: "100%", maxWidth: "22rem" }}>
+        <div className="flex flex-col items-center" style={{ gap: "var(--sp-2_5)", width: "100%" }}>
+          <label
+            htmlFor="onboarding-team-name"
+            className="text-label"
+            style={{ color: "var(--fg-3)", textAlign: "center" }}
+          >
+            {COPY.team.nameLead}
+          </label>
+          {/* Design-system Input (not a hand-rolled box): it carries the
+              focus-visible border-ring, so keyboard focus stays visible on the
+              first screen's only field. */}
+          <Input
+            ref={inputRef}
+            id="onboarding-team-name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            maxLength={200}
+            disabled={saving}
+          />
 
-      {/* Brief "what's next" one-liner above Get started — orients the admin
-          without weight (the two-column split was dropped). */}
-      <p className="text-label" style={{ margin: 0, color: "var(--fg-4)" }}>
-        <span style={{ color: "var(--fg-3)" }}>{COPY.team.nextPrefix}</span>
-        {COPY.team.nextSteps.join("  →  ")}
-      </p>
+          {(saveError || loadError) && (
+            <FlowHint tone="error" role="alert">
+              {saveError ?? `Couldn't load your team — ${loadError}. Refresh and try again.`}
+            </FlowHint>
+          )}
+        </div>
 
-      <div className="flex">
-        <Button type="submit" disabled={!canSubmit}>
+        <Button type="submit" disabled={!canSubmit} className="justify-center">
           <span>{COPY.getStarted}</span>
           <ArrowRight className="h-4 w-4" />
         </Button>

--- a/packages/web/src/pages/onboarding/steps/step-welcome.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-welcome.tsx
@@ -1,36 +1,43 @@
 import { ArrowRight } from "lucide-react";
 import { Button } from "../../../components/ui/button.js";
-import { COPY } from "../copy.js";
+import { COPY, STEP_COPY } from "../copy.js";
+import { StepRoadmap, WelcomeHero } from "../flow-ui.js";
 import { useOnboardingFlow } from "../onboarding-flow.js";
 
 /**
- * Invitee step 1: a warm landing that names the team they just joined. One
- * personalized line — no setup work, no step list (the progress bar names
- * where they are once they start) — so the jump from "I clicked an invite
- * link" to "I'm configuring things" isn't jarring.
+ * Invitee step 1 — the ceremonial welcome, mirroring the admin opening
+ * (StepTeam) via the shared WelcomeHero + StepRoadmap. A centered hero: brand
+ * mark, the "Welcome to the team" greeting, a personalized line naming the team
+ * they just joined, a light one-line roadmap (this bookend has no progress bar,
+ * so it's the only orientation), then the single Get started CTA. No setup work
+ * here — joining is the moment; configuring starts on the next step.
+ *
+ * The shell renders this step in its hero layout (its own title/why suppressed)
+ * — see HERO_STEPS in onboarding-shell.tsx.
  */
 export function StepWelcome() {
   const { teamDisplayName, goNext } = useOnboardingFlow();
   return (
-    <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
-      <p className="text-body" style={{ margin: 0, color: "var(--fg-2)" }}>
-        You're now part of{" "}
-        <span className="font-semibold" style={{ color: "var(--fg)" }}>
-          {teamDisplayName ?? "your team"}
-        </span>
-        . To get started, let's create your own agent.
-      </p>
-      {/* Brief "what's next" one-liner above Get started (mirrors the admin team step). */}
-      <p className="text-label" style={{ margin: 0, color: "var(--fg-4)" }}>
-        <span style={{ color: "var(--fg-3)" }}>{COPY.invitee.nextPrefix}</span>
-        {COPY.invitee.nextSteps.join("  →  ")}
-      </p>
-      <div className="flex">
-        <Button type="button" onClick={goNext}>
-          <span>{COPY.getStarted}</span>
-          <ArrowRight className="h-4 w-4" />
-        </Button>
-      </div>
+    <div className="flex flex-col items-center" style={{ width: "100%", gap: "var(--sp-7)" }}>
+      <WelcomeHero
+        title={STEP_COPY.welcome.title}
+        subtitle={
+          <>
+            {COPY.invitee.welcomeBody.pre}
+            <span className="font-semibold" style={{ color: "var(--fg)" }}>
+              {teamDisplayName ?? "your team"}
+            </span>
+            {COPY.invitee.welcomeBody.post}
+          </>
+        }
+      />
+      <StepRoadmap steps={COPY.invitee.nextSteps} />
+
+      {/* The single CTA (no team-name field — they're joining, not creating). */}
+      <Button type="button" onClick={goNext} className="justify-center">
+        <span>{COPY.getStarted}</span>
+        <ArrowRight className="h-4 w-4" />
+      </Button>
     </div>
   );
 }


### PR DESCRIPTION
## What

Redesign the two onboarding bookends — the admin opening (`StepTeam`) and the
invitee landing (`StepWelcome`) — into a centered "ceremonial" hero: brand mark,
greeting, a one-line value subtitle, a light "N steps" roadmap, then the single
action. Both welcomes now share one template.

## Changes

- **OnboardingShell**: add a `HERO_STEPS` branch — for `team` / `welcome` it uses
  a wider, centered column anchored a touch higher and suppresses the shell's own
  title/why so the step owns its hero. Non-hero steps render unchanged.
- **flow-ui**: extract shared `WelcomeHero` + `StepRoadmap`. `StepRoadmap` derives
  the "N steps" count from the list, so it can never drift out of sync.
- **StepTeam** (admin): label the team-name field with a question above it
  ("What should we call your team?"); inline full-width input that no longer clips
  long or CJK team names.
- **StepWelcome** (invitee): mirror the hero; de-duplicate the subtitle copy
  (no longer restates the roadmap or echoes the CTA) and name the coding agent for
  symmetry with the admin opening.
- Remove the now-superseded `onboarding-team-steps-mocks` gallery mockups — the
  real steps implement the chosen direction (net -149 lines).

## Verification

- `tsc --noEmit` + design-token guardrails: clean
- biome: clean
- onboarding test suite: 74 passed
- DEV `/preview/onboarding` gallery: both admin + invitee welcomes verified,
  including long/CJK team names and narrow-viewport wrapping

## Notes

- No behavior change outside onboarding; the `/preview/onboarding` gallery renders
  the real components.
- Built on top of the connect-steps revamp that already landed in #1137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
