### PR TITLE
[codex] Fix chat summary manual expand

### DIFF
--- a/packages/web/src/pages/workspace/center/__tests__/chat-summary.test.ts
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-summary.test.ts
@@ -1,5 +1,11 @@
+// @vitest-environment happy-dom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
 import { describe, expect, it } from "vitest";
-import { descriptionFirstLine } from "../chat-summary.js";
+import { ChatSummary, descriptionFirstLine } from "../chat-summary.js";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
 /**
  * `descriptionFirstLine` powers the collapsed chat-summary bar: it picks the
@@ -72,5 +78,72 @@ describe("descriptionFirstLine", () => {
 
   it("returns an empty string for an all-whitespace description", () => {
     expect(descriptionFirstLine("   \n\n  ")).toBe("");
+  });
+});
+
+describe("ChatSummary", () => {
+  async function renderSummary(scrollEl: HTMLDivElement): Promise<{ container: HTMLDivElement; root: Root }> {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(
+        createElement(ChatSummary, {
+          chatId: "chat-1",
+          description: "Status: shipping **DescBody** soon.",
+          descriptionUpdatedAt: null,
+          lastReadAt: null,
+          freshnessReady: true,
+          scrollContainerRef: { current: scrollEl },
+        }),
+      );
+    });
+    return { container, root };
+  }
+
+  it("keeps a manual expand open when the stream was already scrolled", async () => {
+    localStorage.clear();
+    const scrollEl = document.createElement("div");
+    scrollEl.scrollTop = 120;
+    const { container, root } = await renderSummary(scrollEl);
+    const button = container.querySelector<HTMLButtonElement>('button[aria-label="Expand summary"]');
+    if (!button) throw new Error("summary button missing");
+
+    await act(async () => {
+      button.click();
+    });
+    expect(container.querySelector("strong")?.textContent).toBe("DescBody");
+
+    await act(async () => {
+      scrollEl.dispatchEvent(new Event("scroll"));
+    });
+    expect(container.querySelector("strong")?.textContent).toBe("DescBody");
+
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  it("still collapses after a fresh downward scroll from a manual expand point", async () => {
+    localStorage.clear();
+    const scrollEl = document.createElement("div");
+    scrollEl.scrollTop = 120;
+    const { container, root } = await renderSummary(scrollEl);
+    const button = container.querySelector<HTMLButtonElement>('button[aria-label="Expand summary"]');
+    if (!button) throw new Error("summary button missing");
+
+    await act(async () => {
+      button.click();
+    });
+    expect(container.querySelector("strong")?.textContent).toBe("DescBody");
+
+    await act(async () => {
+      scrollEl.scrollTop = 170;
+      scrollEl.dispatchEvent(new Event("scroll"));
+    });
+    expect(container.querySelector("strong")).toBeNull();
+    expect(container.querySelector<HTMLButtonElement>('button[aria-label="Expand summary"]')).not.toBeNull();
+
+    await act(async () => root.unmount());
+    container.remove();
   });
 });

--- a/packages/web/src/pages/workspace/center/__tests__/chat-summary.test.ts
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-summary.test.ts
@@ -146,4 +146,33 @@ describe("ChatSummary", () => {
     await act(async () => root.unmount());
     container.remove();
   });
+
+  it("expands on the first click from the sticky-collapsed bar", async () => {
+    localStorage.clear();
+    const scrollEl = document.createElement("div");
+    const { container, root } = await renderSummary(scrollEl);
+    const initialButton = container.querySelector<HTMLButtonElement>('button[aria-label="Expand summary"]');
+    if (!initialButton) throw new Error("summary button missing");
+
+    await act(async () => {
+      initialButton.click();
+    });
+    expect(container.querySelector("strong")?.textContent).toBe("DescBody");
+
+    await act(async () => {
+      scrollEl.scrollTop = 120;
+      scrollEl.dispatchEvent(new Event("scroll"));
+    });
+    expect(container.querySelector("strong")).toBeNull();
+
+    const stickyButton = container.querySelector<HTMLButtonElement>('button[aria-label="Expand summary"]');
+    if (!stickyButton) throw new Error("sticky summary button missing");
+    await act(async () => {
+      stickyButton.click();
+    });
+    expect(container.querySelector("strong")?.textContent).toBe("DescBody");
+
+    await act(async () => root.unmount());
+    container.remove();
+  });
 });

--- a/packages/web/src/pages/workspace/center/chat-summary.tsx
+++ b/packages/web/src/pages/workspace/center/chat-summary.tsx
@@ -204,7 +204,7 @@ export function ChatSummary({
 
   const onToggle = useCallback(() => {
     setOpen((prev) => {
-      const next = !prev;
+      const next = scrollCollapsedRef.current ? true : !prev;
       const el = scrollContainerRef.current;
       manualExpandTopRef.current = next && el ? el.scrollTop : null;
       saveManualPref(chatId, next);

--- a/packages/web/src/pages/workspace/center/chat-summary.tsx
+++ b/packages/web/src/pages/workspace/center/chat-summary.tsx
@@ -238,8 +238,7 @@ export function ChatSummary({
       if (top <= SCROLL_RESTORE_PX) {
         manualExpandTopRef.current = null;
       }
-      const collapseTop =
-        manualExpandTop === null ? SCROLL_COLLAPSE_PX : manualExpandTop + SCROLL_COLLAPSE_PX;
+      const collapseTop = manualExpandTop === null ? SCROLL_COLLAPSE_PX : manualExpandTop + SCROLL_COLLAPSE_PX;
       if (top > collapseTop && openRef.current && !scrollCollapsedRef.current) {
         manualExpandTopRef.current = null;
         setScrollCollapsed(true);

--- a/packages/web/src/pages/workspace/center/chat-summary.tsx
+++ b/packages/web/src/pages/workspace/center/chat-summary.tsx
@@ -182,10 +182,15 @@ export function ChatSummary({
   // Manual toggles for the current version always win (see onToggle).
   const decidedForKey = useRef<string | null>(null);
   const entryKey = `${chatId}|${descriptionUpdatedAt ?? ""}`;
+  // When the user manually expands while already scrolled down, sticky-collapse
+  // must not immediately fold the panel on the next scroll event that reports the
+  // same scrollTop. Store the expansion point and require a fresh downward move.
+  const manualExpandTopRef = useRef<number | null>(null);
   useEffect(() => {
     if (!hasDescription || !freshnessReady) return;
     if (decidedForKey.current === entryKey) return;
     decidedForKey.current = entryKey;
+    manualExpandTopRef.current = null;
     setScrollCollapsed(false);
     setUnreadCleared(false);
     if (unread && isStaleSinceLastView(lastReadMs, Date.now())) {
@@ -200,13 +205,15 @@ export function ChatSummary({
   const onToggle = useCallback(() => {
     setOpen((prev) => {
       const next = !prev;
+      const el = scrollContainerRef.current;
+      manualExpandTopRef.current = next && el ? el.scrollTop : null;
       saveManualPref(chatId, next);
       return next;
     });
     setHighlighted(false);
     setUnreadCleared(true);
     setScrollCollapsed(false);
-  }, [chatId]);
+  }, [chatId, scrollContainerRef]);
 
   // Sticky-collapse: while open, scrolling the message stream down folds the
   // header to its one-line bar; returning to the top restores it. Transient —
@@ -227,7 +234,14 @@ export function ChatSummary({
       const top = el.scrollTop;
       const nextScrolled = top > 1;
       if (nextScrolled !== scrolledRef.current) setScrolled(nextScrolled);
-      if (top > SCROLL_COLLAPSE_PX && openRef.current && !scrollCollapsedRef.current) {
+      const manualExpandTop = manualExpandTopRef.current;
+      if (top <= SCROLL_RESTORE_PX) {
+        manualExpandTopRef.current = null;
+      }
+      const collapseTop =
+        manualExpandTop === null ? SCROLL_COLLAPSE_PX : manualExpandTop + SCROLL_COLLAPSE_PX;
+      if (top > collapseTop && openRef.current && !scrollCollapsedRef.current) {
+        manualExpandTopRef.current = null;
         setScrollCollapsed(true);
       } else if (top <= SCROLL_RESTORE_PX && scrollCollapsedRef.current) {
         setScrollCollapsed(false);


### PR DESCRIPTION
## Summary

Fix the pinned task summary so a manual expand from any collapsed summary bar stays open when the message stream is already scrolled down.

## Root cause

There were two visually similar collapsed-bar states:

- default collapsed: `open` is false
- sticky-collapsed after scrolling an open summary: `open` is true, but `scrollCollapsed` hides the body

The original fix handled the default-collapsed case by preventing the next same-position scroll event from immediately re-collapsing the panel. The sticky-collapsed case still failed because the click handler toggled internal `open` from true to false, so the first click on that bar collapsed the internal state instead of expanding the visible panel.

## Changes

- Track the scroll position where a manual expand occurs.
- Require a fresh downward move past the collapse threshold before sticky-collapse folds the summary again.
- Treat a click from sticky-collapsed state as an expand action rather than toggling `open` false.
- Preserve the existing restore-at-top behavior.
- Add regression coverage for:
  - manual expand at an already-scrolled position
  - subsequent downward scrolling still collapsing
  - first-click expand from the sticky-collapsed bar

## Validation

- `pnpm check` — passed
- `pnpm --dir packages/web exec vitest run src/pages/workspace/center/__tests__/chat-summary.test.ts` — 19 tests passed
- `pnpm --filter @first-tree/web typecheck` — passed, design-token guardrails clean
- `pnpm --filter @first-tree/web test` — 124 files / 959 tests passed
- GitHub checks after `ea92b5e7` — passed

No Context Tree PR: this is an implementation-only interaction bug fix and does not change a durable product decision or ownership constraint.