### PR TITLE
fix(web): bridge wheel scrolling over the expanded chat summary

### DIFF
--- a/packages/web/src/pages/workspace/center/__tests__/chat-summary.test.ts
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-summary.test.ts
@@ -306,7 +306,7 @@ describe("ChatSummary", () => {
     container.remove();
   });
 
-  it("lets the summary body consume the wheel before driving the stream", async () => {
+  it("scrolls the summary body itself before driving the stream", async () => {
     localStorage.clear();
     const scrollEl = document.createElement("div");
     scrollEl.scrollTop = 0;
@@ -323,10 +323,41 @@ describe("ChatSummary", () => {
     Object.defineProperty(inner, "clientHeight", { value: 200, configurable: true });
     inner.scrollTop = 100;
 
-    // Wheel up: the body can still scroll up, so the stream must stay put.
+    // Wheel up: the body can still scroll up, so the body moves and the stream
+    // stays put.
     await act(async () => {
       panel.dispatchEvent(wheelEvent(-40));
     });
+    expect(inner.scrollTop).toBe(60);
+    expect(scrollEl.scrollTop).toBe(0);
+
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  it("scrolls the body for a wheel over the summary header, not just the body", async () => {
+    localStorage.clear();
+    const scrollEl = document.createElement("div");
+    scrollEl.scrollTop = 0;
+    const { container, root } = await renderSummary(scrollEl, {
+      descriptionUpdatedAt: unreadVersionAt,
+      lastReadAt: readRecentlyAt,
+    });
+    // The header control sits OUTSIDE the markdown body's event path; a wheel
+    // there must still drive the body while it has room (regression: target-
+    // unaware deferral to native scroll left the header strip locked).
+    const header = container.querySelector<HTMLButtonElement>('button[aria-label="Collapse summary"]');
+    if (!header) throw new Error("summary header button missing");
+    const inner = container.querySelector<HTMLElement>('[style*="46vh"]');
+    if (!inner) throw new Error("summary scroll body missing");
+    Object.defineProperty(inner, "scrollHeight", { value: 1000, configurable: true });
+    Object.defineProperty(inner, "clientHeight", { value: 200, configurable: true });
+    inner.scrollTop = 0;
+
+    await act(async () => {
+      header.dispatchEvent(wheelEvent(120));
+    });
+    expect(inner.scrollTop).toBe(120);
     expect(scrollEl.scrollTop).toBe(0);
 
     await act(async () => root.unmount());

--- a/packages/web/src/pages/workspace/center/__tests__/chat-summary.test.ts
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-summary.test.ts
@@ -123,6 +123,16 @@ describe("ChatSummary", () => {
     };
   }
 
+  // A wheel event the summary's native (non-passive) listener can read. Built
+  // from a plain cancelable Event so the test does not depend on happy-dom's
+  // WheelEvent constructor; deltaX/deltaY are the only fields the handler reads.
+  function wheelEvent(deltaY: number, deltaX = 0): Event {
+    const e = new Event("wheel", { bubbles: true, cancelable: true });
+    Object.defineProperty(e, "deltaY", { value: deltaY });
+    Object.defineProperty(e, "deltaX", { value: deltaX });
+    return e;
+  }
+
   it("auto-expands an unread summary version on entry even when the chat was read recently", async () => {
     localStorage.clear();
     const scrollEl = document.createElement("div");
@@ -266,6 +276,58 @@ describe("ChatSummary", () => {
       stickyButton.click();
     });
     expect(container.querySelector("strong")?.textContent).toBe("DescBody");
+
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  it("bridges a wheel gesture over the expanded summary to the message stream", async () => {
+    localStorage.clear();
+    const scrollEl = document.createElement("div");
+    scrollEl.scrollTop = 0;
+    // Unread version → auto-expanded on entry, so the panel owns the viewport.
+    const { container, root } = await renderSummary(scrollEl, {
+      descriptionUpdatedAt: unreadVersionAt,
+      lastReadAt: readRecentlyAt,
+    });
+    expect(container.querySelector<HTMLButtonElement>('button[aria-label="Collapse summary"]')).not.toBeNull();
+    const panel = container.firstElementChild as HTMLElement | null;
+    if (!panel) throw new Error("summary panel missing");
+
+    // The expanded body cannot absorb the scroll itself (no overflow), so a wheel
+    // over the summary must drive the message stream — without this it scrolls
+    // nothing and the conversation reads as "locked".
+    await act(async () => {
+      panel.dispatchEvent(wheelEvent(120));
+    });
+    expect(scrollEl.scrollTop).toBe(120);
+
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  it("lets the summary body consume the wheel before driving the stream", async () => {
+    localStorage.clear();
+    const scrollEl = document.createElement("div");
+    scrollEl.scrollTop = 0;
+    const { container, root } = await renderSummary(scrollEl, {
+      descriptionUpdatedAt: unreadVersionAt,
+      lastReadAt: readRecentlyAt,
+    });
+    const panel = container.firstElementChild as HTMLElement | null;
+    if (!panel) throw new Error("summary panel missing");
+    const inner = container.querySelector<HTMLElement>('[style*="46vh"]');
+    if (!inner) throw new Error("summary scroll body missing");
+    // Make the body itself scrollable and parked mid-content (not at top/bottom).
+    Object.defineProperty(inner, "scrollHeight", { value: 1000, configurable: true });
+    Object.defineProperty(inner, "clientHeight", { value: 200, configurable: true });
+    inner.scrollTop = 100;
+
+    // Wheel up: the body can still scroll up, so the stream must stay put.
+    await act(async () => {
+      panel.dispatchEvent(wheelEvent(-40));
+    });
+    expect(scrollEl.scrollTop).toBe(0);
 
     await act(async () => root.unmount());
     container.remove();

--- a/packages/web/src/pages/workspace/center/__tests__/chat-summary.test.ts
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-summary.test.ts
@@ -363,4 +363,36 @@ describe("ChatSummary", () => {
     await act(async () => root.unmount());
     container.remove();
   });
+
+  it("leaves a horizontal-dominant wheel to the browser", async () => {
+    localStorage.clear();
+    const scrollEl = document.createElement("div");
+    scrollEl.scrollTop = 0;
+    const { container, root } = await renderSummary(scrollEl, {
+      descriptionUpdatedAt: unreadVersionAt,
+      lastReadAt: readRecentlyAt,
+    });
+    const panel = container.firstElementChild as HTMLElement | null;
+    if (!panel) throw new Error("summary panel missing");
+    const inner = container.querySelector<HTMLElement>('[style*="46vh"]');
+    if (!inner) throw new Error("summary scroll body missing");
+    // Body is scrollable, so a missing guard would let the small vertical
+    // component move it.
+    Object.defineProperty(inner, "scrollHeight", { value: 1000, configurable: true });
+    Object.defineProperty(inner, "clientHeight", { value: 200, configurable: true });
+    inner.scrollTop = 100;
+
+    // deltaX dominates deltaY (a trackpad horizontal pan): hands off to the
+    // browser — nothing is scrolled and the event is not consumed.
+    const ev = wheelEvent(8, 120);
+    await act(async () => {
+      panel.dispatchEvent(ev);
+    });
+    expect(inner.scrollTop).toBe(100);
+    expect(scrollEl.scrollTop).toBe(0);
+    expect(ev.defaultPrevented).toBe(false);
+
+    await act(async () => root.unmount());
+    container.remove();
+  });
 });

--- a/packages/web/src/pages/workspace/center/chat-summary.tsx
+++ b/packages/web/src/pages/workspace/center/chat-summary.tsx
@@ -292,10 +292,18 @@ export function ChatSummary({
   // scroll container, and its only ancestor is the `overflow-hidden` center
   // column — so a wheel gesture over the summary has no scrollable target and
   // the conversation reads as "locked" (the markdown body only scrolls when its
-  // own content overflows). Bridge it: when the body can still scroll in the
-  // wheel's direction let it; otherwise drive the message stream so scrolling
-  // stays continuous across the summary↔stream seam (and scrolling down folds
-  // the summary via the existing sticky-collapse, same as scrolling the stream).
+  // own content overflows). Bridge it from a single listener on the whole panel:
+  // while the markdown body still has room in the wheel's direction, scroll IT;
+  // otherwise drive the message stream so scrolling stays continuous across the
+  // summary↔stream seam (and scrolling down folds the summary via the existing
+  // sticky-collapse, same as scrolling the stream).
+  //
+  // The body is scrolled EXPLICITLY rather than by deferring to native scroll:
+  // the listener fires for the whole panel (header bar + padding + body), but a
+  // wheel over the header/padding sits OUTSIDE the body's own event path, so
+  // native scrolling there finds no scrollable ancestor and would re-create the
+  // dead zone for that strip. Driving `inner` ourselves makes a wheel anywhere
+  // on the panel scroll the body uniformly.
   const panelRef = useRef<HTMLDivElement | null>(null);
   const innerScrollRef = useRef<HTMLDivElement | null>(null);
   useEffect(() => {
@@ -311,8 +319,13 @@ export function ChatSummary({
       if (inner) {
         const atTop = inner.scrollTop <= 0;
         const atBottom = inner.scrollTop + inner.clientHeight >= inner.scrollHeight - 1;
-        // The markdown body can absorb this delta itself — let native scroll run.
-        if ((e.deltaY < 0 && !atTop) || (e.deltaY > 0 && !atBottom)) return;
+        // The markdown body still has room — scroll it (and suppress native
+        // scroll so a wheel directly over the body isn't applied twice).
+        if ((e.deltaY < 0 && !atTop) || (e.deltaY > 0 && !atBottom)) {
+          inner.scrollTop += e.deltaY;
+          e.preventDefault();
+          return;
+        }
       }
       stream.scrollTop += e.deltaY;
       e.preventDefault();

--- a/packages/web/src/pages/workspace/center/chat-summary.tsx
+++ b/packages/web/src/pages/workspace/center/chat-summary.tsx
@@ -288,6 +288,41 @@ export function ChatSummary({
     return () => el.removeEventListener("scroll", onScroll);
   }, [hasDescription, scrollContainerRef]);
 
+  // Wheel bridging: the expanded summary is a pinned sibling ABOVE the message
+  // scroll container, and its only ancestor is the `overflow-hidden` center
+  // column — so a wheel gesture over the summary has no scrollable target and
+  // the conversation reads as "locked" (the markdown body only scrolls when its
+  // own content overflows). Bridge it: when the body can still scroll in the
+  // wheel's direction let it; otherwise drive the message stream so scrolling
+  // stays continuous across the summary↔stream seam (and scrolling down folds
+  // the summary via the existing sticky-collapse, same as scrolling the stream).
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const innerScrollRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (!hasDescription) return;
+    const panel = panelRef.current;
+    if (!panel) return;
+    const onWheel = (e: WheelEvent) => {
+      const stream = scrollContainerRef.current;
+      if (!stream) return;
+      // Leave horizontal/trackpad-pan gestures to the browser.
+      if (Math.abs(e.deltaX) > Math.abs(e.deltaY) || e.deltaY === 0) return;
+      const inner = innerScrollRef.current;
+      if (inner) {
+        const atTop = inner.scrollTop <= 0;
+        const atBottom = inner.scrollTop + inner.clientHeight >= inner.scrollHeight - 1;
+        // The markdown body can absorb this delta itself — let native scroll run.
+        if ((e.deltaY < 0 && !atTop) || (e.deltaY > 0 && !atBottom)) return;
+      }
+      stream.scrollTop += e.deltaY;
+      e.preventDefault();
+    };
+    // Native, non-passive so preventDefault works (React routes onWheel through a
+    // passive root listener, where preventDefault is a no-op).
+    panel.addEventListener("wheel", onWheel, { passive: false });
+    return () => panel.removeEventListener("wheel", onWheel);
+  }, [hasDescription, scrollContainerRef]);
+
   if (!hasDescription) return null;
 
   const expanded = open && !scrollCollapsed;
@@ -298,6 +333,7 @@ export function ChatSummary({
 
   return (
     <div
+      ref={panelRef}
       className="shrink-0"
       style={{
         // The summary is conversation content, so it shares the message-stream
@@ -375,7 +411,11 @@ export function ChatSummary({
 
       {expanded ? (
         <div style={{ padding: "var(--sp-1) var(--sp-6) var(--sp-3)" }}>
-          <div className="text-body" style={{ color: "var(--fg)", maxHeight: "min(46vh, 30rem)", overflowY: "auto" }}>
+          <div
+            ref={innerScrollRef}
+            className="text-body"
+            style={{ color: "var(--fg)", maxHeight: "min(46vh, 30rem)", overflowY: "auto" }}
+          >
             {/* Faithful markdown render. Headings are flattened to body size so
                 hierarchy is carried by weight + spacing (mirrors the rail's old
                 Summary treatment) rather than shouting over the bar above. */}


### PR DESCRIPTION
## Problem

When a chat's task **Summary** is expanded, hovering the mouse over the summary panel and scrolling does nothing — the page reads as **"locked."** Reported with a screenshot of an expanded summary occupying ~1/3 of the viewport.

## Root cause

The expanded `ChatSummary` (`packages/web/src/pages/workspace/center/chat-summary.tsx`) is a pinned `shrink-0` sibling **above** the message scroll container (`scrollContainerRef`), and its only ancestor is the `overflow-hidden` center column. So a wheel gesture over the summary has **no scrollable target**:

- The inner markdown body (`maxHeight: min(46vh, 30rem); overflowY: auto`) only scrolls when its **own** content overflows.
- There is no scrollable ancestor above the panel.
- The message stream is a **cousin**, not an ancestor — wheel/scroll chaining can't reach it.

→ Mouse wheel over the expanded summary scrolls nothing. The taller the summary, the larger the dead zone. (Confirmed live on staging: walking up from the summary panel, `nearestScrollableAncestor === none`.)

## Fix

Add a **native, non-passive** `wheel` listener on the whole summary panel (header bar + padding + body) that drives scrolling itself instead of relying on a scrollable ancestor:

- While the markdown body still has room in the wheel's direction → scroll the **body** explicitly and `preventDefault()`. Explicit (not "defer to native") on purpose: a wheel over the header/padding sits **outside** the body's event path, so native scroll there has no target and would re-create the dead zone for that strip. Driving the body ourselves makes a wheel anywhere on the panel move it uniformly. `preventDefault` keeps a wheel directly over the body from being applied twice.
- At the body boundary (or when there's no body) → drive `scrollContainerRef.scrollTop`. Scrolling **down** over the summary also folds it via the existing sticky-collapse (it reacts to the stream's scroll), exactly as scrolling the stream directly does.

Native + non-passive is required because React routes `onWheel` through a passive root listener, where `preventDefault()` is a no-op.

The pinned/collapsible design is unchanged — this only restores scroll continuity.

## Verification

- **Real Chromium** (local build, real `WheelEvent` over the expanded panel): the message stream scrolls its full range and `event.defaultPrevented === true` (the native listener fires; preventDefault works).
- **Unit tests** (`chat-summary.test.ts`, 26 passing incl. 4 new wheel tests): wheel over the expanded summary drives the stream; a scrollable body is moved first (and is moved even when the wheel originates on the **header button**, not just inside the body — the R4 regression case); horizontal gestures are left to the browser.
- `pnpm --filter @first-tree/web typecheck` clean; `biome check` clean on changed files.

## Out of scope / honest note

This bridges **wheel** input (the reported case). Touch-drag over the expanded summary has the same root cause but a different mechanism, and is **not** covered here. The durable cure for both is architectural — make the summary a single scroll surface (a `position: sticky` collapsing header inside the stream, or an overlay on expand) — which removes the dead zone for any input without JS bridging. Tracked as a separate design decision; this PR is the immediate stopgap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
