### PR TITLE
fix(web): count cached tokens in usage totals

### DIFF
--- a/packages/web/src/lib/__tests__/token-usage.test.ts
+++ b/packages/web/src/lib/__tests__/token-usage.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { activeTokenCount, formatTokenUsageTitle, processedTokenCount } from "../token-usage.js";
+
+describe("token usage helpers", () => {
+  it("keeps active and processed token counts distinct", () => {
+    const usage = { inputTokens: 100, cachedInputTokens: 250, outputTokens: 50 };
+
+    expect(activeTokenCount(usage)).toBe(150);
+    expect(processedTokenCount(usage)).toBe(400);
+    expect(formatTokenUsageTitle(usage, { turns: 2 })).toBe(
+      "Processed 400 · Active 150 · Input 100 · Cached 250 · Output 50 · 2 usage events",
+    );
+  });
+
+  it("treats missing cached fields as zero for legacy or mocked data", () => {
+    expect(processedTokenCount({ inputTokens: 100, outputTokens: 50 })).toBe(150);
+  });
+});

--- a/packages/web/src/lib/token-usage.ts
+++ b/packages/web/src/lib/token-usage.ts
@@ -1,0 +1,31 @@
+export type TokenUsageParts = {
+  inputTokens?: number | null;
+  cachedInputTokens?: number | null;
+  outputTokens?: number | null;
+};
+
+function tokenPart(value: number | null | undefined): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+export function activeTokenCount(usage: TokenUsageParts): number {
+  return tokenPart(usage.inputTokens) + tokenPart(usage.outputTokens);
+}
+
+export function processedTokenCount(usage: TokenUsageParts): number {
+  return activeTokenCount(usage) + tokenPart(usage.cachedInputTokens);
+}
+
+export function formatTokenUsageTitle(usage: TokenUsageParts, opts: { turns?: number } = {}): string {
+  const activeTokens = activeTokenCount(usage);
+  const processedTokens = processedTokenCount(usage);
+  const parts = [
+    `Processed ${processedTokens.toLocaleString()}`,
+    `Active ${activeTokens.toLocaleString()}`,
+    `Input ${tokenPart(usage.inputTokens).toLocaleString()}`,
+    `Cached ${tokenPart(usage.cachedInputTokens).toLocaleString()}`,
+    `Output ${tokenPart(usage.outputTokens).toLocaleString()}`,
+  ];
+  if (opts.turns != null) parts.push(`${opts.turns.toLocaleString()} usage events`);
+  return parts.join(" · ");
+}

--- a/packages/web/src/pages/__tests__/team-preview-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/team-preview-dom.test.tsx
@@ -156,7 +156,7 @@ describe("team preview page", () => {
 
     await click(buttonByText(container, "All"));
     await click(buttonByText(container, "7d"));
-    expect(container.textContent).toContain("1.4M");
+    expect(container.textContent).toContain("4.9M");
 
     const search = container.querySelector<HTMLInputElement>('input[placeholder="Search name or @handle"]');
     if (!search) throw new Error("Search input missing");

--- a/packages/web/src/pages/agent-detail/__tests__/usage-tab.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/usage-tab.test.tsx
@@ -274,13 +274,15 @@ describe("UsageTab", () => {
     expect(container.textContent).toContain("Active days");
     expect(container.textContent).toContain("Peak day");
     expect(container.textContent).toContain("Recent turns");
-    expect(container.textContent).toContain("Daily active tokens. Darker cells mean more usage.");
-    expect(activityCells.find((cell) => cell.getAttribute("aria-label")?.includes("9.5K active tokens"))).toBeDefined();
+    expect(container.textContent).toContain("Daily processed tokens. Darker cells mean more usage.");
+    expect(
+      activityCells.find((cell) => cell.getAttribute("aria-label")?.includes("10.5K processed tokens")),
+    ).toBeDefined();
     expect(container.textContent).toContain("Your most recent turns from the last 30 days.");
     expect(container.textContent).toContain("Launch planning");
     expect(container.textContent).toContain("private chat");
     expect(container.textContent).toContain("claude-code/sonnet");
-    expect(container.textContent).toContain("16.2K");
+    expect(container.textContent).toContain("46.2K");
     expect(usageMocks.getAgentUsageSummary).toHaveBeenCalledWith("agent-1", "30d");
     expect(usageMocks.getAgentUsageTurns).toHaveBeenCalledWith("agent-1", {
       window: "30d",

--- a/packages/web/src/pages/agent-detail/usage-tab.tsx
+++ b/packages/web/src/pages/agent-detail/usage-tab.tsx
@@ -4,6 +4,7 @@ import { type CSSProperties, type ReactElement, type ReactNode, useEffect, useMe
 import { getAgentUsageSummary, getAgentUsageTurns } from "../../api/usage.js";
 import { Button } from "../../components/ui/button.js";
 import { Section } from "../../components/ui/section.js";
+import { activeTokenCount, processedTokenCount } from "../../lib/token-usage.js";
 import { formatCompactCount, formatRelative } from "../../lib/utils.js";
 import { useAgentDetailContext } from "./layout-context.js";
 
@@ -122,7 +123,7 @@ function ActivityBlock({
           </span>
         </>
       }
-      description="Daily active tokens. Darker cells mean more usage."
+      description="Daily processed tokens. Darker cells mean more usage."
       action={<DensityLegend />}
     >
       {isError ? (
@@ -153,7 +154,7 @@ function DensityLegend(): ReactElement {
 function ActivityBody({ summary }: { summary: UsageAgentSummary | undefined }): ReactElement {
   const days = useMemo(() => buildDays(summary?.daily), [summary?.daily]);
   const columns = useMemo(() => buildColumns(days), [days]);
-  const max = Math.max(1, ...days.map((d) => d.activeTokens));
+  const max = Math.max(1, ...days.map((d) => d.processedTokens));
   const stats = useMemo(() => computeStats(days), [days]);
   const [hover, setHover] = useState<{ d: DayBucket; x: number; y: number } | null>(null);
 
@@ -236,13 +237,13 @@ function Cell({
   if (!day) {
     return <span aria-hidden="true" className="usage-cal-cell usage-cal-cell-empty" />;
   }
-  const b = bucket(day.activeTokens, max);
+  const b = bucket(day.processedTokens, max);
   const colors = ["var(--lvl0)", "var(--lvl1)", "var(--lvl2)", "var(--lvl3)", "var(--lvl4)"];
   return (
     <span
       role="img"
       aria-label={`${WEEKDAYS[day.weekday]} ${MONTHS[day.month]} ${day.day}: ${
-        day.activeTokens > 0 ? `${formatCompactCount(day.activeTokens)} active tokens` : "no activity"
+        day.processedTokens > 0 ? `${formatCompactCount(day.processedTokens)} processed tokens` : "no activity"
       }`}
       onMouseEnter={onEnter}
       onMouseLeave={onLeave}
@@ -254,16 +255,16 @@ function Cell({
 
 function CellTooltip({ day, anchorX, anchorY }: { day: DayBucket; anchorX: number; anchorY: number }): ReactElement {
   const label = `${WEEKDAYS[day.weekday]} · ${MONTHS[day.month]} ${day.day}, ${day.year}`;
-  const value = day.activeTokens > 0 ? `${formatCompactCount(day.activeTokens)} active tokens` : "No activity";
+  const value = day.processedTokens > 0 ? `${formatCompactCount(day.processedTokens)} processed tokens` : "No activity";
   return (
     <div role="tooltip" className="usage-cal-tooltip" style={{ left: anchorX, top: anchorY }}>
       <div className="text-eyebrow mono" style={{ color: "var(--fg-3)" }}>
         {label}
       </div>
       <div className="usage-cal-tooltip-value text-body mono font-semibold">{value}</div>
-      {day.cacheReadTokens > 0 ? (
+      {day.processedTokens > 0 ? (
         <div className="text-caption mono" style={{ color: "var(--fg-3)" }}>
-          {formatCompactCount(day.cacheReadTokens)} cache read · {formatCompactCount(day.processedTokens)} processed
+          {formatCompactCount(day.activeTokens)} active · {formatCompactCount(day.cacheReadTokens)} cached
         </div>
       ) : null}
     </div>
@@ -276,8 +277,8 @@ function ActivityStatsPanel({
   stats: { activeDays: number; avgPerDay: number; peak: DayBucket | null; streak: number };
 }): ReactElement {
   const peakLabel =
-    stats.peak && stats.peak.activeTokens > 0
-      ? `${MONTHS[stats.peak.month]} ${stats.peak.day} · ${formatCompactCount(stats.peak.activeTokens)}`
+    stats.peak && stats.peak.processedTokens > 0
+      ? `${MONTHS[stats.peak.month]} ${stats.peak.day} · ${formatCompactCount(stats.peak.processedTokens)}`
       : "—";
   return (
     <div className="usage-stats-panel">
@@ -292,7 +293,7 @@ function ActivityStatsPanel({
           </>
         }
       />
-      <StatTile label="Avg active / day" value={formatCompactCount(stats.avgPerDay)} mono />
+      <StatTile label="Avg processed / day" value={formatCompactCount(stats.avgPerDay)} mono />
       <StatTile label="Peak day" value={peakLabel} mono />
       <StatTile
         label="Current streak"
@@ -371,8 +372,8 @@ function TurnsTable({
   rows: UsageTurnRow[];
   onOpenChat: (chatId: string) => void;
 }): ReactElement {
-  const activeFor = (r: UsageTurnRow) => r.inputTokens + r.outputTokens;
-  const max = Math.max(1, ...rows.map(activeFor));
+  const processedFor = (r: UsageTurnRow) => processedTokenCount(r);
+  const max = Math.max(1, ...rows.map(processedFor));
   return (
     <div className="usage-turn-scroll">
       <table className="usage-turn-table w-full" style={{ borderCollapse: "collapse", marginTop: "var(--sp-1)" }}>
@@ -384,12 +385,12 @@ function TurnsTable({
             <th style={thStyle("right")}>Input</th>
             <th style={thStyle("right")}>Cached</th>
             <th style={thStyle("right")}>Output</th>
-            <th style={{ ...thStyle("left"), width: "var(--sp-20)" }}>Active</th>
+            <th style={{ ...thStyle("left"), width: "var(--sp-20)" }}>Processed</th>
           </tr>
         </thead>
         <tbody>
           {rows.map((r) => {
-            const active = activeFor(r);
+            const processed = processedFor(r);
             return (
               <tr key={`${r.chatId}:${r.seq}`} className="usage-turn-row">
                 <td className="text-body" style={{ color: "var(--fg-3)", whiteSpace: "nowrap" }}>
@@ -432,13 +433,13 @@ function TurnsTable({
                 </td>
                 <td>
                   <div className="usage-turn-total-cell">
-                    <span className="mono text-body">{formatCompactCount(active)}</span>
+                    <span className="mono text-body">{formatCompactCount(processed)}</span>
                     <div
                       role="img"
                       className="usage-turn-volbar"
-                      aria-label={`${formatCompactCount(active)} active tokens this usage event`}
+                      aria-label={`${formatCompactCount(processed)} processed tokens this usage event`}
                     >
-                      <span style={{ width: `${(active / max) * 100}%` }} />
+                      <span style={{ width: `${(processed / max) * 100}%` }} />
                     </div>
                   </div>
                 </td>
@@ -471,15 +472,15 @@ function buildDays(daily: UsageAgentSummary["daily"] | undefined): DayBucket[] {
   // `daily[].date` is YYYY-MM-DD in UTC (schema). Iterate, label, and join in
   // UTC consistently — local-tz Date methods would shift weekday/date by ±1
   // half the day in non-UTC zones and silently miss the join key.
-  const byDate = new Map<string, number>();
+  const byActive = new Map<string, number>();
   for (const d of daily ?? []) {
-    byDate.set(d.date, d.inputTokens + d.outputTokens);
+    byActive.set(d.date, activeTokenCount(d));
   }
   const byCacheRead = new Map<string, number>();
   const byProcessed = new Map<string, number>();
   for (const d of daily ?? []) {
     byCacheRead.set(d.date, d.cachedInputTokens);
-    byProcessed.set(d.date, d.inputTokens + d.cachedInputTokens + d.outputTokens);
+    byProcessed.set(d.date, processedTokenCount(d));
   }
   const today = new Date();
   today.setUTCHours(0, 0, 0, 0);
@@ -487,7 +488,7 @@ function buildDays(daily: UsageAgentSummary["daily"] | undefined): DayBucket[] {
   for (let i = ACTIVITY_GRID_DAYS - 1; i >= 0; i--) {
     const dt = new Date(today.getTime() - i * 24 * 60 * 60 * 1000);
     const iso = dt.toISOString().slice(0, 10);
-    const activeTokens = byDate.get(iso) ?? 0;
+    const activeTokens = byActive.get(iso) ?? 0;
     const cacheReadTokens = byCacheRead.get(iso) ?? 0;
     days.push({
       date: iso,
@@ -538,15 +539,15 @@ function computeStats(days: DayBucket[]): {
   peak: DayBucket | null;
   streak: number;
 } {
-  const activeDays = days.filter((d) => d.activeTokens > 0).length;
-  const total = days.reduce((acc, d) => acc + d.activeTokens, 0);
+  const activeDays = days.filter((d) => d.processedTokens > 0).length;
+  const total = days.reduce((acc, d) => acc + d.processedTokens, 0);
   const avgPerDay = days.length > 0 ? Math.round(total / days.length) : 0;
   const seed = days[0];
-  const peak = seed ? days.reduce((a, d) => (d.activeTokens > a.activeTokens ? d : a), seed) : null;
+  const peak = seed ? days.reduce((a, d) => (d.processedTokens > a.processedTokens ? d : a), seed) : null;
   let streak = 0;
   for (let i = days.length - 1; i >= 0; i--) {
     const d = days[i];
-    if (d && d.activeTokens > 0) streak++;
+    if (d && d.processedTokens > 0) streak++;
     else break;
   }
   return { activeDays, avgPerDay, peak, streak };

--- a/packages/web/src/pages/team-preview.tsx
+++ b/packages/web/src/pages/team-preview.tsx
@@ -10,6 +10,7 @@ import { Popover } from "../components/ui/popover.js";
 import { PresenceChip } from "../components/ui/presence-chip.js";
 import { type RowAction, RowActionsMenu } from "../components/ui/row-actions-menu.js";
 import { SegmentedControl } from "../components/ui/segmented-control.js";
+import { formatTokenUsageTitle, processedTokenCount } from "../lib/token-usage.js";
 import { formatCompactCount } from "../lib/utils.js";
 import {
   ME_ID,
@@ -611,15 +612,14 @@ function UsageCell({ usage }: { usage: PreviewUsage | null }) {
       </span>
     );
   }
-  const activeTokens = usage.inputTokens + usage.outputTokens;
-  const processedTokens = activeTokens + usage.cachedInputTokens;
+  const processedTokens = processedTokenCount(usage);
   return (
     <span
       className="text-caption mono truncate"
       style={{ color: "var(--fg-2)" }}
-      title={`Active ${activeTokens.toLocaleString()} · Input ${usage.inputTokens.toLocaleString()} · Cached ${usage.cachedInputTokens.toLocaleString()} · Output ${usage.outputTokens.toLocaleString()} · Processed ${processedTokens.toLocaleString()} · ${usage.turns} usage events`}
+      title={formatTokenUsageTitle(usage, { turns: usage.turns })}
     >
-      {formatCompactCount(activeTokens)}
+      {formatCompactCount(processedTokens)}
       <span style={{ color: "var(--fg-4)" }}>{` · ${formatCompactCount(usage.turns)}t`}</span>
     </span>
   );
@@ -1094,7 +1094,7 @@ function agentMetaLine(agent: PreviewAgent, isMine: boolean, usage: PreviewUsage
   const owner = isMine ? "You" : (MEMBERS[agent.managerId]?.displayName ?? "—");
   const usageStr =
     usage && usage.turns > 0
-      ? `${formatCompactCount(usage.inputTokens + usage.outputTokens)} · ${formatCompactCount(usage.turns)}t`
+      ? `${formatCompactCount(processedTokenCount(usage))} · ${formatCompactCount(usage.turns)}t`
       : "—";
   return `${owner} · ${agent.runtimeProvider} · ${usageStr}`;
 }

--- a/packages/web/src/pages/team/__tests__/team-table-dom.test.tsx
+++ b/packages/web/src/pages/team/__tests__/team-table-dom.test.tsx
@@ -218,7 +218,7 @@ describe("TeamTable", () => {
     expect(container.textContent).toContain("Human teammates");
     expect(container.textContent).toContain("Nova");
     expect(container.textContent).toContain("Design");
-    expect(container.textContent).toContain("1.5K");
+    expect(container.textContent).toContain("3.5K");
     expect(container.textContent).toContain("Online");
     expect(container.textContent).toContain("Gandy");
     expect(container.textContent).toContain("Admin");

--- a/packages/web/src/pages/team/team-table.tsx
+++ b/packages/web/src/pages/team/team-table.tsx
@@ -8,6 +8,7 @@ import { Popover } from "../../components/ui/popover.js";
 import { PresenceChip, runtimeStateToPresence } from "../../components/ui/presence-chip.js";
 import { type RowAction, RowActionsMenu } from "../../components/ui/row-actions-menu.js";
 import { SegmentedControl } from "../../components/ui/segmented-control.js";
+import { formatTokenUsageTitle, processedTokenCount } from "../../lib/token-usage.js";
 import { formatCompactCount, formatRelative } from "../../lib/utils.js";
 
 export type { RowAction };
@@ -557,8 +558,7 @@ function UsageCell({ usage, loading }: { usage: UsageByAgentRow | null; loading:
       </div>
     );
   }
-  const activeTokens = usage.inputTokens + usage.outputTokens;
-  const processedTokens = activeTokens + usage.cachedInputTokens;
+  const processedTokens = processedTokenCount(usage);
   // Show only the token magnitude — the turn count was dropped from the cell (it
   // crowded the column and truncated); usage events remain in the hover title
   // for the rare case someone wants the breakdown.
@@ -566,9 +566,9 @@ function UsageCell({ usage, loading }: { usage: UsageByAgentRow | null; loading:
     <div
       className="text-caption mono truncate"
       style={{ color: "var(--fg-2)", textAlign: "right" }}
-      title={`Active ${activeTokens.toLocaleString()} · Input ${usage.inputTokens.toLocaleString()} · Cached ${usage.cachedInputTokens.toLocaleString()} · Output ${usage.outputTokens.toLocaleString()} · Processed ${processedTokens.toLocaleString()} · ${usage.turns} usage events`}
+      title={formatTokenUsageTitle(usage, { turns: usage.turns })}
     >
-      {formatCompactCount(activeTokens)}
+      {formatCompactCount(processedTokens)}
     </div>
   );
 }
@@ -1080,6 +1080,6 @@ function agentMetaLine(
 ): string {
   const owner = isSelf ? "You" : (managerLabel ?? "—");
   // Token magnitude only — usage events were dropped from the Usage display.
-  const usageStr = usage && usage.turns > 0 ? formatCompactCount(usage.inputTokens + usage.outputTokens) : "—";
+  const usageStr = usage && usage.turns > 0 ? formatCompactCount(processedTokenCount(usage)) : "—";
   return `${owner} · ${provider} · ${usageStr}`;
 }

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -113,6 +113,7 @@ import { viewOf } from "../../../lib/agent-status-view.js";
 import { attachmentIdFromHref, parseFailedDocHref, wrapFailedDocMentions } from "../../../lib/doc-preview-links.js";
 import { parkFailedDraftIfSwitched } from "../../../lib/draft-store.js";
 import { isNavigableWebHref } from "../../../lib/safe-href.js";
+import { formatTokenUsageTitle, processedTokenCount } from "../../../lib/token-usage.js";
 import { useAgentIdentityMap, useAgentNameMap } from "../../../lib/use-agent-name-map.js";
 import { useAutoResizeTextarea } from "../../../lib/use-autoresize-textarea.js";
 import { useChatDraftText } from "../../../lib/use-chat-draft-text.js";
@@ -1357,8 +1358,7 @@ export function ChatView({
     enabled: !!chatId,
     refetchInterval: 5_000,
   });
-  const chatActiveTokens = chatTokenUsage ? chatTokenUsage.inputTokens + chatTokenUsage.outputTokens : 0;
-  const chatProcessedTokens = chatTokenUsage ? chatActiveTokens + chatTokenUsage.cachedInputTokens : 0;
+  const chatProcessedTokens = chatTokenUsage ? processedTokenCount(chatTokenUsage) : 0;
 
   /** Org-wide agent list, consumed by `managedByMeMap` for picker
    *  grouping and by the identity-map hooks (`useAgentIdentityMap` etc.)
@@ -3366,9 +3366,9 @@ export function ChatView({
                       <div
                         className="mono text-caption"
                         style={{ color: "var(--fg-4)", padding: "0 var(--sp-0_5) var(--sp-1)" }}
-                        title={`active ${chatActiveTokens.toLocaleString()} · input ${chatTokenUsage.inputTokens.toLocaleString()} · cached ${chatTokenUsage.cachedInputTokens.toLocaleString()} · output ${chatTokenUsage.outputTokens.toLocaleString()} · processed ${chatProcessedTokens.toLocaleString()}`}
+                        title={formatTokenUsageTitle(chatTokenUsage)}
                       >
-                        {formatTokenCount(chatActiveTokens)} active tokens in this chat
+                        {formatTokenCount(chatProcessedTokens)} processed tokens in this chat
                       </div>
                     ) : null}
                     <ComposeStatusBar


### PR DESCRIPTION
## Summary
- add shared Web token-usage helpers for active vs processed token totals
- display processed tokens (`input + cached + output`) as the primary usage number in chat, Team rows, agent detail usage, and the dev Team preview
- keep active/input/cached/output breakdowns in tooltips and supporting text

## Verification
- `pnpm check` (passes; existing warning/info output remains)
- `pnpm typecheck`
- `pnpm --filter @first-tree/web exec vitest run --maxWorkers=2 src/lib/__tests__/token-usage.test.ts src/pages/agent-detail/__tests__/usage-tab.test.tsx src/pages/team/__tests__/team-table-dom.test.tsx src/pages/__tests__/team-preview-dom.test.tsx`