### PR TITLE
fix(client): defer idle-suspend while a provider has a live subprocess

### DIFF
--- a/packages/client/src/__tests__/process-tree-probe.test.ts
+++ b/packages/client/src/__tests__/process-tree-probe.test.ts
@@ -40,10 +40,18 @@ describe("process-tree-probe pure helpers", () => {
     expect(hasDescendant(999, idx)).toBe(false);
   });
 
-  it("extracts FIRST_TREE_CHAT_ID from a ps -E command line", () => {
+  it("extracts FIRST_TREE_CHAT_ID from a Darwin `ps -E` (space-separated) line", () => {
     const line = "FIRST_TREE_HOME=/x FIRST_TREE_CHAT_ID=f93566d9-00c8 FIRST_TREE_AGENT_ID=019e /bin/claude";
     expect(extractChatId(line)).toBe("f93566d9-00c8");
     expect(extractChatId("no marker here")).toBeNull();
+  });
+
+  it("extracts FIRST_TREE_CHAT_ID from Linux `/proc/<pid>/environ` (NUL-separated), stopping at the NUL", () => {
+    const environ = ["FIRST_TREE_HOME=/x", "FIRST_TREE_CHAT_ID=f93566d9-00c8", "FIRST_TREE_AGENT_ID=019e", ""].join(
+      "\0",
+    );
+    // The value must not bleed into the next NUL-separated entry.
+    expect(extractChatId(environ)).toBe("f93566d9-00c8");
   });
 });
 
@@ -71,6 +79,21 @@ describe("PsSubprocessProbe", () => {
     expect(probe.hasLiveSubprocess("chat-A")).toBe(true);
     expect(probe.hasLiveSubprocess("chat-B")).toBe(false);
     expect(probe.hasLiveSubprocess("chat-unknown")).toBe(false);
+    probe.stop();
+  });
+
+  it("attributes providers from NUL-separated env (Linux /proc form)", async () => {
+    const probe = new PsSubprocessProbe({
+      log: silentLogger(),
+      daemonPid,
+      intervalMs: 1_000_000,
+      runProcessSnapshot: async () => snapshot,
+      runEnvForPid: async (pid) =>
+        ["FIRST_TREE_HOME=/x", `FIRST_TREE_CHAT_ID=${pid === 100 ? "chat-A" : "chat-B"}`, ""].join("\0"),
+    });
+    await probe.refresh();
+    expect(probe.hasLiveSubprocess("chat-A")).toBe(true);
+    expect(probe.hasLiveSubprocess("chat-B")).toBe(false);
     probe.stop();
   });
 

--- a/packages/client/src/__tests__/process-tree-probe.test.ts
+++ b/packages/client/src/__tests__/process-tree-probe.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildChildrenIndex,
+  extractChatId,
+  findProviderPids,
+  hasDescendant,
+  PsSubprocessProbe,
+  parseProcessRows,
+} from "../runtime/process-tree-probe.js";
+import { silentLogger } from "./_logger-helpers.js";
+
+describe("process-tree-probe pure helpers", () => {
+  it("parses ps pid/ppid/comm rows and skips unparseable lines", () => {
+    const out = ["  100   55 /opt/homebrew/bin/claude", " 101  100 /bin/zsh", "garbage", "", "102 101 sleep"].join(
+      "\n",
+    );
+    expect(parseProcessRows(out)).toEqual([
+      { pid: 100, ppid: 55, comm: "/opt/homebrew/bin/claude" },
+      { pid: 101, ppid: 100, comm: "/bin/zsh" },
+      { pid: 102, ppid: 101, comm: "sleep" },
+    ]);
+  });
+
+  it("finds claude providers that are direct children of the daemon (macOS path + linux basename)", () => {
+    const rows = [
+      { pid: 100, ppid: 55, comm: "/opt/homebrew/bin/claude" },
+      { pid: 200, ppid: 55, comm: "claude" },
+      { pid: 300, ppid: 55, comm: "/usr/bin/codex" },
+      { pid: 400, ppid: 99, comm: "claude" }, // not a direct child of the daemon
+    ];
+    expect(findProviderPids(rows, 55).sort((a, b) => a - b)).toEqual([100, 200]);
+  });
+
+  it("detects a live descendant via a direct child, and its absence", () => {
+    const idx = buildChildrenIndex([
+      { pid: 101, ppid: 100, comm: "/bin/zsh" },
+      { pid: 102, ppid: 101, comm: "sleep" },
+    ]);
+    expect(hasDescendant(100, idx)).toBe(true);
+    expect(hasDescendant(999, idx)).toBe(false);
+  });
+
+  it("extracts FIRST_TREE_CHAT_ID from a ps -E command line", () => {
+    const line = "FIRST_TREE_HOME=/x FIRST_TREE_CHAT_ID=f93566d9-00c8 FIRST_TREE_AGENT_ID=019e /bin/claude";
+    expect(extractChatId(line)).toBe("f93566d9-00c8");
+    expect(extractChatId("no marker here")).toBeNull();
+  });
+});
+
+describe("PsSubprocessProbe", () => {
+  const daemonPid = 55;
+  // chat-A provider (100) has a live watcher; chat-B provider (200) has none.
+  const snapshot = [
+    `100  ${daemonPid} /opt/homebrew/bin/claude`,
+    "101  100 /bin/zsh",
+    "102  101 sleep",
+    `200  ${daemonPid} /opt/homebrew/bin/claude`,
+  ].join("\n");
+  const envForPid = async (pid: number): Promise<string> =>
+    pid === 100 ? "FIRST_TREE_CHAT_ID=chat-A /bin/claude" : "FIRST_TREE_CHAT_ID=chat-B /bin/claude";
+
+  it("marks only providers that currently have a live descendant", async () => {
+    const probe = new PsSubprocessProbe({
+      log: silentLogger(),
+      daemonPid,
+      intervalMs: 1_000_000,
+      runProcessSnapshot: async () => snapshot,
+      runEnvForPid: envForPid,
+    });
+    await probe.refresh();
+    expect(probe.hasLiveSubprocess("chat-A")).toBe(true);
+    expect(probe.hasLiveSubprocess("chat-B")).toBe(false);
+    expect(probe.hasLiveSubprocess("chat-unknown")).toBe(false);
+    probe.stop();
+  });
+
+  it("falls back to no-live-work when the process scan fails", async () => {
+    const probe = new PsSubprocessProbe({
+      log: silentLogger(),
+      daemonPid,
+      intervalMs: 1_000_000,
+      runProcessSnapshot: async () => {
+        throw new Error("ps unavailable");
+      },
+      runEnvForPid: envForPid,
+    });
+    await probe.refresh();
+    expect(probe.hasLiveSubprocess("chat-A")).toBe(false);
+    probe.stop();
+  });
+});

--- a/packages/client/src/__tests__/session-manager.test.ts
+++ b/packages/client/src/__tests__/session-manager.test.ts
@@ -12,6 +12,7 @@ import type {
   SessionMessage,
   TurnOutcome,
 } from "../runtime/handler.js";
+import type { SubprocessProbe } from "../runtime/process-tree-probe.js";
 import { SessionManager } from "../runtime/session-manager.js";
 import type { FirstTreeHubSDK } from "../sdk.js";
 import { recordingLogger, silentLogger } from "./_logger-helpers.js";
@@ -108,6 +109,7 @@ function createSessionManager(opts: {
   agentConfigCache?: AgentConfigCache;
   recoverChat?: (chatId: string) => Promise<void>;
   onSessionEvent?: (chatId: string, event: SessionEvent) => void;
+  subprocessProbe?: SubprocessProbe;
 }) {
   const handler = opts.handler ?? createMockHandler();
   const factory: HandlerFactory = opts.handlerFactory ?? (() => handler);
@@ -121,6 +123,7 @@ function createSessionManager(opts: {
       reconcile_interval_seconds: 300,
     },
     concurrency: opts.concurrency ?? 5,
+    subprocessProbe: opts.subprocessProbe,
     handlerFactory: factory,
     handlerConfig: opts.handlerConfig ?? { workspaceRoot: "/tmp/test" },
     // Tests never want the live git-backed resolver — default to a no-op so a
@@ -1969,6 +1972,110 @@ describe("SessionManager lazy Context Tree binding", () => {
     await sm.dispatch(mockEntry({ id: 2, chatId: "c-once", messageId: "m2" }));
 
     expect(resolve).toHaveBeenCalledTimes(1);
+
+    await sm.shutdown();
+  });
+});
+
+describe("SessionManager subprocess-aware suspend/eviction", () => {
+  it("defers idle-suspend while the provider has a live subprocess, then suspends once it clears", async () => {
+    vi.useFakeTimers();
+    try {
+      let ctx: SessionContext | undefined;
+      const handler = createMockHandler({
+        async start(_msg, c) {
+          ctx = c;
+          return "sid";
+        },
+      });
+      const hasLive = vi.fn().mockReturnValue(true);
+      const probe: SubprocessProbe = { hasLiveSubprocess: hasLive, stop: vi.fn() };
+      const sm = createSessionManager({
+        handler,
+        subprocessProbe: probe,
+        session: { idle_timeout: 1, max_sessions: 10, working_grace_seconds: 100, reconcile_interval_seconds: 300 },
+      });
+
+      await sm.dispatch(mockEntry({ id: 1, chatId: "chat-1" }));
+      await finishEntry(ctx, 1, "chat-1");
+
+      // Past idle_timeout (1s) but well under the hard cap (1 + 100s): the live
+      // subprocess keeps the session active.
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(handler.suspend).not.toHaveBeenCalled();
+
+      // Subprocess gone -> the next idle tick suspends as usual.
+      hasLive.mockReturnValue(false);
+      await vi.advanceTimersByTimeAsync(11_000);
+      expect(handler.suspend).toHaveBeenCalledTimes(1);
+
+      await sm.shutdown();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("suspends past the idle_timeout + working_grace hard cap even with a live subprocess", async () => {
+    vi.useFakeTimers();
+    try {
+      let ctx: SessionContext | undefined;
+      const handler = createMockHandler({
+        async start(_msg, c) {
+          ctx = c;
+          return "sid";
+        },
+      });
+      const probe: SubprocessProbe = { hasLiveSubprocess: vi.fn().mockReturnValue(true), stop: vi.fn() };
+      const sm = createSessionManager({
+        handler,
+        subprocessProbe: probe,
+        // Hard cap = idle_timeout(1) + working_grace(2) = 3s.
+        session: { idle_timeout: 1, max_sessions: 10, working_grace_seconds: 2, reconcile_interval_seconds: 300 },
+      });
+
+      await sm.dispatch(mockEntry({ id: 1, chatId: "chat-1" }));
+      await finishEntry(ctx, 1, "chat-1");
+
+      await vi.advanceTimersByTimeAsync(15_000);
+      expect(handler.suspend).toHaveBeenCalledTimes(1);
+
+      await sm.shutdown();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("prefers an idle session without a live subprocess as the concurrency-yield victim", async () => {
+    const handlers: AgentHandler[] = [];
+    const ctxs: Record<string, SessionContext> = {};
+    const factory: HandlerFactory = () => {
+      const h = createMockHandler({
+        async start(msg, c) {
+          ctxs[(msg as { chatId: string }).chatId] = c;
+          return `sid-${(msg as { chatId: string }).chatId}`;
+        },
+      });
+      handlers.push(h);
+      return h;
+    };
+    // chat-1 has a live watcher; chat-2 does not.
+    const probe: SubprocessProbe = {
+      hasLiveSubprocess: vi.fn((chatId: string) => chatId === "chat-1"),
+      stop: vi.fn(),
+    };
+    const sm = createSessionManager({ handlerFactory: factory, concurrency: 2, subprocessProbe: probe });
+
+    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-1" }));
+    await finishEntry(ctxs["chat-1"], 1, "chat-1");
+    await sm.dispatch(mockEntry({ id: 2, chatId: "chat-2" }));
+    await finishEntry(ctxs["chat-2"], 2, "chat-2");
+
+    // Slots full (concurrency 2), both idle. chat-1 is older, so the old logic
+    // would yield it — but it has a live subprocess, so chat-2 must yield.
+    await sm.dispatch(mockEntry({ id: 3, chatId: "chat-3" }));
+
+    expect(handlers[0]?.suspend).not.toHaveBeenCalled();
+    expect(handlers[1]?.suspend).toHaveBeenCalledTimes(1);
 
     await sm.shutdown();
   });

--- a/packages/client/src/runtime/agent-slot.ts
+++ b/packages/client/src/runtime/agent-slot.ts
@@ -17,6 +17,7 @@ import { resolveAgentContextTreeBinding } from "./bootstrap.js";
 import type { SessionConfig } from "./config.js";
 import { clampRetryAttempt, classify, ERROR_KINDS, nextRetryDelayMs } from "./error-taxonomy.js";
 import type { HandlerFactory } from "./handler.js";
+import { PsSubprocessProbe } from "./process-tree-probe.js";
 import { SessionManager } from "./session-manager.js";
 
 /**
@@ -244,9 +245,17 @@ export class AgentSlot {
       const recoverChat = (chatId: string) => this.clientConnection.sendInboxRecover(agent.agentId, chatId);
       const runtimeProvider = runtimeProviderSchema.safeParse(runtimeType);
 
+      // Defer idle-suspend while a provider has a live background subprocess
+      // (default on; opt out via `session.defer_suspend_on_subprocess: false`).
+      const subprocessProbe =
+        this.config.session.defer_suspend_on_subprocess !== false
+          ? new PsSubprocessProbe({ log: this.logger })
+          : undefined;
+
       this.sessionManager = new SessionManager({
         session: this.config.session,
         concurrency: this.config.concurrency,
+        subprocessProbe,
         handlerFactory: this.config.handlerFactory,
         handlerConfig: {
           workspaceRoot,

--- a/packages/client/src/runtime/config.ts
+++ b/packages/client/src/runtime/config.ts
@@ -26,6 +26,14 @@ const sessionConfigSchema = z
      * `session-manager.ts`.
      */
     working_grace_seconds: z.number().int().positive().default(3600),
+    /**
+     * Defer idle-suspend (and deprioritize concurrency eviction) for a session
+     * whose provider still has a live background subprocess, up to the
+     * `idle_timeout + working_grace_seconds` hard cap. Optional here (the
+     * authoritative default lives in `@first-tree/shared` `agentConfigSchema`);
+     * unset is treated as enabled by `agent-slot`.
+     */
+    defer_suspend_on_subprocess: z.boolean().optional(),
     /** How often the client reconciles its local chatIds with the server. */
     reconcile_interval_seconds: z.number().int().min(30).max(3600).default(300),
   })

--- a/packages/client/src/runtime/process-tree-probe.ts
+++ b/packages/client/src/runtime/process-tree-probe.ts
@@ -1,0 +1,173 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import type { pino } from "../observability/logger.js";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Detects whether a session's provider process currently has any live
+ * descendant process — e.g. a `Bash run_in_background` watcher polling a CI
+ * run. SessionManager consults this to defer idle-suspend and to deprioritize
+ * concurrency eviction while such background work is in flight, so the
+ * provider's "background task complete -> re-invoke the agent" wake-up is not
+ * lost by tearing the session down underneath it.
+ *
+ * The provider (a `claude` process spawned by the Claude Agent SDK) is a direct
+ * child of this daemon process, and the daemon stamps a per-session
+ * `FIRST_TREE_CHAT_ID` env var onto it. So the probe maps a provider pid back
+ * to its chatId by reading that env var; it never needs to track individual
+ * child pids — only whether the provider currently has a descendant at all.
+ */
+export interface SubprocessProbe {
+  /** True if the provider for `chatId` currently has at least one live descendant. */
+  hasLiveSubprocess(chatId: string): boolean;
+  /** Stop the background refresh loop (called on SessionManager shutdown). */
+  stop(): void;
+}
+
+export type ProcessRow = { pid: number; ppid: number; comm: string };
+
+/** Parse `ps -axo pid=,ppid=,comm=` output into rows. Unparseable lines are skipped. */
+export function parseProcessRows(output: string): ProcessRow[] {
+  const rows: ProcessRow[] = [];
+  for (const line of output.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const match = trimmed.match(/^(\d+)\s+(\d+)\s+(.*)$/);
+    if (!match) continue;
+    rows.push({ pid: Number(match[1]), ppid: Number(match[2]), comm: match[3] ?? "" });
+  }
+  return rows;
+}
+
+/** Build a parent-pid -> child-pids adjacency index. */
+export function buildChildrenIndex(rows: readonly ProcessRow[]): Map<number, number[]> {
+  const byParent = new Map<number, number[]>();
+  for (const { pid, ppid } of rows) {
+    const existing = byParent.get(ppid);
+    if (existing) existing.push(pid);
+    else byParent.set(ppid, [pid]);
+  }
+  return byParent;
+}
+
+/** A provider is a `claude` process; `comm` is a full path on macOS, a basename on Linux. */
+function isClaudeComm(comm: string): boolean {
+  return comm === "claude" || comm.endsWith("/claude");
+}
+
+/** Provider pids = `claude` processes that are direct children of the daemon. */
+export function findProviderPids(rows: readonly ProcessRow[], daemonPid: number): number[] {
+  return rows.filter((row) => row.ppid === daemonPid && isClaudeComm(row.comm)).map((row) => row.pid);
+}
+
+/**
+ * True if `pid` has at least one direct child. A direct-child check is
+ * sufficient to detect any live descendant: a `run_in_background` task lives
+ * under the launcher shell (a direct child of the provider) for its whole life,
+ * and if that launcher exits the task reparents to the provider (a subreaper) —
+ * so a live descendant always implies a live direct child.
+ */
+export function hasDescendant(pid: number, childrenByParent: ReadonlyMap<number, number[]>): boolean {
+  return (childrenByParent.get(pid)?.length ?? 0) > 0;
+}
+
+/** Extract the `FIRST_TREE_CHAT_ID` value from a process's env-annotated `ps -E` line. */
+export function extractChatId(envText: string): string | null {
+  const match = envText.match(/\bFIRST_TREE_CHAT_ID=(\S+)/);
+  return match ? (match[1] ?? null) : null;
+}
+
+type PsSubprocessProbeOptions = {
+  log: pino.Logger;
+  /** Defaults to this daemon process. */
+  daemonPid?: number;
+  /** Refresh cadence; defaults to 10s (matches the idle-eviction tick). */
+  intervalMs?: number;
+  /** Injectable for tests: returns `ps -axo pid=,ppid=,comm=` stdout. */
+  runProcessSnapshot?: () => Promise<string>;
+  /** Injectable for tests: returns `ps -Eww -p <pid> -o command=` stdout. */
+  runEnvForPid?: (pid: number) => Promise<string>;
+};
+
+async function defaultProcessSnapshot(): Promise<string> {
+  const { stdout } = await execFileAsync("ps", ["-axo", "pid=,ppid=,comm="]);
+  return stdout;
+}
+
+async function defaultEnvForPid(pid: number): Promise<string> {
+  const { stdout } = await execFileAsync("ps", ["-Eww", "-p", String(pid), "-o", "command="]);
+  return stdout;
+}
+
+/**
+ * `ps`-backed {@link SubprocessProbe}. Refreshes a `chatId -> has-live-subprocess`
+ * snapshot on a background interval (async, off the event-loop hot path) so the
+ * synchronous `hasLiveSubprocess` lookup used inside `evictIdle` never blocks on
+ * a process scan.
+ */
+export class PsSubprocessProbe implements SubprocessProbe {
+  private chatIdsWithLiveWork = new Set<string>();
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private inflight: Promise<void> | null = null;
+  private readonly daemonPid: number;
+  private readonly runProcessSnapshot: () => Promise<string>;
+  private readonly runEnvForPid: (pid: number) => Promise<string>;
+
+  constructor(private readonly opts: PsSubprocessProbeOptions) {
+    this.daemonPid = opts.daemonPid ?? process.pid;
+    this.runProcessSnapshot = opts.runProcessSnapshot ?? defaultProcessSnapshot;
+    this.runEnvForPid = opts.runEnvForPid ?? defaultEnvForPid;
+    void this.refresh();
+    this.timer = setInterval(() => void this.refresh(), opts.intervalMs ?? 10_000);
+    // Never keep the process alive just for the probe.
+    this.timer.unref?.();
+  }
+
+  hasLiveSubprocess(chatId: string): boolean {
+    return this.chatIdsWithLiveWork.has(chatId);
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  /**
+   * Recompute the snapshot once. Concurrent callers share the in-flight run
+   * (so a test can `await refresh()` and deterministically observe the result
+   * of the constructor's initial refresh).
+   */
+  refresh(): Promise<void> {
+    if (this.inflight) return this.inflight;
+    this.inflight = this.doRefresh().finally(() => {
+      this.inflight = null;
+    });
+    return this.inflight;
+  }
+
+  private async doRefresh(): Promise<void> {
+    try {
+      const rows = parseProcessRows(await this.runProcessSnapshot());
+      const childrenByParent = buildChildrenIndex(rows);
+      const next = new Set<string>();
+      for (const providerPid of findProviderPids(rows, this.daemonPid)) {
+        if (!hasDescendant(providerPid, childrenByParent)) continue;
+        const chatId = extractChatId(await this.runEnvForPid(providerPid));
+        if (chatId) next.add(chatId);
+      }
+      this.chatIdsWithLiveWork = next;
+    } catch (err) {
+      // A probe failure must never wedge the runtime: fall back to "no live
+      // work", which simply lets suspend proceed exactly as it did before this
+      // feature existed.
+      this.opts.log.debug(
+        { err },
+        "subprocess probe refresh failed; treating all sessions as having no live subprocess",
+      );
+      this.chatIdsWithLiveWork = new Set();
+    }
+  }
+}

--- a/packages/client/src/runtime/process-tree-probe.ts
+++ b/packages/client/src/runtime/process-tree-probe.ts
@@ -1,4 +1,5 @@
 import { execFile } from "node:child_process";
+import { readFile } from "node:fs/promises";
 import { promisify } from "node:util";
 import type { pino } from "../observability/logger.js";
 
@@ -72,9 +73,15 @@ export function hasDescendant(pid: number, childrenByParent: ReadonlyMap<number,
   return (childrenByParent.get(pid)?.length ?? 0) > 0;
 }
 
-/** Extract the `FIRST_TREE_CHAT_ID` value from a process's env-annotated `ps -E` line. */
+/**
+ * Extract the `FIRST_TREE_CHAT_ID` value from a process's environment dump.
+ * Handles both forms produced by {@link defaultEnvForPid}: space-separated
+ * (Darwin `ps -Eww`) and NUL-separated (Linux `/proc/<pid>/environ`). The value
+ * therefore stops at the next whitespace OR NUL, so it never bleeds into the
+ * following env entry.
+ */
 export function extractChatId(envText: string): string | null {
-  const match = envText.match(/\bFIRST_TREE_CHAT_ID=(\S+)/);
+  const match = envText.match(/\bFIRST_TREE_CHAT_ID=([^\s\0]+)/);
   return match ? (match[1] ?? null) : null;
 }
 
@@ -96,6 +103,13 @@ async function defaultProcessSnapshot(): Promise<string> {
 }
 
 async function defaultEnvForPid(pid: number): Promise<string> {
+  // Platform-aware: Linux/procps rejects the BSD `-E` flag, so read the env
+  // directly from procfs there (NUL-separated KEY=VALUE entries). Darwin/BSD
+  // `ps` has no procfs, so use its `-E` form. Either output is understood by
+  // `extractChatId`.
+  if (process.platform === "linux") {
+    return readFile(`/proc/${pid}/environ`, "utf8");
+  }
   const { stdout } = await execFileAsync("ps", ["-Eww", "-p", String(pid), "-o", "command="]);
   return stdout;
 }

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -47,6 +47,7 @@ import type {
 } from "./handler.js";
 import { findImagePath, writeImage } from "./image-store.js";
 import { InboxDeliveryCoordinator } from "./inbox-delivery-coordinator.js";
+import type { SubprocessProbe } from "./process-tree-probe.js";
 import {
   buildProviderRetryEvent,
   classifyProviderFailure,
@@ -262,6 +263,15 @@ function repoLocalPath(repo: GitRepo): string {
 type SessionManagerConfig = {
   session: SessionConfig;
   concurrency: number;
+  /**
+   * Optional process-tree probe. When present, an idle session whose provider
+   * still has a live descendant (e.g. a `run_in_background` watcher) is not
+   * idle-suspended and is deprioritized as a concurrency-eviction victim, up to
+   * the `idle_timeout + working_grace_seconds` hard cap. Absent => behaviour is
+   * exactly as before (no deferral). Wired by `agent-slot` per the
+   * `session.defer_suspend_on_subprocess` config flag.
+   */
+  subprocessProbe?: SubprocessProbe;
   handlerFactory: HandlerFactory;
   handlerConfig: HandlerConfig;
   agentIdentity: AgentIdentity;
@@ -696,6 +706,7 @@ export class SessionManager {
 
   /** Shut down all sessions gracefully. */
   async shutdown(): Promise<void> {
+    this.config.subprocessProbe?.stop();
     if (this.idleTimer) {
       clearInterval(this.idleTimer);
       this.idleTimer = null;
@@ -1591,30 +1602,55 @@ export class SessionManager {
   ): boolean {
     if (this._activeCount < this.config.concurrency) return true;
 
-    const idleVictim = this.findOldestActiveSession(
-      (session) => session.chatId !== chatId && !this.inboxDelivery.hasProcessingOwnedWork(session.chatId),
-    );
-    if (idleVictim) {
+    // Pick a victim, preferring (a) idle over working, and (b) within each
+    // tier, sessions with no live background subprocess. A `run_in_background`
+    // watcher cannot be recovered once its session is torn down, so a session
+    // that has one is the worst thing to sacrifice — but it is still a valid
+    // last-resort victim (the evictIdle hard cap bounds how long it could hold
+    // the slot anyway), so we fall back to allowing it rather than starve the
+    // requester. `protectSubprocess=false` is that fallback pass.
+    const choose = (protectSubprocess: boolean): { victim: SessionEntry; kind: "idle" | "working" } | null => {
+      const idle = this.findOldestActiveSession(
+        (session) =>
+          session.chatId !== chatId &&
+          !this.inboxDelivery.hasProcessingOwnedWork(session.chatId) &&
+          (!protectSubprocess || !this.hasLiveSubprocess(session.chatId)),
+      );
+      if (idle) return { victim: idle, kind: "idle" };
+      if (deliveryKind === "fresh") {
+        const working = this.findOldestActiveSession(
+          (session) => session.chatId !== chatId && (!protectSubprocess || !this.hasLiveSubprocess(session.chatId)),
+        );
+        if (working) return { victim: working, kind: "working" };
+      }
+      return null;
+    };
+
+    const chosen = choose(true) ?? choose(false);
+
+    if (chosen?.kind === "idle") {
       this.config.log.info(
-        { chatId: idleVictim.chatId, requesterChatId: chatId },
+        { chatId: chosen.victim.chatId, requesterChatId: chatId },
         "idle session yielded for concurrency",
       );
-      this.suspendSession(idleVictim, { reason: "concurrency_idle_yield", ackConsumedPrefix: true, drainQueue: false });
+      this.suspendSession(chosen.victim, {
+        reason: "concurrency_idle_yield",
+        ackConsumedPrefix: true,
+        drainQueue: false,
+      });
       return true;
     }
 
-    const workingVictim =
-      deliveryKind === "fresh" ? this.findOldestActiveSession((session) => session.chatId !== chatId) : null;
-    if (workingVictim) {
+    if (chosen?.kind === "working") {
       this.config.log.info(
-        { chatId: workingVictim.chatId, requesterChatId: chatId },
+        { chatId: chosen.victim.chatId, requesterChatId: chatId },
         "working session preempted for fresh input",
       );
-      this.emitResilienceEvent(workingVictim.chatId, "resilience.session.preempted", {
+      this.emitResilienceEvent(chosen.victim.chatId, "resilience.session.preempted", {
         reason: "concurrency_preempted",
         requesterChatId: chatId,
       });
-      this.suspendSession(workingVictim, {
+      this.suspendSession(chosen.victim, {
         reason: "concurrency_preempted",
         ackConsumedPrefix: false,
         drainQueue: false,
@@ -1624,6 +1660,15 @@ export class SessionManager {
 
     this.queueForSlot(chatId, message, deliveryKind, "concurrency_limit");
     return false;
+  }
+
+  /**
+   * Whether the session's provider currently has a live background subprocess,
+   * per the optional {@link SubprocessProbe}. Absent probe => always false, so
+   * suspend/eviction behave exactly as before the probe was introduced.
+   */
+  private hasLiveSubprocess(chatId: string): boolean {
+    return this.config.subprocessProbe?.hasLiveSubprocess(chatId) === true;
   }
 
   private findOldestActiveSession(eligible: (session: SessionEntry) => boolean): SessionEntry | null {
@@ -1762,8 +1807,12 @@ export class SessionManager {
     // Prefer non-active sessions, then idle active sessions. Working active
     // sessions are not memory-management victims: dropping them silently loses
     // replies/tool side effects unless their work is explicitly recovered.
+    // Within idle active sessions, deprioritize ones with a live background
+    // subprocess (their watcher's completion wake-up cannot be recovered after
+    // a shutdown) — they are evicted only as a last resort.
     let nonActiveCandidate: { key: string; session: SessionEntry } | null = null;
     let idleActiveCandidate: { key: string; session: SessionEntry } | null = null;
+    let idleActiveSubprocessCandidate: { key: string; session: SessionEntry } | null = null;
     for (const [key, session] of this.sessions) {
       if (session.status !== "active") {
         if (!nonActiveCandidate || session.lastActivity < nonActiveCandidate.session.lastActivity) {
@@ -1772,13 +1821,20 @@ export class SessionManager {
         continue;
       }
       if (!this.inboxDelivery.hasProcessingOwnedWork(key)) {
-        if (!idleActiveCandidate || session.lastActivity < idleActiveCandidate.session.lastActivity) {
+        if (this.hasLiveSubprocess(key)) {
+          if (
+            !idleActiveSubprocessCandidate ||
+            session.lastActivity < idleActiveSubprocessCandidate.session.lastActivity
+          ) {
+            idleActiveSubprocessCandidate = { key, session };
+          }
+        } else if (!idleActiveCandidate || session.lastActivity < idleActiveCandidate.session.lastActivity) {
           idleActiveCandidate = { key, session };
         }
       }
     }
 
-    const candidate = nonActiveCandidate ?? idleActiveCandidate;
+    const candidate = nonActiveCandidate ?? idleActiveCandidate ?? idleActiveSubprocessCandidate;
     if (!candidate) {
       if (chatId && message) {
         this.queueForSlot(chatId, message, deliveryKind, "max_sessions_all_working");
@@ -1847,22 +1903,27 @@ export class SessionManager {
 
       const currentState = this.sessionRuntimeStates.get(session.chatId);
       const hasProcessingWork = this.inboxDelivery.hasProcessingOwnedWork(session.chatId);
+      // A live background subprocess (e.g. a `run_in_background` watcher) is
+      // real in-flight work even though no turn is processing: suspending would
+      // close the provider stream and lose its completion wake-up.
+      const hasLiveSubprocess = this.hasLiveSubprocess(session.chatId);
 
       // Hard cap: regardless of unsettled work, once we are past
       // `idle_timeout + working_grace_seconds` the slot MUST be reclaimed.
-      // Anything else means a stuck handler can hold a slot forever just
-      // by never closing the delivery work.
+      // Anything else means a stuck handler — or a forgotten background
+      // subprocess — can hold a slot forever just by never closing the work.
       const pastHardCap = inactiveMs >= timeoutMs + workingGraceMs;
 
-      if (hasProcessingWork && !pastHardCap) {
+      if ((hasProcessingWork || hasLiveSubprocess) && !pastHardCap) {
         this.config.log.info(
           {
             chatId: session.chatId,
             runtimeState: currentState,
             inactiveSec: Math.round(inactiveMs / 1000),
             graceSec: this.config.session.working_grace_seconds,
+            reason: hasProcessingWork ? "processing_work" : "live_subprocess",
           },
-          "session idle threshold reached but provider work is still processing — skipping suspend",
+          "session idle threshold reached but work is still in flight — skipping suspend",
         );
         continue;
       }

--- a/packages/shared/src/config/agent-config.ts
+++ b/packages/shared/src/config/agent-config.ts
@@ -30,6 +30,13 @@ export const agentConfigSchema = defineConfig({
     // past the last activity the session is reclaimed (see evictIdle in
     // session-manager.ts and #418).
     working_grace_seconds: field(z.number().int().positive().default(3600)),
+    // When a session goes idle but its provider still has a live background
+    // subprocess (e.g. a `run_in_background` watcher polling CI), defer
+    // idle-suspend and deprioritize concurrency eviction so the subprocess's
+    // completion wake-up is not lost — still bounded by the
+    // `idle_timeout + working_grace_seconds` hard cap (see evictIdle in
+    // client `session-manager.ts`). Default on.
+    defer_suspend_on_subprocess: field(z.boolean().default(true)),
   },
 });
 


### PR DESCRIPTION
## Problem

A session whose provider still has a live background subprocess — e.g. a `Bash run_in_background` watcher polling a CI run — was idle-suspended after `idle_timeout` (default 5 min). `lastActivity` is only bumped on provider communication, so a purely-background wait never refreshes it. Suspend then closes the provider stream, so even though the watcher keeps running, its "background task complete → re-invoke the agent" wake-up is lost. The agent goes silent until a human pings it.

Root cause was traced from an exported session transcript (agent waited ~40 min on an iOS build, went silent, user had to ping). Verified locally: the provider is a `claude` process spawned by the Claude Agent SDK as a **direct child of the daemon**, stamped with a per-session `FIRST_TREE_CHAT_ID` env var; both the provider pid and whether it currently has a descendant are reliably observable via `ps`.

## Change (client-only)

- **New `runtime/process-tree-probe.ts`** — a `ps`-backed `SubprocessProbe` that maps each provider pid (daemon's direct `claude` children, attributed by `FIRST_TREE_CHAT_ID`) to whether it currently has a live descendant. Refresh is async + cached, so the synchronous `evictIdle` path never blocks on a process scan; any `ps` failure degrades to "no live work" (i.e. prior behaviour).
- **`session-manager.ts`**
  - `evictIdle`: a live subprocess defers idle-suspend, treated like in-flight processing work — **still bounded by the existing `idle_timeout + working_grace_seconds` hard cap**, so a forgotten/stuck watcher is still reclaimed (no unbounded slot hold).
  - `acquireActiveSlot` (concurrency yield) and `evictIfNeeded` (max_sessions): deprioritize sessions with a live subprocess as eviction victims — sacrificed only as a last resort.
  - `shutdown` stops the probe.
- **Config `session.defer_suspend_on_subprocess`** (default **on**) in both `@first-tree/shared` `agentConfigSchema` and the runtime `config.ts`; `agent-slot` wires the probe per the flag.

No prompt / brief / server changes. With no probe injected, behaviour is identical to before.

## Testing

- New `process-tree-probe.test.ts` (6): pure parsing/attribution/descendant detection + probe class + `ps`-failure fallback.
- New `session-manager.test.ts` cases (3): defer-then-suspend, **hard cap still reclaims** with a live subprocess, concurrency victim prefers the no-subprocess session.
- Full suites green: **client 1165 / 109 files**, **shared 479**. `pnpm check` (Biome, 1345 files) and `pnpm typecheck` clean.
- **Real-daemon QA: PASS, no blocking defects.** With `idle_timeout=5s`, a live watcher keeps the session `active` past idle and the post-completion task-notification wakes the agent; with `idle_timeout=5s`/`working_grace=30s`, the session defers then flips to `suspended` at the hard cap (confirms no unbounded keep-alive).

## Follow-up

A Context Tree decision-record PR (why a local process-tree probe over a server-side decouple / bounded-signal approach) will be opened separately and cross-linked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
