### PR TITLE
[codex] Default new chats to recent manual 1:1 agent

### DIFF
--- a/packages/web/src/pages/workspace/conversations/__tests__/pick-default.test.ts
+++ b/packages/web/src/pages/workspace/conversations/__tests__/pick-default.test.ts
@@ -1,22 +1,22 @@
 import { describe, expect, it } from "vitest";
-import { type PickDefaultAgent, pickDefault } from "../new-chat-draft.js";
+import { type PickDefaultAgent, type PickDefaultChat, pickDefault } from "../new-chat-draft.js";
 
 /**
  * Pure-function tests for the New Chat default-chip seed (`pickDefault`).
  *
- * Locks the issue 494 behaviour:
- *   - default = caller's own human agent's `delegateMention`
- *   - null when caller has no `delegateMention` set
- *   - null when the delegate target is missing from the org list
- *   - null when the delegate target is suspended
- *   - null when the caller's own row is missing from the org list (rare —
- *     the user's row is past the 100-row first-page cap of `useOrgAgents`)
- *   - null when `myAgentId` is null (logged-out or org not yet selected)
+ * Locks the New Chat default-chip seed:
+ *   - prefer the most recent manual 1:1 agent chat
+ *   - fall back to the caller's own human agent's `delegateMention`
+ *   - fall back to the caller's earliest owned active agent
+ *   - null only when no safe, visible, active candidate exists
  */
 
 const ME_HUMAN = "human-me";
 const DELEGATE = "agent-delegate";
 const OTHER = "agent-other";
+const OWNED_FIRST = "agent-owned-first";
+const OWNED_SECOND = "agent-owned-second";
+const NOW = Date.parse("2026-06-26T00:00:00.000Z");
 
 /** Build an agent slice with only the fields `pickDefault` reads. */
 function agent(partial: Partial<PickDefaultAgent> & Pick<PickDefaultAgent, "uuid">): PickDefaultAgent {
@@ -25,6 +25,21 @@ function agent(partial: Partial<PickDefaultAgent> & Pick<PickDefaultAgent, "uuid
     managerId: null,
     status: "active",
     delegateMention: null,
+    createdAt: "2026-06-01T00:00:00.000Z",
+    ...partial,
+  };
+}
+
+function chat(partial: Partial<PickDefaultChat> & Pick<PickDefaultChat, "chatId">): PickDefaultChat {
+  return {
+    source: "manual",
+    membershipKind: "participant",
+    canReply: true,
+    lastMessageAt: "2026-06-25T00:00:00.000Z",
+    participants: [
+      { agentId: ME_HUMAN, type: "human" },
+      { agentId: OTHER, type: "agent" },
+    ],
     ...partial,
   };
 }
@@ -32,63 +47,112 @@ function agent(partial: Partial<PickDefaultAgent> & Pick<PickDefaultAgent, "uuid
 describe("pickDefault", () => {
   it("returns null when myAgentId is null (logged-out or org not yet selected)", () => {
     const agents = [agent({ uuid: ME_HUMAN, type: "human", delegateMention: DELEGATE }), agent({ uuid: DELEGATE })];
-    expect(pickDefault(agents, null)).toBeNull();
+    expect(
+      pickDefault({ orgAgents: agents, recentChats: [], myAgentId: null, myMemberId: "member-me", nowMs: NOW }),
+    ).toBeNull();
   });
 
-  it("returns the human's delegateMention when set and the target is visible + active", () => {
+  it("prefers the most recent manual 1:1 agent chat over delegateMention", () => {
     const agents = [
       agent({ uuid: ME_HUMAN, type: "human", delegateMention: DELEGATE }),
       agent({ uuid: DELEGATE, type: "agent" }),
       agent({ uuid: OTHER, type: "agent" }),
     ];
-    expect(pickDefault(agents, ME_HUMAN)).toBe(DELEGATE);
+    const chats = [
+      chat({
+        chatId: "older",
+        lastMessageAt: "2026-06-20T00:00:00.000Z",
+        participants: [
+          { agentId: ME_HUMAN, type: "human" },
+          { agentId: DELEGATE, type: "agent" },
+        ],
+      }),
+      chat({
+        chatId: "newer",
+        lastMessageAt: "2026-06-25T00:00:00.000Z",
+        participants: [
+          { agentId: ME_HUMAN, type: "human" },
+          { agentId: OTHER, type: "agent" },
+        ],
+      }),
+    ];
+    expect(
+      pickDefault({ orgAgents: agents, recentChats: chats, myAgentId: ME_HUMAN, myMemberId: "member-me", nowMs: NOW }),
+    ).toBe(OTHER);
   });
 
-  it("returns null when the human has no delegateMention set", () => {
+  it("ignores automatic, group, stale, and unavailable recent chats before using delegateMention", () => {
+    const agents = [
+      agent({ uuid: ME_HUMAN, type: "human", delegateMention: DELEGATE }),
+      agent({ uuid: DELEGATE, type: "agent" }),
+      agent({ uuid: OTHER, type: "agent" }),
+    ];
+    const chats = [
+      chat({ chatId: "github", source: "github" }),
+      chat({
+        chatId: "group",
+        participants: [
+          { agentId: ME_HUMAN, type: "human" },
+          { agentId: OTHER, type: "agent" },
+          { agentId: "agent-extra", type: "agent" },
+        ],
+      }),
+      chat({ chatId: "stale", lastMessageAt: "2026-05-01T00:00:00.000Z" }),
+      chat({
+        chatId: "suspended",
+        participants: [
+          { agentId: ME_HUMAN, type: "human" },
+          { agentId: "agent-suspended", type: "agent" },
+        ],
+      }),
+    ];
+    expect(
+      pickDefault({ orgAgents: agents, recentChats: chats, myAgentId: ME_HUMAN, myMemberId: "member-me", nowMs: NOW }),
+    ).toBe(DELEGATE);
+  });
+
+  it("falls back to delegateMention when there is no valid recent manual 1:1 agent chat", () => {
+    const agents = [
+      agent({ uuid: ME_HUMAN, type: "human", delegateMention: DELEGATE }),
+      agent({ uuid: DELEGATE, type: "agent" }),
+      agent({ uuid: OTHER, type: "agent" }),
+    ];
+    expect(
+      pickDefault({ orgAgents: agents, recentChats: [], myAgentId: ME_HUMAN, myMemberId: "member-me", nowMs: NOW }),
+    ).toBe(DELEGATE);
+  });
+
+  it("falls back to the caller's earliest owned active agent when delegate is missing or unusable", () => {
+    const agents = [
+      agent({ uuid: ME_HUMAN, type: "human", delegateMention: DELEGATE }),
+      agent({ uuid: DELEGATE, type: "agent", status: "suspended", managerId: "other-member" }),
+      agent({ uuid: OWNED_SECOND, type: "agent", managerId: "member-me", createdAt: "2026-06-02T00:00:00.000Z" }),
+      agent({ uuid: OWNED_FIRST, type: "agent", managerId: "member-me", createdAt: "2026-06-01T00:00:00.000Z" }),
+      agent({ uuid: OTHER, type: "agent", managerId: "other-member", createdAt: "2026-05-01T00:00:00.000Z" }),
+    ];
+    expect(
+      pickDefault({ orgAgents: agents, recentChats: [], myAgentId: ME_HUMAN, myMemberId: "member-me", nowMs: NOW }),
+    ).toBe(OWNED_FIRST);
+  });
+
+  it("returns null when no safe candidate exists", () => {
     const agents = [
       agent({ uuid: ME_HUMAN, type: "human", delegateMention: null }),
-      agent({ uuid: OTHER, type: "agent" }),
+      agent({ uuid: OTHER, type: "agent", managerId: "other-member" }),
     ];
-    // Notably we do NOT fall back to PA / other my-managed agents —
-    // the caller must declare a delegate explicitly.
-    expect(pickDefault(agents, ME_HUMAN)).toBeNull();
+    expect(
+      pickDefault({ orgAgents: agents, recentChats: [], myAgentId: ME_HUMAN, myMemberId: "member-me", nowMs: NOW }),
+    ).toBeNull();
   });
 
-  it("returns null when the delegate target is missing from the org list", () => {
-    // The delegate uuid was set sometime in the past; meanwhile the row
-    // was deleted / made private / moved orgs. We refuse to seed a chip
-    // that can't be confirmed against the current visible roster.
-    const agents = [agent({ uuid: ME_HUMAN, type: "human", delegateMention: DELEGATE })];
-    expect(pickDefault(agents, ME_HUMAN)).toBeNull();
-  });
-
-  it("returns null when the delegate target is suspended", () => {
-    const agents = [
-      agent({ uuid: ME_HUMAN, type: "human", delegateMention: DELEGATE }),
-      agent({ uuid: DELEGATE, type: "agent", status: "suspended" }),
-    ];
-    expect(pickDefault(agents, ME_HUMAN)).toBeNull();
-  });
-
-  it("returns null when the caller's own human row is missing from the org list", () => {
-    // Edge: caller's human agent is past the 100-row first-page cap, so
-    // we can't read its `delegateMention`. Falling back to null is
-    // intentional — better an empty chip row than guessing.
-    const agents = [agent({ uuid: DELEGATE, type: "agent" })];
-    expect(pickDefault(agents, ME_HUMAN)).toBeNull();
-  });
-
-  it("is stable across calls — does not depend on runtime presence (issue 342 regression lock)", () => {
-    // The pre-issue 343 implementation sorted by `runtimeUpdatedAt` and
-    // could flip between adjacent calls when presence shifted; the
-    // delegate-based default has no such dependency, so two passes
-    // over the same input must agree.
+  it("is stable across calls — does not depend on runtime presence", () => {
     const agents = [
       agent({ uuid: ME_HUMAN, type: "human", delegateMention: DELEGATE }),
       agent({ uuid: DELEGATE, type: "agent" }),
     ];
-    const first = pickDefault(agents, ME_HUMAN);
-    const second = pickDefault(agents, ME_HUMAN);
+    const input = { orgAgents: agents, recentChats: [], myAgentId: ME_HUMAN, myMemberId: "member-me", nowMs: NOW };
+    const first = pickDefault(input);
+    const second = pickDefault(input);
     expect(first).toBe(second);
     expect(first).toBe(DELEGATE);
   });

--- a/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
+++ b/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
@@ -1,11 +1,11 @@
-import { type Agent, extractMentions, type MentionParticipant } from "@first-tree/shared";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { type Agent, extractMentions, type MeChatRow, type MentionParticipant } from "@first-tree/shared";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ArrowUp, Check, Menu, Paperclip, Plus, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { uploadImageAttachment } from "../../../api/attachments.js";
 import { type ImageRefContent, readFileAsBase64 } from "../../../api/chats.js";
 import { putImage } from "../../../api/image-store.js";
-import { createMeTaskChat } from "../../../api/me-chats.js";
+import { createMeTaskChat, listMeChats } from "../../../api/me-chats.js";
 import { useAuth } from "../../../auth/auth-context.js";
 import {
   ambiguousDisplayNames,
@@ -31,10 +31,10 @@ import { cn } from "../../../lib/utils.js";
  *   - Chip row at the top of the composer is the participants list for
  *     the chat being created. Independent of the textarea — adding a
  *     chip never injects text, removing one never strips an `@<name>`.
- *     Default state seeds a single chip (the caller's personal assistant
- *     or any of their managed agents — see `pickDefault`) so the common
- *     "ask my PA something" case is zero-step. Stable across clicks —
- *     no runtime-presence MRU here, see issue 342.
+ *     Default state seeds a single chip from explicit participants, the
+ *     caller's recent manual 1:1 agent chat, delegate, or first owned
+ *     active agent — see `pickDefault`. Runtime presence is deliberately
+ *     not a signal.
  *
  *   - Textarea carries the message content. Server's explicit-recipient enforcement
  *     contract requires an explicit recipient on every send — for 1:1
@@ -132,6 +132,14 @@ export function NewChatDraft({
    *  orgs above the 100-row cap can still reach every addable agent
    *  (issue 494). */
   const { data: orgAgentsPage } = useOrgAgents({ addressableOnly: true });
+  const {
+    data: recentChatsPage,
+    isFetched: recentChatsFetched,
+    isError: recentChatsError,
+  } = useQuery({
+    queryKey: ["me", "chats", "new-chat-default-agent"],
+    queryFn: () => listMeChats({ limit: 50, filter: "all", engagement: "active", origin: ["manual"] }),
+  });
 
   /** Map of every uuid we have ever shown to the user this session —
    *  seeded from the first page and grown with each search round-trip
@@ -291,12 +299,29 @@ export function NewChatDraft({
     // Wait for the org-list query to settle before picking — without
     // this guard the pre-fetch render would always pick `null` and
     // arm `seededDefaultRef`, locking out the real default once the
-    // data arrives.
+    // data arrives. Wait for the recent-chat query as well so delegate fallback
+    // does not win just because the roster resolved first; on query error,
+    // fall back to delegate / first-owned rather than leaving the draft empty.
     if (!orgAgentsPage?.items) return;
-    const defaultId = pickDefault(orgAgentsPage.items, myAgentId);
+    if (!recentChatsFetched && !recentChatsError) return;
+    const defaultId = pickDefault({
+      orgAgents: orgAgentsPage.items,
+      recentChats: recentChatsPage?.rows ?? [],
+      myAgentId,
+      myMemberId,
+    });
     seededDefaultRef.current = true;
     if (defaultId) setChips([defaultId]);
-  }, [orgAgentsPage?.items, myAgentId, chips.length, initialParticipantIds]);
+  }, [
+    orgAgentsPage?.items,
+    recentChatsPage?.rows,
+    recentChatsFetched,
+    recentChatsError,
+    myAgentId,
+    myMemberId,
+    chips.length,
+    initialParticipantIds,
+  ]);
 
   // Persist unsent body + chosen participants for this compose context so
   // navigating away and back (or a reload) restores the draft. saveDraft gates
@@ -1072,38 +1097,80 @@ function ParticipantChips({
   );
 }
 
+const RECENT_MANUAL_CHAT_MAX_AGE_MS = 14 * 24 * 60 * 60 * 1000;
+
 /** Pick a default seed chip when the user opens an empty draft.
  *
- *  Single rule: the caller's own human agent's `delegateMention` — i.e.
- *  the agent the user has explicitly designated as their stand-in. When
- *  it's unset (or the target was suspended / deleted) we return `null`
- *  and let the user pick.
+ *  Priority after explicit `?with=` participants:
+ *  1. the most recent manual 1:1 agent chat;
+ *  2. the caller's delegate agent;
+ *  3. the caller's earliest owned active agent.
  *
- *  Pre-issue 494 the default walked the caller's managed agents
- *  (personal_assistant first, then any) — which seeded a chip even when
- *  the user had no opinion about who that should be. Defaulting to the
- *  caller-declared delegate is a more deliberate signal: if the user
- *  hasn't set one, no chip is the right starting state.
- *
- *  Validation: we still need to confirm the delegate is in the org list
- *  and not suspended, so a delegate set months ago but since deleted
- *  doesn't seed a dangling uuid. When the user's own row is past the
- *  100-row first-page cap of `useOrgAgents()` we can't validate — in
- *  that rare case we return null rather than seed a chip we can't
- *  confirm. */
+ *  Every candidate is validated against the current addressable org roster
+ *  before seeding a chip, so stale chat rows, suspended agents, or invisible
+ *  private agents cannot become a dangling recipient. Runtime presence is not
+ *  considered: "recently online" is not the same as "the user meant to chat
+ *  with this agent."
+ */
 
 /** Exported for `__tests__/pick-default.test.ts`. The signature accepts
  *  a `Pick<Agent, ...>` slice rather than `Agent` so callers (and tests)
  *  can pass minimal fixtures without inventing inboxIds, metadata, etc. */
-export type PickDefaultAgent = Pick<Agent, "uuid" | "type" | "managerId" | "status" | "delegateMention">;
+export type PickDefaultAgent = Pick<Agent, "uuid" | "type" | "managerId" | "status" | "delegateMention" | "createdAt">;
+export type PickDefaultChat = Pick<MeChatRow, "chatId" | "source" | "membershipKind" | "canReply" | "lastMessageAt"> & {
+  participants: Array<Pick<MeChatRow["participants"][number], "agentId" | "type">>;
+};
 
-export function pickDefault(orgAgents: ReadonlyArray<PickDefaultAgent>, myAgentId: string | null): string | null {
+export function pickDefault({
+  orgAgents,
+  recentChats,
+  myAgentId,
+  myMemberId,
+  nowMs = Date.now(),
+}: {
+  orgAgents: ReadonlyArray<PickDefaultAgent>;
+  recentChats: ReadonlyArray<PickDefaultChat>;
+  myAgentId: string | null;
+  myMemberId: string | null;
+  nowMs?: number;
+}): string | null {
   if (!myAgentId) return null;
-  const myHuman = orgAgents.find((a) => a.uuid === myAgentId);
+
+  const activeAgentById = new Map(
+    orgAgents.filter((a) => a.type === "agent" && a.status === "active").map((a) => [a.uuid, a]),
+  );
+
+  const recentDefault = [...recentChats]
+    .sort((a, b) => timestampMs(b.lastMessageAt) - timestampMs(a.lastMessageAt))
+    .find((chat) => {
+      if (chat.source !== "manual") return false;
+      if (chat.membershipKind !== "participant" || !chat.canReply) return false;
+      const lastMessageMs = timestampMs(chat.lastMessageAt);
+      if (lastMessageMs === 0 || nowMs - lastMessageMs > RECENT_MANUAL_CHAT_MAX_AGE_MS) return false;
+      const others = chat.participants.filter((p) => p.agentId !== myAgentId);
+      if (others.length !== 1) return false;
+      const peer = others[0];
+      if (!peer || peer.type === "human") return false;
+      return activeAgentById.has(peer.agentId);
+    });
+  if (recentDefault) {
+    const peer = recentDefault.participants.find((p) => p.agentId !== myAgentId);
+    if (peer && activeAgentById.has(peer.agentId)) return peer.agentId;
+  }
+
+  const myHuman = orgAgents.find((a) => a.uuid === myAgentId && a.type === "human");
   const delegateUuid = myHuman?.delegateMention ?? null;
-  if (!delegateUuid) return null;
-  const delegate = orgAgents.find((a) => a.uuid === delegateUuid);
-  if (!delegate) return null;
-  if (delegate.status === "suspended") return null;
-  return delegate.uuid;
+  if (delegateUuid && activeAgentById.has(delegateUuid)) return delegateUuid;
+
+  if (!myMemberId) return null;
+  const owned = orgAgents
+    .filter((a) => a.type === "agent" && a.status === "active" && a.managerId === myMemberId)
+    .sort((a, b) => timestampMs(a.createdAt) - timestampMs(b.createdAt));
+  return owned[0]?.uuid ?? null;
+}
+
+function timestampMs(value: string | null): number {
+  if (!value) return 0;
+  const ms = Date.parse(value);
+  return Number.isFinite(ms) ? ms : 0;
 }


### PR DESCRIPTION
## Superseded

This PR used a branch name that failed the repository branch-name gate. Replaced by https://github.com/agent-team-foundation/first-tree/pull/1317 on `feat/new-chat-default-agent`.

Original summary retained in the replacement PR.