### PR TITLE
fix(server): reject empty / placeholder message bodies at the write boundary

### DIFF
--- a/packages/server/src/__tests__/agent-send-mention-injection.test.ts
+++ b/packages/server/src/__tests__/agent-send-mention-injection.test.ts
@@ -2,6 +2,7 @@ import { eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 import { agents } from "../db/schema/agents.js";
 import { messages } from "../db/schema/messages.js";
+import { BadRequestError } from "../errors.js";
 import { createChat } from "../services/chat.js";
 import { sendMessage } from "../services/message.js";
 import { createTestAgent, useTestApp } from "./helpers.js";
@@ -373,18 +374,25 @@ describe("mention enforcement + content normalisation", () => {
       expect(result.message.content).toBe(`@${peerA.name} report`);
     });
 
-    it("emits just the prefix when content is the empty string", async () => {
+    it("rejects an empty-string body before mention normalization (fail-closed)", async () => {
+      // An empty body is rejected at the write boundary, so it never reaches
+      // mention normalization to be salvaged into a bare "@name". This is the
+      // degenerate-send class behind the PLACEHOLDER incident: `chat ask`/`send`
+      // always carry a target mention, so an empty `$(cat missing-file)` body
+      // would otherwise fan out a content-less "@name" card. See
+      // message-empty-body-validation.test.ts.
       const app = getApp();
       const uid = crypto.randomUUID().slice(0, 6);
       const { sender, peerA, chat } = await setupGroup(uid);
-      const result = await sendMessage(
-        app.db,
-        chat.id,
-        sender.agent.uuid,
-        { source: "api", format: "text", content: "", metadata: { mentions: [peerA.uuid] } },
-        { normalizeMentionsInContent: true },
-      );
-      expect(result.message.content).toBe(`@${peerA.name}`);
+      await expect(
+        sendMessage(
+          app.db,
+          chat.id,
+          sender.agent.uuid,
+          { source: "api", format: "text", content: "", metadata: { mentions: [peerA.uuid] } },
+          { normalizeMentionsInContent: true },
+        ),
+      ).rejects.toThrow(BadRequestError);
     });
 
     it("leaves non-string content untouched (cards, files, structured payloads)", async () => {

--- a/packages/server/src/__tests__/message-empty-body-validation.test.ts
+++ b/packages/server/src/__tests__/message-empty-body-validation.test.ts
@@ -2,7 +2,7 @@ import type { SendMessage } from "@first-tree/shared";
 import { describe, expect, it } from "vitest";
 import type { Database } from "../db/connection.js";
 import { BadRequestError } from "../errors.js";
-import { sendMessage } from "../services/message.js";
+import { preflightMessageSendIntent, type SendIntentParticipant, sendMessage } from "../services/message.js";
 
 // `validateMessageContent` fires at the very top of `sendMessage`, before the
 // transaction opens, so a doomed write never reaches the DB. The empty stub is
@@ -58,5 +58,50 @@ describe("sendMessage — empty / placeholder body is rejected fail-closed", () 
     await expect(
       sendMessage(stubDb, "chat-1", "sender-1", message("text", "Replace the PLACEHOLDER token in config.")),
     ).rejects.not.toThrow(BadRequestError);
+  });
+});
+
+// R4: an agent can double-encode its content (`JSON.stringify(body)`); the
+// server unwraps it AFTER the raw-content guard, so the empty / placeholder
+// body is only visible post-unwrap. `preflightMessageSendIntent` must re-check
+// the unwrapped `effectiveContent` before mention normalization / persistence.
+const AGENT_SENDER: SendIntentParticipant = {
+  agentId: "s1",
+  name: "asst",
+  displayName: "Asst",
+  status: "active",
+  type: "agent",
+};
+const HUMAN_TARGET: SendIntentParticipant = {
+  agentId: "p1",
+  name: "peer",
+  displayName: "Peer",
+  status: "active",
+  type: "human",
+};
+
+function preflightAgentBody(format: SendMessage["format"], content: unknown) {
+  return preflightMessageSendIntent({
+    chatId: "c1",
+    senderId: "s1",
+    senderType: "agent",
+    data: { source: "api", format, content, metadata: { mentions: ["p1"] } },
+    participants: [AGENT_SENDER, HUMAN_TARGET],
+  });
+}
+
+describe("preflightMessageSendIntent — double-encoded body re-validated after unwrap (R4)", () => {
+  it("rejects a JSON-encoded whitespace body that passes the raw guard", () => {
+    // Raw content is the 6-char literal `"\n\n"` (non-empty, so the raw guard
+    // lets it by); it unwraps to two newlines, which must then be rejected.
+    expect(() => preflightAgentBody("text", JSON.stringify("\n\n"))).toThrow(BadRequestError);
+  });
+
+  it("rejects a JSON-encoded placeholder ask body that passes the raw guard", () => {
+    expect(() => preflightAgentBody("request", JSON.stringify("TODO\n"))).toThrow(BadRequestError);
+  });
+
+  it("does NOT reject a JSON-encoded real body", () => {
+    expect(() => preflightAgentBody("text", JSON.stringify("Here is the real plan.\n"))).not.toThrow(BadRequestError);
   });
 });

--- a/packages/server/src/__tests__/message-empty-body-validation.test.ts
+++ b/packages/server/src/__tests__/message-empty-body-validation.test.ts
@@ -1,0 +1,62 @@
+import type { SendMessage } from "@first-tree/shared";
+import { describe, expect, it } from "vitest";
+import type { Database } from "../db/connection.js";
+import { BadRequestError } from "../errors.js";
+import { sendMessage } from "../services/message.js";
+
+// `validateMessageContent` fires at the very top of `sendMessage`, before the
+// transaction opens, so a doomed write never reaches the DB. The empty stub is
+// enough — any property access would throw and surface as a test failure rather
+// than a silent pass. Mirrors message-file-content-validation.test.ts.
+const stubDb = {} as unknown as Database;
+
+function message(format: SendMessage["format"], content: unknown): SendMessage {
+  return { format, content, source: "web" } as SendMessage;
+}
+
+describe("sendMessage — empty / placeholder body is rejected fail-closed", () => {
+  it("rejects an empty string body", async () => {
+    await expect(sendMessage(stubDb, "chat-1", "sender-1", message("text", ""))).rejects.toThrow(BadRequestError);
+  });
+
+  it("rejects a whitespace-only body", async () => {
+    await expect(sendMessage(stubDb, "chat-1", "sender-1", message("text", "   "))).rejects.toThrow(BadRequestError);
+  });
+
+  it("rejects a newline-only body", async () => {
+    await expect(sendMessage(stubDb, "chat-1", "sender-1", message("markdown", "\n\n\t"))).rejects.toThrow(
+      BadRequestError,
+    );
+  });
+
+  it("rejects a body that is just a placeholder sentinel (the PLACEHOLDER incident)", async () => {
+    await expect(sendMessage(stubDb, "chat-1", "sender-1", message("text", "PLACEHOLDER"))).rejects.toThrow(
+      BadRequestError,
+    );
+  });
+
+  it("rejects a placeholder sentinel case-insensitively, with surrounding whitespace", async () => {
+    await expect(sendMessage(stubDb, "chat-1", "sender-1", message("text", "  placeholder \n"))).rejects.toThrow(
+      BadRequestError,
+    );
+  });
+
+  it("rejects an empty ask ('request') body — the body IS the question", async () => {
+    await expect(sendMessage(stubDb, "chat-1", "sender-1", message("request", "   "))).rejects.toThrow(BadRequestError);
+  });
+
+  it("rejects a placeholder ask ('request') body", async () => {
+    await expect(sendMessage(stubDb, "chat-1", "sender-1", message("request", "TODO"))).rejects.toThrow(
+      BadRequestError,
+    );
+  });
+
+  it("does NOT reject a body that merely contains the word placeholder", async () => {
+    // A real body that mentions the sentinel must pass the content guard (it
+    // then proceeds past validation and fails on the stub DB, which is NOT a
+    // BadRequestError — so the content guard let it through).
+    await expect(
+      sendMessage(stubDb, "chat-1", "sender-1", message("text", "Replace the PLACEHOLDER token in config.")),
+    ).rejects.not.toThrow(BadRequestError);
+  });
+});

--- a/packages/server/src/__tests__/open-question.test.ts
+++ b/packages/server/src/__tests__/open-question.test.ts
@@ -2,6 +2,7 @@ import { and, eq, sql } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 import { chatUserState } from "../db/schema/chat-user-state.js";
 import { messages } from "../db/schema/messages.js";
+import { BadRequestError } from "../errors.js";
 import { createAgent } from "../services/agent.js";
 import { createChat } from "../services/chat.js";
 import { listMeChats } from "../services/me-chat.js";
@@ -762,6 +763,29 @@ describe("open-question (format=request) + open_request_count", () => {
     // A content-only edit of the request is still allowed.
     const edited = await editMessage(app.db, chat.id, question.id, asker.agent.uuid, { content: "ratio (clarified)?" });
     expect(edited.format).toBe("request");
+  });
+
+  it("editMessage rejects turning a live message into an empty / placeholder body (R5)", async () => {
+    // The format of an open `request` is frozen, but its body can still be
+    // edited — an edit must not be able to replace a live ask with an empty /
+    // whitespace / placeholder blocking card after creation.
+    const app = getApp();
+    const uid = crypto.randomUUID().slice(0, 6);
+    const { asker, human, chat } = await setup(app, uid);
+
+    const { message: question } = await sendMessage(app.db, chat.id, asker.agent.uuid, {
+      source: "api",
+      format: "request",
+      content: "ratio?",
+      metadata: { mentions: [human.uuid], request: { question: "5% or 20%?" } },
+    });
+
+    await expect(editMessage(app.db, chat.id, question.id, asker.agent.uuid, { content: "   " })).rejects.toThrow(
+      BadRequestError,
+    );
+    await expect(
+      editMessage(app.db, chat.id, question.id, asker.agent.uuid, { content: "PLACEHOLDER" }),
+    ).rejects.toThrow(BadRequestError);
   });
 });
 

--- a/packages/server/src/services/message.ts
+++ b/packages/server/src/services/message.ts
@@ -69,9 +69,51 @@ function validateFileContent(content: unknown): void {
   );
 }
 
+/**
+ * Placeholder sentinels that are never a legitimate whole message body. They
+ * are the residue of a half-built send — e.g. `chat send "$(cat plan.md
+ * 2>/dev/null || echo PLACEHOLDER)"` run before `plan.md` was written, which
+ * fires a real, irreversible message (and for `request`, a blocking human ask)
+ * carrying only the scaffold token. Matched case-insensitively against the
+ * ENTIRE trimmed body, so a message that merely mentions the word is untouched.
+ */
+const PLACEHOLDER_BODY_SENTINELS = new Set(["placeholder", "todo", "fixme", "tbd", "xxx"]);
+
+/**
+ * Guard a string message body before it is persisted and fanned out. A text
+ * body (text / markdown / request — the human-readable formats carry their
+ * content as a string) must be real content: not empty, not whitespace-only,
+ * and not a lone placeholder sentinel. This fails closed at the write boundary
+ * so a half-built send (an empty command substitution, a `|| echo PLACEHOLDER`
+ * fallback) surfaces as an error the caller must fix instead of a meaningless
+ * message — for a `request`, a blocking ask card the target human must skip.
+ */
+function validateTextBody(content: string, isRequest: boolean): void {
+  const trimmed = content.trim();
+  if (trimmed.length === 0) {
+    throw new BadRequestError(
+      isRequest
+        ? "An ask ('request') needs a non-empty body — the question/background IS the message content."
+        : "Message content cannot be empty or whitespace-only.",
+    );
+  }
+  if (PLACEHOLDER_BODY_SENTINELS.has(trimmed.toLowerCase())) {
+    throw new BadRequestError(
+      `Message content is just a placeholder ("${trimmed}") — this is almost always a half-built send ` +
+        "(e.g. a file read that ran before the file was written). Compose the real body, then send.",
+    );
+  }
+}
+
 function validateMessageContent(data: SendMessage): void {
   if (data.format === "file") {
     validateFileContent(data.content);
+    return;
+  }
+  // Non-string content (card / reference object shapes) is out of scope here;
+  // only string-bearing bodies are guarded against empty / placeholder sends.
+  if (typeof data.content === "string") {
+    validateTextBody(data.content, data.format === "request");
   }
 }
 

--- a/packages/server/src/services/message.ts
+++ b/packages/server/src/services/message.ts
@@ -105,7 +105,10 @@ function validateTextBody(content: string, isRequest: boolean): void {
   }
 }
 
-function validateMessageContent(data: SendMessage): void {
+// Structural param (not `SendMessage`) so the edit path can reuse it against
+// the effective post-edit `{ format, content }`, where `format` is a plain
+// string off the stored row.
+function validateMessageContent(data: { format: string; content: unknown }): void {
   if (data.format === "file") {
     validateFileContent(data.content);
     return;
@@ -247,6 +250,16 @@ export function preflightMessageSendIntent(input: {
       );
       effectiveContent = unwrapped;
     }
+  }
+
+  // Re-validate the UNWRAPPED body. `validateMessageContent(data)` above checked
+  // the raw `data.content`, but for a non-human sender a double-encoded string
+  // (e.g. `JSON.stringify("TODO\n")`) only reveals its empty / whitespace /
+  // placeholder body after `maybeUnwrapDoubleEncoded`. `effectiveContent` is
+  // what gets normalized and persisted, so guard it here too — before mention
+  // normalization can salvage an empty body into a bare "@name".
+  if (typeof effectiveContent === "string") {
+    validateTextBody(effectiveContent, data.format === "request");
   }
 
   const incomingMeta = stripUntrustedMetadataKeys((data.metadata ?? {}) as Record<string, unknown>, options);
@@ -840,7 +853,14 @@ export async function editMessage(
 
   const setClause: Record<string, unknown> = {};
   if (data.format !== undefined) setClause.format = data.format;
-  if (data.content !== undefined) setClause.content = data.content;
+  if (data.content !== undefined) {
+    // An edit can replace the body of any message — including an already-open
+    // `format=request` ask whose format is frozen above. Reuse the send-path
+    // guard against the effective post-edit `{ format, content }` so an edit
+    // can't turn a live message into an empty / placeholder blocking card.
+    validateMessageContent({ format: data.format ?? msg.format, content: data.content });
+    setClause.content = data.content;
+  }
 
   // Track edit in metadata
   const meta = (msg.metadata ?? {}) as Record<string, unknown>;


### PR DESCRIPTION
## 背景

排查一次线上事故:一张 `@l42y PLACEHOLDER` 的 ask 卡片弹给人类,skip 之后紧接着才弹出真正有内容的那张。根因是 agent 把一条 `chat ask` 当成了「可空跑、内容随后补」的普通 shell 命令并提前执行:

```
first-tree chat ask l42y "$(cat /tmp/internal-build-plan.md 2>/dev/null || echo PLACEHOLDER)"
```

文件还没写,`cat` 失败被 `2>/dev/null` 吞掉,兜底 `|| echo PLACEHOLDER` 生效,于是字面量 `PLACEHOLDER` 成了一张**真实、不可撤销、且会阻塞目标人类**的 ask 卡片正文。

服务端 `sendMessageSchema.content` 是 `z.unknown()`,对正文**零校验**,任何半成品/空正文都会落库并 fan-out。

## 改动

在服务端唯一的内容校验 choke point `validateMessageContent`(同时被 `sendMessage` 与 `preflightMessageSendIntent` 调用)加守卫:当 `content` 是字符串且为

- 空 / 纯空白,或
- 仅由占位符 sentinel 构成(`PLACEHOLDER` / `TODO` / `FIXME` / `TBD` / `XXX`,trim 后整体匹配、大小写不敏感)

时,在事务开启前抛 `BadRequestError`,永不落库、永不 fan-out。

设计取舍:
- **放服务层而非 schema**——沿用既有架构,`content: z.unknown()` 故意保持 format-agnostic,format 相关校验归服务层(对标 `validateFileContent`)。所有客户端(CLI / web / SDK)统一受约束。
- **校验原始正文(mention 注入前)**——事故里发出的原始 content 是 `PLACEHOLDER`,经 mention 注入才成 `@l42y PLACEHOLDER`;只有在注入前校验才能命中 sentinel。
- **占位符按整体匹配**——正文里只是「提到」这些词不受影响(有测试覆盖)。

## 行为变更(需 reviewer 注意)

空正文不再被 mention normalization 救成一句光秃秃的 `@name`,而是 fail-closed 直接拒收。这正是事故那一类:`chat ask`/`send` 总带目标 mention,所以 `$(cat 缺失文件)` 的空 body 原本会 fan-out 一张无正文的 `@name` 卡。更新了唯一一个编码旧宽松行为的 normalization 测试。

## 测试

- 新增 `message-empty-body-validation.test.ts`:覆盖 text / request 两种 format 下的空、纯空白、纯换行、占位符正文;并断言「正文只是提到 PLACEHOLDER」仍放行。
- 全套 server 测试 **1567 passed**;`pnpm typecheck`、`biome check` 均过。

## 关联

源于对该事故的排查(本地 session 事件日志)。这是事故修复方案中的 **B1(服务端拒收空白/占位正文)**。可选后续:CLI `send.ts` 的空检查改为 trim 对齐 `create.ts`;以及为 ask/send 增加 `--dry-run` 预览。

🤖 Generated with [Claude Code](https://claude.com/claude-code)