### PR TITLE
[fix] Filter Context Tree skipped IO candidates

### DIFF
--- a/packages/server/src/__tests__/context-tree-io.test.ts
+++ b/packages/server/src/__tests__/context-tree-io.test.ts
@@ -3,6 +3,7 @@ import { eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 import { chats } from "../db/schema/chats.js";
 import { contextTreeIoEvents } from "../db/schema/context-tree-io-events.js";
+import { sessionEvents } from "../db/schema/session-events.js";
 import {
   buildContextTreeIoSummary,
   explainContextTreeIoDecision,
@@ -744,6 +745,74 @@ describe("context-tree IO service", () => {
     const agentRows = timings.find((timing) => timing.name === "io_skipped_agents_rows")?.fields;
     expect(agentRows).toBeDefined();
     expect(Number(agentRows?.agentCount)).toBeGreaterThanOrEqual(1);
+  });
+
+  it("filters unrelated tool calls out of skipped diagnostics candidates", async () => {
+    const app = getApp();
+    const seed = await seedContextTreeChat();
+    const timings: Array<{ name: string; fields?: Record<string, unknown> }> = [];
+
+    await appendEvent(app.db, seed.agent.uuid, seed.chatId, {
+      kind: "tool_call",
+      payload: {
+        toolUseId: "tu-unrelated",
+        name: "TodoWrite",
+        args: {},
+        status: "ok",
+      },
+    });
+    await appendEvent(app.db, seed.agent.uuid, seed.chatId, {
+      kind: "tool_call",
+      payload: {
+        toolUseId: "tu-candidate",
+        name: "Bash",
+        args: { command: "cat /tmp/context-tree/NODE.md" },
+        status: "ok",
+      },
+    });
+
+    const skipped = await summarizeContextTreeIoSkippedEvents(app.db, seed.organizationId, 7, {
+      timing: (name, _ms, fields) => timings.push({ name, fields }),
+    });
+
+    expect(skipped.totalEventCount).toBe(1);
+    expect(skipped.reasons).toEqual([
+      {
+        reason: "no_tool_file_refs",
+        eventCount: 1,
+        agentCount: 1,
+        runtimeProviders: [{ runtimeProvider: "claude-code", eventCount: 1 }],
+        toolNames: [{ toolName: "Bash", eventCount: 1 }],
+      },
+    ]);
+    expect(timings.find((timing) => timing.name === "io_skipped_rows")?.fields).toMatchObject({ rowCount: 1 });
+  });
+
+  it("ignores malformed toolFileRefs while filtering skipped diagnostics candidates", async () => {
+    const app = getApp();
+    const seed = await seedContextTreeChat();
+
+    await app.db.insert(sessionEvents).values({
+      id: `ev-${crypto.randomUUID()}`,
+      agentId: seed.agent.uuid,
+      chatId: seed.chatId,
+      seq: 1,
+      kind: "tool_call",
+      payload: {
+        toolUseId: "tu-malformed-refs",
+        name: "TodoWrite",
+        args: {},
+        status: "ok",
+        toolFileRefs: { repoUrl: TREE_REPO, repoRelativePath: "NODE.md" },
+      },
+      createdAt: new Date(),
+    });
+
+    await expect(summarizeContextTreeIoSkippedEvents(app.db, seed.organizationId, 7)).resolves.toEqual({
+      windowDays: 7,
+      totalEventCount: 0,
+      reasons: [],
+    });
   });
 
   it("records git status delta refs as synthetic writes for unsupported shell commands", async () => {

--- a/packages/server/src/services/context-tree-io.ts
+++ b/packages/server/src/services/context-tree-io.ts
@@ -35,6 +35,19 @@ const CONTEXT_TREE_IO_FEED_LIMIT = 50;
 // per matched file (see the client's TREE_SEARCH_TOOL_NAMES).
 const CLAUDE_READ_TOOLS = new Set(["Read", "NotebookRead", "Grep", "Glob"]);
 const CLAUDE_WRITE_TOOLS = new Set(["Write", "Edit", "MultiEdit", "NotebookEdit"]);
+const CONTEXT_TREE_IO_TOOL_NAMES = [
+  "Bash",
+  "Edit",
+  "Glob",
+  "Grep",
+  "MultiEdit",
+  "NotebookEdit",
+  "NotebookRead",
+  "Read",
+  "Write",
+  "command",
+  "file_change",
+];
 const log = createLogger("ContextTreeIo");
 const GIT_STATUS_DELTA_REF_ORIGIN = "git_status_delta";
 const GIT_STATUS_DELTA_DERIVATION: EventIoDerivation = { action: "write", source: "git_status_delta" };
@@ -385,7 +398,21 @@ export async function summarizeContextTreeIoSkippedEvents(
             candidateAgents.map((agent) => agent.agentId),
           ),
           gte(sessionEvents.createdAt, since),
-          or(eq(sessionEvents.kind, "context_tree_usage"), eq(sessionEvents.kind, "tool_call")),
+          or(
+            eq(sessionEvents.kind, "context_tree_usage"),
+            and(
+              eq(sessionEvents.kind, "tool_call"),
+              sql`${sessionEvents.payload}->>'status' = 'ok'`,
+              or(
+                inArray(sql<string>`${sessionEvents.payload}->>'name'`, CONTEXT_TREE_IO_TOOL_NAMES),
+                sql`CASE
+                  WHEN jsonb_typeof(${sessionEvents.payload}->'toolFileRefs') = 'array'
+                  THEN jsonb_array_length(${sessionEvents.payload}->'toolFileRefs')
+                  ELSE 0
+                END > 0`,
+              ),
+            ),
+          ),
           sql`NOT EXISTS (
             SELECT 1
             FROM context_tree_io_events existing


### PR DESCRIPTION
## Summary

Reduces the number of rows pulled into Context Tree skipped-diagnostics classification.

- Keeps `context_tree_usage` rows in the skipped diagnostics scan.
- For `tool_call` rows, requires `status=ok` and either a known Context Tree IO-capable tool name or attached `toolFileRefs`.
- Preserves existing skipped reason classification for relevant candidates, including `Read`/`Bash` no-ref cases and unknown tools that do attach refs.
- Adds a regression test proving unrelated tool calls do not enter the skipped diagnostics candidate set.

## Why

After #1293 deployed to dev, `Server-Timing` showed `io_skipped_scan` around ~0.69-0.81s and `io_skipped_decide` around ~0.79-0.82s. The `io_skipped_rows` Server-Timing entry is only a 0ms marker; the real row count lives in structured log fields. The remaining cost indicates the skipped scan is returning many ordinary tool calls that then get parsed/classified in JS.

This PR keeps the Context tab `io.skipped` contract intact while excluding obvious non-Context-Tree tool-call noise at SQL time.

## Validation

- `pnpm --filter @first-tree/server exec vitest run src/__tests__/context-tree-io.test.ts -t "filters unrelated tool calls"` red before the fix, green after
- `pnpm --filter @first-tree/server exec vitest run src/__tests__/context-tree-io.test.ts`
- `pnpm --filter @first-tree/server typecheck`
- `pnpm exec biome check packages/server/src/services/context-tree-io.ts packages/server/src/__tests__/context-tree-io.test.ts`
- `git diff --check`
