### PR TITLE
release: bump apps/cli to v0.5.9

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "first-tree-dev",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "type": "module",
   "description": "First Tree — unified CLI for Context Tree onboarding, agent management, and team messaging. (Source-tree dev build; CI rewrites `name` and `bin` for prod / staging publishes — see docs/local-dev-isolation.md.)",
   "keywords": [


### PR DESCRIPTION
## Summary

Release bump: `apps/cli` `0.5.8` → `0.5.9`. Diff is `apps/cli/package.json` version only. Source package name stays `first-tree-dev` (CI rewrites it for prod publish).

This cuts the next stable patch from `origin/main` (82 PRs since `v0.5.8`).

## Draft GitHub Release

**Title:** `v0.5.9 — Multi-team management, in-product Connect, Context Reviewer automation`

### Highlights

- Redesigned multi-team switching & management; team rename moved into the switcher (#1248, #1258)
- In-product browser-OAuth Connect for the Claude/Codex SDK — no separate CLI login; surfaces login failures (#1194, #1225)
- Context Reviewer PR automation, with an immediate-save Switch setting and PR-update wake/dedupe (#1233, #1260, #1236, #1254)
- Build a Context Tree on a personal GitHub account, and pick which repos seed tree init (#1263, #1213, #3da4e8c1)
- Richer ask answer card: @mention + image attachments, plus Enter/Esc shortcuts (#1256, #1179)
- Chat description surfaced as a pinned, collapsible task summary (ChatSummary) (#1195, #1223)
- Offline-agent + leave-a-task affordance in the chat timeline (#1246)
- Adopt a member's first agent as their delegate (#1240)
- Onboarding revamp: agent-first kickoff, work chat starts before tree setup, skill renamed to `first-tree-welcome` (#1218, #1231, #1230)
- Restored `chat send <human>` and retired the agent-final-text mirror; rebind harness "user" to runtime so agents reliably chat send (#1190, #1232, #1226)
- GA4 instrumentation + cross-domain linking on the cloud SPA (#1201, #1203)
- Instant-save profile & add-repo forms; agent-detail IA cleanup (#1212, #1211, #1180, #1182)

### Notable fixes

- Claude SDK provider error handling; session limit surfaced as a provider error; resolve bundled Claude native binary and drop codex device-code (#1242, #1228, #1219)
- Codex provider: app-server token replay/usage deltas, stop retrying deterministic compact failures, suppress expected shutdown noise (#1243, #1241, #1185, #1183, #1222)
- Reject empty / placeholder message bodies at the write boundary (#1257)
- Defer idle-suspend while a provider has a live subprocess (#1253)
- Session provider retry policy + transient agent-config fetch retry during bring-up (#1192, #1239)
- Reconnect after inbox recovery timeout; resume foreground polls on focus/pageshow (#1237, #1244)
- Restore visible text in the chat ask answer input (#1266)

## Verification

- `pnpm check` — pass (only pre-existing warnings unrelated to this diff)
- `pnpm typecheck` — pass (12/12 tasks)

## Post-merge steps

1. Wait for `CI` to pass on the merge commit on `main` (also check main-triggered `npm Publish` / `Docker`).
2. After human confirms title/body/version/target commit, create the `v0.5.9` GitHub Release + tag targeting the merge SHA.
3. Tag push triggers `npm Publish` (prod) and `Docker`; verify `npm view first-tree version` → `0.5.9` and the image `ghcr.io/agent-team-foundation/first-tree:0.5.9`.
4. Remind human to deploy on CapRover.

Do not tag from this PR branch.
