### PR TITLE
[fix] Time Context Tree skipped IO decisions synchronously

### DIFF
--- a/packages/server/src/services/context-tree-io.ts
+++ b/packages/server/src/services/context-tree-io.ts
@@ -26,7 +26,7 @@ import { chats } from "../db/schema/chats.js";
 import { contextTreeIoEvents } from "../db/schema/context-tree-io-events.js";
 import { sessionEvents } from "../db/schema/session-events.js";
 import { createLogger } from "../observability/index.js";
-import { type TimingSink, timeWithSink } from "../observability/timing.js";
+import { type TimingSink, timeSyncWithSink, timeWithSink } from "../observability/timing.js";
 import { getOrgContextTree } from "./org-settings.js";
 
 const CONTEXT_TREE_IO_FEED_LIMIT = 50;
@@ -406,10 +406,10 @@ export async function summarizeContextTreeIoSkippedEvents(
     }
   >();
 
-  await timeWithSink(
+  timeSyncWithSink(
     options.timing,
     "io_skipped_decide",
-    async () => {
+    () => {
       for (const row of rows) {
         const parsed = sessionEventSchema.safeParse({ kind: row.kind, payload: row.payload });
         const event = parsed.success ? parsed.data : null;


### PR DESCRIPTION
## Summary

Makes the `io_skipped_decide` timing segment synchronous.

- Uses `timeSyncWithSink` for the skipped-diagnostics decision loop.
- Keeps the actual skipped diagnostics classification and snapshot response contract unchanged.
- Leaves the async DB scan timing as-is.

## Why

After #1292 deployed to dev, the duplicate binding read disappeared, but `Server-Timing` showed `io_skipped_decide` still costing ~0.76-0.84s even when `io_skipped_rows=0`. The decision loop is synchronous CPU work over the already-loaded rows, so wrapping it in async timing adds an unnecessary await boundary and makes the segment vulnerable to event-loop scheduling delay. This keeps the timing primitive aligned with the code being measured.

## Validation

- `pnpm --filter @first-tree/server exec vitest run src/__tests__/context-tree-io.test.ts`
- `pnpm --filter @first-tree/server typecheck`
- `pnpm exec biome check packages/server/src/services/context-tree-io.ts`
- `git diff --check`
