### PR TITLE
[codex] Make tree setup recovery org-level

### DIFF
--- a/packages/server/src/__tests__/me-onboarding-kickoff.test.ts
+++ b/packages/server/src/__tests__/me-onboarding-kickoff.test.ts
@@ -406,6 +406,62 @@ describe("GET /me/onboarding/tree-setup-status", () => {
     });
   });
 
+  it("returns the same org-level recovery status for admins with different completion times", async () => {
+    const app = getApp();
+    const firstAdmin = await createTestAdmin(app);
+    const laterAdmin = await createTestAdmin(app);
+    expect(laterAdmin.organizationId).toBe(firstAdmin.organizationId);
+
+    await stampCompleted(app, firstAdmin, new Date("2026-06-23T10:00:00Z"));
+    await stampCompleted(app, laterAdmin, new Date("2026-06-23T11:00:00Z"));
+    await putTreeBinding(app, firstAdmin, new Date("2026-06-23T10:30:00Z"));
+
+    const first = await app.inject({
+      method: "GET",
+      url: `${TREE_STATUS_URL}?organizationId=${firstAdmin.organizationId}`,
+      headers: { authorization: `Bearer ${firstAdmin.accessToken}` },
+    });
+    const later = await app.inject({
+      method: "GET",
+      url: `${TREE_STATUS_URL}?organizationId=${firstAdmin.organizationId}`,
+      headers: { authorization: `Bearer ${laterAdmin.accessToken}` },
+    });
+
+    expect(first.statusCode).toBe(200);
+    expect(later.statusCode).toBe(200);
+    expect(first.json()).toEqual({
+      needsTreeSetup: true,
+      hasTreeBinding: true,
+      hasTreeSetupKickoff: false,
+    });
+    expect(later.json()).toEqual(first.json());
+  });
+
+  it("keeps org-level recovery stable when the earliest completed admin is no longer active admin", async () => {
+    const app = getApp();
+    const firstAdmin = await createTestAdmin(app);
+    const laterAdmin = await createTestAdmin(app);
+    expect(laterAdmin.organizationId).toBe(firstAdmin.organizationId);
+
+    await stampCompleted(app, firstAdmin, new Date("2026-06-23T10:00:00Z"));
+    await stampCompleted(app, laterAdmin, new Date("2026-06-23T11:00:00Z"));
+    await putTreeBinding(app, firstAdmin, new Date("2026-06-23T10:30:00Z"));
+    await app.db.update(members).set({ role: "member", status: "left" }).where(eq(members.id, firstAdmin.memberId));
+
+    const res = await app.inject({
+      method: "GET",
+      url: `${TREE_STATUS_URL}?organizationId=${firstAdmin.organizationId}`,
+      headers: { authorization: `Bearer ${laterAdmin.accessToken}` },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({
+      needsTreeSetup: true,
+      hasTreeBinding: true,
+      hasTreeSetupKickoff: false,
+    });
+  });
+
   it("does not offer recovery for an older adopted binding with no onboarding tree chat", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);

--- a/packages/server/src/api/me.ts
+++ b/packages/server/src/api/me.ts
@@ -9,7 +9,7 @@ import {
   updateMyProfileSchema,
 } from "@first-tree/shared";
 import { getChannelConfig } from "@first-tree/shared/channel";
-import { and, eq, isNull, ne } from "drizzle-orm";
+import { and, asc, eq, isNotNull, isNull, ne } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { z } from "zod";
 import { agents } from "../db/schema/agents.js";
@@ -253,10 +253,12 @@ export async function meRoutes(app: FastifyInstance): Promise<void> {
   /**
    * GET /me/onboarding/tree-setup-status — recovery probe for the standalone
    * `/build-tree` surface and Settings nav. A missing tree binding still needs
-   * setup. A binding created after the value-first work chat completed also
-   * needs setup until a tree kickoff bootstrap message exists; this covers the
-   * recoverable edge where Cloud wrote `context_tree` but the background tree
-   * kickoff failed before notifying the agent.
+   * setup. A binding created after the org's value-first work chat completed
+   * also needs setup until a tree kickoff bootstrap message exists; this covers
+   * the recoverable edge where Cloud wrote `context_tree` but the background
+   * tree kickoff failed before notifying the agent. The recovery decision is
+   * org-level: different admins in the same org must not see different setup
+   * debt just because their own onboarding completion timestamps differ.
    */
   app.get("/me/onboarding/tree-setup-status", async (request) => {
     const { userId } = requireUser(request);
@@ -266,14 +268,13 @@ export async function meRoutes(app: FastifyInstance): Promise<void> {
       .select({
         organizationId: members.organizationId,
         role: members.role,
-        onboardingCompletedAt: members.onboardingCompletedAt,
       })
       .from(members)
       .where(eq(members.id, memberId))
       .limit(1);
     if (!member) throw new NotFoundError("Membership not found");
 
-    if (member.role !== "admin" || member.onboardingCompletedAt === null) {
+    if (member.role !== "admin") {
       return {
         needsTreeSetup: false,
         hasTreeBinding: false,
@@ -284,11 +285,21 @@ export async function meRoutes(app: FastifyInstance): Promise<void> {
     const tree = await getOrgContextTreeWithMeta(app.db, member.organizationId);
     const hasTreeBinding = !!tree.repo;
     const hasTreeSetupKickoff = await hasTreeSetupKickoffMessage(app.db, member.organizationId);
-    const bindingCreatedAfterCompletion =
-      hasTreeBinding && tree.updatedAt !== null && tree.updatedAt >= member.onboardingCompletedAt;
+    const [firstCompletedMembership] = await app.db
+      .select({ onboardingCompletedAt: members.onboardingCompletedAt })
+      .from(members)
+      .where(and(eq(members.organizationId, member.organizationId), isNotNull(members.onboardingCompletedAt)))
+      .orderBy(asc(members.onboardingCompletedAt))
+      .limit(1);
+    const orgOnboardingCompletedAt = firstCompletedMembership?.onboardingCompletedAt ?? null;
+    const bindingCreatedAfterOrgCompletion =
+      hasTreeBinding &&
+      tree.updatedAt !== null &&
+      orgOnboardingCompletedAt !== null &&
+      tree.updatedAt >= orgOnboardingCompletedAt;
 
     return {
-      needsTreeSetup: !hasTreeBinding || (bindingCreatedAfterCompletion && !hasTreeSetupKickoff),
+      needsTreeSetup: !hasTreeBinding || (bindingCreatedAfterOrgCompletion && !hasTreeSetupKickoff),
       hasTreeBinding,
       hasTreeSetupKickoff,
     };


### PR DESCRIPTION
## Summary

- Make `/me/onboarding/tree-setup-status` compute recovery debt from org-level onboarding history rather than the currently signed-in admin.
- Keep current admin authorization for showing the recovery action, while making `needsTreeSetup` stable across admins in the same org.
- Add regression coverage for admins with different completion times and for the earliest completed admin later leaving or losing admin role.

## Why

The Context page recovery banner was inconsistent between admins because the endpoint compared the tree binding update time against the current admin's `members.onboarding_completed_at`. Tree setup recovery is a team/org state, so all admins in the selected org should see the same recovery debt.

## Context Tree

Companion Context Tree PR: https://github.com/agent-team-foundation/first-tree-context/pull/617

## Validation

- `pnpm --filter @first-tree/server test src/__tests__/me-onboarding-kickoff.test.ts` (11/11 passed)
- `pnpm --filter @first-tree/server typecheck`
- `pnpm exec biome check packages/server/src/api/me.ts packages/server/src/__tests__/me-onboarding-kickoff.test.ts`