### PR TITLE
feat(web): align the agent add-repo dialog with the Settings repo editor

### DIFF
--- a/packages/web/src/pages/agent-detail/__tests__/resources-tab-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/resources-tab-dom.test.tsx
@@ -200,6 +200,15 @@ function buttonByText(container: ParentNode, text: string): HTMLButtonElement | 
   return [...container.querySelectorAll("button")].find((button) => button.textContent?.includes(text)) ?? null;
 }
 
+async function setInputValue(element: HTMLInputElement, value: string): Promise<void> {
+  await act(async () => {
+    const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+    setter?.call(element, value);
+    element.dispatchEvent(new InputEvent("input", { bubbles: true }));
+  });
+  await flush();
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   document.body.innerHTML = "";
@@ -386,6 +395,38 @@ describe("ResourcesTab", () => {
     // …but the menu stays actionable: add a private repo or jump to Settings.
     expect(buttonByText(document.body, "Add agent repo")).toBeTruthy();
     expect(buttonByText(document.body, "Manage in Settings → Resources")).toBeTruthy();
+  });
+
+  it("agent repo dialog aligns with Settings: no Name field; normalizes URL + derives the name", async () => {
+    const { ResourceTypeSection } = await import("../capability-section.js");
+    const data = agentResources({
+      effective: { version: 1, repos: [], prompts: [], skills: [], mcp: [], unavailable: [] },
+      availableTeamResources: [],
+    });
+    const onMutate = vi.fn();
+    const container = await renderRouted(
+      <ResourceTypeSection type="repo" data={data} canEdit pending={false} onMutate={onMutate} />,
+    );
+    await click(container.querySelector('button[aria-label="Add Repo"]'));
+    await click(buttonByText(document.body, "Add agent repo"));
+    // Two fields only — URL + Default branch — no Name (matches Settings → Resources).
+    expect(document.getElementById("agent-repo-url")).toBeTruthy();
+    expect(document.getElementById("agent-repo-name")).toBeNull();
+    const url = document.getElementById("agent-repo-url");
+    if (!(url instanceof HTMLInputElement)) throw new Error("Expected url input");
+    await setInputValue(url, "github.com/acme/web");
+    const addBtn = [...document.body.querySelectorAll("button")].find((b) => b.textContent?.trim() === "Add") ?? null;
+    await click(addBtn);
+    // Scheme-less URL normalized, name derived from it, no Name field was asked.
+    expect(onMutate).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "repo",
+          mode: "include",
+          agentExtraRepo: { url: "https://github.com/acme/web", name: "web" },
+        }),
+      ]),
+    );
   });
 
   it("keeps the MCP add menu actionable with no team MCP (routes to Settings, no dead end)", async () => {

--- a/packages/web/src/pages/agent-detail/capability-section.tsx
+++ b/packages/web/src/pages/agent-detail/capability-section.tsx
@@ -21,6 +21,7 @@ import { Input } from "../../components/ui/input.js";
 import { Label } from "../../components/ui/label.js";
 import { Popover } from "../../components/ui/popover.js";
 import { Section } from "../../components/ui/section.js";
+import { normalizeRepoUrl } from "../../lib/normalize-repo-url.js";
 import { typeLabelSingular } from "../settings/resource-editors.js";
 import { ResourceRowView, type RowMenu, type RowStatusMarker, type RowToggle } from "./resource-row.js";
 import { sourceLabel } from "./resource-source.js";
@@ -398,23 +399,24 @@ function AgentRepoDialog(props: {
   onSubmit: (repo: { url: string; name?: string; defaultBranch?: string }) => void;
 }) {
   const [url, setUrl] = useState("");
-  const [name, setName] = useState("");
   const [branch, setBranch] = useState("");
   const [error, setError] = useState<string | null>(null);
   function submit(e: FormEvent) {
     e.preventDefault();
-    const trimmed = url.trim();
-    if (!trimmed) {
+    // Normalize so common paste shapes (github.com/org/repo, org/repo) work
+    // without a scheme, then derive the name — matching the Settings → Resources
+    // repo editor. A repo has no user-meaningful name, so we don't ask for one.
+    const normalized = normalizeRepoUrl(url);
+    if (!normalized) {
       setError("URL is required.");
       return;
     }
     props.onSubmit({
-      url: trimmed,
-      ...(name.trim() ? { name: name.trim() } : { name: deriveRepoLocalPath(trimmed) }),
+      url: normalized,
+      name: deriveRepoLocalPath(normalized),
       ...(branch.trim() ? { defaultBranch: branch.trim() } : {}),
     });
     setUrl("");
-    setName("");
     setBranch("");
   }
   return (
@@ -424,21 +426,7 @@ function AgentRepoDialog(props: {
           <DialogTitle>Add agent repository</DialogTitle>
         </DialogHeader>
         <form onSubmit={submit} className="space-y-4">
-          <Field
-            id="agent-repo-url"
-            label="URL"
-            value={url}
-            onChange={setUrl}
-            placeholder="git@github.com:org/repo.git"
-            mono
-          />
-          <Field
-            id="agent-repo-name"
-            label="Name"
-            value={name}
-            onChange={setName}
-            placeholder={deriveRepoLocalPath(url) || "repo"}
-          />
+          <Field id="agent-repo-url" label="URL" value={url} onChange={setUrl} placeholder="github.com/org/repo" mono />
           <Field id="agent-repo-branch" label="Default branch" value={branch} onChange={setBranch} placeholder="main" />
           {error ? (
             <p className="text-body" style={{ color: "var(--state-error)" }}>


### PR DESCRIPTION
## What & why

Follow-up to the merged **#1211** (which aligned the *Settings → Resources* repo editor): gandy flagged that the agent-detail **"Add agent repository"** dialog still used the old design (URL + Name + Default branch), inconsistent with Settings. This aligns it.

## Changes

The agent-private repo dialog (`capability-section.tsx`) now matches the Settings one:
- **Name field dropped** — the name is derived from the URL (`deriveRepoLocalPath`, the local clone path, consistent with how the repo rows render).
- **URL normalized** via the shared `normalizeRepoUrl` (landed on main with #1211): `github.com/org/repo` and `org/repo` → `https://github.com/org/repo`; full `https://` / `ssh://` / scp-like `git@host:org/repo.git` pass through. Placeholder updated to match.

Form is now **URL (required) + Default branch (optional)**.

## Verification

- `pnpm --filter @first-tree/web test` — green (added a DOM test: the agent-repo dialog has no Name field; a scheme-less URL is normalized and the name derived on add).
- `tsc --noEmit` + `lint:tokens` clean; `biome check` clean.

## Notes

- Frontend-only — no backend / API / schema change. No Context Tree write.
- Do not self-merge — gandy-s-assistant coordinates; gandy2025 authorizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
