### PR TITLE
Fix Codex app-server token usage deltas

### DIFF
--- a/packages/client/src/__tests__/codex-app-server-handler.test.ts
+++ b/packages/client/src/__tests__/codex-app-server-handler.test.ts
@@ -49,6 +49,14 @@ type FakeRequest = {
   params: unknown;
 };
 
+type TestTokenUsageBreakdown = {
+  totalTokens: number;
+  inputTokens: number;
+  cachedInputTokens: number;
+  outputTokens: number;
+  reasoningOutputTokens: number;
+};
+
 type NotificationHandler = (notification: { method: string; params?: unknown }) => void;
 type CloseHandler = (error: CodexAppServerTransportError) => void;
 
@@ -61,6 +69,8 @@ class FakeAppServerClient {
   steerError: Error | null = null;
   turnStartError: Error | null = null;
   beforeTurnStartError: (() => void) | null = null;
+  beforeTurnStartReturn: (() => void) | null = null;
+  beforeThreadResumeReturn: (() => void) | null = null;
   threadStartDeferred: { promise: Promise<unknown>; resolve: (value: unknown) => void } | null = null;
   steerDeferred: {
     promise: Promise<unknown>;
@@ -68,6 +78,7 @@ class FakeAppServerClient {
     reject: (error: Error) => void;
   } | null = null;
   turnCounter = 0;
+  tokenUsageTotal = emptyTestTokenUsage();
 
   async request(method: string, params?: unknown): Promise<unknown> {
     this.requests.push({ method, params });
@@ -76,6 +87,7 @@ class FakeAppServerClient {
       return { thread: { id: "thread-app-server" } };
     }
     if (method === "thread/resume") {
+      this.beforeThreadResumeReturn?.();
       return { thread: { id: "thread-app-server" } };
     }
     if (method === "turn/start") {
@@ -83,6 +95,7 @@ class FakeAppServerClient {
         this.beforeTurnStartError?.();
         throw this.turnStartError;
       }
+      this.beforeTurnStartReturn?.();
       this.turnCounter += 1;
       return {
         turn: {
@@ -283,27 +296,65 @@ async function flushAsync(): Promise<void> {
   await new Promise((resolve) => setImmediate(resolve));
 }
 
-function completeTurn(fake: FakeAppServerClient, turnId: string, text: string): void {
+function emptyTestTokenUsage(): TestTokenUsageBreakdown {
+  return {
+    totalTokens: 0,
+    inputTokens: 0,
+    cachedInputTokens: 0,
+    outputTokens: 0,
+    reasoningOutputTokens: 0,
+  };
+}
+
+function addTestTokenUsage(left: TestTokenUsageBreakdown, right: TestTokenUsageBreakdown): TestTokenUsageBreakdown {
+  return {
+    totalTokens: left.totalTokens + right.totalTokens,
+    inputTokens: left.inputTokens + right.inputTokens,
+    cachedInputTokens: left.cachedInputTokens + right.cachedInputTokens,
+    outputTokens: left.outputTokens + right.outputTokens,
+    reasoningOutputTokens: left.reasoningOutputTokens + right.reasoningOutputTokens,
+  };
+}
+
+function emitTokenUsage(
+  fake: FakeAppServerClient,
+  turnId: string,
+  last: TestTokenUsageBreakdown,
+  total: TestTokenUsageBreakdown = addTestTokenUsage(fake.tokenUsageTotal, last),
+): void {
+  fake.tokenUsageTotal = { ...total };
   fake.emit("thread/tokenUsage/updated", {
     threadId: "thread-app-server",
     turnId,
     tokenUsage: {
-      last: {
-        totalTokens: 3,
-        inputTokens: 2,
-        cachedInputTokens: 0,
-        outputTokens: 1,
-        reasoningOutputTokens: 0,
-      },
-      total: {
-        totalTokens: 3,
-        inputTokens: 2,
-        cachedInputTokens: 0,
-        outputTokens: 1,
-        reasoningOutputTokens: 0,
-      },
+      last,
+      total,
       modelContextWindow: null,
     },
+  });
+}
+
+function findTokenUsageEvent(
+  emitEvent: ReturnType<typeof vi.fn<(event: SessionEvent) => void>>,
+): Extract<SessionEvent, { kind: "token_usage" }> | undefined {
+  return tokenUsageEvents(emitEvent)[0];
+}
+
+function tokenUsageEvents(
+  emitEvent: ReturnType<typeof vi.fn<(event: SessionEvent) => void>>,
+): Extract<SessionEvent, { kind: "token_usage" }>[] {
+  return emitEvent.mock.calls
+    .map(([event]) => event)
+    .filter((event): event is Extract<SessionEvent, { kind: "token_usage" }> => event.kind === "token_usage");
+}
+
+function completeTurn(fake: FakeAppServerClient, turnId: string, text: string): void {
+  emitTokenUsage(fake, turnId, {
+    totalTokens: 3,
+    inputTokens: 2,
+    cachedInputTokens: 0,
+    outputTokens: 1,
+    reasoningOutputTokens: 0,
   });
   fake.emit("item/completed", {
     threadId: "thread-app-server",
@@ -396,6 +447,285 @@ describe("codex app-server handler", () => {
 
     expect(finished.map((messages) => messages.map((message) => message.id))).toEqual([["m1", "m2"]]);
     expect(emitEvent.mock.calls.some(([event]) => event.kind === "token_usage")).toBe(true);
+
+    await handler.shutdown();
+  });
+
+  it("emits one token usage event from the cumulative total delta across app-server updates", async () => {
+    const fake = new FakeAppServerClient();
+    const emitEvent = vi.fn<(event: SessionEvent) => void>();
+    const handler = makeHandler(fake);
+    const ctx = makeContext({ emitEvent });
+
+    const startPromise = handler.start(makeMessage("m1", "first"), ctx);
+    await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
+
+    emitTokenUsage(fake, "turn-1", {
+      totalTokens: 125,
+      inputTokens: 100,
+      cachedInputTokens: 20,
+      outputTokens: 5,
+      reasoningOutputTokens: 0,
+    });
+    emitTokenUsage(fake, "turn-1", {
+      totalTokens: 77,
+      inputTokens: 60,
+      cachedInputTokens: 10,
+      outputTokens: 7,
+      reasoningOutputTokens: 0,
+    });
+    fake.emit("item/completed", {
+      threadId: "thread-app-server",
+      turnId: "turn-1",
+      item: { type: "agentMessage", id: "item-turn-1", text: "final answer", phase: null, memoryCitation: null },
+    });
+    fake.emit("turn/completed", {
+      threadId: "thread-app-server",
+      turn: {
+        id: "turn-1",
+        status: "completed",
+        items: [],
+        error: null,
+      },
+    });
+    await startPromise;
+
+    expect(findTokenUsageEvent(emitEvent)?.payload).toMatchObject({
+      provider: "codex",
+      model: "codex-default",
+      inputTokens: 130,
+      cachedInputTokens: 30,
+      outputTokens: 12,
+    });
+
+    await handler.shutdown();
+  });
+
+  it("uses replayed cumulative usage as the resumed thread baseline", async () => {
+    const fake = new FakeAppServerClient();
+    const emitEvent = vi.fn<(event: SessionEvent) => void>();
+    const handler = makeHandler(fake);
+    const ctx = makeContext({ emitEvent });
+
+    fake.beforeThreadResumeReturn = () => {
+      emitTokenUsage(fake, "turn-old", {
+        totalTokens: 1050,
+        inputTokens: 1000,
+        cachedInputTokens: 200,
+        outputTokens: 50,
+        reasoningOutputTokens: 0,
+      });
+    };
+
+    const resumePromise = handler.resume(makeMessage("m1", "first"), "thread-app-server", ctx);
+    await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
+
+    emitTokenUsage(
+      fake,
+      "turn-1",
+      {
+        totalTokens: 25,
+        inputTokens: 20,
+        cachedInputTokens: 0,
+        outputTokens: 5,
+        reasoningOutputTokens: 0,
+      },
+      {
+        totalTokens: 1155,
+        inputTokens: 1100,
+        cachedInputTokens: 220,
+        outputTokens: 55,
+        reasoningOutputTokens: 0,
+      },
+    );
+    fake.emit("item/completed", {
+      threadId: "thread-app-server",
+      turnId: "turn-1",
+      item: { type: "agentMessage", id: "item-turn-1", text: "resumed answer", phase: null, memoryCitation: null },
+    });
+    fake.emit("turn/completed", {
+      threadId: "thread-app-server",
+      turn: {
+        id: "turn-1",
+        status: "completed",
+        items: [],
+        error: null,
+      },
+    });
+    await resumePromise;
+
+    expect(findTokenUsageEvent(emitEvent)?.payload).toMatchObject({
+      provider: "codex",
+      model: "codex-default",
+      inputTokens: 80,
+      cachedInputTokens: 20,
+      outputTokens: 5,
+    });
+
+    await handler.shutdown();
+  });
+
+  it("uses buffered cumulative usage replayed while turn/start is in flight", async () => {
+    const fake = new FakeAppServerClient();
+    const emitEvent = vi.fn<(event: SessionEvent) => void>();
+    const handler = makeHandler(fake);
+    const ctx = makeContext({ emitEvent });
+
+    fake.beforeTurnStartReturn = () => {
+      emitTokenUsage(fake, "turn-old", {
+        totalTokens: 1050,
+        inputTokens: 1000,
+        cachedInputTokens: 200,
+        outputTokens: 50,
+        reasoningOutputTokens: 0,
+      });
+    };
+
+    const resumePromise = handler.resume(makeMessage("m1", "first"), "thread-app-server", ctx);
+    await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
+
+    emitTokenUsage(
+      fake,
+      "turn-1",
+      {
+        totalTokens: 25,
+        inputTokens: 20,
+        cachedInputTokens: 0,
+        outputTokens: 5,
+        reasoningOutputTokens: 0,
+      },
+      {
+        totalTokens: 1155,
+        inputTokens: 1100,
+        cachedInputTokens: 220,
+        outputTokens: 55,
+        reasoningOutputTokens: 0,
+      },
+    );
+    fake.emit("item/completed", {
+      threadId: "thread-app-server",
+      turnId: "turn-1",
+      item: {
+        type: "agentMessage",
+        id: "item-turn-1",
+        text: "resumed answer",
+        phase: null,
+        memoryCitation: null,
+      },
+    });
+    fake.emit("turn/completed", {
+      threadId: "thread-app-server",
+      turn: {
+        id: "turn-1",
+        status: "completed",
+        items: [],
+        error: null,
+      },
+    });
+    await resumePromise;
+
+    expect(findTokenUsageEvent(emitEvent)?.payload).toMatchObject({
+      provider: "codex",
+      model: "codex-default",
+      inputTokens: 80,
+      cachedInputTokens: 20,
+      outputTokens: 5,
+    });
+
+    await handler.shutdown();
+  });
+
+  it("advances the next baseline when compaction lowers the current turn cumulative total", async () => {
+    const fake = new FakeAppServerClient();
+    const emitEvent = vi.fn<(event: SessionEvent) => void>();
+    const handler = makeHandler(fake);
+    const ctx = makeContext({ emitEvent });
+
+    fake.beforeThreadResumeReturn = () => {
+      emitTokenUsage(fake, "turn-old", {
+        totalTokens: 10_000,
+        inputTokens: 9_000,
+        cachedInputTokens: 0,
+        outputTokens: 1_000,
+        reasoningOutputTokens: 0,
+      });
+    };
+
+    const resumePromise = handler.resume(makeMessage("m1", "first"), "thread-app-server", ctx);
+    await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
+
+    emitTokenUsage(
+      fake,
+      "turn-1",
+      {
+        totalTokens: 100,
+        inputTokens: 100,
+        cachedInputTokens: 0,
+        outputTokens: 0,
+        reasoningOutputTokens: 0,
+      },
+      {
+        totalTokens: 2_000,
+        inputTokens: 1_800,
+        cachedInputTokens: 0,
+        outputTokens: 200,
+        reasoningOutputTokens: 0,
+      },
+    );
+    fake.emit("item/completed", {
+      threadId: "thread-app-server",
+      turnId: "turn-1",
+      item: { type: "agentMessage", id: "item-turn-1", text: "first answer", phase: null, memoryCitation: null },
+    });
+    fake.emit("turn/completed", {
+      threadId: "thread-app-server",
+      turn: {
+        id: "turn-1",
+        status: "completed",
+        items: [],
+        error: null,
+      },
+    });
+    await resumePromise;
+
+    handler.inject(makeMessage("m2", "second"));
+    await waitFor(() => fake.requests.filter((request) => request.method === "turn/start").length === 2);
+
+    emitTokenUsage(fake, "turn-2", {
+      totalTokens: 500,
+      inputTokens: 500,
+      cachedInputTokens: 0,
+      outputTokens: 0,
+      reasoningOutputTokens: 0,
+    });
+    fake.emit("item/completed", {
+      threadId: "thread-app-server",
+      turnId: "turn-2",
+      item: { type: "agentMessage", id: "item-turn-2", text: "second answer", phase: null, memoryCitation: null },
+    });
+    fake.emit("turn/completed", {
+      threadId: "thread-app-server",
+      turn: {
+        id: "turn-2",
+        status: "completed",
+        items: [],
+        error: null,
+      },
+    });
+    await waitFor(() => tokenUsageEvents(emitEvent).length === 2);
+
+    expect(tokenUsageEvents(emitEvent).map((event) => event.payload)).toMatchObject([
+      {
+        inputTokens: 0,
+        cachedInputTokens: 0,
+        outputTokens: 0,
+      },
+      {
+        inputTokens: 500,
+        cachedInputTokens: 0,
+        outputTokens: 0,
+      },
+    ]);
 
     await handler.shutdown();
   });

--- a/packages/client/src/handlers/codex/app-server/index.ts
+++ b/packages/client/src/handlers/codex/app-server/index.ts
@@ -93,6 +93,11 @@ type TokenUsageBreakdown = {
   reasoningOutputTokens: number;
 };
 
+type ThreadTokenUsageSnapshot = {
+  total: TokenUsageBreakdown;
+  last: TokenUsageBreakdown;
+};
+
 type TurnErrorInfo = {
   message: string;
   codexErrorInfo: unknown;
@@ -108,7 +113,9 @@ type CurrentTurn = {
   inFlightAppend: Promise<void> | null;
   finalAgentText: string;
   completedItemIds: Set<string>;
-  usageLast: TokenUsageBreakdown | null;
+  usageBaselineTotal: TokenUsageBreakdown | null;
+  usageLatestTotal: TokenUsageBreakdown | null;
+  usageLastSum: TokenUsageBreakdown | null;
   failure: TurnErrorInfo | null;
   lastSdkError: TurnErrorInfo | null;
   providerCompleted: boolean;
@@ -166,6 +173,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
   let shutdownRequested = false;
   let pendingChatContextPrompt: string | null = null;
   let sourceReposForPrompt: PredeclaredSourceRepo[] = [];
+  let latestThreadUsageTotal: TokenUsageBreakdown | null = null;
 
   const pendingInputs: QueueEntry[] = [];
   const pendingNotificationsByTurn = new Map<string, CodexAppServerNotification[]>();
@@ -424,11 +432,13 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
     const id = extractThreadId(result);
     if (!id) throw new CodexAppServerStartupError("thread-start", "missing thread id");
     threadId = id;
+    latestThreadUsageTotal = emptyTokenUsage();
     return id;
   }
 
   async function resumeThread(sessionId: string, payload: AgentRuntimeConfigPayload): Promise<void> {
     const client = requireAppServer();
+    latestThreadUsageTotal = null;
     try {
       await client.request("thread/resume", {
         threadId: sessionId,
@@ -629,6 +639,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
       if (error) recordAppServerFailureSignal(turnStartAttempt, error);
     }
     if (notificationTurnId && (!turn || turn.turnId !== notificationTurnId)) {
+      if (!turnStartInProgress) recordHistoricalTokenUsage(notification);
       bufferNotification(notificationTurnId, notification);
       return;
     }
@@ -650,8 +661,12 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
         return;
       }
       case "thread/tokenUsage/updated": {
-        const usage = parseTokenUsage(asRecord(params.tokenUsage));
-        if (usage && turn) turn.usageLast = usage;
+        const usage = parseThreadTokenUsage(asRecord(params.tokenUsage));
+        if (usage && turn) {
+          recordCurrentTurnTokenUsage(turn, usage);
+        } else if (usage) {
+          recordLatestThreadUsageTotal(usage.total);
+        }
         return;
       }
       case "error": {
@@ -732,6 +747,37 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
     pendingNotificationsByTurn.set(turnId, list);
   }
 
+  function recordHistoricalTokenUsage(notification: CodexAppServerNotification): void {
+    if (notification.method !== "thread/tokenUsage/updated") return;
+    const params = asRecord(notification.params);
+    const usage = parseThreadTokenUsage(asRecord(params?.tokenUsage));
+    if (usage) recordLatestThreadUsageTotal(usage.total);
+  }
+
+  function recordBufferedHistoricalTokenUsageExcept(currentTurnId: string): void {
+    for (const [turnId, notifications] of pendingNotificationsByTurn) {
+      if (turnId === currentTurnId) continue;
+      for (const notification of notifications) recordHistoricalTokenUsage(notification);
+      pendingNotificationsByTurn.delete(turnId);
+    }
+  }
+
+  function recordCurrentTurnTokenUsage(turn: CurrentTurn, usage: ThreadTokenUsageSnapshot): void {
+    turn.usageLatestTotal = cloneTokenUsage(usage.total);
+    turn.usageLastSum = addTokenUsage(turn.usageLastSum ?? emptyTokenUsage(), usage.last);
+    advanceCurrentThreadUsageTotal(usage.total);
+  }
+
+  function recordLatestThreadUsageTotal(usage: TokenUsageBreakdown): void {
+    if (!latestThreadUsageTotal || usage.totalTokens >= latestThreadUsageTotal.totalTokens) {
+      latestThreadUsageTotal = cloneTokenUsage(usage);
+    }
+  }
+
+  function advanceCurrentThreadUsageTotal(usage: TokenUsageBreakdown): void {
+    latestThreadUsageTotal = cloneTokenUsage(usage);
+  }
+
   function handleTransportClose(error: CodexAppServerTransportError): void {
     const sessionCtx = ctx;
     const turn = currentTurn;
@@ -757,6 +803,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
     const resumeThreadId = threadId ?? undefined;
     appServer = null;
     threadId = null;
+    latestThreadUsageTotal = null;
     pendingNotificationsByTurn.clear();
     sessionCtx.log(
       `codex app-server session closed after unknown input custody (${reason}): ${
@@ -779,6 +826,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
     const resumeThreadId = threadId ?? undefined;
     appServer = null;
     threadId = null;
+    latestThreadUsageTotal = null;
     pendingNotificationsByTurn.clear();
     sessionCtx.log(`codex app-server session closed after terminal turn/start failure (${reason})`);
     const shutdown = client?.shutdown();
@@ -794,6 +842,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
     const resumeThreadId = threadId ?? undefined;
     appServer = null;
     threadId = null;
+    latestThreadUsageTotal = null;
     pendingNotificationsByTurn.clear();
     sessionCtx.log(`codex app-server session closed after uncommittable turn prefix (${reason})`);
     const shutdown = client?.shutdown();
@@ -907,6 +956,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
       return false;
     }
 
+    recordBufferedHistoricalTokenUsageExcept(turnId);
     const turn = await createCurrentTurn(turnId, messages, token, sessionCtx);
     turnStartAttempt = null;
     turnStartInProgress = false;
@@ -957,7 +1007,9 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
       inFlightAppend: null,
       finalAgentText: "",
       completedItemIds: new Set(),
-      usageLast: null,
+      usageBaselineTotal: cloneTokenUsage(latestThreadUsageTotal),
+      usageLatestTotal: null,
+      usageLastSum: null,
       failure: null,
       lastSdkError: null,
       providerCompleted: false,
@@ -1007,7 +1059,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
 
     const completedSuccessfully = turn.providerCompleted && turn.failure === null && turn.status === "completed";
     const finalAgentText = turn.finalAgentText.trim();
-    const usage = turn.usageLast;
+    const usage = computeTurnUsageDelta(turn);
     const zeroTokenDelta =
       usage !== null &&
       usage.inputTokens === 0 &&
@@ -1520,6 +1572,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
       await appServer?.shutdown();
       appServer = null;
       pendingChatContextPrompt = null;
+      latestThreadUsageTotal = null;
     },
 
     async shutdown() {
@@ -1537,6 +1590,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
       threadId = null;
       ctx = null;
       pendingChatContextPrompt = null;
+      latestThreadUsageTotal = null;
     },
   } satisfies AgentHandler;
 };
@@ -1568,15 +1622,62 @@ function extractThreadId(result: unknown): string | null {
   return thread ? readString(thread, "id") : null;
 }
 
-function parseTokenUsage(value: JsonRecord | null): TokenUsageBreakdown | null {
-  const last = asRecord(value?.last);
-  if (!last) return null;
+function parseThreadTokenUsage(value: JsonRecord | null): ThreadTokenUsageSnapshot | null {
+  const last = parseTokenUsageBreakdown(asRecord(value?.last));
+  const total = parseTokenUsageBreakdown(asRecord(value?.total));
+  if (!last || !total) return null;
+  return { last, total };
+}
+
+function parseTokenUsageBreakdown(value: JsonRecord | null): TokenUsageBreakdown | null {
+  if (!value) return null;
   return {
-    totalTokens: readNumber(last, "totalTokens") ?? 0,
-    inputTokens: readNumber(last, "inputTokens") ?? 0,
-    cachedInputTokens: readNumber(last, "cachedInputTokens") ?? 0,
-    outputTokens: readNumber(last, "outputTokens") ?? 0,
-    reasoningOutputTokens: readNumber(last, "reasoningOutputTokens") ?? 0,
+    totalTokens: readNumber(value, "totalTokens") ?? 0,
+    inputTokens: readNumber(value, "inputTokens") ?? 0,
+    cachedInputTokens: readNumber(value, "cachedInputTokens") ?? 0,
+    outputTokens: readNumber(value, "outputTokens") ?? 0,
+    reasoningOutputTokens: readNumber(value, "reasoningOutputTokens") ?? 0,
+  };
+}
+
+function computeTurnUsageDelta(turn: CurrentTurn): TokenUsageBreakdown | null {
+  if (turn.usageLatestTotal && turn.usageBaselineTotal) {
+    return subtractTokenUsage(turn.usageLatestTotal, turn.usageBaselineTotal);
+  }
+  return cloneTokenUsage(turn.usageLastSum);
+}
+
+function emptyTokenUsage(): TokenUsageBreakdown {
+  return {
+    totalTokens: 0,
+    inputTokens: 0,
+    cachedInputTokens: 0,
+    outputTokens: 0,
+    reasoningOutputTokens: 0,
+  };
+}
+
+function cloneTokenUsage(usage: TokenUsageBreakdown | null): TokenUsageBreakdown | null {
+  return usage ? { ...usage } : null;
+}
+
+function addTokenUsage(left: TokenUsageBreakdown, right: TokenUsageBreakdown): TokenUsageBreakdown {
+  return {
+    totalTokens: left.totalTokens + right.totalTokens,
+    inputTokens: left.inputTokens + right.inputTokens,
+    cachedInputTokens: left.cachedInputTokens + right.cachedInputTokens,
+    outputTokens: left.outputTokens + right.outputTokens,
+    reasoningOutputTokens: left.reasoningOutputTokens + right.reasoningOutputTokens,
+  };
+}
+
+function subtractTokenUsage(current: TokenUsageBreakdown, baseline: TokenUsageBreakdown): TokenUsageBreakdown {
+  return {
+    totalTokens: Math.max(0, current.totalTokens - baseline.totalTokens),
+    inputTokens: Math.max(0, current.inputTokens - baseline.inputTokens),
+    cachedInputTokens: Math.max(0, current.cachedInputTokens - baseline.cachedInputTokens),
+    outputTokens: Math.max(0, current.outputTokens - baseline.outputTokens),
+    reasoningOutputTokens: Math.max(0, current.reasoningOutputTokens - baseline.reasoningOutputTokens),
   };
 }
 


### PR DESCRIPTION
## Summary
- compute Codex app-server `token_usage` from thread cumulative `tokenUsage.total` deltas instead of the final `tokenUsage.last` snapshot
- preserve resumed-thread baselines from replayed usage notifications, including replay that arrives before `thread/resume` returns or while `turn/start` is in flight
- advance current-turn baselines even when compaction lowers cumulative totals, while keeping monotonic protection for historical replay
- add regression coverage for multi-update turns, resume baseline races, and compaction reset baseline advancement

## Verification
- `pnpm exec biome check packages/client/src/handlers/codex/app-server/index.ts packages/client/src/__tests__/codex-app-server-handler.test.ts`
- `pnpm --filter @first-tree/client exec vitest run --poolOptions.threads.maxThreads=2 --poolOptions.forks.maxForks=2 src/__tests__/codex-app-server-handler.test.ts`
- `pnpm --filter @first-tree/client typecheck`
- `pnpm check`
- `TURBO_CONCURRENCY=2 pnpm typecheck`
- `TURBO_CONCURRENCY=2 pnpm test -- --poolOptions.threads.maxThreads=2 --poolOptions.forks.maxForks=2`

## Review
- Reviewed by codex-reviewer in the task chat; blocking findings were addressed and re-review passed.