### PR TITLE
fix: fallback agents dir watcher on Node 18

### DIFF
--- a/apps/cli/src/__tests__/client-runtime-context-tree.test.ts
+++ b/apps/cli/src/__tests__/client-runtime-context-tree.test.ts
@@ -151,6 +151,12 @@ vi.mock("../core/version.js", () => ({
 describe("ClientRuntime context-tree wiring", () => {
   const originalHome = process.env.FIRST_TREE_HOME;
   let home: string;
+  type WatchCallback = (eventType: string, filename: string | Buffer | null) => void;
+  type WatchRegistration = {
+    path: string;
+    listener: WatchCallback | null;
+    close: ReturnType<typeof vi.fn>;
+  };
 
   beforeEach(() => {
     vi.resetModules();
@@ -181,6 +187,41 @@ describe("ClientRuntime context-tree wiring", () => {
     else process.env.FIRST_TREE_HOME = originalHome;
     vi.clearAllMocks();
   });
+
+  function mockRecursiveUnavailableWatch(): WatchRegistration[] {
+    type Listener = (...args: unknown[]) => void;
+    const registrations: WatchRegistration[] = [];
+    const isWatchCallback = (value: unknown): value is WatchCallback => typeof value === "function";
+
+    fsWatchMocks.watch.mockImplementation((...args: unknown[]) => {
+      const [path, optionsOrListener, maybeListener] = args;
+      if (
+        typeof optionsOrListener === "object" &&
+        optionsOrListener !== null &&
+        "recursive" in optionsOrListener &&
+        optionsOrListener.recursive === true
+      ) {
+        const err = new Error("The feature watch recursively is unavailable on the current platform");
+        (err as Error & { code: string }).code = "ERR_FEATURE_UNAVAILABLE_ON_PLATFORM";
+        throw err;
+      }
+
+      const listener = isWatchCallback(optionsOrListener)
+        ? optionsOrListener
+        : isWatchCallback(maybeListener)
+          ? maybeListener
+          : null;
+      const close = vi.fn();
+      const watcher = {
+        on: vi.fn((_event: string, _listener: Listener) => watcher),
+        close,
+      };
+      registrations.push({ path: String(path), listener, close });
+      return watcher;
+    });
+
+    return registrations;
+  }
 
   it(
     "starts eager slots without a shared Context Tree binding",
@@ -620,5 +661,71 @@ describe("ClientRuntime context-tree wiring", () => {
     expect(print.status).toHaveBeenCalledWith("⚠️", expect.stringContaining("inotify exhausted"));
     expect(close).toHaveBeenCalled();
     await rt.stop();
+  });
+
+  it("falls back to non-recursive agents-dir watchers when recursive watch is unavailable", async () => {
+    vi.useFakeTimers();
+    try {
+      const { print } = await import("../core/output.js");
+      const registrations = mockRecursiveUnavailableWatch();
+
+      const { ClientRuntime } = await import("../core/client-runtime.js");
+      const rt = new ClientRuntime("https://first-tree.test", "client-test");
+      const agentsDir = join(home, "config", "agents");
+      mkdirSync(join(agentsDir, "existing"), { recursive: true });
+      writeFileSync(join(agentsDir, "existing", "agent.yaml"), "agentId: agent-existing\nruntime: claude-code\n");
+
+      expect(() => rt.watchAgentsDir(agentsDir)).not.toThrow();
+      expect(print.status).toHaveBeenCalledWith(
+        "⚠️",
+        expect.stringContaining("recursive agents dir watcher unavailable"),
+      );
+      expect(registrations).toHaveLength(2);
+
+      mkdirSync(join(agentsDir, "newcomer"), { recursive: true });
+      writeFileSync(join(agentsDir, "newcomer", "agent.yaml"), "agentId: agent-new\nruntime: claude-code\n");
+      registrations[0]?.listener?.("rename", "newcomer");
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(slotInstances.map((slot) => slot.name)).toContain("newcomer");
+      expect(registrations.some((registration) => registration.close.mock.calls.length > 0)).toBe(true);
+      await rt.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps watching fallback agent dirs when agent.yaml is written after the directory event", async () => {
+    vi.useFakeTimers();
+    try {
+      const registrations = mockRecursiveUnavailableWatch();
+
+      const { ClientRuntime } = await import("../core/client-runtime.js");
+      const rt = new ClientRuntime("https://first-tree.test", "client-test");
+      const agentsDir = join(home, "config", "agents");
+      mkdirSync(agentsDir, { recursive: true });
+
+      expect(() => rt.watchAgentsDir(agentsDir)).not.toThrow();
+      expect(registrations).toHaveLength(1);
+
+      mkdirSync(join(agentsDir, "newcomer"), { recursive: true });
+      registrations[0]?.listener?.("rename", "newcomer");
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(slotInstances.map((slot) => slot.name)).not.toContain("newcomer");
+      const newcomerWatcher = [...registrations]
+        .reverse()
+        .find((registration) => registration.path === join(agentsDir, "newcomer"));
+      expect(newcomerWatcher).toBeDefined();
+
+      writeFileSync(join(agentsDir, "newcomer", "agent.yaml"), "agentId: agent-new\nruntime: claude-code\n");
+      newcomerWatcher?.listener?.("change", "agent.yaml");
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(slotInstances.map((slot) => slot.name)).toContain("newcomer");
+      await rt.stop();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/apps/cli/src/core/client-runtime.ts
+++ b/apps/cli/src/core/client-runtime.ts
@@ -1,5 +1,5 @@
-import type { FSWatcher } from "node:fs";
-import { existsSync, mkdirSync, readFileSync, watch, writeFileSync } from "node:fs";
+import type { Dirent, FSWatcher } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, watch, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import {
   AgentSlot,
@@ -44,6 +44,12 @@ function authPausedDetail(error: Error): string {
   return `Auth rejection code: ${authCode}${authMessage ? ` — ${authMessage}` : ""}`;
 }
 
+function isRecursiveWatchUnsupported(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const code = "code" in error && typeof error.code === "string" ? error.code : "";
+  return code === "ERR_FEATURE_UNAVAILABLE_ON_PLATFORM" || error.message.includes("watch recursively");
+}
+
 export type ClientRuntimeOptions = {
   /**
    * Version of the Command package this process was launched from. Passed to
@@ -79,7 +85,8 @@ export class ClientRuntime {
   private readonly agentIds = new Set<string>();
   private readonly options: ClientRuntimeOptions;
   private updateManager: UpdateManager | null = null;
-  private watcher: FSWatcher | null = null;
+  private agentWatchers: FSWatcher[] = [];
+  private agentsDirWatchMode: "recursive" | "fallback" | null = null;
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
   /**
    * Directory we write auto-registered agent configs into (same path that
@@ -304,23 +311,88 @@ export class ClientRuntime {
     // Record the directory even if the watcher bails (e.g. dir missing) so
     // the `agent:pinned` handler knows where to materialise configs.
     this.agentsDir = agentsDir;
-    if (this.watcher) return;
+    if (this.agentWatchers.length > 0) return;
     if (!existsSync(agentsDir)) return;
 
-    this.watcher = watch(agentsDir, { recursive: true }, () => {
-      if (this.debounceTimer) clearTimeout(this.debounceTimer);
-      this.debounceTimer = setTimeout(() => {
-        this.debounceTimer = null;
-        this.scanForNewAgents(agentsDir);
-      }, 500);
+    try {
+      const watcher = this.createAgentsDirWatcher(agentsDir, { recursive: true }, () => {
+        this.scheduleAgentsDirScan(agentsDir);
+      });
+      this.agentWatchers = [watcher];
+      this.agentsDirWatchMode = "recursive";
+    } catch (err) {
+      if (!isRecursiveWatchUnsupported(err)) {
+        print.status("⚠️", `agents dir watcher failed: ${err instanceof Error ? err.message : String(err)}`);
+        this.unwatchAgentsDir();
+        return;
+      }
+      print.status("⚠️", "recursive agents dir watcher unavailable; using non-recursive fallback");
+      this.startFallbackAgentsDirWatchers(agentsDir);
+    }
+  }
+
+  private scheduleAgentsDirScan(agentsDir: string): void {
+    if (this.debounceTimer) clearTimeout(this.debounceTimer);
+    this.debounceTimer = setTimeout(() => {
+      this.debounceTimer = null;
+      this.scanForNewAgents(agentsDir);
+      if (this.agentsDirWatchMode === "fallback") this.refreshFallbackAgentsDirWatchers(agentsDir);
+    }, 500);
+  }
+
+  private createAgentsDirWatcher(path: string, options: { recursive?: boolean }, onChange: () => void): FSWatcher {
+    const watcher = watch(path, options, () => {
+      onChange();
     });
-    // A recursive FSWatcher can emit 'error' at runtime (watched dir removed,
-    // or inotify exhaustion on Linux). An unhandled 'error' throws and would
-    // take down the daemon — tear the watcher down so it degrades gracefully.
-    this.watcher.on("error", (err: Error) => {
+    // FSWatchers can emit 'error' at runtime (watched dir removed, or
+    // inotify exhaustion on Linux). An unhandled 'error' throws and would
+    // take down the daemon — tear watchers down so they degrade gracefully.
+    watcher.on("error", (err: Error) => {
       print.status("⚠️", `agents dir watcher error: ${err.message}`);
       this.unwatchAgentsDir();
     });
+    return watcher;
+  }
+
+  private startFallbackAgentsDirWatchers(agentsDir: string): void {
+    this.unwatchAgentsDir();
+    this.agentsDirWatchMode = "fallback";
+    try {
+      this.agentWatchers.push(this.createAgentsDirWatcher(agentsDir, {}, () => this.scheduleAgentsDirScan(agentsDir)));
+    } catch (err) {
+      print.status("⚠️", `agents dir watcher failed: ${err instanceof Error ? err.message : String(err)}`);
+      this.unwatchAgentsDir();
+      return;
+    }
+
+    let entries: Dirent[];
+    try {
+      entries = readdirSync(agentsDir, { withFileTypes: true });
+    } catch (err) {
+      print.status("⚠️", `agents dir watcher scan failed: ${err instanceof Error ? err.message : String(err)}`);
+      return;
+    }
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      try {
+        this.agentWatchers.push(
+          this.createAgentsDirWatcher(join(agentsDir, entry.name), {}, () => this.scheduleAgentsDirScan(agentsDir)),
+        );
+      } catch (err) {
+        print.status(
+          "⚠️",
+          `agent dir watcher skipped for ${entry.name}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+  }
+
+  private refreshFallbackAgentsDirWatchers(agentsDir: string): void {
+    if (this.agentsDirWatchMode !== "fallback") return;
+    for (const watcher of this.agentWatchers.splice(0)) watcher.close();
+    this.agentsDirWatchMode = null;
+    if (existsSync(agentsDir)) this.startFallbackAgentsDirWatchers(agentsDir);
   }
 
   unwatchAgentsDir(): void {
@@ -328,10 +400,8 @@ export class ClientRuntime {
       clearTimeout(this.debounceTimer);
       this.debounceTimer = null;
     }
-    if (this.watcher) {
-      this.watcher.close();
-      this.watcher = null;
-    }
+    for (const watcher of this.agentWatchers.splice(0)) watcher.close();
+    this.agentsDirWatchMode = null;
   }
 
   async stop(): Promise<void> {


### PR DESCRIPTION
## Summary
- fall back from recursive agents-dir watching to non-recursive watchers when the current Node/platform does not support recursive `fs.watch`
- keep watcher setup/runtime failures as warnings so the daemon does not exit and systemd does not restart-loop
- refresh fallback child-directory watchers after scans so hot-added agent directories are still observed when `agent.yaml` is written after the directory event
- add regression coverage for recursive-watch setup failures and delayed `agent.yaml` writes under the fallback path

## Companion PR
- Context Tree: https://github.com/agent-team-foundation/first-tree-context/pull/605

## Validation
- `pnpm typecheck`
- `pnpm --dir apps/cli exec vitest run src/__tests__/client-runtime-context-tree.test.ts`
- Node 18.19.0 Linux smoke via `npx -y node@18.19.0`: import `apps/cli/dist/index.mjs`, call `ClientRuntime.watchAgentsDir`, observe fallback warning and successful return
- `pnpm check` (passes with existing warnings/info)
- `git diff --check`
- `pnpm test --concurrency=2`
