### PR TITLE
fix(client): suppress expected codex app-server shutdown noise

### DIFF
--- a/packages/client/src/__tests__/codex-app-server-client.test.ts
+++ b/packages/client/src/__tests__/codex-app-server-client.test.ts
@@ -11,9 +11,10 @@ function makeChild(exitOnSignals: readonly NodeJS.Signals[] = []) {
   };
   const signals: Array<NodeJS.Signals | number | undefined> = [];
   const stdout = new PassThrough();
+  const stderr = new PassThrough();
   child.stdin = new PassThrough() as ChildProcessWithoutNullStreams["stdin"];
   child.stdout = stdout as ChildProcessWithoutNullStreams["stdout"];
-  child.stderr = new PassThrough() as ChildProcessWithoutNullStreams["stderr"];
+  child.stderr = stderr as ChildProcessWithoutNullStreams["stderr"];
   child.killed = false;
   child.kill = vi.fn((signal?: NodeJS.Signals | number) => {
     signals.push(signal);
@@ -23,22 +24,25 @@ function makeChild(exitOnSignals: readonly NodeJS.Signals[] = []) {
     }
     return true;
   });
-  return { child, signals, stdout };
+  return { child, signals, stderr, stdout };
 }
 
 describe("CodexAppServerClient lifecycle", () => {
   it("cleans up the child process when initialize times out", async () => {
     const { child, signals } = makeChild(["SIGTERM"]);
+    const onClose = vi.fn();
 
     await expect(
       CodexAppServerClient.start({
         binary: "/tmp/fake-codex",
         requestTimeoutMs: 5,
         spawnProcess: () => child,
+        onClose,
       }),
     ).rejects.toThrow("codex app-server request timed out: initialize");
 
     expect(signals).toEqual(["SIGTERM"]);
+    expect(onClose).not.toHaveBeenCalled();
   });
 
   it("escalates to SIGKILL when SIGTERM does not exit the child", async () => {
@@ -56,5 +60,49 @@ describe("CodexAppServerClient lifecycle", () => {
     await client.shutdown(5);
 
     expect(signals).toEqual(["SIGTERM", "SIGKILL"]);
+  });
+
+  it("does not report an expected shutdown as a transport close", async () => {
+    const { child, signals, stderr, stdout } = makeChild(["SIGTERM"]);
+    const onClose = vi.fn();
+    const startPromise = CodexAppServerClient.start({
+      binary: "/tmp/fake-codex",
+      requestTimeoutMs: 50,
+      spawnProcess: () => child,
+      onClose,
+    });
+    setImmediate(() => {
+      stdout.write(`${JSON.stringify({ id: 1, result: {} })}\n`);
+    });
+
+    const client = await startPromise;
+    stderr.write("ERROR old tool failure");
+    await client.shutdown();
+
+    expect(signals).toEqual(["SIGTERM"]);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("reports stderr when the app-server exits unexpectedly", async () => {
+    const { child, stderr, stdout } = makeChild();
+    const onClose = vi.fn();
+    const startPromise = CodexAppServerClient.start({
+      binary: "/tmp/fake-codex",
+      requestTimeoutMs: 50,
+      spawnProcess: () => child,
+      onClose,
+    });
+    setImmediate(() => {
+      stdout.write(`${JSON.stringify({ id: 1, result: {} })}\n`);
+    });
+
+    await startPromise;
+    stderr.write("ERROR unexpected tool failure");
+    child.emit("exit", 1, null);
+
+    expect(onClose).toHaveBeenCalledOnce();
+    expect(onClose.mock.calls[0]?.[0].message).toContain(
+      "codex app-server exited with code 1. stderr: ERROR unexpected tool failure",
+    );
   });
 });

--- a/packages/client/src/handlers/codex/app-server/client.ts
+++ b/packages/client/src/handlers/codex/app-server/client.ts
@@ -86,6 +86,7 @@ export class CodexAppServerClient {
   private closed = false;
   private exited = false;
   private closeNotified = false;
+  private shutdownRequested = false;
   private stderrTail = "";
 
   private constructor(options: Required<Pick<CodexAppServerClientOptions, "binary">> & CodexAppServerClientOptions) {
@@ -114,6 +115,10 @@ export class CodexAppServerClient {
     });
     this.child.on("exit", (code, signal) => {
       this.markExited();
+      if (this.shutdownRequested) {
+        this.closeExpectedly();
+        return;
+      }
       const detail = this.stderrTail.trim();
       const suffix = detail ? ` stderr: ${detail}` : "";
       const error = new CodexAppServerTransportError(
@@ -188,6 +193,7 @@ export class CodexAppServerClient {
   }
 
   async shutdown(timeoutMs = 1_000): Promise<void> {
+    this.shutdownRequested = true;
     if (this.exited) return;
     if (!this.closed) {
       this.closed = true;
@@ -273,6 +279,11 @@ export class CodexAppServerClient {
       pending.reject(error);
     }
     this.pending.clear();
+  }
+
+  private closeExpectedly(): void {
+    this.closed = true;
+    this.rejectAll(new CodexAppServerTransportError("codex app-server client shut down"));
   }
 
   private closeWithError(error: CodexAppServerTransportError): void {


### PR DESCRIPTION
## Summary
- Treat Codex app-server exits after a requested shutdown as expected closes so idle suspend no longer logs transport-close stderr noise.
- Keep unexpected app-server exit/error handling on the existing transport error path with stderr diagnostics intact.
- Add lifecycle tests for initialize-timeout cleanup, expected shutdown, and unexpected stderr reporting.

## Verification
- `pnpm --filter @first-tree/client test -- src/__tests__/codex-app-server-client.test.ts` (ran the full client suite: 102 files / 1062 tests passed)
- `pnpm --filter @first-tree/client typecheck`
- `pnpm exec biome check packages/client/src/handlers/codex/app-server/client.ts packages/client/src/__tests__/codex-app-server-client.test.ts`

## Review
- Reviewed by codex-reviewer in First Tree chat: no blocking issues found.