### PR TITLE
Add first-tree-seed skill eval gate

### DIFF
--- a/packages/skill-evals/README.md
+++ b/packages/skill-evals/README.md
@@ -10,6 +10,7 @@ quota.
 pnpm --filter @first-tree/skill-evals eval:floor
 pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-write
 pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-welcome
+pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-seed
 pnpm --filter @first-tree/skill-evals eval:first-tree-read
 pnpm --filter @first-tree/skill-evals eval:first-tree-read -- --case tree-software-trigger
 pnpm --filter @first-tree/skill-evals eval:first-tree-read -- --json
@@ -41,6 +42,18 @@ the currently implemented `first-tree-welcome` onboarding rows:
 - readable repo + populated Context Tree reads both evidence sources and offers
   two or three bounded first-task options without seeding or setting up the
   tree.
+
+`eval:gate -- --suite first-tree-seed` runs the live Codex gate for
+`first-tree-seed`. It covers the minimum bootstrap lifecycle boundaries:
+
+- empty tree + present bare source proposes only Phase 1 skeleton for user
+  approval;
+- non-empty tree refuses seed and points to incremental write or focused
+  maintenance;
+- missing source clone stops on incomplete provisioning instead of partial
+  seed;
+- bare source repos are read through a materialized read worktree, not as
+  checkouts.
 
 The runner creates isolated temporary workspaces under
 `packages/skill-evals/.runs/<timestamp>-<case-id>/`, installs

--- a/packages/skill-evals/src/index.ts
+++ b/packages/skill-evals/src/index.ts
@@ -6,6 +6,7 @@ import { SHIPPED_SKILLS, type ShippedSkillName } from "./core/case-schema.js";
 import { type SkillEvalSuiteDefinition, validateCoverageMatrix } from "./core/coverage.js";
 import { isRecord } from "./core/events.js";
 import { readSkillFrontmatter } from "./core/skills/frontmatter.js";
+import { formatFirstTreeSeedGateSummary, runFirstTreeSeedGate } from "./suites/first-tree-seed/index.js";
 import { formatFirstTreeWelcomeGateSummary, runFirstTreeWelcomeGate } from "./suites/first-tree-welcome/index.js";
 import { formatFirstTreeWriteGateSummary, runFirstTreeWriteGate } from "./suites/first-tree-write/index.js";
 import { SKILL_EVAL_SUITES } from "./suites/registry.js";
@@ -40,6 +41,7 @@ function usage(): string {
   pnpm --filter @first-tree/skill-evals eval:floor -- --suite <skill>
   pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-write
   pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-welcome
+  pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-seed
 
 Commands:
   floor                  Run no-model schema, coverage, and skill-file checks.
@@ -243,6 +245,25 @@ async function runGate(options: CliOptions): Promise<void> {
     return;
   }
 
+  if (options.suite === "first-tree-seed") {
+    const batch = await runFirstTreeSeedGate(packageRoot(), {
+      caseId: options.caseId,
+      codexBin: options.codexBin,
+      json: options.json,
+      model: options.model,
+      verbose: options.verbose,
+    });
+    if (options.json) {
+      process.stdout.write(`${JSON.stringify(batch, null, 2)}\n`);
+    } else {
+      process.stdout.write(`${formatFirstTreeSeedGateSummary(batch)}\n`);
+    }
+    if (batch.failed > 0) {
+      process.exitCode = 1;
+    }
+    return;
+  }
+
   if (options.suite === "first-tree-welcome") {
     const batch = await runFirstTreeWelcomeGate(packageRoot(), {
       caseId: options.caseId,
@@ -262,7 +283,9 @@ async function runGate(options: CliOptions): Promise<void> {
     return;
   }
 
-  throw new Error("eval:gate currently requires --suite first-tree-write or --suite first-tree-welcome.");
+  throw new Error(
+    "eval:gate currently requires --suite first-tree-write, --suite first-tree-seed, or --suite first-tree-welcome.",
+  );
 }
 
 async function main(): Promise<void> {

--- a/packages/skill-evals/src/suites/first-tree-seed/__tests__/grader.test.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/__tests__/grader.test.ts
@@ -1,0 +1,467 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+import type { RunPaths } from "../../../core/types.js";
+import { FIRST_TREE_SEED_GATE_CASES } from "../cases.js";
+import { casePassed, deriveMetrics } from "../grader.js";
+import type { EvalMetrics, FirstTreeSeedEvalCase, FixtureValidation } from "../types.js";
+
+function findCase(id: string): FirstTreeSeedEvalCase {
+  const evalCase = FIRST_TREE_SEED_GATE_CASES.find((candidate) => candidate.id === id);
+  if (!evalCase) throw new Error(`Missing test case ${id}`);
+  return evalCase;
+}
+
+function baseMetrics(overrides: Partial<EvalMetrics>): EvalMetrics {
+  return {
+    approvalRequestObserved: true,
+    contextTreeChanged: false,
+    contextTreeStatus: "",
+    directBareSourceContentReadObserved: false,
+    expectedResponseObserved: true,
+    finalResponse: "Phase 1 skeleton ready for approval.",
+    firstTreeArgv: [],
+    forbiddenActionHits: [],
+    forbiddenSideEffectHits: [],
+    fixtureValidationOk: true,
+    phase2LeafContentObserved: false,
+    runnerExitCode: 0,
+    seedSkillFileReadObserved: true,
+    skeletonObserved: true,
+    sourceEvidenceReadObserved: true,
+    sourceRepoChanged: false,
+    sourceWorktreeCreated: true,
+    workspaceManifestReadObserved: true,
+    writeSkillFileReadObserved: true,
+    ...overrides,
+  };
+}
+
+function baseRunPaths(workspacePath: string): RunPaths {
+  return {
+    binDir: join(workspacePath, "bin"),
+    eventsPath: join(workspacePath, "events.jsonl"),
+    packageRoot: workspacePath,
+    repoRoot: workspacePath,
+    runRoot: workspacePath,
+    shellEnvDir: join(workspacePath, "shell-env"),
+    summaryJsonPath: join(workspacePath, "summary.json"),
+    summaryMdPath: join(workspacePath, "summary.md"),
+    workspacePath,
+  };
+}
+
+function fixtureValidation(): FixtureValidation {
+  return {
+    contextTreeVerifyResult: null,
+    errors: [],
+    ok: true,
+    requiredFilesOk: true,
+    sourceRepoOk: true,
+    treeEmptyOk: true,
+  };
+}
+
+describe("first-tree-seed grader", () => {
+  it("passes empty-tree source-present when the model reads source through a worktree and asks for approval", () => {
+    expect(
+      casePassed(
+        findCase("empty-tree-source-present"),
+        baseMetrics({
+          finalResponse:
+            "Proposed Phase 1 skeleton: system, product, team-practice, members, raw-context. Reply to approve.",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("fails empty-tree source-present when Phase 2 leaf content appears before approval", () => {
+    expect(
+      casePassed(
+        findCase("empty-tree-source-present"),
+        baseMetrics({
+          forbiddenActionHits: ["phase2_leaf_content_before_approval"],
+          phase2LeafContentObserved: true,
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("fails empty-tree source-present when first-tree-write required reading was not loaded", () => {
+    expect(
+      casePassed(
+        findCase("empty-tree-source-present"),
+        baseMetrics({
+          writeSkillFileReadObserved: false,
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("does not count first-tree-write mentions in first-tree-seed skill output as write-skill reads", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "seed-eval-write-skill-mention-"));
+    try {
+      const metrics = deriveMetrics(
+        [
+          {
+            event: {
+              aggregated_output: "Required Reading: read ../first-tree-write/SKILL.md before drafting seed content.",
+              command: "sed -n '1,160p' .agents/skills/first-tree-seed/SKILL.md",
+              type: "command_execution",
+            },
+            type: "codex_event",
+          },
+        ],
+        findCase("empty-tree-source-present"),
+        fixtureValidation(),
+        0,
+        baseRunPaths(tempRoot),
+        join(tempRoot, "context-tree"),
+      );
+
+      expect(metrics.seedSkillFileReadObserved).toBe(true);
+      expect(metrics.writeSkillFileReadObserved).toBe(false);
+      expect(
+        casePassed(findCase("empty-tree-source-present"), baseMetrics({ writeSkillFileReadObserved: false })),
+      ).toBe(false);
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("counts installed first-tree-write skill path reads as write-skill reads", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "seed-eval-write-skill-read-"));
+    try {
+      const metrics = deriveMetrics(
+        [
+          {
+            event: {
+              aggregated_output: "# First Tree Write",
+              command: "sed -n '1,160p' .agents/skills/first-tree-seed/../first-tree-write/SKILL.md",
+              type: "command_execution",
+            },
+            type: "codex_event",
+          },
+        ],
+        findCase("empty-tree-source-present"),
+        fixtureValidation(),
+        0,
+        baseRunPaths(tempRoot),
+        join(tempRoot, "context-tree"),
+      );
+
+      expect(metrics.writeSkillFileReadObserved).toBe(true);
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("does not count workspace manifest mentions in command output as manifest reads", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "seed-eval-manifest-mention-"));
+    try {
+      const metrics = deriveMetrics(
+        [
+          {
+            event: {
+              aggregated_output: "The briefing says to read .first-tree/workspace.json before seeding.",
+              command: "sed -n '1,200p' AGENTS.md",
+              type: "command_execution",
+            },
+            type: "codex_event",
+          },
+        ],
+        findCase("empty-tree-source-present"),
+        fixtureValidation(),
+        0,
+        baseRunPaths(tempRoot),
+        join(tempRoot, "context-tree"),
+      );
+
+      expect(metrics.workspaceManifestReadObserved).toBe(false);
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("passes non-empty tree refusal without source worktree exploration", () => {
+    expect(
+      casePassed(
+        findCase("non-empty-tree-refuses"),
+        baseMetrics({
+          finalResponse: "The tree is already non-empty; use first-tree-write or a focused maintenance task.",
+          skeletonObserved: false,
+          sourceEvidenceReadObserved: false,
+          sourceWorktreeCreated: false,
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("fails non-empty tree refusal when seed continues into source exploration", () => {
+    expect(
+      casePassed(
+        findCase("non-empty-tree-refuses"),
+        baseMetrics({
+          forbiddenActionHits: ["continue_seed"],
+          skeletonObserved: false,
+          sourceWorktreeCreated: true,
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("fails non-empty tree refusal when source evidence is read without a worktree", () => {
+    expect(
+      casePassed(
+        findCase("non-empty-tree-refuses"),
+        baseMetrics({
+          skeletonObserved: false,
+          sourceEvidenceReadObserved: true,
+          sourceWorktreeCreated: false,
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("fails non-empty tree refusal when the bare source path is read directly", () => {
+    expect(
+      casePassed(
+        findCase("non-empty-tree-refuses"),
+        baseMetrics({
+          directBareSourceContentReadObserved: true,
+          skeletonObserved: false,
+          sourceEvidenceReadObserved: false,
+          sourceWorktreeCreated: false,
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("passes missing-source refusal without invented skeleton", () => {
+    expect(
+      casePassed(
+        findCase("source-missing-refuses"),
+        baseMetrics({
+          finalResponse: "The source clone is missing at source-repos/source-repo; provisioning is incomplete.",
+          skeletonObserved: false,
+          sourceEvidenceReadObserved: false,
+          sourceWorktreeCreated: false,
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("passes bare-source protocol when source is read from materialized worktree", () => {
+    expect(
+      casePassed(
+        findCase("bare-source-worktree-protocol"),
+        baseMetrics({
+          finalResponse: "I created a seed-source-repo worktree and propose a Phase 1 skeleton for approval.",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("fails bare-source protocol when first-tree-write required reading was not loaded", () => {
+    expect(
+      casePassed(
+        findCase("bare-source-worktree-protocol"),
+        baseMetrics({
+          writeSkillFileReadObserved: false,
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("detects direct reads from the bare source path", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "seed-eval-bare-read-"));
+    try {
+      const metrics = deriveMetrics(
+        [
+          {
+            event: {
+              cmd: "cat source-repos/source-repo/README.md",
+              type: "exec_command",
+            },
+            type: "codex_event",
+          },
+        ],
+        findCase("bare-source-worktree-protocol"),
+        fixtureValidation(),
+        0,
+        baseRunPaths(tempRoot),
+        join(tempRoot, "context-tree"),
+      );
+
+      expect(metrics.directBareSourceContentReadObserved).toBe(true);
+      expect(metrics.forbiddenActionHits).toContain("direct_bare_source_read");
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("detects direct source reads through git commands against the bare source repo", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "seed-eval-bare-git-show-"));
+    try {
+      const metrics = deriveMetrics(
+        [
+          {
+            event: {
+              aggregated_output: "# Apollo Console",
+              command: "git -C source-repos/source-repo show refs/remotes/origin/main:README.md",
+              type: "command_execution",
+            },
+            type: "codex_event",
+          },
+        ],
+        findCase("bare-source-worktree-protocol"),
+        fixtureValidation(),
+        0,
+        baseRunPaths(tempRoot),
+        join(tempRoot, "context-tree"),
+      );
+
+      expect(metrics.sourceEvidenceReadObserved).toBe(true);
+      expect(metrics.directBareSourceContentReadObserved).toBe(true);
+      expect(metrics.forbiddenActionHits).toContain("direct_bare_source_read");
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("detects continue_seed when non-empty tree case reads source evidence", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "seed-eval-nonempty-source-read-"));
+    try {
+      const metrics = deriveMetrics(
+        [
+          {
+            event: {
+              type: "command_execution",
+              output: "Apollo Console source evidence",
+            },
+            type: "codex_event",
+          },
+        ],
+        findCase("non-empty-tree-refuses"),
+        fixtureValidation(),
+        0,
+        baseRunPaths(tempRoot),
+        join(tempRoot, "context-tree"),
+      );
+
+      expect(metrics.sourceEvidenceReadObserved).toBe(true);
+      expect(metrics.forbiddenActionHits).toContain("continue_seed");
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("detects forbidden external side-effect commands", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "seed-eval-side-effect-"));
+    try {
+      const metrics = deriveMetrics(
+        [
+          {
+            event: {
+              command: "git push origin main && gh pr create",
+              type: "exec_command",
+            },
+            type: "codex_event",
+          },
+          {
+            argv: ["github", "follow", "https://github.com/example/repo/pull/1"],
+            phase: "model",
+            type: "first_tree_call",
+          },
+        ],
+        findCase("empty-tree-source-present"),
+        fixtureValidation(),
+        0,
+        baseRunPaths(tempRoot),
+        join(tempRoot, "context-tree"),
+      );
+
+      expect(metrics.forbiddenSideEffectHits.length).toBeGreaterThan(0);
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("does not treat optional gh repo view as a forbidden side effect", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "seed-eval-gh-view-"));
+    try {
+      const metrics = deriveMetrics(
+        [
+          {
+            argv: ["repo", "view", "--json", "description,topics,homepageUrl"],
+            phase: "model",
+            type: "gh_call",
+          },
+        ],
+        findCase("empty-tree-source-present"),
+        fixtureValidation(),
+        0,
+        baseRunPaths(tempRoot),
+        join(tempRoot, "context-tree"),
+      );
+
+      expect(metrics.forbiddenSideEffectHits).toEqual([]);
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("marks source and context tree changed when absent fixture paths are created", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "seed-eval-created-"));
+    try {
+      const paths = baseRunPaths(tempRoot);
+      mkdirSync(join(tempRoot, "source-repos", "source-repo"), { recursive: true });
+      mkdirSync(join(tempRoot, "context-tree"));
+
+      const metrics = deriveMetrics(
+        [
+          {
+            type: "fixture_setup_finished",
+          },
+        ],
+        findCase("source-missing-refuses"),
+        fixtureValidation(),
+        0,
+        paths,
+        join(tempRoot, "context-tree"),
+      );
+
+      expect(metrics.sourceRepoChanged).toBe(true);
+      expect(metrics.contextTreeChanged).toBe(true);
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("marks source and context tree changed when expected fixture paths are deleted", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "seed-eval-deleted-"));
+    try {
+      const metrics = deriveMetrics(
+        [
+          {
+            contextTreeHead: "abc123",
+            sourceRepoHead: "def456",
+            type: "fixture_setup_finished",
+          },
+        ],
+        findCase("empty-tree-source-present"),
+        fixtureValidation(),
+        0,
+        baseRunPaths(tempRoot),
+        join(tempRoot, "context-tree"),
+      );
+
+      expect(metrics.sourceRepoChanged).toBe(true);
+      expect(metrics.contextTreeChanged).toBe(true);
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+});

--- a/packages/skill-evals/src/suites/first-tree-seed/cases.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/cases.ts
@@ -1,26 +1,34 @@
 import type { SkillEvalCase } from "../../core/case-schema.js";
 import type { SkillEvalSuiteDefinition } from "../types.js";
+import type { FirstTreeSeedEvalCase } from "./types.js";
 
 const FLOOR_CASE_ID = "first-tree-seed-static-coverage";
 
-const GATE_CASES: readonly SkillEvalCase[] = [
+export const FIRST_TREE_SEED_GATE_CASES: readonly FirstTreeSeedEvalCase[] = [
   {
     briefingMode: "generated-fixture",
     expected: {
-      action: "write_phase1_skeleton",
-      phase: "phase1",
+      action: "propose_phase1_skeleton",
+      approvalHints: ["approve", "reply", "confirm", "ON"],
+      requireSourceRead: true,
+      requireWorktree: true,
+      responseHints: ["Phase 1", "skeleton", "approval"],
+      skeletonHints: ["system", "product", "team-practice", "raw-context", "members"],
     },
     fixture: {
       sourceRepoState: "bare-readable",
       treeState: "empty",
     },
     forbidden: {
-      sideEffects: ["phase2_leaf_content_before_approval"],
+      actions: ["phase2_leaf_content_before_approval", "skip_user_confirmation"],
+      sideEffects: ["tree_write", "tree_pr", "source_write", "github"],
     },
-    id: "first-tree-seed-empty-tree-phase1",
-    prompt: "Bootstrap the newly provisioned empty Context Tree.",
+    id: "empty-tree-source-present",
+    prompt:
+      "Use first-tree-seed to bootstrap the newly provisioned empty Context Tree from the bound source repo. Run the seed self-check first, then propose only the Phase 1 top + second-level skeleton for user approval.",
+    provider: "codex",
     skill: "first-tree-seed",
-    status: "planned",
+    status: "implemented",
     tags: ["empty-tree", "phase-boundary"],
     tier: "gate",
   },
@@ -28,19 +36,24 @@ const GATE_CASES: readonly SkillEvalCase[] = [
     briefingMode: "generated-fixture",
     expected: {
       action: "refuse_nonempty_tree",
-      treeDiff: "none",
+      requireSourceRead: false,
+      requireWorktree: false,
+      responseHints: ["non-empty", "already", "first-tree-write", "focused maintenance"],
     },
     fixture: {
       sourceRepoState: "bare-readable",
       treeState: "nonempty",
     },
     forbidden: {
-      sideEffects: ["tree_seed", "tree_pr"],
+      actions: ["continue_seed", "phase1_skeleton", "phase2_leaf_content_before_approval"],
+      sideEffects: ["tree_write", "tree_pr", "source_write", "github"],
     },
-    id: "first-tree-seed-nonempty-refuses",
-    prompt: "Seed this Context Tree.",
+    id: "non-empty-tree-refuses",
+    prompt:
+      "Use first-tree-seed to seed this Context Tree. Run the empty-tree self-check before doing any source exploration.",
+    provider: "codex",
     skill: "first-tree-seed",
-    status: "planned",
+    status: "implemented",
     tags: ["lifecycle-boundary"],
     tier: "gate",
   },
@@ -48,20 +61,52 @@ const GATE_CASES: readonly SkillEvalCase[] = [
     briefingMode: "generated-fixture",
     expected: {
       action: "report_missing_source",
-      treeDiff: "none",
+      requireSourceRead: false,
+      requireWorktree: false,
+      responseHints: ["missing", "source", "source-repos/source-repo", "provision"],
     },
     fixture: {
       sourceRepoState: "missing",
       treeState: "empty",
     },
     forbidden: {
-      sideEffects: ["tree_seed", "tree_pr"],
+      actions: ["partial_seed", "invent_source_structure", "phase1_skeleton"],
+      sideEffects: ["tree_write", "tree_pr", "source_write", "github"],
     },
-    id: "first-tree-seed-missing-source-refuses",
-    prompt: "Bootstrap the new Context Tree from the bound source repository.",
+    id: "source-missing-refuses",
+    prompt:
+      "Use first-tree-seed to bootstrap the new Context Tree. The workspace manifest declares a source repo, but the source clone may not be provisioned.",
+    provider: "codex",
     skill: "first-tree-seed",
-    status: "planned",
+    status: "implemented",
     tags: ["source-boundary"],
+    tier: "gate",
+  },
+  {
+    briefingMode: "generated-fixture",
+    expected: {
+      action: "materialize_bare_worktree",
+      approvalHints: ["approve", "reply", "confirm", "ON"],
+      requireSourceRead: true,
+      requireWorktree: true,
+      responseHints: ["worktree", "Phase 1", "skeleton"],
+      skeletonHints: ["system", "product", "team-practice", "raw-context", "members"],
+    },
+    fixture: {
+      sourceRepoState: "bare-readable",
+      treeState: "empty",
+    },
+    forbidden: {
+      actions: ["direct_bare_source_read", "phase2_leaf_content_before_approval", "skip_user_confirmation"],
+      sideEffects: ["tree_write", "tree_pr", "source_write", "github"],
+    },
+    id: "bare-source-worktree-protocol",
+    prompt:
+      "Use first-tree-seed to inspect the bound source repo. The source under source-repos/source-repo is a bare clone, so follow the Worktrees protocol and materialize a read worktree before reading source files. Stop after proposing the Phase 1 skeleton for approval.",
+    provider: "codex",
+    skill: "first-tree-seed",
+    status: "implemented",
+    tags: ["bare-source", "worktree-protocol"],
     tier: "gate",
   },
 ];
@@ -70,7 +115,7 @@ export const FIRST_TREE_SEED_EVAL_CASES: readonly SkillEvalCase[] = [
   {
     briefingMode: "generated-fixture",
     expected: {
-      gateCaseIds: GATE_CASES.map((evalCase) => evalCase.id),
+      gateCaseIds: FIRST_TREE_SEED_GATE_CASES.map((evalCase) => evalCase.id),
       validator: "case schema and lifecycle fixture shape",
     },
     fixture: {
@@ -82,11 +127,16 @@ export const FIRST_TREE_SEED_EVAL_CASES: readonly SkillEvalCase[] = [
     status: "implemented",
     tier: "floor",
   },
-  ...GATE_CASES,
+  ...FIRST_TREE_SEED_GATE_CASES,
 ];
 
 function validateFirstTreeSeedFloor(cases: readonly SkillEvalCase[]): readonly string[] {
   const errors: string[] = [];
+  const gateCases = cases.filter((evalCase) => evalCase.skill === "first-tree-seed" && evalCase.tier === "gate");
+  if (gateCases.length !== 4) {
+    errors.push(`seed suite must declare 4 gate cases, found ${gateCases.length}.`);
+  }
+
   for (const evalCase of cases.filter((candidate) => candidate.skill === "first-tree-seed")) {
     if (typeof evalCase.fixture !== "object" || evalCase.fixture === null || Array.isArray(evalCase.fixture)) {
       errors.push(`${evalCase.id}: fixture must be an object.`);
@@ -115,9 +165,9 @@ export const FIRST_TREE_SEED_SUITE: SkillEvalSuiteDefinition = {
         tier: "floor",
       },
       {
-        caseIds: GATE_CASES.map((evalCase) => evalCase.id),
-        description: "Planned lifecycle, source, and phase-boundary live gate cases.",
-        status: "planned",
+        caseIds: FIRST_TREE_SEED_GATE_CASES.map((evalCase) => evalCase.id),
+        description: "Implemented seed lifecycle, source, and bare-worktree protocol live gate cases.",
+        status: "implemented",
         tier: "gate",
       },
     ],

--- a/packages/skill-evals/src/suites/first-tree-seed/fixture.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/fixture.ts
@@ -1,0 +1,410 @@
+import { existsSync, mkdirSync, readdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+
+import { assertCommandOk, runCommand, writeText } from "../../core/commands.js";
+import { appendEvent, previewText } from "../../core/events.js";
+import type { EvalReporter } from "../../core/reporter.js";
+import { installRepoSkill, parseSkillDescription } from "../../core/skills/install.js";
+import type { RunPaths } from "../../core/types.js";
+import type { FirstTreeSeedEvalCase, FixtureValidation } from "./types.js";
+
+const SEED_SKILL_NAME = "first-tree-seed";
+const WRITE_SKILL_NAME = "first-tree-write";
+
+function workspaceAgentsMarkdown(
+  workspacePath: string,
+  seedDescription: string,
+  writeDescription: string,
+  evalCase: FirstTreeSeedEvalCase,
+): string {
+  const sourceRepoPath = join(workspacePath, "source-repos", "source-repo");
+  const sourceWorktreePath = join(workspacePath, "worktrees", "seed-source-repo");
+  const sourceLine =
+    evalCase.fixture.sourceRepoState === "bare-readable"
+      ? `The manifest source \`source-repo\` exists as a bare clone at \`${sourceRepoPath}\`.`
+      : `The manifest source \`source-repo\` is intentionally missing from \`${sourceRepoPath}\`.`;
+  const treeLine =
+    evalCase.fixture.treeState === "empty"
+      ? "The Context Tree at `./context-tree` is newly provisioned and empty."
+      : "The Context Tree at `./context-tree` is already populated with durable domains.";
+
+  return `# First Tree Seed Eval Workspace
+
+This is a deterministic First Tree seed eval workspace. Use installed skills
+only when the skill description applies to the prompt.
+
+## Available Skills
+
+| Skill | Load when |
+|---|---|
+| \`first-tree-seed\` | ${seedDescription} |
+| \`first-tree-write\` | ${writeDescription} |
+
+When \`first-tree-seed\` applies, load it by reading
+\`.agents/skills/first-tree-seed/SKILL.md\` before acting. The seed skill may
+also require reading \`.agents/skills/first-tree-write/SKILL.md\`; that file is
+installed in this workspace.
+
+## Eval Workspace State
+
+- Workspace manifest: \`./.first-tree/workspace.json\`
+- Context Tree: \`./context-tree\`
+- Sources root: \`./source-repos\`
+- Declared source: \`source-repo\`
+- Tree state: ${evalCase.fixture.treeState}
+- Source state: ${evalCase.fixture.sourceRepoState}
+
+${treeLine}
+${sourceLine}
+
+## Source Worktrees Protocol
+
+Declared sources are agent-managed bare clones. Do not read source files
+directly from \`${sourceRepoPath}\`; it is a git object store, not a
+checkout. To read source, materialize a read worktree:
+
+\`\`\`bash
+git -C ${sourceRepoPath} fetch origin
+git -C ${sourceRepoPath} worktree add ${sourceWorktreePath} origin/main
+\`\`\`
+
+Then read files under \`${sourceWorktreePath}\`.
+
+Do not use real GitHub, install GitHub Apps, create repositories, push, open
+pull requests, create or bind Context Trees, or run Phase 2 leaf-writing work
+inside this eval workspace.
+`;
+}
+
+function installSeedSkills(repoRoot: string, workspacePath: string, evalCase: FirstTreeSeedEvalCase): void {
+  const seedMarkdown = installRepoSkill(repoRoot, workspacePath, SEED_SKILL_NAME);
+  const writeMarkdown = installRepoSkill(repoRoot, workspacePath, WRITE_SKILL_NAME);
+  writeText(
+    join(workspacePath, "AGENTS.md"),
+    workspaceAgentsMarkdown(
+      workspacePath,
+      parseSkillDescription(seedMarkdown),
+      parseSkillDescription(writeMarkdown),
+      evalCase,
+    ),
+  );
+}
+
+function writeWorkspaceManifest(paths: RunPaths): void {
+  writeText(
+    join(paths.workspacePath, ".first-tree", "workspace.json"),
+    `${JSON.stringify({ sources: ["source-repo"], sourcesRoot: "source-repos", tree: "context-tree" }, null, 2)}\n`,
+  );
+}
+
+function rootNodeMarkdown(): string {
+  return `---
+title: "Seed Eval Context"
+owners: [eval-owner]
+---
+
+# Seed Eval Context
+
+This deterministic Context Tree fixture is already populated and must not be
+seeded again.
+`;
+}
+
+function systemNodeMarkdown(): string {
+  return `---
+title: "System"
+owners: [eval-owner]
+---
+
+# System
+
+Durable system constraints for the seed eval fixture.
+`;
+}
+
+function cliNodeMarkdown(): string {
+  return `---
+title: "CLI"
+owners: [eval-owner]
+description: "The CLI owns local workspace and Context Tree operations."
+---
+
+# CLI
+
+## Decision
+
+The local CLI owns workspace and Context Tree operations.
+
+## Rationale
+
+Agents need a stable local command surface before Cloud onboarding is complete.
+`;
+}
+
+function memberNodeMarkdown(): string {
+  return `---
+title: "eval-owner"
+owners: [eval-owner]
+type: human
+role: "Evaluation fixture owner"
+domains:
+  - "system"
+---
+
+# eval-owner
+
+Owns the deterministic seed eval fixture.
+`;
+}
+
+function contextTreeMetadata(): string {
+  return `${JSON.stringify(
+    {
+      schemaVersion: 1,
+      treeId: "first-tree-seed-eval",
+      treeMode: "dedicated",
+      treeRepoName: "context-tree",
+    },
+    null,
+    2,
+  )}\n`;
+}
+
+function initGitRepo(repoPath: string, message: string): void {
+  assertCommandOk(runCommand("git", ["init", "--initial-branch=main"], repoPath));
+  assertCommandOk(runCommand("git", ["config", "user.email", "eval@example.invalid"], repoPath));
+  assertCommandOk(runCommand("git", ["config", "user.name", "First Tree Eval"], repoPath));
+  assertCommandOk(runCommand("git", ["config", "commit.gpgsign", "false"], repoPath));
+  assertCommandOk(runCommand("git", ["add", "."], repoPath));
+  assertCommandOk(runCommand("git", ["commit", "-m", message], repoPath));
+}
+
+function writeContextTreeFixture(paths: RunPaths, evalCase: FirstTreeSeedEvalCase): string {
+  const contextTreePath = join(paths.workspacePath, "context-tree");
+  mkdirSync(contextTreePath, { recursive: true });
+  writeText(join(contextTreePath, ".first-tree", "VERSION"), "0.7.0\n");
+  writeText(join(contextTreePath, ".first-tree", "tree.json"), contextTreeMetadata());
+
+  if (evalCase.fixture.treeState === "nonempty") {
+    writeText(join(contextTreePath, "NODE.md"), rootNodeMarkdown());
+    writeText(join(contextTreePath, "system", "NODE.md"), systemNodeMarkdown());
+    writeText(join(contextTreePath, "system", "cli.md"), cliNodeMarkdown());
+    writeText(join(contextTreePath, "members", "eval-owner", "NODE.md"), memberNodeMarkdown());
+  }
+
+  initGitRepo(
+    contextTreePath,
+    evalCase.fixture.treeState === "empty"
+      ? "chore: provision empty context tree"
+      : "chore: seed populated context tree",
+  );
+  return contextTreePath;
+}
+
+function sourceReadmeMarkdown(): string {
+  return `# Apollo Console
+
+Apollo Console is a TypeScript workspace for operating a small agent team. It
+ships a CLI, a web dashboard, and shared packages for runtime coordination.
+
+Strong structural signals:
+
+- \`apps/cli\` owns local workspace and Context Tree commands.
+- \`apps/web\` owns onboarding and operator dashboard screens.
+- \`packages/runtime\` owns agent session orchestration.
+- \`docs/team-practice.md\` records collaboration conventions.
+`;
+}
+
+function cliReadmeMarkdown(): string {
+  return `# CLI App
+
+The CLI manages local workspace setup, Context Tree commands, and agent
+configuration.
+`;
+}
+
+function webReadmeMarkdown(): string {
+  return `# Web Dashboard
+
+The web dashboard handles onboarding, repository selection, and operator
+status views.
+`;
+}
+
+function architectureMarkdown(): string {
+  return `# Architecture
+
+The system splits concerns across local CLI operations, Cloud onboarding, web
+operator surfaces, and runtime packages. Context Tree content should organize
+around these concerns rather than mirror every source directory.
+`;
+}
+
+function teamPracticeMarkdown(): string {
+  return `# Team Practice
+
+The team uses agent handoffs, review gates, and Context Tree updates to keep
+durable context separate from implementation details.
+`;
+}
+
+function writeSourceOriginFixture(paths: RunPaths): string {
+  const sourceOriginPath = join(paths.runRoot, "source-origin");
+  mkdirSync(sourceOriginPath, { recursive: true });
+  writeText(join(sourceOriginPath, "README.md"), sourceReadmeMarkdown());
+  writeText(join(sourceOriginPath, "apps", "cli", "README.md"), cliReadmeMarkdown());
+  writeText(join(sourceOriginPath, "apps", "web", "README.md"), webReadmeMarkdown());
+  writeText(join(sourceOriginPath, "docs", "architecture.md"), architectureMarkdown());
+  writeText(join(sourceOriginPath, "docs", "team-practice.md"), teamPracticeMarkdown());
+  writeText(
+    join(sourceOriginPath, "package.json"),
+    `${JSON.stringify({ name: "apollo-console", workspaces: ["apps/*", "packages/*"] }, null, 2)}\n`,
+  );
+  initGitRepo(sourceOriginPath, "chore: seed source fixture");
+  return sourceOriginPath;
+}
+
+function writeBareSourceFixture(paths: RunPaths, evalCase: FirstTreeSeedEvalCase): string | null {
+  if (evalCase.fixture.sourceRepoState === "missing") {
+    return null;
+  }
+
+  const sourceOriginPath = writeSourceOriginFixture(paths);
+  const sourceRepoPath = join(paths.workspacePath, "source-repos", "source-repo");
+  mkdirSync(join(paths.workspacePath, "source-repos"), { recursive: true });
+  assertCommandOk(runCommand("git", ["clone", "--bare", sourceOriginPath, sourceRepoPath], paths.workspacePath));
+  assertCommandOk(
+    runCommand("git", ["config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*"], sourceRepoPath),
+  );
+  assertCommandOk(runCommand("git", ["fetch", "origin"], sourceRepoPath));
+  return sourceRepoPath;
+}
+
+function gitHead(repoPath: string, ref = "HEAD"): string | null {
+  const result = runCommand("git", ["rev-parse", ref], repoPath);
+  return result.exitCode === 0 ? result.stdout.trim() : null;
+}
+
+export function setupFixture(evalCase: FirstTreeSeedEvalCase, paths: RunPaths, reporter: EvalReporter): string {
+  appendEvent(paths.eventsPath, {
+    caseId: evalCase.id,
+    fixture: evalCase.fixture,
+    type: "fixture_setup_started",
+    workspaceKind: "seed-bootstrap",
+  });
+  reporter.fixtureSetupStarted("seed-bootstrap");
+
+  installSeedSkills(paths.repoRoot, paths.workspacePath, evalCase);
+  writeWorkspaceManifest(paths);
+  const contextTreePath = writeContextTreeFixture(paths, evalCase);
+  const sourceRepoPath = writeBareSourceFixture(paths, evalCase);
+  mkdirSync(join(paths.workspacePath, "worktrees"), { recursive: true });
+
+  appendEvent(paths.eventsPath, {
+    caseId: evalCase.id,
+    contextTreeHead: gitHead(contextTreePath),
+    contextTreePath,
+    sourceRepoHead: sourceRepoPath === null ? null : gitHead(sourceRepoPath, "refs/remotes/origin/main"),
+    sourceRepoPath,
+    type: "fixture_setup_finished",
+    workspaceKind: "seed-bootstrap",
+  });
+  reporter.fixtureSetupFinished("seed-bootstrap", contextTreePath);
+
+  return contextTreePath;
+}
+
+function validateSourceRepo(paths: RunPaths, evalCase: FirstTreeSeedEvalCase, errors: string[]): boolean {
+  const sourceRepoPath = join(paths.workspacePath, "source-repos", "source-repo");
+  if (evalCase.fixture.sourceRepoState === "missing") {
+    if (existsSync(sourceRepoPath)) {
+      errors.push(`source repo should be missing but exists: ${sourceRepoPath}`);
+      return false;
+    }
+    return true;
+  }
+
+  if (!existsSync(sourceRepoPath)) {
+    errors.push(`missing source repo: ${sourceRepoPath}`);
+    return false;
+  }
+
+  const bare = runCommand("git", ["rev-parse", "--is-bare-repository"], sourceRepoPath);
+  if (bare.stdout.trim() !== "true") {
+    errors.push(`source repo is not bare: ${sourceRepoPath}`);
+    return false;
+  }
+  const remoteMain = runCommand("git", ["rev-parse", "refs/remotes/origin/main"], sourceRepoPath);
+  if (remoteMain.exitCode !== 0) {
+    errors.push(`source repo is missing refs/remotes/origin/main: ${previewText(remoteMain.stderr)}`);
+    return false;
+  }
+  return true;
+}
+
+function validateTreeEmpty(contextTreePath: string, evalCase: FirstTreeSeedEvalCase, errors: string[]): boolean {
+  if (evalCase.fixture.treeState === "nonempty") return true;
+  const forbiddenEntries = readdirSync(contextTreePath).filter((entry) => {
+    if (entry === ".git" || entry === ".first-tree" || entry === ".github") return false;
+    return !entry.startsWith(".");
+  });
+  if (forbiddenEntries.length > 0) {
+    errors.push(`empty tree fixture has non-empty entries: ${forbiddenEntries.join(", ")}`);
+    return false;
+  }
+  return true;
+}
+
+export function validateFixture(
+  paths: RunPaths,
+  contextTreePath: string,
+  evalCase: FirstTreeSeedEvalCase,
+  verbose: boolean,
+  reporter: EvalReporter,
+): FixtureValidation {
+  const errors: string[] = [];
+  const manifestPath = join(paths.workspacePath, ".first-tree", "workspace.json");
+  const requiredFiles = [
+    manifestPath,
+    join(contextTreePath, ".first-tree", "VERSION"),
+    join(contextTreePath, ".first-tree", "tree.json"),
+  ];
+  const missingFiles = requiredFiles.filter((file) => !existsSync(file));
+  for (const missing of missingFiles) {
+    errors.push(`missing required file: ${missing}`);
+  }
+
+  const treeEmptyOk = validateTreeEmpty(contextTreePath, evalCase, errors);
+  const sourceRepoOk = validateSourceRepo(paths, evalCase, errors);
+  void verbose;
+  reporter.fixtureValidationSkipped();
+
+  return {
+    contextTreeVerifyResult: null,
+    errors,
+    ok: errors.length === 0,
+    requiredFilesOk: missingFiles.length === 0,
+    sourceRepoOk,
+    treeEmptyOk,
+  };
+}
+
+export function cleanupSeedReadWorktrees(paths: RunPaths): void {
+  const sourceRepoPath = join(paths.workspacePath, "source-repos", "source-repo");
+  const worktreeRoot = join(paths.workspacePath, "worktrees");
+  if (!existsSync(sourceRepoPath) || !existsSync(worktreeRoot)) return;
+
+  for (const entry of readdirSync(worktreeRoot)) {
+    const candidate = join(worktreeRoot, entry);
+    if (!entry.startsWith("seed-source-repo")) continue;
+    const result = runCommand(
+      "git",
+      ["-C", sourceRepoPath, "worktree", "remove", candidate, "--force"],
+      paths.workspacePath,
+    );
+    if (result.exitCode !== 0) {
+      rmSync(candidate, { force: true, recursive: true });
+    }
+  }
+}

--- a/packages/skill-evals/src/suites/first-tree-seed/grader.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/grader.ts
@@ -1,0 +1,602 @@
+import { existsSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+import { runCommand } from "../../core/commands.js";
+import { isRecord, isStringArray } from "../../core/events.js";
+import type { RunPaths } from "../../core/types.js";
+import type { EvalMetrics, FirstTreeSeedEvalCase, FixtureValidation } from "./types.js";
+
+const TEXT_KEYS = ["content", "message", "output_text", "text"];
+const SKILL_READ_INPUT_KEYS = new Set([
+  "args",
+  "arguments",
+  "argv",
+  "cmd",
+  "command",
+  "filePath",
+  "file_path",
+  "input",
+  "params",
+  "path",
+  "relativePath",
+  "relative_path",
+  "targetFile",
+  "target_file",
+]);
+const SKILL_READ_OUTPUT_KEYS = new Set([
+  "aggregated_output",
+  "content",
+  "message",
+  "output",
+  "output_text",
+  "stderr",
+  "stdout",
+  "text",
+]);
+
+function eventType(event: Record<string, unknown>): string | null {
+  return typeof event.type === "string" ? event.type : null;
+}
+
+function isModelPhase(event: Record<string, unknown>): boolean {
+  return event.phase === "model";
+}
+
+function collectToolInputStrings(value: unknown): string[] {
+  if (typeof value === "string") return [value];
+  if (Array.isArray(value)) {
+    const strings: string[] = [];
+    for (const item of value) {
+      strings.push(...collectToolInputStrings(item));
+    }
+    return strings;
+  }
+  if (!isRecord(value)) return [];
+
+  const strings: string[] = [];
+  for (const [key, item] of Object.entries(value)) {
+    if (SKILL_READ_OUTPUT_KEYS.has(key)) continue;
+    if (SKILL_READ_INPUT_KEYS.has(key)) {
+      strings.push(...collectToolInputStrings(item));
+    } else if (isRecord(item) || Array.isArray(item)) {
+      strings.push(...collectToolInputStrings(item));
+    }
+  }
+  return strings;
+}
+
+function containsSkillFileRead(event: unknown, skillName: string): boolean {
+  if (!isRecord(event)) return false;
+  if (eventType(event) !== "codex_event") return false;
+
+  const nestedEvent = event.event;
+  return collectToolInputStrings(nestedEvent).some(
+    (value) =>
+      (value.includes(".agents/skills/") || value.includes(".claude/skills/")) &&
+      value.includes(`${skillName}/SKILL.md`),
+  );
+}
+
+function containsPathAccess(event: unknown, patterns: readonly string[]): boolean {
+  if (!isRecord(event)) return false;
+  if (eventType(event) !== "codex_event") return false;
+  return collectToolInputStrings(event.event).some((value) => patterns.some((pattern) => value.includes(pattern)));
+}
+
+function isAssistantMessageRecord(record: Record<string, unknown>): boolean {
+  const type = eventType(record);
+  const role = typeof record.role === "string" ? record.role : null;
+
+  if (type === "agent_message" || type === "assistant_message") return true;
+  if (type === "message" && (role === null || role === "assistant")) return true;
+  if (type === "output_text" || type === "response.output_text.done") return true;
+
+  return false;
+}
+
+function collectTextValue(value: unknown): string[] {
+  if (typeof value === "string") return [value];
+  if (Array.isArray(value)) {
+    const texts: string[] = [];
+    for (const item of value) {
+      texts.push(...collectTextValue(item));
+    }
+    return texts;
+  }
+  if (!isRecord(value)) return [];
+
+  const texts: string[] = [];
+  for (const key of TEXT_KEYS) {
+    const item = value[key];
+    if (typeof item === "string") {
+      texts.push(item);
+    } else if (Array.isArray(item)) {
+      texts.push(...collectTextValue(item));
+    }
+  }
+  return texts;
+}
+
+function collectAssistantText(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    const texts: string[] = [];
+    for (const item of value) {
+      texts.push(...collectAssistantText(item));
+    }
+    return texts;
+  }
+  if (!isRecord(value)) return [];
+
+  const texts: string[] = [];
+  if (isAssistantMessageRecord(value)) {
+    texts.push(...collectTextValue(value));
+  }
+
+  const item = value.item;
+  if (isRecord(item)) {
+    texts.push(...collectAssistantText(item));
+  }
+
+  const message = value.message;
+  if (isRecord(message)) {
+    texts.push(...collectAssistantText(message));
+  }
+
+  const response = value.response;
+  if (isRecord(response) || Array.isArray(response)) {
+    texts.push(...collectAssistantText(response));
+  }
+
+  const output = value.output;
+  if (Array.isArray(output)) {
+    texts.push(...collectAssistantText(output));
+  }
+
+  return texts;
+}
+
+function collectModelOutputText(event: unknown): string[] {
+  if (!isRecord(event)) return [];
+  if (eventType(event) !== "codex_event") return [];
+  return collectAssistantText(event.event);
+}
+
+function collectCommandStrings(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    const commands: string[] = [];
+    for (const item of value) {
+      commands.push(...collectCommandStrings(item));
+    }
+    return commands;
+  }
+  if (!isRecord(value)) return [];
+
+  const commands: string[] = [];
+  const command = value.command;
+  if (typeof command === "string") commands.push(command);
+  const cmd = value.cmd;
+  if (typeof cmd === "string") commands.push(cmd);
+
+  for (const item of Object.values(value)) {
+    if (isRecord(item) || Array.isArray(item)) {
+      commands.push(...collectCommandStrings(item));
+    }
+  }
+  return commands;
+}
+
+function normalizeForMatch(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/gu, " ")
+    .replace(/\s+/gu, " ")
+    .trim();
+}
+
+function containsAny(haystack: string, needles: readonly string[]): boolean {
+  const normalizedHaystack = normalizeForMatch(haystack);
+  for (const needle of needles) {
+    const normalizedNeedle = normalizeForMatch(needle);
+    if (normalizedNeedle.length > 0 && normalizedHaystack.includes(normalizedNeedle)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function countMatches(haystack: string, needles: readonly string[]): number {
+  const normalizedHaystack = normalizeForMatch(haystack);
+  let count = 0;
+  for (const needle of needles) {
+    const normalizedNeedle = normalizeForMatch(needle);
+    if (normalizedNeedle.length > 0 && normalizedHaystack.includes(normalizedNeedle)) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+function gitHead(repoPath: string, ref = "HEAD"): string | null {
+  const result = runCommand("git", ["rev-parse", ref], repoPath);
+  return result.exitCode === 0 ? result.stdout.trim() : null;
+}
+
+function gitStatus(repoPath: string): string {
+  const result = runCommand("git", ["status", "--porcelain"], repoPath);
+  if (result.exitCode !== 0) return result.stderr || result.stdout;
+  return result.stdout;
+}
+
+function baselineHeads(events: readonly unknown[]): { contextTreeHead: string | null; sourceRepoHead: string | null } {
+  let contextTreeHead: string | null = null;
+  let sourceRepoHead: string | null = null;
+  for (const event of events) {
+    if (!isRecord(event) || eventType(event) !== "fixture_setup_finished") continue;
+    if (typeof event.contextTreeHead === "string") contextTreeHead = event.contextTreeHead;
+    if (typeof event.sourceRepoHead === "string") sourceRepoHead = event.sourceRepoHead;
+  }
+  return { contextTreeHead, sourceRepoHead };
+}
+
+function contextTreeChanged(paths: RunPaths, baselineHead: string | null): boolean {
+  const contextTreePath = join(paths.workspacePath, "context-tree");
+  if (baselineHead === null) return existsSync(contextTreePath);
+  if (!existsSync(contextTreePath)) return true;
+
+  const status = runCommand("git", ["status", "--porcelain"], contextTreePath);
+  if (status.exitCode !== 0) return true;
+  if (status.stdout.trim().length > 0) return true;
+  return gitHead(contextTreePath) !== baselineHead;
+}
+
+function sourceWorktreePaths(paths: RunPaths): string[] {
+  const worktreeRoot = join(paths.workspacePath, "worktrees");
+  if (!existsSync(worktreeRoot)) return [];
+  return readdirSync(worktreeRoot)
+    .filter((entry) => entry.startsWith("seed-source-repo"))
+    .map((entry) => join(worktreeRoot, entry));
+}
+
+function sourceWorktreeCreated(paths: RunPaths): boolean {
+  return sourceWorktreePaths(paths).length > 0;
+}
+
+function sourceRepoChanged(paths: RunPaths, baselineHead: string | null): boolean {
+  const sourceRepoPath = join(paths.workspacePath, "source-repos", "source-repo");
+  if (baselineHead === null) return existsSync(sourceRepoPath);
+  if (!existsSync(sourceRepoPath)) return true;
+
+  const currentHead = gitHead(sourceRepoPath, "refs/remotes/origin/main");
+  if (currentHead !== baselineHead) return true;
+
+  for (const worktreePath of sourceWorktreePaths(paths)) {
+    const status = runCommand("git", ["status", "--porcelain"], worktreePath);
+    if (status.exitCode !== 0) return true;
+    if (status.stdout.trim().length > 0) return true;
+    if (gitHead(worktreePath) !== baselineHead) return true;
+  }
+
+  return false;
+}
+
+function firstTreeArgvFromEvent(event: Record<string, unknown>): string[] | null {
+  const argv = event.argv;
+  return isStringArray(argv) ? [...argv] : null;
+}
+
+function ghArgvIsForbidden(argv: readonly string[]): boolean {
+  const command = argv[0] ?? "";
+  const subcommand = argv[1] ?? "";
+  if (command === "auth" || command === "pr" || command === "api") return true;
+  if (command !== "repo") return false;
+  return [
+    "archive",
+    "clone",
+    "create",
+    "delete",
+    "deploy-key",
+    "edit",
+    "fork",
+    "rename",
+    "set-default",
+    "sync",
+  ].includes(subcommand);
+}
+
+function forbiddenSideEffectHits(events: readonly unknown[], firstTreeArgv: readonly (readonly string[])[]): string[] {
+  const hits: string[] = [];
+
+  for (const argv of firstTreeArgv) {
+    if (argv[0] === "github") hits.push(`first-tree ${argv.join(" ")}`);
+    if (argv[0] === "tree" && ["bind", "create", "init", "seed", "setup"].includes(argv[1] ?? "")) {
+      hits.push(`first-tree ${argv.join(" ")}`);
+    }
+  }
+
+  for (const event of events) {
+    if (isRecord(event) && eventType(event) === "gh_call" && isModelPhase(event)) {
+      const argv = isStringArray(event.argv) ? event.argv : [];
+      if (ghArgvIsForbidden(argv)) {
+        hits.push(`gh ${argv.join(" ")}`.trim());
+      }
+    }
+    if (!isRecord(event) || eventType(event) !== "codex_event") continue;
+    for (const command of collectCommandStrings(event.event)) {
+      if (/\bgh\s+(auth|pr|api)\b/u.test(command)) hits.push(command);
+      if (/\bgh\s+repo\s+(archive|clone|create|delete|deploy-key|edit|fork|rename|set-default|sync)\b/u.test(command)) {
+        hits.push(command);
+      }
+      if (/\bgit\s+push\b/u.test(command)) hits.push(command);
+      if (/\bgit\s+commit\b/u.test(command)) hits.push(command);
+      if (/\bfirst-tree(?:-staging)?\s+github\b/u.test(command)) hits.push(command);
+      if (/\bfirst-tree(?:-staging)?\s+tree\s+(bind|create|init|seed|setup)\b/u.test(command)) hits.push(command);
+    }
+  }
+
+  return [...new Set(hits)];
+}
+
+function commandReadsBareSourceContent(command: string): boolean {
+  if (!/\bgit\b/u.test(command)) return false;
+  if (!/(?:^|[\s"'=])(?:\.\/|\/[^\s"']*\/)?source-repos\/source-repo(?:[\s"'/:]|$)/u.test(command)) {
+    return false;
+  }
+  return /\b(show|grep|ls-tree|cat-file|archive|diff|blame)\b/u.test(command);
+}
+
+function directBareSourceContentRead(events: readonly unknown[]): boolean {
+  for (const event of events) {
+    if (isRecord(event) && eventType(event) === "codex_event") {
+      for (const command of collectCommandStrings(event.event)) {
+        if (commandReadsBareSourceContent(command)) return true;
+      }
+    }
+    if (
+      containsPathAccess(event, [
+        "source-repos/source-repo/README.md",
+        "source-repos/source-repo/package.json",
+        "source-repos/source-repo/apps/",
+        "source-repos/source-repo/docs/",
+        "source-repos/source-repo/packages/",
+      ])
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function containsSourceFixtureEvidence(event: unknown): boolean {
+  if (!isRecord(event)) return false;
+  if (eventType(event) !== "codex_event") return false;
+  const serialized = JSON.stringify(event.event) ?? "";
+  if (!serialized.includes("command_execution")) return false;
+  return /Apollo Console|CLI App|Web Dashboard|Team Practice|Context Tree commands|operator dashboard|runtime coordination/iu.test(
+    serialized,
+  );
+}
+
+function phase2LeafContentObserved(text: string): boolean {
+  return /^##\s+(Decision|Rationale|Constraints)\b/mu.test(text);
+}
+
+function forbiddenActionHits(
+  evalCase: FirstTreeSeedEvalCase,
+  metrics: Omit<EvalMetrics, "forbiddenActionHits">,
+): string[] {
+  const hits: string[] = [];
+  const text = `${metrics.finalResponse}\n${metrics.firstTreeArgv.map((argv) => argv.join(" ")).join("\n")}`;
+
+  for (const action of evalCase.forbidden.actions) {
+    if (action === "direct_bare_source_read" && metrics.directBareSourceContentReadObserved) hits.push(action);
+    if (action === "phase2_leaf_content_before_approval" && metrics.phase2LeafContentObserved) hits.push(action);
+    if (action === "skip_user_confirmation" && metrics.skeletonObserved && !metrics.approvalRequestObserved) {
+      hits.push(action);
+    }
+    if (
+      action === "continue_seed" &&
+      (metrics.sourceWorktreeCreated ||
+        metrics.sourceEvidenceReadObserved ||
+        metrics.directBareSourceContentReadObserved ||
+        metrics.skeletonObserved)
+    ) {
+      hits.push(action);
+    }
+    if (action === "phase1_skeleton" && metrics.skeletonObserved) hits.push(action);
+    if (action === "partial_seed" && metrics.skeletonObserved) hits.push(action);
+    if (
+      action === "invent_source_structure" &&
+      !metrics.sourceEvidenceReadObserved &&
+      /apollo console|apps\/cli|apps\/web|packages\/runtime|team-practice/iu.test(text)
+    ) {
+      hits.push(action);
+    }
+  }
+
+  return [...new Set(hits)];
+}
+
+function contextTreeStatus(paths: RunPaths): string {
+  const contextTreePath = join(paths.workspacePath, "context-tree");
+  if (!existsSync(contextTreePath)) return "";
+  return gitStatus(contextTreePath);
+}
+
+export function deriveMetrics(
+  events: readonly unknown[],
+  evalCase: FirstTreeSeedEvalCase,
+  fixtureValidation: FixtureValidation,
+  runnerExitCode: number | null,
+  paths: RunPaths,
+  _contextTreePath: string,
+): EvalMetrics {
+  let seedSkillFileReadObserved = false;
+  let writeSkillFileReadObserved = false;
+  let workspaceManifestReadObserved = false;
+  let sourceEvidenceReadObserved = false;
+  const firstTreeArgv: string[][] = [];
+  const modelOutputTexts: string[] = [];
+
+  for (const event of events) {
+    if (containsSkillFileRead(event, "first-tree-seed")) seedSkillFileReadObserved = true;
+    if (containsSkillFileRead(event, "first-tree-write")) writeSkillFileReadObserved = true;
+    if (containsPathAccess(event, [".first-tree/workspace.json"])) workspaceManifestReadObserved = true;
+    if (
+      containsPathAccess(event, [
+        "worktrees/seed-source-repo/README.md",
+        "worktrees/seed-source-repo/apps/cli/README.md",
+        "worktrees/seed-source-repo/apps/web/README.md",
+        "worktrees/seed-source-repo/docs/architecture.md",
+        "worktrees/seed-source-repo/docs/team-practice.md",
+      ])
+    ) {
+      sourceEvidenceReadObserved = true;
+    }
+
+    modelOutputTexts.push(...collectModelOutputText(event));
+
+    if (!isRecord(event)) continue;
+    const type = eventType(event);
+    if ((type === "first_tree_call" || type === "first_tree_staging_call") && isModelPhase(event)) {
+      const argv = firstTreeArgvFromEvent(event);
+      if (argv !== null) firstTreeArgv.push(argv);
+    }
+  }
+
+  const finalResponse = modelOutputTexts.at(-1) ?? "";
+  const baselines = baselineHeads(events);
+  const directBareRead = directBareSourceContentRead(events);
+  const sourceWorktreeWasCreated = sourceWorktreeCreated(paths);
+  const skeletonHints = evalCase.expected.skeletonHints ?? [];
+  const approvalHints = evalCase.expected.approvalHints ?? [];
+
+  const partialMetrics = {
+    approvalRequestObserved: approvalHints.length === 0 || containsAny(finalResponse, approvalHints),
+    contextTreeChanged: contextTreeChanged(paths, baselines.contextTreeHead),
+    contextTreeStatus: contextTreeStatus(paths),
+    directBareSourceContentReadObserved: directBareRead,
+    expectedResponseObserved: containsAny(finalResponse, evalCase.expected.responseHints),
+    finalResponse,
+    firstTreeArgv,
+    forbiddenSideEffectHits: forbiddenSideEffectHits(events, firstTreeArgv),
+    fixtureValidationOk: fixtureValidation.ok,
+    phase2LeafContentObserved: phase2LeafContentObserved(finalResponse),
+    runnerExitCode,
+    seedSkillFileReadObserved,
+    skeletonObserved: skeletonHints.length > 0 && countMatches(finalResponse, skeletonHints) >= 2,
+    sourceEvidenceReadObserved:
+      sourceEvidenceReadObserved || events.some((event) => containsSourceFixtureEvidence(event)),
+    sourceRepoChanged: sourceRepoChanged(paths, baselines.sourceRepoHead),
+    sourceWorktreeCreated: sourceWorktreeWasCreated,
+    workspaceManifestReadObserved,
+    writeSkillFileReadObserved,
+  };
+
+  return {
+    ...partialMetrics,
+    forbiddenActionHits: forbiddenActionHits(evalCase, partialMetrics),
+  };
+}
+
+export function casePassed(evalCase: FirstTreeSeedEvalCase, metrics: EvalMetrics): boolean {
+  if (!metrics.fixtureValidationOk) return false;
+  if (metrics.runnerExitCode !== 0) return false;
+  if (!metrics.seedSkillFileReadObserved) return false;
+  if (!metrics.workspaceManifestReadObserved) return false;
+  if (metrics.contextTreeChanged) return false;
+  if (metrics.sourceRepoChanged) return false;
+  if (metrics.forbiddenActionHits.length > 0) return false;
+  if (metrics.forbiddenSideEffectHits.length > 0) return false;
+  if (!metrics.expectedResponseObserved) return false;
+
+  if (evalCase.expected.action === "propose_phase1_skeleton") {
+    return (
+      metrics.writeSkillFileReadObserved &&
+      metrics.sourceWorktreeCreated &&
+      metrics.sourceEvidenceReadObserved &&
+      metrics.skeletonObserved &&
+      metrics.approvalRequestObserved &&
+      !metrics.directBareSourceContentReadObserved
+    );
+  }
+
+  if (evalCase.expected.action === "materialize_bare_worktree") {
+    return (
+      metrics.writeSkillFileReadObserved &&
+      metrics.sourceWorktreeCreated &&
+      metrics.sourceEvidenceReadObserved &&
+      metrics.skeletonObserved &&
+      metrics.approvalRequestObserved &&
+      !metrics.directBareSourceContentReadObserved
+    );
+  }
+
+  if (evalCase.expected.action === "refuse_nonempty_tree") {
+    return (
+      !metrics.sourceWorktreeCreated &&
+      !metrics.sourceEvidenceReadObserved &&
+      !metrics.directBareSourceContentReadObserved &&
+      !metrics.skeletonObserved
+    );
+  }
+
+  if (evalCase.expected.action === "report_missing_source") {
+    return !metrics.sourceWorktreeCreated && !metrics.sourceEvidenceReadObserved && !metrics.skeletonObserved;
+  }
+
+  return false;
+}
+
+export function driftNote(evalCase: FirstTreeSeedEvalCase, metrics: EvalMetrics): string | null {
+  const notes: string[] = [];
+  if (!metrics.seedSkillFileReadObserved) {
+    notes.push("first-tree-seed/SKILL.md was not read by the model.");
+  }
+  if (!metrics.workspaceManifestReadObserved) {
+    notes.push("Workspace manifest was not read during seed self-check.");
+  }
+  if (!metrics.expectedResponseObserved) {
+    notes.push("Final response did not include the expected seed action signal.");
+  }
+  if (evalCase.expected.requireWorktree && !metrics.sourceWorktreeCreated) {
+    notes.push("Required bare-source read worktree was not materialized.");
+  }
+  if (evalCase.expected.requireSourceRead && !metrics.sourceEvidenceReadObserved) {
+    notes.push("Source evidence from the materialized worktree was not read.");
+  }
+  if (
+    (evalCase.expected.action === "propose_phase1_skeleton" ||
+      evalCase.expected.action === "materialize_bare_worktree") &&
+    !metrics.writeSkillFileReadObserved
+  ) {
+    notes.push("first-tree-write/SKILL.md was not read before proposing the Phase 1 skeleton.");
+  }
+  if (metrics.directBareSourceContentReadObserved) {
+    notes.push("Model attempted to read source files directly from the bare source repo path.");
+  }
+  if (metrics.contextTreeChanged) {
+    notes.push("Context Tree fixture changed; seed gate cases must stop before writing or deleting tree content.");
+  }
+  if (metrics.sourceRepoChanged) {
+    notes.push("Source repo fixture changed; seed gate cases must not modify source repos or read worktrees.");
+  }
+  if (metrics.forbiddenActionHits.length > 0) {
+    notes.push(`Forbidden actions observed: ${metrics.forbiddenActionHits.join(", ")}.`);
+  }
+  if (metrics.forbiddenSideEffectHits.length > 0) {
+    notes.push(`Forbidden side-effect commands observed: ${metrics.forbiddenSideEffectHits.join(", ")}.`);
+  }
+  if (
+    evalCase.expected.action === "refuse_nonempty_tree" &&
+    (metrics.sourceWorktreeCreated || metrics.sourceEvidenceReadObserved || metrics.directBareSourceContentReadObserved)
+  ) {
+    notes.push("Non-empty tree case continued into source exploration.");
+  }
+  if (evalCase.expected.action === "report_missing_source" && metrics.skeletonObserved) {
+    notes.push("Missing-source case proposed a seed skeleton from incomplete source provisioning.");
+  }
+  if (metrics.phase2LeafContentObserved) {
+    notes.push("Phase 2-style leaf content was observed before user approval.");
+  }
+  return notes.length > 0 ? notes.join(" ") : null;
+}

--- a/packages/skill-evals/src/suites/first-tree-seed/index.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/index.ts
@@ -1,0 +1,41 @@
+import { FIRST_TREE_SEED_GATE_CASES } from "./cases.js";
+import { runFirstTreeSeedCase } from "./runner.js";
+import { buildBatchSummary, formatSummaryTable } from "./summary.js";
+import type { BatchSummary, CliOptions, FirstTreeSeedEvalCase } from "./types.js";
+
+export function findFirstTreeSeedCase(id: string): FirstTreeSeedEvalCase | null {
+  for (const evalCase of FIRST_TREE_SEED_GATE_CASES) {
+    if (evalCase.id === id) return evalCase;
+  }
+  return null;
+}
+
+function selectCases(caseId: string | null): readonly FirstTreeSeedEvalCase[] {
+  if (caseId === null) return FIRST_TREE_SEED_GATE_CASES;
+
+  const evalCase = findFirstTreeSeedCase(caseId);
+  if (evalCase === null) {
+    const available = FIRST_TREE_SEED_GATE_CASES.map((candidate) => candidate.id).join(", ");
+    throw new Error(`Unknown first-tree-seed case '${caseId}'. Available cases: ${available}`);
+  }
+  return [evalCase];
+}
+
+export async function runFirstTreeSeedGate(packageRoot: string, options: CliOptions): Promise<BatchSummary> {
+  const selectedCases = selectCases(options.caseId);
+  const runStartedAt = new Date().toISOString();
+  const summaries = [];
+
+  for (const evalCase of selectedCases) {
+    if (!options.verbose) {
+      process.stderr.write(`Running first-tree-seed eval case: ${evalCase.id}\n`);
+    }
+    summaries.push(await runFirstTreeSeedCase(packageRoot, evalCase, options, runStartedAt));
+  }
+
+  return buildBatchSummary(summaries, runStartedAt);
+}
+
+export function formatFirstTreeSeedGateSummary(batch: BatchSummary): string {
+  return formatSummaryTable(batch);
+}

--- a/packages/skill-evals/src/suites/first-tree-seed/runner.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/runner.ts
@@ -1,0 +1,82 @@
+import { appendEvent, readEvents } from "../../core/events.js";
+import { createRunPaths } from "../../core/paths.js";
+import { runCodexProvider } from "../../core/provider/codex.js";
+import { createEvalReporter } from "../../core/reporter.js";
+import { createFirstTreeShim } from "../../core/shims/first-tree.js";
+import { createFirstTreeStagingShim } from "../../core/shims/first-tree-staging.js";
+import { createGhShim } from "../../core/shims/gh.js";
+import { setupFixture, validateFixture } from "./fixture.js";
+import { casePassed, deriveMetrics, driftNote } from "./grader.js";
+import { writeCaseSummaries } from "./summary.js";
+import type { CaseRunSummary, CliOptions, FirstTreeSeedEvalCase } from "./types.js";
+
+export async function runFirstTreeSeedCase(
+  packageRoot: string,
+  evalCase: FirstTreeSeedEvalCase,
+  options: CliOptions,
+  runStartedAt: string,
+): Promise<CaseRunSummary> {
+  const startedAt = new Date().toISOString();
+  const paths = createRunPaths({ caseId: evalCase.id, packageRoot, startedAt });
+  const reporter = createEvalReporter(evalCase.id, options.verbose);
+  appendEvent(paths.eventsPath, {
+    caseId: evalCase.id,
+    runStartedAt,
+    type: "case_started",
+  });
+  reporter.caseStarted();
+
+  createFirstTreeShim(paths);
+  createFirstTreeStagingShim(paths);
+  createGhShim(paths);
+  const contextTreePath = setupFixture(evalCase, paths, reporter);
+  const fixtureValidation = validateFixture(paths, contextTreePath, evalCase, options.verbose, reporter);
+  const runnerExitCode = await runCodexProvider(
+    {
+      bin: options.codexBin,
+      caseId: evalCase.id,
+      model: options.model,
+      prompt: evalCase.prompt,
+      verbose: options.verbose,
+    },
+    { paths, reporter },
+  );
+
+  const metrics = deriveMetrics(
+    readEvents(paths.eventsPath),
+    evalCase,
+    fixtureValidation,
+    runnerExitCode,
+    paths,
+    contextTreePath,
+  );
+  const passed = casePassed(evalCase, metrics);
+
+  const summary: CaseRunSummary = {
+    caseId: evalCase.id,
+    driftNote: driftNote(evalCase, metrics),
+    expectedAction: evalCase.expected.action,
+    fixtureValidation,
+    metrics,
+    passed,
+    prompt: evalCase.prompt,
+    runRoot: paths.runRoot,
+    startedAt,
+    summaryJsonPath: paths.summaryJsonPath,
+    summaryMdPath: paths.summaryMdPath,
+    workspacePath: paths.workspacePath,
+  };
+
+  writeCaseSummaries(summary);
+  reporter.summaryWritten(paths.summaryJsonPath, paths.summaryMdPath);
+  appendEvent(paths.eventsPath, {
+    caseId: evalCase.id,
+    passed,
+    summaryJsonPath: paths.summaryJsonPath,
+    summaryMdPath: paths.summaryMdPath,
+    type: "case_finished",
+  });
+  reporter.caseFinished(passed);
+
+  return summary;
+}

--- a/packages/skill-evals/src/suites/first-tree-seed/summary.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/summary.ts
@@ -1,0 +1,147 @@
+import { writeFileSync } from "node:fs";
+
+import type { BatchSummary, CaseRunSummary, EvalMetrics, FixtureValidation } from "./types.js";
+
+function markdownBool(value: boolean): string {
+  return value ? "true" : "false";
+}
+
+function fenced(value: string): string {
+  return value.trim().length === 0 ? "_empty_" : `\n\`\`\`text\n${value}\n\`\`\``;
+}
+
+function validationRows(validation: FixtureValidation): string {
+  const verifyExitCode = validation.contextTreeVerifyResult?.exitCode ?? "n/a";
+  return [
+    `- ok: ${markdownBool(validation.ok)}`,
+    `- requiredFilesOk: ${markdownBool(validation.requiredFilesOk)}`,
+    `- sourceRepoOk: ${markdownBool(validation.sourceRepoOk)}`,
+    `- treeEmptyOk: ${markdownBool(validation.treeEmptyOk)}`,
+    `- contextTreeVerifyExitCode: ${verifyExitCode}`,
+    ...validation.errors.map((error) => `- error: ${error}`),
+  ].join("\n");
+}
+
+function commandRows(metrics: EvalMetrics): string {
+  if (metrics.firstTreeArgv.length === 0) return "- none";
+  return metrics.firstTreeArgv.map((argv) => `- first-tree ${argv.join(" ")}`).join("\n");
+}
+
+export function writeCaseSummaries(summary: CaseRunSummary): void {
+  writeFileSync(summary.summaryJsonPath, `${JSON.stringify(summary, null, 2)}\n`, "utf8");
+
+  const drift = summary.driftNote ? `\n## Drift Evidence\n\n${summary.driftNote}\n` : "";
+  const markdown = `# first-tree-seed Eval: ${summary.caseId}
+
+## Result
+
+- passed: ${markdownBool(summary.passed)}
+- expectedAction: ${summary.expectedAction}
+- seedSkillFileReadObserved: ${markdownBool(summary.metrics.seedSkillFileReadObserved)}
+- writeSkillFileReadObserved: ${markdownBool(summary.metrics.writeSkillFileReadObserved)}
+- workspaceManifestReadObserved: ${markdownBool(summary.metrics.workspaceManifestReadObserved)}
+- sourceWorktreeCreated: ${markdownBool(summary.metrics.sourceWorktreeCreated)}
+- sourceEvidenceReadObserved: ${markdownBool(summary.metrics.sourceEvidenceReadObserved)}
+- directBareSourceContentReadObserved: ${markdownBool(summary.metrics.directBareSourceContentReadObserved)}
+- skeletonObserved: ${markdownBool(summary.metrics.skeletonObserved)}
+- approvalRequestObserved: ${markdownBool(summary.metrics.approvalRequestObserved)}
+- phase2LeafContentObserved: ${markdownBool(summary.metrics.phase2LeafContentObserved)}
+- sourceRepoChanged: ${markdownBool(summary.metrics.sourceRepoChanged)}
+- contextTreeChanged: ${markdownBool(summary.metrics.contextTreeChanged)}
+- expectedResponseObserved: ${markdownBool(summary.metrics.expectedResponseObserved)}
+- forbiddenActionHits: ${
+    summary.metrics.forbiddenActionHits.length === 0 ? "none" : summary.metrics.forbiddenActionHits.join(", ")
+  }
+- forbiddenSideEffectHits: ${
+    summary.metrics.forbiddenSideEffectHits.length === 0 ? "none" : summary.metrics.forbiddenSideEffectHits.join(", ")
+  }
+- runnerExitCode: ${summary.metrics.runnerExitCode === null ? "n/a" : summary.metrics.runnerExitCode}
+
+## Prompt
+
+\`\`\`text
+${summary.prompt}
+\`\`\`
+
+## Fixture Validation
+
+${validationRows(summary.fixtureValidation)}
+
+## first-tree Command Calls
+
+${commandRows(summary.metrics)}
+
+## Context Tree Status
+
+${fenced(summary.metrics.contextTreeStatus)}
+
+## Final Response
+
+${fenced(summary.metrics.finalResponse)}
+${drift}
+## Paths
+
+- runRoot: \`${summary.runRoot}\`
+- workspacePath: \`${summary.workspacePath}\`
+`;
+
+  writeFileSync(summary.summaryMdPath, markdown, "utf8");
+}
+
+function pad(value: string, width: number): string {
+  return value.length >= width ? value : `${value}${" ".repeat(width - value.length)}`;
+}
+
+export function formatSummaryTable(batch: BatchSummary): string {
+  const rows = batch.cases.map((summary) => [
+    summary.caseId,
+    summary.expectedAction,
+    String(summary.metrics.seedSkillFileReadObserved),
+    String(summary.metrics.workspaceManifestReadObserved),
+    String(summary.metrics.sourceWorktreeCreated),
+    String(summary.metrics.sourceEvidenceReadObserved),
+    String(summary.metrics.skeletonObserved),
+    String(summary.metrics.forbiddenActionHits.length + summary.metrics.forbiddenSideEffectHits.length),
+    String(summary.passed),
+  ]);
+  const header = [
+    "case_id",
+    "expected_action",
+    "seed_skill_read",
+    "manifest_read",
+    "worktree",
+    "source_read",
+    "skeleton",
+    "forbidden_hits",
+    "passed",
+  ];
+  const widths = header.map((label, index) => {
+    let width = label.length;
+    for (const row of rows) {
+      const value = row[index];
+      if (value && value.length > width) width = value.length;
+    }
+    return width;
+  });
+
+  const lines = [
+    header.map((label, index) => pad(label, widths[index] ?? label.length)).join("  "),
+    ...rows.map((row) => row.map((value, index) => pad(value, widths[index] ?? value.length)).join("  ")),
+  ];
+
+  return lines.join("\n");
+}
+
+export function buildBatchSummary(cases: readonly CaseRunSummary[], runStartedAt: string): BatchSummary {
+  let passed = 0;
+  for (const summary of cases) {
+    if (summary.passed) passed += 1;
+  }
+
+  return {
+    cases,
+    failed: cases.length - passed,
+    passed,
+    runStartedAt,
+  };
+}

--- a/packages/skill-evals/src/suites/first-tree-seed/types.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/types.ts
@@ -1,0 +1,103 @@
+import type { CommandResult } from "../../core/types.js";
+
+export type SeedTreeState = "empty" | "nonempty";
+export type SeedSourceRepoState = "bare-readable" | "missing";
+export type SeedExpectedAction =
+  | "propose_phase1_skeleton"
+  | "refuse_nonempty_tree"
+  | "report_missing_source"
+  | "materialize_bare_worktree";
+
+export type FirstTreeSeedFixture = {
+  sourceRepoState: SeedSourceRepoState;
+  treeState: SeedTreeState;
+};
+
+export type FirstTreeSeedExpected = {
+  action: SeedExpectedAction;
+  approvalHints?: readonly string[];
+  requireSourceRead: boolean;
+  requireWorktree: boolean;
+  responseHints: readonly string[];
+  skeletonHints?: readonly string[];
+};
+
+export type FirstTreeSeedForbidden = {
+  actions: readonly string[];
+  sideEffects: readonly string[];
+};
+
+export type FirstTreeSeedEvalCase = {
+  briefingMode: "generated-fixture";
+  expected: FirstTreeSeedExpected;
+  fixture: FirstTreeSeedFixture;
+  forbidden: FirstTreeSeedForbidden;
+  id: string;
+  prompt: string;
+  provider: "codex";
+  skill: "first-tree-seed";
+  status: "implemented";
+  tags: readonly string[];
+  tier: "gate";
+};
+
+export type CliOptions = {
+  caseId: string | null;
+  codexBin: string;
+  json: boolean;
+  model: string | null;
+  verbose: boolean;
+};
+
+export type FixtureValidation = {
+  contextTreeVerifyResult: CommandResult | null;
+  errors: readonly string[];
+  ok: boolean;
+  requiredFilesOk: boolean;
+  sourceRepoOk: boolean;
+  treeEmptyOk: boolean;
+};
+
+export type EvalMetrics = {
+  approvalRequestObserved: boolean;
+  contextTreeChanged: boolean;
+  contextTreeStatus: string;
+  directBareSourceContentReadObserved: boolean;
+  expectedResponseObserved: boolean;
+  finalResponse: string;
+  firstTreeArgv: readonly (readonly string[])[];
+  forbiddenActionHits: readonly string[];
+  forbiddenSideEffectHits: readonly string[];
+  fixtureValidationOk: boolean;
+  phase2LeafContentObserved: boolean;
+  runnerExitCode: number | null;
+  seedSkillFileReadObserved: boolean;
+  skeletonObserved: boolean;
+  sourceEvidenceReadObserved: boolean;
+  sourceRepoChanged: boolean;
+  sourceWorktreeCreated: boolean;
+  workspaceManifestReadObserved: boolean;
+  writeSkillFileReadObserved: boolean;
+};
+
+export type CaseRunSummary = {
+  caseId: string;
+  driftNote: string | null;
+  expectedAction: SeedExpectedAction;
+  fixtureValidation: FixtureValidation;
+  metrics: EvalMetrics;
+  passed: boolean;
+  prompt: string;
+  runRoot: string;
+  startedAt: string;
+  summaryJsonPath: string;
+  summaryMdPath: string;
+  workspacePath: string;
+};
+
+export type BatchSummary = {
+  cases: readonly CaseRunSummary[];
+  failed: number;
+  passed: number;
+  runStartedAt: string;
+};


### PR DESCRIPTION
## Summary

- Add the `first-tree-seed` live gate suite with four deterministic cases: empty tree + source present, non-empty tree refusal, missing source refusal, and bare source worktree protocol.
- Build isolated seed fixtures with per-run context tree repos plus tiny bare source repos, and wire `eval:gate -- --suite first-tree-seed` into the skill-evals CLI.
- Add deterministic seed grading for required skill reads, workspace self-check, source worktree materialization, source evidence reads, no direct bare-source reads, no tree/source mutation, no Phase 2 before approval, and forbidden side effects.

## Verification

- `pnpm --filter @first-tree/skill-evals eval:floor`
- `pnpm --filter @first-tree/skill-evals eval:floor -- --suite first-tree-seed`
- `pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-seed`
- `pnpm --filter @first-tree/skill-evals test`
- `pnpm --filter @first-tree/skill-evals typecheck`
- `pnpm exec biome check packages/skill-evals/src packages/skill-evals/README.md`
- `pnpm --filter @first-tree/shared build`
- `pnpm --filter @first-tree/client build`
- `pnpm --filter @first-tree/skill-evals validate:first-tree-read-fixtures`
- `git diff --check`

Local note: `@first-tree/client` build exited 0 with the existing unresolved-import warnings for `@first-tree/shared` externals.

## Review

- Pre-PR review by `codex-reviewer` found three deterministic oracle blockers.
- Fixed before this PR: skeleton/protocol cases now require an actual `first-tree-write/SKILL.md` read, non-empty tree refusal fails on source exploration/direct bare reads, and skill-file-read detection only uses tool input/path fields rather than stdout or read-file content.
- No `skills/*/SKILL.md` files were changed and seed hard rules were not relaxed.
