### PR TITLE
Add skill eval LLM judge quality layer

### DIFF
--- a/packages/skill-evals/README.md
+++ b/packages/skill-evals/README.md
@@ -11,6 +11,9 @@ pnpm --filter @first-tree/skill-evals eval:floor
 pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-write
 pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-welcome
 pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-seed
+pnpm --filter @first-tree/skill-evals eval:quality
+pnpm --filter @first-tree/skill-evals eval:quality -- --suite first-tree-write
+pnpm --filter @first-tree/skill-evals eval:quality -- --suite first-tree-welcome --judge-model <model>
 pnpm --filter @first-tree/skill-evals eval:first-tree-read
 pnpm --filter @first-tree/skill-evals eval:first-tree-read -- --case tree-software-trigger
 pnpm --filter @first-tree/skill-evals eval:first-tree-read -- --json
@@ -23,6 +26,24 @@ validates that all shipped First Tree skills are present in the coverage
 matrix, their `SKILL.md` frontmatter is readable, and their case declarations
 have the minimum schema required by the shared runner. It does not execute
 Codex, Claude Code, LLM-as-judge, or live gate cases.
+
+`eval:quality` is an opt-in LLM-as-judge layer. It does not replace
+deterministic gates and is not called by `eval:gate`. Each quality case first
+runs the corresponding live gate case and requires that deterministic gate to
+pass; only then does it send the actual produced artifact to the judge. The
+first quality cases judge:
+
+- `first-tree-write` node quality from the actual `durable-source-writes` tree
+  diff, with scores for durability, source-boundary discipline, rationale
+  quality, and conciseness;
+- `first-tree-welcome` first-task quality from the actual readable-repo +
+  populated-tree row output, with scores for evidence grounding, boundedness,
+  usefulness, verifiability, and avoiding setup-as-task.
+
+The quality runner calls Codex as the judge by default. Use `--judge-model` or
+`JUDGE_MODEL` to select the judge model, and `--judge-bin` or `JUDGE_CODEX_BIN`
+to select the Codex binary. Judge output must be strict JSON; invalid JSON or a
+schema mismatch fails the quality case rather than being treated as a pass.
 
 `eval:gate -- --suite first-tree-write` runs the live Codex gate for
 `first-tree-write`. It covers the minimum source-boundary cases:
@@ -66,6 +87,10 @@ Each case writes:
   `first-tree` invocations.
 - `summary.json` with derived metrics.
 - `summary.md` with a human-readable case report.
+
+Quality cases also write `judge-prompt.txt` and `judge-raw-output.txt` in the
+case run directory, and include `judge_scores`, `judge_reasoning`,
+`judge_model`, duration, thresholds, and failure reasons in `summary.json`.
 
 Use `--verbose` to print live, human-readable progress to stderr. It can be
 combined with `--case`, `--validate-fixtures`, and `--json`; stdout remains the

--- a/packages/skill-evals/package.json
+++ b/packages/skill-evals/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "eval:floor": "tsx src/index.ts floor",
     "eval:gate": "tsx src/index.ts gate",
+    "eval:quality": "tsx src/index.ts quality",
     "eval:first-tree-read": "tsx src/first-tree-read/index.ts",
     "test": "vitest run --passWithNoTests",
     "validate:first-tree-read-fixtures": "tsx src/first-tree-read/index.ts --validate-fixtures",

--- a/packages/skill-evals/src/core/__tests__/judge.test.ts
+++ b/packages/skill-evals/src/core/__tests__/judge.test.ts
@@ -1,0 +1,226 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { runQualityEval } from "../../suites/quality/runner.js";
+import type { QualityArtifactInput } from "../../suites/quality/types.js";
+import { createFakeJudgeProvider } from "../judge/fake.js";
+import { evaluateJudgeOutput, parseJudgeJson } from "../judge/schema.js";
+import type { JudgeRubricDimension } from "../judge/types.js";
+
+const DIMENSIONS: readonly JudgeRubricDimension[] = [
+  {
+    description: "A",
+    key: "axis_a",
+    threshold: 4,
+  },
+  {
+    description: "B",
+    key: "axis_b",
+    threshold: 3,
+  },
+];
+
+function tempPackageRoot(): string {
+  return mkdtempSync(join(tmpdir(), "skill-evals-quality-test-"));
+}
+
+function fakeArtifactInput(): ReadonlyMap<string, QualityArtifactInput> {
+  return new Map([
+    [
+      "first-tree-write-node-quality",
+      {
+        artifact: "Actual tree diff from a fake deterministic gate.",
+        deterministicGatePassed: true,
+        gateCaseId: "durable-source-writes",
+        gateRunRoot: "/tmp/fake-gate",
+        gateSummaryJsonPath: "/tmp/fake-gate/summary.json",
+        gateSummaryMdPath: "/tmp/fake-gate/summary.md",
+        source: "Durable source artifact from a fake deterministic gate.",
+      },
+    ],
+  ]);
+}
+
+function failedGateArtifactInput(): ReadonlyMap<string, QualityArtifactInput> {
+  return new Map([
+    [
+      "first-tree-write-node-quality",
+      {
+        artifact: "No reliable tree diff because deterministic gate failed.",
+        deterministicGatePassed: false,
+        gateCaseId: "durable-source-writes",
+        gateRunRoot: "/tmp/fake-gate",
+        gateSummaryJsonPath: "/tmp/fake-gate/summary.json",
+        gateSummaryMdPath: "/tmp/fake-gate/summary.md",
+        source: "Durable source artifact from a fake deterministic gate.",
+      },
+    ],
+  ]);
+}
+
+describe("judge schema", () => {
+  it("passes good and borderline scores at configured thresholds", () => {
+    const parsed = parseJudgeJson(
+      JSON.stringify({
+        reasoning: "Borderline but acceptable.",
+        scores: {
+          axis_a: 4,
+          axis_b: 3,
+        },
+      }),
+      DIMENSIONS,
+    );
+
+    const evaluation = evaluateJudgeOutput(parsed, DIMENSIONS);
+    expect(evaluation.passed).toBe(true);
+    expect(evaluation.failures).toEqual([]);
+    expect(evaluation.judge_scores).toEqual({
+      axis_a: 4,
+      axis_b: 3,
+    });
+  });
+
+  it("fails scores below threshold without replacing deterministic pass/fail", () => {
+    const parsed = parseJudgeJson(
+      JSON.stringify({
+        reasoning: "Axis A is too weak.",
+        scores: {
+          axis_a: 3,
+          axis_b: 5,
+        },
+      }),
+      DIMENSIONS,
+    );
+
+    const evaluation = evaluateJudgeOutput(parsed, DIMENSIONS);
+    expect(evaluation.passed).toBe(false);
+    expect(evaluation.failures).toEqual(["axis_a: 3 < 4"]);
+  });
+
+  it("rejects invalid JSON and schema mismatches", () => {
+    expect(() => parseJudgeJson("not json", DIMENSIONS)).toThrow(/not strict JSON/u);
+    expect(() =>
+      parseJudgeJson(
+        JSON.stringify({
+          reasoning: "Missing axis B.",
+          scores: {
+            axis_a: 4,
+          },
+        }),
+        DIMENSIONS,
+      ),
+    ).toThrow(/axis_b score/u);
+  });
+});
+
+describe("quality runner with fake judge", () => {
+  it("records judge scores and pass/fail from fake outputs", async () => {
+    const packageRoot = tempPackageRoot();
+    try {
+      const provider = createFakeJudgeProvider(
+        new Map([
+          [
+            "first-tree-write-node-quality",
+            JSON.stringify({
+              reasoning: "The node is durable and source bounded.",
+              scores: {
+                conciseness: 4,
+                durability: 5,
+                rationale_quality: 4,
+                source_boundary: 5,
+              },
+            }),
+          ],
+        ]),
+      );
+
+      const batch = await runQualityEval(
+        packageRoot,
+        {
+          caseId: "first-tree-write-node-quality",
+          codexBin: "unused",
+          judgeBin: "unused",
+          judgeModel: null,
+          json: false,
+          model: null,
+          suite: "first-tree-write",
+          verbose: false,
+        },
+        provider,
+        fakeArtifactInput(),
+      );
+
+      expect(batch.failed).toBe(0);
+      expect(batch.passed).toBe(1);
+      expect(batch.cases[0]?.judge_scores).toMatchObject({
+        durability: 5,
+        source_boundary: 5,
+      });
+      expect(batch.cases[0]?.judge_model).toBe("fake-judge");
+    } finally {
+      rmSync(packageRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("keeps raw invalid judge output and fails the case", async () => {
+    const packageRoot = tempPackageRoot();
+    try {
+      const provider = createFakeJudgeProvider(new Map([["first-tree-write-node-quality", "```json\n{}\n```"]]));
+
+      const batch = await runQualityEval(
+        packageRoot,
+        {
+          caseId: "first-tree-write-node-quality",
+          codexBin: "unused",
+          judgeBin: "unused",
+          judgeModel: null,
+          json: false,
+          model: null,
+          suite: "first-tree-write",
+          verbose: false,
+        },
+        provider,
+        fakeArtifactInput(),
+      );
+
+      expect(batch.failed).toBe(1);
+      expect(batch.cases[0]?.passed).toBe(false);
+      expect(batch.cases[0]?.raw_output).toBe("```json\n{}\n```");
+      expect(batch.cases[0]?.failures[0]).toMatch(/not strict JSON/u);
+    } finally {
+      rmSync(packageRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("fails without calling judge when the deterministic gate artifact failed", async () => {
+    const packageRoot = tempPackageRoot();
+    try {
+      const provider = createFakeJudgeProvider(new Map());
+
+      const batch = await runQualityEval(
+        packageRoot,
+        {
+          caseId: "first-tree-write-node-quality",
+          codexBin: "unused",
+          judgeBin: "unused",
+          judgeModel: null,
+          json: false,
+          model: null,
+          suite: "first-tree-write",
+          verbose: false,
+        },
+        provider,
+        failedGateArtifactInput(),
+      );
+
+      expect(batch.failed).toBe(1);
+      expect(batch.cases[0]?.judge_model).toBe("not-run");
+      expect(batch.cases[0]?.failures[0]).toMatch(/deterministic gate durable-source-writes failed/u);
+    } finally {
+      rmSync(packageRoot, { force: true, recursive: true });
+    }
+  });
+});

--- a/packages/skill-evals/src/core/judge/codex.ts
+++ b/packages/skill-evals/src/core/judge/codex.ts
@@ -1,0 +1,231 @@
+import { spawn } from "node:child_process";
+import { chmodSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { createInterface } from "node:readline";
+
+import { appendEvent, isRecord, previewText } from "../events.js";
+import type { RunPaths } from "../types.js";
+import type { JudgeProvider, JudgeProviderResponse, JudgeRequest } from "./types.js";
+
+const TEXT_KEYS = ["content", "message", "output_text", "text"];
+
+export type CodexJudgeProviderOptions = {
+  bin: string;
+  eventsPath: string;
+  model: string | null;
+  paths: RunPaths;
+};
+
+function isAssistantMessageRecord(record: Record<string, unknown>): boolean {
+  const type = typeof record.type === "string" ? record.type : null;
+  const role = typeof record.role === "string" ? record.role : null;
+
+  if (type === "agent_message" || type === "assistant_message") return true;
+  if (type === "message" && (role === null || role === "assistant")) return true;
+  if (type === "output_text" || type === "response.output_text.done") return true;
+
+  return false;
+}
+
+function collectTextValue(value: unknown): string[] {
+  if (typeof value === "string") return [value];
+  if (Array.isArray(value)) {
+    const texts: string[] = [];
+    for (const item of value) {
+      texts.push(...collectTextValue(item));
+    }
+    return texts;
+  }
+  if (!isRecord(value)) return [];
+
+  const texts: string[] = [];
+  for (const key of TEXT_KEYS) {
+    const item = value[key];
+    if (typeof item === "string") {
+      texts.push(item);
+    } else if (Array.isArray(item)) {
+      texts.push(...collectTextValue(item));
+    }
+  }
+  return texts;
+}
+
+function collectAssistantText(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    const texts: string[] = [];
+    for (const item of value) {
+      texts.push(...collectAssistantText(item));
+    }
+    return texts;
+  }
+  if (!isRecord(value)) return [];
+
+  const texts: string[] = [];
+  if (isAssistantMessageRecord(value)) {
+    texts.push(...collectTextValue(value));
+  }
+
+  for (const key of ["item", "message", "response"] as const) {
+    const nested = value[key];
+    if (isRecord(nested) || Array.isArray(nested)) {
+      texts.push(...collectAssistantText(nested));
+    }
+  }
+
+  const output = value.output;
+  if (Array.isArray(output)) {
+    texts.push(...collectAssistantText(output));
+  }
+
+  return texts;
+}
+
+function codexArgs(request: JudgeRequest, model: string | null, paths: RunPaths): string[] {
+  const args = [
+    "exec",
+    "--json",
+    "--skip-git-repo-check",
+    "--ephemeral",
+    "--cd",
+    paths.runRoot,
+    "-c",
+    "shell_environment_policy.inherit=none",
+  ];
+
+  if (model !== null) {
+    args.push("--model", model);
+  }
+
+  args.push(request.prompt);
+  return args;
+}
+
+function createJudgeCommandGuards(paths: RunPaths): void {
+  mkdirSync(paths.binDir, { recursive: true });
+  const script = `#!/bin/sh
+printf '[first-tree-skill-evals] judge external command blocked: %s\\n' "$0 $*" >&2
+exit 64
+`;
+  for (const command of ["curl", "first-tree", "first-tree-staging", "gh", "git", "wget"]) {
+    const shimPath = join(paths.binDir, command);
+    writeFileSync(shimPath, script, "utf8");
+    chmodSync(shimPath, 0o755);
+  }
+}
+
+async function waitForExit(
+  child: ReturnType<typeof spawn>,
+  eventsPath: string,
+): Promise<{ exitCode: number; spawnError: string | null }> {
+  return await new Promise((resolve) => {
+    let settled = false;
+    child.once("error", (error) => {
+      if (settled) return;
+      settled = true;
+      appendEvent(eventsPath, {
+        error: error.message,
+        type: "judge_codex_spawn_error",
+      });
+      resolve({ exitCode: 127, spawnError: error.message });
+    });
+    child.once("close", (code) => {
+      if (settled) return;
+      settled = true;
+      resolve({ exitCode: code ?? 1, spawnError: null });
+    });
+  });
+}
+
+export function createCodexJudgeProvider(options: CodexJudgeProviderOptions): JudgeProvider {
+  return {
+    async judge(request: JudgeRequest): Promise<JudgeProviderResponse> {
+      const startedAt = Date.now();
+      const args = codexArgs(request, options.model, options.paths);
+      const assistantTexts: string[] = [];
+      createJudgeCommandGuards(options.paths);
+
+      appendEvent(options.eventsPath, {
+        args,
+        caseId: request.caseId,
+        model: options.model,
+        type: "judge_codex_started",
+      });
+
+      const child = spawn(options.bin, args, {
+        cwd: options.paths.runRoot,
+        env: {
+          ...process.env,
+          FIRST_TREE_EVAL_CASE_ID: request.caseId,
+          FIRST_TREE_EVAL_EVENTS: options.eventsPath,
+          FIRST_TREE_EVAL_PHASE: "judge",
+          PATH: `${options.paths.binDir}:${process.env.PATH ?? ""}`,
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+
+      const stdoutTask = (async (): Promise<void> => {
+        if (!child.stdout) return;
+        const lines = createInterface({ crlfDelay: Number.POSITIVE_INFINITY, input: child.stdout });
+        for await (const line of lines) {
+          if (!line.trim()) continue;
+          try {
+            const event = JSON.parse(line);
+            appendEvent(options.eventsPath, {
+              event,
+              type: "judge_codex_event",
+            });
+            assistantTexts.push(...collectAssistantText(event));
+          } catch {
+            appendEvent(options.eventsPath, {
+              linePreview: previewText(line),
+              type: "judge_codex_stdout",
+            });
+          }
+        }
+      })();
+
+      const stderrTask = (async (): Promise<void> => {
+        if (!child.stderr) return;
+        const lines = createInterface({ crlfDelay: Number.POSITIVE_INFINITY, input: child.stderr });
+        for await (const line of lines) {
+          if (!line.trim()) continue;
+          appendEvent(options.eventsPath, {
+            linePreview: previewText(line),
+            type: "judge_codex_stderr",
+          });
+        }
+      })();
+
+      const { exitCode, spawnError } = await waitForExit(child, options.eventsPath);
+      await Promise.all([stdoutTask, stderrTask]);
+
+      const durationMs = Date.now() - startedAt;
+      appendEvent(options.eventsPath, {
+        caseId: request.caseId,
+        durationMs,
+        exitCode,
+        type: "judge_codex_finished",
+      });
+
+      if (spawnError !== null) {
+        throw new Error(`codex judge spawn error: ${spawnError}. See ${options.eventsPath}.`);
+      }
+      if (exitCode !== 0) {
+        throw new Error(`codex judge exited ${exitCode}. See ${options.eventsPath}.`);
+      }
+
+      const rawOutput = assistantTexts.at(-1)?.trim() ?? "";
+      if (!rawOutput) {
+        throw new Error(`codex judge did not produce assistant JSON output. See ${options.eventsPath}.`);
+      }
+
+      return {
+        cost_usd: null,
+        duration_ms: durationMs,
+        judge_model: options.model ?? "codex-default",
+        provider: "codex",
+        raw_output: rawOutput,
+      };
+    },
+  };
+}

--- a/packages/skill-evals/src/core/judge/fake.ts
+++ b/packages/skill-evals/src/core/judge/fake.ts
@@ -1,0 +1,20 @@
+import type { JudgeProvider, JudgeProviderResponse, JudgeRequest } from "./types.js";
+
+export function createFakeJudgeProvider(rawOutputs: ReadonlyMap<string, string>): JudgeProvider {
+  return {
+    async judge(request: JudgeRequest): Promise<JudgeProviderResponse> {
+      const rawOutput = rawOutputs.get(request.caseId);
+      if (rawOutput === undefined) {
+        throw new Error(`No fake judge output configured for ${request.caseId}.`);
+      }
+
+      return {
+        cost_usd: null,
+        duration_ms: 0,
+        judge_model: "fake-judge",
+        provider: "fake",
+        raw_output: rawOutput,
+      };
+    },
+  };
+}

--- a/packages/skill-evals/src/core/judge/schema.ts
+++ b/packages/skill-evals/src/core/judge/schema.ts
@@ -1,0 +1,68 @@
+import { isRecord } from "../events.js";
+import type { JudgeEvaluation, JudgeRubricDimension, ParsedJudgeOutput } from "./types.js";
+
+function scoreFailurePrefix(dimensions: readonly JudgeRubricDimension[]): string {
+  return `Expected JSON object with scores for: ${dimensions.map((dimension) => dimension.key).join(", ")}`;
+}
+
+export function parseJudgeJson(rawOutput: string, dimensions: readonly JudgeRubricDimension[]): ParsedJudgeOutput {
+  const trimmed = rawOutput.trim();
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Judge output is not strict JSON: ${message}`);
+  }
+
+  if (!isRecord(parsed)) {
+    throw new Error("Judge output must be a JSON object.");
+  }
+
+  const scores = parsed.scores;
+  if (!isRecord(scores)) {
+    throw new Error(`${scoreFailurePrefix(dimensions)} under a scores object.`);
+  }
+
+  const judgeScores: Record<string, number> = {};
+  for (const dimension of dimensions) {
+    const score = scores[dimension.key];
+    if (typeof score !== "number" || !Number.isInteger(score) || score < 1 || score > 5) {
+      throw new Error(`${dimension.key} score must be an integer from 1 to 5.`);
+    }
+    judgeScores[dimension.key] = score;
+  }
+
+  const reasoning = parsed.reasoning;
+  if (typeof reasoning !== "string" || reasoning.trim() === "") {
+    throw new Error("Judge output must include non-empty reasoning.");
+  }
+
+  return {
+    judge_reasoning: reasoning,
+    judge_scores: judgeScores,
+  };
+}
+
+export function evaluateJudgeOutput(
+  output: ParsedJudgeOutput,
+  dimensions: readonly JudgeRubricDimension[],
+): JudgeEvaluation {
+  const failures: string[] = [];
+  const thresholds: Record<string, number> = {};
+
+  for (const dimension of dimensions) {
+    thresholds[dimension.key] = dimension.threshold;
+    const score = output.judge_scores[dimension.key];
+    if (score === undefined || score < dimension.threshold) {
+      failures.push(`${dimension.key}: ${score ?? "missing"} < ${dimension.threshold}`);
+    }
+  }
+
+  return {
+    ...output,
+    failures,
+    passed: failures.length === 0,
+    thresholds,
+  };
+}

--- a/packages/skill-evals/src/core/judge/types.ts
+++ b/packages/skill-evals/src/core/judge/types.ts
@@ -1,0 +1,36 @@
+export type JudgeProviderName = "codex" | "fake";
+
+export type JudgeRubricDimension = {
+  description: string;
+  key: string;
+  threshold: number;
+};
+
+export type JudgeRequest = {
+  caseId: string;
+  dimensions: readonly JudgeRubricDimension[];
+  prompt: string;
+};
+
+export type JudgeProviderResponse = {
+  cost_usd: number | null;
+  duration_ms: number;
+  judge_model: string;
+  provider: JudgeProviderName;
+  raw_output: string;
+};
+
+export type ParsedJudgeOutput = {
+  judge_reasoning: string;
+  judge_scores: Record<string, number>;
+};
+
+export type JudgeEvaluation = ParsedJudgeOutput & {
+  failures: readonly string[];
+  passed: boolean;
+  thresholds: Record<string, number>;
+};
+
+export type JudgeProvider = {
+  judge(request: JudgeRequest): Promise<JudgeProviderResponse>;
+};

--- a/packages/skill-evals/src/core/result-schema.ts
+++ b/packages/skill-evals/src/core/result-schema.ts
@@ -29,6 +29,23 @@ export type SkillEvalRunResult = {
   tier: string;
 };
 
+export type QualityJudgeRunResult = {
+  caseId: string;
+  cost_usd: number | null;
+  duration_ms: number;
+  failures: readonly string[];
+  judge_model: string;
+  judge_provider: string;
+  judge_reasoning: string | null;
+  judge_scores: Record<string, number> | null;
+  passed: boolean;
+  raw_output: string;
+  runId: string;
+  skill: string;
+  thresholds: Record<string, number>;
+  tier: "quality";
+};
+
 export function allScoresPass(scores: SkillCaseScores): boolean {
   return scores.routing_pass && scores.process_pass && scores.outcome_pass && scores.risk_pass;
 }

--- a/packages/skill-evals/src/index.ts
+++ b/packages/skill-evals/src/index.ts
@@ -9,12 +9,16 @@ import { readSkillFrontmatter } from "./core/skills/frontmatter.js";
 import { formatFirstTreeSeedGateSummary, runFirstTreeSeedGate } from "./suites/first-tree-seed/index.js";
 import { formatFirstTreeWelcomeGateSummary, runFirstTreeWelcomeGate } from "./suites/first-tree-welcome/index.js";
 import { formatFirstTreeWriteGateSummary, runFirstTreeWriteGate } from "./suites/first-tree-write/index.js";
+import { formatQualitySummaryTable, runQualityEval } from "./suites/quality/index.js";
+import type { QualitySkillName } from "./suites/quality/types.js";
 import { SKILL_EVAL_SUITES } from "./suites/registry.js";
 
 type CliOptions = {
   caseId: string | null;
   codexBin: string;
-  command: "floor" | "gate";
+  command: "floor" | "gate" | "quality";
+  judgeBin: string;
+  judgeModel: string | null;
   json: boolean;
   model: string | null;
   suite: ShippedSkillName | null;
@@ -42,10 +46,13 @@ function usage(): string {
   pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-write
   pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-welcome
   pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-seed
+  pnpm --filter @first-tree/skill-evals eval:quality
+  pnpm --filter @first-tree/skill-evals eval:quality -- --suite first-tree-write
 
 Commands:
   floor                  Run no-model schema, coverage, and skill-file checks.
   gate                   Run a live model gate suite.
+  quality                Run opt-in LLM-as-judge quality cases.
 
 Options:
   --suite <skill>        Limit per-suite floor checks to one shipped skill.
@@ -53,6 +60,8 @@ Options:
   --json                 Print summary as JSON.
   --model <model>        Pass a model override to codex exec.
   --codex-bin <path>     Codex binary to execute. Defaults to CODEX_BIN or codex.
+  --judge-model <model>  Judge model override. Defaults to JUDGE_MODEL, CODEX_MODEL, or provider default.
+  --judge-bin <path>     Judge Codex binary. Defaults to JUDGE_CODEX_BIN, CODEX_BIN, or codex.
   --verbose              Print live readable progress to stderr.
   --help                 Show this help.
 `;
@@ -73,7 +82,7 @@ function parseArgs(args: readonly string[]): CliOptions {
     process.stdout.write(usage());
     process.exit(0);
   }
-  if (command !== "floor" && command !== "gate") {
+  if (command !== "floor" && command !== "gate" && command !== "quality") {
     throw new Error(`Unknown command: ${command}`);
   }
 
@@ -81,6 +90,8 @@ function parseArgs(args: readonly string[]): CliOptions {
     caseId: null,
     codexBin: process.env.CODEX_BIN ?? "codex",
     command,
+    judgeBin: process.env.JUDGE_CODEX_BIN ?? process.env.CODEX_BIN ?? "codex",
+    judgeModel: process.env.JUDGE_MODEL ?? process.env.CODEX_MODEL ?? null,
     json: false,
     model: process.env.CODEX_MODEL ?? null,
     suite: null,
@@ -117,6 +128,16 @@ function parseArgs(args: readonly string[]): CliOptions {
       index += 1;
       continue;
     }
+    if (arg === "--judge-model") {
+      options.judgeModel = readOptionValue(normalized, index, "--judge-model");
+      index += 1;
+      continue;
+    }
+    if (arg === "--judge-bin") {
+      options.judgeBin = readOptionValue(normalized, index, "--judge-bin");
+      index += 1;
+      continue;
+    }
     if (arg === "--verbose") {
       options.verbose = true;
       continue;
@@ -129,6 +150,14 @@ function parseArgs(args: readonly string[]): CliOptions {
   }
 
   return options;
+}
+
+function qualitySuite(options: CliOptions): QualitySkillName | null {
+  if (options.suite === null) return null;
+  if (options.suite === "first-tree-write" || options.suite === "first-tree-welcome") {
+    return options.suite;
+  }
+  throw new Error("eval:quality currently supports --suite first-tree-write or --suite first-tree-welcome.");
 }
 
 function packageRoot(): string {
@@ -288,10 +317,35 @@ async function runGate(options: CliOptions): Promise<void> {
   );
 }
 
+async function runQuality(options: CliOptions): Promise<void> {
+  const batch = await runQualityEval(packageRoot(), {
+    caseId: options.caseId,
+    codexBin: options.codexBin,
+    judgeBin: options.judgeBin,
+    judgeModel: options.judgeModel,
+    json: options.json,
+    model: options.model,
+    suite: qualitySuite(options),
+    verbose: options.verbose,
+  });
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify(batch, null, 2)}\n`);
+  } else {
+    process.stdout.write(`${formatQualitySummaryTable(batch)}\n`);
+  }
+  if (batch.failed > 0) {
+    process.exitCode = 1;
+  }
+}
+
 async function main(): Promise<void> {
   const options = parseArgs(process.argv.slice(2));
   if (options.command === "gate") {
     await runGate(options);
+    return;
+  }
+  if (options.command === "quality") {
+    await runQuality(options);
     return;
   }
 

--- a/packages/skill-evals/src/suites/first-tree-welcome/cases.ts
+++ b/packages/skill-evals/src/suites/first-tree-welcome/cases.ts
@@ -1,5 +1,6 @@
 import type { SkillEvalCase } from "../../core/case-schema.js";
 import type { SkillEvalSuiteDefinition } from "../types.js";
+import { FIRST_TREE_WELCOME_QUALITY_CASE } from "./quality.js";
 import type { FirstTreeWelcomeEvalCase, WelcomeExpectedAction } from "./types.js";
 
 const FLOOR_CASE_ID = "first-tree-welcome-setup-matrix";
@@ -217,6 +218,7 @@ export const FIRST_TREE_WELCOME_EVAL_CASES: readonly SkillEvalCase[] = [
     tier: "floor",
   },
   ...GATE_CASES,
+  FIRST_TREE_WELCOME_QUALITY_CASE,
 ];
 
 function validateFirstTreeWelcomeFloor(cases: readonly SkillEvalCase[]): readonly string[] {
@@ -279,6 +281,12 @@ export const FIRST_TREE_WELCOME_SUITE: SkillEvalSuiteDefinition = {
         description: "Welcome onboarding matrix gate rows; row 1, row 3, and row 8 run as live gate cases.",
         status: "implemented",
         tier: "gate",
+      },
+      {
+        caseIds: [FIRST_TREE_WELCOME_QUALITY_CASE.id],
+        description: "LLM-as-judge first-task quality case for evidence-backed bounded welcome options.",
+        status: "implemented",
+        tier: "quality",
       },
     ],
   },

--- a/packages/skill-evals/src/suites/first-tree-welcome/quality.ts
+++ b/packages/skill-evals/src/suites/first-tree-welcome/quality.ts
@@ -1,0 +1,89 @@
+import type { JudgeRubricDimension } from "../../core/judge/types.js";
+import type { QualityArtifactInput, QualityCaseDefinition, QualityEvalCase } from "../quality/types.js";
+
+const WELCOME_TASK_QUALITY_DIMENSIONS: readonly JudgeRubricDimension[] = [
+  {
+    description: "The proposed first tasks are grounded in the provided repo and Context Tree evidence.",
+    key: "evidence_backed",
+    threshold: 4,
+  },
+  {
+    description: "Each option is small enough to start immediately and does not balloon into open-ended setup work.",
+    key: "bounded",
+    threshold: 4,
+  },
+  {
+    description:
+      "The options are likely to create visible value for the user rather than merely explaining First Tree.",
+    key: "useful",
+    threshold: 3,
+  },
+  {
+    description: "The options can be checked against code, tree context, or an observable outcome.",
+    key: "verifiable",
+    threshold: 3,
+  },
+  {
+    description:
+      "The options do not package GitHub auth, repo selection, tree creation, or seed setup as the first task.",
+    key: "not_setup_as_task",
+    threshold: 5,
+  },
+];
+
+export const FIRST_TREE_WELCOME_QUALITY_CASE: QualityEvalCase = {
+  briefingMode: "generated-fixture",
+  expected: {
+    dimensions: WELCOME_TASK_QUALITY_DIMENSIONS.map((dimension) => dimension.key),
+    rubric: "first-tree-welcome first-task quality",
+  },
+  fixture: {
+    artifact: "actual chat ask/final task text produced by welcome row 8",
+    gateCaseId: "first-tree-welcome-readable-repo-populated-tree",
+    source: "repo and Context Tree evidence from welcome row 8 fixture",
+  },
+  id: "first-tree-welcome-first-task-quality",
+  prompt: "Judge the quality of first-tree-welcome bounded first-task options from readable repo and tree evidence.",
+  provider: "codex",
+  skill: "first-tree-welcome",
+  status: "implemented",
+  tags: ["llm-judge", "quality", "first-task"],
+  tier: "quality",
+};
+
+function dimensionLines(dimensions: readonly JudgeRubricDimension[]): string {
+  return dimensions
+    .map((dimension) => `- ${dimension.key}: ${dimension.description} Minimum passing score: ${dimension.threshold}.`)
+    .join("\n");
+}
+
+function buildWelcomeJudgePrompt(input: QualityArtifactInput): string {
+  return `You are judging first-tree-welcome first-task options produced by a live gate run.
+
+Return ONLY strict JSON with this shape:
+{"scores":{"evidence_backed":1,"bounded":1,"useful":1,"verifiable":1,"not_setup_as_task":1},"reasoning":"one concise paragraph"}
+
+Scores are integers from 1 to 5. Do not include markdown or any extra text.
+
+Rubric:
+${dimensionLines(WELCOME_TASK_QUALITY_DIMENSIONS)}
+
+Setup state and evidence:
+\`\`\`text
+${input.source}
+\`\`\`
+
+Actual first-task output from the live gate:
+\`\`\`text
+${input.artifact}
+\`\`\`
+`;
+}
+
+export const FIRST_TREE_WELCOME_QUALITY_DEFINITION: QualityCaseDefinition = {
+  buildJudgePrompt: buildWelcomeJudgePrompt,
+  dimensions: WELCOME_TASK_QUALITY_DIMENSIONS,
+  evalCase: FIRST_TREE_WELCOME_QUALITY_CASE,
+  gateCaseId: "first-tree-welcome-readable-repo-populated-tree",
+  title: "first-tree-welcome first-task quality",
+};

--- a/packages/skill-evals/src/suites/first-tree-write/cases.ts
+++ b/packages/skill-evals/src/suites/first-tree-write/cases.ts
@@ -1,5 +1,6 @@
 import type { SkillEvalCase } from "../../core/case-schema.js";
 import type { SkillEvalSuiteDefinition } from "../types.js";
+import { FIRST_TREE_WRITE_QUALITY_CASE } from "./quality.js";
 import type { FirstTreeWriteEvalCase } from "./types.js";
 
 const FLOOR_CASE_ID = "first-tree-write-static-coverage";
@@ -99,6 +100,7 @@ export const FIRST_TREE_WRITE_EVAL_CASES: readonly SkillEvalCase[] = [
     tier: "floor",
   },
   ...FIRST_TREE_WRITE_GATE_CASES,
+  FIRST_TREE_WRITE_QUALITY_CASE,
 ];
 
 function validateFirstTreeWriteFloor(cases: readonly SkillEvalCase[]): readonly string[] {
@@ -135,6 +137,12 @@ export const FIRST_TREE_WRITE_SUITE: SkillEvalSuiteDefinition = {
         description: "Implemented source-boundary and tree-diff live gate cases.",
         status: "implemented",
         tier: "gate",
+      },
+      {
+        caseIds: [FIRST_TREE_WRITE_QUALITY_CASE.id],
+        description: "LLM-as-judge node quality case for durable, source-bounded tree writing.",
+        status: "implemented",
+        tier: "quality",
       },
     ],
   },

--- a/packages/skill-evals/src/suites/first-tree-write/quality.ts
+++ b/packages/skill-evals/src/suites/first-tree-write/quality.ts
@@ -1,0 +1,84 @@
+import type { JudgeRubricDimension } from "../../core/judge/types.js";
+import type { QualityArtifactInput, QualityCaseDefinition, QualityEvalCase } from "../quality/types.js";
+
+const WRITE_NODE_QUALITY_DIMENSIONS: readonly JudgeRubricDimension[] = [
+  {
+    description:
+      "The node captures durable context, decisions, and rationale instead of transient PR process or implementation minutiae.",
+    key: "durability",
+    threshold: 4,
+  },
+  {
+    description:
+      "The node stays bounded to the supplied source material and avoids unsupported claims, PR IDs, code signatures, or API shapes.",
+    key: "source_boundary",
+    threshold: 4,
+  },
+  {
+    description: "The node explains why the decision exists well enough for a future agent to use it.",
+    key: "rationale_quality",
+    threshold: 3,
+  },
+  {
+    description: "The node is concise and avoids bloated historical narration while preserving the necessary context.",
+    key: "conciseness",
+    threshold: 3,
+  },
+];
+
+export const FIRST_TREE_WRITE_QUALITY_CASE: QualityEvalCase = {
+  briefingMode: "minimal",
+  expected: {
+    dimensions: WRITE_NODE_QUALITY_DIMENSIONS.map((dimension) => dimension.key),
+    rubric: "first-tree-write node quality",
+  },
+  fixture: {
+    artifact: "actual tree diff produced by durable-source-writes",
+    gateCaseId: "durable-source-writes",
+    source: "source-artifacts/durable-decision-note.md from the durable-source-writes fixture",
+  },
+  id: "first-tree-write-node-quality",
+  prompt: "Judge the quality of a first-tree-write Context Tree node produced from a durable source note.",
+  provider: "codex",
+  skill: "first-tree-write",
+  status: "implemented",
+  tags: ["llm-judge", "quality", "node-quality"],
+  tier: "quality",
+};
+
+function dimensionLines(dimensions: readonly JudgeRubricDimension[]): string {
+  return dimensions
+    .map((dimension) => `- ${dimension.key}: ${dimension.description} Minimum passing score: ${dimension.threshold}.`)
+    .join("\n");
+}
+
+function buildWriteJudgePrompt(input: QualityArtifactInput): string {
+  return `You are judging a First Tree Context Tree node written by first-tree-write.
+
+Return ONLY strict JSON with this shape:
+{"scores":{"durability":1,"source_boundary":1,"rationale_quality":1,"conciseness":1},"reasoning":"one concise paragraph"}
+
+Scores are integers from 1 to 5. Do not include markdown or any extra text.
+
+Rubric:
+${dimensionLines(WRITE_NODE_QUALITY_DIMENSIONS)}
+
+Source material:
+\`\`\`text
+${input.source}
+\`\`\`
+
+Actual Context Tree diff produced by the live gate:
+\`\`\`text
+${input.artifact}
+\`\`\`
+`;
+}
+
+export const FIRST_TREE_WRITE_QUALITY_DEFINITION: QualityCaseDefinition = {
+  buildJudgePrompt: buildWriteJudgePrompt,
+  dimensions: WRITE_NODE_QUALITY_DIMENSIONS,
+  evalCase: FIRST_TREE_WRITE_QUALITY_CASE,
+  gateCaseId: "durable-source-writes",
+  title: "first-tree-write node quality",
+};

--- a/packages/skill-evals/src/suites/quality/index.ts
+++ b/packages/skill-evals/src/suites/quality/index.ts
@@ -1,0 +1,2 @@
+export { formatQualitySummaryTable, runQualityEval } from "./runner.js";
+export type { QualityBatchSummary, QualityRunOptions } from "./types.js";

--- a/packages/skill-evals/src/suites/quality/runner.ts
+++ b/packages/skill-evals/src/suites/quality/runner.ts
@@ -1,0 +1,309 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { appendEvent } from "../../core/events.js";
+import { createCodexJudgeProvider } from "../../core/judge/codex.js";
+import { evaluateJudgeOutput, parseJudgeJson } from "../../core/judge/schema.js";
+import type { JudgeEvaluation, JudgeProvider, JudgeProviderResponse } from "../../core/judge/types.js";
+import { createRunPaths } from "../../core/paths.js";
+import type { QualityJudgeRunResult } from "../../core/result-schema.js";
+import { runFirstTreeWelcomeGate } from "../first-tree-welcome/index.js";
+import { FIRST_TREE_WELCOME_QUALITY_DEFINITION } from "../first-tree-welcome/quality.js";
+import type { CaseRunSummary as WelcomeCaseRunSummary } from "../first-tree-welcome/types.js";
+import { runFirstTreeWriteGate } from "../first-tree-write/index.js";
+import { FIRST_TREE_WRITE_QUALITY_DEFINITION } from "../first-tree-write/quality.js";
+import type { CaseRunSummary as WriteCaseRunSummary } from "../first-tree-write/types.js";
+import { buildQualityBatchSummary, writeQualityCaseSummaries } from "./summary.js";
+import type {
+  QualityArtifactInput,
+  QualityBatchSummary,
+  QualityCaseDefinition,
+  QualityCaseRunSummary,
+  QualityRunOptions,
+} from "./types.js";
+
+const QUALITY_DEFINITIONS: readonly QualityCaseDefinition[] = [
+  FIRST_TREE_WRITE_QUALITY_DEFINITION,
+  FIRST_TREE_WELCOME_QUALITY_DEFINITION,
+];
+
+function selectedDefinitions(options: QualityRunOptions): readonly QualityCaseDefinition[] {
+  let definitions = QUALITY_DEFINITIONS;
+  if (options.suite !== null) {
+    definitions = definitions.filter((definition) => definition.evalCase.skill === options.suite);
+  }
+  if (options.caseId !== null) {
+    definitions = definitions.filter((definition) => definition.evalCase.id === options.caseId);
+  }
+  if (definitions.length === 0) {
+    const suiteSuffix = options.suite === null ? "" : ` for suite ${options.suite}`;
+    const caseSuffix = options.caseId === null ? "" : ` and case ${options.caseId}`;
+    throw new Error(`No quality cases found${suiteSuffix}${caseSuffix}.`);
+  }
+  return definitions;
+}
+
+function failedJudgeResult(
+  definition: QualityCaseDefinition,
+  rawOutput: string,
+  error: unknown,
+  response: JudgeProviderResponse | null,
+): QualityJudgeRunResult {
+  const message = error instanceof Error ? error.message : String(error);
+  const thresholds = Object.fromEntries(definition.dimensions.map((dimension) => [dimension.key, dimension.threshold]));
+  return {
+    caseId: definition.evalCase.id,
+    cost_usd: response?.cost_usd ?? null,
+    duration_ms: response?.duration_ms ?? 0,
+    failures: [message],
+    judge_model: response?.judge_model ?? "unknown",
+    judge_provider: response?.provider ?? "unknown",
+    judge_reasoning: null,
+    judge_scores: null,
+    passed: false,
+    raw_output: rawOutput,
+    runId: definition.evalCase.id,
+    skill: definition.evalCase.skill,
+    thresholds,
+    tier: "quality",
+  };
+}
+
+function passedJudgeResult(
+  definition: QualityCaseDefinition,
+  response: JudgeProviderResponse,
+  evaluation: JudgeEvaluation,
+): QualityJudgeRunResult {
+  return {
+    caseId: definition.evalCase.id,
+    cost_usd: response.cost_usd,
+    duration_ms: response.duration_ms,
+    failures: evaluation.failures,
+    judge_model: response.judge_model,
+    judge_provider: response.provider,
+    judge_reasoning: evaluation.judge_reasoning,
+    judge_scores: evaluation.judge_scores,
+    passed: evaluation.passed,
+    raw_output: response.raw_output,
+    runId: definition.evalCase.id,
+    skill: definition.evalCase.skill,
+    thresholds: evaluation.thresholds,
+    tier: "quality",
+  };
+}
+
+function deterministicGateFailure(
+  definition: QualityCaseDefinition,
+  input: QualityArtifactInput,
+): QualityJudgeRunResult {
+  const thresholds = Object.fromEntries(definition.dimensions.map((dimension) => [dimension.key, dimension.threshold]));
+  return {
+    caseId: definition.evalCase.id,
+    cost_usd: null,
+    duration_ms: 0,
+    failures: [`deterministic gate ${input.gateCaseId} failed; judge was not run`],
+    judge_model: "not-run",
+    judge_provider: "not-run",
+    judge_reasoning: null,
+    judge_scores: null,
+    passed: false,
+    raw_output: "",
+    runId: definition.evalCase.id,
+    skill: definition.evalCase.skill,
+    thresholds,
+    tier: "quality",
+  };
+}
+
+function readFixtureFile(path: string): string {
+  return readFileSync(path, "utf8");
+}
+
+function writeQualityInput(gateSummary: WriteCaseRunSummary): QualityArtifactInput {
+  return {
+    artifact:
+      gateSummary.metrics.treeDiff.trim().length > 0
+        ? gateSummary.metrics.treeDiff
+        : `Final response:\n${gateSummary.metrics.finalResponse}`,
+    deterministicGatePassed: gateSummary.passed,
+    gateCaseId: gateSummary.caseId,
+    gateRunRoot: gateSummary.runRoot,
+    gateSummaryJsonPath: gateSummary.summaryJsonPath,
+    gateSummaryMdPath: gateSummary.summaryMdPath,
+    source: readFixtureFile(join(gateSummary.workspacePath, "source-artifacts", "durable-decision-note.md")),
+  };
+}
+
+function welcomeEvidenceSource(gateSummary: WelcomeCaseRunSummary): string {
+  const sourceRepoPath = join(gateSummary.workspacePath, "source-repo");
+  const contextTreePath = join(gateSummary.workspacePath, "context-tree");
+  return [
+    "Setup state: readable source repo and populated Context Tree.",
+    "",
+    "Repo README:",
+    readFixtureFile(join(sourceRepoPath, "README.md")),
+    "",
+    "Session source evidence:",
+    readFixtureFile(join(sourceRepoPath, "src", "auth", "session.ts")),
+    "",
+    "Context Tree checkout reliability node:",
+    readFixtureFile(join(contextTreePath, "product", "checkout-reliability.md")),
+  ].join("\n");
+}
+
+function welcomeQualityInput(gateSummary: WelcomeCaseRunSummary): QualityArtifactInput {
+  return {
+    artifact: [
+      "Chat ask/send text:",
+      gateSummary.metrics.chatText.trim() || "_none_",
+      "",
+      "Final response:",
+      gateSummary.metrics.finalResponse.trim() || "_none_",
+    ].join("\n"),
+    deterministicGatePassed: gateSummary.passed,
+    gateCaseId: gateSummary.caseId,
+    gateRunRoot: gateSummary.runRoot,
+    gateSummaryJsonPath: gateSummary.summaryJsonPath,
+    gateSummaryMdPath: gateSummary.summaryMdPath,
+    source: welcomeEvidenceSource(gateSummary),
+  };
+}
+
+async function collectLiveQualityInput(
+  packageRoot: string,
+  definition: QualityCaseDefinition,
+  options: QualityRunOptions,
+): Promise<QualityArtifactInput> {
+  if (definition.evalCase.skill === "first-tree-write") {
+    const batch = await runFirstTreeWriteGate(packageRoot, {
+      caseId: definition.gateCaseId,
+      codexBin: options.codexBin,
+      json: false,
+      model: options.model,
+      verbose: options.verbose,
+    });
+    const summary = batch.cases[0];
+    if (summary === undefined) {
+      throw new Error(`No gate summary produced for ${definition.gateCaseId}.`);
+    }
+    return writeQualityInput(summary);
+  }
+
+  if (definition.evalCase.skill === "first-tree-welcome") {
+    const batch = await runFirstTreeWelcomeGate(packageRoot, {
+      caseId: definition.gateCaseId,
+      codexBin: options.codexBin,
+      json: false,
+      model: options.model,
+      verbose: options.verbose,
+    });
+    const summary = batch.cases[0];
+    if (summary === undefined) {
+      throw new Error(`No gate summary produced for ${definition.gateCaseId}.`);
+    }
+    return welcomeQualityInput(summary);
+  }
+
+  throw new Error(`Unsupported quality suite: ${definition.evalCase.skill}.`);
+}
+
+async function runQualityCase(
+  packageRoot: string,
+  definition: QualityCaseDefinition,
+  options: QualityRunOptions,
+  providerOverride?: JudgeProvider,
+  inputOverride?: ReadonlyMap<string, QualityArtifactInput>,
+): Promise<QualityCaseRunSummary> {
+  const startedAt = new Date().toISOString();
+  const paths = createRunPaths({
+    caseId: definition.evalCase.id,
+    packageRoot,
+    startedAt,
+  });
+  const input =
+    inputOverride?.get(definition.evalCase.id) ?? (await collectLiveQualityInput(packageRoot, definition, options));
+  const judgePrompt = definition.buildJudgePrompt(input);
+  const judgePromptPath = join(paths.runRoot, "judge-prompt.txt");
+  const judgeRawOutputPath = join(paths.runRoot, "judge-raw-output.txt");
+
+  appendEvent(paths.eventsPath, {
+    caseId: definition.evalCase.id,
+    skill: definition.evalCase.skill,
+    type: "quality_case_started",
+  });
+
+  const provider =
+    providerOverride ??
+    createCodexJudgeProvider({
+      bin: options.judgeBin,
+      eventsPath: paths.eventsPath,
+      model: options.judgeModel,
+      paths,
+    });
+
+  let result: QualityJudgeRunResult;
+  let response: JudgeProviderResponse | null = null;
+  if (!input.deterministicGatePassed) {
+    result = deterministicGateFailure(definition, input);
+  } else {
+    try {
+      response = await provider.judge({
+        caseId: definition.evalCase.id,
+        dimensions: definition.dimensions,
+        prompt: judgePrompt,
+      });
+      const parsed = parseJudgeJson(response.raw_output, definition.dimensions);
+      result = passedJudgeResult(definition, response, evaluateJudgeOutput(parsed, definition.dimensions));
+    } catch (error: unknown) {
+      result = failedJudgeResult(definition, response?.raw_output ?? "", error, response);
+    }
+  }
+
+  const summary: QualityCaseRunSummary = {
+    ...result,
+    artifact: input.artifact,
+    deterministicGatePassed: input.deterministicGatePassed,
+    dimensions: definition.dimensions,
+    gateCaseId: input.gateCaseId,
+    gateRunRoot: input.gateRunRoot,
+    gateSummaryJsonPath: input.gateSummaryJsonPath,
+    gateSummaryMdPath: input.gateSummaryMdPath,
+    judgePrompt,
+    judgePromptPath,
+    judgeRawOutputPath,
+    runRoot: paths.runRoot,
+    source: input.source,
+    startedAt,
+    summaryJsonPath: paths.summaryJsonPath,
+    summaryMdPath: paths.summaryMdPath,
+  };
+
+  appendEvent(paths.eventsPath, {
+    caseId: definition.evalCase.id,
+    failures: result.failures,
+    passed: result.passed,
+    type: "quality_case_finished",
+  });
+
+  writeQualityCaseSummaries(summary);
+  if (options.verbose) {
+    process.stderr.write(`[${definition.evalCase.id}] quality ${result.passed ? "passed" : "failed"}\n`);
+  }
+  return summary;
+}
+
+export async function runQualityEval(
+  packageRoot: string,
+  options: QualityRunOptions,
+  providerOverride?: JudgeProvider,
+  inputOverride?: ReadonlyMap<string, QualityArtifactInput>,
+): Promise<QualityBatchSummary> {
+  const runStartedAt = new Date().toISOString();
+  const cases: QualityCaseRunSummary[] = [];
+  for (const definition of selectedDefinitions(options)) {
+    cases.push(await runQualityCase(packageRoot, definition, options, providerOverride, inputOverride));
+  }
+  return buildQualityBatchSummary(cases, runStartedAt);
+}
+
+export { formatQualitySummaryTable } from "./summary.js";

--- a/packages/skill-evals/src/suites/quality/summary.ts
+++ b/packages/skill-evals/src/suites/quality/summary.ts
@@ -1,0 +1,119 @@
+import { writeFileSync } from "node:fs";
+
+import type { QualityBatchSummary, QualityCaseRunSummary } from "./types.js";
+
+function markdownBool(value: boolean): string {
+  return value ? "true" : "false";
+}
+
+function fenced(value: string): string {
+  return value.trim().length === 0 ? "_empty_" : `\n\`\`\`text\n${value}\n\`\`\``;
+}
+
+function scoreRows(summary: QualityCaseRunSummary): string {
+  const scores = summary.judge_scores;
+  return summary.dimensions
+    .map((dimension) => {
+      const score = scores?.[dimension.key] ?? "n/a";
+      return `- ${dimension.key}: score=${score}, threshold=${dimension.threshold}`;
+    })
+    .join("\n");
+}
+
+export function writeQualityCaseSummaries(summary: QualityCaseRunSummary): void {
+  writeFileSync(summary.summaryJsonPath, `${JSON.stringify(summary, null, 2)}\n`, "utf8");
+  writeFileSync(summary.judgePromptPath, summary.judgePrompt, "utf8");
+  writeFileSync(summary.judgeRawOutputPath, summary.raw_output, "utf8");
+
+  const markdown = `# Quality Eval: ${summary.caseId}
+
+## Result
+
+- passed: ${markdownBool(summary.passed)}
+- skill: ${summary.skill}
+- deterministicGatePassed: ${markdownBool(summary.deterministicGatePassed)}
+- gateCaseId: ${summary.gateCaseId}
+- judge_provider: ${summary.judge_provider}
+- judge_model: ${summary.judge_model}
+- duration_ms: ${summary.duration_ms}
+- cost_usd: ${summary.cost_usd ?? "n/a"}
+- failures: ${summary.failures.length === 0 ? "none" : summary.failures.join("; ")}
+
+## Scores
+
+${scoreRows(summary)}
+
+## Judge Reasoning
+
+${summary.judge_reasoning ?? "_none_"}
+
+## Source
+
+${fenced(summary.source)}
+
+## Artifact
+
+${fenced(summary.artifact)}
+
+## Raw Judge Output
+
+${fenced(summary.raw_output)}
+
+## Paths
+
+- runRoot: \`${summary.runRoot}\`
+- gateRunRoot: ${summary.gateRunRoot === null ? "`n/a`" : `\`${summary.gateRunRoot}\``}
+- gateSummaryJsonPath: ${summary.gateSummaryJsonPath === null ? "`n/a`" : `\`${summary.gateSummaryJsonPath}\``}
+- judgePromptPath: \`${summary.judgePromptPath}\`
+- judgeRawOutputPath: \`${summary.judgeRawOutputPath}\`
+`;
+
+  writeFileSync(summary.summaryMdPath, markdown, "utf8");
+}
+
+function pad(value: string, width: number): string {
+  return value.length >= width ? value : `${value}${" ".repeat(width - value.length)}`;
+}
+
+export function formatQualitySummaryTable(batch: QualityBatchSummary): string {
+  const rows = batch.cases.map((summary) => [
+    summary.caseId,
+    summary.skill,
+    summary.judge_model,
+    summary.failures.length === 0 ? "none" : summary.failures.join(","),
+    String(summary.passed),
+  ]);
+  const header = ["case_id", "skill", "judge_model", "failures", "passed"];
+  const widths = header.map((label, index) => {
+    let width = label.length;
+    for (const row of rows) {
+      const value = row[index];
+      if (value && value.length > width) width = value.length;
+    }
+    return width;
+  });
+
+  const lines = [
+    header.map((label, index) => pad(label, widths[index] ?? label.length)).join("  "),
+    ...rows.map((row) => row.map((value, index) => pad(value, widths[index] ?? value.length)).join("  ")),
+  ];
+
+  return lines.join("\n");
+}
+
+export function buildQualityBatchSummary(
+  cases: readonly QualityCaseRunSummary[],
+  runStartedAt: string,
+): QualityBatchSummary {
+  let passed = 0;
+  for (const summary of cases) {
+    if (summary.passed) passed += 1;
+  }
+
+  return {
+    cases,
+    failed: cases.length - passed,
+    passed,
+    runStartedAt,
+  };
+}

--- a/packages/skill-evals/src/suites/quality/types.ts
+++ b/packages/skill-evals/src/suites/quality/types.ts
@@ -1,0 +1,77 @@
+import type { ShippedSkillName, SkillEvalCase } from "../../core/case-schema.js";
+import type { JudgeRubricDimension } from "../../core/judge/types.js";
+import type { QualityJudgeRunResult } from "../../core/result-schema.js";
+
+export type QualitySkillName = Extract<ShippedSkillName, "first-tree-write" | "first-tree-welcome">;
+
+export type QualityFixture = {
+  artifact: string;
+  gateCaseId: string;
+  source: string;
+};
+
+export type QualityArtifactInput = {
+  artifact: string;
+  deterministicGatePassed: boolean;
+  gateCaseId: string;
+  gateRunRoot: string | null;
+  gateSummaryJsonPath: string | null;
+  gateSummaryMdPath: string | null;
+  source: string;
+};
+
+export type QualityExpected = {
+  dimensions: readonly string[];
+  rubric: string;
+};
+
+export type QualityEvalCase = SkillEvalCase<QualityFixture, QualityExpected> & {
+  provider: "codex";
+  skill: QualitySkillName;
+  status: "implemented";
+  tier: "quality";
+};
+
+export type QualityCaseDefinition = {
+  buildJudgePrompt: (input: QualityArtifactInput) => string;
+  dimensions: readonly JudgeRubricDimension[];
+  evalCase: QualityEvalCase;
+  gateCaseId: string;
+  title: string;
+};
+
+export type QualityRunOptions = {
+  caseId: string | null;
+  codexBin: string;
+  judgeBin: string;
+  judgeModel: string | null;
+  json: boolean;
+  model: string | null;
+  suite: QualitySkillName | null;
+  verbose: boolean;
+};
+
+export type QualityCaseRunSummary = QualityJudgeRunResult & {
+  artifact: string;
+  deterministicGatePassed: boolean;
+  dimensions: readonly JudgeRubricDimension[];
+  gateCaseId: string;
+  gateRunRoot: string | null;
+  gateSummaryJsonPath: string | null;
+  gateSummaryMdPath: string | null;
+  judgePrompt: string;
+  judgePromptPath: string;
+  judgeRawOutputPath: string;
+  runRoot: string;
+  source: string;
+  startedAt: string;
+  summaryJsonPath: string;
+  summaryMdPath: string;
+};
+
+export type QualityBatchSummary = {
+  cases: readonly QualityCaseRunSummary[];
+  failed: number;
+  passed: number;
+  runStartedAt: string;
+};


### PR DESCRIPTION
## Summary

- Add core LLM-as-judge infrastructure for skill evals: strict JSON parsing, score threshold evaluation, fake judge tests, and a Codex JSONL judge provider.
- Add the opt-in `eval:quality` command without wiring judge execution into `eval:gate`.
- Add implemented quality coverage for:
  - `first-tree-write` node quality, using the actual `durable-source-writes` live gate output plus its source artifact.
  - `first-tree-welcome` first-task quality, using the actual readable-repo + populated-tree live gate output plus repo/tree evidence.
- Record judge prompts, raw judge output, scores, thresholds, reasoning, gate linkage, and pass/fail summaries in quality run artifacts.

## Notes

- Quality cases first run their corresponding deterministic live gate and require it to pass. If the gate fails, the quality case fails and the judge is not called.
- This PR does not modify `skills/*/SKILL.md` and does not relax deterministic gate or side-effect guards.
- Judge command execution is guarded with PATH-level blockers for common external commands (`gh`, `git`, `first-tree`, `first-tree-staging`, `curl`, `wget`).

## Verification

- `pnpm --filter @first-tree/skill-evals test` (51 passed)
- `pnpm --filter @first-tree/skill-evals typecheck`
- `pnpm exec biome check packages/skill-evals/src packages/skill-evals/package.json packages/skill-evals/README.md`
- `pnpm --filter @first-tree/skill-evals eval:floor`
- `pnpm --filter @first-tree/skill-evals eval:quality` (runs live gate + judge; 2/2 passed)
- `pnpm --filter @first-tree/skill-evals validate:first-tree-read-fixtures`
- `pnpm --filter @first-tree/shared build`
- `pnpm --filter @first-tree/client build` (exits 0; existing unresolved-import warnings for `@first-tree/shared` externals remain)
- `git diff --check`

## Review

- Pre-PR review by `codex-reviewer` found one blocking issue: early quality cases only judged hand-written static samples.
- Fixed before PR: quality cases now judge real live gate artifacts and fail closed when the upstream deterministic gate fails.
