### PR TITLE
fix(client): retry transient agent-config fetch during bring-up

### DIFF
--- a/packages/client/src/__tests__/agent-slot.test.ts
+++ b/packages/client/src/__tests__/agent-slot.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ClientConnection, SessionReconcileResult } from "../client-connection.js";
 import type { AgentSlotConfig } from "../runtime/agent-slot.js";
 import type { HandlerConfig } from "../runtime/handler.js";
-import type { FirstTreeHubSDK, RegisterResult } from "../sdk.js";
+import { type FirstTreeHubSDK, type RegisterResult, SdkError } from "../sdk.js";
 
 type FakeLogger = {
   info: ReturnType<typeof vi.fn>;
@@ -76,11 +76,20 @@ function makeAgent(overrides: Partial<RegisterResult> = {}): RegisterResult {
   };
 }
 
-function makeSdk(options?: { agent?: RegisterResult; configError?: unknown }): FirstTreeHubSDK {
+function makeSdk(options?: {
+  agent?: RegisterResult;
+  configError?: unknown;
+  /** Throw `error` on the first `times` config fetches, then succeed — models a transient blip. */
+  configErrorsThenSucceed?: { error: unknown; times: number };
+}): FirstTreeHubSDK {
   const agent = options?.agent ?? makeAgent();
+  let configCalls = 0;
   const sdk = {
     register: vi.fn(async () => agent),
     fetchAgentConfig: vi.fn(async () => {
+      configCalls++;
+      const blip = options?.configErrorsThenSucceed;
+      if (blip && configCalls <= blip.times) throw blip.error;
       if (options?.configError) throw options.configError;
       return {
         agentId: agent.agentId,
@@ -223,6 +232,7 @@ function installMocks(options: { syncResult?: MockState["syncResult"]; syncDelay
 async function makeSlot(options?: {
   agent?: RegisterResult;
   configError?: unknown;
+  configErrorsThenSucceed?: { error: unknown; times: number };
   runtimeType?: string;
   syncResult?: MockState["syncResult"];
   syncDelayMs?: number;
@@ -234,7 +244,11 @@ async function makeSlot(options?: {
   state: MockState;
 }> {
   const state = installMocks({ syncResult: options?.syncResult, syncDelayMs: options?.syncDelayMs });
-  const sdk = makeSdk({ agent: options?.agent, configError: options?.configError });
+  const sdk = makeSdk({
+    agent: options?.agent,
+    configError: options?.configError,
+    configErrorsThenSucceed: options?.configErrorsThenSucceed,
+  });
   const connection = new FakeClientConnection(sdk);
   const { AgentSlot } = await import("../runtime/agent-slot.js");
   const handlerFactory = vi.fn((config: HandlerConfig) => ({
@@ -309,17 +323,17 @@ describe("AgentSlot", () => {
     expect(state.logger.info).toHaveBeenCalledWith("server reports type=human — message processing disabled");
   });
 
-  it("wraps runtime config fetch failures with a bind-aborted error", async () => {
-    const { slot, connection, state } = await makeSlot({ configError: new Error("server offline") });
+  it("aborts the bind immediately on a permanent (4xx) config rejection — no retry", async () => {
+    const { slot, connection, sdk, state } = await makeSlot({ configError: new SdkError(403, "forbidden") });
 
-    await expect(slot.start()).rejects.toThrow(
-      "First Tree server unreachable while loading agent config: server offline",
-    );
+    await expect(slot.start()).rejects.toThrow(/rejected agent config \(config_unauthorized\)/);
 
+    // A deterministic 4xx must not be retried — exactly one fetch, then abort.
+    expect(vi.mocked(sdk.fetchAgentConfig)).toHaveBeenCalledTimes(1);
     expect(connection.unbindAgent).toHaveBeenCalledWith("agent-1");
     expect(state.logger.error).toHaveBeenCalledWith(
-      { err: new Error("server offline") },
-      "failed to fetch agent config — bind aborted",
+      expect.objectContaining({ reasonCode: "config_unauthorized" }),
+      "agent config fetch rejected — bind aborted",
     );
   });
 
@@ -344,17 +358,71 @@ describe("AgentSlot", () => {
     expect(connection.listenerCount("session:reconcile:result")).toBe(1);
   });
 
-  it("stringifies non-Error runtime config fetch failures", async () => {
-    const { slot, state } = await makeSlot({ configError: "server string offline" });
+  it("self-heals a transient config fetch failure: retries with backoff, then binds", async () => {
+    vi.useFakeTimers();
+    const { slot, connection, sdk, state } = await makeSlot({
+      configErrorsThenSucceed: { error: new SdkError(503, "boom"), times: 1 },
+    });
 
-    await expect(slot.start()).rejects.toThrow(
-      "First Tree server unreachable while loading agent config: server string offline",
-    );
+    const startPromise = slot.start();
+    // Advance past the first backoff (~1s base + jitter) so the retry runs.
+    await vi.advanceTimersByTimeAsync(3_000);
+    await expect(startPromise).resolves.toMatchObject({ agentId: "agent-1" });
 
-    expect(state.logger.error).toHaveBeenCalledWith(
-      { err: "server string offline" },
-      "failed to fetch agent config — bind aborted",
+    expect(vi.mocked(sdk.fetchAgentConfig)).toHaveBeenCalledTimes(2);
+    expect(connection.unbindAgent).not.toHaveBeenCalled();
+    // SessionManager built → the agent is genuinely online, not a dead slot.
+    expect(state.sessions).toHaveLength(1);
+  });
+
+  it("aborts the bind after exhausting retries on a sustained transient failure", async () => {
+    vi.useFakeTimers();
+    const { slot, connection, sdk } = await makeSlot({ configError: new SdkError(503, "down") });
+
+    const outcome = slot.start().then(
+      () => ({ ok: true }) as const,
+      (err: unknown) => ({ ok: false, err }) as const,
     );
+    // Drain every backoff sleep; each is scheduled after the prior fetch rejects.
+    await vi.advanceTimersByTimeAsync(200_000);
+    await vi.advanceTimersByTimeAsync(200_000);
+    const settled = await outcome;
+
+    expect(settled.ok).toBe(false);
+    if (!settled.ok) {
+      expect((settled.err as Error).message).toMatch(/after \d+ attempts/);
+    }
+    // Bounded retry: far more than the SDK's ~1.5s transport budget, then give up.
+    expect(vi.mocked(sdk.fetchAgentConfig)).toHaveBeenCalledTimes(8);
+    expect(connection.unbindAgent).toHaveBeenCalledWith("agent-1");
+  });
+
+  it("does not build a session if stop() aborts while the config fetch is in flight", async () => {
+    const { slot, sdk, state } = await makeSlot();
+    // The server unbinds us (→ stop()) while the config fetch is in flight, and
+    // the fetch then resolves successfully — the slot must NOT come online.
+    vi.mocked(sdk.fetchAgentConfig).mockImplementationOnce(async () => {
+      void slot.stop();
+      return {
+        agentId: "agent-1",
+        version: 7,
+        payload: {
+          kind: "claude-code",
+          prompt: { append: "" },
+          model: "claude-sonnet",
+          mcpServers: [],
+          env: [],
+          gitRepos: [],
+          resourceSkills: [],
+          reasoningEffort: "",
+        },
+        updatedAt: "2026-01-01T00:00:00.000Z",
+        updatedBy: "user-1",
+      };
+    });
+
+    await expect(slot.start()).rejects.toThrow(/aborted — slot stopping/);
+    expect(state.sessions).toHaveLength(0);
   });
 
   it("starts processing, dispatches pushed frames, reconciles state, and stops cleanly", async () => {

--- a/packages/client/src/__tests__/error-taxonomy.test.ts
+++ b/packages/client/src/__tests__/error-taxonomy.test.ts
@@ -349,6 +349,60 @@ describe("error-taxonomy.classify", () => {
       expect(c.message).toContain('"nested":true');
     });
   });
+
+  describe("source=config", () => {
+    // The agent row and its config row are created in the same DB transaction
+    // (server `agent.ts` create path), so a 4xx from `/agent/config` is a
+    // deterministic, non-self-healing condition — never a bring-up race.
+    const cfg = (statusCode: number, message = "config error") => Object.assign(new Error(message), { statusCode });
+
+    it("401 → permanent (auth rejected, won't self-heal)", () => {
+      const c = classify(cfg(401), { source: "config" });
+      expect(c.kind).toBe(ERROR_KINDS.PERMANENT);
+      expect(c.strategy.kind).toBe("none");
+      expect(c.reasonCode).toBe("config_unauthorized");
+    });
+
+    it("403 → permanent (forbidden)", () => {
+      const c = classify(cfg(403), { source: "config" });
+      expect(c.kind).toBe(ERROR_KINDS.PERMANENT);
+      expect(c.reasonCode).toBe("config_unauthorized");
+    });
+
+    it("404 → permanent (agent/config row is gone, not a race)", () => {
+      const c = classify(cfg(404), { source: "config" });
+      expect(c.kind).toBe(ERROR_KINDS.PERMANENT);
+      expect(c.reasonCode).toBe("config_rejected");
+    });
+
+    it("400 → permanent (deterministic bad request)", () => {
+      expect(classify(cfg(400), { source: "config" }).kind).toBe(ERROR_KINDS.PERMANENT);
+    });
+
+    it("503 → transient with exponential backoff", () => {
+      const c = classify(cfg(503), { source: "config" });
+      expect(c.kind).toBe(ERROR_KINDS.TRANSIENT);
+      expect(c.strategy.kind).toBe("exponentialBackoff");
+    });
+
+    it("429 → transient (rate limited)", () => {
+      expect(classify(cfg(429), { source: "config" }).kind).toBe(ERROR_KINDS.TRANSIENT);
+    });
+
+    it("408 → transient (request timeout)", () => {
+      expect(classify(cfg(408), { source: "config" }).kind).toBe(ERROR_KINDS.TRANSIENT);
+    });
+
+    it("network failure → transient", () => {
+      const c = classify(Object.assign(new Error("fetch failed"), { code: "ECONNRESET" }), { source: "config" });
+      expect(c.kind).toBe(ERROR_KINDS.TRANSIENT);
+    });
+
+    it("unknown non-HTTP failure → transient (conservative)", () => {
+      expect(classify(new Error("weird"), { source: "config" }).kind).toBe(ERROR_KINDS.TRANSIENT);
+      expect(classify("oops", { source: "config" }).kind).toBe(ERROR_KINDS.TRANSIENT);
+    });
+  });
 });
 
 describe("error-taxonomy.nextRetryDelayMs", () => {

--- a/packages/client/src/runtime/agent-slot.ts
+++ b/packages/client/src/runtime/agent-slot.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path";
 import type {
+  AgentRuntimeConfig,
   InboxDeliverFrame,
   InboxEntryWithMessage,
   RuntimeState,
@@ -14,8 +15,40 @@ import type { RegisterResult } from "../sdk.js";
 import { type AgentConfigCache, createAgentConfigCache } from "./agent-config-cache.js";
 import { resolveAgentContextTreeBinding } from "./bootstrap.js";
 import type { SessionConfig } from "./config.js";
+import { clampRetryAttempt, classify, ERROR_KINDS, nextRetryDelayMs } from "./error-taxonomy.js";
 import type { HandlerFactory } from "./handler.js";
 import { SessionManager } from "./session-manager.js";
+
+/**
+ * Max attempts to fetch the agent's runtime config during bring-up before a
+ * sustained transient failure aborts the bind. With the taxonomy's transient
+ * backoff (1s base, exponential) this spans ~2 minutes of patient retry —
+ * far beyond the SDK transport layer's ~1.5s budget, so a brief server blip
+ * self-heals without a daemon restart, while a genuinely-down server still
+ * gives up in bounded time instead of blocking bring-up forever.
+ */
+const MAX_CONFIG_FETCH_ATTEMPTS = 8;
+
+/**
+ * Sleep `ms`, resolving early if `signal` aborts. Lets a stop()/unbind during
+ * the bring-up retry window interrupt the backoff immediately instead of
+ * waiting out the full delay. Resolves (never rejects); callers re-check
+ * `signal.aborted` after awaiting.
+ */
+function sleepWithAbort(ms: number, signal?: AbortSignal): Promise<void> {
+  if (ms <= 0 || signal?.aborted) return Promise.resolve();
+  return new Promise((resolve) => {
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
 
 export type AgentSlotConfig = {
   name: string;
@@ -56,6 +89,12 @@ export class AgentSlot {
   private listeners: ConnectionListener[] = [];
   private stopping: Promise<void> | null = null;
   /**
+   * Aborts an in-flight bring-up config-fetch retry (see
+   * {@link loadAgentConfigWithRetry}) so a stop()/unbind during the backoff
+   * window doesn't have to wait out the current delay. Created in `start()`.
+   */
+  private bringupAbort: AbortController | null = null;
+  /**
    * The inbox this slot's agent owns — used to filter `inbox:deliver`
    * frames addressed to other agents on the same client. Captured at
    * `start()` from `sdk.register()`.
@@ -89,6 +128,7 @@ export class AgentSlot {
   }
 
   async start(): Promise<RegisterResult> {
+    this.bringupAbort = new AbortController();
     // Attach listeners BEFORE `bindAgent` so the server's bind-time
     // reset+drain push (which fires within ~1ms of the `agent:bound`
     // response on the server side) never lands on a listener-less
@@ -180,14 +220,8 @@ export class AgentSlot {
       }
 
       this.agentConfigCache = createAgentConfigCache({ sdk, log: this.logger });
-      try {
-        const cfg = await this.agentConfigCache.refresh(agent.agentId);
-        this.logger.info({ version: cfg.version }, "runtime config loaded");
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        this.logger.error({ err }, "failed to fetch agent config — bind aborted");
-        throw new Error(`First Tree server unreachable while loading agent config: ${msg}`);
-      }
+      const cfg = await this.loadAgentConfigWithRetry(agent.agentId);
+      this.logger.info({ version: cfg.version }, "runtime config loaded");
 
       this.inboxId = agent.inboxId;
       // Per-agent home — also the parent of the agent-managed Context Tree
@@ -302,6 +336,68 @@ export class AgentSlot {
     }
   }
 
+  /**
+   * Fetch the agent's runtime config during bring-up, retrying transient
+   * failures with capped exponential backoff instead of killing the slot on
+   * the first error. This fetch runs only after the WebSocket has connected
+   * and the agent has bound, so a failure here is almost always a brief server
+   * blip (5xx, a slow PG query, a network stutter) — the same class of failure
+   * {@link ClientConnection.connect} already rides out with an in-process retry
+   * loop. Pre-fix, one blip threw, aborted the bind, and left the agent offline
+   * until a daemon restart — a root cause of onboarding's "unanswered first
+   * chat".
+   *
+   * Transient failures retry up to {@link MAX_CONFIG_FETCH_ATTEMPTS}; permanent
+   * or degraded failures (4xx auth / not-found, classified by the shared error
+   * taxonomy) abort immediately with a clear reason rather than retrying a
+   * request that cannot succeed.
+   */
+  private async loadAgentConfigWithRetry(agentId: string): Promise<AgentRuntimeConfig> {
+    const cache = this.agentConfigCache;
+    if (!cache) throw new Error("agent config cache not initialised");
+    const signal = this.bringupAbort?.signal;
+    let attempt = 0;
+    while (true) {
+      try {
+        const cfg = await cache.refresh(agentId);
+        // A stop()/unbind may have fired while the fetch was in flight (the
+        // retry window is up to ~2 min); don't build a live session for a slot
+        // that is already tearing down.
+        if (signal?.aborted) throw new Error("agent config fetch aborted — slot stopping");
+        return cfg;
+      } catch (err) {
+        if (signal?.aborted) throw new Error("agent config fetch aborted — slot stopping");
+        attempt++;
+        const classification = classify(err, { source: "config" });
+        if (classification.kind !== ERROR_KINDS.TRANSIENT) {
+          this.logger.error(
+            { err, reasonCode: classification.reasonCode },
+            "agent config fetch rejected — bind aborted",
+          );
+          throw new Error(
+            `First Tree server rejected agent config (${classification.reasonCode}): ${classification.message}`,
+          );
+        }
+        if (attempt >= MAX_CONFIG_FETCH_ATTEMPTS) {
+          this.logger.error(
+            { err, attempts: attempt, reasonCode: classification.reasonCode },
+            "agent config fetch exhausted retries — bind aborted",
+          );
+          throw new Error(
+            `First Tree server unreachable while loading agent config after ${attempt} attempts: ${classification.message}`,
+          );
+        }
+        const delayMs = nextRetryDelayMs(classification.strategy, clampRetryAttempt(attempt));
+        this.logger.warn(
+          { err, attempt, delayMs, reasonCode: classification.reasonCode },
+          "agent config fetch failed — retrying with backoff",
+        );
+        await sleepWithAbort(delayMs, signal);
+        if (signal?.aborted) throw new Error("agent config fetch aborted — slot stopping");
+      }
+    }
+  }
+
   async stop(): Promise<void> {
     if (this.stopping) return this.stopping;
     this.stopping = this.stopOnce();
@@ -313,6 +409,7 @@ export class AgentSlot {
   }
 
   private async stopOnce(): Promise<void> {
+    this.bringupAbort?.abort();
     if (this.reconcileTimer) {
       clearInterval(this.reconcileTimer);
       this.reconcileTimer = null;
@@ -334,6 +431,7 @@ export class AgentSlot {
   }
 
   private async cleanupFailedStart(opts: { unbind: boolean }): Promise<void> {
+    this.bringupAbort?.abort();
     if (this.reconcileTimer) {
       clearInterval(this.reconcileTimer);
       this.reconcileTimer = null;

--- a/packages/client/src/runtime/error-taxonomy.ts
+++ b/packages/client/src/runtime/error-taxonomy.ts
@@ -29,7 +29,7 @@ export const ERROR_KINDS = {
 
 export type ErrorKind = (typeof ERROR_KINDS)[keyof typeof ERROR_KINDS];
 
-export type ErrorSource = "session" | "auth" | "bind" | "update" | "stream";
+export type ErrorSource = "session" | "auth" | "bind" | "update" | "stream" | "config";
 
 export type RetryStrategy =
   | { kind: "exponentialBackoff"; baseMs: number; capMs: number; jitter: boolean }
@@ -212,6 +212,26 @@ export function classify(err: unknown, context?: { source?: ErrorSource }): Clas
       reasonCode: "npm_unknown",
       message: shape.message ?? "npm install failed",
     };
+  }
+
+  // -- Config fetch (agent bring-up) ----------------------------------------
+  // A deterministic 4xx from `/agent/config` does not self-heal: the agent row
+  // and its config row are created in the same DB transaction, so a 404 means
+  // the agent is gone, and 401/403 mean the member JWT is rejected — a human
+  // must act. 408 (timeout) and 429 (rate limit) are the retryable 4xx and
+  // fall through to the transient handlers below, as do 5xx / network /
+  // unknown failures.
+  if (source === "config") {
+    const status = statusOf(shape);
+    if (status !== null && status >= 400 && status < 500 && status !== 408 && status !== 429) {
+      const unauthorized = status === 401 || status === 403;
+      return {
+        kind: ERROR_KINDS.PERMANENT,
+        strategy: NONE,
+        reasonCode: unauthorized ? "config_unauthorized" : "config_rejected",
+        message: shape.message ?? `Agent config request rejected (${status})`,
+      };
+    }
   }
 
   // -- Permanent shapes by error class --------------------------------------


### PR DESCRIPTION
## Why

A config fetch failure during agent bring-up (`AgentSlot.start`) threw immediately, aborted the bind, unbound the agent, and left it offline until a daemon restart — one root cause of onboarding's "unanswered first chat" (a brand-new user's first message lands on an agent that never comes online).

This fetch runs **after** the WebSocket has connected and the agent has bound, so a failure here is almost always a brief server blip (a 5xx from a slow PG query, a network stutter). The SDK transport layer (`sdk.ts` `doFetch`) only retries transient *network* codes for ~1.5s and 5xx for 3 quick attempts; a slightly longer blip or a single non-network failure killed the slot until a daemon restart.

This is **layer ① (client runtime) of a 3-layer fix** for the "unanswered first chat" root cause. Layers ② (first-chat presence / "no response yet" UI) and ③ (onboarding 30s/60s timing) are separate PRs.

## What

Wrap the bring-up config fetch in a capped exponential-backoff retry loop in `AgentSlot`, mirroring `ClientConnection.connect`'s existing in-process bring-up resilience, classified by the shared error taxonomy (`error-taxonomy.ts`, new `config` source):

- **Transient** (5xx / 408 / 429 / network / unknown): retry up to `MAX_CONFIG_FETCH_ATTEMPTS` (8, ~2 min) so a brief blip self-heals without a daemon restart.
- **Permanent** (4xx auth / not-found): abort immediately with a classified reason rather than retrying a request that cannot succeed. The agent row and its config row are created in the **same DB transaction** (`server/services/agent.ts`), so a 404 means the agent is gone, not a bring-up race.

The retry is abortable: a `stop()`/unbind during the (now up to ~2 min) backoff window exits immediately rather than waiting out the delay, and never builds a live session for a slot that is already tearing down.

## Testing

- `error-taxonomy.test.ts`: new `source=config` cases (401/403 → permanent, 404/400 → permanent, 408/429/503/network/unknown → transient).
- `agent-slot.test.ts`: permanent 4xx aborts immediately with no retry; a transient blip retries with backoff then binds (agent comes online, no daemon restart); a sustained transient failure exhausts the bounded retries then aborts; `stop()` during an in-flight fetch builds no session.
- `pnpm --filter @first-tree/client exec vitest run` green (the one unrelated codex-binary launch-verify test is a pre-existing timeout flake under parallel load — passes in isolation).
- `pnpm check` (biome) + `pnpm --filter @first-tree/client typecheck` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)