### PR TITLE
Add skill eval result operations

### DIFF
--- a/packages/skill-evals/README.md
+++ b/packages/skill-evals/README.md
@@ -14,6 +14,8 @@ pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-seed
 pnpm --filter @first-tree/skill-evals eval:quality
 pnpm --filter @first-tree/skill-evals eval:quality -- --suite first-tree-write
 pnpm --filter @first-tree/skill-evals eval:quality -- --suite first-tree-welcome --judge-model <model>
+pnpm --filter @first-tree/skill-evals eval:select -- --base main
+pnpm --filter @first-tree/skill-evals eval:compare
 pnpm --filter @first-tree/skill-evals eval:first-tree-read
 pnpm --filter @first-tree/skill-evals eval:first-tree-read -- --case tree-software-trigger
 pnpm --filter @first-tree/skill-evals eval:first-tree-read -- --json
@@ -26,6 +28,22 @@ validates that all shipped First Tree skills are present in the coverage
 matrix, their `SKILL.md` frontmatter is readable, and their case declarations
 have the minimum schema required by the shared runner. It does not execute
 Codex, Claude Code, LLM-as-judge, or live gate cases.
+
+`eval:select` is a no-model helper for local development and PR review. It
+looks at changed files and recommends the smallest relevant eval commands:
+
+```bash
+pnpm --filter @first-tree/skill-evals eval:select -- --base main
+pnpm --filter @first-tree/skill-evals eval:select -- --changed-file skills/first-tree-write/SKILL.md
+pnpm --filter @first-tree/skill-evals eval:select -- --base main --json
+```
+
+The selector is intentionally conservative for shared skill-eval
+infrastructure: core runner or schema changes recommend floor plus all
+implemented deterministic gates, and judge-core changes also recommend quality.
+Suite or skill changes recommend that suite's floor/gate/quality coverage where
+implemented. The command only recommends; live gate and quality evals remain
+opt-in and are not part of `pnpm test`.
 
 `eval:quality` is an opt-in LLM-as-judge layer. It does not replace
 deterministic gates and is not called by `eval:gate`. Each quality case first
@@ -87,6 +105,27 @@ Each case writes:
   `first-tree` invocations.
 - `summary.json` with derived metrics.
 - `summary.md` with a human-readable case report.
+
+The top-level `eval:floor`, `eval:gate`, and `eval:quality` commands also append
+a lightweight local result-store entry to
+`packages/skill-evals/.runs/index.jsonl`. Entries record the run group, suite,
+tier, case, pass/fail state, git branch/sha, model/provider where available,
+artifact paths, duration, cost, and judge scores when present. The `.runs`
+directory is gitignored local eval state.
+
+Use `eval:compare` to compare the latest result-store run group with the
+previous one:
+
+```bash
+pnpm --filter @first-tree/skill-evals eval:compare
+pnpm --filter @first-tree/skill-evals eval:compare -- --json
+pnpm --filter @first-tree/skill-evals eval:compare -- --current <run-group-id> --previous <run-group-id>
+```
+
+The comparison highlights new failures, recoveries, cases still failing, cases
+still passing, score deltas for judge-backed cases, and artifact paths. If there
+is no previous run group yet, the command prints a clear "not enough runs"
+message instead of failing with a low-level store error.
 
 Quality cases also write `judge-prompt.txt` and `judge-raw-output.txt` in the
 case run directory, and include `judge_scores`, `judge_reasoning`,

--- a/packages/skill-evals/package.json
+++ b/packages/skill-evals/package.json
@@ -8,6 +8,8 @@
     "eval:floor": "tsx src/index.ts floor",
     "eval:gate": "tsx src/index.ts gate",
     "eval:quality": "tsx src/index.ts quality",
+    "eval:select": "tsx src/index.ts select",
+    "eval:compare": "tsx src/index.ts compare",
     "eval:first-tree-read": "tsx src/first-tree-read/index.ts",
     "test": "vitest run --passWithNoTests",
     "validate:first-tree-read-fixtures": "tsx src/first-tree-read/index.ts --validate-fixtures",

--- a/packages/skill-evals/src/core/__tests__/result-store.test.ts
+++ b/packages/skill-evals/src/core/__tests__/result-store.test.ts
@@ -1,0 +1,138 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  appendResultStoreEntries,
+  compareResultGroups,
+  createRunGroupId,
+  groupResultEntries,
+  latestRunGroups,
+  type ResultStoreEntry,
+  readResultStore,
+} from "../result-store.js";
+
+function tempPackageRoot(): string {
+  return mkdtempSync(join(tmpdir(), "skill-evals-result-store-test-"));
+}
+
+function entry(overrides: Partial<ResultStoreEntry> = {}): ResultStoreEntry {
+  return {
+    artifact: {
+      runRoot: "/tmp/run",
+      summaryJsonPath: "/tmp/run/summary.json",
+      summaryMdPath: "/tmp/run/summary.md",
+    },
+    caseId: "durable-source-writes",
+    command: "eval:gate",
+    costUsd: null,
+    durationMs: null,
+    failures: [],
+    git: {
+      base: null,
+      branch: "feat/test",
+      sha: "abc123",
+    },
+    judgeScores: null,
+    model: "gpt-test",
+    passed: true,
+    provider: "codex",
+    runGroupId: "20260629T010000000Z-eval-gate",
+    schemaVersion: 1,
+    skill: "first-tree-write",
+    startedAt: "2026-06-29T01:00:00.000Z",
+    status: "passed",
+    tier: "gate",
+    turns: null,
+    ...overrides,
+  };
+}
+
+describe("result store", () => {
+  it("appends and reads JSONL entries under .runs", () => {
+    const packageRoot = tempPackageRoot();
+    try {
+      appendResultStoreEntries(packageRoot, [entry()]);
+
+      const entries = readResultStore(packageRoot);
+      expect(entries).toHaveLength(1);
+      expect(entries[0]?.caseId).toBe("durable-source-writes");
+      expect(entries[0]?.artifact.summaryJsonPath).toBe("/tmp/run/summary.json");
+    } finally {
+      rmSync(packageRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("groups latest and previous run groups and compares pass/fail transitions", () => {
+    const previous = entry({
+      passed: true,
+      runGroupId: "20260629T010000000Z-eval-gate",
+      startedAt: "2026-06-29T01:00:00.000Z",
+    });
+    const currentFailure = entry({
+      failures: ["expected diff missing"],
+      passed: false,
+      runGroupId: "20260629T020000000Z-eval-gate",
+      startedAt: "2026-06-29T02:00:00.000Z",
+      status: "failed",
+    });
+    const recoveredPrevious = entry({
+      caseId: "first-tree-welcome-first-task-quality",
+      command: "eval:quality",
+      judgeScores: {
+        bounded: 3,
+        useful: 2,
+      },
+      passed: false,
+      runGroupId: "20260629T010000000Z-eval-gate",
+      skill: "first-tree-welcome",
+      startedAt: "2026-06-29T01:00:00.000Z",
+      status: "failed",
+      tier: "quality",
+    });
+    const recoveredCurrent = entry({
+      caseId: "first-tree-welcome-first-task-quality",
+      command: "eval:quality",
+      judgeScores: {
+        bounded: 5,
+        useful: 4,
+      },
+      passed: true,
+      runGroupId: "20260629T020000000Z-eval-gate",
+      skill: "first-tree-welcome",
+      startedAt: "2026-06-29T02:00:00.000Z",
+      tier: "quality",
+    });
+
+    const groups = groupResultEntries([previous, currentFailure, recoveredPrevious, recoveredCurrent]);
+    const { current, previous: selectedPrevious } = latestRunGroups(
+      [previous, currentFailure, recoveredPrevious, recoveredCurrent],
+      null,
+      null,
+    );
+    const comparison = compareResultGroups(current, selectedPrevious);
+
+    expect(groups.map((group) => group.runGroupId)).toEqual([
+      "20260629T010000000Z-eval-gate",
+      "20260629T020000000Z-eval-gate",
+    ]);
+    expect(comparison.newFailures.map((delta) => delta.caseKey)).toEqual([
+      "first-tree-write:gate:durable-source-writes",
+    ]);
+    expect(comparison.recovered.map((delta) => delta.caseKey)).toEqual([
+      "first-tree-welcome:quality:first-tree-welcome-first-task-quality",
+    ]);
+    expect(comparison.recovered[0]?.scoreDeltas).toEqual({
+      bounded: 2,
+      useful: 2,
+    });
+  });
+
+  it("creates stable run group ids from timestamps and labels", () => {
+    expect(createRunGroupId("2026-06-29T02:00:00.000Z", "eval:gate first-tree-write")).toBe(
+      "20260629T020000000Z-eval-gate-first-tree-write",
+    );
+  });
+});

--- a/packages/skill-evals/src/core/__tests__/select.test.ts
+++ b/packages/skill-evals/src/core/__tests__/select.test.ts
@@ -1,0 +1,79 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { changedFilesFromGit, selectSkillEvalRecommendations } from "../select.js";
+
+function runGit(repoRoot: string, args: readonly string[]): void {
+  execFileSync("git", args, {
+    cwd: repoRoot,
+    stdio: "ignore",
+  });
+}
+
+describe("skill eval selection", () => {
+  it("selects write floor, gate, and quality for write skill changes", () => {
+    const summary = selectSkillEvalRecommendations(["skills/first-tree-write/SKILL.md"], "main");
+
+    expect(summary.recommendations.map((recommendation) => recommendation.command)).toEqual([
+      "pnpm --filter @first-tree/skill-evals eval:floor -- --suite first-tree-write",
+      "pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-write",
+      "pnpm --filter @first-tree/skill-evals eval:quality -- --suite first-tree-write",
+    ]);
+  });
+
+  it("selects read fixture validation and opt-in live read eval for read suite changes", () => {
+    const summary = selectSkillEvalRecommendations(["packages/skill-evals/src/suites/first-tree-read/runner.ts"]);
+
+    expect(summary.recommendations.map((recommendation) => recommendation.command)).toEqual([
+      "pnpm --filter @first-tree/skill-evals eval:floor -- --suite first-tree-read",
+      "pnpm --filter @first-tree/skill-evals validate:first-tree-read-fixtures",
+      "pnpm --filter @first-tree/skill-evals eval:first-tree-read",
+    ]);
+    expect(summary.recommendations[2]?.reason).toMatch(/opt-in/u);
+  });
+
+  it("selects all implemented gates and quality when shared judge core changes", () => {
+    const summary = selectSkillEvalRecommendations(["packages/skill-evals/src/core/judge/schema.ts"]);
+
+    expect(summary.recommendations.map((recommendation) => recommendation.command)).toEqual([
+      "pnpm --filter @first-tree/skill-evals eval:floor",
+      "pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-write",
+      "pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-seed",
+      "pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-welcome",
+      "pnpm --filter @first-tree/skill-evals eval:quality -- --suite first-tree-write",
+      "pnpm --filter @first-tree/skill-evals eval:quality -- --suite first-tree-welcome",
+    ]);
+  });
+
+  it("does not recommend live eval for unrelated files", () => {
+    const summary = selectSkillEvalRecommendations(["packages/client/src/runtime/agent-slot.ts"]);
+
+    expect(summary.recommendations).toEqual([]);
+    expect(summary.notes).toEqual(["No skill-eval-related changes were detected."]);
+  });
+
+  it("includes untracked working-tree files when selecting from git", () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), "skill-evals-select-test-"));
+    try {
+      runGit(repoRoot, ["init", "-b", "main"]);
+      runGit(repoRoot, ["config", "user.email", "test@example.com"]);
+      runGit(repoRoot, ["config", "user.name", "Test User"]);
+      writeFileSync(join(repoRoot, "README.md"), "initial\n", "utf8");
+      runGit(repoRoot, ["add", "README.md"]);
+      runGit(repoRoot, ["commit", "-m", "initial"]);
+      runGit(repoRoot, ["update-ref", "refs/remotes/origin/main", "HEAD"]);
+
+      const newFile = join(repoRoot, "packages", "skill-evals", "src", "core", "select.ts");
+      mkdirSync(join(repoRoot, "packages", "skill-evals", "src", "core"), { recursive: true });
+      writeFileSync(newFile, "export const value = true;\n", "utf8");
+
+      expect(changedFilesFromGit(repoRoot, "main")).toContain("packages/skill-evals/src/core/select.ts");
+    } finally {
+      rmSync(repoRoot, { force: true, recursive: true });
+    }
+  });
+});

--- a/packages/skill-evals/src/core/result-store.ts
+++ b/packages/skill-evals/src/core/result-store.ts
@@ -1,0 +1,320 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+import type { ShippedSkillName, SkillEvalTier } from "./case-schema.js";
+import { isRecord } from "./events.js";
+
+export type ResultStoreCommand = "eval:floor" | "eval:gate" | "eval:quality";
+
+export type ResultStoreStatus = "passed" | "failed" | "skipped";
+
+export type ResultStoreGitInfo = {
+  base: string | null;
+  branch: string | null;
+  sha: string | null;
+};
+
+export type ResultStoreArtifact = {
+  runRoot: string | null;
+  summaryJsonPath: string | null;
+  summaryMdPath: string | null;
+};
+
+export type ResultStoreEntry = {
+  artifact: ResultStoreArtifact;
+  caseId: string;
+  command: ResultStoreCommand;
+  costUsd: number | null;
+  durationMs: number | null;
+  failures: readonly string[];
+  git: ResultStoreGitInfo;
+  judgeScores: Record<string, number> | null;
+  model: string | null;
+  passed: boolean;
+  provider: string | null;
+  runGroupId: string;
+  schemaVersion: 1;
+  skill: ShippedSkillName | "framework";
+  startedAt: string;
+  status: ResultStoreStatus;
+  tier: SkillEvalTier;
+  turns: number | null;
+};
+
+export type ResultStoreRunGroup = {
+  entries: readonly ResultStoreEntry[];
+  runGroupId: string;
+  startedAt: string;
+};
+
+export type CompareEntryDelta = {
+  artifactPath: string | null;
+  caseKey: string;
+  costDeltaUsd: number | null;
+  currentPassed: boolean;
+  durationDeltaMs: number | null;
+  previousPassed: boolean | null;
+  scoreDeltas: Record<string, number> | null;
+};
+
+export type ResultCompareSummary = {
+  currentRunGroupId: string | null;
+  newFailures: readonly CompareEntryDelta[];
+  previousRunGroupId: string | null;
+  recovered: readonly CompareEntryDelta[];
+  stillFailing: readonly CompareEntryDelta[];
+  stillPassing: readonly CompareEntryDelta[];
+  unchangedOrNewPassing: readonly CompareEntryDelta[];
+};
+
+export function resultStorePath(packageRoot: string): string {
+  return join(packageRoot, ".runs", "index.jsonl");
+}
+
+export function sanitizeRunPart(value: string): string {
+  return value.replace(/[^0-9A-Za-z_.-]/gu, "-").replace(/-+/gu, "-");
+}
+
+export function createRunGroupId(startedAt: string, label: string): string {
+  const stamp = startedAt.replace(/[-:.]/gu, "");
+  return `${stamp}-${sanitizeRunPart(label)}`;
+}
+
+function nullIfEmpty(value: string): string | null {
+  const trimmed = value.trim();
+  return trimmed.length === 0 ? null : trimmed;
+}
+
+function gitOutput(repoRoot: string, args: readonly string[]): string | null {
+  try {
+    return nullIfEmpty(
+      execFileSync("git", args, {
+        cwd: repoRoot,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      }),
+    );
+  } catch {
+    return null;
+  }
+}
+
+export function readGitInfo(repoRoot: string, base: string | null = null): ResultStoreGitInfo {
+  return {
+    base,
+    branch: gitOutput(repoRoot, ["rev-parse", "--abbrev-ref", "HEAD"]),
+    sha: gitOutput(repoRoot, ["rev-parse", "HEAD"]),
+  };
+}
+
+export function appendResultStoreEntries(packageRoot: string, entries: readonly ResultStoreEntry[]): void {
+  if (entries.length === 0) return;
+  const storePath = resultStorePath(packageRoot);
+  mkdirSync(dirname(storePath), { recursive: true });
+  const payload = entries.map((entry) => JSON.stringify(entry)).join("\n");
+  writeFileSync(storePath, `${payload}\n`, { encoding: "utf8", flag: "a" });
+}
+
+function isResultStoreEntry(value: unknown): value is ResultStoreEntry {
+  return (
+    isRecord(value) &&
+    value.schemaVersion === 1 &&
+    typeof value.runGroupId === "string" &&
+    typeof value.caseId === "string" &&
+    typeof value.startedAt === "string" &&
+    typeof value.passed === "boolean"
+  );
+}
+
+export function readResultStore(packageRoot: string): readonly ResultStoreEntry[] {
+  const storePath = resultStorePath(packageRoot);
+  if (!existsSync(storePath)) return [];
+  const lines = readFileSync(storePath, "utf8")
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  return lines.map((line, index) => {
+    const parsed: unknown = JSON.parse(line);
+    if (!isResultStoreEntry(parsed)) {
+      throw new Error(`${storePath}:${index + 1}: invalid result store entry.`);
+    }
+    return parsed;
+  });
+}
+
+export function groupResultEntries(entries: readonly ResultStoreEntry[]): readonly ResultStoreRunGroup[] {
+  const byGroup = new Map<string, ResultStoreEntry[]>();
+  for (const entry of entries) {
+    const existing = byGroup.get(entry.runGroupId) ?? [];
+    existing.push(entry);
+    byGroup.set(entry.runGroupId, existing);
+  }
+
+  return [...byGroup.entries()]
+    .map(([runGroupId, groupEntries]) => ({
+      entries: groupEntries,
+      runGroupId,
+      startedAt: groupEntries.reduce((latest, entry) => (entry.startedAt > latest ? entry.startedAt : latest), ""),
+    }))
+    .sort((left, right) => left.startedAt.localeCompare(right.startedAt));
+}
+
+function caseKey(entry: ResultStoreEntry): string {
+  return `${entry.skill}:${entry.tier}:${entry.caseId}`;
+}
+
+function scoreDeltas(
+  current: Record<string, number> | null,
+  previous: Record<string, number> | null,
+): Record<string, number> | null {
+  if (current === null || previous === null) return null;
+  const keys = Object.keys(current).filter((key) => typeof previous[key] === "number");
+  if (keys.length === 0) return null;
+  return Object.fromEntries(keys.map((key) => [key, (current[key] ?? 0) - (previous[key] ?? 0)]));
+}
+
+function numericDelta(current: number | null, previous: number | null): number | null {
+  if (current === null || previous === null) return null;
+  return current - previous;
+}
+
+function entryDelta(current: ResultStoreEntry, previous: ResultStoreEntry | null): CompareEntryDelta {
+  return {
+    artifactPath: current.artifact.summaryJsonPath ?? current.artifact.runRoot,
+    caseKey: caseKey(current),
+    costDeltaUsd: numericDelta(current.costUsd, previous?.costUsd ?? null),
+    currentPassed: current.passed,
+    durationDeltaMs: numericDelta(current.durationMs, previous?.durationMs ?? null),
+    previousPassed: previous?.passed ?? null,
+    scoreDeltas: scoreDeltas(current.judgeScores, previous?.judgeScores ?? null),
+  };
+}
+
+export function compareResultGroups(
+  current: ResultStoreRunGroup | null,
+  previous: ResultStoreRunGroup | null,
+): ResultCompareSummary {
+  if (current === null || previous === null) {
+    return {
+      currentRunGroupId: current?.runGroupId ?? null,
+      newFailures: [],
+      previousRunGroupId: previous?.runGroupId ?? null,
+      recovered: [],
+      stillFailing: [],
+      stillPassing: [],
+      unchangedOrNewPassing: [],
+    };
+  }
+
+  const previousByKey = new Map(previous.entries.map((entry) => [caseKey(entry), entry]));
+  const newFailures: CompareEntryDelta[] = [];
+  const recovered: CompareEntryDelta[] = [];
+  const stillFailing: CompareEntryDelta[] = [];
+  const stillPassing: CompareEntryDelta[] = [];
+  const unchangedOrNewPassing: CompareEntryDelta[] = [];
+
+  for (const currentEntry of current.entries) {
+    const previousEntry = previousByKey.get(caseKey(currentEntry)) ?? null;
+    const delta = entryDelta(currentEntry, previousEntry);
+    if (!currentEntry.passed && previousEntry?.passed !== false) {
+      newFailures.push(delta);
+    } else if (currentEntry.passed && previousEntry?.passed === false) {
+      recovered.push(delta);
+    } else if (!currentEntry.passed && previousEntry?.passed === false) {
+      stillFailing.push(delta);
+    } else if (currentEntry.passed && previousEntry?.passed === true) {
+      stillPassing.push(delta);
+    } else {
+      unchangedOrNewPassing.push(delta);
+    }
+  }
+
+  return {
+    currentRunGroupId: current.runGroupId,
+    newFailures,
+    previousRunGroupId: previous.runGroupId,
+    recovered,
+    stillFailing,
+    stillPassing,
+    unchangedOrNewPassing,
+  };
+}
+
+export function latestRunGroups(
+  entries: readonly ResultStoreEntry[],
+  currentRunGroupId: string | null,
+  previousRunGroupId: string | null,
+): { current: ResultStoreRunGroup | null; previous: ResultStoreRunGroup | null } {
+  const groups = groupResultEntries(entries);
+  const byId = new Map(groups.map((group) => [group.runGroupId, group]));
+  const current =
+    currentRunGroupId === null ? (groups[groups.length - 1] ?? null) : (byId.get(currentRunGroupId) ?? null);
+  const previous =
+    previousRunGroupId === null
+      ? current === null
+        ? null
+        : (groups
+            .filter((group) => group.runGroupId !== current.runGroupId)
+            .filter((group) => groupsHaveSharedCaseKeys(current, group))
+            .at(-1) ?? null)
+      : (byId.get(previousRunGroupId) ?? null);
+  return { current, previous };
+}
+
+function groupsHaveSharedCaseKeys(left: ResultStoreRunGroup, right: ResultStoreRunGroup): boolean {
+  const rightKeys = new Set(right.entries.map(caseKey));
+  return left.entries.some((entry) => rightKeys.has(caseKey(entry)));
+}
+
+function formatDeltaList(title: string, deltas: readonly CompareEntryDelta[]): readonly string[] {
+  const lines = [`${title}: ${deltas.length}`];
+  for (const delta of deltas) {
+    const duration =
+      delta.durationDeltaMs === null
+        ? ""
+        : ` duration_delta_ms=${delta.durationDeltaMs >= 0 ? "+" : ""}${delta.durationDeltaMs}`;
+    const cost =
+      delta.costDeltaUsd === null ? "" : ` cost_delta_usd=${delta.costDeltaUsd >= 0 ? "+" : ""}${delta.costDeltaUsd}`;
+    lines.push(`- ${delta.caseKey}${duration}${cost}`);
+    if (delta.scoreDeltas !== null) {
+      const scoreText = Object.entries(delta.scoreDeltas)
+        .map(([key, value]) => `${key}=${value >= 0 ? "+" : ""}${value}`)
+        .join(", ");
+      lines.push(`  score_delta: ${scoreText}`);
+    }
+    if (delta.artifactPath !== null) {
+      lines.push(`  artifact: ${delta.artifactPath}`);
+    }
+  }
+  return lines;
+}
+
+export function formatCompareSummary(summary: ResultCompareSummary): string {
+  if (summary.currentRunGroupId === null || summary.previousRunGroupId === null) {
+    return [
+      "Skill Eval Compare",
+      "",
+      "Not enough eval run groups to compare.",
+      "Run at least two eval commands that write result-store entries, or pass explicit run group ids.",
+    ].join("\n");
+  }
+
+  return [
+    "Skill Eval Compare",
+    "",
+    `Current: ${summary.currentRunGroupId}`,
+    `Previous: ${summary.previousRunGroupId}`,
+    "",
+    ...formatDeltaList("New failures", summary.newFailures),
+    "",
+    ...formatDeltaList("Recovered", summary.recovered),
+    "",
+    ...formatDeltaList("Still failing", summary.stillFailing),
+    "",
+    ...formatDeltaList("Still passing", summary.stillPassing),
+    "",
+    ...formatDeltaList("New or unchanged passing", summary.unchangedOrNewPassing),
+  ].join("\n");
+}

--- a/packages/skill-evals/src/core/select.ts
+++ b/packages/skill-evals/src/core/select.ts
@@ -1,0 +1,297 @@
+import { execFileSync } from "node:child_process";
+
+import type { ShippedSkillName } from "./case-schema.js";
+
+export type EvalRecommendationKind = "floor" | "gate" | "quality" | "fixture-validation" | "read-live";
+
+export type EvalRecommendation = {
+  command: string;
+  kind: EvalRecommendationKind;
+  reason: string;
+  suite: ShippedSkillName | "all" | null;
+};
+
+export type EvalSelectionSummary = {
+  base: string | null;
+  changedFiles: readonly string[];
+  notes: readonly string[];
+  recommendations: readonly EvalRecommendation[];
+};
+
+const SKILL_BY_PATH: readonly {
+  skill: ShippedSkillName;
+  paths: readonly string[];
+}[] = [
+  {
+    paths: ["skills/first-tree-read/", "packages/skill-evals/src/suites/first-tree-read/"],
+    skill: "first-tree-read",
+  },
+  {
+    paths: ["skills/first-tree-write/", "packages/skill-evals/src/suites/first-tree-write/"],
+    skill: "first-tree-write",
+  },
+  {
+    paths: ["skills/first-tree-seed/", "packages/skill-evals/src/suites/first-tree-seed/"],
+    skill: "first-tree-seed",
+  },
+  {
+    paths: ["skills/first-tree-welcome/", "packages/skill-evals/src/suites/first-tree-welcome/"],
+    skill: "first-tree-welcome",
+  },
+];
+
+function normalizePath(path: string): string {
+  return path.replace(/\\/gu, "/").replace(/^\.\//u, "");
+}
+
+function addRecommendation(recommendations: Map<string, EvalRecommendation>, recommendation: EvalRecommendation): void {
+  if (!recommendations.has(recommendation.command)) {
+    recommendations.set(recommendation.command, recommendation);
+  }
+}
+
+function floorCommand(skill: ShippedSkillName | null): string {
+  if (skill === null) return "pnpm --filter @first-tree/skill-evals eval:floor";
+  return `pnpm --filter @first-tree/skill-evals eval:floor -- --suite ${skill}`;
+}
+
+function gateCommand(
+  skill: Extract<ShippedSkillName, "first-tree-write" | "first-tree-seed" | "first-tree-welcome">,
+): string {
+  return `pnpm --filter @first-tree/skill-evals eval:gate -- --suite ${skill}`;
+}
+
+function qualityCommand(skill: Extract<ShippedSkillName, "first-tree-write" | "first-tree-welcome">): string {
+  return `pnpm --filter @first-tree/skill-evals eval:quality -- --suite ${skill}`;
+}
+
+function addSuiteRecommendations(
+  recommendations: Map<string, EvalRecommendation>,
+  skill: ShippedSkillName,
+  reason: string,
+): void {
+  addRecommendation(recommendations, {
+    command: floorCommand(skill),
+    kind: "floor",
+    reason,
+    suite: skill,
+  });
+
+  if (skill === "first-tree-read") {
+    addRecommendation(recommendations, {
+      command: "pnpm --filter @first-tree/skill-evals validate:first-tree-read-fixtures",
+      kind: "fixture-validation",
+      reason,
+      suite: skill,
+    });
+    addRecommendation(recommendations, {
+      command: "pnpm --filter @first-tree/skill-evals eval:first-tree-read",
+      kind: "read-live",
+      reason: `${reason}; live read eval remains opt-in and may consume model quota`,
+      suite: skill,
+    });
+    return;
+  }
+
+  addRecommendation(recommendations, {
+    command: gateCommand(skill),
+    kind: "gate",
+    reason,
+    suite: skill,
+  });
+
+  if (skill === "first-tree-write" || skill === "first-tree-welcome") {
+    addRecommendation(recommendations, {
+      command: qualityCommand(skill),
+      kind: "quality",
+      reason,
+      suite: skill,
+    });
+  }
+}
+
+function addAllImplementedGateRecommendations(recommendations: Map<string, EvalRecommendation>, reason: string): void {
+  addRecommendation(recommendations, {
+    command: floorCommand(null),
+    kind: "floor",
+    reason,
+    suite: "all",
+  });
+  for (const skill of ["first-tree-write", "first-tree-seed", "first-tree-welcome"] as const) {
+    addRecommendation(recommendations, {
+      command: gateCommand(skill),
+      kind: "gate",
+      reason,
+      suite: skill,
+    });
+  }
+}
+
+function addQualityRecommendations(recommendations: Map<string, EvalRecommendation>, reason: string): void {
+  for (const skill of ["first-tree-write", "first-tree-welcome"] as const) {
+    addRecommendation(recommendations, {
+      command: qualityCommand(skill),
+      kind: "quality",
+      reason,
+      suite: skill,
+    });
+  }
+}
+
+function matchingSkill(path: string): ShippedSkillName | null {
+  for (const entry of SKILL_BY_PATH) {
+    if (entry.paths.some((prefix) => path.startsWith(prefix))) {
+      return entry.skill;
+    }
+  }
+  return null;
+}
+
+function isSkillEvalCorePath(path: string): boolean {
+  return path.startsWith("packages/skill-evals/src/core/") || path === "packages/skill-evals/src/index.ts";
+}
+
+function isSkillEvalCliOrSchemaPath(path: string): boolean {
+  return (
+    path === "packages/skill-evals/package.json" ||
+    path === "packages/skill-evals/src/suites/registry.ts" ||
+    path === "packages/skill-evals/src/suites/types.ts"
+  );
+}
+
+function isSkillEvalDocsOnly(path: string): boolean {
+  return path === "packages/skill-evals/README.md" || path.startsWith("packages/skill-evals/docs/");
+}
+
+export function selectSkillEvalRecommendations(
+  changedFilesInput: readonly string[],
+  base: string | null = null,
+): EvalSelectionSummary {
+  const changedFiles = [
+    ...new Set(changedFilesInput.map(normalizePath).filter((path) => path.trim().length > 0)),
+  ].sort();
+  const recommendations = new Map<string, EvalRecommendation>();
+  const notes: string[] = [];
+
+  for (const path of changedFiles) {
+    const skill = matchingSkill(path);
+    if (skill !== null) {
+      addSuiteRecommendations(recommendations, skill, `${path} touches ${skill}`);
+      continue;
+    }
+
+    if (isSkillEvalCorePath(path) || isSkillEvalCliOrSchemaPath(path)) {
+      addAllImplementedGateRecommendations(recommendations, `${path} touches shared skill-eval infrastructure`);
+      if (path.startsWith("packages/skill-evals/src/core/judge/")) {
+        addQualityRecommendations(recommendations, `${path} touches judge infrastructure`);
+      }
+      continue;
+    }
+
+    if (path.startsWith("packages/skill-evals/src/suites/quality/")) {
+      addRecommendation(recommendations, {
+        command: floorCommand(null),
+        kind: "floor",
+        reason: `${path} touches shared quality runner`,
+        suite: "all",
+      });
+      addQualityRecommendations(recommendations, `${path} touches shared quality runner`);
+      continue;
+    }
+
+    if (isSkillEvalDocsOnly(path)) {
+      addRecommendation(recommendations, {
+        command: floorCommand(null),
+        kind: "floor",
+        reason: `${path} is skill-eval documentation or usage text`,
+        suite: "all",
+      });
+    }
+  }
+
+  if (changedFiles.length === 0) {
+    notes.push("No changed files were provided; no skill eval runs selected.");
+  }
+  if (recommendations.size === 0 && changedFiles.length > 0) {
+    notes.push("No skill-eval-related changes were detected.");
+  }
+
+  return {
+    base,
+    changedFiles,
+    notes,
+    recommendations: [...recommendations.values()],
+  };
+}
+
+function gitRefExists(repoRoot: string, ref: string): boolean {
+  try {
+    execFileSync("git", ["rev-parse", "--verify", "--quiet", ref], {
+      cwd: repoRoot,
+      stdio: "ignore",
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function resolveDiffBase(repoRoot: string, base: string): string {
+  if (base.includes("/") || base.includes("...")) return base;
+  const originBase = `origin/${base}`;
+  return gitRefExists(repoRoot, originBase) ? originBase : base;
+}
+
+export function changedFilesFromGit(repoRoot: string, base: string): readonly string[] {
+  const diffBase = resolveDiffBase(repoRoot, base);
+  const outputs = [
+    execFileSync("git", ["diff", "--name-only", `${diffBase}...HEAD`], {
+      cwd: repoRoot,
+      encoding: "utf8",
+    }),
+    execFileSync("git", ["diff", "--name-only"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+    }),
+    execFileSync("git", ["diff", "--name-only", "--cached"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+    }),
+    execFileSync("git", ["ls-files", "--others", "--exclude-standard"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+    }),
+  ];
+  return [
+    ...new Set(
+      outputs
+        .join("\n")
+        .split(/\r?\n/u)
+        .map((line) => line.trim())
+        .filter(Boolean),
+    ),
+  ].sort();
+}
+
+export function formatSelectionSummary(summary: EvalSelectionSummary): string {
+  const lines = ["Skill Eval Selection", ""];
+  lines.push(`Base: ${summary.base ?? "explicit file list"}`);
+  lines.push(`Changed files: ${summary.changedFiles.length}`);
+  for (const path of summary.changedFiles) {
+    lines.push(`- ${path}`);
+  }
+  if (summary.recommendations.length > 0) {
+    lines.push("", "Recommended commands:");
+    for (const recommendation of summary.recommendations) {
+      lines.push(`- ${recommendation.command}`);
+      lines.push(`  reason: ${recommendation.reason}`);
+    }
+  }
+  if (summary.notes.length > 0) {
+    lines.push("", "Notes:");
+    for (const note of summary.notes) {
+      lines.push(`- ${note}`);
+    }
+  }
+  return lines.join("\n");
+}

--- a/packages/skill-evals/src/index.ts
+++ b/packages/skill-evals/src/index.ts
@@ -1,26 +1,44 @@
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { SHIPPED_SKILLS, type ShippedSkillName } from "./core/case-schema.js";
 import { type SkillEvalSuiteDefinition, validateCoverageMatrix } from "./core/coverage.js";
 import { isRecord } from "./core/events.js";
+import {
+  appendResultStoreEntries,
+  compareResultGroups,
+  createRunGroupId,
+  formatCompareSummary,
+  latestRunGroups,
+  type ResultStoreEntry,
+  readGitInfo,
+  readResultStore,
+} from "./core/result-store.js";
+import { changedFilesFromGit, formatSelectionSummary, selectSkillEvalRecommendations } from "./core/select.js";
 import { readSkillFrontmatter } from "./core/skills/frontmatter.js";
 import { formatFirstTreeSeedGateSummary, runFirstTreeSeedGate } from "./suites/first-tree-seed/index.js";
+import type { BatchSummary as SeedBatchSummary } from "./suites/first-tree-seed/types.js";
 import { formatFirstTreeWelcomeGateSummary, runFirstTreeWelcomeGate } from "./suites/first-tree-welcome/index.js";
+import type { BatchSummary as WelcomeBatchSummary } from "./suites/first-tree-welcome/types.js";
 import { formatFirstTreeWriteGateSummary, runFirstTreeWriteGate } from "./suites/first-tree-write/index.js";
+import type { BatchSummary as WriteBatchSummary } from "./suites/first-tree-write/types.js";
 import { formatQualitySummaryTable, runQualityEval } from "./suites/quality/index.js";
-import type { QualitySkillName } from "./suites/quality/types.js";
+import type { QualityBatchSummary, QualitySkillName } from "./suites/quality/types.js";
 import { SKILL_EVAL_SUITES } from "./suites/registry.js";
 
 type CliOptions = {
+  base: string | null;
   caseId: string | null;
+  changedFiles: readonly string[];
   codexBin: string;
-  command: "floor" | "gate" | "quality";
+  command: "compare" | "floor" | "gate" | "quality" | "select";
+  currentRunGroupId: string | null;
   judgeBin: string;
   judgeModel: string | null;
   json: boolean;
   model: string | null;
+  previousRunGroupId: string | null;
   suite: ShippedSkillName | null;
   verbose: boolean;
 };
@@ -48,15 +66,23 @@ function usage(): string {
   pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-seed
   pnpm --filter @first-tree/skill-evals eval:quality
   pnpm --filter @first-tree/skill-evals eval:quality -- --suite first-tree-write
+  pnpm --filter @first-tree/skill-evals eval:select -- --base main
+  pnpm --filter @first-tree/skill-evals eval:compare
 
 Commands:
   floor                  Run no-model schema, coverage, and skill-file checks.
   gate                   Run a live model gate suite.
   quality                Run opt-in LLM-as-judge quality cases.
+  select                 Recommend eval commands from changed files.
+  compare                Compare latest result-store run groups.
 
 Options:
   --suite <skill>        Limit per-suite floor checks to one shipped skill.
   --case <id>            Run one live gate case.
+  --base <ref>           Base ref for eval:select git diff. Defaults to main.
+  --changed-file <path>  Add an explicit changed file for eval:select.
+  --current <run-id>     Current run group for eval:compare. Defaults to latest.
+  --previous <run-id>    Previous run group for eval:compare. Defaults to previous.
   --json                 Print summary as JSON.
   --model <model>        Pass a model override to codex exec.
   --codex-bin <path>     Codex binary to execute. Defaults to CODEX_BIN or codex.
@@ -82,18 +108,28 @@ function parseArgs(args: readonly string[]): CliOptions {
     process.stdout.write(usage());
     process.exit(0);
   }
-  if (command !== "floor" && command !== "gate" && command !== "quality") {
+  if (
+    command !== "floor" &&
+    command !== "gate" &&
+    command !== "quality" &&
+    command !== "select" &&
+    command !== "compare"
+  ) {
     throw new Error(`Unknown command: ${command}`);
   }
 
   const options: CliOptions = {
+    base: null,
     caseId: null,
+    changedFiles: [],
     codexBin: process.env.CODEX_BIN ?? "codex",
     command,
+    currentRunGroupId: null,
     judgeBin: process.env.JUDGE_CODEX_BIN ?? process.env.CODEX_BIN ?? "codex",
     judgeModel: process.env.JUDGE_MODEL ?? process.env.CODEX_MODEL ?? null,
     json: false,
     model: process.env.CODEX_MODEL ?? null,
+    previousRunGroupId: null,
     suite: null,
     verbose: false,
   };
@@ -106,6 +142,26 @@ function parseArgs(args: readonly string[]): CliOptions {
     }
     if (arg === "--case") {
       options.caseId = readOptionValue(normalized, index, "--case");
+      index += 1;
+      continue;
+    }
+    if (arg === "--base") {
+      options.base = readOptionValue(normalized, index, "--base");
+      index += 1;
+      continue;
+    }
+    if (arg === "--changed-file") {
+      options.changedFiles = [...options.changedFiles, readOptionValue(normalized, index, "--changed-file")];
+      index += 1;
+      continue;
+    }
+    if (arg === "--current") {
+      options.currentRunGroupId = readOptionValue(normalized, index, "--current");
+      index += 1;
+      continue;
+    }
+    if (arg === "--previous") {
+      options.previousRunGroupId = readOptionValue(normalized, index, "--previous");
       index += 1;
       continue;
     }
@@ -254,15 +310,151 @@ function formatFloorSummary(summary: FloorSummary): string {
   return lines.join("\n");
 }
 
+function floorCheckCaseId(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/gu, "-")
+    .replace(/^-|-$/gu, "");
+}
+
+function floorCheckSkill(name: string): ShippedSkillName | "framework" {
+  return SHIPPED_SKILLS.find((skill) => name.startsWith(`${skill}:`)) ?? "framework";
+}
+
+function writeFloorArtifact(
+  packageRootPath: string,
+  summary: FloorSummary,
+  runGroupId: string,
+): { runRoot: string; summaryJsonPath: string; summaryMdPath: string } {
+  const runRoot = join(packageRootPath, ".runs", runGroupId);
+  const summaryJsonPath = join(runRoot, "summary.json");
+  const summaryMdPath = join(runRoot, "summary.md");
+  mkdirSync(runRoot, { recursive: true });
+  writeFileSync(summaryJsonPath, `${JSON.stringify(summary, null, 2)}\n`, "utf8");
+  writeFileSync(summaryMdPath, `${formatFloorSummary(summary)}\n`, "utf8");
+  return { runRoot, summaryJsonPath, summaryMdPath };
+}
+
+function floorResultEntries(
+  packageRootPath: string,
+  summary: FloorSummary,
+  options: {
+    artifact: { runRoot: string; summaryJsonPath: string; summaryMdPath: string };
+    base: string | null;
+    durationMs: number;
+    runGroupId: string;
+    startedAt: string;
+  },
+): readonly ResultStoreEntry[] {
+  const git = readGitInfo(repoRootFromPackage(packageRootPath), options.base);
+  return summary.checks.map((check) => ({
+    artifact: options.artifact,
+    caseId: floorCheckCaseId(check.name),
+    command: "eval:floor",
+    costUsd: null,
+    durationMs: options.durationMs,
+    failures: check.ok ? [] : [check.detail],
+    git,
+    judgeScores: null,
+    model: null,
+    passed: check.ok,
+    provider: null,
+    runGroupId: options.runGroupId,
+    schemaVersion: 1,
+    skill: floorCheckSkill(check.name),
+    startedAt: options.startedAt,
+    status: check.ok ? "passed" : "failed",
+    tier: "floor",
+    turns: null,
+  }));
+}
+
+type GateBatchSummary = SeedBatchSummary | WelcomeBatchSummary | WriteBatchSummary;
+
+function gateResultEntries(
+  packageRootPath: string,
+  batch: GateBatchSummary,
+  suite: Exclude<ShippedSkillName, "first-tree-read">,
+  options: CliOptions,
+): readonly ResultStoreEntry[] {
+  const runGroupId = createRunGroupId(batch.runStartedAt, `eval-gate-${suite}`);
+  const git = readGitInfo(repoRootFromPackage(packageRootPath), options.base);
+  return batch.cases.map((summary) => {
+    const durationMs = Math.max(0, Date.now() - Date.parse(summary.startedAt));
+    return {
+      artifact: {
+        runRoot: summary.runRoot,
+        summaryJsonPath: summary.summaryJsonPath,
+        summaryMdPath: summary.summaryMdPath,
+      },
+      caseId: summary.caseId,
+      command: "eval:gate",
+      costUsd: null,
+      durationMs,
+      failures: summary.passed ? [] : [summary.driftNote ?? "gate case failed"],
+      git,
+      judgeScores: null,
+      model: options.model,
+      passed: summary.passed,
+      provider: "codex",
+      runGroupId,
+      schemaVersion: 1,
+      skill: suite,
+      startedAt: summary.startedAt,
+      status: summary.passed ? "passed" : "failed",
+      tier: "gate",
+      turns: null,
+    } satisfies ResultStoreEntry;
+  });
+}
+
+function qualityResultEntries(
+  packageRootPath: string,
+  batch: QualityBatchSummary,
+  options: CliOptions,
+): readonly ResultStoreEntry[] {
+  const runGroupId = createRunGroupId(batch.runStartedAt, `eval-quality-${options.suite ?? "all"}`);
+  const git = readGitInfo(repoRootFromPackage(packageRootPath), options.base);
+  return batch.cases.map(
+    (summary) =>
+      ({
+        artifact: {
+          runRoot: summary.runRoot,
+          summaryJsonPath: summary.summaryJsonPath,
+          summaryMdPath: summary.summaryMdPath,
+        },
+        caseId: summary.caseId,
+        command: "eval:quality",
+        costUsd: summary.cost_usd,
+        durationMs: summary.duration_ms,
+        failures: summary.failures,
+        git,
+        judgeScores: summary.judge_scores,
+        model: summary.judge_model,
+        passed: summary.passed,
+        provider: summary.judge_provider,
+        runGroupId,
+        schemaVersion: 1,
+        skill: summary.skill as ShippedSkillName,
+        startedAt: summary.startedAt,
+        status: summary.passed ? "passed" : "failed",
+        tier: "quality",
+        turns: null,
+      }) satisfies ResultStoreEntry,
+  );
+}
+
 async function runGate(options: CliOptions): Promise<void> {
+  const packageRootPath = packageRoot();
   if (options.suite === "first-tree-write") {
-    const batch = await runFirstTreeWriteGate(packageRoot(), {
+    const batch = await runFirstTreeWriteGate(packageRootPath, {
       caseId: options.caseId,
       codexBin: options.codexBin,
       json: options.json,
       model: options.model,
       verbose: options.verbose,
     });
+    appendResultStoreEntries(packageRootPath, gateResultEntries(packageRootPath, batch, options.suite, options));
     if (options.json) {
       process.stdout.write(`${JSON.stringify(batch, null, 2)}\n`);
     } else {
@@ -275,13 +467,14 @@ async function runGate(options: CliOptions): Promise<void> {
   }
 
   if (options.suite === "first-tree-seed") {
-    const batch = await runFirstTreeSeedGate(packageRoot(), {
+    const batch = await runFirstTreeSeedGate(packageRootPath, {
       caseId: options.caseId,
       codexBin: options.codexBin,
       json: options.json,
       model: options.model,
       verbose: options.verbose,
     });
+    appendResultStoreEntries(packageRootPath, gateResultEntries(packageRootPath, batch, options.suite, options));
     if (options.json) {
       process.stdout.write(`${JSON.stringify(batch, null, 2)}\n`);
     } else {
@@ -294,13 +487,14 @@ async function runGate(options: CliOptions): Promise<void> {
   }
 
   if (options.suite === "first-tree-welcome") {
-    const batch = await runFirstTreeWelcomeGate(packageRoot(), {
+    const batch = await runFirstTreeWelcomeGate(packageRootPath, {
       caseId: options.caseId,
       codexBin: options.codexBin,
       json: options.json,
       model: options.model,
       verbose: options.verbose,
     });
+    appendResultStoreEntries(packageRootPath, gateResultEntries(packageRootPath, batch, options.suite, options));
     if (options.json) {
       process.stdout.write(`${JSON.stringify(batch, null, 2)}\n`);
     } else {
@@ -318,7 +512,8 @@ async function runGate(options: CliOptions): Promise<void> {
 }
 
 async function runQuality(options: CliOptions): Promise<void> {
-  const batch = await runQualityEval(packageRoot(), {
+  const packageRootPath = packageRoot();
+  const batch = await runQualityEval(packageRootPath, {
     caseId: options.caseId,
     codexBin: options.codexBin,
     judgeBin: options.judgeBin,
@@ -328,6 +523,7 @@ async function runQuality(options: CliOptions): Promise<void> {
     suite: qualitySuite(options),
     verbose: options.verbose,
   });
+  appendResultStoreEntries(packageRootPath, qualityResultEntries(packageRootPath, batch, options));
   if (options.json) {
     process.stdout.write(`${JSON.stringify(batch, null, 2)}\n`);
   } else {
@@ -338,8 +534,41 @@ async function runQuality(options: CliOptions): Promise<void> {
   }
 }
 
+function runSelect(options: CliOptions): void {
+  const packageRootPath = packageRoot();
+  const repoRoot = repoRootFromPackage(packageRootPath);
+  const base = options.base ?? "main";
+  const changedFiles = options.changedFiles.length === 0 ? changedFilesFromGit(repoRoot, base) : options.changedFiles;
+  const summary = selectSkillEvalRecommendations(changedFiles, options.changedFiles.length === 0 ? base : null);
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+  } else {
+    process.stdout.write(`${formatSelectionSummary(summary)}\n`);
+  }
+}
+
+function runCompare(options: CliOptions): void {
+  const packageRootPath = packageRoot();
+  const entries = readResultStore(packageRootPath);
+  const { current, previous } = latestRunGroups(entries, options.currentRunGroupId, options.previousRunGroupId);
+  const summary = compareResultGroups(current, previous);
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+  } else {
+    process.stdout.write(`${formatCompareSummary(summary)}\n`);
+  }
+}
+
 async function main(): Promise<void> {
   const options = parseArgs(process.argv.slice(2));
+  if (options.command === "select") {
+    runSelect(options);
+    return;
+  }
+  if (options.command === "compare") {
+    runCompare(options);
+    return;
+  }
   if (options.command === "gate") {
     await runGate(options);
     return;
@@ -349,7 +578,22 @@ async function main(): Promise<void> {
     return;
   }
 
+  const packageRootPath = packageRoot();
+  const startedAt = new Date().toISOString();
+  const before = Date.now();
   const summary = buildFloorSummary(options);
+  const runGroupId = createRunGroupId(startedAt, `eval-floor-${options.suite ?? "all"}`);
+  const artifact = writeFloorArtifact(packageRootPath, summary, runGroupId);
+  appendResultStoreEntries(
+    packageRootPath,
+    floorResultEntries(packageRootPath, summary, {
+      artifact,
+      base: options.base,
+      durationMs: Date.now() - before,
+      runGroupId,
+      startedAt,
+    }),
+  );
   if (options.json) {
     process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
   } else {


### PR DESCRIPTION
## Summary

- Add `eval:select` to recommend skill-eval commands from changed files, including committed, staged, unstaged, and untracked paths.
- Add a local `.runs/index.jsonl` result store for `eval:floor`, `eval:gate`, and `eval:quality` entries with suite/tier/case status, git info, model/provider, artifact paths, duration/cost, and judge scores when present.
- Add `eval:compare` to compare latest comparable run groups and report new failures, recoveries, still-failing/still-passing cases, score deltas, and artifact paths.
- Document the result operations workflow in the skill-evals README.

## Verification

- `pnpm install --frozen-lockfile` (new worktree had no `node_modules`; existing CLI dist bin symlink warnings only)
- `pnpm --filter @first-tree/skill-evals test` (59 passed)
- `pnpm --filter @first-tree/skill-evals typecheck`
- `pnpm exec biome check packages/skill-evals/src packages/skill-evals/package.json packages/skill-evals/README.md`
- `pnpm --filter @first-tree/skill-evals eval:floor`
- `pnpm --filter @first-tree/skill-evals eval:select -- --changed-file skills/first-tree-write/SKILL.md`
- `pnpm --filter @first-tree/skill-evals eval:select -- --changed-file packages/skill-evals/src/core/judge/schema.ts --json`
- `pnpm --filter @first-tree/skill-evals eval:select -- --base main --json`
- `pnpm --filter @first-tree/skill-evals eval:compare`
- `pnpm --filter @first-tree/skill-evals eval:compare -- --json`
- `pnpm --filter @first-tree/shared build`
- `pnpm --filter @first-tree/client build` (exited 0 with existing unresolved-import warnings)
- `pnpm --filter @first-tree/skill-evals validate:first-tree-read-fixtures`
- `git diff --check`

## Notes

- This is result-operations work only: no new live skill cases, no `skills/*/SKILL.md` changes, no read live stability changes, no judge sandbox hardening, and no deterministic gate/oracle relaxation.
- Live gate/quality evals were not run for this PR because the changed layer is no-model result operations; result-store and compare behavior were verified with floor summaries.
- Pre-PR review by `codex-reviewer` found no blocking issues. Two follow-ups were noted as non-blocking: selection can later recommend quality/compare for result-operation entrypoint changes, and durations can be made more precise if trend analysis becomes stricter.
