### PR TITLE
fix(web): detect new version + show refresh entry on narrow layouts

### DIFF
--- a/packages/web/src/components/__tests__/new-version-chip.test.tsx
+++ b/packages/web/src/components/__tests__/new-version-chip.test.tsx
@@ -1,0 +1,40 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createDomHarness, type DomHarness } from "../../test-utils/dom-harness.js";
+import { NewVersionChip } from "../new-version-chip.js";
+
+/**
+ * Presentational tests for the topbar new-version chip. Detection lives in
+ * `useNewVersionAvailable` (covered by use-version-check tests); here we pin
+ * the render contract that the narrow-layout fix depends on — the chip is a
+ * pure function of its props, so it can be mounted (and polled-for) at every
+ * breakpoint rather than only inside the hideable brand cluster.
+ */
+describe("NewVersionChip", () => {
+  let h: DomHarness;
+  beforeEach(() => {
+    h = createDomHarness();
+  });
+  afterEach(() => h.cleanup());
+
+  it("renders nothing when no new version is available", () => {
+    h.render(<NewVersionChip show={false} />);
+    expect(h.container.querySelector("button")).toBeNull();
+  });
+
+  it("renders a labelled refresh button (full) when a new version is available", () => {
+    h.render(<NewVersionChip show={true} />);
+    const btn = h.container.querySelector("button");
+    expect(btn).not.toBeNull();
+    expect(btn?.textContent).toContain("New version");
+    expect(btn?.getAttribute("aria-label")?.toLowerCase()).toContain("refresh");
+  });
+
+  it("renders an icon-only button (compact) with no visible text, still labelled for a11y", () => {
+    h.render(<NewVersionChip show={true} compact />);
+    const btn = h.container.querySelector("button");
+    expect(btn).not.toBeNull();
+    expect(btn?.textContent).toBe("");
+    expect(btn?.getAttribute("aria-label")?.toLowerCase()).toContain("refresh");
+  });
+});

--- a/packages/web/src/components/layout.tsx
+++ b/packages/web/src/components/layout.tsx
@@ -1,6 +1,7 @@
 import { Search } from "lucide-react";
 import { useEffect, useState } from "react";
 import { NavLink, Outlet, useLocation } from "react-router";
+import { useNewVersionAvailable } from "../hooks/use-version-check.js";
 import { useWorkspaceViewport } from "../hooks/use-viewport.js";
 import { cn } from "../lib/utils.js";
 import { CommandPalette } from "../pages/workspace/palette/command-palette.js";
@@ -61,6 +62,12 @@ export function Layout() {
   // fall back to the OS `prefers-color-scheme` (honoured at boot in index.html);
   // the toggle returns at `md`. The avatar is the one control that never drops.
   const viewport = useWorkspaceViewport();
+  // Lifted out of NewVersionChip so the `/version.json` poll runs at EVERY
+  // breakpoint — the brand cluster (and its chip) is dropped on `narrow`, but
+  // version detection must not be. The chip is rendered in two places below:
+  // the full pill in the brand cluster, and a compact icon-only fallback in the
+  // right controls when the brand is dropped.
+  const newVersionAvailable = useNewVersionAvailable();
   const showJumpButton = viewport === "xl";
   const dropBrand = viewport === "narrow";
   const showThemeToggle = viewport !== "narrow";
@@ -119,7 +126,7 @@ export function Layout() {
               </span>
             </a>
             <DisconnectChip />
-            <NewVersionChip />
+            <NewVersionChip show={newVersionAvailable} />
           </div>
         )}
 
@@ -239,6 +246,9 @@ export function Layout() {
               />
             </>
           ) : null}
+          {/* On `narrow` the brand cluster (with the full chip) is dropped, so
+              surface a compact icon-only refresh entry here instead. */}
+          {dropBrand ? <NewVersionChip show={newVersionAvailable} compact /> : null}
           <UserMenu />
         </div>
       </header>

--- a/packages/web/src/components/new-version-chip.tsx
+++ b/packages/web/src/components/new-version-chip.tsx
@@ -1,40 +1,70 @@
 import { RefreshCw } from "lucide-react";
-import { useNewVersionAvailable } from "../hooks/use-version-check.js";
+import type { CSSProperties } from "react";
+
+const TOOLTIP = "A new version is available. Click to refresh.";
+
+// Shared visual vocabulary for both variants — the `needs-you` amber token
+// family reads as "user action needed", not an error.
+const CHIP_STYLE: CSSProperties = {
+  height: 26,
+  border: 0,
+  outline: "var(--hairline) solid color-mix(in oklch, var(--state-needs-you) 42%, transparent)",
+  outlineOffset: -1,
+  background: "var(--state-needs-you-soft)",
+  color: "var(--fg-needs-you-strong)",
+  borderRadius: 999,
+  minWidth: 0,
+};
+
+type NewVersionChipProps = {
+  /** Whether the server is serving a newer build than this tab is running. */
+  show: boolean;
+  /**
+   * Icon-only rendering for the narrow/mobile topbar, where the brand cluster
+   * (and the full chip) is dropped. Keeps a tappable refresh entry without
+   * crowding the tabs/avatar row.
+   */
+  compact?: boolean;
+};
 
 /**
- * Topbar chip that appears next to the brand once the server is serving a
- * newer web build than this tab loaded. Clicking reloads the page to pick up
- * the new build. Renders nothing in the common (up-to-date) case so the topbar
- * stays clean — same self-hiding pattern as `DisconnectChip`.
+ * Topbar control prompting a manual refresh once the server is serving a newer
+ * web build than this tab loaded; clicking reloads the page. Presentational
+ * only — detection/polling lives in `useNewVersionAvailable`, lifted to
+ * `Layout` so it runs at every breakpoint (including narrow, where this chip
+ * renders as the compact variant outside the dropped brand cluster). Renders
+ * nothing when up to date, so the topbar stays clean.
  *
- * Styled with the `needs-you` amber token family — the shared "user action
- * needed" vocabulary — so it reads as an informational nudge, not an error.
  * Copy is intentionally English-only; a future i18n pass owns translation.
  */
-export function NewVersionChip() {
-  const newVersionAvailable = useNewVersionAvailable();
-  if (!newVersionAvailable) return null;
+export function NewVersionChip({ show, compact = false }: NewVersionChipProps) {
+  if (!show) return null;
 
-  const tooltip = "A new version is available. Click to refresh.";
+  const reload = () => window.location.reload();
+
+  if (compact) {
+    return (
+      <button
+        type="button"
+        onClick={reload}
+        title={TOOLTIP}
+        aria-label={TOOLTIP}
+        className="inline-flex items-center justify-center cursor-pointer"
+        style={{ ...CHIP_STYLE, width: 26, padding: 0 }}
+      >
+        <RefreshCw aria-hidden="true" size={14} />
+      </button>
+    );
+  }
+
   return (
     <button
       type="button"
-      onClick={() => window.location.reload()}
-      title={tooltip}
-      aria-label={tooltip}
+      onClick={reload}
+      title={TOOLTIP}
+      aria-label={TOOLTIP}
       className="inline-flex items-center cursor-pointer text-body font-medium"
-      style={{
-        gap: 7,
-        height: 26,
-        padding: "0 var(--sp-2_5) 0 var(--sp-2_25)",
-        borderRadius: 999,
-        border: 0,
-        outline: "var(--hairline) solid color-mix(in oklch, var(--state-needs-you) 42%, transparent)",
-        outlineOffset: -1,
-        background: "var(--state-needs-you-soft)",
-        color: "var(--fg-needs-you-strong)",
-        minWidth: 0,
-      }}
+      style={{ ...CHIP_STYLE, gap: 7, padding: "0 var(--sp-2_5) 0 var(--sp-2_25)" }}
     >
       <RefreshCw aria-hidden="true" size={13} style={{ flexShrink: 0 }} />
       <span>New version — refresh</span>


### PR DESCRIPTION
## Why

Follow-up to #1142. Reviewers (@yuezengwu, @baixiaohang) flagged a real behavior gap: the new-version chip was rendered **inside the brand cluster**, which the `narrow` (mobile) breakpoint drops entirely (`dropBrand ? null : …` in `Layout`).

Because the polling hook lived inside that chip, on narrow screens:
1. `/version.json` polling **never mounted** → no version detection at all, and
2. **no refresh entry** was shown.

So the whole "new version available" feature was dead on mobile — the opposite of the goal.

## Fix

- **Decouple detection from display**: lift `useNewVersionAvailable()` into `Layout` so the poll runs at **every breakpoint**, independent of which chip renders.
- **Make `NewVersionChip` presentational** (`show` + `compact` props) — a pure function of props, so it can be mounted anywhere.
- **Render at all breakpoints**:
  - wide / md → full pill next to the brand logo (unchanged spec).
  - narrow → compact **icon-only** refresh button in the right controls (next to the avatar), which never drops; keeps a tappable entry without crowding the tabs/avatar row.
- Add presentational render tests (hidden / full / compact).

## Files

- `packages/web/src/components/layout.tsx` — lift hook, render full + compact variants
- `packages/web/src/components/new-version-chip.tsx` — presentational `show` / `compact`
- `packages/web/src/components/__tests__/new-version-chip.test.tsx` — render tests

## Testing

- `pnpm --filter @first-tree/web test` → **830 passed** (incl. 3 new chip render tests)
- `pnpm --filter @first-tree/web typecheck` (tsc + design-token lint) → clean
- `pnpm exec biome check` (changed files) → clean
- `pnpm --filter @first-tree/web build` → `dist/version.json` emitted, build id injected

### Manual verification
1. Build + serve `dist/`; resize to a phone width (narrow) — the refresh icon now appears next to the avatar once `version.json`'s buildId differs from the running one (it polls on mount / 10min / focus regardless of width).
2. Wide screen — full pill still appears next to the logo.
3. Click either → page reloads.

## Context Tree

Implementation-only responsive-layout fix; no cross-domain decision/constraint/ownership change → no tree write.
