### PR TITLE
feat(onboarding): polish setup-step copy, states, and disconnected-agent UX

### DIFF
--- a/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
+++ b/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
@@ -1511,12 +1511,11 @@ describe("web DOM interaction coverage", () => {
       setSelectedRepoUrls,
       goNext: vi.fn(),
     });
-    await waitForText("Which repos should your agent work on?", connected.container);
+    await waitForText("Repos your agent can use", connected.container);
     await waitForText("acme/web", connected.container);
-    // 0 repos picked but the list is pickable → friction: the consequence line
-    // shows and the strong primary "Continue" is absent (only the quiet
-    // "Skip for now" link remains; never disabled).
-    await waitForText("Pick a repo so your agent can build your team's Context Tree", connected.container);
+    // 0 repos picked but the list is pickable → no strong primary "Continue"
+    // (only the quiet "Skip for now" link remains; never disabled). The old
+    // no-repo consequence line was dropped, so there's nothing extra to assert.
     expect([...connected.container.querySelectorAll("button")].some((b) => b.textContent?.trim() === "Continue")).toBe(
       false,
     );

--- a/packages/web/src/pages/onboarding-preview.tsx
+++ b/packages/web/src/pages/onboarding-preview.tsx
@@ -49,7 +49,11 @@ const ORG_ID = "org-acme";
 const TEAM_NAME = "Gandy's team";
 const TREE_URL = "https://github.com/acme/context-tree";
 const DEFAULT_AGENT_NAME = "Gandy's assistant";
-const SAMPLE_CLI = "npm install -g <package>\n<binName> login ft_3aK9d2hQ7s_pVx1n8Wc4Lr6";
+// Mirror the real prod bootstrap shape (server fills the channel's actual
+// package + bin name — `first-tree` on prod; see api/me.ts) so the gallery
+// reads true for design review instead of showing literal <package>/<binName>
+// placeholders a real user never sees.
+const SAMPLE_CLI = "npm install -g first-tree\nfirst-tree login ft_3aK9d2hQ7s_pVx1n8Wc4Lr6";
 
 const NOW_ISO = new Date().toISOString();
 
@@ -134,7 +138,7 @@ const ASYNC_NOOP = async (): Promise<void> => {};
 // `selectedRuntime` / `setSelectedRuntime` are made interactive per-scenario in
 // WizardScenarioView (state-backed), so the runtime pills actually switch.
 const COMPUTER: Record<
-  "waiting" | "tokenError" | "detecting" | "noRuntime" | "ready" | "readyMulti",
+  "waiting" | "tokenError" | "detecting" | "noRuntime" | "ready" | "readyMulti" | "lostWhileReady",
   ComputerConnection
 > = {
   waiting: {
@@ -193,6 +197,19 @@ const COMPUTER: Record<
     connectedClient: HOST,
     capabilitiesLoaded: true,
     okRuntimes: ["claude-code", "codex", "claude-code-tui"],
+    selectedRuntime: "claude-code",
+    setSelectedRuntime: NOOP,
+    cliCommand: SAMPLE_CLI,
+    tokenError: null,
+    retry: NOOP,
+  },
+  // Was connected & ready, then the computer dropped mid-form: live capabilities
+  // are gone (okRuntimes empties) but the last pick is remembered, so create-agent
+  // shows that coding agent DISABLED rather than letting the field vanish.
+  lostWhileReady: {
+    connectedClient: null,
+    capabilitiesLoaded: false,
+    okRuntimes: [],
     selectedRuntime: "claude-code",
     setSelectedRuntime: NOOP,
     cliCommand: SAMPLE_CLI,
@@ -566,7 +583,7 @@ export const ONBOARDING_PREVIEW_SCENARIOS: Scenario[] = [
     label: "Form · computer disconnected",
     group: "Agent creation states",
     role: "admin",
-    wizard: { step: "create-agent", flow: { computer: COMPUTER.waiting, agentPhase: "idle" } },
+    wizard: { step: "create-agent", flow: { computer: COMPUTER.lostWhileReady, agentPhase: "idle" } },
   },
 
   {

--- a/packages/web/src/pages/onboarding/__tests__/copy.test.ts
+++ b/packages/web/src/pages/onboarding/__tests__/copy.test.ts
@@ -31,12 +31,9 @@ describe("onboarding vocabulary (connect-agent reframe)", () => {
       cc.connected,
       cc.noRuntime,
       cc.detecting,
-      cc.runtimeReady("Claude Code"),
-      cc.runtimesReady(2),
       ...cc.stuckReasons,
-      cc.troubleshootTitle,
       cc.tokenErrorTitle,
-      ca.joining("Claude Code", "gandys-macbook"),
+      ca.subtitle,
       ca.nameLabel,
       ca.creating,
       ca.creatingHint,
@@ -50,7 +47,9 @@ describe("onboarding vocabulary (connect-agent reframe)", () => {
 
   it("names the coding agent directly once detected", () => {
     expect(COPY.connectComputer.whyWaiting).toContain("Claude Code");
-    expect(COPY.connectComputer.runtimeReady("Claude Code")).toContain("Claude Code");
-    expect(COPY.createAgent.joining("Claude Code", "host")).toContain("Claude Code");
+    // create-agent's subtitle intentionally uses the category word ("local
+    // coding agent"), not the tool names — the concrete tool is named in the
+    // field's pills (PROVIDER_LABEL) instead.
+    expect(COPY.createAgent.subtitle).toContain("local coding agent");
   });
 });

--- a/packages/web/src/pages/onboarding/copy.ts
+++ b/packages/web/src/pages/onboarding/copy.ts
@@ -62,11 +62,13 @@ export const STEP_COPY: Record<StepId, StepCopy> = {
     // self-evident enough, and the why is one glance below). "code" (not jargon
     // "repo") for the concept; "repos" is reserved for the actual selection.
     title: "Connect to GitHub",
-    // why = value + reassurance. The "install the GitHub App" mechanism lives on
-    // the CTA button (so this never reads as "install software"); the reassurance
-    // ("never changes them without your okay") is kept — it's worth a lot at the
-    // first GitHub authorization.
-    why: "Your agent works on your code. Connect your GitHub and choose which repos it can use — and it never changes them without your okay.",
+    // why = explain BOTH the reason and the action: sentence 1 is the WHY (the
+    // agent needs your code), sentence 2 is the WHAT (connect GitHub + scope the
+    // repos). The "install the GitHub App" mechanism lives on the CTA button (so
+    // this never reads as "install software"). Only the trailing "never changes
+    // them without your okay" reassurance was cut — "choose which repos it can
+    // use" already carries the in-control message.
+    why: "Your agent works on your code. Connect your GitHub and choose which repos it can use.",
   },
   "connect-computer": {
     // Reframed: this step installs the First Tree client (a small background app)
@@ -148,7 +150,10 @@ export const COPY = {
       /** Granted-repo count, shown once the repo list loads. */
       repoCount: (n: number) => `${n} ${n === 1 ? "repository" : "repositories"} available`,
     },
-    pickProject: "Which repos should your agent work on?",
+    // Concise field-label for the repo picker — the subtitle already explains
+    // ("choose which repos it can use"), so this just tags the field rather than
+    // re-asking the question (and avoids echoing the subtitle's "choose…use").
+    pickProject: "Repos your agent can use",
     /** Loading state for the repo picker (was hardcoded in the step). */
     loading: "Loading your repos…",
     // The picker is sourced from the team's GitHub App installation grant, so
@@ -167,7 +172,6 @@ export const COPY = {
     // Recovery variant: no "continue without" — offer a retry instead.
     loadFailedRecovery: "Couldn't load your team's repos. Try again in a moment.",
     loadFailedRetry: "Try again",
-    reconnect: "Reconnect GitHub with repo access",
     // Collapsed the two rare, not-user-fixable install errors (App not set up on
     // this server / caller lacks permission) into one recoverable message — the
     // action is the same either way (continue, set up later), so two separate
@@ -178,14 +182,6 @@ export const COPY = {
     // install it). The shell's "Back to workspace" is the way out.
     cantConnectRecovery:
       "Couldn't connect a repo here. Building your team's Context Tree needs First Tree connected to GitHub — a GitHub org owner has to install it. Once it's connected, come back.",
-    continueWithout: "Continue without a repo",
-    continueNoProject: "Continue without a repo",
-    // Shown when the picker has repos but none are selected. Connecting one is
-    // the whole point of this step — it's what gives the team a Context Tree —
-    // so we add friction (state the consequence + a quieter skip button), but
-    // never block: a beginner should still be able to move on.
-    noRepoConsequence:
-      "Pick a repo so your agent can build your team's Context Tree. Without one, teammates who join will be left waiting until you connect one.",
     /**
      * Shown under the CTA/Skip row: the install caveat (who can install) merged
      * with the skip reassurance into one muted line. `emphasis` renders bold so
@@ -203,28 +199,6 @@ export const COPY = {
         `oauth_state_nonce` cookie — re-minting while the first install tab is
         mid-flow would fail its callback. */
     restartInstall: "Didn't work? Start over",
-    /**
-     * Troubleshooting shown inside the "Need help?" disclosure (alongside the
-     * InstallGuide how-to), mirroring connect-computer. The disclosure
-     * auto-opens when the user returns from GitHub without an installation, so
-     * the title is state-neutral (it can also be opened proactively).
-     */
-    /** "Need help?" InstallGuide — a 3-beat visual flow + numbered how-to,
-        written to match GitHub's REAL App-install screen: choose where to
-        install → pick repo access (all / select) → click Install (or Request,
-        for non-owners) → auto-return. */
-    installFlow: ["Choose org", "Pick repos", "Install", "Back here"],
-    installFlowAria: "Flow: choose your org, pick repos, click Install on GitHub, then return to setup.",
-    installSteps: [
-      "Choose where to install First Tree — your team's GitHub org (or your account, if your repos live there).",
-      "Pick which repos it can access: all of them, or just the ones you choose.",
-      "Click Install. Not a GitHub org owner? The button says Request instead — an owner approves it.",
-      "GitHub sends you straight back here, and this page connects on its own.",
-    ],
-    troubleshootTitle: "If it didn't connect:",
-    troubleshootBody:
-      "Make sure you clicked Install (or Request) on GitHub. If you're not a GitHub org owner, an owner has to approve it — once they do, it connects here automatically.",
-    // (skipReassure merged into `notOwnerHint` — one muted line under the row.)
   },
   /** connect-computer states */
   connectComputer: {
@@ -236,14 +210,22 @@ export const COPY = {
     // at the machine where they're installed — the user's coding agent already
     // lives there, so running the command connects it. The "— that connects it
     // to your team" tail gives the bare command its purpose.
-    whyWaiting: "A small background app that lets your local coding agents (Claude Code, Codex) connect to your team.",
+    whyWaiting: "A background app that connects your local coding agents (Claude Code, Codex) to your First Tree team.",
     whyConnected:
-      "A small background app that lets your local coding agents (Claude Code, Codex) connect to your team.",
-    // Two install paths (waiting state): run in a terminal, or paste a ready
-    // prompt to the coding agent the user already has and let it install.
+      "A background app that connects your local coding agents (Claude Code, Codex) to your First Tree team.",
+    // Two install paths (waiting state): run the bare command in a terminal, or
+    // paste a ready prompt to the coding agent the user already has — the prompt
+    // wraps the command in a "please run this" line so the agent executes it
+    // instead of just explaining a bare command.
     terminalBoxLabel: "Run this command in your terminal",
     agentBoxLabel: "Or paste this to your Claude Code or Codex agent",
     agentPromptPrefix: "Help me install First Tree by running the command below:",
+    // Quiet caption naming the nested coding-agent list, so the indented rows
+    // read as "found ON this computer" (the relationship the nesting implies)
+    // rather than as an unlabelled cluster. Count-aware so a single detection
+    // doesn't read as a plural label.
+    detectedLabel: (count: number) =>
+      count === 1 ? "Coding agent on this computer" : "Coding agents on this computer",
     // Bridge below the detected-agents list → the next step (create-agent).
     detectedBridge: "Next, create your first agent.",
     // Stuck recovery (replaces the Need-help disclosure): ONE line, Node.js the
@@ -252,22 +234,12 @@ export const COPY = {
     stuckNodePost: ", re-run.",
     waiting: "Waiting for your computer…",
     connected: "connected",
-    noRuntime:
-      "Your computer is connected, but we didn't find a coding agent on it. Install one (like Claude Code) and sign in — it'll show up here automatically.",
+    // One line: the "✓ <host> connected" row above already says the computer is
+    // connected (so no "Your computer is connected, but…" lead-in), and this is a
+    // live polling state (so the dropped "it'll appear here automatically" tail is
+    // implied — a detected agent just shows up). Problem + fix only.
+    noRuntime: "No coding agent found yet. Install one (like Claude Code) and sign in.",
     detecting: "Looking for coding agents on it…",
-    /**
-     * Ready · exactly one coding agent detected — nothing to choose, so name
-     * the tool and bridge into the next step. `name` is the friendly
-     * PROVIDER_LABEL (e.g. "Claude Code").
-     */
-    runtimeReady: (name: string) => `${name} is ready on this computer. Next, add it to your team.`,
-    /**
-     * Ready · two or more coding agents detected — state the count and prompt
-     * the user to pick which one to connect first (a single-select list
-     * follows).
-     */
-    runtimesReady: (count: number) =>
-      `We found ${count} coding agents on this computer — pick which one to connect first.`,
     stuckTitle: "Taking a while? A few common reasons:",
     stuckReasons: [
       "If you saw “command not found”, your computer needs Node.js first — it's a free install. Get it, then run the command again.",
@@ -276,11 +248,6 @@ export const COPY = {
     ],
     nodeLinkLabel: "Install Node.js (free)",
     nodeUrl: "https://nodejs.org",
-    /** "Need help?" disclosure — label, and the stuck variant it switches to. */
-    helpStuckLabel: "Taking a while? Need help?",
-    /** Troubleshooting block inside the disclosure (neutral title — it can be
-        opened proactively, not only when stuck). Reuses `stuckReasons`. */
-    troubleshootTitle: "If it's not connecting:",
     /** Token-mint failure (POST /me/connect-tokens threw, after silent retries).
         Calm + recoverable: the auto-retry handles transient blips, so by the
         time this shows it's worth a manual Try again. */
@@ -289,38 +256,49 @@ export const COPY = {
   },
   /** create-agent states */
   createAgent: {
-    // Dynamic opener at the top of the step: names the connected tool + the
-    // machine it's on, grounding the abstract "agent" in the concrete coding
-    // agent the user already runs (e.g. "Claude Code on gandys-macbook is about
-    // to join your team."). Rendered only when both are known.
-    joining: (toolLabel: string, hostname: string) => `${toolLabel} on ${hostname} is about to join your team.`,
-    // Collapsed-model subtitle: the agent the user creates IS their local coding
-    // agent given a team identity — no "powered by / runtime" two-layer framing.
-    subtitle: "Your Claude Code or Codex becomes a team agent. Choose which one, name it, and set who can use it.",
+    // Subtitle = relationship + a smooth, generic lead-in to the setup. The
+    // SUBJECT carries the relationship ("your local coding agent" — the category
+    // word, NOT the tool names, which live in the field's pills +
+    // `codingAgentHint`); "ready to join your First Tree team" says what's
+    // happening, and "let's set it up" invites the configuration below WITHOUT
+    // enumerating / echoing the field labels (the robotic "Choose which one,
+    // name it, and set who can use it" list was the redundancy we cut). No
+    // two-layer "powered by / runtime" framing.
+    subtitle: "Your local coding agent is ready to join your First Tree team — let's set it up.",
     // Coding-agent picker (moved here from connect-computer): always a list, even
-    // for one, default-selected to Claude Code when present.
-    codingAgentLabel: "Coding agent",
+    // for one, default-selected to Claude Code when present. Verb-leading to
+    // match the imperative `nameLabel` ("Name your agent") below; "local" keeps
+    // the subtitle's vocabulary and frames the pick as the user's own
+    // machine-side tool — connect-computer already showed which machine, so no
+    // "Detected on <host>" sub-label is repeated here.
+    codingAgentLabel: "Choose your local coding agent",
+    // Amber "not ready" badge beside the label when the computer dropped — so the
+    // disabled picker reads AS unavailable (action needed: reconnect) at a glance,
+    // not just a quietly greyed pill.
+    codingAgentNotReady: "Not ready",
     nameLabel: "Name your agent",
     // "Bringing your agent online…" (not "Setting up…"): the step registers the
     // agent then polls until it comes online. Pairs with timeout's "isn't online
     // yet".
     creating: "Bringing your agent online…",
     creatingHint: "This usually takes a few seconds.",
-    // Timeout: added but didn't report online within 30s. ONE paragraph, no
-    // separate bold title — the shell already renders the step h1 ("Add your
-    // agent to the team"), so a second heading read as a stacked double-title.
-    // Leads with the situation, then causes + fix. "coding agent" matches
-    // connect-computer.
-    timeoutBody:
-      "Your agent isn't online yet — the computer it runs on may have gone to sleep, lost its connection, or the coding agent didn't start. Check that computer, then try again.",
+    // Timeout: added but didn't report online within 30s. One short line — the
+    // shell already renders the step h1, so no second title. Situation + the
+    // condensed likely cause (the three separate causes — sleep / lost
+    // connection / agent didn't start — collapse to "asleep or offline") + fix.
+    timeoutBody: "Your agent isn't online yet — its computer may be asleep or offline. Check it, then try again.",
     retry: "Try again",
     /** Shown on the form when the computer isn't connected (Create is disabled).
-        Rendered as one line with an inline "reconnect it" link (→ connect-computer)
-        rather than a separate orphaned link line. Auto-clears on reconnect. */
+        One line with an inline "reconnect it" link (→ connect-computer). The old
+        "to add your agent to the team" tail was dropped: the disabled "Create
+        agent" button right below already shows the consequence, and the new
+        "Not ready" badge + greyed picker carry the at-a-glance status — so this
+        line just states the specific reason + the recover action. Auto-clears on
+        reconnect. */
     computerDisconnected: {
       pre: "Your computer isn't connected — ",
       link: "reconnect it",
-      post: " to add your agent to the team.",
+      post: ".",
     },
   },
   /** kickoff — one unified "launch" finale across every path. Titles/bodies are

--- a/packages/web/src/pages/onboarding/steps/step-connect-code.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-connect-code.tsx
@@ -168,25 +168,16 @@ export function StepConnectCode({ recovery }: { recovery?: boolean } = {}) {
             appears in place. Intro/why live in STEP_COPY. */}
 
         {installError === "not_configured" || installError === "not_admin" ? (
-          <>
-            <FlowHint>{recovery ? COPY.connectCode.cantConnectRecovery : COPY.connectCode.cantConnect}</FlowHint>
-            {/* Recovery has no skip — a repo is mandatory. A blocked admin
-                leaves via the shell's "Back to workspace". Onboarding: the same
-                unified "Skip for now" quiet link as every other skip in this step. */}
-            {!recovery && (
-              <Button type="button" variant="link" className="h-auto self-start p-0 text-label" onClick={goNext}>
-                {COPY.skipForNow}
-              </Button>
-            )}
-          </>
+          // Just the message — the unified "Skip for now" at the bottom of the
+          // step is the way forward (recovery has no skip; a blocked admin leaves
+          // via the shell's "Back to workspace").
+          <FlowHint>{recovery ? COPY.connectCode.cantConnectRecovery : COPY.connectCode.cantConnect}</FlowHint>
         ) : (
           <>
-            {/* Decision row: primary CTA + Skip as a quiet sibling. Both
-                actions visible side-by-side so the user sees their full set
-                of options at a glance instead of hunting for Skip in a
-                footer. Skip goes straight through (no confirm gate); the
-                muted reassurance line below keeps the choice informed. */}
-            <div className="flex items-center" style={{ gap: "var(--sp-4)", flexWrap: "wrap" }}>
+            {/* Primary CTA only — "Skip for now" lives at the bottom of the step
+                (unified across states), so Install reads as the one clear primary
+                action here rather than competing with a sibling skip. */}
+            <div className="flex">
               {/* Lock the CTA once an attempt is in flight. The original tab
                   never navigates away here, so a second mint would overwrite the
                   first attempt's `oauth_state_nonce` cookie and break its
@@ -200,12 +191,6 @@ export function StepConnectCode({ recovery }: { recovery?: boolean } = {}) {
                 <Github className="h-4 w-4" />
                 {COPY.connectCode.cta}
               </Button>
-              {/* No skip on the recovery surface — a repo is required to build. */}
-              {!recovery && (
-                <Button type="button" variant="link" className="h-auto p-0 text-label" onClick={handleSkip}>
-                  {COPY.skipForNow}
-                </Button>
-              )}
             </div>
             {/* Merged caveat + skip reassurance; the gating fact is bolded. */}
             <p className="text-label" style={{ margin: 0, color: "var(--fg-4)" }}>
@@ -228,22 +213,30 @@ export function StepConnectCode({ recovery }: { recovery?: boolean } = {}) {
                 safe way to retry — see the CTA-lock note above). */}
             {attempted ? (
               // Stuck recovery (replaces the old "Need help?" disclosure): the
-              // live "waiting" status + a re-mint retry, plus the one genuinely
-              // useful, non-obvious explanation — non-owners' installs need an
-              // org owner's approval before they connect.
-              <div className="flex flex-col" style={{ gap: "var(--sp-1_5)" }}>
-                <div className="flex items-center" style={{ gap: "var(--sp-2_5)", flexWrap: "wrap" }}>
-                  <StatusRow state="waiting" label={COPY.connectCode.waiting} />
-                  <Button type="button" variant="link" className="h-auto p-0 text-label" onClick={handleStartOver}>
-                    {COPY.connectCode.restartInstall}
-                  </Button>
-                </div>
-                <p className="text-label" style={{ margin: 0, color: "var(--fg-4)" }}>
-                  {COPY.connectCode.troubleshootBody}
-                </p>
+              // live "waiting" status + a re-mint retry. notOwnerHint above
+              // already covers who can install / owner approval, so no extra
+              // troubleshooting line here.
+              <div className="flex items-center" style={{ gap: "var(--sp-2_5)", flexWrap: "wrap" }}>
+                <StatusRow state="waiting" label={COPY.connectCode.waiting} />
+                <Button type="button" variant="link" className="h-auto p-0 text-label" onClick={handleStartOver}>
+                  {COPY.connectCode.restartInstall}
+                </Button>
               </div>
             ) : null}
           </>
+        )}
+        {/* Unified "Skip for now" at the bottom — the same quiet link in every
+            not-installed state (was beside the CTA / under the error message).
+            handleSkip clears any in-flight install marker first. */}
+        {!recovery && (
+          <Button
+            type="button"
+            variant="link"
+            className="h-auto self-start p-0 text-label underline underline-offset-2"
+            onClick={handleSkip}
+          >
+            {COPY.skipForNow}
+          </Button>
         )}
       </div>
     );
@@ -338,23 +331,17 @@ export function StepConnectCode({ recovery }: { recovery?: boolean } = {}) {
         ) : (
           // No repo (didn't pick / couldn't load / none exist): continuing
           // without one is never the desired path, so it's always a very weak
-          // muted micro-link — never a strong button. When there ARE repos to
-          // pick, add the consequence line so the skip is an informed, deliberate
-          // choice (friction, not a block). When the list failed/empty, the
-          // picker area already explains why, so no extra line.
-          <>
-            {hasPickableRepos && <FlowHint>{COPY.connectCode.noRepoConsequence}</FlowHint>}
-            {/* Unified skip: same "Skip for now" label + quiet link style as the
-                pre-connect skip, so the skip reads identically in every state. */}
-            <Button
-              type="button"
-              variant="link"
-              className="h-auto self-start p-0 text-label underline underline-offset-2"
-              onClick={goNext}
-            >
-              {COPY.skipForNow}
-            </Button>
-          </>
+          // muted micro-link — never a strong button. Unified skip: same
+          // "Skip for now" label + quiet link style as the pre-connect skip, so
+          // the skip reads identically in every state.
+          <Button
+            type="button"
+            variant="link"
+            className="h-auto self-start p-0 text-label underline underline-offset-2"
+            onClick={goNext}
+          >
+            {COPY.skipForNow}
+          </Button>
         )}
       </div>
     </div>

--- a/packages/web/src/pages/onboarding/steps/step-connect-computer.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-connect-computer.tsx
@@ -38,7 +38,8 @@ export function StepConnectComputer({ initialStuck = false }: { initialStuck?: b
   }, [connectedClient]);
 
   // Box 2 hands the SAME command to the user's coding agent as a paste-able
-  // prompt, so it stays in sync with the minted token.
+  // prompt, with a natural-language "please run this" wrapper so the agent
+  // actually executes it (a bare command pasted in might only get explained).
   const agentPrompt = cliCommand ? `${COPY.connectComputer.agentPromptPrefix}\n${cliCommand}` : null;
 
   return (
@@ -48,52 +49,49 @@ export function StepConnectComputer({ initialStuck = false }: { initialStuck?: b
       </p>
 
       {!connectedClient ? (
-        <>
-          {tokenError ? (
+        tokenError ? (
+          // Just the message — the retry action rides on the step's primary
+          // bottom button (which becomes "Try again" in this state), so there's
+          // no separate retry button + a dead disabled "Continue".
+          <FlowHint tone="error" role="alert">
+            {COPY.connectComputer.tokenErrorTitle}
+          </FlowHint>
+        ) : (
+          <>
+            {/* Path 1 — run it yourself in a terminal (bare command). */}
             <div className="flex flex-col" style={{ gap: "var(--sp-2)" }}>
-              <FlowHint tone="error" role="alert">
-                {COPY.connectComputer.tokenErrorTitle}
-              </FlowHint>
-              <Button type="button" variant="outline" onClick={retry} className="self-start">
-                {COPY.connectComputer.retry}
-              </Button>
+              <p className="text-label font-medium" style={{ margin: 0, color: "var(--fg-2)" }}>
+                {COPY.connectComputer.terminalBoxLabel}
+              </p>
+              <CommandBox command={cliCommand} />
             </div>
-          ) : (
-            <>
-              {/* Path 1 — run it yourself in a terminal. */}
-              <div className="flex flex-col" style={{ gap: "var(--sp-2)" }}>
-                <p className="text-label font-medium" style={{ margin: 0, color: "var(--fg-2)" }}>
-                  {COPY.connectComputer.terminalBoxLabel}
-                </p>
-                <CommandBox command={cliCommand} />
-              </div>
-              {/* Path 2 — paste a prompt to the coding agent you already have. */}
-              <div className="flex flex-col" style={{ gap: "var(--sp-2)" }}>
-                <p className="text-label font-medium" style={{ margin: 0, color: "var(--fg-2)" }}>
-                  {COPY.connectComputer.agentBoxLabel}
-                </p>
-                <CommandBox command={agentPrompt} />
-              </div>
-              <StatusRow state="waiting" label={COPY.connectComputer.waiting} />
-              {/* Stuck recovery — one line, Node.js the #1 "command not found" cause. */}
-              {stuck ? (
-                <p className="text-label" style={{ margin: 0, color: "var(--fg-4)" }}>
-                  {COPY.connectComputer.stuckNodePre}
-                  <a
-                    href={COPY.connectComputer.nodeUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="font-medium"
-                    style={{ color: "var(--primary)" }}
-                  >
-                    {COPY.connectComputer.nodeLinkLabel}
-                  </a>
-                  {COPY.connectComputer.stuckNodePost}
-                </p>
-              ) : null}
-            </>
-          )}
-        </>
+            {/* Path 2 — paste a ready prompt to the coding agent you already
+                  have; the "please run this" wrapper makes the agent execute it. */}
+            <div className="flex flex-col" style={{ gap: "var(--sp-2)" }}>
+              <p className="text-label font-medium" style={{ margin: 0, color: "var(--fg-2)" }}>
+                {COPY.connectComputer.agentBoxLabel}
+              </p>
+              <CommandBox command={agentPrompt} />
+            </div>
+            <StatusRow state="waiting" label={COPY.connectComputer.waiting} />
+            {/* Stuck recovery — one line, Node.js the #1 "command not found" cause. */}
+            {stuck ? (
+              <p className="text-label" style={{ margin: 0, color: "var(--fg-4)" }}>
+                {COPY.connectComputer.stuckNodePre}
+                <a
+                  href={COPY.connectComputer.nodeUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="font-medium"
+                  style={{ color: "var(--primary)" }}
+                >
+                  {COPY.connectComputer.nodeLinkLabel}
+                </a>
+                {COPY.connectComputer.stuckNodePost}
+              </p>
+            ) : null}
+          </>
+        )
       ) : (
         <>
           <StatusRow
@@ -113,23 +111,53 @@ export function StepConnectComputer({ initialStuck = false }: { initialStuck?: b
             <FlowHint>{COPY.connectComputer.noRuntime}</FlowHint>
           ) : (
             // Detected coding agents — a READ-ONLY list (name + status). Choosing
-            // which one to use is the next step (create-agent), not here.
+            // which one to use is the next step (create-agent), not here. The
+            // list is nested UNDER the connected-computer row (indented behind a
+            // containment rail, with quieter dot markers) so it reads as "found
+            // ON this machine" rather than as peers of the computer above — the
+            // bold green check stays the computer's alone.
             <div className="flex flex-col" style={{ gap: "var(--sp-2_5)" }}>
-              <div className="flex flex-col" style={{ gap: "var(--sp-1_5)" }}>
-                {okRuntimes.map((r) => (
-                  <StatusRow
-                    key={r}
-                    state="ok"
-                    label={
-                      <>
-                        <span className="font-medium" style={{ color: "var(--fg)" }}>
-                          {runtimeProviderLabel(r)}
-                        </span>{" "}
-                        · ready
-                      </>
-                    }
-                  />
-                ))}
+              <div
+                className="flex flex-col"
+                style={{
+                  gap: "var(--sp-2)",
+                  // Align the rail under the computer row's check glyph so the
+                  // indent reads as containment, not an arbitrary offset.
+                  marginLeft: "var(--sp-1_5)",
+                  paddingLeft: "var(--sp-3)",
+                  borderLeft: "var(--hairline) solid var(--border)",
+                }}
+              >
+                {/* Names the nested group so the relationship is stated, not
+                    only implied by the indent. */}
+                <p className="text-caption" style={{ margin: 0, color: "var(--fg-4)" }}>
+                  {COPY.connectComputer.detectedLabel(okRuntimes.length)}
+                </p>
+                <div className="flex flex-col" style={{ gap: "var(--sp-1_5)" }}>
+                  {okRuntimes.map((r) => (
+                    <div
+                      key={r}
+                      className="inline-flex items-center text-label"
+                      role="status"
+                      style={{ gap: "var(--sp-2)", color: "var(--fg-3)" }}
+                    >
+                      <span
+                        aria-hidden="true"
+                        style={{
+                          width: "var(--sp-1_5)",
+                          height: "var(--sp-1_5)",
+                          flexShrink: 0,
+                          borderRadius: "var(--radius-full)",
+                          background: "var(--success)",
+                        }}
+                      />
+                      <span className="font-medium" style={{ color: "var(--fg)" }}>
+                        {runtimeProviderLabel(r)}
+                      </span>
+                      <span style={{ color: "var(--success)" }}>· ready</span>
+                    </div>
+                  ))}
+                </div>
               </div>
               <p className="text-body" style={{ margin: 0, color: "var(--fg-3)" }}>
                 {COPY.connectComputer.detectedBridge}
@@ -140,10 +168,19 @@ export function StepConnectComputer({ initialStuck = false }: { initialStuck?: b
       )}
 
       <div className="flex">
-        <Button type="button" onClick={goNext} disabled={!ready}>
-          <span>{COPY.continue}</span>
-          <ArrowRight className="h-4 w-4" />
-        </Button>
+        {tokenError && !connectedClient ? (
+          // Token mint failed: the only useful action is retry, so the primary
+          // button itself becomes "Try again" rather than sitting disabled
+          // beside a separate retry button.
+          <Button type="button" onClick={retry}>
+            <span>{COPY.connectComputer.retry}</span>
+          </Button>
+        ) : (
+          <Button type="button" onClick={goNext} disabled={!ready}>
+            <span>{COPY.continue}</span>
+            <ArrowRight className="h-4 w-4" />
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/packages/web/src/pages/onboarding/steps/step-create-agent.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-create-agent.tsx
@@ -69,6 +69,15 @@ export function StepCreateAgent() {
     return provider ? [provider] : [];
   });
 
+  // Coding-agent pills to render. When the computer drops mid-form, okRuntimes
+  // empties but `selectedRuntime` keeps the last pick — so we still show THAT
+  // agent (disabled) rather than letting the whole field vanish and the form
+  // jump. A disabled pill + the reconnect hint reads as "your agent's here, just
+  // temporarily unreachable", not "it's gone".
+  const connected = !!computer.connectedClient;
+  const fallbackProvider = selectedRuntime ? asRuntimeProvider(selectedRuntime) : null;
+  const displayProviders = okProviders.length > 0 ? okProviders : fallbackProvider ? [fallbackProvider] : [];
+
   if (agentPhase === "creating") {
     return <WorkingState label={COPY.createAgent.creating} hint={COPY.createAgent.creatingHint} />;
   }
@@ -109,20 +118,58 @@ export function StepCreateAgent() {
         {COPY.createAgent.subtitle}
       </p>
 
-      {/* Coding agent — always a list (even for one), default Claude Code. */}
-      {okProviders.length > 0 && (
+      {/* Coding agent — always a list (even for one), default Claude Code.
+          Stays visible (disabled) when the computer drops, so the field never
+          vanishes from under the user. */}
+      {displayProviders.length > 0 && (
         <fieldset className="flex flex-col" style={{ gap: "var(--sp-2)", margin: 0, padding: 0, border: 0 }}>
-          <legend className="text-label font-medium" style={{ color: "var(--fg-2)", marginBottom: "var(--sp-1)" }}>
+          <legend
+            className="text-label font-medium"
+            style={{
+              color: "var(--fg-2)",
+              marginBottom: "var(--sp-1)",
+              display: "inline-flex",
+              alignItems: "center",
+              gap: "var(--sp-2)",
+            }}
+          >
             {COPY.createAgent.codingAgentLabel}
+            {/* Prominent amber "Not ready" badge when the computer dropped — makes
+                the disabled pill read as unavailable (reconnect needed), not just
+                quietly greyed. */}
+            {!connected && (
+              <span
+                className="inline-flex items-center text-caption font-medium"
+                style={{
+                  gap: "var(--sp-1)",
+                  padding: "var(--sp-0_5) var(--sp-1_5)",
+                  borderRadius: "var(--radius-chip)",
+                  background: "var(--state-needs-you-soft)",
+                  color: "var(--fg-needs-you-strong)",
+                }}
+              >
+                <span
+                  aria-hidden="true"
+                  style={{
+                    width: "var(--sp-1_5)",
+                    height: "var(--sp-1_5)",
+                    borderRadius: "var(--radius-full)",
+                    background: "var(--state-needs-you)",
+                  }}
+                />
+                {COPY.createAgent.codingAgentNotReady}
+              </span>
+            )}
           </legend>
           <div className="flex flex-wrap" style={{ gap: "var(--sp-2)" }}>
-            {okProviders.map((provider) => (
+            {displayProviders.map((provider) => (
               <OptionCard
                 key={provider}
                 name="onboarding-coding-agent"
                 layout="pill"
                 checked={selectedRuntime === provider}
                 onSelect={() => setSelectedRuntime(provider)}
+                disabled={!connected}
               >
                 <span className="text-body">{PROVIDER_LABEL[provider]}</span>
               </OptionCard>


### PR DESCRIPTION
A pass over the three onboarding setup steps — tighter copy, fewer redundant controls, a clearer "computer dropped" state, and dead-copy cleanup. All changes were reviewed live in the DEV `/preview/onboarding` gallery.

## connect-computer (Install First Tree)
- `whyWaiting`/`whyConnected` → active voice + "First Tree team", drop "small"
- "no coding agent" message → one line; the token-error state now folds into a **single primary "Try again" button** (no separate retry beside a dead, disabled "Continue")
- nest detected coding agents **under** the connected computer (indent rail + quiet dots + "Coding agents on this computer" caption)

## create-agent
- subtitle reframed to the relationship + a smooth setup lead-in; field label is verb-leading **"Choose your local coding agent"**
- keep the coding-agent picker **visible-but-disabled when the computer drops** (it used to vanish), with a prominent amber **"Not ready"** badge; tighten the reconnect hint
- timeout body → one line

## connect-code (Connect to GitHub)
- "why" explains the reason + the action; repo-picker label is **"Repos your agent can use"**; drop the no-repo consequence line
- unify **"Skip for now"** to the bottom of every state (was beside the CTA in one, at the bottom in another), one consistent quiet-link style
- drop the waiting-state troubleshootBody (`notOwnerHint` already covers it)

## cleanup
- remove dead copy left by the retired "Need help?" InstallGuide disclosure + old "Continue without a repo" buttons (connect-code: `installFlow`/`installFlowAria`/`installSteps`/`troubleshootTitle`/`continueWithout`/`continueNoProject`/`reconnect`; connect-computer: `runtimeReady`/`runtimesReady`/`helpStuckLabel`/`troubleshootTitle`)
- drop a leftover useless React fragment in connect-computer
- onboarding preview: realistic prod-shaped `SAMPLE_CLI` + a "lost while ready" computer fixture for the disconnected create-agent state

## Test plan
- `pnpm --filter @first-tree/web run typecheck` — clean (incl. design-token guardrails)
- `pnpm --filter @first-tree/web exec biome check src/pages/onboarding` — clean (0 info)
- onboarding + preview unit tests: **76 passing**
- every state eyeballed in the DEV `/preview/onboarding` gallery

🤖 Generated with [Claude Code](https://claude.com/claude-code)