### PR TITLE
fix(web): sync the chat-id ref in a layout effect, not during render

### DIFF
--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -1083,11 +1083,16 @@ export function ChatView({
   // Always-current chat id for async send rollbacks: a send that FAILS after
   // the user switched chats must restore its rejected text into the originating
   // chat, never the one now in view (the draft state is shared and ChatView
-  // isn't remounted on switch). Written during render (not a passive effect) so
-  // it is already current on the first committed frame after a switch; only
-  // read inside async callbacks, never to compute render output.
+  // isn't remounted on switch). Synced in a layout effect — it runs only for
+  // COMMITTED renders (so a concurrent render React starts then abandons can't
+  // leave the ref pointing at a chat that never committed, which a render-phase
+  // write would) and synchronously in the commit phase before any async
+  // send-failure callback for that frame can fire (so there's no stale window,
+  // unlike a passive effect). Only read inside async callbacks.
   const chatIdRef = useRef(chatId);
-  chatIdRef.current = chatId;
+  useLayoutEffect(() => {
+    chatIdRef.current = chatId;
+  }, [chatId]);
   const [cursor, setCursor] = useState(0);
   const [uploading, setUploading] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);


### PR DESCRIPTION
Follow-up to #1168 resolving a Codex P2 on its head — and, with it, an apparent contradiction between two earlier review rounds.

## Background

`chatIdRef` tracks the currently-viewed chat so an async send-*failure* rollback can tell whether the user has switched chats. Its update timing has been pulled two ways:

- The original passive `useEffect` (#1167) left the ref **stale for the first frame** after a switch — a rollback resolving in that window would mis-decide. #1167's reviewer asked to update it synchronously with render.
- So #1168 wrote `chatIdRef.current = chatId` **during render**. Codex then flagged that a render-phase write also runs for renders React **starts then abandons** (concurrent), leaving the ref pointing at a chat that never committed.

## Fix

`useLayoutEffect` is the synthesis:
- runs **only for committed renders** → concurrent-safe (an abandoned render never runs layout effects), unlike the render-phase write;
- runs **synchronously in the commit phase, before paint** → no async send-failure callback for that frame can fire before it, so there's no stale window, unlike the passive `useEffect`.

Read-only-in-async-callbacks semantics are unchanged.

## Testing

`tsc --noEmit` clean · `biome check` clean · `vitest run` 869 pass (no behavior change to assert beyond existing coverage; this is a render-timing correction). The only failing *suite* is the pre-existing `tests/visual-regression.spec.ts` Playwright skeleton, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)