### PR TITLE
fix(web): clarify what the "Processed" token figure means

### DIFF
--- a/packages/web/src/lib/__tests__/token-usage.test.ts
+++ b/packages/web/src/lib/__tests__/token-usage.test.ts
@@ -8,7 +8,13 @@ describe("token usage helpers", () => {
     expect(activeTokenCount(usage)).toBe(150);
     expect(processedTokenCount(usage)).toBe(400);
     expect(formatTokenUsageTitle(usage, { turns: 2 })).toBe(
-      "Processed 400 · Active 150 · Input 100 · Cached 250 · Output 50 · 2 usage events",
+      "Processed 400 = Input 100 + Cached 250 + Output 50 · Active 150 (input + output, excludes cached) · 2 usage events",
+    );
+  });
+
+  it("defines processed as an equation even without a turn count", () => {
+    expect(formatTokenUsageTitle({ inputTokens: 100, cachedInputTokens: 250, outputTokens: 50 })).toBe(
+      "Processed 400 = Input 100 + Cached 250 + Output 50 · Active 150 (input + output, excludes cached)",
     );
   });
 

--- a/packages/web/src/lib/token-usage.ts
+++ b/packages/web/src/lib/token-usage.ts
@@ -16,15 +16,31 @@ export function processedTokenCount(usage: TokenUsageParts): number {
   return activeTokenCount(usage) + tokenPart(usage.cachedInputTokens);
 }
 
+/**
+ * Plain-language definition of the "Processed" figure, for a `title`/tooltip
+ * anywhere a bare `Processed N` label is shown without its breakdown (e.g. the
+ * Usage tab column header / stat tiles). Users reported "processed" was opaque:
+ * it counts cache-read tokens, which routinely dwarf the non-cached input, so
+ * the number looks inflated next to a provider bill. Spell out what it is — and
+ * what it is NOT — at every surface.
+ */
+export const PROCESSED_TOKENS_HINT =
+  "Processed = input + cached + output: every token the model read or wrote, including cache reads. Not a billing figure (cache reads bill far cheaper).";
+
+/**
+ * Tooltip for a usage figure. Written as an explicit equation so the meaning of
+ * "Processed" is legible on hover rather than left as jargon:
+ *   `Processed 400 = Input 100 + Cached 250 + Output 50 · Active 150 (input + output, excludes cached) · 2 usage events`
+ */
 export function formatTokenUsageTitle(usage: TokenUsageParts, opts: { turns?: number } = {}): string {
+  const input = tokenPart(usage.inputTokens);
+  const cached = tokenPart(usage.cachedInputTokens);
+  const output = tokenPart(usage.outputTokens);
   const activeTokens = activeTokenCount(usage);
   const processedTokens = processedTokenCount(usage);
   const parts = [
-    `Processed ${processedTokens.toLocaleString()}`,
-    `Active ${activeTokens.toLocaleString()}`,
-    `Input ${tokenPart(usage.inputTokens).toLocaleString()}`,
-    `Cached ${tokenPart(usage.cachedInputTokens).toLocaleString()}`,
-    `Output ${tokenPart(usage.outputTokens).toLocaleString()}`,
+    `Processed ${processedTokens.toLocaleString()} = Input ${input.toLocaleString()} + Cached ${cached.toLocaleString()} + Output ${output.toLocaleString()}`,
+    `Active ${activeTokens.toLocaleString()} (input + output, excludes cached)`,
   ];
   if (opts.turns != null) parts.push(`${opts.turns.toLocaleString()} usage events`);
   return parts.join(" · ");

--- a/packages/web/src/pages/agent-detail/usage-tab.tsx
+++ b/packages/web/src/pages/agent-detail/usage-tab.tsx
@@ -4,7 +4,7 @@ import { type CSSProperties, type ReactElement, type ReactNode, useEffect, useMe
 import { getAgentUsageSummary, getAgentUsageTurns } from "../../api/usage.js";
 import { Button } from "../../components/ui/button.js";
 import { Section } from "../../components/ui/section.js";
-import { activeTokenCount, processedTokenCount } from "../../lib/token-usage.js";
+import { activeTokenCount, PROCESSED_TOKENS_HINT, processedTokenCount } from "../../lib/token-usage.js";
 import { formatCompactCount, formatRelative } from "../../lib/utils.js";
 import { useAgentDetailContext } from "./layout-context.js";
 
@@ -298,7 +298,12 @@ function ActivityStatsPanel({
           </>
         }
       />
-      <StatTile label="Avg processed / day" value={formatCompactCount(stats.avgPerDay)} mono />
+      <StatTile
+        label="Avg processed / day"
+        value={formatCompactCount(stats.avgPerDay)}
+        mono
+        title={PROCESSED_TOKENS_HINT}
+      />
       <StatTile label="Peak day" value={peakLabel} mono />
       <StatTile
         label="Current streak"
@@ -316,9 +321,19 @@ function ActivityStatsPanel({
   );
 }
 
-function StatTile({ label, value, mono }: { label: string; value: ReactNode; mono?: boolean }): ReactElement {
+function StatTile({
+  label,
+  value,
+  mono,
+  title,
+}: {
+  label: string;
+  value: ReactNode;
+  mono?: boolean;
+  title?: string;
+}): ReactElement {
   return (
-    <div className="usage-stats-tile">
+    <div className="usage-stats-tile" title={title}>
       <div className="usage-stats-tile-label text-caption">{label}</div>
       <div className={`usage-stats-tile-value text-subtitle${mono ? " mono" : ""}`}>{value}</div>
     </div>
@@ -401,7 +416,9 @@ function TurnsTable({
             <th style={thStyle("right")}>Input</th>
             <th style={thStyle("right")}>Cached</th>
             <th style={thStyle("right")}>Output</th>
-            <th style={{ ...thStyle("left"), width: "var(--sp-20)" }}>Processed</th>
+            <th style={{ ...thStyle("left"), width: "var(--sp-20)" }} title={PROCESSED_TOKENS_HINT}>
+              Processed
+            </th>
           </tr>
         </thead>
         <tbody>


### PR DESCRIPTION
## Why
A user reported the token-usage number was a "calculation error". After a joint audit with yzw-codex, the arithmetic is correct — `processedTokenCount = input + cached + output`, with input and cached disjoint (no double-count). The real problem is **`Processed` is opaque**: it counts cache-read tokens, which routinely dwarf the non-cached input, so the figure looks inflated next to a provider bill.

## What
Make the meaning legible at every surface **without changing any number**:

- `formatTokenUsageTitle` (shared hover tooltip — used by the chat composer marker *and* the Team usage column) now reads as an explicit equation:
  `Processed 400 = Input 100 + Cached 250 + Output 50 · Active 150 (input + output, excludes cached) · 2 usage events`
- New `PROCESSED_TOKENS_HINT` plain-language definition, applied as a `title` on the Usage tab's **Processed** column header and the **Avg processed / day** stat tile (the spots that show a bare label with no breakdown).

No schema / wire / calculation changes. Cache-vs-active semantics unchanged.

## Test
- `pnpm --filter @first-tree/web exec vitest run` → 1016 passed (updated `token-usage.test.ts` for the new equation string).
- `pnpm --filter @first-tree/web typecheck` + biome clean.

## Notes / follow-ups (from the joint audit, not in this PR)
- Separate **real** display-count bug: in Claude fast-mode a single turn emits multiple `token_usage` events (one per model), so the `turns` count / "Recent turns" list overcount (token totals unaffected). Fix is a relabel `turns → usage events`; tracked separately pending product call on whether true logical-turn counts are wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)