### PR TITLE
release: bump apps/cli to v0.5.7

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "first-tree-dev",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "type": "module",
   "description": "First Tree — unified CLI for Context Tree onboarding, agent management, and team messaging. (Source-tree dev build; CI rewrites `name` and `bin` for prod / staging publishes — see docs/local-dev-isolation.md.)",
   "keywords": [


### PR DESCRIPTION
## Release bump: apps/cli `0.5.6` → `0.5.7`

Maintainer-only stable release per the `first-tree-prod-release` flow. Diff touches **only** `apps/cli/package.json` `version`; package name stays `first-tree-dev` (CI rewrites to `first-tree` on the `vX.Y.Z` tag).

### Draft GitHub Release
- **Tag:** `v0.5.7`
- **Title:** `v0.5.7 — Onboarding revamp, chat send/ask/update, GitHub follow CLI`

### Draft release notes

## Highlights

- **Onboarding revamp.** Setup is reframed as "connect your coding agent": ceremonial welcome for admins and invitees, restructured connect steps (Install First Tree → Create agent → Connect GitHub), idempotent server-side kickoff endpoint, connected-account confirmation, and a per-org draft for onboarding repo selection.
- **Agent ↔ human comms split into `chat send` / `chat ask` / `chat update`.** `chat ask` raises a tracked, blocking open question with a docked answer surface; `chat update` upgrades the chat description into a living status report. Open-question prompts render markdown with clamping and caps.
- **Explicit GitHub follow/unfollow.** A `github follow` / `unfollow` CLI replaces session-event auto-binding; GitHub entity titles show in the chat right sidebar.
- **Context Tree authorship & attribution.** Ships the `first-tree-write` skill, detects Context Tree writes from git status, attributes refs by git repo identity, and moves agent-managed source repos under `<workspace>/source-repos/<name>`.
- **"New version available" refresh chip** in the web topbar.
- **Web inspection panel**, dark login page, identicon/pixel avatars, reworked jump-to palette.

## Notable fixes

- Server no longer mints a second chat for a PR's own creator.
- Inbox delivery hardening (terminal ack, fair delivery windows, ack-recovery scheduling, delivery-status index).
- TUI suspend/resume hardening.
- Removed agent re-bind; `login --override` rotates local client identity.
- Chat description guarded against literal `\n` escapes.

### Verification
- `pnpm check` → exit 0 (3 pre-existing biome warnings, unrelated to this diff)
- `pnpm typecheck` → exit 0

### Post-merge steps
1. Wait for `CI` to pass on the merge commit on `main`.
2. After human confirms version/title/body/target SHA, create lightweight tag + GitHub Release `v0.5.7` pointing at the merge SHA.
3. Verify the tag-triggered `npm Publish` (`Publish Command Prod` success; staging/alpha skipped) and `Docker` build; confirm `npm view first-tree version` = `0.5.7`.
4. Remind human to deploy on CapRover; image `ghcr.io/agent-team-foundation/first-tree:0.5.7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
