### PR TITLE
feat(onboarding): 2-state invitee kickoff + honest admin no-repo finale

### DIFF
--- a/packages/web/src/pages/__tests__/onboarding-preview.test.tsx
+++ b/packages/web/src/pages/__tests__/onboarding-preview.test.tsx
@@ -76,7 +76,7 @@ describe("onboarding preview review surface", () => {
   });
 
   it("uses URL params for shareable role, view, and scenario selection", async () => {
-    window.history.replaceState(null, "", "/preview/onboarding?role=invitee&view=states&scenario=inv-ko-noinstall");
+    window.history.replaceState(null, "", "/preview/onboarding?role=invitee&view=states&scenario=inv-ko-not-ready");
 
     const { OnboardingPreviewPage } = await import("../onboarding-preview.js");
     const { container, root } = await renderDom(
@@ -86,7 +86,7 @@ describe("onboarding preview review surface", () => {
     );
 
     expect(container.textContent).toContain("State inventory");
-    expect(container.textContent).toContain("No code connection");
+    expect(container.textContent).toContain("Team not ready");
     expect(container.textContent).not.toContain("Waiting for computer");
     expect(container.textContent).not.toContain("Form (idle)");
 

--- a/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
+++ b/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
@@ -1792,21 +1792,21 @@ describe("web DOM interaction coverage", () => {
     expect(adminNoProject.flow.completeAndEnterChat).toHaveBeenCalledWith("chat-onboarding");
     await unmountRoot(adminNoProject.root);
 
-    // Invitee · waiting (no team tree yet) → "Meet your agent" now lands in a real
+    // Invitee · not-ready via no team tree → "Meet your agent" lands in a real
     // chat (runKickoff → completeAndEnterChat), not finishLater.
     orgSettingsMocks.getContextTreeSetting.mockResolvedValueOnce({ repo: "", branch: null });
-    const inviteeWaiting = await renderOnboardingDom(<StepKickoff />, { path: "invitee", activeStep: "kickoff" });
-    await waitForText("Waiting for your team to set up", inviteeWaiting.container);
-    await click(findButton(inviteeWaiting.container, "Meet your agent"));
-    await waitForText("Starting your agent", inviteeWaiting.container);
-    expect(inviteeWaiting.flow.completeAndEnterChat).toHaveBeenCalled();
-    await unmountRoot(inviteeWaiting.root);
+    const inviteeNoTree = await renderOnboardingDom(<StepKickoff />, { path: "invitee", activeStep: "kickoff" });
+    await waitForText("Your team is still setting up", inviteeNoTree.container);
+    await click(findButton(inviteeNoTree.container, "Meet your agent"));
+    await waitForText("Starting your agent", inviteeNoTree.container);
+    expect(inviteeNoTree.flow.completeAndEnterChat).toHaveBeenCalled();
+    await unmountRoot(inviteeNoTree.root);
 
-    // Invitee · no installation (tree set, GitHub not connected) → hold + the same
-    // "meet your agent" bailout. No share-link/Copy affordance anymore.
+    // Invitee · not-ready via no installation (tree set, GitHub not connected) →
+    // the same single not-ready screen + "meet your agent" bailout.
     githubAppMocks.getGithubAppInstallationExists.mockResolvedValueOnce(false);
     const inviteeNoInstall = await renderOnboardingDom(<StepKickoff />, { path: "invitee", activeStep: "kickoff" });
-    await waitForText("your team's repo isn't connected yet", inviteeNoInstall.container);
+    await waitForText("Your team is still setting up", inviteeNoInstall.container);
     await click(findButton(inviteeNoInstall.container, "Meet your agent"));
     expect(inviteeNoInstall.flow.completeAndEnterChat).toHaveBeenCalled();
     await unmountRoot(inviteeNoInstall.root);

--- a/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
+++ b/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
@@ -1811,6 +1811,16 @@ describe("web DOM interaction coverage", () => {
     expect(inviteeNoInstall.flow.completeAndEnterChat).toHaveBeenCalled();
     await unmountRoot(inviteeNoInstall.root);
 
+    // Invitee · tree present but the install probe FAILS (unknown) → hold in
+    // not-ready, never render "ready"/Start working. An optimistic hasInstallation
+    // (null → true) must not launch tree-reading without an authoritative
+    // install=true, or the agent would 403 on its first git op.
+    githubAppMocks.getGithubAppInstallationExists.mockRejectedValueOnce(new Error("probe failed"));
+    const inviteeProbeFail = await renderOnboardingDom(<StepKickoff />, { path: "invitee", activeStep: "kickoff" });
+    await waitForText("Your team is still setting up", inviteeProbeFail.container);
+    expect(findButton(inviteeProbeFail.container, "Start working")).toBeNull();
+    await unmountRoot(inviteeProbeFail.root);
+
     // Invitee · ready (tree + install) → a single launch, no repo selection. The
     // agent already inherits the team's recommended repos.
     const inviteeReady = await renderOnboardingDom(<StepKickoff />, { path: "invitee", activeStep: "kickoff" });

--- a/packages/web/src/pages/onboarding-preview.tsx
+++ b/packages/web/src/pages/onboarding-preview.tsx
@@ -1,4 +1,4 @@
-import type { AgentVisibility, GithubAppInstallationOutput, ResourceRow } from "@first-tree/shared";
+import type { AgentVisibility, GithubAppInstallationOutput } from "@first-tree/shared";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { type ReactNode, useEffect, useMemo, useState } from "react";
 import type { HubClient } from "../api/activity.js";
@@ -236,14 +236,6 @@ type NetProfile = {
   /** GET /orgs/:id/settings/context_tree → { repo } */
   contextTree?: string | null | "pending";
   /**
-   * Team-recommended repos the invitee inherits. Served as ResourceRow[] from
-   * GET /orgs/:id/resources (what listTeamResourcesForOrg actually calls since
-   * the Resources Phase 1 refactor); InviteeKickoff filters to
-   * type==="repo" && defaultEnabled==="recommended" — non-empty picks the
-   * "works with your team's repos" ready copy, empty the intro copy.
-   */
-  sourceRepos?: string[];
-  /**
    * GET /orgs/:id/github-app-installation/install-url — when set, the install
    * URL mint fails with this status, so clicking "Install on GitHub"
    * surfaces the matching installError state (503 → not_configured, 403 →
@@ -270,26 +262,6 @@ function reposResponse(outcome: RepoOutcome | undefined): Promise<Response> | Re
   if (outcome === "scope") return statusResponse(403, JSON.stringify({ error: "missing project read permission" }));
   if (outcome === "neterror") return Promise.reject(new TypeError("Failed to fetch"));
   return jsonResponse({ repos: outcome ?? [] });
-}
-
-/** A team-recommended repo resource, matching what GET /orgs/:id/resources returns. */
-function teamRepoResource(url: string, i: number): ResourceRow {
-  return {
-    id: `res-${i}`,
-    organizationId: ORG_ID,
-    type: "repo",
-    scope: "team",
-    ownerAgentId: null,
-    name: url.replace(/^https?:\/\/[^/]+\//, "").replace(/\.git$/, ""),
-    repoCanonicalKey: null,
-    defaultEnabled: "recommended",
-    status: "active",
-    payload: { url },
-    createdBy: "preview",
-    updatedBy: "preview",
-    createdAt: "2026-01-01T00:00:00.000Z",
-    updatedAt: "2026-01-01T00:00:00.000Z",
-  };
 }
 
 /** Map a request path (with `/api/v1` prefix) to a canned response, or null to fall through. */
@@ -323,9 +295,6 @@ function handleNet(rawUrl: string): Promise<Response> | Response | null {
   if (p === `/orgs/${ORG_ID}/settings/context_tree`) {
     if (activeNet.contextTree === "pending") return new Promise<Response>(() => {});
     return jsonResponse({ repo: activeNet.contextTree ?? null });
-  }
-  if (p === `/orgs/${ORG_ID}/resources`) {
-    return jsonResponse((activeNet.sourceRepos ?? []).map((url, i) => teamRepoResource(url, i)));
   }
   // Build-tree recovery agent picker. uuid v7 is time-ordered, so the larger
   // string is the "newest" the panel defaults to.
@@ -833,18 +802,12 @@ export const ONBOARDING_PREVIEW_SCENARIOS: Scenario[] = [
   },
 
   {
-    id: "inv-ko-waiting",
-    label: "Waiting for team",
+    id: "inv-ko-not-ready",
+    label: "Team not ready",
     group: "Kickoff states",
     role: "invitee",
-    wizard: { step: "kickoff", net: { installExists: true } },
-  },
-  {
-    id: "inv-ko-noinstall",
-    label: "No code connection",
-    group: "Kickoff states",
-    role: "invitee",
-    wizard: { step: "kickoff", net: { contextTree: TREE_URL, installExists: false } },
+    // Either signal missing → the one not-ready screen (here: no tree + no install).
+    wizard: { step: "kickoff", net: { contextTree: null, installExists: false } },
   },
   {
     id: "inv-ko-ready",
@@ -852,14 +815,7 @@ export const ONBOARDING_PREVIEW_SCENARIOS: Scenario[] = [
     group: "Invitee happy path",
     role: "invitee",
     view: "flow",
-    wizard: { step: "kickoff", net: { contextTree: TREE_URL, installExists: true, sourceRepos: [REPO_WEB, REPO_API] } },
-  },
-  {
-    id: "inv-ko-ready-norepos",
-    label: "Ready · no team repos (intro)",
-    group: "Kickoff states",
-    role: "invitee",
-    wizard: { step: "kickoff", net: { contextTree: TREE_URL, installExists: true, sourceRepos: [] } },
+    wizard: { step: "kickoff", net: { contextTree: TREE_URL, installExists: true } },
   },
   {
     id: "inv-ko-starting",

--- a/packages/web/src/pages/onboarding/__tests__/steps.test.ts
+++ b/packages/web/src/pages/onboarding/__tests__/steps.test.ts
@@ -156,15 +156,10 @@ describe("shouldEnterOnboarding", () => {
 });
 
 describe("resolveInviteeKickoffState", () => {
-  it("waits when the team has no knowledge link yet (admin not done)", () => {
-    expect(resolveInviteeKickoffState({ treeUrl: "", hasInstallation: false })).toBe("waiting");
-    expect(resolveInviteeKickoffState({ treeUrl: "", hasInstallation: true })).toBe("waiting");
-  });
-  it("waiting wins over no-installation when the tree is also missing (fix the bigger blocker first)", () => {
-    expect(resolveInviteeKickoffState({ treeUrl: "", hasInstallation: false })).toBe("waiting");
-  });
-  it("stops at no-installation when the tree is set but the App was never installed (agent would 403)", () => {
-    expect(resolveInviteeKickoffState({ treeUrl: "https://x/y", hasInstallation: false })).toBe("no-installation");
+  it("is not-ready while either the tree or the GitHub connection is missing", () => {
+    expect(resolveInviteeKickoffState({ treeUrl: "", hasInstallation: false })).toBe("not-ready");
+    expect(resolveInviteeKickoffState({ treeUrl: "", hasInstallation: true })).toBe("not-ready");
+    expect(resolveInviteeKickoffState({ treeUrl: "https://x/y", hasInstallation: false })).toBe("not-ready");
   });
   it("is ready to launch once the tree is set and the App is installed (no repo selection)", () => {
     expect(resolveInviteeKickoffState({ treeUrl: "https://x/y", hasInstallation: true })).toBe("ready");

--- a/packages/web/src/pages/onboarding/copy.ts
+++ b/packages/web/src/pages/onboarding/copy.ts
@@ -332,7 +332,7 @@ export const COPY = {
     // Context-Tree lecture; the term is named once, lightly.
     newTitle: "Your agent's ready to get to work",
     newWhy: (repoCount: number): string =>
-      `It'll start by reading your ${repoCount === 1 ? "repo" : `${repoCount} repos`} and drafting your team's Context Tree — the shared memory that lets every agent work like it already knows your project.`,
+      `It'll read your ${repoCount === 1 ? "repo" : `${repoCount} repos`} and draft your team's Context Tree — shared memory every agent works from.`,
     startBuilding: "Build tree & start",
 
     // admin · the team already has a Context Tree (re-run / second admin /
@@ -340,16 +340,23 @@ export const COPY = {
     // instead of seeding.
     existingTitle: "Your agent's ready to get to work",
     existingWhy: (repoCount: number): string =>
-      `Your team already has a Context Tree — your agent will get oriented and start working on your ${repoCount === 1 ? "repo" : `${repoCount} repos`}.`,
+      `Your team already has a Context Tree — your agent gets oriented and starts on your ${repoCount === 1 ? "repo" : `${repoCount} repos`}.`,
     startExisting: "Start",
 
-    // admin · no repo connected (connect-code skipped / 0 picked). Nothing to
-    // seed from, so this is honestly "meet your agent" — not a tree moment. The
-    // affordance points back to connecting a repo (the only way to give the team
-    // a Context Tree), not a silent "do it later in Settings".
-    noProjectTitle: "Your agent's ready",
-    noProjectBody: "No repo connected, so your agent will start with a quick intro.",
-    connectRepoAffordance: "Want a team Context Tree? Connect a repo",
+    // admin · no repo connected (connect-code skipped / 0 picked). "No repo" and
+    // "no Context Tree" are the same state, so frame it as the tree being absent
+    // (the value), not the mechanism. The title is honest, not a "you're done"
+    // celebration — the agent works, but the team has no Context Tree yet. The
+    // recovery is inline in the body: "Connect GitHub" routes back to connect-code
+    // (install + pick a repo), the same pre/link/post idiom as create-agent's
+    // "reconnect it". The agent stays usable now (Meet your agent), so this nudges
+    // toward the tree without blocking the lighter start.
+    noProjectTitle: "Your agent's ready — but your team has no Context Tree yet",
+    noProjectBody: {
+      pre: "No repo connected, so your agent will start with a quick intro. ",
+      link: "Connect GitHub",
+      post: " to build your team's Context Tree.",
+    },
     startChatting: "Meet your agent",
 
     // invitee · ready (team has a tree + a GitHub connection). Replaces the old
@@ -357,21 +364,24 @@ export const COPY = {
     // automatically (recommended team resources are enabled for every org
     // agent), so there is nothing to select.
     inviteeReadyTitle: "Your agent's ready to go",
-    // Deliberately does NOT name specific repos or claim guaranteed access: an
-    // agent clones a team repo with the host machine's git credentials (no org
-    // token is injected), so a joining member without access to a private team
-    // repo can't reach it. "works with your team's repos" stays true regardless.
-    inviteeReadyWithRepos: "Your team's all set up — your agent works with your team's repos and shared Context Tree.",
-    // No "add from Settings": connecting team repos is admin-only, and this is
-    // shown to a joining member, so it must not imply they can do it themselves.
-    inviteeReadyNoRepos:
-      "Your team's all set up — your agent will start with a quick intro. An admin can connect team repos anytime.",
+    // Names what the agent actually has — the team's repos + shared Context Tree —
+    // because onboarding is where we teach that concept, and a joining teammate
+    // benefits from knowing their agent isn't a blank assistant. One line for every
+    // ready case (the agent inherits the team's recommended repos automatically,
+    // so there's nothing to pick). Deliberately doesn't claim specific repo ACCESS:
+    // an agent clones with the host's git credentials, so "works with your team's
+    // repos" stays true regardless — a member without access to a private repo just
+    // can't reach that one.
+    inviteeReadyBody: "Your team's all set up — your agent works with your team's repos and shared Context Tree.",
     startWorking: "Start working",
 
     // shared launch transition
     starting: "Starting your agent…",
   },
-  /** invitee welcome + blocked states */
+  /** invitee · ceremonial welcome + the one not-ready (blocked-on-admin) state.
+   *  The not-ready screen covers both "no Context Tree" and "no GitHub
+   *  connection" — the invitee can't act on either, and it advances on its own
+   *  once the admin finishes. */
   invitee: {
     // The invitee's ceremonial welcome (mirrors the admin opening). `welcomeBody`
     // brackets the team name (rendered bold in StepWelcome); the one-line
@@ -388,17 +398,15 @@ export const COPY = {
       post: " — let's bring your coding agent (Claude Code, Codex) onto the team.",
     },
     nextSteps: ["Install First Tree", "Create your first agent", "Start working"],
-    waitingTitle: "Waiting for your team to set up",
-    waitingBody:
-      "Your team's admin is still setting up repos and a Context Tree. This page updates on its own as soon as they're done.",
-    waitingStatus: "Watching for updates…",
-    // admin set up a tree but never connected the GitHub App; without an
-    // installation every git op the agent runs would 403, so we hold here.
-    noInstallTitle: "Almost there — your team's repo isn't connected yet",
-    noInstallBody:
-      "Your team's admin set up the Context Tree but hasn't connected a repo on GitHub yet. Your agent needs that connection to do real work.",
-    noInstallStatus: "Watching for the connection…",
-    // Bailout on the blocked screens — meet your agent now (an intro chat)
+    // Title states the fact; the body leads with the action, not the wait. In the
+    // default-none world the most common not-ready cause is "admin finished
+    // without a tree", which never resolves — so "Meet your agent" is the real
+    // path forward (the primary CTA), and the auto-advance is a quiet conditional
+    // footnote (notReadyStatus), never a "coming soon" promise the team may break.
+    notReadyTitle: "Your team is still setting up",
+    notReadyBody: "No need to wait — meet your agent now.",
+    notReadyStatus: "This page continues on its own if your team finishes setup.",
+    // The primary action on the not-ready screen — start an intro chat now
     // instead of waiting on the team.
     startAnyway: "Meet your agent",
   },

--- a/packages/web/src/pages/onboarding/flow-ui.tsx
+++ b/packages/web/src/pages/onboarding/flow-ui.tsx
@@ -12,7 +12,7 @@ import { cn } from "../../lib/utils.js";
  * skips title/why when STEP_COPY leaves them empty. Spacing matches the shell's
  * heading so per-state steps line up with static ones.
  */
-export function StepHeading({ title, why }: { title: string; why?: string | null }) {
+export function StepHeading({ title, why }: { title: string; why?: ReactNode }) {
   return (
     <div className="flex flex-col" style={{ gap: "var(--sp-2_5)" }}>
       {/* Skip the h1 on an empty title — the build-tree recovery surface

--- a/packages/web/src/pages/onboarding/steps.ts
+++ b/packages/web/src/pages/onboarding/steps.ts
@@ -207,31 +207,25 @@ export function shouldLeaveOnboarding(facts: OnboardingGateFacts): boolean {
 }
 
 /**
- * Which invitee kickoff sub-state to show, given what the team has set up.
+ * Which invitee kickoff state to show, given what the team has set up. Just two:
+ *   - "ready"     → the team has BOTH a Context Tree and a GitHub connection;
+ *                   the agent can do real work, so launch.
+ *   - "not-ready" → either is missing. We don't distinguish "no tree" from "no
+ *                   GitHub": in both cases the invitee is blocked on the admin
+ *                   and can't act on it, so a single screen ("your team is still
+ *                   setting up" + a "Meet your agent" bailout) covers both. The
+ *                   kickoff query keeps polling, so this flips to "ready" on its
+ *                   own the moment the admin finishes whichever half was missing.
+ *
  * Pure so it's unit-testable (the React component just maps the result to a
- * body). Ordered upstream-first — fix the biggest blocker before launch:
- *   - no Context Tree link yet            → "waiting"          (admin isn't done at all)
- *   - link but no GitHub App installation → "no-installation"  (admin skipped code; agent would 403)
- *   - link + install                      → "ready"            (just launch)
- *
- * There is deliberately no repo-selection sub-state. The invitee's agent
- * inherits the team's `recommended` repo resources automatically (they're
- * enabled for every org agent), so picking repos here changed nothing about
- * what the agent could access — it only flavoured the kickoff message. The
- * "ready" state is a pure launch; the body names the team's repos when there
- * are any, otherwise frames it as an intro.
- *
- * The "no-installation" state exists because the previous flow silently
- * advanced invitees past it, where the agent's first git op would 403. We
- * hold there instead, with a "Meet your agent" bailout so the invitee is
- * never truly blocked.
+ * body). There is no repo-selection state: the invitee's agent inherits the
+ * team's `recommended` repo resources automatically (enabled for every org
+ * agent), so there was never anything to pick here.
  */
-export type InviteeKickoffState = "waiting" | "no-installation" | "ready";
+export type InviteeKickoffState = "ready" | "not-ready";
 
 export function resolveInviteeKickoffState(args: { treeUrl: string; hasInstallation: boolean }): InviteeKickoffState {
-  if (!args.treeUrl) return "waiting";
-  if (!args.hasInstallation) return "no-installation";
-  return "ready";
+  return args.treeUrl && args.hasInstallation ? "ready" : "not-ready";
 }
 
 export type TreeRecoveryFacts = {

--- a/packages/web/src/pages/onboarding/steps/step-kickoff.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-kickoff.tsx
@@ -415,8 +415,15 @@ function InviteeKickoff() {
     return <InviteeNotReady />;
   }
 
-  const { treeUrl, hasInstallation } = teamQuery.data;
-  return resolveInviteeKickoffState({ treeUrl, hasInstallation }) === "ready" ? (
+  const { treeUrl, hasInstallation, installationKnown } = teamQuery.data;
+  // "ready" requires an AUTHORITATIVE install=true. `hasInstallation` is optimistic
+  // on a failed probe (null → true) so the query keeps polling instead of flapping
+  // — but we must NOT render the ready launch (which reads the tree and would 403
+  // without an installation) until the probe actually confirms one. Until then,
+  // not-ready holds: it offers an intro-only "meet your agent" (no git op, no 403)
+  // and keeps polling, so it advances to ready on its own once install is confirmed.
+  const installed = installationKnown && hasInstallation;
+  return resolveInviteeKickoffState({ treeUrl, hasInstallation: installed }) === "ready" ? (
     <InviteeReady treeUrl={treeUrl} />
   ) : (
     <InviteeNotReady />

--- a/packages/web/src/pages/onboarding/steps/step-kickoff.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-kickoff.tsx
@@ -6,7 +6,7 @@ import { listOrgGithubRepos } from "../../../api/github.js";
 import { getGithubAppInstallationExists } from "../../../api/github-app.js";
 import { reportOnboardingEvent } from "../../../api/onboarding-events.js";
 import { getContextTreeSetting, putContextTreeSetting } from "../../../api/org-settings.js";
-import { createTeamResourceForOrg, listTeamResourcesForOrg } from "../../../api/resources.js";
+import { createTeamResourceForOrg } from "../../../api/resources.js";
 import { Button } from "../../../components/ui/button.js";
 import {
   buildBindBootstrap,
@@ -22,16 +22,6 @@ import { resolveInviteeKickoffState } from "../steps.js";
 
 const NO_REPO_BOOTSTRAP =
   "Introduce yourself to the team — what can you help with, and what's a good first thing for me to try?";
-
-function teamRecommendedRepoUrls(resources: Awaited<ReturnType<typeof listTeamResourcesForOrg>>): string[] {
-  return resources
-    .filter((resource) => resource.type === "repo" && resource.defaultEnabled === "recommended")
-    .map((resource) => {
-      const payload = resource.payload as { url?: unknown };
-      return typeof payload.url === "string" ? payload.url : null;
-    })
-    .filter((url): url is string => Boolean(url));
-}
 
 /** Shared "create the chat + send the first task + finish" sequence. */
 async function runKickoff(args: {
@@ -288,13 +278,31 @@ function AdminKickoff({
 
   if (phase === "starting") return <StartingState />;
 
-  // No repo connected — nothing to seed a tree from, so this is honestly just
-  // "meet your agent". A quiet affordance points back to connect-code (the only
-  // way to give the team a Context Tree), not a silent "do it later in Settings".
+  // No repo connected — same state as "no Context Tree". The title is honest
+  // (the agent works, but the team has no tree), and the recovery — go back to
+  // connect-code and connect GitHub — lives INLINE in the body (not a separate
+  // orphaned link below the CTA), the same pre/link/post idiom as create-agent's
+  // "reconnect it".
   if (!hasRepos) {
     return (
       <div className="flex flex-col" style={{ gap: "var(--sp-6)" }}>
-        <StepHeading title={COPY.kickoff.noProjectTitle} why={COPY.kickoff.noProjectBody} />
+        <StepHeading
+          title={COPY.kickoff.noProjectTitle}
+          why={
+            <>
+              {COPY.kickoff.noProjectBody.pre}
+              <button
+                type="button"
+                className="font-medium underline underline-offset-2"
+                style={{ color: "var(--primary)" }}
+                onClick={() => goTo(sequence.indexOf("connect-code"))}
+              >
+                {COPY.kickoff.noProjectBody.link}
+              </button>
+              {COPY.kickoff.noProjectBody.post}
+            </>
+          }
+        />
         <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
           {error && (
             <FlowHint tone="error" role="alert">
@@ -307,17 +315,6 @@ function AdminKickoff({
               <ArrowRight className="h-4 w-4" />
             </Button>
           </div>
-          {/* Standalone affordance back to connect-code (where they can pick a
-              repo, then Continue returns here with one). A persistent underline
-              makes it read as a clickable link, not a heading. */}
-          <Button
-            type="button"
-            variant="link"
-            className="h-auto self-start p-0 text-label underline underline-offset-2"
-            onClick={() => goTo(sequence.indexOf("connect-code"))}
-          >
-            {COPY.kickoff.connectRepoAffordance}
-          </Button>
         </div>
       </div>
     );
@@ -361,31 +358,24 @@ function AdminKickoff({
 
 function InviteeKickoff() {
   const { organizationId } = useOnboardingFlow();
-  // Fetch tree config, team repos, and installation existence together.
-  // The installation bit drives the "no-installation" sub-state, which catches
-  // "admin set up the tree but never connected GitHub" before the invitee
-  // launches and the agent hits a 403 on its first git op.
+  // The team is "ready" only with BOTH a Context Tree and a GitHub connection;
+  // either missing → "not-ready". The install bit matters because a tree without
+  // an installation would 403 the agent's first git op, so we hold rather than
+  // launch into a broken state.
   //
-  // We use the dedicated /github-app-installation/exists endpoint here
-  // (returns `{ exists: boolean }`, member-readable) rather than the full
-  // installation GET — that one is admin-gated (requireOrgAdmin), so as a
-  // non-admin invitee it would 403. Round 1 of codex review caught that
-  // mapping 403→"missing" blocks every invitee of a healthy team; round 2
-  // caught that mapping 403→"installed" makes the new safeguard
-  // unreachable. The /exists endpoint side-steps both by exposing just the
-  // presence bit to members. Any unexpected error here falls through to
-  // `hasInstallation: true` so a transient blip never bounces the user
-  // into the wrong sub-state.
+  // We use the dedicated /github-app-installation/exists endpoint here (returns
+  // `{ exists: boolean }`, member-readable) rather than the full installation
+  // GET — that one is admin-gated (requireOrgAdmin), so as a non-admin invitee
+  // it would 403. Three-state probe: true = installed, false = confirmed
+  // missing, null = probe failed (network blip, 5xx). The null sentinel is kept
+  // distinct from `false` so the refetchInterval below can tell "don't know yet"
+  // from "known missing", and so a transient blip never flips a ready team into
+  // not-ready.
   const teamQuery = useQuery({
     queryKey: ["onboarding", "team-config", organizationId],
     queryFn: async () => {
-      const [tree, resources, installResult] = await Promise.all([
+      const [tree, installResult] = await Promise.all([
         getContextTreeSetting(organizationId ?? ""),
-        listTeamResourcesForOrg(organizationId ?? ""),
-        // Three-state result: true = installed, false = server confirmed
-        // missing, null = probe failed (network blip, 5xx). The null
-        // sentinel is distinct from `false` so refetchInterval below can
-        // tell "we don't know yet" from "we know it's missing".
         getGithubAppInstallationExists(organizationId ?? "").catch<null>((err) => {
           console.warn("onboarding: installation-exists probe failed", err);
           return null;
@@ -393,30 +383,24 @@ function InviteeKickoff() {
       ]);
       return {
         treeUrl: tree.repo ?? "",
-        teamRepoUrls: teamRecommendedRepoUrls(resources),
-        // Optimistic on uncertainty: don't bounce the user into
-        // no-installation on a transient blip. The refetchInterval below
-        // keeps polling until we have an authoritative answer; if that
-        // answer is `false` the UI will flip into no-installation on the
-        // next tick. Codex round-2 review caught the original bug where
-        // catch→true plus "stop polling when hasInstallation truthy"
-        // wedged the query in a success state forever on the first error.
+        // Optimistic on uncertainty: a probe failure (null) counts as installed
+        // so a blip doesn't bounce a ready team into not-ready. `installationKnown`
+        // gates the polling so we keep checking until the answer is authoritative.
         hasInstallation: installResult !== false,
         installationKnown: installResult !== null,
       };
     },
     enabled: !!organizationId,
-    // Keep polling while anything's still unknown OR the admin hasn't
-    // finished. Stop only once we have a tree URL AND an authoritative
-    // (non-null) install probe result. Without the `installationKnown`
-    // gate, a transient error on first probe would set hasInstallation=true
-    // and then stop polling — wedging the user out of the no-installation
-    // safeguard for the rest of the session.
+    // Poll until the team is genuinely ready: a tree URL AND an authoritative
+    // (non-null) probe that came back installed. While either is missing or
+    // unknown, keep polling — so the moment the admin finishes whichever half
+    // was missing, this flips to "ready" on its own (the old code stopped
+    // polling once the tree appeared, stranding the no-install case).
     refetchInterval: (query) => {
       const d = query.state.data;
       if (!d) return 5000;
-      if (!d.treeUrl) return 5000;
       if (!d.installationKnown) return 5000;
+      if (!d.treeUrl || !d.hasInstallation) return 5000;
       return false;
     },
   });
@@ -425,23 +409,18 @@ function InviteeKickoff() {
     return <StatusRow state="waiting" label="Checking what your team has set up…" />;
   }
 
-  // Read failure → waiting; the query keeps polling so a transient blip
+  // Read failure → not-ready; the query keeps polling so a transient blip
   // resolves on its own.
   if (teamQuery.isError || !teamQuery.data) {
-    return <InviteeWaiting />;
+    return <InviteeNotReady />;
   }
 
-  const { treeUrl, teamRepoUrls, hasInstallation } = teamQuery.data;
-  const state = resolveInviteeKickoffState({ treeUrl, hasInstallation });
-
-  switch (state) {
-    case "waiting":
-      return <InviteeWaiting />;
-    case "no-installation":
-      return <InviteeNoInstallation />;
-    case "ready":
-      return <InviteeReady treeUrl={treeUrl} teamRepoUrls={teamRepoUrls} />;
-  }
+  const { treeUrl, hasInstallation } = teamQuery.data;
+  return resolveInviteeKickoffState({ treeUrl, hasInstallation }) === "ready" ? (
+    <InviteeReady treeUrl={treeUrl} />
+  ) : (
+    <InviteeNotReady />
+  );
 }
 
 /**
@@ -449,16 +428,13 @@ function InviteeKickoff() {
  * connection, so there's nothing left to set up — and nothing to pick: the
  * agent already inherits the team's `recommended` repo resources automatically
  * (they're enabled for every org agent). This mirrors the admin finale as a
- * pure launch. The kickoff message names the team's repos when there are any,
- * otherwise it's an intro; either way the agent enters a real chat. `orgWrites`
- * stays null — an invitee never mutates team config.
+ * pure launch into a real chat. `orgWrites` stays null — an invitee never
+ * mutates team config.
  */
-function InviteeReady({ treeUrl, teamRepoUrls }: { treeUrl: string; teamRepoUrls: string[] }) {
+function InviteeReady({ treeUrl }: { treeUrl: string }) {
   const { organizationId, completeAndEnterChat } = useOnboardingFlow();
   const [phase, setPhase] = useState<"idle" | "starting">("idle");
   const [error, setError] = useState<string | null>(null);
-
-  const hasRepos = teamRepoUrls.length > 0;
 
   const handleStart = async (): Promise<void> => {
     setError(null);
@@ -485,10 +461,7 @@ function InviteeReady({ treeUrl, teamRepoUrls }: { treeUrl: string; teamRepoUrls
 
   return (
     <div className="flex flex-col" style={{ gap: "var(--sp-6)" }}>
-      <StepHeading
-        title={COPY.kickoff.inviteeReadyTitle}
-        why={hasRepos ? COPY.kickoff.inviteeReadyWithRepos : COPY.kickoff.inviteeReadyNoRepos}
-      />
+      <StepHeading title={COPY.kickoff.inviteeReadyTitle} why={COPY.kickoff.inviteeReadyBody} />
       <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
         {error && (
           <FlowHint tone="error" role="alert">
@@ -507,20 +480,19 @@ function InviteeReady({ treeUrl, teamRepoUrls }: { treeUrl: string; teamRepoUrls
 }
 
 /**
- * Shared body for the two "team isn't ready yet" sub-states: `waiting` (admin
- * hasn't created the Context Tree) and `no-installation` (tree exists but no
- * GitHub App is connected). Both are blocked on the admin and both poll +
- * advance on their own the moment the admin finishes — so the only thing the
- * invitee can DO here is not wait: meet their agent now.
+ * Invitee · the team's workspace isn't ready yet — either no Context Tree or no
+ * GitHub connection. We don't split those: in both cases the invitee is blocked
+ * on the admin and can't act on it, so one screen covers both. The kickoff query
+ * keeps polling, so this advances to `ready` on its own the moment the admin
+ * finishes whichever half was missing.
  *
  * "Meet your agent" runs an intro-only kickoff (`runKickoff` with no repo → an
  * agent that introduces itself, repos connectable later from Settings), the same
  * launch the `ready` state uses. Routing it through `completeAndEnterChat` — not
  * `finishLater` — means the button lands the user in a real chat WITH the agent,
- * instead of dropping them into an empty workspace. The two states differ only
- * in copy, so they share this body; split them again if their actions diverge.
+ * instead of dropping them into an empty workspace.
  */
-function InviteeBlocked({ title, why, status }: { title: string; why: string; status: string }) {
+function InviteeNotReady() {
   const { organizationId, completeAndEnterChat } = useOnboardingFlow();
   const [phase, setPhase] = useState<"idle" | "starting">("idle");
   const [error, setError] = useState<string | null>(null);
@@ -547,43 +519,27 @@ function InviteeBlocked({ title, why, status }: { title: string; why: string; st
 
   return (
     <div className="flex flex-col" style={{ gap: "var(--sp-6)" }}>
-      {/* Heading carries the screen; the pulsing StatusRow is the "still
-          watching, will advance on its own" signal. */}
-      <StepHeading title={title} why={why} />
+      <StepHeading title={COPY.invitee.notReadyTitle} why={COPY.invitee.notReadyBody} />
       <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
-        <StatusRow state="waiting" label={status} />
         {error && (
           <FlowHint tone="error" role="alert">
             {error}
           </FlowHint>
         )}
+        {/* "Meet your agent" is the PRIMARY action, not an escape hatch: the
+            common not-ready case (admin finished without a tree) never resolves,
+            so the real path forward is to start now. The auto-advance — if the
+            team does finish — is the quiet status footnote below, never the
+            headline. */}
         <div className="flex">
-          <Button type="button" variant="outline" onClick={() => void handleMeet()}>
-            {COPY.invitee.startAnyway}
+          <Button type="button" variant="cta" onClick={() => void handleMeet()}>
+            <span>{COPY.invitee.startAnyway}</span>
+            <ArrowRight className="h-4 w-4" />
           </Button>
         </div>
+        <StatusRow state="waiting" label={COPY.invitee.notReadyStatus} />
       </div>
     </div>
-  );
-}
-
-function InviteeWaiting() {
-  return (
-    <InviteeBlocked
-      title={COPY.invitee.waitingTitle}
-      why={COPY.invitee.waitingBody}
-      status={COPY.invitee.waitingStatus}
-    />
-  );
-}
-
-function InviteeNoInstallation() {
-  return (
-    <InviteeBlocked
-      title={COPY.invitee.noInstallTitle}
-      why={COPY.invitee.noInstallBody}
-      status={COPY.invitee.noInstallStatus}
-    />
   );
 }
 


### PR DESCRIPTION
Refines the final onboarding **kickoff** step for both paths, after reviewing it against the default-none repo flow (admins now commonly finish without connecting a repo, which the old finale copy didn't account for).

## Invitee — 3 states → 2

`waiting` / `no-installation` / `ready` collapse to **`ready` / `not-ready`**. The two blocked screens told the invitee *which half* the admin hadn't finished, but they can't act on either, so one screen covers both.

- **not-ready leads with the action**: `Meet your agent` is now the primary CTA, not a "still setting up — updates soon" wait. In the default-none world the most common not-ready cause is "admin finished without a tree", which never resolves, so the wait copy was a promise the team often never keeps. The auto-advance is now a quiet conditional footnote.
- **ready** keeps the Context Tree concept in its copy; the old with-repos / no-repos copy fork (and its `listTeamResourcesForOrg` fetch) is dropped — the agent inherits the team's recommended repos regardless.
- **Polling fix**: not-ready keeps polling until the team is genuinely ready, so it auto-advances when the admin connects GitHub later. The old `refetchInterval` stopped once the tree appeared, stranding the no-install case.

## Admin — honest no-repo finale

The no-repo screen no longer reads as "done":

- Title `Your agent's ready` → **`Your agent's ready — but your team has no Context Tree yet`** (no repo = no Context Tree, same state).
- The recovery — go back and connect GitHub — is now an **inline link in the body**, not a faint orphaned link below the CTA.
- `new` / `existing` tree copy tightened (kept as distinct states — they're behaviorally different: build vs read).

## Cleanup (from self code-review)

- Widened `StepHeading.why` to `ReactNode` (backward-compatible; all string callers unaffected) so the no-repo body reuses `StepHeading` instead of hand-cloning its `h1`+`p` markup.
- Removed now-dead team-resources mock infra (`sourceRepos` field, `/orgs/:id/resources` handler, `teamRepoResource`, `ResourceRow` import) from the DEV preview gallery.

## Verification

- `pnpm --filter @first-tree/web run typecheck` (incl. design-token guardrail) ✅
- `biome check` ✅
- **107 tests** across onboarding + DOM + SSR + preview suites ✅
- Every state eyeballed in the DEV `/preview/onboarding` gallery (invitee ready/not-ready, admin no-repo/new/existing)
- Self code-review (3 independent finder agents): no correctness bugs; both cleanup findings applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Context Tree

Companion tree PR (durable state-model update): agent-team-foundation/first-tree-context#570 — updates `system/cloud/onboarding.md` to the two-state invitee kickoff + admin no-repo finale, so the tree no longer documents the retired three-state model.
