### PR TITLE
fix(web): handle inaccessible chat deep links

### DIFF
--- a/packages/web/src/pages/workspace/center/__tests__/chat-by-id-center-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-by-id-center-dom.test.tsx
@@ -343,6 +343,28 @@ describe("ChatByIdView and CenterPanel", () => {
     await act(async () => loading.root.unmount());
   });
 
+  it("shows an unavailable empty state when a manual chat URL cannot be loaded", async () => {
+    chatMocks.getChat.mockRejectedValueOnce(new Error("not found"));
+    const onClearChat = vi.fn();
+    const { ChatByIdView } = await import("../chat-by-id.js");
+    const { container, root } = await renderDom(
+      <ChatByIdView chatId="missing-chat" narrow={false} onShowConversations={null} onClearChat={onClearChat} />,
+    );
+
+    await waitForText(container, "This chat doesn't exist or you don't have access.");
+    expect(container.textContent).toContain("Chat unavailable");
+    expect(container.textContent).not.toContain("Resolving participants");
+    expect(chatViewMocks.props).toHaveLength(0);
+    expect(meChatMocks.markMeChatRead).not.toHaveBeenCalled();
+
+    await click(
+      [...container.querySelectorAll("button")].find((button) => button.textContent?.includes("Back")) ?? null,
+    );
+    expect(onClearChat).toHaveBeenCalledTimes(1);
+
+    await act(async () => root.unmount());
+  });
+
   it("passes watcher join state into ChatView and invalidates via the join action", async () => {
     chatMocks.getChat.mockResolvedValueOnce(chatDetail({ viewerMembershipKind: "watching", title: "Watch title" }));
     const { ChatByIdView } = await import("../chat-by-id.js");
@@ -361,12 +383,14 @@ describe("ChatByIdView and CenterPanel", () => {
   it("routes CenterPanel between draft, selected chat, and empty state", async () => {
     const { CenterPanel } = await import("../index.js");
     const onSelectChat = vi.fn();
+    const onClearChat = vi.fn();
     const onShowConversations = vi.fn();
 
     const draft = await renderDom(
       <CenterPanel
         selectedChatId="draft"
         onSelectChat={onSelectChat}
+        onClearChat={onClearChat}
         narrow
         onShowConversations={onShowConversations}
         initialParticipantIds={["agent-1"]}
@@ -382,13 +406,25 @@ describe("ChatByIdView and CenterPanel", () => {
     await act(async () => draft.root.unmount());
 
     const selected = await renderDom(
-      <CenterPanel selectedChatId="chat-1" onSelectChat={onSelectChat} narrow={false} onShowConversations={null} />,
+      <CenterPanel
+        selectedChatId="chat-1"
+        onSelectChat={onSelectChat}
+        onClearChat={onClearChat}
+        narrow={false}
+        onShowConversations={null}
+      />,
     );
     await waitForText(selected.container, "ChatView agent-1 chat-1");
     await act(async () => selected.root.unmount());
 
     const empty = await renderDom(
-      <CenterPanel selectedChatId={null} onSelectChat={onSelectChat} narrow={false} onShowConversations={null} />,
+      <CenterPanel
+        selectedChatId={null}
+        onSelectChat={onSelectChat}
+        onClearChat={onClearChat}
+        narrow={false}
+        onShowConversations={null}
+      />,
     );
     await click(
       [...empty.container.querySelectorAll("button")].find((button) => button.textContent?.includes("New chat")) ??

--- a/packages/web/src/pages/workspace/center/chat-by-id.tsx
+++ b/packages/web/src/pages/workspace/center/chat-by-id.tsx
@@ -1,9 +1,11 @@
 import type { ListMeChatsResponse } from "@first-tree/shared";
 import { type QueryClient, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ArrowLeft } from "lucide-react";
 import { useEffect, useMemo, useRef } from "react";
 import { getChat } from "../../../api/chats.js";
 import { joinMeChat, markMeChatRead } from "../../../api/me-chats.js";
 import { useAuth } from "../../../auth/auth-context.js";
+import { Button } from "../../../components/ui/button.js";
 import { useAdminWs } from "../../../hooks/use-admin-ws.js";
 import { ChatView } from "./chat-view.js";
 
@@ -63,15 +65,17 @@ export function ChatByIdView({
   chatId,
   narrow,
   onShowConversations,
+  onClearChat = null,
 }: {
   chatId: string;
   narrow: boolean;
   onShowConversations: (() => void) | null;
+  onClearChat?: (() => void) | null;
 }) {
   const queryClient = useQueryClient();
   const { agentId: myAgentId } = useAuth();
 
-  const { data: chatDetail } = useQuery({
+  const { data: chatDetail, isError: chatDetailError } = useQuery({
     queryKey: ["chat-detail", chatId],
     queryFn: () => getChat(chatId),
     enabled: !!chatId,
@@ -146,6 +150,10 @@ export function ChatByIdView({
 
   const isWatching = chatDetail?.viewerMembershipKind === "watching";
 
+  if (chatDetailError) {
+    return <ChatUnavailableState onClearChat={onClearChat} />;
+  }
+
   if (!primaryAgent) {
     return (
       <div className="flex-1 flex items-center justify-center" style={{ padding: "var(--sp-8)" }}>
@@ -186,5 +194,28 @@ export function ChatByIdView({
       narrow={narrow}
       onShowConversations={onShowConversations}
     />
+  );
+}
+
+function ChatUnavailableState({ onClearChat }: { onClearChat: (() => void) | null }) {
+  return (
+    <div className="flex-1 flex items-center justify-center" style={{ padding: "var(--sp-8)" }}>
+      <div className="text-center max-w-sm">
+        <div className="text-subtitle" style={{ color: "var(--fg-2)", marginBottom: 6 }}>
+          Chat unavailable
+        </div>
+        <div className="text-body text-muted-foreground" style={{ marginBottom: "var(--sp-4)" }}>
+          This chat doesn't exist or you don't have access.
+        </div>
+        {onClearChat ? (
+          <div className="flex justify-center">
+            <Button type="button" variant="outline" onClick={onClearChat}>
+              <ArrowLeft className="h-3.5 w-3.5" />
+              <span>Back to conversations</span>
+            </Button>
+          </div>
+        ) : null}
+      </div>
+    </div>
   );
 }

--- a/packages/web/src/pages/workspace/center/index.tsx
+++ b/packages/web/src/pages/workspace/center/index.tsx
@@ -19,12 +19,14 @@ import { NoChatView } from "./no-chat-view.js";
 export function CenterPanel({
   selectedChatId,
   onSelectChat,
+  onClearChat,
   narrow,
   onShowConversations,
   initialParticipantIds,
 }: {
   selectedChatId: string | null;
   onSelectChat: (chatId: string) => void;
+  onClearChat: () => void;
   /** True when the workspace shell is in narrow-viewport mode (<768).
    *  Propagated to `ChatView` so it can swap the right rail to an
    *  overlay and surface the conv-list summon button. */
@@ -62,7 +64,14 @@ export function CenterPanel({
   }
 
   if (selectedChatId) {
-    return <ChatByIdView chatId={selectedChatId} narrow={narrow} onShowConversations={onShowConversations} />;
+    return (
+      <ChatByIdView
+        chatId={selectedChatId}
+        narrow={narrow}
+        onShowConversations={onShowConversations}
+        onClearChat={onClearChat}
+      />
+    );
   }
 
   return <NoChatView onNewChat={() => onSelectChat(DRAFT_CHAT_ID)} />;

--- a/packages/web/src/pages/workspace/index.tsx
+++ b/packages/web/src/pages/workspace/index.tsx
@@ -202,6 +202,14 @@ export function WorkspacePage() {
     setSearchParams(next);
   }, [searchParams, setSearchParams]);
 
+  const clearSelectedChat = useCallback(() => {
+    const next = new URLSearchParams(searchParams);
+    next.delete("c");
+    clearDocPreviewParams(next);
+    setSearchParams(next, { replace: true });
+    setConvOverlayOpen(false);
+  }, [searchParams, setSearchParams]);
+
   const setEngagement = useCallback(
     (view: ChatEngagementView) => {
       setSearchParams(nextParamsForEngagement(searchParams, view), { replace: true });
@@ -323,6 +331,7 @@ export function WorkspacePage() {
         <CenterPanel
           selectedChatId={selectedChatId}
           onSelectChat={selectChat}
+          onClearChat={clearSelectedChat}
           narrow={isNarrow}
           onShowConversations={isNarrow ? () => setConvOverlayOpen(true) : null}
           initialParticipantIds={participants}


### PR DESCRIPTION
## Summary

- Show a chat unavailable empty state when a manual `?c=<chatId>` deep link cannot load chat detail.
- Add a Back to conversations action that clears the selected chat URL state.
- Cover the rejected chat-detail query path in `ChatByIdView` DOM tests.

Fixes #490

## Tests

- `pnpm check`
- `pnpm typecheck`
- `pnpm exec turbo run test --concurrency=2`
