### PR TITLE
feat(web): add-repo form — URL + branch only, derive name, normalize URL

### DIFF
--- a/packages/web/src/lib/__tests__/normalize-repo-url.test.ts
+++ b/packages/web/src/lib/__tests__/normalize-repo-url.test.ts
@@ -33,4 +33,13 @@ describe("normalizeRepoUrl", () => {
     expect(normalizeRepoUrl("   ")).toBe("");
     expect(normalizeRepoUrl("not a url")).toBe("not a url");
   });
+
+  it("does not fabricate a URL from input with trailing junk after the path", () => {
+    // The host-path / shorthand matches are fully anchored, so trailing text or
+    // internal whitespace leaves the input untouched for the schema to reject —
+    // it is never silently wrapped into a valid-looking https URL.
+    expect(normalizeRepoUrl("github.com/acme/web extra")).toBe("github.com/acme/web extra");
+    expect(normalizeRepoUrl("acme/web extra")).toBe("acme/web extra");
+    expect(normalizeRepoUrl("github.com/acme/web\tnope")).toBe("github.com/acme/web\tnope");
+  });
 });

--- a/packages/web/src/lib/__tests__/normalize-repo-url.test.ts
+++ b/packages/web/src/lib/__tests__/normalize-repo-url.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { normalizeRepoUrl } from "../normalize-repo-url.js";
+
+describe("normalizeRepoUrl", () => {
+  it("leaves full URLs and scp-like forms unchanged", () => {
+    for (const u of [
+      "https://github.com/acme/web",
+      "https://github.com/acme/web.git",
+      "ssh://git@github.com/acme/web.git",
+      "git@github.com:acme/web.git",
+      "git@github.com:acme/web",
+    ]) {
+      expect(normalizeRepoUrl(u)).toBe(u);
+    }
+  });
+
+  it("prepends https:// to a scheme-less host path", () => {
+    expect(normalizeRepoUrl("github.com/acme/web")).toBe("https://github.com/acme/web");
+    expect(normalizeRepoUrl("github.com/acme/web.git")).toBe("https://github.com/acme/web.git");
+    expect(normalizeRepoUrl("gitlab.com/acme/web")).toBe("https://gitlab.com/acme/web");
+  });
+
+  it("expands owner/repo shorthand to a GitHub URL", () => {
+    expect(normalizeRepoUrl("acme/web")).toBe("https://github.com/acme/web");
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(normalizeRepoUrl("  acme/web  ")).toBe("https://github.com/acme/web");
+  });
+
+  it("leaves empty and unrecognized input for schema validation to reject", () => {
+    expect(normalizeRepoUrl("")).toBe("");
+    expect(normalizeRepoUrl("   ")).toBe("");
+    expect(normalizeRepoUrl("not a url")).toBe("not a url");
+  });
+});

--- a/packages/web/src/lib/normalize-repo-url.ts
+++ b/packages/web/src/lib/normalize-repo-url.ts
@@ -17,9 +17,12 @@ export function normalizeRepoUrl(raw: string): string {
   if (/^[a-z][a-z0-9+.-]*:\/\//i.test(value)) return value;
   // scp-like SSH: user@host:path (e.g. git@github.com:org/repo.git).
   if (/^[^@/\s]+@[^/\s:]+:[^/\s]/.test(value)) return value;
-  // Scheme-less host path: "host.tld/owner/repo…" — prepend https://.
-  if (/^[^/\s]+\.[^/\s]+\/\S+/.test(value)) return `https://${value}`;
-  // GitHub shorthand: "owner/repo" (exactly one segment pair, no host).
+  // Scheme-less host path: "host.tld/owner/repo". Fully anchored (^…$) and
+  // whitespace-free so trailing junk (e.g. "github.com/x/y extra") is NOT wrapped
+  // into a valid-looking URL — unrecognized input must fall through to schema
+  // validation, which rejects it.
+  if (/^[^/\s]+\.[^/\s]+\/\S+$/.test(value)) return `https://${value}`;
+  // GitHub shorthand: exactly "owner/repo" (no host, anchored, no trailing junk).
   if (/^[^/\s]+\/[^/\s]+$/.test(value)) return `https://github.com/${value}`;
   return value;
 }

--- a/packages/web/src/lib/normalize-repo-url.ts
+++ b/packages/web/src/lib/normalize-repo-url.ts
@@ -1,0 +1,25 @@
+/**
+ * Normalize a user-pasted repository URL into a form `repoUrlSchema` accepts, so
+ * the common GitHub paste shapes work without typing a scheme:
+ *   - "https://github.com/org/repo(.git)" / "ssh://…" / "git@host:org/repo.git"
+ *       → returned unchanged (already valid forms)
+ *   - "github.com/org/repo"  → "https://github.com/org/repo"  (scheme-less host path)
+ *   - "org/repo"             → "https://github.com/org/repo"  (GitHub shorthand)
+ *
+ * Anything we don't recognise is returned trimmed and left for schema validation
+ * to reject with its own message — this only widens accepted input, it never
+ * loosens the validation that runs on the result.
+ */
+export function normalizeRepoUrl(raw: string): string {
+  const value = raw.trim();
+  if (!value) return value;
+  // Already has an explicit scheme (https://, ssh://, git://, …).
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(value)) return value;
+  // scp-like SSH: user@host:path (e.g. git@github.com:org/repo.git).
+  if (/^[^@/\s]+@[^/\s:]+:[^/\s]/.test(value)) return value;
+  // Scheme-less host path: "host.tld/owner/repo…" — prepend https://.
+  if (/^[^/\s]+\.[^/\s]+\/\S+/.test(value)) return `https://${value}`;
+  // GitHub shorthand: "owner/repo" (exactly one segment pair, no host).
+  if (/^[^/\s]+\/[^/\s]+$/.test(value)) return `https://github.com/${value}`;
+  return value;
+}

--- a/packages/web/src/pages/__tests__/resource-editors-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/resource-editors-dom.test.tsx
@@ -202,26 +202,41 @@ afterEach(() => {
 });
 
 describe("resource editors", () => {
-  it("creates a repo via the type-first add menu", async () => {
+  it("creates a repo from the URL, deriving the name (no name field)", async () => {
     const { root } = await render();
     // Section-local entry: each section's "+" icon (aria "Add <Type>") opens that type's editor.
     await click(byAria("Add Repo"));
 
-    const name = document.getElementById("repo-name");
+    // No Name field — the display name is derived from the URL.
+    expect(document.getElementById("repo-name")).toBeNull();
     const url = document.getElementById("repo-url");
-    expect(name).toBeTruthy();
     expect(url).toBeTruthy();
-    if (!(name instanceof HTMLInputElement) || !(url instanceof HTMLInputElement)) throw new Error("inputs");
-    await setInputValue(name, "web");
+    if (!(url instanceof HTMLInputElement)) throw new Error("inputs");
     await setInputValue(url, "git@github.com:acme/web.git");
 
     await click(byText("Create"));
 
     expect(resourceMocks.createTeamResource).toHaveBeenCalledTimes(1);
     // Assert on the first arg only — react-query passes its own context as a
-    // trailing arg to mutationFn.
+    // trailing arg to mutationFn. Name is derived (owner/repo); the scp-like URL
+    // is already valid so it is saved unchanged.
     expect(resourceMocks.createTeamResource.mock.calls[0]?.[0]).toEqual(
-      expect.objectContaining({ type: "repo", name: "web", payload: { url: "git@github.com:acme/web.git" } }),
+      expect.objectContaining({ type: "repo", name: "acme/web", payload: { url: "git@github.com:acme/web.git" } }),
+    );
+    await act(async () => root.unmount());
+  });
+
+  it("normalizes a scheme-less repo URL and derives the name on create", async () => {
+    const { root } = await render();
+    await click(byAria("Add Repo"));
+    const url = document.getElementById("repo-url");
+    if (!(url instanceof HTMLInputElement)) throw new Error("inputs");
+    await setInputValue(url, "github.com/acme/web");
+
+    await click(byText("Create"));
+
+    expect(resourceMocks.createTeamResource.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({ type: "repo", name: "acme/web", payload: { url: "https://github.com/acme/web" } }),
     );
     await act(async () => root.unmount());
   });

--- a/packages/web/src/pages/settings/resource-editors.tsx
+++ b/packages/web/src/pages/settings/resource-editors.tsx
@@ -1,4 +1,5 @@
 import type { CreateTeamResource, ResourceRow, ResourceType } from "@first-tree/shared";
+import { deriveRepoShortLabel } from "@first-tree/shared";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Plus, Trash2 } from "lucide-react";
 import { type FormEvent, type ReactNode, useRef, useState } from "react";
@@ -14,6 +15,7 @@ import { Input } from "../../components/ui/input.js";
 import { Label } from "../../components/ui/label.js";
 import { Select, type SelectOption } from "../../components/ui/select.js";
 import { Textarea } from "../../components/ui/textarea.js";
+import { normalizeRepoUrl } from "../../lib/normalize-repo-url.js";
 
 // ─────────────────────────────────────────────────────────────────────────
 // Shared types + constants
@@ -391,30 +393,31 @@ function titleFor(state: EditorState): string {
 
 function RepoEditor({ state, save, onClose }: EditorProps) {
   const init = state.mode === "edit" ? state.resource : null;
-  const [name, setName] = useState(init?.name ?? "");
   const [url, setUrl] = useState(str(init?.payload, "url"));
   const [defaultBranch, setDefaultBranch] = useState(str(init?.payload, "defaultBranch"));
 
-  // Repos are always a team-wide default for now: we don't offer per-repo
-  // Opt-in, so pin `defaultEnabled: "recommended"` instead of rendering the
-  // On-by-default / Opt-in selector the other resource types show. Editing a
-  // legacy Opt-in repo and saving normalizes it to recommended.
+  // A repo has no user-meaningful name — it's the `owner/repo` of the URL — so we
+  // don't ask for one: the display name is derived from the (normalized) URL. The
+  // URL is normalized first so common paste shapes (github.com/org/repo, org/repo)
+  // work without a scheme; the server schema still validates the result. Repos are
+  // always a team-wide default: pin `defaultEnabled: "recommended"` (editing a
+  // legacy Opt-in repo normalizes it to recommended).
+  const normalizedUrl = normalizeRepoUrl(url);
   const payload = (): CreateTeamResource => ({
     type: "repo",
-    name: name.trim() || url.trim(),
+    name: deriveRepoShortLabel(normalizedUrl) || normalizedUrl,
     defaultEnabled: "recommended",
-    payload: { url: url.trim(), ...(defaultBranch.trim() ? { defaultBranch: defaultBranch.trim() } : {}) },
+    payload: { url: normalizedUrl, ...(defaultBranch.trim() ? { defaultBranch: defaultBranch.trim() } : {}) },
   });
 
   return (
     <ModalEditor state={state} save={save} onClose={onClose} payload={payload}>
-      <Field id="repo-name" label="Name" value={name} onChange={setName} placeholder="Resource name" />
       <Field
         id="repo-url"
         label="Repository URL"
         value={url}
         onChange={setUrl}
-        placeholder="git@github.com:org/repo.git"
+        placeholder="github.com/org/repo"
         mono
         required
       />


### PR DESCRIPTION
## What & why

Item 7 of the agent-detail follow-up batch. Simplifies the **Settings → Resources** repo editor: a repo's name is just its `owner/repo`, so asking for it is redundant, and the URL field should accept the shapes people actually paste.

## Changes

- **Drop the Name field.** The repo's display name is derived from the URL (`deriveRepoShortLabel` → `owner/repo`). The form is now **URL (required) + Default branch (optional**, repo default when blank).
- **Normalize the URL** before save + validation so common paste shapes work without a scheme (`github.com/org/repo`, `org/repo` → `https://github.com/org/repo`; full `https://` / `ssh://` / scp-like pass through). New `lib/normalize-repo-url.ts` (+ unit test) — only widens accepted input; the server schema still validates.

## Verification

- `pnpm --filter @first-tree/web test` green; `tsc` + `lint:tokens` + `biome` clean.

## Notes

- Frontend-only; no backend / API / schema change. No Context Tree write.
- **Follow-up:** the agent-detail "Add agent repository" dialog (`capability-section.tsx`) is aligned the same way in **#1220** — it was NOT part of this merged PR (the merged diff here is fixed at `0ce22b42`: the normalize helper + Settings repo editor only).
