### PR TITLE
fix(web): refresh agent roster after onboarding agent creation

### DIFF
--- a/packages/web/src/pages/onboarding/__tests__/hooks-flow.test.tsx
+++ b/packages/web/src/pages/onboarding/__tests__/hooks-flow.test.tsx
@@ -138,16 +138,22 @@ afterEach(async () => {
   document.body.innerHTML = "";
 });
 
-async function renderProbe(element: ReactNode, route = "/onboarding"): Promise<HTMLElement> {
+function testQueryClient(): QueryClient {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+async function renderProbe(
+  element: ReactNode,
+  route = "/onboarding",
+  queryClient: QueryClient = testQueryClient(),
+): Promise<HTMLElement> {
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
   await act(async () => {
     root?.render(
       <MemoryRouter initialEntries={[route]}>
-        <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
-          {element}
-        </QueryClientProvider>
+        <QueryClientProvider client={queryClient}>{element}</QueryClientProvider>
       </MemoryRouter>,
     );
   });
@@ -226,6 +232,12 @@ describe("onboarding hooks and flow", () => {
   it("creates an agent, stores its uuid, reports onboarding, and reaches online", async () => {
     const latest = { current: null as ReturnType<typeof useAgentCreation> | null };
     const onOnline = vi.fn();
+    const queryClient = testQueryClient();
+    const rosterKey = ["agents", "org-list", { addressableOnly: true }] as const;
+    queryClient.setQueryData(rosterKey, {
+      items: [{ uuid: "human-agent-self", type: "human", delegateMention: null }],
+      nextCursor: null,
+    });
     clientMocks.api.post.mockResolvedValueOnce({ uuid: "agent-created" });
     agentConfigMocks.getAgentClientStatus
       .mockResolvedValueOnce({ online: false })
@@ -236,7 +248,7 @@ describe("onboarding hooks and flow", () => {
       return <div>{latest.current.phase}</div>;
     }
 
-    await renderProbe(<Probe />);
+    await renderProbe(<Probe />, "/onboarding", queryClient);
     await act(async () => {
       await expectHookValue(latest.current).create({
         displayName: "Deploy Bot",
@@ -258,6 +270,7 @@ describe("onboarding hooks and flow", () => {
     );
     expect(sessionStorage.getItem("onboarding:agentUuid")).toBe("agent-created");
     expect(eventMocks.reportOnboardingEvent).toHaveBeenCalledWith("agent_created", { runtimeProvider: "claude-code" });
+    expect(queryClient.getQueryState(rosterKey)?.isInvalidated).toBe(true);
     expect(onOnline).toHaveBeenCalledWith("agent-created");
     expect(expectHookValue(latest.current).phase).toBe("online");
   });

--- a/packages/web/src/pages/onboarding/use-agent-creation.ts
+++ b/packages/web/src/pages/onboarding/use-agent-creation.ts
@@ -1,4 +1,5 @@
 import type { AgentVisibility } from "@first-tree/shared";
+import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { getAgentClientStatus } from "../../api/agent-config.js";
 import { api, withOrg } from "../../api/client.js";
@@ -37,6 +38,7 @@ export type CreateAgentArgs = {
  * creation. On success, `onOnline(uuid)` fires once.
  */
 export function useAgentCreation(onOnline: (uuid: string) => void) {
+  const queryClient = useQueryClient();
   const [phase, setPhase] = useState<AgentCreationPhase>("idle");
   const [error, setError] = useState<string | null>(null);
   const createdRef = useRef<string | null>(null);
@@ -100,6 +102,7 @@ export function useAgentCreation(onOnline: (uuid: string) => void) {
         agentUuid = res.uuid;
         createdRef.current = agentUuid;
         writeOnboardingAgentUuid(agentUuid);
+        await queryClient.invalidateQueries({ queryKey: ["agents"] });
         void reportOnboardingEvent("agent_created", { runtimeProvider: args.runtimeProvider });
       } catch (err) {
         setError(err instanceof Error ? err.message : "Failed to add your agent to the team");
@@ -108,7 +111,7 @@ export function useAgentCreation(onOnline: (uuid: string) => void) {
       }
       await pollUntilReady(agentUuid);
     },
-    [pollUntilReady],
+    [pollUntilReady, queryClient],
   );
 
   const retry = useCallback(async (): Promise<void> => {


### PR DESCRIPTION
## Summary
- invalidate the shared agents roster cache after onboarding creates an agent
- keep the existing server-side first-agent delegate adoption as the source of truth
- add a regression assertion so New chat can see the refreshed delegate state

## Verification
- `pnpm --filter @first-tree/web exec vitest run src/pages/onboarding/__tests__/hooks-flow.test.tsx`
- `pnpm --filter @first-tree/web typecheck`
- `pnpm exec biome check packages/web/src/pages/onboarding/use-agent-creation.ts packages/web/src/pages/onboarding/__tests__/hooks-flow.test.tsx`
- `pnpm --filter @first-tree/server exec vitest run src/__tests__/admin-agents.test.ts`
- `pnpm --filter @first-tree/web exec vitest run src/pages/workspace/conversations/__tests__/pick-default.test.ts`