### PR TITLE
feat(web): faster styled tooltips for chat header icons

### DIFF
--- a/packages/web/src/components/add-participant-dropdown.tsx
+++ b/packages/web/src/components/add-participant-dropdown.tsx
@@ -12,6 +12,7 @@ import {
   type MentionCandidate,
   MentionLabel,
 } from "./mention-autocomplete.js";
+import { Tooltip } from "./ui/tooltip.js";
 
 /**
  * Shared "add an agent to this chat" dropdown. Backs both the header
@@ -224,27 +225,28 @@ export function AddParticipantDropdown({
   return (
     <div ref={containerRef} className="relative">
       {variant === "icon" ? (
-        <button
-          type="button"
-          onClick={() => setOpen(!open)}
-          disabled={disabled}
-          title="Add participant"
-          aria-label="Add participant"
-          aria-haspopup="menu"
-          aria-expanded={open}
-          className="inline-flex shrink-0 items-center justify-center transition-colors hover:bg-[var(--bg-hover)]"
-          style={{
-            width: 28,
-            height: 28,
-            border: 0,
-            background: "transparent",
-            borderRadius: "var(--radius-input)",
-            color: disabled ? "var(--fg-4)" : "var(--fg-3)",
-            cursor: disabled ? "not-allowed" : "pointer",
-          }}
-        >
-          <UserPlus size={16} />
-        </button>
+        <Tooltip label="Add participant">
+          <button
+            type="button"
+            onClick={() => setOpen(!open)}
+            disabled={disabled}
+            aria-label="Add participant"
+            aria-haspopup="menu"
+            aria-expanded={open}
+            className="inline-flex shrink-0 items-center justify-center transition-colors hover:bg-[var(--bg-hover)]"
+            style={{
+              width: 28,
+              height: 28,
+              border: 0,
+              background: "transparent",
+              borderRadius: "var(--radius-input)",
+              color: disabled ? "var(--fg-4)" : "var(--fg-3)",
+              cursor: disabled ? "not-allowed" : "pointer",
+            }}
+          >
+            <UserPlus size={16} />
+          </button>
+        </Tooltip>
       ) : (
         <button
           type="button"

--- a/packages/web/src/components/ui/__tests__/tooltip.test.tsx
+++ b/packages/web/src/components/ui/__tests__/tooltip.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDomHarness, type DomHarness } from "../../../test-utils/dom-harness.js";
+import { Tooltip } from "../tooltip.js";
+
+/**
+ * Tooltip is the styled, faster replacement for the native `title` attribute.
+ * The hover path is timer-gated (and exercised in real use); these tests cover
+ * the deterministic, non-timer behavior: the keyboard path (focus shows the
+ * label immediately, blur/Esc hide it), the empty-label pass-through, and that
+ * cloning the trigger preserves its own handlers.
+ */
+describe("Tooltip", () => {
+  let h: DomHarness;
+  beforeEach(() => {
+    h = createDomHarness();
+  });
+  afterEach(() => h.cleanup());
+
+  const tip = () => document.body.querySelector('[role="tooltip"]');
+
+  it("shows the label on focus and hides it on blur", async () => {
+    h.render(
+      <Tooltip label="Show conversations">
+        <button type="button" aria-label="Show conversations">
+          icon
+        </button>
+      </Tooltip>,
+    );
+    const button = h.container.querySelector("button");
+    expect(button).not.toBeNull();
+    expect(tip()).toBeNull();
+
+    await act(async () => button?.focus());
+    expect(tip()?.textContent).toBe("Show conversations");
+
+    await act(async () => button?.blur());
+    expect(tip()).toBeNull();
+  });
+
+  it("hides on Escape while open", async () => {
+    h.render(
+      <Tooltip label="Add participant">
+        <button type="button" aria-label="Add participant">
+          icon
+        </button>
+      </Tooltip>,
+    );
+    const button = h.container.querySelector("button");
+    await act(async () => button?.focus());
+    expect(tip()).not.toBeNull();
+
+    await act(async () => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    });
+    expect(tip()).toBeNull();
+  });
+
+  it("renders the trigger untouched when label is empty", () => {
+    h.render(
+      <Tooltip label={undefined}>
+        <button type="button" aria-label="Save">
+          icon
+        </button>
+      </Tooltip>,
+    );
+    expect(h.container.querySelector('button[aria-label="Save"]')).not.toBeNull();
+    expect(tip()).toBeNull();
+  });
+
+  it("preserves the trigger's own onClick and onFocus", async () => {
+    const onClick = vi.fn();
+    const onFocus = vi.fn();
+    h.render(
+      <Tooltip label="Save">
+        <button type="button" aria-label="Save" onClick={onClick} onFocus={onFocus}>
+          icon
+        </button>
+      </Tooltip>,
+    );
+    const button = h.container.querySelector("button");
+    await act(async () => button?.focus());
+    await act(async () => button?.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+    expect(onFocus).toHaveBeenCalledTimes(1);
+    expect(onClick).toHaveBeenCalledTimes(1);
+    // The tooltip still appeared, so cloning didn't drop our handlers either.
+    expect(tip()?.textContent).toBe("Save");
+  });
+});

--- a/packages/web/src/components/ui/__tests__/tooltip.test.tsx
+++ b/packages/web/src/components/ui/__tests__/tooltip.test.tsx
@@ -40,6 +40,30 @@ describe("Tooltip", () => {
     expect(tip()).toBeNull();
   });
 
+  it("does not open on pointer-induced focus, but still opens on keyboard focus", async () => {
+    h.render(
+      <Tooltip label="Save">
+        <button type="button" aria-label="Save">
+          icon
+        </button>
+      </Tooltip>,
+    );
+    const button = h.container.querySelector("button");
+
+    // A click presses the pointer (which focuses the trigger) — the tooltip
+    // must not flash open from that focus.
+    await act(async () => {
+      button?.dispatchEvent(new Event("pointerdown", { bubbles: true }));
+      button?.focus();
+    });
+    expect(tip()).toBeNull();
+
+    // A later keyboard focus (no preceding pointer press) still opens.
+    await act(async () => button?.blur());
+    await act(async () => button?.focus());
+    expect(tip()?.textContent).toBe("Save");
+  });
+
   it("hides on Escape while open", async () => {
     h.render(
       <Tooltip label="Add participant">

--- a/packages/web/src/components/ui/tooltip.tsx
+++ b/packages/web/src/components/ui/tooltip.tsx
@@ -1,0 +1,207 @@
+import {
+  cloneElement,
+  type ReactElement,
+  type Ref,
+  useCallback,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import { createPortal } from "react-dom";
+
+/**
+ * Lightweight text tooltip (no dependency). A faster, styled replacement for
+ * the native `title` attribute: the browser's `title` delay is fixed by the
+ * OS (~0.5–1.5s) and not tunable, so a control that wants a snappier hover
+ * label has to render its own. Matches the repo's dependency-light style —
+ * same hand-rolled portal + viewport-clamp approach as `HoverCard`, trimmed
+ * to a single non-interactive label.
+ *
+ * Behavior:
+ *  - hover the trigger for `delayMs` (default 120ms) to show; leaving hides at once.
+ *  - keyboard focus shows immediately (no delay) and blur hides — so the label
+ *    is reachable without a pointer.
+ *  - Esc / scroll / route-level unmount hides.
+ *  - portal + viewport-aware placement (prefers `top`, flips to `bottom`, clamps x).
+ *
+ * The trigger is cloned (no wrapper element), so it stays a direct flex/grid
+ * child — overlapping avatar stacks and fixed-size icon buttons keep their
+ * layout. The trigger keeps its own `aria-label` as the accessible name; this
+ * tooltip is a visual affordance only, so it is `aria-hidden` to avoid the
+ * screen reader announcing the same words twice.
+ */
+
+const OPEN_DELAY_MS = 120;
+const VIEWPORT_MARGIN = 8;
+const GAP = 6;
+
+type Coords = { top: number; left: number };
+
+// Merge an incoming ref (callback or object) with our own internal ref so a
+// cloned trigger that already carries a ref keeps working.
+function setRef<T>(ref: Ref<T> | undefined, value: T | null) {
+  if (typeof ref === "function") ref(value);
+  else if (ref && typeof ref === "object") (ref as { current: T | null }).current = value;
+}
+
+export function Tooltip({
+  label,
+  children,
+  placement = "top",
+  delayMs = OPEN_DELAY_MS,
+}: {
+  /** Tooltip text. When empty, the trigger renders untouched (no tooltip). */
+  label: string | undefined | null;
+  /** A single focusable trigger element (e.g. a `<button>` / `<a>`). */
+  children: ReactElement;
+  placement?: "top" | "bottom";
+  delayMs?: number;
+}) {
+  const [open, setOpen] = useState(false);
+  const [coords, setCoords] = useState<Coords | null>(null);
+  const triggerRef = useRef<HTMLElement | null>(null);
+  const tipRef = useRef<HTMLDivElement | null>(null);
+  const openTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const tipId = useId();
+
+  const clearTimer = useCallback(() => {
+    if (openTimer.current) clearTimeout(openTimer.current);
+    openTimer.current = null;
+  }, []);
+  const close = useCallback(() => {
+    clearTimer();
+    setOpen(false);
+  }, [clearTimer]);
+  const scheduleOpen = useCallback(() => {
+    clearTimer();
+    openTimer.current = setTimeout(() => setOpen(true), delayMs);
+  }, [clearTimer, delayMs]);
+  const openNow = useCallback(() => {
+    clearTimer();
+    setOpen(true);
+  }, [clearTimer]);
+
+  useEffect(() => clearTimer, [clearTimer]);
+
+  // Position on open + on resize, preferring `placement` and flipping if it
+  // would overflow, then clamping inside the viewport.
+  useLayoutEffect(() => {
+    if (!open) return;
+    const place = () => {
+      const t = triggerRef.current;
+      const tip = tipRef.current;
+      if (!t || !tip) return;
+      const tr = t.getBoundingClientRect();
+      const tw = tip.offsetWidth;
+      const th = tip.offsetHeight;
+      const vw = window.innerWidth;
+      const vh = window.innerHeight;
+
+      const aboveTop = tr.top - th - GAP;
+      const belowTop = tr.bottom + GAP;
+      let top =
+        placement === "top"
+          ? aboveTop >= VIEWPORT_MARGIN || belowTop + th > vh - VIEWPORT_MARGIN
+            ? aboveTop
+            : belowTop
+          : belowTop + th <= vh - VIEWPORT_MARGIN || aboveTop < VIEWPORT_MARGIN
+            ? belowTop
+            : aboveTop;
+      let left = tr.left + tr.width / 2 - tw / 2;
+      left = Math.max(VIEWPORT_MARGIN, Math.min(left, vw - tw - VIEWPORT_MARGIN));
+      top = Math.max(VIEWPORT_MARGIN, Math.min(top, vh - th - VIEWPORT_MARGIN));
+      setCoords({ top, left });
+    };
+    place();
+    window.addEventListener("resize", place);
+    return () => window.removeEventListener("resize", place);
+  }, [open, placement]);
+
+  // Esc and any scroll hide the tooltip while open.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") close();
+    };
+    const onScroll = () => close();
+    document.addEventListener("keydown", onKey, true);
+    window.addEventListener("scroll", onScroll, true);
+    return () => {
+      document.removeEventListener("keydown", onKey, true);
+      window.removeEventListener("scroll", onScroll, true);
+    };
+  }, [open, close]);
+
+  if (!label) return children;
+
+  const childRef = (children as ReactElement & { ref?: Ref<HTMLElement> }).ref;
+  const childProps = children.props as {
+    onPointerEnter?: (e: React.PointerEvent) => void;
+    onPointerLeave?: (e: React.PointerEvent) => void;
+    onFocus?: (e: React.FocusEvent) => void;
+    onBlur?: (e: React.FocusEvent) => void;
+  };
+
+  const trigger = cloneElement(children, {
+    ref: (node: HTMLElement | null) => {
+      triggerRef.current = node;
+      setRef(childRef, node);
+    },
+    onPointerEnter: (e: React.PointerEvent) => {
+      childProps.onPointerEnter?.(e);
+      if (e.pointerType === "mouse") scheduleOpen();
+    },
+    onPointerLeave: (e: React.PointerEvent) => {
+      childProps.onPointerLeave?.(e);
+      close();
+    },
+    onFocus: (e: React.FocusEvent) => {
+      childProps.onFocus?.(e);
+      openNow();
+    },
+    onBlur: (e: React.FocusEvent) => {
+      childProps.onBlur?.(e);
+      close();
+    },
+  } as Partial<typeof children.props>);
+
+  return (
+    <>
+      {trigger}
+      {open
+        ? createPortal(
+            <div
+              ref={tipRef}
+              id={tipId}
+              role="tooltip"
+              aria-hidden="true"
+              className="mono text-caption"
+              style={{
+                position: "fixed",
+                top: coords?.top ?? -9999,
+                left: coords?.left ?? -9999,
+                zIndex: 70,
+                pointerEvents: "none",
+                visibility: coords ? "visible" : "hidden",
+                maxWidth: 280,
+                whiteSpace: "nowrap",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                color: "var(--fg)",
+                background: "var(--bg-raised)",
+                border: "var(--hairline) solid var(--border)",
+                borderRadius: "var(--radius-chip)",
+                boxShadow: "var(--shadow-sm)",
+                padding: "var(--sp-0_5) var(--sp-1_5)",
+              }}
+            >
+              {label}
+            </div>,
+            document.body,
+          )
+        : null}
+    </>
+  );
+}

--- a/packages/web/src/components/ui/tooltip.tsx
+++ b/packages/web/src/components/ui/tooltip.tsx
@@ -64,6 +64,10 @@ export function Tooltip({
   const triggerRef = useRef<HTMLElement | null>(null);
   const tipRef = useRef<HTMLDivElement | null>(null);
   const openTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // A pointer press focuses the trigger; this flag suppresses the focus-open
+  // that immediately follows so a mouse click doesn't flash the tooltip. The
+  // hover (pointerenter) path still shows it; keyboard focus is unaffected.
+  const suppressFocusOpen = useRef(false);
   const tipId = useId();
 
   const clearTimer = useCallback(() => {
@@ -136,18 +140,26 @@ export function Tooltip({
 
   if (!label) return children;
 
-  const childRef = (children as ReactElement & { ref?: Ref<HTMLElement> }).ref;
+  // React 19 passes `ref` as a regular prop, so read it from `children.props`
+  // (accessing `children.ref` is deprecated and logs a dev warning).
   const childProps = children.props as {
+    ref?: Ref<HTMLElement>;
+    onPointerDown?: (e: React.PointerEvent) => void;
     onPointerEnter?: (e: React.PointerEvent) => void;
     onPointerLeave?: (e: React.PointerEvent) => void;
     onFocus?: (e: React.FocusEvent) => void;
     onBlur?: (e: React.FocusEvent) => void;
   };
+  const childRef = childProps.ref;
 
   const trigger = cloneElement(children, {
     ref: (node: HTMLElement | null) => {
       triggerRef.current = node;
       setRef(childRef, node);
+    },
+    onPointerDown: (e: React.PointerEvent) => {
+      childProps.onPointerDown?.(e);
+      suppressFocusOpen.current = true;
     },
     onPointerEnter: (e: React.PointerEvent) => {
       childProps.onPointerEnter?.(e);
@@ -159,10 +171,18 @@ export function Tooltip({
     },
     onFocus: (e: React.FocusEvent) => {
       childProps.onFocus?.(e);
+      // Open immediately only for keyboard focus. A focus that follows a
+      // pointer press is a click — the hover path covers that case, so opening
+      // here too would just flash the tooltip on every click.
+      if (suppressFocusOpen.current) {
+        suppressFocusOpen.current = false;
+        return;
+      }
       openNow();
     },
     onBlur: (e: React.FocusEvent) => {
       childProps.onBlur?.(e);
+      suppressFocusOpen.current = false;
       close();
     },
   } as Partial<typeof children.props>);

--- a/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
@@ -785,7 +785,7 @@ describe("ChatView", () => {
     const renameInput = container.querySelector<HTMLInputElement>("input");
     if (!renameInput) throw new Error("Rename input missing");
     await setValue(renameInput, "Renamed launch");
-    await click(buttonByTitle(container, "Save"));
+    await click(container.querySelector('button[aria-label="Save"]'));
     await waitForCondition(() => chatMocks.renameChat.mock.calls.length > 0, "Expected rename");
     expect(chatMocks.renameChat).toHaveBeenCalledWith("chat-1", "Renamed launch");
 

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -116,6 +116,7 @@ import {
 import { Button } from "../../../components/ui/button.js";
 import { Markdown, type MarkdownProps } from "../../../components/ui/markdown.js";
 import { StatusGlyph } from "../../../components/ui/status-glyph.js";
+import { Tooltip } from "../../../components/ui/tooltip.js";
 import { UnreadDivider } from "../../../components/unread-divider.js";
 import { useChatScroll } from "../../../hooks/use-chat-scroll.js";
 import { useReadTracker } from "../../../hooks/use-read-tracker.js";
@@ -1284,16 +1285,18 @@ function EntityLink({ metadata }: { metadata: Record<string, unknown> | undefine
   const url = typeof metadata.entityUrl === "string" ? metadata.entityUrl : null;
   if (!url) return null;
   return (
-    <a
-      href={url}
-      target="_blank"
-      rel="noopener noreferrer"
-      title="View on GitHub"
-      className="inline-flex items-center"
-      style={{ color: "var(--fg-3)", padding: "0 var(--sp-1)", textDecoration: "none" }}
-    >
-      <ExternalLink className="h-3.5 w-3.5" />
-    </a>
+    <Tooltip label="View on GitHub">
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="View on GitHub"
+        className="inline-flex items-center"
+        style={{ color: "var(--fg-3)", padding: "0 var(--sp-1)", textDecoration: "none" }}
+      >
+        <ExternalLink className="h-3.5 w-3.5" />
+      </a>
+    </Tooltip>
   );
 }
 
@@ -3344,24 +3347,25 @@ export function ChatView({
                   list, so it sits at the very left of the chat header
                   (i.e. the visible left edge of the workspace). */}
               {onShowConversations ? (
-                <button
-                  type="button"
-                  onClick={onShowConversations}
-                  aria-label="Show conversations"
-                  title="Show conversations"
-                  className="inline-flex shrink-0 items-center justify-center transition-colors hover:bg-[var(--bg-hover)]"
-                  style={{
-                    width: 28,
-                    height: 28,
-                    border: 0,
-                    background: "transparent",
-                    borderRadius: "var(--radius-input)",
-                    color: "var(--fg-3)",
-                    cursor: "pointer",
-                  }}
-                >
-                  <Menu size={16} strokeWidth={2.25} />
-                </button>
+                <Tooltip label="Show conversations">
+                  <button
+                    type="button"
+                    onClick={onShowConversations}
+                    aria-label="Show conversations"
+                    className="inline-flex shrink-0 items-center justify-center transition-colors hover:bg-[var(--bg-hover)]"
+                    style={{
+                      width: 28,
+                      height: 28,
+                      border: 0,
+                      background: "transparent",
+                      borderRadius: "var(--radius-input)",
+                      color: "var(--fg-3)",
+                      cursor: "pointer",
+                    }}
+                  >
+                    <Menu size={16} strokeWidth={2.25} />
+                  </button>
+                </Tooltip>
               ) : null}
               {/* Identity — title is the sole click-to-rename affordance
               (Slack / Linear pattern). The hover-only ✏️ pencil was
@@ -3446,26 +3450,30 @@ export function ChatView({
                         padding: "var(--sp-0_5) var(--sp-1_5)",
                       }}
                     />
-                    <button
-                      type="button"
-                      onClick={commitRename}
-                      disabled={renameMut.isPending}
-                      title="Save"
-                      className="inline-flex items-center"
-                      style={{ color: "var(--primary)", padding: 2 }}
-                    >
-                      <Check className="h-3.5 w-3.5" />
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => setRenaming(false)}
-                      disabled={renameMut.isPending}
-                      title="Cancel"
-                      className="inline-flex items-center"
-                      style={{ color: "var(--fg-3)", padding: 2 }}
-                    >
-                      <X className="h-3.5 w-3.5" />
-                    </button>
+                    <Tooltip label="Save">
+                      <button
+                        type="button"
+                        onClick={commitRename}
+                        disabled={renameMut.isPending}
+                        aria-label="Save"
+                        className="inline-flex items-center"
+                        style={{ color: "var(--primary)", padding: 2 }}
+                      >
+                        <Check className="h-3.5 w-3.5" />
+                      </button>
+                    </Tooltip>
+                    <Tooltip label="Cancel">
+                      <button
+                        type="button"
+                        onClick={() => setRenaming(false)}
+                        disabled={renameMut.isPending}
+                        aria-label="Cancel"
+                        className="inline-flex items-center"
+                        style={{ color: "var(--fg-3)", padding: 2 }}
+                      >
+                        <X className="h-3.5 w-3.5" />
+                      </button>
+                    </Tooltip>
                   </span>
                 ) : (
                   <button
@@ -3543,25 +3551,30 @@ export function ChatView({
               only deliberate sends + human messages. Eye / EyeOff conveys the
               show/hide state; pressed styling marks "currently hiding". */}
               {finalTextToggleEnabled && (
-                <button
-                  type="button"
-                  onClick={toggleHideAgentFinalText}
-                  aria-label={hideAgentFinalText ? "Show agent final messages" : "Hide agent final messages"}
-                  aria-pressed={hideAgentFinalText}
-                  title={hideAgentFinalText ? "Show agent final messages" : "Hide agent final messages"}
-                  className="inline-flex shrink-0 items-center justify-center transition-colors hover:bg-[var(--bg-hover)]"
-                  style={{
-                    width: 28,
-                    height: 28,
-                    border: 0,
-                    background: hideAgentFinalText ? "var(--bg-sunken)" : "transparent",
-                    borderRadius: "var(--radius-input)",
-                    color: hideAgentFinalText ? "var(--fg)" : "var(--fg-3)",
-                    cursor: "pointer",
-                  }}
-                >
-                  {hideAgentFinalText ? <EyeOff size={16} strokeWidth={2.25} /> : <Eye size={16} strokeWidth={2.25} />}
-                </button>
+                <Tooltip label={hideAgentFinalText ? "Show agent final messages" : "Hide agent final messages"}>
+                  <button
+                    type="button"
+                    onClick={toggleHideAgentFinalText}
+                    aria-label={hideAgentFinalText ? "Show agent final messages" : "Hide agent final messages"}
+                    aria-pressed={hideAgentFinalText}
+                    className="inline-flex shrink-0 items-center justify-center transition-colors hover:bg-[var(--bg-hover)]"
+                    style={{
+                      width: 28,
+                      height: 28,
+                      border: 0,
+                      background: hideAgentFinalText ? "var(--bg-sunken)" : "transparent",
+                      borderRadius: "var(--radius-input)",
+                      color: hideAgentFinalText ? "var(--fg)" : "var(--fg-3)",
+                      cursor: "pointer",
+                    }}
+                  >
+                    {hideAgentFinalText ? (
+                      <EyeOff size={16} strokeWidth={2.25} />
+                    ) : (
+                      <Eye size={16} strokeWidth={2.25} />
+                    )}
+                  </button>
+                </Tooltip>
               )}
               {/* Chat details toggle — opens the right rail (Participants /
               GitHub / Chat actions). Sits at the panel's far right,
@@ -3571,26 +3584,27 @@ export function ChatView({
               background + darker foreground) carries the open/closed state.
               An ellipsis is reserved for overflow-action menus (see
               row-actions-menu.tsx), so it would mislead here. */}
-              <button
-                type="button"
-                onClick={toggleSidebar}
-                aria-label={showSidebar ? "Hide chat details" : "Show chat details"}
-                aria-expanded={showSidebar}
-                aria-pressed={showSidebar}
-                title={showSidebar ? "Hide chat details" : "Show chat details"}
-                className="inline-flex shrink-0 items-center justify-center transition-colors hover:bg-[var(--bg-hover)]"
-                style={{
-                  width: 28,
-                  height: 28,
-                  border: 0,
-                  background: showSidebar ? "var(--bg-sunken)" : "transparent",
-                  borderRadius: "var(--radius-input)",
-                  color: showSidebar ? "var(--fg)" : "var(--fg-3)",
-                  cursor: "pointer",
-                }}
-              >
-                <PanelRight size={16} strokeWidth={2.25} />
-              </button>
+              <Tooltip label={showSidebar ? "Hide chat details" : "Show chat details"}>
+                <button
+                  type="button"
+                  onClick={toggleSidebar}
+                  aria-label={showSidebar ? "Hide chat details" : "Show chat details"}
+                  aria-expanded={showSidebar}
+                  aria-pressed={showSidebar}
+                  className="inline-flex shrink-0 items-center justify-center transition-colors hover:bg-[var(--bg-hover)]"
+                  style={{
+                    width: 28,
+                    height: 28,
+                    border: 0,
+                    background: showSidebar ? "var(--bg-sunken)" : "transparent",
+                    borderRadius: "var(--radius-input)",
+                    color: showSidebar ? "var(--fg)" : "var(--fg-3)",
+                    cursor: "pointer",
+                  }}
+                >
+                  <PanelRight size={16} strokeWidth={2.25} />
+                </button>
+              </Tooltip>
             </div>
           </div>
 
@@ -4209,24 +4223,26 @@ function ParticipantsStats({
         />
       ))}
       {overflow > 0 ? (
-        <button
-          type="button"
-          onClick={onOpen}
-          aria-label={`Show ${overflow} more participant${overflow === 1 ? "" : "s"}`}
-          className="mono text-label inline-flex items-center justify-center transition-colors hover:bg-[var(--bg-hover)]"
-          style={{
-            marginLeft: -8,
-            width: 24,
-            height: 24,
-            borderRadius: 999,
-            border: "var(--hairline-bold) solid var(--bg-raised)",
-            background: "var(--bg-sunken)",
-            color: "var(--fg-3)",
-            cursor: "pointer",
-          }}
-        >
-          +{overflow}
-        </button>
+        <Tooltip label={`Show ${overflow} more participant${overflow === 1 ? "" : "s"}`}>
+          <button
+            type="button"
+            onClick={onOpen}
+            aria-label={`Show ${overflow} more participant${overflow === 1 ? "" : "s"}`}
+            className="mono text-label inline-flex items-center justify-center transition-colors hover:bg-[var(--bg-hover)]"
+            style={{
+              marginLeft: -8,
+              width: 24,
+              height: 24,
+              borderRadius: 999,
+              border: "var(--hairline-bold) solid var(--bg-raised)",
+              background: "var(--bg-sunken)",
+              color: "var(--fg-3)",
+              cursor: "pointer",
+            }}
+          >
+            +{overflow}
+          </button>
+        </Tooltip>
       ) : null}
     </div>
   );
@@ -4270,52 +4286,53 @@ function ParticipantAvatar({
   const stateText = view ? view.label : isHuman ? "human" : "…";
 
   return (
-    <button
-      type="button"
-      onClick={onOpen}
-      aria-label={`${label} · ${stateText}. Open chat details.`}
-      title={`${label} · ${stateText}`}
-      className="relative inline-flex items-center justify-center transition-transform hover:translate-y-px"
-      style={{
-        marginLeft: stackIndex === 0 ? 0 : -8,
-        zIndex: MAX_VISIBLE_AVATARS - stackIndex,
-        border: 0,
-        background: "transparent",
-        padding: 0,
-        cursor: "pointer",
-      }}
-    >
-      <span
-        aria-hidden="true"
+    <Tooltip label={`${label} · ${stateText}`}>
+      <button
+        type="button"
+        onClick={onOpen}
+        aria-label={`${label} · ${stateText}. Open chat details.`}
+        className="relative inline-flex items-center justify-center transition-transform hover:translate-y-px"
         style={{
-          display: "inline-block",
-          width: 24,
-          height: 24,
-          borderRadius: 999,
-          border: "var(--hairline-bold) solid var(--bg-raised)",
-          overflow: "hidden",
+          marginLeft: stackIndex === 0 ? 0 : -8,
+          zIndex: MAX_VISIBLE_AVATARS - stackIndex,
+          border: 0,
+          background: "transparent",
+          padding: 0,
+          cursor: "pointer",
         }}
       >
-        <RealAvatar
-          src={ident?.avatarImageUrl ?? null}
-          name={label}
-          seed={participant.agentId}
-          colorToken={ident?.avatarColorToken ?? null}
-          size={22}
-        />
-      </span>
-      {view ? (
-        <span aria-hidden="true" className="absolute" style={{ right: -1, bottom: -2 }}>
-          <StatusGlyph
-            colorVar={view.colorVar}
-            shape={view.shape}
-            pulse={view.pulse}
-            size={8}
-            ariaLabel={view.label}
-            separator
+        <span
+          aria-hidden="true"
+          style={{
+            display: "inline-block",
+            width: 24,
+            height: 24,
+            borderRadius: 999,
+            border: "var(--hairline-bold) solid var(--bg-raised)",
+            overflow: "hidden",
+          }}
+        >
+          <RealAvatar
+            src={ident?.avatarImageUrl ?? null}
+            name={label}
+            seed={participant.agentId}
+            colorToken={ident?.avatarColorToken ?? null}
+            size={22}
           />
         </span>
-      ) : null}
-    </button>
+        {view ? (
+          <span aria-hidden="true" className="absolute" style={{ right: -1, bottom: -2 }}>
+            <StatusGlyph
+              colorVar={view.colorVar}
+              shape={view.shape}
+              pulse={view.pulse}
+              size={8}
+              ariaLabel={view.label}
+              separator
+            />
+          </span>
+        ) : null}
+      </button>
+    </Tooltip>
   );
 }


### PR DESCRIPTION
## What

The icons in the chat header (the bar above the message timeline) already had hover labels via the native HTML `title` attribute — but the browser's `title` delay is fixed by the OS (~0.5–1.5s) and isn't tunable, so the labels felt slow to appear. This adds a small **`Tooltip`** primitive with a short, tunable open delay and applies it to the header icons.

## Changes

- **New `components/ui/tooltip.tsx`** — a dependency-light text tooltip, same hand-rolled portal + viewport-clamp approach as `HoverCard` (no new deps; the repo already avoids `@radix-ui/react-tooltip`). Shows on hover after `120ms` (constant, easy to tune) and **immediately on keyboard focus**; hides on leave / blur / Esc / scroll. The trigger is cloned (no wrapper element), so overlapping avatar stacks and fixed-size icon buttons keep their layout.
- **Applied to the chat header icons** in `chat-view.tsx`: show-conversations, rename save/cancel, hide-final-text toggle, chat-details toggle, the participant avatars, and the **"+N more participants"** chip (which previously had *no* tooltip at all), plus the GitHub entity link; and the add-participant `+` icon in `add-participant-dropdown.tsx` (its `variant="icon"`, header-only).
- Native `title` attributes on those controls are removed (replaced by the component). Each trigger **keeps its `aria-label`** as the accessible name, so the tooltip is a purely visual affordance (`aria-hidden`) — no double announcement for screen readers.

## Notes / scope

- Scoped to the **chat header** by request. Other surfaces still use native `title`; this `Tooltip` is now available to adopt elsewhere incrementally.
- Delay is a single constant (`OPEN_DELAY_MS = 120`) — happy to dial it up/down.

## Testing

- New `tooltip.test.tsx`: focus shows the label, blur/Esc hide it, empty label is a pass-through, and cloning preserves the trigger's own handlers.
- `pnpm --filter @first-tree/web` typecheck + design-token guardrails + full vitest suite (**1028 passing**); updated one existing assertion that looked up the rename **Save** button by `title` to use its `aria-label`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
