### PR TITLE
fix: keep /onboarding flow on hard reload after create-agent

### DIFF
--- a/packages/web/src/pages/onboarding/__tests__/onboarding-page-dom.test.tsx
+++ b/packages/web/src/pages/onboarding/__tests__/onboarding-page-dom.test.tsx
@@ -130,6 +130,26 @@ describe("OnboardingPage", () => {
     expect(container.textContent).toContain("Workspace Home");
   });
 
+  it("keeps a user in the flow on a hard reload after create-agent (no completion stamp yet)", async () => {
+    // A full page reload builds a fresh OnboardingPage whose leave-decision ref
+    // starts null and recomputes from /me. Post-create-agent the server reports
+    // onboardingStep "completed" + a ready org, but this membership's completion
+    // stamp is still null (connect-code / kickoff haven't run). The route must
+    // resume the remaining step, NOT bounce to the workspace.
+    authMock.value = {
+      ...authMock.value,
+      onboardingStep: "completed",
+      currentOrgHasUsableAgent: true,
+      onboardingCompletedAt: null,
+    };
+    flowMock.activeStep = "connect-code";
+
+    const container = await renderRoute(<OnboardingPage />);
+
+    expect(container.textContent).not.toContain("Workspace Home");
+    expect(container.textContent).toContain("Connect Code Step");
+  });
+
   it("does NOT eject a user whose org gains a usable agent mid-flow (created at create-agent)", async () => {
     // Entry: actively onboarding, no usable agent yet → on the create-agent step.
     authMock.value = { ...authMock.value, onboardingStep: "create_agent", currentOrgHasUsableAgent: false };

--- a/packages/web/src/pages/onboarding/__tests__/steps.test.ts
+++ b/packages/web/src/pages/onboarding/__tests__/steps.test.ts
@@ -116,6 +116,8 @@ describe("shouldEnterOnboarding", () => {
     onboardingStep: "connect" as const,
     currentOrgReady: false,
     onboardingSuppressedAt: null,
+    // Ignored by the entry gate; present because both gates share the facts type.
+    onboardingCompletedAt: null,
   };
   it("redirects a fresh incomplete user (no computer yet → connect)", () => {
     expect(shouldEnterOnboarding(base)).toBe(true);
@@ -172,9 +174,31 @@ describe("shouldLeaveOnboarding", () => {
     onboardingStep: "connect" as const,
     currentOrgReady: false,
     onboardingSuppressedAt: null,
+    onboardingCompletedAt: null as string | null,
   };
-  it("leaves once connected AND the current org has a usable agent", () => {
-    expect(shouldLeaveOnboarding({ ...base, onboardingStep: "completed", currentOrgReady: true })).toBe(true);
+  it("leaves once connected, the org is ready, AND the membership completion stamp is set", () => {
+    expect(
+      shouldLeaveOnboarding({
+        ...base,
+        onboardingStep: "completed",
+        currentOrgReady: true,
+        onboardingCompletedAt: "2026-05-31T00:00:00Z",
+      }),
+    ).toBe(true);
+  });
+  it("stays after create-agent on a hard reload until the completion stamp is written", () => {
+    // The bug: a full reload right after create-agent sees onboardingStep
+    // "completed" + a ready org (server infers both the instant the agent comes
+    // online), but the membership stamp is still null because connect-code /
+    // kickoff haven't run. Readiness alone must NOT eject the user.
+    expect(
+      shouldLeaveOnboarding({
+        ...base,
+        onboardingStep: "completed",
+        currentOrgReady: true,
+        onboardingCompletedAt: null,
+      }),
+    ).toBe(false);
   });
   it("stays while the user hasn't connected a computer yet (connect step)", () => {
     expect(shouldLeaveOnboarding(base)).toBe(false);
@@ -194,8 +218,15 @@ describe("shouldLeaveOnboarding", () => {
     ).toBe(false);
   });
   it("waits for /me before deciding", () => {
+    // Otherwise leave-worthy (ready + stamped) so meLoaded is the only gate under test.
     expect(
-      shouldLeaveOnboarding({ ...base, meLoaded: false, onboardingStep: "completed", currentOrgReady: true }),
+      shouldLeaveOnboarding({
+        ...base,
+        meLoaded: false,
+        onboardingStep: "completed",
+        currentOrgReady: true,
+        onboardingCompletedAt: "2026-05-31T00:00:00Z",
+      }),
     ).toBe(false);
   });
 });

--- a/packages/web/src/pages/onboarding/onboarding-page.tsx
+++ b/packages/web/src/pages/onboarding/onboarding-page.tsx
@@ -26,9 +26,18 @@ import { resolveOnboardingPath, shouldLeaveOnboarding } from "./steps.js";
  * they made their agent, skipping those steps. Freezing the decision at entry
  * lets them finish; they leave via the explicit `completeAndEnterChat`
  * navigate at the end of kickoff (or `finishLater`).
+ *
+ * The ref freeze only protects the current component instance, so it cannot
+ * help a full page reload: that builds a fresh `OnboardingPage` whose ref
+ * starts null and recomputes the guard from `/me`. After create-agent a reload
+ * sees `onboardingStep="completed"` + a ready org and would bounce out before
+ * connect-code/kickoff. The guard therefore also requires this membership's
+ * `onboardingCompletedAt` stamp (written only by the kickoff/completion path),
+ * so a reload mid-flow resumes the remaining step instead of leaving.
  */
 export function OnboardingPage() {
-  const { meLoaded, role, onboardingStep, onboardingDismissedAt, currentOrgHasUsableAgent } = useAuth();
+  const { meLoaded, role, onboardingStep, onboardingDismissedAt, onboardingCompletedAt, currentOrgHasUsableAgent } =
+    useAuth();
   const leaveDecision = useRef<boolean | null>(null);
 
   if (!meLoaded) {
@@ -40,6 +49,7 @@ export function OnboardingPage() {
       onboardingStep,
       onboardingSuppressedAt: onboardingDismissedAt,
       currentOrgReady: currentOrgHasUsableAgent,
+      onboardingCompletedAt,
     });
   }
   if (leaveDecision.current) {

--- a/packages/web/src/pages/onboarding/steps.ts
+++ b/packages/web/src/pages/onboarding/steps.ts
@@ -157,6 +157,15 @@ export type OnboardingGateFacts = {
    */
   currentOrgReady: boolean;
   onboardingSuppressedAt: string | null;
+  /**
+   * The *currently selected* membership's completion stamp
+   * (`auth.onboardingCompletedAt`, resolved per-membership) — non-null only
+   * once the kickoff/completion path has run for THIS org. `shouldLeaveOnboarding`
+   * gates the `/onboarding` → `/` bounce on it; `shouldEnterOnboarding` ignores
+   * it (the `/` auto-entry gate keys off connect + org readiness only, never
+   * completion — connect-code and kickoff are not auto-entry predicates).
+   */
+  onboardingCompletedAt: string | null;
 };
 
 /**
@@ -193,17 +202,30 @@ export function shouldEnterOnboarding(facts: OnboardingGateFacts): boolean {
 /**
  * Should the `/onboarding` route bounce the user back to the workspace?
  *
- * Once there is nothing left to set up *for the selected org*: the user is
- * connected AND the org has a usable agent. A user still on `connect`, or in
- * an org without a usable agent, is allowed to stay and work through the
- * wizard (including a "finish later"-dismissed user who deliberately
- * returned via "Resume"). Mirror image of `shouldEnterOnboarding` minus the
- * suppress escape hatch, so the two can't fight over the same user.
+ * Only once the selected org's onboarding is terminally done: the user is
+ * connected, the org has a usable agent, AND this membership carries its
+ * completion stamp (`onboardingCompletedAt`). The stamp is the load-bearing
+ * gate. Creating the agent flips `currentOrgReady` true and makes the server
+ * infer `onboardingStep="completed"` the instant the agent comes online, but
+ * the admin still has connect-code + kickoff ahead (the invitee, kickoff).
+ * The in-page leave decision is frozen in a ref so an active session isn't
+ * ejected mid-flow, yet a full page reload builds a fresh component that
+ * recomputes from `/me`; without the completion gate that reload bounces the
+ * user out before those steps finish. Only the kickoff/completion path writes
+ * the stamp, so gating on it keeps a reloaded user in the flow until setup is
+ * genuinely finished.
+ *
+ * A user still on `connect`, in an org without a usable agent, or in an org
+ * whose membership has not been stamped complete is allowed to stay and work
+ * through the wizard (including a "finish later"-dismissed user who returned
+ * via "Resume"). They leave via the explicit completion / finish-later
+ * navigate, never an entry-time bounce.
  */
 export function shouldLeaveOnboarding(facts: OnboardingGateFacts): boolean {
   if (!facts.meLoaded) return false;
   if (facts.onboardingStep === "connect" || facts.onboardingStep === null) return false;
-  return facts.currentOrgReady;
+  if (!facts.currentOrgReady) return false;
+  return facts.onboardingCompletedAt !== null;
 }
 
 /**

--- a/packages/web/src/pages/workspace/index.tsx
+++ b/packages/web/src/pages/workspace/index.tsx
@@ -108,7 +108,8 @@ export function parseParticipantList(params: URLSearchParams): string[] {
 
 export function WorkspacePage() {
   const [searchParams, setSearchParams] = useSearchParams();
-  const { meLoaded, onboardingStep, onboardingDismissedAt, currentOrgHasUsableAgent } = useAuth();
+  const { meLoaded, onboardingStep, onboardingDismissedAt, onboardingCompletedAt, currentOrgHasUsableAgent } =
+    useAuth();
   const selectedChatId = searchParams.get("c");
   const legacyAgentId = searchParams.get("a");
   const legacySource = searchParams.get("source");
@@ -268,6 +269,9 @@ export function WorkspacePage() {
       onboardingStep,
       onboardingSuppressedAt: onboardingDismissedAt,
       currentOrgReady: currentOrgHasUsableAgent,
+      // Not read by the entry gate (auto-entry keys off connect + org
+      // readiness only); supplied because both gates share OnboardingGateFacts.
+      onboardingCompletedAt,
     })
   ) {
     return <Navigate to="/onboarding" replace />;


### PR DESCRIPTION
> **Supersedes #1206** — that PR was auto-closed when its branch was renamed `fix-1205-…` → `fix/1205-…` to satisfy the repo's `fix/<slug>` branch-name rule (the `Check Branch Name` job). **This PR is the identical commit** (`6edaca74`) that #1206 carried; #1206 was already approved by codex-assistant and yuezengwu on this exact diff.

## Problem

Refreshing `/onboarding` right after the agent is created could eject the user back to the workspace (`/`) before the remaining required steps finished — admin: connect-code + kickoff; invitee: kickoff. (Fixes #1205)

## Root cause

The in-page create-agent transition is already protected: `OnboardingPage` freezes its leave decision in a `useRef`, so the route doesn't eject when `currentOrgHasUsableAgent` flips true mid-session.

A **full page reload** defeats that freeze — it builds a fresh `OnboardingPage` whose ref starts `null` and recomputes the guard from `/me`. After create-agent, `/me` already reports `onboardingStep="completed"` and the org reads ready, so `shouldLeaveOnboarding` returned `true` on **readiness alone** and bounced the user out before connect-code/kickoff.

## Fix

Gate `shouldLeaveOnboarding` on the **per-membership** `onboardingCompletedAt` stamp in addition to org readiness: return `true` only when `/me` loaded, past `connect`/`null`, the org is ready, **and** `onboardingCompletedAt !== null`.

- The stamp is written **only** by the kickoff/completion path, so a reload mid-flow resumes the remaining step instead of leaving.
- `onboardingCompletedAt` from `useAuth()` resolves to the *current membership's* stamp, so multi-org stays correct: a returning user joining a brand-new org is still walked through create-agent + kickoff there.
- The workspace `/` auto-entry gate (`shouldEnterOnboarding`) is **unchanged** — it receives the shared field but ignores it, mirroring how the leave caller already passes `onboardingSuppressedAt` (which leave ignores).

## Tests

- `steps.test.ts`: new regression (`completed` + ready + `onboardingCompletedAt=null` → stays); updated the leave test that treated readiness alone as enough; isolated the `meLoaded` gate test.
- `onboarding-page-dom.test.tsx`: new fresh-mount/hard-reload regression — renders the remaining step, not `Workspace Home`.
- Verified both new tests go RED against the pre-fix logic and GREEN after.

## Verification

- `pnpm --filter @first-tree/web test` — **922 passed**
- `pnpm --filter @first-tree/web typecheck` — clean
- `biome check` on changed files — clean

Context Tree: decision recorded in **first-tree-context#583**.