### PR TITLE
Add session provider retry policy

### DIFF
--- a/packages/client/src/__tests__/claude-code-turn-end-auto-resume-fail.test.ts
+++ b/packages/client/src/__tests__/claude-code-turn-end-auto-resume-fail.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { SessionEvent } from "@first-tree/shared";
+import { parseProviderRetryEventMessage, type SessionEvent } from "@first-tree/shared";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
 /**
@@ -167,7 +167,9 @@ describe("claude-code handler — auto-resume failure surfacing", () => {
     await handler.suspend();
     await new Promise((r) => setImmediate(r));
 
-    const errors = emitted.filter((e) => e.kind === "error");
+    const errors = emitted.filter(
+      (e) => e.kind === "error" && parseProviderRetryEventMessage(e.payload.message) === null,
+    );
     expect(errors).toHaveLength(1);
     const err = errors[0];
     if (!err || err.kind !== "error") throw new Error("expected error event");

--- a/packages/client/src/__tests__/claude-code-turn-end-retry-exhausted.test.ts
+++ b/packages/client/src/__tests__/claude-code-turn-end-retry-exhausted.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { SessionEvent } from "@first-tree/shared";
+import { parseProviderRetryEventMessage, type SessionEvent } from "@first-tree/shared";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
 /**
@@ -171,7 +171,9 @@ describe("claude-code handler — retry-exhausted surfacing", () => {
     // in-process Deduplicator collapses every bind-reset replay.
     expect(finishTurnCalled).toHaveBeenCalledTimes(1);
 
-    const errors = emitted.filter((e) => e.kind === "error");
+    const errors = emitted.filter(
+      (e) => e.kind === "error" && parseProviderRetryEventMessage(e.payload.message) === null,
+    );
     expect(errors).toHaveLength(1);
     const err = errors[0];
     if (!err || err.kind !== "error") throw new Error("expected error event");

--- a/packages/client/src/__tests__/codex-inject-startup-race.test.ts
+++ b/packages/client/src/__tests__/codex-inject-startup-race.test.ts
@@ -550,6 +550,56 @@ describe("codex handler startup inject queue", () => {
     await handler.shutdown();
   });
 
+  it("does not retry user-visible output when a reconnect diagnostic ends without turn.completed", async () => {
+    const sendMessage = vi
+      .fn<(chatId: string, body: Record<string, unknown>) => Promise<unknown>>()
+      .mockResolvedValue(undefined);
+    const emitEvent = vi.fn<(event: SessionEvent) => void>();
+    const completedCounts: Array<number | undefined> = [];
+    const retryTurn = vi.fn<SessionContext["retryTurn"]>();
+    const handler = createCodexHandler({ workspaceRoot });
+    const ctx = makeContext((count) => completedCounts.push(count), { sendMessage, emitEvent, retryTurn });
+
+    state.agentMessagesByTurn.set(1, ["working note"]);
+    state.streamErrorByTurn.set(1, "Reconnecting... 2/5 (request timed out)");
+    state.resolveChatContext?.({
+      chatId: "chat-startup-race",
+      title: "startup race",
+      topic: null,
+      description: null,
+      participants: [],
+    });
+
+    await handler.start(makeMessage("m1", "first"), ctx);
+
+    const events = emitEvent.mock.calls.map(([event]) => event);
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(
+      events.some(
+        (event) =>
+          event.kind === "error" &&
+          event.payload.source === "sdk" &&
+          event.payload.message.includes("Reconnecting... 2/5"),
+      ),
+    ).toBe(true);
+    expect(
+      events.some((event) => {
+        if (event.kind !== "error") return false;
+        const retryPayload = parseProviderRetryEventMessage(event.payload.message);
+        return (
+          retryPayload?.event === "provider_failure_terminal" &&
+          retryPayload.reasonCode === "unsafe_replay" &&
+          retryPayload.scope === "provider_turn"
+        );
+      }),
+    ).toBe(true);
+    expect(events.some((event) => event.kind === "turn_end" && event.payload.status === "error")).toBe(true);
+    expect(completedCounts).toEqual([1]);
+    expect(retryTurn).not.toHaveBeenCalled();
+
+    await handler.shutdown();
+  });
+
   it("does not retry partial Codex text when the turn later fails", async () => {
     const sendMessage = vi
       .fn<(chatId: string, body: Record<string, unknown>) => Promise<unknown>>()

--- a/packages/client/src/__tests__/codex-inject-startup-race.test.ts
+++ b/packages/client/src/__tests__/codex-inject-startup-race.test.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { SessionEvent } from "@first-tree/shared";
+import { parseProviderRetryEventMessage, type SessionEvent } from "@first-tree/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChatContext } from "../runtime/chat-context.js";
 import type { SessionContext, SessionMessage } from "../runtime/handler.js";
@@ -550,7 +550,7 @@ describe("codex handler startup inject queue", () => {
     await handler.shutdown();
   });
 
-  it("does not forward partial Codex text when the turn later fails", async () => {
+  it("does not retry partial Codex text when the turn later fails", async () => {
     const sendMessage = vi
       .fn<(chatId: string, body: Record<string, unknown>) => Promise<unknown>>()
       .mockResolvedValue(undefined);
@@ -580,13 +580,24 @@ describe("codex handler startup inject queue", () => {
       ),
     ).toBe(true);
     expect(events.some((event) => event.kind === "turn_end" && event.payload.status === "error")).toBe(true);
-    expect(completedCounts).toEqual([]);
-    expect(retryTurn).toHaveBeenCalledWith([makeMessage("m1", "first")], "codex_unknown_failure");
+    expect(
+      events.some((event) => {
+        if (event.kind !== "error") return false;
+        const retryPayload = parseProviderRetryEventMessage(event.payload.message);
+        return (
+          retryPayload?.event === "provider_failure_terminal" &&
+          retryPayload.reasonCode === "unsafe_replay" &&
+          retryPayload.scope === "provider_turn"
+        );
+      }),
+    ).toBe(true);
+    expect(completedCounts).toEqual([1]);
+    expect(retryTurn).not.toHaveBeenCalled();
 
     await handler.shutdown();
   });
 
-  it("does not forward partial Codex text when the stream emits a fatal error", async () => {
+  it("does not retry partial Codex text when the stream emits a fatal error", async () => {
     const sendMessage = vi
       .fn<(chatId: string, body: Record<string, unknown>) => Promise<unknown>>()
       .mockResolvedValue(undefined);
@@ -617,8 +628,19 @@ describe("codex handler startup inject queue", () => {
       ),
     ).toBe(true);
     expect(events.some((event) => event.kind === "turn_end" && event.payload.status === "error")).toBe(true);
-    expect(completedCounts).toEqual([]);
-    expect(retryTurn).toHaveBeenCalledWith([makeMessage("m1", "first")], "codex_stream_ended_after_diagnostic_error");
+    expect(
+      events.some((event) => {
+        if (event.kind !== "error") return false;
+        const retryPayload = parseProviderRetryEventMessage(event.payload.message);
+        return (
+          retryPayload?.event === "provider_failure_terminal" &&
+          retryPayload.reasonCode === "unsafe_replay" &&
+          retryPayload.scope === "provider_turn"
+        );
+      }),
+    ).toBe(true);
+    expect(completedCounts).toEqual([1]);
+    expect(retryTurn).not.toHaveBeenCalled();
 
     await handler.shutdown();
   });

--- a/packages/client/src/__tests__/codex-retry-abort.test.ts
+++ b/packages/client/src/__tests__/codex-retry-abort.test.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { SessionEvent } from "@first-tree/shared";
+import { parseProviderRetryEventMessage, type SessionEvent } from "@first-tree/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChatContext } from "../runtime/chat-context.js";
 import type { SessionContext, SessionMessage } from "../runtime/handler.js";
@@ -229,7 +229,16 @@ describe("codex handler retry abort cleanup", () => {
     // event, NOT delivered as a chat message.
     expect(sendMessage).not.toHaveBeenCalled();
     expect(assistantTexts).toEqual(["retry succeeded"]);
-    expect(events.some((event) => event.kind === "error")).toBe(false);
+    const errorEvents = events.filter(
+      (event): event is Extract<SessionEvent, { kind: "error" }> => event.kind === "error",
+    );
+    const retryEvents = errorEvents
+      .map((event) => parseProviderRetryEventMessage(event.payload.message))
+      .filter((event) => event !== null);
+    expect(retryEvents).toHaveLength(1);
+    expect(retryEvents[0]?.event).toBe("provider_retry_scheduled");
+    expect(retryEvents[0]?.userSeverity).toBe("info");
+    expect(errorEvents.filter((event) => parseProviderRetryEventMessage(event.payload.message) === null)).toEqual([]);
     expect(events.some((event) => event.kind === "turn_end" && event.payload.status === "success")).toBe(true);
     expect(completedCounts).toEqual([1]);
     expect(state.lateAbortAfterClose).toBe(false);

--- a/packages/client/src/__tests__/codex-usage-limit.test.ts
+++ b/packages/client/src/__tests__/codex-usage-limit.test.ts
@@ -43,6 +43,7 @@ vi.mock("@openai/codex-sdk", () => {
       state.runInputs.push(input);
       const idx = state.runInputs.length - 1;
       const events = state.turns[idx] ?? [];
+      if (events[0] instanceof Error) throw events[0];
       return {
         events: (async function* () {
           yield { type: "thread.started", thread_id: "thread-usage-limit" };
@@ -118,11 +119,12 @@ function makeMessage(id: string, content: string): SessionMessage {
 }
 
 function makeContext(
-  onFinishTurn: (count?: number) => void,
+  onFinishTurn: (count?: number, outcome?: { status: "success" | "error"; reason?: string }) => void,
   opts: {
     sendMessage?: SendMessageMock;
     emitEvent?: SessionContext["emitEvent"];
     log?: SessionContext["log"];
+    retryTurn?: SessionContext["retryTurn"];
   } = {},
 ): SessionContext {
   const sendMessage =
@@ -149,8 +151,9 @@ function makeContext(
     // that — the usage-limit notice is delivered by an EXPLICIT sdk.sendMessage
     // in the handler, NOT through this path.)
     forwardResult: async () => {},
-    finishTurn: async (messages) => {
-      onFinishTurn(Array.isArray(messages) ? messages.length : 1);
+    retryTurn: opts.retryTurn ?? (() => {}),
+    finishTurn: async (messages, outcome) => {
+      onFinishTurn(Array.isArray(messages) ? messages.length : 1, outcome);
     },
   };
 }
@@ -291,6 +294,57 @@ describe("codex usage-limit empty-turn (issue #971)", () => {
     ).toBe(false);
     expect(events.some((event) => event.kind === "turn_end" && event.payload.status === "success")).toBe(true);
     expect(completedCounts).toEqual([1]);
+
+    await handler.shutdown();
+  });
+
+  it("settles provider-entered rate limits as consumed errors instead of retrying the inbox entry", async () => {
+    state.turns = [[{ type: "turn.failed", error: { message: "rate limit exceeded; retry later" } }]];
+
+    const completed: Array<{ count?: number; reason?: string }> = [];
+    const retryTurn = vi.fn<SessionContext["retryTurn"]>();
+    const emitEvent = vi.fn<(event: SessionEvent) => void>();
+    const handler = createCodexHandler({ workspaceRoot });
+    const ctx = makeContext((count, outcome) => completed.push({ count, reason: outcome?.reason }), {
+      emitEvent,
+      retryTurn,
+    });
+
+    await handler.start(makeMessage("m1", "hello"), ctx);
+
+    expect(retryTurn).not.toHaveBeenCalled();
+    expect(completed).toEqual([{ count: 1, reason: "capacity_wait_required" }]);
+    expect(
+      emitEvent.mock.calls.some(
+        ([event]) => event.kind === "error" && event.payload.message.includes("provider.retry:"),
+      ),
+    ).toBe(true);
+    expect(emitEvent.mock.calls.some(([event]) => event.kind === "turn_end" && event.payload.status === "error")).toBe(
+      true,
+    );
+
+    await handler.shutdown();
+  });
+
+  it("keeps pre-provider exhausted network failures retryable instead of consuming the inbox entry", async () => {
+    state.turns = [[new Error("fetch failed")], [new Error("fetch failed")], [new Error("fetch failed")]];
+
+    const completedCounts: Array<number | undefined> = [];
+    const retryReasons: string[] = [];
+    const emitEvent = vi.fn<(event: SessionEvent) => void>();
+    const handler = createCodexHandler({ workspaceRoot });
+    const ctx = makeContext((count) => completedCounts.push(count), {
+      emitEvent,
+      retryTurn: (_messages, reason) => retryReasons.push(reason),
+    });
+
+    await handler.start(makeMessage("m-pre-provider", "hello"), ctx);
+
+    expect(state.runInputs).toHaveLength(3);
+    expect(completedCounts).toEqual([]);
+    expect(retryReasons).toEqual(["provider_transient_transport_exhausted"]);
+    const events = emitEvent.mock.calls.map(([event]) => event);
+    expect(events.some((event) => event.kind === "turn_end" && event.payload.status === "error")).toBe(true);
 
     await handler.shutdown();
   });

--- a/packages/client/src/__tests__/provider-retry-policy.test.ts
+++ b/packages/client/src/__tests__/provider-retry-policy.test.ts
@@ -1,0 +1,193 @@
+import type { ProviderRetryScope, ReplaySafety, RuntimeProvider } from "@first-tree/shared";
+import { describe, expect, it } from "vitest";
+import {
+  buildProviderRetryEvent,
+  classifyProviderFailure,
+  decideProviderRetry,
+  type ProviderFailureClassification,
+} from "../runtime/provider-retry-policy.js";
+
+class FakeRateLimit extends Error {
+  override name = "RateLimitError";
+  status = 429;
+}
+
+function classification(category: ProviderFailureClassification["category"], reasonCode: string = category) {
+  return {
+    category,
+    reasonCode,
+    message: reasonCode,
+    sourceKind: "transient",
+  } satisfies ProviderFailureClassification;
+}
+
+function decide(input: {
+  category: ProviderFailureClassification["category"];
+  scope?: ProviderRetryScope;
+  attempt?: number;
+  retryAfterMs?: number;
+  replaySafety?: ReplaySafety;
+  reasonCode?: string;
+}) {
+  return decideProviderRetry({
+    classification: classification(input.category, input.reasonCode),
+    scope: input.scope ?? "provider_turn",
+    attempt: input.attempt ?? 1,
+    retryAfterMs: input.retryAfterMs,
+    replaySafety: input.replaySafety ?? "pre_visible",
+  });
+}
+
+describe("classifyProviderFailure", () => {
+  it("maps provider rate limits to provider_capacity", () => {
+    expect(
+      classifyProviderFailure(new FakeRateLimit("rate limited"), {
+        provider: "claude-code",
+        scope: "provider_turn",
+        source: "stream",
+      }),
+    ).toMatchObject({ category: "provider_capacity", reasonCode: "provider_rate_limited" });
+  });
+
+  it("maps network and 5xx failures to transient_transport", () => {
+    for (const err of [new Error("fetch failed"), Object.assign(new Error("upstream 503"), { status: 503 })]) {
+      expect(classifyProviderFailure(err, { provider: "codex", scope: "provider_turn", source: "sdk" }).category).toBe(
+        "transient_transport",
+      );
+    }
+  });
+
+  it("maps deterministic and operator-actionable failures to stop categories", () => {
+    const cases: Array<[unknown, ProviderFailureClassification["category"]]> = [
+      [Object.assign(new Error("401 Unauthorized"), { status: 401 }), "credential"],
+      [Object.assign(new Error("request failed"), { status: 401 }), "credential"],
+      [Object.assign(new Error("request failed"), { statusCode: 403 }), "credential"],
+      [new Error("Codex runtime binary is missing"), "capability"],
+      [new Error("sandbox approval rejected"), "configuration"],
+      [new Error("context length exceeded"), "deterministic_input"],
+    ];
+    for (const [err, category] of cases) {
+      expect(classifyProviderFailure(err, { provider: "codex", scope: "provider_turn", source: "sdk" }).category).toBe(
+        category,
+      );
+    }
+  });
+});
+
+describe("decideProviderRetry", () => {
+  it("keeps provider_turn retry budget finite and foreground-only", () => {
+    expect(decide({ category: "transient_transport", attempt: 1 })).toMatchObject({
+      action: "retry",
+      delayMs: 500,
+      retryMode: "foreground",
+      maxAttempts: 2,
+    });
+    expect(decide({ category: "transient_transport", attempt: 2 })).toMatchObject({
+      action: "retry",
+      delayMs: 1500,
+    });
+    expect(decide({ category: "transient_transport", attempt: 3 })).toMatchObject({
+      action: "stop",
+      terminalKind: "exhausted",
+    });
+  });
+
+  it("does not apply provider_turn budget to session_start/session_resume transient failures", () => {
+    for (const scope of ["session_start", "session_resume"] as const) {
+      expect(decide({ category: "transient_transport", scope, attempt: 20 })).toMatchObject({
+        action: "retry",
+        retryMode: "background",
+      });
+    }
+  });
+
+  it("stops unknown after a small budget in every scope", () => {
+    expect(decide({ category: "unknown", scope: "provider_turn", attempt: 2 })).toMatchObject({
+      action: "retry",
+      delayMs: 15000,
+    });
+    expect(decide({ category: "unknown", scope: "session_resume", attempt: 3 })).toMatchObject({
+      action: "stop",
+      reasonCode: "unknown_exhausted",
+      terminalKind: "exhausted",
+    });
+  });
+
+  it("does not return capacity_wait_required for pre_provider failures", () => {
+    expect(
+      decide({
+        category: "provider_capacity",
+        reasonCode: "provider_rate_limited",
+        replaySafety: "pre_provider",
+        attempt: 3,
+        retryAfterMs: 120_000,
+      }),
+    ).toMatchObject({ action: "stop", terminalKind: "exhausted" });
+  });
+
+  it("returns capacity_wait_required for provider-entered long capacity refusals", () => {
+    expect(
+      decide({
+        category: "provider_capacity",
+        reasonCode: "provider_rate_limited",
+        replaySafety: "provider_entered",
+        retryAfterMs: 120_000,
+      }),
+    ).toMatchObject({
+      action: "stop",
+      reasonCode: "capacity_wait_required",
+      terminalKind: "capacity_wait_required",
+    });
+  });
+
+  it("stops unsafe provider_turn replay before retrying", () => {
+    expect(
+      decide({
+        category: "transient_transport",
+        replaySafety: "user_visible",
+        attempt: 1,
+      }),
+    ).toMatchObject({ action: "stop", terminalKind: "unsafe_replay" });
+    expect(
+      decide({
+        category: "transient_transport",
+        replaySafety: "unknown",
+        attempt: 1,
+      }),
+    ).toMatchObject({ action: "stop", terminalKind: "unsafe_replay" });
+  });
+});
+
+describe("buildProviderRetryEvent", () => {
+  it("builds standard payloads from decisions", () => {
+    const provider: RuntimeProvider = "codex";
+    const c = classification("transient_transport", "network_error");
+    const decision = decideProviderRetry({
+      classification: c,
+      scope: "provider_turn",
+      attempt: 1,
+      replaySafety: "pre_visible",
+    });
+    expect(
+      buildProviderRetryEvent({
+        event: "provider_retry_scheduled",
+        provider,
+        scope: "provider_turn",
+        classification: c,
+        decision,
+        messagePreview: "fetch failed with token ghp_secret_should_be_redacted",
+        now: 1_000,
+      }),
+    ).toMatchObject({
+      event: "provider_retry_scheduled",
+      provider,
+      scope: "provider_turn",
+      category: "transient_transport",
+      reasonCode: "network_error",
+      attempt: 1,
+      maxAttempts: 2,
+      delayMs: 500,
+      userSeverity: "info",
+    });
+  });
+});

--- a/packages/client/src/__tests__/session-manager-retry.test.ts
+++ b/packages/client/src/__tests__/session-manager-retry.test.ts
@@ -1,4 +1,4 @@
-import type { SessionEvent, SessionState } from "@first-tree/shared";
+import { parseProviderRetryEventMessage, type SessionEvent, type SessionState } from "@first-tree/shared";
 import { describe, expect, it, vi } from "vitest";
 import type { AgentHandler, HandlerFactory, SessionContext, SessionMessage } from "../runtime/handler.js";
 import { SessionManager } from "../runtime/session-manager.js";
@@ -151,16 +151,17 @@ describe("SessionManager: transient retry on session start", () => {
     expect(errorEvents.length).toBeGreaterThan(0);
     const scheduled = errorEvents.find(
       (e) =>
-        typeof e.payload.message === "string" && e.payload.message.startsWith("resilience.session.retry_scheduled:"),
+        typeof e.payload.message === "string" &&
+        parseProviderRetryEventMessage(e.payload.message)?.event === "provider_retry_scheduled",
     );
     expect(scheduled).toBeDefined();
-    // Encoded payload follows `<eventName>: <JSON>` — parse the JSON tail.
-    const jsonText = (scheduled?.payload.message as string).slice("resilience.session.retry_scheduled:".length).trim();
-    const parsed = JSON.parse(jsonText) as Record<string, unknown>;
-    expect(parsed.reasonCode).toBe("claude_rate_limit");
-    expect(parsed.attempt).toBe(1);
-    expect(parsed.phase).toBe("start");
-    expect(parsed.rawError).toBe("upstream rate limited — please retry shortly");
+    const message = scheduled?.payload.message;
+    if (typeof message !== "string") throw new Error("Expected string provider retry payload");
+    const parsed = parseProviderRetryEventMessage(message);
+    expect(parsed?.reasonCode).toBe("provider_rate_limited");
+    expect(parsed?.attempt).toBe(1);
+    expect(parsed?.scope).toBe("session_start");
+    expect(parsed?.messagePreview).toBe("upstream rate limited — please retry shortly");
 
     await sm.shutdown();
   });
@@ -199,7 +200,7 @@ describe("SessionManager: transient retry on session start", () => {
       (e): e is Extract<SessionEvent, { kind: "error" }> =>
         e.kind === "error" &&
         typeof e.payload.message === "string" &&
-        e.payload.message.startsWith("resilience.session.retry_scheduled:"),
+        parseProviderRetryEventMessage(e.payload.message)?.event === "provider_retry_scheduled",
     );
     expect(scheduled).toBeDefined();
     const encoded = scheduled?.payload.message ?? "";

--- a/packages/client/src/__tests__/session-start-error-signaling.test.ts
+++ b/packages/client/src/__tests__/session-start-error-signaling.test.ts
@@ -1,4 +1,4 @@
-import type { SessionEvent, SessionState } from "@first-tree/shared";
+import { parseProviderRetryEventMessage, type SessionEvent, type SessionState } from "@first-tree/shared";
 import { describe, expect, it, vi } from "vitest";
 import type {
   AgentHandler,
@@ -168,8 +168,14 @@ describe("SessionManager: session-start failure signalling (F2)", () => {
     expect(errorEvent?.event.kind).toBe("error");
     if (errorEvent?.event.kind === "error") {
       expect(errorEvent.event.payload.source).toBe("runtime");
-      expect(errorEvent.event.payload.message).toContain("Session start failed");
-      expect(errorEvent.event.payload.message).toContain("git worktree add failed");
+      const retryPayload = parseProviderRetryEventMessage(errorEvent.event.payload.message);
+      expect(retryPayload).toMatchObject({
+        event: "provider_failure_terminal",
+        scope: "session_start",
+        category: "configuration",
+        reasonCode: "client_identity_mismatch",
+      });
+      expect(retryPayload?.messagePreview).toContain("git worktree add failed");
     }
 
     await sm.shutdown();
@@ -433,14 +439,22 @@ describe("SessionManager: session-resume failure signalling (F2, resume path)", 
     const chatAStates = stateChanges.filter((c) => c.chatId === "chat-A").map((c) => c.state);
     expect(chatAStates.at(-1)).toBe("errored");
 
-    const resumeErrEvent = events.find(
-      (e) =>
-        e.chatId === "chat-A" && e.event.kind === "error" && e.event.payload.message.includes("Session resume failed"),
-    );
+    const resumeErrEvent = events.find((e) => {
+      if (e.chatId !== "chat-A" || e.event.kind !== "error") return false;
+      const payload = parseProviderRetryEventMessage(e.event.payload.message);
+      return payload?.event === "provider_failure_terminal" && payload.scope === "session_resume";
+    });
     expect(resumeErrEvent).toBeDefined();
     if (resumeErrEvent?.event.kind === "error") {
       expect(resumeErrEvent.event.payload.source).toBe("runtime");
-      expect(resumeErrEvent.event.payload.message).toContain("git mirror fetch failed");
+      const retryPayload = parseProviderRetryEventMessage(resumeErrEvent.event.payload.message);
+      expect(retryPayload).toMatchObject({
+        event: "provider_failure_terminal",
+        scope: "session_resume",
+        category: "configuration",
+        reasonCode: "client_identity_mismatch",
+      });
+      expect(retryPayload?.messagePreview).toContain("git mirror fetch failed");
     }
 
     // sendMessage should NOT carry the error — that's the regression we're

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -11,10 +11,18 @@ import type {
   SDKUserMessage,
 } from "@anthropic-ai/claude-agent-sdk";
 import { query as claudeQuery } from "@anthropic-ai/claude-agent-sdk";
-import type { AgentRuntimeConfigPayload, SessionEvent, SupportedImageMime, ToolFileRef } from "@first-tree/shared";
+import type {
+  AgentRuntimeConfigPayload,
+  RuntimeProvider,
+  SessionEvent,
+  SupportedImageMime,
+  ToolFileRef,
+} from "@first-tree/shared";
 import {
+  encodeProviderRetryEventMessage,
   isImageBatchRefContent,
   isImageRefContent,
+  runtimeProviderSchema,
   SUPPORTED_IMAGE_MIMES as SHARED_SUPPORTED_IMAGE_MIMES,
 } from "@first-tree/shared";
 import { ensureAgentBootstrap as ensureAgentBootstrapShared } from "../runtime/agent-bootstrap.js";
@@ -28,7 +36,6 @@ import {
   type ContextTreeGitWriteTracker,
   createContextTreeGitWriteTracker,
 } from "../runtime/context-tree-git-status.js";
-import { classify } from "../runtime/error-taxonomy.js";
 import {
   type AgentHandler,
   type DeliveryToken,
@@ -39,6 +46,14 @@ import {
 } from "../runtime/handler.js";
 import { findImagePath } from "../runtime/image-store.js";
 import { InputController } from "../runtime/input-controller.js";
+import {
+  buildProviderRetryEvent,
+  classifyProviderFailure,
+  decideProviderRetry,
+  maxProviderTurnRetryAttempts,
+  type ProviderFailureClassification,
+  type ProviderRetryDecision,
+} from "../runtime/provider-retry-policy.js";
 import { materializeResourceSkills } from "../runtime/resource-skills.js";
 import { currentSourceRepoNamesFromPayload, declaredSourceRepos } from "../runtime/source-repos.js";
 import { acquireAgentHome, markWorkspaceInitComplete } from "../runtime/workspace.js";
@@ -46,8 +61,6 @@ import { chunkAssistantText } from "./assistant-text.js";
 import { formatAuthHint, isClaudeAuthError } from "./auth-error-hint.js";
 import { resolveClaudeCodeExecutable } from "./claude-executable.js";
 import { consumedErrorOutcome } from "./turn-settlement.js";
-
-const MAX_RETRIES = 2;
 
 type PendingAckMessage = {
   message: SessionMessage;
@@ -709,6 +722,10 @@ export function isSameModelFamily(a: string, b: string): boolean {
  */
 export const createClaudeCodeHandler: HandlerFactory = (config) => {
   const workspaceRoot = config.workspaceRoot as string;
+  const runtimeProvider: RuntimeProvider = runtimeProviderSchema.safeParse(config.runtimeProvider).success
+    ? runtimeProviderSchema.parse(config.runtimeProvider)
+    : "claude-code";
+  const providerTurnMaxRetries = maxProviderTurnRetryAttempts();
   const agentConfigCache = (config.agentConfigCache as AgentConfigCache | undefined) ?? null;
   // Pre-resolved by registerBuiltinHandlers at process start. Undefined =
   // defer to the SDK's bundled native binary (see claude-executable.ts for
@@ -757,6 +774,31 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
    * tracked separately by `PendingAckMessage.providerEntered`.
    */
   const unclosedSdkInputs: PendingSdkInput[] = [];
+
+  function emitProviderTurnRetryEvent(
+    sessionCtx: SessionContext,
+    event: "provider_retry_scheduled" | "provider_retry_exhausted" | "provider_failure_terminal",
+    classification: ProviderFailureClassification,
+    decision: ProviderRetryDecision,
+    messagePreview: string,
+  ): void {
+    sessionCtx.emitEvent({
+      kind: "error",
+      payload: {
+        source: "runtime",
+        message: encodeProviderRetryEventMessage(
+          buildProviderRetryEvent({
+            event,
+            provider: runtimeProvider,
+            scope: "provider_turn",
+            classification,
+            decision,
+            messagePreview,
+          }),
+        ),
+      },
+    });
+  }
 
   async function toSDKUserMessage(
     message: SessionMessage,
@@ -1331,9 +1373,19 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
                   // turn as a clean success.
                   const sniff = detectStreamApiError(resultText);
                   if (sniff) {
-                    const classification = classify(new Error(sniff.message), { source: "stream" });
+                    const classification = classifyProviderFailure(new Error(sniff.message), {
+                      provider: runtimeProvider,
+                      scope: "provider_turn",
+                      source: "stream",
+                    });
+                    const decision = decideProviderRetry({
+                      classification,
+                      scope: "provider_turn",
+                      attempt: retryCount + 1,
+                      replaySafety: "pre_visible",
+                    });
                     sessionCtx.log(
-                      `Stream API error detected (${classification.kind}/${classification.reasonCode}): ${sniff.message}`,
+                      `Stream API error detected (${classification.category}/${classification.reasonCode}): ${sniff.message}`,
                     );
                     // Design §6.1: emit `resilience.stream.api_error_detected`
                     // on BOTH transient and permanent paths via the closed-kind
@@ -1344,12 +1396,19 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
                         source: "runtime",
                         message: `resilience.stream.api_error_detected: ${JSON.stringify({
                           reasonCode: classification.reasonCode,
-                          kind: classification.kind,
+                          category: classification.category,
                           messagePreview: sniff.message.slice(0, 200),
                         })}`,
                       },
                     });
-                    if (classification.kind === "transient" && retryCount < MAX_RETRIES) {
+                    if (decision.action === "retry") {
+                      emitProviderTurnRetryEvent(
+                        sessionCtx,
+                        "provider_retry_scheduled",
+                        classification,
+                        decision,
+                        sniff.message,
+                      );
                       // Re-throw to drive the outer catch's auto-resume path
                       // (retry counter + self-resume via handler.resume).
                       throw new StreamApiTransientError(sniff.message);
@@ -1357,6 +1416,13 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
                     // Permanent (401/403) OR retries exhausted: surface the
                     // failure as an error event + error turn, and do NOT run
                     // the success/completion path for this turn.
+                    emitProviderTurnRetryEvent(
+                      sessionCtx,
+                      decision.terminalKind === "exhausted" ? "provider_retry_exhausted" : "provider_failure_terminal",
+                      classification,
+                      decision,
+                      sniff.message,
+                    );
                     sessionCtx.emitEvent({
                       kind: "error",
                       payload: {
@@ -1466,10 +1532,22 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
             if (err.stack) sessionCtx.log(`  stack: ${err.stack.split("\n").slice(1, 4).join(" | ")}`);
           }
 
-          if (retryCount >= MAX_RETRIES || !claudeSessionId) {
+          const classification = classifyProviderFailure(err, {
+            provider: runtimeProvider,
+            scope: "provider_turn",
+            source: "stream",
+          });
+          const decision = decideProviderRetry({
+            classification,
+            scope: "provider_turn",
+            attempt: retryCount + 1,
+            replaySafety: "pre_visible",
+          });
+
+          if (decision.action !== "retry" || !claudeSessionId) {
             sessionCtx.log("Exhausted retries, session will be suspended");
             // Surface to the chat timeline so the user sees the failure and
-            // doesn't think the agent silently stalled. The MAX_RETRIES
+            // doesn't think the agent silently stalled. The retry-exhausted
             // case in particular drops the turn entirely — no result will
             // be forwarded — so without an explicit error event the chat
             // would just go quiet.
@@ -1479,8 +1557,25 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
             try {
               const preview = errMsg.slice(0, 800);
               const reason = claudeSessionId
-                ? `Query failed after ${MAX_RETRIES} retries: ${preview}`
+                ? `Query failed after ${providerTurnMaxRetries} retries: ${preview}`
                 : `Query failed and no resume id available: ${preview}`;
+              emitProviderTurnRetryEvent(
+                sessionCtx,
+                decision.action === "stop" && decision.terminalKind === "exhausted"
+                  ? "provider_retry_exhausted"
+                  : "provider_failure_terminal",
+                classification,
+                decision.action === "stop"
+                  ? decision
+                  : {
+                      action: "stop",
+                      reasonCode: "claude_missing_resume_id",
+                      terminalKind: "unsafe_replay",
+                      replaySafety: "unknown",
+                      userSeverity: "error",
+                    },
+                preview,
+              );
               sessionCtx.emitEvent({ kind: "error", payload: { source: "runtime", message: reason } });
               sessionCtx.emitEvent({ kind: "turn_end", payload: { status: "error" } });
             } catch (emitErr) {
@@ -1520,8 +1615,9 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
           // after resume.
           toolCallProcessor.flush();
 
-          retryCount++;
-          sessionCtx.log(`Attempting auto-resume (retry ${retryCount}/${MAX_RETRIES})`);
+          retryCount = decision.attempt;
+          emitProviderTurnRetryEvent(sessionCtx, "provider_retry_scheduled", classification, decision, errMsg);
+          sessionCtx.log(`Attempting auto-resume (retry ${retryCount}/${providerTurnMaxRetries})`);
 
           try {
             respawnQuery(claudeSessionId, sessionCtx);

--- a/packages/client/src/handlers/codex/sdk.ts
+++ b/packages/client/src/handlers/codex/sdk.ts
@@ -108,6 +108,10 @@ export function isTransientCodexErrorMessage(message: string): boolean {
   return classification.category === "transient_transport" || classification.category === "provider_capacity";
 }
 
+function isCodexStreamDiagnosticMessage(message: string): boolean {
+  return /\breconnecting\b.*\b\d+\s*\/\s*\d+\b/i.test(message);
+}
+
 /**
  * Tracks whether re-running this turn would double-emit a chat-visible item.
  * `reasoning` and the bare `error` item are presence-only / diagnostic and
@@ -898,6 +902,19 @@ export const createCodexSdkHandler: HandlerFactory = (config) => {
                 }
                 stopCodexFailure(event.error.message, classification, decision);
               } else if (event.type === "error") {
+                // Codex SDK bare `error` stream events are diagnostic: they
+                // can be followed by more items and a successful
+                // `turn.completed` (for example reconnect progress). Only
+                // treat explicit progress messages as diagnostic; ordinary
+                // stream failures still go through the shared retry policy.
+                if (isCodexStreamDiagnosticMessage(event.message)) {
+                  diagnosticErrorEmittedBox.value = true;
+                  sessionCtx.emitEvent({
+                    kind: "error",
+                    payload: { source: "sdk", message: event.message },
+                  });
+                  continue;
+                }
                 const { classification, decision } = decideCodexFailure(event.message, attempt, true);
                 if (decision.action === "retry") {
                   retryRequested = true;
@@ -912,12 +929,7 @@ export const createCodexSdkHandler: HandlerFactory = (config) => {
                   );
                   break;
                 }
-                if (decision.terminalKind === "capacity_wait_required" || decision.terminalKind === "exhausted") {
-                  stopCodexFailure(event.message, classification, decision);
-                } else {
-                  diagnosticErrorEmittedBox.value = true;
-                  stopCodexFailure(event.message, classification, decision);
-                }
+                stopCodexFailure(event.message, classification, decision);
               }
             }
           } catch (err) {

--- a/packages/client/src/handlers/codex/sdk.ts
+++ b/packages/client/src/handlers/codex/sdk.ts
@@ -1105,10 +1105,34 @@ export const createCodexSdkHandler: HandlerFactory = (config) => {
     } else if (consumedErrorReason) {
       sessionCtx.log(`codex turn stopped with consumed provider error: ${consumedErrorReason}`);
     } else if (!retryReason && !providerCompleted) {
-      retryReason = diagnosticErrorEmittedBox.value
+      const streamEndReason = diagnosticErrorEmittedBox.value
         ? "codex_stream_ended_after_diagnostic_error"
         : "codex_stream_ended_without_completion";
-      sessionCtx.log(`codex stream ended without turn.completed; scheduling recovery (${retryReason})`);
+      if (userVisibleEmitted) {
+        const message = `${streamEndReason}: stream ended without turn.completed after user-visible output`;
+        const classification = classifyProviderFailure(new Error(message), {
+          provider: runtimeProvider,
+          scope: "provider_turn",
+          source: "sdk",
+        });
+        const decision = decideProviderRetry({
+          classification,
+          scope: "provider_turn",
+          attempt: 1,
+          replaySafety: "user_visible",
+        });
+        if (decision.action === "stop") {
+          emitProviderTurnRetryEvent(sessionCtx, "provider_failure_terminal", classification, decision, message);
+          consumedErrorReason = decision.reasonCode;
+          sessionCtx.log(`codex stream ended without turn.completed; stopping unsafe replay (${decision.reasonCode})`);
+        } else {
+          retryReason = streamEndReason;
+          sessionCtx.log(`codex stream ended without turn.completed; scheduling recovery (${retryReason})`);
+        }
+      } else {
+        retryReason = streamEndReason;
+        sessionCtx.log(`codex stream ended without turn.completed; scheduling recovery (${retryReason})`);
+      }
     }
 
     const settlement = resolveTurnSettlement({

--- a/packages/client/src/handlers/codex/sdk.ts
+++ b/packages/client/src/handlers/codex/sdk.ts
@@ -2,6 +2,8 @@ import { isAbsolute, resolve } from "node:path";
 import {
   type AgentRuntimeConfigPayload,
   deriveRepoLocalPath,
+  encodeProviderRetryEventMessage,
+  runtimeProviderSchema,
   type SessionEvent,
   type ToolFileRef,
 } from "@first-tree/shared";
@@ -45,6 +47,14 @@ import type {
   TurnConsumedErrorReason,
 } from "../../runtime/handler.js";
 import { deliveryTokenFromSessionContext } from "../../runtime/handler.js";
+import {
+  buildProviderRetryEvent,
+  classifyProviderFailure,
+  decideProviderRetry,
+  maxProviderTurnRetryAttempts,
+  type ProviderFailureClassification,
+  type ProviderRetryDecision,
+} from "../../runtime/provider-retry-policy.js";
 import { materializeResourceSkills } from "../../runtime/resource-skills.js";
 import { currentSourceRepoNamesFromPayload, declaredSourceRepos } from "../../runtime/source-repos.js";
 import { acquireAgentHome, markWorkspaceInitComplete } from "../../runtime/workspace.js";
@@ -63,34 +73,6 @@ type CodexConfigObject = { [key: string]: CodexConfigValue };
 const RESULT_PREVIEW_LIMIT = 400;
 
 /**
- * Turn-level retry budget for transient codex failures.
- *
- * Total attempts = MAX_TURN_RETRIES + 1 (i.e. 1 initial + 2 retries = 3 tries).
- * Backoff is `RETRY_BASE_MS * RETRY_MULTIPLIER^attempt`, so the schedule is
- * 500 ms → 1500 ms before the third attempt — matches the order of magnitude
- * of the SDK fetch-retry layer (`sdk-retry.test.ts`) without falling into the
- * same band that PostgreSQL LISTEN/NOTIFY uses for inbox redelivery.
- *
- * **Layering with `FirstTreeHubSDK` fetch retry (PR #600 review nit #3):**
- * this counter sits on top of the SDK's internal `doFetch` retry (3 tries,
- * 0/500/1000 ms) AND on top of whatever `@openai/codex-sdk` does inside its
- * child-process call. Worst-case attempts per turn ≈ this layer (3) × inner
- * SDK fetch retry (3) = ~9 model invocations and a wall-clock ceiling near
- * `RETRY_BASE_MS * RETRY_MULTIPLIER^MAX_TURN_RETRIES + sum(inner backoffs)`.
- * Operators looking at long-tail latency / retry logs should know both
- * layers exist before tuning either.
- *
- * Retries fire ONLY when (a) the error message looks transient (see
- * `isTransientCodexErrorMessage`) AND (b) no user-visible event has been
- * emitted yet for this turn (see `isUserVisibleItem`). Once the agent has
- * said something or run a tool, re-running the turn would double-emit those
- * items in the chat timeline — not acceptable.
- */
-const MAX_TURN_RETRIES = 2;
-const RETRY_BASE_MS = 500;
-const RETRY_MULTIPLIER = 3;
-
-/**
  * Chat-visible notice posted when a turn is detected as a usage-limit empty
  * turn (issue #971 — codex account usage limit exhausted: the SDK reports
  * `turn.completed` with no reply and zero token consumption, i.e. the model
@@ -106,15 +88,6 @@ const USAGE_LIMIT_NOTICE =
   "Please resend it once the limit resets.";
 
 /**
- * HTTP status-code matchers anchored at word boundaries so unrelated
- * numeric IDs ("request id 5023", "job_id=5001", "context window 4012")
- * don't smuggle a false-positive match through `includes("500")` etc.
- * See PR #600 review nit #1.
- */
-const AUTH_HTTP_CODE_RE = /\b(401|403)\b/;
-const TRANSIENT_HTTP_CODE_RE = /\b(500|502|503|504)\b/;
-
-/**
  * Transient-error heuristic for `turn.failed` / SDK throws.
  *
  * The codex SDK surfaces `ThreadError = { message: string }` only — no
@@ -127,50 +100,12 @@ const TRANSIENT_HTTP_CODE_RE = /\b(500|502|503|504)\b/;
  * Exported for tests so the classifier table is locked behavioural API.
  */
 export function isTransientCodexErrorMessage(message: string): boolean {
-  const m = message.toLowerCase();
-  // Explicit non-retriables — short-circuit so a message like "401:
-  // unauthorized after fetch failed" doesn't get retried because of
-  // "fetch failed". HTTP codes use \b word boundaries so a `job_id=4012345`
-  // / `request id 4019` in the wrapped error doesn't get misclassified as
-  // an auth failure (which would silently swallow a real transient).
-  if (
-    AUTH_HTTP_CODE_RE.test(m) ||
-    m.includes("unauthorized") ||
-    m.includes("forbidden") ||
-    m.includes("invalid api key") ||
-    m.includes("invalid_api_key") ||
-    m.includes("authentication") ||
-    m.includes("context length") ||
-    m.includes("context_length") ||
-    m.includes("sandbox") ||
-    m.includes("approval")
-  ) {
-    return false;
-  }
-  return (
-    TRANSIENT_HTTP_CODE_RE.test(m) ||
-    m.includes("rate limit") ||
-    m.includes("rate_limit") ||
-    m.includes("overloaded") ||
-    m.includes("unavailable") ||
-    m.includes("timed out") ||
-    m.includes("timeout") ||
-    m.includes("fetch failed") ||
-    m.includes("network") ||
-    m.includes("econnreset") ||
-    m.includes("econnrefused") ||
-    m.includes("etimedout") ||
-    m.includes("epipe")
-  );
-}
-
-type CodexFailureKind = "deterministic" | "transient" | "unknown";
-type CodexTerminalFailure = { kind: CodexFailureKind; message: string };
-
-function classifyCodexFailure(message: string): CodexFailureKind {
-  if (isCodexAuthError(message)) return "deterministic";
-  if (isTransientCodexErrorMessage(message)) return "transient";
-  return "unknown";
+  const classification = classifyProviderFailure(new Error(message), {
+    provider: "codex",
+    scope: "provider_turn",
+    source: "sdk",
+  });
+  return classification.category === "transient_transport" || classification.category === "provider_capacity";
 }
 
 /**
@@ -448,6 +383,8 @@ export function toolFileRefsForTerminalCodexTool(input: {
  */
 export const createCodexSdkHandler: HandlerFactory = (config) => {
   const workspaceRoot = config.workspaceRoot as string;
+  const runtimeProvider = runtimeProviderSchema.parse(config.runtimeProvider ?? "codex");
+  const providerTurnMaxRetries = maxProviderTurnRetryAttempts();
   const agentConfigCache = (config.agentConfigCache as AgentConfigCache | undefined) ?? null;
   const contextTreePath = (config.contextTreePath as string | undefined) ?? null;
   const contextTreeRepoUrl = (config.contextTreeRepoUrl as string | undefined) ?? null;
@@ -498,6 +435,31 @@ export const createCodexSdkHandler: HandlerFactory = (config) => {
    * so the LLM knows the absolute paths and upstream coordinates.
    */
   let sourceReposForPrompt: PredeclaredSourceRepo[] = [];
+
+  function emitProviderTurnRetryEvent(
+    sessionCtx: SessionContext,
+    event: "provider_retry_scheduled" | "provider_retry_exhausted" | "provider_failure_terminal",
+    classification: ProviderFailureClassification,
+    decision: ProviderRetryDecision,
+    messagePreview: string,
+  ): void {
+    sessionCtx.emitEvent({
+      kind: "error",
+      payload: {
+        source: "runtime",
+        message: encodeProviderRetryEventMessage(
+          buildProviderRetryEvent({
+            event,
+            provider: runtimeProvider,
+            scope: "provider_turn",
+            classification,
+            decision,
+            messagePreview,
+          }),
+        ),
+      },
+    });
+  }
 
   function buildEnv(sessionCtx: SessionContext): Record<string, string> {
     // Footgun F1: when `CodexOptions.env` is provided the SDK does NOT
@@ -811,21 +773,77 @@ export const createCodexSdkHandler: HandlerFactory = (config) => {
     let finalResponse = "";
     const providerCompletedBox: { value: boolean } = { value: false };
     const diagnosticErrorEmittedBox: { value: boolean } = { value: false };
-    const terminalFailureBox: { value: CodexTerminalFailure | null } = { value: null };
+    const consumedErrorReasonBox: { value: TurnConsumedErrorReason | null } = { value: null };
     let userVisibleEmitted = false;
     // Wrapper object so TS doesn't narrow `lastUsage` to `null` based on the
     // synchronous initializer (assignments live inside the IIFE below, which
     // TS' control-flow analysis can't reach — microsoft/TypeScript#9998).
     const usageBox: { value: Usage | null } = { value: null };
     const turnStartedAt = Date.now();
+    const retryAfterHelperStopBox: { value: string | null } = { value: null };
+    const decideCodexFailure = (
+      message: string,
+      attemptIndex: number,
+      providerEntered: boolean,
+    ): {
+      classification: ProviderFailureClassification;
+      decision: ProviderRetryDecision;
+    } => {
+      const classification = classifyProviderFailure(new Error(message), {
+        provider: runtimeProvider,
+        scope: "provider_turn",
+        source: "sdk",
+      });
+      const replaySafety = userVisibleEmitted
+        ? "user_visible"
+        : !providerEntered
+          ? "pre_provider"
+          : classification.category === "provider_capacity"
+            ? "provider_entered"
+            : "pre_visible";
+      return {
+        classification,
+        decision: decideProviderRetry({
+          classification,
+          scope: "provider_turn",
+          attempt: attemptIndex + 1,
+          replaySafety,
+        }),
+      };
+    };
+    const stopCodexFailure = (
+      message: string,
+      classification: ProviderFailureClassification,
+      decision: Extract<ProviderRetryDecision, { action: "stop" }>,
+    ): void => {
+      emitProviderTurnRetryEvent(
+        sessionCtx,
+        decision.terminalKind === "exhausted" ? "provider_retry_exhausted" : "provider_failure_terminal",
+        classification,
+        decision,
+        message,
+      );
+      if (decision.replaySafety === "pre_provider" && decision.terminalKind === "exhausted") {
+        retryAfterHelperStopBox.value = decision.reasonCode;
+      } else {
+        consumedErrorReasonBox.value =
+          decision.terminalKind === "capacity_wait_required"
+            ? "capacity_wait_required"
+            : decision.terminalKind === "exhausted"
+              ? "provider_retry_exhausted"
+              : decision.reasonCode;
+      }
+      const formatted = formatCodexSdkError(message);
+      sessionCtx.emitEvent({ kind: "error", payload: { source: "sdk", message: formatted } });
+    };
     const promise = (async () => {
-      for (let attempt = 0; attempt <= MAX_TURN_RETRIES; attempt++) {
+      for (let attempt = 0; ; attempt++) {
         // Reset per-attempt; finalResponse intentionally persists across
         // attempts only because we abort retries the moment any user-visible
         // item is emitted, so it is empty whenever a retry runs.
         providerCompletedBox.value = false;
         diagnosticErrorEmittedBox.value = false;
-        terminalFailureBox.value = null;
+        consumedErrorReasonBox.value = null;
         let retryRequested = false;
         let retryDelay = 0;
         let retryReason = "";
@@ -864,51 +882,55 @@ export const createCodexSdkHandler: HandlerFactory = (config) => {
                 usageBox.value = event.usage;
                 providerCompletedBox.value = true;
               } else if (event.type === "turn.failed") {
-                if (
-                  !userVisibleEmitted &&
-                  attempt < MAX_TURN_RETRIES &&
-                  isTransientCodexErrorMessage(event.error.message)
-                ) {
+                const { classification, decision } = decideCodexFailure(event.error.message, attempt, true);
+                if (decision.action === "retry") {
                   retryRequested = true;
-                  retryDelay = RETRY_BASE_MS * RETRY_MULTIPLIER ** attempt;
-                  retryReason = `turn.failed (transient): ${event.error.message}`;
+                  retryDelay = decision.delayMs;
+                  retryReason = `turn.failed (${classification.category}): ${event.error.message}`;
+                  emitProviderTurnRetryEvent(
+                    sessionCtx,
+                    "provider_retry_scheduled",
+                    classification,
+                    decision,
+                    event.error.message,
+                  );
                   break;
                 }
-                terminalFailureBox.value = {
-                  kind: classifyCodexFailure(event.error.message),
-                  message: event.error.message,
-                };
-                const message = formatCodexSdkError(event.error.message);
-                sessionCtx.emitEvent({
-                  kind: "error",
-                  payload: { source: "sdk", message },
-                });
+                stopCodexFailure(event.error.message, classification, decision);
               } else if (event.type === "error") {
-                if (!userVisibleEmitted && attempt < MAX_TURN_RETRIES && isTransientCodexErrorMessage(event.message)) {
+                const { classification, decision } = decideCodexFailure(event.message, attempt, true);
+                if (decision.action === "retry") {
                   retryRequested = true;
-                  retryDelay = RETRY_BASE_MS * RETRY_MULTIPLIER ** attempt;
-                  retryReason = `stream error (transient): ${event.message}`;
+                  retryDelay = decision.delayMs;
+                  retryReason = `stream error (${classification.category}): ${event.message}`;
+                  emitProviderTurnRetryEvent(
+                    sessionCtx,
+                    "provider_retry_scheduled",
+                    classification,
+                    decision,
+                    event.message,
+                  );
                   break;
                 }
-                diagnosticErrorEmittedBox.value = true;
-                const message = formatCodexSdkError(event.message);
-                sessionCtx.emitEvent({
-                  kind: "error",
-                  payload: { source: "sdk", message },
-                });
+                if (decision.terminalKind === "capacity_wait_required" || decision.terminalKind === "exhausted") {
+                  stopCodexFailure(event.message, classification, decision);
+                } else {
+                  diagnosticErrorEmittedBox.value = true;
+                  stopCodexFailure(event.message, classification, decision);
+                }
               }
             }
           } catch (err) {
             if (abort.signal.aborted) return;
             const msg = err instanceof Error ? err.message : String(err);
-            if (!userVisibleEmitted && attempt < MAX_TURN_RETRIES && isTransientCodexErrorMessage(msg)) {
+            const { classification, decision } = decideCodexFailure(msg, attempt, false);
+            if (decision.action === "retry") {
               retryRequested = true;
-              retryDelay = RETRY_BASE_MS * RETRY_MULTIPLIER ** attempt;
-              retryReason = `runStreamed threw (transient): ${msg}`;
+              retryDelay = decision.delayMs;
+              retryReason = `runStreamed threw (${classification.category}): ${msg}`;
+              emitProviderTurnRetryEvent(sessionCtx, "provider_retry_scheduled", classification, decision, msg);
             } else {
-              terminalFailureBox.value = { kind: classifyCodexFailure(msg), message: msg };
-              const message = formatCodexSdkError(msg);
-              sessionCtx.emitEvent({ kind: "error", payload: { source: "sdk", message } });
+              stopCodexFailure(msg, classification, decision);
             }
           }
         } finally {
@@ -928,7 +950,9 @@ export const createCodexSdkHandler: HandlerFactory = (config) => {
         // ChildProcess AbortError that crashes the client. The backoff still
         // listens to the parent signal below, so suspend/shutdown can cut it
         // short without starting another attempt.
-        sessionCtx.log(`codex turn retry ${attempt + 1}/${MAX_TURN_RETRIES + 1} after ${retryDelay}ms; ${retryReason}`);
+        sessionCtx.log(
+          `codex turn retry ${attempt + 1}/${providerTurnMaxRetries + 1} after ${retryDelay}ms; ${retryReason}`,
+        );
         try {
           // Sleep on PARENT signal: only suspend/shutdown should cut
           // short the backoff window. The per-attempt signal belongs to the
@@ -1003,14 +1027,14 @@ export const createCodexSdkHandler: HandlerFactory = (config) => {
       perTurnUsage.cached_input_tokens === 0 &&
       perTurnUsage.output_tokens === 0 &&
       perTurnUsage.reasoning_output_tokens === 0;
-    const failure = terminalFailureBox.value;
+    const helperConsumedErrorReason = consumedErrorReasonBox.value;
     const providerCompleted = providerCompletedBox.value;
-    const completedSuccessfully = providerCompleted && failure === null;
+    const completedSuccessfully = providerCompleted && helperConsumedErrorReason === null;
     const usageLimitEmptyTurn = completedSuccessfully && accumulated.trim().length === 0 && zeroTokenDelta;
 
     let forwardFailed = false;
-    let retryReason: string | null = null;
-    let consumedErrorReason: TurnConsumedErrorReason | null = null;
+    let retryReason: string | null = retryAfterHelperStopBox.value;
+    let consumedErrorReason: TurnConsumedErrorReason | null = helperConsumedErrorReason;
     if (usageLimitEmptyTurn) {
       // Layer 2 (observability): emit an error event + warn-level log so the
       // daemon log and admin event stream record a real failure instead of a
@@ -1066,12 +1090,9 @@ export const createCodexSdkHandler: HandlerFactory = (config) => {
           payload: { source: "runtime", message: `forwardResult failed: ${msg}` },
         });
       }
-    } else if (failure !== null) {
-      retryReason = `codex_${failure.kind}_failure`;
-      sessionCtx.log(
-        `codex turn did not complete successfully; scheduling recovery (${failure.kind}): ${failure.message}`,
-      );
-    } else if (!providerCompleted) {
+    } else if (consumedErrorReason) {
+      sessionCtx.log(`codex turn stopped with consumed provider error: ${consumedErrorReason}`);
+    } else if (!retryReason && !providerCompleted) {
       retryReason = diagnosticErrorEmittedBox.value
         ? "codex_stream_ended_after_diagnostic_error"
         : "codex_stream_ended_without_completion";

--- a/packages/client/src/runtime/agent-slot.ts
+++ b/packages/client/src/runtime/agent-slot.ts
@@ -6,6 +6,7 @@ import type {
   SessionEvent,
   SessionState,
 } from "@first-tree/shared";
+import { runtimeProviderSchema } from "@first-tree/shared";
 import { defaultDataDir } from "@first-tree/shared/config";
 import type { ClientConnection, SessionReconcileResult } from "../client-connection.js";
 import { createLogger, type pino } from "../observability/logger.js";
@@ -165,11 +166,8 @@ export class AgentSlot {
 
     let bindSucceeded = false;
     try {
-      const bound = await this.clientConnection.bindAgent(
-        this.config.agentId,
-        this.config.runtimeType ?? this.config.type,
-        this.config.runtimeVersion,
-      );
+      const runtimeType = this.config.runtimeType ?? this.config.type;
+      const bound = await this.clientConnection.bindAgent(this.config.agentId, runtimeType, this.config.runtimeVersion);
       bindSucceeded = true;
       const sdk = bound.sdk;
       const agent = await sdk.register();
@@ -210,6 +208,7 @@ export class AgentSlot {
 
       const ackEntry = (entryId: number) => this.clientConnection.sendInboxAck(entryId, agent.agentId);
       const recoverChat = (chatId: string) => this.clientConnection.sendInboxRecover(agent.agentId, chatId);
+      const runtimeProvider = runtimeProviderSchema.safeParse(runtimeType);
 
       this.sessionManager = new SessionManager({
         session: this.config.session,
@@ -221,6 +220,7 @@ export class AgentSlot {
           contextTreePath: contextTreeBinding?.path,
           contextTreeRepoUrl: contextTreeBinding?.repoUrl,
           contextTreeBranch: contextTreeBinding?.branch,
+          ...(runtimeProvider.success ? { runtimeProvider: runtimeProvider.data } : {}),
           // Identifies the owning client process. The claude-code-tui handler
           // uses it to scope tmux session ownership (orphan sweep / names) so
           // it never touches another live client's sessions. Other handlers

--- a/packages/client/src/runtime/handler.ts
+++ b/packages/client/src/runtime/handler.ts
@@ -1,4 +1,4 @@
-import type { AgentVisibility, SessionEvent } from "@first-tree/shared";
+import type { AgentVisibility, RuntimeProvider, SessionEvent } from "@first-tree/shared";
 import type { FirstTreeHubSDK } from "../sdk.js";
 
 /** Agent identity fields flowing from Server through the runtime pipeline. */
@@ -291,6 +291,8 @@ export type HandlerFactory = (config: HandlerConfig) => AgentHandler;
 export type HandlerConfig = {
   /** Root directory for per-chat workspaces (`<dataDir>/workspaces/<agentName>`). */
   workspaceRoot: string;
+  /** Runtime provider for this handler slot, used for structured status payloads. */
+  runtimeProvider?: RuntimeProvider;
   /** Additional handler-specific config. */
   [key: string]: unknown;
 };

--- a/packages/client/src/runtime/provider-retry-policy.ts
+++ b/packages/client/src/runtime/provider-retry-policy.ts
@@ -1,0 +1,451 @@
+import type {
+  ProviderFailureCategory,
+  ProviderRetryEventName,
+  ProviderRetryEventPayload,
+  ProviderRetryScope,
+  ReplaySafety,
+  RuntimeProvider,
+} from "@first-tree/shared";
+import { type Classification, classify, ERROR_KINDS } from "./error-taxonomy.js";
+import { redactErrorPreview } from "./redact-error-preview.js";
+
+export type ProviderFailureClassification = {
+  category: ProviderFailureCategory;
+  reasonCode: string;
+  message: string;
+  retryAfterMs?: number;
+  sourceKind: Classification["kind"];
+};
+
+export type ProviderRetryDecision =
+  | {
+      action: "retry";
+      delayMs: number;
+      reasonCode: string;
+      attempt: number;
+      maxAttempts?: number;
+      retryMode: "foreground" | "background";
+      replaySafety: ReplaySafety;
+      userSeverity: "info" | "warning";
+    }
+  | {
+      action: "stop";
+      reasonCode: string;
+      terminalKind: "deterministic" | "exhausted" | "unsafe_replay" | "needs_operator" | "capacity_wait_required";
+      replaySafety: ReplaySafety;
+      userSeverity: "warning" | "error";
+    };
+
+export type ProviderFailureSource = "session" | "stream" | "sdk" | "auth" | "bind";
+
+const PROVIDER_TURN_MAX_RETRIES = 2;
+const PROVIDER_TURN_DELAYS_MS = [500, 1500] as const;
+const PROVIDER_TURN_CAPACITY_SHORT_WAIT_MS = 30_000;
+const UNKNOWN_MAX_RETRIES = 2;
+const UNKNOWN_DELAYS_MS = [5_000, 15_000] as const;
+const SESSION_FOREGROUND_RETRIES = 3;
+const SESSION_TRANSIENT_CAP_MS = 60_000;
+const SESSION_CAPACITY_CAP_MS = 5 * 60_000;
+const AUTH_HTTP_CODE_RE = /\b(401|403)\b/;
+const TRANSIENT_HTTP_CODE_RE = /\b(500|502|503|504)\b/;
+
+export function classifyProviderFailure(
+  err: unknown,
+  context: {
+    provider: RuntimeProvider;
+    scope: ProviderRetryScope;
+    source?: ProviderFailureSource;
+  },
+): ProviderFailureClassification {
+  const source = context.source === "sdk" ? undefined : context.source;
+  const base = classify(err, source ? { source } : undefined);
+  const shape = readErrorShape(err);
+  const text = `${shape.name ?? ""} ${shape.message ?? ""} ${shape.code ?? ""} ${shape.reason ?? ""}`.toLowerCase();
+  const retryAfterMs = readRetryAfterMs(shape);
+  const status = shape.status ?? shape.statusCode;
+
+  if (isCredential(text, base, status)) {
+    return {
+      category: "credential",
+      reasonCode: credentialReason(base),
+      message: base.message,
+      retryAfterMs,
+      sourceKind: base.kind,
+    };
+  }
+  if (isCapability(text, base)) {
+    return {
+      category: "capability",
+      reasonCode: base.reasonCode,
+      message: base.message,
+      retryAfterMs,
+      sourceKind: base.kind,
+    };
+  }
+  if (isConfiguration(text, base)) {
+    return {
+      category: "configuration",
+      reasonCode: configurationReason(base),
+      message: base.message,
+      retryAfterMs,
+      sourceKind: base.kind,
+    };
+  }
+  if (isDeterministicInput(text, base)) {
+    return {
+      category: "deterministic_input",
+      reasonCode: deterministicReason(base),
+      message: base.message,
+      retryAfterMs,
+      sourceKind: base.kind,
+    };
+  }
+  if (isCapacity(text, base, retryAfterMs)) {
+    return {
+      category: "provider_capacity",
+      reasonCode: capacityReason(text, base),
+      message: base.message,
+      retryAfterMs,
+      sourceKind: base.kind,
+    };
+  }
+  if ((base.kind === ERROR_KINDS.TRANSIENT && base.reasonCode !== "unknown") || isTransportText(text)) {
+    return {
+      category: "transient_transport",
+      reasonCode: transientReason(base, context.provider),
+      message: base.message,
+      retryAfterMs,
+      sourceKind: base.kind,
+    };
+  }
+  if (base.reasonCode === "unknown") {
+    return { category: "unknown", reasonCode: "unknown", message: base.message, retryAfterMs, sourceKind: base.kind };
+  }
+  return {
+    category: "unknown",
+    reasonCode: base.reasonCode || "unknown",
+    message: base.message,
+    retryAfterMs,
+    sourceKind: base.kind,
+  };
+}
+
+export function decideProviderRetry(input: {
+  classification: ProviderFailureClassification;
+  scope: ProviderRetryScope;
+  attempt: number;
+  firstFailedAt?: number;
+  retryAfterMs?: number;
+  replaySafety: ReplaySafety;
+}): ProviderRetryDecision {
+  const attempt = Math.max(1, Math.floor(input.attempt));
+  const retryAfterMs = input.retryAfterMs ?? input.classification.retryAfterMs;
+
+  if (input.scope === "provider_turn" && isUnsafeReplay(input.replaySafety)) {
+    return stop("unsafe_replay", "unsafe_replay", input.replaySafety, "warning");
+  }
+
+  switch (input.classification.category) {
+    case "credential":
+      return stop(input.classification.reasonCode, "needs_operator", input.replaySafety, "error");
+    case "capability":
+    case "configuration":
+      return stop(input.classification.reasonCode, "needs_operator", input.replaySafety, "error");
+    case "deterministic_input":
+      return stop(input.classification.reasonCode, "deterministic", input.replaySafety, "error");
+    case "unknown":
+      return decideUnknown(input.scope, attempt, input.replaySafety);
+    case "transient_transport":
+      return input.scope === "provider_turn"
+        ? decideProviderTurnTransient(input.classification.reasonCode, attempt, input.replaySafety)
+        : decideSessionTransient(input.classification.reasonCode, attempt, input.replaySafety);
+    case "provider_capacity":
+      return input.scope === "provider_turn"
+        ? decideProviderTurnCapacity(input.classification.reasonCode, attempt, retryAfterMs, input.replaySafety)
+        : decideSessionCapacity(input.classification.reasonCode, attempt, retryAfterMs, input.replaySafety);
+  }
+}
+
+export function buildProviderRetryEvent(input: {
+  event: ProviderRetryEventName;
+  provider: RuntimeProvider;
+  scope: ProviderRetryScope;
+  classification: ProviderFailureClassification;
+  decision?: ProviderRetryDecision;
+  messagePreview?: string | null;
+  now?: number;
+}): ProviderRetryEventPayload {
+  const retryDecision = input.decision?.action === "retry" ? input.decision : null;
+  const severity =
+    input.decision?.userSeverity ??
+    (input.event === "provider_retry_exhausted" || input.event === "provider_failure_terminal" ? "error" : "info");
+  return {
+    event: input.event,
+    provider: input.provider,
+    scope: input.scope,
+    category: input.classification.category,
+    reasonCode: input.decision?.reasonCode ?? input.classification.reasonCode,
+    ...(retryDecision ? { attempt: retryDecision.attempt } : {}),
+    ...(retryDecision?.maxAttempts ? { maxAttempts: retryDecision.maxAttempts } : {}),
+    ...(retryDecision ? { retryMode: retryDecision.retryMode } : {}),
+    ...(retryDecision ? { delayMs: retryDecision.delayMs } : {}),
+    ...(retryDecision
+      ? { nextRetryAt: new Date((input.now ?? Date.now()) + retryDecision.delayMs).toISOString() }
+      : {}),
+    ...(input.decision?.replaySafety ? { replaySafety: input.decision.replaySafety } : {}),
+    userSeverity: severity,
+    ...(input.messagePreview ? { messagePreview: redactErrorPreview(input.messagePreview, 256) } : {}),
+  };
+}
+
+export function maxProviderTurnRetryAttempts(): number {
+  return PROVIDER_TURN_MAX_RETRIES;
+}
+
+function decideProviderTurnTransient(
+  reasonCode: string,
+  attempt: number,
+  replaySafety: ReplaySafety,
+): ProviderRetryDecision {
+  if (attempt <= PROVIDER_TURN_MAX_RETRIES) {
+    return retry(
+      reasonCode,
+      attempt,
+      PROVIDER_TURN_MAX_RETRIES,
+      PROVIDER_TURN_DELAYS_MS[attempt - 1] ?? 1500,
+      "foreground",
+      replaySafety,
+      "info",
+    );
+  }
+  return stop(`${reasonCode}_exhausted`, "exhausted", replaySafety, "error");
+}
+
+function decideProviderTurnCapacity(
+  reasonCode: string,
+  attempt: number,
+  retryAfterMs: number | undefined,
+  replaySafety: ReplaySafety,
+): ProviderRetryDecision {
+  if (replaySafety === "pre_provider") {
+    return decideProviderTurnTransient(reasonCode, attempt, replaySafety);
+  }
+  if (reasonCode === "provider_overloaded" && retryAfterMs === undefined && attempt <= PROVIDER_TURN_MAX_RETRIES) {
+    return retry(
+      reasonCode,
+      attempt,
+      PROVIDER_TURN_MAX_RETRIES,
+      PROVIDER_TURN_DELAYS_MS[attempt - 1] ?? 1500,
+      "foreground",
+      replaySafety,
+      "warning",
+    );
+  }
+  if (
+    retryAfterMs !== undefined &&
+    retryAfterMs <= PROVIDER_TURN_CAPACITY_SHORT_WAIT_MS &&
+    attempt <= PROVIDER_TURN_MAX_RETRIES
+  ) {
+    return retry(reasonCode, attempt, PROVIDER_TURN_MAX_RETRIES, retryAfterMs, "foreground", replaySafety, "warning");
+  }
+  return stop("capacity_wait_required", "capacity_wait_required", replaySafety, "warning");
+}
+
+function decideSessionTransient(
+  reasonCode: string,
+  attempt: number,
+  replaySafety: ReplaySafety,
+): ProviderRetryDecision {
+  const delayMs = Math.min(1000 * 2 ** (attempt - 1), SESSION_TRANSIENT_CAP_MS);
+  return retry(
+    reasonCode,
+    attempt,
+    undefined,
+    delayMs,
+    attempt <= SESSION_FOREGROUND_RETRIES ? "foreground" : "background",
+    replaySafety,
+    attempt <= SESSION_FOREGROUND_RETRIES ? "info" : "warning",
+  );
+}
+
+function decideSessionCapacity(
+  reasonCode: string,
+  attempt: number,
+  retryAfterMs: number | undefined,
+  replaySafety: ReplaySafety,
+): ProviderRetryDecision {
+  const backoffMs = Math.min(1000 * 2 ** (attempt - 1), SESSION_CAPACITY_CAP_MS);
+  return retry(reasonCode, attempt, undefined, retryAfterMs ?? backoffMs, "background", replaySafety, "warning");
+}
+
+function decideUnknown(scope: ProviderRetryScope, attempt: number, replaySafety: ReplaySafety): ProviderRetryDecision {
+  if (attempt <= UNKNOWN_MAX_RETRIES) {
+    return retry(
+      "unknown",
+      attempt,
+      UNKNOWN_MAX_RETRIES,
+      UNKNOWN_DELAYS_MS[attempt - 1] ?? 15_000,
+      scope === "provider_turn" ? "foreground" : "foreground",
+      replaySafety,
+      "warning",
+    );
+  }
+  return stop("unknown_exhausted", "exhausted", replaySafety, "error");
+}
+
+function retry(
+  reasonCode: string,
+  attempt: number,
+  maxAttempts: number | undefined,
+  delayMs: number,
+  retryMode: "foreground" | "background",
+  replaySafety: ReplaySafety,
+  userSeverity: "info" | "warning",
+): ProviderRetryDecision {
+  return {
+    action: "retry",
+    delayMs,
+    reasonCode,
+    attempt,
+    ...(maxAttempts ? { maxAttempts } : {}),
+    retryMode,
+    replaySafety,
+    userSeverity,
+  };
+}
+
+function stop(
+  reasonCode: string,
+  terminalKind: Extract<ProviderRetryDecision, { action: "stop" }>["terminalKind"],
+  replaySafety: ReplaySafety,
+  userSeverity: "warning" | "error",
+): ProviderRetryDecision {
+  return { action: "stop", reasonCode, terminalKind, replaySafety, userSeverity };
+}
+
+function isUnsafeReplay(replaySafety: ReplaySafety): boolean {
+  return replaySafety === "user_visible" || replaySafety === "unsafe" || replaySafety === "unknown";
+}
+
+type ErrorShape = {
+  name?: string;
+  message?: string;
+  code?: string | number;
+  status?: number;
+  statusCode?: number;
+  reason?: string;
+  retryAfterMs?: number;
+  retryAfter?: string | number;
+};
+
+function readErrorShape(err: unknown): ErrorShape {
+  if (err instanceof Error) {
+    const record = err as unknown as Record<string, unknown>;
+    return {
+      name: err.name,
+      message: err.message,
+      code: typeof record.code === "string" || typeof record.code === "number" ? record.code : undefined,
+      status: typeof record.status === "number" ? record.status : undefined,
+      statusCode: typeof record.statusCode === "number" ? record.statusCode : undefined,
+      reason: typeof record.reason === "string" ? record.reason : undefined,
+      retryAfterMs: typeof record.retryAfterMs === "number" ? record.retryAfterMs : undefined,
+      retryAfter:
+        typeof record.retryAfter === "string" || typeof record.retryAfter === "number" ? record.retryAfter : undefined,
+    };
+  }
+  if (typeof err === "string") return { message: err };
+  if (!err || typeof err !== "object") return { message: String(err) };
+  const record = err as Record<string, unknown>;
+  return {
+    name: typeof record.name === "string" ? record.name : undefined,
+    message: typeof record.message === "string" ? record.message : JSON.stringify(err),
+    code: typeof record.code === "string" || typeof record.code === "number" ? record.code : undefined,
+    status: typeof record.status === "number" ? record.status : undefined,
+    statusCode: typeof record.statusCode === "number" ? record.statusCode : undefined,
+    reason: typeof record.reason === "string" ? record.reason : undefined,
+    retryAfterMs: typeof record.retryAfterMs === "number" ? record.retryAfterMs : undefined,
+    retryAfter:
+      typeof record.retryAfter === "string" || typeof record.retryAfter === "number" ? record.retryAfter : undefined,
+  };
+}
+
+function readRetryAfterMs(shape: ErrorShape): number | undefined {
+  if (typeof shape.retryAfterMs === "number" && Number.isFinite(shape.retryAfterMs) && shape.retryAfterMs >= 0) {
+    return Math.floor(shape.retryAfterMs);
+  }
+  if (typeof shape.retryAfter === "number" && Number.isFinite(shape.retryAfter) && shape.retryAfter >= 0) {
+    return Math.floor(shape.retryAfter * 1000);
+  }
+  if (typeof shape.retryAfter === "string") {
+    const numeric = Number(shape.retryAfter);
+    if (Number.isFinite(numeric) && numeric >= 0) return Math.floor(numeric * 1000);
+    const dateMs = Date.parse(shape.retryAfter);
+    if (Number.isFinite(dateMs)) return Math.max(0, dateMs - Date.now());
+  }
+  return undefined;
+}
+
+function isCredential(text: string, base: Classification, status: number | undefined): boolean {
+  return (
+    status === 401 ||
+    status === 403 ||
+    base.reasonCode.includes("auth") ||
+    base.reasonCode.includes("unauthorized") ||
+    AUTH_HTTP_CODE_RE.test(text) ||
+    /unauthorized|forbidden|invalid api key|invalid_api_key|authentication|login required|not authenticated/.test(text)
+  );
+}
+
+function credentialReason(base: Classification): string {
+  return base.reasonCode === "unknown" ? "provider_credential_required" : base.reasonCode;
+}
+
+function isCapability(text: string, base: Classification): boolean {
+  return base.reasonCode.includes("binary_missing") || /binary missing|executable missing|unable to locate/.test(text);
+}
+
+function isConfiguration(text: string, base: Classification): boolean {
+  return (
+    base.reasonCode.includes("mismatch") ||
+    /provider mismatch|runtime_provider_mismatch|bad config|sandbox|approval/.test(text)
+  );
+}
+
+function configurationReason(base: Classification): string {
+  return base.reasonCode === "unknown" ? "provider_configuration_error" : base.reasonCode;
+}
+
+function isDeterministicInput(text: string, base: Classification): boolean {
+  return base.reasonCode.includes("context") || /context length|context_length|invalid request|bad request/.test(text);
+}
+
+function deterministicReason(base: Classification): string {
+  return base.reasonCode === "unknown" ? "provider_deterministic_input" : base.reasonCode;
+}
+
+function isCapacity(text: string, base: Classification, retryAfterMs: number | undefined): boolean {
+  return (
+    retryAfterMs !== undefined ||
+    base.reasonCode.includes("rate_limit") ||
+    /rate.?limit|usage limit|quota|insufficient_quota|overloaded|capacity/.test(text)
+  );
+}
+
+function isTransportText(text: string): boolean {
+  return (
+    TRANSIENT_HTTP_CODE_RE.test(text) ||
+    /server error|unavailable|timed out|timeout|fetch failed|network|econnreset|econnrefused|etimedout|epipe/.test(text)
+  );
+}
+
+function capacityReason(text: string, base: Classification): string {
+  if (/usage limit|quota|insufficient_quota/.test(text)) return "provider_usage_limit";
+  if (/overloaded|capacity/.test(text)) return "provider_overloaded";
+  if (/rate.?limit/.test(text) || base.reasonCode.includes("rate_limit")) return "provider_rate_limited";
+  return base.reasonCode === "unknown" ? "provider_capacity" : base.reasonCode;
+}
+
+function transientReason(base: Classification, provider: RuntimeProvider): string {
+  if (provider === "codex" && base.reasonCode.startsWith("claude_")) return "provider_transient_transport";
+  return base.reasonCode === "unknown" ? "provider_transient_transport" : base.reasonCode;
+}

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -4,14 +4,17 @@ import type {
   AgentRuntimeConfigPayload,
   GitRepo,
   InboxEntryWithMessage,
+  RuntimeProvider,
   RuntimeState,
   SessionEvent,
   SessionState,
 } from "@first-tree/shared";
 import {
   deriveRepoLocalPath,
+  encodeProviderRetryEventMessage,
   isImageBatchRefContent,
   isImageRefContent,
+  runtimeProviderSchema,
   SOURCE_REPOS_DIRNAME,
 } from "@first-tree/shared";
 import type { pino } from "../observability/logger.js";
@@ -22,7 +25,7 @@ import { type ContextTreeBinding, resolveAgentContextTreeBinding } from "./boots
 import type { SessionConfig } from "./config.js";
 import { reresolveUnboundTree } from "./context-tree-rebind.js";
 import type { SelfFence } from "./doc-snapshots.js";
-import { type Classification, clampRetryAttempt, classify, ERROR_KINDS, nextRetryDelayMs } from "./error-taxonomy.js";
+import { clampRetryAttempt } from "./error-taxonomy.js";
 import type {
   AgentHandler,
   AgentIdentity,
@@ -38,6 +41,12 @@ import type {
 } from "./handler.js";
 import { findImagePath, writeImage } from "./image-store.js";
 import { InboxDeliveryCoordinator } from "./inbox-delivery-coordinator.js";
+import {
+  buildProviderRetryEvent,
+  classifyProviderFailure,
+  decideProviderRetry,
+  type ProviderFailureClassification,
+} from "./provider-retry-policy.js";
 import { redactErrorPreview } from "./redact-error-preview.js";
 import { createResultSink, type Trigger } from "./result-sink.js";
 import { SessionRegistry } from "./session-registry.js";
@@ -66,6 +75,8 @@ type SessionEntry = {
    * structured logging.
    */
   lastRetryReason: string | null;
+  lastRetryCategory: ProviderFailureClassification["category"] | null;
+  lastRetryScope: "session_start" | "session_resume" | null;
   /**
    * Truncated raw message from the last transient failure. Surfaced into the
    * `resilience.session.retry_started` event payload alongside `reasonCode`
@@ -800,8 +811,24 @@ export class SessionManager {
     entry.retryNextAt = null;
     entry.retryTimer = null;
     entry.lastRetryReason = null;
+    entry.lastRetryCategory = null;
+    entry.lastRetryScope = null;
     entry.lastRetryRawError = null;
     entry.retryQueuedMessages = [];
+  }
+
+  private runtimeProvider(): RuntimeProvider {
+    const parsed = runtimeProviderSchema.safeParse(this.config.handlerConfig.runtimeProvider);
+    return parsed.success ? parsed.data : "claude-code";
+  }
+
+  private retryClassificationForEntry(entry: SessionEntry): ProviderFailureClassification {
+    return {
+      category: entry.lastRetryCategory ?? "unknown",
+      reasonCode: entry.lastRetryReason ?? "unknown",
+      message: entry.lastRetryRawError ?? entry.lastRetryReason ?? "unknown",
+      sourceKind: "transient",
+    };
   }
 
   private async recoverDebtBeforeResume(chatId: string, reason: string): Promise<boolean> {
@@ -1047,6 +1074,8 @@ export class SessionManager {
       retryNextAt: null,
       retryTimer: null,
       lastRetryReason: null,
+      lastRetryCategory: null,
+      lastRetryScope: null,
       lastRetryRawError: null,
       startMessage: message,
       retryQueuedMessages: [],
@@ -1082,7 +1111,11 @@ export class SessionManager {
     } catch (err) {
       if (this.sessions.get(chatId) !== entry) return;
       const phase: "start" | "resume" = evicted ? "resume" : "start";
-      const classification = classify(err, { source: "session" });
+      const classification = classifyProviderFailure(err, {
+        provider: this.runtimeProvider(),
+        scope: phase === "start" ? "session_start" : "session_resume",
+        source: "session",
+      });
       const handled = this.handleSessionFailure({
         entry,
         ctx,
@@ -1149,7 +1182,11 @@ export class SessionManager {
       this.persistRegistry();
     } catch (err) {
       if (this.sessions.get(entry.chatId) !== entry) return;
-      const classification = classify(err, { source: "session" });
+      const classification = classifyProviderFailure(err, {
+        provider: this.runtimeProvider(),
+        scope: "session_resume",
+        source: "session",
+      });
       const handled = this.handleSessionFailure({
         entry,
         ctx,
@@ -1182,20 +1219,31 @@ export class SessionManager {
     ctx: SessionContext;
     err: unknown;
     phase: "start" | "resume";
-    classification: Classification;
+    classification: ProviderFailureClassification;
   }): boolean {
     const { entry, ctx, err, phase, classification } = args;
     const errMsg = err instanceof Error ? err.message : String(err);
     const chatId = entry.chatId;
+    const provider = this.runtimeProvider();
+    const scope = phase === "start" ? "session_start" : "session_resume";
+    const nextAttempt = clampRetryAttempt(entry.retryAttempt + 1);
+    const decision = decideProviderRetry({
+      classification,
+      scope,
+      attempt: nextAttempt,
+      replaySafety: "pre_provider",
+    });
 
     this.config.log.error(
-      { chatId, err, phase, kind: classification.kind, reasonCode: classification.reasonCode },
+      { chatId, err, phase, category: classification.category, reasonCode: classification.reasonCode },
       "session start/resume failed",
     );
 
-    if (classification.kind === ERROR_KINDS.TRANSIENT) {
-      entry.retryAttempt = clampRetryAttempt(entry.retryAttempt + 1);
-      entry.lastRetryReason = classification.reasonCode;
+    if (decision.action === "retry") {
+      entry.retryAttempt = decision.attempt;
+      entry.lastRetryReason = decision.reasonCode;
+      entry.lastRetryCategory = classification.category;
+      entry.lastRetryScope = scope;
       // Truncate the raw err message to 256 chars and persist it on the entry
       // so retry_started can include it too. The web UI renders the encoded
       // payload as text, so any operator looking at a `reasonCode:"unknown"` /
@@ -1206,7 +1254,7 @@ export class SessionManager {
       // and this payload leaves the `safe in logs but NOT chat` boundary
       // — see Classification.message's contract in error-taxonomy.ts.
       entry.lastRetryRawError = errMsg ? redactErrorPreview(errMsg, 256) : null;
-      const delayMs = nextRetryDelayMs(classification.strategy, entry.retryAttempt);
+      const delayMs = decision.delayMs;
       entry.retryNextAt = Date.now() + delayMs;
       // Drop the active slot now so other chats can use it during the
       // backoff window — the retry will re-acquire when it runs.
@@ -1232,9 +1280,10 @@ export class SessionManager {
           chatId,
           attempt: entry.retryAttempt,
           nextDelayMs: delayMs,
-          reasonCode: classification.reasonCode,
+          reasonCode: decision.reasonCode,
+          category: classification.category,
           phase,
-          resilienceEvent: "resilience.session.retry_scheduled",
+          resilienceEvent: "provider_retry_scheduled",
         },
         "session transient failure — scheduling retry",
       );
@@ -1244,17 +1293,19 @@ export class SessionManager {
       // directly, so we encode it as a structured `error` event with the
       // resilience tag in the message prefix — see ResiliencePayload helper.
       try {
+        const payload = buildProviderRetryEvent({
+          event: "provider_retry_scheduled",
+          provider,
+          scope,
+          classification,
+          decision,
+          messagePreview: errMsg,
+        });
         ctx.emitEvent({
           kind: "error",
           payload: {
             source: "runtime",
-            message: encodeResilienceMessage("resilience.session.retry_scheduled", {
-              attempt: entry.retryAttempt,
-              nextDelayMs: delayMs,
-              reasonCode: classification.reasonCode,
-              phase,
-              rawError: entry.lastRetryRawError,
-            }),
+            message: encodeProviderRetryEventMessage(payload),
           },
         });
       } catch (emitErr) {
@@ -1271,8 +1322,8 @@ export class SessionManager {
       return true;
     }
 
-    // Permanent / degraded — legacy F2 signalling (server state + structured
-    // error event), then let caller tear down.
+    // Stop decision — legacy F2 teardown still owns ACK/recovery, but the
+    // visible signal is now the standard provider retry payload.
     entry.status = "errored";
     this.notifySessionState(chatId, "errored");
     this.projectSessionRuntime(chatId);
@@ -1283,11 +1334,19 @@ export class SessionManager {
       // event is rendered into chat-visible UI. Redact before slicing — slicing
       // first risks leaving a partial-token tail across the truncation point.
       const preview = redactErrorPreview(errMsg, 800);
+      const payload = buildProviderRetryEvent({
+        event: decision.terminalKind === "exhausted" ? "provider_retry_exhausted" : "provider_failure_terminal",
+        provider,
+        scope,
+        classification,
+        decision,
+        messagePreview: preview,
+      });
       ctx.emitEvent({
         kind: "error",
         payload: {
           source: "runtime",
-          message: `Session ${phase} failed: ${preview}`,
+          message: encodeProviderRetryEventMessage(payload),
         },
       });
     } catch (emitErr) {
@@ -1318,22 +1377,29 @@ export class SessionManager {
         chatId,
         attempt: entry.retryAttempt,
         reasonCode: entry.lastRetryReason,
-        resilienceEvent: "resilience.session.retry_started",
+        category: entry.lastRetryCategory,
+        resilienceEvent: "provider_retry_started",
       },
       "session transient retry — starting attempt",
     );
     // Design §6.1: emit via SessionContext.emitEvent (post-slot-acquire we
     // build the real ctx; here we use a lightweight onSessionEvent path).
     try {
+      const scope = entry.lastRetryScope ?? (previousAvailable(entry) ? "session_resume" : "session_start");
+      const classification = this.retryClassificationForEntry(entry);
       this.config.onSessionEvent?.(chatId, {
         kind: "error",
         payload: {
           source: "runtime",
-          message: encodeResilienceMessage("resilience.session.retry_started", {
-            attempt: entry.retryAttempt,
-            reasonCode: entry.lastRetryReason,
-            rawError: entry.lastRetryRawError,
-          }),
+          message: encodeProviderRetryEventMessage(
+            buildProviderRetryEvent({
+              event: "provider_retry_started",
+              provider: this.runtimeProvider(),
+              scope,
+              classification,
+              messagePreview: entry.lastRetryRawError,
+            }),
+          ),
         },
       });
     } catch (emitErr) {
@@ -1392,15 +1458,19 @@ export class SessionManager {
         this.markRouteOwned(chatId, message, receipt.route);
       }
       const totalAttempts = entry.retryAttempt;
+      const succeededScope = entry.lastRetryScope ?? (previousAvailable(entry) ? "session_resume" : "session_start");
+      const succeededClassification = this.retryClassificationForEntry(entry);
       entry.retryAttempt = 0;
       entry.retryNextAt = null;
       entry.lastRetryReason = null;
+      entry.lastRetryCategory = null;
+      entry.lastRetryScope = null;
       entry.lastRetryRawError = null;
       this.config.log.info(
         {
           chatId,
           sessionId: entry.claudeSessionId,
-          resilienceEvent: "resilience.session.retry_succeeded",
+          resilienceEvent: "provider_retry_succeeded",
         },
         "session transient retry succeeded",
       );
@@ -1409,9 +1479,15 @@ export class SessionManager {
           kind: "error",
           payload: {
             source: "runtime",
-            message: encodeResilienceMessage("resilience.session.retry_succeeded", {
-              totalAttempts,
-            }),
+            message: encodeProviderRetryEventMessage(
+              buildProviderRetryEvent({
+                event: "provider_retry_succeeded",
+                provider: this.runtimeProvider(),
+                scope: succeededScope,
+                classification: succeededClassification,
+                messagePreview: `retry succeeded after ${totalAttempts} attempt(s)`,
+              }),
+            ),
           },
         });
       } catch (emitErr) {
@@ -1421,12 +1497,17 @@ export class SessionManager {
       this.persistRegistry();
     } catch (err) {
       if (this.sessions.get(chatId) !== entry) return;
-      const classification = classify(err, { source: "session" });
+      const phase = previousAvailable(entry) ? "resume" : "start";
+      const classification = classifyProviderFailure(err, {
+        provider: this.runtimeProvider(),
+        scope: phase === "start" ? "session_start" : "session_resume",
+        source: "session",
+      });
       const handled = this.handleSessionFailure({
         entry,
         ctx,
         err,
-        phase: previousAvailable(entry) ? "resume" : "start",
+        phase,
         classification,
       });
       if (!handled) {

--- a/packages/server/src/__tests__/agent-chat-status.test.ts
+++ b/packages/server/src/__tests__/agent-chat-status.test.ts
@@ -1,5 +1,10 @@
 import { randomUUID } from "node:crypto";
-import { agentChatStatusSchema, type LiveActivity, RUNTIME_STALE_MS } from "@first-tree/shared";
+import {
+  agentChatStatusSchema,
+  encodeProviderRetryEventMessage,
+  type LiveActivity,
+  RUNTIME_STALE_MS,
+} from "@first-tree/shared";
 import { sql } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 import {
@@ -182,6 +187,71 @@ describe("agent-chat-status", () => {
       for (const s of await getChatAgentStatuses(app.db, chatId)) {
         expect(() => agentChatStatusSchema.parse(s)).not.toThrow();
       }
+    });
+
+    it("projects provider retry statusReason without feeding the derived main status", async () => {
+      const { app, peer, chatId } = await newChatWithAgent();
+      await bindPresence(peer.agent.uuid, peer.clientId);
+      await setSession(peer.agent.uuid, chatId, "active");
+      await insertEvent(peer.agent.uuid, chatId, 1, "error", {
+        message: encodeProviderRetryEventMessage({
+          event: "provider_retry_scheduled",
+          provider: "codex",
+          scope: "provider_turn",
+          category: "transient_transport",
+          reasonCode: "provider_transient_transport",
+          attempt: 1,
+          maxAttempts: 2,
+          retryMode: "foreground",
+          delayMs: 500,
+          nextRetryAt: "2026-06-22T10:00:00.000Z",
+          replaySafety: "pre_visible",
+          userSeverity: "info",
+          messagePreview: "fetch failed",
+        }),
+      });
+
+      const s = (await getChatAgentStatuses(app.db, chatId)).find((x) => x.agentId === peer.agent.uuid);
+      expect(s?.main).toBe("ready");
+      expect(s?.statusReason?.kind).toBe("retrying");
+      expect(s?.statusReason?.reasonCode).toBe("provider_transient_transport");
+      expect(() => agentChatStatusSchema.parse(s)).not.toThrow();
+    });
+
+    it("clears provider retry statusReason when the latest structured event is succeeded", async () => {
+      const { app, peer, chatId } = await newChatWithAgent();
+      await bindPresence(peer.agent.uuid, peer.clientId);
+      await setSession(peer.agent.uuid, chatId, "active");
+      await insertEvent(peer.agent.uuid, chatId, 1, "error", {
+        message: encodeProviderRetryEventMessage({
+          event: "provider_retry_scheduled",
+          provider: "codex",
+          scope: "provider_turn",
+          category: "transient_transport",
+          reasonCode: "provider_transient_transport",
+          attempt: 1,
+          maxAttempts: 2,
+          retryMode: "foreground",
+          delayMs: 500,
+          replaySafety: "pre_visible",
+          userSeverity: "info",
+        }),
+      });
+      await insertEvent(peer.agent.uuid, chatId, 2, "error", {
+        message: encodeProviderRetryEventMessage({
+          event: "provider_retry_succeeded",
+          provider: "codex",
+          scope: "provider_turn",
+          category: "transient_transport",
+          reasonCode: "provider_transient_transport",
+          replaySafety: "pre_visible",
+          userSeverity: "info",
+        }),
+      });
+
+      const s = (await getChatAgentStatuses(app.db, chatId)).find((x) => x.agentId === peer.agent.uuid);
+      expect(s?.main).toBe("ready");
+      expect(s?.statusReason).toBeUndefined();
     });
   });
 

--- a/packages/server/src/__tests__/agent-chat-status.test.ts
+++ b/packages/server/src/__tests__/agent-chat-status.test.ts
@@ -253,6 +253,32 @@ describe("agent-chat-status", () => {
       expect(s?.main).toBe("ready");
       expect(s?.statusReason).toBeUndefined();
     });
+
+    it("clears provider-turn retry statusReason when a later turn_end succeeds", async () => {
+      const { app, peer, chatId } = await newChatWithAgent();
+      await bindPresence(peer.agent.uuid, peer.clientId);
+      await setSession(peer.agent.uuid, chatId, "active");
+      await insertEvent(peer.agent.uuid, chatId, 1, "error", {
+        message: encodeProviderRetryEventMessage({
+          event: "provider_retry_scheduled",
+          provider: "codex",
+          scope: "provider_turn",
+          category: "transient_transport",
+          reasonCode: "provider_transient_transport",
+          attempt: 1,
+          maxAttempts: 2,
+          retryMode: "foreground",
+          delayMs: 500,
+          replaySafety: "pre_visible",
+          userSeverity: "info",
+        }),
+      });
+      await insertEvent(peer.agent.uuid, chatId, 2, "turn_end", { status: "success" });
+
+      const s = (await getChatAgentStatuses(app.db, chatId)).find((x) => x.agentId === peer.agent.uuid);
+      expect(s?.main).toBe("ready");
+      expect(s?.statusReason).toBeUndefined();
+    });
   });
 
   describe("withTurnNarration — sticky narration on the working activity", () => {

--- a/packages/server/src/services/agent-chat-status.ts
+++ b/packages/server/src/services/agent-chat-status.ts
@@ -283,33 +283,44 @@ async function deriveStatusReasons(
   const rawRows = (await db.execute(sql`
     SELECT acs.agent_id AS agent_id,
            acs.chat_id  AS chat_id,
+           e.kind       AS kind,
            e.payload    AS payload
       FROM agent_chat_sessions acs
       CROSS JOIN LATERAL (
-        SELECT payload, seq
+        SELECT kind, payload, seq
           FROM session_events se
          WHERE se.agent_id = acs.agent_id
            AND se.chat_id  = acs.chat_id
-           AND se.kind     = 'error'
+           AND se.kind     IN ('error', 'turn_end')
          ORDER BY se.seq DESC
-         LIMIT 5
+         LIMIT 10
       ) e
      WHERE acs.chat_id IN (${chatIdInClause})
+     ORDER BY acs.chat_id, acs.agent_id, e.seq DESC
   `)) as unknown as Array<{
     agent_id: string;
     chat_id: string;
+    kind: string;
     payload: unknown;
   }>;
 
   const seen = new Set<string>();
+  const latestSuccessfulTurnEnd = new Set<string>();
   for (const row of rawRows) {
     const key = pairKey(row.chat_id, row.agent_id);
     if (seen.has(key)) continue;
+    if (row.kind === "turn_end") {
+      const payload = row.payload as { status?: unknown } | null;
+      if (payload?.status === "success") latestSuccessfulTurnEnd.add(key);
+      continue;
+    }
+    if (row.kind !== "error") continue;
     const payload = row.payload as { message?: unknown } | null;
     if (typeof payload?.message !== "string") continue;
     const retryPayload = parseProviderRetryEventMessage(payload.message);
     if (!retryPayload) continue;
     seen.add(key);
+    if (retryPayload.scope === "provider_turn" && latestSuccessfulTurnEnd.has(key)) continue;
     const reason = statusReasonFromProviderRetryEvent(retryPayload);
     if (!reason) continue;
     let perAgent = out.get(row.chat_id);

--- a/packages/server/src/services/agent-chat-status.ts
+++ b/packages/server/src/services/agent-chat-status.ts
@@ -1,13 +1,16 @@
 import {
   type AgentChatStatus,
   type AgentEngagement,
+  type AgentStatusReason,
   ASSISTANT_TEXT_PREVIEW_MAX,
   type AssistantTextEventPayload,
   buildAgentChatStatus,
   LIVE_ACTIVITY_STALE_MS,
   type LiveActivity,
+  parseProviderRetryEventMessage,
   RUNTIME_STALE_MS,
   type RuntimeState,
+  statusReasonFromProviderRetryEvent,
   stripShellCommandDisplayWrapper,
   type ToolCallEventPayload,
 } from "@first-tree/shared";
@@ -266,6 +269,59 @@ async function deriveActivities(
   return out;
 }
 
+async function deriveStatusReasons(
+  db: Database,
+  chatIds: string[],
+): Promise<Map<string, Map<string, AgentStatusReason>>> {
+  const out = new Map<string, Map<string, AgentStatusReason>>();
+  if (chatIds.length === 0) return out;
+
+  const chatIdInClause = sql.join(
+    chatIds.map((id) => sql`${id}`),
+    sql`, `,
+  );
+  const rawRows = (await db.execute(sql`
+    SELECT acs.agent_id AS agent_id,
+           acs.chat_id  AS chat_id,
+           e.payload    AS payload
+      FROM agent_chat_sessions acs
+      CROSS JOIN LATERAL (
+        SELECT payload, seq
+          FROM session_events se
+         WHERE se.agent_id = acs.agent_id
+           AND se.chat_id  = acs.chat_id
+           AND se.kind     = 'error'
+         ORDER BY se.seq DESC
+         LIMIT 5
+      ) e
+     WHERE acs.chat_id IN (${chatIdInClause})
+  `)) as unknown as Array<{
+    agent_id: string;
+    chat_id: string;
+    payload: unknown;
+  }>;
+
+  const seen = new Set<string>();
+  for (const row of rawRows) {
+    const key = pairKey(row.chat_id, row.agent_id);
+    if (seen.has(key)) continue;
+    const payload = row.payload as { message?: unknown } | null;
+    if (typeof payload?.message !== "string") continue;
+    const retryPayload = parseProviderRetryEventMessage(payload.message);
+    if (!retryPayload) continue;
+    seen.add(key);
+    const reason = statusReasonFromProviderRetryEvent(retryPayload);
+    if (!reason) continue;
+    let perAgent = out.get(row.chat_id);
+    if (!perAgent) {
+      perAgent = new Map();
+      out.set(row.chat_id, perAgent);
+    }
+    perAgent.set(row.agent_id, reason);
+  }
+  return out;
+}
+
 // ---------------------------------------------------------------------------
 // The producer
 // ---------------------------------------------------------------------------
@@ -361,10 +417,12 @@ export async function resolveAgentChatStatuses(
   //    current activity description", not "agent is not working" (which is
   //    decided by `computeWorking` above).
   const activityByChat = await deriveActivities(db, chatIds, opts);
+  const statusReasonByChat = await deriveStatusReasons(db, chatIds);
 
   const now = Date.now();
   for (const [chatId, agentSet] of unionByChat) {
     const perAgentActivity = activityByChat.get(chatId);
+    const perAgentStatusReason = statusReasonByChat.get(chatId);
     const arr: AgentChatStatus[] = [];
     for (const agentId of agentSet) {
       const sess = sessionByPair.get(pairKey(chatId, agentId));
@@ -393,6 +451,7 @@ export async function resolveAgentChatStatuses(
           // aren't in chainSessionOp) briefly emits activity=null; the next
           // runtime frame self-heals.
           activity: working ? activity : null,
+          statusReason: perAgentStatusReason?.get(agentId),
         }),
       );
     }

--- a/packages/shared/src/__tests__/agent-status.test.ts
+++ b/packages/shared/src/__tests__/agent-status.test.ts
@@ -90,6 +90,29 @@ describe("agentChatStatusSchema", () => {
     expect(parsed.main).toBe("working");
   });
 
+  it("accepts statusReason without feeding it into main derivation", () => {
+    const parsed = agentChatStatusSchema.parse({
+      agentId: "agent-1",
+      main: "ready",
+      reachable: true,
+      engagement: "active",
+      working: false,
+      errored: false,
+      activity: null,
+      statusReason: {
+        kind: "waiting",
+        severity: "warning",
+        provider: "codex",
+        scope: "session_resume",
+        category: "provider_capacity",
+        reasonCode: "provider_capacity",
+        label: "Waiting for provider capacity",
+      },
+    });
+    expect(parsed.main).toBe("ready");
+    expect(parsed.statusReason?.kind).toBe("waiting");
+  });
+
   it("rejects the runtime-A vocabulary (idle/blocked are not composite main values)", () => {
     // Guards against the two-vocabulary confusion this module exists to prevent.
     expect(agentMainStatusSchema.safeParse("idle").success).toBe(false);
@@ -132,6 +155,30 @@ describe("buildAgentChatStatus", () => {
       engagement: "active",
     });
     expect(status.main).toBe("offline");
+    expect(agentChatStatusSchema.safeParse(status).success).toBe(true);
+  });
+
+  it("preserves statusReason while deriving main from the axes", () => {
+    const status = buildAgentChatStatus({
+      agentId: "agent-1",
+      reachable: true,
+      errored: false,
+      working: false,
+      engagement: "active",
+      statusReason: {
+        kind: "retrying",
+        severity: "info",
+        provider: "claude-code",
+        scope: "provider_turn",
+        category: "transient_transport",
+        reasonCode: "provider_transient_transport",
+        label: "Retrying provider",
+        attempt: 1,
+        maxAttempts: 3,
+      },
+    });
+    expect(status.main).toBe("ready");
+    expect(status.statusReason?.kind).toBe("retrying");
     expect(agentChatStatusSchema.safeParse(status).success).toBe(true);
   });
 });

--- a/packages/shared/src/__tests__/session-event-schema.test.ts
+++ b/packages/shared/src/__tests__/session-event-schema.test.ts
@@ -1,4 +1,9 @@
 import { describe, expect, it } from "vitest";
+import {
+  encodeProviderRetryEventMessage,
+  parseProviderRetryEventMessage,
+  statusReasonFromProviderRetryEvent,
+} from "../schemas/provider-retry.js";
 import { sessionEventSchema } from "../schemas/session-event.js";
 
 describe("sessionEventSchema", () => {
@@ -94,6 +99,38 @@ describe("sessionEventSchema", () => {
         payload: { source: "sdk", message: "x".repeat(2001) },
       });
       expect(r.success).toBe(false);
+    });
+
+    it("round-trips provider retry payloads through the encoded bridge", () => {
+      const message = encodeProviderRetryEventMessage({
+        event: "provider_retry_scheduled",
+        provider: "codex",
+        scope: "provider_turn",
+        category: "transient_transport",
+        reasonCode: "provider_transient_transport",
+        attempt: 1,
+        maxAttempts: 3,
+        retryMode: "foreground",
+        delayMs: 1000,
+        replaySafety: "pre_visible",
+        userSeverity: "info",
+      });
+      const parsed = parseProviderRetryEventMessage(message);
+      expect(parsed).toMatchObject({
+        event: "provider_retry_scheduled",
+        provider: "codex",
+        scope: "provider_turn",
+        category: "transient_transport",
+      });
+      expect(parsed ? statusReasonFromProviderRetryEvent(parsed) : null).toMatchObject({
+        kind: "retrying",
+        label: "Retrying provider",
+      });
+    });
+
+    it("ignores malformed provider retry bridge messages", () => {
+      expect(parseProviderRetryEventMessage("provider.retry: nope")).toBeNull();
+      expect(parseProviderRetryEventMessage("plain sdk failure")).toBeNull();
     });
   });
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -626,6 +626,24 @@ export {
   sessionStateSchema,
 } from "./schemas/presence.js";
 export {
+  type AgentStatusReason,
+  agentStatusReasonSchema,
+  encodeProviderRetryEventMessage,
+  PROVIDER_RETRY_EVENT_MESSAGE_PREFIX,
+  type ProviderFailureCategory,
+  type ProviderRetryEventName,
+  type ProviderRetryEventPayload,
+  type ProviderRetryScope,
+  parseProviderRetryEventMessage,
+  providerFailureCategorySchema,
+  providerRetryEventNameSchema,
+  providerRetryEventPayloadSchema,
+  providerRetryScopeSchema,
+  type ReplaySafety,
+  replaySafetySchema,
+  statusReasonFromProviderRetryEvent,
+} from "./schemas/provider-retry.js";
+export {
   type PulseBucket,
   type PulseTick,
   pulseBucketSchema,

--- a/packages/shared/src/schemas/agent-status.ts
+++ b/packages/shared/src/schemas/agent-status.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { type LiveActivity, liveActivitySchema } from "./me-chat.js";
+import { type AgentStatusReason, agentStatusReasonSchema } from "./provider-retry.js";
 
 /**
  * Composite "main" status — the single value a compact surface (a status
@@ -137,6 +138,12 @@ export const agentChatStatusSchema = z
      * a second round-trip. Not an input to `main` — purely descriptive.
      */
     activity: liveActivitySchema.nullable(),
+    /**
+     * Current retry/waiting/terminal reason projected from runtime-owned
+     * resilience events. Descriptive only: it is not an input to `main`, and
+     * consumers must not infer busy state from it.
+     */
+    statusReason: agentStatusReasonSchema.optional(),
   })
   .superRefine((val, ctx) => {
     const expected = deriveMainStatus(val);
@@ -152,7 +159,11 @@ export type AgentChatStatus = z.infer<typeof agentChatStatusSchema>;
 
 /** Inputs to `buildAgentChatStatus` — the axis fields plus the agent id and
  * the optional descriptive live activity. */
-export type AgentChatStatusInput = DeriveMainStatusInput & { agentId: string; activity?: LiveActivity | null };
+export type AgentChatStatusInput = DeriveMainStatusInput & {
+  agentId: string;
+  activity?: LiveActivity | null;
+  statusReason?: AgentStatusReason;
+};
 
 /**
  * Construct an `AgentChatStatus` with `main` always derived from the axes
@@ -168,5 +179,6 @@ export function buildAgentChatStatus(input: AgentChatStatusInput): AgentChatStat
     errored: input.errored,
     main: deriveMainStatus(input),
     activity: input.activity ?? null,
+    ...(input.statusReason ? { statusReason: input.statusReason } : {}),
   };
 }

--- a/packages/shared/src/schemas/provider-retry.ts
+++ b/packages/shared/src/schemas/provider-retry.ts
@@ -1,0 +1,122 @@
+import { z } from "zod";
+import { runtimeProviderSchema } from "./runtime-provider.js";
+
+export const providerRetryScopeSchema = z.enum(["session_start", "session_resume", "provider_turn"]);
+export type ProviderRetryScope = z.infer<typeof providerRetryScopeSchema>;
+
+export const providerFailureCategorySchema = z.enum([
+  "transient_transport",
+  "provider_capacity",
+  "credential",
+  "capability",
+  "configuration",
+  "deterministic_input",
+  "unknown",
+]);
+export type ProviderFailureCategory = z.infer<typeof providerFailureCategorySchema>;
+
+export const replaySafetySchema = z.enum([
+  "pre_provider",
+  "pre_visible",
+  "provider_entered",
+  "user_visible",
+  "unsafe",
+  "unknown",
+]);
+export type ReplaySafety = z.infer<typeof replaySafetySchema>;
+
+export const providerRetryEventNameSchema = z.enum([
+  "provider_retry_scheduled",
+  "provider_retry_started",
+  "provider_retry_succeeded",
+  "provider_retry_exhausted",
+  "provider_failure_terminal",
+]);
+export type ProviderRetryEventName = z.infer<typeof providerRetryEventNameSchema>;
+
+export const providerRetryEventPayloadSchema = z.object({
+  event: providerRetryEventNameSchema,
+  provider: runtimeProviderSchema,
+  scope: providerRetryScopeSchema,
+  category: providerFailureCategorySchema,
+  reasonCode: z.string().min(1),
+  attempt: z.number().int().positive().optional(),
+  maxAttempts: z.number().int().positive().optional(),
+  retryMode: z.enum(["foreground", "background"]).optional(),
+  delayMs: z.number().int().nonnegative().optional(),
+  nextRetryAt: z.string().optional(),
+  replaySafety: replaySafetySchema.optional(),
+  userSeverity: z.enum(["info", "warning", "error"]),
+  messagePreview: z.string().max(800).optional(),
+});
+export type ProviderRetryEventPayload = z.infer<typeof providerRetryEventPayloadSchema>;
+
+export const agentStatusReasonSchema = z.object({
+  kind: z.enum(["retrying", "waiting", "terminal"]),
+  severity: z.enum(["info", "warning", "error"]),
+  provider: runtimeProviderSchema,
+  scope: providerRetryScopeSchema,
+  category: providerFailureCategorySchema,
+  reasonCode: z.string().min(1),
+  label: z.string().min(1),
+  detail: z.string().optional(),
+  attempt: z.number().int().positive().optional(),
+  maxAttempts: z.number().int().positive().optional(),
+  nextRetryAt: z.string().optional(),
+});
+export type AgentStatusReason = z.infer<typeof agentStatusReasonSchema>;
+
+export const PROVIDER_RETRY_EVENT_MESSAGE_PREFIX = "provider.retry:";
+
+export function encodeProviderRetryEventMessage(payload: ProviderRetryEventPayload): string {
+  return `${PROVIDER_RETRY_EVENT_MESSAGE_PREFIX} ${JSON.stringify(providerRetryEventPayloadSchema.parse(payload))}`;
+}
+
+export function parseProviderRetryEventMessage(message: string): ProviderRetryEventPayload | null {
+  if (!message.startsWith(PROVIDER_RETRY_EVENT_MESSAGE_PREFIX)) return null;
+  const raw = message.slice(PROVIDER_RETRY_EVENT_MESSAGE_PREFIX.length).trim();
+  if (!raw) return null;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    const result = providerRetryEventPayloadSchema.safeParse(parsed);
+    return result.success ? result.data : null;
+  } catch {
+    return null;
+  }
+}
+
+export function statusReasonFromProviderRetryEvent(payload: ProviderRetryEventPayload): AgentStatusReason | null {
+  if (payload.event === "provider_retry_succeeded") return null;
+
+  const terminal = payload.event === "provider_retry_exhausted" || payload.event === "provider_failure_terminal";
+  const kind: AgentStatusReason["kind"] = terminal
+    ? "terminal"
+    : payload.retryMode === "background"
+      ? "waiting"
+      : "retrying";
+
+  return agentStatusReasonSchema.parse({
+    kind,
+    severity: payload.userSeverity,
+    provider: payload.provider,
+    scope: payload.scope,
+    category: payload.category,
+    reasonCode: payload.reasonCode,
+    label: statusReasonLabel(kind, payload),
+    detail: payload.messagePreview,
+    attempt: payload.attempt,
+    maxAttempts: payload.maxAttempts,
+    nextRetryAt: payload.nextRetryAt,
+  });
+}
+
+function statusReasonLabel(kind: AgentStatusReason["kind"], payload: ProviderRetryEventPayload): string {
+  if (kind === "waiting") {
+    if (payload.category === "provider_capacity") return "Waiting for provider capacity";
+    return "Waiting to retry provider";
+  }
+  if (kind === "retrying") return "Retrying provider";
+  if (payload.reasonCode === "capacity_wait_required") return "Provider capacity limit";
+  if (payload.event === "provider_retry_exhausted") return "Provider retry exhausted";
+  return "Provider failure";
+}

--- a/packages/web/src/components/chat/__tests__/compose-status-bar.test.ts
+++ b/packages/web/src/components/chat/__tests__/compose-status-bar.test.ts
@@ -1,6 +1,6 @@
 import { type AgentChatStatusInput, buildAgentChatStatus, MAIN_STATUS_PRIORITY } from "@first-tree/shared";
 import { describe, expect, it } from "vitest";
-import { pickLead, selectAttention } from "../compose-status-bar.js";
+import { pickLead, selectAttention, statusReasonView } from "../compose-status-bar.js";
 
 const mk = (agentId: string, over: Partial<AgentChatStatusInput>) =>
   buildAgentChatStatus({
@@ -32,6 +32,66 @@ describe("selectAttention — the bar surfaces only actionable/active states, mo
     const out = selectAttention([mk("w", { working: true }), mk("f", { errored: true })]);
     const idx = out.map((s) => MAIN_STATUS_PRIORITY.indexOf(s.main));
     expect(idx).toEqual([...idx].sort((x, y) => x - y));
+  });
+
+  it("surfaces provider retry reasons without requiring the status to be working", () => {
+    const retrying = mk("retrying", {
+      statusReason: {
+        kind: "retrying",
+        severity: "info",
+        provider: "codex",
+        scope: "provider_turn",
+        category: "transient_transport",
+        reasonCode: "provider_transient_transport",
+        label: "Retrying provider",
+      },
+    });
+    const waiting = mk("waiting", {
+      statusReason: {
+        kind: "waiting",
+        severity: "warning",
+        provider: "codex",
+        scope: "session_resume",
+        category: "provider_capacity",
+        reasonCode: "provider_rate_limited",
+        label: "Waiting for provider capacity",
+      },
+    });
+    const terminal = mk("terminal", {
+      statusReason: {
+        kind: "terminal",
+        severity: "error",
+        provider: "codex",
+        scope: "provider_turn",
+        category: "unknown",
+        reasonCode: "unknown_exhausted",
+        label: "Provider retry exhausted",
+      },
+    });
+    const terminalWarning = mk("terminal-warning", {
+      statusReason: {
+        kind: "terminal",
+        severity: "warning",
+        provider: "codex",
+        scope: "provider_turn",
+        category: "provider_capacity",
+        reasonCode: "capacity_wait_required",
+        label: "Provider capacity limit",
+      },
+    });
+
+    expect(selectAttention([retrying, waiting, terminalWarning, terminal]).map((s) => s.agentId)).toEqual([
+      "terminal",
+      "terminal-warning",
+      "waiting",
+      "retrying",
+    ]);
+    expect(retrying.main).toBe("ready");
+    expect(waiting.main).toBe("ready");
+    expect(terminal.main).toBe("ready");
+    expect(terminalWarning.main).toBe("ready");
+    expect(statusReasonView(terminal)?.colorVar).toBe("var(--state-error)");
+    expect(statusReasonView(terminalWarning)?.colorVar).toBe("var(--state-blocked)");
   });
 });
 

--- a/packages/web/src/components/chat/agent-status-panel.tsx
+++ b/packages/web/src/components/chat/agent-status-panel.tsx
@@ -215,6 +215,30 @@ function SecondLine({ status, mounted }: { status: AgentChatStatus | null; mount
       </div>
     );
   }
+  if (status.statusReason) {
+    const tone =
+      status.statusReason.severity === "error"
+        ? "error"
+        : status.statusReason.severity === "warning"
+          ? "blocked"
+          : "idle";
+    const pill = <StatePill tone={tone} label={status.statusReason.label} />;
+    if (status.statusReason.kind === "terminal" && status.statusReason.severity === "error") {
+      return (
+        <div className="flex">
+          <TimelineJumpButton
+            agentId={status.agentId}
+            main="failed"
+            anchored={isJumpable(mounted, "failed", status.agentId)}
+            ariaLabel="Jump to this agent's error in the timeline"
+          >
+            {pill}
+          </TimelineJumpButton>
+        </div>
+      );
+    }
+    return <div className="flex min-w-0">{pill}</div>;
+  }
   if (status.main === "working" && status.activity) {
     // "Working" (sans word) · "Bash · 0s" (mono tool + live timer). No leading
     // pulse dot — the avatar already carries the breathing status dot. The
@@ -266,7 +290,7 @@ function SecondLine({ status, mounted }: { status: AgentChatStatus | null; mount
  * sans (not mono): the status word is natural language. Geometry mirrors
  * DenseBadge; tone colours come from the shared `tones` map.
  */
-function StatePill({ tone, label }: { tone: "blocked" | "error"; label: string }) {
+function StatePill({ tone, label }: { tone: "blocked" | "error" | "idle"; label: string }) {
   const t = toneOf(tone);
   return (
     <span

--- a/packages/web/src/components/chat/compose-status-bar.tsx
+++ b/packages/web/src/components/chat/compose-status-bar.tsx
@@ -48,7 +48,7 @@ const EXPANDED_MAX_HEIGHT = 180;
 /** A failure preempts the working-lead anti-flicker hold (see {@link pickLead}).
  *  "alert" is just "failed". */
 function isAlert(s: AgentChatStatus): boolean {
-  return s.main === "failed";
+  return s.main === "failed" || isFatalStatusReason(s);
 }
 
 function activityStartedMs(s: AgentChatStatus): number {
@@ -61,7 +61,22 @@ function activityStartedMs(s: AgentChatStatus): number {
  * Exported for tests.
  */
 export function selectAttention(statuses: AgentChatStatus[]): AgentChatStatus[] {
-  return statuses.filter((s) => ATTENTION.has(s.main)).sort((a, b) => compareMainStatus(a.main, b.main));
+  return statuses
+    .filter((s) => ATTENTION.has(s.main) || s.statusReason !== undefined)
+    .sort((a, b) => attentionRank(a) - attentionRank(b) || compareMainStatus(a.main, b.main));
+}
+
+function attentionRank(status: AgentChatStatus): number {
+  if (status.main === "failed" || isFatalStatusReason(status)) return 0;
+  if (status.main === "working") return 1;
+  if (status.statusReason?.kind === "terminal") return 2;
+  if (status.statusReason?.kind === "waiting") return 3;
+  if (status.statusReason?.kind === "retrying") return 4;
+  return 5;
+}
+
+function isFatalStatusReason(status: AgentChatStatus): boolean {
+  return status.statusReason?.kind === "terminal" && status.statusReason.severity === "error";
 }
 
 /**
@@ -216,6 +231,11 @@ function RailRow({
   mounted: ReadonlySet<string>;
 }) {
   const view = viewOf(status.main);
+  const reasonView = statusReasonView(status);
+  const colorVar = reasonView?.colorVar ?? view.colorVar;
+  const shape = reasonView?.shape ?? view.shape;
+  const pulse = reasonView?.pulse ?? view.pulse;
+  const label = reasonView?.label ?? view.label;
   const jumpable = isJumpable(mounted, status.main, status.agentId);
   return (
     <div className="flex min-w-0 flex-1 items-center" style={{ gap: "var(--sp-1_5)" }}>
@@ -225,9 +245,9 @@ function RailRow({
         anchored={jumpable}
         ariaLabel={`Jump to ${nameOf(status.agentId)} in the timeline`}
         className="flex-1 text-caption"
-        style={{ color: view.colorVar }}
+        style={{ color: colorVar }}
       >
-        <StatusGlyph colorVar={view.colorVar} shape={view.shape} pulse={view.pulse} size={8} ariaLabel={view.label} />
+        <StatusGlyph colorVar={colorVar} shape={shape} pulse={pulse} size={8} ariaLabel={label} />
         <span className="shrink-0">{nameOf(status.agentId)}</span>
         <Sep />
         <LeadDetail status={status} />
@@ -239,8 +259,33 @@ function RailRow({
 /** The detail after the name: a short reason (failed) or the live activity
  *  (working). */
 function LeadDetail({ status }: { status: AgentChatStatus }) {
+  if (status.statusReason) {
+    const detail = status.statusReason.detail ?? status.statusReason.reasonCode;
+    return (
+      <span className="truncate" title={detail}>
+        {status.statusReason.label}
+      </span>
+    );
+  }
   if (status.main === "failed") return <span className="truncate">failed</span>;
   return <WorkingDetail activity={status.activity} />;
+}
+
+export function statusReasonView(status: AgentChatStatus) {
+  const reason = status.statusReason;
+  if (!reason) return null;
+  if (reason.kind === "terminal") {
+    return {
+      colorVar: reason.severity === "error" ? "var(--state-error)" : "var(--state-blocked)",
+      shape: "dot" as const,
+      pulse: null,
+      label: reason.label,
+    };
+  }
+  if (reason.kind === "waiting") {
+    return { colorVar: "var(--state-blocked)", shape: "pause" as const, pulse: null, label: reason.label };
+  }
+  return { colorVar: "var(--state-idle)", shape: "dot" as const, pulse: "working" as const, label: reason.label };
 }
 
 /**

--- a/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
@@ -1,6 +1,11 @@
 // @vitest-environment happy-dom
 
-import type { Agent, ChatDetail, ChatParticipantDetail } from "@first-tree/shared";
+import {
+  type Agent,
+  type ChatDetail,
+  type ChatParticipantDetail,
+  encodeProviderRetryEventMessage,
+} from "@first-tree/shared";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, type ReactElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
@@ -783,6 +788,47 @@ describe("ChatView", () => {
     expect(onJoin).toHaveBeenCalledTimes(1);
     await act(async () => readOnly.root.unmount());
 
+    await act(async () => root.unmount());
+  });
+
+  it("renders provider retry events as non-fatal timeline rows when severity is not error", async () => {
+    const { ChatView } = await import("../chat-view.js");
+    const { container, root } = await renderDom(<ChatView agentId="agent-1" chatId="chat-1" />, (queryClient) => {
+      queryClient.setQueryData(["session-events", "agent-1", "chat-1"], {
+        items: [
+          {
+            id: "retry-event",
+            agentId: "agent-1",
+            chatId: "chat-1",
+            seq: 1,
+            kind: "error",
+            payload: {
+              source: "runtime",
+              message: encodeProviderRetryEventMessage({
+                event: "provider_retry_scheduled",
+                provider: "codex",
+                scope: "provider_turn",
+                category: "transient_transport",
+                reasonCode: "provider_transient_transport",
+                attempt: 1,
+                maxAttempts: 2,
+                retryMode: "foreground",
+                delayMs: 500,
+                replaySafety: "pre_visible",
+                userSeverity: "info",
+                messagePreview: "fetch failed",
+              }),
+            },
+            createdAt: "2026-05-28T11:56:30.000Z",
+          },
+        ] satisfies SessionEventRow[],
+        nextCursor: null,
+      });
+    });
+
+    await waitForText(container, "Retrying provider");
+    expect(container.textContent).toContain("fetch failed");
+    expect(container.querySelector("[data-error-agent]")).toBeNull();
     await act(async () => root.unmount());
   });
 

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -10,7 +10,9 @@ import {
   isImageBatchRefContent,
   isImageRefContent,
   type MentionParticipant,
+  parseProviderRetryEventMessage,
   type RequestResolution,
+  statusReasonFromProviderRetryEvent,
 } from "@first-tree/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
@@ -230,25 +232,54 @@ function ReadReceipt({ msg, myAgentId }: { msg: MessageWithDelivery; myAgentId: 
 
 function ErrorRow({ event, agentNameFn }: { event: SessionEventRow; agentNameFn?: (id: string) => string }) {
   const payload = asErrorPayload(event.payload);
+  const retryPayload = payload ? parseProviderRetryEventMessage(payload.message) : null;
+  const retryReason = retryPayload ? statusReasonFromProviderRetryEvent(retryPayload) : null;
   const ts = formatClockTime(event.createdAt);
   // Resolve the emitting agent so the header reads "error · <agent> · runtime · …".
   // Falls back gracefully if the lookup function isn't provided (legacy callers).
   const agentName = agentNameFn ? agentNameFn(event.agentId) : null;
+  const fatal = !retryPayload || retryPayload.userSeverity === "error";
+  const color =
+    retryPayload?.userSeverity === "info"
+      ? "var(--fg-4)"
+      : retryPayload?.userSeverity === "warning"
+        ? "var(--state-blocked)"
+        : "var(--state-error)";
+  const wash =
+    retryPayload?.userSeverity === "info"
+      ? "color-mix(in oklch, var(--fg-4) 6%, transparent)"
+      : retryPayload?.userSeverity === "warning"
+        ? "color-mix(in oklch, var(--state-blocked) 8%, transparent)"
+        : "color-mix(in oklch, var(--state-error) 6%, transparent)";
+  const label = retryPayload ? retryPayload.event.replace(/^provider_/, "").replace(/_/g, " ") : "error";
+  const message = retryPayload
+    ? [
+        retryReason?.label ?? label,
+        retryPayload.attempt
+          ? `attempt ${retryPayload.attempt}${retryPayload.maxAttempts ? `/${retryPayload.maxAttempts}` : ""}`
+          : null,
+        retryPayload.nextRetryAt ? `next ${formatClockTime(retryPayload.nextRetryAt)}` : null,
+        retryPayload.messagePreview,
+      ]
+        .filter(Boolean)
+        .join(" · ")
+    : (payload?.message ?? "(invalid error payload)");
   return (
     <div
       // Anchor for the compose rail's jump-to-timeline (failed → this agent's error).
-      data-error-agent={event.agentId}
+      data-error-agent={fatal ? event.agentId : undefined}
       style={{
         padding: "var(--sp-1_5) var(--sp-2_5)",
-        borderLeft: "var(--hairline-bold) solid var(--state-error)",
+        borderLeft: `var(--hairline-bold) solid ${color}`,
         // Intentionally fainter than --state-error-soft (14%): this inline error row
         // already carries a solid --hairline-bold error borderLeft, so the wash stays at 6%.
-        background: "color-mix(in oklch, var(--state-error) 6%, transparent)",
+        background: wash,
         borderRadius: "0 var(--radius-input) var(--radius-input) 0",
       }}
     >
-      <div className="mono uppercase text-caption" style={{ color: "var(--state-error)" }}>
-        error{agentName ? ` · ${agentName}` : ""} · {payload?.source ?? "unknown"} · {ts}
+      <div className="mono uppercase text-caption" style={{ color }}>
+        {label}
+        {agentName ? ` · ${agentName}` : ""} · {payload?.source ?? "unknown"} · {ts}
       </div>
       <div
         className="text-label"
@@ -258,7 +289,7 @@ function ErrorRow({ event, agentNameFn }: { event: SessionEventRow; agentNameFn?
           whiteSpace: "pre-wrap",
         }}
       >
-        {payload?.message ?? "(invalid error payload)"}
+        {message}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add a shared provider retry payload/statusReason schema and a client-side provider retry policy helper
- route SessionManager start/resume, Claude, and Codex retry decisions through the shared policy while keeping handler-owned retry execution
- project provider retry statusReason to agent status and render retry/waiting/terminal states in Web without treating info/warning retries as fatal errors

## Safety Boundaries
- provider-turn decisions still only return retry/stop, not a generic recover action
- Codex provider-entered capacity/rate-limit stop is consumed/actionable and does not redeliver the same provider-entered input
- Codex pre-provider exhausted transport failures remain retryable through the existing token.retry/recovery path
- AgentChatStatus.statusReason is descriptive only and does not feed deriveMainStatus or busyAgentIds

## Tests
- pnpm check
- pnpm typecheck
- pnpm --filter @first-tree/shared test --pool=threads --poolOptions.threads.maxThreads=2 --poolOptions.threads.minThreads=1 src/__tests__/session-event-schema.test.ts src/__tests__/agent-status.test.ts --reporter=dot
- pnpm --filter @first-tree/client test --pool=threads --poolOptions.threads.maxThreads=2 --poolOptions.threads.minThreads=1 src/__tests__/provider-retry-policy.test.ts src/__tests__/codex-usage-limit.test.ts src/__tests__/codex-resilience.test.ts src/__tests__/codex-retry-abort.test.ts src/__tests__/session-manager-retry.test.ts --reporter=dot
- pnpm --filter @first-tree/server test --pool=threads --poolOptions.threads.maxThreads=2 --poolOptions.threads.minThreads=1 src/__tests__/agent-chat-status.test.ts --reporter=dot
- pnpm --filter @first-tree/web test --pool=threads --poolOptions.threads.maxThreads=2 --poolOptions.threads.minThreads=1 src/components/chat/__tests__/compose-status-bar.test.ts src/components/chat/__tests__/agent-status-panel.test.ts src/pages/workspace/center/__tests__/chat-view-dom.test.tsx --reporter=dot

Note: the Web DOM suite still prints existing ECONNREFUSED 127.0.0.1:3000 stderr noise, but exits successfully.

## Review
- Reviewed by codex-reviewer in First Tree chat; blocking findings were fixed and复审 passed.