### PR TITLE
chore: temporarily disable the claude-code-tui runtime

### DIFF
--- a/apps/cli/src/__tests__/runtime-auth-login.test.ts
+++ b/apps/cli/src/__tests__/runtime-auth-login.test.ts
@@ -1,6 +1,6 @@
 import { BROWSER_LOGIN_TIMEOUT_MS, type CodexBrowserLoginOptions, type LoginOutcome } from "@first-tree/client";
 import type { CapabilityEntry } from "@first-tree/shared";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { runRuntimeAuthLogin } from "../core/runtime-auth-login.js";
 
 const NOW = Date.parse("2026-06-22T12:00:00.000Z");
@@ -151,6 +151,10 @@ describe("runRuntimeAuthLogin — claude-code browser OAuth (cc/codex parity)", 
   function claudeHarness(opts: { resolveOk?: boolean; outcome?: LoginOutcome; probeResult?: CapabilityEntry }) {
     const calls: Recorded[] = [];
     const logs: string[] = [];
+    // Spy so a test can assert the TUI probe is NOT spawned while claude-code-tui
+    // is disabled (it shares the Claude keychain, but "stop probing it" must hold
+    // on this login-reflection path too).
+    const probeClaudeTui = vi.fn(async (): Promise<CapabilityEntry> => opts.probeResult ?? unauthEntry());
     const deps = {
       currentEntry: (): CapabilityEntry | undefined => undefined,
       setProviderEntry: async (provider: string, entry: CapabilityEntry): Promise<void> => {
@@ -166,50 +170,53 @@ describe("runRuntimeAuthLogin — claude-code browser OAuth (cc/codex parity)", 
           : ({ ok: true, command: "/usr/local/bin/claude", baseArgs: [] as string[] } as const),
       runClaudeBrowser: async (): Promise<LoginOutcome> => opts.outcome ?? ({ ok: true } as const),
       probeClaude: async (): Promise<CapabilityEntry> => opts.probeResult ?? unauthEntry(),
-      // Claude auth is shared with the TUI runtime — re-probe it too.
-      probeClaudeTui: async (): Promise<CapabilityEntry> => opts.probeResult ?? unauthEntry(),
+      probeClaudeTui,
     };
-    return { calls, logs, deps };
+    return { calls, logs, deps, probeClaudeTui };
   }
 
-  it("browser pending, then re-probes BOTH claude-code and claude-code-tui (shared auth)", async () => {
+  // claude-code-tui is in DISABLED_RUNTIME_PROVIDERS, so a claude-code login
+  // reflects claude-code ONLY — the shared-keychain TUI re-probe is suppressed
+  // here exactly as it is in the capability aggregator (no `claude` / tmux spawn,
+  // no tui entry written). If TUI is ever re-enabled, the both-providers path
+  // (Promise.all) takes over again.
+  it("browser pending, then re-probes claude-code only while TUI is disabled (no TUI spawn)", async () => {
     const h = claudeHarness({ outcome: { ok: true }, probeResult: okEntry() });
     await runRuntimeAuthLogin({ provider: "claude-code", ref: "c1" }, h.deps);
 
-    // pending(claude-code) → ok(claude-code) → ok(claude-code-tui)
-    expect(h.calls).toHaveLength(3);
-    expect(h.calls[0]?.provider).toBe("claude-code");
+    // pending(claude-code) → ok(claude-code); no claude-code-tui write.
+    expect(h.calls).toHaveLength(2);
+    expect(h.calls.map((c) => c.provider)).toEqual(["claude-code", "claude-code"]);
     expect(h.calls[0]?.entry.pendingAuth).toEqual({
       method: "browser",
       expiresAt: new Date(NOW + BROWSER_LOGIN_TIMEOUT_MS).toISOString(),
     });
-    const reprobed = h.calls.slice(1);
-    expect(reprobed.map((c) => c.provider).sort()).toEqual(["claude-code", "claude-code-tui"]);
-    for (const c of reprobed) {
-      expect(c.entry.state).toBe("ok");
-      expect(c.entry.pendingAuth).toBeUndefined();
-    }
+    expect(h.calls[1]?.entry.state).toBe("ok");
+    expect(h.calls[1]?.entry.pendingAuth).toBeUndefined();
+    expect(h.calls.some((c) => c.provider === "claude-code-tui")).toBe(false);
+    expect(h.probeClaudeTui).not.toHaveBeenCalled();
   });
 
-  it("on unresolved CLI, reflects real state for both and never logs in", async () => {
+  it("on unresolved CLI, reflects claude-code real state and never logs in (TUI untouched)", async () => {
     const h = claudeHarness({
       resolveOk: false,
       probeResult: { ...unauthEntry(), state: "missing", available: false },
     });
     await runRuntimeAuthLogin({ provider: "claude-code", ref: "c2" }, h.deps);
 
-    expect(h.calls.map((c) => c.provider).sort()).toEqual(["claude-code", "claude-code-tui"]);
+    expect(h.calls.map((c) => c.provider)).toEqual(["claude-code"]);
     expect(h.calls.every((c) => c.entry.state === "missing")).toBe(true);
+    expect(h.probeClaudeTui).not.toHaveBeenCalled();
     expect(h.logs.some((l) => l.includes("claude CLI unavailable"))).toBe(true);
   });
 
-  it("on login failure, stamps lastAuthError on claude-code only (not the shared-keychain tui)", async () => {
+  it("on login failure, stamps lastAuthError on claude-code (TUI not re-probed while disabled)", async () => {
     const h = claudeHarness({ outcome: { ok: false, reason: "timeout", error: "claude auth login timed out" } });
     await runRuntimeAuthLogin({ provider: "claude-code", ref: "c3" }, h.deps);
 
     const cc = h.calls.filter((c) => c.provider === "claude-code").at(-1)?.entry;
-    const tui = h.calls.filter((c) => c.provider === "claude-code-tui").at(-1)?.entry;
     expect(cc?.lastAuthError).toMatchObject({ reason: "timeout", message: "claude auth login timed out" });
-    expect(tui?.lastAuthError).toBeUndefined();
+    expect(h.calls.some((c) => c.provider === "claude-code-tui")).toBe(false);
+    expect(h.probeClaudeTui).not.toHaveBeenCalled();
   });
 });

--- a/apps/cli/src/core/runtime-auth-login.ts
+++ b/apps/cli/src/core/runtime-auth-login.ts
@@ -12,7 +12,12 @@ import {
   runClaudeBrowserLogin,
   runCodexBrowserLogin,
 } from "@first-tree/client";
-import type { CapabilityEntry, PendingAuth, RuntimeAuthFailureReason } from "@first-tree/shared";
+import {
+  type CapabilityEntry,
+  isRuntimeProviderEnabled,
+  type PendingAuth,
+  type RuntimeAuthFailureReason,
+} from "@first-tree/shared";
 
 /**
  * Daemon-side orchestrator for an in-product runtime-auth login.
@@ -179,11 +184,20 @@ async function runClaudeRuntimeAuth(command: RuntimeAuthCommand, deps: RuntimeAu
   // Claude login the user must do — it isn't.
   // A failure stamps `lastAuthError` on the claude-code entry only (the login
   // target); the shared-keychain tui entry just reflects the re-probed state.
+  // While claude-code-tui is disabled (DISABLED_RUNTIME_PROVIDERS), this path
+  // honours the same central switch as the capability aggregator: it must not
+  // spawn the TUI probe (`claude` / tmux) or write a tui entry — a claude-code
+  // login then reflects claude-code only.
   const reflect = async (label: string, failure: AuthFailure | null): Promise<void> => {
     try {
-      const [cc, tui] = await Promise.all([probeClaude(), probeClaudeTui()]);
-      await deps.setProviderEntry("claude-code", attachAuthError(cc, failure, now()));
-      await deps.setProviderEntry("claude-code-tui", tui);
+      if (isRuntimeProviderEnabled("claude-code-tui")) {
+        const [cc, tui] = await Promise.all([probeClaude(), probeClaudeTui()]);
+        await deps.setProviderEntry("claude-code", attachAuthError(cc, failure, now()));
+        await deps.setProviderEntry("claude-code-tui", tui);
+      } else {
+        const cc = await probeClaude();
+        await deps.setProviderEntry("claude-code", attachAuthError(cc, failure, now()));
+      }
     } catch (err) {
       deps.log("⚠️", `runtime-auth: claude re-probe ${label} failed: ${message(err)}`);
     }

--- a/packages/client/src/__tests__/capability-probes.test.ts
+++ b/packages/client/src/__tests__/capability-probes.test.ts
@@ -1153,7 +1153,7 @@ describe("resolveCodexRuntimeBinary (handler-contract parity)", () => {
 });
 
 describe("probeCapabilities (aggregator)", () => {
-  it("returns one entry per built-in provider (probes mocked — no real launches)", async () => {
+  it("probes only the enabled providers (claude-code-tui is temporarily disabled, never invoked)", async () => {
     vi.resetModules();
     const fakeEntry = (state: "ok" | "missing") => ({
       state,
@@ -1165,11 +1165,12 @@ describe("probeCapabilities (aggregator)", () => {
       probeKind: "launch",
       latencyMs: 1,
     });
+    const tuiProbe = vi.fn().mockResolvedValue(fakeEntry("missing"));
     vi.doMock("../runtime/capabilities/claude-code.js", () => ({
       probeClaudeCodeCapability: vi.fn().mockResolvedValue(fakeEntry("ok")),
     }));
     vi.doMock("../runtime/capabilities/claude-code-tui.js", () => ({
-      probeClaudeCodeTuiCapability: vi.fn().mockResolvedValue(fakeEntry("missing")),
+      probeClaudeCodeTuiCapability: tuiProbe,
     }));
     vi.doMock("../runtime/capabilities/codex.js", () => ({
       probeCodexCapability: vi.fn().mockResolvedValue(fakeEntry("ok")),
@@ -1178,10 +1179,13 @@ describe("probeCapabilities (aggregator)", () => {
 
     const caps = await mod.probeCapabilities();
 
-    expect(Object.keys(caps).sort()).toEqual(["claude-code", "claude-code-tui", "codex"]);
+    // claude-code-tui is in DISABLED_RUNTIME_PROVIDERS — it is skipped, so it
+    // gets no capability entry AND its probe is never called (no binary spawn).
+    expect(Object.keys(caps).sort()).toEqual(["claude-code", "codex"]);
     expect(caps["claude-code"]?.state).toBe("ok");
-    expect(caps["claude-code-tui"]?.state).toBe("missing");
+    expect(caps["claude-code-tui"]).toBeUndefined();
     expect(caps.codex?.state).toBe("ok");
+    expect(tuiProbe).not.toHaveBeenCalled();
 
     vi.doUnmock("../runtime/capabilities/claude-code.js");
     vi.doUnmock("../runtime/capabilities/claude-code-tui.js");
@@ -1189,7 +1193,7 @@ describe("probeCapabilities (aggregator)", () => {
     vi.resetModules();
   });
 
-  it("converts provider probe rejections into error capability entries", async () => {
+  it("converts enabled-provider probe rejections into error capability entries", async () => {
     vi.resetModules();
     vi.doMock("../runtime/capabilities/claude-code.js", () => ({
       probeClaudeCodeCapability: vi.fn().mockRejectedValue(new Error("claude probe failed")),
@@ -1212,7 +1216,8 @@ describe("probeCapabilities (aggregator)", () => {
       error: "claude probe failed",
     });
     expect(caps.codex).toMatchObject({ state: "error", error: "codex probe failed" });
-    expect(caps["claude-code-tui"]).toMatchObject({ state: "error", error: "tui probe failed" });
+    // Disabled provider is never probed, so no entry (not even an error one).
+    expect(caps["claude-code-tui"]).toBeUndefined();
 
     vi.doUnmock("../runtime/capabilities/claude-code.js");
     vi.doUnmock("../runtime/capabilities/codex.js");

--- a/packages/client/src/runtime/capabilities/index.ts
+++ b/packages/client/src/runtime/capabilities/index.ts
@@ -1,4 +1,9 @@
-import type { CapabilityEntry, ClientCapabilities, RuntimeProvider } from "@first-tree/shared";
+import {
+  type CapabilityEntry,
+  type ClientCapabilities,
+  isRuntimeProviderEnabled,
+  type RuntimeProvider,
+} from "@first-tree/shared";
 import { probeClaudeCodeCapability } from "./claude-code.js";
 import { probeClaudeCodeTuiCapability } from "./claude-code-tui.js";
 import { probeCodexCapability } from "./codex.js";
@@ -8,10 +13,14 @@ import type { SmokeOutcome } from "./launch-probe.js";
  * real smoke at most this often on reconnect, to catch silent drift. */
 export const REPROBE_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 
-/** The runtime providers a built-in probe exists for. Used by
- * {@link hasNonOkProvider} to decide whether a daemon's advertised capability
- * snapshot still has a provider worth re-probing for. */
-export const PROBED_RUNTIME_PROVIDERS: readonly RuntimeProvider[] = ["claude-code", "claude-code-tui", "codex"];
+/** The runtime providers a built-in probe exists for AND that are not
+ * temporarily disabled. Used by {@link hasNonOkProvider} to decide whether a
+ * daemon's advertised capability snapshot still has a provider worth re-probing
+ * for. A disabled provider (see `DISABLED_RUNTIME_PROVIDERS`) is dropped here so
+ * the degraded-capability re-probe loop never schedules itself just for it. */
+export const PROBED_RUNTIME_PROVIDERS: readonly RuntimeProvider[] = (
+  ["claude-code", "claude-code-tui", "codex"] as const
+).filter((p) => isRuntimeProviderEnabled(p));
 
 /** First delay before the daemon-side degraded-capability re-probe fires. Short
  * enough that a freshly-installed provider is noticed quickly during setup. */
@@ -89,11 +98,14 @@ async function aggregate(
  * whether a runtime is usable before spawning anything).
  */
 export async function probeCapabilities(): Promise<ClientCapabilities> {
-  return aggregate([
-    ["claude-code", probeClaudeCodeCapability()],
-    ["claude-code-tui", probeClaudeCodeTuiCapability()],
-    ["codex", probeCodexCapability()],
-  ]);
+  // Guard BEFORE invoking each probe — calling the fn eagerly would spawn the
+  // provider's binary, so a disabled provider must be skipped here, not filtered
+  // out of the results afterwards.
+  const probes: Array<readonly [RuntimeProvider, Promise<CapabilityEntry>]> = [];
+  if (isRuntimeProviderEnabled("claude-code")) probes.push(["claude-code", probeClaudeCodeCapability()]);
+  if (isRuntimeProviderEnabled("claude-code-tui")) probes.push(["claude-code-tui", probeClaudeCodeTuiCapability()]);
+  if (isRuntimeProviderEnabled("codex")) probes.push(["codex", probeCodexCapability()]);
+  return aggregate(probes);
 }
 
 /**
@@ -152,11 +164,23 @@ export async function revalidateCapabilities(previous: ClientCapabilities): Prom
   const claude = previous["claude-code"];
   const tui = previous["claude-code-tui"];
   const codex = previous.codex;
-  const revalidated = await aggregate([
-    ["claude-code", probeClaudeCodeCapability(claude?.state === "ok" ? { runSmoke: cachedOkSmoke() } : {})],
-    ["claude-code-tui", probeClaudeCodeTuiCapability(tui?.state === "ok" ? { runSmoke: cachedOkSmoke() } : {})],
-    ["codex", probeCodexCapability(codex?.state === "ok" ? { runSmoke: cachedOkSmoke() } : {})],
-  ]);
+  // Same guard as `probeCapabilities`: a disabled provider must not have its
+  // probe invoked (it would re-run resolve/auth against the binary), so skip it
+  // rather than filter the result.
+  const probes: Array<readonly [RuntimeProvider, Promise<CapabilityEntry>]> = [];
+  if (isRuntimeProviderEnabled("claude-code"))
+    probes.push([
+      "claude-code",
+      probeClaudeCodeCapability(claude?.state === "ok" ? { runSmoke: cachedOkSmoke() } : {}),
+    ]);
+  if (isRuntimeProviderEnabled("claude-code-tui"))
+    probes.push([
+      "claude-code-tui",
+      probeClaudeCodeTuiCapability(tui?.state === "ok" ? { runSmoke: cachedOkSmoke() } : {}),
+    ]);
+  if (isRuntimeProviderEnabled("codex"))
+    probes.push(["codex", probeCodexCapability(codex?.state === "ok" ? { runSmoke: cachedOkSmoke() } : {})]);
+  const revalidated = await aggregate(probes);
 
   // Preserve the prior real launch-verified entry wherever the provider stayed
   // `ok` (resolve+auth still pass, smoke skipped); only regressions keep the

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -725,6 +725,8 @@ export {
 } from "./schemas/runtime-auth.js";
 export {
   DEFAULT_RUNTIME_PROVIDER,
+  DISABLED_RUNTIME_PROVIDERS,
+  isRuntimeProviderEnabled,
   RUNTIME_PROVIDERS,
   type RuntimeProvider,
   runtimeProviderSchema,

--- a/packages/shared/src/schemas/runtime-provider.ts
+++ b/packages/shared/src/schemas/runtime-provider.ts
@@ -15,3 +15,21 @@ export const runtimeProviderSchema = z.enum(["claude-code", "claude-code-tui", "
 export type RuntimeProvider = z.infer<typeof runtimeProviderSchema>;
 
 export const DEFAULT_RUNTIME_PROVIDER: RuntimeProvider = "claude-code";
+
+/**
+ * Runtime providers temporarily disabled platform-wide. A disabled provider is
+ * filtered out of UI runtime selection (creating agents, onboarding, the client
+ * setup/ready cards) and skipped by the client capability probe, so it is
+ * neither offered to users nor advertised / re-probed by the daemon. The
+ * provider stays a valid `RuntimeProvider` so already-bound agents keep their
+ * label and continue to run — this only hides it from new selection + detection.
+ *
+ * Empty = nothing disabled. To re-enable a provider, remove it from this list
+ * (single-line revert).
+ */
+export const DISABLED_RUNTIME_PROVIDERS: readonly RuntimeProvider[] = ["claude-code-tui"];
+
+/** True when `provider` is not temporarily disabled (see {@link DISABLED_RUNTIME_PROVIDERS}). */
+export function isRuntimeProviderEnabled(provider: string): boolean {
+  return !DISABLED_RUNTIME_PROVIDERS.some((p) => p === provider);
+}

--- a/packages/web/src/components/new-agent-dialog.tsx
+++ b/packages/web/src/components/new-agent-dialog.tsx
@@ -153,9 +153,14 @@ function asRuntimeProvider(provider: string): RuntimeProvider | null {
  */
 function pickPreferredRuntime(caps: ClientCapabilities): RuntimeProvider | null {
   if (caps["claude-code"]?.state === "ok") return "claude-code";
+  // Keep the documented Claude Code → Claude Code CLI → Codex priority, but guard
+  // the TUI branch on the central switch: disabled today (short-circuits, so a
+  // stale `ok` snapshot is skipped and Codex wins), yet removing it from
+  // DISABLED_RUNTIME_PROVIDERS restores its priority over Codex in one line.
+  if (isRuntimeProviderEnabled("claude-code-tui") && caps["claude-code-tui"]?.state === "ok") return "claude-code-tui";
   if (caps.codex?.state === "ok") return "codex";
-  // Disabled providers (e.g. claude-code-tui) are never auto-picked, even if a
-  // stale snapshot still reports them `ok`.
+  // Any other provider (incl. one still disabled in a stale snapshot) is only
+  // auto-picked when enabled.
   for (const [provider, entry] of Object.entries(caps)) {
     if (entry.state === "ok") {
       const rt = asRuntimeProvider(provider);

--- a/packages/web/src/components/new-agent-dialog.tsx
+++ b/packages/web/src/components/new-agent-dialog.tsx
@@ -5,6 +5,7 @@ import {
   type AgentVisibility,
   type ClientCapabilities,
   isReservedAgentName,
+  isRuntimeProviderEnabled,
   type RuntimeProvider,
 } from "@first-tree/shared";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
@@ -152,12 +153,13 @@ function asRuntimeProvider(provider: string): RuntimeProvider | null {
  */
 function pickPreferredRuntime(caps: ClientCapabilities): RuntimeProvider | null {
   if (caps["claude-code"]?.state === "ok") return "claude-code";
-  if (caps["claude-code-tui"]?.state === "ok") return "claude-code-tui";
   if (caps.codex?.state === "ok") return "codex";
+  // Disabled providers (e.g. claude-code-tui) are never auto-picked, even if a
+  // stale snapshot still reports them `ok`.
   for (const [provider, entry] of Object.entries(caps)) {
     if (entry.state === "ok") {
       const rt = asRuntimeProvider(provider);
-      if (rt) return rt;
+      if (rt && isRuntimeProviderEnabled(rt)) return rt;
     }
   }
   return null;
@@ -483,7 +485,9 @@ export function NewAgentDialog({ open, onOpenChange, onCreated }: Props) {
     for (const [provider, entry] of Object.entries(activeCapabilities)) {
       if (entry.state !== "ok") continue;
       const rt = asRuntimeProvider(provider);
-      if (rt) out.push(rt);
+      // Skip temporarily-disabled providers so they never appear as a
+      // selectable runtime, even if a stale snapshot still reports them `ok`.
+      if (rt && isRuntimeProviderEnabled(rt)) out.push(rt);
     }
     return out;
   }, [activeCapabilities]);

--- a/packages/web/src/pages/clients/__tests__/clients-page-cards-dom.test.tsx
+++ b/packages/web/src/pages/clients/__tests__/clients-page-cards-dom.test.tsx
@@ -71,17 +71,6 @@ function okCapability(sdkVersion = "0.2.84"): CapabilityEntry {
   };
 }
 
-function missingCapability(): CapabilityEntry {
-  return {
-    state: "missing",
-    available: false,
-    authenticated: false,
-    sdkVersion: null,
-    authMethod: "none",
-    detectedAt: NOW,
-  };
-}
-
 function unauthCapability(sdkVersion = "0.134.0"): CapabilityEntry {
   return {
     state: "unauthenticated",
@@ -143,9 +132,11 @@ const SETUP_INCOMPLETE = client({
   hostname: "fresh-linux",
   os: "linux",
   agentCount: 1,
+  // claude-code-tui is in DISABLED_RUNTIME_PROVIDERS, so it is filtered out of
+  // PROVIDER_ORDER and never shown on the card — the errored runtime that
+  // surfaces "probe failed" + a reinstall command is claude-code itself here.
   capabilities: {
-    "claude-code": missingCapability(),
-    "claude-code-tui": errorCapability(),
+    "claude-code": errorCapability(),
     codex: unauthCapability(),
   },
 });

--- a/packages/web/src/pages/clients/cards/shared/providers.ts
+++ b/packages/web/src/pages/clients/cards/shared/providers.ts
@@ -1,4 +1,4 @@
-import { RUNTIME_PROVIDERS, type RuntimeProvider } from "@first-tree/shared";
+import { isRuntimeProviderEnabled, RUNTIME_PROVIDERS, type RuntimeProvider } from "@first-tree/shared";
 
 /**
  * Shared provider constants for runtime-related UI. Previously lived
@@ -8,12 +8,18 @@ import { RUNTIME_PROVIDERS, type RuntimeProvider } from "@first-tree/shared";
  * Display order for runtime sections — Claude Code first because it
  * is the more common entry point, Codex second. Mirrors mockup §"Variant
  * B-2" ordering.
+ *
+ * Temporarily-disabled providers (`DISABLED_RUNTIME_PROVIDERS`) are filtered
+ * out so they are never offered or shown across the client cards (Ready /
+ * Offline / Setup-incomplete / Auth-expired) that drive their selection off
+ * this list. The label / install-command maps below intentionally keep every
+ * provider so an already-bound agent on a disabled runtime still renders.
  */
 export const PROVIDER_ORDER: RuntimeProvider[] = [
   RUNTIME_PROVIDERS.CLAUDE_CODE,
   RUNTIME_PROVIDERS.CLAUDE_CODE_TUI,
   RUNTIME_PROVIDERS.CODEX,
-];
+].filter((p) => isRuntimeProviderEnabled(p));
 
 export const PROVIDER_LABEL: Record<RuntimeProvider, string> = {
   "claude-code": "Claude Code",

--- a/packages/web/src/pages/onboarding/use-computer-connection.ts
+++ b/packages/web/src/pages/onboarding/use-computer-connection.ts
@@ -1,4 +1,4 @@
-import type { ClientCapabilities } from "@first-tree/shared";
+import { type ClientCapabilities, isRuntimeProviderEnabled } from "@first-tree/shared";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { type ConnectTokenResponse, getClientCapabilities, type HubClient, listClients } from "../../api/activity.js";
 import { api } from "../../api/client.js";
@@ -43,7 +43,11 @@ function pickPreferredRuntime(caps: ClientCapabilities): string | null {
   const ok = (provider: string) => caps[provider]?.state === "ok";
   if (ok("claude-code")) return "claude-code";
   if (ok("codex")) return "codex";
-  const first = Object.entries(caps).find(([, entry]) => entry.state === "ok");
+  // Never fall back to a temporarily-disabled provider, even if a stale snapshot
+  // still reports it `ok`.
+  const first = Object.entries(caps).find(
+    ([provider, entry]) => entry.state === "ok" && isRuntimeProviderEnabled(provider),
+  );
   return first ? first[0] : null;
 }
 
@@ -182,7 +186,7 @@ export function useComputerConnection(enabled: boolean): ComputerConnection {
 
   const okRuntimes = activeCapabilities
     ? Object.entries(activeCapabilities)
-        .filter(([, entry]) => entry.state === "ok")
+        .filter(([provider, entry]) => entry.state === "ok" && isRuntimeProviderEnabled(provider))
         .map(([provider]) => provider)
     : [];
 


### PR DESCRIPTION
## What

Temporarily disable the `claude-code-tui` runtime — shown as **"Claude Code (TUI)"** in the new-agent dialog and **"Claude Code CLI"** on the client cards. Scope, as requested: **hide it from the UI + stop probing it**, behind a single central switch that reverts in one line.

Existing agents already bound to this runtime are untouched — they keep running and keep their label. This is implementation-only (no server-side runtime block).

## How

- **shared** — add `DISABLED_RUNTIME_PROVIDERS = ["claude-code-tui"]` and `isRuntimeProviderEnabled()` as the single source of truth. Re-enabling is a one-line revert (remove the entry).
- **client (stop probing)** — guard each capability probe *before* invoking it, so a disabled provider never spawns its binary (`claude` / tmux). Drop it from `PROBED_RUNTIME_PROVIDERS` so the degraded-capability re-probe loop never schedules itself just for it.
- **web (hide from UI)** — filter the disabled provider out of the new-agent dialog, onboarding runtime selection, and the clients cards (`PROVIDER_ORDER`) — including stale snapshots that still report it `ok`. Provider label / install-command maps are intentionally left intact so a previously-bound agent on this runtime still renders.

## Tests

- Updated the two tests that asserted the TUI provider was probed / shown.
- `pnpm typecheck` + `biome check` clean; `shared` + `client` + `web` suites green.
- Local regression by QA: candidate daemon uploads only `codex` + `claude-code` (no `claude-code-tui`, no TUI/tmux probe in the daemon log); web onboarding / clients cards / new-agent dialog no longer offer Claude Code CLI/TUI while keeping Claude Code + Codex; desktop 1280x800 and mobile 390x844 both clean. Verdict: PASS (the report's only caveat is an unrelated server EJS/CJS startup issue already fixed on `main@72ffd998`; this PR does not touch the server).

🤖 Generated with [Claude Code](https://claude.com/claude-code)