### PR TITLE
Support selected GitHub repos for tree init

### DIFF
--- a/packages/server/src/__tests__/context-tree-initialize.test.ts
+++ b/packages/server/src/__tests__/context-tree-initialize.test.ts
@@ -261,13 +261,56 @@ owners: [${ACCOUNT_LOGIN}]
     expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
-  it("returns 409 selected_repositories_unsupported before creating anything", async () => {
+  it("initializes a Context Tree when the installation is scoped to selected repositories but can access the tree repo", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
     const installationId = await seedInstallation(app, admin.organizationId);
+    await renameOrg(app, admin.organizationId, "Acme Labs");
+    let rootNodeWrites = 0;
+    let workflowWrites = 0;
     const fetchSpy = mockFetch(async (url) => {
       if (url === installationTokenUrl(installationId)) {
         return installationTokenResponse({ repository_selection: "selected" });
+      }
+      if (url === orgReposUrl(ACCOUNT_LOGIN)) return githubRepoResponse(201);
+      if (url === repoUrl(ACCOUNT_LOGIN, REPO_NAME)) return githubRepoResponse(200);
+      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, ROOT_NODE_PATH, "main")) {
+        return jsonResponse({ message: "Not Found" }, 404);
+      }
+      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, ROOT_NODE_PATH)) {
+        rootNodeWrites += 1;
+        return jsonResponse({ content: { path: ROOT_NODE_PATH } }, 201);
+      }
+      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, VALIDATE_TREE_WORKFLOW_PATH, "main")) {
+        return jsonResponse({ message: "Not Found" }, 404);
+      }
+      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, VALIDATE_TREE_WORKFLOW_PATH)) {
+        workflowWrites += 1;
+        return jsonResponse({ content: { path: VALIDATE_TREE_WORKFLOW_PATH } }, 201);
+      }
+      return new Response(`unexpected fetch ${url}`, { status: 500 });
+    });
+
+    const res = await initialize(app, admin);
+
+    expect(res.statusCode).toBe(201);
+    expect(rootNodeWrites).toBe(1);
+    expect(workflowWrites).toBe(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(7);
+    expect(await getOrgContextTree(app.db, admin.organizationId)).toEqual({ repo: CLONE_URL, branch: "main" });
+  });
+
+  it("returns 409 repo_unavailable when GitHub refuses to create the tree repo for the installation", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const installationId = await seedInstallation(app, admin.organizationId);
+    await renameOrg(app, admin.organizationId, "Acme Labs");
+    const fetchSpy = mockFetch(async (url) => {
+      if (url === installationTokenUrl(installationId)) {
+        return installationTokenResponse({ repository_selection: "selected" });
+      }
+      if (url === orgReposUrl(ACCOUNT_LOGIN)) {
+        return jsonResponse({ message: "Resource not accessible by integration" }, 403);
       }
       return new Response(`unexpected fetch ${url}`, { status: 500 });
     });
@@ -275,8 +318,9 @@ owners: [${ACCOUNT_LOGIN}]
     const res = await initialize(app, admin);
 
     expect(res.statusCode).toBe(409);
-    expect(res.json()).toMatchObject({ code: "selected_repositories_unsupported" });
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(res.json()).toMatchObject({ code: "repo_unavailable" });
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect((await getOrgContextTree(app.db, admin.organizationId)).repo).toBeUndefined();
   });
 
   const permissionCases: Array<[string, Record<string, "read" | "write" | "admin">]> = [

--- a/packages/server/src/api/orgs/context-tree.ts
+++ b/packages/server/src/api/orgs/context-tree.ts
@@ -65,13 +65,6 @@ export async function orgContextTreeRoutes(app: FastifyInstance): Promise<void> 
         code: "organization_installation_required",
       });
     }
-    if (mint.repositorySelection !== "all") {
-      return reply.status(409).send({
-        error:
-          "One-click Context Tree initialization requires the GitHub App installation to have access to all repositories.",
-        code: "selected_repositories_unsupported",
-      });
-    }
     if (!hasInitializationPermissions(mint.permissions)) {
       return reply.status(403).send({
         error:
@@ -298,6 +291,9 @@ async function createOrAdoptContextTreeRepo(input: {
     if (err instanceof GithubAppApiError && err.status === 422) {
       return await adoptExistingRepository(input.installationToken, input.installation.accountLogin, input.repoName);
     }
+    if (err instanceof GithubAppApiError && isRepoAccessError(err)) {
+      throw repoUnavailableError(input.installation.accountLogin, input.repoName);
+    }
     throw mapUpstreamError(err, "Couldn't create the GitHub repo. Try again in a moment.");
   }
 }
@@ -310,6 +306,9 @@ async function verifyCreatedRepository(
   try {
     return await getRepository(installationToken, owner, repoName);
   } catch (err) {
+    if (err instanceof GithubAppApiError && isRepoAccessError(err)) {
+      throw repoUnavailableError(owner, repoName);
+    }
     throw mapUpstreamError(err, "Couldn't verify the created GitHub repo. Try again in a moment.");
   }
 }
@@ -322,12 +321,8 @@ async function adoptExistingRepository(
   try {
     return await getRepository(installationToken, owner, repoName);
   } catch (err) {
-    if (err instanceof GithubAppApiError && (err.status === 403 || err.status === 404)) {
-      throw new ContextTreeInitializeError(
-        409,
-        "repo_unavailable",
-        `GitHub repo ${owner}/${repoName} already exists but is not accessible to this team's GitHub App installation.`,
-      );
+    if (err instanceof GithubAppApiError && isRepoAccessError(err)) {
+      throw repoUnavailableError(owner, repoName);
     }
     throw mapUpstreamError(err, "Couldn't verify the existing GitHub repo. Try again in a moment.");
   }
@@ -354,7 +349,11 @@ async function ensureRepoFile(
     });
     return;
   } catch (err) {
-    if (!(err instanceof GithubAppApiError) || err.status !== 404) {
+    if (err instanceof GithubAppApiError && err.status === 404) {
+      // The file does not exist yet; create it below.
+    } else if (err instanceof GithubAppApiError && isRepoAccessError(err)) {
+      throw repoUnavailableError(repo.ownerLogin, repo.name);
+    } else {
       throw mapUpstreamError(err, input.verifyErrorMessage);
     }
   }
@@ -372,6 +371,9 @@ async function ensureRepoFile(
     if (err instanceof GithubAppApiError && (err.status === 409 || err.status === 422)) {
       await verifyExistingRepoFile(installationToken, repo, input.path, input.verifyExistingErrorMessage);
       return;
+    }
+    if (err instanceof GithubAppApiError && isRepoAccessError(err)) {
+      throw repoUnavailableError(repo.ownerLogin, repo.name);
     }
     throw mapUpstreamError(err, input.createErrorMessage);
   }
@@ -391,8 +393,23 @@ async function verifyExistingRepoFile(
       branch: BRANCH,
     });
   } catch (err) {
+    if (err instanceof GithubAppApiError && isRepoAccessError(err)) {
+      throw repoUnavailableError(repo.ownerLogin, repo.name);
+    }
     throw mapUpstreamError(err, errorMessage);
   }
+}
+
+function isRepoAccessError(err: GithubAppApiError): boolean {
+  return err.status === 403 || err.status === 404;
+}
+
+function repoUnavailableError(owner: string, repoName: string): ContextTreeInitializeError {
+  return new ContextTreeInitializeError(
+    409,
+    "repo_unavailable",
+    `GitHub repo ${owner}/${repoName} is not accessible to this team's GitHub App installation.`,
+  );
 }
 
 function mapUpstreamError(err: unknown, message: string): ContextTreeInitializeError {

--- a/packages/web/src/pages/onboarding/__tests__/provision-tree.test.ts
+++ b/packages/web/src/pages/onboarding/__tests__/provision-tree.test.ts
@@ -139,9 +139,9 @@ describe("kickoffErrorMessage", () => {
     );
     expect(msg).toMatch(/GitHub organization/);
     expect(msg).not.toMatch(/administration: write/);
-    // repo_unavailable (repo name collision the App can't access) is mapped too.
+    // repo_unavailable (repo create/access denied by the App installation) is mapped too.
     expect(kickoffErrorMessage(new ApiError(409, "not accessible", undefined, "repo_unavailable"), "fallback")).toMatch(
-      /can't access it/,
+      /couldn't create or access/,
     );
   });
   it("falls back for an ApiError with an unknown / missing code (never leaks the server string)", () => {

--- a/packages/web/src/pages/onboarding/copy.ts
+++ b/packages/web/src/pages/onboarding/copy.ts
@@ -406,15 +406,13 @@ export const COPY = {
   provisionErrors: {
     organization_installation_required:
       "First Tree is connected to a personal GitHub account, but a team Context Tree needs a GitHub organization. Connect First Tree to an org, then try again.",
-    selected_repositories_unsupported:
-      "First Tree's GitHub App can only see selected repositories. Give it access to all repositories on GitHub, then try again.",
     installation_permissions_insufficient:
       "First Tree's GitHub App is missing permissions it needs to create your team's tree. Update its access on GitHub, then try again.",
     no_installation: "GitHub isn't connected for your team yet. Connect it first, then try again.",
     suspended: "Your team's GitHub App installation is suspended. Re-enable it on GitHub, then try again.",
     not_configured: "GitHub isn't set up on this First Tree server yet. Ask your First Tree admin to finish the setup.",
     repo_unavailable:
-      "A GitHub repo for your team's Context Tree already exists but First Tree can't access it. Give the GitHub App access to it (or remove it), then try again.",
+      "First Tree couldn't create or access your team's Context Tree repo with the current GitHub App installation. Update the GitHub App repository access, then try again.",
     upstream: "Couldn't reach GitHub just now. Try again in a moment.",
   },
   /**

--- a/packages/web/src/pages/onboarding/provision-tree.ts
+++ b/packages/web/src/pages/onboarding/provision-tree.ts
@@ -58,8 +58,8 @@ function repoKey(url: string): string {
  * A `409` from the initializer is ambiguous — it can mean the tree is **already
  * provisioned** (a detect→create race, or a retry after a later kickoff step
  * failed) OR that **no tree could be created** (the merged initializer also
- * returns 409 for `organization_installation_required` /
- * `selected_repositories_unsupported`). We distinguish by the **actual binding
+ * returns 409 for `organization_installation_required` / `repo_unavailable`).
+ * We distinguish by the **actual binding
  * state** rather than the status code (the "already configured" conflict
  * carries no discriminating `code`): if a tree now exists, provisioning
  * effectively succeeded and we proceed; otherwise we re-throw so the user sees


### PR DESCRIPTION
## Summary
- Remove the hard `selected_repositories_unsupported` block from Context Tree initialization.
- Let selected-repository GitHub App installations attempt the normal create/adopt/write flow.
- Map create/access/write denials for the tree repo to `repo_unavailable` without saving a partial binding, and update onboarding copy for that recovery path.

## Validation
- `pnpm --dir packages/server exec vitest run src/__tests__/context-tree-initialize.test.ts`
- `pnpm --dir packages/web exec vitest run src/pages/onboarding/__tests__/provision-tree.test.ts`
- `pnpm --filter @first-tree/server typecheck`
- `pnpm --filter @first-tree/web typecheck`
- `pnpm exec biome check packages/server/src/api/orgs/context-tree.ts packages/server/src/__tests__/context-tree-initialize.test.ts packages/web/src/pages/onboarding/copy.ts packages/web/src/pages/onboarding/provision-tree.ts packages/web/src/pages/onboarding/__tests__/provision-tree.test.ts`

## Notes
This keeps Context Tree binding fail-stop: the server persists the binding only after the repo and required files are reachable/written.

Supersedes #1196, which used a non-compliant `codex/...` branch name and failed the branch-name check.