### PR TITLE
[codex] Polish topbar search entry

### DIFF
--- a/packages/web/src/components/__tests__/layout-dom.test.tsx
+++ b/packages/web/src/components/__tests__/layout-dom.test.tsx
@@ -222,6 +222,7 @@ describe("Layout", () => {
     if (!jump) throw new Error("Jump button missing");
     expect(jump.getAttribute("aria-keyshortcuts")).toBe("Meta+K Control+K");
     expect(jump.getAttribute("title")).toBe("Jump to… (⌘K / Ctrl+K)");
+    expect(jump.textContent).toContain("Search");
     expect(jump.textContent).toContain("⌘K");
     await act(async () => {
       jump.dispatchEvent(new MouseEvent("mouseenter", { bubbles: true }));
@@ -282,6 +283,7 @@ describe("Layout", () => {
     await flush();
     expect(container.textContent).toContain("First Tree");
     expect(container.querySelector('button[aria-label="Jump to… (⌘K)"]')).not.toBeNull();
+    expect(container.textContent).not.toContain("Search");
 
     await act(async () => root.unmount());
   });
@@ -305,6 +307,7 @@ describe("Layout", () => {
       container.querySelector('button[aria-label="A new version is available. Click to refresh."]'),
     ).not.toBeNull();
     expect(container.querySelector('button[aria-label="Jump to… (⌘K)"]')).not.toBeNull();
+    expect(container.textContent).not.toContain("Search");
 
     await act(async () => root.unmount());
   });

--- a/packages/web/src/components/layout.tsx
+++ b/packages/web/src/components/layout.tsx
@@ -72,6 +72,7 @@ export function Layout() {
   // right controls, and a compact icon-only fallback when the brand is dropped.
   const newVersionAvailable = useNewVersionAvailable();
   const showJumpButton = viewport !== "narrow";
+  const showJumpLabel = viewport === "xl";
   const dropBrand = viewport === "narrow";
   const showThemeToggle = viewport !== "narrow";
   const showFullStatusChips = viewport === "xl";
@@ -232,6 +233,7 @@ export function Layout() {
                 style={{
                   gap: 7,
                   height: 30,
+                  minWidth: showJumpLabel ? 112 : undefined,
                   padding: "0 var(--sp-2)",
                   color: "var(--fg-3)",
                   border: "var(--hairline) solid var(--border)",
@@ -246,6 +248,7 @@ export function Layout() {
                 }}
               >
                 <Search aria-hidden="true" size={14} style={{ flexShrink: 0 }} />
+                {showJumpLabel ? <span>Search</span> : null}
                 <span
                   aria-hidden
                   className="text-caption font-mono"


### PR DESCRIPTION
## Summary

- Add a `Search` label to the topbar command-palette capsule on `xl` layouts so it reads more like a search/jump entry.
- Keep `md` on the compact icon + `⌘K` treatment and keep `narrow` hidden, preserving the right-side status-control spacing from the previous topbar update.
- Update DOM coverage for the wide label and md compact behavior.

## Validation

- `pnpm vitest run src/components/__tests__/layout-dom.test.tsx` (red before implementation, green after)
- `pnpm check`
- `pnpm --filter @first-tree/web typecheck`
- `pnpm --filter @first-tree/shared build && pnpm --filter @first-tree/web build`
- `pnpm --filter @first-tree/web test -- src/components/__tests__/layout-dom.test.tsx` (repo script ran full web suite: 127 files, 1015 tests)
- Playwright geometry smoke at 1280 light/dark, 1024, 390 light/dark with mocked disconnected computer + update available; no header overflow or nav/control overlap.

## Notes

- No Context Tree PR: this remains within the existing shell contract that the command palette uses a compact search/`⌘K` capsule rather than a long search field.
- Build still emits the existing generated-CSS wildcard warning and Rollup large-chunk advisory.