### PR TITLE
fix(web): guard parked drafts against newer text and a stale chat ref

### DIFF
--- a/packages/web/src/lib/__tests__/draft-store.test.ts
+++ b/packages/web/src/lib/__tests__/draft-store.test.ts
@@ -141,6 +141,14 @@ describe("parkFailedDraftIfSwitched", () => {
     expect(loadDraft(chatDraftScope("user-1", "chat-a"))).toBeNull();
   });
 
+  it("does not clobber a newer draft already in the originating chat", () => {
+    // User switched back to chat-a, typed a replacement, then left again before
+    // the in-flight send failed — the stale rollback must not overwrite it.
+    saveDraft(chatDraftScope("user-1", "chat-a"), { text: "newer draft" });
+    expect(parkFailedDraftIfSwitched("user-1", "chat-a", "chat-b", "stale failed text")).toBe(true);
+    expect(loadDraft(chatDraftScope("user-1", "chat-a"))?.text).toBe("newer draft");
+  });
+
   it("parks the failed text in the originating chat when the user switched away", () => {
     // Send started in chat-a, but the user is now viewing chat-b.
     expect(parkFailedDraftIfSwitched("user-1", "chat-a", "chat-b", "retry me")).toBe(true);

--- a/packages/web/src/lib/draft-store.ts
+++ b/packages/web/src/lib/draft-store.ts
@@ -150,10 +150,11 @@ export function clearDraft(scope: string): void {
  * `sendChatId` can resolve AFTER the user switched to `currentChatId`; the
  * rejected text must never be restored into the current composer then — it
  * belongs to a different chat, and the in-chat draft state is shared across
- * chats. Returns `true` when it parked the text in the originating chat's own
- * cache (the caller must leave the live composer untouched); returns `false`
- * when the user is still in the originating chat, so the caller restores the
- * text into the live composer as usual.
+ * chats. Returns `true` when the user has switched away — the caller must
+ * leave the live composer untouched; the rejected text is parked in the
+ * originating chat's own cache unless a newer draft already lives there.
+ * Returns `false` when the user is still in the originating chat, so the
+ * caller restores the text into the live composer as usual.
  */
 export function parkFailedDraftIfSwitched(
   userId: string | null,
@@ -162,7 +163,10 @@ export function parkFailedDraftIfSwitched(
   text: string,
 ): boolean {
   if (currentChatId === sendChatId) return false;
-  // saveDraft no-ops on empty text, so a blank rollback parks nothing.
-  saveDraft(chatDraftScope(userId, sendChatId), { text });
+  const scope = chatDraftScope(userId, sendChatId);
+  // Park the rejected text in the originating chat, but never clobber a newer
+  // draft the user has since typed there (mirrors the same-chat rollback's
+  // "only restore into an empty composer" guard). saveDraft no-ops on empty.
+  if (loadDraft(scope) === null) saveDraft(scope, { text });
   return true;
 }

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -1083,11 +1083,11 @@ export function ChatView({
   // Always-current chat id for async send rollbacks: a send that FAILS after
   // the user switched chats must restore its rejected text into the originating
   // chat, never the one now in view (the draft state is shared and ChatView
-  // isn't remounted on switch).
+  // isn't remounted on switch). Written during render (not a passive effect) so
+  // it is already current on the first committed frame after a switch; only
+  // read inside async callbacks, never to compute render output.
   const chatIdRef = useRef(chatId);
-  useEffect(() => {
-    chatIdRef.current = chatId;
-  }, [chatId]);
+  chatIdRef.current = chatId;
   const [cursor, setCursor] = useState(0);
   const [uploading, setUploading] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);


### PR DESCRIPTION
Follow-up to #1167 addressing two Codex P2s found on its final commit. Both are narrow rollback-timing edge cases in the draft cache.

## 1. Don't clobber a newer originating-chat draft

`parkFailedDraftIfSwitched` wrote the rejected text into the originating chat's scope **unconditionally**. Sequence that loses data:
1. Send from chat A (draft cleared optimistically), switch to B.
2. Switch back to A, type a **replacement** draft, switch to B again — all while the send is still in flight.
3. The send fails → park overwrites A's *newer* draft with the stale rejected text.

Fix: park only when the originating scope is empty (`loadDraft(scope) === null`), mirroring the same-chat rollback's "restore only into an empty composer" guard. A newer draft is preserved; the helper still returns `true` so the current composer is never touched.

## 2. Track the current chat synchronously

`chatIdRef` was advanced in a passive `useEffect`, so for the first committed frame after a chat switch it still held the previous chat — a rollback resolving in that window would mis-decide same-chat vs switched. It's now written during render (only ever read inside async callbacks, never to compute render output), so it's correct on the first frame.

## Testing

- `tsc --noEmit` clean · `biome check` clean · `vitest run` 869 pass (+1 new test: park does not clobber a newer originating-chat draft). The only failing *suite* is the pre-existing `tests/visual-regression.spec.ts` Playwright skeleton, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)