### PR TITLE
feat(web): staging-only toggle to hide agent final-text mirrors

### DIFF
--- a/packages/server/src/__tests__/agent-final-text-purpose.test.ts
+++ b/packages/server/src/__tests__/agent-final-text-purpose.test.ts
@@ -81,6 +81,51 @@ describe("sendMessage — agent-final-text bypass (v1 §四 改造 4 b)", () => 
     }
   });
 
+  it("persists metadata.agentFinalText=true so the web can identify final-text mirror rows", async () => {
+    const app = getApp();
+    const owner = await createTestAgent(app, { type: "human" });
+    const peerA = await createTestAgent(app, { type: "agent" });
+    const peerB = await createTestAgent(app, { type: "agent" });
+
+    const chat = await createChat(app.db, owner.agent.uuid, {
+      type: "group",
+      participantIds: [peerA.agent.uuid, peerB.agent.uuid],
+    });
+
+    const r = await sendMessage(app.db, chat.id, peerA.agent.uuid, {
+      source: "api",
+      format: "text",
+      content: "i am done — turn ended",
+      purpose: "agent-final-text",
+    });
+
+    expect(r.message.metadata.agentFinalText).toBe(true);
+  });
+
+  it("does NOT mark a normal agent send, and strips a client-smuggled agentFinalText flag", async () => {
+    const app = getApp();
+    const owner = await createTestAgent(app, { type: "human" });
+    const peerA = await createTestAgent(app, { type: "agent" });
+    const peerB = await createTestAgent(app, { type: "agent" });
+
+    const chat = await createChat(app.db, owner.agent.uuid, {
+      type: "group",
+      participantIds: [peerA.agent.uuid, peerB.agent.uuid],
+    });
+
+    // A deliberate agent send (has a recipient, no purpose) that tries to
+    // smuggle the flag in via metadata. The flag is server-owned, so it must
+    // be stripped — a real `chat send` must never look like a final-text row.
+    const r = await sendMessage(app.db, chat.id, peerA.agent.uuid, {
+      source: "api",
+      format: "text",
+      content: `@${peerB.agent.name} please look`,
+      metadata: { mentions: [peerB.agent.uuid], agentFinalText: true },
+    });
+
+    expect(r.message.metadata.agentFinalText).toBeUndefined();
+  });
+
   it("still 400s when purpose is absent and no mentions declared (regression guard for the enforce rule)", async () => {
     const app = getApp();
     const owner = await createTestAgent(app, { type: "human" });

--- a/packages/server/src/__tests__/agent-final-text-purpose.test.ts
+++ b/packages/server/src/__tests__/agent-final-text-purpose.test.ts
@@ -126,6 +126,29 @@ describe("sendMessage — agent-final-text bypass (v1 §四 改造 4 b)", () => 
     expect(r.message.metadata.agentFinalText).toBeUndefined();
   });
 
+  it("does NOT mark a human/web send carrying purpose='agent-final-text' (sender-type gate, R5)", async () => {
+    // `purpose` rides the shared sendMessage schema, so the human/web route
+    // (`POST /chats/:id/messages`, source="web") can set it. Such a send still
+    // takes the silent enforcement profile, but must NOT be persisted as a
+    // final-text mirror — otherwise a human send could be hidden by the toggle.
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const peer = await createTestAgent(app, { name: `r5-${crypto.randomUUID().slice(0, 6)}` });
+
+    const { chatId } = await createMeChat(app.db, admin.humanAgentUuid, admin.organizationId, {
+      participantIds: [peer.agent.uuid],
+    });
+
+    const r = await sendMessage(app.db, chatId, admin.humanAgentUuid, {
+      source: "web",
+      format: "text",
+      content: "human pretending to be final text",
+      purpose: "agent-final-text",
+    });
+
+    expect(r.message.metadata.agentFinalText).toBeUndefined();
+  });
+
   it("still 400s when purpose is absent and no mentions declared (regression guard for the enforce rule)", async () => {
     const app = getApp();
     const owner = await createTestAgent(app, { type: "human" });

--- a/packages/server/src/__tests__/bootstrap-config.test.ts
+++ b/packages/server/src/__tests__/bootstrap-config.test.ts
@@ -4,7 +4,7 @@ import { useTestApp } from "./helpers.js";
 describe("GET /bootstrap/config", () => {
   const getApp = useTestApp();
 
-  it("returns the public server command version", async () => {
+  it("returns the public server command version and release channel", async () => {
     const app = getApp();
 
     const res = await app.inject({
@@ -16,6 +16,20 @@ describe("GET /bootstrap/config", () => {
     expect(res.json()).toMatchObject({
       allowedOrg: null,
       serverCommandVersion: "test.version",
+      // Surfaced so the web can gate channel-scoped UI (e.g. the staging-only
+      // "hide agent final text" toggle). Test app defaults to the dev channel.
+      channel: "dev",
     });
+  });
+});
+
+describe("GET /bootstrap/config — non-dev channel", () => {
+  const getApp = useTestApp({ channel: "staging" });
+
+  it("reports the server's configured channel verbatim", async () => {
+    const res = await getApp().inject({ method: "GET", url: "/api/v1/bootstrap/config" });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().channel).toBe("staging");
   });
 });

--- a/packages/server/src/api/bootstrap/config.ts
+++ b/packages/server/src/api/bootstrap/config.ts
@@ -10,6 +10,13 @@ export async function bootstrapConfigRoutes(app: FastifyInstance): Promise<void>
    * installation without a caller, so the field is surfaced as `null`.
    */
   app.get("/config", async () => {
-    return { allowedOrg: null as string | null, serverCommandVersion: app.commandVersion() };
+    return {
+      allowedOrg: null as string | null,
+      serverCommandVersion: app.commandVersion(),
+      // Release channel this server speaks (`dev` | `staging` | `prod`). Lets
+      // the web gate channel-scoped affordances (e.g. the staging-only "hide
+      // agent final text" view toggle) without shipping prod-visible dev UI.
+      channel: app.config.channel,
+    };
   });
 }

--- a/packages/server/src/services/message.ts
+++ b/packages/server/src/services/message.ts
@@ -1,4 +1,5 @@
 import {
+  AGENT_FINAL_TEXT_METADATA_KEY,
   extractCaption,
   imageBatchRefContentSchema,
   imageRefContentSchema,
@@ -345,9 +346,24 @@ export function preflightMessageSendIntent(input: {
     }
   }
 
+  // Persist the final-text intent as a durable metadata flag. `purpose` is a
+  // send-time-only tag that the server consumes above but never stores, so
+  // without this stamp the web cannot tell a silent `agent-final-text` mirror
+  // apart from a deliberate agent `chat send`. The flag is SERVER-OWNED: strip
+  // any inbound client-supplied value, then set it true only for a genuine
+  // final-text mirror. The staging-only "hide agent final text" view toggle
+  // filters on it.
+  const metadataSansFlag =
+    AGENT_FINAL_TEXT_METADATA_KEY in metadataToStore
+      ? Object.fromEntries(Object.entries(metadataToStore).filter(([key]) => key !== AGENT_FINAL_TEXT_METADATA_KEY))
+      : metadataToStore;
+  const storedMetadata = isAgentFinalText
+    ? { ...metadataSansFlag, [AGENT_FINAL_TEXT_METADATA_KEY]: true }
+    : metadataSansFlag;
+
   return {
     content: outboundContent,
-    metadata: metadataToStore,
+    metadata: storedMetadata,
     mentionedAgentIds: mergedMentions,
     isAgentFinalText,
     forceSilentFanOut: purposeProfile.forceSilentFanOut,

--- a/packages/server/src/services/message.ts
+++ b/packages/server/src/services/message.ts
@@ -349,15 +349,21 @@ export function preflightMessageSendIntent(input: {
   // Persist the final-text intent as a durable metadata flag. `purpose` is a
   // send-time-only tag that the server consumes above but never stores, so
   // without this stamp the web cannot tell a silent `agent-final-text` mirror
-  // apart from a deliberate agent `chat send`. The flag is SERVER-OWNED: strip
-  // any inbound client-supplied value, then set it true only for a genuine
-  // final-text mirror. The staging-only "hide agent final text" view toggle
-  // filters on it.
+  // apart from a deliberate agent `chat send`. The flag is SERVER-OWNED:
+  //   1. strip any inbound client-supplied value, then
+  //   2. set it true ONLY for a genuine mirror — a NON-HUMAN sender with the
+  //      final-text purpose.
+  // `purpose` rides the shared send schema, so a human/web send can carry it
+  // (and gets the silent enforcement profile above) — but it must never be
+  // persisted as a mirror, matching the unread-projection's
+  // `senderRow.type !== "human"` gate. The staging-only "hide agent final
+  // text" toggle filters on this flag.
+  const isAgentFinalTextMirror = isAgentFinalText && senderType !== "human";
   const metadataSansFlag =
     AGENT_FINAL_TEXT_METADATA_KEY in metadataToStore
       ? Object.fromEntries(Object.entries(metadataToStore).filter(([key]) => key !== AGENT_FINAL_TEXT_METADATA_KEY))
       : metadataToStore;
-  const storedMetadata = isAgentFinalText
+  const storedMetadata = isAgentFinalTextMirror
     ? { ...metadataSansFlag, [AGENT_FINAL_TEXT_METADATA_KEY]: true }
     : metadataSansFlag;
 

--- a/packages/shared/src/__tests__/agent-final-text.test.ts
+++ b/packages/shared/src/__tests__/agent-final-text.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { AGENT_FINAL_TEXT_METADATA_KEY, isAgentFinalTextMetadata } from "../schemas/message.js";
+
+/**
+ * `isAgentFinalTextMetadata` is the shared reader the web uses to identify a
+ * stored agent final-text mirror row. The server stamps the matching flag at
+ * send time (see services/message.ts); both sides key off the same constant.
+ */
+describe("isAgentFinalTextMetadata", () => {
+  it("is true only when the flag is the boolean true", () => {
+    expect(isAgentFinalTextMetadata({ [AGENT_FINAL_TEXT_METADATA_KEY]: true })).toBe(true);
+  });
+
+  it("is false for a normal message (flag absent)", () => {
+    expect(isAgentFinalTextMetadata({})).toBe(false);
+    expect(isAgentFinalTextMetadata({ mentions: ["abc"] })).toBe(false);
+  });
+
+  it("is false for null / undefined metadata", () => {
+    expect(isAgentFinalTextMetadata(null)).toBe(false);
+    expect(isAgentFinalTextMetadata(undefined)).toBe(false);
+  });
+
+  it("does not treat a truthy non-true value as a final-text marker", () => {
+    expect(isAgentFinalTextMetadata({ [AGENT_FINAL_TEXT_METADATA_KEY]: "true" })).toBe(false);
+    expect(isAgentFinalTextMetadata({ [AGENT_FINAL_TEXT_METADATA_KEY]: 1 })).toBe(false);
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -502,12 +502,14 @@ export {
   updateMyProfileSchema,
 } from "./schemas/member.js";
 export {
+  AGENT_FINAL_TEXT_METADATA_KEY,
   type AskOption,
   type AskRequest,
   askOptionSchema,
   askRequestSchema,
   type ClientMessage,
   clientMessageSchema,
+  isAgentFinalTextMetadata,
   MESSAGE_FORMATS,
   MESSAGE_SOURCES,
   type Message,

--- a/packages/shared/src/schemas/message.ts
+++ b/packages/shared/src/schemas/message.ts
@@ -164,6 +164,24 @@ export type RequestResolution = z.infer<typeof requestResolutionSchema>;
 export const messagePurposeSchema = z.enum(["agent-final-text"]);
 export type MessagePurpose = z.infer<typeof messagePurposeSchema>;
 
+/**
+ * Metadata flag the server stamps on a STORED message when it was sent with
+ * `purpose: "agent-final-text"` (the runtime's per-turn final-text mirror —
+ * see client `runtime/result-sink.ts`). `purpose` itself is a send-time-only
+ * intent tag that the server consumes for enforcement and does NOT persist,
+ * so this boolean is the only durable post-save signal distinguishing a
+ * silent final-text mirror from a deliberate agent `chat send`. Server-owned:
+ * stamped only for genuine final-text mirrors and never honored from inbound
+ * client metadata. The web reads it to optionally hide final-text rows behind
+ * a staging-only view toggle; absent / false on every other message.
+ */
+export const AGENT_FINAL_TEXT_METADATA_KEY = "agentFinalText";
+
+/** True when a stored message's metadata marks it as an agent final-text mirror. */
+export function isAgentFinalTextMetadata(metadata: Record<string, unknown> | null | undefined): boolean {
+  return metadata?.[AGENT_FINAL_TEXT_METADATA_KEY] === true;
+}
+
 export const sendMessageSchema = z.object({
   format: messageFormatSchema.default("text"),
   content: z.unknown(),

--- a/packages/shared/src/schemas/message.ts
+++ b/packages/shared/src/schemas/message.ts
@@ -171,9 +171,11 @@ export type MessagePurpose = z.infer<typeof messagePurposeSchema>;
  * intent tag that the server consumes for enforcement and does NOT persist,
  * so this boolean is the only durable post-save signal distinguishing a
  * silent final-text mirror from a deliberate agent `chat send`. Server-owned:
- * stamped only for genuine final-text mirrors and never honored from inbound
- * client metadata. The web reads it to optionally hide final-text rows behind
- * a staging-only view toggle; absent / false on every other message.
+ * stamped only for a genuine mirror (a NON-HUMAN sender with the final-text
+ * purpose) and never honored from inbound client metadata, so a human/web send
+ * carrying `purpose` cannot masquerade as one. The web reads it to optionally
+ * hide final-text rows behind a staging-only view toggle; absent / false on
+ * every other message.
  */
 export const AGENT_FINAL_TEXT_METADATA_KEY = "agentFinalText";
 

--- a/packages/web/src/hooks/__tests__/use-server-channel.test.ts
+++ b/packages/web/src/hooks/__tests__/use-server-channel.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { extractChannel } from "../use-server-channel.js";
+
+/**
+ * Pure-function unit tests for the bootstrap-config channel probe. The hook
+ * wires this into React Query (fetched once, cached for the session); the
+ * staging-only toggle it gates is covered by manual e2e.
+ */
+describe("extractChannel", () => {
+  it("returns each known channel from a well-formed bootstrap config", () => {
+    expect(extractChannel({ channel: "dev" })).toBe("dev");
+    expect(extractChannel({ channel: "staging" })).toBe("staging");
+    expect(extractChannel({ channel: "prod" })).toBe("prod");
+  });
+
+  it("returns null for null / non-object input", () => {
+    expect(extractChannel(null)).toBeNull();
+    expect(extractChannel("staging")).toBeNull();
+    expect(extractChannel(42)).toBeNull();
+  });
+
+  it("returns null when channel is missing or unrecognised (older server / malformed)", () => {
+    expect(extractChannel({})).toBeNull();
+    expect(extractChannel({ serverCommandVersion: "1.2.3" })).toBeNull();
+    expect(extractChannel({ channel: "qa" })).toBeNull();
+    expect(extractChannel({ channel: 1 })).toBeNull();
+  });
+});

--- a/packages/web/src/hooks/use-server-channel.ts
+++ b/packages/web/src/hooks/use-server-channel.ts
@@ -1,0 +1,40 @@
+import type { ChannelName } from "@first-tree/shared/channel";
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../api/client.js";
+
+/**
+ * Narrow the bootstrap `/config` payload to its release channel without an
+ * `as` cast. Returns null for any unrecognised shape (older server that does
+ * not report `channel`, malformed body) so callers fall back to their safe
+ * default — treat unknown as prod and keep channel-scoped UI hidden.
+ */
+export function extractChannel(data: unknown): ChannelName | null {
+  if (typeof data === "object" && data !== null && "channel" in data) {
+    const { channel } = data;
+    if (channel === "dev" || channel === "staging" || channel === "prod") return channel;
+  }
+  return null;
+}
+
+async function fetchServerChannel(): Promise<ChannelName | null> {
+  const data = await api.get<unknown>("/bootstrap/config");
+  return extractChannel(data);
+}
+
+/**
+ * The release channel this server speaks (`dev` | `staging` | `prod`), or null
+ * while loading / when the server does not report one. Server-wide and fixed
+ * for the life of a deploy, so it is fetched once from the public bootstrap
+ * `/config` endpoint and cached for the session. Gates channel-scoped UI such
+ * as the staging-only "hide agent final text" view toggle.
+ */
+export function useServerChannel(): ChannelName | null {
+  const { data } = useQuery({
+    queryKey: ["server-channel"],
+    queryFn: fetchServerChannel,
+    staleTime: Number.POSITIVE_INFINITY,
+    gcTime: Number.POSITIVE_INFINITY,
+    refetchOnWindowFocus: false,
+  });
+  return data ?? null;
+}

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -7,7 +7,6 @@ import {
   type DocSnapshotFailReason,
   documentContextSchema,
   extractMentions,
-  isAgentFinalTextMetadata,
   isImageBatchRefContent,
   isImageRefContent,
   type MentionParticipant,
@@ -118,6 +117,7 @@ import { useAutoResizeTextarea } from "../../../lib/use-autoresize-textarea.js";
 import { useOrgAgents } from "../../../lib/use-org-agents.js";
 import { usePendingImages } from "../../../lib/use-pending-images.js";
 import { cn } from "../../../lib/utils.js";
+import { selectVisibleMessages } from "../../../utils/agent-final-text-filter.js";
 import { findGapAfterMessageId } from "../../../utils/chat-gap.js";
 import { computeRequiresMention, shouldPrimeMentionOnFocus } from "../../../utils/requires-mention.js";
 import { filterEventsForTimeline } from "../../../utils/session-timeline.js";
@@ -1813,8 +1813,18 @@ export function ChatView({
     const byId = new Map<string, MessageWithDelivery>();
     for (const m of fromCache) byId.set(m.id, m);
     for (const m of fromServer) byId.set(m.id, m);
-    return Array.from(byId.values()).sort((a, b) => a.createdAt.localeCompare(b.createdAt));
-  }, [cachedMessages, messagesData]);
+    const sorted = Array.from(byId.values()).sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+    // Staging-only view filter applied at THE single source feeding the
+    // timeline AND every read-state projection derived from it (pill,
+    // high-water, divider, scroll anchor, useReadTracker's `messages`). Doing
+    // it here — not just at the rendered `items` — keeps the DOM and those
+    // projections from diverging: a hidden row has no DOM node, so it must
+    // also be absent from pill/anchor math or it drives an un-clearable "N
+    // new" pill. The IDB/server caches keep the full set, so toggling off
+    // restores the rows; the read-tracker derives its writes from the visible
+    // DOM (see use-read-tracker), so durable read-state stays coherent.
+    return selectVisibleMessages(sorted, hideFinalTextActive);
+  }, [cachedMessages, messagesData, hideFinalTextActive]);
 
   const gapAfterMessageId = useMemo<string | null>(
     () => findGapAfterMessageId(cachedMessages ?? [], messagesData?.items ?? []),
@@ -1912,16 +1922,11 @@ export function ChatView({
     //
     // mergedMessages (IDB cache ∪ server) feeds the timeline, not the raw server
     // window — otherwise cached messages outside the "last 50" window would
-    // vanish on chat re-open until the server fetch lands.
-    //
-    // Staging-only view filter: when active, drop agent final-text mirror rows
-    // here at the timeline-projection layer only. `mergedMessages` (and thus
-    // read-state, the new-message divider, threading, and blocking-request
-    // detection) keeps the full set — hiding is purely presentational.
-    const timelineMessages = hideFinalTextActive
-      ? mergedMessages.filter((m) => !isAgentFinalTextMetadata(m.metadata))
-      : mergedMessages;
-    const out: TimelineItem[] = timelineMessages.map((m) => ({
+    // vanish on chat re-open until the server fetch lands. When the staging
+    // hide toggle is active, mergedMessages is already the filtered visible set
+    // (see its useMemo), so the timeline, pill, divider, and read-tracker all
+    // share one source.
+    const out: TimelineItem[] = mergedMessages.map((m) => ({
       kind: "message" as const,
       at: m.createdAt,
       key: `m-${m.id}`,
@@ -1948,7 +1953,7 @@ export function ChatView({
 
     out.sort((a, b) => a.at.localeCompare(b.at));
     return out;
-  }, [mergedMessages, eventsData, hideFinalTextActive]);
+  }, [mergedMessages, eventsData]);
 
   const itemCount = items.length;
 

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -7,13 +7,26 @@ import {
   type DocSnapshotFailReason,
   documentContextSchema,
   extractMentions,
+  isAgentFinalTextMetadata,
   isImageBatchRefContent,
   isImageRefContent,
   type MentionParticipant,
   type RequestResolution,
 } from "@first-tree/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ArrowUp, AtSign, Check, ExternalLink, Eye, Menu, MessageSquare, PanelRight, Paperclip, X } from "lucide-react";
+import {
+  ArrowUp,
+  AtSign,
+  Check,
+  ExternalLink,
+  Eye,
+  EyeOff,
+  Menu,
+  MessageSquare,
+  PanelRight,
+  Paperclip,
+  X,
+} from "lucide-react";
 import {
   memo,
   type MouseEvent as ReactMouseEvent,
@@ -96,6 +109,7 @@ import { StatusGlyph } from "../../../components/ui/status-glyph.js";
 import { UnreadDivider } from "../../../components/unread-divider.js";
 import { useChatScroll } from "../../../hooks/use-chat-scroll.js";
 import { useReadTracker } from "../../../hooks/use-read-tracker.js";
+import { useServerChannel } from "../../../hooks/use-server-channel.js";
 import { viewOf } from "../../../lib/agent-status-view.js";
 import { attachmentIdFromHref, parseFailedDocHref, wrapFailedDocMentions } from "../../../lib/doc-preview-links.js";
 import { isNavigableWebHref } from "../../../lib/safe-href.js";
@@ -132,6 +146,34 @@ function saveSidebarOpen(open: boolean): void {
   if (typeof window === "undefined") return;
   try {
     window.localStorage.setItem(SIDEBAR_OPEN_STORAGE_KEY, open ? "1" : "0");
+  } catch {
+    // localStorage may be unavailable (private mode); ignore.
+  }
+}
+
+/**
+ * Temporary, staging-only preference: hide agent final-text mirrors (the
+ * per-turn output the runtime auto-forwards into chat with
+ * `purpose: "agent-final-text"`) so a human watching sees only deliberate
+ * sends + human messages. Defaults to OFF (show everything). Purely a view
+ * filter — nothing is deleted, and it only ever applies on non-prod channels
+ * (the toggle is hidden on prod; see `finalTextToggleEnabled`).
+ */
+const HIDE_AGENT_FINAL_TEXT_STORAGE_KEY = "first-tree:chat:hide-agent-final-text:v1";
+
+function loadHideAgentFinalText(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(HIDE_AGENT_FINAL_TEXT_STORAGE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function saveHideAgentFinalText(hide: boolean): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(HIDE_AGENT_FINAL_TEXT_STORAGE_KEY, hide ? "1" : "0");
   } catch {
     // localStorage may be unavailable (private mode); ignore.
   }
@@ -1063,6 +1105,22 @@ export function ChatView({
       return next;
     });
   }, []);
+
+  // Temporary, staging-only view filter: hide agent final-text mirrors. The
+  // toggle renders only on non-prod channels (`finalTextToggleEnabled`), and
+  // the filter is additionally gated on that flag so a stale localStorage
+  // preference can never hide messages on prod. Default OFF (show everything).
+  const serverChannel = useServerChannel();
+  const finalTextToggleEnabled = serverChannel === "dev" || serverChannel === "staging";
+  const [hideAgentFinalText, setHideAgentFinalText] = useState<boolean>(loadHideAgentFinalText);
+  const toggleHideAgentFinalText = useCallback(() => {
+    setHideAgentFinalText((prev) => {
+      const next = !prev;
+      saveHideAgentFinalText(next);
+      return next;
+    });
+  }, []);
+  const hideFinalTextActive = finalTextToggleEnabled && hideAgentFinalText;
   // The chat id the description-driven rail default was last applied for.
   // `ChatView` is NOT remounted on chat switch (the `chat-detail` query
   // just refetches by `chatId`), so this must be keyed by chat id — not a
@@ -1855,7 +1913,15 @@ export function ChatView({
     // mergedMessages (IDB cache ∪ server) feeds the timeline, not the raw server
     // window — otherwise cached messages outside the "last 50" window would
     // vanish on chat re-open until the server fetch lands.
-    const out: TimelineItem[] = mergedMessages.map((m) => ({
+    //
+    // Staging-only view filter: when active, drop agent final-text mirror rows
+    // here at the timeline-projection layer only. `mergedMessages` (and thus
+    // read-state, the new-message divider, threading, and blocking-request
+    // detection) keeps the full set — hiding is purely presentational.
+    const timelineMessages = hideFinalTextActive
+      ? mergedMessages.filter((m) => !isAgentFinalTextMetadata(m.metadata))
+      : mergedMessages;
+    const out: TimelineItem[] = timelineMessages.map((m) => ({
       kind: "message" as const,
       at: m.createdAt,
       key: `m-${m.id}`,
@@ -1882,7 +1948,7 @@ export function ChatView({
 
     out.sort((a, b) => a.at.localeCompare(b.at));
     return out;
-  }, [mergedMessages, eventsData]);
+  }, [mergedMessages, eventsData, hideFinalTextActive]);
 
   const itemCount = items.length;
 
@@ -3079,6 +3145,32 @@ export function ChatView({
                   participantIds={chatDetail?.participants?.map((p) => p.agentId) ?? [agentId]}
                   onAdded={() => queryClient.invalidateQueries({ queryKey: ["chat-detail", chatId] })}
                 />
+              )}
+              {/* Hide agent final-text toggle — TEMPORARY, staging/dev only
+              (gated on `finalTextToggleEnabled`). Filters the per-turn
+              final-text mirrors out of the timeline so a human watcher sees
+              only deliberate sends + human messages. Eye / EyeOff conveys the
+              show/hide state; pressed styling marks "currently hiding". */}
+              {finalTextToggleEnabled && (
+                <button
+                  type="button"
+                  onClick={toggleHideAgentFinalText}
+                  aria-label={hideAgentFinalText ? "Show agent final messages" : "Hide agent final messages"}
+                  aria-pressed={hideAgentFinalText}
+                  title={hideAgentFinalText ? "Show agent final messages" : "Hide agent final messages"}
+                  className="inline-flex shrink-0 items-center justify-center transition-colors hover:bg-[var(--bg-hover)]"
+                  style={{
+                    width: 28,
+                    height: 28,
+                    border: 0,
+                    background: hideAgentFinalText ? "var(--bg-sunken)" : "transparent",
+                    borderRadius: "var(--radius-input)",
+                    color: hideAgentFinalText ? "var(--fg)" : "var(--fg-3)",
+                    cursor: "pointer",
+                  }}
+                >
+                  {hideAgentFinalText ? <EyeOff size={16} strokeWidth={2.25} /> : <Eye size={16} strokeWidth={2.25} />}
+                </button>
               )}
               {/* Chat details toggle — opens the right rail (Participants /
               GitHub / Chat actions). Sits at the panel's far right,

--- a/packages/web/src/utils/__tests__/agent-final-text-filter.test.ts
+++ b/packages/web/src/utils/__tests__/agent-final-text-filter.test.ts
@@ -1,0 +1,41 @@
+import { AGENT_FINAL_TEXT_METADATA_KEY } from "@first-tree/shared";
+import { describe, expect, it } from "vitest";
+import { selectVisibleMessages } from "../agent-final-text-filter.js";
+
+const FINAL = { [AGENT_FINAL_TEXT_METADATA_KEY]: true };
+const mk = (id: string, metadata: Record<string, unknown> = {}) => ({ id, metadata });
+
+/**
+ * `selectVisibleMessages` is the single visible-message set the chat timeline
+ * and its read-state projections (pill / high-water / divider / scroll anchor)
+ * share. These cases pin the two failure modes raised in review: a hidden
+ * newest row driving an un-clearable pill, and a saved anchor pointing at a
+ * hidden row.
+ */
+describe("selectVisibleMessages", () => {
+  it("returns the same array (identity) when the hide toggle is off", () => {
+    const msgs = [mk("a"), mk("b", FINAL), mk("c")];
+    expect(selectVisibleMessages(msgs, false)).toBe(msgs);
+  });
+
+  it("drops final-text rows when hiding — including the NEWEST row (no phantom pill)", () => {
+    const msgs = [mk("a"), mk("b"), mk("final-newest", FINAL)];
+    const visible = selectVisibleMessages(msgs, true);
+    expect(visible.map((m) => m.id)).toEqual(["a", "b"]);
+    // The hidden newest row is absent, so pill/high-water computed over this
+    // set cannot count a row with no DOM node.
+    expect(visible.some((m) => m.id === "final-newest")).toBe(false);
+  });
+
+  it("a saved scroll anchor pointing at a hidden row does not resolve in the visible set", () => {
+    const msgs = [mk("a"), mk("hidden-anchor", FINAL), mk("c")];
+    const visible = selectVisibleMessages(msgs, true);
+    // bottomVisibleResolution does findIndex(...) === -1 → graceful fallback.
+    expect(visible.findIndex((m) => m.id === "hidden-anchor")).toBe(-1);
+  });
+
+  it("keeps human / normal-agent rows untouched when hiding", () => {
+    const msgs = [mk("human", { mentions: ["x"] }), mk("agent-send")];
+    expect(selectVisibleMessages(msgs, true).map((m) => m.id)).toEqual(["human", "agent-send"]);
+  });
+});

--- a/packages/web/src/utils/agent-final-text-filter.ts
+++ b/packages/web/src/utils/agent-final-text-filter.ts
@@ -1,0 +1,20 @@
+import { isAgentFinalTextMetadata } from "@first-tree/shared";
+
+type WithMetadata = { metadata: Record<string, unknown> };
+
+/**
+ * The single "visible message set" the chat timeline AND every read-state
+ * projection derived from it consume — the rendered rows, the unread pill, the
+ * high-water mark, the new-message divider, and the saved scroll anchor.
+ *
+ * When the staging-only hide toggle is active, agent final-text mirror rows are
+ * dropped HERE, at the one source those projections share, so the rendered DOM
+ * and the projections can never diverge: a hidden row has no DOM node, so it
+ * must also be absent from pill/high-water/anchor math (otherwise it drives an
+ * un-clearable "N new" pill or an unresolvable scroll anchor). When inactive,
+ * the same array is returned unchanged (no copy, stable identity for memo).
+ */
+export function selectVisibleMessages<T extends WithMetadata>(messages: T[], hideAgentFinalText: boolean): T[] {
+  if (!hideAgentFinalText) return messages;
+  return messages.filter((m) => !isAgentFinalTextMetadata(m.metadata));
+}


### PR DESCRIPTION
## What & why

A temporary, **internal/staging-only** chat-page toggle that hides agents' **final-text mirrors** — the per-turn output the runtime auto-forwards into chat with `purpose: "agent-final-text"`. When on, a human watching a chat sees only deliberate `chat send` messages + human messages; the verbose end-of-turn dumps are filtered out. **Default off** (everything shown). Requested by @liuchao-001 for internal use; scope confirmed as *final-text mirrors only* (not all agent messages).

## The core problem

`purpose: "agent-final-text"` is a **send-time-only** tag — the server consumes it for enforcement (skip mention guard, force silent fan-out) but never persists it (`messageSchema` / `messages` table have no such field). So the web currently cannot distinguish a silent final-text mirror from a deliberate agent `chat send`. This PR persists a durable, server-owned marker so the web can.

## Changes

**shared** — `AGENT_FINAL_TEXT_METADATA_KEY` (`"agentFinalText"`) + `isAgentFinalTextMetadata()` reader; both sides key off the one constant.

**server**
- `services/message.ts`: stamp `metadata.agentFinalText = true` for a **genuine mirror only — a non-human sender with `purpose === "agent-final-text"`**. The flag is **server-owned**: any inbound client-supplied `agentFinalText` is stripped, and the non-human gate (matching the unread-projection's `senderRow.type !== "human"`) means a human/web send carrying `purpose` cannot masquerade as a mirror. No migration (`metadata` is jsonb). Normal sends are byte-for-byte unchanged.
- `api/bootstrap/config.ts`: expose the release `channel` (`dev`|`staging`|`prod`) on the public `GET /bootstrap/config`, so the web can gate channel-scoped UI without shipping prod-visible dev affordances.

**web**
- `hooks/use-server-channel.ts`: `useServerChannel()` reads the channel once (cached for the session).
- `utils/agent-final-text-filter.ts`: `selectVisibleMessages(messages, hide)` — the one place the filter is applied.
- `chat-view.tsx`: a chat-header toggle (Eye / EyeOff, pressed = hiding) rendered **only** on dev/staging. When on, `mergedMessages` itself becomes the filtered **visible set**, so the timeline, unread pill, new-message divider, saved scroll anchor, and `useReadTracker` all share one source — a hidden row can never drive an un-clearable pill or an unresolvable anchor. Hiding is presentational: the IDB/server caches keep the full set (toggle off restores), and the read-tracker still writes from the visible DOM. Preference in `localStorage`; double-gated on channel so a stale preference can never hide on prod.

## Limitation

Only messages created **after deploy** carry the flag; older history has no marker and won't be hidden. Acceptable for a temporary internal tool (a live chat fills with marked rows within minutes). The server-side chat-list unread bump on final-text (the "agent done" red dot) is intentionally unchanged — this PR only affects in-chat presentation.

## Testing

- `pnpm check` ✅ · `pnpm typecheck` ✅ · full web suite (837) ✅
- New tests: server `agent-final-text-purpose` — persists flag for an agent mirror, strips a client-smuggled flag, and does **not** mark a human/web send carrying `purpose`; server `bootstrap-config` (channel surfaced, dev + staging); shared `isAgentFinalTextMetadata`; web `extractChannel`; web `selectVisibleMessages` (hidden-newest-row + hidden-saved-anchor).
- Re-ran metadata-sensitive server suites (orgs-chats, agent-chats, direct-chat-mention-mode, me-chat-service, agent-send-mention-injection, admin-clients-capabilities) — 103 passing, no regressions.

## Review history

- **Point 1 — marker forgery (addressed in 53374bed):** the marker was stamped on `data.purpose` alone, so a human/web send carrying `purpose: "agent-final-text"` would have been persisted as a mirror. Now gated on a non-human sender, with a regression test. (Confirmed resolved by reviewers.)
- **Point 2 — hidden rows decoupled from read-state (addressed in 942df0e8):** the filter ran only on rendered `items` while the pill / high-water / divider / scroll anchor / read-tracker read the unfiltered `mergedMessages`. Now filtered once at `mergedMessages` so all projections share the visible set; unit tests cover the hidden-newest-row and hidden-saved-anchor cases.

## Manual acceptance (staging)

On a staging build, open any chat with agent activity → an Eye icon appears in the header (left of the chat-details toggle). Click it → agent final-text rows disappear, leaving directed sends + human messages; click again to restore. Should not appear on prod.