### PR TITLE
fix(web): match team preview search placeholder size to caption scale

### DIFF
--- a/packages/web/src/pages/team-preview.tsx
+++ b/packages/web/src/pages/team-preview.tsx
@@ -165,7 +165,7 @@ function PageHeaderBar({
             value={query}
             onChange={(e) => onQuery(e.target.value)}
             placeholder="Search name or @handle"
-            className="text-body"
+            className="text-caption"
             style={{ width: compact ? "100%" : "var(--sp-60)", paddingLeft: "var(--sp-7)" }}
           />
         </div>


### PR DESCRIPTION
## What

The "Search name or @handle" box on the **Team preview** page
(`team-preview.tsx`, the in-progress *Agent & Human teammates redesign*)
used `text-body` (12px) while the rest of that page — the subtitle and
the table rows — uses `text-caption` (10px). The placeholder therefore
rendered noticeably larger than the surrounding text.

This switches the preview search input to `text-caption`, matching the
canonical Team page search box in `team/index.tsx` (which already uses
`text-caption`) and the surrounding caption-sized text.

## Why a one-line change

The live Team page (`/team`, `team/index.tsx`) was already on
`text-caption`, so only the preview was inconsistent. `cn`'s extended
`font-size` group resolves the input to a single size, so this is the
only edit needed.

## Test

`packages/web/src/pages/__tests__/team-preview-dom.test.tsx` locates the
input by placeholder text only (no class assertion), so behaviour is
unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
