### PR TITLE
release: bump apps/cli to v0.5.11

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "first-tree-dev",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "type": "module",
   "description": "First Tree — unified CLI for Context Tree onboarding, agent management, and team messaging. (Source-tree dev build; CI rewrites `name` and `bin` for prod / staging publishes — see docs/local-dev-isolation.md.)",
   "keywords": [


### PR DESCRIPTION
## Summary

Release bump: `apps/cli` version `0.5.10` → `0.5.11`. Diff is the single `apps/cli/package.json` version field; package `name`, `bin`, `build-info.ts`, dist-tags, and the lockfile are untouched.

Promotes the changes merged to `main` since the `v0.5.10` tag (#1328). Prod `first-tree` is currently `0.5.10`; staging has been dogfooding `0.5.11-staging.*`.

## Draft GitHub Release

**Title:** `v0.5.11 — Value-first onboarding, proxy compatibility, self-service team leave`

```markdown
## Highlights

- Onboarding redesigned around value-first GitHub access, and the create-agent step is skipped when a member already has a personal agent (#1311, #1337).
- Self-service team leave from the workspace UI (#1290).
- Proxy compatibility without managing your proxy: the daemon now reads a user-owned `daemon.env` instead of baking a point-in-time snapshot into the service unit, ending the recurring `403 Request not allowed` egress freeze (#1335).
- `first-tree-welcome` skill is now demand-driven with first-task verification (#1341, #1344).

## Notable fixes

- Channel-correct `daemon.env` path, with inline-comment stripping, empty-value skipping, and tighter egress-vs-auth detection (#1339).
- Stop treating a flaky `codex --version` check as a missing binary (#1329).

## Internal

- Skill-eval tooling: deterministic grading, quality judge, result operations, and seed/read eval gates (#1327, #1331, #1332, #1333, #1338, #1343); removed the unmaintained `packages/e2e` harness (#1336).
```

## Verification performed

- `pnpm install --frozen-lockfile` — clean.
- `pnpm check` — exit 0 (only pre-existing CSS warnings, unrelated to this change).
- `pnpm typecheck` — 10/10 tasks pass; build emits `first-tree-dev@0.5.11`.
- Staging regression (this release's `0.5.11-staging.*`): runtime/CLI/channel layer PASS (proxy compat #1335, channel-aware `daemon.env` path #1339, codex detection #1329, runtime→chat delivery, bundle integrity); QA covered CLI/daemon/API/chat + public web entry. Authenticated web flows (#1311 post-login onboarding, #1337, #1290) were not browser-covered — release approved by maintainer with that scope understood.

## Post-merge steps

1. Wait for the merge-commit `CI` on `main` to pass (also check tag-triggered `npm Publish` / `Docker` once the tag is cut).
2. After maintainer confirms version / tag / target SHA / title / body, create lightweight tag + GitHub Release `v0.5.11` against the merge SHA.
3. Tag triggers `npm Publish` (Publish Command Prod) → verify `npm view first-tree version` == `0.5.11`.
4. Confirm tag-triggered `Docker` build → image `ghcr.io/agent-team-foundation/first-tree:0.5.11`.
5. Maintainer publishes on CapRover: https://captain.prod.unispark.dev/#/apps/details/first-tree
