### PR TITLE
docs: simplify agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,6 @@
 # AGENTS.md
 
-**first-tree** — the unified CLI and infrastructure for agent teams.
-A pnpm monorepo: Server + Client + Command + Shared + Web.
+**first-tree** — the unified CLI and infrastructure for agent teams. It is a pnpm monorepo for the CLI, server, client runtime, web app, docs, and agent-team tooling.
 
 What first-tree is NOT:
 
@@ -11,124 +10,92 @@ What first-tree is NOT:
 ## Tech Stack
 
 - **Server:** Fastify / Drizzle ORM / PostgreSQL / Zod
-- **Client:** fetch + ws (SDK + AgentRuntime + pluggable Handlers)
+- **Client:** fetch + ws (SDK + AgentRuntime + pluggable handlers)
 - **Command:** Commander.js / @inquirer/prompts (unified CLI)
 - **Shared:** Zod schemas + TypeScript types + config system
 - **Web:** React 19 / Vite
-- **Tooling:** pnpm (workspace) / Turborepo / Biome / Vitest / tsdown
+- **Tooling:** pnpm / Turborepo / Biome / Vitest / tsdown
 - **Node.js:** minimum 22.13, recommended 24
 
 ## Common Commands
 
 ```bash
-pnpm install                                       # Install all dependencies
-docker compose up -d                               # Start PostgreSQL (dev)
+pnpm install
+docker compose up -d
 
-# Run the SaaS server locally (auto-runs Drizzle migrations on boot)
 pnpm --filter @first-tree/server dev
-# Web dashboard (separate terminal)
 pnpm --filter @first-tree/web dev
 
-pnpm check && pnpm typecheck                       # Run after every change
-pnpm test                                          # Vitest
+pnpm check && pnpm typecheck
+pnpm test
 
-pnpm --filter @first-tree/server db:generate   # Generate migrations
-pnpm --filter @first-tree/server db:migrate    # Apply migrations
+pnpm --filter @first-tree/server db:generate
+pnpm --filter @first-tree/server db:migrate
 ```
 
-> Full CLI commands, env vars, and per-package dev scripts: [docs/cli-reference.md](docs/cli-reference.md). All other scripts (`format`, `build`, `db:studio`, per-package `dev` / `test`) are in each package's `package.json`.
+Full CLI commands and env vars live in [docs/cli-reference.md](docs/cli-reference.md). Per-package scripts live in each package's `package.json`.
 
-## HTTP Routes & JWT Scope
+## Required Reading By Topic
 
-If your work touches HTTP routes, JWT auth, scope helpers, or anything multi-org — read [docs/development/http-path-conventions.md](docs/development/http-path-conventions.md) first. It's the single source of truth for route naming, JWT shape, and middleware choice.
-
-## Local Testing Isolation
-
-Use `scripts/dev-install.sh` to install the in-tree CLI as `first-tree-dev` on PATH. The dev binary's channel identity (`first-tree-dev` / `~/.first-tree-dev/` / `first-tree-dev.service`) gives it its own home, unit, and label — coexists with whatever prod (`first-tree`) / staging (`first-tree-staging`) install you already have running.
-
-```bash
-./scripts/dev-install.sh                  # build dist + symlink first-tree-dev / ftd into ~/.local/bin/
-first-tree-dev login <connect-token>      # token from http://127.0.0.1:8000/clients
-first-tree-dev daemon status
-```
-
-Full guide (rules, parallel dev installs, what's NOT isolated, teardown): [docs/development/local-dev-isolation.md](docs/development/local-dev-isolation.md).
+- **HTTP routes, JWT auth, scope helpers, or multi-org behavior:** read [docs/development/http-path-conventions.md](docs/development/http-path-conventions.md) before editing. It is the single source of truth.
+- **Running an in-tree CLI next to prod/staging:** use `scripts/dev-install.sh` and read [docs/development/local-dev-isolation.md](docs/development/local-dev-isolation.md).
 
 ## Repo-Local Skills
 
-- `skills/first-tree-write/SKILL.md` — source-driven Context Tree authorship guide: concept model, source-system boundary, authorship read-discipline, and how to write from a specific PR / design doc / meeting note / pasted source. No source artifact means no write task.
-- `skills/first-tree-read/SKILL.md` — task-scoped Context Tree reader-command workflow for locating and reading relevant tree files before acting on source-side work.
-- `skills/first-tree-seed/SKILL.md` — one-time bootstrap for a brand-new, still-empty Context Tree. Use only right after Cloud onboarding provisions an empty workspace/tree repo.
-- Operator-only material (`login`, `daemon install / uninstall`, `agent create / claim / bind`, etc.) is **not** in any skill — it lives in `docs/cli-reference.md` and `docs/onboarding-guide.md`. The dedicated `first-tree-cloud` skill it used to live in was retired because nearly all of its content was for human operators, not for agents at runtime.
+- `skills/first-tree-write/SKILL.md` — source-driven Context Tree authorship
+- `skills/first-tree-read/SKILL.md` — task-scoped Context Tree reading
+- `skills/first-tree-seed/SKILL.md` — one-time bootstrap for an empty tree
+
+Operator-only flows such as `login`, `daemon install`, and `agent create` belong in [docs/cli-reference.md](docs/cli-reference.md) and [docs/onboarding-guide.md](docs/onboarding-guide.md), not in skills.
 
 ## Monorepo Structure
 
-- `packages/shared/` — `@first-tree/shared` — Zod schemas + types + config system (internal, not published)
-- `packages/server/` — `@first-tree/server` — Fastify API server (private, bundled)
-- `packages/client/` — `@first-tree/client` — Agent SDK + Runtime (private, bundled)
-- `packages/web/` — `@first-tree/web` — React admin dashboard (private, bundled)
-- `apps/cli/` — `first-tree` — Unified CLI (**published**, the consumer-facing tarball; binaries `first-tree` and `ft`)
-- `docs/` — [quickstart.md](docs/quickstart.md), [onboarding-guide.md](docs/onboarding-guide.md), [cli-reference.md](docs/cli-reference.md), [observability.md](docs/observability.md), [migration/](docs/migration/), [development/](docs/development/), [troubleshooting/](docs/troubleshooting/)
-- `skills/` — repo-local skill payloads (`first-tree-write`, `first-tree-read`, `first-tree-seed`)
+- `apps/cli/` — unified CLI source; CI publishes channel-specific packages
+- `apps/doc-website/` — documentation website
+- `packages/shared/` — `@first-tree/shared` schemas, types, and config
+- `packages/server/` — `@first-tree/server` Fastify API server
+- `packages/client/` — `@first-tree/client` SDK and AgentRuntime
+- `packages/web/` — `@first-tree/web` React workspace
+- `packages/e2e/` — black-box e2e harness
+- `packages/skill-evals/` — eval tooling for repo-local skills
+- `docs/` — user, operator, development, migration, and troubleshooting docs
+- `skills/` — repo-local skill payloads
 
 ## Architecture Rules
 
-**Five independent packages, Shared in common:** Server, Client, Command, Web are independently packaged and deployed, sharing types, Zod schemas, and config system via `@first-tree/shared`. Command is the user-facing CLI for client / agent operations and depends only on Client + Shared; Server is shipped separately as the SaaS Docker image.
-
-**Stateless Server:** All persistent data lives in PostgreSQL. Server holds no business state.
-
-**PostgreSQL only:** No Redis / MQ. PG covers storage, queuing (SKIP LOCKED), and notifications (LISTEN/NOTIFY).
-
-**Unified user-JWT auth:** A single user JWT (issued by `first-tree login <token>`, stored at `<channel-home>/config/credentials.json` — `~/.first-tree/` for prod, `~/.first-tree-staging/` for staging, `~/.first-tree-dev/` for dev; see [docs/development/local-dev-isolation.md](docs/development/local-dev-isolation.md)) authorizes both Web/Admin API calls and every agent the user manages on the client WebSocket. JWT shape, route classification, and middleware choice live in [docs/development/http-path-conventions.md](docs/development/http-path-conventions.md) — this section covers only the runtime *binding* facts not in that spec. Agents bind via `agents.client_id` + a server-pushed `agent:pinned` frame; **R-RUN** is re-evaluated at every `agent:bind` against the live `agents → manager → user` join (cross-org under one user is allowed; revoked memberships refuse the bind immediately). Switching user requires `first-tree login <token> --override`, which rotates the machine's local client identity and registers a fresh clientId under the new user (there is no server-side ownership transfer; the previous owner's client row and pinned agents are left untouched). Legacy per-agent tokens were retired by migration `0020`.
-
-**Inbox is the Server/Client boundary:** Server writes to Inbox (fan-out on write); Client pulls / receives WebSocket notifications. At-least-once delivery; Client deduplicates.
-
-**Agent identity is managed by the server:** Agents are created, updated, suspended, and deleted via the Admin API. Agent profile (markdown self-description) is stored in the `agents.profile` column. Context Tree integration is optional — when configured, Client injects organizational context (AGENT.md, root NODE.md) into agent workspaces at startup.
-
-**Encrypted credentials:** Sensitive credentials (GitHub tokens, org-settings secrets) are AES-256-GCM encrypted at the application layer via `services/crypto.ts`.
-
-**UUID v7 as Message ID:** Time-ordered; messages are immutable after creation.
+- **Package boundaries:** Server, Client, Command, and Web are independently packaged/deployed and share code through `@first-tree/shared`. The CLI is the user-facing command surface and depends only on Client + Shared. Server ships separately as the SaaS Docker image.
+- **Server state:** Server is stateless. PostgreSQL is the only persistence/queue/notification backend; do not add Redis or MQ.
+- **Unified user-JWT auth:** A single user JWT authorizes Web/Admin API calls and every agent the user manages on the client WebSocket. Route classification, JWT shape, and scope helpers live in [docs/development/http-path-conventions.md](docs/development/http-path-conventions.md). Channel homes live in [docs/development/local-dev-isolation.md](docs/development/local-dev-isolation.md). Agents bind via `agents.client_id` + `agent:pinned`; R-RUN is re-evaluated at every `agent:bind`. Switching users requires `first-tree login <token> --override`.
+- **Inbox boundary:** Server writes to Inbox; Client pulls / receives WebSocket notifications. Delivery is at-least-once; Client deduplicates.
+- **Agent identity:** Agents are managed by the server Admin API. Agent profile markdown lives in `agents.profile`. Context Tree integration is optional and injected by Client at workspace startup.
+- **Credentials:** Sensitive credentials are AES-256-GCM encrypted at the application layer via `services/crypto.ts`.
+- **Messages:** Message IDs are UUID v7 and messages are immutable after creation.
 
 ## Coding Conventions
 
-- **No `any`**: Use `unknown` + type narrowing
-- **No `as` assertions**: Unless unavoidable with third-party libs; add comment explaining why
-- **No `enum`**: Use `as const` objects for Zod compatibility
-- **Type imports**: `import type { Foo } from ...`
-- **Prefer `type`**: Use `interface` only when `extends` / `implements` is needed
-- **Public APIs must have explicit return types**; internal functions may rely on inference
-- **Barrel exports**: Each package's `src/index.ts` is the sole public entry point
-- **Zod as single source of truth**: Define DTOs with Zod, derive types via `z.infer<typeof schema>`
-- **Schema naming**: schemas in camelCase (`createAgentSchema`), types in PascalCase (`CreateAgent`)
-- **Never hand-edit Drizzle migrations**: `drizzle-kit generate` to create, `drizzle-kit migrate` to apply
-- **Custom error classes**: Services throw exceptions, API layer maps to HTTP status codes; no empty `catch {}`
-- **Naming**: files `kebab-case.ts`, types `PascalCase`, variables/functions `camelCase`, constants `UPPER_SNAKE_CASE`
-- **English everywhere on GitHub**: all code, comments, commits, PRs, issues, branch names, and CI logs — anything visible in the repo.
-- **Run after changes**: `pnpm check && pnpm typecheck`
+- Use `unknown` + type narrowing instead of `any`.
+- Avoid `as` assertions; when unavoidable for third-party libraries, explain why nearby.
+- Do not use `enum`; use `as const` objects and Zod-compatible literals.
+- Use `import type`, prefer `type` over `interface` unless extension/implementation requires an interface, and give public APIs explicit return types.
+- Each package's `src/index.ts` is its public entry point.
+- Zod is the source of truth for DTOs; derive TypeScript types with `z.infer<typeof schema>`.
+- Never hand-edit Drizzle migrations; use `drizzle-kit generate` and `drizzle-kit migrate`.
+- Services throw exceptions and API layers map them to HTTP status codes; do not use empty `catch {}` blocks.
+- Follow existing naming and Biome formatting.
+- English everywhere on GitHub: code, comments, commits, PRs, issues, branch names, and CI logs.
+- Run `pnpm check && pnpm typecheck` after changes. Run `pnpm test` before opening a PR unless the change is clearly docs-only.
 
 ## Development Workflow
 
-### New Feature Steps (Server)
+- Update shared schemas/types first when a change crosses packages.
+- Server features usually flow: shared schema -> Drizzle table (if persistent) -> service -> API route -> migration -> tests.
+- Client SDK methods live in `sdk.ts`; handlers register in `handlers/`; runtime changes live under `runtime/`.
+- CLI business logic belongs in `core/`; command files should stay thin and call `core/*`. Wire commands in `cli/index.ts`, and export public helpers from both `core/index.ts` and `src/index.ts`.
+- Config changes belong in `shared/src/config/`.
 
-Zod schema (in `shared`) → Drizzle table (if persistent) → service → API routes → `db:generate` + `db:migrate` → tests. Order matters: types flow left-to-right.
+## Git Conventions
 
-### New Feature Steps (Client)
-
-SDK methods live in `sdk.ts`, handlers register in `handlers/`, runtime changes go in `runtime/` (AgentRuntime / AgentSlot / SessionManager). If shared types are involved, update `shared/` **first** or imports will break.
-
-### New Feature Steps (Command)
-
-1. Business logic → `core/` (exportable, no CLI-specific concerns)
-2. CLI registration → `commands/` (thin arg parsing that calls `core/*`)
-3. Wire into `cli/index.ts`
-4. Export from **both** `core/index.ts` **and** `src/index.ts` — easy to forget, breaks external consumers
-5. Config changes → schema in `shared/src/config/`
-
-### Git Conventions
-
-- **Branching**: trunk-based; feature branch → PR → squash merge → main
-- **Branch naming**: CI accepts only `feat/xxx`, `fix/xxx`, `refactor/xxx`, `test/xxx`, `docs/xxx`, `chore/xxx`, or `merge/xxx`. Do not use agent/person prefixes such as `codex/xxx`.
-- **Commit messages**: Conventional Commits — `feat: xxx`, `fix: xxx`, `refactor: xxx`, `test: xxx`, `docs: xxx`
-- **Releases**: tag + GitHub Release
-- **Do not edit `version` fields in any `package.json`.** Version bumps are handled by CI on tag push, or manually by a maintainer cutting a tag. Coding agents must not touch `version` as part of a feature/fix PR.
-- Do not auto-commit; wait for user to test and confirm before committing
+- Branching: trunk-based; feature branch -> PR -> squash merge -> main.
+- Branch naming: CI accepts only `feat/xxx`, `fix/xxx`, `refactor/xxx`, `test/xxx`, `docs/xxx`, `chore/xxx`, or `merge/xxx`. Do not use agent/person prefixes such as `codex/xxx`.
+- Commit messages: Conventional Commits, e.g. `feat: xxx`, `fix: xxx`, `refactor: xxx`, `test: xxx`, `docs: xxx`.
+- Do not edit `version` fields in any `package.json`. Version bumps are handled by CI on tag push or by a maintainer cutting a tag.


### PR DESCRIPTION
## Summary

- Simplify the root `AGENTS.md` so it stays focused on agent-facing constraints and routing.
- Remove the stale `Do not auto-commit` rule and route detailed HTTP/JWT, local-dev, operator, and skill material to the canonical docs.
- Refresh the monorepo structure list to include `apps/doc-website`, `packages/e2e`, and `packages/skill-evals`.

## Validation

- [x] `pnpm check`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — not run; docs-only change.
- [x] `git diff --check`
- [x] codex-reviewer read-only review: no blocking findings.

## Change Surface

- [ ] `apps/cli` public CLI or help output
- [ ] tree onboarding / binding / inspection behavior
- [ ] shipped or planned skill topology
- [x] docs or contributor-facing repository metadata
- [ ] CI / packaging / release plumbing

## Notes

- package or install behavior changes: none
- docs or tests updated to match: root `AGENTS.md` only
- follow-up work: none
