### PR TITLE
fix: retry daemon capability uploads

### DIFF
--- a/apps/cli/src/__tests__/runtime-provider-reconcile.test.ts
+++ b/apps/cli/src/__tests__/runtime-provider-reconcile.test.ts
@@ -188,6 +188,8 @@ describe("uploadClientCapabilities", () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
   it("PATCHes /clients/:id/capabilities with the snapshot", async () => {
@@ -244,9 +246,48 @@ describe("uploadClientCapabilities", () => {
         clientId: "cli-1",
         capabilities: {},
       }),
-    ).rejects.toThrow(/403/);
+    ).rejects.toMatchObject({ statusCode: 403 });
+  });
+
+  it("retries transient fetch failures through the SDK upload path", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    fetchMock
+      .mockRejectedValueOnce(new TypeError("fetch failed"))
+      .mockRejectedValueOnce(new TypeError("fetch failed"))
+      .mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+    const upload = uploadClientCapabilities({
+      serverUrl: "http://first-tree.test",
+      accessToken: "tok",
+      clientId: "cli-1",
+      capabilities: {},
+    });
+    await flush(upload);
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 });
+
+async function flush(promise: Promise<unknown>, maxFlushes = 50): Promise<void> {
+  let settled = false;
+  let error: unknown;
+  promise.then(
+    () => {
+      settled = true;
+    },
+    (err) => {
+      error = err;
+      settled = true;
+    },
+  );
+  for (let i = 0; i < maxFlushes && !settled; i++) {
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(1000);
+  }
+  if (!settled) throw new Error("flush did not settle within maxFlushes");
+  if (error !== undefined) throw error;
+}
 
 describe("uploadAgentSkills", () => {
   let fetchMock: ReturnType<typeof vi.fn>;

--- a/apps/cli/src/core/runtime-provider-reconcile.ts
+++ b/apps/cli/src/core/runtime-provider-reconcile.ts
@@ -1,8 +1,10 @@
 import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { FirstTreeHubSDK } from "@first-tree/client";
 import type { ClientCapabilities, RuntimeProvider, SkillDescriptor } from "@first-tree/shared";
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import { cliFetch } from "./cli-fetch.js";
+import { CLI_USER_AGENT } from "./version.js";
 
 type LogFn = (level: "info" | "warn", msg: string) => void;
 
@@ -81,8 +83,11 @@ export async function reconcileLocalRuntimeProviders(opts: {
 
 /**
  * Member-scoped capabilities upload. Server stores the snapshot under
- * `clients.metadata.capabilities`. Best-effort: failure does not block
- * client startup since capabilities only matter for UI / admin checks.
+ * `clients.metadata.capabilities`. Uses the SDK retry/timeout layer because
+ * this runs on the daemon's background path where transient socket/DNS failures
+ * should converge silently instead of surfacing as one-shot `fetch failed`
+ * warnings. Best-effort: terminal failure still does not block client startup
+ * since capabilities only matter for UI / admin checks.
  */
 export async function uploadClientCapabilities(opts: {
   serverUrl: string;
@@ -90,17 +95,12 @@ export async function uploadClientCapabilities(opts: {
   clientId: string;
   capabilities: ClientCapabilities;
 }): Promise<void> {
-  const res = await cliFetch(`${opts.serverUrl}/api/v1/clients/${encodeURIComponent(opts.clientId)}/capabilities`, {
-    method: "PATCH",
-    headers: {
-      Authorization: `Bearer ${opts.accessToken}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({ capabilities: opts.capabilities }),
+  const sdk = new FirstTreeHubSDK({
+    serverUrl: opts.serverUrl,
+    getAccessToken: () => opts.accessToken,
+    userAgent: CLI_USER_AGENT,
   });
-  if (!res.ok) {
-    throw new Error(`server returned ${res.status} on PATCH /clients/${opts.clientId}/capabilities`);
-  }
+  await sdk.updateCapabilities(opts.clientId, opts.capabilities);
 }
 
 /**


### PR DESCRIPTION
## Summary
- route daemon capability PATCH uploads through `FirstTreeHubSDK.updateCapabilities()` so the background upload path uses the SDK timeout and transient retry layer
- keep the same upload-time access token, server URL, client id encoding, payload shape, and CLI user-agent
- add regression coverage for two transient `fetch failed` errors followed by a successful capability upload

## Context
After #1215, daemon startup no longer waits for the full capability probe. A staging journal showed startup succeeded quickly, but the post-registration background capability upload logged `fetch failed` during the same window as a WebSocket connect timeout; a later reconnect revalidate uploaded successfully. The direct `cliFetch` upload path did not use the SDK retry behavior already used by other HTTP calls.

## Tests
- `pnpm --filter first-tree-dev exec vitest run src/__tests__/daemon-start-command.test.ts src/__tests__/runtime-provider-reconcile.test.ts --maxWorkers=2 --minWorkers=1`
- `pnpm --filter first-tree-dev typecheck`
- `pnpm exec biome check apps/cli/src/core/runtime-provider-reconcile.ts apps/cli/src/__tests__/runtime-provider-reconcile.test.ts`
- `git diff --check`

Reviewed by codex-reviewer in chat; no blockers found.