### PR TITLE
Add first-tree-write skill eval gate

### DIFF
--- a/packages/skill-evals/README.md
+++ b/packages/skill-evals/README.md
@@ -8,6 +8,7 @@ quota.
 
 ```bash
 pnpm --filter @first-tree/skill-evals eval:floor
+pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-write
 pnpm --filter @first-tree/skill-evals eval:first-tree-read
 pnpm --filter @first-tree/skill-evals eval:first-tree-read -- --case tree-software-trigger
 pnpm --filter @first-tree/skill-evals eval:first-tree-read -- --json
@@ -21,10 +22,18 @@ matrix, their `SKILL.md` frontmatter is readable, and their case declarations
 have the minimum schema required by the shared runner. It does not execute
 Codex, Claude Code, LLM-as-judge, or live gate cases.
 
+`eval:gate -- --suite first-tree-write` runs the live Codex gate for
+`first-tree-write`. It covers the minimum source-boundary cases:
+
+- no source artifact means no Context Tree diff;
+- durable source material can produce a minimal tree diff and must run
+  `first-tree tree verify`;
+- implementation-only source material means no Context Tree diff.
+
 The runner creates isolated temporary workspaces under
 `packages/skill-evals/.runs/<timestamp>-<case-id>/`, installs
-`first-tree-read`, prepends a `first-tree` shim to `PATH`, and runs
-`codex exec --json` from the case workspace.
+the relevant skill, prepends a `first-tree` shim to `PATH`, and runs
+`codex exec --json` from the case workspace for live eval commands.
 
 Each case writes:
 

--- a/packages/skill-evals/package.json
+++ b/packages/skill-evals/package.json
@@ -6,6 +6,7 @@
   "description": "Opt-in live model evaluations for First Tree skills.",
   "scripts": {
     "eval:floor": "tsx src/index.ts floor",
+    "eval:gate": "tsx src/index.ts gate",
     "eval:first-tree-read": "tsx src/first-tree-read/index.ts",
     "test": "vitest run --passWithNoTests",
     "validate:first-tree-read-fixtures": "tsx src/first-tree-read/index.ts --validate-fixtures",

--- a/packages/skill-evals/src/core/__tests__/coverage.test.ts
+++ b/packages/skill-evals/src/core/__tests__/coverage.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { SKILL_EVAL_SUITES } from "../../suites/registry.js";
 import { SHIPPED_SKILLS } from "../case-schema.js";
-import { validateCoverageMatrix } from "../coverage.js";
+import { type SkillEvalSuiteDefinition, validateCoverageMatrix } from "../coverage.js";
 
 describe("skill eval coverage matrix", () => {
   it("covers every shipped First Tree skill with floor and gate entries", () => {
@@ -13,5 +13,58 @@ describe("skill eval coverage matrix", () => {
     for (const skill of SHIPPED_SKILLS) {
       expect(suiteSkills.has(skill)).toBe(true);
     }
+  });
+
+  it("rejects tier entries that reference a case from another tier", () => {
+    const invalidSuite: SkillEvalSuiteDefinition = {
+      cases: [
+        {
+          briefingMode: "minimal",
+          expected: {},
+          fixture: {},
+          id: "static-floor",
+          skill: "first-tree-read",
+          status: "implemented",
+          tier: "floor",
+        },
+        {
+          briefingMode: "minimal",
+          expected: {},
+          fixture: {},
+          id: "live-gate",
+          prompt: "Run a gate case.",
+          provider: "codex",
+          skill: "first-tree-read",
+          status: "implemented",
+          tier: "gate",
+        },
+      ],
+      coverage: {
+        skill: "first-tree-read",
+        tiers: [
+          {
+            caseIds: ["live-gate"],
+            description: "bad floor",
+            status: "implemented",
+            tier: "floor",
+          },
+          {
+            caseIds: ["live-gate"],
+            description: "gate",
+            status: "implemented",
+            tier: "gate",
+          },
+        ],
+      },
+      skill: "first-tree-read",
+    };
+
+    const validation = validateCoverageMatrix([
+      invalidSuite,
+      ...SKILL_EVAL_SUITES.filter((suite) => suite.skill !== "first-tree-read"),
+    ]);
+
+    expect(validation.ok).toBe(false);
+    expect(validation.errors).toContain("first-tree-read: floor coverage references gate case live-gate.");
   });
 });

--- a/packages/skill-evals/src/core/coverage.ts
+++ b/packages/skill-evals/src/core/coverage.ts
@@ -64,10 +64,20 @@ export function validateCoverageMatrix(suites: readonly SkillEvalSuiteDefinition
     }
 
     const suiteCaseIds = new Set(suite.cases.map((evalCase) => evalCase.id));
+    const suiteCasesById = new Map(suite.cases.map((evalCase) => [evalCase.id, evalCase]));
     for (const tierEntry of suite.coverage.tiers) {
       for (const caseId of tierEntry.caseIds) {
         if (!suiteCaseIds.has(caseId)) {
           errors.push(`${suite.skill}: coverage references unknown case ${caseId}.`);
+          continue;
+        }
+
+        const evalCase = suiteCasesById.get(caseId);
+        if (evalCase?.skill !== suite.skill) {
+          errors.push(`${suite.skill}: coverage references case ${caseId} with skill ${evalCase?.skill}.`);
+        }
+        if (evalCase?.tier !== tierEntry.tier) {
+          errors.push(`${suite.skill}: ${tierEntry.tier} coverage references ${evalCase?.tier} case ${caseId}.`);
         }
       }
     }

--- a/packages/skill-evals/src/index.ts
+++ b/packages/skill-evals/src/index.ts
@@ -6,12 +6,17 @@ import { SHIPPED_SKILLS, type ShippedSkillName } from "./core/case-schema.js";
 import { type SkillEvalSuiteDefinition, validateCoverageMatrix } from "./core/coverage.js";
 import { isRecord } from "./core/events.js";
 import { readSkillFrontmatter } from "./core/skills/frontmatter.js";
+import { formatFirstTreeWriteGateSummary, runFirstTreeWriteGate } from "./suites/first-tree-write/index.js";
 import { SKILL_EVAL_SUITES } from "./suites/registry.js";
 
 type CliOptions = {
-  command: "floor";
+  caseId: string | null;
+  codexBin: string;
+  command: "floor" | "gate";
   json: boolean;
+  model: string | null;
   suite: ShippedSkillName | null;
+  verbose: boolean;
 };
 
 type FloorCheck = {
@@ -32,13 +37,19 @@ function usage(): string {
   pnpm --filter @first-tree/skill-evals eval:floor
   pnpm --filter @first-tree/skill-evals eval:floor -- --json
   pnpm --filter @first-tree/skill-evals eval:floor -- --suite <skill>
+  pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-write
 
 Commands:
   floor                  Run no-model schema, coverage, and skill-file checks.
+  gate                   Run a live model gate suite.
 
 Options:
   --suite <skill>        Limit per-suite floor checks to one shipped skill.
+  --case <id>            Run one live gate case.
   --json                 Print summary as JSON.
+  --model <model>        Pass a model override to codex exec.
+  --codex-bin <path>     Codex binary to execute. Defaults to CODEX_BIN or codex.
+  --verbose              Print live readable progress to stderr.
   --help                 Show this help.
 `;
 }
@@ -58,20 +69,29 @@ function parseArgs(args: readonly string[]): CliOptions {
     process.stdout.write(usage());
     process.exit(0);
   }
-  if (command !== "floor") {
+  if (command !== "floor" && command !== "gate") {
     throw new Error(`Unknown command: ${command}`);
   }
 
   const options: CliOptions = {
+    caseId: null,
+    codexBin: process.env.CODEX_BIN ?? "codex",
     command,
     json: false,
+    model: process.env.CODEX_MODEL ?? null,
     suite: null,
+    verbose: false,
   };
 
   for (let index = 1; index < normalized.length; index += 1) {
     const arg = normalized[index];
     if (arg === "--json") {
       options.json = true;
+      continue;
+    }
+    if (arg === "--case") {
+      options.caseId = readOptionValue(normalized, index, "--case");
+      index += 1;
       continue;
     }
     if (arg === "--suite") {
@@ -81,6 +101,20 @@ function parseArgs(args: readonly string[]): CliOptions {
       }
       options.suite = suite as ShippedSkillName;
       index += 1;
+      continue;
+    }
+    if (arg === "--model") {
+      options.model = readOptionValue(normalized, index, "--model");
+      index += 1;
+      continue;
+    }
+    if (arg === "--codex-bin") {
+      options.codexBin = readOptionValue(normalized, index, "--codex-bin");
+      index += 1;
+      continue;
+    }
+    if (arg === "--verbose") {
+      options.verbose = true;
       continue;
     }
     if (arg === "--help" || arg === "-h") {
@@ -187,8 +221,35 @@ function formatFloorSummary(summary: FloorSummary): string {
   return lines.join("\n");
 }
 
+async function runGate(options: CliOptions): Promise<void> {
+  if (options.suite !== "first-tree-write") {
+    throw new Error("eval:gate currently requires --suite first-tree-write.");
+  }
+
+  const batch = await runFirstTreeWriteGate(packageRoot(), {
+    caseId: options.caseId,
+    codexBin: options.codexBin,
+    json: options.json,
+    model: options.model,
+    verbose: options.verbose,
+  });
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify(batch, null, 2)}\n`);
+  } else {
+    process.stdout.write(`${formatFirstTreeWriteGateSummary(batch)}\n`);
+  }
+  if (batch.failed > 0) {
+    process.exitCode = 1;
+  }
+}
+
 async function main(): Promise<void> {
   const options = parseArgs(process.argv.slice(2));
+  if (options.command === "gate") {
+    await runGate(options);
+    return;
+  }
+
   const summary = buildFloorSummary(options);
   if (options.json) {
     process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);

--- a/packages/skill-evals/src/suites/first-tree-write/__tests__/grader.test.ts
+++ b/packages/skill-evals/src/suites/first-tree-write/__tests__/grader.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import { FIRST_TREE_WRITE_GATE_CASES } from "../cases.js";
+import { casePassed } from "../grader.js";
+import type { EvalMetrics, FirstTreeWriteEvalCase } from "../types.js";
+
+function findCase(id: string): FirstTreeWriteEvalCase {
+  const evalCase = FIRST_TREE_WRITE_GATE_CASES.find((candidate) => candidate.id === id);
+  if (!evalCase) throw new Error(`Missing test case ${id}`);
+  return evalCase;
+}
+
+function baseMetrics(overrides: Partial<EvalMetrics>): EvalMetrics {
+  return {
+    expectedDiffSnippetsObserved: true,
+    expectedResponseObserved: true,
+    finalResponse: "Done.",
+    firstTreeArgv: [],
+    firstTreeCommandResults: [],
+    fixtureValidationOk: true,
+    forbiddenContentHits: [],
+    runnerExitCode: 0,
+    skillFileReadObserved: true,
+    sourceRepoChanged: false,
+    treeChanged: false,
+    treeDiff: "",
+    treeStatus: "",
+    verifySucceeded: false,
+    ...overrides,
+  };
+}
+
+describe("first-tree-write grader", () => {
+  it("passes no-source when the model reads the skill, refuses, and leaves the tree unchanged", () => {
+    expect(
+      casePassed(findCase("no-source-refuses"), baseMetrics({ finalResponse: "Please provide a source artifact." })),
+    ).toBe(true);
+  });
+
+  it("fails no-source when the tree changed", () => {
+    expect(
+      casePassed(
+        findCase("no-source-refuses"),
+        baseMetrics({
+          treeChanged: true,
+          treeDiff: "+Unexpected write\n",
+          treeStatus: " M system/context-management/skill-eval-framework.md\n",
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("passes durable source when the tree changes and verify succeeds", () => {
+    expect(
+      casePassed(
+        findCase("durable-source-writes"),
+        baseMetrics({
+          finalResponse: "Updated the tree and verify passed.",
+          treeChanged: true,
+          treeDiff: "+Deterministic gates are separate from quality judges.\n",
+          treeStatus: " M system/context-management/skill-eval-framework.md\n",
+          verifySucceeded: true,
+        }),
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/skill-evals/src/suites/first-tree-write/cases.ts
+++ b/packages/skill-evals/src/suites/first-tree-write/cases.ts
@@ -1,13 +1,16 @@
 import type { SkillEvalCase } from "../../core/case-schema.js";
 import type { SkillEvalSuiteDefinition } from "../types.js";
+import type { FirstTreeWriteEvalCase } from "./types.js";
 
 const FLOOR_CASE_ID = "first-tree-write-static-coverage";
 
-const GATE_CASES: readonly SkillEvalCase[] = [
+export const FIRST_TREE_WRITE_GATE_CASES: readonly FirstTreeWriteEvalCase[] = [
   {
     briefingMode: "minimal",
     expected: {
       action: "refuse_without_source",
+      requireVerify: false,
+      responseHints: ["source", "artifact", "provide"],
       treeDiff: "none",
     },
     fixture: {
@@ -15,12 +18,15 @@ const GATE_CASES: readonly SkillEvalCase[] = [
       treeState: "populated",
     },
     forbidden: {
+      content: ["## Source", "Shipped in", "PR #", "function ", "interface ", "## Owners"],
       sideEffects: ["tree_write", "tree_pr"],
     },
-    id: "first-tree-write-no-source-refuses",
-    prompt: "Update the Context Tree with the latest architecture decision.",
+    id: "no-source-refuses",
+    prompt:
+      "Use first-tree-write to update the Context Tree with the latest architecture decision. No source artifact is available in this workspace.",
+    provider: "codex",
     skill: "first-tree-write",
-    status: "planned",
+    status: "implemented",
     tags: ["source-boundary"],
     tier: "gate",
   },
@@ -28,19 +34,24 @@ const GATE_CASES: readonly SkillEvalCase[] = [
     briefingMode: "minimal",
     expected: {
       action: "write_minimal_tree_diff",
-      verify: true,
+      requiredDiffSnippets: ["deterministic", "quality", "judge"],
+      requireVerify: true,
+      responseHints: ["updated", "verify"],
+      treeDiff: "minimal",
     },
     fixture: {
       sourceArtifact: "durable-decision-note",
       treeState: "populated",
     },
     forbidden: {
-      content: ["PR id", "implementation detail", "history narration", "## Source"],
+      content: ["## Source", "Shipped in", "PR #", "function ", "interface ", "GET /", "## Owners"],
+      sideEffects: ["source_write"],
     },
-    id: "first-tree-write-durable-source-writes",
-    prompt: "Reflect this design note into the Context Tree.",
+    id: "durable-source-writes",
+    prompt: "Use first-tree-write to reflect `source-artifacts/durable-decision-note.md` into the Context Tree.",
+    provider: "codex",
     skill: "first-tree-write",
-    status: "planned",
+    status: "implemented",
     tags: ["tree-diff", "verify"],
     tier: "gate",
   },
@@ -48,6 +59,8 @@ const GATE_CASES: readonly SkillEvalCase[] = [
     briefingMode: "minimal",
     expected: {
       action: "refuse_implementation_only_source",
+      requireVerify: false,
+      responseHints: ["implementation", "detail", "not belong", "does not belong", "durable"],
       treeDiff: "none",
     },
     fixture: {
@@ -55,12 +68,15 @@ const GATE_CASES: readonly SkillEvalCase[] = [
       treeState: "populated",
     },
     forbidden: {
+      content: ["## Source", "Shipped in", "PR #", "function create", "interface Eval", "GET /"],
       sideEffects: ["tree_write", "tree_pr"],
     },
-    id: "first-tree-write-implementation-only-no-write",
-    prompt: "Put this implementation-only diff into the Context Tree.",
+    id: "implementation-only-no-write",
+    prompt:
+      "Use first-tree-write to evaluate whether `source-artifacts/implementation-only-diff.md` belongs in the Context Tree.",
+    provider: "codex",
     skill: "first-tree-write",
-    status: "planned",
+    status: "implemented",
     tags: ["source-boundary"],
     tier: "gate",
   },
@@ -70,7 +86,7 @@ export const FIRST_TREE_WRITE_EVAL_CASES: readonly SkillEvalCase[] = [
   {
     briefingMode: "minimal",
     expected: {
-      gateCaseIds: GATE_CASES.map((evalCase) => evalCase.id),
+      gateCaseIds: FIRST_TREE_WRITE_GATE_CASES.map((evalCase) => evalCase.id),
       validator: "case schema and fixture shape",
     },
     fixture: {
@@ -82,7 +98,7 @@ export const FIRST_TREE_WRITE_EVAL_CASES: readonly SkillEvalCase[] = [
     status: "implemented",
     tier: "floor",
   },
-  ...GATE_CASES,
+  ...FIRST_TREE_WRITE_GATE_CASES,
 ];
 
 function validateFirstTreeWriteFloor(cases: readonly SkillEvalCase[]): readonly string[] {
@@ -115,9 +131,9 @@ export const FIRST_TREE_WRITE_SUITE: SkillEvalSuiteDefinition = {
         tier: "floor",
       },
       {
-        caseIds: GATE_CASES.map((evalCase) => evalCase.id),
-        description: "Planned source-boundary and tree-diff live gate cases.",
-        status: "planned",
+        caseIds: FIRST_TREE_WRITE_GATE_CASES.map((evalCase) => evalCase.id),
+        description: "Implemented source-boundary and tree-diff live gate cases.",
+        status: "implemented",
         tier: "gate",
       },
     ],

--- a/packages/skill-evals/src/suites/first-tree-write/fixture.ts
+++ b/packages/skill-evals/src/suites/first-tree-write/fixture.ts
@@ -1,0 +1,377 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+
+import { assertCommandOk, runCommand, writeText } from "../../core/commands.js";
+import { appendEvent, previewText } from "../../core/events.js";
+import type { EvalReporter } from "../../core/reporter.js";
+import { stripShimTraceLines } from "../../core/reporter.js";
+import { installRepoSkill, parseSkillDescription } from "../../core/skills/install.js";
+import type { CommandResult, RunPaths } from "../../core/types.js";
+import type { FirstTreeWriteEvalCase, FixtureValidation } from "./types.js";
+
+const SKILL_NAME = "first-tree-write";
+
+function rootNodeMarkdown(): string {
+  return `---
+title: "First Tree Write Eval Context"
+owners: [eval-owner]
+---
+
+# First Tree Write Eval Context
+
+This deterministic Context Tree fixture is used to evaluate first-tree-write.
+`;
+}
+
+function systemNodeMarkdown(): string {
+  return `---
+title: "System"
+owners: [eval-owner]
+---
+
+# System
+
+System-level durable constraints for the eval fixture.
+`;
+}
+
+function contextManagementNodeMarkdown(): string {
+  return `---
+title: "Context Management"
+owners: [eval-owner]
+---
+
+# Context Management
+
+Context Tree and skill-eval decisions for the eval fixture.
+`;
+}
+
+function skillEvalNodeMarkdown(): string {
+  return `---
+title: "Skill Eval Framework"
+owners: [eval-owner]
+description: "Durable constraints for First Tree skill evals."
+---
+
+# Skill Eval Framework
+
+## Decision
+
+First Tree uses a small skill eval framework to evaluate shipped skills with
+live agent behavior in isolated workspaces.
+
+## Rationale
+
+Agent-backed behavior cannot be made deterministic like ordinary code, so the
+framework records evidence from representative runs instead of pretending those
+flows are unit tests.
+
+## Constraints
+
+- Default test commands do not run live model evals.
+- Eval workspaces keep the source repo and Context Tree repo separate.
+`;
+}
+
+function memberNodeMarkdown(): string {
+  return `---
+title: "eval-owner"
+owners: [eval-owner]
+type: human
+role: "Evaluation fixture owner"
+domains:
+  - "context management"
+---
+
+# eval-owner
+
+Owns the deterministic write eval fixture.
+`;
+}
+
+function treeAgentsMarkdown(): string {
+  return `# Eval Context Tree
+
+This is a local deterministic Context Tree fixture for first-tree-write skill
+evaluations.
+`;
+}
+
+function workspaceAgentsMarkdown(skillDescription: string): string {
+  return `# Eval Workspace Instructions
+
+Use installed skills only when the skill description applies to the user's
+prompt.
+
+## Available Skills
+
+| Skill | Load when |
+|---|---|
+| \`first-tree-write\` | ${skillDescription} |
+
+When \`first-tree-write\` applies, load it by reading
+\`.agents/skills/first-tree-write/SKILL.md\` before acting. Follow the loaded
+skill workflow exactly.
+
+The Context Tree is at \`./context-tree\`. Source artifacts, when present, are
+under \`./source-artifacts\`. Do not create pull requests or push to any remote
+inside this eval workspace.
+`;
+}
+
+function durableSourceMarkdown(): string {
+  return `# Source Artifact: Skill Eval Gate Policy
+
+This design note records a durable decision for the First Tree skill eval
+framework.
+
+## Durable Decision
+
+The skill eval framework separates deterministic gate checks from optional
+quality judges. Hard risk boundaries such as missing source artifacts,
+forbidden tree side effects, and verify failures are deterministic gate checks.
+Subjective content quality belongs to an explicit quality eval.
+
+## Rationale
+
+Default PR gates must stay stable and explainable. LLM-as-judge can help detect
+quality regressions, but it must not hide hard risk failures behind a score.
+
+## Constraint
+
+The default write gate must not invoke LLM-as-judge. Quality judge runs only
+when an explicit quality command or periodic quality run asks for it.
+
+Do not record this source file name, a PR id, or a delivery history in the
+Context Tree node.
+`;
+}
+
+function implementationOnlySourceMarkdown(): string {
+  return `# Source Artifact: Implementation-only diff
+
+The following source material is implementation detail only. It does not record
+a durable decision or rationale.
+
+\`\`\`diff
+- function createWriteRunner(options: RunnerOptions): Promise<Result>
++ function createFirstTreeWriteRunner(options: RunnerOptions): Promise<Result>
+
+- interface EvalCase { id: string; }
++ interface EvalCase { id: string; tags: string[]; }
+
++ GET /api/internal/evals/:id returns raw JSON for debugging.
+\`\`\`
+
+The change is a local refactor of names, interface shape, and one debug route.
+No cross-domain decision was made.
+`;
+}
+
+function installFirstTreeWriteSkill(repoRoot: string, workspacePath: string): void {
+  const skillMarkdown = installRepoSkill(repoRoot, workspacePath, SKILL_NAME);
+  writeText(join(workspacePath, "AGENTS.md"), workspaceAgentsMarkdown(parseSkillDescription(skillMarkdown)));
+}
+
+function writeWorkspaceManifest(paths: RunPaths): void {
+  writeText(
+    join(paths.workspacePath, ".first-tree", "workspace.json"),
+    `${JSON.stringify({ sources: ["source-repo"], tree: "context-tree" }, null, 2)}\n`,
+  );
+}
+
+function writeSourceArtifacts(evalCase: FirstTreeWriteEvalCase, paths: RunPaths): void {
+  const sourceDir = join(paths.workspacePath, "source-artifacts");
+  mkdirSync(sourceDir, { recursive: true });
+
+  if (evalCase.fixture.sourceArtifact === "durable-decision-note") {
+    writeText(join(sourceDir, "durable-decision-note.md"), durableSourceMarkdown());
+  }
+  if (evalCase.fixture.sourceArtifact === "implementation-only-diff") {
+    writeText(join(sourceDir, "implementation-only-diff.md"), implementationOnlySourceMarkdown());
+  }
+}
+
+function writeSourceRepoFixture(paths: RunPaths): void {
+  const sourceRepoPath = join(paths.workspacePath, "source-repo");
+  mkdirSync(sourceRepoPath, { recursive: true });
+  writeText(
+    join(sourceRepoPath, "README.md"),
+    "# Source Repo\n\nThis fixture should remain unchanged by first-tree-write eval cases.\n",
+  );
+  assertCommandOk(runCommand("git", ["init", "--initial-branch=main"], sourceRepoPath));
+  assertCommandOk(runCommand("git", ["config", "user.email", "eval@example.invalid"], sourceRepoPath));
+  assertCommandOk(runCommand("git", ["config", "user.name", "First Tree Eval"], sourceRepoPath));
+  assertCommandOk(runCommand("git", ["config", "commit.gpgsign", "false"], sourceRepoPath));
+  assertCommandOk(runCommand("git", ["add", "."], sourceRepoPath));
+  assertCommandOk(runCommand("git", ["commit", "-m", "chore: seed source fixture"], sourceRepoPath));
+}
+
+function writeContextTreeFixture(paths: RunPaths): string {
+  const contextTreePath = join(paths.workspacePath, "context-tree");
+  mkdirSync(contextTreePath, { recursive: true });
+
+  writeText(join(contextTreePath, ".first-tree", "VERSION"), "0.7.0\n");
+  writeText(
+    join(contextTreePath, ".first-tree", "tree.json"),
+    `${JSON.stringify(
+      {
+        schemaVersion: 1,
+        treeId: "first-tree-write-eval",
+        treeMode: "dedicated",
+        treeRepoName: "context-tree",
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  writeText(join(contextTreePath, "AGENTS.md"), treeAgentsMarkdown());
+  writeText(join(contextTreePath, "NODE.md"), rootNodeMarkdown());
+  writeText(join(contextTreePath, "system", "NODE.md"), systemNodeMarkdown());
+  writeText(join(contextTreePath, "system", "context-management", "NODE.md"), contextManagementNodeMarkdown());
+  writeText(join(contextTreePath, "system", "context-management", "skill-eval-framework.md"), skillEvalNodeMarkdown());
+  writeText(join(contextTreePath, "members", "eval-owner", "NODE.md"), memberNodeMarkdown());
+
+  initializeGitRepo(paths, contextTreePath);
+  return contextTreePath;
+}
+
+function initializeGitRepo(paths: RunPaths, contextTreePath: string): void {
+  const originPath = join(paths.runRoot, "context-tree-origin.git");
+  const commands: CommandResult[] = [
+    runCommand("git", ["init", "--initial-branch=main"], contextTreePath),
+    runCommand("git", ["config", "user.email", "eval@example.invalid"], contextTreePath),
+    runCommand("git", ["config", "user.name", "First Tree Eval"], contextTreePath),
+    runCommand("git", ["config", "commit.gpgsign", "false"], contextTreePath),
+    runCommand("git", ["add", "."], contextTreePath),
+    runCommand("git", ["commit", "-m", "chore: seed eval context tree"], contextTreePath),
+    runCommand("git", ["init", "--bare", originPath], paths.runRoot),
+    runCommand("git", ["remote", "add", "origin", originPath], contextTreePath),
+    runCommand("git", ["push", "-u", "origin", "main"], contextTreePath),
+  ];
+
+  for (const result of commands) {
+    assertCommandOk(result);
+  }
+}
+
+export function setupFixture(evalCase: FirstTreeWriteEvalCase, paths: RunPaths, reporter: EvalReporter): string {
+  appendEvent(paths.eventsPath, {
+    caseId: evalCase.id,
+    sourceArtifact: evalCase.fixture.sourceArtifact,
+    treeState: evalCase.fixture.treeState,
+    type: "fixture_setup_started",
+    workspaceKind: "context-tree",
+  });
+  reporter.fixtureSetupStarted("context-tree");
+
+  installFirstTreeWriteSkill(paths.repoRoot, paths.workspacePath);
+  writeWorkspaceManifest(paths);
+  writeSourceArtifacts(evalCase, paths);
+  writeSourceRepoFixture(paths);
+  const contextTreePath = writeContextTreeFixture(paths);
+
+  appendEvent(paths.eventsPath, {
+    caseId: evalCase.id,
+    contextTreePath,
+    type: "fixture_setup_finished",
+    workspaceKind: "context-tree",
+  });
+  reporter.fixtureSetupFinished("context-tree", contextTreePath);
+
+  return contextTreePath;
+}
+
+function requiredTreeFiles(contextTreePath: string): readonly string[] {
+  return [
+    join(contextTreePath, ".first-tree", "VERSION"),
+    join(contextTreePath, ".first-tree", "tree.json"),
+    join(contextTreePath, "NODE.md"),
+    join(contextTreePath, "system", "NODE.md"),
+    join(contextTreePath, "system", "context-management", "NODE.md"),
+    join(contextTreePath, "system", "context-management", "skill-eval-framework.md"),
+    join(contextTreePath, "members", "eval-owner", "NODE.md"),
+  ];
+}
+
+export function validateFixture(
+  paths: RunPaths,
+  contextTreePath: string,
+  caseId: string,
+  verbose: boolean,
+  reporter: EvalReporter,
+): FixtureValidation {
+  const errors: string[] = [];
+  const missingFiles = requiredTreeFiles(contextTreePath).filter((file) => !existsSync(file));
+  for (const missing of missingFiles) {
+    errors.push(`missing required file: ${missing}`);
+  }
+
+  const verifyResult = runFixtureVerify(paths, contextTreePath, caseId, verbose, reporter);
+  if (verifyResult.exitCode !== 0) {
+    errors.push(
+      `tree verify failed with exit ${verifyResult.exitCode}: ${previewText(verifyResult.stderr || verifyResult.stdout)}`,
+    );
+  }
+
+  return {
+    errors,
+    ok: errors.length === 0,
+    requiredFilesOk: missingFiles.length === 0,
+    verifyResult,
+  };
+}
+
+function runFixtureVerify(
+  paths: RunPaths,
+  contextTreePath: string,
+  caseId: string,
+  verbose: boolean,
+  reporter: EvalReporter,
+): CommandResult {
+  const args = ["tree", "verify", "--tree-path", contextTreePath];
+  appendEvent(paths.eventsPath, {
+    contextTreePath,
+    type: "fixture_validation_started",
+  });
+  reporter.fixtureValidationStarted(args, contextTreePath);
+
+  const env = {
+    ...process.env,
+    FIRST_TREE_EVAL_EVENTS: paths.eventsPath,
+    FIRST_TREE_EVAL_CASE_ID: caseId,
+    FIRST_TREE_EVAL_PHASE: "fixture_validation",
+    FIRST_TREE_EVAL_VERBOSE: verbose ? "1" : "0",
+    PATH: `${paths.binDir}:${process.env.PATH ?? ""}`,
+  };
+  const result = spawnSync("first-tree", args, {
+    cwd: paths.workspacePath,
+    encoding: "utf8",
+    env,
+    maxBuffer: 20 * 1024 * 1024,
+  });
+  const stdout = result.stdout ?? "";
+  const stderr = result.stderr ?? "";
+  reporter.shimTraceLines(stderr);
+
+  const commandResult: CommandResult = {
+    args,
+    command: "first-tree",
+    cwd: paths.workspacePath,
+    exitCode: result.status ?? 1,
+    stderr: stripShimTraceLines(stderr),
+    stdout,
+  };
+
+  appendEvent(paths.eventsPath, {
+    exitCode: commandResult.exitCode,
+    stderrPreview: previewText(commandResult.stderr),
+    stdoutPreview: previewText(commandResult.stdout),
+    type: "fixture_validation_finished",
+  });
+  reporter.fixtureValidationFinished(commandResult);
+
+  return commandResult;
+}

--- a/packages/skill-evals/src/suites/first-tree-write/grader.ts
+++ b/packages/skill-evals/src/suites/first-tree-write/grader.ts
@@ -1,0 +1,299 @@
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+
+import { runCommand } from "../../core/commands.js";
+import { findStringValue, isRecord, isStringArray } from "../../core/events.js";
+import type { RunPaths } from "../../core/types.js";
+import type { EvalMetrics, FirstTreeWriteEvalCase, FixtureValidation, TreeStateSnapshot } from "./types.js";
+
+const TEXT_KEYS = ["content", "message", "output_text", "text"];
+
+function eventType(event: Record<string, unknown>): string | null {
+  return typeof event.type === "string" ? event.type : null;
+}
+
+function isModelPhase(event: Record<string, unknown>): boolean {
+  return event.phase === "model";
+}
+
+function containsSkillFileRead(event: unknown): boolean {
+  if (!isRecord(event)) return false;
+  if (eventType(event) !== "codex_event") return false;
+
+  const nestedEvent = event.event;
+  if (!findStringValue(nestedEvent, (value) => value.includes("first-tree-write/SKILL.md"))) {
+    return false;
+  }
+
+  const serialized = JSON.stringify(nestedEvent) ?? "";
+  if (serialized.includes("Available Skills")) return false;
+  return /tool|exec|command|cmd|read|cat|sed/iu.test(serialized);
+}
+
+function isAssistantMessageRecord(record: Record<string, unknown>): boolean {
+  const type = eventType(record);
+  const role = typeof record.role === "string" ? record.role : null;
+
+  if (type === "agent_message" || type === "assistant_message") return true;
+  if (type === "message" && (role === null || role === "assistant")) return true;
+  if (type === "output_text" || type === "response.output_text.done") return true;
+
+  return false;
+}
+
+function collectTextValue(value: unknown): string[] {
+  if (typeof value === "string") return [value];
+  if (Array.isArray(value)) {
+    const texts: string[] = [];
+    for (const item of value) {
+      texts.push(...collectTextValue(item));
+    }
+    return texts;
+  }
+  if (!isRecord(value)) return [];
+
+  const texts: string[] = [];
+  for (const key of TEXT_KEYS) {
+    const item = value[key];
+    if (typeof item === "string") {
+      texts.push(item);
+    } else if (Array.isArray(item)) {
+      texts.push(...collectTextValue(item));
+    }
+  }
+  return texts;
+}
+
+function collectAssistantText(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    const texts: string[] = [];
+    for (const item of value) {
+      texts.push(...collectAssistantText(item));
+    }
+    return texts;
+  }
+  if (!isRecord(value)) return [];
+
+  const texts: string[] = [];
+  if (isAssistantMessageRecord(value)) {
+    texts.push(...collectTextValue(value));
+  }
+
+  const item = value.item;
+  if (isRecord(item)) {
+    texts.push(...collectAssistantText(item));
+  }
+
+  const message = value.message;
+  if (isRecord(message)) {
+    texts.push(...collectAssistantText(message));
+  }
+
+  const response = value.response;
+  if (isRecord(response) || Array.isArray(response)) {
+    texts.push(...collectAssistantText(response));
+  }
+
+  const output = value.output;
+  if (Array.isArray(output)) {
+    texts.push(...collectAssistantText(output));
+  }
+
+  return texts;
+}
+
+function collectModelOutputText(event: unknown): string[] {
+  if (!isRecord(event)) return [];
+  if (eventType(event) !== "codex_event") return [];
+  return collectAssistantText(event.event);
+}
+
+function normalizeForMatch(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/gu, " ")
+    .replace(/\s+/gu, " ")
+    .trim();
+}
+
+function containsAny(haystack: string, needles: readonly string[]): boolean {
+  const normalizedHaystack = normalizeForMatch(haystack);
+  for (const needle of needles) {
+    const normalizedNeedle = normalizeForMatch(needle);
+    if (normalizedNeedle.length > 0 && normalizedHaystack.includes(normalizedNeedle)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function containsAll(haystack: string, needles: readonly string[]): boolean {
+  const normalizedHaystack = normalizeForMatch(haystack);
+  for (const needle of needles) {
+    const normalizedNeedle = normalizeForMatch(needle);
+    if (normalizedNeedle.length > 0 && !normalizedHaystack.includes(normalizedNeedle)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function argvIsVerify(argv: readonly string[]): boolean {
+  return argv[0] === "tree" && argv[1] === "verify";
+}
+
+function collectMarkdownFiles(root: string): string[] {
+  const files: string[] = [];
+  function walk(dir: string): void {
+    const entries = existsSync(dir) ? readdirSync(dir).sort() : [];
+    for (const entry of entries) {
+      if (entry === ".git" || entry === "node_modules") continue;
+      const child = join(dir, entry);
+      let stat: ReturnType<typeof statSync>;
+      try {
+        stat = statSync(child);
+      } catch {
+        continue;
+      }
+      if (stat.isDirectory()) {
+        walk(child);
+        continue;
+      }
+      if (entry.endsWith(".md")) {
+        files.push(child);
+      }
+    }
+  }
+  walk(root);
+  return files;
+}
+
+function contextTreeMarkdown(contextTreePath: string): string {
+  const chunks: string[] = [];
+  for (const file of collectMarkdownFiles(contextTreePath)) {
+    chunks.push(`\n--- ${relative(contextTreePath, file)} ---\n${readFileSync(file, "utf8")}`);
+  }
+  return chunks.join("\n");
+}
+
+export function snapshotTreeState(contextTreePath: string): TreeStateSnapshot {
+  const status = runCommand("git", ["status", "--porcelain"], contextTreePath).stdout;
+  const diff = runCommand("git", ["diff", "--", "."], contextTreePath).stdout;
+  return { diff, status };
+}
+
+function sourceRepoChanged(paths: RunPaths): boolean {
+  const sourceRepoPath = join(paths.workspacePath, "source-repo");
+  const status = runCommand("git", ["status", "--porcelain"], sourceRepoPath);
+  return status.stdout.trim().length > 0;
+}
+
+export function deriveMetrics(
+  events: readonly unknown[],
+  evalCase: FirstTreeWriteEvalCase,
+  fixtureValidation: FixtureValidation,
+  runnerExitCode: number | null,
+  paths: RunPaths,
+  contextTreePath: string,
+): EvalMetrics {
+  let skillFileReadObserved = false;
+  const firstTreeArgv: string[][] = [];
+  const firstTreeCommandResults: Array<{ argv: string[]; exitCode: number }> = [];
+  const modelOutputTexts: string[] = [];
+
+  for (const event of events) {
+    if (containsSkillFileRead(event)) {
+      skillFileReadObserved = true;
+    }
+
+    modelOutputTexts.push(...collectModelOutputText(event));
+
+    if (!isRecord(event)) continue;
+    const type = eventType(event);
+    if ((type === "first_tree_call" || type === "first_tree_result") && isModelPhase(event)) {
+      const argv = event.argv;
+      if (!isStringArray(argv)) continue;
+
+      if (type === "first_tree_call") {
+        firstTreeArgv.push([...argv]);
+      }
+
+      if (type === "first_tree_result" && typeof event.exitCode === "number") {
+        firstTreeCommandResults.push({ argv: [...argv], exitCode: event.exitCode });
+      }
+    }
+  }
+
+  const treeState = snapshotTreeState(contextTreePath);
+  const finalResponse = modelOutputTexts.at(-1) ?? "";
+  const markdown = contextTreeMarkdown(contextTreePath);
+  const forbiddenContentHits = evalCase.forbidden.content.filter((pattern) => markdown.includes(pattern));
+  const requiredDiffSnippets = evalCase.expected.requiredDiffSnippets ?? [];
+  const verifySucceeded = firstTreeCommandResults.some((result) => argvIsVerify(result.argv) && result.exitCode === 0);
+
+  return {
+    expectedDiffSnippetsObserved:
+      requiredDiffSnippets.length === 0 || containsAll(treeState.diff, requiredDiffSnippets),
+    expectedResponseObserved: containsAny(finalResponse, evalCase.expected.responseHints),
+    finalResponse,
+    firstTreeArgv,
+    firstTreeCommandResults,
+    fixtureValidationOk: fixtureValidation.ok,
+    forbiddenContentHits,
+    runnerExitCode,
+    skillFileReadObserved,
+    sourceRepoChanged: sourceRepoChanged(paths),
+    treeChanged: treeState.status.trim().length > 0,
+    treeDiff: treeState.diff,
+    treeStatus: treeState.status,
+    verifySucceeded,
+  };
+}
+
+export function casePassed(evalCase: FirstTreeWriteEvalCase, metrics: EvalMetrics): boolean {
+  if (!metrics.fixtureValidationOk) return false;
+  if (metrics.runnerExitCode !== 0) return false;
+  if (!metrics.skillFileReadObserved) return false;
+  if (metrics.sourceRepoChanged) return false;
+  if (metrics.forbiddenContentHits.length > 0) return false;
+  if (!metrics.expectedResponseObserved) return false;
+
+  if (evalCase.expected.treeDiff === "none") {
+    return !metrics.treeChanged;
+  }
+
+  return (
+    metrics.treeChanged &&
+    metrics.expectedDiffSnippetsObserved &&
+    (!evalCase.expected.requireVerify || metrics.verifySucceeded)
+  );
+}
+
+export function driftNote(evalCase: FirstTreeWriteEvalCase, metrics: EvalMetrics): string | null {
+  const notes: string[] = [];
+  if (!metrics.skillFileReadObserved) {
+    notes.push("first-tree-write/SKILL.md was not read by the model.");
+  }
+  if (evalCase.expected.treeDiff === "none" && metrics.treeChanged) {
+    notes.push("Context Tree changed even though this case expected no tree diff.");
+  }
+  if (evalCase.expected.treeDiff === "minimal" && !metrics.treeChanged) {
+    notes.push("Context Tree did not change even though this case expected a tree diff.");
+  }
+  if (evalCase.expected.treeDiff === "minimal" && !metrics.expectedDiffSnippetsObserved) {
+    notes.push("Context Tree diff did not contain all required durable-decision snippets.");
+  }
+  if (evalCase.expected.requireVerify && !metrics.verifySucceeded) {
+    notes.push("Required first-tree tree verify command did not succeed during model phase.");
+  }
+  if (metrics.sourceRepoChanged) {
+    notes.push("Source repo fixture changed; write eval cases must not modify source repo.");
+  }
+  if (metrics.forbiddenContentHits.length > 0) {
+    notes.push(`Forbidden content appeared in Context Tree markdown: ${metrics.forbiddenContentHits.join(", ")}.`);
+  }
+  if (!metrics.expectedResponseObserved) {
+    notes.push("Final response did not include the expected refusal/update signal.");
+  }
+  return notes.length > 0 ? notes.join(" ") : null;
+}

--- a/packages/skill-evals/src/suites/first-tree-write/index.ts
+++ b/packages/skill-evals/src/suites/first-tree-write/index.ts
@@ -1,0 +1,41 @@
+import { FIRST_TREE_WRITE_GATE_CASES } from "./cases.js";
+import { runFirstTreeWriteCase } from "./runner.js";
+import { buildBatchSummary, formatSummaryTable } from "./summary.js";
+import type { BatchSummary, CliOptions, FirstTreeWriteEvalCase } from "./types.js";
+
+export function findFirstTreeWriteCase(id: string): FirstTreeWriteEvalCase | null {
+  for (const evalCase of FIRST_TREE_WRITE_GATE_CASES) {
+    if (evalCase.id === id) return evalCase;
+  }
+  return null;
+}
+
+function selectCases(caseId: string | null): readonly FirstTreeWriteEvalCase[] {
+  if (caseId === null) return FIRST_TREE_WRITE_GATE_CASES;
+
+  const evalCase = findFirstTreeWriteCase(caseId);
+  if (evalCase === null) {
+    const available = FIRST_TREE_WRITE_GATE_CASES.map((candidate) => candidate.id).join(", ");
+    throw new Error(`Unknown first-tree-write case '${caseId}'. Available cases: ${available}`);
+  }
+  return [evalCase];
+}
+
+export async function runFirstTreeWriteGate(packageRoot: string, options: CliOptions): Promise<BatchSummary> {
+  const selectedCases = selectCases(options.caseId);
+  const runStartedAt = new Date().toISOString();
+  const summaries = [];
+
+  for (const evalCase of selectedCases) {
+    if (!options.verbose) {
+      process.stderr.write(`Running first-tree-write eval case: ${evalCase.id}\n`);
+    }
+    summaries.push(await runFirstTreeWriteCase(packageRoot, evalCase, options, runStartedAt));
+  }
+
+  return buildBatchSummary(summaries, runStartedAt);
+}
+
+export function formatFirstTreeWriteGateSummary(batch: BatchSummary): string {
+  return formatSummaryTable(batch);
+}

--- a/packages/skill-evals/src/suites/first-tree-write/runner.ts
+++ b/packages/skill-evals/src/suites/first-tree-write/runner.ts
@@ -1,0 +1,78 @@
+import { appendEvent, readEvents } from "../../core/events.js";
+import { createRunPaths } from "../../core/paths.js";
+import { runCodexProvider } from "../../core/provider/codex.js";
+import { createEvalReporter } from "../../core/reporter.js";
+import { createFirstTreeShim } from "../../core/shims/first-tree.js";
+import { setupFixture, validateFixture } from "./fixture.js";
+import { casePassed, deriveMetrics, driftNote } from "./grader.js";
+import { writeCaseSummaries } from "./summary.js";
+import type { CaseRunSummary, CliOptions, FirstTreeWriteEvalCase } from "./types.js";
+
+export async function runFirstTreeWriteCase(
+  packageRoot: string,
+  evalCase: FirstTreeWriteEvalCase,
+  options: CliOptions,
+  runStartedAt: string,
+): Promise<CaseRunSummary> {
+  const startedAt = new Date().toISOString();
+  const paths = createRunPaths({ caseId: evalCase.id, packageRoot, startedAt });
+  const reporter = createEvalReporter(evalCase.id, options.verbose);
+  appendEvent(paths.eventsPath, {
+    caseId: evalCase.id,
+    runStartedAt,
+    type: "case_started",
+  });
+  reporter.caseStarted();
+
+  createFirstTreeShim(paths);
+  const contextTreePath = setupFixture(evalCase, paths, reporter);
+  const fixtureValidation = validateFixture(paths, contextTreePath, evalCase.id, options.verbose, reporter);
+  const runnerExitCode = await runCodexProvider(
+    {
+      bin: options.codexBin,
+      caseId: evalCase.id,
+      model: options.model,
+      prompt: evalCase.prompt,
+      verbose: options.verbose,
+    },
+    { paths, reporter },
+  );
+
+  const metrics = deriveMetrics(
+    readEvents(paths.eventsPath),
+    evalCase,
+    fixtureValidation,
+    runnerExitCode,
+    paths,
+    contextTreePath,
+  );
+  const passed = casePassed(evalCase, metrics);
+
+  const summary: CaseRunSummary = {
+    caseId: evalCase.id,
+    driftNote: driftNote(evalCase, metrics),
+    expectedAction: evalCase.expected.action,
+    fixtureValidation,
+    metrics,
+    passed,
+    prompt: evalCase.prompt,
+    runRoot: paths.runRoot,
+    startedAt,
+    summaryJsonPath: paths.summaryJsonPath,
+    summaryMdPath: paths.summaryMdPath,
+    workspacePath: paths.workspacePath,
+  };
+
+  writeCaseSummaries(summary);
+  reporter.summaryWritten(paths.summaryJsonPath, paths.summaryMdPath);
+  appendEvent(paths.eventsPath, {
+    caseId: evalCase.id,
+    passed,
+    summaryJsonPath: paths.summaryJsonPath,
+    summaryMdPath: paths.summaryMdPath,
+    type: "case_finished",
+  });
+  reporter.caseFinished(passed);
+
+  return summary;
+}

--- a/packages/skill-evals/src/suites/first-tree-write/summary.ts
+++ b/packages/skill-evals/src/suites/first-tree-write/summary.ts
@@ -1,0 +1,146 @@
+import { writeFileSync } from "node:fs";
+
+import type { BatchSummary, CaseRunSummary, EvalMetrics, FixtureValidation } from "./types.js";
+
+function markdownBool(value: boolean): string {
+  return value ? "true" : "false";
+}
+
+function formatArg(arg: string): string {
+  if (/^[A-Za-z0-9_./:=@+-]+$/u.test(arg)) return arg;
+  return JSON.stringify(arg);
+}
+
+function formatCommand(argv: readonly string[]): string {
+  return argv.map(formatArg).join(" ");
+}
+
+function validationRows(validation: FixtureValidation): string {
+  return [
+    `- ok: ${markdownBool(validation.ok)}`,
+    `- requiredFilesOk: ${markdownBool(validation.requiredFilesOk)}`,
+    `- verifyExitCode: ${validation.verifyResult.exitCode}`,
+    ...validation.errors.map((error) => `- error: ${error}`),
+  ].join("\n");
+}
+
+function commandResultRows(metrics: EvalMetrics): string {
+  if (metrics.firstTreeCommandResults.length === 0) return "- none";
+  return metrics.firstTreeCommandResults
+    .map((result) => `- first-tree ${formatCommand(result.argv)}: exit=${result.exitCode}`)
+    .join("\n");
+}
+
+function fenced(value: string): string {
+  return value.trim().length === 0 ? "_empty_" : `\n\`\`\`text\n${value}\n\`\`\``;
+}
+
+export function writeCaseSummaries(summary: CaseRunSummary): void {
+  writeFileSync(summary.summaryJsonPath, `${JSON.stringify(summary, null, 2)}\n`, "utf8");
+
+  const drift = summary.driftNote ? `\n## Drift Evidence\n\n${summary.driftNote}\n` : "";
+  const markdown = `# first-tree-write Eval: ${summary.caseId}
+
+## Result
+
+- passed: ${markdownBool(summary.passed)}
+- expectedAction: ${summary.expectedAction}
+- skillFileReadObserved: ${markdownBool(summary.metrics.skillFileReadObserved)}
+- treeChanged: ${markdownBool(summary.metrics.treeChanged)}
+- expectedDiffSnippetsObserved: ${markdownBool(summary.metrics.expectedDiffSnippetsObserved)}
+- verifySucceeded: ${markdownBool(summary.metrics.verifySucceeded)}
+- sourceRepoChanged: ${markdownBool(summary.metrics.sourceRepoChanged)}
+- expectedResponseObserved: ${markdownBool(summary.metrics.expectedResponseObserved)}
+- forbiddenContentHits: ${summary.metrics.forbiddenContentHits.length === 0 ? "none" : summary.metrics.forbiddenContentHits.join(", ")}
+- runnerExitCode: ${summary.metrics.runnerExitCode === null ? "n/a" : summary.metrics.runnerExitCode}
+
+## Prompt
+
+\`\`\`text
+${summary.prompt}
+\`\`\`
+
+## Fixture Validation
+
+${validationRows(summary.fixtureValidation)}
+
+## first-tree Command Results
+
+${commandResultRows(summary.metrics)}
+
+## Tree Status
+
+${fenced(summary.metrics.treeStatus)}
+
+## Tree Diff
+
+${fenced(summary.metrics.treeDiff)}
+
+## Final Response
+
+${fenced(summary.metrics.finalResponse)}
+${drift}
+## Paths
+
+- runRoot: \`${summary.runRoot}\`
+- workspacePath: \`${summary.workspacePath}\`
+`;
+
+  writeFileSync(summary.summaryMdPath, markdown, "utf8");
+}
+
+function pad(value: string, width: number): string {
+  return value.length >= width ? value : `${value}${" ".repeat(width - value.length)}`;
+}
+
+export function formatSummaryTable(batch: BatchSummary): string {
+  const rows = batch.cases.map((summary) => [
+    summary.caseId,
+    summary.expectedAction,
+    String(summary.metrics.skillFileReadObserved),
+    String(summary.metrics.treeChanged),
+    String(summary.metrics.verifySucceeded),
+    String(summary.metrics.expectedResponseObserved),
+    String(summary.metrics.forbiddenContentHits.length),
+    String(summary.passed),
+  ]);
+  const header = [
+    "case_id",
+    "expected_action",
+    "skill_file_read",
+    "treeChanged",
+    "verifySucceeded",
+    "responseObserved",
+    "forbiddenHits",
+    "passed",
+  ];
+  const widths = header.map((label, index) => {
+    let width = label.length;
+    for (const row of rows) {
+      const value = row[index];
+      if (value && value.length > width) width = value.length;
+    }
+    return width;
+  });
+
+  const lines = [
+    header.map((label, index) => pad(label, widths[index] ?? label.length)).join("  "),
+    ...rows.map((row) => row.map((value, index) => pad(value, widths[index] ?? value.length)).join("  ")),
+  ];
+
+  return lines.join("\n");
+}
+
+export function buildBatchSummary(cases: readonly CaseRunSummary[], runStartedAt: string): BatchSummary {
+  let passed = 0;
+  for (const summary of cases) {
+    if (summary.passed) passed += 1;
+  }
+
+  return {
+    cases,
+    failed: cases.length - passed,
+    passed,
+    runStartedAt,
+  };
+}

--- a/packages/skill-evals/src/suites/first-tree-write/types.ts
+++ b/packages/skill-evals/src/suites/first-tree-write/types.ts
@@ -1,0 +1,100 @@
+import type { CommandResult } from "../../core/types.js";
+
+export type SourceArtifactKind = "absent" | "durable-decision-note" | "implementation-only-diff";
+export type TreeState = "populated";
+export type TreeDiffExpectation = "none" | "minimal";
+export type ExpectedAction = "refuse_without_source" | "write_minimal_tree_diff" | "refuse_implementation_only_source";
+
+export type FirstTreeWriteFixture = {
+  sourceArtifact: SourceArtifactKind;
+  treeState: TreeState;
+};
+
+export type FirstTreeWriteExpected = {
+  action: ExpectedAction;
+  requiredDiffSnippets?: readonly string[];
+  requireVerify: boolean;
+  responseHints: readonly string[];
+  treeDiff: TreeDiffExpectation;
+};
+
+export type FirstTreeWriteForbidden = {
+  content: readonly string[];
+  sideEffects: readonly string[];
+};
+
+export type FirstTreeWriteEvalCase = {
+  briefingMode: "minimal";
+  expected: FirstTreeWriteExpected;
+  fixture: FirstTreeWriteFixture;
+  forbidden: FirstTreeWriteForbidden;
+  id: string;
+  prompt: string;
+  provider: "codex";
+  skill: "first-tree-write";
+  status: "implemented";
+  tags: readonly string[];
+  tier: "gate";
+};
+
+export type CliOptions = {
+  caseId: string | null;
+  codexBin: string;
+  json: boolean;
+  model: string | null;
+  verbose: boolean;
+};
+
+export type FixtureValidation = {
+  errors: readonly string[];
+  ok: boolean;
+  requiredFilesOk: boolean;
+  verifyResult: CommandResult;
+};
+
+export type TreeStateSnapshot = {
+  diff: string;
+  status: string;
+};
+
+export type EvalMetrics = {
+  expectedDiffSnippetsObserved: boolean;
+  expectedResponseObserved: boolean;
+  finalResponse: string;
+  firstTreeArgv: readonly (readonly string[])[];
+  firstTreeCommandResults: readonly {
+    argv: readonly string[];
+    exitCode: number;
+  }[];
+  fixtureValidationOk: boolean;
+  forbiddenContentHits: readonly string[];
+  runnerExitCode: number | null;
+  skillFileReadObserved: boolean;
+  sourceRepoChanged: boolean;
+  treeChanged: boolean;
+  treeDiff: string;
+  treeStatus: string;
+  verifySucceeded: boolean;
+};
+
+export type CaseRunSummary = {
+  caseId: string;
+  driftNote: string | null;
+  expectedAction: ExpectedAction;
+  fixtureValidation: FixtureValidation;
+  metrics: EvalMetrics;
+  passed: boolean;
+  prompt: string;
+  runRoot: string;
+  startedAt: string;
+  summaryJsonPath: string;
+  summaryMdPath: string;
+  workspacePath: string;
+};
+
+export type BatchSummary = {
+  cases: readonly CaseRunSummary[];
+  failed: number;
+  passed: number;
+  runStartedAt: string;
+};


### PR DESCRIPTION
## Summary

- Add the live `first-tree-write` gate suite with three source-boundary cases: `no-source-refuses`, `durable-source-writes`, and `implementation-only-no-write`.
- Add write-specific fixture setup, deterministic grader, summaries, and tests using isolated per-run Context Tree and source fixtures.
- Add `eval:gate -- --suite first-tree-write`, and harden coverage validation so referenced cases must match the suite skill and tier.

## Scope

This PR does not add welcome or seed live cases, LLM-as-judge quality evals, selection/compare, or changes to the existing `first-tree-read` live runner behavior.

## Verification

- `pnpm --filter @first-tree/skill-evals eval:floor`
- `pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-write --case no-source-refuses`
- `pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-write`
- `pnpm --filter @first-tree/skill-evals test`
- `pnpm --filter @first-tree/skill-evals typecheck`
- `pnpm exec biome check packages/skill-evals/src packages/skill-evals/package.json packages/skill-evals/README.md`
- `pnpm --filter @first-tree/shared build`
- `pnpm --filter @first-tree/client build`
- `pnpm --filter @first-tree/skill-evals validate:first-tree-read-fixtures`

Live write gate result: all 3 first-tree-write cases passed. Latest full-run artifacts:

- `packages/skill-evals/.runs/20260626T093047628Z-no-source-refuses/summary.md`
- `packages/skill-evals/.runs/20260626T093110673Z-durable-source-writes/summary.md`
- `packages/skill-evals/.runs/20260626T093303926Z-implementation-only-no-write/summary.md`
