### PR TITLE
[codex] Instrument context tree snapshot timing

### DIFF
--- a/packages/server/src/__tests__/context-tree-snapshot-timing.test.ts
+++ b/packages/server/src/__tests__/context-tree-snapshot-timing.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { createTestAdmin, useTestApp } from "./helpers.js";
+
+describe("context tree snapshot timing", () => {
+  const getApp = useTestApp();
+
+  it("emits Server-Timing for org-scoped context tree snapshots", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+
+    const response = await app.inject({
+      method: "GET",
+      url: `/api/v1/orgs/${admin.organizationId}/context-tree/snapshot?window=7d`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers["server-timing"]).toEqual(expect.stringContaining("auth;dur="));
+    expect(response.headers["server-timing"]).toEqual(expect.stringContaining("snapshot_build;dur="));
+    expect(response.headers["server-timing"]).toEqual(expect.stringContaining("schema_parse;dur="));
+  });
+});

--- a/packages/server/src/__tests__/context-tree-snapshot.test.ts
+++ b/packages/server/src/__tests__/context-tree-snapshot.test.ts
@@ -221,8 +221,11 @@ Body`);
     await initRepoAt(remoteDir);
     await writeFile(join(remoteDir, "NODE.md"), "---\ntitle: Remote Context\nowners: [alice]\n---\nGuidance\n");
     await commitAllAt(remoteDir, "docs: add remote context");
+    const timings: string[] = [];
 
-    const snapshot = await getContextTreeSnapshot({ repo: `file://${remoteDir}`, branch: "main" }, "7d");
+    const snapshot = await getContextTreeSnapshot({ repo: `file://${remoteDir}`, branch: "main" }, "7d", {
+      timing: (name) => timings.push(name),
+    });
 
     expect(snapshot.snapshotStatus).toBe("active");
     expect(snapshot.repo).toBe(`file://${remoteDir}`);
@@ -234,6 +237,9 @@ Body`);
           owners: ["alice"],
         }),
       ]),
+    );
+    expect(timings).toEqual(
+      expect.arrayContaining(["resolve_root", "git_head", "comparison_base", "read_markdown_files", "build_tree"]),
     );
   });
 

--- a/packages/server/src/api/context-tree-snapshot.ts
+++ b/packages/server/src/api/context-tree-snapshot.ts
@@ -1,6 +1,7 @@
 import { contextTreeSnapshotSchema } from "@first-tree/shared";
 import type { FastifyInstance } from "fastify";
 import { z } from "zod";
+import { createTimingCollector } from "../observability/timing.js";
 import { resolveOrgViewer } from "../scope/require-resource.js";
 import { requireUser } from "../scope/require-user.js";
 import { buildContextTreeIoSummary } from "../services/context-tree-io.js";
@@ -26,37 +27,65 @@ const querySchema = z
   .strict();
 
 export async function contextTreeSnapshotRoutes(app: FastifyInstance): Promise<void> {
-  app.get("/snapshot", async (request) => {
-    const query = querySchema.parse(request.query);
-    const { userId } = requireUser(request);
-    const orgId = await resolveUserPrimaryOrgId(app.db, userId);
-    const binding: ContextTreeBinding = orgId ? await getOrgContextTree(app.db, orgId) : {};
+  app.get("/snapshot", async (request, reply) => {
+    const timing = createTimingCollector();
+    const query = timing.timeSync("parse_query", () => querySchema.parse(request.query));
+    const { userId } = timing.timeSync("auth", () => requireUser(request));
+    const orgId = await timing.time("resolve_primary_org", () => resolveUserPrimaryOrgId(app.db, userId));
+    const binding: ContextTreeBinding = orgId
+      ? await timing.time("binding", () => getOrgContextTree(app.db, orgId))
+      : {};
     let mintResult: ContextTreeInstallationTokenResult | null = null;
     if (orgId && isGithubRemoteBinding(binding)) {
-      const installation = await findInstallationByOrg(app.db, orgId);
-      mintResult = await mintContextTreeInstallationToken(installation, app.config.oauth?.githubApp);
+      mintResult = await timing.time("github_token", async () => {
+        const installation = await findInstallationByOrg(app.db, orgId);
+        return mintContextTreeInstallationToken(installation, app.config.oauth?.githubApp);
+      });
     }
     const githubToken = mintResult?.ok ? mintResult.token : undefined;
     const window = query.window ?? "7d";
-    const rawSnapshot = await getContextTreeSnapshot({ ...binding, githubToken }, window);
+    const rawSnapshot = await timing.time("snapshot_build", () =>
+      getContextTreeSnapshot({ ...binding, githubToken }, window, { timing: timing.add }),
+    );
     const snapshot = mintResult ? decorateSnapshotWithMintGuidance(rawSnapshot, binding, mintResult) : rawSnapshot;
-    const viewer = orgId ? await resolveOrgViewer(app.db, userId, orgId) : null;
+    const viewer = orgId ? await timing.time("resolve_viewer", () => resolveOrgViewer(app.db, userId, orgId)) : null;
     const usage = orgId
-      ? await summarizeContextTreeUsage(app.db, orgId, contextTreeSnapshotWindowDays(window), viewer ?? undefined)
+      ? await timing.time("usage_summary", () =>
+          summarizeContextTreeUsage(app.db, orgId, contextTreeSnapshotWindowDays(window), viewer ?? undefined),
+        )
       : snapshot.usage;
     // With an org: telemetry reads + git-derived writes reconciled for agent
     // attribution. Without one: keep the snapshot's git-derived io.writes as-is
     // (no telemetry to reconcile against). Same path as the org-scoped route so
     // writes never silently empty here. See buildContextTreeIoSummary.
     const io = orgId
-      ? await buildContextTreeIoSummary(
-          app.db,
-          orgId,
-          contextTreeSnapshotWindowDays(window),
-          snapshot.io.writes,
-          viewer ?? undefined,
+      ? await timing.time("io_summary", () =>
+          buildContextTreeIoSummary(
+            app.db,
+            orgId,
+            contextTreeSnapshotWindowDays(window),
+            snapshot.io.writes,
+            viewer ?? undefined,
+            { timing: timing.add },
+          ),
         )
       : snapshot.io;
-    return contextTreeSnapshotSchema.parse({ ...snapshot, usage, io });
+    const response = timing.timeSync("schema_parse", () => contextTreeSnapshotSchema.parse({ ...snapshot, usage, io }));
+    const totalMs = timing.elapsedMs();
+    reply.header("Server-Timing", timing.serverTimingHeader());
+    request.log[totalMs > 1500 || timing.records.some((record) => record.ms > 500) ? "warn" : "info"](
+      {
+        event: "context_tree_snapshot_timing",
+        orgId,
+        window,
+        snapshotStatus: response.snapshotStatus,
+        nodeCount: response.nodes.length,
+        updateCount: response.updates.length,
+        totalMs,
+        timings: timing.records,
+      },
+      "context tree snapshot timing",
+    );
+    return response;
   });
 }

--- a/packages/server/src/api/orgs/context-tree-snapshot.ts
+++ b/packages/server/src/api/orgs/context-tree-snapshot.ts
@@ -1,6 +1,7 @@
 import { contextTreeSnapshotSchema } from "@first-tree/shared";
 import type { FastifyInstance } from "fastify";
 import { z } from "zod";
+import { createTimingCollector } from "../../observability/timing.js";
 import { requireOrgMembership } from "../../scope/require-org.js";
 import { buildContextTreeIoSummary } from "../../services/context-tree-io.js";
 import {
@@ -25,31 +26,65 @@ const querySchema = z
   .strict();
 
 export async function orgContextTreeSnapshotRoutes(app: FastifyInstance): Promise<void> {
-  app.get<{ Params: { orgId: string } }>("/snapshot", async (request) => {
-    const query = querySchema.parse(request.query);
-    const scope = await requireOrgMembership(request, app.db);
-    const binding: ContextTreeBinding = await getOrgContextTree(app.db, scope.organizationId);
+  app.get<{ Params: { orgId: string } }>("/snapshot", async (request, reply) => {
+    const timing = createTimingCollector();
+    const query = timing.timeSync("parse_query", () => querySchema.parse(request.query));
+    const scope = await timing.time("auth", () => requireOrgMembership(request, app.db));
+    const binding: ContextTreeBinding = await timing.time("binding", () =>
+      getOrgContextTree(app.db, scope.organizationId),
+    );
     let mintResult: ContextTreeInstallationTokenResult | null = null;
     if (isGithubRemoteBinding(binding)) {
-      const installation = await findInstallationByOrg(app.db, scope.organizationId);
-      mintResult = await mintContextTreeInstallationToken(installation, app.config.oauth?.githubApp);
+      mintResult = await timing.time("github_token", async () => {
+        const installation = await findInstallationByOrg(app.db, scope.organizationId);
+        return mintContextTreeInstallationToken(installation, app.config.oauth?.githubApp);
+      });
     }
     const githubToken = mintResult?.ok ? mintResult.token : undefined;
     const window = query.window ?? "7d";
-    const rawSnapshot = await getContextTreeSnapshot({ ...binding, githubToken }, window);
+    const rawSnapshot = await timing.time("snapshot_build", () =>
+      getContextTreeSnapshot({ ...binding, githubToken }, window, { timing: timing.add }),
+    );
     const snapshot = mintResult ? decorateSnapshotWithMintGuidance(rawSnapshot, binding, mintResult) : rawSnapshot;
-    const usage = await summarizeContextTreeUsage(app.db, scope.organizationId, contextTreeSnapshotWindowDays(window), {
-      humanAgentId: scope.humanAgentId,
-      memberId: scope.memberId,
-    });
+    const usage = await timing.time("usage_summary", () =>
+      summarizeContextTreeUsage(app.db, scope.organizationId, contextTreeSnapshotWindowDays(window), {
+        humanAgentId: scope.humanAgentId,
+        memberId: scope.memberId,
+      }),
+    );
     const windowDays = contextTreeSnapshotWindowDays(window);
     // Reads come from telemetry; writes are the snapshot's git-derived rows
     // reconciled against write telemetry for agent attribution (complete,
     // PR merges included, deduped). See buildContextTreeIoSummary.
-    const io = await buildContextTreeIoSummary(app.db, scope.organizationId, windowDays, snapshot.io.writes, {
-      humanAgentId: scope.humanAgentId,
-      memberId: scope.memberId,
-    });
-    return contextTreeSnapshotSchema.parse({ ...snapshot, usage, io });
+    const io = await timing.time("io_summary", () =>
+      buildContextTreeIoSummary(
+        app.db,
+        scope.organizationId,
+        windowDays,
+        snapshot.io.writes,
+        {
+          humanAgentId: scope.humanAgentId,
+          memberId: scope.memberId,
+        },
+        { timing: timing.add },
+      ),
+    );
+    const response = timing.timeSync("schema_parse", () => contextTreeSnapshotSchema.parse({ ...snapshot, usage, io }));
+    const totalMs = timing.elapsedMs();
+    reply.header("Server-Timing", timing.serverTimingHeader());
+    request.log[totalMs > 1500 || timing.records.some((record) => record.ms > 500) ? "warn" : "info"](
+      {
+        event: "context_tree_snapshot_timing",
+        orgId: scope.organizationId,
+        window,
+        snapshotStatus: response.snapshotStatus,
+        nodeCount: response.nodes.length,
+        updateCount: response.updates.length,
+        totalMs,
+        timings: timing.records,
+      },
+      "context tree snapshot timing",
+    );
+    return response;
   });
 }

--- a/packages/server/src/observability/timing.ts
+++ b/packages/server/src/observability/timing.ts
@@ -1,0 +1,65 @@
+export type TimingFields = Record<string, unknown>;
+
+export type TimingRecord = {
+  name: string;
+  ms: number;
+  fields?: TimingFields;
+};
+
+export type TimingSink = (name: string, ms: number, fields?: TimingFields) => void;
+
+export type TimingCollector = {
+  readonly records: TimingRecord[];
+  readonly add: TimingSink;
+  elapsedMs(): number;
+  serverTimingHeader(): string;
+  time<T>(name: string, fn: () => Promise<T>, fields?: TimingFields): Promise<T>;
+  timeSync<T>(name: string, fn: () => T, fields?: TimingFields): T;
+};
+
+export function createTimingCollector(): TimingCollector {
+  const startedAt = performance.now();
+  const records: TimingRecord[] = [];
+  const add: TimingSink = (name, ms, fields) => {
+    records.push({ name, ms: Math.max(0, Math.round(ms)), ...(fields ? { fields } : {}) });
+  };
+
+  return {
+    records,
+    add,
+    elapsedMs: () => Math.max(0, Math.round(performance.now() - startedAt)),
+    serverTimingHeader: () => records.map((record) => `${serverTimingToken(record.name)};dur=${record.ms}`).join(", "),
+    time: async (name, fn, fields) => timeWithSink(add, name, fn, fields),
+    timeSync: (name, fn, fields) => timeSyncWithSink(add, name, fn, fields),
+  };
+}
+
+export async function timeWithSink<T>(
+  sink: TimingSink | undefined,
+  name: string,
+  fn: () => Promise<T>,
+  fields?: TimingFields,
+): Promise<T> {
+  if (!sink) return fn();
+  const startedAt = performance.now();
+  try {
+    return await fn();
+  } finally {
+    sink(name, performance.now() - startedAt, fields);
+  }
+}
+
+export function timeSyncWithSink<T>(sink: TimingSink | undefined, name: string, fn: () => T, fields?: TimingFields): T {
+  if (!sink) return fn();
+  const startedAt = performance.now();
+  try {
+    return fn();
+  } finally {
+    sink(name, performance.now() - startedAt, fields);
+  }
+}
+
+function serverTimingToken(name: string): string {
+  const token = name.replace(/[^A-Za-z0-9!#$%&'*+.^_`|~-]/g, "_");
+  return token.length > 0 ? token : "stage";
+}

--- a/packages/server/src/services/context-tree-io.ts
+++ b/packages/server/src/services/context-tree-io.ts
@@ -26,6 +26,7 @@ import { chats } from "../db/schema/chats.js";
 import { contextTreeIoEvents } from "../db/schema/context-tree-io-events.js";
 import { sessionEvents } from "../db/schema/session-events.js";
 import { createLogger } from "../observability/index.js";
+import { type TimingSink, timeWithSink } from "../observability/timing.js";
 import { getOrgContextTree } from "./org-settings.js";
 
 const CONTEXT_TREE_IO_FEED_LIMIT = 50;
@@ -41,6 +42,10 @@ const GIT_STATUS_DELTA_DERIVATION: EventIoDerivation = { action: "write", source
 export type ContextTreeIoViewer = {
   humanAgentId: string;
   memberId: string;
+};
+
+export type ContextTreeIoSummaryOptions = {
+  timing?: TimingSink;
 };
 
 export type RecordContextTreeIoInput = {
@@ -311,30 +316,34 @@ export async function summarizeContextTreeIoSkippedEvents(
   db: Database,
   organizationId: string,
   windowDays: number,
+  options: ContextTreeIoSummaryOptions = {},
 ): Promise<ContextTreeIoSkipSummary> {
   const since = new Date(Date.now() - windowDays * 24 * 60 * 60 * 1000);
   const binding = await getOrgContextTree(db, organizationId);
   const bindingBranch = binding.branch ?? "main";
-  const rows = await db
-    .select({
-      id: sessionEvents.id,
-      agentId: sessionEvents.agentId,
-      chatId: sessionEvents.chatId,
-      kind: sessionEvents.kind,
-      payload: sessionEvents.payload,
-      runtimeProvider: agents.runtimeProvider,
-      chatOrganizationId: chats.organizationId,
-    })
-    .from(sessionEvents)
-    .innerJoin(agents, eq(agents.uuid, sessionEvents.agentId))
-    .leftJoin(chats, eq(chats.id, sessionEvents.chatId))
-    .where(
-      and(
-        eq(agents.organizationId, organizationId),
-        gte(sessionEvents.createdAt, since),
-        or(eq(sessionEvents.kind, "context_tree_usage"), eq(sessionEvents.kind, "tool_call")),
+  const rows = await timeWithSink(options.timing, "io_skipped_scan", () =>
+    db
+      .select({
+        id: sessionEvents.id,
+        agentId: sessionEvents.agentId,
+        chatId: sessionEvents.chatId,
+        kind: sessionEvents.kind,
+        payload: sessionEvents.payload,
+        runtimeProvider: agents.runtimeProvider,
+        chatOrganizationId: chats.organizationId,
+      })
+      .from(sessionEvents)
+      .innerJoin(agents, eq(agents.uuid, sessionEvents.agentId))
+      .leftJoin(chats, eq(chats.id, sessionEvents.chatId))
+      .where(
+        and(
+          eq(agents.organizationId, organizationId),
+          gte(sessionEvents.createdAt, since),
+          or(eq(sessionEvents.kind, "context_tree_usage"), eq(sessionEvents.kind, "tool_call")),
+        ),
       ),
-    );
+  );
+  options.timing?.("io_skipped_rows", 0, { rowCount: rows.length });
 
   const byReason = new Map<
     ContextTreeIoSkipReason,
@@ -480,63 +489,78 @@ export async function recordFromSessionEvent(db: Database, input: RecordContextT
     });
 }
 
-async function backfillContextTreeIoSessionEvents(db: Database, organizationId: string, since: Date): Promise<void> {
-  const rows = await db
-    .select({
-      id: sessionEvents.id,
-      agentId: sessionEvents.agentId,
-      chatId: sessionEvents.chatId,
-      kind: sessionEvents.kind,
-      payload: sessionEvents.payload,
-      createdAt: sessionEvents.createdAt,
-      runtimeProvider: agents.runtimeProvider,
-    })
-    .from(sessionEvents)
-    .innerJoin(agents, eq(agents.uuid, sessionEvents.agentId))
-    .where(
-      and(
-        eq(agents.organizationId, organizationId),
-        or(
-          eq(sessionEvents.kind, "context_tree_usage"),
-          and(
-            eq(sessionEvents.kind, "tool_call"),
-            sql`${sessionEvents.payload}->>'status' = 'ok'`,
-            sql`EXISTS (
-              SELECT 1
-              FROM jsonb_array_elements(
-                CASE
-                  WHEN jsonb_typeof(${sessionEvents.payload}->'toolFileRefs') = 'array'
-                  THEN ${sessionEvents.payload}->'toolFileRefs'
-                  ELSE '[]'::jsonb
-                END
-              ) AS ref
-              WHERE ref ? 'repoUrl' AND ref ? 'repoRelativePath'
-            )`,
+async function backfillContextTreeIoSessionEvents(
+  db: Database,
+  organizationId: string,
+  since: Date,
+  options: ContextTreeIoSummaryOptions = {},
+): Promise<void> {
+  const rows = await timeWithSink(options.timing, "io_backfill_scan", () =>
+    db
+      .select({
+        id: sessionEvents.id,
+        agentId: sessionEvents.agentId,
+        chatId: sessionEvents.chatId,
+        kind: sessionEvents.kind,
+        payload: sessionEvents.payload,
+        createdAt: sessionEvents.createdAt,
+        runtimeProvider: agents.runtimeProvider,
+      })
+      .from(sessionEvents)
+      .innerJoin(agents, eq(agents.uuid, sessionEvents.agentId))
+      .where(
+        and(
+          eq(agents.organizationId, organizationId),
+          or(
+            eq(sessionEvents.kind, "context_tree_usage"),
+            and(
+              eq(sessionEvents.kind, "tool_call"),
+              sql`${sessionEvents.payload}->>'status' = 'ok'`,
+              sql`EXISTS (
+                SELECT 1
+                FROM jsonb_array_elements(
+                  CASE
+                    WHEN jsonb_typeof(${sessionEvents.payload}->'toolFileRefs') = 'array'
+                    THEN ${sessionEvents.payload}->'toolFileRefs'
+                    ELSE '[]'::jsonb
+                  END
+                ) AS ref
+                WHERE ref ? 'repoUrl' AND ref ? 'repoRelativePath'
+              )`,
+            ),
           ),
+          gte(sessionEvents.createdAt, since),
+          sql`NOT EXISTS (
+            SELECT 1
+            FROM context_tree_io_events existing
+            WHERE existing.source_session_event_id = ${sessionEvents.id}
+          )`,
         ),
-        gte(sessionEvents.createdAt, since),
-        sql`NOT EXISTS (
-          SELECT 1
-          FROM context_tree_io_events existing
-          WHERE existing.source_session_event_id = ${sessionEvents.id}
-        )`,
       ),
-    );
+  );
+  options.timing?.("io_backfill_rows", 0, { rowCount: rows.length });
 
-  for (const row of rows) {
-    await recordFromSessionEvent(db, {
-      organizationId,
-      agentId: row.agentId,
-      chatId: row.chatId,
-      runtimeProvider: row.runtimeProvider,
-      sessionEvent: {
-        id: row.id,
-        kind: row.kind,
-        payload: row.payload,
-        createdAt: isoOrNull(row.createdAt) ?? new Date().toISOString(),
-      },
-    });
-  }
+  await timeWithSink(
+    options.timing,
+    "io_backfill_record",
+    async () => {
+      for (const row of rows) {
+        await recordFromSessionEvent(db, {
+          organizationId,
+          agentId: row.agentId,
+          chatId: row.chatId,
+          runtimeProvider: row.runtimeProvider,
+          sessionEvent: {
+            id: row.id,
+            kind: row.kind,
+            payload: row.payload,
+            createdAt: isoOrNull(row.createdAt) ?? new Date().toISOString(),
+          },
+        });
+      }
+    },
+    { rowCount: rows.length },
+  );
 }
 
 function allEventsSql(organizationId: string, sinceIso: string) {
@@ -671,29 +695,35 @@ export async function reconcileContextTreeWrites(
   organizationId: string,
   windowDays: number,
   gitWrites: ContextTreeWriteEvent[],
+  options: ContextTreeIoSummaryOptions = {},
 ): Promise<ContextTreeWriteEvent[]> {
   const since = new Date(Date.now() - windowDays * 24 * 60 * 60 * 1000);
   const sinceIso = since.toISOString();
-  await backfillContextTreeIoSessionEvents(db, organizationId, since);
+  await timeWithSink(options.timing, "write_reconcile_backfill", () =>
+    backfillContextTreeIoSessionEvents(db, organizationId, since, options),
+  );
 
-  const writeRows = await db.execute<{
-    agent_id: string;
-    agent_name: string;
-    agent_avatar_color_token: string | null;
-    target_path: string;
-    created_at: Date | string;
-  }>(sql`
-    ${allEventsSql(organizationId, sinceIso)}
-    SELECT
-      all_events.agent_id,
-      all_events.agent_name,
-      all_events.agent_avatar_color_token,
-      all_events.target_path,
-      all_events.created_at
-    FROM all_events
-    WHERE all_events.action = 'write'
-    ORDER BY all_events.created_at ASC
-  `);
+  const writeRows = await timeWithSink(options.timing, "write_reconcile_query", () =>
+    db.execute<{
+      agent_id: string;
+      agent_name: string;
+      agent_avatar_color_token: string | null;
+      target_path: string;
+      created_at: Date | string;
+    }>(sql`
+      ${allEventsSql(organizationId, sinceIso)}
+      SELECT
+        all_events.agent_id,
+        all_events.agent_name,
+        all_events.agent_avatar_color_token,
+        all_events.target_path,
+        all_events.created_at
+      FROM all_events
+      WHERE all_events.action = 'write'
+      ORDER BY all_events.created_at ASC
+    `),
+  );
+  options.timing?.("write_reconcile_rows", 0, { rowCount: writeRows.length, gitWriteCount: gitWrites.length });
 
   const telemetryByKey = new Map<string, ReconcileTelemetryWrite[]>();
   for (const row of writeRows) {
@@ -775,26 +805,31 @@ export async function summarizeContextTreeIo(
   organizationId: string,
   windowDays: number,
   viewer?: ContextTreeIoViewer,
+  options: ContextTreeIoSummaryOptions = {},
 ): Promise<ContextTreeIoSummary> {
   const since = new Date(Date.now() - windowDays * 24 * 60 * 60 * 1000);
   const sinceIso = since.toISOString();
-  await backfillContextTreeIoSessionEvents(db, organizationId, since);
+  await timeWithSink(options.timing, "io_backfill", () =>
+    backfillContextTreeIoSessionEvents(db, organizationId, since, options),
+  );
 
-  const countRows = await db.execute<{
-    action: string;
-    agent_count: number;
-    event_count: number;
-    target_count: number;
-  }>(sql`
-    ${allEventsSql(organizationId, sinceIso)}
-    SELECT
-      action,
-      count(DISTINCT agent_id)::int AS agent_count,
-      count(*)::int AS event_count,
-      count(DISTINCT target_path)::int AS target_count
-    FROM all_events
-    GROUP BY action
-  `);
+  const countRows = await timeWithSink(options.timing, "io_counts", () =>
+    db.execute<{
+      action: string;
+      agent_count: number;
+      event_count: number;
+      target_count: number;
+    }>(sql`
+      ${allEventsSql(organizationId, sinceIso)}
+      SELECT
+        action,
+        count(DISTINCT agent_id)::int AS agent_count,
+        count(*)::int AS event_count,
+        count(DISTINCT target_path)::int AS target_count
+      FROM all_events
+      GROUP BY action
+    `),
+  );
 
   const summary = {
     read: emptyBucket(),
@@ -809,74 +844,82 @@ export async function summarizeContextTreeIo(
     };
   }
 
-  const agentRows = await db.execute<{
-    agent_id: string;
-    agent_name: string;
-    agent_avatar_color_token: string | null;
-    runtime_provider: string;
-    read_count: number;
-    write_count: number;
-    last_read_at: Date | string | null;
-    last_write_at: Date | string | null;
-    last_event_at: Date | string;
-  }>(sql`
-    ${allEventsSql(organizationId, sinceIso)}
-    SELECT
-      agent_id,
-      agent_name,
-      agent_avatar_color_token,
-      runtime_provider,
-      count(*) FILTER (WHERE action = 'read')::int AS read_count,
-      count(*) FILTER (WHERE action = 'write')::int AS write_count,
-      max(created_at) FILTER (WHERE action = 'read') AS last_read_at,
-      max(created_at) FILTER (WHERE action = 'write') AS last_write_at,
-      max(created_at) AS last_event_at
-    FROM all_events
-    GROUP BY agent_id, agent_name, agent_avatar_color_token, runtime_provider
-    ORDER BY last_event_at DESC
-  `);
+  const agentRows = await timeWithSink(options.timing, "io_agents", () =>
+    db.execute<{
+      agent_id: string;
+      agent_name: string;
+      agent_avatar_color_token: string | null;
+      runtime_provider: string;
+      read_count: number;
+      write_count: number;
+      last_read_at: Date | string | null;
+      last_write_at: Date | string | null;
+      last_event_at: Date | string;
+    }>(sql`
+      ${allEventsSql(organizationId, sinceIso)}
+      SELECT
+        agent_id,
+        agent_name,
+        agent_avatar_color_token,
+        runtime_provider,
+        count(*) FILTER (WHERE action = 'read')::int AS read_count,
+        count(*) FILTER (WHERE action = 'write')::int AS write_count,
+        max(created_at) FILTER (WHERE action = 'read') AS last_read_at,
+        max(created_at) FILTER (WHERE action = 'write') AS last_write_at,
+        max(created_at) AS last_event_at
+      FROM all_events
+      GROUP BY agent_id, agent_name, agent_avatar_color_token, runtime_provider
+      ORDER BY last_event_at DESC
+    `),
+  );
 
-  const recentRows = await db.execute<{
-    id: string;
-    agent_id: string;
-    agent_name: string;
-    agent_avatar_color_token: string | null;
-    runtime_provider: string;
-    action: string;
-    source: string;
-    target_kind: string;
-    target_path: string;
-    raw_chat_id: string;
-    joined_chat_id: string | null;
-    chat_topic: string | null;
-    created_at: Date | string;
-  }>(sql`
-    ${allEventsSql(organizationId, sinceIso)}
-    SELECT
-      all_events.id,
-      all_events.agent_id,
-      all_events.agent_name,
-      all_events.agent_avatar_color_token,
-      all_events.runtime_provider,
-      all_events.action,
-      all_events.source,
-      all_events.target_kind,
-      all_events.target_path,
-      all_events.chat_id AS raw_chat_id,
-      c.id AS joined_chat_id,
-      c.topic AS chat_topic,
-      all_events.created_at
-    FROM all_events
-    LEFT JOIN chats c ON c.id = all_events.chat_id AND c.organization_id = ${organizationId}
-    WHERE all_events.action = 'read'
-    ORDER BY all_events.created_at DESC
-    LIMIT ${CONTEXT_TREE_IO_FEED_LIMIT}
-  `);
+  const recentRows = await timeWithSink(options.timing, "io_recent_reads", () =>
+    db.execute<{
+      id: string;
+      agent_id: string;
+      agent_name: string;
+      agent_avatar_color_token: string | null;
+      runtime_provider: string;
+      action: string;
+      source: string;
+      target_kind: string;
+      target_path: string;
+      raw_chat_id: string;
+      joined_chat_id: string | null;
+      chat_topic: string | null;
+      created_at: Date | string;
+    }>(sql`
+      ${allEventsSql(organizationId, sinceIso)}
+      SELECT
+        all_events.id,
+        all_events.agent_id,
+        all_events.agent_name,
+        all_events.agent_avatar_color_token,
+        all_events.runtime_provider,
+        all_events.action,
+        all_events.source,
+        all_events.target_kind,
+        all_events.target_path,
+        all_events.chat_id AS raw_chat_id,
+        c.id AS joined_chat_id,
+        c.topic AS chat_topic,
+        all_events.created_at
+      FROM all_events
+      LEFT JOIN chats c ON c.id = all_events.chat_id AND c.organization_id = ${organizationId}
+      WHERE all_events.action = 'read'
+      ORDER BY all_events.created_at DESC
+      LIMIT ${CONTEXT_TREE_IO_FEED_LIMIT}
+    `),
+  );
 
   const inOrgChatIds = [
     ...new Set(recentRows.filter((row) => row.joined_chat_id !== null).map((row) => row.raw_chat_id)),
   ];
-  const accessibleChatIds = viewer ? await accessibleChatIdSet(db, viewer, inOrgChatIds) : new Set<string>();
+  const accessibleChatIds = viewer
+    ? await timeWithSink(options.timing, "io_accessible_chats", () => accessibleChatIdSet(db, viewer, inOrgChatIds), {
+        chatCount: inOrgChatIds.length,
+      })
+    : new Set<string>();
 
   const recentEvents: ContextTreeIoEvent[] = recentRows.map((row) => {
     const sameOrgChat = row.joined_chat_id !== null;
@@ -896,7 +939,9 @@ export async function summarizeContextTreeIo(
       createdAt: isoOrNull(row.created_at) ?? new Date().toISOString(),
     };
   });
-  const skipped = await summarizeContextTreeIoSkippedEvents(db, organizationId, windowDays);
+  const skipped = await timeWithSink(options.timing, "io_skipped", () =>
+    summarizeContextTreeIoSkippedEvents(db, organizationId, windowDays, options),
+  );
 
   return {
     windowDays,
@@ -934,8 +979,11 @@ export async function buildContextTreeIoSummary(
   windowDays: number,
   gitWrites: ContextTreeWriteEvent[],
   viewer?: ContextTreeIoViewer,
+  options: ContextTreeIoSummaryOptions = {},
 ): Promise<ContextTreeIoSummary> {
-  const io = await summarizeContextTreeIo(db, organizationId, windowDays, viewer);
-  const writes = await reconcileContextTreeWrites(db, organizationId, windowDays, gitWrites);
+  const io = await summarizeContextTreeIo(db, organizationId, windowDays, viewer, options);
+  const writes = await timeWithSink(options.timing, "write_reconcile", () =>
+    reconcileContextTreeWrites(db, organizationId, windowDays, gitWrites, options),
+  );
   return { ...io, writes, writesTotal: writes.length };
 }

--- a/packages/server/src/services/context-tree-snapshot.ts
+++ b/packages/server/src/services/context-tree-snapshot.ts
@@ -19,6 +19,7 @@ import type {
 } from "@first-tree/shared";
 import { defaultDataDir } from "@first-tree/shared/config";
 import matter from "gray-matter";
+import { type TimingSink, timeSyncWithSink, timeWithSink } from "../observability/timing.js";
 
 const execFileAsync = promisify(execFile);
 const ROOT_NODE_ID = "root";
@@ -133,13 +134,21 @@ export type ContextTreeBinding = {
   githubToken?: string;
 };
 
+export type ContextTreeSnapshotOptions = {
+  timing?: TimingSink;
+};
+
 export async function getContextTreeSnapshot(
   binding: ContextTreeBinding,
   window: ContextTreeSnapshotWindow = CONTEXT_TREE_SNAPSHOT_WINDOWS.SEVEN_DAYS,
+  options: ContextTreeSnapshotOptions = {},
 ): Promise<ContextTreeSnapshot> {
   const repo = binding.repo ?? null;
   const branch = binding.branch ?? null;
-  const resolved = await resolveContextTreeRoot(repo, binding.localPath, branch, binding.githubToken);
+  const timing = options.timing;
+  const resolved = await timeWithSink(timing, "resolve_root", () =>
+    resolveContextTreeRoot(repo, binding.localPath, branch, binding.githubToken, timing),
+  );
 
   if (!resolved.root) {
     return unavailableSnapshot(repo, branch, resolved.reason);
@@ -147,8 +156,10 @@ export async function getContextTreeSnapshot(
 
   const now = new Date().toISOString();
   try {
-    const headCommit = await gitOutput(resolved.root, ["rev-parse", "HEAD"]);
-    const actualBranch = await safeGitOutput(resolved.root, ["rev-parse", "--abbrev-ref", "HEAD"]);
+    const { headCommit, actualBranch } = await timeWithSink(timing, "git_head", async () => ({
+      headCommit: await gitOutput(resolved.root ?? "", ["rev-parse", "HEAD"]),
+      actualBranch: await safeGitOutput(resolved.root ?? "", ["rev-parse", "--abbrev-ref", "HEAD"]),
+    }));
     if (branch && actualBranch && actualBranch !== branch) {
       return unavailableSnapshot(
         repo,
@@ -157,9 +168,12 @@ export async function getContextTreeSnapshot(
       );
     }
 
-    const comparisonBaseCommit = await comparisonBaseForWindow(resolved.root, window);
+    const comparisonBaseCommit = await timeWithSink(timing, "comparison_base", () =>
+      comparisonBaseForWindow(resolved.root ?? "", window),
+    );
     const cacheKey = snapshotCacheKey(resolved.root, actualBranch ?? branch, headCommit, comparisonBaseCommit, window);
     const cached = snapshotCache.get(cacheKey);
+    timing?.("snapshot_cache_lookup", 0, { hit: !!cached });
     if (cached && cached.expiresAt > Date.now()) {
       const staleCacheRecovered = cached.snapshot.snapshotStatus === "stale" && !resolved.staleReason;
       if (!staleCacheRecovered) {
@@ -167,38 +181,45 @@ export async function getContextTreeSnapshot(
       }
     }
 
-    const files = await readMarkdownFiles(resolved.root);
-    const tree = buildTree(files);
+    const files = await timeWithSink(timing, "read_markdown_files", () => readMarkdownFiles(resolved.root ?? ""));
+    timing?.("read_markdown_files_count", 0, { fileCount: files.length });
+    const tree = timeSyncWithSink(timing, "build_tree", () => buildTree(files), { fileCount: files.length });
+    timing?.("build_tree_count", 0, { nodeCount: tree.nodes.length, edgeCount: tree.edges.length });
     const diffResult = comparisonBaseCommit
-      ? await readDiffEntries(resolved.root, comparisonBaseCommit, headCommit)
+      ? await timeWithSink(timing, "read_diff_entries", () =>
+          readDiffEntries(resolved.root ?? "", comparisonBaseCommit, headCommit),
+        )
       : { entries: [], truncated: false };
-    const changes = buildChanges(diffResult.entries, tree);
-    const nodes = applyChangesToNodes(tree.nodes, changes);
-    const nodesWithGhosts = addRemovedGhostNodes(nodes, changes);
-    const summary = summarizeChanges(changes);
-    const updates = buildUpdates(changes, nodesWithGhosts);
-    // Git-derived writes are cacheable with the rest of the snapshot — they
-    // depend only on the repo's git history, not on the viewer or any DB
-    // state. The route enriches them with session-telemetry agent attribution
-    // (which is viewer-dependent) after this cached snapshot is read.
-    const writes = buildWriteEvents(changes, nodesWithGhosts);
-    const statusWarning = statusWarningFromResolved(resolved.staleReason, diffResult.truncated);
+    timing?.("read_diff_entries_count", 0, { changeCount: diffResult.entries.length, truncated: diffResult.truncated });
+    const snapshot = timeSyncWithSink(timing, "build_snapshot", () => {
+      const changes = buildChanges(diffResult.entries, tree);
+      const nodes = applyChangesToNodes(tree.nodes, changes);
+      const nodesWithGhosts = addRemovedGhostNodes(nodes, changes);
+      const summary = summarizeChanges(changes);
+      const updates = buildUpdates(changes, nodesWithGhosts);
+      // Git-derived writes are cacheable with the rest of the snapshot — they
+      // depend only on the repo's git history, not on the viewer or any DB
+      // state. The route enriches them with session-telemetry agent attribution
+      // (which is viewer-dependent) after this cached snapshot is read.
+      const writes = buildWriteEvents(changes, nodesWithGhosts);
+      const statusWarning = statusWarningFromResolved(resolved.staleReason, diffResult.truncated);
 
-    const snapshot: ContextTreeSnapshot = {
-      repo,
-      branch: actualBranch ?? branch,
-      headCommit,
-      syncedAt: now,
-      snapshotStatus: statusWarning?.stale ? "stale" : "active",
-      contextStatus: contextStatus(statusWarning),
-      summary,
-      usage: emptyUsageSummary(window),
-      io: { ...emptyIoSummary(window), writes, writesTotal: writes.length },
-      updates,
-      nodes: nodesWithGhosts,
-      edges: tree.edges,
-      changes,
-    };
+      return {
+        repo,
+        branch: actualBranch ?? branch,
+        headCommit,
+        syncedAt: now,
+        snapshotStatus: statusWarning?.stale ? "stale" : "active",
+        contextStatus: contextStatus(statusWarning),
+        summary,
+        usage: emptyUsageSummary(window),
+        io: { ...emptyIoSummary(window), writes, writesTotal: writes.length },
+        updates,
+        nodes: nodesWithGhosts,
+        edges: tree.edges,
+        changes,
+      } satisfies ContextTreeSnapshot;
+    });
     snapshotCache.set(cacheKey, { expiresAt: Date.now() + SNAPSHOT_CACHE_TTL_MS, snapshot });
     return snapshot;
   } catch (error) {
@@ -234,6 +255,7 @@ async function resolveContextTreeRoot(
   localPath: string | null | undefined,
   branch: string | null,
   githubToken?: string | null,
+  timing?: TimingSink,
 ): Promise<ResolvedContextTreeRoot> {
   if (localPath && localPath.trim().length > 0) {
     const root = resolveLocalPath(localPath);
@@ -255,7 +277,7 @@ async function resolveContextTreeRoot(
       };
     }
     try {
-      const materialized = await materializeRemoteContextTree(repo, resolvedBranch, undefined, githubToken);
+      const materialized = await materializeRemoteContextTree(repo, resolvedBranch, undefined, githubToken, timing);
       return { root: materialized.root, reason: "ok", staleReason: materialized.staleReason };
     } catch (error) {
       return {
@@ -327,11 +349,13 @@ async function materializeRemoteContextTree(
   branch: string,
   cacheRoot = managedContextTreeCacheRoot(),
   githubToken?: string | null,
+  timing?: TimingSink,
 ): Promise<{ root: string; staleReason: string | null }> {
   const repoUrl = normalizeRemoteRepoUrl(repo);
   const root = managedContextTreePath(repoUrl, branch, cacheRoot);
   const lastSyncedAt = remoteLastSyncedAt.get(root);
   if (lastSyncedAt && Date.now() - lastSyncedAt < REMOTE_SYNC_TTL_MS && existsSync(join(root, ".git"))) {
+    timing?.("remote_sync_skip_ttl", 0, { stale: remoteLastSyncWarnings.has(root) });
     return { root, staleReason: remoteLastSyncWarnings.get(root) ?? null };
   }
   const lastFailure = remoteLastFailures.get(root);
@@ -341,11 +365,11 @@ async function materializeRemoteContextTree(
 
   const existing = remoteSyncPromises.get(root);
   if (existing) {
-    const result = await existing;
+    const result = await timeWithSink(timing, "remote_sync_wait_existing", () => existing);
     return { root, staleReason: result.staleReason };
   }
 
-  const syncPromise = syncRemoteContextTree(repoUrl, branch, root, cacheRoot, githubToken);
+  const syncPromise = syncRemoteContextTree(repoUrl, branch, root, cacheRoot, githubToken, timing);
   remoteSyncPromises.set(root, syncPromise);
   try {
     const syncResult = await syncPromise;
@@ -376,16 +400,23 @@ async function syncRemoteContextTree(
   root: string,
   cacheRoot: string,
   githubToken?: string | null,
+  timing?: TimingSink,
 ): Promise<RemoteSyncResult> {
   await mkdir(cacheRoot, { recursive: true });
   const env = await gitAuthEnv(repoUrl, cacheRoot, githubToken);
   if (!existsSync(join(root, ".git"))) {
     await rm(root, { recursive: true, force: true });
-    await gitOutput(cacheRoot, ["clone", "--branch", branch, "--single-branch", repoUrl, root], {
-      timeout: GIT_SYNC_TIMEOUT_MS,
-      env,
-      disableHooks: true,
-    });
+    await timeWithSink(
+      timing,
+      "remote_clone",
+      () =>
+        gitOutput(cacheRoot, ["clone", "--branch", branch, "--single-branch", repoUrl, root], {
+          timeout: GIT_SYNC_TIMEOUT_MS,
+          env,
+          disableHooks: true,
+        }),
+      { branch },
+    );
     return { staleReason: null };
   }
 
@@ -394,18 +425,26 @@ async function syncRemoteContextTree(
       timeout: GIT_TIMEOUT_MS,
       disableHooks: true,
     });
-    await gitOutput(root, ["fetch", "origin", branch, "--prune"], {
-      timeout: GIT_SYNC_TIMEOUT_MS,
-      env,
-      disableHooks: true,
-    });
-    await gitOutput(root, ["checkout", "-B", branch, `origin/${branch}`], {
-      timeout: GIT_TIMEOUT_MS,
-      disableHooks: true,
-    });
+    await timeWithSink(
+      timing,
+      "remote_fetch_checkout",
+      async () => {
+        await gitOutput(root, ["fetch", "origin", branch, "--prune"], {
+          timeout: GIT_SYNC_TIMEOUT_MS,
+          env,
+          disableHooks: true,
+        });
+        await gitOutput(root, ["checkout", "-B", branch, `origin/${branch}`], {
+          timeout: GIT_TIMEOUT_MS,
+          disableHooks: true,
+        });
+      },
+      { branch },
+    );
     return { staleReason: null };
   } catch (error) {
     if (existsSync(join(root, ".git"))) {
+      timing?.("remote_sync_stale_fallback", 0);
       return {
         staleReason: `Showing the last synced Context Tree snapshot because First Tree could not refresh the configured repo. ${errorMessage(error)}`,
       };


### PR DESCRIPTION
## Summary

Adds segmented timing instrumentation to the Context tab snapshot path so slow loads can be attributed to the specific backend stage.

- Adds a small timing collector that emits `Server-Timing` and structured timing records.
- Instruments org-scoped and legacy Context Tree snapshot routes with route, snapshot, usage, and IO stages.
- Instruments snapshot internals for remote sync, cache lookup, markdown scanning, tree/diff building, and snapshot assembly.
- Instruments Context Tree IO summary and write reconciliation queries.
- Adds test coverage for the `Server-Timing` response header and service-level timing hooks.

## Why

The Context tab can sometimes stay in the loading state for a long time. This gives both browser-visible timing (`Server-Timing`) and backend logs (`context_tree_snapshot_timing`) so we can tell whether time is going into git/remote sync, markdown scanning, tree construction, usage telemetry, IO reconciliation, or response validation.

## Validation

- `pnpm --filter @first-tree/server exec vitest run src/__tests__/context-tree-snapshot.test.ts src/__tests__/context-tree-snapshot-timing.test.ts`
- `pnpm --filter @first-tree/server exec vitest run src/__tests__/context-tree-io.test.ts`
- `pnpm --filter @first-tree/server typecheck`
- `pnpm exec biome check packages/server/src/observability/timing.ts packages/server/src/api/orgs/context-tree-snapshot.ts packages/server/src/api/context-tree-snapshot.ts packages/server/src/services/context-tree-snapshot.ts packages/server/src/services/context-tree-io.ts packages/server/src/__tests__/context-tree-snapshot.test.ts packages/server/src/__tests__/context-tree-snapshot-timing.test.ts`
- `git diff --check`
