### PR TITLE
fix(web): label effective instructions block

### DIFF
--- a/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
@@ -486,6 +486,7 @@ describe("AgentDetailPage", () => {
       "Usage",
     ]);
     expect(container.textContent).toContain("Always explain tradeoffs.");
+    expect(container.textContent).toContain("Effective");
     await waitForText(container, "Team style guide");
     expect(container.textContent).toContain("Team style guide");
     expect(container.textContent).toContain("Added by you");

--- a/packages/web/src/pages/agent-detail/prompt-tab.tsx
+++ b/packages/web/src/pages/agent-detail/prompt-tab.tsx
@@ -197,6 +197,9 @@ function EffectiveInstructionsBlock({ prompt }: { prompt: string }) {
     <div style={{ marginBottom: "var(--sp-4)" }}>
       {prompt.trim() ? (
         <>
+          <p className="text-eyebrow" style={{ color: "var(--fg-4)", margin: "0 0 var(--sp-1_5)" }}>
+            Effective
+          </p>
           <section
             ref={bodyRef}
             aria-label="Effective instructions"


### PR DESCRIPTION
## What & why

Tiny follow-up to #1198 from ux-expert's final visual read: the effective instructions panel needs a quiet one-word label so it reads as the merged/effective result rather than as the first expanded instruction row.

## Changes

- Add a minimal `Effective` eyebrow above the effective instructions block.
- Keep the prior #1198 behavior intact: the block still only appears when it adds merge/override value, and simple single-source instruction cases still avoid duplicate text.
- Add a focused DOM assertion so the multi-source prompt case keeps the label.

## Verification

- `pnpm --dir packages/web exec vitest run --passWithNoTests src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx` — 12 tests passed.
- `pnpm exec biome check packages/web/src/pages/agent-detail/prompt-tab.tsx packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx` — clean.
- `pnpm --filter @first-tree/web typecheck` — clean, including `lint:tokens`.
- `git diff --check` — clean.

## Tree

Implementation-only Web UI label polish; no new durable Context Tree decision.