### PR TITLE
feat(web): converge agent-detail resource actions to Switch + overflow menu

### DIFF
--- a/packages/web/src/components/ui/switch.tsx
+++ b/packages/web/src/components/ui/switch.tsx
@@ -1,0 +1,55 @@
+import type { ReactNode } from "react";
+import { cn } from "../../lib/utils.js";
+
+/**
+ * Accessible on/off toggle — a single control that flips a boolean. Used on the
+ * agent detail page to enable/disable a team-recommended resource in place (the
+ * row stays, greyed, when off), and anywhere a compact binary toggle fits.
+ *
+ * Renders as an ARIA switch button: the whole track is the hit target,
+ * Space/Enter toggle it, and `aria-checked` exposes the state to assistive tech.
+ * It has no built-in visible label — name it via `aria-label`, or point
+ * `aria-labelledby` at the row title that already names what it controls.
+ *
+ * The on/off track shades use confirmed design tokens (`bg-primary` / neutral
+ * `bg-secondary`); exact shade is subject to the visual review pass.
+ */
+export function Switch(props: {
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+  disabled?: boolean;
+  /** Accessible name when no visible label element is associated. */
+  "aria-label"?: string;
+  /** Id of the visible element (e.g. the row title) that names this switch. */
+  "aria-labelledby"?: string;
+  id?: string;
+  className?: string;
+}): ReactNode {
+  const { checked, onCheckedChange, disabled, className } = props;
+  return (
+    <button
+      type="button"
+      role="switch"
+      id={props.id}
+      aria-checked={checked}
+      aria-label={props["aria-label"]}
+      aria-labelledby={props["aria-labelledby"]}
+      disabled={disabled}
+      onClick={() => onCheckedChange(!checked)}
+      className={cn(
+        "inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent p-0 transition-colors",
+        "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background",
+        "disabled:cursor-not-allowed disabled:opacity-50",
+        checked ? "bg-primary" : "bg-secondary",
+        className,
+      )}
+    >
+      <span
+        className={cn(
+          "pointer-events-none block h-4 w-4 rounded-full bg-background shadow-sm transition-transform",
+          checked ? "translate-x-4" : "translate-x-0.5",
+        )}
+      />
+    </button>
+  );
+}

--- a/packages/web/src/components/ui/switch.tsx
+++ b/packages/web/src/components/ui/switch.tsx
@@ -40,7 +40,10 @@ export function Switch(props: {
         "inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent p-0 transition-colors",
         "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background",
         "disabled:cursor-not-allowed disabled:opacity-50",
-        checked ? "bg-primary" : "bg-secondary",
+        // Off track: in dark mode bg-secondary sits too close to the page bg and
+        // reads as a blurry block, so outline it with a hairline border to keep it
+        // legible as a control. Light mode reads fine without it (on stays filled).
+        checked ? "bg-primary" : "bg-secondary dark:border-[var(--border-strong)]",
         className,
       )}
     >

--- a/packages/web/src/pages/agent-detail-preview.tsx
+++ b/packages/web/src/pages/agent-detail-preview.tsx
@@ -17,8 +17,10 @@ import { ResourcesTab } from "./agent-detail/resources-tab.js";
  * QueryClient + a mock outlet context — no backend, no auth. The sample data is
  * crafted so every label / marker / control is visible at once:
  *   - source labels: `From your team` vs `Added by you`
- *   - status markers: `Off`, `Overridden`, `Unavailable`, `Can't load`
- *   - controls: Customize / Disable / Edit / Remove / Re-enable / Enable
+ *   - status markers: `Overridden`, `Can't load` (plain disabled is conveyed by
+ *     the Switch in its off position + a greyed row, not a badge)
+ *   - controls: the on/off Switch (team-recommended only) + the ⋯ overflow menu
+ *     (Customize / Edit / Remove). Opt-in and custom rows have no Switch.
  *
  * This page is for looking, not round-tripping — clicking a mutating button hits
  * the real API and will fail without a server.
@@ -137,6 +139,25 @@ const RESOURCES: AgentResourcesOutput = {
         unavailableReason: null,
         order: 2,
       },
+      {
+        // Team prompt the agent overrode with its own version → the original
+        // shows the `Overridden` badge (the custom replacement is its own row).
+        id: "eff:prompt:replaced",
+        bindingId: "bind-replace",
+        resourceId: "prompt-review",
+        replacesResourceId: null,
+        type: "prompt",
+        name: "Review checklist",
+        scope: "team",
+        source: "team_recommended",
+        mode: "replaced",
+        defaultEnabled: "recommended",
+        payload: null,
+        repo: null,
+        promptBody: "Use the team's standard review checklist.",
+        unavailableReason: null,
+        order: 3,
+      },
     ],
     skills: [
       {
@@ -160,6 +181,25 @@ const RESOURCES: AgentResourcesOutput = {
         promptBody: null,
         unavailableReason: null,
         order: 0,
+      },
+      {
+        // Opt-in team skill the agent enabled for itself: no Switch (present-or-
+        // removed) — managed via the ⋯ Remove + the section "+".
+        id: "eff:skill:optin",
+        bindingId: "bind-skill-optin",
+        resourceId: "skill-optin",
+        replacesResourceId: null,
+        type: "skill",
+        name: "pr-summary",
+        scope: "team",
+        source: "team_available",
+        mode: "enabled",
+        defaultEnabled: "available",
+        payload: { name: "pr-summary", description: "Summarize a PR for reviewers.", body: "", metadata: {} },
+        repo: null,
+        promptBody: null,
+        unavailableReason: null,
+        order: 1,
       },
     ],
     mcp: [
@@ -186,6 +226,14 @@ const RESOURCES: AgentResourcesOutput = {
   bindings: [
     { id: "bind-repo-extra", type: "repo", mode: "include", resourceId: null, replacesResourceId: null, order: 1 },
     {
+      id: "bind-skill-optin",
+      type: "skill",
+      mode: "include",
+      resourceId: "skill-optin",
+      replacesResourceId: null,
+      order: 4,
+    },
+    {
       id: "bind-inline",
       type: "prompt",
       mode: "include",
@@ -201,6 +249,26 @@ const RESOURCES: AgentResourcesOutput = {
       resourceId: "prompt-tone",
       replacesResourceId: null,
       order: 2,
+    },
+    {
+      id: "bind-replace",
+      type: "prompt",
+      mode: "replace",
+      resourceId: null,
+      replacesResourceId: "prompt-review",
+      inlinePromptBody: "Use our stricter, security-focused review checklist.",
+      order: 6,
+    },
+    {
+      // An inline prompt binding the backend kept but produced no effective row
+      // for (empty body) — recovered as an "orphan" row so it's editable/removable.
+      id: "bind-orphan",
+      type: "prompt",
+      mode: "include",
+      resourceId: null,
+      replacesResourceId: null,
+      inlinePromptBody: "",
+      order: 5,
     },
   ],
   availableTeamResources: [
@@ -358,7 +426,8 @@ export function AgentDetailPreviewPage() {
             Tools &amp; skills tab
           </h1>
           <p className="text-body" style={{ color: "var(--fg-3)", marginTop: "var(--sp-1)" }}>
-            Skills / MCP — each row tagged From your team or Added by you; deviations show Off / Can't load.
+            Skills / MCP — team-recommended rows carry an on/off Switch (off = greyed, stays in the list); opt-in /
+            added rows have no Switch, just ⋯ Remove. Can't load flags a broken reference.
           </p>
           <div style={{ marginTop: "var(--sp-4)", marginBottom: "var(--sp-8)" }}>
             <TabHost element={<ResourcesTab />} />
@@ -368,9 +437,10 @@ export function AgentDetailPreviewPage() {
             Instructions tab
           </h1>
           <p className="text-body" style={{ color: "var(--fg-3)", marginTop: "var(--sp-1)" }}>
-            Per-instruction management (Customize / Disable / Edit / Remove / Re-enable) with each block collapsed to a
-            summary (Show full to expand), an Add menu for custom or team instructions, and the read-only merged
-            Effective instructions at the bottom.
+            Per-instruction management converged to the Switch (team-recommended enable / disable) + the ⋯ menu
+            (Customize / Edit / Remove); each block collapses to a summary (expand to read the full body), an Add menu
+            adds custom or team instructions, and the 👁 Effective instructions button shows the merged runtime prompt.
+            (The always-on top Effective block + the density pass land in PR2.)
           </p>
           <div style={{ marginTop: "var(--sp-4)" }}>
             <TabHost element={<PromptTab />} />

--- a/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
@@ -344,6 +344,20 @@ function exactButtonByText(container: ParentNode, text: string): HTMLButtonEleme
   return [...container.querySelectorAll("button")].find((button) => button.textContent?.trim() === text) ?? null;
 }
 
+function menuItemByText(container: ParentNode, text: string): HTMLButtonElement | null {
+  return (
+    ([...container.querySelectorAll('[role="menuitem"]')] as HTMLButtonElement[]).find(
+      (item) => item.textContent?.trim() === text,
+    ) ?? null
+  );
+}
+
+/** Open a row's ⋯ overflow menu, then click one of its items by label. */
+async function clickRowMenuItem(container: ParentNode, menuAriaLabel: string, itemText: string): Promise<void> {
+  await click(container.querySelector(`button[aria-label="${menuAriaLabel}"]`));
+  await click(menuItemByText(container, itemText));
+}
+
 async function chooseSelectOption(trigger: Element | null, optionText: string): Promise<void> {
   await click(trigger);
   await click(buttonByText(document.body, optionText));
@@ -476,7 +490,8 @@ describe("AgentDetailPage", () => {
     expect(container.textContent).toContain("Use the team style guide.");
     expect(container.textContent).toContain("Added by you");
 
-    await click(container.querySelector('button[aria-label="Edit custom instructions"]'));
+    // The custom prompt's edit action now lives in the row's ⋯ overflow menu.
+    await clickRowMenuItem(container, "More actions for Custom instructions", "Edit custom instructions");
     await waitForText(container, "Save instructions");
     expect(container.textContent).toContain("Team style guide");
     expect(container.textContent).toContain("Use the team style guide.");
@@ -558,7 +573,7 @@ describe("AgentDetailPage", () => {
     await waitForText(container, "Added by you");
     expect(container.textContent).toContain("No instructions yet.");
 
-    await click(container.querySelector('button[aria-label="Edit custom instructions"]'));
+    await clickRowMenuItem(container, "More actions for Custom instructions", "Edit custom instructions");
     await waitForText(container, "Save instructions");
     expect(container.textContent).toContain("Use the team style guide.");
     const textarea = container.querySelector<HTMLTextAreaElement>("#custom-prompt-body");
@@ -618,7 +633,7 @@ describe("AgentDetailPage", () => {
 
     const { container, root } = await renderDom("/agents/agent-1/prompt", <PromptTab />);
     await waitForText(container, "Effective instructions");
-    await click(container.querySelector('button[aria-label="Customize for this agent"]'));
+    await clickRowMenuItem(container, "More actions for Team style guide", "Customize for this agent");
     await waitForText(container, "Save instructions");
     const textarea = container.querySelector<HTMLTextAreaElement>("#custom-prompt-body");
     expect(textarea?.value).toBe("Use the team style guide.");
@@ -686,7 +701,7 @@ describe("AgentDetailPage", () => {
 
     const { container, root } = await renderDom("/agents/agent-1/prompt", <PromptTab />);
     await waitForText(container, "Effective instructions");
-    await click(container.querySelector('button[aria-label="Customize for this agent"]'));
+    await clickRowMenuItem(container, "More actions for Team style guide", "Customize for this agent");
     await waitForText(container, "Save instructions");
     const textarea = container.querySelector<HTMLTextAreaElement>("#custom-prompt-body");
     expect(textarea?.value).toBe("Use the team style guide.");
@@ -755,7 +770,8 @@ describe("AgentDetailPage", () => {
 
     const { container, root } = await renderDom("/agents/agent-1/prompt", <PromptTab />);
     await waitForText(container, "Effective instructions");
-    await click(exactButtonByText(container, "Disable"));
+    // Disabling a recommended prompt is now the row's Switch, toggled off.
+    await click(container.querySelector('button[role="switch"]'));
     await waitForCondition(
       () => agentResourceMocks.updateAgentResources.mock.calls.length > 0,
       "Expected prompt resource update",

--- a/packages/web/src/pages/agent-detail/__tests__/resource-row.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/resource-row.test.tsx
@@ -1,0 +1,116 @@
+// @vitest-environment happy-dom
+
+import { act, type ReactElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ResourceRowView } from "../resource-row.js";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+function render(node: ReactElement): void {
+  act(() => root.render(node));
+}
+
+async function click(element: Element | null): Promise<void> {
+  if (!element) throw new Error("Expected element to click");
+  await act(async () => {
+    element.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+  });
+}
+
+describe("ResourceRowView — converged action slots", () => {
+  it("renders the toggle as an ARIA switch reflecting checked state and flips it on click", async () => {
+    const changes: boolean[] = [];
+    render(
+      <ResourceRowView
+        name="Style guide"
+        source="From your team"
+        toggle={{ checked: true, ariaLabel: "Enable Style guide", onChange: (v) => changes.push(v) }}
+      />,
+    );
+    const sw = container.querySelector('[role="switch"]') as HTMLButtonElement | null;
+    expect(sw).toBeTruthy();
+    expect(sw?.getAttribute("aria-checked")).toBe("true");
+    await click(sw);
+    expect(changes).toEqual([false]);
+  });
+
+  it("disables the toggle when toggle.disabled is set (can't-load state)", () => {
+    render(
+      <ResourceRowView
+        name="Broken skill"
+        source="From your team"
+        toggle={{ checked: false, disabled: true, ariaLabel: "Enable Broken skill", onChange: () => {} }}
+      />,
+    );
+    const sw = container.querySelector('[role="switch"]') as HTMLButtonElement | null;
+    expect(sw?.disabled).toBe(true);
+  });
+
+  it("renders the ⋯ overflow menu and fires the selected action", async () => {
+    const removed: string[] = [];
+    render(
+      <ResourceRowView
+        name="My repo"
+        source="Added by you"
+        menu={{
+          ariaLabel: "More actions for My repo",
+          actions: [
+            { key: "remove", label: "Remove My repo", destructive: true, onSelect: () => removed.push("my-repo") },
+          ],
+        }}
+      />,
+    );
+    const trigger = container.querySelector('[aria-haspopup="menu"]');
+    expect(trigger).toBeTruthy();
+    await click(trigger);
+    const item = [...container.querySelectorAll('[role="menuitem"]')].find((b) => b.textContent === "Remove My repo");
+    await click(item ?? null);
+    expect(removed).toEqual(["my-repo"]);
+  });
+
+  it("suppresses the ⋯ menu entirely when a row has no secondary actions", () => {
+    render(
+      <ResourceRowView name="Recommended skill" source="From your team" menu={{ ariaLabel: "More", actions: [] }} />,
+    );
+    expect(container.querySelector('[aria-haspopup="menu"]')).toBeNull();
+  });
+
+  it("renders the status marker as a bordered dense badge (Overridden / Can't load), not a plain dot label", () => {
+    render(
+      <ResourceRowView name="Style guide" source="From your team" status={{ label: "Overridden", tone: "neutral" }} />,
+    );
+    const overridden = [...container.querySelectorAll("span")].find((s) => s.textContent === "Overridden");
+    expect(overridden?.getAttribute("style")).toContain("border");
+
+    render(<ResourceRowView name="Broken" source="From your team" status={{ label: "Can't load", tone: "error" }} />);
+    const cantLoad = [...container.querySelectorAll("span")].find((s) => s.textContent === "Can't load");
+    expect(cantLoad?.getAttribute("style")).toContain("border");
+  });
+
+  it("marks a dimmed row so the disabled-greyed state is visually distinct", () => {
+    render(
+      <ResourceRowView
+        name="Disabled skill"
+        source="From your team"
+        dimmed
+        toggle={{ checked: false, ariaLabel: "Enable Disabled skill", onChange: () => {} }}
+      />,
+    );
+    expect(container.querySelector('[data-dimmed="true"]')).toBeTruthy();
+  });
+});

--- a/packages/web/src/pages/agent-detail/__tests__/resources-tab-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/resources-tab-dom.test.tsx
@@ -406,6 +406,129 @@ describe("ResourcesTab", () => {
     expect(document.body.textContent).toContain("Manage in Settings → Resources");
   });
 
+  it("disables a recommended skill via its Switch (off = disable binding)", async () => {
+    const { ResourceTypeSection } = await import("../capability-section.js");
+    const onMutate = vi.fn();
+    const data = agentResources({
+      effective: {
+        version: 3,
+        repos: [],
+        prompts: [],
+        mcp: [],
+        unavailable: [],
+        skills: [
+          {
+            id: "resource:skill-1",
+            bindingId: null,
+            resourceId: "skill-1",
+            replacesResourceId: null,
+            type: "skill",
+            name: "Team skill",
+            scope: "team",
+            source: "team_recommended",
+            mode: "enabled",
+            defaultEnabled: "recommended",
+            payload: { name: "Team skill", description: "Does things.", body: "Do it.", metadata: {} },
+            repo: null,
+            promptBody: null,
+            unavailableReason: null,
+            order: 0,
+          },
+        ],
+      },
+    });
+
+    const container = await renderRouted(
+      <ResourceTypeSection type="skill" data={data} canEdit pending={false} onMutate={onMutate} />,
+    );
+    const sw = container.querySelector('button[role="switch"]');
+    expect(sw?.getAttribute("aria-checked")).toBe("true");
+    await click(sw);
+    expect(onMutate).toHaveBeenCalledWith([{ type: "skill", mode: "disable", resourceId: "skill-1", order: 1 }]);
+  });
+
+  it("removes an opted-in skill via the ⋯ overflow menu (no Switch)", async () => {
+    const { ResourceTypeSection } = await import("../capability-section.js");
+    const onMutate = vi.fn();
+    const data = agentResources({
+      bindings: [{ id: "skill-binding-1", type: "skill", mode: "include", resourceId: "skill-1", order: 1 }],
+      effective: {
+        version: 3,
+        repos: [],
+        prompts: [],
+        mcp: [],
+        unavailable: [],
+        skills: [
+          {
+            id: "binding:skill-binding-1:enabled",
+            bindingId: "skill-binding-1",
+            resourceId: "skill-1",
+            replacesResourceId: null,
+            type: "skill",
+            name: "Opt-in skill",
+            scope: "team",
+            source: "team_available",
+            mode: "enabled",
+            defaultEnabled: "available",
+            payload: { name: "Opt-in skill", description: "Optional.", body: "Maybe.", metadata: {} },
+            repo: null,
+            promptBody: null,
+            unavailableReason: null,
+            order: 1,
+          },
+        ],
+      },
+    });
+
+    const container = await renderRouted(
+      <ResourceTypeSection type="skill" data={data} canEdit pending={false} onMutate={onMutate} />,
+    );
+    // Opt-in resources are present-or-removed — no Switch, just ⋯ Remove.
+    expect(container.querySelector('button[role="switch"]')).toBeNull();
+    await click(container.querySelector('button[aria-label="More actions for Opt-in skill"]'));
+    await click(buttonByText(container, "Remove Opt-in skill"));
+    expect(onMutate).toHaveBeenCalledWith([]);
+  });
+
+  it("shows a disabled Switch and a Can't load badge for an unavailable recommended skill", async () => {
+    const { ResourceTypeSection } = await import("../capability-section.js");
+    const data = agentResources({
+      effective: {
+        version: 3,
+        repos: [],
+        prompts: [],
+        mcp: [],
+        unavailable: [],
+        skills: [
+          {
+            id: "resource:skill-x",
+            bindingId: null,
+            resourceId: "skill-x",
+            replacesResourceId: null,
+            type: "skill",
+            name: "Broken skill",
+            scope: "team",
+            source: "team_recommended",
+            mode: "unavailable",
+            defaultEnabled: "recommended",
+            payload: null,
+            repo: null,
+            promptBody: null,
+            unavailableReason: "Skill failed to load.",
+            order: 0,
+          },
+        ],
+      },
+    });
+
+    const container = await renderRouted(
+      <ResourceTypeSection type="skill" data={data} canEdit pending={false} onMutate={vi.fn()} />,
+    );
+    expect(container.textContent).toContain("Can't load");
+    const sw = container.querySelector<HTMLButtonElement>('button[role="switch"]');
+    expect(sw?.disabled).toBe(true);
+  });
+
   it("renders flat-section row primitives", async () => {
     const row = await renderElement(
       <div>

--- a/packages/web/src/pages/agent-detail/capability-section.tsx
+++ b/packages/web/src/pages/agent-detail/capability-section.tsx
@@ -22,7 +22,7 @@ import { Label } from "../../components/ui/label.js";
 import { Popover } from "../../components/ui/popover.js";
 import { Section } from "../../components/ui/section.js";
 import { typeLabelSingular } from "../settings/resource-editors.js";
-import { ResourceRowView, RowAction } from "./resource-row.js";
+import { ResourceRowView, type RowMenu, type RowStatusMarker, type RowToggle } from "./resource-row.js";
 import { sourceLabel } from "./resource-source.js";
 import { titleWithSemantics, useJustSaved } from "./save-semantics.js";
 
@@ -323,46 +323,64 @@ function EffectiveRow(props: {
   onRemoveBinding: (bindingId: string) => void;
   onDisable: (resourceId: string) => void;
 }) {
+  const row = props.row;
   // Unavailable rows surface the failure reason as the subtitle; everything
   // else shows a type-appropriate detail. The subtitle never falls back to the
   // raw `source` enum (that used to duplicate the source under skills/MCP rows).
-  const subtitle = props.row.mode === "unavailable" ? props.row.unavailableReason : rowSubtitle(props.row);
-  const status = statusMarker(props.row.mode);
-  const source = sourceLabel(props.row.source);
-  const canRemove = props.row.bindingId && props.bindings.some((b) => b.id === props.row.bindingId);
-  const canDisable = props.row.resourceId && props.row.source === "team_recommended" && props.row.mode === "enabled";
+  const subtitle = row.mode === "unavailable" ? row.unavailableReason : rowSubtitle(row);
+  const status = statusMarker(row.mode);
+  const source = sourceLabel(row.source);
+  const isTeamRecommended = row.source === "team_recommended";
+  const canRemove = !!row.bindingId && props.bindings.some((b) => b.id === row.bindingId);
   // Mono only for technical detail (repo URL, MCP command). A skill description
   // and an "unavailable" failure reason are prose and stay in the sans body.
-  const monoPeek = props.row.mode !== "unavailable" && (props.row.type === "repo" || props.row.type === "mcp");
-  const actions =
-    props.canEdit && (canDisable || canRemove) ? (
-      <>
-        {canDisable ? (
-          <RowAction
-            label="Disable"
-            disabled={props.pending}
-            onClick={() => props.onDisable(props.row.resourceId ?? "")}
-          />
-        ) : null}
-        {canRemove ? (
-          <RowAction
-            icon="remove"
-            label={`Remove ${props.row.name}`}
-            disabled={props.pending}
-            onClick={() => props.onRemoveBinding(props.row.bindingId ?? "")}
-          />
-        ) : null}
-      </>
-    ) : null;
+  const monoPeek = row.mode !== "unavailable" && (row.type === "repo" || row.type === "mcp");
+
+  // Team-recommended resources get the on/off Switch (off = stays listed, greyed).
+  // It reuses the existing disable-binding mutation: toggling off adds a disable
+  // binding; toggling on removes it (the disabled row's bindingId IS that disable
+  // binding). Unavailable team rows show the Switch disabled rather than hide it.
+  const toggle: RowToggle | undefined =
+    props.canEdit && isTeamRecommended && row.resourceId && row.mode !== "replaced"
+      ? {
+          checked: row.mode === "enabled",
+          disabled: props.pending || row.mode === "unavailable",
+          ariaLabel: `Enable ${row.name}`,
+          onChange: (next) =>
+            next ? props.onRemoveBinding(row.bindingId ?? "") : props.onDisable(row.resourceId ?? ""),
+        }
+      : undefined;
+
+  // ⋯ Remove only for the present-or-removed sources (opt-in / agent-added). A
+  // team-recommended resource is never "removed" — it belongs to the team set and
+  // is toggled off instead — so it gets no ⋯ when there's nothing else to offer.
+  const menu: RowMenu | undefined =
+    props.canEdit && canRemove && !isTeamRecommended
+      ? {
+          ariaLabel: `More actions for ${row.name}`,
+          actions: [
+            {
+              key: "remove",
+              label: `Remove ${row.name}`,
+              destructive: true,
+              disabled: props.pending,
+              onSelect: () => props.onRemoveBinding(row.bindingId ?? ""),
+            },
+          ],
+        }
+      : undefined;
+
   return (
     <ResourceRowView
-      name={props.row.name}
+      name={row.name}
       source={source}
       status={status}
       peek={subtitle}
       monoPeek={monoPeek}
-      actions={actions}
-      leadingIcon={resourceTypeIcon(props.row.type)}
+      toggle={toggle}
+      menu={menu}
+      dimmed={row.mode === "disabled"}
+      leadingIcon={resourceTypeIcon(row.type)}
     />
   );
 }
@@ -503,13 +521,13 @@ function rowSubtitle(row: EffectiveResourceRow): string | null {
 }
 
 /**
- * Status marker — only rendered when a row deviates from the normal "enabled"
- * state, so normal rows stay clean. `Off` (not `Disabled`) avoids colliding
- * with the row's own `Disable` action button.
+ * Status marker — a dense badge, rendered only for the two states a row can't
+ * convey through its own controls: `Overridden` (a team resource replaced by a
+ * custom one) and `Can't load` (a broken reference). The plain disabled state is
+ * NOT a badge — it's the Switch in its off position plus a greyed (`dimmed`) row.
  */
-export function statusMarker(mode: EffectiveResourceRow["mode"]): { label: string; color: string } | null {
-  if (mode === "disabled") return { label: "Off", color: "var(--fg-4)" };
-  if (mode === "replaced") return { label: "Overridden", color: "var(--fg-4)" };
-  if (mode === "unavailable") return { label: "Can't load", color: "var(--state-error)" };
+export function statusMarker(mode: EffectiveResourceRow["mode"]): RowStatusMarker {
+  if (mode === "replaced") return { label: "Overridden", tone: "neutral" };
+  if (mode === "unavailable") return { label: "Can't load", tone: "error" };
   return null;
 }

--- a/packages/web/src/pages/agent-detail/prompt-tab.tsx
+++ b/packages/web/src/pages/agent-detail/prompt-tab.tsx
@@ -19,11 +19,12 @@ import {
 } from "../../components/ui/dialog.js";
 import { Markdown } from "../../components/ui/markdown.js";
 import { Popover } from "../../components/ui/popover.js";
+import type { RowAction as RowMenuAction } from "../../components/ui/row-actions-menu.js";
 import { Section } from "../../components/ui/section.js";
 import { Textarea } from "../../components/ui/textarea.js";
 import { agentResourcesMutationHandlers, resourceTypeIcon, statusMarker } from "./capability-section.js";
 import { useAgentDetailContext } from "./layout-context.js";
-import { ResourceRowView, RowAction, type RowStatusMarker } from "./resource-row.js";
+import { ResourceRowView, type RowMenu, type RowStatusMarker, type RowToggle } from "./resource-row.js";
 import { sourceLabel } from "./resource-source.js";
 import { titleWithSemantics, useJustSaved } from "./save-semantics.js";
 
@@ -383,14 +384,15 @@ function PromptResourceBlocks(props: {
 
   const blocks: ReactNode[] = rows.map((row) => {
     const isEditingRow = !!props.editor && editorIsInline && props.editor.rowId === row.id;
-    const action = props.editor || !props.canEdit ? null : promptRowAction(row, props);
+    const controls = props.editor || !props.canEdit ? {} : promptRowControls(row, props);
     return (
       <PromptResourceBlock
         key={row.id}
         name={promptBlockName(row)}
         source={row.source}
         marker={statusMarker(row.mode)}
-        action={action}
+        toggle={controls.toggle}
+        menu={controls.menu}
         body={row.promptBody ?? ""}
         expanded={expandedIds.has(row.id)}
         onToggle={() => toggleExpand(row.id)}
@@ -414,28 +416,49 @@ function PromptResourceBlocks(props: {
   }
 
   for (const row of inactiveRows) {
-    // Disabled team prompt → Re-enable. Overridden prompt with no live replacement
-    // row (e.g. an empty inline replacement) → Remove, so it never gets stuck.
+    // Disabled team prompt → Switch off (toggling on removes the disable binding).
+    // Overridden prompt with no live replacement row (e.g. an empty inline
+    // replacement) → ⋯ Remove, so it never gets stuck.
     const manageable =
       props.canEdit &&
       !props.editor &&
       !!row.bindingId &&
       (row.mode === "disabled" || !enabledBindingIds.has(row.bindingId));
-    const action = manageable ? (
-      <RowAction
-        label={row.mode === "disabled" ? "Re-enable" : "Remove"}
-        icon={row.mode === "disabled" ? undefined : "remove"}
-        disabled={props.busy}
-        onClick={() => row.bindingId && props.onRemoveBinding(row.bindingId)}
-      />
-    ) : null;
+    const name = promptBlockName(row) ?? "instructions";
+    let toggle: RowToggle | undefined;
+    let menu: RowMenu | undefined;
+    if (manageable && row.bindingId) {
+      if (row.mode === "disabled") {
+        toggle = {
+          checked: false,
+          disabled: props.busy,
+          ariaLabel: `Enable ${name}`,
+          onChange: () => row.bindingId && props.onRemoveBinding(row.bindingId),
+        };
+      } else {
+        menu = {
+          ariaLabel: `More actions for ${name}`,
+          actions: [
+            {
+              key: "remove",
+              label: "Remove",
+              destructive: true,
+              disabled: props.busy,
+              onSelect: () => row.bindingId && props.onRemoveBinding(row.bindingId),
+            },
+          ],
+        };
+      }
+    }
     blocks.push(
       <PromptResourceBlock
         key={row.id}
         name={promptBlockName(row)}
         source={row.source}
         marker={statusMarker(row.mode)}
-        action={action}
+        toggle={toggle}
+        menu={menu}
+        dimmed={row.mode === "disabled"}
         body={row.promptBody ?? ""}
         expanded={expandedIds.has(row.id)}
         onToggle={() => toggleExpand(row.id)}
@@ -448,24 +471,28 @@ function PromptResourceBlocks(props: {
     if (!bindingId) continue;
     const orphanId = `orphan:${bindingId}`;
     const isEditingOrphan = !!props.editor && props.editor.rowId === orphanId;
+    const menu: RowMenu | undefined =
+      props.editor || !props.canEdit
+        ? undefined
+        : {
+            ariaLabel: "More actions for custom instructions",
+            actions: [
+              { key: "edit", label: "Edit custom instructions", onSelect: () => props.onEditBinding(bindingId) },
+              {
+                key: "remove",
+                label: "Remove",
+                destructive: true,
+                disabled: props.busy,
+                onSelect: () => props.onRemoveBinding(bindingId),
+              },
+            ],
+          };
     blocks.push(
       <PromptResourceBlock
         key={orphanId}
         name={null}
         source="inline_prompt"
-        action={
-          props.editor || !props.canEdit ? null : (
-            <div className="flex gap-2">
-              <RowAction icon="edit" label="Edit custom instructions" onClick={() => props.onEditBinding(bindingId)} />
-              <RowAction
-                label="Remove"
-                icon="remove"
-                disabled={props.busy}
-                onClick={() => props.onRemoveBinding(bindingId)}
-              />
-            </div>
-          )
-        }
+        menu={menu}
         body=""
         expanded={isEditingOrphan}
         onToggle={() => {}}
@@ -483,9 +510,10 @@ function PromptResourceBlocks(props: {
   );
 }
 
-/** Inline action buttons for an active prompt row, mirroring the old Resources tab:
- *  customize / edit any prompt, disable a recommended one, remove a custom or opted-in one. */
-function promptRowAction(
+/** Converged controls for an active prompt row: a Switch for a team-recommended
+ *  prompt (enable / disable in place), and a ⋯ menu for the secondary actions —
+ *  Customize a team prompt, Edit a custom one, Remove a custom or opted-in one. */
+function promptRowControls(
   row: EffectivePromptRow,
   props: {
     busy: boolean;
@@ -493,42 +521,55 @@ function promptRowAction(
     onDisable: (resourceId: string) => void;
     onRemoveBinding: (bindingId: string) => void;
   },
-): ReactNode {
-  const buttons: ReactNode[] = [];
-  const remove = (
-    <RowAction
-      key="remove"
-      label="Remove"
-      icon="remove"
-      disabled={props.busy}
-      onClick={() => row.bindingId && props.onRemoveBinding(row.bindingId)}
-    />
-  );
+): { toggle?: RowToggle; menu?: RowMenu } {
+  const name = promptBlockName(row) ?? "instructions";
+  const removeItem: RowMenuAction = {
+    key: "remove",
+    label: "Remove",
+    destructive: true,
+    disabled: props.busy,
+    onSelect: () => {
+      if (row.bindingId) props.onRemoveBinding(row.bindingId);
+    },
+  };
+
   if (row.source === "inline_prompt") {
-    buttons.push(
-      <RowAction key="edit" icon="edit" label="Edit custom instructions" onClick={() => props.onStartEdit(row)} />,
-    );
-    if (row.bindingId) buttons.push(remove);
-  } else if (row.source.startsWith("team_") && row.resourceId) {
-    buttons.push(
-      <RowAction key="customize" icon="edit" label="Customize for this agent" onClick={() => props.onStartEdit(row)} />,
-    );
-    if (row.source === "team_recommended") {
-      buttons.push(
-        <RowAction
-          key="disable"
-          label="Disable"
-          disabled={props.busy}
-          onClick={() => row.resourceId && props.onDisable(row.resourceId)}
-        />,
-      );
-    } else if (row.bindingId) {
-      buttons.push(remove);
-    }
-  } else if (row.bindingId) {
-    buttons.push(remove);
+    const actions: RowMenuAction[] = [
+      { key: "edit", label: "Edit custom instructions", onSelect: () => props.onStartEdit(row) },
+    ];
+    if (row.bindingId) actions.push(removeItem);
+    return { menu: { ariaLabel: `More actions for ${name}`, actions } };
   }
-  return buttons.length > 0 ? <div className="flex gap-2">{buttons}</div> : null;
+
+  if (row.source.startsWith("team_") && row.resourceId) {
+    const actions: RowMenuAction[] = [
+      { key: "customize", label: "Customize for this agent", onSelect: () => props.onStartEdit(row) },
+    ];
+    if (row.source === "team_recommended") {
+      // Switch carries enable/disable; the ⋯ keeps only Customize.
+      const toggle: RowToggle = {
+        checked: row.mode === "enabled",
+        disabled: props.busy || row.mode === "unavailable",
+        ariaLabel: `Enable ${name}`,
+        onChange: (next) => {
+          if (next) {
+            if (row.bindingId) props.onRemoveBinding(row.bindingId);
+          } else if (row.resourceId) {
+            props.onDisable(row.resourceId);
+          }
+        },
+      };
+      return { toggle, menu: { ariaLabel: `More actions for ${name}`, actions } };
+    }
+    // team_available (opt-in): no Switch — present-or-removed.
+    if (row.bindingId) actions.push(removeItem);
+    return { menu: { ariaLabel: `More actions for ${name}`, actions } };
+  }
+
+  if (row.bindingId) {
+    return { menu: { ariaLabel: `More actions for ${name}`, actions: [removeItem] } };
+  }
+  return {};
 }
 
 function PromptFallbackPanel(props: { prompt: string }) {
@@ -569,7 +610,9 @@ function PromptResourceBlock(props: {
   name: string | null;
   source: EffectivePromptRow["source"];
   marker?: RowStatusMarker;
-  action?: ReactNode;
+  toggle?: RowToggle;
+  menu?: RowMenu;
+  dimmed?: boolean;
   body: string;
   expanded: boolean;
   onToggle: () => void;
@@ -585,7 +628,9 @@ function PromptResourceBlock(props: {
       source={sourceLabel(props.source)}
       status={props.marker}
       peek={peek || undefined}
-      actions={props.action}
+      toggle={props.toggle}
+      menu={props.menu}
+      dimmed={props.dimmed}
       emptyPeek="No instructions yet."
       expandLabel="instructions"
       leadingIcon={resourceTypeIcon("prompt")}

--- a/packages/web/src/pages/agent-detail/resource-row.tsx
+++ b/packages/web/src/pages/agent-detail/resource-row.tsx
@@ -1,25 +1,40 @@
-import { ChevronDown, ChevronUp, Pencil, Trash2 } from "lucide-react";
+import { ChevronDown, ChevronUp } from "lucide-react";
 import type { ReactNode } from "react";
 import { Button } from "../../components/ui/button.js";
-import { StatusGlyph } from "../../components/ui/status-glyph.js";
+import { DenseBadge, type DenseBadgeTone } from "../../components/ui/dense-badge.js";
+import { RowActionsMenu, type RowAction as RowMenuAction } from "../../components/ui/row-actions-menu.js";
+import { Switch } from "../../components/ui/switch.js";
 import { cn } from "../../lib/utils.js";
 
 /**
  * The single flat row primitive for every "effective resource" on the agent
  * detail page — instructions (Instructions tab), skills + MCP (Tools & skills),
- * and repositories (Environment). Before this, the Instructions tab and the
- * shared resource sections rendered near-identical-but-divergent rows: the
- * metadata order was reversed (name → source → status here vs name → status →
- * source there), row padding differed, and only Instructions could expand.
- *
- * `ResourceRow` locks all of that down so the rows read identically wherever
- * they appear:
- *   - line 1: name → source → status, then a right-aligned action group, then an
- *     optional expand chevron;
+ * and repositories (Repositories tab). All rows read identically wherever they
+ * appear:
+ *   - line 1: name → source → status, then the converged action cluster
+ *     (`[Switch] [⋯]`), then an optional expand chevron;
  *   - line 2 (collapsed): a single-line truncated `peek`;
  *   - expanded / editing: a sunken contained block below.
+ *
+ * Actions are structured, not freeform: a `toggle` (the on/off Switch for a
+ * team-recommended resource) and a `menu` (the ⋯ overflow for the secondary
+ * Customize / Edit / Remove actions). A row's controls are derived entirely
+ * from its source + state by the call site, so the language stays consistent:
+ * Switch = "enabled / disabled (stays, greyed)", ⋯ = "everything else".
  */
-export type RowStatusMarker = { label: string; color: string } | null;
+export type RowStatusMarker = { label: string; tone: DenseBadgeTone } | null;
+
+/** The converged on/off control for a team-recommended row. */
+export type RowToggle = {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  disabled?: boolean;
+  /** Accessible name — the row title alone isn't enough to announce the control. */
+  ariaLabel: string;
+};
+
+/** The ⋯ overflow menu's secondary actions. Empty → no ⋯ is rendered. */
+export type RowMenu = { actions: RowMenuAction[]; ariaLabel: string };
 
 export function ResourceRowView(props: {
   /** Row title. `null` when the row has no resource name (inline custom prompt);
@@ -27,15 +42,20 @@ export function ResourceRowView(props: {
   name: ReactNode | null;
   /** Already-resolved source label text (e.g. "From your team"). */
   source: ReactNode;
-  /** Off / Overridden / Can't load marker — omitted for a normal enabled row. */
+  /** Overridden / Can't load marker — omitted for a normal row. A disabled row
+   *  is conveyed by `toggle` (off) + `dimmed`, not a status badge. */
   status?: RowStatusMarker;
   /** Collapsed single-line preview. */
   peek?: ReactNode;
   /** Render the peek in mono — for technical content (repo URL, MCP command),
    *  NOT for prose (a skill description). */
   monoPeek?: boolean;
-  /** Right-aligned ghost action group (use `RowAction`). */
-  actions?: ReactNode;
+  /** On/off Switch — the primary control for a team-recommended resource. */
+  toggle?: RowToggle;
+  /** ⋯ overflow menu for secondary actions (Customize / Edit / Remove). */
+  menu?: RowMenu;
+  /** Grey the row down — the disabled (Switch-off, still-listed) state. */
+  dimmed?: boolean;
   /** Expand affordance + body rendered in the sunken block when expanded. */
   expand?: { canExpand: boolean; expanded: boolean; onToggle: () => void; body: ReactNode };
   /** When set, the sunken block always shows this (an inline editor) regardless
@@ -53,23 +73,40 @@ export function ResourceRowView(props: {
   const expanded = !!props.expand?.expanded;
   const canExpand = !props.editor && !!props.expand?.canExpand;
   const showSunken = props.editor ? true : expanded && !!props.expand?.body;
+  const hasMenu = !!props.menu && props.menu.actions.length > 0;
+  const showCluster = !!props.toggle || hasMenu || canExpand;
   return (
     <div
+      data-dimmed={props.dimmed ? "true" : undefined}
       style={{
         padding: "var(--sp-3) 0",
         borderBottom: "var(--hairline) solid var(--border-faint)",
       }}
     >
-      {/* Title + actions. On mobile they stack (title, then the action group wraps
-          below) so long management buttons never overflow a phone width; on sm+
-          they sit on one row with the actions right-aligned. */}
+      {/* Title + action cluster. On mobile they stack (title, then the controls
+          wrap below) so a long control group never overflows a phone width; on
+          sm+ they sit on one row with the controls right-aligned. */}
       <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:gap-3">
         <div className="min-w-0 flex-1">
-          <RowHeading name={props.name} source={props.source} status={props.status} leadingIcon={props.leadingIcon} />
+          <RowHeading
+            name={props.name}
+            source={props.source}
+            status={props.status}
+            leadingIcon={props.leadingIcon}
+            dimmed={props.dimmed}
+          />
         </div>
-        {props.actions || canExpand ? (
+        {showCluster ? (
           <div className="flex flex-wrap items-center gap-1 shrink-0">
-            {props.actions}
+            {props.toggle ? (
+              <Switch
+                checked={props.toggle.checked}
+                onCheckedChange={props.toggle.onChange}
+                disabled={props.toggle.disabled}
+                aria-label={props.toggle.ariaLabel}
+              />
+            ) : null}
+            {props.menu ? <RowActionsMenu actions={props.menu.actions} ariaLabel={props.menu.ariaLabel} /> : null}
             {canExpand ? (
               <Button
                 type="button"
@@ -123,11 +160,13 @@ function RowHeading({
   source,
   status,
   leadingIcon,
+  dimmed,
 }: {
   name: ReactNode | null;
   source: ReactNode;
   status?: RowStatusMarker;
   leadingIcon?: ReactNode;
+  dimmed?: boolean;
 }) {
   return (
     <span className="inline-flex items-center gap-2">
@@ -137,7 +176,7 @@ function RowHeading({
         </span>
       ) : null}
       {name ? (
-        <span className="text-body font-medium truncate" style={{ color: "var(--fg)" }}>
+        <span className="text-body font-medium truncate" style={{ color: dimmed ? "var(--fg-4)" : "var(--fg)" }}>
           {name}
         </span>
       ) : null}
@@ -145,48 +184,10 @@ function RowHeading({
         {source}
       </span>
       {status ? (
-        <span
-          className="mono inline-flex items-center gap-1.5 text-caption font-normal"
-          style={{ color: status.color }}
-        >
-          <StatusGlyph colorVar={status.color} shape="dot" size={7} ariaLabel={status.label} />
+        <DenseBadge tone={status.tone} className="shrink-0">
           {status.label}
-        </span>
+        </DenseBadge>
       ) : null}
     </span>
-  );
-}
-
-/**
- * One ghost action button for a ResourceRow. `icon` collapses the control to a
- * single glyph (label moves to aria-label/title) so the widest controls don't
- * overflow the flat row on narrow screens; text mode keeps the label inline.
- */
-export function RowAction(props: {
-  label: string;
-  onClick: () => void;
-  disabled?: boolean;
-  icon?: "edit" | "remove";
-}): ReactNode {
-  if (props.icon) {
-    const Icon = props.icon === "remove" ? Trash2 : Pencil;
-    return (
-      <Button
-        type="button"
-        size="xs"
-        variant="ghost"
-        disabled={props.disabled}
-        aria-label={props.label}
-        title={props.label}
-        onClick={props.onClick}
-      >
-        <Icon className="h-4 w-4" />
-      </Button>
-    );
-  }
-  return (
-    <Button type="button" size="xs" variant="ghost" disabled={props.disabled} onClick={props.onClick}>
-      {props.label}
-    </Button>
   );
 }


### PR DESCRIPTION
## What & why

P1 of the agent-detail UX rework — the **interaction layer**. On the merged P0 (engine-first IA + section hierarchy + type icons), each effective resource row exposed a scatter of ghost text buttons (Disable / Customize / Edit / Remove / Re-enable), and every row assembled its actions ad-hoc per surface. This converges them into one consistent control language shared by **every** resource row — skills, MCP, repositories, and instructions.

## Changes

- **`ResourceRowView` (shared row) gains structured action slots**, replacing the freeform `actions` prop:
  - `toggle` — the accessible `Switch`. The primary on/off control for a **team-recommended** resource. Off keeps the row listed but greyed (`dimmed`).
  - `menu` — the `⋯` overflow (`RowActionsMenu`) for secondary actions (Customize / Edit / Remove). An empty menu renders nothing.
  - status markers are now dense badges limited to the two states a control can't convey: **Overridden** (neutral) and **Can't load** (error). Plain "Off" is gone — the Switch + greyed row express it.
- **Both call sites build controls from a row's `source` + `mode`** (`capability-section` `EffectiveRow`, `prompt-tab` `promptRowControls`). Switch on/off **reuses the existing disable-binding mutation** (off = add disable binding, on = remove it) — **no new backend/API semantics**.
- **Dead code removed:** the ghost `RowAction` button (only the two converted files used it).
- **`Switch` primitive** (new `components/ui/switch.tsx`): ARIA `role="switch"`, Space/Enter toggle, focus ring. ON uses neutral `bg-primary` (never green) per DESIGN.md Pillar 2; the dark-mode off track carries a hairline border so it stays legible.
- **DEV preview** (`/preview/agent-detail`) extended to show every state.

### Source → control mapping

| Source / state | Switch | ⋯ menu |
|---|---|---|
| team-recommended, enabled | on | Customize (prompts only) |
| team-recommended, disabled | off + greyed | Customize (prompts only) |
| opt-in (`team_available`) | — | Remove |
| agent-added repo / custom inline | — | Remove (+ Edit for custom) |
| can't-load (unavailable) | disabled | Remove (if removable) |
| overridden (replaced) | — | Remove (if no live replacement) |

> Team-recommended skill/MCP have no Customize → Switch only, no ⋯. Opt-in/custom are present-or-removed → no Switch (a toggle that makes a row vanish is unintuitive).

## Verification

- `pnpm --filter @first-tree/web test` — 119 files / 892 tests green (incl. a new `resource-row` unit test, 3 new capability DOM tests, 5 rewritten prompt-action tests).
- `pnpm check` (biome) — 0 errors. `pnpm --filter @first-tree/web typecheck` (+ lint:tokens) — clean.
- Per-state visual QA by gandy-s-assistant + ux-expert via `/preview/agent-detail` (light + dark + ⋯ menu): enabled / disabled-greyed / overridden / can't-load / opt-in / custom / orphan-empty. **Visual: PASS.**

## Review disposition (ux-expert)

- **dark-mode Switch off-track contrast** → fixed here (hairline border on the off track in dark).
- 3-control crowding on a team-recommended prompt row (Switch + ⋯ + chevron) → **deferred to PR2**, where "expand to read" moves to the row body and the chevron is dropped.
- `team_recommended` vs `team_available` both labelled "From your team" → **pre-existing, out of P1 scope** (the differing controls already convey the difference).

## Out of scope (follow-up PR2)

Instructions result-first (top Effective block + row density, removing the 👁 modal), the info-cleanup batch, and the visual nudges. PR2 stacks on this.

## Notes

- Implementation-only: no Context Tree change (the IA / save-model decisions already landed in the tree). No backend/API change.
- **Do not self-merge** — merge is coordinated by gandy-s-assistant; gandy2025 authorizes.
