### PR TITLE
fix(web): show all addressable agents in @-mention popover, not just 8

### DIFF
--- a/packages/web/src/components/__tests__/mention-autocomplete.test.ts
+++ b/packages/web/src/components/__tests__/mention-autocomplete.test.ts
@@ -187,7 +187,7 @@ describe("groupAndSortCandidates", () => {
  * managedByMe signal is intentionally ignored once they've typed.
  */
 describe("rankCandidates", () => {
-  it("empty query: my-managed first, then alpha within each group, capped at 8", () => {
+  it("empty query: my-managed first, then alpha within each group", () => {
     const input = [
       cand({ agentId: "zoe", managedByMe: false, displayName: "Zoe" }),
       cand({ agentId: "alice", managedByMe: true, displayName: "Alice" }),
@@ -261,11 +261,41 @@ describe("rankCandidates", () => {
     expect(result.map((c) => c.agentId)[0]).toBe("pfx");
   });
 
-  it("empty query: caps the popover at 8 entries even when more match", () => {
+  it("empty query: returns every candidate, uncapped (popover scrolls instead of truncating)", () => {
+    // Regression lock for the user-reported "list looks incomplete": a
+    // prior `.slice(0, 8)` hid the 9th+ addressable agent from the
+    // empty-`@` view. The popover is height-capped + scrollable, so the
+    // full roster is reachable by scrolling — matching the `[+]` picker,
+    // which never capped.
     const input = Array.from({ length: 12 }, (_, i) =>
       cand({ agentId: `agent-${i.toString().padStart(2, "0")}`, managedByMe: i < 3 }),
     );
-    expect(rankCandidates(input, "").length).toBe(8);
+    const result = rankCandidates(input, "");
+    // All 12 surface, mine-first (00/01/02) then alpha — none dropped.
+    expect(result.map((c) => c.agentId)).toEqual([
+      "agent-00",
+      "agent-01",
+      "agent-02",
+      "agent-03",
+      "agent-04",
+      "agent-05",
+      "agent-06",
+      "agent-07",
+      "agent-08",
+      "agent-09",
+      "agent-10",
+      "agent-11",
+    ]);
+  });
+
+  it("non-empty query: returns every match, uncapped", () => {
+    // Same no-cap guarantee on the typed path: a substring shared by more
+    // than eight agents must surface them all, not silently truncate at 8.
+    const input = Array.from({ length: 12 }, (_, i) =>
+      cand({ agentId: `team-${i.toString().padStart(2, "0")}`, name: `team-${i.toString().padStart(2, "0")}` }),
+    );
+    const result = rankCandidates(input, "team");
+    expect(result).toHaveLength(12);
   });
 });
 

--- a/packages/web/src/components/mention-autocomplete.tsx
+++ b/packages/web/src/components/mention-autocomplete.tsx
@@ -243,13 +243,17 @@ export function buildPickerSections(
  */
 export function rankCandidates(candidates: MentionCandidate[], query: string): MentionCandidate[] {
   if (!query) {
-    // Reuse the picker's grouping logic, strip the divider marker, and
-    // cap at 8. Keeping the empty-query path in lockstep with the
-    // picker means changing one (mine-first, alpha) tomorrow won't
-    // silently leave the other behind.
-    return groupAndSortCandidates(candidates)
-      .filter((item): item is MentionCandidate => !("divider" in item))
-      .slice(0, 8);
+    // Reuse the picker's grouping logic and strip the divider marker.
+    // Keeping the empty-query path in lockstep with the picker means
+    // changing one (mine-first, alpha) tomorrow won't silently leave the
+    // other behind — and that lockstep now includes "no cap": the `[+]`
+    // picker lists every addable agent, so the `@` popover does too. The
+    // popover is height-capped + scrollable (`max-h-56 overflow-auto`), so
+    // a long roster scrolls rather than hiding agents past an arbitrary
+    // cut. A prior hard `.slice(0, 8)` dropped the 9th+ addressable agent
+    // from the empty-`@` view with no "more" affordance, so the list read
+    // as broken/incomplete the moment an org had more than eight.
+    return groupAndSortCandidates(candidates).filter((item): item is MentionCandidate => !("divider" in item));
   }
   const scored: Array<{ c: MentionCandidate; score: number }> = [];
   for (const c of candidates) {
@@ -263,7 +267,12 @@ export function rankCandidates(candidates: MentionCandidate[], query: string): M
     if (score !== Infinity) scored.push({ c, score });
   }
   scored.sort((a, b) => a.score - b.score || (a.c.displayName ?? "").localeCompare(b.c.displayName ?? ""));
-  return scored.slice(0, 8).map((s) => s.c);
+  // No cap here either: every scored match surfaces, scrolling inside the
+  // popover. Capping the typed path would hide later matches behind a
+  // query the user can't refine further (the substring is already as
+  // narrow as they typed). The candidate pool is bounded upstream by the
+  // server's 100-row fetch — see useOrgAgentsSearch / issue 494.
+  return scored.map((s) => s.c);
 }
 
 type MentionInsert = {


### PR DESCRIPTION
## Problem

In the new-chat composer, typing `@` to mention an agent only ever showed **8** entries. Once an org had more than eight addressable agents, the 9th onward silently disappeared from the empty-`@` list — no "more" affordance, no way to scroll to them — so the list read as incomplete/broken. (Reported from an org whose `@` list was visibly truncated at 8.)

The sibling `[+]` participant picker in the *same* composer — same grouping, same scrollable dropdown — already listed every addable agent, so the two surfaces disagreed.

## Root cause

`rankCandidates` (`packages/web/src/components/mention-autocomplete.tsx`) hard-capped both paths with `.slice(0, 8)`:
- empty query → `groupAndSortCandidates(...).slice(0, 8)`
- typed query → `scored.slice(0, 8)`

The `8` predates issue 494's server-side search and the scrollable popover; with both of those in place the cap only hides reachable agents.

## Fix

Drop both caps. The popover is already height-capped + scrollable (`max-h-56 overflow-auto`), so a long roster scrolls instead of truncating, and the `@` popover now matches the uncapped `[+]` picker. The candidate pool stays bounded upstream by the server's 100-row fetch (`useOrgAgentsSearch`, issue 494); agents beyond that are reached by typing to narrow the search.

## Test

- Converted the two cap-asserting unit tests into no-cap regression locks (empty path: all 12 surface, mine-first then alpha; typed path: all 12 matches returned).
- `vitest run src/components/__tests__/mention-autocomplete.test.ts` → **29 passed**
- `biome check` (changed files) clean; `typecheck` clean (incl. design-token guardrails)

## Not in scope / residual

For orgs above the **100-agent** server fetch cap, an empty `@` still cannot list literally everyone (those agents remain reachable by typing). A "keep typing to find more" affordance for that case needs the fetch-truncation signal plumbed into the popover and is left as a follow-up — it affects no current org and is unrelated to the reported 8-cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)