### PR TITLE
[codex] Polish topbar status controls

### DIFF
--- a/packages/web/src/components/__tests__/layout-dom.test.tsx
+++ b/packages/web/src/components/__tests__/layout-dom.test.tsx
@@ -25,9 +25,13 @@ const authMock = vi.hoisted(() => ({
 
 const disconnectMock = vi.hoisted(() => ({
   value: {
-    rows: [],
-    firstHostname: null,
+    rows: [] as Array<{ clientId: string }>,
+    firstHostname: null as string | null,
   },
+}));
+
+const versionMock = vi.hoisted(() => ({
+  value: false,
 }));
 
 const clientMocks = vi.hoisted(() => ({
@@ -40,6 +44,10 @@ vi.mock("../../auth/auth-context.js", () => ({
 
 vi.mock("../../hooks/use-disconnected-computers.js", () => ({
   useDisconnectedComputers: () => disconnectMock.value,
+}));
+
+vi.mock("../../hooks/use-version-check.js", () => ({
+  useNewVersionAvailable: () => versionMock.value,
 }));
 
 vi.mock("../../api/client.js", async (importOriginal) => {
@@ -188,6 +196,8 @@ beforeEach(() => {
   Object.defineProperty(globalThis, "localStorage", { configurable: true, value: storage });
   installMatchMedia((query) => query.includes("80rem") || query.includes("48rem"));
   clientMocks.get.mockResolvedValue([{ id: "org-1", name: "acme", displayName: "Acme", role: "admin" }]);
+  disconnectMock.value = { rows: [], firstHostname: null };
+  versionMock.value = false;
   authMock.value.logout.mockClear();
   authMock.value.selectOrganization.mockClear();
 });
@@ -204,12 +214,15 @@ describe("Layout", () => {
     expect(container.textContent).toContain("First Tree");
     expect(container.textContent).toContain("Workspace");
     expect(container.textContent).toContain("Context child");
-    expect(container.textContent).toContain("Jump to");
+    expect(container.textContent).not.toContain("Jump to…");
     // Team anchor sits in the brand cluster at wide widths.
     expect(container.querySelector('[data-testid="team-switcher"]')).not.toBeNull();
 
-    const jump = container.querySelector<HTMLButtonElement>('button[aria-label="Open command palette"]');
+    const jump = container.querySelector<HTMLButtonElement>('button[aria-label="Jump to… (⌘K)"]');
     if (!jump) throw new Error("Jump button missing");
+    expect(jump.getAttribute("aria-keyshortcuts")).toBe("Meta+K Control+K");
+    expect(jump.getAttribute("title")).toBe("Jump to… (⌘K / Ctrl+K)");
+    expect(jump.textContent).toContain("⌘K");
     await act(async () => {
       jump.dispatchEvent(new MouseEvent("mouseenter", { bubbles: true }));
       jump.dispatchEvent(new MouseEvent("mouseleave", { bubbles: true }));
@@ -222,6 +235,28 @@ describe("Layout", () => {
     expect(container.textContent).toContain("Mock command palette");
     await keyDown("k", { ctrlKey: true });
     expect(container.textContent).not.toContain("Mock command palette");
+
+    await act(async () => root.unmount());
+  });
+
+  it("keeps status chips in the right controls before the compact command palette entry", async () => {
+    disconnectMock.value = {
+      firstHostname: "Yue-MacPro.local",
+      rows: [{ clientId: "client-1" }],
+    };
+    versionMock.value = true;
+    const { container, root } = await renderLayout("/context");
+
+    const commandButton = container.querySelector<HTMLButtonElement>('button[aria-label="Jump to… (⌘K)"]');
+    if (!commandButton?.parentElement) throw new Error("Command palette button missing");
+
+    const controlsText = commandButton.parentElement.textContent ?? "";
+    expect(controlsText).toContain("Computer disconnected");
+    expect(controlsText).toContain("Update available");
+    expect(controlsText).not.toContain("Yue-MacPro");
+    expect(controlsText).not.toContain("Jump to…");
+    expect(controlsText.indexOf("Computer disconnected")).toBeLessThan(controlsText.indexOf("⌘K"));
+    expect(controlsText.indexOf("Update available")).toBeLessThan(controlsText.indexOf("⌘K"));
 
     await act(async () => root.unmount());
   });
@@ -246,7 +281,54 @@ describe("Layout", () => {
     });
     await flush();
     expect(container.textContent).toContain("First Tree");
-    expect(container.textContent).not.toContain("Jump to");
+    expect(container.querySelector('button[aria-label="Jump to… (⌘K)"]')).not.toBeNull();
+
+    await act(async () => root.unmount());
+  });
+
+  it("uses compact status controls at md so text chips do not crowd the centered nav", async () => {
+    installMatchMedia((query) => query.includes("48rem"));
+    disconnectMock.value = {
+      firstHostname: "Yue-MacPro.local",
+      rows: [{ clientId: "client-1" }],
+    };
+    versionMock.value = true;
+    const { container, root } = await renderLayout("/context");
+
+    expect(container.textContent).toContain("First Tree");
+    expect(container.textContent).not.toContain("Computer disconnected");
+    expect(container.textContent).not.toContain("Update available");
+    expect(
+      container.querySelector('button[aria-label="Yue-MacPro.local is disconnected. Click to manage."]'),
+    ).not.toBeNull();
+    expect(
+      container.querySelector('button[aria-label="A new version is available. Click to refresh."]'),
+    ).not.toBeNull();
+    expect(container.querySelector('button[aria-label="Jump to… (⌘K)"]')).not.toBeNull();
+
+    await act(async () => root.unmount());
+  });
+
+  it("keeps compact status affordances on narrow viewports without showing full chip copy", async () => {
+    installMatchMedia(() => false);
+    disconnectMock.value = {
+      firstHostname: "Yue-MacPro.local",
+      rows: [{ clientId: "client-1" }],
+    };
+    versionMock.value = true;
+    const { container, root } = await renderLayout("/context");
+
+    expect(container.textContent).not.toContain("First Tree");
+    expect(container.textContent).not.toContain("Computer disconnected");
+    expect(container.textContent).not.toContain("Update available");
+    expect(
+      container.querySelector('button[aria-label="Yue-MacPro.local is disconnected. Click to manage."]'),
+    ).not.toBeNull();
+    expect(
+      container.querySelector('button[aria-label="A new version is available. Click to refresh."]'),
+    ).not.toBeNull();
+    expect(container.querySelector('button[aria-label="Jump to… (⌘K)"]')).toBeNull();
+    expect(container.querySelector('[data-testid="user-menu"]')).not.toBeNull();
 
     await act(async () => root.unmount());
   });

--- a/packages/web/src/components/__tests__/low-coverage-components.test.tsx
+++ b/packages/web/src/components/__tests__/low-coverage-components.test.tsx
@@ -159,7 +159,8 @@ describe("low coverage UI components", () => {
       rows: [{ clientId: "client-1" }],
     });
     const single = await renderDom(<DisconnectChip />);
-    expect(single.container.textContent).toContain("gandy-macbook");
+    expect(single.container.textContent).toContain("Computer disconnected");
+    expect(single.container.textContent).not.toContain("gandy-macbook");
     expect(single.container.querySelector("button")?.getAttribute("aria-label")).toContain("gandy-macbook");
     await act(async () => single.root.unmount());
 

--- a/packages/web/src/components/__tests__/new-version-chip.test.tsx
+++ b/packages/web/src/components/__tests__/new-version-chip.test.tsx
@@ -26,7 +26,7 @@ describe("NewVersionChip", () => {
     h.render(<NewVersionChip show={true} />);
     const btn = h.container.querySelector("button");
     expect(btn).not.toBeNull();
-    expect(btn?.textContent).toContain("New version");
+    expect(btn?.textContent).toContain("Update available");
     expect(btn?.getAttribute("aria-label")?.toLowerCase()).toContain("refresh");
   });
 

--- a/packages/web/src/components/disconnect-chip.tsx
+++ b/packages/web/src/components/disconnect-chip.tsx
@@ -1,7 +1,10 @@
 import { useNavigate } from "react-router";
 import { useDisconnectedComputers } from "../hooks/use-disconnected-computers.js";
 
-const HOSTNAME_MAX_PX = 160;
+type DisconnectChipProps = {
+  /** Icon-only rendering for md/narrow topbars where full text would crowd nav. */
+  compact?: boolean;
+};
 
 /**
  * Topbar warning chip — surfaces in `Layout` whenever any of the caller's
@@ -9,7 +12,7 @@ const HOSTNAME_MAX_PX = 160;
  * the Computers settings page. Renders nothing in the healthy case so the
  * topbar stays clean.
  */
-export function DisconnectChip() {
+export function DisconnectChip({ compact = false }: DisconnectChipProps) {
   const navigate = useNavigate();
   const { rows, firstHostname } = useDisconnectedComputers();
   if (rows.length === 0) return null;
@@ -18,6 +21,32 @@ export function DisconnectChip() {
   const tooltip = isMulti
     ? `${rows.length} computers disconnected. Click to manage.`
     : `${firstHostname ?? "Your computer"} is disconnected. Click to manage.`;
+
+  if (compact) {
+    return (
+      <button
+        type="button"
+        onClick={() => navigate("/settings/computers")}
+        title={tooltip}
+        aria-label={tooltip}
+        className="inline-flex items-center justify-center cursor-pointer"
+        style={{
+          height: 26,
+          width: 26,
+          padding: 0,
+          borderRadius: 999,
+          border: 0,
+          outline: "var(--hairline) solid color-mix(in oklch, var(--state-error) 38%, transparent)",
+          outlineOffset: -1,
+          background: "var(--state-error-soft)",
+          color: "color-mix(in oklch, var(--state-error) 80%, var(--fg))",
+          flexShrink: 0,
+        }}
+      >
+        <PulseDot />
+      </button>
+    );
+  }
 
   return (
     <button
@@ -37,6 +66,7 @@ export function DisconnectChip() {
         background: "var(--state-error-soft)",
         color: "color-mix(in oklch, var(--state-error) 80%, var(--fg))",
         minWidth: 0,
+        whiteSpace: "nowrap",
       }}
     >
       <PulseDot />
@@ -45,21 +75,7 @@ export function DisconnectChip() {
           <span className="font-semibold">{rows.length}</span> computers disconnected
         </span>
       ) : (
-        <span className="inline-flex items-center" style={{ gap: 5, minWidth: 0 }}>
-          <span
-            className="mono text-label font-medium"
-            style={{
-              maxWidth: HOSTNAME_MAX_PX,
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-              whiteSpace: "nowrap",
-              color: "color-mix(in oklch, var(--state-error) 60%, var(--fg))",
-            }}
-          >
-            {firstHostname ?? "computer"}
-          </span>
-          <span style={{ flexShrink: 0 }}>disconnected</span>
-        </span>
+        <span>Computer disconnected</span>
       )}
     </button>
   );

--- a/packages/web/src/components/layout.tsx
+++ b/packages/web/src/components/layout.tsx
@@ -57,24 +57,24 @@ export function Layout() {
   // Top-bar progressive collapse, tuned so the user menu (sign-out, org-switch)
   // is reachable at EVERY width — dropping it below `xl` previously stranded
   // every phone / tablet / sub-1280 desktop window with no way to log out.
-  //   - `xl`     : brand | tabs | [Jump to…] [theme] [avatar]
-  //   - `md`     : brand | tabs | [theme] [avatar]   (Jump to… too wide)
-  //   - `narrow` : tabs | [avatar]                   (also drops brand)
-  // On `narrow` the theme toggle drops too: four full tabs + theme + avatar
-  // overflow a phone-width row and would clip the avatar off the right edge.
-  // Phones
-  // fall back to the OS `prefers-color-scheme` (honoured at boot in index.html);
-  // the toggle returns at `md`. The avatar is the one control that never drops.
+  //   - `xl`     : brand | tabs | [status chips] [⌘K] [theme] [avatar]
+  //   - `md`     : brand | tabs | [status icons] [⌘K] [theme] [avatar]
+  //   - `narrow` : tabs | [status icons] [avatar]       (also drops brand)
+  // On `narrow` the theme toggle and full status chips drop too: four full tabs
+  // plus text chips + theme + avatar overflow a phone-width row and would clip
+  // the avatar off the right edge. Phones fall back to the OS
+  // `prefers-color-scheme` (honoured at boot in index.html); the toggle returns
+  // at `md`. The avatar is the one control that never drops.
   const viewport = useWorkspaceViewport();
   // Lifted out of NewVersionChip so the `/version.json` poll runs at EVERY
-  // breakpoint — the brand cluster (and its chip) is dropped on `narrow`, but
-  // version detection must not be. The chip is rendered in two places below:
-  // the full pill in the brand cluster, and a compact icon-only fallback in the
-  // right controls when the brand is dropped.
+  // breakpoint — the full chip is dropped on `narrow`, but version detection
+  // must not be. The chip is rendered in two places below: the full pill in the
+  // right controls, and a compact icon-only fallback when the brand is dropped.
   const newVersionAvailable = useNewVersionAvailable();
-  const showJumpButton = viewport === "xl";
+  const showJumpButton = viewport !== "narrow";
   const dropBrand = viewport === "narrow";
   const showThemeToggle = viewport !== "narrow";
+  const showFullStatusChips = viewport === "xl";
   // The team anchor is reachable at every breakpoint (like the avatar). It is
   // absent only when no org is selected (mid-onboarding), where it would have
   // nothing to anchor to and Create / Join is carried by the onboarding flow.
@@ -117,9 +117,9 @@ export function Layout() {
           background: "var(--bg-raised)",
         }}
       >
-        {/* Brand cluster: logo + name welded together, the team anchor, then the
-            optional chips. On narrow the cluster is dropped, but the anchor must
-            stay reachable — it surfaces icon-only in its own leading column. */}
+        {/* Brand cluster: logo + name welded together, then the team anchor. On
+            narrow the cluster is dropped, but the anchor must stay reachable —
+            it surfaces icon-only in its own leading column. */}
         {dropBrand ? (
           showAnchor ? (
             <div style={{ justifySelf: "start", minWidth: 0 }}>
@@ -151,8 +151,6 @@ export function Layout() {
                 <TeamSwitcher variant="full" />
               </>
             )}
-            <DisconnectChip />
-            <NewVersionChip show={newVersionAvailable} />
           </div>
         )}
 
@@ -172,7 +170,7 @@ export function Layout() {
             // Narrow track is `minmax(0, 1fr)`: let the row scroll horizontally
             // if the tabs can't all fit (tiny phones / long i18n labels) rather
             // than overflow and clip the avatar. No-op when the tabs fit.
-            ...(dropBrand ? { minWidth: 0, overflowX: "auto" } : null),
+            ...(dropBrand ? { minWidth: 0, width: "100%", overflowX: "auto" } : null),
           }}
         >
           {navTabs.map((tab) => (
@@ -207,20 +205,34 @@ export function Layout() {
 
         {/* Right controls. The user menu (avatar) renders at every breakpoint
             so sign-out / org-switch stay reachable on phones and tablets; the
-            theme toggle drops on `narrow` and the wide "Jump to…" button is
-            xl-only (see the collapse comment above). */}
+            theme toggle and command-palette entry drop on `narrow`. Status
+            stays visible at every width: full text on `xl`, compact icons
+            below it so the right track cannot crowd the centred tabs. */}
         <div className="flex items-center shrink-0" style={{ gap: 6, justifySelf: "end" }}>
+          {showFullStatusChips ? (
+            <>
+              <DisconnectChip />
+              <NewVersionChip show={newVersionAvailable} />
+            </>
+          ) : (
+            <>
+              <DisconnectChip compact />
+              <NewVersionChip show={newVersionAvailable} compact />
+            </>
+          )}
           {showJumpButton ? (
             <>
               <button
                 type="button"
                 onClick={() => setPaletteOpen(true)}
-                aria-label="Open command palette"
+                aria-label="Jump to… (⌘K)"
+                aria-keyshortcuts="Meta+K Control+K"
+                title="Jump to… (⌘K / Ctrl+K)"
                 className="inline-flex items-center transition-colors text-body"
                 style={{
-                  gap: 8,
-                  padding: "var(--sp-1) var(--sp-3)",
-                  minWidth: 200,
+                  gap: 7,
+                  height: 30,
+                  padding: "0 var(--sp-2)",
                   color: "var(--fg-3)",
                   border: "var(--hairline) solid var(--border)",
                   borderRadius: "var(--radius-input)",
@@ -233,15 +245,14 @@ export function Layout() {
                   e.currentTarget.style.color = "var(--fg-3)";
                 }}
               >
-                <Search className="h-4 w-4" />
-                <span className="flex-1 text-left">Jump to…</span>
+                <Search aria-hidden="true" size={14} style={{ flexShrink: 0 }} />
                 <span
                   aria-hidden
                   className="text-caption font-mono"
                   style={{
-                    padding: "var(--sp-0_5) var(--sp-1_5)",
+                    padding: "var(--sp-0_5) var(--sp-1_25)",
                     border: "var(--hairline) solid var(--border)",
-                    borderRadius: "var(--sp-1)",
+                    borderRadius: "var(--radius-chip)",
                     color: "var(--fg-3)",
                     background: "var(--bg-raised)",
                   }}
@@ -272,9 +283,6 @@ export function Layout() {
               />
             </>
           ) : null}
-          {/* On `narrow` the brand cluster (with the full chip) is dropped, so
-              surface a compact icon-only refresh entry here instead. */}
-          {dropBrand ? <NewVersionChip show={newVersionAvailable} compact /> : null}
           <UserMenu />
         </div>
       </header>

--- a/packages/web/src/components/new-version-chip.tsx
+++ b/packages/web/src/components/new-version-chip.tsx
@@ -14,6 +14,7 @@ const CHIP_STYLE: CSSProperties = {
   color: "var(--fg-needs-you-strong)",
   borderRadius: 999,
   minWidth: 0,
+  whiteSpace: "nowrap",
 };
 
 type NewVersionChipProps = {
@@ -67,7 +68,7 @@ export function NewVersionChip({ show, compact = false }: NewVersionChipProps) {
       style={{ ...CHIP_STYLE, gap: 7, padding: "0 var(--sp-2_5) 0 var(--sp-2_25)" }}
     >
       <RefreshCw aria-hidden="true" size={13} style={{ flexShrink: 0 }} />
-      <span>New version — refresh</span>
+      <span>Update available</span>
     </button>
   );
 }


### PR DESCRIPTION
## Summary

- Move the disconnected-computer and update-available status chips out of the brand cluster and into the right-side topbar controls.
- Change visible copy to `Computer disconnected` / `<n> computers disconnected` and `Update available`, with the hostname retained in the disconnect tooltip and accessible label.
- Replace the 200px `Jump to…` field with a compact search + `⌘K` capsule; expose `Meta+K Control+K` via `aria-keyshortcuts`.
- Keep the wide layout readable while using compact status affordances at md/narrow breakpoints to avoid crowding the centered tabs.

## Context Tree

- https://github.com/agent-team-foundation/first-tree-context/pull/610

## Validation

- `pnpm vitest run src/components/__tests__/layout-dom.test.tsx src/components/__tests__/low-coverage-components.test.tsx src/components/__tests__/new-version-chip.test.tsx`
- `pnpm --filter @first-tree/web typecheck`
- `pnpm --filter @first-tree/web test`
- `pnpm --filter @first-tree/web build`
- Playwright geometry smoke at 1280 light/dark, 1024, 390 light/dark with mocked disconnected computer + update available; no header overflow or nav/control overlap.

## Notes

Build still emits the existing generated-CSS wildcard warning and Rollup large-chunk advisory.