### PR TITLE
release: bump apps/cli to v0.5.10

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "first-tree-dev",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "type": "module",
   "description": "First Tree — unified CLI for Context Tree onboarding, agent management, and team messaging. (Source-tree dev build; CI rewrites `name` and `bin` for prod / staging publishes — see docs/local-dev-isolation.md.)",
   "keywords": [


### PR DESCRIPTION
Bumps `apps/cli/package.json` from `0.5.9` to `0.5.10` (patch). Only the `version` field changes — `name` (`first-tree-dev`), `bin`, `build-info.ts`, dist-tags, and the lockfile are untouched. CI rewrites name/bin to the prod shape on the `vX.Y.Z` tag publish.

## Draft GitHub Release

**Title:** `v0.5.10 — Externalized native engines, shell-safe chat bodies, longer idle grace`

## Highlights

- **Native engines are now externalized.** The Claude and Codex native engines resolve from your `PATH` (with a one-click install) instead of shipping inside the package — global installs are smaller (~15MB saved by pruning unused Claude SDK JS peer deps), capability detection is install-aware, and missing runtime credentials can be logged in directly from chat.
- **Shell-safe chat bodies.** `chat send` / `chat ask` accept `--message-file` / `-F` / stdin for shell-safe message bodies; inline bodies are now guarded against shell residue, and chat send/ask/update are framed as real CLI tool calls so replies actually get delivered.
- **Long tasks survive idle-suspend.** The client `working_grace` default is widened 1h → 12h.
- **Inline Context build entry.** Connect GitHub and pick a repo inline when starting a Context build.

## Notable fixes

- Login-shell `PATH` probe is now shell-agnostic — fish users are no longer reported as missing — and canonicalizes `PATH` dirs; `CLAUDE_CODE_EXECUTABLE` is gated on executability.
- Stop iOS Safari auto-zoom on mobile inputs (16px floor).
- Context Tree IO diagnostics performance: prefilter/index/reduce candidate scans, time decisions synchronously, reuse the tree binding.
- Onboarding: require a personal agent for readiness, default new chats to a cached starter agent, org-level tree setup recovery.
- Added skill eval gates (welcome, write, floor coverage matrix) and refactored the read suite into the core framework.

## Verification

- `pnpm check` → exit 0 (pre-existing Biome warnings on `main`, unrelated to this diff)
- `pnpm typecheck` → exit 0

## Post-merge steps

1. Wait for the merge-commit `CI` (and main-branch `npm Publish` / `Docker`) to succeed.
2. Confirm the version on the merge SHA, then create GitHub Release + lightweight tag `v0.5.10` targeting that SHA.
3. Verify the tag-triggered `npm Publish` (`first-tree@0.5.10`, dist-tag `latest`) and `Docker` build, then ping for the CapRover deploy.

Do not create the tag from this PR branch.
