### PR TITLE
Add skill eval floor coverage matrix

### DIFF
--- a/packages/skill-evals/README.md
+++ b/packages/skill-evals/README.md
@@ -7,12 +7,19 @@ quota.
 ## first-tree-read
 
 ```bash
+pnpm --filter @first-tree/skill-evals eval:floor
 pnpm --filter @first-tree/skill-evals eval:first-tree-read
 pnpm --filter @first-tree/skill-evals eval:first-tree-read -- --case tree-software-trigger
 pnpm --filter @first-tree/skill-evals eval:first-tree-read -- --json
 pnpm --filter @first-tree/skill-evals eval:first-tree-read -- --verbose
 pnpm --filter @first-tree/skill-evals eval:first-tree-read -- --case tree-software-trigger --validate-fixtures --verbose
 ```
+
+`eval:floor` is a no-model check for the skill-eval framework itself. It
+validates that all shipped First Tree skills are present in the coverage
+matrix, their `SKILL.md` frontmatter is readable, and their case declarations
+have the minimum schema required by the shared runner. It does not execute
+Codex, Claude Code, LLM-as-judge, or live gate cases.
 
 The runner creates isolated temporary workspaces under
 `packages/skill-evals/.runs/<timestamp>-<case-id>/`, installs

--- a/packages/skill-evals/package.json
+++ b/packages/skill-evals/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "description": "Opt-in live model evaluations for First Tree skills.",
   "scripts": {
+    "eval:floor": "tsx src/index.ts floor",
     "eval:first-tree-read": "tsx src/first-tree-read/index.ts",
     "test": "vitest run --passWithNoTests",
     "validate:first-tree-read-fixtures": "tsx src/first-tree-read/index.ts --validate-fixtures",

--- a/packages/skill-evals/src/core/__tests__/case-schema.test.ts
+++ b/packages/skill-evals/src/core/__tests__/case-schema.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { type SkillEvalCase, validateSkillEvalCase } from "../case-schema.js";
+import { allScoresPass } from "../result-schema.js";
+
+describe("skill eval case schema", () => {
+  it("accepts a complete floor case", () => {
+    const evalCase: SkillEvalCase = {
+      briefingMode: "minimal",
+      expected: { action: "validate" },
+      fixture: { kind: "static" },
+      id: "first-tree-read-static",
+      skill: "first-tree-read",
+      status: "implemented",
+      tier: "floor",
+    };
+
+    expect(validateSkillEvalCase(evalCase)).toEqual({ errors: [], ok: true });
+  });
+
+  it("requires prompts for live-style cases", () => {
+    const evalCase: SkillEvalCase = {
+      briefingMode: "minimal",
+      expected: { action: "run" },
+      fixture: { kind: "workspace" },
+      id: "first-tree-read-gate",
+      skill: "first-tree-read",
+      status: "implemented",
+      tier: "gate",
+    };
+
+    expect(validateSkillEvalCase(evalCase).errors).toContain("gate cases must include prompt.");
+  });
+
+  it("summarizes the four hard score axes", () => {
+    expect(
+      allScoresPass({
+        outcome_pass: true,
+        process_pass: true,
+        risk_pass: true,
+        routing_pass: true,
+      }),
+    ).toBe(true);
+
+    expect(
+      allScoresPass({
+        outcome_pass: true,
+        process_pass: true,
+        risk_pass: false,
+        routing_pass: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/skill-evals/src/core/__tests__/coverage.test.ts
+++ b/packages/skill-evals/src/core/__tests__/coverage.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { SKILL_EVAL_SUITES } from "../../suites/registry.js";
+import { SHIPPED_SKILLS } from "../case-schema.js";
+import { validateCoverageMatrix } from "../coverage.js";
+
+describe("skill eval coverage matrix", () => {
+  it("covers every shipped First Tree skill with floor and gate entries", () => {
+    const validation = validateCoverageMatrix(SKILL_EVAL_SUITES);
+    expect(validation.errors).toEqual([]);
+    expect(validation.ok).toBe(true);
+
+    const suiteSkills = new Set(SKILL_EVAL_SUITES.map((suite) => suite.skill));
+    for (const skill of SHIPPED_SKILLS) {
+      expect(suiteSkills.has(skill)).toBe(true);
+    }
+  });
+});

--- a/packages/skill-evals/src/core/case-schema.ts
+++ b/packages/skill-evals/src/core/case-schema.ts
@@ -1,0 +1,115 @@
+export const SHIPPED_SKILLS = ["first-tree-read", "first-tree-write", "first-tree-seed", "first-tree-welcome"] as const;
+
+export const SKILL_EVAL_TIERS = ["floor", "gate", "quality", "periodic"] as const;
+export const EVAL_CASE_STATUSES = ["implemented", "planned"] as const;
+export const BRIEFING_MODES = ["minimal", "generated-fixture", "runtime-generated"] as const;
+export const PROVIDER_NAMES = ["codex", "claude"] as const;
+
+export type ShippedSkillName = (typeof SHIPPED_SKILLS)[number];
+export type SkillEvalTier = (typeof SKILL_EVAL_TIERS)[number];
+export type EvalCaseStatus = (typeof EVAL_CASE_STATUSES)[number];
+export type BriefingMode = (typeof BRIEFING_MODES)[number];
+export type ProviderName = (typeof PROVIDER_NAMES)[number];
+
+export type SkillEvalCase<Fixture = unknown, Expected = unknown> = {
+  briefingMode: BriefingMode;
+  expected: Expected;
+  fixture: Fixture;
+  forbidden?: unknown;
+  id: string;
+  prompt?: string;
+  provider?: ProviderName;
+  skill: ShippedSkillName;
+  status: EvalCaseStatus;
+  tags?: readonly string[];
+  tier: SkillEvalTier;
+};
+
+export type ValidationResult = {
+  errors: readonly string[];
+  ok: boolean;
+};
+
+type StringSet = readonly string[];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isOneOf<T extends StringSet>(value: unknown, allowed: T): value is T[number] {
+  return typeof value === "string" && allowed.includes(value);
+}
+
+function validateOptionalStringArray(value: unknown, field: string, errors: string[]): void {
+  if (value === undefined) return;
+  if (!Array.isArray(value)) {
+    errors.push(`${field} must be an array when present.`);
+    return;
+  }
+  for (const item of value) {
+    if (typeof item !== "string" || item.trim() === "") {
+      errors.push(`${field} must contain only non-empty strings.`);
+      return;
+    }
+  }
+}
+
+export function validateSkillEvalCase(value: unknown): ValidationResult {
+  const errors: string[] = [];
+  if (!isRecord(value)) {
+    return { errors: ["case must be an object."], ok: false };
+  }
+
+  if (typeof value.id !== "string" || value.id.trim() === "") {
+    errors.push("id must be a non-empty string.");
+  }
+  if (!isOneOf(value.skill, SHIPPED_SKILLS)) {
+    errors.push(`skill must be one of: ${SHIPPED_SKILLS.join(", ")}.`);
+  }
+  if (!isOneOf(value.tier, SKILL_EVAL_TIERS)) {
+    errors.push(`tier must be one of: ${SKILL_EVAL_TIERS.join(", ")}.`);
+  }
+  if (!isOneOf(value.status, EVAL_CASE_STATUSES)) {
+    errors.push(`status must be one of: ${EVAL_CASE_STATUSES.join(", ")}.`);
+  }
+  if (!isOneOf(value.briefingMode, BRIEFING_MODES)) {
+    errors.push(`briefingMode must be one of: ${BRIEFING_MODES.join(", ")}.`);
+  }
+  if (value.provider !== undefined && !isOneOf(value.provider, PROVIDER_NAMES)) {
+    errors.push(`provider must be one of: ${PROVIDER_NAMES.join(", ")} when present.`);
+  }
+  if (value.prompt !== undefined && (typeof value.prompt !== "string" || value.prompt.trim() === "")) {
+    errors.push("prompt must be a non-empty string when present.");
+  }
+  if ((value.tier === "gate" || value.tier === "quality" || value.tier === "periodic") && value.prompt === undefined) {
+    errors.push(`${String(value.tier)} cases must include prompt.`);
+  }
+  if (!isRecord(value.fixture)) {
+    errors.push("fixture must be an object.");
+  }
+  if (!isRecord(value.expected)) {
+    errors.push("expected must be an object.");
+  }
+  validateOptionalStringArray(value.tags, "tags", errors);
+
+  return { errors, ok: errors.length === 0 };
+}
+
+export function validateCaseCollection(cases: readonly SkillEvalCase[]): ValidationResult {
+  const errors: string[] = [];
+  const seen = new Set<string>();
+
+  for (const evalCase of cases) {
+    const caseValidation = validateSkillEvalCase(evalCase);
+    for (const error of caseValidation.errors) {
+      errors.push(`${evalCase.id || "<missing-id>"}: ${error}`);
+    }
+
+    if (seen.has(evalCase.id)) {
+      errors.push(`${evalCase.id}: duplicate case id.`);
+    }
+    seen.add(evalCase.id);
+  }
+
+  return { errors, ok: errors.length === 0 };
+}

--- a/packages/skill-evals/src/core/coverage.ts
+++ b/packages/skill-evals/src/core/coverage.ts
@@ -1,0 +1,88 @@
+import {
+  SHIPPED_SKILLS,
+  type ShippedSkillName,
+  type SkillEvalCase,
+  type SkillEvalTier,
+  type ValidationResult,
+  validateCaseCollection,
+} from "./case-schema.js";
+
+export type CoverageStatus = "implemented" | "planned";
+
+export type CoverageTierEntry = {
+  caseIds: readonly string[];
+  description: string;
+  status: CoverageStatus;
+  tier: SkillEvalTier;
+};
+
+export type SkillCoverageEntry = {
+  skill: ShippedSkillName;
+  tiers: readonly CoverageTierEntry[];
+};
+
+export type SkillEvalSuiteDefinition = {
+  cases: readonly SkillEvalCase[];
+  coverage: SkillCoverageEntry;
+  skill: ShippedSkillName;
+  validateFloor?: (cases: readonly SkillEvalCase[]) => readonly string[];
+};
+
+function entryForTier(entry: SkillCoverageEntry, tier: SkillEvalTier): CoverageTierEntry | null {
+  return entry.tiers.find((candidate) => candidate.tier === tier) ?? null;
+}
+
+export function validateCoverageMatrix(suites: readonly SkillEvalSuiteDefinition[]): ValidationResult {
+  const errors: string[] = [];
+  const seenSkills = new Set<string>();
+
+  for (const suite of suites) {
+    if (suite.skill !== suite.coverage.skill) {
+      errors.push(`${suite.skill}: suite skill does not match coverage skill ${suite.coverage.skill}.`);
+    }
+    if (seenSkills.has(suite.skill)) {
+      errors.push(`${suite.skill}: duplicate suite coverage entry.`);
+    }
+    seenSkills.add(suite.skill);
+
+    const floor = entryForTier(suite.coverage, "floor");
+    const gate = entryForTier(suite.coverage, "gate");
+    if (floor === null) {
+      errors.push(`${suite.skill}: missing floor coverage entry.`);
+    } else if (floor.caseIds.length === 0) {
+      errors.push(`${suite.skill}: floor coverage entry must list at least one case.`);
+    }
+    if (gate === null) {
+      errors.push(`${suite.skill}: missing gate coverage entry.`);
+    } else if (gate.caseIds.length === 0) {
+      errors.push(`${suite.skill}: gate coverage entry must list at least one case.`);
+    }
+
+    const validation = validateCaseCollection(suite.cases);
+    for (const error of validation.errors) {
+      errors.push(`${suite.skill}: ${error}`);
+    }
+
+    const suiteCaseIds = new Set(suite.cases.map((evalCase) => evalCase.id));
+    for (const tierEntry of suite.coverage.tiers) {
+      for (const caseId of tierEntry.caseIds) {
+        if (!suiteCaseIds.has(caseId)) {
+          errors.push(`${suite.skill}: coverage references unknown case ${caseId}.`);
+        }
+      }
+    }
+
+    const floorValidationErrors = suite.validateFloor?.(suite.cases) ?? [];
+    for (const error of floorValidationErrors) {
+      errors.push(`${suite.skill}: ${error}`);
+    }
+  }
+
+  for (const skill of SHIPPED_SKILLS) {
+    if (!seenSkills.has(skill)) {
+      errors.push(`${skill}: missing suite coverage entry.`);
+    }
+  }
+
+  return { errors, ok: errors.length === 0 };
+}

--- a/packages/skill-evals/src/core/result-schema.ts
+++ b/packages/skill-evals/src/core/result-schema.ts
@@ -1,0 +1,34 @@
+export type SkillCaseScoreKey = "routing_pass" | "process_pass" | "outcome_pass" | "risk_pass";
+
+export type SkillCaseScores = Record<SkillCaseScoreKey, boolean>;
+
+export type GradingEvidence = {
+  detail: string;
+  label: string;
+};
+
+export type RiskFlag = {
+  detail: string;
+  label: string;
+};
+
+export type SkillCaseGrading = {
+  caseId: string;
+  evidence: readonly GradingEvidence[];
+  passed: boolean;
+  riskFlags: readonly RiskFlag[];
+  scores: SkillCaseScores;
+};
+
+export type SkillEvalRunResult = {
+  caseId: string;
+  durationMs?: number;
+  grading: SkillCaseGrading;
+  runId: string;
+  skill: string;
+  tier: string;
+};
+
+export function allScoresPass(scores: SkillCaseScores): boolean {
+  return scores.routing_pass && scores.process_pass && scores.outcome_pass && scores.risk_pass;
+}

--- a/packages/skill-evals/src/core/skills/frontmatter.ts
+++ b/packages/skill-evals/src/core/skills/frontmatter.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from "node:fs";
+
+export type SkillFrontmatter = {
+  description: string;
+  name: string;
+};
+
+function unquote(value: string): string {
+  const trimmed = value.trim();
+  if ((trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+export function parseSkillFrontmatter(markdown: string): SkillFrontmatter {
+  const lines = markdown.split(/\r?\n/u);
+  if (lines[0] !== "---") {
+    throw new Error("missing frontmatter opening marker.");
+  }
+
+  const values = new Map<string, string>();
+  for (let index = 1; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (line === undefined) continue;
+    if (line === "---") break;
+    const match = /^([A-Za-z][A-Za-z0-9_-]*):\s*(.*)$/u.exec(line);
+    if (match) {
+      const key = match[1];
+      const value = match[2];
+      if (key !== undefined && value !== undefined) {
+        values.set(key, unquote(value));
+      }
+    }
+  }
+
+  const name = values.get("name");
+  const description = values.get("description");
+  if (!name) {
+    throw new Error("missing frontmatter name.");
+  }
+  if (!description) {
+    throw new Error("missing frontmatter description.");
+  }
+
+  return { description, name };
+}
+
+export function readSkillFrontmatter(skillMarkdownPath: string): SkillFrontmatter {
+  return parseSkillFrontmatter(readFileSync(skillMarkdownPath, "utf8"));
+}

--- a/packages/skill-evals/src/index.ts
+++ b/packages/skill-evals/src/index.ts
@@ -1,0 +1,207 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { SHIPPED_SKILLS, type ShippedSkillName } from "./core/case-schema.js";
+import { type SkillEvalSuiteDefinition, validateCoverageMatrix } from "./core/coverage.js";
+import { isRecord } from "./core/events.js";
+import { readSkillFrontmatter } from "./core/skills/frontmatter.js";
+import { SKILL_EVAL_SUITES } from "./suites/registry.js";
+
+type CliOptions = {
+  command: "floor";
+  json: boolean;
+  suite: ShippedSkillName | null;
+};
+
+type FloorCheck = {
+  detail: string;
+  name: string;
+  ok: boolean;
+};
+
+type FloorSummary = {
+  checks: readonly FloorCheck[];
+  failed: number;
+  passed: number;
+  suites: readonly string[];
+};
+
+function usage(): string {
+  return `Usage:
+  pnpm --filter @first-tree/skill-evals eval:floor
+  pnpm --filter @first-tree/skill-evals eval:floor -- --json
+  pnpm --filter @first-tree/skill-evals eval:floor -- --suite <skill>
+
+Commands:
+  floor                  Run no-model schema, coverage, and skill-file checks.
+
+Options:
+  --suite <skill>        Limit per-suite floor checks to one shipped skill.
+  --json                 Print summary as JSON.
+  --help                 Show this help.
+`;
+}
+
+function readOptionValue(args: readonly string[], index: number, optionName: string): string {
+  const value = args[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${optionName} requires a value.`);
+  }
+  return value;
+}
+
+function parseArgs(args: readonly string[]): CliOptions {
+  const normalized = args.filter((arg) => arg !== "--");
+  const command = normalized[0] ?? "floor";
+  if (command === "--help" || command === "-h") {
+    process.stdout.write(usage());
+    process.exit(0);
+  }
+  if (command !== "floor") {
+    throw new Error(`Unknown command: ${command}`);
+  }
+
+  const options: CliOptions = {
+    command,
+    json: false,
+    suite: null,
+  };
+
+  for (let index = 1; index < normalized.length; index += 1) {
+    const arg = normalized[index];
+    if (arg === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (arg === "--suite") {
+      const suite = readOptionValue(normalized, index, "--suite");
+      if (!SHIPPED_SKILLS.includes(suite as ShippedSkillName)) {
+        throw new Error(`Unknown suite '${suite}'. Available suites: ${SHIPPED_SKILLS.join(", ")}`);
+      }
+      options.suite = suite as ShippedSkillName;
+      index += 1;
+      continue;
+    }
+    if (arg === "--help" || arg === "-h") {
+      process.stdout.write(usage());
+      process.exit(0);
+    }
+    throw new Error(`Unknown option: ${arg}`);
+  }
+
+  return options;
+}
+
+function packageRoot(): string {
+  let current = dirname(fileURLToPath(import.meta.url));
+  while (current !== dirname(current)) {
+    const packageJsonPath = `${current}/package.json`;
+    if (existsSync(packageJsonPath)) {
+      const packageJson: unknown = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+      if (isRecord(packageJson) && packageJson.name === "@first-tree/skill-evals") {
+        return current;
+      }
+    }
+    current = dirname(current);
+  }
+  throw new Error("Could not locate @first-tree/skill-evals package root.");
+}
+
+function repoRootFromPackage(packageRootPath: string): string {
+  return dirname(dirname(packageRootPath));
+}
+
+function checkSkillFiles(repoRoot: string, suites: readonly SkillEvalSuiteDefinition[]): readonly FloorCheck[] {
+  return suites.map((suite) => {
+    const skillPath = join(repoRoot, "skills", suite.skill, "SKILL.md");
+    if (!existsSync(skillPath)) {
+      return {
+        detail: `Missing ${skillPath}`,
+        name: `${suite.skill}: skill file`,
+        ok: false,
+      };
+    }
+
+    try {
+      const frontmatter = readSkillFrontmatter(skillPath);
+      if (frontmatter.name !== suite.skill) {
+        return {
+          detail: `Frontmatter name is ${frontmatter.name}, expected ${suite.skill}`,
+          name: `${suite.skill}: skill file`,
+          ok: false,
+        };
+      }
+      return {
+        detail: frontmatter.description,
+        name: `${suite.skill}: skill file`,
+        ok: true,
+      };
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      return {
+        detail: message,
+        name: `${suite.skill}: skill file`,
+        ok: false,
+      };
+    }
+  });
+}
+
+function checkCoverage(suites: readonly SkillEvalSuiteDefinition[]): FloorCheck {
+  const validation = validateCoverageMatrix(suites);
+  return {
+    detail: validation.ok
+      ? "Coverage matrix includes all shipped skills with floor and gate entries."
+      : validation.errors.join("; "),
+    name: "coverage matrix",
+    ok: validation.ok,
+  };
+}
+
+function buildFloorSummary(options: CliOptions): FloorSummary {
+  const packageRootPath = packageRoot();
+  const allSuites = SKILL_EVAL_SUITES;
+  const selectedSuites =
+    options.suite === null ? allSuites : allSuites.filter((suite) => suite.skill === options.suite);
+  const checks = [checkCoverage(allSuites), ...checkSkillFiles(repoRootFromPackage(packageRootPath), selectedSuites)];
+  const passed = checks.filter((check) => check.ok).length;
+
+  return {
+    checks,
+    failed: checks.length - passed,
+    passed,
+    suites: selectedSuites.map((suite) => suite.skill),
+  };
+}
+
+function formatFloorSummary(summary: FloorSummary): string {
+  const lines = ["Skill Eval Floor", ""];
+  for (const check of summary.checks) {
+    lines.push(`${check.ok ? "PASS" : "FAIL"}  ${check.name}`);
+    if (!check.ok) {
+      lines.push(`      ${check.detail}`);
+    }
+  }
+  lines.push("", `Total: ${summary.passed}/${summary.checks.length} passed`);
+  return lines.join("\n");
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
+  const summary = buildFloorSummary(options);
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+  } else {
+    process.stdout.write(`${formatFloorSummary(summary)}\n`);
+  }
+  if (summary.failed > 0) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`${message}\n`);
+  process.exitCode = 1;
+});

--- a/packages/skill-evals/src/suites/first-tree-read/eval-cases.ts
+++ b/packages/skill-evals/src/suites/first-tree-read/eval-cases.ts
@@ -1,0 +1,89 @@
+import type { SkillEvalCase } from "../../core/case-schema.js";
+import type { SkillEvalSuiteDefinition } from "../types.js";
+import { FIRST_TREE_READ_CASES } from "./cases.js";
+
+const FLOOR_CASE_ID = "first-tree-read-fixture-validation";
+
+export const FIRST_TREE_READ_EVAL_CASES: readonly SkillEvalCase[] = [
+  {
+    briefingMode: "minimal",
+    expected: {
+      command: "validate:first-tree-read-fixtures",
+      hardOracle: [
+        "skill file read",
+        "first-tree tree tree --help",
+        "selector success",
+        "expected facts",
+        "non-trigger no first-tree usage",
+      ],
+    },
+    fixture: {
+      caseIds: FIRST_TREE_READ_CASES.map((evalCase) => evalCase.id),
+      workspaceKinds: ["blank", "context-tree"],
+    },
+    id: FLOOR_CASE_ID,
+    skill: "first-tree-read",
+    status: "implemented",
+    tier: "floor",
+  },
+  ...FIRST_TREE_READ_CASES.map(
+    (evalCase): SkillEvalCase => ({
+      briefingMode: "minimal",
+      expected: {
+        expectedFacts: evalCase.expectedFacts,
+        expectedTrigger: evalCase.expectedTrigger,
+      },
+      fixture: {
+        workspaceKind: evalCase.workspaceKind,
+      },
+      id: evalCase.id,
+      prompt: evalCase.prompt,
+      provider: "codex",
+      skill: "first-tree-read",
+      status: "implemented",
+      tags: evalCase.expectedTrigger ? ["trigger"] : ["non-trigger"],
+      tier: "gate",
+    }),
+  ),
+];
+
+function validateFirstTreeReadFloor(cases: readonly SkillEvalCase[]): readonly string[] {
+  const errors: string[] = [];
+  const floor = cases.find((evalCase) => evalCase.id === FLOOR_CASE_ID);
+  if (!floor || typeof floor.fixture !== "object" || floor.fixture === null || Array.isArray(floor.fixture)) {
+    return [`${FLOOR_CASE_ID}: missing fixture object.`];
+  }
+
+  const fixture = floor.fixture as { caseIds?: unknown; workspaceKinds?: unknown };
+  if (!Array.isArray(fixture.caseIds) || fixture.caseIds.length !== FIRST_TREE_READ_CASES.length) {
+    errors.push(`${FLOOR_CASE_ID}: fixture must list all first-tree-read case ids.`);
+  }
+  if (!Array.isArray(fixture.workspaceKinds) || !fixture.workspaceKinds.includes("context-tree")) {
+    errors.push(`${FLOOR_CASE_ID}: fixture must include context-tree workspace kind.`);
+  }
+
+  return errors;
+}
+
+export const FIRST_TREE_READ_SUITE: SkillEvalSuiteDefinition = {
+  cases: FIRST_TREE_READ_EVAL_CASES,
+  coverage: {
+    skill: "first-tree-read",
+    tiers: [
+      {
+        caseIds: [FLOOR_CASE_ID],
+        description: "Validate skill file and existing read fixture coverage without model calls.",
+        status: "implemented",
+        tier: "floor",
+      },
+      {
+        caseIds: FIRST_TREE_READ_CASES.map((evalCase) => evalCase.id),
+        description: "Run the existing three live read cases through the migrated suite.",
+        status: "implemented",
+        tier: "gate",
+      },
+    ],
+  },
+  skill: "first-tree-read",
+  validateFloor: validateFirstTreeReadFloor,
+};

--- a/packages/skill-evals/src/suites/first-tree-seed/cases.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/cases.ts
@@ -1,0 +1,127 @@
+import type { SkillEvalCase } from "../../core/case-schema.js";
+import type { SkillEvalSuiteDefinition } from "../types.js";
+
+const FLOOR_CASE_ID = "first-tree-seed-static-coverage";
+
+const GATE_CASES: readonly SkillEvalCase[] = [
+  {
+    briefingMode: "generated-fixture",
+    expected: {
+      action: "write_phase1_skeleton",
+      phase: "phase1",
+    },
+    fixture: {
+      sourceRepoState: "bare-readable",
+      treeState: "empty",
+    },
+    forbidden: {
+      sideEffects: ["phase2_leaf_content_before_approval"],
+    },
+    id: "first-tree-seed-empty-tree-phase1",
+    prompt: "Bootstrap the newly provisioned empty Context Tree.",
+    skill: "first-tree-seed",
+    status: "planned",
+    tags: ["empty-tree", "phase-boundary"],
+    tier: "gate",
+  },
+  {
+    briefingMode: "generated-fixture",
+    expected: {
+      action: "refuse_nonempty_tree",
+      treeDiff: "none",
+    },
+    fixture: {
+      sourceRepoState: "bare-readable",
+      treeState: "nonempty",
+    },
+    forbidden: {
+      sideEffects: ["tree_seed", "tree_pr"],
+    },
+    id: "first-tree-seed-nonempty-refuses",
+    prompt: "Seed this Context Tree.",
+    skill: "first-tree-seed",
+    status: "planned",
+    tags: ["lifecycle-boundary"],
+    tier: "gate",
+  },
+  {
+    briefingMode: "generated-fixture",
+    expected: {
+      action: "report_missing_source",
+      treeDiff: "none",
+    },
+    fixture: {
+      sourceRepoState: "missing",
+      treeState: "empty",
+    },
+    forbidden: {
+      sideEffects: ["tree_seed", "tree_pr"],
+    },
+    id: "first-tree-seed-missing-source-refuses",
+    prompt: "Bootstrap the new Context Tree from the bound source repository.",
+    skill: "first-tree-seed",
+    status: "planned",
+    tags: ["source-boundary"],
+    tier: "gate",
+  },
+];
+
+export const FIRST_TREE_SEED_EVAL_CASES: readonly SkillEvalCase[] = [
+  {
+    briefingMode: "generated-fixture",
+    expected: {
+      gateCaseIds: GATE_CASES.map((evalCase) => evalCase.id),
+      validator: "case schema and lifecycle fixture shape",
+    },
+    fixture: {
+      sourceRepoStates: ["bare-readable", "missing"],
+      treeStates: ["empty", "nonempty"],
+    },
+    id: FLOOR_CASE_ID,
+    skill: "first-tree-seed",
+    status: "implemented",
+    tier: "floor",
+  },
+  ...GATE_CASES,
+];
+
+function validateFirstTreeSeedFloor(cases: readonly SkillEvalCase[]): readonly string[] {
+  const errors: string[] = [];
+  for (const evalCase of cases.filter((candidate) => candidate.skill === "first-tree-seed")) {
+    if (typeof evalCase.fixture !== "object" || evalCase.fixture === null || Array.isArray(evalCase.fixture)) {
+      errors.push(`${evalCase.id}: fixture must be an object.`);
+      continue;
+    }
+    const fixture = evalCase.fixture as { sourceRepoState?: unknown; treeState?: unknown };
+    if (evalCase.tier === "gate" && typeof fixture.sourceRepoState !== "string") {
+      errors.push(`${evalCase.id}: gate fixture must declare sourceRepoState.`);
+    }
+    if (evalCase.tier === "gate" && typeof fixture.treeState !== "string") {
+      errors.push(`${evalCase.id}: gate fixture must declare treeState.`);
+    }
+  }
+  return errors;
+}
+
+export const FIRST_TREE_SEED_SUITE: SkillEvalSuiteDefinition = {
+  cases: FIRST_TREE_SEED_EVAL_CASES,
+  coverage: {
+    skill: "first-tree-seed",
+    tiers: [
+      {
+        caseIds: [FLOOR_CASE_ID],
+        description: "Validate seed suite case schema and empty/nonempty source fixture shape.",
+        status: "implemented",
+        tier: "floor",
+      },
+      {
+        caseIds: GATE_CASES.map((evalCase) => evalCase.id),
+        description: "Planned lifecycle, source, and phase-boundary live gate cases.",
+        status: "planned",
+        tier: "gate",
+      },
+    ],
+  },
+  skill: "first-tree-seed",
+  validateFloor: validateFirstTreeSeedFloor,
+};

--- a/packages/skill-evals/src/suites/first-tree-welcome/cases.ts
+++ b/packages/skill-evals/src/suites/first-tree-welcome/cases.ts
@@ -1,0 +1,192 @@
+import type { SkillEvalCase } from "../../core/case-schema.js";
+import type { SkillEvalSuiteDefinition } from "../types.js";
+
+const FLOOR_CASE_ID = "first-tree-welcome-setup-matrix";
+
+const WELCOME_ROWS = [
+  {
+    action: "route_to_tree_skill",
+    id: "first-tree-welcome-tree-kickoff-chat",
+    kickoffKind: "tree",
+    prompt: "First Tree system kickoff: prepare this workspace tree.",
+    repoState: "unknown",
+    role: "admin",
+    treeState: "unknown",
+  },
+  {
+    action: "invitee_waits_for_team_readiness",
+    id: "first-tree-welcome-invitee-not-ready",
+    kickoffKind: "intro",
+    prompt: "Introduce First Tree to this invited teammate.",
+    repoState: "none",
+    role: "invitee",
+    treeState: "none",
+  },
+  {
+    action: "ask_for_repo_path_or_url",
+    id: "first-tree-welcome-no-repo-intro",
+    kickoffKind: "intro",
+    prompt: "Welcome the user and help them get value from First Tree.",
+    repoState: "none",
+    role: "admin",
+    treeState: "none",
+  },
+  {
+    action: "report_auth_failure_without_claiming_repo_read",
+    id: "first-tree-welcome-repo-auth-fails",
+    kickoffKind: "intro",
+    prompt: "Welcome the user using the selected repository.",
+    repoState: "selected-auth-fails",
+    role: "admin",
+    treeState: "unknown",
+  },
+  {
+    action: "value_first_then_setup_handoff",
+    id: "first-tree-welcome-admin-missing-github-app",
+    kickoffKind: "intro",
+    prompt: "Welcome the admin using local repository evidence.",
+    repoState: "local-readable",
+    role: "admin",
+    treeState: "unknown",
+  },
+  {
+    action: "guide_repo_selection_without_claiming_repo_read",
+    id: "first-tree-welcome-app-installed-no-repo-selected",
+    kickoffKind: "intro",
+    prompt: "Welcome the admin after GitHub App installation.",
+    repoState: "none",
+    role: "admin",
+    treeState: "unknown",
+  },
+  {
+    action: "offer_code_value_without_tree_setup_task",
+    id: "first-tree-welcome-readable-repo-empty-tree",
+    kickoffKind: "work",
+    prompt: "Help the user pick the first valuable task.",
+    repoState: "selected-readable",
+    role: "admin",
+    treeState: "empty",
+  },
+  {
+    action: "offer_bounded_first_tasks_from_repo_and_tree",
+    id: "first-tree-welcome-readable-repo-populated-tree",
+    kickoffKind: "work",
+    prompt: "Use repo and Context Tree evidence to suggest first work.",
+    repoState: "selected-readable",
+    role: "admin",
+    treeState: "populated",
+  },
+  {
+    action: "offer_repo_value_without_claiming_tree_ready",
+    id: "first-tree-welcome-readable-repo-tree-unknown",
+    kickoffKind: "work",
+    prompt: "Use available repo evidence to suggest first work.",
+    repoState: "selected-readable",
+    role: "admin",
+    treeState: "unknown",
+  },
+] as const;
+
+const GATE_CASES: readonly SkillEvalCase[] = WELCOME_ROWS.map(
+  (row): SkillEvalCase => ({
+    briefingMode: "generated-fixture",
+    expected: {
+      action: row.action,
+      forbiddenClaims: ["repo read without evidence", "tree ready without evidence"],
+    },
+    fixture: {
+      githubAppState:
+        row.id === "first-tree-welcome-admin-missing-github-app"
+          ? "missing"
+          : row.id === "first-tree-welcome-app-installed-no-repo-selected"
+            ? "installed"
+            : "unknown",
+      kickoffKind: row.kickoffKind,
+      repoState: row.repoState,
+      role: row.role,
+      treeSetupChat: row.kickoffKind === "tree" ? "exists" : "absent",
+      treeState: row.treeState,
+    },
+    forbidden: {
+      sideEffects: ["github_auth", "tree_seed", "tree_pr"],
+    },
+    id: row.id,
+    prompt: row.prompt,
+    skill: "first-tree-welcome",
+    status: "planned",
+    tags: ["onboarding-matrix"],
+    tier: "gate",
+  }),
+);
+
+export const FIRST_TREE_WELCOME_EVAL_CASES: readonly SkillEvalCase[] = [
+  {
+    briefingMode: "generated-fixture",
+    expected: {
+      matrixRows: WELCOME_ROWS.length,
+      validator: "9-row onboarding setup matrix",
+    },
+    fixture: {
+      kickoffKinds: ["intro", "work", "tree"],
+      repoStates: ["none", "local-readable", "selected-readable", "selected-auth-fails", "unknown"],
+      roles: ["admin", "invitee"],
+      treeStates: ["none", "empty", "populated", "unknown"],
+    },
+    id: FLOOR_CASE_ID,
+    skill: "first-tree-welcome",
+    status: "implemented",
+    tier: "floor",
+  },
+  ...GATE_CASES,
+];
+
+function validateFirstTreeWelcomeFloor(cases: readonly SkillEvalCase[]): readonly string[] {
+  const errors: string[] = [];
+  const gateRows = cases.filter((evalCase) => evalCase.skill === "first-tree-welcome" && evalCase.tier === "gate");
+  if (gateRows.length !== 9) {
+    errors.push(`welcome matrix must declare 9 gate rows, found ${gateRows.length}.`);
+  }
+
+  for (const evalCase of gateRows) {
+    if (typeof evalCase.fixture !== "object" || evalCase.fixture === null || Array.isArray(evalCase.fixture)) {
+      errors.push(`${evalCase.id}: fixture must be an object.`);
+      continue;
+    }
+    const fixture = evalCase.fixture as {
+      kickoffKind?: unknown;
+      repoState?: unknown;
+      role?: unknown;
+      treeState?: unknown;
+    };
+    for (const field of ["role", "kickoffKind", "repoState", "treeState"] as const) {
+      if (typeof fixture[field] !== "string") {
+        errors.push(`${evalCase.id}: fixture must declare ${field}.`);
+      }
+    }
+  }
+
+  return errors;
+}
+
+export const FIRST_TREE_WELCOME_SUITE: SkillEvalSuiteDefinition = {
+  cases: FIRST_TREE_WELCOME_EVAL_CASES,
+  coverage: {
+    skill: "first-tree-welcome",
+    tiers: [
+      {
+        caseIds: [FLOOR_CASE_ID],
+        description: "Validate the 9-row onboarding setup matrix schema.",
+        status: "implemented",
+        tier: "floor",
+      },
+      {
+        caseIds: GATE_CASES.map((evalCase) => evalCase.id),
+        description: "Planned welcome onboarding matrix live gate rows.",
+        status: "planned",
+        tier: "gate",
+      },
+    ],
+  },
+  skill: "first-tree-welcome",
+  validateFloor: validateFirstTreeWelcomeFloor,
+};

--- a/packages/skill-evals/src/suites/first-tree-write/cases.ts
+++ b/packages/skill-evals/src/suites/first-tree-write/cases.ts
@@ -1,0 +1,127 @@
+import type { SkillEvalCase } from "../../core/case-schema.js";
+import type { SkillEvalSuiteDefinition } from "../types.js";
+
+const FLOOR_CASE_ID = "first-tree-write-static-coverage";
+
+const GATE_CASES: readonly SkillEvalCase[] = [
+  {
+    briefingMode: "minimal",
+    expected: {
+      action: "refuse_without_source",
+      treeDiff: "none",
+    },
+    fixture: {
+      sourceArtifact: "absent",
+      treeState: "populated",
+    },
+    forbidden: {
+      sideEffects: ["tree_write", "tree_pr"],
+    },
+    id: "first-tree-write-no-source-refuses",
+    prompt: "Update the Context Tree with the latest architecture decision.",
+    skill: "first-tree-write",
+    status: "planned",
+    tags: ["source-boundary"],
+    tier: "gate",
+  },
+  {
+    briefingMode: "minimal",
+    expected: {
+      action: "write_minimal_tree_diff",
+      verify: true,
+    },
+    fixture: {
+      sourceArtifact: "durable-decision-note",
+      treeState: "populated",
+    },
+    forbidden: {
+      content: ["PR id", "implementation detail", "history narration", "## Source"],
+    },
+    id: "first-tree-write-durable-source-writes",
+    prompt: "Reflect this design note into the Context Tree.",
+    skill: "first-tree-write",
+    status: "planned",
+    tags: ["tree-diff", "verify"],
+    tier: "gate",
+  },
+  {
+    briefingMode: "minimal",
+    expected: {
+      action: "refuse_implementation_only_source",
+      treeDiff: "none",
+    },
+    fixture: {
+      sourceArtifact: "implementation-only-diff",
+      treeState: "populated",
+    },
+    forbidden: {
+      sideEffects: ["tree_write", "tree_pr"],
+    },
+    id: "first-tree-write-implementation-only-no-write",
+    prompt: "Put this implementation-only diff into the Context Tree.",
+    skill: "first-tree-write",
+    status: "planned",
+    tags: ["source-boundary"],
+    tier: "gate",
+  },
+];
+
+export const FIRST_TREE_WRITE_EVAL_CASES: readonly SkillEvalCase[] = [
+  {
+    briefingMode: "minimal",
+    expected: {
+      gateCaseIds: GATE_CASES.map((evalCase) => evalCase.id),
+      validator: "case schema and fixture shape",
+    },
+    fixture: {
+      sourceArtifacts: ["absent", "durable-decision-note", "implementation-only-diff"],
+      treeStates: ["populated"],
+    },
+    id: FLOOR_CASE_ID,
+    skill: "first-tree-write",
+    status: "implemented",
+    tier: "floor",
+  },
+  ...GATE_CASES,
+];
+
+function validateFirstTreeWriteFloor(cases: readonly SkillEvalCase[]): readonly string[] {
+  const errors: string[] = [];
+  for (const evalCase of cases.filter((candidate) => candidate.skill === "first-tree-write")) {
+    if (typeof evalCase.fixture !== "object" || evalCase.fixture === null || Array.isArray(evalCase.fixture)) {
+      errors.push(`${evalCase.id}: fixture must be an object.`);
+      continue;
+    }
+    const fixture = evalCase.fixture as { sourceArtifact?: unknown; treeState?: unknown };
+    if (evalCase.tier === "gate" && typeof fixture.sourceArtifact !== "string") {
+      errors.push(`${evalCase.id}: gate fixture must declare sourceArtifact.`);
+    }
+    if (evalCase.tier === "gate" && typeof fixture.treeState !== "string") {
+      errors.push(`${evalCase.id}: gate fixture must declare treeState.`);
+    }
+  }
+  return errors;
+}
+
+export const FIRST_TREE_WRITE_SUITE: SkillEvalSuiteDefinition = {
+  cases: FIRST_TREE_WRITE_EVAL_CASES,
+  coverage: {
+    skill: "first-tree-write",
+    tiers: [
+      {
+        caseIds: [FLOOR_CASE_ID],
+        description: "Validate write suite case schema and source/tree fixture shape.",
+        status: "implemented",
+        tier: "floor",
+      },
+      {
+        caseIds: GATE_CASES.map((evalCase) => evalCase.id),
+        description: "Planned source-boundary and tree-diff live gate cases.",
+        status: "planned",
+        tier: "gate",
+      },
+    ],
+  },
+  skill: "first-tree-write",
+  validateFloor: validateFirstTreeWriteFloor,
+};

--- a/packages/skill-evals/src/suites/registry.ts
+++ b/packages/skill-evals/src/suites/registry.ts
@@ -1,0 +1,12 @@
+import type { SkillEvalSuiteDefinition } from "../core/coverage.js";
+import { FIRST_TREE_READ_SUITE } from "./first-tree-read/eval-cases.js";
+import { FIRST_TREE_SEED_SUITE } from "./first-tree-seed/cases.js";
+import { FIRST_TREE_WELCOME_SUITE } from "./first-tree-welcome/cases.js";
+import { FIRST_TREE_WRITE_SUITE } from "./first-tree-write/cases.js";
+
+export const SKILL_EVAL_SUITES: readonly SkillEvalSuiteDefinition[] = [
+  FIRST_TREE_READ_SUITE,
+  FIRST_TREE_WRITE_SUITE,
+  FIRST_TREE_SEED_SUITE,
+  FIRST_TREE_WELCOME_SUITE,
+];

--- a/packages/skill-evals/src/suites/types.ts
+++ b/packages/skill-evals/src/suites/types.ts
@@ -1,0 +1,1 @@
+export type { SkillEvalSuiteDefinition } from "../core/coverage.js";


### PR DESCRIPTION
## Summary

- Add a shared skill-eval case schema, result schema, coverage matrix validation, and skill frontmatter reader.
- Register floor/gate coverage declarations for `first-tree-read`, `first-tree-write`, `first-tree-seed`, and `first-tree-welcome`.
- Add the no-model `eval:floor` command plus README notes and tests, while leaving live write/welcome/seed gates, judge, selection, and compare out of scope.

## Verification

- `pnpm --filter @first-tree/skill-evals eval:floor`
- `pnpm --filter @first-tree/skill-evals eval:floor -- --json`
- `pnpm --filter @first-tree/skill-evals eval:floor -- --suite first-tree-read`
- `pnpm --filter @first-tree/skill-evals eval:floor -- --suite first-tree-write`
- `pnpm --filter @first-tree/skill-evals eval:floor -- --suite first-tree-seed`
- `pnpm --filter @first-tree/skill-evals eval:floor -- --suite first-tree-welcome`
- `pnpm --filter @first-tree/skill-evals test`
- `pnpm --filter @first-tree/skill-evals typecheck`
- `pnpm exec biome check packages/skill-evals/src packages/skill-evals/package.json packages/skill-evals/README.md`
- `pnpm --filter @first-tree/shared build`
- `pnpm --filter @first-tree/client build`
- `pnpm --filter @first-tree/skill-evals validate:first-tree-read-fixtures`

## Live model eval

After review, I also ran the existing live Codex read eval on request:

- `pnpm --filter @first-tree/skill-evals eval:first-tree-read`

Result: failed 1 of 3 cases. The two non-trigger cases passed. `tree-software-trigger` failed because Codex did load `first-tree-read`, ran `tree tree --help`, succeeded on selector discovery, and read the relevant tree nodes, but also attempted invalid path selectors and its final answer did not match the current exact expected-facts matcher. Artifact path: `packages/skill-evals/.runs/20260626T091402609Z-tree-software-trigger/summary.md`.

This does not indicate a PR2 regression: PR2 does not change the live read runner or read metrics; the newly added write/seed/welcome cases are static planned case declarations covered by `eval:floor`, not executable live gates yet.
