### PR TITLE
feat: externalize native claude engine; resolve from PATH + one-click install

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -29,6 +29,7 @@
     "dist",
     "skills",
     "scripts/prune-codex-runtime-binary.mjs",
+    "scripts/prune-claude-runtime-binary.mjs",
     "README.md",
     "LICENSE"
   ],
@@ -43,7 +44,7 @@
     "coverage": "pnpm run build && vitest run --coverage --passWithNoTests",
     "prepack": "rm -rf skills && cp -R ../../skills .",
     "postpack": "rm -rf skills",
-    "postinstall": "node scripts/prune-codex-runtime-binary.mjs"
+    "postinstall": "node scripts/prune-codex-runtime-binary.mjs && node scripts/prune-claude-runtime-binary.mjs"
   },
   "license": "Apache-2.0",
   "repository": {

--- a/apps/cli/scripts/prune-claude-runtime-binary.mjs
+++ b/apps/cli/scripts/prune-claude-runtime-binary.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+// Surgically remove the SDK-bundled native Claude engine after install.
+//
+// Why: the `@anthropic-ai/claude-agent-sdk-{platform}` package ships a ~210MB
+// native `claude` binary as a transitive optionalDependency of
+// `@anthropic-ai/claude-agent-sdk`. First Tree does not need it bundled — the
+// runtime resolves a system `claude` first (env override / PATH / well-known
+// install dirs; see packages/client/src/handlers/claude-executable.ts) and the
+// daemon can install the native engine on demand (`daemon install-claude`).
+// Removing the vendored binary at install time trims the install footprint
+// without touching the `@anthropic-ai/claude-agent-sdk` TypeScript SDK we
+// actually import.
+//
+// Zero-config: runs as a `postinstall` of the published package, but ONLY
+// prunes for a global install (`npm install -g first-tree`) — see the
+// ownership-boundary note in main(). Honors FIRST_TREE_KEEP_CLAUDE_BINARY=1 for
+// users who prefer the bundled engine. The whole body is wrapped so it NEVER
+// exits non-zero — a prune failure must not break the install (the runtime
+// degrades gracefully to PATH / one-click install).
+import { existsSync, readdirSync, rmSync, statSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+
+// Per-platform packages the SDK ships the bundled `claude` binary in. Mirrors
+// `@anthropic-ai/claude-agent-sdk`'s own optionalDependencies (and the list in
+// packages/client/src/runtime/capabilities/claude-code.ts). Linux carries both
+// the glibc and the musl variant — only the one matching the host's libc is
+// installed; removing whichever resolved is enough, and the absent one is a
+// no-op here.
+const PLATFORM_PKGS = [
+  "@anthropic-ai/claude-agent-sdk-darwin-arm64",
+  "@anthropic-ai/claude-agent-sdk-darwin-x64",
+  "@anthropic-ai/claude-agent-sdk-linux-arm64",
+  "@anthropic-ai/claude-agent-sdk-linux-arm64-musl",
+  "@anthropic-ai/claude-agent-sdk-linux-x64",
+  "@anthropic-ai/claude-agent-sdk-linux-x64-musl",
+  "@anthropic-ai/claude-agent-sdk-win32-arm64",
+  "@anthropic-ai/claude-agent-sdk-win32-x64",
+];
+
+// Dev guard: when this runs as a workspace `postinstall` inside the first-tree
+// monorepo (pnpm install during development), the bundled claude binary is the
+// dev runtime we want to keep. Only prune in a real consumer install. Detect
+// the source checkout by walking up for a `pnpm-workspace.yaml` beside an
+// `apps/cli` — a published global/local install never has one above it.
+function insideSourceMonorepo() {
+  let dir = process.cwd();
+  for (let i = 0; i < 6; i++) {
+    if (existsSync(join(dir, "pnpm-workspace.yaml")) && existsSync(join(dir, "apps", "cli"))) return true;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return false;
+}
+
+function tryResolvePackageRoot(spec, fromPaths) {
+  try {
+    const req = createRequire(import.meta.url);
+    return dirname(req.resolve(`${spec}/package.json`, { paths: fromPaths }));
+  } catch {
+    return null;
+  }
+}
+
+function dirSize(dir) {
+  let total = 0;
+  const stack = [dir];
+  while (stack.length > 0) {
+    const cur = stack.pop();
+    let entries;
+    try {
+      entries = readdirSync(cur, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const e of entries) {
+      const p = join(cur, e.name);
+      if (e.isDirectory()) stack.push(p);
+      else {
+        try {
+          total += statSync(p).size;
+        } catch {
+          /* ignore unreadable entry */
+        }
+      }
+    }
+  }
+  return total;
+}
+
+function main() {
+  if (process.env.FIRST_TREE_KEEP_CLAUDE_BINARY === "1") return;
+  if (insideSourceMonorepo()) return;
+
+  // Ownership boundary: only prune in a GLOBAL install (`npm install -g
+  // first-tree`), where the claude engine sits in first-tree's own global
+  // root and is there because of first-tree. In a non-global consumer
+  // install, npm hoists `@anthropic-ai/claude-agent-sdk-*` to the app's root
+  // node_modules, where another dependency may share it — deleting it there
+  // could break an unrelated package. npm sets `npm_config_global=true` for
+  // `-g` installs; absent it (local dependency install, or a package manager
+  // that doesn't export the flag) we skip and leave the binary in place. The
+  // runtime still resolves a system `claude` on PATH, so skipping only forgoes
+  // the size win.
+  if (process.env.npm_config_global !== "true") return;
+
+  // Anchor resolution at both the install package dir (cwd during a
+  // `postinstall`) and this script's own dir, so the node_modules walk-up
+  // finds a sibling `@anthropic-ai/*` in either flat (npm) or nested layouts.
+  const anchorPaths = [process.cwd(), import.meta.dirname];
+  let removedBytes = 0;
+  for (const pkg of PLATFORM_PKGS) {
+    const root = tryResolvePackageRoot(pkg, anchorPaths);
+    if (!root) continue;
+    try {
+      const before = dirSize(root);
+      rmSync(root, { recursive: true, force: true });
+      removedBytes += before;
+      console.log(`[first-tree] pruned bundled claude engine: ${pkg} (${(before / 1e6).toFixed(0)}MB)`);
+    } catch {
+      /* best-effort: a read-only or vanished tree is fine, runtime falls back to PATH */
+    }
+  }
+  if (removedBytes > 0) {
+    console.log(
+      `[first-tree] claude runtime resolves from PATH or \`daemon install-claude\` (~${(removedBytes / 1e6).toFixed(0)}MB saved)`,
+    );
+  }
+}
+
+try {
+  main();
+} catch {
+  // Never fail the install — the runtime degrades to PATH / one-click install.
+}

--- a/apps/cli/src/__tests__/command-registration-smoke.test.ts
+++ b/apps/cli/src/__tests__/command-registration-smoke.test.ts
@@ -91,6 +91,7 @@ describe("CLI command registration", () => {
     expect(subcommands(root, "daemon")).toEqual([
       "doctor",
       "home-info",
+      "install-claude",
       "install-codex",
       "probe",
       "refresh-unit",

--- a/apps/cli/src/__tests__/daemon-refresh-unit.test.ts
+++ b/apps/cli/src/__tests__/daemon-refresh-unit.test.ts
@@ -33,7 +33,16 @@ describe("daemon namespace — refresh-unit hidden subcommand", () => {
       .filter((c) => !(c as unknown as { _hidden?: boolean })._hidden)
       .map((c) => c.name())
       .sort();
-    expect(visibleNames).toEqual(["doctor", "install-codex", "probe", "restart", "start", "status", "stop"]);
+    expect(visibleNames).toEqual([
+      "doctor",
+      "install-claude",
+      "install-codex",
+      "probe",
+      "restart",
+      "start",
+      "status",
+      "stop",
+    ]);
   });
 });
 

--- a/apps/cli/src/commands/daemon/index.ts
+++ b/apps/cli/src/commands/daemon/index.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 import { registerDaemonDoctorCommand } from "./doctor.js";
 import { registerDaemonHomeInfoCommand } from "./home-info.js";
+import { registerDaemonInstallClaudeCommand } from "./install-claude.js";
 import { registerDaemonInstallCodexCommand } from "./install-codex.js";
 import { registerDaemonProbeCommand } from "./probe.js";
 import { registerDaemonRefreshUnitCommand } from "./refresh-unit.js";
@@ -20,6 +21,7 @@ export function registerDaemonCommands(program: Command): void {
   registerDaemonDoctorCommand(daemon);
   registerDaemonProbeCommand(daemon);
   registerDaemonInstallCodexCommand(daemon);
+  registerDaemonInstallClaudeCommand(daemon);
   // Hidden — supervisor-cooperation interface invoked by `createExecuteUpdate`
   // after a self-install to refresh the unit file with the new binary's
   // templates before exit(75).

--- a/apps/cli/src/commands/daemon/install-claude.ts
+++ b/apps/cli/src/commands/daemon/install-claude.ts
@@ -58,6 +58,6 @@ export function registerDaemonInstallClaudeCommand(daemon: Command): void {
         return;
       }
       printResults(runtimeProviderChecks(capabilities));
-      print.line("  If claude-code now reports `unauthenticated`, run runtime auth (claude /login) to finish.\n\n");
+      print.line("  If claude-code now reports `unauthenticated`, run runtime auth (claude auth login) to finish.\n\n");
     });
 }

--- a/apps/cli/src/commands/daemon/install-claude.ts
+++ b/apps/cli/src/commands/daemon/install-claude.ts
@@ -1,0 +1,63 @@
+import { probeCapabilities } from "@first-tree/client";
+import type { Command } from "commander";
+import { fail } from "../../cli/output.js";
+import { installClaudeRuntime, printResults, runtimeProviderChecks } from "../../core/index.js";
+import { isJsonMode, print } from "../../core/output.js";
+
+/**
+ * `daemon install-claude` — one-click install of the native Claude Code engine.
+ *
+ * First Tree does not bundle the ~210MB native `claude` binary by default; the
+ * runtime resolves a system `claude` (env override / PATH / well-known install
+ * dirs). When none exists, the claude-code capability probes as `missing`. This
+ * command is the remediation: it runs `npm install -g @anthropic-ai/claude-code`
+ * through the same tracked-subprocess path the CLI self-update uses, then
+ * re-probes so the freshly installed binary is reflected in the capability
+ * snapshot.
+ *
+ * It is purely local (no First Tree credentials needed). The daemon exposes
+ * the same routine to the web UI via the reverse-command channel so an
+ * operator can trigger it from "Claude runtime missing → Install".
+ */
+export function registerDaemonInstallClaudeCommand(daemon: Command): void {
+  daemon
+    .command("install-claude")
+    .description(
+      "Install the native Claude Code runtime engine on this machine (npm install -g @anthropic-ai/claude-code)",
+    )
+    .option("--spec <spec>", "npm dist-tag or exact version to install", "latest")
+    .option("--json", "Emit the post-install capability snapshot as a machine-readable JSON envelope")
+    .action(async (options: { spec?: string; json?: boolean }) => {
+      const wantJson = options.json === true || isJsonMode();
+      const spec = options.spec ?? "latest";
+
+      if (!wantJson) print.line(`\n  Installing native Claude Code runtime (@anthropic-ai/claude-code@${spec})...\n\n`);
+      const result = await installClaudeRuntime(spec);
+
+      if (!result.ok) {
+        if (wantJson) fail("CLAUDE_INSTALL_FAILED", result.reason, 1);
+        print.status("✖", `Claude install failed: ${result.reason}`);
+        if (result.retryable) print.line("  This looks transient — retry in a moment.\n\n");
+        process.exitCode = 1;
+        return;
+      }
+
+      if (!wantJson) {
+        print.status(
+          "✓",
+          `Installed @anthropic-ai/claude-code${result.installedVersion ? `@${result.installedVersion}` : ""}`,
+        );
+        print.line("\n  Re-probing claude-code capability...\n\n");
+      }
+
+      // Re-probe so the new PATH binary is launch-verified and the claude-code
+      // row flips from `missing` toward `ok`/`unauthenticated`.
+      const capabilities = await probeCapabilities();
+      if (wantJson) {
+        print.result(capabilities);
+        return;
+      }
+      printResults(runtimeProviderChecks(capabilities));
+      print.line("  If claude-code now reports `unauthenticated`, run runtime auth (claude /login) to finish.\n\n");
+    });
+}

--- a/apps/cli/src/core/index.ts
+++ b/apps/cli/src/core/index.ts
@@ -37,6 +37,8 @@ export {
   runtimeProviderCheck,
   runtimeProviderChecks,
 } from "./doctor.js";
+export type { InstallClaudeResult } from "./install-claude-runtime.js";
+export { installClaudeRuntime } from "./install-claude-runtime.js";
 export type { InstallCodexResult } from "./install-codex-runtime.js";
 export { installCodexRuntime } from "./install-codex-runtime.js";
 // Phase 3 of the agent-naming refactor — renames local agent dirs whose

--- a/apps/cli/src/core/install-claude-runtime.ts
+++ b/apps/cli/src/core/install-claude-runtime.ts
@@ -1,0 +1,116 @@
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { classify, ERROR_KINDS, getChildProcessRegistry } from "@first-tree/client";
+import { print } from "./output.js";
+
+/**
+ * The npm package that carries the native Claude Code engine. Installing it
+ * globally exposes a `claude` executable on PATH. This is the engine First Tree
+ * intentionally does NOT bundle by default — the runtime resolves a system
+ * `claude` (env override / PATH / well-known install dirs; see
+ * packages/client/src/handlers/claude-executable.ts), and this one-click
+ * install is the remediation when none exists.
+ */
+const CLAUDE_RUNTIME_PACKAGE = "@anthropic-ai/claude-code";
+
+/** Hard ceiling on the install (the native engine download is large; 8 min). */
+const CLAUDE_INSTALL_TIMEOUT_MS = 8 * 60 * 1000;
+
+export type InstallClaudeResult =
+  | { ok: true; installedVersion: string | null }
+  | { ok: false; reason: string; retryable: boolean; reasonCode: string };
+
+/** Same defensive contract as the self-update spec guard. */
+function isSafeInstallSpec(spec: string): boolean {
+  if (typeof spec !== "string" || spec.length === 0 || spec.length > 128) return false;
+  if (spec.startsWith("-")) return false;
+  return /^[A-Za-z0-9.+-]+$/.test(spec);
+}
+
+/** Pick the `npm` binary, preferring the sibling of the launching Node. */
+function resolveNpmCommand(): string {
+  const binName = process.platform === "win32" ? "npm.cmd" : "npm";
+  const sibling = join(dirname(process.execPath), binName);
+  if (existsSync(sibling)) return sibling;
+  return "npm";
+}
+
+function parseInstalledVersion(stdout: string): string | null {
+  // npm prints `+ @anthropic-ai/claude-code@2.1.84` (legacy) or `added N packages` lines.
+  const match = stdout.match(/@anthropic-ai\/claude-code@(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.+-]+)?)/);
+  return match ? match[1] : null;
+}
+
+/**
+ * Install the native Claude Code runtime globally
+ * (`npm install -g @anthropic-ai/claude-code@<spec>`).
+ *
+ * This is the daemon's one-click remediation for a host with no `claude` on
+ * PATH: it runs the same tracked-subprocess install path the CLI self-update
+ * uses (reaped on shutdown, hard-timeout, error-taxonomy classification), then
+ * the caller is expected to re-probe the claude-code capability so the new
+ * binary is picked up via PATH resolution. Does not exit the process.
+ */
+export async function installClaudeRuntime(spec = "latest"): Promise<InstallClaudeResult> {
+  if (!isSafeInstallSpec(spec)) {
+    return {
+      ok: false,
+      reason: `Refusing to install: invalid npm spec ${JSON.stringify(spec)}`,
+      retryable: false,
+      reasonCode: "invalid_spec",
+    };
+  }
+
+  return new Promise((resolvePromise) => {
+    const npmCmd = resolveNpmCommand();
+    const npmArgs = ["install", "-g", `${CLAUDE_RUNTIME_PACKAGE}@${spec}`];
+    const { child } = getChildProcessRegistry().spawn(npmCmd, npmArgs, {
+      category: "npm-install",
+      label: `npm install -g ${CLAUDE_RUNTIME_PACKAGE}@${spec}`,
+      timeoutMs: CLAUDE_INSTALL_TIMEOUT_MS,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+    let timedOut = false;
+    child.stdout?.on("data", (chunk: Buffer) => stdoutChunks.push(chunk));
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderrChunks.push(chunk);
+      print.line(chunk.toString("utf8"));
+    });
+
+    child.on("error", (err) => {
+      const message = err instanceof Error ? err.message : String(err);
+      const classification = classify(err, { source: "update" });
+      resolvePromise({
+        ok: false,
+        reason: message,
+        retryable: classification.kind === ERROR_KINDS.TRANSIENT,
+        reasonCode: classification.reasonCode,
+      });
+    });
+
+    child.on("exit", (code, signal) => {
+      if (code === 0) {
+        const stdout = Buffer.concat(stdoutChunks).toString("utf8");
+        resolvePromise({ ok: true, installedVersion: parseInstalledVersion(stdout) });
+        return;
+      }
+      if (code === null && signal) timedOut = true;
+      const stderr = Buffer.concat(stderrChunks).toString("utf8").trim();
+      const reason = `npm install -g ${CLAUDE_RUNTIME_PACKAGE} ${
+        timedOut ? `killed by signal ${signal} (timeout)` : `exited with code ${code}`
+      }${stderr ? `: ${stderr.split("\n").slice(-3).join(" | ")}` : ""}`;
+      const classification = timedOut
+        ? { kind: ERROR_KINDS.TRANSIENT, reasonCode: "npm_timeout" as const }
+        : classify(new Error(reason), { source: "update" });
+      resolvePromise({
+        ok: false,
+        reason,
+        retryable: classification.kind === ERROR_KINDS.TRANSIENT,
+        reasonCode: classification.reasonCode,
+      });
+    });
+  });
+}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -456,7 +456,8 @@ first-tree daemon
 ├── status
 ├── doctor
 ├── probe [--no-upload] [--json]
-└── install-codex [--spec <spec>] [--json]
+├── install-codex [--spec <spec>] [--json]
+└── install-claude [--spec <spec>] [--json]
 ```
 
 | Subcommand | Purpose |
@@ -468,6 +469,7 @@ first-tree daemon
 | `doctor` | Walk Node version, config, server reachability, WS, agent registrations, the installed service file, **and the runtime providers** — each step reported. The runtime-provider rows run the real launch-verified probe (a 1-turn model call for `claude-code`, a `codex doctor` handshake for `codex`), so `doctor` makes live provider calls; it is a deliberate diagnostic, not a hot path. |
 | `probe` | Launch-probe the local runtime providers on demand and upload the result to the server (`PATCH /clients/:id/capabilities`). This is the manual refresh for a client's advertised capabilities after a provider is installed / logged in. Each probe really launches its provider. `--no-upload` runs a **credentials-free local-only** diagnostic (probe + print, no server auth needed). `--json` (or the global `--json`) emits the capability snapshot as the machine-readable `{ ok, data }` envelope on stdout. |
 | `install-codex` | Install the native Codex runtime engine on this machine (`npm install -g @openai/codex`). First Tree does not bundle the ~225MB native `codex` binary by default — the runtime resolves a system `codex` on PATH — so this is the on-demand remediation when the `codex` capability probes as `missing`. Runs the same tracked-subprocess install path as self-update, then re-probes so the freshly installed binary is reflected. Purely local (no credentials). `--spec <spec>` picks an npm dist-tag or exact version (default `latest`); `--json` emits the post-install capability snapshot as the `{ ok, data }` envelope. |
+| `install-claude` | Install the native Claude Code runtime engine on this machine (`npm install -g @anthropic-ai/claude-code`). First Tree does not bundle the ~210MB native `claude` binary by default — the runtime resolves a system `claude` (env override / PATH / well-known install dirs) — so this is the on-demand remediation when the `claude-code` capability probes as `missing`. Runs the same tracked-subprocess install path as self-update, then re-probes so the freshly installed binary is reflected. Purely local (no credentials). `--spec <spec>` picks an npm dist-tag or exact version (default `latest`); `--json` emits the post-install capability snapshot as the `{ ok, data }` envelope. |
 
 **Capability refresh timing.** The daemon launch-probes runtime providers at
 startup and re-probes automatically on every WebSocket reconnect. A full real

--- a/packages/client/src/__tests__/capability-probes.test.ts
+++ b/packages/client/src/__tests__/capability-probes.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ClaudeExecutableResolution } from "../handlers/claude-executable.js";
 import {
   classifyClaudeSmokeFailure,
+  formatClaudeBinaryMissingMessage,
   probeClaudeCodeCapability,
   resolveBundledClaudeBinary,
   verifyBundledClaudeArtifact,
@@ -501,6 +502,18 @@ describe("verifyBundledClaudeArtifact (real node_modules)", () => {
     const res = await verifyBundledClaudeArtifact();
     expect(res.ok).toBe(true);
     if (res.ok) expect(res.version === null || /^\d+\.\d+(\.\d+)?$/.test(res.version)).toBe(true);
+  });
+});
+
+describe("formatClaudeBinaryMissingMessage", () => {
+  it("names the repo-canonical `claude auth login`, not `claude /login`, and points at the one-click install", () => {
+    const msg = formatClaudeBinaryMissingMessage("Native CLI binary for darwin-arm64 not found");
+    // Guard against the login-command drift codex-assistant caught: the
+    // remediation must match the command the runtime-auth orchestrator runs.
+    expect(msg).toContain("claude auth login");
+    expect(msg).not.toContain("claude /login");
+    expect(msg).toContain("daemon install-claude");
+    expect(msg).toContain("Native CLI binary for darwin-arm64 not found");
   });
 });
 

--- a/packages/client/src/__tests__/capability-probes.test.ts
+++ b/packages/client/src/__tests__/capability-probes.test.ts
@@ -393,6 +393,9 @@ describe("probeClaudeCodeCapability", () => {
       authMethod: "oauth",
       sdkVersion: "1.0.42",
       probeKind: "launch",
+      // Provenance (mirrors codex): a resolved on-disk binary is a system claude.
+      runtimeSource: "path",
+      runtimePath: "/usr/local/bin/claude",
     });
     // The smoke must target the binary the runtime would spawn.
     expect(runSmoke).toHaveBeenCalledWith("/usr/local/bin/claude");
@@ -409,6 +412,10 @@ describe("probeClaudeCodeCapability", () => {
     expect(entry.state).toBe("ok");
     // Version is the real CLI version from the bundled artifact's `--version`.
     expect(entry.sdkVersion).toBe("2.1.84");
+    // Provenance: no on-disk binary resolved → the runtime falls back to the
+    // SDK-bundled engine, reported as `bundled` with no path.
+    expect(entry.runtimeSource).toBe("bundled");
+    expect(entry.runtimePath).toBeNull();
     // undefined binary → the SDK spawns its own bundled Claude binary.
     expect(runSmoke).toHaveBeenCalledWith(undefined);
   });

--- a/packages/client/src/runtime/capabilities/claude-code.ts
+++ b/packages/client/src/runtime/capabilities/claude-code.ts
@@ -149,7 +149,10 @@ export async function verifyBundledClaudeArtifact(): Promise<
   } catch (err) {
     return {
       ok: false,
-      error: `@anthropic-ai/claude-agent-sdk bundled Claude binary could not be located: ${err instanceof Error ? err.message : String(err)}`,
+      error:
+        "Claude runtime binary is missing on this machine. First Tree does not bundle the native Claude engine by default — it resolves a system `claude` (env override / PATH / well-known install dirs). " +
+        "Install it with the daemon's one-click `daemon install-claude` (or `npm install -g @anthropic-ai/claude-code`), then run `claude /login` and retry. " +
+        `Original error: ${err instanceof Error ? err.message : String(err)}`,
     };
   }
   const [command, args, label] =

--- a/packages/client/src/runtime/capabilities/claude-code.ts
+++ b/packages/client/src/runtime/capabilities/claude-code.ts
@@ -130,6 +130,22 @@ export function resolveBundledClaudeBinary(deps: ResolveBundledClaudeDeps = {}):
 }
 
 /**
+ * Remediation message shown when no `claude` resolves and the SDK-bundled
+ * native binary is also absent (the externalized-engine `missing` case). The
+ * login command MUST stay `claude auth login` — the repo-canonical command the
+ * runtime-auth orchestrator actually runs and every other user-facing hint
+ * names (see `runClaudeBrowserLogin` and the auth-precheck messages) — so a
+ * user who installs the engine then logs in follows one consistent command.
+ */
+export function formatClaudeBinaryMissingMessage(originalError: string): string {
+  return (
+    "Claude runtime binary is missing on this machine. First Tree does not bundle the native Claude engine by default — it resolves a system `claude` (env override / PATH / well-known install dirs). " +
+    "Install it with the daemon's one-click `daemon install-claude` (or `npm install -g @anthropic-ai/claude-code`), then run `claude auth login` and retry. " +
+    `Original error: ${originalError}`
+  );
+}
+
+/**
  * Launch-verify the SDK's bundled Claude CLI via `<artifact> --version`.
  *
  * This is the resolve-stage proof for the no-on-disk-binary path: when no
@@ -149,10 +165,7 @@ export async function verifyBundledClaudeArtifact(): Promise<
   } catch (err) {
     return {
       ok: false,
-      error:
-        "Claude runtime binary is missing on this machine. First Tree does not bundle the native Claude engine by default — it resolves a system `claude` (env override / PATH / well-known install dirs). " +
-        "Install it with the daemon's one-click `daemon install-claude` (or `npm install -g @anthropic-ai/claude-code`), then run `claude /login` and retry. " +
-        `Original error: ${err instanceof Error ? err.message : String(err)}`,
+      error: formatClaudeBinaryMissingMessage(err instanceof Error ? err.message : String(err)),
     };
   }
   const [command, args, label] =

--- a/packages/client/src/runtime/capabilities/claude-code.ts
+++ b/packages/client/src/runtime/capabilities/claude-code.ts
@@ -328,7 +328,17 @@ export async function probeClaudeCodeCapability(deps: ClaudeCodeProbeDeps = {}):
         const verified = await verifyBinary(resolution.path);
         if (!verified.ok) return { ok: false, error: verified.error };
         resolvedBinary = resolution.path;
-        return { ok: true, binary: resolution.path, version: verified.version };
+        // Provenance for the capability snapshot (mirrors codex): an on-disk
+        // `claude` the runtime resolved itself — env override, PATH, or a
+        // well-known install dir — all surface as `runtimeSource: "path"` with
+        // the resolved absolute path, so a consumer can assert "this host runs
+        // a system claude" directly instead of inferring it from the version.
+        return {
+          ok: true,
+          binary: resolution.path,
+          version: verified.version,
+          meta: { runtimeSource: "path", runtimePath: resolution.path },
+        };
       }
       // No on-disk binary — the SDK will spawn its bundled Claude binary
       // (legacy cli.js, or a modern per-platform native binary). Launch-verify
@@ -337,7 +347,7 @@ export async function probeClaudeCodeCapability(deps: ClaudeCodeProbeDeps = {}):
       // it only runs after a passing auth precheck).
       const verified = await verifyBundledArtifact();
       if (!verified.ok) return { ok: false, error: verified.error };
-      return { ok: true, version: verified.version };
+      return { ok: true, version: verified.version, meta: { runtimeSource: "bundled", runtimePath: null } };
     },
     authPrecheck: async (): Promise<AuthPrecheckOutcome> => {
       const auth = detectAuth();


### PR DESCRIPTION
## What

Mirrors the codex externalization (#1297) for the Claude engine. The bundled
`@anthropic-ai/claude-agent-sdk-{platform}` native `claude` binary adds ~210MB
to every install, but the runtime already resolves a system `claude` **first**
(`CLAUDE_CODE_EXECUTABLE` env → PATH → well-known dirs `~/.local/bin`,
`~/.claude/local`; the SDK's bundled native binary is only the last-resort
fallback in `handlers/claude-executable.ts`). So we stop shipping it by default
and install it on demand.

## Changes

- **postinstall prune** — `apps/cli/scripts/prune-claude-runtime-binary.mjs`
  removes the `@anthropic-ai/claude-agent-sdk-{platform}` packages after a
  consumer install (~210MB). Structural mirror of the codex prune:
  - bound to **global installs only** (`npm_config_global=true`) — a non-global
    consumer install hoists the platform pkg to the app root where another dep
    may share it, so we never delete a shared copy there;
  - dev-monorepo guard (keeps the dev runtime), `FIRST_TREE_KEEP_CLAUDE_BINARY=1`
    opt-out, whole body wrapped to **never exit non-zero**;
  - chained after the codex prune in the same `postinstall`.
- **`daemon install-claude`** + core `installClaudeRuntime()` — on-demand
  remediation via `npm install -g @anthropic-ai/claude-code`, reusing the
  self-update tracked-subprocess path (reap on shutdown, hard timeout, error
  taxonomy), then re-probes the `claude-code` capability.
- Points the claude bundled-missing probe message at the one-click install.
- Retains the small `@anthropic-ai/claude-agent-sdk` TS SDK we import.

With codex already external (#1297), a darwin-arm64 global install drops
**255MB → ~46MB**.

## Verification

- `pnpm typecheck` (cli + client) clean; `biome check` clean.
- CLI suite **507/507**; client `capability-probes` **86/86** (incl. the real
  `verifyBundledClaudeArtifact` launch test). Updated the two registration
  tests (`command-registration-smoke`, `daemon-refresh-unit`).
- Prune logic verified against a **simulated flat npm-global layout**: removes
  `@anthropic-ai/claude-agent-sdk-darwin-arm64`, **keeps** the JS
  `@anthropic-ai/claude-agent-sdk`; both guards (keep-flag, non-global) no-op
  with exit 0.
- Built `daemon install-claude --help` renders.

## Follow-up

Web one-click "Install Claude runtime" button (server route + WS reverse
command + capability remediation UI) — shares the codex install-button work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)