### PR TITLE
fix: stop retrying codex deterministic compact failures

### DIFF
--- a/packages/client/src/__tests__/codex-app-server-handler.test.ts
+++ b/packages/client/src/__tests__/codex-app-server-handler.test.ts
@@ -248,6 +248,18 @@ function completeTurn(fake: FakeAppServerClient, turnId: string, text: string): 
   });
 }
 
+function completeEmptyTurn(fake: FakeAppServerClient, turnId: string): void {
+  fake.emit("turn/completed", {
+    threadId: "thread-app-server",
+    turn: {
+      id: turnId,
+      status: "completed",
+      items: [],
+      error: null,
+    },
+  });
+}
+
 function failTurn(
   fake: FakeAppServerClient,
   turnId: string,
@@ -472,6 +484,63 @@ describe("codex app-server handler", () => {
     });
     expect(token.retry).not.toHaveBeenCalled();
     expect(retryTurn).not.toHaveBeenCalled();
+
+    await handler.shutdown();
+  });
+
+  it("terminal-rejects completed empty turns when stderr reports pre-sampling compact failure", async () => {
+    const fake = new FakeAppServerClient();
+    fake.stderr = "2026-06-22T03:02:58Z ERROR codex_core::session::turn: Failed to run pre-sampling compact";
+    const retryTurn = vi.fn<SessionContext["retryTurn"]>();
+    const finishTurn = vi.fn<SessionContext["finishTurn"]>();
+    const emitEvent = vi.fn<(event: SessionEvent) => void>();
+    const token = makeDeliveryToken();
+    const handler = makeHandler(fake);
+    const ctx = makeContext({ retryTurn, finishTurn, emitEvent });
+    const message = makeMessage("m1", "first");
+
+    const startPromise = handler.start(message, ctx, token);
+    await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
+
+    completeEmptyTurn(fake, "turn-1");
+    await startPromise;
+
+    expect(token.terminalRejected).toHaveBeenCalledWith([message], "codex_compact_failure", {
+      kind: "server_terminal_record",
+      recordId: "turn-1",
+    });
+    expect(token.retry).not.toHaveBeenCalled();
+    expect(token.complete).not.toHaveBeenCalled();
+    expect(retryTurn).not.toHaveBeenCalled();
+    expect(finishTurn).not.toHaveBeenCalled();
+    expect(
+      emitEvent.mock.calls.some(
+        ([event]) =>
+          event.kind === "error" &&
+          event.payload.source === "sdk" &&
+          event.payload.message.includes("failed to compact this thread"),
+      ),
+    ).toBe(true);
+
+    await handler.shutdown();
+  });
+
+  it("keeps completed empty turns without compact diagnostics as successful silence", async () => {
+    const fake = new FakeAppServerClient();
+    const token = makeDeliveryToken();
+    const handler = makeHandler(fake);
+    const ctx = makeContext();
+    const message = makeMessage("m1", "first");
+
+    const startPromise = handler.start(message, ctx, token);
+    await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
+
+    completeEmptyTurn(fake, "turn-1");
+    await startPromise;
+
+    expect(token.complete).toHaveBeenCalledWith([message], { status: "success", terminal: true });
+    expect(token.terminalRejected).not.toHaveBeenCalled();
+    expect(token.retry).not.toHaveBeenCalled();
 
     await handler.shutdown();
   });

--- a/packages/client/src/__tests__/codex-app-server-handler.test.ts
+++ b/packages/client/src/__tests__/codex-app-server-handler.test.ts
@@ -5,7 +5,7 @@ import type { SessionEvent } from "@first-tree/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CodexAppServerRpcError, CodexAppServerTransportError } from "../handlers/codex/app-server/client.js";
 import { createCodexAppServerHandler } from "../handlers/codex/app-server/index.js";
-import type { SessionContext, SessionMessage } from "../runtime/handler.js";
+import type { DeliveryToken, SessionContext, SessionMessage } from "../runtime/handler.js";
 import { mockCtxPlumbing } from "./test-helpers.js";
 
 vi.mock("../runtime/bootstrap.js", () => ({
@@ -188,6 +188,15 @@ function makeHandler(fake: FakeAppServerClient) {
   });
 }
 
+function makeDeliveryToken(): DeliveryToken {
+  return {
+    processingStarted: vi.fn<DeliveryToken["processingStarted"]>(),
+    complete: vi.fn<DeliveryToken["complete"]>().mockResolvedValue(undefined),
+    retry: vi.fn<DeliveryToken["retry"]>(),
+    terminalRejected: vi.fn<DeliveryToken["terminalRejected"]>().mockResolvedValue(undefined),
+  };
+}
+
 async function waitFor(assertion: () => boolean): Promise<void> {
   const deadline = Date.now() + 1000;
   while (!assertion()) {
@@ -235,6 +244,26 @@ function completeTurn(fake: FakeAppServerClient, turnId: string, text: string): 
       status: "completed",
       items: [],
       error: null,
+    },
+  });
+}
+
+function failTurn(
+  fake: FakeAppServerClient,
+  turnId: string,
+  error: { message: string; codexErrorInfo?: unknown; additionalDetails?: string | null },
+): void {
+  fake.emit("turn/completed", {
+    threadId: "thread-app-server",
+    turn: {
+      id: turnId,
+      status: "failed",
+      items: [],
+      error: {
+        message: error.message,
+        codexErrorInfo: error.codexErrorInfo ?? null,
+        additionalDetails: error.additionalDetails ?? null,
+      },
     },
   });
 }
@@ -341,6 +370,151 @@ describe("codex app-server handler", () => {
     await waitFor(() => finished.length === 2);
 
     expect(finished.map((messages) => messages.map((message) => message.id))).toEqual([["m1"], ["m2"]]);
+
+    await handler.shutdown();
+  });
+
+  it("terminal-rejects deterministic context-window turn failures instead of retrying delivery", async () => {
+    const fake = new FakeAppServerClient();
+    const retryTurn = vi.fn<SessionContext["retryTurn"]>();
+    const finishTurn = vi.fn<SessionContext["finishTurn"]>();
+    const emitEvent = vi.fn<(event: SessionEvent) => void>();
+    const token = makeDeliveryToken();
+    const handler = makeHandler(fake);
+    const ctx = makeContext({ retryTurn, finishTurn, emitEvent });
+    const message = makeMessage("m1", "first");
+
+    const startPromise = handler.start(message, ctx, token);
+    await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
+
+    failTurn(fake, "turn-1", {
+      message:
+        "Error running remote compact task: Codex ran out of room in the model's context window. Start a new thread.",
+      codexErrorInfo: "contextWindowExceeded",
+    });
+    await startPromise;
+
+    expect(token.terminalRejected).toHaveBeenCalledWith([message], "codex_context_window_exceeded", {
+      kind: "server_terminal_record",
+      recordId: "turn-1",
+    });
+    expect(token.retry).not.toHaveBeenCalled();
+    expect(token.complete).not.toHaveBeenCalled();
+    expect(retryTurn).not.toHaveBeenCalled();
+    expect(finishTurn).not.toHaveBeenCalled();
+    expect(
+      emitEvent.mock.calls.some(
+        ([event]) =>
+          event.kind === "error" &&
+          event.payload.source === "sdk" &&
+          event.payload.message.includes("Codex ran out of room"),
+      ),
+    ).toBe(true);
+    expect(emitEvent).toHaveBeenCalledWith({ kind: "turn_end", payload: { status: "error" } });
+
+    await handler.shutdown();
+  });
+
+  it("terminal-rejects stderr-only remote compact context-window failures", async () => {
+    const fake = new FakeAppServerClient();
+    const retryTurn = vi.fn<SessionContext["retryTurn"]>();
+    const token = makeDeliveryToken();
+    const handler = makeHandler(fake);
+    const ctx = makeContext({ retryTurn });
+    const message = makeMessage("m1", "first");
+
+    const startPromise = handler.start(message, ctx, token);
+    await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
+
+    fake.close(
+      "codex app-server exited signal SIGTERM. stderr: Failed to run pre-sampling compact\n" +
+        "Error running remote compact task: Codex ran out of room in the model's context window.",
+    );
+    await startPromise;
+
+    expect(token.terminalRejected).toHaveBeenCalledWith([message], "codex_context_window_exceeded", {
+      kind: "server_terminal_record",
+      recordId: "turn-1",
+    });
+    expect(token.retry).not.toHaveBeenCalled();
+    expect(retryTurn).not.toHaveBeenCalled();
+
+    await handler.shutdown();
+  });
+
+  it("uses prior sdk compact errors to classify a later compact transport close", async () => {
+    const fake = new FakeAppServerClient();
+    const retryTurn = vi.fn<SessionContext["retryTurn"]>();
+    const token = makeDeliveryToken();
+    const handler = makeHandler(fake);
+    const ctx = makeContext({ retryTurn });
+    const message = makeMessage("m1", "first");
+
+    const startPromise = handler.start(message, ctx, token);
+    await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
+
+    fake.emit("error", {
+      threadId: "thread-app-server",
+      turnId: "turn-1",
+      error: {
+        message:
+          "Error running remote compact task: Codex ran out of room in the model's context window. Start a new thread.",
+        codexErrorInfo: null,
+        additionalDetails: null,
+      },
+    });
+    fake.close("codex app-server exited signal SIGTERM. stderr: Failed to run pre-sampling compact");
+    await startPromise;
+
+    expect(token.terminalRejected).toHaveBeenCalledWith([message], "codex_context_window_exceeded", {
+      kind: "server_terminal_record",
+      recordId: "turn-1",
+    });
+    expect(token.retry).not.toHaveBeenCalled();
+    expect(retryTurn).not.toHaveBeenCalled();
+
+    await handler.shutdown();
+  });
+
+  it("keeps transient app-server turn failures retryable", async () => {
+    const fake = new FakeAppServerClient();
+    const token = makeDeliveryToken();
+    const handler = makeHandler(fake);
+    const ctx = makeContext();
+    const message = makeMessage("m1", "first");
+
+    const startPromise = handler.start(message, ctx, token);
+    await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
+
+    failTurn(fake, "turn-1", {
+      message: "server overloaded",
+      codexErrorInfo: "serverOverloaded",
+    });
+    await startPromise;
+
+    expect(token.retry).toHaveBeenCalledWith([message], "codex_transient_failure");
+    expect(token.terminalRejected).not.toHaveBeenCalled();
+    expect(token.complete).not.toHaveBeenCalled();
+
+    await handler.shutdown();
+  });
+
+  it("does not classify ordinary transport close text as deterministic", async () => {
+    const fake = new FakeAppServerClient();
+    const token = makeDeliveryToken();
+    const handler = makeHandler(fake);
+    const ctx = makeContext();
+    const message = makeMessage("m1", "first");
+
+    const startPromise = handler.start(message, ctx, token);
+    await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
+
+    fake.close("transport is closed");
+    await startPromise;
+
+    expect(token.retry).toHaveBeenCalledWith([message], "codex_unknown_failure");
+    expect(token.terminalRejected).not.toHaveBeenCalled();
+    expect(token.complete).not.toHaveBeenCalled();
 
     await handler.shutdown();
   });

--- a/packages/client/src/handlers/codex/app-server/index.ts
+++ b/packages/client/src/handlers/codex/app-server/index.ts
@@ -111,6 +111,8 @@ const USAGE_LIMIT_NOTICE =
 const CODEX_CONTEXT_WINDOW_FAILURE_MESSAGE =
   "Codex ran out of room in the model context while compacting this thread. " +
   "Start a new thread or clear earlier history before retrying.";
+const CODEX_COMPACT_FAILURE_MESSAGE =
+  "Codex failed to compact this thread before answering. Start a new thread or clear earlier history before retrying.";
 
 export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfig): AgentHandler => {
   const workspaceRoot = config.workspaceRoot as string;
@@ -762,6 +764,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
     }
 
     const completedSuccessfully = turn.providerCompleted && turn.failure === null && turn.status === "completed";
+    const finalAgentText = turn.finalAgentText.trim();
     const usage = turn.usageLast;
     const zeroTokenDelta =
       usage !== null &&
@@ -769,7 +772,11 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
       usage.cachedInputTokens === 0 &&
       usage.outputTokens === 0 &&
       usage.reasoningOutputTokens === 0;
-    const usageLimitEmptyTurn = completedSuccessfully && turn.finalAgentText.trim().length === 0 && zeroTokenDelta;
+    const usageLimitEmptyTurn = completedSuccessfully && finalAgentText.length === 0 && zeroTokenDelta;
+    const completedEmptyCompactFailure =
+      completedSuccessfully && finalAgentText.length === 0
+        ? completedEmptyCompactFailureInfo(turn, appServer?.stderr ?? "")
+        : null;
     const usageLimitFailure = turn.failure ? isUsageLimitErrorInfo(turn.failure.codexErrorInfo) : false;
 
     let forwardFailed = false;
@@ -777,7 +784,16 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
     let consumedErrorReason: TurnConsumedErrorReason | null = null;
     let terminalRejectionReason: string | null = null;
 
-    if (usageLimitEmptyTurn || usageLimitFailure) {
+    if (completedEmptyCompactFailure) {
+      terminalRejectionReason = deterministicTerminalRejectionReason(completedEmptyCompactFailure);
+      sessionCtx.emitEvent({
+        kind: "error",
+        payload: { source: "sdk", message: formatDeterministicFailureMessage(completedEmptyCompactFailure) },
+      });
+      sessionCtx.log(
+        `codex app-server turn completed empty after compact failure; terminal rejecting delivery (${terminalRejectionReason}): ${completedEmptyCompactFailure.message}`,
+      );
+    } else if (usageLimitEmptyTurn || usageLimitFailure) {
       sessionCtx.emitEvent({
         kind: "error",
         payload: {
@@ -796,9 +812,9 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
         });
         retryReason = "codex_usage_limit_notice_delivery_failed";
       }
-    } else if (completedSuccessfully && turn.finalAgentText.trim()) {
+    } else if (completedSuccessfully && finalAgentText) {
       try {
-        await sessionCtx.forwardResult(turn.finalAgentText);
+        await sessionCtx.forwardResult(finalAgentText);
       } catch (err) {
         forwardFailed = true;
         const msg = err instanceof Error ? err.message : String(err);
@@ -1166,6 +1182,22 @@ function mergeFailureWithDiagnostic(failure: TurnErrorInfo, diagnostic: TurnErro
   };
 }
 
+function completedEmptyCompactFailureInfo(turn: CurrentTurn, stderr: string): TurnErrorInfo | null {
+  const details = [turn.lastSdkError?.message, turn.lastSdkError?.additionalDetails, stderr]
+    .filter((part): part is string => typeof part === "string" && part.length > 0)
+    .join("\n");
+  if (!details) return null;
+
+  const diagnostic: TurnErrorInfo = {
+    message: "codex app-server completed without output after pre-sampling compact failure",
+    codexErrorInfo: turn.lastSdkError?.codexErrorInfo ?? null,
+    additionalDetails: details,
+  };
+  if (isDeterministicCompactFailure(diagnostic)) return diagnostic;
+  if (isPreSamplingCompactFailureText(details)) return diagnostic;
+  return null;
+}
+
 function formatAppServerError(message: string): string {
   if (isCodexAuthError(message)) return formatAuthHint("codex", message);
   return message;
@@ -1185,6 +1217,7 @@ function classifyAppServerFailure(error: TurnErrorInfo): "deterministic" | "tran
 
 function deterministicTerminalRejectionReason(error: TurnErrorInfo): string {
   if (isContextWindowFailure(error)) return "codex_context_window_exceeded";
+  if (isPreSamplingCompactFailure(error)) return "codex_compact_failure";
   if (isCodexAuthError(error.message) || error.codexErrorInfo === "unauthorized") return "codex_auth_failure";
   if (error.codexErrorInfo === "badRequest") return "codex_bad_request_failure";
   if (error.codexErrorInfo === "sandboxError") return "codex_sandbox_failure";
@@ -1194,6 +1227,7 @@ function deterministicTerminalRejectionReason(error: TurnErrorInfo): string {
 
 function formatDeterministicFailureMessage(error: TurnErrorInfo): string {
   if (isContextWindowFailure(error)) return CODEX_CONTEXT_WINDOW_FAILURE_MESSAGE;
+  if (isPreSamplingCompactFailure(error)) return CODEX_COMPACT_FAILURE_MESSAGE;
   return formatAppServerError(error.message);
 }
 
@@ -1212,6 +1246,14 @@ function isDeterministicCompactFailure(error: TurnErrorInfo): boolean {
     text.includes("remote compact");
   const contextFailure = text.includes("context window") || text.includes("context length");
   return compactFailure && contextFailure;
+}
+
+function isPreSamplingCompactFailure(error: TurnErrorInfo): boolean {
+  return isPreSamplingCompactFailureText(`${error.message}\n${error.additionalDetails ?? ""}`);
+}
+
+function isPreSamplingCompactFailureText(value: string): boolean {
+  return value.toLowerCase().includes("failed to run pre-sampling compact");
 }
 
 function isUsageLimitErrorInfo(value: unknown): boolean {

--- a/packages/client/src/handlers/codex/app-server/index.ts
+++ b/packages/client/src/handlers/codex/app-server/index.ts
@@ -86,8 +86,10 @@ type CurrentTurn = {
   completedItemIds: Set<string>;
   usageLast: TokenUsageBreakdown | null;
   failure: TurnErrorInfo | null;
+  lastSdkError: TurnErrorInfo | null;
   providerCompleted: boolean;
   stopRequested: boolean;
+  sdkErrorEmitted: boolean;
   resolveTerminal: () => void;
 };
 
@@ -106,6 +108,9 @@ const RESULT_PREVIEW_LIMIT = 400;
 const USAGE_LIMIT_NOTICE =
   "⚠️ My runtime has reached its usage limit, so I couldn't process the message you just sent. " +
   "Please resend it once the limit resets.";
+const CODEX_CONTEXT_WINDOW_FAILURE_MESSAGE =
+  "Codex ran out of room in the model context while compacting this thread. " +
+  "Start a new thread or clear earlier history before retrying.";
 
 export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfig): AgentHandler => {
   const workspaceRoot = config.workspaceRoot as string;
@@ -523,6 +528,10 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
       case "error": {
         const error = parseTurnError(params.error);
         if (error) {
+          if (turn) {
+            turn.lastSdkError = error;
+            turn.sdkErrorEmitted = true;
+          }
           sessionCtx.emitEvent({
             kind: "error",
             payload: { source: "sdk", message: formatAppServerError(error.message) },
@@ -710,8 +719,10 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
       completedItemIds: new Set(),
       usageLast: null,
       failure: null,
+      lastSdkError: null,
       providerCompleted: false,
       stopRequested: false,
+      sdkErrorEmitted: false,
       resolveTerminal,
     };
     currentTurn = turn;
@@ -764,6 +775,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
     let forwardFailed = false;
     let retryReason: string | null = null;
     let consumedErrorReason: TurnConsumedErrorReason | null = null;
+    let terminalRejectionReason: string | null = null;
 
     if (usageLimitEmptyTurn || usageLimitFailure) {
       sessionCtx.emitEvent({
@@ -796,18 +808,26 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
         });
       }
     } else if (turn.failure) {
-      const kind = classifyAppServerFailure(turn.failure);
-      retryReason = `codex_${kind}_failure`;
-      sessionCtx.log(`codex app-server turn failed (${kind}): ${turn.failure.message}`);
+      const failure = mergeFailureWithDiagnostic(turn.failure, turn.lastSdkError);
+      const kind = classifyAppServerFailure(failure);
+      if (kind === "deterministic") {
+        terminalRejectionReason = deterministicTerminalRejectionReason(failure);
+        if (!turn.sdkErrorEmitted) {
+          sessionCtx.emitEvent({
+            kind: "error",
+            payload: { source: "sdk", message: formatDeterministicFailureMessage(failure) },
+          });
+        }
+        sessionCtx.log(
+          `codex app-server turn failed deterministically; terminal rejecting delivery (${terminalRejectionReason}): ${turn.failure.message}`,
+        );
+      } else {
+        retryReason = `codex_${kind}_failure`;
+        sessionCtx.log(`codex app-server turn failed (${kind}): ${turn.failure.message}`);
+      }
     } else if (!turn.providerCompleted) {
       retryReason = "codex_app_server_stream_ended_without_completion";
     }
-
-    const settlement = resolveTurnSettlement({
-      retryReason,
-      consumedErrorReason,
-      forwardFailed,
-    });
 
     if (usage) {
       sessionCtx.emitEvent({
@@ -821,12 +841,25 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
         },
       });
     }
-    sessionCtx.emitEvent({ kind: "turn_end", payload: { status: settlement.status } });
 
-    if (settlement.action.kind === "complete") {
-      await turn.primaryToken.complete(turn.acceptedMessages, settlement.action.outcome);
+    if (terminalRejectionReason) {
+      sessionCtx.emitEvent({ kind: "turn_end", payload: { status: "error" } });
+      await turn.primaryToken.terminalRejected(turn.acceptedMessages, terminalRejectionReason, {
+        kind: "server_terminal_record",
+        recordId: turn.turnId,
+      });
     } else {
-      turn.primaryToken.retry(turn.acceptedMessages, settlement.action.reason);
+      const settlement = resolveTurnSettlement({
+        retryReason,
+        consumedErrorReason,
+        forwardFailed,
+      });
+      sessionCtx.emitEvent({ kind: "turn_end", payload: { status: settlement.status } });
+      if (settlement.action.kind === "complete") {
+        await turn.primaryToken.complete(turn.acceptedMessages, settlement.action.outcome);
+      } else {
+        turn.primaryToken.retry(turn.acceptedMessages, settlement.action.reason);
+      }
     }
     schedulePostTurnDrain();
   }
@@ -1121,15 +1154,64 @@ function parseTurnError(value: unknown): TurnErrorInfo | null {
   };
 }
 
+function mergeFailureWithDiagnostic(failure: TurnErrorInfo, diagnostic: TurnErrorInfo | null): TurnErrorInfo {
+  if (!diagnostic) return failure;
+  const details = [failure.additionalDetails, diagnostic.message, diagnostic.additionalDetails]
+    .filter((part): part is string => typeof part === "string" && part.length > 0)
+    .join("\n");
+  return {
+    message: failure.message,
+    codexErrorInfo: failure.codexErrorInfo ?? diagnostic.codexErrorInfo,
+    additionalDetails: details || null,
+  };
+}
+
 function formatAppServerError(message: string): string {
   if (isCodexAuthError(message)) return formatAuthHint("codex", message);
   return message;
 }
 
 function classifyAppServerFailure(error: TurnErrorInfo): "deterministic" | "transient" | "unknown" {
-  if (isCodexAuthError(error.message) || isDeterministicErrorInfo(error.codexErrorInfo)) return "deterministic";
+  if (
+    isCodexAuthError(error.message) ||
+    isDeterministicErrorInfo(error.codexErrorInfo) ||
+    isDeterministicCompactFailure(error)
+  ) {
+    return "deterministic";
+  }
   if (isTransientCodexErrorMessage(error.message) || isTransientErrorInfo(error.codexErrorInfo)) return "transient";
   return "unknown";
+}
+
+function deterministicTerminalRejectionReason(error: TurnErrorInfo): string {
+  if (isContextWindowFailure(error)) return "codex_context_window_exceeded";
+  if (isCodexAuthError(error.message) || error.codexErrorInfo === "unauthorized") return "codex_auth_failure";
+  if (error.codexErrorInfo === "badRequest") return "codex_bad_request_failure";
+  if (error.codexErrorInfo === "sandboxError") return "codex_sandbox_failure";
+  if (error.codexErrorInfo === "cyberPolicy") return "codex_cyber_policy_failure";
+  return "codex_deterministic_failure";
+}
+
+function formatDeterministicFailureMessage(error: TurnErrorInfo): string {
+  if (isContextWindowFailure(error)) return CODEX_CONTEXT_WINDOW_FAILURE_MESSAGE;
+  return formatAppServerError(error.message);
+}
+
+function isContextWindowFailure(error: TurnErrorInfo): boolean {
+  return error.codexErrorInfo === "contextWindowExceeded" || isDeterministicCompactFailure(error);
+}
+
+function isDeterministicCompactFailure(error: TurnErrorInfo): boolean {
+  const text = `${error.message}\n${error.additionalDetails ?? ""}`.toLowerCase();
+  if (text.includes("contextwindowexceeded") || text.includes("context_length_exceeded")) return true;
+  if (text.includes("ran out of room") && text.includes("context window")) return true;
+
+  const compactFailure =
+    text.includes("failed to run pre-sampling compact") ||
+    text.includes("error running remote compact task") ||
+    text.includes("remote compact");
+  const contextFailure = text.includes("context window") || text.includes("context length");
+  return compactFailure && contextFailure;
 }
 
 function isUsageLimitErrorInfo(value: unknown): boolean {


### PR DESCRIPTION
## Summary

- Stop routing Codex app-server deterministic turn failures through delivery retry/recovery.
- Terminal-reject deterministic Codex failures, including context-window / remote compact failures, with provider turn evidence.
- Catch the current pre-sampling compact failure shape where the app-server reports `status: "completed"` with no assistant output but stderr contains `Failed to run pre-sampling compact`.
- Preserve transient and unknown-custody retry behavior, including ordinary transport-close recovery and completed-empty successful silence without compact diagnostics.
- Add Codex app-server handler regressions for deterministic compact failures, completed-empty compact diagnostics, prior SDK compact errors followed by transport close, transient retry, ordinary transport close, and successful silence.

## Context

Codex pre-sampling remote compact can fail deterministically when the current thread exceeds or cannot fit within the model context window. The app-server handler already classified several provider failures as deterministic, but settlement still converted every turn failure into a `retryReason`, which sent the same input back through inbox recovery. For compact/context-window failures, replaying the same input into the same thread repeats the same provider failure and can produce a stream of visible SDK errors.

The app-server can also surface compact failure as a completed-but-empty turn with no wire-visible error. This PR treats that shape as terminal only when stderr or a prior turn diagnostic explicitly contains compact failure evidence, so normal empty successful turns remain allowed.

This change keeps the fix scoped to the Codex app-server handler. It does not change generic inbox recovery, retryCount, Claude handling, or Web error rendering.

## Risk

- Deterministic classification remains conservative: ordinary `transport is closed`, timeout, and connection reset paths still retry/recover.
- Completed-empty turns without compact diagnostics still settle as successful silence.
- A terminal-rejected close may leave the closed app-server object in place until the next recovery/cleanup path. That can be optimized later, but it does not redeliver the already terminal-rejected input.

## Verification

- `pnpm --filter @first-tree/client test -- codex-app-server-handler` (passed; ran client suite: 102 files / 1067 tests)
- `pnpm --filter @first-tree/client typecheck`
- `pnpm check` (exit 0; existing warnings only in untouched files)
- `git diff --check`
