### PR TITLE
[codex] Share Context Reviewer visibility across roles

### DIFF
--- a/packages/server/src/__tests__/org-settings.test.ts
+++ b/packages/server/src/__tests__/org-settings.test.ts
@@ -354,16 +354,14 @@ describe("org-settings service", () => {
     const admin = await createTestAdmin(app);
 
     const out = await orgSettingsService.getOrgSetting(app.db, admin.organizationId, "context_tree_features");
-    expect(out).toEqual({ contextReviewer: { enabled: false, agentUuid: null } });
+    expect(out).toEqual({ contextReviewer: { enabled: false, agentUuid: null, reviewerAgent: null } });
   });
 
-  it("context_tree_features stores a caller-owned active non-human reviewer and round-trips", async () => {
+  it("context_tree_features stores an active non-human reviewer in the organization and round-trips", async () => {
     const app = getApp();
     const admin = await createAdminContext(app);
-    const reviewer = await createReviewerAgent(app, {
-      clientId: admin.clientId,
-      managerId: admin.memberId,
-    });
+    const otherManager = await createAdminContext(app);
+    const reviewer = await createReviewerAgent(app, { managerId: otherManager.memberId });
 
     const out = await orgSettingsService.putOrgSetting(
       app.db,
@@ -372,7 +370,13 @@ describe("org-settings service", () => {
       { contextReviewer: { enabled: true, agentUuid: reviewer.uuid } },
       { updatedBy: admin.userId, memberId: admin.memberId },
     );
-    expect(out).toEqual({ contextReviewer: { enabled: true, agentUuid: reviewer.uuid } });
+    expect(out).toEqual({
+      contextReviewer: {
+        enabled: true,
+        agentUuid: reviewer.uuid,
+        reviewerAgent: { uuid: reviewer.uuid, name: reviewer.name, displayName: reviewer.displayName },
+      },
+    });
 
     const re = await orgSettingsService.getOrgSetting(app.db, admin.organizationId, "context_tree_features");
     expect(re).toEqual(out);
@@ -401,7 +405,7 @@ describe("org-settings service", () => {
       { updatedBy: admin.userId, memberId: admin.memberId },
     );
 
-    expect(disabled).toEqual({ contextReviewer: { enabled: false, agentUuid: null } });
+    expect(disabled).toEqual({ contextReviewer: { enabled: false, agentUuid: null, reviewerAgent: null } });
   });
 
   it("context_tree_features rejects enabled reviewer input without agentUuid", async () => {
@@ -419,7 +423,7 @@ describe("org-settings service", () => {
     ).rejects.toThrow(/agentUuid is required/);
   });
 
-  it("context_tree_features rejects human, suspended, side-org, and other-manager reviewers", async () => {
+  it("context_tree_features rejects human, suspended, and side-org reviewers", async () => {
     const app = getApp();
     const admin = await createAdminContext(app);
     const suspended = await createReviewerAgent(app, {
@@ -427,12 +431,6 @@ describe("org-settings service", () => {
       managerId: admin.memberId,
       status: "suspended",
     });
-    const otherManager = await createAdminContext(app);
-    const otherManagerAgent = await createReviewerAgent(app, {
-      clientId: otherManager.clientId,
-      managerId: otherManager.memberId,
-    });
-
     const sideOrgId = `org-reviewer-${crypto.randomUUID().slice(0, 8)}`;
     const sideMemberId = uuidv7();
     await app.db.transaction(async (tx) => {
@@ -470,10 +468,9 @@ describe("org-settings service", () => {
         { updatedBy: admin.userId, memberId: admin.memberId },
       );
 
-    await expect(putReviewer(admin.humanAgentUuid)).rejects.toThrow(/active non-human agent managed by the caller/);
-    await expect(putReviewer(suspended.uuid)).rejects.toThrow(/active non-human agent managed by the caller/);
-    await expect(putReviewer(sideOrgAgent.uuid)).rejects.toThrow(/active non-human agent managed by the caller/);
-    await expect(putReviewer(otherManagerAgent.uuid)).rejects.toThrow(/active non-human agent managed by the caller/);
+    await expect(putReviewer(admin.humanAgentUuid)).rejects.toThrow(/active non-human agent in this organization/);
+    await expect(putReviewer(suspended.uuid)).rejects.toThrow(/active non-human agent in this organization/);
+    await expect(putReviewer(sideOrgAgent.uuid)).rejects.toThrow(/active non-human agent in this organization/);
   });
 
   it("rejects unknown namespace with BadRequestError", async () => {
@@ -800,7 +797,7 @@ describe("org-settings API (admin gating + masking)", () => {
       headers: { authorization: `Bearer ${admin.accessToken}` },
     });
     expect(get1.statusCode).toBe(200);
-    expect(get1.json()).toEqual({ contextReviewer: { enabled: false, agentUuid: null } });
+    expect(get1.json()).toEqual({ contextReviewer: { enabled: false, agentUuid: null, reviewerAgent: null } });
 
     const put = await app.inject({
       method: "PUT",
@@ -809,7 +806,13 @@ describe("org-settings API (admin gating + masking)", () => {
       payload: { contextReviewer: { enabled: true, agentUuid: reviewer.uuid } },
     });
     expect(put.statusCode).toBe(200);
-    expect(put.json()).toEqual({ contextReviewer: { enabled: true, agentUuid: reviewer.uuid } });
+    expect(put.json()).toEqual({
+      contextReviewer: {
+        enabled: true,
+        agentUuid: reviewer.uuid,
+        reviewerAgent: { uuid: reviewer.uuid, name: reviewer.name, displayName: reviewer.displayName },
+      },
+    });
 
     const disabled = await app.inject({
       method: "PUT",
@@ -818,7 +821,7 @@ describe("org-settings API (admin gating + masking)", () => {
       payload: { contextReviewer: { enabled: false, agentUuid: reviewer.uuid } },
     });
     expect(disabled.statusCode).toBe(200);
-    expect(disabled.json()).toEqual({ contextReviewer: { enabled: false, agentUuid: null } });
+    expect(disabled.json()).toEqual({ contextReviewer: { enabled: false, agentUuid: null, reviewerAgent: null } });
   });
 
   it("member can GET source_repos and context_tree (readPolicy: member) but cannot PUT / DELETE", async () => {
@@ -852,12 +855,39 @@ describe("org-settings API (admin gating + masking)", () => {
     }
   });
 
-  it("member cannot GET, PUT, or DELETE context_tree_features", async () => {
+  it("member can GET context_tree_features but cannot PUT or DELETE", async () => {
     const app = getApp();
     const { admin, member } = await adminAndMember(app);
+    const reviewer = await createReviewerAgent(app, {
+      managerId: admin.memberId,
+      displayName: "Team Reviewer",
+      name: `team-reviewer-${crypto.randomUUID().slice(0, 8)}`,
+    });
     const url = `/api/v1/orgs/${admin.organizationId}/settings/context_tree_features`;
 
-    for (const method of ["GET", "PUT", "DELETE"] as const) {
+    await orgSettingsService.putOrgSetting(
+      app.db,
+      admin.organizationId,
+      "context_tree_features",
+      { contextReviewer: { enabled: true, agentUuid: reviewer.uuid } },
+      { updatedBy: admin.userId, memberId: admin.memberId },
+    );
+
+    const get = await app.inject({
+      method: "GET",
+      url,
+      headers: { authorization: `Bearer ${member.accessToken}` },
+    });
+    expect(get.statusCode).toBe(200);
+    expect(get.json()).toEqual({
+      contextReviewer: {
+        enabled: true,
+        agentUuid: reviewer.uuid,
+        reviewerAgent: { uuid: reviewer.uuid, name: reviewer.name, displayName: "Team Reviewer" },
+      },
+    });
+
+    for (const method of ["PUT", "DELETE"] as const) {
       const res = await app.inject({
         method,
         url,

--- a/packages/server/src/services/org-settings.ts
+++ b/packages/server/src/services/org-settings.ts
@@ -8,7 +8,7 @@ import {
   type OrgSettingOutput,
   type OrgSettingStorage,
 } from "@first-tree/shared";
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq, ne, sql } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 import { agents } from "../db/schema/agents.js";
 import { members } from "../db/schema/members.js";
@@ -106,7 +106,12 @@ function applyInputDelta<K extends OrgSettingNamespace>(
  * Project the storage row into the API output for a namespace, masking
  * any secret fields.
  */
-function toOutput<K extends OrgSettingNamespace>(namespace: K, storage: OrgSettingStorage<K>): OrgSettingOutput<K> {
+async function toOutput<K extends OrgSettingNamespace>(
+  db: Database,
+  orgId: string,
+  namespace: K,
+  storage: OrgSettingStorage<K>,
+): Promise<OrgSettingOutput<K>> {
   if (namespace === "context_tree") {
     const s = storage as OrgSettingStorage<"context_tree">;
     const out: OrgSettingOutput<"context_tree"> = {
@@ -128,6 +133,7 @@ function toOutput<K extends OrgSettingNamespace>(namespace: K, storage: OrgSetti
       contextReviewer: {
         enabled: s.contextReviewer.enabled,
         agentUuid: s.contextReviewer.agentUuid,
+        reviewerAgent: await resolveContextReviewerAgentSummary(db, orgId, s.contextReviewer.agentUuid),
       },
     };
     return out as OrgSettingOutput<K>;
@@ -147,7 +153,7 @@ export async function getOrgSetting<K extends OrgSettingNamespace>(
 ): Promise<OrgSettingOutput<K>> {
   assertNamespace(namespace);
   const storage = (await fetchStorageRow(db, orgId, namespace)) ?? emptyStorage(namespace);
-  return toOutput(namespace, storage);
+  return toOutput(db, orgId, namespace, storage);
 }
 
 /**
@@ -240,8 +246,26 @@ export async function putOrgSetting<K extends OrgSettingNamespace>(
         },
       });
 
-    return toOutput(namespace, validated);
+    return toOutput(txDb, orgId, namespace, validated);
   });
+}
+
+async function resolveContextReviewerAgentSummary(
+  db: Database,
+  orgId: string,
+  agentUuid: string | null,
+): Promise<{ uuid: string; name: string | null; displayName: string } | null> {
+  if (!agentUuid) return null;
+  const [agent] = await db
+    .select({
+      uuid: agents.uuid,
+      name: agents.name,
+      displayName: agents.displayName,
+    })
+    .from(agents)
+    .where(and(eq(agents.uuid, agentUuid), eq(agents.organizationId, orgId), ne(agents.status, "deleted")))
+    .limit(1);
+  return agent ?? null;
 }
 
 async function assertContextReviewerAgentAllowed(
@@ -265,20 +289,13 @@ async function assertContextReviewerAgentAllowed(
       type: agents.type,
       status: agents.status,
       organizationId: agents.organizationId,
-      managerId: agents.managerId,
     })
     .from(agents)
     .where(eq(agents.uuid, agentUuid))
     .limit(1);
 
-  if (
-    !agent ||
-    agent.organizationId !== orgId ||
-    agent.managerId !== memberId ||
-    agent.type === "human" ||
-    agent.status !== "active"
-  ) {
-    throw new BadRequestError("Context Reviewer agent must be an active non-human agent managed by the caller");
+  if (!agent || agent.organizationId !== orgId || agent.type === "human" || agent.status !== "active") {
+    throw new BadRequestError("Context Reviewer agent must be an active non-human agent in this organization");
   }
 }
 

--- a/packages/shared/src/__tests__/org-settings-schema.test.ts
+++ b/packages/shared/src/__tests__/org-settings-schema.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   isOrgSettingNamespace,
   orgContextTreeFeaturesInputSchema,
+  orgContextTreeFeaturesOutputSchema,
   orgContextTreeFeaturesStorageSchema,
   orgContextTreeInputSchema,
   orgSettingNamespaceSchema,
@@ -71,6 +72,24 @@ describe("org settings schemas", () => {
   it("validates context tree feature settings", () => {
     expect(orgContextTreeFeaturesStorageSchema.parse({})).toEqual({
       contextReviewer: { enabled: false, agentUuid: null },
+    });
+    expect(orgContextTreeFeaturesOutputSchema.parse({})).toEqual({
+      contextReviewer: { enabled: false, agentUuid: null, reviewerAgent: null },
+    });
+    expect(
+      orgContextTreeFeaturesOutputSchema.parse({
+        contextReviewer: {
+          enabled: true,
+          agentUuid: "agent-1",
+          reviewerAgent: { uuid: "agent-1", name: "reviewer", displayName: "Context Reviewer" },
+        },
+      }),
+    ).toEqual({
+      contextReviewer: {
+        enabled: true,
+        agentUuid: "agent-1",
+        reviewerAgent: { uuid: "agent-1", name: "reviewer", displayName: "Context Reviewer" },
+      },
     });
     expect(
       orgContextTreeFeaturesInputSchema.parse({

--- a/packages/shared/src/schemas/org-settings.ts
+++ b/packages/shared/src/schemas/org-settings.ts
@@ -181,6 +181,12 @@ const orgContextReviewerSchema = z.object({
   agentUuid: z.string().min(1).nullable().default(null),
 });
 
+const orgContextReviewerAgentSummarySchema = z.object({
+  uuid: z.string().min(1),
+  name: z.string().nullable(),
+  displayName: z.string().min(1),
+});
+
 export const orgContextTreeFeaturesStorageSchema = z.object({
   contextReviewer: orgContextReviewerSchema
     .default({
@@ -210,7 +216,17 @@ export const orgContextTreeFeaturesInputSchema = z.object({
   }),
 });
 
-export const orgContextTreeFeaturesOutputSchema = orgContextTreeFeaturesStorageSchema;
+export const orgContextTreeFeaturesOutputSchema = z.object({
+  contextReviewer: orgContextReviewerSchema
+    .extend({
+      reviewerAgent: orgContextReviewerAgentSummarySchema.nullable().default(null),
+    })
+    .default({
+      enabled: false,
+      agentUuid: null,
+      reviewerAgent: null,
+    }),
+});
 
 // -- registry --
 
@@ -246,7 +262,7 @@ export const ORG_SETTINGS_NAMESPACES = {
     storage: orgContextTreeFeaturesStorageSchema,
     input: orgContextTreeFeaturesInputSchema,
     output: orgContextTreeFeaturesOutputSchema,
-    readPolicy: "admin",
+    readPolicy: "member",
   },
 } as const satisfies Record<
   string,

--- a/packages/web/src/pages/__tests__/settings-panels-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/settings-panels-dom.test.tsx
@@ -28,7 +28,7 @@ const settingsMocks = vi.hoisted(() => ({
 }));
 
 const agentApiMocks = vi.hoisted(() => ({
-  listManagedAgents: vi.fn(),
+  listAllAgents: vi.fn(),
 }));
 
 const onboardingEventMocks = vi.hoisted(() => ({
@@ -82,6 +82,7 @@ function contextTreeFeatures(overrides: Partial<OrgContextTreeFeaturesOutput["co
     contextReviewer: {
       enabled: overrides.enabled ?? false,
       agentUuid: overrides.agentUuid ?? null,
+      reviewerAgent: overrides.reviewerAgent ?? null,
     },
   } satisfies OrgContextTreeFeaturesOutput;
 }
@@ -107,6 +108,10 @@ function managedAgent(overrides: {
     status: overrides.status ?? "active",
     avatarImageUrl: null,
   };
+}
+
+function paginatedAgents(items: ReturnType<typeof managedAgent>[]) {
+  return { items, nextCursor: null };
 }
 
 function createClient(): QueryClient {
@@ -262,13 +267,15 @@ beforeEach(() => {
   settingsMocks.putContextTreeFeaturesSetting.mockImplementation(
     async (_id: string, body: OrgContextTreeFeaturesOutput) => body,
   );
-  agentApiMocks.listManagedAgents.mockResolvedValue([
-    managedAgent({ uuid: "agent-beta", displayName: "Beta Reviewer", name: "beta" }),
-    managedAgent({ uuid: "agent-alpha", displayName: "Alpha Reviewer", name: "alpha" }),
-    managedAgent({ uuid: "human-1", displayName: "Human User", type: "human" }),
-    managedAgent({ uuid: "suspended-1", displayName: "Suspended", status: "suspended" }),
-    managedAgent({ uuid: "other-org-1", displayName: "Other Org", organizationId: "org-2" }),
-  ]);
+  agentApiMocks.listAllAgents.mockResolvedValue(
+    paginatedAgents([
+      managedAgent({ uuid: "agent-beta", displayName: "Beta Reviewer", name: "beta" }),
+      managedAgent({ uuid: "agent-alpha", displayName: "Alpha Reviewer", name: "alpha" }),
+      managedAgent({ uuid: "human-1", displayName: "Human User", type: "human" }),
+      managedAgent({ uuid: "suspended-1", displayName: "Suspended", status: "suspended" }),
+      managedAgent({ uuid: "other-org-1", displayName: "Other Org", organizationId: "org-2" }),
+    ]),
+  );
   contextApiMocks.initializeContextTree.mockResolvedValue({
     repo: "https://github.com/acme/acme-context-tree.git",
     htmlUrl: "https://github.com/acme/acme-context-tree",
@@ -405,7 +412,10 @@ describe("settings panels", () => {
     expect(container.textContent).toContain("https://github.com/acme/context");
     expect(container.textContent).toContain("branch main");
     expect(buttonByText(container, "Edit")).toBeNull();
-    expect(container.textContent).not.toContain("Context Reviewer");
+    expect(container.textContent).toContain("Context Reviewer");
+    expect(container.textContent).toContain("Automatic PR review");
+    expect(container.textContent).toContain("Off");
+    expect(reviewerSwitch(container)).toBeNull();
     expect(container.textContent).not.toContain("Repo URL");
     expect(container.querySelector('button[type="submit"]')).toBeNull();
     await act(async () => root.unmount());
@@ -435,7 +445,7 @@ describe("settings panels", () => {
     await waitForText(container, "Context Reviewer");
     expect(reviewerSwitch(container)?.getAttribute("aria-checked")).toBe("false");
     expect(settingsMocks.getContextTreeFeaturesSetting).toHaveBeenCalledWith("org-1");
-    expect(agentApiMocks.listManagedAgents).not.toHaveBeenCalled();
+    expect(agentApiMocks.listAllAgents).not.toHaveBeenCalled();
     expect(inputByLabel(container, "Repo URL")?.value).toBe("https://github.com/acme/draft-context");
 
     await act(async () => root.unmount());
@@ -482,7 +492,7 @@ describe("settings panels", () => {
 
     await click(reviewerSwitch(container));
     await waitForText(container, "Reviewer agent");
-    await waitForCondition(() => agentApiMocks.listManagedAgents.mock.calls.length > 0, "Expected agents to load");
+    await waitForCondition(() => agentApiMocks.listAllAgents.mock.calls.length > 0, "Expected agents to load");
     await waitForText(container, "Select an agent to enable Context Reviewer.");
 
     await selectOption(container, "Alpha Reviewer");
@@ -514,10 +524,12 @@ describe("settings panels", () => {
   });
 
   it("shows the empty state and saves nothing when no eligible agents exist", async () => {
-    agentApiMocks.listManagedAgents.mockResolvedValueOnce([
-      managedAgent({ uuid: "human-only", displayName: "Only Human", type: "human" }),
-      managedAgent({ uuid: "suspended-only", displayName: "Only Suspended", status: "suspended" }),
-    ]);
+    agentApiMocks.listAllAgents.mockResolvedValueOnce(
+      paginatedAgents([
+        managedAgent({ uuid: "human-only", displayName: "Only Human", type: "human" }),
+        managedAgent({ uuid: "suspended-only", displayName: "Only Suspended", status: "suspended" }),
+      ]),
+    );
     const { ContextTreeSettingsPanel } = await import("../context-tree-settings-panel.js");
     const { container, root } = await renderPanel(<ContextTreeSettingsPanel />);
     await waitForText(container, "Context Reviewer");
@@ -530,36 +542,51 @@ describe("settings panels", () => {
     await act(async () => root.unmount());
   });
 
-  it("warns when the saved Context Reviewer is not visible to the current admin", async () => {
+  it("shows a saved Context Reviewer managed by another admin", async () => {
     settingsMocks.getContextTreeFeaturesSetting.mockResolvedValueOnce(
-      contextTreeFeatures({ enabled: true, agentUuid: "agent-hidden" }),
+      contextTreeFeatures({ enabled: true, agentUuid: "agent-other-admin" }),
+    );
+    agentApiMocks.listAllAgents.mockResolvedValueOnce(
+      paginatedAgents([
+        managedAgent({
+          uuid: "agent-other-admin",
+          displayName: "Other Admin Reviewer",
+          name: "other-admin-reviewer",
+        }),
+      ]),
     );
     const { ContextTreeSettingsPanel } = await import("../context-tree-settings-panel.js");
     const { container, root } = await renderPanel(<ContextTreeSettingsPanel />);
     await waitForText(container, "Context Reviewer");
 
-    await waitForText(container, "Current reviewer is not your active agent.");
+    await waitForText(container, "Other Admin Reviewer");
+    expect(container.textContent).not.toContain("Current reviewer is not your active agent.");
     expect(reviewerSwitch(container)?.getAttribute("aria-checked")).toBe("true");
-
-    // Turning it off from the warning state persists disabled/null at once.
-    await click(reviewerSwitch(container));
-    expect(settingsMocks.putContextTreeFeaturesSetting).toHaveBeenCalledWith("org-1", {
-      contextReviewer: { enabled: false, agentUuid: null },
-    });
 
     await act(async () => root.unmount());
   });
 
-  it("shows admin-only Context Reviewer copy for members without requesting feature settings", async () => {
+  it("shows Context Reviewer read-only status for members", async () => {
     const { ContextTreeSettingsPanel } = await import("../context-tree-settings-panel.js");
     authMock.value = { ...authMock.value, role: "member" };
+    settingsMocks.getContextTreeFeaturesSetting.mockResolvedValueOnce(
+      contextTreeFeatures({
+        enabled: true,
+        agentUuid: "agent-reviewer",
+        reviewerAgent: { uuid: "agent-reviewer", name: "context-reviewer", displayName: "Context Reviewer Bot" },
+      }),
+    );
     const { container, root } = await renderPanel(<ContextTreeSettingsPanel />);
 
     await waitForText(container, "Your team's Context Tree");
-    expect(container.textContent).not.toContain("Context Reviewer");
-    expect(settingsMocks.getContextTreeFeaturesSetting).not.toHaveBeenCalled();
+    await waitForText(container, "Context Reviewer Bot");
+    expect(container.textContent).toContain("Automatic PR review");
+    expect(container.textContent).toContain("On");
+    expect(settingsMocks.getContextTreeFeaturesSetting).toHaveBeenCalledWith("org-1");
     expect(settingsMocks.putContextTreeFeaturesSetting).not.toHaveBeenCalled();
-    expect(agentApiMocks.listManagedAgents).not.toHaveBeenCalled();
+    expect(agentApiMocks.listAllAgents).not.toHaveBeenCalled();
+    expect(reviewerSwitch(container)).toBeNull();
+    expect(container.querySelector('[aria-label="Context Reviewer agent"]')).toBeNull();
 
     await act(async () => root.unmount());
   });

--- a/packages/web/src/pages/__tests__/settings-panels-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/settings-panels-dom.test.tsx
@@ -110,8 +110,8 @@ function managedAgent(overrides: {
   };
 }
 
-function paginatedAgents(items: ReturnType<typeof managedAgent>[]) {
-  return { items, nextCursor: null };
+function paginatedAgents(items: ReturnType<typeof managedAgent>[], nextCursor: string | null = null) {
+  return { items, nextCursor };
 }
 
 function createClient(): QueryClient {
@@ -523,6 +523,39 @@ describe("settings panels", () => {
     await act(async () => root.unmount());
   });
 
+  it("loads all admin agent pages before deciding whether the saved reviewer is available", async () => {
+    settingsMocks.getContextTreeFeaturesSetting.mockResolvedValueOnce(
+      contextTreeFeatures({ enabled: true, agentUuid: "agent-late-page" }),
+    );
+    agentApiMocks.listAllAgents
+      .mockResolvedValueOnce(
+        paginatedAgents(
+          [
+            managedAgent({ uuid: "human-page-one", displayName: "Human Page One", type: "human" }),
+            managedAgent({ uuid: "suspended-page-one", displayName: "Suspended Page One", status: "suspended" }),
+          ],
+          "older",
+        ),
+      )
+      .mockResolvedValueOnce(
+        paginatedAgents([
+          managedAgent({ uuid: "agent-late-page", displayName: "Late Page Reviewer", name: "late-reviewer" }),
+        ]),
+      );
+    const { ContextTreeSettingsPanel } = await import("../context-tree-settings-panel.js");
+    const { container, root } = await renderPanel(<ContextTreeSettingsPanel />);
+    await waitForText(container, "Context Reviewer");
+
+    await waitForText(container, "Late Page Reviewer");
+    expect(agentApiMocks.listAllAgents).toHaveBeenNthCalledWith(1, { limit: 100 });
+    expect(agentApiMocks.listAllAgents).toHaveBeenNthCalledWith(2, { limit: 100, cursor: "older" });
+    expect(container.textContent).not.toContain("No active non-human agents are available.");
+    expect(container.textContent).not.toContain("Current reviewer is not an active organization agent.");
+    expect(reviewerSwitch(container)?.getAttribute("aria-checked")).toBe("true");
+
+    await act(async () => root.unmount());
+  });
+
   it("shows the empty state and saves nothing when no eligible agents exist", async () => {
     agentApiMocks.listAllAgents.mockResolvedValueOnce(
       paginatedAgents([
@@ -584,6 +617,25 @@ describe("settings panels", () => {
     expect(container.textContent).toContain("On");
     expect(settingsMocks.getContextTreeFeaturesSetting).toHaveBeenCalledWith("org-1");
     expect(settingsMocks.putContextTreeFeaturesSetting).not.toHaveBeenCalled();
+    expect(agentApiMocks.listAllAgents).not.toHaveBeenCalled();
+    expect(reviewerSwitch(container)).toBeNull();
+    expect(container.querySelector('[aria-label="Context Reviewer agent"]')).toBeNull();
+
+    await act(async () => root.unmount());
+  });
+
+  it("does not expose raw reviewer UUID to members when the reviewer summary is unavailable", async () => {
+    const { ContextTreeSettingsPanel } = await import("../context-tree-settings-panel.js");
+    authMock.value = { ...authMock.value, role: "member" };
+    settingsMocks.getContextTreeFeaturesSetting.mockResolvedValueOnce(
+      contextTreeFeatures({ enabled: true, agentUuid: "agent-deleted", reviewerAgent: null }),
+    );
+    const { container, root } = await renderPanel(<ContextTreeSettingsPanel />);
+
+    await waitForText(container, "Configured reviewer is no longer available.");
+    expect(container.textContent).toContain("Automatic PR review");
+    expect(container.textContent).toContain("On");
+    expect(container.textContent).not.toContain("agent-deleted");
     expect(agentApiMocks.listAllAgents).not.toHaveBeenCalled();
     expect(reviewerSwitch(container)).toBeNull();
     expect(container.querySelector('[aria-label="Context Reviewer agent"]')).toBeNull();

--- a/packages/web/src/pages/context-tree-settings-panel.tsx
+++ b/packages/web/src/pages/context-tree-settings-panel.tsx
@@ -16,6 +16,7 @@ import { Select } from "../components/ui/select.js";
 import { SettingsField, SettingsSaveButton } from "../components/ui/settings-field.js";
 import { Switch } from "../components/ui/switch.js";
 import { titleWithSemantics, useJustSaved } from "./agent-detail/save-semantics.js";
+import { fetchAllAgents } from "./team/index.js";
 
 /**
  * Settings → Context tree. Per-org Context Tree **configuration**: which repo /
@@ -278,12 +279,12 @@ function ContextReviewerSection({ hasBinding, isAdmin }: { hasBinding: boolean; 
 
   const managedAgentsQuery = useQuery({
     queryKey: ["context-reviewer", "org-agents", organizationId],
-    queryFn: () => listAllAgents({ limit: 100 }),
+    queryFn: () => fetchAllAgents((params) => listAllAgents(params)),
     enabled: isAdmin && !!organizationId && switchOn,
   });
 
   const reviewerCandidates = useMemo(() => {
-    return (managedAgentsQuery.data?.items ?? [])
+    return (managedAgentsQuery.data ?? [])
       .filter((agent) => agent.organizationId === organizationId && agent.type !== "human" && agent.status === "active")
       .sort((a, b) => {
         const byLabel = agentLabel(a).localeCompare(agentLabel(b), undefined, { sensitivity: "base" });
@@ -405,7 +406,8 @@ function ContextReviewerSection({ hasBinding, isAdmin }: { hasBinding: boolean; 
                 ) : null}
                 {reviewerMissing ? (
                   <div className="text-label" style={{ color: "var(--fg-3)" }}>
-                    Current reviewer is not your active agent. Choose one of your agents, or turn Context Reviewer off.
+                    Current reviewer is not an active organization agent. Choose another agent, or turn Context Reviewer
+                    off.
                   </div>
                 ) : null}
                 {managedAgentsQuery.error ? (
@@ -447,7 +449,7 @@ function ContextReviewerReadOnly({
     ? contextReviewer.reviewerAgent.displayName.trim() ||
       contextReviewer.reviewerAgent.name?.trim() ||
       contextReviewer.reviewerAgent.uuid
-    : contextReviewer.agentUuid;
+    : null;
 
   return (
     <div className="flex flex-col" style={{ gap: "var(--sp-2)" }}>

--- a/packages/web/src/pages/context-tree-settings-panel.tsx
+++ b/packages/web/src/pages/context-tree-settings-panel.tsx
@@ -2,7 +2,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ArrowRight } from "lucide-react";
 import { type FormEvent, useEffect, useId, useMemo, useState } from "react";
 import { useNavigate } from "react-router";
-import { listManagedAgents, type ManagedAgent } from "../api/agents.js";
+import { listAllAgents, type ManagedAgent } from "../api/agents.js";
 import {
   getContextTreeFeaturesSetting,
   getContextTreeSetting,
@@ -144,7 +144,7 @@ export function ContextTreeSettingsPanel() {
         </div>
       </Section>
 
-      {isAdmin ? <ContextReviewerSection hasBinding={hasBinding} /> : null}
+      <ContextReviewerSection hasBinding={hasBinding} isAdmin={isAdmin} />
     </div>
   );
 }
@@ -253,7 +253,7 @@ function NoTree({
  *  persists only once an agent is chosen. State is driven from the server query,
  *  not a local mirror, and every save passes an explicit payload so an instant
  *  handler never reads stale local state. */
-function ContextReviewerSection({ hasBinding }: { hasBinding: boolean }) {
+function ContextReviewerSection({ hasBinding, isAdmin }: { hasBinding: boolean; isAdmin: boolean }) {
   const { organizationId } = useAuth();
   const queryClient = useQueryClient();
   const { justSaved, markSaved } = useJustSaved();
@@ -277,13 +277,13 @@ function ContextReviewerSection({ hasBinding }: { hasBinding: boolean }) {
   const switchOn = serverEnabled || setupOpen;
 
   const managedAgentsQuery = useQuery({
-    queryKey: ["context-reviewer", "managed-agents", organizationId],
-    queryFn: listManagedAgents,
-    enabled: !!organizationId && switchOn,
+    queryKey: ["context-reviewer", "org-agents", organizationId],
+    queryFn: () => listAllAgents({ limit: 100 }),
+    enabled: isAdmin && !!organizationId && switchOn,
   });
 
   const reviewerCandidates = useMemo(() => {
-    return (managedAgentsQuery.data ?? [])
+    return (managedAgentsQuery.data?.items ?? [])
       .filter((agent) => agent.organizationId === organizationId && agent.type !== "human" && agent.status === "active")
       .sort((a, b) => {
         const byLabel = agentLabel(a).localeCompare(agentLabel(b), undefined, { sensitivity: "base" });
@@ -347,21 +347,27 @@ function ContextReviewerSection({ hasBinding }: { hasBinding: boolean }) {
           </div>
         ) : (
           <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
-            {/* Config row: the feature's on/off control, mirroring the agent-detail
-                Switch rows (label left, Switch right, instant save). */}
-            <div className="flex items-center justify-between" style={{ gap: "var(--sp-3)" }}>
-              <span id={toggleLabelId} className="text-body font-medium" style={{ color: "var(--fg)" }}>
-                Automatic PR review
-              </span>
-              <Switch
-                checked={switchOn}
-                onCheckedChange={handleToggle}
-                disabled={saving}
-                aria-labelledby={toggleLabelId}
+            {isAdmin ? (
+              <div className="flex items-center justify-between" style={{ gap: "var(--sp-3)" }}>
+                <span id={toggleLabelId} className="text-body font-medium" style={{ color: "var(--fg)" }}>
+                  Automatic PR review
+                </span>
+                <Switch
+                  checked={switchOn}
+                  onCheckedChange={handleToggle}
+                  disabled={saving}
+                  aria-labelledby={toggleLabelId}
+                />
+              </div>
+            ) : (
+              <ContextReviewerReadOnly
+                contextReviewer={
+                  featuresQuery.data?.contextReviewer ?? { enabled: false, agentUuid: null, reviewerAgent: null }
+                }
               />
-            </div>
+            )}
 
-            {switchOn ? (
+            {isAdmin && switchOn ? (
               <div className="flex flex-col" style={{ gap: "var(--sp-2)" }}>
                 <span className="text-label font-medium" style={{ color: "var(--fg)" }}>
                   Reviewer agent
@@ -426,4 +432,43 @@ function ContextReviewerSection({ hasBinding }: { hasBinding: boolean }) {
 
 function agentLabel(agent: ManagedAgent): string {
   return agent.displayName.trim() || agent.name?.trim() || agent.uuid;
+}
+
+function ContextReviewerReadOnly({
+  contextReviewer,
+}: {
+  contextReviewer: {
+    enabled: boolean;
+    agentUuid: string | null;
+    reviewerAgent?: { uuid: string; name: string | null; displayName: string } | null;
+  };
+}) {
+  const reviewerLabel = contextReviewer.reviewerAgent
+    ? contextReviewer.reviewerAgent.displayName.trim() ||
+      contextReviewer.reviewerAgent.name?.trim() ||
+      contextReviewer.reviewerAgent.uuid
+    : contextReviewer.agentUuid;
+
+  return (
+    <div className="flex flex-col" style={{ gap: "var(--sp-2)" }}>
+      <div className="flex items-center justify-between" style={{ gap: "var(--sp-3)" }}>
+        <span className="text-body font-medium" style={{ color: "var(--fg)" }}>
+          Automatic PR review
+        </span>
+        <span className="text-label" style={{ color: contextReviewer.enabled ? "var(--success)" : "var(--fg-3)" }}>
+          {contextReviewer.enabled ? "On" : "Off"}
+        </span>
+      </div>
+      {contextReviewer.enabled ? (
+        <div className="flex flex-col" style={{ gap: "var(--sp-1)" }}>
+          <span className="text-label font-medium" style={{ color: "var(--fg)" }}>
+            Reviewer agent
+          </span>
+          <span className="text-body" style={{ color: reviewerLabel ? "var(--fg)" : "var(--fg-3)" }}>
+            {reviewerLabel ?? "Configured reviewer is no longer available."}
+          </span>
+        </div>
+      ) : null}
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary

- Treat Context Reviewer as an organization-scoped setting instead of a caller-owned agent setting.
- Let admins configure any active non-human agent in the organization as the reviewer.
- Let members read the current Context Reviewer status and configured reviewer name without exposing the admin-only full agent roster.

## Root Cause

The setting was stored at the organization level, but the save path and UI treated the reviewer as if it had to belong to the current admin. That made other admins see an empty selector/warning for a valid reviewer configured by someone else. Members also had no read-only projection for the feature state.

## Impact

Admins now see and edit the same team-level reviewer configuration. Members see a read-only On/Off state and reviewer identity, but still cannot toggle, select, PUT, or DELETE the feature setting.

## Context Tree

Companion tree PR: https://github.com/agent-team-foundation/first-tree-context/pull/609

## Validation

- `pnpm --filter @first-tree/shared test src/__tests__/org-settings-schema.test.ts`
- `pnpm --filter @first-tree/server test src/__tests__/org-settings.test.ts`
- `pnpm --filter @first-tree/web test src/pages/__tests__/settings-panels-dom.test.tsx`
- `pnpm typecheck`
- `pnpm exec biome check packages/shared/src/schemas/org-settings.ts packages/shared/src/__tests__/org-settings-schema.test.ts packages/server/src/services/org-settings.ts packages/server/src/__tests__/org-settings.test.ts packages/web/src/pages/context-tree-settings-panel.tsx packages/web/src/pages/__tests__/settings-panels-dom.test.tsx`