### PR TITLE
fix(cli): set channel process title

### DIFF
--- a/apps/cli/src/__tests__/cli-entry-and-tree-actions-extra.test.ts
+++ b/apps/cli/src/__tests__/cli-entry-and-tree-actions-extra.test.ts
@@ -44,6 +44,7 @@ const originalCwd = process.cwd();
 const originalHome = process.env.FIRST_TREE_HOME;
 const originalJson = process.env.FIRST_TREE_JSON;
 const originalLogLevel = process.env.FIRST_TREE_LOG_LEVEL;
+const originalProcessTitle = process.title;
 
 beforeEach(() => {
   vi.resetModules();
@@ -65,6 +66,7 @@ afterEach(() => {
   else process.env.FIRST_TREE_JSON = originalJson;
   if (originalLogLevel === undefined) delete process.env.FIRST_TREE_LOG_LEVEL;
   else process.env.FIRST_TREE_LOG_LEVEL = originalLogLevel;
+  process.title = originalProcessTitle;
 });
 
 describe("CLI entry and public exports", () => {
@@ -79,6 +81,7 @@ describe("CLI entry and public exports", () => {
     await import("../cli/index.js");
 
     expect(process.env.FIRST_TREE_HOME).toBeDefined();
+    expect(process.title).toBe("first-tree-dev");
     expect(clientMocks.setCliBinding).toHaveBeenCalledWith(expect.objectContaining({ binName: "first-tree-dev" }));
     expect(parseSpy).toHaveBeenCalledTimes(1);
     expect(

--- a/apps/cli/src/core/channel-env.ts
+++ b/apps/cli/src/core/channel-env.ts
@@ -47,4 +47,11 @@ if (!process.env.FIRST_TREE_HOME) {
   process.env.FIRST_TREE_HOME = channelConfig.defaultHome;
 }
 
+// Best-effort operator UX: npm-installed CLIs run inside the Node.js
+// interpreter, so process viewers and filesystem activity tools can otherwise
+// show "node" while First Tree is reading the workspace. TCC/code-signing
+// prompts may still identify the underlying Node binary, but process-title
+// aware tools should show the channel-specific CLI name.
+process.title = channelConfig.binName;
+
 setCliBinding({ binName: channelConfig.binName, packageName: channelConfig.packageName });


### PR DESCRIPTION
## Summary
- Set the CLI process title to the channel-specific binary name during early channel initialization.
- Cover the CLI entrypoint behavior with a regression test.

## Notes
- This improves process-title-aware tools that otherwise show `node` while First Tree is running.
- macOS TCC/code-signing prompts may still identify the underlying Node.js interpreter; changing that would require an app/native launcher packaging path.

## Verification
- `pnpm --filter first-tree-dev test -- --runInBand=false`

## Known unrelated verification failures
- `pnpm check && pnpm typecheck` is currently blocked by existing Biome findings in client/web files and existing Claude SDK type mismatches in `packages/client`.
- `pnpm --filter first-tree-dev typecheck` is blocked by the same client Claude SDK type mismatch.