### PR TITLE
feat: redesign multi-team switching and management

### DIFF
--- a/packages/web/src/app.tsx
+++ b/packages/web/src/app.tsx
@@ -104,6 +104,12 @@ const ChatSummaryPreviewPage = import.meta.env.DEV
   ? lazy(() => import("./pages/chat-summary-preview.js").then((module) => ({ default: module.ChatSummaryPreviewPage })))
   : null;
 
+const TeamSwitcherPreviewPage = import.meta.env.DEV
+  ? lazy(() =>
+      import("./pages/team-switcher-preview.js").then((module) => ({ default: module.TeamSwitcherPreviewPage })),
+    )
+  : null;
+
 // Living design-system reference (companion to DESIGN.md). Unlike the previews
 // above this ships in prod too, so it can be opened on a deployed URL — it has
 // no auth-gated data, only tokens and `components/ui` primitives.
@@ -193,6 +199,16 @@ export function App() {
                   element={
                     <Suspense fallback={null}>
                       <UserMenuPreviewPage />
+                    </Suspense>
+                  }
+                />
+              ) : null}
+              {TeamSwitcherPreviewPage ? (
+                <Route
+                  path="/preview/team-switcher"
+                  element={
+                    <Suspense fallback={null}>
+                      <TeamSwitcherPreviewPage />
                     </Suspense>
                   }
                 />

--- a/packages/web/src/auth/auth-context.tsx
+++ b/packages/web/src/auth/auth-context.tsx
@@ -1,4 +1,4 @@
-import type { MeMembership } from "@first-tree/shared";
+import type { MeMembership, OrgBrief } from "@first-tree/shared";
 import { useQueryClient } from "@tanstack/react-query";
 import { createContext, type ReactNode, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import { trackEvent } from "../analytics.js";
@@ -136,6 +136,17 @@ type AuthContextValue = {
    * org (`ADMIN_WS_ORG_CHANGED_EVENT`).
    */
   selectOrganization: (organizationId: string) => Promise<void>;
+  /**
+   * The org a switch is transitioning to, or `null` when no switch is in
+   * flight. Set by the team switcher when a switch starts and cleared when it
+   * settles (or fails). It is the single signal that drives the optimistic
+   * anchor label, the in-row spinner + disabled list, and the global
+   * "Switching to {name}…" transition veil — consolidating the per-component
+   * blank flash into one intentional overlay. `selectOrganization` itself is
+   * unchanged; this is purely the in-flight UI state wrapped around it.
+   */
+  switchingOrg: OrgBrief | null;
+  setSwitchingOrg: (org: OrgBrief | null) => void;
   refreshMe: () => Promise<void>;
   logout: () => void;
 };
@@ -212,6 +223,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   // below — RequireAuth only blocks the loading frame when the user IS
   // authenticated.
   const [meLoaded, setMeLoaded] = useState(false);
+  // In-flight org-switch target (drives the switcher's optimistic anchor, the
+  // row spinner, and the global transition veil). Lives here so the veil
+  // (mounted in the layout) and the switcher (in the header) read one source.
+  const [switchingOrg, setSwitchingOrg] = useState<OrgBrief | null>(null);
 
   const logout = useCallback(() => {
     clearStoredTokens();
@@ -236,6 +251,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setOnboardingDismissedAt(null);
     setOnboardingCompletedAt(null);
     setMeLoaded(false);
+    setSwitchingOrg(null);
   }, [queryClient]);
 
   const fetchMe = useCallback(async () => {
@@ -498,6 +514,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         login,
         adoptTokens,
         selectOrganization,
+        switchingOrg,
+        setSwitchingOrg,
         refreshMe: fetchMe,
         logout,
       }}

--- a/packages/web/src/components/__tests__/layout-dom.test.tsx
+++ b/packages/web/src/components/__tests__/layout-dom.test.tsx
@@ -16,6 +16,8 @@ const authMock = vi.hoisted(() => ({
     memberships: [],
     currentMembership: null,
     teamDisplayName: "Acme",
+    switchingOrg: null,
+    setSwitchingOrg: vi.fn(),
     logout: vi.fn(),
     selectOrganization: vi.fn(),
   },
@@ -203,6 +205,8 @@ describe("Layout", () => {
     expect(container.textContent).toContain("Workspace");
     expect(container.textContent).toContain("Context child");
     expect(container.textContent).toContain("Jump to");
+    // Team anchor sits in the brand cluster at wide widths.
+    expect(container.querySelector('[data-testid="team-switcher"]')).not.toBeNull();
 
     const jump = container.querySelector<HTMLButtonElement>('button[aria-label="Open command palette"]');
     if (!jump) throw new Error("Jump button missing");
@@ -230,6 +234,9 @@ describe("Layout", () => {
     expect(container.textContent).not.toContain("Jump to");
     expect(container.textContent).toContain("Settings child");
     expect(container.querySelector('[data-testid="user-menu"]')).not.toBeNull();
+    // The brand drops on narrow, but the team anchor must NOT — it stays
+    // reachable in its own leading column (§7).
+    expect(container.querySelector('[data-testid="team-switcher"]')).not.toBeNull();
 
     const xlController = mediaControllers.find((controller) => controller.query.includes("80rem"));
     const mdController = mediaControllers.find((controller) => controller.query.includes("48rem"));

--- a/packages/web/src/components/__tests__/team-switcher-dom.test.tsx
+++ b/packages/web/src/components/__tests__/team-switcher-dom.test.tsx
@@ -1,0 +1,212 @@
+// @vitest-environment happy-dom
+
+import type { OrgBrief } from "@first-tree/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, useMemo, useState } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthContext } from "../../auth/auth-context.js";
+import { TeamSwitcher } from "../team-switcher.js";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const ORGS: OrgBrief[] = [
+  { id: "org-1", name: "acme", displayName: "Acme Robotics", role: "admin" },
+  { id: "org-2", name: "globex", displayName: "Globex", role: "member" },
+  { id: "org-3", name: "initech", displayName: "Initech", role: "member" },
+];
+
+const clientMocks = vi.hoisted(() => ({ get: vi.fn() }));
+
+// Mock api so the org list is deterministic, and stub the avatar + the two
+// dialogs so assertions key off real text, not identicon SVGs or portal chrome.
+vi.mock("../../api/client.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../api/client.js")>();
+  return { ...actual, api: { ...actual.api, get: clientMocks.get } };
+});
+vi.mock("../avatar.js", () => ({ Avatar: () => <span data-testid="avatar" /> }));
+vi.mock("../invite-dialog.js", () => ({ InviteDialog: () => null }));
+vi.mock("../team-setup-modal.js", () => ({ TeamSetupModal: () => null }));
+
+function deferred<T = void>(): { promise: Promise<T>; resolve: (v: T) => void; reject: (e: unknown) => void } {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+async function click(element: Element | null): Promise<void> {
+  if (!element) throw new Error("Expected element to click");
+  await act(async () => {
+    element.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+  });
+  await flush();
+}
+
+function buttonByText(scope: ParentNode, text: string): HTMLButtonElement | null {
+  return [...scope.querySelectorAll("button")].find((b) => b.textContent?.includes(text)) ?? null;
+}
+
+function anchorOf(container: ParentNode): HTMLButtonElement {
+  const anchor = container.querySelector<HTMLButtonElement>('button[aria-haspopup="menu"]');
+  if (!anchor) throw new Error("anchor missing");
+  return anchor;
+}
+
+function Harness({ select }: { select: (id: string) => Promise<void> }) {
+  // Fresh client per mount so the ['me-organizations'] cache never leaks across
+  // tests (the single-team case swaps the mock and must not read a stale list).
+  const queryClient = useMemo(() => new QueryClient({ defaultOptions: { queries: { retry: false } } }), []);
+  const [organizationId, setOrganizationId] = useState("org-1");
+  const [switchingOrg, setSwitchingOrg] = useState<OrgBrief | null>(null);
+  const value = useMemo(
+    () =>
+      ({
+        isAuthenticated: true,
+        meLoaded: true,
+        organizationId,
+        role: "admin",
+        teamDisplayName: "Acme Robotics",
+        user: { id: "u", displayName: "Gandy", username: "gandy", avatarUrl: null },
+        switchingOrg,
+        setSwitchingOrg,
+        selectOrganization: async (id: string) => {
+          await select(id);
+          setOrganizationId(id);
+        },
+        logout: () => undefined,
+      }) as unknown as Parameters<typeof AuthContext.Provider>[0]["value"],
+    [organizationId, switchingOrg, select],
+  );
+  return (
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <AuthContext.Provider value={value}>
+          <TeamSwitcher redirectHomeOnSwitch={false} />
+        </AuthContext.Provider>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+async function renderHarness(select: (id: string) => Promise<void>): Promise<{ container: HTMLElement; root: Root }> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(<Harness select={select} />);
+  });
+  await flush();
+  return { container, root };
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  clientMocks.get.mockResolvedValue(ORGS);
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  vi.clearAllMocks();
+});
+
+describe("TeamSwitcher", () => {
+  it("shows the current team on the anchor and opens a menu with the other teams + management actions", async () => {
+    const { container, root } = await renderHarness(vi.fn(async () => {}));
+
+    expect(anchorOf(container).textContent).toContain("Acme Robotics");
+
+    await click(anchorOf(container));
+    expect(container.textContent).toContain("current team");
+    expect(container.textContent).toContain("Switch team");
+    expect(buttonByText(container, "Globex")).not.toBeNull();
+    expect(buttonByText(container, "Initech")).not.toBeNull();
+    // The current team is in the header, not the switch list.
+    expect(buttonByText(container, "Globex")?.getAttribute("role")).toBe("menuitem");
+    expect(buttonByText(container, "Create new team")).not.toBeNull();
+    expect(buttonByText(container, "Join with invite link")).not.toBeNull();
+    expect(buttonByText(container, "Invite teammates")).not.toBeNull();
+
+    await act(async () => root.unmount());
+  });
+
+  it("drives the in-flight switch from one signal: optimistic anchor, row spinner, disabled list, no double-click", async () => {
+    const gate = deferred();
+    const select = vi.fn(() => gate.promise);
+    const { container, root } = await renderHarness(select);
+
+    await click(anchorOf(container));
+    await click(buttonByText(container, "Globex"));
+
+    // Optimistic anchor flips to the target while the switch is in flight.
+    expect(anchorOf(container).textContent).toContain("Globex");
+    // The picked row spins…
+    expect(container.querySelector(".animate-spin")).not.toBeNull();
+    // …and the rest of the list is disabled.
+    expect(buttonByText(container, "Initech")?.disabled).toBe(true);
+
+    // A second click while switching is ignored (hard guard).
+    await click(buttonByText(container, "Initech"));
+    expect(select).toHaveBeenCalledTimes(1);
+
+    // Settle: the promise resolves, the veil floor elapses, the anchor lands.
+    gate.resolve();
+    await flush();
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 350));
+    });
+    await flush();
+    expect(container.querySelector(".animate-spin")).toBeNull();
+    expect(anchorOf(container).textContent).toContain("Globex");
+
+    await act(async () => root.unmount());
+  });
+
+  it("rolls back and shows an inline retry hint when the switch fails, keeping the menu open", async () => {
+    const gate = deferred();
+    const select = vi.fn(() => gate.promise);
+    const { container, root } = await renderHarness(select);
+
+    await click(anchorOf(container));
+    await click(buttonByText(container, "Globex"));
+    expect(anchorOf(container).textContent).toContain("Globex");
+
+    gate.reject(new Error("switch failed"));
+    await flush();
+
+    // Anchor reverts to the current team; an inline hint appears; menu stays open.
+    expect(anchorOf(container).textContent).toContain("Acme Robotics");
+    expect(container.textContent).toContain("Couldn't switch — try again");
+    expect(buttonByText(container, "Globex")).not.toBeNull();
+    expect(container.querySelector(".animate-spin")).toBeNull();
+
+    await act(async () => root.unmount());
+  });
+
+  it("keeps the anchor but hides the switch list for a single-team user", async () => {
+    clientMocks.get.mockResolvedValue([ORGS[0]]);
+    const { container, root } = await renderHarness(vi.fn(async () => {}));
+
+    expect(anchorOf(container).textContent).toContain("Acme Robotics");
+    await click(anchorOf(container));
+
+    expect(container.textContent).not.toContain("Switch team");
+    expect(buttonByText(container, "Globex")).toBeNull();
+    // Management actions are still present for single-team users.
+    expect(buttonByText(container, "Create new team")).not.toBeNull();
+
+    await act(async () => root.unmount());
+  });
+});

--- a/packages/web/src/components/layout.tsx
+++ b/packages/web/src/components/layout.tsx
@@ -1,6 +1,7 @@
 import { Search } from "lucide-react";
 import { useEffect, useState } from "react";
 import { NavLink, Outlet, useLocation } from "react-router";
+import { useAuth } from "../auth/auth-context.js";
 import { useNewVersionAvailable } from "../hooks/use-version-check.js";
 import { useWorkspaceViewport } from "../hooks/use-viewport.js";
 import { cn } from "../lib/utils.js";
@@ -8,6 +9,8 @@ import { CommandPalette } from "../pages/workspace/palette/command-palette.js";
 import { DisconnectChip } from "./disconnect-chip.js";
 import { FirstTreeLogo } from "./first-tree-logo.js";
 import { NewVersionChip } from "./new-version-chip.js";
+import { TeamSwitchOverlay } from "./team-switch-overlay.js";
+import { TeamSwitcher } from "./team-switcher.js";
 import { ThemeToggle } from "./ui/theme-toggle.js";
 import { UserMenu } from "./user-menu.js";
 
@@ -26,6 +29,7 @@ const PARENT_URL = "https://first-tree.ai";
 
 export function Layout() {
   const [paletteOpen, setPaletteOpen] = useState(false);
+  const { organizationId } = useAuth();
 
   // ⌘K / Ctrl+K to open the Jump-to palette from anywhere. Listens at
   // window-level so the shortcut survives inside textareas / editable
@@ -71,12 +75,18 @@ export function Layout() {
   const showJumpButton = viewport === "xl";
   const dropBrand = viewport === "narrow";
   const showThemeToggle = viewport !== "narrow";
+  // The team anchor is reachable at every breakpoint (like the avatar). It is
+  // absent only when no org is selected (mid-onboarding), where it would have
+  // nothing to anchor to and Create / Join is carried by the onboarding flow.
+  const showAnchor = !!organizationId;
   // Brand present → brand | tabs(center) | controls(end). Brand collapsed
-  // (narrow) → tabs(start) | controls(end). The narrow tabs track is
-  // `minmax(0, 1fr)` (not the default `minmax(auto, 1fr)`) so it can shrink
-  // below the tabs' intrinsic width and let them scroll, instead of pushing
-  // the avatar past the right edge.
-  const headerColumns = dropBrand ? "minmax(0, 1fr) auto" : "1fr auto 1fr";
+  // (narrow) → [team anchor] | tabs(start) | controls(end): the anchor moves to
+  // its own leading `auto` column so "which team am I in" stays reachable after
+  // the brand drops. With no selected org the anchor is absent and the row falls
+  // back to tabs | controls. The narrow tabs track is `minmax(0, 1fr)` (not the
+  // default `minmax(auto, 1fr)`) so it can shrink below the tabs' intrinsic
+  // width and let them scroll, instead of pushing the avatar past the right edge.
+  const headerColumns = dropBrand ? (showAnchor ? "auto minmax(0, 1fr) auto" : "minmax(0, 1fr) auto") : "1fr auto 1fr";
 
   return (
     <div
@@ -107,8 +117,16 @@ export function Layout() {
           background: "var(--bg-raised)",
         }}
       >
-        {/* Brand cluster: logo + name welded together, then the optional chip. */}
-        {dropBrand ? null : (
+        {/* Brand cluster: logo + name welded together, the team anchor, then the
+            optional chips. On narrow the cluster is dropped, but the anchor must
+            stay reachable — it surfaces icon-only in its own leading column. */}
+        {dropBrand ? (
+          showAnchor ? (
+            <div style={{ justifySelf: "start", minWidth: 0 }}>
+              <TeamSwitcher variant="compact" />
+            </div>
+          ) : null
+        ) : (
           <div className="flex items-center" style={{ gap: "var(--sp-3_5)", justifySelf: "start", minWidth: 0 }}>
             {/* Brand links out to the parent marketing site in a new tab. */}
             <a
@@ -125,6 +143,14 @@ export function Layout() {
                 First Tree
               </span>
             </a>
+            {/* Team anchor sits next to the brand (workspace identity, left side),
+                separated by a hairline rule; absent when no org is selected. */}
+            {showAnchor && (
+              <>
+                <span aria-hidden style={{ width: 1, height: 18, background: "var(--border)", flexShrink: 0 }} />
+                <TeamSwitcher variant="full" />
+              </>
+            )}
             <DisconnectChip />
             <NewVersionChip show={newVersionAvailable} />
           </div>
@@ -252,6 +278,9 @@ export function Layout() {
           <UserMenu />
         </div>
       </header>
+
+      {/* One intentional veil over the content while an org switch runs. */}
+      <TeamSwitchOverlay />
 
       <CommandPalette open={paletteOpen} onOpenChange={setPaletteOpen} />
 

--- a/packages/web/src/components/team-setup-modal.tsx
+++ b/packages/web/src/components/team-setup-modal.tsx
@@ -10,9 +10,10 @@ import { Input } from "./ui/input.js";
  * Modal for creating a new team or joining one via an invite link.
  *
  * Replaces the dedicated `/setup` route. The action prop selects which
- * form to render — `null` keeps the modal closed. On success we adopt
- * the new tokens (which carry the new org context) and reload the
- * dashboard so all per-org queries refetch cleanly.
+ * form to render — `null` keeps the modal closed. On success we select the
+ * new org via `selectOrganization` — a client-side switch with no token swap
+ * and no reload; it clears the React-Query cache and refetches /me — then route
+ * into onboarding so the fresh team finishes setup.
  */
 export function TeamSetupModal({ action, onClose }: { action: "create" | "join" | null; onClose: () => void }) {
   const open = action !== null;

--- a/packages/web/src/components/team-switch-overlay.tsx
+++ b/packages/web/src/components/team-switch-overlay.tsx
@@ -1,0 +1,23 @@
+import { Loader2 } from "lucide-react";
+import { useAuth } from "../auth/auth-context.js";
+
+/**
+ * Global team-switch transition veil. Reads `switchingOrg` from auth-context
+ * (set by the TeamSwitcher) and, while a switch is in flight, covers the content
+ * region below the header with one intentional "Switching to {name}…" overlay —
+ * replacing the old flash where every org-scoped component blanked to its own
+ * skeleton as the React-Query cache cleared. Mounted once by the layout; the
+ * styling + reduced-motion fallback live in `.team-switch-veil` (index.css).
+ */
+export function TeamSwitchOverlay() {
+  const { switchingOrg } = useAuth();
+  if (!switchingOrg) return null;
+  return (
+    <div className="team-switch-veil" role="status" aria-live="polite">
+      <div className="flex items-center gap-2 text-body" style={{ color: "var(--fg-2)" }}>
+        <Loader2 className="h-4 w-4 animate-spin" />
+        <span>Switching to {switchingOrg.displayName}…</span>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/team-switcher.tsx
+++ b/packages/web/src/components/team-switcher.tsx
@@ -1,0 +1,308 @@
+import type { OrgBrief } from "@first-tree/shared";
+import { useQuery } from "@tanstack/react-query";
+import { ChevronDown, Link2, Loader2, Plus, UserPlus } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router";
+import { api } from "../api/client.js";
+import { useAuth } from "../auth/auth-context.js";
+import { cn } from "../lib/utils.js";
+import { Avatar } from "./avatar.js";
+import { InviteDialog } from "./invite-dialog.js";
+import { TeamSetupModal } from "./team-setup-modal.js";
+
+// Floor for how long the "Switching to {name}…" veil stays up, so a fast
+// switch (cache clear + reconnect + /me) doesn't flash the veil for a single
+// frame. Tunable by feel during QA.
+const MIN_SHOW_MS = 300;
+
+/**
+ * Header-left team anchor: the always-present "which team am I in" marker and
+ * the entry point for switching teams + team management. Consolidates the
+ * team half of the old right-side user menu — the org list, `selectOrganization`,
+ * Create / Join / Invite entries, and the `TeamSetupModal` / `InviteDialog`
+ * mounts all live here now; the avatar menu is account-only.
+ *
+ * One state drives the whole switch (`switchingOrg`, from `auth-context`): the
+ * picked row spins + the rest of the list disables, the anchor optimistically
+ * shows the target team, and a single `TeamSwitchOverlay` veils the content —
+ * replacing the old per-component blank-skeleton flash. The data isolation from
+ * PR 1221 (`queryClient.clear()` inside `selectOrganization`) is unchanged.
+ */
+export function TeamSwitcher({
+  variant = "full",
+  // After a successful switch we land on the workspace root because deep routes
+  // (e.g. an agent detail) don't exist under the newly selected org. The DEV
+  // preview sets this false to stay mounted (it has no nested router to absorb
+  // the navigation).
+  redirectHomeOnSwitch = true,
+}: {
+  variant?: "full" | "compact";
+  redirectHomeOnSwitch?: boolean;
+}) {
+  const { organizationId, role, teamDisplayName, selectOrganization, switchingOrg, setSwitchingOrg } = useAuth();
+  const navigate = useNavigate();
+  const [open, setOpen] = useState(false);
+  const [inviteOpen, setInviteOpen] = useState(false);
+  const [setupAction, setSetupAction] = useState<"create" | "join" | null>(null);
+  // Org id whose last switch attempt failed, so we can show a retry hint
+  // without conflating it with a fresh attempt.
+  const [switchError, setSwitchError] = useState<string | null>(null);
+  const ref = useRef<HTMLDivElement>(null);
+
+  // Shared `me-organizations` cache: a rename in Settings invalidates this key
+  // (team-identity-panel), so the anchor + switch list refresh without a reload.
+  // Best-effort — on failure the anchor still renders the current team from
+  // useAuth (see currentOrg fallback below).
+  const { data: orgs = [] } = useQuery({
+    queryKey: ["me-organizations"],
+    queryFn: () => api.get<OrgBrief[]>("/me/organizations"),
+    enabled: !!organizationId,
+  });
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (open && ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    const escHandler = (e: KeyboardEvent) => {
+      if (open && e.key === "Escape") setOpen(false);
+    };
+    window.addEventListener("mousedown", handler);
+    window.addEventListener("keydown", escHandler);
+    return () => {
+      window.removeEventListener("mousedown", handler);
+      window.removeEventListener("keydown", escHandler);
+    };
+  }, [open]);
+
+  // Drop a stale retry hint when the menu is dismissed.
+  useEffect(() => {
+    if (!open) setSwitchError(null);
+  }, [open]);
+
+  const handleSwitch = async (org: OrgBrief) => {
+    if (org.id === organizationId) {
+      setOpen(false);
+      return;
+    }
+    if (switchingOrg) return; // hard guard: ignore clicks while a switch is in flight
+    setSwitchError(null);
+    setSwitchingOrg(org); // → veil + optimistic anchor + row spinner + list disabled
+    const startedAt = Date.now();
+    try {
+      // PR 1221: clears every org-scoped React-Query cache, reconnects the
+      // admin WebSocket to the new org, and refetches /me. Unchanged.
+      await selectOrganization(org.id);
+      setOpen(false);
+      if (redirectHomeOnSwitch) navigate("/", { replace: true });
+      // Hold the veil through the cache-clear → home-mount gap, but no longer
+      // than needed, so a fast switch doesn't flash it for one frame.
+      const wait = Math.max(0, MIN_SHOW_MS - (Date.now() - startedAt));
+      window.setTimeout(() => setSwitchingOrg(null), wait);
+    } catch {
+      // Roll the optimistic anchor back and re-enable the list; keep the menu
+      // open with an inline retry hint.
+      setSwitchingOrg(null);
+      setSwitchError(org.id);
+    }
+  };
+
+  // Hooks above run unconditionally; bail out only after them. No selected org
+  // (e.g. mid-onboarding) → no anchor; Create / Join is carried by onboarding.
+  if (!organizationId) return null;
+
+  const isCompact = variant === "compact";
+  const fallbackRole: "admin" | "member" = role === "admin" ? "admin" : "member";
+  // Current team: prefer the fetched list (full name + role), else fall back to
+  // what useAuth already knows so the anchor never waits on /me/organizations.
+  const currentOrg: OrgBrief = orgs.find((o) => o.id === organizationId) ?? {
+    id: organizationId,
+    name: teamDisplayName ?? "",
+    displayName: teamDisplayName ?? "Current team",
+    role: fallbackRole,
+  };
+  const others = orgs.filter((o) => o.id !== organizationId);
+  // Anchor reads the optimistic target while switching, so it flips to the
+  // destination on click and self-reverts if the switch fails.
+  const anchorName = switchingOrg?.displayName ?? currentOrg.displayName;
+  const anchorSeed = switchingOrg?.id ?? currentOrg.id;
+
+  return (
+    <>
+      <div ref={ref} className="relative" data-testid="team-switcher">
+        <button
+          type="button"
+          aria-haspopup="menu"
+          aria-expanded={open}
+          aria-label={`Switch team, current: ${currentOrg.displayName}`}
+          onClick={() => setOpen((v) => !v)}
+          className={cn(
+            "inline-flex items-center transition-colors",
+            open ? "bg-[var(--bg-hover)]" : "bg-[var(--bg)] hover:bg-[var(--bg-hover)]",
+          )}
+          style={{
+            gap: "var(--sp-1_75)",
+            padding: isCompact ? "var(--sp-1) var(--sp-1_25)" : "var(--sp-1) var(--sp-2) var(--sp-1) var(--sp-1_25)",
+            border: `var(--hairline) solid ${open ? "var(--border-strong)" : "var(--border)"}`,
+            borderRadius: "var(--radius-input)",
+            maxWidth: isCompact ? undefined : 185,
+            cursor: "pointer",
+          }}
+        >
+          <Avatar seed={anchorSeed} name={anchorName} size={18} />
+          {!isCompact && (
+            <span className="min-w-0 flex-1 truncate text-body" style={{ color: "var(--fg)" }}>
+              {anchorName}
+            </span>
+          )}
+          <ChevronDown className="h-3.5 w-3.5 flex-none" style={{ color: "var(--fg-3)" }} />
+        </button>
+
+        {open && (
+          <div
+            role="menu"
+            // z-[46]: above the switch veil (45) so the in-menu spinner stays
+            // visible during a switch, and above content overlays (conv-list /
+            // right-rail z-30, doc drawer z-40); below dialogs (z-50).
+            className="absolute left-0 z-[46] mt-2 overflow-hidden rounded-[var(--radius-panel)] border bg-popover shadow-[var(--shadow-md)]"
+            style={{ width: 270, borderColor: "var(--border)" }}
+          >
+            {/* ① Current team header — always shown. */}
+            <div className="flex items-center gap-2.5 border-b px-3.5 py-2.5" style={{ borderColor: "var(--border)" }}>
+              <Avatar seed={currentOrg.id} name={currentOrg.displayName} size={26} />
+              <div className="min-w-0">
+                <div className="text-subtitle truncate" style={{ color: "var(--fg)" }}>
+                  {currentOrg.displayName}
+                </div>
+                <div className="text-label truncate" style={{ color: "var(--fg-3)" }}>
+                  {currentOrg.role} · current team
+                </div>
+              </div>
+            </div>
+
+            {/* ② Switch list — other teams only; hidden for single-team users. */}
+            {others.length > 0 && (
+              <div className="border-b" style={{ borderColor: "var(--border)" }}>
+                <div
+                  className="text-eyebrow"
+                  style={{ color: "var(--fg-3)", padding: "var(--sp-1_25) var(--sp-3_5) var(--sp-0_75)" }}
+                >
+                  Switch team
+                </div>
+                <div
+                  style={{
+                    maxHeight: "var(--sp-45)",
+                    overflowY: "auto",
+                    pointerEvents: switchingOrg ? "none" : undefined,
+                  }}
+                >
+                  {others.map((o) => {
+                    const isBusy = switchingOrg?.id === o.id;
+                    return (
+                      <button
+                        key={o.id}
+                        type="button"
+                        role="menuitem"
+                        disabled={!!switchingOrg}
+                        aria-busy={isBusy}
+                        onClick={() => void handleSwitch(o)}
+                        className="flex w-full items-center gap-2 px-3.5 py-1.5 text-left text-body transition-colors hover:bg-[var(--bg-hover)]"
+                        style={{ color: "var(--fg)", opacity: switchingOrg && !isBusy ? 0.45 : undefined }}
+                      >
+                        <span className="inline-flex flex-none justify-center" style={{ width: 18 }}>
+                          {isBusy ? (
+                            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                          ) : (
+                            <Avatar seed={o.id} name={o.displayName} size={18} />
+                          )}
+                        </span>
+                        <span className="min-w-0 flex-1 truncate">{o.displayName}</span>
+                        <RoleBadge role={o.role} dim />
+                      </button>
+                    );
+                  })}
+                </div>
+                {switchError && (
+                  <div
+                    className="text-label"
+                    style={{ padding: "var(--sp-1) var(--sp-3_5) var(--sp-1_5)", color: "var(--color-error)" }}
+                  >
+                    Couldn't switch — try again
+                  </div>
+                )}
+              </div>
+            )}
+
+            {/* ③ Team management — always shown. */}
+            <div className="py-1">
+              <button
+                type="button"
+                role="menuitem"
+                onClick={() => {
+                  setOpen(false);
+                  setSetupAction("create");
+                }}
+                className="flex w-full items-center gap-2 px-3.5 py-1.5 text-left text-body transition-colors hover:bg-[var(--bg-hover)]"
+                style={{ color: "var(--fg)" }}
+              >
+                <Plus className="h-3.5 w-3.5" />
+                <span>Create new team</span>
+              </button>
+              <button
+                type="button"
+                role="menuitem"
+                onClick={() => {
+                  setOpen(false);
+                  setSetupAction("join");
+                }}
+                className="flex w-full items-center gap-2 px-3.5 py-1.5 text-left text-body transition-colors hover:bg-[var(--bg-hover)]"
+                style={{ color: "var(--fg)" }}
+              >
+                <UserPlus className="h-3.5 w-3.5" />
+                <span>Join with invite link</span>
+              </button>
+              {/* Invite teammates — org-scoped link, so only when a team is
+                  selected (mirrors the prior user-menu guard). */}
+              {organizationId && (
+                <button
+                  type="button"
+                  role="menuitem"
+                  onClick={() => {
+                    setOpen(false);
+                    setInviteOpen(true);
+                  }}
+                  className="flex w-full items-center gap-2 px-3.5 py-1.5 text-left text-body transition-colors hover:bg-[var(--bg-hover)]"
+                  style={{ color: "var(--fg)" }}
+                >
+                  <Link2 className="h-3.5 w-3.5" />
+                  <span>Invite teammates</span>
+                </button>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+
+      <TeamSetupModal action={setupAction} onClose={() => setSetupAction(null)} />
+      <InviteDialog open={inviteOpen} onOpenChange={setInviteOpen} />
+    </>
+  );
+}
+
+function RoleBadge({ role, dim }: { role: string | null | undefined; dim?: boolean }) {
+  if (role !== "admin" && role !== "member") return null;
+  return (
+    <span
+      className="mono uppercase text-caption"
+      style={{
+        padding: "var(--hairline) var(--sp-1_75)",
+        borderRadius: "var(--radius-chip)",
+        color: role === "admin" ? "var(--brand-dim)" : "var(--fg-3)",
+        border: "var(--hairline) solid var(--border)",
+        background: role === "admin" ? "var(--brand-bg)" : "var(--bg-sunken)",
+        opacity: dim ? 0.7 : undefined,
+      }}
+    >
+      {role}
+    </span>
+  );
+}

--- a/packages/web/src/components/team-switcher.tsx
+++ b/packages/web/src/components/team-switcher.tsx
@@ -136,13 +136,16 @@ export function TeamSwitcher({
           aria-label={`Switch team, current: ${currentOrg.displayName}`}
           onClick={() => setOpen((v) => !v)}
           className={cn(
-            "inline-flex items-center transition-colors",
-            open ? "bg-[var(--bg-hover)]" : "bg-[var(--bg)] hover:bg-[var(--bg-hover)]",
+            "inline-flex items-center border transition-colors",
+            open
+              ? "border-[var(--border-strong)] bg-[var(--bg-hover)]"
+              : isCompact
+                ? "border-[var(--border)] bg-[var(--bg)] hover:bg-[var(--bg-hover)]"
+                : "border-transparent bg-[var(--bg)] hover:border-[var(--border)] hover:bg-[var(--bg-hover)]",
           )}
           style={{
             gap: "var(--sp-1_75)",
             padding: isCompact ? "var(--sp-1) var(--sp-1_25)" : "var(--sp-1) var(--sp-2) var(--sp-1) var(--sp-1_25)",
-            border: `var(--hairline) solid ${open ? "var(--border-strong)" : "var(--border)"}`,
             borderRadius: "var(--radius-input)",
             maxWidth: isCompact ? undefined : 185,
             cursor: "pointer",

--- a/packages/web/src/components/user-menu.tsx
+++ b/packages/web/src/components/user-menu.tsx
@@ -1,14 +1,7 @@
-import type { OrgBrief } from "@first-tree/shared";
-import { Check, ChevronDown, ChevronUp, Link2, LogOut, Plus, UserPlus } from "lucide-react";
+import { LogOut } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
-import { useNavigate } from "react-router";
-import { api } from "../api/client.js";
 import { useAuth } from "../auth/auth-context.js";
 import { Avatar } from "./avatar.js";
-import { InviteDialog } from "./invite-dialog.js";
-import { TeamSetupModal } from "./team-setup-modal.js";
-
-const COLLAPSED_TEAM_LIMIT = 5;
 
 // Marketing site — where an explicit sign-out lands the browser, so the user
 // leaves the app on the parent brand surface rather than an app route (which
@@ -17,34 +10,17 @@ const COLLAPSED_TEAM_LIMIT = 5;
 const PARENT_URL = "https://first-tree.ai";
 
 /**
- * Right-side user menu. Avatar trigger; dropdown nests team switching,
- * admin team management, Create / Join entry points, and sign-out.
+ * Right-side account menu. Avatar trigger; dropdown shows the signed-in user
+ * and Sign out.
  *
- * Replaces the previous brand-side OrganizationSwitcher and the
- * standalone right-side logout button. Single org users see the same
- * dropdown as multi-org users — the Create / Join entries are always
- * present so they can self-serve into a multi-org state.
+ * Team switching and team management (the org list, Create / Join / Invite)
+ * moved to the header-left `TeamSwitcher` — team and account are now separate
+ * surfaces (team on the left, account on the right).
  */
 export function UserMenu() {
-  const { organizationId, role, user, selectOrganization, logout } = useAuth();
-  const navigate = useNavigate();
-  const [orgs, setOrgs] = useState<OrgBrief[]>([]);
+  const { user, logout } = useAuth();
   const [open, setOpen] = useState(false);
-  const [teamsExpanded, setTeamsExpanded] = useState(false);
-  const [inviteOpen, setInviteOpen] = useState(false);
-  const [setupAction, setSetupAction] = useState<"create" | "join" | null>(null);
   const ref = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    void (async () => {
-      try {
-        const list = await api.get<OrgBrief[]>("/me/organizations");
-        setOrgs(list);
-      } catch {
-        // best-effort; the static avatar still works
-      }
-    })();
-  }, []);
 
   useEffect(() => {
     const handler = (e: MouseEvent) => {
@@ -63,232 +39,70 @@ export function UserMenu() {
     };
   }, [open]);
 
-  useEffect(() => {
-    if (!open) setTeamsExpanded(false);
-  }, [open]);
-
   const displayName = user?.displayName ?? "User";
   const username = user?.username ?? "";
   const avatarSrc = user?.avatarUrl ?? null;
-  const currentOrg = orgs.find((o) => o.id === organizationId) ?? null;
-  const currentRole = currentOrg?.role ?? (role === "admin" || role === "member" ? role : null);
-  const orderedOrgs = currentOrg ? [currentOrg, ...orgs.filter((o) => o.id !== currentOrg.id)] : orgs;
-  const hasHiddenTeams = orderedOrgs.length > COLLAPSED_TEAM_LIMIT;
-  const visibleOrgs = teamsExpanded ? orderedOrgs : orderedOrgs.slice(0, COLLAPSED_TEAM_LIMIT);
-  const hiddenTeamCount = Math.max(0, orderedOrgs.length - COLLAPSED_TEAM_LIMIT);
-
-  const switchOrg = async (id: string) => {
-    if (id === organizationId) {
-      setOpen(false);
-      return;
-    }
-    try {
-      // selectOrganization persists `localStorage.selectedOrganizationId`
-      // and refreshes /me. The server returns 204 — no token swap, the WS
-      // session keeps its bound agents (decouple-client-from-identity §4.6).
-      await selectOrganization(id);
-      setOpen(false);
-      navigate("/", { replace: true });
-    } catch {
-      // keep dropdown open so the user can retry
-    }
-  };
-
-  const openCreate = () => {
-    setOpen(false);
-    setSetupAction("create");
-  };
-  const openJoin = () => {
-    setOpen(false);
-    setSetupAction("join");
-  };
-  const openInvite = () => {
-    setOpen(false);
-    setInviteOpen(true);
-  };
 
   return (
-    <>
-      <div ref={ref} className="relative" data-testid="user-menu">
-        <button
-          type="button"
-          aria-label={`User menu, ${displayName}`}
-          aria-haspopup="menu"
-          aria-expanded={open}
-          onClick={() => setOpen((o) => !o)}
-          className="inline-flex items-center justify-center rounded-full focus:outline-none focus:ring-1 focus:ring-ring transition-shadow"
-          style={{
-            background: "transparent",
-            border: open ? "var(--hairline) solid var(--border)" : "var(--hairline) solid transparent",
-            padding: 1,
-            cursor: "pointer",
-          }}
+    <div ref={ref} className="relative" data-testid="user-menu">
+      <button
+        type="button"
+        aria-label={`User menu, ${displayName}`}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => setOpen((o) => !o)}
+        className="inline-flex items-center justify-center rounded-full focus:outline-none focus:ring-1 focus:ring-ring transition-shadow"
+        style={{
+          background: "transparent",
+          border: open ? "var(--hairline) solid var(--border)" : "var(--hairline) solid transparent",
+          padding: 1,
+          cursor: "pointer",
+        }}
+      >
+        <Avatar src={avatarSrc} name={displayName} size={28} />
+      </button>
+
+      {open && (
+        <div
+          role="menu"
+          className="absolute right-0 z-30 mt-2 rounded-[var(--radius-panel)] border bg-popover shadow-md"
+          style={{ width: 280 }}
         >
-          <Avatar src={avatarSrc} name={displayName} size={28} />
-        </button>
-
-        {open && (
-          <div
-            role="menu"
-            className="absolute right-0 z-30 mt-2 rounded-[var(--radius-panel)] border bg-popover shadow-md"
-            style={{ width: 280 }}
-          >
-            {/* User header */}
-            <div className="flex items-center gap-3 border-b px-4 py-3" style={{ borderColor: "var(--border)" }}>
-              <Avatar src={avatarSrc} name={displayName} size={32} />
-              <div className="min-w-0">
-                <div className="text-subtitle font-medium truncate" style={{ color: "var(--fg)" }}>
-                  {displayName}
-                </div>
-                {username && username !== displayName && (
-                  <div className="text-label text-muted-foreground truncate">@{username}</div>
-                )}
+          {/* User header */}
+          <div className="flex items-center gap-3 border-b px-4 py-3" style={{ borderColor: "var(--border)" }}>
+            <Avatar src={avatarSrc} name={displayName} size={32} />
+            <div className="min-w-0">
+              <div className="text-subtitle font-medium truncate" style={{ color: "var(--fg)" }}>
+                {displayName}
               </div>
-            </div>
-
-            {/* Teams section — proposal §"OrganizationSwitcher":
-                single-org users see a static label (the user still
-                needs to know which team they're in), multi-org users
-                get clickable rows with a checkmark on the active one. */}
-            {orgs.length > 0 && (
-              <div className="border-b py-1" style={{ borderColor: "var(--border)" }}>
-                <div className="px-4 py-1 text-eyebrow text-muted-foreground">Current team</div>
-                {orgs.length === 1 ? (
-                  <div
-                    className="flex w-full items-center gap-2 px-4 py-1.5 text-left text-body"
-                    style={{ color: "var(--fg)" }}
-                  >
-                    <span style={{ width: 14, display: "inline-flex" }}>
-                      <Check className="h-3.5 w-3.5" />
-                    </span>
-                    <span className="min-w-0 flex-1 truncate">{orderedOrgs[0]?.displayName}</span>
-                    <RoleBadge role={orderedOrgs[0]?.role ?? currentRole} />
-                  </div>
-                ) : (
-                  <div>
-                    <div style={teamsExpanded ? { maxHeight: "var(--sp-75)", overflowY: "auto" } : undefined}>
-                      {visibleOrgs.map((o) => (
-                        <button
-                          type="button"
-                          role="menuitem"
-                          key={o.id}
-                          onClick={() => void switchOrg(o.id)}
-                          className="flex w-full items-center gap-2 px-4 py-1.5 text-left text-body hover:bg-accent transition-colors"
-                          style={{ color: "var(--fg)" }}
-                        >
-                          <span style={{ width: 14, display: "inline-flex" }}>
-                            {o.id === organizationId ? <Check className="h-3.5 w-3.5" /> : null}
-                          </span>
-                          <span className="min-w-0 flex-1 truncate">{o.displayName}</span>
-                          <RoleBadge role={o.role} />
-                        </button>
-                      ))}
-                    </div>
-                    {hasHiddenTeams && (
-                      <button
-                        type="button"
-                        role="menuitem"
-                        onClick={() => setTeamsExpanded((value) => !value)}
-                        className="flex w-full items-center gap-2 px-4 py-1.5 text-left text-label hover:bg-accent transition-colors"
-                        style={{ color: "var(--fg-2)" }}
-                      >
-                        {teamsExpanded ? (
-                          <ChevronUp className="h-3.5 w-3.5" />
-                        ) : (
-                          <ChevronDown className="h-3.5 w-3.5" />
-                        )}
-                        <span>{teamsExpanded ? "Show fewer teams" : `View ${hiddenTeamCount} more teams`}</span>
-                      </button>
-                    )}
-                  </div>
-                )}
-              </div>
-            )}
-
-            {/* Org actions */}
-            <div className="border-b py-1" style={{ borderColor: "var(--border)" }}>
-              <button
-                type="button"
-                role="menuitem"
-                onClick={openCreate}
-                className="flex w-full items-center gap-2 px-4 py-1.5 text-left text-body hover:bg-accent transition-colors"
-                style={{ color: "var(--fg)" }}
-              >
-                <Plus className="h-3.5 w-3.5" />
-                <span>Create new team</span>
-              </button>
-              <button
-                type="button"
-                role="menuitem"
-                onClick={openJoin}
-                className="flex w-full items-center gap-2 px-4 py-1.5 text-left text-body hover:bg-accent transition-colors"
-                style={{ color: "var(--fg)" }}
-              >
-                <UserPlus className="h-3.5 w-3.5" />
-                <span>Join with invite link</span>
-              </button>
-              {/* Invite teammates — the global, role-agnostic entry to share the
-                  org's invite link from any page (issue 836). Only shown when a
-                  team is selected, since the link is org-scoped; the dialog's
-                  panel role-forks (members copy, admins also rotate). */}
-              {organizationId && (
-                <button
-                  type="button"
-                  role="menuitem"
-                  onClick={openInvite}
-                  className="flex w-full items-center gap-2 px-4 py-1.5 text-left text-body hover:bg-accent transition-colors"
-                  style={{ color: "var(--fg)" }}
-                >
-                  <Link2 className="h-3.5 w-3.5" />
-                  <span>Invite teammates</span>
-                </button>
+              {username && username !== displayName && (
+                <div className="text-label text-muted-foreground truncate">@{username}</div>
               )}
             </div>
-
-            {/* User actions */}
-            <div className="py-1">
-              <button
-                type="button"
-                role="menuitem"
-                onClick={() => {
-                  setOpen(false);
-                  logout();
-                  // Leave the app on the marketing site rather than an app
-                  // route — `logout()` clears local auth state, so staying in
-                  // the SPA would just redirect to the login page.
-                  window.location.href = PARENT_URL;
-                }}
-                className="flex w-full items-center gap-2 px-4 py-1.5 text-left text-body hover:bg-accent transition-colors"
-                style={{ color: "var(--fg)" }}
-              >
-                <LogOut className="h-3.5 w-3.5" />
-                <span>Sign out</span>
-              </button>
-            </div>
           </div>
-        )}
-      </div>
 
-      <TeamSetupModal action={setupAction} onClose={() => setSetupAction(null)} />
-      <InviteDialog open={inviteOpen} onOpenChange={setInviteOpen} />
-    </>
-  );
-}
-
-function RoleBadge({ role }: { role: string | null | undefined }) {
-  if (role !== "admin" && role !== "member") return null;
-  return (
-    <span
-      className="mono uppercase text-caption"
-      style={{
-        padding: "var(--hairline) var(--sp-1_75)",
-        borderRadius: "var(--radius-chip)",
-        color: role === "admin" ? "var(--brand-dim)" : "var(--fg-3)",
-        border: "var(--hairline) solid var(--border)",
-        background: role === "admin" ? "var(--brand-bg)" : "var(--bg-sunken)",
-      }}
-    >
-      {role}
-    </span>
+          {/* User actions */}
+          <div className="py-1">
+            <button
+              type="button"
+              role="menuitem"
+              onClick={() => {
+                setOpen(false);
+                logout();
+                // Leave the app on the marketing site rather than an app
+                // route — `logout()` clears local auth state, so staying in
+                // the SPA would just redirect to the login page.
+                window.location.href = PARENT_URL;
+              }}
+              className="flex w-full items-center gap-2 px-4 py-1.5 text-left text-body hover:bg-accent transition-colors"
+              style={{ color: "var(--fg)" }}
+            >
+              <LogOut className="h-3.5 w-3.5" />
+              <span>Sign out</span>
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
   );
 }

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -878,6 +878,40 @@
   animation: subtle-fade 180ms ease-out;
 }
 
+/* Team-switch transition veil — a single intentional overlay shown while an
+   org switch runs, replacing the old "every per-org component blanks to its
+   own skeleton" flash (the cache clear in `selectOrganization` is kept; only
+   the visual is consolidated). Covers the content region below the 48-tall
+   header, including content-area overlays (conversation list / right rail
+   z-30, doc-preview drawer z-40). z-index 45 keeps it above those but below
+   the switch menu (z-[46], so its in-flight spinner stays visible) and any
+   dialog (z-50). Opacity-only fade so reduced-motion can drop it. */
+@keyframes team-switch-veil-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+.team-switch-veil {
+  position: fixed;
+  inset: 48px 0 0 0;
+  z-index: 45;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: color-mix(in oklch, var(--bg) 76%, transparent);
+  backdrop-filter: blur(1px);
+  animation: team-switch-veil-in 140ms ease-out;
+}
+@media (prefers-reduced-motion: reduce) {
+  .team-switch-veil {
+    animation: none;
+    backdrop-filter: none;
+  }
+}
+
 /* Left-aligned content column that fills the shared 960 canvas, matching the
    Team / Agent Detail tabs (same `--sp-2 --sp-5 --sp-7` content padding under a
    PageHeader). No min-height / centering — the page used to render as a

--- a/packages/web/src/pages/__tests__/team-switcher-preview.test.ts
+++ b/packages/web/src/pages/__tests__/team-switcher-preview.test.ts
@@ -8,7 +8,7 @@ const REAL_ORGS: OrgBrief[] = [{ id: "real-org", name: "real", displayName: "Rea
 beforeEach(() => {
   vi.resetModules();
   localStorage.clear();
-  window.history.replaceState(null, "", "/preview/user-menu");
+  window.history.replaceState(null, "", "/preview/team-switcher");
   globalThis.fetch = vi.fn(async () => {
     return new Response(JSON.stringify(REAL_ORGS), {
       status: 200,
@@ -21,13 +21,17 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-it("does not intercept the organizations endpoint — the account menu no longer fetches orgs", async () => {
+it("scopes the mocked organizations endpoint to the team-switcher preview path", async () => {
   const { api } = await import("../../api/client.js");
-  await import("../user-menu-preview.js");
+  await import("../team-switcher-preview.js");
 
-  // The account preview must NOT patch api.get: team switching (and its org
-  // fetch) moved to /preview/team-switcher. /me/organizations falls straight
-  // through to the real client even while on the user-menu preview path.
+  const previewOrgs = await api.get<OrgBrief[]>("/me/organizations");
+  expect(previewOrgs.length).toBeGreaterThan(1);
+  expect(previewOrgs.map((org) => org.id)).toContain("org-1");
+  expect(globalThis.fetch).not.toHaveBeenCalled();
+
+  window.history.replaceState(null, "", "/");
+
   await expect(api.get<OrgBrief[]>("/me/organizations")).resolves.toEqual(REAL_ORGS);
   expect(globalThis.fetch).toHaveBeenCalledWith("/api/v1/me/organizations", expect.objectContaining({ method: "GET" }));
 });

--- a/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
+++ b/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
@@ -127,6 +127,8 @@ const authMock = vi.hoisted(() => {
       login: vi.fn(async () => undefined),
       adoptTokens: vi.fn(async () => undefined),
       selectOrganization: vi.fn(async () => undefined),
+      switchingOrg: null,
+      setSwitchingOrg: vi.fn(),
       refreshMe: vi.fn(async () => undefined),
       logout: vi.fn(),
     },
@@ -1367,14 +1369,16 @@ describe("web DOM interaction coverage", () => {
     await waitForText("npm install -g first-tree", document.body);
   });
 
-  it("opens UserMenu, switches orgs, opens setup actions, and signs out", async () => {
+  it("switches orgs and opens setup actions from the TeamSwitcher, and signs out from the UserMenu", async () => {
     clientApiMocks.post.mockResolvedValue({});
+    const { TeamSwitcher } = await import("../../components/team-switcher.js");
     const { UserMenu } = await import("../../components/user-menu.js");
     const selectOrganization = vi.fn(async () => undefined);
     const logout = vi.fn();
     authMock.value = {
       ...authMock.value,
       organizationId: "org-1",
+      teamDisplayName: "Acme",
       selectOrganization,
       logout,
     };
@@ -1387,45 +1391,51 @@ describe("web DOM interaction coverage", () => {
     const originalGet = api.get;
     api.get = getMock;
 
-    const menu = await renderDom(<UserMenu />);
-    await waitForText("", menu.container);
-    await click(menu.container.querySelector('button[aria-haspopup="menu"]'));
-    await waitForText("Acme", menu.container);
+    // Team switching + management live in the header-left TeamSwitcher now.
+    const switcher = await renderDom(<TeamSwitcher redirectHomeOnSwitch={false} />);
+    await click(switcher.container.querySelector('button[aria-haspopup="menu"]'));
+    await waitForText("Beta", switcher.container);
     await click(
-      [...menu.container.querySelectorAll("button")].find((button) => button.textContent?.includes("Beta")) ?? null,
+      [...switcher.container.querySelectorAll("button")].find((button) => button.textContent?.includes("Beta")) ?? null,
     );
     expect(selectOrganization).toHaveBeenCalledWith("org-2");
 
-    await click(menu.container.querySelector('button[aria-haspopup="menu"]'));
+    await click(switcher.container.querySelector('button[aria-haspopup="menu"]'));
     await click(
-      [...menu.container.querySelectorAll("button")].find((button) =>
+      [...switcher.container.querySelectorAll("button")].find((button) =>
         button.textContent?.includes("Create new team"),
       ) ?? null,
     );
     await waitForText("Create", document.body);
 
-    await click(menu.container.querySelector('button[aria-haspopup="menu"]'));
+    await click(switcher.container.querySelector('button[aria-haspopup="menu"]'));
     await click(
-      [...menu.container.querySelectorAll("button")].find((button) =>
+      [...switcher.container.querySelectorAll("button")].find((button) =>
         button.textContent?.includes("Join with invite link"),
       ) ?? null,
     );
     await waitForText("Join", document.body);
 
-    await click(menu.container.querySelector('button[aria-haspopup="menu"]'));
+    // The avatar menu is account-only: no team rows, just Sign out.
+    const account = await renderDom(<UserMenu />);
+    await click(account.container.querySelector('button[aria-haspopup="menu"]'));
+    expect(account.container.textContent).not.toContain("Beta");
+    expect(account.container.textContent).not.toContain("Create new team");
     await click(
-      [...menu.container.querySelectorAll("button")].find((button) => button.textContent?.includes("Sign out")) ?? null,
+      [...account.container.querySelectorAll("button")].find((button) => button.textContent?.includes("Sign out")) ??
+        null,
     );
     expect(logout).toHaveBeenCalled();
     api.get = originalGet;
   });
 
-  it("keeps the selected team first and collapses long team lists", async () => {
-    const { UserMenu } = await import("../../components/user-menu.js");
+  it("shows the current team in the header and lists the other teams without a collapse", async () => {
+    const { TeamSwitcher } = await import("../../components/team-switcher.js");
     authMock.value = {
       ...authMock.value,
       organizationId: "org-current",
       role: "admin",
+      teamDisplayName: "Current Team",
       selectOrganization: vi.fn(async () => undefined),
     };
     const getMock = async <T,>(): Promise<T> =>
@@ -1442,33 +1452,20 @@ describe("web DOM interaction coverage", () => {
     const originalGet = api.get;
     api.get = getMock;
 
-    const menu = await renderDom(<UserMenu />);
-    await click(menu.container.querySelector('button[aria-haspopup="menu"]'));
-    await waitForText("Current Team", menu.container);
+    const switcher = await renderDom(<TeamSwitcher redirectHomeOnSwitch={false} />);
+    await click(switcher.container.querySelector('button[aria-haspopup="menu"]'));
+    await waitForText("Current Team", switcher.container);
 
-    const visibleTeamButtons = [...menu.container.querySelectorAll("button[role='menuitem']")].filter((button) =>
-      ["Current Team", "Alpha", "Beta", "Gamma", "Delta", "Epsilon", "Zeta"].some((name) =>
-        button.textContent?.includes(name),
-      ),
-    );
-    expect(
-      visibleTeamButtons.map(
-        (button) =>
-          ["Current Team", "Alpha", "Beta", "Gamma", "Delta", "Epsilon", "Zeta"].find((name) =>
-            button.textContent?.includes(name),
-          ) ?? "",
-      ),
-    ).toEqual(["Current Team", "Alpha", "Beta", "Gamma", "Delta"]);
-    expect(menu.container.textContent).not.toContain("Epsilon");
-    expect(menu.container.textContent).toContain("View 2 more teams");
-
-    await click(
-      [...menu.container.querySelectorAll("button")].find((button) =>
-        button.textContent?.includes("View 2 more teams"),
-      ) ?? null,
-    );
-    await waitForText("Zeta", menu.container);
-    expect(menu.container.textContent).toContain("Show fewer teams");
+    // The current team is the menu header; the switch list is the OTHER teams,
+    // all shown (scroll, not a "View N more" collapse), with no duplicate row.
+    const teamNames = ["Alpha", "Beta", "Gamma", "Delta", "Epsilon", "Zeta", "Current Team"];
+    const switchRowNames = [...switcher.container.querySelectorAll("button[role='menuitem']")]
+      .map((button) => teamNames.find((name) => button.textContent?.includes(name)))
+      .filter((name): name is string => Boolean(name));
+    expect(switchRowNames).toEqual(["Alpha", "Beta", "Gamma", "Delta", "Epsilon", "Zeta"]);
+    expect(switcher.container.textContent).toContain("Epsilon");
+    expect(switcher.container.textContent).not.toContain("View 2 more teams");
+    expect(switcher.container.textContent).not.toContain("Show fewer teams");
     api.get = originalGet;
   });
 

--- a/packages/web/src/pages/onboarding/__tests__/hooks-flow.test.tsx
+++ b/packages/web/src/pages/onboarding/__tests__/hooks-flow.test.tsx
@@ -404,7 +404,7 @@ describe("onboarding hooks and flow", () => {
   });
 
   it("re-derives the step when the org changes on a still-mounted provider", async () => {
-    // The onboarding shell renders the full UserMenu for multi-team users, so a
+    // The onboarding shell renders the real TeamSwitcher for multi-team users, so a
     // user can create/join/switch teams from inside /onboarding. That calls
     // selectOrganization without leaving the route, so the provider does NOT
     // remount — the org changes underneath a mounted provider.

--- a/packages/web/src/pages/onboarding/__tests__/shell-rail-team-dom.test.tsx
+++ b/packages/web/src/pages/onboarding/__tests__/shell-rail-team-dom.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
 
 import type { OrgBrief } from "@first-tree/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, type ReactElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { MemoryRouter } from "react-router";
@@ -19,14 +20,15 @@ const eventMock = vi.hoisted(() => ({
 
 const authMock = vi.hoisted(() => ({
   logout: vi.fn(),
+  organizationId: "org-1",
+  role: "admin" as "admin" | "member",
+  teamDisplayName: "Acme",
+  user: { id: "user-1", displayName: "Gandy", username: "gandy", avatarUrl: null },
+  selectOrganization: vi.fn(async () => undefined),
+  switchingOrg: null as OrgBrief | null,
+  setSwitchingOrg: vi.fn(),
   // Shell only reads memberships.length; keep the shape minimal.
   memberships: [] as Array<{ organizationId: string }>,
-}));
-
-const userMenuMock = vi.hoisted(() => ({
-  // The real UserMenu has its own DOM tests (layout-dom); here we only assert
-  // the shell's conditional mounting, so a marker stub keeps this test focused.
-  UserMenu: () => <div data-testid="user-menu-stub" />,
 }));
 
 const toastMock = vi.hoisted(() => ({
@@ -61,7 +63,17 @@ vi.mock("../../../components/ui/toast.js", () => ({
   useToast: () => toastMock,
 }));
 
-vi.mock("../../../components/user-menu.js", () => userMenuMock);
+vi.mock("../../../components/avatar.js", () => ({
+  Avatar: ({ name }: { name?: string }) => <span data-testid="avatar">{name ?? ""}</span>,
+}));
+
+vi.mock("../../../components/invite-dialog.js", () => ({
+  InviteDialog: () => null,
+}));
+
+vi.mock("../../../components/team-setup-modal.js", () => ({
+  TeamSetupModal: () => null,
+}));
 
 vi.mock("../onboarding-flow.js", () => ({
   useOnboardingFlow: () => flowMock.value,
@@ -90,8 +102,13 @@ async function renderDom(element: ReactElement): Promise<HTMLElement> {
   const container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   await act(async () => {
-    root?.render(<MemoryRouter>{element}</MemoryRouter>);
+    root?.render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>{element}</MemoryRouter>
+      </QueryClientProvider>,
+    );
   });
   await flush();
   return container;
@@ -125,6 +142,10 @@ async function submit(form: HTMLFormElement | null): Promise<void> {
 beforeEach(() => {
   vi.clearAllMocks();
   authMock.memberships = [];
+  authMock.organizationId = "org-1";
+  authMock.role = "admin";
+  authMock.teamDisplayName = "Acme";
+  authMock.switchingOrg = null;
   document.body.innerHTML = "";
   flowMock.value = {
     activeStep: "team",
@@ -194,18 +215,35 @@ describe("onboarding shell and team step", () => {
     expect(container.textContent).toContain("Step 1 of 2");
   });
 
-  it("mounts the full UserMenu for multi-team users in place of the bare sign-out link", async () => {
+  it("mounts a real team switcher for multi-team users in place of the bare sign-out link", async () => {
     // The trapped-user scenario: routed into onboarding for a second org with
-    // no agent here (finish-later hidden) — the workspace UserMenu is the way
+    // no agent here (finish-later hidden) — the team switcher is the way
     // back to their other team.
     flowMock.value = { ...flowMock.value, activeStep: "connect-computer", hasAgent: false, organizationId: "org-2" };
+    authMock.organizationId = "org-2";
+    authMock.teamDisplayName = "Globex";
     authMock.memberships = [{ organizationId: "org-2" }, { organizationId: "org-1" }];
+    apiMock.get.mockResolvedValueOnce([
+      org({ id: "org-2", name: "globex", displayName: "Globex", role: "member" }),
+      org({ id: "org-1", name: "acme", displayName: "Acme", role: "admin" }),
+    ]);
     const { OnboardingShell } = await import("../onboarding-shell.js");
 
     const container = await renderDom(<OnboardingShell>Body</OnboardingShell>);
 
-    expect(container.querySelector("[data-testid='user-menu-stub']")).not.toBeNull();
+    const anchor = container.querySelector<HTMLButtonElement>(
+      "[data-testid='team-switcher'] button[aria-haspopup='menu']",
+    );
+    expect(anchor).not.toBeNull();
+    expect(anchor?.textContent).toContain("Globex");
     expect(container.textContent).not.toContain("Sign out");
+
+    await click(anchor);
+    const acmeRow = [...container.querySelectorAll("button")].find((button) => button.textContent?.includes("Acme"));
+    expect(acmeRow).not.toBeNull();
+
+    await click(acmeRow ?? null);
+    expect(authMock.selectOrganization).toHaveBeenCalledWith("org-1");
   });
 
   it("keeps the minimal sign-out chrome for first-run single-team users", async () => {
@@ -215,7 +253,7 @@ describe("onboarding shell and team step", () => {
 
     const container = await renderDom(<OnboardingShell>Body</OnboardingShell>);
 
-    expect(container.querySelector("[data-testid='user-menu-stub']")).toBeNull();
+    expect(container.querySelector("[data-testid='team-switcher']")).toBeNull();
     expect(container.textContent).toContain("Sign out");
   });
 

--- a/packages/web/src/pages/onboarding/__tests__/shell-rail-team-dom.test.tsx
+++ b/packages/web/src/pages/onboarding/__tests__/shell-rail-team-dom.test.tsx
@@ -236,7 +236,7 @@ describe("onboarding shell and team step", () => {
     );
     expect(anchor).not.toBeNull();
     expect(anchor?.textContent).toContain("Globex");
-    expect(container.textContent).not.toContain("Sign out");
+    expect(container.textContent).toContain("Sign out");
 
     await click(anchor);
     const acmeRow = [...container.querySelectorAll("button")].find((button) => button.textContent?.includes("Acme"));
@@ -244,6 +244,11 @@ describe("onboarding shell and team step", () => {
 
     await click(acmeRow ?? null);
     expect(authMock.selectOrganization).toHaveBeenCalledWith("org-1");
+
+    await click(
+      [...container.querySelectorAll("button")].find((button) => button.textContent?.includes("Sign out")) ?? null,
+    );
+    expect(authMock.logout).toHaveBeenCalled();
   });
 
   it("keeps the minimal sign-out chrome for first-run single-team users", async () => {

--- a/packages/web/src/pages/onboarding/onboarding-flow.tsx
+++ b/packages/web/src/pages/onboarding/onboarding-flow.tsx
@@ -176,7 +176,7 @@ export function OnboardingFlowProvider({ path, children }: { path: OnboardingPat
   const sequence = getStepSequence(path);
   const [activeIndex, setActiveIndex] = useState<number>(() => resolveLandingStep(path, orgStep, organizationId));
 
-  // The onboarding shell renders the full UserMenu for multi-team users, so the
+  // The onboarding shell renders the real TeamSwitcher for multi-team users, so the
   // selected org can change while this provider stays mounted (creating /
   // joining / switching teams calls selectOrganization without a route
   // remount). Re-derive the landing step for the new org rather than carry the

--- a/packages/web/src/pages/onboarding/onboarding-shell.tsx
+++ b/packages/web/src/pages/onboarding/onboarding-shell.tsx
@@ -2,9 +2,10 @@ import type { ReactNode } from "react";
 import { useNavigate } from "react-router";
 import { useAuth } from "../../auth/auth-context.js";
 import { FirstTreeLogo } from "../../components/first-tree-logo.js";
+import { TeamSwitchOverlay } from "../../components/team-switch-overlay.js";
+import { TeamSwitcher } from "../../components/team-switcher.js";
 import { Button } from "../../components/ui/button.js";
 import { useToast } from "../../components/ui/toast.js";
-import { UserMenu } from "../../components/user-menu.js";
 import { COPY, STEP_COPY } from "./copy.js";
 import { useOnboardingFlow } from "./onboarding-flow.js";
 import { StepProgress } from "./step-progress.js";
@@ -40,12 +41,12 @@ export function OnboardingShell({ children }: { children: ReactNode }) {
   const copy = STEP_COPY[activeStep];
   const isHero = HERO_STEPS.has(activeStep);
 
-  // A multi-team user gets the full workspace UserMenu (team switching,
-  // create/join, invite, sign out) instead of the bare "Sign out" link. The
+  // A multi-team user gets the real TeamSwitcher instead of the bare "Sign out"
+  // link. The account-only UserMenu is absent from onboarding chrome. The
   // workspace gate routes a returning user into onboarding whenever the
   // SELECTED org has no usable agent, so a user who switches into a
   // not-yet-set-up team lands here with no agent in THIS org ("finish later"
-  // hidden below) — without the menu they had no way back to the team they
+  // hidden below) — without the switcher they had no way back to the team they
   // came from short of signing out. Switching teams via the menu is the same
   // affordance they used to get here, and it carries no dismissal side effect
   // (the account-level dismissal would suppress onboarding for every org).
@@ -87,11 +88,11 @@ export function OnboardingShell({ children }: { children: ReactNode }) {
               {COPY.finishLater}
             </Button>
           )}
-          {/* Multi-team: the full workspace UserMenu (sign out lives inside it).
+          {/* Multi-team: the real team switcher escape hatch.
               First-run: a bare Sign out link, always available so a user who
               can't finish right now isn't locked out. */}
           {isMultiTeam ? (
-            <UserMenu />
+            <TeamSwitcher />
           ) : (
             <Button type="button" variant="link" className="h-auto p-0 text-label" onClick={logout}>
               Sign out
@@ -165,6 +166,7 @@ export function OnboardingShell({ children }: { children: ReactNode }) {
           </div>
         </main>
       </div>
+      <TeamSwitchOverlay />
     </div>
   );
 }

--- a/packages/web/src/pages/onboarding/onboarding-shell.tsx
+++ b/packages/web/src/pages/onboarding/onboarding-shell.tsx
@@ -41,8 +41,8 @@ export function OnboardingShell({ children }: { children: ReactNode }) {
   const copy = STEP_COPY[activeStep];
   const isHero = HERO_STEPS.has(activeStep);
 
-  // A multi-team user gets the real TeamSwitcher instead of the bare "Sign out"
-  // link. The account-only UserMenu is absent from onboarding chrome. The
+  // A multi-team user gets the real TeamSwitcher plus the bare "Sign out" link.
+  // The account-only UserMenu is absent from onboarding chrome. The
   // workspace gate routes a returning user into onboarding whenever the
   // SELECTED org has no usable agent, so a user who switches into a
   // not-yet-set-up team lands here with no agent in THIS org ("finish later"
@@ -88,11 +88,16 @@ export function OnboardingShell({ children }: { children: ReactNode }) {
               {COPY.finishLater}
             </Button>
           )}
-          {/* Multi-team: the real team switcher escape hatch.
+          {/* Multi-team: the real team switcher escape hatch plus account exit.
               First-run: a bare Sign out link, always available so a user who
               can't finish right now isn't locked out. */}
           {isMultiTeam ? (
-            <TeamSwitcher />
+            <>
+              <TeamSwitcher />
+              <Button type="button" variant="link" className="h-auto p-0 text-label" onClick={logout}>
+                Sign out
+              </Button>
+            </>
           ) : (
             <Button type="button" variant="link" className="h-auto p-0 text-label" onClick={logout}>
               Sign out

--- a/packages/web/src/pages/team-identity-panel.tsx
+++ b/packages/web/src/pages/team-identity-panel.tsx
@@ -39,8 +39,8 @@ export function TeamIdentityPanel() {
     },
     onSuccess: (next: Organization) => {
       queryClient.setQueryData(["organization", organizationId], next);
-      // /me/organizations cached in UserMenu — bust so the dropdown
-      // displayName updates without a reload.
+      // /me/organizations is cached by the header TeamSwitcher — bust it so the
+      // team anchor + switch list pick up the new displayName without a reload.
       queryClient.invalidateQueries({ queryKey: ["me-organizations"] });
       setSaved(true);
       setTimeout(() => setSaved(false), 2000);

--- a/packages/web/src/pages/team-switcher-preview.tsx
+++ b/packages/web/src/pages/team-switcher-preview.tsx
@@ -1,0 +1,196 @@
+import type { OrgBrief } from "@first-tree/shared";
+import { useMemo, useRef, useState } from "react";
+import { api } from "../api/client.js";
+import { AuthContext } from "../auth/auth-context.js";
+import { TeamSwitchOverlay } from "../components/team-switch-overlay.js";
+import { TeamSwitcher } from "../components/team-switcher.js";
+
+/**
+ * DEV-only visual preview of the header team switcher, mounted at
+ * `/preview/team-switcher` (gated by `import.meta.env.DEV` in app.tsx).
+ *
+ * Renders the REAL `TeamSwitcher` + `TeamSwitchOverlay` against an 8-org
+ * fixture under a faked auth context, so every state under review is demoable
+ * without a backend or login:
+ *   - multi-team menu (current-team header + scrollable "other teams" list),
+ *   - the in-flight switch (row spinner + disabled list + optimistic anchor +
+ *     "Switching to {name}…" veil) via a deliberately slow `selectOrganization`,
+ *   - the failure path (rollback + inline "Couldn't switch" + menu stays open)
+ *     via the "force failure" toggle, and
+ *   - the single-team degrade (anchor stays, no switch list) via the toggle.
+ *
+ * `TeamSwitcher` gets `redirectHomeOnSwitch={false}` so a successful switch
+ * stays on this page (react-router forbids nesting a router to absorb the
+ * production `navigate("/")`).
+ */
+
+// Extracted so it can double as the provably-defined fallback below (the index
+// `MOCK_ORGS[0]` is `OrgBrief | undefined` under noUncheckedIndexedAccess).
+const FALLBACK_ORG: OrgBrief = { id: "org-1", name: "acme-robotics", displayName: "Acme Robotics", role: "admin" };
+
+const MOCK_ORGS: OrgBrief[] = [
+  FALLBACK_ORG,
+  { id: "org-2", name: "globex", displayName: "Globex", role: "member" },
+  { id: "org-3", name: "initech", displayName: "Initech", role: "member" },
+  { id: "org-4", name: "umbrella-corp", displayName: "Umbrella Corp", role: "member" },
+  { id: "org-5", name: "wayne-enterprises", displayName: "Wayne Enterprises", role: "admin" },
+  { id: "org-6", name: "stark-industries", displayName: "Stark Industries", role: "member" },
+  { id: "org-7", name: "cyberdyne", displayName: "Cyberdyne", role: "member" },
+  { id: "org-8", name: "tyrell-corp", displayName: "Tyrell Corp", role: "admin" },
+];
+
+type ApiGet = typeof api.get;
+
+declare global {
+  interface Window {
+    __ftTeamSwitcherPreviewOriginalGet?: ApiGet;
+  }
+}
+
+// Single-team toggle: read by the path-gated `/me/organizations` patch below.
+// Assigned during render (not in an effect) so the value is current before the
+// remounted TeamSwitcher's fetch effect — child effects run before parent
+// effects, so an effect-set flag would lag a frame behind the remount.
+let previewSingle = false;
+
+// Patch at module load so the TeamSwitcher effect sees the mock on first render.
+// Path-gated and HMR-safe — matches the user-menu / onboarding preview shims.
+window.__ftTeamSwitcherPreviewOriginalGet ??= api.get;
+const originalGet = window.__ftTeamSwitcherPreviewOriginalGet;
+api.get = (<T,>(path: string): Promise<T> => {
+  if (window.location.pathname.startsWith("/preview/team-switcher") && path === "/me/organizations") {
+    // The generic API client cannot infer this string path maps to OrgBrief[].
+    const list = previewSingle ? MOCK_ORGS.slice(0, 1) : MOCK_ORGS;
+    return Promise.resolve(list as T);
+  }
+  return originalGet<T>(path);
+}) as ApiGet;
+
+export function TeamSwitcherPreviewPage() {
+  const [organizationId, setOrganizationId] = useState("org-1");
+  const [switchingOrg, setSwitchingOrg] = useState<OrgBrief | null>(null);
+  const [single, setSingle] = useState(false);
+  const [forceFail, setForceFail] = useState(false);
+  // Render the icon-only anchor variant the header falls back to on narrow.
+  const [compact, setCompact] = useState(false);
+  // Read synchronously inside the async `selectOrganization`, so toggling
+  // "force failure" mid-session takes effect without re-creating the auth value.
+  const forceFailRef = useRef(forceFail);
+  forceFailRef.current = forceFail;
+  // Sync the module flag before children render/fetch (see note above).
+  previewSingle = single;
+
+  const currentOrg = MOCK_ORGS.find((o) => o.id === organizationId) ?? FALLBACK_ORG;
+
+  const auth = useMemo(
+    () =>
+      ({
+        isAuthenticated: true,
+        meLoaded: true,
+        organizationId,
+        role: currentOrg.role,
+        teamDisplayName: currentOrg.displayName,
+        user: { id: "user-self", displayName: "Gandy", username: "gandy2025", avatarUrl: null },
+        switchingOrg,
+        setSwitchingOrg,
+        selectOrganization: async (id: string) => {
+          // Deliberately slow so the in-flight visuals (spinner, disabled list,
+          // optimistic anchor, veil) are observable; the real one is fast.
+          await new Promise((resolve) => window.setTimeout(resolve, 700));
+          if (forceFailRef.current) throw new Error("preview: forced switch failure");
+          setOrganizationId(id);
+        },
+        logout: () => undefined,
+        // The remaining auth fields are irrelevant to the switcher — same
+        // unavoidable-cast pattern as /preview/user-menu.
+      }) as unknown as Parameters<typeof AuthContext.Provider>[0]["value"],
+    [organizationId, currentOrg.role, currentOrg.displayName, switchingOrg],
+  );
+
+  return (
+    <AuthContext.Provider value={auth}>
+      <div style={{ minHeight: "100vh", background: "var(--bg)" }}>
+        {/* Mock header — anchor sits header-left, account avatar would be right. */}
+        <header
+          className="flex items-center"
+          style={{
+            height: 48,
+            gap: "var(--sp-3_5)",
+            padding: "0 var(--sp-3)",
+            borderBottom: "var(--hairline) solid var(--border)",
+            background: "var(--bg-raised)",
+          }}
+        >
+          <span className="text-title" style={{ color: "var(--fg)" }}>
+            First Tree
+          </span>
+          <span aria-hidden style={{ width: 1, height: 18, background: "var(--border)", flexShrink: 0 }} />
+          {/* key remounts the switcher when the single-team fixture flips, so it
+              re-fetches the filtered org list. */}
+          <TeamSwitcher
+            key={single ? "single" : "multi"}
+            variant={compact ? "compact" : "full"}
+            redirectHomeOnSwitch={false}
+          />
+        </header>
+
+        {/* Mock content so the transition veil has something to dim. */}
+        <div style={{ padding: "var(--sp-4)" }}>
+          <div className="flex flex-col" style={{ gap: "var(--sp-2_5)" }}>
+            {["team standup", "release checklist", "context tree review", "onboarding polish"].map((title) => (
+              <div key={title} className="flex items-center" style={{ gap: "var(--sp-2_5)" }}>
+                <div
+                  style={{
+                    width: 30,
+                    height: 30,
+                    flex: "none",
+                    borderRadius: "var(--radius-full)",
+                    background: "var(--bg-sunken)",
+                  }}
+                />
+                <div className="text-subtitle" style={{ color: "var(--fg)" }}>
+                  {title}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* Preview controls */}
+          <div className="flex items-center" style={{ gap: "var(--sp-2)", marginTop: "var(--sp-5)", flexWrap: "wrap" }}>
+            <PreviewToggle on={single} label="Single team" onClick={() => setSingle((v) => !v)} />
+            <PreviewToggle on={forceFail} label="Force switch failure" onClick={() => setForceFail((v) => !v)} />
+            <PreviewToggle on={compact} label="Compact anchor (narrow)" onClick={() => setCompact((v) => !v)} />
+            <PreviewToggle on={false} label="Theme" onClick={() => document.documentElement.classList.toggle("dark")} />
+          </div>
+          <p className="text-caption" style={{ color: "var(--fg-3)", marginTop: "var(--sp-3)" }}>
+            Open the anchor and pick a team — watch the row spinner, disabled list, optimistic anchor, and the
+            "Switching to…" veil (~0.7s here). "Force switch failure" rolls back with an inline retry hint; "Single
+            team" drops the switch list but keeps the anchor.
+          </p>
+        </div>
+      </div>
+
+      <TeamSwitchOverlay />
+    </AuthContext.Provider>
+  );
+}
+
+function PreviewToggle({ on, label, onClick }: { on: boolean; label: string; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="text-label"
+      style={{
+        padding: "var(--sp-1_5) var(--sp-3)",
+        border: "var(--hairline) solid var(--border)",
+        borderRadius: "var(--radius-input)",
+        background: on ? "var(--fg)" : "var(--bg-raised)",
+        color: on ? "var(--bg)" : "var(--fg-2)",
+        cursor: "pointer",
+      }}
+    >
+      {label}
+    </button>
+  );
+}

--- a/packages/web/src/pages/user-menu-preview.tsx
+++ b/packages/web/src/pages/user-menu-preview.tsx
@@ -1,86 +1,27 @@
-import type { OrgBrief } from "@first-tree/shared";
-import { useMemo, useState } from "react";
-import { api } from "../api/client.js";
+import { useMemo } from "react";
 import { AuthContext } from "../auth/auth-context.js";
 import { UserMenu } from "../components/user-menu.js";
 
 /**
- * DEV-only visual preview of the user menu's team list, mounted at
- * `/preview/user-menu` (gated by `import.meta.env.DEV` in app.tsx).
+ * DEV-only visual preview of the account menu, mounted at `/preview/user-menu`
+ * (gated by `import.meta.env.DEV` in app.tsx).
  *
- * Renders the REAL `UserMenu` against a 8-org fixture so the two behaviours
- * under review are demoable without a backend or login:
- *   - the current team is always pinned as the first row, and
- *   - lists longer than 5 collapse behind "View N more teams".
- *
- * Switching teams in the preview updates the faked auth `organizationId`
- * in-place and then REJECTS — `switchOrg`'s catch branch keeps the menu
- * open and skips its `navigate("/")` (react-router forbids nesting a
- * MemoryRouter here), so the re-pinned order is visible immediately.
- *
- * `api.get` is patched for `/me/organizations` only while the current route
- * is `/preview/user-menu` — every other path and every non-preview route falls
- * through to the real client.
+ * Renders the REAL `UserMenu` — now account-only (user header + Sign out) —
+ * under a faked auth context, no backend or login needed. Team switching and
+ * team management moved to the header-left switcher; see `/preview/team-switcher`.
  */
-
-const MOCK_ORGS: OrgBrief[] = [
-  { id: "org-1", name: "antgroup", displayName: "antgroup", role: "member" },
-  { id: "org-2", name: "gandy2025s-team", displayName: "gandy2025's team", role: "admin" },
-  { id: "org-3", name: "agent-team-foundation", displayName: "agent-team-foundation", role: "admin" },
-  { id: "org-4", name: "first-tree-qa", displayName: "first-tree-qa", role: "member" },
-  { id: "org-5", name: "hearback", displayName: "hearback", role: "admin" },
-  { id: "org-6", name: "kael-labs", displayName: "kael-labs", role: "member" },
-  { id: "org-7", name: "weekend-hacks", displayName: "weekend-hacks", role: "member" },
-  { id: "org-8", name: "design-playground", displayName: "design-playground", role: "member" },
-];
-
-type ApiGet = typeof api.get;
-
-declare global {
-  interface Window {
-    __ftUserMenuPreviewOriginalGet?: ApiGet;
-  }
-}
-
-// Patch at module load so the UserMenu effect sees the mock on first render.
-// The interception is path-gated and the original is stashed for HMR, matching
-// the safer preview-shim pattern used by onboarding-preview.tsx.
-window.__ftUserMenuPreviewOriginalGet ??= api.get;
-const originalGet = window.__ftUserMenuPreviewOriginalGet;
-api.get = (<T,>(path: string): Promise<T> => {
-  if (window.location.pathname.startsWith("/preview/user-menu") && path === "/me/organizations") {
-    // The generic API client cannot infer that this string path maps to OrgBrief[].
-    return Promise.resolve(MOCK_ORGS as T);
-  }
-  return originalGet<T>(path);
-}) as ApiGet;
-
 export function UserMenuPreviewPage() {
-  // Default to a mid-list org so the pin-to-top behaviour is visible
-  // immediately (org-5 sits 5th in the raw /me/organizations order).
-  const [organizationId, setOrganizationId] = useState("org-5");
-  const currentRole = MOCK_ORGS.find((o) => o.id === organizationId)?.role ?? "member";
-
   const auth = useMemo(
     () =>
       ({
         isAuthenticated: true,
         meLoaded: true,
-        organizationId,
-        role: currentRole,
-        user: { displayName: "Gandy", username: "gandy2025", avatarUrl: null },
-        selectOrganization: async (id: string) => {
-          setOrganizationId(id);
-          // Reject on purpose: switchOrg's catch keeps the dropdown open and
-          // skips navigate("/"), so the preview stays on this page with the
-          // newly pinned order visible in place.
-          throw new Error("preview: stay on page");
-        },
+        user: { id: "user-self", displayName: "Gandy", username: "gandy2025", avatarUrl: null },
         logout: () => undefined,
-        // The remaining ~15 fields are irrelevant to UserMenu — same
+        // The remaining auth fields are irrelevant to the account menu — same
         // unavoidable-cast pattern as /preview/resources.
       }) as unknown as Parameters<typeof AuthContext.Provider>[0]["value"],
-    [organizationId, currentRole],
+    [],
   );
 
   return (
@@ -95,24 +36,16 @@ export function UserMenuPreviewPage() {
           }}
         >
           <span className="text-label" style={{ color: "var(--fg-2)" }}>
-            /preview/user-menu — click the avatar; current team is pinned first, 8 mock teams collapse at 5
+            /preview/user-menu — account menu (team switching lives at /preview/team-switcher)
           </span>
           <UserMenu />
         </header>
         <div className="text-caption" style={{ padding: "var(--sp-4)", color: "var(--fg-3)" }}>
-          <p>
-            Current team:{" "}
-            <strong style={{ color: "var(--fg)" }}>
-              {MOCK_ORGS.find((o) => o.id === organizationId)?.displayName}
-            </strong>{" "}
-            (switching a team re-pins it to the top — reopen the menu to see).
-          </p>
           <button
             type="button"
             className="text-caption mono"
             onClick={() => document.documentElement.classList.toggle("dark")}
             style={{
-              marginTop: "var(--sp-2)",
               padding: "var(--sp-1) var(--sp-2_5)",
               border: "var(--hairline) solid var(--border)",
               borderRadius: "var(--radius-input)",


### PR DESCRIPTION
## Why

The "switch team" interaction in the right-side avatar menu wasn't smooth: switching felt like a full-page reload (cache clear + jump home + zero feedback → a blank flash), you could never tell *which* team you were in (the current team lived nowhere persistent), and the list was flat with a mislabeled "Current team" header. The core data-isolation bug (realtime/data stuck on the old org) was already fixed in #1221; this is the UX redesign on top of it.

Design + interactive prototype by **ux-expert** (behavior follows the prototype; this PR implements its dev SPEC).

## What

**Part 1 — smoother switching + Part 2 — a persistent team anchor, in one PR.**

- **New `TeamSwitcher`** (header-left anchor): the always-present "which team am I in" marker and the entry point for switching + team management. Opens a menu with the current team, a scrollable list of the *other* teams, and Create / Join / Invite. Team identicons reuse `<Avatar seed={org.id}>` (no backend change — `OrgBrief` has no logo/color).
- **New `TeamSwitchOverlay`**: one intentional `Switching to {name}…` veil over the content during a switch, replacing the per-component blank-skeleton flash. Driven by a single `switchingOrg` signal in `auth-context` that also powers the optimistic anchor label and the picked row's spinner + disabled list. Double-click guarded; failure rolls back the optimistic anchor and shows an inline retry hint with the menu kept open.
- **`UserMenu` slimmed to account-only** (user header + Sign out). Team and account are now separate surfaces — team on the left, account on the right.
- **Responsive header**: the anchor sits in the brand cluster at `xl`/`md` and becomes an icon-only leading column on `narrow` (so it survives the brand drop). Single-team users keep the anchor too (no switch list).
- Keeps #1221's `queryClient.clear()` for org data isolation. Fixes a stale `team-setup-modal` comment. No search (long lists scroll).
- **`/preview/team-switcher`** (DEV) added for QA, covering multi/single team, in-flight, failure, compact, and dark mode.

## Verification

- `pnpm --filter @first-tree/web lint:tokens`, `pnpm check` (Biome), `pnpm --filter @first-tree/web typecheck`, and the full web suite (**126 files / 980 tests**) all green. New DOM tests cover the switch orchestration (optimistic anchor, double-click guard, failure rollback, single-team) + the header anchor at wide/narrow.
- Live browse·QA on `/preview/team-switcher`: multi-team menu, in-flight veil (optimistic anchor + row spinner + disabled list, no blank flash), failure rollback + inline error, single-team degrade, compact/narrow anchor, dark mode. No real console errors.
- Independent **codex review**: PASS (no P1). Two P2 findings fixed in this branch — the switch veil now layers above content-area overlays (z-45, below the menu z-46 and dialogs z-50), and the anchor/list now read from a shared `["me-organizations"]` React Query so a team rename refreshes them without a reload (the existing rename invalidation now actually applies).

## Note for review

The one residual is the `narrow` real-Layout grid reflow (tabs horizontal scroll + avatar not clipped). It's covered by `layout-dom` test logic, but the authenticated Layout can't be loaded headlessly without a backend, so it's worth a quick spot-check on staging after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)