### PR TITLE
[codex] Polish expanded chat summary label

### DIFF
--- a/packages/web/src/pages/chat-summary-preview.tsx
+++ b/packages/web/src/pages/chat-summary-preview.tsx
@@ -7,8 +7,8 @@ import { ChatSummary } from "./workspace/center/chat-summary.js";
  * `app.tsx`). Each demo wraps the summary in a faux white "chat header" + grey
  * "message stream" so the surface reads as it does live: the summary shares the
  * content canvas (`--bg`), set off from the white header (`--bg-raised`) above
- * by a single hairline + the natural bg step. Covers: the auto-expanded "unread
- * + not seen in a while" state (amber highlight), collapsed-with-freshness, the
+ * by a single hairline + the natural bg step. Covers: the auto-expanded unread
+ * summary-version state (amber highlight), collapsed-with-freshness, the
  * no-freshness-data fallback, the empty (renders nothing) case, and first-line
  * heading degradation. Click to expand / collapse. Scroll sticky-collapse + the
  * pinned shadow need the real stream and are verified in the live app.
@@ -121,16 +121,13 @@ export function ChatSummaryPreviewPage() {
         </h1>
         <p className="text-body" style={{ color: "var(--fg-3)" }}>
           Each demo sits under a faux white header and over the grey content canvas, as it does live. Click to expand /
-          collapse. Read-only: no edit affordance; expanded is just the markdown; the freshness ("9 days ago") lives on
-          the bar in both states.
+          collapse. Read-only: no edit affordance; expanded uses a fixed Summary label above the markdown; the freshness
+          ("9 days ago") lives on the bar in both states.
         </p>
       </div>
 
       <section style={{ display: "flex", flexDirection: "column", gap: "var(--sp-6)" }}>
-        <Col
-          label="Unread + not seen in a while"
-          note="auto-expands once + amber highlight · faithful markdown · freshness on the bar"
-        >
+        <Col label="Unread new summary version" note="auto-expands once + amber highlight · freshness on the bar">
           <Demo chatId="preview-unread" description={RICH} descriptionUpdatedAt={hoursAgo(2)} lastReadAt={null} />
         </Col>
 

--- a/packages/web/src/pages/workspace/center/__tests__/chat-summary.test.ts
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-summary.test.ts
@@ -82,24 +82,110 @@ describe("descriptionFirstLine", () => {
 });
 
 describe("ChatSummary", () => {
-  async function renderSummary(scrollEl: HTMLDivElement): Promise<{ container: HTMLDivElement; root: Root }> {
+  const readRecentlyAt = "2026-05-28T12:00:00.000Z";
+  const unreadVersionAt = "2026-05-28T12:01:00.000Z";
+  const newerUnreadVersionAt = "2026-05-28T12:02:00.000Z";
+
+  type SummaryProps = Parameters<typeof ChatSummary>[0];
+
+  function summaryProps(scrollEl: HTMLDivElement, overrides: Partial<SummaryProps> = {}): SummaryProps {
+    return {
+      chatId: "chat-1",
+      description: "Status: shipping **DescBody** soon.",
+      descriptionUpdatedAt: null,
+      lastReadAt: null,
+      freshnessReady: true,
+      scrollContainerRef: { current: scrollEl },
+      ...overrides,
+    };
+  }
+
+  async function renderSummary(
+    scrollEl: HTMLDivElement,
+    overrides: Partial<SummaryProps> = {},
+  ): Promise<{ container: HTMLDivElement; root: Root; rerender: (next: Partial<SummaryProps>) => Promise<void> }> {
     const container = document.createElement("div");
     document.body.appendChild(container);
     const root = createRoot(container);
+    let props = summaryProps(scrollEl, overrides);
     await act(async () => {
-      root.render(
-        createElement(ChatSummary, {
-          chatId: "chat-1",
-          description: "Status: shipping **DescBody** soon.",
-          descriptionUpdatedAt: null,
-          lastReadAt: null,
-          freshnessReady: true,
-          scrollContainerRef: { current: scrollEl },
-        }),
-      );
+      root.render(createElement(ChatSummary, props));
     });
-    return { container, root };
+    return {
+      container,
+      root,
+      rerender: async (next: Partial<SummaryProps>) => {
+        props = { ...props, ...next };
+        await act(async () => {
+          root.render(createElement(ChatSummary, props));
+        });
+      },
+    };
   }
+
+  it("auto-expands an unread summary version on entry even when the chat was read recently", async () => {
+    localStorage.clear();
+    const scrollEl = document.createElement("div");
+    const { container, root } = await renderSummary(scrollEl, {
+      descriptionUpdatedAt: unreadVersionAt,
+      lastReadAt: readRecentlyAt,
+    });
+
+    expect(container.querySelector<HTMLButtonElement>('button[aria-label="Collapse summary"]')?.textContent).toContain(
+      "Summary",
+    );
+    expect(container.querySelector("strong")?.textContent).toBe("DescBody");
+
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  it("does not auto-expand the same unread summary version after the user manually collapses it", async () => {
+    localStorage.clear();
+    const scrollEl = document.createElement("div");
+    const unreadProps = {
+      descriptionUpdatedAt: unreadVersionAt,
+      lastReadAt: readRecentlyAt,
+    };
+    const first = await renderSummary(scrollEl, unreadProps);
+    const collapseButton = first.container.querySelector<HTMLButtonElement>('button[aria-label="Collapse summary"]');
+    if (!collapseButton) throw new Error("summary collapse button missing");
+    await act(async () => {
+      collapseButton.click();
+    });
+    await act(async () => first.root.unmount());
+    first.container.remove();
+
+    const second = await renderSummary(scrollEl, unreadProps);
+    expect(second.container.querySelector<HTMLButtonElement>('button[aria-label="Expand summary"]')).not.toBeNull();
+    expect(second.container.querySelector("strong")).toBeNull();
+    expect(second.container.textContent).toContain("Updated");
+
+    await act(async () => second.root.unmount());
+    second.container.remove();
+  });
+
+  it("keeps the current mounted chat collapsed when a newer unread summary version arrives", async () => {
+    localStorage.clear();
+    const scrollEl = document.createElement("div");
+    const { container, root, rerender } = await renderSummary(scrollEl, {
+      descriptionUpdatedAt: readRecentlyAt,
+      lastReadAt: unreadVersionAt,
+    });
+    expect(container.querySelector<HTMLButtonElement>('button[aria-label="Expand summary"]')).not.toBeNull();
+
+    await rerender({
+      descriptionUpdatedAt: newerUnreadVersionAt,
+      lastReadAt: unreadVersionAt,
+    });
+
+    expect(container.querySelector<HTMLButtonElement>('button[aria-label="Expand summary"]')).not.toBeNull();
+    expect(container.querySelector("strong")).toBeNull();
+    expect(container.textContent).toContain("Updated");
+
+    await act(async () => root.unmount());
+    container.remove();
+  });
 
   it("keeps a manual expand open when the stream was already scrolled", async () => {
     localStorage.clear();
@@ -112,6 +198,9 @@ describe("ChatSummary", () => {
     await act(async () => {
       button.click();
     });
+    expect(container.querySelector<HTMLButtonElement>('button[aria-label="Collapse summary"]')?.textContent).toContain(
+      "Summary",
+    );
     expect(container.querySelector("strong")?.textContent).toBe("DescBody");
 
     await act(async () => {
@@ -134,6 +223,9 @@ describe("ChatSummary", () => {
     await act(async () => {
       button.click();
     });
+    expect(container.querySelector<HTMLButtonElement>('button[aria-label="Collapse summary"]')?.textContent).toContain(
+      "Summary",
+    );
     expect(container.querySelector("strong")?.textContent).toBe("DescBody");
 
     await act(async () => {
@@ -157,6 +249,9 @@ describe("ChatSummary", () => {
     await act(async () => {
       initialButton.click();
     });
+    expect(container.querySelector<HTMLButtonElement>('button[aria-label="Collapse summary"]')?.textContent).toContain(
+      "Summary",
+    );
     expect(container.querySelector("strong")?.textContent).toBe("DescBody");
 
     await act(async () => {

--- a/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
@@ -1427,10 +1427,38 @@ describe("ChatView", () => {
       await act(async () => {
         button.click();
       });
+      expect(chatSummaryButton(container)?.textContent).toContain("Summary");
+      expect(chatSummaryButton(container)?.textContent).not.toContain("Status: shipping DescBody soon.");
       await waitForCondition(
         () => [...container.querySelectorAll("strong")].some((el) => el.textContent === "DescBody"),
         "Expected the expanded summary to render the description markdown",
       );
+
+      await act(async () => root.unmount());
+    });
+
+    it("auto-expands an unread summary version on entry", async () => {
+      localStorage.clear();
+      const { ChatView } = await import("../chat-view.js");
+      const unreadDescription = chatDetail({
+        description: DESCRIPTION_MD,
+        descriptionUpdatedAt: "2026-05-28T12:05:00.000Z",
+        lastReadAt: "2026-05-28T12:00:00.000Z",
+      });
+      chatMocks.getChat.mockResolvedValue(unreadDescription);
+      const { container, root } = await renderDom(
+        <ChatView agentId="agent-1" chatId="chat-1" />,
+        (queryClient) => seedChat(queryClient, unreadDescription),
+        "/",
+      );
+
+      await waitForCondition(
+        () =>
+          chatSummaryButton(container)?.getAttribute("aria-label") === "Collapse summary" &&
+          [...container.querySelectorAll("strong")].some((el) => el.textContent === "DescBody"),
+        "Expected the unread summary version to auto-expand on entry",
+      );
+      expect(chatSummaryButton(container)?.textContent).toContain("Summary");
 
       await act(async () => root.unmount());
     });

--- a/packages/web/src/pages/workspace/center/chat-summary.tsx
+++ b/packages/web/src/pages/workspace/center/chat-summary.tsx
@@ -26,23 +26,18 @@ import { formatRelative } from "../../../lib/utils.js";
  *     an "Updated" chip when there's an unread change, the freshness
  *     ("9 days ago"), and a quiet chevron. Freshness shows in BOTH states, so an
  *     auto-expanded summary still surfaces when it last changed.
- *   - Expanded: just the description rendered as markdown — no footer. Read-only
- *     is self-evident (no edit affordance anywhere); the updater name is not
- *     shown (single-agent maintenance makes it noise — the data stays on the
- *     chat detail).
+ *   - Expanded: a fixed "Summary" control label plus the description rendered
+ *     as markdown — no footer. Read-only is self-evident (no edit affordance
+ *     anywhere); the updater name is not shown (single-agent maintenance makes
+ *     it noise — the data stays on the chat detail).
  *
- * Auto behavior: default collapsed; auto-expand once on entry ONLY when the
- * update is unread AND the viewer hasn't looked in a while; while expanded,
- * scrolling the stream folds it to the bar (restores at the top); a manual
- * toggle always wins and is remembered per chat. Renders nothing when the chat
- * has no description.
+ * Auto behavior: default collapsed; auto-expand once on entry when the update
+ * is unread for this viewer, unless they already manually dismissed this exact
+ * summary version; while expanded, scrolling the stream folds it to the bar
+ * (restores at the top); a manual toggle always wins and is remembered per
+ * chat. Renders nothing when the chat has no description.
  */
 
-// Auto-expand "haven't looked in a while" gate: an unread description update
-// only pops the header open on entry when the viewer last read this chat at
-// least this long ago — or on an earlier calendar day. Long enough that a quick
-// tab-away-and-back doesn't re-pop the panel.
-const STALE_SINCE_VIEW_MS = 8 * 60 * 60 * 1000;
 // Scroll sticky-collapse thresholds (px from the stream top). The hysteresis
 // gap (40 vs 6) debounces the boundary so a hair of scroll doesn't flutter it.
 const SCROLL_COLLAPSE_PX = 40;
@@ -51,6 +46,10 @@ const SCROLL_RESTORE_PX = 6;
 // Per-chat manual expand/collapse preference. Mirrors the localStorage pattern
 // used elsewhere in the chat view (private-mode safe, per-chat key suffix).
 const MANUAL_PREF_KEY = "first-tree:chat-summary-expanded:v1";
+// Per-chat summary version the user has explicitly collapsed while it was
+// unread. This suppresses repeat auto-open for the same `descriptionUpdatedAt`
+// while still allowing the next summary update to surface.
+const DISMISSED_VERSION_KEY = "first-tree:chat-summary-dismissed-version:v1";
 
 function loadManualPref(chatId: string): boolean | null {
   if (typeof window === "undefined") return null;
@@ -67,6 +66,34 @@ function saveManualPref(chatId: string, expanded: boolean): void {
   if (typeof window === "undefined") return;
   try {
     window.localStorage.setItem(`${MANUAL_PREF_KEY}:${chatId}`, expanded ? "1" : "0");
+  } catch {
+    // localStorage may be unavailable (private mode); ignore.
+  }
+}
+
+function loadDismissedVersion(chatId: string): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage.getItem(`${DISMISSED_VERSION_KEY}:${chatId}`);
+  } catch {
+    return null;
+  }
+}
+
+function saveDismissedVersion(chatId: string, version: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(`${DISMISSED_VERSION_KEY}:${chatId}`, version);
+  } catch {
+    // localStorage may be unavailable (private mode); ignore.
+  }
+}
+
+function clearDismissedVersion(chatId: string, version: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    const key = `${DISMISSED_VERSION_KEY}:${chatId}`;
+    if (window.localStorage.getItem(key) === version) window.localStorage.removeItem(key);
   } catch {
     // localStorage may be unavailable (private mode); ignore.
   }
@@ -119,13 +146,6 @@ export function descriptionFirstLine(description: string): string {
   return headingFallback;
 }
 
-function isStaleSinceLastView(lastReadAtMs: number | null, nowMs: number): boolean {
-  if (lastReadAtMs === null) return true; // never read this chat → treat as "a while"
-  if (nowMs - lastReadAtMs >= STALE_SINCE_VIEW_MS) return true;
-  // A different calendar day also counts as "haven't looked in a while".
-  return new Date(lastReadAtMs).toDateString() !== new Date(nowMs).toDateString();
-}
-
 export function ChatSummary({
   chatId,
   description,
@@ -171,49 +191,67 @@ export function ChatSummary({
   const [scrolled, setScrolled] = useState(false);
   const [unreadCleared, setUnreadCleared] = useState(false);
 
-  // Decide the entry state, after the real detail has settled, keyed by chat AND
-  // the description's freshness version (`descriptionUpdatedAt`): auto-expand +
-  // highlight only when the update is unread AND the viewer hasn't looked in a
-  // while; otherwise honor their remembered per-chat preference (default
-  // collapsed). Keying on the version (not just chatId) means a NEW description
-  // update re-asserts its unread cue / auto-expand even within the same open
-  // chat, instead of being suppressed by a once-per-chat guard — while the
-  // user's manual collapse/expand preference is still remembered per chat.
-  // Manual toggles for the current version always win (see onToggle).
+  // Decide the entry state after the real detail has settled. A newly entered
+  // chat auto-opens an unread summary version once; manually collapsing that
+  // version suppresses repeat auto-open. If the summary updates while the user
+  // is already in the chat, do not suddenly expand the reading pane — show the
+  // Updated chip in the collapsed bar instead.
   const decidedForKey = useRef<string | null>(null);
   const entryKey = `${chatId}|${descriptionUpdatedAt ?? ""}`;
+  const activeChatIdRef = useRef<string | null>(null);
   // When the user manually expands while already scrolled down, sticky-collapse
   // must not immediately fold the panel on the next scroll event that reports the
   // same scrollTop. Store the expansion point and require a fresh downward move.
   const manualExpandTopRef = useRef<number | null>(null);
   useEffect(() => {
-    if (!hasDescription || !freshnessReady) return;
+    if (!freshnessReady) return;
     if (decidedForKey.current === entryKey) return;
+    const enteringChat = activeChatIdRef.current !== chatId;
+    activeChatIdRef.current = chatId;
     decidedForKey.current = entryKey;
+    setUnreadCleared(false);
+    if (!hasDescription) {
+      manualExpandTopRef.current = null;
+      setOpen(false);
+      setScrollCollapsed(false);
+      setHighlighted(false);
+      return;
+    }
+    if (!enteringChat) {
+      setHighlighted(false);
+      return;
+    }
     manualExpandTopRef.current = null;
     setScrollCollapsed(false);
-    setUnreadCleared(false);
-    if (unread && isStaleSinceLastView(lastReadMs, Date.now())) {
+    const dismissedVersion = loadDismissedVersion(chatId);
+    if (unread && descriptionUpdatedAt && dismissedVersion !== descriptionUpdatedAt) {
       setOpen(true);
       setHighlighted(true);
     } else {
       setOpen(loadManualPref(chatId) ?? false);
       setHighlighted(false);
     }
-  }, [entryKey, chatId, hasDescription, freshnessReady, unread, lastReadMs]);
+  }, [entryKey, chatId, descriptionUpdatedAt, hasDescription, freshnessReady, unread]);
 
   const onToggle = useCallback(() => {
     setOpen((prev) => {
       const next = scrollCollapsedRef.current ? true : !prev;
       const el = scrollContainerRef.current;
       manualExpandTopRef.current = next && el ? el.scrollTop : null;
+      if (descriptionUpdatedAt) {
+        if (next) {
+          clearDismissedVersion(chatId, descriptionUpdatedAt);
+        } else if (unread) {
+          saveDismissedVersion(chatId, descriptionUpdatedAt);
+        }
+      }
       saveManualPref(chatId, next);
       return next;
     });
     setHighlighted(false);
     setUnreadCleared(true);
     setScrollCollapsed(false);
-  }, [chatId, scrollContainerRef]);
+  }, [chatId, descriptionUpdatedAt, scrollContainerRef, unread]);
 
   // Sticky-collapse: while open, scrolling the message stream down folds the
   // header to its one-line bar; returning to the top restores it. Transient —
@@ -291,14 +329,15 @@ export function ChatSummary({
         <span
           className="text-body min-w-0 flex-1"
           style={{
-            color: firstLine ? "var(--fg)" : "var(--fg-3)",
+            color: expanded || firstLine ? "var(--fg)" : "var(--fg-3)",
             whiteSpace: "nowrap",
             overflow: "hidden",
             textOverflow: "ellipsis",
-            fontStyle: firstLine ? undefined : "italic",
+            fontStyle: !expanded && !firstLine ? "italic" : undefined,
+            fontWeight: expanded ? 600 : undefined,
           }}
         >
-          {firstLine || "No summary yet"}
+          {expanded ? "Summary" : firstLine || "No summary yet"}
         </span>
         {showAmberChip ? (
           <span
@@ -335,7 +374,7 @@ export function ChatSummary({
       </button>
 
       {expanded ? (
-        <div style={{ padding: "0 var(--sp-6) var(--sp-3)" }}>
+        <div style={{ padding: "var(--sp-1) var(--sp-6) var(--sp-3)" }}>
           <div className="text-body" style={{ color: "var(--fg)", maxHeight: "min(46vh, 30rem)", overflowY: "auto" }}>
             {/* Faithful markdown render. Headings are flattened to body size so
                 hierarchy is carried by weight + spacing (mirrors the rail's old


### PR DESCRIPTION
## Summary

Polish the pinned chat summary expanded state and make unread summary auto-open behavior version-based instead of time-gated.

## Changes

- Show `Summary` in the expanded summary header while keeping the collapsed bar preview as the description's first line.
- Give the expanded label a slightly stronger weight and add a small top padding before the rendered markdown body.
- Replace the old `8 hours / cross-day / never read` auto-open gate with summary-version behavior:
  - auto-expand on chat entry when `descriptionUpdatedAt` is newer than `lastReadAt`
  - remember a manual collapse for that exact `chatId + descriptionUpdatedAt` version so the same unread summary does not keep popping open
  - allow the next summary version to auto-open again
  - avoid suddenly expanding while the user is already mounted in the same chat; the collapsed bar still shows `Updated`
- Update the DEV chat-summary preview copy so it matches the version-based behavior.
- Add regression coverage for unread-version entry auto-open, same-version manual dismissal, in-chat update behavior, and expanded-state label/body separation.

## Validation

- `git diff --check` — passed
- `pnpm check` — passed with existing unrelated warnings/info
- `pnpm --dir packages/web exec vitest run src/pages/workspace/center/__tests__/chat-summary.test.ts src/pages/workspace/center/__tests__/chat-view-dom.test.tsx` — 2 files / 43 tests passed
- `pnpm --filter @first-tree/web typecheck` — passed, design-token guardrails clean
- `pnpm --filter @first-tree/web test` — 124 files / 963 tests passed

No Context Tree PR: this is implementation-level Workspace summary behavior polish; it follows the existing attention/work-stream model and does not introduce a new durable product taxonomy or ownership constraint.