### PR TITLE
fix(client): scope the no-send brake to agents so humans always get a reply

### DIFF
--- a/packages/client/src/__tests__/agent-briefing.test.ts
+++ b/packages/client/src/__tests__/agent-briefing.test.ts
@@ -659,15 +659,20 @@ describe("buildAgentBriefing — # Working in First Tree subsections", () => {
     expect(briefing).toMatch(/\*\*Asking a human\*\*/);
     expect(briefing).toMatch(/\*\*Reporting progress to a human\*\*/);
     expect(briefing).toMatch(/\*\*Reaching an agent to make them act\*\*/);
-    // Plain human reply is the explicit replacement for the retired final-text
-    // mirror, collected into ONE concise message near the turn's end.
-    expect(briefing).toContain("explicit replacement for the retired final-text");
-    expect(briefing).toMatch(/Replying to a human \/ your result for this turn/);
+    // A human-directed message gets a required reply, gathered into ONE concise
+    // message. The human-vs-agent asymmetry is explicit: a human never auto-wakes
+    // from a reply (no loop risk in answering), and the courtesy-send brake is
+    // scoped to agents only.
+    expect(briefing).toContain("Replying to a human is required, not optional");
+    expect(briefing).toContain("no loop risk in always answering");
+    expect(briefing).toMatch(/This brake is for agents/);
     // Anti-spam discipline: at most one plain human reply per turn; ongoing
-    // progress goes to `chat update --description`; no "nothing changed" replies.
+    // progress goes to `chat update --description`. The only skip-the-reply case
+    // is a re-delivery / no-op wake-up, NOT a fresh human message judged "covered".
     expect(briefing).toContain("Don't stream a human through repeated");
     expect(briefing).toContain("at most one plain human reply");
-    expect(briefing).toMatch(/Don't send a reply just to say nothing changed/);
+    expect(briefing).toMatch(/skip a human reply entirely is a turn/);
+    expect(briefing).toMatch(/not merely because you judge a fresh/);
     // A decision the human must make goes through `chat ask`, not a plain send.
     expect(briefing).toMatch(/must decide, approve, or answer before you proceed/);
     expect(briefing).toContain("chat invite <name>");

--- a/packages/client/src/runtime/agent-briefing.ts
+++ b/packages/client/src/runtime/agent-briefing.ts
@@ -320,10 +320,12 @@ You are running inside **First Tree**, a messaging platform for agent teams.
   to make an agent act, or to send a human a free reply / conversational answer.
   For a human you can also raise a tracked decision with \`${bin} chat ask
   <human>\`, or push progress with \`${bin} chat update --description\`.
-- **Don't fire a courtesy \`chat send\`.** Not every wake-up needs one back.
-  If after reasoning there's nothing new for any teammate, end the turn
-  without sending — a courteous "got it" between two agents is how loops
-  start.
+- **Reply to a human; don't fire a courtesy \`chat send\` to an agent.** A
+  message a human directs at you gets a \`chat send\` reply before you end the
+  turn — a human never auto-wakes from your reply, so there is no loop risk and
+  silence just reads as no reply. Between agents it is the opposite: if a
+  wake-up leaves nothing new to act on, end the turn without sending — a
+  courteous "got it" between two agents is how loops start.
 - **Content rules (Issue #389):** pass content as a **raw string** — never
   \`JSON.stringify\` it first. Wrapping in outer quotes + \`\\n\` escapes
   produces a literal \`"@x ...\\n..."\` row that the UI cannot render as
@@ -599,18 +601,19 @@ intent-specific channels: \`chat ask\` (decisions) and \`chat update
 --description\` (progress). Decision guide (based on participant \`type\` in
 the Current Chat Context block):
 
-- **Replying to a human / your result for this turn** → one \`${bin} chat send
-  <name> "..."\`. This is the explicit replacement for the retired final-text
-  mirror: your turn's final text is no longer posted to chat on its own, so
-  when the human should see the result, gather it — what you did, decisions
-  made, blockers, and the next step — into ONE concise message near the end of
-  the turn. A plain send is informational and raises no red dot.
+- **Replying to a human is required, not optional** → when a human directs a
+  message at you, end the turn with one \`${bin} chat send <name> "..."\`
+  carrying the result — what you did, decisions made, blockers, and the next
+  step — gathered into ONE concise message. A turn that ends without it is, to
+  the human, no reply at all. A plain send is informational, raises no red dot,
+  and never auto-wakes the human, so there is no loop risk in always answering.
 - **Don't stream a human through repeated \`chat send\`.** Within a turn, send
   at most one plain human reply; merge related updates into that single
   message, and use \`${bin} chat update --description\` for ongoing
-  progress/status. Don't send a reply just to say nothing changed — on a
-  re-delivery, an already-handled event, or a no-op turn, end without sending
-  unless there is genuinely new information the human needs.
+  progress/status. The one case where you skip a human reply entirely is a turn
+  with genuinely nothing to answer — a re-delivery of a message you already
+  handled, or a system / no-op wake-up — not merely because you judge a fresh
+  human message already covered.
 - **Asking a human** for a decision, approval, or answer → \`${bin} chat ask
   <human> "<background + the question>"\` (see \`## Asking Humans\`). The message
   body IS the ask. This raises a tracked open question (red-dot / open-request
@@ -628,8 +631,10 @@ the Current Chat Context block):
 - After an agent handoff, continue only independent work. If their reply is the
   only remaining input, end the turn and wait to be woken; do not poll status
   or escalate on delayed replies alone.
-- **Don't fire a courtesy \`chat send\`.** If after reasoning there is nothing
-  new for any teammate, end the turn without sending; the list above is
+- **Don't fire a courtesy \`chat send\` between agents.** If an agent wake-up
+  leaves nothing new to act on, end the turn without sending — agent↔agent "got
+  it" replies are how loops start. This brake is for agents: a human who
+  directed a message at you still gets a reply (first bullet). The list above is
   exhaustive for the *send* side.
 
 Every \`chat send\` names a recipient — there is no no-mention send. A group


### PR DESCRIPTION
## Problem

Agents sometimes don't reply to a human even though the message and `[From: …]` header arrived fine. Root cause is **not** the per-message header — it's the **Communication briefing** telling the agent it's fine to stay silent.

The brief repeated a general brake **three times** (intro block + two Communication bullets):

> if after reasoning there's nothing new for any teammate, end the turn without sending

Its rationale is **agent↔agent** echo-loop avoidance ("a courteous 'got it' between two agents is how loops start"), but the wording — *"any teammate"*, *"a reply"*, *"no-op turn"* — sweeps in **human-directed messages**, which carry zero loop risk. Paired with the silent-turn protocol, an agent that judges a human's message "already handled / nothing new" ends the turn silently → the human experiences a **dropped reply**.

Three concrete conflicts (all in the on-disk `AGENTS.md` agents actually receive):
1. **Over-broad brake** swept onto humans (the silence cause).
2. **Internal contradiction**: "Replying to a human → one chat send" vs. "don't send a reply just to say nothing changed → end without sending".
3. **Stale framing**: "the retired final-text mirror: your turn's final text is no longer posted to chat" — the last vestige of output-channel framing the 2026-06-16 cleanup removed elsewhere, and in conflict with the still-active mirror (first-tree#941).

## Fix (brief-side, not runtime)

- **Human-reply rule is now hard and primary**: a message a human directs at you gets a `chat send` reply before the turn ends. A human never auto-wakes from a reply, so there is **no loop risk** in always answering.
- **Courtesy-send brake scoped to agents** + genuine no-op / re-delivery wake-ups. It no longer applies to a fresh human message judged "covered".
- **Dropped** the "retired final-text mirror / no longer posted" sentence, completing the 2026-06-16 removal of output-channel framing and resolving the brief↔runtime conflict.

Deliberately **not** landing first-tree#941 (removing the runtime mirror): that would *increase* silence risk. This brief fix is the prerequisite that makes #941 safe to land later.

## Tests

`agent-briefing.test.ts` updated to lock in the human-vs-agent asymmetry (human reply required; brake is agent-only). Full `@first-tree/client` suite green except two pre-existing, environment-dependent binary-launch tests (`capability-probes`, `codex-binary`) unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)