### PR TITLE
fix(client): wait for eviction cleanup before resume

### DIFF
--- a/packages/client/src/__tests__/session-manager.test.ts
+++ b/packages/client/src/__tests__/session-manager.test.ts
@@ -720,6 +720,84 @@ describe("SessionManager", () => {
     await sm.shutdown();
   });
 
+  it("waits for evicted active handler shutdown before resuming the same chat", async () => {
+    const shutdownGate = deferred<void>();
+    const contexts = new Map<string, SessionContext>();
+    const messages = new Map<string, SessionMessage>();
+    const resumeSpy = vi.fn(async (msg: SessionMessage | undefined, sessionId: string, ctx: SessionContext) => {
+      if (msg) {
+        contexts.set(`${msg.chatId}:resume`, ctx);
+        messages.set(`${msg.chatId}:resume`, msg);
+      }
+      return sessionId;
+    });
+
+    const handlerA = createMockHandler({
+      async start(msg, ctx) {
+        contexts.set(msg.chatId, ctx);
+        messages.set(msg.chatId, msg);
+        return "session-chat-a";
+      },
+      shutdown: vi.fn(() => shutdownGate.promise),
+    });
+    const handlerB = createMockHandler({
+      async start(msg, ctx) {
+        contexts.set(msg.chatId, ctx);
+        messages.set(msg.chatId, msg);
+        return "session-chat-b";
+      },
+    });
+    const handlerAResume = createMockHandler({
+      resume: resumeSpy,
+    });
+    const handlers = [handlerA, handlerB, handlerAResume];
+    const sm = createSessionManager({
+      handlerFactory: () => {
+        const handler = handlers.shift();
+        if (!handler) throw new Error("unexpected handler allocation");
+        return handler;
+      },
+      recoverChat: vi.fn().mockResolvedValue(undefined),
+      concurrency: 1,
+      session: { idle_timeout: 300, max_sessions: 1, working_grace_seconds: 3600, reconcile_interval_seconds: 300 },
+    });
+
+    const chatA = mockEntry({ id: 1, chatId: "chat-a", messageId: "msg-a" });
+    await sm.dispatch(chatA);
+    await finishEntry(contexts.get("chat-a"), 1, "chat-a", "msg-a");
+
+    const chatB = mockEntry({ id: 2, chatId: "chat-b", messageId: "msg-b" });
+    await sm.dispatch(chatB);
+    expect(handlerA.shutdown).toHaveBeenCalledTimes(1);
+    await finishEntry(contexts.get("chat-b"), 2, "chat-b", "msg-b");
+
+    const chatAReturn = mockEntry({ id: 3, chatId: "chat-a", messageId: "msg-a-return" });
+    await sm.dispatch(chatAReturn);
+
+    let resumeDispatchSettled = false;
+    const resumeDispatch = sm.dispatch(chatAReturn).then(() => {
+      resumeDispatchSettled = true;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(resumeSpy).not.toHaveBeenCalled();
+    expect(resumeDispatchSettled).toBe(false);
+
+    shutdownGate.resolve(undefined);
+    await resumeDispatch;
+
+    expect(resumeSpy).toHaveBeenCalledTimes(1);
+    expect(resumeSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ chatId: "chat-a", id: "msg-a-return" }),
+      "session-chat-a",
+      expect.any(Object),
+      expect.any(Object),
+    );
+    await finishEntry(contexts.get("chat-a:resume"), 3, "chat-a", "msg-a-return");
+
+    await sm.shutdown();
+  });
+
   it("enforces concurrency limit and queues overflow", async () => {
     const startCalls: string[] = [];
     const factory: HandlerFactory = () =>

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -91,6 +91,12 @@ type SessionEntry = {
   retryFromEvicted: { claudeSessionId: string; lastActivity: number } | null;
 };
 
+type EvictedMapping = {
+  claudeSessionId: string;
+  lastActivity: number;
+  cleanup?: Promise<void>;
+};
+
 type PendingMessage = {
   message: SessionMessage | null;
   chatId: string;
@@ -374,7 +380,7 @@ export function encodeResilienceMessage(eventName: string, payload: Record<strin
 
 export class SessionManager {
   private readonly sessions = new Map<string, SessionEntry>();
-  private readonly evictedMappings = new Map<string, { claudeSessionId: string; lastActivity: number }>();
+  private readonly evictedMappings = new Map<string, EvictedMapping>();
   private readonly config: SessionManagerConfig;
   private readonly inboxDelivery: InboxDeliveryCoordinator;
   /** Last lazy Context-Tree re-resolution attempt (epoch ms); see `TREE_RERESOLVE_INTERVAL_MS`. */
@@ -1021,7 +1027,9 @@ export class SessionManager {
       lastRetryRawError: null,
       startMessage: message,
       retryQueuedMessages: [],
-      retryFromEvicted: evicted ?? null,
+      retryFromEvicted: evicted
+        ? { claudeSessionId: evicted.claudeSessionId, lastActivity: evicted.lastActivity }
+        : null,
     };
 
     this.sessions.set(chatId, entry);
@@ -1037,6 +1045,7 @@ export class SessionManager {
       this.setCurrentTrigger(chatId, message);
       const token = this.createDeliveryToken(chatId);
       if (evicted) {
+        if (evicted.cleanup) await evicted.cleanup;
         const receipt = normalizeResumeReceipt(await handler.resume(message, evicted.claudeSessionId, ctx, token));
         entry.claudeSessionId = receipt.sessionId;
         if (receipt.route) this.markRouteOwned(chatId, message, receipt.route);
@@ -1665,17 +1674,24 @@ export class SessionManager {
     }
 
     if (candidate) {
+      let cleanup: Promise<void> | undefined;
+      if (candidate.session.status === "active") {
+        this._activeCount--;
+        cleanup = candidate.session.handler.shutdown().catch((err) => {
+          this.config.log.warn({ chatId: candidate.key, err }, "evicted session shutdown error");
+        });
+      } else {
+        cleanup = candidate.session.suspending ?? undefined;
+      }
+
       // Preserve mapping for future recovery
       this.addEvictedMapping(candidate.key, {
         claudeSessionId: candidate.session.claudeSessionId,
         lastActivity: candidate.session.lastActivity,
+        cleanup,
       });
 
       this.config.log.info({ chatId: candidate.key }, "session evicted (max_sessions reached)");
-      if (candidate.session.status === "active") {
-        this._activeCount--;
-        candidate.session.handler.shutdown().catch(() => {});
-      }
       // LRU eviction is local memory-management, not operator intent — do
       // NOT emit a wire state here. The chat now lives in `evictedMappings`
       // and the next `agent:bound` (initial bind or reconnect) will pick it
@@ -1757,7 +1773,7 @@ export class SessionManager {
   }
 
   /** Add an evicted mapping, pruning the oldest if over capacity. */
-  private addEvictedMapping(chatId: string, mapping: { claudeSessionId: string; lastActivity: number }): void {
+  private addEvictedMapping(chatId: string, mapping: EvictedMapping): void {
     this.evictedMappings.set(chatId, mapping);
     if (this.evictedMappings.size > MAX_EVICTED_MAPPINGS) {
       // Map iteration order is insertion order — first key is the oldest


### PR DESCRIPTION
## Summary

- Store a runtime-only cleanup promise on evicted session mappings.
- Capture active handler `shutdown()` and in-flight `suspending` cleanup before dropping a session from `sessions`.
- Await that cleanup before calling `handler.resume(...)` for the evicted chat, while keeping the new session entry as the in-flight routing placeholder.
- Add a regression test proving redelivery does not resume until the old shutdown gate settles.

## Root Cause

`evictIfNeeded` preserved only the prior session id when LRU/max-session eviction dropped a session. For active sessions it started `handler.shutdown()` fire-and-forget, deleted the local entry, and allowed a later same-chat redelivery to immediately create a fresh handler and call `resume(...)` against the same saved session id. That could overlap the old handler's shutdown/abort path and violate the `(agent, chat) = 1 live handler` boundary.

## Validation

- `pnpm --filter @first-tree/client exec vitest run src/__tests__/session-manager.test.ts`
- `pnpm --filter @first-tree/client typecheck`
- `pnpm exec biome check packages/client/src/runtime/session-manager.ts packages/client/src/__tests__/session-manager.test.ts`
- `pnpm --filter @first-tree/client test`

Fixes #1151