### PR TITLE
docs(client): state the chat-send visibility WHY in the agent briefing

### DIFF
--- a/packages/client/src/__tests__/agent-briefing.test.ts
+++ b/packages/client/src/__tests__/agent-briefing.test.ts
@@ -438,11 +438,14 @@ describe("buildAgentBriefing — # Working in First Tree subsections", () => {
     expect(briefing).not.toMatch(/reach path/i);
     expect(briefing).not.toMatch(/decoupled channels/i);
 
-    // yuezengwu 2026-06-23: the visibility WHY is stated WITHOUT reviving any
-    // output-streaming framing — a teammate only sees what you `chat send`, so
-    // no send is no reply. Worded to clear every guard above.
-    expect(briefing).toMatch(/only ever sees what you `?chat send`?/);
-    expect(briefing).toMatch(/the human sees nothing at all/);
+    // yuezengwu 2026-06-23: the WHY is stated as a mechanism (working text is
+    // not a delivered message, so you must send) WITHOUT reviving any
+    // output-streaming framing AND without absolutizing it to `chat send` —
+    // `chat ask` / `chat update` stay valid human-visible channels (codex R1).
+    expect(briefing).toMatch(/not a message addressed to anyone/);
+    expect(briefing).toMatch(/has sent nothing/);
+    // Must NOT claim chat send is the sole channel a teammate ever sees.
+    expect(briefing).not.toMatch(/only ever sees what you `?chat send`?/);
 
     // Courtesy-send guard stays — the brake is on the *send* side.
     expect(briefing).toContain("Don't fire a courtesy");

--- a/packages/client/src/__tests__/agent-briefing.test.ts
+++ b/packages/client/src/__tests__/agent-briefing.test.ts
@@ -429,21 +429,24 @@ describe("buildAgentBriefing — # Working in First Tree subsections", () => {
     expect(briefing).not.toMatch(/server rejects a `?chat send`? to a human/);
 
     // yuezengwu 2026-06-23: reinstate the "your output stream is your reasoning
-    // trace, fully decoupled from communication" framing as a deliberate prompt
-    // principle (reverses the 2026-06-16 removal). The agent should narrate
-    // freely in its output stream AND understand that reaching a teammate is
-    // therefore always an explicit send. Stated WITHOUT the absolute
-    // "chat send is the only visible channel" claim — `chat ask` / `chat update`
-    // stay valid human-visible channels (codex R1).
+    // trace" framing as a deliberate prompt principle (reverses the 2026-06-16
+    // removal), but with the PRECISE product boundary (codex R1/R5): the output
+    // stream is not an addressed reply and not durable chat history, yet it is
+    // NOT private — a one-line preview surfaces as live session activity
+    // (`liveActivity.detail` / `turnText`) to viewers. So communication is
+    // always an explicit send, and narration is never a substitute for it.
     expect(briefing).toMatch(/output stream is your reasoning trace/i);
-    expect(briefing).toMatch(/fully decoupled from\s+communication/i);
-    expect(briefing).toMatch(/not a message\s+addressed to anyone/);
-    expect(briefing).toMatch(/has sent nothing/);
+    expect(briefing).toMatch(/never written to durable\s+chat history/i);
+    expect(briefing).toMatch(/not\s+private/i);
+    expect(briefing).toMatch(/live session\s+activity to anyone viewing the chat/i);
+    expect(briefing).toMatch(/has sent\s+nothing/);
     // The retired mirror term stays out — there is no `agent-final-text` row
-    // post-#1190; the brief says the output stream is NOT mirrored into chat.
+    // post-#1190.
     expect(briefing).not.toContain("agent-final-text");
-    expect(briefing).toMatch(/does not mirror\s+it into the chat/i);
-    // Must NOT claim chat send is the sole channel a teammate ever sees.
+    // Must NOT overclaim invisibility/privacy: the output stream is NOT
+    // undelivered-to-everyone (it shows as live activity), and chat send is NOT
+    // the sole channel a teammate ever sees (`chat ask` / `chat update` too).
+    expect(briefing).not.toMatch(/does not deliver it to anyone/i);
     expect(briefing).not.toMatch(/only ever sees what you `?chat send`?/);
 
     // Courtesy-send guard stays — the brake is on the *send* side.

--- a/packages/client/src/__tests__/agent-briefing.test.ts
+++ b/packages/client/src/__tests__/agent-briefing.test.ts
@@ -438,6 +438,12 @@ describe("buildAgentBriefing — # Working in First Tree subsections", () => {
     expect(briefing).not.toMatch(/reach path/i);
     expect(briefing).not.toMatch(/decoupled channels/i);
 
+    // yuezengwu 2026-06-23: the visibility WHY is stated WITHOUT reviving any
+    // output-streaming framing — a teammate only sees what you `chat send`, so
+    // no send is no reply. Worded to clear every guard above.
+    expect(briefing).toMatch(/only ever sees what you `?chat send`?/);
+    expect(briefing).toMatch(/the human sees nothing at all/);
+
     // Courtesy-send guard stays — the brake is on the *send* side.
     expect(briefing).toContain("Don't fire a courtesy");
     expect(briefing).toContain("end the turn without sending");

--- a/packages/client/src/__tests__/agent-briefing.test.ts
+++ b/packages/client/src/__tests__/agent-briefing.test.ts
@@ -428,22 +428,21 @@ describe("buildAgentBriefing — # Working in First Tree subsections", () => {
     expect(briefing).toContain("first-tree chat update --description");
     expect(briefing).not.toMatch(/server rejects a `?chat send`? to a human/);
 
-    // yuezengwu 2026-06-16: all output-streaming framing is removed from the
-    // briefing — no reasoning-trace channel, no `agent-final-text` mirror, no
-    // "separate channel" / "reach path" / "decoupled channels" phrasing survives.
-    expect(briefing).not.toMatch(/output stream/i);
-    expect(briefing).not.toMatch(/reasoning trace/i);
-    expect(briefing).not.toContain("agent-final-text");
-    expect(briefing).not.toMatch(/separate channel/i);
-    expect(briefing).not.toMatch(/reach path/i);
-    expect(briefing).not.toMatch(/decoupled channels/i);
-
-    // yuezengwu 2026-06-23: the WHY is stated as a mechanism (working text is
-    // not a delivered message, so you must send) WITHOUT reviving any
-    // output-streaming framing AND without absolutizing it to `chat send` —
-    // `chat ask` / `chat update` stay valid human-visible channels (codex R1).
-    expect(briefing).toMatch(/not a message addressed to anyone/);
+    // yuezengwu 2026-06-23: reinstate the "your output stream is your reasoning
+    // trace, fully decoupled from communication" framing as a deliberate prompt
+    // principle (reverses the 2026-06-16 removal). The agent should narrate
+    // freely in its output stream AND understand that reaching a teammate is
+    // therefore always an explicit send. Stated WITHOUT the absolute
+    // "chat send is the only visible channel" claim — `chat ask` / `chat update`
+    // stay valid human-visible channels (codex R1).
+    expect(briefing).toMatch(/output stream is your reasoning trace/i);
+    expect(briefing).toMatch(/fully decoupled from\s+communication/i);
+    expect(briefing).toMatch(/not a message\s+addressed to anyone/);
     expect(briefing).toMatch(/has sent nothing/);
+    // The retired mirror term stays out — there is no `agent-final-text` row
+    // post-#1190; the brief says the output stream is NOT mirrored into chat.
+    expect(briefing).not.toContain("agent-final-text");
+    expect(briefing).toMatch(/does not mirror\s+it into the chat/i);
     // Must NOT claim chat send is the sole channel a teammate ever sees.
     expect(briefing).not.toMatch(/only ever sees what you `?chat send`?/);
 

--- a/packages/client/src/__tests__/codex-bootstrap.test.ts
+++ b/packages/client/src/__tests__/codex-bootstrap.test.ts
@@ -141,12 +141,12 @@ describe("bootstrapWorkspace — codex briefing + workspace marker", () => {
     expect(briefing).toContain("first-tree-staging chat --help");
     expect(briefing).toContain("first-tree-staging chat send");
     // `chat send` reaches any teammate — agent or human; a human also has
-    // `chat ask` (decisions) / `chat update --description` (progress). No
-    // output-stream or `agent-final-text` mirror framing survives in the
-    // briefing.
+    // `chat ask` (decisions) / `chat update --description` (progress). The
+    // output stream is framed as the agent's decoupled reasoning trace, but the
+    // retired `agent-final-text` mirror term must NOT survive (post-#1190).
     expect(briefing).toContain("first-tree-staging chat ask <human>");
     expect(briefing).toContain("first-tree-staging chat update --description");
-    expect(briefing).not.toMatch(/output stream/i);
+    expect(briefing).toMatch(/output stream is your reasoning trace/i);
     expect(briefing).not.toContain("agent-final-text");
     // The new Skill Map and Context Tree section are now part of every
     // briefing — pin both so a regenerator dropping them doesn't slip past

--- a/packages/client/src/runtime/agent-briefing.ts
+++ b/packages/client/src/runtime/agent-briefing.ts
@@ -320,12 +320,14 @@ You are running inside **First Tree**, a messaging platform for agent teams.
   to make an agent act, or to send a human a free reply / conversational answer.
   For a human you can also raise a tracked decision with \`${bin} chat ask
   <human>\`, or push progress with \`${bin} chat update --description\`.
-- **Working through a turn delivers nothing on its own — you must send.**
-  First Tree is a messaging platform: the text you produce while working a
-  turn is you doing the work, not a message addressed to anyone, so by itself
-  it reaches no teammate. To put something in front of a teammate you run an
-  explicit command — \`chat send\` for a free reply (and to make an agent
-  act), and for a human also \`chat ask\` for a decision or
+- **Your output stream is your reasoning trace** — think, plan, and narrate
+  there as freely as you need while you work. It is fully decoupled from
+  communication: First Tree does not deliver it to anyone and does not mirror
+  it into the chat. Working a turn is you doing the work, not a message
+  addressed to anyone.
+- **So reaching a teammate is always an explicit send.** Nothing moves to a
+  teammate until you run a command — \`chat send\` for a free reply (and to
+  make an agent act), and for a human also \`chat ask\` for a decision or
   \`chat update --description\` for progress. That is the WHY behind the rule
   below: a turn that produces only working text has sent nothing — no reply,
   not a terse one.

--- a/packages/client/src/runtime/agent-briefing.ts
+++ b/packages/client/src/runtime/agent-briefing.ts
@@ -320,12 +320,15 @@ You are running inside **First Tree**, a messaging platform for agent teams.
   to make an agent act, or to send a human a free reply / conversational answer.
   For a human you can also raise a tracked decision with \`${bin} chat ask
   <human>\`, or push progress with \`${bin} chat update --description\`.
-- **A teammate only ever sees what you \`chat send\`.** The text you type as
-  you work — thinking, planning, narrating — is never shown to anyone. End a
-  turn without \`chat send\` and the human sees nothing at all, however much
-  you wrote; \`chat send\` is the only thing that puts your words in front of a
-  teammate. This is the WHY behind the rule below: no \`chat send\` is not a
-  terse reply, it is no reply.
+- **Working through a turn delivers nothing on its own — you must send.**
+  First Tree is a messaging platform: the text you produce while working a
+  turn is you doing the work, not a message addressed to anyone, so by itself
+  it reaches no teammate. To put something in front of a teammate you run an
+  explicit command — \`chat send\` for a free reply (and to make an agent
+  act), and for a human also \`chat ask\` for a decision or
+  \`chat update --description\` for progress. That is the WHY behind the rule
+  below: a turn that produces only working text has sent nothing — no reply,
+  not a terse one.
 - **Reply to a human; don't fire a courtesy \`chat send\` to an agent.** A
   message a human directs at you gets a \`chat send\` reply before you end the
   turn — a human never auto-wakes from your reply, so there is no loop risk and

--- a/packages/client/src/runtime/agent-briefing.ts
+++ b/packages/client/src/runtime/agent-briefing.ts
@@ -321,16 +321,17 @@ You are running inside **First Tree**, a messaging platform for agent teams.
   For a human you can also raise a tracked decision with \`${bin} chat ask
   <human>\`, or push progress with \`${bin} chat update --description\`.
 - **Your output stream is your reasoning trace** — think, plan, and narrate
-  there as freely as you need while you work. It is fully decoupled from
-  communication: First Tree does not deliver it to anyone and does not mirror
-  it into the chat. Working a turn is you doing the work, not a message
-  addressed to anyone.
-- **So reaching a teammate is always an explicit send.** Nothing moves to a
-  teammate until you run a command — \`chat send\` for a free reply (and to
-  make an agent act), and for a human also \`chat ask\` for a decision or
-  \`chat update --description\` for progress. That is the WHY behind the rule
-  below: a turn that produces only working text has sent nothing — no reply,
-  not a terse one.
+  there as you work. It is decoupled from communication: it is never an
+  addressed reply and is never written to durable chat history. It is not
+  private, though — a one-line preview of it can surface as live session
+  activity to anyone viewing the chat. So narrating is never a substitute for
+  reaching someone.
+- **So reaching a teammate is always an explicit send.** Nothing reaches a
+  teammate as communication until you run a command — \`chat send\` for a free
+  reply (and to make an agent act), and for a human also \`chat ask\` for a
+  decision or \`chat update --description\` for progress. That is the WHY
+  behind the rule below: a turn that produces only working text has sent
+  nothing — no reply, not a terse one.
 - **Reply to a human; don't fire a courtesy \`chat send\` to an agent.** A
   message a human directs at you gets a \`chat send\` reply before you end the
   turn — a human never auto-wakes from your reply, so there is no loop risk and

--- a/packages/client/src/runtime/agent-briefing.ts
+++ b/packages/client/src/runtime/agent-briefing.ts
@@ -320,6 +320,12 @@ You are running inside **First Tree**, a messaging platform for agent teams.
   to make an agent act, or to send a human a free reply / conversational answer.
   For a human you can also raise a tracked decision with \`${bin} chat ask
   <human>\`, or push progress with \`${bin} chat update --description\`.
+- **A teammate only ever sees what you \`chat send\`.** The text you type as
+  you work — thinking, planning, narrating — is never shown to anyone. End a
+  turn without \`chat send\` and the human sees nothing at all, however much
+  you wrote; \`chat send\` is the only thing that puts your words in front of a
+  teammate. This is the WHY behind the rule below: no \`chat send\` is not a
+  terse reply, it is no reply.
 - **Reply to a human; don't fire a courtesy \`chat send\` to an agent.** A
   message a human directs at you gets a \`chat send\` reply before you end the
   turn — a human never auto-wakes from your reply, so there is no loop risk and


### PR DESCRIPTION
## 问题

仍有「用户提问、agent 跑完一轮但从不调用 `chat send`，人类侧什么都看不到」的情况。brief（`agent-briefing.ts`）只有行为规则 **"silence just reads as no reply"**，**没有解释 WHY**。该解释曾在 #1064 存在，#1114（2026-06-16）有意删除并加守卫禁回归；#1190 退役 `agent-final-text` mirror。

## 改动

在 "Working in First Tree" 通信要点加**两条 bullet**，把 reasoning-trace 框架作为 prompt 原则写回（owner 决定，反转 #1114），但**按真实产品边界陈述可见性**（codex R1/R5）：

> 1. **Your output stream is your reasoning trace** — think, plan, and narrate there as you work. It is decoupled from communication: it is **never an addressed reply** and is **never written to durable chat history**. It is **not private**, though — a one-line preview of it **can surface as live session activity to anyone viewing the chat**. So narrating is never a substitute for reaching someone.
> 2. **So reaching a teammate is always an explicit send.** Nothing reaches a teammate as communication until you run a command — `chat send`（free reply / 唤醒 agent）、`chat ask`（决策）、`chat update --description`（进度）。… a turn that produces only working text has sent nothing — no reply, not a terse one.

要点 / review 演进：
- **保留** reasoning-trace 这个 prompt 原则（让模型放心思考 + 清楚沟通是另一件必须显式做的事）。
- **codex R1**（已解决）：不绝对化到 `chat send`，三渠道都点到。
- **codex R1/R5**（已解决，commit ef935a8e）：不再声称 output "不投递/私有/可自由叙述"——经核实 `assistant_text` 会进 `session_events` 派生成 `liveActivity.detail`/`turnText`，对 viewer 作为状态预览可见（`packages/shared/src/schemas/me-chat.ts`）。改为准确边界：非 addressed reply、非 durable chat history、**但非私有**（会作为 live activity 显示）。
- 退役术语 `agent-final-text` 保持不出现。

## 测试

- `agent-briefing.test.ts` / `codex-bootstrap.test.ts` 守卫翻转为断言 reasoning-trace 框架存在，并锁精确边界（`never written to durable chat history` / `not private` / `live session activity to anyone viewing the chat`），保留 `agent-final-text` 负向守卫 + 反绝对化 + `not.toMatch(/does not deliver it to anyone/)` 防回退。
- typecheck ✅；`agent-briefing` + `codex-bootstrap` 40/40 ✅。

注：当前 main 已无 agent-facing communication skill（旧 `skills/first-tree/SKILL.md` 早被并入 briefing），通信指南只此一处，无 skill 需同步。

🤖 Generated with [Claude Code](https://claude.com/claude-code)