### PR TITLE
[codex] Slim onboarding bootstrap copy and set chat titles

### DIFF
--- a/packages/server/src/__tests__/me-onboarding-kickoff.test.ts
+++ b/packages/server/src/__tests__/me-onboarding-kickoff.test.ts
@@ -64,6 +64,7 @@ describe("POST /me/onboarding/kickoff", () => {
     // Chat carries the kind-scoped kickoff key.
     const [chat] = await app.db.select().from(chats).where(eq(chats.id, chatId)).limit(1);
     expect(chat?.onboardingKickoffKey).toBe(`${admin.humanAgentUuid}:${agent.uuid}:tree`);
+    expect(chat?.topic).toBe("Team memory setup");
 
     // Bootstrap message landed.
     const msgs = await app.db.select().from(messages).where(eq(messages.chatId, chatId));
@@ -98,6 +99,7 @@ describe("POST /me/onboarding/kickoff", () => {
 
     const [chat] = await app.db.select().from(chats).where(eq(chats.id, chatId)).limit(1);
     expect(chat?.onboardingKickoffKey).toBe(`${admin.humanAgentUuid}:${agent.uuid}:work`);
+    expect(chat?.topic).toBe("First task");
 
     const [msg] = await app.db.select().from(messages).where(eq(messages.chatId, chatId)).limit(1);
     expect(msg?.senderId).toBe(admin.humanAgentUuid);
@@ -186,6 +188,7 @@ describe("POST /me/onboarding/kickoff", () => {
       payload,
     });
     const firstChatId = first.json<{ chatId: string }>().chatId;
+    await app.db.update(chats).set({ topic: "Custom kickoff title" }).where(eq(chats.id, firstChatId));
     const [firstMember] = await app.db.select().from(members).where(eq(members.id, admin.memberId)).limit(1);
     const firstStamp = firstMember?.onboardingCompletedAt;
 
@@ -207,6 +210,7 @@ describe("POST /me/onboarding/kickoff", () => {
       .from(chats)
       .where(eq(chats.onboardingKickoffKey, `${admin.humanAgentUuid}:${agent.uuid}:tree`));
     expect(kickoffChats).toHaveLength(1);
+    expect(kickoffChats[0]?.topic).toBe("Custom kickoff title");
 
     // No duplicate bootstrap.
     const msgs = await app.db.select().from(messages).where(eq(messages.chatId, firstChatId));
@@ -266,6 +270,8 @@ describe("POST /me/onboarding/kickoff", () => {
       payload: { ...base, bootstrap: "Meet your agent.", kind: "intro" },
     });
     const introChatId = intro.json<{ chatId: string }>().chatId;
+    const [introChat] = await app.db.select().from(chats).where(eq(chats.id, introChatId)).limit(1);
+    expect(introChat?.topic).toBe("Meet your agent");
 
     // 2) Later, /build-tree with the SAME agent → tree kickoff. Must be a NEW
     //    chat carrying the tree-seeding bootstrap, not the intro chat (regression
@@ -277,6 +283,8 @@ describe("POST /me/onboarding/kickoff", () => {
       payload: { ...base, bootstrap: "Seed the team tree.", kind: "tree" },
     });
     const treeChatId = tree.json<{ chatId: string }>().chatId;
+    const [treeChat] = await app.db.select().from(chats).where(eq(chats.id, treeChatId)).limit(1);
+    expect(treeChat?.topic).toBe("Team memory setup");
 
     expect(treeChatId).not.toBe(introChatId);
     const treeMsgs = await app.db.select().from(messages).where(eq(messages.chatId, treeChatId));

--- a/packages/server/src/__tests__/me-onboarding-kickoff.test.ts
+++ b/packages/server/src/__tests__/me-onboarding-kickoff.test.ts
@@ -99,7 +99,7 @@ describe("POST /me/onboarding/kickoff", () => {
 
     const [chat] = await app.db.select().from(chats).where(eq(chats.id, chatId)).limit(1);
     expect(chat?.onboardingKickoffKey).toBe(`${admin.humanAgentUuid}:${agent.uuid}:work`);
-    expect(chat?.topic).toBe("Choose your first task");
+    expect(chat?.topic).toBe("First task chat");
 
     const [msg] = await app.db.select().from(messages).where(eq(messages.chatId, chatId)).limit(1);
     expect(msg?.senderId).toBe(admin.humanAgentUuid);
@@ -271,7 +271,7 @@ describe("POST /me/onboarding/kickoff", () => {
     });
     const introChatId = intro.json<{ chatId: string }>().chatId;
     const [introChat] = await app.db.select().from(chats).where(eq(chats.id, introChatId)).limit(1);
-    expect(introChat?.topic).toBe("Meet your agent and share code");
+    expect(introChat?.topic).toBe("Meet your agent");
 
     // 2) Later, /build-tree with the SAME agent → tree kickoff. Must be a NEW
     //    chat carrying the tree-seeding bootstrap, not the intro chat (regression

--- a/packages/server/src/__tests__/me-onboarding-kickoff.test.ts
+++ b/packages/server/src/__tests__/me-onboarding-kickoff.test.ts
@@ -64,7 +64,7 @@ describe("POST /me/onboarding/kickoff", () => {
     // Chat carries the kind-scoped kickoff key.
     const [chat] = await app.db.select().from(chats).where(eq(chats.id, chatId)).limit(1);
     expect(chat?.onboardingKickoffKey).toBe(`${admin.humanAgentUuid}:${agent.uuid}:tree`);
-    expect(chat?.topic).toBe("Team memory setup");
+    expect(chat?.topic).toBe("Set up team context");
 
     // Bootstrap message landed.
     const msgs = await app.db.select().from(messages).where(eq(messages.chatId, chatId));
@@ -99,7 +99,7 @@ describe("POST /me/onboarding/kickoff", () => {
 
     const [chat] = await app.db.select().from(chats).where(eq(chats.id, chatId)).limit(1);
     expect(chat?.onboardingKickoffKey).toBe(`${admin.humanAgentUuid}:${agent.uuid}:work`);
-    expect(chat?.topic).toBe("First task");
+    expect(chat?.topic).toBe("Choose your first task");
 
     const [msg] = await app.db.select().from(messages).where(eq(messages.chatId, chatId)).limit(1);
     expect(msg?.senderId).toBe(admin.humanAgentUuid);
@@ -271,7 +271,7 @@ describe("POST /me/onboarding/kickoff", () => {
     });
     const introChatId = intro.json<{ chatId: string }>().chatId;
     const [introChat] = await app.db.select().from(chats).where(eq(chats.id, introChatId)).limit(1);
-    expect(introChat?.topic).toBe("Meet your agent");
+    expect(introChat?.topic).toBe("Meet your agent and share code");
 
     // 2) Later, /build-tree with the SAME agent → tree kickoff. Must be a NEW
     //    chat carrying the tree-seeding bootstrap, not the intro chat (regression
@@ -284,7 +284,7 @@ describe("POST /me/onboarding/kickoff", () => {
     });
     const treeChatId = tree.json<{ chatId: string }>().chatId;
     const [treeChat] = await app.db.select().from(chats).where(eq(chats.id, treeChatId)).limit(1);
-    expect(treeChat?.topic).toBe("Team memory setup");
+    expect(treeChat?.topic).toBe("Set up team context");
 
     expect(treeChatId).not.toBe(introChatId);
     const treeMsgs = await app.db.select().from(messages).where(eq(messages.chatId, treeChatId));

--- a/packages/server/src/services/onboarding-kickoff.ts
+++ b/packages/server/src/services/onboarding-kickoff.ts
@@ -36,6 +36,17 @@ export type KickoffOnboardingResult = {
   sent?: { recipients: string[]; messageId: string };
 };
 
+function topicForKickoffKind(kind: KickoffKind): string {
+  switch (kind) {
+    case "intro":
+      return "Meet your agent";
+    case "work":
+      return "First task";
+    case "tree":
+      return "Team memory setup";
+  }
+}
+
 /**
  * True only after a tree setup kickoff has a bootstrap message. A chat row by
  * itself is not enough: `kickoffOnboarding` creates the chat before sending the
@@ -90,6 +101,7 @@ export async function kickoffOnboarding(db: Database, args: KickoffOnboardingArg
       mode: "legacy-empty-agent",
       creatorAgentId: args.humanAgentId,
       participantAgentIds: [args.targetAgentId],
+      topic: topicForKickoffKind(args.kind),
       onboardingKickoffKey: kickoffKey,
     });
     chatId = created.id;

--- a/packages/server/src/services/onboarding-kickoff.ts
+++ b/packages/server/src/services/onboarding-kickoff.ts
@@ -39,9 +39,9 @@ export type KickoffOnboardingResult = {
 function topicForKickoffKind(kind: KickoffKind): string {
   switch (kind) {
     case "intro":
-      return "Meet your agent and share code";
+      return "Meet your agent";
     case "work":
-      return "Choose your first task";
+      return "First task chat";
     case "tree":
       return "Set up team context";
   }

--- a/packages/server/src/services/onboarding-kickoff.ts
+++ b/packages/server/src/services/onboarding-kickoff.ts
@@ -39,11 +39,11 @@ export type KickoffOnboardingResult = {
 function topicForKickoffKind(kind: KickoffKind): string {
   switch (kind) {
     case "intro":
-      return "Meet your agent";
+      return "Meet your agent and share code";
     case "work":
-      return "First task";
+      return "Choose your first task";
     case "tree":
-      return "Team memory setup";
+      return "Set up team context";
   }
 }
 

--- a/packages/web/src/pages/__tests__/context-page-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/context-page-dom.test.tsx
@@ -643,7 +643,7 @@ describe("ContextPage DOM behavior", () => {
     expect(onboardingEventMocks.kickoffOnboarding).toHaveBeenCalledWith(
       expect.objectContaining({
         agentUuid: "agent-1",
-        bootstrap: expect.stringContaining("First Tree Cloud found an existing org Context Tree binding"),
+        bootstrap: expect.stringContaining("This chat sets up team context for future agent work."),
         kind: "tree",
         complete: true,
       }),

--- a/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
+++ b/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
@@ -1832,7 +1832,7 @@ describe("web DOM interaction coverage", () => {
       expect.objectContaining({
         organizationId: "org-1",
         agentUuid: "agent-1",
-        bootstrap: expect.stringContaining("getting Nova up to speed"),
+        bootstrap: expect.stringContaining("This is your first task chat with Nova."),
         kind: "work",
         complete: true,
       }),
@@ -1846,7 +1846,7 @@ describe("web DOM interaction coverage", () => {
       expect.objectContaining({
         organizationId: "org-1",
         agentUuid: "agent-1",
-        bootstrap: expect.stringContaining("Read the bound Context Tree first"),
+        bootstrap: expect.stringContaining("This chat sets up team context for future agent work."),
         kind: "tree",
         complete: false,
       }),
@@ -1914,7 +1914,7 @@ describe("web DOM interaction coverage", () => {
     expect(onboardingEventMocks.kickoffOnboarding).toHaveBeenCalledWith(
       expect.objectContaining({
         agentUuid: "agent-1",
-        bootstrap: expect.stringContaining("welcoming Nova"),
+        bootstrap: expect.stringContaining("This is your first task chat with Nova."),
         kind: "work",
       }),
     );
@@ -1984,7 +1984,7 @@ describe("web DOM interaction coverage", () => {
     expect(onboardingEventMocks.kickoffOnboarding).toHaveBeenCalledWith(
       expect.objectContaining({
         agentUuid: "agent-1",
-        bootstrap: expect.stringContaining("Read the bound Context Tree first"),
+        bootstrap: expect.stringContaining("This chat sets up team context for future agent work."),
         kind: "tree",
         complete: true,
       }),

--- a/packages/web/src/pages/workspace/center/onboarding/__tests__/bootstrap-prose.test.ts
+++ b/packages/web/src/pages/workspace/center/onboarding/__tests__/bootstrap-prose.test.ts
@@ -7,18 +7,21 @@ import {
 } from "../bootstrap-prose.js";
 
 describe("kickoff bootstrap prose", () => {
-  it("builds a slim value-first kickoff that routes to welcome without repeating its checklist", () => {
+  it("builds a first-task kickoff that explains the chat before the operational note", () => {
     const message = buildValueFirstBootstrap(["https://github.com/acme/app"], {
       agentDisplayName: "Nova",
       treeSetup: "pending",
     });
 
-    expect(message).toContain("First Tree is getting Nova ready to help with https://github.com/acme/app");
-    expect(message).toContain("Use the first-tree-welcome skill");
+    expect(message).toContain("This is your first task chat with Nova.");
     expect(message).toContain("Connected code:");
     expect(message).toContain("https://github.com/acme/app");
-    expect(message).toContain("Start with useful work");
-    expect(message).toContain("shared memory");
+    expect(message).toContain("Nova will first read the available code and team context");
+    expect(message).toContain("then suggest a few small tasks you can start with");
+    expect(message).toContain("Operational note: use the first-tree-welcome skill");
+    expect(message).toContain("Keep team context setup in the separate setup chat");
+    expect(message).not.toContain("First Tree is getting");
+    expect(message).not.toContain("Start with useful work");
     expect(message).not.toContain("First response requirements:");
     expect(message).not.toContain("evidence-backed");
     expect(message).not.toContain("2–3");
@@ -32,11 +35,13 @@ describe("kickoff bootstrap prose", () => {
   it("builds a slim no-repo kickoff that asks for code without authorization-first setup", () => {
     const message = buildNoRepoBootstrap("Nova");
 
-    expect(message).toContain("First Tree is introducing Nova before code is connected");
-    expect(message).toContain("Use the first-tree-welcome skill");
+    expect(message).toContain("This is your first chat with Nova.");
+    expect(message).toContain("No code is connected yet.");
     expect(message).toContain("local folder path or a GitHub repo URL");
     expect(message).toContain("Keep setup light");
     expect(message).toContain("show value from real code first");
+    expect(message).toContain("Operational note: use the first-tree-welcome skill");
+    expect(message).not.toContain("First Tree is introducing");
     expect(message).not.toContain("First response requirements:");
     expect(message).not.toContain("tracked request primitive");
     expect(message).not.toContain("chat ask");
@@ -50,14 +55,17 @@ describe("kickoff bootstrap prose", () => {
       treeUrl: "https://github.com/acme/context",
     });
 
-    expect(message).toContain("separate setup chat");
+    expect(message).toContain("This chat sets up team context for future agent work.");
     expect(message).toContain("Source code:");
     expect(message).toContain("- https://github.com/acme/app");
     expect(message).toContain("Context Tree: https://github.com/acme/context");
+    expect(message).toContain("This setup helps future agents understand the team's code, decisions, and conventions.");
+    expect(message).toContain("The first task chat stays separate.");
+    expect(message).toContain("Operational note: after reading the bound tree");
     expect(message).toContain("first-tree-seed");
     expect(message).toContain("first-tree-read");
     expect(message).toContain("first-tree-write");
-    expect(message).toContain("the user's first work chat is separate");
+    expect(message).not.toContain("First Tree opened");
     expect(message).not.toContain("First response requirements:");
     expect(message).not.toContain("Do not impersonate");
     expect(message).not.toContain("first-tree-context");
@@ -87,10 +95,14 @@ describe("kickoff bootstrap prose", () => {
   it("builds a slim value-first joining-teammate invitee message", () => {
     const message = buildInviteeReadyBootstrap("Nova", "https://github.com/acme/context");
 
-    expect(message).toContain("First Tree is getting Nova ready for this team");
-    expect(message).toContain("Use the first-tree-welcome skill");
+    expect(message).toContain("This is your first task chat with Nova.");
     expect(message).toContain("Team context: https://github.com/acme/context");
-    expect(message).toContain("Start with useful work");
+    expect(message).toContain("Nova will use the team's code and context");
+    expect(message).toContain("suggest a few small tasks you can start with");
+    expect(message).toContain("Operational note: use the first-tree-welcome skill");
+    expect(message).toContain("Do not make team context setup the invitee's first task");
+    expect(message).not.toContain("First Tree is getting");
+    expect(message).not.toContain("Start with useful work");
     expect(message).not.toContain("First response requirements:");
     expect(message).not.toContain("2–3");
     expect(message).not.toContain("tracked request primitive");

--- a/packages/web/src/pages/workspace/center/onboarding/__tests__/bootstrap-prose.test.ts
+++ b/packages/web/src/pages/workspace/center/onboarding/__tests__/bootstrap-prose.test.ts
@@ -4,64 +4,67 @@ import {
   buildNoRepoBootstrap,
   buildTreeSetupBootstrap,
   buildValueFirstBootstrap,
-  FIRST_TREE_REFERENCE_URL,
 } from "../bootstrap-prose.js";
 
 describe("kickoff bootstrap prose", () => {
-  it("builds a value-first kickoff that asks for evidence-backed task options before tree work", () => {
+  it("builds a slim value-first kickoff that routes to welcome without repeating its checklist", () => {
     const message = buildValueFirstBootstrap(["https://github.com/acme/app"], {
       agentDisplayName: "Nova",
       treeSetup: "pending",
     });
 
-    expect(message).toContain("First Tree is getting Nova up to speed on https://github.com/acme/app");
+    expect(message).toContain("First Tree is getting Nova ready to help with https://github.com/acme/app");
     expect(message).toContain("Use the first-tree-welcome skill");
-    expect(message).toContain("evidence-backed");
-    expect(message).toContain("2–3");
-    expect(message).toContain("tracked request primitive");
-    expect(message).toContain("chat ask");
+    expect(message).toContain("Connected code:");
+    expect(message).toContain("https://github.com/acme/app");
+    expect(message).toContain("Start with useful work");
+    expect(message).toContain("shared memory");
+    expect(message).not.toContain("First response requirements:");
+    expect(message).not.toContain("evidence-backed");
+    expect(message).not.toContain("2–3");
+    expect(message).not.toContain("tracked request primitive");
+    expect(message).not.toContain("chat ask");
     expect(message).not.toContain("Skip for now");
-    expect(message).toContain("free-text accepted");
-    expect(message).toContain("separate Context Tree setup chat");
     expect(message).not.toContain("My team's Context Tree");
     expect(message).not.toContain("Build tree");
   });
 
-  it("builds a no-repo kickoff that asks for local code before authorization", () => {
+  it("builds a slim no-repo kickoff that asks for code without authorization-first setup", () => {
     const message = buildNoRepoBootstrap("Nova");
 
-    expect(message).toContain("First Tree is introducing Nova before a repo is connected");
+    expect(message).toContain("First Tree is introducing Nova before code is connected");
     expect(message).toContain("Use the first-tree-welcome skill");
-    expect(message).toContain("local clone path or a GitHub URL");
-    expect(message).toContain("before any long-term team setup");
-    expect(message).toContain("tracked request primitive");
-    expect(message).toContain("chat ask");
+    expect(message).toContain("local folder path or a GitHub repo URL");
+    expect(message).toContain("Keep setup light");
+    expect(message).toContain("show value from real code first");
+    expect(message).not.toContain("First response requirements:");
+    expect(message).not.toContain("tracked request primitive");
+    expect(message).not.toContain("chat ask");
+    expect(message).not.toContain("2–3");
     expect(message).not.toContain("Skip for now");
-    expect(message).toContain("free-text");
-    expect(message).toContain("broad GitHub authorization before the user has seen repo-specific value");
   });
 
-  it("builds tree setup instructions that inspect a bound tree before choosing seed or write", () => {
+  it("builds slim tree setup instructions that inspect a bound tree before choosing seed or write", () => {
     const message = buildTreeSetupBootstrap(["https://github.com/acme/app"], {
       treeBindingPlan: "useBoundTree",
       treeUrl: "https://github.com/acme/context",
     });
 
-    expect(message).toContain("separate Context Tree setup chat");
-    expect(message).toContain("Source repo: https://github.com/acme/app");
-    expect(message).toContain("Bound Context Tree: https://github.com/acme/context");
-    expect(message).toContain("existing org Context Tree binding");
-    expect(message).toContain("Read the bound Context Tree first");
-    expect(message).toContain("If the tree is still empty");
+    expect(message).toContain("separate setup chat");
+    expect(message).toContain("Source code:");
+    expect(message).toContain("- https://github.com/acme/app");
+    expect(message).toContain("Context Tree: https://github.com/acme/context");
     expect(message).toContain("first-tree-seed");
     expect(message).toContain("first-tree-read");
     expect(message).toContain("first-tree-write");
+    expect(message).toContain("the user's first work chat is separate");
+    expect(message).not.toContain("First response requirements:");
+    expect(message).not.toContain("Do not impersonate");
     expect(message).not.toContain("first-tree-context");
     expect(message).not.toContain("bind the repo to that existing tree");
     expect(message).not.toContain("PR back to the source");
     expect(message).not.toContain("My source repo");
     expect(message).not.toContain("My team's Context Tree");
-    expect(message).toContain(FIRST_TREE_REFERENCE_URL);
   });
 
   it("builds plural create-binding tree setup instructions without a tree URL", () => {
@@ -70,11 +73,10 @@ describe("kickoff bootstrap prose", () => {
       treeUrl: null,
     });
 
-    expect(message).toContain("Source repos:");
+    expect(message).toContain("Source code:");
     expect(message).toContain("- https://github.com/acme/web");
     expect(message).toContain("- https://github.com/acme/api");
     expect(message).toContain("resolved by First Tree Cloud");
-    expect(message).toContain("created or adopted");
     expect(message).toContain("first-tree-seed");
     expect(message).not.toContain("Host the new tree");
     expect(message).not.toContain("record its URL");
@@ -82,18 +84,17 @@ describe("kickoff bootstrap prose", () => {
     expect(message).not.toContain("ask me which owner");
   });
 
-  it("builds a value-first joining-teammate invitee message", () => {
+  it("builds a slim value-first joining-teammate invitee message", () => {
     const message = buildInviteeReadyBootstrap("Nova", "https://github.com/acme/context");
 
-    expect(message).toContain("welcoming Nova");
+    expect(message).toContain("First Tree is getting Nova ready for this team");
     expect(message).toContain("Use the first-tree-welcome skill");
-    expect(message).toContain("Team Context Tree: https://github.com/acme/context");
-    expect(message).toContain("Read the team's Context Tree first");
-    expect(message).toContain("Briefly introduce");
-    expect(message).toContain("2–3");
-    expect(message).toContain("tracked request primitive");
-    expect(message).toContain("chat ask");
-    expect(message).toContain(FIRST_TREE_REFERENCE_URL);
+    expect(message).toContain("Team context: https://github.com/acme/context");
+    expect(message).toContain("Start with useful work");
+    expect(message).not.toContain("First response requirements:");
+    expect(message).not.toContain("2–3");
+    expect(message).not.toContain("tracked request primitive");
+    expect(message).not.toContain("chat ask");
     // A brand-new teammate is NOT asked to write to the tree or seed it, and the
     // admin's "my repos are now connected" voice must not leak in.
     expect(message).not.toContain("first-tree-seed");

--- a/packages/web/src/pages/workspace/center/onboarding/bootstrap-prose.ts
+++ b/packages/web/src/pages/workspace/center/onboarding/bootstrap-prose.ts
@@ -19,12 +19,6 @@ function formatSourceList(sourceUrls: readonly string[], heading: string): strin
   return [heading, ...sourceUrls.map((u) => `- ${u}`)];
 }
 
-function formatInlineScope(sourceUrls: readonly string[]): string {
-  if (sourceUrls.length === 0) return "your team's connected repos";
-  if (sourceUrls.length === 1) return sourceUrls[0] ?? "the connected repo";
-  return `${sourceUrls.length} connected repos`;
-}
-
 export function buildValueFirstBootstrap(
   sourceUrls: readonly string[],
   opts: {
@@ -35,29 +29,28 @@ export function buildValueFirstBootstrap(
   const sourceLines = sourceUrls.length > 0 ? ["", ...formatSourceList(sourceUrls, "Connected code:")] : [];
   const treeLine =
     opts.treeSetup === "pending"
-      ? "A separate setup chat will prepare the team's shared memory, so keep this chat focused on the user's first useful task."
+      ? "Operational note: use the first-tree-welcome skill for this onboarding first chat. Keep team context setup in the separate setup chat."
       : opts.treeSetup === "bound"
-        ? "Team context is available; keep this chat focused on the user's first useful task."
-        : "If the user shares code later, help them get value from it before asking about long-term team setup.";
+        ? "Operational note: use the first-tree-welcome skill for this onboarding first chat. Use team context when helpful, but keep this chat focused on the first task."
+        : "Operational note: use the first-tree-welcome skill for this onboarding first chat. If the user shares code later, help from that code before asking about long-term setup.";
 
   return [
-    `First Tree is getting ${opts.agentDisplayName} ready to help with ${formatInlineScope(sourceUrls)}.`,
-    "",
-    "Use the first-tree-welcome skill for this onboarding first chat.",
+    `This is your first task chat with ${opts.agentDisplayName}.`,
     ...sourceLines,
     "",
-    "Start with useful work: use the available code and team context to help the user choose a small first task.",
+    `${opts.agentDisplayName} will first read the available code and team context, then suggest a few small tasks you can start with.`,
+    "",
     treeLine,
   ].join("\n");
 }
 
 export function buildNoRepoBootstrap(agentDisplayName: string): string {
   return [
-    `First Tree is introducing ${agentDisplayName} before code is connected.`,
+    `This is your first chat with ${agentDisplayName}.`,
     "",
-    "Use the first-tree-welcome skill for this onboarding first chat.",
+    `No code is connected yet. Share a local folder path or a GitHub repo URL, and ${agentDisplayName} can start from there.`,
     "",
-    "Help the user start by sharing a local folder path or a GitHub repo URL. Keep setup light and show value from real code first.",
+    "Operational note: use the first-tree-welcome skill for this onboarding first chat. Keep setup light and show value from real code first.",
   ].join("\n");
 }
 
@@ -68,13 +61,15 @@ export function buildTreeSetupBootstrap(
   const sourceLines = formatSourceList(sourceUrls, "Source code:");
   const treeLine = `Context Tree: ${opts.treeUrl ?? "resolved by First Tree Cloud"}`;
   return [
-    "First Tree opened this separate setup chat to prepare the team's shared memory.",
+    "This chat sets up team context for future agent work.",
     "",
     treeLine,
     "",
     ...sourceLines,
     "",
-    "Use first-tree-read, first-tree-seed, or first-tree-write after reading the bound tree. Keep this chat focused on shared-memory setup; the user's first work chat is separate.",
+    "This setup helps future agents understand the team's code, decisions, and conventions. The first task chat stays separate.",
+    "",
+    "Operational note: after reading the bound tree, use first-tree-read, first-tree-seed, or first-tree-write as appropriate.",
   ].join("\n");
 }
 
@@ -85,12 +80,12 @@ export function buildTreeSetupBootstrap(
  */
 export function buildInviteeReadyBootstrap(agentDisplayName: string, treeUrl: string): string {
   return [
-    `First Tree is getting ${agentDisplayName} ready for this team.`,
-    "",
-    "Use the first-tree-welcome skill for this onboarding first chat.",
+    `This is your first task chat with ${agentDisplayName}.`,
     "",
     `Team context: ${treeUrl}`,
     "",
-    "Start with useful work: use the team's code and context to help the user choose a small first task.",
+    `${agentDisplayName} will use the team's code and context to suggest a few small tasks you can start with.`,
+    "",
+    "Operational note: use the first-tree-welcome skill for this onboarding first chat. Do not make team context setup the invitee's first task.",
   ].join("\n");
 }

--- a/packages/web/src/pages/workspace/center/onboarding/bootstrap-prose.ts
+++ b/packages/web/src/pages/workspace/center/onboarding/bootstrap-prose.ts
@@ -13,15 +13,10 @@
  * needs the same prompts, hoist these builders to `packages/shared`.
  */
 
-export const FIRST_TREE_REFERENCE_URL = "https://github.com/agent-team-foundation/first-tree";
-
 export type TreeSetupBootstrapPlan = "createBinding" | "useBoundTree";
 
-function formatSourceList(sourceUrls: readonly string[]): string[] {
-  if (sourceUrls.length === 1) {
-    return [`Source repo: ${sourceUrls[0]}`];
-  }
-  return ["Source repos:", ...sourceUrls.map((u) => `- ${u}`)];
+function formatSourceList(sourceUrls: readonly string[], heading: string): string[] {
+  return [heading, ...sourceUrls.map((u) => `- ${u}`)];
 }
 
 function formatInlineScope(sourceUrls: readonly string[]): string {
@@ -37,51 +32,32 @@ export function buildValueFirstBootstrap(
     treeSetup: "none" | "pending" | "bound";
   },
 ): string {
-  const sourceLines = sourceUrls.length > 0 ? ["", ...formatSourceList(sourceUrls)] : [];
+  const sourceLines = sourceUrls.length > 0 ? ["", ...formatSourceList(sourceUrls, "Connected code:")] : [];
   const treeLine =
     opts.treeSetup === "pending"
-      ? "A separate Context Tree setup chat will handle the heavier shared-memory bootstrap; mention it lightly, but do not make tree setup the user's first task."
+      ? "A separate setup chat will prepare the team's shared memory, so keep this chat focused on the user's first useful task."
       : opts.treeSetup === "bound"
-        ? "A separate Context Tree setup chat may refresh the team's shared memory; keep this chat focused on helping the user get useful work done."
-        : "If the user later points you at a repo, help them get immediate value before asking for any long-term team setup.";
+        ? "Team context is available; keep this chat focused on the user's first useful task."
+        : "If the user shares code later, help them get value from it before asking about long-term team setup.";
 
   return [
-    `First Tree is getting ${opts.agentDisplayName} up to speed on ${formatInlineScope(sourceUrls)}.`,
+    `First Tree is getting ${opts.agentDisplayName} ready to help with ${formatInlineScope(sourceUrls)}.`,
     "",
     "Use the first-tree-welcome skill for this onboarding first chat.",
-    "",
-    "Goal: read before speaking, show concrete understanding, then help the user complete one useful first task.",
     ...sourceLines,
     "",
-    "First response requirements:",
-    "- Cite specific evidence from the repo or team context: stack, entry points, modules, tests, TODOs, conventions, or a concrete risk you actually observed.",
-    "- Offer 2–3 evidence-backed first tasks that are small, low-risk, verifiable, and likely to produce user-visible value quickly.",
-    "- Ask with the host's tracked request primitive when available; in First Tree CLI use chat ask with concise real-task options and free-text accepted. Do not add a separate skip option because the Web ask footer already provides Skip.",
-    "- If evidence is thin, prefer read-only orientation tasks such as mapping the architecture or explaining the test strategy; do not invent bugs.",
-    `- ${treeLine}`,
-    "- Do not impersonate the user or say the user asked for this. First Tree sent this system kickoff.",
-    "",
-    `Reference: ${FIRST_TREE_REFERENCE_URL}`,
+    "Start with useful work: use the available code and team context to help the user choose a small first task.",
+    treeLine,
   ].join("\n");
 }
 
 export function buildNoRepoBootstrap(agentDisplayName: string): string {
   return [
-    `First Tree is introducing ${agentDisplayName} before a repo is connected.`,
+    `First Tree is introducing ${agentDisplayName} before code is connected.`,
     "",
     "Use the first-tree-welcome skill for this onboarding first chat.",
     "",
-    "Goal: be useful immediately, then invite the user to point you at real code without requiring GitHub authorization first.",
-    "",
-    "First response requirements:",
-    "- Introduce yourself briefly as the user's agent.",
-    "- Ask for either a local clone path or a GitHub URL so you can read the code on this machine.",
-    "- Make clear that reading a local clone or accessible URL can happen before any long-term team setup.",
-    "- If the user gives code, inspect it and then ask with the host's tracked request primitive when available; in First Tree CLI use chat ask with 2–3 evidence-backed, bounded first tasks and free-text accepted. Do not add a separate skip option because the Web ask footer already provides Skip.",
-    "- Only after showing value should you ask whether the repo should become long-term team code.",
-    "- Do not ask for broad GitHub authorization before the user has seen repo-specific value.",
-    "",
-    `Reference: ${FIRST_TREE_REFERENCE_URL}`,
+    "Help the user start by sharing a local folder path or a GitHub repo URL. Keep setup light and show value from real code first.",
   ].join("\n");
 }
 
@@ -89,31 +65,16 @@ export function buildTreeSetupBootstrap(
   sourceUrls: readonly string[],
   opts: { treeBindingPlan: TreeSetupBootstrapPlan; treeUrl: string | null },
 ): string {
-  const sourceLines = formatSourceList(sourceUrls);
-  const bindingLine = opts.treeUrl
-    ? `Bound Context Tree: ${opts.treeUrl}`
-    : "Bound Context Tree: resolved by First Tree Cloud";
-  const setupLine =
-    opts.treeBindingPlan === "createBinding"
-      ? "First Tree Cloud has created or adopted the team's Context Tree repo and recorded the org binding for this setup lane."
-      : "First Tree Cloud found an existing org Context Tree binding for this setup lane.";
+  const sourceLines = formatSourceList(sourceUrls, "Source code:");
+  const treeLine = `Context Tree: ${opts.treeUrl ?? "resolved by First Tree Cloud"}`;
   return [
-    "First Tree has connected the selected source repos and opened this separate Context Tree setup chat.",
+    "First Tree opened this separate setup chat to prepare the team's shared memory.",
+    "",
+    treeLine,
     "",
     ...sourceLines,
-    bindingLine,
     "",
-    setupLine,
-    "",
-    "Read the bound Context Tree first, starting at root NODE.md.",
-    "If the tree is still empty or only contains the Cloud bootstrap placeholder, use the first-tree-seed skill to draft the initial tree from the bound source repos.",
-    "If the tree already has real structure or content, use first-tree-read to orient and first-tree-write only for warranted incremental updates from the connected repos.",
-    "Show the user the diff and walk through any PR before pushing.",
-    "This tree chat owns shared-memory setup/update; do not turn it into the user's first value task.",
-    "",
-    "Do not impersonate the user or say the user asked for this. First Tree sent this system kickoff.",
-    "",
-    `Reference: ${FIRST_TREE_REFERENCE_URL}`,
+    "Use first-tree-read, first-tree-seed, or first-tree-write after reading the bound tree. Keep this chat focused on shared-memory setup; the user's first work chat is separate.",
   ].join("\n");
 }
 
@@ -124,21 +85,12 @@ export function buildTreeSetupBootstrap(
  */
 export function buildInviteeReadyBootstrap(agentDisplayName: string, treeUrl: string): string {
   return [
-    `First Tree is welcoming ${agentDisplayName} for a teammate joining a team that already has code access and a shared Context Tree.`,
+    `First Tree is getting ${agentDisplayName} ready for this team.`,
     "",
     "Use the first-tree-welcome skill for this onboarding first chat.",
     "",
-    `Team Context Tree: ${treeUrl}`,
+    `Team context: ${treeUrl}`,
     "",
-    "First response requirements:",
-    "- Read the team's Context Tree first, starting at root NODE.md, and use inherited recommended repos where available.",
-    "- Cite concrete evidence from the tree, repos, or both; do not promise access to private repos the member's local credentials cannot reach.",
-    "- Briefly introduce what you can help with as this teammate's agent.",
-    "- Offer 2–3 evidence-backed first tasks that are small, low-risk, verifiable, and likely to produce user-visible value quickly.",
-    "- Ask with the host's tracked request primitive when available; in First Tree CLI use chat ask with concise real-task options and free-text accepted. Do not add a separate skip option because the Web ask footer already provides Skip.",
-    "- Do not make writing or seeding the Context Tree the invitee's first task.",
-    "- Do not impersonate the user or say the user asked for this. First Tree sent this system kickoff.",
-    "",
-    `Reference: ${FIRST_TREE_REFERENCE_URL}`,
+    "Start with useful work: use the team's code and context to help the user choose a small first task.",
   ].join("\n");
 }


### PR DESCRIPTION
## Summary
- Slim the onboarding kickoff bootstrap messages so the first visible message is shorter and easier to understand.
- Clarify the first task chat opening line as `This is your first task chat with {agentDisplayName}.`
- Set server-owned default topics for onboarding kickoff chats: `Meet your agent`, `First task chat`, and `Set up team context`.

## Why
The kickoff bootstrap message is both visible to users and used as the first system-authored scene handoff to the agent. The previous copy and auto-generated chat titles were harder to scan during onboarding. This keeps the operational routing intact while making the user-facing chat purpose clearer.

## Validation
- `pnpm --filter @first-tree/web test src/pages/workspace/center/onboarding/__tests__/bootstrap-prose.test.ts`
- `pnpm --filter @first-tree/server test src/__tests__/me-onboarding-kickoff.test.ts`
- `pnpm exec biome check packages/web/src/pages/workspace/center/onboarding/bootstrap-prose.ts packages/web/src/pages/workspace/center/onboarding/__tests__/bootstrap-prose.test.ts packages/server/src/services/onboarding-kickoff.ts packages/server/src/__tests__/me-onboarding-kickoff.test.ts`
- `pnpm --filter @first-tree/web typecheck`
- `pnpm --filter @first-tree/server typecheck`
- `git diff --check`