### PR TITLE
docs: update dev install restart guidance

### DIFF
--- a/docs/development/local-dev-isolation.md
+++ b/docs/development/local-dev-isolation.md
@@ -37,11 +37,12 @@ first-tree-dev daemon status
 journalctl --user -u first-tree-dev -f
 ```
 
-After editing any source file, re-run `./scripts/dev-install.sh` (it
-rebuilds dist) and restart the daemon if it's already running:
+After editing any source file, re-run `./scripts/dev-install.sh`; it
+rebuilds dist and restarts the installed dev daemon so the running
+service picks up the new build:
 
 ```bash
-./scripts/dev-install.sh && first-tree-dev daemon restart
+./scripts/dev-install.sh
 ```
 
 After login, on Linux:


### PR DESCRIPTION
## Summary
- Update local dev isolation docs after `dev-install.sh` learned to restart the installed `first-tree-dev` daemon itself.
- Remove the now-redundant explicit `first-tree-dev daemon restart` from the documented reinstall flow.

## Validation
- `rg -n "dev-install\.sh && first-tree-dev daemon restart|and restart the daemon" docs/development/local-dev-isolation.md docs -g "*.md"` returns no matches.
- `git diff --check origin/main..HEAD`