### PR TITLE
feat: support @mention and image attachments in the ask answer card

### DIFF
--- a/packages/web/src/api/chats.ts
+++ b/packages/web/src/api/chats.ts
@@ -171,17 +171,29 @@ export function sendFileMessageBatch(
   chatId: string,
   content: SendFileMessageBatchBody,
   metadata?: SendFileMessageMetadata,
-  opts?: { inReplyTo?: string },
+  opts?: { inReplyTo?: string; resolves?: RequestResolution },
 ): Promise<Message> {
   // Project explicit fields rather than spreading `metadata` whole so future
   // additions to SendFileMessageMetadata don't ride out on the `mentions`
   // truthiness check by accident — each new field must be opted in here.
   const mentions = metadata?.mentions;
   const hasMentions = Array.isArray(mentions) && mentions.length > 0;
+  // `resolves` rides a file-format send only when the human answers a blocking
+  // ask WITH an attached image (the AskTakeover image path). The server's
+  // resolution gate is format-agnostic — it authorizes off `senderId === target`
+  // (services/message.ts), so a captioned image from the target resolves the
+  // question exactly like a text answer. Mirrors `sendChatMessage`.
+  const meta =
+    hasMentions || opts?.resolves
+      ? {
+          ...(hasMentions ? { mentions } : {}),
+          ...(opts?.resolves ? { resolves: opts.resolves } : {}),
+        }
+      : undefined;
   return api.post<Message>(`/chats/${encodeURIComponent(chatId)}/messages`, {
     format: "file",
     content,
-    ...(hasMentions ? { metadata: { mentions } } : {}),
+    ...(meta ? { metadata: meta } : {}),
     // `inReplyTo` is format-agnostic threading (`sendMessageSchema`) — a
     // captioned image answering a docked question threads under it just like
     // a text reply.

--- a/packages/web/src/components/chat/__tests__/ask-takeover-dom.test.tsx
+++ b/packages/web/src/components/chat/__tests__/ask-takeover-dom.test.tsx
@@ -13,10 +13,17 @@ vi.mock("../../ui/markdown.js", () => ({
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
+// usePendingImages stages a revocable object-URL per file; give the test a
+// deterministic, side-effect-free implementation regardless of happy-dom's.
+URL.createObjectURL = () => "blob:mock";
+URL.revokeObjectURL = () => {};
+
 const OPTS = [
   { label: "Ship", description: "ship now", preview: "ft deploy --to 20" },
   { label: "Hold", description: "wait 24h" },
 ];
+
+const CANDIDATES = [{ agentId: "agent-alice", name: "alice", displayName: "Alice", managedByMe: false }];
 
 const roots: Root[] = [];
 async function renderDom(element: ReactElement): Promise<HTMLElement> {
@@ -57,6 +64,20 @@ async function setValue(el: HTMLTextAreaElement, value: string): Promise<void> {
     el.dispatchEvent(new InputEvent("input", { bubbles: true, data: value, inputType: "insertText" }));
   });
 }
+async function changeFiles(el: HTMLInputElement, files: File[]): Promise<void> {
+  await act(async () => {
+    Object.defineProperty(el, "files", { configurable: true, value: files });
+    el.dispatchEvent(new Event("change", { bubbles: true }));
+  });
+}
+function freeTextBox(c: ParentNode): HTMLTextAreaElement | null {
+  return c.querySelector<HTMLTextAreaElement>(
+    'textarea[placeholder^="Type your answer"], textarea[placeholder^="Other"]',
+  );
+}
+function thumbnails(c: ParentNode): HTMLImageElement[] {
+  return [...c.querySelectorAll<HTMLImageElement>("img")];
+}
 function option(c: ParentNode, text: string): HTMLButtonElement | null {
   return (
     [...c.querySelectorAll<HTMLButtonElement>('[role="radio"],[role="checkbox"]')].find((b) =>
@@ -94,7 +115,7 @@ describe("AskTakeover", () => {
     expect(option(c, "Hold")?.getAttribute("aria-checked")).toBe("true");
 
     await click(btn(c, "Reply"));
-    expect(onReply).toHaveBeenCalledWith("Hold");
+    expect(onReply).toHaveBeenCalledWith({ content: "Hold", mentions: [], images: [] });
   });
 
   it("multi-select: toggles several options; Reply joins the labels", async () => {
@@ -107,7 +128,7 @@ describe("AskTakeover", () => {
     expect(option(c, "Ship")?.getAttribute("aria-checked")).toBe("true");
     expect(option(c, "Hold")?.getAttribute("aria-checked")).toBe("true");
     await click(btn(c, "Reply"));
-    expect(onReply).toHaveBeenCalledWith("Ship, Hold");
+    expect(onReply).toHaveBeenCalledWith({ content: "Ship, Hold", mentions: [], images: [] });
   });
 
   it("options + Other free text merge into the answer", async () => {
@@ -120,7 +141,7 @@ describe("AskTakeover", () => {
     if (!other) throw new Error("Other input missing");
     await setValue(other, "but watch the canary");
     await click(btn(c, "Reply"));
-    expect(onReply).toHaveBeenCalledWith("Ship\nbut watch the canary");
+    expect(onReply).toHaveBeenCalledWith({ content: "Ship\nbut watch the canary", mentions: [], images: [] });
   });
 
   it("free-text ask (no options): Reply gated on text, sends the typed answer", async () => {
@@ -134,7 +155,7 @@ describe("AskTakeover", () => {
     await setValue(ta, "looks risky");
     expect(btn(c, "Reply")?.disabled).toBe(false);
     await click(btn(c, "Reply"));
-    expect(onReply).toHaveBeenCalledWith("looks risky");
+    expect(onReply).toHaveBeenCalledWith({ content: "looks risky", mentions: [], images: [] });
   });
 
   it("body + options scroll together while the Skip/Reply footer stays pinned", async () => {
@@ -212,7 +233,7 @@ describe("AskTakeover", () => {
 
     await setValue(ta, "looks risky");
     const entered = await keyDown(ta, "Enter");
-    expect(onReply).toHaveBeenCalledWith("looks risky");
+    expect(onReply).toHaveBeenCalledWith({ content: "looks risky", mentions: [], images: [] });
     expect(entered.defaultPrevented).toBe(true); // no newline gets inserted
 
     // Esc skips, regardless of focus / typed text.
@@ -291,7 +312,97 @@ describe("AskTakeover", () => {
     // Once the overlay closes (aria-hidden cleared), the shortcuts resume.
     c.removeAttribute("aria-hidden");
     await keyDown(ta, "Enter");
-    expect(onReply).toHaveBeenCalledWith("looks risky");
+    expect(onReply).toHaveBeenCalledWith({ content: "looks risky", mentions: [], images: [] });
+  });
+
+  it("resolves free-text `@<name>` tokens to agentIds against the candidates", async () => {
+    const onReply = vi.fn();
+    const c = await renderDom(
+      <AskTakeover
+        body="# Who?"
+        payload={{ multiSelect: false }}
+        mentionCandidates={CANDIDATES}
+        onReply={onReply}
+        onSkip={() => {}}
+      />,
+    );
+    const ta = freeTextBox(c);
+    if (!ta) throw new Error("free-text input missing");
+    await setValue(ta, "@alice please confirm");
+    await click(btn(c, "Reply"));
+    expect(onReply).toHaveBeenCalledWith({
+      content: "@alice please confirm",
+      mentions: ["agent-alice"],
+      images: [],
+    });
+  });
+
+  it("renders the `@` autocomplete popover when the caret sits in an `@` query", async () => {
+    const c = await renderDom(
+      <AskTakeover
+        body="# Who?"
+        payload={{ multiSelect: false }}
+        mentionCandidates={CANDIDATES}
+        onReply={() => {}}
+        onSkip={() => {}}
+      />,
+    );
+    const ta = freeTextBox(c);
+    if (!ta) throw new Error("free-text input missing");
+    await setValue(ta, "@al");
+    // The popover is a listbox of candidate rows anchored to the textarea.
+    const listbox = c.querySelector('[role="listbox"]');
+    expect(listbox?.textContent).toContain("Alice");
+  });
+
+  it("stages a pasted/attached image and lets an image-only answer resolve", async () => {
+    const onReply = vi.fn();
+    const c = await renderDom(
+      <AskTakeover body="# Evidence?" payload={{ multiSelect: false }} onReply={onReply} onSkip={() => {}} />,
+    );
+    // No text yet → Reply gated.
+    expect(btn(c, "Reply")?.disabled).toBe(true);
+
+    const file = new File(["x"], "shot.png", { type: "image/png" });
+    const fileInput = c.querySelector<HTMLInputElement>('input[type="file"]');
+    if (!fileInput) throw new Error("file input missing");
+    await changeFiles(fileInput, [file]);
+
+    // A thumbnail appears and an image alone now satisfies Reply.
+    expect(thumbnails(c).length).toBe(1);
+    expect(btn(c, "Reply")?.disabled).toBe(false);
+
+    await click(btn(c, "Reply"));
+    expect(onReply).toHaveBeenCalledWith({ content: "", mentions: [], images: [file] });
+  });
+
+  it("rejects an oversized image with an error and stages nothing", async () => {
+    const onReply = vi.fn();
+    const c = await renderDom(
+      <AskTakeover body="# Evidence?" payload={{ multiSelect: false }} onReply={onReply} onSkip={() => {}} />,
+    );
+    // 5MB + 1 byte — over the per-image cap usePendingImages enforces.
+    const big = new File([new ArrayBuffer(5 * 1024 * 1024 + 1)], "big.png", { type: "image/png" });
+    const fileInput = c.querySelector<HTMLInputElement>('input[type="file"]');
+    if (!fileInput) throw new Error("file input missing");
+    await changeFiles(fileInput, [big]);
+
+    expect(c.textContent).toContain("too large");
+    expect(thumbnails(c).length).toBe(0);
+    expect(btn(c, "Reply")?.disabled).toBe(true);
+  });
+
+  it("surfaces a host send error inside the card", async () => {
+    const c = await renderDom(
+      <AskTakeover
+        body="# Concerns?"
+        payload={{ multiSelect: false }}
+        error="Failed to send your answer"
+        onReply={() => {}}
+        onSkip={() => {}}
+      />,
+    );
+    expect(c.textContent).toContain("Failed to send your answer");
   });
 
   it("yields to a focused control that already consumed the keystroke (defaultPrevented)", async () => {

--- a/packages/web/src/components/chat/ask-takeover.tsx
+++ b/packages/web/src/components/chat/ask-takeover.tsx
@@ -19,16 +19,45 @@
  *     than waiting on a never-answered question. There is no "dismiss but keep it
  *     open" path — skip is an answer, not a deferral.
  *
- * The answer is plain text: selected option labels join on one line, any typed
- * note follows — `buildResolveAnswer` owns the format. This is the ONLY way to
+ * The free-text answer surface mirrors the chat composer: it supports `@mention`
+ * autocomplete (against the chat's members) and image attachments (paste / drop /
+ * file-picker), so answering an ask is as expressive as a normal message. The
+ * readable answer is still plain text (`buildResolveAnswer`: selected option
+ * labels join on one line, any typed note follows); the host turns the assembled
+ * {content, mentions, images} into the resolving reply. This is the ONLY way to
  * resolve a question: the target human answers here, in the web UI; an agent can
  * only ask, never answer or close.
  */
-import type { AskOption, AskRequest } from "@first-tree/shared";
-import { useEffect, useRef, useState } from "react";
+import type { AskOption, AskRequest, MentionParticipant } from "@first-tree/shared";
+import { extractMentions } from "@first-tree/shared";
+import { AtSign, Paperclip, X } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useWorkspaceViewport } from "../../hooks/use-viewport.js";
+import { usePendingImages } from "../../lib/use-pending-images.js";
+import { MentionAutocompletePopover, type MentionCandidate, useMentionAutocomplete } from "../mention-autocomplete.js";
+import { MentionHighlightOverlay } from "../mention-highlight-overlay.js";
 import { Markdown } from "../ui/markdown.js";
 import { allRequiredAnswered, buildResolveAnswer } from "./request-state.js";
+
+/**
+ * The composed answer handed back to the host on Reply. The host owns the
+ * actual send + resolve (it has the chat/request context and the upload
+ * machinery); this card only assembles the answer.
+ *
+ *   - `content` — the readable answer (`buildResolveAnswer`): selected option
+ *     labels and/or the typed note.
+ *   - `mentions` — agentIds the free-text `@<name>` tokens resolved to (against
+ *     `mentionCandidates`); the host routes the resolving reply to the asker
+ *     PLUS these.
+ *   - `images` — staged image files to upload + attach; a non-empty list makes
+ *     the resolving reply a `format="file"` message (which the server resolves
+ *     just like a text answer — the resolve gate is format-agnostic).
+ */
+export type AskAnswer = {
+  content: string;
+  mentions: string[];
+  images: File[];
+};
 
 /**
  * Height (px) the on-screen keyboard currently steals from the bottom of the
@@ -64,6 +93,8 @@ export function AskTakeover({
   payload,
   askerName,
   sending = false,
+  mentionCandidates = [],
+  error,
   onReply,
   onSkip,
 }: {
@@ -72,8 +103,15 @@ export function AskTakeover({
   payload: AskRequest;
   askerName?: string;
   sending?: boolean;
-  /** Resolve the question with the composed answer content. */
-  onReply: (content: string) => void;
+  /** Chat members the free-text `@` autocomplete suggests + resolves against
+   *  (self-excluded, same source as the composer). Empty → no autocomplete and
+   *  every `@<token>` stays plain text. */
+  mentionCandidates?: MentionCandidate[];
+  /** A host-side send failure to surface in the card (the composer is covered,
+   *  so a failed resolve must show here or it looks like nothing happened). */
+  error?: string;
+  /** Resolve the question with the composed answer. */
+  onReply: (answer: AskAnswer) => void;
   /** Resolve the question with a "skipped" answer (caller sends the reply). */
   onSkip: () => void;
 }) {
@@ -81,12 +119,50 @@ export function AskTakeover({
   const multi = payload.multiSelect === true;
   const [selected, setSelected] = useState<string[]>([]);
   const [freeText, setFreeText] = useState("");
+  const [cursor, setCursor] = useState(0);
   // Tighten the horizontal padding on phone widths so the card uses the
   // available width instead of burning it on gutters.
   const viewport = useWorkspaceViewport();
   const padX = viewport === "narrow" ? "var(--sp-4)" : "var(--sp-6)";
   // Keep the card (and its pinned footer) above the on-screen keyboard.
   const keyboardInset = useKeyboardInset();
+
+  // Staged image attachments — same hook (and same `image/* ≤5MB` rules + object-
+  // URL lifecycle) the chat composer uses. A local validation error (oversized
+  // image) renders alongside any host send error below.
+  const [imageError, setImageError] = useState<string | null>(null);
+  const { pendingImages, addImages, removeImage } = usePendingImages({
+    onError: setImageError,
+    onChange: () => setImageError(null),
+  });
+
+  // Self-excluded membership projection for `@` resolution + the mirror overlay.
+  const mentionParticipants = useMemo<MentionParticipant[]>(
+    () => mentionCandidates.map((c) => ({ agentId: c.agentId, name: c.name })),
+    [mentionCandidates],
+  );
+
+  const taRef = useRef<HTMLTextAreaElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const mention = useMentionAutocomplete({
+    value: freeText,
+    cursor,
+    candidates: mentionCandidates,
+    disabled: sending,
+    onSelect: (update) => {
+      setFreeText(update.text);
+      setCursor(update.cursor);
+      // Defer so React commits the new value before we move the selection —
+      // otherwise the textarea snaps back to its old caret position.
+      requestAnimationFrame(() => {
+        const el = taRef.current;
+        if (!el) return;
+        el.focus();
+        el.setSelectionRange(update.cursor, update.cursor);
+      });
+    },
+  });
 
   const toggle = (label: string) => {
     setSelected((prev) => {
@@ -95,10 +171,34 @@ export function AskTakeover({
     });
   };
 
-  const canReply = allRequiredAnswered(payload, selected, freeText) && !sending;
-  const reply = () => {
+  // An attached image is itself an answer, so it lifts the "must select or type"
+  // gate even on a free-text ask with an empty box.
+  const canReply = (allRequiredAnswered(payload, selected, freeText) || pendingImages.length > 0) && !sending;
+  // Memoized so the window-level keydown effect below has a stable dep (it would
+  // otherwise re-bind the listener every render).
+  const reply = useCallback(() => {
     if (!canReply) return;
-    onReply(buildResolveAnswer(payload, selected, freeText));
+    onReply({
+      content: buildResolveAnswer(payload, selected, freeText),
+      mentions: extractMentions(freeText, mentionParticipants),
+      images: pendingImages.map((p) => p.file),
+    });
+  }, [canReply, onReply, payload, selected, freeText, mentionParticipants, pendingImages]);
+
+  // Insert `@` at the caret (or over the selection) and refocus — the
+  // autocomplete picks it up from the resulting value/cursor, same path as
+  // typing `@`. Mirrors the composer's explicit `@` button.
+  const insertMentionTrigger = () => {
+    const el = taRef.current;
+    const start = el?.selectionStart ?? freeText.length;
+    const end = el?.selectionEnd ?? start;
+    const next = `${freeText.slice(0, start)}@${freeText.slice(end)}`;
+    setFreeText(next);
+    setCursor(start + 1);
+    requestAnimationFrame(() => {
+      el?.focus();
+      el?.setSelectionRange(start + 1, start + 1);
+    });
   };
 
   // Keyboard shortcuts, mirroring the chat composer: Enter (no Shift, and not
@@ -110,9 +210,9 @@ export function AskTakeover({
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.isComposing) return;
-      // A focused control already claimed this keystroke (e.g. the composer's
-      // mention/slash popover, which preventDefaults Enter/Escape). Don't also
-      // resolve the ask behind it.
+      // A focused control already claimed this keystroke (e.g. the free-text
+      // box's mention popover, which preventDefaults Enter/Escape to drive
+      // selection). Don't also resolve the ask behind it.
       if (e.defaultPrevented) return;
       // A modal layered ABOVE the card owns the keyboard. Radix dialogs (the
       // ⌘K command palette, etc.) render in a body-level portal and mark the
@@ -133,12 +233,12 @@ export function AskTakeover({
         if (e.target instanceof HTMLElement && e.target.tagName === "BUTTON") return;
         if (!canReply) return;
         e.preventDefault();
-        onReply(buildResolveAnswer(payload, selected, freeText));
+        reply();
       }
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [sending, canReply, onReply, onSkip, payload, selected, freeText]);
+  }, [sending, canReply, onSkip, reply]);
 
   const ftStyle = {
     width: "100%",
@@ -152,6 +252,175 @@ export function AskTakeover({
     resize: "vertical" as const,
     outline: "none",
   };
+
+  // The mirror overlay MUST share the textarea's box metrics so painted chips
+  // stay character-aligned with the (transparent) textarea glyphs.
+  const mirrorStyle = {
+    padding: "var(--sp-2_5) var(--sp-3)",
+    lineHeight: 1.5,
+    fontFamily: "inherit",
+    boxSizing: "border-box" as const,
+  };
+
+  /** The shared free-text answer surface (used as "Other" beside options, or
+   *  as the sole box on a free-text ask): mention autocomplete + highlight +
+   *  image paste, with the text drawn by the mirror overlay. */
+  const renderAnswerInput = (placeholder: string, minHeight: number) => (
+    <div style={{ position: "relative" }}>
+      <MentionAutocompletePopover
+        trigger={mention.trigger}
+        results={mention.results}
+        highlightIndex={mention.highlightIndex}
+        anchorRef={taRef}
+        onPick={mention.pick}
+      />
+      <MentionHighlightOverlay
+        value={freeText}
+        participants={mentionParticipants}
+        textareaRef={taRef}
+        chipClassName="mention-text"
+        mirrorStyle={mirrorStyle}
+      />
+      <textarea
+        ref={taRef}
+        value={freeText}
+        onChange={(e) => {
+          setFreeText(e.target.value);
+          setCursor(e.target.selectionStart ?? e.target.value.length);
+        }}
+        onSelect={(e) => setCursor(e.currentTarget.selectionStart ?? freeText.length)}
+        onPaste={(e) => {
+          const files = Array.from(e.clipboardData.files);
+          if (files.length > 0) {
+            e.preventDefault();
+            addImages(files);
+          }
+        }}
+        onKeyDown={(e) => {
+          // Skip while an IME is composing so Enter confirms the candidate.
+          if (e.nativeEvent.isComposing) return;
+          // Mention autocomplete gets first crack: when the caret is inside an
+          // active `@trigger`, Enter/Tab/Arrows/Escape drive the popover (and
+          // are preventDefaulted, so the window-level Enter→Reply / Esc→Skip
+          // backstop sees `defaultPrevented` and stays out of the way).
+          mention.handleKey(e);
+        }}
+        placeholder={placeholder}
+        style={{
+          ...ftStyle,
+          minHeight,
+          // Text is painted by the mirror overlay behind the textarea; keep
+          // only the caret + selection visible here.
+          color: "transparent",
+          caretColor: "var(--fg)",
+          // Promote above the overlay so the caret isn't hidden by it.
+          position: "relative",
+          zIndex: 1,
+        }}
+      />
+    </div>
+  );
+
+  /** Staged-image thumbnails with a remove affordance — above the input. */
+  const renderImageTray = () =>
+    pendingImages.length > 0 ? (
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginBottom: "var(--sp-2)" }}>
+        {pendingImages.map((img) => (
+          <div
+            key={img.id}
+            style={{
+              position: "relative",
+              flexShrink: 0,
+              borderRadius: 4,
+              border: "var(--hairline) solid var(--border)",
+              overflow: "hidden",
+            }}
+          >
+            <img
+              src={img.previewUrl}
+              alt={img.file.name}
+              style={{ height: 44, width: "auto", display: "block", objectFit: "cover" }}
+            />
+            <button
+              type="button"
+              onClick={() => removeImage(img.id)}
+              aria-label="Remove image"
+              style={{
+                position: "absolute",
+                top: 2,
+                right: 2,
+                width: 16,
+                height: 16,
+                borderRadius: "50%",
+                background: "var(--color-overlay-scrim)",
+                border: "none",
+                color: "var(--bg-raised)",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                cursor: "pointer",
+                padding: 0,
+              }}
+            >
+              <X className="h-2.5 w-2.5" />
+            </button>
+          </div>
+        ))}
+      </div>
+    ) : null;
+
+  /** The @ / attach icon row + hidden file input — below the input. */
+  const renderInputToolbar = () => (
+    <div style={{ display: "flex", alignItems: "center", gap: "var(--sp-3)", marginTop: "var(--sp-2)" }}>
+      <button
+        type="button"
+        onClick={insertMentionTrigger}
+        title="Mention an agent (or type @)"
+        aria-label="Mention an agent"
+        style={{
+          background: "none",
+          border: "none",
+          cursor: "pointer",
+          color: "var(--fg-3)",
+          padding: 0,
+          display: "inline-flex",
+          alignItems: "center",
+        }}
+      >
+        <AtSign className="h-3.5 w-3.5" />
+      </button>
+      <button
+        type="button"
+        onClick={() => fileInputRef.current?.click()}
+        title="Attach image"
+        aria-label="Attach image"
+        style={{
+          background: "none",
+          border: "none",
+          cursor: "pointer",
+          color: "var(--fg-3)",
+          padding: 0,
+          display: "inline-flex",
+          alignItems: "center",
+        }}
+      >
+        <Paperclip className="h-3.5 w-3.5" />
+      </button>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        multiple
+        style={{ display: "none" }}
+        onChange={(e) => {
+          if (e.target.files) {
+            addImages(Array.from(e.target.files));
+            e.target.value = "";
+          }
+        }}
+      />
+    </div>
+  );
 
   return (
     <div
@@ -215,11 +484,19 @@ export function AskTakeover({
             <Markdown>{body}</Markdown>
           </div>
 
-          {/* Answer surface — options + Other (or a single free-text box). */}
+          {/* Answer surface — options + Other (or a single free-text box),
+              both with `@mention` + image attachments. Drop anywhere here to
+              stage images, matching the composer. */}
+          {/* biome-ignore lint/a11y/noStaticElementInteractions: drop target for image upload (keyboard users use the attach button) */}
           <div
             style={{
               padding: `var(--sp-4) ${padX} var(--sp-5)`,
               borderTop: "var(--hairline) solid var(--border-faint)",
+            }}
+            onDragOver={(e) => e.preventDefault()}
+            onDrop={(e) => {
+              e.preventDefault();
+              addImages(Array.from(e.dataTransfer.files));
             }}
           >
             {options ? (
@@ -235,20 +512,27 @@ export function AskTakeover({
                     />
                   ))}
                 </div>
-                <textarea
-                  value={freeText}
-                  onChange={(e) => setFreeText(e.target.value)}
-                  placeholder="Other (type your own)…"
-                  style={{ ...ftStyle, marginTop: "var(--sp-2)", minHeight: 42 }}
-                />
+                <div style={{ marginTop: "var(--sp-2)" }}>
+                  {renderImageTray()}
+                  {renderAnswerInput("Other (type your own)…", 42)}
+                  {renderInputToolbar()}
+                </div>
               </>
             ) : (
-              <textarea
-                value={freeText}
-                onChange={(e) => setFreeText(e.target.value)}
-                placeholder="Type your answer…"
-                style={{ ...ftStyle, minHeight: 110 }}
-              />
+              <>
+                {renderImageTray()}
+                {renderAnswerInput("Type your answer…", 110)}
+                {renderInputToolbar()}
+              </>
+            )}
+
+            {(imageError || error) && (
+              <p
+                className="mono text-label"
+                style={{ color: "var(--state-error)", padding: "var(--sp-2) var(--sp-0_5) 0" }}
+              >
+                {imageError ?? error}
+              </p>
             )}
           </div>
         </div>

--- a/packages/web/src/pages/request-dock-preview.tsx
+++ b/packages/web/src/pages/request-dock-preview.tsx
@@ -73,7 +73,13 @@ function ModeBlock({ label, payload, height = 560 }: { label: string; payload: A
           body={BODY}
           payload={payload}
           askerName="deploy-agent"
-          onReply={(content) => setStatus(`Reply → ${content.replace(/\n/g, " · ")}`)}
+          onReply={(answer) =>
+            setStatus(
+              `Reply → ${answer.content.replace(/\n/g, " · ")}` +
+                (answer.mentions.length > 0 ? ` · @${answer.mentions.length}` : "") +
+                (answer.images.length > 0 ? ` · ${answer.images.length}🖼` : ""),
+            )
+          }
           onSkip={() => setStatus("Skipped → resolves the request with a skipped answer")}
         />
       </div>

--- a/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
@@ -1278,9 +1278,10 @@ describe("ChatView", () => {
     await act(async () => root.unmount());
   });
 
-  it("resolves a blocking free-text question via a text reply; an attached image is not sent while blocked", async () => {
-    const { ChatView } = await import("../chat-view.js");
-    const dockMessages = messages([
+  // Shared free-text (legacy-shape → free-text fallback) blocking ask used by the
+  // text-resolve and image-resolve cases below.
+  const freeTextDockMessages = () =>
+    messages([
       message({
         id: "req-file",
         senderId: "agent-1",
@@ -1296,9 +1297,12 @@ describe("ChatView", () => {
         createdAt: "2026-05-28T12:00:00.000Z",
       }),
     ]);
+
+  it("resolves a blocking free-text question via a typed text answer", async () => {
+    const { ChatView } = await import("../chat-view.js");
     const { container, root } = await renderDom(
       <ChatView agentId="agent-1" chatId="chat-1" />,
-      (client) => seedChat(client, chatDetail(), dockMessages),
+      (client) => seedChat(client, chatDetail(), freeTextDockMessages()),
       "/",
     );
 
@@ -1306,12 +1310,6 @@ describe("ChatView", () => {
     const answerBox = askTextarea(container);
     if (!answerBox) throw new Error("Overlay free-text input missing");
     await setValue(answerBox, "Screenshot evidence attached");
-    // The (covered) composer's image attachment is NOT part of the answer — the
-    // overlay Reply sends a text resolve only.
-    const file = new File(["abc"], "evidence.png", { type: "image/png" });
-    const fileInput = container.querySelector<HTMLInputElement>('input[type="file"]');
-    if (!fileInput) throw new Error("File input missing");
-    await changeFiles(fileInput, [file]);
     await click(buttonByText(container, "Reply"));
     await waitForCondition(() => chatMocks.sendChatMessage.mock.calls.length > 0, "Expected text resolve send");
     expect(chatMocks.sendChatMessage).toHaveBeenCalledWith("chat-1", "Screenshot evidence attached", ["agent-1"], {
@@ -1319,6 +1317,46 @@ describe("ChatView", () => {
       resolves: { request: "req-file", kind: "answered" },
     });
     expect(chatMocks.sendFileMessageBatch).not.toHaveBeenCalled();
+
+    await act(async () => root.unmount());
+  });
+
+  it("resolves a blocking free-text question with an attached image via a file-batch resolve", async () => {
+    const { ChatView } = await import("../chat-view.js");
+    const { container, root } = await renderDom(
+      <ChatView agentId="agent-1" chatId="chat-1" />,
+      (client) => seedChat(client, chatDetail(), freeTextDockMessages()),
+      "/",
+    );
+
+    await waitForText(container, "Reply");
+    const answerBox = askTextarea(container);
+    if (!answerBox) throw new Error("Overlay free-text input missing");
+    await setValue(answerBox, "Screenshot evidence attached");
+    // The ask card now owns image attachments — its file input is the first one
+    // in the DOM (the overlay renders above the covered composer). Attaching an
+    // image makes the resolving reply a `format="file"` batch that STILL carries
+    // `metadata.resolves`, so the question resolves exactly like a text answer.
+    const file = new File(["abc"], "evidence.png", { type: "image/png" });
+    const fileInput = container.querySelector<HTMLInputElement>('input[type="file"]');
+    if (!fileInput) throw new Error("File input missing");
+    await changeFiles(fileInput, [file]);
+    await click(buttonByText(container, "Reply"));
+    await waitForCondition(
+      () => chatMocks.sendFileMessageBatch.mock.calls.length > 0,
+      "Expected image file-batch resolve",
+    );
+    expect(attachmentMocks.uploadImageAttachment).toHaveBeenCalledWith(file);
+    expect(chatMocks.sendFileMessageBatch).toHaveBeenCalledWith(
+      "chat-1",
+      {
+        caption: "Screenshot evidence attached",
+        attachments: [{ imageId: "uploaded-image", mimeType: "image/png", filename: "evidence.png", size: 3 }],
+      },
+      { mentions: ["agent-1"] },
+      { inReplyTo: "req-file", resolves: { request: "req-file", kind: "answered" } },
+    );
+    expect(chatMocks.sendChatMessage).not.toHaveBeenCalled();
 
     await act(async () => root.unmount());
   });

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -74,7 +74,7 @@ import { useAuth } from "../../../auth/auth-context.js";
 import { AddParticipantDropdown } from "../../../components/add-participant-dropdown.js";
 import { Avatar as RealAvatar } from "../../../components/avatar.js";
 import { AgentHovercard } from "../../../components/chat/agent-hovercard.js";
-import { AskTakeover } from "../../../components/chat/ask-takeover.js";
+import { type AskAnswer, AskTakeover } from "../../../components/chat/ask-takeover.js";
 import { awaitedAgentsFromMessage, ChatOfflineNotice } from "../../../components/chat/chat-offline-notice.js";
 import { ComposeStatusBar } from "../../../components/chat/compose-status-bar.js";
 import {
@@ -1160,6 +1160,13 @@ export function ChatView({
   const [cursor, setCursor] = useState(0);
   const [uploading, setUploading] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);
+  // Answering a blocking ask is owned by the AskTakeover overlay, which composes
+  // its own text + @mentions + image attachments. `askBusy` disables the card
+  // while its resolving reply is in flight (kept true through success so the
+  // card stays inert until the resolved request unmounts it — no double-submit);
+  // `askError` surfaces a send failure IN the card (the composer is covered).
+  const [askBusy, setAskBusy] = useState(false);
+  const [askError, setAskError] = useState<string | null>(null);
   const { pendingImages, addImages, removeImage, clearImages } = usePendingImages({
     onError: setUploadError,
     // Dismiss a stale upload error (e.g. "image too large") the moment the
@@ -1831,6 +1838,59 @@ export function ChatView({
     });
   };
 
+  // Resolve the blocking ask with the answer composed in the AskTakeover card.
+  // Routed here (not through the composer's `sendMut`) because the card owns its
+  // own text + @mentions + staged images, and an image answer must go out as a
+  // `format="file"` message carrying `metadata.resolves` (the server's resolve
+  // gate is format-agnostic — it authorizes off sender == target).
+  //
+  // Deliberately NON-optimistic: the card stays mounted until the server's
+  // resolving reply lands (via the messages invalidate -> refetch -> request
+  // reads as resolved -> overlay unmounts). So a send failure neither unmounts
+  // the card nor drops the typed answer / staged images — the user just sees
+  // the error and retries. On success `askBusy` stays true so the card is inert
+  // during the refetch window (no double-submit) and clears when it unmounts.
+  const submitAskAnswer = async (request: { id: string; senderId: string }, answer: AskAnswer) => {
+    if (askBusy) return;
+    setAskError(null);
+    setAskBusy(true);
+    // Route to the asker PLUS anyone the free text @mentioned (deduped).
+    const routedMentions = [...new Set([request.senderId, ...answer.mentions])];
+    const resolves: RequestResolution = { request: request.id, kind: "answered" };
+    try {
+      if (answer.images.length > 0) {
+        const refs: ImageRefContent[] = [];
+        for (const file of answer.images) {
+          const uploaded = await uploadImageAttachment(file);
+          // Warm the per-browser cache so the sender renders its own image
+          // instantly. Best-effort — the render path re-fetches on a miss.
+          try {
+            await putImage({ imageId: uploaded.id, base64: await readFileAsBase64(file), mimeType: file.type });
+          } catch {
+            // IndexedDB quota / availability — ignore, fall back to server fetch.
+          }
+          refs.push({ imageId: uploaded.id, mimeType: file.type, filename: file.name, size: file.size });
+        }
+        await sendFileMessageBatch(
+          chatId,
+          { ...(answer.content ? { caption: answer.content } : {}), attachments: refs },
+          { mentions: routedMentions },
+          { inReplyTo: request.id, resolves },
+        );
+      } else {
+        await sendChatMessage(chatId, answer.content, routedMentions, { inReplyTo: request.id, resolves });
+      }
+      queryClient.invalidateQueries({ queryKey: messagesQueryKey });
+      queryClient.invalidateQueries({ queryKey: agentSessionsQueryKey(agentId) });
+      scrollToBottom("smooth");
+      // Leave `askBusy` true: the overlay disables itself until the resolved
+      // request unmounts it, so a slow refetch can't invite a second submit.
+    } catch (err) {
+      setAskError(err instanceof Error ? err.message : "Failed to send your answer");
+      setAskBusy(false);
+    }
+  };
+
   const [renaming, setRenaming] = useState(false);
   const [renameDraft, setRenameDraft] = useState("");
   const renameInputRef = useRef<HTMLInputElement>(null);
@@ -1945,6 +2005,15 @@ export function ChatView({
   // resolving reply lands; there is no "dismiss but keep it open" path.
   const askOverlayActive = dockRequest != null && dockPayload != null;
   const dockRequestId = askOverlayActive ? dockRequest.id : undefined;
+  // Reset the ask card's send state whenever the blocking question changes (a
+  // resolved one unmounts the card; a different FIFO ask takes over): a stale
+  // error or a stuck "Replying…" from the previous question must not bleed into
+  // the next card.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: keyed intentionally on the request id — the reset fires when the blocking ask changes, not on every render.
+  useEffect(() => {
+    setAskError(null);
+    setAskBusy(false);
+  }, [dockRequestId]);
   useEffect(() => {
     if (!dockRequestId || draft !== "@" || !autoPrimedDraftRef.current) return;
     // Real message data can arrive after an empty group composer already
@@ -2958,27 +3027,23 @@ export function ChatView({
                 body={typeof dockRequest.content === "string" ? dockRequest.content : ""}
                 payload={dockPayload}
                 askerName={chatScopedAgentName(dockRequest.senderId)}
-                sending={sendMut.isPending}
-                onReply={(content) =>
-                  sendMut.mutate({
-                    content,
-                    mentions: [dockRequest.senderId],
-                    inReplyTo: dockRequest.id,
-                    resolves: { request: dockRequest.id, kind: "answered" },
-                  })
-                }
-                onSkip={() =>
+                sending={askBusy}
+                error={askError ?? undefined}
+                mentionCandidates={mentionCandidates}
+                onReply={(answer) => {
+                  void submitAskAnswer(dockRequest, answer);
+                }}
+                onSkip={() => {
                   // Skip is an answer, not a dismiss: send a resolving reply
                   // (kind="answered") carrying a "skipped" body so the open
                   // request resolves, the red dot clears, and the asking agent
                   // unblocks and proceeds with its own judgment.
-                  sendMut.mutate({
+                  void submitAskAnswer(dockRequest, {
                     content: "(Skipped — no answer provided.)",
-                    mentions: [dockRequest.senderId],
-                    inReplyTo: dockRequest.id,
-                    resolves: { request: dockRequest.id, kind: "answered" },
-                  })
-                }
+                    mentions: [],
+                    images: [],
+                  });
+                }}
               />
             </div>
           ) : null}


### PR DESCRIPTION
## What & why

The **AskTakeover** card (the pop-up answer surface for a blocking `chat ask`) used a bare `<textarea>`, so answering a question could **neither @mention a member nor attach an image** — unlike the chat composer at the bottom of every chat. This unifies the two: the free-text answer surface now mirrors the composer with `@mention` autocomplete + inline highlight and image attachments (paste / drag-drop / file-picker), on **both** the options "Other" box and the pure free-text box.

## Key finding: server needs no change

An ask answer must carry `metadata.resolves` to clear the blocking question. The server's resolve gate authorizes purely off `senderId === target` (`services/message.ts`) and `metadata.resolves` is a **format-agnostic** field — so an image answer can go out as a `format="file"` batch that *still resolves* the question, exactly like a text answer. The only client-side gap was `sendFileMessageBatch` not threading `resolves`; that's the one API tweak.

## Changes (all `packages/web`)

- **`api/chats.ts`** — `sendFileMessageBatch` opts now carry `resolves` (mirrors `sendChatMessage`).
- **`components/chat/ask-takeover.tsx`** — `onReply` contract changes from `(content: string)` to `({ content, mentions, images })`; new `mentionCandidates` + `error` props; the free-text surface gets mention overlay/popover + a staged-image thumbnail tray + an `@`/attach toolbar; an attached image alone can resolve.
- **`pages/workspace/center/chat-view.tsx`** — new `submitAskAnswer` owns upload + send + resolve. **Non-optimistic by design**: the card stays mounted until the server's resolving reply lands, so a failed send never unmounts the card or drops the typed answer / staged images. Routes the resolving reply to the asker **plus** anyone the free text @mentioned.
- **`pages/request-dock-preview.tsx`** — dev preview updated to the new contract.

## Tests

- `ask-takeover-dom`: answer-contract (object form), `@<name>` → agentId resolution, popover render, image staging + image-only resolve, oversized-image rejection, host-error surfacing.
- `chat-view-dom`: free-text question resolved via text (`sendChatMessage`) and via an attached image (`sendFileMessageBatch` with `resolves`).

`pnpm --filter @first-tree/web typecheck` ✓ · `biome check` ✓ · web suite **1002 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)