### PR TITLE
Fix GitHub webhook delivery echo pruning

### DIFF
--- a/packages/server/src/__tests__/github-app-webhook-route.test.ts
+++ b/packages/server/src/__tests__/github-app-webhook-route.test.ts
@@ -7,7 +7,9 @@ import { chats } from "../db/schema/chats.js";
 import { githubAppInstallations } from "../db/schema/github-app-installations.js";
 import { githubEntityChatMappings } from "../db/schema/github-entity-chat-mappings.js";
 import { inboxEntries } from "../db/schema/inbox-entries.js";
+import { members } from "../db/schema/members.js";
 import { messages } from "../db/schema/messages.js";
+import { users } from "../db/schema/users.js";
 import { putOrgSetting } from "../services/org-settings.js";
 import { uuidv7 } from "../uuid.js";
 import { createTestAdmin, useTestApp } from "./helpers.js";
@@ -46,9 +48,40 @@ async function postWebhook(
 
 async function seedAgent(
   app: App,
-  opts: { orgId: string; memberId: string; name: string; delegateMention?: string | null },
+  opts: { orgId: string; memberId: string; name: string; type?: "agent" | "human"; delegateMention?: string | null },
 ): Promise<string> {
   const uuid = randomUUID();
+  const managerId = opts.type === "human" ? randomUUID() : opts.memberId;
+  if (opts.type === "human") {
+    const userId = randomUUID();
+    await app.db.transaction(async (tx) => {
+      await tx.insert(users).values({
+        id: userId,
+        username: `user-${uuid}`,
+        passwordHash: "test",
+        displayName: opts.name,
+      });
+      await tx.insert(agents).values({
+        uuid,
+        name: opts.name,
+        organizationId: opts.orgId,
+        type: "human",
+        displayName: opts.name,
+        inboxId: `inbox_${uuid}`,
+        managerId,
+        delegateMention: opts.delegateMention ?? null,
+        visibility: "organization",
+      });
+      await tx.insert(members).values({
+        id: managerId,
+        userId,
+        organizationId: opts.orgId,
+        agentId: uuid,
+        role: "member",
+      });
+    });
+    return uuid;
+  }
   await app.db.insert(agents).values({
     uuid,
     name: opts.name,
@@ -56,8 +89,9 @@ async function seedAgent(
     type: "agent",
     displayName: opts.name,
     inboxId: `inbox_${uuid}`,
-    managerId: opts.memberId,
+    managerId,
     delegateMention: opts.delegateMention ?? null,
+    visibility: "organization",
   });
   return uuid;
 }
@@ -302,6 +336,7 @@ describe("POST /webhooks/github-app", () => {
       memberId: admin.memberId,
       name: `human-${randomUUID().slice(0, 6)}`,
       delegateMention: delegate,
+      type: "human",
     });
     const chatId = `chat_${randomUUID()}`;
     await app.db.insert(chats).values({ id: chatId, organizationId: admin.organizationId, type: "direct" });
@@ -349,6 +384,7 @@ describe("POST /webhooks/github-app", () => {
       memberId: admin.memberId,
       name: `human-${randomUUID().slice(0, 6)}`,
       delegateMention: delegate,
+      type: "human",
     });
     const prChatId = `chat_${randomUUID()}`;
     await app.db.insert(chats).values({ id: prChatId, organizationId: admin.organizationId, type: "direct" });
@@ -404,6 +440,7 @@ describe("POST /webhooks/github-app", () => {
       memberId: admin.memberId,
       name: `human-${randomUUID().slice(0, 6)}`,
       delegateMention: delegate,
+      type: "human",
     });
     const chatId = `chat_${randomUUID()}`;
     await app.db.insert(chats).values({ id: chatId, organizationId: admin.organizationId, type: "direct" });
@@ -475,6 +512,7 @@ describe("POST /webhooks/github-app", () => {
       memberId: admin.memberId,
       name: `human-${randomUUID().slice(0, 6)}`,
       delegateMention: delegate,
+      type: "human",
     });
     const chatId = `chat_${randomUUID()}`;
     await app.db.insert(chats).values({ id: chatId, organizationId: admin.organizationId, type: "direct" });
@@ -530,6 +568,7 @@ describe("POST /webhooks/github-app", () => {
       memberId: admin.memberId,
       name: `human-${randomUUID().slice(0, 6)}`,
       delegateMention: delegate,
+      type: "human",
     });
     const chatId = `chat_${randomUUID()}`;
     await app.db.insert(chats).values({ id: chatId, organizationId: admin.organizationId, type: "direct" });
@@ -626,6 +665,7 @@ describe("POST /webhooks/github-app", () => {
       memberId: admin.memberId,
       name: `human-${randomUUID().slice(0, 6)}`,
       delegateMention: delegate,
+      type: "human",
     });
     const chatId = `chat_${randomUUID()}`;
     await app.db.insert(chats).values({ id: chatId, organizationId: admin.organizationId, type: "direct" });
@@ -681,6 +721,7 @@ describe("POST /webhooks/github-app", () => {
       memberId: admin.memberId,
       name: `human-${randomUUID().slice(0, 6)}`,
       delegateMention: delegate,
+      type: "human",
     });
     const chatId = `chat_${randomUUID()}`;
     await app.db.insert(chats).values({ id: chatId, organizationId: admin.organizationId, type: "direct" });
@@ -738,6 +779,7 @@ describe("POST /webhooks/github-app", () => {
       memberId: admin.memberId,
       name: humanName,
       delegateMention: delegate,
+      type: "human",
     });
 
     const res = await postWebhook(app, "pull_request", {
@@ -788,6 +830,7 @@ describe("POST /webhooks/github-app", () => {
       memberId: admin.memberId,
       name: humanName,
       delegateMention: delegate,
+      type: "human",
     });
 
     const res = await postWebhook(app, "issue_comment", {
@@ -840,6 +883,7 @@ describe("POST /webhooks/github-app", () => {
       memberId: admin.memberId,
       name: humanName,
       delegateMention: delegate,
+      type: "human",
     });
 
     const res = await postWebhook(app, "issue_comment", {
@@ -893,6 +937,7 @@ describe("POST /webhooks/github-app", () => {
       memberId: admin.memberId,
       name: humanName,
       delegateMention: delegate,
+      type: "human",
     });
 
     const res = await postWebhook(app, "pull_request_review_comment", {
@@ -946,6 +991,7 @@ describe("POST /webhooks/github-app", () => {
       memberId: admin.memberId,
       name: `human-${randomUUID().slice(0, 6)}`,
       delegateMention: delegate,
+      type: "human",
     });
     const chatId = `chat_${randomUUID()}`;
     await app.db.insert(chats).values({ id: chatId, organizationId: admin.organizationId, type: "direct" });
@@ -998,6 +1044,7 @@ describe("POST /webhooks/github-app", () => {
       memberId: admin.memberId,
       name: `human-${randomUUID().slice(0, 6)}`,
       delegateMention: delegate,
+      type: "human",
     });
     const chatId = `chat_${randomUUID()}`;
     await app.db.insert(chats).values({ id: chatId, organizationId: admin.organizationId, type: "direct" });

--- a/packages/server/src/__tests__/github-audience.test.ts
+++ b/packages/server/src/__tests__/github-audience.test.ts
@@ -5,10 +5,17 @@ import { describe, expect, it } from "vitest";
 import { agents } from "../db/schema/agents.js";
 import { chats } from "../db/schema/chats.js";
 import { githubEntityChatMappings } from "../db/schema/github-entity-chat-mappings.js";
-import { identifyActor, resolveAudience } from "../services/github-audience.js";
+import { resolveActorHumanId, resolveAudience as resolveAudienceResolution } from "../services/github-audience.js";
 import { createTestAdmin, useTestApp } from "./helpers.js";
 
 type App = ReturnType<ReturnType<typeof useTestApp>>;
+
+async function resolveAudience(
+  db: Parameters<typeof resolveAudienceResolution>[0],
+  event: Parameters<typeof resolveAudienceResolution>[1],
+) {
+  return (await resolveAudienceResolution(db, event)).targets;
+}
 
 async function seedAgent(
   app: App,
@@ -135,69 +142,45 @@ function makeEvent(opts: {
   };
 }
 
-describe("identifyActor", () => {
+describe("resolveActorHumanId", () => {
   const getApp = useTestApp();
 
-  it("returns our-app-bot when the sender login matches `<slug>[bot]` (case-insensitive)", async () => {
+  it("returns the human agent id when the sender login matches an org human (case-insensitive)", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
-    const id = await identifyActor(
-      app.db,
-      admin.organizationId,
-      { githubLogin: "First-Tree[bot]", isBot: true },
-      "first-tree",
-    );
-    expect(id).toEqual({ kind: "our-app-bot" });
+    const humanId = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `alice-${randomUUID().slice(0, 6)}`,
+      type: "human",
+    });
+    const [row] = await app.db.select({ name: agents.name }).from(agents).where(eq(agents.uuid, humanId)).limit(1);
+    if (!row?.name) throw new Error("seeded agent has no name");
+    const id = await resolveActorHumanId(app.db, admin.organizationId, { githubLogin: row.name.toUpperCase() });
+    expect(id).toBe(humanId);
   });
 
-  it("falls through to external when isBot is true but the slug does NOT match", async () => {
-    const app = getApp();
-    const admin = await createTestAdmin(app);
-    const id = await identifyActor(
-      app.db,
-      admin.organizationId,
-      { githubLogin: "dependabot[bot]", isBot: true },
-      "first-tree",
-    );
-    expect(id).toEqual({ kind: "external" });
-  });
-
-  it("returns external when appSlug is null even for bot senders", async () => {
-    const app = getApp();
-    const admin = await createTestAdmin(app);
-    const id = await identifyActor(app.db, admin.organizationId, { githubLogin: "first-tree[bot]", isBot: true }, null);
-    expect(id).toEqual({ kind: "external" });
-  });
-
-  it("returns agent identity when the sender login matches an org agent (case-insensitive)", async () => {
+  it("returns null when the sender login matches a non-human agent", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
     const agentId = await seedAgent(app, {
       orgId: admin.organizationId,
       memberId: admin.memberId,
-      name: `alice-${randomUUID().slice(0, 6)}`,
+      name: `agent-${randomUUID().slice(0, 6)}`,
     });
     const [row] = await app.db.select({ name: agents.name }).from(agents).where(eq(agents.uuid, agentId)).limit(1);
     if (!row?.name) throw new Error("seeded agent has no name");
-    const id = await identifyActor(
-      app.db,
-      admin.organizationId,
-      { githubLogin: row.name.toUpperCase(), isBot: false },
-      "first-tree",
-    );
-    expect(id).toEqual({ kind: "agent", agentId });
+    const id = await resolveActorHumanId(app.db, admin.organizationId, { githubLogin: row.name });
+    expect(id).toBeNull();
   });
 
-  it("returns external for unknown senders", async () => {
+  it("returns null for unknown senders and bots", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
-    const id = await identifyActor(
-      app.db,
-      admin.organizationId,
-      { githubLogin: "stranger", isBot: false },
-      "first-tree",
-    );
-    expect(id).toEqual({ kind: "external" });
+    await expect(resolveActorHumanId(app.db, admin.organizationId, { githubLogin: "stranger" })).resolves.toBeNull();
+    await expect(
+      resolveActorHumanId(app.db, admin.organizationId, { githubLogin: "first-tree[bot]" }),
+    ).resolves.toBeNull();
   });
 });
 
@@ -217,6 +200,7 @@ describe("resolveAudience", () => {
       memberId: admin.memberId,
       name: `human-a-${randomUUID().slice(0, 6)}`,
       delegateMention: delegateA,
+      type: "human",
     });
     const chatId = await seedChat(app, admin.organizationId, humanA);
     await seedMapping(app, {
@@ -237,7 +221,6 @@ describe("resolveAudience", () => {
         actorLogin: "outsider",
         kind: "synchronized",
       }),
-      "first-tree",
     );
 
     expect(audience).toEqual([
@@ -248,7 +231,6 @@ describe("resolveAudience", () => {
         chatId,
         involveReason: null,
         involveLogin: null,
-        actorAgentId: null,
       },
     ]);
   });
@@ -266,6 +248,7 @@ describe("resolveAudience", () => {
       memberId: admin.memberId,
       name: `human-a-${randomUUID().slice(0, 6)}`,
       delegateMention: delegateA,
+      type: "human",
     });
     const chatId = await seedChat(app, admin.organizationId, humanA);
     await seedMapping(app, {
@@ -287,7 +270,6 @@ describe("resolveAudience", () => {
         kind: "commented",
         rawEventType: "discussion_comment",
       }),
-      "first-tree",
     );
 
     expect(audience).toEqual([
@@ -298,7 +280,6 @@ describe("resolveAudience", () => {
         chatId,
         involveReason: null,
         involveLogin: null,
-        actorAgentId: null,
       },
     ]);
   });
@@ -317,6 +298,7 @@ describe("resolveAudience", () => {
       memberId: admin.memberId,
       name: humanName,
       delegateMention: delegate,
+      type: "human",
     });
 
     const audience = await resolveAudience(
@@ -329,7 +311,6 @@ describe("resolveAudience", () => {
         involves: [{ githubLogin: humanName, reason: "review_requested" }],
         kind: "review_requested",
       }),
-      "first-tree",
     );
 
     expect(audience).toEqual([
@@ -340,12 +321,11 @@ describe("resolveAudience", () => {
         chatId: null,
         involveReason: "review_requested",
         involveLogin: humanName.toLowerCase(),
-        actorAgentId: null,
       },
     ]);
   });
 
-  it("subscribed + involved union; subscribed wins de-dup (existing kept over new)", async () => {
+  it("target human reuses an existing mapping instead of creating a new delegate route", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
     const delegate = await seedAgent(app, {
@@ -359,6 +339,7 @@ describe("resolveAudience", () => {
       memberId: admin.memberId,
       name: humanName,
       delegateMention: delegate,
+      type: "human",
     });
     const chatId = await seedChat(app, admin.organizationId, human);
     await seedMapping(app, {
@@ -380,12 +361,14 @@ describe("resolveAudience", () => {
         involves: [{ githubLogin: humanName, reason: "mentioned" }],
         kind: "commented",
       }),
-      "first-tree",
     );
 
     expect(audience).toHaveLength(1);
     expect(audience[0]?.kind).toBe("existing");
     expect(audience[0]?.chatId).toBe(chatId);
+    expect(audience[0]?.delegateAgentId).toBe(delegate);
+    expect(audience[0]?.involveReason).toBe("mentioned");
+    expect(audience[0]?.involveLogin).toBe(humanName.toLowerCase());
   });
 
   it("collapses subscribed rows by human (sibling mappings on same chat → one audience target)", async () => {
@@ -445,7 +428,6 @@ describe("resolveAudience", () => {
         actorLogin: "outsider",
         kind: "commented",
       }),
-      "first-tree",
     );
 
     expect(audience).toHaveLength(1);
@@ -507,7 +489,6 @@ describe("resolveAudience", () => {
         actorLogin: "outsider",
         kind: "commented",
       }),
-      "first-tree",
     );
 
     expect(audience).toHaveLength(2);
@@ -540,6 +521,7 @@ describe("resolveAudience", () => {
       memberId: admin.memberId,
       name: humanName,
       delegateMention: delegateB,
+      type: "human",
     });
     const chatId = await seedChat(app, admin.organizationId, human);
     await seedMapping(app, {
@@ -561,24 +543,17 @@ describe("resolveAudience", () => {
         involves: [{ githubLogin: humanName, reason: "assigned" }],
         kind: "assigned",
       }),
-      "first-tree",
     );
 
     expect(audience).toHaveLength(1);
     expect(audience[0]?.kind).toBe("existing");
     expect(audience[0]?.delegateAgentId).toBe(delegateA);
     expect(audience[0]?.chatId).toBe(chatId);
+    expect(audience[0]?.involveReason).toBe("assigned");
+    expect(audience[0]?.involveLogin).toBe(humanName.toLowerCase());
   });
 
-  it("keeps subscribed targets when actor is our-app-bot (route First Tree's own writes back to existing chats)", async () => {
-    // Background: when an agent creates a PR via First Tree's GitHub App token, the
-    // resulting `pull_request.opened` webhook arrives with `sender = <app>[bot]`.
-    // Pre-agent-binding behaviour silenced the whole audience here, which
-    // meant PR comments / CI changes on bot-authored entities never reached
-    // the chat the agent worked in. The new behaviour keeps `kind: "existing"`
-    // rows so subscribed chats still get the event; `kind: "new"` rows are
-    // dropped because minting a fresh chat just to echo our own write is
-    // never useful.
+  it("keeps subscribed targets when actor is an unresolved app bot", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
     const delegate = await seedAgent(app, {
@@ -591,6 +566,7 @@ describe("resolveAudience", () => {
       memberId: admin.memberId,
       name: `human-${randomUUID().slice(0, 6)}`,
       delegateMention: delegate,
+      type: "human",
     });
     const chatId = await seedChat(app, admin.organizationId, human);
     await seedMapping(app, {
@@ -612,7 +588,6 @@ describe("resolveAudience", () => {
         actorIsBot: true,
         kind: "synchronized",
       }),
-      "first-tree",
     );
 
     expect(audience).toHaveLength(1);
@@ -620,7 +595,7 @@ describe("resolveAudience", () => {
     expect(audience[0]?.chatId).toBe(chatId);
   });
 
-  it("drops mention-only targets when actor is our-app-bot (no fresh chat for our own write)", async () => {
+  it("keeps target deliveries when actor is an unresolved app bot", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
     const delegate = await seedAgent(app, {
@@ -634,6 +609,7 @@ describe("resolveAudience", () => {
       memberId: admin.memberId,
       name: humanName,
       delegateMention: delegate,
+      type: "human",
     });
 
     const audience = await resolveAudience(
@@ -647,13 +623,17 @@ describe("resolveAudience", () => {
         involves: [{ githubLogin: humanName, reason: "mentioned" }],
         kind: "opened",
       }),
-      "first-tree",
     );
 
-    expect(audience).toEqual([]);
+    expect(audience).toHaveLength(1);
+    expect(audience[0]).toMatchObject({
+      kind: "new",
+      involveReason: "mentioned",
+      involveLogin: humanName.toLowerCase(),
+    });
   });
 
-  it("echo (#942): keeps every mapping but annotates actorAgentId (notification-layer suppression)", async () => {
+  it("resolves actorHumanId separately while keeping every audience target", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
     const delegate = await seedAgent(app, {
@@ -671,12 +651,14 @@ describe("resolveAudience", () => {
       memberId: admin.memberId,
       name: `human-${randomUUID().slice(0, 6)}`,
       delegateMention: delegate,
+      type: "human",
     });
     const otherHuman = await seedAgent(app, {
       orgId: admin.organizationId,
       memberId: admin.memberId,
       name: `human-other-${randomUUID().slice(0, 6)}`,
       delegateMention: otherDelegate,
+      type: "human",
     });
     const chatHuman = await seedChat(app, admin.organizationId, human);
     const chatOther = await seedChat(app, admin.organizationId, otherHuman);
@@ -697,13 +679,10 @@ describe("resolveAudience", () => {
       chatId: chatOther,
     });
 
-    // Actor is the human-side agent. The previous behaviour DROPPED the
-    // actor's own row, which silently killed delivery to that chat (the
-    // multi-human-not-pushed bug). Now no row is dropped — every target is
-    // annotated with `actorAgentId` so Stage 3 excludes the actor from the
-    // notification addressing while the card still lands in every chat.
+    // Actor identity is carried as a separate human id. Audience construction
+    // still returns every route; delivery prunes the actor's own entry later.
     const [humanRow] = await app.db.select({ name: agents.name }).from(agents).where(eq(agents.uuid, human)).limit(1);
-    const audience = await resolveAudience(
+    const resolution = await resolveAudienceResolution(
       app.db,
       makeEvent({
         orgId: admin.organizationId,
@@ -712,21 +691,14 @@ describe("resolveAudience", () => {
         actorLogin: humanRow?.name ?? "",
         kind: "synchronized",
       }),
-      "first-tree",
     );
+    const audience = resolution.targets;
     expect(audience).toHaveLength(2);
     expect(new Set(audience.map((a) => a.humanAgentId))).toEqual(new Set([human, otherHuman]));
-    for (const target of audience) {
-      expect(target.actorAgentId).toBe(human);
-    }
+    expect(resolution.actorHumanId).toBe(human);
   });
 
-  it("keeps an involved-new row when actor self-mentions (explicit intent, not echo)", async () => {
-    // Regression test for #345: the legacy mention-driven webhook routed
-    // self-mentions to the actor's own delegate. The normalize → audience
-    // pipeline accidentally suppressed this because `identifyActor` classifies
-    // any actor with an agents-row as `kind: "agent"`, and the echo filter
-    // dropped all rows touching that agent — including the brand-new mention.
+  it("keeps a self target as an audience candidate for delivery pruning", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
     const delegate = await seedAgent(app, {
@@ -740,6 +712,7 @@ describe("resolveAudience", () => {
       memberId: admin.memberId,
       name: humanName,
       delegateMention: delegate,
+      type: "human",
     });
 
     const audience = await resolveAudience(
@@ -752,7 +725,6 @@ describe("resolveAudience", () => {
         involves: [{ githubLogin: humanName, reason: "mentioned" }],
         kind: "commented",
       }),
-      "first-tree",
     );
 
     expect(audience).toHaveLength(1);
@@ -765,16 +737,7 @@ describe("resolveAudience", () => {
     });
   });
 
-  it("self-mention in an already-subscribed entity keeps the existing row, annotated (no fork, #942)", async () => {
-    // Actor self-targets an entity they already subscribe to:
-    //   - the `subscribedKeys` short-circuit (resolveAudience) skips adding a
-    //     `kind: "new"` row because (human, delegate) is already subscribed
-    //   - the surviving `kind: "existing"` row is NOT dropped (#942): it is
-    //     annotated with `actorAgentId` so Stage 3 excludes the actor from
-    //     addressing. The card still lands; the delegate (≠ actor) is woken
-    //     normally — activity on a subscribed entity is real signal.
-    // Previously the actor-agent echo filter dropped this row, leaving an
-    // empty audience and silently swallowing the event.
+  it("self target on an already-subscribed entity reuses the existing row", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
     const delegate = await seedAgent(app, {
@@ -788,6 +751,7 @@ describe("resolveAudience", () => {
       memberId: admin.memberId,
       name: humanName,
       delegateMention: delegate,
+      type: "human",
     });
     const chatId = await seedChat(app, admin.organizationId, human);
     await seedMapping(app, {
@@ -809,7 +773,6 @@ describe("resolveAudience", () => {
         involves: [{ githubLogin: humanName, reason: "mentioned" }],
         kind: "commented",
       }),
-      "first-tree",
     );
 
     expect(audience).toHaveLength(1);
@@ -818,21 +781,12 @@ describe("resolveAudience", () => {
       delegateAgentId: delegate,
       kind: "existing",
       chatId,
-      actorAgentId: human,
+      involveReason: "mentioned",
+      involveLogin: humanName.toLowerCase(),
     });
   });
 
-  it("creator carve-out: drops the actor's own kind:new involvement on a creation (opened) event", async () => {
-    // Regression for the dispatcher-mints-a-second-chat bug. An agent opens a
-    // PR under its own GitHub identity and self-assigns (or self-@mentions) in
-    // the opened payload, so its login lands in `involves`. The creator binds
-    // the PR through `github follow`; the dispatcher must NOT *also* mint a
-    // separate chat for the same creator. Once #942 stopped echo-dropping the
-    // actor's audience row, that fresh `kind: "new"` row survived and forked a
-    // duplicate chat. The creator carve-out drops it before delivery, leaving
-    // an empty audience (nothing else is involved) — equivalent to the
-    // already-accepted "opened with nobody else involved → confirmation card
-    // is lost, the creator already knows it opened" outcome.
+  it("creation self target remains a candidate and is identified by actorHumanId", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
     const delegate = await seedAgent(app, {
@@ -841,14 +795,15 @@ describe("resolveAudience", () => {
       name: `dlg-${randomUUID().slice(0, 6)}`,
     });
     const creatorName = `creator-${randomUUID().slice(0, 6)}`;
-    await seedAgent(app, {
+    const creator = await seedAgent(app, {
       orgId: admin.organizationId,
       memberId: admin.memberId,
       name: creatorName,
       delegateMention: delegate,
+      type: "human",
     });
 
-    const audience = await resolveAudience(
+    const resolution = await resolveAudienceResolution(
       app.db,
       makeEvent({
         orgId: admin.organizationId,
@@ -858,18 +813,18 @@ describe("resolveAudience", () => {
         involves: [{ githubLogin: creatorName, reason: "assigned" }],
         kind: "opened",
       }),
-      "first-tree",
     );
 
-    expect(audience).toEqual([]);
+    expect(resolution.actorHumanId).toBe(creator);
+    expect(resolution.targets).toHaveLength(1);
+    expect(resolution.targets[0]).toMatchObject({
+      humanAgentId: creator,
+      kind: "new",
+      involveReason: "assigned",
+    });
   });
 
-  it("creator carve-out: keeps a DIFFERENT involved human's fresh chat when the creator also self-targets on opened", async () => {
-    // Only the *creator's own* fresh involvement is dropped. A genuinely
-    // different human named in the same opened payload (assignee / @mention)
-    // is a real directed signal and still gets its `kind: "new"` chat, carrying
-    // the creator's id as `actorAgentId` so Stage 3 keeps the actor out of the
-    // notification wake-set.
+  it("creation with self and another target keeps both candidates for delivery pruning", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
     const creatorDelegate = await seedAgent(app, {
@@ -883,6 +838,7 @@ describe("resolveAudience", () => {
       memberId: admin.memberId,
       name: creatorName,
       delegateMention: creatorDelegate,
+      type: "human",
     });
     const otherDelegate = await seedAgent(app, {
       orgId: admin.organizationId,
@@ -895,9 +851,10 @@ describe("resolveAudience", () => {
       memberId: admin.memberId,
       name: otherName,
       delegateMention: otherDelegate,
+      type: "human",
     });
 
-    const audience = await resolveAudience(
+    const resolution = await resolveAudienceResolution(
       app.db,
       makeEvent({
         orgId: admin.organizationId,
@@ -910,21 +867,15 @@ describe("resolveAudience", () => {
         ],
         kind: "opened",
       }),
-      "first-tree",
     );
+    const audience = resolution.targets;
 
-    expect(audience).toHaveLength(1);
-    expect(audience[0]?.humanAgentId).toBe(other);
-    expect(audience[0]?.kind).toBe("new");
-    expect(audience[0]?.actorAgentId).toBe(creator);
+    expect(resolution.actorHumanId).toBe(creator);
+    expect(audience).toHaveLength(2);
+    expect(new Set(audience.map((target) => target.humanAgentId))).toEqual(new Set([creator, other]));
   });
 
-  it("creator carve-out: keeps the creator's own declared follow chat on opened, drops only the duplicate", async () => {
-    // The real-world shape: the creator followed the PR (`agent_declared`)
-    // AND self-assigned in the opened payload. The existing followed chat must
-    // survive (the #766 declared carve-out keeps its opened confirmation card,
-    // annotated with the actor for notify suppression); only the would-be
-    // second `kind: "new"` chat for the same creator is dropped.
+  it("creation self target reuses the creator's declared follow chat", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
     const delegate = await seedAgent(app, {
@@ -938,6 +889,7 @@ describe("resolveAudience", () => {
       memberId: admin.memberId,
       name: creatorName,
       delegateMention: delegate,
+      type: "human",
     });
     const chatId = await seedChat(app, admin.organizationId, creator);
     await seedMapping(app, {
@@ -950,7 +902,7 @@ describe("resolveAudience", () => {
       boundVia: "agent_declared",
     });
 
-    const audience = await resolveAudience(
+    const resolution = await resolveAudienceResolution(
       app.db,
       makeEvent({
         orgId: admin.organizationId,
@@ -960,13 +912,14 @@ describe("resolveAudience", () => {
         involves: [{ githubLogin: creatorName, reason: "assigned" }],
         kind: "opened",
       }),
-      "first-tree",
     );
+    const audience = resolution.targets;
 
+    expect(resolution.actorHumanId).toBe(creator);
     expect(audience).toHaveLength(1);
     expect(audience[0]?.kind).toBe("existing");
     expect(audience[0]?.chatId).toBe(chatId);
-    expect(audience[0]?.actorAgentId).toBe(creator);
+    expect(audience[0]?.involveReason).toBe("assigned");
   });
 
   it("skips an involve whose delegate target is inactive (suspended/deleted)", async () => {
@@ -985,6 +938,7 @@ describe("resolveAudience", () => {
       memberId: admin.memberId,
       name: humanInactiveName,
       delegateMention: inactiveDelegate,
+      type: "human",
     });
 
     const audience = await resolveAudience(
@@ -997,7 +951,6 @@ describe("resolveAudience", () => {
         involves: [{ githubLogin: humanInactiveName, reason: "mentioned" }],
         kind: "opened",
       }),
-      "first-tree",
     );
 
     expect(audience).toEqual([]);
@@ -1011,6 +964,7 @@ describe("resolveAudience", () => {
       orgId: admin.organizationId,
       memberId: admin.memberId,
       name: humanName,
+      type: "human",
     });
 
     const audience = await resolveAudience(
@@ -1023,7 +977,6 @@ describe("resolveAudience", () => {
         involves: [{ githubLogin: humanName, reason: "mentioned" }],
         kind: "opened",
       }),
-      "first-tree",
     );
 
     expect(audience).toEqual([]);
@@ -1049,12 +1002,14 @@ describe("resolveAudience", () => {
       memberId: admin.memberId,
       name: bobName,
       delegateMention: delegateBob,
+      type: "human",
     });
     const carol = await seedAgent(app, {
       orgId: admin.organizationId,
       memberId: admin.memberId,
       name: carolName,
       delegateMention: delegateCarol,
+      type: "human",
     });
 
     const audience = await resolveAudience(
@@ -1070,7 +1025,6 @@ describe("resolveAudience", () => {
         ],
         kind: "opened",
       }),
-      "first-tree",
     );
 
     expect(audience).toHaveLength(2);
@@ -1101,6 +1055,7 @@ describe("resolveAudience", () => {
       memberId: admin.memberId,
       name: `reviewer-${randomUUID().slice(0, 6)}`,
       delegateMention: delegate,
+      type: "human",
     });
     const chatId = await seedChat(app, admin.organizationId, human);
     await seedMapping(app, {
@@ -1122,7 +1077,6 @@ describe("resolveAudience", () => {
         actorLogin: "outsider",
         kind: "opened",
       }),
-      "first-tree",
     );
 
     expect(audience).toEqual([]);
@@ -1146,6 +1100,7 @@ describe("resolveAudience", () => {
       memberId: admin.memberId,
       name: `author-${randomUUID().slice(0, 6)}`,
       delegateMention: delegate,
+      type: "human",
     });
     const chatId = await seedChat(app, admin.organizationId, human);
     await seedMapping(app, {
@@ -1168,7 +1123,6 @@ describe("resolveAudience", () => {
         actorIsBot: true,
         kind: "opened",
       }),
-      "first-tree",
     );
 
     expect(audience).toHaveLength(1);
@@ -1193,6 +1147,7 @@ describe("resolveAudience", () => {
       memberId: admin.memberId,
       name: humanName,
       delegateMention: delegate,
+      type: "human",
     });
     const chatId = await seedChat(app, admin.organizationId, human);
     await seedMapping(app, {
@@ -1215,7 +1170,6 @@ describe("resolveAudience", () => {
         involves: [{ githubLogin: humanName, reason: "assigned" }],
         kind: "opened",
       }),
-      "first-tree",
     );
 
     expect(audience).toHaveLength(1);

--- a/packages/server/src/__tests__/github-delivery.test.ts
+++ b/packages/server/src/__tests__/github-delivery.test.ts
@@ -7,7 +7,9 @@ import { chatMembership } from "../db/schema/chat-membership.js";
 import { chats } from "../db/schema/chats.js";
 import { githubEntityChatMappings } from "../db/schema/github-entity-chat-mappings.js";
 import { inboxEntries } from "../db/schema/inbox-entries.js";
+import { members } from "../db/schema/members.js";
 import { messages } from "../db/schema/messages.js";
+import { users } from "../db/schema/users.js";
 import { type AudienceTarget, resolveAudience } from "../services/github-audience.js";
 import { deliverNormalizedEvent } from "../services/github-delivery.js";
 import { createTestAdmin, useTestApp } from "./helpers.js";
@@ -20,10 +22,42 @@ async function seedAgent(
     orgId: string;
     memberId: string;
     name: string;
+    type?: "agent" | "human";
     delegateMention?: string | null;
   },
 ): Promise<string> {
   const uuid = randomUUID();
+  const managerId = opts.type === "human" ? randomUUID() : opts.memberId;
+  if (opts.type === "human") {
+    const userId = randomUUID();
+    await app.db.transaction(async (tx) => {
+      await tx.insert(users).values({
+        id: userId,
+        username: `user-${uuid}`,
+        passwordHash: "test",
+        displayName: opts.name,
+      });
+      await tx.insert(agents).values({
+        uuid,
+        name: opts.name,
+        organizationId: opts.orgId,
+        type: "human",
+        displayName: opts.name,
+        inboxId: `inbox_${uuid}`,
+        managerId,
+        delegateMention: opts.delegateMention ?? null,
+        visibility: "organization",
+      });
+      await tx.insert(members).values({
+        id: managerId,
+        userId,
+        organizationId: opts.orgId,
+        agentId: uuid,
+        role: "member",
+      });
+    });
+    return uuid;
+  }
   await app.db.insert(agents).values({
     uuid,
     name: opts.name,
@@ -31,7 +65,7 @@ async function seedAgent(
     type: "agent",
     displayName: opts.name,
     inboxId: `inbox_${uuid}`,
-    managerId: opts.memberId,
+    managerId,
     delegateMention: opts.delegateMention ?? null,
     // Match `services/agent.ts::defaultVisibility` — an `autonomous_agent`
     // created via the service layer is `organization`-visible. The raw
@@ -53,6 +87,7 @@ function makeEvent(opts: {
   body?: string;
   rawEventType?: string;
   rawAction?: string;
+  kind?: NormalizedEvent["kind"];
   title?: string;
   actorLogin?: string;
 }): NormalizedEvent {
@@ -69,7 +104,7 @@ function makeEvent(opts: {
       url: `https://github.com/owner/repo/pull/1`,
     },
     actor: { githubLogin: opts.actorLogin ?? "alice", isBot: false },
-    kind: "opened",
+    kind: opts.kind ?? "opened",
     involves: opts.involves ?? [],
     surface: {
       title: "PR #1: Refactor inbox",
@@ -78,6 +113,25 @@ function makeEvent(opts: {
     },
     relatedRefs: [],
   };
+}
+
+async function notifyCount(app: App, chatId: string, agentId: string): Promise<number> {
+  const [agent] = await app.db
+    .select({ inboxId: agents.inboxId })
+    .from(agents)
+    .where(eq(agents.uuid, agentId))
+    .limit(1);
+  const rows = await app.db
+    .select({ id: inboxEntries.messageId })
+    .from(inboxEntries)
+    .where(
+      and(
+        eq(inboxEntries.inboxId, agent?.inboxId ?? ""),
+        eq(inboxEntries.chatId, chatId),
+        eq(inboxEntries.notify, true),
+      ),
+    );
+  return rows.length;
 }
 
 describe("deliverNormalizedEvent", () => {
@@ -96,6 +150,7 @@ describe("deliverNormalizedEvent", () => {
       memberId: admin.memberId,
       name: `human-${randomUUID().slice(0, 6)}`,
       delegateMention: delegate,
+      type: "human",
     });
 
     // Seed an existing chat + mapping for the target entity
@@ -118,7 +173,6 @@ describe("deliverNormalizedEvent", () => {
       chatId,
       involveReason: null,
       involveLogin: null,
-      actorAgentId: null,
     };
     const event = makeEvent({
       orgId: admin.organizationId,
@@ -157,6 +211,7 @@ describe("deliverNormalizedEvent", () => {
       memberId: admin.memberId,
       name: `human-${randomUUID().slice(0, 6)}`,
       delegateMention: delegate,
+      type: "human",
     });
 
     // Bind a chat for the entity, but make ONLY the human a speaker — the
@@ -189,7 +244,6 @@ describe("deliverNormalizedEvent", () => {
       chatId,
       involveReason: null,
       involveLogin: null,
-      actorAgentId: null,
     };
     const event = makeEvent({
       orgId: admin.organizationId,
@@ -213,14 +267,11 @@ describe("deliverNormalizedEvent", () => {
     expect(delegateEntries).toHaveLength(0);
   });
 
-  it("echo (#942, S2/D1): suppresses the actor's notify but keeps it addressed — card lands as a silent row", async () => {
-    // The delegate is a live speaker of the bound chat, so it would normally
-    // be woken. When the delegate is ALSO the event's actor (its own GitHub
-    // action, surfaced as `target.actorAgentId`), Stage 3 passes it through
-    // `suppressNotifyAgentIds` (#942, S2/D1): the delegate stays structurally
-    // addressed and the card still lands as a silent `notify=false` row, but
-    // the actor is not woken / red-dotted. With `actorAgentId = null` the same
-    // speaker-delegate IS woken — the two deliveries below pin both sides.
+  it("echo pruning: drops a self-only delivery before writing a card", async () => {
+    // The delegate is a live speaker of the bound chat, so an unresolved actor
+    // would normally wake it. When the GitHub actor resolves to the same human
+    // that owns this mapping, delivery prunes that entry before send: no card,
+    // no inbox row, and no wake.
     const app = getApp();
     const admin = await createTestAdmin(app);
     const delegate = await seedAgent(app, {
@@ -233,6 +284,7 @@ describe("deliverNormalizedEvent", () => {
       memberId: admin.memberId,
       name: `human-${randomUUID().slice(0, 6)}`,
       delegateMention: delegate,
+      type: "human",
     });
     const chatId = `chat_${randomUUID()}`;
     await app.db.insert(chats).values({ id: chatId, organizationId: admin.organizationId, type: "group" });
@@ -256,45 +308,280 @@ describe("deliverNormalizedEvent", () => {
       chatId,
       involveReason: null,
       involveLogin: null,
-    } satisfies Omit<AudienceTarget, "actorAgentId">;
+    } satisfies AudienceTarget;
     const event = makeEvent({
       orgId: admin.organizationId,
       entityType: "pull_request",
       entityKey: "owner/repo#205",
     });
 
-    // (1) actor === delegate: suppressed from notify but kept addressed →
-    // card written, no wake, yet the actor still gets a silent context row.
-    const echoStats = await deliverNormalizedEvent(app, event, [{ ...baseTarget, actorAgentId: delegate }]);
-    expect(echoStats.delivered).toBe(1);
-    const afterEcho = await app.db
-      .select()
-      .from(inboxEntries)
-      .where(and(eq(inboxEntries.chatId, chatId), eq(inboxEntries.notify, true)));
-    expect(afterEcho).toHaveLength(0);
-    // The suppressed actor-delegate still receives exactly one silent
-    // (notify=false) row — the card lands as context, it just doesn't wake.
-    const [delegateRow] = await app.db
-      .select({ inboxId: agents.inboxId })
-      .from(agents)
-      .where(eq(agents.uuid, delegate))
-      .limit(1);
-    const delegateInbox = delegateRow?.inboxId ?? "";
-    const delegateSilent = await app.db
-      .select({ notify: inboxEntries.notify })
-      .from(inboxEntries)
-      .where(and(eq(inboxEntries.inboxId, delegateInbox), eq(inboxEntries.chatId, chatId)));
-    expect(delegateSilent).toHaveLength(1);
-    expect(delegateSilent[0]?.notify).toBe(false);
+    const echoStats = await deliverNormalizedEvent(app, event, [baseTarget], { actorHumanId: human });
+    expect(echoStats).toEqual({ delivered: 0, newChats: 0, failed: 0 });
+    await expect(app.db.select().from(messages).where(eq(messages.chatId, chatId))).resolves.toHaveLength(0);
+    await expect(app.db.select().from(inboxEntries).where(eq(inboxEntries.chatId, chatId))).resolves.toHaveLength(0);
 
-    // (2) actor !== delegate (null): the speaker-delegate IS woken.
-    const okStats = await deliverNormalizedEvent(app, event, [{ ...baseTarget, actorAgentId: null }]);
+    // Unknown actor: no self pruning, so the speaker-delegate IS woken.
+    const okStats = await deliverNormalizedEvent(app, event, [baseTarget], { actorHumanId: null });
     expect(okStats.delivered).toBe(1);
     const afterOk = await app.db
       .select()
       .from(inboxEntries)
       .where(and(eq(inboxEntries.chatId, chatId), eq(inboxEntries.notify, true)));
     expect(afterOk.length).toBeGreaterThan(0);
+  });
+
+  it("humanA requesting humanB review prunes humanA's follow delivery and wakes humanB's delegate", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const delegateA = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-a-${randomUUID().slice(0, 6)}`,
+    });
+    const humanAName = `human-a-${randomUUID().slice(0, 6)}`;
+    const humanA = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: humanAName,
+      delegateMention: delegateA,
+      type: "human",
+    });
+    const delegateB = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-b-${randomUUID().slice(0, 6)}`,
+    });
+    const humanBName = `human-b-${randomUUID().slice(0, 6)}`;
+    const humanB = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: humanBName,
+      delegateMention: delegateB,
+      type: "human",
+    });
+
+    const chatA = `chat_${randomUUID()}`;
+    await app.db.insert(chats).values({ id: chatA, organizationId: admin.organizationId, type: "group" });
+    await app.db.insert(chatMembership).values([
+      { chatId: chatA, agentId: humanA, role: "owner", accessMode: "speaker", mode: "full", source: "manual" },
+      { chatId: chatA, agentId: delegateA, role: "member", accessMode: "speaker", mode: "full", source: "manual" },
+    ]);
+    await app.db.insert(githubEntityChatMappings).values({
+      organizationId: admin.organizationId,
+      humanAgentId: humanA,
+      delegateAgentId: delegateA,
+      entityType: "pull_request",
+      entityKey: "owner/repo#206",
+      chatId: chatA,
+      boundVia: "agent_declared",
+    });
+
+    const event = makeEvent({
+      orgId: admin.organizationId,
+      entityType: "pull_request",
+      entityKey: "owner/repo#206",
+      actorLogin: humanAName,
+      involves: [{ githubLogin: humanBName, reason: "review_requested" }],
+      kind: "review_requested",
+      rawAction: "review_requested",
+    });
+    const resolution = await resolveAudience(app.db, event);
+    expect(resolution.actorHumanId).toBe(humanA);
+
+    const stats = await deliverNormalizedEvent(app, event, resolution.targets, {
+      actorHumanId: resolution.actorHumanId,
+    });
+    expect(stats).toEqual({ delivered: 1, newChats: 1, failed: 0 });
+    expect(await app.db.select().from(messages).where(eq(messages.chatId, chatA))).toHaveLength(0);
+    expect(await notifyCount(app, chatA, delegateA)).toBe(0);
+
+    const [mappingB] = await app.db
+      .select()
+      .from(githubEntityChatMappings)
+      .where(
+        and(
+          eq(githubEntityChatMappings.entityKey, "owner/repo#206"),
+          eq(githubEntityChatMappings.humanAgentId, humanB),
+        ),
+      )
+      .limit(1);
+    expect(mappingB?.delegateAgentId).toBe(delegateB);
+    expect(mappingB?.chatId).toBeTruthy();
+    const chatB = mappingB?.chatId ?? "";
+    expect(await notifyCount(app, chatB, delegateB)).toBe(1);
+    const [messageB] = await app.db.select().from(messages).where(eq(messages.chatId, chatB)).limit(1);
+    expect(messageB?.senderId).toBe(humanB);
+  });
+
+  it("reviewer comment prunes the reviewer's own follow chat but not the PR author's chat", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const delegateA = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-a-${randomUUID().slice(0, 6)}`,
+    });
+    const humanA = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `human-a-${randomUUID().slice(0, 6)}`,
+      delegateMention: delegateA,
+      type: "human",
+    });
+    const delegateB = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-b-${randomUUID().slice(0, 6)}`,
+    });
+    const humanBName = `human-b-${randomUUID().slice(0, 6)}`;
+    const humanB = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: humanBName,
+      delegateMention: delegateB,
+      type: "human",
+    });
+    const chatA = `chat_${randomUUID()}`;
+    const chatB = `chat_${randomUUID()}`;
+    await app.db.insert(chats).values([
+      { id: chatA, organizationId: admin.organizationId, type: "group" },
+      { id: chatB, organizationId: admin.organizationId, type: "group" },
+    ]);
+    await app.db.insert(chatMembership).values([
+      { chatId: chatA, agentId: humanA, role: "owner", accessMode: "speaker", mode: "full", source: "manual" },
+      { chatId: chatA, agentId: delegateA, role: "member", accessMode: "speaker", mode: "full", source: "manual" },
+      { chatId: chatB, agentId: humanB, role: "owner", accessMode: "speaker", mode: "full", source: "manual" },
+      { chatId: chatB, agentId: delegateB, role: "member", accessMode: "speaker", mode: "full", source: "manual" },
+    ]);
+    await app.db.insert(githubEntityChatMappings).values([
+      {
+        organizationId: admin.organizationId,
+        humanAgentId: humanA,
+        delegateAgentId: delegateA,
+        entityType: "pull_request",
+        entityKey: "owner/repo#207",
+        chatId: chatA,
+        boundVia: "agent_declared",
+      },
+      {
+        organizationId: admin.organizationId,
+        humanAgentId: humanB,
+        delegateAgentId: delegateB,
+        entityType: "pull_request",
+        entityKey: "owner/repo#207",
+        chatId: chatB,
+        boundVia: "direct",
+      },
+    ]);
+
+    const event = makeEvent({
+      orgId: admin.organizationId,
+      entityType: "pull_request",
+      entityKey: "owner/repo#207",
+      actorLogin: humanBName,
+      rawEventType: "issue_comment",
+      rawAction: "created",
+      kind: "commented",
+    });
+    const resolution = await resolveAudience(app.db, event);
+    expect(resolution.actorHumanId).toBe(humanB);
+    const stats = await deliverNormalizedEvent(app, event, resolution.targets, {
+      actorHumanId: resolution.actorHumanId,
+    });
+
+    expect(stats).toEqual({ delivered: 1, newChats: 0, failed: 0 });
+    expect(await app.db.select().from(messages).where(eq(messages.chatId, chatA))).toHaveLength(1);
+    expect(await app.db.select().from(messages).where(eq(messages.chatId, chatB))).toHaveLength(0);
+    expect(await notifyCount(app, chatA, delegateA)).toBe(1);
+    expect(await notifyCount(app, chatB, delegateB)).toBe(0);
+  });
+
+  it("mixed chat echo pruning removes only the actor's entry", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const delegateA = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-a-${randomUUID().slice(0, 6)}`,
+    });
+    const humanAName = `human-a-${randomUUID().slice(0, 6)}`;
+    const humanA = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: humanAName,
+      delegateMention: delegateA,
+      type: "human",
+    });
+    const delegateB = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-b-${randomUUID().slice(0, 6)}`,
+    });
+    const humanBName = `human-b-${randomUUID().slice(0, 6)}`;
+    const humanB = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: humanBName,
+      delegateMention: delegateB,
+      type: "human",
+    });
+    const chatId = `chat_${randomUUID()}`;
+    await app.db.insert(chats).values({ id: chatId, organizationId: admin.organizationId, type: "group" });
+    await app.db.insert(chatMembership).values(
+      [humanA, delegateA, humanB, delegateB].map((agentId, index) => ({
+        chatId,
+        agentId,
+        role: index === 0 ? "owner" : "member",
+        accessMode: "speaker" as const,
+        mode: "full" as const,
+        source: "manual" as const,
+      })),
+    );
+    await app.db.insert(githubEntityChatMappings).values([
+      {
+        organizationId: admin.organizationId,
+        humanAgentId: humanA,
+        delegateAgentId: delegateA,
+        entityType: "pull_request",
+        entityKey: "owner/repo#208",
+        chatId,
+        boundVia: "agent_declared",
+      },
+      {
+        organizationId: admin.organizationId,
+        humanAgentId: humanB,
+        delegateAgentId: delegateB,
+        entityType: "pull_request",
+        entityKey: "owner/repo#208",
+        chatId,
+        boundVia: "direct",
+      },
+    ]);
+
+    const event = makeEvent({
+      orgId: admin.organizationId,
+      entityType: "pull_request",
+      entityKey: "owner/repo#208",
+      actorLogin: humanAName,
+      involves: [{ githubLogin: humanBName, reason: "mentioned" }],
+      rawEventType: "issue_comment",
+      rawAction: "created",
+      kind: "commented",
+    });
+    const resolution = await resolveAudience(app.db, event);
+    expect(resolution.actorHumanId).toBe(humanA);
+
+    const stats = await deliverNormalizedEvent(app, event, resolution.targets, {
+      actorHumanId: resolution.actorHumanId,
+    });
+    expect(stats).toEqual({ delivered: 1, newChats: 0, failed: 0 });
+    const [message] = await app.db.select().from(messages).where(eq(messages.chatId, chatId)).limit(1);
+    expect(message?.senderId).toBe(humanB);
+    const metadata = message?.metadata as { mentions?: string[]; reason?: string };
+    expect(metadata.mentions).toEqual([delegateB]);
+    expect(metadata.reason).toBe("mentioned");
+    expect(await notifyCount(app, chatId, delegateA)).toBe(0);
+    expect(await notifyCount(app, chatId, delegateB)).toBe(1);
   });
 
   it("refreshes chats.topic to match the current entity title on each subsequent event for a github-bound chat", async () => {
@@ -310,6 +597,7 @@ describe("deliverNormalizedEvent", () => {
       memberId: admin.memberId,
       name: `human-${randomUUID().slice(0, 6)}`,
       delegateMention: delegate,
+      type: "human",
     });
 
     // Seed an existing github-bound chat with a stale topic (e.g. PR title
@@ -338,7 +626,6 @@ describe("deliverNormalizedEvent", () => {
       chatId,
       involveReason: null,
       involveLogin: null,
-      actorAgentId: null,
     };
     const event = makeEvent({
       orgId: admin.organizationId,
@@ -364,6 +651,7 @@ describe("deliverNormalizedEvent", () => {
       memberId: admin.memberId,
       name: `human-${randomUUID().slice(0, 6)}`,
       delegateMention: delegate,
+      type: "human",
     });
 
     // Chat was minted from `pull_request.opened` → head is the plain "PR"
@@ -393,7 +681,6 @@ describe("deliverNormalizedEvent", () => {
       chatId,
       involveReason: null,
       involveLogin: null,
-      actorAgentId: null,
     };
     const event = makeEvent({
       orgId: admin.organizationId,
@@ -419,6 +706,71 @@ describe("deliverNormalizedEvent", () => {
     expect(mapping?.title).toBe("Renamed title");
   });
 
+  it("refreshes entity projection even when self-echo pruning drops the card", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const delegate = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-${randomUUID().slice(0, 6)}`,
+    });
+    const humanName = `human-${randomUUID().slice(0, 6)}`;
+    const human = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: humanName,
+      delegateMention: delegate,
+      type: "human",
+    });
+
+    const chatId = `chat_${randomUUID()}`;
+    await app.db.insert(chats).values({
+      id: chatId,
+      organizationId: admin.organizationId,
+      type: "direct",
+      topic: "PR repo#209: Old title",
+    });
+    await app.db.insert(githubEntityChatMappings).values({
+      organizationId: admin.organizationId,
+      humanAgentId: human,
+      delegateAgentId: delegate,
+      entityType: "pull_request",
+      entityKey: "owner/repo#209",
+      chatId,
+      boundVia: "direct",
+      title: "Old title",
+    });
+
+    const event = makeEvent({
+      orgId: admin.organizationId,
+      entityType: "pull_request",
+      entityKey: "owner/repo#209",
+      actorLogin: humanName,
+      rawEventType: "pull_request",
+      rawAction: "edited",
+      kind: "edited",
+      title: "New title",
+    });
+    const resolution = await resolveAudience(app.db, event);
+    expect(resolution.actorHumanId).toBe(human);
+
+    const stats = await deliverNormalizedEvent(app, event, resolution.targets, {
+      actorHumanId: resolution.actorHumanId,
+    });
+    expect(stats).toEqual({ delivered: 0, newChats: 0, failed: 0 });
+    expect(await app.db.select().from(messages).where(eq(messages.chatId, chatId))).toHaveLength(0);
+    expect(await app.db.select().from(inboxEntries).where(eq(inboxEntries.chatId, chatId))).toHaveLength(0);
+
+    const [chat] = await app.db.select({ topic: chats.topic }).from(chats).where(eq(chats.id, chatId)).limit(1);
+    expect(chat?.topic).toBe("PR repo#209: New title");
+    const [mapping] = await app.db
+      .select({ title: githubEntityChatMappings.title })
+      .from(githubEntityChatMappings)
+      .where(eq(githubEntityChatMappings.entityKey, "owner/repo#209"))
+      .limit(1);
+    expect(mapping?.title).toBe("New title");
+  });
+
   it("does NOT overwrite the owning topic when a linked (fixes_link) entity's event arrives", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
@@ -432,6 +784,7 @@ describe("deliverNormalizedEvent", () => {
       memberId: admin.memberId,
       name: `human-${randomUUID().slice(0, 6)}`,
       delegateMention: delegate,
+      type: "human",
     });
 
     // Chat was minted for issue#42 (its direct anchor + topic). A PR#99 that
@@ -472,7 +825,6 @@ describe("deliverNormalizedEvent", () => {
       chatId,
       involveReason: null,
       involveLogin: null,
-      actorAgentId: null,
     };
     const event = makeEvent({
       orgId: admin.organizationId,
@@ -499,6 +851,7 @@ describe("deliverNormalizedEvent", () => {
       memberId: admin.memberId,
       name: `human-${randomUUID().slice(0, 6)}`,
       delegateMention: delegate,
+      type: "human",
     });
 
     // A chat that the agent renamed to a custom label — no mapping row.
@@ -517,7 +870,6 @@ describe("deliverNormalizedEvent", () => {
       chatId,
       involveReason: null,
       involveLogin: null,
-      actorAgentId: null,
     };
     const event = makeEvent({
       orgId: admin.organizationId,
@@ -544,6 +896,7 @@ describe("deliverNormalizedEvent", () => {
       memberId: admin.memberId,
       name: humanName,
       delegateMention: delegate,
+      type: "human",
     });
 
     const target: AudienceTarget = {
@@ -553,7 +906,6 @@ describe("deliverNormalizedEvent", () => {
       chatId: null,
       involveReason: "review_requested",
       involveLogin: humanName.toLowerCase(),
-      actorAgentId: null,
     };
     const event = makeEvent({
       orgId: admin.organizationId,
@@ -608,6 +960,7 @@ describe("deliverNormalizedEvent", () => {
       memberId: admin.memberId,
       name: `human-good-${randomUUID().slice(0, 6)}`,
       delegateMention: delegate,
+      type: "human",
     });
     const goodChatId = `chat_${randomUUID()}`;
     await app.db.insert(chats).values({ id: goodChatId, organizationId: admin.organizationId, type: "direct" });
@@ -628,7 +981,6 @@ describe("deliverNormalizedEvent", () => {
       chatId: null, // forces the runtime guard to throw
       involveReason: null,
       involveLogin: null,
-      actorAgentId: null,
     };
     const ok: AudienceTarget = {
       humanAgentId: goodHuman,
@@ -637,7 +989,6 @@ describe("deliverNormalizedEvent", () => {
       chatId: goodChatId,
       involveReason: null,
       involveLogin: null,
-      actorAgentId: null,
     };
     const event = makeEvent({
       orgId: admin.organizationId,
@@ -670,6 +1021,7 @@ describe("deliverNormalizedEvent", () => {
       memberId: admin.memberId,
       name: `humanA-${randomUUID().slice(0, 6)}`,
       delegateMention: delegateA,
+      type: "human",
     });
     const delegateR = await mk("dlgR");
     const humanR = await seedAgent(app, {
@@ -677,6 +1029,7 @@ describe("deliverNormalizedEvent", () => {
       memberId: admin.memberId,
       name: `humanR-${randomUUID().slice(0, 6)}`,
       delegateMention: delegateR,
+      type: "human",
     });
 
     const chatId = `chat_${randomUUID()}`;
@@ -711,7 +1064,6 @@ describe("deliverNormalizedEvent", () => {
       chatId,
       involveReason: null,
       involveLogin: null,
-      actorAgentId: null,
     };
     const involved: AudienceTarget = {
       humanAgentId: humanR,
@@ -720,7 +1072,6 @@ describe("deliverNormalizedEvent", () => {
       chatId: null,
       involveReason: "review_requested",
       involveLogin: "humanr",
-      actorAgentId: null,
     };
 
     const stats = await deliverNormalizedEvent(app, event, [subscribed, involved]);
@@ -777,6 +1128,7 @@ describe("deliverNormalizedEvent", () => {
       memberId: admin.memberId,
       name: `humanA-${randomUUID().slice(0, 6)}`,
       delegateMention: delegateA,
+      type: "human",
     });
     const delegateM = await seedAgent(app, {
       orgId: admin.organizationId,
@@ -788,6 +1140,7 @@ describe("deliverNormalizedEvent", () => {
       memberId: admin.memberId,
       name: `humanM-${randomUUID().slice(0, 6)}`,
       delegateMention: delegateM,
+      type: "human",
     });
 
     const chatId = `chat_${randomUUID()}`;
@@ -821,7 +1174,6 @@ describe("deliverNormalizedEvent", () => {
       chatId: null,
       involveReason: "mentioned",
       involveLogin: "humanm",
-      actorAgentId: null,
     };
 
     const stats = await deliverNormalizedEvent(app, event, [involvedMention]);
@@ -860,6 +1212,7 @@ describe("deliverNormalizedEvent", () => {
       memberId: admin.memberId,
       name: `human-${randomUUID().slice(0, 6)}`,
       delegateMention: delegate,
+      type: "human",
     });
     const watcher = await seedAgent(app, {
       orgId: admin.organizationId,
@@ -891,7 +1244,6 @@ describe("deliverNormalizedEvent", () => {
       chatId,
       involveReason: null,
       involveLogin: null,
-      actorAgentId: null,
     };
     const event = makeEvent({
       orgId: admin.organizationId,
@@ -923,17 +1275,10 @@ describe("deliverNormalizedEvent", () => {
     expect(watcherRow?.notify).toBe(false);
   });
 
-  it("M2 + echo combined: actor is the represented human, entity bound from two chats — both wake their delegate (regression)", async () => {
-    // Single fixture that lights up BOTH old defects at once — the exact shape
-    // of the multi-human-not-pushed bug, which only manifests when they stack:
-    //   - old M2 (dedup by `humanAgentId`, keep earliest) dropped the LATER
-    //     chat (chatB) — bound_at order is load-bearing;
-    //   - old echo (actor on the human side → drop the whole row) then dropped
-    //     chatA too, since the actor IS chatA's represented human.
-    // Old code → empty audience → both chats silent. This pins the fix end to
-    // end: drives `resolveAudience` → `deliverNormalizedEvent` and asserts both
-    // chats not only re-enter the audience but each delegate (≠ actor) is
-    // actually woken — a pure audience-layer assertion cannot prove the wake.
+  it("prunes every self-owned follow delivery even when the actor has multiple mapped chats", async () => {
+    // Stage 2 must still keep distinct (human, chat) mappings so routing facts
+    // are not lost, but Stage 3 removes entries owned by actorHuman before
+    // sending. With no other human entry left, neither chat gets a card.
     const app = getApp();
     const admin = await createTestAdmin(app);
     const humanName = `rep-human-${randomUUID().slice(0, 6)}`;
@@ -941,6 +1286,7 @@ describe("deliverNormalizedEvent", () => {
       orgId: admin.organizationId,
       memberId: admin.memberId,
       name: humanName,
+      type: "human",
     });
     const da = await seedAgent(app, {
       orgId: admin.organizationId,
@@ -999,54 +1345,17 @@ describe("deliverNormalizedEvent", () => {
       rawAction: "synchronize",
     });
 
-    // Stage 2: both chats survive. M2 keeps the (human, chat) pairs distinct;
-    // echo annotates `actorAgentId = H` on every row instead of dropping any.
-    const audience = await resolveAudience(app.db, event, "first-tree");
+    // Stage 2: both chats survive. M2 keeps the (human, chat) pairs distinct.
+    const resolution = await resolveAudience(app.db, event);
+    const audience = resolution.targets;
     expect(audience).toHaveLength(2);
     expect(new Set(audience.map((a) => a.chatId))).toEqual(new Set([chatA, chatB]));
-    for (const target of audience) expect(target.actorAgentId).toBe(human);
+    expect(resolution.actorHumanId).toBe(human);
 
-    // Stage 3: both cards land AND each chat's delegate (≠ actor) is woken.
-    const stats = await deliverNormalizedEvent(app, event, audience);
-    expect(stats.delivered).toBe(2);
-
-    const [daRow] = await app.db.select({ inboxId: agents.inboxId }).from(agents).where(eq(agents.uuid, da)).limit(1);
-    const [dbRow] = await app.db.select({ inboxId: agents.inboxId }).from(agents).where(eq(agents.uuid, db)).limit(1);
-    const [hRow] = await app.db.select({ inboxId: agents.inboxId }).from(agents).where(eq(agents.uuid, human)).limit(1);
-
-    // chatA: card written + Da woken.
-    expect(await app.db.select().from(messages).where(eq(messages.chatId, chatA))).toHaveLength(1);
-    const daWoken = await app.db
-      .select()
-      .from(inboxEntries)
-      .where(
-        and(
-          eq(inboxEntries.chatId, chatA),
-          eq(inboxEntries.notify, true),
-          eq(inboxEntries.inboxId, daRow?.inboxId ?? ""),
-        ),
-      );
-    expect(daWoken.length).toBeGreaterThan(0);
-
-    // chatB: card written + Db woken — chatB is the chat the OLD dedup silently dropped.
-    expect(await app.db.select().from(messages).where(eq(messages.chatId, chatB))).toHaveLength(1);
-    const dbWoken = await app.db
-      .select()
-      .from(inboxEntries)
-      .where(
-        and(
-          eq(inboxEntries.chatId, chatB),
-          eq(inboxEntries.notify, true),
-          eq(inboxEntries.inboxId, dbRow?.inboxId ?? ""),
-        ),
-      );
-    expect(dbWoken.length).toBeGreaterThan(0);
-
-    // The actor (== represented human H) is never woken by its own action.
-    const hWoken = await app.db
-      .select()
-      .from(inboxEntries)
-      .where(and(eq(inboxEntries.notify, true), eq(inboxEntries.inboxId, hRow?.inboxId ?? "")));
-    expect(hWoken).toHaveLength(0);
+    const stats = await deliverNormalizedEvent(app, event, audience, { actorHumanId: resolution.actorHumanId });
+    expect(stats).toEqual({ delivered: 0, newChats: 0, failed: 0 });
+    expect(await app.db.select().from(messages).where(eq(messages.chatId, chatA))).toHaveLength(0);
+    expect(await app.db.select().from(messages).where(eq(messages.chatId, chatB))).toHaveLength(0);
+    expect(await app.db.select().from(inboxEntries).where(eq(inboxEntries.notify, true))).toHaveLength(0);
   });
 });

--- a/packages/server/src/api/webhooks/github-app.ts
+++ b/packages/server/src/api/webhooks/github-app.ts
@@ -249,7 +249,6 @@ export async function githubAppWebhookRoutes(app: FastifyInstance): Promise<void
     return;
   }
   const webhookSecret = appConfig.webhookSecret;
-  const appSlug = appConfig.slug ?? null;
 
   app.post("/github-app", async (request, reply) => {
     const rawBody = request.body;
@@ -381,8 +380,8 @@ export async function githubAppWebhookRoutes(app: FastifyInstance): Promise<void
         return reply.status(200).send({ ok: true, event: eventType, handled: false, contextReviewer });
       }
 
-      const audience = await resolveAudience(app.db, event, appSlug);
-      if (audience.length === 0) {
+      const audience = await resolveAudience(app.db, event);
+      if (audience.targets.length === 0) {
         // Distinguish "expected nobody" (no involves, no subscription)
         // from "had explicit involves but resolved to zero agents" — the
         // latter usually means a mentioned GitHub login has no
@@ -403,7 +402,10 @@ export async function githubAppWebhookRoutes(app: FastifyInstance): Promise<void
         );
         return reply.status(200).send({ ok: true, event: eventType, audience: 0, reason, contextReviewer });
       }
-      const stats = await deliverNormalizedEvent(app, event, audience, { entityStateSeed });
+      const stats = await deliverNormalizedEvent(app, event, audience.targets, {
+        entityStateSeed,
+        actorHumanId: audience.actorHumanId,
+      });
       return reply.status(200).send({ ok: true, event: eventType, ...stats, contextReviewer });
     } catch (err) {
       if (deliveryId) {

--- a/packages/server/src/services/github-audience.ts
+++ b/packages/server/src/services/github-audience.ts
@@ -1,5 +1,11 @@
-import { type InvolveReason, isDeclaredBoundVia, type NormalizedEvent } from "@first-tree/shared";
-import { and, eq, inArray, isNotNull, sql } from "drizzle-orm";
+import {
+  AGENT_STATUSES,
+  AGENT_TYPES,
+  type InvolveReason,
+  isDeclaredBoundVia,
+  type NormalizedEvent,
+} from "@first-tree/shared";
+import { and, eq, inArray, sql } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 import { agents } from "../db/schema/agents.js";
 import { githubEntityChatMappings } from "../db/schema/github-entity-chat-mappings.js";
@@ -31,119 +37,75 @@ export function evaluateDelegateTarget(
 }
 
 /**
- * Identity classification for the actor (the GitHub user who triggered the
- * event). Three buckets:
+ * Resolve the GitHub actor to the represented First Tree human when possible.
  *
- *   - `agent`         — actor.login maps to one of this org's agents. Used
- *                       for echo suppression at the notification layer: the
- *                       card still lands in every mapped chat (the public
- *                       record of what happened), but the actor is excluded
- *                       from notify only (Stage 3 passes its id to `suppressNotifyAgentIds` while it stays structurally addressed) so agents aren't
- *                       woken by their own actions. See #942.
- *   - `our-app-bot`   — actor is `<app-slug>[bot]`. The event is a downstream
- *                       effect of First Tree's own outbound write. `kind: "existing"`
- *                       targets are kept (so PRs the agent opens via First Tree's
- *                       installation token still surface their comments / CI
- *                       back to the agent's chat via the subscription path);
- *                       `kind: "new"` mention rows are dropped — minting a
- *                       fresh chat for our own write is never useful.
- *   - `external`      — anyone else (other humans, third-party bots like
- *                       dependabot, …). No echo filter applied.
+ * GitHub tells us which login triggered the event; it does not tell us which
+ * local agent, if any, performed the action. Echo pruning is therefore
+ * human-scoped: if the actor login maps to an org-local human agent, delivery
+ * can remove entries that belong to that same human. Unknown humans, external
+ * users, and bot/app senders return null and are delivered without self
+ * pruning.
  */
-export type ActorIdentity = { kind: "agent"; agentId: string } | { kind: "our-app-bot" } | { kind: "external" };
-
-export async function identifyActor(
+export async function resolveActorHumanId(
   db: Database,
   organizationId: string,
-  actor: { githubLogin: string; isBot: boolean },
-  appSlug: string | null,
-): Promise<ActorIdentity> {
-  if (actor.isBot && appSlug && actor.githubLogin.toLowerCase() === `${appSlug.toLowerCase()}[bot]`) {
-    return { kind: "our-app-bot" };
-  }
+  actor: { githubLogin: string },
+): Promise<string | null> {
   const [agentRow] = await db
     .select({ uuid: agents.uuid })
     .from(agents)
     .where(
-      and(eq(agents.organizationId, organizationId), eq(sql`lower(${agents.name})`, actor.githubLogin.toLowerCase())),
+      and(
+        eq(agents.organizationId, organizationId),
+        eq(agents.type, AGENT_TYPES.HUMAN),
+        eq(sql`lower(${agents.name})`, actor.githubLogin.toLowerCase()),
+      ),
     )
     .limit(1);
-  if (agentRow) return { kind: "agent", agentId: agentRow.uuid };
-  return { kind: "external" };
+  return agentRow?.uuid ?? null;
 }
 
-/**
- * One row in the Stage 2 audience output. `existing` carries the persistent
- * subscription's chat id (Stage 3 sends directly); `new` carries the
- * involvement reason (Stage 3 creates the chat + writes the mapping row, then
- * picks the card `reason` from `subscribed` vs `involveReason`).
- */
+/** One candidate delivery entry from Stage 2. */
 export type AudienceTarget = {
   humanAgentId: string;
   delegateAgentId: string;
   kind: "existing" | "new";
   /** Set only when `kind === "existing"`. */
   chatId: string | null;
-  /** Set only when `kind === "new"`. */
+  /** Set when this delivery is also a target-human route. */
   involveReason: InvolveReason | null;
   /**
-   * Lower-cased GitHub login that caused this fresh involvement (the human
-   * agent's name, matched against `event.involves[i].githubLogin`). Set only
-   * when `kind === "new"`. Stage 3 reads it to fill the card's
-   * `mentionedUser` field so a chat targeted at user X never displays "Y was
-   * mentioned" because two involves shared the same reason.
+   * Lower-cased GitHub login that caused this target route. Stage 3 reads it
+   * to fill the card's `mentionedUser` field so a chat targeted at user X
+   * never displays "Y was mentioned" because two involves shared the same
+   * reason.
    */
   involveLogin: string | null;
-  /**
-   * Set when the event's actor resolves to an org agent (`identifyActor`
-   * returned `kind: "agent"`). Stage 3 passes this id as the message's
-   * `suppressNotifyAgentIds` so the actor is never woken / red-dotted by its
-   * own action, while staying structurally addressed — the card still lands
-   * in the chat (as a silent `notify=false` row for the actor) as the public
-   * record (#942, S2/D1). The suppress target is decoupled from `senderId`.
-   * `null` for our-app-bot and external actors.
-   */
-  actorAgentId: string | null;
+};
+
+export type AudienceResolution = {
+  targets: AudienceTarget[];
+  actorHumanId: string | null;
 };
 
 /**
  * Compute the Stage 2 audience for a normalized event.
  *
- *   audience = subscribed ∪ involved
+ *   audience = follow mappings ∪ target deliveries
  *
  * `subscribed` reads every `(human, delegate)` row already bound to
  * `(org, entity)` in `github_entity_chat_mappings`. `involved` walks
- * `event.involves` and for each login that resolves to an org-local
- * `delegate_mention`-configured agent whose target is eligible AND isn't
- * already subscribed, appends a `new` row.
+ * `event.involves` as target-human candidates. A target human first reuses
+ * their existing mapping(s) on the entity; only humans without a mapping fall
+ * back to their default delegate and produce a `kind: "new"` row.
  *
- * Echo filtering runs after the union:
- *   - actor = `agent`: no row is dropped for echo — every mapped chat keeps
- *     the card as the public record of what happened. Instead, each row is
- *     annotated with `actorAgentId` so Stage 3 passes the actor as
- *     `suppressNotifyAgentIds` (the actor isn't woken / red-dotted by its own
- *     action, other recipients are notified normally; the actor still gets a
- *     silent row). Dropping rows here used to conflate "should this chat get
- *     the card" with "should this recipient be notified" and silently killed
- *     delivery to multi-participant chats whose only routing entry had the
- *     actor on one side (#942). The one row this branch DOES drop is the
- *     creator carve-out: on a creation event (`kind: "opened"`) the actor's
- *     OWN `kind: "new"` involvement is removed — a creator never gets a
- *     dispatcher-minted chat for the entity it just opened; it binds that
- *     entity via explicit `github follow`. This is a delivery-side drop of a
- *     would-be fresh chat, not an echo/notification concern.
- *   - actor = `our-app-bot`: `kind: "existing"` rows are kept so follow-up
- *     events on entities the agent opened still reach the chat through the
- *     subscription path; `kind: "new"` rows are dropped to avoid forking a
- *     fresh chat just to echo First Tree's own outbound write. See `ActorIdentity`.
+ * Echo pruning happens in delivery, before fresh-chat resolution, so self-only
+ * events do not write cards and mixed events keep the other humans' entries.
  */
-export async function resolveAudience(
-  db: Database,
-  event: NormalizedEvent,
-  appSlug: string | null,
-): Promise<AudienceTarget[]> {
+export async function resolveAudience(db: Database, event: NormalizedEvent): Promise<AudienceResolution> {
   const organizationId = event.source.organizationId;
   const entityKeys = githubEntityKeyCandidates(event.entity.type, event.entity.key);
+  const actorHumanId = await resolveActorHumanId(db, organizationId, event.actor);
 
   const subscribedRows = await db
     .select({
@@ -222,18 +184,14 @@ export async function resolveAudience(
     chatId: row.chatId,
     involveReason: null,
     involveLogin: null,
-    actorAgentId: null,
   }));
 
-  // Dedup involved candidates by `humanAgentId` only — once any (human, *,
-  // entity) mapping exists, the entity is already routed to that human's
-  // chat and the involves-driven path must NOT fork a sibling chat just
-  // because the candidate's `delegateMention` differs from the delegate
-  // recorded on the existing mapping. The downstream resolver still applies
-  // a human-scoped fallback (see `resolveTargetChat` step a.5), so even if
-  // a race lets a `kind: "new"` row through with a different delegate, the
-  // chat is reused — this dedup is the first line of defence.
-  const subscribedHumanIds = new Set(subscribed.map((s) => s.humanAgentId));
+  const subscribedByHuman = new Map<string, AudienceTarget[]>();
+  for (const target of subscribed) {
+    const rows = subscribedByHuman.get(target.humanAgentId);
+    if (rows) rows.push(target);
+    else subscribedByHuman.set(target.humanAgentId, [target]);
+  }
 
   const involved: AudienceTarget[] = [];
   if (event.involves.length > 0) {
@@ -252,7 +210,7 @@ export async function resolveAudience(
       .where(
         and(
           eq(agents.organizationId, organizationId),
-          isNotNull(agents.delegateMention),
+          eq(agents.type, AGENT_TYPES.HUMAN),
           inArray(sql`lower(${agents.name})`, candidateLogins),
         ),
       );
@@ -277,13 +235,23 @@ export async function resolveAudience(
       delegateById.set(row.id, { organizationId: row.organizationId, status: row.status });
 
     for (const c of candidates) {
-      if (c.status !== "active" || !c.delegateMention || !c.name) continue;
-      const verdict = evaluateDelegateTarget(delegateById.get(c.delegateMention), organizationId);
-      if (verdict !== "ok") continue;
-      if (subscribedHumanIds.has(c.id)) continue;
+      if (c.status !== AGENT_STATUSES.ACTIVE || !c.name) continue;
       const candidateLogin = c.name.toLowerCase();
       const reason = reasonByLogin.get(candidateLogin);
       if (!reason) continue;
+
+      const existingForHuman = subscribedByHuman.get(c.id);
+      if (existingForHuman) {
+        for (const target of existingForHuman) {
+          target.involveReason = reason;
+          target.involveLogin = candidateLogin;
+        }
+        continue;
+      }
+
+      if (!c.delegateMention) continue;
+      const verdict = evaluateDelegateTarget(delegateById.get(c.delegateMention), organizationId);
+      if (verdict !== "ok") continue;
       involved.push({
         humanAgentId: c.id,
         delegateAgentId: c.delegateMention,
@@ -291,69 +259,10 @@ export async function resolveAudience(
         chatId: null,
         involveReason: reason,
         involveLogin: candidateLogin,
-        actorAgentId: null,
       });
     }
   }
 
   const audience = [...subscribed, ...involved];
-  if (audience.length === 0) return audience;
-
-  const actor = await identifyActor(db, organizationId, event.actor, appSlug);
-  if (actor.kind === "our-app-bot") {
-    // The App bot is on the wire because First Tree itself wrote to GitHub — the
-    // user already saw their own action client-side. We still need to fan
-    // out to *existing* subscriptions so PR comments / CI changes reach
-    // the chat the agent worked in; mention-driven `kind: "new"` rows are
-    // dropped because creating a fresh chat just to echo our own write is
-    // never useful.
-    return audience.filter((a) => a.kind === "existing");
-  }
-  if (actor.kind === "agent") {
-    // Echo suppression is a *notification* concern, not a delivery one
-    // (#942). Every mapped chat keeps its card — the chat row is the public
-    // record of what happened, and other participants of a multi-member
-    // chat legitimately want to see it. The actor's id is annotated onto
-    // every target so Stage 3 (`deliverNormalizedEvent`) passes it as
-    // `suppressNotifyAgentIds`: the actor stays structurally addressed but is
-    // not woken / red-dotted by its own action (it still gets a silent
-    // `notify=false` row), while everyone else is notified normally.
-    // Suppression is decoupled from `senderId` (S2/D1) — the actor is
-    // frequently not a speaker of the chat, so it must not become the
-    // chat-local sender. A 1:1 chat where the actor is the sole addressable
-    // recipient reduces naturally to "card visible, nobody woken".
-    //
-    // The previous implementation dropped `kind: "existing"` rows whose
-    // human or delegate side matched the actor. When such a row was the
-    // chat's only routing entry, that silently killed delivery to the entire
-    // chat — multi-participant chats lost the event altogether. It also
-    // assumed `actor.login` identifies a single acting agent, which is
-    // unsound: agents act on GitHub under a human's GitHub identity, so
-    // identity-based echo cannot reliably tell an agent's own write from a
-    // human's. Notification-layer exclusion is best-effort — at worst it
-    // re-wakes the actor once; it never drops an event.
-    //
-    // Creator carve-out: a creation event ("opened" — `pull_request.opened`,
-    // `issues.opened`, `discussion.created`) never mints a *fresh* chat for
-    // its own creator. The creator IS the actor; it binds the entity it just
-    // created through an explicit `github follow` (an `agent_declared`
-    // mapping), which arrives on the subscribed path as a `kind: "existing"`
-    // row and survives the #766 opened carve-out as the creation-confirmation
-    // card. Minting a second, dispatcher-owned chat for the same creator on
-    // the same PR (because the creator self-assigned / self-@mentioned in the
-    // opened payload) is a duplicate — it surfaced once #942 stopped
-    // echo-dropping the actor's audience row. So drop ONLY the actor's own
-    // `kind: "new"` involvement, and ONLY on creation events. Other involved
-    // humans (a reviewer/assignee who is NOT the creator) still get their
-    // chat, the actor's `existing` subscriptions (its followed chat) are
-    // untouched, and non-creation self-mentions — an agent pinging its own
-    // delegate in a comment (#345) — still route. This filtering is part of
-    // before-delivery audience resolution (Stage 2), so it completes before
-    // any chat is minted or card is sent (S8).
-    const isCreation = event.kind === "opened";
-    return audience
-      .filter((a) => !(isCreation && a.kind === "new" && a.humanAgentId === actor.agentId))
-      .map((a) => ({ ...a, actorAgentId: actor.agentId }));
-  }
-  return audience;
+  return { targets: audience, actorHumanId };
 }

--- a/packages/server/src/services/github-delivery.ts
+++ b/packages/server/src/services/github-delivery.ts
@@ -27,25 +27,29 @@ export type DeliveryStats = {
 
 type DeliveryOptions = {
   entityStateSeed?: EntityStateSeed | null;
+  actorHumanId?: string | null;
 };
 
 /**
  * Per-chat delivery accumulator. "Deliver once per chat" (S7/S9): multiple
  * audience targets (subscribed and/or involved) that resolve to the same chat
- * collapse into a single card whose wake-set is the union of their delegates.
+ * collapse into a single card whose wake-set is the union of surviving
+ * per-human entries.
  */
+type DeliveryReason = "follow" | InvolveReason;
+
+type DeliveryEntry = {
+  humanAgentId: string;
+  wakeAgentId: string;
+  reasons: Set<DeliveryReason>;
+  involveReason: InvolveReason | null;
+  involveLogin: string | null;
+};
+
 type ChatDelivery = {
   chatId: string;
   created: boolean;
-  /** Native mention / wake-set — the delegates to notify in this chat. */
-  delegateIds: Set<string>;
-  /** Echo suppress-set — actor agents excluded from notify (still get a silent row). */
-  actorIds: Set<string>;
-  /** Card framing: an involved target's reason/login wins over plain subscribed. */
-  involveReason: InvolveReason | null;
-  involveLogin: string | null;
-  /** Chat-local representative human used as `senderId` (rendered as the GitHub system sender). */
-  humanAgentId: string;
+  entries: Map<string, DeliveryEntry>;
 };
 
 /**
@@ -54,9 +58,10 @@ type ChatDelivery = {
  * Two phases. Phase 1 resolves every audience target to a chat (subscribed
  * targets short-circuit; involved targets reuse the entity's existing chat
  * when the involved human+delegate are already speakers, else mint a fresh
- * one) and accumulates the per-chat wake-set / suppress-set / card framing.
- * Phase 2 delivers one card per chat, waking the union of delegates via native
- * `metadata.mentions` and suppressing the actor via `suppressNotifyAgentIds`.
+ * one) and accumulates the per-chat entries. Self-echo pruning happens before
+ * fresh-chat resolution, so an actor's own target does not create an empty
+ * chat. Phase 2 delivers one card per chat, waking the union of surviving
+ * wake agents via native `metadata.mentions`.
  * Each chat is delivered independently so a single failure doesn't poison the
  * rest — the loop logs and continues.
  */
@@ -67,10 +72,16 @@ export async function deliverNormalizedEvent(
   options: DeliveryOptions = {},
 ): Promise<DeliveryStats> {
   const stats: DeliveryStats = { delivered: 0, newChats: 0, failed: 0 };
+  const actorHumanId = options.actorHumanId ?? null;
+  const existingMappedChatIds = existingMappedChatIdsForProjection(audience);
+  const entity = entityFromEvent(event);
 
   // Phase 1 — resolve each target to a chat and merge into per-chat deliveries.
   const byChat = new Map<string, ChatDelivery>();
   for (const target of audience) {
+    if (actorHumanId && target.humanAgentId === actorHumanId) {
+      continue;
+    }
     let resolved: ResolvedChat | null;
     try {
       resolved = await resolveChatFor(app, event, target, options);
@@ -119,31 +130,21 @@ export async function deliverNormalizedEvent(
       delivery = {
         chatId: resolved.chatId,
         created: resolved.created,
-        delegateIds: new Set(),
-        actorIds: new Set(),
-        involveReason: null,
-        involveLogin: null,
-        humanAgentId: target.humanAgentId,
+        entries: new Map(),
       };
       byChat.set(resolved.chatId, delivery);
     } else if (resolved.created) {
       delivery.created = true;
     }
-    delivery.delegateIds.add(target.delegateAgentId);
-    if (target.actorAgentId) delivery.actorIds.add(target.actorAgentId);
-    // Prefer an involved target's reason/login for the (single) card framing.
-    if (target.kind === "new" && target.involveReason && !delivery.involveReason) {
-      delivery.involveReason = target.involveReason;
-      delivery.involveLogin = target.involveLogin;
-    }
+    addDeliveryEntry(delivery, target);
   }
 
-  // Phase 1.5 — refresh the persisted title for this entity's mapping rows.
-  // Seeding happens on insert, but rows created before titles were persisted
-  // (and any upstream rename) only get a label here. Scoped to the entity's
-  // cluster, gated on at least one resolved chat, and isolated so a title
-  // write never aborts card delivery.
-  if (byChat.size > 0 && event.entity.title && event.entity.title.length > 0) {
+  // Phase 1.5 — refresh the local projection for this entity independently
+  // from card delivery. A self-only event can prune every delivery entry, but
+  // it still proves the entity has an existing local mapping whose title/topic
+  // projection must stay fresh.
+  const shouldRefreshEntityProjection = byChat.size > 0 || existingMappedChatIds.length > 0;
+  if (shouldRefreshEntityProjection && event.entity.title && event.entity.title.length > 0) {
     try {
       await setEntityTitle(app.db, {
         organizationId: event.source.organizationId,
@@ -163,6 +164,9 @@ export async function deliverNormalizedEvent(
       );
     }
   }
+  for (const chatId of existingMappedChatIds) {
+    await refreshGithubChatTopic(app.db, chatId, entity);
+  }
 
   // Phase 2 — one card per chat.
   for (const delivery of byChat.values()) {
@@ -173,16 +177,13 @@ export async function deliverNormalizedEvent(
         // edits propagate into the chat list. The helper only touches a chat
         // whose own `direct` anchor entity matches this event, preserves the
         // original prefix, and no-ops when the payload carries no title.
-        const entity: GithubEntity = {
-          type: event.entity.type,
-          key: event.entity.key,
-          title: event.entity.title,
-          url: event.entity.url,
-        };
         await refreshGithubChatTopic(app.db, delivery.chatId, entity);
       }
 
-      const card = buildCard(event, delivery.involveReason, delivery.involveLogin);
+      const entries = [...delivery.entries.values()].sort(compareEntries);
+      const senderId = selectSenderId(entries);
+      const cardContext = selectCardContext(entries);
+      const card = buildCard(event, cardContext.involveReason, cardContext.involveLogin);
       const mentionedUser = card.mentionedUser ?? undefined;
       // Native wake-set (S8): the delegates are passed as `metadata.mentions`,
       // so the generic fan-out wakes them — no GitHub-specific addressing
@@ -190,15 +191,11 @@ export async function deliverNormalizedEvent(
       // out by the message service (the card still lands as a silent row via
       // `allowRecipientlessSend`). The unread-mention red dot stays off because
       // delegates are non-human mention targets.
-      const mentions = [...delivery.delegateIds].sort();
-      // Echo suppression (S2 / D1): the event's actor agent(s), decoupled from
-      // `senderId` and from the wake-set. A suppressed agent still gets a
-      // silent (notify=false) inbox row — the card lands, it just doesn't wake.
-      const suppressNotifyAgentIds = [...delivery.actorIds];
+      const mentions = [...new Set(entries.map((entry) => entry.wakeAgentId))].sort();
       const { message, recipients } = await sendMessage(
         app.db,
         delivery.chatId,
-        delivery.humanAgentId,
+        senderId,
         {
           format: "card",
           content: card,
@@ -222,7 +219,6 @@ export async function deliverNormalizedEvent(
           },
         },
         {
-          suppressNotifyAgentIds,
           // Opt in to writing `metadata.systemSender` — the message service
           // strips that key from every untrusted caller (web / agent SDK POST)
           // so HTTP boundaries cannot impersonate the GitHub sender. This is
@@ -231,10 +227,9 @@ export async function deliverNormalizedEvent(
           // Opt out of the default explicit-recipient guard. This trusted
           // system delivery owns its own routing, but on some events the
           // wake-set resolves to no live speaker (every delegate is a
-          // non-speaker, or the only addressable agent is the suppressed
-          // actor). Such a card is still a valid history/context row for human
-          // observers; without this opt-out the default guard would make this
-          // trusted path start throwing.
+          // non-speaker). Such a card is still a valid history/context row
+          // for human observers; without this opt-out the default guard would
+          // make this trusted path start throwing.
           allowRecipientlessSend: true,
         },
       );
@@ -252,7 +247,7 @@ export async function deliverNormalizedEvent(
           metric: "github_delivery_failed_total",
           errorClass: err instanceof Error ? err.name : "Unknown",
           chatId: delivery.chatId,
-          delegateAgents: [...delivery.delegateIds],
+          delegateAgents: [...delivery.entries.values()].map((entry) => entry.wakeAgentId),
           entityType: event.entity.type,
           entityKey: event.entity.key,
           eventType: event.rawEventType,
@@ -264,6 +259,84 @@ export async function deliverNormalizedEvent(
   }
 
   return stats;
+}
+
+function existingMappedChatIdsForProjection(audience: AudienceTarget[]): string[] {
+  return [
+    ...new Set(
+      audience.filter((target) => target.kind === "existing" && target.chatId).map((target) => target.chatId as string),
+    ),
+  ].sort();
+}
+
+function entityFromEvent(event: NormalizedEvent): GithubEntity {
+  return {
+    type: event.entity.type,
+    key: event.entity.key,
+    title: event.entity.title,
+    url: event.entity.url,
+  };
+}
+
+function addDeliveryEntry(delivery: ChatDelivery, target: AudienceTarget): void {
+  const key = `${target.humanAgentId}:${target.delegateAgentId}`;
+  const existing = delivery.entries.get(key);
+  const reasons = reasonsForTarget(target);
+  if (existing) {
+    for (const reason of reasons) existing.reasons.add(reason);
+    if (!existing.involveReason && target.involveReason) {
+      existing.involveReason = target.involveReason;
+      existing.involveLogin = target.involveLogin;
+    }
+    return;
+  }
+  delivery.entries.set(key, {
+    humanAgentId: target.humanAgentId,
+    wakeAgentId: target.delegateAgentId,
+    reasons,
+    involveReason: target.involveReason,
+    involveLogin: target.involveLogin,
+  });
+}
+
+function reasonsForTarget(target: AudienceTarget): Set<DeliveryReason> {
+  const reasons = new Set<DeliveryReason>();
+  if (target.kind === "existing") reasons.add("follow");
+  if (target.involveReason) reasons.add(target.involveReason);
+  return reasons;
+}
+
+function compareEntries(a: DeliveryEntry, b: DeliveryEntry): number {
+  return a.humanAgentId.localeCompare(b.humanAgentId) || a.wakeAgentId.localeCompare(b.wakeAgentId);
+}
+
+function selectSenderId(entries: DeliveryEntry[]): string {
+  const first = entries[0];
+  if (!first) throw new Error("delivery plan must have at least one surviving entry");
+  return first.humanAgentId;
+}
+
+function selectCardContext(entries: DeliveryEntry[]): {
+  involveReason: InvolveReason | null;
+  involveLogin: string | null;
+} {
+  const involved = [...entries]
+    .filter((entry) => entry.involveReason)
+    .sort((a, b) => involveReasonRank(a.involveReason) - involveReasonRank(b.involveReason) || compareEntries(a, b))[0];
+  return { involveReason: involved?.involveReason ?? null, involveLogin: involved?.involveLogin ?? null };
+}
+
+function involveReasonRank(reason: InvolveReason | null): number {
+  switch (reason) {
+    case "review_requested":
+      return 0;
+    case "mentioned":
+      return 1;
+    case "assigned":
+      return 2;
+    default:
+      return 3;
+  }
 }
 
 type ResolvedChat = { chatId: string; created: boolean };

--- a/packages/server/src/services/message.ts
+++ b/packages/server/src/services/message.ts
@@ -169,9 +169,8 @@ export type SendMessageOptions = {
   normalizeMentionsInContent?: boolean;
   /**
    * Agent IDs that this message is **addressed to** by construction — used
-   * for system-routed messages whose recipient is fixed at write time
-   * (today: `github-delivery.deliverNormalizedEvent`). Within the
-   * non-silenced fan-out branch, addressed agents always receive
+   * for trusted system-routed messages whose recipient is fixed at write time.
+   * Within the non-silenced fan-out branch, addressed agents always receive
    * `notify=true` regardless of `metadata.mentions`.
    *
    * `purpose === "agent-final-text"` still takes precedence (it forces
@@ -186,13 +185,10 @@ export type SendMessageOptions = {
    * suppressed agent still receives a `notify=false` inbox row (the message
    * still lands in history / replays as context), it is simply not woken.
    *
-   * Today's caller is `github-delivery.deliverNormalizedEvent`, which passes
-   * the event's actor agent so an agent is never woken by its own GitHub
-   * action (echo suppression) — without binding that exclusion to `senderId`
-   * (the actor is frequently not a speaker of the target chat, so it must not
-   * be the chat-local sender). See `system/cloud/github/github-entity-chat-binding.md`
-   * S2. `purpose === "agent-final-text"` still forces silent for everyone;
-   * this only narrows the notify set within the non-silenced branch.
+   * This is intentionally generic and decoupled from `senderId`; a trusted
+   * dispatcher can keep attribution chat-local while excluding specific agents
+   * from wake. `purpose === "agent-final-text"` still forces silent for
+   * everyone; this only narrows the notify set within the non-silenced branch.
    */
   suppressNotifyAgentIds?: readonly string[];
   /**
@@ -583,10 +579,8 @@ async function sendMessageInner(
     //      nobody is woken.
     const mentionSet = new Set(mergedMentions);
     const addressedSet = new Set(options.addressedToAgentIds ?? []);
-    // Generic echo / wake-exclusion: agents here still get a `notify=false`
-    // inbox row (message lands), they are just not woken. Decoupled from
-    // `senderId` so a non-member actor can be excluded without being made the
-    // chat-local sender. See SendMessageOptions.suppressNotifyAgentIds.
+    // Generic wake-exclusion: agents here still get a `notify=false` inbox
+    // row (message lands), they are just not woken. Decoupled from `senderId`.
     const suppressNotifySet = new Set(options.suppressNotifyAgentIds ?? []);
     // Build a single fan-out structure that carries agentId alongside the
     // inbox row. agentId is needed by the post-tx session-activation step


### PR DESCRIPTION
## Summary
- split GitHub webhook audience resolution into `actorHumanId` plus explicit delivery targets
- make target humans reuse their existing entity mappings before falling back to default delegates
- prune actor-owned delivery entries before chat resolution so self-only events write no card, while mixed chats keep other humans
- keep entity title/topic projection refresh independent from card delivery, including self-pruned existing mappings
- make GitHub card `sender_id` come from the surviving DeliveryPlan human

## Tests
- `pnpm --filter @first-tree/server exec vitest run src/__tests__/github-audience.test.ts src/__tests__/github-delivery.test.ts src/__tests__/github-normalize.test.ts src/__tests__/message-addressed-agents.test.ts src/__tests__/message-system-sender-strip.test.ts src/__tests__/github-app-webhook-route.test.ts --maxWorkers=2`
- `pnpm check` (passes; existing unrelated Biome warnings remain in client/web files)
- `pnpm typecheck`
- `git diff --check`

## Review
- codex-reviewer found one blocker around self-pruned events skipping local projection refresh. Fixed by decoupling mapping title/direct chat topic refresh from surviving card deliveries, with regression coverage.