### PR TITLE
Fix Codex provider attempt failure handling

### DIFF
--- a/packages/client/src/__tests__/codex-app-server-handler.test.ts
+++ b/packages/client/src/__tests__/codex-app-server-handler.test.ts
@@ -60,6 +60,7 @@ class FakeAppServerClient {
   onClose: CloseHandler | null = null;
   steerError: Error | null = null;
   turnStartError: Error | null = null;
+  beforeTurnStartError: (() => void) | null = null;
   threadStartDeferred: { promise: Promise<unknown>; resolve: (value: unknown) => void } | null = null;
   steerDeferred: {
     promise: Promise<unknown>;
@@ -78,7 +79,10 @@ class FakeAppServerClient {
       return { thread: { id: "thread-app-server" } };
     }
     if (method === "turn/start") {
-      if (this.turnStartError) throw this.turnStartError;
+      if (this.turnStartError) {
+        this.beforeTurnStartError?.();
+        throw this.turnStartError;
+      }
       this.turnCounter += 1;
       return {
         turn: {
@@ -761,6 +765,30 @@ describe("codex app-server handler", () => {
     await handler.shutdown();
   });
 
+  it("does not classify normal app-server assistant text that mentions provider error keywords", async () => {
+    const fake = new FakeAppServerClient();
+    const token = makeDeliveryToken();
+    const emitEvent = vi.fn<(event: SessionEvent) => void>();
+    const handler = makeHandler(fake);
+    const ctx = makeContext({ emitEvent });
+    const message = makeMessage("m1", "first");
+
+    const startPromise = handler.start(message, ctx, token);
+    await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
+
+    completeTurn(fake, "turn-1", "Normal answer mentioning 401 Unauthorized and context window.");
+    await startPromise;
+
+    expect(token.complete).toHaveBeenCalledWith([message], { status: "success", terminal: true });
+    expect(token.retry).not.toHaveBeenCalled();
+    expect(token.terminalRejected).not.toHaveBeenCalled();
+    expect(emitEvent.mock.calls.some(([event]) => event.kind === "error" && event.payload.source === "runtime")).toBe(
+      false,
+    );
+
+    await handler.shutdown();
+  });
+
   it("keeps transient app-server turn failures retryable", async () => {
     const fake = new FakeAppServerClient();
     const token = makeDeliveryToken();
@@ -784,6 +812,61 @@ describe("codex app-server handler", () => {
     await handler.shutdown();
   });
 
+  it("consumes accepted-turn capacity wait stops instead of terminal-rejecting them", async () => {
+    const fake = new FakeAppServerClient();
+    const token = makeDeliveryToken();
+    const handler = makeHandler(fake);
+    const ctx = makeContext();
+    const message = makeMessage("m1", "first");
+
+    const startPromise = handler.start(message, ctx, token);
+    await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
+
+    failTurn(fake, "turn-1", { message: "rate limit exceeded; retry later" });
+    await startPromise;
+
+    expect(token.complete).toHaveBeenCalledWith([message], {
+      status: "error",
+      terminal: true,
+      completion: "consumed",
+      reason: "capacity_wait_required",
+    });
+    expect(token.terminalRejected).not.toHaveBeenCalled();
+    expect(token.retry).not.toHaveBeenCalled();
+
+    await handler.shutdown();
+  });
+
+  it("consumes unsafe replay stops after visible output instead of terminal-rejecting them", async () => {
+    const fake = new FakeAppServerClient();
+    const token = makeDeliveryToken();
+    const handler = makeHandler(fake);
+    const ctx = makeContext();
+    const message = makeMessage("m1", "first");
+
+    const startPromise = handler.start(message, ctx, token);
+    await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
+
+    fake.emit("item/completed", {
+      threadId: "thread-app-server",
+      turnId: "turn-1",
+      item: { type: "agentMessage", id: "item-turn-1", text: "partial answer", phase: null, memoryCitation: null },
+    });
+    fake.close("transport is closed");
+    await startPromise;
+
+    expect(token.complete).toHaveBeenCalledWith([message], {
+      status: "error",
+      terminal: true,
+      completion: "consumed",
+      reason: "unsafe_replay",
+    });
+    expect(token.terminalRejected).not.toHaveBeenCalled();
+    expect(token.retry).not.toHaveBeenCalled();
+
+    await handler.shutdown();
+  });
+
   it("does not classify ordinary transport close text as deterministic", async () => {
     const fake = new FakeAppServerClient();
     const token = makeDeliveryToken();
@@ -800,6 +883,100 @@ describe("codex app-server handler", () => {
     expect(token.retry).toHaveBeenCalledWith([message], "codex_unknown_failure");
     expect(token.terminalRejected).not.toHaveBeenCalled();
     expect(token.complete).not.toHaveBeenCalled();
+
+    await handler.shutdown();
+  });
+
+  it("consumes pre-turn 401 credential failures instead of retrying turn/start", async () => {
+    const fake = new FakeAppServerClient();
+    fake.turnStartError = new Error(
+      "unexpected status 401 Unauthorized: Missing bearer or basic authentication in header",
+    );
+    const retryTurn = vi.fn<SessionContext["retryTurn"]>();
+    const failSessionForRecovery = vi.fn<(reason: string, sessionId?: string) => void>();
+    const token = makeDeliveryToken();
+    const handler = makeHandler(fake);
+    const ctx = makeContext({ retryTurn, failSessionForRecovery });
+    const message = makeMessage("m1", "first");
+
+    await handler.start(message, ctx, token);
+
+    expect(token.complete).toHaveBeenCalledWith([message], {
+      status: "error",
+      terminal: true,
+      completion: "consumed",
+      reason: "provider_credential_required",
+    });
+    expect(token.retry).not.toHaveBeenCalled();
+    expect(token.terminalRejected).not.toHaveBeenCalled();
+    expect(retryTurn).not.toHaveBeenCalled();
+    expect(failSessionForRecovery).toHaveBeenCalledWith("provider_credential_required", "thread-app-server");
+    expect(fake.isClosed).toBe(true);
+
+    await handler.shutdown();
+  });
+
+  it("consumes pre-turn compact context-window failures instead of retrying turn/start", async () => {
+    const fake = new FakeAppServerClient();
+    fake.turnStartError = new Error(
+      "Error running remote compact task: Codex ran out of room in the model's context window. Start a new thread.",
+    );
+    const retryTurn = vi.fn<SessionContext["retryTurn"]>();
+    const failSessionForRecovery = vi.fn<(reason: string, sessionId?: string) => void>();
+    const token = makeDeliveryToken();
+    const handler = makeHandler(fake);
+    const ctx = makeContext({ retryTurn, failSessionForRecovery });
+    const message = makeMessage("m1", "first");
+
+    await handler.start(message, ctx, token);
+
+    expect(token.complete).toHaveBeenCalledWith([message], {
+      status: "error",
+      terminal: true,
+      completion: "consumed",
+      reason: "codex_context_window_exceeded",
+    });
+    expect(token.retry).not.toHaveBeenCalled();
+    expect(token.terminalRejected).not.toHaveBeenCalled();
+    expect(retryTurn).not.toHaveBeenCalled();
+    expect(failSessionForRecovery).toHaveBeenCalledWith("codex_context_window_exceeded", "thread-app-server");
+    expect(fake.isClosed).toBe(true);
+
+    await handler.shutdown();
+  });
+
+  it("uses pre-currentTurn turnId error notifications when later turn/start rejects", async () => {
+    const fake = new FakeAppServerClient();
+    fake.turnStartError = new CodexAppServerTransportError("codex app-server request timed out: turn/start");
+    fake.beforeTurnStartError = () => {
+      fake.emit("error", {
+        threadId: "thread-app-server",
+        turnId: "turn-before-rpc",
+        error: {
+          message: "unexpected status 401 Unauthorized: Missing bearer or basic authentication in header",
+          codexErrorInfo: null,
+          additionalDetails: null,
+        },
+      });
+    };
+    const retryTurn = vi.fn<SessionContext["retryTurn"]>();
+    const failSessionForRecovery = vi.fn<(reason: string, sessionId?: string) => void>();
+    const token = makeDeliveryToken();
+    const handler = makeHandler(fake);
+    const ctx = makeContext({ retryTurn, failSessionForRecovery });
+    const message = makeMessage("m1", "first");
+
+    await handler.start(message, ctx, token);
+
+    expect(token.complete).toHaveBeenCalledWith([message], {
+      status: "error",
+      terminal: true,
+      completion: "consumed",
+      reason: "provider_credential_required",
+    });
+    expect(token.retry).not.toHaveBeenCalled();
+    expect(retryTurn).not.toHaveBeenCalled();
+    expect(failSessionForRecovery).toHaveBeenCalledWith("provider_credential_required", "thread-app-server");
 
     await handler.shutdown();
   });

--- a/packages/client/src/__tests__/codex-inject-startup-race.test.ts
+++ b/packages/client/src/__tests__/codex-inject-startup-race.test.ts
@@ -507,7 +507,7 @@ describe("codex handler startup inject queue", () => {
     await handler.shutdown();
   });
 
-  it("treats a stream error followed by final and turn.completed as success with diagnostics", async () => {
+  it("treats a reconnect diagnostic followed by final and turn.completed as success", async () => {
     const sendMessage = vi
       .fn<(chatId: string, body: Record<string, unknown>) => Promise<unknown>>()
       .mockResolvedValue(undefined);
@@ -543,9 +543,43 @@ describe("codex handler startup inject queue", () => {
           event.payload.source === "sdk" &&
           event.payload.message.includes("Reconnecting... 2/5"),
       ),
-    ).toBe(true);
+    ).toBe(false);
     expect(events.some((event) => event.kind === "turn_end" && event.payload.status === "success")).toBe(true);
     expect(completedCounts).toEqual([1]);
+
+    await handler.shutdown();
+  });
+
+  it("does not classify normal final text that mentions provider error keywords", async () => {
+    const emitEvent = vi.fn<(event: SessionEvent) => void>();
+    const completedCounts: Array<number | undefined> = [];
+    const retryTurn = vi.fn<SessionContext["retryTurn"]>();
+    const handler = createCodexHandler({ workspaceRoot });
+    const ctx = makeContext((count) => completedCounts.push(count), { emitEvent, retryTurn });
+
+    state.agentMessagesByTurn.set(1, [
+      "The log says 401 Unauthorized and context window, but this is just the answer text.",
+    ]);
+    state.resolveChatContext?.({
+      chatId: "chat-startup-race",
+      title: "startup race",
+      topic: null,
+      description: null,
+      participants: [],
+    });
+
+    await handler.start(makeMessage("m1", "first"), ctx);
+
+    const events = emitEvent.mock.calls.map(([event]) => event);
+    expect(
+      events.some((event) => {
+        if (event.kind !== "error") return false;
+        return parseProviderRetryEventMessage(event.payload.message) !== null;
+      }),
+    ).toBe(false);
+    expect(events.some((event) => event.kind === "turn_end" && event.payload.status === "success")).toBe(true);
+    expect(completedCounts).toEqual([1]);
+    expect(retryTurn).not.toHaveBeenCalled();
 
     await handler.shutdown();
   });
@@ -589,6 +623,51 @@ describe("codex handler startup inject queue", () => {
         return (
           retryPayload?.event === "provider_failure_terminal" &&
           retryPayload.reasonCode === "unsafe_replay" &&
+          retryPayload.scope === "provider_turn"
+        );
+      }),
+    ).toBe(true);
+    expect(events.some((event) => event.kind === "turn_end" && event.payload.status === "error")).toBe(true);
+    expect(completedCounts).toEqual([1]);
+    expect(retryTurn).not.toHaveBeenCalled();
+
+    await handler.shutdown();
+  });
+
+  it("does not retry 401 stream errors", async () => {
+    const sendMessage = vi
+      .fn<(chatId: string, body: Record<string, unknown>) => Promise<unknown>>()
+      .mockResolvedValue(undefined);
+    const emitEvent = vi.fn<(event: SessionEvent) => void>();
+    const completedCounts: Array<number | undefined> = [];
+    const retryTurn = vi.fn<SessionContext["retryTurn"]>();
+    const handler = createCodexHandler({ workspaceRoot });
+    const ctx = makeContext((count) => completedCounts.push(count), { sendMessage, emitEvent, retryTurn });
+
+    state.agentMessagesByTurn.set(1, []);
+    state.streamErrorByTurn.set(
+      1,
+      "unexpected status 401 Unauthorized: Missing bearer or basic authentication in header",
+    );
+    state.resolveChatContext?.({
+      chatId: "chat-startup-race",
+      title: "startup race",
+      topic: null,
+      description: null,
+      participants: [],
+    });
+
+    await handler.start(makeMessage("m1", "first"), ctx);
+
+    const events = emitEvent.mock.calls.map(([event]) => event);
+    expect(state.runInputs).toHaveLength(1);
+    expect(
+      events.some((event) => {
+        if (event.kind !== "error") return false;
+        const retryPayload = parseProviderRetryEventMessage(event.payload.message);
+        return (
+          retryPayload?.event === "provider_failure_terminal" &&
+          retryPayload.reasonCode === "provider_credential_required" &&
           retryPayload.scope === "provider_turn"
         );
       }),

--- a/packages/client/src/__tests__/codex-resilience.test.ts
+++ b/packages/client/src/__tests__/codex-resilience.test.ts
@@ -61,6 +61,7 @@ describe("isTransientCodexErrorMessage", () => {
       "authentication failed",
       "context length exceeded",
       "context_length_exceeded",
+      "Error running remote compact task: Codex ran out of room in the model's context window.",
       "sandbox denied write to /etc/passwd",
       "approval policy rejected the action",
     ];

--- a/packages/client/src/__tests__/provider-attempt.test.ts
+++ b/packages/client/src/__tests__/provider-attempt.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { ProviderAttempt } from "../runtime/provider-attempt.js";
+
+function attempt() {
+  return new ProviderAttempt({ provider: "codex", scope: "provider_turn", source: "sdk" });
+}
+
+describe("ProviderAttempt", () => {
+  it("does not settle diagnostics alone as a retry", () => {
+    const a = attempt();
+
+    a.recordSignal({ kind: "diagnostic", error: new Error("Reconnecting... 2/5 (request timed out)") });
+
+    expect(a.settle({ attempt: 1 })).toBeNull();
+  });
+
+  it("records credential diagnostics as terminal failures", () => {
+    const a = attempt();
+
+    a.recordSignal({
+      kind: "diagnostic",
+      error: Object.assign(new Error("unexpected status 401 Unauthorized: Missing bearer or basic authentication"), {
+        status: 401,
+      }),
+    });
+
+    const settled = a.settle({ attempt: 1 });
+    expect(settled?.decision).toMatchObject({
+      action: "stop",
+      terminalKind: "needs_operator",
+      reasonCode: "provider_credential_required",
+    });
+    expect(settled?.eventName).toBe("provider_failure_terminal");
+  });
+
+  it("does not let later transient text downgrade a prior hard failure", () => {
+    const a = attempt();
+
+    a.recordSignal({
+      kind: "provider_error",
+      error: Object.assign(new Error("401 Unauthorized"), { status: 401 }),
+    });
+    a.recordSignal({ kind: "transport_close", error: new Error("request timed out after reconnecting") });
+
+    const settled = a.settle({ attempt: 1 });
+    expect(settled?.classification.category).toBe("credential");
+    expect(settled?.decision.action).toBe("stop");
+  });
+
+  it("classifies compact context-window text as deterministic terminal input", () => {
+    const a = attempt();
+
+    a.recordSignal({
+      kind: "provider_error",
+      error: new Error(
+        "Error running remote compact task: Codex ran out of room in the model's context window. Start a new thread.",
+      ),
+    });
+
+    const settled = a.settle({ attempt: 1 });
+    expect(settled?.classification.category).toBe("deterministic_input");
+    expect(settled?.decision).toMatchObject({
+      action: "stop",
+      terminalKind: "deterministic",
+    });
+  });
+
+  it("keeps diagnostic details while fallback transport drives retry", () => {
+    const a = attempt();
+
+    a.recordSignal({ kind: "diagnostic", error: new Error("Reconnecting... 2/5 (request timed out)") });
+    const settled = a.settle({
+      attempt: 1,
+      fallback: { kind: "transport_close", error: new Error("stream ended without completion") },
+    });
+
+    expect(settled?.decision).toMatchObject({ action: "retry", reasonCode: "unknown" });
+    expect(settled?.messagePreview).toContain("diagnostic: Reconnecting... 2/5");
+  });
+
+  it("stops retry when user-visible output makes replay unsafe", () => {
+    const a = attempt();
+
+    a.markUserVisibleOutput();
+    const settled = a.settle({
+      attempt: 1,
+      fallback: { kind: "transport_close", error: new Error("fetch failed") },
+    });
+
+    expect(settled?.decision).toMatchObject({
+      action: "stop",
+      terminalKind: "unsafe_replay",
+      reasonCode: "unsafe_replay",
+    });
+  });
+});

--- a/packages/client/src/__tests__/session-manager.test.ts
+++ b/packages/client/src/__tests__/session-manager.test.ts
@@ -541,6 +541,47 @@ describe("SessionManager", () => {
     await sm.shutdown();
   });
 
+  it("routes the next message through resume after a terminal pre-turn failure evicts the handler", async () => {
+    const ackEntry = mockAckEntry();
+    let startCtx: SessionContext | undefined;
+    let startMessage: SessionMessage | undefined;
+    let startToken: DeliveryToken | undefined;
+    const handler = createMockHandler({
+      start: vi.fn(async (message, ctx, token) => {
+        startCtx = ctx;
+        startMessage = message;
+        startToken = token;
+        return { sessionId: "session-id-mock", route: { kind: "owned", mode: "processing" } as const };
+      }),
+      inject: vi.fn().mockReturnValue({ kind: "rejected", reason: "no_active_context", retryable: true } as const),
+      resume: vi.fn(async () => {
+        return { sessionId: "session-id-mock", route: { kind: "owned", mode: "processing" } as const };
+      }),
+    });
+    const sm = createSessionManager({ handler, ackEntry });
+
+    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-terminal", messageId: "msg-1" }));
+    if (!startCtx || !startMessage || !startToken) throw new Error("expected captured start state");
+
+    await startToken.complete(startMessage, {
+      status: "error",
+      terminal: true,
+      completion: "consumed",
+      reason: "provider_credential_required",
+    });
+    startCtx.failSessionForRecovery?.("provider_credential_required", "session-id-mock");
+
+    expect(sm.activeCount).toBe(0);
+    expect(handler.inject).not.toHaveBeenCalled();
+
+    await sm.dispatch(mockEntry({ id: 2, chatId: "chat-terminal", messageId: "msg-2" }));
+
+    expect(handler.inject).not.toHaveBeenCalled();
+    expect(handler.resume).toHaveBeenCalledTimes(1);
+
+    await sm.shutdown();
+  });
+
   it("creates separate sessions for different chats", async () => {
     const handlers: AgentHandler[] = [];
     const factory: HandlerFactory = () => {

--- a/packages/client/src/handlers/codex/app-server/index.ts
+++ b/packages/client/src/handlers/codex/app-server/index.ts
@@ -1,5 +1,10 @@
 import { isAbsolute, join, resolve } from "node:path";
-import type { AgentRuntimeConfigPayload, SessionEvent, ToolFileRef } from "@first-tree/shared";
+import {
+  type AgentRuntimeConfigPayload,
+  encodeProviderRetryEventMessage,
+  type SessionEvent,
+  type ToolFileRef,
+} from "@first-tree/shared";
 import { ensureAgentBootstrap as ensureAgentBootstrapShared } from "../../../runtime/agent-bootstrap.js";
 import { buildAgentBriefing } from "../../../runtime/agent-briefing.js";
 import type { AgentConfigCache } from "../../../runtime/agent-config-cache.js";
@@ -30,6 +35,7 @@ import type {
   TurnConsumedErrorReason,
 } from "../../../runtime/handler.js";
 import { deliveryTokenFromSessionContext } from "../../../runtime/handler.js";
+import { ProviderAttempt, type ProviderAttemptSettlement } from "../../../runtime/provider-attempt.js";
 import { materializeResourceSkills } from "../../../runtime/resource-skills.js";
 import {
   buildBriefingUpdateNotice,
@@ -41,8 +47,13 @@ import { currentSourceRepoNamesFromPayload, declaredSourceRepos } from "../../..
 import { acquireAgentHome, markWorkspaceInitComplete } from "../../../runtime/workspace.js";
 import { chunkAssistantText } from "../../assistant-text.js";
 import { formatAuthHint, isCodexAuthError } from "../../auth-error-hint.js";
-import { resolveTurnSettlement } from "../../turn-settlement.js";
-import { buildCodexThreadOptions, collectCodexFileChangePaths, isTransientCodexErrorMessage } from "../sdk.js";
+import { consumedErrorOutcome, resolveTurnSettlement } from "../../turn-settlement.js";
+import {
+  buildCodexThreadOptions,
+  collectCodexFileChangePaths,
+  isCodexStreamDiagnosticMessage,
+  isTransientCodexErrorMessage,
+} from "../sdk.js";
 import {
   CodexAppServerClient,
   type CodexAppServerClientOptions,
@@ -103,6 +114,8 @@ type CurrentTurn = {
   providerCompleted: boolean;
   stopRequested: boolean;
   sdkErrorEmitted: boolean;
+  providerAttempt: ProviderAttempt;
+  userVisibleOutput: boolean;
   resolveTerminal: () => void;
 };
 
@@ -147,6 +160,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
   let turnSettlementInProgress = false;
   let startupTurnPending = false;
   let turnStartInProgress = false;
+  let turnStartAttempt: ProviderAttempt | null = null;
   let pendingDrainInProgress = false;
   let pendingDrainScheduled = false;
   let shutdownRequested = false;
@@ -162,6 +176,85 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
     contextTreeBranch,
     log: (message) => ctx?.log(message),
   });
+
+  function createProviderAttempt(): ProviderAttempt {
+    return new ProviderAttempt({
+      provider: "codex",
+      scope: "provider_turn",
+      source: "sdk",
+    });
+  }
+
+  function emitProviderSettlementEvent(sessionCtx: SessionContext, settlement: ProviderAttemptSettlement): void {
+    sessionCtx.emitEvent({
+      kind: "error",
+      payload: {
+        source: "runtime",
+        message: encodeProviderRetryEventMessage(settlement.eventPayload),
+      },
+    });
+  }
+
+  function recordAppServerFailureSignal(
+    attempt: ProviderAttempt,
+    error: TurnErrorInfo,
+    turn?: Pick<CurrentTurn, "userVisibleOutput">,
+  ): ProviderAttemptSettlement | null {
+    const diagnostic = isCodexStreamDiagnosticMessage(error.message);
+    const classification = attempt.recordSignal({
+      kind: diagnostic ? "diagnostic" : "provider_error",
+      error: providerErrorFromTurnErrorInfo(error),
+      messagePreview: providerErrorPreview(error),
+    });
+    if (!classification && diagnostic) return null;
+    if (turn) {
+      if (turn.userVisibleOutput) {
+        attempt.markUserVisibleOutput();
+      } else if (classification?.category === "provider_capacity") {
+        attempt.setReplaySafety("provider_entered");
+      } else {
+        attempt.setReplaySafety("pre_visible");
+      }
+    }
+    return attempt.settle({ attempt: 1 });
+  }
+
+  type AcceptedTurnStopDisposition =
+    | { kind: "terminal_reject"; reason: TurnConsumedErrorReason }
+    | { kind: "consume"; reason: TurnConsumedErrorReason };
+
+  function stopReasonForSettlement(
+    error: TurnErrorInfo,
+    settlement: ProviderAttemptSettlement,
+  ): TurnConsumedErrorReason | null {
+    if (settlement.decision.action !== "stop") return null;
+    if (settlement.decision.terminalKind === "exhausted") return null;
+    if (settlement.classification.category === "deterministic_input") {
+      return deterministicTerminalRejectionReason(errorInfoForSettlement(error, settlement));
+    }
+    return settlement.decision.reasonCode;
+  }
+
+  function acceptedTurnStopDisposition(
+    error: TurnErrorInfo,
+    settlement: ProviderAttemptSettlement,
+  ): AcceptedTurnStopDisposition | null {
+    const reason = stopReasonForSettlement(error, settlement);
+    if (!reason) return null;
+    if (settlement.classification.category === "deterministic_input") {
+      return { kind: "terminal_reject", reason };
+    }
+    return { kind: "consume", reason };
+  }
+
+  function terminalTurnStartSettlement(
+    error: TurnErrorInfo,
+    attempt: ProviderAttempt,
+  ): ProviderAttemptSettlement | null {
+    const settlement = attempt.settle({ attempt: 1 });
+    if (!settlement) return null;
+    return stopReasonForSettlement(error, settlement) ? settlement : null;
+  }
 
   function buildEnv(sessionCtx: SessionContext): NodeJS.ProcessEnv {
     const env: NodeJS.ProcessEnv = {};
@@ -382,6 +475,8 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
       case "agentMessage": {
         const text = typeof item.text === "string" ? item.text : "";
         if (!text.trim()) return;
+        turn.userVisibleOutput = true;
+        turn.providerAttempt.markUserVisibleOutput();
         // Chunk so the FULL assistant text is preserved across one or more
         // events — the durable troubleshooting record now that the per-turn
         // final-text chat mirror is retired.
@@ -392,6 +487,8 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
         return;
       }
       case "commandExecution": {
+        turn.userVisibleOutput = true;
+        turn.providerAttempt.markUserVisibleOutput();
         const status = toolStatus(item.status);
         const command = typeof item.command === "string" ? item.command : "";
         const commandCwd = typeof item.cwd === "string" ? item.cwd : (cwd ?? undefined);
@@ -423,6 +520,8 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
         return;
       }
       case "fileChange": {
+        turn.userVisibleOutput = true;
+        turn.providerAttempt.markUserVisibleOutput();
         const status = toolStatus(item.status);
         const changes = item.changes;
         const fileChangeRefs =
@@ -452,6 +551,8 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
         return;
       }
       case "mcpToolCall": {
+        turn.userVisibleOutput = true;
+        turn.providerAttempt.markUserVisibleOutput();
         const status = toolStatus(item.status);
         const error = asRecord(item.error);
         const result = asRecord(item.result);
@@ -472,6 +573,8 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
         return;
       }
       case "webSearch": {
+        turn.userVisibleOutput = true;
+        turn.providerAttempt.markUserVisibleOutput();
         emitToolCall(sessionCtx, {
           toolUseId: id,
           name: "web_search",
@@ -481,6 +584,8 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
         return;
       }
       case "plan": {
+        turn.userVisibleOutput = true;
+        turn.providerAttempt.markUserVisibleOutput();
         emitToolCall(sessionCtx, {
           toolUseId: id,
           name: "todo_list",
@@ -514,6 +619,15 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
     if (threadId && notificationThreadId && notificationThreadId !== threadId) return;
 
     const turn = currentTurn;
+    if (
+      turnStartAttempt &&
+      notification.method === "error" &&
+      notificationTurnId &&
+      (!turn || turn.turnId !== notificationTurnId)
+    ) {
+      const error = params ? parseTurnError(params.error) : null;
+      if (error) recordAppServerFailureSignal(turnStartAttempt, error);
+    }
     if (notificationTurnId && (!turn || turn.turnId !== notificationTurnId)) {
       bufferNotification(notificationTurnId, notification);
       return;
@@ -543,14 +657,20 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
       case "error": {
         const error = parseTurnError(params.error);
         if (error) {
+          const diagnostic = isCodexStreamDiagnosticMessage(error.message);
           if (turn) {
             turn.lastSdkError = error;
-            turn.sdkErrorEmitted = true;
+            turn.sdkErrorEmitted = !diagnostic;
+            recordAppServerFailureSignal(turn.providerAttempt, error, turn);
+          } else if (turnStartAttempt) {
+            recordAppServerFailureSignal(turnStartAttempt, error);
           }
-          sessionCtx.emitEvent({
-            kind: "error",
-            payload: { source: "sdk", message: formatAppServerError(error.message) },
-          });
+          if (!diagnostic) {
+            sessionCtx.emitEvent({
+              kind: "error",
+              payload: { source: "sdk", message: formatAppServerError(error.message) },
+            });
+          }
         }
         return;
       }
@@ -648,6 +768,24 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
     await shutdown;
   }
 
+  async function closeAppServerAfterTerminalTurnStartFailure(
+    sessionCtx: SessionContext,
+    reason: string,
+  ): Promise<void> {
+    shutdownRequested = true;
+    turnStartInProgress = false;
+    retryQueuedMessages(reason);
+    const client = appServer;
+    const resumeThreadId = threadId ?? undefined;
+    appServer = null;
+    threadId = null;
+    pendingNotificationsByTurn.clear();
+    sessionCtx.log(`codex app-server session closed after terminal turn/start failure (${reason})`);
+    const shutdown = client?.shutdown();
+    sessionCtx.failSessionForRecovery?.(reason, resumeThreadId);
+    await shutdown;
+  }
+
   async function closeAppServerAfterUncommittablePrefix(sessionCtx: SessionContext, reason: string): Promise<void> {
     shutdownRequested = true;
     turnStartInProgress = false;
@@ -695,6 +833,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
     gitWriteTracker.captureBaseline();
     let result: unknown;
     turnStartInProgress = true;
+    turnStartAttempt = createProviderAttempt();
     try {
       result = await client.request("turn/start", {
         threadId,
@@ -706,6 +845,31 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
       });
     } catch (err) {
       turnStartInProgress = false;
+      const attempt = turnStartAttempt ?? createProviderAttempt();
+      turnStartAttempt = null;
+      const syntheticFailure = {
+        message: err instanceof Error ? err.message : String(err),
+        codexErrorInfo: null,
+        additionalDetails: null,
+      };
+      const classification = attempt.recordSignal({
+        kind: "local_error",
+        error: err instanceof Error ? err : new Error(syntheticFailure.message),
+        messagePreview: syntheticFailure.message,
+      });
+      attempt.setReplaySafety(classification?.category === "provider_capacity" ? "provider_entered" : "pre_provider");
+      const terminalSettlement = terminalTurnStartSettlement(syntheticFailure, attempt);
+      if (terminalSettlement) {
+        const terminalReason = stopReasonForSettlement(syntheticFailure, terminalSettlement);
+        if (terminalReason) {
+          emitProviderSettlementEvent(sessionCtx, terminalSettlement);
+          token.processingStarted(messages);
+          sessionCtx.emitEvent({ kind: "turn_end", payload: { status: "error" } });
+          await token.complete(messages, consumedErrorOutcome(terminalReason));
+          await closeAppServerAfterTerminalTurnStartFailure(sessionCtx, terminalReason);
+          return false;
+        }
+      }
       const reason = isCodexAppServerTransientError(err)
         ? "codex_app_server_turn_start_unknown_custody_transient"
         : "codex_app_server_turn_start_unknown_custody_failed";
@@ -718,6 +882,25 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
     const turnId = turnRecord ? readString(turnRecord, "id") : null;
     if (!turnId) {
       turnStartInProgress = false;
+      const attempt = turnStartAttempt ?? createProviderAttempt();
+      turnStartAttempt = null;
+      const syntheticFailure = {
+        message: "missing turn id in turn/start response",
+        codexErrorInfo: null,
+        additionalDetails: null,
+      };
+      const terminalSettlement = terminalTurnStartSettlement(syntheticFailure, attempt);
+      if (terminalSettlement) {
+        const terminalReason = stopReasonForSettlement(syntheticFailure, terminalSettlement);
+        if (terminalReason) {
+          emitProviderSettlementEvent(sessionCtx, terminalSettlement);
+          token.processingStarted(messages);
+          sessionCtx.emitEvent({ kind: "turn_end", payload: { status: "error" } });
+          await token.complete(messages, consumedErrorOutcome(terminalReason));
+          await closeAppServerAfterTerminalTurnStartFailure(sessionCtx, terminalReason);
+          return false;
+        }
+      }
       const reason = "codex_app_server_turn_start_missing_id_unknown_custody";
       token.retry(messages, reason);
       await closeAppServerAfterUnknownCustody(sessionCtx, reason, "missing turn id in turn/start response");
@@ -725,6 +908,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
     }
 
     const turn = await createCurrentTurn(turnId, messages, token, sessionCtx);
+    turnStartAttempt = null;
     turnStartInProgress = false;
     schedulePendingDrain();
     if (turnRecord && readString(turnRecord, "status") !== "inProgress") {
@@ -762,6 +946,8 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
     const terminalPromise = new Promise<void>((resolve) => {
       resolveTerminal = resolve;
     });
+    const providerAttempt = turnStartAttempt ?? createProviderAttempt();
+    providerAttempt.setReplaySafety("pre_visible");
     const turn: CurrentTurn = {
       turnId,
       status: "inProgress",
@@ -777,6 +963,8 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
       providerCompleted: false,
       stopRequested: false,
       sdkErrorEmitted: false,
+      providerAttempt,
+      userVisibleOutput: false,
       resolveTerminal,
     };
     currentTurn = turn;
@@ -889,24 +1077,67 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
       }
     } else if (turn.failure) {
       const failure = mergeFailureWithDiagnostic(turn.failure, turn.lastSdkError);
-      const kind = classifyAppServerFailure(failure);
-      if (kind === "deterministic") {
-        terminalRejectionReason = deterministicTerminalRejectionReason(failure);
+      const providerSettlement = recordAppServerFailureSignal(turn.providerAttempt, failure, turn);
+      const providerStopDisposition = providerSettlement
+        ? acceptedTurnStopDisposition(failure, providerSettlement)
+        : null;
+      if (providerSettlement && providerStopDisposition) {
+        emitProviderSettlementEvent(sessionCtx, providerSettlement);
         if (!turn.sdkErrorEmitted) {
           sessionCtx.emitEvent({
             kind: "error",
-            payload: { source: "sdk", message: formatDeterministicFailureMessage(failure) },
+            payload: { source: "sdk", message: formatProviderTerminalFailureMessage(failure, providerSettlement) },
           });
         }
-        sessionCtx.log(
-          `codex app-server turn failed deterministically; terminal rejecting delivery (${terminalRejectionReason}): ${turn.failure.message}`,
-        );
+        if (providerStopDisposition.kind === "terminal_reject") {
+          terminalRejectionReason = providerStopDisposition.reason;
+          sessionCtx.log(
+            `codex app-server turn failed terminally; terminal rejecting delivery (${terminalRejectionReason}): ${turn.failure.message}`,
+          );
+        } else {
+          consumedErrorReason = providerStopDisposition.reason;
+          sessionCtx.log(
+            `codex app-server turn failed terminally; consuming provider stop (${consumedErrorReason}): ${turn.failure.message}`,
+          );
+        }
       } else {
+        const kind = classifyAppServerFailure(failure);
         retryReason = `codex_${kind}_failure`;
         sessionCtx.log(`codex app-server turn failed (${kind}): ${turn.failure.message}`);
       }
     } else if (!turn.providerCompleted) {
-      retryReason = "codex_app_server_stream_ended_without_completion";
+      const streamEndError: TurnErrorInfo = {
+        message: "codex_app_server_stream_ended_without_completion",
+        codexErrorInfo: null,
+        additionalDetails: null,
+      };
+      const streamEndSettlement = recordAppServerFailureSignal(turn.providerAttempt, streamEndError, turn);
+      const providerStopDisposition = streamEndSettlement
+        ? acceptedTurnStopDisposition(streamEndError, streamEndSettlement)
+        : null;
+      if (streamEndSettlement && providerStopDisposition) {
+        emitProviderSettlementEvent(sessionCtx, streamEndSettlement);
+        sessionCtx.emitEvent({
+          kind: "error",
+          payload: {
+            source: "sdk",
+            message: formatProviderTerminalFailureMessage(streamEndError, streamEndSettlement),
+          },
+        });
+        if (providerStopDisposition.kind === "terminal_reject") {
+          terminalRejectionReason = providerStopDisposition.reason;
+          sessionCtx.log(
+            `codex app-server stream ended without completion; terminal rejecting delivery (${terminalRejectionReason})`,
+          );
+        } else {
+          consumedErrorReason = providerStopDisposition.reason;
+          sessionCtx.log(
+            `codex app-server stream ended without completion; consuming provider stop (${consumedErrorReason})`,
+          );
+        }
+      } else {
+        retryReason = "codex_app_server_stream_ended_without_completion";
+      }
     }
 
     if (usage) {
@@ -1394,6 +1625,22 @@ function formatAppServerError(message: string): string {
   return message;
 }
 
+function formatProviderTerminalFailureMessage(error: TurnErrorInfo, settlement: ProviderAttemptSettlement): string {
+  if (settlement.classification.category === "deterministic_input") {
+    return formatDeterministicFailureMessage(errorInfoForSettlement(error, settlement));
+  }
+  return formatAppServerError(providerErrorPreview(error));
+}
+
+function errorInfoForSettlement(error: TurnErrorInfo, settlement: ProviderAttemptSettlement): TurnErrorInfo {
+  if (settlement.classification.category !== "deterministic_input" || isContextWindowFailure(error)) return error;
+  return {
+    message: settlement.messagePreview,
+    codexErrorInfo: error.codexErrorInfo,
+    additionalDetails: error.additionalDetails,
+  };
+}
+
 function classifyAppServerFailure(error: TurnErrorInfo): "deterministic" | "transient" | "unknown" {
   if (
     isCodexAuthError(error.message) ||
@@ -1420,6 +1667,24 @@ function formatDeterministicFailureMessage(error: TurnErrorInfo): string {
   if (isContextWindowFailure(error)) return CODEX_CONTEXT_WINDOW_FAILURE_MESSAGE;
   if (isPreSamplingCompactFailure(error)) return CODEX_COMPACT_FAILURE_MESSAGE;
   return formatAppServerError(error.message);
+}
+
+type ProviderClassifiableError = Error & {
+  reason?: string;
+  code?: string;
+};
+
+function providerErrorFromTurnErrorInfo(error: TurnErrorInfo): Error {
+  const out = new Error(providerErrorPreview(error)) as ProviderClassifiableError;
+  if (typeof error.codexErrorInfo === "string") {
+    out.reason = error.codexErrorInfo;
+    out.code = error.codexErrorInfo;
+  }
+  return out;
+}
+
+function providerErrorPreview(error: TurnErrorInfo): string {
+  return [error.message, error.additionalDetails].filter((part): part is string => Boolean(part)).join("\n");
 }
 
 function isContextWindowFailure(error: TurnErrorInfo): boolean {

--- a/packages/client/src/handlers/codex/sdk.ts
+++ b/packages/client/src/handlers/codex/sdk.ts
@@ -51,14 +51,8 @@ import type {
   TurnConsumedErrorReason,
 } from "../../runtime/handler.js";
 import { deliveryTokenFromSessionContext } from "../../runtime/handler.js";
-import {
-  buildProviderRetryEvent,
-  classifyProviderFailure,
-  decideProviderRetry,
-  maxProviderTurnRetryAttempts,
-  type ProviderFailureClassification,
-  type ProviderRetryDecision,
-} from "../../runtime/provider-retry-policy.js";
+import { ProviderAttempt, type ProviderAttemptSettlement } from "../../runtime/provider-attempt.js";
+import { classifyProviderFailure, maxProviderTurnRetryAttempts } from "../../runtime/provider-retry-policy.js";
 import { materializeResourceSkills } from "../../runtime/resource-skills.js";
 import {
   buildBriefingUpdateNotice,
@@ -118,7 +112,7 @@ export function isTransientCodexErrorMessage(message: string): boolean {
   return classification.category === "transient_transport" || classification.category === "provider_capacity";
 }
 
-function isCodexStreamDiagnosticMessage(message: string): boolean {
+export function isCodexStreamDiagnosticMessage(message: string): boolean {
   return /\breconnecting\b.*\b\d+\s*\/\s*\d+\b/i.test(message);
 }
 
@@ -450,27 +444,12 @@ export const createCodexSdkHandler: HandlerFactory = (config) => {
    */
   let sourceReposForPrompt: PredeclaredSourceRepo[] = [];
 
-  function emitProviderTurnRetryEvent(
-    sessionCtx: SessionContext,
-    event: "provider_retry_scheduled" | "provider_retry_exhausted" | "provider_failure_terminal",
-    classification: ProviderFailureClassification,
-    decision: ProviderRetryDecision,
-    messagePreview: string,
-  ): void {
+  function emitProviderTurnSettlementEvent(sessionCtx: SessionContext, settlement: ProviderAttemptSettlement): void {
     sessionCtx.emitEvent({
       kind: "error",
       payload: {
         source: "runtime",
-        message: encodeProviderRetryEventMessage(
-          buildProviderRetryEvent({
-            event,
-            provider: runtimeProvider,
-            scope: "provider_turn",
-            classification,
-            decision,
-            messagePreview,
-          }),
-        ),
+        message: encodeProviderRetryEventMessage(settlement.eventPayload),
       },
     });
   }
@@ -803,48 +782,28 @@ export const createCodexSdkHandler: HandlerFactory = (config) => {
     const usageBox: { value: Usage | null } = { value: null };
     const turnStartedAt = Date.now();
     const retryAfterHelperStopBox: { value: string | null } = { value: null };
-    const decideCodexFailure = (
-      message: string,
-      attemptIndex: number,
+    let lastProviderAttempt: ProviderAttempt | null = null;
+    let lastProviderAttemptNumber = 1;
+
+    const updateAttemptReplaySafety = (
+      attemptState: ProviderAttempt,
       providerEntered: boolean,
-    ): {
-      classification: ProviderFailureClassification;
-      decision: ProviderRetryDecision;
-    } => {
-      const classification = classifyProviderFailure(new Error(message), {
-        provider: runtimeProvider,
-        scope: "provider_turn",
-        source: "sdk",
-      });
-      const replaySafety = userVisibleEmitted
-        ? "user_visible"
-        : !providerEntered
-          ? "pre_provider"
-          : classification.category === "provider_capacity"
-            ? "provider_entered"
-            : "pre_visible";
-      return {
-        classification,
-        decision: decideProviderRetry({
-          classification,
-          scope: "provider_turn",
-          attempt: attemptIndex + 1,
-          replaySafety,
-        }),
-      };
-    };
-    const stopCodexFailure = (
-      message: string,
-      classification: ProviderFailureClassification,
-      decision: Extract<ProviderRetryDecision, { action: "stop" }>,
+      providerCapacity: boolean,
     ): void => {
-      emitProviderTurnRetryEvent(
-        sessionCtx,
-        decision.terminalKind === "exhausted" ? "provider_retry_exhausted" : "provider_failure_terminal",
-        classification,
-        decision,
-        message,
-      );
+      if (userVisibleEmitted) {
+        attemptState.markUserVisibleOutput();
+      } else if (!providerEntered) {
+        attemptState.setReplaySafety("pre_provider");
+      } else if (providerCapacity) {
+        attemptState.setReplaySafety("provider_entered");
+      } else {
+        attemptState.setReplaySafety("pre_visible");
+      }
+    };
+    const stopCodexFailure = (settlement: ProviderAttemptSettlement): void => {
+      emitProviderTurnSettlementEvent(sessionCtx, settlement);
+      const decision = settlement.decision;
+      if (decision.action !== "stop") return;
       if (decision.replaySafety === "pre_provider" && decision.terminalKind === "exhausted") {
         retryAfterHelperStopBox.value = decision.reasonCode;
       } else {
@@ -855,7 +814,7 @@ export const createCodexSdkHandler: HandlerFactory = (config) => {
               ? "provider_retry_exhausted"
               : decision.reasonCode;
       }
-      const formatted = formatCodexSdkError(message);
+      const formatted = formatCodexSdkError(settlement.messagePreview);
       sessionCtx.emitEvent({ kind: "error", payload: { source: "sdk", message: formatted } });
     };
     const promise = (async () => {
@@ -869,6 +828,24 @@ export const createCodexSdkHandler: HandlerFactory = (config) => {
         let retryRequested = false;
         let retryDelay = 0;
         let retryReason = "";
+        const providerAttempt = new ProviderAttempt({
+          provider: runtimeProvider,
+          scope: "provider_turn",
+          source: "sdk",
+        });
+        lastProviderAttempt = providerAttempt;
+        lastProviderAttemptNumber = attempt + 1;
+
+        const applySettlement = (settlement: ProviderAttemptSettlement, reasonPrefix: string): void => {
+          if (settlement.decision.action === "retry") {
+            retryRequested = true;
+            retryDelay = settlement.decision.delayMs;
+            retryReason = `${reasonPrefix} (${settlement.classification.category}): ${settlement.messagePreview}`;
+            emitProviderTurnSettlementEvent(sessionCtx, settlement);
+            return;
+          }
+          stopCodexFailure(settlement);
+        };
 
         // Per-attempt child AbortController (PR #600 review nit #4): keep
         // parent suspend/shutdown cancellation scoped to the active
@@ -893,7 +870,10 @@ export const createCodexSdkHandler: HandlerFactory = (config) => {
               } else if (event.type === "item.completed") {
                 const text = processItem(event.item, sessionCtx);
                 if (text) finalResponse = text;
-                if (isUserVisibleItem(event.item)) userVisibleEmitted = true;
+                if (isUserVisibleItem(event.item)) {
+                  userVisibleEmitted = true;
+                  providerAttempt.markUserVisibleOutput();
+                }
               } else if (event.type === "item.started" || event.type === "item.updated") {
                 // Stream-only intermediate states — claude-code likewise emits
                 // events on terminal items only; codex's run-to-completion model
@@ -904,21 +884,14 @@ export const createCodexSdkHandler: HandlerFactory = (config) => {
                 usageBox.value = event.usage;
                 providerCompletedBox.value = true;
               } else if (event.type === "turn.failed") {
-                const { classification, decision } = decideCodexFailure(event.error.message, attempt, true);
-                if (decision.action === "retry") {
-                  retryRequested = true;
-                  retryDelay = decision.delayMs;
-                  retryReason = `turn.failed (${classification.category}): ${event.error.message}`;
-                  emitProviderTurnRetryEvent(
-                    sessionCtx,
-                    "provider_retry_scheduled",
-                    classification,
-                    decision,
-                    event.error.message,
-                  );
-                  break;
-                }
-                stopCodexFailure(event.error.message, classification, decision);
+                const classification = providerAttempt.recordSignal({
+                  kind: "provider_error",
+                  error: new Error(event.error.message),
+                });
+                updateAttemptReplaySafety(providerAttempt, true, classification?.category === "provider_capacity");
+                const settlement = providerAttempt.settle({ attempt: attempt + 1 });
+                if (settlement) applySettlement(settlement, "turn.failed");
+                break;
               } else if (event.type === "error") {
                 // Codex SDK bare `error` stream events are diagnostic: they
                 // can be followed by more items and a successful
@@ -927,41 +900,38 @@ export const createCodexSdkHandler: HandlerFactory = (config) => {
                 // stream failures still go through the shared retry policy.
                 if (isCodexStreamDiagnosticMessage(event.message)) {
                   diagnosticErrorEmittedBox.value = true;
-                  sessionCtx.emitEvent({
-                    kind: "error",
-                    payload: { source: "sdk", message: event.message },
+                  const classification = providerAttempt.recordSignal({
+                    kind: "diagnostic",
+                    error: new Error(event.message),
                   });
+                  if (classification) {
+                    updateAttemptReplaySafety(providerAttempt, true, classification.category === "provider_capacity");
+                    const settlement = providerAttempt.settle({ attempt: attempt + 1 });
+                    if (settlement) applySettlement(settlement, "stream diagnostic");
+                    break;
+                  }
                   continue;
                 }
-                const { classification, decision } = decideCodexFailure(event.message, attempt, true);
-                if (decision.action === "retry") {
-                  retryRequested = true;
-                  retryDelay = decision.delayMs;
-                  retryReason = `stream error (${classification.category}): ${event.message}`;
-                  emitProviderTurnRetryEvent(
-                    sessionCtx,
-                    "provider_retry_scheduled",
-                    classification,
-                    decision,
-                    event.message,
-                  );
-                  break;
-                }
-                stopCodexFailure(event.message, classification, decision);
+                const classification = providerAttempt.recordSignal({
+                  kind: "provider_error",
+                  error: new Error(event.message),
+                });
+                updateAttemptReplaySafety(providerAttempt, true, classification?.category === "provider_capacity");
+                const settlement = providerAttempt.settle({ attempt: attempt + 1 });
+                if (settlement) applySettlement(settlement, "stream error");
+                break;
               }
             }
           } catch (err) {
             if (abort.signal.aborted) return;
             const msg = err instanceof Error ? err.message : String(err);
-            const { classification, decision } = decideCodexFailure(msg, attempt, false);
-            if (decision.action === "retry") {
-              retryRequested = true;
-              retryDelay = decision.delayMs;
-              retryReason = `runStreamed threw (${classification.category}): ${msg}`;
-              emitProviderTurnRetryEvent(sessionCtx, "provider_retry_scheduled", classification, decision, msg);
-            } else {
-              stopCodexFailure(msg, classification, decision);
-            }
+            const classification = providerAttempt.recordSignal({
+              kind: "local_error",
+              error: err instanceof Error ? err : new Error(msg),
+            });
+            updateAttemptReplaySafety(providerAttempt, false, classification?.category === "provider_capacity");
+            const settlement = providerAttempt.settle({ attempt: attempt + 1 });
+            if (settlement) applySettlement(settlement, "runStreamed threw");
           }
         } finally {
           // Detach the parent listener whether we retry or break. Even
@@ -1127,27 +1097,55 @@ export const createCodexSdkHandler: HandlerFactory = (config) => {
       const streamEndReason = diagnosticErrorEmittedBox.value
         ? "codex_stream_ended_after_diagnostic_error"
         : "codex_stream_ended_without_completion";
-      if (userVisibleEmitted) {
-        const message = `${streamEndReason}: stream ended without turn.completed after user-visible output`;
-        const classification = classifyProviderFailure(new Error(message), {
+      const message = userVisibleEmitted
+        ? `${streamEndReason}: stream ended without turn.completed after user-visible output`
+        : `${streamEndReason}: stream ended without turn.completed`;
+      const attemptState =
+        lastProviderAttempt ??
+        new ProviderAttempt({
           provider: runtimeProvider,
           scope: "provider_turn",
           source: "sdk",
         });
-        const decision = decideProviderRetry({
-          classification,
-          scope: "provider_turn",
-          attempt: 1,
-          replaySafety: "user_visible",
-        });
-        if (decision.action === "stop") {
-          emitProviderTurnRetryEvent(sessionCtx, "provider_failure_terminal", classification, decision, message);
-          consumedErrorReason = decision.reasonCode;
-          sessionCtx.log(`codex stream ended without turn.completed; stopping unsafe replay (${decision.reasonCode})`);
-        } else {
-          retryReason = streamEndReason;
+      if (userVisibleEmitted) {
+        attemptState.markUserVisibleOutput();
+      } else {
+        attemptState.setReplaySafety("pre_provider");
+      }
+      const streamEndSettlement = attemptState.settle({
+        attempt: lastProviderAttemptNumber,
+        fallback: {
+          kind: "transport_close",
+          error: new Error(message),
+        },
+      });
+      if (streamEndSettlement?.decision.action === "stop") {
+        emitProviderTurnSettlementEvent(sessionCtx, streamEndSettlement);
+        if (
+          streamEndSettlement.decision.replaySafety === "pre_provider" &&
+          streamEndSettlement.decision.terminalKind === "exhausted"
+        ) {
+          retryReason = streamEndSettlement.decision.reasonCode;
           sessionCtx.log(`codex stream ended without turn.completed; scheduling recovery (${retryReason})`);
+        } else {
+          consumedErrorReason =
+            streamEndSettlement.decision.terminalKind === "capacity_wait_required"
+              ? "capacity_wait_required"
+              : streamEndSettlement.decision.terminalKind === "exhausted"
+                ? "provider_retry_exhausted"
+                : streamEndSettlement.decision.reasonCode;
+          sessionCtx.emitEvent({
+            kind: "error",
+            payload: { source: "sdk", message: formatCodexSdkError(streamEndSettlement.messagePreview) },
+          });
+          sessionCtx.log(
+            `codex stream ended without turn.completed; stopping replay (${streamEndSettlement.decision.reasonCode})`,
+          );
         }
+      } else if (streamEndSettlement?.decision.action === "retry") {
+        emitProviderTurnSettlementEvent(sessionCtx, streamEndSettlement);
+        retryReason = streamEndSettlement.decision.reasonCode;
+        sessionCtx.log(`codex stream ended without turn.completed; scheduling recovery (${retryReason})`);
       } else {
         retryReason = streamEndReason;
         sessionCtx.log(`codex stream ended without turn.completed; scheduling recovery (${retryReason})`);

--- a/packages/client/src/runtime/provider-attempt.ts
+++ b/packages/client/src/runtime/provider-attempt.ts
@@ -1,0 +1,165 @@
+import type {
+  ProviderFailureCategory,
+  ProviderRetryEventName,
+  ProviderRetryEventPayload,
+  ProviderRetryScope,
+  ReplaySafety,
+  RuntimeProvider,
+} from "@first-tree/shared";
+import {
+  buildProviderRetryEvent,
+  classifyProviderFailure,
+  decideProviderRetry,
+  type ProviderFailureClassification,
+  type ProviderFailureSource,
+  type ProviderRetryDecision,
+} from "./provider-retry-policy.js";
+
+type ProviderAttemptSignalKind = "provider_error" | "local_error" | "transport_close" | "diagnostic";
+
+export type ProviderAttemptSignal = {
+  kind: ProviderAttemptSignalKind;
+  error: unknown;
+  source?: ProviderFailureSource;
+  replaySafety?: ReplaySafety;
+  messagePreview?: string;
+};
+
+export type ProviderAttemptSettlement = {
+  classification: ProviderFailureClassification;
+  decision: ProviderRetryDecision;
+  eventName: ProviderRetryEventName;
+  eventPayload: ProviderRetryEventPayload;
+  messagePreview: string;
+};
+
+export type ProviderAttemptOptions = {
+  provider: RuntimeProvider;
+  scope: ProviderRetryScope;
+  source?: ProviderFailureSource;
+  replaySafety?: ReplaySafety;
+};
+
+export class ProviderAttempt {
+  private readonly provider: RuntimeProvider;
+  private readonly scope: ProviderRetryScope;
+  private readonly source?: ProviderFailureSource;
+  private replaySafety: ReplaySafety;
+  private strongestFailure: { classification: ProviderFailureClassification; messagePreview: string } | null = null;
+  private readonly diagnostics: string[] = [];
+
+  constructor(options: ProviderAttemptOptions) {
+    this.provider = options.provider;
+    this.scope = options.scope;
+    this.source = options.source;
+    this.replaySafety = options.replaySafety ?? "pre_provider";
+  }
+
+  setReplaySafety(replaySafety: ReplaySafety): void {
+    this.replaySafety = replaySafety;
+  }
+
+  markUserVisibleOutput(): void {
+    this.replaySafety = "user_visible";
+  }
+
+  recordSignal(signal: ProviderAttemptSignal): ProviderFailureClassification | null {
+    const messagePreview = signal.messagePreview ?? errorMessage(signal.error);
+    if (signal.kind === "diagnostic") {
+      if (messagePreview.length > 0) this.diagnostics.push(messagePreview);
+      const classification = this.classify(signal);
+      if (isHardFailureCategory(classification.category)) {
+        this.recordFailure(classification, messagePreview);
+        return classification;
+      }
+      return null;
+    }
+
+    const classification = this.classify(signal);
+    this.recordFailure(classification, messagePreview);
+    return classification;
+  }
+
+  settle(input: { attempt: number; fallback?: ProviderAttemptSignal; now?: number }): ProviderAttemptSettlement | null {
+    if (!this.strongestFailure && input.fallback) this.recordSignal(input.fallback);
+    if (!this.strongestFailure) return null;
+
+    const { classification, messagePreview } = this.strongestFailure;
+    const decision = decideProviderRetry({
+      classification,
+      scope: this.scope,
+      attempt: input.attempt,
+      replaySafety: this.replaySafety,
+    });
+    const eventName: ProviderRetryEventName =
+      decision.action === "retry"
+        ? "provider_retry_scheduled"
+        : decision.terminalKind === "exhausted"
+          ? "provider_retry_exhausted"
+          : "provider_failure_terminal";
+    const detail = this.messagePreviewWithDiagnostics(messagePreview);
+    return {
+      classification,
+      decision,
+      eventName,
+      eventPayload: buildProviderRetryEvent({
+        event: eventName,
+        provider: this.provider,
+        scope: this.scope,
+        classification,
+        decision,
+        messagePreview: detail,
+        now: input.now,
+      }),
+      messagePreview: detail,
+    };
+  }
+
+  private classify(signal: ProviderAttemptSignal): ProviderFailureClassification {
+    const source = signal.source ?? this.source;
+    return classifyProviderFailure(signal.error, {
+      provider: this.provider,
+      scope: this.scope,
+      ...(source ? { source } : {}),
+    });
+  }
+
+  private recordFailure(classification: ProviderFailureClassification, messagePreview: string): void {
+    if (!this.strongestFailure) {
+      this.strongestFailure = { classification, messagePreview };
+      return;
+    }
+    const currentScore = failureCategoryScore(this.strongestFailure.classification.category);
+    const nextScore = failureCategoryScore(classification.category);
+    if (nextScore > currentScore) this.strongestFailure = { classification, messagePreview };
+  }
+
+  private messagePreviewWithDiagnostics(messagePreview: string): string {
+    if (this.diagnostics.length === 0) return messagePreview;
+    const uniqueDiagnostics = [...new Set(this.diagnostics)].filter((diagnostic) => diagnostic !== messagePreview);
+    if (uniqueDiagnostics.length === 0) return messagePreview;
+    return [messagePreview, ...uniqueDiagnostics.map((diagnostic) => `diagnostic: ${diagnostic}`)].join("\n");
+  }
+}
+
+export function isHardFailureCategory(category: ProviderFailureCategory): boolean {
+  return (
+    category === "credential" ||
+    category === "capability" ||
+    category === "configuration" ||
+    category === "deterministic_input"
+  );
+}
+
+function failureCategoryScore(category: ProviderFailureCategory): number {
+  if (isHardFailureCategory(category)) return 400;
+  if (category === "provider_capacity") return 300;
+  if (category === "transient_transport") return 200;
+  return 100;
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  return String(error);
+}

--- a/packages/client/src/runtime/provider-retry-policy.ts
+++ b/packages/client/src/runtime/provider-retry-policy.ts
@@ -416,7 +416,11 @@ function configurationReason(base: Classification): string {
 }
 
 function isDeterministicInput(text: string, base: Classification): boolean {
-  return base.reasonCode.includes("context") || /context length|context_length|invalid request|bad request/.test(text);
+  return (
+    base.reasonCode.includes("context") ||
+    /context length|context_length|context window|invalid request|bad request/.test(text) ||
+    (text.includes("ran out of room") && text.includes("context"))
+  );
 }
 
 function deterministicReason(base: Classification): string {

--- a/packages/web/src/components/chat/agent-status-panel.tsx
+++ b/packages/web/src/components/chat/agent-status-panel.tsx
@@ -215,30 +215,6 @@ function SecondLine({ status, mounted }: { status: AgentChatStatus | null; mount
       </div>
     );
   }
-  if (status.statusReason) {
-    const tone =
-      status.statusReason.severity === "error"
-        ? "error"
-        : status.statusReason.severity === "warning"
-          ? "blocked"
-          : "idle";
-    const pill = <StatePill tone={tone} label={status.statusReason.label} />;
-    if (status.statusReason.kind === "terminal" && status.statusReason.severity === "error") {
-      return (
-        <div className="flex">
-          <TimelineJumpButton
-            agentId={status.agentId}
-            main="failed"
-            anchored={isJumpable(mounted, "failed", status.agentId)}
-            ariaLabel="Jump to this agent's error in the timeline"
-          >
-            {pill}
-          </TimelineJumpButton>
-        </div>
-      );
-    }
-    return <div className="flex min-w-0">{pill}</div>;
-  }
   if (status.main === "working" && status.activity) {
     // "Working" (sans word) · "Bash · 0s" (mono tool + live timer). No leading
     // pulse dot — the avatar already carries the breathing status dot. The

--- a/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
+++ b/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
@@ -1106,6 +1106,63 @@ describe("page SSR smoke coverage", () => {
     );
   });
 
+  it("keeps the right sidebar roster on agent lifecycle labels when provider reasons are present", async () => {
+    const { AgentStatusPanel } = await import("../../components/chat/agent-status-panel.js");
+    const client = createClient();
+    client.setQueryData(chatAgentStatusQueryKey("chat-1"), [
+      {
+        agentId: "agent-1",
+        main: "failed",
+        reachable: true,
+        engagement: "active",
+        working: false,
+        errored: true,
+        activity: null,
+        statusReason: {
+          kind: "terminal",
+          severity: "error",
+          provider: "codex",
+          scope: "provider_turn",
+          category: "deterministic_input",
+          reasonCode: "codex_context_window_exceeded",
+          label: "Provider failure",
+        },
+      },
+      {
+        agentId: "agent-2",
+        main: "ready",
+        reachable: true,
+        engagement: "active",
+        working: false,
+        errored: false,
+        activity: null,
+        statusReason: {
+          kind: "terminal",
+          severity: "error",
+          provider: "codex",
+          scope: "provider_turn",
+          category: "deterministic_input",
+          reasonCode: "codex_context_window_exceeded",
+          label: "Provider failure",
+        },
+      },
+    ] satisfies AgentChatStatus[]);
+
+    const html = renderWithClient(
+      <AgentStatusPanel
+        chatId="chat-1"
+        agents={CHAT_PARTICIPANTS.filter((participant) => participant.type !== "human")}
+        canManage={() => true}
+        order="priority"
+      />,
+      client,
+    );
+
+    expect(html).toContain("Failed");
+    expect(html).toContain("Idle");
+    expect(html).not.toContain("Provider failure");
+  });
+
   it("renders ChatView alternate chrome, composer, and recovery states", async () => {
     const { ChatView } = await import("../workspace/center/chat-view.js");
 


### PR DESCRIPTION
## Summary
- add a ProviderAttempt runtime decision layer for Codex provider-turn failures
- route Codex SDK and app-server errors through shared credential/deterministic/capacity/replay-safety settlement
- stop retrying terminal 401/auth and compact/context-window failures, including pre-turn app-server failures
- keep normal assistant/final text out of provider-error classification, even when it mentions error keywords
- ensure non-deterministic accepted-turn stops complete as consumed errors instead of deterministic terminal rejections
- keep the right sidebar agent roster on lifecycle labels (`Working` / `Failed` / `Idle` / `Paused` / `Offline`) even when provider status reasons are present

## Validation
- `pnpm --filter @first-tree/client typecheck`
- `pnpm --filter @first-tree/client test -- src/__tests__/provider-attempt.test.ts src/__tests__/codex-resilience.test.ts src/__tests__/codex-inject-startup-race.test.ts src/__tests__/codex-app-server-handler.test.ts src/__tests__/session-manager.test.ts` (Vitest ran client full suite: 105 files / 1114 tests at that point)
- `pnpm --filter @first-tree/client test -- src/__tests__/codex-app-server-handler.test.ts` (Vitest ran client full suite: 105 files / 1116 tests after accepted-turn mapping fix)
- `pnpm exec biome check --write packages/web/src/components/chat/agent-status-panel.tsx packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx`
- `pnpm --filter @first-tree/web test -- src/pages/__tests__/page-ssr-smoke.test.tsx src/components/chat/__tests__/compose-status-bar.test.ts` (Vitest ran web full suite: 121 files / 923 tests)
- `pnpm --filter @first-tree/web typecheck`
- `pnpm check` (passes with existing unrelated Biome warnings/info)
- `pnpm typecheck`

## Review
- codex-reviewer reviewed the final accepted-turn stop disposition fix and approved with no remaining blockers.
