### PR TITLE
fix(cli): guard inline chat send/ask bodies against shell residue + steer rich bodies to -F/stdin

### DIFF
--- a/apps/cli/src/__tests__/chat-send-shell-residue-guard.test.ts
+++ b/apps/cli/src/__tests__/chat-send-shell-residue-guard.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { looksLikeHeredocResidueBody, looksLikeJsonWrappedBody } from "../commands/chat/_shared/io.js";
+
+/**
+ * Pins the inline `chat send` / `chat ask` shell-residue guards. When a model
+ * composes a body through a heredoc or `JSON.stringify` and the shell collapses
+ * it, the CLI receives a recognisable wreck — a bare `@EOF` delimiter (the
+ * reported screenshot) or a quote-wrapped `"...\n..."` row. These predicates
+ * reject exactly those shapes BEFORE anything is sent, while leaving real
+ * messages — including ones that merely mention `<<EOF` / `@EOF` — sendable.
+ */
+describe("looksLikeHeredocResidueBody", () => {
+  it("matches the screenshot shape — a lone @-prefixed delimiter", () => {
+    expect(looksLikeHeredocResidueBody("@EOF")).toBe(true);
+    expect(looksLikeHeredocResidueBody("  @EOF  ")).toBe(true);
+  });
+
+  it("matches bare common terminators, case-insensitively", () => {
+    expect(looksLikeHeredocResidueBody("EOF")).toBe(true);
+    expect(looksLikeHeredocResidueBody("eof")).toBe(true);
+    expect(looksLikeHeredocResidueBody("EOT")).toBe(true);
+    expect(looksLikeHeredocResidueBody("HEREDOC")).toBe(true);
+  });
+
+  it("matches a leaked heredoc opener line", () => {
+    expect(looksLikeHeredocResidueBody("<<EOF")).toBe(true);
+    expect(looksLikeHeredocResidueBody("<<-'END'")).toBe(true);
+    expect(looksLikeHeredocResidueBody("<< END")).toBe(true);
+  });
+
+  it("leaves a real message that merely mentions a delimiter alone", () => {
+    // qa's adversarial smoke body carries <<EOF / @EOF as tokens — must send.
+    expect(looksLikeHeredocResidueBody("heredoc-like text: <<EOF and @EOF here")).toBe(false);
+    expect(looksLikeHeredocResidueBody("the heredoc terminator EOF goes on its own line")).toBe(false);
+  });
+
+  it("leaves short legitimate all-caps replies alone", () => {
+    for (const ok of ["OK", "LGTM", "DONE", "WIP", "TODO", "FYI", "END."]) {
+      expect(looksLikeHeredocResidueBody(ok)).toBe(false);
+    }
+  });
+
+  it("does not match empty / whitespace", () => {
+    expect(looksLikeHeredocResidueBody("")).toBe(false);
+    expect(looksLikeHeredocResidueBody("   ")).toBe(false);
+  });
+});
+
+describe("looksLikeJsonWrappedBody", () => {
+  it("matches a JSON.stringify wrapper with a single escaped newline", () => {
+    expect(looksLikeJsonWrappedBody('"@x line1\\nline2"')).toBe(true);
+    expect(looksLikeJsonWrappedBody('  "@alice ping\\nthanks"  ')).toBe(true);
+  });
+
+  it("leaves a plain quoted phrase (no escaped newline) alone", () => {
+    expect(looksLikeJsonWrappedBody('"hello world"')).toBe(false);
+    expect(looksLikeJsonWrappedBody('he said "hi" then left')).toBe(false);
+  });
+
+  it("leaves a real-newline body alone — that arrived intact", () => {
+    expect(looksLikeJsonWrappedBody('"line1\nline2"')).toBe(false);
+  });
+
+  it("leaves an unquoted body alone", () => {
+    expect(looksLikeJsonWrappedBody("line1\\nline2")).toBe(false);
+  });
+});

--- a/apps/cli/src/commands/chat/_shared/io.ts
+++ b/apps/cli/src/commands/chat/_shared/io.ts
@@ -90,6 +90,97 @@ export function looksLikeEscapedNewlineBody(body: string): boolean {
 }
 
 /**
+ * Detect an inline body that is the residue of a collapsed heredoc — the value
+ * the shell actually handed the CLI is a bare heredoc delimiter (the reported
+ * `@EOF` screenshot) rather than the intended markdown. The shell mangled the
+ * body before the CLI ran, so this is the one inline malformation that survives
+ * as a recognisable shape we can fail loudly on.
+ *
+ * Deliberately whole-body and narrow, to keep prose that merely *mentions* a
+ * delimiter sendable:
+ * - the ENTIRE trimmed body is a lone, optionally `@`-prefixed common heredoc
+ *   terminator (`@EOF`, `EOF`, `EOT`, `HEREDOC`), or
+ * - the ENTIRE trimmed body is a lone heredoc *opener* line that leaked
+ *   verbatim (`<<EOF`, `<<-'END'`).
+ * A larger message that contains `<<EOF` / `@EOF` as one token among others is
+ * left alone — and any such rich body should go through `-F`/stdin, which is
+ * never checked.
+ */
+export function looksLikeHeredocResidueBody(body: string): boolean {
+  const trimmed = body.trim();
+  if (trimmed.length === 0) return false;
+  if (/^@?(?:EOF|EOT|HEREDOC)$/i.test(trimmed)) return true;
+  if (/^<<-?\s*['"]?[A-Za-z_]\w*['"]?$/.test(trimmed)) return true;
+  return false;
+}
+
+/**
+ * Detect an inline body that was `JSON.stringify`-wrapped (Issue #389): the
+ * shell passed a value wrapped in outer double quotes whose newlines are the
+ * two-character `\n` escape — e.g. `"@x line1\nline2"`. The UI renders the
+ * literal quotes and `\n` tokens instead of markdown.
+ *
+ * `looksLikeEscapedNewlineBody` already rejects the ≥2-escape shape; this
+ * catches the single-escape wrapper it misses. Whole-body and inline-only: a
+ * body that legitimately quotes a phrase but carries no `\n` escape is left
+ * alone (and a rich body belongs on `-F`/stdin, which is never checked).
+ */
+export function looksLikeJsonWrappedBody(body: string): boolean {
+  const trimmed = body.trim();
+  if (trimmed.length < 4) return false;
+  if (!(trimmed.startsWith('"') && trimmed.endsWith('"'))) return false;
+  if (trimmed.includes("\n")) return false;
+  return /\\n/.test(trimmed);
+}
+
+/**
+ * Guard an inline `chat send` / `chat ask` body against the two shell-residue
+ * shapes the CLI can still recognise after the shell has already mangled the
+ * argument: a collapsed-heredoc delimiter (`@EOF`) and a `JSON.stringify`
+ * wrapper. Mirrors {@link guardInlineDescription} — prints a copyable retry to
+ * stderr, then `fail()`s (exit 2). Only ever called for an inline `[message]`;
+ * `-F`/stdin bodies reach the server verbatim and are never checked.
+ */
+export function guardInlineShellResidue(body: string, opts: { command: "send" | "ask" }): void {
+  const bin = channelConfig.binName;
+  const cmd = `chat ${opts.command}`;
+  if (looksLikeHeredocResidueBody(body)) {
+    print.line(
+      `${cmd}: the message body is a bare heredoc delimiter (\`${body.trim()}\`) — a heredoc that collapsed in the ` +
+        "shell, so the intended markdown never reached the argument. Send the real body via stdin or a file:\n\n" +
+        `  cat <<'EOF' | ${bin} ${cmd} <name> -f markdown\n` +
+        "  your real message\n" +
+        "  EOF\n\n" +
+        `(or: ${bin} ${cmd} <name> -f markdown -F <file>)\n\n`,
+    );
+    fail(
+      "HEREDOC_RESIDUE",
+      `Inline message body is a bare heredoc delimiter (\`${body.trim()}\`) — the heredoc collapsed before the CLI ` +
+        "ran, so the intended body was lost. Resend the real body via stdin/heredoc or --message-file (copyable " +
+        "form printed above).",
+      2,
+    );
+  }
+  if (looksLikeJsonWrappedBody(body)) {
+    print.line(
+      `${cmd}: the message body looks JSON-stringified — wrapped in outer quotes with \\n escapes — so the UI would ` +
+        "render literal quotes and `\\n` text instead of markdown. Pass the raw string via stdin or a file:\n\n" +
+        `  cat <<'EOF' | ${bin} ${cmd} <name> -f markdown\n` +
+        "  first line\n" +
+        "\n" +
+        "  **second** line\n" +
+        "  EOF\n\n",
+    );
+    fail(
+      "JSON_WRAPPED_BODY",
+      "Inline message body looks JSON-stringified (outer quotes + \\n escapes) — pass the raw markdown string via " +
+        "stdin/heredoc or --message-file instead (copyable form printed above).",
+      2,
+    );
+  }
+}
+
+/**
  * Guard an inline `--description` (chat update / create) exactly the way
  * `chat send` guards a message body. A chat description is authored markdown,
  * surfaced verbatim in the chat sidebar and in every agent's prompt. When its

--- a/apps/cli/src/commands/chat/ask.ts
+++ b/apps/cli/src/commands/chat/ask.ts
@@ -5,7 +5,7 @@ import { channelConfig } from "../../core/channel.js";
 import { captureOutboundDocs } from "../../core/doc-capture.js";
 import { print } from "../../core/output.js";
 import { createSdk, handleSdkError } from "../_shared/local-agent.js";
-import { looksLikeEscapedNewlineBody, readMessageBody, readStdin } from "./_shared/io.js";
+import { guardInlineShellResidue, looksLikeEscapedNewlineBody, readMessageBody, readStdin } from "./_shared/io.js";
 import { buildRequestMetadata } from "./_shared/request.js";
 
 interface AskOptions {
@@ -88,6 +88,13 @@ export function registerChatAskCommand(chat: Command): void {
               "long unformatted line. Resend the body via stdin/heredoc with real newlines.",
             2,
           );
+        }
+
+        // Catch the two shell-residue shapes the CLI can still recognise in an
+        // inline body: a collapsed-heredoc delimiter (`@EOF`) and a
+        // JSON.stringify wrapper. Inline-only — `-F`/stdin is never checked.
+        if (inlineBody !== undefined) {
+          guardInlineShellResidue(inlineBody, { command: "ask" });
         }
 
         const content =

--- a/apps/cli/src/commands/chat/send.ts
+++ b/apps/cli/src/commands/chat/send.ts
@@ -5,7 +5,7 @@ import { channelConfig } from "../../core/channel.js";
 import { captureOutboundDocs } from "../../core/doc-capture.js";
 import { print } from "../../core/output.js";
 import { createSdk, handleSdkError } from "../_shared/local-agent.js";
-import { looksLikeEscapedNewlineBody, readMessageBody, readStdin } from "./_shared/io.js";
+import { guardInlineShellResidue, looksLikeEscapedNewlineBody, readMessageBody, readStdin } from "./_shared/io.js";
 
 interface SendOptions {
   format: MessageFormat;
@@ -98,6 +98,13 @@ export function registerChatSendCommand(chat: Command): void {
               "printed above; stdin is not checked, so it also sends intentional literal \\n text).",
             2,
           );
+        }
+
+        // Catch the two shell-residue shapes the CLI can still recognise in an
+        // inline body: a collapsed-heredoc delimiter (`@EOF`) and a
+        // JSON.stringify wrapper. Inline-only — `-F`/stdin is never checked.
+        if (inlineBody !== undefined) {
+          guardInlineShellResidue(inlineBody, { command: "send" });
         }
 
         const content =

--- a/packages/client/src/__tests__/agent-briefing.test.ts
+++ b/packages/client/src/__tests__/agent-briefing.test.ts
@@ -458,8 +458,13 @@ describe("buildAgentBriefing — # Working in First Tree subsections", () => {
     expect(briefing).not.toMatch(/\boutput nothing\b/);
 
     // Issue #389: pin the anti-double-encode rule.
-    expect(briefing).toContain("Content rules (Issue #389)");
+    expect(briefing).toContain("Issue #389");
     expect(briefing).toContain("JSON.stringify");
+    // Pin the hard `-F`/stdin rule for non-trivial bodies (the shell-quote
+    // regression fix): mandatory wording, not a soft "prefer".
+    expect(briefing).toContain("MUST go through");
+    expect(briefing).toMatch(/-F|stdin/);
+    expect(briefing).toContain("-f markdown");
   });
 
   it("interpolates the agent home into the Working Directory block", () => {

--- a/packages/client/src/__tests__/agent-briefing.test.ts
+++ b/packages/client/src/__tests__/agent-briefing.test.ts
@@ -462,14 +462,19 @@ describe("buildAgentBriefing — # Working in First Tree subsections", () => {
     expect(briefing).toContain("end the turn without sending");
     expect(briefing).not.toMatch(/\boutput nothing\b/);
 
-    // Issue #389: pin the anti-double-encode rule.
+    // Issue #389: pin the anti-double-encode rule (rationale now in the
+    // Communication block, where the shell-mechanics WHY was moved).
     expect(briefing).toContain("Issue #389");
     expect(briefing).toContain("JSON.stringify");
-    // Pin the hard `-F`/stdin rule for non-trivial bodies (the shell-quote
-    // regression fix): mandatory wording, not a soft "prefer".
-    expect(briefing).toContain("MUST go through");
+    // Pin the `-F`/stdin body rule (the shell-quote regression fix): a concise
+    // affirmative principle up top, with the detailed shell-mechanics rationale
+    // (heredoc residue `@EOF`, the CLI cannot repair it) moved down into the
+    // Communication block.
+    expect(briefing).toMatch(/Form a rich body as a file or stdin/i);
     expect(briefing).toMatch(/-F|stdin/);
     expect(briefing).toContain("-f markdown");
+    expect(briefing).toMatch(/Why a rich body goes through a file or stdin/i);
+    expect(briefing).toContain("@EOF");
   });
 
   it("interpolates the agent home into the Working Directory block", () => {

--- a/packages/client/src/runtime/agent-briefing.ts
+++ b/packages/client/src/runtime/agent-briefing.ts
@@ -339,10 +339,24 @@ You are running inside **First Tree**, a messaging platform for agent teams.
   silence just reads as no reply. Between agents it is the opposite: if a
   wake-up leaves nothing new to act on, end the turn without sending — a
   courteous "got it" between two agents is how loops start.
-- **Content rules (Issue #389):** pass content as a **raw string** — never
-  \`JSON.stringify\` it first. Wrapping in outer quotes + \`\\n\` escapes
-  produces a literal \`"@x ...\\n..."\` row that the UI cannot render as
-  markdown.`);
+- **Non-trivial bodies MUST go through \`-F\`/stdin — never an inline shell
+  argument.** A \`chat send\`/\`chat ask\` body and a \`chat update --description\`
+  are markdown: full of backticks, quotes, \`$\`, and newlines — exactly the
+  characters the shell rewrites *before the CLI ever runs*. Inline \`"..."\` lets
+  the shell execute backticks / \`$()\`, expand \`$VAR\`, truncate on a quote, or
+  collapse a botched heredoc into residue like a bare \`@EOF\` — silent
+  corruption the CLI cannot see or repair. So any body that contains backticks,
+  quotes, \`$\`, more than one line, or markdown structure goes through a file or
+  stdin: \`${bin} chat send <name> -f markdown -F <file>\`, or pipe it —
+  \`cat <file> | ${bin} chat send <name> -f markdown\` (\`chat update\` reads
+  stdin via \`--description -\`). Reserve inline \`"..."\` for a short, plain,
+  single-line string with no shell metacharacters.
+- **Never \`JSON.stringify\` a body (Issue #389):** pass content as a **raw
+  string**. Outer quotes + \`\\n\` escapes produce a literal \`"@x ...\\n..."\`
+  row the UI cannot render as markdown.
+- **Markdown bodies need \`-f markdown\`:** the default format is \`text\`, which
+  shows \`**bold**\`, lists, and \`\`code\`\` as literal characters. Pass
+  \`-f markdown\` whenever the body is markdown.`);
 
   blocks.push(workingDirectoryBlock(opts.agentHome));
 

--- a/packages/client/src/runtime/agent-briefing.ts
+++ b/packages/client/src/runtime/agent-briefing.ts
@@ -339,24 +339,15 @@ You are running inside **First Tree**, a messaging platform for agent teams.
   silence just reads as no reply. Between agents it is the opposite: if a
   wake-up leaves nothing new to act on, end the turn without sending — a
   courteous "got it" between two agents is how loops start.
-- **Non-trivial bodies MUST go through \`-F\`/stdin — never an inline shell
-  argument.** A \`chat send\`/\`chat ask\` body and a \`chat update --description\`
-  are markdown: full of backticks, quotes, \`$\`, and newlines — exactly the
-  characters the shell rewrites *before the CLI ever runs*. Inline \`"..."\` lets
-  the shell execute backticks / \`$()\`, expand \`$VAR\`, truncate on a quote, or
-  collapse a botched heredoc into residue like a bare \`@EOF\` — silent
-  corruption the CLI cannot see or repair. So any body that contains backticks,
-  quotes, \`$\`, more than one line, or markdown structure goes through a file or
-  stdin: \`${bin} chat send <name> -f markdown -F <file>\`, or pipe it —
-  \`cat <file> | ${bin} chat send <name> -f markdown\` (\`chat update\` reads
-  stdin via \`--description -\`). Reserve inline \`"..."\` for a short, plain,
-  single-line string with no shell metacharacters.
-- **Never \`JSON.stringify\` a body (Issue #389):** pass content as a **raw
-  string**. Outer quotes + \`\\n\` escapes produce a literal \`"@x ...\\n..."\`
-  row the UI cannot render as markdown.
-- **Markdown bodies need \`-f markdown\`:** the default format is \`text\`, which
-  shows \`**bold**\`, lists, and \`\`code\`\` as literal characters. Pass
-  \`-f markdown\` whenever the body is markdown.`);
+- **Form a rich body as a file or stdin, so the markdown reaches the chat
+  verbatim.** Write a \`chat send\`/\`chat ask\` body — or a \`chat update
+  --description\` — to a file and send it with \`-F\`, or pipe it via stdin
+  (\`chat update\` reads \`--description -\`): \`${bin} chat send <name> -f markdown -F <file>\`.
+  Reserve inline \`"..."\` for a short, plain, single-line string. Markdown needs
+  \`-f markdown\` (the default \`text\` shows \`**bold**\`, lists, and \`\`code\`\`
+  as literal characters), and the body is a raw string — never \`JSON.stringify\`
+  it. Why a file/stdin is the verbatim-safe path — and the Issue #389
+  double-encode trap — is in \`## Communication\`.`);
 
   blocks.push(workingDirectoryBlock(opts.agentHome));
 
@@ -675,7 +666,18 @@ message in the chat.
 
 Every \`chat send\` names a recipient — there is no no-mention send. A group
 chat rejects a message that addresses no one; pass \`<name>\` to @mention the
-recipient.`;
+recipient.
+
+**Why a rich body goes through a file or stdin.** An inline \`"..."\` body is
+parsed by the shell before the CLI runs: it executes backticks and \`$(...)\`,
+expands \`$VAR\`, ends the string early on a quote, and collapses a botched
+heredoc into residue like a bare \`@EOF\` — silent corruption the CLI cannot see
+or repair. A file (\`-F <path>\`) or a pipe (stdin) hands the bytes to the CLI
+untouched, so backticks, quotes, \`$\`, and newlines arrive verbatim; \`chat
+update\` takes its description the same way via \`--description -\`. For the same
+reason pass the body as a raw string and never \`JSON.stringify\` it — outer
+quotes plus \`\\n\` escapes persist as a literal \`"@x ...\\n..."\` row the UI
+cannot render as markdown (Issue #389).`;
 }
 
 function workspaceCollaborationBlock(bin: string): string {


### PR DESCRIPTION
## Why

Recurring "weird shell-quote bugs" (the reported screenshot: a message delivered as a bare `@EOF`) all share one root cause: an agent composes a non-trivial `chat send`/`chat ask` body as an **inline shell argument**, and the shell executes backticks/`$()`, expands `$VAR`, truncates on a quote, or collapses a botched heredoc **before the CLI process even starts**. The CLI receives the already-mangled string and cannot recover it.

QA verified (local isolated dev stack) that the safe path (`-F`/stdin) preserves every adversarial body byte, and that `ESCAPED_NEWLINES` already guards inline literal `\n\n` — but unsafe inline, **heredoc residue (`@EOF`), and JSON-stringified wrappers had no guard**.

> Rebased on `main` after #1325 (which frames `chat send`/`ask`/`update` as real CLI tool calls, stated affirmatively as principles). The behavior-layer wording below was reworked to match that affirmative style — see the **What** section.

## What

Two complementary fixes, split by which layer can actually solve each class:

### Behavioral (the durable fix) — `packages/client/src/runtime/agent-briefing.ts`
> **⚠️ @yuezengwu: this is the behavior-layer-rule hunk you asked to review manually.**

Per your pick of option **(c)**: the top-level *Working in First Tree* block now carries **one concise affirmative principle** — *form a rich body as a file or stdin so the markdown reaches the chat verbatim*; reserve inline `"..."` for a short, plain, single-line string; pass `-f markdown` for markdown; the body is a raw string, never `JSON.stringify`d (#389). The detailed **shell-mechanics rationale** (backtick/`$()` exec, `$VAR` expansion, quote truncation, heredoc collapse to a bare `@EOF` the CLI cannot repair, and the #389 double-encode trap) **moves down into the Communication block**, where #1325 already frames the chat commands as real tool calls.

This affirmative principle is the only thing that closes the shell-layer classes the CLI structurally cannot detect (a *successful* `$()` substitution produces clean-looking text).

### Fail-loud CLI guards — `apps/cli/src/commands/chat/{_shared/io.ts,send.ts,ask.ts}`
For the two residue shapes the CLI **can** still recognise after mangling:
- **`HEREDOC_RESIDUE`** — inline body is a collapsed heredoc delimiter (`@EOF`, `EOF`, `EOT`, `HEREDOC`, `<<EOF`). Catches the reported screenshot.
- **`JSON_WRAPPED_BODY`** — inline body is a `JSON.stringify` wrapper (`"@x line1\nline2"`) that the existing ≥2-escape `ESCAPED_NEWLINES` guard misses (single-escape case).

Both mirror the existing `ESCAPED_NEWLINES` guard: **whole-body, inline-only**, with a copyable stdin/heredoc retry. `-F`/stdin bodies and larger messages that merely *mention* `<<EOF`/`@EOF` (e.g. QA's adversarial smoke marker) are never touched.

## Verification
- New unit tests pin both predicates incl. negatives (`LGTM`/`DONE`/delimiter-mentioning bodies stay sendable).
- Briefing test re-pinned to the affirmative principle + the moved rationale (`agent-briefing.test.ts`).
- Built-CLI smoke: `@EOF`→`HEREDOC_RESIDUE`, `<<EOF`→`HEREDOC_RESIDUE`, `"@x ...\n..."`→`JSON_WRAPPED_BODY`, `LGTM`→passes, sentence-mentioning-`<<EOF`→passes.
- Targeted suites green after the #1325 merge: `agent-briefing` (36), CLI guards (`chat-send-shell-residue` / `-message-file` / `-escaped-newline`, 30). Full CI runs the rest.
- **QA re-verifying** the bad-case coverage matrix against this PR's build in the isolated dev stack.

## Deliberately NOT in this PR (needs a product decision)
- **doc-capture `*.md` false-positive** (QA finding: real agent-runtime replies mentioning `body.md`/`CLAUDE.md` get `documentContext.failedMentions`). The bare-`.md` scanner is **intentionally aggressive** — it linkifies even backtick-wrapped workspace paths by design. Narrowing it (e.g. drop *unresolved* bare tokens from `failedMentions`) is reasonable but changes a deliberate feature, so I'm flagging it rather than bundling it. Happy to do it as a follow-up if we agree on the target behavior.
- **`-f text` default footgun** — addressed here via the briefing `-f markdown` reminder rather than flipping the default (flipping would mis-render intentional plain-text/code sends).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
