### PR TITLE
fix(server): wake context reviewer on PR updates

### DIFF
--- a/packages/server/src/__tests__/context-reviewer-pr.test.ts
+++ b/packages/server/src/__tests__/context-reviewer-pr.test.ts
@@ -9,6 +9,7 @@ import { messages } from "../db/schema/messages.js";
 import { createAgent } from "../services/agent.js";
 import {
   contextReviewerPrTestInternals,
+  handleContextReviewerPrEvent,
   handleContextReviewerPullRequest,
   normalizeGithubRepo,
   renderContextReviewerPrPrompt,
@@ -30,6 +31,47 @@ function pullRequestPayload(overrides: Partial<Record<string, unknown>> = {}) {
     },
     repository: { full_name: "owner/context-tree" },
     sender: { login: "writer", type: "User" },
+    ...overrides,
+  };
+}
+
+function issueCommentPayload(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    action: "created",
+    issue: {
+      number: 123,
+      title: "Clarify agent routing context",
+      html_url: "https://github.com/owner/context-tree/issues/123",
+      pull_request: { html_url: "https://github.com/owner/context-tree/pull/123" },
+    },
+    comment: {
+      html_url: "https://github.com/owner/context-tree/pull/123#issuecomment-1",
+      user: { login: "commenter" },
+      body: "Please re-check this context.",
+    },
+    repository: { full_name: "owner/context-tree" },
+    sender: { login: "commenter", type: "User" },
+    ...overrides,
+  };
+}
+
+function reviewCommentPayload(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    action: "created",
+    pull_request: {
+      number: 123,
+      title: "Clarify agent routing context",
+      html_url: "https://github.com/owner/context-tree/pull/123",
+      base: { ref: "main" },
+      head: { ref: "context-update" },
+    },
+    comment: {
+      html_url: "https://github.com/owner/context-tree/pull/123#discussion_r1",
+      user: { login: "reviewer-user" },
+      body: "This line needs another look.",
+    },
+    repository: { full_name: "owner/context-tree" },
+    sender: { login: "reviewer-user", type: "User" },
     ...overrides,
   };
 }
@@ -71,6 +113,9 @@ describe("Context Reviewer PR prompt", () => {
       baseRef: "main",
       headRef: "context-update",
       senderLogin: "writer",
+      triggerEvent: "pull_request.opened",
+      commentUrl: null,
+      commentAuthorLogin: null,
       organizationId: "org-1",
     });
 
@@ -90,12 +135,36 @@ describe("Context Reviewer PR prompt", () => {
       baseRef: null,
       headRef: null,
       senderLogin: "writer",
+      triggerEvent: "pull_request.synchronize",
+      commentUrl: null,
+      commentAuthorLogin: null,
       organizationId: "org-1",
     });
 
     expect(prompt).toContain("Base ref: unknown");
     expect(prompt).toContain("Head ref: unknown");
+    expect(prompt).toContain("Trigger event: pull_request.synchronize");
     expect(prompt).toContain("gh pr comment 124 --repo owner/context-tree --body");
+  });
+
+  it("renders comment trigger context when present", async () => {
+    const prompt = await renderContextReviewerPrPrompt({
+      repoFullName: "owner/context-tree",
+      prNumber: 125,
+      title: "Comment trigger",
+      htmlUrl: "https://github.com/owner/context-tree/pull/125",
+      baseRef: null,
+      headRef: null,
+      senderLogin: "writer",
+      triggerEvent: "issue_comment.created",
+      commentUrl: "https://github.com/owner/context-tree/pull/125#issuecomment-1",
+      commentAuthorLogin: "commenter",
+      organizationId: "org-1",
+    });
+
+    expect(prompt).toContain("Trigger event: issue_comment.created");
+    expect(prompt).toContain("Comment author: commenter");
+    expect(prompt).toContain("Comment URL: https://github.com/owner/context-tree/pull/125#issuecomment-1");
   });
 });
 
@@ -125,7 +194,7 @@ describe("normalizeGithubRepo", () => {
   });
 });
 
-describe("handleContextReviewerPullRequest", () => {
+describe("handleContextReviewerPrEvent", () => {
   const getApp = useTestApp();
 
   it("skips when webhook repo is not the bound context repo", async () => {
@@ -134,7 +203,7 @@ describe("handleContextReviewerPullRequest", () => {
     const reviewer = await createReviewer(app, admin);
     await enableReviewer(app, admin, reviewer.uuid);
 
-    const result = await handleContextReviewerPullRequest(app, {
+    const result = await handleContextReviewerPrEvent(app, {
       eventType: "pull_request",
       payload: pullRequestPayload({ repository: { full_name: "owner/code" } }),
       organizationId: admin.organizationId,
@@ -182,9 +251,9 @@ describe("handleContextReviewerPullRequest", () => {
     ).resolves.toEqual({ handled: false, reason: "reviewer_agent_invalid" });
 
     await expect(
-      handleContextReviewerPullRequest(app, {
+      handleContextReviewerPrEvent(app, {
         eventType: "pull_request",
-        payload: pullRequestPayload({ action: "synchronize" }),
+        payload: pullRequestPayload({ action: "labeled" }),
         organizationId: admin.organizationId,
       }),
     ).resolves.toEqual({ handled: false, reason: "unsupported_event" });
@@ -196,7 +265,7 @@ describe("handleContextReviewerPullRequest", () => {
     const reviewer = await createReviewer(app, admin);
     await enableReviewer(app, admin, reviewer.uuid);
 
-    const result = await handleContextReviewerPullRequest(app, {
+    const result = await handleContextReviewerPrEvent(app, {
       eventType: "pull_request",
       payload: pullRequestPayload(),
       organizationId: admin.organizationId,
@@ -227,6 +296,7 @@ describe("handleContextReviewerPullRequest", () => {
 
     const [message] = await app.db.select().from(messages).where(eq(messages.id, result.messageId)).limit(1);
     expect(message?.content).toContain("gh pr comment 123 --repo owner/context-tree --body");
+    expect(message?.content).toContain("Trigger event: pull_request.opened");
     expect(message?.metadata).toMatchObject({
       contextTreeReviewer: true,
       mentions: [reviewer.uuid],
@@ -246,12 +316,12 @@ describe("handleContextReviewerPullRequest", () => {
     const reviewer = await createReviewer(app, admin);
     await enableReviewer(app, admin, reviewer.uuid);
 
-    const first = await handleContextReviewerPullRequest(app, {
+    const first = await handleContextReviewerPrEvent(app, {
       eventType: "pull_request",
       payload: pullRequestPayload(),
       organizationId: admin.organizationId,
     });
-    const second = await handleContextReviewerPullRequest(app, {
+    const second = await handleContextReviewerPrEvent(app, {
       eventType: "pull_request",
       payload: pullRequestPayload(),
       organizationId: admin.organizationId,
@@ -266,18 +336,187 @@ describe("handleContextReviewerPullRequest", () => {
     expect(chatRows).toHaveLength(1);
   });
 
+  it("reuses the reviewer chat for pull_request.synchronize and notifies the reviewer", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app);
+    const reviewer = await createReviewer(app, admin);
+    await enableReviewer(app, admin, reviewer.uuid);
+
+    const first = await handleContextReviewerPrEvent(app, {
+      eventType: "pull_request",
+      payload: pullRequestPayload(),
+      organizationId: admin.organizationId,
+    });
+    if (!first.handled) throw new Error("expected first event handled");
+
+    const second = await handleContextReviewerPrEvent(app, {
+      eventType: "pull_request",
+      payload: pullRequestPayload({ action: "synchronize" }),
+      organizationId: admin.organizationId,
+    });
+
+    expect(second).toMatchObject({ handled: true, reused: true, chatId: first.chatId });
+    if (!second.handled) throw new Error("expected second event handled");
+
+    const messageRows = await app.db.select().from(messages).where(eq(messages.chatId, first.chatId));
+    expect(messageRows).toHaveLength(2);
+    const followUp = messageRows.find((row) => row.id === second.messageId);
+    expect(followUp?.source).toBe("github");
+    expect(followUp?.format).toBe("markdown");
+    expect(followUp?.content).toContain("Trigger event: pull_request.synchronize");
+    expect(followUp?.metadata).toMatchObject({
+      source: "github",
+      event: "pull_request",
+      action: "synchronize",
+      triggerEvent: "pull_request.synchronize",
+      contextTreeReviewer: true,
+      mentions: [reviewer.uuid],
+    });
+
+    const [entry] = await app.db
+      .select({ notify: inboxEntries.notify })
+      .from(inboxEntries)
+      .where(and(eq(inboxEntries.messageId, second.messageId), eq(inboxEntries.inboxId, reviewer.inboxId)))
+      .limit(1);
+    expect(entry?.notify).toBe(true);
+  });
+
+  it("reuses the reviewer chat for PR issue_comment.created and notifies the reviewer", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app);
+    const reviewer = await createReviewer(app, admin);
+    await enableReviewer(app, admin, reviewer.uuid);
+
+    const first = await handleContextReviewerPrEvent(app, {
+      eventType: "pull_request",
+      payload: pullRequestPayload(),
+      organizationId: admin.organizationId,
+    });
+    if (!first.handled) throw new Error("expected first event handled");
+
+    const second = await handleContextReviewerPrEvent(app, {
+      eventType: "issue_comment",
+      payload: issueCommentPayload(),
+      organizationId: admin.organizationId,
+    });
+
+    expect(second).toMatchObject({ handled: true, reused: true, chatId: first.chatId });
+    if (!second.handled) throw new Error("expected second event handled");
+
+    const [followUp] = await app.db.select().from(messages).where(eq(messages.id, second.messageId)).limit(1);
+    expect(followUp?.content).toContain("Trigger event: issue_comment.created");
+    expect(followUp?.content).toContain("Comment author: commenter");
+    expect(followUp?.content).toContain("Comment URL: https://github.com/owner/context-tree/pull/123#issuecomment-1");
+    expect(followUp?.metadata).toMatchObject({
+      source: "github",
+      event: "issue_comment",
+      action: "created",
+      triggerEvent: "issue_comment.created",
+      contextTreeReviewer: true,
+      mentions: [reviewer.uuid],
+    });
+
+    const [entry] = await app.db
+      .select({ notify: inboxEntries.notify })
+      .from(inboxEntries)
+      .where(and(eq(inboxEntries.messageId, second.messageId), eq(inboxEntries.inboxId, reviewer.inboxId)))
+      .limit(1);
+    expect(entry?.notify).toBe(true);
+  });
+
+  it("reuses the reviewer chat for pull_request_review_comment.created and notifies the reviewer", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app);
+    const reviewer = await createReviewer(app, admin);
+    await enableReviewer(app, admin, reviewer.uuid);
+
+    const first = await handleContextReviewerPrEvent(app, {
+      eventType: "pull_request",
+      payload: pullRequestPayload(),
+      organizationId: admin.organizationId,
+    });
+    if (!first.handled) throw new Error("expected first event handled");
+
+    const second = await handleContextReviewerPrEvent(app, {
+      eventType: "pull_request_review_comment",
+      payload: reviewCommentPayload(),
+      organizationId: admin.organizationId,
+    });
+
+    expect(second).toMatchObject({ handled: true, reused: true, chatId: first.chatId });
+    if (!second.handled) throw new Error("expected second event handled");
+
+    const [followUp] = await app.db.select().from(messages).where(eq(messages.id, second.messageId)).limit(1);
+    expect(followUp?.content).toContain("Trigger event: pull_request_review_comment.created");
+    expect(followUp?.content).toContain("Comment author: reviewer-user");
+    expect(followUp?.content).toContain("Comment URL: https://github.com/owner/context-tree/pull/123#discussion_r1");
+    expect(followUp?.metadata).toMatchObject({
+      source: "github",
+      event: "pull_request_review_comment",
+      action: "created",
+      triggerEvent: "pull_request_review_comment.created",
+      contextTreeReviewer: true,
+      mentions: [reviewer.uuid],
+    });
+
+    const [entry] = await app.db
+      .select({ notify: inboxEntries.notify })
+      .from(inboxEntries)
+      .where(and(eq(inboxEntries.messageId, second.messageId), eq(inboxEntries.inboxId, reviewer.inboxId)))
+      .limit(1);
+    expect(entry?.notify).toBe(true);
+  });
+
+  it("skips non-PR issue_comment.created without creating a reviewer chat", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app);
+    const reviewer = await createReviewer(app, admin);
+    await enableReviewer(app, admin, reviewer.uuid);
+
+    const result = await handleContextReviewerPrEvent(app, {
+      eventType: "issue_comment",
+      payload: issueCommentPayload({
+        issue: {
+          number: 123,
+          title: "Plain issue",
+          html_url: "https://github.com/owner/context-tree/issues/123",
+        },
+      }),
+      organizationId: admin.organizationId,
+    });
+
+    expect(result).toEqual({ handled: false, reason: "malformed_payload" });
+    const chatRows = await app.db.select({ id: chats.id }).from(chats);
+    expect(chatRows).toHaveLength(0);
+  });
+
   it("extracts pull request info defensively", () => {
-    expect(contextReviewerPrTestInternals.extractPullRequestPayloadInfo(pullRequestPayload(), "org-1")).toMatchObject({
+    expect(
+      contextReviewerPrTestInternals.extractPullRequestPayloadInfo("pull_request", pullRequestPayload(), "org-1"),
+    ).toMatchObject({
       repoFullName: "owner/context-tree",
       entityKey: "owner/context-tree#123",
       baseRef: "main",
       headRef: "context-update",
+      triggerEvent: "pull_request.opened",
     });
     expect(
       contextReviewerPrTestInternals.extractPullRequestPayloadInfo(
+        "pull_request",
         pullRequestPayload({ pull_request: { number: 123 } }),
         "org-1",
       ),
     ).toBeNull();
+    expect(
+      contextReviewerPrTestInternals.extractPullRequestPayloadInfo("issue_comment", issueCommentPayload(), "org-1"),
+    ).toMatchObject({
+      repoFullName: "owner/context-tree",
+      entityKey: "owner/context-tree#123",
+      baseRef: null,
+      headRef: null,
+      commentUrl: "https://github.com/owner/context-tree/pull/123#issuecomment-1",
+      commentAuthorLogin: "commenter",
+      triggerEvent: "issue_comment.created",
+    });
   });
 });

--- a/packages/server/src/__tests__/github-app-webhook-route.test.ts
+++ b/packages/server/src/__tests__/github-app-webhook-route.test.ts
@@ -6,6 +6,7 @@ import { chatUserState } from "../db/schema/chat-user-state.js";
 import { chats } from "../db/schema/chats.js";
 import { githubAppInstallations } from "../db/schema/github-app-installations.js";
 import { githubEntityChatMappings } from "../db/schema/github-entity-chat-mappings.js";
+import { inboxEntries } from "../db/schema/inbox-entries.js";
 import { messages } from "../db/schema/messages.js";
 import { putOrgSetting } from "../services/org-settings.js";
 import { uuidv7 } from "../uuid.js";
@@ -113,6 +114,26 @@ function contextPullRequestPayload(installationId: number, repoFullName = "owner
     },
     repository: { full_name: repoFullName },
     sender: { login: "context-writer", type: "User" },
+    installation: { id: installationId },
+  };
+}
+
+function contextIssueCommentPayload(installationId: number, repoFullName = "owner/context-tree") {
+  return {
+    action: "created",
+    issue: {
+      number: 42,
+      title: "Improve context review guidance",
+      html_url: `https://github.com/${repoFullName}/issues/42`,
+      pull_request: { html_url: `https://github.com/${repoFullName}/pull/42` },
+    },
+    comment: {
+      body: "Please take another pass.",
+      html_url: `https://github.com/${repoFullName}/pull/42#issuecomment-2`,
+      user: { login: "context-commenter" },
+    },
+    repository: { full_name: repoFullName },
+    sender: { login: "context-commenter", type: "User" },
     installation: { id: installationId },
   };
 }
@@ -1108,9 +1129,61 @@ describe("POST /webhooks/github-app", () => {
       source: "github",
       event: "pull_request",
       action: "opened",
+      triggerEvent: "pull_request.opened",
       contextTreeReviewer: true,
       mentions: [reviewer],
     });
+  });
+
+  it("follow-up activity on a bound context PR wakes the existing Context Reviewer chat", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const installationId = 100043;
+    await seedInstallation(app, { installationId, orgId: admin.organizationId });
+    const reviewer = await configureContextReviewer(app, admin);
+
+    const opened = await postWebhook(app, "pull_request", contextPullRequestPayload(installationId));
+    expect(opened.statusCode).toBe(200);
+    expect(opened.json()).toMatchObject({ contextReviewer: { handled: true, reused: false } });
+
+    const followUp = await postWebhook(app, "issue_comment", contextIssueCommentPayload(installationId));
+
+    expect(followUp.statusCode).toBe(200);
+    expect(followUp.json()).toMatchObject({
+      ok: true,
+      event: "issue_comment",
+      audience: 0,
+      contextReviewer: { handled: true, reused: true },
+    });
+
+    const chatRows = await app.db.select().from(chats);
+    expect(chatRows).toHaveLength(1);
+
+    const messageRows = await app.db
+      .select()
+      .from(messages)
+      .where(eq(messages.chatId, chatRows[0]?.id ?? ""));
+    expect(messageRows).toHaveLength(2);
+    const followUpMessage = messageRows.find((message) => message.metadata.triggerEvent === "issue_comment.created");
+    expect(followUpMessage?.content).toContain("Trigger event: issue_comment.created");
+    expect(followUpMessage?.content).toContain(
+      "Comment URL: https://github.com/owner/context-tree/pull/42#issuecomment-2",
+    );
+    expect(followUpMessage?.metadata).toMatchObject({
+      source: "github",
+      event: "issue_comment",
+      action: "created",
+      triggerEvent: "issue_comment.created",
+      contextTreeReviewer: true,
+      mentions: [reviewer],
+    });
+
+    const [entry] = await app.db
+      .select({ notify: inboxEntries.notify })
+      .from(inboxEntries)
+      .where(and(eq(inboxEntries.messageId, followUpMessage?.id ?? ""), eq(inboxEntries.inboxId, `inbox_${reviewer}`)))
+      .limit(1);
+    expect(entry?.notify).toBe(true);
   });
 
   it("pull_request.opened on an ordinary code repo does not trigger Context Reviewer", async () => {

--- a/packages/server/src/api/webhooks/github-app.ts
+++ b/packages/server/src/api/webhooks/github-app.ts
@@ -3,7 +3,7 @@ import { githubAppInstallationPermissionsSchema, type WebhookSource } from "@fir
 import type { FastifyInstance } from "fastify";
 import { BadRequestError, UnauthorizedError } from "../../errors.js";
 import { createLogger } from "../../observability/index.js";
-import { handleContextReviewerPullRequest } from "../../services/context-reviewer-pr.js";
+import { handleContextReviewerPrEvent } from "../../services/context-reviewer-pr.js";
 import { claimEvent, unclaimEvent } from "../../services/event-dedup.js";
 import type { AppInstallation } from "../../services/github-app.js";
 import {
@@ -84,6 +84,13 @@ function pullRequestStateFromIssuePayload(issue: Record<string, unknown>, action
     return readString(pr?.merged_at) ? "merged" : "closed";
   }
   return issue.draft === true ? "draft" : "open";
+}
+
+function isContextReviewerCandidateEvent(eventType: string, action: string | null): boolean {
+  if (eventType === "pull_request") return action === "opened" || action === "synchronize";
+  if (eventType === "issue_comment") return action === "created";
+  if (eventType === "pull_request_review_comment") return action === "created" || action === "edited";
+  return false;
 }
 
 /**
@@ -345,9 +352,11 @@ export async function githubAppWebhookRoutes(app: FastifyInstance): Promise<void
       }
     }
 
+    const rawAction = isRecord(payload) ? readString(payload.action) : null;
     const event = normalizeGithubEvent(eventType, payload, source, deliveryId);
-    if (!event) {
-      log.debug({ eventType, action: isRecord(payload) ? payload.action : null }, "Stage 1 returned null");
+    const shouldRunContextReviewer = isContextReviewerCandidateEvent(eventType, rawAction);
+    if (!event && !shouldRunContextReviewer) {
+      log.debug({ eventType, action: rawAction }, "Stage 1 returned null");
       return reply.status(200).send({ ok: true, event: eventType, handled: false });
     }
 
@@ -360,11 +369,17 @@ export async function githubAppWebhookRoutes(app: FastifyInstance): Promise<void
     }
 
     try {
-      const contextReviewer = await handleContextReviewerPullRequest(app, {
-        eventType,
-        payload,
-        organizationId: installation.hubOrganizationId,
-      });
+      const contextReviewer = shouldRunContextReviewer
+        ? await handleContextReviewerPrEvent(app, {
+            eventType,
+            payload,
+            organizationId: installation.hubOrganizationId,
+          })
+        : ({ handled: false, reason: "unsupported_event" } as const);
+      if (!event) {
+        log.debug({ eventType, action: rawAction }, "Stage 1 returned null");
+        return reply.status(200).send({ ok: true, event: eventType, handled: false, contextReviewer });
+      }
 
       const audience = await resolveAudience(app.db, event, appSlug);
       if (audience.length === 0) {

--- a/packages/server/src/prompts/context-reviewer-pr.ejs
+++ b/packages/server/src/prompts/context-reviewer-pr.ejs
@@ -9,6 +9,13 @@ URL: <%= htmlUrl %>
 Base ref: <%= baseRef || "unknown" %>
 Head ref: <%= headRef || "unknown" %>
 Opened by: <%= senderLogin %>
+Trigger event: <%= triggerEvent %>
+<% if (commentAuthorLogin) { -%>
+Comment author: <%= commentAuthorLogin %>
+<% } -%>
+<% if (commentUrl) { -%>
+Comment URL: <%= commentUrl %>
+<% } -%>
 First Tree organization: <%= organizationId %>
 
 Review goals:

--- a/packages/server/src/services/context-reviewer-pr.ts
+++ b/packages/server/src/services/context-reviewer-pr.ts
@@ -39,6 +39,9 @@ export type ContextReviewerPrTemplateInput = {
   baseRef: string | null;
   headRef: string | null;
   senderLogin: string;
+  triggerEvent: string;
+  commentUrl: string | null;
+  commentAuthorLogin: string | null;
   organizationId: string;
 };
 
@@ -56,8 +59,15 @@ export type ContextReviewerPrSkipReason =
   | "reviewer_agent_invalid";
 
 type PullRequestPayloadInfo = ContextReviewerPrTemplateInput & {
+  eventType: "pull_request" | "issue_comment" | "pull_request_review_comment";
+  action: "opened" | "synchronize" | "created" | "edited";
   entityKey: string;
 };
+
+type ContextReviewerPrTrigger =
+  | { eventType: "pull_request"; action: "opened" | "synchronize"; triggerEvent: string }
+  | { eventType: "issue_comment"; action: "created"; triggerEvent: string }
+  | { eventType: "pull_request_review_comment"; action: "created" | "edited"; triggerEvent: string };
 
 type ReviewerAgent = {
   uuid: string;
@@ -163,7 +173,7 @@ function parseUrlRepo(value: string): string | null {
   return normalizeOwnerRepo(owner, repo);
 }
 
-export async function handleContextReviewerPullRequest(
+export async function handleContextReviewerPrEvent(
   app: FastifyInstance,
   input: {
     eventType: string;
@@ -171,14 +181,13 @@ export async function handleContextReviewerPullRequest(
     organizationId: string;
   },
 ): Promise<ContextReviewerPrResult> {
-  if (input.eventType !== "pull_request") {
-    return { handled: false, reason: "unsupported_event" };
-  }
-  if (isRecord(input.payload) && readString(input.payload.action) !== "opened") {
+  if (
+    !resolveContextReviewerPrTrigger(input.eventType, isRecord(input.payload) ? readString(input.payload.action) : null)
+  ) {
     return { handled: false, reason: "unsupported_event" };
   }
 
-  const info = extractPullRequestPayloadInfo(input.payload, input.organizationId);
+  const info = extractPullRequestPayloadInfo(input.eventType, input.payload, input.organizationId);
   if (!info) {
     return { handled: false, reason: "malformed_payload" };
   }
@@ -251,8 +260,9 @@ export async function handleContextReviewerPullRequest(
         content: prompt,
         metadata: {
           source: "github",
-          event: "pull_request",
-          action: "opened",
+          event: info.eventType,
+          action: info.action,
+          triggerEvent: info.triggerEvent,
           entityType: "pull_request",
           entityKey: info.entityKey,
           contextTreeReviewer: true,
@@ -282,8 +292,9 @@ export async function handleContextReviewerPullRequest(
       content: prompt,
       metadata: {
         source: "github",
-        event: "pull_request",
-        action: "opened",
+        event: info.eventType,
+        action: info.action,
+        triggerEvent: info.triggerEvent,
         entityType: "pull_request",
         entityKey: info.entityKey,
         contextTreeReviewer: true,
@@ -300,33 +311,124 @@ export async function handleContextReviewerPullRequest(
   return { handled: true, chatId: created.chat.id, messageId: created.message.id, reused: false };
 }
 
-function extractPullRequestPayloadInfo(payload: unknown, organizationId: string): PullRequestPayloadInfo | null {
+export async function handleContextReviewerPullRequest(
+  app: FastifyInstance,
+  input: {
+    eventType: string;
+    payload: unknown;
+    organizationId: string;
+  },
+): Promise<ContextReviewerPrResult> {
+  return handleContextReviewerPrEvent(app, input);
+}
+
+function isSupportedContextReviewerPrEvent(eventType: string, action: string | null): boolean {
+  return resolveContextReviewerPrTrigger(eventType, action) !== null;
+}
+
+function resolveContextReviewerPrTrigger(eventType: string, action: string | null): ContextReviewerPrTrigger | null {
+  if (eventType === "pull_request" && (action === "opened" || action === "synchronize")) {
+    return { eventType, action, triggerEvent: `${eventType}.${action}` };
+  }
+  if (eventType === "issue_comment" && action === "created") {
+    return { eventType, action, triggerEvent: `${eventType}.${action}` };
+  }
+  if (eventType === "pull_request_review_comment" && (action === "created" || action === "edited")) {
+    return { eventType, action, triggerEvent: `${eventType}.${action}` };
+  }
+  return null;
+}
+
+function extractPullRequestPayloadInfo(
+  eventType: string,
+  payload: unknown,
+  organizationId: string,
+): PullRequestPayloadInfo | null {
   if (!isRecord(payload)) return null;
   const action = readString(payload.action);
-  if (action !== "opened") return null;
+  const trigger = resolveContextReviewerPrTrigger(eventType, action);
+  if (!trigger) return null;
 
   const repo = isRecord(payload.repository) ? payload.repository : null;
   const repoFullName = readString(repo?.full_name);
-  const pr = isRecord(payload.pull_request) ? payload.pull_request : null;
-  const prNumber = readNumber(pr?.number);
-  const title = readString(pr?.title);
-  const htmlUrl = readString(pr?.html_url);
   const sender = isRecord(payload.sender) ? payload.sender : null;
   const senderLogin = readString(sender?.login);
-  if (!repoFullName || prNumber === null || !title || !htmlUrl || !senderLogin) return null;
+  if (!repoFullName || !senderLogin) return null;
   const normalizedRepoFullName = normalizeGithubRepo(repoFullName) ?? repoFullName;
 
-  return {
+  const common = {
+    ...trigger,
     repoFullName,
-    prNumber,
-    title,
-    htmlUrl,
-    baseRef: readString(isRecord(pr?.base) ? pr.base.ref : null),
-    headRef: readString(isRecord(pr?.head) ? pr.head.ref : null),
     senderLogin,
     organizationId,
-    entityKey: `${normalizedRepoFullName}#${prNumber}`,
   };
+
+  if (trigger.eventType === "pull_request") {
+    const pr = isRecord(payload.pull_request) ? payload.pull_request : null;
+    const prNumber = readNumber(pr?.number);
+    const title = readString(pr?.title);
+    const htmlUrl = readString(pr?.html_url);
+    if (prNumber === null || !title || !htmlUrl) return null;
+    return {
+      ...common,
+      prNumber,
+      title,
+      htmlUrl,
+      baseRef: readString(isRecord(pr?.base) ? pr.base.ref : null),
+      headRef: readString(isRecord(pr?.head) ? pr.head.ref : null),
+      commentUrl: null,
+      commentAuthorLogin: null,
+      entityKey: `${normalizedRepoFullName}#${prNumber}`,
+    };
+  }
+
+  if (trigger.eventType === "issue_comment") {
+    const issue = isRecord(payload.issue) ? payload.issue : null;
+    const prInfo = isRecord(issue?.pull_request) ? issue.pull_request : null;
+    const prNumber = readNumber(issue?.number);
+    const title = readString(issue?.title);
+    const htmlUrl = readString(prInfo?.html_url) ?? readString(issue?.html_url);
+    const comment = isRecord(payload.comment) ? payload.comment : null;
+    if (!prInfo || prNumber === null || !title || !htmlUrl) return null;
+    return {
+      ...common,
+      prNumber,
+      title,
+      htmlUrl,
+      baseRef: null,
+      headRef: null,
+      commentUrl: readString(comment?.html_url),
+      commentAuthorLogin: readCommentAuthorLogin(comment) ?? senderLogin,
+      entityKey: `${normalizedRepoFullName}#${prNumber}`,
+    };
+  }
+
+  if (trigger.eventType === "pull_request_review_comment") {
+    const pr = isRecord(payload.pull_request) ? payload.pull_request : null;
+    const prNumber = readNumber(pr?.number);
+    const title = readString(pr?.title);
+    const htmlUrl = readString(pr?.html_url);
+    const comment = isRecord(payload.comment) ? payload.comment : null;
+    if (prNumber === null || !title || !htmlUrl) return null;
+    return {
+      ...common,
+      prNumber,
+      title,
+      htmlUrl,
+      baseRef: readString(isRecord(pr?.base) ? pr.base.ref : null),
+      headRef: readString(isRecord(pr?.head) ? pr.head.ref : null),
+      commentUrl: readString(comment?.html_url),
+      commentAuthorLogin: readCommentAuthorLogin(comment) ?? senderLogin,
+      entityKey: `${normalizedRepoFullName}#${prNumber}`,
+    };
+  }
+
+  return null;
+}
+
+function readCommentAuthorLogin(comment: Record<string, unknown> | null): string | null {
+  const user = isRecord(comment?.user) ? comment.user : null;
+  return readString(user?.login);
 }
 
 async function loadValidReviewerAgent(
@@ -378,6 +480,7 @@ async function findExistingReviewerChat(
 export const contextReviewerPrTestInternals = {
   extractPullRequestPayloadInfo,
   findExistingReviewerChat,
+  isSupportedContextReviewerPrEvent,
   loadValidReviewerAgent,
   parseBareRepo,
   parseScpLikeRepo,


### PR DESCRIPTION
## Summary
- run the context reviewer on PR synchronize events and PR-related comments, not only new PR opens
- reuse the existing reviewer task chat for follow-up review triggers
- include trigger/comment metadata in the reviewer prompt and message metadata
- keep webhook normalization optional for reviewer-only candidate events

## Tests
- Not run in this session; this task only rebased, pushed, and opened the PR.