### PR TITLE
feat(web): connect GitHub and pick a repo inline on the Context build entry

### DIFF
--- a/packages/server/src/api/orgs/__tests__/post-install-next.test.ts
+++ b/packages/server/src/api/orgs/__tests__/post-install-next.test.ts
@@ -11,10 +11,10 @@ describe("resolvePostInstallNext", () => {
     expect(resolvePostInstallNext("/onboarding")).toBe("/onboarding");
     expect(resolvePostInstallNext("/onboarding/connected")).toBe("/onboarding/connected");
     expect(resolvePostInstallNext("/settings/github")).toBe("/settings/github");
-    // The build-tree recovery surface passes itself as `next` when the install
-    // popup is blocked — rewriting it to Settings would strand the recovery
-    // admin outside the flow they were in.
-    expect(resolvePostInstallNext("/build-tree")).toBe("/build-tree");
+    // The Context tab build entry passes itself as `next` when the install popup
+    // is blocked — rewriting it to Settings would bounce the admin out of the
+    // inline build/repo-pick flow they were in.
+    expect(resolvePostInstallNext("/context")).toBe("/context");
   });
 
   it("falls back to Settings for an absent value", () => {
@@ -31,7 +31,7 @@ describe("resolvePostInstallNext", () => {
 
   it("only allows the known internal destinations", () => {
     expect([...ALLOWED_POST_INSTALL_NEXT].sort()).toEqual([
-      "/build-tree",
+      "/context",
       "/onboarding",
       "/onboarding/connected",
       "/settings/github",

--- a/packages/server/src/api/orgs/github-app.ts
+++ b/packages/server/src/api/orgs/github-app.ts
@@ -47,10 +47,12 @@ export const ALLOWED_POST_INSTALL_NEXT: ReadonlySet<string> = new Set([
   // installs in a popup and lands the popup here so it can auto-close while the
   // original tab keeps polling.
   "/onboarding/connected",
-  // Build-tree recovery surface: its connect-code step passes itself as `next`
-  // when the install popup is blocked (the full-page redirect must return to
-  // the recovery flow, not Settings — see step-connect-code.tsx).
-  "/build-tree",
+  // Context tab build entry: its inline connect-code passes the Context page as
+  // `next` when the install popup is blocked (the full-page redirect must return
+  // to the inline build/repo-pick flow, not Settings — see
+  // context-tree-build-entry.tsx). This replaced the removed /build-tree page,
+  // whose recovery surface moved onto the Context tab.
+  "/context",
 ]);
 
 /**

--- a/packages/web/src/pages/__tests__/context-page-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/context-page-dom.test.tsx
@@ -33,6 +33,17 @@ const orgSettingsMocks = vi.hoisted(() => ({
   getContextTreeSetting: vi.fn(),
 }));
 
+const githubAppMocks = vi.hoisted(() => ({
+  getGithubAppInstallation: vi.fn(),
+  getGithubAppInstallationExists: vi.fn(),
+  getGithubAppInstallUrl: vi.fn(),
+}));
+
+const githubMocks = vi.hoisted(() => ({
+  listGithubRepos: vi.fn(),
+  listOrgGithubRepos: vi.fn(),
+}));
+
 const authMock = vi.hoisted(() => ({
   value: {
     organizationId: "org-1" as string | null,
@@ -45,6 +56,8 @@ vi.mock("../../api/agents.js", () => agentApiMocks);
 vi.mock("../../api/resources.js", () => resourceApiMocks);
 vi.mock("../../api/onboarding-events.js", () => onboardingEventMocks);
 vi.mock("../../api/org-settings.js", () => orgSettingsMocks);
+vi.mock("../../api/github-app.js", () => githubAppMocks);
+vi.mock("../../api/github.js", () => githubMocks);
 
 vi.mock("../../auth/auth-context.js", () => ({
   useAuth: () => authMock.value,
@@ -194,6 +207,21 @@ beforeEach(() => {
     hasTreeSetupKickoff: true,
   });
   onboardingEventMocks.kickoffOnboarding.mockResolvedValue({ chatId: "chat-tree-setup" });
+  githubAppMocks.getGithubAppInstallation.mockReset();
+  githubAppMocks.getGithubAppInstallationExists.mockReset();
+  githubAppMocks.getGithubAppInstallUrl.mockReset();
+  githubMocks.listGithubRepos.mockReset();
+  githubMocks.listOrgGithubRepos.mockReset();
+  // Default: GitHub App not connected and no repos granted — the inline build
+  // entry shows its install CTA. Tests that exercise the connected/pick states
+  // override these.
+  githubAppMocks.getGithubAppInstallation.mockResolvedValue(null);
+  githubAppMocks.getGithubAppInstallationExists.mockResolvedValue(false);
+  githubAppMocks.getGithubAppInstallUrl.mockResolvedValue(
+    "https://github.com/apps/first-tree/installations/new?state=test",
+  );
+  githubMocks.listGithubRepos.mockResolvedValue([]);
+  githubMocks.listOrgGithubRepos.mockResolvedValue([]);
   contextApiMocks.initializeContextTree.mockResolvedValue({
     repo: "https://github.com/acme/acme-context-tree.git",
     htmlUrl: "https://github.com/acme/acme-context-tree",
@@ -381,47 +409,120 @@ describe("ContextPage DOM behavior", () => {
     await act(async () => disconnected.root.unmount());
   });
 
-  it("offers the Context tab build entry to a no-tree admin and routes no-repo setup to Resources", async () => {
-    authMock.value = { organizationId: "org-1", role: "admin" };
-    agentApiMocks.listManagedAgents.mockResolvedValue([
-      {
-        uuid: "agent-1",
-        name: "agent-1",
-        displayName: "Tree Agent",
-        type: "agent",
-        organizationId: "org-1",
-        inboxId: "inbox-agent-1",
-        visibility: "private",
-        runtimeProvider: "claude-code",
-        clientId: "client-agent-1",
-        status: "active",
-        avatarImageUrl: null,
-      },
-    ]);
-    resourceApiMocks.listTeamResourcesForOrg.mockResolvedValue([]);
-    const { ContextPage } = await import("../context.js");
-    const unavailable = snapshot({
+  const treeAgent = {
+    uuid: "agent-1",
+    name: "agent-1",
+    displayName: "Tree Agent",
+    type: "agent",
+    organizationId: "org-1",
+    inboxId: "inbox-agent-1",
+    visibility: "private",
+    runtimeProvider: "claude-code",
+    clientId: "client-agent-1",
+    status: "active",
+    avatarImageUrl: null,
+  };
+  const unavailableSnapshot = () =>
+    snapshot({
       repo: null,
       branch: null,
       snapshotStatus: "unavailable",
       contextStatus: { label: "Not configured", detail: null, severity: "warning" },
     });
-    contextApiMocks.getContextTreeSnapshot.mockResolvedValue(unavailable);
+
+  it("installs the GitHub App inline for a no-repo admin instead of bouncing to Resources", async () => {
+    authMock.value = { organizationId: "org-1", role: "admin" };
+    agentApiMocks.listManagedAgents.mockResolvedValue([treeAgent]);
+    resourceApiMocks.listTeamResourcesForOrg.mockResolvedValue([]);
+    githubAppMocks.getGithubAppInstallation.mockResolvedValue(null); // GitHub not connected yet
+    const fakeTab = { location: { href: "" }, close: vi.fn() };
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(fakeTab as unknown as Window);
+    const { ContextPage } = await import("../context.js");
+    contextApiMocks.getContextTreeSnapshot.mockResolvedValue(unavailableSnapshot());
 
     const { container, root } = await renderDom(<ContextPage />);
-    await waitForText(container, "Connect a code repository first");
-    await waitForText(container, "Connect your code");
-    // The low-level "create an empty private repo" button is gone (it lived in
-    // Settings → Context tree). The Context page build entry launches the
-    // chat-driven flow only after a repo exists.
+    // No repo connected → the inline install CTA, NOT a bounce to /settings/resources.
+    await waitForText(container, "Install First Tree on GitHub");
     expect(container.textContent).not.toContain("Create private GitHub repo");
     expect(contextApiMocks.initializeContextTree).not.toHaveBeenCalled();
 
-    // Clicking the link routes to the existing team resource configuration.
-    await click(buttonByText(container, "Connect your code"));
-    const location = container.querySelector('[data-testid="location"]');
-    expect(location?.textContent).toBe("/settings/resources");
+    // Clicking it mints the install URL into a popup and stays on the page.
+    await click(buttonByText(container, "Install First Tree on GitHub"));
+    await flush();
+    expect(githubAppMocks.getGithubAppInstallUrl).toHaveBeenCalledWith("org-1", "/onboarding/connected");
+    expect(fakeTab.location.href).toContain("installations/new");
+    expect(container.querySelector('[data-testid="location"]')?.textContent).toBe("/");
 
+    openSpy.mockRestore();
+    await act(async () => root.unmount());
+  });
+
+  it("lists the granted repos inline for a connected no-repo admin (no settings bounce)", async () => {
+    authMock.value = { organizationId: "org-1", role: "admin" };
+    agentApiMocks.listManagedAgents.mockResolvedValue([treeAgent]);
+    resourceApiMocks.listTeamResourcesForOrg.mockResolvedValue([]);
+    githubAppMocks.getGithubAppInstallation.mockResolvedValue({
+      installationId: 7,
+      accountLogin: "acme",
+      accountType: "Organization",
+      manageUrl: "https://github.com/organizations/acme/settings/installations/7",
+      suspended: false,
+      permissions: {},
+      events: [],
+    });
+    githubMocks.listOrgGithubRepos.mockResolvedValue([
+      {
+        fullName: "acme/acme-web",
+        cloneUrl: "https://github.com/acme/acme-web.git",
+        htmlUrl: "https://github.com/acme/acme-web",
+        private: true,
+        defaultBranch: "main",
+        pushedAt: null,
+      },
+    ]);
+    const { ContextPage } = await import("../context.js");
+    contextApiMocks.getContextTreeSnapshot.mockResolvedValue(unavailableSnapshot());
+
+    const { container, root } = await renderDom(<ContextPage />);
+    // Connected → the repos the App grants are listed inline for the user to pick.
+    await waitForText(container, "Repos your agent can use");
+    await waitForText(container, "acme-web");
+    // The build CTA only appears after a repo is picked, and the user is never
+    // routed away to a settings page to wire up a repo.
+    expect(buttonByText(container, "Build your Context Tree")).toBeNull();
+    expect(container.querySelector('[data-testid="location"]')?.textContent).toBe("/");
+
+    // Picking a repo reveals the build CTA (inline pick → build wiring) without
+    // navigating anywhere — the actual kickoff mechanics are covered by the
+    // bound-tree recovery test below, which shares handleBuild.
+    await click(container.querySelector('input[type="checkbox"]'));
+    await waitForText(container, "Build your Context Tree");
+    expect(container.querySelector('[data-testid="location"]')?.textContent).toBe("/");
+
+    await act(async () => root.unmount());
+  });
+
+  it("returns to the allowlisted /context route when the install popup is blocked", async () => {
+    authMock.value = { organizationId: "org-1", role: "admin" };
+    agentApiMocks.listManagedAgents.mockResolvedValue([treeAgent]);
+    resourceApiMocks.listTeamResourcesForOrg.mockResolvedValue([]);
+    githubAppMocks.getGithubAppInstallation.mockResolvedValue(null);
+    // Popup blocked → window.open returns null → full-page redirect. The post-
+    // install `next` must be the allowlisted "/context" (not the raw pathname),
+    // or the server bounces the user to /settings/github after install.
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
+    const assignSpy = vi.spyOn(window.location, "assign").mockImplementation(() => undefined);
+    const { ContextPage } = await import("../context.js");
+    contextApiMocks.getContextTreeSnapshot.mockResolvedValue(unavailableSnapshot());
+
+    const { container, root } = await renderDom(<ContextPage />);
+    await waitForText(container, "Install First Tree on GitHub");
+    await click(buttonByText(container, "Install First Tree on GitHub"));
+    await flush();
+    expect(githubAppMocks.getGithubAppInstallUrl).toHaveBeenCalledWith("org-1", "/context");
+
+    openSpy.mockRestore();
+    assignSpy.mockRestore();
     await act(async () => root.unmount());
   });
 

--- a/packages/web/src/pages/context-tree-build-entry.tsx
+++ b/packages/web/src/pages/context-tree-build-entry.tsx
@@ -1,21 +1,41 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { ArrowRight, RefreshCw } from "lucide-react";
-import { useMemo, useState } from "react";
+import { ArrowRight, Github, RefreshCw } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router";
 import { listManagedAgents, type ManagedAgent } from "../api/agents.js";
+import { ApiError } from "../api/client.js";
+import { listOrgGithubRepos } from "../api/github.js";
+import { getGithubAppInstallation, getGithubAppInstallUrl } from "../api/github-app.js";
 import { listTeamResourcesForOrg } from "../api/resources.js";
 import { useAuth } from "../auth/auth-context.js";
 import { Button } from "../components/ui/button.js";
 import { Select } from "../components/ui/select.js";
+import { COPY } from "./onboarding/copy.js";
+import { FlowHint, RepoTokenPicker, StatusRow } from "./onboarding/flow-ui.js";
 import type { TreeBindingPlan } from "./onboarding/onboarding-flow.js";
 import { kickoffErrorMessage } from "./onboarding/provision-tree.js";
 import { ensureKickoffRepos, startTreeSetupKickoff } from "./onboarding/tree-kickoff.js";
+
+/**
+ * Per-tab marker set when the user kicks off a GitHub App install from this
+ * card, so a return render shows "waiting for GitHub" + a deliberate re-mint.
+ * Distinct key from the onboarding step so the two flows never cross. Same
+ * install-popup discipline as the onboarding connect-code step (see
+ * steps/step-connect-code.tsx) — kept as a small local copy on purpose so the
+ * critical first-run path stays untouched.
+ */
+const INSTALL_ATTEMPT_KEY = "context-build:install-attempt";
 
 /**
  * The team's single "build your Context Tree" action, on the Context tab.
  * Building is one chat-driven flow: connect code (if needed) → provision or
  * reuse the binding → start the `tree` agent chat that seeds/updates it. This
  * replaced the standalone `/build-tree` wizard page — there is one build home.
+ *
+ * When no code is connected yet, the connect + repo pick happens INLINE here
+ * (install the GitHub App, then choose from the repos it grants) instead of
+ * bouncing to Settings — the team already grants those repos, so sending the
+ * user off to retype a URL was busywork.
  *
  * Admin-only (the caller gates on role + setup status). It never edits the tree
  * in the tab; it just launches the chat where the agent does, so it does not
@@ -71,19 +91,19 @@ export function ContextTreeBuildEntry({
   const loading = agentsQuery.isLoading || resourcesQuery.isLoading;
   const chosenAgent: ManagedAgent | undefined = agents.find((a) => a.uuid === selectedAgentUuid) ?? agents[0];
 
-  const handleBuild = async (): Promise<void> => {
+  const handleBuild = async (sourceRepos: readonly string[]): Promise<void> => {
     if (!organizationId || !chosenAgent) return;
     setError(null);
     setPhase("building");
     try {
-      // New-tree setup registers selected repos before Cloud one-click creates
-      // the binding; recovery states with an existing binding only need to
-      // resend the idempotent tree kickoff.
-      if (repoUrls.length > 0) await ensureKickoffRepos(organizationId, repoUrls);
+      // New-tree setup registers the chosen repos before Cloud one-click creates
+      // the binding; a bound-tree recovery passes no repos and only re-sends the
+      // idempotent tree kickoff.
+      if (sourceRepos.length > 0) await ensureKickoffRepos(organizationId, sourceRepos);
       const chatId = await startTreeSetupKickoff({
         agent: chosenAgent,
         organizationId,
-        sourceRepos: repoUrls,
+        sourceRepos,
         treeBindingPlan,
         detectedTreeUrl,
         queryClient,
@@ -104,25 +124,9 @@ export function ContextTreeBuildEntry({
     );
   }
 
-  // No code connected and no tree binding → nothing to seed a new tree from.
-  // Recovery with an existing binding can still launch the setup chat so the
-  // agent reads the bound tree and decides seed vs. incremental update there.
-  if (!usesBoundTree && repoUrls.length === 0) {
-    return (
-      <div className="flex flex-col" style={{ gap: "var(--sp-2)" }}>
-        <span className="text-body" style={{ color: "var(--fg-2)" }}>
-          Connect a code repository first — your agent builds the tree from your code.
-        </span>
-        <div className="flex">
-          <Button type="button" variant="cta" onClick={() => navigate("/settings/resources")}>
-            <span>Connect your code</span>
-            <ArrowRight className="h-4 w-4" />
-          </Button>
-        </div>
-      </div>
-    );
-  }
-
+  // An agent is required to build, with or without code connected — so this check
+  // comes first. It also guarantees the inline connect+pick below always has an
+  // agent to hand the build to.
   if (agents.length === 0) {
     return (
       <div className="flex flex-col" style={{ gap: "var(--sp-2)" }}>
@@ -139,6 +143,249 @@ export function ContextTreeBuildEntry({
     );
   }
 
+  // No repo resource yet (and not a bound-tree recovery) → connect the GitHub App
+  // and pick a repo INLINE, then build. A bound-tree recovery skips this and
+  // re-sends the kickoff for the existing binding (no repo pick needed).
+  if (!usesBoundTree && repoUrls.length === 0) {
+    return (
+      <ConnectAndPickRepos
+        organizationId={organizationId}
+        agents={agents}
+        chosenAgent={chosenAgent}
+        onSelectAgent={setSelectedAgentUuid}
+        building={phase === "building"}
+        buildError={error}
+        onBuild={(sourceRepos) => void handleBuild(sourceRepos)}
+      />
+    );
+  }
+
+  // Code already connected (or a bound-tree recovery): pick the builder agent and
+  // build straight from the team's recommended repos.
+  return (
+    <BuildAgentControls
+      agents={agents}
+      chosenAgent={chosenAgent}
+      onSelectAgent={setSelectedAgentUuid}
+      building={phase === "building"}
+      buildError={error}
+      onBuild={() => void handleBuild(repoUrls)}
+    />
+  );
+}
+
+/**
+ * Inline "connect your code" for the no-repo state: install the GitHub App (if
+ * needed) in a popup, then pick from the repos the team's installation grants —
+ * the same install + pick the onboarding connect-code step does, surfaced here
+ * so the user never leaves the Context tab to wire up a repo.
+ */
+function ConnectAndPickRepos({
+  organizationId,
+  agents,
+  chosenAgent,
+  onSelectAgent,
+  building,
+  buildError,
+  onBuild,
+}: {
+  organizationId: string | null;
+  agents: ManagedAgent[];
+  chosenAgent: ManagedAgent | undefined;
+  onSelectAgent: (uuid: string | null) => void;
+  building: boolean;
+  buildError: string | null;
+  onBuild: (sourceRepos: readonly string[]) => void;
+}) {
+  const [selectedRepoUrls, setSelectedRepoUrls] = useState<string[]>([]);
+  const [redirecting, setRedirecting] = useState(false);
+  const [installError, setInstallError] = useState<"not_configured" | "not_admin" | "generic" | null>(null);
+  const [attempted, setAttempted] = useState(
+    () => typeof window !== "undefined" && !!window.sessionStorage.getItem(INSTALL_ATTEMPT_KEY),
+  );
+
+  // Poll for the installation until it appears: the popup installs on GitHub and
+  // self-closes, and this card advances on its own once the row shows up.
+  const installQuery = useQuery({
+    queryKey: ["context-build", "installation", organizationId],
+    queryFn: () => getGithubAppInstallation(organizationId ?? ""),
+    enabled: !!organizationId,
+    refetchInterval: (query) => (query.state.data ? false : 4000),
+  });
+  const installed = !!installQuery.data;
+
+  useEffect(() => {
+    if (installed && typeof window !== "undefined") window.sessionStorage.removeItem(INSTALL_ATTEMPT_KEY);
+  }, [installed]);
+
+  // The pickable repos come from the App installation's grant (server-minted
+  // token), not the caller's personal repos — so only repos the agent can
+  // actually reach show up.
+  const reposQuery = useQuery({
+    queryKey: ["context-build", "org-github-repos", organizationId],
+    queryFn: () => listOrgGithubRepos(organizationId ?? ""),
+    enabled: installed && !!organizationId,
+  });
+  const loadFailed = !!reposQuery.error;
+  const hasPickableRepos = !reposQuery.error && (reposQuery.data?.length ?? 0) > 0;
+
+  const handleConnect = async (): Promise<void> => {
+    if (!organizationId) return;
+    setInstallError(null);
+    setRedirecting(true);
+    // Open the popup synchronously inside the click gesture so the browser doesn't
+    // treat the post-await open as a blocked popup; fill its location once the
+    // install URL is minted. GitHub installs in that tab and lands it on
+    // /onboarding/connected to self-close, while this card keeps polling above.
+    const installTab = window.open("", "_blank");
+    // Popup path lands the new tab on the self-closing /onboarding/connected
+    // page; the popup-blocked full-redirect must return THIS tab to the card to
+    // finish the inline pick. Both targets are on the server's post-install
+    // allowlist (ALLOWED_POST_INSTALL_NEXT) — "/context" is the card's route, so
+    // an off-allowlist value isn't silently bounced to /settings/github.
+    const postInstallNext = installTab ? "/onboarding/connected" : "/context";
+    try {
+      const url = await getGithubAppInstallUrl(organizationId, postInstallNext);
+      window.sessionStorage.setItem(INSTALL_ATTEMPT_KEY, String(Date.now()));
+      setAttempted(true);
+      if (installTab) installTab.location.href = url;
+      else window.location.assign(url); // popup blocked — fall back to a full redirect
+      setRedirecting(false);
+    } catch (err) {
+      installTab?.close();
+      setRedirecting(false);
+      if (err instanceof ApiError && err.status === 503) setInstallError("not_configured");
+      else if (err instanceof ApiError && err.status === 403) setInstallError("not_admin");
+      else setInstallError("generic");
+    }
+  };
+
+  // Deliberate re-mint after a stuck install: a fresh URL overwrites the
+  // oauth-state nonce cookie, so retry is an explicit action — never an auto
+  // re-click while the first popup may still be mid-flow.
+  const handleStartOver = (): void => {
+    window.sessionStorage.removeItem(INSTALL_ATTEMPT_KEY);
+    setAttempted(false);
+    setInstallError(null);
+  };
+
+  const toggleRepo = (cloneUrl: string): void => {
+    setSelectedRepoUrls((prev) => (prev.includes(cloneUrl) ? prev.filter((u) => u !== cloneUrl) : [...prev, cloneUrl]));
+  };
+
+  // ── Not connected yet ──────────────────────────────────────────────────
+  if (!installed) {
+    // The two install errors that can't be fixed here (App not set up on this
+    // server / caller isn't an org admin) share one message — building needs the
+    // App and only an org owner can install it, so there's no inline way forward.
+    if (installError === "not_configured" || installError === "not_admin") {
+      return <FlowHint>{COPY.connectCode.cantConnectRecovery}</FlowHint>;
+    }
+    return (
+      <div className="flex flex-col" style={{ gap: "var(--sp-3)" }}>
+        <div className="flex">
+          <Button
+            type="button"
+            variant="cta"
+            onClick={() => void handleConnect()}
+            disabled={redirecting || attempted || !organizationId}
+          >
+            <Github className="h-4 w-4" />
+            <span>{COPY.connectCode.cta}</span>
+          </Button>
+        </div>
+        <p className="text-label" style={{ margin: 0, color: "var(--fg-4)" }}>
+          {COPY.connectCode.notOwnerHint.pre}
+          <span className="font-medium" style={{ color: "var(--fg-3)" }}>
+            {COPY.connectCode.notOwnerHint.emphasis}
+          </span>
+          {COPY.connectCode.notOwnerHint.post}
+        </p>
+        {installError === "generic" && (
+          <FlowHint tone="error" role="alert">
+            {COPY.errors.generic}
+          </FlowHint>
+        )}
+        {attempted ? (
+          <div className="flex items-center" style={{ gap: "var(--sp-2_5)", flexWrap: "wrap" }}>
+            <StatusRow state="waiting" label={COPY.connectCode.waiting} />
+            <Button type="button" variant="link" className="h-auto p-0 text-label" onClick={handleStartOver}>
+              {COPY.connectCode.restartInstall}
+            </Button>
+          </div>
+        ) : null}
+      </div>
+    );
+  }
+
+  // ── Connected — pick a repo, then build ────────────────────────────────
+  return (
+    <div className="flex flex-col" style={{ gap: "var(--sp-3)" }}>
+      <div className="flex flex-col" style={{ gap: "var(--sp-2)" }}>
+        {hasPickableRepos && (
+          <p className="text-label font-medium" style={{ margin: 0, color: "var(--fg-2)" }}>
+            {COPY.connectCode.pickProject}
+          </p>
+        )}
+        {reposQuery.isLoading ? (
+          <p className="text-label" style={{ margin: 0, color: "var(--fg-4)" }}>
+            {COPY.connectCode.loading}
+          </p>
+        ) : loadFailed ? (
+          <div className="flex flex-col" style={{ gap: "var(--sp-2)" }}>
+            <FlowHint tone="error" role="alert">
+              {COPY.connectCode.loadFailedRecovery}
+            </FlowHint>
+            <div className="flex">
+              <Button type="button" onClick={() => void reposQuery.refetch()}>
+                {COPY.connectCode.loadFailedRetry}
+              </Button>
+            </div>
+          </div>
+        ) : (reposQuery.data?.length ?? 0) === 0 ? (
+          <FlowHint>{COPY.connectCode.noReposRecovery}</FlowHint>
+        ) : (
+          <RepoTokenPicker
+            repos={reposQuery.data ?? []}
+            selected={selectedRepoUrls}
+            onToggle={toggleRepo}
+            onClear={() => setSelectedRepoUrls([])}
+          />
+        )}
+      </div>
+      {selectedRepoUrls.length > 0 ? (
+        <BuildAgentControls
+          agents={agents}
+          chosenAgent={chosenAgent}
+          onSelectAgent={onSelectAgent}
+          building={building}
+          buildError={buildError}
+          onBuild={() => onBuild(selectedRepoUrls)}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * Agent selector (only shown when >1 agent) + the "Build your Context Tree" CTA.
+ * Shared by the code-already-connected state and the just-picked-a-repo state.
+ */
+function BuildAgentControls({
+  agents,
+  chosenAgent,
+  onSelectAgent,
+  building,
+  buildError,
+  onBuild,
+}: {
+  agents: ManagedAgent[];
+  chosenAgent: ManagedAgent | undefined;
+  onSelectAgent: (uuid: string | null) => void;
+  building: boolean;
+  buildError: string | null;
+  onBuild: () => void;
+}) {
   return (
     <div className="flex flex-col" style={{ gap: "var(--sp-3)" }}>
       {agents.length > 1 ? (
@@ -149,19 +396,19 @@ export function ContextTreeBuildEntry({
           <Select
             aria-label="Agent that builds the Context Tree"
             value={chosenAgent?.uuid ?? ""}
-            onChange={(v) => setSelectedAgentUuid(v || null)}
+            onChange={(v) => onSelectAgent(v || null)}
             options={agents.map((a) => ({ value: a.uuid, label: agentLabel(a) }))}
           />
         </div>
       ) : null}
-      {error ? (
+      {buildError ? (
         <div className="text-label" style={{ color: "var(--state-error)" }}>
-          {error}
+          {buildError}
         </div>
       ) : null}
       <div className="flex">
-        <Button type="button" variant="cta" disabled={phase === "building"} onClick={() => void handleBuild()}>
-          {phase === "building" ? (
+        <Button type="button" variant="cta" disabled={building} onClick={() => onBuild()}>
+          {building ? (
             <>
               <RefreshCw className="h-4 w-4 animate-spin" />
               <span>Building…</span>

--- a/packages/web/src/pages/context-tree-preview.tsx
+++ b/packages/web/src/pages/context-tree-preview.tsx
@@ -39,6 +39,35 @@ const AGENTS = [
 const REPO_RESOURCE = [
   { type: "repo", defaultEnabled: "recommended", payload: { url: "https://github.com/acme/acme-web" } },
 ];
+// GitHub App installation + the repos it grants — seeds the inline connect+pick
+// states of the Context tab build entry (no repo resource yet).
+const INSTALLATION = {
+  installationId: 42,
+  accountLogin: "acme",
+  accountType: "Organization",
+  manageUrl: "https://github.com/organizations/acme/settings/installations/42",
+  suspended: false,
+  permissions: {},
+  events: [],
+};
+const GH_REPOS = [
+  {
+    fullName: "acme/acme-web",
+    cloneUrl: "https://github.com/acme/acme-web.git",
+    htmlUrl: "https://github.com/acme/acme-web",
+    private: true,
+    defaultBranch: "main",
+    pushedAt: null,
+  },
+  {
+    fullName: "acme/acme-api",
+    cloneUrl: "https://github.com/acme/acme-api.git",
+    htmlUrl: "https://github.com/acme/acme-api",
+    private: true,
+    defaultBranch: "main",
+    pushedAt: null,
+  },
+];
 const FEATURES_DISABLED = { contextReviewer: { enabled: false, agentUuid: null } };
 const FEATURES_ENABLED = { contextReviewer: { enabled: true, agentUuid: "0192bbbb-bot2" } };
 // Enabled, but the saved reviewer is no longer one of the admin's active agents.
@@ -204,10 +233,20 @@ export function ContextTreePreviewPage() {
           ]}
         />
         <BuildEntryCase
-          title="no repo connected"
+          title="no repo · GitHub not connected (install CTA)"
           seed={[
             [["context-build", "managed-agents", ORG], AGENTS],
             [["context-build", "resources", ORG], []],
+            [["context-build", "installation", ORG], null],
+          ]}
+        />
+        <BuildEntryCase
+          title="no repo · connected → pick a repo inline"
+          seed={[
+            [["context-build", "managed-agents", ORG], AGENTS],
+            [["context-build", "resources", ORG], []],
+            [["context-build", "installation", ORG], INSTALLATION],
+            [["context-build", "org-github-repos", ORG], GH_REPOS],
           ]}
         />
         <BuildEntryCase


### PR DESCRIPTION
## What & why

Follow-up to #1251. When a team has no Context Tree yet, the Context tab build entry's **"Connect your code"** button sent the user to `/settings/resources` to type a repo URL by hand. But once the team's GitHub App is installed, First Tree already knows which repos it grants — so that bounce was busywork. (And `/settings/github` alone wouldn't fix it either: the build gate keys on having a repo **resource**, which installing the App doesn't create.)

Now the connect + repo pick happen **inline on the card**:

- **No GitHub App** → install it in a popup (the same install flow onboarding uses), card polls and advances on its own once it lands.
- **App installed** → list the repos the installation grants and let the user pick (`listOrgGithubRepos` + the onboarding `RepoTokenPicker`), then choose the builder agent and build.

No more leaving the Context tab to wire up a repo.

## Implementation notes

- **Reuses the onboarding connect-code building blocks** (`RepoTokenPicker`, `FlowHint`/`StatusRow`, `COPY.connectCode.*`, `getGithubAppInstallation`/`getGithubAppInstallUrl`/`listOrgGithubRepos`, `ensureKickoffRepos`/`startTreeSetupKickoff`) — no new visual components. The only new code is the orchestration that assembles them on the card (`ConnectAndPickRepos`) plus a factored-out `BuildAgentControls`.
- The install-popup logic is a deliberate **local copy** of `StepConnectCode`'s (synchronous `window.open`, install-attempt marker, `oauth_state_nonce`-safe re-mint), kept separate on purpose so onboarding's critical first-connect path stays untouched. A future refactor could extract a shared hook.
- The **agent check now runs before the no-repo check**, so the inline pick always has an agent to hand the build to. A bound-tree recovery still builds straight from its binding (unchanged).

## Popup-blocked redirect (server)

When the install popup is blocked, the full-page redirect must return to the card to finish the inline pick. The post-install `next` is server-allowlisted (`ALLOWED_POST_INSTALL_NEXT`) — anything off it is silently rewritten to `/settings/github`. So the web passes the allowlisted `/context`, and `/context` is added to the allowlist, **replacing the now-removed `/build-tree`** entry (its recovery role moved onto the Context tab in #1251). Without this, a popup-blocked install would land the user back on Settings — the exact bounce this PR removes. (Caught by an independent codex review.)

## Testing

- `biome` + `tsc` + web `lint:tokens` clean; root `pnpm check` + `pnpm typecheck` (12/12 packages) green.
- Web: 1008 tests pass, incl. new cases — no-repo → inline install CTA (not a Settings bounce), connected → inline repo list + pick → build CTA, and popup-blocked → allowlisted `/context`.
- Server: `post-install-next` / `install-url` / `github-app-callback` tests pass with the `/context` allowlist change.
- Verified each state visually against the real components via the DEV `/preview/context-tree` gallery.

## Review

Two independent reviews before opening: codex (external) flagged the popup-blocked redirect issue above — fixed; a Claude review returned SHIP with two hardening items (mock completeness + inline pick→build coverage) folded in.
