### PR TITLE
fix(server): dedupe context reviewer PR events

### DIFF
--- a/packages/server/src/__tests__/context-reviewer-pr.test.ts
+++ b/packages/server/src/__tests__/context-reviewer-pr.test.ts
@@ -19,6 +19,8 @@ import { createAdminContext, useTestApp } from "./helpers.js";
 
 type App = ReturnType<ReturnType<typeof useTestApp>>;
 
+const FOLLOW_UP_NOTICE = "A new GitHub event was received. I'll check the current PR state.";
+
 function pullRequestPayload(overrides: Partial<Record<string, unknown>> = {}) {
   return {
     action: "opened",
@@ -76,9 +78,13 @@ function reviewCommentPayload(overrides: Partial<Record<string, unknown>> = {}) 
   };
 }
 
-async function createReviewer(app: App, admin: Awaited<ReturnType<typeof createAdminContext>>) {
+async function createReviewer(
+  app: App,
+  admin: Awaited<ReturnType<typeof createAdminContext>>,
+  options: { name?: string } = {},
+) {
   return createAgent(app.db, {
-    name: `reviewer-${randomUUID().slice(0, 8)}`,
+    name: options.name ?? `reviewer-${randomUUID().slice(0, 8)}`,
     type: "agent",
     displayName: "Context Reviewer",
     managerId: admin.memberId,
@@ -214,7 +220,7 @@ describe("handleContextReviewerPrEvent", () => {
     expect(rows).toHaveLength(0);
   });
 
-  it("skips when the feature is disabled, context repo is missing, reviewer is missing, or action is not opened", async () => {
+  it("skips when the feature is disabled, context repo is missing, reviewer is missing, or action is unsupported", async () => {
     const app = getApp();
     const admin = await createAdminContext(app);
     const reviewer = await createReviewer(app, admin);
@@ -327,11 +333,15 @@ describe("handleContextReviewerPrEvent", () => {
       organizationId: admin.organizationId,
     });
 
-    expect(first.handled && second.handled && second.chatId === first.chatId).toBe(true);
+    if (!first.handled || !second.handled) throw new Error("expected handled results");
+    expect(second.chatId).toBe(first.chatId);
     expect(second).toMatchObject({ handled: true, reused: true });
 
     const messageRows = await app.db.select({ id: messages.id }).from(messages);
     expect(messageRows).toHaveLength(2);
+    const [followUp] = await app.db.select().from(messages).where(eq(messages.id, second.messageId)).limit(1);
+    expect(followUp?.content).toBe(FOLLOW_UP_NOTICE);
+    expect(followUp?.content).not.toContain("gh pr comment 123 --repo owner/context-tree --body");
     const chatRows = await app.db.select({ id: chats.id }).from(chats);
     expect(chatRows).toHaveLength(1);
   });
@@ -363,12 +373,15 @@ describe("handleContextReviewerPrEvent", () => {
     const followUp = messageRows.find((row) => row.id === second.messageId);
     expect(followUp?.source).toBe("github");
     expect(followUp?.format).toBe("markdown");
-    expect(followUp?.content).toContain("Trigger event: pull_request.synchronize");
+    expect(followUp?.content).toBe(FOLLOW_UP_NOTICE);
+    expect(followUp?.content).not.toContain("clear, accurate");
+    expect(followUp?.content).not.toContain("gh pr comment 123 --repo owner/context-tree --body");
     expect(followUp?.metadata).toMatchObject({
       source: "github",
       event: "pull_request",
       action: "synchronize",
       triggerEvent: "pull_request.synchronize",
+      entityKey: "owner/context-tree#123",
       contextTreeReviewer: true,
       mentions: [reviewer.uuid],
     });
@@ -404,14 +417,15 @@ describe("handleContextReviewerPrEvent", () => {
     if (!second.handled) throw new Error("expected second event handled");
 
     const [followUp] = await app.db.select().from(messages).where(eq(messages.id, second.messageId)).limit(1);
-    expect(followUp?.content).toContain("Trigger event: issue_comment.created");
-    expect(followUp?.content).toContain("Comment author: commenter");
-    expect(followUp?.content).toContain("Comment URL: https://github.com/owner/context-tree/pull/123#issuecomment-1");
+    expect(followUp?.content).toBe(FOLLOW_UP_NOTICE);
+    expect(followUp?.content).not.toContain("Trigger event: issue_comment.created");
+    expect(followUp?.content).not.toContain("gh pr comment 123 --repo owner/context-tree --body");
     expect(followUp?.metadata).toMatchObject({
       source: "github",
       event: "issue_comment",
       action: "created",
       triggerEvent: "issue_comment.created",
+      entityKey: "owner/context-tree#123",
       contextTreeReviewer: true,
       mentions: [reviewer.uuid],
     });
@@ -447,14 +461,15 @@ describe("handleContextReviewerPrEvent", () => {
     if (!second.handled) throw new Error("expected second event handled");
 
     const [followUp] = await app.db.select().from(messages).where(eq(messages.id, second.messageId)).limit(1);
-    expect(followUp?.content).toContain("Trigger event: pull_request_review_comment.created");
-    expect(followUp?.content).toContain("Comment author: reviewer-user");
-    expect(followUp?.content).toContain("Comment URL: https://github.com/owner/context-tree/pull/123#discussion_r1");
+    expect(followUp?.content).toBe(FOLLOW_UP_NOTICE);
+    expect(followUp?.content).not.toContain("Trigger event: pull_request_review_comment.created");
+    expect(followUp?.content).not.toContain("gh pr comment 123 --repo owner/context-tree --body");
     expect(followUp?.metadata).toMatchObject({
       source: "github",
       event: "pull_request_review_comment",
       action: "created",
       triggerEvent: "pull_request_review_comment.created",
+      entityKey: "owner/context-tree#123",
       contextTreeReviewer: true,
       mentions: [reviewer.uuid],
     });
@@ -465,6 +480,48 @@ describe("handleContextReviewerPrEvent", () => {
       .where(and(eq(inboxEntries.messageId, second.messageId), eq(inboxEntries.inboxId, reviewer.inboxId)))
       .limit(1);
     expect(entry?.notify).toBe(true);
+  });
+
+  it("suppresses a reviewer-authored PR comment echo after the initial opened task", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app);
+    const reviewer = await createReviewer(app, admin, { name: `context-reviewer-${randomUUID().slice(0, 8)}` });
+    await enableReviewer(app, admin, reviewer.uuid);
+
+    const first = await handleContextReviewerPrEvent(app, {
+      eventType: "pull_request",
+      payload: pullRequestPayload(),
+      organizationId: admin.organizationId,
+    });
+    if (!first.handled) throw new Error("expected first event handled");
+
+    const second = await handleContextReviewerPrEvent(app, {
+      eventType: "issue_comment",
+      payload: issueCommentPayload({
+        comment: {
+          html_url: "https://github.com/owner/context-tree/pull/123#issuecomment-2",
+          user: { login: reviewer.name },
+          body: "Context Reviewer found no blocking gaps.",
+        },
+        sender: { login: reviewer.name, type: "User" },
+      }),
+      organizationId: admin.organizationId,
+    });
+
+    expect(second).toMatchObject({ handled: true, reused: true, suppressed: true, chatId: first.chatId });
+    if (!second.handled) throw new Error("expected second event handled");
+    expect(second.messageId).toBe(first.messageId);
+
+    const messageRows = await app.db
+      .select({ id: messages.id })
+      .from(messages)
+      .where(eq(messages.chatId, first.chatId));
+    expect(messageRows).toHaveLength(1);
+    const inboxRows = await app.db
+      .select({ messageId: inboxEntries.messageId, notify: inboxEntries.notify })
+      .from(inboxEntries)
+      .where(eq(inboxEntries.inboxId, reviewer.inboxId));
+    expect(inboxRows).toEqual([{ messageId: first.messageId, notify: true }]);
   });
 
   it("skips non-PR issue_comment.created without creating a reviewer chat", async () => {

--- a/packages/server/src/__tests__/context-reviewer-pr.test.ts
+++ b/packages/server/src/__tests__/context-reviewer-pr.test.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { and, eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 import { agents } from "../db/schema/agents.js";
+import { authIdentities } from "../db/schema/auth-identities.js";
 import { chatMembership } from "../db/schema/chat-membership.js";
 import { chats } from "../db/schema/chats.js";
 import { inboxEntries } from "../db/schema/inbox-entries.js";
@@ -107,6 +108,22 @@ async function enableReviewer(app: App, admin: Awaited<ReturnType<typeof createA
     { contextReviewer: { enabled: true, agentUuid: reviewerUuid } },
     { updatedBy: admin.userId, memberId: admin.memberId },
   );
+}
+
+async function seedGithubIdentity(
+  app: App,
+  admin: Awaited<ReturnType<typeof createAdminContext>>,
+  login: string,
+): Promise<void> {
+  await app.db.insert(authIdentities).values({
+    id: randomUUID(),
+    userId: admin.userId,
+    provider: "github",
+    identifier: `github-${randomUUID()}`,
+    email: null,
+    verifiedAt: new Date(),
+    metadata: { login },
+  });
 }
 
 describe("Context Reviewer PR prompt", () => {
@@ -417,8 +434,13 @@ describe("handleContextReviewerPrEvent", () => {
     if (!second.handled) throw new Error("expected second event handled");
 
     const [followUp] = await app.db.select().from(messages).where(eq(messages.id, second.messageId)).limit(1);
-    expect(followUp?.content).toBe(FOLLOW_UP_NOTICE);
-    expect(followUp?.content).not.toContain("Trigger event: issue_comment.created");
+    expect(followUp?.content).toBe(
+      [
+        FOLLOW_UP_NOTICE,
+        "Comment author: commenter",
+        "Comment URL: https://github.com/owner/context-tree/pull/123#issuecomment-1",
+      ].join("\n"),
+    );
     expect(followUp?.content).not.toContain("gh pr comment 123 --repo owner/context-tree --body");
     expect(followUp?.metadata).toMatchObject({
       source: "github",
@@ -427,6 +449,8 @@ describe("handleContextReviewerPrEvent", () => {
       triggerEvent: "issue_comment.created",
       entityKey: "owner/context-tree#123",
       contextTreeReviewer: true,
+      commentAuthorLogin: "commenter",
+      commentUrl: "https://github.com/owner/context-tree/pull/123#issuecomment-1",
       mentions: [reviewer.uuid],
     });
 
@@ -461,8 +485,13 @@ describe("handleContextReviewerPrEvent", () => {
     if (!second.handled) throw new Error("expected second event handled");
 
     const [followUp] = await app.db.select().from(messages).where(eq(messages.id, second.messageId)).limit(1);
-    expect(followUp?.content).toBe(FOLLOW_UP_NOTICE);
-    expect(followUp?.content).not.toContain("Trigger event: pull_request_review_comment.created");
+    expect(followUp?.content).toBe(
+      [
+        FOLLOW_UP_NOTICE,
+        "Comment author: reviewer-user",
+        "Comment URL: https://github.com/owner/context-tree/pull/123#discussion_r1",
+      ].join("\n"),
+    );
     expect(followUp?.content).not.toContain("gh pr comment 123 --repo owner/context-tree --body");
     expect(followUp?.metadata).toMatchObject({
       source: "github",
@@ -471,6 +500,8 @@ describe("handleContextReviewerPrEvent", () => {
       triggerEvent: "pull_request_review_comment.created",
       entityKey: "owner/context-tree#123",
       contextTreeReviewer: true,
+      commentAuthorLogin: "reviewer-user",
+      commentUrl: "https://github.com/owner/context-tree/pull/123#discussion_r1",
       mentions: [reviewer.uuid],
     });
 
@@ -482,10 +513,11 @@ describe("handleContextReviewerPrEvent", () => {
     expect(entry?.notify).toBe(true);
   });
 
-  it("suppresses a reviewer-authored PR comment echo after the initial opened task", async () => {
+  it("suppresses a manager-authored PR comment echo after the initial opened task", async () => {
     const app = getApp();
     const admin = await createAdminContext(app);
     const reviewer = await createReviewer(app, admin, { name: `context-reviewer-${randomUUID().slice(0, 8)}` });
+    await seedGithubIdentity(app, admin, "manager-login");
     await enableReviewer(app, admin, reviewer.uuid);
 
     const first = await handleContextReviewerPrEvent(app, {
@@ -500,10 +532,10 @@ describe("handleContextReviewerPrEvent", () => {
       payload: issueCommentPayload({
         comment: {
           html_url: "https://github.com/owner/context-tree/pull/123#issuecomment-2",
-          user: { login: reviewer.name },
+          user: { login: "MANAGER-LOGIN", type: "User" },
           body: "Context Reviewer found no blocking gaps.",
         },
-        sender: { login: reviewer.name, type: "User" },
+        sender: { login: "MANAGER-LOGIN", type: "User" },
       }),
       organizationId: admin.organizationId,
     });
@@ -522,6 +554,94 @@ describe("handleContextReviewerPrEvent", () => {
       .from(inboxEntries)
       .where(eq(inboxEntries.inboxId, reviewer.inboxId));
     expect(inboxRows).toEqual([{ messageId: first.messageId, notify: true }]);
+  });
+
+  it("suppresses the configured GitHub App bot PR comment echo after the initial opened task", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app);
+    const reviewer = await createReviewer(app, admin);
+    await enableReviewer(app, admin, reviewer.uuid);
+
+    const first = await handleContextReviewerPrEvent(app, {
+      eventType: "pull_request",
+      payload: pullRequestPayload(),
+      organizationId: admin.organizationId,
+    });
+    if (!first.handled) throw new Error("expected first event handled");
+
+    const second = await handleContextReviewerPrEvent(app, {
+      eventType: "issue_comment",
+      payload: issueCommentPayload({
+        comment: {
+          html_url: "https://github.com/owner/context-tree/pull/123#issuecomment-4",
+          user: { login: "TEST-APP-SLUG[bot]", type: "Bot" },
+          body: "Posted by the First Tree GitHub App.",
+        },
+        sender: { login: "TEST-APP-SLUG[bot]", type: "Bot" },
+      }),
+      organizationId: admin.organizationId,
+    });
+
+    expect(second).toMatchObject({ handled: true, reused: true, suppressed: true, chatId: first.chatId });
+    if (!second.handled) throw new Error("expected second event handled");
+    expect(second.messageId).toBe(first.messageId);
+
+    const messageRows = await app.db
+      .select({ id: messages.id })
+      .from(messages)
+      .where(eq(messages.chatId, first.chatId));
+    expect(messageRows).toHaveLength(1);
+    const inboxRows = await app.db
+      .select({ messageId: inboxEntries.messageId, notify: inboxEntries.notify })
+      .from(inboxEntries)
+      .where(eq(inboxEntries.inboxId, reviewer.inboxId));
+    expect(inboxRows).toEqual([{ messageId: first.messageId, notify: true }]);
+  });
+
+  it("does not suppress when only the reviewer agent name matches an unrelated human GitHub login", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app);
+    const reviewer = await createReviewer(app, admin, { name: "unrelated-human" });
+    await seedGithubIdentity(app, admin, "manager-login");
+    await enableReviewer(app, admin, reviewer.uuid);
+
+    const first = await handleContextReviewerPrEvent(app, {
+      eventType: "pull_request",
+      payload: pullRequestPayload(),
+      organizationId: admin.organizationId,
+    });
+    if (!first.handled) throw new Error("expected first event handled");
+
+    const second = await handleContextReviewerPrEvent(app, {
+      eventType: "issue_comment",
+      payload: issueCommentPayload({
+        comment: {
+          html_url: "https://github.com/owner/context-tree/pull/123#issuecomment-3",
+          user: { login: "unrelated-human", type: "User" },
+          body: "This is not the manager.",
+        },
+        sender: { login: "unrelated-human", type: "User" },
+      }),
+      organizationId: admin.organizationId,
+    });
+
+    expect(second).toMatchObject({ handled: true, reused: true, chatId: first.chatId });
+    if (!second.handled) throw new Error("expected second event handled");
+    expect(second).not.toMatchObject({ suppressed: true });
+
+    const messageRows = await app.db
+      .select({ id: messages.id })
+      .from(messages)
+      .where(eq(messages.chatId, first.chatId));
+    expect(messageRows).toHaveLength(2);
+    const [followUp] = await app.db.select().from(messages).where(eq(messages.id, second.messageId)).limit(1);
+    expect(followUp?.content).toBe(
+      [
+        FOLLOW_UP_NOTICE,
+        "Comment author: unrelated-human",
+        "Comment URL: https://github.com/owner/context-tree/pull/123#issuecomment-3",
+      ].join("\n"),
+    );
   });
 
   it("skips non-PR issue_comment.created without creating a reviewer chat", async () => {

--- a/packages/server/src/__tests__/context-reviewer-pr.test.ts
+++ b/packages/server/src/__tests__/context-reviewer-pr.test.ts
@@ -2,7 +2,6 @@ import { randomUUID } from "node:crypto";
 import { and, eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 import { agents } from "../db/schema/agents.js";
-import { authIdentities } from "../db/schema/auth-identities.js";
 import { chatMembership } from "../db/schema/chat-membership.js";
 import { chats } from "../db/schema/chats.js";
 import { inboxEntries } from "../db/schema/inbox-entries.js";
@@ -108,22 +107,6 @@ async function enableReviewer(app: App, admin: Awaited<ReturnType<typeof createA
     { contextReviewer: { enabled: true, agentUuid: reviewerUuid } },
     { updatedBy: admin.userId, memberId: admin.memberId },
   );
-}
-
-async function seedGithubIdentity(
-  app: App,
-  admin: Awaited<ReturnType<typeof createAdminContext>>,
-  login: string,
-): Promise<void> {
-  await app.db.insert(authIdentities).values({
-    id: randomUUID(),
-    userId: admin.userId,
-    provider: "github",
-    identifier: `github-${randomUUID()}`,
-    email: null,
-    verifiedAt: new Date(),
-    metadata: { login },
-  });
 }
 
 describe("Context Reviewer PR prompt", () => {
@@ -513,11 +496,10 @@ describe("handleContextReviewerPrEvent", () => {
     expect(entry?.notify).toBe(true);
   });
 
-  it("suppresses a manager-authored PR comment echo after the initial opened task", async () => {
+  it("creates a follow-up for a manager-authored PR comment after the initial opened task", async () => {
     const app = getApp();
     const admin = await createAdminContext(app);
     const reviewer = await createReviewer(app, admin, { name: `context-reviewer-${randomUUID().slice(0, 8)}` });
-    await seedGithubIdentity(app, admin, "manager-login");
     await enableReviewer(app, admin, reviewer.uuid);
 
     const first = await handleContextReviewerPrEvent(app, {
@@ -540,20 +522,35 @@ describe("handleContextReviewerPrEvent", () => {
       organizationId: admin.organizationId,
     });
 
-    expect(second).toMatchObject({ handled: true, reused: true, suppressed: true, chatId: first.chatId });
+    expect(second).toMatchObject({ handled: true, reused: true, chatId: first.chatId });
     if (!second.handled) throw new Error("expected second event handled");
-    expect(second.messageId).toBe(first.messageId);
+    expect(second).not.toMatchObject({ suppressed: true });
+    expect(second.messageId).not.toBe(first.messageId);
 
     const messageRows = await app.db
       .select({ id: messages.id })
       .from(messages)
       .where(eq(messages.chatId, first.chatId));
-    expect(messageRows).toHaveLength(1);
-    const inboxRows = await app.db
-      .select({ messageId: inboxEntries.messageId, notify: inboxEntries.notify })
-      .from(inboxEntries)
-      .where(eq(inboxEntries.inboxId, reviewer.inboxId));
-    expect(inboxRows).toEqual([{ messageId: first.messageId, notify: true }]);
+    expect(messageRows).toHaveLength(2);
+    const [followUp] = await app.db.select().from(messages).where(eq(messages.id, second.messageId)).limit(1);
+    expect(followUp?.content).toBe(
+      [
+        FOLLOW_UP_NOTICE,
+        "Comment author: MANAGER-LOGIN",
+        "Comment URL: https://github.com/owner/context-tree/pull/123#issuecomment-2",
+      ].join("\n"),
+    );
+    expect(followUp?.metadata).toMatchObject({
+      source: "github",
+      event: "issue_comment",
+      action: "created",
+      triggerEvent: "issue_comment.created",
+      entityKey: "owner/context-tree#123",
+      contextTreeReviewer: true,
+      commentAuthorLogin: "MANAGER-LOGIN",
+      commentUrl: "https://github.com/owner/context-tree/pull/123#issuecomment-2",
+      mentions: [reviewer.uuid],
+    });
   });
 
   it("suppresses the configured GitHub App bot PR comment echo after the initial opened task", async () => {
@@ -602,7 +599,6 @@ describe("handleContextReviewerPrEvent", () => {
     const app = getApp();
     const admin = await createAdminContext(app);
     const reviewer = await createReviewer(app, admin, { name: "unrelated-human" });
-    await seedGithubIdentity(app, admin, "manager-login");
     await enableReviewer(app, admin, reviewer.uuid);
 
     const first = await handleContextReviewerPrEvent(app, {

--- a/packages/server/src/__tests__/github-app-webhook-route.test.ts
+++ b/packages/server/src/__tests__/github-app-webhook-route.test.ts
@@ -1166,16 +1166,24 @@ describe("POST /webhooks/github-app", () => {
       .where(eq(messages.chatId, chatRows[0]?.id ?? ""));
     expect(messageRows).toHaveLength(2);
     const followUpMessage = messageRows.find((message) => message.metadata.triggerEvent === "issue_comment.created");
-    expect(followUpMessage?.content).toBe(FOLLOW_UP_NOTICE);
-    expect(followUpMessage?.content).not.toContain("Trigger event: issue_comment.created");
+    expect(followUpMessage?.content).toBe(
+      [
+        FOLLOW_UP_NOTICE,
+        "Comment author: context-commenter",
+        "Comment URL: https://github.com/owner/context-tree/pull/42#issuecomment-2",
+      ].join("\n"),
+    );
     expect(followUpMessage?.content).not.toContain("gh pr comment 42 --repo owner/context-tree --body");
     expect(followUpMessage?.metadata).toMatchObject({
       source: "github",
       event: "issue_comment",
       action: "created",
       triggerEvent: "issue_comment.created",
+      entityType: "pull_request",
       entityKey: "owner/context-tree#42",
       contextTreeReviewer: true,
+      commentAuthorLogin: "context-commenter",
+      commentUrl: "https://github.com/owner/context-tree/pull/42#issuecomment-2",
       mentions: [reviewer],
     });
 

--- a/packages/server/src/__tests__/github-app-webhook-route.test.ts
+++ b/packages/server/src/__tests__/github-app-webhook-route.test.ts
@@ -13,6 +13,7 @@ import { uuidv7 } from "../uuid.js";
 import { createTestAdmin, useTestApp } from "./helpers.js";
 
 const APP_WEBHOOK_SECRET = "test-app-webhook-secret";
+const FOLLOW_UP_NOTICE = "A new GitHub event was received. I'll check the current PR state.";
 
 function signBody(secret: string, body: string): string {
   return `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`;
@@ -1165,15 +1166,15 @@ describe("POST /webhooks/github-app", () => {
       .where(eq(messages.chatId, chatRows[0]?.id ?? ""));
     expect(messageRows).toHaveLength(2);
     const followUpMessage = messageRows.find((message) => message.metadata.triggerEvent === "issue_comment.created");
-    expect(followUpMessage?.content).toContain("Trigger event: issue_comment.created");
-    expect(followUpMessage?.content).toContain(
-      "Comment URL: https://github.com/owner/context-tree/pull/42#issuecomment-2",
-    );
+    expect(followUpMessage?.content).toBe(FOLLOW_UP_NOTICE);
+    expect(followUpMessage?.content).not.toContain("Trigger event: issue_comment.created");
+    expect(followUpMessage?.content).not.toContain("gh pr comment 42 --repo owner/context-tree --body");
     expect(followUpMessage?.metadata).toMatchObject({
       source: "github",
       event: "issue_comment",
       action: "created",
       triggerEvent: "issue_comment.created",
+      entityKey: "owner/context-tree#42",
       contextTreeReviewer: true,
       mentions: [reviewer],
     });

--- a/packages/server/src/services/context-reviewer-pr.ts
+++ b/packages/server/src/services/context-reviewer-pr.ts
@@ -8,6 +8,7 @@ import type { FastifyInstance } from "fastify";
 import { isRecord, readNumber, readString } from "../api/webhooks/github-entity.js";
 import type { Database } from "../db/connection.js";
 import { agents } from "../db/schema/agents.js";
+import { authIdentities } from "../db/schema/auth-identities.js";
 import { chats } from "../db/schema/chats.js";
 import { members } from "../db/schema/members.js";
 import { messages } from "../db/schema/messages.js";
@@ -65,6 +66,8 @@ type PullRequestPayloadInfo = ContextReviewerPrTemplateInput & {
   eventType: "pull_request" | "issue_comment" | "pull_request_review_comment";
   action: "opened" | "synchronize" | "created" | "edited";
   entityKey: string;
+  senderType: string | null;
+  commentAuthorType: string | null;
 };
 
 type ContextReviewerPrTrigger =
@@ -74,7 +77,7 @@ type ContextReviewerPrTrigger =
 
 type ReviewerAgent = {
   uuid: string;
-  name: string | null;
+  managerUserId: string;
   managerHumanAgentId: string;
 };
 
@@ -256,6 +259,7 @@ export async function handleContextReviewerPrEvent(
       chatId: existingChatId,
       info,
       reviewer,
+      appSlug: app.config.oauth?.githubApp?.slug ?? null,
     });
     if (suppressedEchoMessageId) {
       log.info(
@@ -283,7 +287,7 @@ export async function handleContextReviewerPrEvent(
       {
         source: "github",
         format: "markdown",
-        content: FOLLOW_UP_NOTICE,
+        content: contextReviewerFollowUpContent(info),
         metadata: contextReviewerMessageMetadata(info, reviewer),
       },
       { normalizeMentionsInContent: false },
@@ -370,6 +374,7 @@ function extractPullRequestPayloadInfo(
     ...trigger,
     repoFullName,
     senderLogin,
+    senderType: readString(sender?.type),
     organizationId,
   };
 
@@ -388,6 +393,7 @@ function extractPullRequestPayloadInfo(
       headRef: readString(isRecord(pr?.head) ? pr.head.ref : null),
       commentUrl: null,
       commentAuthorLogin: null,
+      commentAuthorType: null,
       entityKey: `${normalizedRepoFullName}#${prNumber}`,
     };
   }
@@ -399,6 +405,7 @@ function extractPullRequestPayloadInfo(
     const title = readString(issue?.title);
     const htmlUrl = readString(prInfo?.html_url) ?? readString(issue?.html_url);
     const comment = isRecord(payload.comment) ? payload.comment : null;
+    const commentAuthor = readCommentAuthor(comment);
     if (!prInfo || prNumber === null || !title || !htmlUrl) return null;
     return {
       ...common,
@@ -408,7 +415,8 @@ function extractPullRequestPayloadInfo(
       baseRef: null,
       headRef: null,
       commentUrl: readString(comment?.html_url),
-      commentAuthorLogin: readCommentAuthorLogin(comment) ?? senderLogin,
+      commentAuthorLogin: commentAuthor.login ?? senderLogin,
+      commentAuthorType: commentAuthor.type ?? common.senderType,
       entityKey: `${normalizedRepoFullName}#${prNumber}`,
     };
   }
@@ -419,6 +427,7 @@ function extractPullRequestPayloadInfo(
     const title = readString(pr?.title);
     const htmlUrl = readString(pr?.html_url);
     const comment = isRecord(payload.comment) ? payload.comment : null;
+    const commentAuthor = readCommentAuthor(comment);
     if (prNumber === null || !title || !htmlUrl) return null;
     return {
       ...common,
@@ -428,7 +437,8 @@ function extractPullRequestPayloadInfo(
       baseRef: readString(isRecord(pr?.base) ? pr.base.ref : null),
       headRef: readString(isRecord(pr?.head) ? pr.head.ref : null),
       commentUrl: readString(comment?.html_url),
-      commentAuthorLogin: readCommentAuthorLogin(comment) ?? senderLogin,
+      commentAuthorLogin: commentAuthor.login ?? senderLogin,
+      commentAuthorType: commentAuthor.type ?? common.senderType,
       entityKey: `${normalizedRepoFullName}#${prNumber}`,
     };
   }
@@ -436,16 +446,24 @@ function extractPullRequestPayloadInfo(
   return null;
 }
 
-function readCommentAuthorLogin(comment: Record<string, unknown> | null): string | null {
+function readCommentAuthor(comment: Record<string, unknown> | null): { login: string | null; type: string | null } {
   const user = isRecord(comment?.user) ? comment.user : null;
-  return readString(user?.login);
+  return { login: readString(user?.login), type: readString(user?.type) };
+}
+
+function contextReviewerFollowUpContent(info: PullRequestPayloadInfo): string {
+  const details = [
+    info.commentAuthorLogin ? `Comment author: ${info.commentAuthorLogin}` : null,
+    info.commentUrl ? `Comment URL: ${info.commentUrl}` : null,
+  ].filter((line): line is string => line !== null);
+  return [FOLLOW_UP_NOTICE, ...details].join("\n");
 }
 
 function contextReviewerMessageMetadata(
   info: PullRequestPayloadInfo,
   reviewer: ReviewerAgent,
 ): Record<string, unknown> {
-  return {
+  const metadata: Record<string, unknown> = {
     source: "github",
     event: info.eventType,
     action: info.action,
@@ -455,6 +473,13 @@ function contextReviewerMessageMetadata(
     contextTreeReviewer: true,
     mentions: [reviewer.uuid],
   };
+  if (info.commentAuthorLogin) {
+    metadata.commentAuthorLogin = info.commentAuthorLogin;
+  }
+  if (info.commentUrl) {
+    metadata.commentUrl = info.commentUrl;
+  }
+  return metadata;
 }
 
 async function loadValidReviewerAgent(
@@ -464,7 +489,7 @@ async function loadValidReviewerAgent(
   const [agent] = await db
     .select({
       uuid: agents.uuid,
-      name: agents.name,
+      managerUserId: members.userId,
       managerHumanAgentId: members.agentId,
     })
     .from(agents)
@@ -505,29 +530,38 @@ async function findExistingReviewerChat(
 
 async function findSuppressibleReviewerEchoMessageId(
   db: Database,
-  input: { chatId: string; info: PullRequestPayloadInfo; reviewer: ReviewerAgent },
+  input: { chatId: string; info: PullRequestPayloadInfo; reviewer: ReviewerAgent; appSlug: string | null },
 ): Promise<string | null> {
   if (input.info.eventType !== "issue_comment" || input.info.action !== "created") return null;
 
   const commentAuthorLogin = input.info.commentAuthorLogin?.trim().toLowerCase();
   if (!commentAuthorLogin) return null;
 
-  const reviewerGithubLogin = input.reviewer.name?.trim().toLowerCase();
-  if (!reviewerGithubLogin) {
+  const appBotLogin = input.appSlug ? `${input.appSlug.toLowerCase()}[bot]` : null;
+  const commentAuthorIsAppBot =
+    appBotLogin !== null && commentAuthorLogin === appBotLogin && isCommentAuthorBot(input.info);
+  const managerGithubLogin = await loadManagerGithubLogin(db, input.reviewer.managerUserId);
+  const commentAuthorIsManager = managerGithubLogin !== null && commentAuthorLogin === managerGithubLogin;
+  if (!commentAuthorIsManager && !commentAuthorIsAppBot) {
     log.debug(
-      { reviewerAgentUuid: input.reviewer.uuid, entityKey: input.info.entityKey },
-      "context reviewer echo comment not suppressed: reviewer github login is unavailable",
+      {
+        reviewerAgentUuid: input.reviewer.uuid,
+        managerUserId: input.reviewer.managerUserId,
+        entityKey: input.info.entityKey,
+        commentAuthorLogin: input.info.commentAuthorLogin,
+        managerGithubLoginAvailable: managerGithubLogin !== null,
+        appBotLogin,
+        commentAuthorType: input.info.commentAuthorType,
+        senderType: input.info.senderType,
+      },
+      "context reviewer echo comment not suppressed: comment author is not the manager or app bot",
     );
     return null;
   }
-  if (commentAuthorLogin !== reviewerGithubLogin) return null;
 
-  const [latestReviewerTask] = await db
+  const [initialOpenedTask] = await db
     .select({
       id: messages.id,
-      event: sql<string>`${messages.metadata}->>'event'`,
-      action: sql<string>`${messages.metadata}->>'action'`,
-      triggerEvent: sql<string>`${messages.metadata}->>'triggerEvent'`,
     })
     .from(messages)
     .where(
@@ -535,23 +569,42 @@ async function findSuppressibleReviewerEchoMessageId(
         eq(messages.chatId, input.chatId),
         sql`${messages.metadata}->>'entityKey' = ${input.info.entityKey}`,
         sql`${messages.metadata}->>'contextTreeReviewer' = 'true'`,
+        sql`${messages.metadata}->>'event' = 'pull_request'`,
+        sql`${messages.metadata}->>'action' = 'opened'`,
+        sql`${messages.metadata}->>'triggerEvent' = 'pull_request.opened'`,
         sql`${messages.createdAt} >= NOW() - make_interval(secs => ${REVIEWER_OPENED_ECHO_SUPPRESSION_WINDOW_SECONDS})`,
       ),
     )
     .orderBy(desc(messages.createdAt), desc(messages.id))
     .limit(1);
 
-  const isInitialOpenedTask =
-    latestReviewerTask?.event === "pull_request" &&
-    latestReviewerTask.action === "opened" &&
-    latestReviewerTask.triggerEvent === "pull_request.opened";
-  return isInitialOpenedTask ? latestReviewerTask.id : null;
+  return initialOpenedTask?.id ?? null;
+}
+
+function isCommentAuthorBot(info: PullRequestPayloadInfo): boolean {
+  if (info.commentAuthorType?.toLowerCase() === "bot") return true;
+  return (
+    info.senderType?.toLowerCase() === "bot" &&
+    info.commentAuthorLogin?.trim().toLowerCase() === info.senderLogin.trim().toLowerCase()
+  );
+}
+
+async function loadManagerGithubLogin(db: Database, userId: string): Promise<string | null> {
+  const [identity] = await db
+    .select({ metadata: authIdentities.metadata })
+    .from(authIdentities)
+    .where(and(eq(authIdentities.userId, userId), eq(authIdentities.provider, "github")))
+    .limit(1);
+  const login = identity?.metadata?.login;
+  return typeof login === "string" && login.trim() ? login.trim().toLowerCase() : null;
 }
 
 export const contextReviewerPrTestInternals = {
+  contextReviewerFollowUpContent,
   extractPullRequestPayloadInfo,
   findExistingReviewerChat,
   isSupportedContextReviewerPrEvent,
+  loadManagerGithubLogin,
   loadValidReviewerAgent,
   parseBareRepo,
   parseScpLikeRepo,

--- a/packages/server/src/services/context-reviewer-pr.ts
+++ b/packages/server/src/services/context-reviewer-pr.ts
@@ -8,7 +8,6 @@ import type { FastifyInstance } from "fastify";
 import { isRecord, readNumber, readString } from "../api/webhooks/github-entity.js";
 import type { Database } from "../db/connection.js";
 import { agents } from "../db/schema/agents.js";
-import { authIdentities } from "../db/schema/auth-identities.js";
 import { chats } from "../db/schema/chats.js";
 import { members } from "../db/schema/members.js";
 import { messages } from "../db/schema/messages.js";
@@ -77,7 +76,6 @@ type ContextReviewerPrTrigger =
 
 type ReviewerAgent = {
   uuid: string;
-  managerUserId: string;
   managerHumanAgentId: string;
 };
 
@@ -489,7 +487,6 @@ async function loadValidReviewerAgent(
   const [agent] = await db
     .select({
       uuid: agents.uuid,
-      managerUserId: members.userId,
       managerHumanAgentId: members.agentId,
     })
     .from(agents)
@@ -540,21 +537,17 @@ async function findSuppressibleReviewerEchoMessageId(
   const appBotLogin = input.appSlug ? `${input.appSlug.toLowerCase()}[bot]` : null;
   const commentAuthorIsAppBot =
     appBotLogin !== null && commentAuthorLogin === appBotLogin && isCommentAuthorBot(input.info);
-  const managerGithubLogin = await loadManagerGithubLogin(db, input.reviewer.managerUserId);
-  const commentAuthorIsManager = managerGithubLogin !== null && commentAuthorLogin === managerGithubLogin;
-  if (!commentAuthorIsManager && !commentAuthorIsAppBot) {
+  if (!commentAuthorIsAppBot) {
     log.debug(
       {
         reviewerAgentUuid: input.reviewer.uuid,
-        managerUserId: input.reviewer.managerUserId,
         entityKey: input.info.entityKey,
         commentAuthorLogin: input.info.commentAuthorLogin,
-        managerGithubLoginAvailable: managerGithubLogin !== null,
         appBotLogin,
         commentAuthorType: input.info.commentAuthorType,
         senderType: input.info.senderType,
       },
-      "context reviewer echo comment not suppressed: comment author is not the manager or app bot",
+      "context reviewer echo comment not suppressed: comment author is not the configured app bot",
     );
     return null;
   }
@@ -582,21 +575,7 @@ async function findSuppressibleReviewerEchoMessageId(
 }
 
 function isCommentAuthorBot(info: PullRequestPayloadInfo): boolean {
-  if (info.commentAuthorType?.toLowerCase() === "bot") return true;
-  return (
-    info.senderType?.toLowerCase() === "bot" &&
-    info.commentAuthorLogin?.trim().toLowerCase() === info.senderLogin.trim().toLowerCase()
-  );
-}
-
-async function loadManagerGithubLogin(db: Database, userId: string): Promise<string | null> {
-  const [identity] = await db
-    .select({ metadata: authIdentities.metadata })
-    .from(authIdentities)
-    .where(and(eq(authIdentities.userId, userId), eq(authIdentities.provider, "github")))
-    .limit(1);
-  const login = identity?.metadata?.login;
-  return typeof login === "string" && login.trim() ? login.trim().toLowerCase() : null;
+  return info.commentAuthorType?.trim().toLowerCase() === "bot";
 }
 
 export const contextReviewerPrTestInternals = {
@@ -604,7 +583,6 @@ export const contextReviewerPrTestInternals = {
   extractPullRequestPayloadInfo,
   findExistingReviewerChat,
   isSupportedContextReviewerPrEvent,
-  loadManagerGithubLogin,
   loadValidReviewerAgent,
   parseBareRepo,
   parseScpLikeRepo,

--- a/packages/server/src/services/context-reviewer-pr.ts
+++ b/packages/server/src/services/context-reviewer-pr.ts
@@ -2,7 +2,7 @@ import { access, readFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
 import { chatMetadataSchema } from "@first-tree/shared";
-import { and, eq, sql } from "drizzle-orm";
+import { and, desc, eq, sql } from "drizzle-orm";
 import type * as ejs from "ejs";
 import type { FastifyInstance } from "fastify";
 import { isRecord, readNumber, readString } from "../api/webhooks/github-entity.js";
@@ -10,6 +10,7 @@ import type { Database } from "../db/connection.js";
 import { agents } from "../db/schema/agents.js";
 import { chats } from "../db/schema/chats.js";
 import { members } from "../db/schema/members.js";
+import { messages } from "../db/schema/messages.js";
 import { createLogger } from "../observability/index.js";
 import { createChat } from "./chat.js";
 import { sendMessage } from "./message.js";
@@ -19,6 +20,8 @@ import { applyMembershipWrite } from "./participant-mode.js";
 
 const log = createLogger("ContextReviewerPr");
 const require = createRequire(import.meta.url);
+const FOLLOW_UP_NOTICE = "A new GitHub event was received. I'll check the current PR state.";
+const REVIEWER_OPENED_ECHO_SUPPRESSION_WINDOW_SECONDS = 60 * 60;
 // EJS is published as CommonJS at runtime even though its types expose named
 // exports, so native ESM cannot import `render` directly.
 const ejsRuntime: typeof ejs = require("ejs");
@@ -47,7 +50,7 @@ export type ContextReviewerPrTemplateInput = {
 
 export type ContextReviewerPrResult =
   | { handled: false; reason: ContextReviewerPrSkipReason }
-  | { handled: true; chatId: string; messageId: string; reused: boolean };
+  | { handled: true; chatId: string; messageId: string; reused: boolean; suppressed?: boolean };
 
 export type ContextReviewerPrSkipReason =
   | "unsupported_event"
@@ -228,7 +231,6 @@ export async function handleContextReviewerPrEvent(
     return { handled: false, reason: "reviewer_agent_invalid" };
   }
 
-  const prompt = await renderContextReviewerPrPrompt(info);
   const metadata = chatMetadataSchema.parse({
     source: "github",
     entityType: "pull_request",
@@ -250,6 +252,30 @@ export async function handleContextReviewerPrEvent(
       [{ agentId: reviewer.managerHumanAgentId }, { agentId: reviewer.uuid }],
       { onConflictDoNothing: true, upgradeWatcherToSpeaker: true },
     );
+    const suppressedEchoMessageId = await findSuppressibleReviewerEchoMessageId(app.db, {
+      chatId: existingChatId,
+      info,
+      reviewer,
+    });
+    if (suppressedEchoMessageId) {
+      log.info(
+        {
+          organizationId: input.organizationId,
+          entityKey: info.entityKey,
+          chatId: existingChatId,
+          commentAuthorLogin: info.commentAuthorLogin,
+        },
+        "context reviewer echo comment suppressed",
+      );
+      return {
+        handled: true,
+        chatId: existingChatId,
+        messageId: suppressedEchoMessageId,
+        reused: true,
+        suppressed: true,
+      };
+    }
+
     const { message, recipients } = await sendMessage(
       app.db,
       existingChatId,
@@ -257,17 +283,8 @@ export async function handleContextReviewerPrEvent(
       {
         source: "github",
         format: "markdown",
-        content: prompt,
-        metadata: {
-          source: "github",
-          event: info.eventType,
-          action: info.action,
-          triggerEvent: info.triggerEvent,
-          entityType: "pull_request",
-          entityKey: info.entityKey,
-          contextTreeReviewer: true,
-          mentions: [reviewer.uuid],
-        },
+        content: FOLLOW_UP_NOTICE,
+        metadata: contextReviewerMessageMetadata(info, reviewer),
       },
       { normalizeMentionsInContent: false },
     );
@@ -279,6 +296,7 @@ export async function handleContextReviewerPrEvent(
     return { handled: true, chatId: existingChatId, messageId: message.id, reused: true };
   }
 
+  const prompt = await renderContextReviewerPrPrompt(info);
   const created = await createChat(app.db, {
     mode: "task",
     initiatorAgentId: reviewer.managerHumanAgentId,
@@ -290,15 +308,7 @@ export async function handleContextReviewerPrEvent(
       source: "github",
       format: "markdown",
       content: prompt,
-      metadata: {
-        source: "github",
-        event: info.eventType,
-        action: info.action,
-        triggerEvent: info.triggerEvent,
-        entityType: "pull_request",
-        entityKey: info.entityKey,
-        contextTreeReviewer: true,
-      },
+      metadata: contextReviewerMessageMetadata(info, reviewer),
     },
     source: "manual",
   });
@@ -431,6 +441,22 @@ function readCommentAuthorLogin(comment: Record<string, unknown> | null): string
   return readString(user?.login);
 }
 
+function contextReviewerMessageMetadata(
+  info: PullRequestPayloadInfo,
+  reviewer: ReviewerAgent,
+): Record<string, unknown> {
+  return {
+    source: "github",
+    event: info.eventType,
+    action: info.action,
+    triggerEvent: info.triggerEvent,
+    entityType: "pull_request",
+    entityKey: info.entityKey,
+    contextTreeReviewer: true,
+    mentions: [reviewer.uuid],
+  };
+}
+
 async function loadValidReviewerAgent(
   db: Database,
   input: { organizationId: string; reviewerAgentUuid: string },
@@ -477,6 +503,51 @@ async function findExistingReviewerChat(
   return row?.id ?? null;
 }
 
+async function findSuppressibleReviewerEchoMessageId(
+  db: Database,
+  input: { chatId: string; info: PullRequestPayloadInfo; reviewer: ReviewerAgent },
+): Promise<string | null> {
+  if (input.info.eventType !== "issue_comment" || input.info.action !== "created") return null;
+
+  const commentAuthorLogin = input.info.commentAuthorLogin?.trim().toLowerCase();
+  if (!commentAuthorLogin) return null;
+
+  const reviewerGithubLogin = input.reviewer.name?.trim().toLowerCase();
+  if (!reviewerGithubLogin) {
+    log.debug(
+      { reviewerAgentUuid: input.reviewer.uuid, entityKey: input.info.entityKey },
+      "context reviewer echo comment not suppressed: reviewer github login is unavailable",
+    );
+    return null;
+  }
+  if (commentAuthorLogin !== reviewerGithubLogin) return null;
+
+  const [latestReviewerTask] = await db
+    .select({
+      id: messages.id,
+      event: sql<string>`${messages.metadata}->>'event'`,
+      action: sql<string>`${messages.metadata}->>'action'`,
+      triggerEvent: sql<string>`${messages.metadata}->>'triggerEvent'`,
+    })
+    .from(messages)
+    .where(
+      and(
+        eq(messages.chatId, input.chatId),
+        sql`${messages.metadata}->>'entityKey' = ${input.info.entityKey}`,
+        sql`${messages.metadata}->>'contextTreeReviewer' = 'true'`,
+        sql`${messages.createdAt} >= NOW() - make_interval(secs => ${REVIEWER_OPENED_ECHO_SUPPRESSION_WINDOW_SECONDS})`,
+      ),
+    )
+    .orderBy(desc(messages.createdAt), desc(messages.id))
+    .limit(1);
+
+  const isInitialOpenedTask =
+    latestReviewerTask?.event === "pull_request" &&
+    latestReviewerTask.action === "opened" &&
+    latestReviewerTask.triggerEvent === "pull_request.opened";
+  return isInitialOpenedTask ? latestReviewerTask.id : null;
+}
+
 export const contextReviewerPrTestInternals = {
   extractPullRequestPayloadInfo,
   findExistingReviewerChat,
@@ -485,4 +556,5 @@ export const contextReviewerPrTestInternals = {
   parseBareRepo,
   parseScpLikeRepo,
   parseUrlRepo,
+  findSuppressibleReviewerEchoMessageId,
 };


### PR DESCRIPTION
## Summary

- Keep the initial `pull_request.opened` Context Reviewer task prompt unchanged.
- Send a short follow-up notice for subsequent GitHub events in the existing reviewer chat instead of replaying the full review prompt.
- Suppress the reviewer agent's own PR comment echo after the initial opened task to avoid duplicate task messages.
- Preserve Context Reviewer metadata on follow-up notices for event/action/entity tracking.

## Tests

- `pnpm --filter @first-tree/server test -- context-reviewer-pr`
- `pnpm --filter @first-tree/server typecheck`
- `git diff --check`

## Notes

- `pnpm check && pnpm typecheck` was attempted. Server typecheck passed, but the combined command is currently blocked by unrelated existing client/web issues:
  - Biome warnings/info in `packages/client/src/__tests__/assistant-text.test.ts`, `packages/client/src/runtime/workspace-migrations.ts`, and `packages/web/src/index.css`.
  - `@first-tree/client` typecheck errors around `SDKAssistantMessageError` values in Claude provider error handling tests/code.
