### PR TITLE
fix: follow the chat's org when opening a cross-team chat link

### DIFF
--- a/packages/web/src/api/client.ts
+++ b/packages/web/src/api/client.ts
@@ -27,6 +27,17 @@ export function getApiSelectedOrganizationId(): string | null {
 }
 
 /**
+ * Window event announcing that the active org selection changed (a user-driven
+ * `selectOrganization`). The org-scoped admin WebSocket (`/orgs/:orgId/ws/`)
+ * reads `getApiSelectedOrganizationId()` only when it (re)connects and is not
+ * re-opened by React state, so `useAdminWs` listens for this to reconnect
+ * against the new org — otherwise a team switch keeps streaming the previous
+ * org's realtime frames. Dispatched on `window` to stay decoupled, mirroring
+ * the existing `auth:logout` signal.
+ */
+export const ADMIN_WS_ORG_CHANGED_EVENT = "admin-ws:org-changed";
+
+/**
  * Prefix an org-scoped path with `/orgs/<currentOrgId>/`. Use this on every
  * call that targets a resource living inside the user's currently-viewed
  * organization. Paths that aren't org-scoped (`/me/...`, `/auth/...`,

--- a/packages/web/src/auth/__tests__/auth-context-provider.test.tsx
+++ b/packages/web/src/auth/__tests__/auth-context-provider.test.tsx
@@ -34,6 +34,7 @@ vi.mock("../../api/client.js", () => ({
   getStoredTokens: apiMocks.getStoredTokens,
   setApiSelectedOrganizationId: apiMocks.setApiSelectedOrganizationId,
   setStoredTokens: apiMocks.setStoredTokens,
+  ADMIN_WS_ORG_CHANGED_EVENT: "admin-ws:org-changed",
 }));
 
 vi.mock("../../api/auth.js", () => ({

--- a/packages/web/src/auth/auth-context.tsx
+++ b/packages/web/src/auth/auth-context.tsx
@@ -4,6 +4,7 @@ import { createContext, type ReactNode, useCallback, useContext, useEffect, useM
 import { trackEvent } from "../analytics.js";
 import { login as loginApi } from "../api/auth.js";
 import {
+  ADMIN_WS_ORG_CHANGED_EVENT,
   api,
   clearStoredTokens,
   getStoredTokens,
@@ -313,6 +314,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       // is restored only for this account.
       writeSelectedOrgId(userIdFromToken(), organizationId);
       setApiSelectedOrganizationId(organizationId);
+      // The org-scoped admin WebSocket is not re-opened by React state changes;
+      // signal it to reconnect against the newly selected org so realtime frames
+      // follow the switch instead of staying on the previously selected org.
+      window.dispatchEvent(new CustomEvent(ADMIN_WS_ORG_CHANGED_EVENT));
       // Drop every cached React Query result keyed off the previous org —
       // the next render refetches with the new prefix so a non-default org
       // never reuses the previous selection's data.

--- a/packages/web/src/auth/auth-context.tsx
+++ b/packages/web/src/auth/auth-context.tsx
@@ -131,8 +131,9 @@ type AuthContextValue = {
    * Switch the active organization view. Pure client-side state — the
    * /orgs/:orgId/* routes themselves probe membership in real time on
    * every request, so a stale or unauthorized selection just yields a
-   * clean 403 from the next API call. Does NOT re-issue tokens or touch
-   * the WS connection.
+   * clean 403 from the next API call. Does NOT re-issue tokens; it does
+   * signal the org-scoped admin WebSocket to reconnect against the new
+   * org (`ADMIN_WS_ORG_CHANGED_EVENT`).
    */
   selectOrganization: (organizationId: string) => Promise<void>;
   refreshMe: () => Promise<void>;

--- a/packages/web/src/hooks/__tests__/use-admin-ws.test.tsx
+++ b/packages/web/src/hooks/__tests__/use-admin-ws.test.tsx
@@ -12,6 +12,7 @@ const clientMocks = vi.hoisted(() => ({
   getStoredTokens: vi.fn(),
   refreshAccessToken: vi.fn(),
   getApiSelectedOrganizationId: vi.fn(),
+  ADMIN_WS_ORG_CHANGED_EVENT: "admin-ws:org-changed",
 }));
 
 vi.mock("../../api/client.js", () => clientMocks);
@@ -199,5 +200,39 @@ describe("useAdminWs", () => {
     if (!socket) throw new Error("socket missing");
     await act(async () => root?.unmount());
     expect(socket.closed).toBe(true);
+  });
+
+  it("reconnects to the new org's socket when the selected org changes", async () => {
+    await renderHook();
+    const first = FakeWebSocket.instances[0];
+    if (!first) throw new Error("socket missing");
+    expect(first.url).toBe("wss://first-tree.test/api/v1/orgs/org-1/ws/?token=access-1");
+
+    // selectOrganization flips the API client's selected-org value and fires the
+    // org-changed event; the shared socket must drop org-1 and reopen on org-2.
+    clientMocks.getApiSelectedOrganizationId.mockReturnValue("org-2");
+    await act(async () => {
+      window.dispatchEvent(new CustomEvent("admin-ws:org-changed"));
+    });
+    await flush();
+
+    expect(first.closed).toBe(true);
+    const second = FakeWebSocket.instances[1];
+    expect(second?.url).toBe("wss://first-tree.test/api/v1/orgs/org-2/ws/?token=access-1");
+  });
+
+  it("ignores the org-changed event after the workspace socket has torn down", async () => {
+    await renderHook();
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    await act(async () => root?.unmount());
+
+    clientMocks.getApiSelectedOrganizationId.mockReturnValue("org-2");
+    await act(async () => {
+      window.dispatchEvent(new CustomEvent("admin-ws:org-changed"));
+    });
+    await flush();
+
+    // No live consumer → no reconnect; the listener was removed on teardown.
+    expect(FakeWebSocket.instances).toHaveLength(1);
   });
 });

--- a/packages/web/src/hooks/use-admin-ws.ts
+++ b/packages/web/src/hooks/use-admin-ws.ts
@@ -2,7 +2,12 @@ import { type AgentChatStatus, agentChatStatusSchema } from "@first-tree/shared"
 import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef } from "react";
 import { chatAgentStatusQueryKey } from "../api/agent-status.js";
-import { getApiSelectedOrganizationId, getStoredTokens, refreshAccessToken } from "../api/client.js";
+import {
+  ADMIN_WS_ORG_CHANGED_EVENT,
+  getApiSelectedOrganizationId,
+  getStoredTokens,
+  refreshAccessToken,
+} from "../api/client.js";
 import { upsertAgentStatus } from "../lib/agent-status-view.js";
 
 type WsMessage = {
@@ -407,6 +412,7 @@ function scheduleReconnect() {
 
 function teardown() {
   closing = true;
+  window.removeEventListener(ADMIN_WS_ORG_CHANGED_EVENT, reconnectForOrgChange);
   if (reconnectTimer) {
     clearTimeout(reconnectTimer);
     reconnectTimer = null;
@@ -420,6 +426,30 @@ function teardown() {
     ws.close(1000, "unmount");
     ws = null;
   }
+}
+
+/**
+ * Rebuild the shared connection against the now-current selected org. Fires on
+ * `ADMIN_WS_ORG_CHANGED_EVENT` (a user-driven `selectOrganization`): `connect()`
+ * reads the org from `getApiSelectedOrganizationId()` at call time, so closing
+ * the stale socket and reconnecting is enough to move to the new org's
+ * `/orgs/:orgId/ws/`. No-op when no consumer is mounted — the next mount
+ * connects fresh against the new org.
+ */
+function reconnectForOrgChange(): void {
+  if (refCount === 0) return;
+  if (reconnectTimer) {
+    clearTimeout(reconnectTimer);
+    reconnectTimer = null;
+  }
+  reconnectAttempt = 0;
+  const previous = ws;
+  // Detach before closing so the stale socket's onclose (`socket !== ws`)
+  // no-ops instead of scheduling a backoff reconnect to the previous org.
+  ws = null;
+  closing = false;
+  if (previous) previous.close(1000, "org-switch");
+  connect();
 }
 
 /**
@@ -448,6 +478,7 @@ export function useAdminWs(options?: UseAdminWsOptions) {
     if (refCount === 1) {
       closing = false;
       connect();
+      window.addEventListener(ADMIN_WS_ORG_CHANGED_EVENT, reconnectForOrgChange);
     }
 
     return () => {

--- a/packages/web/src/pages/workspace/center/__tests__/chat-by-id-center-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-by-id-center-dom.test.tsx
@@ -23,6 +23,8 @@ const authMock = vi.hoisted(() => ({
   value: {
     agentId: "human-agent-self" as string | null,
     organizationId: "org-1" as string | null,
+    memberships: [{ organizationId: "org-1" }, { organizationId: "org-2" }] as Array<{ organizationId: string }>,
+    selectOrganization: vi.fn(),
   },
 }));
 
@@ -245,7 +247,12 @@ beforeEach(() => {
   wsMock.handler = null;
   chatViewMocks.props.length = 0;
   draftMocks.props.length = 0;
-  authMock.value = { agentId: "human-agent-self", organizationId: "org-1" };
+  authMock.value = {
+    agentId: "human-agent-self",
+    organizationId: "org-1",
+    memberships: [{ organizationId: "org-1" }, { organizationId: "org-2" }],
+    selectOrganization: vi.fn(),
+  };
   chatMocks.getChat.mockResolvedValue(chatDetail());
   meChatMocks.markMeChatRead.mockResolvedValue({
     chatId: "chat-1",
@@ -434,5 +441,51 @@ describe("ChatByIdView and CenterPanel", () => {
     );
     expect(onSelectChat).toHaveBeenCalledWith("draft");
     await act(async () => empty.root.unmount());
+  });
+
+  it("switches the workspace to the chat's org when it differs and the user is a member", async () => {
+    authMock.value.organizationId = "org-1";
+    authMock.value.memberships = [{ organizationId: "org-1" }, { organizationId: "org-2" }];
+    chatMocks.getChat.mockResolvedValueOnce(chatDetail({ organizationId: "org-2" }));
+    const { ChatByIdView } = await import("../chat-by-id.js");
+    const { container, root } = await renderDom(
+      <ChatByIdView chatId="chat-xorg" narrow={false} onShowConversations={null} />,
+    );
+
+    await waitForText(container, "ChatView agent-1 chat-xorg");
+    expect(authMock.value.selectOrganization).toHaveBeenCalledTimes(1);
+    expect(authMock.value.selectOrganization).toHaveBeenCalledWith("org-2");
+
+    await act(async () => root.unmount());
+  });
+
+  it("does not switch org when the opened chat is already in the current org", async () => {
+    authMock.value.organizationId = "org-1";
+    authMock.value.memberships = [{ organizationId: "org-1" }, { organizationId: "org-2" }];
+    chatMocks.getChat.mockResolvedValueOnce(chatDetail({ organizationId: "org-1" }));
+    const { ChatByIdView } = await import("../chat-by-id.js");
+    const { container, root } = await renderDom(
+      <ChatByIdView chatId="chat-sameorg" narrow={false} onShowConversations={null} />,
+    );
+
+    await waitForText(container, "ChatView agent-1 chat-sameorg");
+    expect(authMock.value.selectOrganization).not.toHaveBeenCalled();
+
+    await act(async () => root.unmount());
+  });
+
+  it("does not switch into an org the caller is not a member of (stale /me guard)", async () => {
+    authMock.value.organizationId = "org-1";
+    authMock.value.memberships = [{ organizationId: "org-1" }];
+    chatMocks.getChat.mockResolvedValueOnce(chatDetail({ organizationId: "org-2" }));
+    const { ChatByIdView } = await import("../chat-by-id.js");
+    const { container, root } = await renderDom(
+      <ChatByIdView chatId="chat-guard" narrow={false} onShowConversations={null} />,
+    );
+
+    await waitForText(container, "ChatView agent-1 chat-guard");
+    expect(authMock.value.selectOrganization).not.toHaveBeenCalled();
+
+    await act(async () => root.unmount());
   });
 });

--- a/packages/web/src/pages/workspace/center/chat-by-id.tsx
+++ b/packages/web/src/pages/workspace/center/chat-by-id.tsx
@@ -73,13 +73,38 @@ export function ChatByIdView({
   onClearChat?: (() => void) | null;
 }) {
   const queryClient = useQueryClient();
-  const { agentId: myAgentId } = useAuth();
+  const { agentId: myAgentId, organizationId: currentOrgId, selectOrganization, memberships } = useAuth();
 
   const { data: chatDetail, isError: chatDetailError } = useQuery({
     queryKey: ["chat-detail", chatId],
     queryFn: () => getChat(chatId),
     enabled: !!chatId,
   });
+
+  // Cross-org chat links: a chat is routed by a global `?c=<chatId>` with no
+  // org segment, and the per-chat reads (`getChat` / messages) resolve by UUID
+  // regardless of the selected org. So opening a chat that lives in a *different*
+  // org than the one currently selected would render that org's conversation in
+  // the center while the rest of the shell (conversation rail, team name, agent
+  // roster, admin WebSocket) stayed on the old org. Switch the whole workspace
+  // to the chat's org so the shell follows the conversation.
+  //
+  // Only switch into an org the user actually belongs to. The server already
+  // guarantees this (`requireChatAccess` 404s a chat outside the caller's orgs
+  // before its detail can load), but the guard keeps a stale `/me` from looping:
+  // `currentOrgId` is derived from `memberships`, so a switch into an org absent
+  // from that list would never settle and the effect would re-fire. The
+  // per-target ref additionally suppresses a re-fire while the switch + `/me`
+  // refetch is in flight.
+  const switchedOrgRef = useRef<string | null>(null);
+  useEffect(() => {
+    const chatOrg = chatDetail?.organizationId;
+    if (!chatOrg || !currentOrgId || chatOrg === currentOrgId) return;
+    if (switchedOrgRef.current === chatOrg) return;
+    if (!memberships.some((m) => m.organizationId === chatOrg)) return;
+    switchedOrgRef.current = chatOrg;
+    void selectOrganization(chatOrg);
+  }, [chatDetail?.organizationId, currentOrgId, memberships, selectOrganization]);
 
   const primaryAgent = useMemo(() => {
     if (!chatDetail) return null;


### PR DESCRIPTION
## Problem

Opening a chat that belongs to **Team B** while the workspace is on **Team A** loaded Team B's messages in the center pane, but the rest of the workspace stayed on Team A — the conversation rail, team name, agent roster, and realtime updates never switched.

## Root cause

The web app has no org/team segment in any route. The active org is a single client-side `selectedOrgId` (localStorage + the `/orgs/:orgId/*` API prefix + the admin WebSocket URL), changed **only** by `selectOrganization()` (org switcher, team creation, invite accept).

A chat is opened purely by `?c=<chatId>` — no org. The per-chat reads (`getChat`, messages) hit the **global, non-org-scoped** `/chats/:id` paths, which resolve a chat by its globally-unique UUID regardless of the selected org. So the center pane renders the cross-org chat correctly, while everything keyed off `selectedOrgId` stays on the old org. Nothing in the open-chat path calls `selectOrganization`.

Realtime is a second, related gap: even once the selected org changes, the shared admin WebSocket is a module-level singleton that reads the org only inside `connect()`, and `useAdminWs`'s effect depends on `enabled` alone — so an already-open socket never re-points after `selectOrganization`. This is pre-existing: the top-menu team switcher has the same staleness.

## Fix

**1. Switch the workspace org when opening a cross-org chat** (`chat-by-id.tsx`). Once `chatDetail` loads, if its `organizationId` differs from the selected org, switch the whole workspace via `selectOrganization`.
- **Member guard:** only switch into an org the caller belongs to. `requireChatAccess` already 404s a chat outside the caller's orgs, so any chat that loads is in a member org — the guard plus a per-target ref keep a stale `/me` from looping the switch.
- **No toast by design:** the shell visibly flips to the chat's team, which is itself the feedback.

**2. Reconnect the admin WebSocket on org change** (`auth-context.tsx` + `use-admin-ws.ts`). `selectOrganization` now dispatches `ADMIN_WS_ORG_CHANGED_EVENT`; `useAdminWs` listens (registered/removed with the shared connection lifecycle) to close the stale socket and reconnect against the new org. Fixes the realtime gap for both this feature and the existing top-menu switcher.

## Testing

- `chat-by-id-center-dom.test.tsx`: cross-org switch, same-org no-op, non-member stale-`/me` guard.
- `use-admin-ws.test.tsx`: reconnect-to-new-org on the org-changed event, and no-op after teardown.
- `pnpm --filter @first-tree/web test` → 954 passing
- `pnpm exec biome check` (changed files) + `pnpm --filter @first-tree/web typecheck` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
