### PR TITLE
feat: redesign Context Reviewer setting as an immediate-save Switch

### DIFF
--- a/packages/web/src/pages/__tests__/settings-panels-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/settings-panels-dom.test.tsx
@@ -269,6 +269,11 @@ function inputByLabel(container: ParentNode, label: string): HTMLInputElement | 
   return control instanceof HTMLInputElement ? control : null;
 }
 
+/** The Context Reviewer on/off Switch — the only ARIA switch in this panel. */
+function reviewerSwitch(container: ParentNode): HTMLButtonElement | null {
+  return container.querySelector<HTMLButtonElement>('button[role="switch"]');
+}
+
 beforeEach(() => {
   document.body.innerHTML = "";
   vi.clearAllMocks();
@@ -488,7 +493,7 @@ describe("settings panels", () => {
     await setInputValue(repoInput, "https://github.com/acme/draft-context");
 
     await waitForText(container, "Context Reviewer");
-    expect(inputByLabel(container, "Enabled")?.checked).toBe(false);
+    expect(reviewerSwitch(container)?.getAttribute("aria-checked")).toBe("false");
     expect(settingsMocks.getContextTreeFeaturesSetting).toHaveBeenCalledWith("org-1");
     expect(agentApiMocks.listManagedAgents).not.toHaveBeenCalled();
     expect(inputByLabel(container, "Repo URL")?.value).toBe("https://github.com/acme/draft-context");
@@ -496,17 +501,36 @@ describe("settings panels", () => {
     await act(async () => root.unmount());
   });
 
-  it("saves disabled Context Reviewer as disabled/null", async () => {
+  it("turning the Context Reviewer Switch off saves disabled/null immediately", async () => {
+    settingsMocks.getContextTreeFeaturesSetting.mockResolvedValueOnce(
+      contextTreeFeatures({ enabled: true, agentUuid: "agent-alpha" }),
+    );
     const { ContextTreeSettingsPanel } = await import("../context-tree-settings-panel.js");
     const { container, root } = await renderPanel(<ContextTreeSettingsPanel />);
     await waitForText(container, "Context Reviewer");
+    await waitForText(container, "Alpha Reviewer");
+    expect(reviewerSwitch(container)?.getAttribute("aria-checked")).toBe("true");
 
-    await click(buttonByText(container, "Save"));
+    await click(reviewerSwitch(container));
 
     expect(settingsMocks.putContextTreeFeaturesSetting).toHaveBeenCalledWith("org-1", {
       contextReviewer: { enabled: false, agentUuid: null },
     });
-    expect(agentApiMocks.listManagedAgents).not.toHaveBeenCalled();
+
+    await act(async () => root.unmount());
+  });
+
+  it("does not save when flipping the Switch on (no agent) and back off", async () => {
+    const { ContextTreeSettingsPanel } = await import("../context-tree-settings-panel.js");
+    const { container, root } = await renderPanel(<ContextTreeSettingsPanel />);
+    await waitForText(container, "Context Reviewer");
+
+    await click(reviewerSwitch(container));
+    await waitForText(container, "Reviewer agent");
+    await click(reviewerSwitch(container));
+
+    expect(settingsMocks.putContextTreeFeaturesSetting).not.toHaveBeenCalled();
+    expect(reviewerSwitch(container)?.getAttribute("aria-checked")).toBe("false");
 
     await act(async () => root.unmount());
   });
@@ -516,17 +540,17 @@ describe("settings panels", () => {
     const { container, root } = await renderPanel(<ContextTreeSettingsPanel />);
     await waitForText(container, "Context Reviewer");
 
-    await click(inputByLabel(container, "Enabled"));
+    await click(reviewerSwitch(container));
     await waitForText(container, "Reviewer agent");
     await waitForCondition(() => agentApiMocks.listManagedAgents.mock.calls.length > 0, "Expected agents to load");
-    expect(container.textContent).toContain("Select an agent");
+    await waitForText(container, "Select an agent to enable Context Reviewer.");
 
     await selectOption(container, "Alpha Reviewer");
     expect(document.body.textContent).not.toContain("Human User");
     expect(document.body.textContent).not.toContain("Suspended");
     expect(document.body.textContent).not.toContain("Other Org");
-    await click(buttonByText(container, "Save"));
 
+    // The pick itself persists — there is no separate Save step.
     expect(settingsMocks.putContextTreeFeaturesSetting).toHaveBeenCalledWith("org-1", {
       contextReviewer: { enabled: true, agentUuid: "agent-alpha" },
     });
@@ -543,13 +567,13 @@ describe("settings panels", () => {
     await waitForText(container, "Context Reviewer");
 
     await waitForText(container, "Beta Reviewer");
-    expect(inputByLabel(container, "Enabled")?.checked).toBe(true);
+    expect(reviewerSwitch(container)?.getAttribute("aria-checked")).toBe("true");
     expect(container.textContent).toContain("Beta Reviewer");
 
     await act(async () => root.unmount());
   });
 
-  it("disables Save when Context Reviewer is enabled but no eligible agents exist", async () => {
+  it("shows the empty state and saves nothing when no eligible agents exist", async () => {
     agentApiMocks.listManagedAgents.mockResolvedValueOnce([
       managedAgent({ uuid: "human-only", displayName: "Only Human", type: "human" }),
       managedAgent({ uuid: "suspended-only", displayName: "Only Suspended", status: "suspended" }),
@@ -558,9 +582,10 @@ describe("settings panels", () => {
     const { container, root } = await renderPanel(<ContextTreeSettingsPanel />);
     await waitForText(container, "Context Reviewer");
 
-    await click(inputByLabel(container, "Enabled"));
+    await click(reviewerSwitch(container));
     await waitForText(container, "No active non-human agents are available.");
-    expect(buttonByText(container, "Save")?.disabled).toBe(true);
+    expect(reviewerSwitch(container)?.getAttribute("aria-checked")).toBe("true");
+    expect(settingsMocks.putContextTreeFeaturesSetting).not.toHaveBeenCalled();
 
     await act(async () => root.unmount());
   });
@@ -574,10 +599,10 @@ describe("settings panels", () => {
     await waitForText(container, "Context Reviewer");
 
     await waitForText(container, "Current reviewer is not your active agent.");
-    expect(buttonByText(container, "Save")?.disabled).toBe(true);
+    expect(reviewerSwitch(container)?.getAttribute("aria-checked")).toBe("true");
 
-    await click(inputByLabel(container, "Enabled"));
-    await click(buttonByText(container, "Save"));
+    // Turning it off from the warning state persists disabled/null at once.
+    await click(reviewerSwitch(container));
     expect(settingsMocks.putContextTreeFeaturesSetting).toHaveBeenCalledWith("org-1", {
       contextReviewer: { enabled: false, agentUuid: null },
     });

--- a/packages/web/src/pages/context-tree-preview.tsx
+++ b/packages/web/src/pages/context-tree-preview.tsx
@@ -40,8 +40,13 @@ const REPO_RESOURCE = [
   { type: "repo", defaultEnabled: "recommended", payload: { url: "https://github.com/acme/acme-web" } },
 ];
 const FEATURES_DISABLED = { contextReviewer: { enabled: false, agentUuid: null } };
+const FEATURES_ENABLED = { contextReviewer: { enabled: true, agentUuid: "0192bbbb-bot2" } };
+// Enabled, but the saved reviewer is no longer one of the admin's active agents.
+const FEATURES_ENABLED_MISSING = { contextReviewer: { enabled: true, agentUuid: "0192ffff-gone" } };
 const BOUND = { repo: "https://github.com/acme/acme-context", branch: "main" };
 const UNBOUND = { repo: null, branch: null };
+// The Context Reviewer section loads candidate agents from this key once on.
+const REVIEWER_AGENTS_KEY = ["context-reviewer", "managed-agents", ORG] as const;
 
 type Seed = ReadonlyArray<readonly [readonly unknown[], unknown]>;
 
@@ -145,6 +150,39 @@ export function ContextTreePreviewPage() {
           title="Settings → Context tree · member (read-only)"
           authRole="member"
           seed={[[["org-setting", ORG, "context_tree"], BOUND]]}
+        />
+      </div>
+
+      <div className="text-eyebrow" style={{ color: "var(--fg-3)", margin: "var(--sp-4) 0 var(--sp-3)" }}>
+        Context Reviewer · immediate-save Switch (replaces the old checkbox + Save). Toggle on/off to see setup ↔ saved.
+      </div>
+      <div style={{ marginTop: "var(--sp-2)" }}>
+        <FullPageCase
+          title="Context Reviewer · OFF (flip the Switch on → agent selector appears, pick one to enable)"
+          authRole="admin"
+          seed={[
+            [["org-setting", ORG, "context_tree"], BOUND],
+            [["org-setting", ORG, "context_tree_features"], FEATURES_DISABLED],
+            [REVIEWER_AGENTS_KEY, AGENTS],
+          ]}
+        />
+        <FullPageCase
+          title="Context Reviewer · ON with a selected agent (Switch on, agent in the Select)"
+          authRole="admin"
+          seed={[
+            [["org-setting", ORG, "context_tree"], BOUND],
+            [["org-setting", ORG, "context_tree_features"], FEATURES_ENABLED],
+            [REVIEWER_AGENTS_KEY, AGENTS],
+          ]}
+        />
+        <FullPageCase
+          title="Context Reviewer · ON but saved reviewer no longer available (warning + re-pick / turn off)"
+          authRole="admin"
+          seed={[
+            [["org-setting", ORG, "context_tree"], BOUND],
+            [["org-setting", ORG, "context_tree_features"], FEATURES_ENABLED_MISSING],
+            [REVIEWER_AGENTS_KEY, AGENTS],
+          ]}
         />
       </div>
 

--- a/packages/web/src/pages/context-tree-settings-panel.tsx
+++ b/packages/web/src/pages/context-tree-settings-panel.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ArrowRight, Check } from "lucide-react";
-import { type FormEvent, useEffect, useMemo, useState } from "react";
+import { ArrowRight } from "lucide-react";
+import { type FormEvent, useEffect, useId, useMemo, useState } from "react";
 import { useNavigate } from "react-router";
 import { listManagedAgents, type ManagedAgent } from "../api/agents.js";
 import {
@@ -14,6 +14,8 @@ import { Button } from "../components/ui/button.js";
 import { Section } from "../components/ui/section.js";
 import { Select } from "../components/ui/select.js";
 import { SettingsField, SettingsSaveButton } from "../components/ui/settings-field.js";
+import { Switch } from "../components/ui/switch.js";
+import { titleWithSemantics, useJustSaved } from "./agent-detail/save-semantics.js";
 
 /**
  * Settings → Context tree. Per-org Context Tree **configuration**: which repo /
@@ -240,10 +242,22 @@ function NoTree({
 }
 
 /** Context Reviewer: assign an agent to auto-review Context Tree PRs. Meaningful
- *  only once a tree is bound. Was the old "Features" tab; now a plain section. */
+ *  only once a tree is bound. Was the old "Features" tab; now a plain section.
+ *
+ *  This is an immediate-save config block (no page-level Save), mirroring the
+ *  Agent Detail Switch rows: flipping the Switch or picking an agent persists at
+ *  once and flashes "Saved" next to the title. The one wrinkle is the backend
+ *  contract — `enabled=true` is rejected without a valid `agentUuid` — so turning
+ *  the Switch ON cannot blindly PATCH `enabled`. Instead it opens a local "setup"
+ *  on-state (`setupOpen`) that reveals the agent selector; the enable actually
+ *  persists only once an agent is chosen. State is driven from the server query,
+ *  not a local mirror, and every save passes an explicit payload so an instant
+ *  handler never reads stale local state. */
 function ContextReviewerSection({ hasBinding }: { hasBinding: boolean }) {
   const { organizationId } = useAuth();
   const queryClient = useQueryClient();
+  const { justSaved, markSaved } = useJustSaved();
+  const toggleLabelId = useId();
 
   const featuresQuery = useQuery({
     queryKey: ["org-setting", organizationId, "context_tree_features"],
@@ -252,20 +266,20 @@ function ContextReviewerSection({ hasBinding }: { hasBinding: boolean }) {
     enabled: !!organizationId,
   });
 
-  const [reviewerEnabled, setReviewerEnabled] = useState(false);
-  const [reviewerAgentUuid, setReviewerAgentUuid] = useState<string | null>(null);
-  const [featuresSaved, setFeaturesSaved] = useState(false);
+  const serverEnabled = featuresQuery.data?.contextReviewer.enabled ?? false;
+  const serverAgentUuid = featuresQuery.data?.contextReviewer.agentUuid ?? null;
 
-  useEffect(() => {
-    if (!featuresQuery.data) return;
-    setReviewerEnabled(featuresQuery.data.contextReviewer.enabled);
-    setReviewerAgentUuid(featuresQuery.data.contextReviewer.agentUuid);
-  }, [featuresQuery.data]);
+  // Pre-persistence on-state: the Switch is flipped on but `enabled` is not yet
+  // saved (no agent picked). Once enabled persists, `serverEnabled` carries the
+  // on-state and this resets. Off + already-enabled persists `enabled=false`;
+  // off while only `setupOpen` just abandons the un-saved setup.
+  const [setupOpen, setSetupOpen] = useState(false);
+  const switchOn = serverEnabled || setupOpen;
 
   const managedAgentsQuery = useQuery({
     queryKey: ["context-reviewer", "managed-agents", organizationId],
     queryFn: listManagedAgents,
-    enabled: !!organizationId && reviewerEnabled,
+    enabled: !!organizationId && switchOn,
   });
 
   const reviewerCandidates = useMemo(() => {
@@ -277,40 +291,45 @@ function ContextReviewerSection({ hasBinding }: { hasBinding: boolean }) {
       });
   }, [managedAgentsQuery.data, organizationId]);
 
-  const selectedReviewerIsCandidate = reviewerCandidates.some((agent) => agent.uuid === reviewerAgentUuid);
-  const reviewerSelectionInvalid = reviewerEnabled && (!reviewerAgentUuid || !selectedReviewerIsCandidate);
-  const featuresSaveDisabled =
-    featuresQuery.isLoading ||
-    featuresQuery.isError ||
-    managedAgentsQuery.isLoading ||
-    (reviewerEnabled && (reviewerCandidates.length === 0 || reviewerSelectionInvalid));
+  const agentsLoading = managedAgentsQuery.isLoading;
+  const selectedIsCandidate = reviewerCandidates.some((agent) => agent.uuid === serverAgentUuid);
+  // Enabled, but the saved reviewer is no longer an active agent this admin can
+  // see: keep the Switch on, warn, and let them re-pick or turn it off.
+  const reviewerMissing = serverEnabled && !selectedIsCandidate && !agentsLoading && reviewerCandidates.length > 0;
+  // Switch is on for setup but no agent chosen yet — prompt for the pick that
+  // actually enables the feature.
+  const awaitingAgent = setupOpen && !serverEnabled && !agentsLoading && reviewerCandidates.length > 0;
 
   const featuresMutation = useMutation({
-    mutationFn: () => {
+    mutationFn: (next: { enabled: boolean; agentUuid: string | null }) => {
       if (!organizationId) throw new Error("organization not loaded");
-      return putContextTreeFeaturesSetting(organizationId, {
-        contextReviewer: {
-          enabled: reviewerEnabled,
-          agentUuid: reviewerEnabled ? reviewerAgentUuid : null,
-        },
-      });
+      return putContextTreeFeaturesSetting(organizationId, { contextReviewer: next });
     },
     onSuccess: (next) => {
       queryClient.setQueryData(["org-setting", organizationId, "context_tree_features"], next);
-      setFeaturesSaved(true);
-      setTimeout(() => setFeaturesSaved(false), 2000);
+      setSetupOpen(false);
+      markSaved();
     },
   });
+  const saving = featuresMutation.isPending;
 
-  const handleFeaturesSubmit = (e: FormEvent) => {
-    e.preventDefault();
-    if (featuresSaveDisabled) return;
-    featuresMutation.mutate();
+  const handleToggle = (next: boolean) => {
+    if (next) {
+      setSetupOpen(true);
+      return;
+    }
+    setSetupOpen(false);
+    if (serverEnabled) featuresMutation.mutate({ enabled: false, agentUuid: null });
+  };
+
+  const handleSelectAgent = (uuid: string) => {
+    if (!uuid) return;
+    featuresMutation.mutate({ enabled: true, agentUuid: uuid });
   };
 
   return (
     <Section
-      title="Context Reviewer"
+      title={titleWithSemantics("Context Reviewer", justSaved)}
       description="Assign one of your agents to automatically review Context Tree pull requests."
     >
       <div style={{ paddingTop: "var(--sp-4)" }}>
@@ -327,39 +346,27 @@ function ContextReviewerSection({ hasBinding }: { hasBinding: boolean }) {
             {featuresQuery.error instanceof Error ? featuresQuery.error.message : "Failed to load feature settings"}
           </div>
         ) : (
-          <form onSubmit={handleFeaturesSubmit}>
-            <div className="flex items-baseline justify-between" style={{ gap: "var(--sp-2)" }}>
-              <label
-                className="text-body inline-flex items-center font-medium"
-                style={{ color: "var(--fg)", gap: "var(--sp-2)" }}
-              >
-                <input
-                  type="checkbox"
-                  checked={reviewerEnabled}
-                  onChange={(e) => {
-                    setReviewerEnabled(e.target.checked);
-                    if (!e.target.checked) setReviewerAgentUuid(null);
-                  }}
-                />
-                <span>Enabled</span>
-              </label>
-              {featuresSaved && (
-                <span
-                  className="text-label inline-flex items-center fade-in"
-                  style={{ gap: "var(--sp-1)", color: "var(--fg-confirm)" }}
-                >
-                  <Check className="h-3 w-3" />
-                  Saved
-                </span>
-              )}
+          <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
+            {/* Config row: the feature's on/off control, mirroring the agent-detail
+                Switch rows (label left, Switch right, instant save). */}
+            <div className="flex items-center justify-between" style={{ gap: "var(--sp-3)" }}>
+              <span id={toggleLabelId} className="text-body font-medium" style={{ color: "var(--fg)" }}>
+                Automatic PR review
+              </span>
+              <Switch
+                checked={switchOn}
+                onCheckedChange={handleToggle}
+                disabled={saving}
+                aria-labelledby={toggleLabelId}
+              />
             </div>
 
-            {reviewerEnabled ? (
-              <div className="flex flex-col" style={{ gap: "var(--sp-2)", marginTop: "var(--sp-4)" }}>
+            {switchOn ? (
+              <div className="flex flex-col" style={{ gap: "var(--sp-2)" }}>
                 <span className="text-label font-medium" style={{ color: "var(--fg)" }}>
                   Reviewer agent
                 </span>
-                {managedAgentsQuery.isLoading ? (
+                {agentsLoading ? (
                   <div className="text-body" style={{ color: "var(--fg-3)" }}>
                     Loading agents…
                   </div>
@@ -370,8 +377,9 @@ function ContextReviewerSection({ hasBinding }: { hasBinding: boolean }) {
                 ) : (
                   <Select
                     aria-label="Context Reviewer agent"
-                    value={selectedReviewerIsCandidate ? (reviewerAgentUuid ?? "") : ""}
-                    onChange={(value) => setReviewerAgentUuid(value || null)}
+                    value={serverEnabled && selectedIsCandidate ? (serverAgentUuid ?? "") : ""}
+                    onChange={handleSelectAgent}
+                    disabled={saving}
                     options={[
                       { value: "", label: "Select an agent", disabled: true },
                       ...reviewerCandidates.map((agent) => ({
@@ -384,6 +392,16 @@ function ContextReviewerSection({ hasBinding }: { hasBinding: boolean }) {
                     searchable={reviewerCandidates.length > 6}
                   />
                 )}
+                {awaitingAgent ? (
+                  <div className="text-label" style={{ color: "var(--fg-3)" }}>
+                    Select an agent to enable Context Reviewer.
+                  </div>
+                ) : null}
+                {reviewerMissing ? (
+                  <div className="text-label" style={{ color: "var(--fg-3)" }}>
+                    Current reviewer is not your active agent. Choose one of your agents, or turn Context Reviewer off.
+                  </div>
+                ) : null}
                 {managedAgentsQuery.error ? (
                   <div className="text-body" style={{ color: "var(--state-error)" }}>
                     {managedAgentsQuery.error instanceof Error
@@ -391,26 +409,15 @@ function ContextReviewerSection({ hasBinding }: { hasBinding: boolean }) {
                       : "Failed to load agents"}
                   </div>
                 ) : null}
-                {reviewerAgentUuid && !selectedReviewerIsCandidate && !managedAgentsQuery.isLoading ? (
-                  <div className="text-label" style={{ color: "var(--fg-3)" }}>
-                    Current reviewer is not your active agent. Choose one of your agents or turn Context Reviewer off.
-                  </div>
-                ) : null}
               </div>
             ) : null}
 
-            <div className="flex items-center justify-end" style={{ gap: "var(--sp-2)", marginTop: "var(--sp-4)" }}>
-              <Button type="submit" size="sm" disabled={featuresMutation.isPending || featuresSaveDisabled}>
-                <Check className="h-4 w-4" />
-                <span>Save</span>
-              </Button>
-            </div>
-            {featuresMutation.error instanceof Error && (
-              <div className="text-body" style={{ color: "var(--state-error)", marginTop: "var(--sp-2)" }}>
+            {featuresMutation.error instanceof Error ? (
+              <div className="text-body" style={{ color: "var(--state-error)" }}>
                 {featuresMutation.error.message}
               </div>
-            )}
-          </form>
+            ) : null}
+          </div>
         )}
       </div>
     </Section>


### PR DESCRIPTION
## What

Redesigns the **Settings → Context tree → Context Reviewer** section from a checkbox + page-level **Save** button into an **immediate-save Switch**, mirroring the Agent Detail page's switch + instant-save model. Settings and Agent Detail now share one save mental model (no staged "fill the form, then Save").

Before: an `Enabled` checkbox + a `Reviewer agent` select + a bottom `Save` button (form). After: an `Automatic PR review` row with a Switch that saves immediately; "Saved" flashes next to the section title.

## Why

The old checkbox + Save read like a temporary form, not a product-grade Settings config item, and it conflicted with Agent Detail's established "changes save immediately, no page Save" model. The Switch expresses the binary feature toggle; the whole row expresses what the feature is.

## How

The one wrinkle is the backend contract: `enabled=true` is rejected without a valid `agentUuid` (an active non-human agent in the org). So flipping the Switch on cannot blindly PATCH `enabled`. Instead:

- Flipping the Switch **on** opens a local **setup** state that reveals the `Reviewer agent` selector and prompts `Select an agent to enable Context Reviewer.` The enable persists (`{ enabled: true, agentUuid }`) only once an agent is picked.
- Flipping it **off** persists `{ enabled: false, agentUuid: null }` immediately when something was enabled; abandoning an un-saved setup fires no request.
- Changing the agent while on saves immediately.
- State is driven from the server query (no local mirror); every save passes an explicit payload so instant handlers never read stale state.

States handled: `off`, `setup` (awaiting agent), `on + agent`, `on + saved reviewer no longer available` (warn → re-pick or turn off), and `no eligible agents`.

Reuses the shared `Switch` primitive and Agent Detail's `useJustSaved` / `titleWithSemantics` Saved-flash.

## Verification

- `pnpm --filter @first-tree/web typecheck` + `lint:tokens` clean; `pnpm exec biome check` clean.
- Full web suite green: **998 tests / 127 files**. DOM tests rewritten to the instant-save model and assert the exact PUT payloads (incl. that on→off-without-agent fires **no** request, and human/suspended/other-org agents are filtered out).
- Visual review via the DEV `/preview/context-tree` gallery (extended here with the new reviewer states): off, setup, on+agent, missing-reviewer all verified in a headless browser.

## Notes

- Tree-write: **skipped (implementation-only)**. The durable Context Reviewer decision + backend contract already live at `system/cloud/github/context-tree-pr-reviewer.md`; this PR changes only the Settings presentation/save model.
- Independent review: SOUND (no correctness bugs; two Low cosmetic notes about the error banner lingering until the next save, matching the existing agent-detail pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)