### PR TITLE
fix: restore visible text in the chat ask answer input

### DIFF
--- a/packages/web/src/components/chat/__tests__/ask-takeover-dom.test.tsx
+++ b/packages/web/src/components/chat/__tests__/ask-takeover-dom.test.tsx
@@ -425,4 +425,23 @@ describe("AskTakeover", () => {
     expect(onSkip).not.toHaveBeenCalled();
     ta.removeEventListener("keydown", consume);
   });
+
+  it("free-text answer surface stays transparent so the mention overlay shows the typed text", async () => {
+    // Regression guard (PR 1256): the answer textarea is painted transparent and
+    // a mirror overlay behind it draws the glyphs. If the textarea keeps an
+    // opaque background it sits on top of the overlay and the typed text turns
+    // invisible — the white-on-white bug on the light theme. The visible chrome
+    // (border + fill) must live on the wrapper, not the textarea.
+    const c = await renderDom(
+      <AskTakeover body="# Concerns?" payload={{ multiSelect: false }} onReply={() => {}} onSkip={() => {}} />,
+    );
+    const ta = freeTextBox(c);
+    if (!ta) throw new Error("free-text input missing");
+    expect(ta.style.background).toBe("transparent");
+    expect(ta.style.color).toBe("transparent");
+    // The mirror overlay that actually paints the glyphs is a sibling.
+    expect(ta.parentElement?.querySelector("[aria-hidden]")).not.toBeNull();
+    // The opaque fill now lives on the wrapper so the field still reads as a box.
+    expect(ta.parentElement?.style.background).toBe("var(--bg)");
+  });
 });

--- a/packages/web/src/components/chat/ask-takeover.tsx
+++ b/packages/web/src/components/chat/ask-takeover.tsx
@@ -240,12 +240,24 @@ export function AskTakeover({
     return () => window.removeEventListener("keydown", onKeyDown);
   }, [sending, canReply, onSkip, reply]);
 
-  const ftStyle = {
-    width: "100%",
+  // Visible chrome (border + fill + radius) lives on the WRAPPER, not the
+  // textarea: the textarea is painted transparent so the mention overlay
+  // behind it can draw the actual glyphs (PR 1256). An opaque textarea
+  // background sits *above* that overlay and hides the typed text — the
+  // white-on-white regression this restores. Mirrors chat-view's composer.
+  const fieldChrome = {
+    position: "relative" as const,
     border: "var(--hairline) solid var(--border-strong)",
     borderRadius: "var(--radius-input)",
     background: "var(--bg)",
-    color: "var(--fg)",
+  };
+
+  const ftStyle = {
+    width: "100%",
+    display: "block" as const,
+    boxSizing: "border-box" as const,
+    border: "none",
+    background: "transparent",
     fontFamily: "inherit",
     lineHeight: 1.5,
     padding: "var(--sp-2_5) var(--sp-3)",
@@ -266,7 +278,7 @@ export function AskTakeover({
    *  as the sole box on a free-text ask): mention autocomplete + highlight +
    *  image paste, with the text drawn by the mirror overlay. */
   const renderAnswerInput = (placeholder: string, minHeight: number) => (
-    <div style={{ position: "relative" }}>
+    <div style={fieldChrome}>
       <MentionAutocompletePopover
         trigger={mention.trigger}
         results={mention.results}


### PR DESCRIPTION
## What

Typed text in the `chat ask` answer box (`AskTakeover`) was invisible — white-on-white on the light theme, and equally hidden on dark. This restores it.

## Root cause (regression from #1256)

#1256 added a mention-highlight mirror overlay to the answer box: the real `<textarea>` is set `color: transparent` and `MentionHighlightOverlay` (behind it) paints the visible glyphs in `var(--fg)`. But the textarea kept an opaque `background: var(--bg)` **and** `zIndex: 1`, so it sat *on top of* the overlay and hid the painted glyphs; the textarea's own text is transparent → nothing visible.

This is the one piece the working chat composer (`chat-view.tsx`) gets right and this box missed: there the textarea is `background: transparent`, so the overlay shows through.

## Fix

Move the visible chrome (border + fill + radius) from the textarea onto the field **wrapper**, and make the textarea `background: transparent` + `border: none` — mirroring `chat-view.tsx`. Both answer inputs route through `renderAnswerInput`, so this covers the sole free-text box and the "Other…" box beside options. It also removes a pre-existing ~1px glyph drift: the overlay's `inset:0` and the textarea text box now share the same origin.

## Test / verification

- Added a regression test in `ask-takeover-dom.test.tsx`: the answer textarea must stay `background: transparent` / `color: transparent`, the mirror overlay sibling must exist, and the opaque fill must live on the wrapper. Verified red on the buggy code, green after the fix.
- `pnpm --filter @first-tree/web test` → 1006/1006 pass. `biome check` clean on changed files. `typecheck` + `lint:tokens` clean.
- Reproduced + verified visually on the DEV `/preview/request-dock` gallery (free-text + "Other"), light theme: **before** = empty white box (typed text invisible), **after** = text clearly rendered.

## How to reproduce

`pnpm --filter @first-tree/web dev` → open `/preview/request-dock` → type into the "free text" box. On `main` the text is invisible; with this branch it renders.