### PR TITLE
Unify first-tree-read skill eval gate

### DIFF
--- a/packages/skill-evals/README.md
+++ b/packages/skill-evals/README.md
@@ -4,10 +4,12 @@ Opt-in live model evaluations for First Tree skills. These scripts are not part
 of `pnpm test`, `pnpm check`, or default CI because they can consume real model
 quota.
 
-## first-tree-read
+## Commands
 
 ```bash
 pnpm --filter @first-tree/skill-evals eval:floor
+pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-read
+pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-read --case tree-software-trigger
 pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-write
 pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-welcome
 pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-seed
@@ -16,11 +18,6 @@ pnpm --filter @first-tree/skill-evals eval:quality -- --suite first-tree-write
 pnpm --filter @first-tree/skill-evals eval:quality -- --suite first-tree-welcome --judge-model <model>
 pnpm --filter @first-tree/skill-evals eval:select -- --base main
 pnpm --filter @first-tree/skill-evals eval:compare
-pnpm --filter @first-tree/skill-evals eval:first-tree-read
-pnpm --filter @first-tree/skill-evals eval:first-tree-read -- --case tree-software-trigger
-pnpm --filter @first-tree/skill-evals eval:first-tree-read -- --json
-pnpm --filter @first-tree/skill-evals eval:first-tree-read -- --verbose
-pnpm --filter @first-tree/skill-evals eval:first-tree-read -- --case tree-software-trigger --validate-fixtures --verbose
 ```
 
 `eval:floor` is a no-model check for the skill-eval framework itself. It
@@ -67,6 +64,16 @@ isolated `HOME` / temp directory, an environment allowlist, and failing command
 guards for common external side-effect commands such as `git`, `gh`,
 `first-tree`, `curl`, and `wget`. This is a guardrail for the text judge; it is
 not a substitute for a future direct no-tools judge API.
+
+`eval:gate -- --suite first-tree-read` runs the live Codex gate for
+`first-tree-read`. It covers the existing read cases through the shared gate
+runner:
+
+- blank workspace + casual prompt should not trigger Context Tree reads;
+- Context Tree workspace + software prompt should read the skill, inspect
+  `first-tree tree tree --help`, use a selector successfully, and report the
+  expected durable facts;
+- Context Tree workspace + non-software prompt should not use `first-tree`.
 
 `eval:gate -- --suite first-tree-write` runs the live Codex gate for
 `first-tree-write`. It covers the minimum source-boundary cases:
@@ -144,4 +151,13 @@ Fixture-only validation is available without model calls:
 
 ```bash
 pnpm --filter @first-tree/skill-evals validate:first-tree-read-fixtures
+```
+
+Legacy read eval aliases are retained for compatibility, but the shared gate
+command is the primary live path:
+
+```bash
+pnpm --filter @first-tree/skill-evals eval:first-tree-read
+pnpm --filter @first-tree/skill-evals eval:first-tree-read -- --case tree-software-trigger
+pnpm --filter @first-tree/skill-evals eval:first-tree-read -- --case tree-software-trigger --validate-fixtures --verbose
 ```

--- a/packages/skill-evals/src/core/__tests__/select.test.ts
+++ b/packages/skill-evals/src/core/__tests__/select.test.ts
@@ -25,15 +25,13 @@ describe("skill eval selection", () => {
     ]);
   });
 
-  it("selects read fixture validation and opt-in live read eval for read suite changes", () => {
-    const summary = selectSkillEvalRecommendations(["packages/skill-evals/src/suites/first-tree-read/runner.ts"]);
+  it("selects read floor and unified gate for read suite changes", () => {
+    const summary = selectSkillEvalRecommendations(["skills/first-tree-read/SKILL.md"]);
 
     expect(summary.recommendations.map((recommendation) => recommendation.command)).toEqual([
       "pnpm --filter @first-tree/skill-evals eval:floor -- --suite first-tree-read",
-      "pnpm --filter @first-tree/skill-evals validate:first-tree-read-fixtures",
-      "pnpm --filter @first-tree/skill-evals eval:first-tree-read",
+      "pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-read",
     ]);
-    expect(summary.recommendations[2]?.reason).toMatch(/opt-in/u);
   });
 
   it("selects all implemented gates and quality when shared judge core changes", () => {
@@ -41,6 +39,7 @@ describe("skill eval selection", () => {
 
     expect(summary.recommendations.map((recommendation) => recommendation.command)).toEqual([
       "pnpm --filter @first-tree/skill-evals eval:floor",
+      "pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-read",
       "pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-write",
       "pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-seed",
       "pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-welcome",

--- a/packages/skill-evals/src/core/__tests__/select.test.ts
+++ b/packages/skill-evals/src/core/__tests__/select.test.ts
@@ -34,6 +34,15 @@ describe("skill eval selection", () => {
     ]);
   });
 
+  it("selects read floor and unified gate for legacy read wrapper changes", () => {
+    const summary = selectSkillEvalRecommendations(["packages/skill-evals/src/first-tree-read/index.ts"]);
+
+    expect(summary.recommendations.map((recommendation) => recommendation.command)).toEqual([
+      "pnpm --filter @first-tree/skill-evals eval:floor -- --suite first-tree-read",
+      "pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-read",
+    ]);
+  });
+
   it("selects all implemented gates and quality when shared judge core changes", () => {
     const summary = selectSkillEvalRecommendations(["packages/skill-evals/src/core/judge/schema.ts"]);
 

--- a/packages/skill-evals/src/core/select.ts
+++ b/packages/skill-evals/src/core/select.ts
@@ -2,7 +2,7 @@ import { execFileSync } from "node:child_process";
 
 import type { ShippedSkillName } from "./case-schema.js";
 
-export type EvalRecommendationKind = "floor" | "gate" | "quality" | "fixture-validation" | "read-live";
+export type EvalRecommendationKind = "floor" | "gate" | "quality";
 
 export type EvalRecommendation = {
   command: string;
@@ -55,9 +55,7 @@ function floorCommand(skill: ShippedSkillName | null): string {
   return `pnpm --filter @first-tree/skill-evals eval:floor -- --suite ${skill}`;
 }
 
-function gateCommand(
-  skill: Extract<ShippedSkillName, "first-tree-write" | "first-tree-seed" | "first-tree-welcome">,
-): string {
+function gateCommand(skill: ShippedSkillName): string {
   return `pnpm --filter @first-tree/skill-evals eval:gate -- --suite ${skill}`;
 }
 
@@ -76,22 +74,6 @@ function addSuiteRecommendations(
     reason,
     suite: skill,
   });
-
-  if (skill === "first-tree-read") {
-    addRecommendation(recommendations, {
-      command: "pnpm --filter @first-tree/skill-evals validate:first-tree-read-fixtures",
-      kind: "fixture-validation",
-      reason,
-      suite: skill,
-    });
-    addRecommendation(recommendations, {
-      command: "pnpm --filter @first-tree/skill-evals eval:first-tree-read",
-      kind: "read-live",
-      reason: `${reason}; live read eval remains opt-in and may consume model quota`,
-      suite: skill,
-    });
-    return;
-  }
 
   addRecommendation(recommendations, {
     command: gateCommand(skill),
@@ -117,7 +99,7 @@ function addAllImplementedGateRecommendations(recommendations: Map<string, EvalR
     reason,
     suite: "all",
   });
-  for (const skill of ["first-tree-write", "first-tree-seed", "first-tree-welcome"] as const) {
+  for (const skill of ["first-tree-read", "first-tree-write", "first-tree-seed", "first-tree-welcome"] as const) {
     addRecommendation(recommendations, {
       command: gateCommand(skill),
       kind: "gate",

--- a/packages/skill-evals/src/core/select.ts
+++ b/packages/skill-evals/src/core/select.ts
@@ -23,7 +23,11 @@ const SKILL_BY_PATH: readonly {
   paths: readonly string[];
 }[] = [
   {
-    paths: ["skills/first-tree-read/", "packages/skill-evals/src/suites/first-tree-read/"],
+    paths: [
+      "skills/first-tree-read/",
+      "packages/skill-evals/src/first-tree-read/",
+      "packages/skill-evals/src/suites/first-tree-read/",
+    ],
     skill: "first-tree-read",
   },
   {

--- a/packages/skill-evals/src/first-tree-read/index.ts
+++ b/packages/skill-evals/src/first-tree-read/index.ts
@@ -1,1 +1,7 @@
-import "../suites/first-tree-read/index.js";
+import { runFirstTreeReadLegacyCli } from "../suites/first-tree-read/index.js";
+
+runFirstTreeReadLegacyCli(process.argv.slice(2)).catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`${message}\n`);
+  process.exitCode = 1;
+});

--- a/packages/skill-evals/src/index.ts
+++ b/packages/skill-evals/src/index.ts
@@ -17,6 +17,8 @@ import {
 } from "./core/result-store.js";
 import { changedFilesFromGit, formatSelectionSummary, selectSkillEvalRecommendations } from "./core/select.js";
 import { readSkillFrontmatter } from "./core/skills/frontmatter.js";
+import { formatFirstTreeReadGateSummary, runFirstTreeReadGate } from "./suites/first-tree-read/index.js";
+import type { BatchSummary as ReadBatchSummary } from "./suites/first-tree-read/types.js";
 import { formatFirstTreeSeedGateSummary, runFirstTreeSeedGate } from "./suites/first-tree-seed/index.js";
 import type { BatchSummary as SeedBatchSummary } from "./suites/first-tree-seed/types.js";
 import { formatFirstTreeWelcomeGateSummary, runFirstTreeWelcomeGate } from "./suites/first-tree-welcome/index.js";
@@ -61,6 +63,7 @@ function usage(): string {
   pnpm --filter @first-tree/skill-evals eval:floor
   pnpm --filter @first-tree/skill-evals eval:floor -- --json
   pnpm --filter @first-tree/skill-evals eval:floor -- --suite <skill>
+  pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-read
   pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-write
   pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-welcome
   pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-seed
@@ -369,12 +372,12 @@ function floorResultEntries(
   }));
 }
 
-type GateBatchSummary = SeedBatchSummary | WelcomeBatchSummary | WriteBatchSummary;
+type GateBatchSummary = ReadBatchSummary | SeedBatchSummary | WelcomeBatchSummary | WriteBatchSummary;
 
 function gateResultEntries(
   packageRootPath: string,
   batch: GateBatchSummary,
-  suite: Exclude<ShippedSkillName, "first-tree-read">,
+  suite: ShippedSkillName,
   options: CliOptions,
 ): readonly ResultStoreEntry[] {
   const runGroupId = createRunGroupId(batch.runStartedAt, `eval-gate-${suite}`);
@@ -446,6 +449,26 @@ function qualityResultEntries(
 
 async function runGate(options: CliOptions): Promise<void> {
   const packageRootPath = packageRoot();
+  if (options.suite === "first-tree-read") {
+    const batch = await runFirstTreeReadGate(packageRootPath, {
+      caseId: options.caseId,
+      codexBin: options.codexBin,
+      json: options.json,
+      model: options.model,
+      verbose: options.verbose,
+    });
+    appendResultStoreEntries(packageRootPath, gateResultEntries(packageRootPath, batch, options.suite, options));
+    if (options.json) {
+      process.stdout.write(`${JSON.stringify(batch, null, 2)}\n`);
+    } else {
+      process.stdout.write(`${formatFirstTreeReadGateSummary(batch)}\n`);
+    }
+    if (batch.failed > 0) {
+      process.exitCode = 1;
+    }
+    return;
+  }
+
   if (options.suite === "first-tree-write") {
     const batch = await runFirstTreeWriteGate(packageRootPath, {
       caseId: options.caseId,
@@ -507,7 +530,7 @@ async function runGate(options: CliOptions): Promise<void> {
   }
 
   throw new Error(
-    "eval:gate currently requires --suite first-tree-write, --suite first-tree-seed, or --suite first-tree-welcome.",
+    "eval:gate currently requires --suite first-tree-read, --suite first-tree-write, --suite first-tree-seed, or --suite first-tree-welcome.",
   );
 }
 

--- a/packages/skill-evals/src/suites/first-tree-read/index.ts
+++ b/packages/skill-evals/src/suites/first-tree-read/index.ts
@@ -6,10 +6,18 @@ import { isRecord } from "../../core/events.js";
 import { FIRST_TREE_READ_CASES, findFirstTreeReadCase } from "./cases.js";
 import { runFirstTreeReadCase } from "./runner.js";
 import { buildBatchSummary, formatSummaryTable } from "./summary.js";
-import type { CliOptions, FirstTreeReadEvalCase } from "./types.js";
+import type { BatchSummary, CliOptions, FirstTreeReadEvalCase } from "./types.js";
+
+export { findFirstTreeReadCase };
+
+export type FirstTreeReadGateOptions = Omit<CliOptions, "validateFixtures">;
 
 function usage(): string {
   return `Usage:
+  pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-read
+  pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-read --case <id>
+
+Compatibility aliases:
   pnpm --filter @first-tree/skill-evals eval:first-tree-read
   pnpm --filter @first-tree/skill-evals eval:first-tree-read -- --case <id>
   pnpm --filter @first-tree/skill-evals eval:first-tree-read -- --json
@@ -87,15 +95,47 @@ function parseArgs(args: readonly string[]): CliOptions {
   return options;
 }
 
-function selectCases(options: CliOptions): readonly FirstTreeReadEvalCase[] {
-  if (options.caseId === null) return FIRST_TREE_READ_CASES;
+function selectCases(caseId: string | null): readonly FirstTreeReadEvalCase[] {
+  if (caseId === null) return FIRST_TREE_READ_CASES;
 
-  const evalCase = findFirstTreeReadCase(options.caseId);
+  const evalCase = findFirstTreeReadCase(caseId);
   if (evalCase === null) {
     const available = FIRST_TREE_READ_CASES.map((candidate) => candidate.id).join(", ");
-    throw new Error(`Unknown case '${options.caseId}'. Available cases: ${available}`);
+    throw new Error(`Unknown case '${caseId}'. Available cases: ${available}`);
   }
   return [evalCase];
+}
+
+export async function runFirstTreeReadGate(
+  packageRootPath: string,
+  options: FirstTreeReadGateOptions,
+): Promise<BatchSummary> {
+  const selectedCases = selectCases(options.caseId);
+  const runStartedAt = new Date().toISOString();
+  const summaries = [];
+
+  for (const evalCase of selectedCases) {
+    if (!options.verbose) {
+      process.stderr.write(`Running first-tree-read eval case: ${evalCase.id}\n`);
+    }
+    summaries.push(
+      await runFirstTreeReadCase(
+        packageRootPath,
+        evalCase,
+        {
+          ...options,
+          validateFixtures: false,
+        },
+        runStartedAt,
+      ),
+    );
+  }
+
+  return buildBatchSummary(summaries, runStartedAt);
+}
+
+export function formatFirstTreeReadGateSummary(batch: BatchSummary): string {
+  return formatSummaryTable(batch);
 }
 
 function packageRoot(): string {
@@ -113,9 +153,9 @@ function packageRoot(): string {
   throw new Error("Could not locate @first-tree/skill-evals package root.");
 }
 
-async function main(): Promise<void> {
-  const options = parseArgs(process.argv.slice(2));
-  const selectedCases = selectCases(options);
+export async function runFirstTreeReadLegacyCli(args: readonly string[]): Promise<void> {
+  const options = parseArgs(args);
+  const selectedCases = selectCases(options.caseId);
   const runStartedAt = new Date().toISOString();
   const summaries = [];
 
@@ -141,9 +181,3 @@ async function main(): Promise<void> {
     process.exitCode = 1;
   }
 }
-
-main().catch((error: unknown) => {
-  const message = error instanceof Error ? error.message : String(error);
-  process.stderr.write(`${message}\n`);
-  process.exitCode = 1;
-});


### PR DESCRIPTION
## Summary

- Route `first-tree-read` through the shared `eval:gate -- --suite first-tree-read` command.
- Keep the legacy `eval:first-tree-read` and `validate:first-tree-read-fixtures` scripts as compatibility wrappers.
- Update `eval:select` so read changes recommend the unified floor/gate path, and include read in shared skill-eval gate recommendations.
- Update skill-evals README and top-level CLI usage for the unified read gate path.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter @first-tree/skill-evals typecheck`
- `pnpm --filter @first-tree/skill-evals exec vitest run --passWithNoTests --maxWorkers=2 --minWorkers=1`
- `pnpm --filter @first-tree/skill-evals eval:floor -- --suite first-tree-read`
- `pnpm --filter @first-tree/skill-evals eval:select -- --changed-file skills/first-tree-read/SKILL.md`
- `pnpm --filter first-tree-dev... build`
- `pnpm --filter @first-tree/skill-evals validate:first-tree-read-fixtures`
- `pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-read --case tree-software-trigger --codex-bin /bin/false --json` (expected failure from fake provider; verified the unified gate route, fixture validation, and result-store write)
- `pnpm check` (exits 0; reports existing warnings outside this PR)
- `pnpm typecheck`
- `pnpm exec biome check packages/skill-evals/README.md packages/skill-evals/src/core/__tests__/select.test.ts packages/skill-evals/src/core/select.ts packages/skill-evals/src/first-tree-read/index.ts packages/skill-evals/src/index.ts packages/skill-evals/src/suites/first-tree-read/index.ts`

## Notes

- This PR intentionally does not add `grading.json`, four-axis grading, hermetic runner changes, `eval:summary`, `--include-quality`, periodic coverage, extra welcome rows, or multi-provider runner support.
- I did not run a real Codex live read gate to avoid consuming model quota during PR preparation.
