### PR TITLE
fix: support Node 18.14 CLI installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,55 @@ jobs:
       - run: pnpm build
       - run: pnpm test
 
+  cli-node18-smoke:
+    name: CLI Node 18 Smoke
+    needs: changes
+    if: needs.changes.outputs.code == 'true' || github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+      - run: pnpm install --frozen-lockfile
+      # The CLI bundle imports workspace packages through their package
+      # exports. Build them first so the packed smoke test matches the
+      # publish workflow, where `pnpm build` has already produced dist
+      # outputs before `npm publish`.
+      - run: pnpm --filter @first-tree/shared build
+      - run: pnpm --filter @first-tree/client build
+      - run: pnpm --filter first-tree-dev build
+      - name: Pack CLI tarball
+        id: pack
+        working-directory: apps/cli
+        run: |
+          TARBALL=$(npm pack --json --silent | node -e "let s=''; process.stdin.on('data', c => s += c); process.stdin.on('end', () => { const p = JSON.parse(s)[0]; console.log(p.filename); });")
+          echo "tarball=apps/cli/$TARBALL" >> "$GITHUB_OUTPUT"
+          tar -tzf "$TARBALL" | grep -qx "package/bin/first-tree.cjs"
+          tar -tzf "$TARBALL" | grep -qx "package/dist/cli/index.mjs"
+          tar -xOf "$TARBALL" package/package.json | node -e '
+            let s = "";
+            process.stdin.on("data", (chunk) => s += chunk);
+            process.stdin.on("end", () => {
+              const pkg = JSON.parse(s);
+              if (pkg.engines?.node !== ">=18.14.1") throw new Error(`unexpected engines.node ${pkg.engines?.node}`);
+              if (pkg.bin?.["first-tree-dev"] !== "./bin/first-tree.cjs") throw new Error("first-tree-dev bin must point to wrapper");
+              if (pkg.bin?.ftd !== "./bin/first-tree.cjs") throw new Error("ftd bin must point to wrapper");
+            });
+          '
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "18.14.1"
+      - name: Run packed CLI on Node 18
+        run: |
+          PREFIX="$RUNNER_TEMP/first-tree-node18"
+          npm install --engine-strict --prefix "$PREFIX" "${{ steps.pack.outputs.tarball }}"
+          FIRST_TREE_HOME="$RUNNER_TEMP/first-tree-home" node "$PREFIX/node_modules/.bin/first-tree-dev" --version
+          FIRST_TREE_HOME="$RUNNER_TEMP/first-tree-home" node "$PREFIX/node_modules/.bin/first-tree-dev" --help > "$RUNNER_TEMP/first-tree-help.txt"
+          grep -q "Usage: first-tree-dev" "$RUNNER_TEMP/first-tree-help.txt"
+
   check-migrations:
     name: Migrations
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-npm-package.yml
+++ b/.github/workflows/publish-npm-package.yml
@@ -128,8 +128,8 @@ jobs:
           const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
           pkg.name = "first-tree";
           pkg.bin = {
-            "first-tree": "./dist/cli/index.mjs",
-            "ft": "./dist/cli/index.mjs",
+            "first-tree": "./bin/first-tree.cjs",
+            "ft": "./bin/first-tree.cjs",
           };
           fs.writeFileSync("package.json", `${JSON.stringify(pkg, null, 2)}\n`);
           fs.writeFileSync(
@@ -285,8 +285,8 @@ jobs:
           pkg.name = "first-tree-staging";
           pkg.version = process.env.STAGING_VERSION;
           pkg.bin = {
-            "first-tree-staging": "./dist/cli/index.mjs",
-            "fts": "./dist/cli/index.mjs",
+            "first-tree-staging": "./bin/first-tree.cjs",
+            "fts": "./bin/first-tree.cjs",
           };
           fs.writeFileSync("package.json", `${JSON.stringify(pkg, null, 2)}\n`);
           fs.writeFileSync(

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ What first-tree is NOT:
 - **Shared:** Zod schemas + TypeScript types + config system
 - **Web:** React 19 / Vite
 - **Tooling:** pnpm / Turborepo / Biome / Vitest / tsdown
-- **Node.js:** minimum 22.13, recommended 24
+- **Node.js:** published CLI minimum 18.14.1; repository development minimum 22.13, recommended 24
 
 ## Common Commands
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ architecture rules. Quick map:
 
 ## Local setup
 
-- Node.js 22+ (24 recommended)
+- Node.js 22.13+ for repository development (24 recommended)
 - pnpm 10+
 - Docker (for local PostgreSQL via `docker-compose`)
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -7,7 +7,7 @@ using [AGENTS.md](AGENTS.md). For the PR workflow, see
 
 ## Prerequisites
 
-- Node.js 22.13 or newer. Node.js 24 is recommended.
+- Node.js 22.13 or newer for repository development. Node.js 24 is recommended.
 - pnpm 10.x.
 - Docker, for the local PostgreSQL service in [docker-compose.yml](docker-compose.yml).
 - Optional: an HTTPS tunnel tool such as `ngrok`, `cloudflared`, or a similar

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -55,7 +55,7 @@ mv ~/.first-tree/hub ~/.first-tree-staging
 
 # 3. Switch CLI package
 npm uninstall -g first-tree 2>/dev/null || true
-npm install -g first-tree-staging
+npm install -g first-tree-staging@latest
 
 # 4. Re-login — rewrites first-tree-staging.service and starts the daemon
 first-tree-staging login "$TOKEN"
@@ -83,14 +83,14 @@ first-tree-staging status
 
 ### Rollback
 
-If `npm install -g first-tree-staging` or `first-tree-staging login`
+If `npm install -g first-tree-staging@latest` or `first-tree-staging login`
 fails after step 2 has already moved your home dir, the original layout
 is one `mv` away (everything is preserved bit-for-bit since the migration
 never copies):
 
 ```bash
 mv ~/.first-tree-staging ~/.first-tree/hub
-npm install -g first-tree         # restore the old package
+npm install -g first-tree@latest  # restore the old package
 first-tree login "$TOKEN"          # rewrites the original service unit
 ```
 
@@ -107,7 +107,7 @@ Once you have a prod connect-token, install the prod package alongside
 staging — they share zero state:
 
 ```bash
-npm install -g first-tree
+npm install -g first-tree@latest
 first-tree login <prod-token>
 # → ~/.first-tree/, first-tree.service, prod cloud
 ```

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ At the "connect a computer" step, setup gives you the command to install the
 CLI and link the machine:
 
 ```bash
-npm install -g first-tree
+npm install -g first-tree@latest
 first-tree login <connect-token>
 ```
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -82,7 +82,7 @@ First Tree 围绕 Context Tree 连接五个部分：
 走到“连接一台电脑”这步时，引导流程会给你安装 CLI、把这台机器登入的命令：
 
 ```bash
-npm install -g first-tree
+npm install -g first-tree@latest
 first-tree login <connect-token>
 ```
 

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -5,7 +5,7 @@ First Tree is the unified CLI for Context Tree onboarding, agent management, and
 Install the CLI globally:
 
 ```bash
-npm install -g first-tree
+npm install -g first-tree@latest
 ```
 
 Then connect this computer with a token from the First Tree web console:

--- a/apps/cli/bin/first-tree.cjs
+++ b/apps/cli/bin/first-tree.cjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+"use strict";
+
+function parseNodeVersion(version) {
+  var parts = String(version || "").split(".");
+  return {
+    major: Number(parts[0]),
+    minor: Number(parts[1] || 0),
+    patch: Number(parts[2] || 0),
+  };
+}
+
+function isSupportedNode(version) {
+  var parsed = parseNodeVersion(version);
+  if (!Number.isFinite(parsed.major) || !Number.isFinite(parsed.minor) || !Number.isFinite(parsed.patch)) {
+    return false;
+  }
+  if (parsed.major > 18) return true;
+  if (parsed.major < 18) return false;
+  if (parsed.minor > 14) return true;
+  if (parsed.minor < 14) return false;
+  return parsed.patch >= 1;
+}
+
+// biome-ignore lint/complexity/useOptionalChain: keep the preflight parseable on old Node versions.
+if (!isSupportedNode(process.versions && process.versions.node)) {
+  console.error("First Tree requires Node.js >=18.14.1.");
+  console.error("Please upgrade Node.js, then run this command again.");
+  process.exit(1);
+}
+
+var loadCli = new Function("specifier", "return import(specifier)");
+loadCli("../dist/cli/index.mjs").catch(function handleCliLoadError(error) {
+  // biome-ignore lint/complexity/useOptionalChain: keep the wrapper parseable on old Node versions.
+  console.error(error && error.stack ? error.stack : String(error));
+  process.exit(1);
+});

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -22,10 +22,11 @@
     }
   },
   "bin": {
-    "first-tree-dev": "./dist/cli/index.mjs",
-    "ftd": "./dist/cli/index.mjs"
+    "first-tree-dev": "./bin/first-tree.cjs",
+    "ftd": "./bin/first-tree.cjs"
   },
   "files": [
+    "bin",
     "dist",
     "skills",
     "README.md",
@@ -50,11 +51,11 @@
     "directory": "apps/cli"
   },
   "engines": {
-    "node": ">=22.13.0"
+    "node": ">=18.14.1"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.187",
-    "@inquirer/prompts": "^8.3.0",
+    "@inquirer/prompts": "^6.0.1",
     "@openai/codex-sdk": "^0.140.0",
     "commander": "^13.1.0",
     "gray-matter": "^4.0.3",

--- a/apps/cli/src/__tests__/agent-lifecycle-commands-extra.test.ts
+++ b/apps/cli/src/__tests__/agent-lifecycle-commands-extra.test.ts
@@ -353,7 +353,7 @@ describe("logout and upgrade commands", () => {
 
     coreMocks.detectInstallMode.mockReturnValueOnce("npx");
     await runTopLevel(registerUpgradeCommand, ["upgrade"]);
-    expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain("npm i -g first-tree");
+    expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain("npm i -g first-tree@latest");
 
     coreMocks.detectInstallMode.mockReturnValue("global");
     coreMocks.fetchServerCommandVersion.mockResolvedValueOnce({ ok: false, reason: "server down" });

--- a/apps/cli/src/__tests__/bin-wrapper.test.ts
+++ b/apps/cli/src/__tests__/bin-wrapper.test.ts
@@ -1,0 +1,83 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { runInNewContext } from "node:vm";
+import { describe, expect, it } from "vitest";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const WRAPPER_PATH = resolve(HERE, "../../bin/first-tree.cjs");
+const WRAPPER_SOURCE = readFileSync(WRAPPER_PATH, "utf-8");
+
+type WrapperRun = {
+  exitCode: number | null;
+  loadedSpecifier: string | null;
+  stderr: string[];
+};
+
+function runWrapperWithNode(version: string): WrapperRun {
+  const stderr: string[] = [];
+  let exitCode: number | null = null;
+  let loadedSpecifier: string | null = null;
+
+  const processShim = {
+    versions: { node: version },
+    exit(code?: number): never {
+      exitCode = code ?? 0;
+      throw new Error(`process.exit:${exitCode}`);
+    },
+  };
+  const consoleShim = {
+    error(message: unknown): void {
+      stderr.push(String(message));
+    },
+  };
+  function FunctionShim(): (specifier: string) => Promise<void> {
+    return (specifier: string) => {
+      loadedSpecifier = specifier;
+      return Promise.resolve();
+    };
+  }
+
+  try {
+    runInNewContext(
+      WRAPPER_SOURCE,
+      {
+        console: consoleShim,
+        Function: FunctionShim,
+        Number,
+        process: processShim,
+        String,
+      },
+      { filename: WRAPPER_PATH },
+    );
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("process.exit:")) {
+      return { exitCode, loadedSpecifier, stderr };
+    }
+    throw error;
+  }
+
+  return { exitCode, loadedSpecifier, stderr };
+}
+
+describe("CLI bin wrapper", () => {
+  it("prints a clear preflight error before loading the bundled CLI on Node <18.14.1", () => {
+    for (const version of ["17.9.1", "18.13.0", "18.14.0"]) {
+      const result = runWrapperWithNode(version);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.loadedSpecifier).toBeNull();
+      expect(result.stderr.join("\n")).toContain("First Tree requires Node.js >=18.14.1.");
+    }
+  });
+
+  it("loads the bundled CLI entrypoint on Node 18.14.1 and newer", () => {
+    for (const version of ["18.14.1", "18.15.0", "20.0.0"]) {
+      const result = runWrapperWithNode(version);
+
+      expect(result.exitCode).toBeNull();
+      expect(result.stderr).toEqual([]);
+      expect(result.loadedSpecifier).toBe("../dist/cli/index.mjs");
+    }
+  });
+});

--- a/apps/cli/src/__tests__/package-metadata.test.ts
+++ b/apps/cli/src/__tests__/package-metadata.test.ts
@@ -32,7 +32,7 @@ describe("npm package metadata", () => {
   it("includes package-root documentation and license files in the tarball allow-list", () => {
     const files = packageFiles(readJson(join(CLI_ROOT, "package.json")));
 
-    expect(files).toEqual(expect.arrayContaining(["dist", "README.md", "LICENSE"]));
+    expect(files).toEqual(expect.arrayContaining(["bin", "dist", "README.md", "LICENSE"]));
   });
 
   it("keeps a package-local README for the npm registry page", () => {
@@ -42,7 +42,7 @@ describe("npm package metadata", () => {
 
     const readme = readText(readmePath);
 
-    expect(readme).toContain("npm install -g first-tree");
+    expect(readme).toContain("npm install -g first-tree@latest");
     expect(readme).toContain("first-tree login <connect-token>");
     expect(readme).toContain("https://github.com/agent-team-foundation/first-tree/blob/main/docs/cli-reference.md");
     expect(readme).toContain("Apache-2.0");

--- a/apps/cli/src/__tests__/update-detect-install-mode.test.ts
+++ b/apps/cli/src/__tests__/update-detect-install-mode.test.ts
@@ -59,17 +59,17 @@ describe("detectInstallMode", () => {
     expect(detectInstallMode(argv1, "first-tree")).toBe("npx");
   });
 
-  it("classifies a global install as 'global' when invoked through a symlinked bin/", () => {
+  it("classifies a global install as 'global' when invoked through a symlinked wrapper bin/", () => {
     // Regression: standard `npm i -g` lays the binary out as
-    // `<prefix>/bin/<name> -> ../lib/node_modules/<pkg>/dist/cli/index.mjs`.
+    // `<prefix>/bin/<name> -> ../lib/node_modules/<pkg>/bin/first-tree.cjs`.
     // process.argv[1] keeps the symlink path, so without realpath the walk
     // starts in `<prefix>/bin/` and never reaches the package.json — the
     // command falls through to "npx" and `update` refuses to run.
     const prefix = join(root, "usr", "local");
     const pkgDir = join(prefix, "lib", "node_modules", "@agent-team-foundation", "first-tree");
-    mkdirSync(join(pkgDir, "dist", "cli"), { recursive: true });
+    mkdirSync(join(pkgDir, "bin"), { recursive: true });
     writeFileSync(join(pkgDir, "package.json"), JSON.stringify({ name: "first-tree", version: "0.10.12" }));
-    const target = join(pkgDir, "dist", "cli", "index.mjs");
+    const target = join(pkgDir, "bin", "first-tree.cjs");
     writeFileSync(target, "// stub");
 
     const binDir = join(prefix, "bin");
@@ -78,6 +78,16 @@ describe("detectInstallMode", () => {
     symlinkSync(target, binLink);
 
     expect(detectInstallMode(binLink, "first-tree")).toBe("global");
+  });
+
+  it("classifies a global install as 'global' when argv1 is the package wrapper", () => {
+    const pkgDir = join(root, ".nvm/versions/node/v22/lib/node_modules/first-tree");
+    mkdirSync(join(pkgDir, "bin"), { recursive: true });
+    writeFileSync(join(pkgDir, "package.json"), JSON.stringify({ name: "first-tree", version: "0.10.12" }));
+    const argv1 = join(pkgDir, "bin", "first-tree.cjs");
+    writeFileSync(argv1, "// stub");
+
+    expect(detectInstallMode(argv1, "first-tree")).toBe("global");
   });
 
   it("classifies a global install as 'global' even when an ancestor of the npm prefix has a .git dir", () => {

--- a/apps/cli/src/commands/upgrade.ts
+++ b/apps/cli/src/commands/upgrade.ts
@@ -51,7 +51,7 @@ export function registerUpgradeCommand(program: Command): void {
         // pkg) short-circuits to mode==="source" above. Defend anyway so
         // the message stays readable if that contract ever changes.
         const installHint = PACKAGE_NAME ?? binName;
-        print.line(`  Install globally first:  npm i -g ${installHint}\n\n`);
+        print.line(`  Install globally first:  npm i -g ${installHint}@latest\n\n`);
         return;
       }
 

--- a/apps/cli/src/core/doctor.ts
+++ b/apps/cli/src/core/doctor.ts
@@ -45,18 +45,12 @@ function get(obj: Record<string, unknown>, dotPath: string): unknown {
 
 export function checkNodeVersion(): CheckResult {
   const version = process.versions.node;
-  const [major, minor] = version.split(".").map(Number);
-  // Floor of `>=22.13.0` matches engines.node on the published packages
-  // and reflects the real strict-resolver floor — `@inquirer/prompts`
-  // (a direct dep of apps/cli) is the tightest constraint at `^22.13.0`,
-  // so under pnpm / yarn / `engine-strict=true` installs on 22.0-22.12
-  // hard-fail despite engines saying otherwise. Mirror that here so the
-  // doctor is honest about the supported range, not just the major.
-  const ok = major !== undefined && (major >= 23 || (major === 22 && minor !== undefined && minor >= 13));
+  const [major, minor = 0, patch = 0] = version.split(".").map(Number);
+  const ok = major !== undefined && (major > 18 || (major === 18 && (minor > 14 || (minor === 14 && patch >= 1))));
   return {
     label: "Node.js",
     ok,
-    detail: ok ? `v${version}` : `v${version} (requires >= 22.13)`,
+    detail: ok ? `v${version}` : `v${version} (requires >= 18.14.1)`,
   };
 }
 

--- a/apps/cli/src/core/update-glue.ts
+++ b/apps/cli/src/core/update-glue.ts
@@ -87,7 +87,7 @@ export function createExecuteUpdate({
     if (mode === "npx") {
       const installHint = PACKAGE_NAME ?? channelConfig.binName;
       print.line(
-        `  [update] Cannot self-update — not launched from a global npm install.\n  Run \`npm i -g ${installHint}\` manually.\n`,
+        `  [update] Cannot self-update — not launched from a global npm install.\n  Run \`npm i -g ${installHint}@latest\` manually.\n`,
       );
       return { installed: false };
     }

--- a/apps/cli/src/core/update.ts
+++ b/apps/cli/src/core/update.ts
@@ -58,7 +58,7 @@ export function detectInstallMode(
   if (packageName === null) return "source";
   if (!argv1) return "npx";
   // Resolve symlinks first. Standard `npm i -g` lays the binary out as
-  // `<prefix>/bin/<name> -> ../lib/node_modules/<pkg>/dist/cli/index.mjs`,
+  // `<prefix>/bin/<name> -> ../lib/node_modules/<pkg>/bin/first-tree.cjs`,
   // and `process.argv[1]` keeps the symlink path. Walking from the link
   // dir (`<prefix>/bin/`) never hits an ancestor `package.json` matching
   // our name, so the function falls through to "npx" and `update` refuses

--- a/apps/cli/tsdown.config.ts
+++ b/apps/cli/tsdown.config.ts
@@ -5,7 +5,7 @@ export default defineConfig([
     entry: { index: "src/index.ts" },
     format: "esm",
     platform: "node",
-    target: "node22",
+    target: "node18",
     // `react-devtools-core` is an optional dev-only dep of `ink` that is
     // never reachable at runtime in our CLI. Mark it external so rolldown
     // doesn't emit an UNRESOLVED_IMPORT warning during the build.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -15,12 +15,12 @@ human-friendly index over them.
 ## Install
 
 ```bash
-npm install -g first-tree
+npm install -g first-tree@latest
 first-tree --version
 ```
 
 The binary lives at `first-tree`; the short alias `ft` is also installed.
-Requirements: Node.js ≥ 22.13 (24 recommended).
+Requirements: Node.js ≥ 18.14.1 (24 recommended).
 
 ## Global flags
 

--- a/docs/development/local-dev-isolation.md
+++ b/docs/development/local-dev-isolation.md
@@ -16,8 +16,8 @@ already have.
 | Channel | Install via | Bin | Default home | Service unit |
 |---|---|---|---|---|
 | dev | `scripts/dev-install.sh` (in-tree, symlinked) | `first-tree-dev` / `ftd` | `~/.first-tree-dev/` | `first-tree-dev.service` |
-| staging | `npm i -g first-tree-staging` | `first-tree-staging` / `fts` | `~/.first-tree-staging/` | `first-tree-staging.service` |
-| prod | `npm i -g first-tree` | `first-tree` / `ft` | `~/.first-tree/` | `first-tree.service` |
+| staging | `npm i -g first-tree-staging@latest` | `first-tree-staging` / `fts` | `~/.first-tree-staging/` | `first-tree-staging.service` |
+| prod | `npm i -g first-tree@latest` | `first-tree` / `ft` | `~/.first-tree/` | `first-tree.service` |
 
 Each install registers as a separate `clientId` on whichever server it
 connects to (dev → local server, staging → `dev.cloud.first-tree.ai`,
@@ -92,7 +92,7 @@ If you need to swap dev for staging without `git pull`, install staging
 side-by-side:
 
 ```bash
-npm i -g first-tree-staging
+npm i -g first-tree-staging@latest
 first-tree-staging login <staging-token>
 # now both `first-tree-dev daemon status` and `first-tree-staging daemon status` work
 ```
@@ -106,7 +106,7 @@ first-tree-staging login <staging-token>
 - **Direct `pnpm --filter ... dev`** — running parts of the system in
   isolation (server-only, web-only) where you don't need the full CLI
   surface. `tsx` runs against source.
-- **`npm i -g first-tree-staging`** — when you want to test against the
+- **`npm i -g first-tree-staging@latest`** — when you want to test against the
   exact bits that team members run. Coexists with dev install; data
   stays in `~/.first-tree-staging/`.
 

--- a/docs/onboarding-guide.md
+++ b/docs/onboarding-guide.md
@@ -15,8 +15,8 @@ everything online.
 
 ## Prerequisites
 
-- **Node.js** ≥ 22.13 (24 recommended).
-- **The CLI** — `npm install -g first-tree && first-tree --version`.
+- **Node.js** ≥ 18.14.1 (24 recommended).
+- **The CLI** — `npm install -g first-tree@latest && first-tree --version`.
 - **A connect token** — generated from the web console's *Computers → New
   Connection* dialog. The token's `iss` claim carries the server URL, so
   the CLI does not need a server flag.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -17,7 +17,7 @@ page mirrors that flow.
 ## Before you start
 
 - A **GitHub account** to sign in with.
-- **Node.js ≥ 22.13** (24 recommended) on the computer your agent will run
+- **Node.js ≥ 18.14.1** (24 recommended) on the computer your agent will run
   on. Setup installs the CLI for you, but Node must already be present.
 
 ## 1. Sign in and name your team
@@ -32,7 +32,7 @@ Your agent runs on a real machine, so the next step links one to your team.
 Copy the command the page shows and run it in a terminal on that machine:
 
 ```bash
-npm install -g first-tree
+npm install -g first-tree@latest
 first-tree login <connect-token>
 ```
 

--- a/packages/server/src/__tests__/me-multi-org.test.ts
+++ b/packages/server/src/__tests__/me-multi-org.test.ts
@@ -155,6 +155,105 @@ describe("Connect token carries iss claim", () => {
   });
 });
 
+describe("Connect token bootstrap commands", () => {
+  const getProdApp = useTestApp({ channel: "prod", commandVersion: "0.6.0" });
+  const getStagingApp = useTestApp({ channel: "staging", commandVersion: "0.6.1-staging.123.1" });
+  const getStagingWithStableFallbackApp = useTestApp({ channel: "staging", commandVersion: "0.6.0" });
+
+  it("pins the server-advertised prod CLI package version", async () => {
+    const app = getProdApp();
+    const admin = await createTestAdmin(app);
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/me/connect-tokens",
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{
+      command: string;
+      bootstrapCommand: string;
+      npmSpec: string | null;
+      binName: string;
+    }>();
+
+    expect(body.binName).toBe("first-tree");
+    expect(body.npmSpec).toBe("first-tree@0.6.0");
+    expect(body.command).toMatch(/^first-tree login /);
+    expect(body.bootstrapCommand).toBe(`npm install -g ${body.npmSpec}\n${body.command}`);
+  });
+
+  it("pins the server-advertised staging CLI package version", async () => {
+    const app = getStagingApp();
+    const admin = await createTestAdmin(app);
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/me/connect-tokens",
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{
+      command: string;
+      bootstrapCommand: string;
+      npmSpec: string | null;
+      binName: string;
+    }>();
+
+    expect(body.binName).toBe("first-tree-staging");
+    expect(body.npmSpec).toBe("first-tree-staging@0.6.1-staging.123.1");
+    expect(body.command).toMatch(/^first-tree-staging login /);
+    expect(body.bootstrapCommand).toBe(`npm install -g ${body.npmSpec}\n${body.command}`);
+  });
+
+  it("refuses a staging bootstrap command when the advertised version is not staging", async () => {
+    const app = getStagingWithStableFallbackApp();
+    const admin = await createTestAdmin(app);
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/me/connect-tokens",
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+    });
+
+    expect(res.statusCode).toBe(503);
+    expect(res.json<{ code: string; error: string }>()).toMatchObject({
+      code: "command_version_unavailable",
+    });
+    expect(res.body).not.toContain("first-tree-staging@0.6.0");
+  });
+
+  it("uses the already-validated command version snapshot for exact npm specs", async () => {
+    const app = getStagingApp();
+    const admin = await createTestAdmin(app);
+    const originalCommandVersion = app.commandVersion;
+    const versions = ["0.6.1-staging.123.1", "0.6.0"];
+    let calls = 0;
+    app.commandVersion = () => {
+      calls += 1;
+      return versions.shift() ?? "0.6.0";
+    };
+
+    try {
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/v1/me/connect-tokens",
+        headers: { authorization: `Bearer ${admin.accessToken}` },
+      });
+      expect(res.statusCode).toBe(200);
+      const body = res.json<{
+        command: string;
+        bootstrapCommand: string;
+        npmSpec: string | null;
+      }>();
+
+      expect(calls).toBe(1);
+      expect(body.npmSpec).toBe("first-tree-staging@0.6.1-staging.123.1");
+      expect(body.bootstrapCommand).toBe(`npm install -g ${body.npmSpec}\n${body.command}`);
+      expect(body.bootstrapCommand).not.toContain("first-tree-staging@0.6.0");
+    } finally {
+      app.commandVersion = originalCommandVersion;
+    }
+  });
+});
+
 describe("/me onboarding step inference", () => {
   const getApp = useTestApp();
 

--- a/packages/server/src/api/me.ts
+++ b/packages/server/src/api/me.ts
@@ -8,7 +8,7 @@ import {
   patchOnboardingSchema,
   updateMyProfileSchema,
 } from "@first-tree/shared";
-import { getChannelConfig } from "@first-tree/shared/channel";
+import { getChannelConfig, inferChannelFromVersion } from "@first-tree/shared/channel";
 import { and, eq, isNull, ne } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { z } from "zod";
@@ -388,8 +388,25 @@ export async function meRoutes(app: FastifyInstance): Promise<void> {
    * The token now carries only `sub = userId`; the CLI rejoins via
    * `exchangeConnectToken` which probes `members` realtime.
    */
-  app.post("/me/connect-tokens", async (request) => {
+  app.post("/me/connect-tokens", async (request, reply) => {
     const { userId } = requireUser(request);
+    const ch = getChannelConfig(app.config.channel);
+    const advertisedCommandVersion = app.commandVersion();
+    if (ch.packageName !== null && inferChannelFromVersion(advertisedCommandVersion) !== app.config.channel) {
+      app.log.warn(
+        {
+          channel: app.config.channel,
+          packageName: ch.packageName,
+          commandVersion: advertisedCommandVersion,
+        },
+        "Refusing to generate onboarding npm spec for channel-mismatched command version",
+      );
+      return reply.status(503).send({
+        error: "First Tree CLI install version is not ready for this deployment channel. Try again shortly.",
+        code: "command_version_unavailable",
+      });
+    }
+
     const issuer = resolvePublicUrl(app, request);
     const { token, expiresIn } = await authService.generateConnectToken(
       userId,
@@ -402,12 +419,11 @@ export async function meRoutes(app: FastifyInstance): Promise<void> {
     // install lands on the right package without web needing to know
     // about channels.
     //
-    // Multi-env: each channel is its own npm package, so the spec is
-    // always the bare package name (no `@<dist-tag>` suffix — each
-    // package has exactly one `latest`). dev servers have
-    // `packageName=null`: the bootstrap line skips the `npm install -g`
-    // step entirely because the operator builds from source.
-    const ch = getChannelConfig(app.config.channel);
+    // Multi-env: each published channel is its own npm package, and
+    // onboarding pins the server-advertised command version so npm cannot
+    // resolve an older CLI for users on lower Node versions. dev servers
+    // have `packageName=null`: the bootstrap line skips the `npm install
+    // -g` step entirely because the operator builds from source.
     const command = `${ch.binName} login ${token}`;
     if (ch.packageName === null) {
       return {
@@ -419,7 +435,7 @@ export async function meRoutes(app: FastifyInstance): Promise<void> {
         binName: ch.binName,
       };
     }
-    const npmSpec = ch.packageName;
+    const npmSpec = `${ch.packageName}@${advertisedCommandVersion}`;
     const bootstrapCommand = `npm install -g ${npmSpec}\n${command}`;
     return { token, expiresIn, command, bootstrapCommand, npmSpec, binName: ch.binName };
   });

--- a/packages/shared/src/schemas/auth.ts
+++ b/packages/shared/src/schemas/auth.ts
@@ -29,15 +29,15 @@ export const connectTokenResponseSchema = z.object({
   command: z.string(),
   /**
    * Full bootstrap line shown by web onboarding / connect-computer dialogs.
-   * For prod/staging: `npm install -g <pkg>\n<binName> login <token>`.
+   * For prod/staging: `npm install -g <pkg>@<version>\n<binName> login <token>`.
    * For dev (server has no published package): just the `<binName> login
    * <token>` line.
    */
   bootstrapCommand: z.string(),
   /**
-   * Bare npm package name (no `@<dist-tag>` suffix; multi-env each
-   * channel has its own `latest`). `null` for dev servers — the web UI
-   * suppresses the `npm install -g` step.
+   * npm install spec for the CLI package. Published channels include the
+   * exact server-advertised version; `null` for dev servers where the web
+   * UI suppresses the `npm install -g` step.
    */
   npmSpec: z.string().nullable(),
   /**

--- a/packages/web/src/api/activity.ts
+++ b/packages/web/src/api/activity.ts
@@ -126,14 +126,15 @@ export type ConnectTokenResponse = {
   /** `<binName> login <token>` — channel-aware bin name. */
   command: string;
   /**
-   * Full bootstrap line: `npm install -g <pkg>\n<binName> login <token>`
+   * Full bootstrap line: `npm install -g <pkg>@<version>\n<binName> login <token>`
    * for prod/staging; just `<binName> login <token>` for dev (no
    * published package).
    */
   bootstrapCommand: string;
   /**
-   * Bare npm package name. `null` for dev (no published package — UI
-   * suppresses the `npm install -g` step).
+   * npm install spec for the CLI package. Published channels include the
+   * exact server-advertised version; `null` for dev where the UI suppresses
+   * the `npm install -g` step.
    */
   npmSpec: string | null;
   /**

--- a/packages/web/src/components/__tests__/new-agent-dialog-extra.test.tsx
+++ b/packages/web/src/components/__tests__/new-agent-dialog-extra.test.tsx
@@ -392,7 +392,7 @@ describe("NewAgentDialog extra branches", () => {
       token: "old-token",
       expiresIn: 600,
       command: "first-tree-dev login old-token",
-      bootstrapCommand: "npm install -g first-tree-dev\nfirst-tree-dev login old-token",
+      bootstrapCommand: "first-tree-dev login old-token",
     });
 
     const container = await renderDom(
@@ -400,12 +400,9 @@ describe("NewAgentDialog extra branches", () => {
     );
 
     await waitForText(container, "No computer connected yet.");
-    await waitForText(container, "npm install -g first-tree-dev");
     await waitForText(container, "first-tree-dev login old-token");
     await click(buttonByText(document.body, "Copy"));
-    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
-      "npm install -g first-tree-dev\nfirst-tree-dev login old-token",
-    );
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("first-tree-dev login old-token");
     expect(document.body.textContent).toContain("Copied");
   });
 

--- a/packages/web/src/components/last-step-modal.tsx
+++ b/packages/web/src/components/last-step-modal.tsx
@@ -77,10 +77,10 @@ export function LastStepModal({ agent, open, onClose, onBound }: Props) {
 
   // Assemble the Last-step one-liner from the channel-aware fields the
   // server returns. The three segments, in order:
-  //   1. `npm install -g <pkg>` — bootstrap the CLI for users who've
-  //                                never run it. SKIPPED for dev servers
-  //                                (npmSpec=null) since dev installs from
-  //                                source via scripts/dev-install.sh.
+  //   1. `npm install -g <pkg>@<version>` — bootstrap the CLI for users
+  //                                who've never run it. SKIPPED for dev
+  //                                servers (npmSpec=null) since dev installs
+  //                                from source via scripts/dev-install.sh.
   //   2. `<bin> agent add`      — pure local file write, no auth/network;
   //                                the resulting `agent.yaml` is what the
   //                                runtime picks up on first load.

--- a/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
+++ b/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
@@ -747,7 +747,7 @@ function createFlowValue(overrides: Partial<OnboardingFlowValue> = {}): Onboardi
       okRuntimes: ["claude-code", "codex"],
       selectedRuntime: "claude-code",
       setSelectedRuntime: () => undefined,
-      cliCommand: "npm install -g first-tree\nfirst-tree login connect-token",
+      cliCommand: "npm install -g first-tree@0.6.0\nfirst-tree login connect-token",
       tokenError: null,
       retry: () => undefined,
     },
@@ -1234,7 +1234,7 @@ describe("page SSR smoke coverage", () => {
 
     const html = renderPage(
       <>
-        <CommandBox command="npm install -g first-tree\nfirst-tree login token" />
+        <CommandBox command="npm install -g first-tree@0.6.0\nfirst-tree login token" />
         <FlowNote tone="info">Heads up</FlowNote>
         <StatusRow state="waiting" label="Waiting now" />
         <StatusRow state="ok" label="Connected now" />

--- a/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
+++ b/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
@@ -1354,8 +1354,8 @@ describe("web DOM interaction coverage", () => {
       token: "prod-token",
       expiresIn: 600,
       command: "first-tree login prod-token",
-      bootstrapCommand: "npm install -g first-tree\nfirst-tree login prod-token",
-      npmSpec: "first-tree",
+      bootstrapCommand: "npm install -g first-tree@0.6.0\nfirst-tree login prod-token",
+      npmSpec: "first-tree@0.6.0",
       binName: "first-tree",
     });
     await renderDom(
@@ -1366,7 +1366,7 @@ describe("web DOM interaction coverage", () => {
         onBound={() => undefined}
       />,
     );
-    await waitForText("npm install -g first-tree", document.body);
+    await waitForText("npm install -g first-tree@0.6.0", document.body);
   });
 
   it("switches orgs and opens setup actions from the TeamSwitcher, and signs out from the UserMenu", async () => {

--- a/packages/web/src/pages/onboarding-preview.tsx
+++ b/packages/web/src/pages/onboarding-preview.tsx
@@ -51,7 +51,7 @@ const DEFAULT_AGENT_NAME = "gandy assistant";
 // package + bin name — `first-tree` on prod; see api/me.ts) so the gallery
 // reads true for design review instead of showing literal <package>/<binName>
 // placeholders a real user never sees.
-const SAMPLE_CLI = "npm install -g first-tree\nfirst-tree login ft_3aK9d2hQ7s_pVx1n8Wc4Lr6";
+const SAMPLE_CLI = "npm install -g first-tree@0.5.8\nfirst-tree login ft_3aK9d2hQ7s_pVx1n8Wc4Lr6";
 
 const NOW_ISO = new Date().toISOString();
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: ^0.3.187
         version: 0.3.187(@anthropic-ai/sdk@0.105.0(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)
       '@inquirer/prompts':
-        specifier: ^8.3.0
-        version: 8.3.2(@types/node@22.19.15)
+        specifier: ^6.0.1
+        version: 6.0.1
       '@openai/codex-sdk':
         specifier: ^0.140.0
         version: 0.140.0
@@ -1176,139 +1176,61 @@ packages:
     peerDependencies:
       hono: ^4
 
-  '@inquirer/ansi@2.0.4':
-    resolution: {integrity: sha512-DpcZrQObd7S0R/U3bFdkcT5ebRwbTTC4D3tCc1vsJizmgPLxNJBo+AAFmrZwe8zk30P2QzgzGWZ3Q9uJwWuhIg==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+  '@inquirer/checkbox@3.0.1':
+    resolution: {integrity: sha512-0hm2nrToWUdD6/UHnel/UKGdk1//ke5zGUpHIvk5ZWmaKezlGxZkOJXNSWsdxO/rEqTkbB3lNC2J6nBElV2aAQ==}
+    engines: {node: '>=18'}
 
-  '@inquirer/checkbox@5.1.2':
-    resolution: {integrity: sha512-PubpMPO2nJgMufkoB3P2wwxNXEMUXnBIKi/ACzDUYfaoPuM7gSTmuxJeMscoLVEsR4qqrCMf5p0SiYGWnVJ8kw==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
-    peerDependencies:
-      '@types/node': '>=18'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
+  '@inquirer/confirm@4.0.1':
+    resolution: {integrity: sha512-46yL28o2NJ9doViqOy0VDcoTzng7rAb6yPQKU7VDLqkmbCaH4JqK4yk4XqlzNWy9PVC5pG1ZUXPBQv+VqnYs2w==}
+    engines: {node: '>=18'}
 
-  '@inquirer/confirm@6.0.10':
-    resolution: {integrity: sha512-tiNyA73pgpQ0FQ7axqtoLUe4GDYjNCDcVsbgcA5anvwg2z6i+suEngLKKJrWKJolT//GFPZHwN30binDIHgSgQ==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
-    peerDependencies:
-      '@types/node': '>=18'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
+  '@inquirer/core@9.2.1':
+    resolution: {integrity: sha512-F2VBt7W/mwqEU4bL0RnHNZmC/OxzNx9cOYxHqnXX3MP6ruYvZUZAW9imgN9+h/uBT/oP8Gh888J2OZSbjSeWcg==}
+    engines: {node: '>=18'}
 
-  '@inquirer/core@11.1.7':
-    resolution: {integrity: sha512-1BiBNDk9btIwYIzNZpkikIHXWeNzNncJePPqwDyVMhXhD1ebqbpn1mKGctpoqAbzywZfdG0O4tvmsGIcOevAPQ==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
-    peerDependencies:
-      '@types/node': '>=18'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
+  '@inquirer/editor@3.0.1':
+    resolution: {integrity: sha512-VA96GPFaSOVudjKFraokEEmUQg/Lub6OXvbIEZU1SDCmBzRkHGhxoFAVaF30nyiB4m5cEbDgiI2QRacXZ2hw9Q==}
+    engines: {node: '>=18'}
 
-  '@inquirer/editor@5.0.10':
-    resolution: {integrity: sha512-VJx4XyaKea7t8hEApTw5dxeIyMtWXre2OiyJcICCRZI4hkoHsMoCnl/KbUnJJExLbH9csLLHMVR144ZhFE1CwA==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
-    peerDependencies:
-      '@types/node': '>=18'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
+  '@inquirer/expand@3.0.1':
+    resolution: {integrity: sha512-ToG8d6RIbnVpbdPdiN7BCxZGiHOTomOX94C2FaT5KOHupV40tKEDozp12res6cMIfRKrXLJyexAZhWVHgbALSQ==}
+    engines: {node: '>=18'}
 
-  '@inquirer/expand@5.0.10':
-    resolution: {integrity: sha512-fC0UHJPXsTRvY2fObiwuQYaAnHrp3aDqfwKUJSdfpgv18QUG054ezGbaRNStk/BKD5IPijeMKWej8VV8O5Q/eQ==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
-    peerDependencies:
-      '@types/node': '>=18'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
+  '@inquirer/figures@1.0.15':
+    resolution: {integrity: sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==}
+    engines: {node: '>=18'}
 
-  '@inquirer/external-editor@2.0.4':
-    resolution: {integrity: sha512-Prenuv9C1PHj2Itx0BcAOVBTonz02Hc2Nd2DbU67PdGUaqn0nPCnV34oDyyoaZHnmfRxkpuhh/u51ThkrO+RdA==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
-    peerDependencies:
-      '@types/node': '>=18'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
+  '@inquirer/input@3.0.1':
+    resolution: {integrity: sha512-BDuPBmpvi8eMCxqC5iacloWqv+5tQSJlUafYWUe31ow1BVXjW2a5qe3dh4X/Z25Wp22RwvcaLCc2siHobEOfzg==}
+    engines: {node: '>=18'}
 
-  '@inquirer/figures@2.0.4':
-    resolution: {integrity: sha512-eLBsjlS7rPS3WEhmOmh1znQ5IsQrxWzxWDxO51e4urv+iVrSnIHbq4zqJIOiyNdYLa+BVjwOtdetcQx1lWPpiQ==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+  '@inquirer/number@2.0.1':
+    resolution: {integrity: sha512-QpR8jPhRjSmlr/mD2cw3IR8HRO7lSVOnqUvQa8scv1Lsr3xoAMMworcYW3J13z3ppjBFBD2ef1Ci6AE5Qn8goQ==}
+    engines: {node: '>=18'}
 
-  '@inquirer/input@5.0.10':
-    resolution: {integrity: sha512-nvZ6qEVeX/zVtZ1dY2hTGDQpVGD3R7MYPLODPgKO8Y+RAqxkrP3i/3NwF3fZpLdaMiNuK0z2NaYIx9tPwiSegQ==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
-    peerDependencies:
-      '@types/node': '>=18'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
+  '@inquirer/password@3.0.1':
+    resolution: {integrity: sha512-haoeEPUisD1NeE2IanLOiFr4wcTXGWrBOyAyPZi1FfLJuXOzNmxCJPgUrGYKVh+Y8hfGJenIfz5Wb/DkE9KkMQ==}
+    engines: {node: '>=18'}
 
-  '@inquirer/number@4.0.10':
-    resolution: {integrity: sha512-Ht8OQstxiS3APMGjHV0aYAjRAysidWdwurWEo2i8yI5xbhOBWqizT0+MU1S2GCcuhIBg+3SgWVjEoXgfhY+XaA==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
-    peerDependencies:
-      '@types/node': '>=18'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
+  '@inquirer/prompts@6.0.1':
+    resolution: {integrity: sha512-yl43JD/86CIj3Mz5mvvLJqAOfIup7ncxfJ0Btnl0/v5TouVUyeEdcpknfgc+yMevS/48oH9WAkkw93m7otLb/A==}
+    engines: {node: '>=18'}
 
-  '@inquirer/password@5.0.10':
-    resolution: {integrity: sha512-QbNyvIE8q2GTqKLYSsA8ATG+eETo+m31DSR0+AU7x3d2FhaTWzqQek80dj3JGTo743kQc6mhBR0erMjYw5jQ0A==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
-    peerDependencies:
-      '@types/node': '>=18'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
+  '@inquirer/rawlist@3.0.1':
+    resolution: {integrity: sha512-VgRtFIwZInUzTiPLSfDXK5jLrnpkuSOh1ctfaoygKAdPqjcjKYmGh6sCY1pb0aGnCGsmhUxoqLDUAU0ud+lGXQ==}
+    engines: {node: '>=18'}
 
-  '@inquirer/prompts@8.3.2':
-    resolution: {integrity: sha512-yFroiSj2iiBFlm59amdTvAcQFvWS6ph5oKESls/uqPBect7rTU2GbjyZO2DqxMGuIwVA8z0P4K6ViPcd/cp+0w==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
-    peerDependencies:
-      '@types/node': '>=18'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
+  '@inquirer/search@2.0.1':
+    resolution: {integrity: sha512-r5hBKZk3g5MkIzLVoSgE4evypGqtOannnB3PKTG9NRZxyFRKcfzrdxXXPcoJQsxJPzvdSU2Rn7pB7lw0GCmGAg==}
+    engines: {node: '>=18'}
 
-  '@inquirer/rawlist@5.2.6':
-    resolution: {integrity: sha512-jfw0MLJ5TilNsa9zlJ6nmRM0ZFVZhhTICt4/6CU2Dv1ndY7l3sqqo1gIYZyMMDw0LvE1u1nzJNisfHEhJIxq5w==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
-    peerDependencies:
-      '@types/node': '>=18'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
+  '@inquirer/select@3.0.1':
+    resolution: {integrity: sha512-lUDGUxPhdWMkN/fHy1Lk7pF3nK1fh/gqeyWXmctefhxLYxlDsc7vsPBEpxrfVGDsVdyYJsiJoD4bJ1b623cV1Q==}
+    engines: {node: '>=18'}
 
-  '@inquirer/search@4.1.6':
-    resolution: {integrity: sha512-3/6kTRae98hhDevENScy7cdFEuURnSpM3JbBNg8yfXLw88HgTOl+neUuy/l9W0No5NzGsLVydhBzTIxZP7yChQ==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
-    peerDependencies:
-      '@types/node': '>=18'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-
-  '@inquirer/select@5.1.2':
-    resolution: {integrity: sha512-kTK8YIkHV+f02y7bWCh7E0u2/11lul5WepVTclr3UMBtBr05PgcZNWfMa7FY57ihpQFQH/spLMHTcr0rXy50tA==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
-    peerDependencies:
-      '@types/node': '>=18'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-
-  '@inquirer/type@4.0.4':
-    resolution: {integrity: sha512-PamArxO3cFJZoOzspzo6cxVlLeIftyBsZw/S9bKY5DzxqJVZgjoj1oP8d0rskKtp7sZxBycsoer1g6UeJV1BBA==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
-    peerDependencies:
-      '@types/node': '>=18'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
+  '@inquirer/type@2.0.0':
+    resolution: {integrity: sha512-XvJRx+2KR3YXyYtPUUy+qd9i7p+GO9Ko6VIIpWlBrpWwXDv8WLFeHTxz35CfQFUiBMLXlGHhGzys7lqit9gWag==}
+    engines: {node: '>=18'}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -2583,6 +2505,9 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
+  '@types/mute-stream@0.0.4':
+    resolution: {integrity: sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==}
+
   '@types/mysql@2.15.27':
     resolution: {integrity: sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==}
 
@@ -2641,6 +2566,9 @@ packages:
 
   '@types/whatwg-mimetype@3.0.2':
     resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
+  '@types/wrap-ansi@3.0.0':
+    resolution: {integrity: sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -2728,6 +2656,10 @@ packages:
 
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+
+  ansi-escapes@4.3.2:
+    resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
+    engines: {node: '>=8'}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -2953,8 +2885,8 @@ packages:
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
-  chardet@2.1.1:
-    resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
+  chardet@0.7.0:
+    resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
 
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
@@ -3371,6 +3303,10 @@ packages:
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
+  external-editor@3.1.0:
+    resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
+    engines: {node: '>=4'}
+
   fake-indexeddb@6.2.5:
     resolution: {integrity: sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==}
     engines: {node: '>=18'}
@@ -3393,17 +3329,8 @@ packages:
   fast-sha256@1.3.0:
     resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
-  fast-string-truncated-width@3.0.3:
-    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
-
-  fast-string-width@3.0.2:
-    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
-
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
-
-  fast-wrap-ansi@0.2.0:
-    resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
 
   fastify-plugin@5.1.0:
     resolution: {integrity: sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==}
@@ -3572,6 +3499,10 @@ packages:
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
+
+  iconv-lite@0.4.24:
+    resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
 
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
@@ -4041,9 +3972,9 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  mute-stream@3.0.0:
-    resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
-    engines: {node: ^20.17.0 || >=22.9.0}
+  mute-stream@1.0.0:
+    resolution: {integrity: sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
   nan@2.26.2:
     resolution: {integrity: sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==}
@@ -4102,6 +4033,10 @@ packages:
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  os-tmpdir@1.0.2:
+    resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
+    engines: {node: '>=0.10.0'}
 
   p-retry@6.2.1:
     resolution: {integrity: sha512-hEt02O4hUct5wtwg4H4KcWgDdm+l1bOaEy/hWzd8xtXB9BqxTWBBhb+2ImAtH4Cv4rPjV76xN3Zumqk3k3AhhQ==}
@@ -4697,6 +4632,10 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
+  tmp@0.0.33:
+    resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
+    engines: {node: '>=0.6.0'}
+
   tmp@0.2.5:
     resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
     engines: {node: '>=14.14'}
@@ -4764,6 +4703,10 @@ packages:
 
   tweetnacl@0.14.5:
     resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
+
+  type-fest@0.21.3:
+    resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
+    engines: {node: '>=10'}
 
   type-is@2.1.0:
     resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
@@ -4954,6 +4897,10 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  wrap-ansi@6.2.0:
+    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
+    engines: {node: '>=8'}
+
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
@@ -5005,6 +4952,10 @@ packages:
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
+
+  yoctocolors-cjs@2.1.3:
+    resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
+    engines: {node: '>=18'}
 
   zip-stream@6.0.1:
     resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
@@ -5592,124 +5543,101 @@ snapshots:
     dependencies:
       hono: 4.12.27
 
-  '@inquirer/ansi@2.0.4': {}
-
-  '@inquirer/checkbox@5.1.2(@types/node@22.19.15)':
+  '@inquirer/checkbox@3.0.1':
     dependencies:
-      '@inquirer/ansi': 2.0.4
-      '@inquirer/core': 11.1.7(@types/node@22.19.15)
-      '@inquirer/figures': 2.0.4
-      '@inquirer/type': 4.0.4(@types/node@22.19.15)
-    optionalDependencies:
-      '@types/node': 22.19.15
+      '@inquirer/core': 9.2.1
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 2.0.0
+      ansi-escapes: 4.3.2
+      yoctocolors-cjs: 2.1.3
 
-  '@inquirer/confirm@6.0.10(@types/node@22.19.15)':
+  '@inquirer/confirm@4.0.1':
     dependencies:
-      '@inquirer/core': 11.1.7(@types/node@22.19.15)
-      '@inquirer/type': 4.0.4(@types/node@22.19.15)
-    optionalDependencies:
-      '@types/node': 22.19.15
+      '@inquirer/core': 9.2.1
+      '@inquirer/type': 2.0.0
 
-  '@inquirer/core@11.1.7(@types/node@22.19.15)':
+  '@inquirer/core@9.2.1':
     dependencies:
-      '@inquirer/ansi': 2.0.4
-      '@inquirer/figures': 2.0.4
-      '@inquirer/type': 4.0.4(@types/node@22.19.15)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 2.0.0
+      '@types/mute-stream': 0.0.4
+      '@types/node': 22.19.19
+      '@types/wrap-ansi': 3.0.0
+      ansi-escapes: 4.3.2
       cli-width: 4.1.0
-      fast-wrap-ansi: 0.2.0
-      mute-stream: 3.0.0
+      mute-stream: 1.0.0
       signal-exit: 4.1.0
-    optionalDependencies:
-      '@types/node': 22.19.15
+      strip-ansi: 6.0.1
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.3
 
-  '@inquirer/editor@5.0.10(@types/node@22.19.15)':
+  '@inquirer/editor@3.0.1':
     dependencies:
-      '@inquirer/core': 11.1.7(@types/node@22.19.15)
-      '@inquirer/external-editor': 2.0.4(@types/node@22.19.15)
-      '@inquirer/type': 4.0.4(@types/node@22.19.15)
-    optionalDependencies:
-      '@types/node': 22.19.15
+      '@inquirer/core': 9.2.1
+      '@inquirer/type': 2.0.0
+      external-editor: 3.1.0
 
-  '@inquirer/expand@5.0.10(@types/node@22.19.15)':
+  '@inquirer/expand@3.0.1':
     dependencies:
-      '@inquirer/core': 11.1.7(@types/node@22.19.15)
-      '@inquirer/type': 4.0.4(@types/node@22.19.15)
-    optionalDependencies:
-      '@types/node': 22.19.15
+      '@inquirer/core': 9.2.1
+      '@inquirer/type': 2.0.0
+      yoctocolors-cjs: 2.1.3
 
-  '@inquirer/external-editor@2.0.4(@types/node@22.19.15)':
+  '@inquirer/figures@1.0.15': {}
+
+  '@inquirer/input@3.0.1':
     dependencies:
-      chardet: 2.1.1
-      iconv-lite: 0.7.2
-    optionalDependencies:
-      '@types/node': 22.19.15
+      '@inquirer/core': 9.2.1
+      '@inquirer/type': 2.0.0
 
-  '@inquirer/figures@2.0.4': {}
-
-  '@inquirer/input@5.0.10(@types/node@22.19.15)':
+  '@inquirer/number@2.0.1':
     dependencies:
-      '@inquirer/core': 11.1.7(@types/node@22.19.15)
-      '@inquirer/type': 4.0.4(@types/node@22.19.15)
-    optionalDependencies:
-      '@types/node': 22.19.15
+      '@inquirer/core': 9.2.1
+      '@inquirer/type': 2.0.0
 
-  '@inquirer/number@4.0.10(@types/node@22.19.15)':
+  '@inquirer/password@3.0.1':
     dependencies:
-      '@inquirer/core': 11.1.7(@types/node@22.19.15)
-      '@inquirer/type': 4.0.4(@types/node@22.19.15)
-    optionalDependencies:
-      '@types/node': 22.19.15
+      '@inquirer/core': 9.2.1
+      '@inquirer/type': 2.0.0
+      ansi-escapes: 4.3.2
 
-  '@inquirer/password@5.0.10(@types/node@22.19.15)':
+  '@inquirer/prompts@6.0.1':
     dependencies:
-      '@inquirer/ansi': 2.0.4
-      '@inquirer/core': 11.1.7(@types/node@22.19.15)
-      '@inquirer/type': 4.0.4(@types/node@22.19.15)
-    optionalDependencies:
-      '@types/node': 22.19.15
+      '@inquirer/checkbox': 3.0.1
+      '@inquirer/confirm': 4.0.1
+      '@inquirer/editor': 3.0.1
+      '@inquirer/expand': 3.0.1
+      '@inquirer/input': 3.0.1
+      '@inquirer/number': 2.0.1
+      '@inquirer/password': 3.0.1
+      '@inquirer/rawlist': 3.0.1
+      '@inquirer/search': 2.0.1
+      '@inquirer/select': 3.0.1
 
-  '@inquirer/prompts@8.3.2(@types/node@22.19.15)':
+  '@inquirer/rawlist@3.0.1':
     dependencies:
-      '@inquirer/checkbox': 5.1.2(@types/node@22.19.15)
-      '@inquirer/confirm': 6.0.10(@types/node@22.19.15)
-      '@inquirer/editor': 5.0.10(@types/node@22.19.15)
-      '@inquirer/expand': 5.0.10(@types/node@22.19.15)
-      '@inquirer/input': 5.0.10(@types/node@22.19.15)
-      '@inquirer/number': 4.0.10(@types/node@22.19.15)
-      '@inquirer/password': 5.0.10(@types/node@22.19.15)
-      '@inquirer/rawlist': 5.2.6(@types/node@22.19.15)
-      '@inquirer/search': 4.1.6(@types/node@22.19.15)
-      '@inquirer/select': 5.1.2(@types/node@22.19.15)
-    optionalDependencies:
-      '@types/node': 22.19.15
+      '@inquirer/core': 9.2.1
+      '@inquirer/type': 2.0.0
+      yoctocolors-cjs: 2.1.3
 
-  '@inquirer/rawlist@5.2.6(@types/node@22.19.15)':
+  '@inquirer/search@2.0.1':
     dependencies:
-      '@inquirer/core': 11.1.7(@types/node@22.19.15)
-      '@inquirer/type': 4.0.4(@types/node@22.19.15)
-    optionalDependencies:
-      '@types/node': 22.19.15
+      '@inquirer/core': 9.2.1
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 2.0.0
+      yoctocolors-cjs: 2.1.3
 
-  '@inquirer/search@4.1.6(@types/node@22.19.15)':
+  '@inquirer/select@3.0.1':
     dependencies:
-      '@inquirer/core': 11.1.7(@types/node@22.19.15)
-      '@inquirer/figures': 2.0.4
-      '@inquirer/type': 4.0.4(@types/node@22.19.15)
-    optionalDependencies:
-      '@types/node': 22.19.15
+      '@inquirer/core': 9.2.1
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 2.0.0
+      ansi-escapes: 4.3.2
+      yoctocolors-cjs: 2.1.3
 
-  '@inquirer/select@5.1.2(@types/node@22.19.15)':
+  '@inquirer/type@2.0.0':
     dependencies:
-      '@inquirer/ansi': 2.0.4
-      '@inquirer/core': 11.1.7(@types/node@22.19.15)
-      '@inquirer/figures': 2.0.4
-      '@inquirer/type': 4.0.4(@types/node@22.19.15)
-    optionalDependencies:
-      '@types/node': 22.19.15
-
-  '@inquirer/type@4.0.4(@types/node@22.19.15)':
-    optionalDependencies:
-      '@types/node': 22.19.15
+      mute-stream: 1.0.0
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -7059,6 +6987,10 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
+  '@types/mute-stream@0.0.4':
+    dependencies:
+      '@types/node': 22.19.19
+
   '@types/mysql@2.15.27':
     dependencies:
       '@types/node': 22.19.19
@@ -7126,6 +7058,8 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@types/whatwg-mimetype@3.0.2': {}
+
+  '@types/wrap-ansi@3.0.0': {}
 
   '@types/ws@8.18.1':
     dependencies:
@@ -7210,22 +7144,6 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
-
-  '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
-
   '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 3.2.4
@@ -7289,6 +7207,10 @@ snapshots:
       fast-uri: 3.1.0
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
+
+  ansi-escapes@4.3.2:
+    dependencies:
+      type-fest: 0.21.3
 
   ansi-regex@5.0.1: {}
 
@@ -7514,7 +7436,7 @@ snapshots:
 
   character-reference-invalid@2.0.1: {}
 
-  chardet@2.1.1: {}
+  chardet@0.7.0: {}
 
   check-error@2.1.3: {}
 
@@ -7894,6 +7816,12 @@ snapshots:
 
   extend@3.0.2: {}
 
+  external-editor@3.1.0:
+    dependencies:
+      chardet: 0.7.0
+      iconv-lite: 0.4.24
+      tmp: 0.0.33
+
   fake-indexeddb@6.2.5: {}
 
   fast-decode-uri-component@1.0.1: {}
@@ -7917,17 +7845,7 @@ snapshots:
 
   fast-sha256@1.3.0: {}
 
-  fast-string-truncated-width@3.0.3: {}
-
-  fast-string-width@3.0.2:
-    dependencies:
-      fast-string-truncated-width: 3.0.3
-
   fast-uri@3.1.0: {}
-
-  fast-wrap-ansi@0.2.0:
-    dependencies:
-      fast-string-width: 3.0.2
 
   fastify-plugin@5.1.0: {}
 
@@ -8149,6 +8067,10 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  iconv-lite@0.4.24:
+    dependencies:
+      safer-buffer: 2.1.2
 
   iconv-lite@0.7.2:
     dependencies:
@@ -8766,7 +8688,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  mute-stream@3.0.0: {}
+  mute-stream@1.0.0: {}
 
   nan@2.26.2:
     optional: true
@@ -8806,6 +8728,8 @@ snapshots:
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
+
+  os-tmpdir@1.0.2: {}
 
   p-retry@6.2.1:
     dependencies:
@@ -9567,6 +9491,10 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
+  tmp@0.0.33:
+    dependencies:
+      os-tmpdir: 1.0.2
+
   tmp@0.2.5: {}
 
   toad-cache@3.7.0: {}
@@ -9627,6 +9555,8 @@ snapshots:
       '@turbo/windows-arm64': 2.8.20
 
   tweetnacl@0.14.5: {}
+
+  type-fest@0.21.3: {}
 
   type-is@2.1.0:
     dependencies:
@@ -9838,7 +9768,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -9881,7 +9811,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -9976,6 +9906,12 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  wrap-ansi@6.2.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -10013,6 +9949,8 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yoctocolors-cjs@2.1.3: {}
 
   zip-stream@6.0.1:
     dependencies:


### PR DESCRIPTION
## Summary
- lower the published CLI runtime floor to Node.js >=18.14.1 while keeping the latest Claude agent SDK range
- route npm bins through a CommonJS wrapper that preflights unsupported Node versions before loading the ESM bundle
- pin onboarding install commands to exact prod/staging package versions and fail closed when the server command version does not match the deployment channel
- keep prod/staging publish bin rewrites pointed at the wrapper and add packed CLI smoke coverage for Node 18.14.1 with strict engine installs

## Companion PR
- Context Tree: https://github.com/agent-team-foundation/first-tree-context/pull/602

## Validation
- `pnpm check`
- `pnpm typecheck`
- `pnpm test --concurrency=2`
- `pnpm --filter @first-tree/server test -- me-multi-org` (server suite: 170 files / 1563 tests)
- `pnpm --filter first-tree-dev test -- bin-wrapper package-metadata prompt-core doctor-core`
- packed tarball strict smoke on Node 18.14.1 + npm 9.3.1 (`npm install --engine-strict`, `first-tree-dev --version`, `first-tree-dev --help`)
- `git diff --check`
