### PR TITLE
docs(readme): tighten top CTA tone (drop "free!!!" / "loopmaxx")

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   English | <a href="README_zh-CN.md">中文</a>
 </p>
 
-> Use this [link](https://cloud.first-tree.ai/login?utm_source=github&utm_medium=readme&utm_campaign=top-cta-app) to use [first-tree 🌳](https://first-tree.ai/?utm_source=github&utm_medium=readme&utm_campaign=top-cta-site) for **free!!!** — the most efficient way to **loopmaxx your engineering work**.
+> Try [first-tree 🌳](https://first-tree.ai/?utm_source=github&utm_medium=readme&utm_campaign=top-cta-site) **free** — the fastest way to give every agent your team's shared context. [Open the app](https://cloud.first-tree.ai/login?utm_source=github&utm_medium=readme&utm_campaign=top-cta-app).
 
 # First-Tree
 


### PR DESCRIPTION
## What

The README's top call-to-action read:

> …to use first-tree 🌳 for **free!!!** — the most efficient way to **loopmaxx your engineering work**.

A marketing review flagged the triple-bang `free!!!` and the coined slang `loopmaxx` as undercutting the B2B-credible voice the rest of the README uses. A CTO evaluating dev infra reads slang as "unserious project."

## Change

> Try first-tree 🌳 **free** — the fastest way to give every agent your team's shared context. Open the app.

- Both links and their per-repo UTM slugs (`top-cta-site`, `top-cta-app`) are **preserved** — only the wording changed.
- `README_zh-CN.md` has no equivalent line (different structure), so no change there.

One line, docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)