### PR TITLE
refactor(web): declutter Settings → GitHub connected card

### DIFF
--- a/packages/web/src/app.tsx
+++ b/packages/web/src/app.tsx
@@ -121,6 +121,12 @@ const TeamSwitcherPreviewPage = import.meta.env.DEV
     )
   : null;
 
+const SettingsGithubPreviewPage = import.meta.env.DEV
+  ? lazy(() =>
+      import("./pages/settings-github-preview.js").then((module) => ({ default: module.SettingsGithubPreviewPage })),
+    )
+  : null;
+
 // Living design-system reference (companion to DESIGN.md). Unlike the previews
 // above this ships in prod too, so it can be opened on a deployed URL — it has
 // no auth-gated data, only tokens and `components/ui` primitives.
@@ -250,6 +256,16 @@ export function App() {
                   element={
                     <Suspense fallback={null}>
                       <ChatSummaryPreviewPage />
+                    </Suspense>
+                  }
+                />
+              ) : null}
+              {SettingsGithubPreviewPage ? (
+                <Route
+                  path="/preview/settings-github"
+                  element={
+                    <Suspense fallback={null}>
+                      <SettingsGithubPreviewPage />
                     </Suspense>
                   }
                 />

--- a/packages/web/src/pages/__tests__/github-app-installation-panel-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/github-app-installation-panel-dom.test.tsx
@@ -110,7 +110,7 @@ afterEach(() => {
 });
 
 describe("GithubAppInstallationPanel", () => {
-  it("renders bound installation metadata including suspended state", async () => {
+  it("renders bound installation; connection details collapsed until expanded", async () => {
     githubMocks.getGithubAppInstallation.mockResolvedValueOnce(
       installation({ accountType: "User", accountLogin: "octocat", suspended: true }),
     );
@@ -120,14 +120,26 @@ describe("GithubAppInstallationPanel", () => {
     await waitForText(container, "Connected as");
     expect(container.textContent).toContain("octocat");
     expect(container.textContent).toContain("User");
-    expect(container.textContent).toContain("contents:");
-    expect(container.textContent).toContain("issues:");
-    expect(container.textContent).toContain("pull_request");
-    expect(container.textContent).toContain(`Installation ${"#"}123`);
     expect(container.textContent).toContain("suspended upstream");
     expect(container.querySelector<HTMLAnchorElement>("a")?.href).toBe(
       "https://github.com/organizations/acme/settings/installations/123",
     );
+
+    // The developer-facing metadata (scopes, events, installation id) lives
+    // behind a collapsed "Connection details" disclosure — not mounted until
+    // the admin opens it.
+    const detailsToggle = buttonByText(container, "Connection details");
+    expect(detailsToggle?.getAttribute("aria-expanded")).toBe("false");
+    expect(container.textContent).not.toContain("contents:");
+    expect(container.textContent).not.toContain(`Installation ${"#"}123`);
+
+    await click(detailsToggle);
+
+    expect(detailsToggle?.getAttribute("aria-expanded")).toBe("true");
+    expect(container.textContent).toContain("contents:");
+    expect(container.textContent).toContain("issues:");
+    expect(container.textContent).toContain("pull_request");
+    expect(container.textContent).toContain(`Installation ${"#"}123`);
 
     await act(async () => root.unmount());
   });

--- a/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
+++ b/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
@@ -1340,7 +1340,7 @@ describe("page SSR smoke coverage", () => {
         />,
       ),
     ).toContain("Join Acme");
-    expect(renderPage(<GithubAppInstallationPanel />)).toContain("GitHub App");
+    expect(renderPage(<GithubAppInstallationPanel />)).toContain("Connected as");
     expect(renderPage(<ContextTreeSettingsPanel />)).toContain("Repository");
     expect(renderPage(<UserMenu />)).toContain("user-menu");
     expect(() => renderPage(<TeamSetupModal action="create" onClose={() => undefined} />)).not.toThrow();

--- a/packages/web/src/pages/github-app-installation-panel.tsx
+++ b/packages/web/src/pages/github-app-installation-panel.tsx
@@ -1,13 +1,15 @@
 import type { GithubAppInstallationOutput } from "@first-tree/shared";
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { Building2, ExternalLink, PauseCircle, User } from "lucide-react";
+import { Building2, ChevronRight, ExternalLink, PauseCircle, User } from "lucide-react";
+import { useState } from "react";
 import { ApiError } from "../api/client.js";
 import { getGithubAppInstallation, getGithubAppInstallUrl } from "../api/github-app.js";
 import { useAuth } from "../auth/auth-context.js";
-import { Section } from "../components/ui/section.js";
 
 /**
- * Settings → Integrations panel for the GitHub App installation.
+ * Settings → GitHub panel for the GitHub App installation. The page header
+ * (`settings/github.tsx`) already titles the surface "GitHub", so this panel
+ * stays untitled — a single hairline rule under the header opens it.
  *
  * Three visible states:
  *
@@ -15,9 +17,12 @@ import { Section } from "../components/ui/section.js";
  *   - **Not bound**   — 404 from the admin API. Renders an "Install on
  *                       GitHub" CTA that triggers the OAuth + install
  *                       redirect via `/auth/github/start`.
- *   - **Bound**       — shows account login + type + permissions block +
- *                       subscribed events + a "Manage on GitHub" link
- *                       that opens the right per-account-type URL.
+ *   - **Bound**       — account login + type and a "Manage on GitHub" link.
+ *                       The granted permissions, subscribed events, and
+ *                       installation id are tucked behind a collapsed
+ *                       "Connection details" disclosure — present for the
+ *                       admin who wants to audit scope, out of the way by
+ *                       default.
  *
  * Suspended installations get a prominent "suspended upstream" banner —
  * webhook delivery is paused on GitHub's side and the binding is
@@ -32,29 +37,30 @@ export function GithubAppInstallationPanel() {
     enabled: !!organizationId,
   });
 
-  return (
-    <Section
-      title="GitHub App"
-      description="One installation unlocks user sign-in, webhook ingestion, and (later) server-side write access."
-    >
-      {installationQuery.isLoading ? (
-        <div className="text-body" style={{ color: "var(--fg-3)" }}>
-          Loading…
-        </div>
-      ) : installationQuery.error ? (
-        <div className="text-body" style={{ color: "var(--state-error)" }}>
-          {installationQuery.error instanceof Error ? installationQuery.error.message : "Failed to load installation"}
-        </div>
-      ) : installationQuery.data == null ? (
-        // `null` (404 — no install bound) and `undefined` (query disabled
-        // because organizationId hasn't loaded) both render the empty
-        // state; the loading branch above already caught the in-flight case.
-        <NotInstalledState organizationId={organizationId} />
-      ) : (
-        <InstalledState data={installationQuery.data} />
-      )}
-    </Section>
-  );
+  // Only the bound card draws a top hairline (it anchors "Connected as"); the
+  // loading / error / not-installed states sit flush under the page header so
+  // the rule never floats above an unheadinged CTA or spinner.
+  if (installationQuery.isLoading) {
+    return (
+      <div className="text-body" style={{ color: "var(--fg-3)" }}>
+        Loading…
+      </div>
+    );
+  }
+  if (installationQuery.error) {
+    return (
+      <div className="text-body" style={{ color: "var(--state-error)" }}>
+        {installationQuery.error instanceof Error ? installationQuery.error.message : "Failed to load installation"}
+      </div>
+    );
+  }
+  // `null` (404 — no install bound) and `undefined` (query disabled because
+  // organizationId hasn't loaded) both render the empty state; the loading
+  // branch above already caught the in-flight case.
+  if (installationQuery.data == null) {
+    return <NotInstalledState organizationId={organizationId} />;
+  }
+  return <InstalledState data={installationQuery.data} />;
 }
 
 function NotInstalledState({ organizationId }: { organizationId: string | null }) {
@@ -137,9 +143,16 @@ function NotInstalledState({ organizationId }: { organizationId: string | null }
 
 function InstalledState({ data }: { data: GithubAppInstallationOutput }) {
   const AccountIcon = data.accountType === "Organization" ? Building2 : User;
-  const permissionEntries = Object.entries(data.permissions);
   return (
-    <div style={{ display: "flex", flexDirection: "column", gap: "var(--sp-4)" }}>
+    <div
+      style={{
+        borderTop: "var(--hairline) solid var(--border)",
+        paddingTop: "var(--sp-4)",
+        display: "flex",
+        flexDirection: "column",
+        gap: "var(--sp-4)",
+      }}
+    >
       {data.suspended && <SuspendedBanner />}
 
       <div>
@@ -165,44 +178,7 @@ function InstalledState({ data }: { data: GithubAppInstallationOutput }) {
         </div>
       </div>
 
-      {permissionEntries.length > 0 && (
-        <div>
-          <div className="text-label" style={{ color: "var(--fg-3)", marginBottom: "var(--sp-1)" }}>
-            Permissions granted
-          </div>
-          <ul
-            className="text-body"
-            style={{
-              listStyle: "none",
-              padding: 0,
-              margin: 0,
-              display: "grid",
-              gridTemplateColumns: "1fr 1fr",
-              gap: "var(--sp-1)",
-              color: "var(--fg-2)",
-            }}
-          >
-            {permissionEntries.map(([key, value]) => (
-              <li key={key} className="mono">
-                {key}: <strong style={{ color: "var(--fg)" }}>{value}</strong>
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
-
-      {data.events.length > 0 && (
-        <div>
-          <div className="text-label" style={{ color: "var(--fg-3)", marginBottom: "var(--sp-1)" }}>
-            Subscribed events
-          </div>
-          <div className="text-body mono" style={{ color: "var(--fg-2)" }}>
-            {data.events.join(", ")}
-          </div>
-        </div>
-      )}
-
-      <div className="flex items-center" style={{ gap: "var(--sp-2)" }}>
+      <div>
         <a
           href={data.manageUrl}
           target="_blank"
@@ -220,10 +196,99 @@ function InstalledState({ data }: { data: GithubAppInstallationOutput }) {
           Manage on GitHub
           <ExternalLink className="h-3 w-3" />
         </a>
-        <span className="text-label" style={{ color: "var(--fg-3)" }}>
-          Installation #{data.installationId}
-        </span>
       </div>
+
+      <ConnectionDetails data={data} />
+    </div>
+  );
+}
+
+/**
+ * Collapsed-by-default disclosure for the developer-facing connection
+ * metadata: the granted permission scopes, the subscribed webhook events,
+ * and the installation id. Kept off the default view (most admins only need
+ * "who's connected" + Manage) but one click away for scope auditing. A plain
+ * `aria-expanded` button — there's no shared collapsible primitive in this app,
+ * and the controlled toggle keeps the chevron and the mounted content in
+ * lockstep.
+ */
+function ConnectionDetails({ data }: { data: GithubAppInstallationOutput }) {
+  const [open, setOpen] = useState(false);
+  const permissionEntries = Object.entries(data.permissions);
+  const regionId = "github-connection-details";
+
+  return (
+    <div style={{ borderTop: "var(--hairline) solid var(--border)", paddingTop: "var(--sp-3)" }}>
+      <button
+        type="button"
+        onClick={() => setOpen((value) => !value)}
+        aria-expanded={open}
+        aria-controls={open ? regionId : undefined}
+        className="inline-flex items-center text-label"
+        style={{
+          gap: "var(--sp-1)",
+          color: "var(--fg-3)",
+          background: "transparent",
+          border: "none",
+          padding: 0,
+          cursor: "pointer",
+        }}
+      >
+        <ChevronRight
+          aria-hidden
+          className="h-3 w-3 transition-transform"
+          style={{ transform: open ? "rotate(90deg)" : "none" }}
+        />
+        Connection details
+      </button>
+
+      {open && (
+        <div
+          id={regionId}
+          style={{ display: "flex", flexDirection: "column", gap: "var(--sp-3)", marginTop: "var(--sp-3)" }}
+        >
+          {permissionEntries.length > 0 && (
+            <div>
+              <div className="text-label" style={{ color: "var(--fg-3)", marginBottom: "var(--sp-1)" }}>
+                Permissions granted
+              </div>
+              <ul
+                className="text-body"
+                style={{
+                  listStyle: "none",
+                  padding: 0,
+                  margin: 0,
+                  display: "grid",
+                  gridTemplateColumns: "1fr 1fr",
+                  gap: "var(--sp-1)",
+                  color: "var(--fg-2)",
+                }}
+              >
+                {permissionEntries.map(([key, value]) => (
+                  <li key={key} className="mono">
+                    {key}: <strong style={{ color: "var(--fg)" }}>{value}</strong>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {data.events.length > 0 && (
+            <div>
+              <div className="text-label" style={{ color: "var(--fg-3)", marginBottom: "var(--sp-1)" }}>
+                Subscribed events
+              </div>
+              <div className="text-body mono" style={{ color: "var(--fg-2)" }}>
+                {data.events.join(", ")}
+              </div>
+            </div>
+          )}
+
+          <span className="text-label" style={{ color: "var(--fg-3)" }}>
+            Installation #{data.installationId}
+          </span>
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/web/src/pages/settings-github-preview.tsx
+++ b/packages/web/src/pages/settings-github-preview.tsx
@@ -1,0 +1,327 @@
+import { Building2, ChevronRight, ExternalLink, PauseCircle, User } from "lucide-react";
+import { useState } from "react";
+import { PageHeader } from "../components/ui/page-header.js";
+
+/**
+ * DEV-only visual review for Settings → GitHub (the connected GitHub App
+ * card). No backend / no auth — same gating as the other `/preview/*`
+ * routes (DEV-only in `app.tsx`).
+ *
+ * Mirrors the shipped layout of `github-app-installation-panel.tsx` so the
+ * states can be eyeballed without a live install:
+ *
+ *   - **Connected (collapsed)** — the default: who's connected + Manage on
+ *     GitHub. Permissions / events / installation id sit behind a closed
+ *     "Connection details" disclosure.
+ *   - **Connected (expanded)**  — the same card with the disclosure open.
+ *   - **Suspended**             — the suspended-upstream banner above the card.
+ *   - **Not installed**         — the "Install on GitHub" CTA.
+ *   - **Loading**               — the initial fetch state.
+ *
+ * Only the bound card draws a top hairline; the not-installed / loading states
+ * sit flush under the page header (matching the real panel). The markup here
+ * is a faithful copy of the real panel's; keep them in sync.
+ */
+
+const MOCK = {
+  accountLogin: "agent-team-foundation",
+  accountType: "Organization" as const,
+  permissions: {
+    issues: "read",
+    members: "read",
+    metadata: "read",
+    actions: "write",
+    contents: "write",
+    pull_requests: "read",
+    administration: "write",
+  } as Record<string, string>,
+  events: ["issues", "issue_comment", "member", "pull_request", "pull_request_review", "push"],
+  manageUrl: "https://github.com/organizations/agent-team-foundation/settings/installations/131952074",
+  installationId: 131952074,
+};
+
+const AccountIcon = MOCK.accountType === "Organization" ? Building2 : User;
+
+function SuspendedBanner() {
+  return (
+    <div
+      className="flex items-start text-body"
+      style={{
+        gap: "var(--sp-2)",
+        padding: "var(--sp-2) var(--sp-2_5)",
+        background: "var(--color-warn-soft)",
+        borderRadius: "var(--radius-input)",
+        color: "var(--color-warn)",
+      }}
+    >
+      <PauseCircle className="h-4 w-4 shrink-0" style={{ marginTop: "var(--sp-0_5)" }} />
+      <span>
+        This installation is suspended upstream. GitHub is not delivering webhooks and First Tree can't act as the App
+        on this account. Unsuspend it from the GitHub side to restore service.
+      </span>
+    </div>
+  );
+}
+
+function ConnectionDetails({ defaultOpen = false }: { defaultOpen?: boolean }) {
+  const [open, setOpen] = useState(defaultOpen);
+  const permissionEntries = Object.entries(MOCK.permissions);
+  const regionId = "github-connection-details";
+
+  return (
+    <div style={{ borderTop: "var(--hairline) solid var(--border)", paddingTop: "var(--sp-3)" }}>
+      <button
+        type="button"
+        onClick={() => setOpen((value) => !value)}
+        aria-expanded={open}
+        aria-controls={open ? regionId : undefined}
+        className="inline-flex items-center text-label"
+        style={{
+          gap: "var(--sp-1)",
+          color: "var(--fg-3)",
+          background: "transparent",
+          border: "none",
+          padding: 0,
+          cursor: "pointer",
+        }}
+      >
+        <ChevronRight
+          aria-hidden
+          className="h-3 w-3 transition-transform"
+          style={{ transform: open ? "rotate(90deg)" : "none" }}
+        />
+        Connection details
+      </button>
+
+      {open && (
+        <div
+          id={regionId}
+          style={{ display: "flex", flexDirection: "column", gap: "var(--sp-3)", marginTop: "var(--sp-3)" }}
+        >
+          {permissionEntries.length > 0 && (
+            <div>
+              <div className="text-label" style={{ color: "var(--fg-3)", marginBottom: "var(--sp-1)" }}>
+                Permissions granted
+              </div>
+              <ul
+                className="text-body"
+                style={{
+                  listStyle: "none",
+                  padding: 0,
+                  margin: 0,
+                  display: "grid",
+                  gridTemplateColumns: "1fr 1fr",
+                  gap: "var(--sp-1)",
+                  color: "var(--fg-2)",
+                }}
+              >
+                {permissionEntries.map(([key, value]) => (
+                  <li key={key} className="mono">
+                    {key}: <strong style={{ color: "var(--fg)" }}>{value}</strong>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {MOCK.events.length > 0 && (
+            <div>
+              <div className="text-label" style={{ color: "var(--fg-3)", marginBottom: "var(--sp-1)" }}>
+                Subscribed events
+              </div>
+              <div className="text-body mono" style={{ color: "var(--fg-2)" }}>
+                {MOCK.events.join(", ")}
+              </div>
+            </div>
+          )}
+          <span className="text-label" style={{ color: "var(--fg-3)" }}>
+            Installation #{MOCK.installationId}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** PageHeader + content padding — the shell every state renders inside. */
+function PageShell({ children }: { children: React.ReactNode }) {
+  return (
+    <div>
+      <PageHeader title="GitHub" subtitle="Connected GitHub App" />
+      <div style={{ padding: "var(--sp-2) var(--sp-5) var(--sp-7)" }}>{children}</div>
+    </div>
+  );
+}
+
+function InstalledCard({ suspended = false, detailsOpen = false }: { suspended?: boolean; detailsOpen?: boolean }) {
+  return (
+    <PageShell>
+      <div
+        style={{
+          borderTop: "var(--hairline) solid var(--border)",
+          paddingTop: "var(--sp-4)",
+          display: "flex",
+          flexDirection: "column",
+          gap: "var(--sp-4)",
+        }}
+      >
+        {suspended && <SuspendedBanner />}
+        <div>
+          <div className="text-label" style={{ color: "var(--fg-3)", marginBottom: "var(--sp-1)" }}>
+            Connected as
+          </div>
+          <div className="flex items-center" style={{ gap: "var(--sp-2)" }}>
+            <AccountIcon className="h-4 w-4" style={{ color: "var(--fg-2)" }} />
+            <span className="text-body font-medium" style={{ color: "var(--fg)" }}>
+              {MOCK.accountLogin}
+            </span>
+            <span
+              className="text-label"
+              style={{
+                padding: "var(--sp-0_5) var(--sp-1_5)",
+                background: "var(--bg-sunken)",
+                borderRadius: "var(--radius-input)",
+                color: "var(--fg-3)",
+              }}
+            >
+              {MOCK.accountType}
+            </span>
+          </div>
+        </div>
+        <div>
+          <a
+            href={MOCK.manageUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center text-body"
+            style={{
+              gap: "var(--sp-1)",
+              padding: "var(--sp-1_5) var(--sp-2_5)",
+              border: "var(--hairline) solid var(--border)",
+              borderRadius: "var(--radius-input)",
+              color: "var(--fg)",
+              textDecoration: "none",
+            }}
+          >
+            Manage on GitHub
+            <ExternalLink className="h-3 w-3" />
+          </a>
+        </div>
+        <ConnectionDetails defaultOpen={detailsOpen} />
+      </div>
+    </PageShell>
+  );
+}
+
+/** Not-installed CTA — flush under the header, no hairline (matches the real panel). */
+function NotInstalledCard() {
+  return (
+    <PageShell>
+      <div>
+        <p className="text-body" style={{ color: "var(--fg-2)", marginBottom: "var(--sp-3)" }}>
+          Install the GitHub App on your personal account or organization to start receiving issues, pull requests, and
+          reviews as routed messages.
+        </p>
+        <button
+          type="button"
+          className="inline-flex items-center justify-center font-medium"
+          style={{
+            gap: "var(--sp-1)",
+            padding: "var(--sp-2) var(--sp-3)",
+            background: "var(--primary)",
+            color: "var(--primary-on)",
+            border: "none",
+            borderRadius: "var(--radius-input)",
+            cursor: "pointer",
+          }}
+        >
+          Install on GitHub
+          <ExternalLink className="h-3 w-3" />
+        </button>
+      </div>
+    </PageShell>
+  );
+}
+
+/** Loading — flush under the header, no hairline. */
+function LoadingCard() {
+  return (
+    <PageShell>
+      <div className="text-body" style={{ color: "var(--fg-3)" }}>
+        Loading…
+      </div>
+    </PageShell>
+  );
+}
+
+function Frame({ label, note, children }: { label: string; note: string; children: React.ReactNode }) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "var(--sp-2)" }}>
+      <div>
+        <div className="text-caption font-semibold" style={{ color: "var(--fg)" }}>
+          {label}
+        </div>
+        <div className="text-caption" style={{ color: "var(--fg-4)" }}>
+          {note}
+        </div>
+      </div>
+      <div
+        style={{
+          width: 880,
+          maxWidth: "100%",
+          background: "var(--bg)",
+          border: "var(--hairline) solid var(--border)",
+          borderRadius: "var(--radius-panel)",
+          overflow: "hidden",
+        }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
+export function SettingsGithubPreviewPage() {
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        background: "var(--bg-sunken)",
+        padding: "var(--sp-6)",
+        display: "flex",
+        flexDirection: "column",
+        gap: "var(--sp-8)",
+      }}
+    >
+      <div>
+        <h1 className="text-title" style={{ color: "var(--fg)" }}>
+          Settings → GitHub — shipped layout
+        </h1>
+        <p className="text-body" style={{ color: "var(--fg-3)" }}>
+          Lean default: who's connected + Manage on GitHub. Permissions, subscribed events, and the installation id sit
+          behind a collapsed "Connection details" disclosure (click to toggle). Only the bound card carries a top
+          hairline; not-installed and loading sit flush under the header.
+        </p>
+      </div>
+
+      <Frame label="Connected — default" note="developer metadata collapsed behind 'Connection details'">
+        <InstalledCard />
+      </Frame>
+
+      <Frame label="Connected — details expanded" note="the disclosure open: scopes, events, installation id">
+        <InstalledCard detailsOpen />
+      </Frame>
+
+      <Frame label="Suspended upstream" note="webhook delivery paused on GitHub's side — banner preserved">
+        <InstalledCard suspended />
+      </Frame>
+
+      <Frame label="Not installed" note="the Install on GitHub CTA — flush under the header, no orphaned rule">
+        <NotInstalledCard />
+      </Frame>
+
+      <Frame label="Loading" note="initial fetch — flush under the header">
+        <LoadingCard />
+      </Frame>
+    </div>
+  );
+}

--- a/packages/web/src/pages/settings/github.tsx
+++ b/packages/web/src/pages/settings/github.tsx
@@ -23,7 +23,7 @@ export function SettingsGithubPage() {
 
   return (
     <>
-      <PageHeader title="GitHub" subtitle="Connected GitHub App and granted permissions" />
+      <PageHeader title="GitHub" subtitle="Connected GitHub App" />
       <div style={{ padding: "var(--sp-2) var(--sp-5) var(--sp-7)" }}>
         <GithubAppInstallationPanel />
       </div>


### PR DESCRIPTION
## What

Declutters the **Settings → GitHub** page (the connected GitHub App card). The bound state now leads with just the essentials:

- **Connected as** `<account>` `[type]`
- **Manage on GitHub**

The developer-facing metadata — granted permission scopes, subscribed webhook events, and the installation id — moves behind a collapsed **Connection details** disclosure (one click to expand). The duplicated "GitHub App" section heading (the page header already titles the surface "GitHub") and its roadmap-y description line are removed.

Unchanged: the not-installed "Install on GitHub" CTA and the suspended-upstream banner.

## Why

The page is the management home for the GitHub App integration, but the connected view was dominated by a 7-row permission-scope dump, an events list, and an installation id — developer metadata most admins never read. Leading with "who's connected + how to manage" and tucking the scope/event details behind a disclosure keeps the page lean while preserving scope transparency for an admin who wants to audit it.

## Notes

- Only the bound card draws a top hairline (it anchors "Connected as"); the loading and not-installed states sit flush under the page header so the rule never floats above un-headinged content.
- The disclosure is an `aria-expanded` / `aria-controls` button with an `aria-hidden` rotating chevron — there is no shared collapsible primitive in the app yet.
- Adds a DEV-only `/preview/settings-github` route to eyeball the connected (collapsed / expanded), suspended, not-installed, and loading states without a live install.

## Verification

- `pnpm --filter @first-tree/web test` — 127 files / 997 tests pass
- `pnpm --filter @first-tree/web typecheck` (tsc + `lint:tokens`) — clean
- biome — clean
- Two independent code reviews (no blockers; fixed an orphaned-hairline regression on the loading / not-installed states + a11y polish: `aria-hidden` chevron, `aria-controls`)
