### PR TITLE
feat(web): clearer runtime install guidance (TUI→CLI rename, OS-specific tmux hints)

### DIFF
--- a/packages/client/src/runtime/error-taxonomy.ts
+++ b/packages/client/src/runtime/error-taxonomy.ts
@@ -244,7 +244,7 @@ export function classify(err: unknown, context?: { source?: ErrorSource }): Clas
       kind: ERROR_KINDS.PERMANENT,
       strategy: NONE,
       reasonCode: "claude_login_required",
-      message: shape.message ?? "Claude TUI requires re-authentication (run /login)",
+      message: shape.message ?? "Claude Code CLI requires re-authentication (run /login)",
     };
   }
   if (isCodexBinaryMissingError(err)) {

--- a/packages/web/src/components/new-agent-dialog.tsx
+++ b/packages/web/src/components/new-agent-dialog.tsx
@@ -144,7 +144,7 @@ function asRuntimeProvider(provider: string): RuntimeProvider | null {
 
 /**
  * Pick the preferred runtime among the ones in `ok` state on a given
- * client. Claude Code wins over Claude Code (TUI) which wins over Codex;
+ * client. Claude Code wins over Claude Code CLI which wins over Codex;
  * if none of those is ok we fall back to whatever else the client reports
  * as ok (still narrowed to a known RuntimeProvider), then `null`.
  */
@@ -163,7 +163,7 @@ function pickPreferredRuntime(caps: ClientCapabilities): RuntimeProvider | null 
 
 function prettyRuntimeLabel(provider: RuntimeProvider): string {
   if (provider === "claude-code") return "Claude Code";
-  if (provider === "claude-code-tui") return "Claude Code (TUI)";
+  if (provider === "claude-code-tui") return "Claude Code CLI";
   if (provider === "codex") return "Codex";
   return provider;
 }

--- a/packages/web/src/pages/agent-detail/runtime-section.tsx
+++ b/packages/web/src/pages/agent-detail/runtime-section.tsx
@@ -28,7 +28,7 @@ const RUNTIME_COPY: Record<RuntimeProvider, { name: string; caption: string }> =
     caption: "Runs through Anthropic's Claude Code runtime.",
   },
   "claude-code-tui": {
-    name: "Claude Code (TUI)",
+    name: "Claude Code CLI",
     caption: "Runs Claude Code through tmux for terminal-native sessions.",
   },
   codex: {

--- a/packages/web/src/pages/clients.tsx
+++ b/packages/web/src/pages/clients.tsx
@@ -802,7 +802,7 @@ function ProviderRow({
             {label}
           </span>
           <span className="text-caption" style={{ color: "var(--fg-4)" }}>
-            ✗ not installed · {providerInstallHint(provider, os)}
+            ✗ {providerInstallHint(provider, os, entry.error)}
           </span>
         </div>
       );

--- a/packages/web/src/pages/clients/__tests__/runtime-state-line.test.tsx
+++ b/packages/web/src/pages/clients/__tests__/runtime-state-line.test.tsx
@@ -106,8 +106,26 @@ describe("RuntimeStateLine", () => {
     const dom = await render(<RuntimeStateLine provider="claude-code-tui" entry={entry} os="darwin" />);
 
     expect(dom.textContent).toContain("Claude Code CLI");
-    expect(dom.textContent).toContain("Install `tmux` (>= 3.0)");
+    // macOS → Homebrew command, not a generic "install tmux".
+    expect(dom.textContent).toContain("brew install tmux");
     expect(dom.textContent).not.toContain("npm install");
+  });
+
+  it("keys the tmux install command to the host OS (Linux → apt)", async () => {
+    const entry: CapabilityEntry = {
+      available: false,
+      state: "missing",
+      authenticated: false,
+      sdkVersion: "2.1.84",
+      authMethod: "none",
+      error: "tmux not found",
+      detectedAt: "2026-06-12T12:00:00.000Z",
+    };
+
+    const dom = await render(<RuntimeStateLine provider="claude-code-tui" entry={entry} os="linux" />);
+
+    expect(dom.textContent).toContain("sudo apt install tmux");
+    expect(dom.textContent).not.toContain("brew");
   });
 
   it("names both requirements when the TUI runtime is missing claude and tmux", async () => {

--- a/packages/web/src/pages/clients/__tests__/runtime-state-line.test.tsx
+++ b/packages/web/src/pages/clients/__tests__/runtime-state-line.test.tsx
@@ -128,6 +128,26 @@ describe("RuntimeStateLine", () => {
     expect(dom.textContent).not.toContain("brew");
   });
 
+  it("names tmux generically when the OS is unknown, with no guessed package manager", async () => {
+    const entry: CapabilityEntry = {
+      available: false,
+      state: "missing",
+      authenticated: false,
+      sdkVersion: "2.1.84",
+      authMethod: "none",
+      error: "tmux not found",
+      detectedAt: "2026-06-12T12:00:00.000Z",
+    };
+
+    const dom = await render(<RuntimeStateLine provider="claude-code-tui" entry={entry} os={null} />);
+
+    expect(dom.textContent).toContain("tmux (>= 3.0)");
+    expect(dom.textContent).toContain("package manager");
+    // No OS evidence → don't show a Linux/macOS command.
+    expect(dom.textContent).not.toContain("apt");
+    expect(dom.textContent).not.toContain("brew");
+  });
+
   it("names both requirements when the TUI runtime is missing claude and tmux", async () => {
     const entry: CapabilityEntry = {
       available: false,

--- a/packages/web/src/pages/clients/__tests__/runtime-state-line.test.tsx
+++ b/packages/web/src/pages/clients/__tests__/runtime-state-line.test.tsx
@@ -69,4 +69,61 @@ describe("RuntimeStateLine", () => {
     expect(dom.textContent).toContain("needs login");
     expect(dom.textContent).toContain("codex login");
   });
+
+  it("gives a concrete install command when a runtime is missing", async () => {
+    const entry: CapabilityEntry = {
+      available: false,
+      state: "missing",
+      authenticated: false,
+      sdkVersion: null,
+      authMethod: "none",
+      error: "@anthropic-ai/claude-agent-sdk bundled cli.js missing",
+      detectedAt: "2026-06-12T12:00:00.000Z",
+    };
+
+    const dom = await render(<RuntimeStateLine provider="claude-code" entry={entry} os="darwin" />);
+
+    expect(dom.textContent).toContain("Claude Code");
+    expect(dom.textContent).toContain("npm install -g @anthropic-ai/claude-code");
+    // The bare "not installed" label is replaced by an actionable hint.
+    expect(dom.textContent).not.toContain("not installed");
+  });
+
+  it("tells a Claude-Code machine that only lacks tmux to install just tmux", async () => {
+    // The `claude` CLI resolved fine; only tmux is absent, so the probe's
+    // resolve reason names tmux alone. The hint must not tell the user to
+    // reinstall the Claude CLI they already have.
+    const entry: CapabilityEntry = {
+      available: false,
+      state: "missing",
+      authenticated: false,
+      sdkVersion: "2.1.84",
+      authMethod: "none",
+      error: "tmux not found",
+      detectedAt: "2026-06-12T12:00:00.000Z",
+    };
+
+    const dom = await render(<RuntimeStateLine provider="claude-code-tui" entry={entry} os="darwin" />);
+
+    expect(dom.textContent).toContain("Claude Code CLI");
+    expect(dom.textContent).toContain("Install `tmux` (>= 3.0)");
+    expect(dom.textContent).not.toContain("npm install");
+  });
+
+  it("names both requirements when the TUI runtime is missing claude and tmux", async () => {
+    const entry: CapabilityEntry = {
+      available: false,
+      state: "missing",
+      authenticated: false,
+      sdkVersion: null,
+      authMethod: "none",
+      error: "`claude` not found (checked CLAUDE_CODE_EXECUTABLE, PATH, …); tmux not found",
+      detectedAt: "2026-06-12T12:00:00.000Z",
+    };
+
+    const dom = await render(<RuntimeStateLine provider="claude-code-tui" entry={entry} os="darwin" />);
+
+    expect(dom.textContent).toContain("@anthropic-ai/claude-code");
+    expect(dom.textContent).toContain("tmux");
+  });
 });

--- a/packages/web/src/pages/clients/cards/setup-incomplete-card-body.tsx
+++ b/packages/web/src/pages/clients/cards/setup-incomplete-card-body.tsx
@@ -64,6 +64,7 @@ export function SetupIncompleteCardBody({ client, boundAgents, agentName }: Setu
               provider={provider}
               entry={client.capabilities[provider] ?? null}
               hostname={hostname}
+              os={client.os}
             />
           ))}
         </div>

--- a/packages/web/src/pages/clients/cards/shared/providers.ts
+++ b/packages/web/src/pages/clients/cards/shared/providers.ts
@@ -17,7 +17,7 @@ export const PROVIDER_ORDER: RuntimeProvider[] = [
 
 export const PROVIDER_LABEL: Record<RuntimeProvider, string> = {
   "claude-code": "Claude Code",
-  "claude-code-tui": "Claude Code (TUI)",
+  "claude-code-tui": "Claude Code CLI",
   codex: "Codex",
 };
 

--- a/packages/web/src/pages/clients/cards/shared/providers.ts
+++ b/packages/web/src/pages/clients/cards/shared/providers.ts
@@ -76,15 +76,35 @@ export const PROVIDER_LOGIN_COMMAND: Record<RuntimeProvider, string> = {
  * lines. The Setup-incomplete card body wraps this in a per-provider
  * box with a copy button per box.
  */
-export function buildInstallCommand(provider: RuntimeProvider): string {
+export function buildInstallCommand(provider: RuntimeProvider, os?: string | null): string {
   const base = `npm install -g ${PROVIDER_NPM_PACKAGE[provider]}\n${PROVIDER_LOGIN_COMMAND[provider]}`;
   if (provider === "claude-code-tui") {
-    // The tmux-driven runtime additionally needs tmux (>= 3.0). Its install
-    // command is OS-specific, so surface it as a comment line rather than guess
-    // the package manager — the npm + login lines above stay copy-paste runnable.
-    return `${base}\n# tmux (>= 3.0) is also required — e.g. brew install tmux (macOS) / apt install tmux (Linux)`;
+    // The tmux-driven runtime additionally needs tmux (>= 3.0). tmux is not an
+    // npm package, so emit the command for the host's actual package manager
+    // (keyed off the client's reported OS) instead of a generic note.
+    return `${base}\n${tmuxInstallCommand(os)}`;
   }
   return base;
+}
+
+/**
+ * OS-specific command to install tmux (>= 3.0), keyed off the client's reported
+ * OS (`darwin` / `linux` / `win32`). tmux is not an npm package, so the right
+ * command depends on the host package manager. Windows has no native tmux — it
+ * runs inside WSL, so the command targets the WSL distro.
+ */
+export function tmuxInstallCommand(os: string | null | undefined): string {
+  switch (os) {
+    case "darwin":
+      return "brew install tmux";
+    case "win32":
+    case "windows":
+      return "wsl sudo apt install tmux";
+    default:
+      // Linux / unknown — apt covers Debian/Ubuntu; other distros swap the
+      // package manager (dnf / pacman / …).
+      return "sudo apt install tmux";
+  }
 }
 
 /**
@@ -147,16 +167,18 @@ export function providerInstallHint(
   }
   if (provider === "claude-code-tui") {
     // The probe joins per-requirement reasons (claude + tmux) into one string;
-    // match on each so we can tailor the hint to what's genuinely missing.
+    // match on each so we can tailor the hint to what's genuinely missing. The
+    // tmux command is keyed to the host OS (brew / apt / WSL).
     const claudeMissing = error == null || /claude/i.test(error);
     const tmuxMissing = error == null || /tmux/i.test(error);
+    const tmuxCmd = tmuxInstallCommand(os);
     if (tmuxMissing && !claudeMissing) {
-      return `Install \`tmux\` (>= 3.0) on this ${device}.`;
+      return `Run \`${tmuxCmd}\` on this ${device} (tmux >= 3.0).`;
     }
     if (claudeMissing && !tmuxMissing) {
       return `Run \`npm install -g @anthropic-ai/claude-code\` on this ${device}.`;
     }
-    return `Install \`@anthropic-ai/claude-code\` and \`tmux\` (>= 3.0) on this ${device}.`;
+    return `Run \`npm install -g @anthropic-ai/claude-code\` and \`${tmuxCmd}\` (tmux >= 3.0) on this ${device}.`;
   }
   return `Install the OpenAI Codex CLI on this ${device}.`;
 }

--- a/packages/web/src/pages/clients/cards/shared/providers.ts
+++ b/packages/web/src/pages/clients/cards/shared/providers.ts
@@ -81,8 +81,10 @@ export function buildInstallCommand(provider: RuntimeProvider, os?: string | nul
   if (provider === "claude-code-tui") {
     // The tmux-driven runtime additionally needs tmux (>= 3.0). tmux is not an
     // npm package, so emit the command for the host's actual package manager
-    // (keyed off the client's reported OS) instead of a generic note.
-    return `${base}\n${tmuxInstallCommand(os)}`;
+    // (keyed off the client's reported OS). Unknown OS → a non-command note
+    // rather than a guessed package manager.
+    const tmuxCmd = tmuxInstallCommand(os);
+    return `${base}\n${tmuxCmd ?? "# install tmux (>= 3.0) with your OS package manager"}`;
   }
   return base;
 }
@@ -93,17 +95,23 @@ export function buildInstallCommand(provider: RuntimeProvider, os?: string | nul
  * command depends on the host package manager. Windows has no native tmux — it
  * runs inside WSL, so the command targets the WSL distro.
  */
-export function tmuxInstallCommand(os: string | null | undefined): string {
+export function tmuxInstallCommand(os: string | null | undefined): string | null {
   switch (os) {
     case "darwin":
       return "brew install tmux";
+    case "linux":
+      // apt covers Debian/Ubuntu; other distros swap the package manager
+      // (dnf / pacman / …), but apt is the common default.
+      return "sudo apt install tmux";
     case "win32":
     case "windows":
+      // No native Windows tmux — it runs inside WSL.
       return "wsl sudo apt install tmux";
     default:
-      // Linux / unknown — apt covers Debian/Ubuntu; other distros swap the
-      // package manager (dnf / pacman / …).
-      return "sudo apt install tmux";
+      // Unknown / unreported OS — don't assume a package manager. A real client
+      // always reports `process.platform`; this only guards legacy/unknown rows,
+      // where callers fall back to naming the requirement without a command.
+      return null;
   }
 }
 
@@ -171,14 +179,20 @@ export function providerInstallHint(
     // tmux command is keyed to the host OS (brew / apt / WSL).
     const claudeMissing = error == null || /claude/i.test(error);
     const tmuxMissing = error == null || /tmux/i.test(error);
+    // OS-keyed tmux command (brew / apt / WSL), or null for an unknown OS — then
+    // name the requirement without assuming a package manager.
     const tmuxCmd = tmuxInstallCommand(os);
     if (tmuxMissing && !claudeMissing) {
-      return `Run \`${tmuxCmd}\` on this ${device} (tmux >= 3.0).`;
+      return tmuxCmd
+        ? `Run \`${tmuxCmd}\` on this ${device} (tmux >= 3.0).`
+        : `Install tmux (>= 3.0) on this ${device} with your package manager.`;
     }
     if (claudeMissing && !tmuxMissing) {
       return `Run \`npm install -g @anthropic-ai/claude-code\` on this ${device}.`;
     }
-    return `Run \`npm install -g @anthropic-ai/claude-code\` and \`${tmuxCmd}\` (tmux >= 3.0) on this ${device}.`;
+    return tmuxCmd
+      ? `Run \`npm install -g @anthropic-ai/claude-code\` and \`${tmuxCmd}\` (tmux >= 3.0) on this ${device}.`
+      : `Run \`npm install -g @anthropic-ai/claude-code\`, then install tmux (>= 3.0) with your package manager, on this ${device}.`;
   }
   return `Install the OpenAI Codex CLI on this ${device}.`;
 }

--- a/packages/web/src/pages/clients/cards/shared/providers.ts
+++ b/packages/web/src/pages/clients/cards/shared/providers.ts
@@ -77,7 +77,14 @@ export const PROVIDER_LOGIN_COMMAND: Record<RuntimeProvider, string> = {
  * box with a copy button per box.
  */
 export function buildInstallCommand(provider: RuntimeProvider): string {
-  return `npm install -g ${PROVIDER_NPM_PACKAGE[provider]}\n${PROVIDER_LOGIN_COMMAND[provider]}`;
+  const base = `npm install -g ${PROVIDER_NPM_PACKAGE[provider]}\n${PROVIDER_LOGIN_COMMAND[provider]}`;
+  if (provider === "claude-code-tui") {
+    // The tmux-driven runtime additionally needs tmux (>= 3.0). Its install
+    // command is OS-specific, so surface it as a comment line rather than guess
+    // the package manager — the npm + login lines above stay copy-paste runnable.
+    return `${base}\n# tmux (>= 3.0) is also required — e.g. brew install tmux (macOS) / apt install tmux (Linux)`;
+  }
+  return base;
 }
 
 /**
@@ -120,17 +127,36 @@ export function providerUnauthHint(provider: RuntimeProvider, os: string | null 
  * reported") — that case is suppressed in the Ready card entirely, so
  * the hint only shows when the SDK explicitly probed and confirmed the
  * runtime is not installed.
+ *
+ * `error` is the probe's verbatim resolve-stage reason. For
+ * `claude-code-tui` the runtime needs BOTH the `claude` CLI and tmux
+ * (>= 3.0), and the probe reports exactly which is missing ("tmux not
+ * found" / "`claude` not found …"). Passing it lets the hint name only the
+ * piece that is actually absent, so a machine that already has Claude Code
+ * and only lacks tmux is told to install tmux — not to reinstall the CLI
+ * it already has. When `error` is absent we fall back to naming both.
  */
-export function providerInstallHint(provider: RuntimeProvider, os: string | null | undefined): string {
+export function providerInstallHint(
+  provider: RuntimeProvider,
+  os: string | null | undefined,
+  error?: string | null,
+): string {
+  const device = osDeviceName(os);
   if (provider === "claude-code") {
-    return `Run \`npm install -g @anthropic-ai/claude-code\` on this ${osDeviceName(os)}.`;
+    return `Run \`npm install -g @anthropic-ai/claude-code\` on this ${device}.`;
   }
   if (provider === "claude-code-tui") {
-    // TUI shares the `claude` CLI install with `claude-code`, but additionally
-    // requires `tmux` (>= 3.0) so the daemon can spawn the runtime in a
-    // detached session. The capability probe in
-    // `runtime/capabilities/claude-code-tui.ts` enforces both at probe time.
-    return `Install \`@anthropic-ai/claude-code\` and \`tmux\` (>= 3.0) on this ${osDeviceName(os)}.`;
+    // The probe joins per-requirement reasons (claude + tmux) into one string;
+    // match on each so we can tailor the hint to what's genuinely missing.
+    const claudeMissing = error == null || /claude/i.test(error);
+    const tmuxMissing = error == null || /tmux/i.test(error);
+    if (tmuxMissing && !claudeMissing) {
+      return `Install \`tmux\` (>= 3.0) on this ${device}.`;
+    }
+    if (claudeMissing && !tmuxMissing) {
+      return `Run \`npm install -g @anthropic-ai/claude-code\` on this ${device}.`;
+    }
+    return `Install \`@anthropic-ai/claude-code\` and \`tmux\` (>= 3.0) on this ${device}.`;
   }
-  return `Install the OpenAI Codex CLI on this ${osDeviceName(os)}.`;
+  return `Install the OpenAI Codex CLI on this ${device}.`;
 }

--- a/packages/web/src/pages/clients/cards/shared/runtime-install-box.tsx
+++ b/packages/web/src/pages/clients/cards/shared/runtime-install-box.tsx
@@ -16,6 +16,8 @@ type RuntimeInstallBoxProps = {
   entry: CapabilityEntry | null;
   /** Computer hostname for the diagnostic copy. */
   hostname: string;
+  /** Host OS (`darwin` / `linux` / `win32`) — keys the tmux install command. */
+  os?: string | null;
 };
 
 /**
@@ -27,9 +29,9 @@ type RuntimeInstallBoxProps = {
  * from the `ProviderRow` chips in the Ready card's CapabilityMatrix —
  * that's a state-only summary line; this is an actionable surface.
  */
-export function RuntimeInstallBox({ provider, entry, hostname }: RuntimeInstallBoxProps) {
+export function RuntimeInstallBox({ provider, entry, hostname, os }: RuntimeInstallBoxProps) {
   const label = PROVIDER_LABEL[provider];
-  const { headline, command } = installBoxView(entry, provider, hostname);
+  const { headline, command } = installBoxView(entry, provider, hostname, os);
 
   // No outer raised-bg / border / radius — the inner `InlineCommand`'s
   // sunken pre-block is the only chrome that earns its weight (commands
@@ -88,16 +90,17 @@ export function installBoxView(
   entry: CapabilityEntry | null,
   provider: RuntimeProvider,
   hostname: string,
+  os?: string | null,
 ): { headline: string; command: string } {
   if (!entry || entry.state === "missing") {
     // `claude-code-tui` needs the `claude` CLI AND tmux (>= 3.0); name the tmux
     // requirement explicitly so the box isn't read as a CLI-only install (the
-    // command from `buildInstallCommand` carries the matching tmux line).
+    // command from `buildInstallCommand` carries the matching OS tmux line).
     const headline =
       provider === "claude-code-tui"
         ? `Install ${PROVIDER_LABEL[provider]} (the \`claude\` CLI + tmux >= 3.0) and run \`${PROVIDER_LOGIN_COMMAND[provider]}\` on ${hostname}.`
         : `Install ${PROVIDER_LABEL[provider]} and run \`${PROVIDER_LOGIN_COMMAND[provider]}\` on ${hostname}.`;
-    return { headline, command: buildInstallCommand(provider) };
+    return { headline, command: buildInstallCommand(provider, os) };
   }
   if (entry.state === "unauthenticated") {
     return {
@@ -115,6 +118,6 @@ export function installBoxView(
   // entries out. Provide a defensive fallback that's still actionable.
   return {
     headline: `${PROVIDER_LABEL[provider]} is configured. To reinstall, run on ${hostname}:`,
-    command: buildInstallCommand(provider),
+    command: buildInstallCommand(provider, os),
   };
 }

--- a/packages/web/src/pages/clients/cards/shared/runtime-install-box.tsx
+++ b/packages/web/src/pages/clients/cards/shared/runtime-install-box.tsx
@@ -90,10 +90,14 @@ export function installBoxView(
   hostname: string,
 ): { headline: string; command: string } {
   if (!entry || entry.state === "missing") {
-    return {
-      headline: `Install ${PROVIDER_LABEL[provider]} and run \`${PROVIDER_LOGIN_COMMAND[provider]}\` on ${hostname}.`,
-      command: buildInstallCommand(provider),
-    };
+    // `claude-code-tui` needs the `claude` CLI AND tmux (>= 3.0); name the tmux
+    // requirement explicitly so the box isn't read as a CLI-only install (the
+    // command from `buildInstallCommand` carries the matching tmux line).
+    const headline =
+      provider === "claude-code-tui"
+        ? `Install ${PROVIDER_LABEL[provider]} (the \`claude\` CLI + tmux >= 3.0) and run \`${PROVIDER_LOGIN_COMMAND[provider]}\` on ${hostname}.`
+        : `Install ${PROVIDER_LABEL[provider]} and run \`${PROVIDER_LOGIN_COMMAND[provider]}\` on ${hostname}.`;
+    return { headline, command: buildInstallCommand(provider) };
   }
   if (entry.state === "unauthenticated") {
     return {

--- a/packages/web/src/pages/clients/cards/shared/runtime-state-line.tsx
+++ b/packages/web/src/pages/clients/cards/shared/runtime-state-line.tsx
@@ -1,5 +1,5 @@
 import type { CapabilityEntry, RuntimeProvider } from "@first-tree/shared";
-import { PROVIDER_LABEL, providerUnauthHint } from "./providers.js";
+import { PROVIDER_LABEL, providerInstallHint, providerUnauthHint } from "./providers.js";
 
 /**
  * Per-runtime state line — single rendering used by every card body
@@ -49,9 +49,14 @@ export function RuntimeStateLine({
         </div>
       );
     case "missing":
+      // Lead with the concrete install action keyed to what the probe found
+      // missing — for `claude-code-tui` that may be only tmux, so a bare "not
+      // installed" would wrongly tell a Claude-Code-equipped machine to
+      // reinstall the CLI it already has. `entry.error` carries the probe's
+      // per-requirement reason; `providerInstallHint` narrows on it.
       return (
         <div className="text-body" style={{ color: "var(--fg-3)" }}>
-          <span style={{ color: "var(--fg-4)" }}>✗</span> {label} · not installed
+          <span style={{ color: "var(--fg-4)" }}>✗</span> {label} · {providerInstallHint(provider, os, entry.error)}
         </div>
       );
     case "error":


### PR DESCRIPTION
## What

Tightens how the web surfaces a runtime that isn't ready to use, driven by three concrete pain points: the display name was confusing, the `missing` state gave no actionable hint, and the tmux requirement was never shown as a real command.

Three commits:

1. **Rename `claude-code-tui` display label → "Claude Code CLI".** The provider drives the real `claude` CLI inside tmux, so "Claude Code CLI" reads truer than "Claude Code (TUI)". Display-only: the `claude-code-tui` enum id (wire/DB) is untouched, so no migration. Covers the 3 web label sites + the client-side re-auth error string.

2. **Specific install hint for a missing runtime.** The `missing` state line read a flat "not installed", which is wrong for `claude-code-tui` — it needs both the `claude` CLI and tmux (>= 3.0), so a machine that already had Claude Code and only lacked tmux was told it wasn't installed at all. `providerInstallHint` now narrows on the probe's verbatim resolve reason ("tmux not found" / "`claude` not found …") and names only what's actually missing (tmux-only / CLI-only / both). Applied to the card state line, the legacy `ProviderRow`, and the Setup-incomplete install box.

3. **OS-specific tmux command.** tmux isn't an npm package, so the command depends on the host. New `tmuxInstallCommand(os)` keys off the client's reported OS:
   - macOS → `brew install tmux`
   - Linux → `sudo apt install tmux`
   - Windows → `wsl sudo apt install tmux` (no native Windows tmux; runs under WSL)

   Wired into the state-line hint, the install-box headline, and the copy-paste command block (`os` threaded from `client.os`).

## Scope notes

- The capability **probe semantics are unchanged** — the launch-verified real smoke stays the only path to `ok` (that behavior is expected). This PR is display/guidance only.
- No schema, server, or wire changes. `packages/web` only, plus one client-side error-message string.

## Test

- New/updated `runtime-state-line` tests cover tmux-only, CLI-only, both-missing, and OS-keyed tmux commands (macOS→brew, Linux→apt).
- `pnpm --filter @first-tree/web typecheck` ✅, `biome` ✅
- web suites: runtime-state-line (6), view-models (16), clients-page-cards-dom (3), page-ssr-smoke + web-dom-interactions (37) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)