### PR TITLE
feat(web): cache unsent composer drafts per chat in local storage

### DIFF
--- a/packages/web/src/lib/__tests__/draft-store.test.ts
+++ b/packages/web/src/lib/__tests__/draft-store.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
 import { beforeEach, describe, expect, it } from "vitest";
-import { clearDraft, loadDraft, newChatDraftScope, saveDraft } from "../draft-store.js";
+import { chatDraftScope, clearDraft, loadDraft, newChatDraftScope, saveDraft } from "../draft-store.js";
 
 const STORAGE_KEY = "first-tree:chat-drafts:v1";
 
@@ -99,12 +99,31 @@ describe("robustness", () => {
   });
 });
 
-describe("newChatDraftScope", () => {
-  it("encodes org + seed participants", () => {
-    expect(newChatDraftScope("org-7", ["a", "b"])).toBe("new:org-7:a,b");
+describe("scope helpers", () => {
+  it("chatDraftScope encodes user + chat", () => {
+    expect(chatDraftScope("user-1", "chat-9")).toBe("u:user-1:chat:chat-9");
   });
 
-  it("falls back to no-org and empty participants", () => {
-    expect(newChatDraftScope(null)).toBe("new:no-org:");
+  it("chatDraftScope falls back to anon when no user", () => {
+    expect(chatDraftScope(null, "chat-9")).toBe("u:anon:chat:chat-9");
+  });
+
+  it("newChatDraftScope encodes user + org + seed participants", () => {
+    expect(newChatDraftScope("user-1", "org-7", ["a", "b"])).toBe("u:user-1:new:org-7:a,b");
+  });
+
+  it("newChatDraftScope falls back to anon / no-org / empty participants", () => {
+    expect(newChatDraftScope(null, null)).toBe("u:anon:new:no-org:");
+  });
+
+  it("keeps drafts isolated per user (no cross-account leak on a shared browser)", () => {
+    // User A's draft for a chat must be invisible to user B in the same chat.
+    saveDraft(chatDraftScope("user-a", "chat-1"), { text: "A's secret" });
+    expect(loadDraft(chatDraftScope("user-b", "chat-1"))).toBeNull();
+    expect(loadDraft(chatDraftScope("user-a", "chat-1"))?.text).toBe("A's secret");
+
+    // Same for the new-chat composer within one org.
+    saveDraft(newChatDraftScope("user-a", "org-1"), { text: "A's new chat" });
+    expect(loadDraft(newChatDraftScope("user-b", "org-1"))).toBeNull();
   });
 });

--- a/packages/web/src/lib/__tests__/draft-store.test.ts
+++ b/packages/web/src/lib/__tests__/draft-store.test.ts
@@ -1,0 +1,110 @@
+// @vitest-environment happy-dom
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { clearDraft, loadDraft, newChatDraftScope, saveDraft } from "../draft-store.js";
+
+const STORAGE_KEY = "first-tree:chat-drafts:v1";
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe("saveDraft / loadDraft", () => {
+  it("round-trips body text for a chat scope", () => {
+    saveDraft("chat-1", { text: "hello world" });
+    expect(loadDraft("chat-1")).toEqual({ text: "hello world", participantIds: [] });
+  });
+
+  it("round-trips body text + participants for a new-chat scope", () => {
+    saveDraft("new:org:", { text: "draft body", participantIds: ["a", "b"] });
+    expect(loadDraft("new:org:")).toEqual({ text: "draft body", participantIds: ["a", "b"] });
+  });
+
+  it("returns null when nothing is stored for the scope", () => {
+    expect(loadDraft("missing")).toBeNull();
+  });
+
+  it("keeps scopes isolated", () => {
+    saveDraft("chat-1", { text: "one" });
+    saveDraft("chat-2", { text: "two" });
+    expect(loadDraft("chat-1")?.text).toBe("one");
+    expect(loadDraft("chat-2")?.text).toBe("two");
+  });
+
+  it("treats an empty / whitespace body as no draft and removes any existing entry", () => {
+    saveDraft("chat-1", { text: "something" });
+    expect(loadDraft("chat-1")).not.toBeNull();
+    saveDraft("chat-1", { text: "   " });
+    expect(loadDraft("chat-1")).toBeNull();
+  });
+
+  it("does not store chips on their own (body-less drafts are dropped)", () => {
+    saveDraft("new:org:", { text: "", participantIds: ["a", "b"] });
+    expect(loadDraft("new:org:")).toBeNull();
+  });
+
+  it("normalizes an empty participant list to []", () => {
+    saveDraft("new:org:", { text: "body", participantIds: [] });
+    expect(loadDraft("new:org:")).toEqual({ text: "body", participantIds: [] });
+  });
+
+  it("overwrites in place on re-save", () => {
+    saveDraft("chat-1", { text: "first" });
+    saveDraft("chat-1", { text: "second" });
+    expect(loadDraft("chat-1")?.text).toBe("second");
+  });
+});
+
+describe("clearDraft", () => {
+  it("removes a stored draft", () => {
+    saveDraft("chat-1", { text: "bye" });
+    clearDraft("chat-1");
+    expect(loadDraft("chat-1")).toBeNull();
+  });
+
+  it("is a no-op for an unknown scope", () => {
+    expect(() => clearDraft("nope")).not.toThrow();
+  });
+});
+
+describe("pruning", () => {
+  it("keeps only the newest 100 drafts by updatedAt", () => {
+    // Insert 101 entries with strictly increasing timestamps; the oldest
+    // (scope "draft-0") must be evicted once the cap is exceeded.
+    for (let i = 0; i < 101; i++) {
+      saveDraft(`draft-${i}`, { text: `body ${i}` }, 1000 + i);
+    }
+    expect(loadDraft("draft-0")).toBeNull();
+    expect(loadDraft("draft-1")?.text).toBe("body 1");
+    expect(loadDraft("draft-100")?.text).toBe("body 100");
+  });
+});
+
+describe("robustness", () => {
+  it("recovers from corrupt JSON in storage", () => {
+    window.localStorage.setItem(STORAGE_KEY, "{not valid json");
+    expect(loadDraft("chat-1")).toBeNull();
+    // A subsequent save still works (corrupt blob is replaced).
+    saveDraft("chat-1", { text: "recovered" });
+    expect(loadDraft("chat-1")?.text).toBe("recovered");
+  });
+
+  it("ignores malformed entries", () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ "chat-1": { text: 42 }, "chat-2": { text: "ok", updatedAt: 1 } }),
+    );
+    expect(loadDraft("chat-1")).toBeNull();
+    expect(loadDraft("chat-2")?.text).toBe("ok");
+  });
+});
+
+describe("newChatDraftScope", () => {
+  it("encodes org + seed participants", () => {
+    expect(newChatDraftScope("org-7", ["a", "b"])).toBe("new:org-7:a,b");
+  });
+
+  it("falls back to no-org and empty participants", () => {
+    expect(newChatDraftScope(null)).toBe("new:no-org:");
+  });
+});

--- a/packages/web/src/lib/__tests__/use-chat-draft-text.test.tsx
+++ b/packages/web/src/lib/__tests__/use-chat-draft-text.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createDomHarness, type DomHarness } from "../../test-utils/dom-harness.js";
+import { loadDraft, saveDraft } from "../draft-store.js";
+import { useChatDraftText } from "../use-chat-draft-text.js";
+
+let h: DomHarness;
+
+beforeEach(() => {
+  window.localStorage.clear();
+  h = createDomHarness();
+});
+afterEach(() => h.cleanup());
+
+/** Probe: surfaces the hook's draft text and buttons to mutate it. Rendering
+ *  it with a changing `chatId` (same element type at the root) reconciles in
+ *  place — it does NOT remount — which is exactly how ChatView switches chats. */
+function Probe({ chatId }: { chatId: string }) {
+  const [draft, setDraft] = useChatDraftText(chatId);
+  return (
+    <div>
+      <span data-testid="draft">{draft}</span>
+      <button type="button" data-testid="type" onClick={() => setDraft(`body-${chatId}`)}>
+        type
+      </button>
+      <button type="button" data-testid="clear" onClick={() => setDraft("")}>
+        clear
+      </button>
+    </div>
+  );
+}
+
+function draftText(): string {
+  return h.container.querySelector('[data-testid="draft"]')?.textContent ?? "";
+}
+
+async function click(testid: string): Promise<void> {
+  const btn = h.container.querySelector<HTMLButtonElement>(`[data-testid="${testid}"]`);
+  if (!btn) throw new Error(`button ${testid} not found`);
+  await act(async () => {
+    btn.click();
+    await Promise.resolve();
+  });
+}
+
+describe("useChatDraftText", () => {
+  it("seeds the initial value from the stored draft for the chat", async () => {
+    saveDraft("chat-a", { text: "preexisting" });
+    h.render(<Probe chatId="chat-a" />);
+    await h.flush();
+    expect(draftText()).toBe("preexisting");
+  });
+
+  it("persists typed text under the chat scope", async () => {
+    h.render(<Probe chatId="chat-a" />);
+    await click("type");
+    expect(draftText()).toBe("body-chat-a");
+    expect(loadDraft("chat-a")?.text).toBe("body-chat-a");
+  });
+
+  it("swaps drafts on chat switch without leaking across chats", async () => {
+    h.render(<Probe chatId="chat-a" />);
+    await click("type"); // stored under chat-a
+
+    // Switch to a chat with no stored draft → composer is empty.
+    h.render(<Probe chatId="chat-b" />);
+    await h.flush();
+    expect(draftText()).toBe("");
+
+    await click("type"); // stored under chat-b
+    expect(loadDraft("chat-b")?.text).toBe("body-chat-b");
+
+    // Back to chat-a → its draft is restored, chat-a's text was never lost.
+    h.render(<Probe chatId="chat-a" />);
+    await h.flush();
+    expect(draftText()).toBe("body-chat-a");
+  });
+
+  it("clears the stored draft when emptied (mirrors clearing on send)", async () => {
+    h.render(<Probe chatId="chat-a" />);
+    await click("type");
+    expect(loadDraft("chat-a")).not.toBeNull();
+    await click("clear");
+    expect(draftText()).toBe("");
+    expect(loadDraft("chat-a")).toBeNull();
+  });
+});

--- a/packages/web/src/lib/__tests__/use-chat-draft-text.test.tsx
+++ b/packages/web/src/lib/__tests__/use-chat-draft-text.test.tsx
@@ -3,7 +3,7 @@
 import { act } from "react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createDomHarness, type DomHarness } from "../../test-utils/dom-harness.js";
-import { loadDraft, saveDraft } from "../draft-store.js";
+import { chatDraftScope, loadDraft, saveDraft } from "../draft-store.js";
 import { useChatDraftText } from "../use-chat-draft-text.js";
 
 let h: DomHarness;
@@ -15,10 +15,11 @@ beforeEach(() => {
 afterEach(() => h.cleanup());
 
 /** Probe: surfaces the hook's draft text and buttons to mutate it. Rendering
- *  it with a changing `chatId` (same element type at the root) reconciles in
- *  place — it does NOT remount — which is exactly how ChatView switches chats. */
-function Probe({ chatId }: { chatId: string }) {
-  const [draft, setDraft] = useChatDraftText(chatId);
+ *  it with a changing `chatId` / `userId` (same element type at the root)
+ *  reconciles in place — it does NOT remount — which is exactly how ChatView
+ *  switches chats (and how a re-login swaps the user without a fresh mount). */
+function Probe({ userId = "user-1", chatId }: { userId?: string; chatId: string }) {
+  const [draft, setDraft] = useChatDraftText(userId, chatId);
   return (
     <div>
       <span data-testid="draft">{draft}</span>
@@ -46,18 +47,18 @@ async function click(testid: string): Promise<void> {
 }
 
 describe("useChatDraftText", () => {
-  it("seeds the initial value from the stored draft for the chat", async () => {
-    saveDraft("chat-a", { text: "preexisting" });
+  it("seeds the initial value from the stored draft for the user + chat", async () => {
+    saveDraft(chatDraftScope("user-1", "chat-a"), { text: "preexisting" });
     h.render(<Probe chatId="chat-a" />);
     await h.flush();
     expect(draftText()).toBe("preexisting");
   });
 
-  it("persists typed text under the chat scope", async () => {
+  it("persists typed text under the user + chat scope", async () => {
     h.render(<Probe chatId="chat-a" />);
     await click("type");
     expect(draftText()).toBe("body-chat-a");
-    expect(loadDraft("chat-a")?.text).toBe("body-chat-a");
+    expect(loadDraft(chatDraftScope("user-1", "chat-a"))?.text).toBe("body-chat-a");
   });
 
   it("swaps drafts on chat switch without leaking across chats", async () => {
@@ -70,7 +71,7 @@ describe("useChatDraftText", () => {
     expect(draftText()).toBe("");
 
     await click("type"); // stored under chat-b
-    expect(loadDraft("chat-b")?.text).toBe("body-chat-b");
+    expect(loadDraft(chatDraftScope("user-1", "chat-b"))?.text).toBe("body-chat-b");
 
     // Back to chat-a → its draft is restored, chat-a's text was never lost.
     h.render(<Probe chatId="chat-a" />);
@@ -78,12 +79,22 @@ describe("useChatDraftText", () => {
     expect(draftText()).toBe("body-chat-a");
   });
 
+  it("does not leak a draft across users on the same chat", async () => {
+    h.render(<Probe userId="user-1" chatId="chat-a" />);
+    await click("type"); // stored under user-1 / chat-a
+
+    // A different account opens the same chat in the same browser → empty.
+    h.render(<Probe userId="user-2" chatId="chat-a" />);
+    await h.flush();
+    expect(draftText()).toBe("");
+  });
+
   it("clears the stored draft when emptied (mirrors clearing on send)", async () => {
     h.render(<Probe chatId="chat-a" />);
     await click("type");
-    expect(loadDraft("chat-a")).not.toBeNull();
+    expect(loadDraft(chatDraftScope("user-1", "chat-a"))).not.toBeNull();
     await click("clear");
     expect(draftText()).toBe("");
-    expect(loadDraft("chat-a")).toBeNull();
+    expect(loadDraft(chatDraftScope("user-1", "chat-a"))).toBeNull();
   });
 });

--- a/packages/web/src/lib/draft-store.ts
+++ b/packages/web/src/lib/draft-store.ts
@@ -1,0 +1,129 @@
+/**
+ * Local (browser-only) cache for unsent composer drafts.
+ *
+ * Persists what a user has typed but not yet sent so it survives chat
+ * switches and page reloads. Scope is per chat for the in-chat composer
+ * (keyed by chatId) and one per-(org, seed-participants) scope for the
+ * "new chat" composer (see `newChatDraftScope`). Storage is `localStorage`,
+ * so drafts are intentionally local to one browser — they do not sync across
+ * devices or browsers.
+ *
+ * All entries live under ONE `localStorage` key as a JSON map. A single key
+ * keeps "clear on send" and the size cap one-object operations and avoids
+ * scanning every key in the namespace.
+ */
+
+const STORAGE_KEY = "first-tree:chat-drafts:v1";
+
+/** Cap on retained drafts; oldest-by-`updatedAt` are pruned past this. Drafts
+ *  are small, but ones for chats the user abandoned should not grow
+ *  `localStorage` without bound. */
+const MAX_ENTRIES = 100;
+
+/** A persisted draft. `participantIds` is only meaningful for the new-chat
+ *  composer (the in-chat composer never sets it). */
+type StoredDraft = {
+  text: string;
+  participantIds?: string[];
+  updatedAt: number;
+};
+
+/** What callers read back: the typed body and (new-chat only) chosen chips. */
+export type DraftSnapshot = {
+  text: string;
+  participantIds: string[];
+};
+
+type DraftMap = Record<string, StoredDraft>;
+
+function isStoredDraft(v: unknown): v is StoredDraft {
+  if (typeof v !== "object" || v === null) return false;
+  if (!("text" in v) || typeof v.text !== "string") return false;
+  if ("participantIds" in v && v.participantIds !== undefined && !Array.isArray(v.participantIds)) return false;
+  if (!("updatedAt" in v) || typeof v.updatedAt !== "number") return false;
+  return true;
+}
+
+function readMap(): DraftMap {
+  if (typeof window === "undefined") return {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null) return {};
+    const out: DraftMap = {};
+    for (const [k, v] of Object.entries(parsed)) {
+      if (isStoredDraft(v)) out[k] = v;
+    }
+    return out;
+  } catch {
+    // Corrupt JSON or unavailable storage — start from empty rather than throw.
+    return {};
+  }
+}
+
+function writeMap(map: DraftMap): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
+  } catch {
+    // localStorage may be unavailable (private mode) or full; drafts are a
+    // best-effort convenience, so a write failure is silently ignored.
+  }
+}
+
+/** Keep only the newest `MAX_ENTRIES` drafts by `updatedAt`. */
+function prune(map: DraftMap): DraftMap {
+  const entries = Object.entries(map);
+  if (entries.length <= MAX_ENTRIES) return map;
+  entries.sort((a, b) => b[1].updatedAt - a[1].updatedAt);
+  return Object.fromEntries(entries.slice(0, MAX_ENTRIES));
+}
+
+/** Stable storage scope for the "new chat" composer. Mirrors the remount key
+ *  used by the center-panel router (org + seed participants) so each distinct
+ *  compose context keeps its own draft. */
+export function newChatDraftScope(organizationId: string | null, withIds?: readonly string[]): string {
+  return `new:${organizationId ?? "no-org"}:${(withIds ?? []).join(",")}`;
+}
+
+/** Read the stored draft for `scope`, or `null` when none is stored. */
+export function loadDraft(scope: string): DraftSnapshot | null {
+  const entry = readMap()[scope];
+  if (!entry) return null;
+  return { text: entry.text, participantIds: entry.participantIds ?? [] };
+}
+
+/**
+ * Persist (or clear) the draft for `scope`. A draft with no typed body is
+ * treated as empty and removes the entry — participant chips are remembered
+ * only alongside real text, never on their own (an auto-seeded default chip
+ * must not masquerade as an unsent draft).
+ */
+export function saveDraft(
+  scope: string,
+  draft: { text: string; participantIds?: readonly string[] },
+  now: number = Date.now(),
+): void {
+  const map = readMap();
+  if (draft.text.trim().length === 0) {
+    if (scope in map) {
+      delete map[scope];
+      writeMap(map);
+    }
+    return;
+  }
+  const participantIds =
+    draft.participantIds && draft.participantIds.length > 0 ? [...draft.participantIds] : undefined;
+  map[scope] = { text: draft.text, participantIds, updatedAt: now };
+  writeMap(prune(map));
+}
+
+/** Remove any stored draft for `scope` (used on successful send). */
+export function clearDraft(scope: string): void {
+  const map = readMap();
+  if (scope in map) {
+    delete map[scope];
+    writeMap(map);
+  }
+}

--- a/packages/web/src/lib/draft-store.ts
+++ b/packages/web/src/lib/draft-store.ts
@@ -80,11 +80,28 @@ function prune(map: DraftMap): DraftMap {
   return Object.fromEntries(entries.slice(0, MAX_ENTRIES));
 }
 
-/** Stable storage scope for the "new chat" composer. Mirrors the remount key
- *  used by the center-panel router (org + seed participants) so each distinct
+/** Per-user prefix so a shared browser never restores another account's draft
+ *  after a logout/login on the same profile — `logout()` clears tokens and
+ *  query state, not this store. Mirrors the userId-bucketed selected-org
+ *  storage in auth-context (`first-tree:selectedOrganizationId:<userId>`). */
+function userPrefix(userId: string | null): string {
+  return `u:${userId ?? "anon"}`;
+}
+
+/** Storage scope for the in-chat composer: per user, per chat. */
+export function chatDraftScope(userId: string | null, chatId: string): string {
+  return `${userPrefix(userId)}:chat:${chatId}`;
+}
+
+/** Storage scope for the "new chat" composer: per user, per (org, seed
+ *  participants) — mirroring the center-panel remount key so each distinct
  *  compose context keeps its own draft. */
-export function newChatDraftScope(organizationId: string | null, withIds?: readonly string[]): string {
-  return `new:${organizationId ?? "no-org"}:${(withIds ?? []).join(",")}`;
+export function newChatDraftScope(
+  userId: string | null,
+  organizationId: string | null,
+  withIds?: readonly string[],
+): string {
+  return `${userPrefix(userId)}:new:${organizationId ?? "no-org"}:${(withIds ?? []).join(",")}`;
 }
 
 /** Read the stored draft for `scope`, or `null` when none is stored. */

--- a/packages/web/src/lib/use-chat-draft-text.ts
+++ b/packages/web/src/lib/use-chat-draft-text.ts
@@ -1,0 +1,36 @@
+import { type Dispatch, type SetStateAction, useEffect, useRef, useState } from "react";
+import { loadDraft, saveDraft } from "./draft-store.js";
+
+/**
+ * In-chat composer draft text, persisted per chat in browser-local storage.
+ *
+ * A drop-in for `useState("")`: returns `[draft, setDraft]`. On top of plain
+ * state it (a) seeds the initial value from the stored draft for `chatId`,
+ * (b) writes every change back to storage, and (c) swaps to the target chat's
+ * stored draft when `chatId` changes.
+ *
+ * The swap matters because `ChatView` is NOT remounted on chat switch (the
+ * chat-detail query just refetches by id) — without it the single `draft`
+ * state would leak one chat's unsent text into the next chat. An empty draft
+ * removes its stored entry, so a successful send (which sets the draft to "")
+ * also clears the cache.
+ */
+export function useChatDraftText(chatId: string): [string, Dispatch<SetStateAction<string>>] {
+  const [draft, setDraft] = useState<string>(() => loadDraft(chatId)?.text ?? "");
+  // The chat the current `draft` value belongs to. Lets the persist effect
+  // write under the right scope and detect a chat switch (the prop changes a
+  // render before the state catches up).
+  const scopeRef = useRef(chatId);
+
+  useEffect(() => {
+    if (scopeRef.current === chatId) return;
+    scopeRef.current = chatId;
+    setDraft(loadDraft(chatId)?.text ?? "");
+  }, [chatId]);
+
+  useEffect(() => {
+    saveDraft(scopeRef.current, { text: draft });
+  }, [draft]);
+
+  return [draft, setDraft];
+}

--- a/packages/web/src/lib/use-chat-draft-text.ts
+++ b/packages/web/src/lib/use-chat-draft-text.ts
@@ -1,32 +1,35 @@
 import { type Dispatch, type SetStateAction, useEffect, useRef, useState } from "react";
-import { loadDraft, saveDraft } from "./draft-store.js";
+import { chatDraftScope, loadDraft, saveDraft } from "./draft-store.js";
 
 /**
- * In-chat composer draft text, persisted per chat in browser-local storage.
+ * In-chat composer draft text, persisted per user + chat in browser-local
+ * storage.
  *
  * A drop-in for `useState("")`: returns `[draft, setDraft]`. On top of plain
- * state it (a) seeds the initial value from the stored draft for `chatId`,
- * (b) writes every change back to storage, and (c) swaps to the target chat's
- * stored draft when `chatId` changes.
+ * state it (a) seeds the initial value from the stored draft for this user +
+ * chat, (b) writes every change back to storage, and (c) swaps to the target
+ * chat's stored draft when the chat (or the signed-in user) changes.
  *
  * The swap matters because `ChatView` is NOT remounted on chat switch (the
  * chat-detail query just refetches by id) — without it the single `draft`
  * state would leak one chat's unsent text into the next chat. An empty draft
  * removes its stored entry, so a successful send (which sets the draft to "")
- * also clears the cache.
+ * also clears the cache. Keys are user-scoped so a shared browser never
+ * restores another account's unsent text.
  */
-export function useChatDraftText(chatId: string): [string, Dispatch<SetStateAction<string>>] {
-  const [draft, setDraft] = useState<string>(() => loadDraft(chatId)?.text ?? "");
-  // The chat the current `draft` value belongs to. Lets the persist effect
-  // write under the right scope and detect a chat switch (the prop changes a
+export function useChatDraftText(userId: string | null, chatId: string): [string, Dispatch<SetStateAction<string>>] {
+  const scope = chatDraftScope(userId, chatId);
+  const [draft, setDraft] = useState<string>(() => loadDraft(scope)?.text ?? "");
+  // The scope the current `draft` value belongs to. Lets the persist effect
+  // write under the right scope and detect a switch (the scope changes a
   // render before the state catches up).
-  const scopeRef = useRef(chatId);
+  const scopeRef = useRef(scope);
 
   useEffect(() => {
-    if (scopeRef.current === chatId) return;
-    scopeRef.current = chatId;
-    setDraft(loadDraft(chatId)?.text ?? "");
-  }, [chatId]);
+    if (scopeRef.current === scope) return;
+    scopeRef.current = scope;
+    setDraft(loadDraft(scope)?.text ?? "");
+  }, [scope]);
 
   useEffect(() => {
     saveDraft(scopeRef.current, { text: draft });

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -1074,11 +1074,11 @@ export function ChatView({
    * `ChatRowAvatar` on the left rail (both feed `resolveAvatarHue`).
    */
   const agentColorToken = useCallback((id: string) => agentIdentity(id)?.avatarColorToken ?? null, [agentIdentity]);
-  const { agentId: myAgentId, memberId: myMemberId } = useAuth();
-  // Unsent draft text, cached per chat in browser-local storage so it survives
-  // chat switches and reloads (ChatView is not remounted on switch). Clearing
-  // the draft on send empties its stored entry.
-  const [draft, setDraft] = useChatDraftText(chatId);
+  const { agentId: myAgentId, memberId: myMemberId, user } = useAuth();
+  // Unsent draft text, cached per user + chat in browser-local storage so it
+  // survives chat switches and reloads (ChatView is not remounted on switch).
+  // Clearing the draft on send empties its stored entry.
+  const [draft, setDraft] = useChatDraftText(user?.id ?? null, chatId);
   const [cursor, setCursor] = useState(0);
   const [uploading, setUploading] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -114,6 +114,7 @@ import { attachmentIdFromHref, parseFailedDocHref, wrapFailedDocMentions } from 
 import { isNavigableWebHref } from "../../../lib/safe-href.js";
 import { useAgentIdentityMap, useAgentNameMap } from "../../../lib/use-agent-name-map.js";
 import { useAutoResizeTextarea } from "../../../lib/use-autoresize-textarea.js";
+import { useChatDraftText } from "../../../lib/use-chat-draft-text.js";
 import { useOrgAgents } from "../../../lib/use-org-agents.js";
 import { usePendingImages } from "../../../lib/use-pending-images.js";
 import { cn } from "../../../lib/utils.js";
@@ -1074,7 +1075,10 @@ export function ChatView({
    */
   const agentColorToken = useCallback((id: string) => agentIdentity(id)?.avatarColorToken ?? null, [agentIdentity]);
   const { agentId: myAgentId, memberId: myMemberId } = useAuth();
-  const [draft, setDraft] = useState("");
+  // Unsent draft text, cached per chat in browser-local storage so it survives
+  // chat switches and reloads (ChatView is not remounted on switch). Clearing
+  // the draft on send empties its stored entry.
+  const [draft, setDraft] = useChatDraftText(chatId);
   const [cursor, setCursor] = useState(0);
   const [uploading, setUploading] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);
@@ -1888,7 +1892,7 @@ export function ChatView({
       if (!el || el.value !== "") return;
       el.setSelectionRange(0, 0);
     });
-  }, [dockRequestId, draft]);
+  }, [dockRequestId, draft, setDraft]);
   // Reset the per-question answer state when the block moves to a DIFFERENT
   // request (the current one resolved, or a newer one became the oldest live
   // question). Selections always reset; the free-text draft is dropped only on
@@ -2669,6 +2673,7 @@ export function ChatView({
     displayName,
     requiresMention,
     readOnly,
+    setDraft,
   ]);
 
   /** AgentIds the draft text addresses via `@<name>` tokens, resolved

--- a/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
+++ b/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
@@ -16,6 +16,7 @@ import {
   MentionLabel,
   useMentionAutocomplete,
 } from "../../../components/mention-autocomplete.js";
+import { clearDraft, type DraftSnapshot, loadDraft, newChatDraftScope, saveDraft } from "../../../lib/draft-store.js";
 import { useAgentIdentityMap } from "../../../lib/use-agent-name-map.js";
 import { useAutoResizeTextarea } from "../../../lib/use-autoresize-textarea.js";
 import { useDebouncedValue } from "../../../lib/use-debounced-value.js";
@@ -79,18 +80,33 @@ export function NewChatDraft({
   initialParticipantIds?: string[];
 }) {
   const queryClient = useQueryClient();
-  const { agentId: myAgentId, memberId: myMemberId } = useAuth();
+  const { agentId: myAgentId, memberId: myMemberId, organizationId } = useAuth();
   const agentIdentity = useAgentIdentityMap();
 
-  const [chips, setChips] = useState<string[]>([]);
-  const [draft, setDraft] = useState("");
+  // Browser-local unsent-draft cache for this compose context (org + seed
+  // participants, mirroring the center-panel remount key). Read once at first
+  // render so later writes never feed back into the initial value.
+  const draftScope = useMemo(
+    () => newChatDraftScope(organizationId, initialParticipantIds),
+    [organizationId, initialParticipantIds],
+  );
+  const initialDraftRef = useRef<DraftSnapshot | null | undefined>(undefined);
+  if (initialDraftRef.current === undefined) {
+    initialDraftRef.current = loadDraft(draftScope);
+  }
+  const restoredDraft = initialDraftRef.current;
+
+  const [chips, setChips] = useState<string[]>(() => restoredDraft?.participantIds ?? []);
+  const [draft, setDraft] = useState(() => restoredDraft?.text ?? "");
   const [cursor, setCursor] = useState(0);
   const [error, setError] = useState<string | null>(null);
   const [sending, setSending] = useState(false);
   const [pickerOpen, setPickerOpen] = useState(false);
   const [pickerSearch, setPickerSearch] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const seededDefaultRef = useRef(false);
+  // Skip the default-delegate seed when a stored draft was restored — its
+  // chips (if any) are the user's own choice and must not be overwritten.
+  const seededDefaultRef = useRef(restoredDraft != null);
   const pickerContainerRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -281,6 +297,15 @@ export function NewChatDraft({
     if (defaultId) setChips([defaultId]);
   }, [orgAgentsPage?.items, myAgentId, chips.length, initialParticipantIds]);
 
+  // Persist unsent body + chosen participants for this compose context so
+  // navigating away and back (or a reload) restores the draft. saveDraft gates
+  // on a non-empty trimmed body, so chip-only state is never stored and
+  // emptying the body clears the entry; we also clear explicitly on send below
+  // because onCreated unmounts this component before the effect could flush.
+  useEffect(() => {
+    saveDraft(draftScope, { text: draft, participantIds: chips });
+  }, [draftScope, draft, chips]);
+
   const bodyMentions = useMemo(() => {
     const ps: MentionParticipant[] = candidates.map((c) => ({ agentId: c.agentId, name: c.name }));
     return extractMentions(draft, ps);
@@ -411,6 +436,7 @@ export function NewChatDraft({
       return created.chatId;
     },
     onSuccess: (chatId) => {
+      clearDraft(draftScope);
       setDraft("");
       setChips([]);
       clearImages();

--- a/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
+++ b/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
@@ -80,15 +80,16 @@ export function NewChatDraft({
   initialParticipantIds?: string[];
 }) {
   const queryClient = useQueryClient();
-  const { agentId: myAgentId, memberId: myMemberId, organizationId } = useAuth();
+  const { agentId: myAgentId, memberId: myMemberId, organizationId, user } = useAuth();
   const agentIdentity = useAgentIdentityMap();
 
-  // Browser-local unsent-draft cache for this compose context (org + seed
-  // participants, mirroring the center-panel remount key). Read once at first
+  // Browser-local unsent-draft cache for this compose context (user + org +
+  // seed participants, mirroring the center-panel remount key). User-scoped so
+  // a shared browser never restores another account's draft. Read once at first
   // render so later writes never feed back into the initial value.
   const draftScope = useMemo(
-    () => newChatDraftScope(organizationId, initialParticipantIds),
-    [organizationId, initialParticipantIds],
+    () => newChatDraftScope(user?.id ?? null, organizationId, initialParticipantIds),
+    [user?.id, organizationId, initialParticipantIds],
   );
   const initialDraftRef = useRef<DraftSnapshot | null | undefined>(undefined);
   if (initialDraftRef.current === undefined) {


### PR DESCRIPTION
## What

Cache **unsent composer input** in the browser so it survives chat switches and page reloads, for both the in-chat composer and the **new-chat** composer.

- **In-chat composer**: draft body text is cached per `chatId`. `ChatView` is not remounted on chat switch, so previously the single `draft` state both **leaked** one chat's unsent text into the next chat and was **lost on reload**. A new `useChatDraftText(chatId)` hook seeds the initial value from storage, persists every change, and swaps to the target chat's draft when `chatId` changes.
- **New-chat composer**: restores both the **body text** and the **chosen participant chips**, scoped per `(org, seed-participants)` — mirroring the center-panel remount key. Restoring chips suppresses the default-delegate seed so the user's own selection is never overwritten.
- **Clear on send**: a successful send empties the draft, which removes its stored entry; the new-chat path also clears explicitly since it unmounts on navigate.
- **Local only**: backed by `localStorage` under a single size-capped JSON map (`first-tree:chat-drafts:v1`, newest 100 kept). Drafts do not sync across browsers/devices — as requested. Chip-only state (no typed body) is intentionally **not** persisted, so an auto-seeded default chip never masquerades as an unsent draft. Images are out of scope.

## Why

Users lose half-written messages when they glance at another chat or reload, and the in-chat draft leaking into the wrong chat is a latent correctness bug. This keeps each composer's unsent content where the user left it.

## Files

- `packages/web/src/lib/draft-store.ts` — localStorage draft store (load/save/clear, scope helper, pruning, corruption-safe)
- `packages/web/src/lib/use-chat-draft-text.ts` — per-chat draft hook (drop-in for `useState`)
- `packages/web/src/pages/workspace/center/chat-view.tsx` — in-chat composer uses the hook
- `packages/web/src/pages/workspace/conversations/new-chat-draft.tsx` — restore/persist body + chips, clear on send
- `+ unit tests` for the store and the hook (swap/persist/clear behavior)

## Testing

- `tsc --noEmit` clean, `biome check` clean
- `vitest run` — all 860 tests pass (19 new). The single failing *suite*, `tests/visual-regression.spec.ts`, is a pre-existing Playwright skeleton unrelated to this change (`@playwright/test` is not installed).
- Manual UX verification still pending — see PR thread.

## Scope notes

Implementation-only, client-side UX feature — no Context Tree write (no durable cross-domain decision/constraint/ownership change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)