### PR TITLE
fix(client): make login-shell PATH probe shell-agnostic (fish users no longer reported missing)

### DIFF
--- a/packages/client/src/__tests__/login-shell-path.test.ts
+++ b/packages/client/src/__tests__/login-shell-path.test.ts
@@ -1,5 +1,11 @@
+import { spawnSync } from "node:child_process";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { getLoginShellPathDirs, type RunShell, resetLoginShellPathDirsCache } from "../runtime/login-shell-path.js";
+import {
+  buildProbeScript,
+  getLoginShellPathDirs,
+  type RunShell,
+  resetLoginShellPathDirsCache,
+} from "../runtime/login-shell-path.js";
 
 const DELIM = "__FT_SHELL_PATH__";
 
@@ -112,5 +118,44 @@ describe("getLoginShellPathDirs", () => {
     expect(getLoginShellPathDirs(runShell)).toEqual([]);
     expect(getLoginShellPathDirs(runShell)).toEqual([]);
     expect(runShell).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Integration coverage for the real probe script. The script is launched by the
+ * user's login shell as a single opaque `/bin/sh -c '…'` token, so it must run
+ * identically no matter what that outer shell is — that shell-agnostic launcher
+ * shape is exactly what lets fish / tcsh (which cannot parse a POSIX `do … done`
+ * loop) work. We cannot assume fish is installed in CI, so this exercises the
+ * mechanism through `/bin/sh` as the outer launcher (and the platform default
+ * via the real `defaultRunShell`); fish itself is covered by the runtime-env-qa
+ * `DW7_fish_frozen` scenario.
+ */
+describe("probe script (real execution)", () => {
+  afterEach(() => resetLoginShellPathDirsCache());
+
+  it.skipIf(process.platform === "win32")(
+    "runs under a POSIX /bin/sh launcher and yields this process's canonical, absolute PATH dirs",
+    () => {
+      const runViaSh: RunShell = () => {
+        const r = spawnSync("/bin/sh", ["-lic", buildProbeScript()], {
+          encoding: "utf-8",
+          timeout: 4_000,
+          stdio: ["ignore", "pipe", "ignore"],
+        });
+        return typeof r.stdout === "string" ? r.stdout : null;
+      };
+      const dirs = getLoginShellPathDirs(runViaSh);
+      // A real environment always has at least one PATH dir, and every dir the
+      // probe returns is canonicalized (`pwd -P`) so it must be absolute.
+      expect(dirs.length).toBeGreaterThan(0);
+      for (const dir of dirs) expect(dir.startsWith("/")).toBe(true);
+    },
+  );
+
+  it.skipIf(process.platform === "win32")("the real default-shell probe returns absolute dirs without throwing", () => {
+    const dirs = getLoginShellPathDirs();
+    expect(Array.isArray(dirs)).toBe(true);
+    for (const dir of dirs) expect(dir.startsWith("/")).toBe(true);
   });
 });

--- a/packages/client/src/__tests__/login-shell-path.test.ts
+++ b/packages/client/src/__tests__/login-shell-path.test.ts
@@ -122,30 +122,37 @@ describe("getLoginShellPathDirs", () => {
 });
 
 /**
- * Integration coverage for the real probe script. The script is launched by the
- * user's login shell as a single opaque `/bin/sh -c '…'` token, so it must run
- * identically no matter what that outer shell is — that shell-agnostic launcher
- * shape is exactly what lets fish / tcsh (which cannot parse a POSIX `do … done`
- * loop) work. We cannot assume fish is installed in CI, so this exercises the
- * mechanism through `/bin/sh` as the outer launcher (and the platform default
- * via the real `defaultRunShell`); fish itself is covered by the runtime-env-qa
+ * Integration coverage for the real probe script. The login shell launches it as
+ * a single opaque `/bin/sh -c '…'` token, so it must run identically no matter
+ * what that outer shell is — that shell-agnostic launcher shape is exactly what
+ * lets fish / tcsh (which cannot parse a POSIX `do … done` loop) work. We cannot
+ * assume fish is installed in CI, so this exercises the mechanism through
+ * `/bin/sh` as the outer launcher (and the platform default via the real
+ * `defaultRunShell`); fish itself is covered by the runtime-env-qa
  * `DW7_fish_frozen` scenario.
+ *
+ * The outer launcher is invoked with `-c` only — NOT the production `-lic`. The
+ * `-l`/`-i` flags exist solely to source the user's rc files, which this test
+ * does not need, and they are not portable: on Ubuntu CI `/bin/sh` is `dash`,
+ * whose `-l` support varies. `-c` is universally supported, and the nested
+ * `for`/`cd`/`pwd -P` loop runs identically under dash, so this stays green on
+ * every POSIX `/bin/sh`.
  */
 describe("probe script (real execution)", () => {
   afterEach(() => resetLoginShellPathDirsCache());
 
   it.skipIf(process.platform === "win32")(
-    "runs under a POSIX /bin/sh launcher and yields this process's canonical, absolute PATH dirs",
+    "runs the opaque nested /bin/sh command under a POSIX shell and yields canonical, absolute PATH dirs",
     () => {
-      const runViaSh: RunShell = () => {
-        const r = spawnSync("/bin/sh", ["-lic", buildProbeScript()], {
-          encoding: "utf-8",
-          timeout: 4_000,
-          stdio: ["ignore", "pipe", "ignore"],
-        });
-        return typeof r.stdout === "string" ? r.stdout : null;
-      };
-      const dirs = getLoginShellPathDirs(runViaSh);
+      const r = spawnSync("/bin/sh", ["-c", buildProbeScript()], {
+        encoding: "utf-8",
+        timeout: 4_000,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      // Surface a launcher failure explicitly instead of as an opaque empty result.
+      expect(r.error).toBeUndefined();
+      expect(r.status).toBe(0);
+      const dirs = getLoginShellPathDirs(() => (typeof r.stdout === "string" ? r.stdout : null));
       // A real environment always has at least one PATH dir, and every dir the
       // probe returns is canonicalized (`pwd -P`) so it must be absolute.
       expect(dirs.length).toBeGreaterThan(0);

--- a/packages/client/src/runtime/login-shell-path.ts
+++ b/packages/client/src/runtime/login-shell-path.ts
@@ -105,26 +105,49 @@ function probe(runShell: RunShell): string[] | null {
 }
 
 /**
- * Spawn the user's interactive login shell and print, bracketed by {@link DELIM},
- * the **canonicalized** dirs of `$PATH` — one per line.
+ * Build the probe command the login shell launches: it prints, bracketed by
+ * {@link DELIM}, the **canonicalized** dirs of `$PATH` — one per line. Exported
+ * for tests.
  *
- * The script splits `$PATH` with `tr ':' '\n'` (NOT a `for d in $PATH` loop:
- * zsh, the macOS default, does not field-split an unquoted scalar, so a for-loop
- * would iterate once over the whole string), then for each dir runs
- * `(cd "$d" && pwd -P)` in a subshell to resolve symlinks to the real install dir
- * while the shell — and any per-session fnm/nvm multishell symlink — is still
- * alive. Dirs that fail `cd` (gone / unreadable) are silently dropped; they could
- * not hold a spawnable binary anyway. Verified to split correctly and canonicalize
- * symlinked dirs under bash, zsh, and sh.
+ * The probe must work no matter what the user's login shell is — including
+ * **non-POSIX shells like fish / tcsh**, whose loop and quoting syntax differ
+ * from `sh`. So the login shell is used only as a launcher: it runs a single
+ * opaque `/bin/sh -c '…'` token (a literal, single-quoted string it never parses
+ * as code), and ALL of the `$PATH` splitting and canonicalization happens inside
+ * that nested POSIX `sh`. An earlier version inlined a POSIX `while … do … done`
+ * pipeline directly in the login shell; fish parses the whole `-c` string as one
+ * unit, hits the `do`/`done`, errors at parse time, and prints nothing — so every
+ * login-shell-only `claude` / `codex` was reported missing.
+ *
+ * Inside the nested `sh`, `IFS=:; for d in $PATH` field-splits `$PATH` on `:`
+ * (POSIX-defined here — unlike zsh, which would not field-split an unquoted
+ * scalar), and each dir is canonicalized with `(cd "$d" && pwd -P)` **while the
+ * login shell — and any per-session fnm/nvm multishell symlink — is still alive**.
+ * Those multishell PATH entries (e.g. `/tmp/fnm_multishells/xxx/bin`) are torn
+ * down when the login shell exits, so resolving them here, in-process, hands back
+ * the stable underlying install dir that still exists at search time;
+ * canonicalizing later in Node would find the symlink already gone. Dirs that
+ * fail `cd` (gone / unreadable) are silently dropped — they could not hold a
+ * spawnable binary anyway. The nested `sh` reads the login shell's exported
+ * `$PATH`, which is colon-delimited regardless of how the outer shell stores it.
+ * Verified end to end under bash, zsh, and sh; fish is covered by the
+ * runtime-env-qa `DW7_fish_frozen` scenario.
  */
+export function buildProbeScript(): string {
+  // POSIX body run by the nested `sh`; uses only double quotes so the whole
+  // string can be wrapped in single quotes for `/bin/sh -c '…'`. DELIM is a bare
+  // word (letters + underscores), safe unquoted.
+  const posix =
+    `printf %s ${DELIM}; ` +
+    `IFS=:; for d in $PATH; do [ -n "$d" ] && (cd "$d" 2>/dev/null && pwd -P); done; ` +
+    `printf %s ${DELIM}`;
+  return `/bin/sh -c '${posix}'`;
+}
+
+/** Spawn the user's interactive login shell to run the probe; raw stdout or null. */
 function defaultRunShell(): string | null {
   const shell = pickShell();
-  const script =
-    `printf %s '${DELIM}'; ` +
-    `printf %s "$PATH" | tr ':' '\\n' | ` +
-    `while IFS= read -r d; do [ -n "$d" ] && (cd "$d" 2>/dev/null && pwd -P); done; ` +
-    `printf %s '${DELIM}'`;
-  const result = spawnSync(shell, ["-lic", script], {
+  const result = spawnSync(shell, ["-lic", buildProbeScript()], {
     encoding: "utf-8",
     timeout: 4_000,
     // SIGTERM (the spawnSync default) is ignored by a shell that traps it, spawns


### PR DESCRIPTION
## Problem

When a user's default shell is **fish** (or another non-POSIX shell: tcsh/csh), every `claude` / `codex` reachable only through fish's interactive PATH (`config.fish` / `fish_add_path` / fnm / nvm) is detected as **`missing`** — even though `fish -lic 'type -p claude'` finds it fine. Onboarding / `daemon doctor` then report the runtime missing, push users toward needless `daemon install-claude` / `install-codex`, and capability binding fails.

### Root cause

`packages/client/src/runtime/login-shell-path.ts` ran the PATH-discovery script as a **POSIX `while … do … done` pipeline inlined directly in the user's `$SHELL`**:

```sh
printf %s '<DELIM>'; printf %s "$PATH" | tr ':' '\n' | \
  while IFS= read -r d; do [ -n "$d" ] && (cd "$d" 2>/dev/null && pwd -P); done; printf %s '<DELIM>'
```

fish's loop syntax is `while …; …; end` — no `do`/`done`. fish parses the whole `-c` string as one unit and **errors at parse time** (`Missing end to balance this while loop`), so even the leading `printf` never runs → stdout is empty → the probe finds no dirs → returns `null` (treated as a retryable failure) → login-shell PATH discovery yields nothing.

This is a regression from #1314, which replaced #1300's simpler `printf %s "$PATH"` with the POSIX loop to canonicalize fnm/nvm ephemeral symlinks — and broke fish in the process.

## Fix

Use the login shell only as a **launcher**: it runs a single opaque `/bin/sh -c '…'` token — a literal, single-quoted string it never parses as code — and all `$PATH` splitting + canonicalization happens inside that **nested POSIX `sh`**. fish (and any shell) just exec's `/bin/sh`; it never sees the loop.

```sh
/bin/sh -c 'printf %s __FT_SHELL_PATH__; IFS=:; for d in $PATH; do [ -n "$d" ] && (cd "$d" 2>/dev/null && pwd -P); done; printf %s __FT_SHELL_PATH__'
```

### Why canonicalization stays in-shell (not Node `realpathSync`)

A tempting alternative is to emit only the raw `$PATH` and canonicalize in Node. But fnm/nvm per-session **multishell symlinks** (`/tmp/fnm_multishells/.../bin`) are **torn down when the login shell exits** — exactly the reason #1314 canonicalizes in-shell. A Node `realpathSync` runs *after* the probe subprocess (and its symlinks) are gone → `ENOENT` → the dir is dropped, reintroducing the bug #1314 fixed. Running the canonicalization in the nested `sh` keeps it **inside the login shell's lifetime**, while those symlinks are still alive, so we preserve #1314's capability and fix the fish regression together. The nested `sh` reads the login shell's exported `$PATH`, which is colon-delimited regardless of how the outer shell stores it internally.

## Testing

- Existing 11 hermetic unit tests pass **unchanged** — the `RunShell` seam contract (newline-delimited canonical dirs bracketed by `DELIM`) is identical.
- Added 2 guarded (`skipIf(win32)`) real-execution tests that run the probe script through a POSIX `/bin/sh` launcher and via the real default shell, asserting canonical absolute dirs.
- Verified end to end under bash, zsh, and sh locally.
- fish itself is covered by the runtime-env-qa **`DW7_fish_frozen`** scenario (expects `ok`, was `FAIL=missing`) — should flip green with this fix.
- `pnpm --filter @first-tree/client typecheck` + full client suite (1147 tests) + `biome check` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
