### PR TITLE
[codex] remove commit entity follow support

### DIFF
--- a/apps/cli/src/commands/github/follow.ts
+++ b/apps/cli/src/commands/github/follow.ts
@@ -14,8 +14,8 @@ export function registerGithubFollowCommand(github: Command): void {
   github
     .command("follow <entity>")
     .description(
-      "Follow a GitHub entity (PR / Issue / Discussion / Commit): route its webhook events into the current " +
-        "chat. <entity> is a GitHub URL, owner/repo#42, or owner/repo@<sha>. Creating a PR or issue never " +
+      "Follow a GitHub entity (PR / Issue / Discussion): route its webhook events into the current " +
+        "chat. <entity> is a GitHub URL or owner/repo#42. Creating a PR or issue never " +
         "follows it for you — declare the dependency yourself, immediately after creation.",
     )
     .option("--chat <chatId>", "Target chat (default: the session's FIRST_TREE_CHAT_ID)")

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -415,12 +415,11 @@ first-tree github
 # Inside an agent session the chat is inferred from FIRST_TREE_CHAT_ID
 first-tree github follow https://github.com/acme/api/pull/42
 first-tree github follow acme/api#42        # issue vs PR resolved automatically
-first-tree github follow acme/api@3f2a91c   # commit
 first-tree github following
 first-tree github unfollow acme/api#42
 ```
 
-`<entity>` accepts a full GitHub URL, `owner/repo#N`, or `owner/repo@<sha>`.
+`<entity>` accepts a full GitHub PR / Issue / Discussion URL, or `owner/repo#N`.
 A `409` means the same (human, delegate) line already lives in another chat
 — `--rebind` MOVES it here (a line is never duplicated). `unfollow` is
 idempotent: `removed: 0` is success, not an error. Requires the org's

--- a/packages/client/src/runtime/agent-briefing.ts
+++ b/packages/client/src/runtime/agent-briefing.ts
@@ -833,7 +833,7 @@ everyone (reading a description to self-locate needs no ownership).
    description that no longer matches what the thread has actually done.
 
 **Exception: GitHub-sourced topics — leave them alone.** Topics like
-\`PR repo#307: title\`, \`Issue repo#42\`, \`Commit repo@sha\` are
+\`PR repo#307: title\`, \`Issue repo#42\`, \`Discussion repo#9\` are
 auto-set and kept in sync by First Tree from the upstream entity;
 overriding the topic loses the repo / entity-id anchor. This applies to
 the **topic only** — the owner still maintains the description.`;

--- a/packages/server/src/__tests__/github-audience.test.ts
+++ b/packages/server/src/__tests__/github-audience.test.ts
@@ -53,7 +53,7 @@ async function seedMapping(
     orgId: string;
     humanId: string;
     delegateId: string;
-    entityType: "issue" | "pull_request" | "discussion" | "commit";
+    entityType: "issue" | "pull_request" | "discussion";
     entityKey: string;
     chatId: string;
     boundVia?: "direct" | "fixes_link" | "agent_declared" | "human_declared" | "human_fallback";
@@ -87,21 +87,19 @@ const KIND_TO_ACTION: Record<NormalizedEvent["kind"], string> = {
   review_requested: "review_requested",
   synchronized: "synchronize",
   assigned: "assigned",
-  commit_commented: "created",
   other: "other",
 };
 
-const ENTITY_TO_EVENT_TYPE: Record<"issue" | "pull_request" | "discussion" | "commit", string> = {
+const ENTITY_TO_EVENT_TYPE: Record<"issue" | "pull_request" | "discussion", string> = {
   issue: "issues",
   pull_request: "pull_request",
   discussion: "discussion",
-  commit: "commit_comment",
 };
 
 function makeEvent(opts: {
   orgId: string;
   installationId?: number;
-  entityType: "issue" | "pull_request" | "discussion" | "commit";
+  entityType: "issue" | "pull_request" | "discussion";
   entityKey: string;
   actorLogin: string;
   actorIsBot?: boolean;

--- a/packages/server/src/__tests__/github-entity-follow.test.ts
+++ b/packages/server/src/__tests__/github-entity-follow.test.ts
@@ -68,7 +68,7 @@ describe("github-entity-follow", () => {
         accountType: "Organization",
         accountLogin: "acme",
         accountGithubId: 1001,
-        permissions: { contents: "read" },
+        permissions: { issues: "read", pull_requests: "read" },
         events: ["pull_request", "issues"],
         suspendedAt: null,
       },
@@ -88,7 +88,7 @@ describe("github-entity-follow", () => {
           JSON.stringify({
             token: "ghs_test_token",
             expires_at: "2099-01-01T00:00:00Z",
-            permissions: { contents: "read" },
+            permissions: { issues: "read", pull_requests: "read" },
             repository_selection: "selected",
           }),
           { status: 201, headers: { "content-type": "application/json" } },
@@ -176,14 +176,12 @@ describe("github-entity-follow", () => {
       expect(parseEntityReference("https://github.com/o/r/discussions/9")).toMatchObject({
         explicitType: "discussion",
       });
-      expect(parseEntityReference("https://github.com/o/r/commit/3F2A91C0")).toEqual({
-        kind: "commit",
-        owner: "o",
-        repo: "r",
-        sha: "3f2a91c0",
-      });
       expect(parseEntityReference("o/r#42")).toMatchObject({ kind: "numeric", explicitType: null, number: 42 });
-      expect(parseEntityReference("o/r@abcdef1")).toMatchObject({ kind: "commit", sha: "abcdef1" });
+    });
+
+    it("does not parse commit URL or owner/repo@sha references as followable entities", () => {
+      expect(parseEntityReference("https://github.com/o/r/commit/3F2A91C0")).toBeNull();
+      expect(parseEntityReference("o/r@abcdef1")).toBeNull();
     });
 
     it("rejects garbage", () => {
@@ -494,6 +492,21 @@ describe("github-entity-follow", () => {
     );
   });
 
+  it("rejects commit references as unsupported before GitHub resolution", async () => {
+    const app = getApp();
+    const s = await setup(app);
+    const failFetcher = (() => {
+      throw new Error("unexpected GitHub fetch");
+    }) as typeof fetch;
+
+    await expect(
+      declareEntityFollow(app.db, deps(failFetcher), followParams(s, "https://github.com/acme/api/commit/3f2a91c")),
+    ).rejects.toThrow(/Commit references are no longer supported/);
+    await expect(removeEntityFollow(app.db, { chatId: s.chatId, entity: "acme/api@3f2a91c" })).rejects.toThrow(
+      /Commit references are no longer supported/,
+    );
+  });
+
   it("R4: unfollow is idempotent — removed: 0 on a non-followed entity, repeatable", async () => {
     const app = getApp();
     const s = await setup(app);
@@ -606,31 +619,21 @@ describe("github-entity-follow", () => {
     ).resolves.toEqual({ removed: 1 });
   });
 
-  it("commit unfollow escapes LIKE metacharacters — an underscore repo cannot sweep a sibling", async () => {
+  it("following filters legacy commit mappings because commit is no longer a valid entity type", async () => {
     const app = getApp();
     const s = await setup(app);
-    const base = {
+    await app.db.insert(githubEntityChatMappings).values({
       organizationId: s.admin.organizationId,
       humanAgentId: s.human,
       delegateAgentId: s.delegate,
       entityType: "commit",
+      entityKey: "Acme/Api@3f2a91c0aaaabbbbccccddddeeeeffff00001111",
       chatId: s.chatId,
       boundVia: "agent_declared",
-    };
-    await app.db.insert(githubEntityChatMappings).values([
-      { ...base, entityKey: "acme/my_app@3f2a91c0aaaabbbbccccddddeeeeffff00001111" },
-      // `_` as LIKE-any-char would also match this sibling repo's row.
-      { ...base, entityKey: "acme/myxapp@3f2a91c0aaaabbbbccccddddeeeeffff00001111" },
-    ]);
-
-    await expect(removeEntityFollow(app.db, { chatId: s.chatId, entity: "acme/my_app@3f2a91c0" })).resolves.toEqual({
-      removed: 1,
     });
-    const remaining = await app.db
-      .select({ entityKey: githubEntityChatMappings.entityKey })
-      .from(githubEntityChatMappings)
-      .where(eq(githubEntityChatMappings.chatId, s.chatId));
-    expect(remaining).toEqual([{ entityKey: "acme/myxapp@3f2a91c0aaaabbbbccccddddeeeeffff00001111" }]);
+
+    const list = await listChatGithubEntities(app.db, { chatId: s.chatId });
+    expect(list.items).toEqual([]);
   });
 
   it("rebind whose conflicting row vanished concurrently falls back to a real insert (no ghost success)", async () => {
@@ -771,23 +774,6 @@ describe("github-entity-follow", () => {
       entityKey: "Acme/Api#42",
       htmlUrl: "https://github.com/Acme/Api/discussions/42",
       number: 42,
-    });
-  });
-
-  it("unfollow by short commit sha prefix removes the full-sha row", async () => {
-    const app = getApp();
-    const s = await setup(app);
-    await app.db.insert(githubEntityChatMappings).values({
-      organizationId: s.admin.organizationId,
-      humanAgentId: s.human,
-      delegateAgentId: s.delegate,
-      entityType: "commit",
-      entityKey: "Acme/Api@3f2a91c0aaaabbbbccccddddeeeeffff00001111",
-      chatId: s.chatId,
-      boundVia: "agent_declared",
-    });
-    await expect(removeEntityFollow(app.db, { chatId: s.chatId, entity: "acme/api@3f2a91c0" })).resolves.toEqual({
-      removed: 1,
     });
   });
 });

--- a/packages/server/src/__tests__/github-entity-helpers.test.ts
+++ b/packages/server/src/__tests__/github-entity-helpers.test.ts
@@ -83,16 +83,13 @@ describe("extractEventEntity", () => {
     });
   });
 
-  it("derives commit entity from commit_comment with commit_id", () => {
-    const entity = extractEventEntity("commit_comment", {
-      comment: { commit_id: "abc1234", html_url: "https://github.com/owner/repo/commit/abc1234" },
-      repository: { full_name: "owner/repo" },
-    });
-    expect(entity).toEqual({
-      type: "commit",
-      key: "owner/repo@abc1234",
-      url: "https://github.com/owner/repo/commit/abc1234",
-    });
+  it("returns null for commit_comment events because commit entities are unsupported", () => {
+    expect(
+      extractEventEntity("commit_comment", {
+        comment: { commit_id: "abc1234", html_url: "https://github.com/owner/repo/commit/abc1234" },
+        repository: { full_name: "owner/repo" },
+      }),
+    ).toBeNull();
   });
 
   it("returns null for unknown event types", () => {
@@ -221,12 +218,6 @@ describe("formatEntityTitle", () => {
   it("renders Discussion title", () => {
     expect(formatEntityTitle({ type: "discussion", key: "owner/repo#9", title: "RFC" }, "discussion", "created")).toBe(
       "Discussion repo#9: RFC",
-    );
-  });
-
-  it("renders Commit title (no entity title)", () => {
-    expect(formatEntityTitle({ type: "commit", key: "owner/repo@abc1234" }, "commit_comment", "created")).toBe(
-      "Commit repo@abc1234",
     );
   });
 

--- a/packages/server/src/__tests__/github-entity-live.test.ts
+++ b/packages/server/src/__tests__/github-entity-live.test.ts
@@ -7,7 +7,7 @@ function jsonResponse(body: unknown, status = 200): Response {
 }
 
 describe("github entity live helpers", () => {
-  it("parses numeric and sha entity keys", () => {
+  it("parses numeric entity keys", () => {
     expect(__testing.parseEntityKey("pull_request", "owner/repo#42")).toEqual({
       kind: "numeric",
       owner: "owner",
@@ -26,13 +26,6 @@ describe("github entity live helpers", () => {
       repo: "repo",
       number: 9,
     });
-    expect(__testing.parseEntityKey("commit", "owner/repo@abcdef1")).toEqual({
-      kind: "sha",
-      owner: "owner",
-      repo: "repo",
-      sha: "abcdef1",
-    });
-    expect(__testing.parseEntityKey("commit", "owner/repo#42")).toBeNull();
     expect(__testing.parseEntityKey("issue", "owner/repo@abcdef1")).toBeNull();
     expect(__testing.parseEntityKey("pull_request", "owner/repo#not-a-number")).toBeNull();
   });
@@ -46,9 +39,6 @@ describe("github entity live helpers", () => {
     );
     expect(__testing.buildHtmlUrl("discussion", { kind: "numeric", owner: "o", repo: "r", number: 3 })).toBe(
       "https://github.com/o/r/discussions/3",
-    );
-    expect(__testing.buildHtmlUrl("commit", { kind: "sha", owner: "o", repo: "r", sha: "abcdef1" })).toBe(
-      "https://github.com/o/r/commit/abcdef1",
     );
   });
 });
@@ -83,7 +73,7 @@ describe("fetchEntityLiveFields", () => {
     );
   });
 
-  it("fetches issue state and commit title", async () => {
+  it("fetches issue state", async () => {
     const issueFetcher = vi.fn<typeof fetch>().mockResolvedValueOnce(jsonResponse({ title: "Bug", state: "closed" }));
     await expect(
       __testing.fetchEntityLiveFields(
@@ -93,18 +83,6 @@ describe("fetchEntityLiveFields", () => {
         issueFetcher,
       ),
     ).resolves.toEqual({ title: "Bug", state: "closed" });
-
-    const commitFetcher = vi
-      .fn<typeof fetch>()
-      .mockResolvedValueOnce(jsonResponse({ commit: { message: "Fix startup\n\nBody" } }));
-    await expect(
-      __testing.fetchEntityLiveFields(
-        "commit",
-        { kind: "sha", owner: "owner", repo: "repo", sha: "abcdef1" },
-        "token",
-        commitFetcher,
-      ),
-    ).resolves.toEqual({ title: "Fix startup", state: null });
   });
 
   it("returns empty live fields when fetch fails or entity type has no live endpoint", async () => {
@@ -192,7 +170,7 @@ describe("resolveChatGithubEntity", () => {
     });
   });
 
-  it("does not fetch live fields without a token", async () => {
+  it("filters legacy commit rows because commit is no longer a valid entity type", async () => {
     const fetcher = vi.fn<typeof fetch>();
 
     await expect(
@@ -201,15 +179,7 @@ describe("resolveChatGithubEntity", () => {
         null,
         fetcher,
       ),
-    ).resolves.toEqual({
-      entityType: "commit",
-      entityKey: "owner/repo@abcdef1",
-      boundVia: "agent_declared",
-      htmlUrl: "https://github.com/owner/repo/commit/abcdef1",
-      title: null,
-      state: null,
-      number: null,
-    });
+    ).resolves.toBeNull();
     expect(fetcher).not.toHaveBeenCalled();
   });
 

--- a/packages/server/src/__tests__/github-normalize.test.ts
+++ b/packages/server/src/__tests__/github-normalize.test.ts
@@ -356,7 +356,7 @@ describe("normalizeGithubEvent — issues", () => {
   });
 });
 
-describe("normalizeGithubEvent — discussion / discussion_comment / commit_comment", () => {
+describe("normalizeGithubEvent — discussion / discussion_comment", () => {
   it("discussion.created → kind=opened with body mentions", () => {
     const event = normalize("discussion", {
       action: "created",
@@ -387,24 +387,19 @@ describe("normalizeGithubEvent — discussion / discussion_comment / commit_comm
     expect(event?.kind).toBe("commented");
   });
 
-  it("commit_comment.created → entity is commit keyed on sha", () => {
-    const event = normalize("commit_comment", {
-      action: "created",
-      sender: senderUser,
-      repository,
-      comment: {
-        body: "nit",
-        commit_id: "abc1234",
-        html_url: "https://github.com/owner/repo/commit/abc1234#comment-1",
-      },
-    });
-    expect(event?.entity).toEqual({
-      type: "commit",
-      repo: "owner/repo",
-      key: "owner/repo@abc1234",
-      url: "https://github.com/owner/repo/commit/abc1234#comment-1",
-    });
-    expect(event?.kind).toBe("commit_commented");
+  it("commit_comment.created → null because commit entities are unsupported", () => {
+    expect(
+      normalize("commit_comment", {
+        action: "created",
+        sender: senderUser,
+        repository,
+        comment: {
+          body: "nit",
+          commit_id: "abc1234",
+          html_url: "https://github.com/owner/repo/commit/abc1234#comment-1",
+        },
+      }),
+    ).toBeNull();
   });
 });
 

--- a/packages/server/src/__tests__/me-chat-source-tags.test.ts
+++ b/packages/server/src/__tests__/me-chat-source-tags.test.ts
@@ -7,7 +7,7 @@
  *      values — `manual` / `github` / `agent` — by inspecting `chats.metadata`
  *      (no schema migration; the field already existed and was only
  *      written by the github-entity-chat path). Phase C collapsed the
- *      GitHub entity types (PR / Issue / Discussion / Commit) into a
+ *      GitHub entity types (PR / Issue / Discussion) into a
  *      single `github` origin; the per-entity granularity lives on
  *      `MeChatRow.entityType` (drives the leading icon, not the filter
  *      dimension).

--- a/packages/server/src/api/agent/chats.ts
+++ b/packages/server/src/api/agent/chats.ts
@@ -254,7 +254,7 @@ export async function agentChatRoutes(app: FastifyInstance): Promise<void> {
       await chatService.assertParticipant(app.db, request.params.chatId, identity.uuid);
       const entity = request.query.entity;
       if (!entity) {
-        throw new BadRequestError("Pass ?entity=<GitHub URL | owner/repo#N | owner/repo@sha> to unfollow.");
+        throw new BadRequestError("Pass ?entity=<GitHub PR/Issue/Discussion URL | owner/repo#N> to unfollow.");
       }
       return removeEntityFollow(app.db, { chatId: request.params.chatId, entity });
     },

--- a/packages/server/src/api/chats.ts
+++ b/packages/server/src/api/chats.ts
@@ -292,7 +292,7 @@ export async function chatRoutes(app: FastifyInstance): Promise<void> {
       const { chat } = await requireChatAccess(request, app.db);
       const entity = request.query.entity;
       if (!entity) {
-        throw new BadRequestError("Pass ?entity=<GitHub URL | owner/repo#N | owner/repo@sha> to unfollow.");
+        throw new BadRequestError("Pass ?entity=<GitHub PR/Issue/Discussion URL | owner/repo#N> to unfollow.");
       }
       return removeEntityFollow(app.db, { chatId: chat.id, entity });
     },

--- a/packages/server/src/api/webhooks/github-entity.ts
+++ b/packages/server/src/api/webhooks/github-entity.ts
@@ -7,7 +7,7 @@ import type { GithubEntityType } from "@first-tree/shared";
  */
 export type GithubEntity = {
   type: GithubEntityType;
-  /** Stable string id, e.g. `"owner/repo#42"` or `"owner/repo@<sha>"`. */
+  /** Stable string id, e.g. `"owner/repo#42"`. */
   key: string;
   /** Human label, e.g. `"Refactor inbox dispatcher"`. Optional — falls back to key. */
   title?: string;
@@ -40,12 +40,6 @@ export function readString(value: unknown): string | null {
  * Returns `null` when the event isn't a clustering candidate (event type
  * outside the §4.1 "core" list, malformed payload). Caller is expected to
  * skip such events.
- *
- * Notes
- * - `commit_comment` falls back to a `commit` entity keyed on `<repo>@<sha>`
- *   when no associated PR is in the payload — the design hedges on "optionally
- *   resolve to a PR", but doing so requires an extra GitHub API call which we
- *   defer to Phase 1+.
  */
 export function extractEventEntity(eventType: string, payload: unknown): GithubEntity | null {
   if (!isRecord(payload)) return null;
@@ -111,16 +105,6 @@ export function extractEventEntity(eventType: string, payload: unknown): GithubE
         key: `${repo}#${number}`,
         title: readString(disc?.title) ?? undefined,
         url: readString(disc?.html_url) ?? undefined,
-      };
-    }
-    case "commit_comment": {
-      const comment = isRecord(payload.comment) ? payload.comment : null;
-      const sha = readString(comment?.commit_id);
-      if (!sha) return null;
-      return {
-        type: "commit",
-        key: `${repo}@${sha}`,
-        url: readString(comment?.html_url) ?? undefined,
       };
     }
     default:
@@ -193,15 +177,12 @@ function baseTypePrefix(type: GithubEntity["type"]): string {
       return "PR";
     case "discussion":
       return "Discussion";
-    case "commit":
-      return "Commit";
   }
 }
 
 /**
  * Strip the leading `owner/` segment from an entity key so the chat title
- * stays compact. `owner/repo#42` → `repo#42`; `owner/repo@abc1234` →
- * `repo@abc1234`. The full `owner/repo#N` form is still used as the
+ * stays compact. `owner/repo#42` → `repo#42`. The full `owner/repo#N` form is still used as the
  * clustering primary key (`github_entity_chat_mappings.entity_key`); only the
  * display string is shortened.
  */

--- a/packages/server/src/services/github-entity-follow.ts
+++ b/packages/server/src/services/github-entity-follow.ts
@@ -50,10 +50,10 @@ const GITHUB_FETCH_TIMEOUT_MS = 5_000;
 // usually has one); short forms match the stored entity-key syntax.
 const URL_NUMERIC_RE =
   /^https?:\/\/(?:www\.)?github\.com\/([^/\s]+)\/([^/\s]+)\/(pull|issues|discussions)\/(\d+)(?:[/?#].*)?$/;
-const URL_COMMIT_RE =
+const UNSUPPORTED_URL_COMMIT_RE =
   /^https?:\/\/(?:www\.)?github\.com\/([^/\s]+)\/([^/\s]+)\/commit\/([0-9a-fA-F]{6,40})(?:[/?#].*)?$/;
 const SHORT_NUMERIC_RE = /^([^/\s]+)\/([^/\s#@]+)#(\d+)$/;
-const SHORT_COMMIT_RE = /^([^/\s]+)\/([^/\s#@]+)@([0-9a-fA-F]{6,40})$/;
+const UNSUPPORTED_SHORT_COMMIT_RE = /^([^/\s]+)\/([^/\s#@]+)@([0-9a-fA-F]{6,40})$/;
 
 const URL_PATH_TYPE: Record<string, GithubEntityType> = {
   pull: "pull_request",
@@ -61,16 +61,14 @@ const URL_PATH_TYPE: Record<string, GithubEntityType> = {
   discussions: "discussion",
 };
 
-export type EntityReference =
-  | {
-      kind: "numeric";
-      owner: string;
-      repo: string;
-      number: number;
-      /** Explicit type from a URL path; null for the short `owner/repo#N` form. */
-      explicitType: Exclude<GithubEntityType, "commit"> | null;
-    }
-  | { kind: "commit"; owner: string; repo: string; sha: string };
+export type EntityReference = {
+  kind: "numeric";
+  owner: string;
+  repo: string;
+  number: number;
+  /** Explicit type from a URL path; null for the short `owner/repo#N` form. */
+  explicitType: GithubEntityType | null;
+};
 
 /** Parse the raw `entity` argument. Returns null when no shape matches. */
 export function parseEntityReference(raw: string): EntityReference | null {
@@ -81,15 +79,8 @@ export function parseEntityReference(raw: string): EntityReference | null {
     const [, owner, repo, path, numberStr] = urlNumeric;
     if (!owner || !repo || !path || !numberStr) return null;
     const explicitType = URL_PATH_TYPE[path];
-    if (!explicitType || explicitType === "commit") return null;
+    if (!explicitType) return null;
     return { kind: "numeric", owner, repo, number: Number(numberStr), explicitType };
-  }
-
-  const urlCommit = URL_COMMIT_RE.exec(trimmed);
-  if (urlCommit) {
-    const [, owner, repo, sha] = urlCommit;
-    if (!owner || !repo || !sha) return null;
-    return { kind: "commit", owner, repo, sha: sha.toLowerCase() };
   }
 
   const shortNumeric = SHORT_NUMERIC_RE.exec(trimmed);
@@ -99,14 +90,12 @@ export function parseEntityReference(raw: string): EntityReference | null {
     return { kind: "numeric", owner, repo, number: Number(numberStr), explicitType: null };
   }
 
-  const shortCommit = SHORT_COMMIT_RE.exec(trimmed);
-  if (shortCommit) {
-    const [, owner, repo, sha] = shortCommit;
-    if (!owner || !repo || !sha) return null;
-    return { kind: "commit", owner, repo, sha: sha.toLowerCase() };
-  }
-
   return null;
+}
+
+function isUnsupportedCommitReference(raw: string): boolean {
+  const trimmed = raw.trim();
+  return UNSUPPORTED_URL_COMMIT_RE.test(trimmed) || UNSUPPORTED_SHORT_COMMIT_RE.test(trimmed);
 }
 
 /**
@@ -115,35 +104,33 @@ export function parseEntityReference(raw: string): EntityReference | null {
  * one copy.
  */
 function parseEntityReferenceOrThrow(raw: string): EntityReference {
+  if (isUnsupportedCommitReference(raw)) {
+    throw new BadRequestError(
+      "Commit references are no longer supported by `github follow` / `github unfollow`. " +
+        "Follow a pull request, issue, or discussion instead.",
+    );
+  }
   const ref = parseEntityReference(raw);
   if (!ref) {
     throw new BadRequestError(
       `Unrecognized entity reference "${raw}". Pass a GitHub URL ` +
-        `(https://github.com/owner/repo/pull/42), "owner/repo#42", or "owner/repo@<sha>".`,
+        `(https://github.com/owner/repo/pull/42), ` +
+        `(https://github.com/owner/repo/issues/42), ` +
+        `(https://github.com/owner/repo/discussions/42), or "owner/repo#42".`,
     );
   }
   return ref;
 }
 
-/**
- * Escape SQL LIKE metacharacters (`\`, `%`, `_`) in a literal that will be
- * embedded in a LIKE pattern. GitHub repo names legitimately contain `_`,
- * which LIKE would otherwise treat as match-any-one-char and over-delete
- * across sibling repos.
- */
-function escapeLikeLiteral(value: string): string {
-  return value.replaceAll("\\", "\\\\").replaceAll("%", "\\%").replaceAll("_", "\\_");
-}
-
 type ResolvedEntity = {
   entityType: GithubEntityType;
-  /** Canonical key — GitHub's `full_name` casing, full commit sha. */
+  /** Canonical key — GitHub's `full_name` casing plus entity number. */
   entityKey: string;
   htmlUrl: string;
   title: string | null;
   liveState: GithubEntityLiveState | null;
   entityState: EntityState;
-  /** Issue / PR / Discussion number; null for commits. Set where `entityKey` is built. */
+  /** Issue / PR / Discussion number. Set where `entityKey` is built. */
   number: number | null;
 };
 
@@ -219,30 +206,6 @@ async function resolveEntityOnGithub(
   // Canonical casing (and current name after a rename — the API follows the
   // redirect) so the written key always matches webhook-side keys. (R8)
   const fullName = readStr(repoRes.body.full_name) ?? `${ref.owner}/${ref.repo}`;
-
-  if (ref.kind === "commit") {
-    const res = await ghGet(`/repos/${fullName}/commits/${ref.sha}`, token, fetcher);
-    if (res.kind === "unavailable") return { ok: false, reason: "github-unavailable" };
-    if (res.kind !== "ok") return { ok: false, reason: "entity-not-found" };
-    const fullSha = readStr(res.body.sha) ?? ref.sha;
-    const commit =
-      typeof res.body.commit === "object" && res.body.commit !== null
-        ? (res.body.commit as Record<string, unknown>)
-        : null;
-    const message = readStr(commit?.message);
-    return {
-      ok: true,
-      entity: {
-        entityType: "commit",
-        entityKey: `${fullName}@${fullSha}`,
-        htmlUrl: readStr(res.body.html_url) ?? `https://github.com/${fullName}/commit/${fullSha}`,
-        title: message ? (message.split("\n", 1)[0]?.trim() ?? null) : null,
-        liveState: null,
-        entityState: "open",
-        number: null,
-      },
-    };
-  }
 
   if (ref.explicitType === "discussion") {
     return resolveDiscussion(fullName, ref.number, token, fetcher);
@@ -352,7 +315,7 @@ export type DeclareFollowParams = {
   humanAgentId: string;
   delegateAgentId: string;
   boundVia: DeclaredBoundVia;
-  /** Raw entity reference — URL, `owner/repo#N`, or `owner/repo@sha`. */
+  /** Raw entity reference — URL or `owner/repo#N`. */
   entity: string;
   rebind: boolean;
 };
@@ -547,8 +510,7 @@ export async function declareEntityFollow(
  * succeeds (R4: `removed: 0` is terminal success).
  *
  * Matching is case-insensitive on the key (GitHub repo slugs are
- * case-insensitive) and prefix-based for commit shas so a short sha
- * unfollows the full-sha row. A repo renamed since the row was written
+ * case-insensitive). A repo renamed since the row was written
  * cannot be matched without the API — that is the known whole-table key
  * drift limitation, out of scope here (R8 note).
  */
@@ -559,53 +521,35 @@ export async function removeEntityFollow(
   const ref = parseEntityReferenceOrThrow(params.entity);
 
   const chatCond = eq(githubEntityChatMappings.chatId, params.chatId);
-  let removedRows: Array<{ entityKey: string }>;
-  if (ref.kind === "commit") {
-    // Prefix match so a short sha unfollows the full-sha row; LIKE
-    // metacharacters in owner/repo (GitHub allows `_`) are escaped so the
-    // pattern can't over-match sibling repos.
-    const prefix = escapeLikeLiteral(`${ref.owner}/${ref.repo}@${ref.sha}`.toLowerCase());
-    removedRows = await db
-      .delete(githubEntityChatMappings)
-      .where(
-        and(
-          chatCond,
-          eq(githubEntityChatMappings.entityType, "commit"),
-          sql`lower(${githubEntityChatMappings.entityKey}) LIKE ${`${prefix}%`}`,
-        ),
-      )
-      .returning({ entityKey: githubEntityChatMappings.entityKey });
-  } else {
-    const key = `${ref.owner}/${ref.repo}#${ref.number}`.toLowerCase();
-    // Type matching without a GitHub call (unfollow must not depend on
-    // GitHub being up):
-    //   - Issues and PRs share one numbering space, and follow auto-corrects
-    //     a `/pull/N` URL that actually points at an issue (and vice versa)
-    //     — so an explicit issue/PR reference matches BOTH types, otherwise
-    //     the row created through the auto-corrected follow could never be
-    //     removed with the same reference the caller used to create it.
-    //   - Discussions number independently; an explicit `/discussions/N`
-    //     URL matches only discussions, and only the bare `owner/repo#N`
-    //     form sweeps all three ("make this chat quiet about #N").
-    const types: GithubEntityType[] =
-      ref.explicitType === "discussion"
-        ? ["discussion"]
-        : ref.explicitType !== null
-          ? ["issue", "pull_request"]
-          : ["issue", "pull_request", "discussion"];
-    const lowerKeys = new Set([key]);
-    if (types.includes("discussion")) {
-      const legacyKey = legacyDiscussionEntityKey(key);
-      if (legacyKey) lowerKeys.add(legacyKey);
-    }
-    const keyConditions = [...lowerKeys].map(
-      (lowerKey) => sql`lower(${githubEntityChatMappings.entityKey}) = ${lowerKey}`,
-    );
-    removedRows = await db
-      .delete(githubEntityChatMappings)
-      .where(and(chatCond, inArray(githubEntityChatMappings.entityType, types), or(...keyConditions)))
-      .returning({ entityKey: githubEntityChatMappings.entityKey });
+  const key = `${ref.owner}/${ref.repo}#${ref.number}`.toLowerCase();
+  // Type matching without a GitHub call (unfollow must not depend on
+  // GitHub being up):
+  //   - Issues and PRs share one numbering space, and follow auto-corrects
+  //     a `/pull/N` URL that actually points at an issue (and vice versa)
+  //     — so an explicit issue/PR reference matches BOTH types, otherwise
+  //     the row created through the auto-corrected follow could never be
+  //     removed with the same reference the caller used to create it.
+  //   - Discussions number independently; an explicit `/discussions/N`
+  //     URL matches only discussions, and only the bare `owner/repo#N`
+  //     form sweeps all three ("make this chat quiet about #N").
+  const types: GithubEntityType[] =
+    ref.explicitType === "discussion"
+      ? ["discussion"]
+      : ref.explicitType !== null
+        ? ["issue", "pull_request"]
+        : ["issue", "pull_request", "discussion"];
+  const lowerKeys = new Set([key]);
+  if (types.includes("discussion")) {
+    const legacyKey = legacyDiscussionEntityKey(key);
+    if (legacyKey) lowerKeys.add(legacyKey);
   }
+  const keyConditions = [...lowerKeys].map(
+    (lowerKey) => sql`lower(${githubEntityChatMappings.entityKey}) = ${lowerKey}`,
+  );
+  const removedRows = await db
+    .delete(githubEntityChatMappings)
+    .where(and(chatCond, inArray(githubEntityChatMappings.entityType, types), or(...keyConditions)))
+    .returning({ entityKey: githubEntityChatMappings.entityKey });
 
   if (removedRows.length > 0) {
     log.info({ chatId: params.chatId, entity: params.entity, removed: removedRows.length }, "github unfollow");

--- a/packages/server/src/services/github-entity-live.ts
+++ b/packages/server/src/services/github-entity-live.ts
@@ -19,28 +19,14 @@ const GITHUB_FETCH_TIMEOUT_MS = 4_000;
 const GITHUB_ENTITY_TYPE_SET = new Set<string>(GITHUB_ENTITY_TYPES);
 
 /**
- * Parsed `entityKey`. Two shapes:
- *
- *   - `owner/repo#42`      — issue / pull_request / discussion
- *   - `owner/repo@<sha>`   — commit
+ * Parsed `entityKey`: `owner/repo#42` for issue / pull_request / discussion.
  */
-type ParsedEntityKey =
-  | { kind: "numeric"; owner: string; repo: string; number: number }
-  | { kind: "sha"; owner: string; repo: string; sha: string }
-  | null;
+type ParsedEntityKey = { kind: "numeric"; owner: string; repo: string; number: number } | null;
 
 const NUMERIC_ENTITY_KEY = /^([^/\s]+)\/([^/\s#@]+)#(\d+)$/;
 const LEGACY_DISCUSSION_ENTITY_KEY = /^([^/\s]+)\/([^/\s#@]+)#discussion-(\d+)$/;
-const SHA_ENTITY_KEY = /^([^/\s]+)\/([^/\s#@]+)@([0-9a-f]{6,40})$/;
 
 function parseEntityKey(entityType: GithubEntityType, entityKey: string): ParsedEntityKey {
-  if (entityType === "commit") {
-    const m = SHA_ENTITY_KEY.exec(entityKey);
-    if (!m) return null;
-    const [, owner, repo, sha] = m;
-    if (!owner || !repo || !sha) return null;
-    return { kind: "sha", owner, repo, sha };
-  }
   if (entityType === "discussion") {
     const legacy = LEGACY_DISCUSSION_ENTITY_KEY.exec(entityKey);
     if (legacy) {
@@ -63,7 +49,6 @@ function parseEntityKey(entityType: GithubEntityType, entityKey: string): Parsed
  */
 function buildHtmlUrl(entityType: GithubEntityType, parsed: NonNullable<ParsedEntityKey>): string {
   const repoBase = `https://github.com/${parsed.owner}/${parsed.repo}`;
-  if (parsed.kind === "sha") return `${repoBase}/commit/${parsed.sha}`;
   switch (entityType) {
     case "pull_request":
       return `${repoBase}/pull/${parsed.number}`;
@@ -138,17 +123,6 @@ async function fetchEntityLiveFields(
       const state: GithubEntityLiveState | null = body.state === "open" || body.state === "closed" ? body.state : null;
       return { title: body.title ?? null, state };
     }
-    if (entityType === "commit" && parsed.kind === "sha") {
-      const res = await fetcher(
-        `${GITHUB_API_BASE}/repos/${parsed.owner}/${parsed.repo}/commits/${parsed.sha}`,
-        fetchOpts,
-      );
-      if (!res.ok) return { title: null, state: null };
-      const body = (await res.json()) as { commit?: { message?: string } };
-      // First line of the commit message is its de-facto title.
-      const title = body.commit?.message?.split("\n", 1)[0]?.trim() ?? null;
-      return { title, state: null };
-    }
     return { title: null, state: null };
   } catch {
     // Network errors, AbortController timeouts, and JSON parse errors all
@@ -188,7 +162,7 @@ function stateFromPersistedEntityState(
  * Materialise the wire-shape `ChatGithubEntity` for a single mapping row.
  *
  * `parsed` may be null when `entityKey` doesn't match the expected
- * `owner/repo#N` or `owner/repo@<sha>` shape; in that case the row is
+ * `owner/repo#N` shape; in that case the row is
  * dropped because the right rail cannot build a trustworthy GitHub link.
  * Title and lifecycle state come straight from the persisted projection
  * (`title` / `entity_state`), both webhook-synced; an empty title degrades

--- a/packages/server/src/services/github-normalize.ts
+++ b/packages/server/src/services/github-normalize.ts
@@ -66,8 +66,6 @@ function entitySurfacePrefix(entity: GithubEntity): string {
       return "Issue";
     case "discussion":
       return "Discussion";
-    case "commit":
-      return "Commit";
   }
 }
 
@@ -156,8 +154,6 @@ function buildRule(
       return buildDiscussionRule(action, payload);
     case "discussion_comment":
       return buildDiscussionCommentRule(action, payload);
-    case "commit_comment":
-      return buildCommitCommentRule(action, payload);
     default:
       return null;
   }
@@ -512,26 +508,6 @@ function buildDiscussionCommentRule(action: string | null, payload: Record<strin
     involves: buildInvolves([{ logins: extractMentions(body), reason: "mentioned" }]),
     surface: {
       title: entitySurfaceTitle(entity, number),
-      body,
-      url: readString(comment.html_url) ?? "",
-    },
-    relatedRefs: [],
-  };
-}
-
-function buildCommitCommentRule(action: string | null, payload: Record<string, unknown>): RuleOutcome | null {
-  if (action !== "created") return null;
-  const comment = isRecord(payload.comment) ? payload.comment : null;
-  if (!comment) return null;
-  const entity = extractEventEntity("commit_comment", payload);
-  if (!entity) return null;
-  const body = readString(comment.body) ?? "";
-  return {
-    entity,
-    kind: "commit_commented",
-    involves: buildInvolves([{ logins: extractMentions(body), reason: "mentioned" }]),
-    surface: {
-      title: entitySurfaceTitle(entity, null),
       body,
       url: readString(comment.html_url) ?? "",
     },

--- a/packages/server/src/services/me-chat.ts
+++ b/packages/server/src/services/me-chat.ts
@@ -157,7 +157,7 @@ export async function getCallerEngagement(
 // The conversation-list filter popover splits chats by coarse-grained
 // origin — Manual / GitHub / Agent (one per integration/workflow, not one
 // per entity type within an integration). The per-entity GitHub granularity
-// (PR / Issue / Discussion / Commit) is preserved on the row via the
+// (PR / Issue / Discussion) is preserved on the row via the
 // separate `entity_type` SELECT so the rail's leading icon can still
 // render the right glyph.
 //

--- a/packages/shared/src/schemas/chat-github-entities.ts
+++ b/packages/shared/src/schemas/chat-github-entities.ts
@@ -56,7 +56,7 @@ export type GithubEntityLiveState = z.infer<typeof githubEntityLiveStateSchema>;
 
 export const chatGithubEntitySchema = z.object({
   entityType: githubEntityTypeSchema,
-  /** Stable cluster key, e.g. "owner/repo#42" or "owner/repo@<sha>". */
+  /** Stable cluster key, e.g. "owner/repo#42". */
   entityKey: z.string().min(1),
   /** How the binding was first created — audit-only, surfaced by the UI as a small caption. */
   boundVia: githubEntityBoundViaSchema,
@@ -68,7 +68,7 @@ export const chatGithubEntitySchema = z.object({
   htmlUrl: z.string().url(),
   /** Persisted title projection when available; currently null for mapping-only rows. */
   title: z.string().nullable(),
-  /** Webhook-synced state projection. `null` for commits/discussions. */
+  /** Webhook-synced state projection. `null` for discussions. */
   state: githubEntityLiveStateSchema.nullable(),
   /** Issue / PR / Discussion number when applicable. */
   number: z.number().int().nullable(),
@@ -85,7 +85,7 @@ export type ChatGithubEntityListResponse = z.infer<typeof chatGithubEntityListRe
  *
  * `entity` accepts a full GitHub URL (`https://github.com/o/r/pull/42`),
  * the short numeric form (`owner/repo#42` — issue vs PR resolved against
- * the GitHub API), or the commit form (`owner/repo@<sha>`).
+ * the GitHub API, with discussion fallback).
  *
  * `rebind: true` MOVES the binding into the target chat when the same
  * (human, delegate) line already lives in another chat — the 409 outcome's

--- a/packages/shared/src/schemas/chat-metadata.ts
+++ b/packages/shared/src/schemas/chat-metadata.ts
@@ -20,14 +20,14 @@ import { z } from "zod";
  * `packages/web/src/components/chat/source-icon.tsx`; the SQL classifier
  * does not need to be touched.
  */
-export const GITHUB_ENTITY_TYPES = ["issue", "pull_request", "discussion", "commit"] as const;
+export const GITHUB_ENTITY_TYPES = ["issue", "pull_request", "discussion"] as const;
 export const githubEntityTypeSchema = z.enum(GITHUB_ENTITY_TYPES);
 export type GithubEntityType = z.infer<typeof githubEntityTypeSchema>;
 
 export const githubChatMetadataSchema = z.object({
   source: z.literal("github"),
   entityType: githubEntityTypeSchema,
-  /** Stable cluster key, e.g. "owner/repo#42" or "owner/repo@<sha>". */
+  /** Stable cluster key, e.g. "owner/repo#42". */
   entityKey: z.string().min(1),
   /** Optional canonical URL back to the GitHub entity (for UI deep-link). */
   entityUrl: z.string().url().optional(),
@@ -65,7 +65,7 @@ export type OptionalChatMetadata = z.infer<typeof optionalChatMetadataSchema>;
 /**
  * Conversation-list origin tag. Coarse-grained "where does this chat come
  * from" classifier — one per integration, NOT per entity type within an
- * integration. GitHub PR / Issue / Discussion / Commit all collapse to
+ * integration. GitHub PR / Issue / Discussion all collapse to
  * `github`; the per-entity granularity is preserved via the separate
  * `MeChatRow.entityType` field (so the row's leading icon can still
  * render a PR vs Issue glyph even though the filter popover only

--- a/packages/shared/src/schemas/me-chat.ts
+++ b/packages/shared/src/schemas/me-chat.ts
@@ -214,9 +214,9 @@ export const meChatRowSchema = z.object({
   source: chatSourceSchema.default("manual"),
   /**
    * Within-origin sub-type. Only meaningful when `source === "github"`,
-   * in which case it's one of `pull_request | issue | discussion | commit`
+   * in which case it's one of `pull_request | issue | discussion`
    * — drives the per-row leading icon so users still get a PR vs Issue
-   * vs Commit glyph even though the filter popover collapses every
+   * vs Discussion glyph even though the filter popover collapses every
    * GitHub entity into a single "GitHub" origin. Null for `manual` rows.
    *
    * Server projects this straight from `chats.metadata->>'entityType'`

--- a/packages/shared/src/schemas/normalized-event.ts
+++ b/packages/shared/src/schemas/normalized-event.ts
@@ -35,7 +35,6 @@ export const NORMALIZED_EVENT_KINDS = [
   "reviewed",
   "review_comment",
   "synchronized",
-  "commit_commented",
   "assigned",
   "other",
 ] as const;

--- a/packages/web/src/components/chat/__tests__/github-event-card.test.ts
+++ b/packages/web/src/components/chat/__tests__/github-event-card.test.ts
@@ -162,7 +162,7 @@ describe("isTrustedGithubDispatcherMessage", () => {
 /**
  * Server-side `entitySurfaceTitle` (services/github-normalize.ts) prefixes
  * the raw entity title with `"PR #N: "` / `"Issue #N: "` /
- * `"Discussion #N: "` / `"Commit: "`. The L1 chip already renders that
+ * `"Discussion #N: "`. The L1 chip already renders that
  * prefix as a badge, so the card strips it before showing the title. Pin
  * the stripping contract so a regression silently re-introduces the
  * "PR-NN: PR-NN: ..." visual duplication that motivated this change.
@@ -180,11 +180,6 @@ describe("stripEntityPrefix", () => {
     // entitySurfaceTitle returns just `"PR #N"` (no colon) when entity.title is empty.
     // The chip already shows it, so render-side returns "" to hide the title element.
     expect(stripEntityPrefix("PR #42", "pull_request", "#42")).toBe("");
-    expect(stripEntityPrefix("Commit", "commit", "@x")).toBe("");
-  });
-
-  it("strips Commit prefix (no number in surface title) for commits", () => {
-    expect(stripEntityPrefix("Commit: Fix typo in README", "commit", "@x")).toBe("Fix typo in README");
   });
 
   it("returns the title as-is when the prefix does not match (older messages / schema drift)", () => {
@@ -215,10 +210,6 @@ describe("shortEntityNumber", () => {
 
   it("collapses the legacy discussion-N infix so chip and surface title agree on #N", () => {
     expect(shortEntityNumber("owner/repo#discussion-9", "owner/repo")).toBe("#9");
-  });
-
-  it("keeps the full sha for commit keys (server commit title has no number)", () => {
-    expect(shortEntityNumber("owner/repo@abc", "owner/repo")).toBe("@abc");
   });
 });
 
@@ -251,7 +242,6 @@ describe("entity-key → strip integration (mirrors GithubEventCardMessage)", ()
       title: "Discussion #9: Legacy RFC draft",
       expected: "Legacy RFC draft",
     },
-    { type: "commit" as const, key: "owner/repo@abc", title: "Commit: Fix typo", expected: "Fix typo" },
   ];
 
   for (const c of cases) {

--- a/packages/web/src/components/chat/__tests__/github-event-card.test.tsx
+++ b/packages/web/src/components/chat/__tests__/github-event-card.test.tsx
@@ -95,7 +95,6 @@ describe("GitHub event card", () => {
       "reviewed",
       "review_comment",
       "synchronized",
-      "commit_commented",
       "assigned",
       "edited",
       "other",

--- a/packages/web/src/components/chat/github-event-card.tsx
+++ b/packages/web/src/components/chat/github-event-card.tsx
@@ -77,12 +77,11 @@ const ENTITY_TAG_LABEL: Record<GithubEntityType, string> = {
   issue: "Issue",
   pull_request: "PR",
   discussion: "Discussion",
-  commit: "Commit",
 };
 
 /**
  * `entity.key` arrives canonically as `owner/repo#N` (issue / PR /
- * discussion) or `owner/repo@<sha>` (commit). Older persisted discussion
+ * discussion). Older persisted discussion
  * cards may still carry `owner/repo#discussion-N`; collapse that legacy
  * infix so the chip and the surface-title-strip both reference the same
  * `#N` form that appears in the server-rendered title.
@@ -91,7 +90,7 @@ const ENTITY_TAG_LABEL: Record<GithubEntityType, string> = {
  */
 export function shortEntityNumber(key: string, repository: string): string {
   let tail: string;
-  if (repository && (key.startsWith(`${repository}#`) || key.startsWith(`${repository}@`))) {
+  if (repository && key.startsWith(`${repository}#`)) {
     tail = key.slice(repository.length);
   } else {
     const lastSlash = key.lastIndexOf("/");
@@ -109,7 +108,7 @@ function shortRepoName(repository: string): string {
 /**
  * Server-side `entitySurfaceTitle` (services/github-normalize.ts) wraps the
  * raw entity title as `"PR #N: <title>"` / `"Issue #N: <title>"` /
- * `"Discussion #N: <title>"` / `"Commit: <title>"`. The L1 chip already
+ * `"Discussion #N: <title>"`. The L1 chip already
  * renders that prefix as a colored badge, so leaving it inside the title
  * string duplicates information. Strip the exact prefix we expect from the
  * server formatter; if the title doesn't match (older messages, schema
@@ -117,11 +116,6 @@ function shortRepoName(repository: string): string {
  */
 export function stripEntityPrefix(title: string, entityType: GithubEntityType, entityNumber: string): string {
   const prefix = ENTITY_TAG_LABEL[entityType];
-  if (entityType === "commit") {
-    if (title.startsWith(`${prefix}: `)) return title.slice(prefix.length + 2);
-    if (title === prefix) return "";
-    return title;
-  }
   const head = `${prefix} ${entityNumber}`;
   if (title.startsWith(`${head}: `)) return title.slice(head.length + 2);
   if (title === head) return "";
@@ -148,8 +142,6 @@ function subscribedVerb(kind: GithubEventCard["kind"]): string {
       return "requested a review";
     case "synchronized":
       return "pushed new commits";
-    case "commit_commented":
-      return "commented on a commit";
     case "assigned":
       // Passive voice on the subscribed track avoids a semantic clash
       // with `actionVerb`'s "assigned this to you" (reason=assigned),

--- a/packages/web/src/components/chat/source-icon.tsx
+++ b/packages/web/src/components/chat/source-icon.tsx
@@ -1,7 +1,6 @@
 import type { ChatSource, GithubEntityType } from "@first-tree/shared";
 import {
   CircleDot,
-  GitCommit,
   Github,
   GitPullRequest,
   type LucideIcon,
@@ -41,7 +40,6 @@ const GITHUB_ENTITY_ICON_MAP: Record<GithubEntityType, LucideIcon> = {
   pull_request: GitPullRequest,
   issue: CircleDot,
   discussion: MessageCircle,
-  commit: GitCommit,
 };
 
 const SOURCE_LABEL_MAP: Record<ChatSource, string> = {
@@ -54,7 +52,6 @@ const GITHUB_ENTITY_LABEL_MAP: Record<GithubEntityType, string> = {
   pull_request: "Pull request",
   issue: "Issue",
   discussion: "Discussion",
-  commit: "Commit",
 };
 
 export function SourceIcon({

--- a/packages/web/src/pages/workspace/conversations/filter-popover.tsx
+++ b/packages/web/src/pages/workspace/conversations/filter-popover.tsx
@@ -5,7 +5,7 @@ import type { GroupMode } from "./group-rows.js";
 
 /**
  * Canonical order of origin filters shown in the popover. Phase C
- * collapsed the GitHub entity types (PR / Issue / Discussion / Commit)
+ * collapsed the GitHub entity types (PR / Issue / Discussion)
  * into a single `github` entry — the per-entity granularity lives on
  * `MeChatRow.entityType` and drives the row's leading icon, not a
  * separate filter dimension.

--- a/packages/web/src/pages/workspace/right-sidebar/__tests__/github-sort.test.ts
+++ b/packages/web/src/pages/workspace/right-sidebar/__tests__/github-sort.test.ts
@@ -15,19 +15,9 @@ function entity(entityType: GithubEntityType, key: string): ChatGithubEntity {
 }
 
 describe("sortEntitiesByType", () => {
-  it("clusters by type in PR → issue → discussion → commit order", () => {
-    const items = [
-      entity("issue", "i1"),
-      entity("commit", "c1"),
-      entity("pull_request", "p1"),
-      entity("discussion", "d1"),
-    ];
-    expect(sortEntitiesByType(items).map((e) => e.entityType)).toEqual([
-      "pull_request",
-      "issue",
-      "discussion",
-      "commit",
-    ]);
+  it("clusters by type in PR → issue → discussion order", () => {
+    const items = [entity("issue", "i1"), entity("pull_request", "p1"), entity("discussion", "d1")];
+    expect(sortEntitiesByType(items).map((e) => e.entityType)).toEqual(["pull_request", "issue", "discussion"]);
   });
 
   it("preserves server order within a type group (stable)", () => {

--- a/packages/web/src/pages/workspace/right-sidebar/github-section.tsx
+++ b/packages/web/src/pages/workspace/right-sidebar/github-section.tsx
@@ -1,6 +1,6 @@
 import type { ChatGithubEntity, GithubEntityLiveState, GithubEntityType } from "@first-tree/shared";
 import { useQuery } from "@tanstack/react-query";
-import { CircleDot, ExternalLink, GitCommit, GitMerge, GitPullRequest, MessageCircle } from "lucide-react";
+import { CircleDot, ExternalLink, GitMerge, GitPullRequest, MessageCircle } from "lucide-react";
 import { listChatGithubEntities } from "../../../api/chats.js";
 import { DenseBadge, type DenseBadgeTone } from "../../../components/ui/dense-badge.js";
 
@@ -23,7 +23,7 @@ export function useChatGithubEntities(chatId: string): { items: ChatGithubEntity
 }
 
 /**
- * GitHub section — lists every PR / Issue / Discussion / Commit bound to
+ * GitHub section — lists every PR / Issue / Discussion bound to
  * the current chat via `github_entity_chat_mappings`. State comes from the
  * server's webhook-synced projection; title may be null because the mapping
  * table does not persist titles, so rows degrade gracefully to link-only.
@@ -42,7 +42,7 @@ export function GitHubSection({ chatId }: { chatId: string }) {
   }
 
   // Group by type so same-kind entities cluster — PRs (the primary work
-  // artifact) first, then issues, discussions, commits. Type is conveyed by
+  // artifact) first, then issues and discussions. Type is conveyed by
   // the per-row icon alone (no subheaders).
   const sorted = sortEntitiesByType(items);
 
@@ -65,12 +65,11 @@ export function GitHubSection({ chatId }: { chatId: string }) {
   );
 }
 
-/** Group order for the GitHub list: PR → Issue → Discussion → Commit. */
+/** Group order for the GitHub list: PR → Issue → Discussion. */
 const TYPE_ORDER: Record<string, number> = {
   pull_request: 0,
   issue: 1,
   discussion: 2,
-  commit: 3,
 };
 
 function typeRank(type: GithubEntityType): number {
@@ -78,7 +77,7 @@ function typeRank(type: GithubEntityType): number {
 }
 
 /**
- * Cluster entities by type (PR → Issue → Discussion → Commit) without
+ * Cluster entities by type (PR → Issue → Discussion) without
  * subheaders — the per-row icon carries the type. `Array.prototype.sort` is
  * stable, so server order is preserved within each type group. Pure + exported
  * for unit testing (the panel itself needs live bindings to render).
@@ -177,8 +176,7 @@ function GitHubRow({ entity }: { entity: ChatGithubEntity }) {
 function iconForType(type: GithubEntityType, state: GithubEntityLiveState | null) {
   if (type === "pull_request") return state === "merged" ? GitMerge : GitPullRequest;
   if (type === "issue") return CircleDot;
-  if (type === "discussion") return MessageCircle;
-  return GitCommit;
+  return MessageCircle;
 }
 
 function iconColor(state: GithubEntityLiveState | null): string {


### PR DESCRIPTION
## Summary

Removes commit as a followable / resolvable GitHub entity type.

- drops `commit` from `GithubEntityType` and active entity parsing
- rejects commit URLs and `owner/repo@sha` references with a clear unsupported error
- removes commit webhook normalization, live-field fetching, UI affordances, docs, and fixtures
- keeps legacy commit mapping rows inert by filtering them out of materialized entity lists

Fixes agent-team-foundation/first-tree#1301.

## Context Tree

Companion Context Tree PR: https://github.com/agent-team-foundation/first-tree-context/pull/616

## Validation

- `pnpm test`
- `pnpm check && pnpm typecheck`
- `first-tree-staging tree verify` in the companion Context Tree worktree
- no remaining `/repos/.../commits/{sha}` entity-resolution path