### PR TITLE
Fix Claude SDK provider error handling

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -53,7 +53,7 @@
     "node": ">=22.13.0"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.84",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.187",
     "@inquirer/prompts": "^8.3.0",
     "@openai/codex-sdk": "^0.140.0",
     "commander": "^13.1.0",

--- a/apps/cli/src/core/runtime-auth-login.ts
+++ b/apps/cli/src/core/runtime-auth-login.ts
@@ -203,7 +203,7 @@ async function runClaudeRuntimeAuth(command: RuntimeAuthCommand, deps: RuntimeAu
     }
   };
 
-  deps.log("•", `runtime-auth: starting claude login (method=browser, ref ${command.ref})`);
+  deps.log("•", `runtime-auth: starting claude auth login (method=browser, ref ${command.ref})`);
 
   const invocation = resolveLogin();
   if (!invocation.ok) {
@@ -228,7 +228,7 @@ async function runClaudeRuntimeAuth(command: RuntimeAuthCommand, deps: RuntimeAu
       onAuthUrl: (url) => void setPending(url),
     });
   } catch (err) {
-    deps.log("⚠️", `runtime-auth: claude login threw: ${message(err)}`);
+    deps.log("⚠️", `runtime-auth: claude auth login threw: ${message(err)}`);
     await reflect("after login threw", { reason: "spawn-error", message: message(err) });
     return;
   }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -28,7 +28,7 @@
     "node": ">=22.13.0"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.84",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.187",
     "@openai/codex-sdk": "^0.140.0",
     "pino": "^9.5.0",
     "semver": "^7.6.3",

--- a/packages/client/src/__tests__/auth-error-hint.test.ts
+++ b/packages/client/src/__tests__/auth-error-hint.test.ts
@@ -106,10 +106,10 @@ describe("formatAuthHint", () => {
     expect(hint).toContain("refresh token was revoked");
   });
 
-  it("targets `claude login` for the claude-code runtime", () => {
+  it("targets `claude auth login` for the claude-code runtime", () => {
     const hint = formatAuthHint("claude-code", "authentication_failed");
     expect(hint).toContain("claude-code");
-    expect(hint).toContain("`claude login`");
+    expect(hint).toContain("`claude auth login`");
     expect(hint).toContain("Anthropic");
     expect(hint).toContain("not First Tree's");
     expect(hint).toContain("authentication_failed");

--- a/packages/client/src/__tests__/auth-error-hint.test.ts
+++ b/packages/client/src/__tests__/auth-error-hint.test.ts
@@ -71,7 +71,17 @@ describe("isClaudeAuthError", () => {
   });
 
   it("does NOT match other SDKAssistantMessageError codes", () => {
-    const nonAuth = ["billing_error", "rate_limit", "invalid_request", "server_error", "unknown", "max_output_tokens"];
+    const nonAuth = [
+      "oauth_org_not_allowed",
+      "billing_error",
+      "rate_limit",
+      "overloaded",
+      "invalid_request",
+      "model_not_found",
+      "server_error",
+      "unknown",
+      "max_output_tokens",
+    ];
     for (const code of nonAuth) {
       expect(isClaudeAuthError(code), `expected NOT auth-error: ${code}`).toBe(false);
     }

--- a/packages/client/src/__tests__/capability-probes.test.ts
+++ b/packages/client/src/__tests__/capability-probes.test.ts
@@ -318,6 +318,55 @@ describe("Claude smoke ↔ handler settings-source parity", () => {
     vi.doUnmock("@anthropic-ai/claude-agent-sdk");
     vi.resetModules();
   });
+
+  it("defaultClaudeSdkSmoke maps structured auth error results to unauthenticated", async () => {
+    vi.resetModules();
+    vi.doMock("@anthropic-ai/claude-agent-sdk", () => ({
+      query: () =>
+        (async function* () {
+          yield {
+            type: "result",
+            subtype: "success",
+            is_error: true,
+            api_error_status: 401,
+            result: "authentication_failed",
+          };
+        })(),
+    }));
+    const mod = await import("../runtime/capabilities/claude-code.js");
+
+    const out = await mod.defaultClaudeSdkSmoke(undefined);
+
+    expect(out).toEqual({ state: "unauthenticated", error: "authentication_failed" });
+    vi.doUnmock("@anthropic-ai/claude-agent-sdk");
+    vi.resetModules();
+  });
+
+  it("defaultClaudeSdkSmoke keeps structured billing errors as provider errors, not unauthenticated", async () => {
+    vi.resetModules();
+    vi.doMock("@anthropic-ai/claude-agent-sdk", () => ({
+      query: () =>
+        (async function* () {
+          yield {
+            type: "result",
+            subtype: "success",
+            is_error: true,
+            api_error_status: 403,
+            result: "Failed to authenticate. API Error: 403 Insufficient account balance.",
+          };
+        })(),
+    }));
+    const mod = await import("../runtime/capabilities/claude-code.js");
+
+    const out = await mod.defaultClaudeSdkSmoke(undefined);
+
+    expect(out).toEqual({
+      state: "error",
+      error: "Failed to authenticate. API Error: 403 Insufficient account balance.",
+    });
+    vi.doUnmock("@anthropic-ai/claude-agent-sdk");
+    vi.resetModules();
+  });
 });
 
 describe("probeClaudeCodeCapability", () => {

--- a/packages/client/src/__tests__/claude-auth-failure-detector.test.ts
+++ b/packages/client/src/__tests__/claude-auth-failure-detector.test.ts
@@ -83,9 +83,12 @@ describe("SDKAssistantMessageError union — exhaustive classification", () => {
     // is an auth signal or not, and add it here AND update isClaudeAuthError.
     const KNOWN_CODES: Record<SDKAssistantMessageError, boolean> = {
       authentication_failed: true,
+      oauth_org_not_allowed: false,
       billing_error: false,
       rate_limit: false,
+      overloaded: false,
       invalid_request: false,
+      model_not_found: false,
       server_error: false,
       unknown: false,
       max_output_tokens: false,
@@ -115,9 +118,12 @@ describe("detectClaudeAuthFailure — negative cases (drift counter-examples)", 
     // code lands, the exhaustiveness test forces a triage; this loop just
     // proves the current classification is wired through detect→isAuthError.
     const nonAuthCodes: readonly SDKAssistantMessageError[] = [
+      "oauth_org_not_allowed",
       "billing_error",
       "rate_limit",
+      "overloaded",
       "invalid_request",
+      "model_not_found",
       "server_error",
       "unknown",
       "max_output_tokens",

--- a/packages/client/src/__tests__/claude-code-provider-error-result.test.ts
+++ b/packages/client/src/__tests__/claude-code-provider-error-result.test.ts
@@ -208,7 +208,7 @@ describe("claude-code handler — structured provider error result", () => {
 
     expect(forwardResult).not.toHaveBeenCalled();
     expect(sendMessage).toHaveBeenCalledTimes(1);
-    expect(String(sendMessage.mock.calls[0]?.[1].content)).toContain("`claude login`");
+    expect(String(sendMessage.mock.calls[0]?.[1].content)).toContain("`claude auth login`");
 
     const providerPayloads = emitted
       .filter((event) => event.kind === "error")
@@ -293,7 +293,7 @@ describe("claude-code handler — structured provider error result", () => {
     expect(sendMessage).toHaveBeenCalledTimes(1);
     const notice = String(sendMessage.mock.calls[0]?.[1].content);
     expect(notice).toContain("insufficient account balance");
-    expect(notice).not.toContain("`claude login`");
+    expect(notice).not.toContain("`claude auth login`");
 
     const providerPayloads = emitted
       .filter((event) => event.kind === "error")

--- a/packages/client/src/__tests__/claude-code-provider-error-result.test.ts
+++ b/packages/client/src/__tests__/claude-code-provider-error-result.test.ts
@@ -1,0 +1,339 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parseProviderRetryEventMessage, type SessionEvent } from "@first-tree/shared";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+const BILLING_RESULT = "Failed to authenticate. API Error: 403 Insufficient account balance.";
+const TRANSIENT_RESULT =
+  "API Error: The socket connection was closed unexpectedly. For more information, pass `verbose: true` in the second argument to fetch()";
+const mockState = vi.hoisted(() => ({
+  nextMessages: [] as unknown[],
+  queryCalls: 0,
+  observedInputMessages: [] as Array<{ attempt: number; content: string }>,
+}));
+
+vi.mock("@anthropic-ai/claude-agent-sdk", () => {
+  const drainPrompt = async (prompt: AsyncIterable<{ message?: { content?: unknown } }>, attempt: number) => {
+    let drained = 0;
+    for await (const sdkMsg of prompt) {
+      const content = sdkMsg.message?.content;
+      mockState.observedInputMessages.push({
+        attempt,
+        content: typeof content === "string" ? content : JSON.stringify(content),
+      });
+      drained += 1;
+      if (drained >= 1) break;
+    }
+  };
+  return {
+    query: (args: { prompt: AsyncIterable<{ message?: { content?: unknown } }> }) => {
+      mockState.queryCalls += 1;
+      const attempt = mockState.queryCalls;
+      const messages = mockState.nextMessages.slice();
+      void drainPrompt(args.prompt, attempt);
+      return {
+        [Symbol.asyncIterator]() {
+          let idx = 0;
+          return {
+            next: async () => {
+              if (idx < messages.length) {
+                const value = messages[idx];
+                idx += 1;
+                return { done: false, value };
+              }
+              return { done: true, value: undefined };
+            },
+          };
+        },
+        close: () => {},
+        setModel: async () => {},
+      };
+    },
+  };
+});
+
+import { createClaudeCodeHandler } from "../handlers/claude-code.js";
+import { createAgentConfigCache } from "../runtime/agent-config-cache.js";
+import type { SessionContext, TurnOutcome } from "../runtime/handler.js";
+import { mockCtxPlumbing } from "./test-helpers.js";
+
+const AGENT_ID = "019ef431-0000-7000-9000-000000000002";
+
+let workspaceRoot: string;
+
+beforeAll(() => {
+  workspaceRoot = mkdtempSync(join(tmpdir(), "ftt-claude-provider-error-"));
+});
+
+afterAll(() => {
+  rmSync(workspaceRoot, { recursive: true, force: true });
+});
+
+function buildCache() {
+  const stubSdk = {
+    fetchAgentConfig: async () => ({
+      agentId: AGENT_ID,
+      version: 1,
+      payload: { prompt: { append: "" }, model: "", mcpServers: [], env: [], gitRepos: [] },
+      updatedAt: new Date().toISOString(),
+      updatedBy: "test",
+    }),
+  } as unknown as Parameters<typeof createAgentConfigCache>[0]["sdk"];
+  return createAgentConfigCache({ sdk: stubSdk });
+}
+
+async function runSingleResultTurn() {
+  mockState.queryCalls = 0;
+  mockState.observedInputMessages.length = 0;
+  const sendMessage = vi.fn().mockResolvedValue(undefined);
+  const forwardResult = vi.fn<SessionContext["forwardResult"]>().mockResolvedValue(undefined);
+  const emitted: SessionEvent[] = [];
+  const completed: Array<{ count: number; outcome: TurnOutcome }> = [];
+  const logs: string[] = [];
+
+  const cache = buildCache();
+  await cache.refresh(AGENT_ID);
+
+  const handler = createClaudeCodeHandler({ workspaceRoot, agentConfigCache: cache });
+  const ctx: SessionContext = {
+    agent: {
+      agentId: AGENT_ID,
+      inboxId: "inbox-test",
+      displayName: "test",
+      type: "agent",
+      visibility: "organization",
+      delegateMention: null,
+      metadata: {},
+    },
+    sdk: { serverUrl: "http://test", sendMessage } as unknown as SessionContext["sdk"],
+    chatId: "chat-claude-provider-error",
+    log: (m) => logs.push(m),
+    recordProviderActivity: () => {},
+    emitEvent: (e) => emitted.push(e),
+    ...mockCtxPlumbing({ sendMessage }, "chat-claude-provider-error"),
+    forwardResult,
+    finishTurn: async (messages, outcome) => {
+      completed.push({ count: Array.isArray(messages) ? messages.length : 1, outcome });
+    },
+  };
+
+  await handler.start(
+    {
+      id: "m1",
+      chatId: "chat-claude-provider-error",
+      senderId: "user-1",
+      format: "text",
+      content: "hello",
+      metadata: null,
+    },
+    ctx,
+  );
+  await handler.suspend();
+  await new Promise((r) => setImmediate(r));
+
+  return { sendMessage, forwardResult, emitted, completed, logs };
+}
+
+describe("claude-code handler — structured provider error result", () => {
+  it("posts a runtime notice and consumes a billing failure instead of forwarding final text", async () => {
+    mockState.nextMessages = [
+      {
+        type: "result",
+        subtype: "success",
+        is_error: true,
+        api_error_status: 403,
+        result: BILLING_RESULT,
+      },
+    ];
+    const { sendMessage, forwardResult, emitted, completed, logs } = await runSingleResultTurn();
+
+    expect(forwardResult).not.toHaveBeenCalled();
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage.mock.calls[0]?.[1]).toMatchObject({
+      source: "api",
+      format: "text",
+      purpose: "agent-final-text",
+    });
+    expect(String(sendMessage.mock.calls[0]?.[1].content)).toContain("insufficient account balance");
+    expect(logs.some((line) => line.includes("Claude SDK provider failure"))).toBe(true);
+
+    const providerPayloads = emitted
+      .filter((event) => event.kind === "error")
+      .map((event) => parseProviderRetryEventMessage(event.payload.message))
+      .filter((payload) => payload !== null);
+    expect(providerPayloads).toHaveLength(1);
+    expect(providerPayloads[0]).toMatchObject({
+      event: "provider_failure_terminal",
+      provider: "claude-code",
+      scope: "provider_turn",
+      category: "provider_capacity",
+      reasonCode: "provider_billing_limit",
+      userSeverity: "error",
+    });
+
+    expect(
+      emitted.some(
+        (event) =>
+          event.kind === "error" &&
+          event.payload.source === "sdk" &&
+          event.payload.message.includes("provider_billing_limit"),
+      ),
+    ).toBe(true);
+    expect(emitted.some((event) => event.kind === "turn_end" && event.payload.status === "error")).toBe(true);
+    expect(completed).toEqual([
+      {
+        count: 1,
+        outcome: {
+          status: "error",
+          terminal: true,
+          completion: "consumed",
+          reason: "provider_billing_limit",
+        },
+      },
+    ]);
+  });
+
+  it("keeps structured auth failures as credential failures with a relogin notice", async () => {
+    mockState.nextMessages = [
+      {
+        type: "result",
+        subtype: "success",
+        is_error: true,
+        api_error_status: 401,
+        result: "authentication_failed",
+      },
+    ];
+    const { sendMessage, forwardResult, emitted, completed } = await runSingleResultTurn();
+
+    expect(forwardResult).not.toHaveBeenCalled();
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(String(sendMessage.mock.calls[0]?.[1].content)).toContain("`claude login`");
+
+    const providerPayloads = emitted
+      .filter((event) => event.kind === "error")
+      .map((event) => parseProviderRetryEventMessage(event.payload.message))
+      .filter((payload) => payload !== null);
+    expect(providerPayloads[0]).toMatchObject({
+      event: "provider_failure_terminal",
+      provider: "claude-code",
+      scope: "provider_turn",
+      category: "credential",
+      reasonCode: "provider_credential_required",
+      userSeverity: "error",
+    });
+    expect(completed[0]?.outcome).toMatchObject({
+      status: "error",
+      terminal: true,
+      completion: "consumed",
+      reason: "provider_credential_required",
+    });
+  });
+
+  it("does not replay a transient structured failure after assistant text was emitted", async () => {
+    mockState.nextMessages = [
+      {
+        type: "assistant",
+        message: {
+          content: [{ type: "text", text: "I started working on this." }],
+        },
+      },
+      {
+        type: "result",
+        subtype: "success",
+        is_error: true,
+        api_error_status: 503,
+        result: TRANSIENT_RESULT,
+      },
+    ];
+    const { sendMessage, forwardResult, emitted, completed } = await runSingleResultTurn();
+
+    expect(mockState.queryCalls).toBe(1);
+    expect(forwardResult).not.toHaveBeenCalled();
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(emitted.some((event) => event.kind === "assistant_text")).toBe(true);
+
+    const providerPayloads = emitted
+      .filter((event) => event.kind === "error")
+      .map((event) => parseProviderRetryEventMessage(event.payload.message))
+      .filter((payload) => payload !== null);
+    expect(providerPayloads[0]).toMatchObject({
+      event: "provider_failure_terminal",
+      provider: "claude-code",
+      scope: "provider_turn",
+      category: "transient_transport",
+      reasonCode: "unsafe_replay",
+      replaySafety: "user_visible",
+    });
+    expect(completed[0]?.outcome).toMatchObject({
+      status: "error",
+      terminal: true,
+      completion: "consumed",
+      reason: "unsafe_replay",
+    });
+  });
+
+  it("keeps assistant billing_error as the primary classification for a generic 403 result", async () => {
+    mockState.nextMessages = [
+      {
+        type: "assistant",
+        error: "billing_error",
+      },
+      {
+        type: "result",
+        subtype: "success",
+        is_error: true,
+        api_error_status: 403,
+        result: "Failed to authenticate.",
+      },
+    ];
+    const { sendMessage, forwardResult, emitted, completed } = await runSingleResultTurn();
+
+    expect(forwardResult).not.toHaveBeenCalled();
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    const notice = String(sendMessage.mock.calls[0]?.[1].content);
+    expect(notice).toContain("insufficient account balance");
+    expect(notice).not.toContain("`claude login`");
+
+    const providerPayloads = emitted
+      .filter((event) => event.kind === "error")
+      .map((event) => parseProviderRetryEventMessage(event.payload.message))
+      .filter((payload) => payload !== null);
+    expect(providerPayloads[0]).toMatchObject({
+      event: "provider_failure_terminal",
+      provider: "claude-code",
+      scope: "provider_turn",
+      category: "provider_capacity",
+      reasonCode: "provider_billing_limit",
+      userSeverity: "error",
+    });
+    expect(completed[0]?.outcome).toMatchObject({
+      status: "error",
+      terminal: true,
+      completion: "consumed",
+      reason: "provider_billing_limit",
+    });
+  });
+
+  it("does not sniff ordinary success result text as a provider error", async () => {
+    const resultText = "API Error: 401 Unauthorized is an example the user asked about.";
+    mockState.nextMessages = [
+      {
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        result: resultText,
+      },
+    ];
+    const { sendMessage, forwardResult, emitted } = await runSingleResultTurn();
+
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(forwardResult).toHaveBeenCalledWith(resultText);
+    expect(
+      emitted
+        .filter((event) => event.kind === "error")
+        .some((event) => parseProviderRetryEventMessage(event.payload.message) !== null),
+    ).toBe(false);
+    expect(emitted.some((event) => event.kind === "turn_end" && event.payload.status === "success")).toBe(true);
+  });
+});

--- a/packages/client/src/__tests__/claude-code-session-limit-result.test.ts
+++ b/packages/client/src/__tests__/claude-code-session-limit-result.test.ts
@@ -19,6 +19,7 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => {
               value: {
                 type: "result",
                 subtype: "success",
+                is_error: true,
                 result: SESSION_LIMIT_RESULT,
               },
             };
@@ -112,8 +113,10 @@ describe("claude-code handler — session-limit success result", () => {
     await new Promise((r) => setImmediate(r));
 
     expect(forwardResult).not.toHaveBeenCalled();
-    expect(sendMessage).not.toHaveBeenCalled();
-    expect(logs.some((line) => line.includes("Claude Code session limit detected"))).toBe(true);
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage.mock.calls[0]?.[1].purpose).toBe("agent-final-text");
+    expect(String(sendMessage.mock.calls[0]?.[1].content)).toContain("capacity or usage limit");
+    expect(logs.some((line) => line.includes("Claude SDK provider failure"))).toBe(true);
 
     const providerPayloads = emitted
       .filter((event) => event.kind === "error")
@@ -134,7 +137,7 @@ describe("claude-code handler — session-limit success result", () => {
         (event) =>
           event.kind === "error" &&
           event.payload.source === "sdk" &&
-          event.payload.message.includes("Claude Code session limit"),
+          event.payload.message.includes("Claude SDK provider failure"),
       ),
     ).toBe(true);
     expect(emitted.some((event) => event.kind === "turn_end" && event.payload.status === "error")).toBe(true);

--- a/packages/client/src/__tests__/claude-code-stream-error-retry-replay.test.ts
+++ b/packages/client/src/__tests__/claude-code-stream-error-retry-replay.test.ts
@@ -7,9 +7,9 @@ import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 /**
  * Regression test for the `claude_socket_closed` transient retry path.
  *
- * Reported bug: a Claude SDK "wrapped" stream-API error (subtype=`success`
- * payload whose `result` text is `"API Error: The socket connection was
- * closed unexpectedly..."`) was correctly classified `transient/
+ * Reported bug: a Claude SDK stream-API error (subtype=`success`,
+ * `is_error: true`, payload whose `result` text is `"API Error: The socket
+ * connection was closed unexpectedly..."`) was correctly classified `transient/
  * claude_socket_closed` and triggered the auto-resume branch — but the
  * old `respawnQuery()` only rebuilt the SDK query and left the new
  * `InputController` empty. With no user prompt in the iterable the SDK
@@ -90,14 +90,14 @@ function makeWrappedStreamErrorQuery(
           await waitForObservedInputs(attempt, requiredInputsForAttempt(attempt));
           await resultReleaseGates.get(attempt);
           yielded = true;
-          // Yield a "success" subtype with the wrapped API-error text —
-          // the handler's `detectStreamApiError` sniff will classify
-          // this as transient/claude_socket_closed and throw to drive
-          // the auto-resume path.
+          // Yield latest-SDK structured "success but error" result. The
+          // handler classifies it from `is_error` / provider fields, not from
+          // final-text regex sniffing.
           return {
             value: {
               type: "result",
               subtype: "success",
+              is_error: true,
               result: FAKE_API_ERROR_TEXT,
             },
             done: false,

--- a/packages/client/src/__tests__/claude-code-turn-end-sdk-error.test.ts
+++ b/packages/client/src/__tests__/claude-code-turn-end-sdk-error.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { SessionEvent } from "@first-tree/shared";
+import { parseProviderRetryEventMessage, type SessionEvent } from "@first-tree/shared";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
 /**
@@ -105,16 +105,28 @@ describe("claude-code handler — turn_end on SDK-reported subtype error", () =>
     await handler.suspend();
     await new Promise((r) => setImmediate(r));
 
-    // Success path was NOT taken.
-    expect(sendMessage).not.toHaveBeenCalled();
+    // Success path was NOT taken; the only chat write is an explicit runtime
+    // notice, not final-text forwarding.
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage.mock.calls[0]?.[1]).toMatchObject({
+      source: "api",
+      format: "text",
+      purpose: "agent-final-text",
+    });
+    expect(String(sendMessage.mock.calls[0]?.[1].content)).toContain("exceeded max turns");
 
     // Error event carries the SDK-reported cause.
     const errors = emitted.filter((e) => e.kind === "error");
-    expect(errors).toHaveLength(1);
-    const err = errors[0];
-    if (!err || err.kind !== "error") throw new Error("expected error event");
-    expect(err.payload.source).toBe("sdk");
-    expect(err.payload.message).toContain("exceeded max turns");
+    expect(errors).toHaveLength(2);
+    const providerPayload = parseProviderRetryEventMessage(errors[0]?.payload.message ?? "");
+    expect(providerPayload).toMatchObject({
+      event: "provider_failure_terminal",
+      provider: "claude-code",
+      scope: "provider_turn",
+    });
+    const sdkErr = errors.find((event) => event.payload.source === "sdk");
+    if (!sdkErr || sdkErr.kind !== "error") throw new Error("expected sdk error event");
+    expect(sdkErr.payload.message).toContain("exceeded max turns");
 
     // turn_end:error closes the turn — and comes AFTER the error event.
     const turnEnds = emitted.filter((e) => e.kind === "turn_end");
@@ -123,7 +135,7 @@ describe("claude-code handler — turn_end on SDK-reported subtype error", () =>
     if (!te || te.kind !== "turn_end") throw new Error("expected turn_end event");
     expect(te.payload.status).toBe("error");
 
-    const errIdx = emitted.findIndex((e) => e.kind === "error");
+    const errIdx = emitted.findIndex((e) => e.kind === "error" && e.payload.source === "sdk");
     const turnEndIdx = emitted.findIndex((e) => e.kind === "turn_end");
     expect(errIdx).toBeLessThan(turnEndIdx);
   });

--- a/packages/client/src/__tests__/claude-provider-error.test.ts
+++ b/packages/client/src/__tests__/claude-provider-error.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import {
+  claudeFailureFromAssistantMessage,
+  claudeFailureFromSdkResult,
+  formatClaudeProviderFailureNotice,
+} from "../handlers/claude-provider-error.js";
+import { classifyProviderFailure } from "../runtime/provider-retry-policy.js";
+
+function classify(error: unknown) {
+  return classifyProviderFailure(error, {
+    provider: "claude-code",
+    scope: "provider_turn",
+    source: "sdk",
+  });
+}
+
+describe("claude provider error adapter", () => {
+  it("treats SDK success result with is_error as provider failure using structured status", () => {
+    const failure = claudeFailureFromSdkResult({
+      type: "result",
+      subtype: "success",
+      is_error: true,
+      api_error_status: 403,
+      result: "Failed to authenticate. API Error: 403 Insufficient account balance.",
+    });
+
+    expect(failure).not.toBeNull();
+    if (!failure) throw new Error("expected failure");
+    expect(failure.messagePreview).toBe("Failed to authenticate. API Error: 403 Insufficient account balance.");
+    expect(classify(failure.signal.error)).toMatchObject({
+      category: "provider_capacity",
+      reasonCode: "provider_billing_limit",
+    });
+  });
+
+  it("does not inspect ordinary success result text", () => {
+    expect(
+      claudeFailureFromSdkResult({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        result: "Here is how to handle API Error: 403 in your app.",
+      }),
+    ).toBeNull();
+  });
+
+  it("maps non-success result subtype and errors into a provider failure", () => {
+    const failure = claudeFailureFromSdkResult({
+      type: "result",
+      subtype: "error_during_execution",
+      is_error: true,
+      errors: ["authentication_failed"],
+    });
+
+    expect(failure).not.toBeNull();
+    if (!failure) throw new Error("expected failure");
+    expect(classify(failure.signal.error)).toMatchObject({ category: "credential" });
+  });
+
+  it("maps assistant typed errors through provider retry classification", () => {
+    const cases = [
+      ["authentication_failed", "credential", "provider_credential_required"],
+      ["billing_error", "provider_capacity", "provider_billing_limit"],
+      ["rate_limit", "provider_capacity", "provider_rate_limited"],
+      ["overloaded", "provider_capacity", "provider_overloaded"],
+      ["invalid_request", "deterministic_input", "provider_deterministic_input"],
+      ["model_not_found", "configuration", "provider_configuration_error"],
+      ["server_error", "transient_transport", "claude_server_error"],
+    ] as const;
+
+    for (const [code, category, reasonCode] of cases) {
+      const failure = claudeFailureFromAssistantMessage({ type: "assistant", error: code });
+      expect(failure, code).not.toBeNull();
+      if (!failure) throw new Error(`expected failure for ${code}`);
+      expect(classify(failure.signal.error), code).toMatchObject({ category, reasonCode });
+    }
+  });
+
+  it("formats a chat-visible billing notice without restoring final-text forwarding", () => {
+    const notice = formatClaudeProviderFailureNotice(
+      {
+        category: "provider_capacity",
+        reasonCode: "provider_billing_limit",
+        message: "billing",
+        sourceKind: "permanent",
+      },
+      "API Error: 403 Insufficient account balance",
+    );
+
+    expect(notice).toContain("Claude Code could not run this turn");
+    expect(notice).toContain("insufficient account balance");
+    expect(notice).toContain("Original provider message");
+  });
+});

--- a/packages/client/src/__tests__/provider-retry-policy.test.ts
+++ b/packages/client/src/__tests__/provider-retry-policy.test.ts
@@ -70,6 +70,35 @@ describe("classifyProviderFailure", () => {
     });
   });
 
+  it("maps billing and account-balance errors to provider billing capacity before generic 403 credential", () => {
+    const cases = [
+      Object.assign(new Error("Failed to authenticate. API Error: 403 Insufficient account balance."), { status: 403 }),
+      Object.assign(new Error("Credit balance is too low"), { statusCode: 403 }),
+      Object.assign(new Error("billing_error"), { status: 403 }),
+    ];
+
+    for (const err of cases) {
+      const c = classifyProviderFailure(err, {
+        provider: "claude-code",
+        scope: "provider_turn",
+        source: "sdk",
+      });
+      expect(c).toMatchObject({ category: "provider_capacity", reasonCode: "provider_billing_limit" });
+      expect(
+        decideProviderRetry({
+          classification: c,
+          scope: "provider_turn",
+          attempt: 1,
+          replaySafety: "provider_entered",
+        }),
+      ).toMatchObject({
+        action: "stop",
+        reasonCode: "provider_billing_limit",
+        terminalKind: "capacity_wait_required",
+      });
+    }
+  });
+
   it("maps network and 5xx failures to transient_transport", () => {
     for (const err of [new Error("fetch failed"), Object.assign(new Error("upstream 503"), { status: 503 })]) {
       expect(classifyProviderFailure(err, { provider: "codex", scope: "provider_turn", source: "sdk" }).category).toBe(
@@ -86,6 +115,7 @@ describe("classifyProviderFailure", () => {
       [new Error("Codex runtime binary is missing"), "capability"],
       [new Error("sandbox approval rejected"), "configuration"],
       [new Error("context length exceeded"), "deterministic_input"],
+      [new Error("error_max_turns: exceeded max turns"), "deterministic_input"],
     ];
     for (const [err, category] of cases) {
       expect(classifyProviderFailure(err, { provider: "codex", scope: "provider_turn", source: "sdk" }).category).toBe(

--- a/packages/client/src/handlers/auth-error-hint.ts
+++ b/packages/client/src/handlers/auth-error-hint.ts
@@ -71,8 +71,8 @@ export function formatAuthHint(runtime: Runtime, originalMessage: string): strin
   // packages/web/src/pages/clients/cards/shared/providers.ts so the in-chat
   // hint matches what the Setup-incomplete card already prints. Keeping them
   // textually identical is intentional — if the provider's canonical command
-  // ever changes (e.g. `claude auth login`), update both call sites together.
-  const reauth = runtime === "codex" ? "`codex login`" : "`claude login`";
+  // ever changes, update both call sites together.
+  const reauth = runtime === "codex" ? "`codex login`" : "`claude auth login`";
   const provider = runtime === "codex" ? "OpenAI" : "Anthropic";
   // Cap the appended raw message so an upstream stack-trace envelope (codex
   // wraps its `event.error.message` in surprising ways) doesn't bloat the

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -13,6 +13,7 @@ import type {
 import { query as claudeQuery } from "@anthropic-ai/claude-agent-sdk";
 import type {
   AgentRuntimeConfigPayload,
+  ReplaySafety,
   RuntimeProvider,
   SessionEvent,
   SupportedImageMime,
@@ -46,6 +47,7 @@ import {
 } from "../runtime/handler.js";
 import { findImagePath } from "../runtime/image-store.js";
 import { InputController } from "../runtime/input-controller.js";
+import { ProviderAttempt, type ProviderAttemptSettlement } from "../runtime/provider-attempt.js";
 import {
   buildProviderRetryEvent,
   classifyProviderFailure,
@@ -66,6 +68,13 @@ import { acquireAgentHome, markWorkspaceInitComplete } from "../runtime/workspac
 import { chunkAssistantText } from "./assistant-text.js";
 import { formatAuthHint, isClaudeAuthError } from "./auth-error-hint.js";
 import { resolveClaudeCodeExecutable } from "./claude-executable.js";
+import {
+  type ClaudeProviderFailure,
+  claudeFailureFromAssistantMessage,
+  claudeFailureFromSdkResult,
+  formatClaudeProviderFailureNotice,
+  mergeClaudeProviderFailures,
+} from "./claude-provider-error.js";
 import { consumedErrorOutcome } from "./turn-settlement.js";
 
 type PendingAckMessage = {
@@ -262,6 +271,10 @@ function isThinkingBlock(block: unknown): block is ThinkingBlock {
   if (!block || typeof block !== "object") return false;
   const b = block as Record<string, unknown>;
   return b.type === "thinking";
+}
+
+function eventMakesReplayUnsafe(event: SessionEvent): boolean {
+  return event.kind === "assistant_text" || event.kind === "thinking" || event.kind === "tool_call";
 }
 
 type ResultMessage = {
@@ -844,6 +857,58 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
     });
   }
 
+  function emitProviderTurnSettlementEvent(sessionCtx: SessionContext, settlement: ProviderAttemptSettlement): void {
+    sessionCtx.emitEvent({
+      kind: "error",
+      payload: {
+        source: "runtime",
+        message: encodeProviderRetryEventMessage(settlement.eventPayload),
+      },
+    });
+  }
+
+  async function sendClaudeProviderFailureNotice(
+    sessionCtx: SessionContext,
+    settlement: ProviderAttemptSettlement,
+  ): Promise<boolean> {
+    try {
+      await sessionCtx.sdk.sendMessage(sessionCtx.chatId, {
+        source: "api",
+        format: "text",
+        content: formatClaudeProviderFailureNotice(settlement.classification, settlement.messagePreview),
+        purpose: "agent-final-text",
+      });
+      return true;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      sessionCtx.emitEvent({
+        kind: "error",
+        payload: { source: "runtime", message: `claude provider failure notice delivery failed: ${msg}` },
+      });
+      return false;
+    }
+  }
+
+  function consumedReasonForProviderSettlement(
+    settlement: ProviderAttemptSettlement,
+  ): Parameters<typeof consumedErrorOutcome>[0] {
+    const decision = settlement.decision;
+    if (decision.action !== "stop") return settlement.classification.reasonCode;
+    if (decision.terminalKind === "exhausted") return "provider_retry_exhausted";
+    return decision.reasonCode;
+  }
+
+  function settleClaudeProviderFailure(failure: ClaudeProviderFailure): ProviderAttemptSettlement | null {
+    const attempt = new ProviderAttempt({
+      provider: runtimeProvider,
+      scope: "provider_turn",
+      source: "sdk",
+      ...(failure.signal.replaySafety ? { replaySafety: failure.signal.replaySafety } : {}),
+    });
+    attempt.recordSignal(failure.signal);
+    return attempt.settle({ attempt: retryCount + 1 });
+  }
+
   async function toSDKUserMessage(
     message: SessionMessage,
     sessionCtx: SessionContext,
@@ -1400,8 +1465,12 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
   }
 
   async function consumeOutput(sessionCtx: SessionContext): Promise<void> {
+    let turnHadUserVisibleOutput = false;
     const toolCallProcessor = createToolCallProcessor(
-      (event) => sessionCtx.emitEvent(event),
+      (event) => {
+        if (eventMakesReplayUnsafe(event)) turnHadUserVisibleOutput = true;
+        sessionCtx.emitEvent(event);
+      },
       {
         path: contextTreePath,
         repoUrl: contextTreeRepoUrl,
@@ -1432,8 +1501,13 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
     // Hoisted out of the try block so the outer catch's reentry preserves it
     // across the resume boundary.
     let authHintEmitted = false;
+    let pendingAssistantProviderFailure: ClaudeProviderFailure | null = null;
+    const currentTurnReplaySafety = (): ReplaySafety => (turnHadUserVisibleOutput ? "user_visible" : "pre_visible");
+    const resetTurnReplaySafety = (): void => {
+      turnHadUserVisibleOutput = false;
+    };
     try {
-      while (true) {
+      queryLoop: while (true) {
         if (!currentQuery) return;
 
         try {
@@ -1455,10 +1529,74 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
                 payload: { source: "sdk", message: formatAuthHint("claude-code", authFailure.rawMessage) },
               });
             }
+            const assistantProviderFailure = claudeFailureFromAssistantMessage(message);
+            if (assistantProviderFailure) pendingAssistantProviderFailure = assistantProviderFailure;
 
             if (isResultMessage(message)) {
               const providerEnteredPrefix = pendingProviderEnteredPrefix();
               emitTokenUsageFromResult(message, sessionCtx);
+              const providerFailure = mergeClaudeProviderFailures({
+                resultFailure: claudeFailureFromSdkResult(message),
+                assistantFailure: pendingAssistantProviderFailure,
+                ...(turnHadUserVisibleOutput ? { replaySafety: "user_visible" as const } : {}),
+              });
+              pendingAssistantProviderFailure = null;
+              if (providerFailure) {
+                const settlement = settleClaudeProviderFailure(providerFailure);
+                if (settlement) {
+                  sessionCtx.log(
+                    `Claude SDK provider failure (${settlement.classification.category}/${settlement.classification.reasonCode}): ${settlement.messagePreview}`,
+                  );
+                  if (settlement.decision.action === "retry") {
+                    if (!claudeSessionId) {
+                      throw new StreamApiTransientError(settlement.messagePreview);
+                    }
+                    retryCount = settlement.decision.attempt;
+                    emitProviderTurnSettlementEvent(sessionCtx, settlement);
+                    sessionCtx.log(`Attempting auto-resume (retry ${retryCount}/${providerTurnMaxRetries})`);
+                    toolCallProcessor.flush();
+                    try {
+                      respawnQuery(claudeSessionId, sessionCtx);
+                    } catch (resumeErr) {
+                      const resumeMsg = resumeErr instanceof Error ? resumeErr.message : String(resumeErr);
+                      sessionCtx.log(`Auto-resume failed after Claude SDK provider failure: ${resumeMsg}`);
+                      sessionCtx.emitEvent({
+                        kind: "error",
+                        payload: { source: "runtime", message: `Auto-resume failed: ${resumeMsg.slice(0, 800)}` },
+                      });
+                      sessionCtx.emitEvent({ kind: "turn_end", payload: { status: "error" } });
+                      await ackTurnClose("error", "auto_resume_failed_notice_posted", providerEnteredPrefix);
+                      retryBufferedMessages("claude_auto_resume_failed_tail_recovery");
+                      failFatalSessionForRecovery(sessionCtx, "claude_auto_resume_failed");
+                      return;
+                    }
+                    continue queryLoop;
+                  }
+
+                  emitProviderTurnSettlementEvent(sessionCtx, settlement);
+                  if (!(authHintEmitted && settlement.classification.category === "credential")) {
+                    sessionCtx.emitEvent({
+                      kind: "error",
+                      payload: {
+                        source: "sdk",
+                        message: `Claude SDK provider failure (${settlement.classification.reasonCode}): ${settlement.messagePreview}`,
+                      },
+                    });
+                  }
+                  sessionCtx.emitEvent({ kind: "turn_end", payload: { status: "error" } });
+                  retryCount = 0;
+                  const noticePosted = await sendClaudeProviderFailureNotice(sessionCtx, settlement);
+                  if (!noticePosted) {
+                    retryBufferedMessages("claude_provider_failure_notice_delivery_failed");
+                    failFatalSessionForRecovery(sessionCtx, "claude_provider_failure_notice_delivery_failed");
+                    return;
+                  }
+                  await ackTurnClose("error", consumedReasonForProviderSettlement(settlement), providerEnteredPrefix);
+                  resetTurnReplaySafety();
+                  continue;
+                }
+              }
+
               if (message.subtype === "success") {
                 // Close out the turn. The result text is already captured as
                 // `assistant_text` events; `forwardResult` no longer delivers
@@ -1473,154 +1611,46 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
                 // live events.
                 if (message.result && sessionCtx.chatId) {
                   const resultText = message.result;
-                  const sessionLimit = detectClaudeSessionLimitResult(resultText);
-                  if (sessionLimit) {
-                    const classification = classifyProviderFailure(new Error(sessionLimit.message), {
-                      provider: runtimeProvider,
-                      scope: "provider_turn",
-                      source: "stream",
-                    });
-                    const decision = decideProviderRetry({
-                      classification,
-                      scope: "provider_turn",
-                      attempt: 1,
-                      replaySafety: "provider_entered",
-                    });
-                    sessionCtx.log(
-                      `Claude Code session limit detected (${classification.category}/${classification.reasonCode}): ${sessionLimit.message}`,
-                    );
-                    emitProviderTurnRetryEvent(
-                      sessionCtx,
-                      "provider_failure_terminal",
-                      classification,
-                      decision,
-                      sessionLimit.message,
-                    );
+                  // Genuine success — reset retry budget for the next turn.
+                  retryCount = 0;
+                  try {
+                    // Turn-completion hook. The agent's text is already
+                    // captured as `assistant_text` events above; `forwardResult`
+                    // no longer delivers it to chat (the per-turn final-text
+                    // mirror is retired — see runtime/result-sink.ts), it just
+                    // closes out the turn trigger.
+                    await sessionCtx.forwardResult(resultText);
+                    sessionCtx.emitEvent({ kind: "turn_end", payload: { status: "success" } });
+                    // Turn closed cleanly — drain in-flight inbox entries.
+                    await ackTurnClose("success", "provider_clean_error", providerEnteredPrefix);
+                    resetTurnReplaySafety();
+                  } catch (err) {
+                    const reason = err instanceof Error ? err.message : String(err);
+                    sessionCtx.log(`Failed to forward result: ${reason}`);
+                    const preview = resultText.slice(0, 1500);
+                    const forwardErrMessage = `Result forward failed: ${reason}\n---\n${preview}`.slice(0, 2000);
                     sessionCtx.emitEvent({
                       kind: "error",
-                      payload: {
-                        source: "sdk",
-                        message: `Claude Code session limit: ${sessionLimit.message}`,
-                      },
+                      payload: { source: "runtime", message: forwardErrMessage },
                     });
                     sessionCtx.emitEvent({ kind: "turn_end", payload: { status: "error" } });
+                    // A failure in the completion hook is treated as terminal
+                    // for this turn — ack so we don't loop on redelivery. The
+                    // hook only closes the turn trigger now (the final-text
+                    // mirror is retired, so there is no chat-delivery step to
+                    // fail); a throw here is unexpected, but we still degrade
+                    // gracefully. If recovery is needed the user can retry by
+                    // sending a new message.
+                    //
+                    // Reset retryCount along with the success branch above:
+                    // the SDK actually returned a clean `result` here (any
+                    // failure is in our own turn-completion plumbing, not the
+                    // model), so the next turn should not inherit the prior
+                    // turn's transient-retry counter when an unrelated future
+                    // stream error fires.
                     retryCount = 0;
-                    await ackTurnClose("error", decision.reasonCode, providerEnteredPrefix);
-                    continue;
-                  }
-                  // Bug 6: SDK sometimes packages its own catch'd API error
-                  // as a `result.subtype === "success"` payload. Sniff it so
-                  // we surface an error turn instead of silently closing the
-                  // turn as a clean success.
-                  const sniff = detectStreamApiError(resultText);
-                  if (sniff) {
-                    const classification = classifyProviderFailure(new Error(sniff.message), {
-                      provider: runtimeProvider,
-                      scope: "provider_turn",
-                      source: "stream",
-                    });
-                    const decision = decideProviderRetry({
-                      classification,
-                      scope: "provider_turn",
-                      attempt: retryCount + 1,
-                      replaySafety: "pre_visible",
-                    });
-                    sessionCtx.log(
-                      `Stream API error detected (${classification.category}/${classification.reasonCode}): ${sniff.message}`,
-                    );
-                    // Design §6.1: emit `resilience.stream.api_error_detected`
-                    // on BOTH transient and permanent paths via the closed-kind
-                    // bridge (encoded into the `error` event message).
-                    sessionCtx.emitEvent({
-                      kind: "error",
-                      payload: {
-                        source: "runtime",
-                        message: `resilience.stream.api_error_detected: ${JSON.stringify({
-                          reasonCode: classification.reasonCode,
-                          category: classification.category,
-                          messagePreview: sniff.message.slice(0, 200),
-                        })}`,
-                      },
-                    });
-                    if (decision.action === "retry") {
-                      emitProviderTurnRetryEvent(
-                        sessionCtx,
-                        "provider_retry_scheduled",
-                        classification,
-                        decision,
-                        sniff.message,
-                      );
-                      // Re-throw to drive the outer catch's auto-resume path
-                      // (retry counter + self-resume via handler.resume).
-                      throw new StreamApiTransientError(sniff.message);
-                    }
-                    // Permanent (401/403) OR retries exhausted: surface the
-                    // failure as an error event + error turn, and do NOT run
-                    // the success/completion path for this turn.
-                    emitProviderTurnRetryEvent(
-                      sessionCtx,
-                      decision.terminalKind === "exhausted" ? "provider_retry_exhausted" : "provider_failure_terminal",
-                      classification,
-                      decision,
-                      sniff.message,
-                    );
-                    sessionCtx.emitEvent({
-                      kind: "error",
-                      payload: {
-                        source: "sdk",
-                        message: `Claude API error (${classification.reasonCode}): ${sniff.message}`,
-                      },
-                    });
-                    sessionCtx.emitEvent({ kind: "turn_end", payload: { status: "error" } });
-                    // Permanent stream API failure — ack so the server
-                    // doesn't redeliver a message that would just produce
-                    // the same error. Retry was exhausted upstream.
-                    await ackTurnClose("error", "stream_api_error_posted", providerEnteredPrefix);
-                  } else {
-                    // Genuine success — reset retry budget for the next turn.
-                    // Do NOT reset on the sniff-hit branches above: a wrapped
-                    // transient API error masquerades as `subtype: "success"`
-                    // and we MUST let `retryCount` accumulate so MAX_RETRIES
-                    // can fire and break us out of an unhealing transient
-                    // loop (rate limit / socket closed / etc.).
-                    retryCount = 0;
-                    try {
-                      // Turn-completion hook. The agent's text is already
-                      // captured as `assistant_text` events above; `forwardResult`
-                      // no longer delivers it to chat (the per-turn final-text
-                      // mirror is retired — see runtime/result-sink.ts), it just
-                      // closes out the turn trigger.
-                      await sessionCtx.forwardResult(resultText);
-                      sessionCtx.emitEvent({ kind: "turn_end", payload: { status: "success" } });
-                      // Turn closed cleanly — drain in-flight inbox entries.
-                      await ackTurnClose("success", "provider_clean_error", providerEnteredPrefix);
-                    } catch (err) {
-                      const reason = err instanceof Error ? err.message : String(err);
-                      sessionCtx.log(`Failed to forward result: ${reason}`);
-                      const preview = resultText.slice(0, 1500);
-                      const forwardErrMessage = `Result forward failed: ${reason}\n---\n${preview}`.slice(0, 2000);
-                      sessionCtx.emitEvent({
-                        kind: "error",
-                        payload: { source: "runtime", message: forwardErrMessage },
-                      });
-                      sessionCtx.emitEvent({ kind: "turn_end", payload: { status: "error" } });
-                      // A failure in the completion hook is treated as terminal
-                      // for this turn — ack so we don't loop on redelivery. The
-                      // hook only closes the turn trigger now (the final-text
-                      // mirror is retired, so there is no chat-delivery step to
-                      // fail); a throw here is unexpected, but we still degrade
-                      // gracefully. If recovery is needed the user can retry by
-                      // sending a new message.
-                      //
-                      // Reset retryCount along with the success branch above:
-                      // the SDK actually returned a clean `result` here (any
-                      // failure is in our own turn-completion plumbing, not the
-                      // model), so the next turn should not inherit the prior
-                      // turn's transient-retry counter when an unrelated future
-                      // stream error fires.
-                      retryCount = 0;
-                      await ackTurnClose("error", "forward_failed", providerEnteredPrefix);
-                    }
+                    await ackTurnClose("error", "forward_failed", providerEnteredPrefix);
+                    resetTurnReplaySafety();
                   }
                 } else {
                   // No result text to forward (edge case) — still close the turn.
@@ -1628,23 +1658,8 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
                   retryCount = 0;
                   sessionCtx.emitEvent({ kind: "turn_end", payload: { status: "success" } });
                   await ackTurnClose("success", "provider_clean_error", providerEnteredPrefix);
+                  resetTurnReplaySafety();
                 }
-              } else {
-                const errors = message.errors ? message.errors.join("; ") : message.subtype;
-                const errorLog = `Query result error: ${errors} (subtype=${message.subtype}, turns=${message.num_turns ?? "?"}, duration=${message.duration_ms ?? "?"}ms)`;
-                sessionCtx.log(errorLog);
-                // If we already emitted an auth-failure hint earlier in this
-                // turn (typed `authentication_failed` on an assistant /
-                // api_retry / auth_status message), skip the raw SDK error
-                // emit so the timeline shows the actionable hint instead of
-                // a redundant opaque second line.
-                if (!authHintEmitted) {
-                  sessionCtx.emitEvent({ kind: "error", payload: { source: "sdk", message: errors } });
-                }
-                sessionCtx.emitEvent({ kind: "turn_end", payload: { status: "error" } });
-                // SDK reported a turn-level error (non-success subtype):
-                // redelivery would just hit the same error — ack.
-                await ackTurnClose("error", "provider_clean_error", providerEnteredPrefix);
               }
               // Reset the auth-hint flag only on a SUCCESSFUL result. This
               // gives a clean slate for the next turn once auth is clearly
@@ -1682,7 +1697,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
             classification,
             scope: "provider_turn",
             attempt: retryCount + 1,
-            replaySafety: "pre_visible",
+            replaySafety: currentTurnReplaySafety(),
           });
 
           if (decision.action !== "retry" || !claudeSessionId) {

--- a/packages/client/src/handlers/claude-provider-error.ts
+++ b/packages/client/src/handlers/claude-provider-error.ts
@@ -1,0 +1,256 @@
+import type { SDKAssistantMessageError } from "@anthropic-ai/claude-agent-sdk";
+import type { ProviderFailureCategory, ReplaySafety } from "@first-tree/shared";
+import type { ProviderAttemptSignal } from "../runtime/provider-attempt.js";
+import type { ProviderFailureClassification } from "../runtime/provider-retry-policy.js";
+import { redactErrorPreview } from "../runtime/redact-error-preview.js";
+
+type ClaudeProviderErrorShape = {
+  name: "ClaudeSdkProviderError";
+  message: string;
+  code: string;
+  reason: string;
+  status?: number;
+  statusCode?: number;
+};
+
+export type ClaudeProviderFailure = {
+  signal: ProviderAttemptSignal;
+  messagePreview: string;
+  origin: "sdk_result" | "assistant_error";
+  assistantError?: SDKAssistantMessageError;
+};
+
+const CLAUDE_ASSISTANT_ERROR_CODES: Record<SDKAssistantMessageError, true> = {
+  authentication_failed: true,
+  oauth_org_not_allowed: true,
+  billing_error: true,
+  rate_limit: true,
+  overloaded: true,
+  invalid_request: true,
+  model_not_found: true,
+  server_error: true,
+  unknown: true,
+  max_output_tokens: true,
+};
+
+export function claudeFailureFromSdkResult(message: unknown): ClaudeProviderFailure | null {
+  const result = readResultMessage(message);
+  if (!result) return null;
+
+  if (result.subtype === "success" && result.isError !== true) return null;
+
+  const messagePreview =
+    result.subtype === "success"
+      ? firstNonEmpty(result.result, "Claude SDK returned an error result")
+      : firstNonEmpty(result.errors.join("; "), result.result, result.subtype);
+  const status = result.apiErrorStatus ?? undefined;
+  const reason = result.subtype === "success" ? "claude_result_is_error" : `claude_result_${result.subtype}`;
+  return buildFailure({
+    messagePreview,
+    reason,
+    code: status ? `${reason}_${status}` : reason,
+    status,
+    replaySafety: result.subtype === "success" ? "pre_visible" : "provider_entered",
+    origin: "sdk_result",
+  });
+}
+
+export function claudeFailureFromAssistantMessage(message: unknown): ClaudeProviderFailure | null {
+  if (!message || typeof message !== "object") return null;
+  const record = message as Record<string, unknown>;
+  if (record.type !== "assistant") return null;
+  const code = claudeAssistantErrorCode(record.error);
+  if (!code) return null;
+  const status = statusForAssistantError(code);
+  return buildFailure({
+    messagePreview: code,
+    reason: code,
+    code,
+    status,
+    replaySafety: "provider_entered",
+    origin: "assistant_error",
+    assistantError: code,
+  });
+}
+
+export function mergeClaudeProviderFailures(input: {
+  resultFailure: ClaudeProviderFailure | null;
+  assistantFailure: ClaudeProviderFailure | null;
+  replaySafety?: ReplaySafety;
+}): ClaudeProviderFailure | null {
+  const primary = choosePrimaryFailure(input.resultFailure, input.assistantFailure);
+  if (!primary) return null;
+  const secondary = primary === input.assistantFailure ? input.resultFailure : input.assistantFailure;
+  const merged = secondary ? withMergedPreview(primary, secondary) : primary;
+  return input.replaySafety ? withReplaySafety(merged, input.replaySafety) : merged;
+}
+
+export function formatClaudeProviderFailureNotice(
+  classification: ProviderFailureClassification,
+  messagePreview: string,
+): string {
+  const detail = redactErrorPreview(messagePreview.trim(), 500);
+  const suffix = detail.length > 0 ? ` Original provider message: ${detail}` : "";
+  return `${noticeLead(classification.category, classification.reasonCode)}${suffix}`;
+}
+
+function readResultMessage(message: unknown): {
+  subtype: string;
+  result?: string;
+  errors: string[];
+  isError?: boolean;
+  apiErrorStatus?: number | null;
+} | null {
+  if (!message || typeof message !== "object") return null;
+  const record = message as Record<string, unknown>;
+  if (record.type !== "result" || typeof record.subtype !== "string") return null;
+  return {
+    subtype: record.subtype,
+    result: typeof record.result === "string" ? record.result : undefined,
+    errors: Array.isArray(record.errors)
+      ? record.errors.filter((item): item is string => typeof item === "string")
+      : [],
+    isError: typeof record.is_error === "boolean" ? record.is_error : undefined,
+    apiErrorStatus: typeof record.api_error_status === "number" ? record.api_error_status : undefined,
+  };
+}
+
+function claudeAssistantErrorCode(value: unknown): SDKAssistantMessageError | null {
+  if (typeof value !== "string") return null;
+  return value in CLAUDE_ASSISTANT_ERROR_CODES ? (value as SDKAssistantMessageError) : null;
+}
+
+function statusForAssistantError(code: SDKAssistantMessageError): number | undefined {
+  switch (code) {
+    case "authentication_failed":
+      return 401;
+    case "oauth_org_not_allowed":
+    case "billing_error":
+      return 403;
+    case "rate_limit":
+      return 429;
+    case "overloaded":
+    case "server_error":
+      return 503;
+    case "invalid_request":
+    case "max_output_tokens":
+      return 400;
+    case "model_not_found":
+      return 404;
+    case "unknown":
+      return undefined;
+  }
+}
+
+function buildFailure(input: {
+  messagePreview: string;
+  reason: string;
+  code: string;
+  status?: number;
+  replaySafety: NonNullable<ProviderAttemptSignal["replaySafety"]>;
+  origin: ClaudeProviderFailure["origin"];
+  assistantError?: SDKAssistantMessageError;
+}): ClaudeProviderFailure {
+  const error: ClaudeProviderErrorShape = {
+    name: "ClaudeSdkProviderError",
+    message: input.messagePreview,
+    code: input.code,
+    reason: input.reason,
+    ...(input.status ? { status: input.status, statusCode: input.status } : {}),
+  };
+  return {
+    messagePreview: input.messagePreview,
+    origin: input.origin,
+    ...(input.assistantError ? { assistantError: input.assistantError } : {}),
+    signal: {
+      kind: "provider_error",
+      error,
+      source: "sdk",
+      replaySafety: input.replaySafety,
+      messagePreview: input.messagePreview,
+    },
+  };
+}
+
+function choosePrimaryFailure(
+  resultFailure: ClaudeProviderFailure | null,
+  assistantFailure: ClaudeProviderFailure | null,
+): ClaudeProviderFailure | null {
+  if (!assistantFailure) return resultFailure;
+  if (!resultFailure) return assistantFailure;
+  if (assistantFailure.origin === "assistant_error" && assistantFailure.assistantError !== "unknown") {
+    return assistantFailure;
+  }
+  return resultFailure;
+}
+
+function withMergedPreview(primary: ClaudeProviderFailure, secondary: ClaudeProviderFailure): ClaudeProviderFailure {
+  const messagePreview = combinePreviews(primary.messagePreview, secondary.messagePreview);
+  if (messagePreview === primary.messagePreview) return primary;
+  return {
+    ...primary,
+    messagePreview,
+    signal: {
+      ...primary.signal,
+      messagePreview,
+      error: withErrorMessage(primary.signal.error, messagePreview),
+    },
+  };
+}
+
+function withReplaySafety(failure: ClaudeProviderFailure, replaySafety: ReplaySafety): ClaudeProviderFailure {
+  if (failure.signal.replaySafety === replaySafety) return failure;
+  return {
+    ...failure,
+    signal: {
+      ...failure.signal,
+      replaySafety,
+    },
+  };
+}
+
+function combinePreviews(primary: string, secondary: string): string {
+  const values = [primary.trim(), secondary.trim()].filter((value) => value.length > 0);
+  return [...new Set(values)].join("\n");
+}
+
+function withErrorMessage(error: unknown, message: string): unknown {
+  if (!error || typeof error !== "object") return error;
+  return { ...(error as Record<string, unknown>), message };
+}
+
+function firstNonEmpty(...values: Array<string | undefined>): string {
+  for (const value of values) {
+    const trimmed = value?.trim();
+    if (trimmed) return trimmed;
+  }
+  return "Claude SDK provider failure";
+}
+
+function noticeLead(category: ProviderFailureCategory, reasonCode: string): string {
+  if (category === "credential") {
+    return "Claude Code could not run this turn: Anthropic rejected the local Claude authentication. Run `claude login` on this machine, then retry.";
+  }
+  if (category === "provider_capacity") {
+    if (reasonCode === "provider_billing_limit") {
+      return "Claude Code could not run this turn: Anthropic reports insufficient account balance or unavailable billing credits. Add credits or switch accounts, then retry.";
+    }
+    if (reasonCode === "provider_rate_limited") {
+      return "Claude Code could not run this turn: Anthropic rate-limited this account. Wait for the limit to reset, then retry.";
+    }
+    return "Claude Code could not run this turn: Anthropic reported a capacity or usage limit. Wait or switch accounts, then retry.";
+  }
+  if (category === "transient_transport") {
+    return "Claude Code could not run this turn: the Anthropic connection failed after retry handling. Retry later.";
+  }
+  if (category === "configuration") {
+    return "Claude Code could not run this turn: the Claude runtime configuration is invalid. Update the agent or provider configuration, then retry.";
+  }
+  if (category === "deterministic_input") {
+    return "Claude Code could not run this turn: Anthropic rejected this request as invalid. Adjust the request or configuration, then retry.";
+  }
+  if (category === "capability") {
+    return "Claude Code could not run this turn: the Claude runtime is not launchable on this machine. Fix the local runtime, then retry.";
+  }
+  return "Claude Code could not run this turn: Claude SDK reported a provider failure. Retry after checking the provider status.";
+}

--- a/packages/client/src/handlers/claude-provider-error.ts
+++ b/packages/client/src/handlers/claude-provider-error.ts
@@ -229,7 +229,7 @@ function firstNonEmpty(...values: Array<string | undefined>): string {
 
 function noticeLead(category: ProviderFailureCategory, reasonCode: string): string {
   if (category === "credential") {
-    return "Claude Code could not run this turn: Anthropic rejected the local Claude authentication. Run `claude login` on this machine, then retry.";
+    return "Claude Code could not run this turn: Anthropic rejected the local Claude authentication. Run `claude auth login` on this machine, then retry.";
   }
   if (category === "provider_capacity") {
     if (reasonCode === "provider_billing_limit") {

--- a/packages/client/src/runtime/capabilities/claude-code-tui.ts
+++ b/packages/client/src/runtime/capabilities/claude-code-tui.ts
@@ -176,7 +176,7 @@ export async function probeClaudeCodeTuiCapability(deps: ClaudeCodeTuiProbeDeps 
         return {
           ok: false,
           error:
-            "no Claude credentials found (ANTHROPIC_API_KEY unset and ~/.claude.json has no OAuth account); run `claude login` on this machine",
+            "no Claude credentials found (ANTHROPIC_API_KEY unset and ~/.claude.json has no OAuth account); run `claude auth login` on this machine",
         };
       }
       return { ok: true, method: auth.method };

--- a/packages/client/src/runtime/capabilities/claude-code.ts
+++ b/packages/client/src/runtime/capabilities/claude-code.ts
@@ -5,6 +5,12 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { CapabilityEntry } from "@first-tree/shared";
 import { type ClaudeExecutableResolution, resolveClaudeCodeExecutable } from "../../handlers/claude-executable.js";
+import {
+  type ClaudeProviderFailure,
+  claudeFailureFromAssistantMessage,
+  claudeFailureFromSdkResult,
+} from "../../handlers/claude-provider-error.js";
+import { classifyProviderFailure } from "../provider-retry-policy.js";
 import { detectClaudeAuth } from "./claude-shared.js";
 import {
   type AuthPrecheckOutcome,
@@ -178,6 +184,21 @@ export function classifyClaudeSmokeFailure(message: string): SmokeOutcome {
   return { state: "error", error: text.length > 0 ? text : "smoke failed without output" };
 }
 
+export function classifyClaudeSmokeProviderFailure(failure: ClaudeProviderFailure): SmokeOutcome {
+  const classification = classifyProviderFailure(failure.signal.error, {
+    provider: "claude-code",
+    scope: "session_start",
+    source: "sdk",
+  });
+  if (classification.category === "credential") {
+    return { state: "unauthenticated", error: failure.messagePreview };
+  }
+  return {
+    state: "error",
+    error: failure.messagePreview.trim().length > 0 ? failure.messagePreview : "smoke failed without output",
+  };
+}
+
 /**
  * Real launch smoke through the exact code path the runtime uses: the SDK's
  * `query()` (which spawns the resolved binary, or its bundled native binary
@@ -211,17 +232,17 @@ export async function defaultClaudeSdkSmoke(binary: string | undefined): Promise
         ...(binary ? { pathToClaudeCodeExecutable: binary } : {}),
       },
     });
+    let pendingAssistantProviderFailure: ClaudeProviderFailure | null = null;
     for await (const message of q) {
+      const assistantFailure = claudeFailureFromAssistantMessage(message);
+      if (assistantFailure) pendingAssistantProviderFailure = assistantFailure;
       if (message.type !== "result") continue;
+      const providerFailure = claudeFailureFromSdkResult(message) ?? pendingAssistantProviderFailure;
+      pendingAssistantProviderFailure = null;
+      if (providerFailure) return classifyClaudeSmokeProviderFailure(providerFailure);
       if (message.subtype === "success" && !message.is_error) {
         return { state: "ok" };
       }
-      if (message.subtype === "success") {
-        // is_error=true: the CLI forwarded an API error string as the result.
-        return classifyClaudeSmokeFailure(message.result);
-      }
-      const detail = message.errors.length > 0 ? message.errors.join("; ") : message.subtype;
-      return classifyClaudeSmokeFailure(detail);
     }
     return { state: "error", error: "SDK smoke ended without a result message" };
   } catch (err) {

--- a/packages/client/src/runtime/capabilities/claude-code.ts
+++ b/packages/client/src/runtime/capabilities/claude-code.ts
@@ -329,7 +329,7 @@ export async function probeClaudeCodeCapability(deps: ClaudeCodeProbeDeps = {}):
         return {
           ok: false,
           error:
-            "no Claude credentials found (ANTHROPIC_API_KEY unset and ~/.claude.json has no OAuth account); run `claude login` on this machine",
+            "no Claude credentials found (ANTHROPIC_API_KEY unset and ~/.claude.json has no OAuth account); run `claude auth login` on this machine",
         };
       }
       return { ok: true, method: auth.method };

--- a/packages/client/src/runtime/provider-retry-policy.ts
+++ b/packages/client/src/runtime/provider-retry-policy.ts
@@ -64,6 +64,15 @@ export function classifyProviderFailure(
   const retryAfterMs = readRetryAfterMs(shape);
   const status = shape.status ?? shape.statusCode;
 
+  if (isBillingLimit(text)) {
+    return {
+      category: "provider_capacity",
+      reasonCode: "provider_billing_limit",
+      message: base.message,
+      retryAfterMs,
+      sourceKind: base.kind,
+    };
+  }
   if (isCredential(text, base, status)) {
     return {
       category: "credential",
@@ -227,6 +236,9 @@ function decideProviderTurnCapacity(
   retryAfterMs: number | undefined,
   replaySafety: ReplaySafety,
 ): ProviderRetryDecision {
+  if (reasonCode === "provider_billing_limit") {
+    return stop(reasonCode, "capacity_wait_required", replaySafety, "error");
+  }
   if (replaySafety === "pre_provider") {
     return decideProviderTurnTransient(reasonCode, attempt, replaySafety);
   }
@@ -392,7 +404,9 @@ function isCredential(text: string, base: Classification, status: number | undef
     base.reasonCode.includes("auth") ||
     base.reasonCode.includes("unauthorized") ||
     AUTH_HTTP_CODE_RE.test(text) ||
-    /unauthorized|forbidden|invalid api key|invalid_api_key|authentication|login required|not authenticated/.test(text)
+    /unauthorized|forbidden|invalid api key|invalid_api_key|authentication|login required|not authenticated|oauth_org_not_allowed/.test(
+      text,
+    )
   );
 }
 
@@ -407,7 +421,7 @@ function isCapability(text: string, base: Classification): boolean {
 function isConfiguration(text: string, base: Classification): boolean {
   return (
     base.reasonCode.includes("mismatch") ||
-    /provider mismatch|runtime_provider_mismatch|bad config|sandbox|approval/.test(text)
+    /provider mismatch|runtime_provider_mismatch|bad config|sandbox|approval|model_not_found|model not found/.test(text)
   );
 }
 
@@ -418,7 +432,9 @@ function configurationReason(base: Classification): string {
 function isDeterministicInput(text: string, base: Classification): boolean {
   return (
     base.reasonCode.includes("context") ||
-    /context length|context_length|context window|invalid request|bad request/.test(text) ||
+    /context length|context_length|context window|invalid request|invalid_request|bad request|max_output_tokens|error_max_turns|exceeded max turns|error_max_budget_usd|error_max_structured_output_retries/.test(
+      text,
+    ) ||
     (text.includes("ran out of room") && text.includes("context"))
   );
 }
@@ -438,7 +454,9 @@ function isCapacity(text: string, base: Classification, retryAfterMs: number | u
 function isTransportText(text: string): boolean {
   return (
     TRANSIENT_HTTP_CODE_RE.test(text) ||
-    /server error|unavailable|timed out|timeout|fetch failed|network|econnreset|econnrefused|etimedout|epipe/.test(text)
+    /server error|server_error|unavailable|timed out|timeout|fetch failed|network|econnreset|econnrefused|etimedout|epipe/.test(
+      text,
+    )
   );
 }
 
@@ -447,6 +465,13 @@ function capacityReason(text: string, base: Classification): string {
   if (/overloaded|capacity/.test(text)) return "provider_overloaded";
   if (/rate.?limit/.test(text) || base.reasonCode.includes("rate_limit")) return "provider_rate_limited";
   return base.reasonCode === "unknown" ? "provider_capacity" : base.reasonCode;
+}
+
+function isBillingLimit(text: string): boolean {
+  return (
+    /billing_error|insufficient account balance|credit balance is too low|credits_required|out_of_credits/.test(text) ||
+    (text.includes("billing") && text.includes("credit"))
+  );
 }
 
 function transientReason(base: Classification, provider: RuntimeProvider): string {

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -16,20 +16,20 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "first-tree-dev": "workspace:*",
-    "@first-tree/shared": "workspace:*",
-    "@anthropic-ai/claude-agent-sdk": "^0.2.84",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.187",
     "@first-tree/server": "workspace:*",
+    "@first-tree/shared": "workspace:*",
     "@types/node": "^22.16.0",
     "@types/pg": "^8.11.10",
+    "@types/ws": "^8.5.13",
     "fastify": "^5.2.0",
+    "first-tree-dev": "workspace:*",
     "get-port": "^7.1.0",
     "jose": "^5.9.6",
     "pg": "^8.13.1",
     "tsx": "^4.19.0",
     "vitest": "^3.2.0",
     "ws": "^8.18.0",
-    "@types/ws": "^8.5.13",
     "zod": "^4.0.0"
   }
 }

--- a/packages/shared/src/schemas/provider-retry.ts
+++ b/packages/shared/src/schemas/provider-retry.ts
@@ -116,7 +116,9 @@ function statusReasonLabel(kind: AgentStatusReason["kind"], payload: ProviderRet
     return "Waiting to retry provider";
   }
   if (kind === "retrying") return "Retrying provider";
-  if (payload.reasonCode === "capacity_wait_required") return "Provider capacity limit";
+  if (payload.reasonCode === "capacity_wait_required" || payload.category === "provider_capacity") {
+    return "Provider capacity limit";
+  }
   if (payload.event === "provider_retry_exhausted") return "Provider retry exhausted";
   return "Provider failure";
 }

--- a/packages/web/src/pages/clients/cards/shared/providers.ts
+++ b/packages/web/src/pages/clients/cards/shared/providers.ts
@@ -65,14 +65,14 @@ export const PROVIDER_NPM_PACKAGE: Record<RuntimeProvider, string> = {
 
 /**
  * Per-runtime login command shown after install. Codex prints
- * `codex login`; Claude Code prints `claude login`. Both accept
+ * `codex login`; Claude Code prints `claude auth login`. Both accept
  * `--api-key` flavored alternatives the user discovers on the install
  * step's stdout — the card surfaces the OAuth form by default since
  * it's the documented happy path.
  */
 export const PROVIDER_LOGIN_COMMAND: Record<RuntimeProvider, string> = {
-  "claude-code": "claude login",
-  "claude-code-tui": "claude login",
+  "claude-code": "claude auth login",
+  "claude-code-tui": "claude auth login",
   codex: "codex login",
 };
 

--- a/packages/web/src/pages/clients/cards/shared/runtime-auth-view.test.ts
+++ b/packages/web/src/pages/clients/cards/shared/runtime-auth-view.test.ts
@@ -107,7 +107,7 @@ describe("deriveRuntimeAuthView", () => {
 
   it("treats claude-code-tui's auth as in-product (shared Claude keychain) — no manual login hint", () => {
     // tui has no Connect of its own, but its credentials come from the Claude
-    // Code login, so it must not show a manual "Run `claude login`" hint.
+    // Code login, so it must not show a manual "Run `claude auth login`" hint.
     expect(providerAuthHandledInProduct("claude-code-tui")).toBe(true);
     expect(providerAuthHandledInProduct("codex")).toBe(true);
     expect(providerAuthHandledInProduct("claude-code")).toBe(true);

--- a/packages/web/src/pages/clients/cards/shared/runtime-install-box.tsx
+++ b/packages/web/src/pages/clients/cards/shared/runtime-install-box.tsx
@@ -62,7 +62,7 @@ export function RuntimeInstallBox({ provider, entry, hostname, os }: RuntimeInst
 
 /**
  * Render a headline string with `inline-code` segments wrapped in `<code>`.
- * The view-model emits literal backticks (e.g. "Run `claude login` on
+ * The view-model emits literal backticks (e.g. "Run `claude auth login` on
  * host") for the diagnostic copy; without this helper the user sees raw
  * backticks rendered as text.
  */

--- a/packages/web/src/pages/clients/dev-fixtures.ts
+++ b/packages/web/src/pages/clients/dev-fixtures.ts
@@ -294,7 +294,7 @@ function buildDemoData(): { scenarios: DemoScenario[]; agentNames: Record<string
       summary:
         "Mixed setup: Claude Code installed-not-logged-in, Codex not installed. Each install box adapts its command.",
       whatToCheck: [
-        "Claude Code box: 'installed (v0.2.141) but not logged in' — command is ONLY `claude login` (no npm install)",
+        "Claude Code box: 'installed (v0.2.141) but not logged in' — command is ONLY `claude auth login` (no npm install)",
         "Codex box: full install + login two-liner",
         "Backticks in headlines render as <code> elements, not literal backticks",
       ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
   apps/cli:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.2.84
-        version: 0.2.84(zod@4.3.6)
+        specifier: ^0.3.187
+        version: 0.3.187(@anthropic-ai/sdk@0.105.0(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)
       '@inquirer/prompts':
         specifier: ^8.3.0
         version: 8.3.2(@types/node@22.19.15)
@@ -91,8 +91,8 @@ importers:
   packages/client:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.2.84
-        version: 0.2.84(zod@4.3.6)
+        specifier: ^0.3.187
+        version: 0.3.187(@anthropic-ai/sdk@0.105.0(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)
       '@openai/codex-sdk':
         specifier: ^0.140.0
         version: 0.140.0
@@ -137,8 +137,8 @@ importers:
   packages/e2e:
     devDependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.2.84
-        version: 0.2.84(zod@4.3.6)
+        specifier: ^0.3.187
+        version: 0.3.187(@anthropic-ai/sdk@0.105.0(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)
       '@first-tree/server':
         specifier: workspace:*
         version: link:../server
@@ -425,11 +425,62 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/claude-agent-sdk@0.2.84':
-    resolution: {integrity: sha512-rvp3kZJM4IgDBE1zwj30H3N0bI3pYRF28tDJoyAVuWTLiWls7diNVCyFz7GeXZEAYYD87lCBE3vnQplLLluNHg==}
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.187':
+    resolution: {integrity: sha512-0DNzATzaRmjS/Q1T4T9SLP/VT67gRX7J4reYPnEdcTm91lJwjqOPkHr17+sv+7DoerZ421ZG38dPsQd/V67qQw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.187':
+    resolution: {integrity: sha512-Va3O8lTDa9IHq/DbSJwU63JJknNV3YCBh4PEznOHXJtyFoXHgRjrks4QQvN3baZm79avVq2sn+6tvpTz9CuY8A==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.187':
+    resolution: {integrity: sha512-XQ7w2pX0mjPYUC7ayTKiHeAbePOny/ezBATxTWt5JVDZZPfljzvHA0jyXHsN8aLphbgRUfbUpdrtt5b57Bhx5g==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.187':
+    resolution: {integrity: sha512-VEvrs3MgwckdWRNa7+2rJdyOBbCWGoRaM6OnL+/n9qi4gKlZnXZlj/90Tw9o8ttcN260Opz120/SE1fYwzu/JA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.187':
+    resolution: {integrity: sha512-yi2/L5oztFqTDnAZl4mWOINr+r7WBot70gYUxG2jOoqdYUl6j50vG/ME605X80v+l2qBmKjSGxb5trY/6DkRzQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.187':
+    resolution: {integrity: sha512-s/Fmg29tzMrbdeCbseTpL3DlzfWineSQ3bDPvhdKw4jcsgLC1YgQhIkAyE8WlceUyhQyw82NAUgYoPwfGny6hQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.187':
+    resolution: {integrity: sha512-HjEl3cDRLAWKopdlrLI54fxTVWq4lZpWA4bTTBVc9UDdDj6AmJIRHKxaCCYLQRvnoswbAUF1sJmJ8EFJ+b6lfw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.187':
+    resolution: {integrity: sha512-FnrLhoZ8y/+gkZynL12UeQ8pWKCu6B/8myyRrYMNJRZqFw4DZlPvPCywAjFZf1e1hiXCoiSK0Orl5wzKfAeQsQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@anthropic-ai/claude-agent-sdk@0.3.187':
+    resolution: {integrity: sha512-HHkuC3he/Wi8fX/WjfS8mJr4TFPGoAd1QyxOuTwjnyOLboGkX1H+UhBYLxHX1ouFvHnYVJglB2wsuWemVQgahQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
+      '@anthropic-ai/sdk': '>=0.93.0'
+      '@modelcontextprotocol/sdk': ^1.29.0
       zod: ^4.0.0
+
+  '@anthropic-ai/sdk@0.105.0':
+    resolution: {integrity: sha512-sDyu+aM9cE6uZE+HgRjjHRb+qqb87GHZOx+8bE0YlWetdL1YcVLxn8h9ltxGOflyChTe6PMEo50kMQV4cw0hfg==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   '@autotelic/fastify-opentelemetry@0.23.0':
     resolution: {integrity: sha512-l6m+EkB4wtLmDatTMZtTI6rwv4OWai4ZY+aNugldrL0kdn0Ipe8yHZ5axqxTlw//qaz97ssAp3LveWOLjn7FWw==}
@@ -524,6 +575,10 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
@@ -1115,94 +1170,11 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  '@img/sharp-darwin-arm64@0.34.5':
-    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@img/sharp-darwin-x64@0.34.5':
-    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [darwin]
-
-  '@img/sharp-libvips-darwin-arm64@1.2.4':
-    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@img/sharp-libvips-darwin-x64@1.2.4':
-    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@img/sharp-libvips-linux-arm64@1.2.4':
-    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@img/sharp-libvips-linux-arm@1.2.4':
-    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
-    cpu: [arm]
-    os: [linux]
-
-  '@img/sharp-libvips-linux-x64@1.2.4':
-    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
-    cpu: [x64]
-    os: [linux]
-
-  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
-    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
-    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
-    cpu: [x64]
-    os: [linux]
-
-  '@img/sharp-linux-arm64@0.34.5':
-    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [linux]
-
-  '@img/sharp-linux-arm@0.34.5':
-    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm]
-    os: [linux]
-
-  '@img/sharp-linux-x64@0.34.5':
-    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [linux]
-
-  '@img/sharp-linuxmusl-arm64@0.34.5':
-    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [linux]
-
-  '@img/sharp-linuxmusl-x64@0.34.5':
-    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [linux]
-
-  '@img/sharp-win32-arm64@0.34.5':
-    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [win32]
-
-  '@img/sharp-win32-x64@0.34.5':
-    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [win32]
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
 
   '@inquirer/ansi@2.0.4':
     resolution: {integrity: sha512-DpcZrQObd7S0R/U3bFdkcT5ebRwbTTC4D3tCc1vsJizmgPLxNJBo+AAFmrZwe8zk30P2QzgzGWZ3Q9uJwWuhIg==}
@@ -1371,6 +1343,16 @@ packages:
   '@lukeed/ms@2.0.2':
     resolution: {integrity: sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==}
     engines: {node: '>=8'}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
@@ -2393,6 +2375,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@tailwindcss/node@4.2.2':
     resolution: {integrity: sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==}
 
@@ -2715,6 +2700,10 @@ packages:
   abstract-logging@2.0.1:
     resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-import-attributes@1.9.5:
     resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
     peerDependencies:
@@ -2885,6 +2874,10 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    engines: {node: '>=18'}
+
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
 
@@ -2918,6 +2911,10 @@ packages:
     resolution: {integrity: sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q==}
     engines: {node: '>=0.10.0'}
 
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
@@ -2925,6 +2922,14 @@ packages:
   cac@7.0.0:
     resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
     engines: {node: '>=20.19.0'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
 
   caniuse-lite@1.0.30001780:
     resolution: {integrity: sha512-llngX0E7nQci5BPJDqoZSbuZ5Bcs9F5db7EtgfwBerX9XGtkkiO4NwfDDIRzHTTwcYC8vC7bmeUEPGrKlR/TkQ==}
@@ -3004,8 +3009,24 @@ packages:
     resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
     engines: {node: '>=18'}
 
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
 
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
@@ -3013,6 +3034,10 @@ packages:
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   cpu-features@0.0.10:
     resolution: {integrity: sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==}
@@ -3204,11 +3229,18 @@ packages:
       oxc-resolver:
         optional: true
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
   duplexify@4.1.3:
     resolution: {integrity: sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==}
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
   ejs@6.0.1:
     resolution: {integrity: sha512-UaaM14yby8U3k02ihS1Bmj5Kz2d7CCQM1scxpgs4Mhkq8F1wR2gl3+Ts4h5Ne4Mnt7M9m4Dw7jsuMr3+xO4vZA==}
@@ -3228,6 +3260,10 @@ packages:
     resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
     engines: {node: '>=14'}
 
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
@@ -3239,8 +3275,20 @@ packages:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.18.20:
     resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
@@ -3279,6 +3327,10 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
@@ -3290,9 +3342,27 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  express-rate-limit@8.5.2:
+    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   extend-shallow@2.0.1:
     resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
@@ -3319,6 +3389,9 @@ packages:
 
   fast-querystring@1.1.2:
     resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
+
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
   fast-string-truncated-width@3.0.3:
     resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
@@ -3354,6 +3427,10 @@ packages:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-my-way@9.5.0:
     resolution: {integrity: sha512-VW2RfnmscZO5KgBY5XVyKREMW5nMZcxDy+buTOsL+zIPnBlbKm+00sgzoQzq1EVh4aALZLfKdwv6atBGcjvjrQ==}
     engines: {node: '>=20'}
@@ -3369,6 +3446,14 @@ packages:
   forwarded-parse@2.1.2:
     resolution: {integrity: sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==}
 
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
+
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
@@ -3376,6 +3461,9 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
   gaxios@7.1.4:
     resolution: {integrity: sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==}
@@ -3393,6 +3481,10 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
   get-nonce@1.0.1:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
     engines: {node: '>=6'}
@@ -3400,6 +3492,10 @@ packages:
   get-port@7.1.0:
     resolution: {integrity: sha512-QB9NKEeDg3xxVwCCwJQ9+xycaz6pBB6iQ76wiWMl1927n0Kir6alPiP+yuiICLLU4jpMe08dXfpebuQppFA2zw==}
     engines: {node: '>=16'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   get-tsconfig@4.13.6:
     resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
@@ -3417,6 +3513,10 @@ packages:
     resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
     engines: {node: '>=14'}
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
@@ -3432,6 +3532,14 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
+
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
 
@@ -3443,6 +3551,10 @@ packages:
 
   hearback-server@0.1.6:
     resolution: {integrity: sha512-IlwduoRJvUBW3dU4H0hBvLjsgZHfXeOLQMqK9ahCLb45wgotIVL+CqieJnN7cQMNGU0i0sSpgyji5ELuwB+H5g==}
+
+  hono@4.12.27:
+    resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
+    engines: {node: '>=16.9.0'}
 
   hookable@6.1.0:
     resolution: {integrity: sha512-ZoKZSJgu8voGK2geJS+6YtYjvIzu9AOM/KZXsBxr83uhLL++e9pEv/dlgwgy3dvHg06kTz6JOh1hk3C8Ceiymw==}
@@ -3482,6 +3594,14 @@ packages:
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
 
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
   ipaddr.js@2.3.0:
     resolution: {integrity: sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==}
     engines: {node: '>= 10'}
@@ -3513,6 +3633,9 @@ packages:
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
@@ -3581,8 +3704,15 @@ packages:
   json-schema-ref-resolver@3.0.0:
     resolution: {integrity: sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A==}
 
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
+
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
@@ -3724,6 +3854,10 @@ packages:
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
   mdast-util-find-and-replace@3.0.2:
     resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
 
@@ -3771,6 +3905,14 @@ packages:
 
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -3856,6 +3998,14 @@ packages:
   micromark@4.0.2:
     resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
+
   mime@3.0.0:
     resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
     engines: {node: '>=10.0.0'}
@@ -3903,6 +4053,10 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   node-addon-api@8.6.0:
     resolution: {integrity: sha512-gBVjCaqDlRUk0EwoPNKzIr9KkS9041G/q31IBShPs1Xz6UTA+EXdZADbzqAJQrpDRq71CIMnOP5VMut3SL0z5Q==}
     engines: {node: ^18 || ^20 || >= 21}
@@ -3927,12 +4081,24 @@ packages:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
 
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -3947,6 +4113,10 @@ packages:
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
@@ -3958,6 +4128,9 @@ packages:
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -4024,6 +4197,10 @@ packages:
     resolution: {integrity: sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==}
     hasBin: true
 
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
+
   postcss-selector-parser@6.0.10:
     resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
     engines: {node: '>=4'}
@@ -4083,14 +4260,30 @@ packages:
     resolution: {integrity: sha512-LBYnMWkKLB8fE/ljROPDbCl7mgLSlI+oBe1fAAr5MTqFg4TIi0tYrVVurJvQggOjnUYMQtEZBjrej59ojMNTHQ==}
     engines: {node: '>=12.0.0'}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
+    engines: {node: '>=0.6'}
 
   quansync@1.0.0:
     resolution: {integrity: sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA==}
 
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   react-dom@19.2.4:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
@@ -4247,6 +4440,10 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
@@ -4283,6 +4480,14 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
@@ -4296,6 +4501,22 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -4343,6 +4564,9 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
 
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
@@ -4495,6 +4719,9 @@ packages:
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
   tsdown@0.21.4:
     resolution: {integrity: sha512-Q/kBi8SXkr4X6JI/NAZKZY1UuiEcbuXtIskL4tZCsgpDiEPM/2W6lC+OonNA31S+V3KsWedFvbFDBs23hvt+Aw==}
     engines: {node: '>=20.19.0'}
@@ -4538,6 +4765,10 @@ packages:
   tweetnacl@0.14.5:
     resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
 
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -4573,6 +4804,10 @@ packages:
 
   unist-util-visit@5.1.0:
     resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
 
   unrun@0.2.32:
     resolution: {integrity: sha512-opd3z6791rf281JdByf0RdRQrpcc7WyzqittqIXodM/5meNWdTwrVxeyzbaCp4/Rgls/um14oUaif1gomO8YGg==}
@@ -4617,6 +4852,10 @@ packages:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
@@ -4771,6 +5010,11 @@ packages:
     resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
     engines: {node: '>= 14'}
 
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
@@ -4787,19 +5031,51 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@anthropic-ai/claude-agent-sdk@0.2.84(zod@4.3.6)':
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.187':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.187':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.187':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.187':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.187':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.187':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.187':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.187':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk@0.3.187(@anthropic-ai/sdk@0.105.0(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)':
     dependencies:
+      '@anthropic-ai/sdk': 0.105.0(zod@4.3.6)
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.3.6)
       zod: 4.3.6
     optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.34.5
-      '@img/sharp-darwin-x64': 0.34.5
-      '@img/sharp-linux-arm': 0.34.5
-      '@img/sharp-linux-arm64': 0.34.5
-      '@img/sharp-linux-x64': 0.34.5
-      '@img/sharp-linuxmusl-arm64': 0.34.5
-      '@img/sharp-linuxmusl-x64': 0.34.5
-      '@img/sharp-win32-arm64': 0.34.5
-      '@img/sharp-win32-x64': 0.34.5
+      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.187
+      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.187
+      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.187
+      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.187
+      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.187
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.187
+      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.187
+      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.187
+
+  '@anthropic-ai/sdk@0.105.0(zod@4.3.6)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+      standardwebhooks: 1.0.0
+    optionalDependencies:
+      zod: 4.3.6
 
   '@autotelic/fastify-opentelemetry@0.23.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -4911,6 +5187,8 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/runtime@7.29.7': {}
 
   '@babel/template@7.28.6':
     dependencies:
@@ -5310,67 +5588,9 @@ snapshots:
       protobufjs: 7.5.4
       yargs: 17.7.2
 
-  '@img/sharp-darwin-arm64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-darwin-arm64': 1.2.4
-    optional: true
-
-  '@img/sharp-darwin-x64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-darwin-x64': 1.2.4
-    optional: true
-
-  '@img/sharp-libvips-darwin-arm64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-darwin-x64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-arm64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-arm@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-x64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
-    optional: true
-
-  '@img/sharp-linux-arm64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-arm64': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-arm@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-arm': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-x64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-x64': 1.2.4
-    optional: true
-
-  '@img/sharp-linuxmusl-arm64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
-    optional: true
-
-  '@img/sharp-linuxmusl-x64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
-    optional: true
-
-  '@img/sharp-win32-arm64@0.34.5':
-    optional: true
-
-  '@img/sharp-win32-x64@0.34.5':
-    optional: true
+  '@hono/node-server@1.19.14(hono@4.12.27)':
+    dependencies:
+      hono: 4.12.27
 
   '@inquirer/ansi@2.0.4': {}
 
@@ -5530,6 +5750,28 @@ snapshots:
       - supports-color
 
   '@lukeed/ms@2.0.2': {}
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.27)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.27
+      jose: 6.2.2
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
+    transitivePeerDependencies:
+      - supports-color
 
   '@napi-rs/wasm-runtime@1.1.1':
     dependencies:
@@ -6620,6 +6862,8 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.59.0':
     optional: true
 
+  '@stablelib/base64@1.0.1': {}
+
   '@tailwindcss/node@4.2.2':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -6966,6 +7210,22 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
+  '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
+
+  '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+
   '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 3.2.4
@@ -7005,6 +7265,11 @@ snapshots:
       event-target-shim: 5.0.1
 
   abstract-logging@2.0.1: {}
+
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
 
   acorn-import-attributes@1.9.5(acorn@8.16.0):
     dependencies:
@@ -7164,6 +7429,20 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  body-parser@2.3.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.0.0
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.2
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
@@ -7199,9 +7478,21 @@ snapshots:
 
   byline@5.0.0: {}
 
+  bytes@3.1.2: {}
+
   cac@6.7.14: {}
 
   cac@7.0.0: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   caniuse-lite@1.0.30001780: {}
 
@@ -7277,11 +7568,24 @@ snapshots:
 
   content-disposition@1.0.1: {}
 
+  content-type@1.0.5: {}
+
+  content-type@2.0.0: {}
+
   convert-source-map@2.0.0: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
 
   cookie@1.1.1: {}
 
   core-util-is@1.0.3: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cpu-features@0.0.10:
     dependencies:
@@ -7379,6 +7683,12 @@ snapshots:
 
   dts-resolver@2.1.3: {}
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
   duplexify@4.1.3:
     dependencies:
       end-of-stream: 1.4.5
@@ -7387,6 +7697,8 @@ snapshots:
       stream-shift: 1.0.3
 
   eastasianwidth@0.2.0: {}
+
+  ee-first@1.1.1: {}
 
   ejs@6.0.1: {}
 
@@ -7397,6 +7709,8 @@ snapshots:
   emoji-regex@9.2.2: {}
 
   empathic@2.0.0: {}
+
+  encodeurl@2.0.0: {}
 
   end-of-stream@1.4.5:
     dependencies:
@@ -7409,7 +7723,15 @@ snapshots:
 
   entities@7.0.1: {}
 
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@1.7.0: {}
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
 
   esbuild@0.18.20:
     optionalDependencies:
@@ -7508,6 +7830,8 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
+  etag@1.8.1: {}
+
   event-target-shim@5.0.1: {}
 
   events-universal@1.0.1:
@@ -7518,7 +7842,51 @@ snapshots:
 
   events@3.3.0: {}
 
+  eventsource-parser@3.1.0: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.0
+
   expect-type@1.3.0: {}
+
+  express-rate-limit@8.5.2(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.2.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.3.0
+      content-disposition: 1.0.1
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.2
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   extend-shallow@2.0.1:
     dependencies:
@@ -7546,6 +7914,8 @@ snapshots:
   fast-querystring@1.1.2:
     dependencies:
       fast-decode-uri-component: 1.0.1
+
+  fast-sha256@1.3.0: {}
 
   fast-string-truncated-width@3.0.3: {}
 
@@ -7592,6 +7962,17 @@ snapshots:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   find-my-way@9.5.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -7609,10 +7990,16 @@ snapshots:
 
   forwarded-parse@2.1.2: {}
 
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
+
   fs-constants@1.0.0: {}
 
   fsevents@2.3.3:
     optional: true
+
+  function-bind@1.1.2: {}
 
   gaxios@7.1.4:
     dependencies:
@@ -7634,9 +8021,27 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.4
+      math-intrinsics: 1.1.0
+
   get-nonce@1.0.1: {}
 
   get-port@7.1.0: {}
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
 
   get-tsconfig@4.13.6:
     dependencies:
@@ -7658,6 +8063,8 @@ snapshots:
       path-scurry: 2.0.2
 
   google-logging-utils@1.1.3: {}
+
+  gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
 
@@ -7681,6 +8088,12 @@ snapshots:
       - utf-8-validate
 
   has-flag@4.0.0: {}
+
+  has-symbols@1.1.0: {}
+
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
 
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
@@ -7713,6 +8126,8 @@ snapshots:
   hearback-server@0.1.6:
     dependencies:
       hearback-core: 0.1.1
+
+  hono@4.12.27: {}
 
   hookable@6.1.0: {}
 
@@ -7754,6 +8169,10 @@ snapshots:
 
   inline-style-parser@0.2.7: {}
 
+  ip-address@10.2.0: {}
+
+  ipaddr.js@1.9.1: {}
+
   ipaddr.js@2.3.0: {}
 
   is-alphabetical@2.0.1: {}
@@ -7774,6 +8193,8 @@ snapshots:
   is-network-error@1.3.1: {}
 
   is-plain-obj@4.1.0: {}
+
+  is-promise@4.0.0: {}
 
   is-stream@2.0.1: {}
 
@@ -7839,7 +8260,14 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      ts-algebra: 2.0.0
+
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json5@2.2.3: {}
 
@@ -7952,6 +8380,8 @@ snapshots:
       semver: 7.7.4
 
   markdown-table@3.0.4: {}
+
+  math-intrinsics@1.1.0: {}
 
   mdast-util-find-and-replace@3.0.2:
     dependencies:
@@ -8110,6 +8540,10 @@ snapshots:
   mdast-util-to-string@4.0.0:
     dependencies:
       '@types/mdast': 4.0.4
+
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
 
   micromark-core-commonmark@2.0.3:
     dependencies:
@@ -8302,6 +8736,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  mime-db@1.54.0: {}
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
+
   mime@3.0.0: {}
 
   minimatch@10.2.4:
@@ -8333,6 +8773,8 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  negotiator@1.0.0: {}
+
   node-addon-api@8.6.0: {}
 
   node-domexception@1.0.0: {}
@@ -8349,9 +8791,17 @@ snapshots:
 
   normalize-path@3.0.0: {}
 
+  object-assign@4.1.1: {}
+
+  object-inspect@1.13.4: {}
+
   obug@2.1.1: {}
 
   on-exit-leak-free@2.1.2: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
 
   once@1.4.0:
     dependencies:
@@ -8375,6 +8825,8 @@ snapshots:
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
 
+  parseurl@1.3.3: {}
+
   path-key@3.1.1: {}
 
   path-scurry@1.11.1:
@@ -8386,6 +8838,8 @@ snapshots:
     dependencies:
       lru-cache: 11.2.7
       minipass: 7.1.3
+
+  path-to-regexp@8.4.2: {}
 
   pathe@2.0.3: {}
 
@@ -8468,6 +8922,8 @@ snapshots:
       sonic-boom: 4.2.1
       thread-stream: 3.1.0
 
+  pkce-challenge@5.0.1: {}
+
   postcss-selector-parser@6.0.10:
     dependencies:
       cssesc: 3.0.0
@@ -8534,14 +8990,32 @@ snapshots:
       '@types/node': 22.19.19
       long: 5.3.2
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
 
+  qs@6.15.2:
+    dependencies:
+      side-channel: 1.1.1
+
   quansync@1.0.0: {}
 
   quick-format-unescaped@4.0.4: {}
+
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
 
   react-dom@19.2.4(react@19.2.4):
     dependencies:
@@ -8767,6 +9241,16 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.59.0
       fsevents: 2.3.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   safe-buffer@5.1.2: {}
 
   safe-buffer@5.2.1: {}
@@ -8792,6 +9276,31 @@ snapshots:
 
   semver@7.7.4: {}
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
   set-cookie-parser@2.7.2: {}
 
   setprototypeof@1.2.0: {}
@@ -8801,6 +9310,34 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
 
@@ -8843,6 +9380,11 @@ snapshots:
       nan: 2.26.2
 
   stackback@0.0.2: {}
+
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
 
   statuses@2.0.2: {}
 
@@ -9037,6 +9579,8 @@ snapshots:
 
   trough@2.2.0: {}
 
+  ts-algebra@2.0.0: {}
+
   tsdown@0.21.4(typescript@5.9.3):
     dependencies:
       ansis: 4.2.0
@@ -9084,6 +9628,12 @@ snapshots:
 
   tweetnacl@0.14.5: {}
 
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
   typescript@5.9.3: {}
 
   unconfig-core@7.5.0:
@@ -9130,6 +9680,8 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
+  unpipe@1.0.0: {}
+
   unrun@0.2.32:
     dependencies:
       rolldown: 1.0.0-rc.9
@@ -9158,6 +9710,8 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   uuid@10.0.0: {}
+
+  vary@1.1.2: {}
 
   vfile-message@4.0.3:
     dependencies:
@@ -9284,7 +9838,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -9327,7 +9881,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -9465,6 +10019,10 @@ snapshots:
       archiver-utils: 5.0.2
       compress-commons: 6.0.2
       readable-stream: 4.7.0
+
+  zod-to-json-schema@3.25.2(zod@4.3.6):
+    dependencies:
+      zod: 4.3.6
 
   zod@3.25.76: {}
 


### PR DESCRIPTION
## Summary
- upgrade `@anthropic-ai/claude-agent-sdk` to `0.3.187`
- classify Claude SDK provider failures from structured SDK fields (`is_error`, `api_error_status`, typed `assistant.error`, non-success result subtypes, `errors[]`)
- route terminal Claude SDK provider failures through provider settlement events, readable runtime errors, `turn_end:error`, and an explicit chat-visible runtime notice
- classify Claude billing/account-balance failures as `provider_capacity/provider_billing_limit` while keeping true auth failures as credential errors
- keep replay safe by stopping automatic provider-turn replay once assistant/tool live output has been emitted

## Scope Notes
- `claude-code-tui` is intentionally unchanged.
- SDK success results with `is_error:false` are not treated as provider errors from final text.
- Generic thrown `Error.message` classification remains in the shared provider retry policy for non-structured failures.

## Tests
- `pnpm --filter @first-tree/client exec vitest run --maxWorkers=2 src/__tests__/claude-code-provider-error-result.test.ts src/__tests__/claude-provider-error.test.ts src/__tests__/provider-retry-policy.test.ts`
- `pnpm check`
- `pnpm typecheck`
- `pnpm exec turbo run test --concurrency=2 -- --maxWorkers=2`
- `git diff --check`
