### PR TITLE
fix(web): scope onboarding step resume by org so a new team isn't skipped past create-agent

### DIFF
--- a/packages/web/src/pages/onboarding/__tests__/hooks-flow.test.tsx
+++ b/packages/web/src/pages/onboarding/__tests__/hooks-flow.test.tsx
@@ -402,4 +402,64 @@ describe("onboarding hooks and flow", () => {
     await renderProbe(<Probe />);
     expect(expectHookValue(latest.current).activeStep).toBe("create-agent");
   });
+
+  it("re-derives the step when the org changes on a still-mounted provider", async () => {
+    // The onboarding shell renders the full UserMenu for multi-team users, so a
+    // user can create/join/switch teams from inside /onboarding. That calls
+    // selectOrganization without leaving the route, so the provider does NOT
+    // remount — the org changes underneath a mounted provider.
+    const latest = { current: null as OnboardingFlowValue | null };
+
+    function Tree() {
+      function Inner() {
+        latest.current = useOnboardingFlow();
+        return <div>{latest.current.activeStep}</div>;
+      }
+      return (
+        <OnboardingFlowProvider path="admin">
+          <Inner />
+        </OnboardingFlowProvider>
+      );
+    }
+
+    // Same root + same QueryClient instance across both renders, so React
+    // reconciles (re-renders) the provider instead of remounting it.
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const rerender = async () => {
+      await act(async () => {
+        root?.render(
+          <MemoryRouter initialEntries={["/onboarding"]}>
+            <QueryClientProvider client={client}>
+              <Tree />
+            </QueryClientProvider>
+          </MemoryRouter>,
+        );
+      });
+      await flush();
+    };
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    // Team A: returning admin, no agent in this org yet → create-agent; advance
+    // to connect-code, persisting team A's position.
+    authMock.value = {
+      ...authMock.value,
+      organizationId: "org-A",
+      onboardingStep: "completed",
+      currentOrgHasUsableAgent: false,
+    };
+    await rerender();
+    expect(expectHookValue(latest.current).activeStep).toBe("create-agent");
+    await act(async () => expectHookValue(latest.current).goTo(3));
+    expect(expectHookValue(latest.current).activeStep).toBe("connect-code");
+
+    // Switch to a brand-new team B (no agent) without leaving the route. The
+    // flow must re-derive for team B and land on create-agent — and must not
+    // write team A's connect-code index under team B's key.
+    authMock.value = { ...authMock.value, organizationId: "org-B" };
+    await rerender();
+    expect(expectHookValue(latest.current).activeStep).toBe("create-agent");
+    expect(sessionStorage.getItem("onboarding:stepIndex:admin:org-B")).not.toBe("3");
+  });
 });

--- a/packages/web/src/pages/onboarding/__tests__/hooks-flow.test.tsx
+++ b/packages/web/src/pages/onboarding/__tests__/hooks-flow.test.tsx
@@ -7,6 +7,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { MemoryRouter } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { OnboardingFlowProvider, type OnboardingFlowValue, useOnboardingFlow } from "../onboarding-flow.js";
+import type { ServerOnboardingStep } from "../steps.js";
 import { useAgentCreation } from "../use-agent-creation.js";
 import type { ComputerConnection } from "../use-computer-connection.js";
 import { useComputerConnection } from "../use-computer-connection.js";
@@ -58,7 +59,8 @@ const authMock = vi.hoisted(() => ({
     agentId: "human-agent-self",
     teamDisplayName: "Acme",
     orgHasOtherMembers: true,
-    onboardingStep: "connect" as const,
+    onboardingStep: "connect" as ServerOnboardingStep,
+    currentOrgHasUsableAgent: false,
     onboardingDismissedAt: null,
     onboardingCompletedAt: null,
     dismissOnboarding: vi.fn(async () => undefined),
@@ -341,7 +343,7 @@ describe("onboarding hooks and flow", () => {
     expect(host.textContent).toContain("team");
     await act(async () => expectHookValue(latest.current).goTo(1));
     expect(expectHookValue(latest.current).activeStep).toBe("connect-computer");
-    expect(sessionStorage.getItem("onboarding:stepIndex:admin")).toBe("1");
+    expect(sessionStorage.getItem("onboarding:stepIndex:admin:org-1")).toBe("1");
 
     await act(async () => expectHookValue(latest.current).finishLater());
     expect(authMock.value.dismissOnboarding).toHaveBeenCalled();
@@ -352,6 +354,52 @@ describe("onboarding hooks and flow", () => {
     // forever, so only the explicit finishLater above may have called it.
     expect(authMock.value.dismissOnboarding).toHaveBeenCalledTimes(1);
     expect(authMock.value.markOnboardingCompleted).toHaveBeenCalled();
-    expect(sessionStorage.getItem("onboarding:stepIndex:admin")).toBeNull();
+    expect(sessionStorage.getItem("onboarding:stepIndex:admin:org-1")).toBeNull();
+  });
+
+  it("does not carry a previous team's saved step into a newly created team", async () => {
+    const latest = { current: null as OnboardingFlowValue | null };
+
+    function Probe() {
+      function Inner() {
+        latest.current = useOnboardingFlow();
+        return <div>{latest.current.activeStep}</div>;
+      }
+      return (
+        <OnboardingFlowProvider path="admin">
+          <Inner />
+        </OnboardingFlowProvider>
+      );
+    }
+
+    // A returning admin (already has an agent in another team, so the account
+    // step is "completed") sets up team A. The org has no usable agent yet, so
+    // they land on create-agent; they advance to connect-code, persisting team
+    // A's position for the GitHub-redirect round-trip.
+    authMock.value = {
+      ...authMock.value,
+      organizationId: "org-A",
+      onboardingStep: "completed",
+      currentOrgHasUsableAgent: false,
+    };
+    await renderProbe(<Probe />);
+    expect(expectHookValue(latest.current).activeStep).toBe("create-agent");
+    await act(async () => expectHookValue(latest.current).goTo(3));
+    expect(expectHookValue(latest.current).activeStep).toBe("connect-code");
+
+    await act(async () => root?.unmount());
+    root = null;
+
+    // Same tab: the admin now creates a brand-new team B (no agent yet). The
+    // saved position is scoped per org, so team A's connect-code marker must
+    // NOT skip team B past create-agent — they must land on create-agent.
+    authMock.value = {
+      ...authMock.value,
+      organizationId: "org-B",
+      onboardingStep: "completed",
+      currentOrgHasUsableAgent: false,
+    };
+    await renderProbe(<Probe />);
+    expect(expectHookValue(latest.current).activeStep).toBe("create-agent");
   });
 });

--- a/packages/web/src/pages/onboarding/onboarding-flow.tsx
+++ b/packages/web/src/pages/onboarding/onboarding-flow.tsx
@@ -126,6 +126,24 @@ function clearPersistedStep(path: OnboardingPath, orgId: string | null): void {
   window.sessionStorage.removeItem(key);
 }
 
+/**
+ * The step index to land on for `path` within `orgId`: the server-inferred
+ * step, but never behind a position already persisted for THIS org (so a
+ * same-tab GitHub-redirect round-trip resumes where the user was). Used on
+ * first mount and whenever the selected org changes under a mounted provider.
+ */
+function resolveLandingStep(path: OnboardingPath, orgStep: ServerOnboardingStep, orgId: string | null): number {
+  const inferred = inferInitialStepIndex(path, {
+    onboardingStep: orgStep,
+    // We can't observe finer team-rename state synchronously; the team step is
+    // cheap to revisit, so default returning admins past it only when the
+    // server already proves a computer exists.
+    teamSettled: orgStep !== "connect",
+  });
+  const persisted = readPersistedStep(path, orgId);
+  return clampStepIndex(path, persisted === null ? inferred : Math.max(inferred, persisted));
+}
+
 export function OnboardingFlowProvider({ path, children }: { path: OnboardingPath; children: ReactNode }) {
   const navigate = useNavigate();
   const {
@@ -156,20 +174,22 @@ export function OnboardingFlowProvider({ path, children }: { path: OnboardingPat
         : "create_agent";
 
   const sequence = getStepSequence(path);
-  const [activeIndex, setActiveIndex] = useState<number>(() => {
-    const inferred = inferInitialStepIndex(path, {
-      onboardingStep: orgStep,
-      // We can't observe finer team-rename state synchronously; the team
-      // step is cheap to revisit, so default returning admins past it only
-      // when the server already proves a computer exists.
-      teamSettled: orgStep !== "connect",
-    });
-    // Resume a persisted position, but never drop *behind* what the server
-    // can prove (so a stale marker can't strand a user before their real
-    // progress).
-    const persisted = readPersistedStep(path, organizationId);
-    return clampStepIndex(path, persisted === null ? inferred : Math.max(inferred, persisted));
-  });
+  const [activeIndex, setActiveIndex] = useState<number>(() => resolveLandingStep(path, orgStep, organizationId));
+
+  // The onboarding shell renders the full UserMenu for multi-team users, so the
+  // selected org can change while this provider stays mounted (creating /
+  // joining / switching teams calls selectOrganization without a route
+  // remount). Re-derive the landing step for the new org rather than carry the
+  // previous team's activeIndex — otherwise the write effect below would
+  // persist it under the new org's key and skip the new team past create-agent.
+  // Adjusting state during render (guarded by the org check) is React's
+  // recommended way to reset derived state on a prop change; it runs before the
+  // write effect, so the stale index is never committed to the new org's key.
+  const [stepOrg, setStepOrg] = useState(organizationId);
+  if (organizationId !== stepOrg) {
+    setStepOrg(organizationId);
+    setActiveIndex(resolveLandingStep(path, orgStep, organizationId));
+  }
 
   useEffect(() => {
     writePersistedStep(path, organizationId, activeIndex);

--- a/packages/web/src/pages/onboarding/onboarding-flow.tsx
+++ b/packages/web/src/pages/onboarding/onboarding-flow.tsx
@@ -91,24 +91,39 @@ export const OnboardingFlowContext = createContext<OnboardingFlowValue | null>(n
 // Remember the active step for the tab's lifetime so a full-page round-trip
 // (notably the GitHub App install redirect to github.com and back) returns
 // the user exactly where they were instead of resetting to step 1.
-const STEP_KEY = (path: OnboardingPath) => `onboarding:stepIndex:${path}`;
+//
+// Scoped by org as well as path: a returning admin can run the admin flow for
+// more than one team in the same tab (create team A, then create team B), and
+// team A's saved position must not carry into team B and skip it past
+// create-agent. A null org (`/me` not resolved yet, so there is no team to
+// scope to) disables persistence and falls back to the inferred step — safe
+// because the provider mounts only after `/me` loads (see onboarding-page.tsx),
+// so anyone actually in the flow already has a resolved org.
+const STEP_KEY = (path: OnboardingPath, orgId: string | null): string | null =>
+  orgId ? `onboarding:stepIndex:${path}:${orgId}` : null;
 
-function readPersistedStep(path: OnboardingPath): number | null {
+function readPersistedStep(path: OnboardingPath, orgId: string | null): number | null {
   if (typeof window === "undefined") return null;
-  const raw = window.sessionStorage.getItem(STEP_KEY(path));
+  const key = STEP_KEY(path, orgId);
+  if (key === null) return null;
+  const raw = window.sessionStorage.getItem(key);
   if (raw === null) return null;
   const n = Number.parseInt(raw, 10);
   return Number.isInteger(n) ? n : null;
 }
 
-function writePersistedStep(path: OnboardingPath, index: number): void {
+function writePersistedStep(path: OnboardingPath, orgId: string | null, index: number): void {
   if (typeof window === "undefined") return;
-  window.sessionStorage.setItem(STEP_KEY(path), String(index));
+  const key = STEP_KEY(path, orgId);
+  if (key === null) return;
+  window.sessionStorage.setItem(key, String(index));
 }
 
-function clearPersistedStep(path: OnboardingPath): void {
+function clearPersistedStep(path: OnboardingPath, orgId: string | null): void {
   if (typeof window === "undefined") return;
-  window.sessionStorage.removeItem(STEP_KEY(path));
+  const key = STEP_KEY(path, orgId);
+  if (key === null) return;
+  window.sessionStorage.removeItem(key);
 }
 
 export function OnboardingFlowProvider({ path, children }: { path: OnboardingPath; children: ReactNode }) {
@@ -152,13 +167,13 @@ export function OnboardingFlowProvider({ path, children }: { path: OnboardingPat
     // Resume a persisted position, but never drop *behind* what the server
     // can prove (so a stale marker can't strand a user before their real
     // progress).
-    const persisted = readPersistedStep(path);
+    const persisted = readPersistedStep(path, organizationId);
     return clampStepIndex(path, persisted === null ? inferred : Math.max(inferred, persisted));
   });
 
   useEffect(() => {
-    writePersistedStep(path, activeIndex);
-  }, [path, activeIndex]);
+    writePersistedStep(path, organizationId, activeIndex);
+  }, [path, organizationId, activeIndex]);
 
   const goTo = useCallback((index: number) => setActiveIndex(clampStepIndex(path, index)), [path]);
   const goNext = useCallback(() => setActiveIndex((i) => clampStepIndex(path, i + 1)), [path]);
@@ -237,7 +252,7 @@ export function OnboardingFlowProvider({ path, children }: { path: OnboardingPat
       // membership-scoped suppress stamp with reason="completed". Reusing the
       // finish-later path here would blur the reason semantics that keep new
       // memberships eligible for first-need onboarding.
-      clearPersistedStep(path);
+      clearPersistedStep(path, organizationId);
       // Clear the per-tab agent-uuid stash now that the kickoff has resolved and
       // used it — so a later same-tab onboarding/recovery in a DIFFERENT org
       // can't read a stale cross-org agent (the org filter in


### PR DESCRIPTION
## Problem

Creating a new team can drop the user **past** the "create agent" step of onboarding — the very step a brand-new team needs. Repro: a returning admin creates a new team and lands on connect-code / kickoff, skipping create-agent.

## Root cause

The standalone onboarding flow remembers the active step in `sessionStorage` so a full-page round-trip (the GitHub App install redirect) resumes where the user was. The key was **path-only** — `onboarding:stepIndex:<path>` (`onboarding-flow.tsx`) — and the provider never moves *behind* server-proven progress via `Math.max(inferred, persisted)`.

For a returning admin (already has an agent in another team → account-level step `completed`), a brand-new team correctly infers `create-agent` (the new org has no usable agent, so `orgStep` recomputes to `create_agent`). But if that admin had advanced past create-agent in **another** team earlier in the same tab, the stale marker (e.g. `connect-code` = 3) was restored and `Math.max`-ed over the inferred `create-agent` (2), landing them past create-agent.

The marker is cleared only on full kickoff completion (`clearPersistedStep`), not on finish-later / org switch / new-team creation, so it lingers across teams. The org switch itself is correct (`selectOrganization` awaits `/me`; `currentMembership` resolves to the new org with `hasUsableAgent: false`); only the step marker leaked because it wasn't org-scoped.

## Fix

Scope the key by org as well as path: `onboarding:stepIndex:<path>:<orgId>`. Each team resumes independently, while the GitHub-redirect resume still works within a team. A null org (before `/me` resolves) disables persistence and falls back to the inferred step — safe because the provider mounts only after `/me` loads (`onboarding-page.tsx` gates on `meLoaded`), so anyone actually in the flow already has a resolved org.

## Testing

- New regression test in `hooks-flow.test.tsx`: a returning admin advances past create-agent in team A, then creates team B in the same tab → team B lands on **create-agent**. Fails before the fix (lands on `connect-code`), passes after.
- `pnpm --filter @first-tree/web test` → 863 passed.
- `pnpm --filter @first-tree/web typecheck` + Biome clean.

No Context Tree change: `system/cloud/onboarding.md` already records that fine-grained step progress is local to the standalone flow, so org-scoping that local key is implementation-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
