### PR TITLE
feat(web): fire GA sign_up conversion on first onboarding completion

### DIFF
--- a/packages/web/src/auth/__tests__/auth-context-provider.test.tsx
+++ b/packages/web/src/auth/__tests__/auth-context-provider.test.tsx
@@ -19,6 +19,7 @@ const apiMocks = vi.hoisted(() => ({
 
 const loginMock = vi.hoisted(() => vi.fn());
 const onboardingCompletedMock = vi.hoisted(() => vi.fn());
+const trackEventMock = vi.hoisted(() => vi.fn());
 const flagsMocks = vi.hoisted(() => ({
   clearOnboardingJoinPath: vi.fn(),
   clearOnboardingSessionFlags: vi.fn(),
@@ -41,6 +42,10 @@ vi.mock("../../api/auth.js", () => ({
 
 vi.mock("../../api/onboarding-events.js", () => ({
   markOnboardingCompleted: onboardingCompletedMock,
+}));
+
+vi.mock("../../analytics.js", () => ({
+  trackEvent: trackEventMock,
 }));
 
 vi.mock("../../utils/onboarding-flags.js", () => flagsMocks);
@@ -312,6 +317,58 @@ describe("AuthProvider", () => {
     });
     expect(onboardingCompletedMock).toHaveBeenCalled();
     expect(latestAuth?.onboardingCompletedAt).toBeTruthy();
+  });
+
+  it("fires the sign_up conversion exactly once when a fresh user first completes onboarding", async () => {
+    // Authenticated fresh signup: stored tokens present so fetchMe runs and
+    // populates memberships, and /me reports onboarding not yet completed in
+    // any membership.
+    apiMocks.getStoredTokens.mockReturnValue({ accessToken: "a", refreshToken: "r" });
+    apiMocks.apiGet.mockResolvedValue({
+      user: { id: "user-1", username: "gandy", displayName: "Gandy", avatarUrl: null },
+      memberships: MEMBERSHIPS, // both fixtures carry onboardingCompletedAt: null
+      defaultOrganizationId: "org-1",
+      onboarding: { step: "create_agent", dismissedAt: null, completedAt: null },
+    });
+    await renderAuth();
+
+    await act(async () => {
+      await latestAuth?.markOnboardingCompleted();
+    });
+    expect(trackEventMock).toHaveBeenCalledWith("sign_up");
+    expect(trackEventMock.mock.calls.filter(([name]) => name === "sign_up")).toHaveLength(1);
+
+    // A second completion (e.g. a stray re-trigger) does not re-fire: the
+    // optimistic patch has now stamped the membership, so the account-level
+    // "never completed anywhere" guard is false.
+    trackEventMock.mockClear();
+    await act(async () => {
+      await latestAuth?.markOnboardingCompleted();
+    });
+    expect(trackEventMock).not.toHaveBeenCalledWith("sign_up");
+  });
+
+  it("does NOT fire sign_up when a returning user completes onboarding in a second org", async () => {
+    // Account-level conversion: this user already finished onboarding in org-1
+    // (membership stamp set), and is now completing in a freshly-joined org-2.
+    // Joining a second team is not a new signup, so sign_up must not re-fire.
+    apiMocks.getStoredTokens.mockReturnValue({ accessToken: "a", refreshToken: "r" });
+    apiMocks.apiGet.mockResolvedValue({
+      user: { id: "user-1", username: "gandy", displayName: "Gandy", avatarUrl: null },
+      memberships: [
+        { ...MEMBERSHIPS[0], onboardingCompletedAt: "2026-05-01T00:00:00.000Z" },
+        { ...MEMBERSHIPS[1], onboardingCompletedAt: null },
+      ],
+      defaultOrganizationId: "org-2",
+      onboarding: { step: "create_agent", dismissedAt: null, completedAt: null },
+    });
+    await renderAuth();
+
+    await act(async () => {
+      await latestAuth?.markOnboardingCompleted();
+    });
+    expect(onboardingCompletedMock).toHaveBeenCalled();
+    expect(trackEventMock).not.toHaveBeenCalledWith("sign_up");
   });
 
   it("adopts external token pairs and falls back when /me fails", async () => {

--- a/packages/web/src/auth/auth-context.tsx
+++ b/packages/web/src/auth/auth-context.tsx
@@ -1,6 +1,7 @@
 import type { MeMembership } from "@first-tree/shared";
 import { useQueryClient } from "@tanstack/react-query";
 import { createContext, type ReactNode, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+import { trackEvent } from "../analytics.js";
 import { login as loginApi } from "../api/auth.js";
 import {
   api,
@@ -425,6 +426,16 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     // un-completing the user.
     const organizationId = currentMembership?.organizationId;
     const optimistic = new Date().toISOString();
+    // Fire the GA `sign_up` conversion exactly once per *account*, on the
+    // user's first ever onboarding completion. Completion is stamped per
+    // membership (a user can belong to several orgs), so a per-membership gate
+    // would re-fire every time the same person finishes onboarding in a new
+    // team — that's not a new signup. The account-level "never completed
+    // anywhere" signal is: no membership carries a completion stamp AND the
+    // legacy top-level stamp is empty (older /me payloads). trackEvent
+    // self-gates to the production host, so dev / StrictMode re-invokes can't
+    // pollute GA either way.
+    const firstCompletion = !onboardingCompletedAt && memberships.every((m) => !m.onboardingCompletedAt);
     setOnboardingCompletedAt((prev) => prev ?? optimistic);
     setOnboardingDismissedAt((prev) => prev ?? optimistic);
     patchMembershipOnboarding({
@@ -432,8 +443,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       onboardingSuppressedAt: currentMembership?.onboardingSuppressedAt ?? optimistic,
       onboardingSuppressedReason: "completed",
     });
+    if (firstCompletion) trackEvent("sign_up");
     await postOnboardingCompleted(organizationId ?? undefined);
   }, [
+    onboardingCompletedAt,
+    memberships,
     currentMembership?.onboardingCompletedAt,
     currentMembership?.onboardingSuppressedAt,
     currentMembership?.organizationId,


### PR DESCRIPTION
## What

Fires a GA4 `sign_up` conversion event when a user completes onboarding for the first time, closing the conversion blind spot that #1201 left open.

`Refs #1200.` (second half of the cloud-analytics funnel work — #1201 laid the GA pipeline, this marks the actual conversion.)

## Why

#1201 instrumented the cloud SPA with GA + cross-domain linking, so we can now see marketing-site → cloud sessions. But nothing marked the **conversion** itself — without it, every repo-hook / UTM campaign shows traffic that vanishes into the app with no signal of whether anyone actually signed up. Onboarding completion is the activation moment: a user who finishes onboarding is a real new user, which is exactly what repo-hook attribution wants to measure.

## How it stays correct

- **Account-level, exactly once per user.** Onboarding completion is stamped **per membership** (a user can belong to several orgs — see #1025). A naive per-membership gate would re-fire `sign_up` every time the same person finishes onboarding in a newly-joined team, inflating the conversion count. The guard instead requires **no membership carries a completion stamp AND the legacy top-level stamp is empty**, so a returning user completing onboarding in a second org never re-fires.
- **No prod-data pollution.** `trackEvent` already self-gates to the `cloud.first-tree.ai` host (from #1201), so dev / staging / StrictMode double-invokes can't write to the production GA property.
- **No new network calls, no backend change** — rides the existing optimistic completion path in `markOnboardingCompleted`.

## Tests

`packages/web/src/auth/__tests__/auth-context-provider.test.tsx`:
1. Fresh user's first completion fires `sign_up` exactly once.
2. A second completion does not re-fire (optimistic stamp now set).
3. A returning user completing onboarding in a second org does not fire.

`pnpm --filter @first-tree/web typecheck` + biome both clean. The 4 unrelated pre-existing failures in `group-rows`/`command-palette`/`visual-regression` (time-dependent tests) reproduce on clean `origin/main` and are untouched by this PR.

## Follow-up

Once merged + deployed, validate in GA Realtime that `sign_up` fires on a fresh cloud onboarding, then mark it as a Key Event (conversion) in the GA UI so it shows up in attribution reports.

---
🤖 Authored by Claude (Claude Code) on behalf of @serenakeyitan. Do not self-merge.