### PR TITLE
fix: clear stale terminal provider statusReason once agent is working

### DIFF
--- a/packages/server/src/__tests__/agent-chat-status.test.ts
+++ b/packages/server/src/__tests__/agent-chat-status.test.ts
@@ -292,6 +292,40 @@ describe("agent-chat-status", () => {
       expect(s?.statusReason).toBeUndefined();
     });
 
+    it("keeps a session-scoped terminal statusReason even while the agent is working", async () => {
+      // The working-gate is scoped strictly to `provider_turn`. A
+      // `session_resume` / `session_start` terminal reason is session-scoped, not
+      // turn-scoped, so a turn-level "working" signal must NOT hide it — otherwise
+      // it would flicker (hidden while working, reappearing when idle). It keeps
+      // its own lifecycle.
+      const { app, peer, chatId } = await newChatWithAgent();
+      await bindPresence(peer.agent.uuid, peer.clientId);
+      await setSession(peer.agent.uuid, chatId, "active");
+      await setRuntime(peer.agent.uuid, chatId, "working");
+      await insertEvent(peer.agent.uuid, chatId, 1, "error", {
+        message: encodeProviderRetryEventMessage({
+          event: "provider_failure_terminal",
+          provider: "claude-code",
+          scope: "session_resume",
+          category: "credential",
+          reasonCode: "session_resume_failed",
+          replaySafety: "unsafe",
+          userSeverity: "error",
+        }),
+      });
+      await insertEvent(peer.agent.uuid, chatId, 2, "tool_call", {
+        toolUseId: "t1",
+        name: "Bash",
+        args: null,
+        status: "pending",
+      });
+
+      const s = (await getChatAgentStatuses(app.db, chatId)).find((x) => x.agentId === peer.agent.uuid);
+      expect(s?.main).toBe("working");
+      expect(s?.statusReason?.kind).toBe("terminal");
+      expect(s?.statusReason?.scope).toBe("session_resume");
+    });
+
     it("keeps a terminal statusReason while the agent is NOT working (last turn failed)", async () => {
       // Idle after a terminal exhaustion with no new turn yet: the reason still
       // describes the genuine last outcome and should remain visible until a new

--- a/packages/server/src/__tests__/agent-chat-status.test.ts
+++ b/packages/server/src/__tests__/agent-chat-status.test.ts
@@ -254,6 +254,106 @@ describe("agent-chat-status", () => {
       expect(s?.statusReason).toBeUndefined();
     });
 
+    it("drops a stale terminal statusReason once the agent is working a new turn", async () => {
+      // Repro: a turn exhausted its provider retries (terminal), then the user
+      // re-sent and a NEW turn is in flight (runtime working) but has not yet
+      // emitted a `turn_end`. The exhausted reason is from the prior, superseded
+      // turn — it must not keep rendering as a red "Provider retry exhausted"
+      // over a visibly-working agent. (Without the working-gate the compose bar
+      // shows the terminal reason for the whole new turn — the reported bug.)
+      const { app, peer, chatId } = await newChatWithAgent();
+      await bindPresence(peer.agent.uuid, peer.clientId);
+      await setSession(peer.agent.uuid, chatId, "active");
+      await setRuntime(peer.agent.uuid, chatId, "working");
+      await insertEvent(peer.agent.uuid, chatId, 1, "error", {
+        message: encodeProviderRetryEventMessage({
+          event: "provider_retry_exhausted",
+          provider: "claude-code",
+          scope: "provider_turn",
+          category: "configuration",
+          reasonCode: "claude_native_binary_missing",
+          attempt: 2,
+          maxAttempts: 2,
+          retryMode: "foreground",
+          replaySafety: "pre_provider",
+          userSeverity: "error",
+        }),
+      });
+      // The new turn's first activity event — higher seq than the exhaustion.
+      await insertEvent(peer.agent.uuid, chatId, 2, "tool_call", {
+        toolUseId: "t1",
+        name: "Bash",
+        args: null,
+        status: "pending",
+      });
+
+      const s = (await getChatAgentStatuses(app.db, chatId)).find((x) => x.agentId === peer.agent.uuid);
+      expect(s?.main).toBe("working");
+      expect(s?.statusReason).toBeUndefined();
+    });
+
+    it("keeps a terminal statusReason while the agent is NOT working (last turn failed)", async () => {
+      // Idle after a terminal exhaustion with no new turn yet: the reason still
+      // describes the genuine last outcome and should remain visible until a new
+      // turn supersedes it. Guards against the working-gate over-clearing.
+      const { app, peer, chatId } = await newChatWithAgent();
+      await bindPresence(peer.agent.uuid, peer.clientId);
+      await setSession(peer.agent.uuid, chatId, "active");
+      await insertEvent(peer.agent.uuid, chatId, 1, "error", {
+        message: encodeProviderRetryEventMessage({
+          event: "provider_retry_exhausted",
+          provider: "claude-code",
+          scope: "provider_turn",
+          category: "configuration",
+          reasonCode: "claude_native_binary_missing",
+          attempt: 2,
+          maxAttempts: 2,
+          retryMode: "foreground",
+          replaySafety: "pre_provider",
+          userSeverity: "error",
+        }),
+      });
+
+      const s = (await getChatAgentStatuses(app.db, chatId)).find((x) => x.agentId === peer.agent.uuid);
+      expect(s?.main).toBe("ready");
+      expect(s?.statusReason?.kind).toBe("terminal");
+      expect(s?.statusReason?.label).toBe("Provider retry exhausted");
+    });
+
+    it("keeps a retrying statusReason while the agent is working (in-turn foreground retry)", async () => {
+      // A foreground retry mid-turn is the legitimate working+reason combo — the
+      // working-gate only drops `terminal`, never `retrying` / `waiting`.
+      const { app, peer, chatId } = await newChatWithAgent();
+      await bindPresence(peer.agent.uuid, peer.clientId);
+      await setSession(peer.agent.uuid, chatId, "active");
+      await setRuntime(peer.agent.uuid, chatId, "working");
+      await insertEvent(peer.agent.uuid, chatId, 1, "tool_call", {
+        toolUseId: "t1",
+        name: "Bash",
+        args: null,
+        status: "pending",
+      });
+      await insertEvent(peer.agent.uuid, chatId, 2, "error", {
+        message: encodeProviderRetryEventMessage({
+          event: "provider_retry_scheduled",
+          provider: "claude-code",
+          scope: "provider_turn",
+          category: "transient_transport",
+          reasonCode: "provider_transient_transport",
+          attempt: 1,
+          maxAttempts: 2,
+          retryMode: "foreground",
+          delayMs: 500,
+          replaySafety: "pre_visible",
+          userSeverity: "info",
+        }),
+      });
+
+      const s = (await getChatAgentStatuses(app.db, chatId)).find((x) => x.agentId === peer.agent.uuid);
+      expect(s?.main).toBe("working");
+      expect(s?.statusReason?.kind).toBe("retrying");
+    });
+
     it("clears provider-turn retry statusReason when a later turn_end succeeds", async () => {
       const { app, peer, chatId } = await newChatWithAgent();
       await bindPresence(peer.agent.uuid, peer.clientId);

--- a/packages/server/src/services/agent-chat-status.ts
+++ b/packages/server/src/services/agent-chat-status.ts
@@ -442,6 +442,20 @@ export async function resolveAgentChatStatuses(
       const activity = perAgentActivity?.get(agentId) ?? null;
       const engagement: AgentEngagement = state === "active" ? "active" : state === "suspended" ? "suspended" : "none";
       const working = computeWorking(sess, activity, now);
+      // A `terminal` reason (provider_retry_exhausted / provider_failure_terminal)
+      // records that a *past* turn's provider attempts gave up. Once the agent is
+      // `working` again it is on a NEW turn, so that terminal reason is stale and
+      // must be dropped — otherwise the compose status bar (where the reason view
+      // overrides the main view) keeps rendering a red "Provider retry exhausted"
+      // over an agent that has visibly recovered. `deriveStatusReasons` only
+      // clears a provider_turn terminal reason at the next *successful* `turn_end`,
+      // which has not landed while the new turn is still in flight; this is the
+      // mid-turn gap. `retrying` / `waiting` reasons legitimately co-occur with
+      // working (an in-turn foreground retry) and are kept. Failed agents
+      // (errored ⇒ main "failed", working=false) also keep the reason — that is
+      // the correct co-display on the failure row.
+      const reason = perAgentStatusReason?.get(agentId);
+      const statusReason = working && reason?.kind === "terminal" ? undefined : reason;
       arr.push(
         buildAgentChatStatus({
           agentId,
@@ -462,7 +476,7 @@ export async function resolveAgentChatStatuses(
           // aren't in chainSessionOp) briefly emits activity=null; the next
           // runtime frame self-heals.
           activity: working ? activity : null,
-          statusReason: perAgentStatusReason?.get(agentId),
+          statusReason,
         }),
       );
     }

--- a/packages/server/src/services/agent-chat-status.ts
+++ b/packages/server/src/services/agent-chat-status.ts
@@ -442,20 +442,27 @@ export async function resolveAgentChatStatuses(
       const activity = perAgentActivity?.get(agentId) ?? null;
       const engagement: AgentEngagement = state === "active" ? "active" : state === "suspended" ? "suspended" : "none";
       const working = computeWorking(sess, activity, now);
-      // A `terminal` reason (provider_retry_exhausted / provider_failure_terminal)
-      // records that a *past* turn's provider attempts gave up. Once the agent is
-      // `working` again it is on a NEW turn, so that terminal reason is stale and
-      // must be dropped — otherwise the compose status bar (where the reason view
-      // overrides the main view) keeps rendering a red "Provider retry exhausted"
-      // over an agent that has visibly recovered. `deriveStatusReasons` only
-      // clears a provider_turn terminal reason at the next *successful* `turn_end`,
-      // which has not landed while the new turn is still in flight; this is the
-      // mid-turn gap. `retrying` / `waiting` reasons legitimately co-occur with
+      // A `provider_turn`-scoped `terminal` reason (provider_retry_exhausted /
+      // provider_failure_terminal) records that a *past* turn's provider attempts
+      // gave up. Once the agent is `working` again it is on a NEW turn, so that
+      // reason is stale and must be dropped — otherwise the compose status bar
+      // (where the reason view overrides the main view) keeps rendering a red
+      // "Provider retry exhausted" over an agent that has visibly recovered.
+      // `deriveStatusReasons` only clears a provider_turn terminal reason at the
+      // next *successful* `turn_end`, which has not landed while the new turn is
+      // still in flight; this closes that mid-turn gap.
+      //
+      // Scoped strictly to `provider_turn`: a `session_start` / `session_resume`
+      // terminal reason is session-scoped, not turn-scoped, so a turn-level
+      // "working" signal must NOT hide it (doing so would make it flicker —
+      // hidden while working, reappearing when idle). Those keep their own
+      // lifecycle. `retrying` / `waiting` reasons legitimately co-occur with
       // working (an in-turn foreground retry) and are kept. Failed agents
       // (errored ⇒ main "failed", working=false) also keep the reason — that is
       // the correct co-display on the failure row.
       const reason = perAgentStatusReason?.get(agentId);
-      const statusReason = working && reason?.kind === "terminal" ? undefined : reason;
+      const isStaleTurnTerminal = reason?.kind === "terminal" && reason.scope === "provider_turn";
+      const statusReason = working && isStaleTurnTerminal ? undefined : reason;
       arr.push(
         buildAgentChatStatus({
           agentId,


### PR DESCRIPTION
## Problem

The compose status bar (bottom of a chat) kept showing a red `Provider retry exhausted` over an agent that had **already recovered** and was visibly working a new turn (`working · 21s`).

## Root cause

Two seams compound:

1. **`compose-status-bar.tsx` → `RailRow`**: the `statusReason` view **overrides** the `main` view, so as long as an agent carries a `statusReason`, the rail renders the red dot + reason label even when `main === "working"`.
2. **`server/services/agent-chat-status.ts` → `deriveStatusReasons`**: a `provider_retry_exhausted` (terminal) reason is cleared only by ① a later `provider_retry_succeeded`, or ② `scope === "provider_turn"` + a later **successful** `turn_end`.

An exhausted turn has *given up retrying*, so it never emits `provider_retry_succeeded`. The user re-sent and a new turn started (`working`) but had **not yet** emitted a `turn_end` — so the prior turn's terminal reason lingered for the entire new turn. (It self-clears once that new turn ends successfully via path ②; this PR closes the mid-turn gap.)

## Fix

In `resolveAgentChatStatuses`, drop a `terminal`-kind `statusReason` whenever the agent is `working` — a terminal reason describes a *superseded* turn. `retrying` / `waiting` reasons legitimately co-occur with working (in-turn foreground retry) and are kept; failed agents (`errored ⇒ main "failed"`, not working) keep the reason as the correct failure-row co-display.

```ts
const reason = perAgentStatusReason?.get(agentId);
const statusReason = working && reason?.kind === "terminal" ? undefined : reason;
```

## Tests

Adds 3 unit tests to `agent-chat-status.test.ts`:
- drops a stale terminal reason once the agent is working a new turn (the repro);
- keeps a terminal reason while NOT working (last turn genuinely failed);
- keeps a `retrying` reason while working (in-turn foreground retry).

## Verification

- `pnpm --filter @first-tree/server typecheck` ✅
- `@first-tree/server` full suite — **1599 passed** ✅
- `biome check` on changed files ✅

Server-only change; no schema/migration/web changes.
