### PR TITLE
feat(agents): adopt a member's first agent as their delegate

### DIFF
--- a/packages/server/src/__tests__/agent-first-agent-delegate.test.ts
+++ b/packages/server/src/__tests__/agent-first-agent-delegate.test.ts
@@ -6,15 +6,15 @@ import { createAgent, updateAgent } from "../services/agent.js";
 import { createTestAdmin, useTestApp } from "./helpers.js";
 
 /**
- * First-agent → delegate adoption (createAgent).
+ * First-agent → delegate adoption (createAgent + POST /orgs/:orgId/agents).
  *
  * A member's FIRST non-human agent is auto-adopted as their delegate
  * (`delegateMention` on their human agent), so the new-chat default recipient
- * and the GitHub @mention forward target work out of the box with no manual
- * trip to the profile editor. The adoption is only-if-unset and
- * first-agent-only, and never fires on the system/webhook agent path (which
- * supplies no caller `managerId`). Companion to the source-type and cross-org
- * delegate guards.
+ * and the GitHub @mention forward target work out of the box. Adoption fires
+ * only on a SELF-create (the route passes `adoptAsDelegateIfFirst` only when
+ * `managerId === scope.memberId`), is first-agent-only, and is only-if-unset
+ * (atomic via a `delegateMention IS NULL` UPDATE guard). Companion to the
+ * source-type and cross-org delegate guards.
  */
 async function readDelegate(
   app: ReturnType<ReturnType<typeof useTestApp>>,
@@ -31,17 +31,16 @@ async function readDelegate(
 describe("agent service — first-agent delegate adoption", () => {
   const getApp = useTestApp();
 
-  it("adopts a member's first agent as their delegate", async () => {
+  it("adopts a member's first agent as their delegate when self-created", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
     expect(await readDelegate(app, admin.humanAgentUuid)).toBeNull();
 
-    const first = await createAgent(app.db, {
-      name: `a1-${randomUUID().slice(0, 6)}`,
-      type: "agent",
-      displayName: "First",
-      managerId: admin.memberId,
-    });
+    const first = await createAgent(
+      app.db,
+      { name: `a1-${randomUUID().slice(0, 6)}`, type: "agent", displayName: "First", managerId: admin.memberId },
+      { adoptAsDelegateIfFirst: true },
+    );
 
     expect(await readDelegate(app, admin.humanAgentUuid)).toBe(first.uuid);
   });
@@ -50,33 +49,52 @@ describe("agent service — first-agent delegate adoption", () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
 
-    const first = await createAgent(app.db, {
-      name: `pa-${randomUUID().slice(0, 6)}`,
-      type: "agent",
-      displayName: "Private assistant",
-      visibility: "private",
-      managerId: admin.memberId,
-    });
+    const first = await createAgent(
+      app.db,
+      {
+        name: `pa-${randomUUID().slice(0, 6)}`,
+        type: "agent",
+        displayName: "Private assistant",
+        visibility: "private",
+        managerId: admin.memberId,
+      },
+      { adoptAsDelegateIfFirst: true },
+    );
 
     expect(first.visibility).toBe("private");
     expect(await readDelegate(app, admin.humanAgentUuid)).toBe(first.uuid);
   });
 
+  it("does not adopt unless the self-create intent is passed", async () => {
+    // The bootstrap, system/webhook, and admin-for-other paths never pass
+    // `adoptAsDelegateIfFirst`, so a first agent created without it leaves the
+    // manager's delegate untouched.
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+
+    await createAgent(app.db, {
+      name: `sys-${randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "System",
+      managerId: admin.memberId,
+    });
+
+    expect(await readDelegate(app, admin.humanAgentUuid)).toBeNull();
+  });
+
   it("does not change the delegate when a second agent is created", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
-    const first = await createAgent(app.db, {
-      name: `a1-${randomUUID().slice(0, 6)}`,
-      type: "agent",
-      displayName: "First",
-      managerId: admin.memberId,
-    });
-    const second = await createAgent(app.db, {
-      name: `a2-${randomUUID().slice(0, 6)}`,
-      type: "agent",
-      displayName: "Second",
-      managerId: admin.memberId,
-    });
+    const first = await createAgent(
+      app.db,
+      { name: `a1-${randomUUID().slice(0, 6)}`, type: "agent", displayName: "First", managerId: admin.memberId },
+      { adoptAsDelegateIfFirst: true },
+    );
+    const second = await createAgent(
+      app.db,
+      { name: `a2-${randomUUID().slice(0, 6)}`, type: "agent", displayName: "Second", managerId: admin.memberId },
+      { adoptAsDelegateIfFirst: true },
+    );
 
     expect(second.uuid).not.toBe(first.uuid);
     expect(await readDelegate(app, admin.humanAgentUuid)).toBe(first.uuid);
@@ -86,43 +104,83 @@ describe("agent service — first-agent delegate adoption", () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
     // A second member in the same org owns the pre-set target, so it does not
-    // count toward `admin`'s own-agent tally (which keeps the first-agent count
-    // at 1 below — isolating the only-if-unset guard from the count guard).
+    // count toward `admin`'s own-agent tally (keeping the first-agent count at 1
+    // below — isolating the only-if-unset guard from the count guard).
     const other = await createTestAdmin(app);
-    const target = await createAgent(app.db, {
-      name: `tgt-${randomUUID().slice(0, 6)}`,
-      type: "agent",
-      displayName: "Pre-set target",
-      visibility: "organization",
-      managerId: other.memberId,
-    });
+    const target = await createAgent(
+      app.db,
+      {
+        name: `tgt-${randomUUID().slice(0, 6)}`,
+        type: "agent",
+        displayName: "Pre-set target",
+        visibility: "organization",
+        managerId: other.memberId,
+      },
+      { adoptAsDelegateIfFirst: true },
+    );
     await updateAgent(app.db, admin.humanAgentUuid, { delegateMention: target.uuid });
 
     // admin's OWN first agent — tally is 1, but the delegate is already set.
-    await createAgent(app.db, {
-      name: `a1-${randomUUID().slice(0, 6)}`,
-      type: "agent",
-      displayName: "First own",
-      managerId: admin.memberId,
-    });
+    await createAgent(
+      app.db,
+      { name: `a1-${randomUUID().slice(0, 6)}`, type: "agent", displayName: "First own", managerId: admin.memberId },
+      { adoptAsDelegateIfFirst: true },
+    );
 
     expect(await readDelegate(app, admin.humanAgentUuid)).toBe(target.uuid);
   });
+});
 
-  it("does not adopt on the system/webhook path (no caller managerId)", async () => {
+describe("POST /orgs/:orgId/agents — delegate adoption is self-only", () => {
+  const getApp = useTestApp();
+
+  async function postAgent(
+    app: ReturnType<ReturnType<typeof useTestApp>>,
+    accessToken: string,
+    orgId: string,
+    body: Record<string, unknown>,
+  ) {
+    return app.inject({
+      method: "POST",
+      url: `/api/v1/orgs/${orgId}/agents`,
+      headers: { authorization: `Bearer ${accessToken}` },
+      payload: body,
+    });
+  }
+
+  it("adopts the caller's first agent as their delegate on a self-create", async () => {
+    const app = getApp();
+    const member = await createTestAdmin(app);
+
+    const res = await postAgent(app, member.accessToken, member.organizationId, {
+      name: `mine-${randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "Mine",
+    });
+    expect(res.statusCode).toBe(201);
+    const created = res.json() as { uuid: string };
+
+    expect(await readDelegate(app, member.humanAgentUuid)).toBe(created.uuid);
+  });
+
+  it("does NOT set another member's delegate when an admin creates an agent for them", async () => {
+    // Regression: delegate is a personal choice — the PATCH path rejects an
+    // admin setting another member's delegate, so create-for-other must not set
+    // it as a side effect either.
     const app = getApp();
     const admin = await createTestAdmin(app);
+    const bob = await createTestAdmin(app); // same default org, a different member
 
-    // Branch 3: with no `managerId`, the manager resolves to the org's admin,
-    // but the adoption guard requires a caller-supplied `managerId`, so it
-    // no-ops and a webhook-spawned agent never hijacks the admin's delegate.
-    await createAgent(app.db, {
-      name: `sys-${randomUUID().slice(0, 6)}`,
+    const res = await postAgent(app, admin.accessToken, admin.organizationId, {
+      name: `for-bob-${randomUUID().slice(0, 6)}`,
       type: "agent",
-      displayName: "System",
-      organizationId: admin.organizationId,
+      displayName: "For Bob",
+      managerId: bob.memberId,
     });
+    expect(res.statusCode).toBe(201);
 
-    expect(await readDelegate(app, admin.humanAgentUuid)).toBeNull();
+    // Bob's first agent now exists, but his delegate was NOT touched by the
+    // admin's create.
+    expect(await readDelegate(app, bob.humanAgentUuid)).toBeNull();
   });
 });

--- a/packages/server/src/__tests__/agent-first-agent-delegate.test.ts
+++ b/packages/server/src/__tests__/agent-first-agent-delegate.test.ts
@@ -1,0 +1,128 @@
+import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import { agents } from "../db/schema/agents.js";
+import { createAgent, updateAgent } from "../services/agent.js";
+import { createTestAdmin, useTestApp } from "./helpers.js";
+
+/**
+ * First-agent → delegate adoption (createAgent).
+ *
+ * A member's FIRST non-human agent is auto-adopted as their delegate
+ * (`delegateMention` on their human agent), so the new-chat default recipient
+ * and the GitHub @mention forward target work out of the box with no manual
+ * trip to the profile editor. The adoption is only-if-unset and
+ * first-agent-only, and never fires on the system/webhook agent path (which
+ * supplies no caller `managerId`). Companion to the source-type and cross-org
+ * delegate guards.
+ */
+async function readDelegate(
+  app: ReturnType<ReturnType<typeof useTestApp>>,
+  humanAgentUuid: string,
+): Promise<string | null> {
+  const [row] = await app.db
+    .select({ delegateMention: agents.delegateMention })
+    .from(agents)
+    .where(eq(agents.uuid, humanAgentUuid))
+    .limit(1);
+  return row?.delegateMention ?? null;
+}
+
+describe("agent service — first-agent delegate adoption", () => {
+  const getApp = useTestApp();
+
+  it("adopts a member's first agent as their delegate", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    expect(await readDelegate(app, admin.humanAgentUuid)).toBeNull();
+
+    const first = await createAgent(app.db, {
+      name: `a1-${randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "First",
+      managerId: admin.memberId,
+    });
+
+    expect(await readDelegate(app, admin.humanAgentUuid)).toBe(first.uuid);
+  });
+
+  it("adopts a private first agent (visibility is not required)", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+
+    const first = await createAgent(app.db, {
+      name: `pa-${randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "Private assistant",
+      visibility: "private",
+      managerId: admin.memberId,
+    });
+
+    expect(first.visibility).toBe("private");
+    expect(await readDelegate(app, admin.humanAgentUuid)).toBe(first.uuid);
+  });
+
+  it("does not change the delegate when a second agent is created", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const first = await createAgent(app.db, {
+      name: `a1-${randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "First",
+      managerId: admin.memberId,
+    });
+    const second = await createAgent(app.db, {
+      name: `a2-${randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "Second",
+      managerId: admin.memberId,
+    });
+
+    expect(second.uuid).not.toBe(first.uuid);
+    expect(await readDelegate(app, admin.humanAgentUuid)).toBe(first.uuid);
+  });
+
+  it("does not overwrite a delegate already set before the member's first own agent", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    // A second member in the same org owns the pre-set target, so it does not
+    // count toward `admin`'s own-agent tally (which keeps the first-agent count
+    // at 1 below — isolating the only-if-unset guard from the count guard).
+    const other = await createTestAdmin(app);
+    const target = await createAgent(app.db, {
+      name: `tgt-${randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "Pre-set target",
+      visibility: "organization",
+      managerId: other.memberId,
+    });
+    await updateAgent(app.db, admin.humanAgentUuid, { delegateMention: target.uuid });
+
+    // admin's OWN first agent — tally is 1, but the delegate is already set.
+    await createAgent(app.db, {
+      name: `a1-${randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "First own",
+      managerId: admin.memberId,
+    });
+
+    expect(await readDelegate(app, admin.humanAgentUuid)).toBe(target.uuid);
+  });
+
+  it("does not adopt on the system/webhook path (no caller managerId)", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+
+    // Branch 3: with no `managerId`, the manager resolves to the org's admin,
+    // but the adoption guard requires a caller-supplied `managerId`, so it
+    // no-ops and a webhook-spawned agent never hijacks the admin's delegate.
+    await createAgent(app.db, {
+      name: `sys-${randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "System",
+      organizationId: admin.organizationId,
+    });
+
+    expect(await readDelegate(app, admin.humanAgentUuid)).toBeNull();
+  });
+});

--- a/packages/server/src/api/orgs/agents.ts
+++ b/packages/server/src/api/orgs/agents.ts
@@ -128,12 +128,21 @@ export async function orgAgentRoutes(app: FastifyInstance): Promise<void> {
     // member role: managerId forced to caller's member; admin role may
     // specify any managerId in the same org.
     const managerId = scope.role === "admin" ? (body.managerId ?? scope.memberId) : scope.memberId;
-    const agent = await agentService.createAgent(app.db, {
-      ...body,
-      organizationId: scope.organizationId,
-      source: body.source ?? "admin-api",
-      managerId,
-    });
+    // First-agent → delegate adoption fires ONLY for a self-create. Delegate is
+    // a personal choice (the PATCH path rejects an admin setting another
+    // member's delegate), so an admin creating an agent FOR another member must
+    // not implicitly set that member's delegate. Only the caller acting on
+    // their own member can adopt.
+    const agent = await agentService.createAgent(
+      app.db,
+      {
+        ...body,
+        organizationId: scope.organizationId,
+        source: body.source ?? "admin-api",
+        managerId,
+      },
+      { adoptAsDelegateIfFirst: managerId === scope.memberId },
+    );
     notifyClientAgentPinned(agent);
     return reply.status(201).send({
       ...agent,

--- a/packages/server/src/services/agent.ts
+++ b/packages/server/src/services/agent.ts
@@ -17,7 +17,7 @@ import {
   runtimeProviderSchema,
 } from "@first-tree/shared";
 import { getServerCliBinding } from "@first-tree/shared/channel";
-import { and, count, desc, eq, getTableColumns, ilike, lt, ne, or } from "drizzle-orm";
+import { and, count, desc, eq, getTableColumns, ilike, isNull, lt, ne, or } from "drizzle-orm";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import type { Database } from "../db/connection.js";
 import { agentConfigs } from "../db/schema/agent-configs.js";
@@ -371,7 +371,7 @@ async function resolveFallbackManagerId(db: Database, orgId: string): Promise<st
 export async function createAgent(
   db: Database,
   data: CreateAgent & { managerId?: string },
-  options: { force?: boolean } = {},
+  options: { force?: boolean; adoptAsDelegateIfFirst?: boolean } = {},
 ) {
   const uuid = uuidv7();
   const name = data.name ?? null;
@@ -537,19 +537,28 @@ export async function createAgent(
       // without a manual trip to the profile editor. Runs inside this
       // transaction so the delegate is set atomically with the agent insert.
       // Guards keep it safe and unsurprising:
-      //   - only `type=agent` created through a user path (`data.managerId`
-      //     supplied) — excludes the human-bootstrap insert and the
-      //     system/webhook agent path (branch 3 omits `managerId`);
-      //   - only when the member has no delegate yet — never overwrites a
-      //     deliberate choice (incl. a delegate pointing at someone else's
-      //     org-visible agent set before they had any agent of their own);
-      //   - only their FIRST agent — the just-inserted row makes the count 1,
-      //     so a 2nd agent never steals the delegate.
+      //   - SELF-CREATED ONLY. `delegateMention` is a personal choice the
+      //     self-only API guard reserves to the member (an admin PATCHing
+      //     another member's delegate is rejected). The org agent route lets an
+      //     admin create an agent FOR another member, so gating on a resolved
+      //     managerId alone would let create-for-Bob silently set Bob's
+      //     delegate — the same write the PATCH guard forbids. The caller is
+      //     the only one who knows "this is my own create", so the route passes
+      //     `adoptAsDelegateIfFirst` true only when `managerId === scope.memberId`.
+      //     Every non-self path (admin-for-other, member bootstrap, system /
+      //     webhook) omits it and never triggers adoption.
+      //   - FIRST agent only — the just-inserted row makes the count 1, so a
+      //     2nd agent never steals the delegate.
+      //   - ONLY-IF-UNSET, atomically — the final UPDATE carries
+      //     `delegateMention IS NULL` in its WHERE, so two concurrent
+      //     first-creates can't both win on a stale read; the second's write
+      //     no-ops instead of clobbering the first. Never overwrites a
+      //     deliberate choice either.
       // The agent stays whatever visibility it was created with (private by
       // default); the picker and webhook routing both accept a private
       // delegate, so no visibility change is forced. Reversible: the member
       // can re-point or clear it anytime.
-      if (data.managerId && data.type === AGENT_TYPES.AGENT) {
+      if (options.adoptAsDelegateIfFirst && data.type === AGENT_TYPES.AGENT) {
         const [manager] = await tx
           .select({ humanAgentId: members.agentId })
           .from(members)
@@ -573,7 +582,10 @@ export async function createAgent(
                 ),
               );
             if ((tally?.value ?? 0) === 1) {
-              await tx.update(agents).set({ delegateMention: row.uuid }).where(eq(agents.uuid, human.uuid));
+              await tx
+                .update(agents)
+                .set({ delegateMention: row.uuid })
+                .where(and(eq(agents.uuid, human.uuid), isNull(agents.delegateMention)));
             }
           }
         }

--- a/packages/server/src/services/agent.ts
+++ b/packages/server/src/services/agent.ts
@@ -530,6 +530,55 @@ export async function createAgent(
         })
         .onConflictDoNothing();
 
+      // First-agent → delegate adoption. When a member creates their FIRST
+      // non-human agent and hasn't picked a delegate yet, adopt it as their
+      // delegate (`delegateMention` on their human agent) so it becomes the
+      // new-chat default recipient and the GitHub @mention forward target
+      // without a manual trip to the profile editor. Runs inside this
+      // transaction so the delegate is set atomically with the agent insert.
+      // Guards keep it safe and unsurprising:
+      //   - only `type=agent` created through a user path (`data.managerId`
+      //     supplied) — excludes the human-bootstrap insert and the
+      //     system/webhook agent path (branch 3 omits `managerId`);
+      //   - only when the member has no delegate yet — never overwrites a
+      //     deliberate choice (incl. a delegate pointing at someone else's
+      //     org-visible agent set before they had any agent of their own);
+      //   - only their FIRST agent — the just-inserted row makes the count 1,
+      //     so a 2nd agent never steals the delegate.
+      // The agent stays whatever visibility it was created with (private by
+      // default); the picker and webhook routing both accept a private
+      // delegate, so no visibility change is forced. Reversible: the member
+      // can re-point or clear it anytime.
+      if (data.managerId && data.type === AGENT_TYPES.AGENT) {
+        const [manager] = await tx
+          .select({ humanAgentId: members.agentId })
+          .from(members)
+          .where(eq(members.id, managerId))
+          .limit(1);
+        if (manager) {
+          const [human] = await tx
+            .select({ uuid: agents.uuid, delegateMention: agents.delegateMention, type: agents.type })
+            .from(agents)
+            .where(eq(agents.uuid, manager.humanAgentId))
+            .limit(1);
+          if (human && human.type === AGENT_TYPES.HUMAN && !human.delegateMention) {
+            const [tally] = await tx
+              .select({ value: count() })
+              .from(agents)
+              .where(
+                and(
+                  eq(agents.managerId, managerId),
+                  eq(agents.type, AGENT_TYPES.AGENT),
+                  ne(agents.status, AGENT_STATUSES.DELETED),
+                ),
+              );
+            if ((tally?.value ?? 0) === 1) {
+              await tx.update(agents).set({ delegateMention: row.uuid }).where(eq(agents.uuid, human.uuid));
+            }
+          }
+        }
+      }
+
       return row;
     });
 

--- a/packages/web/src/components/new-agent-dialog.tsx
+++ b/packages/web/src/components/new-agent-dialog.tsx
@@ -67,7 +67,9 @@ function issuesToFieldErrors(issues: ValidationIssue[] | undefined): FieldErrors
  * Hidden defaults:
  *   - type = "agent"
  *   - manager = current user
- *   - delegateMention = not surfaced
+ *   - delegateMention = not surfaced here; the server auto-adopts a
+ *     member's FIRST agent as their delegate (createAgent in
+ *     services/agent.ts), so the common case needs no manual step.
  *
  * Surfaced choices: visibility (visible to your team / private to you), the
  * connected computer the agent will run on, and the runtime provider —

--- a/packages/web/src/pages/agent-detail/__tests__/appearance-identity-options-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/appearance-identity-options-dom.test.tsx
@@ -554,6 +554,36 @@ describe("ProfileEditDialog (merged identity + appearance)", () => {
     expect(document.body.textContent).toContain("Only the owner or an admin can change this agent's visibility.");
     await act(async () => nonOwner.root.unmount());
   });
+
+  it("offers your own private agent as a delegate (visibility no longer filtered)", async () => {
+    const { ProfileEditDialog } = await import("../profile-edit-dialog.js");
+    // A private agent you own is a valid delegate: the picker no longer filters
+    // on visibility, mirroring the server (which accepts a private delegate).
+    // Only `managerId === you` + active + type=agent gate the options now.
+    agentApiMocks.listAgents.mockResolvedValue({
+      items: [
+        agent({ uuid: "private-pa", name: "pa", displayName: "Private PA", type: "agent", visibility: "private" }),
+      ],
+      nextCursor: null,
+    });
+    const human = agent({
+      uuid: "human-1",
+      name: "bestony",
+      displayName: "Bestony",
+      type: "human",
+      visibility: "private",
+    });
+    const onSave = vi.fn().mockResolvedValue(undefined);
+
+    const owner = await renderDom(
+      <ProfileEditDialog agent={human} open onOpenChange={vi.fn()} onSave={onSave} onSaved={vi.fn()} />,
+    );
+    const delegateSelect = document.body.querySelector<HTMLButtonElement>("#profile-delegate");
+    if (!delegateSelect) throw new Error("Expected delegate field");
+    await chooseSelectOption(delegateSelect, "Private PA");
+    expect(onSave).toHaveBeenCalledWith({ delegateMention: "private-pa" });
+    await act(async () => owner.root.unmount());
+  });
 });
 
 describe("Select", () => {

--- a/packages/web/src/pages/agent-detail/profile-edit-dialog.tsx
+++ b/packages/web/src/pages/agent-detail/profile-edit-dialog.tsx
@@ -186,10 +186,14 @@ export function ProfileEditDialog({ agent, open, onOpenChange, onSave, onRefresh
     queryKey: ["agents-for-delegate", memberId],
     queryFn: async () => {
       const res = await listAgents({ limit: 100 });
-      return res.items.filter(
-        (a) =>
-          a.type === "agent" && a.visibility === "organization" && a.status === "active" && a.managerId === memberId,
-      );
+      // Eligible delegates = your own active agents. Visibility is NOT a
+      // filter: a private agent (your personal assistant) is the most natural
+      // delegate, and the server already accepts it (validateDelegateMention
+      // checks same-org only; webhook routing checks same-org + active). The
+      // list endpoint returns your own private agents (agentVisibilityCondition
+      // = org-visible OR managerId = you), so `managerId === memberId` is what
+      // scopes this to agents you own.
+      return res.items.filter((a) => a.type === "agent" && a.status === "active" && a.managerId === memberId);
     },
     enabled: open && canEditDelegate,
   });

--- a/packages/web/src/pages/team/__tests__/team-groups.test.ts
+++ b/packages/web/src/pages/team/__tests__/team-groups.test.ts
@@ -269,7 +269,7 @@ describe("buildTeamData", () => {
 });
 
 describe("selectDelegateCandidates", () => {
-  it("returns only the given manager's active team-visible (organization) agents", () => {
+  it("returns the manager's own active agents, including private ones (visibility not filtered)", () => {
     const mineOrg = agent({
       uuid: "mine-org",
       type: "agent",
@@ -301,8 +301,10 @@ describe("selectDelegateCandidates", () => {
     });
     const human = agent({ uuid: "human-1", type: "human", displayName: "Ada", managerId: "member-1" });
 
+    // mine-private now qualifies; their-org (other manager), suspended, and the
+    // human are still excluded.
     expect(
       selectDelegateCandidates([mineOrg, theirOrg, minePrivate, suspended, human], "member-1").map((a) => a.uuid),
-    ).toEqual(["mine-org"]);
+    ).toEqual(["mine-org", "mine-private"]);
   });
 });

--- a/packages/web/src/pages/team/__tests__/team-table-dom.test.tsx
+++ b/packages/web/src/pages/team/__tests__/team-table-dom.test.tsx
@@ -292,7 +292,7 @@ describe("TeamTable", () => {
     expect(props.onHumanDetails).toHaveBeenCalledWith(props.humans[0]);
 
     await click(container.querySelector('button[title="Set delegate"]'));
-    expect(document.body.textContent).toContain("Only team-visible agents can be a delegate.");
+    expect(document.body.textContent).toContain("Create an agent to set as your delegate.");
     await click(buttonByText(document.body, "Remove delegate"));
     expect(props.onSetDelegate).toHaveBeenCalledWith("human-self", null);
 

--- a/packages/web/src/pages/team/index.tsx
+++ b/packages/web/src/pages/team/index.tsx
@@ -536,15 +536,15 @@ export function buildTeamData(args: {
 }
 
 export function selectDelegateCandidates(agents: Agent[], managerId: string | null | undefined): Agent[] {
-  // Delegate candidates are the viewer's own team-visible assistants:
-  // type=agent + organization-visible + active + managed by the viewer.
-  // Private agents are excluded — a delegate acts on the human's behalf in
-  // team chats, so it must be mentionable by the team (visibility=organization).
-  // The managerId filter is the issue 669 candidate fix — the selector only
-  // lists the user's own agents, not the whole org's.
-  return agents.filter(
-    (a) => a.type === "agent" && a.visibility === "organization" && a.status === "active" && a.managerId === managerId,
-  );
+  // Delegate candidates are the viewer's own active agents: type=agent + active
+  // + managed by the viewer. Visibility is NOT a filter — a private agent (your
+  // personal assistant) is a first-class delegate, and the server accepts it
+  // (same-org check only; webhook routing checks same-org + active). This must
+  // stay in sync with the Agent Detail picker (profile-edit-dialog.tsx): both
+  // entry points set the same field and must offer the same candidates. The
+  // managerId filter is the issue 669 candidate fix — the selector only lists
+  // the user's own agents, not the whole org's.
+  return agents.filter((a) => a.type === "agent" && a.status === "active" && a.managerId === managerId);
 }
 
 const roleValues = Object.values(MEMBER_ROLES);

--- a/packages/web/src/pages/team/team-table.tsx
+++ b/packages/web/src/pages/team/team-table.tsx
@@ -873,7 +873,7 @@ function DelegateSelector({
       />
       {candidates.length === 0 ? (
         <div className="text-caption" style={{ color: "var(--fg-4)", padding: "var(--sp-1_5) var(--sp-2)" }}>
-          Only team-visible agents can be a delegate.
+          Create an agent to set as your delegate.
         </div>
       ) : (
         candidates.map((agent) => (


### PR DESCRIPTION
## What

Two coupled changes that make the human delegate agent (`delegateMention`) useful by default:

1. **Auto-adopt the first agent as delegate.** When a member creates their first non-human agent and has no delegate set, `createAgent` adopts it as their delegate (`delegateMention` on their human agent), atomically in the same transaction. The delegate drives the new-chat default recipient (`pickDefault`) and the GitHub `@mention` forward target — value previously gated behind a manual step in the profile editor that most users never took.

2. **Drop the visibility filter from the delegate pickers.** A private agent (the most natural "personal assistant") is now eligible as a delegate in **both** entry points — Agent Detail (`profile-edit-dialog`) and the Team page (`selectDelegateCandidates`). The server already accepts a private delegate — `validateDelegateMentionTarget` checks same-org only, webhook routing checks same-org + active, never visibility — so the pickers were stricter than the backend. They now mirror it: `managerId === you` + active + `type=agent`.

## Why

The delegate is what makes "ask my assistant" zero-step and what lets you follow GitHub entities, but it defaulted to unset and lived only in the profile editor, so most users never set it. A member's first agent is almost always their de-facto assistant, so adopting it removes the manual step.

Allowing a private delegate resolves a standing inconsistency: a new agent defaults to `private` (a deliberate anti-surprise choice — see `new-agent-dialog.tsx`), yet the old pickers required `organization` visibility, so the natural delegate couldn't be selected. Keeping the first agent private *and* adopting it as the delegate is the most coherent default.

### Guards (auto-adoption)
- **self-create only** — adoption fires only when the caller creates their own agent (`managerId === scope.memberId`). Delegate is a personal choice, so an admin creating an agent *for* another member — and the bootstrap / system-webhook paths — never adopt, matching the self-only PATCH guard.
- **only-if-unset, atomically** — the final UPDATE carries `delegateMention IS NULL` in its WHERE, so concurrent first-creates can't clobber a freshly-set delegate.
- **first-agent-only** — the just-inserted row makes the count 1, so a 2nd agent never steals the delegate.
- **reversible** — the member can re-point or clear it anytime.

## Test plan
- `agent-first-agent-delegate.test.ts` — service cases (first agent adopted; a **private** first agent adopted; no adoption without the self-create intent; 2nd agent unchanged; pre-existing delegate not overwritten) **plus route-level** (`POST /orgs/:orgId/agents`): a self-create sets the delegate; an **admin-create-for-other leaves the target's delegate `null`** (the authorization regression).
- Web: Agent Detail + Team picker tests assert a private owned agent is selectable; Team empty-state copy updated.
- Full server suite (1552 tests) + full web suite (975) green; `pnpm typecheck` (12/12) + `biome check` clean.

## Context Tree
Tree write-back: **agent-team-foundation/first-tree-context#596** (delegate agent model node) — land alongside or shortly after this PR.
