### PR TITLE
fix: run daemon capability probe asynchronously

### DIFF
--- a/apps/cli/src/__tests__/capability-refresh.test.ts
+++ b/apps/cli/src/__tests__/capability-refresh.test.ts
@@ -367,17 +367,45 @@ describe("CapabilityRefresher", () => {
     expect(revalidate).not.toHaveBeenCalled();
   });
 
-  it("treats a null startup snapshot as degraded and recovers via the poll", async () => {
-    const { refresher, upload, revalidate } = makeRefresher({ initial: null });
-    revalidate.mockResolvedValueOnce(allOk());
+  it("starts an immediate background full probe when no startup snapshot exists", async () => {
+    const gate = deferred<{ capabilities: ClientCapabilities; mode: "full" | "revalidate" }>();
+    const { refresher, upload, log, reprobe, revalidate } = makeRefresher({ initial: null });
+    reprobe.mockReturnValueOnce(gate.promise);
 
     await refresher.start();
-    expect(upload).not.toHaveBeenCalled(); // nothing to upload yet
+    expect(reprobe).toHaveBeenCalledTimes(1);
+    expect(reprobe).toHaveBeenCalledWith({});
+    expect(revalidate).not.toHaveBeenCalled();
+    expect(upload).not.toHaveBeenCalled(); // start() did not wait for the full probe
 
-    await vi.advanceTimersByTimeAsync(BASE);
-    expect(revalidate).toHaveBeenCalledTimes(1);
-    expect(revalidate).toHaveBeenCalledWith({}); // empty previous
+    gate.resolve({ capabilities: allOk(), mode: "full" });
+    await vi.advanceTimersByTimeAsync(0);
     expect(upload).toHaveBeenCalledWith(allOk());
+    expect(log).toHaveBeenCalledWith("•", expect.stringContaining("runtime capabilities re-probed (startup, full)"));
+    refresher.stop();
+  });
+
+  it("preserves pendingAuth published while a startup full probe is in flight", async () => {
+    const gate = deferred<{ capabilities: ClientCapabilities; mode: "full" | "revalidate" }>();
+    const { refresher, upload, reprobe } = makeRefresher({ initial: null });
+    reprobe.mockReturnValueOnce(gate.promise);
+
+    await refresher.start();
+    expect(reprobe).toHaveBeenCalledWith({});
+
+    refresher.beginInteractive("codex");
+    await refresher.setProviderEntry("codex", codexPending());
+    expect(refresher.currentEntry("codex")?.pendingAuth).toBeDefined();
+    expect(upload).toHaveBeenCalledTimes(1);
+
+    gate.resolve({ capabilities: codexUnauthSnapshot(), mode: "full" });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(refresher.currentEntry("codex")?.pendingAuth).toBeDefined();
+    expect(upload).toHaveBeenCalledTimes(2);
+    for (const [snapshot] of upload.mock.calls) {
+      expect((snapshot as ClientCapabilities).codex?.pendingAuth).toBeDefined();
+    }
     refresher.stop();
   });
 });

--- a/apps/cli/src/__tests__/capability-refresh.test.ts
+++ b/apps/cli/src/__tests__/capability-refresh.test.ts
@@ -408,4 +408,31 @@ describe("CapabilityRefresher", () => {
     }
     refresher.stop();
   });
+
+  it("preserves provider state published after interactive login completes while startup probe is in flight", async () => {
+    const gate = deferred<{ capabilities: ClientCapabilities; mode: "full" | "revalidate" }>();
+    const { refresher, upload, reprobe } = makeRefresher({ initial: null });
+    reprobe.mockReturnValueOnce(gate.promise);
+
+    await refresher.start();
+    expect(reprobe).toHaveBeenCalledWith({});
+
+    refresher.beginInteractive("codex");
+    await refresher.setProviderEntry("codex", codexPending());
+    refresher.endInteractive("codex");
+    await refresher.setProviderEntry("codex", ok({ detectedAt: "2026-06-17T00:01:00.000Z" }));
+
+    gate.resolve({ capabilities: codexUnauthSnapshot(), mode: "full" });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(refresher.currentEntry("codex")).toMatchObject({ state: "ok", authenticated: true });
+    const uploadedSnapshots = upload.mock.calls.map(([snapshot]) => snapshot as ClientCapabilities);
+    expect(uploadedSnapshots).toHaveLength(3);
+    expect(uploadedSnapshots.some(({ codex }) => codex?.state === "unauthenticated" && !codex.pendingAuth)).toBe(false);
+    expect(uploadedSnapshots[uploadedSnapshots.length - 1]?.codex).toMatchObject({
+      state: "ok",
+      authenticated: true,
+    });
+    refresher.stop();
+  });
 });

--- a/apps/cli/src/__tests__/daemon-start-command.test.ts
+++ b/apps/cli/src/__tests__/daemon-start-command.test.ts
@@ -262,7 +262,7 @@ describe("daemon start command", () => {
     expect(coreMocks.promptMissingFields).toHaveBeenCalledWith(expect.objectContaining({ noInteractive: false }));
     expect(clientMocks.applyClientLoggerConfig).toHaveBeenCalledWith({ level: "info" });
     expect(coreMocks.migrateLocalAgentDirs).toHaveBeenCalled();
-    expect(clientMocks.probeCapabilities).toHaveBeenCalled();
+    expect(clientMocks.probeCapabilities).not.toHaveBeenCalled();
     expect(coreMocks.reconcileLocalRuntimeProviders).toHaveBeenCalled();
     expect(coreMocks.ClientRuntime).toHaveBeenCalledWith(
       "https://first-tree.example",
@@ -271,12 +271,13 @@ describe("daemon start command", () => {
     );
     expect(runtimeInstance.addAgent).toHaveBeenCalledWith("nova", expect.objectContaining({ agentId: "agent-1" }));
     expect(runtimeInstance.start).toHaveBeenCalled();
-    // Capability refresh is owned by the refresher: it is seeded with the
-    // startup probe snapshot, wired to reconnect, and started (which uploads
-    // the snapshot and arms the background poll).
+    // Capability refresh is owned by the refresher: daemon start no longer runs
+    // a blocking provider smoke before Connecting; the refresher starts the
+    // post-registration background full probe.
     expect(coreMocks.CapabilityRefresher).toHaveBeenCalledWith(
-      expect.objectContaining({ initial: { "claude-code": { state: "ok" } } }),
+      expect.objectContaining({ upload: expect.any(Function), log: expect.any(Function) }),
     );
+    expect(coreMocks.CapabilityRefresher.mock.calls[0]?.[0]).not.toHaveProperty("initial");
     expect(runtimeInstance.onReconnect).toHaveBeenCalledWith(expect.any(Function));
     expect(refresherInstance.start).toHaveBeenCalled();
     expect(coreMocks.listPinnedAgents).toHaveBeenCalledWith({

--- a/apps/cli/src/commands/daemon/start.ts
+++ b/apps/cli/src/commands/daemon/start.ts
@@ -5,7 +5,6 @@ import {
   ClientUserMismatchError,
   configureClientLoggerForService,
   discoverClaudeCodeSkills,
-  probeCapabilities,
 } from "@first-tree/client";
 import {
   agentConfigSchema,
@@ -188,16 +187,13 @@ export function registerDaemonStartCommand(daemon: Command): void {
           print.status("⚠️", `agent-dir migration skipped: ${msg}`);
         }
 
-        // Pre-flight runtime-provider reconciliation: probe local runtime SDKs
-        // and rewrite any local `agent.yaml::runtime` whose value drifted from
-        // the authoritative `agents.runtime_provider` (so the spawn loop sees
-        // up-to-date config). The capabilities upload itself runs AFTER WS
-        // registration — see post-start block — because the `clients` row is
-        // created lazily during the `client:register` handshake.
-        let probedCapabilities: Awaited<ReturnType<typeof probeCapabilities>> | null = null;
+        // Pre-flight runtime-provider reconciliation rewrites any local
+        // `agent.yaml::runtime` whose value drifted from the server-authoritative
+        // `agents.runtime_provider`, so the spawn loop sees up-to-date config.
+        // Do NOT run full capability probes here: provider smokes can take
+        // seconds and should not delay the daemon from connecting/registering.
         try {
           const accessToken = await ensureFreshAccessToken();
-          probedCapabilities = await probeCapabilities();
           await reconcileLocalRuntimeProviders({
             serverUrl: config.server.url,
             accessToken,
@@ -246,16 +242,11 @@ export function registerDaemonStartCommand(daemon: Command): void {
         }
 
         // Runtime-capability refresh as a single probing model. The refresher
-        // owns BOTH the WS-reconnect re-probe AND a bounded, backoff-scheduled
-        // background poll that runs while the daemon stays connected — the gap
-        // this fixes: the startup snapshot goes stale the instant the operator
-        // installs / logs into a provider, and with no reconnect there was
-        // otherwise no refresh until a restart or a manual `daemon probe`. The
-        // poll re-probes only while a provider is non-`ok` and stops once every
-        // provider is `ok`; reconnect and poll share one in-flight guard so
-        // providers are never launched concurrently. Uploads are deduped.
+        // owns startup, WS-reconnect, and bounded background probes. Startup is
+        // deliberately post-registration and fire-and-forget: capability rows
+        // still come from launch-verified full probes, but slow provider smokes
+        // must not delay `Connecting...`, WS registration, or agent bind.
         const capabilityRefresher = new CapabilityRefresher({
-          initial: probedCapabilities,
           upload: async (capabilities) => {
             const accessToken = await ensureFreshAccessToken();
             await uploadClientCapabilities({
@@ -302,7 +293,7 @@ export function registerDaemonStartCommand(daemon: Command): void {
         // so the first PATCH runs here rather than pre-flight. Best-effort: a
         // transient failure logs and moves on; agents still bind, and the poll
         // (or a later restart) retries.
-        await capabilityRefresher.start();
+        void capabilityRefresher.start();
 
         // Post-register slash-command skill upload. Phase 1B scope is
         // user-global Claude Code skills — every claude-code agent on this

--- a/apps/cli/src/core/capability-refresh.ts
+++ b/apps/cli/src/core/capability-refresh.ts
@@ -44,7 +44,8 @@ export type CapabilityRefresherDeps = {
   upload: (capabilities: ClientCapabilities) => Promise<void>;
   /** Status logger (symbol + message), e.g. `print.status`. */
   log: (symbol: string, message: string) => void;
-  /** Initial snapshot from the daemon's startup probe (null if it failed). */
+  /** Optional initial snapshot from a caller-owned probe. Daemon startup normally
+   * omits this so full launch probes run only after WS registration. */
   initial?: ClientCapabilities | null;
   /** Override the backoff base (test seam). */
   baseMs?: number;
@@ -60,11 +61,13 @@ export type CapabilityRefresherDeps = {
 
 /**
  * Owns the daemon's post-registration runtime-capability refresh as a SINGLE
- * probing model, so the two refresh triggers never overlap or fight:
+ * probing model, so the refresh triggers never overlap or fight:
  *
- *   1. WS reconnect (`onReconnect`) — TTL-aware full-or-revalidate via
+ *   1. Startup (`start`) — if no caller supplied an initial snapshot, immediately
+ *      launch a full probe in the background after the Client has registered.
+ *   2. WS reconnect (`onReconnect`) — TTL-aware full-or-revalidate via
  *      {@link reprobeOnReconnect}, preserving the existing reconnect behavior.
- *   2. A bounded, backoff-scheduled background poll (`start`) that fires *while
+ *   3. A bounded, backoff-scheduled background poll (`start`) that fires *while
  *      the daemon stays connected* — the gap this fixes. A capability snapshot
  *      goes stale the moment the operator installs / logs into a provider; with
  *      no reconnect there was previously no refresh until a restart or a manual
@@ -115,10 +118,10 @@ export class CapabilityRefresher {
   }
 
   /**
-   * Push the startup snapshot to the server (deduped) and arm the background
-   * poll if a refresh is still warranted (a non-`ok` provider, or a snapshot
-   * the server has not confirmed). Best-effort: an upload failure is logged and
-   * the poll is still armed (a later poll re-tries the upload).
+   * Start post-registration capability refresh. If an initial snapshot was
+   * supplied, upload it (deduped) and arm the background poll. Otherwise kick off
+   * an immediate full probe in the background. Best-effort: failures are logged
+   * and later polls retry convergence.
    */
   async start(): Promise<void> {
     if (this.snapshot) {
@@ -127,6 +130,9 @@ export class CapabilityRefresher {
       } catch (err) {
         this.deps.log("⚠️", `capabilities upload skipped: ${message(err)}`);
       }
+    } else {
+      void this.runRefresh("startup");
+      return;
     }
     this.idleAttempts = 0;
     this.scheduleNext();
@@ -216,16 +222,17 @@ export class CapabilityRefresher {
     return true;
   }
 
-  private async runRefresh(trigger: "reconnect" | "poll"): Promise<void> {
+  private async runRefresh(trigger: "startup" | "reconnect" | "poll"): Promise<void> {
     if (this.stopped) return;
     if (this.inFlight) return; // a coincident reconnect is held in pendingReconnect
 
     this.inFlight = true;
+    const refreshStartedAt = Date.now();
     try {
       // A reconnect that arrived (now, or while a prior refresh ran) wins over a
       // poll: it carries the stricter TTL/full re-probe semantics. Drain the
       // intent into this run so it is honored rather than dropped.
-      const effective: "reconnect" | "poll" = this.pendingReconnect ? "reconnect" : trigger;
+      const effective: "startup" | "reconnect" | "poll" = this.pendingReconnect ? "reconnect" : trigger;
       this.pendingReconnect = false;
 
       const previous = this.snapshot ?? {};
@@ -233,27 +240,30 @@ export class CapabilityRefresher {
       try {
         let next: ClientCapabilities;
         let modeLabel: string;
-        if (effective === "reconnect") {
+        if (effective === "startup" || effective === "reconnect") {
           const { capabilities, mode } = await this.reprobe(previous);
           next = capabilities;
-          modeLabel = `reconnect, ${mode}`;
+          modeLabel = `${effective}, ${mode}`;
         } else {
           next = await this.revalidate(previous);
           modeLabel = "poll";
         }
         probed = true;
+        // Re-read at merge time: runtime-auth may have published a pendingAuth
+        // entry while this provider probe was awaiting a slow smoke.
+        const current = this.snapshot ?? previous;
         // Preserve any provider with an in-flight interactive login: the
         // orchestrator owns its entry (a pending device-code) and a fresh probe
         // would clobber it, making the web device-code panel vanish mid-login.
         if (this.interactiveProviders.size > 0) {
           const preserved: ClientCapabilities = { ...next };
           for (const provider of this.interactiveProviders) {
-            const owned = previous[provider];
+            const owned = current[provider] ?? previous[provider];
             if (owned) preserved[provider] = owned;
           }
           next = preserved;
         }
-        const changed = stableCapabilitySyncJson(next) !== stableCapabilitySyncJson(previous);
+        const changed = stableCapabilitySyncJson(next) !== stableCapabilitySyncJson(current);
         this.snapshot = next;
         // Upload is tracked separately from the probe: a probe that recovered a
         // provider to `ok` but whose PATCH failed must NOT let the poll stop —
@@ -263,17 +273,27 @@ export class CapabilityRefresher {
         try {
           const uploaded = await this.uploadIfChanged(next);
           if (uploaded) {
-            this.deps.log("•", `runtime capabilities re-probed (${modeLabel}) and uploaded`);
+            this.deps.log(
+              "•",
+              `runtime capabilities re-probed (${modeLabel}) and uploaded in ${Date.now() - refreshStartedAt}ms`,
+            );
           }
         } catch (uploadErr) {
           uploadFailed = true;
-          this.deps.log("⚠️", `capabilities upload skipped: ${message(uploadErr)}`);
+          this.deps.log(
+            "⚠️",
+            `capabilities upload skipped after ${Date.now() - refreshStartedAt}ms: ${message(uploadErr)}`,
+          );
         }
         // A reconnect, an observed state change, or a failed upload all warrant
         // a prompt next attempt; only an unchanged, fully-synced poll backs off.
-        this.idleAttempts = effective === "reconnect" || changed || uploadFailed ? 0 : this.idleAttempts + 1;
+        this.idleAttempts =
+          effective === "startup" || effective === "reconnect" || changed || uploadFailed ? 0 : this.idleAttempts + 1;
       } catch (probeErr) {
-        this.deps.log("⚠️", `${effective} capability re-probe skipped: ${message(probeErr)}`);
+        this.deps.log(
+          "⚠️",
+          `${effective} capability re-probe skipped after ${Date.now() - refreshStartedAt}ms: ${message(probeErr)}`,
+        );
         // Keep polling on a transient probe failure so the daemon still converges.
       }
       if (!probed) this.idleAttempts += 1;

--- a/apps/cli/src/core/capability-refresh.ts
+++ b/apps/cli/src/core/capability-refresh.ts
@@ -91,6 +91,14 @@ export class CapabilityRefresher {
   private lastUploadedSyncJson: string | null = null;
   private inFlight = false;
   /**
+   * Monotonic per-provider local write tracking. Runtime-auth can publish a
+   * provider update via setProviderEntry() while a slow aggregate probe is in
+   * flight; the version lets the merge preserve that newer local entry even if
+   * the interactive flag has already been cleared by the time the probe returns.
+   */
+  private providerWriteVersion = 0;
+  private readonly providerWriteVersions = new Map<string, number>();
+  /**
    * Providers with an in-flight interactive login (runtime-auth device-code).
    * While a provider is in this set, a background re-probe must NOT overwrite
    * its entry — the orchestrator owns it and is publishing a pending
@@ -179,6 +187,7 @@ export class CapabilityRefresher {
   async setProviderEntry(provider: string, entry: CapabilityEntry): Promise<void> {
     const next: ClientCapabilities = { ...(this.snapshot ?? {}), [provider]: entry };
     this.snapshot = next;
+    this.providerWriteVersions.set(provider, ++this.providerWriteVersion);
     try {
       await this.uploadIfChanged(next);
     } catch (err) {
@@ -228,6 +237,7 @@ export class CapabilityRefresher {
 
     this.inFlight = true;
     const refreshStartedAt = Date.now();
+    const refreshStartedProviderWriteVersion = this.providerWriteVersion;
     try {
       // A reconnect that arrived (now, or while a prior refresh ran) wins over a
       // poll: it carries the stricter TTL/full re-probe semantics. Drain the
@@ -249,15 +259,20 @@ export class CapabilityRefresher {
           modeLabel = "poll";
         }
         probed = true;
-        // Re-read at merge time: runtime-auth may have published a pendingAuth
-        // entry while this provider probe was awaiting a slow smoke.
+        // Re-read at merge time: runtime-auth may have published provider state
+        // while this aggregate probe was awaiting a slow smoke.
         const current = this.snapshot ?? previous;
-        // Preserve any provider with an in-flight interactive login: the
-        // orchestrator owns its entry (a pending device-code) and a fresh probe
-        // would clobber it, making the web device-code panel vanish mid-login.
-        if (this.interactiveProviders.size > 0) {
+        // Preserve providers still owned by an interactive login, plus provider
+        // entries written after this refresh started. The latter covers the
+        // common race where login completes and clears the interactive flag
+        // before a slow startup/full probe returns with stale aggregate state.
+        const providersToPreserve = new Set(this.interactiveProviders);
+        for (const [provider, version] of this.providerWriteVersions) {
+          if (version > refreshStartedProviderWriteVersion) providersToPreserve.add(provider);
+        }
+        if (providersToPreserve.size > 0) {
           const preserved: ClientCapabilities = { ...next };
-          for (const provider of this.interactiveProviders) {
+          for (const provider of providersToPreserve) {
             const owned = current[provider] ?? previous[provider];
             if (owned) preserved[provider] = owned;
           }


### PR DESCRIPTION
## Summary
- move daemon startup capability full probes out of the pre-connection path
- start the post-registration capability refresher immediately in the background when no startup snapshot exists
- preserve runtime-auth capability entries published during slow probes, including both pending device-code state and the final completed-login provider state

## Tests
- pnpm --filter first-tree-dev exec vitest run src/__tests__/daemon-start-command.test.ts src/__tests__/capability-refresh.test.ts --maxWorkers=2 --minWorkers=1
- pnpm --filter first-tree-dev typecheck
- pnpm exec biome check apps/cli/src/commands/daemon/start.ts apps/cli/src/core/capability-refresh.ts apps/cli/src/__tests__/daemon-start-command.test.ts apps/cli/src/__tests__/capability-refresh.test.ts
- git diff --check