### PR TITLE
docs: update top README CTA to artifacts/collaboration wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   English | <a href="README_zh-CN.md">中文</a>
 </p>
 
-> Use this [link](https://cloud.first-tree.ai/login?utm_source=github&utm_medium=readme&utm_campaign=top-cta-app) to use [first-tree 🌳](https://first-tree.ai/?utm_source=github&utm_medium=readme&utm_campaign=top-cta-site) for **free!!!** — the most efficient way to **loopmaxx your engineering work**.
+> 🌳 use artifacts in [first-tree](https://first-tree.ai/?utm_source=github&utm_medium=readme&utm_campaign=top-cta-site) for **free** — the most efficient way for **human & agent collaboration** :D
 
 # First-Tree
 


### PR DESCRIPTION
## What

Updates the top README CTA wording from the "loopmaxx your engineering work" framing to lead with artifacts + human/agent collaboration:

```
> 🌳 use artifacts in [first-tree](https://first-tree.ai/?utm_source=github&utm_medium=readme&utm_campaign=top-cta-site) for **free** — the most efficient way for **human & agent collaboration** :D
```

## Notes

- Keeps the existing `top-cta-site` campaign slug, so GA attribution is unaffected.
- Drops the cloud-app login link (`top-cta-app`): site-first funnel, app conversion is measured on the site.
- Kept blockquote (`>`) form to match the centered-HTML hero above it.
- Docs-only change, no code touched.

Refs #1174

🤖 Generated with [Claude Code](https://claude.com/claude-code) on behalf of @serenakeyitan. Leaving merge to a maintainer.