### PR TITLE
refactor(web): chat summary on the content canvas, vertical chevron, drop the dot; rename to ChatSummary

### DIFF
--- a/packages/web/src/app.tsx
+++ b/packages/web/src/app.tsx
@@ -100,8 +100,8 @@ const UserMenuPreviewPage = import.meta.env.DEV
   ? lazy(() => import("./pages/user-menu-preview.js").then((module) => ({ default: module.UserMenuPreviewPage })))
   : null;
 
-const TaskSummaryPreviewPage = import.meta.env.DEV
-  ? lazy(() => import("./pages/task-summary-preview.js").then((module) => ({ default: module.TaskSummaryPreviewPage })))
+const ChatSummaryPreviewPage = import.meta.env.DEV
+  ? lazy(() => import("./pages/chat-summary-preview.js").then((module) => ({ default: module.ChatSummaryPreviewPage })))
   : null;
 
 // Living design-system reference (companion to DESIGN.md). Unlike the previews
@@ -197,12 +197,12 @@ export function App() {
                   }
                 />
               ) : null}
-              {TaskSummaryPreviewPage ? (
+              {ChatSummaryPreviewPage ? (
                 <Route
-                  path="/preview/task-summary"
+                  path="/preview/chat-summary"
                   element={
                     <Suspense fallback={null}>
-                      <TaskSummaryPreviewPage />
+                      <ChatSummaryPreviewPage />
                     </Suspense>
                   }
                 />

--- a/packages/web/src/hooks/use-admin-ws.ts
+++ b/packages/web/src/hooks/use-admin-ws.ts
@@ -262,7 +262,7 @@ function broadcast(msg: WsMessage) {
       }
     } else if (msg.type === "chat:updated") {
       // A chat's metadata changed (e.g. an agent ran `chat update --description`).
-      // Refresh the open chat's detail — the pinned task summary reads description
+      // Refresh the open chat's detail — the pinned summary reads description
       // + freshness off `["chat-detail", chatId]` — and the conversation list,
       // whose row renders the description. No message arrived, so the message
       // timeline is deliberately NOT invalidated.

--- a/packages/web/src/pages/chat-summary-preview.tsx
+++ b/packages/web/src/pages/chat-summary-preview.tsx
@@ -1,26 +1,28 @@
 import { useRef } from "react";
-import { TaskSummary } from "./workspace/center/task-summary.js";
+import { ChatSummary } from "./workspace/center/chat-summary.js";
 
 /**
- * DEV-only visual review for the pinned chat TaskSummary (chat.description).
- * No backend / no auth — same gating as the other `/preview/*` routes (DEV-only
- * in `app.tsx`). Covers: the auto-expanded "unread + not seen in a while" state
- * (amber highlight + green pulse dot), the collapsed-with-freshness state, the
- * muted "stale" dot, the no-freshness-data fallback (existing chats), the empty
- * (no description → renders nothing) case, and first-line degradation. Click a
- * header to expand / collapse. Scroll sticky-collapse is NOT exercised here (it
- * needs the real message stream); that is verified in the live app.
+ * DEV-only visual review for the pinned ChatSummary (chat.description). No
+ * backend / no auth — same gating as the other `/preview/*` routes (DEV-only in
+ * `app.tsx`). Each demo wraps the summary in a faux white "chat header" + grey
+ * "message stream" so the surface reads as it does live: the summary shares the
+ * content canvas (`--bg`), set off from the white header (`--bg-raised`) above
+ * by a single hairline + the natural bg step. Covers: the auto-expanded "unread
+ * + not seen in a while" state (amber highlight), collapsed-with-freshness, the
+ * no-freshness-data fallback, the empty (renders nothing) case, and first-line
+ * heading degradation. Click to expand / collapse. Scroll sticky-collapse + the
+ * pinned shadow need the real stream and are verified in the live app.
  */
 
 const hoursAgo = (h: number): string => new Date(Date.now() - h * 3_600_000).toISOString();
 
 const RICH = [
   "## 任务",
-  "把右侧 summary 从「侧栏一段文字」改为**置顶可折叠任务头**。",
+  "把右侧 summary 从「侧栏一段文字」改为**置顶可折叠摘要**。",
   "",
   "## 进展",
   "- 后端：`description_updated_at` 已落库",
-  "- 前端：任务头组件接入 chat-view，右栏只留成员",
+  "- 前端：摘要组件接入 chat-view，右栏只留成员",
   "",
   "## 下一步",
   "- gate 全绿后开 PR，详见 [关联 PR](#)。",
@@ -37,7 +39,7 @@ const HEADING_FIRST = [
 const PANEL: React.CSSProperties = {
   width: 720,
   maxWidth: "100%",
-  background: "var(--bg-raised)",
+  background: "var(--bg)",
   border: "var(--hairline) solid var(--border)",
   borderRadius: "var(--radius-panel)",
   overflow: "hidden",
@@ -58,7 +60,15 @@ function Demo({
   const scrollRef = useRef<HTMLDivElement>(null);
   return (
     <div style={PANEL}>
-      <TaskSummary
+      {/* Faux chat header (white chrome) so the summary's content-canvas tone
+          reads against it exactly as it does live. */}
+      <div
+        className="text-caption"
+        style={{ background: "var(--bg-raised)", padding: "var(--sp-3) var(--sp-6)", color: "var(--fg-3)" }}
+      >
+        (chat header)
+      </div>
+      <ChatSummary
         chatId={chatId}
         description={description}
         descriptionUpdatedAt={descriptionUpdatedAt}
@@ -93,7 +103,7 @@ function Col({ label, note, children }: { label: string; note: string; children:
   );
 }
 
-export function TaskSummaryPreviewPage() {
+export function ChatSummaryPreviewPage() {
   return (
     <div
       style={{
@@ -107,27 +117,28 @@ export function TaskSummaryPreviewPage() {
     >
       <div>
         <h1 className="text-title" style={{ color: "var(--fg)" }}>
-          Chat task summary — states
+          Chat summary — states
         </h1>
         <p className="text-body" style={{ color: "var(--fg-3)" }}>
-          Click a header to expand / collapse. Read-only: there is no edit affordance anywhere. Expanded is just the
-          markdown; the freshness ("9 days ago") lives on the bar in both states.
+          Each demo sits under a faux white header and over the grey content canvas, as it does live. Click to expand /
+          collapse. Read-only: no edit affordance; expanded is just the markdown; the freshness ("9 days ago") lives on
+          the bar in both states.
         </p>
       </div>
 
       <section style={{ display: "flex", flexDirection: "column", gap: "var(--sp-6)" }}>
         <Col
           label="Unread + not seen in a while"
-          note="auto-expands once + amber highlight · green pulse dot · faithful markdown · freshness stays on the bar"
+          note="auto-expands once + amber highlight · faithful markdown · freshness on the bar"
         >
           <Demo chatId="preview-unread" description={RICH} descriptionUpdatedAt={hoursAgo(2)} lastReadAt={null} />
         </Col>
 
-        <Col label="Recently updated, already seen" note="collapsed · green pulse dot · freshness on the bar">
+        <Col label="Recently updated, already seen" note="collapsed · freshness on the bar · vertical chevron">
           <Demo chatId="preview-seen" description={PLAIN} descriptionUpdatedAt={hoursAgo(3)} lastReadAt={hoursAgo(1)} />
         </Col>
 
-        <Col label="Stale update, already seen" note="collapsed · muted grey dot (no pulse) · older freshness">
+        <Col label="Stale update, already seen" note="collapsed · older freshness">
           <Demo
             chatId="preview-stale"
             description={PLAIN}
@@ -136,16 +147,13 @@ export function TaskSummaryPreviewPage() {
           />
         </Col>
 
-        <Col
-          label="No freshness data (existing chat)"
-          note="collapsed · grey dot · no freshness line (honest: not stamped yet)"
-        >
+        <Col label="No freshness data (existing chat)" note="collapsed · no freshness line (honest: not stamped yet)">
           <Demo chatId="preview-nofresh" description={PLAIN} descriptionUpdatedAt={null} lastReadAt={null} />
         </Col>
 
         <Col
           label="First line is a section heading"
-          note="collapsed bar skips the heading → shows the first prose line (truncated if long)"
+          note="collapsed bar skips the heading → first prose line (truncated if long)"
         >
           <Demo
             chatId="preview-edge"
@@ -155,7 +163,7 @@ export function TaskSummaryPreviewPage() {
           />
         </Col>
 
-        <Col label="No description" note="renders nothing — the panel below has no header strip">
+        <Col label="No description" note="renders nothing — no summary strip appears between header and stream">
           <Demo chatId="preview-empty" description={null} descriptionUpdatedAt={null} lastReadAt={null} />
         </Col>
 

--- a/packages/web/src/pages/workspace/center/__tests__/chat-summary.test.ts
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-summary.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { descriptionFirstLine } from "../task-summary.js";
+import { descriptionFirstLine } from "../chat-summary.js";
 
 /**
- * `descriptionFirstLine` powers the collapsed task-summary bar: it picks the
+ * `descriptionFirstLine` powers the collapsed chat-summary bar: it picks the
  * first content line of the chat description and strips the common markdown
  * markers so a `- bullet` reads as plain text (visual truncation is left to
  * CSS). A leading section heading (`## 任务`) is skipped in favor of the prose

--- a/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
@@ -1390,17 +1390,17 @@ describe("ChatView", () => {
     await act(async () => root.unmount());
   });
 
-  // The chat summary (`chat.description`) now renders in the pinned TaskSummary
+  // The chat summary (`chat.description`) now renders in the pinned ChatSummary
   // between the chat header and the message stream — NOT in the right rail.
-  describe("pinned task summary", () => {
+  describe("pinned summary", () => {
     // Distinct from BASE_MESSAGES' body so assertions can't match unrelated chrome.
     const DESCRIPTION_MD = "Status: shipping **DescBody** soon.";
 
     function sidebarOpen(container: ParentNode): boolean {
       return container.querySelector('aside[aria-label="Chat details"]') !== null;
     }
-    function taskSummaryButton(container: ParentNode): HTMLButtonElement | null {
-      return container.querySelector<HTMLButtonElement>('button[aria-label$="task summary"]');
+    function chatSummaryButton(container: ParentNode): HTMLButtonElement | null {
+      return container.querySelector<HTMLButtonElement>('button[aria-label$="summary"]');
     }
 
     it("renders the description's first line collapsed and the full markdown when expanded", async () => {
@@ -1415,11 +1415,11 @@ describe("ChatView", () => {
       );
 
       await waitForCondition(
-        () => taskSummaryButton(container) !== null,
-        "Expected the task summary to render for a chat with a description",
+        () => chatSummaryButton(container) !== null,
+        "Expected the summary to render for a chat with a description",
       );
-      const button = taskSummaryButton(container);
-      if (!button) throw new Error("task summary button missing");
+      const button = chatSummaryButton(container);
+      if (!button) throw new Error("summary button missing");
       // Collapsed bar = the first line with markdown markers stripped.
       expect(button.textContent).toContain("Status: shipping DescBody soon.");
 
@@ -1429,13 +1429,13 @@ describe("ChatView", () => {
       });
       await waitForCondition(
         () => [...container.querySelectorAll("strong")].some((el) => el.textContent === "DescBody"),
-        "Expected the expanded task summary to render the description markdown",
+        "Expected the expanded summary to render the description markdown",
       );
 
       await act(async () => root.unmount());
     });
 
-    it("renders no task summary when the chat has no description", async () => {
+    it("renders no summary when the chat has no description", async () => {
       localStorage.clear();
       const { ChatView } = await import("../chat-view.js");
       const noDescription = chatDetail({ description: null });
@@ -1448,12 +1448,12 @@ describe("ChatView", () => {
 
       await waitForText(container, "Launch planning");
       await flush();
-      expect(taskSummaryButton(container)).toBeNull();
+      expect(chatSummaryButton(container)).toBeNull();
 
       await act(async () => root.unmount());
     });
 
-    it("does NOT auto-open the right rail for a described chat — the summary lives in the task summary", async () => {
+    it("does NOT auto-open the right rail for a described chat — the summary lives in the summary", async () => {
       localStorage.clear();
       const { ChatView } = await import("../chat-view.js");
       const withDescription = chatDetail({ description: DESCRIPTION_MD });
@@ -1464,7 +1464,7 @@ describe("ChatView", () => {
         "/",
       );
 
-      await waitForCondition(() => taskSummaryButton(container) !== null, "Expected the task summary to render");
+      await waitForCondition(() => chatSummaryButton(container) !== null, "Expected the summary to render");
       await flush();
       // The rail no longer pops open just because the chat has a description.
       expect(sidebarOpen(container)).toBe(false);
@@ -1483,16 +1483,16 @@ describe("ChatView", () => {
         "/",
       );
 
-      await waitForCondition(() => taskSummaryButton(container) !== null, "Expected the task summary to render");
-      const button = taskSummaryButton(container);
-      if (!button) throw new Error("task summary button missing");
+      await waitForCondition(() => chatSummaryButton(container) !== null, "Expected the summary to render");
+      const button = chatSummaryButton(container);
+      if (!button) throw new Error("summary button missing");
       // Expand and confirm the expanded surface still exposes no edit affordance.
       await act(async () => {
         button.click();
       });
       await flush();
       const headerRoot = button.parentElement;
-      if (!headerRoot) throw new Error("task summary root missing");
+      if (!headerRoot) throw new Error("summary root missing");
       // Read-only is self-evident: the only control is the expand/collapse toggle —
       // no edit button / input / textarea (the footer + info hint were removed).
       expect(headerRoot.querySelectorAll("button")).toHaveLength(1);

--- a/packages/web/src/pages/workspace/center/chat-summary.tsx
+++ b/packages/web/src/pages/workspace/center/chat-summary.tsx
@@ -1,13 +1,12 @@
-import { ChevronRight } from "lucide-react";
+import { ChevronDown } from "lucide-react";
 import type { RefObject } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Markdown } from "../../../components/ui/markdown.js";
-import { StatusGlyph } from "../../../components/ui/status-glyph.js";
 import { stripInlineMarkdown } from "../../../lib/strip-inline-markdown.js";
 import { formatRelative } from "../../../lib/utils.js";
 
 /**
- * Task summary — the chat's running summary (`chat.description`), surfaced as a
+ * Chat summary — the chat's running summary (`chat.description`), surfaced as a
  * pinned, collapsible strip between the chat header and the message stream
  * rather than buried in the right rail. Read-only: the description is the chat
  * `description`, maintained by agents via `chat update --description`; there is
@@ -15,24 +14,28 @@ import { formatRelative } from "../../../lib/utils.js";
  * agent in chat). The component renders the description's markdown faithfully —
  * it never invents sections, fields, or a "stage".
  *
+ * It belongs to the conversation content, not the header chrome: it shares the
+ * message-stream canvas (`--bg`) rather than a fill of its own, is separated
+ * from the white header (`--bg-raised`) above by a single hairline + the
+ * natural bg step, and lifts on a faint shadow only while the stream scrolls
+ * under it.
+ *
  * Two forms:
- *   - Collapsed (default): one line — an activity dot (green pulse when the
- *     description changed recently, else muted grey — a freshness signal, NOT a
- *     task stage), the description's first meaningful line (section headings
- *     skipped, markdown markers stripped, ellipsis-truncated), an "Updated" chip
- *     when there's an unread change, and the freshness ("9 days ago"). The bar
- *     shows the freshness in BOTH states, so an auto-expanded summary still
- *     surfaces when it last changed.
+ *   - Collapsed (default): one line — the description's first meaningful line
+ *     (section headings skipped, markdown markers stripped, ellipsis-truncated),
+ *     an "Updated" chip when there's an unread change, the freshness
+ *     ("9 days ago"), and a quiet chevron. Freshness shows in BOTH states, so an
+ *     auto-expanded summary still surfaces when it last changed.
  *   - Expanded: just the description rendered as markdown — no footer. Read-only
  *     is self-evident (no edit affordance anywhere); the updater name is not
  *     shown (single-agent maintenance makes it noise — the data stays on the
  *     chat detail).
  *
- * Auto behavior (SPEC §五): default collapsed; auto-expand once on entry ONLY
- * when the update is unread AND the viewer hasn't looked in a while; while
- * expanded, scrolling the stream folds it to the bar (restores at the top); a
- * manual toggle always wins and is remembered per chat. Renders nothing when
- * the chat has no description.
+ * Auto behavior: default collapsed; auto-expand once on entry ONLY when the
+ * update is unread AND the viewer hasn't looked in a while; while expanded,
+ * scrolling the stream folds it to the bar (restores at the top); a manual
+ * toggle always wins and is remembered per chat. Renders nothing when the chat
+ * has no description.
  */
 
 // Auto-expand "haven't looked in a while" gate: an unread description update
@@ -40,9 +43,6 @@ import { formatRelative } from "../../../lib/utils.js";
 // least this long ago — or on an earlier calendar day. Long enough that a quick
 // tab-away-and-back doesn't re-pop the panel.
 const STALE_SINCE_VIEW_MS = 8 * 60 * 60 * 1000;
-// Activity-dot freshness window: green + pulse when the description changed
-// within this window, muted grey (no pulse) beyond it.
-const FRESH_WINDOW_MS = 24 * 60 * 60 * 1000;
 // Scroll sticky-collapse thresholds (px from the stream top). The hysteresis
 // gap (40 vs 6) debounces the boundary so a hair of scroll doesn't flutter it.
 const SCROLL_COLLAPSE_PX = 40;
@@ -50,7 +50,7 @@ const SCROLL_RESTORE_PX = 6;
 
 // Per-chat manual expand/collapse preference. Mirrors the localStorage pattern
 // used elsewhere in the chat view (private-mode safe, per-chat key suffix).
-const MANUAL_PREF_KEY = "first-tree:chat-task-summary-expanded:v1";
+const MANUAL_PREF_KEY = "first-tree:chat-summary-expanded:v1";
 
 function loadManualPref(chatId: string): boolean | null {
   if (typeof window === "undefined") return null;
@@ -126,7 +126,7 @@ function isStaleSinceLastView(lastReadAtMs: number | null, nowMs: number): boole
   return new Date(lastReadAtMs).toDateString() !== new Date(nowMs).toDateString();
 }
 
-export function TaskSummary({
+export function ChatSummary({
   chatId,
   description,
   descriptionUpdatedAt,
@@ -166,6 +166,9 @@ export function TaskSummary({
   const [open, setOpen] = useState(false);
   const [highlighted, setHighlighted] = useState(false);
   const [scrollCollapsed, setScrollCollapsed] = useState(false);
+  // Pinned-elevation: true once the stream has scrolled under the bar (drives a
+  // faint shadow); flat when the stream is at the top.
+  const [scrolled, setScrolled] = useState(false);
   const [unreadCleared, setUnreadCleared] = useState(false);
 
   // Decide the entry state, after the real detail has settled, keyed by chat AND
@@ -213,12 +216,17 @@ export function TaskSummary({
   openRef.current = open;
   const scrollCollapsedRef = useRef(scrollCollapsed);
   scrollCollapsedRef.current = scrollCollapsed;
+  const scrolledRef = useRef(scrolled);
+  scrolledRef.current = scrolled;
   useEffect(() => {
     if (!hasDescription) return;
     const el = scrollContainerRef.current;
     if (!el) return;
+    setScrolled(el.scrollTop > 1); // initial elevation state (does not collapse on mount)
     const onScroll = () => {
       const top = el.scrollTop;
+      const nextScrolled = top > 1;
+      if (nextScrolled !== scrolledRef.current) setScrolled(nextScrolled);
       if (top > SCROLL_COLLAPSE_PX && openRef.current && !scrollCollapsedRef.current) {
         setScrollCollapsed(true);
       } else if (top <= SCROLL_RESTORE_PX && scrollCollapsedRef.current) {
@@ -232,7 +240,6 @@ export function TaskSummary({
   if (!hasDescription) return null;
 
   const expanded = open && !scrollCollapsed;
-  const fresh = updatedAtMs !== null && Date.now() - updatedAtMs < FRESH_WINDOW_MS;
   const firstLine = descriptionFirstLine(trimmed);
   const freshnessText = updatedAtMs !== null ? formatRelative(descriptionUpdatedAt) : null;
   const showAmberChip = unread && !unreadCleared && !expanded;
@@ -242,21 +249,23 @@ export function TaskSummary({
     <div
       className="shrink-0"
       style={{
-        // A recessed band (`--bg-sunken`) so the summary reads as its own pinned
-        // strip at the top of the conversation — distinct from the white header
-        // chrome above (header + composer share `--bg-raised`), not fused into
-        // it. Hairlines top + bottom delimit the band without a heavy card.
-        background: amberActive ? "var(--bg-warn-soft)" : "var(--bg-sunken)",
+        // The summary is conversation content, so it shares the message-stream
+        // canvas (`--bg`) — the white header (`--bg-raised`) above gives a
+        // natural one-step contrast. Only the header↔summary seam carries a
+        // hairline (the header itself has no bottom border); nothing separates
+        // the summary from the stream below (same surface). A faint shadow
+        // appears only while the stream scrolls under it, reading as "pinned".
+        background: amberActive ? "var(--bg-warn-soft)" : "var(--bg)",
         borderTop: `var(--hairline) solid ${amberActive ? "var(--state-blocked-border)" : "var(--border-faint)"}`,
-        borderBottom: `var(--hairline) solid ${amberActive ? "var(--state-blocked-border)" : "var(--border-faint)"}`,
-        transition: "background 160ms ease",
+        boxShadow: scrolled ? "var(--shadow-sm)" : "none",
+        transition: "background 160ms ease, box-shadow 160ms ease",
       }}
     >
       <button
         type="button"
         onClick={onToggle}
         aria-expanded={expanded}
-        aria-label={expanded ? "Collapse task summary" : "Expand task summary"}
+        aria-label={expanded ? "Collapse summary" : "Expand summary"}
         className="flex w-full items-center text-left transition-colors hover:bg-[var(--bg-hover)]"
         style={{
           gap: "var(--sp-2)",
@@ -266,13 +275,6 @@ export function TaskSummary({
           cursor: "pointer",
         }}
       >
-        <StatusGlyph
-          colorVar={fresh ? "var(--success)" : "var(--fg-4)"}
-          shape="dot"
-          pulse={fresh ? "working" : null}
-          size={8}
-          ariaLabel={fresh ? "Recently updated" : "No recent update"}
-        />
         <span
           className="text-body min-w-0 flex-1"
           style={{
@@ -304,16 +306,16 @@ export function TaskSummary({
             {freshnessText}
           </span>
         ) : null}
-        <ChevronRight
-          size={13}
-          strokeWidth={1.75}
+        <ChevronDown
+          size={15}
+          strokeWidth={2}
           className="shrink-0"
           style={{
-            // Deliberately quiet (smaller + thinner): the activity dot and the
-            // freshness text ("9 days ago") are the primary right-side signal;
-            // the chevron is just a low-key "expandable" hint, not a competing mark.
+            // Vertical axis matches the open/close motion: ▼ collapsed (opens
+            // downward) → ▲ expanded (collapses up). Kept quiet (muted grey) so
+            // the freshness stays the primary right-side signal.
             color: "var(--fg-4)",
-            transform: expanded ? "rotate(90deg)" : "none",
+            transform: expanded ? "rotate(180deg)" : "none",
             transition: "transform 180ms ease",
           }}
         />

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -132,7 +132,7 @@ import { findGapAfterMessageId } from "../../../utils/chat-gap.js";
 import { computeRequiresMention, shouldPrimeMentionOnFocus } from "../../../utils/requires-mention.js";
 import { filterEventsForTimeline } from "../../../utils/session-timeline.js";
 import { ChatRightSidebar } from "../right-sidebar/index.js";
-import { TaskSummary } from "./task-summary.js";
+import { ChatSummary } from "./chat-summary.js";
 
 const SIDEBAR_OPEN_STORAGE_KEY = "first-tree:chat-right-sidebar:open:v1";
 
@@ -1151,7 +1151,7 @@ export function ChatView({
     onChange: () => setUploadError(null),
   });
   // Right-rail visibility. The rail holds participants + GitHub bindings; the
-  // running summary now lives in the pinned TaskSummary above the stream, not
+  // running summary now lives in the pinned ChatSummary above the stream, not
   // here. Default: the user's stored preference if they have ever toggled the
   // rail (a global preference, not per-chat), otherwise collapsed for the full
   // reading column.
@@ -1372,7 +1372,7 @@ export function ChatView({
   });
 
   // The right rail no longer auto-opens per chat: the running summary moved to
-  // the pinned TaskSummary (above the stream), so the rail — now just
+  // the pinned ChatSummary (above the stream), so the rail — now just
   // participants + GitHub bindings — simply follows the user's stored
   // open/closed preference.
 
@@ -2977,7 +2977,7 @@ export function ChatView({
             style={{
               // Min-height as a comfortable floor for a now-stable single-row
               // header: the topic sits on one line (truncating with an ellipsis
-              // when long) and the description lives in the pinned task summary
+              // when long) and the description lives in the pinned summary
               // directly below, so the header no longer grows with content.
               // Vertical padding centers that single row within the min-height.
               minHeight: 52,
@@ -3043,7 +3043,7 @@ export function ChatView({
                   the optional GitHub entity link. The description text is not
                   rendered inline (it made the header height jitter with the
                   running summary and buried the topic) — it now lives in the
-                  pinned task summary directly below. With the multi-line
+                  pinned summary directly below. With the multi-line
                   description gone the row is naturally bounded, so the old
                   narrow-viewport `line-clamp-3` cap is no longer needed. */}
               <div className="flex min-w-0 items-center" style={{ flex: 1, gap: "var(--sp-1)" }}>
@@ -3165,7 +3165,7 @@ export function ChatView({
                 )}
                 <EntityLink metadata={chatDetail?.metadata} />
                 {/* Chat description (running work summary) is NOT shown in the
-                    header. It lives in the pinned task summary between this
+                    header. It lives in the pinned summary between this
                     header and the message stream (rendered as markdown).
                     Read-only on the web — written by the owning agent via
                     `chat update --description`. */}
@@ -3261,7 +3261,7 @@ export function ChatView({
             </div>
           </div>
 
-          <TaskSummary
+          <ChatSummary
             chatId={chatId}
             description={chatDetail?.description ?? null}
             descriptionUpdatedAt={chatDetail?.descriptionUpdatedAt ?? null}

--- a/packages/web/src/pages/workspace/right-sidebar/index.tsx
+++ b/packages/web/src/pages/workspace/right-sidebar/index.tsx
@@ -50,7 +50,7 @@ function saveWidth(width: number): void {
  * × inside the panel was just redundant clutter.
  *
  * The chat's running summary (the `description`) is NOT here — it lives in the
- * pinned TaskSummary above the message stream. This rail carries only the
+ * pinned ChatSummary above the message stream. This rail carries only the
  * secondary "who + what's bound" context:
  *   1. Participants — humans + agents (agents first, since their live status
  *      is the glanceable pulse). Caps the visible roster; rest behind


### PR DESCRIPTION
## What

Post-ship follow-up on the pinned chat summary (#1195), addressing gandy's review of the live surface, with the chrome direction set by ux-expert.

## Changes

- **Background → content canvas.** The summary now shares the message-stream canvas (`var(--bg)`) instead of a grey `--bg-sunken` fill of its own. The white header (`--bg-raised`) above gives a natural one-step contrast, so the summary reads as the top of the conversation content rather than a muddy sunken band. It is set off from the header by a single header↔summary hairline; nothing separates it from the stream below (same surface); a faint shadow (`--shadow-sm`) appears only while the stream scrolls under it, reading as "pinned". (A grey fill looked sunken/disabled; a white fill would have fused with the white header — the header and stream are *not* the same colour.)
- **Drop the activity dot.** Freshness is already carried by the "9 days ago" text, and the dot was not self-evident.
- **Vertical chevron.** `ChevronDown` ▼ (collapsed, opens down) → ▲ (expanded, collapses up), matching the open/close motion, instead of a rotating right-chevron.
- **Rename `TaskSummary` → `ChatSummary`** across component / file / route (`/preview/chat-summary`) / preview / tests — "task" clashed with the product's work-stream language and only lived in the component name + aria.

## Verification

- `pnpm --filter @first-tree/web test` — **950 pass**.
- `pnpm --filter @first-tree/web typecheck` + web `lint:tokens` + `pnpm check` (biome) — clean.
- Web-only change; no server / shared / client surface touched.

Follow-up to #1195. Design reference: ux-expert `mockups/task-header/chrome-v3.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
