### PR TITLE
Fix late Codex app-server token replay baseline

### DIFF
--- a/packages/client/src/__tests__/codex-app-server-handler.test.ts
+++ b/packages/client/src/__tests__/codex-app-server-handler.test.ts
@@ -635,6 +635,85 @@ describe("codex app-server handler", () => {
     await handler.shutdown();
   });
 
+  it("uses late replayed cumulative usage as the current resumed turn baseline", async () => {
+    const fake = new FakeAppServerClient();
+    const emitEvent = vi.fn<(event: SessionEvent) => void>();
+    const handler = makeHandler(fake);
+    const ctx = makeContext({ emitEvent });
+
+    const resumePromise = handler.resume(makeMessage("m1", "first"), "thread-app-server", ctx);
+    await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
+    await flushAsync();
+
+    emitTokenUsage(
+      fake,
+      "turn-old",
+      {
+        totalTokens: 1050,
+        inputTokens: 1000,
+        cachedInputTokens: 200,
+        outputTokens: 50,
+        reasoningOutputTokens: 0,
+      },
+      {
+        totalTokens: 1050,
+        inputTokens: 1000,
+        cachedInputTokens: 200,
+        outputTokens: 50,
+        reasoningOutputTokens: 0,
+      },
+    );
+    emitTokenUsage(
+      fake,
+      "turn-1",
+      {
+        totalTokens: 25,
+        inputTokens: 20,
+        cachedInputTokens: 0,
+        outputTokens: 5,
+        reasoningOutputTokens: 0,
+      },
+      {
+        totalTokens: 1155,
+        inputTokens: 1100,
+        cachedInputTokens: 220,
+        outputTokens: 55,
+        reasoningOutputTokens: 0,
+      },
+    );
+    fake.emit("item/completed", {
+      threadId: "thread-app-server",
+      turnId: "turn-1",
+      item: {
+        type: "agentMessage",
+        id: "item-turn-1",
+        text: "resumed answer",
+        phase: null,
+        memoryCitation: null,
+      },
+    });
+    fake.emit("turn/completed", {
+      threadId: "thread-app-server",
+      turn: {
+        id: "turn-1",
+        status: "completed",
+        items: [],
+        error: null,
+      },
+    });
+    await resumePromise;
+
+    expect(findTokenUsageEvent(emitEvent)?.payload).toMatchObject({
+      provider: "codex",
+      model: "codex-default",
+      inputTokens: 80,
+      cachedInputTokens: 20,
+      outputTokens: 5,
+    });
+
+    await handler.shutdown();
+  });
+
   it("advances the next baseline when compaction lowers the current turn cumulative total", async () => {
     const fake = new FakeAppServerClient();
     const emitEvent = vi.fn<(event: SessionEvent) => void>();
@@ -688,16 +767,46 @@ describe("codex app-server handler", () => {
     });
     await resumePromise;
 
+    emitTokenUsage(
+      fake,
+      "turn-old-stale",
+      {
+        totalTokens: 10_000,
+        inputTokens: 9_000,
+        cachedInputTokens: 0,
+        outputTokens: 1_000,
+        reasoningOutputTokens: 0,
+      },
+      {
+        totalTokens: 10_000,
+        inputTokens: 9_000,
+        cachedInputTokens: 0,
+        outputTokens: 1_000,
+        reasoningOutputTokens: 0,
+      },
+    );
+
     handler.inject(makeMessage("m2", "second"));
     await waitFor(() => fake.requests.filter((request) => request.method === "turn/start").length === 2);
 
-    emitTokenUsage(fake, "turn-2", {
-      totalTokens: 500,
-      inputTokens: 500,
-      cachedInputTokens: 0,
-      outputTokens: 0,
-      reasoningOutputTokens: 0,
-    });
+    emitTokenUsage(
+      fake,
+      "turn-2",
+      {
+        totalTokens: 500,
+        inputTokens: 500,
+        cachedInputTokens: 0,
+        outputTokens: 0,
+        reasoningOutputTokens: 0,
+      },
+      {
+        totalTokens: 2_500,
+        inputTokens: 2_300,
+        cachedInputTokens: 0,
+        outputTokens: 200,
+        reasoningOutputTokens: 0,
+      },
+    );
     fake.emit("item/completed", {
       threadId: "thread-app-server",
       turnId: "turn-2",
@@ -717,6 +826,177 @@ describe("codex app-server handler", () => {
     expect(tokenUsageEvents(emitEvent).map((event) => event.payload)).toMatchObject([
       {
         inputTokens: 0,
+        cachedInputTokens: 0,
+        outputTokens: 0,
+      },
+      {
+        inputTokens: 500,
+        cachedInputTokens: 0,
+        outputTokens: 0,
+      },
+    ]);
+
+    await handler.shutdown();
+  });
+
+  it("syncs a waiting turn baseline from late usage on the previous own turn", async () => {
+    const fake = new FakeAppServerClient();
+    const emitEvent = vi.fn<(event: SessionEvent) => void>();
+    const handler = makeHandler(fake);
+    const ctx = makeContext({ emitEvent });
+
+    fake.beforeThreadResumeReturn = () => {
+      emitTokenUsage(fake, "turn-old", {
+        totalTokens: 10_000,
+        inputTokens: 9_000,
+        cachedInputTokens: 0,
+        outputTokens: 1_000,
+        reasoningOutputTokens: 0,
+      });
+    };
+
+    const resumePromise = handler.resume(makeMessage("m1", "first"), "thread-app-server", ctx);
+    await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
+
+    emitTokenUsage(
+      fake,
+      "turn-1",
+      {
+        totalTokens: 100,
+        inputTokens: 100,
+        cachedInputTokens: 0,
+        outputTokens: 0,
+        reasoningOutputTokens: 0,
+      },
+      {
+        totalTokens: 2_000,
+        inputTokens: 1_800,
+        cachedInputTokens: 0,
+        outputTokens: 200,
+        reasoningOutputTokens: 0,
+      },
+    );
+    fake.emit("item/completed", {
+      threadId: "thread-app-server",
+      turnId: "turn-1",
+      item: { type: "agentMessage", id: "item-turn-1", text: "first answer", phase: null, memoryCitation: null },
+    });
+    fake.emit("turn/completed", {
+      threadId: "thread-app-server",
+      turn: { id: "turn-1", status: "completed", items: [], error: null },
+    });
+    await resumePromise;
+
+    handler.inject(makeMessage("m2", "second"));
+    await waitFor(() => fake.requests.filter((request) => request.method === "turn/start").length === 2);
+    await flushAsync();
+
+    emitTokenUsage(
+      fake,
+      "turn-1",
+      {
+        totalTokens: 100,
+        inputTokens: 100,
+        cachedInputTokens: 0,
+        outputTokens: 0,
+        reasoningOutputTokens: 0,
+      },
+      {
+        totalTokens: 2_100,
+        inputTokens: 1_900,
+        cachedInputTokens: 0,
+        outputTokens: 200,
+        reasoningOutputTokens: 0,
+      },
+    );
+    emitTokenUsage(
+      fake,
+      "turn-2",
+      {
+        totalTokens: 500,
+        inputTokens: 500,
+        cachedInputTokens: 0,
+        outputTokens: 0,
+        reasoningOutputTokens: 0,
+      },
+      {
+        totalTokens: 2_600,
+        inputTokens: 2_400,
+        cachedInputTokens: 0,
+        outputTokens: 200,
+        reasoningOutputTokens: 0,
+      },
+    );
+    fake.emit("item/completed", {
+      threadId: "thread-app-server",
+      turnId: "turn-2",
+      item: { type: "agentMessage", id: "item-turn-2", text: "second answer", phase: null, memoryCitation: null },
+    });
+    fake.emit("turn/completed", {
+      threadId: "thread-app-server",
+      turn: { id: "turn-2", status: "completed", items: [], error: null },
+    });
+    await waitFor(() => tokenUsageEvents(emitEvent).length === 2);
+
+    emitTokenUsage(
+      fake,
+      "turn-1",
+      {
+        totalTokens: 10_000,
+        inputTokens: 9_000,
+        cachedInputTokens: 0,
+        outputTokens: 1_000,
+        reasoningOutputTokens: 0,
+      },
+      {
+        totalTokens: 10_000,
+        inputTokens: 9_000,
+        cachedInputTokens: 0,
+        outputTokens: 1_000,
+        reasoningOutputTokens: 0,
+      },
+    );
+
+    handler.inject(makeMessage("m3", "third"));
+    await waitFor(() => fake.requests.filter((request) => request.method === "turn/start").length === 3);
+
+    emitTokenUsage(
+      fake,
+      "turn-3",
+      {
+        totalTokens: 500,
+        inputTokens: 500,
+        cachedInputTokens: 0,
+        outputTokens: 0,
+        reasoningOutputTokens: 0,
+      },
+      {
+        totalTokens: 3_100,
+        inputTokens: 2_900,
+        cachedInputTokens: 0,
+        outputTokens: 200,
+        reasoningOutputTokens: 0,
+      },
+    );
+    fake.emit("item/completed", {
+      threadId: "thread-app-server",
+      turnId: "turn-3",
+      item: { type: "agentMessage", id: "item-turn-3", text: "third answer", phase: null, memoryCitation: null },
+    });
+    fake.emit("turn/completed", {
+      threadId: "thread-app-server",
+      turn: { id: "turn-3", status: "completed", items: [], error: null },
+    });
+    await waitFor(() => tokenUsageEvents(emitEvent).length === 3);
+
+    expect(tokenUsageEvents(emitEvent).map((event) => event.payload)).toMatchObject([
+      {
+        inputTokens: 0,
+        cachedInputTokens: 0,
+        outputTokens: 0,
+      },
+      {
+        inputTokens: 500,
         cachedInputTokens: 0,
         outputTokens: 0,
       },

--- a/packages/client/src/handlers/codex/app-server/index.ts
+++ b/packages/client/src/handlers/codex/app-server/index.ts
@@ -174,6 +174,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
   let pendingChatContextPrompt: string | null = null;
   let sourceReposForPrompt: PredeclaredSourceRepo[] = [];
   let latestThreadUsageTotal: TokenUsageBreakdown | null = null;
+  let latestCurrentSessionUsageTurnId: string | null = null;
 
   const pendingInputs: QueueEntry[] = [];
   const pendingNotificationsByTurn = new Map<string, CodexAppServerNotification[]>();
@@ -432,13 +433,13 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
     const id = extractThreadId(result);
     if (!id) throw new CodexAppServerStartupError("thread-start", "missing thread id");
     threadId = id;
-    latestThreadUsageTotal = emptyTokenUsage();
+    resetThreadUsageTracking(emptyTokenUsage());
     return id;
   }
 
   async function resumeThread(sessionId: string, payload: AgentRuntimeConfigPayload): Promise<void> {
     const client = requireAppServer();
-    latestThreadUsageTotal = null;
+    resetThreadUsageTracking(null);
     try {
       await client.request("thread/resume", {
         threadId: sessionId,
@@ -639,8 +640,8 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
       if (error) recordAppServerFailureSignal(turnStartAttempt, error);
     }
     if (notificationTurnId && (!turn || turn.turnId !== notificationTurnId)) {
-      if (!turnStartInProgress) recordHistoricalTokenUsage(notification);
-      bufferNotification(notificationTurnId, notification);
+      const historicalTokenUsageRecorded = !turnStartInProgress && recordHistoricalTokenUsage(notification);
+      if (!historicalTokenUsageRecorded) bufferNotification(notificationTurnId, notification);
       return;
     }
     applyNotification(notification, sessionCtx, turn);
@@ -747,11 +748,23 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
     pendingNotificationsByTurn.set(turnId, list);
   }
 
-  function recordHistoricalTokenUsage(notification: CodexAppServerNotification): void {
-    if (notification.method !== "thread/tokenUsage/updated") return;
+  function recordHistoricalTokenUsage(notification: CodexAppServerNotification): boolean {
+    if (notification.method !== "thread/tokenUsage/updated") return false;
     const params = asRecord(notification.params);
     const usage = parseThreadTokenUsage(asRecord(params?.tokenUsage));
-    if (usage) recordLatestThreadUsageTotal(usage.total);
+    if (!usage) return true;
+
+    const turn = currentTurn;
+    if (turn?.usageLatestTotal) return true;
+    const notificationTurnId = params ? (readString(params, "turnId") ?? readString(params, "turn_id")) : null;
+
+    if (latestCurrentSessionUsageTurnId) {
+      if (notificationTurnId === latestCurrentSessionUsageTurnId) acceptHistoricalTokenUsageTotal(usage.total);
+      return true;
+    }
+
+    acceptHistoricalTokenUsageTotal(usage.total);
+    return true;
   }
 
   function recordBufferedHistoricalTokenUsageExcept(currentTurnId: string): void {
@@ -763,9 +776,29 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
   }
 
   function recordCurrentTurnTokenUsage(turn: CurrentTurn, usage: ThreadTokenUsageSnapshot): void {
+    latestCurrentSessionUsageTurnId = turn.turnId;
     turn.usageLatestTotal = cloneTokenUsage(usage.total);
     turn.usageLastSum = addTokenUsage(turn.usageLastSum ?? emptyTokenUsage(), usage.last);
     advanceCurrentThreadUsageTotal(usage.total);
+  }
+
+  function acceptHistoricalTokenUsageTotal(usage: TokenUsageBreakdown): void {
+    if (latestCurrentSessionUsageTurnId) {
+      advanceCurrentThreadUsageTotal(usage);
+    } else {
+      recordLatestThreadUsageTotal(usage);
+    }
+    syncCurrentTurnUsageBaseline();
+  }
+
+  function syncCurrentTurnUsageBaseline(): void {
+    const turn = currentTurn;
+    if (turn && !turn.usageLatestTotal) turn.usageBaselineTotal = cloneTokenUsage(latestThreadUsageTotal);
+  }
+
+  function resetThreadUsageTracking(baseline: TokenUsageBreakdown | null): void {
+    latestThreadUsageTotal = cloneTokenUsage(baseline);
+    latestCurrentSessionUsageTurnId = null;
   }
 
   function recordLatestThreadUsageTotal(usage: TokenUsageBreakdown): void {
@@ -803,7 +836,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
     const resumeThreadId = threadId ?? undefined;
     appServer = null;
     threadId = null;
-    latestThreadUsageTotal = null;
+    resetThreadUsageTracking(null);
     pendingNotificationsByTurn.clear();
     sessionCtx.log(
       `codex app-server session closed after unknown input custody (${reason}): ${
@@ -826,7 +859,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
     const resumeThreadId = threadId ?? undefined;
     appServer = null;
     threadId = null;
-    latestThreadUsageTotal = null;
+    resetThreadUsageTracking(null);
     pendingNotificationsByTurn.clear();
     sessionCtx.log(`codex app-server session closed after terminal turn/start failure (${reason})`);
     const shutdown = client?.shutdown();
@@ -842,7 +875,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
     const resumeThreadId = threadId ?? undefined;
     appServer = null;
     threadId = null;
-    latestThreadUsageTotal = null;
+    resetThreadUsageTracking(null);
     pendingNotificationsByTurn.clear();
     sessionCtx.log(`codex app-server session closed after uncommittable turn prefix (${reason})`);
     const shutdown = client?.shutdown();
@@ -1572,7 +1605,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
       await appServer?.shutdown();
       appServer = null;
       pendingChatContextPrompt = null;
-      latestThreadUsageTotal = null;
+      resetThreadUsageTracking(null);
     },
 
     async shutdown() {
@@ -1590,7 +1623,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
       threadId = null;
       ctx = null;
       pendingChatContextPrompt = null;
-      latestThreadUsageTotal = null;
+      resetThreadUsageTracking(null);
     },
   } satisfies AgentHandler;
 };


### PR DESCRIPTION
## Summary
- handle restored `thread/tokenUsage/updated` replay that arrives after a resumed turn has already been created but before that turn reports its own usage
- track the latest current-session turn id that has reported usage, so late usage from that turn can update a waiting next-turn baseline while older observed-turn replay is consumed without re-raising or regressing the baseline
- sync the active turn's pending `usageBaselineTotal` whenever accepted historical usage is folded into the thread baseline before that turn has reported its own usage
- extend app-server handler regressions for late resume replay, post-settle stale replay after a compaction reset, previous-own-turn late updates during a waiting turn, and older observed-turn stale replay

## Validation
- `pnpm exec biome check packages/client/src/handlers/codex/app-server/index.ts packages/client/src/__tests__/codex-app-server-handler.test.ts`
- `pnpm --filter @first-tree/client exec vitest run --poolOptions.threads.maxThreads=2 --poolOptions.forks.maxForks=2 src/__tests__/codex-app-server-handler.test.ts`
- `pnpm --filter @first-tree/client typecheck`
- `pnpm check` (passes with existing unrelated warnings/info)
- `TURBO_CONCURRENCY=2 pnpm typecheck`
- `TURBO_CONCURRENCY=2 pnpm test -- --poolOptions.threads.maxThreads=2 --poolOptions.forks.maxForks=2`