### PR TITLE
fix: notify resumed Claude sessions when the briefing changed

### DIFF
--- a/packages/client/src/__tests__/codex-app-server-handler.test.ts
+++ b/packages/client/src/__tests__/codex-app-server-handler.test.ts
@@ -861,3 +861,51 @@ describe("codex app-server handler", () => {
     await handler.shutdown();
   });
 });
+
+describe("codex app-server briefing-update notice", () => {
+  it("prepends a re-read notice on resume when the session has no recorded briefing baseline", async () => {
+    const fake = new FakeAppServerClient();
+    const handler = makeHandler(fake);
+    const ctx = makeContext({ finishTurn: async () => {} });
+
+    const resumePromise = handler.resume(makeMessage("m1", "hello"), "thread-app-server", ctx);
+    await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
+
+    const start = fake.requests.find((request) => request.method === "turn/start");
+    const input = JSON.stringify(start?.params ?? {});
+    expect(input).toContain("<system-reminder>");
+    expect(input).toContain("re-read");
+
+    completeTurn(fake, "turn-1", "ok");
+    await resumePromise;
+    await handler.shutdown();
+  });
+
+  it("adds no notice when the briefing is unchanged since the session last ran a turn", async () => {
+    // First session start seeds the briefing baseline for this thread id at the
+    // shared agent home (keyed off `workspaceRoot`).
+    const startFake = new FakeAppServerClient();
+    const startHandler = makeHandler(startFake);
+    const startCtx = makeContext({ finishTurn: async () => {} });
+    const startPromise = startHandler.start(makeMessage("m1", "first"), startCtx);
+    await waitFor(() => startFake.requests.some((request) => request.method === "turn/start"));
+    completeTurn(startFake, "turn-1", "first answer");
+    await startPromise;
+    await startHandler.shutdown();
+
+    // A later resume of the same thread, same config (briefing unchanged) →
+    // baseline matches → no re-read notice.
+    const resumeFake = new FakeAppServerClient();
+    const resumeHandler = makeHandler(resumeFake);
+    const resumeCtx = makeContext({ finishTurn: async () => {} });
+    const resumePromise = resumeHandler.resume(makeMessage("m2", "again"), "thread-app-server", resumeCtx);
+    await waitFor(() => resumeFake.requests.some((request) => request.method === "turn/start"));
+
+    const start = resumeFake.requests.find((request) => request.method === "turn/start");
+    expect(JSON.stringify(start?.params ?? {})).not.toContain("<system-reminder>");
+
+    completeTurn(resumeFake, "turn-1", "second answer");
+    await resumePromise;
+    await resumeHandler.shutdown();
+  });
+});

--- a/packages/client/src/__tests__/codex-app-server-handler.test.ts
+++ b/packages/client/src/__tests__/codex-app-server-handler.test.ts
@@ -908,4 +908,31 @@ describe("codex app-server briefing-update notice", () => {
     await resumePromise;
     await resumeHandler.shutdown();
   });
+
+  it("keeps the notice for the next resume when the turn fails before reaching the provider", async () => {
+    // First resume hits a pre-provider turn/start failure: the notice was
+    // consumed for that attempt but the model never saw it, so the baseline
+    // must NOT advance.
+    const failFake = new FakeAppServerClient();
+    failFake.turnStartError = new CodexAppServerTransportError("codex app-server request timed out: turn/start");
+    const failHandler = makeHandler(failFake);
+    const failCtx = makeContext({ failSessionForRecovery: vi.fn(), finishTurn: async () => {} });
+    await failHandler.resume(makeMessage("m1", "hello"), "thread-app-server", failCtx);
+    expect(failFake.requests.some((request) => request.method === "turn/start")).toBe(true);
+    await failHandler.shutdown();
+
+    // Second resume of the same thread: baseline was never recorded, so the
+    // briefing still reads as changed and the re-read notice reappears.
+    const okFake = new FakeAppServerClient();
+    const okHandler = makeHandler(okFake);
+    const okCtx = makeContext({ finishTurn: async () => {} });
+    const resumePromise = okHandler.resume(makeMessage("m2", "again"), "thread-app-server", okCtx);
+    await waitFor(() => okFake.requests.some((request) => request.method === "turn/start"));
+    const start = okFake.requests.find((request) => request.method === "turn/start");
+    expect(JSON.stringify(start?.params ?? {})).toContain("<system-reminder>");
+
+    completeTurn(okFake, "turn-1", "ok");
+    await resumePromise;
+    await okHandler.shutdown();
+  });
 });

--- a/packages/client/src/__tests__/codex-app-server-handler.test.ts
+++ b/packages/client/src/__tests__/codex-app-server-handler.test.ts
@@ -5,6 +5,7 @@ import type { SessionEvent } from "@first-tree/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CodexAppServerRpcError, CodexAppServerTransportError } from "../handlers/codex/app-server/client.js";
 import { createCodexAppServerHandler } from "../handlers/codex/app-server/index.js";
+import { writeAgentBriefing } from "../runtime/bootstrap.js";
 import type { DeliveryToken, SessionContext, SessionMessage } from "../runtime/handler.js";
 import { mockCtxPlumbing } from "./test-helpers.js";
 
@@ -997,6 +998,32 @@ describe("codex app-server briefing-update notice", () => {
 
     const injectedStart = fake.requests.filter((request) => request.method === "turn/start")[startTurns];
     expect(JSON.stringify(injectedStart?.params ?? {})).toContain("<system-reminder>");
+
+    completeTurn(fake, "turn-2", "second answer");
+    await handler.shutdown();
+  });
+
+  it("still delivers the injected message when the active-session briefing rewrite throws", async () => {
+    const { cache, setAppend } = makeMutableConfigCache("BEFORE_MARKER");
+    const fake = new FakeAppServerClient();
+    const handler = makeHandler(fake, { agentConfigCache: cache });
+    const ctx = makeContext({ finishTurn: async () => {} });
+
+    const startPromise = handler.start(makeMessage("m1", "first"), ctx);
+    await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
+    completeTurn(fake, "turn-1", "first answer");
+    await startPromise;
+    const startTurns = fake.requests.filter((request) => request.method === "turn/start").length;
+
+    // Prompt changes; the active-turn briefing rewrite throws (e.g. disk error).
+    // The batch was already dequeued, so the message must still reach turn/start
+    // rather than being stranded.
+    setAppend("AFTER_MARKER");
+    vi.mocked(writeAgentBriefing).mockImplementationOnce(() => {
+      throw new Error("simulated disk failure");
+    });
+    handler.inject(makeMessage("m2", "again"));
+    await waitFor(() => fake.requests.filter((request) => request.method === "turn/start").length === startTurns + 1);
 
     completeTurn(fake, "turn-2", "second answer");
     await handler.shutdown();

--- a/packages/client/src/__tests__/codex-app-server-handler.test.ts
+++ b/packages/client/src/__tests__/codex-app-server-handler.test.ts
@@ -200,7 +200,7 @@ function makeContext(
   };
 }
 
-function makeHandler(fake: FakeAppServerClient) {
+function makeHandler(fake: FakeAppServerClient, extraConfig: Record<string, unknown> = {}) {
   return createCodexAppServerHandler({
     workspaceRoot,
     codexRuntimeBinaryResolver: async () => ({
@@ -215,7 +215,45 @@ function makeHandler(fake: FakeAppServerClient) {
       fake.onClose = options.onClose ?? null;
       return fake;
     },
+    ...extraConfig,
   });
+}
+
+/**
+ * Minimal mutable agent-config cache: `.get()` / `.refresh()` return a codex
+ * payload whose prompt body the test can flip mid-session to simulate an admin
+ * prompt change. Only the methods the handler actually calls are real.
+ */
+function makeMutableConfigCache(initialAppend: string) {
+  const state = { append: initialAppend };
+  const config = () => ({
+    agentId: AGENT_ID,
+    version: 1,
+    payload: {
+      kind: "codex" as const,
+      prompt: { append: state.append },
+      model: "",
+      mcpServers: [],
+      env: [],
+      gitRepos: [],
+      resourceSkills: [],
+      reasoningEffort: "high" as const,
+    },
+    updatedAt: "",
+    updatedBy: "",
+  });
+  return {
+    cache: {
+      get: () => config(),
+      refresh: async () => config(),
+      maybeRefresh: async () => config(),
+      updateUrls: () => {},
+      forget: () => {},
+    } as unknown as Record<string, unknown>,
+    setAppend: (value: string) => {
+      state.append = value;
+    },
+  };
 }
 
 function makeDeliveryToken(): DeliveryToken {
@@ -934,5 +972,33 @@ describe("codex app-server briefing-update notice", () => {
     completeTurn(okFake, "turn-1", "ok");
     await resumePromise;
     await okHandler.shutdown();
+  });
+
+  it("prepends the notice on an injected turn when the prompt changed mid active session (no resume)", async () => {
+    const { cache, setAppend } = makeMutableConfigCache("BEFORE_MARKER");
+    const fake = new FakeAppServerClient();
+    const handler = makeHandler(fake, { agentConfigCache: cache });
+    const ctx = makeContext({ finishTurn: async () => {} });
+
+    // Start the session and finish its first turn (seeds the briefing baseline
+    // for the BEFORE prompt). Session is now idle/active.
+    const startPromise = handler.start(makeMessage("m1", "first"), ctx);
+    await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
+    completeTurn(fake, "turn-1", "first answer");
+    await startPromise;
+    const startTurns = fake.requests.filter((request) => request.method === "turn/start").length;
+
+    // Admin changes the prompt mid-session, then a message arrives — no
+    // suspend/resume. The injected turn must pick up the new briefing and carry
+    // the re-read notice.
+    setAppend("AFTER_MARKER");
+    handler.inject(makeMessage("m2", "again"));
+    await waitFor(() => fake.requests.filter((request) => request.method === "turn/start").length === startTurns + 1);
+
+    const injectedStart = fake.requests.filter((request) => request.method === "turn/start")[startTurns];
+    expect(JSON.stringify(injectedStart?.params ?? {})).toContain("<system-reminder>");
+
+    completeTurn(fake, "turn-2", "second answer");
+    await handler.shutdown();
   });
 });

--- a/packages/client/src/__tests__/session-briefing-fingerprint.test.ts
+++ b/packages/client/src/__tests__/session-briefing-fingerprint.test.ts
@@ -1,0 +1,86 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  buildBriefingUpdateNotice,
+  computeBriefingFingerprint,
+  readSessionBriefingFingerprint,
+  SESSION_BRIEFINGS_DIR_REL,
+  writeSessionBriefingFingerprint,
+} from "../runtime/session-briefing-fingerprint.js";
+
+const SESSION_ID = "019d9a97-90b0-716b-8317-a8c0be8430d7";
+
+let workspace: string;
+
+beforeEach(() => {
+  workspace = mkdtempSync(join(tmpdir(), "ftt-briefing-fp-"));
+});
+
+afterEach(() => {
+  rmSync(workspace, { recursive: true, force: true });
+});
+
+describe("computeBriefingFingerprint", () => {
+  it("is deterministic for identical content", () => {
+    expect(computeBriefingFingerprint("hello briefing")).toBe(computeBriefingFingerprint("hello briefing"));
+  });
+
+  it("changes when the briefing content changes", () => {
+    expect(computeBriefingFingerprint("v1")).not.toBe(computeBriefingFingerprint("v2"));
+  });
+});
+
+describe("read/write round-trip", () => {
+  it("returns null before any write (unknown baseline)", () => {
+    expect(readSessionBriefingFingerprint(workspace, SESSION_ID)).toBeNull();
+  });
+
+  it("round-trips a written fingerprint", () => {
+    const fp = computeBriefingFingerprint("the briefing");
+    writeSessionBriefingFingerprint(workspace, SESSION_ID, fp);
+    expect(readSessionBriefingFingerprint(workspace, SESSION_ID)).toBe(fp);
+  });
+
+  it("isolates fingerprints per session id (shared agent home, no cross-session bleed)", () => {
+    const other = "019d9a97-90b0-716b-8317-aaaaaaaaaaaa";
+    writeSessionBriefingFingerprint(workspace, SESSION_ID, computeBriefingFingerprint("a"));
+    writeSessionBriefingFingerprint(workspace, other, computeBriefingFingerprint("b"));
+    expect(readSessionBriefingFingerprint(workspace, SESSION_ID)).toBe(computeBriefingFingerprint("a"));
+    expect(readSessionBriefingFingerprint(workspace, other)).toBe(computeBriefingFingerprint("b"));
+  });
+
+  it("overwrites a prior fingerprint for the same session", () => {
+    writeSessionBriefingFingerprint(workspace, SESSION_ID, computeBriefingFingerprint("old"));
+    writeSessionBriefingFingerprint(workspace, SESSION_ID, computeBriefingFingerprint("new"));
+    expect(readSessionBriefingFingerprint(workspace, SESSION_ID)).toBe(computeBriefingFingerprint("new"));
+  });
+});
+
+describe("readSessionBriefingFingerprint resilience", () => {
+  it("returns null on malformed JSON", () => {
+    const path = join(workspace, SESSION_BRIEFINGS_DIR_REL, `${SESSION_ID}.json`);
+    writeSessionBriefingFingerprint(workspace, SESSION_ID, "seed-so-dir-exists");
+    writeFileSync(path, "{not json", "utf-8");
+    expect(readSessionBriefingFingerprint(workspace, SESSION_ID)).toBeNull();
+  });
+
+  it("returns null for an unknown schema version (future writer)", () => {
+    const path = join(workspace, SESSION_BRIEFINGS_DIR_REL, `${SESSION_ID}.json`);
+    writeSessionBriefingFingerprint(workspace, SESSION_ID, "seed");
+    writeFileSync(path, JSON.stringify({ schemaVersion: 2, fingerprint: "x" }), "utf-8");
+    expect(readSessionBriefingFingerprint(workspace, SESSION_ID)).toBeNull();
+  });
+});
+
+describe("buildBriefingUpdateNotice", () => {
+  it("wraps a system-reminder, names the CLAUDE.md path, and flags the comms-contract change", () => {
+    const notice = buildBriefingUpdateNotice("/home/agent/CLAUDE.md");
+    expect(notice.startsWith("<system-reminder>")).toBe(true);
+    expect(notice.trimEnd().endsWith("</system-reminder>")).toBe(true);
+    expect(notice).toContain("/home/agent/CLAUDE.md");
+    expect(notice).toContain("re-read");
+    expect(notice).toContain("reply to a human");
+  });
+});

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -55,6 +55,12 @@ import {
   type ProviderRetryDecision,
 } from "../runtime/provider-retry-policy.js";
 import { materializeResourceSkills } from "../runtime/resource-skills.js";
+import {
+  buildBriefingUpdateNotice,
+  computeBriefingFingerprint,
+  readSessionBriefingFingerprint,
+  writeSessionBriefingFingerprint,
+} from "../runtime/session-briefing-fingerprint.js";
 import { currentSourceRepoNamesFromPayload, declaredSourceRepos } from "../runtime/source-repos.js";
 import { acquireAgentHome, markWorkspaceInitComplete } from "../runtime/workspace.js";
 import { chunkAssistantText } from "./assistant-text.js";
@@ -909,6 +915,22 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       message: { role: "user", content: await sessionCtx.formatInboundContent(message) },
       parent_tool_use_id: null,
       session_id: sessionId,
+    };
+  }
+
+  /**
+   * Prepend the one-time "your instructions changed — re-read CLAUDE.md" notice
+   * to a resumed turn's user message, so the agent reads it before acting on
+   * the message. Only the text content shape is handled (every
+   * `toSDKUserMessage` branch returns a string `content`); anything else is
+   * returned untouched.
+   */
+  function prependBriefingUpdateNotice(sdkMsg: SDKUserMessage, claudeMdPath: string): SDKUserMessage {
+    const { content } = sdkMsg.message;
+    if (typeof content !== "string") return sdkMsg;
+    return {
+      ...sdkMsg,
+      message: { ...sdkMsg.message, content: `${buildBriefingUpdateNotice(claudeMdPath)}\n\n${content}` },
     };
   }
 
@@ -1811,6 +1833,11 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       // circuit the expensive integrate path on its presence.
       markWorkspaceInitComplete(cwd);
 
+      // Record the briefing this session is starting under, so a later resume
+      // can detect a runtime-upgrade briefing change and nudge the agent to
+      // re-read CLAUDE.md (see session-briefing-fingerprint.ts).
+      writeSessionBriefingFingerprint(cwd, claudeSessionId, computeBriefingFingerprint(briefing));
+
       sessionCtx.log(
         `Starting session (${claudeSessionId}), cwd=${cwd}, permissionMode=${config.permissionMode ?? "bypassPermissions"}`,
       );
@@ -1922,6 +1949,10 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
             "First Tree message history is preserved.",
         );
         claudeSessionId = freshSessionId;
+        // Cold start under a fresh id: record the current briefing as this
+        // session's baseline. No update notice — there is no prior transcript
+        // built under a stale briefing to warn about.
+        writeSessionBriefingFingerprint(cwd, freshSessionId, computeBriefingFingerprint(briefing));
         let freshSdkMsg: SDKUserMessage | null = null;
         if (message) {
           freshSdkMsg = await toSDKUserMessage(message, sessionCtx, freshSessionId);
@@ -1938,9 +1969,29 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       }
 
       sessionCtx.log(`Resuming session (${sessionId}), cwd=${cwd}`);
+
+      // Briefing-change detection: the freshly-rewritten briefing this resume
+      // reads may differ from the one this session's transcript was built
+      // under (typically a runtime upgrade that changed the operating contract
+      // or skill set). A resumed Claude session does not reliably act on the
+      // changed CLAUDE.md against its established behavior, so surface a
+      // one-time notice into this turn telling it to re-read CLAUDE.md. A
+      // missing baseline (a session predating this mechanism) counts as
+      // changed — those are exactly the stale sessions worth nudging once.
+      // Only touch this on a message-bearing turn: a no-message reclaim has no
+      // turn to carry the notice and must not advance the baseline, or the
+      // next real turn would miss the change.
       let resumeSdkMsg: SDKUserMessage | null = null;
       if (message) {
+        const briefingFingerprint = computeBriefingFingerprint(briefing);
+        const briefingChanged = readSessionBriefingFingerprint(cwd, sessionId) !== briefingFingerprint;
         resumeSdkMsg = await toSDKUserMessage(message, sessionCtx, sessionId);
+        if (briefingChanged) {
+          sessionCtx.log(`Resume: briefing changed since last turn — prepending re-read notice (${sessionId})`);
+          resumeSdkMsg = prependBriefingUpdateNotice(resumeSdkMsg, join(cwd, "CLAUDE.md"));
+        }
+        // Advance the baseline to what the agent is told this turn.
+        writeSessionBriefingFingerprint(cwd, sessionId, briefingFingerprint);
       }
       spawnQuery(sessionId, sessionCtx, sessionId);
       if (resumeSdkMsg) {

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -752,6 +752,20 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
   let appliedModel = "";
   let appliedPayload: AgentRuntimeConfigPayload | null = null;
   /**
+   * Briefing-staleness tracking for the active session (see
+   * session-briefing-fingerprint.ts). `current` is the fingerprint of the
+   * briefing on disk right now — refreshed wherever the briefing is
+   * (re)written: start, resume, fresh-fallback, and the config hot-switch
+   * restart. `delivered` is the fingerprint the most recently *delivered* turn
+   * ran under (mirrored to the per-session file). A turn-starting user message
+   * gets the one-time re-read notice exactly when `current` differs from
+   * `delivered` — which covers cold resume, a session predating the mechanism
+   * (`delivered` loads as null), AND a mid-session config hot-switch that
+   * rewrote the briefing before the next message.
+   */
+  let currentBriefingFingerprint: string | null = null;
+  let deliveredBriefingFingerprint: string | null = null;
+  /**
    * Latest chat-context snapshot for the active session. Used to build the
    * session/resume system-prompt block injected via `systemPrompt.append`.
    * Cleared when the session ends or `start()` runs for a fresh session.
@@ -935,6 +949,43 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
   }
 
   /**
+   * The single chokepoint for delivering a turn-starting user message to the
+   * SDK input controller. Used by start / resume / fresh-fallback / the inject
+   * drain so every path shares one briefing-staleness contract:
+   *
+   *   - prepend the one-time re-read notice when the on-disk briefing
+   *     (`currentBriefingFingerprint`) differs from what the last delivered
+   *     turn ran under (`deliveredBriefingFingerprint`);
+   *   - advance the baseline ONLY after the input is in the replay buffer, so a
+   *     synchronous `buildQuery()` failure before this point leaves the notice
+   *     pending for the retry rather than recording it as already shown.
+   */
+  function deliverUserMessage(
+    sdkMsg: SDKUserMessage,
+    message: SessionMessage,
+    token: DeliveryToken,
+    sessionId: string,
+    sessionCtx: SessionContext,
+  ): void {
+    const briefingChanged =
+      currentBriefingFingerprint !== null && deliveredBriefingFingerprint !== currentBriefingFingerprint;
+    let outgoing = sdkMsg;
+    if (briefingChanged && cwd) {
+      sessionCtx.log(`Briefing changed since last delivered turn — prepending re-read notice (${sessionId})`);
+      outgoing = prependBriefingUpdateNotice(sdkMsg, join(cwd, "CLAUDE.md"));
+    }
+    pushPendingSdkInput(createPendingSdkInput(outgoing, message, token));
+    // The input is now buffered for replay; advancing the baseline here ties it
+    // to delivery actually reaching the controller.
+    if (briefingChanged) {
+      deliveredBriefingFingerprint = currentBriefingFingerprint;
+      if (cwd && currentBriefingFingerprint) {
+        writeSessionBriefingFingerprint(cwd, sessionId, currentBriefingFingerprint);
+      }
+    }
+  }
+
+  /**
    * Build env for the child Claude Code process.
    *
    * When the client runtime runs inside a Claude Code session (nested env),
@@ -1100,7 +1151,10 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
     try {
       const sdkMsg = await toSDKUserMessage(message, sessionCtx, sessionId);
       if (recoverIfInputClosed(item)) return;
-      pushPendingSdkInput(createPendingSdkInput(sdkMsg, message, token));
+      // Same chokepoint as start/resume: if a config hot-switch (or anything
+      // else) rewrote the briefing since the last delivered turn, this is where
+      // the re-read notice is attached before the message enters the buffer.
+      deliverUserMessage(sdkMsg, message, token, sessionId, sessionCtx);
     } catch (err) {
       if (recoverIfInputClosed(item)) return;
       sessionCtx.log(`toSDKUserMessage errored: ${err instanceof Error ? err.message : String(err)}`);
@@ -1300,7 +1354,13 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
     // would update model/mcp/effort but silently leave the per-agent prompt
     // at the old version until the next session restart.
     if (cwd) {
-      writeAgentBriefing(cwd, currentBriefing(sessionCtx, cwd, newPayload));
+      const switchedBriefing = currentBriefing(sessionCtx, cwd, newPayload);
+      writeAgentBriefing(cwd, switchedBriefing);
+      // Refresh the on-disk briefing fingerprint so the NEXT delivered message
+      // (drained right after this restart in pushInjectedMessage) sees the
+      // change and carries the re-read notice. `delivered` is intentionally
+      // left untouched — the transcript still reflects the pre-switch briefing.
+      currentBriefingFingerprint = computeBriefingFingerprint(switchedBriefing);
     }
     const sid = claudeSessionId;
     const oldQuery = currentQuery;
@@ -1833,10 +1893,13 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       // circuit the expensive integrate path on its presence.
       markWorkspaceInitComplete(cwd);
 
-      // Record the briefing this session is starting under, so a later resume
-      // can detect a runtime-upgrade briefing change and nudge the agent to
-      // re-read CLAUDE.md (see session-briefing-fingerprint.ts).
-      writeSessionBriefingFingerprint(cwd, claudeSessionId, computeBriefingFingerprint(briefing));
+      // Seed the briefing baseline: a fresh session starts in sync with the
+      // briefing it was built under, so its first turn carries no notice. The
+      // baseline is also persisted so a resume before this session ever ran a
+      // turn has a real baseline rather than reading null (a false "changed").
+      currentBriefingFingerprint = computeBriefingFingerprint(briefing);
+      deliveredBriefingFingerprint = currentBriefingFingerprint;
+      writeSessionBriefingFingerprint(cwd, claudeSessionId, currentBriefingFingerprint);
 
       sessionCtx.log(
         `Starting session (${claudeSessionId}), cwd=${cwd}, permissionMode=${config.permissionMode ?? "bypassPermissions"}`,
@@ -1847,7 +1910,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       // pull the prompt.
       const sdkMsg = await toSDKUserMessage(message, sessionCtx, claudeSessionId);
       spawnQuery(claudeSessionId, sessionCtx);
-      pushPendingSdkInput(createPendingSdkInput(sdkMsg, message, deliveryToken));
+      deliverUserMessage(sdkMsg, message, deliveryToken, claudeSessionId, sessionCtx);
       scheduleInjectedMessagesDrain(sessionCtx, claudeSessionId);
 
       sessionCtx.log(`Session started (${claudeSessionId})`);
@@ -1949,17 +2012,19 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
             "First Tree message history is preserved.",
         );
         claudeSessionId = freshSessionId;
-        // Cold start under a fresh id: record the current briefing as this
-        // session's baseline. No update notice — there is no prior transcript
-        // built under a stale briefing to warn about.
-        writeSessionBriefingFingerprint(cwd, freshSessionId, computeBriefingFingerprint(briefing));
+        // Cold start under a fresh id: seed the baseline in sync, so the first
+        // turn carries no notice — there is no prior transcript built under a
+        // stale briefing to warn about.
+        currentBriefingFingerprint = computeBriefingFingerprint(briefing);
+        deliveredBriefingFingerprint = currentBriefingFingerprint;
+        writeSessionBriefingFingerprint(cwd, freshSessionId, currentBriefingFingerprint);
         let freshSdkMsg: SDKUserMessage | null = null;
         if (message) {
           freshSdkMsg = await toSDKUserMessage(message, sessionCtx, freshSessionId);
         }
         spawnQuery(freshSessionId, sessionCtx);
-        if (freshSdkMsg) {
-          if (message) pushPendingSdkInput(createPendingSdkInput(freshSdkMsg, message, deliveryToken));
+        if (freshSdkMsg && message) {
+          deliverUserMessage(freshSdkMsg, message, deliveryToken, freshSessionId, sessionCtx);
         }
         scheduleInjectedMessagesDrain(sessionCtx, freshSessionId);
         sessionCtx.log(`Session started (${freshSessionId}, replacing ${sessionId})`);
@@ -1970,32 +2035,23 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
 
       sessionCtx.log(`Resuming session (${sessionId}), cwd=${cwd}`);
 
-      // Briefing-change detection: the freshly-rewritten briefing this resume
-      // reads may differ from the one this session's transcript was built
-      // under (typically a runtime upgrade that changed the operating contract
-      // or skill set). A resumed Claude session does not reliably act on the
-      // changed CLAUDE.md against its established behavior, so surface a
-      // one-time notice into this turn telling it to re-read CLAUDE.md. A
-      // missing baseline (a session predating this mechanism) counts as
-      // changed — those are exactly the stale sessions worth nudging once.
-      // Only touch this on a message-bearing turn: a no-message reclaim has no
-      // turn to carry the notice and must not advance the baseline, or the
-      // next real turn would miss the change.
+      // Briefing-staleness baseline for this resumed session. `current` is the
+      // briefing just rewritten above; `delivered` loads the fingerprint the
+      // session last ran a turn under — null means a session predating this
+      // mechanism, treated as changed so it gets one re-read nudge. The compare
+      // + notice + baseline advance happen in deliverUserMessage, after the
+      // input is buffered (a no-message reclaim advances nothing, so the next
+      // real turn still surfaces the change).
+      currentBriefingFingerprint = computeBriefingFingerprint(briefing);
+      deliveredBriefingFingerprint = readSessionBriefingFingerprint(cwd, sessionId);
+
       let resumeSdkMsg: SDKUserMessage | null = null;
       if (message) {
-        const briefingFingerprint = computeBriefingFingerprint(briefing);
-        const briefingChanged = readSessionBriefingFingerprint(cwd, sessionId) !== briefingFingerprint;
         resumeSdkMsg = await toSDKUserMessage(message, sessionCtx, sessionId);
-        if (briefingChanged) {
-          sessionCtx.log(`Resume: briefing changed since last turn — prepending re-read notice (${sessionId})`);
-          resumeSdkMsg = prependBriefingUpdateNotice(resumeSdkMsg, join(cwd, "CLAUDE.md"));
-        }
-        // Advance the baseline to what the agent is told this turn.
-        writeSessionBriefingFingerprint(cwd, sessionId, briefingFingerprint);
       }
       spawnQuery(sessionId, sessionCtx, sessionId);
-      if (resumeSdkMsg) {
-        if (message) pushPendingSdkInput(createPendingSdkInput(resumeSdkMsg, message, deliveryToken));
+      if (resumeSdkMsg && message) {
+        deliverUserMessage(resumeSdkMsg, message, deliveryToken, sessionId, sessionCtx);
       }
       scheduleInjectedMessagesDrain(sessionCtx, sessionId);
 

--- a/packages/client/src/handlers/codex/app-server/index.ts
+++ b/packages/client/src/handlers/codex/app-server/index.ts
@@ -3,7 +3,11 @@ import type { AgentRuntimeConfigPayload, SessionEvent, ToolFileRef } from "@firs
 import { ensureAgentBootstrap as ensureAgentBootstrapShared } from "../../../runtime/agent-bootstrap.js";
 import { buildAgentBriefing } from "../../../runtime/agent-briefing.js";
 import type { AgentConfigCache } from "../../../runtime/agent-config-cache.js";
-import { FIRST_TREE_WORKSPACE_MARKER, type PredeclaredSourceRepo } from "../../../runtime/bootstrap.js";
+import {
+  FIRST_TREE_WORKSPACE_MARKER,
+  type PredeclaredSourceRepo,
+  writeAgentBriefing,
+} from "../../../runtime/bootstrap.js";
 import { type CodexBinaryResolution, resolveCodexRuntimeBinary } from "../../../runtime/capabilities/codex.js";
 import { type ChatContext, fetchChatContext } from "../../../runtime/chat-context.js";
 import { renderChatContextPrompt } from "../../../runtime/chat-context-section.js";
@@ -1052,6 +1056,26 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
     }
   }
 
+  /**
+   * Active-session config hot-switch for the Codex app-server: a thread reads
+   * AGENTS.md once at init and never re-reads it, so a mid-session prompt change
+   * would otherwise only land after a suspend/resume. Before an injected turn we
+   * rebuild the briefing from the latest cached config; if it changed, rewrite
+   * AGENTS.md and report so the caller prepends the re-read notice. Synchronous
+   * + `.get()` so it adds no await on the drain path. The prompt is the target;
+   * model / MCP hot-switch (which needs a thread restart) stays out of scope.
+   */
+  function refreshBriefingForActiveTurn(sessionCtx: SessionContext): { fingerprint: string; changed: boolean } | null {
+    if (!agentConfigCache || !cwd || !threadId) return null;
+    const payload = agentConfigCache.get(sessionCtx.agent.agentId)?.payload;
+    if (!payload) return null;
+    const briefing = buildBriefing(sessionCtx, payload, cwd);
+    const fingerprint = computeBriefingFingerprint(briefing);
+    if (readSessionBriefingFingerprint(cwd, threadId) === fingerprint) return { fingerprint, changed: false };
+    writeAgentBriefing(cwd, briefing);
+    return { fingerprint, changed: true };
+  }
+
   async function startTurnFromPendingInputs(sessionCtx: SessionContext): Promise<void> {
     if (pendingInputs.length === 0 || turnStartInProgress) return;
     const batch = pendingInputs.slice();
@@ -1067,18 +1091,32 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
     removePendingPrefix(batch);
     const token = batch[0]?.token;
     if (!token) return;
+    // Active-session hot-switch: pick up a mid-session briefing change before
+    // this injected turn and surface the re-read notice.
+    const refreshed = refreshBriefingForActiveTurn(sessionCtx);
+    if (refreshed?.changed && cwd) {
+      const notice = buildBriefingUpdateNotice(join(cwd, "AGENTS.md"));
+      pendingChatContextPrompt = pendingChatContextPrompt ? `${notice}\n\n${pendingChatContextPrompt}` : notice;
+      sessionCtx.log(`Active session briefing changed — prepending re-read notice (${threadId})`);
+    }
     void runTurnFromText(
       text,
       batch.map((entry) => entry.message),
       token,
       sessionCtx,
-    ).catch((err) => {
-      sessionCtx.log(`codex app-server pending turn failed: ${err instanceof Error ? err.message : String(err)}`);
-      token.retry(
-        batch.map((entry) => entry.message),
-        "codex_pending_turn_failed",
-      );
-    });
+    )
+      .then((delivered) => {
+        if (refreshed?.changed && delivered && cwd && threadId) {
+          writeSessionBriefingFingerprint(cwd, threadId, refreshed.fingerprint);
+        }
+      })
+      .catch((err) => {
+        sessionCtx.log(`codex app-server pending turn failed: ${err instanceof Error ? err.message : String(err)}`);
+        token.retry(
+          batch.map((entry) => entry.message),
+          "codex_pending_turn_failed",
+        );
+      });
   }
 
   async function formatBatchInput(

--- a/packages/client/src/handlers/codex/app-server/index.ts
+++ b/packages/client/src/handlers/codex/app-server/index.ts
@@ -1067,13 +1067,25 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
    */
   function refreshBriefingForActiveTurn(sessionCtx: SessionContext): { fingerprint: string; changed: boolean } | null {
     if (!agentConfigCache || !cwd || !threadId) return null;
-    const payload = agentConfigCache.get(sessionCtx.agent.agentId)?.payload;
-    if (!payload) return null;
-    const briefing = buildBriefing(sessionCtx, payload, cwd);
-    const fingerprint = computeBriefingFingerprint(briefing);
-    if (readSessionBriefingFingerprint(cwd, threadId) === fingerprint) return { fingerprint, changed: false };
-    writeAgentBriefing(cwd, briefing);
-    return { fingerprint, changed: true };
+    // Never throw: `startTurnFromPendingInputs` has already dequeued the batch
+    // by the time this runs, so a thrown briefing rewrite would strand the
+    // message (no turn/start, no token.retry). On any failure, skip the
+    // hot-switch for this turn — the message still delivers under the prior
+    // briefing, and the next injected turn retries the refresh.
+    try {
+      const payload = agentConfigCache.get(sessionCtx.agent.agentId)?.payload;
+      if (!payload) return null;
+      const briefing = buildBriefing(sessionCtx, payload, cwd);
+      const fingerprint = computeBriefingFingerprint(briefing);
+      if (readSessionBriefingFingerprint(cwd, threadId) === fingerprint) return { fingerprint, changed: false };
+      writeAgentBriefing(cwd, briefing);
+      return { fingerprint, changed: true };
+    } catch (err) {
+      sessionCtx.log(
+        `active-session briefing refresh failed, delivering under prior briefing: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return null;
+    }
   }
 
   async function startTurnFromPendingInputs(sessionCtx: SessionContext): Promise<void> {

--- a/packages/client/src/handlers/codex/app-server/index.ts
+++ b/packages/client/src/handlers/codex/app-server/index.ts
@@ -1,4 +1,4 @@
-import { isAbsolute, resolve } from "node:path";
+import { isAbsolute, join, resolve } from "node:path";
 import type { AgentRuntimeConfigPayload, SessionEvent, ToolFileRef } from "@first-tree/shared";
 import { ensureAgentBootstrap as ensureAgentBootstrapShared } from "../../../runtime/agent-bootstrap.js";
 import { buildAgentBriefing } from "../../../runtime/agent-briefing.js";
@@ -27,6 +27,12 @@ import type {
 } from "../../../runtime/handler.js";
 import { deliveryTokenFromSessionContext } from "../../../runtime/handler.js";
 import { materializeResourceSkills } from "../../../runtime/resource-skills.js";
+import {
+  buildBriefingUpdateNotice,
+  computeBriefingFingerprint,
+  readSessionBriefingFingerprint,
+  writeSessionBriefingFingerprint,
+} from "../../../runtime/session-briefing-fingerprint.js";
 import { currentSourceRepoNamesFromPayload, declaredSourceRepos } from "../../../runtime/source-repos.js";
 import { acquireAgentHome, markWorkspaceInitComplete } from "../../../runtime/workspace.js";
 import { chunkAssistantText } from "../../assistant-text.js";
@@ -258,6 +264,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
   async function prepareSession(sessionCtx: SessionContext): Promise<{
     payload: AgentRuntimeConfigPayload;
     env: NodeJS.ProcessEnv;
+    briefingFingerprint: string;
   }> {
     cwd = acquireAgentHome(workspaceRoot);
     const { payload, resolved } = await resolvePayload(sessionCtx);
@@ -270,7 +277,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
     markWorkspaceInitComplete(cwd);
     currentModel = payload.model || "";
     currentReasoningEffort = payload.kind === "codex" ? payload.reasoningEffort : "high";
-    return { payload, env: buildEnv(sessionCtx) };
+    return { payload, env: buildEnv(sessionCtx), briefingFingerprint: computeBriefingFingerprint(briefing) };
   }
 
   async function startAppServer(sessionCtx: SessionContext, env: NodeJS.ProcessEnv): Promise<void> {
@@ -1131,7 +1138,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
       startupTurnPending = true;
       ctx = sessionCtx;
       try {
-        const { payload, env } = await prepareSession(sessionCtx);
+        const { payload, env, briefingFingerprint } = await prepareSession(sessionCtx);
         await startAppServer(sessionCtx, env);
         const id = await startThread(payload);
         let input: string;
@@ -1145,6 +1152,9 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
           return hasExplicitDeliveryToken ? { sessionId: id, route: { kind: "owned", mode: "queued" } } : id;
         }
         await runTurnFromText(input, [message], deliveryToken, sessionCtx);
+        // Fresh thread: seed the briefing baseline now that the thread id is
+        // known, so a later resume only nudges on a real briefing change.
+        if (cwd) writeSessionBriefingFingerprint(cwd, id, briefingFingerprint);
         return hasExplicitDeliveryToken ? { sessionId: id, route: { kind: "owned", mode: "processing" } } : id;
       } finally {
         startupTurnPending = false;
@@ -1159,7 +1169,22 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
       startupTurnPending = message !== undefined;
       ctx = sessionCtx;
       try {
-        const { payload, env } = await prepareSession(sessionCtx);
+        const { payload, env, briefingFingerprint } = await prepareSession(sessionCtx);
+        // Briefing-staleness notice: a resumed Codex thread read AGENTS.md once
+        // at thread init and never re-reads it. If the briefing changed since
+        // this session last ran a turn — or there is no baseline (a session
+        // predating this mechanism) — prepend a one-time re-read notice ahead of
+        // the Current Chat Context that prepareSession just staged. The baseline
+        // advances only after the turn runs, so a failed turn keeps it pending.
+        const briefingChanged =
+          message !== undefined &&
+          cwd !== null &&
+          readSessionBriefingFingerprint(cwd, sessionId) !== briefingFingerprint;
+        if (briefingChanged && cwd) {
+          const notice = buildBriefingUpdateNotice(join(cwd, "AGENTS.md"));
+          pendingChatContextPrompt = pendingChatContextPrompt ? `${notice}\n\n${pendingChatContextPrompt}` : notice;
+          sessionCtx.log(`Resume: briefing changed since last turn — prepending re-read notice (${sessionId})`);
+        }
         await startAppServer(sessionCtx, env);
         await resumeThread(sessionId, payload);
         if (message) {
@@ -1174,6 +1199,8 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
             return hasExplicitDeliveryToken ? { sessionId, route: { kind: "owned", mode: "queued" } } : sessionId;
           }
           await runTurnFromText(input, [message], deliveryToken, sessionCtx);
+          // Turn delivered → advance / seed the baseline.
+          if (cwd) writeSessionBriefingFingerprint(cwd, sessionId, briefingFingerprint);
         }
         return hasExplicitDeliveryToken
           ? { sessionId, route: message ? { kind: "owned", mode: "processing" } : null }

--- a/packages/client/src/handlers/codex/app-server/index.ts
+++ b/packages/client/src/handlers/codex/app-server/index.ts
@@ -659,24 +659,32 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
     await shutdown;
   }
 
+  /**
+   * Returns whether the turn actually reached the provider (turn/start
+   * accepted, turn id assigned). The briefing-update notice rides this turn's
+   * input (consumed from `pendingChatContextPrompt`), so the caller must only
+   * advance the briefing baseline when this is `true`: every early `token.retry`
+   * path below bounced the message for redelivery before the model saw the
+   * notice, and advancing the baseline there would suppress it on redelivery.
+   */
   async function runTurnFromText(
     inputText: string,
     messages: readonly SessionMessage[],
     token: DeliveryToken,
     sessionCtx: SessionContext,
-  ): Promise<void> {
+  ): Promise<boolean> {
     const client = appServer;
     if (!client || !threadId) {
       token.retry(messages, "codex_app_server_missing_thread");
-      return;
+      return false;
     }
     if (shutdownRequested) {
       token.retry(messages, "codex_app_server_shutdown_before_turn_start");
-      return;
+      return false;
     }
     if (turnStartInProgress) {
       token.retry(messages, "codex_app_server_turn_start_already_in_progress");
-      return;
+      return false;
     }
 
     const providerInputText = consumePendingChatContext(inputText);
@@ -699,7 +707,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
         : "codex_app_server_turn_start_unknown_custody_failed";
       token.retry(messages, reason);
       await closeAppServerAfterUnknownCustody(sessionCtx, reason, err);
-      return;
+      return false;
     }
 
     const turnRecord = asRecord(asRecord(result)?.turn);
@@ -709,7 +717,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
       const reason = "codex_app_server_turn_start_missing_id_unknown_custody";
       token.retry(messages, reason);
       await closeAppServerAfterUnknownCustody(sessionCtx, reason, "missing turn id in turn/start response");
-      return;
+      return false;
     }
 
     const turn = await createCurrentTurn(turnId, messages, token, sessionCtx);
@@ -728,6 +736,9 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
       if (currentTurn === turn) currentTurn = null;
       schedulePendingDrain();
     }
+    // Reached the provider (turn/start accepted, turn id assigned), so the
+    // notice-bearing input was delivered to the model.
+    return true;
   }
 
   function consumePendingChatContext(inputText: string): string {
@@ -1151,10 +1162,10 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
           );
           return hasExplicitDeliveryToken ? { sessionId: id, route: { kind: "owned", mode: "queued" } } : id;
         }
-        await runTurnFromText(input, [message], deliveryToken, sessionCtx);
-        // Fresh thread: seed the briefing baseline now that the thread id is
-        // known, so a later resume only nudges on a real briefing change.
-        if (cwd) writeSessionBriefingFingerprint(cwd, id, briefingFingerprint);
+        const delivered = await runTurnFromText(input, [message], deliveryToken, sessionCtx);
+        // Fresh thread: seed the briefing baseline once the turn actually
+        // delivered, so a later resume only nudges on a real briefing change.
+        if (cwd && delivered) writeSessionBriefingFingerprint(cwd, id, briefingFingerprint);
         return hasExplicitDeliveryToken ? { sessionId: id, route: { kind: "owned", mode: "processing" } } : id;
       } finally {
         startupTurnPending = false;
@@ -1198,9 +1209,10 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
             );
             return hasExplicitDeliveryToken ? { sessionId, route: { kind: "owned", mode: "queued" } } : sessionId;
           }
-          await runTurnFromText(input, [message], deliveryToken, sessionCtx);
-          // Turn delivered → advance / seed the baseline.
-          if (cwd) writeSessionBriefingFingerprint(cwd, sessionId, briefingFingerprint);
+          const delivered = await runTurnFromText(input, [message], deliveryToken, sessionCtx);
+          // Advance the baseline ONLY when the notice-bearing turn actually
+          // delivered; a retried / pre-provider turn leaves it for redelivery.
+          if (cwd && delivered) writeSessionBriefingFingerprint(cwd, sessionId, briefingFingerprint);
         }
         return hasExplicitDeliveryToken
           ? { sessionId, route: message ? { kind: "owned", mode: "processing" } : null }

--- a/packages/client/src/handlers/codex/sdk.ts
+++ b/packages/client/src/handlers/codex/sdk.ts
@@ -19,7 +19,11 @@ import {
 import { ensureAgentBootstrap as ensureAgentBootstrapShared } from "../../runtime/agent-bootstrap.js";
 import { buildAgentBriefing } from "../../runtime/agent-briefing.js";
 import type { AgentConfigCache } from "../../runtime/agent-config-cache.js";
-import { FIRST_TREE_WORKSPACE_MARKER, type PredeclaredSourceRepo } from "../../runtime/bootstrap.js";
+import {
+  FIRST_TREE_WORKSPACE_MARKER,
+  type PredeclaredSourceRepo,
+  writeAgentBriefing,
+} from "../../runtime/bootstrap.js";
 import { type ChatContext, fetchChatContext } from "../../runtime/chat-context.js";
 import { renderChatContextPrompt } from "../../runtime/chat-context-section.js";
 import {
@@ -1246,6 +1250,32 @@ export const createCodexSdkHandler: HandlerFactory = (config) => {
     });
   }
 
+  /**
+   * Active-session config hot-switch for Codex. A Codex thread reads AGENTS.md
+   * once at thread init and never re-reads it, and — unlike the Claude SDK
+   * handler — there is no query restart on the inject path. So when an admin
+   * changes the agent prompt mid-session, an injected message would otherwise
+   * run a fresh turn still under the OLD briefing until the next suspend/resume.
+   *
+   * Before an injected turn we rebuild the briefing from the latest cached
+   * config (kept fresh by config-update pushes, same source the Claude
+   * hot-switch reads). If it changed, rewrite AGENTS.md on disk and report the
+   * change so the caller prepends the one-time re-read notice — the agent then
+   * re-reads the now-current AGENTS.md before acting. Synchronous + `.get()` so
+   * it adds no await/race on the drain path. Model / MCP hot-switch (which would
+   * need a thread restart) stays out of scope; this targets the prompt.
+   */
+  function refreshBriefingForActiveTurn(sessionCtx: SessionContext): { fingerprint: string; changed: boolean } | null {
+    if (!agentConfigCache || !cwd || !threadId) return null;
+    const payload = agentConfigCache.get(sessionCtx.agent.agentId)?.payload;
+    if (!payload) return null;
+    const briefing = buildBriefing(sessionCtx, payload, cwd);
+    const fingerprint = computeBriefingFingerprint(briefing);
+    if (readSessionBriefingFingerprint(cwd, threadId) === fingerprint) return { fingerprint, changed: false };
+    writeAgentBriefing(cwd, briefing);
+    return { fingerprint, changed: true };
+  }
+
   async function mergeAndRun(
     drained: Array<{ message: SessionMessage; token: DeliveryToken }>,
     sessionCtx: SessionContext,
@@ -1270,7 +1300,18 @@ export const createCodexSdkHandler: HandlerFactory = (config) => {
       for (const queued of drained) queued.token.retry(queued.message, "codex_queued_turn_format_failed");
       return;
     }
-    await runTurn(inputs.join("\n\n"), sessionCtx, messages, token);
+    // Active-session hot-switch: pick up a mid-session briefing change before
+    // this injected turn and surface the re-read notice.
+    const refreshed = refreshBriefingForActiveTurn(sessionCtx);
+    if (refreshed?.changed && cwd) {
+      const notice = buildBriefingUpdateNotice(join(cwd, "AGENTS.md"));
+      pendingChatContextPrompt = pendingChatContextPrompt ? `${notice}\n\n${pendingChatContextPrompt}` : notice;
+      sessionCtx.log(`Active session briefing changed — prepending re-read notice (${threadId})`);
+    }
+    const delivered = await runTurn(inputs.join("\n\n"), sessionCtx, messages, token);
+    if (refreshed?.changed && delivered && cwd && threadId) {
+      writeSessionBriefingFingerprint(cwd, threadId, refreshed.fingerprint);
+    }
   }
 
   function retryQueuedMessages(reason: string): void {

--- a/packages/client/src/handlers/codex/sdk.ts
+++ b/packages/client/src/handlers/codex/sdk.ts
@@ -1,4 +1,4 @@
-import { isAbsolute, resolve } from "node:path";
+import { isAbsolute, join, resolve } from "node:path";
 import {
   type AgentRuntimeConfigPayload,
   deriveRepoLocalPath,
@@ -56,6 +56,12 @@ import {
   type ProviderRetryDecision,
 } from "../../runtime/provider-retry-policy.js";
 import { materializeResourceSkills } from "../../runtime/resource-skills.js";
+import {
+  buildBriefingUpdateNotice,
+  computeBriefingFingerprint,
+  readSessionBriefingFingerprint,
+  writeSessionBriefingFingerprint,
+} from "../../runtime/session-briefing-fingerprint.js";
 import { currentSourceRepoNamesFromPayload, declaredSourceRepos } from "../../runtime/source-repos.js";
 import { acquireAgentHome, markWorkspaceInitComplete } from "../../runtime/workspace.js";
 import { chunkAssistantText } from "../assistant-text.js";
@@ -1354,6 +1360,10 @@ export const createCodexSdkHandler: HandlerFactory = (config) => {
       if (!threadId) {
         throw new Error("codex did not assign a thread id during the first turn");
       }
+      // Seed the briefing baseline now that Codex has assigned the thread id
+      // (only known after the first turn). A fresh thread starts in sync, so a
+      // later resume only nudges on a real change.
+      if (cwd) writeSessionBriefingFingerprint(cwd, threadId, computeBriefingFingerprint(briefing));
       return hasExplicitDeliveryToken
         ? { sessionId: threadId, route: { kind: "owned", mode: "processing" } }
         : threadId;
@@ -1395,6 +1405,24 @@ export const createCodexSdkHandler: HandlerFactory = (config) => {
       ensureCodexBootstrap(cwd, sessionCtx, briefing, payload, resumePayloadResolved);
       markWorkspaceInitComplete(cwd);
 
+      // Briefing-staleness notice: a resumed Codex thread read AGENTS.md once at
+      // thread init and never re-reads it, so a briefing rewritten by a runtime
+      // upgrade (changed operating contract / skill set) would otherwise never
+      // reach the resumed thread. If the current briefing differs from what this
+      // session last ran a turn under — or there is no baseline, i.e. a session
+      // predating this mechanism — prepend a one-time re-read notice ahead of the
+      // Current Chat Context in the next provider turn. The baseline is advanced
+      // only after the turn actually runs, so a failed turn keeps the notice
+      // pending for the retry.
+      const briefingFingerprint = computeBriefingFingerprint(briefing);
+      const briefingChanged =
+        Boolean(message) && readSessionBriefingFingerprint(cwd, sessionId) !== briefingFingerprint;
+      if (briefingChanged) {
+        const notice = buildBriefingUpdateNotice(join(cwd, "AGENTS.md"));
+        pendingChatContextPrompt = pendingChatContextPrompt ? `${notice}\n\n${pendingChatContextPrompt}` : notice;
+        sessionCtx.log(`Resume: briefing changed since last turn — prepending re-read notice (${sessionId})`);
+      }
+
       codex = createCodexClient({ env: buildEnv(sessionCtx), config: buildCodexConfig(payload) }, sessionCtx);
       // Footgun F2: resumeThread does NOT inherit first-call ThreadOptions —
       // re-pass them every time.
@@ -1413,6 +1441,9 @@ export const createCodexSdkHandler: HandlerFactory = (config) => {
           initialTurnPreparing = false;
           if (initialTurnCompleted) scheduleQueuedMessagesDrain();
         }
+        // Turn delivered → advance the baseline (also seeds it for a session
+        // that had none).
+        if (initialTurnCompleted) writeSessionBriefingFingerprint(cwd, sessionId, briefingFingerprint);
       }
       return hasExplicitDeliveryToken
         ? { sessionId, route: message ? { kind: "owned", mode: "processing" } : null }

--- a/packages/client/src/handlers/codex/sdk.ts
+++ b/packages/client/src/handlers/codex/sdk.ts
@@ -1267,13 +1267,25 @@ export const createCodexSdkHandler: HandlerFactory = (config) => {
    */
   function refreshBriefingForActiveTurn(sessionCtx: SessionContext): { fingerprint: string; changed: boolean } | null {
     if (!agentConfigCache || !cwd || !threadId) return null;
-    const payload = agentConfigCache.get(sessionCtx.agent.agentId)?.payload;
-    if (!payload) return null;
-    const briefing = buildBriefing(sessionCtx, payload, cwd);
-    const fingerprint = computeBriefingFingerprint(briefing);
-    if (readSessionBriefingFingerprint(cwd, threadId) === fingerprint) return { fingerprint, changed: false };
-    writeAgentBriefing(cwd, briefing);
-    return { fingerprint, changed: true };
+    // Never throw: this runs on the inject drain path AFTER the batch has been
+    // dequeued, so a thrown briefing rewrite would strand the message (no
+    // turn/start, no token.retry). On any failure, skip the hot-switch for this
+    // turn — the message still delivers under the prior briefing, and the next
+    // injected turn retries the refresh.
+    try {
+      const payload = agentConfigCache.get(sessionCtx.agent.agentId)?.payload;
+      if (!payload) return null;
+      const briefing = buildBriefing(sessionCtx, payload, cwd);
+      const fingerprint = computeBriefingFingerprint(briefing);
+      if (readSessionBriefingFingerprint(cwd, threadId) === fingerprint) return { fingerprint, changed: false };
+      writeAgentBriefing(cwd, briefing);
+      return { fingerprint, changed: true };
+    } catch (err) {
+      sessionCtx.log(
+        `active-session briefing refresh failed, delivering under prior briefing: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return null;
+    }
   }
 
   async function mergeAndRun(

--- a/packages/client/src/handlers/codex/sdk.ts
+++ b/packages/client/src/handlers/codex/sdk.ts
@@ -762,16 +762,24 @@ export const createCodexSdkHandler: HandlerFactory = (config) => {
    * fuses queued messages into one input. Completion acks through the last
    * consumed message id instead of shifting a count from SessionManager state.
    */
+  /**
+   * Returns whether the turn was actually delivered to the provider and
+   * settled as complete. The briefing-update notice rides this turn's input
+   * (consumed from `pendingChatContextPrompt`), so the caller must only advance
+   * the briefing baseline when this is `true` — a pre-provider / aborted /
+   * retried turn never showed the notice to the model, and a redelivery must
+   * still surface it.
+   */
   async function runTurn(
     input: Input,
     sessionCtx: SessionContext,
     messages: readonly SessionMessage[],
     token: DeliveryToken,
-  ): Promise<void> {
+  ): Promise<boolean> {
     const activeThread = thread;
     if (!activeThread) {
       token.retry(messages, "codex_missing_thread");
-      return;
+      return false;
     }
     const providerInput = consumePendingChatContext(input);
 
@@ -993,8 +1001,9 @@ export const createCodexSdkHandler: HandlerFactory = (config) => {
     }
 
     if (abort.signal.aborted) {
-      // Suspend/shutdown raced ahead — let the abort handler set state.
-      return;
+      // Suspend/shutdown raced ahead — let the abort handler set state. Not a
+      // delivered turn: the notice (if any) must survive for the redelivery.
+      return false;
     }
 
     // Match @openai/codex-sdk's Thread.run() success semantics: when a turn
@@ -1175,6 +1184,7 @@ export const createCodexSdkHandler: HandlerFactory = (config) => {
       kind: "turn_end",
       payload: { status: settlement.status },
     });
+    const turnDelivered = settlement.action.kind === "complete";
     if (settlement.action.kind === "complete") {
       await token.complete(messages, settlement.action.outcome);
     } else {
@@ -1199,6 +1209,7 @@ export const createCodexSdkHandler: HandlerFactory = (config) => {
     }
 
     scheduleQueuedMessagesDrain();
+    return turnDelivered;
   }
 
   function scheduleQueuedMessagesDrain(): void {
@@ -1433,17 +1444,20 @@ export const createCodexSdkHandler: HandlerFactory = (config) => {
       if (message) {
         initialTurnPreparing = true;
         let initialTurnCompleted = false;
+        let turnDelivered = false;
         try {
           const input = await toCodexInput(message, sessionCtx);
-          await runTurn(input, sessionCtx, [message], deliveryToken);
+          turnDelivered = await runTurn(input, sessionCtx, [message], deliveryToken);
           initialTurnCompleted = true;
         } finally {
           initialTurnPreparing = false;
           if (initialTurnCompleted) scheduleQueuedMessagesDrain();
         }
-        // Turn delivered → advance the baseline (also seeds it for a session
-        // that had none).
-        if (initialTurnCompleted) writeSessionBriefingFingerprint(cwd, sessionId, briefingFingerprint);
+        // Advance the baseline ONLY when the notice-bearing turn was actually
+        // delivered (settled complete). A pre-provider / retried turn consumed
+        // the notice without the model seeing it, so leaving the baseline
+        // unchanged lets the redelivery's resume re-surface it.
+        if (turnDelivered) writeSessionBriefingFingerprint(cwd, sessionId, briefingFingerprint);
       }
       return hasExplicitDeliveryToken
         ? { sessionId, route: message ? { kind: "owned", mode: "processing" } : null }

--- a/packages/client/src/runtime/session-briefing-fingerprint.ts
+++ b/packages/client/src/runtime/session-briefing-fingerprint.ts
@@ -1,0 +1,118 @@
+// Per-(SDK)session fingerprint of the briefing the agent was last told in a
+// turn. The shared briefing (`<cwd>/AGENTS.md`, symlinked to `CLAUDE.md`) is
+// rewritten on every session start / resume, and the Claude Code SDK reloads
+// it via `settingSources: ["project"]` on query construction — yet a *resumed*
+// session carries a transcript built under the PREVIOUS briefing. When a
+// runtime upgrade changes the briefing (e.g. a communication-contract change),
+// the resumed agent keeps acting on the stale instructions its transcript
+// established, because the freshly-read briefing is not salient against the
+// established behavior.
+//
+// This module lets `resume()` detect that case: it records a fingerprint of
+// the briefing each turn ran with, keyed by SDK session id, and compares on
+// the next resume. A mismatch (or a missing baseline — a session that predates
+// this mechanism) is the signal to surface a one-time re-read notice into the
+// resumed turn.
+//
+// Scope / placement: one tiny JSON file per session under the agent home's
+// `.first-tree-workspace/` runtime dir. Per-session files (rather than one
+// shared map) are deliberate — the agent home is SHARED by every chat of the
+// same agent, so a single map would race between sibling-chat sessions; each
+// session only ever writes its own file.
+
+import { createHash, randomBytes } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * The per-agent runtime directory name. Inlined as a literal (rather than
+ * imported from `bootstrap.ts`) to avoid an import cycle — same convention
+ * `managed-state.ts` follows. Keep in sync with the source of truth in
+ * `bootstrap.ts` (`FIRST_TREE_RUNTIME_DIR`).
+ */
+const RUNTIME_DIR = ".first-tree-workspace";
+
+/** Subdirectory holding the per-session briefing fingerprints. */
+export const SESSION_BRIEFINGS_DIR_REL = join(RUNTIME_DIR, "session-briefings");
+
+/**
+ * Stable content fingerprint of a rendered briefing. The whole briefing is
+ * hashed: it is cache-friendly / stable across resumes for the same config and
+ * runtime version (per-chat Current Chat Context is NOT part of it), so the
+ * hash changes exactly when something the agent reads changes — a prompt-stack
+ * edit, identity / source-repo / tree-binding change, a skill set change, or a
+ * runtime template change between CLI versions (the upgrade case this targets).
+ */
+export function computeBriefingFingerprint(briefing: string): string {
+  return createHash("sha256").update(briefing, "utf8").digest("hex");
+}
+
+function sessionFingerprintPath(workspacePath: string, sessionId: string): string {
+  return join(workspacePath, SESSION_BRIEFINGS_DIR_REL, `${sessionId}.json`);
+}
+
+type SessionBriefingRecord = {
+  schemaVersion: 1;
+  fingerprint: string;
+};
+
+/**
+ * Read the fingerprint recorded for `sessionId`, or `null` when none exists
+ * (first run on this mechanism, unreadable, malformed, or a future schema).
+ * Callers treat `null` as "baseline unknown".
+ */
+export function readSessionBriefingFingerprint(workspacePath: string, sessionId: string): string | null {
+  const path = sessionFingerprintPath(workspacePath, sessionId);
+  if (!existsSync(path)) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(path, "utf-8"));
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const record = parsed as Record<string, unknown>;
+  if (record.schemaVersion !== 1) return null;
+  return typeof record.fingerprint === "string" ? record.fingerprint : null;
+}
+
+/**
+ * Record the briefing fingerprint for `sessionId`. Atomic (temp + rename) so a
+ * concurrent reader never sees a half-written file. Best-effort: never throws —
+ * a fingerprint write failure must not take down the session.
+ */
+export function writeSessionBriefingFingerprint(workspacePath: string, sessionId: string, fingerprint: string): void {
+  try {
+    const dir = join(workspacePath, SESSION_BRIEFINGS_DIR_REL);
+    mkdirSync(dir, { recursive: true });
+    const record: SessionBriefingRecord = { schemaVersion: 1, fingerprint };
+    const finalPath = sessionFingerprintPath(workspacePath, sessionId);
+    const tmpPath = join(dir, `.${sessionId}.${randomBytes(6).toString("hex")}.tmp`);
+    writeFileSync(tmpPath, JSON.stringify(record), "utf-8");
+    renameSync(tmpPath, finalPath);
+  } catch {
+    // best-effort; the worst case is a redundant re-read notice next resume.
+  }
+}
+
+/**
+ * The one-time re-read notice prepended to a resumed turn when the briefing
+ * fingerprint changed since the session last ran. Kept pure/exported so the
+ * exact wording is unit-testable.
+ */
+export function buildBriefingUpdateNotice(claudeMdPath: string): string {
+  return [
+    "<system-reminder>",
+    "Your workspace operating instructions (CLAUDE.md / AGENTS.md) and/or the " +
+      "skills installed for you have changed since this conversation last ran — " +
+      "most likely a First Tree runtime upgrade rewrote the briefing or the skill set. " +
+      "The earlier turns in this conversation were produced under the PREVIOUS " +
+      "instructions and may now be stale.",
+    `Before acting on the message below, re-read your instructions at ${claudeMdPath} ` +
+      "and follow the current contract. Pay particular attention to anything about how " +
+      "you communicate — especially how you reply to a human (the way to deliver a " +
+      "human-visible reply may have changed).",
+    "This notice is shown once per update.",
+    "</system-reminder>",
+  ].join("\n");
+}


### PR DESCRIPTION
## Problem

After #1190 retired the agent-final-text mirror, conversations that **resumed an existing transcript** kept behaving under the *previous* operating contract — most visibly, they no longer delivered a human-visible reply because they never learned the mirror was gone and `chat send <human>` is now the way to reply.

Root cause is subtle and affects **both providers**:
- The briefing (`AGENTS.md` / `CLAUDE.md`) **is** rewritten on every resume, and the Claude SDK reloads it via `settingSources: ["project"]`. But a resumed session's behavior is anchored to the long transcript it was built under; a freshly-read-but-changed briefing is not salient enough to override the established behavior.
- A resumed **Codex** thread is worse: the CLI reads `AGENTS.md` once at thread init and never re-reads it, with no detection at all.

## Fix

Detect the change explicitly and surface it on the next turn, where the model will actually read it. Shared module `session-briefing-fingerprint.ts`: sha256 the rendered briefing, keyed per session at `.first-tree-workspace/session-briefings/<id>.json`; when the briefing the next turn would run under differs from the last delivered turn's baseline (or there is no baseline — a session predating the mechanism), prepend a one-time `<system-reminder>` re-read notice.

**Claude SDK handler** — start / resume / fresh-fallback / inject-drain all route through one `deliverUserMessage()` chokepoint that does the compare + prepend, then advances the baseline **only after the input is in the replay buffer**. This:
- covers the `maybeSwitchConfig()` resume-mode restart: a mid-session config change rewrites the briefing, and the next message (drained through `pushInjectedMessage`) now carries the notice **(review pt 1)**;
- leaves the notice pending for the retry if `buildQuery()` throws before the input is buffered, instead of recording it as shown **(review pt 2)**.

**Codex (both transports)** — reuse the fingerprint module; prepend the notice ahead of the Current Chat Context in `pendingChatContextPrompt`. The baseline is advanced **only when the turn actually reached the provider and settled complete** — `runTurn()` / `runTurnFromText()` return that signal — so a pre-provider / retried / aborted turn leaves the notice pending for redelivery **(follow-up review pt 1)**. Covered turn boundaries:
- **resume** — compare against the persisted baseline;
- **active-session prompt hot-switch** — a Codex thread reads `AGENTS.md` once at init and (unlike Claude) had no inject-path hot-switch, so a mid-session prompt change only landed after a suspend/resume. Before an injected turn both transports rebuild the briefing from the latest cached config (synchronous `.get()`, kept fresh by config-update pushes), rewrite `AGENTS.md` on change, and fire the notice **(QA finding)**. The refresh is **non-throwing**: it runs after the batch is dequeued, so a rewrite failure skips the hot-switch for that turn (message still delivers under the prior briefing, retried next turn) rather than stranding the message **(follow-up review pt 2)**.

Model / MCP hot-switch for Codex (which would need a thread restart) stays out of scope; this targets the prompt/briefing.

## Design notes

- **Per-session files, not one shared map** — the agent home is shared by every chat of the agent, so each session writes only its own file and sibling chats never race.
- **Whole-briefing fingerprint** — the briefing is stable/cache-friendly across resumes for the same config + runtime (Current Chat Context is not in it), so the hash changes exactly when something the agent reads changes: a prompt-stack edit, identity / source-repo / tree-binding change, a skill-set change, or a runtime template change between CLI versions (the upgrade case this targets).
- **One migration nudge** — a missing baseline counts as changed, so each pre-existing conversation gets exactly one re-read nudge on its first post-deploy turn, then compares normally.

## Scope / follow-ups

- Covered: Claude Code SDK handler (all delivery paths incl. config hot-switch) + Codex SDK + Codex app-server (resume **and** active-session prompt hot-switch).
- Not covered: the Claude **legacy per-chat resume path** (deliberately avoids writing `.first-tree-workspace/`), the **Claude-TUI** handler (append-system-prompt file, a different channel), and Codex **model / MCP** hot-switch (needs a thread restart) — follow-ups.

## Tests

`pnpm --filter @first-tree/client test` — 104 files / **1101** pass. New: `session-briefing-fingerprint.test.ts` (9) and five codex app-server cases (resume missing-baseline → notice; unchanged briefing → none; pre-provider turn/start failure does not advance the baseline; mid active-session prompt change → injected turn carries the notice; active-session rewrite failure still delivers the message). `biome check` + `typecheck` clean. Claude resume-wiring is covered by typecheck + the existing handler suites (a full Claude integration test would need faked `~/.claude/projects/<cwd>/<id>.jsonl` transcripts, which pollute the real home dir).

## Context Tree

Paired tree PR updating `system/cloud/agents/agent-behavior-steering.md` (briefing channel lifecycle, provider-agnostic + hot-switch): agent-team-foundation/first-tree-context#582.
