### PR TITLE
fix(server): stop dispatcher minting a second chat for a PR's own creator

### DIFF
--- a/packages/server/src/__tests__/github-audience.test.ts
+++ b/packages/server/src/__tests__/github-audience.test.ts
@@ -822,6 +822,153 @@ describe("resolveAudience", () => {
     });
   });
 
+  it("creator carve-out: drops the actor's own kind:new involvement on a creation (opened) event", async () => {
+    // Regression for the dispatcher-mints-a-second-chat bug. An agent opens a
+    // PR under its own GitHub identity and self-assigns (or self-@mentions) in
+    // the opened payload, so its login lands in `involves`. The creator binds
+    // the PR through `github follow`; the dispatcher must NOT *also* mint a
+    // separate chat for the same creator. Once #942 stopped echo-dropping the
+    // actor's audience row, that fresh `kind: "new"` row survived and forked a
+    // duplicate chat. The creator carve-out drops it before delivery, leaving
+    // an empty audience (nothing else is involved) — equivalent to the
+    // already-accepted "opened with nobody else involved → confirmation card
+    // is lost, the creator already knows it opened" outcome.
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const delegate = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-${randomUUID().slice(0, 6)}`,
+    });
+    const creatorName = `creator-${randomUUID().slice(0, 6)}`;
+    await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: creatorName,
+      delegateMention: delegate,
+    });
+
+    const audience = await resolveAudience(
+      app.db,
+      makeEvent({
+        orgId: admin.organizationId,
+        entityType: "pull_request",
+        entityKey: "owner/repo#600",
+        actorLogin: creatorName,
+        involves: [{ githubLogin: creatorName, reason: "assigned" }],
+        kind: "opened",
+      }),
+      "first-tree",
+    );
+
+    expect(audience).toEqual([]);
+  });
+
+  it("creator carve-out: keeps a DIFFERENT involved human's fresh chat when the creator also self-targets on opened", async () => {
+    // Only the *creator's own* fresh involvement is dropped. A genuinely
+    // different human named in the same opened payload (assignee / @mention)
+    // is a real directed signal and still gets its `kind: "new"` chat, carrying
+    // the creator's id as `actorAgentId` so Stage 3 keeps the actor out of the
+    // notification wake-set.
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const creatorDelegate = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-creator-${randomUUID().slice(0, 6)}`,
+    });
+    const creatorName = `creator-${randomUUID().slice(0, 6)}`;
+    const creator = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: creatorName,
+      delegateMention: creatorDelegate,
+    });
+    const otherDelegate = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-other-${randomUUID().slice(0, 6)}`,
+    });
+    const otherName = `other-${randomUUID().slice(0, 6)}`;
+    const other = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: otherName,
+      delegateMention: otherDelegate,
+    });
+
+    const audience = await resolveAudience(
+      app.db,
+      makeEvent({
+        orgId: admin.organizationId,
+        entityType: "pull_request",
+        entityKey: "owner/repo#601",
+        actorLogin: creatorName,
+        involves: [
+          { githubLogin: creatorName, reason: "assigned" },
+          { githubLogin: otherName, reason: "mentioned" },
+        ],
+        kind: "opened",
+      }),
+      "first-tree",
+    );
+
+    expect(audience).toHaveLength(1);
+    expect(audience[0]?.humanAgentId).toBe(other);
+    expect(audience[0]?.kind).toBe("new");
+    expect(audience[0]?.actorAgentId).toBe(creator);
+  });
+
+  it("creator carve-out: keeps the creator's own declared follow chat on opened, drops only the duplicate", async () => {
+    // The real-world shape: the creator followed the PR (`agent_declared`)
+    // AND self-assigned in the opened payload. The existing followed chat must
+    // survive (the #766 declared carve-out keeps its opened confirmation card,
+    // annotated with the actor for notify suppression); only the would-be
+    // second `kind: "new"` chat for the same creator is dropped.
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const delegate = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-${randomUUID().slice(0, 6)}`,
+    });
+    const creatorName = `creator-${randomUUID().slice(0, 6)}`;
+    const creator = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: creatorName,
+      delegateMention: delegate,
+    });
+    const chatId = await seedChat(app, admin.organizationId, creator);
+    await seedMapping(app, {
+      orgId: admin.organizationId,
+      humanId: creator,
+      delegateId: delegate,
+      entityType: "pull_request",
+      entityKey: "owner/repo#602",
+      chatId,
+      boundVia: "agent_declared",
+    });
+
+    const audience = await resolveAudience(
+      app.db,
+      makeEvent({
+        orgId: admin.organizationId,
+        entityType: "pull_request",
+        entityKey: "owner/repo#602",
+        actorLogin: creatorName,
+        involves: [{ githubLogin: creatorName, reason: "assigned" }],
+        kind: "opened",
+      }),
+      "first-tree",
+    );
+
+    expect(audience).toHaveLength(1);
+    expect(audience[0]?.kind).toBe("existing");
+    expect(audience[0]?.chatId).toBe(chatId);
+    expect(audience[0]?.actorAgentId).toBe(creator);
+  });
+
   it("skips an involve whose delegate target is inactive (suspended/deleted)", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);

--- a/packages/server/src/services/github-audience.ts
+++ b/packages/server/src/services/github-audience.ts
@@ -118,15 +118,20 @@ export type AudienceTarget = {
  * already subscribed, appends a `new` row.
  *
  * Echo filtering runs after the union:
- *   - actor = `agent`: no row is dropped — every mapped chat keeps the card
- *     as the public record of what happened. Instead, each row is annotated
- *     with `actorAgentId` so Stage 3 passes the actor as
+ *   - actor = `agent`: no row is dropped for echo — every mapped chat keeps
+ *     the card as the public record of what happened. Instead, each row is
+ *     annotated with `actorAgentId` so Stage 3 passes the actor as
  *     `suppressNotifyAgentIds` (the actor isn't woken / red-dotted by its own
  *     action, other recipients are notified normally; the actor still gets a
  *     silent row). Dropping rows here used to conflate "should this chat get
  *     the card" with "should this recipient be notified" and silently killed
  *     delivery to multi-participant chats whose only routing entry had the
- *     actor on one side (#942).
+ *     actor on one side (#942). The one row this branch DOES drop is the
+ *     creator carve-out: on a creation event (`kind: "opened"`) the actor's
+ *     OWN `kind: "new"` involvement is removed — a creator never gets a
+ *     dispatcher-minted chat for the entity it just opened; it binds that
+ *     entity via explicit `github follow`. This is a delivery-side drop of a
+ *     would-be fresh chat, not an echo/notification concern.
  *   - actor = `our-app-bot`: `kind: "existing"` rows are kept so follow-up
  *     events on entities the agent opened still reach the chat through the
  *     subscription path; `kind: "new"` rows are dropped to avoid forking a
@@ -327,7 +332,28 @@ export async function resolveAudience(
     // identity-based echo cannot reliably tell an agent's own write from a
     // human's. Notification-layer exclusion is best-effort — at worst it
     // re-wakes the actor once; it never drops an event.
-    return audience.map((a) => ({ ...a, actorAgentId: actor.agentId }));
+    //
+    // Creator carve-out: a creation event ("opened" — `pull_request.opened`,
+    // `issues.opened`, `discussion.created`) never mints a *fresh* chat for
+    // its own creator. The creator IS the actor; it binds the entity it just
+    // created through an explicit `github follow` (an `agent_declared`
+    // mapping), which arrives on the subscribed path as a `kind: "existing"`
+    // row and survives the #766 opened carve-out as the creation-confirmation
+    // card. Minting a second, dispatcher-owned chat for the same creator on
+    // the same PR (because the creator self-assigned / self-@mentioned in the
+    // opened payload) is a duplicate — it surfaced once #942 stopped
+    // echo-dropping the actor's audience row. So drop ONLY the actor's own
+    // `kind: "new"` involvement, and ONLY on creation events. Other involved
+    // humans (a reviewer/assignee who is NOT the creator) still get their
+    // chat, the actor's `existing` subscriptions (its followed chat) are
+    // untouched, and non-creation self-mentions — an agent pinging its own
+    // delegate in a comment (#345) — still route. This filtering is part of
+    // before-delivery audience resolution (Stage 2), so it completes before
+    // any chat is minted or card is sent (S8).
+    const isCreation = event.kind === "opened";
+    return audience
+      .filter((a) => !(isCreation && a.kind === "new" && a.humanAgentId === actor.agentId))
+      .map((a) => ({ ...a, actorAgentId: actor.agentId }));
   }
   return audience;
 }


### PR DESCRIPTION
## Problem

`@liuchao-001` reported: after an agent submits a new PR, the GitHub dispatcher **also** starts a new chat for it — a regression that appeared after GitHub echo handling changed.

Root cause is **#942**. That refactor moved echo suppression from the **audience layer** to the **notification layer**, so it no longer drops the actor's audience row. When a creator opens a PR under its own GitHub identity and self-assigns / self-@mentions itself in the opened payload, its login lands in `involves` and produces a `kind:"new"` audience row. Pre-#942 that row was dropped at the audience layer (no chat minted); post-#942 it survives, so the dispatcher mints a **fresh chat for the creator** — duplicating the chat the creator already binds via `github follow`.

## Fix

In `resolveAudience` (Stage 2, **before delivery**), the `actor=agent` branch now drops the actor's **own** `kind:"new"` involvement on creation events (`kind:"opened"` — `pull_request.opened`, `issues.opened`, `discussion.created`). The creator binds the entity it just opened **solely through explicit `github follow`**, never through a dispatcher-minted chat.

Scope is deliberately narrow:
- only the actor's **own** fresh involvement is dropped — other humans named in the opened payload still get their chat (real reviewer / mention routing is preserved);
- the actor's **existing** follow subscriptions (its followed chat + the #766 declared opened-confirmation card) are untouched;
- **non-creation** self-mentions (an agent pinging its own delegate in a comment, #345) still route.

This restores the pre-#942 "creator gets no fork" outcome, but as a deliberate audience drop scoped to the creator + creation events — not an echo/notification drop, and never silencing another recipient.

## Tests

3 new cases in `github-audience.test.ts`, matching QA's regression suite:
- **TC1** — creator self-mention/self-assign on `opened` → actor's own `kind:"new"` row dropped (empty audience when nobody else involved).
- **TC2** — creator already has an `agent_declared` follow mapping → its followed chat is kept, only the duplicate `kind:"new"` is dropped.
- **TC3** — a *different* human mentioned in the same `opened` payload still gets its `kind:"new"` chat (no friendly-fire on real reviewers/mentions).

Verification: `pnpm --filter @first-tree/server typecheck` ✓, all **284** github tests ✓, biome ✓.

QA independently reproduced on `origin/main ff165e4c4` (signed `pull_request.opened` with `sender == pull_request.user == mention` → `newChats=1`, `bound_via=direct`, creator delegate notified) and confirmed the no-mention and existing-follow negative cases.

## Context Tree

Decision reflected in the tree (companion PR, cross-linked below): adds semantic **S11** ("the creator binds by follow, never by dispatch") to `system/cloud/github/github-entity-chat-binding.md` and updates the "Creation races are converged" rationale. That node is `decisionLocksCode: true`; the change was directed by a node owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Companion tree PR:** agent-team-foundation/first-tree-context#571
