### PR TITLE
fix: skip onboarding create-agent step when member already has a personal agent

### DIFF
--- a/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
+++ b/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
@@ -1878,6 +1878,34 @@ describe("web DOM interaction coverage", () => {
     await unmountRoot(view.root);
   });
 
+  it("skips the create-agent step when the member already has a personal agent", async () => {
+    authMock.value = { ...authMock.value, currentOrgHasPersonalAgent: true };
+    const { StepCreateAgent } = await import("../onboarding/steps/step-create-agent.js");
+    const { flow, root } = await renderOnboardingDom(<StepCreateAgent />, {
+      activeStep: "create-agent",
+      agentPhase: "idle",
+    });
+    await flush();
+    // A fresh re-entry (refresh / new tab) after the agent already came online
+    // but before start-chat lands back here; advancing past the form keeps the
+    // member from creating a duplicate agent.
+    expect(flow.goNext).toHaveBeenCalledTimes(1);
+    expect(flow.createAgent).not.toHaveBeenCalled();
+    await unmountRoot(root);
+  });
+
+  it("shows the create-agent form when the member has no personal agent yet", async () => {
+    authMock.value = { ...authMock.value, currentOrgHasPersonalAgent: false };
+    const { StepCreateAgent } = await import("../onboarding/steps/step-create-agent.js");
+    const { flow, root } = await renderOnboardingDom(<StepCreateAgent />, {
+      activeStep: "create-agent",
+      agentPhase: "idle",
+    });
+    await flush();
+    expect(flow.goNext).not.toHaveBeenCalled();
+    await unmountRoot(root);
+  });
+
   it("drives StepStartChat admin and invitee start flows", async () => {
     const { StepStartChat } = await import("../onboarding/steps/step-start-chat.js");
     const findButton = (container: ParentNode, text: string): HTMLButtonElement | null =>

--- a/packages/web/src/pages/onboarding/steps/step-create-agent.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-create-agent.tsx
@@ -1,6 +1,7 @@
 import type { AgentVisibility } from "@first-tree/shared";
 import { ArrowRight } from "lucide-react";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
+import { useAuth } from "../../../auth/auth-context.js";
 import { Button } from "../../../components/ui/button.js";
 import { Input } from "../../../components/ui/input.js";
 import { OptionCard } from "../../../components/ui/option-card.js";
@@ -44,9 +45,27 @@ export function StepCreateAgent() {
     finishLater,
     agentPhase,
     agentError,
+    goNext,
     goTo,
     sequence,
   } = useOnboardingFlow();
+  const { currentOrgHasPersonalAgent } = useAuth();
+
+  // Fresh onboarding entry always lands on the opening step and walks forward
+  // (inferInitialStepIndex ignores server readiness), so a member who already
+  // created their personal agent in this org — e.g. a refresh / new tab after
+  // the agent came online but before start-chat — can reach this step again.
+  // Creating here would make a duplicate agent, so skip straight past the form.
+  // Gated on `idle` + the one-shot ref so it never double-advances the normal
+  // create path, which advances itself via the flow's onAgentOnline -> goNext.
+  const skippedExistingAgent = useRef(false);
+  useEffect(() => {
+    if (skippedExistingAgent.current) return;
+    if (currentOrgHasPersonalAgent && agentPhase === "idle") {
+      skippedExistingAgent.current = true;
+      goNext();
+    }
+  }, [currentOrgHasPersonalAgent, agentPhase, goNext]);
 
   const trimmed = agentDisplayName.trim();
   const canCreate =


### PR DESCRIPTION
Fast-follow to #1311. A codex review of #1311 flagged this [P2]: the value-first redesign makes fresh onboarding entry always land on the opening step and walk forward (`inferInitialStepIndex` ignores server readiness). So a member who already created their personal agent — e.g. a **refresh / new tab after the agent came online but before start-chat** — reaches `StepCreateAgent` again, where submitting would create a **duplicate agent** (the step had no existing-agent guard).

**Fix:** `StepCreateAgent` advances past itself (`goNext`) on entry when `currentOrgHasPersonalAgent` is already true — gated on idle phase + a one-shot ref so it never double-advances the normal create path (which advances via the flow's `onAgentOnline -> goNext`). Preserves the redesign's "walk from the opening step" behavior while preventing the duplicate.

Tests: two cases added to web-dom-interactions (skips when a personal agent exists; shows the form when it doesn't). Full file green, typecheck + lint:tokens + biome clean.