### PR TITLE
[fix] Reduce Context Tree IO summary scans

### DIFF
--- a/packages/server/src/__tests__/context-tree-io.test.ts
+++ b/packages/server/src/__tests__/context-tree-io.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import { chats } from "../db/schema/chats.js";
 import { contextTreeIoEvents } from "../db/schema/context-tree-io-events.js";
 import {
+  buildContextTreeIoSummary,
   explainContextTreeIoDecision,
   reconcileContextTreeWrites,
   recordFromSessionEvent,
@@ -673,6 +674,63 @@ describe("context-tree IO service", () => {
     expect(io.skipped).toEqual(skipped);
   });
 
+  it("skips diagnostics scan for already-recorded IO events", async () => {
+    const app = getApp();
+    const seed = await seedContextTreeChat();
+    const timings: Array<{ name: string; fields?: Record<string, unknown> }> = [];
+
+    const recorded = await appendEvent(app.db, seed.agent.uuid, seed.chatId, {
+      kind: "tool_call",
+      payload: {
+        toolUseId: "tu-recorded",
+        name: "Read",
+        args: {},
+        status: "ok",
+        toolFileRefs: [
+          {
+            origin: "tool_arg",
+            repoUrl: TREE_REPO,
+            repoBranch: "main",
+            repoRelativePath: "NODE.md",
+            pathKind: "file",
+          },
+        ],
+      },
+    });
+    await appendEvent(app.db, seed.agent.uuid, seed.chatId, {
+      kind: "tool_call",
+      payload: {
+        toolUseId: "tu-skipped",
+        name: "Bash",
+        args: { command: "echo x > /tmp/context-tree/NODE.md" },
+        status: "ok",
+        toolFileRefs: [
+          {
+            origin: "tool_arg",
+            repoUrl: TREE_REPO,
+            repoBranch: "main",
+            repoRelativePath: "NODE.md",
+            pathKind: "file",
+          },
+        ],
+      },
+    });
+    await recordFromSessionEvent(app.db, {
+      organizationId: seed.organizationId,
+      agentId: seed.agent.uuid,
+      chatId: seed.chatId,
+      runtimeProvider: "claude-code",
+      sessionEvent: recorded,
+    });
+
+    const skipped = await summarizeContextTreeIoSkippedEvents(app.db, seed.organizationId, 7, {
+      timing: (name, _ms, fields) => timings.push({ name, fields }),
+    });
+
+    expect(skipped.totalEventCount).toBe(1);
+    expect(timings.find((timing) => timing.name === "io_skipped_rows")?.fields).toMatchObject({ rowCount: 1 });
+  });
+
   it("records git status delta refs as synthetic writes for unsupported shell commands", async () => {
     const app = getApp();
     const seed = await seedContextTreeChat();
@@ -739,6 +797,19 @@ describe("context-tree IO service", () => {
     expect(summary.recentEvents.some((event) => event.source === "git_status_delta")).toBe(false);
     expect(summary.recentEvents.every((event) => event.action === "read")).toBe(true);
     expect(summary.summary.write.eventCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it("builds full IO summary with a single session-event backfill pass", async () => {
+    const app = getApp();
+    const seed = await seedContextTreeChat();
+    const timings: string[] = [];
+
+    const summary = await buildContextTreeIoSummary(app.db, seed.organizationId, 7, [], undefined, {
+      timing: (name) => timings.push(name),
+    });
+
+    expect(summary.writes).toEqual([]);
+    expect(timings.filter((name) => name === "io_backfill_scan")).toHaveLength(1);
   });
 
   it("reconciles git writes with telemetry: attributes the agent, keeps unmatched git authors, surfaces telemetry-only writes", async () => {

--- a/packages/server/src/services/context-tree-io.ts
+++ b/packages/server/src/services/context-tree-io.ts
@@ -46,6 +46,7 @@ export type ContextTreeIoViewer = {
 
 export type ContextTreeIoSummaryOptions = {
   timing?: TimingSink;
+  backfillSessionEvents?: boolean;
 };
 
 export type RecordContextTreeIoInput = {
@@ -340,6 +341,11 @@ export async function summarizeContextTreeIoSkippedEvents(
           eq(agents.organizationId, organizationId),
           gte(sessionEvents.createdAt, since),
           or(eq(sessionEvents.kind, "context_tree_usage"), eq(sessionEvents.kind, "tool_call")),
+          sql`NOT EXISTS (
+            SELECT 1
+            FROM context_tree_io_events existing
+            WHERE existing.source_session_event_id = ${sessionEvents.id}
+          )`,
         ),
       ),
   );
@@ -699,9 +705,11 @@ export async function reconcileContextTreeWrites(
 ): Promise<ContextTreeWriteEvent[]> {
   const since = new Date(Date.now() - windowDays * 24 * 60 * 60 * 1000);
   const sinceIso = since.toISOString();
-  await timeWithSink(options.timing, "write_reconcile_backfill", () =>
-    backfillContextTreeIoSessionEvents(db, organizationId, since, options),
-  );
+  if (options.backfillSessionEvents !== false) {
+    await timeWithSink(options.timing, "write_reconcile_backfill", () =>
+      backfillContextTreeIoSessionEvents(db, organizationId, since, options),
+    );
+  }
 
   const writeRows = await timeWithSink(options.timing, "write_reconcile_query", () =>
     db.execute<{
@@ -809,9 +817,11 @@ export async function summarizeContextTreeIo(
 ): Promise<ContextTreeIoSummary> {
   const since = new Date(Date.now() - windowDays * 24 * 60 * 60 * 1000);
   const sinceIso = since.toISOString();
-  await timeWithSink(options.timing, "io_backfill", () =>
-    backfillContextTreeIoSessionEvents(db, organizationId, since, options),
-  );
+  if (options.backfillSessionEvents !== false) {
+    await timeWithSink(options.timing, "io_backfill", () =>
+      backfillContextTreeIoSessionEvents(db, organizationId, since, options),
+    );
+  }
 
   const countRows = await timeWithSink(options.timing, "io_counts", () =>
     db.execute<{
@@ -981,9 +991,14 @@ export async function buildContextTreeIoSummary(
   viewer?: ContextTreeIoViewer,
   options: ContextTreeIoSummaryOptions = {},
 ): Promise<ContextTreeIoSummary> {
-  const io = await summarizeContextTreeIo(db, organizationId, windowDays, viewer, options);
+  const since = new Date(Date.now() - windowDays * 24 * 60 * 60 * 1000);
+  await timeWithSink(options.timing, "io_backfill", () =>
+    backfillContextTreeIoSessionEvents(db, organizationId, since, options),
+  );
+  const downstreamOptions = { ...options, backfillSessionEvents: false };
+  const io = await summarizeContextTreeIo(db, organizationId, windowDays, viewer, downstreamOptions);
   const writes = await timeWithSink(options.timing, "write_reconcile", () =>
-    reconcileContextTreeWrites(db, organizationId, windowDays, gitWrites, options),
+    reconcileContextTreeWrites(db, organizationId, windowDays, gitWrites, downstreamOptions),
   );
   return { ...io, writes, writesTotal: writes.length };
 }


### PR DESCRIPTION
## Summary

Reduces repeated work in the Context tab snapshot IO summary path.

- Runs Context Tree IO session-event backfill once in `buildContextTreeIoSummary`, then reuses that pass for summary and write reconciliation.
- Lets standalone `summarizeContextTreeIo` and `reconcileContextTreeWrites` keep their existing default behavior.
- Excludes already-recorded IO events from skipped-diagnostics scans so `io.skipped` only evaluates unrecorded candidates.
- Adds regression tests for both performance behaviors.

## Why

After PR #1287 landed, dev timing from `https://dev.cloud.first-tree.ai/context` showed the slow path is not git snapshot building:

- `snapshot_build`: usually ~19ms, one remote fetch case ~547ms
- `io_summary`: ~2.57-2.72s
- `io_skipped`: ~1.69-1.80s
- `io_backfill_scan`: repeated twice per snapshot request, ~416-449ms each

The first low-risk fix is to remove duplicate backfill scanning and reduce skipped diagnostics input size without changing the server-managed Context tab read model or feed semantics.

## Validation

- `pnpm --filter @first-tree/server exec vitest run src/__tests__/context-tree-io.test.ts -t "single session-event backfill pass"` red before the fix, green after
- `pnpm --filter @first-tree/server exec vitest run src/__tests__/context-tree-io.test.ts -t "already-recorded IO events"` red before the fix, green after
- `pnpm --filter @first-tree/server exec vitest run src/__tests__/context-tree-io.test.ts`
- `pnpm --filter @first-tree/server exec vitest run src/__tests__/context-tree-snapshot-timing.test.ts src/__tests__/context-tree-snapshot.test.ts`
- `pnpm --filter @first-tree/server typecheck`
- `pnpm exec biome check packages/server/src/services/context-tree-io.ts packages/server/src/__tests__/context-tree-io.test.ts`
- `git diff --check`
