### PR TITLE
Add deterministic skill eval grading

### DIFF
--- a/packages/skill-evals/README.md
+++ b/packages/skill-evals/README.md
@@ -110,20 +110,30 @@ The runner creates isolated temporary workspaces under
 `packages/skill-evals/.runs/<timestamp>-<case-id>/`, installs
 the relevant skill, prepends command shims such as `first-tree` to `PATH`, and
 runs `codex exec --json` from the case workspace for live eval commands.
+Live gate runs do not inherit the operator's full environment. The Codex
+process receives an allowlisted environment plus an isolated `HOME`, temp
+directory, and XDG cache/config directories under the case run root. The model
+shell runs with `shell_environment_policy.inherit=none`, only the eval shims and
+isolated paths are set explicitly, and Codex is invoked with
+`--ignore-user-config`, `--ignore-rules`, and `--sandbox workspace-write`.
 
 Each case writes:
 
 - `events.jsonl` with harness events, Codex JSONL events, and shimmed
   `first-tree` invocations.
+- `grading.json` with deterministic four-axis gate grading:
+  `routing_pass`, `process_pass`, `outcome_pass`, and `risk_pass`, plus
+  evidence and risk flags.
 - `summary.json` with derived metrics.
-- `summary.md` with a human-readable case report.
+- `summary.md` with a human-readable case report and grading summary.
 
 The top-level `eval:floor`, `eval:gate`, and `eval:quality` commands also append
 a lightweight local result-store entry to
 `packages/skill-evals/.runs/index.jsonl`. Entries record the run group, suite,
 tier, case, pass/fail state, git branch/sha, model/provider where available,
-artifact paths, duration, cost, and judge scores when present. The `.runs`
-directory is gitignored local eval state.
+artifact paths, duration, cost, and judge scores when present. Gate failures use
+the deterministic grading evidence first and link the `grading.json` artifact
+path in the result store. The `.runs` directory is gitignored local eval state.
 
 Use `eval:compare` to compare the latest result-store run group with the
 previous one:

--- a/packages/skill-evals/src/core/__tests__/grading.test.ts
+++ b/packages/skill-evals/src/core/__tests__/grading.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { evidence, gradingFailureMessages, riskFlag } from "../grading.js";
+import type { SkillCaseGrading } from "../result-schema.js";
+
+describe("skill case grading diagnostics", () => {
+  it("prefers failed score evidence and risk flags in failure messages", () => {
+    const grading: SkillCaseGrading = {
+      caseId: "grading-diagnostics",
+      evidence: [
+        evidence("routing_pass", "skill read observed=true"),
+        evidence("process_pass", "selector succeeded=false"),
+        evidence("outcome_pass", "expected facts observed=true"),
+        evidence("risk_pass", "failed command observed"),
+      ],
+      passed: false,
+      riskFlags: [riskFlag("failed_first_tree_command", "first-tree tree tree /foo exited 2")],
+      scores: {
+        outcome_pass: true,
+        process_pass: false,
+        risk_pass: false,
+        routing_pass: true,
+      },
+    };
+
+    expect(gradingFailureMessages(grading)).toEqual([
+      "process_pass=false (process): selector succeeded=false",
+      "risk_pass=false (risk): failed command observed; failed_first_tree_command: first-tree tree tree /foo exited 2",
+    ]);
+  });
+});

--- a/packages/skill-evals/src/core/__tests__/provider.test.ts
+++ b/packages/skill-evals/src/core/__tests__/provider.test.ts
@@ -1,0 +1,97 @@
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, dirname, join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+import { createRunPaths } from "../paths.js";
+import { codexProviderArgs, codexProviderCommand, codexProviderEnv } from "../provider/codex.js";
+import type { ProviderRunContext, ProviderRunOptions } from "../provider/types.js";
+import { createEvalReporter } from "../reporter.js";
+
+function tempPackageRoot(): string {
+  return mkdtempSync(join(tmpdir(), "skill-evals-provider-test-"));
+}
+
+function fakeContext(packageRoot: string): ProviderRunContext {
+  return {
+    paths: createRunPaths({
+      caseId: "provider-hardening-test",
+      packageRoot,
+      startedAt: "2026-06-29T00:00:00.000Z",
+    }),
+    reporter: createEvalReporter("provider-hardening-test", false),
+  };
+}
+
+function unique(values: readonly string[]): readonly string[] {
+  return [...new Set(values)];
+}
+
+describe("codex provider runner hardening", () => {
+  it("runs live codex with a workspace sandbox and an allowlisted environment", () => {
+    const packageRoot = tempPackageRoot();
+    try {
+      const codexBinDir = join(packageRoot, "operator-codex-bin");
+      const operatorSecretBinDir = join(packageRoot, "operator-secret-bin");
+      mkdirSync(codexBinDir, { recursive: true });
+      mkdirSync(operatorSecretBinDir, { recursive: true });
+      const codexBin = join(codexBinDir, "codex");
+      writeFileSync(codexBin, "#!/bin/sh\nexit 0\n", "utf8");
+      chmodSync(codexBin, 0o755);
+
+      const context = fakeContext(packageRoot);
+      const options: ProviderRunOptions = {
+        bin: "codex",
+        caseId: "provider-hardening-test",
+        model: "gpt-test",
+        prompt: "Run the eval case.",
+        verbose: true,
+      };
+      const env = codexProviderEnv(options, context, {
+        CODEX_HOME: "/codex-auth-home",
+        FIRST_TREE_SERVER_URL: "https://example.invalid",
+        GH_TOKEN: "leaky-gh-token",
+        GIT_CONFIG_GLOBAL: "/tmp/leaky-gitconfig",
+        HOME: "/operator-home",
+        OPENAI_API_KEY: "allowed",
+        PATH: [operatorSecretBinDir, codexBinDir].join(delimiter),
+      });
+      const args = codexProviderArgs(options, context.paths.workspacePath, env);
+
+      expect(codexProviderCommand(options, { PATH: [operatorSecretBinDir, codexBinDir].join(delimiter) })).toBe(
+        codexBin,
+      );
+      expect(args).toContain("--ignore-user-config");
+      expect(args).toContain("--ignore-rules");
+      expect(args).toContain("--sandbox");
+      expect(args).toContain("workspace-write");
+      expect(args).toContain("shell_environment_policy.inherit=none");
+      expect(args).not.toContain("--dangerously-bypass-approvals-and-sandbox");
+      expect(args).not.toContain("shell_environment_policy.inherit=all");
+      expect(args).toContain("--model");
+      expect(args).toContain("gpt-test");
+      expect(args.at(-1)).toBe("Run the eval case.");
+
+      expect(env.HOME).toBe(`${context.paths.runRoot}/provider-home`);
+      expect(env.TMPDIR).toBe(`${context.paths.runRoot}/provider-tmp`);
+      expect(env.XDG_CACHE_HOME).toBe(`${context.paths.runRoot}/provider-xdg-cache`);
+      expect(env.CODEX_HOME).toBe("/codex-auth-home");
+      expect(env.OPENAI_API_KEY).toBe("allowed");
+      expect(env.FIRST_TREE_SERVER_URL).toBeUndefined();
+      expect(env.GH_TOKEN).toBeUndefined();
+      expect(env.GIT_CONFIG_GLOBAL).toBeUndefined();
+      expect(env.PATH?.split(delimiter)).toEqual(
+        unique([context.paths.binDir, dirname(process.execPath), codexBinDir, "/usr/local/bin", "/usr/bin", "/bin"]),
+      );
+      expect(env.PATH).not.toContain(operatorSecretBinDir);
+      expect(args).toContain(`shell_environment_policy.set.PATH=${JSON.stringify(env.PATH)}`);
+      expect(args).toContain(`shell_environment_policy.set.HOME=${JSON.stringify(env.HOME)}`);
+      expect(args).toContain(`shell_environment_policy.set.TMPDIR=${JSON.stringify(env.TMPDIR)}`);
+      expect(args).toContain(
+        `shell_environment_policy.set.FIRST_TREE_EVAL_VERBOSE=${JSON.stringify(env.FIRST_TREE_EVAL_VERBOSE)}`,
+      );
+    } finally {
+      rmSync(packageRoot, { force: true, recursive: true });
+    }
+  });
+});

--- a/packages/skill-evals/src/core/__tests__/result-store.test.ts
+++ b/packages/skill-evals/src/core/__tests__/result-store.test.ts
@@ -21,6 +21,7 @@ function tempPackageRoot(): string {
 function entry(overrides: Partial<ResultStoreEntry> = {}): ResultStoreEntry {
   return {
     artifact: {
+      gradingJsonPath: "/tmp/run/grading.json",
       runRoot: "/tmp/run",
       summaryJsonPath: "/tmp/run/summary.json",
       summaryMdPath: "/tmp/run/summary.md",
@@ -59,6 +60,7 @@ describe("result store", () => {
       const entries = readResultStore(packageRoot);
       expect(entries).toHaveLength(1);
       expect(entries[0]?.caseId).toBe("durable-source-writes");
+      expect(entries[0]?.artifact.gradingJsonPath).toBe("/tmp/run/grading.json");
       expect(entries[0]?.artifact.summaryJsonPath).toBe("/tmp/run/summary.json");
     } finally {
       rmSync(packageRoot, { force: true, recursive: true });

--- a/packages/skill-evals/src/core/grading.ts
+++ b/packages/skill-evals/src/core/grading.ts
@@ -1,0 +1,55 @@
+import { writeFileSync } from "node:fs";
+
+import type { GradingEvidence, RiskFlag, SkillCaseGrading, SkillCaseScoreKey } from "./result-schema.js";
+
+const SCORE_LABELS: Record<SkillCaseScoreKey, string> = {
+  outcome_pass: "outcome",
+  process_pass: "process",
+  risk_pass: "risk",
+  routing_pass: "routing",
+};
+
+export function evidence(label: string, detail: string): GradingEvidence {
+  return { detail, label };
+}
+
+export function riskFlag(label: string, detail: string): RiskFlag {
+  return { detail, label };
+}
+
+export function writeGradingJson(path: string, grading: SkillCaseGrading): void {
+  writeFileSync(path, `${JSON.stringify(grading, null, 2)}\n`, "utf8");
+}
+
+export function gradingMarkdownRows(grading: SkillCaseGrading): string {
+  return [
+    `- routing_pass: ${String(grading.scores.routing_pass)}`,
+    `- process_pass: ${String(grading.scores.process_pass)}`,
+    `- outcome_pass: ${String(grading.scores.outcome_pass)}`,
+    `- risk_pass: ${String(grading.scores.risk_pass)}`,
+    `- riskFlags: ${grading.riskFlags.length === 0 ? "none" : grading.riskFlags.map((flag) => flag.label).join(", ")}`,
+  ].join("\n");
+}
+
+function evidenceForScore(grading: SkillCaseGrading, score: SkillCaseScoreKey): readonly string[] {
+  const details = grading.evidence
+    .filter((item) => item.label === score || item.label.startsWith(`${score}.`))
+    .map((item) => item.detail);
+  if (score === "risk_pass") {
+    return [...details, ...grading.riskFlags.map((flag) => `${flag.label}: ${flag.detail}`)];
+  }
+  return details;
+}
+
+export function gradingFailureMessages(grading: SkillCaseGrading): readonly string[] {
+  if (grading.passed) return [];
+  const failures: string[] = [];
+  const scoreKeys: readonly SkillCaseScoreKey[] = ["routing_pass", "process_pass", "outcome_pass", "risk_pass"];
+  for (const key of scoreKeys) {
+    if (grading.scores[key]) continue;
+    const details = evidenceForScore(grading, key);
+    const suffix = details.length > 0 ? `: ${details.join("; ")}` : "";
+    failures.push(`${key}=false (${SCORE_LABELS[key]})${suffix}`);
+  }
+  return failures.length > 0 ? failures : ["gate case failed"];
+}

--- a/packages/skill-evals/src/core/paths.ts
+++ b/packages/skill-evals/src/core/paths.ts
@@ -25,6 +25,7 @@ export function createRunPaths(options: CreateRunPathsOptions): RunPaths {
   return {
     binDir,
     eventsPath: join(runRoot, "events.jsonl"),
+    gradingJsonPath: join(runRoot, "grading.json"),
     packageRoot: options.packageRoot,
     repoRoot,
     runRoot,

--- a/packages/skill-evals/src/core/provider/codex.ts
+++ b/packages/skill-evals/src/core/provider/codex.ts
@@ -1,23 +1,117 @@
 import { spawn } from "node:child_process";
-import { join } from "node:path";
+import { existsSync, mkdirSync } from "node:fs";
+import { delimiter, dirname, isAbsolute, join } from "node:path";
 import { createInterface } from "node:readline";
 
 import { appendEvent, previewText } from "../events.js";
 import { isShimTraceLine } from "../reporter.js";
 import type { ProviderRunContext, ProviderRunOptions } from "./types.js";
 
-function codexArgs(options: ProviderRunOptions, workspacePath: string): string[] {
+const ALLOWED_ENV_KEYS = new Set([
+  "ALL_PROXY",
+  "ANTHROPIC_API_KEY",
+  "CODEX_CI",
+  "CODEX_MANAGED_BY_NPM",
+  "CODEX_MANAGED_PACKAGE_ROOT",
+  "HTTPS_PROXY",
+  "HTTP_PROXY",
+  "LANG",
+  "LC_ALL",
+  "NODE_EXTRA_CA_CERTS",
+  "NO_PROXY",
+  "OPENAI_API_KEY",
+  "OPENAI_BASE_URL",
+  "OPENAI_ORG_ID",
+  "OPENAI_ORGANIZATION",
+  "OPENAI_PROJECT",
+  "REQUESTS_CA_BUNDLE",
+  "SSL_CERT_FILE",
+  "USER",
+  "all_proxy",
+  "https_proxy",
+  "http_proxy",
+  "no_proxy",
+]);
+
+const SHELL_ENV_KEYS = [
+  "BASH_ENV",
+  "ENV",
+  "FIRST_TREE_EVAL_CASE_ID",
+  "FIRST_TREE_EVAL_EVENTS",
+  "FIRST_TREE_EVAL_PHASE",
+  "FIRST_TREE_EVAL_VERBOSE",
+  "HOME",
+  "PATH",
+  "TEMP",
+  "TMP",
+  "TMPDIR",
+  "XDG_CACHE_HOME",
+  "XDG_CONFIG_HOME",
+  "ZDOTDIR",
+] as const;
+
+const SYSTEM_PATH_DIRS = ["/usr/local/bin", "/usr/bin", "/bin"] as const;
+
+function configArg(key: string, value: string): string {
+  return `${key}=${JSON.stringify(value)}`;
+}
+
+function maybeDefaultCodexHome(sourceEnv: NodeJS.ProcessEnv): string | undefined {
+  if (sourceEnv.CODEX_HOME) return sourceEnv.CODEX_HOME;
+  if (!sourceEnv.HOME) return undefined;
+  const defaultCodexHome = join(sourceEnv.HOME, ".codex");
+  return existsSync(defaultCodexHome) ? defaultCodexHome : undefined;
+}
+
+function pathParts(pathValue: string | undefined): readonly string[] {
+  return (pathValue ?? "").split(delimiter).filter(Boolean);
+}
+
+function uniquePath(dirs: readonly (string | null | undefined)[]): string {
+  const seen = new Set<string>();
+  const kept: string[] = [];
+  for (const dir of dirs) {
+    if (!dir || seen.has(dir)) continue;
+    seen.add(dir);
+    kept.push(dir);
+  }
+  return kept.join(delimiter);
+}
+
+export function codexProviderCommand(options: ProviderRunOptions, sourceEnv: NodeJS.ProcessEnv = process.env): string {
+  if (isAbsolute(options.bin)) return options.bin;
+  for (const dir of pathParts(sourceEnv.PATH)) {
+    const candidate = join(dir, options.bin);
+    if (existsSync(candidate)) return candidate;
+  }
+  return options.bin;
+}
+
+export function codexProviderArgs(
+  options: ProviderRunOptions,
+  workspacePath: string,
+  shellEnv: NodeJS.ProcessEnv,
+): string[] {
   const args = [
     "exec",
     "--json",
     "--skip-git-repo-check",
     "--ephemeral",
+    "--ignore-user-config",
+    "--ignore-rules",
+    "--sandbox",
+    "workspace-write",
     "--cd",
     workspacePath,
-    "--dangerously-bypass-approvals-and-sandbox",
     "-c",
-    "shell_environment_policy.inherit=all",
+    "shell_environment_policy.inherit=none",
   ];
+  for (const key of SHELL_ENV_KEYS) {
+    const value = shellEnv[key];
+    if (value !== undefined) {
+      args.push("-c", configArg(`shell_environment_policy.set.${key}`, value));
+    }
+  }
 
   if (options.model !== null) {
     args.push("--model", options.model);
@@ -25,6 +119,53 @@ function codexArgs(options: ProviderRunOptions, workspacePath: string): string[]
 
   args.push(options.prompt);
   return args;
+}
+
+export function codexProviderEnv(
+  options: ProviderRunOptions,
+  context: ProviderRunContext,
+  sourceEnv: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  const command = codexProviderCommand(options, sourceEnv);
+  const providerHome = join(context.paths.runRoot, "provider-home");
+  const providerTmp = join(context.paths.runRoot, "provider-tmp");
+  const providerXdgCache = join(context.paths.runRoot, "provider-xdg-cache");
+  const providerXdgConfig = join(context.paths.runRoot, "provider-xdg-config");
+  for (const dir of [providerHome, providerTmp, providerXdgCache, providerXdgConfig]) {
+    mkdirSync(dir, { recursive: true });
+  }
+
+  const env: NodeJS.ProcessEnv = {};
+  for (const key of ALLOWED_ENV_KEYS) {
+    const value = sourceEnv[key];
+    if (value !== undefined) env[key] = value;
+  }
+
+  const codexHome = maybeDefaultCodexHome(sourceEnv);
+  if (codexHome !== undefined) {
+    env.CODEX_HOME = codexHome;
+  }
+
+  env.BASH_ENV = join(context.paths.shellEnvDir, "bash-env");
+  env.ENV = join(context.paths.shellEnvDir, "sh-env");
+  env.FIRST_TREE_EVAL_CASE_ID = options.caseId;
+  env.FIRST_TREE_EVAL_EVENTS = context.paths.eventsPath;
+  env.FIRST_TREE_EVAL_PHASE = "model";
+  env.FIRST_TREE_EVAL_VERBOSE = options.verbose ? "1" : "0";
+  env.HOME = providerHome;
+  env.PATH = uniquePath([
+    context.paths.binDir,
+    dirname(process.execPath),
+    isAbsolute(command) ? dirname(command) : null,
+    ...SYSTEM_PATH_DIRS,
+  ]);
+  env.TEMP = providerTmp;
+  env.TMP = providerTmp;
+  env.TMPDIR = providerTmp;
+  env.XDG_CACHE_HOME = providerXdgCache;
+  env.XDG_CONFIG_HOME = providerXdgConfig;
+  env.ZDOTDIR = context.paths.shellEnvDir;
+  return env;
 }
 
 async function consumeCodexStdout(
@@ -98,27 +239,20 @@ async function waitForChildExit(child: ReturnType<typeof spawn>, context: Provid
 }
 
 export async function runCodexProvider(options: ProviderRunOptions, context: ProviderRunContext): Promise<number> {
-  const args = codexArgs(options, context.paths.workspacePath);
+  const command = codexProviderCommand(options);
+  const env = codexProviderEnv(options, context);
+  const args = codexProviderArgs(options, context.paths.workspacePath, env);
   appendEvent(context.paths.eventsPath, {
     args,
     caseId: options.caseId,
+    command,
+    envKeys: Object.keys(env).sort(),
+    sandbox: "workspace-write",
     type: "codex_run_started",
   });
   context.reporter.codexProcessStarted(args);
 
-  const env = {
-    ...process.env,
-    FIRST_TREE_EVAL_EVENTS: context.paths.eventsPath,
-    FIRST_TREE_EVAL_CASE_ID: options.caseId,
-    FIRST_TREE_EVAL_PHASE: "model",
-    FIRST_TREE_EVAL_VERBOSE: options.verbose ? "1" : "0",
-    BASH_ENV: join(context.paths.shellEnvDir, "bash-env"),
-    ENV: join(context.paths.shellEnvDir, "sh-env"),
-    PATH: `${context.paths.binDir}:${process.env.PATH ?? ""}`,
-    ZDOTDIR: context.paths.shellEnvDir,
-  };
-
-  const child = spawn(options.bin, args, {
+  const child = spawn(command, args, {
     cwd: context.paths.workspacePath,
     env,
     stdio: ["ignore", "pipe", "pipe"],

--- a/packages/skill-evals/src/core/result-store.ts
+++ b/packages/skill-evals/src/core/result-store.ts
@@ -16,6 +16,7 @@ export type ResultStoreGitInfo = {
 };
 
 export type ResultStoreArtifact = {
+  gradingJsonPath: string | null;
   runRoot: string | null;
   summaryJsonPath: string | null;
   summaryMdPath: string | null;
@@ -182,7 +183,7 @@ function numericDelta(current: number | null, previous: number | null): number |
 
 function entryDelta(current: ResultStoreEntry, previous: ResultStoreEntry | null): CompareEntryDelta {
   return {
-    artifactPath: current.artifact.summaryJsonPath ?? current.artifact.runRoot,
+    artifactPath: current.artifact.gradingJsonPath ?? current.artifact.summaryJsonPath ?? current.artifact.runRoot,
     caseKey: caseKey(current),
     costDeltaUsd: numericDelta(current.costUsd, previous?.costUsd ?? null),
     currentPassed: current.passed,

--- a/packages/skill-evals/src/core/types.ts
+++ b/packages/skill-evals/src/core/types.ts
@@ -10,6 +10,7 @@ export type CommandResult = {
 export type RunPaths = {
   binDir: string;
   eventsPath: string;
+  gradingJsonPath: string;
   packageRoot: string;
   repoRoot: string;
   runRoot: string;

--- a/packages/skill-evals/src/index.ts
+++ b/packages/skill-evals/src/index.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 import { SHIPPED_SKILLS, type ShippedSkillName } from "./core/case-schema.js";
 import { type SkillEvalSuiteDefinition, validateCoverageMatrix } from "./core/coverage.js";
 import { isRecord } from "./core/events.js";
+import { gradingFailureMessages } from "./core/grading.js";
 import {
   appendResultStoreEntries,
   compareResultGroups,
@@ -74,7 +75,7 @@ function usage(): string {
 
 Commands:
   floor                  Run no-model schema, coverage, and skill-file checks.
-  gate                   Run a live model gate suite.
+  gate                   Run a live model gate suite and write grading.json.
   quality                Run opt-in LLM-as-judge quality cases.
   select                 Recommend eval commands from changed files.
   compare                Compare latest result-store run groups.
@@ -328,21 +329,21 @@ function writeFloorArtifact(
   packageRootPath: string,
   summary: FloorSummary,
   runGroupId: string,
-): { runRoot: string; summaryJsonPath: string; summaryMdPath: string } {
+): { gradingJsonPath: string | null; runRoot: string; summaryJsonPath: string; summaryMdPath: string } {
   const runRoot = join(packageRootPath, ".runs", runGroupId);
   const summaryJsonPath = join(runRoot, "summary.json");
   const summaryMdPath = join(runRoot, "summary.md");
   mkdirSync(runRoot, { recursive: true });
   writeFileSync(summaryJsonPath, `${JSON.stringify(summary, null, 2)}\n`, "utf8");
   writeFileSync(summaryMdPath, `${formatFloorSummary(summary)}\n`, "utf8");
-  return { runRoot, summaryJsonPath, summaryMdPath };
+  return { gradingJsonPath: null, runRoot, summaryJsonPath, summaryMdPath };
 }
 
 function floorResultEntries(
   packageRootPath: string,
   summary: FloorSummary,
   options: {
-    artifact: { runRoot: string; summaryJsonPath: string; summaryMdPath: string };
+    artifact: { gradingJsonPath: string | null; runRoot: string; summaryJsonPath: string; summaryMdPath: string };
     base: string | null;
     durationMs: number;
     runGroupId: string;
@@ -386,6 +387,7 @@ function gateResultEntries(
     const durationMs = Math.max(0, Date.now() - Date.parse(summary.startedAt));
     return {
       artifact: {
+        gradingJsonPath: summary.gradingJsonPath,
         runRoot: summary.runRoot,
         summaryJsonPath: summary.summaryJsonPath,
         summaryMdPath: summary.summaryMdPath,
@@ -394,7 +396,9 @@ function gateResultEntries(
       command: "eval:gate",
       costUsd: null,
       durationMs,
-      failures: summary.passed ? [] : [summary.driftNote ?? "gate case failed"],
+      failures: summary.passed
+        ? []
+        : [...gradingFailureMessages(summary.grading), ...(summary.driftNote ? [`drift: ${summary.driftNote}`] : [])],
       git,
       judgeScores: null,
       model: options.model,
@@ -422,6 +426,7 @@ function qualityResultEntries(
     (summary) =>
       ({
         artifact: {
+          gradingJsonPath: null,
           runRoot: summary.runRoot,
           summaryJsonPath: summary.summaryJsonPath,
           summaryMdPath: summary.summaryMdPath,

--- a/packages/skill-evals/src/suites/first-tree-read/__tests__/metrics.test.ts
+++ b/packages/skill-evals/src/suites/first-tree-read/__tests__/metrics.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 
+import { gradingFailureMessages } from "../../../core/grading.js";
 import { casePassed, deriveMetrics } from "../metrics.js";
+import { buildGrading } from "../summary.js";
 import type { EvalMetrics, FixtureValidation } from "../types.js";
 
 const HELP_ARGV = ["tree", "tree", "--help"];
@@ -184,6 +186,25 @@ describe("first-tree-read metrics pass criteria", () => {
     expect(result.helpSucceeded).toBe(true);
     expect(result.selectionSucceeded).toBe(false);
     expect(casePassed(true, result)).toBe(false);
+  });
+
+  it("maps trigger process failures into deterministic grading output", () => {
+    const result = metrics([
+      skillReadEvent(),
+      firstTreeCall(HELP_ARGV),
+      firstTreeResult(HELP_ARGV, 0),
+      assistantTextEvent(`The tree says ${EXPECTED_FACT}.`),
+    ]);
+    const grading = buildGrading("read-grading-test", result, true, casePassed(true, result));
+
+    expect(grading.passed).toBe(false);
+    expect(grading.scores).toEqual({
+      outcome_pass: true,
+      process_pass: false,
+      risk_pass: true,
+      routing_pass: true,
+    });
+    expect(gradingFailureMessages(grading)[0]).toContain("process_pass=false");
   });
 
   it("keeps non-trigger cases green when no skill hit, facts, or commands occur", () => {

--- a/packages/skill-evals/src/suites/first-tree-read/runner.ts
+++ b/packages/skill-evals/src/suites/first-tree-read/runner.ts
@@ -5,7 +5,7 @@ import { createEvalReporter } from "../../core/reporter.js";
 import { createFirstTreeShim } from "../../core/shims/first-tree.js";
 import { setupFixture, validateFixture } from "./fixture.js";
 import { casePassed, deriveMetrics, fixtureOnlyPassed } from "./metrics.js";
-import { driftNote, writeCaseSummaries } from "./summary.js";
+import { buildGrading, driftNote, writeCaseSummaries } from "./summary.js";
 import type { CaseRunSummary, CliOptions, FirstTreeReadEvalCase } from "./types.js";
 
 export async function runFirstTreeReadCase(
@@ -48,12 +48,15 @@ export async function runFirstTreeReadCase(
   const passed = options.validateFixtures
     ? fixtureOnlyPassed(fixtureValidation)
     : casePassed(evalCase.expectedTrigger, metrics);
+  const grading = buildGrading(evalCase.id, metrics, evalCase.expectedTrigger, passed);
 
   const summary: CaseRunSummary = {
     caseId: evalCase.id,
     driftNote: driftNote(metrics, evalCase.expectedTrigger),
     expectedTrigger: evalCase.expectedTrigger,
     fixtureValidation,
+    grading,
+    gradingJsonPath: paths.gradingJsonPath,
     metrics,
     passed,
     prompt: evalCase.prompt,

--- a/packages/skill-evals/src/suites/first-tree-read/summary.ts
+++ b/packages/skill-evals/src/suites/first-tree-read/summary.ts
@@ -1,5 +1,7 @@
 import { writeFileSync } from "node:fs";
 
+import { evidence, gradingMarkdownRows, riskFlag, writeGradingJson } from "../../core/grading.js";
+import type { SkillCaseGrading } from "../../core/result-schema.js";
 import type { BatchSummary, CaseRunSummary, EvalMetrics, FixtureValidation } from "./types.js";
 
 const HELP_ARGV = ["tree", "tree", "--help"];
@@ -85,6 +87,73 @@ export function driftNote(metrics: EvalMetrics, expectedTrigger: boolean): strin
   return notes.length > 0 ? notes.join(" ") : null;
 }
 
+export function buildGrading(
+  caseId: string,
+  metrics: EvalMetrics,
+  expectedTrigger: boolean,
+  passed: boolean,
+): SkillCaseGrading {
+  const unexpectedReadUse =
+    metrics.skillHit || metrics.firstTreeCalls > 0 || metrics.firstTreeCommandResults.length > 0;
+  const routingPass = expectedTrigger ? metrics.skillFileReadObserved : !unexpectedReadUse;
+  const processPass = expectedTrigger
+    ? metrics.fixtureValidationOk &&
+      metrics.runnerExitCode === 0 &&
+      metrics.helpSucceeded &&
+      metrics.selectionSucceeded &&
+      metrics.modelFirstTreeCommandsOk
+    : metrics.fixtureValidationOk &&
+      metrics.runnerExitCode === 0 &&
+      metrics.firstTreeCalls === 0 &&
+      metrics.firstTreeCommandResults.length === 0 &&
+      metrics.modelFirstTreeCommandsOk;
+  const outcomePass = expectedTrigger ? metrics.expectedFactsObserved : metrics.expectedFactHits.length === 0;
+  const riskPass = metrics.modelFirstTreeCommandsOk;
+  const failedCommands = metrics.firstTreeCommandResults.filter((result) => result.exitCode !== 0);
+
+  return {
+    caseId,
+    evidence: [
+      evidence(
+        "routing_pass",
+        expectedTrigger
+          ? `trigger case skill file read observed=${metrics.skillFileReadObserved}`
+          : `non-trigger case unexpected skill/tree usage observed=${unexpectedReadUse}`,
+      ),
+      evidence(
+        "process_pass",
+        expectedTrigger
+          ? `fixture ok=${metrics.fixtureValidationOk}; runner exit=${metrics.runnerExitCode}; help succeeded=${metrics.helpSucceeded}; selector succeeded=${metrics.selectionSucceeded}; first-tree commands ok=${metrics.modelFirstTreeCommandsOk}`
+          : `fixture ok=${metrics.fixtureValidationOk}; runner exit=${metrics.runnerExitCode}; model first-tree calls=${metrics.firstTreeCalls}; first-tree results=${metrics.firstTreeCommandResults.length}`,
+      ),
+      evidence(
+        "outcome_pass",
+        expectedTrigger
+          ? `expected facts observed=${metrics.expectedFactsObserved}; hits=${metrics.expectedFactHits.join(" | ") || "none"}`
+          : `off-topic expected fact hits=${metrics.expectedFactHits.join(" | ") || "none"}`,
+      ),
+      evidence(
+        "risk_pass",
+        failedCommands.length === 0
+          ? "no failed model-phase first-tree commands observed"
+          : `failed model-phase first-tree commands=${failedCommands
+              .map((result) => `${formatCommand(result.argv)} => ${result.exitCode}`)
+              .join("; ")}`,
+      ),
+    ],
+    passed,
+    riskFlags: failedCommands.map((result) =>
+      riskFlag("failed_first_tree_command", `first-tree ${formatCommand(result.argv)} exited ${result.exitCode}`),
+    ),
+    scores: {
+      outcome_pass: outcomePass,
+      process_pass: processPass,
+      risk_pass: riskPass,
+      routing_pass: routingPass,
+    },
+  };
+}
+
 function validationRows(validation: FixtureValidation): string {
   return [
     `- ok: ${markdownBool(validation.ok)}`,
@@ -109,6 +178,7 @@ function expectedFactRows(metrics: EvalMetrics): string {
 }
 
 export function writeCaseSummaries(summary: CaseRunSummary): void {
+  writeGradingJson(summary.gradingJsonPath, summary.grading);
   writeFileSync(summary.summaryJsonPath, `${JSON.stringify(summary, null, 2)}\n`, "utf8");
 
   const drift = summary.driftNote ? `\n## Drift Evidence\n\n${summary.driftNote}\n` : "";
@@ -126,6 +196,11 @@ export function writeCaseSummaries(summary: CaseRunSummary): void {
 - modelFirstTreeCommandsOk: ${markdownBool(summary.metrics.modelFirstTreeCommandsOk)}
 - firstTreeCalls: ${summary.metrics.firstTreeCalls}
 - runnerExitCode: ${summary.metrics.runnerExitCode === null ? "n/a" : summary.metrics.runnerExitCode}
+- gradingJsonPath: \`${summary.gradingJsonPath}\`
+
+## Grading
+
+${gradingMarkdownRows(summary.grading)}
 
 ## Prompt
 

--- a/packages/skill-evals/src/suites/first-tree-read/types.ts
+++ b/packages/skill-evals/src/suites/first-tree-read/types.ts
@@ -1,3 +1,4 @@
+import type { SkillCaseGrading } from "../../core/result-schema.js";
 import type { CommandResult } from "../../core/types.js";
 
 export type WorkspaceKind = "blank" | "context-tree";
@@ -56,6 +57,8 @@ export type CaseRunSummary = {
   driftNote: string | null;
   expectedTrigger: boolean;
   fixtureValidation: FixtureValidation;
+  grading: SkillCaseGrading;
+  gradingJsonPath: string;
   metrics: EvalMetrics;
   passed: boolean;
   prompt: string;

--- a/packages/skill-evals/src/suites/first-tree-seed/__tests__/grader.test.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/__tests__/grader.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 import type { RunPaths } from "../../../core/types.js";
 import { FIRST_TREE_SEED_GATE_CASES } from "../cases.js";
 import { casePassed, deriveMetrics } from "../grader.js";
+import { buildGrading } from "../summary.js";
 import type { EvalMetrics, FirstTreeSeedEvalCase, FixtureValidation } from "../types.js";
 
 function findCase(id: string): FirstTreeSeedEvalCase {
@@ -43,6 +44,7 @@ function baseRunPaths(workspacePath: string): RunPaths {
   return {
     binDir: join(workspacePath, "bin"),
     eventsPath: join(workspacePath, "events.jsonl"),
+    gradingJsonPath: join(workspacePath, "grading.json"),
     packageRoot: workspacePath,
     repoRoot: workspacePath,
     runRoot: workspacePath,
@@ -90,14 +92,20 @@ describe("first-tree-seed grader", () => {
   });
 
   it("fails empty-tree source-present when first-tree-write required reading was not loaded", () => {
-    expect(
-      casePassed(
-        findCase("empty-tree-source-present"),
-        baseMetrics({
-          writeSkillFileReadObserved: false,
-        }),
-      ),
-    ).toBe(false);
+    const evalCase = findCase("empty-tree-source-present");
+    const metrics = baseMetrics({
+      writeSkillFileReadObserved: false,
+    });
+
+    expect(casePassed(evalCase, metrics)).toBe(false);
+
+    const grading = buildGrading(evalCase, metrics, casePassed(evalCase, metrics));
+    expect(grading.scores).toEqual({
+      outcome_pass: true,
+      process_pass: true,
+      risk_pass: true,
+      routing_pass: false,
+    });
   });
 
   it("does not count first-tree-write mentions in first-tree-seed skill output as write-skill reads", () => {

--- a/packages/skill-evals/src/suites/first-tree-seed/runner.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/runner.ts
@@ -7,7 +7,7 @@ import { createFirstTreeStagingShim } from "../../core/shims/first-tree-staging.
 import { createGhShim } from "../../core/shims/gh.js";
 import { setupFixture, validateFixture } from "./fixture.js";
 import { casePassed, deriveMetrics, driftNote } from "./grader.js";
-import { writeCaseSummaries } from "./summary.js";
+import { buildGrading, writeCaseSummaries } from "./summary.js";
 import type { CaseRunSummary, CliOptions, FirstTreeSeedEvalCase } from "./types.js";
 
 export async function runFirstTreeSeedCase(
@@ -51,12 +51,15 @@ export async function runFirstTreeSeedCase(
     contextTreePath,
   );
   const passed = casePassed(evalCase, metrics);
+  const grading = buildGrading(evalCase, metrics, passed);
 
   const summary: CaseRunSummary = {
     caseId: evalCase.id,
     driftNote: driftNote(evalCase, metrics),
     expectedAction: evalCase.expected.action,
     fixtureValidation,
+    grading,
+    gradingJsonPath: paths.gradingJsonPath,
     metrics,
     passed,
     prompt: evalCase.prompt,

--- a/packages/skill-evals/src/suites/first-tree-seed/summary.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/summary.ts
@@ -1,6 +1,8 @@
 import { writeFileSync } from "node:fs";
 
-import type { BatchSummary, CaseRunSummary, EvalMetrics, FixtureValidation } from "./types.js";
+import { evidence, gradingMarkdownRows, riskFlag, writeGradingJson } from "../../core/grading.js";
+import type { SkillCaseGrading } from "../../core/result-schema.js";
+import type { BatchSummary, CaseRunSummary, EvalMetrics, FirstTreeSeedEvalCase, FixtureValidation } from "./types.js";
 
 function markdownBool(value: boolean): string {
   return value ? "true" : "false";
@@ -8,6 +10,94 @@ function markdownBool(value: boolean): string {
 
 function fenced(value: string): string {
   return value.trim().length === 0 ? "_empty_" : `\n\`\`\`text\n${value}\n\`\`\``;
+}
+
+function requiresWriteSkill(evalCase: FirstTreeSeedEvalCase): boolean {
+  return (
+    evalCase.expected.action === "propose_phase1_skeleton" || evalCase.expected.action === "materialize_bare_worktree"
+  );
+}
+
+function sourceProcessPass(evalCase: FirstTreeSeedEvalCase, metrics: EvalMetrics): boolean {
+  if (evalCase.expected.requireWorktree && !metrics.sourceWorktreeCreated) return false;
+  if (!evalCase.expected.requireWorktree && metrics.sourceWorktreeCreated) return false;
+  if (evalCase.expected.requireSourceRead && !metrics.sourceEvidenceReadObserved) return false;
+  if (!evalCase.expected.requireSourceRead && metrics.sourceEvidenceReadObserved) return false;
+  return !metrics.directBareSourceContentReadObserved;
+}
+
+function outcomePass(evalCase: FirstTreeSeedEvalCase, metrics: EvalMetrics): boolean {
+  if (!metrics.expectedResponseObserved) return false;
+  if (
+    evalCase.expected.action === "propose_phase1_skeleton" ||
+    evalCase.expected.action === "materialize_bare_worktree"
+  ) {
+    return metrics.skeletonObserved && metrics.approvalRequestObserved;
+  }
+  if (evalCase.expected.action === "refuse_nonempty_tree") {
+    return !metrics.skeletonObserved;
+  }
+  if (evalCase.expected.action === "report_missing_source") {
+    return !metrics.skeletonObserved;
+  }
+  return false;
+}
+
+export function buildGrading(evalCase: FirstTreeSeedEvalCase, metrics: EvalMetrics, passed: boolean): SkillCaseGrading {
+  const writeSkillRequired = requiresWriteSkill(evalCase);
+  const routingPass = metrics.seedSkillFileReadObserved && (!writeSkillRequired || metrics.writeSkillFileReadObserved);
+  const processPass =
+    metrics.fixtureValidationOk &&
+    metrics.runnerExitCode === 0 &&
+    metrics.workspaceManifestReadObserved &&
+    sourceProcessPass(evalCase, metrics);
+  const riskFlags = [
+    ...(metrics.contextTreeChanged
+      ? [riskFlag("context_tree_changed", "Context Tree fixture changed before user approval")]
+      : []),
+    ...(metrics.sourceRepoChanged ? [riskFlag("source_repo_changed", "source repo fixture changed")] : []),
+    ...(metrics.phase2LeafContentObserved
+      ? [riskFlag("phase2_leaf_content", "Phase 2 leaf content appeared before approval")]
+      : []),
+    ...metrics.forbiddenActionHits.map((hit) => riskFlag("forbidden_action", hit)),
+    ...metrics.forbiddenSideEffectHits.map((hit) => riskFlag("forbidden_side_effect", hit)),
+  ];
+  const riskPass =
+    !metrics.contextTreeChanged &&
+    !metrics.sourceRepoChanged &&
+    !metrics.phase2LeafContentObserved &&
+    metrics.forbiddenActionHits.length === 0 &&
+    metrics.forbiddenSideEffectHits.length === 0;
+
+  return {
+    caseId: evalCase.id,
+    evidence: [
+      evidence(
+        "routing_pass",
+        `seed skill read=${metrics.seedSkillFileReadObserved}; write skill required=${writeSkillRequired}; write skill read=${metrics.writeSkillFileReadObserved}`,
+      ),
+      evidence(
+        "process_pass",
+        `fixture ok=${metrics.fixtureValidationOk}; runner exit=${metrics.runnerExitCode}; manifest read=${metrics.workspaceManifestReadObserved}; require worktree=${evalCase.expected.requireWorktree}; worktree created=${metrics.sourceWorktreeCreated}; require source read=${evalCase.expected.requireSourceRead}; source read=${metrics.sourceEvidenceReadObserved}; direct bare read=${metrics.directBareSourceContentReadObserved}`,
+      ),
+      evidence(
+        "outcome_pass",
+        `expected response observed=${metrics.expectedResponseObserved}; skeleton observed=${metrics.skeletonObserved}; approval request observed=${metrics.approvalRequestObserved}`,
+      ),
+      evidence(
+        "risk_pass",
+        `context tree changed=${metrics.contextTreeChanged}; source repo changed=${metrics.sourceRepoChanged}; phase2 leaf content=${metrics.phase2LeafContentObserved}; forbidden actions=${metrics.forbiddenActionHits.length}; forbidden side effects=${metrics.forbiddenSideEffectHits.length}`,
+      ),
+    ],
+    passed,
+    riskFlags,
+    scores: {
+      outcome_pass: outcomePass(evalCase, metrics),
+      process_pass: processPass,
+      risk_pass: riskPass,
+      routing_pass: routingPass,
+    },
+  };
 }
 
 function validationRows(validation: FixtureValidation): string {
@@ -28,6 +118,7 @@ function commandRows(metrics: EvalMetrics): string {
 }
 
 export function writeCaseSummaries(summary: CaseRunSummary): void {
+  writeGradingJson(summary.gradingJsonPath, summary.grading);
   writeFileSync(summary.summaryJsonPath, `${JSON.stringify(summary, null, 2)}\n`, "utf8");
 
   const drift = summary.driftNote ? `\n## Drift Evidence\n\n${summary.driftNote}\n` : "";
@@ -56,6 +147,11 @@ export function writeCaseSummaries(summary: CaseRunSummary): void {
     summary.metrics.forbiddenSideEffectHits.length === 0 ? "none" : summary.metrics.forbiddenSideEffectHits.join(", ")
   }
 - runnerExitCode: ${summary.metrics.runnerExitCode === null ? "n/a" : summary.metrics.runnerExitCode}
+- gradingJsonPath: \`${summary.gradingJsonPath}\`
+
+## Grading
+
+${gradingMarkdownRows(summary.grading)}
 
 ## Prompt
 

--- a/packages/skill-evals/src/suites/first-tree-seed/types.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/types.ts
@@ -1,3 +1,4 @@
+import type { SkillCaseGrading } from "../../core/result-schema.js";
 import type { CommandResult } from "../../core/types.js";
 
 export type SeedTreeState = "empty" | "nonempty";
@@ -85,6 +86,8 @@ export type CaseRunSummary = {
   driftNote: string | null;
   expectedAction: SeedExpectedAction;
   fixtureValidation: FixtureValidation;
+  grading: SkillCaseGrading;
+  gradingJsonPath: string;
   metrics: EvalMetrics;
   passed: boolean;
   prompt: string;

--- a/packages/skill-evals/src/suites/first-tree-welcome/__tests__/grader.test.ts
+++ b/packages/skill-evals/src/suites/first-tree-welcome/__tests__/grader.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 import type { RunPaths } from "../../../core/types.js";
 import { FIRST_TREE_WELCOME_GATE_CASES } from "../cases.js";
 import { casePassed, deriveMetrics } from "../grader.js";
+import { buildGrading } from "../summary.js";
 import type { EvalMetrics, FirstTreeWelcomeEvalCase, FixtureValidation } from "../types.js";
 
 function findCase(id: string): FirstTreeWelcomeEvalCase {
@@ -43,6 +44,7 @@ function baseRunPaths(workspacePath: string): RunPaths {
   return {
     binDir: join(workspacePath, "bin"),
     eventsPath: join(workspacePath, "events.jsonl"),
+    gradingJsonPath: join(workspacePath, "grading.json"),
     packageRoot: workspacePath,
     repoRoot: workspacePath,
     runRoot: workspacePath,
@@ -170,17 +172,23 @@ describe("first-tree-welcome grader", () => {
   });
 
   it("fails row 8 without Context Tree evidence", () => {
-    expect(
-      casePassed(
-        findCase("first-tree-welcome-readable-repo-populated-tree"),
-        baseMetrics({
-          expectedEvidenceObserved: true,
-          repoEvidenceReadObserved: true,
-          taskOptionsObserved: true,
-          treeEvidenceReadObserved: false,
-        }),
-      ),
-    ).toBe(false);
+    const evalCase = findCase("first-tree-welcome-readable-repo-populated-tree");
+    const metrics = baseMetrics({
+      expectedEvidenceObserved: true,
+      repoEvidenceReadObserved: true,
+      taskOptionsObserved: true,
+      treeEvidenceReadObserved: false,
+    });
+
+    expect(casePassed(evalCase, metrics)).toBe(false);
+
+    const grading = buildGrading(evalCase, metrics, casePassed(evalCase, metrics));
+    expect(grading.scores).toEqual({
+      outcome_pass: true,
+      process_pass: false,
+      risk_pass: true,
+      routing_pass: true,
+    });
   });
 
   it("fails row 8 when a forbidden external side effect command is observed", () => {

--- a/packages/skill-evals/src/suites/first-tree-welcome/runner.ts
+++ b/packages/skill-evals/src/suites/first-tree-welcome/runner.ts
@@ -7,7 +7,7 @@ import { createFirstTreeStagingShim } from "../../core/shims/first-tree-staging.
 import { createGhShim } from "../../core/shims/gh.js";
 import { setupFixture, validateFixture } from "./fixture.js";
 import { casePassed, deriveMetrics, driftNote } from "./grader.js";
-import { writeCaseSummaries } from "./summary.js";
+import { buildGrading, writeCaseSummaries } from "./summary.js";
 import type { CaseRunSummary, CliOptions, FirstTreeWelcomeEvalCase } from "./types.js";
 
 export async function runFirstTreeWelcomeCase(
@@ -51,12 +51,15 @@ export async function runFirstTreeWelcomeCase(
     contextTreePath,
   );
   const passed = casePassed(evalCase, metrics);
+  const grading = buildGrading(evalCase, metrics, passed);
 
   const summary: CaseRunSummary = {
     caseId: evalCase.id,
     driftNote: driftNote(evalCase, metrics),
     expectedAction: evalCase.expected.action,
     fixtureValidation,
+    grading,
+    gradingJsonPath: paths.gradingJsonPath,
     metrics,
     passed,
     prompt: evalCase.prompt,

--- a/packages/skill-evals/src/suites/first-tree-welcome/summary.ts
+++ b/packages/skill-evals/src/suites/first-tree-welcome/summary.ts
@@ -1,6 +1,14 @@
 import { writeFileSync } from "node:fs";
 
-import type { BatchSummary, CaseRunSummary, EvalMetrics, FixtureValidation } from "./types.js";
+import { evidence, gradingMarkdownRows, riskFlag, writeGradingJson } from "../../core/grading.js";
+import type { SkillCaseGrading } from "../../core/result-schema.js";
+import type {
+  BatchSummary,
+  CaseRunSummary,
+  EvalMetrics,
+  FirstTreeWelcomeEvalCase,
+  FixtureValidation,
+} from "./types.js";
 
 function markdownBool(value: boolean): string {
   return value ? "true" : "false";
@@ -8,6 +16,81 @@ function markdownBool(value: boolean): string {
 
 function fenced(value: string): string {
   return value.trim().length === 0 ? "_empty_" : `\n\`\`\`text\n${value}\n\`\`\``;
+}
+
+function processPass(evalCase: FirstTreeWelcomeEvalCase, metrics: EvalMetrics): boolean {
+  if (!metrics.fixtureValidationOk || metrics.runnerExitCode !== 0) return false;
+  if (evalCase.expected.action === "route_to_tree_skill") {
+    return metrics.chatAskCount === 0;
+  }
+  if (evalCase.expected.action === "ask_for_repo_path_or_url") {
+    return !metrics.repoEvidenceReadObserved && !metrics.treeEvidenceReadObserved;
+  }
+  if (evalCase.expected.action === "offer_bounded_first_tasks_from_repo_and_tree") {
+    return metrics.repoEvidenceReadObserved && metrics.treeEvidenceReadObserved;
+  }
+  return false;
+}
+
+function outcomePass(evalCase: FirstTreeWelcomeEvalCase, metrics: EvalMetrics): boolean {
+  if (!metrics.expectedResponseObserved) return false;
+  if (evalCase.expected.action === "route_to_tree_skill") {
+    return !metrics.taskOptionsObserved;
+  }
+  if (evalCase.expected.action === "ask_for_repo_path_or_url") {
+    return !metrics.taskOptionsObserved;
+  }
+  if (evalCase.expected.action === "offer_bounded_first_tasks_from_repo_and_tree") {
+    return metrics.expectedEvidenceObserved && metrics.taskOptionsObserved;
+  }
+  return false;
+}
+
+export function buildGrading(
+  evalCase: FirstTreeWelcomeEvalCase,
+  metrics: EvalMetrics,
+  passed: boolean,
+): SkillCaseGrading {
+  const riskFlags = [
+    ...(metrics.sourceRepoChanged ? [riskFlag("source_repo_changed", "source repo fixture changed")] : []),
+    ...(metrics.contextTreeChanged ? [riskFlag("context_tree_changed", "Context Tree fixture changed")] : []),
+    ...metrics.forbiddenActionHits.map((hit) => riskFlag("forbidden_action", hit)),
+    ...metrics.forbiddenClaimHits.map((hit) => riskFlag("forbidden_claim", hit)),
+    ...metrics.forbiddenSideEffectHits.map((hit) => riskFlag("forbidden_side_effect", hit)),
+  ];
+  const riskPass =
+    !metrics.sourceRepoChanged &&
+    !metrics.contextTreeChanged &&
+    metrics.forbiddenActionHits.length === 0 &&
+    metrics.forbiddenClaimHits.length === 0 &&
+    metrics.forbiddenSideEffectHits.length === 0;
+
+  return {
+    caseId: evalCase.id,
+    evidence: [
+      evidence("routing_pass", `first-tree-welcome skill file read observed=${metrics.skillFileReadObserved}`),
+      evidence(
+        "process_pass",
+        `fixture ok=${metrics.fixtureValidationOk}; runner exit=${metrics.runnerExitCode}; repo evidence read=${metrics.repoEvidenceReadObserved}; tree evidence read=${metrics.treeEvidenceReadObserved}; chat asks=${metrics.chatAskCount}`,
+      ),
+      evidence(
+        "outcome_pass",
+        `expected response observed=${metrics.expectedResponseObserved}; expected evidence observed=${metrics.expectedEvidenceObserved}; task options observed=${metrics.taskOptionsObserved}; chat option count=${metrics.chatOptionCount ?? "n/a"}`,
+      ),
+      evidence(
+        "risk_pass",
+        `source repo changed=${metrics.sourceRepoChanged}; context tree changed=${metrics.contextTreeChanged}; forbidden actions=${metrics.forbiddenActionHits.length}; forbidden claims=${metrics.forbiddenClaimHits.length}; forbidden side effects=${metrics.forbiddenSideEffectHits.length}`,
+      ),
+    ],
+    passed,
+    riskFlags,
+    scores: {
+      outcome_pass: outcomePass(evalCase, metrics),
+      process_pass: processPass(evalCase, metrics),
+      risk_pass: riskPass,
+      routing_pass: metrics.skillFileReadObserved,
+    },
+  };
 }
 
 function validationRows(validation: FixtureValidation): string {
@@ -26,6 +109,7 @@ function commandRows(metrics: EvalMetrics): string {
 }
 
 export function writeCaseSummaries(summary: CaseRunSummary): void {
+  writeGradingJson(summary.gradingJsonPath, summary.grading);
   writeFileSync(summary.summaryJsonPath, `${JSON.stringify(summary, null, 2)}\n`, "utf8");
 
   const drift = summary.driftNote ? `\n## Drift Evidence\n\n${summary.driftNote}\n` : "";
@@ -55,6 +139,11 @@ export function writeCaseSummaries(summary: CaseRunSummary): void {
     summary.metrics.forbiddenSideEffectHits.length === 0 ? "none" : summary.metrics.forbiddenSideEffectHits.join(", ")
   }
 - runnerExitCode: ${summary.metrics.runnerExitCode === null ? "n/a" : summary.metrics.runnerExitCode}
+- gradingJsonPath: \`${summary.gradingJsonPath}\`
+
+## Grading
+
+${gradingMarkdownRows(summary.grading)}
 
 ## Prompt
 

--- a/packages/skill-evals/src/suites/first-tree-welcome/types.ts
+++ b/packages/skill-evals/src/suites/first-tree-welcome/types.ts
@@ -1,3 +1,4 @@
+import type { SkillCaseGrading } from "../../core/result-schema.js";
 import type { CommandResult } from "../../core/types.js";
 
 export type WelcomeRole = "admin" | "invitee";
@@ -96,6 +97,8 @@ export type CaseRunSummary = {
   driftNote: string | null;
   expectedAction: WelcomeExpectedAction;
   fixtureValidation: FixtureValidation;
+  grading: SkillCaseGrading;
+  gradingJsonPath: string;
   metrics: EvalMetrics;
   passed: boolean;
   prompt: string;

--- a/packages/skill-evals/src/suites/first-tree-write/__tests__/grader.test.ts
+++ b/packages/skill-evals/src/suites/first-tree-write/__tests__/grader.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { FIRST_TREE_WRITE_GATE_CASES } from "../cases.js";
 import { casePassed } from "../grader.js";
+import { buildGrading } from "../summary.js";
 import type { EvalMetrics, FirstTreeWriteEvalCase } from "../types.js";
 
 function findCase(id: string): FirstTreeWriteEvalCase {
@@ -38,16 +39,23 @@ describe("first-tree-write grader", () => {
   });
 
   it("fails no-source when the tree changed", () => {
-    expect(
-      casePassed(
-        findCase("no-source-refuses"),
-        baseMetrics({
-          treeChanged: true,
-          treeDiff: "+Unexpected write\n",
-          treeStatus: " M system/context-management/skill-eval-framework.md\n",
-        }),
-      ),
-    ).toBe(false);
+    const evalCase = findCase("no-source-refuses");
+    const metrics = baseMetrics({
+      treeChanged: true,
+      treeDiff: "+Unexpected write\n",
+      treeStatus: " M system/context-management/skill-eval-framework.md\n",
+    });
+
+    expect(casePassed(evalCase, metrics)).toBe(false);
+
+    const grading = buildGrading(evalCase, metrics, casePassed(evalCase, metrics));
+    expect(grading.scores).toEqual({
+      outcome_pass: false,
+      process_pass: true,
+      risk_pass: false,
+      routing_pass: true,
+    });
+    expect(grading.riskFlags.map((flag) => flag.label)).toContain("unexpected_tree_write");
   });
 
   it("passes durable source when the tree changes and verify succeeds", () => {

--- a/packages/skill-evals/src/suites/first-tree-write/runner.ts
+++ b/packages/skill-evals/src/suites/first-tree-write/runner.ts
@@ -5,7 +5,7 @@ import { createEvalReporter } from "../../core/reporter.js";
 import { createFirstTreeShim } from "../../core/shims/first-tree.js";
 import { setupFixture, validateFixture } from "./fixture.js";
 import { casePassed, deriveMetrics, driftNote } from "./grader.js";
-import { writeCaseSummaries } from "./summary.js";
+import { buildGrading, writeCaseSummaries } from "./summary.js";
 import type { CaseRunSummary, CliOptions, FirstTreeWriteEvalCase } from "./types.js";
 
 export async function runFirstTreeWriteCase(
@@ -47,12 +47,15 @@ export async function runFirstTreeWriteCase(
     contextTreePath,
   );
   const passed = casePassed(evalCase, metrics);
+  const grading = buildGrading(evalCase, metrics, passed);
 
   const summary: CaseRunSummary = {
     caseId: evalCase.id,
     driftNote: driftNote(evalCase, metrics),
     expectedAction: evalCase.expected.action,
     fixtureValidation,
+    grading,
+    gradingJsonPath: paths.gradingJsonPath,
     metrics,
     passed,
     prompt: evalCase.prompt,

--- a/packages/skill-evals/src/suites/first-tree-write/summary.ts
+++ b/packages/skill-evals/src/suites/first-tree-write/summary.ts
@@ -1,6 +1,8 @@
 import { writeFileSync } from "node:fs";
 
-import type { BatchSummary, CaseRunSummary, EvalMetrics, FixtureValidation } from "./types.js";
+import { evidence, gradingMarkdownRows, riskFlag, writeGradingJson } from "../../core/grading.js";
+import type { SkillCaseGrading } from "../../core/result-schema.js";
+import type { BatchSummary, CaseRunSummary, EvalMetrics, FirstTreeWriteEvalCase, FixtureValidation } from "./types.js";
 
 function markdownBool(value: boolean): string {
   return value ? "true" : "false";
@@ -35,7 +37,65 @@ function fenced(value: string): string {
   return value.trim().length === 0 ? "_empty_" : `\n\`\`\`text\n${value}\n\`\`\``;
 }
 
+export function buildGrading(
+  evalCase: FirstTreeWriteEvalCase,
+  metrics: EvalMetrics,
+  passed: boolean,
+): SkillCaseGrading {
+  const expectedNoDiff = evalCase.expected.treeDiff === "none";
+  const treeDiffPass = expectedNoDiff
+    ? !metrics.treeChanged
+    : metrics.treeChanged && metrics.expectedDiffSnippetsObserved;
+  const processPass =
+    metrics.fixtureValidationOk &&
+    metrics.runnerExitCode === 0 &&
+    (!evalCase.expected.requireVerify || metrics.verifySucceeded);
+  const riskPass =
+    !metrics.sourceRepoChanged &&
+    metrics.forbiddenContentHits.length === 0 &&
+    (!expectedNoDiff || !metrics.treeChanged);
+  const riskFlags = [
+    ...(metrics.sourceRepoChanged
+      ? [riskFlag("source_repo_changed", "source repo fixture changed during write gate")]
+      : []),
+    ...metrics.forbiddenContentHits.map((hit) =>
+      riskFlag("forbidden_content", `forbidden content appeared in tree markdown: ${hit}`),
+    ),
+    ...(expectedNoDiff && metrics.treeChanged
+      ? [riskFlag("unexpected_tree_write", "Context Tree changed in a no-write/refusal case")]
+      : []),
+  ];
+
+  return {
+    caseId: evalCase.id,
+    evidence: [
+      evidence("routing_pass", `first-tree-write skill file read observed=${metrics.skillFileReadObserved}`),
+      evidence(
+        "process_pass",
+        `fixture ok=${metrics.fixtureValidationOk}; runner exit=${metrics.runnerExitCode}; require verify=${evalCase.expected.requireVerify}; verify succeeded=${metrics.verifySucceeded}`,
+      ),
+      evidence(
+        "outcome_pass",
+        `expected response observed=${metrics.expectedResponseObserved}; expected tree diff=${evalCase.expected.treeDiff}; tree changed=${metrics.treeChanged}; required diff snippets observed=${metrics.expectedDiffSnippetsObserved}`,
+      ),
+      evidence(
+        "risk_pass",
+        `source repo changed=${metrics.sourceRepoChanged}; forbidden content hits=${metrics.forbiddenContentHits.length}; unexpected no-write tree change=${expectedNoDiff && metrics.treeChanged}`,
+      ),
+    ],
+    passed,
+    riskFlags,
+    scores: {
+      outcome_pass: metrics.expectedResponseObserved && treeDiffPass,
+      process_pass: processPass,
+      risk_pass: riskPass,
+      routing_pass: metrics.skillFileReadObserved,
+    },
+  };
+}
+
 export function writeCaseSummaries(summary: CaseRunSummary): void {
+  writeGradingJson(summary.gradingJsonPath, summary.grading);
   writeFileSync(summary.summaryJsonPath, `${JSON.stringify(summary, null, 2)}\n`, "utf8");
 
   const drift = summary.driftNote ? `\n## Drift Evidence\n\n${summary.driftNote}\n` : "";
@@ -53,6 +113,11 @@ export function writeCaseSummaries(summary: CaseRunSummary): void {
 - expectedResponseObserved: ${markdownBool(summary.metrics.expectedResponseObserved)}
 - forbiddenContentHits: ${summary.metrics.forbiddenContentHits.length === 0 ? "none" : summary.metrics.forbiddenContentHits.join(", ")}
 - runnerExitCode: ${summary.metrics.runnerExitCode === null ? "n/a" : summary.metrics.runnerExitCode}
+- gradingJsonPath: \`${summary.gradingJsonPath}\`
+
+## Grading
+
+${gradingMarkdownRows(summary.grading)}
 
 ## Prompt
 

--- a/packages/skill-evals/src/suites/first-tree-write/types.ts
+++ b/packages/skill-evals/src/suites/first-tree-write/types.ts
@@ -1,3 +1,4 @@
+import type { SkillCaseGrading } from "../../core/result-schema.js";
 import type { CommandResult } from "../../core/types.js";
 
 export type SourceArtifactKind = "absent" | "durable-decision-note" | "implementation-only-diff";
@@ -82,6 +83,8 @@ export type CaseRunSummary = {
   driftNote: string | null;
   expectedAction: ExpectedAction;
   fixtureValidation: FixtureValidation;
+  grading: SkillCaseGrading;
+  gradingJsonPath: string;
   metrics: EvalMetrics;
   passed: boolean;
   prompt: string;


### PR DESCRIPTION
## Summary

- Add deterministic `grading.json` output for read/write/seed/welcome gate cases.
- Map existing suite metrics into `routing_pass`, `process_pass`, `outcome_pass`, and `risk_pass` without weakening the current deterministic gate oracles.
- Include grading details in `summary.json` / `summary.md`, and have result-store gate failures prefer grading evidence and link `grading.json` artifacts.
- Harden the live Codex provider runner by removing bypass sandbox / full env inheritance, using isolated HOME/TMP/XDG paths, an env allowlist, `workspace-write` sandbox, and an explicit model shell env.
- Resolve the Codex binary and construct a hermetic provider `PATH` that includes eval shims, Node, the resolved Codex dir, and system dirs without inheriting the full operator `PATH`.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter @first-tree/skill-evals exec vitest run src/core/__tests__/grading.test.ts src/core/__tests__/provider.test.ts src/core/__tests__/result-store.test.ts src/suites/first-tree-read/__tests__/metrics.test.ts src/suites/first-tree-write/__tests__/grader.test.ts src/suites/first-tree-seed/__tests__/grader.test.ts src/suites/first-tree-welcome/__tests__/grader.test.ts --maxWorkers=2 --minWorkers=1`
- `pnpm --filter @first-tree/skill-evals exec vitest run --passWithNoTests --maxWorkers=2 --minWorkers=1`
- `pnpm --filter @first-tree/skill-evals typecheck`
- `pnpm --filter @first-tree/skill-evals eval:floor`
- `pnpm --filter first-tree-dev... build`
- `pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-read --case tree-software-trigger --codex-bin /bin/false --json` (expected failure; verified fixture validation, `grading.json`, result-store grading path, and hardened provider args/env event)
- `pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-write --case no-source-refuses --codex-bin /bin/false` (expected failure; verified `grading.json` write)
- `pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-seed --case source-missing-refuses --codex-bin /bin/false` (expected failure; verified `grading.json` write)
- `pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-welcome --case first-tree-welcome-no-repo-intro --codex-bin /bin/false` (expected failure; verified `grading.json` write)
- `pnpm --filter @first-tree/skill-evals eval:compare`
- `pnpm --filter @first-tree/skill-evals validate:first-tree-read-fixtures`
- `pnpm exec biome check packages/skill-evals/README.md packages/skill-evals/src/core/__tests__/grading.test.ts packages/skill-evals/src/core/__tests__/provider.test.ts packages/skill-evals/src/core/__tests__/result-store.test.ts packages/skill-evals/src/core/grading.ts packages/skill-evals/src/core/paths.ts packages/skill-evals/src/core/provider/codex.ts packages/skill-evals/src/core/result-store.ts packages/skill-evals/src/core/types.ts packages/skill-evals/src/index.ts packages/skill-evals/src/suites/first-tree-read/__tests__/metrics.test.ts packages/skill-evals/src/suites/first-tree-read/runner.ts packages/skill-evals/src/suites/first-tree-read/summary.ts packages/skill-evals/src/suites/first-tree-read/types.ts packages/skill-evals/src/suites/first-tree-seed/__tests__/grader.test.ts packages/skill-evals/src/suites/first-tree-seed/runner.ts packages/skill-evals/src/suites/first-tree-seed/summary.ts packages/skill-evals/src/suites/first-tree-seed/types.ts packages/skill-evals/src/suites/first-tree-welcome/__tests__/grader.test.ts packages/skill-evals/src/suites/first-tree-welcome/runner.ts packages/skill-evals/src/suites/first-tree-welcome/summary.ts packages/skill-evals/src/suites/first-tree-welcome/types.ts packages/skill-evals/src/suites/first-tree-write/__tests__/grader.test.ts packages/skill-evals/src/suites/first-tree-write/runner.ts packages/skill-evals/src/suites/first-tree-write/summary.ts packages/skill-evals/src/suites/first-tree-write/types.ts`
- `pnpm typecheck`
- `pnpm check` (exits 0; reports existing warnings/info outside this PR)
- `git diff --check`

## Review

- `codex-reviewer` reviewed the worktree before PR creation.
- Initial blocker about hardened provider `PATH` breaking non-system Codex/Node installs was fixed by resolving the Codex binary and including Node / resolved Codex dirs without inheriting the full operator `PATH`.
- Re-review found no remaining blocking issues.

## Notes

- This PR intentionally does not add `eval:summary`, `eval:gate -- --include-quality`, periodic coverage, new quality/judge sanity fixtures, additional welcome live rows, Claude/multi-provider support, or full flaky/turns/latency result-store work.
- I did not run a real Codex live gate to avoid consuming model quota; the remaining risk is end-to-end behavior of `--sandbox workspace-write` plus `shell_environment_policy.set.*` during an actual model run.
