### PR TITLE
chore(ci): add workflow_dispatch to website-changelog-rebuild

### DIFF
--- a/.github/workflows/website-changelog-rebuild.yml
+++ b/.github/workflows/website-changelog-rebuild.yml
@@ -8,6 +8,7 @@ name: Rebuild website changelog on release
 on:
   release:
     types: [published]
+  workflow_dispatch: # allow a manual rebuild from the Actions tab (and to test the hook)
 
 # This job only POSTs to an external Vercel hook — it never needs the
 # repo GITHUB_TOKEN, so drop all default token permissions.


### PR DESCRIPTION
Follow-up to #1050. Adds `workflow_dispatch` to the `website-changelog-rebuild` workflow so it can be run on demand from the Actions tab.

## Why
The workflow only triggered on `release: published`, so there was no way to test the deploy-hook → Vercel rebuild chain without cutting a real release, nor to force a rebuild manually after a stale-content incident.

## Change
One line: add `workflow_dispatch` alongside the existing `release` trigger. The job is otherwise unchanged — it still only POSTs the existing `VERCEL_DEPLOY_HOOK_URL` secret, with `permissions: {}`.

Closes #1161.