### PR TITLE
[fix] Reuse Context Tree binding in IO diagnostics

### DIFF
--- a/packages/server/src/__tests__/context-tree-io.test.ts
+++ b/packages/server/src/__tests__/context-tree-io.test.ts
@@ -17,6 +17,7 @@ import { createTestAgent, useTestApp } from "./helpers.js";
 
 const TREE_REPO = "https://github.com/acme/first-tree-context.git";
 const TREE_REPO_SSH = "git@github.com:acme/first-tree-context.git";
+const ALT_TREE_REPO = "https://github.com/acme/alternate-context.git";
 
 const getApp = useTestApp();
 
@@ -859,6 +860,40 @@ describe("context-tree IO service", () => {
       { reason: "unsupported_shell_command", eventCount: 1 },
     ]);
     expect(timings).toContain("io_skipped_scan");
+  });
+
+  it("reuses snapshot binding for skipped diagnostics in the aggregate path", async () => {
+    const app = getApp();
+    const seed = await seedContextTreeChat();
+    const timings: string[] = [];
+
+    await appendEvent(app.db, seed.agent.uuid, seed.chatId, {
+      kind: "tool_call",
+      payload: {
+        toolUseId: "tu-reused-binding",
+        name: "Read",
+        args: {},
+        status: "ok",
+        toolFileRefs: [
+          {
+            origin: "tool_arg",
+            repoUrl: ALT_TREE_REPO,
+            repoBranch: "main",
+            repoRelativePath: "NODE.md",
+            pathKind: "file",
+          },
+        ],
+      },
+    });
+
+    const summary = await buildContextTreeIoSummary(app.db, seed.organizationId, 7, [], undefined, {
+      contextTreeBinding: { repo: ALT_TREE_REPO, branch: "main" },
+      timing: (name) => timings.push(name),
+    });
+
+    expect(summary.skipped.totalEventCount).toBe(0);
+    expect(timings).toContain("io_skipped_scan");
+    expect(timings).not.toContain("io_skipped_binding");
   });
 
   it("reconciles git writes with telemetry: attributes the agent, keeps unmatched git authors, surfaces telemetry-only writes", async () => {

--- a/packages/server/src/api/context-tree-snapshot.ts
+++ b/packages/server/src/api/context-tree-snapshot.ts
@@ -66,7 +66,7 @@ export async function contextTreeSnapshotRoutes(app: FastifyInstance): Promise<v
             contextTreeSnapshotWindowDays(window),
             snapshot.io.writes,
             viewer ?? undefined,
-            { timing: timing.add },
+            { contextTreeBinding: binding, timing: timing.add },
           ),
         )
       : snapshot.io;

--- a/packages/server/src/api/orgs/context-tree-snapshot.ts
+++ b/packages/server/src/api/orgs/context-tree-snapshot.ts
@@ -66,7 +66,7 @@ export async function orgContextTreeSnapshotRoutes(app: FastifyInstance): Promis
           humanAgentId: scope.humanAgentId,
           memberId: scope.memberId,
         },
-        { timing: timing.add },
+        { contextTreeBinding: binding, timing: timing.add },
       ),
     );
     const response = timing.timeSync("schema_parse", () => contextTreeSnapshotSchema.parse({ ...snapshot, usage, io }));

--- a/packages/server/src/services/context-tree-io.ts
+++ b/packages/server/src/services/context-tree-io.ts
@@ -44,9 +44,15 @@ export type ContextTreeIoViewer = {
   memberId: string;
 };
 
+type ContextTreeIoBinding = {
+  repo?: string | null;
+  branch?: string | null;
+};
+
 export type ContextTreeIoSummaryOptions = {
   timing?: TimingSink;
   backfillSessionEvents?: boolean;
+  contextTreeBinding?: ContextTreeIoBinding;
 };
 
 export type RecordContextTreeIoInput = {
@@ -348,7 +354,11 @@ export async function summarizeContextTreeIoSkippedEvents(
   options: ContextTreeIoSummaryOptions = {},
 ): Promise<ContextTreeIoSkipSummary> {
   const since = new Date(Date.now() - windowDays * 24 * 60 * 60 * 1000);
-  const binding = await getOrgContextTree(db, organizationId);
+  const binding =
+    options.contextTreeBinding ??
+    (await timeWithSink(options.timing, "io_skipped_binding", () => getOrgContextTree(db, organizationId), {
+      organizationId,
+    }));
   const bindingBranch = binding.branch ?? "main";
   const candidateAgents = await listContextTreeIoCandidateAgents(db, organizationId, options.timing, "io_skipped");
   const runtimeProviderByAgent = new Map(candidateAgents.map((agent) => [agent.agentId, agent.runtimeProvider]));
@@ -396,33 +406,40 @@ export async function summarizeContextTreeIoSkippedEvents(
     }
   >();
 
-  for (const row of rows) {
-    const parsed = sessionEventSchema.safeParse({ kind: row.kind, payload: row.payload });
-    const event = parsed.success ? parsed.data : null;
-    const decision = event
-      ? buildContextTreeIoDecision({
-          event,
-          runtimeProvider: runtimeProviderByAgent.get(row.agentId) ?? "unknown",
-          bindingRepo: binding.repo,
-          bindingBranch,
-          chatInOrg: row.chatOrganizationId === organizationId,
-        })
-      : ({ recordable: false, reason: "event_kind_not_io" } as const);
-    if (decision.recordable) continue;
+  await timeWithSink(
+    options.timing,
+    "io_skipped_decide",
+    async () => {
+      for (const row of rows) {
+        const parsed = sessionEventSchema.safeParse({ kind: row.kind, payload: row.payload });
+        const event = parsed.success ? parsed.data : null;
+        const decision = event
+          ? buildContextTreeIoDecision({
+              event,
+              runtimeProvider: runtimeProviderByAgent.get(row.agentId) ?? "unknown",
+              bindingRepo: binding.repo,
+              bindingBranch,
+              chatInOrg: row.chatOrganizationId === organizationId,
+            })
+          : ({ recordable: false, reason: "event_kind_not_io" } as const);
+        if (decision.recordable) continue;
 
-    const bucket = byReason.get(decision.reason) ?? {
-      eventCount: 0,
-      agentIds: new Set<string>(),
-      runtimeProviders: new Map<string, number>(),
-      toolNames: new Map<string, number>(),
-    };
-    bucket.eventCount += 1;
-    bucket.agentIds.add(row.agentId);
-    incrementCount(bucket.runtimeProviders, runtimeProviderByAgent.get(row.agentId) ?? "unknown");
-    const toolName = event ? toolNameOf(event) : null;
-    if (toolName) incrementCount(bucket.toolNames, toolName);
-    byReason.set(decision.reason, bucket);
-  }
+        const bucket = byReason.get(decision.reason) ?? {
+          eventCount: 0,
+          agentIds: new Set<string>(),
+          runtimeProviders: new Map<string, number>(),
+          toolNames: new Map<string, number>(),
+        };
+        bucket.eventCount += 1;
+        bucket.agentIds.add(row.agentId);
+        incrementCount(bucket.runtimeProviders, runtimeProviderByAgent.get(row.agentId) ?? "unknown");
+        const toolName = event ? toolNameOf(event) : null;
+        if (toolName) incrementCount(bucket.toolNames, toolName);
+        byReason.set(decision.reason, bucket);
+      }
+    },
+    { rowCount: rows.length },
+  );
 
   const reasons = [...byReason.entries()]
     .sort(


### PR DESCRIPTION
## Summary

Removes a repeated Context Tree binding read from the Context tab snapshot IO diagnostics path.

- Adds an optional `contextTreeBinding` to Context Tree IO summary options.
- Passes the snapshot route's already-loaded binding into `buildContextTreeIoSummary` for both org-scoped and legacy snapshot routes.
- Keeps standalone `summarizeContextTreeIo*` behavior unchanged: callers that do not pass a binding still read the org setting themselves.
- Adds `io_skipped_binding` / `io_skipped_decide` sub-timing so remaining `io_skipped` cost is attributable.
- Adds a regression test proving the aggregate path uses the supplied binding for skipped diagnostics.

## Why

After #1291 deployed to dev, fresh captures still showed `io_skipped` around 1.48-1.55s while `io_skipped_scan` was only ~0.74-0.80s and `io_skipped_rows=0`. The large gap points to non-scan work inside the `io_skipped` wrapper. The snapshot routes already load the org Context Tree binding before snapshot build, but skipped diagnostics loaded it again. This PR removes that duplicate read and adds sub-segment timing for the remaining decision loop.

## Validation

- `pnpm --filter @first-tree/server exec vitest run src/__tests__/context-tree-io.test.ts -t "reuses snapshot binding"` red before the fix, green after
- `pnpm --filter @first-tree/server exec vitest run src/__tests__/context-tree-io.test.ts`
- `pnpm --filter @first-tree/server exec vitest run src/__tests__/context-tree-snapshot-timing.test.ts src/__tests__/context-tree-snapshot.test.ts`
- `pnpm --filter @first-tree/server typecheck`
- `pnpm exec biome check packages/server/src/services/context-tree-io.ts packages/server/src/api/orgs/context-tree-snapshot.ts packages/server/src/api/context-tree-snapshot.ts packages/server/src/__tests__/context-tree-io.test.ts`
- `git diff --check`
