### PR TITLE
fix: stop treating a flaky codex --version check as a missing binary

### DIFF
--- a/packages/client/src/__tests__/capability-probes.test.ts
+++ b/packages/client/src/__tests__/capability-probes.test.ts
@@ -505,14 +505,37 @@ describe("resolveCodexRuntimeBinary (handler-contract parity)", () => {
     });
   });
 
-  it("bundle NOT found + PATH codex fails validation → binary-missing", async () => {
-    const verifyPath = (): CodexExecutableVerification => ({ ok: false, reason: "`codex --version` timed out" });
+  it("bundle NOT found + PATH codex non-transient validation failure → binary-missing", async () => {
+    const verifyPath = (): CodexExecutableVerification => ({
+      ok: false,
+      transient: false,
+      reason: "`codex --version` exited 1: broken shim",
+    });
     const res = await resolveCodexRuntimeBinary(
       {},
       { resolveBundled: notFound, findOnPath: () => "/usr/local/bin/codex", verifyPath },
     );
     expect(res.ok).toBe(false);
     if (!res.ok) expect(res.error).toContain("Codex runtime binary is missing");
+  });
+
+  it("bundle NOT found + PATH codex TRANSIENT validation flake → NOT binary-missing", async () => {
+    const verifyPath = (): CodexExecutableVerification => ({
+      ok: false,
+      transient: true,
+      reason: "`codex --version` timed out",
+    });
+    const res = await resolveCodexRuntimeBinary(
+      {},
+      { resolveBundled: notFound, findOnPath: () => "/usr/local/bin/codex", verifyPath },
+    );
+    expect(res.ok).toBe(false);
+    // A flaky smoke check on a present binary must not tell the operator to
+    // reinstall codex.
+    if (!res.ok) {
+      expect(res.error).not.toContain("Codex runtime binary is missing");
+      expect(res.error).toContain("transient host condition");
+    }
   });
 
   it("bundle NOT found + no PATH codex → binary-missing", async () => {

--- a/packages/client/src/__tests__/codex-binary.test.ts
+++ b/packages/client/src/__tests__/codex-binary.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  CodexBinaryVerifyTransientError,
   createCodexClientWithBinaryFallback,
   findCodexExecutableOnPath,
   formatCodexBinaryMissingMessage,
@@ -70,10 +71,33 @@ describe("codex binary resolution", () => {
         },
         {
           resolvePath: () => "/usr/local/bin/codex",
-          verifyPath: () => ({ ok: false, reason: "`codex --version` exited 1: broken shim" }),
+          verifyPath: () => ({ ok: false, transient: false, reason: "`codex --version` exited 1: broken shim" }),
         },
       ),
     ).toThrow(/PATH codex failed validation: `codex --version` exited 1: broken shim/);
+  });
+
+  it("treats a transient PATH-codex verify flake as retryable, NOT a missing binary", () => {
+    let thrown: unknown;
+    try {
+      createCodexClientWithBinaryFallback(
+        { env: { PATH: "/usr/local/bin" } },
+        () => {
+          throw new Error("Unable to locate Codex CLI binaries for x86_64-apple-darwin");
+        },
+        {
+          resolvePath: () => "/usr/local/bin/codex",
+          verifyPath: () => ({ ok: false, transient: true, reason: "`codex --version` timed out" }),
+        },
+      );
+    } catch (err) {
+      thrown = err;
+    }
+    // A present-but-flaky binary must surface as the transient error the
+    // taxonomy retries — never as a permanent "binary missing".
+    expect(thrown).toBeInstanceOf(CodexBinaryVerifyTransientError);
+    expect((thrown as Error).message).not.toMatch(/binary is missing/i);
+    expect(isCodexBinaryMissingError(thrown)).toBe(false);
   });
 
   it("throws an actionable error when neither bundled nor PATH codex exists", () => {

--- a/packages/client/src/__tests__/codex-binary.test.ts
+++ b/packages/client/src/__tests__/codex-binary.test.ts
@@ -137,6 +137,34 @@ describe("codex binary resolution", () => {
     );
   });
 
+  it("verifyCodexExecutable: a deterministic crash signal is NOT transient (broken binary surfaces, no infinite retry)", () => {
+    tmp = mkdtempSync(join(tmpdir(), "ft-codex-crash-"));
+    const executable = join(tmp, "codex");
+    // Self-terminate with SIGSEGV: a binary that always faults on `--version`.
+    writeFileSync(executable, "#!/bin/sh\nkill -SEGV $$\n");
+    chmodSync(executable, 0o755);
+
+    const v = verifyCodexExecutable(executable, { PATH: "" });
+    expect(v.ok).toBe(false);
+    if (!v.ok) {
+      expect(v.transient).toBe(false);
+      expect(v.reason).toMatch(/SEGV/);
+    }
+  });
+
+  it("verifyCodexExecutable: a termination kill (timeout-equivalent) IS transient", () => {
+    tmp = mkdtempSync(join(tmpdir(), "ft-codex-term-"));
+    const executable = join(tmp, "codex");
+    // SIGTERM is how a spawnSync timeout enforces its deadline — a host
+    // condition, not a broken binary.
+    writeFileSync(executable, "#!/bin/sh\nkill -TERM $$\n");
+    chmodSync(executable, 0o755);
+
+    const v = verifyCodexExecutable(executable, { PATH: "" });
+    expect(v.ok).toBe(false);
+    if (!v.ok) expect(v.transient).toBe(true);
+  });
+
   it("finds an executable codex via a login-shell-only PATH dir", () => {
     const dir = mkdtempSync(join(tmpdir(), "ft-codex-login-"));
     tmp = dir;

--- a/packages/client/src/__tests__/error-taxonomy.test.ts
+++ b/packages/client/src/__tests__/error-taxonomy.test.ts
@@ -147,6 +147,27 @@ describe("error-taxonomy.classify", () => {
       expect(stackClass.strategy.kind).toBe("none");
     });
 
+    it("a transient codex --version verify flake is transient, not a missing binary", () => {
+      const err = new Error("codex --version smoke check did not complete (transient host condition); will retry.");
+      err.name = "CodexBinaryVerifyTransientError";
+      const c = classify(err, { source: "session" });
+      expect(c.kind).toBe(ERROR_KINDS.TRANSIENT);
+      expect(c.reasonCode).toBe("codex_verify_transient");
+      expect(c.strategy.kind).toBe("exponentialBackoff");
+    });
+
+    it("AbortSignal.timeout TimeoutError is transient (recognised by name and by message)", () => {
+      const byName = classify(new DOMException("The operation was aborted due to timeout", "TimeoutError"), {
+        source: "session",
+      });
+      expect(byName.kind).toBe(ERROR_KINDS.TRANSIENT);
+      expect(byName.reasonCode).toBe("operation_timeout");
+      // Proxied/wrapped errors that lose the DOMException name still match on text.
+      const byText = classify(new Error("The operation was aborted due to timeout"));
+      expect(byText.reasonCode).toBe("operation_timeout");
+      expect(byText.kind).toBe(ERROR_KINDS.TRANSIENT);
+    });
+
     it("status-only and text-only Claude errors cover non-name branches and defaults", () => {
       expect(classify(noMessageShape({ status: 429 })).message).toBe("Claude API rate limit");
       expect(classify("rate limit exceeded").reasonCode).toBe("claude_rate_limit");

--- a/packages/client/src/__tests__/provider-retry-policy.test.ts
+++ b/packages/client/src/__tests__/provider-retry-policy.test.ts
@@ -107,6 +107,42 @@ describe("classifyProviderFailure", () => {
     }
   });
 
+  it("a transient codex --version verify flake is retried at session start, NOT a terminal capability failure", () => {
+    const err = new Error(
+      "codex --version smoke check did not complete (transient host condition); will retry. Detail: `codex --version` timed out",
+    );
+    err.name = "CodexBinaryVerifyTransientError";
+    const c = classifyProviderFailure(err, { provider: "codex", scope: "session_start", source: "session" });
+    // The regression: this used to land in `capability` → needs_operator →
+    // terminal. It must now be transient_transport so the bring-up retries.
+    expect(c.category).toBe("transient_transport");
+    expect(c.reasonCode).toBe("codex_verify_transient");
+    expect(
+      decideProviderRetry({ classification: c, scope: "session_start", attempt: 1, replaySafety: "pre_provider" }),
+    ).toMatchObject({ action: "retry" });
+  });
+
+  it("a codex backend AbortSignal.timeout is transient_transport and retried", () => {
+    const err = new DOMException("The operation was aborted due to timeout", "TimeoutError");
+    const c = classifyProviderFailure(err, { provider: "codex", scope: "provider_turn", source: "sdk" });
+    expect(c.category).toBe("transient_transport");
+    expect(c.reasonCode).toBe("operation_timeout");
+    expect(
+      decideProviderRetry({ classification: c, scope: "provider_turn", attempt: 1, replaySafety: "pre_provider" }),
+    ).toMatchObject({ action: "retry" });
+  });
+
+  it("a genuinely missing codex binary stays terminal needs_operator (no false retry)", () => {
+    const err = new Error(
+      "Codex runtime binary is missing on this machine. First Tree does not bundle the native Codex engine by default.",
+    );
+    const c = classifyProviderFailure(err, { provider: "codex", scope: "session_start", source: "session" });
+    expect(c.category).toBe("capability");
+    expect(
+      decideProviderRetry({ classification: c, scope: "session_start", attempt: 1, replaySafety: "pre_provider" }),
+    ).toMatchObject({ action: "stop", terminalKind: "needs_operator" });
+  });
+
   it("maps deterministic and operator-actionable failures to stop categories", () => {
     const cases: Array<[unknown, ProviderFailureClassification["category"]]> = [
       [Object.assign(new Error("401 Unauthorized"), { status: 401 }), "credential"],

--- a/packages/client/src/runtime/capabilities/codex.ts
+++ b/packages/client/src/runtime/capabilities/codex.ts
@@ -208,6 +208,15 @@ export async function resolveCodexRuntimeBinary(
         version: match ? match[0] : null,
       };
     }
+    // A present binary that only flaked its smoke check (timeout / host
+    // pressure) is NOT missing — say so honestly instead of telling the
+    // operator to reinstall codex.
+    if (verification.transient) {
+      return {
+        ok: false,
+        error: `codex resolved at ${pathBinary} but \`codex --version\` did not complete (transient host condition): ${verification.reason}`,
+      };
+    }
     return {
       ok: false,
       error: formatCodexBinaryMissingMessage(`PATH codex failed validation: ${verification.reason}`),

--- a/packages/client/src/runtime/codex-binary.ts
+++ b/packages/client/src/runtime/codex-binary.ts
@@ -25,7 +25,46 @@ export type CodexBinaryFallbackDeps = {
   log?: (message: string) => void;
 };
 
-export type CodexExecutableVerification = { ok: true; output?: string } | { ok: false; reason: string };
+export type CodexExecutableVerification =
+  | { ok: true; output?: string }
+  | { ok: false; reason: string; transient: boolean };
+
+/**
+ * `codex --version` smoke-check ceiling. A cold `codex` behind a version-manager
+ * shim (nvm / fnm / volta / mise / asdf) or on a loaded machine can take several
+ * seconds to first respond, so a tight bound turns a present, working binary
+ * into a spurious failure. Paired with the transient-vs-missing split below: a
+ * verify that flakes (timeout / machine pressure) is retried, not declared
+ * permanently missing.
+ */
+const CODEX_VERSION_VERIFY_TIMEOUT_MS = 10_000;
+
+/**
+ * Spawn errnos that mean "the machine couldn't run the check right now", NOT
+ * "the binary is broken/absent": the timeout kill, plus transient resource
+ * pressure. These map to a transient verification failure (→ retry), never to a
+ * missing-binary verdict (→ permanent / needs-operator / terminal).
+ */
+const TRANSIENT_SPAWN_CODES: ReadonlySet<string> = new Set(["ETIMEDOUT", "EAGAIN", "ENOMEM", "ETXTBSY"]);
+
+/**
+ * A codex binary that EXISTS on PATH (resolution already found it) but whose
+ * `--version` smoke check did not complete for a transient reason — a spawn
+ * timeout, a kill by the timeout signal, or transient resource pressure. The
+ * binary is installed; the host was merely too busy / cold to answer in time.
+ *
+ * This carries a distinct `name` the error taxonomy maps to `transient`, so a
+ * flaky check reschedules the session bring-up instead of surfacing as a
+ * permanent "Codex runtime binary is missing" terminal failure (which does NOT
+ * retry). The message deliberately avoids the missing-binary / capability
+ * wording so it never gets re-absorbed into the terminal `capability` bucket.
+ */
+export class CodexBinaryVerifyTransientError extends Error {
+  constructor(reason: string) {
+    super(`codex --version smoke check did not complete (transient host condition); will retry. Detail: ${reason}`);
+    this.name = "CodexBinaryVerifyTransientError";
+  }
+}
 
 const CODEX_BINARY_MISSING_PATTERNS: readonly RegExp[] = [
   /codex runtime binary is missing/i,
@@ -66,6 +105,14 @@ export function createCodexClientWithBinaryFallback<TOptions extends CodexOption
     }
     const verification = (deps.verifyPath ?? verifyCodexExecutable)(fallbackPath, options.env);
     if (!verification.ok) {
+      // The binary EXISTS (resolution found it at `fallbackPath`) — only the
+      // smoke check failed. A transient flake (timeout / machine pressure) must
+      // stay transient so the session bring-up is retried; only a genuine
+      // non-transient failure (broken / incompatible binary) is reported as
+      // missing, which classifies permanent and terminates the session.
+      if (verification.transient) {
+        throw new CodexBinaryVerifyTransientError(verification.reason);
+      }
       throw new Error(
         formatCodexBinaryMissingMessage(`${errorText(err)} PATH codex failed validation: ${verification.reason}`),
       );
@@ -92,20 +139,32 @@ export function verifyCodexExecutable(
     env: { ...process.env, ...env },
     encoding: "utf-8",
     shell: false,
-    timeout: 3_000,
+    timeout: CODEX_VERSION_VERIFY_TIMEOUT_MS,
     windowsHide: true,
   });
   if (result.error) {
     const code = (result.error as NodeJS.ErrnoException).code;
     const timedOut = code === "ETIMEDOUT";
-    return { ok: false, reason: timedOut ? "`codex --version` timed out" : result.error.message };
+    const transient = timedOut || (typeof code === "string" && TRANSIENT_SPAWN_CODES.has(code));
+    return { ok: false, transient, reason: timedOut ? "`codex --version` timed out" : result.error.message };
+  }
+  // A timeout can surface as a kill signal (e.g. SIGTERM) with no `error`
+  // populated; treat any signal-kill as the same transient host condition.
+  if (result.signal) {
+    return { ok: false, transient: true, reason: `\`codex --version\` killed by ${result.signal}` };
   }
   if (result.status !== 0) {
     const detail = [result.stderr, result.stdout]
       .filter((text): text is string => typeof text === "string" && text.trim().length > 0)
       .join(" ")
       .trim();
-    return { ok: false, reason: `\`codex --version\` exited ${result.status}${detail ? `: ${detail}` : ""}` };
+    // A clean non-zero exit is the binary answering "I'm broken/incompatible"
+    // — a genuine, non-transient install problem.
+    return {
+      ok: false,
+      transient: false,
+      reason: `\`codex --version\` exited ${result.status}${detail ? `: ${detail}` : ""}`,
+    };
   }
   const output = [result.stdout, result.stderr]
     .filter((text): text is string => typeof text === "string" && text.trim().length > 0)

--- a/packages/client/src/runtime/codex-binary.ts
+++ b/packages/client/src/runtime/codex-binary.ts
@@ -48,6 +48,23 @@ const CODEX_VERSION_VERIFY_TIMEOUT_MS = 10_000;
 const TRANSIENT_SPAWN_CODES: ReadonlySet<string> = new Set(["ETIMEDOUT", "EAGAIN", "ENOMEM", "ETXTBSY"]);
 
 /**
+ * Kill signals that mean "the binary crashed deterministically" — a broken /
+ * incompatible native install that will fault the same way on every retry.
+ * These must stay NON-transient: classifying them transient would loop a
+ * permanently-broken binary through session-bring-up retries forever instead of
+ * surfacing an actionable binary failure. Any OTHER signal (the SIGTERM/SIGKILL
+ * a `spawnSync` timeout uses to enforce its deadline, an OOM kill, an external
+ * shutdown) is a host condition and stays transient.
+ */
+const DETERMINISTIC_CRASH_SIGNALS: ReadonlySet<NodeJS.Signals> = new Set([
+  "SIGSEGV",
+  "SIGABRT",
+  "SIGILL",
+  "SIGBUS",
+  "SIGFPE",
+]);
+
+/**
  * A codex binary that EXISTS on PATH (resolution already found it) but whose
  * `--version` smoke check did not complete for a transient reason — a spawn
  * timeout, a kill by the timeout signal, or transient resource pressure. The
@@ -149,9 +166,12 @@ export function verifyCodexExecutable(
     return { ok: false, transient, reason: timedOut ? "`codex --version` timed out" : result.error.message };
   }
   // A timeout can surface as a kill signal (e.g. SIGTERM) with no `error`
-  // populated; treat any signal-kill as the same transient host condition.
+  // populated. Treat a termination/timeout kill as transient, but a
+  // deterministic crash signal (SIGSEGV/SIGABRT/…) as a real broken binary so a
+  // permanently-faulting `--version` does not retry forever.
   if (result.signal) {
-    return { ok: false, transient: true, reason: `\`codex --version\` killed by ${result.signal}` };
+    const crashed = DETERMINISTIC_CRASH_SIGNALS.has(result.signal);
+    return { ok: false, transient: !crashed, reason: `\`codex --version\` killed by ${result.signal}` };
   }
   if (result.status !== 0) {
     const detail = [result.stderr, result.stdout]

--- a/packages/client/src/runtime/error-taxonomy.ts
+++ b/packages/client/src/runtime/error-taxonomy.ts
@@ -267,12 +267,39 @@ export function classify(err: unknown, context?: { source?: ErrorSource }): Clas
       message: shape.message ?? "Claude Code CLI requires re-authentication (run /login)",
     };
   }
+  // A *present* codex binary whose `--version` smoke check flaked (spawn
+  // timeout / host pressure) is transient — retry the bring-up. This MUST win
+  // over the missing-binary check below so a busy host never masquerades as an
+  // uninstalled codex (which would terminate the session with no retry).
+  if (shape.name === "CodexBinaryVerifyTransientError") {
+    return {
+      kind: ERROR_KINDS.TRANSIENT,
+      strategy: TRANSIENT_FAST,
+      reasonCode: "codex_verify_transient",
+      message: shape.message ?? "codex --version smoke check did not complete (transient)",
+    };
+  }
   if (isCodexBinaryMissingError(err)) {
     return {
       kind: ERROR_KINDS.PERMANENT,
       strategy: NONE,
       reasonCode: "codex_binary_missing",
       message: shape.message ?? "Codex runtime binary missing",
+    };
+  }
+  // `AbortSignal.timeout()` aborts with a `DOMException` whose `name` is
+  // `TimeoutError` (Web spec, Node 22+) and message "The operation was aborted
+  // due to timeout" — a clearly transient backend/SDK timeout. Recognise it
+  // explicitly so it retries on the fast transient strategy instead of falling
+  // into the `unknown` bucket with a slow, mislabelled backoff. (The hub-fetch
+  // path in `sdk.ts` already treats this shape as a timeout; this keeps the
+  // provider-side taxonomy consistent with it.)
+  if (shape.name === "TimeoutError" || /operation was aborted due to timeout/i.test(shape.message ?? "")) {
+    return {
+      kind: ERROR_KINDS.TRANSIENT,
+      strategy: TRANSIENT_FAST,
+      reasonCode: "operation_timeout",
+      message: shape.message ?? "Operation aborted due to timeout",
     };
   }
   // -- Anthropic SDK / stream errors ---------------------------------------


### PR DESCRIPTION
## Problem

A user on 0.5.10 reported a terminal **`Provider failure · Codex runtime binary is missing`** while their agent was **running fine** — codex was installed and working, yet the runtime declared it missing and terminated the session.

### Root cause

Codex session bring-up (`createCodexClientWithBinaryFallback`, at every `start`/`resume`) resolves a system `codex` on PATH and smoke-checks it with `spawnSync("codex","--version")` under a **3s** ceiling. **Every** failure of that check was wrapped into `formatCodexBinaryMissingMessage(...)` → `error-taxonomy.classify()` permanent `codex_binary_missing` → `capability` → `needs_operator` → **terminal, no retry**.

So a single slow/cold `codex --version` (busy host, an `nvm`/`fnm`/`volta`/`mise`/`asdf` shim, a cold start) exceeding 3s → `ETIMEDOUT` → a permanent "go install codex" terminal failure, even though the next bring-up succeeds. 0.5.10 made this user-visible by moving codex failure discovery into the in-chat session-run path.

## Fix

Distinguish a **transient verify flake on a present binary** from a **genuinely absent/broken** one:

- `verifyCodexExecutable` reports `transient` on failure: timeout (`ETIMEDOUT`) / termination-or-timeout kill signal / `EAGAIN` / `ENOMEM` / `ETXTBSY`. Ceiling raised **3s → 10s**.
- **Deterministic crash signals** (`SIGSEGV`/`SIGABRT`/`SIGILL`/`SIGBUS`/`SIGFPE`) and a **clean non-zero exit** stay **non-transient** → permanent binary-missing, so a genuinely broken binary still surfaces as actionable and never loops in retry.
- A present-but-flaky binary throws the new `CodexBinaryVerifyTransientError` (run path) / returns a transient-worded error (resolve path) instead of "binary missing".
- `error-taxonomy.classify()` maps `CodexBinaryVerifyTransientError` → **transient** (fast retry), landing in session-manager's existing `decideProviderRetry` retry loop instead of terminating.

### Related gap closed in the same audit

An `AbortSignal.timeout()` `DOMException` (`name: "TimeoutError"`, "The operation was aborted due to timeout") was unrecognised and fell into the slow `unknown` bucket. It now classifies as transient `operation_timeout`, consistent with the hub-fetch path in `sdk.ts`. (Same backend-timeout the user saw in a first screenshot, which the system already auto-recovered from.)

## Tests

- `codex-binary.test.ts`: transient flake → `CodexBinaryVerifyTransientError`, not binary-missing; non-transient exit → binary-missing; direct `verifyCodexExecutable` — self-`SIGSEGV` stays non-transient, self-`SIGTERM` is transient.
- `capability-probes.test.ts`: transient path-verify → not "binary missing"; non-transient → binary-missing.
- `error-taxonomy.test.ts`: `CodexBinaryVerifyTransientError` → transient; `TimeoutError` (name + text) → `operation_timeout`.
- `provider-retry-policy.test.ts`: end-to-end — verify flake at `session_start` and a codex `AbortSignal.timeout` → `transient_transport` + `action: retry`; genuinely missing binary stays `needs_operator` terminal.

Full `@first-tree/client` suite: **1160 passed**. `typecheck` + `biome` clean.

## Scope / not changed

Claude TUI `claude_login_required` is genuinely permanent (correct) and untouched. The bundled-binary launch path is not the live concern (First Tree does not bundle codex).

## Context Tree

Paired tree PR recording the decision: agent-team-foundation/first-tree-context#631.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
