### PR TITLE
fix(web): stabilize computer sort tie-breaks

### DIFF
--- a/packages/web/src/pages/clients.tsx
+++ b/packages/web/src/pages/clients.tsx
@@ -217,10 +217,10 @@ export function ClientsPage({ embedded = false }: { embedded?: boolean } = {}) {
 
   // admin grouped view: split the single org-scoped list into the viewer's
   // own machines vs everyone else's. Each group sorts by status pill priority
-  // (auth_expired → setup_incomplete → offline → ready) with lastSeenAt as
-  // tie-break — surfaces problem rows at the top without forcing the viewer
-  // to scan the full list. `userId === null` (legacy clients that pre-date
-  // user binding) lands in the team block.
+  // (auth_expired → setup_incomplete → offline → ready), then stable
+  // hostname/id order — surfaces problem rows without letting heartbeat-time
+  // churn reshuffle same-state computers. `userId === null` (legacy clients
+  // that pre-date user binding) lands in the team block.
   const mineList = useMemo<HubClient[]>(() => {
     if (!grouped || !orgClientsData || !viewerUserId) return [];
     return [...orgClientsData].filter((c) => c.userId === viewerUserId).sort(compareByPillPriority);

--- a/packages/web/src/pages/clients/__tests__/derive-status.test.ts
+++ b/packages/web/src/pages/clients/__tests__/derive-status.test.ts
@@ -128,18 +128,28 @@ describe("compareByPillPriority", () => {
     expect(sorted[1]?.id).toBe("rdy");
   });
 
-  it("ties on pill priority break by lastSeenAt descending (most recent first)", () => {
-    const newer = client({ id: "new", lastSeenAt: "2026-05-01T10:00:00Z" });
-    const older = client({ id: "old", lastSeenAt: "2026-05-01T05:00:00Z" });
-    // Both are setup_incomplete (no caps); the more recently-seen one wins.
-    const sorted = [older, newer].sort(compareByPillPriority);
-    expect(sorted[0]?.id).toBe("new");
-    expect(sorted[1]?.id).toBe("old");
+  it("ties on pill priority break by hostname natural sort, not lastSeenAt", () => {
+    const newer = client({ id: "newer", hostname: "box-10", lastSeenAt: "2026-05-01T10:00:00Z" });
+    const older = client({ id: "older", hostname: "box-2", lastSeenAt: "2026-05-01T05:00:00Z" });
+    // Both are setup_incomplete (no caps); stable identity order wins over recency.
+    const sorted = [newer, older].sort(compareByPillPriority);
+    expect(sorted[0]?.id).toBe("older");
+    expect(sorted[1]?.id).toBe("newer");
   });
 
-  it("is stable when both pill and lastSeenAt match (returns 0)", () => {
+  it("puts unnamed computers after named computers within the same pill", () => {
+    const unnamed = client({ id: "unnamed", hostname: null });
+    const named = client({ id: "named", hostname: "alpha" });
+    const sorted = [unnamed, named].sort(compareByPillPriority);
+    expect(sorted[0]?.id).toBe("named");
+    expect(sorted[1]?.id).toBe("unnamed");
+  });
+
+  it("falls back to client id when pill and hostname match", () => {
     const a = client({ id: "a" });
     const b = client({ id: "b" });
-    expect(compareByPillPriority(a, b)).toBe(0);
+    const sorted = [b, a].sort(compareByPillPriority);
+    expect(sorted[0]?.id).toBe("a");
+    expect(sorted[1]?.id).toBe("b");
   });
 });

--- a/packages/web/src/pages/clients/derive-status.ts
+++ b/packages/web/src/pages/clients/derive-status.ts
@@ -60,16 +60,33 @@ export const PILL_PRIORITY: Record<ComputerStatusPill, number> = {
   ready: 3,
 };
 
+const HOSTNAME_COLLATOR = new Intl.Collator("en", { numeric: true, sensitivity: "base" });
+
+function normalizedHostname(client: HubClient): string | null {
+  const hostname = client.hostname?.trim();
+  return hostname ? hostname : null;
+}
+
 /**
  * Sort comparator: pill priority ascending (problems first), then
- * `lastSeenAt` descending (most recently active wins the tie). Stable
- * w.r.t. the underlying `Array.prototype.sort`.
+ * stable computer identity: hostname natural-sort ascending (unnamed
+ * computers last), then client id.
  */
 export function compareByPillPriority(a: HubClient, b: HubClient): number {
   const pa = PILL_PRIORITY[deriveComputerStatus(a).pill];
   const pb = PILL_PRIORITY[deriveComputerStatus(b).pill];
   if (pa !== pb) return pa - pb;
-  if (a.lastSeenAt > b.lastSeenAt) return -1;
-  if (a.lastSeenAt < b.lastSeenAt) return 1;
-  return 0;
+
+  const ah = normalizedHostname(a);
+  const bh = normalizedHostname(b);
+  if (ah && !bh) return -1;
+  if (!ah && bh) return 1;
+  if (ah && bh) {
+    const byHostname = HOSTNAME_COLLATOR.compare(ah, bh);
+    if (byHostname !== 0) return byHostname;
+    const byRawHostname = ah.localeCompare(bh);
+    if (byRawHostname !== 0) return byRawHostname;
+  }
+
+  return a.id.localeCompare(b.id);
 }


### PR DESCRIPTION
## Summary

- Keep Settings → Computers status-priority ordering unchanged.
- Replace the same-status `lastSeenAt` tie-break with stable hostname natural sorting, unnamed computers last, then client id.
- Update the computers sort unit tests and page comment to document the stable tie-break.

## Testing

- `pnpm exec biome check packages/web/src/pages/clients/derive-status.ts packages/web/src/pages/clients/__tests__/derive-status.test.ts packages/web/src/pages/clients.tsx`
- `pnpm --filter @first-tree/web exec vitest run --passWithNoTests src/pages/clients/__tests__/derive-status.test.ts --maxWorkers=2`
- `pnpm --filter @first-tree/web typecheck`
- `pnpm check` (returns 0; reports pre-existing unrelated Biome warnings)