### PR TITLE
fix(web): drop misleading 'system CLI fallback' runtime-state copy

### DIFF
--- a/packages/web/src/pages/clients/__tests__/runtime-state-line.test.tsx
+++ b/packages/web/src/pages/clients/__tests__/runtime-state-line.test.tsx
@@ -33,7 +33,7 @@ afterEach(async () => {
 });
 
 describe("RuntimeStateLine", () => {
-  it("shows when Codex is running through the system CLI fallback", async () => {
+  it("shows a system-PATH codex as plainly installed (no `fallback` copy)", async () => {
     const entry: CapabilityEntry = {
       available: true,
       state: "ok",
@@ -45,8 +45,10 @@ describe("RuntimeStateLine", () => {
 
     const dom = await render(<RuntimeStateLine provider="codex" entry={entry} os="darwin" />);
 
+    // Under install-only, a system `codex` on PATH is the normal case, not a
+    // "fallback" — the state line just reads "installed".
     expect(dom.textContent).toContain("Codex installed v0.139.0");
-    expect(dom.textContent).toContain("system CLI fallback");
+    expect(dom.textContent).not.toContain("fallback");
   });
 
   // Dropped "drops the manual login hint for an in-product provider (codex)":

--- a/packages/web/src/pages/clients/cards/shared/runtime-state-line.tsx
+++ b/packages/web/src/pages/clients/cards/shared/runtime-state-line.tsx
@@ -25,14 +25,15 @@ export function RuntimeStateLine({
   os?: string | null;
 }) {
   const label = PROVIDER_LABEL[provider];
-  const runtimeSuffix = entry.runtimeSource === "path" ? " · system CLI fallback" : "";
   switch (entry.state) {
     case "ok":
+      // Install-only detection: a system `claude`/`codex` resolved on PATH is the
+      // normal case (both engines are external by default), not a "fallback", so
+      // the `runtimeSource` provenance is no longer surfaced as UI copy here.
       return (
         <div className="text-body" style={{ color: "var(--fg-2)" }}>
           <span style={{ color: "var(--success)" }}>✓</span> {label} installed
           {entry.sdkVersion ? ` v${entry.sdkVersion}` : ""}
-          {runtimeSuffix}
         </div>
       );
     case "missing":


### PR DESCRIPTION
Under install-only detection both runtime engines are external by default, so a system `claude`/`codex` resolved on PATH (`runtimeSource: "path"`) is the **normal** case — calling it a "fallback" in the UI is misleading. The runtime state line now reads plainly `<provider> installed [vX]`; the `runtimeSource` provenance is still carried on the capability entry for diagnostics (`daemon doctor`, API).

- `runtime-state-line.tsx`: removed the ` · system CLI fallback` suffix.
- test updated: a system-PATH codex now asserts plain "installed" and `not.toContain("fallback")`.

Web suite green (1027), typecheck + Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)