### PR TITLE
fix: recover service unit after CLI entry update

### DIFF
--- a/apps/cli/bin/first-tree.cjs
+++ b/apps/cli/bin/first-tree.cjs
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+
+const { spawnSync } = require("node:child_process");
+const { join } = require("node:path");
+
+const cli = join(__dirname, "..", "dist", "cli", "index.mjs");
+const result = spawnSync(process.execPath, [cli, ...process.argv.slice(2)], {
+  stdio: "inherit",
+});
+
+if (result.signal) {
+  process.kill(process.pid, result.signal);
+}
+process.exit(result.status ?? 1);

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -26,6 +26,7 @@
     "ftd": "./dist/cli/index.mjs"
   },
   "files": [
+    "bin",
     "dist",
     "skills",
     "README.md",

--- a/apps/cli/src/__tests__/daemon-start-command.test.ts
+++ b/apps/cli/src/__tests__/daemon-start-command.test.ts
@@ -22,12 +22,14 @@ const coreMocks = vi.hoisted(() => ({
   getClientServiceStatus: vi.fn(),
   handleClientOrgMismatch: vi.fn(),
   isServiceSupported: vi.fn(),
+  isServiceUnitDriftDetected: vi.fn(),
   listPinnedAgents: vi.fn(),
   loadCredentials: vi.fn(),
   migrateLocalAgentDirs: vi.fn(),
   promptMissingFields: vi.fn(),
   promptUpdate: vi.fn(),
   reconcileLocalRuntimeProviders: vi.fn(),
+  refreshClientServiceUnitForUpdate: vi.fn(),
   refreshServerUpdateTarget: vi.fn(),
   startClientService: vi.fn(),
   uploadAgentSkills: vi.fn(),
@@ -115,6 +117,14 @@ beforeEach(() => {
   clientMocks.discoverClaudeCodeSkills.mockResolvedValue([{ name: "review", description: "Review code." }]);
   coreMocks.loadCredentials.mockReturnValue({ refreshToken: "refresh" });
   coreMocks.isServiceSupported.mockReturnValue(false);
+  coreMocks.isServiceUnitDriftDetected.mockReturnValue(false);
+  coreMocks.refreshClientServiceUnitForUpdate.mockReturnValue({
+    platform: "systemd",
+    state: "active",
+    label: "first-tree-dev.service",
+    unitPath: join(home, "unit.service"),
+    logDir: join(home, "logs"),
+  });
   coreMocks.getClientServiceStatus.mockReturnValue({
     platform: "launchd",
     state: "not-installed",
@@ -347,6 +357,17 @@ describe("daemon start command", () => {
         update: expect.objectContaining({ prompt: coreMocks.declineUpdate }),
       }),
     );
+  });
+
+  it("refreshes a drifted service unit when a supervisor child starts", async () => {
+    process.env.FIRST_TREE_SERVICE_MODE = "1";
+    coreMocks.isServiceSupported.mockReturnValue(true);
+    coreMocks.isServiceUnitDriftDetected.mockReturnValue(true);
+
+    await expect(runStart(["--no-interactive"])).rejects.toMatchObject({ exitCode: 1 });
+
+    expect(coreMocks.refreshClientServiceUnitForUpdate).toHaveBeenCalledTimes(1);
+    expect(output()).toContain("service unit refreshed");
   });
 
   it("does not treat non-supervisor --no-interactive inline runs as managed updates", async () => {

--- a/apps/cli/src/__tests__/package-metadata.test.ts
+++ b/apps/cli/src/__tests__/package-metadata.test.ts
@@ -32,7 +32,7 @@ describe("npm package metadata", () => {
   it("includes package-root documentation and license files in the tarball allow-list", () => {
     const files = packageFiles(readJson(join(CLI_ROOT, "package.json")));
 
-    expect(files).toEqual(expect.arrayContaining(["dist", "README.md", "LICENSE"]));
+    expect(files).toEqual(expect.arrayContaining(["bin", "dist", "README.md", "LICENSE"]));
   });
 
   it("keeps a package-local README for the npm registry page", () => {

--- a/apps/cli/src/__tests__/service-install-core.test.ts
+++ b/apps/cli/src/__tests__/service-install-core.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -124,6 +124,72 @@ describe("service install helpers", () => {
       program: "/opt/node/bin/node",
       args: ["/repo/dist/cli/index.mjs"],
     });
+  });
+
+  it("keeps the npm bin shim path instead of resolving it to package-internal dist", () => {
+    const prefix = join(home, "npm-prefix");
+    const binDir = join(prefix, "bin");
+    const pkgDist = join(
+      prefix,
+      "lib",
+      "node_modules",
+      channelConfig.packageName ?? channelConfig.binName,
+      "dist",
+      "cli",
+    );
+    mkdirSync(binDir, { recursive: true });
+    mkdirSync(pkgDist, { recursive: true });
+    const target = join(pkgDist, "index.mjs");
+    writeFileSync(target, "#!/usr/bin/env node\n");
+    const binLink = join(binDir, channelConfig.binName);
+    symlinkSync(target, binLink);
+    execFileSyncMock.mockReturnValueOnce(`${binLink}\n`);
+
+    const invocation = resolveCliInvocation();
+    expect(invocation).toEqual({ kind: "bin", program: binLink });
+
+    const unit = renderSystemdUnit(invocation, {});
+    expect(unit).toContain(`ExecStart=${binLink} daemon start --no-interactive`);
+    const pathLine = unit.split("\n").find((line) => line.startsWith("Environment=PATH="));
+    expect(pathLine?.replace("Environment=PATH=", "").split(":")).toContain(binDir);
+  });
+
+  it("infers the npm bin shim from a package-internal argv path when PATH lacks the shim dir", () => {
+    const prefix = join(home, "npm-prefix");
+    const binDir = join(prefix, "bin");
+    const pkgDist = join(
+      prefix,
+      "lib",
+      "node_modules",
+      channelConfig.packageName ?? channelConfig.binName,
+      "dist",
+      "cli",
+    );
+    mkdirSync(binDir, { recursive: true });
+    mkdirSync(pkgDist, { recursive: true });
+    const target = join(pkgDist, "index.mjs");
+    writeFileSync(target, "#!/usr/bin/env node\n");
+    const binLink = join(binDir, channelConfig.binName);
+    symlinkSync(target, binLink);
+    execFileSyncMock.mockImplementationOnce(() => {
+      throw new Error("not found");
+    });
+    process.argv = ["node", target];
+
+    expect(resolveCliInvocation()).toEqual({ kind: "bin", program: binLink });
+  });
+
+  it("keeps an absolute bin argv as the service invocation when PATH lacks the shim dir", () => {
+    const binDir = join(home, "npm-prefix", "bin");
+    mkdirSync(binDir, { recursive: true });
+    const binPath = join(binDir, channelConfig.binName);
+    writeFileSync(binPath, "#!/usr/bin/env node\n");
+    execFileSyncMock.mockImplementationOnce(() => {
+      throw new Error("not found");
+    });
+    process.argv = ["node", binPath];
+
+    expect(resolveCliInvocation()).toEqual({ kind: "bin", program: binPath });
   });
 
   it("renders service templates with escaped values and quoted shell arguments", () => {
@@ -273,6 +339,7 @@ describe("service install helpers", () => {
     setPlatform("linux");
     spawnSyncMock
       .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" })
+      .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" })
       .mockReturnValueOnce({ status: 0, stdout: "no\n", stderr: "" })
       .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" })
       .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" })
@@ -296,6 +363,7 @@ describe("service install helpers", () => {
     expect(unit).toContain(`Environment=FIRST_TREE_HOME=${process.env.FIRST_TREE_HOME}`);
     expect(spawnSyncMock.mock.calls.map((call) => [call[0], call[1]])).toEqual([
       ["systemctl", ["--user", "daemon-reload"]],
+      ["systemctl", ["--user", "reset-failed", channelConfig.serviceUnitFile]],
       ["loginctl", ["show-user", "gandy", "-p", "Linger", "--value"]],
       ["loginctl", ["enable-linger", "gandy"]],
       ["systemctl", ["--user", "enable", "--now", channelConfig.serviceUnitFile]],
@@ -312,10 +380,12 @@ describe("service install helpers", () => {
     spawnSyncMock.mockReset();
     spawnSyncMock
       .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" })
+      .mockReturnValueOnce({ status: 1, stdout: "", stderr: "start-limit still busy" })
       .mockReturnValueOnce({ status: 0, stdout: "no\n", stderr: "" })
       .mockReturnValueOnce({ status: 1, stdout: "", stderr: "linger denied" })
       .mockReturnValueOnce({ status: 1, stdout: "", stderr: "enable failed" });
     expect(() => installClientService()).toThrow("systemctl --user enable --now");
+    expect(printMocks.line).toHaveBeenCalledWith(expect.stringContaining("systemctl reset-failed"));
     expect(printMocks.line).toHaveBeenCalledWith(
       expect.stringContaining("loginctl enable-linger failed: linger denied"),
     );
@@ -336,6 +406,7 @@ describe("service install helpers", () => {
     setPlatform("linux");
     spawnSyncMock
       .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" })
+      .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" })
       .mockReturnValueOnce({ status: 0, stdout: "yes\n", stderr: "" })
       .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" })
       .mockReturnValueOnce({ status: 0, stdout: "inactive\n", stderr: "" });
@@ -343,6 +414,7 @@ describe("service install helpers", () => {
     expect(installClientService()).toMatchObject({ platform: "systemd", state: "inactive" });
     expect(spawnSyncMock.mock.calls.map((call) => [call[0], call[1]])).toEqual([
       ["systemctl", ["--user", "daemon-reload"]],
+      ["systemctl", ["--user", "reset-failed", channelConfig.serviceUnitFile]],
       ["loginctl", ["show-user", "gandy", "-p", "Linger", "--value"]],
       ["systemctl", ["--user", "enable", "--now", channelConfig.serviceUnitFile]],
       ["systemctl", ["--user", "is-active", channelConfig.serviceUnitFile]],

--- a/apps/cli/src/__tests__/update-glue.test.ts
+++ b/apps/cli/src/__tests__/update-glue.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { channelConfig } from "../core/channel.js";
 
 const updateMocks = vi.hoisted(() => ({
   detectInstallMode: vi.fn(),
@@ -10,6 +9,10 @@ const updateMocks = vi.hoisted(() => ({
 const updateStateMocks = vi.hoisted(() => ({
   isLoopGuarded: vi.fn(),
   recordUpdateAttempt: vi.fn(),
+}));
+
+const serviceInstallMocks = vi.hoisted(() => ({
+  resolveCliInvocation: vi.fn(),
 }));
 
 const spawnSyncMock = vi.hoisted(() => vi.fn());
@@ -24,6 +27,7 @@ vi.mock("node:child_process", () => ({
 
 vi.mock("../core/update.js", () => updateMocks);
 vi.mock("../core/update-state.js", () => updateStateMocks);
+vi.mock("../core/service-install.js", () => serviceInstallMocks);
 vi.mock("../core/output.js", () => ({
   print: { line: printLineMock },
 }));
@@ -38,6 +42,7 @@ describe("update glue", () => {
     updateMocks.installGlobalSpec.mockReset();
     updateStateMocks.isLoopGuarded.mockReset();
     updateStateMocks.recordUpdateAttempt.mockReset();
+    serviceInstallMocks.resolveCliInvocation.mockReset();
     spawnSyncMock.mockReset();
     printLineMock.mockClear();
     exitMock.mockClear();
@@ -49,6 +54,10 @@ describe("update glue", () => {
       installedVersion: "0.6.0",
     });
     updateStateMocks.isLoopGuarded.mockReturnValue(false);
+    serviceInstallMocks.resolveCliInvocation.mockReturnValue({
+      kind: "bin",
+      program: "/home/alice/.npm/bin/first-tree",
+    });
     spawnSyncMock.mockReturnValue({ status: 0, signal: null });
   });
 
@@ -146,7 +155,7 @@ describe("update glue", () => {
       createExecuteUpdate({ managed: true })({ currentVersion: "0.5.0", targetVersion: "0.6.0" }),
     ).rejects.toMatchObject({ exitCode: SELF_RESTART_EXIT_CODE });
     expect(spawnSyncMock).toHaveBeenCalledWith(
-      channelConfig.binName,
+      "/home/alice/.npm/bin/first-tree",
       ["daemon", "refresh-unit"],
       expect.objectContaining({ timeout: 45_000 }),
     );

--- a/apps/cli/src/commands/daemon/start.ts
+++ b/apps/cli/src/commands/daemon/start.ts
@@ -31,12 +31,14 @@ import {
   getClientServiceStatus,
   handleClientOrgMismatch,
   isServiceSupported,
+  isServiceUnitDriftDetected,
   listPinnedAgents,
   loadCredentials,
   migrateLocalAgentDirs,
   promptMissingFields,
   promptUpdate,
   reconcileLocalRuntimeProviders,
+  refreshClientServiceUnitForUpdate,
   refreshServerUpdateTarget,
   runRuntimeAuthLogin,
   startClientService,
@@ -166,6 +168,18 @@ export function registerDaemonStartCommand(daemon: Command): void {
         // capture stays empty under normal operation.
         if (process.env.FIRST_TREE_SERVICE_MODE === "1") {
           configureClientLoggerForService(join(defaultHome(), "logs"));
+        }
+
+        if (isSupervisorChild && isServiceSupported()) {
+          try {
+            if (isServiceUnitDriftDetected()) {
+              const info = refreshClientServiceUnitForUpdate();
+              print.status("•", `service unit refreshed at ${info.unitPath}`);
+            }
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            print.status("⚠️", `service unit refresh skipped: ${msg}`);
+          }
         }
 
         // Load agents (may be empty — daemon can start without agents).

--- a/apps/cli/src/core/service-install.ts
+++ b/apps/cli/src/core/service-install.ts
@@ -1,7 +1,7 @@
 import { execFileSync, spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { homedir, userInfo } from "node:os";
-import { dirname, isAbsolute, join } from "node:path";
+import { basename, dirname, isAbsolute, join } from "node:path";
 import { defaultHome } from "@first-tree/shared/config";
 import { channelConfig } from "./channel.js";
 import { print } from "./output.js";
@@ -106,9 +106,9 @@ function launchdWrapperPath(): string {
   return join(defaultHome(), "service", LAUNCHD_DISPLAY_NAME);
 }
 
-function servicePathEnv(basePaths: readonly string[]): string {
+function servicePathEnv(basePaths: readonly string[], extraPaths: readonly string[] = []): string {
   const seen = new Set<string>();
-  const paths = [dirname(process.execPath), ...basePaths].filter((value) => {
+  const paths = [dirname(process.execPath), ...extraPaths, ...basePaths].filter((value) => {
     if (seen.has(value)) return false;
     seen.add(value);
     return true;
@@ -116,12 +116,16 @@ function servicePathEnv(basePaths: readonly string[]): string {
   return paths.join(":");
 }
 
-function systemdPathEnv(): string {
-  return servicePathEnv(SYSTEMD_BASE_PATH);
+function invocationPathEntries(invocation?: ResolvedBinary): string[] {
+  return invocation?.kind === "bin" ? [dirname(invocation.program)] : [];
 }
 
-function launchdPathEnv(): string {
-  return servicePathEnv(LAUNCHD_BASE_PATH);
+function systemdPathEnv(invocation?: ResolvedBinary): string {
+  return servicePathEnv(SYSTEMD_BASE_PATH, invocationPathEntries(invocation));
+}
+
+function launchdPathEnv(invocation?: ResolvedBinary): string {
+  return servicePathEnv(LAUNCHD_BASE_PATH, invocationPathEntries(invocation));
 }
 
 const PROXY_ENV_KEYS = [
@@ -196,12 +200,13 @@ function whichBin(name: string): string | null {
  * `first-tree-staging` / `first-tree-dev`), so a PATH lookup against
  * `channelConfig.binName` cannot collide with another channel's install.
  *
- *   ① bin found on PATH — use the installed shim. For npm-installed
+ *   ① bin found on PATH — use the installed shim path. For npm-installed
  *      packages (prod, staging) the shim is usually under /usr/local/bin
  *      or ~/.npm-global/bin; for dev it's typically a symlink under
- *      ~/.local/bin pointing at the in-tree dist. Either way, using the
- *      shim means a re-install / re-link atomically swaps the binary
- *      without rewriting the unit file.
+ *      ~/.local/bin pointing at the in-tree dist. Keep the shim path in
+ *      service files: npm re-install / re-link atomically swaps it, while
+ *      resolving it to the package-internal dist path can leave systemd
+ *      executing a file removed by the next package version.
  *
  *   ② bin NOT on PATH — pin to the running interpreter + script. Common
  *      for dev when `~/.local/bin` is not in the install-time shell's
@@ -212,12 +217,7 @@ function whichBin(name: string): string | null {
 export function resolveCliInvocation(): ResolvedBinary {
   const bin = whichBin(channelConfig.binName);
   if (bin && isAbsolute(bin)) {
-    try {
-      // Resolve symlinks so launchd records a stable path.
-      return { kind: "bin", program: realpathSync(bin) };
-    } catch {
-      return { kind: "bin", program: bin };
-    }
+    return { kind: "bin", program: bin };
   }
 
   const script = process.argv[1];
@@ -225,7 +225,23 @@ export function resolveCliInvocation(): ResolvedBinary {
     throw new Error("Cannot resolve CLI entry point (process.argv[1] is empty).");
   }
   const scriptAbs = isAbsolute(script) ? script : join(process.cwd(), script);
+  if (basename(scriptAbs) === channelConfig.binName && existsSync(scriptAbs)) {
+    return { kind: "bin", program: scriptAbs };
+  }
+  const inferredShim = inferNpmGlobalShimFromScript(scriptAbs);
+  if (inferredShim) return { kind: "bin", program: inferredShim };
   return { kind: "node", program: process.execPath, args: [scriptAbs] };
+}
+
+function inferNpmGlobalShimFromScript(scriptAbs: string): string | null {
+  const packageName = channelConfig.packageName ?? channelConfig.binName;
+  const marker = `/lib/node_modules/${packageName}/`;
+  const markerIndex = scriptAbs.indexOf(marker);
+  if (markerIndex <= 0) return null;
+
+  const prefix = scriptAbs.slice(0, markerIndex);
+  const shim = join(prefix, "bin", channelConfig.binName);
+  return existsSync(shim) ? shim : null;
 }
 
 function ensureLogDir(): void {
@@ -245,7 +261,11 @@ function launchdPlistPath(): string {
  * itself `exec`s the resolved CLI invocation with the daemon args (see
  * `renderLaunchdWrapper`), so nothing else needs to be on the command line.
  */
-export function renderPlist(wrapperPath: string, proxyEnv: Record<string, string> = collectProxyEnv()): string {
+export function renderPlist(
+  wrapperPath: string,
+  proxyEnv: Record<string, string> = collectProxyEnv(),
+  invocation?: ResolvedBinary,
+): string {
   const programArgs: string[] = [wrapperPath];
 
   const argsXml = programArgs.map((a) => `    <string>${escapeXml(a)}</string>`).join("\n");
@@ -273,7 +293,9 @@ export function renderPlist(wrapperPath: string, proxyEnv: Record<string, string
   // launchd does not inherit the operator's interactive shell PATH. Put the
   // current Node directory first so npm-installed CLI shims and self-update
   // run under the same Node toolchain that installed/refreshed the service.
-  const pathEnvXml = escapeXml(launchdPathEnv());
+  // If the CLI shim lives outside the Node directory (custom npm prefix),
+  // include that directory too so in-daemon refresh-unit can find it.
+  const pathEnvXml = escapeXml(launchdPathEnv(invocation));
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTD/PropertyList-1.0.dtd">
@@ -398,7 +420,7 @@ function writeLaunchdServiceFiles(): { plistPath: string; wrapperPath: string } 
 
   const plistPath = launchdPlistPath();
   mkdirSync(dirname(plistPath), { recursive: true });
-  writeFileSync(plistPath, renderPlist(wrapperPath), { mode: 0o644 });
+  writeFileSync(plistPath, renderPlist(wrapperPath, collectProxyEnv(), invocation), { mode: 0o644 });
 
   return { plistPath, wrapperPath };
 }
@@ -541,8 +563,10 @@ export function renderSystemdUnit(
   const homeEnv = `Environment=FIRST_TREE_HOME=${shellQuote(defaultHome())}\n`;
   // `systemd --user` does not inherit the operator's interactive shell PATH.
   // Put this CLI's Node directory first so npm/nvm-installed shebangs and
-  // self-update use the same Node toolchain when supervised.
-  const pathEnv = `Environment=PATH=${shellQuote(systemdPathEnv())}\n`;
+  // self-update use the same Node toolchain when supervised. If the CLI shim
+  // lives outside the Node directory (custom npm prefix), include that
+  // directory too so in-daemon refresh-unit can find it before exiting 75.
+  const pathEnv = `Environment=PATH=${shellQuote(systemdPathEnv(invocation))}\n`;
 
   // Forward shell-side proxy env (see `collectProxyEnv` docblock for why).
   const proxyEnvLines = Object.entries(proxyEnv)
@@ -645,6 +669,15 @@ function tryEnableLinger(): { ok: true; alreadyOn: boolean } | { ok: false; reas
   return { ok: false, reason: res.stderr || `exit ${res.code ?? "unknown"}` };
 }
 
+function resetSystemdFailedState(): void {
+  const res = runCapture("systemctl", ["--user", "reset-failed", SYSTEMD_UNIT], 5_000);
+  if (!res.ok) {
+    print.line(
+      `    warning: systemctl reset-failed ${SYSTEMD_UNIT} failed: ${res.stderr || `exit ${res.code ?? "unknown"}`}\n`,
+    );
+  }
+}
+
 function installSystemd(): ServiceInfo {
   // Legacy unit auto-cleanup deliberately not done here — same reason
   // as `installLaunchd` above. A blanket `disable --now` + `rm` of
@@ -665,6 +698,11 @@ function installSystemd(): ServiceInfo {
     );
   }
 
+  // A broken ExecStart can trip StartLimitBurst before the refreshed unit is
+  // written. Clear that hold-back before enable --now so install/refresh can
+  // recover immediately instead of waiting for StartLimitIntervalSec.
+  resetSystemdFailedState();
+
   // Enable linger BEFORE enable --now so the unit can survive logout from
   // the very first session. Best-effort: if polkit denies it, surface a
   // warning with the manual recovery command rather than failing install.
@@ -680,7 +718,7 @@ function installSystemd(): ServiceInfo {
   if (!enableRes.ok) {
     throw new Error(
       `systemctl --user enable --now ${SYSTEMD_UNIT} failed: ${enableRes.stderr || `exit ${enableRes.code ?? "unknown"}`}\n` +
-        `    Recovery: \`systemctl --user stop ${SYSTEMD_UNIT}\` then \`${channelConfig.binName} login <token>\`.`,
+        `    Recovery: \`systemctl --user reset-failed ${SYSTEMD_UNIT}\` then \`${channelConfig.binName} login <token>\`.`,
     );
   }
 
@@ -795,7 +833,7 @@ function launchdUnitDriftDetected(): boolean {
   // upgrade or install-path move — check both or auto-update would skip a
   // reinstall and keep launching a stale binary.
   const wrapperDrift = readFileOrFlagDrift(wrapperPath, renderLaunchdWrapper(invocation));
-  const plistDrift = readFileOrFlagDrift(launchdPlistPath(), renderPlist(wrapperPath));
+  const plistDrift = readFileOrFlagDrift(launchdPlistPath(), renderPlist(wrapperPath, collectProxyEnv(), invocation));
   return wrapperDrift || plistDrift;
 }
 

--- a/apps/cli/src/core/update-glue.ts
+++ b/apps/cli/src/core/update-glue.ts
@@ -4,6 +4,7 @@ import { confirm } from "@inquirer/prompts";
 import * as semver from "semver";
 import { channelConfig } from "./channel.js";
 import { print } from "./output.js";
+import { resolveCliInvocation } from "./service-install.js";
 import { detectInstallMode, fetchServerCommandVersion, installGlobalSpec, PACKAGE_NAME } from "./update.js";
 import { isLoopGuarded, recordUpdateAttempt } from "./update-state.js";
 
@@ -257,8 +258,11 @@ function refreshServiceUnit(): void {
   // templates.
   const bin = channelConfig.binName;
   const recovery = `\`${bin} logout && ${bin} login <token>\``;
+  const invocation = resolveCliInvocation();
+  const program = invocation.program;
+  const args = invocation.kind === "bin" ? ["daemon", "refresh-unit"] : [...invocation.args, "daemon", "refresh-unit"];
   try {
-    const res = spawnSync(bin, ["daemon", "refresh-unit"], {
+    const res = spawnSync(program, args, {
       stdio: ["ignore", "inherit", "inherit"],
       timeout: 45_000,
       // Sanitize FIRST_TREE_SERVICE_MODE so the child doesn't think it's


### PR DESCRIPTION
## Summary
- Restore a compatibility `bin/first-tree.cjs` entry so existing systemd units that still point at the old package-internal wrapper do not fail with `203/EXEC` after the CLI entrypoint update.
- Keep refreshed systemd/launchd units pointed at the stable npm bin shim, include the shim directory in service `PATH`, and refresh service units through a resolved absolute CLI invocation.
- Clear systemd start-limit state with best-effort `systemctl --user reset-failed` before `enable --now`, and let supervisor-started daemons self-heal drifted service units.

## Companion Context Tree PR
- https://github.com/agent-team-foundation/first-tree-context/pull/608

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm --filter first-tree-dev test -- src/__tests__/service-install-core.test.ts src/__tests__/daemon-start-command.test.ts src/__tests__/update-glue.test.ts src/__tests__/daemon-refresh-unit.test.ts src/__tests__/package-metadata.test.ts src/__tests__/render-unit-channel.test.ts` (exercised 63 CLI test files / 511 tests)
- `pnpm check`
- `pnpm typecheck`
- `npm pack --dry-run --json` from `apps/cli` (confirmed `bin/first-tree.cjs` is included and executable)
- `apps/cli/bin/first-tree.cjs --version`
- `git diff --check`
