### PR TITLE
fix(client): widen working_grace default 1h→12h so long tasks survive idle-suspend

### DIFF
--- a/packages/client/src/__tests__/config.test.ts
+++ b/packages/client/src/__tests__/config.test.ts
@@ -1,7 +1,11 @@
 import { writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { DEFAULT_AGENT_CONCURRENCY, DEFAULT_AGENT_MAX_SESSIONS } from "@first-tree/shared/config";
+import {
+  DEFAULT_AGENT_CONCURRENCY,
+  DEFAULT_AGENT_MAX_SESSIONS,
+  DEFAULT_WORKING_GRACE_SECONDS,
+} from "@first-tree/shared/config";
 import { describe, expect, it } from "vitest";
 import { loadRuntimeConfig } from "../runtime/config.js";
 
@@ -33,7 +37,7 @@ agents:
     expect(nova?.concurrency).toBe(DEFAULT_AGENT_CONCURRENCY);
     expect(nova?.session.idle_timeout).toBe(300);
     expect(nova?.session.max_sessions).toBe(DEFAULT_AGENT_MAX_SESSIONS);
-    expect(nova?.session.working_grace_seconds).toBe(3600);
+    expect(nova?.session.working_grace_seconds).toBe(DEFAULT_WORKING_GRACE_SECONDS);
   });
 
   it("loads config with custom session and concurrency settings", () => {

--- a/packages/client/src/runtime/config.ts
+++ b/packages/client/src/runtime/config.ts
@@ -1,5 +1,9 @@
 import { readFileSync } from "node:fs";
-import { DEFAULT_AGENT_CONCURRENCY, DEFAULT_AGENT_MAX_SESSIONS } from "@first-tree/shared/config";
+import {
+  DEFAULT_AGENT_CONCURRENCY,
+  DEFAULT_AGENT_MAX_SESSIONS,
+  DEFAULT_WORKING_GRACE_SECONDS,
+} from "@first-tree/shared/config";
 import { parse as parseYaml } from "yaml";
 import { z } from "zod";
 
@@ -23,9 +27,10 @@ const sessionConfigSchema = z
     /**
      * Upper bound on how long `working` / `blocked` may keep a session
      * alive past `idle_timeout` before force-suspend. See `evictIdle` in
-     * `session-manager.ts`.
+     * `session-manager.ts`. Default kept in lock-step with
+     * `@first-tree/shared` `DEFAULT_WORKING_GRACE_SECONDS` (12h).
      */
-    working_grace_seconds: z.number().int().positive().default(3600),
+    working_grace_seconds: z.number().int().positive().default(DEFAULT_WORKING_GRACE_SECONDS),
     /**
      * Defer idle-suspend (and deprioritize concurrency eviction) for a session
      * whose provider still has a live background subprocess, up to the

--- a/packages/shared/src/config/__tests__/agent-config.test.ts
+++ b/packages/shared/src/config/__tests__/agent-config.test.ts
@@ -1,11 +1,19 @@
 import { describe, expect, it } from "vitest";
-import { agentConfigSchema, DEFAULT_AGENT_CONCURRENCY, DEFAULT_AGENT_MAX_SESSIONS } from "../agent-config.js";
+import {
+  agentConfigSchema,
+  DEFAULT_AGENT_CONCURRENCY,
+  DEFAULT_AGENT_MAX_SESSIONS,
+  DEFAULT_WORKING_GRACE_SECONDS,
+} from "../agent-config.js";
 import { buildZodSchema } from "../resolver.js";
 
 describe("agentConfigSchema", () => {
   it("defaults session guardrails to effectively unbounded product values", () => {
     expect(DEFAULT_AGENT_CONCURRENCY).toBe(99);
     expect(DEFAULT_AGENT_MAX_SESSIONS).toBe(99);
+    // 12h: wide enough for hours-long / overnight background tasks. The shipped
+    // CLI reads this authoritative schema, so pin the default here directly.
+    expect(DEFAULT_WORKING_GRACE_SECONDS).toBe(43_200);
 
     const parsed = buildZodSchema(agentConfigSchema).parse({ agentId: "agent-1" });
 
@@ -13,6 +21,7 @@ describe("agentConfigSchema", () => {
       concurrency: DEFAULT_AGENT_CONCURRENCY,
       session: {
         max_sessions: DEFAULT_AGENT_MAX_SESSIONS,
+        working_grace_seconds: DEFAULT_WORKING_GRACE_SECONDS,
       },
     });
   });

--- a/packages/shared/src/config/agent-config.ts
+++ b/packages/shared/src/config/agent-config.ts
@@ -4,6 +4,20 @@ import type { InferConfig } from "./types.js";
 
 export const DEFAULT_AGENT_CONCURRENCY = 99;
 export const DEFAULT_AGENT_MAX_SESSIONS = 99;
+/**
+ * Grace past `idle_timeout` before a session with in-flight work (a processing
+ * turn or a live background subprocess) is force-suspended. 12h: long enough to
+ * cover hours-long / overnight background tasks (a `run_in_background` watcher
+ * polling CI, a self-paced explore run) that go quiet between bursts of provider
+ * output, instead of force-suspending them mid-flight at the old ~65min cap. It
+ * is NOT a per-task budget — a healthy active turn refreshes `lastActivity` on
+ * every provider message and never approaches it; the cap only bites a session
+ * that has produced no provider activity for this long while still claiming
+ * work, i.e. a genuinely stuck handler or a forgotten subprocess. Slot pressure
+ * (`evictIfNeeded`, max_sessions) is the primary bound; this just keeps a stuck
+ * slot from leaking forever.
+ */
+export const DEFAULT_WORKING_GRACE_SECONDS = 43_200;
 
 /**
  * Agent config layout on disk: `$FIRST_TREE_HOME/config/agents/<name>/agent.yaml`.
@@ -25,11 +39,12 @@ export const agentConfigSchema = defineConfig({
     max_sessions: field(z.number().int().positive().default(DEFAULT_AGENT_MAX_SESSIONS)),
     // Upper bound on how long a session may stay `working`/`blocked` past
     // `idle_timeout` before the runtime force-suspends it. Protects long
-    // thinking / large message generation from idle eviction while still
-    // bounding stuck-state slot leaks: at `idle_timeout + working_grace_seconds`
-    // past the last activity the session is reclaimed (see evictIdle in
-    // session-manager.ts and #418).
-    working_grace_seconds: field(z.number().int().positive().default(3600)),
+    // thinking / large message generation AND hours-long / overnight background
+    // tasks from idle eviction while still bounding stuck-state slot leaks: at
+    // `idle_timeout + working_grace_seconds` past the last activity the session
+    // is reclaimed (see evictIdle in session-manager.ts and #418). See
+    // DEFAULT_WORKING_GRACE_SECONDS for why the default is 12h.
+    working_grace_seconds: field(z.number().int().positive().default(DEFAULT_WORKING_GRACE_SECONDS)),
     // When a session goes idle but its provider still has a live background
     // subprocess (e.g. a `run_in_background` watcher polling CI), defer
     // idle-suspend and deprioritize concurrency eviction so the subprocess's

--- a/packages/shared/src/config/index.ts
+++ b/packages/shared/src/config/index.ts
@@ -1,7 +1,12 @@
 // Schema declaration utilities
 
 export type { AgentConfig } from "./agent-config.js";
-export { agentConfigSchema, DEFAULT_AGENT_CONCURRENCY, DEFAULT_AGENT_MAX_SESSIONS } from "./agent-config.js";
+export {
+  agentConfigSchema,
+  DEFAULT_AGENT_CONCURRENCY,
+  DEFAULT_AGENT_MAX_SESSIONS,
+  DEFAULT_WORKING_GRACE_SECONDS,
+} from "./agent-config.js";
 export type { ClientConfig } from "./client-config.js";
 export { clientConfigSchema, getClientConfig, updatePolicySchema } from "./client-config.js";
 // Agent loader


### PR DESCRIPTION
## 背景

用户反馈(约 6-22 起):长任务的 agent 不再定期 report progress,反而频繁 **Idle → Paused**,需手动 @ 才能继续。

排查结论:client 端 `evictIdle` 有个时间硬上限 = `idle_timeout(5min) + working_grace_seconds(1h) ≈ 65min`。一个有在飞工作的 session(正在处理 turn,或有 `run_in_background` 活子进程)一旦 `lastActivity` 超过这个上限没刷新,就被**无条件强制挂起**。

而用户的典型用法——跑几个小时的后台任务、睡前让 agent 自己探索几小时——在两次 provider 输出之间会"安静"很久,`lastActivity` 不再刷新,于是在 ~65min 处被中途砍掉(`#1253` 的"有活子进程则推迟挂起"也被这个硬上限削顶)。

## 改动

把 `working_grace_seconds` 默认值 **1h → 12h**(`DEFAULT_WORKING_GRACE_SECONDS = 43200`),由 `@first-tree/shared` 的 `agentConfigSchema` 与 client `runtime/config.ts` 两处 schema 共用同一常量,保持 lock-step。

**纯默认值调整,无逻辑改动**:
- 健康的活跃 turn 每条 provider message 都会刷新 `lastActivity`,**永远碰不到这个上限**;上限只对"长时间无 provider 活动却仍 claim 有工作"的 session 生效(真卡死的 handler / 被遗忘的子进程)。
- 上限仍在,只是从 65min 放宽到 ~12h,足够覆盖通宵任务;真·僵尸最终仍由并发回收(`evictIfNeeded` / `max_sessions`,活子进程已是最后兜底 victim)兜住,**slot 泄漏上限仍是 max_sessions**。
- 不动 server。

## 关于取值

12h 覆盖通宵场景且保留防泄漏天花板。若需要更激进(如 24h)或更保守,改这一个常量即可。

## 测试

- 更新 `config.test.ts` 的默认值断言为常量。
- shared 全量 **479 passed**;client 全量 **1167 passed**;`typecheck` + `biome` 均过。

## 关联

源于对"长任务 Idle→Paused"回归的排查。这是商定的 A 档(纯调大 working_grace)止血方案;更彻底的 B 档(对有 live work 的 session 去掉时间维度、回收只交给 slot 压力)可作后续。

🤖 Generated with [Claude Code](https://claude.com/claude-code)