### PR TITLE
fix: rebind harness "user" to runtime so agents reliably chat send

### DIFF
--- a/packages/client/src/__tests__/agent-briefing.test.ts
+++ b/packages/client/src/__tests__/agent-briefing.test.ts
@@ -428,17 +428,20 @@ describe("buildAgentBriefing — # Working in First Tree subsections", () => {
     expect(briefing).toContain("first-tree chat update --description");
     expect(briefing).not.toMatch(/server rejects a `?chat send`? to a human/);
 
-    // yuezengwu 2026-06-23: reinstate the "your output stream is your reasoning
-    // trace" framing as a deliberate prompt principle (reverses the 2026-06-16
-    // removal), but with the PRECISE product boundary (codex R1/R5): the output
-    // stream is not an addressed reply and not durable chat history, yet it is
-    // NOT private — a one-line preview surfaces as live session activity
-    // (`liveActivity.detail` / `turnText`) to viewers. So communication is
-    // always an explicit send, and narration is never a substitute for it.
-    expect(briefing).toMatch(/output stream is your reasoning trace/i);
-    expect(briefing).toMatch(/never written to durable\s+chat history/i);
+    // yuezengwu 2026-06-23: rebind, rather than negate, the base Claude Code
+    // harness ("all text you output … is displayed to the user"). The brief
+    // pins the harness's "user" to the First Tree runtime and frames teammates
+    // as a separate audience reached only by an explicit send (console vs
+    // outbox). Keep the PRECISE product boundary (codex R1/R5): the output
+    // stream is not an addressed reply, yet it is NOT private — a one-line
+    // preview surfaces as live session activity (`liveActivity.detail` /
+    // `turnText`) to viewers. So communication is always an explicit send.
+    expect(briefing).toMatch(/the "user" the Claude Code harness writes to is the First Tree runtime/i);
+    expect(briefing).toMatch(/reasoning\/activity\s+trace/i);
+    expect(briefing).toMatch(/never delivered to\s+anyone as a message/i);
     expect(briefing).toMatch(/not\s+private/i);
-    expect(briefing).toMatch(/live session\s+activity to anyone viewing the chat/i);
+    expect(briefing).toMatch(/live session activity/i);
+    expect(briefing).toMatch(/console; `?chat send`? is the outbox/i);
     expect(briefing).toMatch(/has sent\s+nothing/);
     // The retired mirror term stays out — there is no `agent-final-text` row
     // post-#1190.

--- a/packages/client/src/__tests__/agent-io.test.ts
+++ b/packages/client/src/__tests__/agent-io.test.ts
@@ -86,7 +86,24 @@ describe("formatInboundContent", () => {
       content: "hello",
       metadata: null,
     };
-    expect(await formatInboundContent(msg, cache)).toBe("[From: alice]\n\nhello");
+    expect(await formatInboundContent(msg, cache)).toBe("[From: alice · type=agent]\n\nhello");
+  });
+
+  it("annotates the header with the sender type and send time when both are known", async () => {
+    const sdk = mkSdk(async () => participants);
+    const cache = createParticipantCache(sdk, "chat-1", () => {});
+    const msg: SessionMessage = {
+      id: "m1",
+      chatId: "chat-1",
+      senderId: "agent-a",
+      format: "text",
+      content: "hello",
+      metadata: null,
+      createdAt: "2026-01-01T00:00:00.000Z",
+    };
+    expect(await formatInboundContent(msg, cache)).toBe(
+      "[From: alice · type=agent · sent=2026-01-01T00:00:00.000Z]\n\nhello",
+    );
   });
 
   it("falls back to senderId in the prefix when the sender is not a participant", async () => {
@@ -114,7 +131,9 @@ describe("formatInboundContent", () => {
       content: { title: "hi" },
       metadata: null,
     };
-    expect(await formatInboundContent(msg, cache)).toBe(`[From: alice]\n\n${JSON.stringify({ title: "hi" })}`);
+    expect(await formatInboundContent(msg, cache)).toBe(
+      `[From: alice · type=agent]\n\n${JSON.stringify({ title: "hi" })}`,
+    );
   });
 
   it("omits the attribution prefix when senderId is empty", async () => {
@@ -152,7 +171,7 @@ describe("formatInboundContent", () => {
     // Bytes never landed on this client (no `writeImage` ran in the test
     // harness) so each attachment surfaces the not-available placeholder.
     // The point: caption + per-image lines, not a `{"caption":"…"}` blob.
-    expect(out).toContain("[From: alice]");
+    expect(out).toContain("[From: alice · type=agent]");
     expect(out).toContain("look at these");
     expect(out).toContain("2 images were shared");
     expect(out).toContain("a.png");
@@ -176,7 +195,7 @@ describe("formatInboundContent", () => {
       metadata: null,
     };
     const out = await formatInboundContent(msg, cache);
-    expect(out).toContain("[From: alice]");
+    expect(out).toContain("[From: alice · type=agent]");
     expect(out).toContain("legacy.png");
     expect(out).not.toContain('{"imageId"');
   });
@@ -271,7 +290,7 @@ describe("formatInboundContent", () => {
           format: "text",
           content: "anyone seen the report?",
           metadata: {},
-          createdAt: new Date().toISOString(),
+          createdAt: "2026-01-01T00:00:00.000Z",
         },
         {
           id: "m2",
@@ -279,19 +298,19 @@ describe("formatInboundContent", () => {
           format: "text",
           content: "yeah, working on it",
           metadata: {},
-          createdAt: new Date().toISOString(),
+          createdAt: "2026-01-01T00:00:01.000Z",
         },
       ],
     };
     const out = await formatInboundContent(msg, cache);
     expect(out).toContain("[Earlier in chat — context you missed]");
-    expect(out).toContain("[From: alice] anyone seen the report?");
-    expect(out).toContain("[From: bob] yeah, working on it");
+    expect(out).toContain("[From: alice · type=agent · sent=2026-01-01T00:00:00.000Z] anyone seen the report?");
+    expect(out).toContain("[From: bob · type=agent · sent=2026-01-01T00:00:01.000Z] yeah, working on it");
     expect(out).toContain("[Now — message that woke you]");
-    expect(out).toContain("[From: carol]\n\n@me what do you think?");
+    expect(out).toContain("[From: carol · type=agent]\n\n@me what do you think?");
     // Ordering: earlier block must precede the trigger.
     expect(out.indexOf("[Earlier in chat")).toBeLessThan(out.indexOf("[Now — message"));
-    expect(out.indexOf("[Now — message")).toBeLessThan(out.indexOf("[From: carol]"));
+    expect(out.indexOf("[Now — message")).toBeLessThan(out.indexOf("[From: carol · type=agent]"));
   });
 
   it("serializes structured preceding message content", async () => {
@@ -312,14 +331,16 @@ describe("formatInboundContent", () => {
           format: "card",
           content: { title: "earlier" },
           metadata: {},
-          createdAt: new Date().toISOString(),
+          createdAt: "2026-01-01T00:00:00.000Z",
         },
       ],
     };
 
     const out = await formatInboundContent(msg, cache);
 
-    expect(out).toContain(`[From: alice] ${JSON.stringify({ title: "earlier" })}`);
+    expect(out).toContain(
+      `[From: alice · type=agent · sent=2026-01-01T00:00:00.000Z] ${JSON.stringify({ title: "earlier" })}`,
+    );
   });
 
   it("omits the [Earlier in chat] block when precedingMessages is empty / absent", async () => {
@@ -335,7 +356,7 @@ describe("formatInboundContent", () => {
       precedingMessages: [],
     };
     const out = await formatInboundContent(msg, cache);
-    expect(out).toBe("[From: alice]\n\nhi");
+    expect(out).toBe("[From: alice · type=agent]\n\nhi");
     expect(out).not.toContain("[Earlier in chat");
   });
 });

--- a/packages/client/src/__tests__/chat-context.test.ts
+++ b/packages/client/src/__tests__/chat-context.test.ts
@@ -1,7 +1,11 @@
 import type { ChatDetail, ChatParticipantDetail } from "@first-tree/shared";
 import { describe, expect, it, vi } from "vitest";
 import { fetchChatContext } from "../runtime/chat-context.js";
-import { renderChatContextPrompt, renderChatContextSection } from "../runtime/chat-context-section.js";
+import {
+  renderChatContextPrompt,
+  renderChatContextSection,
+  renderRuntimeOutputContract,
+} from "../runtime/chat-context-section.js";
 
 function mkParticipant(extras: Partial<ChatParticipantDetail>): ChatParticipantDetail {
   return {
@@ -38,6 +42,37 @@ function mkChatDetail(overrides?: Partial<ChatDetail>): ChatDetail {
     ...overrides,
   };
 }
+
+describe("renderRuntimeOutputContract", () => {
+  // The contract resolves the base-harness conflict by REBINDING "the user"
+  // (runtime, not teammates) rather than negating "output is displayed to the
+  // user". Pin the three load-bearing framings + the accurate visibility
+  // boundary so a future edit can't silently gut or over-claim them.
+  const contract = renderRuntimeOutputContract();
+
+  it("rebinds the harness 'user' to the First Tree runtime", () => {
+    expect(contract).toMatch(/that user is the First Tree runtime/i);
+  });
+
+  it("frames reach as an explicit outbound publish (console vs outbox)", () => {
+    expect(contract).toMatch(/outbound publish to the chat service/i);
+    expect(contract).toMatch(/output stream is the console; `chat send` is the outbox/i);
+    expect(contract).toContain("`chat send`");
+    expect(contract).toContain("`chat ask`");
+    expect(contract).toContain("`chat update`");
+  });
+
+  it("keeps the visibility boundary accurate — not private, but never a delivered message", () => {
+    expect(contract).toMatch(/it is not private/i);
+    expect(contract).toMatch(/never delivered to anyone as a message/i);
+    // Must not over-claim that nobody ever sees the trace.
+    expect(contract).not.toMatch(/no one (?:can )?sees?/i);
+  });
+
+  it("does not resurrect the retired agent-final-text mirror term", () => {
+    expect(contract).not.toContain("agent-final-text");
+  });
+});
 
 describe("fetchChatContext", () => {
   it("returns a narrow ChatContext with only name/displayName/type for participants", async () => {

--- a/packages/client/src/__tests__/claude-query-options.test.ts
+++ b/packages/client/src/__tests__/claude-query-options.test.ts
@@ -24,8 +24,16 @@ describe("buildClaudeQueryOptions", () => {
   // through SDK `systemPrompt.append` so sibling chats sharing one agent home
   // cannot race on the shared briefing file.
 
-  it("returns an empty slice when there is no payload", () => {
-    expect(buildClaudeQueryOptions(undefined)).toEqual({});
+  it("injects the runtime output contract even with no payload (no model/mcp/effort)", () => {
+    // The runtime output contract does not depend on payload or chatContext, so
+    // it always rides along through `systemPrompt.append`; nothing else is set.
+    const opts = buildClaudeQueryOptions(undefined);
+    expect(opts.systemPrompt).toEqual(expect.objectContaining({ type: "preset", preset: "claude_code" }));
+    expect(opts.systemPrompt?.append).toContain("<first-tree-runtime-contract>");
+    expect(opts.systemPrompt?.append).not.toContain("<first-tree-current-chat-context");
+    expect("model" in opts).toBe(false);
+    expect("mcpServers" in opts).toBe(false);
+    expect("effort" in opts).toBe(false);
   });
 
   it("omits `effort` when reasoningEffort is '' (inherit the local effortLevel)", () => {
@@ -67,8 +75,15 @@ describe("buildClaudeQueryOptions", () => {
         preset: "claude_code",
       }),
     );
-    expect(opts.systemPrompt?.append).toContain('<first-tree-current-chat-context format="json">');
-    expect(opts.systemPrompt?.append).toContain('"chatId": "chat-claude"');
-    expect(opts.systemPrompt?.append).toContain('"name": "alice"');
+    // Both blocks ride in the append: the runtime contract first, the per-chat
+    // context after it.
+    const append = opts.systemPrompt?.append ?? "";
+    expect(append).toContain("<first-tree-runtime-contract>");
+    expect(append).toContain('<first-tree-current-chat-context format="json">');
+    expect(append).toContain('"chatId": "chat-claude"');
+    expect(append).toContain('"name": "alice"');
+    expect(append.indexOf("<first-tree-runtime-contract>")).toBeLessThan(
+      append.indexOf("<first-tree-current-chat-context"),
+    );
   });
 });

--- a/packages/client/src/__tests__/codex-bootstrap.test.ts
+++ b/packages/client/src/__tests__/codex-bootstrap.test.ts
@@ -142,11 +142,12 @@ describe("bootstrapWorkspace — codex briefing + workspace marker", () => {
     expect(briefing).toContain("first-tree-staging chat send");
     // `chat send` reaches any teammate — agent or human; a human also has
     // `chat ask` (decisions) / `chat update --description` (progress). The
-    // output stream is framed as the agent's decoupled reasoning trace, but the
-    // retired `agent-final-text` mirror term must NOT survive (post-#1190).
+    // output stream is reframed as a reasoning/activity trace read by the First
+    // Tree runtime (the harness's "user"), not the teammates — but the retired
+    // `agent-final-text` mirror term must NOT survive (post-#1190).
     expect(briefing).toContain("first-tree-staging chat ask <human>");
     expect(briefing).toContain("first-tree-staging chat update --description");
-    expect(briefing).toMatch(/output stream is your reasoning trace/i);
+    expect(briefing).toMatch(/the "user" the Claude Code harness writes to is the First Tree runtime/i);
     expect(briefing).not.toContain("agent-final-text");
     // The new Skill Map and Context Tree section are now part of every
     // briefing — pin both so a regenerator dropping them doesn't slip past

--- a/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
+++ b/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
@@ -442,8 +442,11 @@ describe("SessionManager edge coverage", () => {
       ],
     });
     expect(formatted).toContain("[Earlier in chat");
-    expect(formatted).toContain("[From: helper] prior text");
-    expect(formatted).toContain("[From: alice]");
+    // Header now carries name + optional type/sent annotations; assert the
+    // attribution prefix and the body rather than the exact bracket close.
+    expect(formatted).toContain("[From: helper");
+    expect(formatted).toContain("prior text");
+    expect(formatted).toContain("[From: alice");
     expect(await ctx.resolveSenderLabel("sender-1")).toBe("alice");
 
     // Final-text delivery is retired: forwardResult writes nothing to chat.

--- a/packages/client/src/__tests__/test-helpers.ts
+++ b/packages/client/src/__tests__/test-helpers.ts
@@ -30,6 +30,7 @@ export function mockCtxPlumbing(
   buildAgentEnv: (env: NodeJS.ProcessEnv) => NodeJS.ProcessEnv;
   formatInboundContent: (msg: SessionMessage) => Promise<string>;
   resolveSenderLabel: (senderId: string) => Promise<string>;
+  formatFromHeader: (msg: SessionMessage) => Promise<string>;
 } {
   return {
     // Turn-completion hook — delivers nothing (final-text mirror retired).
@@ -44,6 +45,7 @@ export function mockCtxPlumbing(
       return msg.senderId ? `[From: ${msg.senderId}]\n\n${raw}` : raw;
     },
     resolveSenderLabel: async (senderId) => senderId,
+    formatFromHeader: async (msg) => (msg.senderId ? `[From: ${msg.senderId}]` : ""),
   };
 }
 

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -30,7 +30,7 @@ import { buildAgentBriefing } from "../runtime/agent-briefing.js";
 import type { AgentConfigCache } from "../runtime/agent-config-cache.js";
 import { type PredeclaredSourceRepo, writeAgentBriefing } from "../runtime/bootstrap.js";
 import { type ChatContext, fetchChatContext } from "../runtime/chat-context.js";
-import { renderChatContextPrompt } from "../runtime/chat-context-section.js";
+import { renderChatContextPrompt, renderRuntimeOutputContract } from "../runtime/chat-context-section.js";
 import { resolveContextTreeRelativePath, toolFileRefsFromShellCommand } from "../runtime/context-tree-file-refs.js";
 import {
   type ContextTreeGitWriteTracker,
@@ -688,12 +688,18 @@ export function buildClaudeQueryOptions(
   if (payload?.kind === "claude-code" && payload.reasoningEffort) {
     options.effort = payload.reasoningEffort;
   }
-  const chatPrompt = renderChatContextPrompt(chatContext);
-  if (chatPrompt) {
+  // The runtime output contract always rides along (it does not depend on
+  // chatContext); the per-chat context block is appended after it when present.
+  // Both live in `systemPrompt.append`, which the SDK places after the
+  // `claude_code` base preset but at higher salience than the project CLAUDE.md.
+  const append = [renderRuntimeOutputContract(), renderChatContextPrompt(chatContext)]
+    .filter((part): part is string => Boolean(part))
+    .join("\n\n");
+  if (append) {
     options.systemPrompt = {
       type: "preset",
       preset: "claude_code",
-      append: chatPrompt,
+      append,
     };
   }
   return options;
@@ -838,10 +844,10 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
     // does not reliably forward `{ type: "image" }` blocks to the underlying
     // model.
     if (message.format === "file") {
-      // Resolve the sender's chat-local name once up front so both branches
-      // emit the same `[From: <name>]` header as the default text path.
-      const senderLabel = message.senderId ? await sessionCtx.resolveSenderLabel(message.senderId) : "";
-      const prefix = senderLabel ? `[From: ${senderLabel}]\n\n` : "";
+      // Build the full attribution header (name · type · sent) once up front so
+      // both branches emit the same `[From: …]` header as the default text path.
+      const header = await sessionCtx.formatFromHeader(message);
+      const prefix = header ? `${header}\n\n` : "";
 
       // Batched send (caption + N images in one message). Resolve every
       // imageId to a local path the Read tool can open; missing-byte cases

--- a/packages/client/src/runtime/agent-briefing.ts
+++ b/packages/client/src/runtime/agent-briefing.ts
@@ -314,24 +314,25 @@ function workingInFirstTreeSection(opts: WorkingInFirstTreeOpts): string {
 You are running inside **First Tree**, a messaging platform for agent teams.
 
 - Messages from other team members arrive as your prompt input. Each message
-  has a \`[From: <agent-name>]\` header — that name is what you pass back to
-  \`chat send\`.
+  has a \`[From: <name> · type=<human|agent> · sent=<timestamp>]\` header — the
+  name is what you pass back to \`chat send\`, \`type\` tells you which reply
+  discipline applies (see below), and \`sent\` is when it was sent. (The
+  annotations are omitted when unknown.)
 - **\`${bin} chat send <name>\` reaches any teammate — agent or human.** Use it
   to make an agent act, or to send a human a free reply / conversational answer.
   For a human you can also raise a tracked decision with \`${bin} chat ask
   <human>\`, or push progress with \`${bin} chat update --description\`.
-- **Your output stream is your reasoning trace** — think, plan, and narrate
-  there as you work. It is decoupled from communication: it is never an
-  addressed reply and is never written to durable chat history. It is not
-  private, though — a one-line preview of it can surface as live session
-  activity to anyone viewing the chat. So narrating is never a substitute for
-  reaching someone.
-- **So reaching a teammate is always an explicit send.** Nothing reaches a
-  teammate as communication until you run a command — \`chat send\` for a free
-  reply (and to make an agent act), and for a human also \`chat ask\` for a
-  decision or \`chat update --description\` for progress. That is the WHY
-  behind the rule below: a turn that produces only working text has sent
-  nothing — no reply, not a terse one.
+- **The "user" the Claude Code harness writes to is the First Tree runtime, not
+  your teammates.** Your output stream is recorded as a live reasoning/activity
+  trace — think, plan, and narrate there freely. It is not private (a one-line
+  preview can surface as live session activity), but it is never delivered to
+  anyone as a message. Your output is the console; \`chat send\` is the outbox.
+- **So reaching a teammate is always an explicit send.** Finishing your thoughts
+  writes the console; it does not send the outbox. Nothing reaches a teammate
+  until you run a command — \`chat send\` for a reply (and to make an agent act),
+  \`chat ask\` for a human decision, \`chat update --description\` for progress.
+  A turn that produces only working text has sent nothing — no reply, not a
+  terse one.
 - **Reply to a human; don't fire a courtesy \`chat send\` to an agent.** A
   message a human directs at you gets a \`chat send\` reply before you end the
   turn — a human never auto-wakes from your reply, so there is no loop risk and

--- a/packages/client/src/runtime/agent-io.ts
+++ b/packages/client/src/runtime/agent-io.ts
@@ -219,6 +219,51 @@ export function resolveSenderLabel(senderId: string, participants: ChatParticipa
 }
 
 /**
+ * Resolve `senderId` → participant `type` ("human" | "agent" | …). Returns
+ * null when the sender is not among the known participants (stale cache /
+ * ex-member) or carries an empty type. The `[From: …]` header surfaces this so
+ * the agent applies the right reply discipline — a human directing a message
+ * requires a `chat send` reply; an agent wake-up with nothing new does not.
+ */
+export function resolveSenderType(senderId: string, participants: ChatParticipantDetail[]): string | null {
+  for (const p of participants) {
+    if (p.agentId !== senderId) continue;
+    return p.type.length > 0 ? p.type : null;
+  }
+  return null;
+}
+
+/**
+ * Build the `[From: …]` attribution line for an inbound message: the sender's
+ * chat-local name plus, when available, the participant `type` and the message
+ * send time (ISO 8601). Both annotations are appended as ` · key=value`
+ * segments and omitted when unknown, so callers without participant or
+ * timestamp data degrade cleanly to the bare `[From: <name>]` form.
+ */
+export function formatFromHeaderLine(
+  senderId: string,
+  createdAt: string | undefined,
+  participants: ChatParticipantDetail[],
+): string {
+  const parts = [resolveSenderLabel(senderId, participants)];
+  const type = resolveSenderType(senderId, participants);
+  if (type) parts.push(`type=${type}`);
+  if (createdAt) parts.push(`sent=${createdAt}`);
+  return `[From: ${parts.join(" · ")}]`;
+}
+
+/**
+ * SessionContext-facing wrapper: resolve the participant cache and build the
+ * `[From: …]` header for `message`, or `""` when it has no sender. Shared by
+ * the runtime text path and the handlers' synthesised (image) path so every
+ * inbound header is framed identically.
+ */
+export async function buildFromHeader(message: SessionMessage, participants: ParticipantCache): Promise<string> {
+  if (!message.senderId) return "";
+  return formatFromHeaderLine(message.senderId, message.createdAt, await participants.get());
+}
+
+/**
  * Produce the handler-facing string form of an inbound message. Prefixes a
  * `[From: <name>]` line when the sender is a known participant. Structured
  * content is serialised to JSON — handlers that want to feed structured
@@ -301,15 +346,14 @@ export async function formatInboundContent(message: SessionMessage, participants
     const ps = await participants.get();
     const lines: string[] = ["[Earlier in chat — context you missed]"];
     for (const p of preceding) {
-      const label = resolveSenderLabel(p.senderId, ps);
       const text = typeof p.content === "string" ? p.content : JSON.stringify(p.content);
-      lines.push(`[From: ${label}] ${text}`);
+      lines.push(`${formatFromHeaderLine(p.senderId, p.createdAt, ps)} ${text}`);
     }
     lines.push("", "[Now — message that woke you]");
     header = `${lines.join("\n")}\n\n`;
   }
 
   if (!message.senderId) return `${header}${rawContent}`;
-  const label = resolveSenderLabel(message.senderId, await participants.get());
-  return `${header}[From: ${label}]\n\n${rawContent}`;
+  const headerLine = formatFromHeaderLine(message.senderId, message.createdAt, await participants.get());
+  return `${header}${headerLine}\n\n${rawContent}`;
 }

--- a/packages/client/src/runtime/chat-context-section.ts
+++ b/packages/client/src/runtime/chat-context-section.ts
@@ -58,6 +58,36 @@ export function renderChatContextSection(chatContext: ChatContext | undefined): 
   return `${lines.join("\n")}\n`;
 }
 
+/**
+ * Provider system-prompt contract that resolves a conflict between the base
+ * Claude Code harness ("all text you output outside of tool calls is displayed
+ * to the user") and First Tree's delivery model, where reaching a teammate
+ * requires an explicit `chat send` / `ask` / `update`.
+ *
+ * Rather than *negating* the base instruction (a downstream, lower-salience
+ * "your output is not a reply" loses to the model's strong prior ~1/3 of the
+ * time), this *rebinds* it: the "user" reading the output stream is the First
+ * Tree runtime; teammates are a separate audience reached only by an explicit
+ * send. It folds three mutually-reinforcing framings — runtime-as-user, reach
+ * = an outbound publish, and console-vs-outbox — into one block, kept accurate
+ * about visibility (the trace is not private; it surfaces as a live-activity
+ * preview). Injected through `systemPrompt.append`, which the SDK places after
+ * the base preset yet at higher salience than the project CLAUDE.md.
+ */
+export function renderRuntimeOutputContract(): string {
+  return [
+    "<first-tree-runtime-contract>",
+    "This block is authored by the First Tree runtime.",
+    "",
+    'Who reads your output: the Claude Code harness tells you that all text you write outside of tool calls is displayed to "the user". Inside First Tree that user is the First Tree runtime — an automated operator that records your output as a live reasoning/activity trace, not a chat participant. Think, plan, and narrate there freely. That trace surfaces to people viewing the session as a one-line activity preview, so it is not private — but it is never delivered to anyone as a message.',
+    "",
+    "Your teammates — the humans and agents in this chat — are a different audience. They never receive your output text. Reaching a teammate is an outbound publish to the chat service that happens only when you run an explicit command: `chat send` (a reply, or to make an agent act), `chat ask` (a tracked decision for a human), or `chat update` (status). Your output stream is the console; `chat send` is the outbox. Finishing your thoughts writes the console; it does not send the outbox.",
+    "",
+    "So answering a teammate is two acts, not one: do the work (console), then deliver the result with `chat send` (outbox). A turn that ends with only output text has told the runtime everything and told the teammate nothing — to them it reads as no reply.",
+    "</first-tree-runtime-contract>",
+  ].join("\n");
+}
+
 function escapePromptJson(value: unknown): string {
   return JSON.stringify(value, null, 2).replace(/[<>&]/g, (char) => {
     switch (char) {

--- a/packages/client/src/runtime/handler.ts
+++ b/packages/client/src/runtime/handler.ts
@@ -204,6 +204,16 @@ export type SessionContext = HandlerContext & {
    * to keep `[From: ...]` attribution consistent with the text path.
    */
   resolveSenderLabel: (senderId: string) => Promise<string>;
+
+  /**
+   * Build the full `[From: <name> · type=<human|agent> · sent=<ts>]`
+   * attribution header for an inbound message — name plus, when known, the
+   * sender's participant type and the message send time. Returns `""` when
+   * the message has no senderId. Handlers that synthesise content (e.g. the
+   * image path) call this so every inbound header is framed identically to
+   * the text path. Async for the same one-time participant fetch.
+   */
+  formatFromHeader: (message: SessionMessage) => Promise<string>;
 };
 
 export function deliveryTokenFromSessionContext(ctx: SessionContext): DeliveryToken {
@@ -233,6 +243,14 @@ export type SessionMessage = {
   content: string | Record<string, unknown>;
   /** Optional metadata. */
   metadata: Record<string, unknown> | null;
+  /**
+   * Server-stamped message creation time (ISO 8601). Carried so the
+   * `[From: …]` attribution header can annotate when a message was sent —
+   * the agent weighs recency. Optional because some synthetic/legacy
+   * SessionMessage construction sites do not have it; the header omits the
+   * `sent=` segment when absent.
+   */
+  createdAt?: string;
   /**
    * Group-chat history the recipient missed (mention_only + not @mentioned)
    * up to this triggering message. Sorted oldest-first. Server attaches and

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -20,7 +20,13 @@ import {
 import type { pino } from "../observability/logger.js";
 import type { FirstTreeHubSDK } from "../sdk.js";
 import type { AgentConfigCache } from "./agent-config-cache.js";
-import { buildAgentEnv, createParticipantCache, formatInboundContent, resolveSenderLabel } from "./agent-io.js";
+import {
+  buildAgentEnv,
+  buildFromHeader,
+  createParticipantCache,
+  formatInboundContent,
+  resolveSenderLabel,
+} from "./agent-io.js";
 import { type ContextTreeBinding, resolveAgentContextTreeBinding } from "./bootstrap.js";
 import type { SessionConfig } from "./config.js";
 import { reresolveUnboundTree } from "./context-tree-rebind.js";
@@ -1989,6 +1995,7 @@ export class SessionManager {
       buildAgentEnv: (parentEnv) => buildAgentEnv(parentEnv, envCtx),
       formatInboundContent: (message) => formatInboundContent(message, participants),
       resolveSenderLabel: async (senderId) => resolveSenderLabel(senderId, await participants.get()),
+      formatFromHeader: (message) => buildFromHeader(message, participants),
     };
   }
 
@@ -2129,6 +2136,7 @@ export class SessionManager {
       format: msg.format,
       content: msg.content as string | Record<string, unknown>,
       metadata: msg.metadata,
+      createdAt: msg.createdAt,
       precedingMessages: msg.precedingMessages ?? [],
     };
   }


### PR DESCRIPTION
## Problem (P0)

Agents on the Claude Code SDK regularly finish a teammate's request, write the answer to the **output stream**, and stop — without ever running `chat send`. The output stream is a reasoning trace that the teammate never receives, so to them it reads as **no reply**. Reproduces on ~1/3 of human-directed turns (worst on "give me an X" code/SQL-producing prompts).

## Root cause

A prompt conflict the brief was losing:

- The base `claude_code` preset asserts: *"all text you output outside of tool use is displayed to the user."* This matches the model's strong trained prior (output = talking to the user).
- The First Tree brief tried to **negate** it ("your output stream is not a reply"). That is a downstream, lower-salience instruction — it loses to the prior a meaningful fraction of the time.

## Fix — rebind, don't negate

Instead of fighting "output is displayed to the user", **rebind who "the user" is**. A new **runtime output contract**:

- pins the harness's *user* to the **First Tree runtime** (an automated operator that records the trace) — so the base sentence stays true but no longer implies a teammate was reached;
- frames **teammates** (human + agent) as a separate audience reached **only** by an explicit `chat send` / `ask` / `update`;
- adds the **console-vs-outbox** metaphor (finishing your thoughts writes the console; it does not send the outbox);
- stays accurate about visibility — the trace is **not private** (it surfaces as a live-activity preview), it is just never delivered as a message.

It is injected through `systemPrompt.append` (`buildClaudeQueryOptions`), which the SDK places after the base preset but at **higher salience than the project `CLAUDE.md`**. The shared brief (`agent-briefing.ts`) is reworded to the same framing so codex (which has no append channel) is covered too.

These three framings (runtime-as-user, reach = outbound publish, console/outbox) were synthesized together per the chat design discussion.

## `[From: …]` header enrichment

The inbound attribution header now carries the sender's **participant type** (human/agent — so the agent applies the right reply discipline) and the **message send time**:

```
[From: alice · type=human · sent=2026-06-23T13:30:00.000Z]
```

Threaded via a new optional `SessionMessage.createdAt` and a shared `formatFromHeader` (`SessionContext`) used by both the text path (`formatInboundContent`) and the image path in `claude-code.ts`, so every header is framed identically. Annotations are omitted when unknown, degrading to the bare `[From: <name>]`.

## Tests

- New `renderRuntimeOutputContract` guards (rebinding, console/outbox, accurate-visibility, no `agent-final-text`).
- New `buildClaudeQueryOptions` guards: contract always injected (even with no payload) and ordered before the per-chat context block.
- New `formatInboundContent` coverage for the `type=` / `sent=` annotations; existing `[From:]` assertions updated to the new format.
- Brief guards (`agent-briefing.test.ts`, `codex-bootstrap.test.ts`) updated from the old "reasoning trace" phrasing to the runtime-as-user framing.

`pnpm --filter @first-tree/client typecheck`, `pnpm check`, and the full client suite (1113 tests) pass.

## Scope

This is **P0** of a broader brief↔base-prompt audit. Follow-ups tracked separately: P1 carve-out for "NEVER create .md docs" vs Context Tree/memory writes, and P1 "NEVER commit unless asked" vs task-completion→PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)