### PR TITLE
feat(web): instrument cloud SPA with GA4 + cross-domain linking

### DIFF
--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -25,21 +25,22 @@
       same host gate before sending, as defense in depth.
     -->
     <script>
-      if (window.location.hostname === "cloud.first-tree.ai") {
+      (() => {
+        if (window.location.hostname !== "cloud.first-tree.ai") return;
         window.dataLayer = window.dataLayer || [];
-        window.gtag = function () {
-          dataLayer.push(arguments);
+        window.gtag = (...args) => {
+          window.dataLayer.push(args);
         };
-        var s = document.createElement("script");
-        s.async = true;
-        s.src = "https://www.googletagmanager.com/gtag/js?id=G-BHG918MZ02";
-        document.head.appendChild(s);
-        gtag("js", new Date());
-        gtag("config", "G-BHG918MZ02", {
+        const tag = document.createElement("script");
+        tag.async = true;
+        tag.src = "https://www.googletagmanager.com/gtag/js?id=G-BHG918MZ02";
+        document.head.appendChild(tag);
+        window.gtag("js", new Date());
+        window.gtag("config", "G-BHG918MZ02", {
           send_page_view: false,
           linker: { domains: ["first-tree.ai", "cloud.first-tree.ai"] },
         });
-      }
+      })();
     </script>
     <script>
       (() => {

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -16,18 +16,30 @@
       attributable per repo/campaign). send_page_view is off: this is a
       react-router SPA, so RouteTracker (src/analytics.tsx) reports page_view on
       every route change — leaving it on would double-count the first screen.
+
+      PRODUCTION ONLY: the Docker build produces one web dist for every channel,
+      so we gate here on hostname. Without this, dev (127.0.0.1) and staging
+      (dev.cloud.first-tree.ai) would load gtag and write into the shared
+      production property, polluting the attribution dataset. gtag is neither
+      fetched nor configured off the production host. analytics.tsx applies the
+      same host gate before sending, as defense in depth.
     -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-BHG918MZ02"></script>
     <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag() {
-        dataLayer.push(arguments);
+      if (window.location.hostname === "cloud.first-tree.ai") {
+        window.dataLayer = window.dataLayer || [];
+        window.gtag = function () {
+          dataLayer.push(arguments);
+        };
+        var s = document.createElement("script");
+        s.async = true;
+        s.src = "https://www.googletagmanager.com/gtag/js?id=G-BHG918MZ02";
+        document.head.appendChild(s);
+        gtag("js", new Date());
+        gtag("config", "G-BHG918MZ02", {
+          send_page_view: false,
+          linker: { domains: ["first-tree.ai", "cloud.first-tree.ai"] },
+        });
       }
-      gtag("js", new Date());
-      gtag("config", "G-BHG918MZ02", {
-        send_page_view: false,
-        linker: { domains: ["first-tree.ai", "cloud.first-tree.ai"] },
-      });
     </script>
     <script>
       (() => {

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -9,6 +9,26 @@
     <link rel="preload" href="/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin />
     <link rel="preload" href="/fonts/jetbrains-mono-latin.woff2" as="font" type="font/woff2" crossorigin />
     <title>First Tree</title>
+    <!--
+      Google Analytics 4 — same property (G-BHG918MZ02) as first-tree.ai, with
+      cross-domain linking so a visitor who goes marketing-site -> cloud is
+      stitched into one user (that's what makes "click_app -> signup"
+      attributable per repo/campaign). send_page_view is off: this is a
+      react-router SPA, so RouteTracker (src/analytics.tsx) reports page_view on
+      every route change — leaving it on would double-count the first screen.
+    -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-BHG918MZ02"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag("js", new Date());
+      gtag("config", "G-BHG918MZ02", {
+        send_page_view: false,
+        linker: { domains: ["first-tree.ai", "cloud.first-tree.ai"] },
+      });
+    </script>
     <script>
       (() => {
         const t = localStorage.getItem("theme");

--- a/packages/web/src/__tests__/analytics.test.ts
+++ b/packages/web/src/__tests__/analytics.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { sanitizePath } from "../analytics.js";
+
+describe("sanitizePath", () => {
+  it("templates invite tokens so the code never reaches GA", () => {
+    expect(sanitizePath("/invite/abc123secret")).toBe("/invite/[token]");
+    expect(sanitizePath("/invite/another-long-token")).toBe("/invite/[token]");
+  });
+
+  it("collapses the OAuth complete route to a fixed path", () => {
+    // The token lives in the hash, but template the path too as defense in depth.
+    expect(sanitizePath("/auth/github/complete")).toBe("/auth/github/complete");
+  });
+
+  it("passes through ordinary routes unchanged", () => {
+    expect(sanitizePath("/")).toBe("/");
+    expect(sanitizePath("/agents")).toBe("/agents");
+    expect(sanitizePath("/settings/team")).toBe("/settings/team");
+  });
+
+  it("does not leak a token even when the invite path has extra segments", () => {
+    expect(sanitizePath("/invite/tok/extra")).toBe("/invite/[token]");
+  });
+});

--- a/packages/web/src/analytics.tsx
+++ b/packages/web/src/analytics.tsx
@@ -1,0 +1,51 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router";
+
+/**
+ * GA4 analytics for the cloud SPA. The gtag snippet + config live in
+ * index.html (property G-BHG918MZ02, cross-domain linker, send_page_view off).
+ * This module reports SPA navigations and exposes a typed event helper.
+ *
+ * Why manual page_view: gtag fires page_view once on initial load. A
+ * react-router app changes the URL without a full load, so without this every
+ * post-login screen would be invisible. send_page_view is disabled in the
+ * config so the first screen is reported here exactly once, not twice.
+ */
+
+type GtagArgs =
+  | [command: "config", targetId: string, config?: Record<string, unknown>]
+  | [command: "event", eventName: string, params?: Record<string, unknown>]
+  | [command: "set", params: Record<string, unknown>];
+
+function gtag(...args: GtagArgs): void {
+  if (typeof window === "undefined") return;
+  const w = window as unknown as { gtag?: (...a: GtagArgs) => void };
+  // gtag is defined inline in index.html; guard in case the snippet is absent
+  // (e.g. an ad-blocker removed it) so analytics never breaks the app.
+  w.gtag?.(...args);
+}
+
+/** Report a custom event. Use for conversions like sign_up. No PII in params. */
+export function trackEvent(
+  name: string,
+  params?: Record<string, unknown>,
+): void {
+  gtag("event", name, params);
+}
+
+/**
+ * Mount once inside <BrowserRouter>. Reports a page_view on every route
+ * change, including the first render.
+ */
+export function RouteTracker(): null {
+  const location = useLocation();
+  useEffect(() => {
+    const path = location.pathname + location.search;
+    gtag("event", "page_view", {
+      page_path: path,
+      page_location: window.location.href,
+      page_title: document.title,
+    });
+  }, [location.pathname, location.search]);
+  return null;
+}

--- a/packages/web/src/analytics.tsx
+++ b/packages/web/src/analytics.tsx
@@ -11,7 +11,7 @@ import { useLocation } from "react-router";
  * post-login screen would be invisible. send_page_view is disabled in the
  * config so the first screen is reported here exactly once, not twice.
  *
- * Two hard rules enforced here (see PR review on #1201):
+ * Two hard rules enforced here (see the PR 1201 review):
  *  1. Production only. dev (127.0.0.1) and staging (dev.cloud.first-tree.ai)
  *     must NOT write into the shared production property, or they pollute the
  *     very attribution dataset this exists to make trustworthy.

--- a/packages/web/src/analytics.tsx
+++ b/packages/web/src/analytics.tsx
@@ -10,7 +10,40 @@ import { useLocation } from "react-router";
  * react-router app changes the URL without a full load, so without this every
  * post-login screen would be invisible. send_page_view is disabled in the
  * config so the first screen is reported here exactly once, not twice.
+ *
+ * Two hard rules enforced here (see PR review on #1201):
+ *  1. Production only. dev (127.0.0.1) and staging (dev.cloud.first-tree.ai)
+ *     must NOT write into the shared production property, or they pollute the
+ *     very attribution dataset this exists to make trustworthy.
+ *  2. Never leak bearer-style URLs to GA. The SPA has routes whose hash or path
+ *     carries credentials — /auth/github/complete#access=...&refresh=... and
+ *     /invite/:token. We strip the hash and search, and template sensitive
+ *     paths, before anything is sent.
  */
+
+const PROD_HOST = "cloud.first-tree.ai";
+
+/** Only the production cloud host reports to the shared GA property. */
+export function analyticsEnabled(): boolean {
+  if (typeof window === "undefined") return false;
+  return window.location.hostname === PROD_HOST;
+}
+
+/**
+ * Map a raw pathname to a safe, credential-free path for analytics.
+ * Sensitive routes are templated so no token/code reaches GA; everything else
+ * passes through (the search string is dropped by the caller, not kept here).
+ */
+export function sanitizePath(pathname: string): string {
+  // /invite/<token> -> /invite/[token]  (path-borne invite code)
+  if (pathname.startsWith("/invite/")) return "/invite/[token]";
+  // /auth/github/complete carries the OAuth token in the hash; report the
+  // fixed path only. (Defense in depth — we also drop the hash below.)
+  if (pathname.startsWith("/auth/github/complete")) {
+    return "/auth/github/complete";
+  }
+  return pathname;
+}
 
 type GtagArgs =
   | [command: "config", targetId: string, config?: Record<string, unknown>]
@@ -18,7 +51,7 @@ type GtagArgs =
   | [command: "set", params: Record<string, unknown>];
 
 function gtag(...args: GtagArgs): void {
-  if (typeof window === "undefined") return;
+  if (!analyticsEnabled()) return;
   const w = window as unknown as { gtag?: (...a: GtagArgs) => void };
   // gtag is defined inline in index.html; guard in case the snippet is absent
   // (e.g. an ad-blocker removed it) so analytics never breaks the app.
@@ -26,26 +59,26 @@ function gtag(...args: GtagArgs): void {
 }
 
 /** Report a custom event. Use for conversions like sign_up. No PII in params. */
-export function trackEvent(
-  name: string,
-  params?: Record<string, unknown>,
-): void {
+export function trackEvent(name: string, params?: Record<string, unknown>): void {
   gtag("event", name, params);
 }
 
 /**
  * Mount once inside <BrowserRouter>. Reports a page_view on every route
- * change, including the first render.
+ * change, including the first render. Never sends the hash or query string,
+ * and templates credential-bearing paths.
  */
 export function RouteTracker(): null {
   const location = useLocation();
   useEffect(() => {
-    const path = location.pathname + location.search;
+    const safePath = sanitizePath(location.pathname);
     gtag("event", "page_view", {
-      page_path: path,
-      page_location: window.location.href,
+      page_path: safePath,
+      // Reconstruct a clean location: origin + safe path only. Never the raw
+      // href — that would carry the OAuth hash / invite token to GA.
+      page_location: window.location.origin + safePath,
       page_title: document.title,
     });
-  }, [location.pathname, location.search]);
+  }, [location.pathname]);
   return null;
 }

--- a/packages/web/src/app.tsx
+++ b/packages/web/src/app.tsx
@@ -1,6 +1,7 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { lazy, Suspense } from "react";
 import { BrowserRouter, Navigate, Route, Routes, useLocation } from "react-router";
+import { RouteTracker } from "./analytics.js";
 import { AuthProvider } from "./auth/auth-context.js";
 import { RequireAuth } from "./auth/require-auth.js";
 import { Layout } from "./components/layout.js";
@@ -118,6 +119,7 @@ export function App() {
       <AuthProvider>
         <ToastProvider>
           <BrowserRouter>
+            <RouteTracker />
             <Routes>
               {/* Public routes — no auth required */}
               <Route path="/login" element={<LoginPage />} />


### PR DESCRIPTION
Refs #1200.

## Why
`cloud.first-tree.ai` (`@first-tree/web`) shipped **no analytics**. Verified: GA4 property `539170414` has zero `hostName = cloud.first-tree.ai` sessions over 90 days, no `sign_up`/`login` event exists, and the live bundle has no `G-` id. So attribution dies at `click_app` — we measure repo/campaign ROI in clicks, not sign-ups.

## What
- **`index.html`** — gtag for the **same property as the marketing site** (`G-BHG918MZ02`) with `linker: { domains: ['first-tree.ai','cloud.first-tree.ai'] }`, so a `marketing-site → cloud` visitor is stitched into one user. `send_page_view: false` (SPA reports manually).
- **`src/analytics.tsx`** (new) — `RouteTracker` reports `page_view` on every react-router navigation (gtag fires once otherwise); `trackEvent()` helper for future conversion events. Both gtag calls are guarded so an ad-blocker stripping the snippet can't break the app.
- **`app.tsx`** — mount `<RouteTracker/>` inside `<BrowserRouter>`.

## Verification
- `tsc --noEmit` clean (new files included).
- `vite build` succeeds; `dist/index.html` contains gtag + linker + `send_page_view:false`.
- Test suite: 897 pass / 4 pre-existing failures — confirmed unrelated by running them on clean `main` (e.g. `command-palette-dom` fails identically without this change).

## Follow-up (separate PR)
Fire a `sign_up` event on successful registration (via `trackEvent`) so per-repo signup conversion becomes measurable. This PR is the plumbing; that's the payoff.

## Privacy
Same GA4 property + consent model already live on the marketing site, extended to the app under the same terms. No PII in events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)