### PR TITLE
feat: add --message-file to chat send/ask for shell-safe bodies

### DIFF
--- a/apps/cli/src/__tests__/chat-send-message-file.test.ts
+++ b/apps/cli/src/__tests__/chat-send-message-file.test.ts
@@ -1,0 +1,172 @@
+import { EventEmitter } from "node:events";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const localAgentMocks = vi.hoisted(() => ({
+  createSdk: vi.fn(),
+  handleSdkError: vi.fn((error: unknown) => {
+    throw error;
+  }),
+}));
+
+const docCaptureMock = vi.hoisted(() => ({
+  captureOutboundDocs: vi.fn(),
+}));
+
+const outputMocks = vi.hoisted(() => ({
+  fail: vi.fn((code: string, message: string, exitCode = 1) => {
+    throw Object.assign(new Error(message), { code, exitCode });
+  }),
+  success: vi.fn(),
+}));
+
+vi.mock("../commands/_shared/local-agent.js", () => localAgentMocks);
+vi.mock("../core/doc-capture.js", () => docCaptureMock);
+vi.mock("../cli/output.js", () => outputMocks);
+
+const originalChatId = process.env.FIRST_TREE_CHAT_ID;
+const originalStdinDescriptor = Object.getOwnPropertyDescriptor(process, "stdin");
+
+/** Stdin stand-in that replays its body once `readStdin` attaches `end`. */
+class MockStdin extends EventEmitter {
+  isTTY = false;
+  destroy = vi.fn();
+
+  constructor(private readonly body: string) {
+    super();
+  }
+
+  override on(event: string, listener: (...args: unknown[]) => void): this {
+    super.on(event, listener);
+    if (event === "end") {
+      queueMicrotask(() => {
+        this.emit("data", Buffer.from(this.body, "utf-8"));
+        this.emit("end");
+      });
+    }
+    return this;
+  }
+}
+
+function setProcessStdin(stdin: unknown): void {
+  Object.defineProperty(process, "stdin", { configurable: true, value: stdin });
+}
+
+async function runChat(kind: "send" | "ask", args: string[]): Promise<void> {
+  const { registerChatCommands } = await import("../commands/chat/index.js");
+  const program = new Command();
+  program.exitOverride();
+  program.configureOutput({ writeErr: () => undefined, writeOut: () => undefined });
+  registerChatCommands(program);
+  await program.parseAsync(["node", "test", "chat", kind, ...args]);
+}
+
+/**
+ * Pins the `--message-file` / `-F` path for `chat send` and `chat ask`. This is
+ * the shell-safe body channel: the content is read from a file (or stdin) and
+ * reaches the server byte-for-byte, so backticks, quotes, apostrophes, and
+ * newlines that an inline shell argument would mangle survive intact.
+ */
+describe("chat send/ask --message-file", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.FIRST_TREE_CHAT_ID = "chat-env";
+    dir = mkdtempSync(join(tmpdir(), "ft-msgfile-"));
+    docCaptureMock.captureOutboundDocs.mockImplementation(async (content: string) => ({ content }));
+    localAgentMocks.createSdk.mockReturnValue({
+      sendMessage: vi.fn(async () => ({ id: "msg-1" })),
+    });
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    if (originalChatId === undefined) {
+      delete process.env.FIRST_TREE_CHAT_ID;
+    } else {
+      process.env.FIRST_TREE_CHAT_ID = originalChatId;
+    }
+    if (originalStdinDescriptor) {
+      Object.defineProperty(process, "stdin", originalStdinDescriptor);
+    }
+  });
+
+  it("sends a file body verbatim — backticks, quotes, apostrophes, newlines all survive", async () => {
+    // Exactly the shape the shell would mangle inline: backticks become command
+    // substitution, double quotes terminate the arg, apostrophes break a
+    // single-quoted retry.
+    const body = 'status: ran `git pull` then `pnpm build`.\n\nIt\'s a "clean" pass — see `explores/[id]`.';
+    const path = join(dir, "reply.md");
+    writeFileSync(path, body);
+
+    await runChat("send", ["code-agent", "-f", "markdown", "--message-file", path]);
+
+    const sdk = localAgentMocks.createSdk.mock.results.at(-1)?.value;
+    expect(sdk.sendMessage).toHaveBeenCalledWith(
+      "chat-env",
+      expect.objectContaining({ content: body, format: "markdown" }),
+    );
+    expect(outputMocks.success).toHaveBeenCalledWith({ id: "msg-1" });
+  });
+
+  it("`-F -` reads the body from stdin", async () => {
+    const body = 'piped `code` and "quotes" intact';
+    setProcessStdin(new MockStdin(body));
+
+    await runChat("send", ["code-agent", "-F", "-"]);
+
+    const sdk = localAgentMocks.createSdk.mock.results.at(-1)?.value;
+    expect(sdk.sendMessage).toHaveBeenCalledWith("chat-env", expect.objectContaining({ content: body }));
+  });
+
+  it("rejects a missing file (exit 2, nothing sent)", async () => {
+    await expect(runChat("send", ["code-agent", "--message-file", join(dir, "nope.md")])).rejects.toMatchObject({
+      code: "MESSAGE_FILE_NOT_FOUND",
+      exitCode: 2,
+    });
+    expect(outputMocks.success).not.toHaveBeenCalled();
+  });
+
+  it("rejects combining an inline body with --message-file", async () => {
+    const path = join(dir, "reply.md");
+    writeFileSync(path, "body");
+
+    await expect(runChat("send", ["code-agent", "inline body", "--message-file", path])).rejects.toMatchObject({
+      code: "CONFLICTING_ARGS",
+      exitCode: 2,
+    });
+    expect(outputMocks.success).not.toHaveBeenCalled();
+  });
+
+  it("does NOT run the escaped-newline guard on a file body (a file may hold literal \\n)", async () => {
+    // Inline, this exact string is rejected (ESCAPED_NEWLINES). From a file it
+    // is a legitimate body and must pass through untouched.
+    const body = "line1\\n\\n**title**\\nline3";
+    const path = join(dir, "literal.md");
+    writeFileSync(path, body);
+
+    await runChat("send", ["code-agent", "-f", "markdown", "--message-file", path]);
+
+    const sdk = localAgentMocks.createSdk.mock.results.at(-1)?.value;
+    expect(sdk.sendMessage).toHaveBeenCalledWith("chat-env", expect.objectContaining({ content: body }));
+  });
+
+  it("chat ask also accepts --message-file", async () => {
+    const body = "Background: `migration 0021` drops a column.\n\nShip it?";
+    const path = join(dir, "ask.md");
+    writeFileSync(path, body);
+
+    await runChat("ask", ["alice", "--message-file", path]);
+
+    const sdk = localAgentMocks.createSdk.mock.results.at(-1)?.value;
+    expect(sdk.sendMessage).toHaveBeenCalledWith(
+      "chat-env",
+      expect.objectContaining({ content: body, format: "request" }),
+    );
+  });
+});

--- a/apps/cli/src/__tests__/chat-send-message-file.test.ts
+++ b/apps/cli/src/__tests__/chat-send-message-file.test.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from "node:events";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -168,5 +169,60 @@ describe("chat send/ask --message-file", () => {
       "chat-env",
       expect.objectContaining({ content: body, format: "request" }),
     );
+  });
+
+  // Adversarial edge cases — every fs failure must surface as a clean
+  // MESSAGE_FILE_* / NO_MESSAGE error (exit 2) and write nothing, never an
+  // UNKNOWN_ERROR (exit 1) leaked from a raw fs throw.
+  it("an empty file is treated as no message (exit 2, nothing sent)", async () => {
+    const path = join(dir, "empty.md");
+    writeFileSync(path, "");
+
+    await expect(runChat("send", ["code-agent", "--message-file", path])).rejects.toMatchObject({
+      code: "NO_MESSAGE",
+      exitCode: 2,
+    });
+    expect(outputMocks.success).not.toHaveBeenCalled();
+  });
+
+  it("a directory path fails as MESSAGE_FILE_NOT_FILE", async () => {
+    await expect(runChat("send", ["code-agent", "--message-file", dir])).rejects.toMatchObject({
+      code: "MESSAGE_FILE_NOT_FILE",
+      exitCode: 2,
+    });
+    expect(outputMocks.success).not.toHaveBeenCalled();
+  });
+
+  it("a file that stat()s but cannot be read fails as MESSAGE_FILE_UNREADABLE (not UNKNOWN_ERROR)", async () => {
+    const path = join(dir, "locked.md");
+    writeFileSync(path, "secret body");
+    chmodSync(path, 0o000);
+
+    try {
+      // Root ignores 0o000, so skip the assertion when the read still succeeds.
+      const readable = await readFile(path).then(
+        () => true,
+        () => false,
+      );
+      if (!readable) {
+        await expect(runChat("send", ["code-agent", "--message-file", path])).rejects.toMatchObject({
+          code: "MESSAGE_FILE_UNREADABLE",
+          exitCode: 2,
+        });
+        expect(outputMocks.success).not.toHaveBeenCalled();
+      }
+    } finally {
+      chmodSync(path, 0o600);
+    }
+  });
+
+  it("`-F -` with a TTY stdin (nothing piped) fails as NO_MESSAGE", async () => {
+    setProcessStdin({ isTTY: true });
+
+    await expect(runChat("send", ["code-agent", "-F", "-"])).rejects.toMatchObject({
+      code: "NO_MESSAGE",
+      exitCode: 2,
+    });
+    expect(outputMocks.success).not.toHaveBeenCalled();
   });
 });

--- a/apps/cli/src/commands/chat/_shared/io.ts
+++ b/apps/cli/src/commands/chat/_shared/io.ts
@@ -42,9 +42,12 @@ export function readStdin(): Promise<string | null> {
 export async function readMessageBody(spec: string): Promise<string | null> {
   if (spec === "-") return readStdin();
 
-  // `.catch(() => null)` swallows only the stat() rejection (missing path /
-  // permissions); the fail() calls below stay OUTSIDE any try so their
-  // exit-throwing envelope is never caught and remapped here.
+  // Each fs call maps its own rejection to a clean `fail()` (exit 2) via
+  // `.catch`. fail() calls process.exit, so the `.catch` arms below never let a
+  // raw fs error escape to `handleSdkError` (which would mislabel it
+  // UNKNOWN_ERROR, exit 1). stat() fast-fails missing/non-file/oversize BEFORE
+  // reading; readFile() still has its own arm because the file can become
+  // unreadable or vanish between stat and read (EACCES, TOCTOU race).
   const info = await stat(spec).catch(() => null);
   if (info === null) {
     return fail("MESSAGE_FILE_NOT_FOUND", `--message-file path does not exist or is not readable: ${spec}`, 2);
@@ -55,7 +58,11 @@ export async function readMessageBody(spec: string): Promise<string | null> {
   if (info.size > MAX_STDIN_BYTES) {
     return fail("MESSAGE_FILE_TOO_LARGE", `--message-file exceeds the ${MAX_STDIN_BYTES}-byte limit: ${spec}`, 2);
   }
-  return (await readFile(spec)).toString("utf-8");
+  const buf = await readFile(spec).catch((err: unknown) => {
+    const detail = err instanceof Error ? err.message : String(err);
+    return fail("MESSAGE_FILE_UNREADABLE", `--message-file could not be read: ${detail}`, 2);
+  });
+  return buf.toString("utf-8");
 }
 
 /**

--- a/apps/cli/src/commands/chat/_shared/io.ts
+++ b/apps/cli/src/commands/chat/_shared/io.ts
@@ -1,3 +1,4 @@
+import { readFile, stat } from "node:fs/promises";
 import { fail } from "../../../cli/output.js";
 import { channelConfig } from "../../../core/channel.js";
 import { print } from "../../../core/output.js";
@@ -23,6 +24,38 @@ export function readStdin(): Promise<string | null> {
     process.stdin.on("end", () => resolve(Buffer.concat(chunks).toString("utf-8")));
     process.stdin.on("error", reject);
   });
+}
+
+/**
+ * Resolve an outbound body from a `--message-file <path>` spec. `-` reads
+ * stdin (the clig.dev convention); any other value is a filesystem path read
+ * verbatim. Routing the body through a file or stdin — never an inline shell
+ * argument — is the one robust fix for shell mangling: backticks (command
+ * substitution), double quotes (early argument termination), apostrophes, and
+ * newlines all reach the server byte-for-byte because the shell never
+ * word-parses the file's contents. Unlike an inline body, a file body is NOT
+ * run through `looksLikeEscapedNewlineBody`: a file can legitimately contain a
+ * literal `\n`, and its real newlines already survive intact. Returns null
+ * only when `-` is given but stdin is a TTY (nothing piped); the caller
+ * surfaces its own "no body" error.
+ */
+export async function readMessageBody(spec: string): Promise<string | null> {
+  if (spec === "-") return readStdin();
+
+  // `.catch(() => null)` swallows only the stat() rejection (missing path /
+  // permissions); the fail() calls below stay OUTSIDE any try so their
+  // exit-throwing envelope is never caught and remapped here.
+  const info = await stat(spec).catch(() => null);
+  if (info === null) {
+    return fail("MESSAGE_FILE_NOT_FOUND", `--message-file path does not exist or is not readable: ${spec}`, 2);
+  }
+  if (!info.isFile()) {
+    return fail("MESSAGE_FILE_NOT_FILE", `--message-file is not a regular file: ${spec}`, 2);
+  }
+  if (info.size > MAX_STDIN_BYTES) {
+    return fail("MESSAGE_FILE_TOO_LARGE", `--message-file exceeds the ${MAX_STDIN_BYTES}-byte limit: ${spec}`, 2);
+  }
+  return (await readFile(spec)).toString("utf-8");
 }
 
 /**

--- a/apps/cli/src/commands/chat/ask.ts
+++ b/apps/cli/src/commands/chat/ask.ts
@@ -5,7 +5,7 @@ import { channelConfig } from "../../core/channel.js";
 import { captureOutboundDocs } from "../../core/doc-capture.js";
 import { print } from "../../core/output.js";
 import { createSdk, handleSdkError } from "../_shared/local-agent.js";
-import { looksLikeEscapedNewlineBody, readStdin } from "./_shared/io.js";
+import { looksLikeEscapedNewlineBody, readMessageBody, readStdin } from "./_shared/io.js";
 import { buildRequestMetadata } from "./_shared/request.js";
 
 interface AskOptions {
@@ -14,6 +14,7 @@ interface AskOptions {
   agent?: string;
   options?: string;
   multiSelect?: boolean;
+  messageFile?: string;
 }
 
 export function registerChatAskCommand(chat: Command): void {
@@ -24,11 +25,20 @@ export function registerChatAskCommand(chat: Command): void {
         "answer. Writes an open question (format=request) directed at a single human <name>: the message body IS " +
         "the ask (background + question). Omit --options for a free-text answer, or pass 2–4 --options for a " +
         "choice. Raises a tracked red dot and blocks the chat for them until they answer. The human resolves it " +
-        "in the web UI — an agent can only ASK; it cannot answer or close a question.",
+        "in the web UI — an agent can only ASK; it cannot answer or close a question. The body can be the " +
+        "[message] argument, piped via stdin (omit [message]), or read from a file with --message-file <path> " +
+        "(`-` = stdin); prefer stdin or --message-file for any rich or multi-line body so the shell cannot mangle " +
+        "backticks, quotes, or newlines.",
     )
     .option("-f, --format <format>", "Message format (text|markdown|card)", "text")
     .option("-m, --metadata <json>", "JSON metadata to attach")
     .option("--agent <name>", "Agent name on the First Tree server (default: first configured on this client)")
+    .option(
+      "-F, --message-file <path>",
+      "Read the ask body from <path> (or `-` for stdin) instead of the [message] argument. Preferred for any rich " +
+        "or multi-line body: the content never passes through the shell, so backticks, quotes, and newlines are " +
+        "sent verbatim.",
+    )
     .option(
       "--options <json>",
       "Answer options as a JSON array, 2–4 items of {label (1–5 words), description, preview?}. e.g. " +
@@ -54,6 +64,12 @@ export function registerChatAskCommand(chat: Command): void {
           fail("NO_TARGET", "Pass <name> to direct the question at a single human member.", 2);
         }
 
+        // --message-file (a path, or `-` for stdin) is the shell-safe path for
+        // a rich body; it cannot also take an inline [message].
+        if (options.messageFile !== undefined && inlineBody !== undefined) {
+          fail("CONFLICTING_ARGS", "Pass the ask body either inline as [message] or via --message-file, not both.", 2);
+        }
+
         // Reject an inline body whose newlines are the two-character escape
         // `\n` — shell quotes do not expand it, so the row would render as one
         // long unformatted line. Stdin bodies are never checked.
@@ -74,7 +90,10 @@ export function registerChatAskCommand(chat: Command): void {
           );
         }
 
-        const content = inlineBody ?? (await readStdin());
+        const content =
+          options.messageFile !== undefined
+            ? await readMessageBody(options.messageFile)
+            : (inlineBody ?? (await readStdin()));
 
         let metadata: Record<string, unknown> | undefined;
         if (options.metadata) {
@@ -93,7 +112,7 @@ export function registerChatAskCommand(chat: Command): void {
           fail(
             "ASK_NEEDS_BODY",
             "`chat ask` needs a message body — the body is the ask (background + question). " +
-              "Pass it as an argument or via stdin.",
+              "Pass it as the [message] argument, via stdin, or with --message-file <path>.",
             2,
           );
         }

--- a/apps/cli/src/commands/chat/send.ts
+++ b/apps/cli/src/commands/chat/send.ts
@@ -5,13 +5,14 @@ import { channelConfig } from "../../core/channel.js";
 import { captureOutboundDocs } from "../../core/doc-capture.js";
 import { print } from "../../core/output.js";
 import { createSdk, handleSdkError } from "../_shared/local-agent.js";
-import { looksLikeEscapedNewlineBody, readStdin } from "./_shared/io.js";
+import { looksLikeEscapedNewlineBody, readMessageBody, readStdin } from "./_shared/io.js";
 
 interface SendOptions {
   format: MessageFormat;
   metadata?: string;
   agent?: string;
   replyTo?: string;
+  messageFile?: string;
 }
 
 export function registerChatSendCommand(chat: Command): void {
@@ -22,7 +23,9 @@ export function registerChatSendCommand(chat: Command): void {
         "human; the recipient is @mentioned and woken (must already be a participant — `chat invite` an agent " +
         "first). A plain send to a human is a free reply; put a tracked decision to a human with `chat ask`, or " +
         "report progress with `chat update --description`. A message must name a recipient — there is no " +
-        "no-mention send.",
+        "no-mention send. The body can be the [message] argument, piped via stdin (omit [message]), or read " +
+        "from a file with --message-file <path> (`-` = stdin); prefer stdin or --message-file for any rich or " +
+        "multi-line body so the shell cannot mangle backticks, quotes, or newlines.",
     )
     .option("-f, --format <format>", "Message format (text|markdown|card)", "text")
     .option("-m, --metadata <json>", "JSON metadata to attach")
@@ -30,6 +33,12 @@ export function registerChatSendCommand(chat: Command): void {
     .option(
       "--reply-to <messageId>",
       "Thread a reply under a message — sets inReplyTo (pure threading; does NOT resolve a question)",
+    )
+    .option(
+      "-F, --message-file <path>",
+      "Read the message body from <path> (or `-` for stdin) instead of the [message] argument. Preferred for any " +
+        "rich or multi-line body: the content never passes through the shell, so backticks, quotes, and newlines " +
+        "are sent verbatim.",
     )
     .action(async (name: string | undefined, message: string | undefined, options: SendOptions) => {
       try {
@@ -53,6 +62,16 @@ export function registerChatSendCommand(chat: Command): void {
           fail(
             "NO_TARGET",
             "Pass <name> to @mention a recipient — a message must name a recipient (there is no no-mention send).",
+            2,
+          );
+        }
+
+        // --message-file (a path, or `-` for stdin) is the shell-safe path for
+        // a rich body; it cannot also take an inline [message].
+        if (options.messageFile !== undefined && inlineBody !== undefined) {
+          fail(
+            "CONFLICTING_ARGS",
+            "Pass the message body either inline as [message] or via --message-file, not both.",
             2,
           );
         }
@@ -81,9 +100,16 @@ export function registerChatSendCommand(chat: Command): void {
           );
         }
 
-        const content = inlineBody ?? (await readStdin());
+        const content =
+          options.messageFile !== undefined
+            ? await readMessageBody(options.messageFile)
+            : (inlineBody ?? (await readStdin()));
         if (!content) {
-          fail("NO_MESSAGE", "No message provided. Pass as argument or pipe via stdin.", 2);
+          fail(
+            "NO_MESSAGE",
+            "No message provided. Pass it as the [message] argument, pipe it via stdin, or use --message-file <path>.",
+            2,
+          );
         }
 
         let metadata: Record<string, unknown> | undefined;

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -258,8 +258,12 @@ first-tree chat
 │     --request                                    #   first message is a tracked ask; the body IS the ask; exactly one --to human
 │     --options <json> / --multi-select            #   (with --request) 2–4 options {label,description,preview?}; allow multi-pick
 ├── send <name> [message]                            # wake a participant — agent or human (a plain send to a human is a free reply; use `chat ask` for a tracked decision)
+│     # body: [message] arg, or stdin (omit [message]), or -F <path>; prefer stdin/-F for rich bodies (shell-safe)
+│     -F, --message-file <path>                      #   read the body from <path> (`-` = stdin); content never hits the shell
 │     --reply-to <messageId>                         #   thread a reply under a message (pure threading)
 ├── ask <name> [message]                             # ask a HUMAN a tracked question; the body IS the ask (background + question)
+│     # body: [message] arg, or stdin (omit [message]), or -F <path>; prefer stdin/-F for rich bodies (shell-safe)
+│     -F, --message-file <path>                      #   read the body from <path> (`-` = stdin); content never hits the shell
 │     --options <json>                               #   2–4 answer options {label (1–5 words), description, preview?}; omit for free-text
 │     --multi-select                                 #   allow picking more than one option (requires --options)
 │     # always a fresh top-level question — no threading, and no resolve flag
@@ -299,6 +303,14 @@ first-tree chat send code-agent "ship the PR"
 # Stdin (multiline, markdown, special chars)
 echo "long body" | first-tree chat send code-agent -f markdown
 
+# Rich / multi-line bodies: write to a file, then read it with --message-file
+# (or `-F`). This is the most robust form — the body never passes through the
+# shell, so backticks (`code`), quotes, apostrophes, and newlines are sent
+# byte-for-byte. Inlining such a body lets the shell run backticks as command
+# substitution and break on quotes, silently mangling the message.
+first-tree chat send code-agent -f markdown --message-file reply.md
+first-tree chat send code-agent -f markdown -F -   < reply.md   # `-` = stdin
+
 # Inline bodies must carry REAL newlines. A one-line quoted body written with
 # `\n` escapes — chat send code-agent "line1\n\n**title**" — is rejected
 # BEFORE anything is sent (ESCAPED_NEWLINES, exit 2): shells do not expand
@@ -323,6 +335,9 @@ first-tree chat ask alice \
 
 # Free-text ask (no options)
 first-tree chat ask alice "What rollback window do you want before we ship 0021?"
+
+# Rich ask body via a file (shell-safe — same rationale as `chat send -F`)
+first-tree chat ask alice --message-file ask-body.md
 
 # `chat ask` always opens a fresh top-level question — there is no threading
 # (no --reply-to) and no resolve command. An agent can only ASK — it cannot mark a question


### PR DESCRIPTION
## Problem

Rich `chat send` / `chat ask` bodies — markdown full of `` `inline code` ``, `"quotes"`, apostrophes, and newlines — get **mangled by the shell** when passed as an inline argument, *before the CLI process starts*:

- backticks → **command substitution** (the shell runs them; tokens vanish or output is spliced in)
- ASCII `"` → **terminates the argument** early
- a single-quoted retry → breaks on the first **apostrophe**

Because the damage happens during shell word-splitting, the CLI only ever sees the already-mangled `argv` — **no CLI-side validation can detect or recover it** (unlike the literal-`\n` guard, whose token survives into `argv`). A real incident: a plain-language explanation where `` `exploreId` ``, `` `<Slot/>` ``, `` `(maps)/(surface)` `` were all run as commands and deleted, delivering "…plus . … group, , … rendered with ,".

## Fix (the only robust class: keep the body out of `argv`)

`send`/`ask` already read **stdin** when `[message]` is omitted, but that path was undocumented and easy to miss.

- **L2** — add `-F, --message-file <path>` to `chat send` and `chat ask` (`-` = stdin, per clig.dev). The body is read from the file/stdin **verbatim**; the shell never word-parses the content. Combining it with an inline `[message]` is rejected (`CONFLICTING_ARGS`); the escaped-newline guard is intentionally **skipped** for file bodies (a file may legitimately contain a literal `\n`). Missing/non-file/oversize paths fail with exit 2.
- **L1** — document the stdin / `--message-file` path in both command descriptions and `docs/cli-reference.md`, and broaden the `NO_MESSAGE` / `ASK_NEEDS_BODY` hints to mention it.

Agent workflow becomes bulletproof: write the body to a file, then `chat send <name> -f markdown -F reply.md` — backticks/quotes/apostrophes/newlines all arrive byte-for-byte.

## Scope notes

- `chat update --description` already supports `-` (stdin); a symmetric `--description-file` is a easy follow-up, left out to keep this PR focused on the reported `send`/`ask` path.
- L3 (a non-fatal stderr nudge for risky inline bodies) and L4 (agent-contract docs) from the design discussion are deliberately out of scope here.

## Testing

- `apps/cli` typecheck clean; biome clean.
- Full CLI suite: **511 passed**. New `chat-send-message-file.test.ts` (6 tests) covers verbatim round-trip of shell-hostile content, `-F -` stdin, missing-file + conflict errors, the file-body guard skip, and `ask` parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
