### PR TITLE
fix(web): keep failed-send draft rollback in its originating chat

### DIFF
--- a/packages/web/src/lib/__tests__/draft-store.test.ts
+++ b/packages/web/src/lib/__tests__/draft-store.test.ts
@@ -1,7 +1,14 @@
 // @vitest-environment happy-dom
 
 import { beforeEach, describe, expect, it } from "vitest";
-import { chatDraftScope, clearDraft, loadDraft, newChatDraftScope, saveDraft } from "../draft-store.js";
+import {
+  chatDraftScope,
+  clearDraft,
+  loadDraft,
+  newChatDraftScope,
+  parkFailedDraftIfSwitched,
+  saveDraft,
+} from "../draft-store.js";
 
 const STORAGE_KEY = "first-tree:chat-drafts:v1";
 
@@ -125,5 +132,30 @@ describe("scope helpers", () => {
     // Same for the new-chat composer within one org.
     saveDraft(newChatDraftScope("user-a", "org-1"), { text: "A's new chat" });
     expect(loadDraft(newChatDraftScope("user-b", "org-1"))).toBeNull();
+  });
+});
+
+describe("parkFailedDraftIfSwitched", () => {
+  it("returns false and stores nothing when still in the originating chat", () => {
+    expect(parkFailedDraftIfSwitched("user-1", "chat-a", "chat-a", "retry me")).toBe(false);
+    expect(loadDraft(chatDraftScope("user-1", "chat-a"))).toBeNull();
+  });
+
+  it("parks the failed text in the originating chat when the user switched away", () => {
+    // Send started in chat-a, but the user is now viewing chat-b.
+    expect(parkFailedDraftIfSwitched("user-1", "chat-a", "chat-b", "retry me")).toBe(true);
+    expect(loadDraft(chatDraftScope("user-1", "chat-a"))?.text).toBe("retry me");
+    // The chat now in view must be left untouched (no cross-chat leak).
+    expect(loadDraft(chatDraftScope("user-1", "chat-b"))).toBeNull();
+  });
+
+  it("parks nothing for an empty rollback even after a switch", () => {
+    expect(parkFailedDraftIfSwitched("user-1", "chat-a", "chat-b", "   ")).toBe(true);
+    expect(loadDraft(chatDraftScope("user-1", "chat-a"))).toBeNull();
+  });
+
+  it("parks under the originating user's scope only", () => {
+    parkFailedDraftIfSwitched("user-1", "chat-a", "chat-b", "retry me");
+    expect(loadDraft(chatDraftScope("user-2", "chat-a"))).toBeNull();
   });
 });

--- a/packages/web/src/lib/draft-store.ts
+++ b/packages/web/src/lib/draft-store.ts
@@ -144,3 +144,25 @@ export function clearDraft(scope: string): void {
     writeMap(map);
   }
 }
+
+/**
+ * Decide where a failed send's unsent text belongs. A send started in chat
+ * `sendChatId` can resolve AFTER the user switched to `currentChatId`; the
+ * rejected text must never be restored into the current composer then — it
+ * belongs to a different chat, and the in-chat draft state is shared across
+ * chats. Returns `true` when it parked the text in the originating chat's own
+ * cache (the caller must leave the live composer untouched); returns `false`
+ * when the user is still in the originating chat, so the caller restores the
+ * text into the live composer as usual.
+ */
+export function parkFailedDraftIfSwitched(
+  userId: string | null,
+  sendChatId: string,
+  currentChatId: string,
+  text: string,
+): boolean {
+  if (currentChatId === sendChatId) return false;
+  // saveDraft no-ops on empty text, so a blank rollback parks nothing.
+  saveDraft(chatDraftScope(userId, sendChatId), { text });
+  return true;
+}

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -111,6 +111,7 @@ import { useReadTracker } from "../../../hooks/use-read-tracker.js";
 import { useServerChannel } from "../../../hooks/use-server-channel.js";
 import { viewOf } from "../../../lib/agent-status-view.js";
 import { attachmentIdFromHref, parseFailedDocHref, wrapFailedDocMentions } from "../../../lib/doc-preview-links.js";
+import { parkFailedDraftIfSwitched } from "../../../lib/draft-store.js";
 import { isNavigableWebHref } from "../../../lib/safe-href.js";
 import { useAgentIdentityMap, useAgentNameMap } from "../../../lib/use-agent-name-map.js";
 import { useAutoResizeTextarea } from "../../../lib/use-autoresize-textarea.js";
@@ -1079,6 +1080,14 @@ export function ChatView({
   // survives chat switches and reloads (ChatView is not remounted on switch).
   // Clearing the draft on send empties its stored entry.
   const [draft, setDraft] = useChatDraftText(user?.id ?? null, chatId);
+  // Always-current chat id for async send rollbacks: a send that FAILS after
+  // the user switched chats must restore its rejected text into the originating
+  // chat, never the one now in view (the draft state is shared and ChatView
+  // isn't remounted on switch).
+  const chatIdRef = useRef(chatId);
+  useEffect(() => {
+    chatIdRef.current = chatId;
+  }, [chatId]);
   const [cursor, setCursor] = useState(0);
   const [uploading, setUploading] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);
@@ -1497,9 +1506,9 @@ export function ChatView({
       const previousDraft = draft;
       setDraft("");
       const optimistic = buildOptimisticTextMessage(content, { mentions, inReplyTo, resolves });
-      if (!optimistic) return { tempId: null, previousDraft };
+      if (!optimistic) return { tempId: null, previousDraft, sendChatId: chatId };
       insertOwnOptimisticMessage(optimistic);
-      return { tempId: optimistic.id, previousDraft };
+      return { tempId: optimistic.id, previousDraft, sendChatId: chatId };
     },
     onSuccess: (saved, _content, ctx) => {
       if (ctx?.tempId) replaceOptimisticMessage(ctx.tempId, saved);
@@ -1553,7 +1562,12 @@ export function ChatView({
       // unconditionally would overwrite the new keystrokes (PR review
       // observation #1). Functional setState reads the latest draft inside
       // React's commit so we don't race the textarea's controlled value.
-      if (ctx?.previousDraft) setDraft((current) => (current === "" ? ctx.previousDraft : current));
+      if (
+        ctx?.previousDraft &&
+        !parkFailedDraftIfSwitched(user?.id ?? null, ctx.sendChatId, chatIdRef.current, ctx.previousDraft)
+      ) {
+        setDraft((current) => (current === "" ? ctx.previousDraft : current));
+      }
     },
     // Resync against the server in the background so any fan-out side-effects
     // (e.g. server-rewritten content, mention resolution) eventually overwrite
@@ -1635,6 +1649,7 @@ export function ChatView({
       // Optimistic rows render into the cache below; rollback restores both
       // the textarea draft and any not-yet-acked optimistic tempIds on error.
       const previousDraft = draft;
+      const sendChatId = chatId;
       setDraft("");
       clearImages();
       await queryClient.cancelQueries({ queryKey: messagesQueryKey });
@@ -1751,7 +1766,12 @@ export function ChatView({
         // Only restore the pre-send draft if the user hasn't already started
         // typing something new during the upload window (PR review
         // observation #1).
-        if (previousDraft) setDraft((current) => (current === "" ? previousDraft : current));
+        if (
+          previousDraft &&
+          !parkFailedDraftIfSwitched(user?.id ?? null, sendChatId, chatIdRef.current, previousDraft)
+        ) {
+          setDraft((current) => (current === "" ? previousDraft : current));
+        }
       } finally {
         setUploading(false);
       }

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -1506,9 +1506,9 @@ export function ChatView({
       const previousDraft = draft;
       setDraft("");
       const optimistic = buildOptimisticTextMessage(content, { mentions, inReplyTo, resolves });
-      if (!optimistic) return { tempId: null, previousDraft, sendChatId: chatId };
+      if (!optimistic) return { tempId: null, previousDraft, sendChatId: chatId, sendUserId: user?.id ?? null };
       insertOwnOptimisticMessage(optimistic);
-      return { tempId: optimistic.id, previousDraft, sendChatId: chatId };
+      return { tempId: optimistic.id, previousDraft, sendChatId: chatId, sendUserId: user?.id ?? null };
     },
     onSuccess: (saved, _content, ctx) => {
       if (ctx?.tempId) replaceOptimisticMessage(ctx.tempId, saved);
@@ -1564,7 +1564,7 @@ export function ChatView({
       // React's commit so we don't race the textarea's controlled value.
       if (
         ctx?.previousDraft &&
-        !parkFailedDraftIfSwitched(user?.id ?? null, ctx.sendChatId, chatIdRef.current, ctx.previousDraft)
+        !parkFailedDraftIfSwitched(ctx.sendUserId, ctx.sendChatId, chatIdRef.current, ctx.previousDraft)
       ) {
         setDraft((current) => (current === "" ? ctx.previousDraft : current));
       }
@@ -1650,6 +1650,7 @@ export function ChatView({
       // the textarea draft and any not-yet-acked optimistic tempIds on error.
       const previousDraft = draft;
       const sendChatId = chatId;
+      const sendUserId = user?.id ?? null;
       setDraft("");
       clearImages();
       await queryClient.cancelQueries({ queryKey: messagesQueryKey });
@@ -1766,10 +1767,7 @@ export function ChatView({
         // Only restore the pre-send draft if the user hasn't already started
         // typing something new during the upload window (PR review
         // observation #1).
-        if (
-          previousDraft &&
-          !parkFailedDraftIfSwitched(user?.id ?? null, sendChatId, chatIdRef.current, previousDraft)
-        ) {
+        if (previousDraft && !parkFailedDraftIfSwitched(sendUserId, sendChatId, chatIdRef.current, previousDraft)) {
           setDraft((current) => (current === "" ? previousDraft : current));
         }
       } finally {


### PR DESCRIPTION
Follow-up to #1165 addressing a Codex P2 found on that PR.

## Bug

The composer clears the draft optimistically on send and restores it on failure (`setDraft(previousDraft)` when the live composer is still empty). The in-chat `draft` state is **shared** and `ChatView` isn't remounted on chat switch — so if the user switches from chat A to chat B **during** an in-flight send that then **fails**, the rollback writes chat A's rejected text into chat B's composer, and the per-chat draft hook persists it under **chat B's** key. Chat A's text is misfiled into chat B.

This affects both send paths (text and image/file).

## Fix

- Thread the **send-time `chatId`** through the send context (`sendChatId`), and track the **currently-viewed `chatId`** in a ref.
- New pure helper `parkFailedDraftIfSwitched(userId, sendChatId, currentChatId, text)`:
  - same chat → returns `false`, caller restores into the live composer as before;
  - switched away → **parks** the rejected text in the *originating* chat's own draft cache (`u:<userId>:chat:<sendChatId>`) and returns `true`, so it's neither lost nor leaked into the current composer. The user finds it waiting when they return to that chat.
- Both rollback sites (`sendMut.onError` + the image/file `catch`) go through the helper.

## Testing

- `tsc --noEmit` clean · `biome check` clean · `vitest run` 868 pass, incl. 4 new unit tests for `parkFailedDraftIfSwitched` (same-chat / switched-away park / empty-rollback no-op / per-user scope). The only failing *suite* is the pre-existing `tests/visual-regression.spec.ts` Playwright skeleton, unrelated.
- The decision logic is unit-tested; the ChatView wiring (ctx `sendChatId`, `chatIdRef`) is type-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)