### PR TITLE
fix: dedupe runtime capability refresh uploads

### DIFF
--- a/apps/cli/src/__tests__/capability-refresh.test.ts
+++ b/apps/cli/src/__tests__/capability-refresh.test.ts
@@ -1,6 +1,10 @@
 import type { CapabilityEntry, ClientCapabilities } from "@first-tree/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { CapabilityRefresher, type CapabilityRefresherDeps } from "../core/capability-refresh.js";
+import {
+  CapabilityRefresher,
+  type CapabilityRefresherDeps,
+  stableCapabilitySyncJson,
+} from "../core/capability-refresh.js";
 
 /**
  * The refresher unifies the daemon's two capability-refresh triggers — the WS
@@ -44,6 +48,20 @@ const codexMissing = (): ClientCapabilities => ({
 
 const BASE = 100;
 const MAX = 400;
+
+describe("stableCapabilitySyncJson", () => {
+  it("ignores volatile probe metadata", () => {
+    expect(
+      stableCapabilitySyncJson({
+        codex: missing({ detectedAt: "2026-06-17T00:00:15.000Z", latencyMs: 15 }),
+      }),
+    ).toBe(
+      stableCapabilitySyncJson({
+        codex: missing({ detectedAt: "2026-06-17T00:05:15.000Z", latencyMs: 925 }),
+      }),
+    );
+  });
+});
 
 function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
   let resolve!: (value: T) => void;
@@ -118,7 +136,7 @@ describe("CapabilityRefresher", () => {
   });
 
   it("skips the upload when a poll produces an unchanged snapshot, and backs off", async () => {
-    const { refresher, upload, revalidate } = makeRefresher({ initial: codexMissing() });
+    const { refresher, upload, log, revalidate } = makeRefresher({ initial: codexMissing() });
     revalidate.mockResolvedValue(codexMissing()); // never changes
 
     await refresher.start();
@@ -128,12 +146,37 @@ describe("CapabilityRefresher", () => {
     await vi.advanceTimersByTimeAsync(BASE);
     expect(revalidate).toHaveBeenCalledTimes(1);
     expect(upload).toHaveBeenCalledTimes(1);
+    expect(log).not.toHaveBeenCalled();
 
     // Nothing fires before the backed-off interval elapses.
     await vi.advanceTimersByTimeAsync(BASE);
     expect(revalidate).toHaveBeenCalledTimes(1);
 
     // Second poll at 2×BASE.
+    await vi.advanceTimersByTimeAsync(BASE);
+    expect(revalidate).toHaveBeenCalledTimes(2);
+    expect(upload).toHaveBeenCalledTimes(1);
+    refresher.stop();
+  });
+
+  it("backs off without uploading when only volatile probe metadata changes", async () => {
+    const { refresher, upload, log, revalidate } = makeRefresher({ initial: codexMissing() });
+    revalidate.mockResolvedValue({
+      ...codexMissing(),
+      codex: missing({ detectedAt: "2026-06-17T00:00:15.000Z", latencyMs: 15 }),
+    });
+
+    await refresher.start();
+    expect(upload).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(BASE);
+    expect(revalidate).toHaveBeenCalledTimes(1);
+    expect(upload).toHaveBeenCalledTimes(1);
+    expect(log).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(BASE);
+    expect(revalidate).toHaveBeenCalledTimes(1);
+
     await vi.advanceTimersByTimeAsync(BASE);
     expect(revalidate).toHaveBeenCalledTimes(2);
     expect(upload).toHaveBeenCalledTimes(1);

--- a/apps/cli/src/core/capability-refresh.ts
+++ b/apps/cli/src/core/capability-refresh.ts
@@ -6,17 +6,35 @@ import {
 } from "@first-tree/client";
 import type { ClientCapabilities } from "@first-tree/shared";
 
+const EMPTY_OMITTED_KEYS = new Set<string>();
+const VOLATILE_CAPABILITY_FIELDS = new Set(["detectedAt", "latencyMs"]);
+
 /**
  * Stable JSON stringify — sorts object keys so two capability snapshots that
- * differ only in key order serialize identically. Used to dedupe uploads: a
- * re-probe that produced the same snapshot must not re-PATCH the server.
+ * differ only in key order serialize identically.
  */
 export function stableCapabilitiesJson(value: unknown): string {
+  return stableCapabilitiesJsonWithOmittedKeys(value, EMPTY_OMITTED_KEYS);
+}
+
+/**
+ * Stable semantic snapshot for upload / backoff decisions. Probe timestamps and
+ * durations change on every run, but they do not mean the server-visible runtime
+ * readiness changed.
+ */
+export function stableCapabilitySyncJson(value: unknown): string {
+  return stableCapabilitiesJsonWithOmittedKeys(value, VOLATILE_CAPABILITY_FIELDS);
+}
+
+function stableCapabilitiesJsonWithOmittedKeys(value: unknown, omittedKeys: ReadonlySet<string>): string {
   if (value === null || typeof value !== "object") return JSON.stringify(value) ?? "null";
-  if (Array.isArray(value)) return `[${value.map((item) => stableCapabilitiesJson(item)).join(",")}]`;
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableCapabilitiesJsonWithOmittedKeys(item, omittedKeys)).join(",")}]`;
+  }
   return `{${Object.entries(value)
+    .filter(([key]) => !omittedKeys.has(key))
     .sort(([a], [b]) => a.localeCompare(b))
-    .map(([key, item]) => `${JSON.stringify(key)}:${stableCapabilitiesJson(item)}`)
+    .map(([key, item]) => `${JSON.stringify(key)}:${stableCapabilitiesJsonWithOmittedKeys(item, omittedKeys)}`)
     .join(",")}}`;
 }
 
@@ -67,7 +85,7 @@ export class CapabilityRefresher {
   private readonly revalidate: typeof revalidateCapabilities;
 
   private snapshot: ClientCapabilities | null;
-  private lastUploadedJson: string | null = null;
+  private lastUploadedSyncJson: string | null = null;
   private inFlight = false;
   /** A reconnect that landed while a refresh was in flight, to be drained (in
    * reconnect mode) once the current refresh finishes — never dropped, so the
@@ -134,10 +152,10 @@ export class CapabilityRefresher {
   }
 
   private async uploadIfChanged(capabilities: ClientCapabilities): Promise<boolean> {
-    const nextJson = stableCapabilitiesJson(capabilities);
-    if (this.lastUploadedJson === nextJson) return false;
+    const nextJson = stableCapabilitySyncJson(capabilities);
+    if (this.lastUploadedSyncJson === nextJson) return false;
     await this.deps.upload(capabilities);
-    this.lastUploadedJson = nextJson;
+    this.lastUploadedSyncJson = nextJson;
     return true;
   }
 
@@ -167,7 +185,7 @@ export class CapabilityRefresher {
           modeLabel = "poll";
         }
         probed = true;
-        const changed = stableCapabilitiesJson(next) !== stableCapabilitiesJson(previous);
+        const changed = stableCapabilitySyncJson(next) !== stableCapabilitySyncJson(previous);
         this.snapshot = next;
         // Upload is tracked separately from the probe: a probe that recovered a
         // provider to `ok` but whose PATCH failed must NOT let the poll stop —
@@ -176,10 +194,9 @@ export class CapabilityRefresher {
         let uploadFailed = false;
         try {
           const uploaded = await this.uploadIfChanged(next);
-          this.deps.log(
-            "•",
-            `runtime capabilities re-probed (${modeLabel})${uploaded ? " and uploaded" : "; unchanged, upload skipped"}`,
-          );
+          if (uploaded) {
+            this.deps.log("•", `runtime capabilities re-probed (${modeLabel}) and uploaded`);
+          }
         } catch (uploadErr) {
           uploadFailed = true;
           this.deps.log("⚠️", `capabilities upload skipped: ${message(uploadErr)}`);
@@ -236,7 +253,7 @@ export class CapabilityRefresher {
     const snap = this.snapshot;
     if (!snap) return true;
     if (hasNonOkProvider(snap)) return true;
-    return stableCapabilitiesJson(snap) !== this.lastUploadedJson;
+    return stableCapabilitySyncJson(snap) !== this.lastUploadedSyncJson;
   }
 }
 


### PR DESCRIPTION
## Summary
- Add semantic capability snapshot dedupe that ignores volatile probe metadata (`detectedAt`, `latencyMs`) for upload/backoff decisions.
- Stop logging successful background refreshes when no capability state actually changed.
- Cover volatile metadata churn so degraded provider polling backs off instead of uploading every cycle.

## Tests
- `pnpm --filter first-tree-dev exec vitest run src/__tests__/capability-refresh.test.ts --maxWorkers=2 --maxConcurrency=2`
- `pnpm check`
- `pnpm typecheck`

Note: `pnpm check` exits 0 but reports pre-existing warnings outside this change.
