### PR TITLE
[codex] Remove Context tab setup recovery card

### DIFF
--- a/packages/web/src/pages/__tests__/context-page-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/context-page-dom.test.tsx
@@ -602,7 +602,7 @@ describe("ContextPage DOM behavior", () => {
     await act(async () => root.unmount());
   });
 
-  it("recovers a bound tree whose setup kickoff was never sent", async () => {
+  it("does not show setup recovery on a live tree even when setup kickoff was never sent", async () => {
     authMock.value = { organizationId: "org-1", role: "admin" };
     onboardingEventMocks.getTreeSetupStatus.mockResolvedValueOnce({
       needsTreeSetup: true,
@@ -636,19 +636,53 @@ describe("ContextPage DOM behavior", () => {
     );
 
     const { container, root } = await renderDom(<ContextPage />);
-    await waitForText(container, "Finish Context Tree setup");
-    await click(buttonByText(container, "Build your Context Tree"));
+    await waitForText(container, "LIVE");
+    expect(container.textContent).not.toContain("Finish Context Tree setup");
+    expect(container.textContent).not.toContain("Build your Context Tree");
+    expect(onboardingEventMocks.kickoffOnboarding).not.toHaveBeenCalled();
 
-    expect(contextApiMocks.initializeContextTree).not.toHaveBeenCalled();
-    expect(onboardingEventMocks.kickoffOnboarding).toHaveBeenCalledWith(
-      expect.objectContaining({
-        agentUuid: "agent-1",
-        bootstrap: expect.stringContaining("This chat sets up team context for future agent work."),
-        kind: "tree",
-        complete: true,
+    await act(async () => root.unmount());
+  });
+
+  it("does not show setup recovery on a bootstrap-only live tree", async () => {
+    authMock.value = { organizationId: "org-1", role: "admin" };
+    onboardingEventMocks.getTreeSetupStatus.mockResolvedValueOnce({
+      needsTreeSetup: true,
+      hasTreeBinding: true,
+      hasTreeSetupKickoff: false,
+    });
+    const { ContextPage } = await import("../context.js");
+    contextApiMocks.getContextTreeSnapshot.mockResolvedValue(
+      snapshot({
+        repo: "https://github.com/acme/context-tree",
+        branch: "main",
+        snapshotStatus: "active",
+        contextStatus: { label: "Live", detail: null, severity: "ok" },
+        nodes: [
+          {
+            id: "root",
+            parentId: null,
+            path: "",
+            sourcePath: "NODE.md",
+            title: "Context Tree",
+            kind: "root",
+            owners: [],
+            preview: null,
+            relatedNodeIds: [],
+            affectedContextArea: "root",
+            changeType: null,
+            changedAtCommit: null,
+          },
+        ],
+        edges: [],
       }),
     );
-    expect(container.querySelector('[data-testid="location"]')?.textContent).toBe("/?c=chat-tree-setup");
+
+    const { container, root } = await renderDom(<ContextPage />);
+    await waitForText(container, "LIVE");
+    expect(container.textContent).not.toContain("Finish Context Tree setup");
+    expect(container.textContent).not.toContain("Build your Context Tree");
+    expect(onboardingEventMocks.kickoffOnboarding).not.toHaveBeenCalled();
 
     await act(async () => root.unmount());
   });

--- a/packages/web/src/pages/context.tsx
+++ b/packages/web/src/pages/context.tsx
@@ -11,7 +11,6 @@ import { AlertTriangle, Network, RefreshCw } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router";
 import { getContextTreeSnapshot } from "../api/context-tree.js";
-import { getTreeSetupStatus } from "../api/onboarding-events.js";
 import { useAuth } from "../auth/auth-context.js";
 import { resolveAvatarHue } from "../components/chat/chat-row-avatar.js";
 import { Identicon } from "../components/identicon.js";
@@ -43,18 +42,7 @@ export function ContextPage({ previewSnapshot }: { previewSnapshot?: ContextTree
     refetchIntervalInBackground: false,
   });
 
-  const treeSetupQuery = useQuery({
-    queryKey: ["me", "onboarding", "tree-setup-status", organizationId],
-    queryFn: () => {
-      if (!organizationId) throw new Error("No organization selected");
-      return getTreeSetupStatus(organizationId);
-    },
-    enabled: !preview && !!organizationId && isAdmin,
-  });
-
   const snapshot = previewSnapshot ?? query.data;
-  const treeSetupStatus = treeSetupQuery.data;
-  const needsTreeSetup = !preview && isAdmin && (treeSetupStatus?.needsTreeSetup ?? false);
   const selectedUpdate = useMemo(() => {
     if (!snapshot) return null;
     return snapshot.updates.find((update) => update.id === selectedUpdateId) ?? snapshot.updates[0] ?? null;
@@ -86,13 +74,10 @@ export function ContextPage({ previewSnapshot }: { previewSnapshot?: ContextTree
             <UnavailableState
               snapshot={snapshot}
               isAdmin={isAdmin}
-              canInitialize={!preview && isAdmin && (needsTreeSetup || !snapshot.repo)}
+              canInitialize={!preview && isAdmin && !snapshot.repo}
             />
           ) : (
             <>
-              {needsTreeSetup ? (
-                <ContextTreeSetupRecovery repo={snapshot.repo} hasTreeBinding={!!treeSetupStatus?.hasTreeBinding} />
-              ) : null}
               <ContextStatusNote snapshot={snapshot} />
               <ChangeMap
                 snapshot={snapshot}
@@ -109,27 +94,6 @@ export function ContextPage({ previewSnapshot }: { previewSnapshot?: ContextTree
         ) : null}
       </div>
     </>
-  );
-}
-
-function ContextTreeSetupRecovery({ repo, hasTreeBinding }: { repo: string | null; hasTreeBinding: boolean }) {
-  return (
-    <Panel>
-      <PanelBody className="flex flex-col" style={{ gap: "var(--sp-3)" }}>
-        <div className="flex flex-col" style={{ gap: "var(--sp-1)" }}>
-          <span className="text-subtitle" style={{ color: "var(--fg)" }}>
-            Finish Context Tree setup
-          </span>
-          <span className="text-body" style={{ color: "var(--fg-3)" }}>
-            Your team has a Context Tree binding, but the setup chat still needs to start.
-          </span>
-        </div>
-        <ContextTreeBuildEntry
-          treeBindingPlan={hasTreeBinding ? "useBoundTree" : "createBinding"}
-          detectedTreeUrl={repo}
-        />
-      </PanelBody>
-    </Panel>
   );
 }
 


### PR DESCRIPTION
## Summary

- Remove the bound-tree setup recovery card from the Context tab.
- Stop querying `/me/onboarding/tree-setup-status` from the Context page.
- Keep the no-binding unavailable setup entry intact.

## Root Cause

The previous org-level recovery fix made `/me/onboarding/tree-setup-status` stable across admins, but the Context tab still rendered that recovery debt above an active live snapshot. A missing historical tree kickoff message is not proof that a synced bound tree needs setup.

## Context Tree

Companion Context Tree PR: https://github.com/agent-team-foundation/first-tree-context/pull/620

## Validation

- `pnpm --filter @first-tree/web test src/pages/__tests__/context-page-dom.test.tsx` (12/12 passed)
- `pnpm --filter @first-tree/web typecheck`
- `pnpm exec biome check packages/web/src/pages/context.tsx packages/web/src/pages/__tests__/context-page-dom.test.tsx`