### PR TITLE
release: bump apps/cli to v0.5.8

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "first-tree-dev",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "type": "module",
   "description": "First Tree — unified CLI for Context Tree onboarding, agent management, and team messaging. (Source-tree dev build; CI rewrites `name` and `bin` for prod / staging publishes — see docs/local-dev-isolation.md.)",
   "keywords": [


### PR DESCRIPTION
## Version bump

`apps/cli` `0.5.7` → `0.5.8` (patch). Diff is the single `version` field in `apps/cli/package.json`; package `name`, `bin`, and `build-info.ts` untouched. Stable line; npm `first-tree@0.5.7` is already published and `first-tree-staging` is on `0.5.8-staging.*`.

## Draft GitHub Release

**Title:** `v0.5.8 — Per-chat composer drafts, phone-friendly ask card, agent runtime fixes`

```markdown
## Highlights

- Composer drafts are now cached per chat in local storage, so an unsent message survives switching chats and reloading the page (with rollback / stale-ref hardening). (#1165, #1167, #1168, #1169)
- Returning sign-in lands you back in your last-used org, plus onboarding copy polish. (#1148)

## Notable fixes

- The chat-ask answer card is phone-friendly: Reply / Skip stay reachable on short viewports, the card lifts above the on-screen keyboard, and long option previews wrap instead of overflowing. (#1177)
- Agent runtime: prepend the channel CLI bin for agents (#1164), batch-settle Claude Code coalesced inputs (#1159), and inject chat context per provider session (#1157).
- Route the Codex handler through the app-server. (#1155)
- agent-detail edits now save immediately. (#1171)
- Right-rail Summary uses a single, tighter type scale. (#1150)

## Internal

- Staging-only toggle to hide agent final-text mirrors (#1149); docs + CI upkeep (#1166, #1163, #1050).
```

## Verification

- `pnpm check` → exit 0 (3 pre-existing warnings, 1 info; no errors).
- `pnpm typecheck` → exit 0.
- Pre-release QA (separate run) on `origin/main` @ `571852523212907bcdadc6f0c04060cdce117f52`: frozen install, validate:skill, build, migration/old-name guards, e2e:smoke, per-package isolated tests, GitHub CI / Docker / npm Publish / CodeQL all green, plus real local server+Web+PostgreSQL smoke incl. ask-card desktop / 390×844 / 375×300.

## Post-merge steps

1. Confirm merge commit SHA; wait for `CI` (and the same-SHA `npm Publish` / `Docker`) on `main` to succeed.
2. Confirm `apps/cli/package.json` is `0.5.8` at the merge SHA.
3. After human confirms version / title / body / target SHA, create the `v0.5.8` GitHub Release + tag on that SHA (lightweight tag via GitHub Release).
4. Verify tag-triggered `npm Publish` (`Publish Command Prod` success), `npm view first-tree version` → `0.5.8`, and the `Docker` build → `ghcr.io/agent-team-foundation/first-tree:0.5.8`.
5. Remind human to deploy on CapRover.

Tag is NOT created from this PR branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)