### PR TITLE
feat(web): keep chat list stable — only ask/failed pin, not red dots

### DIFF
--- a/packages/web/src/pages/workspace/__tests__/group-rows.test.ts
+++ b/packages/web/src/pages/workspace/__tests__/group-rows.test.ts
@@ -209,9 +209,10 @@ describe("groupRows — source", () => {
 
 // Chat-granularity predicate.
 // R1 (mine-failed via failedAgentIds), R2 (open question directed at me via
-// openRequestCount > 0 — ANSWER-cleared, so reading the chat does not unpin),
-// R3 (explicit @<me> in unread window via chatHasExplicitMentionToMe +
-// unreadMentionCount > 0). See the rule ladder in group-rows.ts.
+// openRequestCount > 0 — ANSWER-cleared, so reading the chat does not unpin).
+// A plain unread mention / red dot is deliberately NOT a pinning rule: the
+// list stays stable and only an ask (R2) or a broken agent (R1) reorders it.
+// See the rule ladder in group-rows.ts.
 describe("splitAttentionRows — predicate", () => {
   it("R1: mine-failed → attention bucket, failed tier", () => {
     const rows = [row({ id: "r1", lastMessageAt: null, failedAgentIds: ["mine"] })];
@@ -253,7 +254,10 @@ describe("splitAttentionRows — predicate", () => {
     expect(rest.map((r) => r.chatId)).toEqual(["r2-answered"]);
   });
 
-  it("R3: unread + explicit @<me> → attention bucket, mention tier", () => {
+  it("unread + explicit @<me> → NOT attention (red dot does not pin)", () => {
+    // A plain unread mention bumps the red-dot counter but no longer hoists
+    // the chat: pinning is reserved for an ask (R2) or a broken agent (R1),
+    // so the list stays stable. The row stays in its normal recency group.
     const rows = [
       row({
         id: "r2",
@@ -262,16 +266,15 @@ describe("splitAttentionRows — predicate", () => {
         chatHasExplicitMentionToMe: true,
       }),
     ];
-    const { attention } = splitAttentionRows(rows);
-    expect(attention.map((r) => r.chatId)).toEqual(["r2"]);
-    expect(attention[0] && rowAttentionReason(attention[0])).toBe("mention");
+    const { attention, rest } = splitAttentionRows(rows);
+    expect(attention).toEqual([]);
+    expect(rest.map((r) => r.chatId)).toEqual(["r2"]);
   });
 
-  it("R3 disabled by 1-on-1 implicit auto-mention: unreadMentionCount > 0 but flag false → NOT attention", () => {
-    // The original痛点 (t7): in a 1v1, agent → human plain "ack" bumps the
-    // v1 red-dot counter but `metadata.mentions` is empty, so the server
-    // emits `chatHasExplicitMentionToMe: false`. The front-end must NOT
-    // pin this row even though unreadMentionCount > 0.
+  it("unread 1-on-1 implicit auto-mention → NOT attention", () => {
+    // In a 1v1, agent → human plain "ack" bumps the v1 red-dot counter but
+    // `metadata.mentions` is empty (`chatHasExplicitMentionToMe: false`).
+    // Like any unread mention, it must NOT pin.
     const rows = [
       row({
         id: "r2-implicit",
@@ -292,20 +295,23 @@ describe("splitAttentionRows — predicate", () => {
     expect(rest.map((r) => r.chatId)).toEqual(["quiet"]);
   });
 
-  it("priority: failed > request > mention across three tiers", () => {
+  it("priority: failed > request; a plain mention stays unpinned", () => {
+    // The mention-only row "m" is NOT hoisted; only failed + request pin,
+    // with failed first.
     const rows = [
       row({ id: "m", lastMessageAt: null, unreadMentionCount: 1, chatHasExplicitMentionToMe: true }),
       row({ id: "q", lastMessageAt: null, openRequestCount: 1 }),
       row({ id: "f", lastMessageAt: null, failedAgentIds: ["y"] }),
     ];
-    const { attention } = splitAttentionRows(rows);
-    expect(attention.map((r) => r.chatId)).toEqual(["f", "q", "m"]);
+    const { attention, rest } = splitAttentionRows(rows);
+    expect(attention.map((r) => r.chatId)).toEqual(["f", "q"]);
+    expect(rest.map((r) => r.chatId)).toEqual(["m"]);
   });
 
-  it("priority: request beats mention on the same row", () => {
-    // A fresh `chat ask` (request) is typically also an unread explicit mention —
-    // the row sorts under the request tier, and stays pinned (as `request`)
-    // after the mention half is read away.
+  it("request + unread mention on the same row → pins as request", () => {
+    // A fresh `chat ask` (request) is typically also an unread explicit
+    // mention. The request pins it (the mention half is irrelevant to
+    // ordering), and it stays pinned as `request` after the mention is read.
     const rows = [
       row({
         id: "qm",
@@ -319,7 +325,7 @@ describe("splitAttentionRows — predicate", () => {
     expect(attention[0] && rowAttentionReason(attention[0])).toBe("request");
   });
 
-  it("priority: failed beats mention on the same row", () => {
+  it("failed + unread mention on the same row → pins as failed", () => {
     const rows = [
       row({
         id: "fm",
@@ -362,21 +368,10 @@ describe("splitAttentionRows — predicate", () => {
 
 // Version-skew safety: the web client casts the server response as-is and
 // does NOT run rows through `meChatRowSchema.parse`, so the zod
-// `.default(false)` only applies server-side. The predicate must therefore
-// check the new boolean with strict `=== true` so an `undefined` value from
-// an old server returns "off" for that rule instead of trusting a `&&`
-// coercion of an unknown shape.
+// `.default(...)` only applies server-side. The predicate must therefore
+// tolerate an `undefined` field from an old server by degrading that rule
+// to "off" rather than mispinning.
 describe("splitAttentionRows — version skew (old server, new web)", () => {
-  it("missing chatHasExplicitMentionToMe (undefined) → R3 disabled", () => {
-    const stale = {
-      ...row({ id: "stale", lastMessageAt: null, unreadMentionCount: 1 }),
-    };
-    delete (stale as { chatHasExplicitMentionToMe?: boolean }).chatHasExplicitMentionToMe;
-    const { attention, rest } = splitAttentionRows([stale]);
-    expect(attention).toEqual([]);
-    expect(rest.map((r) => r.chatId)).toEqual(["stale"]);
-  });
-
   it("missing openRequestCount (undefined) → R2 disabled", () => {
     // `undefined > 0` is `false` — an old server build that predates the
     // field degrades the request rule to "off" rather than mispinning.

--- a/packages/web/src/pages/workspace/conversations/__tests__/conversation-list-dom.test.tsx
+++ b/packages/web/src/pages/workspace/conversations/__tests__/conversation-list-dom.test.tsx
@@ -90,6 +90,10 @@ const BASE_ROWS: MeChatRow[] = [
   row({
     chatId: "chat-needs",
     title: "Waiting approval",
+    // An open ask (R2) — pins to "Needs attention". The unread badge below
+    // still renders (unreadMentionCount: 1), but the mention is no longer
+    // what pins the row; the open request is.
+    openRequestCount: 1,
     unreadMentionCount: 1,
     chatHasExplicitMentionToMe: true,
     lastMessageAt: null,
@@ -276,7 +280,8 @@ describe("ConversationList", () => {
     expect(container.textContent).toContain("From GitHub");
     expect(container.querySelector('[aria-label="watching"]')).toBeTruthy();
     expect(container.querySelector('[aria-label="failed, 3 unread"]')).toBeTruthy();
-    expect(container.querySelector('[aria-label="1 unread"]')).toBeTruthy();
+    // The open-ask row carries the "needs you" badge alongside its unread count.
+    expect(container.querySelector('[aria-label="needs you, 1 unread"]')).toBeTruthy();
 
     await click(rowButton(container, "Manual planning"));
     expect(onSelectChat).toHaveBeenCalledWith("chat-manual");

--- a/packages/web/src/pages/workspace/conversations/group-rows.ts
+++ b/packages/web/src/pages/workspace/conversations/group-rows.ts
@@ -183,7 +183,7 @@ function groupBySource(rows: ReadonlyArray<MeChatRow>): ReadonlyArray<GroupBucke
 }
 
 // ---------------------------------------------------------------------------
-// attention pinning (failed + request + mention)
+// attention pinning (failed + request)
 // ---------------------------------------------------------------------------
 //
 // Chat-granularity predicate — see docs/development/needs-attention-scoping.20260526.md.
@@ -192,7 +192,9 @@ function groupBySource(rows: ReadonlyArray<MeChatRow>): ReadonlyArray<GroupBucke
 //   R1. `failedAgentIds.length > 0`
 //       — A non-human agent I MANAGE is `failed` in this chat. Server
 //         narrows `failedAgentIds` to `agents.manager_id = caller` so a
-//         peer's broken agent never pins my row.
+//         peer's broken agent never pins my row. A broken agent is stuck
+//         until I intervene, so recovery is a legitimate attention signal
+//         and it still pins.
 //
 //   R2. `openRequestCount > 0`
 //       — An agent raised a structured question (`format=request`) at me
@@ -203,51 +205,39 @@ function groupBySource(rows: ReadonlyArray<MeChatRow>): ReadonlyArray<GroupBucke
 //         bucket — the asking agent is still blocked on me until I actually
 //         answer the question.
 //
-//   R3. `unreadMentionCount > 0 && chatHasExplicitMentionToMe === true`
-//       — I have unread, and at least one unread message explicitly
-//         `@<me>`-mentions me (server checks `messages.metadata.mentions`
-//         in the unread window). Distinguishes explicit `@<me>` from the
-//         v1 1-on-1 implicit DM auto-mention (`services/message.ts:282
-//         dmAutoProjection`), which still bumps `unreadMentionCount` for
-//         the red dot but never writes the recipient into
-//         `metadata.mentions` — so an agent's plain `"ack"` to me in a DM
-//         correctly stays out of attention. Read-cleared — which is why
-//         an open request needs its own rule (R2) instead of riding on
-//         this one.
+// Deliberately NOT a pinning rule — a plain unread mention / red dot. An
+// `@<me>` mention bumps `unreadMentionCount` (and still renders the red
+// dot) but no longer hoists the chat to the top. The chat list is kept as
+// stable as possible: only an explicit ask (R2) or a broken agent needing
+// recovery (R1) reorders it. A red dot is awareness, not a demand for
+// judgment, so it must not churn the ordering. (`chatHasExplicitMentionToMe`
+// stays on the row as a precise signal for the red dot / a future
+// explicit-@me affordance, but no longer feeds pinning.)
 //
-// Sort priority: `failed > request > mention`. An open question outranks a
-// plain mention because the asker is explicitly blocked waiting on the
-// caller; both yield to `failed` (broken agent needs recovery first).
+// Sort priority: `failed > request`. Both demand action; `failed` outranks
+// because a stuck agent needs recovery before its chat can make progress
+// at all.
 //
 // This ladder is INTENTIONALLY separate from the shared agent-status
-// `compareMainStatus` (`failed`, `working`, ...). `mention` is a chat-level
-// signal, not an agent main status — overloading the shared comparator would
-// couple two ladders that should evolve independently.
-//
-// `=== true` checks (not truthy) on booleans: the web client does NOT run
-// rows through `meChatRowSchema.parse`, so the Zod `.default(false)` only
-// applies server-side; an older server returning `undefined` would
-// silently degrade the rule to "off" under strict equality (safer
-// direction).
+// `compareMainStatus` (`failed`, `working`, ...) — overloading the shared
+// comparator would couple two ladders that should evolve independently.
 
-const ATTENTION_PRIORITY = ["failed", "request", "mention"] as const;
+const ATTENTION_PRIORITY = ["failed", "request"] as const;
 type AttentionReason = (typeof ATTENTION_PRIORITY)[number];
 
 /**
  * Highest-priority attention reason for this row, or `null` when the row is
  * NOT in the attention bucket. Order matters: a row that satisfies multiple
- * rules sorts under its highest tier (e.g. failed + mention → failed).
+ * rules sorts under its highest tier (e.g. failed + request → failed).
  */
 export function rowAttentionReason(r: MeChatRow): AttentionReason | null {
   if (r.failedAgentIds.length > 0) return "failed";
   // `> 0` is skew-safe without an explicit guard: an older server build
   // that predates `openRequestCount` yields `undefined`, and
-  // `undefined > 0` is `false` — the rule degrades to "off", same safe
-  // direction as the `=== true` boolean checks above.
+  // `undefined > 0` is `false` — the rule degrades to "off" (safe
+  // direction). A plain unread mention is intentionally not a reason here:
+  // the red dot must not pin (see the rules block above).
   if (r.openRequestCount > 0) return "request";
-  if (r.unreadMentionCount > 0 && r.chatHasExplicitMentionToMe === true) {
-    return "mention";
-  }
   return null;
 }
 

--- a/packages/web/src/pages/workspace/conversations/index.tsx
+++ b/packages/web/src/pages/workspace/conversations/index.tsx
@@ -219,10 +219,11 @@ export function ConversationList({
   // (e.g. an inactive tab the browser throttles) won't see the bucket
   // shift until the next refetch lands; that's an acceptable degree
   // of staleness for a presentational concern.
-  // Hoist attention chats (failed + open request + mention) into a pinned
-  // section at the top WITHOUT touching cursor pagination or reordering the
-  // main list: partition them out, group the rest as usual, then prepend a
-  // synthetic "Needs attention" bucket (failed > request > mention). A chat
+  // Hoist attention chats (failed + open request) into a pinned section at
+  // the top WITHOUT touching cursor pagination or reordering the main list:
+  // partition them out, group the rest as usual, then prepend a synthetic
+  // "Needs attention" bucket (failed > request). A plain unread mention /
+  // red dot deliberately does NOT pin, so the list stays stable. A chat
   // appears in exactly one place (pinned OR its normal group), never both.
   const buckets = useMemo(() => {
     const { attention, rest } = splitAttentionRows(allRows);


### PR DESCRIPTION
## What

Make the workspace chat list ordering as stable as possible: a plain unread mention (red dot) no longer reorders the list. Only an explicit **ask** (open request) or a **failed managed agent** (needs recovery) pins a chat to the top.

## Why

The "Needs attention" bucket previously hoisted a chat on three signals — failed (R1), open request (R2), and unread explicit `@<me>` mention (R3). The mention rule (R3) meant the list churned every time a red dot appeared, even though a red dot is awareness, not a demand for action.

Per the product attention model, attention should mark where human **judgment** or **recovery** changes the outcome — an ask (judgment) and a broken agent (recovery) qualify; a passing mention does not.

## Change

- Drop the mention pinning rule (R3). Sort priority becomes `failed > request`.
- An unread mention still renders the red dot — it just no longer pins/reorders.
- `chatHasExplicitMentionToMe` stays on the row contract (precise red-dot / future explicit-`@me` signal); it no longer feeds pinning.
- Tests updated: mention-only rows assert NOT pinned; the DOM fixture's "Waiting approval" is now a genuine open ask so the request path stays exercised.

## Verification

- `pnpm --filter @first-tree/web typecheck` ✅
- `pnpm --filter @first-tree/web test` — 118 files / 882 tests ✅
- Biome check on changed files ✅

## Context Tree

Records the stable-ordering decision: agent-team-foundation/first-tree-context#577

🤖 Generated with [Claude Code](https://claude.com/claude-code)