### PR TITLE
fix(client): reconnect after inbox recovery timeout

### DIFF
--- a/packages/client/src/__tests__/client-connection-websocket-coverage.test.ts
+++ b/packages/client/src/__tests__/client-connection-websocket-coverage.test.ts
@@ -530,6 +530,37 @@ describe("ClientConnection — WebSocket edge coverage", () => {
       reason: "recover_failed",
     });
     await expect(rejected).rejects.toThrow("recover_failed");
+    expect(socket.closeCalls).toHaveLength(0);
+  });
+
+  it("forces a reconnect when an inbox recovery confirmation times out", async () => {
+    vi.useFakeTimers();
+    const connection = await makeConnection();
+    const internal = priv(connection);
+    const events: string[] = [];
+    connection.on("reconnecting", () => events.push("reconnecting"));
+    const socket = await openRegisteredConnection(connection, { wsInboxAckConfirm: true });
+
+    const bindPromise = internal.sendBind("agent-1", "codex");
+    const bindFrame = parseSent(socket, socket.sent.length - 1);
+    socket.emitMessage({
+      type: "agent:bound",
+      ref: bindFrame.ref,
+      agentId: "agent-1",
+      displayName: "Agent One",
+      agentType: "agent",
+    });
+    await bindPromise;
+
+    const recovering = connection.sendInboxRecover("agent-1", "chat-timeout");
+    const rejection = expect(recovering).rejects.toThrow("inbox:recover rejected (timeout)");
+    await vi.advanceTimersByTimeAsync(3000);
+
+    await rejection;
+    expect(socket.closeCalls.at(-1)).toEqual({ code: 1011, reason: "inbox recover timeout" });
+    expect(events).toContain("reconnecting");
+
+    internal.clearTimers();
   });
 
   it("holds agent-scoped confirmed inbox ACKs until that agent is rebound on the current socket", async () => {

--- a/packages/client/src/client-connection.ts
+++ b/packages/client/src/client-connection.ts
@@ -289,6 +289,8 @@ const WS_CONNECT_TIMEOUT_MS = 10_000;
 const HEARTBEAT_INTERVAL_MS = 30_000;
 const INBOX_ACK_CONFIRM_TIMEOUT_MS = 3_000;
 const INBOX_RECOVER_CONFIRM_TIMEOUT_MS = 3_000;
+const INBOX_RECOVER_TIMEOUT_CLOSE_CODE = 1011;
+const INBOX_RECOVER_TIMEOUT_CLOSE_REASON = "inbox recover timeout";
 /**
  * Silence watchdog: if no server frame (data message OR control-frame pong)
  * arrives within this many ms, the socket is presumed dead and terminated so
@@ -603,6 +605,7 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
     pending.timer = setTimeout(() => {
       if (!this.pendingInboxRecovers.has(pending.ref)) return;
       this.rejectPendingInboxRecover(pending, "timeout");
+      this.forceReconnectAfterInboxRecoverTimeout(pending);
     }, INBOX_RECOVER_CONFIRM_TIMEOUT_MS);
     return pending.promise;
   }
@@ -802,6 +805,22 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
       "inbox:recover rejected",
     );
     pending.reject(new Error(`inbox:recover rejected (${reason})`));
+  }
+
+  private forceReconnectAfterInboxRecoverTimeout(pending: PendingInboxRecover): void {
+    const ws = this.ws;
+    if (!ws || ws.readyState !== WebSocket.OPEN || !this.registered || this.closing) return;
+    this.wsLogger.warn(
+      {
+        agentId: pending.agentId,
+        chatId: pending.chatId,
+        ref: pending.ref,
+        closeCode: INBOX_RECOVER_TIMEOUT_CLOSE_CODE,
+        recoverEvent: "inbox_recover_timeout_reconnect",
+      },
+      "inbox:recover confirmation timed out — closing socket to force bind recovery",
+    );
+    ws.close(INBOX_RECOVER_TIMEOUT_CLOSE_CODE, INBOX_RECOVER_TIMEOUT_CLOSE_REASON);
   }
 
   private clearPendingInboxRecoverTimer(pending: PendingInboxRecover): void {


### PR DESCRIPTION
## Summary
- close the current registered WebSocket when a chat-scoped inbox recovery confirmation times out
- let the existing reconnect + agent bind reset path recover delivered/unacked inbox rows
- cover timeout reconnect behavior while ensuring server-side recover_failed does not reconnect

## Tests
- pnpm --filter @first-tree/client exec vitest run src/__tests__/client-connection-websocket-coverage.test.ts
- pnpm --filter @first-tree/client exec vitest run src/__tests__/client-connection-heartbeat-timeout.test.ts src/__tests__/client-connection-auth-expired.test.ts src/__tests__/session-manager.test.ts
- pnpm --filter @first-tree/client typecheck
- pnpm --filter @first-tree/client test
- pnpm exec biome check packages/client/src/client-connection.ts packages/client/src/__tests__/client-connection-websocket-coverage.test.ts
- git diff --check