### PR TITLE
fix(web): update context tree settings states

### DIFF
--- a/packages/web/src/components/ui/tab-bar.tsx
+++ b/packages/web/src/components/ui/tab-bar.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, type HTMLAttributes, type ReactNode } from "react";
+import { type ButtonHTMLAttributes, forwardRef, type HTMLAttributes, type ReactNode } from "react";
 import { cn } from "../../lib/utils.js";
 
 // Workspace-style underline tab bar.
@@ -43,13 +43,17 @@ type TabProps = {
   /** Shows a neutral "unsaved changes" dot after the label. */
   dirty?: boolean;
   className?: string;
-} & Pick<HTMLAttributes<HTMLButtonElement>, "role" | "aria-selected" | "aria-controls" | "id">;
+} & Pick<
+  ButtonHTMLAttributes<HTMLButtonElement>,
+  "role" | "aria-selected" | "aria-controls" | "aria-disabled" | "disabled" | "id" | "title"
+>;
 
-export function Tab({ active, onClick, children, dirty, className, ...rest }: TabProps) {
+export function Tab({ active, onClick, children, dirty, className, disabled, ...rest }: TabProps) {
   return (
     <button
       type="button"
       onClick={onClick}
+      disabled={disabled}
       className={cn(
         // No border-radius: the active state is a straight bottom border, and a
         // corner radius would bow its ends upward into little hooks.
@@ -60,15 +64,15 @@ export function Tab({ active, onClick, children, dirty, className, ...rest }: Ta
         padding: "var(--sp-1_75) var(--sp-3)",
         marginBottom: -1,
         borderBottom: `var(--hairline-bold) solid ${active ? "var(--primary)" : "transparent"}`,
-        color: active ? "var(--fg)" : "var(--fg-3)",
-        cursor: "pointer",
+        color: disabled ? "var(--fg-4)" : active ? "var(--fg)" : "var(--fg-3)",
+        cursor: disabled ? "not-allowed" : "pointer",
         transition: "color 0.12s",
       }}
       onMouseEnter={(e) => {
-        if (!active) e.currentTarget.style.color = "var(--fg)";
+        if (!active && !disabled) e.currentTarget.style.color = "var(--fg)";
       }}
       onMouseLeave={(e) => {
-        if (!active) e.currentTarget.style.color = "var(--fg-3)";
+        if (!active && !disabled) e.currentTarget.style.color = "var(--fg-3)";
       }}
       {...rest}
     >

--- a/packages/web/src/pages/__tests__/settings-panels-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/settings-panels-dom.test.tsx
@@ -372,19 +372,21 @@ describe("settings panels", () => {
     await act(async () => failed.root.unmount());
   });
 
-  it("renders context tree tabs and keeps manual settings hidden by default", async () => {
+  it("renders configured context tree settings directly", async () => {
     const { ContextTreeSettingsPanel } = await import("../context-tree-settings-panel.js");
     const { container, root } = await renderPanel(<ContextTreeSettingsPanel />);
-    await waitForText(container, "Manual Set");
+    await waitForText(container, "Repo URL");
 
     const tabs = container.querySelectorAll<HTMLButtonElement>('[role="tab"]');
     expect([...tabs].map((tab) => tab.textContent?.trim())).toEqual(["Initial", "Features"]);
     expect(tabs[0]?.getAttribute("aria-selected")).toBe("true");
     expect(tabs[1]?.getAttribute("aria-selected")).toBe("false");
-    expect(container.textContent).toContain("Connect your code & build your Context Tree");
-    expect(inputByLabel(container, "Manual Set")?.checked).toBe(false);
-    expect(container.textContent).not.toContain("Repo URL");
-    expect(container.textContent).not.toContain("Branch");
+    expect(tabs[1]?.disabled).toBe(false);
+    expect(tabs[1]?.getAttribute("aria-disabled")).toBeNull();
+    expect(container.textContent).not.toContain("Connect your code & build your Context Tree");
+    expect(container.textContent).not.toContain("Manual Set");
+    expect(inputByLabel(container, "Repo URL")?.value).toBe("https://github.com/acme/context");
+    expect(inputByLabel(container, "Branch")?.value).toBe("main");
 
     await act(async () => root.unmount());
   });
@@ -392,9 +394,6 @@ describe("settings panels", () => {
   it("shows and saves manual context tree settings with blank values normalized to null", async () => {
     const { ContextTreeSettingsPanel } = await import("../context-tree-settings-panel.js");
     const { container, root } = await renderPanel(<ContextTreeSettingsPanel />);
-    await waitForText(container, "Manual Set");
-
-    await click(inputByLabel(container, "Manual Set"));
     await waitForText(container, "Repo URL");
 
     const repoInput = inputByLabel(container, "Repo URL");
@@ -430,6 +429,13 @@ describe("settings panels", () => {
     expect(container.textContent).toContain("Manual Set");
     expect(container.textContent).not.toContain("Repo URL");
     expect(container.textContent).not.toContain("Branch");
+    const featuresTab = buttonByText(container, "Features");
+    expect(featuresTab?.disabled).toBe(true);
+    expect(featuresTab?.getAttribute("aria-disabled")).toBe("true");
+    await click(featuresTab);
+    expect(buttonByText(container, "Initial")?.getAttribute("aria-selected")).toBe("true");
+    expect(buttonByText(container, "Features")?.getAttribute("aria-selected")).toBe("false");
+    expect(container.textContent).not.toContain("Context Reviewer");
     // No raw "create private repo" button, and the panel no longer initializes
     // the tree in place — that's the /build-tree flow's job now.
     expect(container.textContent).not.toContain("Create private GitHub repo");
@@ -446,14 +452,13 @@ describe("settings panels", () => {
     const { ContextTreeSettingsPanel } = await import("../context-tree-settings-panel.js");
     authMock.value = { ...authMock.value, role: "member" };
     const { container, root } = await renderPanel(<ContextTreeSettingsPanel />);
-    await waitForText(container, "Manual Set");
-    await click(inputByLabel(container, "Manual Set"));
     await waitForText(container, "Repo URL");
 
     expect(inputByLabel(container, "Repo URL")?.hasAttribute("readonly")).toBe(true);
     expect(inputByLabel(container, "Branch")?.hasAttribute("readonly")).toBe(true);
     // No Save affordance for members.
     expect(container.querySelector('button[type="submit"]')).toBeNull();
+    expect(container.textContent).not.toContain("Manual Set");
     await act(async () => root.unmount());
   });
 
@@ -464,15 +469,13 @@ describe("settings panels", () => {
     const { container, root } = await renderPanel(<ContextTreeSettingsPanel />);
     await waitForText(container, "Ask an admin to initialize");
     expect(container.textContent).not.toContain("Create private GitHub repo");
+    expect(container.textContent).toContain("Manual Set");
     await act(async () => root.unmount());
   });
 
   it("renders Context Reviewer settings without resetting manual draft values", async () => {
     const { ContextTreeSettingsPanel } = await import("../context-tree-settings-panel.js");
     const { container, root } = await renderPanel(<ContextTreeSettingsPanel />);
-    await waitForText(container, "Manual Set");
-
-    await click(inputByLabel(container, "Manual Set"));
     await waitForText(container, "Repo URL");
     const repoInput = inputByLabel(container, "Repo URL");
     if (!repoInput) throw new Error("Expected repo input");
@@ -498,7 +501,7 @@ describe("settings panels", () => {
   it("saves disabled Context Reviewer as disabled/null", async () => {
     const { ContextTreeSettingsPanel } = await import("../context-tree-settings-panel.js");
     const { container, root } = await renderPanel(<ContextTreeSettingsPanel />);
-    await waitForText(container, "Manual Set");
+    await waitForText(container, "Repo URL");
 
     await click(buttonByText(container, "Features"));
     await waitForText(container, "Context Reviewer is disabled.");
@@ -515,7 +518,7 @@ describe("settings panels", () => {
   it("enables Context Reviewer, filters eligible agents, and saves the selected agent", async () => {
     const { ContextTreeSettingsPanel } = await import("../context-tree-settings-panel.js");
     const { container, root } = await renderPanel(<ContextTreeSettingsPanel />);
-    await waitForText(container, "Manual Set");
+    await waitForText(container, "Repo URL");
 
     await click(buttonByText(container, "Features"));
     await waitForText(container, "Context Reviewer");
@@ -543,7 +546,7 @@ describe("settings panels", () => {
     );
     const { ContextTreeSettingsPanel } = await import("../context-tree-settings-panel.js");
     const { container, root } = await renderPanel(<ContextTreeSettingsPanel />);
-    await waitForText(container, "Manual Set");
+    await waitForText(container, "Repo URL");
 
     await click(buttonByText(container, "Features"));
     await waitForText(container, "Beta Reviewer");
@@ -560,7 +563,7 @@ describe("settings panels", () => {
     ]);
     const { ContextTreeSettingsPanel } = await import("../context-tree-settings-panel.js");
     const { container, root } = await renderPanel(<ContextTreeSettingsPanel />);
-    await waitForText(container, "Manual Set");
+    await waitForText(container, "Repo URL");
 
     await click(buttonByText(container, "Features"));
     await click(inputByLabel(container, "Context Reviewer"));
@@ -576,7 +579,7 @@ describe("settings panels", () => {
     );
     const { ContextTreeSettingsPanel } = await import("../context-tree-settings-panel.js");
     const { container, root } = await renderPanel(<ContextTreeSettingsPanel />);
-    await waitForText(container, "Manual Set");
+    await waitForText(container, "Repo URL");
 
     await click(buttonByText(container, "Features"));
     await waitForText(container, "Current reviewer is not your active agent.");
@@ -595,7 +598,7 @@ describe("settings panels", () => {
     const { ContextTreeSettingsPanel } = await import("../context-tree-settings-panel.js");
     authMock.value = { ...authMock.value, role: "member" };
     const { container, root } = await renderPanel(<ContextTreeSettingsPanel />);
-    await waitForText(container, "Manual Set");
+    await waitForText(container, "Repo URL");
 
     await click(buttonByText(container, "Features"));
     await waitForText(container, "Only admins can configure Context Reviewer.");

--- a/packages/web/src/pages/context-tree-settings-panel.tsx
+++ b/packages/web/src/pages/context-tree-settings-panel.tsx
@@ -51,6 +51,8 @@ export function ContextTreeSettingsPanel() {
   const [branch, setBranch] = useState("");
   const [saved, setSaved] = useState(false);
   const hasConfiguredRepo = !!settingQuery.data?.repo;
+  const shouldShowManualForm = hasConfiguredRepo || manualEnabled;
+  const featuresTabDisabled = !hasConfiguredRepo;
 
   const featuresQuery = useQuery({
     queryKey: ["org-setting", organizationId, "context_tree_features"],
@@ -97,6 +99,11 @@ export function ContextTreeSettingsPanel() {
     setRepo(settingQuery.data.repo ?? "");
     setBranch(settingQuery.data.branch ?? "main");
   }, [settingQuery.data]);
+
+  useEffect(() => {
+    if (!settingQuery.data || hasConfiguredRepo || activeTab !== "features") return;
+    setActiveTab("initial");
+  }, [activeTab, hasConfiguredRepo, settingQuery.data]);
 
   const mutation = useMutation({
     mutationFn: () => {
@@ -175,9 +182,14 @@ export function ContextTreeSettingsPanel() {
               id="context-tree-settings-features-tab"
               role="tab"
               aria-selected={activeTab === "features"}
+              aria-disabled={featuresTabDisabled ? "true" : undefined}
               aria-controls="context-tree-settings-features-panel"
               active={activeTab === "features"}
-              onClick={() => setActiveTab("features")}
+              disabled={featuresTabDisabled}
+              onClick={() => {
+                if (!featuresTabDisabled) setActiveTab("features");
+              }}
+              title={featuresTabDisabled ? "Initialize the Context Tree before configuring features." : undefined}
             >
               Features
             </Tab>
@@ -191,29 +203,33 @@ export function ContextTreeSettingsPanel() {
               style={{ paddingTop: "var(--sp-4)" }}
             >
               {isAdmin ? (
-                <div style={{ marginBottom: "var(--sp-4)" }}>
-                  {/* The team's tree is built via the /build-tree flow
-                      (connect code -> build -> seed). Manual settings below are
-                      only for pointing at an existing tree repo. */}
-                  <Button type="button" onClick={() => navigate("/build-tree")}>
-                    <span>{COPY.buildTree.buildCta}</span>
-                    <ArrowRight className="h-4 w-4" />
-                  </Button>
-                </div>
+                !hasConfiguredRepo ? (
+                  <div style={{ marginBottom: "var(--sp-4)" }}>
+                    {/* The team's tree is built via the /build-tree flow
+                        (connect code -> build -> seed). Manual settings below are
+                        only for pointing at an existing tree repo. */}
+                    <Button type="button" onClick={() => navigate("/build-tree")}>
+                      <span>{COPY.buildTree.buildCta}</span>
+                      <ArrowRight className="h-4 w-4" />
+                    </Button>
+                  </div>
+                ) : null
               ) : null}
               {!isAdmin && !hasConfiguredRepo ? (
                 <div className="text-body" style={{ color: "var(--fg-3)", marginBottom: "var(--sp-4)" }}>
                   Ask an admin to initialize this team's Context Tree.
                 </div>
               ) : null}
-              <label
-                className="text-body inline-flex items-center"
-                style={{ color: "var(--fg)", gap: "var(--sp-2)", marginBottom: "var(--sp-4)" }}
-              >
-                <input type="checkbox" checked={manualEnabled} onChange={(e) => setManualEnabled(e.target.checked)} />
-                <span>Manual Set</span>
-              </label>
-              {manualEnabled ? (
+              {!hasConfiguredRepo ? (
+                <label
+                  className="text-body inline-flex items-center"
+                  style={{ color: "var(--fg)", gap: "var(--sp-2)", marginBottom: "var(--sp-4)" }}
+                >
+                  <input type="checkbox" checked={manualEnabled} onChange={(e) => setManualEnabled(e.target.checked)} />
+                  <span>Manual Set</span>
+                </label>
+              ) : null}
+              {shouldShowManualForm ? (
                 <form onSubmit={handleSubmit}>
                   <SettingsField
                     label="Repo URL"


### PR DESCRIPTION
## Summary
- show the Context Tree repo/branch form directly when a repo is already configured
- keep the build-tree CTA and Manual Set entry only for uninitialized teams
- disable the Features tab until a Context Tree repo exists
- update settings panel DOM coverage for admin/member configured and unconfigured states

## Tests
- pnpm --filter @first-tree/web exec vitest run src/pages/__tests__/settings-panels-dom.test.tsx
- pnpm --filter @first-tree/web typecheck
- pnpm check

## Notes
- `pnpm typecheck` still fails in @first-tree/client due to existing Claude SDK error union mismatches unrelated to this web change.