### PR TITLE
fix(client): canonicalize login-shell PATH dirs; gate CLAUDE_CODE_EXECUTABLE on executability

### DIFF
--- a/packages/client/src/__tests__/claude-executable.test.ts
+++ b/packages/client/src/__tests__/claude-executable.test.ts
@@ -44,6 +44,56 @@ describe("resolveClaudeCodeExecutable", () => {
     expect(resolution).toEqual({ path: fakeClaude, source: "path" });
   });
 
+  it("ignores an override that is a directory (not an executable file) and falls through to PATH", () => {
+    const dirOverride = mkdtempSync(join(tmpdir(), "ftt-claude-dirovr-"));
+    try {
+      const resolution = resolveClaudeCodeExecutable({
+        env: { CLAUDE_CODE_EXECUTABLE: dirOverride, PATH: binDir },
+      });
+      // A bare existsSync() would have accepted the directory; isExecutableFile rejects it.
+      expect(resolution).toEqual({ path: fakeClaude, source: "path" });
+    } finally {
+      rmSync(dirOverride, { recursive: true, force: true });
+    }
+  });
+
+  it("ignores a non-executable override file and falls through to PATH", () => {
+    const nonExec = join(binDir, "claude-nonexec");
+    writeFileSync(nonExec, "#!/bin/sh\nexit 0\n");
+    chmodSync(nonExec, 0o644); // readable, NOT executable
+    try {
+      const resolution = resolveClaudeCodeExecutable({
+        env: { CLAUDE_CODE_EXECUTABLE: nonExec, PATH: binDir },
+      });
+      expect(resolution).toEqual({ path: fakeClaude, source: "path" });
+    } finally {
+      rmSync(nonExec, { force: true });
+    }
+  });
+
+  it("surfaces overrideError on the default resolution when an unusable override and nothing else resolves", () => {
+    const badOverride = join(binDir, "nonexistent-override");
+    const resolution = resolveClaudeCodeExecutable({
+      env: {
+        CLAUDE_CODE_EXECUTABLE: badOverride,
+        PATH: join(tmpdir(), "definitely-not-a-real-bin-dir-xyz"),
+        HOME: emptyHome,
+      },
+      loginShellPathDirs: noLoginShell,
+    });
+    expect(resolution.path).toBeUndefined();
+    expect(resolution.source).toBe("default");
+    expect(resolution.overrideError).toContain(badOverride);
+  });
+
+  it("does NOT attach overrideError when the override is unusable but PATH resolves a claude", () => {
+    const resolution = resolveClaudeCodeExecutable({
+      env: { CLAUDE_CODE_EXECUTABLE: join(binDir, "nonexistent"), PATH: binDir },
+    });
+    expect(resolution).toEqual({ path: fakeClaude, source: "path" });
+    expect(resolution.overrideError).toBeUndefined();
+  });
+
   it("finds `claude` on PATH when the env override is absent", () => {
     const resolution = resolveClaudeCodeExecutable({
       env: { PATH: `${join(binDir, "missing")}${delimiter}${binDir}` },

--- a/packages/client/src/__tests__/login-shell-path.test.ts
+++ b/packages/client/src/__tests__/login-shell-path.test.ts
@@ -3,8 +3,12 @@ import { getLoginShellPathDirs, type RunShell, resetLoginShellPathDirsCache } fr
 
 const DELIM = "__FT_SHELL_PATH__";
 
-function wrap(path: string): string {
-  return `some prompt noise\n${DELIM}${path}${DELIM}\n`;
+/**
+ * Simulate the probe stdout: the canonical dirs the login shell prints (one per
+ * line) bracketed by {@link DELIM}, preceded by some rc-file prompt noise.
+ */
+function wrap(dirs: string[]): string {
+  return `some prompt noise\n${DELIM}${dirs.join("\n")}${DELIM}\n`;
 }
 
 describe("getLoginShellPathDirs", () => {
@@ -13,8 +17,8 @@ describe("getLoginShellPathDirs", () => {
     Object.defineProperty(process, "platform", { value: "linux" });
   });
 
-  it("parses the delimited PATH from shell output, dropping empties", () => {
-    const dirs = getLoginShellPathDirs(() => wrap("/home/u/.nvm/v/bin::/usr/local/bin:"));
+  it("parses the delimited canonical dirs from shell output, dropping empty lines", () => {
+    const dirs = getLoginShellPathDirs(() => wrap(["/home/u/.nvm/v/bin", "", "/usr/local/bin", ""]));
     expect(dirs).toEqual(["/home/u/.nvm/v/bin", "/usr/local/bin"]);
   });
 
@@ -27,7 +31,7 @@ describe("getLoginShellPathDirs", () => {
   });
 
   it("treats a successfully-parsed empty PATH as success (cached, no retry)", () => {
-    const runShell = vi.fn(() => wrap(""));
+    const runShell = vi.fn(() => wrap([]));
     expect(getLoginShellPathDirs(runShell)).toEqual([]);
     expect(getLoginShellPathDirs(runShell)).toEqual([]);
     expect(runShell).toHaveBeenCalledTimes(1);
@@ -35,7 +39,7 @@ describe("getLoginShellPathDirs", () => {
 
   it("returns [] on win32 without invoking the shell", () => {
     Object.defineProperty(process, "platform", { value: "win32" });
-    const runShell = vi.fn(() => wrap("/should/not/be/used"));
+    const runShell = vi.fn(() => wrap(["/should/not/be/used"]));
     expect(getLoginShellPathDirs(runShell)).toEqual([]);
     expect(runShell).not.toHaveBeenCalled();
   });
@@ -54,7 +58,7 @@ describe("getLoginShellPathDirs", () => {
   });
 
   it("memoizes a successful probe: the shell seam runs once across calls", () => {
-    const runShell = vi.fn(() => wrap("/a/bin"));
+    const runShell = vi.fn(() => wrap(["/a/bin"]));
     const first = getLoginShellPathDirs(runShell);
     const second = getLoginShellPathDirs(runShell);
     const third = getLoginShellPathDirs(runShell);
@@ -93,8 +97,8 @@ describe("getLoginShellPathDirs", () => {
     const runShell = vi
       .fn<RunShell>()
       .mockReturnValueOnce(null)
-      .mockReturnValueOnce(wrap("/late/bin"))
-      .mockReturnValue(wrap("/unused/bin"));
+      .mockReturnValueOnce(wrap(["/late/bin"]))
+      .mockReturnValue(wrap(["/unused/bin"]));
     // First call fails (re-probable), second succeeds and caches.
     expect(getLoginShellPathDirs(runShell)).toEqual([]);
     expect(getLoginShellPathDirs(runShell)).toEqual(["/late/bin"]);
@@ -104,7 +108,7 @@ describe("getLoginShellPathDirs", () => {
 
   it("does not spawn on win32 even on repeated calls", () => {
     Object.defineProperty(process, "platform", { value: "win32" });
-    const runShell = vi.fn(() => wrap("/should/not/be/used"));
+    const runShell = vi.fn(() => wrap(["/should/not/be/used"]));
     expect(getLoginShellPathDirs(runShell)).toEqual([]);
     expect(getLoginShellPathDirs(runShell)).toEqual([]);
     expect(runShell).not.toHaveBeenCalled();

--- a/packages/client/src/handlers/claude-executable.ts
+++ b/packages/client/src/handlers/claude-executable.ts
@@ -1,4 +1,4 @@
-import { accessSync, constants, existsSync, statSync } from "node:fs";
+import { accessSync, constants, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { delimiter, join } from "node:path";
 import { wellKnownBinDirs } from "../runtime/install-locations.js";
@@ -26,6 +26,14 @@ export type ClaudeExecutableSource = "env" | "path" | "well-known" | "default";
 export type ClaudeExecutableResolution = {
   path: string | undefined;
   source: ClaudeExecutableSource;
+  /**
+   * Set only when `CLAUDE_CODE_EXECUTABLE` was provided but did not resolve to an
+   * executable regular file. The override is still soft (we fall through to PATH /
+   * well-known / login-shell), so this is populated only on the final `default`
+   * resolution — i.e. when nothing else resolved either — letting the probe name
+   * the misconfigured override precisely instead of the generic missing text.
+   */
+  overrideError?: string;
 };
 
 /** Injectable seams so probe tests stay hermetic (no real shell spawn / no host install dirs). */
@@ -92,9 +100,18 @@ export function resolveClaudeCodeExecutable(
   const home = env.HOME && env.HOME.length > 0 ? env.HOME : homedir();
   const wellKnownDirs = opts.wellKnownDirs ?? (() => wellKnownBinDirs(home));
 
+  // Explicit operator override. Accept it ONLY when it is an executable regular
+  // file — the same isFile + X_OK gate the PATH / well-known search applies. A
+  // bare existsSync() also matched a directory named `claude` or a non-executable
+  // shim, yielding a false `env` hit the SDK then can't spawn. A set-but-unusable
+  // override stays non-fatal (First Tree's soft-override contract: fall through to
+  // PATH / well-known / login-shell), but the reason is captured so the probe can
+  // name it precisely if nothing else resolves.
   const override = env.CLAUDE_CODE_EXECUTABLE;
-  if (override && override.length > 0 && existsSync(override)) {
-    return { path: override, source: "env" };
+  let overrideError: string | undefined;
+  if (override && override.length > 0) {
+    if (isExecutableFile(override)) return { path: override, source: "env" };
+    overrideError = `CLAUDE_CODE_EXECUTABLE is set to "${override}" but is not an executable file; searching PATH and well-known install dirs instead`;
   }
 
   // Daemon PATH first, then cheap well-known dirs — both pure existence checks,
@@ -116,7 +133,7 @@ export function resolveClaudeCodeExecutable(
     if (fromLogin) return { path: fromLogin, source: "path" };
   }
 
-  return { path: undefined, source: "default" };
+  return { path: undefined, source: "default", ...(overrideError ? { overrideError } : {}) };
 }
 
 function pathDirs(env: NodeJS.ProcessEnv): string[] {

--- a/packages/client/src/runtime/capabilities/claude-code.ts
+++ b/packages/client/src/runtime/capabilities/claude-code.ts
@@ -159,6 +159,10 @@ export async function probeClaudeCodeCapability(deps: ClaudeCodeProbeDeps = {}):
     if (resolution.source !== "default" && resolution.path && exists(resolution.path)) {
       return { installed: true, runtimeSource: "path", runtimePath: resolution.path };
     }
+    // A set-but-unusable CLAUDE_CODE_EXECUTABLE only surfaces here, when nothing
+    // resolved — prepend it so the operator sees the precise cause, not just the
+    // generic "no claude found" text.
+    const overridePrefix = resolution.overrideError ? `${resolution.overrideError}. ` : "";
     // No on-disk binary — the SDK would spawn its bundled Claude binary (absent
     // by default since the native engine is externalized).
     try {
@@ -166,14 +170,16 @@ export async function probeClaudeCodeCapability(deps: ClaudeCodeProbeDeps = {}):
       if (exists(bundled.path)) return { installed: true, runtimeSource: "bundled", runtimePath: null };
       return {
         installed: false,
-        error: formatClaudeBinaryMissingMessage(
-          `the SDK-bundled Claude binary is declared at ${bundled.path} but does not exist`,
-        ),
+        error:
+          overridePrefix +
+          formatClaudeBinaryMissingMessage(
+            `the SDK-bundled Claude binary is declared at ${bundled.path} but does not exist`,
+          ),
       };
     } catch (err) {
       return {
         installed: false,
-        error: formatClaudeBinaryMissingMessage(err instanceof Error ? err.message : String(err)),
+        error: overridePrefix + formatClaudeBinaryMissingMessage(err instanceof Error ? err.message : String(err)),
       };
     }
   });

--- a/packages/client/src/runtime/login-shell-path.ts
+++ b/packages/client/src/runtime/login-shell-path.ts
@@ -1,9 +1,9 @@
 import { spawnSync } from "node:child_process";
 
 /**
- * Unique marker that brackets `$PATH` in the probe output so we can isolate it
- * from any prompt / rc-file noise the interactive login shell prints. Chosen to
- * be vanishingly unlikely to appear in a real PATH entry.
+ * Unique marker that brackets the canonical dir list in the probe output so we
+ * can isolate it from any prompt / rc-file noise the interactive login shell
+ * prints. Chosen to be vanishingly unlikely to appear in a real PATH entry.
  */
 const DELIM = "__FT_SHELL_PATH__";
 
@@ -34,6 +34,13 @@ let failedAttempts = 0;
  * that interactive PATH — so a `claude` / `codex` installed there is invisible to
  * the daemon's `env.PATH`. This probes the login shell and returns the extra
  * dirs so install-only capability detection can find those binaries.
+ *
+ * Each dir is **canonicalized inside the still-alive shell** (`cd "$d" && pwd -P`)
+ * before being returned. fnm / nvm "multishell" PATH entries are per-session
+ * symlink dirs (e.g. `/tmp/fnm_multishells/xxx/bin`) that are torn down when the
+ * probe shell exits — by the time the caller `existsSync`-checks them they would
+ * be gone. Resolving the symlink to the stable underlying install dir while the
+ * shell lives hands back a path that still exists at search time.
  *
  * Properties:
  *   - **Memoized on success**: a probe that ran the shell, exited 0, and parsed a
@@ -97,10 +104,27 @@ function probe(runShell: RunShell): string[] | null {
   return parsePathFromShellOutput(output);
 }
 
-/** Spawn the user's interactive login shell and echo `$PATH` bracketed by {@link DELIM}. */
+/**
+ * Spawn the user's interactive login shell and print, bracketed by {@link DELIM},
+ * the **canonicalized** dirs of `$PATH` — one per line.
+ *
+ * The script splits `$PATH` with `tr ':' '\n'` (NOT a `for d in $PATH` loop:
+ * zsh, the macOS default, does not field-split an unquoted scalar, so a for-loop
+ * would iterate once over the whole string), then for each dir runs
+ * `(cd "$d" && pwd -P)` in a subshell to resolve symlinks to the real install dir
+ * while the shell — and any per-session fnm/nvm multishell symlink — is still
+ * alive. Dirs that fail `cd` (gone / unreadable) are silently dropped; they could
+ * not hold a spawnable binary anyway. Verified to split correctly and canonicalize
+ * symlinked dirs under bash, zsh, and sh.
+ */
 function defaultRunShell(): string | null {
   const shell = pickShell();
-  const result = spawnSync(shell, ["-lic", `printf '${DELIM}%s${DELIM}' "$PATH"`], {
+  const script =
+    `printf %s '${DELIM}'; ` +
+    `printf %s "$PATH" | tr ':' '\\n' | ` +
+    `while IFS= read -r d; do [ -n "$d" ] && (cd "$d" 2>/dev/null && pwd -P); done; ` +
+    `printf %s '${DELIM}'`;
+  const result = spawnSync(shell, ["-lic", script], {
     encoding: "utf-8",
     timeout: 4_000,
     // SIGTERM (the spawnSync default) is ignored by a shell that traps it, spawns
@@ -122,15 +146,16 @@ function pickShell(): string {
 }
 
 /**
- * Extract the text between the two delimiters and split it into PATH dirs.
- * Returns `null` on a parse miss (delimiters absent) so the caller treats it as a
- * retryable failure rather than a genuine empty PATH.
+ * Extract the text between the two delimiters and split it into the canonical
+ * dirs the shell printed (one per line). Returns `null` on a parse miss
+ * (delimiters absent) so the caller treats it as a retryable failure rather than
+ * a genuine empty PATH.
  */
 function parsePathFromShellOutput(output: string): string[] | null {
   const start = output.indexOf(DELIM);
   if (start < 0) return null;
   const end = output.indexOf(DELIM, start + DELIM.length);
   if (end < 0) return null;
-  const path = output.slice(start + DELIM.length, end);
-  return path.split(":").filter((dir) => dir.length > 0);
+  const inner = output.slice(start + DELIM.length, end);
+  return inner.split("\n").filter((dir) => dir.length > 0);
 }


### PR DESCRIPTION
## What

Two install-only capability-detection robustness gaps, surfaced by deep-reading **Multica**'s probe layer (`server/internal/daemon/config.go`) and comparing it against First Tree's current `login-shell-path.ts` / `claude-executable.ts`.

### 1. fnm/nvm "multishell" dirs vanish before search → false `missing`

`wellKnownBinDirs` deliberately can't enumerate version-manager install dirs, so a `claude`/`codex` installed via a Node version manager is found **only** through the login-shell PATH probe. But fnm `--use-on-cd` (and nvm shims) put per-session **symlink** dirs on PATH (e.g. `/tmp/fnm_multishells/xxx/bin`) that are torn down when the probe shell exits. `getLoginShellPathDirs` recorded the raw dir string and memoized it; by the time a resolver `existsSync`-checks it, the dir is gone → the binary is invisible → false `missing`.

**Fix:** the probe now canonicalizes each PATH dir with `cd "$d" && pwd -P` **inside the still-alive shell**, resolving the ephemeral symlink to the stable underlying install dir before returning. Splitting uses `tr ':' '\n'` rather than `for d in $PATH`, because **zsh** (the macOS default) does not field-split an unquoted scalar and a for-loop would iterate once over the whole string. Verified to split correctly and canonicalize a symlinked dir under bash, zsh, and sh.

(Multica solves the same case with `cd "$dir" && pwd -P` + a daemon-side `LookPath` reality-check; this adapts the idea to First Tree's "grab the PATH dirs, search in-process" model.)

### 2. `CLAUDE_CODE_EXECUTABLE` accepted via bare `existsSync()`

A directory named `claude` or a non-executable shim passed the override check and yielded a false `ok` the SDK then couldn't spawn — while the PATH/well-known search already used the stricter `isFile + X_OK` gate (`isExecutableFile`). The override now goes through the same gate.

The override stays **soft** (an unusable override still falls through to PATH / well-known / login-shell — preserving existing intentional behavior, see the `falls through to PATH lookup when the env override does not exist` test), but the reason is captured as `overrideError` and surfaced in the probe's `missing` message **only when nothing else resolves**, so a misconfigured override gets named precisely instead of the generic "no claude found" text.

> Note: Multica hard-misses on an unusable explicit `MULTICA_*_PATH` ("honored exactly, don't substitute a different binary"). First Tree's existing test encodes the opposite (soft fall-through) on purpose, so this PR keeps fall-through and only improves the executability gate + diagnosability rather than reversing that decision.

## Test

- `pnpm typecheck` (root, 12/12) ✅
- `pnpm --filter @first-tree/client test` — 1145/1145 ✅ (login-shell-path / claude-executable / capability-probes updated)
- Biome clean ✅
- New tests: dir override → fall-through; non-executable override → fall-through; `overrideError` surfaced on total miss; no `overrideError` when PATH resolves.

## Background

From research comparing Multica/Paperclip's local-CLI detection with First Tree's post-#1300 install-only model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)