### PR TITLE
feat(web): agent-detail P2 — Instructions result-first, Usage slim, info cleanup

### DIFF
--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -1927,6 +1927,13 @@ body:has(#onboarding-preview-root) hearback-widget {
   border-top: var(--hairline) solid var(--border-faint);
 }
 
+/* Agent-detail: drop the bottom hairline on a section's last row/block so it
+   doesn't double up with the gap before the next section. Inter-row lines stay;
+   only the trailing one goes. Beats the rows' inline border-bottom (!important). */
+.ad-tail-trim > :last-child {
+  border-bottom: 0 !important;
+}
+
 .usage-turn-table th {
   padding: var(--sp-2) var(--sp-2_5);
   text-transform: uppercase;

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -1908,16 +1908,6 @@ body:has(#onboarding-preview-root) hearback-widget {
   min-width: var(--sp-20);
 }
 
-.usage-model-chip {
-  display: inline-flex;
-  align-items: center;
-  padding: 1px var(--sp-1_75);
-  border-radius: var(--radius-chip);
-  background: var(--bg-sunken);
-  color: var(--fg-2);
-  border: var(--hairline) solid var(--border);
-}
-
 .usage-turn-row td {
   padding: var(--sp-2_5);
   vertical-align: middle;

--- a/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
+++ b/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
@@ -974,7 +974,7 @@ describe("page SSR smoke coverage", () => {
       // moved to their own Repositories tab; Tools & skills lists only skills + MCP.
       ["/agents/agent-1/runtime", "Reasoning effort"],
       ["/agents/agent-1/repositories", "Team web"],
-      ["/agents/agent-1/prompt", "Effective instructions"],
+      ["/agents/agent-1/prompt", "What this agent is told"],
       ["/agents/agent-1/resources", "Integrations (MCP)"],
     ] as const) {
       expect(

--- a/packages/web/src/pages/agent-detail-preview.tsx
+++ b/packages/web/src/pages/agent-detail-preview.tsx
@@ -1,4 +1,10 @@
-import type { Agent, AgentResourcesOutput, AgentRuntimeConfig } from "@first-tree/shared";
+import type {
+  Agent,
+  AgentResourcesOutput,
+  AgentRuntimeConfig,
+  UsageAgentSummary,
+  UsageTurnsResponse,
+} from "@first-tree/shared";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 import { Outlet, Route, Routes } from "react-router";
@@ -7,6 +13,7 @@ import { ResourceTypeSection } from "./agent-detail/capability-section.js";
 import type { AgentDetailContext } from "./agent-detail/layout-context.js";
 import { PromptTab } from "./agent-detail/prompt-tab.js";
 import { ResourcesTab } from "./agent-detail/resources-tab.js";
+import { UsageTab } from "./agent-detail/usage-tab.js";
 
 /**
  * DEV-only visual preview of the redesigned agent-detail **Capabilities** and
@@ -349,6 +356,70 @@ const CONFIG: AgentRuntimeConfig = {
   updatedBy: "member-self",
 };
 
+// Usage tab sample data — crafted to exercise the slimmed Recent turns table:
+// a long chat title (truncates), a non-default model (claude-haiku) next to the
+// dominant one, and big token counts (compact in-cell, exact on hover).
+const USAGE_SUMMARY: UsageAgentSummary = {
+  agentId: UUID,
+  from: "2026-05-23T00:00:00.000Z",
+  to: NOW,
+  totals: {
+    inputTokens: 1_293_770,
+    cachedInputTokens: 3_538_960,
+    outputTokens: 236_600,
+    turns: 3,
+    chats: 3,
+    lastUsageAt: NOW,
+  },
+  daily: [
+    { date: "2026-06-02", inputTokens: 121_730, cachedInputTokens: 656_880, outputTokens: 38_460, turns: 1 },
+    { date: "2026-06-03", inputTokens: 1_100_000, cachedInputTokens: 2_880_000, outputTokens: 187_500, turns: 1 },
+    { date: "2026-06-04", inputTokens: 72_040, cachedInputTokens: 2_080, outputTokens: 10_640, turns: 1 },
+  ],
+};
+
+const USAGE_TURNS: UsageTurnsResponse = {
+  agentId: UUID,
+  from: "2026-05-23T00:00:00.000Z",
+  to: NOW,
+  rows: [
+    {
+      seq: 1,
+      chatId: "chat-uxr",
+      chatTitle: "Agent 详情页 UX 审查 — a deliberately long chat title that should truncate with an ellipsis",
+      createdAt: NOW,
+      inputTokens: 121_730,
+      cachedInputTokens: 656_880,
+      outputTokens: 38_460,
+      provider: "claude-code",
+      model: "claude-opus-4-8",
+    },
+    {
+      seq: 2,
+      chatId: "chat-launch",
+      chatTitle: "Launch planning",
+      createdAt: NOW,
+      inputTokens: 1_100_000,
+      cachedInputTokens: 2_880_000,
+      outputTokens: 187_500,
+      provider: "claude-code",
+      model: "claude-opus-4-8",
+    },
+    {
+      seq: 3,
+      chatId: "chat-triage",
+      chatTitle: "Quick triage",
+      createdAt: NOW,
+      inputTokens: 72_040,
+      cachedInputTokens: 2_080,
+      outputTokens: 10_640,
+      provider: "claude-code",
+      model: "claude-haiku-4-5",
+    },
+  ],
+  nextCursor: null,
+};
+
 // The tabs only read uuid / agent / isHuman / canManageAgent / config / configLoading
 // from the context. Building the full ~30-field shape adds no signal to the preview.
 // (unavoidable cast: the omitted fields are never touched by these two tabs.)
@@ -360,6 +431,7 @@ const CTX = {
   canEditConfig: true,
   config: CONFIG,
   configLoading: false,
+  navigateAway: () => undefined,
 } as unknown as AgentDetailContext;
 
 function buildClient(): QueryClient {
@@ -369,6 +441,8 @@ function buildClient(): QueryClient {
     },
   });
   client.setQueryData(["agent-resources", UUID], RESOURCES);
+  client.setQueryData(["usage-summary", UUID, "30d"], USAGE_SUMMARY);
+  client.setQueryData(["usage-turns", UUID, "30d", 10], USAGE_TURNS);
   // Seed the agent switcher list (both admin/member keys, since preview auth is
   // ambient). fetchAllAgents flattens to Agent[].
   const switcherAgents: Agent[] = [
@@ -437,13 +511,23 @@ export function AgentDetailPreviewPage() {
             Instructions tab
           </h1>
           <p className="text-body" style={{ color: "var(--fg-3)", marginTop: "var(--sp-1)" }}>
-            Per-instruction management converged to the Switch (team-recommended enable / disable) + the ⋯ menu
-            (Customize / Edit / Remove); each block collapses to a summary (expand to read the full body), an Add menu
-            adds custom or team instructions, and the 👁 Effective instructions button shows the merged runtime prompt.
-            (The always-on top Effective block + the density pass land in PR2.)
+            Result-first: the top "What this agent is told" block shows the merged runtime instructions (clamp + Show
+            all). Source rows are de-crowded — Switch + ⋯ only, click a row to read its full body. The old 👁 modal is
+            gone.
           </p>
           <div style={{ marginTop: "var(--sp-4)" }}>
             <TabHost element={<PromptTab />} />
+          </div>
+
+          <h1 className="text-title m-0" style={{ marginTop: "var(--sp-8)", color: "var(--fg)" }}>
+            Usage tab — Recent turns
+          </h1>
+          <p className="text-body" style={{ color: "var(--fg-3)", marginTop: "var(--sp-1)" }}>
+            Slimmed: model name only (provider on hover), Chat truncates with a tooltip, token columns compact with the
+            exact value on hover, window in the title.
+          </p>
+          <div style={{ marginTop: "var(--sp-4)" }}>
+            <TabHost element={<UsageTab />} />
           </div>
         </div>
         <button

--- a/packages/web/src/pages/agent-detail-preview.tsx
+++ b/packages/web/src/pages/agent-detail-preview.tsx
@@ -13,6 +13,7 @@ import { ResourceTypeSection } from "./agent-detail/capability-section.js";
 import type { AgentDetailContext } from "./agent-detail/layout-context.js";
 import { PromptTab } from "./agent-detail/prompt-tab.js";
 import { ResourcesTab } from "./agent-detail/resources-tab.js";
+import { RuntimeSection } from "./agent-detail/runtime-section.js";
 import { UsageTab } from "./agent-detail/usage-tab.js";
 
 /**
@@ -528,6 +529,30 @@ export function AgentDetailPreviewPage() {
           </p>
           <div style={{ marginTop: "var(--sp-4)" }}>
             <TabHost element={<UsageTab />} />
+          </div>
+
+          <h1 className="text-title m-0" style={{ marginTop: "var(--sp-8)", color: "var(--fg)" }}>
+            Execution — computer presence
+          </h1>
+          <p className="text-body" style={{ color: "var(--fg-3)", marginTop: "var(--sp-1)" }}>
+            Runtime row is label:value only; the bound Computer row shows the computer's live connection state (online /
+            offline dot) instead of a restated caption.
+          </p>
+          <div style={{ marginTop: "var(--sp-4)" }}>
+            <RuntimeSection
+              runtimeProvider="claude-code"
+              computerLabel="gandy-macbook"
+              computerOnline={true}
+              canBindComputer={false}
+            />
+          </div>
+          <div style={{ marginTop: "var(--sp-4)" }}>
+            <RuntimeSection
+              runtimeProvider="claude-code"
+              computerLabel="gandy-macbook"
+              computerOnline={false}
+              canBindComputer={false}
+            />
           </div>
         </div>
         <button

--- a/packages/web/src/pages/agent-detail.tsx
+++ b/packages/web/src/pages/agent-detail.tsx
@@ -307,6 +307,10 @@ function AgentDetailPageView() {
     : null;
   const boundClientLabel: string | null =
     boundClientId && canEditConfig ? (boundClient?.hostname ?? boundClientId) : null;
+  // The bound computer's OWN connection state (the matched client row), distinct
+  // from this agent's presence: a connected computer with no active agent presence
+  // row must still read as online. null when no computer is bound / unknown.
+  const boundComputerOnline: boolean | null = boundClient ? boundClient.status === "connected" : null;
 
   const setupRuntimeProvider: RuntimeProvider = agent.runtimeProvider ?? "claude-code";
 
@@ -337,6 +341,7 @@ function AgentDetailPageView() {
     isUnclaimed,
     isOffline,
     boundClientLabel,
+    boundComputerOnline,
     setupRuntimeProvider,
     onOpenBindDialog: () => setBindClientOpen(true),
     bindClientPending: bindClientMutation.isPending,

--- a/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
@@ -473,7 +473,7 @@ describe("AgentDetailPage", () => {
     );
 
     const { container, root } = await renderDom("/agents/agent-1/prompt", <PromptTab />);
-    await waitForText(container, "Effective instructions");
+    await waitForText(container, "What this agent is told");
     expect(container.textContent).toContain("Vega");
     expect(container.textContent).toContain("1 active");
     expect(container.textContent).toContain("Chat");
@@ -487,14 +487,14 @@ describe("AgentDetailPage", () => {
     ]);
     expect(container.textContent).toContain("Always explain tradeoffs.");
     await waitForText(container, "Team style guide");
-    expect(container.textContent).toContain("Use the team style guide.");
+    expect(container.textContent).toContain("Team style guide");
     expect(container.textContent).toContain("Added by you");
 
     // The custom prompt's edit action now lives in the row's ⋯ overflow menu.
     await clickRowMenuItem(container, "More actions for Custom instructions", "Edit custom instructions");
     await waitForText(container, "Save instructions");
     expect(container.textContent).toContain("Team style guide");
-    expect(container.textContent).toContain("Use the team style guide.");
+    expect(container.textContent).toContain("Team style guide");
     const textarea = container.querySelector<HTMLTextAreaElement>("#custom-prompt-body");
     expect(textarea?.value).toBe("Always explain tradeoffs.");
     expect(textarea?.style.minHeight).toBe("16rem");
@@ -575,7 +575,7 @@ describe("AgentDetailPage", () => {
 
     await clickRowMenuItem(container, "More actions for Custom instructions", "Edit custom instructions");
     await waitForText(container, "Save instructions");
-    expect(container.textContent).toContain("Use the team style guide.");
+    expect(container.textContent).toContain("Team style guide");
     const textarea = container.querySelector<HTMLTextAreaElement>("#custom-prompt-body");
     expect(textarea?.value).toBe("");
     if (!textarea) throw new Error("Expected custom prompt textarea");
@@ -632,7 +632,7 @@ describe("AgentDetailPage", () => {
     );
 
     const { container, root } = await renderDom("/agents/agent-1/prompt", <PromptTab />);
-    await waitForText(container, "Effective instructions");
+    await waitForText(container, "What this agent is told");
     await clickRowMenuItem(container, "More actions for Team style guide", "Customize for this agent");
     await waitForText(container, "Save instructions");
     const textarea = container.querySelector<HTMLTextAreaElement>("#custom-prompt-body");
@@ -700,7 +700,7 @@ describe("AgentDetailPage", () => {
     );
 
     const { container, root } = await renderDom("/agents/agent-1/prompt", <PromptTab />);
-    await waitForText(container, "Effective instructions");
+    await waitForText(container, "What this agent is told");
     await clickRowMenuItem(container, "More actions for Team style guide", "Customize for this agent");
     await waitForText(container, "Save instructions");
     const textarea = container.querySelector<HTMLTextAreaElement>("#custom-prompt-body");
@@ -769,7 +769,7 @@ describe("AgentDetailPage", () => {
     );
 
     const { container, root } = await renderDom("/agents/agent-1/prompt", <PromptTab />);
-    await waitForText(container, "Effective instructions");
+    await waitForText(container, "What this agent is told");
     // Disabling a recommended prompt is now the row's Switch, toggled off.
     await click(container.querySelector('button[role="switch"]'));
     await waitForCondition(
@@ -885,7 +885,7 @@ describe("AgentDetailPage", () => {
   it("starts a draft chat with the current agent from the header", async () => {
     const { PromptTab } = await import("../prompt-tab.js");
     const { container, root } = await renderDom("/agents/agent-1/prompt", <PromptTab />);
-    await waitForText(container, "Effective instructions");
+    await waitForText(container, "What this agent is told");
 
     await click(container.querySelector('button[aria-label="Start chat"]'));
     await waitForText(container, "/?c=draft&with=agent-1");
@@ -937,7 +937,7 @@ describe("AgentDetailPage", () => {
     expect(active.container.textContent).toContain("@vega");
     expect(active.container.textContent).toContain("Owner");
     expect(active.container.textContent).toContain("Agent lifecycle");
-    expect(active.container.textContent).toContain("Lifecycle changes save immediately.");
+    expect(active.container.textContent).not.toContain("Lifecycle changes save immediately.");
     expect(
       [...active.container.querySelectorAll("section h2")].filter((heading) =>
         heading.textContent?.includes("Agent lifecycle"),

--- a/packages/web/src/pages/agent-detail/__tests__/resource-row.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/resource-row.test.tsx
@@ -126,7 +126,7 @@ describe("ResourceRowView — converged action slots", () => {
       />,
     );
     // The heading itself is the expand trigger; clicking it fires onToggle.
-    const heading = container.querySelector('button[aria-label="Expand instructions"]');
+    const heading = container.querySelector('button[aria-label="Expand Style guide"]');
     expect(heading).toBeTruthy();
     await click(heading);
     expect(toggles).toEqual([1]);
@@ -135,6 +135,6 @@ describe("ResourceRowView — converged action slots", () => {
     const switches = buttons.filter((b) => b.getAttribute("role") === "switch");
     expect(switches).toHaveLength(1);
     // The expand control is the heading (aria-label), not a duplicate chevron button.
-    expect(buttons.filter((b) => b.getAttribute("aria-label") === "Expand instructions")).toHaveLength(1);
+    expect(buttons.filter((b) => b.getAttribute("aria-label") === "Expand Style guide")).toHaveLength(1);
   });
 });

--- a/packages/web/src/pages/agent-detail/__tests__/resource-row.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/resource-row.test.tsx
@@ -113,4 +113,28 @@ describe("ResourceRowView — converged action slots", () => {
     );
     expect(container.querySelector('[data-dimmed="true"]')).toBeTruthy();
   });
+
+  it("expands via the row heading (no separate chevron button), keeping the cluster to Switch + ⋯", async () => {
+    const toggles: number[] = [];
+    render(
+      <ResourceRowView
+        name="Style guide"
+        source="From your team"
+        expandLabel="instructions"
+        toggle={{ checked: true, ariaLabel: "Enable Style guide", onChange: () => {} }}
+        expand={{ canExpand: true, expanded: false, onToggle: () => toggles.push(1), body: <p>Full body</p> }}
+      />,
+    );
+    // The heading itself is the expand trigger; clicking it fires onToggle.
+    const heading = container.querySelector('button[aria-label="Expand instructions"]');
+    expect(heading).toBeTruthy();
+    await click(heading);
+    expect(toggles).toEqual([1]);
+    // Only the Switch lives in the right cluster — no extra chevron button.
+    const buttons = [...container.querySelectorAll("button")];
+    const switches = buttons.filter((b) => b.getAttribute("role") === "switch");
+    expect(switches).toHaveLength(1);
+    // The expand control is the heading (aria-label), not a duplicate chevron button.
+    expect(buttons.filter((b) => b.getAttribute("aria-label") === "Expand instructions")).toHaveLength(1);
+  });
 });

--- a/packages/web/src/pages/agent-detail/__tests__/resources-tab-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/resources-tab-dom.test.tsx
@@ -107,6 +107,7 @@ function context(overrides: Partial<AgentDetailContext> = {}): AgentDetailContex
     isUnclaimed: false,
     isOffline: false,
     boundClientLabel: "gandy-macbook",
+    boundComputerOnline: true,
     setupRuntimeProvider: "claude-code",
     onOpenBindDialog: vi.fn(),
     bindClientPending: false,

--- a/packages/web/src/pages/agent-detail/__tests__/usage-tab.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/usage-tab.test.tsx
@@ -274,15 +274,28 @@ describe("UsageTab", () => {
     expect(container.textContent).toContain("Active days");
     expect(container.textContent).toContain("Peak day");
     expect(container.textContent).toContain("Recent turns");
-    expect(container.textContent).toContain("Daily processed tokens. Darker cells mean more usage.");
+    expect(container.textContent).toContain("Daily processed tokens.");
+    expect(container.textContent).not.toContain("Darker cells mean more usage");
     expect(
       activityCells.find((cell) => cell.getAttribute("aria-label")?.includes("10.5K processed tokens")),
     ).toBeDefined();
-    expect(container.textContent).toContain("Your most recent turns from the last 30 days.");
+    // Recent turns: the window moved into the title and the standalone subtitle is gone.
+    expect(container.textContent).not.toContain("Your most recent turns from the last 30 days.");
+    expect(container.textContent).toContain("last 30 days");
     expect(container.textContent).toContain("Launch planning");
     expect(container.textContent).toContain("private chat");
-    expect(container.textContent).toContain("claude-code/sonnet");
+    // Model column kept but slimmed: provider prefix dropped from the visible chip
+    // (model name only), the full provider/model stays on hover via title.
+    expect(container.textContent).toContain("sonnet");
+    expect(container.textContent).not.toContain("claude-code/sonnet");
+    expect(
+      [...container.querySelectorAll("[title]")].some((el) => el.getAttribute("title") === "claude-code/sonnet"),
+    ).toBe(true);
+    // Numbers stay compact in-cell, with the exact value on hover (title).
     expect(container.textContent).toContain("46.2K");
+    expect(
+      [...container.querySelectorAll("[title]")].some((el) => (el.getAttribute("title") ?? "").includes("12,000")),
+    ).toBe(true);
     expect(usageMocks.getAgentUsageSummary).toHaveBeenCalledWith("agent-1", "30d");
     expect(usageMocks.getAgentUsageTurns).toHaveBeenCalledWith("agent-1", {
       window: "30d",

--- a/packages/web/src/pages/agent-detail/__tests__/usage-tab.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/usage-tab.test.tsx
@@ -94,6 +94,7 @@ function createContext(overrides: Partial<AgentDetailContext> = {}): AgentDetail
     isUnclaimed: false,
     isOffline: false,
     boundClientLabel: "gandy-macbook",
+    boundComputerOnline: true,
     setupRuntimeProvider: "claude-code",
     onOpenBindDialog: () => undefined,
     bindClientPending: false,

--- a/packages/web/src/pages/agent-detail/appearance-section.tsx
+++ b/packages/web/src/pages/agent-detail/appearance-section.tsx
@@ -95,11 +95,6 @@ export function AppearanceSection({ agent, canEdit = true, onEdit, variant = "se
         <div className="text-caption" style={{ color: "var(--fg-4)", marginTop: "var(--sp-0_5)" }}>
           {agent.avatarImageUrl ? "Image uploaded" : "No custom image uploaded"} · Color {colorLabel}
         </div>
-        {variant === "section" && (
-          <div className="text-caption" style={{ color: "var(--fg-4)", marginTop: "var(--sp-1)" }}>
-            Updates appear immediately in chats, lists, and mentions.
-          </div>
-        )}
       </div>
     </div>
   );
@@ -109,11 +104,7 @@ export function AppearanceSection({ agent, canEdit = true, onEdit, variant = "se
   }
 
   return (
-    <Section
-      title="Appearance"
-      description="Controls how this agent is recognized in chats, lists, and mentions."
-      action={action}
-    >
+    <Section title="Appearance" description="Shows in chats, lists, and mentions." action={action}>
       {content}
     </Section>
   );

--- a/packages/web/src/pages/agent-detail/capability-section.tsx
+++ b/packages/web/src/pages/agent-detail/capability-section.tsx
@@ -161,7 +161,7 @@ export function ResourceTypeSection(props: {
         ) : null
       }
     >
-      <div>
+      <div className="ad-tail-trim">
         {rows.length === 0 ? (
           <p className="text-body" style={{ color: "var(--fg-4)", padding: "var(--sp-3) 0", margin: 0 }}>
             No {emptyNoun(type)} yet.

--- a/packages/web/src/pages/agent-detail/danger-zone.tsx
+++ b/packages/web/src/pages/agent-detail/danger-zone.tsx
@@ -40,10 +40,7 @@ export function DangerZone(props: DangerZoneProps) {
 
   return (
     <div id="ad-danger" style={{ marginTop: "var(--sp-10)" }}>
-      <Section
-        title="Agent lifecycle"
-        description="Manage availability and deletion. Lifecycle changes save immediately."
-      >
+      <Section title="Agent lifecycle">
         {agent.status === "active" ? (
           <DangerActionRow
             label="Availability"

--- a/packages/web/src/pages/agent-detail/identity-section.tsx
+++ b/packages/web/src/pages/agent-detail/identity-section.tsx
@@ -67,7 +67,7 @@ export function IdentitySection({
     <Section title={titleWithSemantics(title, saved)} description={description} action={action}>
       <div
         className={aside ? "grid gap-4 lg:grid-cols-[minmax(0,1.5fr)_minmax(18rem,0.85fr)] lg:gap-8" : undefined}
-        style={{ padding: "var(--sp-3) 0", borderBottom: "var(--hairline) solid var(--border-faint)" }}
+        style={{ padding: "var(--sp-3) 0" }}
       >
         <div className="min-w-0">
           <div className={aside ? "grid gap-0" : "grid gap-0 md:grid-cols-2 md:gap-x-8"}>

--- a/packages/web/src/pages/agent-detail/identity-section.tsx
+++ b/packages/web/src/pages/agent-detail/identity-section.tsx
@@ -39,7 +39,7 @@ export function IdentitySection({
   onEdit,
   saved = false,
   title = "Identity",
-  description = "Identity saves immediately; runtime behavior is configured from the other tabs.",
+  description,
   aside,
 }: IdentitySectionProps) {
   const resolveAgent = useAgentIdentityMap();

--- a/packages/web/src/pages/agent-detail/layout-context.ts
+++ b/packages/web/src/pages/agent-detail/layout-context.ts
@@ -37,6 +37,9 @@ export type AgentDetailContext = {
   isUnclaimed: boolean;
   isOffline: boolean;
   boundClientLabel: string | null;
+  /** The bound computer's own connection state (connected client row), distinct
+   *  from agent presence; null when no computer is bound or it's unknown. */
+  boundComputerOnline: boolean | null;
   setupRuntimeProvider: RuntimeProvider;
   onOpenBindDialog: () => void;
   bindClientPending: boolean;

--- a/packages/web/src/pages/agent-detail/prompt-tab.tsx
+++ b/packages/web/src/pages/agent-detail/prompt-tab.tsx
@@ -4,19 +4,11 @@ import {
   PROMPT_APPEND_MAX_LENGTH,
 } from "@first-tree/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Eye, Plus } from "lucide-react";
+import { Plus } from "lucide-react";
 import { type FormEvent, type ReactNode, useEffect, useRef, useState } from "react";
 import { Navigate } from "react-router";
 import { getAgentResources, updateAgentResources } from "../../api/agent-resources.js";
 import { Button } from "../../components/ui/button.js";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "../../components/ui/dialog.js";
 import { Markdown } from "../../components/ui/markdown.js";
 import { Popover } from "../../components/ui/popover.js";
 import type { RowAction as RowMenuAction } from "../../components/ui/row-actions-menu.js";
@@ -130,22 +122,19 @@ export function PromptTab() {
     <div className="flex flex-col" style={{ gap: "var(--sp-5)" }}>
       <Section
         title={titleWithSemantics("Instructions", justSaved)}
-        description="Team and your own instructions for this agent — toggle, customize, or add your own."
         action={
-          <div className="flex items-center gap-2">
-            <EffectiveInstructionsTrigger prompt={prompt} />
-            {canEditPrompt && !resourceError && !editor && resources ? (
-              <AddInstructionsMenu
-                available={availablePrompts}
-                pending={bindingMut.isPending}
-                onAddCustom={() => openPromptEditor(null)}
-                onEnable={enablePrompt}
-                onNavigateAway={ctx.navigateAway}
-              />
-            ) : null}
-          </div>
+          canEditPrompt && !resourceError && !editor && resources ? (
+            <AddInstructionsMenu
+              available={availablePrompts}
+              pending={bindingMut.isPending}
+              onAddCustom={() => openPromptEditor(null)}
+              onEnable={enablePrompt}
+              onNavigateAway={ctx.navigateAway}
+            />
+          ) : null
         }
       >
+        <EffectiveInstructionsBlock prompt={prompt} />
         <div>
           {resources ? (
             <PromptResourceBlocks
@@ -182,41 +171,61 @@ export function PromptTab() {
   );
 }
 
-// On-demand `Effective instructions` dialog. Replaces the always-on bottom
-// section: the merged runtime truth (`ctx.config.payload.prompt.append`, after
-// every override) is revealed in a centered modal — same dialog pattern as the
-// rest of the app — only when asked for. Long bodies scroll inside the modal.
-function EffectiveInstructionsTrigger(props: { prompt: string }) {
+// Result-first: the merged runtime instructions (`ctx.config.payload.prompt.append`,
+// after every team prompt + override) are surfaced at the TOP of the tab as the
+// thing the agent actually runs with — replacing the old on-demand 👁 modal. Long
+// bodies clamp to ~8 lines with a Show all toggle; the source list below is for
+// management (toggle / customize / add).
+function EffectiveInstructionsBlock({ prompt }: { prompt: string }) {
+  const [showAll, setShowAll] = useState(false);
+  const [clamped, setClamped] = useState(false);
+  const bodyRef = useRef<HTMLDivElement | null>(null);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: re-measure when the prompt text changes.
+  useEffect(() => {
+    const el = bodyRef.current;
+    if (el) setClamped(el.scrollHeight > el.clientHeight + 2);
+  }, [prompt]);
+
   return (
-    <Dialog>
-      <DialogTrigger asChild>
-        <Button
-          type="button"
-          size="xs"
-          variant="ghost"
-          aria-label="Effective instructions"
-          title="Effective instructions"
-        >
-          <Eye className="h-3 w-3" />
-          Effective instructions
-        </Button>
-      </DialogTrigger>
-      <DialogContent className="max-w-2xl">
-        <DialogHeader>
-          <DialogTitle>Effective instructions</DialogTitle>
-          <DialogDescription>
-            The full instructions this agent runs with, after your changes — team and custom, in order.
-          </DialogDescription>
-        </DialogHeader>
-        <div className="text-body" style={{ maxHeight: "60vh", overflowY: "auto" }}>
-          {props.prompt ? (
-            <Markdown>{props.prompt}</Markdown>
-          ) : (
-            <span className="text-muted-foreground">No instructions yet.</span>
-          )}
-        </div>
-      </DialogContent>
-    </Dialog>
+    <div style={{ marginBottom: "var(--sp-4)" }}>
+      <p className="text-eyebrow" style={{ color: "var(--fg-3)", margin: "0 0 var(--sp-1_5)" }}>
+        What this agent is told
+      </p>
+      {prompt.trim() ? (
+        <>
+          <div
+            ref={bodyRef}
+            className="text-body"
+            style={{
+              background: "var(--bg-sunken)",
+              border: "var(--hairline) solid var(--border-faint)",
+              borderRadius: "var(--radius-panel)",
+              padding: "var(--sp-3)",
+              maxHeight: showAll ? undefined : "var(--sp-35)",
+              overflow: showAll ? undefined : "hidden",
+            }}
+          >
+            <Markdown>{prompt}</Markdown>
+          </div>
+          {clamped || showAll ? (
+            <Button
+              type="button"
+              size="xs"
+              variant="ghost"
+              aria-expanded={showAll}
+              onClick={() => setShowAll((v) => !v)}
+              style={{ marginTop: "var(--sp-1)" }}
+            >
+              {showAll ? "Collapse" : "Show all"}
+            </Button>
+          ) : null}
+        </>
+      ) : (
+        <p className="text-body" style={{ color: "var(--fg-4)", margin: 0 }}>
+          No extra instructions — this agent runs on its base profile only.
+        </p>
+      )}
+    </div>
   );
 }
 
@@ -602,10 +611,10 @@ function PromptPanel(props: { children: ReactNode; minHeight?: string; sunken?: 
 }
 
 // One instruction row — a thin wrapper over the shared `ResourceRowView`
-// primitive (the same flat skeleton the Tools & skills / Environment resource
-// rows use): name → source → status, right-aligned ghost actions, a one-line
-// peek, and an in-place sunken expansion holding the full Markdown or the inline
-// editor. Short, single-line prompts have no chevron, so the list stays calm.
+// primitive (the same flat skeleton the Tools & skills / Repositories rows use):
+// name → source → status, plus Switch / ⋯. De-crowded: no per-row body peek —
+// click the row to read the full Markdown in the sunken block (the merged net
+// result lives in the top Effective block).
 function PromptResourceBlock(props: {
   name: string | null;
   source: EffectivePromptRow["source"];
@@ -619,27 +628,26 @@ function PromptResourceBlock(props: {
   /** When present (editor active), the sunken area shows this instead of Markdown. */
   editor?: ReactNode;
 }) {
-  const peek = peekLine(props.body);
-  // Trivially-short single-line prompts need no expander.
-  const canExpand = props.body.length > 120 || props.body.includes("\n");
+  // Any non-empty body is readable on demand (click the row); only the empty
+  // orphan binding falls back to the "No instructions yet." hint so it stays
+  // editable/removable.
+  const hasBody = props.body.trim().length > 0;
   return (
     <ResourceRowView
       name={props.name}
       source={sourceLabel(props.source)}
       status={props.marker}
-      peek={peek || undefined}
       toggle={props.toggle}
       menu={props.menu}
       dimmed={props.dimmed}
-      emptyPeek="No instructions yet."
+      emptyPeek={hasBody ? undefined : "No instructions yet."}
       expandLabel="instructions"
       leadingIcon={resourceTypeIcon("prompt")}
       expand={{
-        canExpand,
+        canExpand: hasBody,
         expanded: props.expanded,
         onToggle: props.onToggle,
-        // Cap prose to a readable measure (~66–75ch), matching the Effective
-        // instructions dialog (max-w-2xl) instead of stretching the full rail.
+        // Cap prose to a readable measure (~66–75ch) instead of the full rail.
         body: props.body ? (
           <div className="max-w-2xl">
             <Markdown>{props.body}</Markdown>
@@ -649,16 +657,6 @@ function PromptResourceBlock(props: {
       editor={props.editor ?? undefined}
     />
   );
-}
-
-// First non-empty line of the body, for the single-line truncated peek. Markdown
-// heading markers are stripped so the peek reads as plain text.
-function peekLine(body: string): string {
-  for (const raw of body.split("\n")) {
-    const line = raw.replace(/^#+\s*/, "").trim();
-    if (line) return line;
-  }
-  return "";
 }
 
 // Per-section add control on the Instructions tab. One "+" trigger opens a menu:

--- a/packages/web/src/pages/agent-detail/prompt-tab.tsx
+++ b/packages/web/src/pages/agent-detail/prompt-tab.tsx
@@ -22,6 +22,12 @@ import { titleWithSemantics, useJustSaved } from "./save-semantics.js";
 
 type AvailablePrompt = { id: string; name: string };
 
+// Clamp markdown headings to the dense in-app scale inside the Effective block, so
+// a prompt that opens with a big "# Heading" doesn't blow out the ~8-line clamp
+// (h1 → subtitle, the rest → body).
+const PROSE_COMPACT_HEADINGS =
+  "prose-headings:font-semibold prose-h1:text-subtitle prose-h1:mt-0 prose-h2:text-body prose-h3:text-body prose-h4:text-body";
+
 export function PromptTab() {
   const ctx = useAgentDetailContext();
   const queryClient = useQueryClient();
@@ -205,7 +211,7 @@ function EffectiveInstructionsBlock({ prompt }: { prompt: string }) {
               overflow: showAll ? undefined : "hidden",
             }}
           >
-            <Markdown>{prompt}</Markdown>
+            <Markdown className={PROSE_COMPACT_HEADINGS}>{prompt}</Markdown>
           </div>
           {clamped || showAll ? (
             <Button
@@ -511,7 +517,7 @@ function PromptResourceBlocks(props: {
   }
 
   return blocks.length > 0 ? (
-    <>{blocks}</>
+    <div className="ad-tail-trim">{blocks}</div>
   ) : (
     <p className="text-body text-muted-foreground" style={{ margin: 0, padding: "var(--sp-3) 0" }}>
       No instructions yet.

--- a/packages/web/src/pages/agent-detail/resource-row.tsx
+++ b/packages/web/src/pages/agent-detail/resource-row.tsx
@@ -1,6 +1,5 @@
 import { ChevronDown, ChevronUp } from "lucide-react";
 import type { ReactNode } from "react";
-import { Button } from "../../components/ui/button.js";
 import { DenseBadge, type DenseBadgeTone } from "../../components/ui/dense-badge.js";
 import { RowActionsMenu, type RowAction as RowMenuAction } from "../../components/ui/row-actions-menu.js";
 import { Switch } from "../../components/ui/switch.js";
@@ -74,7 +73,9 @@ export function ResourceRowView(props: {
   const canExpand = !props.editor && !!props.expand?.canExpand;
   const showSunken = props.editor ? true : expanded && !!props.expand?.body;
   const hasMenu = !!props.menu && props.menu.actions.length > 0;
-  const showCluster = !!props.toggle || hasMenu || canExpand;
+  // Expand is triggered by clicking the row heading (de-crowd), not a separate
+  // chevron button — so the right cluster carries only the Switch + ⋯.
+  const showCluster = !!props.toggle || hasMenu;
   return (
     <div
       data-dimmed={props.dimmed ? "true" : undefined}
@@ -88,13 +89,38 @@ export function ResourceRowView(props: {
           sm+ they sit on one row with the controls right-aligned. */}
       <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:gap-3">
         <div className="min-w-0 flex-1">
-          <RowHeading
-            name={props.name}
-            source={props.source}
-            status={props.status}
-            leadingIcon={props.leadingIcon}
-            dimmed={props.dimmed}
-          />
+          {canExpand ? (
+            <button
+              type="button"
+              aria-expanded={expanded}
+              aria-label={
+                expanded
+                  ? `Collapse${props.expandLabel ? ` ${props.expandLabel}` : ""}`
+                  : `Expand${props.expandLabel ? ` ${props.expandLabel}` : ""}`
+              }
+              onClick={props.expand?.onToggle}
+              className="block w-full text-left"
+              style={{ background: "transparent", border: 0, padding: 0, cursor: "pointer" }}
+            >
+              <RowHeading
+                name={props.name}
+                source={props.source}
+                status={props.status}
+                leadingIcon={props.leadingIcon}
+                dimmed={props.dimmed}
+                expandable
+                expanded={expanded}
+              />
+            </button>
+          ) : (
+            <RowHeading
+              name={props.name}
+              source={props.source}
+              status={props.status}
+              leadingIcon={props.leadingIcon}
+              dimmed={props.dimmed}
+            />
+          )}
         </div>
         {showCluster ? (
           <div className="flex flex-wrap items-center gap-1 shrink-0">
@@ -107,22 +133,6 @@ export function ResourceRowView(props: {
               />
             ) : null}
             {props.menu ? <RowActionsMenu actions={props.menu.actions} ariaLabel={props.menu.ariaLabel} /> : null}
-            {canExpand ? (
-              <Button
-                type="button"
-                size="xs"
-                variant="ghost"
-                aria-expanded={expanded}
-                aria-label={
-                  expanded
-                    ? `Collapse${props.expandLabel ? ` ${props.expandLabel}` : ""}`
-                    : `Expand${props.expandLabel ? ` ${props.expandLabel}` : ""}`
-                }
-                onClick={props.expand?.onToggle}
-              >
-                {expanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
-              </Button>
-            ) : null}
           </div>
         ) : null}
       </div>
@@ -161,12 +171,17 @@ function RowHeading({
   status,
   leadingIcon,
   dimmed,
+  expandable,
+  expanded,
 }: {
   name: ReactNode | null;
   source: ReactNode;
   status?: RowStatusMarker;
   leadingIcon?: ReactNode;
   dimmed?: boolean;
+  /** When the heading itself is the expand trigger, show a subtle affordance. */
+  expandable?: boolean;
+  expanded?: boolean;
 }) {
   return (
     <span className="inline-flex items-center gap-2">
@@ -187,6 +202,11 @@ function RowHeading({
         <DenseBadge tone={status.tone} className="shrink-0">
           {status.label}
         </DenseBadge>
+      ) : null}
+      {expandable ? (
+        <span className="inline-flex shrink-0 items-center" style={{ color: "var(--fg-4)" }} aria-hidden>
+          {expanded ? <ChevronUp className="h-3.5 w-3.5" /> : <ChevronDown className="h-3.5 w-3.5" />}
+        </span>
       ) : null}
     </span>
   );

--- a/packages/web/src/pages/agent-detail/resource-row.tsx
+++ b/packages/web/src/pages/agent-detail/resource-row.tsx
@@ -76,6 +76,9 @@ export function ResourceRowView(props: {
   // Expand is triggered by clicking the row heading (de-crowd), not a separate
   // chevron button — so the right cluster carries only the Switch + ⋯.
   const showCluster = !!props.toggle || hasMenu;
+  // Name the expand control after the row so multiple expanders stay
+  // distinguishable to assistive tech (not a generic "Expand instructions").
+  const expandNoun = typeof props.name === "string" && props.name ? props.name : (props.expandLabel ?? "");
   return (
     <div
       data-dimmed={props.dimmed ? "true" : undefined}
@@ -95,8 +98,8 @@ export function ResourceRowView(props: {
               aria-expanded={expanded}
               aria-label={
                 expanded
-                  ? `Collapse${props.expandLabel ? ` ${props.expandLabel}` : ""}`
-                  : `Expand${props.expandLabel ? ` ${props.expandLabel}` : ""}`
+                  ? `Collapse${expandNoun ? ` ${expandNoun}` : ""}`
+                  : `Expand${expandNoun ? ` ${expandNoun}` : ""}`
               }
               onClick={props.expand?.onToggle}
               className="block w-full text-left"
@@ -186,7 +189,9 @@ function RowHeading({
   return (
     <span className="inline-flex items-center gap-2">
       {leadingIcon ? (
-        <span className="inline-flex shrink-0 items-center" style={{ color: "var(--fg-4)" }} aria-hidden>
+        // Type glyph one step stronger than --fg-4 so the four resource kinds read
+        // apart at a glance (ux-expert trial; revert to --fg-4 if too heavy).
+        <span className="inline-flex shrink-0 items-center" style={{ color: "var(--fg-3)" }} aria-hidden>
           {leadingIcon}
         </span>
       ) : null}

--- a/packages/web/src/pages/agent-detail/resource-source.ts
+++ b/packages/web/src/pages/agent-detail/resource-source.ts
@@ -5,8 +5,14 @@ import type { EffectiveResourceRow } from "@first-tree/shared";
  * owner's first person — this page is the user looking at their own agent, not
  * an admin managing a fleet. `agent_extra` / `inline_prompt` are things the
  * user added to this agent; everything else is inherited from the team.
+ *
+ * Team resources split by how they got here: `team_recommended` is on by default
+ * (a Switch toggles it), while `team_available` is one the user opted into (no
+ * Switch — it's removed via ⋯). The `· optional` qualifier disambiguates the two,
+ * which otherwise read identically as "From your team" despite different controls.
  */
 export function sourceLabel(source: EffectiveResourceRow["source"]): string {
   if (source === "agent_extra" || source === "inline_prompt") return "Added by you";
+  if (source === "team_available") return "From your team · optional";
   return "From your team";
 }

--- a/packages/web/src/pages/agent-detail/runtime-section.tsx
+++ b/packages/web/src/pages/agent-detail/runtime-section.tsx
@@ -3,6 +3,7 @@ import { Link2 } from "lucide-react";
 import type { ReactNode } from "react";
 import { Button } from "../../components/ui/button.js";
 import { Section } from "../../components/ui/section.js";
+import { StatusGlyph } from "../../components/ui/status-glyph.js";
 import { ConfigRow } from "./flat-section.js";
 import { titleWithSemantics } from "./save-semantics.js";
 
@@ -14,6 +15,8 @@ export type RuntimeSectionProps = {
   runtimeProvider: RuntimeProvider;
   /** Display label of the bound computer; null when no computer is bound yet. */
   computerLabel: string | null;
+  /** Whether the bound computer is currently connected; null when unknown. */
+  computerOnline?: boolean | null;
   computerStatusLoading?: boolean;
   computerStatusError?: string | null;
   /** Whether the "Bind computer" CTA should be shown (only when no client is bound and agent is active). */
@@ -22,23 +25,13 @@ export type RuntimeSectionProps = {
   onBindComputer?: () => void;
 };
 
-const RUNTIME_COPY: Record<RuntimeProvider, { name: string; caption: string }> = {
-  "claude-code": {
-    name: "Claude Code",
-    caption: "Runs through Anthropic's Claude Code runtime.",
-  },
-  "claude-code-tui": {
-    name: "Claude Code CLI",
-    caption: "Runs Claude Code through tmux for terminal-native sessions.",
-  },
-  codex: {
-    name: "Codex",
-    caption: "Runs through OpenAI's Codex CLI runtime.",
-  },
+const RUNTIME_NAME: Record<RuntimeProvider, string> = {
+  "claude-code": "Claude Code",
+  "claude-code-tui": "Claude Code CLI",
+  codex: "Codex",
 };
 
 export function RuntimeSection(props: RuntimeSectionProps) {
-  const copy = RUNTIME_COPY[props.runtimeProvider];
   return (
     <Section
       title={titleWithSemantics("Execution")}
@@ -46,23 +39,28 @@ export function RuntimeSection(props: RuntimeSectionProps) {
     >
       <ComputerRow
         computerLabel={props.computerLabel}
+        online={props.computerOnline ?? null}
         statusLoading={props.computerStatusLoading ?? false}
         statusError={props.computerStatusError ?? null}
         canBindComputer={props.canBindComputer}
         bindPending={props.bindComputerPending ?? false}
         onBindComputer={props.onBindComputer}
       />
-      <RuntimeRow name={copy.name} caption={copy.caption} />
+      <RuntimeRow name={RUNTIME_NAME[props.runtimeProvider]} />
     </Section>
   );
 }
 
-function RuntimeRow({ name, caption }: { name: string; caption: string }) {
-  return <ConfigRow label="Runtime" value={name} description={caption} />;
+// Runtime is fixed at creation, so it's a read-only label. The old per-provider
+// caption just restated the value — the section subtitle already says runtime is
+// fixed — so the row carries only `label: value`.
+function RuntimeRow({ name }: { name: string }) {
+  return <ConfigRow label="Runtime" value={name} />;
 }
 
 function ComputerRow(props: {
   computerLabel: string | null;
+  online: boolean | null;
   statusLoading: boolean;
   statusError: string | null;
   canBindComputer: boolean;
@@ -95,8 +93,23 @@ function ComputerRow(props: {
     value = "No computer bound";
     description = "Bind a connected computer before this agent can run.";
   } else {
-    description = "Runtime process and local tool access come from this computer.";
+    // Bound computer → show its live connection state instead of a static
+    // caption that just restated "this computer runs the agent".
+    description = <ComputerPresence online={props.online} />;
   }
 
   return <ConfigRow label="Computer" value={value} description={description} action={action} />;
+}
+
+// Live presence of the bound computer: a connected computer is "present" (blue,
+// per the state map), a disconnected one is offline (gray). Unknown → nothing.
+function ComputerPresence({ online }: { online: boolean | null }) {
+  if (online == null) return null;
+  const color = online ? "var(--state-idle)" : "var(--state-offline)";
+  return (
+    <span className="inline-flex items-center gap-1.5" style={{ color: "var(--fg-3)" }}>
+      <StatusGlyph colorVar={color} shape="dot" size={7} ariaLabel={online ? "Online" : "Offline"} />
+      {online ? "Online" : "Offline"}
+    </span>
+  );
 }

--- a/packages/web/src/pages/agent-detail/runtime-tab.tsx
+++ b/packages/web/src/pages/agent-detail/runtime-tab.tsx
@@ -76,6 +76,7 @@ export function RuntimeTab() {
           <RuntimeSection
             runtimeProvider={ctx.setupRuntimeProvider}
             computerLabel={ctx.boundClientLabel}
+            computerOnline={ctx.clientStatus?.online ?? null}
             computerStatusLoading={ctx.clientStatusLoading}
             computerStatusError={ctx.clientStatusError}
             canBindComputer={ctx.isUnclaimed && ctx.agent.status === "active"}

--- a/packages/web/src/pages/agent-detail/runtime-tab.tsx
+++ b/packages/web/src/pages/agent-detail/runtime-tab.tsx
@@ -76,7 +76,7 @@ export function RuntimeTab() {
           <RuntimeSection
             runtimeProvider={ctx.setupRuntimeProvider}
             computerLabel={ctx.boundClientLabel}
-            computerOnline={ctx.clientStatus?.online ?? null}
+            computerOnline={ctx.boundComputerOnline}
             computerStatusLoading={ctx.clientStatusLoading}
             computerStatusError={ctx.clientStatusError}
             canBindComputer={ctx.isUnclaimed && ctx.agent.status === "active"}

--- a/packages/web/src/pages/agent-detail/usage-tab.tsx
+++ b/packages/web/src/pages/agent-detail/usage-tab.tsx
@@ -123,7 +123,7 @@ function ActivityBlock({
           </span>
         </>
       }
-      description="Daily processed tokens. Darker cells mean more usage."
+      description="Daily processed tokens."
       action={<DensityLegend />}
     >
       {isError ? (
@@ -342,7 +342,16 @@ function RecentTurnsBlock({
   onShowMore: () => void;
 }): ReactElement {
   return (
-    <Section title="Recent turns" description="Your most recent turns from the last 30 days.">
+    <Section
+      title={
+        <>
+          Recent turns{" "}
+          <span className="font-normal" style={{ color: "var(--fg-4)" }}>
+            · last 30 days
+          </span>
+        </>
+      }
+    >
       {isError ? (
         <UsagePlaceholder tone="error">Failed to load recent turns.</UsagePlaceholder>
       ) : isLoading ? (
@@ -374,6 +383,8 @@ function TurnsTable({
 }): ReactElement {
   const processedFor = (r: UsageTurnRow) => processedTokenCount(r);
   const max = Math.max(1, ...rows.map(processedFor));
+  // Keep all columns; slim each one (gandy's call): model name only, Chat
+  // truncated with a tooltip, and compact numbers with the exact value on hover.
   return (
     <div className="usage-turn-scroll">
       <table className="usage-turn-table w-full" style={{ borderCollapse: "collapse", marginTop: "var(--sp-1)" }}>
@@ -401,8 +412,11 @@ function TurnsTable({
                     <button
                       type="button"
                       onClick={() => onOpenChat(r.chatId)}
-                      className="text-body font-medium"
+                      title={r.chatTitle}
+                      className="text-body font-medium truncate"
                       style={{
+                        display: "block",
+                        maxWidth: "var(--sp-70)",
                         background: "transparent",
                         border: 0,
                         padding: 0,
@@ -422,17 +436,29 @@ function TurnsTable({
                 <td>
                   <ModelChip provider={r.provider} model={r.model} />
                 </td>
-                <td className="mono text-body" style={{ textAlign: "right", color: "var(--fg-2)" }}>
+                <td
+                  className="mono text-body"
+                  style={{ textAlign: "right", color: "var(--fg-2)" }}
+                  title={fullCount(r.inputTokens)}
+                >
                   {formatCompactCount(r.inputTokens)}
                 </td>
-                <td className="mono text-body" style={{ textAlign: "right", color: "var(--fg-3)" }}>
+                <td
+                  className="mono text-body"
+                  style={{ textAlign: "right", color: "var(--fg-3)" }}
+                  title={fullCount(r.cachedInputTokens)}
+                >
                   {formatCompactCount(r.cachedInputTokens)}
                 </td>
-                <td className="mono text-body" style={{ textAlign: "right", color: "var(--fg-2)" }}>
+                <td
+                  className="mono text-body"
+                  style={{ textAlign: "right", color: "var(--fg-2)" }}
+                  title={fullCount(r.outputTokens)}
+                >
                   {formatCompactCount(r.outputTokens)}
                 </td>
                 <td>
-                  <div className="usage-turn-total-cell">
+                  <div className="usage-turn-total-cell" title={fullCount(processed)}>
                     <span className="mono text-body">{formatCompactCount(processed)}</span>
                     <div
                       role="img"
@@ -456,10 +482,17 @@ function thStyle(align: "left" | "right"): CSSProperties {
   return { textAlign: align };
 }
 
+/** Exact token count with thousands separators, for the per-cell hover title. */
+function fullCount(n: number): string {
+  return `${n.toLocaleString("en-US")} tokens`;
+}
+
+/** Model chip — model name only (provider dropped for width); the full
+ *  `provider/model` stays available on hover. */
 function ModelChip({ provider, model }: { provider: string; model: string }): ReactElement {
   return (
-    <span className="usage-model-chip mono text-caption">
-      {provider}/{model}
+    <span className="usage-model-chip mono text-caption" title={`${provider}/${model}`}>
+      {model}
     </span>
   );
 }

--- a/packages/web/src/pages/agent-detail/usage-tab.tsx
+++ b/packages/web/src/pages/agent-detail/usage-tab.tsx
@@ -434,7 +434,7 @@ function TurnsTable({
                   )}
                 </td>
                 <td>
-                  <ModelChip provider={r.provider} model={r.model} />
+                  <ModelLabel provider={r.provider} model={r.model} />
                 </td>
                 <td
                   className="mono text-body"
@@ -487,11 +487,15 @@ function fullCount(n: number): string {
   return `${n.toLocaleString("en-US")} tokens`;
 }
 
-/** Model chip — model name only (provider dropped for width); the full
- *  `provider/model` stays available on hover. */
-function ModelChip({ provider, model }: { provider: string; model: string }): ReactElement {
+/** Model name — plain mono metadata kept on a single line (no chip box);
+ *  the full `provider/model` stays available on hover. */
+function ModelLabel({ provider, model }: { provider: string; model: string }): ReactElement {
   return (
-    <span className="usage-model-chip mono text-caption" title={`${provider}/${model}`}>
+    <span
+      className="mono text-caption"
+      style={{ color: "var(--fg-3)", whiteSpace: "nowrap" }}
+      title={`${provider}/${model}`}
+    >
       {model}
     </span>
   );


### PR DESCRIPTION
## What & why

PR2 of the agent-detail UX rework — the **interaction + cleanup pass**, stacked on the merged PR1 (action convergence, #1191). It makes each tab read result-first and trims the residual noise.

## Changes

- **Instructions → result-first.** A top **"What this agent is told"** block surfaces the merged runtime instructions (`prompt.append`, after every override) — clamped to ~8 lines with a *Show all* toggle; markdown heading scale is clamped inside it so a big `# Heading` doesn't blow the clamp. The on-demand 👁 *Effective instructions* modal is deleted. Source rows are **de-crowded**: no per-row body peek, click the row heading to read the full body in place (right cluster is just Switch + ⋯, the chevron button is gone).
- **Usage · Recent turns slimmed** (the table flagged as too dense). All 7 columns kept, each slimmed: **Model** shows the model name only (provider on hover), **Chat** truncates with a tooltip, the four token columns stay compact with the **exact value on hover**, and the window moves into the title (`Recent turns · last 30 days`, subtitle removed).
- **Source-label disambiguation.** `team_available` rows read **"From your team · optional"** so they're distinguishable from Switch-bearing `team_recommended` rows.
- **Info cleanup.** Dropped the residual "saves immediately" / restated subtitles on Danger zone, Identity (default), Appearance, and Usage · Activity.
- **Execution.** Runtime row is `label: value` only; the bound Computer row shows the computer's live presence (online/offline dot), sourced from the **bound client's** connection state.
- **Tail-line.** A section's last row/block drops its trailing `:last-child` bottom hairline (Identity block + resource lists) so it doesn't double up with the gap before the next section.
- **Type glyph** `--fg-4 → --fg-3` so the four resource kinds read apart (ux-expert trial — revert if too heavy).

## Verification

- `pnpm --filter @first-tree/web test` — 119 files / 901 tests green.
- `pnpm check` (biome) — 0 errors. `pnpm --filter @first-tree/web typecheck` (+ lint:tokens) — clean.
- **DEV preview** `/preview/agent-detail` now also covers the slimmed Usage · Recent turns (mock turns) and the Execution computer-presence (online/offline), so both are reviewable without a live bound computer.

## Review follow-ups — landed on this PR (no separate issues)

- **R1 (codex-assistant / yuezengwu):** Computer presence now sourced from the bound client (`status === "connected"`) via `ctx.boundComputerOnline`, not agent presence → codex-assistant re-reviewed and approved.
- **R2:** the prompt-row expand control's accessible name includes the row name (e.g. `Expand Style guide`), so multiple expanders are distinguishable.
- ux-expert visual polish (tail-line, icon trial, Usage + Execution-presence in the preview, Effective-block heading scale) — all landed; ux-expert's final light+dark read in progress.

## Notes

- No backend/API change; implementation-only (no Context Tree change).
- **Do not self-merge** — gandy-s-assistant coordinates merge; gandy2025 authorizes.
