### PR TITLE
fix(client): prepend channel CLI bin for agents

### DIFF
--- a/packages/client/src/__tests__/agent-io.test.ts
+++ b/packages/client/src/__tests__/agent-io.test.ts
@@ -1,11 +1,15 @@
+import { chmodSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
 import type { ChatParticipantDetail } from "@first-tree/shared";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   buildAgentEnv,
   createParticipantCache,
   formatInboundContent,
   resolveSenderLabel,
 } from "../runtime/agent-io.js";
+import { setCliBinding } from "../runtime/cli-binding.js";
 import type { SessionMessage } from "../runtime/handler.js";
 import type { FirstTreeHubSDK } from "../sdk.js";
 
@@ -32,6 +36,10 @@ function mkSdk(listImpl?: () => Promise<ChatParticipantDetail[]>): FirstTreeHubS
   } as unknown as FirstTreeHubSDK;
   return sdk;
 }
+
+afterEach(() => {
+  setCliBinding({ binName: "first-tree", packageName: "first-tree" });
+});
 
 describe("resolveSenderLabel", () => {
   const ps = [
@@ -354,6 +362,83 @@ describe("buildAgentEnv", () => {
     expect(env.FIRST_TREE_AGENT_ID).toBe("agent-a");
     expect(env.FIRST_TREE_INBOX_ID).toBe("inbox-a");
     expect(env.FIRST_TREE_CHAT_ID).toBe("chat-1");
+  });
+
+  it("prepends FIRST_TREE_HOME/bin to PATH for channel-local CLI resolution", () => {
+    const parent = {
+      FIRST_TREE_HOME: "/first-tree-home",
+      PATH: `/usr/bin${delimiter}/first-tree-home/bin${delimiter}/opt/bin`,
+    } as NodeJS.ProcessEnv;
+    const env = buildAgentEnv(parent, {
+      sdk: { serverUrl: "http://first-tree" },
+      agent: {
+        agentId: "agent-a",
+        inboxId: "inbox-a",
+        displayName: "agent-a",
+        type: "agent",
+        visibility: "organization",
+        delegateMention: null,
+        metadata: {},
+      },
+      chatId: "chat-1",
+    });
+    expect(env.PATH).toBe(`/first-tree-home/bin${delimiter}/usr/bin${delimiter}/opt/bin`);
+  });
+
+  it("logs once when the channel-local CLI binary is not resolvable", () => {
+    setCliBinding({ binName: "first-tree-staging", packageName: "first-tree-staging" });
+    const home = mkdtempSync(join(tmpdir(), "first-tree-agent-env-"));
+    const logs: string[] = [];
+    const parent = { FIRST_TREE_HOME: home, PATH: "/usr/bin" } as NodeJS.ProcessEnv;
+    const ctx = {
+      sdk: { serverUrl: "http://first-tree" },
+      agent: {
+        agentId: "agent-a",
+        inboxId: "inbox-a",
+        displayName: "agent-a",
+        type: "agent" as const,
+        visibility: "organization" as const,
+        delegateMention: null,
+        metadata: {},
+      },
+      chatId: "chat-1",
+      log: (msg: string) => logs.push(msg),
+    };
+
+    buildAgentEnv(parent, ctx);
+    buildAgentEnv(parent, ctx);
+
+    expect(logs).toHaveLength(1);
+    expect(logs[0]).toContain("first-tree-staging");
+    expect(logs[0]).toContain(join(home, "bin"));
+  });
+
+  it("does not warn when the channel-local CLI binary exists", () => {
+    setCliBinding({ binName: "first-tree-dev", packageName: null });
+    const home = mkdtempSync(join(tmpdir(), "first-tree-agent-env-"));
+    const binDir = join(home, "bin");
+    mkdirSync(binDir, { recursive: true });
+    const binPath = join(binDir, "first-tree-dev");
+    writeFileSync(binPath, "#!/bin/sh\n");
+    chmodSync(binPath, 0o755);
+    const logs: string[] = [];
+
+    buildAgentEnv({ FIRST_TREE_HOME: home, PATH: "/usr/bin" } as NodeJS.ProcessEnv, {
+      sdk: { serverUrl: "http://first-tree" },
+      agent: {
+        agentId: "agent-a",
+        inboxId: "inbox-a",
+        displayName: "agent-a",
+        type: "agent",
+        visibility: "organization",
+        delegateMention: null,
+        metadata: {},
+      },
+      chatId: "chat-1",
+      log: (msg) => logs.push(msg),
+    });
+
+    expect(logs).toEqual([]);
   });
 
   it("overrides any pre-existing FIRST_TREE_* value in the parent env", () => {

--- a/packages/client/src/runtime/agent-io.ts
+++ b/packages/client/src/runtime/agent-io.ts
@@ -1,3 +1,5 @@
+import { accessSync, constants } from "node:fs";
+import { delimiter, join } from "node:path";
 import {
   type ChatParticipantDetail,
   extractCaption,
@@ -6,6 +8,7 @@ import {
   isImageRefContent,
 } from "@first-tree/shared";
 import type { FirstTreeHubSDK } from "../sdk.js";
+import { getCliBinding } from "./cli-binding.js";
 import type { AgentIdentity, SessionMessage } from "./handler.js";
 import { findImagePath } from "./image-store.js";
 
@@ -24,10 +27,11 @@ import { findImagePath } from "./image-store.js";
 
 /**
  * Build the env for CLI sub-processes that need to call `<binName> ...`.
- * Layers the First Tree envelope variables on top of the parent env. Handlers
- * that start sub-processes should call this so every one of them sees the
- * same envelope — enabling replyTo inference, access-token propagation, and
- * agent-id binding without per-handler duplication.
+ * Layers the First Tree envelope variables on top of the parent env, and keeps
+ * the channel-local CLI binary ahead of any globally installed sibling. Handlers
+ * that start sub-processes should call this so every one of them sees the same
+ * envelope — enabling replyTo inference, access-token propagation, agent-id
+ * binding, and channel-correct CLI calls without per-handler duplication.
  */
 export function buildAgentEnv(
   parentEnv: NodeJS.ProcessEnv,
@@ -68,10 +72,12 @@ export function buildAgentEnv(
       workspacesRoot: string;
       selfSlug: string;
     };
+    log?: (msg: string) => void;
   },
 ): NodeJS.ProcessEnv {
+  const env = withChannelCliOnPath(parentEnv, ctx.log);
   return {
-    ...parentEnv,
+    ...env,
     FIRST_TREE_SERVER_URL: ctx.sdk.serverUrl,
     FIRST_TREE_AGENT_ID: ctx.agent.agentId,
     FIRST_TREE_INBOX_ID: ctx.agent.inboxId,
@@ -88,6 +94,77 @@ export function buildAgentEnv(
         }
       : {}),
   };
+}
+
+const warnedCliResolutionKeys = new Set<string>();
+
+function withChannelCliOnPath(parentEnv: NodeJS.ProcessEnv, log?: (msg: string) => void): NodeJS.ProcessEnv {
+  const firstTreeHome = parentEnv.FIRST_TREE_HOME;
+  if (!firstTreeHome) {
+    warnCliResolutionOnce(
+      "missing-home",
+      log,
+      "FIRST_TREE_HOME is not set; spawned agents cannot receive the channel-local CLI on PATH",
+    );
+    return { ...parentEnv };
+  }
+
+  const binDir = join(firstTreeHome, "bin");
+  const pathKey = resolvePathKey(parentEnv);
+  const currentPath = parentEnv[pathKey] ?? "";
+  const existing = currentPath.split(delimiter).filter((part) => part.length > 0 && part !== binDir);
+  const nextPath = [binDir, ...existing].join(delimiter);
+  const env = { ...parentEnv, [pathKey]: nextPath };
+
+  const { binName } = getCliBinding();
+  if (!canResolveExecutable(binDir, binName, parentEnv)) {
+    warnCliResolutionOnce(
+      `missing-bin:${binDir}:${binName}`,
+      log,
+      `channel-local CLI ${binName} was not found at ${binDir}; spawned agents may resolve a stale or wrong-channel CLI from PATH`,
+    );
+  }
+
+  return env;
+}
+
+function resolvePathKey(env: NodeJS.ProcessEnv): string {
+  if (process.platform === "win32") {
+    if ("Path" in env) return "Path";
+    if ("PATH" in env) return "PATH";
+    if ("path" in env) return "path";
+    return "Path";
+  }
+  return "PATH";
+}
+
+function canResolveExecutable(binDir: string, binName: string, env: NodeJS.ProcessEnv): boolean {
+  for (const candidate of executableCandidates(binDir, binName, env)) {
+    try {
+      accessSync(candidate, process.platform === "win32" ? constants.F_OK : constants.X_OK);
+      return true;
+    } catch {
+      // Keep probing.
+    }
+  }
+  return false;
+}
+
+function executableCandidates(binDir: string, binName: string, env: NodeJS.ProcessEnv): string[] {
+  const bare = join(binDir, binName);
+  if (process.platform !== "win32") return [bare];
+  const pathExts = (env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD")
+    .split(";")
+    .map((ext) => ext.trim())
+    .filter(Boolean);
+  return [bare, ...pathExts.map((ext) => `${bare}${ext.toLowerCase()}`), ...pathExts.map((ext) => `${bare}${ext}`)];
+}
+
+function warnCliResolutionOnce(key: string, log: ((msg: string) => void) | undefined, message: string): void {
+  if (!log) return;
+  if (warnedCliResolutionKeys.has(key)) return;
+  warnedCliResolutionKeys.add(key);
+  log(message);
 }
 
 /** Session-scoped participant cache shared by result-sink and inbound formatter. */

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -1831,6 +1831,7 @@ export class SessionManager {
       sdk: this.config.sdk,
       agent: this.config.agentIdentity,
       chatId,
+      log,
       docContext: {
         base: docBase,
         agentHome: selfFence.agentHome,


### PR DESCRIPTION
## Summary

- prepend `$FIRST_TREE_HOME/bin` to spawned agent process `PATH` when building the shared First Tree agent env
- keep the parent `PATH` entries while de-duplicating the channel-local bin dir
- warn once per missing channel-local CLI binary so agents do not silently fall back to a stale or wrong-channel global install
- pass the session logger into `buildAgentEnv` and add coverage for PATH ordering, warning behavior, and the no-warning happy path

Closes #927.

## Verification

- `pnpm --filter @first-tree/client test -- src/__tests__/agent-io.test.ts` (passed; ran the full client suite: 100 files / 1039 tests)
- `pnpm --filter @first-tree/client typecheck`
- `pnpm exec biome check packages/client/src/runtime/agent-io.ts packages/client/src/runtime/session-manager.ts packages/client/src/__tests__/agent-io.test.ts`
- `pnpm check` (exit 0; existing unrelated warnings/info remain outside this change)
- `pnpm typecheck`

QA result: PASS_WITH_SCOPE_CAVEAT. QA verified the targeted spawned-agent env behavior, candidate `first-tree-dev` CLI build/parity surface, and a focused runtime-env probe. Scope caveat: QA did not run a full local Server/daemon/provider E2E turn because this patch is limited to spawned-agent env assembly.
