### PR TITLE
fix(web): resume foreground polls on focus/pageshow so onboarding doesn't stick on "connecting"

### DIFF
--- a/packages/web/src/lib/__tests__/visibility-interval.test.ts
+++ b/packages/web/src/lib/__tests__/visibility-interval.test.ts
@@ -61,4 +61,79 @@ describe("runVisibilityAwareInterval", () => {
 
     cleanup();
   });
+
+  it("resumes on window focus when visibilitychange is missed (app-switch return)", async () => {
+    const { runVisibilityAwareInterval } = await import("../visibility-interval.js");
+    const tick = vi.fn();
+
+    const cleanup = runVisibilityAwareInterval(tick, 1000);
+    expect(tick).toHaveBeenCalledTimes(1);
+
+    // Tab goes hidden → pause (this event does fire).
+    setHidden(true);
+    document.dispatchEvent(new Event("visibilitychange"));
+    vi.advanceTimersByTime(3000);
+    expect(tick).toHaveBeenCalledTimes(1);
+
+    // User returns from a terminal: the window regains focus but the matching
+    // `visibilitychange` → visible never arrives. `focus` must resume the poll
+    // and re-tick immediately — this is the onboarding stuck-on-"connecting" fix.
+    setHidden(false);
+    window.dispatchEvent(new Event("focus"));
+    expect(tick).toHaveBeenCalledTimes(2);
+    vi.advanceTimersByTime(1000);
+    expect(tick).toHaveBeenCalledTimes(3);
+
+    cleanup();
+  });
+
+  it("ignores focus while already running (no double tick, no stacked interval)", async () => {
+    const { runVisibilityAwareInterval } = await import("../visibility-interval.js");
+    const tick = vi.fn();
+
+    const cleanup = runVisibilityAwareInterval(tick, 1000);
+    expect(tick).toHaveBeenCalledTimes(1);
+
+    // Refocus while visible + running is a no-op (handle guard).
+    window.dispatchEvent(new Event("focus"));
+    expect(tick).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(1000);
+    expect(tick).toHaveBeenCalledTimes(2); // single interval, not stacked
+
+    cleanup();
+  });
+
+  it("does not resume on focus while the page is still hidden", async () => {
+    const { runVisibilityAwareInterval } = await import("../visibility-interval.js");
+    const tick = vi.fn();
+
+    const cleanup = runVisibilityAwareInterval(tick, 1000);
+    expect(tick).toHaveBeenCalledTimes(1);
+
+    setHidden(true);
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect(tick).toHaveBeenCalledTimes(1);
+
+    // A focus event while still hidden must not start the poll.
+    window.dispatchEvent(new Event("focus"));
+    vi.advanceTimersByTime(2000);
+    expect(tick).toHaveBeenCalledTimes(1);
+
+    cleanup();
+  });
+
+  it("removes focus/pageshow listeners on teardown", async () => {
+    const { runVisibilityAwareInterval } = await import("../visibility-interval.js");
+    const tick = vi.fn();
+
+    const cleanup = runVisibilityAwareInterval(tick, 1000);
+    expect(tick).toHaveBeenCalledTimes(1);
+    cleanup();
+
+    window.dispatchEvent(new Event("focus"));
+    window.dispatchEvent(new Event("pageshow"));
+    vi.advanceTimersByTime(2000);
+    expect(tick).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/web/src/lib/visibility-interval.ts
+++ b/packages/web/src/lib/visibility-interval.ts
@@ -6,17 +6,35 @@
  *     and fires `tick()` once on mount to populate state.
  *   - On `visibilitychange` → hidden: `clearInterval` so the timer truly
  *     stops (no wakeups, no pointless tick-time `document.hidden` returns).
- *   - On `visibilitychange` → visible: `setInterval` again AND fire
- *     `tick()` immediately so the consumer catches up after a long
- *     background period without waiting `intervalMs`.
+ *   - On `visibilitychange` → visible, OR a window `focus` / `pageshow`:
+ *     `setInterval` again AND fire `tick()` immediately so the consumer
+ *     catches up after a background period without waiting `intervalMs`.
  *
- * Returns a teardown that clears the interval and removes the listener.
+ * Why resume on `focus` / `pageshow` too, not `visibilitychange` alone:
+ * returning from *another application* — e.g. the user switches to a
+ * terminal to run a command, then switches back — frequently does NOT
+ * fire a reliable `visibilitychange`. That return is a window-focus
+ * change, which is not always a page-visibility change, and the two
+ * diverge across browser / OS / window-occlusion. Resuming on
+ * `visibilitychange` alone leaves the poll paused forever after such a
+ * return, so the UI goes stale until a manual refresh — exactly the
+ * onboarding "connect your computer" failure mode, where leaving the tab
+ * for the terminal is the *expected* flow. `focus` (app/tab refocus) and
+ * `pageshow` (bfcache restore) are the belt-and-suspenders resume
+ * triggers. Resuming is idempotent: `start()`'s handle guard makes a
+ * refocus while already running a no-op (no double tick, no stacked
+ * interval), and `onResume` never starts while the page is genuinely
+ * hidden. Stop stays bound to `visibilitychange` → hidden only, so a mere
+ * blur (window still visible, e.g. side-by-side with a terminal) does not
+ * pause the poll.
+ *
+ * Returns a teardown that clears the interval and removes the listeners.
  * Callers that need their own cancelled-flag for stale-setState protection
  * should still keep it — this helper is purely about the timer lifecycle.
  *
  * Intended for foreground-only modal/dialog polls (Last-step, New-agent,
- * New-connection, onboarding step 2). React Query users already have
- * `refetchIntervalInBackground: false` for the same effect.
+ * New-connection, onboarding connect-computer). React Query users already
+ * have `refetchIntervalInBackground: false` for the same effect.
  */
 export function runVisibilityAwareInterval(tick: () => void | Promise<void>, intervalMs: number): () => void {
   let handle: ReturnType<typeof setInterval> | null = null;
@@ -39,11 +57,22 @@ export function runVisibilityAwareInterval(tick: () => void | Promise<void>, int
     else start();
   };
 
+  // Resume on app/tab refocus or bfcache restore, but never start while the
+  // page is actually hidden. `start()` is idempotent, so firing this while
+  // the interval is already running is a harmless no-op.
+  const onResume = (): void => {
+    if (!document.hidden) start();
+  };
+
   if (!document.hidden) start();
   document.addEventListener("visibilitychange", onVisibility);
+  window.addEventListener("focus", onResume);
+  window.addEventListener("pageshow", onResume);
 
   return () => {
     stop();
     document.removeEventListener("visibilitychange", onVisibility);
+    window.removeEventListener("focus", onResume);
+    window.removeEventListener("pageshow", onResume);
   };
 }


### PR DESCRIPTION
## Problem

In the onboarding **Connect your computer** step, users sometimes had to **manually refresh the page** before the UI updated to "connected" — otherwise it stayed on "connecting…" indefinitely, even though the computer had already connected server-side.

## Root cause

`runVisibilityAwareInterval` (the foreground-only poll used by the onboarding connect step and the new-agent / new-connection dialogs) pauses the poll while the tab is hidden and resumes it **only** on `visibilitychange` → visible.

The connect step’s normal flow is to leave the browser for a terminal (to run the install one-liner) and come back. Returning from **another application** frequently does **not** fire a reliable `visibilitychange` — that return is a window-focus change, which is not always a page-visibility change, and the two diverge across browser / OS / window occlusion. When the event is missed, the paused poll never restarts, so the UI is stale until a hard refresh (which remounts and re-fetches).

## Fix

Add `window` `focus` and `pageshow` as additional **resume** triggers alongside `visibilitychange`:

- `focus` covers app/tab refocus; `pageshow` covers bfcache restore.
- Resuming is idempotent — `start()`’s handle guard makes a refocus while already running a no-op (no double tick, no stacked interval), and it never starts while the page is genuinely hidden.
- **Stop** stays bound to `visibilitychange` → hidden only, so a mere blur (window still visible, e.g. side-by-side with a terminal) does not pause the poll.

One change to the shared helper fixes the same latent issue at all three call sites (onboarding connect-computer, new-agent dialog, new-connection dialog).

## Tests

`packages/web/src/lib/__tests__/visibility-interval.test.ts` — added cases: resume on `focus` when `visibilitychange` is missed (the bug), idempotent refocus while running, no resume on `focus` while still hidden, and listener teardown. Full web suite green (979 tests); biome + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)