### PR TITLE
feat: support building a Context Tree on a personal GitHub account

### DIFF
--- a/packages/server/src/__tests__/context-tree-initialize.test.ts
+++ b/packages/server/src/__tests__/context-tree-initialize.test.ts
@@ -21,6 +21,9 @@ const ACCOUNT_LOGIN = "acme-github";
 const REPO_NAME = "acme-labs-context-tree";
 const CLONE_URL = `https://github.com/${ACCOUNT_LOGIN}/${REPO_NAME}.git`;
 const HTML_URL = `https://github.com/${ACCOUNT_LOGIN}/${REPO_NAME}`;
+const USER_LOGIN = "octocat";
+const USER_GITHUB_ID = 4242;
+const USER_REPO_CLONE_URL = `https://github.com/${USER_LOGIN}/${REPO_NAME}.git`;
 const ROOT_NODE_PATH = "NODE.md";
 const VALIDATE_TREE_WORKFLOW_PATH = ".github/workflows/validate-tree.yml";
 const VALIDATE_TREE_WORKFLOW_CONTENT = `name: Validate Context Tree
@@ -648,6 +651,213 @@ owners: [${ACCOUNT_LOGIN}]
     expect(repoCreateCalls).toBe(2);
     expect(await getOrgContextTree(app.db, admin.organizationId)).toEqual({ repo: CLONE_URL, branch: "main" });
   });
+
+  describe("personal GitHub account (User installation)", () => {
+    it("adopts an existing personal repo the installation can access, without needing a GitHub user token", async () => {
+      const app = getApp();
+      const admin = await createTestAdmin(app);
+      const installationId = await seedUserInstallation(app, admin.organizationId);
+      await renameOrg(app, admin.organizationId, "Acme Labs");
+      // No GitHub identity seeded on purpose: adopting an already-accessible repo
+      // uses only the installation token and must not require the user token.
+      let userReposCalls = 0;
+      const fetchSpy = mockFetch(async (url) => {
+        if (url === installationTokenUrl(installationId)) return installationTokenResponse();
+        if (url === repoUrl(USER_LOGIN, REPO_NAME)) return githubRepoResponse(200, { owner: USER_LOGIN });
+        if (url === userReposUrl()) {
+          userReposCalls += 1;
+          return new Response("unexpected user repo create", { status: 500 });
+        }
+        if (url === contentsUrl(USER_LOGIN, REPO_NAME, ROOT_NODE_PATH, "main")) {
+          return jsonResponse({ message: "Not Found" }, 404);
+        }
+        if (url === contentsUrl(USER_LOGIN, REPO_NAME, ROOT_NODE_PATH)) {
+          return jsonResponse({ content: { path: ROOT_NODE_PATH } }, 201);
+        }
+        if (url === contentsUrl(USER_LOGIN, REPO_NAME, VALIDATE_TREE_WORKFLOW_PATH, "main")) {
+          return jsonResponse({ message: "Not Found" }, 404);
+        }
+        if (url === contentsUrl(USER_LOGIN, REPO_NAME, VALIDATE_TREE_WORKFLOW_PATH)) {
+          return jsonResponse({ content: { path: VALIDATE_TREE_WORKFLOW_PATH } }, 201);
+        }
+        return new Response(`unexpected fetch ${url}`, { status: 500 });
+      });
+
+      const res = await initialize(app, admin);
+
+      expect(res.statusCode).toBe(201);
+      expect(userReposCalls).toBe(0);
+      expect(fetchSpy).toHaveBeenCalledTimes(6);
+      expect(await getOrgContextTree(app.db, admin.organizationId)).toEqual({
+        repo: USER_REPO_CLONE_URL,
+        branch: "main",
+      });
+    });
+
+    it("creates a personal repo with the GitHub user token when missing, verifies installation access, and persists", async () => {
+      const app = getApp();
+      const admin = await createTestAdmin(app);
+      const installationId = await seedUserInstallation(app, admin.organizationId);
+      await renameOrg(app, admin.organizationId, "Acme Labs");
+      await seedGithubIdentity(app, admin, {
+        login: USER_LOGIN,
+        accessToken: "ghu_user",
+        githubId: String(USER_GITHUB_ID),
+      });
+      let createUserRepoPayload: unknown;
+      let repoGetCalls = 0;
+      const fetchSpy = mockFetch(async (url, init) => {
+        if (url === installationTokenUrl(installationId)) return installationTokenResponse();
+        if (url === repoUrl(USER_LOGIN, REPO_NAME)) {
+          repoGetCalls += 1;
+          // 1st GET: adopt probe → missing; 2nd GET: post-create access verify → found.
+          return repoGetCalls === 1
+            ? jsonResponse({ message: "Not Found" }, 404)
+            : githubRepoResponse(200, { owner: USER_LOGIN });
+        }
+        if (url === userReposUrl()) {
+          expectAuth(init, "Bearer ghu_user");
+          createUserRepoPayload = parseJsonBody(init);
+          return githubRepoResponse(201, { owner: USER_LOGIN });
+        }
+        if (url === contentsUrl(USER_LOGIN, REPO_NAME, ROOT_NODE_PATH, "main")) {
+          return jsonResponse({ message: "Not Found" }, 404);
+        }
+        if (url === contentsUrl(USER_LOGIN, REPO_NAME, ROOT_NODE_PATH)) {
+          return jsonResponse({ content: { path: ROOT_NODE_PATH } }, 201);
+        }
+        if (url === contentsUrl(USER_LOGIN, REPO_NAME, VALIDATE_TREE_WORKFLOW_PATH, "main")) {
+          return jsonResponse({ message: "Not Found" }, 404);
+        }
+        if (url === contentsUrl(USER_LOGIN, REPO_NAME, VALIDATE_TREE_WORKFLOW_PATH)) {
+          return jsonResponse({ content: { path: VALIDATE_TREE_WORKFLOW_PATH } }, 201);
+        }
+        return new Response(`unexpected fetch ${url}`, { status: 500 });
+      });
+
+      const res = await initialize(app, admin);
+
+      expect(res.statusCode).toBe(201);
+      expect(createUserRepoPayload).toMatchObject({
+        name: REPO_NAME,
+        private: true,
+        auto_init: false,
+        description: "Acme Labs Context Tree",
+      });
+      expect(repoGetCalls).toBe(2);
+      expect(fetchSpy).toHaveBeenCalledTimes(8);
+      expect(await getOrgContextTree(app.db, admin.organizationId)).toEqual({
+        repo: USER_REPO_CLONE_URL,
+        branch: "main",
+      });
+    });
+
+    it("returns context_tree_repo_access_required when the created personal repo is still not visible to the installation", async () => {
+      const app = getApp();
+      const admin = await createTestAdmin(app);
+      const installationId = await seedUserInstallation(app, admin.organizationId);
+      await renameOrg(app, admin.organizationId, "Acme Labs");
+      await seedGithubIdentity(app, admin, {
+        login: USER_LOGIN,
+        accessToken: "ghu_user",
+        githubId: String(USER_GITHUB_ID),
+      });
+      const fetchSpy = mockFetch(async (url) => {
+        if (url === installationTokenUrl(installationId)) return installationTokenResponse();
+        if (url === repoUrl(USER_LOGIN, REPO_NAME)) return jsonResponse({ message: "Not Found" }, 404);
+        if (url === userReposUrl()) return githubRepoResponse(201, { owner: USER_LOGIN });
+        return new Response(`unexpected fetch ${url}`, { status: 500 });
+      });
+
+      const res = await initialize(app, admin);
+
+      expect(res.statusCode).toBe(409);
+      expect(res.json()).toMatchObject({ code: "context_tree_repo_access_required" });
+      expect(fetchSpy).toHaveBeenCalledTimes(4);
+      expect((await getOrgContextTree(app.db, admin.organizationId)).repo).toBeUndefined();
+    });
+
+    it("returns context_tree_repo_access_required when the personal repo already exists but the installation cannot see it", async () => {
+      const app = getApp();
+      const admin = await createTestAdmin(app);
+      const installationId = await seedUserInstallation(app, admin.organizationId);
+      await renameOrg(app, admin.organizationId, "Acme Labs");
+      await seedGithubIdentity(app, admin, {
+        login: USER_LOGIN,
+        accessToken: "ghu_user",
+        githubId: String(USER_GITHUB_ID),
+      });
+      const fetchSpy = mockFetch(async (url) => {
+        if (url === installationTokenUrl(installationId)) return installationTokenResponse();
+        if (url === repoUrl(USER_LOGIN, REPO_NAME)) return jsonResponse({ message: "Not Found" }, 404);
+        if (url === userReposUrl()) return jsonResponse({ message: "name already exists on this account" }, 422);
+        return new Response(`unexpected fetch ${url}`, { status: 500 });
+      });
+
+      const res = await initialize(app, admin);
+
+      expect(res.statusCode).toBe(409);
+      expect(res.json()).toMatchObject({ code: "context_tree_repo_access_required" });
+      expect(fetchSpy).toHaveBeenCalledTimes(3);
+      expect((await getOrgContextTree(app.db, admin.organizationId)).repo).toBeUndefined();
+    });
+
+    it("returns 503 github_user_token_required without creating a repo when the admin has no GitHub token", async () => {
+      const app = getApp();
+      const admin = await createTestAdmin(app);
+      const installationId = await seedUserInstallation(app, admin.organizationId);
+      await renameOrg(app, admin.organizationId, "Acme Labs");
+      // No GitHub identity for this admin → no usable user token.
+      let userReposCalls = 0;
+      const fetchSpy = mockFetch(async (url) => {
+        if (url === installationTokenUrl(installationId)) return installationTokenResponse();
+        if (url === repoUrl(USER_LOGIN, REPO_NAME)) return jsonResponse({ message: "Not Found" }, 404);
+        if (url === userReposUrl()) {
+          userReposCalls += 1;
+          return githubRepoResponse(201, { owner: USER_LOGIN });
+        }
+        return new Response(`unexpected fetch ${url}`, { status: 500 });
+      });
+
+      const res = await initialize(app, admin);
+
+      expect(res.statusCode).toBe(503);
+      expect(res.json()).toMatchObject({ code: "github_user_token_required" });
+      expect(userReposCalls).toBe(0);
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+      expect((await getOrgContextTree(app.db, admin.organizationId)).repo).toBeUndefined();
+    });
+
+    it("returns context_tree_repo_account_mismatch when the admin's GitHub account differs from the installation account", async () => {
+      const app = getApp();
+      const admin = await createTestAdmin(app);
+      const installationId = await seedUserInstallation(app, admin.organizationId);
+      await renameOrg(app, admin.organizationId, "Acme Labs");
+      await seedGithubIdentity(app, admin, {
+        login: "someone-else",
+        accessToken: "ghu_other",
+        githubId: "9999", // does not match USER_GITHUB_ID
+      });
+      let userReposCalls = 0;
+      const fetchSpy = mockFetch(async (url) => {
+        if (url === installationTokenUrl(installationId)) return installationTokenResponse();
+        if (url === repoUrl(USER_LOGIN, REPO_NAME)) return jsonResponse({ message: "Not Found" }, 404);
+        if (url === userReposUrl()) {
+          userReposCalls += 1;
+          return githubRepoResponse(201, { owner: USER_LOGIN });
+        }
+        return new Response(`unexpected fetch ${url}`, { status: 500 });
+      });
+
+      const res = await initialize(app, admin);
+
+      expect(res.statusCode).toBe(409);
+      expect(res.json()).toMatchObject({ code: "context_tree_repo_account_mismatch" });
+      expect(userReposCalls).toBe(0);
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+      expect((await getOrgContextTree(app.db, admin.organizationId)).repo).toBeUndefined();
+    });
+  });
 });
 
 async function initialize(app: FastifyInstance, admin: Pick<TestAdmin, "organizationId" | "accessToken">) {
@@ -675,6 +885,7 @@ async function seedInstallation(
   opts: {
     accountLogin?: string;
     accountType?: "User" | "Organization";
+    accountGithubId?: number;
     permissions?: Record<string, "read" | "write" | "admin">;
     repositoryEvents?: string[];
     suspendedAt?: string | null;
@@ -687,7 +898,7 @@ async function seedInstallation(
       id: installationId,
       accountType: opts.accountType ?? "Organization",
       accountLogin: opts.accountLogin ?? ACCOUNT_LOGIN,
-      accountGithubId: installationId + 1_000_000,
+      accountGithubId: opts.accountGithubId ?? installationId + 1_000_000,
       permissions: opts.permissions ?? { administration: "write", contents: "write", workflows: "write" },
       events: opts.repositoryEvents ?? ["push"],
       suspendedAt: opts.suspendedAt ?? null,
@@ -697,19 +908,28 @@ async function seedInstallation(
   return installationId;
 }
 
+async function seedUserInstallation(app: FastifyInstance, organizationId: string): Promise<number> {
+  return seedInstallation(app, organizationId, {
+    accountType: "User",
+    accountLogin: USER_LOGIN,
+    accountGithubId: USER_GITHUB_ID,
+  });
+}
+
 async function seedGithubIdentity(
   app: FastifyInstance,
   admin: TestAdmin,
   opts: {
     login: string;
     accessToken: string;
+    githubId?: string;
   },
 ): Promise<void> {
   await app.db.insert(authIdentities).values({
     id: uuidv7(),
     userId: admin.userId,
     provider: "github",
-    identifier: "123456",
+    identifier: opts.githubId ?? "123456",
     email: `${opts.login}@example.test`,
     verifiedAt: new Date(),
     metadata: {
@@ -778,6 +998,10 @@ function installationTokenUrl(installationId: number): string {
 
 function orgReposUrl(org: string): string {
   return `${GITHUB_API_BASE}/orgs/${encodeURIComponent(org)}/repos`;
+}
+
+function userReposUrl(): string {
+  return `${GITHUB_API_BASE}/user/repos`;
 }
 
 function repoUrl(owner: string, repo: string): string {

--- a/packages/server/src/api/orgs/context-tree.ts
+++ b/packages/server/src/api/orgs/context-tree.ts
@@ -3,15 +3,14 @@ import type { FastifyInstance, FastifyReply } from "fastify";
 import { ConflictError } from "../../errors.js";
 import { requireOrgAdmin } from "../../scope/require-org.js";
 import {
-  createOrganizationRepo,
-  createRepoFileWithToken,
-  GithubAppApiError,
-  getRepoFileWithToken,
-  getRepository,
-} from "../../services/github-app.js";
-import { findInstallationByOrg, type InstallationRow } from "../../services/github-app-installations.js";
+  ContextTreeRepoProvisionError,
+  ensureInstallationOwnedContextTreeRepo,
+} from "../../services/context-tree-repo-provisioner.js";
+import { createRepoFileWithToken, GithubAppApiError, getRepoFileWithToken } from "../../services/github-app.js";
+import { findInstallationByOrg } from "../../services/github-app-installations.js";
 import { mintContextTreeInstallationToken } from "../../services/github-app-token.js";
 import type { GithubCreatedRepo } from "../../services/github-oauth.js";
+import { GithubUserTokenError, getFreshGithubUserToken } from "../../services/github-user-token.js";
 import { getOrgContextTree, putOrgSetting } from "../../services/org-settings.js";
 import { getOrganization } from "../../services/organization.js";
 
@@ -59,12 +58,6 @@ export async function orgContextTreeRoutes(app: FastifyInstance): Promise<void> 
         code: "no_installation",
       });
     }
-    if (installation.accountType !== "Organization") {
-      return reply.status(409).send({
-        error: "One-click Context Tree initialization requires a GitHub organization installation.",
-        code: "organization_installation_required",
-      });
-    }
     if (!hasInitializationPermissions(mint.permissions)) {
       return reply.status(403).send({
         error:
@@ -88,28 +81,45 @@ export async function orgContextTreeRoutes(app: FastifyInstance): Promise<void> 
       "context tree initialize: creating or adopting github repo",
     );
 
+    const refreshConfig = app.config.oauth?.githubApp;
     let repo: GithubCreatedRepo;
     try {
-      repo = await createOrAdoptContextTreeRepo({
-        installationToken: mint.token,
+      repo = await ensureInstallationOwnedContextTreeRepo({
         installation,
+        installationToken: mint.token,
         repoName,
         teamName,
+        getUserToken: () =>
+          getFreshGithubUserToken(app.db, scope.userId, app.config.secrets.encryptionKey, refreshConfig),
       });
     } catch (err) {
-      if (err instanceof ContextTreeInitializeError) {
+      if (err instanceof ContextTreeRepoProvisionError) {
         app.log.warn(
           {
             err,
             organizationId: scope.organizationId,
             installationId: installation.installationId,
             githubAccount: installation.accountLogin,
+            accountType: installation.accountType,
             repoName,
             code: err.code,
           },
-          "context tree initialize: create or adopt github repo failed",
+          "context tree initialize: provision repo failed",
         );
         return reply.status(err.statusCode).send({ error: err.message, code: err.code });
+      }
+      if (err instanceof GithubUserTokenError) {
+        app.log.warn(
+          {
+            err: err.cause ?? err,
+            organizationId: scope.organizationId,
+            userId: scope.userId,
+            installationId: installation.installationId,
+            githubAccount: installation.accountLogin,
+          },
+          "context tree initialize: github user token unavailable",
+        );
+        return reply.status(err.statusCode).send({ error: err.message, code: "github_user_token_required" });
       }
       app.log.warn(
         {
@@ -119,7 +129,7 @@ export async function orgContextTreeRoutes(app: FastifyInstance): Promise<void> 
           githubAccount: installation.accountLogin,
           repoName,
         },
-        "context tree initialize: create or adopt github repo failed",
+        "context tree initialize: provision repo failed",
       );
       throw err;
     }
@@ -271,61 +281,6 @@ function hasInitializationPermissions(permissions: Record<string, "read" | "writ
   return (
     permissions.administration === "write" && permissions.contents === "write" && permissions.workflows === "write"
   );
-}
-
-async function createOrAdoptContextTreeRepo(input: {
-  installationToken: string;
-  installation: InstallationRow;
-  repoName: string;
-  teamName: string;
-}): Promise<GithubCreatedRepo> {
-  try {
-    const created = await createOrganizationRepo(input.installationToken, {
-      org: input.installation.accountLogin,
-      name: input.repoName,
-      private: true,
-      description: `${input.teamName} Context Tree`,
-    });
-    return await verifyCreatedRepository(input.installationToken, created.ownerLogin, created.name);
-  } catch (err) {
-    if (err instanceof GithubAppApiError && err.status === 422) {
-      return await adoptExistingRepository(input.installationToken, input.installation.accountLogin, input.repoName);
-    }
-    if (err instanceof GithubAppApiError && isRepoAccessError(err)) {
-      throw repoUnavailableError(input.installation.accountLogin, input.repoName);
-    }
-    throw mapUpstreamError(err, "Couldn't create the GitHub repo. Try again in a moment.");
-  }
-}
-
-async function verifyCreatedRepository(
-  installationToken: string,
-  owner: string,
-  repoName: string,
-): Promise<GithubCreatedRepo> {
-  try {
-    return await getRepository(installationToken, owner, repoName);
-  } catch (err) {
-    if (err instanceof GithubAppApiError && isRepoAccessError(err)) {
-      throw repoUnavailableError(owner, repoName);
-    }
-    throw mapUpstreamError(err, "Couldn't verify the created GitHub repo. Try again in a moment.");
-  }
-}
-
-async function adoptExistingRepository(
-  installationToken: string,
-  owner: string,
-  repoName: string,
-): Promise<GithubCreatedRepo> {
-  try {
-    return await getRepository(installationToken, owner, repoName);
-  } catch (err) {
-    if (err instanceof GithubAppApiError && isRepoAccessError(err)) {
-      throw repoUnavailableError(owner, repoName);
-    }
-    throw mapUpstreamError(err, "Couldn't verify the existing GitHub repo. Try again in a moment.");
-  }
 }
 
 async function ensureRepoFile(

--- a/packages/server/src/services/context-tree-repo-provisioner.ts
+++ b/packages/server/src/services/context-tree-repo-provisioner.ts
@@ -1,0 +1,223 @@
+import {
+  createOrganizationRepo,
+  GithubAppApiError,
+  getRepository,
+  verifyUserCanAdministerInstallation,
+} from "./github-app.js";
+import type { InstallationRow } from "./github-app-installations.js";
+import { createUserRepo, GithubApiError, type GithubCreatedRepo } from "./github-oauth.js";
+import type { GithubUserToken } from "./github-user-token.js";
+
+/**
+ * Owner-agnostic Context Tree repo provisioner.
+ *
+ * The First Tree-side binding is always `First Tree org -> context_tree repo`;
+ * the GitHub repo is only the storage backend, and its owner may be a GitHub
+ * `Organization` OR a personal `User`. This module is the single seam where the
+ * owner-type branching lives, so the route and the rest of onboarding stay
+ * owner-agnostic and reason purely about `owner/name` + live installation
+ * capability rather than account type.
+ *
+ * GitHub API constraint that forces the split: an organization repo can be
+ * created with the App *installation* token (`POST /orgs/{org}/repos`), but a
+ * personal repo can only be created with the App *user* token
+ * (`POST /user/repos`) — the installation token has no authority to create a
+ * repo under a user account. After a personal repo is created we re-check with
+ * the installation token, because the App can only read/write the new repo once
+ * it has been granted access (always true for an "all repositories" install, but
+ * a "selected repositories" install must add the freshly-created repo first).
+ */
+
+export class ContextTreeRepoProvisionError extends Error {
+  constructor(
+    public readonly statusCode: number,
+    public readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ContextTreeRepoProvisionError";
+  }
+}
+
+export type EnsureContextTreeRepoInput = {
+  installation: InstallationRow;
+  installationToken: string;
+  repoName: string;
+  teamName: string;
+  /**
+   * Lazily resolve the acting admin's GitHub App user token. Only invoked on the
+   * personal (User) create path: adopting an already-accessible repo, and the
+   * entire Organization path, never need it — so an admin without a usable GitHub
+   * token can still adopt an existing tree.
+   */
+  getUserToken: () => Promise<GithubUserToken>;
+};
+
+export async function ensureInstallationOwnedContextTreeRepo(
+  input: EnsureContextTreeRepoInput,
+): Promise<GithubCreatedRepo> {
+  if (input.installation.accountType === "Organization") {
+    return ensureOrganizationRepo(input);
+  }
+  return ensureUserRepo(input);
+}
+
+/**
+ * Organization storage backend — unchanged from the original org-only path:
+ * optimistically create with the installation token, fall back to adopting the
+ * deterministic repo on `422 already exists`, and persist only if the
+ * installation can actually read it.
+ */
+async function ensureOrganizationRepo(input: EnsureContextTreeRepoInput): Promise<GithubCreatedRepo> {
+  const { installationToken, installation, repoName, teamName } = input;
+  try {
+    const created = await createOrganizationRepo(installationToken, {
+      org: installation.accountLogin,
+      name: repoName,
+      private: true,
+      description: contextTreeRepoDescription(teamName),
+    });
+    return await verifyInstallationCanAccess(installationToken, created.ownerLogin, created.name);
+  } catch (err) {
+    if (err instanceof GithubAppApiError && err.status === 422) {
+      return await verifyInstallationCanAccess(installationToken, installation.accountLogin, repoName);
+    }
+    if (err instanceof GithubAppApiError && isInstallationAccessError(err)) {
+      throw repoUnavailableError(installation.accountLogin, repoName);
+    }
+    throw mapUpstreamError(err, "Couldn't create the GitHub repo. Try again in a moment.");
+  }
+}
+
+/**
+ * Personal (User) storage backend. Adopt first with the installation token;
+ * when the repo is missing, create it with the user token, then re-verify that
+ * the installation can reach the freshly-created repo before persisting.
+ */
+async function ensureUserRepo(input: EnsureContextTreeRepoInput): Promise<GithubCreatedRepo> {
+  const { installationToken, installation, repoName, teamName } = input;
+
+  // 1. Adopt: if the installation can already read the deterministic repo, use it.
+  const existing = await probeInstallationAccess(installationToken, installation.accountLogin, repoName);
+  if (existing) {
+    return existing;
+  }
+
+  // 2. Create under the user account. `POST /user/repos` creates the repo under
+  //    the *token owner*, so the acting admin must own the installation account
+  //    — otherwise the repo lands in the wrong account and this installation
+  //    could never reach it. Enforce that with the same authority rule the
+  //    install-time bind uses (a User installation short-circuits to a pure
+  //    GitHub-ID equality check, no extra API call).
+  const userToken = await input.getUserToken();
+  const ownsInstallationAccount = await verifyUserCanAdministerInstallation(
+    userToken.accessToken,
+    Number(userToken.githubId),
+    installation,
+  );
+  if (!ownsInstallationAccount) {
+    throw new ContextTreeRepoProvisionError(
+      409,
+      "context_tree_repo_account_mismatch",
+      `Your Context Tree repo must be created by the GitHub account that installed First Tree (@${installation.accountLogin}). Sign in as that account, or install First Tree on a GitHub organization.`,
+    );
+  }
+
+  try {
+    await createUserRepo(userToken.accessToken, {
+      name: repoName,
+      private: true,
+      description: contextTreeRepoDescription(teamName),
+    });
+  } catch (err) {
+    if (err instanceof GithubApiError && err.status === 422) {
+      // The repo already exists but the installation couldn't see it at step 1,
+      // so the App still needs to be granted access to it.
+      throw repoAccessRequiredError(installation.accountLogin, repoName);
+    }
+    if (err instanceof GithubApiError && (err.status === 401 || err.status === 403)) {
+      throw new ContextTreeRepoProvisionError(
+        403,
+        "github_user_token_required",
+        "GitHub wouldn't let First Tree create your Context Tree repo with the current authorization. Reconnect GitHub, then try again.",
+      );
+    }
+    throw mapUpstreamError(err, "Couldn't create your Context Tree repo on GitHub. Try again in a moment.");
+  }
+
+  // 3. The App can only read/write the new repo once it has been granted access
+  //    (a "selected repositories" install does not auto-include a new repo).
+  const created = await probeInstallationAccess(installationToken, installation.accountLogin, repoName);
+  if (!created) {
+    throw repoAccessRequiredError(installation.accountLogin, repoName);
+  }
+  return created;
+}
+
+/** Read the repo with the installation token; throw `repo_unavailable` if the App can't reach it. */
+async function verifyInstallationCanAccess(
+  installationToken: string,
+  owner: string,
+  repoName: string,
+): Promise<GithubCreatedRepo> {
+  try {
+    return await getRepository(installationToken, owner, repoName);
+  } catch (err) {
+    if (err instanceof GithubAppApiError && isInstallationAccessError(err)) {
+      throw repoUnavailableError(owner, repoName);
+    }
+    throw mapUpstreamError(err, "Couldn't verify the GitHub repo. Try again in a moment.");
+  }
+}
+
+/**
+ * Read the repo with the installation token; return `null` when the App simply
+ * can't see it (403/404) so the caller can decide whether that means "create it"
+ * (adopt probe) or "grant access and retry" (post-create verify). Other failures
+ * (5xx / auth) surface as upstream errors.
+ */
+async function probeInstallationAccess(
+  installationToken: string,
+  owner: string,
+  repoName: string,
+): Promise<GithubCreatedRepo | null> {
+  try {
+    return await getRepository(installationToken, owner, repoName);
+  } catch (err) {
+    if (err instanceof GithubAppApiError && isInstallationAccessError(err)) {
+      return null;
+    }
+    throw mapUpstreamError(err, "Couldn't reach GitHub to check your Context Tree repo. Try again in a moment.");
+  }
+}
+
+function isInstallationAccessError(err: GithubAppApiError): boolean {
+  return err.status === 403 || err.status === 404;
+}
+
+function repoUnavailableError(owner: string, repoName: string): ContextTreeRepoProvisionError {
+  return new ContextTreeRepoProvisionError(
+    409,
+    "repo_unavailable",
+    `GitHub repo ${owner}/${repoName} is not accessible to this team's GitHub App installation.`,
+  );
+}
+
+function repoAccessRequiredError(owner: string, repoName: string): ContextTreeRepoProvisionError {
+  return new ContextTreeRepoProvisionError(
+    409,
+    "context_tree_repo_access_required",
+    `GitHub repo ${owner}/${repoName} exists, but First Tree's GitHub App can't access it yet. Grant the App access to the repo on GitHub, then try again.`,
+  );
+}
+
+function mapUpstreamError(err: unknown, message: string): ContextTreeRepoProvisionError {
+  if (err instanceof ContextTreeRepoProvisionError) {
+    return err;
+  }
+  return new ContextTreeRepoProvisionError(502, "upstream", message);
+}
+
+function contextTreeRepoDescription(teamName: string): string {
+  return `${teamName} Context Tree`;
+}

--- a/packages/web/src/pages/onboarding/__tests__/provision-tree.test.ts
+++ b/packages/web/src/pages/onboarding/__tests__/provision-tree.test.ts
@@ -51,8 +51,10 @@ describe("provisionNewTree", () => {
     await expect(provisionNewTree("org-1")).resolves.toBeUndefined();
   });
 
-  it("re-throws a 409 when no tree was created (e.g. org installation required)", async () => {
-    mocks.initializeContextTree.mockRejectedValue(new ApiError(409, "requires a GitHub organization installation"));
+  it("re-throws a 409 when no tree was created (e.g. repo access required)", async () => {
+    mocks.initializeContextTree.mockRejectedValue(
+      new ApiError(409, "repo access required", undefined, "context_tree_repo_access_required"),
+    );
     mocks.getContextTreeSetting.mockResolvedValue({ repo: null, branch: null });
     await expect(provisionNewTree("org-1")).rejects.toBeInstanceOf(ApiError);
   });
@@ -134,15 +136,19 @@ describe("repoLabel", () => {
 describe("kickoffErrorMessage", () => {
   it("maps a known provisioning code to a plain message (not the raw server string)", () => {
     const msg = kickoffErrorMessage(
-      new ApiError(409, "administration: write and contents: write", undefined, "organization_installation_required"),
+      new ApiError(409, "GitHub repo octocat/team-context-tree exists", undefined, "context_tree_repo_access_required"),
       "fallback",
     );
-    expect(msg).toMatch(/GitHub organization/);
-    expect(msg).not.toMatch(/administration: write/);
+    expect(msg).toMatch(/Grant the App access/i);
+    expect(msg).not.toMatch(/octocat\/team-context-tree/);
     // repo_unavailable (repo create/access denied by the App installation) is mapped too.
     expect(kickoffErrorMessage(new ApiError(409, "not accessible", undefined, "repo_unavailable"), "fallback")).toMatch(
       /couldn't create or access/,
     );
+    // A missing/expired GitHub user token maps to a "reconnect GitHub" message.
+    expect(
+      kickoffErrorMessage(new ApiError(503, "token", undefined, "github_user_token_required"), "fallback"),
+    ).toMatch(/Reconnect GitHub/);
   });
   it("falls back for an ApiError with an unknown / missing code (never leaks the server string)", () => {
     expect(kickoffErrorMessage(new ApiError(500, "internal detail"), "fallback")).toBe("fallback");

--- a/packages/web/src/pages/onboarding/copy.ts
+++ b/packages/web/src/pages/onboarding/copy.ts
@@ -406,8 +406,12 @@ export const COPY = {
    * that code; an unmapped code falls back to the generic chat-failed message.
    */
   provisionErrors: {
-    organization_installation_required:
-      "First Tree is connected to a personal GitHub account, but a team Context Tree needs a GitHub organization. Connect First Tree to an org, then try again.",
+    context_tree_repo_access_required:
+      "First Tree's GitHub App can't access your team's Context Tree repo yet. Grant the App access to the repo on GitHub, then try again.",
+    context_tree_repo_account_mismatch:
+      "Your Context Tree repo must be created by the GitHub account that installed First Tree. Sign in as that account, or install First Tree on a GitHub organization.",
+    github_user_token_required:
+      "First Tree needs access to your GitHub account to create your team's Context Tree repo. Reconnect GitHub, then try again.",
     installation_permissions_insufficient:
       "First Tree's GitHub App is missing permissions it needs to create your team's tree. Update its access on GitHub, then try again.",
     no_installation: "GitHub isn't connected for your team yet. Connect it first, then try again.",

--- a/packages/web/src/pages/onboarding/provision-tree.ts
+++ b/packages/web/src/pages/onboarding/provision-tree.ts
@@ -8,7 +8,7 @@ import { COPY } from "./copy.js";
 /**
  * Turn a kickoff failure into a message worth showing the user. Context Tree
  * provisioning errors arrive as an `ApiError` carrying the server's machine
- * `code` (organization_installation_required, installation_permissions_insufficient,
+ * `code` (context_tree_repo_access_required, installation_permissions_insufficient,
  * …); map those to plain language with a way forward rather than leaking the raw
  * server string. Our own thrown Errors (e.g. `ensureSourceReposRegistered`)
  * already carry a friendly message, so surface those as-is; an unmapped ApiError
@@ -57,7 +57,7 @@ function repoKey(url: string): string {
  * A `409` from the initializer is ambiguous — it can mean the tree is **already
  * provisioned** (a detect→create race, or a retry after a later kickoff step
  * failed) OR that **no tree could be created** (the merged initializer also
- * returns 409 for `organization_installation_required` / `repo_unavailable`).
+ * returns 409 for `context_tree_repo_access_required` / `repo_unavailable`).
  * We distinguish by the **actual binding
  * state** rather than the status code (the "already configured" conflict
  * carries no discriminating `code`): if a tree now exists, provisioning


### PR DESCRIPTION
## Why

The Context Tree initializer hard-required a GitHub **Organization** installation. A user who installed the First Tree GitHub App on their **personal account** could finish connect + repo selection, then hit `409 organization_installation_required` at build time with no way forward. Walking the whole flow only to fail at the end is the bug.

## What

Make Context Tree **storage owner-agnostic**. The First Tree binding stays `First Tree org → context_tree repo`; the GitHub repo is only the storage backend, and its owner may be a `User` **or** an `Organization`. Personal accounts are a first-class storage owner, not a special case.

### Server
- New `services/context-tree-repo-provisioner.ts` — `ensureInstallationOwnedContextTreeRepo(...)`, the single seam where owner-type branching lives. The route no longer reasons about account type.
  - **Organization** (unchanged): create with the installation token (`POST /orgs/{org}/repos`), `422 → adopt`, persist only if the installation can read it.
  - **User**: adopt an installation-accessible repo first; if missing, create it with the acting admin's GitHub App **user token** (`POST /user/repos`), then **re-verify** the installation token can reach the new repo before persisting.
- **Account-identity guard:** `POST /user/repos` creates under the *token owner*, so the acting admin must own the installation account. Enforced with the existing `verifyUserCanAdministerInstallation` authority primitive (the same rule the install-time bind uses) — prevents creating the repo under the wrong account when a different org admin triggers init.
- Removed the org-only `409` guard. New owner-agnostic, **recoverable** error codes, all fail-stop **before** persisting the binding:
  - `context_tree_repo_access_required` — repo exists/created but the App can't access it yet → grant the App access on GitHub, then retry (covers "selected repositories" installs).
  - `context_tree_repo_account_mismatch` — acting admin's GitHub account ≠ installation account.
  - `github_user_token_required` — no usable GitHub user token → reconnect GitHub.

### Web
- Dropped the personal-account block copy; added recovery copy for the new codes. The centralized `kickoffErrorMessage` mapping surfaces them in **both** onboarding kickoff and the `/build-tree` recovery page — no extra wiring.

## GitHub API constraint

Org repos can be created with the App **installation** token; a personal repo can only be created with the App **user** token (the installation token has no authority to create a repo under a user account). That is why the provisioner branches on auth mode internally — necessary complexity, not scattered `if accountType` logic.
- https://docs.github.com/en/rest/repos/repos#create-an-organization-repository
- https://docs.github.com/en/rest/repos/repos#create-a-repository-for-the-authenticated-user

## Testing

- `context-tree-initialize.test.ts`: +6 User-installation cases (adopt accessible repo with no user token; create-when-missing + verify; created-but-not-accessible → `context_tree_repo_access_required`; exists-but-not-accessible `422` → same; no user token → `github_user_token_required`; account mismatch). Organization-path behavior unchanged.
- `provision-tree.test.ts`: updated to the new codes.
- Full suites green: **server 1565**, **web 997**; server + web typecheck, design-token lint, and biome all clean.

## Security

The user token is the acting admin's own GitHub App user token, used only to create a repo under their own account (gated by the account-identity guard). `findInstallationByOrg` filters strictly by `hubOrganizationId`, so the provisioner only ever sees this org's bound installation; the existing "no cross-org user-token fallback" guarantee is preserved. All failures fail-stop before persisting `context_tree`.

## Not in scope / follow-up

- Context Tree tree-write for the owner-agnostic storage decision: agent-team-foundation/first-tree-context#603.
- Merge gated on explicit go + runtime E2E.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
