### PR TITLE
fix: daemon.env channel path + parse/egress hardening (QA follow-up to #1335)

### DIFF
--- a/apps/cli/src/__tests__/daemon-env.test.ts
+++ b/apps/cli/src/__tests__/daemon-env.test.ts
@@ -24,6 +24,15 @@ describe("parseDaemonEnv", () => {
   it("skips malformed lines rather than throwing", () => {
     expect(parseDaemonEnv("not-an-assignment\n=novalue\n9BAD=x\nGOOD=ok")).toEqual({ GOOD: "ok" });
   });
+
+  it("strips a trailing ` # comment` from an unquoted value but keeps it inside quotes", () => {
+    expect(parseDaemonEnv("HTTP_PROXY=http://127.0.0.1:7897 # office proxy")).toEqual({
+      HTTP_PROXY: "http://127.0.0.1:7897",
+    });
+    // A '#' that is part of the value (quoted, or not whitespace-preceded) stays.
+    expect(parseDaemonEnv('HTTPS_PROXY="http://u:p#a@host:1"')).toEqual({ HTTPS_PROXY: "http://u:p#a@host:1" });
+    expect(parseDaemonEnv("ALL_PROXY=socks5://h#ash")).toEqual({ ALL_PROXY: "socks5://h#ash" });
+  });
 });
 
 describe("loadDaemonEnv", () => {
@@ -59,5 +68,13 @@ describe("loadDaemonEnv", () => {
     const env: NodeJS.ProcessEnv = {};
     expect(loadDaemonEnv(join(dir, "nope.env"), env)).toEqual([]);
     expect(env).toEqual({});
+  });
+
+  it("skips an empty value rather than injecting an egress-disabling blank", () => {
+    writeFileSync(envPath, "HTTPS_PROXY=\nHTTP_PROXY=http://proxy:1\n");
+    const env: NodeJS.ProcessEnv = {};
+    expect(loadDaemonEnv(envPath, env)).toEqual(["HTTP_PROXY"]);
+    expect(env.HTTPS_PROXY).toBeUndefined();
+    expect(env.HTTP_PROXY).toBe("http://proxy:1");
   });
 });

--- a/apps/cli/src/core/daemon-env.ts
+++ b/apps/cli/src/core/daemon-env.ts
@@ -1,6 +1,5 @@
 import { existsSync, readFileSync } from "node:fs";
-import { join } from "node:path";
-import { defaultHome } from "@first-tree/shared/config";
+import { daemonEnvFile } from "@first-tree/shared/config";
 
 /**
  * Path of the user-owned environment file the daemon loads at start.
@@ -12,20 +11,24 @@ import { defaultHome } from "@first-tree/shared/config";
  * interactive `claude` / `git` work. This file is the user's explicit, opt-in
  * channel to supply that environment to the background daemon.
  *
- * First Tree only ever READS this file; it never writes a proxy here on the
- * user's behalf. The lone exception is the one-time upgrade migration in
- * `service-install.ts` that lifts a proxy a previous version had baked into the
- * service unit — after which the file is the user's to edit or delete.
+ * Resolves under the channel home (`daemonEnvFile`), so guidance and loading
+ * always agree on the same per-channel path. First Tree only ever READS this
+ * file; it never writes a proxy here on the user's behalf. The lone exception is
+ * the one-time upgrade migration in `service-install.ts` that lifts a proxy a
+ * previous version had baked into the service unit — after which the file is the
+ * user's to edit or delete.
  */
 export function daemonEnvPath(): string {
-  return join(defaultHome(), "daemon.env");
+  return daemonEnvFile();
 }
 
 /**
  * Parse simple `KEY=VALUE` env-file lines. Tolerates blank lines, `#` comments,
- * an optional leading `export `, and surrounding single / double quotes. Never
- * throws — a malformed line is skipped rather than aborting the load, so a
- * user's typo in this file can never crash the daemon at start.
+ * an optional leading `export `, and surrounding single / double quotes. An
+ * UNQUOTED value also has a trailing ` # comment` stripped (a `#` inside quotes,
+ * or not preceded by whitespace, is kept — proxy URLs and passwords may contain
+ * it). Never throws — a malformed line is skipped rather than aborting the load,
+ * so a user's typo in this file can never crash the daemon at start.
  */
 export function parseDaemonEnv(content: string): Record<string, string> {
   const out: Record<string, string> = {};
@@ -42,7 +45,12 @@ export function parseDaemonEnv(content: string): Record<string, string> {
       value.length >= 2 &&
       ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'")))
     ) {
+      // Quoted: take the literal interior, no comment stripping.
       value = value.slice(1, -1);
+    } else {
+      // Unquoted: a ` #...` tail is a trailing comment, not part of the value.
+      const hash = value.search(/\s#/);
+      if (hash >= 0) value = value.slice(0, hash).trimEnd();
     }
     out[key] = value;
   }
@@ -57,8 +65,11 @@ export function parseDaemonEnv(content: string): Record<string, string> {
  * Fill-don't-clobber: a key already present and non-empty in `process.env` (e.g.
  * pinned by the service unit, or inherited when the daemon runs in the
  * foreground) is left untouched — the file fills gaps, it does not override a
- * live environment. Returns the keys that were applied, for logging. A missing,
- * unreadable, or malformed file yields `[]` (a clean no-op); never throws.
+ * live environment. An empty value (`KEY=`) is skipped, not applied: injecting
+ * an empty proxy var silently disables egress, and a half-deleted entry should
+ * not read as "loaded". Returns the keys that were applied, for logging. A
+ * missing, unreadable, or malformed file yields `[]` (a clean no-op); never
+ * throws.
  */
 export function loadDaemonEnv(envPath: string = daemonEnvPath(), env: NodeJS.ProcessEnv = process.env): string[] {
   let content: string;
@@ -70,6 +81,7 @@ export function loadDaemonEnv(envPath: string = daemonEnvPath(), env: NodeJS.Pro
   }
   const applied: string[] = [];
   for (const [key, value] of Object.entries(parseDaemonEnv(content))) {
+    if (value === "") continue;
     const existing = env[key];
     if (existing !== undefined && existing !== "") continue;
     env[key] = value;

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -612,8 +612,11 @@ daemon and the agent runtimes it spawns. That is why an interactive `claude` /
 `git` can work while the daemon's calls to `api.anthropic.com` / `github.com`
 fail.
 
-To supply that environment, create `~/.first-tree/daemon.env` (under your
-channel's `FIRST_TREE_HOME`) with simple `KEY=VALUE` lines:
+To supply that environment, create `daemon.env` under your channel's
+`FIRST_TREE_HOME` with simple `KEY=VALUE` lines. **The path is channel-specific**
+(`~/.first-tree/daemon.env` on prod, `~/.first-tree-staging/daemon.env` on
+staging, `~/.first-tree-dev/daemon.env` on dev) — it must match the channel of
+the daemon that reads it:
 
 ```sh
 HTTPS_PROXY=http://127.0.0.1:7897

--- a/docs/troubleshooting/proxy.md
+++ b/docs/troubleshooting/proxy.md
@@ -29,10 +29,18 @@ because your terminal already has the proxy in its environment.
 
 ## Fix: tell the daemon your proxy (`daemon.env`)
 
-Create `~/.first-tree/daemon.env` (under your channel's `FIRST_TREE_HOME`) with
-`KEY=VALUE` lines, then restart the daemon:
+Create `daemon.env` under your channel's `FIRST_TREE_HOME`, with `KEY=VALUE`
+lines, then restart the daemon. **The path is channel-specific** — use the home
+that matches the binary you run:
+
+| Channel | Binary | `daemon.env` path |
+|---|---|---|
+| prod | `first-tree` | `~/.first-tree/daemon.env` |
+| staging | `first-tree-staging` | `~/.first-tree-staging/daemon.env` |
+| dev | `first-tree-dev` | `~/.first-tree-dev/daemon.env` |
 
 ```sh
+# Example for the prod channel — swap the home if you run staging/dev.
 cat > ~/.first-tree/daemon.env <<'EOF'
 HTTPS_PROXY=http://127.0.0.1:7897
 HTTP_PROXY=http://127.0.0.1:7897
@@ -41,6 +49,10 @@ EOF
 
 first-tree daemon stop && first-tree daemon start   # use your channel's binary
 ```
+
+`KEY=VALUE` only — one per line. A `# comment` is allowed on its own line or as
+a trailing ` # ...` on an unquoted value; quote the value (`KEY="..."`) to keep
+a literal `#`. An empty `KEY=` is ignored.
 
 This file is **yours**: First Tree reads it on daemon start and never rewrites
 it. Edit or delete it any time and restart to apply.

--- a/packages/client/src/__tests__/claude-code-provider-error-result.test.ts
+++ b/packages/client/src/__tests__/claude-code-provider-error-result.test.ts
@@ -367,6 +367,28 @@ describe("claude-code handler — structured provider error result", () => {
     expect(notice).not.toContain("rejected the local Claude authentication");
   });
 
+  it("does not leak a deferred auth hint when an auth_status warning is followed by success", async () => {
+    mockState.nextMessages = [
+      { type: "auth_status", error: "token will expire soon" },
+      {
+        type: "assistant",
+        message: { content: [{ type: "text", text: "done" }] },
+      },
+      { type: "result", subtype: "success", is_error: false, result: "all good" },
+    ];
+    const { emitted, forwardResult } = await runSingleResultTurn();
+
+    expect(forwardResult).toHaveBeenCalledWith("all good");
+    expect(
+      emitted.some(
+        (event) =>
+          event.kind === "error" &&
+          typeof event.payload.message === "string" &&
+          event.payload.message.includes("auth on this machine looks broken"),
+      ),
+    ).toBe(false);
+  });
+
   it("does not sniff ordinary success result text as a provider error", async () => {
     const resultText = "API Error: 401 Unauthorized is an example the user asked about.";
     mockState.nextMessages = [

--- a/packages/client/src/__tests__/claude-provider-error.test.ts
+++ b/packages/client/src/__tests__/claude-provider-error.test.ts
@@ -131,6 +131,22 @@ describe("claude provider error adapter", () => {
     expect(notice).toContain("Original provider message");
   });
 
+  it("does not treat a non-403 credential error as egress even if it mentions request not allowed", () => {
+    // The egress lead requires a 403/forbidden co-marker, so a 401 whose body
+    // happens to contain the phrase still gets the auth lead, not egress.
+    const notice = formatClaudeProviderFailureNotice(
+      {
+        category: "credential",
+        reasonCode: "provider_credential_required",
+        message: "auth",
+        sourceKind: "permanent",
+      },
+      "API Error: 401 invalid x-api-key — request not allowed for this key",
+    );
+    expect(notice).toContain("rejected the local Claude authentication");
+    expect(notice).not.toContain("before authentication");
+  });
+
   it("still surfaces the auth lead for a genuine credential failure", () => {
     const notice = formatClaudeProviderFailureNotice(
       {

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -1699,6 +1699,10 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
               // to do; repeating it adds noise without new information.
               if (message.subtype === "success") {
                 authHintEmitted = false;
+                // Drop any deferred auth signal too: a transient auth_status
+                // warning followed by a successful turn must not leak a stale
+                // auth-login hint at the next stream-end / turn boundary.
+                pendingAuthHint = null;
               }
             }
           }

--- a/packages/client/src/handlers/claude-provider-error.ts
+++ b/packages/client/src/handlers/claude-provider-error.ts
@@ -1,5 +1,6 @@
 import type { SDKAssistantMessageError } from "@anthropic-ai/claude-agent-sdk";
 import type { ProviderFailureCategory, ReplaySafety } from "@first-tree/shared";
+import { daemonEnvFile } from "@first-tree/shared/config";
 import type { ProviderAttemptSignal } from "../runtime/provider-attempt.js";
 import type { ProviderFailureClassification } from "../runtime/provider-retry-policy.js";
 import { redactErrorPreview } from "../runtime/redact-error-preview.js";
@@ -96,7 +97,7 @@ export function formatClaudeProviderFailureNotice(
   const detail = redactErrorPreview(messagePreview.trim(), 500);
   const suffix = detail.length > 0 ? ` Original provider message: ${detail}` : "";
   const lead = looksLikeEgressForbidden(classification, messagePreview)
-    ? EGRESS_FORBIDDEN_LEAD
+    ? egressForbiddenLead()
     : noticeLead(classification.category, classification.reasonCode);
   return `${lead}${suffix}`;
 }
@@ -119,18 +120,30 @@ function looksLikeEgressForbidden(classification: ProviderFailureClassification,
  * True when a provider message carries Anthropic's pre-auth edge-block signature
  * (`403 Request not allowed`). Shared with the Claude handler so the early auth
  * hint and the final failure notice make the same egress-vs-auth call.
+ *
+ * Requires both the `Request not allowed` phrase AND a `403` / `forbidden`
+ * co-marker so a genuine credential error (e.g. a 401 whose body happens to
+ * contain the phrase) is not mis-routed to the egress guidance and have its
+ * auth hint suppressed.
  */
 export function isEgressForbiddenText(text: string): boolean {
-  return /request not allowed/i.test(text);
+  return /request not allowed/i.test(text) && /\b403\b|forbidden/i.test(text);
 }
 
-const EGRESS_FORBIDDEN_LEAD =
-  'Claude Code could not run this turn: Anthropic returned 403 "Request not allowed". ' +
-  "This status comes back before authentication, so it is usually NOT a login problem — most often " +
-  "the background daemon cannot reach Anthropic (e.g. it is not going through your network proxy). " +
-  "Check, in order: (1) if you use a proxy, give the daemon its proxy env via ~/.first-tree/daemon.env " +
-  "and restart it; (2) your Anthropic plan / region entitlement; (3) only if those are fine, " +
-  "re-authenticate with `claude auth login`.";
+function egressForbiddenLead(): string {
+  // Channel-correct path: dogfood / staging daemons live under
+  // ~/.first-tree-staging (dev under ~/.first-tree-dev), so a hardcoded
+  // ~/.first-tree would send those users to a file the daemon never reads —
+  // re-introducing the very misdiagnosis this lead exists to prevent.
+  return (
+    'Claude Code could not run this turn: Anthropic returned 403 "Request not allowed". ' +
+    "This status comes back before authentication, so it is usually NOT a login problem — most often " +
+    "the background daemon cannot reach Anthropic (e.g. it is not going through your network proxy). " +
+    `Check, in order: (1) if you use a proxy, give the daemon its proxy env via ${daemonEnvFile()} ` +
+    "and restart it; (2) your Anthropic plan / region entitlement; (3) only if those are fine, " +
+    "re-authenticate with `claude auth login`."
+  );
+}
 
 function readResultMessage(message: unknown): {
   subtype: string;

--- a/packages/shared/src/config/index.ts
+++ b/packages/shared/src/config/index.ts
@@ -18,6 +18,7 @@ export type { ConfigMeta } from "./resolver.js";
 export {
   buildZodSchema,
   collectMissingPrompts,
+  daemonEnvFile,
   defaultConfigDir,
   defaultDataDir,
   defaultHome,

--- a/packages/shared/src/config/resolver.ts
+++ b/packages/shared/src/config/resolver.ts
@@ -62,6 +62,15 @@ export function defaultDataDir(): string {
   return join(defaultHome(), "data");
 }
 
+// The user-owned env file the daemon loads at start (proxy etc.). Channel-aware
+// via `defaultHome()`, so it resolves to `~/.first-tree-staging/daemon.env` on
+// staging and `~/.first-tree-dev/daemon.env` on dev — NOT a hardcoded
+// `~/.first-tree`. Single source of truth shared by the CLI loader and the
+// in-product egress hint so user-facing guidance always names the real path.
+export function daemonEnvFile(): string {
+  return join(defaultHome(), "daemon.env");
+}
+
 // ── Type guards ──────────────────────────────────────────────────────
 
 function isFieldDef(value: unknown): value is FieldDef {


### PR DESCRIPTION
## Why

Follow-up to #1335 (merged as `01e9929`). The black-box QA pass landed **after**
#1335 was squash-merged, so the QA fixes never made it onto `main` — `main`
currently has the proxy-compat feature **with the F1 blocker still in it**. This
PR carries the QA fixes forward.

## What (from the QA report on #1335)

- **F1 (blocker)** — user-facing guidance hardcoded `~/.first-tree`, but the
  loader resolves the channel home. On staging/dev (the dogfood channels) a user
  following the in-chat hint / docs writes to a file the daemon never reads, so
  the 403 persists — the signature fix defeats itself off-prod. Adds a single
  source of truth `daemonEnvFile()` in `@first-tree/shared/config` (channel-aware);
  the in-product egress hint now prints the resolved path, and the CLI loader +
  docs use it. Docs spell out the per-channel path.
- **F2** — strip a trailing ` # comment` on an unquoted value (a `#` inside
  quotes / not whitespace-preceded is kept for URLs & passwords).
- **F3** — skip an empty `KEY=` instead of injecting an egress-disabling blank
  and reporting it as loaded.
- **F4** — require a `403`/`forbidden` co-marker alongside `request not allowed`
  so a non-403 credential error mentioning the phrase isn't mis-routed to egress.
- **Leak** — the success branch reset `authHintEmitted` but not `pendingAuthHint`,
  so a transient `auth_status` warning before a successful turn could leak a stale
  auth-login hint. Clear it on success.

## Tests
daemon-env (inline-comment strip, empty-skip), claude-provider-error (non-403
phrase stays auth), handler regression (auth_status warning + success leaks no
hint). cli + client affected suites green; shared rebuilt; typecheck + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
