### PR TITLE
fix: stop iOS Safari auto-zoom on mobile inputs (16px floor)

### DIFF
--- a/packages/web/src/components/chat/ask-takeover.tsx
+++ b/packages/web/src/components/chat/ask-takeover.tsx
@@ -271,10 +271,10 @@ export function AskTakeover({
     padding: "var(--sp-2_5) var(--sp-3)",
     lineHeight: 1.5,
     fontFamily: "inherit",
-    // The textarea inherits the 13px body size at rest, but the mobile zoom
-    // guard (index.css) lifts form controls to 16px on phone widths. The mirror
-    // is a <div>, so it isn't caught by that rule — read the same var so its
-    // glyphs stay aligned with the textarea at both sizes.
+    // The textarea inherits the resting body size, but the mobile zoom guard
+    // (index.css) raises form controls to the iOS no-zoom floor on phone
+    // widths. The mirror is a <div>, so it isn't caught by that rule — read the
+    // same var so its glyphs stay aligned with the textarea at both sizes.
     fontSize: "var(--composer-font-size)",
     boxSizing: "border-box" as const,
   };

--- a/packages/web/src/components/chat/ask-takeover.tsx
+++ b/packages/web/src/components/chat/ask-takeover.tsx
@@ -271,6 +271,11 @@ export function AskTakeover({
     padding: "var(--sp-2_5) var(--sp-3)",
     lineHeight: 1.5,
     fontFamily: "inherit",
+    // The textarea inherits the 13px body size at rest, but the mobile zoom
+    // guard (index.css) lifts form controls to 16px on phone widths. The mirror
+    // is a <div>, so it isn't caught by that rule — read the same var so its
+    // glyphs stay aligned with the textarea at both sizes.
+    fontSize: "var(--composer-font-size)",
     boxSizing: "border-box" as const,
   };
 

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -1983,3 +1983,38 @@ body:has(#onboarding-preview-root) hearback-widget {
   padding: var(--sp-2) var(--sp-2_5);
   text-transform: uppercase;
 }
+
+/* ============================================================================
+   Mobile form-control zoom guard
+   ----------------------------------------------------------------------------
+   iOS Safari auto-zooms the viewport when a focused <input>/<textarea>/<select>
+   resolves to a font-size below 16px. Our dense type scale puts most controls
+   at 12–13px (text-body / text-subtitle), so every tap on the composer zoomed
+   the page. On phone-width viewports, raise every form control to the 16px
+   threshold so focusing one never triggers the zoom.
+
+   This rule is intentionally UNLAYERED: it sits outside Tailwind's
+   `@layer utilities`, so it beats the inlined `.text-body` / `.text-subtitle`
+   font-size utilities (cascade layers lose to unlayered rules) without needing
+   `!important`.
+
+   The composer / new-chat / ask-takeover surfaces paint a mention-highlight
+   *mirror* layer (a sibling <div>, not a form control) that must stay
+   glyph-aligned with its textarea. The rule above can't reach those divs, so
+   each mirror reads `--composer-font-size` instead — defined here as the
+   resting subtitle size and bumped to the same 16px under the SAME breakpoint,
+   so textarea and mirror flip together and never drift. */
+:root {
+  --composer-font-size: var(--text-subtitle);
+}
+
+@media (max-width: 47.999rem) {
+  input,
+  textarea,
+  select {
+    font-size: 16px;
+  }
+  :root {
+    --composer-font-size: 16px;
+  }
+}

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -3600,7 +3600,10 @@ export function ChatView({
                           chipClassName="mention-text"
                           mirrorStyle={{
                             padding: "var(--sp-2_25) var(--sp-3) var(--sp-7_5)",
-                            fontSize: "var(--text-subtitle)",
+                            // Tracks the textarea, which the mobile zoom guard
+                            // (index.css) lifts to 16px on phone widths; reading
+                            // the same var keeps mirror glyphs aligned there.
+                            fontSize: "var(--composer-font-size)",
                             lineHeight: "var(--text-subtitle--line-height)",
                             letterSpacing: "var(--text-subtitle--letter-spacing)",
                             // Textarea is `font-normal` (400) which overrides

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -3601,8 +3601,9 @@ export function ChatView({
                           mirrorStyle={{
                             padding: "var(--sp-2_25) var(--sp-3) var(--sp-7_5)",
                             // Tracks the textarea, which the mobile zoom guard
-                            // (index.css) lifts to 16px on phone widths; reading
-                            // the same var keeps mirror glyphs aligned there.
+                            // (index.css) raises to the iOS no-zoom floor on
+                            // phone widths; reading the same var keeps mirror
+                            // glyphs aligned there.
                             fontSize: "var(--composer-font-size)",
                             lineHeight: "var(--text-subtitle--line-height)",
                             letterSpacing: "var(--text-subtitle--letter-spacing)",

--- a/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
+++ b/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
@@ -687,8 +687,9 @@ export function NewChatDraft({
                     padding: "var(--sp-2) var(--sp-3)",
                     margin: 0,
                     // Tracks the textarea, which the mobile zoom guard
-                    // (index.css) lifts to 16px on phone widths; reading the
-                    // same var keeps this ghost hint aligned with typed text.
+                    // (index.css) raises to the iOS no-zoom floor on phone
+                    // widths; reading the same var keeps this ghost hint
+                    // aligned with typed text.
                     fontSize: "var(--composer-font-size)",
                     whiteSpace: "pre-wrap",
                     wordBreak: "break-word",

--- a/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
+++ b/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
@@ -686,6 +686,10 @@ export function NewChatDraft({
                     inset: 0,
                     padding: "var(--sp-2) var(--sp-3)",
                     margin: 0,
+                    // Tracks the textarea, which the mobile zoom guard
+                    // (index.css) lifts to 16px on phone widths; reading the
+                    // same var keeps this ghost hint aligned with typed text.
+                    fontSize: "var(--composer-font-size)",
                     whiteSpace: "pre-wrap",
                     wordBreak: "break-word",
                     pointerEvents: "none",


### PR DESCRIPTION
## What

On mobile (cloud.first-tree.ai), focusing any input/textarea auto-zoomed the page — most visibly the chat composer. iOS Safari does this whenever a **focused form control resolves below 16px** font-size. Our dense type scale puts most controls at 12–13px (`text-body` / `text-subtitle`), so every tap triggered the zoom.

## Fix

`packages/web/src/index.css` — an **unlayered** mobile media query (`max-width: 47.999rem`, the app's existing phone breakpoint) raising every `input`/`textarea`/`select` to `16px`:

```css
@media (max-width: 47.999rem) {
  input, textarea, select { font-size: 16px; }
  :root { --composer-font-size: 16px; }
}
```

Being **unlayered**, it beats Tailwind v4's `@theme inline`-generated `.text-body` / `.text-subtitle` font-size utilities (cascade layers lose to unlayered rules) **without `!important`**.

### Keeping mention mirrors aligned

The composer (`chat-view`), new-chat draft, and ask-takeover answer box each paint a mention-highlight / ghost **mirror layer** — a sibling `<div>`, not a form control — that must stay glyph-aligned with its textarea. The element rule can't reach those divs, so each mirror now reads a new `--composer-font-size` var (resting `var(--text-subtitle)` → `16px` under the **same** breakpoint). Textarea and mirror flip together, so chips/ghost text never drift at either size.

Vertical/horizontal alignment holds because both sides already share the same unitless `line-height` (1.35 / 1.5) and `letter-spacing`, which scale with the new font-size.

## Scope

- `index.css` — mobile zoom-guard rule + `--composer-font-size` token
- `chat-view.tsx`, `new-chat-draft.tsx`, `ask-takeover.tsx` — point each mirror's font-size at the shared var

Pure presentational change; no logic touched. Desktop is unaffected (rule is mobile-only).

## Verification

- Biome `check` clean on all 4 files (no new warnings).
- Type-safe: only string-valued `fontSize` added to existing `CSSProperties` objects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)