### PR TITLE
feat(web): profile dialog saves every field instantly (no Save button)

### DIFF
--- a/packages/web/src/pages/agent-detail/__tests__/appearance-identity-options-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/appearance-identity-options-dom.test.tsx
@@ -374,6 +374,60 @@ describe("ProfileEditDialog (merged identity + appearance)", () => {
     await act(async () => root.unmount());
   });
 
+  it("commits a pending name edit when Done is clicked without an explicit blur", async () => {
+    const { ProfileEditDialog } = await import("../profile-edit-dialog.js");
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    const onOpenChange = vi.fn();
+    const { root } = await renderDom(
+      <ProfileEditDialog agent={agent()} open onOpenChange={onOpenChange} onSave={onSave} onSaved={vi.fn()} />,
+    );
+    const displayInput = document.body.querySelector<HTMLInputElement>("#profile-display");
+    if (!displayInput) throw new Error("Expected display field");
+    // Type a new name but do NOT blur — click Done straight away.
+    await setInputValue(displayInput, "Nova Done");
+    await click(buttonByText(document.body, "Done"));
+    // Done commits the pending name before closing, so the edit isn't lost.
+    expect(onSave).toHaveBeenCalledWith({ displayName: "Nova Done" });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    await act(async () => root.unmount());
+  });
+
+  it("serializes field saves — controls and Done disable while a save is in flight", async () => {
+    const { ProfileEditDialog } = await import("../profile-edit-dialog.js");
+    let resolveSave: (() => void) | undefined;
+    const onSave = vi.fn().mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSave = resolve;
+        }),
+    );
+    const onOpenChange = vi.fn();
+    const { root } = await renderDom(
+      <ProfileEditDialog
+        agent={agent({ avatarColorToken: "hue-1" })}
+        open
+        onOpenChange={onOpenChange}
+        onSave={onSave}
+        onSaved={vi.fn()}
+      />,
+    );
+    // Pick a color — the save starts and stays pending (unresolved).
+    await click(document.body.querySelector('button[title="hue-3"]'));
+    expect(onSave).toHaveBeenCalledTimes(1);
+    // While pending: other swatches + Done are disabled, and a second click is
+    // dropped by the in-flight guard — no overlapping PATCH, no close mid-save.
+    expect(document.body.querySelector<HTMLButtonElement>('button[title="hue-2"]')?.disabled).toBe(true);
+    expect(buttonByText(document.body, "Done")?.disabled).toBe(true);
+    await click(document.body.querySelector('button[title="hue-2"]'));
+    expect(onSave).toHaveBeenCalledTimes(1);
+    // Resolve the save → controls re-enable.
+    await act(async () => {
+      resolveSave?.();
+    });
+    expect(buttonByText(document.body, "Done")?.disabled).toBe(false);
+    await act(async () => root.unmount());
+  });
+
   it("offers the pixel-avatar generator only for non-human agents (humans use their GitHub avatar)", async () => {
     const { ProfileEditDialog } = await import("../profile-edit-dialog.js");
 

--- a/packages/web/src/pages/agent-detail/__tests__/appearance-identity-options-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/appearance-identity-options-dom.test.tsx
@@ -129,6 +129,15 @@ async function setInputValue(element: HTMLInputElement, value: string): Promise<
   await flush();
 }
 
+async function blurInput(element: Element | null): Promise<void> {
+  if (!element) throw new Error("Expected element to blur");
+  await act(async () => {
+    // React's onBlur listens to the bubbling `focusout` event.
+    element.dispatchEvent(new FocusEvent("focusout", { bubbles: true }));
+  });
+  await flush();
+}
+
 async function setFileInput(element: HTMLInputElement, file: File): Promise<void> {
   Object.defineProperty(element, "files", { configurable: true, value: [file] });
   await act(async () => {
@@ -324,11 +333,12 @@ describe("ProfileEditDialog (merged identity + appearance)", () => {
     await click(buttonByText(document.body, "Remove image"));
     expect(agentApiMocks.deleteAgentAvatar).toHaveBeenCalledWith("agent-1");
 
-    // Save commits identity fields + the fallback color in one PATCH.
+    // Colour saves instantly on swatch click — there is no Save button.
     await click(document.body.querySelector('button[title="hue-3"]'));
-    await click(buttonByText(document.body, "Save"));
-    expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ displayName: "Nova", avatarColorToken: "hue-3" }));
-    expect(onSaved).toHaveBeenCalledTimes(1);
+    expect(onSave).toHaveBeenCalledWith({ avatarColorToken: "hue-3" });
+    expect(onSaved).toHaveBeenCalled();
+    // "Done" just closes — every field already saved on its own commit.
+    await click(buttonByText(document.body, "Done"));
     expect(onOpenChange).toHaveBeenCalledWith(false);
 
     await act(async () => root.unmount());
@@ -346,15 +356,17 @@ describe("ProfileEditDialog (merged identity + appearance)", () => {
 
     const displayInput = document.body.querySelector<HTMLInputElement>("#profile-display");
     if (!displayInput) throw new Error("Expected display field");
+    // Name commits on blur: empty → inline error, no save.
     await setInputValue(displayInput, " ");
-    await click(buttonByText(document.body, "Save"));
+    await blurInput(displayInput);
     expect(document.body.textContent).toContain("Display name is required.");
     expect(onSave).not.toHaveBeenCalled();
 
+    // Valid name commits on blur; the (rejected) save surfaces an error and does
+    // not flash "saved". Nothing closes the dialog (Done was never clicked).
     await setInputValue(displayInput, "Nova Updated");
-    await click(buttonByText(document.body, "Save"));
-    expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ displayName: "Nova Updated" }));
-    // Save failed → dialog stays open (no close), error surfaced, no saved flash.
+    await blurInput(displayInput);
+    expect(onSave).toHaveBeenCalledWith({ displayName: "Nova Updated" });
     expect(document.body.textContent).toContain("Identity update failed");
     expect(onOpenChange).not.toHaveBeenCalledWith(false);
     expect(onSaved).not.toHaveBeenCalled();
@@ -412,17 +424,14 @@ describe("ProfileEditDialog (merged identity + appearance)", () => {
     const visibilitySelect = document.body.querySelector<HTMLButtonElement>("#profile-visibility");
     const delegateSelect = document.body.querySelector<HTMLButtonElement>("#profile-delegate");
     if (!displayInput || !visibilitySelect || !delegateSelect) throw new Error("Expected fields");
+    // Each field saves on its own commit — no Save button.
     await setInputValue(displayInput, "Bestony Renamed");
+    await blurInput(displayInput);
+    expect(onSave).toHaveBeenCalledWith({ displayName: "Bestony Renamed" });
     await chooseSelectOption(visibilitySelect, "Visible to your team");
+    expect(onSave).toHaveBeenCalledWith({ visibility: "organization" });
     await chooseSelectOption(delegateSelect, "Second Helper");
-    await click(buttonByText(document.body, "Save"));
-    expect(onSave).toHaveBeenCalledWith(
-      expect.objectContaining({
-        displayName: "Bestony Renamed",
-        delegateMention: "delegate-2",
-        visibility: "organization",
-      }),
-    );
+    expect(onSave).toHaveBeenCalledWith({ delegateMention: "delegate-2" });
     await act(async () => owner.root.unmount());
 
     authMock.value = { memberId: "member-other", role: "member", agentId: "human-other" };

--- a/packages/web/src/pages/agent-detail/__tests__/appearance-identity-options-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/appearance-identity-options-dom.test.tsx
@@ -452,6 +452,33 @@ describe("ProfileEditDialog (merged identity + appearance)", () => {
     await act(async () => root.unmount());
   });
 
+  it("from a focused display-name input, a blur racing the Done click still saves once and closes", async () => {
+    const { ProfileEditDialog } = await import("../profile-edit-dialog.js");
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    const onOpenChange = vi.fn();
+    const { root } = await renderDom(
+      <ProfileEditDialog agent={agent()} open onOpenChange={onOpenChange} onSave={onSave} onSaved={vi.fn()} />,
+    );
+    const displayInput = document.body.querySelector<HTMLInputElement>("#profile-display");
+    if (!displayInput) throw new Error("Expected display field");
+    displayInput.focus();
+    await setInputValue(displayInput, "Nova Focused");
+    // Reproduce the real pointer order with the blur-started save still in flight
+    // when Done's click lands — dispatched together, no flush between. Done must
+    // wait for the save and still close, saving the name exactly once.
+    const done = buttonByText(document.body, "Done");
+    await act(async () => {
+      done?.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true }));
+      displayInput.dispatchEvent(new FocusEvent("focusout", { bubbles: true }));
+      done?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+    await flush();
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect(onSave).toHaveBeenCalledWith({ displayName: "Nova Focused" });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    await act(async () => root.unmount());
+  });
+
   it("offers the pixel-avatar generator only for non-human agents (humans use their GitHub avatar)", async () => {
     const { ProfileEditDialog } = await import("../profile-edit-dialog.js");
 

--- a/packages/web/src/pages/agent-detail/__tests__/appearance-identity-options-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/appearance-identity-options-dom.test.tsx
@@ -428,6 +428,30 @@ describe("ProfileEditDialog (merged identity + appearance)", () => {
     await act(async () => root.unmount());
   });
 
+  it("retries a rejected name save and does not close on Done", async () => {
+    const { ProfileEditDialog } = await import("../profile-edit-dialog.js");
+    const onSave = vi.fn().mockRejectedValueOnce(new Error("Name update failed")).mockResolvedValueOnce(undefined);
+    const onOpenChange = vi.fn();
+    const { root } = await renderDom(
+      <ProfileEditDialog agent={agent()} open onOpenChange={onOpenChange} onSave={onSave} onSaved={vi.fn()} />,
+    );
+    const displayInput = document.body.querySelector<HTMLInputElement>("#profile-display");
+    if (!displayInput) throw new Error("Expected display field");
+    await setInputValue(displayInput, "Nova X");
+    // First Done: the name PATCH rejects → error shown, dialog NOT closed, and the
+    // value is NOT marked saved (the dedupe baseline only advances on success).
+    await click(buttonByText(document.body, "Done"));
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect(document.body.textContent).toContain("Name update failed");
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+    // Second Done: Done retries the same value (not skipped); it succeeds and closes.
+    await click(buttonByText(document.body, "Done"));
+    expect(onSave).toHaveBeenCalledTimes(2);
+    expect(onSave).toHaveBeenLastCalledWith({ displayName: "Nova X" });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    await act(async () => root.unmount());
+  });
+
   it("offers the pixel-avatar generator only for non-human agents (humans use their GitHub avatar)", async () => {
     const { ProfileEditDialog } = await import("../profile-edit-dialog.js");
 

--- a/packages/web/src/pages/agent-detail/profile-edit-dialog.tsx
+++ b/packages/web/src/pages/agent-detail/profile-edit-dialog.tsx
@@ -22,13 +22,17 @@ import { Select, type SelectOption } from "../../components/ui/select.js";
 import { AVATAR_HUE_COUNT, avatarHueColor, fgOnVividColor } from "../../lib/avatar-hues.js";
 import { useAgentIdentityMap } from "../../lib/use-agent-name-map.js";
 import { AvatarPreview } from "./appearance-section.js";
+import { useJustSaved } from "./save-semantics.js";
 
 /**
- * PR2 §Profile: one "Edit profile" dialog merging the former Identity and
- * Appearance dialogs. Two independent save paths, each with its own error so a
- * partial failure never silently swallows one half:
- *   - Identity + fallback color → one PATCH /agents/:uuid on the Save button
- *     (`onSave`). Closes the dialog + flashes "Saved" only when this succeeds.
+ * One "Edit profile" dialog merging the former Identity and Appearance dialogs.
+ * Every field saves on its own commit (immediate-save, like the rest of the
+ * agent-detail page) — there is no Save button:
+ *   - Identity / visibility / fallback color → a partial PATCH /agents/:uuid per
+ *     field (`onSave`): display name on blur / Enter, the rest on change. Saves
+ *     serialize — controls + Done disable while one is in flight — so partial
+ *     PATCHes never race and the dialog never closes mid-save; a rejected save
+ *     surfaces inline. Done just commits any pending name, then closes.
  *   - Avatar image → eager PUT/DELETE /agents/:uuid/avatar on pick/remove
  *     (raw bytes don't share the JSON envelope); never closes the dialog.
  */
@@ -119,6 +123,7 @@ export type ProfileEditDialogProps = {
 export function ProfileEditDialog({ agent, open, onOpenChange, onSave, onRefresh, onSaved }: ProfileEditDialogProps) {
   const { memberId, role, agentId } = useAuth();
   const resolveAgent = useAgentIdentityMap();
+  const { justSaved, markSaved } = useJustSaved();
 
   const initialColor: AvatarColorToken | null = AVATAR_COLOR_TOKENS.find((t) => t === agent.avatarColorToken) ?? null;
   const [displayName, setDisplayName] = useState(agent.displayName);
@@ -133,6 +138,13 @@ export function ProfileEditDialog({ agent, open, onOpenChange, onSave, onRefresh
   const [pixelCandidates, setPixelCandidates] = useState<Array<{ seed: string; hueIdx: number }>>([]);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const initializedFor = useRef<string | null>(null);
+  // The display name we last issued a PATCH for — dedupes a blur + Done so the
+  // same name change isn't saved twice.
+  const savedNameRef = useRef(agent.displayName);
+  // Synchronous in-flight guard: two quick clicks can fire before React re-renders
+  // the disabled controls, so a ref (not lagging state) is what actually serializes
+  // the partial PATCHes and prevents an older write landing after a newer one.
+  const savingRef = useRef(false);
 
   useEffect(() => {
     if (!open) {
@@ -147,6 +159,7 @@ export function ProfileEditDialog({ agent, open, onOpenChange, onSave, onRefresh
     if (initializedFor.current === agent.uuid) return;
     initializedFor.current = agent.uuid;
     setDisplayName(agent.displayName);
+    savedNameRef.current = agent.displayName;
     setDelegateMention(agent.delegateMention ?? "");
     setVisibility(agent.visibility);
     setPicked(AVATAR_COLOR_TOKENS.find((t) => t === agent.avatarColorToken) ?? null);
@@ -160,6 +173,10 @@ export function ProfileEditDialog({ agent, open, onOpenChange, onSave, onRefresh
   const canChangeVisibility = role === "admin" || agent.managerId === memberId;
   const canEditDelegate = isHuman && agent.uuid === agentId;
   const delegateIdentity = agent.delegateMention ? resolveAgent(agent.delegateMention) : null;
+  // While any save (field PATCH or avatar upload) is in flight, every control and
+  // Done disable — this serializes saves (no racing partial PATCHes) and keeps
+  // the dialog open until the save settles (a rejected save always surfaces).
+  const editsDisabled = saving || uploading;
 
   const assistantsQuery = useQuery({
     queryKey: ["agents-for-delegate", memberId],
@@ -187,29 +204,47 @@ export function ProfileEditDialog({ agent, open, onOpenChange, onSave, onRefresh
   // on change) — consistent with the rest of the agent-detail page, which has no
   // Save button. Each save is a partial PATCH /agents/:uuid; the avatar image is
   // handled eagerly below, separately.
-  async function saveField(patch: UpdateAgent) {
+  async function saveField(patch: UpdateAgent): Promise<boolean> {
+    // Serialize: ignore a new save while one is in flight, so overlapping partial
+    // PATCHes can't race and leave the server with a stale value.
+    if (savingRef.current) return false;
+    savingRef.current = true;
     setSaveError(null);
     setSaving(true);
     try {
       await onSave(patch);
       onSaved?.();
+      markSaved();
+      return true;
     } catch (err) {
       setSaveError(err instanceof Error ? err.message : String(err));
+      return false;
     } finally {
+      savingRef.current = false;
       setSaving(false);
     }
   }
 
   // Display name is required, so it commits on blur / Enter (not per keystroke):
-  // empty → inline error and no save; changed + valid → save.
-  function commitName() {
+  // empty → inline error and no save; changed + valid → save. `savedNameRef`
+  // dedupes so a blur immediately followed by Done doesn't fire the PATCH twice.
+  async function commitName(): Promise<boolean> {
     const trimmed = displayName.trim();
     if (!trimmed) {
       setNameError("Display name is required.");
-      return;
+      return false;
     }
     setNameError(null);
-    if (trimmed !== agent.displayName) saveField({ displayName: trimmed });
+    if (trimmed === savedNameRef.current) return true;
+    savedNameRef.current = trimmed;
+    return saveField({ displayName: trimmed });
+  }
+
+  // Done commits a pending (valid, changed) name and waits for it before closing,
+  // so a typed-but-not-yet-blurred name isn't lost; a rejected save keeps the
+  // dialog open with its inline error.
+  async function handleDone() {
+    if (await commitName()) onOpenChange(false);
   }
 
   async function onFileChange(e: ChangeEvent<HTMLInputElement>) {
@@ -289,7 +324,7 @@ export function ProfileEditDialog({ agent, open, onOpenChange, onSave, onRefresh
         <form
           onSubmit={(e) => {
             e.preventDefault();
-            commitName();
+            void commitName();
           }}
           className="space-y-5"
         >
@@ -307,7 +342,8 @@ export function ProfileEditDialog({ agent, open, onOpenChange, onSave, onRefresh
               id="profile-display"
               value={displayName}
               onChange={(e) => setDisplayName(e.target.value)}
-              onBlur={commitName}
+              onBlur={() => void commitName()}
+              disabled={editsDisabled}
               placeholder="How teammates see this agent"
               maxLength={200}
             />
@@ -324,7 +360,7 @@ export function ProfileEditDialog({ agent, open, onOpenChange, onSave, onRefresh
                 setVisibility(next);
                 saveField({ visibility: next });
               }}
-              disabled={!canChangeVisibility}
+              disabled={!canChangeVisibility || editsDisabled}
               options={[
                 { value: AGENT_VISIBILITY.ORGANIZATION, label: VISIBILITY_LABELS[AGENT_VISIBILITY.ORGANIZATION] },
                 { value: AGENT_VISIBILITY.PRIVATE, label: VISIBILITY_LABELS[AGENT_VISIBILITY.PRIVATE] },
@@ -346,6 +382,7 @@ export function ProfileEditDialog({ agent, open, onOpenChange, onSave, onRefresh
                   }}
                   options={delegateOptions}
                   searchable
+                  disabled={editsDisabled}
                 />
               ) : (
                 <div className="flex h-9 w-full items-center rounded-[var(--radius-input)] border border-input bg-transparent px-3 text-body opacity-70">
@@ -460,6 +497,7 @@ export function ProfileEditDialog({ agent, open, onOpenChange, onSave, onRefresh
                 }}
                 background={resolveAvatarHue(null, agent.uuid)}
                 isAuto
+                disabled={editsDisabled}
               />
               {AVATAR_COLOR_TOKENS.map((token) => (
                 <Swatch
@@ -471,6 +509,7 @@ export function ProfileEditDialog({ agent, open, onOpenChange, onSave, onRefresh
                     saveField({ avatarColorToken: token });
                   }}
                   background={`var(--avatar-${token})`}
+                  disabled={editsDisabled}
                 />
               ))}
             </div>
@@ -482,9 +521,12 @@ export function ProfileEditDialog({ agent, open, onOpenChange, onSave, onRefresh
           {saveError && <p className="text-body text-destructive">{saveError}</p>}
           <DialogFooter>
             <span className="mr-auto self-center text-caption text-muted-foreground" aria-live="polite">
-              {saving ? "Saving…" : null}
+              {saving ? "Saving…" : justSaved ? "Saved" : null}
             </span>
-            <Button type="button" onClick={() => onOpenChange(false)} disabled={uploading}>
+            {/* Done commits a pending name edit (and waits for it) before closing,
+                so a typed-but-not-yet-blurred name isn't lost. Disabled while a
+                save is in flight so the dialog never closes mid-PATCH. */}
+            <Button type="button" onClick={() => void handleDone()} disabled={editsDisabled}>
               Done
             </Button>
           </DialogFooter>
@@ -500,12 +542,14 @@ function Swatch({
   onClick,
   background,
   isAuto,
+  disabled,
 }: {
   label: string;
   selected: boolean;
   onClick: () => void;
   background: string;
   isAuto?: boolean;
+  disabled?: boolean;
 }) {
   // Selection follows the OptionCard rule: the border stays the same faint
   // hairline in both states; selection is signalled by a filled neutral marker,
@@ -516,6 +560,7 @@ function Swatch({
     <button
       type="button"
       onClick={onClick}
+      disabled={disabled}
       aria-pressed={selected}
       title={label}
       className="relative inline-flex items-center justify-center focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1"
@@ -525,7 +570,8 @@ function Swatch({
         borderRadius: "var(--radius-full)",
         background,
         border: "var(--hairline) solid var(--border)",
-        cursor: "pointer",
+        cursor: disabled ? "not-allowed" : "pointer",
+        opacity: disabled ? 0.5 : 1,
         padding: 0,
       }}
     >

--- a/packages/web/src/pages/agent-detail/profile-edit-dialog.tsx
+++ b/packages/web/src/pages/agent-detail/profile-edit-dialog.tsx
@@ -236,8 +236,12 @@ export function ProfileEditDialog({ agent, open, onOpenChange, onSave, onRefresh
     }
     setNameError(null);
     if (trimmed === savedNameRef.current) return true;
-    savedNameRef.current = trimmed;
-    return saveField({ displayName: trimmed });
+    const ok = await saveField({ displayName: trimmed });
+    // Advance the dedupe baseline only after a SUCCESSFUL save. If the PATCH is
+    // rejected, the baseline stays put so a retry (blur / Done) re-attempts the
+    // save instead of treating the unsaved value as already committed.
+    if (ok) savedNameRef.current = trimmed;
+    return ok;
   }
 
   // Done commits a pending (valid, changed) name and waits for it before closing,
@@ -356,9 +360,10 @@ export function ProfileEditDialog({ agent, open, onOpenChange, onSave, onRefresh
               aria-label="Visibility"
               value={visibility}
               onChange={(v) => {
+                if (savingRef.current) return;
                 const next = v as typeof visibility;
                 setVisibility(next);
-                saveField({ visibility: next });
+                void saveField({ visibility: next });
               }}
               disabled={!canChangeVisibility || editsDisabled}
               options={[
@@ -377,8 +382,9 @@ export function ProfileEditDialog({ agent, open, onOpenChange, onSave, onRefresh
                   aria-label="Delegate Mention"
                   value={delegateMention}
                   onChange={(v) => {
+                    if (savingRef.current) return;
                     setDelegateMention(v);
-                    saveField({ delegateMention: v || null });
+                    void saveField({ delegateMention: v || null });
                   }}
                   options={delegateOptions}
                   searchable
@@ -492,8 +498,9 @@ export function ProfileEditDialog({ agent, open, onOpenChange, onSave, onRefresh
                 label="Auto"
                 selected={picked === null}
                 onClick={() => {
+                  if (savingRef.current) return;
                   setPicked(null);
-                  saveField({ avatarColorToken: null });
+                  void saveField({ avatarColorToken: null });
                 }}
                 background={resolveAvatarHue(null, agent.uuid)}
                 isAuto
@@ -505,8 +512,9 @@ export function ProfileEditDialog({ agent, open, onOpenChange, onSave, onRefresh
                   label={token}
                   selected={picked === token}
                   onClick={() => {
+                    if (savingRef.current) return;
                     setPicked(token);
-                    saveField({ avatarColorToken: token });
+                    void saveField({ avatarColorToken: token });
                   }}
                   background={`var(--avatar-${token})`}
                   disabled={editsDisabled}

--- a/packages/web/src/pages/agent-detail/profile-edit-dialog.tsx
+++ b/packages/web/src/pages/agent-detail/profile-edit-dialog.tsx
@@ -145,6 +145,10 @@ export function ProfileEditDialog({ agent, open, onOpenChange, onSave, onRefresh
   // the disabled controls, so a ref (not lagging state) is what actually serializes
   // the partial PATCHes and prevents an older write landing after a newer one.
   const savingRef = useRef(false);
+  // An in-flight display-name commit (or null). Done awaits THIS same commit
+  // before closing, so a save a focused-input blur started still finishes — and
+  // isn't fired a second time by the Done click.
+  const pendingNameRef = useRef<Promise<boolean> | null>(null);
 
   useEffect(() => {
     if (!open) {
@@ -236,18 +240,34 @@ export function ProfileEditDialog({ agent, open, onOpenChange, onSave, onRefresh
     }
     setNameError(null);
     if (trimmed === savedNameRef.current) return true;
-    const ok = await saveField({ displayName: trimmed });
-    // Advance the dedupe baseline only after a SUCCESSFUL save. If the PATCH is
-    // rejected, the baseline stays put so a retry (blur / Done) re-attempts the
-    // save instead of treating the unsaved value as already committed.
-    if (ok) savedNameRef.current = trimmed;
-    return ok;
+    // Track this commit so a racing Done click awaits the SAME save instead of
+    // firing a second one. Advance the dedupe baseline only after the PATCH
+    // succeeds (inside the chain, before it resolves) — a rejected save stays
+    // retryable rather than being treated as already committed.
+    const p = saveField({ displayName: trimmed }).then((ok) => {
+      if (ok) savedNameRef.current = trimmed;
+      return ok;
+    });
+    pendingNameRef.current = p;
+    try {
+      return await p;
+    } finally {
+      if (pendingNameRef.current === p) pendingNameRef.current = null;
+    }
   }
 
   // Done commits a pending (valid, changed) name and waits for it before closing,
   // so a typed-but-not-yet-blurred name isn't lost; a rejected save keeps the
   // dialog open with its inline error.
   async function handleDone() {
+    // A focused-input blur can start a name save just before this click. Await
+    // THAT same in-flight commit (don't fire a second one); otherwise commit any
+    // pending name here. Close only when the name actually persisted.
+    const inflight = pendingNameRef.current;
+    if (inflight) {
+      if (await inflight) onOpenChange(false);
+      return;
+    }
     if (await commitName()) onOpenChange(false);
   }
 
@@ -531,10 +551,17 @@ export function ProfileEditDialog({ agent, open, onOpenChange, onSave, onRefresh
             <span className="mr-auto self-center text-caption text-muted-foreground" aria-live="polite">
               {saving ? "Saving…" : justSaved ? "Saved" : null}
             </span>
-            {/* Done commits a pending name edit (and waits for it) before closing,
-                so a typed-but-not-yet-blurred name isn't lost. Disabled while a
-                save is in flight so the dialog never closes mid-PATCH. */}
-            <Button type="button" onClick={() => void handleDone()} disabled={editsDisabled}>
+            {/* preventDefault on mousedown keeps focus on a focused display-name
+                input (so it doesn't blur), which means THIS click — not a racing
+                blur-triggered save — owns the commit + close. Done then commits a
+                pending name and closes only if it persisted; disabled while a save
+                is in flight so the dialog never closes mid-PATCH. */}
+            <Button
+              type="button"
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={() => void handleDone()}
+              disabled={editsDisabled}
+            >
               Done
             </Button>
           </DialogFooter>

--- a/packages/web/src/pages/agent-detail/profile-edit-dialog.tsx
+++ b/packages/web/src/pages/agent-detail/profile-edit-dialog.tsx
@@ -8,21 +8,14 @@ import {
 } from "@first-tree/shared";
 import { useQuery } from "@tanstack/react-query";
 import { Check } from "lucide-react";
-import { type ChangeEvent, type FormEvent, useEffect, useMemo, useRef, useState } from "react";
+import { type ChangeEvent, useEffect, useMemo, useRef, useState } from "react";
 import { deleteAgentAvatar, listAgents, uploadAgentAvatar } from "../../api/agents.js";
 import { useAuth } from "../../auth/auth-context.js";
 import { AgentChip } from "../../components/agent-chip.js";
 import { resolveAvatarHue } from "../../components/chat/chat-row-avatar.js";
 import { Identicon } from "../../components/identicon.js";
 import { Button } from "../../components/ui/button.js";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "../../components/ui/dialog.js";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "../../components/ui/dialog.js";
 import { Input } from "../../components/ui/input.js";
 import { Label } from "../../components/ui/label.js";
 import { Select, type SelectOption } from "../../components/ui/select.js";
@@ -134,7 +127,8 @@ export function ProfileEditDialog({ agent, open, onOpenChange, onSave, onRefresh
   const [picked, setPicked] = useState<AvatarColorToken | null>(initialColor);
   const [saving, setSaving] = useState(false);
   const [uploading, setUploading] = useState(false);
-  const [formError, setFormError] = useState<string | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [nameError, setNameError] = useState<string | null>(null);
   const [imageError, setImageError] = useState<string | null>(null);
   const [pixelCandidates, setPixelCandidates] = useState<Array<{ seed: string; hueIdx: number }>>([]);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
@@ -156,7 +150,8 @@ export function ProfileEditDialog({ agent, open, onOpenChange, onSave, onRefresh
     setDelegateMention(agent.delegateMention ?? "");
     setVisibility(agent.visibility);
     setPicked(AVATAR_COLOR_TOKENS.find((t) => t === agent.avatarColorToken) ?? null);
-    setFormError(null);
+    setSaveError(null);
+    setNameError(null);
     setImageError(null);
     setPixelCandidates([]);
   }, [open, agent]);
@@ -188,29 +183,33 @@ export function ProfileEditDialog({ agent, open, onOpenChange, onSave, onRefresh
     [assistantsQuery.data],
   );
 
-  async function submit(e: FormEvent) {
-    e.preventDefault();
-    setFormError(null);
-    const trimmed = displayName.trim();
-    if (!trimmed) {
-      setFormError("Display name is required.");
-      return;
-    }
+  // Every field saves on its own commit (text on blur / Enter, selects + colour
+  // on change) — consistent with the rest of the agent-detail page, which has no
+  // Save button. Each save is a partial PATCH /agents/:uuid; the avatar image is
+  // handled eagerly below, separately.
+  async function saveField(patch: UpdateAgent) {
+    setSaveError(null);
     setSaving(true);
     try {
-      // Identity fields and the fallback color are all PATCH /agents/:uuid, so
-      // they go in one atomic call. Image is handled eagerly below, separately.
-      const patch: UpdateAgent = { displayName: trimmed, avatarColorToken: picked };
-      if (canEditDelegate) patch.delegateMention = delegateMention || null;
-      if (visibility !== agent.visibility) patch.visibility = visibility;
       await onSave(patch);
       onSaved?.();
-      onOpenChange(false);
     } catch (err) {
-      setFormError(err instanceof Error ? err.message : String(err));
+      setSaveError(err instanceof Error ? err.message : String(err));
     } finally {
       setSaving(false);
     }
+  }
+
+  // Display name is required, so it commits on blur / Enter (not per keystroke):
+  // empty → inline error and no save; changed + valid → save.
+  function commitName() {
+    const trimmed = displayName.trim();
+    if (!trimmed) {
+      setNameError("Display name is required.");
+      return;
+    }
+    setNameError(null);
+    if (trimmed !== agent.displayName) saveField({ displayName: trimmed });
   }
 
   async function onFileChange(e: ChangeEvent<HTMLInputElement>) {
@@ -283,16 +282,17 @@ export function ProfileEditDialog({ agent, open, onOpenChange, onSave, onRefresh
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
+      <DialogContent aria-describedby={undefined}>
         <DialogHeader>
           <DialogTitle>Edit profile</DialogTitle>
-          <DialogDescription>
-            {isHuman
-              ? "Avatar changes (image) save immediately. Other details save when you click Save."
-              : "Avatar changes (image or pixel avatar) save immediately. Other details save when you click Save."}
-          </DialogDescription>
         </DialogHeader>
-        <form onSubmit={submit} className="space-y-5">
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            commitName();
+          }}
+          className="space-y-5"
+        >
           {/* Identity */}
           <div className="space-y-2">
             <Label>Agent name</Label>
@@ -307,9 +307,11 @@ export function ProfileEditDialog({ agent, open, onOpenChange, onSave, onRefresh
               id="profile-display"
               value={displayName}
               onChange={(e) => setDisplayName(e.target.value)}
+              onBlur={commitName}
               placeholder="How teammates see this agent"
               maxLength={200}
             />
+            {nameError && <p className="text-caption text-destructive">{nameError}</p>}
           </div>
           <div className="space-y-2">
             <Label htmlFor="profile-visibility">Visibility</Label>
@@ -317,7 +319,11 @@ export function ProfileEditDialog({ agent, open, onOpenChange, onSave, onRefresh
               id="profile-visibility"
               aria-label="Visibility"
               value={visibility}
-              onChange={(v) => setVisibility(v as typeof visibility)}
+              onChange={(v) => {
+                const next = v as typeof visibility;
+                setVisibility(next);
+                saveField({ visibility: next });
+              }}
               disabled={!canChangeVisibility}
               options={[
                 { value: AGENT_VISIBILITY.ORGANIZATION, label: VISIBILITY_LABELS[AGENT_VISIBILITY.ORGANIZATION] },
@@ -334,7 +340,10 @@ export function ProfileEditDialog({ agent, open, onOpenChange, onSave, onRefresh
                   id="profile-delegate"
                   aria-label="Delegate Mention"
                   value={delegateMention}
-                  onChange={setDelegateMention}
+                  onChange={(v) => {
+                    setDelegateMention(v);
+                    saveField({ delegateMention: v || null });
+                  }}
                   options={delegateOptions}
                   searchable
                 />
@@ -445,7 +454,10 @@ export function ProfileEditDialog({ agent, open, onOpenChange, onSave, onRefresh
               <Swatch
                 label="Auto"
                 selected={picked === null}
-                onClick={() => setPicked(null)}
+                onClick={() => {
+                  setPicked(null);
+                  saveField({ avatarColorToken: null });
+                }}
                 background={resolveAvatarHue(null, agent.uuid)}
                 isAuto
               />
@@ -454,24 +466,26 @@ export function ProfileEditDialog({ agent, open, onOpenChange, onSave, onRefresh
                   key={token}
                   label={token}
                   selected={picked === token}
-                  onClick={() => setPicked(token)}
+                  onClick={() => {
+                    setPicked(token);
+                    saveField({ avatarColorToken: token });
+                  }}
                   background={`var(--avatar-${token})`}
                 />
               ))}
             </div>
             <p className="text-caption text-muted-foreground">
-              Auto chooses a stable color for this agent. The color is used only when no image is set, and saves with
-              the identity fields below.
+              Auto chooses a stable color for this agent. Used only when no image is set.
             </p>
           </div>
 
-          {formError && <p className="text-body text-destructive">{formError}</p>}
+          {saveError && <p className="text-body text-destructive">{saveError}</p>}
           <DialogFooter>
-            <Button type="button" variant="ghost" onClick={() => onOpenChange(false)} disabled={saving || uploading}>
-              Cancel
-            </Button>
-            <Button type="submit" disabled={saving || uploading}>
-              {saving ? "Saving…" : "Save"}
+            <span className="mr-auto self-center text-caption text-muted-foreground" aria-live="polite">
+              {saving ? "Saving…" : null}
+            </span>
+            <Button type="button" onClick={() => onOpenChange(false)} disabled={uploading}>
+              Done
             </Button>
           </DialogFooter>
         </form>


### PR DESCRIPTION
## What & why

Item 1 of the agent-detail follow-up batch. The Edit-profile dialog was the one place on the page with a split save model — the avatar saved instantly but name / visibility / color / delegate waited for a Save button — plus a caption explaining that split. This makes the whole dialog instant-save, consistent with every other control on the page, so the caption is no longer needed.

## Changes

- **Every field saves on its own commit:** display name on **blur / Enter**, visibility / color / delegate on **change**. Each is a partial `PATCH /agents/:uuid`.
- **Removed the Save button** — the footer is now a single **Done** that just closes (a subtle "Saving…" indicator shows while a field is in flight).
- **Removed the caption** ("Avatar changes save immediately. Other details save when you click Save.") — the split it described is gone.
- **Display name stays required:** empty on blur shows an inline error and does not save. A failed save surfaces an inline error without a "saved" flash.
- Avatar image / pixel uploads remain eager (unchanged).

## Verification

- `pnpm --filter @first-tree/web test` — 922 tests green (the profile-dialog DOM test reworked: color / visibility / delegate assert per-field instant PATCHes; name commits on blur; empty name blocks the save).
- `tsc --noEmit` + `lint:tokens` clean; `biome check` clean.

## Notes

- Frontend-only — no backend / API / schema change (the PATCH endpoint already accepts partial agent updates). No Context Tree write.
- Final PR of the batch: #1209 (items 2–6), #1211 (item 7), this (item 1).
- Do not self-merge — gandy-s-assistant coordinates; gandy2025 authorizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
