### PR TITLE
fix(web): keep sticky-collapsed summary closed on scroll

### DIFF
--- a/packages/web/src/pages/workspace/center/__tests__/chat-summary.test.ts
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-summary.test.ts
@@ -249,6 +249,33 @@ describe("ChatSummary", () => {
     container.remove();
   });
 
+  it("does not auto-expand a sticky-collapsed summary when scrolling back to the top", async () => {
+    localStorage.clear();
+    const scrollEl = document.createElement("div");
+    const { container, root } = await renderSummary(scrollEl, {
+      descriptionUpdatedAt: unreadVersionAt,
+      lastReadAt: readRecentlyAt,
+    });
+    expect(container.querySelector<HTMLButtonElement>('button[aria-label="Collapse summary"]')).not.toBeNull();
+
+    await act(async () => {
+      scrollEl.scrollTop = 120;
+      scrollEl.dispatchEvent(new Event("scroll"));
+    });
+    expect(container.querySelector<HTMLButtonElement>('button[aria-label="Expand summary"]')).not.toBeNull();
+    expect(container.querySelector("strong")).toBeNull();
+
+    await act(async () => {
+      scrollEl.scrollTop = 0;
+      scrollEl.dispatchEvent(new Event("scroll"));
+    });
+    expect(container.querySelector<HTMLButtonElement>('button[aria-label="Expand summary"]')).not.toBeNull();
+    expect(container.querySelector("strong")).toBeNull();
+
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
   it("expands on the first click from the sticky-collapsed bar", async () => {
     localStorage.clear();
     const scrollEl = document.createElement("div");

--- a/packages/web/src/pages/workspace/center/chat-summary.tsx
+++ b/packages/web/src/pages/workspace/center/chat-summary.tsx
@@ -33,15 +33,18 @@ import { formatRelative } from "../../../lib/utils.js";
  *
  * Auto behavior: default collapsed; auto-expand once on entry when the update
  * is unread for this viewer, unless they already manually dismissed this exact
- * summary version; while expanded, scrolling the stream folds it to the bar
- * (restores at the top); a manual toggle always wins and is remembered per
- * chat. Renders nothing when the chat has no description.
+ * summary version; while expanded, scrolling the stream folds it to the bar;
+ * expanding again is an explicit toggle. A manual toggle always wins and is
+ * remembered per chat. Renders nothing when the chat has no description.
  */
 
-// Scroll sticky-collapse thresholds (px from the stream top). The hysteresis
-// gap (40 vs 6) debounces the boundary so a hair of scroll doesn't flutter it.
+// Scroll sticky-collapse threshold (px from the stream top). Moving beyond this
+// folds the expanded summary to its one-line bar.
 const SCROLL_COLLAPSE_PX = 40;
-const SCROLL_RESTORE_PX = 6;
+// When a manual expand happens while already scrolled down, returning near the
+// top clears that temporary anchor so later downward movement uses the standard
+// collapse threshold. It does not auto-expand a sticky-collapsed summary.
+const MANUAL_EXPAND_RESET_PX = 6;
 
 // Per-chat manual expand/collapse preference. Mirrors the localStorage pattern
 // used elsewhere in the chat view (private-mode safe, per-chat key suffix).
@@ -254,9 +257,9 @@ export function ChatSummary({
   }, [chatId, descriptionUpdatedAt, scrollContainerRef, unread]);
 
   // Sticky-collapse: while open, scrolling the message stream down folds the
-  // header to its one-line bar; returning to the top restores it. Transient —
-  // never persisted — and a manual toggle clears it. Refs keep the scroll
-  // handler cheap and free of stale closures.
+  // header to its one-line bar. It never auto-expands on scroll; opening again
+  // is an explicit toggle. Transient — never persisted — and a manual toggle
+  // clears it. Refs keep the scroll handler cheap and free of stale closures.
   const openRef = useRef(open);
   openRef.current = open;
   const scrollCollapsedRef = useRef(scrollCollapsed);
@@ -273,15 +276,13 @@ export function ChatSummary({
       const nextScrolled = top > 1;
       if (nextScrolled !== scrolledRef.current) setScrolled(nextScrolled);
       const manualExpandTop = manualExpandTopRef.current;
-      if (top <= SCROLL_RESTORE_PX) {
+      if (top <= MANUAL_EXPAND_RESET_PX) {
         manualExpandTopRef.current = null;
       }
       const collapseTop = manualExpandTop === null ? SCROLL_COLLAPSE_PX : manualExpandTop + SCROLL_COLLAPSE_PX;
       if (top > collapseTop && openRef.current && !scrollCollapsedRef.current) {
         manualExpandTopRef.current = null;
         setScrollCollapsed(true);
-      } else if (top <= SCROLL_RESTORE_PX && scrollCollapsedRef.current) {
-        setScrollCollapsed(false);
       }
     };
     el.addEventListener("scroll", onScroll, { passive: true });


### PR DESCRIPTION
## Problem

After the expanded chat Summary auto-collapses while the user scrolls the message stream, pulling/scrolling back to the top expands the Summary again. That reads as the UI fighting the user's scroll gesture: once the user has moved past the Summary, scrolling should not reopen it.

## Root cause

The sticky-collapse logic had an explicit restore branch: when `scrollTop <= 6` and the Summary was `scrollCollapsed`, it cleared the collapsed state and expanded the body again.

That branch predates the wheel-bridge stopgap in #1245. #1245 did not introduce the restore behavior, but by forwarding more wheel input from the Summary region into the message stream it can make the old restore path easier to hit.

## Fix

- Keep the existing downward-scroll auto-collapse behavior.
- Remove scroll-driven auto-expand on return to the top.
- Preserve explicit user control: clicking the collapsed Summary bar still expands it on the first click.
- Keep the small top reset only for the manual-expand anchor; it no longer changes `scrollCollapsed`.

## Verification

- `pnpm exec vitest run src/pages/workspace/center/__tests__/chat-summary.test.ts` from `packages/web` (27 tests)
- `pnpm --filter @first-tree/web typecheck`
- `pnpm exec biome check packages/web/src/pages/workspace/center/chat-summary.tsx packages/web/src/pages/workspace/center/__tests__/chat-summary.test.ts`
- `pnpm --filter @first-tree/web test` (125 files / 994 tests)

🤖 Generated with Codex