### PR TITLE
fix(web): trim agent-detail explanatory copy

### DIFF
--- a/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
+++ b/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
@@ -974,7 +974,7 @@ describe("page SSR smoke coverage", () => {
       // moved to their own Repositories tab; Tools & skills lists only skills + MCP.
       ["/agents/agent-1/runtime", "Reasoning effort"],
       ["/agents/agent-1/repositories", "Team web"],
-      ["/agents/agent-1/prompt", "What this agent is told"],
+      ["/agents/agent-1/prompt", "Instructions"],
       ["/agents/agent-1/resources", "Integrations (MCP)"],
     ] as const) {
       expect(

--- a/packages/web/src/pages/agent-detail-preview.tsx
+++ b/packages/web/src/pages/agent-detail-preview.tsx
@@ -512,9 +512,8 @@ export function AgentDetailPreviewPage() {
             Instructions tab
           </h1>
           <p className="text-body" style={{ color: "var(--fg-3)", marginTop: "var(--sp-1)" }}>
-            Result-first: the top "What this agent is told" block shows the merged runtime instructions (clamp + Show
-            all). Source rows are de-crowded — Switch + ⋯ only, click a row to read its full body. The old 👁 modal is
-            gone.
+            Result-first: the top block shows the merged runtime instructions (clamp + Show all), without extra label
+            copy. Source rows are de-crowded — Switch + ⋯ only, click a row to read its full body.
           </p>
           <div style={{ marginTop: "var(--sp-4)" }}>
             <TabHost element={<PromptTab />} />
@@ -528,15 +527,15 @@ export function AgentDetailPreviewPage() {
             exact value on hover, window in the title.
           </p>
           <div style={{ marginTop: "var(--sp-4)" }}>
-            <TabHost element={<UsageTab />} />
+            <TabHost element={<UsageTab fetchEnabled={false} refetchInterval={false} />} />
           </div>
 
           <h1 className="text-title m-0" style={{ marginTop: "var(--sp-8)", color: "var(--fg)" }}>
             Execution — computer presence
           </h1>
           <p className="text-body" style={{ color: "var(--fg-3)", marginTop: "var(--sp-1)" }}>
-            Runtime row is label:value only; the bound Computer row shows the computer's live connection state (online /
-            offline dot) instead of a restated caption.
+            Runtime row is label:value only; the bound Computer row keeps the computer name and connection state on one
+            line.
           </p>
           <div style={{ marginTop: "var(--sp-4)" }}>
             <RuntimeSection

--- a/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
@@ -473,7 +473,7 @@ describe("AgentDetailPage", () => {
     );
 
     const { container, root } = await renderDom("/agents/agent-1/prompt", <PromptTab />);
-    await waitForText(container, "What this agent is told");
+    await waitForText(container, "Team style guide");
     expect(container.textContent).toContain("Vega");
     expect(container.textContent).toContain("1 active");
     expect(container.textContent).toContain("Chat");
@@ -632,7 +632,7 @@ describe("AgentDetailPage", () => {
     );
 
     const { container, root } = await renderDom("/agents/agent-1/prompt", <PromptTab />);
-    await waitForText(container, "What this agent is told");
+    await waitForText(container, "Team style guide");
     await clickRowMenuItem(container, "More actions for Team style guide", "Customize for this agent");
     await waitForText(container, "Save instructions");
     const textarea = container.querySelector<HTMLTextAreaElement>("#custom-prompt-body");
@@ -700,7 +700,7 @@ describe("AgentDetailPage", () => {
     );
 
     const { container, root } = await renderDom("/agents/agent-1/prompt", <PromptTab />);
-    await waitForText(container, "What this agent is told");
+    await waitForText(container, "Team style guide");
     await clickRowMenuItem(container, "More actions for Team style guide", "Customize for this agent");
     await waitForText(container, "Save instructions");
     const textarea = container.querySelector<HTMLTextAreaElement>("#custom-prompt-body");
@@ -769,7 +769,7 @@ describe("AgentDetailPage", () => {
     );
 
     const { container, root } = await renderDom("/agents/agent-1/prompt", <PromptTab />);
-    await waitForText(container, "What this agent is told");
+    await waitForText(container, "Team style guide");
     // Disabling a recommended prompt is now the row's Switch, toggled off.
     await click(container.querySelector('button[role="switch"]'));
     await waitForCondition(
@@ -885,7 +885,7 @@ describe("AgentDetailPage", () => {
   it("starts a draft chat with the current agent from the header", async () => {
     const { PromptTab } = await import("../prompt-tab.js");
     const { container, root } = await renderDom("/agents/agent-1/prompt", <PromptTab />);
-    await waitForText(container, "What this agent is told");
+    await waitForText(container, "Custom instructions");
 
     await click(container.querySelector('button[aria-label="Start chat"]'));
     await waitForText(container, "/?c=draft&with=agent-1");

--- a/packages/web/src/pages/agent-detail/__tests__/usage-tab.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/usage-tab.test.tsx
@@ -275,7 +275,7 @@ describe("UsageTab", () => {
     expect(container.textContent).toContain("Active days");
     expect(container.textContent).toContain("Peak day");
     expect(container.textContent).toContain("Recent turns");
-    expect(container.textContent).toContain("Daily processed tokens.");
+    expect(container.textContent).not.toContain("Daily processed tokens.");
     expect(container.textContent).not.toContain("Darker cells mean more usage");
     expect(
       activityCells.find((cell) => cell.getAttribute("aria-label")?.includes("10.5K processed tokens")),

--- a/packages/web/src/pages/agent-detail/appearance-section.tsx
+++ b/packages/web/src/pages/agent-detail/appearance-section.tsx
@@ -104,7 +104,7 @@ export function AppearanceSection({ agent, canEdit = true, onEdit, variant = "se
   }
 
   return (
-    <Section title="Appearance" description="Shows in chats, lists, and mentions." action={action}>
+    <Section title="Appearance" action={action}>
       {content}
     </Section>
   );

--- a/packages/web/src/pages/agent-detail/capability-section.tsx
+++ b/packages/web/src/pages/agent-detail/capability-section.tsx
@@ -142,7 +142,6 @@ export function ResourceTypeSection(props: {
     <Section
       title={titleWithSemantics(typeLabel(type), saved)}
       count={rows.length}
-      description={type === "mcp" ? "From the MCP servers you connect." : undefined}
       action={
         canEdit ? (
           <AddCapabilityMenu

--- a/packages/web/src/pages/agent-detail/env-section.tsx
+++ b/packages/web/src/pages/agent-detail/env-section.tsx
@@ -122,7 +122,7 @@ export function EnvSection({ items, onSave, disabled, saving, saveError, saved }
     <Section
       title={titleWithSemantics("Environment variables", saved)}
       count={items.length}
-      description="Injected into this agent's runtime process. Sensitive values are encrypted and hidden after save."
+      description="Sensitive values are encrypted and hidden after save."
       action={action}
     >
       <div>

--- a/packages/web/src/pages/agent-detail/model-section.tsx
+++ b/packages/web/src/pages/agent-detail/model-section.tsx
@@ -69,7 +69,7 @@ export function ModelSection({ value, onChange, disabled, provider = "claude-cod
   }, [presetOptions, value]);
 
   return (
-    <ConfigRow label="Model" description={MODEL_HELP_BY_PROVIDER[provider]}>
+    <ConfigRow label="Model" helpText={MODEL_HELP_BY_PROVIDER[provider]}>
       <Select options={items} value={value} onChange={onChange} disabled={disabled} mono aria-label="Model" />
     </ConfigRow>
   );

--- a/packages/web/src/pages/agent-detail/prompt-tab.tsx
+++ b/packages/web/src/pages/agent-detail/prompt-tab.tsx
@@ -71,6 +71,7 @@ export function PromptTab() {
   const canEditPrompt = ctx.canManageAgent && ctx.agent.status === "active";
   const resourceError = resourcesQuery.error instanceof Error ? resourcesQuery.error.message : null;
   const resources = resourcesQuery.data;
+  const showEffectiveInstructions = resources ? shouldShowEffectiveInstructions(resources, prompt) : false;
   const editorError = savePromptMut.error instanceof Error ? savePromptMut.error.message : null;
   const bindingError = bindingMut.error instanceof Error ? bindingMut.error.message : null;
   const bindings = resources?.bindings ?? [];
@@ -140,7 +141,7 @@ export function PromptTab() {
           ) : null
         }
       >
-        <EffectiveInstructionsBlock prompt={prompt} />
+        {showEffectiveInstructions ? <EffectiveInstructionsBlock prompt={prompt} /> : null}
         <div>
           {resources ? (
             <PromptResourceBlocks
@@ -185,7 +186,7 @@ export function PromptTab() {
 function EffectiveInstructionsBlock({ prompt }: { prompt: string }) {
   const [showAll, setShowAll] = useState(false);
   const [clamped, setClamped] = useState(false);
-  const bodyRef = useRef<HTMLDivElement | null>(null);
+  const bodyRef = useRef<HTMLElement | null>(null);
   // biome-ignore lint/correctness/useExhaustiveDependencies: re-measure when the prompt text changes.
   useEffect(() => {
     const el = bodyRef.current;
@@ -194,13 +195,11 @@ function EffectiveInstructionsBlock({ prompt }: { prompt: string }) {
 
   return (
     <div style={{ marginBottom: "var(--sp-4)" }}>
-      <p className="text-eyebrow" style={{ color: "var(--fg-3)", margin: "0 0 var(--sp-1_5)" }}>
-        What this agent is told
-      </p>
       {prompt.trim() ? (
         <>
-          <div
+          <section
             ref={bodyRef}
+            aria-label="Effective instructions"
             className="text-body"
             style={{
               background: "var(--bg-sunken)",
@@ -212,7 +211,7 @@ function EffectiveInstructionsBlock({ prompt }: { prompt: string }) {
             }}
           >
             <Markdown className={PROSE_COMPACT_HEADINGS}>{prompt}</Markdown>
-          </div>
+          </section>
           {clamped || showAll ? (
             <Button
               type="button"
@@ -334,6 +333,13 @@ function convertPromptBindingToInline(
 
 function nextOrder(bindings: readonly AgentResourceBindingInput[]): number {
   return bindings.reduce((max, binding) => Math.max(max, binding.order ?? 0), 0) + 1;
+}
+
+function shouldShowEffectiveInstructions(data: AgentResourcesOutput, prompt: string): boolean {
+  if (!prompt.trim()) return false;
+  const activeRows = enabledPromptRows(data);
+  if (activeRows.length > 1) return true;
+  return data.effective.prompts.some((row) => row.mode === "replaced" || !!row.replacesResourceId);
 }
 
 function PromptResourceBlocks(props: {

--- a/packages/web/src/pages/agent-detail/reasoning-effort-section.tsx
+++ b/packages/web/src/pages/agent-detail/reasoning-effort-section.tsx
@@ -68,7 +68,7 @@ export function ReasoningEffortSection({
   }, [presetOptions, value]);
 
   return (
-    <ConfigRow label="Reasoning effort" description={EFFORT_HELP_BY_PROVIDER[provider]}>
+    <ConfigRow label="Reasoning effort" helpText={EFFORT_HELP_BY_PROVIDER[provider]}>
       <Select
         options={items}
         value={value}

--- a/packages/web/src/pages/agent-detail/runtime-section.tsx
+++ b/packages/web/src/pages/agent-detail/runtime-section.tsx
@@ -33,10 +33,7 @@ const RUNTIME_NAME: Record<RuntimeProvider, string> = {
 
 export function RuntimeSection(props: RuntimeSectionProps) {
   return (
-    <Section
-      title={titleWithSemantics("Execution")}
-      description="Runtime is set when the agent is created; the computer is bound once and is then fixed."
-    >
+    <Section title={titleWithSemantics("Execution")}>
       <ComputerRow
         computerLabel={props.computerLabel}
         online={props.computerOnline ?? null}
@@ -51,9 +48,7 @@ export function RuntimeSection(props: RuntimeSectionProps) {
   );
 }
 
-// Runtime is fixed at creation, so it's a read-only label. The old per-provider
-// caption just restated the value — the section subtitle already says runtime is
-// fixed — so the row carries only `label: value`.
+// Runtime is fixed at creation, so it's a read-only label.
 function RuntimeRow({ name }: { name: string }) {
   return <ConfigRow label="Runtime" value={name} />;
 }
@@ -93,21 +88,24 @@ function ComputerRow(props: {
     value = "No computer bound";
     description = "Bind a connected computer before this agent can run.";
   } else {
-    // Bound computer → show its live connection state instead of a static
-    // caption that just restated "this computer runs the agent".
-    description = <ComputerPresence online={props.online} />;
+    value = (
+      <span className="inline-flex min-w-0 items-center" style={{ gap: "var(--sp-2)" }}>
+        <span className="truncate">{props.computerLabel}</span>
+        <ComputerPresence online={props.online} />
+      </span>
+    );
   }
 
   return <ConfigRow label="Computer" value={value} description={description} action={action} />;
 }
 
 // Live presence of the bound computer: a connected computer is "present" (blue,
-// per the state map), a disconnected one is offline (gray). Unknown → nothing.
+// per the state map), a disconnected one is offline (gray). Unknown → hidden.
 function ComputerPresence({ online }: { online: boolean | null }) {
   if (online == null) return null;
   const color = online ? "var(--state-idle)" : "var(--state-offline)";
   return (
-    <span className="inline-flex items-center gap-1.5" style={{ color: "var(--fg-3)" }}>
+    <span className="inline-flex shrink-0 items-center gap-1.5 text-caption" style={{ color: "var(--fg-3)" }}>
       <StatusGlyph colorVar={color} shape="dot" size={7} ariaLabel={online ? "Online" : "Offline"} />
       {online ? "Online" : "Offline"}
     </span>

--- a/packages/web/src/pages/agent-detail/usage-tab.tsx
+++ b/packages/web/src/pages/agent-detail/usage-tab.tsx
@@ -34,14 +34,20 @@ const WEEKDAY_RAIL: readonly string[] = ["", "Mon", "", "Wed", "", "Fri", ""];
  * trailing-90d `daily` series regardless of the `from` window, so the 30d
  * call here is just a stable, server-cached key.
  */
-export function UsageTab(): ReactElement {
+export function UsageTab({
+  fetchEnabled = true,
+  refetchInterval = 60_000,
+}: {
+  fetchEnabled?: boolean;
+  refetchInterval?: number | false;
+} = {}): ReactElement {
   const ctx = useAgentDetailContext();
 
   const summaryQuery = useQuery({
     queryKey: ["usage-summary", ctx.agent.uuid, "30d"],
     queryFn: () => getAgentUsageSummary(ctx.agent.uuid, "30d"),
-    enabled: !ctx.isHuman,
-    refetchInterval: 60_000,
+    enabled: fetchEnabled && !ctx.isHuman,
+    refetchInterval,
     staleTime: 30_000,
   });
   const [turnsLimit, setTurnsLimit] = useState(RECENT_TURNS_LIMIT);
@@ -51,8 +57,8 @@ export function UsageTab(): ReactElement {
   const turnsQuery = useQuery({
     queryKey: ["usage-turns", ctx.agent.uuid, "30d", turnsLimit],
     queryFn: () => getAgentUsageTurns(ctx.agent.uuid, { window: "30d", limit: turnsLimit }),
-    enabled: !ctx.isHuman,
-    refetchInterval: 60_000,
+    enabled: fetchEnabled && !ctx.isHuman,
+    refetchInterval,
     staleTime: 30_000,
   });
   useEffect(() => {
@@ -123,7 +129,6 @@ function ActivityBlock({
           </span>
         </>
       }
-      description="Daily processed tokens."
       action={<DensityLegend />}
     >
       {isError ? (


### PR DESCRIPTION
## What & why

Follow-up to #1193 after gandy's Agent Detail review: remove remaining explanatory/caption copy that was still making the tabs feel noisy, and keep the Computer connection state on the same row as the bound computer name.

## Changes

- **Execution:** remove the section subtitle and render bound Computer presence inline (`gandy-macbook · Online/Offline`) instead of as a second-line caption.
- **Model / Reasoning effort:** move provider-specific explanatory text out of visible row captions and into the existing label help tooltip.
- **Instructions:** remove the visible "What this agent is told" eyebrow and show the effective-instructions block only when it adds merge/override value (multi-source or replacement cases). Simple single-source instructions now avoid duplicate text.
- **Usage / resources / profile cleanup:** remove remaining low-value subtitles: Usage Activity, MCP integration caption, Appearance caption; shorten Environment variables to only the security-relevant hidden-after-save note.
- **DEV preview:** pin Usage preview to seeded fixtures (`fetchEnabled={false}`) so long review sessions no longer refetch real usage APIs.

## Verification

- `pnpm --dir packages/web exec vitest run --passWithNoTests src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx src/pages/agent-detail/__tests__/usage-tab.test.tsx src/pages/agent-detail/__tests__/resources-tab-dom.test.tsx src/pages/agent-detail/__tests__/appearance-identity-options-dom.test.tsx src/pages/__tests__/page-ssr-smoke.test.tsx` — 40 tests passed.
- `pnpm exec biome check ...` on changed files — clean.
- `pnpm --filter @first-tree/web typecheck` — clean, including `lint:tokens`.
- `pnpm check` — exit 0 (repo still reports existing warnings/info only).
- `pnpm --filter @first-tree/web test` — 119 files / 901 tests passed.
- `git diff --check` — clean.
- Local DEV preview at `/preview/agent-detail`: Usage fixtures render without usage API refetch; Computer presence container verified as inline-flex.

## Tree

Implementation-only Web UI cleanup; no new durable cross-domain decision or Context Tree write.

Supersedes #1197, which used a non-compliant `codex/` branch name.