### PR TITLE
fix(client): frame chat send/ask/update as real CLI tool calls so replies get delivered

### DIFF
--- a/packages/client/src/__tests__/agent-briefing.test.ts
+++ b/packages/client/src/__tests__/agent-briefing.test.ts
@@ -445,7 +445,12 @@ describe("buildAgentBriefing — # Working in First Tree subsections", () => {
     expect(briefing).toMatch(/This is your \*\*console\*\*/i);
     expect(briefing).toMatch(/the outbox: the explicit\s+commands/i);
     expect(briefing).toMatch(/places your message in front of\s+a teammate/i);
-    expect(briefing).toMatch(/complete once you deliver your reply through the\s+outbox/i);
+    // The outbox-completion rule is scoped to HUMAN-directed turns, so it never
+    // contradicts the adjacent agent no-courtesy-send brake (codex review R5):
+    // an agent no-op wake-up must still be allowed to end without a send.
+    expect(briefing).toMatch(/A human-directed\s+turn is complete once you deliver your reply through the outbox/i);
+    expect(briefing).toMatch(/an agent\s+wake-up with nothing new to act on can end without a send/i);
+    expect(briefing).not.toMatch(/teammate triggered is complete/i);
     // The retired mirror term stays out — there is no `agent-final-text` row
     // post-#1190.
     expect(briefing).not.toContain("agent-final-text");

--- a/packages/client/src/__tests__/agent-briefing.test.ts
+++ b/packages/client/src/__tests__/agent-briefing.test.ts
@@ -428,29 +428,29 @@ describe("buildAgentBriefing — # Working in First Tree subsections", () => {
     expect(briefing).toContain("first-tree chat update --description");
     expect(briefing).not.toMatch(/server rejects a `?chat send`? to a human/);
 
-    // yuezengwu 2026-06-23: rebind, rather than negate, the base Claude Code
-    // harness ("all text you output … is displayed to the user"). The brief
-    // pins the harness's "user" to the First Tree runtime and frames teammates
-    // as a separate audience reached only by an explicit send (console vs
-    // outbox). Keep the PRECISE product boundary (codex R1/R5): the output
-    // stream is not an addressed reply, yet it is NOT private — a one-line
-    // preview surfaces as live session activity (`liveActivity.detail` /
-    // `turnText`) to viewers. So communication is always an explicit send.
-    expect(briefing).toMatch(/the "user" the Claude Code harness writes to is the First Tree runtime/i);
-    expect(briefing).toMatch(/reasoning\/activity\s+trace/i);
-    expect(briefing).toMatch(/never delivered to\s+anyone as a message/i);
-    expect(briefing).toMatch(/not\s+private/i);
+    // yuezengwu 2026-06-26: rebind, rather than negate, the agent's native
+    // output model with one provider-neutral boundary rule — everything apart
+    // from an explicit chat command is the console (addressed to the First Tree
+    // runtime); the chat commands are the outbox (the only path to a teammate).
+    // Stating it by exclusion binds the turn-closing message (Codex's `final`
+    // prior) without naming a provider. Keep the PRECISE product boundary
+    // (codex R1/R5): the output is not an addressed reply, yet it is visible —
+    // a one-line preview surfaces as live session activity to viewers.
+    expect(briefing).toMatch(/the "user" your underlying agent addresses is the First\s+Tree runtime/i);
+    expect(briefing).toMatch(/Everything you produce apart from an explicit chat\s+command/i);
+    expect(briefing).toMatch(/message that closes your turn/i);
+    expect(briefing).toMatch(/live reasoning\/activity trace/i);
+    expect(briefing).toMatch(/treating it as visible/i);
     expect(briefing).toMatch(/live session activity/i);
-    expect(briefing).toMatch(/console; `?chat send`? is the outbox/i);
-    expect(briefing).toMatch(/has sent\s+nothing/);
+    expect(briefing).toMatch(/This is your \*\*console\*\*/i);
+    expect(briefing).toMatch(/the outbox: the explicit\s+commands/i);
+    expect(briefing).toMatch(/places your message in front of\s+a teammate/i);
+    expect(briefing).toMatch(/complete once you deliver your reply through the\s+outbox/i);
     // The retired mirror term stays out — there is no `agent-final-text` row
     // post-#1190.
     expect(briefing).not.toContain("agent-final-text");
-    // Must NOT overclaim invisibility/privacy: the output stream is NOT
-    // undelivered-to-everyone (it shows as live activity), and chat send is NOT
-    // the sole channel a teammate ever sees (`chat ask` / `chat update` too).
-    expect(briefing).not.toMatch(/does not deliver it to anyone/i);
-    expect(briefing).not.toMatch(/only ever sees what you `?chat send`?/);
+    // Provider-neutral: the brief no longer names a specific harness.
+    expect(briefing).not.toMatch(/Claude Code harness/i);
 
     // Courtesy-send guard stays — the brake is on the *send* side.
     expect(briefing).toContain("Don't fire a courtesy");
@@ -666,6 +666,15 @@ describe("buildAgentBriefing — # Working in First Tree subsections", () => {
   it("emits Communication, Workspace Collaboration, Asking Humans, Chat Topic & Description, and CLI Overview subsections", () => {
     const briefing = buildAgentBriefing(makeOpts());
     expect(briefing).toContain("## Communication");
+    // Action classification (the 07:22 root fix): reply transport is framed as
+    // a real command you run with the chat CLI (binds "reply" to executing a
+    // command, per real-agent QA 2026-06-26), and stated as a principle so a
+    // "hold off / discuss only" instruction scopes business actions and never
+    // suppresses the reply.
+    expect(briefing).toMatch(/is\s+a real command you run with the chat CLI/i);
+    expect(briefing).toMatch(/running it delivers your words to a teammate/i);
+    expect(briefing).toMatch(/A business action\s+is anything that changes the workspace or the world/i);
+    expect(briefing).toMatch(/hold off from acting/i);
     // Communication routing: `chat send` reaches any teammate (a plain send to a
     // human is a free reply); a human also has `chat ask` (decisions) and
     // `chat update --description` (progress). The courtesy-send guard prevents

--- a/packages/client/src/__tests__/chat-context.test.ts
+++ b/packages/client/src/__tests__/chat-context.test.ts
@@ -81,6 +81,14 @@ describe("renderRuntimeOutputContract", () => {
     expect(contract).toMatch(/hold off from acting/i);
   });
 
+  it("scopes the outbox-completion rule to human-directed turns, preserving the agent no-op exception (codex review R5)", () => {
+    expect(contract).toMatch(/the way you finish a human-directed turn/i);
+    expect(contract).toMatch(/an agent wake-up with nothing new to act on can end without a send/i);
+    // Must not broaden completion to every teammate-triggered turn — that would
+    // contradict the agent no-courtesy-send loop guard.
+    expect(contract).not.toMatch(/teammate-triggered turn/i);
+  });
+
   it("keeps the visibility boundary accurate — visible activity, not a delivered message", () => {
     expect(contract).toMatch(/treat it as visible/i);
     // Must not over-claim that nobody ever sees the trace.

--- a/packages/client/src/__tests__/chat-context.test.ts
+++ b/packages/client/src/__tests__/chat-context.test.ts
@@ -44,27 +44,45 @@ function mkChatDetail(overrides?: Partial<ChatDetail>): ChatDetail {
 }
 
 describe("renderRuntimeOutputContract", () => {
-  // The contract resolves the base-harness conflict by REBINDING "the user"
-  // (runtime, not teammates) rather than negating "output is displayed to the
-  // user". Pin the three load-bearing framings + the accurate visibility
-  // boundary so a future edit can't silently gut or over-claim them.
+  // The contract resolves the native-output conflict by REBINDING "the user"
+  // (runtime, not teammates) with one provider-neutral boundary rule —
+  // everything apart from an explicit chat command is the console — rather than
+  // negating "output is a reply". Pin the load-bearing framings + the accurate
+  // visibility boundary so a future edit can't silently gut or over-claim them.
   const contract = renderRuntimeOutputContract();
 
-  it("rebinds the harness 'user' to the First Tree runtime", () => {
-    expect(contract).toMatch(/that user is the First Tree runtime/i);
+  it("rebinds 'the user' to the First Tree runtime, provider-neutrally", () => {
+    expect(contract).toMatch(/the "user" your underlying agent addresses/i);
+    expect(contract).toMatch(/is the First Tree runtime, an automated operator/i);
+    // Stays provider-agnostic: names no specific harness.
+    expect(contract).not.toMatch(/Claude Code harness/i);
   });
 
-  it("frames reach as an explicit outbound publish (console vs outbox)", () => {
-    expect(contract).toMatch(/outbound publish to the chat service/i);
-    expect(contract).toMatch(/output stream is the console; `chat send` is the outbox/i);
-    expect(contract).toContain("`chat send`");
-    expect(contract).toContain("`chat ask`");
-    expect(contract).toContain("`chat update`");
+  it("draws the boundary by exclusion and binds the turn-closing message", () => {
+    expect(contract).toMatch(/everything you produce apart from running a chat command/i);
+    expect(contract).toMatch(/the message that closes your turn/i);
+    expect(contract).toMatch(/This is your console/i);
   });
 
-  it("keeps the visibility boundary accurate — not private, but never a delivered message", () => {
-    expect(contract).toMatch(/it is not private/i);
-    expect(contract).toMatch(/never delivered to anyone as a message/i);
+  it("frames reach as running the chat CLI command-line tool, with executable signatures", () => {
+    expect(contract).toMatch(/running the chat CLI as a command-line tool — a real command you run/i);
+    expect(contract).toMatch(/running one of these commands is what places your message in front of a teammate/i);
+    expect(contract).toMatch(
+      /Describing a reply in your output records words on the console, while running the command delivers them/i,
+    );
+    // Executable invocation signatures (the tool surface), bin from the binding.
+    expect(contract).toContain('first-tree chat send <name> "<message>"');
+    expect(contract).toContain('first-tree chat ask <human> "<question>"');
+    expect(contract).toContain('first-tree chat update --description "<status>"');
+  });
+
+  it("classifies reply transport apart from business actions (hold-off carve-out)", () => {
+    expect(contract).toMatch(/running a chat command delivers your words and changes nothing else/i);
+    expect(contract).toMatch(/hold off from acting/i);
+  });
+
+  it("keeps the visibility boundary accurate — visible activity, not a delivered message", () => {
+    expect(contract).toMatch(/treat it as visible/i);
     // Must not over-claim that nobody ever sees the trace.
     expect(contract).not.toMatch(/no one (?:can )?sees?/i);
   });

--- a/packages/client/src/__tests__/codex-app-server-handler.test.ts
+++ b/packages/client/src/__tests__/codex-app-server-handler.test.ts
@@ -1707,6 +1707,29 @@ describe("codex app-server briefing-update notice", () => {
     await handler.shutdown();
   });
 
+  it("prepends the same provider-neutral runtime contract onto every turn input (immediate-tail salience)", async () => {
+    // Codex has no persistent system-prompt channel (unlike the Claude path's
+    // `systemPrompt.append`), so the same runtime contract both providers get
+    // must ride every Codex turn input — keeping the console/outbox boundary
+    // next to where a "discuss only / hold off" instruction lands. Without this
+    // the rule lives only in the thread-init AGENTS read and loses salience.
+    const fake = new FakeAppServerClient();
+    const handler = makeHandler(fake);
+    const ctx = makeContext({ finishTurn: async () => {} });
+
+    const startPromise = handler.start(makeMessage("m1", "先讨论下，不动手"), ctx);
+    await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
+
+    const start = fake.requests.find((request) => request.method === "turn/start");
+    const input = JSON.stringify(start?.params ?? {});
+    expect(input).toContain("first-tree-runtime-contract");
+    expect(input).toContain("running the chat CLI as a command-line tool");
+
+    completeTurn(fake, "turn-1", "ok");
+    await startPromise;
+    await handler.shutdown();
+  });
+
   it("adds no notice when the briefing is unchanged since the session last ran a turn", async () => {
     // First session start seeds the briefing baseline for this thread id at the
     // shared agent home (keyed off `workspaceRoot`).

--- a/packages/client/src/__tests__/codex-bootstrap.test.ts
+++ b/packages/client/src/__tests__/codex-bootstrap.test.ts
@@ -142,12 +142,15 @@ describe("bootstrapWorkspace — codex briefing + workspace marker", () => {
     expect(briefing).toContain("first-tree-staging chat send");
     // `chat send` reaches any teammate — agent or human; a human also has
     // `chat ask` (decisions) / `chat update --description` (progress). The
-    // output stream is reframed as a reasoning/activity trace read by the First
-    // Tree runtime (the harness's "user"), not the teammates — but the retired
-    // `agent-final-text` mirror term must NOT survive (post-#1190).
+    // output is reframed, provider-neutrally, as a reasoning/activity trace read
+    // by the First Tree runtime ("the user" the agent addresses), not the
+    // teammates — but the retired `agent-final-text` mirror term must NOT
+    // survive (post-#1190), and the brief names no Claude-specific harness so a
+    // Codex agent maps it onto its own `commentary` / `final` channels.
     expect(briefing).toContain("first-tree-staging chat ask <human>");
     expect(briefing).toContain("first-tree-staging chat update --description");
-    expect(briefing).toMatch(/the "user" the Claude Code harness writes to is the First Tree runtime/i);
+    expect(briefing).toMatch(/the "user" your underlying agent addresses is the First\s+Tree runtime/i);
+    expect(briefing).not.toMatch(/Claude Code harness/i);
     expect(briefing).not.toContain("agent-final-text");
     // The new Skill Map and Context Tree section are now part of every
     // briefing — pin both so a regenerator dropping them doesn't slip past

--- a/packages/client/src/handlers/codex/app-server/index.ts
+++ b/packages/client/src/handlers/codex/app-server/index.ts
@@ -15,7 +15,7 @@ import {
 } from "../../../runtime/bootstrap.js";
 import { type CodexBinaryResolution, resolveCodexRuntimeBinary } from "../../../runtime/capabilities/codex.js";
 import { type ChatContext, fetchChatContext } from "../../../runtime/chat-context.js";
-import { renderChatContextPrompt } from "../../../runtime/chat-context-section.js";
+import { renderChatContextPrompt, renderRuntimeOutputContract } from "../../../runtime/chat-context-section.js";
 import {
   type ContextTreeAttribution,
   resolveContextTreeRelativePath,
@@ -1015,8 +1015,14 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
   function consumePendingChatContext(inputText: string): string {
     const chatPrompt = pendingChatContextPrompt;
     pendingChatContextPrompt = null;
-    if (!chatPrompt) return inputText;
-    return `${chatPrompt}\n\n${inputText}`;
+    // Codex has no persistent system-prompt channel (unlike the Claude path's
+    // `systemPrompt.append`), so the same provider-neutral runtime contract
+    // rides every turn input — keeping the console/outbox boundary in the
+    // immediate context tail where a "discuss only / hold off" instruction also
+    // lands. Prepended ahead of any chat-context block.
+    const contract = renderRuntimeOutputContract();
+    const prefix = chatPrompt ? `${contract}\n\n${chatPrompt}` : contract;
+    return `${prefix}\n\n${inputText}`;
   }
 
   async function createCurrentTurn(

--- a/packages/client/src/handlers/codex/sdk.ts
+++ b/packages/client/src/handlers/codex/sdk.ts
@@ -25,7 +25,7 @@ import {
   writeAgentBriefing,
 } from "../../runtime/bootstrap.js";
 import { type ChatContext, fetchChatContext } from "../../runtime/chat-context.js";
-import { renderChatContextPrompt } from "../../runtime/chat-context-section.js";
+import { renderChatContextPrompt, renderRuntimeOutputContract } from "../../runtime/chat-context-section.js";
 import {
   createCodexClientWithBinaryFallback,
   formatCodexBinaryMissingMessage,
@@ -548,9 +548,15 @@ export const createCodexSdkHandler: HandlerFactory = (config) => {
   function consumePendingChatContext(input: Input): Input {
     const chatPrompt = pendingChatContextPrompt;
     pendingChatContextPrompt = null;
-    if (!chatPrompt) return input;
-    if (typeof input === "string") return `${chatPrompt}\n\n${input}`;
-    return [{ type: "text", text: chatPrompt }, ...input];
+    // Codex has no persistent system-prompt channel (unlike the Claude path's
+    // `systemPrompt.append`), so the same provider-neutral runtime contract
+    // rides every turn input — keeping the console/outbox boundary in the
+    // immediate context tail where a "discuss only / hold off" instruction also
+    // lands. Prepended ahead of any chat-context block.
+    const contract = renderRuntimeOutputContract();
+    const prefix = chatPrompt ? `${contract}\n\n${chatPrompt}` : contract;
+    if (typeof input === "string") return `${prefix}\n\n${input}`;
+    return [{ type: "text", text: prefix }, ...input];
   }
 
   /**

--- a/packages/client/src/runtime/agent-briefing.ts
+++ b/packages/client/src/runtime/agent-briefing.ts
@@ -330,8 +330,9 @@ You are running inside **First Tree**, a messaging platform for agent teams.
   preview can surface as live session activity. This is your **console**.
 - **A teammate is reached through the outbox: the explicit commands
   \`chat send\`, \`chat ask\`, and \`chat update\`.** The console addresses the
-  runtime; the outbox places your message in front of a teammate. A turn that a
-  teammate triggered is complete once you deliver your reply through the outbox.
+  runtime; the outbox places your message in front of a teammate. A human-directed
+  turn is complete once you deliver your reply through the outbox; an agent
+  wake-up with nothing new to act on can end without a send.
 - **Reply to a human; don't fire a courtesy \`chat send\` to an agent.** A
   message a human directs at you gets a \`chat send\` reply before you end the
   turn — a human never auto-wakes from your reply, so there is no loop risk and

--- a/packages/client/src/runtime/agent-briefing.ts
+++ b/packages/client/src/runtime/agent-briefing.ts
@@ -322,17 +322,16 @@ You are running inside **First Tree**, a messaging platform for agent teams.
   to make an agent act, or to send a human a free reply / conversational answer.
   For a human you can also raise a tracked decision with \`${bin} chat ask
   <human>\`, or push progress with \`${bin} chat update --description\`.
-- **The "user" the Claude Code harness writes to is the First Tree runtime, not
-  your teammates.** Your output stream is recorded as a live reasoning/activity
-  trace — think, plan, and narrate there freely. It is not private (a one-line
-  preview can surface as live session activity), but it is never delivered to
-  anyone as a message. Your output is the console; \`chat send\` is the outbox.
-- **So reaching a teammate is always an explicit send.** Finishing your thoughts
-  writes the console; it does not send the outbox. Nothing reaches a teammate
-  until you run a command — \`chat send\` for a reply (and to make an agent act),
-  \`chat ask\` for a human decision, \`chat update --description\` for progress.
-  A turn that produces only working text has sent nothing — no reply, not a
-  terse one.
+- **Inside First Tree, the "user" your underlying agent addresses is the First
+  Tree runtime.** Everything you produce apart from an explicit chat command —
+  your reasoning, your progress, and the message that closes your turn alike —
+  is addressed to that runtime and recorded as a live reasoning/activity trace.
+  Think, plan, and narrate there freely, treating it as visible: a one-line
+  preview can surface as live session activity. This is your **console**.
+- **A teammate is reached through the outbox: the explicit commands
+  \`chat send\`, \`chat ask\`, and \`chat update\`.** The console addresses the
+  runtime; the outbox places your message in front of a teammate. A turn that a
+  teammate triggered is complete once you deliver your reply through the outbox.
 - **Reply to a human; don't fire a courtesy \`chat send\` to an agent.** A
   message a human directs at you gets a \`chat send\` reply before you end the
   turn — a human never auto-wakes from your reply, so there is no loop risk and
@@ -613,6 +612,15 @@ function communicationBlock(bin: string): string {
 intent-specific channels: \`chat ask\` (decisions) and \`chat update
 --description\` (progress). Decision guide (based on participant \`type\` in
 the Current Chat Context block):
+
+A reply-transport command — \`chat send\`, \`chat ask\`, or \`chat update\` — is
+a real command you run with the chat CLI, the same execution path you use for
+any other tool; running it delivers your words to a teammate. A business action
+is anything that changes the workspace or the world beyond that delivery. When a
+teammate asks you to hold off from acting, that scope governs changes to things,
+while running the chat CLI to deliver your reply stays the way you finish a
+human-directed turn, because that delivery changes nothing beyond placing your
+message in the chat.
 
 - **Replying to a human is required, not optional** → when a human directs a
   message at you, end the turn with one \`${bin} chat send <name> "..."\`

--- a/packages/client/src/runtime/chat-context-section.ts
+++ b/packages/client/src/runtime/chat-context-section.ts
@@ -99,7 +99,7 @@ export function renderRuntimeOutputContract(): string {
     `- \`${bin} chat update --description "<status>"\` — record status`,
     "The console addresses the runtime; running one of these commands is what places your message in front of a teammate. Describing a reply in your output records words on the console, while running the command delivers them.",
     "",
-    "So a request to hold off from acting scopes the business actions that change the workspace or the world — running a chat command delivers your words and changes nothing else, so it stays the way you finish a teammate-triggered turn.",
+    "So a request to hold off from acting scopes the business actions that change the workspace or the world — running a chat command delivers your words and changes nothing else, so it stays the way you finish a human-directed turn. (Replying to a human is required; an agent wake-up with nothing new to act on can end without a send.)",
     "</first-tree-runtime-contract>",
   ].join("\n");
 }

--- a/packages/client/src/runtime/chat-context-section.ts
+++ b/packages/client/src/runtime/chat-context-section.ts
@@ -1,4 +1,5 @@
 import type { ChatContext } from "./chat-context.js";
+import { getCliBinding } from "./cli-binding.js";
 
 /**
  * Render the per-chat "Current Chat Context" markdown section. This material
@@ -59,31 +60,46 @@ export function renderChatContextSection(chatContext: ChatContext | undefined): 
 }
 
 /**
- * Provider system-prompt contract that resolves a conflict between the base
- * Claude Code harness ("all text you output outside of tool calls is displayed
- * to the user") and First Tree's delivery model, where reaching a teammate
- * requires an explicit `chat send` / `ask` / `update`.
+ * Provider-neutral runtime contract that reconciles an agent's native output
+ * model with First Tree's delivery model, where reaching a teammate requires an
+ * explicit `chat send` / `ask` / `update`. Every provider has a native channel
+ * it treats as user-facing — text outside tool calls (Claude Code), or the
+ * `commentary` / `final` channels (Codex). The wording stays provider-agnostic
+ * so each agent maps it onto its own output.
  *
- * Rather than *negating* the base instruction (a downstream, lower-salience
+ * Rather than *negating* the native instruction (a downstream, lower-salience
  * "your output is not a reply" loses to the model's strong prior ~1/3 of the
- * time), this *rebinds* it: the "user" reading the output stream is the First
- * Tree runtime; teammates are a separate audience reached only by an explicit
- * send. It folds three mutually-reinforcing framings — runtime-as-user, reach
- * = an outbound publish, and console-vs-outbox — into one block, kept accurate
- * about visibility (the trace is not private; it surfaces as a live-activity
- * preview). Injected through `systemPrompt.append`, which the SDK places after
- * the base preset yet at higher salience than the project CLAUDE.md.
+ * time), this *rebinds* it with a single boundary rule: everything you produce
+ * apart from an explicit chat command is the console, addressed to the First
+ * Tree runtime; the explicit commands are the outbox, the only path to a
+ * teammate. Stating the boundary by exclusion (console = everything but the
+ * chat commands) binds the turn-closing message — Codex's strong `final` prior
+ * — without enumerating channels. Kept accurate about visibility (the trace is
+ * not private; it surfaces as a live-activity preview).
+ *
+ * This is the single contract BOTH providers receive — keeping provider prompt
+ * differences minimal. The only difference is the delivery mechanism, which the
+ * provider's architecture forces: on the Claude path it rides `systemPrompt.append`
+ * (after the base preset, above the project CLAUDE.md); Codex has no persistent
+ * system-prompt channel, so it is prepended to every Codex turn input alongside
+ * the chat-context block. Either way the same block rides every turn and sits in
+ * the immediate context tail where a "discuss only / hold off" instruction lands.
  */
 export function renderRuntimeOutputContract(): string {
+  const bin = getCliBinding().binName;
   return [
     "<first-tree-runtime-contract>",
     "This block is authored by the First Tree runtime.",
     "",
-    'Who reads your output: the Claude Code harness tells you that all text you write outside of tool calls is displayed to "the user". Inside First Tree that user is the First Tree runtime — an automated operator that records your output as a live reasoning/activity trace, not a chat participant. Think, plan, and narrate there freely. That trace surfaces to people viewing the session as a one-line activity preview, so it is not private — but it is never delivered to anyone as a message.',
+    'Who reads your output: inside First Tree, the "user" your underlying agent addresses — the reader of everything you produce apart from running a chat command, including the text you write outside of tool calls and the message that closes your turn — is the First Tree runtime, an automated operator that records it as a live reasoning/activity trace. Think, plan, and narrate there freely. That trace surfaces to people viewing the session as a one-line activity preview, so treat it as visible. This is your console.',
     "",
-    "Your teammates — the humans and agents in this chat — are a different audience. They never receive your output text. Reaching a teammate is an outbound publish to the chat service that happens only when you run an explicit command: `chat send` (a reply, or to make an agent act), `chat ask` (a tracked decision for a human), or `chat update` (status). Your output stream is the console; `chat send` is the outbox. Finishing your thoughts writes the console; it does not send the outbox.",
+    "Your teammates — the humans and agents in this chat — are a separate audience. You reach a teammate by running the chat CLI as a command-line tool — a real command you run, the same execution path you use for any other tool:",
+    `- \`${bin} chat send <name> "<message>"\` — deliver a reply, or hand an agent its next step`,
+    `- \`${bin} chat ask <human> "<question>"\` — put a tracked decision to a human`,
+    `- \`${bin} chat update --description "<status>"\` — record status`,
+    "The console addresses the runtime; running one of these commands is what places your message in front of a teammate. Describing a reply in your output records words on the console, while running the command delivers them.",
     "",
-    "So answering a teammate is two acts, not one: do the work (console), then deliver the result with `chat send` (outbox). A turn that ends with only output text has told the runtime everything and told the teammate nothing — to them it reads as no reply.",
+    "So a request to hold off from acting scopes the business actions that change the workspace or the world — running a chat command delivers your words and changes nothing else, so it stays the way you finish a teammate-triggered turn.",
     "</first-tree-runtime-contract>",
   ].join("\n");
 }


### PR DESCRIPTION
## Problem

Agents — Codex especially — would end a human-directed **discussion-only / "先讨论，不动手"** turn with their **final/output text only** and never run `chat send`, so the human saw **no reply** at all (the `agent-final-text` mirror is retired since #1190, so final text is not forwarded to chat).

Real-agent QA reproduced it on a resumed Codex thread: the model **restated** "I need to reply via `chat send`" yet answered on its native `final` channel **with no `function_call`**. So this is **execution binding, not comprehension** — "reply" was bound to *emitting text*, not to *running a command*.

## Fix (prompt-level, provider-neutral)

Reframe the runtime delivery contract so "reply" binds to executing a command:

- **Describe `chat send` / `chat ask` / `chat update` as the chat CLI run as a real command-line tool** — the same exec/function-call path the agent uses for any other tool — with executable command signatures (`<bin> chat send <name> "<message>"`, …).
- **One boundary rule by exclusion**: *console = everything you produce apart from running a chat command* → binds Codex's strong `final` prior without enumerating provider channels.
- **Action classification**: reply transport is not a business action, so a "hold off / don't act" instruction scopes business actions only — the reply is still required.
- Stated **affirmatively as principles** (minimal negations / examples), per owner guidance.

## Minimal provider differences

A single provider-neutral `renderRuntimeOutputContract()` is the **same block both providers receive** — Claude via `systemPrompt.append`, Codex prepended to every turn input (no persistent system-prompt channel). The Codex-only reply-discipline reminder is removed. The shared brief (`# Working in First Tree` / `## Communication`) carries the same rules.

## Validation

- Automated: `tsc` + `biome` clean; **`@first-tree/client` 1148 tests pass** (updated assertions pin the new principle/CLI-tool anchors + the per-turn Codex injection).
- **Real-agent QA** (isolated server / PostgreSQL / CLI / daemon + real Codex `0.142.2`), resumed discussion-only adversarial turn: Codex now **executes `chat send` via `exec_command`** and creates a durable `source=cli` reply; workspace tracked status unchanged. Verified on both the intermediate and the final unified contract.

## Notes

- Client-only change (prompt text + Codex handler injection + tests).
- A paired Context Tree PR (the "agent replies are delivered by running the chat CLI command" communication decision) follows and will be cross-linked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
