### PR TITLE
fix(web): lock env dialog inputs mid-save + field-locate config save errors

### DIFF
--- a/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
+++ b/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
@@ -2233,4 +2233,40 @@ describe("web DOM interaction coverage", () => {
 
     await unmountRoot(root);
   });
+
+  it("clears a stale validation error so a later save failure is shown, not masked", async () => {
+    const { EnvSection } = await import("../agent-detail/env-section.js");
+    function Harness() {
+      const [saveError, setSaveError] = useState<string | null>(null);
+      // The save fails (no onSuccess) and surfaces an error to the dialog.
+      const onSave = (_next: EnvEntryLike[]) => setSaveError("Save failed");
+      return (
+        <EnvSection items={[{ key: "EXISTING", value: "x", sensitive: false }]} onSave={onSave} saveError={saveError} />
+      );
+    }
+    const { container, root } = await renderDom(<Harness />);
+
+    await click([...container.querySelectorAll("button")].find((b) => b.textContent?.includes("Add")) ?? null);
+    await waitForText("Add environment variable", document.body);
+    const key = document.body.querySelector<HTMLInputElement>("#env-key");
+    const value = document.body.querySelector<HTMLInputElement>("#env-value");
+    if (!key || !value) throw new Error("Env fields missing");
+
+    // Trigger a local validation error (duplicate key), then fix it and resubmit.
+    await setValue(key, "EXISTING");
+    await setValue(value, "v");
+    await click([...document.body.querySelectorAll("button")].find((b) => b.textContent === "Add") ?? null);
+    await waitForText('Another entry already uses key "EXISTING".', document.body);
+    await setValue(key, "NEWKEY");
+    await click([...document.body.querySelectorAll("button")].find((b) => b.textContent === "Add") ?? null);
+
+    // The real save failure shows; the stale validation message no longer masks it.
+    await waitForText("Save failed", document.body);
+    expect(document.body.textContent).not.toContain("Another entry already uses key");
+
+    await unmountRoot(root);
+  });
 });
+
+// Minimal structural shape for the env onSave callback in the test above.
+type EnvEntryLike = { key: string; value: string; sensitive: boolean };

--- a/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
+++ b/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
@@ -2152,6 +2152,10 @@ describe("web DOM interaction coverage", () => {
     // The save is now in flight.
     await act(async () => setSaving(true));
 
+    // Inputs are locked mid-save so a value typed in the pending window can't be
+    // silently dropped when the save resolves.
+    expect(document.body.querySelector<HTMLInputElement>("#env-value")?.disabled).toBe(true);
+
     // The Radix close (X), Escape, and outside click all route through the
     // dialog's onOpenChange — none of them may dismiss it mid-save.
     await click([...document.body.querySelectorAll("button")].find((b) => b.textContent?.trim() === "Close") ?? null);
@@ -2167,6 +2171,65 @@ describe("web DOM interaction coverage", () => {
     expect(document.body.querySelector<HTMLInputElement>("#env-key")?.value).toBe("API_KEY");
     expect(document.body.querySelector<HTMLInputElement>("#env-value")?.value).toBe("s3cr3t");
     expect(document.body.textContent).toContain("Save failed");
+
+    await unmountRoot(root);
+  });
+
+  it("shows a toast when an env row delete fails (no dialog to host the error)", async () => {
+    const { EnvSection } = await import("../agent-detail/env-section.js");
+    // onSave invokes onError, simulating a rejected/409 delete.
+    const onSave = vi.fn((_next: unknown, opts?: { onError?: () => void }) => opts?.onError?.());
+    const items = [{ key: "FIRST_TREE_ENV", value: "test", sensitive: false }];
+    const { container, root } = await renderDom(<EnvSection items={items} onSave={onSave} />);
+
+    await click(container.querySelector('button[title="Delete"]'));
+    expect(onSave).toHaveBeenCalledTimes(1);
+    await waitForText("Couldn't remove FIRST_TREE_ENV", document.body);
+
+    await unmountRoot(root);
+  });
+
+  it("locks the secret input mid-save so a successful old request can't drop a late edit", async () => {
+    const { EnvSection } = await import("../agent-detail/env-section.js");
+    let setSaving: (v: boolean) => void = () => {};
+    let resolveSuccess: () => void = () => {};
+    const onSave = vi.fn((_next: unknown, opts?: { onSuccess?: () => void }) => {
+      resolveSuccess = () => opts?.onSuccess?.();
+    });
+    function Harness() {
+      const [saving, s] = useState(false);
+      setSaving = s;
+      return <EnvSection items={[]} onSave={onSave} saving={saving} />;
+    }
+    const { container, root } = await renderDom(<Harness />);
+
+    await click([...container.querySelectorAll("button")].find((b) => b.textContent?.includes("Add")) ?? null);
+    await waitForText("Add environment variable", document.body);
+    const key = document.body.querySelector<HTMLInputElement>("#env-key");
+    const value = document.body.querySelector<HTMLInputElement>("#env-value");
+    const sensitive = document.body.querySelector<HTMLInputElement>('input[type="checkbox"]');
+    if (!key || !value || !sensitive) throw new Error("Env fields missing");
+    await setValue(key, "API_KEY");
+    await setValue(value, "secret1");
+    await click(sensitive);
+    await click([...document.body.querySelectorAll("button")].find((b) => b.textContent === "Add") ?? null);
+    expect(onSave.mock.calls[0]?.[0]).toEqual([{ key: "API_KEY", value: "secret1", sensitive: true }]);
+
+    // Save is in flight: the inputs are disabled, so the user CANNOT type a late
+    // "correction" into the still-open dialog — there is no unsubmitted edit that
+    // the succeeding old request could silently drop.
+    await act(async () => setSaving(true));
+    expect(document.body.querySelector<HTMLInputElement>("#env-value")?.disabled).toBe(true);
+    expect(document.body.querySelector<HTMLInputElement>("#env-key")?.disabled).toBe(true);
+
+    // The original request succeeds and closes the dialog. Only the submitted
+    // secret1 was ever sent — exactly one save, no silent second value.
+    await act(async () => {
+      resolveSuccess();
+      setSaving(false);
+    });
+    expect(document.body.textContent).not.toContain("Add environment variable");
+    expect(onSave).toHaveBeenCalledTimes(1);
 
     await unmountRoot(root);
   });

--- a/packages/web/src/pages/agent-detail/__tests__/resources-tab-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/resources-tab-dom.test.tsx
@@ -97,6 +97,7 @@ function context(overrides: Partial<AgentDetailContext> = {}): AgentDetailContex
       pending: false,
       saveError: null,
       conflict: false,
+      errorField: null,
       justSaved: false,
       savedField: null,
     },

--- a/packages/web/src/pages/agent-detail/__tests__/usage-tab.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/usage-tab.test.tsx
@@ -84,6 +84,7 @@ function createContext(overrides: Partial<AgentDetailContext> = {}): AgentDetail
       pending: false,
       saveError: null,
       conflict: false,
+      errorField: null,
       justSaved: false,
       savedField: null,
     },

--- a/packages/web/src/pages/agent-detail/__tests__/use-agent-config-save.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/use-agent-config-save.test.tsx
@@ -142,6 +142,7 @@ describe("useAgentConfigSave", () => {
     expect(cached?.version).toBe(1);
     expect(latest?.conflict).toBe(true);
     expect(latest?.saveError).toBeNull();
+    expect(latest?.errorField).toBe("model");
   });
 
   it("surfaces a non-conflict error and rolls back", async () => {
@@ -156,5 +157,27 @@ describe("useAgentConfigSave", () => {
     expect(queryClient.getQueryData<AgentRuntimeConfig>(KEY)?.payload.reasoningEffort).toBe("medium");
     expect(latest?.conflict).toBe(false);
     expect(latest?.saveError).toContain("boom");
+    expect(latest?.errorField).toBe("effort");
+  });
+
+  it("invokes the per-call onError and clears errorField on the next successful save", async () => {
+    apiMocks.updateAgentConfig.mockRejectedValueOnce(new ApiError(500, "nope"));
+    await renderHook();
+    const onError = vi.fn();
+
+    await act(async () => {
+      latest?.save({ env: [] }, { field: "env", onError });
+    });
+    await flush();
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(latest?.errorField).toBe("env");
+
+    apiMocks.updateAgentConfig.mockResolvedValueOnce(config({ model: "opus" }, 2));
+    await act(async () => {
+      latest?.save({ model: "opus" }, { field: "model" });
+    });
+    await flush();
+    expect(latest?.errorField).toBeNull();
+    expect(latest?.savedField).toBe("model");
   });
 });

--- a/packages/web/src/pages/agent-detail/env-section.tsx
+++ b/packages/web/src/pages/agent-detail/env-section.tsx
@@ -272,6 +272,9 @@ function EnvDialog({
       setErr("Value is required for non-sensitive entries.");
       return;
     }
+    // Validation passed — clear any prior local error so it can't mask a save
+    // failure surfaced via `saveError` (the dialog hides saveError while `err` is set).
+    setErr(null);
     onSubmit({ key, value: resolved.value, sensitive });
   }
 

--- a/packages/web/src/pages/agent-detail/env-section.tsx
+++ b/packages/web/src/pages/agent-detail/env-section.tsx
@@ -33,8 +33,8 @@ import { titleWithSemantics } from "./save-semantics.js";
 
 export type EnvSectionProps = {
   items: EnvEntry[];
-  /** Persist the full next env array. `onSuccess` fires only after the server confirms. */
-  onSave: (nextEnv: EnvEntry[], opts?: { onSuccess?: () => void }) => void;
+  /** Persist the full next env array. `onSuccess` fires after the server confirms; `onError` on failure. */
+  onSave: (nextEnv: EnvEntry[], opts?: { onSuccess?: () => void; onError?: () => void }) => void;
   /** The agent is inactive (suspended) — hide edit affordances. */
   disabled?: boolean;
   /** A config save is in flight — serialize edits and show the dialog's submit as pending. */
@@ -90,6 +90,11 @@ export function EnvSection({ items, onSave, disabled, saving, saveError, saved }
             : undefined,
           action: entry.sensitive ? undefined : { label: "Undo", onClick: () => onSave([...itemsRef.current, entry]) },
         });
+      },
+      // A row delete has no open dialog to host an inline error, so surface the
+      // failure as a toast right here (the optimistic removal is rolled back).
+      onError: () => {
+        addToast({ title: `Couldn't remove ${entry.key}`, description: "The change wasn't saved — try again." });
       },
     });
   };
@@ -287,6 +292,9 @@ function EnvDialog({
           <DialogTitle>{initial ? "Edit environment variable" : "Add environment variable"}</DialogTitle>
           <DialogDescription>Saved immediately when you submit.</DialogDescription>
         </DialogHeader>
+        {/* Every input disables while a save is in flight (`submitting`), so a value
+            typed in the pending window can't be silently dropped when the earlier
+            request resolves and closes the dialog. */}
         <form onSubmit={submit} className="space-y-4">
           <div className="space-y-2">
             <Label htmlFor="env-key">Key</Label>
@@ -296,7 +304,7 @@ function EnvDialog({
               onChange={(e) => setKey(e.target.value.toUpperCase())}
               placeholder="OPENAI_API_KEY"
               className="font-mono"
-              disabled={!!initial}
+              disabled={!!initial || submitting}
             />
             {initial && <p className="text-caption text-muted-foreground">Key can't be renamed — delete and re-add.</p>}
           </div>
@@ -312,6 +320,7 @@ function EnvDialog({
                 allowKeepExisting ? "Leave empty to keep existing value" : sensitive ? "new secret" : "value"
               }
               className="font-mono"
+              disabled={submitting}
             />
           </div>
           <label className="flex items-center gap-2 text-body">
@@ -320,7 +329,7 @@ function EnvDialog({
               checked={sensitive}
               onChange={(e) => setSensitive(e.target.checked)}
               className="h-4 w-4"
-              disabled={!!initial && initial.sensitive}
+              disabled={(!!initial && initial.sensitive) || submitting}
             />
             Mark as sensitive (encrypted at rest, never displayed again)
           </label>

--- a/packages/web/src/pages/agent-detail/runtime-tab.tsx
+++ b/packages/web/src/pages/agent-detail/runtime-tab.tsx
@@ -80,14 +80,18 @@ export function RuntimeTab() {
               provider={ctx.setupRuntimeProvider}
             />
           </Section>
-          {configSave.conflict ? (
-            <p className="text-body" style={{ color: "var(--state-blocked)", margin: "var(--sp-2) 0 0" }}>
-              This agent's configuration was updated elsewhere; reloaded the latest values.
-            </p>
-          ) : configSave.saveError ? (
-            <p className="text-body" style={{ color: "var(--state-error)", margin: "var(--sp-2) 0 0" }}>
-              Failed to save: {configSave.saveError}
-            </p>
+          {/* Only model/effort failures belong here; env failures surface at the
+              Env section (dialog for add/edit, toast for delete). */}
+          {configSave.errorField === "model" || configSave.errorField === "effort" ? (
+            configSave.conflict ? (
+              <p className="text-body" style={{ color: "var(--state-blocked)", margin: "var(--sp-2) 0 0" }}>
+                This agent's configuration was updated elsewhere; reloaded the latest values.
+              </p>
+            ) : configSave.saveError ? (
+              <p className="text-body" style={{ color: "var(--state-error)", margin: "var(--sp-2) 0 0" }}>
+                Failed to save: {configSave.saveError}
+              </p>
+            ) : null
           ) : null}
         </div>
       )}
@@ -132,13 +136,17 @@ export function RuntimeTab() {
         <div style={{ marginTop: "var(--sp-8)" }}>
           <EnvSection
             items={config.payload.env}
-            onSave={(next, opts) => configSave.save({ env: next }, { field: "env", onSuccess: opts?.onSuccess })}
+            onSave={(next, opts) =>
+              configSave.save({ env: next }, { field: "env", onSuccess: opts?.onSuccess, onError: opts?.onError })
+            }
             disabled={ctx.agent.status !== "active"}
             saving={configSave.pending}
             saveError={
-              configSave.conflict
-                ? "This agent's configuration was updated elsewhere — reloaded the latest values. Re-enter and try again."
-                : configSave.saveError
+              configSave.errorField === "env"
+                ? configSave.conflict
+                  ? "This agent's configuration was updated elsewhere — reloaded the latest values. Re-enter and try again."
+                  : configSave.saveError
+                : null
             }
             saved={envSaved}
           />

--- a/packages/web/src/pages/agent-detail/use-agent-config-save.ts
+++ b/packages/web/src/pages/agent-detail/use-agent-config-save.ts
@@ -24,13 +24,18 @@ import { useJustSaved } from "./save-semantics.js";
 export type ConfigField = "model" | "effort" | "env";
 
 export type AgentConfigSaveController = {
-  /** Save a partial config patch immediately. `field` drives which section flashes "Saved". */
-  save: (patch: AgentRuntimeConfigPatch, opts?: { field?: ConfigField; onSuccess?: () => void }) => void;
+  /** Save a partial config patch immediately. `field` drives which section flashes "Saved" / shows the error. */
+  save: (
+    patch: AgentRuntimeConfigPatch,
+    opts?: { field?: ConfigField; onSuccess?: () => void; onError?: () => void },
+  ) => void;
   pending: boolean;
   /** Non-conflict save failure message, else null. */
   saveError: string | null;
   /** True after a 409 (someone else saved a newer version); cleared on the next successful save. */
   conflict: boolean;
+  /** Which field's save last failed (conflict or error), so the UI can show it field-located; null when clean. */
+  errorField: ConfigField | null;
   justSaved: boolean;
   savedField: ConfigField | null;
 };
@@ -43,6 +48,7 @@ export function useAgentConfigSave(uuid: string): AgentConfigSaveController {
   const { justSaved, markSaved } = useJustSaved();
   const [saveError, setSaveError] = useState<string | null>(null);
   const [conflict, setConflict] = useState(false);
+  const [errorField, setErrorField] = useState<ConfigField | null>(null);
   const [savedField, setSavedField] = useState<ConfigField | null>(null);
 
   const { mutate, isPending } = useMutation<AgentRuntimeConfig, unknown, SaveVars, SaveContext>({
@@ -60,8 +66,9 @@ export function useAgentConfigSave(uuid: string): AgentConfigSaveController {
       }
       return { prev };
     },
-    onError: (err, _vars, context) => {
+    onError: (err, vars, context) => {
       if (context?.prev) queryClient.setQueryData(["agent-config", uuid], context.prev);
+      setErrorField(vars.field ?? null);
       if (err instanceof ApiError && err.status === 409) {
         setConflict(true);
         setSaveError(null);
@@ -76,6 +83,7 @@ export function useAgentConfigSave(uuid: string): AgentConfigSaveController {
       queryClient.setQueryData(["agent-config", uuid], next);
       setSaveError(null);
       setConflict(false);
+      setErrorField(null);
       setSavedField(vars.field ?? null);
       markSaved();
     },
@@ -87,10 +95,14 @@ export function useAgentConfigSave(uuid: string): AgentConfigSaveController {
       if (!current) return;
       setSaveError(null);
       setConflict(false);
-      mutate({ patch, expectedVersion: current.version, field: opts?.field }, { onSuccess: () => opts?.onSuccess?.() });
+      setErrorField(null);
+      mutate(
+        { patch, expectedVersion: current.version, field: opts?.field },
+        { onSuccess: () => opts?.onSuccess?.(), onError: () => opts?.onError?.() },
+      );
     },
     [queryClient, uuid, mutate],
   );
 
-  return { save, pending: isPending, saveError, conflict, justSaved, savedField };
+  return { save, pending: isPending, saveError, conflict, errorField, justSaved, savedField };
 }


### PR DESCRIPTION
Follow-up to #1171 (merged), addressing two post-merge review findings (@yuezengwu + @baixiaohang request_changes on the immediate-save env flow). #1171 was already merged, so these land here.

## [P2] Env dialog editable mid-save → typed value silently dropped
After the R4 dismiss guard, the env dialog stays open during an in-flight save but its inputs were still **editable**. If a slow PATCH let the user keep typing (e.g. correcting a secret) and the earlier request then succeeded, `onSuccess` closed the dialog and discarded the latest input — same atomicity class the PR set out to fix.

**Fix:** disable the dialog inputs (Key / Value / sensitive) while `submitting`, alongside the already-disabled buttons. No unsubmitted edit can be lost; the dialog still only closes on a confirmed save.

## [P3] Env delete failure shown far from the env list
A row delete has no open dialog, so its failure surfaced via the shared `configSave` error block under **Model settings** — the user could miss why the delete failed.

**Fix:** add `errorField` to `useAgentConfigSave` so save failures are field-located:
- model / effort errors → stay under Model settings,
- env add/edit errors → in the dialog (gated to `errorField === "env"`),
- a rejected env **delete** → a toast at the env section (via a new per-call `onError`).

## Tests / gates
- Hook unit test: `errorField` set on failure + cleared on next success; per-call `onError` invoked.
- DOM: inputs disabled mid-save — including the **success-path** (submit → inputs locked → the old request succeeds → only the submitted value was saved); plus a delete-failure toast.
- `pnpm check` (biome) ✓ · `--filter @first-tree/web typecheck` ✓ · `lint:tokens` ✓ · full web suite **865/865** ✓.

Pure frontend. Separate from the in-flight IA-recut PR (kept distinct per concern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)