### PR TITLE
feat(chat): surface an offline agent + leave-a-task affordance in the timeline

### DIFF
--- a/packages/server/src/__tests__/agent-chats.test.ts
+++ b/packages/server/src/__tests__/agent-chats.test.ts
@@ -89,7 +89,10 @@ describe("Agent Chats API", () => {
       format: "text",
       content: `@${target.agent.name} please review`,
     });
-    expect(messageRow?.metadata).toEqual({ mentions: [target.agent.uuid] });
+    expect(messageRow?.metadata).toEqual({
+      mentions: [target.agent.uuid],
+      addressedAgentIds: [target.agent.uuid],
+    });
 
     const targetInbox = await app.db
       .select({ notify: inboxEntries.notify, messageId: inboxEntries.messageId })
@@ -133,7 +136,10 @@ describe("Agent Chats API", () => {
 
     const [messageRow] = await app.db.select().from(messages).where(eq(messages.id, body.messageId)).limit(1);
     expect(messageRow?.content).toBe(`@${target.agent.name} please review by name`);
-    expect(messageRow?.metadata).toEqual({ mentions: [target.agent.uuid] });
+    expect(messageRow?.metadata).toEqual({
+      mentions: [target.agent.uuid],
+      addressedAgentIds: [target.agent.uuid],
+    });
 
     const targetInbox = await app.db
       .select({ notify: inboxEntries.notify, messageId: inboxEntries.messageId })
@@ -183,6 +189,7 @@ describe("Agent Chats API", () => {
     expect(messageRow?.senderId).toBe(manager?.agentId);
     expect(messageRow?.metadata).toEqual({
       mentions: [sender.agent.uuid],
+      addressedAgentIds: [sender.agent.uuid],
       initiatedByAgentId: sender.agent.uuid,
       effectiveSenderReason: "self_target_manager_human",
     });

--- a/packages/server/src/__tests__/me-onboarding-kickoff.test.ts
+++ b/packages/server/src/__tests__/me-onboarding-kickoff.test.ts
@@ -104,7 +104,10 @@ describe("POST /me/onboarding/kickoff", () => {
     expect(msg?.source).toBe("api");
     expect(msg?.format).toBe("text");
     expect(msg?.content).toBe("First Tree is getting Bootstrap Agent up to speed on acme/web.");
-    expect(msg?.metadata).toEqual({ systemSender: "first_tree_onboarding" });
+    expect(msg?.metadata).toEqual({
+      systemSender: "first_tree_onboarding",
+      addressedAgentIds: [agent.uuid],
+    });
 
     const deliveries = await app.db
       .select()

--- a/packages/server/src/__tests__/message-addressed-agents.test.ts
+++ b/packages/server/src/__tests__/message-addressed-agents.test.ts
@@ -15,13 +15,21 @@ const AGENT: SendIntentParticipant = {
   status: "active",
   type: "agent",
 };
+const AGENT_TWO: SendIntentParticipant = {
+  agentId: "agent-2",
+  name: "reviewer",
+  displayName: "Reviewer",
+  status: "active",
+  type: "agent",
+};
 
 /**
- * `metadata.addressedAgentIds` carries the real routed non-human recipients so a
- * web surface (the chat offline notice) can tell who a turn awaits a reply from.
- * `mentions` only covers explicit @s / receiverNames — NOT the system
- * `addressedToAgentIds` routing the onboarding kickoff bootstrap uses — so the
- * bootstrap case below is the one a `mentions`-only read would miss.
+ * `metadata.addressedAgentIds` carries server-owned notify-worthy non-human
+ * recipients so a web surface (the chat offline notice) can tell who a turn
+ * awaits a reply from. `mentions` only covers explicit @s / receiverNames —
+ * NOT the system `addressedToAgentIds` routing the onboarding kickoff bootstrap
+ * uses — so the bootstrap case below is the one a `mentions`-only read would
+ * miss.
  */
 describe("preflightMessageSendIntent — addressedAgentIds", () => {
   it("persists the system addressedToAgentIds (onboarding bootstrap) even with no mentions", () => {
@@ -59,10 +67,68 @@ describe("preflightMessageSendIntent — addressedAgentIds", () => {
       chatId: "c1",
       senderId: "agent-1",
       senderType: "agent",
-      data: { format: "text", content: "done", source: "api", metadata: {} },
+      data: {
+        format: "text",
+        content: "done",
+        source: "api",
+        metadata: { addressedAgentIds: ["agent-1"] },
+      },
       options: { addressedToAgentIds: ["human-1"] },
       participants: [HUMAN, AGENT],
     });
     expect(result.metadata.addressedAgentIds).toBeUndefined();
+  });
+
+  it("strips caller-supplied addressedAgentIds when the server computes no awaited agents", () => {
+    const result = preflightMessageSendIntent({
+      chatId: "c1",
+      senderId: "human-1",
+      senderType: "human",
+      data: {
+        format: "text",
+        content: "history note",
+        source: "api",
+        metadata: { addressedAgentIds: ["agent-1"] },
+      },
+      options: { allowRecipientlessSend: true },
+      participants: [HUMAN, AGENT],
+    });
+    expect(result.metadata.addressedAgentIds).toBeUndefined();
+  });
+
+  it("does not record agent-final-text recipients as awaited agents", () => {
+    const result = preflightMessageSendIntent({
+      chatId: "c1",
+      senderId: "agent-1",
+      senderType: "agent",
+      data: {
+        format: "text",
+        content: "final answer",
+        source: "api",
+        purpose: "agent-final-text",
+        metadata: { mentions: ["agent-2"] },
+      },
+      participants: [HUMAN, AGENT, AGENT_TWO],
+    });
+    expect(result.metadata.mentions).toEqual(["agent-2"]);
+    expect(result.metadata.addressedAgentIds).toBeUndefined();
+  });
+
+  it("excludes suppressNotifyAgentIds from addressedAgentIds", () => {
+    const result = preflightMessageSendIntent({
+      chatId: "c1",
+      senderId: "human-1",
+      senderType: "human",
+      data: {
+        format: "text",
+        content: "please review",
+        source: "api",
+        metadata: { mentions: ["agent-1", "agent-2"] },
+      },
+      options: { suppressNotifyAgentIds: ["agent-2"] },
+      participants: [HUMAN, AGENT, AGENT_TWO],
+    });
+    expect(result.metadata.mentions).toEqual(["agent-1", "agent-2"]);
+    expect(result.metadata.addressedAgentIds).toEqual(["agent-1"]);
   });
 });

--- a/packages/server/src/__tests__/message-addressed-agents.test.ts
+++ b/packages/server/src/__tests__/message-addressed-agents.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { preflightMessageSendIntent, type SendIntentParticipant } from "../services/message.js";
+
+const HUMAN: SendIntentParticipant = {
+  agentId: "human-1",
+  name: "gandy",
+  displayName: "Gandy",
+  status: "active",
+  type: "human",
+};
+const AGENT: SendIntentParticipant = {
+  agentId: "agent-1",
+  name: "asst",
+  displayName: "Assistant",
+  status: "active",
+  type: "agent",
+};
+
+/**
+ * `metadata.addressedAgentIds` carries the real routed non-human recipients so a
+ * web surface (the chat offline notice) can tell who a turn awaits a reply from.
+ * `mentions` only covers explicit @s / receiverNames — NOT the system
+ * `addressedToAgentIds` routing the onboarding kickoff bootstrap uses — so the
+ * bootstrap case below is the one a `mentions`-only read would miss.
+ */
+describe("preflightMessageSendIntent — addressedAgentIds", () => {
+  it("persists the system addressedToAgentIds (onboarding bootstrap) even with no mentions", () => {
+    const result = preflightMessageSendIntent({
+      chatId: "c1",
+      senderId: "human-1",
+      senderType: "human",
+      data: {
+        format: "text",
+        content: "Welcome — here are a few first tasks.",
+        source: "api",
+        metadata: { systemSender: "first_tree_onboarding" },
+      },
+      options: { addressedToAgentIds: ["agent-1"], allowSystemSender: true },
+      participants: [HUMAN, AGENT],
+    });
+    expect(result.metadata.addressedAgentIds).toEqual(["agent-1"]);
+    expect(result.metadata.mentions).toBeUndefined();
+  });
+
+  it("persists an explicit @agent in both mentions and addressedAgentIds", () => {
+    const result = preflightMessageSendIntent({
+      chatId: "c1",
+      senderId: "human-1",
+      senderType: "human",
+      data: { format: "text", content: "hi", source: "web", metadata: { mentions: ["agent-1"] } },
+      participants: [HUMAN, AGENT],
+    });
+    expect(result.metadata.addressedAgentIds).toEqual(["agent-1"]);
+    expect(result.metadata.mentions).toEqual(["agent-1"]);
+  });
+
+  it("does not record a human recipient as an addressed agent", () => {
+    const result = preflightMessageSendIntent({
+      chatId: "c1",
+      senderId: "agent-1",
+      senderType: "agent",
+      data: { format: "text", content: "done", source: "api", metadata: {} },
+      options: { addressedToAgentIds: ["human-1"] },
+      participants: [HUMAN, AGENT],
+    });
+    expect(result.metadata.addressedAgentIds).toBeUndefined();
+  });
+});

--- a/packages/server/src/__tests__/orgs-chats.test.ts
+++ b/packages/server/src/__tests__/orgs-chats.test.ts
@@ -121,7 +121,10 @@ describe("POST /orgs/:orgId/chats — multi-org chat creation (regression #238)"
       format: "text",
       content: "start from web",
     });
-    expect(messageRow?.metadata).toEqual({ mentions: [target.uuid] });
+    expect(messageRow?.metadata).toEqual({
+      mentions: [target.uuid],
+      addressedAgentIds: [target.uuid],
+    });
   });
 
   it("rejects participants from a different org (404 — anti-enumeration, not 400)", async () => {

--- a/packages/server/src/services/message.ts
+++ b/packages/server/src/services/message.ts
@@ -25,12 +25,13 @@ import { applyAfterFanOut, fireChatMessageKick } from "./chat-projection.js";
 import { validateDocumentContext, validateMessageAttachmentRefs } from "./doc-snapshots.js";
 
 const log = createLogger("message");
+const ADDRESSED_AGENT_IDS_METADATA_KEY = "addressedAgentIds";
 
 /**
- * Metadata keys reserved for trusted-internal write paths. Stripped from
- * untrusted-caller input (any send that doesn't opt in) so an HTTP POST
- * cannot smuggle a UI-trust marker into a regular message — see the
- * `allowSystemSender` field on `SendMessageOptions` for the threat model.
+ * Metadata keys reserved for server-owned write paths. Stripped from caller
+ * input so an HTTP POST cannot smuggle a UI-trust marker into a regular
+ * message — see the `allowSystemSender` field on `SendMessageOptions` for the
+ * `systemSender` threat model.
  *
  * Returns the same reference when nothing is stripped, so the common case
  * (no reserved keys present) does not allocate.
@@ -39,9 +40,14 @@ function stripUntrustedMetadataKeys(
   meta: Record<string, unknown>,
   options: SendMessageOptions,
 ): Record<string, unknown> {
-  if (options.allowSystemSender || !("systemSender" in meta)) return meta;
-  const { systemSender: _drop, ...rest } = meta;
-  return rest;
+  const shouldStripSystemSender = !options.allowSystemSender && "systemSender" in meta;
+  const shouldStripAddressedAgentIds = ADDRESSED_AGENT_IDS_METADATA_KEY in meta;
+  if (!shouldStripSystemSender && !shouldStripAddressedAgentIds) return meta;
+  return Object.fromEntries(
+    Object.entries(meta).filter(
+      ([key]) => key !== ADDRESSED_AGENT_IDS_METADATA_KEY && (options.allowSystemSender || key !== "systemSender"),
+    ),
+  );
 }
 
 /**
@@ -269,20 +275,36 @@ export function preflightMessageSendIntent(input: {
     throw new BadRequestError(`Cannot route to "${label}" because the agent is ${participant.status}. ${recovery}`);
   }
 
-  // Persist the addressed live non-human agents — the real routed recipients.
-  // `mentions` only carries explicit @s / receiverNames, NOT the system
-  // `addressedToAgentIds` routing (e.g. the onboarding kickoff bootstrap), so a
-  // surface that needs to know who a turn actually awaits a reply from (the chat
-  // offline notice) can't rely on `mentions` alone. `routedRecipientIds` is the
-  // validated fan-out set; keep only its active non-human agents.
-  const addressedAgentIds = [...routedRecipientIds].filter((id) => {
-    const participant = participantsById.get(id);
-    return participant !== undefined && participant.type !== "human";
-  });
+  const isAgentFinalText = data.purpose === "agent-final-text";
+  const purposeProfile = isAgentFinalText
+    ? {
+        skipMentionEnforcement: true,
+        forceSilentFanOut: true,
+      }
+    : {
+        skipMentionEnforcement: false,
+        forceSilentFanOut: false,
+      };
+  const suppressNotifySet = new Set(options.suppressNotifyAgentIds ?? []);
+
+  // Persist the notify-worthy live non-human agents — the recipients whose
+  // sessions the send is expected to wake. `mentions` only carries explicit @s /
+  // receiverNames, NOT system `addressedToAgentIds` routing (e.g. onboarding
+  // kickoff bootstrap), so a surface that needs to know who a turn awaits a
+  // reply from can't rely on `mentions` alone. This projection is server-owned
+  // and mirrors fan-out notify semantics: final-text and suppressed recipients
+  // are silent context, not awaited agents.
+  const addressedAgentIds = !purposeProfile.forceSilentFanOut
+    ? [...routedRecipientIds].filter((id) => {
+        if (suppressNotifySet.has(id)) return false;
+        const participant = participantsById.get(id);
+        return participant !== undefined && participant.status === "active" && participant.type !== "human";
+      })
+    : [];
   const metadataToStore = {
     ...incomingMeta,
     ...(mergedMentions.length > 0 ? { mentions: mergedMentions } : {}),
-    ...(addressedAgentIds.length > 0 ? { addressedAgentIds } : {}),
+    ...(addressedAgentIds.length > 0 ? { [ADDRESSED_AGENT_IDS_METADATA_KEY]: addressedAgentIds } : {}),
   };
 
   if (data.format === MESSAGE_FORMATS.REQUEST) {
@@ -305,17 +327,6 @@ export function preflightMessageSendIntent(input: {
   // `chat update --description`, but neither is the only path to a human.
   // (Resolution stays human-only — enforced by the resolution authorization
   // below, independent of who may send.)
-
-  const isAgentFinalText = data.purpose === "agent-final-text";
-  const purposeProfile = isAgentFinalText
-    ? {
-        skipMentionEnforcement: true,
-        forceSilentFanOut: true,
-      }
-    : {
-        skipMentionEnforcement: false,
-        forceSilentFanOut: false,
-      };
 
   const skipRecipientEnforcement = purposeProfile.skipMentionEnforcement || options.allowRecipientlessSend === true;
   if (!skipRecipientEnforcement) {

--- a/packages/server/src/services/message.ts
+++ b/packages/server/src/services/message.ts
@@ -269,7 +269,21 @@ export function preflightMessageSendIntent(input: {
     throw new BadRequestError(`Cannot route to "${label}" because the agent is ${participant.status}. ${recovery}`);
   }
 
-  const metadataToStore = mergedMentions.length > 0 ? { ...incomingMeta, mentions: mergedMentions } : incomingMeta;
+  // Persist the addressed live non-human agents — the real routed recipients.
+  // `mentions` only carries explicit @s / receiverNames, NOT the system
+  // `addressedToAgentIds` routing (e.g. the onboarding kickoff bootstrap), so a
+  // surface that needs to know who a turn actually awaits a reply from (the chat
+  // offline notice) can't rely on `mentions` alone. `routedRecipientIds` is the
+  // validated fan-out set; keep only its active non-human agents.
+  const addressedAgentIds = [...routedRecipientIds].filter((id) => {
+    const participant = participantsById.get(id);
+    return participant !== undefined && participant.type !== "human";
+  });
+  const metadataToStore = {
+    ...incomingMeta,
+    ...(mergedMentions.length > 0 ? { mentions: mergedMentions } : {}),
+    ...(addressedAgentIds.length > 0 ? { addressedAgentIds } : {}),
+  };
 
   if (data.format === MESSAGE_FORMATS.REQUEST) {
     const targetId = mergedMentions[0];

--- a/packages/web/src/app.tsx
+++ b/packages/web/src/app.tsx
@@ -66,6 +66,14 @@ const ComposeStatusBarPreviewPage = import.meta.env.DEV
     )
   : null;
 
+const ChatOfflineNoticePreviewPage = import.meta.env.DEV
+  ? lazy(() =>
+      import("./pages/chat-offline-notice-preview.js").then((module) => ({
+        default: module.ChatOfflineNoticePreviewPage,
+      })),
+    )
+  : null;
+
 const RequestDockPreviewPage = import.meta.env.DEV
   ? lazy(() =>
       import("./pages/request-dock-preview.js").then((module) => ({
@@ -163,6 +171,16 @@ export function App() {
                   element={
                     <Suspense fallback={null}>
                       <ComposeStatusBarPreviewPage />
+                    </Suspense>
+                  }
+                />
+              ) : null}
+              {ChatOfflineNoticePreviewPage ? (
+                <Route
+                  path="/preview/chat-offline-notice"
+                  element={
+                    <Suspense fallback={null}>
+                      <ChatOfflineNoticePreviewPage />
                     </Suspense>
                   }
                 />

--- a/packages/web/src/components/chat/__tests__/chat-offline-notice.test.tsx
+++ b/packages/web/src/components/chat/__tests__/chat-offline-notice.test.tsx
@@ -1,0 +1,141 @@
+// @vitest-environment happy-dom
+
+import { type AgentChatStatus, buildAgentChatStatus, type ChatParticipantDetail } from "@first-tree/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, type ReactElement } from "react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDomHarness, type DomHarness } from "../../../test-utils/dom-harness.js";
+
+vi.mock("../../../api/agent-status.js", () => ({
+  chatAgentStatusQueryKey: (chatId: string) => ["chat-agent-status", chatId],
+  fetchChatAgentStatuses: vi.fn(() => Promise.resolve([])),
+}));
+
+// Imported after the mock is registered.
+import { ChatOfflineNotice, OfflineNotice } from "../chat-offline-notice.js";
+
+let h: DomHarness;
+let queryClient: QueryClient;
+let latestPath = "";
+
+function LocationProbe(): null {
+  latestPath = useLocation().pathname;
+  return null;
+}
+
+function render(ui: ReactElement): void {
+  h.render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={["/start"]}>
+        <LocationProbe />
+        <Routes>
+          <Route path="*" element={ui} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+const flush = (): Promise<void> => h.flush();
+const notice = (): Element | null => h.container.querySelector('[role="status"]');
+
+function agent(agentId: string, displayName: string): ChatParticipantDetail {
+  return {
+    agentId,
+    role: "member",
+    mode: "auto",
+    joinedAt: "2026-01-01T00:00:00.000Z",
+    name: displayName,
+    displayName,
+    type: "agent",
+    avatarColorToken: null,
+    avatarImageUrl: null,
+  };
+}
+
+/** A reachable agent → derived `main` is anything but "offline". */
+function onlineStatus(agentId: string): AgentChatStatus {
+  return buildAgentChatStatus({ agentId, reachable: true, errored: false, working: false, engagement: "active" });
+}
+
+const ARIA = agent("a1", "Aria");
+
+beforeEach(() => {
+  h = createDomHarness();
+  queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Number.POSITIVE_INFINITY } },
+  });
+  latestPath = "";
+});
+
+afterEach(() => {
+  h.cleanup();
+  vi.useRealTimers();
+});
+
+describe("OfflineNotice (presentational)", () => {
+  it("starting phase shows a coming-online line with no action", async () => {
+    let clicks = 0;
+    render(<OfflineNotice phase="starting" agentName="Aria" onReconnect={() => clicks++} />);
+    await flush();
+    expect(notice()?.textContent).toContain("Aria is coming online");
+    expect(h.container.querySelector("button")).toBeNull();
+    expect(clicks).toBe(0);
+  });
+
+  it("offline phase invites a queued task and exposes a working Reconnect", async () => {
+    let clicks = 0;
+    render(<OfflineNotice phase="offline" agentName="Aria" onReconnect={() => clicks++} />);
+    await flush();
+    expect(notice()?.textContent).toContain("anything you send will start once its computer reconnects");
+    const btn = h.container.querySelector<HTMLButtonElement>("button");
+    expect(btn?.textContent).toContain("Reconnect");
+    await act(async () => {
+      btn?.click();
+      await Promise.resolve();
+    });
+    expect(clicks).toBe(1);
+  });
+});
+
+describe("ChatOfflineNotice (container)", () => {
+  it("renders nothing when not awaiting a reply", async () => {
+    queryClient.setQueryData(["chat-agent-status", "c1"], []);
+    render(<ChatOfflineNotice chatId="c1" agents={[ARIA]} awaitingReply={false} />);
+    await flush();
+    expect(notice()).toBeNull();
+  });
+
+  it("renders nothing when the awaited agent is online", async () => {
+    queryClient.setQueryData(["chat-agent-status", "c1"], [onlineStatus("a1")]);
+    render(<ChatOfflineNotice chatId="c1" agents={[ARIA]} awaitingReply={true} />);
+    await flush();
+    expect(notice()).toBeNull();
+  });
+
+  it("holds 'coming online' during the grace window, then escalates to offline + reconnect", async () => {
+    vi.useFakeTimers();
+    // No status row for the agent → treated as offline (a freshly-created agent
+    // that hasn't reported in is exactly the case we surface).
+    queryClient.setQueryData(["chat-agent-status", "c1"], []);
+    render(<ChatOfflineNotice chatId="c1" agents={[ARIA]} awaitingReply={true} />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(notice()?.textContent).toContain("Aria is coming online");
+
+    await act(async () => {
+      vi.advanceTimersByTime(8100);
+      await Promise.resolve();
+    });
+    expect(notice()?.textContent).toContain("anything you send will start");
+
+    const btn = h.container.querySelector<HTMLButtonElement>("button");
+    await act(async () => {
+      btn?.click();
+      await Promise.resolve();
+    });
+    expect(latestPath).toBe("/settings/computers");
+  });
+});

--- a/packages/web/src/components/chat/__tests__/chat-offline-notice.test.tsx
+++ b/packages/web/src/components/chat/__tests__/chat-offline-notice.test.tsx
@@ -14,7 +14,7 @@ vi.mock("../../../api/agent-status.js", () => ({
 }));
 
 // Imported after the mock is registered.
-import { ChatOfflineNotice, OfflineNotice } from "../chat-offline-notice.js";
+import { awaitedAgentsFromMessage, ChatOfflineNotice, OfflineNotice } from "../chat-offline-notice.js";
 
 let h: DomHarness;
 let queryClient: QueryClient;
@@ -59,6 +59,24 @@ const status = (agentId: string, reachable: boolean): AgentChatStatus =>
   buildAgentChatStatus({ agentId, reachable, errored: false, working: false, engagement: "active" });
 
 const ARIA = agent("a1", "Aria");
+
+describe("awaitedAgentsFromMessage", () => {
+  it("returns the routed non-human agents (addressedAgentIds intersect chat agents)", () => {
+    const bee = agent("b", "Bee");
+    expect(awaitedAgentsFromMessage({ addressedAgentIds: ["a1"] }, [ARIA, bee])).toEqual([ARIA]);
+  });
+  it("covers the onboarding bootstrap (systemSender + addressedAgentIds, no mentions)", () => {
+    const meta = { systemSender: "first_tree_onboarding", addressedAgentIds: ["a1"] };
+    expect(awaitedAgentsFromMessage(meta, [ARIA])).toEqual([ARIA]);
+  });
+  it("returns [] when no agent was routed (empty / missing metadata)", () => {
+    expect(awaitedAgentsFromMessage({}, [ARIA])).toEqual([]);
+    expect(awaitedAgentsFromMessage(undefined, [ARIA])).toEqual([]);
+  });
+  it("ignores addressed ids that are not chat agents", () => {
+    expect(awaitedAgentsFromMessage({ addressedAgentIds: ["ghost"] }, [ARIA])).toEqual([]);
+  });
+});
 
 beforeEach(() => {
   h = createDomHarness();

--- a/packages/web/src/components/chat/__tests__/chat-offline-notice.test.tsx
+++ b/packages/web/src/components/chat/__tests__/chat-offline-notice.test.tsx
@@ -7,9 +7,10 @@ import { MemoryRouter, Route, Routes, useLocation } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDomHarness, type DomHarness } from "../../../test-utils/dom-harness.js";
 
+const mocks = vi.hoisted(() => ({ fetchChatAgentStatuses: vi.fn() }));
 vi.mock("../../../api/agent-status.js", () => ({
   chatAgentStatusQueryKey: (chatId: string) => ["chat-agent-status", chatId],
-  fetchChatAgentStatuses: vi.fn(() => Promise.resolve([])),
+  fetchChatAgentStatuses: mocks.fetchChatAgentStatuses,
 }));
 
 // Imported after the mock is registered.
@@ -54,10 +55,8 @@ function agent(agentId: string, displayName: string): ChatParticipantDetail {
   };
 }
 
-/** A reachable agent → derived `main` is anything but "offline". */
-function onlineStatus(agentId: string): AgentChatStatus {
-  return buildAgentChatStatus({ agentId, reachable: true, errored: false, working: false, engagement: "active" });
-}
+const status = (agentId: string, reachable: boolean): AgentChatStatus =>
+  buildAgentChatStatus({ agentId, reachable, errored: false, working: false, engagement: "active" });
 
 const ARIA = agent("a1", "Aria");
 
@@ -67,6 +66,7 @@ beforeEach(() => {
     defaultOptions: { queries: { retry: false, staleTime: Number.POSITIVE_INFINITY } },
   });
   latestPath = "";
+  mocks.fetchChatAgentStatuses.mockReset().mockResolvedValue([]);
 });
 
 afterEach(() => {
@@ -100,26 +100,33 @@ describe("OfflineNotice (presentational)", () => {
 });
 
 describe("ChatOfflineNotice (container)", () => {
-  it("renders nothing when not awaiting a reply", async () => {
-    queryClient.setQueryData(["chat-agent-status", "c1"], []);
-    render(<ChatOfflineNotice chatId="c1" agents={[ARIA]} awaitingReply={false} />);
+  it("renders nothing when no agent is awaited this turn", async () => {
+    queryClient.setQueryData(["chat-agent-status", "c1"], [status("a1", false)]);
+    render(<ChatOfflineNotice chatId="c1" agents={[]} />);
     await flush();
     expect(notice()).toBeNull();
   });
 
   it("renders nothing when the awaited agent is online", async () => {
-    queryClient.setQueryData(["chat-agent-status", "c1"], [onlineStatus("a1")]);
-    render(<ChatOfflineNotice chatId="c1" agents={[ARIA]} awaitingReply={true} />);
+    queryClient.setQueryData(["chat-agent-status", "c1"], [status("a1", true)]);
+    render(<ChatOfflineNotice chatId="c1" agents={[ARIA]} />);
+    await flush();
+    expect(notice()).toBeNull();
+  });
+
+  it("does not read a still-loading status query as offline (no premature notice)", async () => {
+    // queryFn pending → not isSuccess → must not flash "coming online" on a chat
+    // whose agent may well be online (R2).
+    mocks.fetchChatAgentStatuses.mockReturnValue(new Promise<AgentChatStatus[]>(() => {}));
+    render(<ChatOfflineNotice chatId="c-loading" agents={[ARIA]} />);
     await flush();
     expect(notice()).toBeNull();
   });
 
   it("holds 'coming online' during the grace window, then escalates to offline + reconnect", async () => {
     vi.useFakeTimers();
-    // No status row for the agent → treated as offline (a freshly-created agent
-    // that hasn't reported in is exactly the case we surface).
-    queryClient.setQueryData(["chat-agent-status", "c1"], []);
-    render(<ChatOfflineNotice chatId="c1" agents={[ARIA]} awaitingReply={true} />);
+    queryClient.setQueryData(["chat-agent-status", "c1"], [status("a1", false)]); // explicit offline row
+    render(<ChatOfflineNotice chatId="c1" agents={[ARIA]} />);
     await act(async () => {
       await Promise.resolve();
     });

--- a/packages/web/src/components/chat/chat-offline-notice.tsx
+++ b/packages/web/src/components/chat/chat-offline-notice.tsx
@@ -67,36 +67,35 @@ export function OfflineNotice({
  * happens). Rendered where the agent's reply would appear, it names the state
  * and routes to the one action that fixes it: reconnect the computer.
  *
- * Shown only when (a) a non-human agent in this chat is offline AND (b) the user
- * is awaiting its reply (the latest turn isn't the agent's) — so a finished chat
- * whose agent later sleeps stays quiet. General to any chat, not onboarding-only.
+ * `agents` are the non-human agents THIS turn awaits a reply from — the caller
+ * derives them from the latest message's structured routing (metadata.mentions),
+ * not a sender heuristic, so a group chat never flags an offline agent the latest
+ * message didn't address. General to any chat, not onboarding-only.
  */
 export function ChatOfflineNotice({
   chatId,
   agents,
-  awaitingReply,
 }: {
   chatId: string;
-  /** Non-human agent participants of this chat. */
+  /** Non-human agents this turn is awaiting a reply from (routing-derived). */
   agents: ChatParticipantDetail[];
-  /** True when the latest turn is not the agent's, i.e. a reply is expected. */
-  awaitingReply: boolean;
 }) {
   const navigate = useNavigate();
-  const enabled = awaitingReply && agents.length > 0;
-  const { data: statuses } = useQuery({
+  const enabled = agents.length > 0;
+  const { data: statuses, isSuccess } = useQuery({
     queryKey: chatAgentStatusQueryKey(chatId),
     queryFn: () => fetchChatAgentStatuses(chatId),
     refetchInterval: 30_000, // safety net; admin-WS invalidation is the live path
     enabled,
   });
 
+  // Only interpret status once the query has SUCCEEDED: a not-yet-loaded query
+  // must not read as "offline" (that would flash "coming online" → reconnect on a
+  // normal online-agent chat open). The /agent-status contract returns a row for
+  // every non-human speaker (an unbound agent is main:"offline"), so a real
+  // offline agent is an explicit "offline" row, not a missing one.
   const byAgent = new Map<string, AgentChatStatus>((statuses ?? []).map((s) => [s.agentId, s]));
-  // An agent with no status row yet is treated as offline: a freshly-created
-  // agent that hasn't reported in is exactly the case we want to surface.
-  const offlineAgent = enabled
-    ? agents.find((a) => (byAgent.get(a.agentId)?.main ?? "offline") === "offline")
-    : undefined;
+  const offlineAgent = isSuccess ? agents.find((a) => byAgent.get(a.agentId)?.main === "offline") : undefined;
   const offlineAgentId = offlineAgent?.agentId ?? null;
 
   // Local grace timer: hold "coming online" briefly, then escalate. Re-armed

--- a/packages/web/src/components/chat/chat-offline-notice.tsx
+++ b/packages/web/src/components/chat/chat-offline-notice.tsx
@@ -13,6 +13,25 @@ const STARTING_GRACE_MS = 8_000;
 export type OfflineNoticePhase = "starting" | "offline";
 
 /**
+ * The non-human agents a turn awaits a reply from: the latest message's persisted
+ * routed recipients (`metadata.addressedAgentIds` — the active non-human agents
+ * the server actually routed it to, including system `addressedToAgentIds` such
+ * as the onboarding kickoff bootstrap, which carries no `mentions`), intersected
+ * with the chat's non-human participants. Routing-derived, never a sender
+ * heuristic, so a group chat never flags an offline agent the latest turn did
+ * not address.
+ */
+export function awaitedAgentsFromMessage(
+  latestMessageMeta: Record<string, unknown> | null | undefined,
+  nonHumanAgents: ChatParticipantDetail[],
+): ChatParticipantDetail[] {
+  const raw = latestMessageMeta?.addressedAgentIds;
+  const ids = Array.isArray(raw) ? raw.filter((x): x is string => typeof x === "string") : [];
+  if (ids.length === 0) return [];
+  return nonHumanAgents.filter((a) => ids.includes(a.agentId));
+}
+
+/**
  * Presentational inline notice (no data deps) — exported so the DEV preview and
  * tests render both phases directly. `starting` holds the hopeful framing during
  * the grace window; `offline` escalates to the reconnect action.

--- a/packages/web/src/components/chat/chat-offline-notice.tsx
+++ b/packages/web/src/components/chat/chat-offline-notice.tsx
@@ -1,0 +1,121 @@
+import type { AgentChatStatus, ChatParticipantDetail } from "@first-tree/shared";
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router";
+import { chatAgentStatusQueryKey, fetchChatAgentStatuses } from "../../api/agent-status.js";
+
+// Hold the hopeful "coming online" framing this long before escalating to the
+// reconnect action. A just-created agent (onboarding's first chat) or a
+// momentarily-dropped one usually binds within a few seconds, so we only frame
+// it as "needs reconnect" once it is genuinely overdue.
+const STARTING_GRACE_MS = 8_000;
+
+export type OfflineNoticePhase = "starting" | "offline";
+
+/**
+ * Presentational inline notice (no data deps) — exported so the DEV preview and
+ * tests render both phases directly. `starting` holds the hopeful framing during
+ * the grace window; `offline` escalates to the reconnect action.
+ */
+export function OfflineNotice({
+  phase,
+  agentName,
+  onReconnect,
+}: {
+  phase: OfflineNoticePhase;
+  agentName: string;
+  onReconnect: () => void;
+}) {
+  return (
+    <div className="flex justify-center" style={{ margin: "var(--sp-2) 0 var(--sp-1)" }}>
+      <div
+        role="status"
+        className="text-caption inline-flex items-center"
+        style={{
+          gap: "var(--sp-2)",
+          padding: "var(--sp-1_75) var(--sp-3)",
+          borderRadius: "var(--radius-input)",
+          background: "var(--bg-sunken)",
+          color: "var(--fg-3)",
+        }}
+      >
+        {phase === "offline" ? (
+          <>
+            <span>{`${agentName} is offline — anything you send will start once its computer reconnects.`}</span>
+            <button
+              type="button"
+              className="font-medium underline underline-offset-2 shrink-0"
+              style={{ color: "var(--primary)" }}
+              onClick={onReconnect}
+            >
+              Reconnect
+            </button>
+          </>
+        ) : (
+          <span>{`${agentName} is coming online…`}</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Inline timeline notice for "you're waiting on an agent whose runtime is
+ * offline". Most visible in onboarding's first chat: a just-created agent that
+ * never comes online would otherwise leave a silent, dead chat — no sign the
+ * agent is offline, no way out (the agent IS the product, so offline = nothing
+ * happens). Rendered where the agent's reply would appear, it names the state
+ * and routes to the one action that fixes it: reconnect the computer.
+ *
+ * Shown only when (a) a non-human agent in this chat is offline AND (b) the user
+ * is awaiting its reply (the latest turn isn't the agent's) — so a finished chat
+ * whose agent later sleeps stays quiet. General to any chat, not onboarding-only.
+ */
+export function ChatOfflineNotice({
+  chatId,
+  agents,
+  awaitingReply,
+}: {
+  chatId: string;
+  /** Non-human agent participants of this chat. */
+  agents: ChatParticipantDetail[];
+  /** True when the latest turn is not the agent's, i.e. a reply is expected. */
+  awaitingReply: boolean;
+}) {
+  const navigate = useNavigate();
+  const enabled = awaitingReply && agents.length > 0;
+  const { data: statuses } = useQuery({
+    queryKey: chatAgentStatusQueryKey(chatId),
+    queryFn: () => fetchChatAgentStatuses(chatId),
+    refetchInterval: 30_000, // safety net; admin-WS invalidation is the live path
+    enabled,
+  });
+
+  const byAgent = new Map<string, AgentChatStatus>((statuses ?? []).map((s) => [s.agentId, s]));
+  // An agent with no status row yet is treated as offline: a freshly-created
+  // agent that hasn't reported in is exactly the case we want to surface.
+  const offlineAgent = enabled
+    ? agents.find((a) => (byAgent.get(a.agentId)?.main ?? "offline") === "offline")
+    : undefined;
+  const offlineAgentId = offlineAgent?.agentId ?? null;
+
+  // Local grace timer: hold "coming online" briefly, then escalate. Re-armed
+  // whenever the awaited offline agent changes (or clears).
+  const [graceElapsed, setGraceElapsed] = useState(false);
+  useEffect(() => {
+    setGraceElapsed(false);
+    if (!offlineAgentId) return;
+    const timer = window.setTimeout(() => setGraceElapsed(true), STARTING_GRACE_MS);
+    return () => window.clearTimeout(timer);
+  }, [offlineAgentId]);
+
+  if (!offlineAgent) return null;
+
+  return (
+    <OfflineNotice
+      phase={graceElapsed ? "offline" : "starting"}
+      agentName={offlineAgent.displayName}
+      onReconnect={() => navigate("/settings/computers")}
+    />
+  );
+}

--- a/packages/web/src/pages/chat-offline-notice-preview.tsx
+++ b/packages/web/src/pages/chat-offline-notice-preview.tsx
@@ -1,0 +1,79 @@
+import { useEffect } from "react";
+import { OfflineNotice, type OfflineNoticePhase } from "../components/chat/chat-offline-notice.js";
+
+/**
+ * DEV-only visual review for `ChatOfflineNotice` — the inline timeline notice
+ * shown when you're awaiting a reply from an agent whose runtime is offline
+ * (onboarding's "unanswered first chat" safety net, but general to any chat).
+ *
+ * The two phases of the production component are rendered directly via its
+ * presentational `OfflineNotice`, inside a timeline-column mimic so placement
+ * reads true. No backend / no auth — same DEV-only gating as the sibling
+ * previews in `app.tsx`. Append `?theme=dark` to flip the theme.
+ */
+const VARIANTS: { name: string; subtitle: string; phase: OfflineNoticePhase }[] = [
+  {
+    name: "phase 1 · starting (grace window)",
+    subtitle: "hopeful framing during a normal cold start — no action yet",
+    phase: "starting",
+  },
+  {
+    name: "phase 2 · offline (escalated)",
+    subtitle: "agent overdue → leaving a task still works (it queues); reconnect to run it",
+    phase: "offline",
+  },
+];
+
+export function ChatOfflineNoticePreviewPage() {
+  const params = typeof window !== "undefined" ? new URLSearchParams(window.location.search) : new URLSearchParams();
+  const themeOverride = params.get("theme");
+  useEffect(() => {
+    if (themeOverride === "light" || themeOverride === "dark") {
+      document.documentElement.classList.toggle("dark", themeOverride === "dark");
+    }
+  }, [themeOverride]);
+
+  return (
+    <div style={{ background: "var(--bg)", minHeight: "100vh", padding: "var(--sp-6)" }}>
+      <div style={{ maxWidth: "clamp(40rem, 75%, 62rem)", margin: "0 auto" }}>
+        <h1 className="text-title" style={{ color: "var(--fg-2)", marginBottom: "var(--sp-1)" }}>
+          ChatOfflineNotice — waiting on an offline agent
+        </h1>
+        <p className="text-body" style={{ color: "var(--fg-3)", marginBottom: "var(--sp-6)" }}>
+          DEV preview. Inline timeline notice (option A): when a reply is due from an agent whose runtime is offline, it
+          surfaces where the reply would appear and routes to reconnect. Append <code>?theme=dark</code> to flip the
+          theme.
+        </p>
+        <div className="flex flex-col" style={{ gap: "var(--sp-6)" }}>
+          {VARIANTS.map((v) => (
+            <section key={v.phase} className="flex flex-col" style={{ gap: "var(--sp-2)" }}>
+              <div>
+                <div className="text-label" style={{ color: "var(--fg-2)" }}>
+                  {v.name}
+                </div>
+                <div className="text-caption" style={{ color: "var(--fg-4)" }}>
+                  {v.subtitle}
+                </div>
+              </div>
+              {/* Timeline-column mimic: a stand-in opening turn above so the
+                  notice reads as sitting where the agent's reply would appear. */}
+              <div
+                style={{
+                  padding: "var(--sp-2_5) var(--sp-6)",
+                  background: "var(--bg)",
+                  border: "var(--hairline) solid var(--border)",
+                  borderRadius: "var(--radius-input)",
+                }}
+              >
+                <div className="text-body" style={{ color: "var(--fg-2)", paddingBottom: "var(--sp-2)" }}>
+                  First Tree · Welcome! Your agent will greet you here with a few first tasks to pick from.
+                </div>
+                <OfflineNotice phase={v.phase} agentName="gandy-assistant" onReconnect={() => undefined} />
+              </div>
+            </section>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -75,7 +75,7 @@ import { AddParticipantDropdown } from "../../../components/add-participant-drop
 import { Avatar as RealAvatar } from "../../../components/avatar.js";
 import { AgentHovercard } from "../../../components/chat/agent-hovercard.js";
 import { AskTakeover } from "../../../components/chat/ask-takeover.js";
-import { ChatOfflineNotice } from "../../../components/chat/chat-offline-notice.js";
+import { awaitedAgentsFromMessage, ChatOfflineNotice } from "../../../components/chat/chat-offline-notice.js";
 import { ComposeStatusBar } from "../../../components/chat/compose-status-bar.js";
 import {
   FIRST_TREE_SYSTEM_SENDER_NAME,
@@ -935,17 +935,15 @@ const ChatTimeline = memo(function ChatTimeline({
   pillCount,
   onPillClick,
 }: ChatTimelineProps) {
-  // Which non-human agents this turn awaits a reply from: the latest message's
-  // structured routing (metadata.mentions) intersected with the chat's agents.
-  // mentions is the canonical recipient set (the composer + addressedToAgentIds
-  // both write it, incl. the onboarding kickoff bootstrap), so we never flag an
-  // offline agent the latest turn didn't address; a 2-speaker direct chat carries
-  // the peer in mentions too, so no sender heuristic is needed.
+  // Which non-human agents this turn awaits a reply from — routing-derived from
+  // the latest message's persisted recipients (metadata.addressedAgentIds, which
+  // includes the system addressedToAgentIds routing the onboarding bootstrap uses
+  // but `mentions` omits). See awaitedAgentsFromMessage.
   const lastMessageItem = [...visibleItems].reverse().find((it) => it.kind === "message");
-  // `metadata` is an open record, so narrow `mentions` to string[] before use.
-  const rawMentions = lastMessageItem?.kind === "message" ? lastMessageItem.data.metadata?.mentions : undefined;
-  const lastMentions = Array.isArray(rawMentions) ? rawMentions.filter((m): m is string => typeof m === "string") : [];
-  const awaitedAgents = agents.filter((a) => lastMentions.includes(a.agentId));
+  const awaitedAgents = awaitedAgentsFromMessage(
+    lastMessageItem?.kind === "message" ? lastMessageItem.data.metadata : undefined,
+    agents,
+  );
   return (
     <div className="relative flex-1 flex flex-col min-h-0">
       <div ref={scrollContainerRef} className="flex-1 overflow-y-auto" style={{ padding: "var(--sp-2_5) var(--sp-6)" }}>

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -935,12 +935,17 @@ const ChatTimeline = memo(function ChatTimeline({
   pillCount,
   onPillClick,
 }: ChatTimelineProps) {
-  // Are we waiting on an agent's reply? True when the latest message isn't an
-  // agent's — so the inline offline notice only surfaces when a reply is due.
-  const agentIds = new Set(agents.map((a) => a.agentId));
+  // Which non-human agents this turn awaits a reply from: the latest message's
+  // structured routing (metadata.mentions) intersected with the chat's agents.
+  // mentions is the canonical recipient set (the composer + addressedToAgentIds
+  // both write it, incl. the onboarding kickoff bootstrap), so we never flag an
+  // offline agent the latest turn didn't address; a 2-speaker direct chat carries
+  // the peer in mentions too, so no sender heuristic is needed.
   const lastMessageItem = [...visibleItems].reverse().find((it) => it.kind === "message");
-  const awaitingReply =
-    !!lastMessageItem && lastMessageItem.kind === "message" && !agentIds.has(lastMessageItem.data.senderId);
+  // `metadata` is an open record, so narrow `mentions` to string[] before use.
+  const rawMentions = lastMessageItem?.kind === "message" ? lastMessageItem.data.metadata?.mentions : undefined;
+  const lastMentions = Array.isArray(rawMentions) ? rawMentions.filter((m): m is string => typeof m === "string") : [];
+  const awaitedAgents = agents.filter((a) => lastMentions.includes(a.agentId));
   return (
     <div className="relative flex-1 flex flex-col min-h-0">
       <div ref={scrollContainerRef} className="flex-1 overflow-y-auto" style={{ padding: "var(--sp-2_5) var(--sp-6)" }}>
@@ -1033,7 +1038,7 @@ const ChatTimeline = memo(function ChatTimeline({
               </div>
             ) : null}
           </div>
-          <ChatOfflineNotice chatId={chatId} agents={agents} awaitingReply={awaitingReply} />
+          <ChatOfflineNotice chatId={chatId} agents={awaitedAgents} />
           <div ref={messagesEndRef} />
         </div>
       </div>

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -75,6 +75,7 @@ import { AddParticipantDropdown } from "../../../components/add-participant-drop
 import { Avatar as RealAvatar } from "../../../components/avatar.js";
 import { AgentHovercard } from "../../../components/chat/agent-hovercard.js";
 import { AskTakeover } from "../../../components/chat/ask-takeover.js";
+import { ChatOfflineNotice } from "../../../components/chat/chat-offline-notice.js";
 import { ComposeStatusBar } from "../../../components/chat/compose-status-bar.js";
 import {
   FIRST_TREE_SYSTEM_SENDER_NAME,
@@ -900,6 +901,9 @@ type ChatTimelineProps = {
   agentAvatarFn: (id: string) => string | null;
   agentColorTokenFn: (id: string) => string | null;
   myAgentId: string | null;
+  chatId: string;
+  /** Non-human agent participants — drives the inline offline notice. */
+  agents: ChatParticipantDetail[];
   mentionParticipants: MentionParticipant[];
   dockRequestId: string | undefined;
   gapAfterMessageId: string | null;
@@ -921,6 +925,8 @@ const ChatTimeline = memo(function ChatTimeline({
   agentAvatarFn,
   agentColorTokenFn,
   myAgentId,
+  chatId,
+  agents,
   mentionParticipants,
   dockRequestId,
   gapAfterMessageId,
@@ -929,6 +935,12 @@ const ChatTimeline = memo(function ChatTimeline({
   pillCount,
   onPillClick,
 }: ChatTimelineProps) {
+  // Are we waiting on an agent's reply? True when the latest message isn't an
+  // agent's — so the inline offline notice only surfaces when a reply is due.
+  const agentIds = new Set(agents.map((a) => a.agentId));
+  const lastMessageItem = [...visibleItems].reverse().find((it) => it.kind === "message");
+  const awaitingReply =
+    !!lastMessageItem && lastMessageItem.kind === "message" && !agentIds.has(lastMessageItem.data.senderId);
   return (
     <div className="relative flex-1 flex flex-col min-h-0">
       <div ref={scrollContainerRef} className="flex-1 overflow-y-auto" style={{ padding: "var(--sp-2_5) var(--sp-6)" }}>
@@ -1021,6 +1033,7 @@ const ChatTimeline = memo(function ChatTimeline({
               </div>
             ) : null}
           </div>
+          <ChatOfflineNotice chatId={chatId} agents={agents} awaitingReply={awaitingReply} />
           <div ref={messagesEndRef} />
         </div>
       </div>
@@ -3329,6 +3342,8 @@ export function ChatView({
             agentAvatarFn={agentAvatar}
             agentColorTokenFn={agentColorToken}
             myAgentId={myAgentId}
+            chatId={chatId}
+            agents={(chatDetail?.participants ?? []).filter((p) => p.type !== "human")}
             mentionParticipants={renderMentionParticipants}
             dockRequestId={dockRequestId}
             gapAfterMessageId={gapAfterMessageId}


### PR DESCRIPTION
## What & why

When you're awaiting a reply from an agent whose runtime is **offline**, the chat left a silent, dead timeline — no sign the agent was offline, no way out. Most visibly this is onboarding's **"unanswered first chat"**: a just-created agent that never comes online. The agent *is* the product, so offline = nothing happens — and the only existing offline indicator lived in the right rail, which **defaults closed for a new user**.

This is the **chat-side layer** of the three-layer fix for that root cause (companion to the runtime config-fetch retry #1239 and the create-agent timing reframe #1238).

## Changes

An inline notice rendered **where the agent's reply would appear**, shown only when a non-human agent in the chat is offline **AND** a reply is due (the latest turn isn't the agent's) — so a finished chat whose agent later sleeps stays quiet. General to any chat, not onboarding-only.

- A grace window holds a hopeful **"&lt;agent&gt; is coming online…"** for a normal cold start, then escalates to **"&lt;agent&gt; is offline — anything you send will start once its computer reconnects."** with a **Reconnect** action (→ Settings · Computers).
- **Leave a task while offline:** the composer is already usable when the agent is offline (its disable is membership-based, not presence), so the user can type their first task now; the durable inbox queues it and the agent runs it on reconnect. The notice copy makes that explicit, so it doubles as the "queued" confirmation **without a redundant badge**.
- Split into a presentational `OfflineNotice` + a `ChatOfflineNotice` container, so both phases are unit-tested and DEV-previewable at `/preview/chat-offline-notice`.

## Verification

- `pnpm --filter @first-tree/web typecheck` (tsc + lint:tokens) clean · `biome` clean · `pnpm --filter @first-tree/web test` → **980 passed** (incl. 5 new: phase rendering, trigger gating, grace→escalate→navigate).
- Visually reviewed both phases in the DEV preview, light + dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)