### PR TITLE
fix: prevent chat view from reverting team switches

### DIFF
--- a/packages/web/src/pages/workspace/center/__tests__/chat-by-id-center-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-by-id-center-dom.test.tsx
@@ -25,6 +25,7 @@ const authMock = vi.hoisted(() => ({
     organizationId: "org-1" as string | null,
     memberships: [{ organizationId: "org-1" }, { organizationId: "org-2" }] as Array<{ organizationId: string }>,
     selectOrganization: vi.fn(),
+    switchingOrg: null as { id: string; displayName: string } | null,
   },
 }));
 
@@ -252,6 +253,7 @@ beforeEach(() => {
     organizationId: "org-1",
     memberships: [{ organizationId: "org-1" }, { organizationId: "org-2" }],
     selectOrganization: vi.fn(),
+    switchingOrg: null,
   };
   chatMocks.getChat.mockResolvedValue(chatDetail());
   meChatMocks.markMeChatRead.mockResolvedValue({
@@ -455,6 +457,22 @@ describe("ChatByIdView and CenterPanel", () => {
     await waitForText(container, "ChatView agent-1 chat-xorg");
     expect(authMock.value.selectOrganization).toHaveBeenCalledTimes(1);
     expect(authMock.value.selectOrganization).toHaveBeenCalledWith("org-2");
+
+    await act(async () => root.unmount());
+  });
+
+  it("does not auto-switch back to the open chat's org while a team switch is in flight", async () => {
+    authMock.value.organizationId = "org-2";
+    authMock.value.switchingOrg = { id: "org-2", displayName: "Globex" };
+    authMock.value.memberships = [{ organizationId: "org-1" }, { organizationId: "org-2" }];
+    chatMocks.getChat.mockResolvedValueOnce(chatDetail({ organizationId: "org-1" }));
+    const { ChatByIdView } = await import("../chat-by-id.js");
+    const { container, root } = await renderDom(
+      <ChatByIdView chatId="chat-old-org" narrow={false} onShowConversations={null} />,
+    );
+
+    await waitForText(container, "ChatView agent-1 chat-old-org");
+    expect(authMock.value.selectOrganization).not.toHaveBeenCalled();
 
     await act(async () => root.unmount());
   });

--- a/packages/web/src/pages/workspace/center/chat-by-id.tsx
+++ b/packages/web/src/pages/workspace/center/chat-by-id.tsx
@@ -73,7 +73,7 @@ export function ChatByIdView({
   onClearChat?: (() => void) | null;
 }) {
   const queryClient = useQueryClient();
-  const { agentId: myAgentId, organizationId: currentOrgId, selectOrganization, memberships } = useAuth();
+  const { agentId: myAgentId, organizationId: currentOrgId, selectOrganization, memberships, switchingOrg } = useAuth();
 
   const { data: chatDetail, isError: chatDetailError } = useQuery({
     queryKey: ["chat-detail", chatId],
@@ -99,12 +99,13 @@ export function ChatByIdView({
   const switchedOrgRef = useRef<string | null>(null);
   useEffect(() => {
     const chatOrg = chatDetail?.organizationId;
+    if (switchingOrg) return;
     if (!chatOrg || !currentOrgId || chatOrg === currentOrgId) return;
     if (switchedOrgRef.current === chatOrg) return;
     if (!memberships.some((m) => m.organizationId === chatOrg)) return;
     switchedOrgRef.current = chatOrg;
     void selectOrganization(chatOrg);
-  }, [chatDetail?.organizationId, currentOrgId, memberships, selectOrganization]);
+  }, [chatDetail?.organizationId, currentOrgId, memberships, selectOrganization, switchingOrg]);
 
   const primaryAgent = useMemo(() => {
     if (!chatDetail) return null;


### PR DESCRIPTION
## Why

After #1248 landed, switching teams could appear unstable from a currently-open chat: the header anchor briefly flipped to the new team, then the workspace returned to the old team.

Root cause: `TeamSwitcher` starts a global org switch and only navigates home after `selectOrganization` settles. During that in-flight window, the still-mounted `ChatByIdView` can see its old chat belongs to a different org than the newly selected org and run its own cross-org auto-switch back to the old chat's org.

## What

- Make `ChatByIdView` pause its cross-org chat auto-switch while `switchingOrg` is non-null.
- Keep the normal direct-link behavior intact: opening a cross-org chat still switches the workspace to that chat's org when no team switch is already in flight.
- Add a DOM regression test for the exact race: current org is the new team, old chat detail belongs to the old team, and `switchingOrg` is active, so `selectOrganization(oldOrg)` must not fire.

## Verification

- `pnpm --filter @first-tree/web exec vitest run src/pages/workspace/center/__tests__/chat-by-id-center-dom.test.tsx src/components/__tests__/team-switcher-dom.test.tsx src/components/__tests__/layout-dom.test.tsx --reporter=dot`
- `pnpm exec biome check packages/web/src/pages/workspace/center/chat-by-id.tsx packages/web/src/pages/workspace/center/__tests__/chat-by-id-center-dom.test.tsx`
- `pnpm --filter @first-tree/web typecheck`
- `git diff --check origin/main...HEAD`

Note: `layout-dom` still prints the existing localhost:3000 version-check ECONNREFUSED stderr in this local environment, but the suite passes.