### PR TITLE
fix(client): surface Claude session limit as provider error

### DIFF
--- a/packages/client/src/__tests__/claude-code-session-limit-result.test.ts
+++ b/packages/client/src/__tests__/claude-code-session-limit-result.test.ts
@@ -1,0 +1,153 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parseProviderRetryEventMessage, type SessionEvent } from "@first-tree/shared";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+const SESSION_LIMIT_RESULT = "You've hit your session limit \u00b7 resets 9:50pm (Asia/Shanghai)";
+
+vi.mock("@anthropic-ai/claude-agent-sdk", () => {
+  const fakeQuery = {
+    [Symbol.asyncIterator]() {
+      let step = 0;
+      return {
+        next: async () => {
+          step += 1;
+          if (step === 1) {
+            return {
+              done: false,
+              value: {
+                type: "result",
+                subtype: "success",
+                result: SESSION_LIMIT_RESULT,
+              },
+            };
+          }
+          return { done: true, value: undefined };
+        },
+      };
+    },
+    close: () => {},
+    setModel: async () => {},
+  };
+  return { query: () => fakeQuery };
+});
+
+import { createClaudeCodeHandler } from "../handlers/claude-code.js";
+import { createAgentConfigCache } from "../runtime/agent-config-cache.js";
+import type { SessionContext, TurnOutcome } from "../runtime/handler.js";
+import { mockCtxPlumbing } from "./test-helpers.js";
+
+const AGENT_ID = "019ef431-0000-7000-9000-000000000001";
+
+let workspaceRoot: string;
+
+beforeAll(() => {
+  workspaceRoot = mkdtempSync(join(tmpdir(), "ftt-claude-session-limit-"));
+});
+
+afterAll(() => {
+  rmSync(workspaceRoot, { recursive: true, force: true });
+});
+
+function buildCache() {
+  const stubSdk = {
+    fetchAgentConfig: async () => ({
+      agentId: AGENT_ID,
+      version: 1,
+      payload: { prompt: { append: "" }, model: "", mcpServers: [], env: [], gitRepos: [] },
+      updatedAt: new Date().toISOString(),
+      updatedBy: "test",
+    }),
+  } as unknown as Parameters<typeof createAgentConfigCache>[0]["sdk"];
+  return createAgentConfigCache({ sdk: stubSdk });
+}
+
+describe("claude-code handler — session-limit success result", () => {
+  it("treats the limit notice as a consumed provider error instead of final text", async () => {
+    const sendMessage = vi.fn().mockResolvedValue(undefined);
+    const forwardResult = vi.fn<SessionContext["forwardResult"]>().mockResolvedValue(undefined);
+    const emitted: SessionEvent[] = [];
+    const completed: Array<{ count: number; outcome: TurnOutcome }> = [];
+    const logs: string[] = [];
+
+    const cache = buildCache();
+    await cache.refresh(AGENT_ID);
+
+    const handler = createClaudeCodeHandler({ workspaceRoot, agentConfigCache: cache });
+    const ctx: SessionContext = {
+      agent: {
+        agentId: AGENT_ID,
+        inboxId: "inbox-test",
+        displayName: "test",
+        type: "agent",
+        visibility: "organization",
+        delegateMention: null,
+        metadata: {},
+      },
+      sdk: { serverUrl: "http://test", sendMessage } as unknown as SessionContext["sdk"],
+      chatId: "chat-claude-session-limit",
+      log: (m) => logs.push(m),
+      recordProviderActivity: () => {},
+      emitEvent: (e) => emitted.push(e),
+      ...mockCtxPlumbing({ sendMessage }, "chat-claude-session-limit"),
+      forwardResult,
+      finishTurn: async (messages, outcome) => {
+        completed.push({ count: Array.isArray(messages) ? messages.length : 1, outcome });
+      },
+    };
+
+    await handler.start(
+      {
+        id: "m1",
+        chatId: "chat-claude-session-limit",
+        senderId: "user-1",
+        format: "text",
+        content: "hello",
+        metadata: null,
+      },
+      ctx,
+    );
+    await handler.suspend();
+    await new Promise((r) => setImmediate(r));
+
+    expect(forwardResult).not.toHaveBeenCalled();
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(logs.some((line) => line.includes("Claude Code session limit detected"))).toBe(true);
+
+    const providerPayloads = emitted
+      .filter((event) => event.kind === "error")
+      .map((event) => parseProviderRetryEventMessage(event.payload.message))
+      .filter((payload) => payload !== null);
+    expect(providerPayloads).toHaveLength(1);
+    expect(providerPayloads[0]).toMatchObject({
+      event: "provider_failure_terminal",
+      provider: "claude-code",
+      scope: "provider_turn",
+      category: "provider_capacity",
+      reasonCode: "capacity_wait_required",
+      userSeverity: "warning",
+    });
+
+    expect(
+      emitted.some(
+        (event) =>
+          event.kind === "error" &&
+          event.payload.source === "sdk" &&
+          event.payload.message.includes("Claude Code session limit"),
+      ),
+    ).toBe(true);
+    expect(emitted.some((event) => event.kind === "turn_end" && event.payload.status === "error")).toBe(true);
+    expect(completed).toEqual([
+      {
+        count: 1,
+        outcome: {
+          status: "error",
+          terminal: true,
+          completion: "consumed",
+          reason: "capacity_wait_required",
+        },
+      },
+    ]);
+  });
+});

--- a/packages/client/src/__tests__/claude-stream-error-sniff.test.ts
+++ b/packages/client/src/__tests__/claude-stream-error-sniff.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { detectStreamApiError } from "../handlers/claude-code.js";
+import { detectClaudeSessionLimitResult, detectStreamApiError } from "../handlers/claude-code.js";
 
 /**
  * Task 8 (Bug 6): the `detectStreamApiError` sniffer recognises Claude SDK
@@ -98,5 +98,28 @@ Hope that helps!`.trim();
       const r = detectStreamApiError(`API Error: server returned ${code}`);
       expect(r, `expected detection for ${code}`).not.toBeNull();
     }
+  });
+});
+
+describe("detectClaudeSessionLimitResult", () => {
+  it("flags the Claude Code session-limit success payload", () => {
+    const r = detectClaudeSessionLimitResult("You've hit your session limit \u00b7 resets 9:50pm (Asia/Shanghai)");
+    expect(r).toEqual({ message: "You've hit your session limit \u00b7 resets 9:50pm (Asia/Shanghai)" });
+  });
+
+  it("flags the typographic apostrophe variant", () => {
+    const r = detectClaudeSessionLimitResult("You\u2019ve hit your session limit \u00b7 resets 9:50pm (Asia/Shanghai)");
+    expect(r).not.toBeNull();
+  });
+
+  it("does NOT flag normal text that only mentions a session limit", () => {
+    expect(
+      detectClaudeSessionLimitResult("If you've hit your session limit, wait until the reset time and try again."),
+    ).toBeNull();
+    expect(
+      detectClaudeSessionLimitResult(
+        "You've hit your session limit \u00b7 resets 9:50pm (Asia/Shanghai)\n\nThis is how Claude Code reports it.",
+      ),
+    ).toBeNull();
   });
 });

--- a/packages/client/src/__tests__/provider-retry-policy.test.ts
+++ b/packages/client/src/__tests__/provider-retry-policy.test.ts
@@ -49,6 +49,27 @@ describe("classifyProviderFailure", () => {
     ).toMatchObject({ category: "provider_capacity", reasonCode: "provider_rate_limited" });
   });
 
+  it("maps Claude session limits to unrecoverable provider capacity", () => {
+    const c = classifyProviderFailure(new Error("You've hit your session limit \u00b7 resets 9:50pm (Asia/Shanghai)"), {
+      provider: "claude-code",
+      scope: "provider_turn",
+      source: "stream",
+    });
+    expect(c).toMatchObject({ category: "provider_capacity", reasonCode: "provider_usage_limit" });
+    expect(
+      decideProviderRetry({
+        classification: c,
+        scope: "provider_turn",
+        attempt: 1,
+        replaySafety: "provider_entered",
+      }),
+    ).toMatchObject({
+      action: "stop",
+      reasonCode: "capacity_wait_required",
+      terminalKind: "capacity_wait_required",
+    });
+  });
+
   it("maps network and 5xx failures to transient_transport", () => {
     for (const err of [new Error("fetch failed"), Object.assign(new Error("upstream 503"), { status: 503 })]) {
       expect(classifyProviderFailure(err, { provider: "codex", scope: "provider_turn", source: "sdk" }).category).toBe(

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -154,6 +154,24 @@ export function detectStreamApiError(text: string): { message: string } | null {
   return { message: firstLine };
 }
 
+const CLAUDE_SESSION_LIMIT_RESULT_RE =
+  /^You(?:'|\u2019)ve hit your session limit\b(?:\s*(?:\u00b7|\u2022|-)\s*resets\s+.+)?\.?$/i;
+
+/**
+ * Claude Code can report account/session exhaustion as a `result.success`
+ * payload instead of an SDK error. Treat only the exact runtime notice shape as
+ * a provider capacity failure; normal assistant answers must still flow through
+ * the retired final-text hook.
+ */
+export function detectClaudeSessionLimitResult(text: string): { message: string } | null {
+  if (typeof text !== "string") return null;
+  const trimmed = text.trim();
+  if (trimmed.length === 0 || trimmed.length >= 500) return null;
+  const firstLine = trimmed.split("\n")[0]?.trim() ?? "";
+  if (firstLine.length === 0 || firstLine !== trimmed) return null;
+  return CLAUDE_SESSION_LIMIT_RESULT_RE.test(firstLine) ? { message: firstLine } : null;
+}
+
 const TOOL_RESULT_PREVIEW_LIMIT = 400;
 
 type ToolUseBlock = { type: "tool_use"; id: string; name: string; input: unknown };
@@ -1449,6 +1467,41 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
                 // live events.
                 if (message.result && sessionCtx.chatId) {
                   const resultText = message.result;
+                  const sessionLimit = detectClaudeSessionLimitResult(resultText);
+                  if (sessionLimit) {
+                    const classification = classifyProviderFailure(new Error(sessionLimit.message), {
+                      provider: runtimeProvider,
+                      scope: "provider_turn",
+                      source: "stream",
+                    });
+                    const decision = decideProviderRetry({
+                      classification,
+                      scope: "provider_turn",
+                      attempt: 1,
+                      replaySafety: "provider_entered",
+                    });
+                    sessionCtx.log(
+                      `Claude Code session limit detected (${classification.category}/${classification.reasonCode}): ${sessionLimit.message}`,
+                    );
+                    emitProviderTurnRetryEvent(
+                      sessionCtx,
+                      "provider_failure_terminal",
+                      classification,
+                      decision,
+                      sessionLimit.message,
+                    );
+                    sessionCtx.emitEvent({
+                      kind: "error",
+                      payload: {
+                        source: "sdk",
+                        message: `Claude Code session limit: ${sessionLimit.message}`,
+                      },
+                    });
+                    sessionCtx.emitEvent({ kind: "turn_end", payload: { status: "error" } });
+                    retryCount = 0;
+                    await ackTurnClose("error", decision.reasonCode, providerEnteredPrefix);
+                    continue;
+                  }
                   // Bug 6: SDK sometimes packages its own catch'd API error
                   // as a `result.subtype === "success"` payload. Sniff it so
                   // we surface an error turn instead of silently closing the

--- a/packages/client/src/runtime/provider-retry-policy.ts
+++ b/packages/client/src/runtime/provider-retry-policy.ts
@@ -431,7 +431,7 @@ function isCapacity(text: string, base: Classification, retryAfterMs: number | u
   return (
     retryAfterMs !== undefined ||
     base.reasonCode.includes("rate_limit") ||
-    /rate.?limit|usage limit|quota|insufficient_quota|overloaded|capacity/.test(text)
+    /rate.?limit|usage limit|session limit|quota|insufficient_quota|overloaded|capacity/.test(text)
   );
 }
 
@@ -443,7 +443,7 @@ function isTransportText(text: string): boolean {
 }
 
 function capacityReason(text: string, base: Classification): string {
-  if (/usage limit|quota|insufficient_quota/.test(text)) return "provider_usage_limit";
+  if (/usage limit|session limit|quota|insufficient_quota/.test(text)) return "provider_usage_limit";
   if (/overloaded|capacity/.test(text)) return "provider_overloaded";
   if (/rate.?limit/.test(text) || base.reasonCode.includes("rate_limit")) return "provider_rate_limited";
   return base.reasonCode === "unknown" ? "provider_capacity" : base.reasonCode;


### PR DESCRIPTION
## Summary
- detect Claude Code session-limit success payloads before the normal final-result path
- classify them as provider capacity usage limits and surface the existing terminal provider-error/status path
- keep final text out of chat messages and cover detector, retry policy, and handler integration behavior

## Tests
- `pnpm exec biome check --write packages/client/src/handlers/claude-code.ts packages/client/src/runtime/provider-retry-policy.ts packages/client/src/__tests__/claude-stream-error-sniff.test.ts packages/client/src/__tests__/claude-code-session-limit-result.test.ts packages/client/src/__tests__/provider-retry-policy.test.ts`
- `pnpm --filter @first-tree/client exec vitest run src/__tests__/claude-stream-error-sniff.test.ts src/__tests__/claude-code-session-limit-result.test.ts src/__tests__/provider-retry-policy.test.ts --maxWorkers=2`
- `pnpm --filter @first-tree/client typecheck`
- `pnpm check`
- `pnpm typecheck`
- `pnpm turbo run test --concurrency=2 -- --maxWorkers=2`

Review: codex-reviewer found no blocking issues.