### PR TITLE
feat(web): return to last-used org on returning sign-in (+ onboarding copy polish)

### DIFF
--- a/packages/server/src/__tests__/github-app-callback-target-org.test.ts
+++ b/packages/server/src/__tests__/github-app-callback-target-org.test.ts
@@ -177,6 +177,11 @@ describe("/auth/github/callback honors targetOrganizationId in the state (codex 
       // Caller's `next` is preserved (the Settings page), not rewritten to "/".
       expect(params.get("next")).toBe("/settings/github");
       expect(params.get("joinPath")).toBe("returning");
+      // The install target is a deliberate destination: even though the join
+      // path reads as "returning", the org must be pinned so the SPA activates
+      // the just-bound org instead of restoring the user's last-used one.
+      expect(params.get("org")).toBe(orgBId);
+      expect(params.get("orgPinned")).toBe("1");
     } finally {
       restore();
     }

--- a/packages/server/src/__tests__/oauth-flow.test.ts
+++ b/packages/server/src/__tests__/oauth-flow.test.ts
@@ -52,6 +52,9 @@ describe("GitHub OAuth onboarding flow", () => {
     // The callback carries the resolved org back so the web selects it
     // (overriding any stale localStorage org) — here the freshly-minted team.
     expect(params.get("org")).toBe(orgRow.id);
+    // A fresh solo signup is a deliberate destination — pinned so the SPA
+    // activates the just-minted org rather than a stale last-used selection.
+    expect(params.get("orgPinned")).toBe("1");
 
     // The new user is its admin.
     const memberRows = await app.db.select().from(members).where(eq(members.organizationId, orgRow.id));
@@ -255,6 +258,8 @@ describe("GitHub OAuth invite-only single-org entry gate", () => {
     // The invited org is carried back in the fragment so the web makes it the
     // active selection instead of dropping the invitee into a stale org.
     expect(params.get("org")).toBe(allowedOrganizationId);
+    // An invite redemption is a deliberate destination — pinned.
+    expect(params.get("orgPinned")).toBe("1");
 
     const userId = await findGithubUserId(app, "1201");
     const memberRows = await app.db.select().from(members).where(eq(members.userId, userId));
@@ -324,6 +329,9 @@ describe("GitHub OAuth invite-only single-org entry gate", () => {
     const fragment = res.headers.location?.split("#")[1] ?? "";
     const params = new URLSearchParams(fragment);
     expect(params.get("joinPath")).toBe("returning");
+    // A plain returning sign-in is NOT pinned: the SPA keeps the user's
+    // own last-used org selection rather than activating the callback org.
+    expect(params.get("orgPinned")).toBeNull();
   });
 });
 

--- a/packages/server/src/api/auth/github.ts
+++ b/packages/server/src/api/auth/github.ts
@@ -424,6 +424,13 @@ async function completeOauthFlow(
   const inviteMatch = /^\/invite\/([^/?#]+)/.exec(next);
   let resolved = false;
   let resolvedOrganizationId: string | null = null;
+  // Whether the resolved org is a *deliberate* destination the SPA must
+  // activate (invite link, fresh solo signup, or an App-install target),
+  // versus a plain returning sign-in whose org the client restores from its
+  // own last-used selection. `joinPath` cannot carry this on its own: the
+  // App-install target path keeps `joinPath="returning"` (it reuses the
+  // caller's Settings `next`) yet still names a specific org to pin.
+  let orgPinned = false;
 
   if (inviteMatch?.[1]) {
     const token = inviteMatch[1];
@@ -452,6 +459,7 @@ async function completeOauthFlow(
     joinPath = "invite";
     resolved = true;
     resolvedOrganizationId = inv.organizationId;
+    orgPinned = true;
     // Drop the now-consumed invite path; land on the team dashboard so the
     // onboarding modal can layer on top.
     next = "/";
@@ -529,7 +537,12 @@ async function completeOauthFlow(
     resolved = true;
     resolvedOrganizationId = targetOrganizationId;
     // joinPath stays "returning"; keep caller's `next` (the Settings page)
-    // so the panel re-renders with the now-bound installation.
+    // so the panel re-renders with the now-bound installation. Pin the org
+    // explicitly: this is a deliberate App-install destination, so the SPA
+    // must activate the just-bound org even though the join path reads as a
+    // returning sign-in — otherwise a concurrent org switch in another tab
+    // would land the Settings page on the user's last-used org instead.
+    orgPinned = true;
   } else {
     const primary = await pickPrimaryMembership(app.db, userId);
     if (primary) {
@@ -553,6 +566,7 @@ async function completeOauthFlow(
       joinPath = "solo";
       resolved = true;
       resolvedOrganizationId = personal.organizationId;
+      orgPinned = true;
       next = "/";
       // Onboarding funnel: structured log marker. Picked up by logfire/otel
       // pipelines via `event: "onboarding.team_created"` for funnel views.
@@ -633,10 +647,12 @@ async function completeOauthFlow(
   const tokens = await signTokensForUser(app.config.secrets.jwtSecret, userId, app.config.auth);
 
   // Carry the org this callback resolved to (the invited org for an invite
-  // link, otherwise the user's primary/personal org) so the web can make it
-  // the active selection. Without this the client keeps whatever stale org
-  // sits in `localStorage.selectedOrganizationId`, dropping an invitee into
-  // their *previous* org instead of the one they just joined.
+  // link, an App-install target, otherwise the user's primary/personal org)
+  // so the web can make it the active selection. `orgPinned=1` marks the
+  // deliberate destinations (invite / solo / install-target) the SPA must
+  // activate; without it the client keeps its own last-used selection, which
+  // is the intended behaviour for a plain returning sign-in but would drop an
+  // invitee — or an install-return — into their *previous* org.
   const fragmentParams: Record<string, string> = {
     access: tokens.accessToken,
     refresh: tokens.refreshToken,
@@ -644,6 +660,7 @@ async function completeOauthFlow(
     joinPath,
   };
   if (resolvedOrganizationId) fragmentParams.org = resolvedOrganizationId;
+  if (orgPinned) fragmentParams.orgPinned = "1";
   const fragment = new URLSearchParams(fragmentParams).toString();
   return reply.redirect(`/auth/github/complete#${fragment}`, 302);
 }

--- a/packages/web/src/api/client.ts
+++ b/packages/web/src/api/client.ts
@@ -17,6 +17,16 @@ export function setApiSelectedOrganizationId(value: string | null): void {
 }
 
 /**
+ * The currently-selected org id, as the AuthProvider keeps it in sync (mount,
+ * /me reconcile, switch, logout). The single source of truth for non-React
+ * consumers (e.g. the admin websocket) — read this instead of localStorage,
+ * which is now keyed per user and not safe to read by a fixed key.
+ */
+export function getApiSelectedOrganizationId(): string | null {
+  return selectedOrganizationId;
+}
+
+/**
  * Prefix an org-scoped path with `/orgs/<currentOrgId>/`. Use this on every
  * call that targets a resource living inside the user's currently-viewed
  * organization. Paths that aren't org-scoped (`/me/...`, `/auth/...`,

--- a/packages/web/src/auth/__tests__/auth-context-provider.test.tsx
+++ b/packages/web/src/auth/__tests__/auth-context-provider.test.tsx
@@ -166,7 +166,7 @@ afterEach(async () => {
 
 describe("AuthProvider", () => {
   it("loads stored tokens, reconciles organization selection, and exposes current membership", async () => {
-    localStorage.setItem("first-tree:selectedOrganizationId", "org-2");
+    localStorage.setItem("first-tree:selectedOrganizationId:user-1", "org-2");
     apiMocks.getStoredTokens.mockReturnValue({ accessToken: "access", refreshToken: "refresh" });
 
     await renderAuth();
@@ -179,7 +179,7 @@ describe("AuthProvider", () => {
   });
 
   it("does not fall back to another membership's onboarding stamps when selected membership stamps are null", async () => {
-    localStorage.setItem("first-tree:selectedOrganizationId", "org-2");
+    localStorage.setItem("first-tree:selectedOrganizationId:user-1", "org-2");
     apiMocks.getStoredTokens.mockReturnValue({ accessToken: "access", refreshToken: "refresh" });
     apiMocks.apiGet.mockResolvedValueOnce({
       user: { id: "user-1", username: "gandy", displayName: "Gandy", avatarUrl: null },
@@ -224,7 +224,7 @@ describe("AuthProvider", () => {
     await act(async () => {
       await latestAuth?.selectOrganization("org-2");
     });
-    expect(localStorage.getItem("first-tree:selectedOrganizationId")).toBe("org-2");
+    expect(localStorage.getItem("first-tree:selectedOrganizationId:user-1")).toBe("org-2");
     expect(apiMocks.setApiSelectedOrganizationId).toHaveBeenCalledWith("org-2");
 
     await act(async () => {
@@ -233,6 +233,64 @@ describe("AuthProvider", () => {
     expect(apiMocks.clearStoredTokens).toHaveBeenCalled();
     expect(flagsMocks.clearOnboardingSessionFlags).toHaveBeenCalled();
     expect(latestAuth?.isAuthenticated).toBe(false);
+  });
+
+  it("keeps the persisted org across logout so a returning sign-in lands back in the last-used org", async () => {
+    // /me's default (most-recent) is org-1, but the user last used org-2.
+    localStorage.setItem("first-tree:selectedOrganizationId:user-1", "org-2");
+    apiMocks.getStoredTokens.mockReturnValue({ accessToken: "access", refreshToken: "refresh" });
+
+    await renderAuth();
+    expect(latestAuth?.currentMembership?.organizationId).toBe("org-2");
+
+    // Logout must NOT wipe the persisted org — it's how a returning sign-in
+    // restores the last-used org instead of jumping to the most-recent one.
+    await act(async () => {
+      window.dispatchEvent(new CustomEvent("auth:logout"));
+    });
+    expect(latestAuth?.isAuthenticated).toBe(false);
+    expect(localStorage.getItem("first-tree:selectedOrganizationId:user-1")).toBe("org-2");
+
+    // Returning sign-in: fetchMe restores org-2, not the server default org-1.
+    apiMocks.setApiSelectedOrganizationId.mockClear();
+    await act(async () => {
+      await latestAuth?.adoptTokens({ accessToken: "access-2", refreshToken: "refresh-2" });
+    });
+    await flush();
+    expect(latestAuth?.currentMembership?.organizationId).toBe("org-2");
+    expect(apiMocks.setApiSelectedOrganizationId).toHaveBeenLastCalledWith("org-2");
+  });
+
+  it("falls back to the server default when the persisted org is no longer a membership", async () => {
+    // Stored org the user has since left → must fall back to /me's default.
+    localStorage.setItem("first-tree:selectedOrganizationId:user-1", "org-gone");
+    apiMocks.getStoredTokens.mockReturnValue({ accessToken: "access", refreshToken: "refresh" });
+
+    await renderAuth();
+
+    expect(latestAuth?.currentMembership?.organizationId).toBe("org-1");
+    expect(localStorage.getItem("first-tree:selectedOrganizationId:user-1")).toBe("org-1");
+  });
+
+  it("does not let a different user on the same browser inherit the previous account's org", async () => {
+    // user-1 left org-2 persisted. Now user-2 signs in on the same browser and
+    // is ALSO an active member of org-2 — so a global (non-user-scoped) key
+    // would leak. The per-user key must isolate them: user-2 lands in the
+    // server default, and user-1's stored value is untouched.
+    localStorage.setItem("first-tree:selectedOrganizationId:user-1", "org-2");
+    apiMocks.getStoredTokens.mockReturnValue({ accessToken: "access", refreshToken: "refresh" });
+    apiMocks.apiGet.mockResolvedValueOnce({
+      user: { id: "user-2", username: "other", displayName: "Other", avatarUrl: null },
+      memberships: MEMBERSHIPS,
+      defaultOrganizationId: "org-1",
+      onboarding: { step: "completed", dismissedAt: null, completedAt: "2026-05-01T00:00:00.000Z" },
+    });
+
+    await renderAuth();
+
+    expect(latestAuth?.currentMembership?.organizationId).toBe("org-1");
+    expect(localStorage.getItem("first-tree:selectedOrganizationId:user-1")).toBe("org-2");
+    expect(localStorage.getItem("first-tree:selectedOrganizationId:user-2")).toBe("org-1");
   });
 
   it("optimistically dismisses, restores, and completes onboarding with rollback on patch failure", async () => {

--- a/packages/web/src/auth/auth-context.tsx
+++ b/packages/web/src/auth/auth-context.tsx
@@ -144,18 +144,45 @@ export const AuthContext = createContext<AuthContextValue | null>(null);
 
 const SELECTED_ORG_KEY = "first-tree:selectedOrganizationId";
 
-function readSelectedOrgId(): string | null {
+// The persisted org selection is scoped per user — keyed by `${SELECTED_ORG_KEY}:${userId}`
+// — so a shared browser never lets one account inherit another's last-used team
+// (two accounts can be members of the same org, so validating "is an active
+// membership" is not enough). The userId comes from the access token's `sub`
+// claim (a plain JWT, no decode lib needed) so the first-paint pre-seed can read
+// the right key before /me resolves.
+function userIdFromToken(): string | null {
   try {
-    return localStorage.getItem(SELECTED_ORG_KEY);
+    const payload = getStoredTokens()?.accessToken?.split(".")[1];
+    if (!payload) return null;
+    const decoded: unknown = JSON.parse(atob(payload.replace(/-/g, "+").replace(/_/g, "/")));
+    if (typeof decoded === "object" && decoded !== null && "sub" in decoded) {
+      const sub = decoded.sub;
+      return typeof sub === "string" ? sub : null;
+    }
+    return null;
   } catch {
     return null;
   }
 }
 
-function writeSelectedOrgId(value: string | null): void {
+function orgStorageKey(userId: string): string {
+  return `${SELECTED_ORG_KEY}:${userId}`;
+}
+
+function readSelectedOrgId(userId: string | null): string | null {
+  if (!userId) return null;
   try {
-    if (value === null) localStorage.removeItem(SELECTED_ORG_KEY);
-    else localStorage.setItem(SELECTED_ORG_KEY, value);
+    return localStorage.getItem(orgStorageKey(userId));
+  } catch {
+    return null;
+  }
+}
+
+function writeSelectedOrgId(userId: string | null, value: string | null): void {
+  if (!userId) return;
+  try {
+    if (value === null) localStorage.removeItem(orgStorageKey(userId));
+    else localStorage.setItem(orgStorageKey(userId), value);
   } catch {
     // localStorage may be denied in private mode — ignore.
   }
@@ -167,7 +194,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<MeUser | null>(null);
   const [memberships, setMemberships] = useState<MeMembership[]>([]);
   const [selectedOrgId, setSelectedOrgId] = useState<string | null>(() => {
-    const init = readSelectedOrgId();
+    const init = readSelectedOrgId(userIdFromToken());
     // Sync the API client's module-level override on first paint so the
     // first wave of requests (made before fetchMe resolves) already carries
     // the correct `?organizationId=` query (codex P1 #2 fix).
@@ -185,7 +212,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const logout = useCallback(() => {
     clearStoredTokens();
-    writeSelectedOrgId(null);
+    // Keep the persisted last-used org (no writeSelectedOrgId(null) here) so a
+    // returning sign-in lands back in the org this user left rather than their
+    // most-recently-joined one. It's stored per-user (keyed by the token's
+    // `sub`), so a different account on the same browser can never inherit it.
+    // Clear only the in-memory + API-client selection so nothing org-scoped
+    // fires before the next fetchMe reconciles.
     setApiSelectedOrganizationId(null);
     queryClient.clear();
     // Drop per-tab onboarding flags so the next login (different user, or
@@ -221,16 +253,25 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       // stale "you've joined {team}" headline that no longer fits.
       if (nextStep === "completed") clearOnboardingJoinPath();
 
-      // Reconcile selectedOrgId: stored value wins if still valid, else
-      // /me's `defaultOrganizationId`, else the first active membership.
+      // Reconcile selectedOrgId, each candidate only if it's still an active
+      // membership: (1) the in-memory selection, (2) this user's persisted
+      // last-used org — survives logout so a returning user lands back in the
+      // org they left — then (3) /me's `defaultOrganizationId` (most-recent),
+      // (4) the first active membership.
+      const userId = data.user?.id ?? null;
       setSelectedOrgId((prev) => {
-        const valid = prev && ms.some((m) => m.organizationId === prev) ? prev : null;
-        if (valid) {
-          setApiSelectedOrganizationId(valid);
-          return valid;
+        const isMember = (id: string | null): id is string => !!id && ms.some((m) => m.organizationId === id);
+        const prevValid = isMember(prev) ? prev : null;
+        const stored = readSelectedOrgId(userId);
+        const storedValid = isMember(stored) ? stored : null;
+        const candidate = prevValid ?? storedValid;
+        if (candidate) {
+          writeSelectedOrgId(userId, candidate);
+          setApiSelectedOrganizationId(candidate);
+          return candidate;
         }
         const fallback = data.defaultOrganizationId ?? ms[0]?.organizationId ?? null;
-        writeSelectedOrgId(fallback);
+        writeSelectedOrgId(userId, fallback);
         setApiSelectedOrganizationId(fallback);
         return fallback;
       });
@@ -267,7 +308,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       // Pure client-side switch — the /orgs/:orgId/* routes probe
       // membership in real time on every request, so a stale or
       // unauthorized selection just yields a clean 403 from the next call.
-      writeSelectedOrgId(organizationId);
+      // Persist under the current user's key (token `sub`) so the selection
+      // is restored only for this account.
+      writeSelectedOrgId(userIdFromToken(), organizationId);
       setApiSelectedOrganizationId(organizationId);
       // Drop every cached React Query result keyed off the previous org —
       // the next render refetches with the new prefix so a non-default org

--- a/packages/web/src/hooks/__tests__/use-admin-ws.test.tsx
+++ b/packages/web/src/hooks/__tests__/use-admin-ws.test.tsx
@@ -11,6 +11,7 @@ globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 const clientMocks = vi.hoisted(() => ({
   getStoredTokens: vi.fn(),
   refreshAccessToken: vi.fn(),
+  getApiSelectedOrganizationId: vi.fn(),
 }));
 
 vi.mock("../../api/client.js", () => clientMocks);
@@ -120,9 +121,9 @@ beforeEach(() => {
     value: { protocol: "https:", host: "first-tree.test" },
   });
   const storage = createStorage();
-  storage.setItem("first-tree:selectedOrganizationId", "org-1");
   Object.defineProperty(globalThis, "localStorage", { configurable: true, value: storage });
   Object.defineProperty(window, "localStorage", { configurable: true, value: storage });
+  clientMocks.getApiSelectedOrganizationId.mockReturnValue("org-1");
   clientMocks.getStoredTokens.mockReturnValue({ accessToken: "access-1", refreshToken: "refresh-1" });
   clientMocks.refreshAccessToken.mockResolvedValue({ accessToken: "access-2", refreshToken: "refresh-2" });
   root = null;

--- a/packages/web/src/hooks/use-admin-ws.ts
+++ b/packages/web/src/hooks/use-admin-ws.ts
@@ -2,7 +2,7 @@ import { type AgentChatStatus, agentChatStatusSchema } from "@first-tree/shared"
 import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef } from "react";
 import { chatAgentStatusQueryKey } from "../api/agent-status.js";
-import { getStoredTokens, refreshAccessToken } from "../api/client.js";
+import { getApiSelectedOrganizationId, getStoredTokens, refreshAccessToken } from "../api/client.js";
 import { upsertAgentStatus } from "../lib/agent-status-view.js";
 
 type WsMessage = {
@@ -277,16 +277,13 @@ function connect() {
   const tokens = getStoredTokens();
   if (!tokens?.accessToken) return;
 
-  // Resolve the selected org from localStorage. The org-scoped admin WS
-  // path is `/api/v1/orgs/:orgId/ws/`. If no org is selected yet, skip
-  // connecting — the hook reconnects automatically once the auth
-  // context populates `selectedOrganizationId`.
-  let orgId: string | null = null;
-  try {
-    orgId = localStorage.getItem("first-tree:selectedOrganizationId");
-  } catch {
-    orgId = null;
-  }
+  // Resolve the selected org from the API client's live value (kept in sync by
+  // the AuthProvider). The org-scoped admin WS path is
+  // `/api/v1/orgs/:orgId/ws/`. Reading localStorage directly is wrong now that
+  // the persisted key is per-user; the API-client value is the single source of
+  // truth. If no org is selected yet, skip connecting — the hook reconnects once
+  // the auth context populates the selection.
+  const orgId = getApiSelectedOrganizationId();
   if (!orgId) return;
 
   const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";

--- a/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
+++ b/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
@@ -1197,6 +1197,58 @@ describe("web DOM interaction coverage", () => {
     await unmountRoot(notAdmin.root);
   });
 
+  it("activates the callback org only when the server pins it", async () => {
+    const { OAuthCompletePage } = await import("../oauth-complete.js");
+    Object.defineProperty(window, "history", {
+      configurable: true,
+      value: { replaceState: vi.fn() },
+    });
+
+    // A pinned destination (install-return keeps joinPath="returning" yet
+    // names a specific org): the SPA must activate it, otherwise a concurrent
+    // org switch would strand the Settings page on the user's last-used org.
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        ...window.location,
+        hash: "#access=a&refresh=r&next=/settings/github&joinPath=returning&org=org-b&orgPinned=1",
+        pathname: "/auth/github/complete",
+      },
+    });
+    const pinnedSelect = vi.fn(async () => undefined);
+    authMock.value = {
+      ...authMock.value,
+      adoptTokens: vi.fn(async () => undefined),
+      selectOrganization: pinnedSelect,
+    };
+    const pinned = await renderDom(<OAuthCompletePage />, "/auth/github/complete");
+    await flush();
+    expect(pinnedSelect).toHaveBeenCalledWith("org-b");
+    await unmountRoot(pinned.root);
+
+    // A plain returning sign-in carries no pin: the SPA keeps the user's own
+    // last-used org (restored by adoptTokens → fetchMe) instead of activating
+    // the callback's default org.
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        ...window.location,
+        hash: "#access=a&refresh=r&next=/&joinPath=returning&org=org-default",
+        pathname: "/auth/github/complete",
+      },
+    });
+    const plainSelect = vi.fn(async () => undefined);
+    authMock.value = {
+      ...authMock.value,
+      adoptTokens: vi.fn(async () => undefined),
+      selectOrganization: plainSelect,
+    };
+    const plain = await renderDom(<OAuthCompletePage />, "/auth/github/complete");
+    await flush();
+    expect(plainSelect).not.toHaveBeenCalled();
+    await unmountRoot(plain.root);
+  });
+
   it("renders SettingsOnboardingPage resume, hide, disabled, and completed states", async () => {
     const { SettingsOnboardingPage } = await import("../settings/onboarding.js");
 

--- a/packages/web/src/pages/oauth-complete.tsx
+++ b/packages/web/src/pages/oauth-complete.tsx
@@ -50,11 +50,14 @@ export function OAuthCompletePage() {
     const refreshToken = params.get("refresh");
     const next = safeRedirectPath(params.get("next"));
     const joinPath = params.get("joinPath");
-    // The org this callback resolved to. We pin it only for a *deliberate*
-    // join — an invite link or a fresh solo signup (joinPath !== "returning").
-    // A plain returning sign-in resolves to the user's default (most-recent)
-    // org, which we do NOT pin: fetchMe restores the org they last used instead.
+    // The org this callback resolved to. We activate it only when the server
+    // flags it as a *deliberate* destination via `orgPinned=1` — an invite
+    // link, a fresh solo signup, or an App-install target. A plain returning
+    // sign-in carries no pin: fetchMe restores the org the user last used.
+    // (We can't key off `joinPath` here — an install-return keeps
+    // joinPath="returning" yet still pins a specific org.)
     const org = params.get("org");
+    const orgPinned = params.get("orgPinned") === "1";
     const errorCode = params.get("error");
 
     if (errorCode) {
@@ -81,12 +84,13 @@ export function OAuthCompletePage() {
 
     void (async () => {
       await adoptTokens({ accessToken, refreshToken });
-      // Pin the resolved org BEFORE navigating only for a deliberate join, so
-      // the workspace/onboarding gate evaluates against the just-joined org.
-      // For a plain returning sign-in we skip it: adoptTokens → fetchMe already
-      // restored the user's last-used org (falling back to the server default
-      // when there's no valid one), and pinning here would clobber it.
-      if (org && joinPath !== "returning") await selectOrganization(org);
+      // Activate the resolved org BEFORE navigating only when the server pinned
+      // it (deliberate join / install-return), so the workspace/onboarding gate
+      // evaluates against the just-joined org. For a plain returning sign-in we
+      // skip it: adoptTokens → fetchMe already restored the user's last-used org
+      // (falling back to the server default when there's no valid one), and
+      // selecting here would clobber it.
+      if (org && orgPinned) await selectOrganization(org);
       navigate(next, { replace: true });
     })();
   }, [adoptTokens, selectOrganization, navigate]);

--- a/packages/web/src/pages/oauth-complete.tsx
+++ b/packages/web/src/pages/oauth-complete.tsx
@@ -50,10 +50,10 @@ export function OAuthCompletePage() {
     const refreshToken = params.get("refresh");
     const next = safeRedirectPath(params.get("next"));
     const joinPath = params.get("joinPath");
-    // The org this callback resolved to (invited org for an invite link).
-    // Selecting it overrides any stale `selectedOrganizationId` left in
-    // localStorage so an invitee lands in the org they just joined, not a
-    // previously-used one.
+    // The org this callback resolved to. We pin it only for a *deliberate*
+    // join — an invite link or a fresh solo signup (joinPath !== "returning").
+    // A plain returning sign-in resolves to the user's default (most-recent)
+    // org, which we do NOT pin: fetchMe restores the org they last used instead.
     const org = params.get("org");
     const errorCode = params.get("error");
 
@@ -81,9 +81,12 @@ export function OAuthCompletePage() {
 
     void (async () => {
       await adoptTokens({ accessToken, refreshToken });
-      // Set the active org BEFORE navigating so the workspace/onboarding
-      // gate evaluates against the just-joined org rather than a stale one.
-      if (org) await selectOrganization(org);
+      // Pin the resolved org BEFORE navigating only for a deliberate join, so
+      // the workspace/onboarding gate evaluates against the just-joined org.
+      // For a plain returning sign-in we skip it: adoptTokens → fetchMe already
+      // restored the user's last-used org (falling back to the server default
+      // when there's no valid one), and pinning here would clobber it.
+      if (org && joinPath !== "returning") await selectOrganization(org);
       navigate(next, { replace: true });
     })();
   }, [adoptTokens, selectOrganization, navigate]);

--- a/packages/web/src/pages/onboarding-preview.tsx
+++ b/packages/web/src/pages/onboarding-preview.tsx
@@ -48,7 +48,7 @@ const ORG_ID = "org-acme";
 // review and matches the file's existing "Gandy" persona (DEFAULT_AGENT_NAME).
 const TEAM_NAME = "Gandy's team";
 const TREE_URL = "https://github.com/acme/context-tree";
-const DEFAULT_AGENT_NAME = "Gandy's assistant";
+const DEFAULT_AGENT_NAME = "gandy assistant";
 // Mirror the real prod bootstrap shape (server fills the channel's actual
 // package + bin name — `first-tree` on prod; see api/me.ts) so the gallery
 // reads true for design review instead of showing literal <package>/<binName>

--- a/packages/web/src/pages/onboarding/copy.ts
+++ b/packages/web/src/pages/onboarding/copy.ts
@@ -376,14 +376,15 @@ export const COPY = {
       post: " — let's bring your coding agent (Claude Code, Codex) onto the team.",
     },
     nextSteps: ["Install First Tree", "Create your first agent", "Start working"],
-    // Title states the fact; the body leads with the action, not the wait. In the
-    // default-none world the most common not-ready cause is "admin finished
-    // without a tree", which never resolves — so "Meet your agent" is the real
-    // path forward (the primary CTA), and the auto-advance is a quiet conditional
-    // footnote (notReadyStatus), never a "coming soon" promise the team may break.
+    // Title states the fact; the body names the cause (the admin's First Tree
+    // setup) and leads with the reassurance — you can start now. The most common
+    // not-ready cause is "admin finished without a tree", which never resolves,
+    // so "Meet your agent" is the real path forward (the primary CTA). The page
+    // still advances on its own if the team does finish, but we no longer
+    // announce it — a "coming soon" promise the team may break reads worse than
+    // a quiet hand-off.
     notReadyTitle: "Your team is still setting up",
-    notReadyBody: "No need to wait — meet your agent now.",
-    notReadyStatus: "This page continues on its own if your team finishes setup.",
+    notReadyBody: "Your admin is still setting up the team on First Tree — but you can meet your agent now.",
     // The primary action on the not-ready screen — start an intro chat now
     // instead of waiting on the team.
     startAnyway: "Meet your agent",

--- a/packages/web/src/pages/onboarding/onboarding-flow.tsx
+++ b/packages/web/src/pages/onboarding/onboarding-flow.tsx
@@ -182,7 +182,7 @@ export function OnboardingFlowProvider({ path, children }: { path: OnboardingPat
   } = useAgentCreation(onAgentOnline);
 
   const [agentDisplayName, setAgentDisplayName] = useState<string>(() =>
-    user?.username ? `${user.username}'s assistant` : "Assistant",
+    user?.username ? `${user.username} assistant` : "Assistant",
   );
   const [visibility, setVisibility] = useState<AgentVisibility>("organization");
   // Hydrate the repo selection from this org's saved draft so a bailout before

--- a/packages/web/src/pages/onboarding/steps/step-kickoff.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-kickoff.tsx
@@ -544,16 +544,14 @@ function InviteeNotReady() {
         )}
         {/* "Meet your agent" is the PRIMARY action, not an escape hatch: the
             common not-ready case (admin finished without a tree) never resolves,
-            so the real path forward is to start now. The auto-advance — if the
-            team does finish — is the quiet status footnote below, never the
-            headline. */}
+            so the real path forward is to start now. If the team does finish,
+            the page still advances on its own — quietly, no longer announced. */}
         <div className="flex">
           <Button type="button" variant="cta" onClick={() => void handleMeet()}>
             <span>{COPY.invitee.startAnyway}</span>
             <ArrowRight className="h-4 w-4" />
           </Button>
         </div>
-        <StatusRow state="waiting" label={COPY.invitee.notReadyStatus} />
       </div>
     </div>
   );


### PR DESCRIPTION
## What & why

Onboarding / sign-in changes. Mostly client-side (web); one small server change adds a signal the SPA needs (see #4).

### 1. Return to last-used org on a returning sign-in (the main change)
Previously a returning user always landed in their **most-recently-joined** org. Now they land in the org they **last worked in**.

- **Per-user persistence.** The selected org is stored under `first-tree:selectedOrganizationId:<userId>` (userId decoded from the access-token `sub`), so it survives logout **and** never leaks across accounts on a shared browser — two accounts can both be members of the same org, so validating "is an active membership" was not enough on its own.
- **Reconcile order** in `fetchMe`: in-memory selection → this user's last-used → `/me` default (most-recent) → first membership; each only if still an active membership.
- **Admin websocket** reads the live selected org from the api client (`getApiSelectedOrganizationId()`) instead of the raw localStorage key, which is now per-user.

### 2. Default agent name drops the possessive
`<username>'s assistant` → `<username> assistant` (falls back to `Assistant`). Preview-gallery fixture matches.

### 3. Invitee "team not ready" copy
Subtitle now says the admin is still setting up the team on First Tree but the invitee can meet their agent now. Removed the "this page continues on its own" footnote — the page still auto-advances, it just no longer promises it.

### 4. Server `orgPinned` signal so the SPA can tell deliberate destinations apart
A plain returning sign-in must **not** clobber the user's last-used org, but an invite / fresh solo signup / **GitHub-App install-return** must still activate the org the callback resolved to. These can't be told apart from `joinPath` alone: the Settings-initiated install-return path keeps `joinPath="returning"` (it reuses the caller's Settings `next`) yet names a specific target org.

The GitHub callback now emits `orgPinned=1` in the post-OAuth fragment for the deliberate destinations (invite / solo / install-target) and omits it for a plain returning sign-in. `oauth-complete` activates the callback org **only when `orgPinned` is set** — so a plain returning sign-in restores the last-used org, while an install/invite return reaches its target. This replaces the earlier `joinPath !== "returning"` gate, which regressed the install-return case (a concurrent org switch in another tab could land `/settings/github` on the user's last-used org instead of the just-bound one).

## Scope
The "last-used org" persistence is localStorage, so it does not sync across devices/browsers; a fresh device falls back to the server default (most-recent). The only server change is the additive `orgPinned` fragment flag — no schema, no migration.

## Testing
- `pnpm check` (biome) — clean on all touched files
- `pnpm typecheck` — server + web clean (incl. web design-token guardrails)
- **server:** full suite **1483/1483** pass. Install-target callback asserts `org` + `orgPinned=1`; solo & invite assert `orgPinned=1`; plain returning asserts `orgPinned` absent.
- **web:** full suite **834/834** pass. `OAuthCompletePage` activates the org when `orgPinned=1` (even with `joinPath="returning"`) and skips selection for a plain returning sign-in; `auth-context-provider` (last-used-restore / fallback-when-left / cross-user-isolation) + `use-admin-ws` pass.
- Onboarding copy + default-agent-name verified in the DEV `/preview/onboarding` gallery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)