### PR TITLE
fix(skill-evals): resolve fixture verify CLI by channel

### DIFF
--- a/packages/skill-evals/src/core/__tests__/first-tree-bin.test.ts
+++ b/packages/skill-evals/src/core/__tests__/first-tree-bin.test.ts
@@ -1,0 +1,58 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { firstTreeCommandLabel, resolveFirstTreeBin } from "../first-tree-bin.js";
+import type { RunPaths } from "../types.js";
+
+function pathsWithBinDir(binDir: string): RunPaths {
+  const paths = {
+    binDir,
+    eventsPath: join(binDir, "events.jsonl"),
+    gradingJsonPath: join(binDir, "grading.json"),
+    packageRoot: binDir,
+    repoRoot: binDir,
+    runRoot: binDir,
+    shellEnvDir: binDir,
+    summaryJsonPath: join(binDir, "summary.json"),
+    summaryMdPath: join(binDir, "summary.md"),
+    workspacePath: binDir,
+  };
+  return paths;
+}
+
+function touch(path: string): void {
+  writeFileSync(path, "#!/bin/sh\n", { mode: 0o755 });
+}
+
+describe("resolveFirstTreeBin", () => {
+  it("prefers explicit eval override", () => {
+    const binDir = mkdtempSync(join(tmpdir(), "first-tree-bin-override-"));
+
+    expect(resolveFirstTreeBin(pathsWithBinDir(binDir), { FIRST_TREE_EVAL_FIRST_TREE_BIN: "/tmp/ft-custom" })).toBe(
+      "/tmp/ft-custom",
+    );
+  });
+
+  it("uses channel-aware shims from the run bin directory before the prod shim", () => {
+    const binDir = mkdtempSync(join(tmpdir(), "first-tree-bin-shim-"));
+    touch(join(binDir, "first-tree"));
+    touch(join(binDir, "first-tree-staging"));
+
+    expect(resolveFirstTreeBin(pathsWithBinDir(binDir), { PATH: "" })).toBe(join(binDir, "first-tree-staging"));
+  });
+
+  it("falls back to first-tree when no channel binary is resolvable", () => {
+    const binDir = mkdtempSync(join(tmpdir(), "first-tree-bin-fallback-"));
+
+    expect(resolveFirstTreeBin(pathsWithBinDir(binDir), { PATH: "" })).toBe("first-tree");
+  });
+});
+
+describe("firstTreeCommandLabel", () => {
+  it("labels absolute shim paths by executable name", () => {
+    expect(firstTreeCommandLabel("/tmp/eval/bin/first-tree-staging")).toBe("first-tree-staging");
+  });
+});

--- a/packages/skill-evals/src/core/first-tree-bin.ts
+++ b/packages/skill-evals/src/core/first-tree-bin.ts
@@ -1,0 +1,36 @@
+import { existsSync } from "node:fs";
+import { basename, delimiter, isAbsolute, join } from "node:path";
+
+import type { RunPaths } from "./types.js";
+
+const FIRST_TREE_BIN_ENV_VARS = ["FIRST_TREE_EVAL_FIRST_TREE_BIN", "FT_BIN"] as const;
+const FIRST_TREE_BIN_NAMES = ["first-tree-staging", "first-tree-dev", "first-tree"] as const;
+
+export function resolveFirstTreeBin(paths: RunPaths, env: NodeJS.ProcessEnv = process.env): string {
+  for (const key of FIRST_TREE_BIN_ENV_VARS) {
+    const value = env[key]?.trim();
+    if (value) return value;
+  }
+
+  for (const name of FIRST_TREE_BIN_NAMES) {
+    const localShim = join(paths.binDir, name);
+    if (existsSync(localShim)) return localShim;
+  }
+
+  for (const name of FIRST_TREE_BIN_NAMES) {
+    if (canResolveExecutable(name, env.PATH)) return name;
+  }
+
+  return "first-tree";
+}
+
+export function firstTreeCommandLabel(command: string): string {
+  return isAbsolute(command) ? basename(command) : command;
+}
+
+function canResolveExecutable(command: string, pathValue: string | undefined): boolean {
+  if (isAbsolute(command)) return existsSync(command);
+  if (!pathValue) return false;
+
+  return pathValue.split(delimiter).some((dir) => dir.length > 0 && existsSync(join(dir, command)));
+}

--- a/packages/skill-evals/src/suites/first-tree-read/fixture.ts
+++ b/packages/skill-evals/src/suites/first-tree-read/fixture.ts
@@ -4,6 +4,7 @@ import { join, relative } from "node:path";
 
 import { assertCommandOk, runCommand, writeText } from "../../core/commands.js";
 import { appendEvent, previewText } from "../../core/events.js";
+import { firstTreeCommandLabel, resolveFirstTreeBin } from "../../core/first-tree-bin.js";
 import type { EvalReporter } from "../../core/reporter.js";
 import { stripShimTraceLines } from "../../core/reporter.js";
 import { installRepoSkill, parseSkillDescription } from "../../core/skills/install.js";
@@ -499,7 +500,9 @@ function runFixtureVerify(
     FIRST_TREE_EVAL_VERBOSE: verbose ? "1" : "0",
     PATH: `${paths.binDir}:${process.env.PATH ?? ""}`,
   };
-  const result = spawnSync("first-tree", args, {
+  const command = resolveFirstTreeBin(paths, env);
+  const commandLabel = firstTreeCommandLabel(command);
+  const result = spawnSync(command, args, {
     cwd: paths.workspacePath,
     encoding: "utf8",
     env,
@@ -511,7 +514,7 @@ function runFixtureVerify(
 
   const commandResult: CommandResult = {
     args,
-    command: "first-tree",
+    command: commandLabel,
     cwd: paths.workspacePath,
     exitCode: result.status ?? 1,
     stderr: stripShimTraceLines(stderr),

--- a/packages/skill-evals/src/suites/first-tree-welcome/fixture.ts
+++ b/packages/skill-evals/src/suites/first-tree-welcome/fixture.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 
 import { assertCommandOk, runCommand, writeText } from "../../core/commands.js";
 import { appendEvent, previewText } from "../../core/events.js";
+import { firstTreeCommandLabel, resolveFirstTreeBin } from "../../core/first-tree-bin.js";
 import type { EvalReporter } from "../../core/reporter.js";
 import { stripShimTraceLines } from "../../core/reporter.js";
 import { installRepoSkill, parseSkillDescription } from "../../core/skills/install.js";
@@ -339,7 +340,9 @@ function runFixtureVerify(
     FIRST_TREE_EVAL_VERBOSE: verbose ? "1" : "0",
     PATH: `${paths.binDir}:${process.env.PATH ?? ""}`,
   };
-  const result = spawnSync("first-tree", args, {
+  const command = resolveFirstTreeBin(paths, env);
+  const commandLabel = firstTreeCommandLabel(command);
+  const result = spawnSync(command, args, {
     cwd: paths.workspacePath,
     encoding: "utf8",
     env,
@@ -351,7 +354,7 @@ function runFixtureVerify(
 
   const commandResult: CommandResult = {
     args,
-    command: "first-tree",
+    command: commandLabel,
     cwd: paths.workspacePath,
     exitCode: result.status ?? 1,
     stderr: stripShimTraceLines(stderr),

--- a/packages/skill-evals/src/suites/first-tree-write/fixture.ts
+++ b/packages/skill-evals/src/suites/first-tree-write/fixture.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 
 import { assertCommandOk, runCommand, writeText } from "../../core/commands.js";
 import { appendEvent, previewText } from "../../core/events.js";
+import { firstTreeCommandLabel, resolveFirstTreeBin } from "../../core/first-tree-bin.js";
 import type { EvalReporter } from "../../core/reporter.js";
 import { stripShimTraceLines } from "../../core/reporter.js";
 import { installRepoSkill, parseSkillDescription } from "../../core/skills/install.js";
@@ -346,7 +347,9 @@ function runFixtureVerify(
     FIRST_TREE_EVAL_VERBOSE: verbose ? "1" : "0",
     PATH: `${paths.binDir}:${process.env.PATH ?? ""}`,
   };
-  const result = spawnSync("first-tree", args, {
+  const command = resolveFirstTreeBin(paths, env);
+  const commandLabel = firstTreeCommandLabel(command);
+  const result = spawnSync(command, args, {
     cwd: paths.workspacePath,
     encoding: "utf8",
     env,
@@ -358,7 +361,7 @@ function runFixtureVerify(
 
   const commandResult: CommandResult = {
     args,
-    command: "first-tree",
+    command: commandLabel,
     cwd: paths.workspacePath,
     exitCode: result.status ?? 1,
     stderr: stripShimTraceLines(stderr),


### PR DESCRIPTION
## Summary

- add a shared skill-evals resolver for the First Tree CLI used by fixture validation
- prefer explicit eval overrides, then channel-aware run-bin shims (`first-tree-staging`, `first-tree-dev`, `first-tree`), before falling back to `first-tree`
- use the resolver for `tree verify` fixture validation in read/write/welcome suites so welcome row 8 no longer hardcodes the prod binary

Fixes #1342.

## Validation

- `pnpm --filter @first-tree/skill-evals exec vitest run src/core/__tests__/first-tree-bin.test.ts`
- `pnpm --filter @first-tree/skill-evals test`
- `pnpm --filter @first-tree/skill-evals typecheck`
- `pnpm exec biome check packages/skill-evals/src/core/first-tree-bin.ts packages/skill-evals/src/core/__tests__/first-tree-bin.test.ts packages/skill-evals/src/suites/first-tree-read/fixture.ts packages/skill-evals/src/suites/first-tree-welcome/fixture.ts packages/skill-evals/src/suites/first-tree-write/fixture.ts`
- `pnpm --filter @first-tree/skill-evals eval:floor -- --suite first-tree-welcome`
- fixture-only row 8 probe: `ok=true`, `verifyCommand=first-tree-staging`, `exitCode=0`, `stagingCalls=1`

## Context Tree

No Context Tree update: this is an implementation-only harness fix that preserves the existing eval and channel contracts.
