### PR TITLE
[fix] Fast-path skipped Context Tree IO decisions

### DIFF
--- a/packages/server/src/__tests__/context-tree-io.test.ts
+++ b/packages/server/src/__tests__/context-tree-io.test.ts
@@ -788,6 +788,87 @@ describe("context-tree IO service", () => {
     expect(timings.find((timing) => timing.name === "io_skipped_rows")?.fields).toMatchObject({ rowCount: 1 });
   });
 
+  it("fast-paths skipped diagnostics decisions for no-ref candidates", async () => {
+    const app = getApp();
+    const seed = await seedContextTreeChat();
+    const timings: Array<{ name: string; fields?: Record<string, unknown> }> = [];
+
+    await appendEvent(app.db, seed.agent.uuid, seed.chatId, {
+      kind: "tool_call",
+      payload: {
+        toolUseId: "tu-read-no-refs",
+        name: "Read",
+        args: {},
+        status: "ok",
+      },
+    });
+    await appendEvent(app.db, seed.agent.uuid, seed.chatId, {
+      kind: "tool_call",
+      payload: {
+        toolUseId: "tu-shell-read-no-refs",
+        name: "Bash",
+        args: { command: "cat /tmp/context-tree/NODE.md" },
+        status: "ok",
+      },
+    });
+    await appendEvent(app.db, seed.agent.uuid, seed.chatId, {
+      kind: "tool_call",
+      payload: {
+        toolUseId: "tu-shell-write-no-refs",
+        name: "Bash",
+        args: { command: "echo x > /tmp/context-tree/NODE.md" },
+        status: "ok",
+      },
+    });
+
+    const skipped = await summarizeContextTreeIoSkippedEvents(app.db, seed.organizationId, 7, {
+      timing: (name, _ms, fields) => timings.push({ name, fields }),
+    });
+
+    expect(skipped.totalEventCount).toBe(3);
+    expect(skipped.reasons.map((row) => ({ reason: row.reason, eventCount: row.eventCount }))).toEqual([
+      { reason: "no_tool_file_refs", eventCount: 2 },
+      { reason: "unsupported_shell_command", eventCount: 1 },
+    ]);
+    expect(timings.find((timing) => timing.name === "io_skipped_decide_fast_rows")?.fields).toMatchObject({
+      rowCount: 3,
+    });
+    expect(timings.find((timing) => timing.name === "io_skipped_decide_slow_rows")?.fields).toMatchObject({
+      rowCount: 0,
+    });
+  });
+
+  it("keeps no-binding skipped diagnostics off the no-ref fast path", async () => {
+    const app = getApp();
+    const seed = await createTestAgent(app);
+    const chatId = `chat-${crypto.randomUUID()}`;
+    const timings: Array<{ name: string; fields?: Record<string, unknown> }> = [];
+    await app.db.insert(chats).values({ id: chatId, organizationId: seed.organizationId, type: "direct", topic: "io" });
+    await appendEvent(app.db, seed.agent.uuid, chatId, {
+      kind: "tool_call",
+      payload: {
+        toolUseId: "tu-read-no-binding",
+        name: "Read",
+        args: {},
+        status: "ok",
+      },
+    });
+
+    const skipped = await summarizeContextTreeIoSkippedEvents(app.db, seed.organizationId, 7, {
+      timing: (name, _ms, fields) => timings.push({ name, fields }),
+    });
+
+    expect(skipped.reasons.map((row) => ({ reason: row.reason, eventCount: row.eventCount }))).toEqual([
+      { reason: "no_org_context_tree_binding", eventCount: 1 },
+    ]);
+    expect(timings.find((timing) => timing.name === "io_skipped_decide_fast_rows")?.fields).toMatchObject({
+      rowCount: 0,
+    });
+    expect(timings.find((timing) => timing.name === "io_skipped_decide_slow_rows")?.fields).toMatchObject({
+      rowCount: 1,
+    });
+  });
+
   it("ignores malformed toolFileRefs while filtering skipped diagnostics candidates", async () => {
     const app = getApp();
     const seed = await seedContextTreeChat();

--- a/packages/server/src/services/context-tree-io.ts
+++ b/packages/server/src/services/context-tree-io.ts
@@ -141,6 +141,16 @@ type InternalContextTreeIoDecision =
       reason: ContextTreeIoSkipReason;
     };
 
+type SkippedDecisionFastPath =
+  | {
+      handled: true;
+      decision: ContextTreeIoDecision;
+      toolName: string | null;
+    }
+  | {
+      handled: false;
+    };
+
 function normalizeTargetPath(rawPath: string, targetKind: ContextTreeIoTargetKind): string | null {
   const trimmed = rawPath.trim().replaceAll("\\", "/");
   if (trimmed.length === 0 || trimmed.includes("\0")) return null;
@@ -176,6 +186,49 @@ function isShellTool(runtimeProvider: string, toolName: string): boolean {
   return (
     (runtimeProvider === "codex" && toolName === "command") || (isClaudeRuntime(runtimeProvider) && toolName === "Bash")
   );
+}
+
+function recordFromUnknown(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : null;
+}
+
+function skippedDecisionFastPathForNoRefs(
+  kind: string,
+  payload: unknown,
+  runtimeProvider: string,
+  bindingRepo: string | null | undefined,
+): SkippedDecisionFastPath {
+  if (!bindingRepo) return { handled: false };
+  if (kind !== "tool_call") return { handled: false };
+
+  const record = recordFromUnknown(payload);
+  if (!record) return { handled: false };
+  const toolName = typeof record.name === "string" ? record.name : null;
+  if (typeof record.toolUseId !== "string" || !toolName) return { handled: false };
+  if (record.status !== "ok") {
+    return { handled: true, decision: { recordable: false, reason: "status_not_ok" }, toolName };
+  }
+  if ("toolFileRefs" in record) {
+    if (!Array.isArray(record.toolFileRefs)) return { handled: false };
+    if (record.toolFileRefs.length > 0) return { handled: false };
+  }
+
+  if (runtimeProvider === "codex" && toolName === "file_change") {
+    return { handled: true, decision: { recordable: false, reason: "no_tool_file_refs" }, toolName };
+  }
+  if (isClaudeRuntime(runtimeProvider) && (CLAUDE_READ_TOOLS.has(toolName) || CLAUDE_WRITE_TOOLS.has(toolName))) {
+    return { handled: true, decision: { recordable: false, reason: "no_tool_file_refs" }, toolName };
+  }
+  if (isShellTool(runtimeProvider, toolName)) {
+    const args = recordFromUnknown(record.args);
+    const command = typeof args?.command === "string" ? args.command : null;
+    const classification = command ? classifyShellCommandIo(command) : null;
+    const reason =
+      classification?.supported && classification.action === "read" ? "no_tool_file_refs" : "unsupported_shell_command";
+    return { handled: true, decision: { recordable: false, reason }, toolName };
+  }
+
+  return { handled: true, decision: { recordable: false, reason: "unsupported_tool" }, toolName };
 }
 
 function deriveEventIo(event: SessionEvent, runtimeProvider: string): EventIoDerivation | ContextTreeIoSkipReason {
@@ -433,40 +486,59 @@ export async function summarizeContextTreeIoSkippedEvents(
     }
   >();
 
+  const recordSkippedDecision = (
+    decision: ContextTreeIoDecision,
+    row: (typeof rows)[number],
+    toolName: string | null,
+  ): void => {
+    if (decision.recordable) return;
+
+    const bucket = byReason.get(decision.reason) ?? {
+      eventCount: 0,
+      agentIds: new Set<string>(),
+      runtimeProviders: new Map<string, number>(),
+      toolNames: new Map<string, number>(),
+    };
+    bucket.eventCount += 1;
+    bucket.agentIds.add(row.agentId);
+    incrementCount(bucket.runtimeProviders, runtimeProviderByAgent.get(row.agentId) ?? "unknown");
+    if (toolName) incrementCount(bucket.toolNames, toolName);
+    byReason.set(decision.reason, bucket);
+  };
+
+  let fastPathRows = 0;
+  let slowPathRows = 0;
   timeSyncWithSink(
     options.timing,
     "io_skipped_decide",
     () => {
       for (const row of rows) {
+        const runtimeProvider = runtimeProviderByAgent.get(row.agentId) ?? "unknown";
+        const fastPath = skippedDecisionFastPathForNoRefs(row.kind, row.payload, runtimeProvider, binding.repo);
+        if (fastPath.handled) {
+          fastPathRows += 1;
+          recordSkippedDecision(fastPath.decision, row, fastPath.toolName);
+          continue;
+        }
+        slowPathRows += 1;
         const parsed = sessionEventSchema.safeParse({ kind: row.kind, payload: row.payload });
         const event = parsed.success ? parsed.data : null;
         const decision = event
           ? buildContextTreeIoDecision({
               event,
-              runtimeProvider: runtimeProviderByAgent.get(row.agentId) ?? "unknown",
+              runtimeProvider,
               bindingRepo: binding.repo,
               bindingBranch,
               chatInOrg: row.chatOrganizationId === organizationId,
             })
           : ({ recordable: false, reason: "event_kind_not_io" } as const);
-        if (decision.recordable) continue;
-
-        const bucket = byReason.get(decision.reason) ?? {
-          eventCount: 0,
-          agentIds: new Set<string>(),
-          runtimeProviders: new Map<string, number>(),
-          toolNames: new Map<string, number>(),
-        };
-        bucket.eventCount += 1;
-        bucket.agentIds.add(row.agentId);
-        incrementCount(bucket.runtimeProviders, runtimeProviderByAgent.get(row.agentId) ?? "unknown");
-        const toolName = event ? toolNameOf(event) : null;
-        if (toolName) incrementCount(bucket.toolNames, toolName);
-        byReason.set(decision.reason, bucket);
+        recordSkippedDecision(decision, row, event ? toolNameOf(event) : null);
       }
     },
     { rowCount: rows.length },
   );
+  options.timing?.("io_skipped_decide_fast_rows", 0, { rowCount: fastPathRows });
+  options.timing?.("io_skipped_decide_slow_rows", 0, { rowCount: slowPathRows });
 
   const reasons = [...byReason.entries()]
     .sort(


### PR DESCRIPTION
## Summary

Reduces CPU work in the remaining Context Tree `io.skipped` diagnostics decision loop.

- Adds a no-ref fast path for valid tool-call candidates that cannot become recorded IO because they have no `toolFileRefs`.
- Keeps rows with refs, malformed refs, legacy `context_tree_usage`, and other non-fast-path cases on the existing schema validation and normalization path.
- Preserves existing skip-reason semantics for Claude/Codex read/write tools and shell commands.
- Adds `io_skipped_decide_fast_rows` / `io_skipped_decide_slow_rows` timing markers so dev captures can show whether the hot path is actually using the fast path.
- Adds regression coverage for no-ref Read, shell read, and shell write candidates.

## Why

After #1294 landed and deployed to dev, fresh captures from `https://dev.cloud.first-tree.ai/context` showed the SQL candidate filter helped:

- cached snapshot wall time is now roughly ~2.0-2.2s
- `io_skipped_scan` dropped to ~522-671ms
- `io_skipped_decide` still stays around ~720-740ms

The remaining cost is in the per-row decision loop. A large class of candidates has no file refs; those rows can only produce skipped diagnostics and do not need full event schema validation plus ref normalization.

## Validation

- `pnpm --filter @first-tree/server exec vitest run src/__tests__/context-tree-io.test.ts -t "fast-paths skipped diagnostics"`
- `pnpm --filter @first-tree/server exec vitest run src/__tests__/context-tree-io.test.ts`
- `pnpm --filter @first-tree/server exec vitest run src/__tests__/context-tree-snapshot-timing.test.ts src/__tests__/context-tree-snapshot.test.ts`
- `pnpm --filter @first-tree/server typecheck`
- `pnpm exec biome check packages/server/src/services/context-tree-io.ts packages/server/src/__tests__/context-tree-io.test.ts`
- `git diff --check`
