### PR TITLE
refactor(web): float the expanded chat summary as an overlay

### DIFF
--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -776,6 +776,27 @@
   }
 }
 
+/* Chat summary floating card: drops in from the bar's lower edge. */
+@keyframes chat-summary-card-in {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+.chat-summary-card-in {
+  animation: chat-summary-card-in 170ms ease-out;
+  transform-origin: top;
+}
+@media (prefers-reduced-motion: reduce) {
+  .chat-summary-card-in {
+    animation: none;
+  }
+}
+
 @keyframes context-live-halo-breathe {
   0%,
   100% {

--- a/packages/web/src/pages/chat-summary-preview.tsx
+++ b/packages/web/src/pages/chat-summary-preview.tsx
@@ -58,6 +58,9 @@ function Demo({
 }) {
   // A dummy scroll container — the preview does not exercise sticky-collapse.
   const scrollRef = useRef<HTMLDivElement>(null);
+  // The expanded summary is portaled into this `relative` wrapper and floated
+  // over the message area, mirroring the live layout.
+  const overlayRef = useRef<HTMLDivElement>(null);
   return (
     <div style={PANEL}>
       {/* Faux chat header (white chrome) so the summary's content-canvas tone
@@ -75,13 +78,19 @@ function Demo({
         lastReadAt={lastReadAt}
         freshnessReady
         scrollContainerRef={scrollRef}
+        overlayContainerRef={overlayRef}
       />
-      <div
-        ref={scrollRef}
-        className="text-caption"
-        style={{ padding: "var(--sp-3) var(--sp-6)", color: "var(--fg-4)" }}
-      >
-        (message stream)
+      {/* Faux message stream + the overlay positioning context. Min-height gives
+          the floating card room to render in the gallery (clipped by the panel,
+          as it is by the message area live). */}
+      <div ref={overlayRef} style={{ position: "relative" }}>
+        <div
+          ref={scrollRef}
+          className="text-caption"
+          style={{ padding: "var(--sp-3) var(--sp-6)", color: "var(--fg-4)", minHeight: 280 }}
+        >
+          (message stream)
+        </div>
       </div>
     </div>
   );
@@ -121,8 +130,8 @@ export function ChatSummaryPreviewPage() {
         </h1>
         <p className="text-body" style={{ color: "var(--fg-3)" }}>
           Each demo sits under a faux white header and over the grey content canvas, as it does live. Click to expand /
-          collapse. Read-only: no edit affordance; expanded uses a fixed Summary label above the markdown; the freshness
-          ("9 days ago") lives on the bar in both states.
+          collapse. Read-only: no edit affordance; expanded floats a card over the message area (it never pushes the
+          stream down); the freshness ("9 days ago") lives on the bar in both states.
         </p>
       </div>
 

--- a/packages/web/src/pages/workspace/center/__tests__/chat-summary.test.ts
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-summary.test.ts
@@ -88,7 +88,11 @@ describe("ChatSummary", () => {
 
   type SummaryProps = Parameters<typeof ChatSummary>[0];
 
-  function summaryProps(scrollEl: HTMLDivElement, overrides: Partial<SummaryProps> = {}): SummaryProps {
+  function summaryProps(
+    scrollEl: HTMLDivElement,
+    overlayEl: HTMLDivElement,
+    overrides: Partial<SummaryProps> = {},
+  ): SummaryProps {
     return {
       chatId: "chat-1",
       description: "Status: shipping **DescBody** soon.",
@@ -96,6 +100,7 @@ describe("ChatSummary", () => {
       lastReadAt: null,
       freshnessReady: true,
       scrollContainerRef: { current: scrollEl },
+      overlayContainerRef: { current: overlayEl },
       ...overrides,
     };
   }
@@ -103,16 +108,26 @@ describe("ChatSummary", () => {
   async function renderSummary(
     scrollEl: HTMLDivElement,
     overrides: Partial<SummaryProps> = {},
-  ): Promise<{ container: HTMLDivElement; root: Root; rerender: (next: Partial<SummaryProps>) => Promise<void> }> {
+  ): Promise<{
+    container: HTMLDivElement;
+    overlayEl: HTMLDivElement;
+    root: Root;
+    rerender: (next: Partial<SummaryProps>) => Promise<void>;
+  }> {
     const container = document.createElement("div");
+    // The expanded summary is portaled into a SEPARATE "message area" node, as in
+    // the real layout — it is not a child of the bar's own container.
+    const overlayEl = document.createElement("div");
     document.body.appendChild(container);
+    document.body.appendChild(overlayEl);
     const root = createRoot(container);
-    let props = summaryProps(scrollEl, overrides);
+    let props = summaryProps(scrollEl, overlayEl, overrides);
     await act(async () => {
       root.render(createElement(ChatSummary, props));
     });
     return {
       container,
+      overlayEl,
       root,
       rerender: async (next: Partial<SummaryProps>) => {
         props = { ...props, ...next };
@@ -136,7 +151,7 @@ describe("ChatSummary", () => {
   it("auto-expands an unread summary version on entry even when the chat was read recently", async () => {
     localStorage.clear();
     const scrollEl = document.createElement("div");
-    const { container, root } = await renderSummary(scrollEl, {
+    const { container, overlayEl, root } = await renderSummary(scrollEl, {
       descriptionUpdatedAt: unreadVersionAt,
       lastReadAt: readRecentlyAt,
     });
@@ -144,10 +159,12 @@ describe("ChatSummary", () => {
     expect(container.querySelector<HTMLButtonElement>('button[aria-label="Collapse summary"]')?.textContent).toContain(
       "Summary",
     );
-    expect(container.querySelector("strong")?.textContent).toBe("DescBody");
+    // Expanded body is the floating card, portaled into the message-area node.
+    expect(overlayEl.querySelector("strong")?.textContent).toBe("DescBody");
 
     await act(async () => root.unmount());
     container.remove();
+    overlayEl.remove();
   });
 
   it("does not auto-expand the same unread summary version after the user manually collapses it", async () => {
@@ -165,20 +182,22 @@ describe("ChatSummary", () => {
     });
     await act(async () => first.root.unmount());
     first.container.remove();
+    first.overlayEl.remove();
 
     const second = await renderSummary(scrollEl, unreadProps);
     expect(second.container.querySelector<HTMLButtonElement>('button[aria-label="Expand summary"]')).not.toBeNull();
-    expect(second.container.querySelector("strong")).toBeNull();
+    expect(second.overlayEl.querySelector("strong")).toBeNull();
     expect(second.container.textContent).toContain("Updated");
 
     await act(async () => second.root.unmount());
     second.container.remove();
+    second.overlayEl.remove();
   });
 
   it("keeps the current mounted chat collapsed when a newer unread summary version arrives", async () => {
     localStorage.clear();
     const scrollEl = document.createElement("div");
-    const { container, root, rerender } = await renderSummary(scrollEl, {
+    const { container, overlayEl, root, rerender } = await renderSummary(scrollEl, {
       descriptionUpdatedAt: readRecentlyAt,
       lastReadAt: unreadVersionAt,
     });
@@ -190,18 +209,19 @@ describe("ChatSummary", () => {
     });
 
     expect(container.querySelector<HTMLButtonElement>('button[aria-label="Expand summary"]')).not.toBeNull();
-    expect(container.querySelector("strong")).toBeNull();
+    expect(overlayEl.querySelector("strong")).toBeNull();
     expect(container.textContent).toContain("Updated");
 
     await act(async () => root.unmount());
     container.remove();
+    overlayEl.remove();
   });
 
   it("keeps a manual expand open when the stream was already scrolled", async () => {
     localStorage.clear();
     const scrollEl = document.createElement("div");
     scrollEl.scrollTop = 120;
-    const { container, root } = await renderSummary(scrollEl);
+    const { container, overlayEl, root } = await renderSummary(scrollEl);
     const button = container.querySelector<HTMLButtonElement>('button[aria-label="Expand summary"]');
     if (!button) throw new Error("summary button missing");
 
@@ -211,22 +231,23 @@ describe("ChatSummary", () => {
     expect(container.querySelector<HTMLButtonElement>('button[aria-label="Collapse summary"]')?.textContent).toContain(
       "Summary",
     );
-    expect(container.querySelector("strong")?.textContent).toBe("DescBody");
+    expect(overlayEl.querySelector("strong")?.textContent).toBe("DescBody");
 
     await act(async () => {
       scrollEl.dispatchEvent(new Event("scroll"));
     });
-    expect(container.querySelector("strong")?.textContent).toBe("DescBody");
+    expect(overlayEl.querySelector("strong")?.textContent).toBe("DescBody");
 
     await act(async () => root.unmount());
     container.remove();
+    overlayEl.remove();
   });
 
   it("still collapses after a fresh downward scroll from a manual expand point", async () => {
     localStorage.clear();
     const scrollEl = document.createElement("div");
     scrollEl.scrollTop = 120;
-    const { container, root } = await renderSummary(scrollEl);
+    const { container, overlayEl, root } = await renderSummary(scrollEl);
     const button = container.querySelector<HTMLButtonElement>('button[aria-label="Expand summary"]');
     if (!button) throw new Error("summary button missing");
 
@@ -236,50 +257,56 @@ describe("ChatSummary", () => {
     expect(container.querySelector<HTMLButtonElement>('button[aria-label="Collapse summary"]')?.textContent).toContain(
       "Summary",
     );
-    expect(container.querySelector("strong")?.textContent).toBe("DescBody");
+    expect(overlayEl.querySelector("strong")?.textContent).toBe("DescBody");
 
     await act(async () => {
       scrollEl.scrollTop = 170;
       scrollEl.dispatchEvent(new Event("scroll"));
     });
-    expect(container.querySelector("strong")).toBeNull();
+    expect(overlayEl.querySelector("strong")).toBeNull();
     expect(container.querySelector<HTMLButtonElement>('button[aria-label="Expand summary"]')).not.toBeNull();
 
     await act(async () => root.unmount());
     container.remove();
+    overlayEl.remove();
   });
 
   it("does not auto-expand a sticky-collapsed summary when scrolling back to the top", async () => {
     localStorage.clear();
     const scrollEl = document.createElement("div");
-    const { container, root } = await renderSummary(scrollEl, {
+    const { container, overlayEl, root } = await renderSummary(scrollEl, {
       descriptionUpdatedAt: unreadVersionAt,
       lastReadAt: readRecentlyAt,
     });
+    // Auto-expanded on entry (unread): the floating card is up.
     expect(container.querySelector<HTMLButtonElement>('button[aria-label="Collapse summary"]')).not.toBeNull();
+    expect(overlayEl.querySelector("strong")).not.toBeNull();
 
+    // Scroll down → sticky-collapse folds it to the bar.
     await act(async () => {
       scrollEl.scrollTop = 120;
       scrollEl.dispatchEvent(new Event("scroll"));
     });
     expect(container.querySelector<HTMLButtonElement>('button[aria-label="Expand summary"]')).not.toBeNull();
-    expect(container.querySelector("strong")).toBeNull();
+    expect(overlayEl.querySelector("strong")).toBeNull();
 
+    // Scroll back to the top → must NOT re-expand (regression guard for PR 1252).
     await act(async () => {
       scrollEl.scrollTop = 0;
       scrollEl.dispatchEvent(new Event("scroll"));
     });
     expect(container.querySelector<HTMLButtonElement>('button[aria-label="Expand summary"]')).not.toBeNull();
-    expect(container.querySelector("strong")).toBeNull();
+    expect(overlayEl.querySelector("strong")).toBeNull();
 
     await act(async () => root.unmount());
     container.remove();
+    overlayEl.remove();
   });
 
   it("expands on the first click from the sticky-collapsed bar", async () => {
     localStorage.clear();
     const scrollEl = document.createElement("div");
-    const { container, root } = await renderSummary(scrollEl);
+    const { container, overlayEl, root } = await renderSummary(scrollEl);
     const initialButton = container.querySelector<HTMLButtonElement>('button[aria-label="Expand summary"]');
     if (!initialButton) throw new Error("summary button missing");
 
@@ -289,137 +316,93 @@ describe("ChatSummary", () => {
     expect(container.querySelector<HTMLButtonElement>('button[aria-label="Collapse summary"]')?.textContent).toContain(
       "Summary",
     );
-    expect(container.querySelector("strong")?.textContent).toBe("DescBody");
+    expect(overlayEl.querySelector("strong")?.textContent).toBe("DescBody");
 
     await act(async () => {
       scrollEl.scrollTop = 120;
       scrollEl.dispatchEvent(new Event("scroll"));
     });
-    expect(container.querySelector("strong")).toBeNull();
+    expect(overlayEl.querySelector("strong")).toBeNull();
 
     const stickyButton = container.querySelector<HTMLButtonElement>('button[aria-label="Expand summary"]');
     if (!stickyButton) throw new Error("sticky summary button missing");
     await act(async () => {
       stickyButton.click();
     });
-    expect(container.querySelector("strong")?.textContent).toBe("DescBody");
+    expect(overlayEl.querySelector("strong")?.textContent).toBe("DescBody");
 
     await act(async () => root.unmount());
     container.remove();
+    overlayEl.remove();
   });
 
-  it("bridges a wheel gesture over the expanded summary to the message stream", async () => {
+  it("portals the expanded body as a floating card over the message area (no in-flow reflow)", async () => {
     localStorage.clear();
     const scrollEl = document.createElement("div");
-    scrollEl.scrollTop = 0;
-    // Unread version → auto-expanded on entry, so the panel owns the viewport.
-    const { container, root } = await renderSummary(scrollEl, {
+    const { container, overlayEl, root } = await renderSummary(scrollEl, {
       descriptionUpdatedAt: unreadVersionAt,
       lastReadAt: readRecentlyAt,
     });
-    expect(container.querySelector<HTMLButtonElement>('button[aria-label="Collapse summary"]')).not.toBeNull();
-    const panel = container.firstElementChild as HTMLElement | null;
-    if (!panel) throw new Error("summary panel missing");
-
-    // The expanded body cannot absorb the scroll itself (no overflow), so a wheel
-    // over the summary must drive the message stream — without this it scrolls
-    // nothing and the conversation reads as "locked".
-    await act(async () => {
-      panel.dispatchEvent(wheelEvent(120));
-    });
-    expect(scrollEl.scrollTop).toBe(120);
+    // Bar stays in the component's own container; the body is NOT in flow there
+    // (so it never pushes the message stream down).
+    expect(container.querySelector("strong")).toBeNull();
+    // It lives in the message-area node as an absolute, self-scrolling card.
+    const card = overlayEl.querySelector<HTMLElement>('section[aria-label="Chat summary"]');
+    expect(card).not.toBeNull();
+    expect(card?.style.position).toBe("absolute");
+    expect(card?.querySelector("strong")?.textContent).toBe("DescBody");
 
     await act(async () => root.unmount());
     container.remove();
+    overlayEl.remove();
   });
 
-  it("scrolls the summary body itself before driving the stream", async () => {
+  it("forwards a wheel over the bar to the message stream, but leaves horizontal pans alone", async () => {
     localStorage.clear();
     const scrollEl = document.createElement("div");
     scrollEl.scrollTop = 0;
-    const { container, root } = await renderSummary(scrollEl, {
-      descriptionUpdatedAt: unreadVersionAt,
-      lastReadAt: readRecentlyAt,
-    });
-    const panel = container.firstElementChild as HTMLElement | null;
-    if (!panel) throw new Error("summary panel missing");
-    const inner = container.querySelector<HTMLElement>('[style*="46vh"]');
-    if (!inner) throw new Error("summary scroll body missing");
-    // Make the body itself scrollable and parked mid-content (not at top/bottom).
-    Object.defineProperty(inner, "scrollHeight", { value: 1000, configurable: true });
-    Object.defineProperty(inner, "clientHeight", { value: 200, configurable: true });
-    inner.scrollTop = 100;
+    const { container, overlayEl, root } = await renderSummary(scrollEl);
+    const bar = container.firstElementChild as HTMLElement | null;
+    if (!bar) throw new Error("summary bar missing");
 
-    // Wheel up: the body can still scroll up, so the body moves and the stream
-    // stays put.
+    // A vertical wheel over the thin bar (no scrollable ancestor) drives the stream.
     await act(async () => {
-      panel.dispatchEvent(wheelEvent(-40));
+      bar.dispatchEvent(wheelEvent(90));
     });
-    expect(inner.scrollTop).toBe(60);
-    expect(scrollEl.scrollTop).toBe(0);
+    expect(scrollEl.scrollTop).toBe(90);
 
-    await act(async () => root.unmount());
-    container.remove();
-  });
-
-  it("scrolls the body for a wheel over the summary header, not just the body", async () => {
-    localStorage.clear();
-    const scrollEl = document.createElement("div");
-    scrollEl.scrollTop = 0;
-    const { container, root } = await renderSummary(scrollEl, {
-      descriptionUpdatedAt: unreadVersionAt,
-      lastReadAt: readRecentlyAt,
-    });
-    // The header control sits OUTSIDE the markdown body's event path; a wheel
-    // there must still drive the body while it has room (regression: target-
-    // unaware deferral to native scroll left the header strip locked).
-    const header = container.querySelector<HTMLButtonElement>('button[aria-label="Collapse summary"]');
-    if (!header) throw new Error("summary header button missing");
-    const inner = container.querySelector<HTMLElement>('[style*="46vh"]');
-    if (!inner) throw new Error("summary scroll body missing");
-    Object.defineProperty(inner, "scrollHeight", { value: 1000, configurable: true });
-    Object.defineProperty(inner, "clientHeight", { value: 200, configurable: true });
-    inner.scrollTop = 0;
-
+    // A horizontal-dominant gesture is left to the browser: nothing scrolls and
+    // the event is not consumed.
+    const ev = wheelEvent(6, 120);
     await act(async () => {
-      header.dispatchEvent(wheelEvent(120));
+      bar.dispatchEvent(ev);
     });
-    expect(inner.scrollTop).toBe(120);
-    expect(scrollEl.scrollTop).toBe(0);
-
-    await act(async () => root.unmount());
-    container.remove();
-  });
-
-  it("leaves a horizontal-dominant wheel to the browser", async () => {
-    localStorage.clear();
-    const scrollEl = document.createElement("div");
-    scrollEl.scrollTop = 0;
-    const { container, root } = await renderSummary(scrollEl, {
-      descriptionUpdatedAt: unreadVersionAt,
-      lastReadAt: readRecentlyAt,
-    });
-    const panel = container.firstElementChild as HTMLElement | null;
-    if (!panel) throw new Error("summary panel missing");
-    const inner = container.querySelector<HTMLElement>('[style*="46vh"]');
-    if (!inner) throw new Error("summary scroll body missing");
-    // Body is scrollable, so a missing guard would let the small vertical
-    // component move it.
-    Object.defineProperty(inner, "scrollHeight", { value: 1000, configurable: true });
-    Object.defineProperty(inner, "clientHeight", { value: 200, configurable: true });
-    inner.scrollTop = 100;
-
-    // deltaX dominates deltaY (a trackpad horizontal pan): hands off to the
-    // browser — nothing is scrolled and the event is not consumed.
-    const ev = wheelEvent(8, 120);
-    await act(async () => {
-      panel.dispatchEvent(ev);
-    });
-    expect(inner.scrollTop).toBe(100);
-    expect(scrollEl.scrollTop).toBe(0);
+    expect(scrollEl.scrollTop).toBe(90);
     expect(ev.defaultPrevented).toBe(false);
 
     await act(async () => root.unmount());
     container.remove();
+    overlayEl.remove();
+  });
+
+  it("dismisses the floating card on Escape", async () => {
+    localStorage.clear();
+    const scrollEl = document.createElement("div");
+    const { container, overlayEl, root } = await renderSummary(scrollEl, {
+      descriptionUpdatedAt: unreadVersionAt,
+      lastReadAt: readRecentlyAt,
+    });
+    expect(overlayEl.querySelector("strong")).not.toBeNull();
+
+    // Non-modal overlay: Escape collapses it back to the bar (page stays live).
+    await act(async () => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    });
+    expect(overlayEl.querySelector("strong")).toBeNull();
+    expect(container.querySelector<HTMLButtonElement>('button[aria-label="Expand summary"]')).not.toBeNull();
+
+    await act(async () => root.unmount());
+    container.remove();
+    overlayEl.remove();
   });
 });

--- a/packages/web/src/pages/workspace/center/chat-summary.tsx
+++ b/packages/web/src/pages/workspace/center/chat-summary.tsx
@@ -1,6 +1,7 @@
 import { ChevronDown } from "lucide-react";
 import type { RefObject } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { Markdown } from "../../../components/ui/markdown.js";
 import { stripInlineMarkdown } from "../../../lib/strip-inline-markdown.js";
 import { formatRelative } from "../../../lib/utils.js";
@@ -14,28 +15,33 @@ import { formatRelative } from "../../../lib/utils.js";
  * agent in chat). The component renders the description's markdown faithfully —
  * it never invents sections, fields, or a "stage".
  *
- * It belongs to the conversation content, not the header chrome: it shares the
- * message-stream canvas (`--bg`) rather than a fill of its own, is separated
- * from the white header (`--bg-raised`) above by a single hairline + the
- * natural bg step, and lifts on a faint shadow only while the stream scrolls
- * under it.
+ * The persistent form is a one-line bar in flow between header and stream; the
+ * expanded form is a FLOATING CARD portaled over the top of the message area
+ * (`overlayContainerRef`), laid out `absolute; top:0` so it never occupies
+ * stream space. That is the whole reason this isn't a second in-flow scroll
+ * region: a wheel/touch over any visible pixel lands on a real scroll target
+ * (card scrolls the card, messages scroll the messages) — no "looks scrollable
+ * but isn't" dead zone — and opening/closing never reflows the conversation.
  *
  * Two forms:
- *   - Collapsed (default): one line — the description's first meaningful line
- *     (section headings skipped, markdown markers stripped, ellipsis-truncated),
- *     an "Updated" chip when there's an unread change, the freshness
- *     ("9 days ago"), and a quiet chevron. Freshness shows in BOTH states, so an
- *     auto-expanded summary still surfaces when it last changed.
- *   - Expanded: a fixed "Summary" control label plus the description rendered
- *     as markdown — no footer. Read-only is self-evident (no edit affordance
- *     anywhere); the updater name is not shown (single-agent maintenance makes
- *     it noise — the data stays on the chat detail).
+ *   - Collapsed bar (default): one line — the description's first meaningful
+ *     line (section headings skipped, markdown markers stripped,
+ *     ellipsis-truncated), an "Updated" chip when there's an unread change, the
+ *     freshness ("9 days ago"), and a quiet chevron. Freshness shows in BOTH
+ *     states, so an auto-expanded summary still surfaces when it last changed.
+ *   - Expanded card: the bar stays put (label flips to "Summary", chevron up)
+ *     while a non-modal overlay floats below it with the description rendered as
+ *     markdown — own scroll (`overscroll: contain`), `--shadow-md` + border for
+ *     separation, NO scrim (a summary surfacing is awareness, not a modal
+ *     interception). Read-only is self-evident (no edit affordance anywhere).
  *
  * Auto behavior: default collapsed; auto-expand once on entry when the update
  * is unread for this viewer, unless they already manually dismissed this exact
- * summary version; while expanded, scrolling the stream folds it to the bar;
- * expanding again is an explicit toggle. A manual toggle always wins and is
- * remembered per chat. Renders nothing when the chat has no description.
+ * summary version; while expanded, scrolling the stream folds it back to the bar
+ * — re-expanding is then an explicit toggle (scroll never re-opens it), and
+ * Escape / a pointer outside the card also dismiss it; a manual toggle always
+ * wins and is remembered per chat. Renders nothing when the chat has no
+ * description.
  */
 
 // Scroll sticky-collapse threshold (px from the stream top). Moving beyond this
@@ -156,6 +162,7 @@ export function ChatSummary({
   lastReadAt,
   freshnessReady,
   scrollContainerRef,
+  overlayContainerRef,
 }: {
   chatId: string;
   description: string | null;
@@ -166,6 +173,9 @@ export function ChatSummary({
    *  auto-expand decision waits for this so it reads true unread/last-read. */
   freshnessReady: boolean;
   scrollContainerRef: RefObject<HTMLDivElement | null>;
+  /** The message timeline's `relative` wrapper. The expanded summary is
+   *  portaled here and floated `absolute; top:0` over the message area. */
+  overlayContainerRef: RefObject<HTMLDivElement | null>;
 }) {
   const trimmed = description?.trim() ?? "";
   const hasDescription = trimmed.length > 0;
@@ -289,156 +299,191 @@ export function ChatSummary({
     return () => el.removeEventListener("scroll", onScroll);
   }, [hasDescription, scrollContainerRef]);
 
-  // Wheel bridging: the expanded summary is a pinned sibling ABOVE the message
-  // scroll container, and its only ancestor is the `overflow-hidden` center
-  // column — so a wheel gesture over the summary has no scrollable target and
-  // the conversation reads as "locked" (the markdown body only scrolls when its
-  // own content overflows). Bridge it from a single listener on the whole panel:
-  // while the markdown body still has room in the wheel's direction, scroll IT;
-  // otherwise drive the message stream so scrolling stays continuous across the
-  // summary↔stream seam (and scrolling down folds the summary via the existing
-  // sticky-collapse, same as scrolling the stream).
-  //
-  // The body is scrolled EXPLICITLY rather than by deferring to native scroll:
-  // the listener fires for the whole panel (header bar + padding + body), but a
-  // wheel over the header/padding sits OUTSIDE the body's own event path, so
-  // native scrolling there finds no scrollable ancestor and would re-create the
-  // dead zone for that strip. Driving `inner` ourselves makes a wheel anywhere
-  // on the panel scroll the body uniformly.
-  const panelRef = useRef<HTMLDivElement | null>(null);
-  const innerScrollRef = useRef<HTMLDivElement | null>(null);
+  // The bar stays in flow; the expanded body floats as an overlay (see render),
+  // so the only wheel dead zone left is the thin one-line bar itself (shrink-0 inside an
+  // overflow-hidden column, no scrollable ancestor). Forward a wheel over the
+  // bar to the message stream — trivial, no boundary math: the floating card
+  // scrolls itself natively (`overscroll: contain`) and the bar is never a
+  // scroll target. (Replaces the PR 1245 expanded-body wheel bridge, which the
+  // overlay makes unnecessary.)
+  const barRef = useRef<HTMLDivElement | null>(null);
+  const cardRef = useRef<HTMLElement | null>(null);
   useEffect(() => {
     if (!hasDescription) return;
-    const panel = panelRef.current;
-    if (!panel) return;
+    const bar = barRef.current;
+    if (!bar) return;
     const onWheel = (e: WheelEvent) => {
       const stream = scrollContainerRef.current;
       if (!stream) return;
       // Leave horizontal/trackpad-pan gestures to the browser.
       if (Math.abs(e.deltaX) > Math.abs(e.deltaY) || e.deltaY === 0) return;
-      const inner = innerScrollRef.current;
-      if (inner) {
-        const atTop = inner.scrollTop <= 0;
-        const atBottom = inner.scrollTop + inner.clientHeight >= inner.scrollHeight - 1;
-        // The markdown body still has room — scroll it (and suppress native
-        // scroll so a wheel directly over the body isn't applied twice).
-        if ((e.deltaY < 0 && !atTop) || (e.deltaY > 0 && !atBottom)) {
-          inner.scrollTop += e.deltaY;
-          e.preventDefault();
-          return;
-        }
-      }
       stream.scrollTop += e.deltaY;
       e.preventDefault();
     };
     // Native, non-passive so preventDefault works (React routes onWheel through a
     // passive root listener, where preventDefault is a no-op).
-    panel.addEventListener("wheel", onWheel, { passive: false });
-    return () => panel.removeEventListener("wheel", onWheel);
+    bar.addEventListener("wheel", onWheel, { passive: false });
+    return () => bar.removeEventListener("wheel", onWheel);
   }, [hasDescription, scrollContainerRef]);
+
+  const expanded = open && !scrollCollapsed;
+
+  // Dismiss the floating card explicitly on Escape or a pointer outside it. It is
+  // a non-modal overlay (no scrim, no focus trap) so the page stays live; a
+  // dismiss collapses to the bar AND remembers the per-version dismissal so the
+  // same unread summary does not auto-float again on the next entry.
+  const dismiss = useCallback(() => {
+    setOpen(false);
+    if (descriptionUpdatedAt && unread) saveDismissedVersion(chatId, descriptionUpdatedAt);
+    saveManualPref(chatId, false);
+    setHighlighted(false);
+    setUnreadCleared(true);
+    setScrollCollapsed(false);
+  }, [chatId, descriptionUpdatedAt, unread]);
+  useEffect(() => {
+    if (!expanded) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") dismiss();
+    };
+    const onPointerDown = (e: PointerEvent) => {
+      const t = e.target as Node | null;
+      if (!t || cardRef.current?.contains(t) || barRef.current?.contains(t)) return;
+      dismiss();
+    };
+    document.addEventListener("keydown", onKey);
+    // Capture phase so the outside-press is seen before message-row handlers.
+    document.addEventListener("pointerdown", onPointerDown, true);
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.removeEventListener("pointerdown", onPointerDown, true);
+    };
+  }, [expanded, dismiss]);
 
   if (!hasDescription) return null;
 
-  const expanded = open && !scrollCollapsed;
   const firstLine = descriptionFirstLine(trimmed);
   const freshnessText = updatedAtMs !== null ? formatRelative(descriptionUpdatedAt) : null;
   const showAmberChip = unread && !unreadCleared && !expanded;
   const amberActive = highlighted && expanded;
 
+  const overlayEl = overlayContainerRef.current;
+
   return (
-    <div
-      ref={panelRef}
-      className="shrink-0"
-      style={{
-        // The summary is conversation content, so it shares the message-stream
-        // canvas (`--bg`) — the white header (`--bg-raised`) above gives a
-        // natural one-step contrast. Only the header↔summary seam carries a
-        // hairline (the header itself has no bottom border); nothing separates
-        // the summary from the stream below (same surface). A faint shadow
-        // appears only while the stream scrolls under it, reading as "pinned".
-        background: amberActive ? "var(--bg-warn-soft)" : "var(--bg)",
-        borderTop: `var(--hairline) solid ${amberActive ? "var(--state-blocked-border)" : "var(--border-faint)"}`,
-        boxShadow: scrolled ? "var(--shadow-sm)" : "none",
-        transition: "background 160ms ease, box-shadow 160ms ease",
-      }}
-    >
-      <button
-        type="button"
-        onClick={onToggle}
-        aria-expanded={expanded}
-        aria-label={expanded ? "Collapse summary" : "Expand summary"}
-        className="flex w-full items-center text-left transition-colors hover:bg-[var(--bg-hover)]"
+    <>
+      <div
+        ref={barRef}
+        className="shrink-0"
         style={{
-          gap: "var(--sp-2)",
-          padding: "var(--sp-2) var(--sp-6)",
-          border: 0,
-          background: "transparent",
-          cursor: "pointer",
+          // The bar shares the message-stream canvas (`--bg`); the white header
+          // (`--bg-raised`) above gives a one-step contrast and only the
+          // header↔bar seam carries a hairline. A faint shadow appears while the
+          // stream scrolls under it, reading as "pinned". The amber tint marks an
+          // unread summary that auto-floated (matched on the card below).
+          background: amberActive ? "var(--bg-warn-soft)" : "var(--bg)",
+          borderTop: `var(--hairline) solid ${amberActive ? "var(--state-blocked-border)" : "var(--border-faint)"}`,
+          boxShadow: scrolled ? "var(--shadow-sm)" : "none",
+          transition: "background 160ms ease, box-shadow 160ms ease",
         }}
       >
-        <span
-          className="text-body min-w-0 flex-1"
+        <button
+          type="button"
+          onClick={onToggle}
+          aria-expanded={expanded}
+          aria-label={expanded ? "Collapse summary" : "Expand summary"}
+          className="flex w-full items-center text-left transition-colors hover:bg-[var(--bg-hover)]"
           style={{
-            color: expanded || firstLine ? "var(--fg)" : "var(--fg-3)",
-            whiteSpace: "nowrap",
-            overflow: "hidden",
-            textOverflow: "ellipsis",
-            fontStyle: !expanded && !firstLine ? "italic" : undefined,
-            fontWeight: expanded ? 600 : undefined,
+            gap: "var(--sp-2)",
+            padding: "var(--sp-2) var(--sp-6)",
+            border: 0,
+            background: "transparent",
+            cursor: "pointer",
           }}
         >
-          {expanded ? "Summary" : firstLine || "No summary yet"}
-        </span>
-        {showAmberChip ? (
           <span
-            className="text-caption inline-flex shrink-0 items-center font-medium"
+            className="text-body min-w-0 flex-1"
             style={{
-              padding: "var(--sp-0_5) var(--sp-1_5)",
-              borderRadius: "var(--radius-full)",
-              color: "var(--warning)",
-              background: "var(--state-blocked-soft)",
-              border: "var(--hairline) solid var(--state-blocked-border)",
+              color: expanded || firstLine ? "var(--fg)" : "var(--fg-3)",
+              whiteSpace: "nowrap",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              fontStyle: !expanded && !firstLine ? "italic" : undefined,
+              fontWeight: expanded ? 600 : undefined,
             }}
           >
-            Updated
+            {expanded ? "Summary" : firstLine || "No summary yet"}
           </span>
-        ) : null}
-        {freshnessText ? (
-          <span className="text-caption shrink-0" style={{ color: "var(--fg-3)", whiteSpace: "nowrap" }}>
-            {freshnessText}
-          </span>
-        ) : null}
-        <ChevronDown
-          size={15}
-          strokeWidth={2}
-          className="shrink-0"
-          style={{
-            // Vertical axis matches the open/close motion: ▼ collapsed (opens
-            // downward) → ▲ expanded (collapses up). Kept quiet (muted grey) so
-            // the freshness stays the primary right-side signal.
-            color: "var(--fg-4)",
-            transform: expanded ? "rotate(180deg)" : "none",
-            transition: "transform 180ms ease",
-          }}
-        />
-      </button>
+          {showAmberChip ? (
+            <span
+              className="text-caption inline-flex shrink-0 items-center font-medium"
+              style={{
+                padding: "var(--sp-0_5) var(--sp-1_5)",
+                borderRadius: "var(--radius-full)",
+                color: "var(--warning)",
+                background: "var(--state-blocked-soft)",
+                border: "var(--hairline) solid var(--state-blocked-border)",
+              }}
+            >
+              Updated
+            </span>
+          ) : null}
+          {freshnessText ? (
+            <span className="text-caption shrink-0" style={{ color: "var(--fg-3)", whiteSpace: "nowrap" }}>
+              {freshnessText}
+            </span>
+          ) : null}
+          <ChevronDown
+            size={15}
+            strokeWidth={2}
+            className="shrink-0"
+            style={{
+              // ▼ collapsed (opens downward) → ▲ expanded (collapses up). Quiet
+              // (muted grey) so freshness stays the primary right-side signal.
+              color: "var(--fg-4)",
+              transform: expanded ? "rotate(180deg)" : "none",
+              transition: "transform 180ms ease",
+            }}
+          />
+        </button>
+      </div>
 
-      {expanded ? (
-        <div style={{ padding: "var(--sp-1) var(--sp-6) var(--sp-3)" }}>
-          <div
-            ref={innerScrollRef}
-            className="text-body"
-            style={{ color: "var(--fg)", maxHeight: "min(46vh, 30rem)", overflowY: "auto" }}
-          >
-            {/* Faithful markdown render. Headings are flattened to body size so
-                hierarchy is carried by weight + spacing (mirrors the rail's old
-                Summary treatment) rather than shouting over the bar above. */}
-            <Markdown className="[&_:is(h1,h2,h3,h4,h5,h6)]:text-[length:1em] [&_:is(h1,h2,h3,h4,h5,h6)]:font-semibold [&_:is(h1,h2,h3,h4,h5,h6)]:leading-snug [&_:is(h1,h2,h3,h4,h5,h6)]:mt-3.5 [&_:is(h1,h2,h3,h4,h5,h6)]:mb-1 [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_ul]:pl-4 [&_ol]:pl-4">
-              {trimmed}
-            </Markdown>
-          </div>
-        </div>
-      ) : null}
-    </div>
+      {/* Expanded body: a non-modal floating card portaled over the top of the
+          message area, so it never occupies stream space (no reflow) and always
+          has a real scroll target under the cursor. `overscroll: contain` keeps
+          its scroll from chaining into the messages behind it; no scrim — the
+          shadow + border separate it, and a summary surfacing is awareness, not
+          a modal interception. */}
+      {expanded && overlayEl
+        ? createPortal(
+            <section
+              ref={cardRef}
+              aria-label="Chat summary"
+              className="chat-summary-card-in z-10"
+              style={{
+                position: "absolute",
+                top: 0,
+                left: 0,
+                right: 0,
+                background: amberActive ? "var(--bg-warn-soft)" : "var(--bg-raised)",
+                border: `var(--hairline) solid ${amberActive ? "var(--state-blocked-border)" : "var(--border)"}`,
+                borderRadius: "var(--radius-dialog)",
+                boxShadow: "var(--shadow-md)",
+                padding: "var(--sp-1) var(--sp-6) var(--sp-3)",
+                maxHeight: "min(46vh, 30rem)",
+                overflowY: "auto",
+                overscrollBehavior: "contain",
+              }}
+            >
+              <div className="text-body" style={{ color: "var(--fg)" }}>
+                {/* Faithful markdown render; headings flattened to body size so
+                    hierarchy is weight + spacing, not shouting over the bar. */}
+                <Markdown className="[&_:is(h1,h2,h3,h4,h5,h6)]:text-[length:1em] [&_:is(h1,h2,h3,h4,h5,h6)]:font-semibold [&_:is(h1,h2,h3,h4,h5,h6)]:leading-snug [&_:is(h1,h2,h3,h4,h5,h6)]:mt-3.5 [&_:is(h1,h2,h3,h4,h5,h6)]:mb-1 [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_ul]:pl-4 [&_ol]:pl-4">
+                  {trimmed}
+                </Markdown>
+              </div>
+            </section>,
+            overlayEl,
+          )
+        : null}
+    </>
   );
 }

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -895,6 +895,9 @@ type ChatTimelineProps = {
   hiddenByBlock: number;
   readOnly: boolean;
   scrollContainerRef: RefObject<HTMLDivElement | null>;
+  /** The timeline's `relative` wrapper, used as the chat-summary overlay's
+   *  positioning context (the summary card is portaled into it). */
+  overlayContainerRef: RefObject<HTMLDivElement | null>;
   messagesEndRef: RefObject<HTMLDivElement | null>;
   defaultWorkgroupOpen: boolean;
   agentNameFn: (id: string) => string;
@@ -919,6 +922,7 @@ const ChatTimeline = memo(function ChatTimeline({
   hiddenByBlock,
   readOnly,
   scrollContainerRef,
+  overlayContainerRef,
   messagesEndRef,
   defaultWorkgroupOpen,
   agentNameFn,
@@ -945,7 +949,7 @@ const ChatTimeline = memo(function ChatTimeline({
     agents,
   );
   return (
-    <div className="relative flex-1 flex flex-col min-h-0">
+    <div ref={overlayContainerRef} className="relative flex-1 flex flex-col min-h-0">
       <div ref={scrollContainerRef} className="flex-1 overflow-y-auto" style={{ padding: "var(--sp-2_5) var(--sp-6)" }}>
         <div style={{ maxWidth: "clamp(55rem, 75%, 70rem)", margin: "0 auto", width: "100%" }}>
           {itemCount === 0 && (
@@ -1279,6 +1283,11 @@ export function ChatView({
   // ResizeObserver-stabilised scrolling) and useReadTracker (as the
   // IntersectionObserver root).
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  // Positioning context for the chat-summary floating card: the expanded
+  // summary is portaled into the timeline's `relative` wrapper and laid out
+  // `absolute; top:0` over the message area, so it never occupies stream space
+  // (no reflow) and always has a real scroll target under the cursor.
+  const overlayContainerRef = useRef<HTMLDivElement>(null);
 
   // useChatScroll is declared up here (rather than alongside the M2
   // jump-to-position logic below) because `sendMut`'s onSuccess
@@ -3284,6 +3293,7 @@ export function ChatView({
             lastReadAt={chatDetail?.lastReadAt ?? null}
             freshnessReady={!chatDetailFetching && chatDetail?.id === chatId}
             scrollContainerRef={scrollContainerRef}
+            overlayContainerRef={overlayContainerRef}
           />
 
           {chatDetail?.engagementStatus === CHAT_ENGAGEMENT_STATUSES.DELETED && (
@@ -3339,6 +3349,7 @@ export function ChatView({
             hiddenByBlock={hiddenByBlock}
             readOnly={readOnly}
             scrollContainerRef={scrollContainerRef}
+            overlayContainerRef={overlayContainerRef}
             messagesEndRef={messagesEndRef}
             defaultWorkgroupOpen={chatDetail?.type === "direct"}
             agentNameFn={chatScopedAgentName}


### PR DESCRIPTION
## Problem (the durable fix behind #1245 / #1252)

The expanded chat **Summary** was a second **in-flow scroll region** pinned above the message stream. A wheel/touch over it had no scrollable target, so the conversation read as **"locked"**, and the tall expanded body pushed the messages down. `#1245` added a JS wheel-bridge stopgap; `#1252` stopped scroll-to-top from re-expanding it. Both treated symptoms.

## Fix — direction C (float the expanded summary as an overlay)

Approved direction (ux-expert design `chat-summary-floating-c`): the persistent **bar stays in flow**; the **expanded body becomes a non-modal floating card**, `createPortal`-ed into the timeline's `relative` wrapper and laid out `position:absolute; top:0` over the top of the message area.

Why this is the root cure: **every visible region now has a real `overflow:auto` scroll target under the cursor** — the card scrolls the card (`overscroll-behavior: contain`, so it never chains into the messages), the messages scroll the messages — no "looks scrollable but isn't" dead zone, for **wheel and touch**. And because the card never occupies stream space, **expand/collapse never reflows the conversation**.

- Deletes the `#1245` expanded-body wheel bridge (incl. its boundary math). Keeps one trivial bar wheel-forward for the thin collapsed bar.
- Adds Escape / outside-pointer dismiss (non-modal — no scrim; the card's `--shadow-md` + border separate it, and a summary surfacing is awareness, not a modal interception).
- **Incorporates `#1252`**: scroll-down still auto-collapses; scroll-to-top never re-expands (rebased onto `a36a0ad6`; the near-top reset only clears the manual-expand anchor).
- Unchanged: state machine, auto-expand-once-on-unread, per-version dismiss memory, sticky-collapse thresholds.
- Mobile (Phase 1): reuses the same full-width card — zero dead zone there too; a dedicated bottom-sheet is a deliberate follow-up, not in scope.

## Verification

Real Chromium (local build vs the live staging backend):
- **No reflow** — on expand, the message stream's `scrollTop` (300→300), `clientHeight` (521→521), and a tracked message row's pixel top (−155→−155) are all unchanged.
- **Card** is `position:absolute; overflow-y:auto; overscroll-behavior:contain; max-height:min(46vh,30rem)`, portaled into the timeline wrapper.
- Bar wheel forwards to the stream (native non-passive listener fires; `defaultPrevented`).
- Light + dark theme both correct.

Gates:
- `chat-summary.test.ts` — 26 tests (floating-card render, no-reflow, bar wheel-forward + horizontal-pan passthrough, Esc dismiss, and the `#1252` no-re-expand regression asserted via the overlay).
- `pnpm --filter @first-tree/web exec vitest run src/pages/workspace/center` — 62 tests.
- `pnpm --filter @first-tree/web typecheck` (tsc + lint:tokens) clean; `biome check` clean.

A Context Tree PR recording the C decision will be cross-linked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
