### PR TITLE
feat: gzip-compress Context Tree snapshot responses

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@autotelic/fastify-opentelemetry": "^0.23.0",
+    "@fastify/compress": "^9.0.0",
     "@fastify/cors": "^11.2.0",
     "@fastify/rate-limit": "^10.3.0",
     "@fastify/static": "^9.0.0",

--- a/packages/server/src/__tests__/context-tree-snapshot-compression.test.ts
+++ b/packages/server/src/__tests__/context-tree-snapshot-compression.test.ts
@@ -1,0 +1,109 @@
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { gunzipSync } from "node:zlib";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { createTestAdmin, useTestApp } from "./helpers.js";
+
+const execFileAsync = promisify(execFile);
+
+// Shared ref the mock factory reads at call time. The validated org-settings
+// binding only accepts HTTPS/SSH repo URLs, so we cannot point an org at an
+// on-disk tree through the public path. Instead we mock the snapshot service to
+// delegate to its REAL implementation against a local checkout — exercising the
+// real route + @fastify/compress wiring against a genuine, populated snapshot.
+const treeRef = vi.hoisted(() => ({ path: "" }));
+
+vi.mock("../services/context-tree-snapshot.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../services/context-tree-snapshot.js")>();
+  return {
+    ...actual,
+    getContextTreeSnapshot: (
+      _binding: Parameters<typeof actual.getContextTreeSnapshot>[0],
+      window: Parameters<typeof actual.getContextTreeSnapshot>[1],
+      options: Parameters<typeof actual.getContextTreeSnapshot>[2],
+    ) => actual.getContextTreeSnapshot({ repo: treeRef.path, branch: "main" }, window, options),
+  };
+});
+
+const getApp = useTestApp();
+
+async function git(cwd: string, args: string[]): Promise<void> {
+  await execFileAsync("git", args, { cwd });
+}
+
+function node(title: string, description: string): string {
+  return `---
+title: "${title}"
+description: "${description}"
+owners: ["alice", "bob"]
+---
+
+# ${title}
+
+${description} ${"Context detail line. ".repeat(8)}
+`;
+}
+
+// A small but multi-node tree whose snapshot JSON comfortably exceeds the 1 KB
+// compression threshold, so compression actually engages (it is byte-gated).
+beforeAll(async () => {
+  treeRef.path = await mkdtemp(join(tmpdir(), "context-tree-compress-"));
+  await git(treeRef.path, ["init", "--initial-branch=main"]);
+  await git(treeRef.path, ["config", "user.name", "Compression Tester"]);
+  await git(treeRef.path, ["config", "user.email", "compression-tester@example.com"]);
+  await git(treeRef.path, ["config", "commit.gpgsign", "false"]);
+
+  await writeFile(join(treeRef.path, "NODE.md"), node("Acme Context Tree", "Root of the Acme team context tree."));
+  for (const domain of ["runtime", "platform", "billing", "identity"]) {
+    const dir = join(treeRef.path, "domains", domain);
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      join(dir, "NODE.md"),
+      node(`${domain} domain`, `Decisions, constraints, and ownership for the ${domain} domain.`),
+    );
+  }
+  await git(treeRef.path, ["add", "."]);
+  await git(treeRef.path, ["commit", "-m", "seed context tree"]);
+});
+
+afterAll(async () => {
+  await rm(treeRef.path, { recursive: true, force: true });
+});
+
+describe("context tree snapshot compression", () => {
+  it("gzip-compresses the org snapshot response when the client accepts it", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+
+    const response = await app.inject({
+      method: "GET",
+      url: `/api/v1/orgs/${admin.organizationId}/context-tree/snapshot?window=7d`,
+      headers: { authorization: `Bearer ${admin.accessToken}`, "accept-encoding": "gzip" },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers["content-encoding"]).toBe("gzip");
+    // The decompressed body is still a valid, populated snapshot.
+    const decoded = JSON.parse(gunzipSync(response.rawPayload).toString("utf-8"));
+    expect(decoded.snapshotStatus).toBe("active");
+    expect(decoded.nodes.length).toBeGreaterThan(1);
+  });
+
+  it("leaves the response uncompressed when the client does not accept encoding", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+
+    const response = await app.inject({
+      method: "GET",
+      url: `/api/v1/orgs/${admin.organizationId}/context-tree/snapshot?window=7d`,
+      headers: { authorization: `Bearer ${admin.accessToken}`, "accept-encoding": "identity" },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers["content-encoding"]).toBeUndefined();
+    expect(JSON.parse(response.payload).snapshotStatus).toBe("active");
+  });
+});

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -2,6 +2,7 @@ import { existsSync } from "node:fs";
 import { createRequire } from "node:module";
 import { extname, resolve } from "node:path";
 import fastifyOpenTelemetry from "@autotelic/fastify-opentelemetry";
+import compress from "@fastify/compress";
 import cors from "@fastify/cors";
 import rateLimit from "@fastify/rate-limit";
 import fastifyStatic from "@fastify/static";
@@ -138,6 +139,16 @@ function namePlugin<T extends FastifyPluginAsync>(name: string, fn: T): T {
   Object.defineProperty(fn, "name", { value: name, configurable: true });
   return fn;
 }
+
+// Response compression, scoped to the Context Tree snapshot endpoints only.
+// The snapshot payload (all nodes + edges + changes + writes) is large, highly
+// compressible JSON, and browser content-download was the second-largest chunk
+// of the context-tree page load. Registered inside an encapsulated child scope
+// per route (not global) so the rest of the API is untouched. Content-negotiated
+// and threshold-gated: small responses and clients without `Accept-Encoding`
+// are unaffected. @fastify/compress defaults brotli quality to 4, so it avoids
+// the slow zlib max-quality default.
+const CONTEXT_TREE_SNAPSHOT_COMPRESSION = { threshold: 1024 } as const;
 
 export async function buildApp(config: Config) {
   // Validate token-lifetime config eagerly so a typo in
@@ -503,7 +514,12 @@ export async function buildApp(config: Config) {
       await api.register(
         userScope("contextTreeScope", async (scope) => {
           await scope.register(contextTreeInfoRoutes);
-          await scope.register(contextTreeSnapshotRoutes);
+          await scope.register(
+            namePlugin("contextTreeSnapshotCompressedScope", async (snap) => {
+              await snap.register(compress, CONTEXT_TREE_SNAPSHOT_COMPRESSION);
+              await snap.register(contextTreeSnapshotRoutes);
+            }),
+          );
         }),
         { prefix: "/context-tree" },
       );
@@ -544,7 +560,13 @@ export async function buildApp(config: Config) {
           await scope.register(orgResourceRoutes, { prefix: "/resources" });
           await scope.register(orgGithubAppRoutes, { prefix: "/github-app-installation" });
           await scope.register(orgContextTreeRoutes, { prefix: "/context-tree" });
-          await scope.register(orgContextTreeSnapshotRoutes, { prefix: "/context-tree" });
+          await scope.register(
+            namePlugin("orgContextTreeSnapshotCompressedScope", async (treeSnap) => {
+              await treeSnap.register(compress, CONTEXT_TREE_SNAPSHOT_COMPRESSION);
+              await treeSnap.register(orgContextTreeSnapshotRoutes);
+            }),
+            { prefix: "/context-tree" },
+          );
           await scope.register(orgAttachmentRoutes, { prefix: "/attachments" });
         }),
         { prefix: "/orgs/:orgId" },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,6 +139,9 @@ importers:
       '@autotelic/fastify-opentelemetry':
         specifier: ^0.23.0
         version: 0.23.0(@opentelemetry/api@1.9.1)
+      '@fastify/compress':
+        specifier: ^9.0.0
+        version: 9.0.0
       '@fastify/cors':
         specifier: ^11.2.0
         version: 11.2.0
@@ -1077,6 +1080,9 @@ packages:
 
   '@fastify/ajv-compiler@4.0.5':
     resolution: {integrity: sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==}
+
+  '@fastify/compress@9.0.0':
+    resolution: {integrity: sha512-PZRg+ut5xd/ubsGPWfoPNryoCOtEdHboIWpDieTUHov1gKdLitF8mRmT3JbqNnRbelQXSNXUsIpakAEKR6AcTQ==}
 
   '@fastify/cors@11.2.0':
     resolution: {integrity: sha512-LbLHBuSAdGdSFZYTLVA3+Ch2t+sA6nq3Ejc6XLAKiQ6ViS2qFnvicpj0htsx03FyYeLs04HfRNBsz/a8SvbcUw==}
@@ -3185,6 +3191,9 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  duplexify@3.7.1:
+    resolution: {integrity: sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==}
+
   duplexify@4.1.3:
     resolution: {integrity: sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==}
 
@@ -3621,9 +3630,6 @@ packages:
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
-
-  jose@5.10.0:
-    resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
 
   jose@6.2.2:
     resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
@@ -4090,6 +4096,9 @@ packages:
   pathval@2.0.1:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
+
+  peek-stream@1.1.3:
+    resolution: {integrity: sha512-FhJ+YbOSBb9/rIl2ZeE/QHEsWn7PqNYt8ARAY3kIgNGOk13g9FGyIY6JIl/xB/3TFRVoTv5as0l11weORrTekA==}
 
   pg-cloudflare@1.3.0:
     resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
@@ -4622,6 +4631,9 @@ packages:
   thread-stream@4.0.0:
     resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
     engines: {node: '>=20'}
+
+  through2@2.0.5:
+    resolution: {integrity: sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -5466,6 +5478,15 @@ snapshots:
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       fast-uri: 3.1.0
+
+  '@fastify/compress@9.0.0':
+    dependencies:
+      '@fastify/accept-negotiator': 2.0.1
+      fastify-plugin: 5.1.0
+      mime-db: 1.54.0
+      minipass: 7.1.3
+      peek-stream: 1.1.3
+      readable-stream: 4.7.0
 
   '@fastify/cors@11.2.0':
     dependencies:
@@ -7037,7 +7058,7 @@ snapshots:
 
   '@types/pg@8.15.6':
     dependencies:
-      '@types/node': 22.19.15
+      '@types/node': 22.19.19
       pg-protocol: 1.13.0
       pg-types: 2.2.0
 
@@ -7641,6 +7662,13 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  duplexify@3.7.1:
+    dependencies:
+      end-of-stream: 1.4.5
+      inherits: 2.0.4
+      readable-stream: 2.3.8
+      stream-shift: 1.0.3
+
   duplexify@4.1.3:
     dependencies:
       end-of-stream: 1.4.5
@@ -8182,8 +8210,6 @@ snapshots:
       '@pkgjs/parseargs': 0.11.0
 
   jiti@2.6.1: {}
-
-  jose@5.10.0: {}
 
   jose@6.2.2: {}
 
@@ -8797,16 +8823,24 @@ snapshots:
 
   pathval@2.0.1: {}
 
+  peek-stream@1.1.3:
+    dependencies:
+      buffer-from: 1.1.2
+      duplexify: 3.7.1
+      through2: 2.0.5
+
   pg-cloudflare@1.3.0:
     optional: true
 
-  pg-connection-string@2.12.0: {}
+  pg-connection-string@2.12.0:
+    optional: true
 
   pg-int8@1.0.1: {}
 
   pg-pool@3.13.0(pg@8.20.0):
     dependencies:
       pg: 8.20.0
+    optional: true
 
   pg-protocol@1.13.0: {}
 
@@ -8827,10 +8861,12 @@ snapshots:
       pgpass: 1.0.5
     optionalDependencies:
       pg-cloudflare: 1.3.0
+    optional: true
 
   pgpass@1.0.5:
     dependencies:
       split2: 4.2.0
+    optional: true
 
   picocolors@1.1.1: {}
 
@@ -9501,6 +9537,11 @@ snapshots:
   thread-stream@4.0.0:
     dependencies:
       real-require: 0.2.0
+
+  through2@2.0.5:
+    dependencies:
+      readable-stream: 2.3.8
+      xtend: 4.0.2
 
   tinybench@2.9.0: {}
 


### PR DESCRIPTION
## What

Enables gzip/brotli response compression for the Context Tree snapshot endpoints (`GET /context-tree/snapshot`, both user- and org-scoped).

## Why

Profiling the slow context-tree **page** (not the CLI) with a real `Server-Timing` trace showed the load was ~3.08s = ~2.39s TTFB + **684ms content download**. The snapshot payload — all nodes + edges + changes + writes — is large, highly compressible JSON, and the server runs **no** response compression today: there's no `@fastify/compress` in deps or `app.ts`, and no in-repo reverse proxy that would add it. Content-download was the second-largest single chunk of the page load.

## How

- Add `@fastify/compress@^9` (Fastify 5 compatible).
- Register it **scoped to just the two snapshot routes** via encapsulated child scopes, so the rest of the API is untouched (minimal blast radius — the request that was asked about).
- Content-negotiated + threshold-gated (1 KB): small responses and clients without `Accept-Encoding` are unaffected. `@fastify/compress` defaults brotli quality to 4, avoiding the slow zlib max-quality default.

## Tests

`packages/server/src/__tests__/context-tree-snapshot-compression.test.ts` — route-level: asserts the snapshot response is `content-encoding: gzip` when the client accepts it, and left uncompressed otherwise (decoded body is still a valid, populated snapshot). Existing snapshot/timing/io suites pass (46 tests green locally).

## Notes / follow-ups

This addresses the content-download slice only. The larger find from the same trace was that **~1.7s of the 2.39s TTFB is in no Server-Timing span** (uninstrumented pre-handlers / serialization / DB), plus an uncached GitHub token mint (229ms) and a 305ms telemetry IO scan — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
