### PR TITLE
feat(web): show "new version available" refresh chip in topbar

### DIFF
--- a/packages/web/src/components/layout.tsx
+++ b/packages/web/src/components/layout.tsx
@@ -6,6 +6,7 @@ import { cn } from "../lib/utils.js";
 import { CommandPalette } from "../pages/workspace/palette/command-palette.js";
 import { DisconnectChip } from "./disconnect-chip.js";
 import { FirstTreeLogo } from "./first-tree-logo.js";
+import { NewVersionChip } from "./new-version-chip.js";
 import { ThemeToggle } from "./ui/theme-toggle.js";
 import { UserMenu } from "./user-menu.js";
 
@@ -118,6 +119,7 @@ export function Layout() {
               </span>
             </a>
             <DisconnectChip />
+            <NewVersionChip />
           </div>
         )}
 

--- a/packages/web/src/components/new-version-chip.tsx
+++ b/packages/web/src/components/new-version-chip.tsx
@@ -1,0 +1,43 @@
+import { RefreshCw } from "lucide-react";
+import { useNewVersionAvailable } from "../hooks/use-version-check.js";
+
+/**
+ * Topbar chip that appears next to the brand once the server is serving a
+ * newer web build than this tab loaded. Clicking reloads the page to pick up
+ * the new build. Renders nothing in the common (up-to-date) case so the topbar
+ * stays clean — same self-hiding pattern as `DisconnectChip`.
+ *
+ * Styled with the `needs-you` amber token family — the shared "user action
+ * needed" vocabulary — so it reads as an informational nudge, not an error.
+ * Copy is intentionally English-only; a future i18n pass owns translation.
+ */
+export function NewVersionChip() {
+  const newVersionAvailable = useNewVersionAvailable();
+  if (!newVersionAvailable) return null;
+
+  const tooltip = "A new version is available. Click to refresh.";
+  return (
+    <button
+      type="button"
+      onClick={() => window.location.reload()}
+      title={tooltip}
+      aria-label={tooltip}
+      className="inline-flex items-center cursor-pointer text-body font-medium"
+      style={{
+        gap: 7,
+        height: 26,
+        padding: "0 var(--sp-2_5) 0 var(--sp-2_25)",
+        borderRadius: 999,
+        border: 0,
+        outline: "var(--hairline) solid color-mix(in oklch, var(--state-needs-you) 42%, transparent)",
+        outlineOffset: -1,
+        background: "var(--state-needs-you-soft)",
+        color: "var(--fg-needs-you-strong)",
+        minWidth: 0,
+      }}
+    >
+      <RefreshCw aria-hidden="true" size={13} style={{ flexShrink: 0 }} />
+      <span>New version — refresh</span>
+    </button>
+  );
+}

--- a/packages/web/src/hooks/__tests__/use-version-check.test.ts
+++ b/packages/web/src/hooks/__tests__/use-version-check.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { extractBuildId, isNewVersionAvailable } from "../use-version-check.js";
+
+/**
+ * Pure-function unit tests for the topbar new-version chip. The hook wires
+ * these helpers into React Query (mount + 10min interval + focus refetch);
+ * the visual/behavioural surface is covered by manual e2e.
+ */
+
+describe("extractBuildId", () => {
+  it("returns the buildId from a well-formed manifest", () => {
+    expect(extractBuildId({ buildId: "abc123" })).toBe("abc123");
+  });
+
+  it("returns null for null / non-object input", () => {
+    expect(extractBuildId(null)).toBeNull();
+    expect(extractBuildId("abc123")).toBeNull();
+    expect(extractBuildId(42)).toBeNull();
+  });
+
+  it("returns null when buildId is missing, empty, or not a string", () => {
+    expect(extractBuildId({})).toBeNull();
+    expect(extractBuildId({ buildId: "" })).toBeNull();
+    expect(extractBuildId({ buildId: 123 })).toBeNull();
+  });
+});
+
+describe("isNewVersionAvailable", () => {
+  it("is false when no deployed id is known (manifest missing / dev / fetch error)", () => {
+    expect(isNewVersionAvailable(null, "abc123")).toBe(false);
+  });
+
+  it("is false when the deployed id matches the running id", () => {
+    expect(isNewVersionAvailable("abc123", "abc123")).toBe(false);
+  });
+
+  it("is true when the deployed id differs from the running id", () => {
+    expect(isNewVersionAvailable("def456", "abc123")).toBe(true);
+  });
+});

--- a/packages/web/src/hooks/use-version-check.ts
+++ b/packages/web/src/hooks/use-version-check.ts
@@ -1,0 +1,74 @@
+import { useQuery } from "@tanstack/react-query";
+import { useAuth } from "../auth/auth-context.js";
+
+/**
+ * Poll cadence for the deployed-version check. 10 minutes surfaces a deploy
+ * within a short break without adding meaningful load — the request is a
+ * single tiny static JSON.
+ */
+const VERSION_POLL_MS = 10 * 60 * 1000;
+
+/**
+ * Build manifest emitted by Vite at build time (see vite.config.ts), served
+ * as a static file alongside the SPA, so a fresh GET always reflects the
+ * *currently deployed* build.
+ */
+const VERSION_MANIFEST_PATH = "/version.json";
+
+/**
+ * Narrow a parsed version manifest to its `buildId` without an `as` cast.
+ * Returns null for any unrecognised shape so a malformed/missing manifest
+ * reads as "no new version" rather than throwing.
+ */
+export function extractBuildId(data: unknown): string | null {
+  if (typeof data === "object" && data !== null && "buildId" in data) {
+    const { buildId } = data;
+    if (typeof buildId === "string" && buildId.length > 0) return buildId;
+  }
+  return null;
+}
+
+/**
+ * True when the deployed build differs from the one this tab is running. A
+ * null deployed id (manifest missing — e.g. `vite dev`, or a fetch error) is
+ * treated as "no new version" so the chip never shows spuriously.
+ */
+export function isNewVersionAvailable(deployedBuildId: string | null, runningBuildId: string): boolean {
+  if (!deployedBuildId) return false;
+  return deployedBuildId !== runningBuildId;
+}
+
+async function fetchDeployedBuildId(): Promise<string | null> {
+  // Cache-bust + no-store so a long-lived tab never reads a stale manifest out
+  // of the HTTP cache; the static server may otherwise attach caching headers.
+  const res = await fetch(`${VERSION_MANIFEST_PATH}?t=${Date.now()}`, { cache: "no-store" });
+  if (!res.ok) return null;
+  try {
+    const data: unknown = await res.json();
+    return extractBuildId(data);
+  } catch {
+    // Non-JSON body (e.g. dev server SPA fallback returning index.html) — treat
+    // as no manifest.
+    return null;
+  }
+}
+
+/**
+ * Polls the deployed build manifest and reports whether the server is now
+ * serving a newer web build than this tab loaded. The query refetches on mount
+ * (so a freshly opened/reloaded tab checks immediately), every 10 minutes, and
+ * when the tab regains focus. Gated on an authenticated user so it only runs
+ * inside the app shell.
+ */
+export function useNewVersionAvailable(): boolean {
+  const { user } = useAuth();
+  const { data } = useQuery({
+    queryKey: ["web-version"],
+    queryFn: fetchDeployedBuildId,
+    enabled: Boolean(user),
+    refetchInterval: VERSION_POLL_MS,
+    refetchOnWindowFocus: true,
+    staleTime: 0,
+  });
+  return isNewVersionAvailable(data ?? null, __WEB_BUILD_ID__);
+}

--- a/packages/web/src/vite-env.d.ts
+++ b/packages/web/src/vite-env.d.ts
@@ -1,1 +1,8 @@
 /// <reference types="vite/client" />
+
+/**
+ * Build id injected by Vite's `define` (see vite.config.ts). Identifies the
+ * web build THIS tab is running; compared against `dist/version.json` to
+ * detect a newer deployed build.
+ */
+declare const __WEB_BUILD_ID__: string;

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -1,11 +1,64 @@
+import { execSync } from "node:child_process";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
 
 const HUB_TARGET = process.env.VITE_PROXY_TARGET ?? "http://localhost:8000";
 
+/**
+ * A unique id for this web build. Resolution order:
+ *   1. `FIRST_TREE_WEB_BUILD_ID` — explicit override (e.g. a CI-passed git
+ *      SHA, mirroring the `COMMAND_VERSION` build-arg the Docker image uses).
+ *   2. `git rev-parse --short HEAD` — when building from a checkout with `.git`.
+ *   3. a build timestamp — guarantees a fresh id per build when neither of the
+ *      above is available (e.g. `.git` excluded from the Docker build context).
+ *
+ * The id is both injected into the bundle as `__WEB_BUILD_ID__` (the version
+ * THIS tab is running) and written to `dist/version.json` (the version the
+ * server is currently serving). The client polls the manifest and compares the
+ * two to detect that a newer build has been deployed — see use-version-check.
+ */
+function resolveBuildId(): string {
+  const fromEnv = process.env.FIRST_TREE_WEB_BUILD_ID?.trim();
+  if (fromEnv) return fromEnv;
+  try {
+    return execSync("git rev-parse --short HEAD", {
+      stdio: ["ignore", "pipe", "ignore"],
+    })
+      .toString()
+      .trim();
+  } catch {
+    return `build-${Date.now()}`;
+  }
+}
+
+/**
+ * Emits `version.json` ({ buildId }) into the build output so the running SPA
+ * can poll for the currently deployed build id. Build-only: the dev server has
+ * no bundle, so the manifest fetch simply 404s and is treated as "no new
+ * version" (the chip never shows in local dev).
+ */
+function versionManifestPlugin(buildId: string): Plugin {
+  return {
+    name: "first-tree:version-manifest",
+    apply: "build",
+    generateBundle() {
+      this.emitFile({
+        type: "asset",
+        fileName: "version.json",
+        source: JSON.stringify({ buildId }),
+      });
+    },
+  };
+}
+
+const buildId = resolveBuildId();
+
 export default defineConfig({
-  plugins: [react(), tailwindcss()],
+  plugins: [react(), tailwindcss(), versionManifestPlugin(buildId)],
+  define: {
+    __WEB_BUILD_ID__: JSON.stringify(buildId),
+  },
   server: {
     proxy: {
       "/api/v1": { target: HUB_TARGET, changeOrigin: true, ws: true },

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -7,6 +7,13 @@ import { unitCoverageConfig } from "../../scripts/vitest-coverage.js";
 // directly, so the React plugin is needed at transform time to strip JSX.
 export default defineConfig({
   plugins: [react()],
+  // `__WEB_BUILD_ID__` is injected by Vite's `define` at build time (see
+  // vite.config.ts). Vitest doesn't read that config, so provide a stub here so
+  // components that read it (e.g. NewVersionChip) don't hit a ReferenceError
+  // when rendered in tests.
+  define: {
+    __WEB_BUILD_ID__: JSON.stringify("test"),
+  },
   test: {
     coverage: unitCoverageConfig(),
     testTimeout: 20_000,


### PR DESCRIPTION
## What

When the server is serving a **newer web build than the tab loaded**, show a small chip next to the top-left brand logo prompting a manual page refresh. Clicking it reloads the page to pick up the new build. Renders nothing when up to date.

Requested by @liuchao-001.

## How detection works

In production the web SPA and server ship in the **same Docker image** (server serves `web-dist/` via `@fastify/static`), so every deploy swaps the web assets.

1. At build time Vite resolves a per-build id (`FIRST_TREE_WEB_BUILD_ID` env → `git rev-parse --short HEAD` → build timestamp) and:
   - injects it into the bundle as the compile-time constant `__WEB_BUILD_ID__` (the version **this tab is running**), and
   - emits it as a static `dist/version.json` `{ "buildId": ... }` (the version the server is **currently serving**).
2. The client polls `version.json` **on mount (page open/refresh) + every 10 minutes + on tab focus**, cache-busted + `no-store`.
3. If the deployed id differs from the running id → show the chip.

A fresh load is always up to date (running id == deployed id → no chip). The prompt only appears once a *new* build is deployed while the tab stays open. The on-mount check also catches a stale browser cache for free.

## Scope

**Web-only — no server / Docker / CI changes.** The server already serves the SPA statically, so `version.json` ships with the existing `web-dist` artifact. `@fastify/static` serves it directly; the SPA-fallback handler 404s on `.json` paths when absent (e.g. `vite dev`), which the client treats as "no new version".

## Files

- `packages/web/vite.config.ts` — build-id resolution, `__WEB_BUILD_ID__` define, `version.json` emit plugin
- `packages/web/src/hooks/use-version-check.ts` — polling hook + pure `extractBuildId` / `isNewVersionAvailable`
- `packages/web/src/components/new-version-chip.tsx` — self-hiding topbar pill (needs-you amber token family), reload on click
- `packages/web/src/components/layout.tsx` — render next to `DisconnectChip`
- `packages/web/src/vite-env.d.ts` — declare `__WEB_BUILD_ID__`
- `packages/web/vitest.config.ts` — stub `__WEB_BUILD_ID__` for tests
- `packages/web/src/hooks/__tests__/use-version-check.test.ts` — unit tests

## Design notes (confirmed with @liuchao-001)

- Poll cadence **10 min** (not 60s).
- Copy **English-only** ("New version — refresh"); future i18n pass owns translation.
- **Not dismissible** — the only action is click-to-refresh.

## Testing

- `pnpm --filter @first-tree/web test` → **826 passed**
- `pnpm --filter @first-tree/web typecheck` (tsc + design-token lint) → clean
- `pnpm check` (biome) → clean (pre-existing warnings only)
- `pnpm --filter @first-tree/web build` → confirmed `dist/version.json` emitted and the build id is present in the JS bundle (define injection works)

### Manual verification
1. `pnpm --filter @first-tree/web build`, serve `dist/` (or run the server image), open the app — **no chip** (up to date).
2. Edit `dist/version.json`'s `buildId` to a different value (simulating a new deploy) and wait ≤10 min (or refocus the tab) — the chip appears next to the logo.
3. Click it → page reloads, chip gone.

## Context Tree

Implementation-only (UI + a client-side version-check mechanism); no cross-domain decision/constraint/ownership change, so no tree write. Tree was read before implementing.
