### PR TITLE
fix(onboarding): treat slow agent bring-up as still-starting, not failure

### DIFF
--- a/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
+++ b/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
@@ -1277,7 +1277,7 @@ describe("page SSR smoke coverage", () => {
     ).toContain("Bringing your agent online");
     expect(
       await renderOnboardingStep(<StepCreateAgent />, { activeStep: "create-agent", agentPhase: "timeout" }),
-    ).toContain("online yet");
+    ).toContain("taking longer");
     expect(await renderOnboardingStep(<StepConnectCode />, { activeStep: "connect-code" })).toContain(
       "Loading your repos",
     );

--- a/packages/web/src/pages/onboarding/__tests__/hooks-flow.test.tsx
+++ b/packages/web/src/pages/onboarding/__tests__/hooks-flow.test.tsx
@@ -308,7 +308,7 @@ describe("onboarding hooks and flow", () => {
         organizationId: null,
       });
       await Promise.resolve();
-      await vi.advanceTimersByTimeAsync(31_000);
+      await vi.advanceTimersByTimeAsync(61_000);
       await promise;
     });
     await slowCreate;
@@ -317,7 +317,7 @@ describe("onboarding hooks and flow", () => {
     const retry = act(async () => {
       const promise = expectHookValue(latest.current).retry();
       await Promise.resolve();
-      await vi.advanceTimersByTimeAsync(31_000);
+      await vi.advanceTimersByTimeAsync(61_000);
       await promise;
     });
     await retry;

--- a/packages/web/src/pages/onboarding/copy.ts
+++ b/packages/web/src/pages/onboarding/copy.ts
@@ -282,12 +282,14 @@ export const COPY = {
     // yet".
     creating: "Bringing your agent online…",
     creatingHint: "This usually takes a few seconds.",
-    // Timeout: added but didn't report online within 30s. One short line — the
-    // shell already renders the step h1, so no second title. Situation + the
-    // condensed likely cause (the three separate causes — sleep / lost
-    // connection / agent didn't start — collapse to "asleep or offline") + fix.
-    timeoutBody: "Your agent isn't online yet — its computer may be asleep or offline. Check it, then try again.",
-    retry: "Try again",
+    // Slow-start, NOT a failure: reached only after the full 60s server-liveness
+    // window, so the agent is genuinely late — but a cold runtime or a waking
+    // computer can still arrive, so the framing stays hopeful (keep waiting) with
+    // a graceful, resumable exit (finish later) instead of an error. No second
+    // title — the shell renders the step h1.
+    timeoutBody:
+      "Your agent is taking longer than usual to come online — its computer may be waking up. Keep waiting, or finish setup and start once it's ready.",
+    keepWaiting: "Keep waiting",
     /** Shown on the form when the computer isn't connected (Create is disabled).
         One line with an inline "reconnect it" link (→ connect-computer). The old
         "to add your agent to the team" tail was dropped: the disabled "Create

--- a/packages/web/src/pages/onboarding/steps/step-create-agent.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-create-agent.tsx
@@ -41,6 +41,7 @@ export function StepCreateAgent() {
     organizationId,
     createAgent,
     retryAgent,
+    finishLater,
     agentPhase,
     agentError,
     goTo,
@@ -85,15 +86,25 @@ export function StepCreateAgent() {
   if (agentPhase === "timeout") {
     return (
       <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
-        {/* One plain paragraph — the shell's step h1 ("Add your agent to the team")
-            already heads the screen, so no second bold title here — then retry. */}
+        {/* Slow-start, not a failure: the shell's step h1 already heads the screen,
+            so one plain paragraph, then two paths — keep waiting (re-poll) or the
+            graceful, resumable "finish later" so a genuinely-stuck runtime is never
+            a dead end. */}
         <p className="text-body" style={{ margin: 0, color: "var(--fg-3)" }}>
           {COPY.createAgent.timeoutBody}
         </p>
-        <div className="flex">
+        <div className="flex items-center" style={{ gap: "var(--sp-3)" }}>
           <Button type="button" onClick={() => void retryAgent()}>
-            {COPY.createAgent.retry}
+            {COPY.createAgent.keepWaiting}
           </Button>
+          <button
+            type="button"
+            className="text-label font-medium underline underline-offset-2"
+            style={{ color: "var(--fg-3)" }}
+            onClick={() => void finishLater()}
+          >
+            {COPY.finishLater}
+          </button>
         </div>
       </div>
     );

--- a/packages/web/src/pages/onboarding/use-agent-creation.ts
+++ b/packages/web/src/pages/onboarding/use-agent-creation.ts
@@ -31,7 +31,7 @@ export type CreateAgentArgs = {
  * `visibility`) and waits for it to come online on the connected computer.
  *
  * Same two-phase shape the legacy Step2Body used: POST `/agents`, then poll
- * `client-status` until the runtime reports online (or a 30s timeout). The
+ * `client-status` until the runtime reports online (or a 60s timeout). The
  * agent is created without any project binding — the kickoff step attaches
  * the source repo later, so a slow GitHub call can never block teammate
  * creation. On success, `onOnline(uuid)` fires once.

--- a/packages/web/src/pages/onboarding/use-agent-creation.ts
+++ b/packages/web/src/pages/onboarding/use-agent-creation.ts
@@ -6,7 +6,14 @@ import { reportOnboardingEvent } from "../../api/onboarding-events.js";
 import { slugify } from "../../utils/agent-naming.js";
 import { writeOnboardingAgentUuid } from "../../utils/onboarding-flags.js";
 
-const RUNTIME_READY_TIMEOUT_MS = 30_000;
+// Wait the full server-side offline window before surfacing the "still starting"
+// state: a cold runtime (first claude-code/codex spawn, proxy-slow TLS) can take
+// well past 30s to publish its first heartbeat, and the server itself doesn't
+// consider an agent offline until 60s without one (presence reaper). Timing out
+// at 30s told healthy-but-slow users their agent had failed; 60s matches the
+// server's own liveness threshold so we only surface "taking longer" once the
+// agent is genuinely late, not merely cold-starting.
+const RUNTIME_READY_TIMEOUT_MS = 60_000;
 const RUNTIME_READY_POLL_MS = 1_000;
 
 export type AgentCreationPhase = "idle" | "creating" | "online" | "timeout";


### PR DESCRIPTION
## What & why

Part of the fix for onboarding's "unanswered first chat" (a new user finishes setup, lands in their first chat, and the agent never responds). The root cause is a three-layer decoupling; this PR is the **onboarding-timing layer**.

The create-agent step polled for the new agent coming online for only **30s**, then switched to a failure-framed screen ("Your agent isn't online yet … try again") whose only action re-polled the same agent. But a cold runtime (first claude-code/codex spawn, proxy-slow TLS) routinely takes longer, and the **server itself does not consider an agent offline until 60s** without a heartbeat. So a healthy-but-slow agent was told it had failed, with no graceful exit.

## Changes

- Extend the online-readiness poll **30s → 60s** (`use-agent-creation.ts`), matching the server's presence-reaper threshold, so the late state is reached only when the agent is genuinely overdue, not merely cold-starting.
- Reframe the late state from an error into a hopeful **"taking longer than usual"** with two paths: **Keep waiting** (re-poll) or a graceful, resumable **I'll finish later** — so a stuck runtime is never a dead end (`step-create-agent.tsx`, `copy.ts`).
- Update the hook timeout test (31s → 61s) and the SSR-smoke copy assertion.

## Verification

- `pnpm check` (biome) clean · `pnpm --filter @first-tree/web typecheck` clean · `pnpm --filter @first-tree/web test` → **974 passed**.
- Visually verified the reframed state in the DEV `/preview/onboarding` gallery (admin · Agent creation states · Timeout), light + dark themes.

## Scope

One of a three-layer fix for the unanswered-first-chat root cause:
1. **(runtime)** retry agent config-fetch on bind so a transient failure self-heals instead of bricking the agent — in progress separately.
2. **(chat)** surface agent presence / "no response yet" in the first chat so a not-yet-live agent is never a silent dead end — next.
3. **(this PR)** onboarding create-agent timing + copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)