### PR TITLE
Add first-tree-welcome skill eval gate

### DIFF
--- a/packages/skill-evals/README.md
+++ b/packages/skill-evals/README.md
@@ -9,6 +9,7 @@ quota.
 ```bash
 pnpm --filter @first-tree/skill-evals eval:floor
 pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-write
+pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-welcome
 pnpm --filter @first-tree/skill-evals eval:first-tree-read
 pnpm --filter @first-tree/skill-evals eval:first-tree-read -- --case tree-software-trigger
 pnpm --filter @first-tree/skill-evals eval:first-tree-read -- --json
@@ -30,10 +31,21 @@ Codex, Claude Code, LLM-as-judge, or live gate cases.
   `first-tree tree verify`;
 - implementation-only source material means no Context Tree diff.
 
+`eval:gate -- --suite first-tree-welcome` runs the live Codex gate for
+the currently implemented `first-tree-welcome` onboarding rows:
+
+- tree kickoff chat routes to the tree setup lane instead of welcome first-task
+  options;
+- no repo connected / intro chat asks for a local clone path or GitHub URL
+  without requiring GitHub authorization first;
+- readable repo + populated Context Tree reads both evidence sources and offers
+  two or three bounded first-task options without seeding or setting up the
+  tree.
+
 The runner creates isolated temporary workspaces under
 `packages/skill-evals/.runs/<timestamp>-<case-id>/`, installs
-the relevant skill, prepends a `first-tree` shim to `PATH`, and runs
-`codex exec --json` from the case workspace for live eval commands.
+the relevant skill, prepends command shims such as `first-tree` to `PATH`, and
+runs `codex exec --json` from the case workspace for live eval commands.
 
 Each case writes:
 

--- a/packages/skill-evals/src/core/shims/first-tree-staging.ts
+++ b/packages/skill-evals/src/core/shims/first-tree-staging.ts
@@ -5,17 +5,13 @@ import { writeText } from "../commands.js";
 import { writeShellPathBootstrap } from "../paths.js";
 import type { RunPaths } from "../types.js";
 
-export function createFirstTreeShim(paths: RunPaths): void {
-  const tsxBin = join(paths.packageRoot, "node_modules", ".bin", "tsx");
-  const cliEntry = join(paths.repoRoot, "apps", "cli", "src", "cli", "index.ts");
-  const shimPath = join(paths.binDir, "first-tree");
+export function createFirstTreeStagingShim(paths: RunPaths): void {
+  const shimPath = join(paths.binDir, "first-tree-staging");
   const script = `#!/usr/bin/env node
 import { spawnSync } from "node:child_process";
 import { appendFileSync } from "node:fs";
 
 const EVENTS_PATH = ${JSON.stringify(paths.eventsPath)};
-const TSX_BIN = ${JSON.stringify(tsxBin)};
-const CLI_ENTRY = ${JSON.stringify(cliEntry)};
 
 function preview(value) {
   if (!value) return "";
@@ -43,53 +39,15 @@ function trace(message) {
 
 const argv = process.argv.slice(2);
 const phase = process.env.FIRST_TREE_EVAL_PHASE || "model";
-append({ type: "first_tree_call", phase, argv, cwd: process.cwd() });
-trace("first-tree call: " + commandLine(argv));
-
-if (argv[0] === "github") {
-  const exitCode = 1;
-  const stderr = "Blocked first-tree github command in skill eval. No real GitHub side effect was attempted.\\n";
-  process.stderr.write(stderr);
-  append({
-    type: "first_tree_result",
-    phase,
-    argv,
-    cwd: process.cwd(),
-    exitCode,
-    signal: null,
-    stdoutPreview: "",
-    stderrPreview: preview(stderr),
-    blockedByEval: true,
-  });
-  trace("first-tree result: exit=1 blocked github command");
-  process.exit(exitCode);
-}
-
-if (argv[0] === "tree" && ["bind", "create", "init", "seed", "setup"].includes(argv[1] || "")) {
-  const exitCode = 1;
-  const stderr = "Blocked first-tree tree setup command in skill eval. No real tree setup side effect was attempted.\\n";
-  process.stderr.write(stderr);
-  append({
-    type: "first_tree_result",
-    phase,
-    argv,
-    cwd: process.cwd(),
-    exitCode,
-    signal: null,
-    stdoutPreview: "",
-    stderrPreview: preview(stderr),
-    blockedByEval: true,
-  });
-  trace("first-tree result: exit=1 blocked tree setup command");
-  process.exit(exitCode);
-}
+append({ type: "first_tree_staging_call", phase, argv, cwd: process.cwd() });
+trace("first-tree-staging call: " + commandLine(argv));
 
 if (argv[0] === "chat" && ["ask", "send", "update"].includes(argv[1] || "")) {
   const exitCode = 0;
-  const stdout = "Recorded first-tree chat " + argv[1] + " in skill eval. No real message was sent.\\n";
+  const stdout = "Recorded first-tree-staging chat " + argv[1] + " in skill eval. No real message was sent.\\n";
   process.stdout.write(stdout);
   append({
-    type: "first_tree_result",
+    type: "first_tree_staging_result",
     phase,
     argv,
     cwd: process.cwd(),
@@ -99,13 +57,11 @@ if (argv[0] === "chat" && ["ask", "send", "update"].includes(argv[1] || "")) {
     stderrPreview: "",
     recordedOnly: true,
   });
-  trace("first-tree result: exit=0 recorded-only chat " + argv[1]);
+  trace("first-tree-staging result: exit=0 recorded-only chat " + argv[1]);
   process.exit(exitCode);
 }
 
-const realCommand = process.env.FIRST_TREE_EVAL_REAL_FIRST_TREE || TSX_BIN;
-const realArgs = process.env.FIRST_TREE_EVAL_REAL_FIRST_TREE ? argv : [CLI_ENTRY, ...argv];
-const result = spawnSync(realCommand, realArgs, {
+const result = spawnSync("first-tree", argv, {
   cwd: process.cwd(),
   encoding: "utf8",
   env: process.env,
@@ -117,7 +73,7 @@ if (result.stderr) process.stderr.write(result.stderr);
 
 if (result.error) {
   append({
-    type: "first_tree_result",
+    type: "first_tree_staging_result",
     phase,
     argv,
     cwd: process.cwd(),
@@ -126,13 +82,13 @@ if (result.error) {
     stdoutPreview: preview(result.stdout || ""),
     stderrPreview: preview(result.stderr || ""),
   });
-  trace("first-tree result: exit=127 error=" + preview(String(result.error)));
+  trace("first-tree-staging result: exit=127 error=" + preview(String(result.error)));
   process.exit(127);
 }
 
 const exitCode = result.status == null ? 1 : result.status;
 append({
-  type: "first_tree_result",
+  type: "first_tree_staging_result",
   phase,
   argv,
   cwd: process.cwd(),
@@ -141,7 +97,7 @@ append({
   stdoutPreview: preview(result.stdout || ""),
   stderrPreview: preview(result.stderr || ""),
 });
-trace("first-tree result: exit=" + exitCode);
+trace("first-tree-staging result: exit=" + exitCode);
 
 process.exit(exitCode);
 `;

--- a/packages/skill-evals/src/core/shims/gh.ts
+++ b/packages/skill-evals/src/core/shims/gh.ts
@@ -1,0 +1,64 @@
+import { chmodSync } from "node:fs";
+import { join } from "node:path";
+
+import { writeText } from "../commands.js";
+import { writeShellPathBootstrap } from "../paths.js";
+import type { RunPaths } from "../types.js";
+
+export function createGhShim(paths: RunPaths): void {
+  const shimPath = join(paths.binDir, "gh");
+  const script = `#!/usr/bin/env node
+import { appendFileSync } from "node:fs";
+
+const EVENTS_PATH = ${JSON.stringify(paths.eventsPath)};
+
+function preview(value) {
+  if (!value) return "";
+  return value.length <= 4000 ? value : value.slice(0, 4000) + "...<truncated " + (value.length - 4000) + " chars>";
+}
+
+function append(event) {
+  appendFileSync(EVENTS_PATH, JSON.stringify({ timestamp: new Date().toISOString(), ...event }) + "\\n", "utf8");
+}
+
+function formatArg(arg) {
+  return /^[A-Za-z0-9_./:=@+-]+$/.test(arg) ? arg : JSON.stringify(arg);
+}
+
+function commandLine(argv) {
+  return argv.map(formatArg).join(" ");
+}
+
+function trace(message) {
+  if (process.env.FIRST_TREE_EVAL_VERBOSE === "1") {
+    const caseId = process.env.FIRST_TREE_EVAL_CASE_ID || "unknown";
+    process.stderr.write("[" + caseId + "] " + message + "\\n");
+  }
+}
+
+const argv = process.argv.slice(2);
+const phase = process.env.FIRST_TREE_EVAL_PHASE || "model";
+append({ type: "gh_call", phase, argv, cwd: process.cwd() });
+trace("gh call blocked: " + commandLine(argv));
+
+const stderr = "Blocked gh command in skill eval. No real GitHub side effect was attempted.\\n";
+process.stderr.write(stderr);
+append({
+  type: "gh_result",
+  phase,
+  argv,
+  cwd: process.cwd(),
+  exitCode: 1,
+  signal: null,
+  stdoutPreview: "",
+  stderrPreview: preview(stderr),
+  blockedByEval: true,
+});
+
+process.exit(1);
+`;
+
+  writeText(shimPath, script);
+  chmodSync(shimPath, 0o755);
+  writeShellPathBootstrap(paths);
+}

--- a/packages/skill-evals/src/index.ts
+++ b/packages/skill-evals/src/index.ts
@@ -6,6 +6,7 @@ import { SHIPPED_SKILLS, type ShippedSkillName } from "./core/case-schema.js";
 import { type SkillEvalSuiteDefinition, validateCoverageMatrix } from "./core/coverage.js";
 import { isRecord } from "./core/events.js";
 import { readSkillFrontmatter } from "./core/skills/frontmatter.js";
+import { formatFirstTreeWelcomeGateSummary, runFirstTreeWelcomeGate } from "./suites/first-tree-welcome/index.js";
 import { formatFirstTreeWriteGateSummary, runFirstTreeWriteGate } from "./suites/first-tree-write/index.js";
 import { SKILL_EVAL_SUITES } from "./suites/registry.js";
 
@@ -38,6 +39,7 @@ function usage(): string {
   pnpm --filter @first-tree/skill-evals eval:floor -- --json
   pnpm --filter @first-tree/skill-evals eval:floor -- --suite <skill>
   pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-write
+  pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-welcome
 
 Commands:
   floor                  Run no-model schema, coverage, and skill-file checks.
@@ -222,25 +224,45 @@ function formatFloorSummary(summary: FloorSummary): string {
 }
 
 async function runGate(options: CliOptions): Promise<void> {
-  if (options.suite !== "first-tree-write") {
-    throw new Error("eval:gate currently requires --suite first-tree-write.");
+  if (options.suite === "first-tree-write") {
+    const batch = await runFirstTreeWriteGate(packageRoot(), {
+      caseId: options.caseId,
+      codexBin: options.codexBin,
+      json: options.json,
+      model: options.model,
+      verbose: options.verbose,
+    });
+    if (options.json) {
+      process.stdout.write(`${JSON.stringify(batch, null, 2)}\n`);
+    } else {
+      process.stdout.write(`${formatFirstTreeWriteGateSummary(batch)}\n`);
+    }
+    if (batch.failed > 0) {
+      process.exitCode = 1;
+    }
+    return;
   }
 
-  const batch = await runFirstTreeWriteGate(packageRoot(), {
-    caseId: options.caseId,
-    codexBin: options.codexBin,
-    json: options.json,
-    model: options.model,
-    verbose: options.verbose,
-  });
-  if (options.json) {
-    process.stdout.write(`${JSON.stringify(batch, null, 2)}\n`);
-  } else {
-    process.stdout.write(`${formatFirstTreeWriteGateSummary(batch)}\n`);
+  if (options.suite === "first-tree-welcome") {
+    const batch = await runFirstTreeWelcomeGate(packageRoot(), {
+      caseId: options.caseId,
+      codexBin: options.codexBin,
+      json: options.json,
+      model: options.model,
+      verbose: options.verbose,
+    });
+    if (options.json) {
+      process.stdout.write(`${JSON.stringify(batch, null, 2)}\n`);
+    } else {
+      process.stdout.write(`${formatFirstTreeWelcomeGateSummary(batch)}\n`);
+    }
+    if (batch.failed > 0) {
+      process.exitCode = 1;
+    }
+    return;
   }
-  if (batch.failed > 0) {
-    process.exitCode = 1;
-  }
+
+  throw new Error("eval:gate currently requires --suite first-tree-write or --suite first-tree-welcome.");
 }
 
 async function main(): Promise<void> {

--- a/packages/skill-evals/src/suites/first-tree-welcome/__tests__/grader.test.ts
+++ b/packages/skill-evals/src/suites/first-tree-welcome/__tests__/grader.test.ts
@@ -1,0 +1,199 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+import type { RunPaths } from "../../../core/types.js";
+import { FIRST_TREE_WELCOME_GATE_CASES } from "../cases.js";
+import { casePassed, deriveMetrics } from "../grader.js";
+import type { EvalMetrics, FirstTreeWelcomeEvalCase, FixtureValidation } from "../types.js";
+
+function findCase(id: string): FirstTreeWelcomeEvalCase {
+  const evalCase = FIRST_TREE_WELCOME_GATE_CASES.find((candidate) => candidate.id === id);
+  if (!evalCase) throw new Error(`Missing test case ${id}`);
+  return evalCase;
+}
+
+function baseMetrics(overrides: Partial<EvalMetrics>): EvalMetrics {
+  return {
+    chatAskCount: 0,
+    chatOptionCount: null,
+    chatText: "",
+    contextTreeChanged: false,
+    contextTreeStatus: "",
+    expectedEvidenceObserved: true,
+    expectedResponseObserved: true,
+    finalResponse: "Done.",
+    firstTreeArgv: [],
+    forbiddenActionHits: [],
+    forbiddenClaimHits: [],
+    forbiddenSideEffectHits: [],
+    fixtureValidationOk: true,
+    repoEvidenceReadObserved: false,
+    runnerExitCode: 0,
+    skillFileReadObserved: true,
+    sourceRepoChanged: false,
+    taskOptionsObserved: false,
+    treeEvidenceReadObserved: false,
+    ...overrides,
+  };
+}
+
+function baseRunPaths(workspacePath: string): RunPaths {
+  return {
+    binDir: join(workspacePath, "bin"),
+    eventsPath: join(workspacePath, "events.jsonl"),
+    packageRoot: workspacePath,
+    repoRoot: workspacePath,
+    runRoot: workspacePath,
+    shellEnvDir: join(workspacePath, "shell-env"),
+    summaryJsonPath: join(workspacePath, "summary.json"),
+    summaryMdPath: join(workspacePath, "summary.md"),
+    workspacePath,
+  };
+}
+
+function fixtureValidation(): FixtureValidation {
+  return {
+    contextTreeVerifyResult: null,
+    errors: [],
+    ok: true,
+    requiredFilesOk: true,
+  };
+}
+
+describe("first-tree-welcome grader", () => {
+  it("passes row 1 when the model routes tree kickoff to the tree setup lane", () => {
+    expect(
+      casePassed(
+        findCase("first-tree-welcome-tree-kickoff-chat"),
+        baseMetrics({
+          finalResponse: "This is the tree setup lane; use first-tree-seed rather than the welcome value chat.",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("fails row 1 when the model offers welcome first-task options", () => {
+    expect(
+      casePassed(
+        findCase("first-tree-welcome-tree-kickoff-chat"),
+        baseMetrics({
+          chatAskCount: 1,
+          chatOptionCount: 3,
+          forbiddenActionHits: ["first-task-options"],
+          taskOptionsObserved: true,
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("passes row 3 when the model asks for a local clone path or GitHub URL without evidence claims", () => {
+    expect(
+      casePassed(
+        findCase("first-tree-welcome-no-repo-intro"),
+        baseMetrics({
+          finalResponse: "Please send one local clone path or GitHub URL so I can inspect the repo first.",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("passes row 8 when the model reads repo and tree evidence and offers bounded options", () => {
+    expect(
+      casePassed(
+        findCase("first-tree-welcome-readable-repo-populated-tree"),
+        baseMetrics({
+          chatAskCount: 1,
+          chatOptionCount: 3,
+          expectedEvidenceObserved: true,
+          finalResponse: "I found the expired session TODO and Checkout Reliability tree constraint.",
+          repoEvidenceReadObserved: true,
+          taskOptionsObserved: true,
+          treeEvidenceReadObserved: true,
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("fails row 8 without Context Tree evidence", () => {
+    expect(
+      casePassed(
+        findCase("first-tree-welcome-readable-repo-populated-tree"),
+        baseMetrics({
+          expectedEvidenceObserved: true,
+          repoEvidenceReadObserved: true,
+          taskOptionsObserved: true,
+          treeEvidenceReadObserved: false,
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("fails row 8 when a forbidden external side effect command is observed", () => {
+    expect(
+      casePassed(
+        findCase("first-tree-welcome-readable-repo-populated-tree"),
+        baseMetrics({
+          expectedEvidenceObserved: true,
+          forbiddenSideEffectHits: ["gh pr create"],
+          repoEvidenceReadObserved: true,
+          taskOptionsObserved: true,
+          treeEvidenceReadObserved: true,
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("marks source and context tree changed when absent fixture paths are created", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "welcome-eval-created-"));
+    try {
+      const paths = baseRunPaths(tempRoot);
+      mkdirSync(join(tempRoot, "source-repo"));
+      mkdirSync(join(tempRoot, "context-tree"));
+
+      const metrics = deriveMetrics(
+        [
+          {
+            type: "fixture_setup_finished",
+          },
+        ],
+        findCase("first-tree-welcome-no-repo-intro"),
+        fixtureValidation(),
+        0,
+        paths,
+        null,
+      );
+
+      expect(metrics.sourceRepoChanged).toBe(true);
+      expect(metrics.contextTreeChanged).toBe(true);
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("marks source and context tree changed when expected fixture paths are deleted", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "welcome-eval-deleted-"));
+    try {
+      const metrics = deriveMetrics(
+        [
+          {
+            contextTreeHead: "abc123",
+            sourceRepoHead: "def456",
+            type: "fixture_setup_finished",
+          },
+        ],
+        findCase("first-tree-welcome-readable-repo-populated-tree"),
+        fixtureValidation(),
+        0,
+        baseRunPaths(tempRoot),
+        join(tempRoot, "context-tree"),
+      );
+
+      expect(metrics.sourceRepoChanged).toBe(true);
+      expect(metrics.contextTreeChanged).toBe(true);
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+});

--- a/packages/skill-evals/src/suites/first-tree-welcome/__tests__/grader.test.ts
+++ b/packages/skill-evals/src/suites/first-tree-welcome/__tests__/grader.test.ts
@@ -99,6 +99,59 @@ describe("first-tree-welcome grader", () => {
     ).toBe(true);
   });
 
+  it("fails row 3 when setup is packaged as first-task options", () => {
+    expect(
+      casePassed(
+        findCase("first-tree-welcome-no-repo-intro"),
+        baseMetrics({
+          chatAskCount: 1,
+          chatOptionCount: 3,
+          finalResponse: "Choose a local clone path or GitHub URL setup option.",
+          forbiddenActionHits: ["setup-as-first-task"],
+          taskOptionsObserved: true,
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("detects setup-as-first-task from chat ask options", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "welcome-eval-row3-options-"));
+    try {
+      const metrics = deriveMetrics(
+        [
+          {
+            argv: [
+              "chat",
+              "ask",
+              "baixiaohang",
+              "Choose a setup task: local clone path, GitHub URL, or install GitHub App.",
+              "--options",
+              JSON.stringify({
+                options: [
+                  { description: "Provide a local clone path.", label: "Local path" },
+                  { description: "Provide a GitHub URL.", label: "GitHub URL" },
+                  { description: "Install the GitHub App.", label: "Install app" },
+                ],
+              }),
+            ],
+            phase: "model",
+            type: "first_tree_call",
+          },
+        ],
+        findCase("first-tree-welcome-no-repo-intro"),
+        fixtureValidation(),
+        0,
+        baseRunPaths(tempRoot),
+        null,
+      );
+
+      expect(metrics.taskOptionsObserved).toBe(true);
+      expect(metrics.forbiddenActionHits).toContain("setup-as-first-task");
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
   it("passes row 8 when the model reads repo and tree evidence and offers bounded options", () => {
     expect(
       casePassed(

--- a/packages/skill-evals/src/suites/first-tree-welcome/cases.ts
+++ b/packages/skill-evals/src/suites/first-tree-welcome/cases.ts
@@ -1,106 +1,176 @@
 import type { SkillEvalCase } from "../../core/case-schema.js";
 import type { SkillEvalSuiteDefinition } from "../types.js";
+import type { FirstTreeWelcomeEvalCase, WelcomeExpectedAction } from "./types.js";
 
 const FLOOR_CASE_ID = "first-tree-welcome-setup-matrix";
+const IMPLEMENTED_GATE_CASE_IDS = new Set([
+  "first-tree-welcome-tree-kickoff-chat",
+  "first-tree-welcome-no-repo-intro",
+  "first-tree-welcome-readable-repo-populated-tree",
+]);
 
-const WELCOME_ROWS = [
+type WelcomeRow = {
+  action: WelcomeExpectedAction;
+  forbiddenActions: readonly string[];
+  forbiddenClaims: readonly string[];
+  id: string;
+  kickoffKind: FirstTreeWelcomeEvalCase["fixture"]["kickoffKind"];
+  prompt: string;
+  repoState: FirstTreeWelcomeEvalCase["fixture"]["repoState"];
+  requiredResponseHints: readonly string[];
+  role: FirstTreeWelcomeEvalCase["fixture"]["role"];
+  tags: readonly string[];
+  taskOptionHints?: readonly string[];
+  treeState: FirstTreeWelcomeEvalCase["fixture"]["treeState"];
+};
+
+const WELCOME_ROWS: readonly WelcomeRow[] = [
   {
     action: "route_to_tree_skill",
+    forbiddenActions: ["first-task-options", "seed-tree-in-welcome-chat", "tree-setup-as-value-task"],
+    forbiddenClaims: ["repo evidence", "tree readiness"],
     id: "first-tree-welcome-tree-kickoff-chat",
     kickoffKind: "tree",
-    prompt: "First Tree system kickoff: prepare this workspace tree.",
+    prompt: `First Tree system kickoff explicitly named first-tree-welcome, but this chat is the Context Tree setup kickoff.
+
+Use first-tree-welcome only to classify the setup state from its matrix. Reply with the correct lane for this chat. Do not offer value-chat first-task options.`,
     repoState: "unknown",
+    requiredResponseHints: ["tree setup", "first-tree-seed", "first-tree-read", "first-tree-write"],
     role: "admin",
+    tags: ["welcome-row-1", "tree-lane"],
     treeState: "unknown",
   },
   {
     action: "invitee_waits_for_team_readiness",
+    forbiddenActions: ["admin-setup", "repo-selection", "duplicate-tree"],
+    forbiddenClaims: ["repo evidence", "tree readiness"],
     id: "first-tree-welcome-invitee-not-ready",
     kickoffKind: "intro",
     prompt: "Introduce First Tree to this invited teammate.",
     repoState: "none",
+    requiredResponseHints: ["admin", "local", "path"],
     role: "invitee",
+    tags: ["welcome-row-2", "planned"],
     treeState: "none",
   },
   {
     action: "ask_for_repo_path_or_url",
+    forbiddenActions: ["github-auth-first", "github-app-install-first", "setup-as-first-task"],
+    forbiddenClaims: ["repo evidence", "tree readiness"],
     id: "first-tree-welcome-no-repo-intro",
     kickoffKind: "intro",
-    prompt: "Welcome the user and help them get value from First Tree.",
+    prompt: `First Tree onboarding intro chat explicitly named first-tree-welcome.
+
+No repository is connected, no local path or GitHub URL is available, and no populated Context Tree is readable. Give the smallest useful next ask.`,
     repoState: "none",
+    requiredResponseHints: ["local clone path", "GitHub URL"],
     role: "admin",
+    tags: ["welcome-row-3", "no-repo"],
     treeState: "none",
   },
   {
     action: "report_auth_failure_without_claiming_repo_read",
+    forbiddenActions: ["claim-private-repo-read", "invent-repo-evidence"],
+    forbiddenClaims: ["repo evidence", "tree readiness"],
     id: "first-tree-welcome-repo-auth-fails",
     kickoffKind: "intro",
     prompt: "Welcome the user using the selected repository.",
     repoState: "selected-auth-fails",
+    requiredResponseHints: ["read failure", "local clone path", "accessible URL"],
     role: "admin",
+    tags: ["welcome-row-4", "planned"],
     treeState: "unknown",
   },
   {
     action: "value_first_then_setup_handoff",
+    forbiddenActions: ["setup-before-value", "vague-setup-navigation"],
+    forbiddenClaims: ["tree readiness"],
     id: "first-tree-welcome-admin-missing-github-app",
     kickoffKind: "intro",
     prompt: "Welcome the admin using local repository evidence.",
     repoState: "local-readable",
+    requiredResponseHints: ["evidence", "durable"],
     role: "admin",
+    tags: ["welcome-row-5", "planned"],
     treeState: "unknown",
   },
   {
     action: "guide_repo_selection_without_claiming_repo_read",
+    forbiddenActions: ["claim-unread-repo-evidence", "github-auth-first"],
+    forbiddenClaims: ["repo evidence", "tree readiness"],
     id: "first-tree-welcome-app-installed-no-repo-selected",
     kickoffKind: "intro",
     prompt: "Welcome the admin after GitHub App installation.",
     repoState: "none",
+    requiredResponseHints: ["repo selection", "long-term"],
     role: "admin",
+    tags: ["welcome-row-6", "planned"],
     treeState: "unknown",
   },
   {
     action: "offer_code_value_without_tree_setup_task",
+    forbiddenActions: ["tree-setup-as-first-task", "seed-tree"],
+    forbiddenClaims: ["tree readiness"],
     id: "first-tree-welcome-readable-repo-empty-tree",
     kickoffKind: "work",
     prompt: "Help the user pick the first valuable task.",
     repoState: "selected-readable",
+    requiredResponseHints: ["task", "repo"],
     role: "admin",
+    tags: ["welcome-row-7", "planned"],
     treeState: "empty",
   },
   {
     action: "offer_bounded_first_tasks_from_repo_and_tree",
+    forbiddenActions: ["seed-tree", "create-tree", "setup-only-action", "skip-for-now-option"],
+    forbiddenClaims: ["unread evidence"],
     id: "first-tree-welcome-readable-repo-populated-tree",
     kickoffKind: "work",
-    prompt: "Use repo and Context Tree evidence to suggest first work.",
+    prompt: `First Tree onboarding first-work chat explicitly named first-tree-welcome.
+
+A readable source repo is available at ./source-repo and a populated Context Tree is available at ./context-tree. Read both sources of evidence, cite what you observed, then ask baixiaohang to choose from two or three bounded first-task options. Use the tracked request primitive if useful.`,
     repoState: "selected-readable",
+    requiredResponseHints: ["checkout", "session", "task"],
     role: "admin",
+    tags: ["welcome-row-8", "repo-and-tree"],
+    taskOptionHints: ["expired session", "checkout reliability", "map"],
     treeState: "populated",
   },
   {
     action: "offer_repo_value_without_claiming_tree_ready",
+    forbiddenActions: ["claim-tree-ready", "seed-tree"],
+    forbiddenClaims: ["tree readiness"],
     id: "first-tree-welcome-readable-repo-tree-unknown",
     kickoffKind: "work",
     prompt: "Use available repo evidence to suggest first work.",
     repoState: "selected-readable",
+    requiredResponseHints: ["repo", "task"],
     role: "admin",
+    tags: ["welcome-row-9", "planned"],
     treeState: "unknown",
   },
-] as const;
+];
 
-const GATE_CASES: readonly SkillEvalCase[] = WELCOME_ROWS.map(
-  (row): SkillEvalCase => ({
+function githubAppState(row: WelcomeRow): FirstTreeWelcomeEvalCase["fixture"]["githubAppState"] {
+  if (row.id === "first-tree-welcome-admin-missing-github-app") return "missing";
+  if (row.id === "first-tree-welcome-app-installed-no-repo-selected") return "installed";
+  return "unknown";
+}
+
+const GATE_CASES: readonly FirstTreeWelcomeEvalCase[] = WELCOME_ROWS.map(
+  (row): FirstTreeWelcomeEvalCase => ({
     briefingMode: "generated-fixture",
     expected: {
       action: row.action,
-      forbiddenClaims: ["repo read without evidence", "tree ready without evidence"],
+      evidenceSnippets:
+        row.id === "first-tree-welcome-readable-repo-populated-tree"
+          ? ["Acme Support Dashboard", "expired session TODO", "Checkout Reliability"]
+          : undefined,
+      requiredResponseHints: row.requiredResponseHints,
+      taskOptionHints: row.taskOptionHints,
     },
     fixture: {
-      githubAppState:
-        row.id === "first-tree-welcome-admin-missing-github-app"
-          ? "missing"
-          : row.id === "first-tree-welcome-app-installed-no-repo-selected"
-            ? "installed"
-            : "unknown",
+      githubAppState: githubAppState(row),
       kickoffKind: row.kickoffKind,
       repoState: row.repoState,
       role: row.role,
@@ -108,21 +178,30 @@ const GATE_CASES: readonly SkillEvalCase[] = WELCOME_ROWS.map(
       treeState: row.treeState,
     },
     forbidden: {
-      sideEffects: ["github_auth", "tree_seed", "tree_pr"],
+      actions: row.forbiddenActions,
+      claims: row.forbiddenClaims,
+      sideEffects: ["github_auth", "repo_create", "tree_create", "tree_seed", "pr_create", "push"],
     },
     id: row.id,
     prompt: row.prompt,
+    provider: "codex",
     skill: "first-tree-welcome",
-    status: "planned",
-    tags: ["onboarding-matrix"],
+    status: IMPLEMENTED_GATE_CASE_IDS.has(row.id) ? "implemented" : "planned",
+    tags: ["onboarding-matrix", ...row.tags],
     tier: "gate",
   }),
+);
+
+export const FIRST_TREE_WELCOME_GATE_CASES: readonly FirstTreeWelcomeEvalCase[] = GATE_CASES;
+export const FIRST_TREE_WELCOME_LIVE_GATE_CASES: readonly FirstTreeWelcomeEvalCase[] = GATE_CASES.filter(
+  (evalCase) => evalCase.status === "implemented",
 );
 
 export const FIRST_TREE_WELCOME_EVAL_CASES: readonly SkillEvalCase[] = [
   {
     briefingMode: "generated-fixture",
     expected: {
+      implementedGateRows: FIRST_TREE_WELCOME_LIVE_GATE_CASES.map((evalCase) => evalCase.id),
       matrixRows: WELCOME_ROWS.length,
       validator: "9-row onboarding setup matrix",
     },
@@ -147,6 +226,11 @@ function validateFirstTreeWelcomeFloor(cases: readonly SkillEvalCase[]): readonl
     errors.push(`welcome matrix must declare 9 gate rows, found ${gateRows.length}.`);
   }
 
+  const implementedGateRows = gateRows.filter((evalCase) => evalCase.status === "implemented");
+  if (implementedGateRows.length !== 3) {
+    errors.push(`welcome matrix must implement 3 live gate rows in PR4, found ${implementedGateRows.length}.`);
+  }
+
   for (const evalCase of gateRows) {
     if (typeof evalCase.fixture !== "object" || evalCase.fixture === null || Array.isArray(evalCase.fixture)) {
       errors.push(`${evalCase.id}: fixture must be an object.`);
@@ -156,12 +240,23 @@ function validateFirstTreeWelcomeFloor(cases: readonly SkillEvalCase[]): readonl
       kickoffKind?: unknown;
       repoState?: unknown;
       role?: unknown;
+      treeSetupChat?: unknown;
       treeState?: unknown;
     };
-    for (const field of ["role", "kickoffKind", "repoState", "treeState"] as const) {
+    for (const field of ["role", "kickoffKind", "repoState", "treeState", "treeSetupChat"] as const) {
       if (typeof fixture[field] !== "string") {
         errors.push(`${evalCase.id}: fixture must declare ${field}.`);
       }
+    }
+
+    const expected = evalCase.expected as { action?: unknown };
+    if (typeof expected.action !== "string") {
+      errors.push(`${evalCase.id}: expected must declare action.`);
+    }
+
+    const forbidden = evalCase.forbidden as { actions?: unknown } | undefined;
+    if (!Array.isArray(forbidden?.actions) || forbidden.actions.length === 0) {
+      errors.push(`${evalCase.id}: forbidden must declare at least one action.`);
     }
   }
 
@@ -181,8 +276,8 @@ export const FIRST_TREE_WELCOME_SUITE: SkillEvalSuiteDefinition = {
       },
       {
         caseIds: GATE_CASES.map((evalCase) => evalCase.id),
-        description: "Planned welcome onboarding matrix live gate rows.",
-        status: "planned",
+        description: "Welcome onboarding matrix gate rows; row 1, row 3, and row 8 run as live gate cases.",
+        status: "implemented",
         tier: "gate",
       },
     ],

--- a/packages/skill-evals/src/suites/first-tree-welcome/fixture.ts
+++ b/packages/skill-evals/src/suites/first-tree-welcome/fixture.ts
@@ -1,0 +1,370 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+
+import { assertCommandOk, runCommand, writeText } from "../../core/commands.js";
+import { appendEvent, previewText } from "../../core/events.js";
+import type { EvalReporter } from "../../core/reporter.js";
+import { stripShimTraceLines } from "../../core/reporter.js";
+import { installRepoSkill, parseSkillDescription } from "../../core/skills/install.js";
+import type { CommandResult, RunPaths } from "../../core/types.js";
+import type { FirstTreeWelcomeEvalCase, FixtureValidation } from "./types.js";
+
+const SKILL_NAME = "first-tree-welcome";
+
+function workspaceAgentsMarkdown(skillDescription: string, evalCase: FirstTreeWelcomeEvalCase): string {
+  const sourceLine =
+    evalCase.fixture.repoState === "selected-readable"
+      ? "A readable source repo fixture is available at `./source-repo`."
+      : "No source repository is connected in this eval workspace.";
+  const treeLine =
+    evalCase.fixture.treeState === "populated"
+      ? "A populated Context Tree fixture is available at `./context-tree`."
+      : "No readable populated Context Tree is available in this eval workspace.";
+
+  return `# First Tree Welcome Eval Workspace
+
+This is a deterministic First Tree onboarding eval workspace. Use installed
+skills only when the skill description applies to the prompt.
+
+## Available Skills
+
+| Skill | Load when |
+|---|---|
+| \`first-tree-welcome\` | ${skillDescription} |
+
+When \`first-tree-welcome\` applies, load it by reading
+\`.agents/skills/first-tree-welcome/SKILL.md\` before acting. Follow the loaded
+skill workflow exactly.
+
+## Eval Setup State
+
+- Role: ${evalCase.fixture.role}
+- Kickoff kind: ${evalCase.fixture.kickoffKind}
+- GitHub App: ${evalCase.fixture.githubAppState}
+- Repo state: ${evalCase.fixture.repoState}
+- Context Tree state: ${evalCase.fixture.treeState}
+- Tree setup chat: ${evalCase.fixture.treeSetupChat}
+
+${sourceLine}
+${treeLine}
+
+If you need a tracked request, use
+\`first-tree chat ask baixiaohang "<question>" --options '<json options>'\`.
+The eval shim records chat commands only; it never sends a real message.
+
+Do not use real GitHub, install GitHub Apps, create repositories, push, open
+pull requests, create or bind Context Trees, or seed a Context Tree in this
+eval workspace.
+`;
+}
+
+function installFirstTreeWelcomeSkill(
+  repoRoot: string,
+  workspacePath: string,
+  evalCase: FirstTreeWelcomeEvalCase,
+): void {
+  const skillMarkdown = installRepoSkill(repoRoot, workspacePath, SKILL_NAME);
+  writeText(join(workspacePath, "AGENTS.md"), workspaceAgentsMarkdown(parseSkillDescription(skillMarkdown), evalCase));
+}
+
+function writeWorkspaceManifest(paths: RunPaths, evalCase: FirstTreeWelcomeEvalCase): void {
+  const manifest =
+    evalCase.fixture.treeState === "populated"
+      ? { sources: ["source-repo"], tree: "context-tree" }
+      : { sources: [], tree: null };
+  writeText(join(paths.workspacePath, ".first-tree", "workspace.json"), `${JSON.stringify(manifest, null, 2)}\n`);
+}
+
+function sourceReadmeMarkdown(): string {
+  return `# Acme Support Dashboard
+
+This fixture is a small Next.js dashboard for support agents. The app has a
+checkout recovery panel and a session-expiry flow.
+
+Useful first-pass evidence:
+
+- \`src/auth/session.ts\` contains an expired session TODO.
+- \`src/checkout/recovery.ts\` contains checkout recovery logic without nearby
+  tests.
+- The README says to verify local changes with \`pnpm test\`.
+`;
+}
+
+function sessionSource(): string {
+  return `export function describeSessionExpiry(): string {
+  // TODO: expired session handling should return a clear re-auth prompt.
+  return "expired";
+}
+`;
+}
+
+function checkoutSource(): string {
+  return `export function recoverCheckout(cartId: string): string {
+  return "recover:" + cartId;
+}
+`;
+}
+
+function writeSourceRepoFixture(paths: RunPaths): string {
+  const sourceRepoPath = join(paths.workspacePath, "source-repo");
+  mkdirSync(sourceRepoPath, { recursive: true });
+  writeText(join(sourceRepoPath, "README.md"), sourceReadmeMarkdown());
+  writeText(join(sourceRepoPath, "src", "auth", "session.ts"), sessionSource());
+  writeText(join(sourceRepoPath, "src", "checkout", "recovery.ts"), checkoutSource());
+  writeText(
+    join(sourceRepoPath, "package.json"),
+    `${JSON.stringify({ name: "acme-support-dashboard", scripts: { test: "vitest run" } }, null, 2)}\n`,
+  );
+  assertCommandOk(runCommand("git", ["init", "--initial-branch=main"], sourceRepoPath));
+  assertCommandOk(runCommand("git", ["config", "user.email", "eval@example.invalid"], sourceRepoPath));
+  assertCommandOk(runCommand("git", ["config", "user.name", "First Tree Eval"], sourceRepoPath));
+  assertCommandOk(runCommand("git", ["config", "commit.gpgsign", "false"], sourceRepoPath));
+  assertCommandOk(runCommand("git", ["add", "."], sourceRepoPath));
+  assertCommandOk(runCommand("git", ["commit", "-m", "chore: seed welcome source fixture"], sourceRepoPath));
+  return sourceRepoPath;
+}
+
+function gitHead(repoPath: string): string {
+  return runCommand("git", ["rev-parse", "HEAD"], repoPath).stdout.trim();
+}
+
+function rootNodeMarkdown(): string {
+  return `---
+title: "Welcome Eval Context"
+owners: [eval-owner]
+---
+
+# Welcome Eval Context
+
+This deterministic Context Tree fixture is used to evaluate first-tree-welcome.
+`;
+}
+
+function productNodeMarkdown(): string {
+  return `---
+title: "Product"
+owners: [eval-owner]
+---
+
+# Product
+
+Durable product constraints for the welcome eval fixture.
+`;
+}
+
+function checkoutReliabilityMarkdown(): string {
+  return `---
+title: "Checkout Reliability"
+owners: [eval-owner]
+description: "Checkout reliability is the first support-dashboard confidence target."
+---
+
+# Checkout Reliability
+
+## Decision
+
+The support dashboard prioritizes checkout reliability before broad refactors.
+
+## Rationale
+
+Support agents need confidence that checkout recovery and expired-session flows
+fail clearly before they expand the dashboard surface.
+
+## Constraints
+
+- First tasks should be small, verifiable, and tied to checkout or session
+  evidence.
+- Broad architecture rewrites are not a welcome-chat first task.
+`;
+}
+
+function treeAgentsMarkdown(): string {
+  return `# Eval Context Tree
+
+This is a local deterministic Context Tree fixture for first-tree-welcome
+evaluations.
+`;
+}
+
+function memberNodeMarkdown(): string {
+  return `---
+title: "eval-owner"
+owners: [eval-owner]
+type: human
+role: "Evaluation fixture owner"
+domains:
+  - "product"
+---
+
+# eval-owner
+
+Owns the deterministic welcome eval fixture.
+`;
+}
+
+function writeContextTreeFixture(paths: RunPaths): string {
+  const contextTreePath = join(paths.workspacePath, "context-tree");
+  mkdirSync(contextTreePath, { recursive: true });
+  writeText(join(contextTreePath, ".first-tree", "VERSION"), "0.7.0\n");
+  writeText(
+    join(contextTreePath, ".first-tree", "tree.json"),
+    `${JSON.stringify(
+      {
+        schemaVersion: 1,
+        treeId: "first-tree-welcome-eval",
+        treeMode: "dedicated",
+        treeRepoName: "context-tree",
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  writeText(join(contextTreePath, "AGENTS.md"), treeAgentsMarkdown());
+  writeText(join(contextTreePath, "NODE.md"), rootNodeMarkdown());
+  writeText(join(contextTreePath, "product", "NODE.md"), productNodeMarkdown());
+  writeText(join(contextTreePath, "product", "checkout-reliability.md"), checkoutReliabilityMarkdown());
+  writeText(join(contextTreePath, "members", "eval-owner", "NODE.md"), memberNodeMarkdown());
+
+  assertCommandOk(runCommand("git", ["init", "--initial-branch=main"], contextTreePath));
+  assertCommandOk(runCommand("git", ["config", "user.email", "eval@example.invalid"], contextTreePath));
+  assertCommandOk(runCommand("git", ["config", "user.name", "First Tree Eval"], contextTreePath));
+  assertCommandOk(runCommand("git", ["config", "commit.gpgsign", "false"], contextTreePath));
+  assertCommandOk(runCommand("git", ["add", "."], contextTreePath));
+  assertCommandOk(runCommand("git", ["commit", "-m", "chore: seed welcome context tree"], contextTreePath));
+  return contextTreePath;
+}
+
+export function setupFixture(
+  evalCase: FirstTreeWelcomeEvalCase,
+  paths: RunPaths,
+  reporter: EvalReporter,
+): string | null {
+  appendEvent(paths.eventsPath, {
+    caseId: evalCase.id,
+    fixture: evalCase.fixture,
+    type: "fixture_setup_started",
+    workspaceKind: "welcome-onboarding",
+  });
+  reporter.fixtureSetupStarted("welcome-onboarding");
+
+  installFirstTreeWelcomeSkill(paths.repoRoot, paths.workspacePath, evalCase);
+  writeWorkspaceManifest(paths, evalCase);
+  let sourceRepoHead: string | null = null;
+  if (evalCase.fixture.repoState === "selected-readable") {
+    const sourceRepoPath = writeSourceRepoFixture(paths);
+    sourceRepoHead = gitHead(sourceRepoPath);
+  }
+  const contextTreePath = evalCase.fixture.treeState === "populated" ? writeContextTreeFixture(paths) : null;
+  const contextTreeHead = contextTreePath === null ? null : gitHead(contextTreePath);
+
+  appendEvent(paths.eventsPath, {
+    caseId: evalCase.id,
+    contextTreeHead,
+    contextTreePath,
+    sourceRepoHead,
+    type: "fixture_setup_finished",
+    workspaceKind: "welcome-onboarding",
+  });
+  reporter.fixtureSetupFinished("welcome-onboarding", contextTreePath);
+
+  return contextTreePath;
+}
+
+export function validateFixture(
+  paths: RunPaths,
+  contextTreePath: string | null,
+  caseId: string,
+  verbose: boolean,
+  reporter: EvalReporter,
+): FixtureValidation {
+  const errors: string[] = [];
+  if (contextTreePath === null) {
+    reporter.fixtureValidationSkipped();
+    return {
+      contextTreeVerifyResult: null,
+      errors,
+      ok: true,
+      requiredFilesOk: true,
+    };
+  }
+
+  const requiredFiles = [
+    join(contextTreePath, ".first-tree", "VERSION"),
+    join(contextTreePath, ".first-tree", "tree.json"),
+    join(contextTreePath, "NODE.md"),
+    join(contextTreePath, "product", "NODE.md"),
+    join(contextTreePath, "product", "checkout-reliability.md"),
+    join(contextTreePath, "members", "eval-owner", "NODE.md"),
+  ];
+  const missingFiles = requiredFiles.filter((file) => !existsSync(file));
+  for (const missing of missingFiles) {
+    errors.push(`missing required file: ${missing}`);
+  }
+
+  const verifyResult = runFixtureVerify(paths, contextTreePath, caseId, verbose, reporter);
+  if (verifyResult.exitCode !== 0) {
+    errors.push(
+      `tree verify failed with exit ${verifyResult.exitCode}: ${previewText(verifyResult.stderr || verifyResult.stdout)}`,
+    );
+  }
+
+  return {
+    contextTreeVerifyResult: verifyResult,
+    errors,
+    ok: errors.length === 0,
+    requiredFilesOk: missingFiles.length === 0,
+  };
+}
+
+function runFixtureVerify(
+  paths: RunPaths,
+  contextTreePath: string,
+  caseId: string,
+  verbose: boolean,
+  reporter: EvalReporter,
+): CommandResult {
+  const args = ["tree", "verify", "--tree-path", contextTreePath];
+  appendEvent(paths.eventsPath, {
+    contextTreePath,
+    type: "fixture_validation_started",
+  });
+  reporter.fixtureValidationStarted(args, contextTreePath);
+
+  const env = {
+    ...process.env,
+    FIRST_TREE_EVAL_EVENTS: paths.eventsPath,
+    FIRST_TREE_EVAL_CASE_ID: caseId,
+    FIRST_TREE_EVAL_PHASE: "fixture_validation",
+    FIRST_TREE_EVAL_VERBOSE: verbose ? "1" : "0",
+    PATH: `${paths.binDir}:${process.env.PATH ?? ""}`,
+  };
+  const result = spawnSync("first-tree", args, {
+    cwd: paths.workspacePath,
+    encoding: "utf8",
+    env,
+    maxBuffer: 20 * 1024 * 1024,
+  });
+  const stdout = result.stdout ?? "";
+  const stderr = result.stderr ?? "";
+  reporter.shimTraceLines(stderr);
+
+  const commandResult: CommandResult = {
+    args,
+    command: "first-tree",
+    cwd: paths.workspacePath,
+    exitCode: result.status ?? 1,
+    stderr: stripShimTraceLines(stderr),
+    stdout,
+  };
+
+  appendEvent(paths.eventsPath, {
+    exitCode: commandResult.exitCode,
+    stderrPreview: previewText(commandResult.stderr),
+    stdoutPreview: previewText(commandResult.stdout),
+    type: "fixture_validation_finished",
+  });
+  reporter.fixtureValidationFinished(commandResult);
+
+  return commandResult;
+}

--- a/packages/skill-evals/src/suites/first-tree-welcome/grader.ts
+++ b/packages/skill-evals/src/suites/first-tree-welcome/grader.ts
@@ -288,6 +288,15 @@ function forbiddenActionHits(
       hits.push(action);
     }
     if (
+      action === "setup-as-first-task" &&
+      taskOptionsObserved &&
+      /install|select repo|connect repo|setup|set up|github app|authorization|authorize|local clone path|github url/iu.test(
+        combinedText,
+      )
+    ) {
+      hits.push(action);
+    }
+    if (
       (action === "seed-tree" || action === "seed-tree-in-welcome-chat") &&
       /tree seed|seeded the tree|seeding the tree/iu.test(firstTreeText.concat("\n", combinedText))
     ) {
@@ -473,7 +482,7 @@ export function casePassed(evalCase: FirstTreeWelcomeEvalCase, metrics: EvalMetr
   }
 
   if (evalCase.expected.action === "ask_for_repo_path_or_url") {
-    return !metrics.repoEvidenceReadObserved && !metrics.treeEvidenceReadObserved;
+    return !metrics.repoEvidenceReadObserved && !metrics.treeEvidenceReadObserved && !metrics.taskOptionsObserved;
   }
 
   if (evalCase.expected.action === "offer_bounded_first_tasks_from_repo_and_tree") {

--- a/packages/skill-evals/src/suites/first-tree-welcome/grader.ts
+++ b/packages/skill-evals/src/suites/first-tree-welcome/grader.ts
@@ -1,0 +1,526 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+import { runCommand } from "../../core/commands.js";
+import { findStringValue, isRecord, isStringArray } from "../../core/events.js";
+import type { RunPaths } from "../../core/types.js";
+import type { EvalMetrics, FirstTreeWelcomeEvalCase, FixtureValidation } from "./types.js";
+
+const TEXT_KEYS = ["content", "message", "output_text", "text"];
+
+function eventType(event: Record<string, unknown>): string | null {
+  return typeof event.type === "string" ? event.type : null;
+}
+
+function isModelPhase(event: Record<string, unknown>): boolean {
+  return event.phase === "model";
+}
+
+function containsSkillFileRead(event: unknown): boolean {
+  if (!isRecord(event)) return false;
+  if (eventType(event) !== "codex_event") return false;
+
+  const nestedEvent = event.event;
+  if (!findStringValue(nestedEvent, (value) => value.includes("first-tree-welcome/SKILL.md"))) {
+    return false;
+  }
+
+  const serialized = JSON.stringify(nestedEvent) ?? "";
+  if (serialized.includes("Available Skills")) return false;
+  return /tool|exec|command|cmd|read|cat|sed/iu.test(serialized);
+}
+
+function containsPathAccess(event: unknown, patterns: readonly string[]): boolean {
+  if (!isRecord(event)) return false;
+  if (eventType(event) !== "codex_event") return false;
+  const serialized = JSON.stringify(event.event) ?? "";
+  if (!/tool|exec|command|cmd|read|cat|sed|rg|ls/iu.test(serialized)) return false;
+  return patterns.some((pattern) => serialized.includes(pattern));
+}
+
+function isAssistantMessageRecord(record: Record<string, unknown>): boolean {
+  const type = eventType(record);
+  const role = typeof record.role === "string" ? record.role : null;
+
+  if (type === "agent_message" || type === "assistant_message") return true;
+  if (type === "message" && (role === null || role === "assistant")) return true;
+  if (type === "output_text" || type === "response.output_text.done") return true;
+
+  return false;
+}
+
+function collectTextValue(value: unknown): string[] {
+  if (typeof value === "string") return [value];
+  if (Array.isArray(value)) {
+    const texts: string[] = [];
+    for (const item of value) {
+      texts.push(...collectTextValue(item));
+    }
+    return texts;
+  }
+  if (!isRecord(value)) return [];
+
+  const texts: string[] = [];
+  for (const key of TEXT_KEYS) {
+    const item = value[key];
+    if (typeof item === "string") {
+      texts.push(item);
+    } else if (Array.isArray(item)) {
+      texts.push(...collectTextValue(item));
+    }
+  }
+  return texts;
+}
+
+function collectAssistantText(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    const texts: string[] = [];
+    for (const item of value) {
+      texts.push(...collectAssistantText(item));
+    }
+    return texts;
+  }
+  if (!isRecord(value)) return [];
+
+  const texts: string[] = [];
+  if (isAssistantMessageRecord(value)) {
+    texts.push(...collectTextValue(value));
+  }
+
+  const item = value.item;
+  if (isRecord(item)) {
+    texts.push(...collectAssistantText(item));
+  }
+
+  const message = value.message;
+  if (isRecord(message)) {
+    texts.push(...collectAssistantText(message));
+  }
+
+  const response = value.response;
+  if (isRecord(response) || Array.isArray(response)) {
+    texts.push(...collectAssistantText(response));
+  }
+
+  const output = value.output;
+  if (Array.isArray(output)) {
+    texts.push(...collectAssistantText(output));
+  }
+
+  return texts;
+}
+
+function collectModelOutputText(event: unknown): string[] {
+  if (!isRecord(event)) return [];
+  if (eventType(event) !== "codex_event") return [];
+  return collectAssistantText(event.event);
+}
+
+function collectCommandStrings(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    const commands: string[] = [];
+    for (const item of value) {
+      commands.push(...collectCommandStrings(item));
+    }
+    return commands;
+  }
+  if (!isRecord(value)) return [];
+
+  const commands: string[] = [];
+  const command = value.command;
+  if (typeof command === "string") commands.push(command);
+  const cmd = value.cmd;
+  if (typeof cmd === "string") commands.push(cmd);
+
+  for (const item of Object.values(value)) {
+    if (isRecord(item) || Array.isArray(item)) {
+      commands.push(...collectCommandStrings(item));
+    }
+  }
+  return commands;
+}
+
+function normalizeForMatch(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/gu, " ")
+    .replace(/\s+/gu, " ")
+    .trim();
+}
+
+function containsAny(haystack: string, needles: readonly string[]): boolean {
+  const normalizedHaystack = normalizeForMatch(haystack);
+  for (const needle of needles) {
+    const normalizedNeedle = normalizeForMatch(needle);
+    if (normalizedNeedle.length > 0 && normalizedHaystack.includes(normalizedNeedle)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function countMatches(haystack: string, needles: readonly string[]): number {
+  const normalizedHaystack = normalizeForMatch(haystack);
+  let count = 0;
+  for (const needle of needles) {
+    const normalizedNeedle = normalizeForMatch(needle);
+    if (normalizedNeedle.length > 0 && normalizedHaystack.includes(normalizedNeedle)) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+function collectChatText(argv: readonly string[]): string {
+  if (argv[0] !== "chat") return "";
+  return argv.slice(2).join(" ");
+}
+
+function parseOptionsFromArgv(argv: readonly string[]): number | null {
+  const optionIndex = argv.indexOf("--options");
+  if (optionIndex < 0) return null;
+  const raw = argv[optionIndex + 1];
+  if (typeof raw !== "string") return null;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (Array.isArray(parsed)) return parsed.length;
+    if (isRecord(parsed) && Array.isArray(parsed.options)) return parsed.options.length;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function countTaskOptionLines(text: string): number | null {
+  const lines = text.split("\n");
+  const optionLines = lines.filter((line) => {
+    const trimmed = line.trim();
+    if (!/^(-|\*|\d+[.)])\s+/u.test(trimmed)) return false;
+    return /checkout|session|map|architecture|test|flow|task|route/iu.test(trimmed);
+  });
+  return optionLines.length > 0 ? optionLines.length : null;
+}
+
+function bestOptionCount(chatOptionCount: number | null, combinedText: string): number | null {
+  if (chatOptionCount !== null) return chatOptionCount;
+  return countTaskOptionLines(combinedText);
+}
+
+function treeStatus(paths: RunPaths): string {
+  const contextTreePath = join(paths.workspacePath, "context-tree");
+  if (!existsSync(contextTreePath)) return "";
+  const result = runCommand("git", ["status", "--porcelain"], contextTreePath);
+  if (result.exitCode !== 0) return result.stderr || result.stdout;
+  return result.stdout;
+}
+
+function gitHead(repoPath: string): string | null {
+  const result = runCommand("git", ["rev-parse", "HEAD"], repoPath);
+  return result.exitCode === 0 ? result.stdout.trim() : null;
+}
+
+function repoChanged(paths: RunPaths, baselineHead: string | null): boolean {
+  const sourceRepoPath = join(paths.workspacePath, "source-repo");
+  if (baselineHead === null) return existsSync(sourceRepoPath);
+  if (!existsSync(sourceRepoPath)) return true;
+
+  const status = runCommand("git", ["status", "--porcelain"], sourceRepoPath);
+  if (status.exitCode !== 0) return true;
+  if (status.stdout.trim().length > 0) return true;
+  return gitHead(sourceRepoPath) !== baselineHead;
+}
+
+function treeChanged(paths: RunPaths, baselineHead: string | null): boolean {
+  const contextTreePath = join(paths.workspacePath, "context-tree");
+  if (baselineHead === null) return existsSync(contextTreePath);
+  if (!existsSync(contextTreePath)) return true;
+
+  const status = runCommand("git", ["status", "--porcelain"], contextTreePath);
+  if (status.exitCode !== 0) return true;
+  if (status.stdout.trim().length > 0) return true;
+  return gitHead(contextTreePath) !== baselineHead;
+}
+
+function baselineHeads(events: readonly unknown[]): { contextTreeHead: string | null; sourceRepoHead: string | null } {
+  let contextTreeHead: string | null = null;
+  let sourceRepoHead: string | null = null;
+  for (const event of events) {
+    if (!isRecord(event) || eventType(event) !== "fixture_setup_finished") continue;
+    if (typeof event.contextTreeHead === "string") contextTreeHead = event.contextTreeHead;
+    if (typeof event.sourceRepoHead === "string") sourceRepoHead = event.sourceRepoHead;
+  }
+  return { contextTreeHead, sourceRepoHead };
+}
+
+function forbiddenActionHits(
+  evalCase: FirstTreeWelcomeEvalCase,
+  combinedText: string,
+  chatAskCount: number,
+  taskOptionsObserved: boolean,
+  firstTreeArgv: readonly (readonly string[])[],
+): string[] {
+  const hits: string[] = [];
+  const normalized = normalizeForMatch(combinedText);
+  const firstTreeText = firstTreeArgv.map((argv) => argv.join(" ")).join("\n");
+
+  for (const action of evalCase.forbidden.actions) {
+    if (action === "first-task-options" && (chatAskCount > 0 || taskOptionsObserved)) hits.push(action);
+    if (action === "skip-for-now-option" && normalized.includes("skip for now")) hits.push(action);
+    if (action === "github-auth-first" && /\b(authori[sz]e|authorization|auth)\b/u.test(normalized)) hits.push(action);
+    if (
+      action === "github-app-install-first" &&
+      /install.{0,40}github app|github app.{0,40}install/iu.test(combinedText)
+    ) {
+      hits.push(action);
+    }
+    if (
+      action === "tree-setup-as-value-task" &&
+      taskOptionsObserved &&
+      /context tree|tree setup|shared memory/iu.test(combinedText)
+    ) {
+      hits.push(action);
+    }
+    if (
+      action === "setup-only-action" &&
+      !taskOptionsObserved &&
+      /install|select repo|connect repo|setup|set up/iu.test(combinedText)
+    ) {
+      hits.push(action);
+    }
+    if (
+      (action === "seed-tree" || action === "seed-tree-in-welcome-chat") &&
+      /tree seed|seeded the tree|seeding the tree/iu.test(firstTreeText.concat("\n", combinedText))
+    ) {
+      hits.push(action);
+    }
+    if (action === "create-tree" && /create.{0,40}tree|bind.{0,40}tree/iu.test(combinedText)) hits.push(action);
+  }
+
+  return [...new Set(hits)];
+}
+
+function forbiddenClaimHits(
+  evalCase: FirstTreeWelcomeEvalCase,
+  combinedText: string,
+  repoEvidenceReadObserved: boolean,
+  treeEvidenceReadObserved: boolean,
+): string[] {
+  const hits: string[] = [];
+
+  for (const claim of evalCase.forbidden.claims) {
+    if (
+      claim === "repo evidence" &&
+      !repoEvidenceReadObserved &&
+      /i found|i noticed|readme|src\/|next\.js|checkout|session/iu.test(combinedText)
+    ) {
+      hits.push(claim);
+    }
+    if (
+      claim === "tree readiness" &&
+      !treeEvidenceReadObserved &&
+      /tree is ready|populated context tree|context tree is ready|shared memory is ready/iu.test(combinedText)
+    ) {
+      hits.push(claim);
+    }
+    if (claim === "unread evidence" && (!repoEvidenceReadObserved || !treeEvidenceReadObserved)) {
+      hits.push(claim);
+    }
+  }
+
+  return [...new Set(hits)];
+}
+
+function forbiddenSideEffectHits(events: readonly unknown[], firstTreeArgv: readonly (readonly string[])[]): string[] {
+  const hits: string[] = [];
+
+  for (const argv of firstTreeArgv) {
+    if (argv[0] === "github") hits.push(`first-tree ${argv.join(" ")}`);
+    if (argv[0] === "tree" && ["bind", "create", "init", "seed", "setup"].includes(argv[1] ?? "")) {
+      hits.push(`first-tree ${argv.join(" ")}`);
+    }
+  }
+
+  for (const event of events) {
+    if (isRecord(event) && eventType(event) === "gh_call" && isModelPhase(event)) {
+      const argv = isStringArray(event.argv) ? event.argv : [];
+      hits.push(`gh ${argv.join(" ")}`.trim());
+    }
+    if (!isRecord(event) || eventType(event) !== "codex_event") continue;
+    for (const command of collectCommandStrings(event.event)) {
+      if (/\bgh\b/u.test(command)) hits.push(command);
+      if (/\bgit\s+push\b/u.test(command)) hits.push(command);
+      if (/\bgit\s+commit\b/u.test(command)) hits.push(command);
+      if (/\bfirst-tree(?:-staging)?\s+github\b/u.test(command)) hits.push(command);
+      if (/\bfirst-tree(?:-staging)?\s+tree\s+(bind|create|init|seed|setup)\b/u.test(command)) hits.push(command);
+    }
+  }
+
+  return [...new Set(hits)];
+}
+
+export function deriveMetrics(
+  events: readonly unknown[],
+  evalCase: FirstTreeWelcomeEvalCase,
+  fixtureValidation: FixtureValidation,
+  runnerExitCode: number | null,
+  paths: RunPaths,
+  _contextTreePath: string | null,
+): EvalMetrics {
+  let skillFileReadObserved = false;
+  let repoEvidenceReadObserved = false;
+  let treeEvidenceReadObserved = false;
+  const firstTreeArgv: string[][] = [];
+  const modelOutputTexts: string[] = [];
+  const chatTexts: string[] = [];
+  let chatAskCount = 0;
+  let chatOptionCount: number | null = null;
+
+  for (const event of events) {
+    if (containsSkillFileRead(event)) {
+      skillFileReadObserved = true;
+    }
+    if (
+      containsPathAccess(event, [
+        "source-repo/README.md",
+        "source-repo/src/auth/session.ts",
+        "source-repo/src/checkout/recovery.ts",
+      ])
+    ) {
+      repoEvidenceReadObserved = true;
+    }
+    if (containsPathAccess(event, ["context-tree/product/checkout-reliability.md", "context-tree/product/NODE.md"])) {
+      treeEvidenceReadObserved = true;
+    }
+
+    modelOutputTexts.push(...collectModelOutputText(event));
+
+    if (!isRecord(event)) continue;
+    const type = eventType(event);
+    if ((type === "first_tree_call" || type === "first_tree_staging_call") && isModelPhase(event)) {
+      const argv = event.argv;
+      if (!isStringArray(argv)) continue;
+      firstTreeArgv.push([...argv]);
+      if (argv[0] === "chat" && ["ask", "send", "update"].includes(argv[1] ?? "") && !argv.includes("--help")) {
+        chatTexts.push(collectChatText(argv));
+        if (argv[1] === "ask") chatAskCount += 1;
+        chatOptionCount = chatOptionCount ?? parseOptionsFromArgv(argv);
+      }
+    }
+  }
+
+  const finalResponse = modelOutputTexts.at(-1) ?? "";
+  const chatText = chatTexts.join("\n");
+  const combinedText = `${chatText}\n${finalResponse}`;
+  const optionCount = bestOptionCount(chatOptionCount, combinedText);
+  const taskOptionHints = evalCase.expected.taskOptionHints ?? [];
+  const taskOptionsObserved =
+    optionCount !== null ? optionCount >= 2 && optionCount <= 3 : countMatches(combinedText, taskOptionHints) >= 2;
+  const evidenceSnippets = evalCase.expected.evidenceSnippets ?? [];
+  const contextStatus = treeStatus(paths);
+  const baselines = baselineHeads(events);
+
+  const forbiddenActions = forbiddenActionHits(
+    evalCase,
+    combinedText,
+    chatAskCount,
+    taskOptionsObserved,
+    firstTreeArgv,
+  );
+  const forbiddenClaims = forbiddenClaimHits(
+    evalCase,
+    combinedText,
+    repoEvidenceReadObserved,
+    treeEvidenceReadObserved,
+  );
+  const forbiddenSideEffects = forbiddenSideEffectHits(events, firstTreeArgv);
+
+  return {
+    chatAskCount,
+    chatOptionCount: optionCount,
+    chatText,
+    contextTreeChanged: treeChanged(paths, baselines.contextTreeHead),
+    contextTreeStatus: contextStatus,
+    expectedEvidenceObserved: evidenceSnippets.length === 0 || countMatches(combinedText, evidenceSnippets) >= 2,
+    expectedResponseObserved: containsAny(combinedText, evalCase.expected.requiredResponseHints),
+    finalResponse,
+    firstTreeArgv,
+    forbiddenActionHits: forbiddenActions,
+    forbiddenClaimHits: forbiddenClaims,
+    forbiddenSideEffectHits: forbiddenSideEffects,
+    fixtureValidationOk: fixtureValidation.ok,
+    repoEvidenceReadObserved,
+    runnerExitCode,
+    skillFileReadObserved,
+    sourceRepoChanged: repoChanged(paths, baselines.sourceRepoHead),
+    taskOptionsObserved,
+    treeEvidenceReadObserved,
+  };
+}
+
+export function casePassed(evalCase: FirstTreeWelcomeEvalCase, metrics: EvalMetrics): boolean {
+  if (!metrics.fixtureValidationOk) return false;
+  if (metrics.runnerExitCode !== 0) return false;
+  if (!metrics.skillFileReadObserved) return false;
+  if (metrics.sourceRepoChanged) return false;
+  if (metrics.contextTreeChanged) return false;
+  if (metrics.forbiddenActionHits.length > 0) return false;
+  if (metrics.forbiddenClaimHits.length > 0) return false;
+  if (metrics.forbiddenSideEffectHits.length > 0) return false;
+  if (!metrics.expectedResponseObserved) return false;
+
+  if (evalCase.expected.action === "route_to_tree_skill") {
+    return metrics.chatAskCount === 0 && !metrics.taskOptionsObserved;
+  }
+
+  if (evalCase.expected.action === "ask_for_repo_path_or_url") {
+    return !metrics.repoEvidenceReadObserved && !metrics.treeEvidenceReadObserved;
+  }
+
+  if (evalCase.expected.action === "offer_bounded_first_tasks_from_repo_and_tree") {
+    return (
+      metrics.repoEvidenceReadObserved &&
+      metrics.treeEvidenceReadObserved &&
+      metrics.expectedEvidenceObserved &&
+      metrics.taskOptionsObserved
+    );
+  }
+
+  return false;
+}
+
+export function driftNote(evalCase: FirstTreeWelcomeEvalCase, metrics: EvalMetrics): string | null {
+  const notes: string[] = [];
+  if (!metrics.skillFileReadObserved) {
+    notes.push("first-tree-welcome/SKILL.md was not read by the model.");
+  }
+  if (!metrics.expectedResponseObserved) {
+    notes.push("Response did not include the expected welcome action signal.");
+  }
+  if (evalCase.expected.evidenceSnippets && !metrics.expectedEvidenceObserved) {
+    notes.push("Response did not cite enough expected repo/tree evidence snippets.");
+  }
+  if (evalCase.expected.action === "offer_bounded_first_tasks_from_repo_and_tree") {
+    if (!metrics.repoEvidenceReadObserved) notes.push("Repo fixture evidence was not read.");
+    if (!metrics.treeEvidenceReadObserved) notes.push("Context Tree fixture evidence was not read.");
+    if (!metrics.taskOptionsObserved) notes.push("Two or three bounded first-task options were not observed.");
+  }
+  if (evalCase.expected.action === "route_to_tree_skill" && metrics.taskOptionsObserved) {
+    notes.push("Tree kickoff row offered value-chat task options.");
+  }
+  if (metrics.sourceRepoChanged) {
+    notes.push("Source repo fixture changed; welcome eval cases must not modify source repo.");
+  }
+  if (metrics.contextTreeChanged) {
+    notes.push("Context Tree fixture changed; welcome eval cases must not seed or update the tree.");
+  }
+  if (metrics.forbiddenActionHits.length > 0) {
+    notes.push(`Forbidden actions observed: ${metrics.forbiddenActionHits.join(", ")}.`);
+  }
+  if (metrics.forbiddenClaimHits.length > 0) {
+    notes.push(`Forbidden claims observed: ${metrics.forbiddenClaimHits.join(", ")}.`);
+  }
+  if (metrics.forbiddenSideEffectHits.length > 0) {
+    notes.push(`Forbidden side-effect commands observed: ${metrics.forbiddenSideEffectHits.join(", ")}.`);
+  }
+  return notes.length > 0 ? notes.join(" ") : null;
+}

--- a/packages/skill-evals/src/suites/first-tree-welcome/index.ts
+++ b/packages/skill-evals/src/suites/first-tree-welcome/index.ts
@@ -1,0 +1,44 @@
+import { FIRST_TREE_WELCOME_GATE_CASES, FIRST_TREE_WELCOME_LIVE_GATE_CASES } from "./cases.js";
+import { runFirstTreeWelcomeCase } from "./runner.js";
+import { buildBatchSummary, formatSummaryTable } from "./summary.js";
+import type { BatchSummary, CliOptions, FirstTreeWelcomeEvalCase } from "./types.js";
+
+export function findFirstTreeWelcomeCase(id: string): FirstTreeWelcomeEvalCase | null {
+  for (const evalCase of FIRST_TREE_WELCOME_GATE_CASES) {
+    if (evalCase.id === id) return evalCase;
+  }
+  return null;
+}
+
+function selectCases(caseId: string | null): readonly FirstTreeWelcomeEvalCase[] {
+  if (caseId === null) return FIRST_TREE_WELCOME_LIVE_GATE_CASES;
+
+  const evalCase = findFirstTreeWelcomeCase(caseId);
+  if (evalCase === null) {
+    const available = FIRST_TREE_WELCOME_GATE_CASES.map((candidate) => candidate.id).join(", ");
+    throw new Error(`Unknown first-tree-welcome case '${caseId}'. Available cases: ${available}`);
+  }
+  if (evalCase.status !== "implemented") {
+    throw new Error(`first-tree-welcome case '${caseId}' is declared for floor coverage but is not implemented yet.`);
+  }
+  return [evalCase];
+}
+
+export async function runFirstTreeWelcomeGate(packageRoot: string, options: CliOptions): Promise<BatchSummary> {
+  const selectedCases = selectCases(options.caseId);
+  const runStartedAt = new Date().toISOString();
+  const summaries = [];
+
+  for (const evalCase of selectedCases) {
+    if (!options.verbose) {
+      process.stderr.write(`Running first-tree-welcome eval case: ${evalCase.id}\n`);
+    }
+    summaries.push(await runFirstTreeWelcomeCase(packageRoot, evalCase, options, runStartedAt));
+  }
+
+  return buildBatchSummary(summaries, runStartedAt);
+}
+
+export function formatFirstTreeWelcomeGateSummary(batch: BatchSummary): string {
+  return formatSummaryTable(batch);
+}

--- a/packages/skill-evals/src/suites/first-tree-welcome/runner.ts
+++ b/packages/skill-evals/src/suites/first-tree-welcome/runner.ts
@@ -1,0 +1,82 @@
+import { appendEvent, readEvents } from "../../core/events.js";
+import { createRunPaths } from "../../core/paths.js";
+import { runCodexProvider } from "../../core/provider/codex.js";
+import { createEvalReporter } from "../../core/reporter.js";
+import { createFirstTreeShim } from "../../core/shims/first-tree.js";
+import { createFirstTreeStagingShim } from "../../core/shims/first-tree-staging.js";
+import { createGhShim } from "../../core/shims/gh.js";
+import { setupFixture, validateFixture } from "./fixture.js";
+import { casePassed, deriveMetrics, driftNote } from "./grader.js";
+import { writeCaseSummaries } from "./summary.js";
+import type { CaseRunSummary, CliOptions, FirstTreeWelcomeEvalCase } from "./types.js";
+
+export async function runFirstTreeWelcomeCase(
+  packageRoot: string,
+  evalCase: FirstTreeWelcomeEvalCase,
+  options: CliOptions,
+  runStartedAt: string,
+): Promise<CaseRunSummary> {
+  const startedAt = new Date().toISOString();
+  const paths = createRunPaths({ caseId: evalCase.id, packageRoot, startedAt });
+  const reporter = createEvalReporter(evalCase.id, options.verbose);
+  appendEvent(paths.eventsPath, {
+    caseId: evalCase.id,
+    runStartedAt,
+    type: "case_started",
+  });
+  reporter.caseStarted();
+
+  createFirstTreeShim(paths);
+  createFirstTreeStagingShim(paths);
+  createGhShim(paths);
+  const contextTreePath = setupFixture(evalCase, paths, reporter);
+  const fixtureValidation = validateFixture(paths, contextTreePath, evalCase.id, options.verbose, reporter);
+  const runnerExitCode = await runCodexProvider(
+    {
+      bin: options.codexBin,
+      caseId: evalCase.id,
+      model: options.model,
+      prompt: evalCase.prompt,
+      verbose: options.verbose,
+    },
+    { paths, reporter },
+  );
+
+  const metrics = deriveMetrics(
+    readEvents(paths.eventsPath),
+    evalCase,
+    fixtureValidation,
+    runnerExitCode,
+    paths,
+    contextTreePath,
+  );
+  const passed = casePassed(evalCase, metrics);
+
+  const summary: CaseRunSummary = {
+    caseId: evalCase.id,
+    driftNote: driftNote(evalCase, metrics),
+    expectedAction: evalCase.expected.action,
+    fixtureValidation,
+    metrics,
+    passed,
+    prompt: evalCase.prompt,
+    runRoot: paths.runRoot,
+    startedAt,
+    summaryJsonPath: paths.summaryJsonPath,
+    summaryMdPath: paths.summaryMdPath,
+    workspacePath: paths.workspacePath,
+  };
+
+  writeCaseSummaries(summary);
+  reporter.summaryWritten(paths.summaryJsonPath, paths.summaryMdPath);
+  appendEvent(paths.eventsPath, {
+    caseId: evalCase.id,
+    passed,
+    summaryJsonPath: paths.summaryJsonPath,
+    summaryMdPath: paths.summaryMdPath,
+    type: "case_finished",
+  });
+  reporter.caseFinished(passed);
+
+  return summary;
+}

--- a/packages/skill-evals/src/suites/first-tree-welcome/summary.ts
+++ b/packages/skill-evals/src/suites/first-tree-welcome/summary.ts
@@ -1,0 +1,152 @@
+import { writeFileSync } from "node:fs";
+
+import type { BatchSummary, CaseRunSummary, EvalMetrics, FixtureValidation } from "./types.js";
+
+function markdownBool(value: boolean): string {
+  return value ? "true" : "false";
+}
+
+function fenced(value: string): string {
+  return value.trim().length === 0 ? "_empty_" : `\n\`\`\`text\n${value}\n\`\`\``;
+}
+
+function validationRows(validation: FixtureValidation): string {
+  const verifyExitCode = validation.contextTreeVerifyResult?.exitCode ?? "n/a";
+  return [
+    `- ok: ${markdownBool(validation.ok)}`,
+    `- requiredFilesOk: ${markdownBool(validation.requiredFilesOk)}`,
+    `- contextTreeVerifyExitCode: ${verifyExitCode}`,
+    ...validation.errors.map((error) => `- error: ${error}`),
+  ].join("\n");
+}
+
+function commandRows(metrics: EvalMetrics): string {
+  if (metrics.firstTreeArgv.length === 0) return "- none";
+  return metrics.firstTreeArgv.map((argv) => `- first-tree ${argv.join(" ")}`).join("\n");
+}
+
+export function writeCaseSummaries(summary: CaseRunSummary): void {
+  writeFileSync(summary.summaryJsonPath, `${JSON.stringify(summary, null, 2)}\n`, "utf8");
+
+  const drift = summary.driftNote ? `\n## Drift Evidence\n\n${summary.driftNote}\n` : "";
+  const markdown = `# first-tree-welcome Eval: ${summary.caseId}
+
+## Result
+
+- passed: ${markdownBool(summary.passed)}
+- expectedAction: ${summary.expectedAction}
+- skillFileReadObserved: ${markdownBool(summary.metrics.skillFileReadObserved)}
+- repoEvidenceReadObserved: ${markdownBool(summary.metrics.repoEvidenceReadObserved)}
+- treeEvidenceReadObserved: ${markdownBool(summary.metrics.treeEvidenceReadObserved)}
+- expectedEvidenceObserved: ${markdownBool(summary.metrics.expectedEvidenceObserved)}
+- expectedResponseObserved: ${markdownBool(summary.metrics.expectedResponseObserved)}
+- taskOptionsObserved: ${markdownBool(summary.metrics.taskOptionsObserved)}
+- chatAskCount: ${summary.metrics.chatAskCount}
+- chatOptionCount: ${summary.metrics.chatOptionCount ?? "n/a"}
+- sourceRepoChanged: ${markdownBool(summary.metrics.sourceRepoChanged)}
+- contextTreeChanged: ${markdownBool(summary.metrics.contextTreeChanged)}
+- forbiddenActionHits: ${
+    summary.metrics.forbiddenActionHits.length === 0 ? "none" : summary.metrics.forbiddenActionHits.join(", ")
+  }
+- forbiddenClaimHits: ${
+    summary.metrics.forbiddenClaimHits.length === 0 ? "none" : summary.metrics.forbiddenClaimHits.join(", ")
+  }
+- forbiddenSideEffectHits: ${
+    summary.metrics.forbiddenSideEffectHits.length === 0 ? "none" : summary.metrics.forbiddenSideEffectHits.join(", ")
+  }
+- runnerExitCode: ${summary.metrics.runnerExitCode === null ? "n/a" : summary.metrics.runnerExitCode}
+
+## Prompt
+
+\`\`\`text
+${summary.prompt}
+\`\`\`
+
+## Fixture Validation
+
+${validationRows(summary.fixtureValidation)}
+
+## Chat Command Text
+
+${fenced(summary.metrics.chatText)}
+
+## first-tree Command Calls
+
+${commandRows(summary.metrics)}
+
+## Context Tree Status
+
+${fenced(summary.metrics.contextTreeStatus)}
+
+## Final Response
+
+${fenced(summary.metrics.finalResponse)}
+${drift}
+## Paths
+
+- runRoot: \`${summary.runRoot}\`
+- workspacePath: \`${summary.workspacePath}\`
+`;
+
+  writeFileSync(summary.summaryMdPath, markdown, "utf8");
+}
+
+function pad(value: string, width: number): string {
+  return value.length >= width ? value : `${value}${" ".repeat(width - value.length)}`;
+}
+
+export function formatSummaryTable(batch: BatchSummary): string {
+  const rows = batch.cases.map((summary) => [
+    summary.caseId,
+    summary.expectedAction,
+    String(summary.metrics.skillFileReadObserved),
+    String(summary.metrics.repoEvidenceReadObserved),
+    String(summary.metrics.treeEvidenceReadObserved),
+    String(summary.metrics.taskOptionsObserved),
+    String(
+      summary.metrics.forbiddenActionHits.length +
+        summary.metrics.forbiddenClaimHits.length +
+        summary.metrics.forbiddenSideEffectHits.length,
+    ),
+    String(summary.passed),
+  ]);
+  const header = [
+    "case_id",
+    "expected_action",
+    "skill_file_read",
+    "repo_read",
+    "tree_read",
+    "task_options",
+    "forbidden_hits",
+    "passed",
+  ];
+  const widths = header.map((label, index) => {
+    let width = label.length;
+    for (const row of rows) {
+      const value = row[index];
+      if (value && value.length > width) width = value.length;
+    }
+    return width;
+  });
+
+  const lines = [
+    header.map((label, index) => pad(label, widths[index] ?? label.length)).join("  "),
+    ...rows.map((row) => row.map((value, index) => pad(value, widths[index] ?? value.length)).join("  ")),
+  ];
+
+  return lines.join("\n");
+}
+
+export function buildBatchSummary(cases: readonly CaseRunSummary[], runStartedAt: string): BatchSummary {
+  let passed = 0;
+  for (const summary of cases) {
+    if (summary.passed) passed += 1;
+  }
+
+  return {
+    cases,
+    failed: cases.length - passed,
+    passed,
+    runStartedAt,
+  };
+}

--- a/packages/skill-evals/src/suites/first-tree-welcome/types.ts
+++ b/packages/skill-evals/src/suites/first-tree-welcome/types.ts
@@ -1,0 +1,114 @@
+import type { CommandResult } from "../../core/types.js";
+
+export type WelcomeRole = "admin" | "invitee";
+export type WelcomeKickoffKind = "intro" | "work" | "tree";
+export type WelcomeRepoState = "none" | "local-readable" | "selected-readable" | "selected-auth-fails" | "unknown";
+export type WelcomeTreeState = "none" | "empty" | "populated" | "unknown";
+export type WelcomeGithubAppState = "installed" | "missing" | "unknown";
+export type WelcomeTreeSetupChatState = "absent" | "exists" | "promised";
+
+export type WelcomeExpectedAction =
+  | "route_to_tree_skill"
+  | "invitee_waits_for_team_readiness"
+  | "ask_for_repo_path_or_url"
+  | "report_auth_failure_without_claiming_repo_read"
+  | "value_first_then_setup_handoff"
+  | "guide_repo_selection_without_claiming_repo_read"
+  | "offer_code_value_without_tree_setup_task"
+  | "offer_bounded_first_tasks_from_repo_and_tree"
+  | "offer_repo_value_without_claiming_tree_ready";
+
+export type FirstTreeWelcomeFixture = {
+  githubAppState: WelcomeGithubAppState;
+  kickoffKind: WelcomeKickoffKind;
+  repoState: WelcomeRepoState;
+  role: WelcomeRole;
+  treeSetupChat: WelcomeTreeSetupChatState;
+  treeState: WelcomeTreeState;
+};
+
+export type FirstTreeWelcomeExpected = {
+  action: WelcomeExpectedAction;
+  evidenceSnippets?: readonly string[];
+  requiredResponseHints: readonly string[];
+  taskOptionHints?: readonly string[];
+};
+
+export type FirstTreeWelcomeForbidden = {
+  actions: readonly string[];
+  claims: readonly string[];
+  sideEffects: readonly string[];
+};
+
+export type FirstTreeWelcomeEvalCase = {
+  briefingMode: "generated-fixture";
+  expected: FirstTreeWelcomeExpected;
+  fixture: FirstTreeWelcomeFixture;
+  forbidden: FirstTreeWelcomeForbidden;
+  id: string;
+  prompt: string;
+  provider: "codex";
+  skill: "first-tree-welcome";
+  status: "implemented" | "planned";
+  tags: readonly string[];
+  tier: "gate";
+};
+
+export type CliOptions = {
+  caseId: string | null;
+  codexBin: string;
+  json: boolean;
+  model: string | null;
+  verbose: boolean;
+};
+
+export type FixtureValidation = {
+  contextTreeVerifyResult: CommandResult | null;
+  errors: readonly string[];
+  ok: boolean;
+  requiredFilesOk: boolean;
+};
+
+export type EvalMetrics = {
+  chatAskCount: number;
+  chatOptionCount: number | null;
+  chatText: string;
+  contextTreeChanged: boolean;
+  contextTreeStatus: string;
+  expectedEvidenceObserved: boolean;
+  expectedResponseObserved: boolean;
+  finalResponse: string;
+  forbiddenActionHits: readonly string[];
+  forbiddenClaimHits: readonly string[];
+  forbiddenSideEffectHits: readonly string[];
+  firstTreeArgv: readonly (readonly string[])[];
+  fixtureValidationOk: boolean;
+  repoEvidenceReadObserved: boolean;
+  runnerExitCode: number | null;
+  skillFileReadObserved: boolean;
+  sourceRepoChanged: boolean;
+  taskOptionsObserved: boolean;
+  treeEvidenceReadObserved: boolean;
+};
+
+export type CaseRunSummary = {
+  caseId: string;
+  driftNote: string | null;
+  expectedAction: WelcomeExpectedAction;
+  fixtureValidation: FixtureValidation;
+  metrics: EvalMetrics;
+  passed: boolean;
+  prompt: string;
+  runRoot: string;
+  startedAt: string;
+  summaryJsonPath: string;
+  summaryMdPath: string;
+  workspacePath: string;
+};
+
+export type BatchSummary = {
+  cases: readonly CaseRunSummary[];
+  failed: number;
+  passed: number;
+  runStartedAt: string;
+};


### PR DESCRIPTION
## Summary

- Add the `first-tree-welcome` live gate runner for the three implemented onboarding rows: tree kickoff lane routing, no-repo intro, and readable repo + populated Context Tree.
- Keep all nine welcome setup-matrix rows declared for floor coverage while leaving the six remaining rows planned.
- Add recorded-only chat shims, blocked `gh` / GitHub / tree-setup side-effect guards, fixture baseline checks, and welcome grader/unit coverage.

## Verification

- `pnpm --filter @first-tree/skill-evals eval:floor`
- `pnpm --filter @first-tree/skill-evals eval:floor -- --suite first-tree-welcome`
- `pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-welcome`
- `pnpm --filter @first-tree/skill-evals test`
- `pnpm --filter @first-tree/skill-evals typecheck`
- `pnpm exec biome check packages/skill-evals/src packages/skill-evals/README.md`
- `pnpm --filter @first-tree/shared build`
- `pnpm --filter @first-tree/client build`
- `pnpm --filter @first-tree/skill-evals validate:first-tree-read-fixtures`
- `git diff --check`

## Review

- Pre-PR review by `codex-reviewer` found two side-effect guard blockers.
- Both were fixed before this PR: forbidden external commands now fail the case, and source/context fixture path existence plus HEAD baselines are checked.
