### PR TITLE
fix: make skill eval fixture verify channel-aware

### DIFF
--- a/packages/skill-evals/README.md
+++ b/packages/skill-evals/README.md
@@ -110,6 +110,10 @@ The runner creates isolated temporary workspaces under
 `packages/skill-evals/.runs/<timestamp>-<case-id>/`, installs
 the relevant skill, prepends command shims such as `first-tree` to `PATH`, and
 runs `codex exec --json` from the case workspace for live eval commands.
+Fixture validation runs `tree verify` through the per-run `first-tree` shim by
+default. To validate fixtures with an installed channel binary instead, set
+`FIRST_TREE_EVAL_VERIFY_BIN` to the desired executable, for example
+`FIRST_TREE_EVAL_VERIFY_BIN=first-tree-staging`.
 Live gate runs do not inherit the operator's full environment. The Codex
 process receives an allowlisted environment plus an isolated `HOME`, temp
 directory, and XDG cache/config directories under the case run root. The model

--- a/packages/skill-evals/src/core/__tests__/fixture-verify.test.ts
+++ b/packages/skill-evals/src/core/__tests__/fixture-verify.test.ts
@@ -1,0 +1,119 @@
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { readEvents } from "../events.js";
+import { FIRST_TREE_EVAL_VERIFY_BIN, runFixtureVerify } from "../fixture-verify.js";
+import { createRunPaths } from "../paths.js";
+import { createEvalReporter } from "../reporter.js";
+
+function tempPackageRoot(): string {
+  return mkdtempSync(join(tmpdir(), "skill-evals-fixture-verify-test-"));
+}
+
+function writeExecutable(path: string, script: string): void {
+  writeFileSync(path, script, "utf8");
+  chmodSync(path, 0o755);
+}
+
+describe("fixture tree verify runner", () => {
+  it("uses the per-run first-tree shim by absolute path by default", () => {
+    const packageRoot = tempPackageRoot();
+    try {
+      const paths = createRunPaths({
+        caseId: "fixture-verify-shim-test",
+        packageRoot,
+        startedAt: "2026-06-29T00:00:00.000Z",
+      });
+      const shimPath = join(paths.binDir, "first-tree");
+      writeExecutable(
+        shimPath,
+        `#!/bin/sh
+printf 'harness shim verify\\n'
+exit 0
+`,
+      );
+
+      const result = runFixtureVerify({
+        caseId: "fixture-verify-shim-test",
+        contextTreePath: join(paths.workspacePath, "context-tree"),
+        paths,
+        reporter: createEvalReporter("fixture-verify-shim-test", false),
+        sourceEnv: { PATH: "" },
+        verbose: false,
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.command).toBe(shimPath);
+      expect(result.stdout).toContain("harness shim verify");
+      expect(readEvents(paths.eventsPath)).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            command: shimPath,
+            commandSource: "harness-shim",
+            type: "fixture_validation_started",
+          }),
+        ]),
+      );
+    } finally {
+      rmSync(packageRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("resolves an explicit channel verify binary without shadowing it with binDir shims", () => {
+    const packageRoot = tempPackageRoot();
+    try {
+      const paths = createRunPaths({
+        caseId: "fixture-verify-channel-test",
+        packageRoot,
+        startedAt: "2026-06-29T00:00:00.000Z",
+      });
+      const realBinDir = join(packageRoot, "real-bin");
+      mkdirSync(realBinDir, { recursive: true });
+      writeExecutable(
+        join(paths.binDir, "first-tree-staging"),
+        `#!/bin/sh
+printf 'shadowed staging shim\\n'
+exit 64
+`,
+      );
+      writeExecutable(
+        join(realBinDir, "first-tree-staging"),
+        `#!/bin/sh
+printf 'real staging verify\\n'
+exit 0
+`,
+      );
+
+      const result = runFixtureVerify({
+        caseId: "fixture-verify-channel-test",
+        contextTreePath: join(paths.workspacePath, "context-tree"),
+        paths,
+        reporter: createEvalReporter("fixture-verify-channel-test", false),
+        sourceEnv: {
+          [FIRST_TREE_EVAL_VERIFY_BIN]: "first-tree-staging",
+          PATH: realBinDir,
+        },
+        verbose: false,
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.command).toBe("first-tree-staging");
+      expect(result.stdout).toContain("real staging verify");
+      expect(result.stdout).not.toContain("shadowed staging shim");
+      expect(readEvents(paths.eventsPath)).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            command: "first-tree-staging",
+            commandSource: "eval-verify-bin",
+            type: "fixture_validation_finished",
+          }),
+        ]),
+      );
+    } finally {
+      rmSync(packageRoot, { force: true, recursive: true });
+    }
+  });
+});

--- a/packages/skill-evals/src/core/fixture-verify.ts
+++ b/packages/skill-evals/src/core/fixture-verify.ts
@@ -1,0 +1,123 @@
+import { spawnSync } from "node:child_process";
+import { delimiter, join } from "node:path";
+
+import { appendEvent, previewText } from "./events.js";
+import type { EvalReporter } from "./reporter.js";
+import { stripShimTraceLines } from "./reporter.js";
+import type { CommandResult, RunPaths } from "./types.js";
+
+export const FIRST_TREE_EVAL_VERIFY_BIN = "FIRST_TREE_EVAL_VERIFY_BIN";
+const FIRST_TREE_EVAL_REAL_FIRST_TREE = "FIRST_TREE_EVAL_REAL_FIRST_TREE";
+
+type FixtureVerifyCommand = {
+  command: string;
+  source: "eval-real-first-tree" | "eval-verify-bin" | "harness-shim";
+};
+
+export type RunFixtureVerifyOptions = {
+  caseId: string;
+  contextTreePath: string;
+  paths: RunPaths;
+  reporter: EvalReporter;
+  sourceEnv?: NodeJS.ProcessEnv;
+  verbose: boolean;
+};
+
+export function runFixtureVerify(options: RunFixtureVerifyOptions): CommandResult {
+  const { caseId, contextTreePath, paths, reporter, verbose } = options;
+  const sourceEnv = options.sourceEnv ?? process.env;
+  const args = ["tree", "verify", "--tree-path", contextTreePath];
+  const verifyCommand = resolveFixtureVerifyCommand(paths, sourceEnv);
+
+  appendEvent(paths.eventsPath, {
+    command: verifyCommand.command,
+    commandSource: verifyCommand.source,
+    contextTreePath,
+    type: "fixture_validation_started",
+  });
+  reporter.fixtureValidationStarted(args, contextTreePath);
+
+  const result = spawnSync(verifyCommand.command, args, {
+    cwd: paths.workspacePath,
+    encoding: "utf8",
+    env: fixtureVerifyEnv(paths, caseId, verbose, verifyCommand.source, sourceEnv),
+    maxBuffer: 20 * 1024 * 1024,
+  });
+  const stdout = result.stdout ?? "";
+  const rawStderr = result.stderr ?? "";
+  const stderrWithSpawnError = result.error
+    ? `${rawStderr}${rawStderr.length > 0 && !rawStderr.endsWith("\n") ? "\n" : ""}${result.error.message}`
+    : rawStderr;
+  reporter.shimTraceLines(stderrWithSpawnError);
+
+  const commandResult: CommandResult = {
+    args,
+    command: verifyCommand.command,
+    cwd: paths.workspacePath,
+    exitCode: result.status ?? 1,
+    stderr: stripShimTraceLines(stderrWithSpawnError),
+    stdout,
+  };
+
+  appendEvent(paths.eventsPath, {
+    command: commandResult.command,
+    commandSource: verifyCommand.source,
+    exitCode: commandResult.exitCode,
+    stderrPreview: previewText(commandResult.stderr),
+    stdoutPreview: previewText(commandResult.stdout),
+    type: "fixture_validation_finished",
+  });
+  reporter.fixtureValidationFinished(commandResult);
+
+  return commandResult;
+}
+
+function resolveFixtureVerifyCommand(paths: RunPaths, sourceEnv: NodeJS.ProcessEnv): FixtureVerifyCommand {
+  const verifyBin = cleanEnvValue(sourceEnv[FIRST_TREE_EVAL_VERIFY_BIN]);
+  if (verifyBin !== null) {
+    return {
+      command: verifyBin,
+      source: "eval-verify-bin",
+    };
+  }
+
+  const realFirstTree = cleanEnvValue(sourceEnv[FIRST_TREE_EVAL_REAL_FIRST_TREE]);
+  if (realFirstTree !== null) {
+    return {
+      command: realFirstTree,
+      source: "eval-real-first-tree",
+    };
+  }
+
+  return {
+    command: join(paths.binDir, "first-tree"),
+    source: "harness-shim",
+  };
+}
+
+function fixtureVerifyEnv(
+  paths: RunPaths,
+  caseId: string,
+  verbose: boolean,
+  commandSource: FixtureVerifyCommand["source"],
+  sourceEnv: NodeJS.ProcessEnv,
+): NodeJS.ProcessEnv {
+  const path = sourceEnv.PATH ?? "";
+  return {
+    ...sourceEnv,
+    FIRST_TREE_EVAL_CASE_ID: caseId,
+    FIRST_TREE_EVAL_EVENTS: paths.eventsPath,
+    FIRST_TREE_EVAL_PHASE: "fixture_validation",
+    FIRST_TREE_EVAL_VERBOSE: verbose ? "1" : "0",
+    PATH: commandSource === "harness-shim" ? prependPath(paths.binDir, path) : path,
+  };
+}
+
+function cleanEnvValue(value: string | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+function prependPath(entry: string, path: string): string {
+  return path ? `${entry}${delimiter}${path}` : entry;
+}

--- a/packages/skill-evals/src/suites/first-tree-read/fixture.ts
+++ b/packages/skill-evals/src/suites/first-tree-read/fixture.ts
@@ -1,11 +1,10 @@
-import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { join, relative } from "node:path";
 
 import { assertCommandOk, runCommand, writeText } from "../../core/commands.js";
 import { appendEvent, previewText } from "../../core/events.js";
+import { runFixtureVerify } from "../../core/fixture-verify.js";
 import type { EvalReporter } from "../../core/reporter.js";
-import { stripShimTraceLines } from "../../core/reporter.js";
 import { installRepoSkill, parseSkillDescription } from "../../core/skills/install.js";
 import type { CommandResult, RunPaths } from "../../core/types.js";
 import type { FirstTreeReadEvalCase, FixtureValidation } from "./types.js";
@@ -460,7 +459,7 @@ export function validateFixture(
     errors.push(`missing ${missing.reason}: ${missing.path}`);
   }
 
-  const verifyResult = runFixtureVerify(paths, contextTreePath, caseId, verbose, reporter);
+  const verifyResult = runFixtureVerify({ caseId, contextTreePath, paths, reporter, verbose });
   if (verifyResult.exitCode !== 0) {
     errors.push(
       `tree verify failed with exit ${verifyResult.exitCode}: ${previewText(verifyResult.stderr || verifyResult.stdout)}`,
@@ -475,56 +474,4 @@ export function validateFixture(
     requiredFilesOk,
     verifyResult,
   };
-}
-
-function runFixtureVerify(
-  paths: RunPaths,
-  contextTreePath: string,
-  caseId: string,
-  verbose: boolean,
-  reporter: EvalReporter,
-): CommandResult {
-  const args = ["tree", "verify", "--tree-path", contextTreePath];
-  appendEvent(paths.eventsPath, {
-    contextTreePath,
-    type: "fixture_validation_started",
-  });
-  reporter.fixtureValidationStarted(args, contextTreePath);
-
-  const env = {
-    ...process.env,
-    FIRST_TREE_EVAL_EVENTS: paths.eventsPath,
-    FIRST_TREE_EVAL_CASE_ID: caseId,
-    FIRST_TREE_EVAL_PHASE: "fixture_validation",
-    FIRST_TREE_EVAL_VERBOSE: verbose ? "1" : "0",
-    PATH: `${paths.binDir}:${process.env.PATH ?? ""}`,
-  };
-  const result = spawnSync("first-tree", args, {
-    cwd: paths.workspacePath,
-    encoding: "utf8",
-    env,
-    maxBuffer: 20 * 1024 * 1024,
-  });
-  const stdout = result.stdout ?? "";
-  const stderr = result.stderr ?? "";
-  reporter.shimTraceLines(stderr);
-
-  const commandResult: CommandResult = {
-    args,
-    command: "first-tree",
-    cwd: paths.workspacePath,
-    exitCode: result.status ?? 1,
-    stderr: stripShimTraceLines(stderr),
-    stdout,
-  };
-
-  appendEvent(paths.eventsPath, {
-    exitCode: commandResult.exitCode,
-    stderrPreview: previewText(commandResult.stderr),
-    stdoutPreview: previewText(commandResult.stdout),
-    type: "fixture_validation_finished",
-  });
-  reporter.fixtureValidationFinished(commandResult);
-
-  return commandResult;
 }

--- a/packages/skill-evals/src/suites/first-tree-welcome/fixture.ts
+++ b/packages/skill-evals/src/suites/first-tree-welcome/fixture.ts
@@ -1,13 +1,12 @@
-import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 
 import { assertCommandOk, runCommand, writeText } from "../../core/commands.js";
 import { appendEvent, previewText } from "../../core/events.js";
+import { runFixtureVerify } from "../../core/fixture-verify.js";
 import type { EvalReporter } from "../../core/reporter.js";
-import { stripShimTraceLines } from "../../core/reporter.js";
 import { installRepoSkill, parseSkillDescription } from "../../core/skills/install.js";
-import type { CommandResult, RunPaths } from "../../core/types.js";
+import type { RunPaths } from "../../core/types.js";
 import type { FirstTreeWelcomeEvalCase, FixtureValidation } from "./types.js";
 
 const SKILL_NAME = "first-tree-welcome";
@@ -302,7 +301,7 @@ export function validateFixture(
     errors.push(`missing required file: ${missing}`);
   }
 
-  const verifyResult = runFixtureVerify(paths, contextTreePath, caseId, verbose, reporter);
+  const verifyResult = runFixtureVerify({ caseId, contextTreePath, paths, reporter, verbose });
   if (verifyResult.exitCode !== 0) {
     errors.push(
       `tree verify failed with exit ${verifyResult.exitCode}: ${previewText(verifyResult.stderr || verifyResult.stdout)}`,
@@ -315,56 +314,4 @@ export function validateFixture(
     ok: errors.length === 0,
     requiredFilesOk: missingFiles.length === 0,
   };
-}
-
-function runFixtureVerify(
-  paths: RunPaths,
-  contextTreePath: string,
-  caseId: string,
-  verbose: boolean,
-  reporter: EvalReporter,
-): CommandResult {
-  const args = ["tree", "verify", "--tree-path", contextTreePath];
-  appendEvent(paths.eventsPath, {
-    contextTreePath,
-    type: "fixture_validation_started",
-  });
-  reporter.fixtureValidationStarted(args, contextTreePath);
-
-  const env = {
-    ...process.env,
-    FIRST_TREE_EVAL_EVENTS: paths.eventsPath,
-    FIRST_TREE_EVAL_CASE_ID: caseId,
-    FIRST_TREE_EVAL_PHASE: "fixture_validation",
-    FIRST_TREE_EVAL_VERBOSE: verbose ? "1" : "0",
-    PATH: `${paths.binDir}:${process.env.PATH ?? ""}`,
-  };
-  const result = spawnSync("first-tree", args, {
-    cwd: paths.workspacePath,
-    encoding: "utf8",
-    env,
-    maxBuffer: 20 * 1024 * 1024,
-  });
-  const stdout = result.stdout ?? "";
-  const stderr = result.stderr ?? "";
-  reporter.shimTraceLines(stderr);
-
-  const commandResult: CommandResult = {
-    args,
-    command: "first-tree",
-    cwd: paths.workspacePath,
-    exitCode: result.status ?? 1,
-    stderr: stripShimTraceLines(stderr),
-    stdout,
-  };
-
-  appendEvent(paths.eventsPath, {
-    exitCode: commandResult.exitCode,
-    stderrPreview: previewText(commandResult.stderr),
-    stdoutPreview: previewText(commandResult.stdout),
-    type: "fixture_validation_finished",
-  });
-  reporter.fixtureValidationFinished(commandResult);
-
-  return commandResult;
 }

--- a/packages/skill-evals/src/suites/first-tree-write/fixture.ts
+++ b/packages/skill-evals/src/suites/first-tree-write/fixture.ts
@@ -1,11 +1,10 @@
-import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 
 import { assertCommandOk, runCommand, writeText } from "../../core/commands.js";
 import { appendEvent, previewText } from "../../core/events.js";
+import { runFixtureVerify } from "../../core/fixture-verify.js";
 import type { EvalReporter } from "../../core/reporter.js";
-import { stripShimTraceLines } from "../../core/reporter.js";
 import { installRepoSkill, parseSkillDescription } from "../../core/skills/install.js";
 import type { CommandResult, RunPaths } from "../../core/types.js";
 import type { FirstTreeWriteEvalCase, FixtureValidation } from "./types.js";
@@ -309,7 +308,7 @@ export function validateFixture(
     errors.push(`missing required file: ${missing}`);
   }
 
-  const verifyResult = runFixtureVerify(paths, contextTreePath, caseId, verbose, reporter);
+  const verifyResult = runFixtureVerify({ caseId, contextTreePath, paths, reporter, verbose });
   if (verifyResult.exitCode !== 0) {
     errors.push(
       `tree verify failed with exit ${verifyResult.exitCode}: ${previewText(verifyResult.stderr || verifyResult.stdout)}`,
@@ -322,56 +321,4 @@ export function validateFixture(
     requiredFilesOk: missingFiles.length === 0,
     verifyResult,
   };
-}
-
-function runFixtureVerify(
-  paths: RunPaths,
-  contextTreePath: string,
-  caseId: string,
-  verbose: boolean,
-  reporter: EvalReporter,
-): CommandResult {
-  const args = ["tree", "verify", "--tree-path", contextTreePath];
-  appendEvent(paths.eventsPath, {
-    contextTreePath,
-    type: "fixture_validation_started",
-  });
-  reporter.fixtureValidationStarted(args, contextTreePath);
-
-  const env = {
-    ...process.env,
-    FIRST_TREE_EVAL_EVENTS: paths.eventsPath,
-    FIRST_TREE_EVAL_CASE_ID: caseId,
-    FIRST_TREE_EVAL_PHASE: "fixture_validation",
-    FIRST_TREE_EVAL_VERBOSE: verbose ? "1" : "0",
-    PATH: `${paths.binDir}:${process.env.PATH ?? ""}`,
-  };
-  const result = spawnSync("first-tree", args, {
-    cwd: paths.workspacePath,
-    encoding: "utf8",
-    env,
-    maxBuffer: 20 * 1024 * 1024,
-  });
-  const stdout = result.stdout ?? "";
-  const stderr = result.stderr ?? "";
-  reporter.shimTraceLines(stderr);
-
-  const commandResult: CommandResult = {
-    args,
-    command: "first-tree",
-    cwd: paths.workspacePath,
-    exitCode: result.status ?? 1,
-    stderr: stripShimTraceLines(stderr),
-    stdout,
-  };
-
-  appendEvent(paths.eventsPath, {
-    exitCode: commandResult.exitCode,
-    stderrPreview: previewText(commandResult.stderr),
-    stdoutPreview: previewText(commandResult.stdout),
-    type: "fixture_validation_finished",
-  });
-  reporter.fixtureValidationFinished(commandResult);
-
-  return commandResult;
 }


### PR DESCRIPTION
## Summary

- Move fixture `tree verify` execution into a shared skill-evals helper.
- Run the default verify command through the per-run `first-tree` shim by absolute path instead of a bare PATH lookup.
- Add `FIRST_TREE_EVAL_VERIFY_BIN` for installed channel binaries such as `first-tree-staging`, while preserving `FIRST_TREE_EVAL_REAL_FIRST_TREE` support.
- Reuse the helper across `first-tree-read`, `first-tree-write`, and `first-tree-welcome`, and document the override.

Closes #1342.

## Validation

- `pnpm --filter @first-tree/skill-evals test`
- `pnpm --filter @first-tree/skill-evals typecheck`
- `pnpm --filter @first-tree/skill-evals eval:floor`
- `pnpm check` (passed; existing unrelated Biome warnings remain in `packages/client/src/__tests__/assistant-text.test.ts`, `packages/client/src/runtime/workspace-migrations.ts`, and `packages/web/src/index.css`)
- `pnpm typecheck`
- `pnpm test` (failed during full turbo parallel run due 4 unrelated `first-tree-dev` 5s test timeouts)
- `pnpm --filter first-tree-dev test -- src/__tests__/agent-lifecycle-commands-extra.test.ts src/__tests__/chat-send-escaped-newline-stderr.test.ts src/__tests__/chat-send-message-file.test.ts src/__tests__/migrate-agent-dirs-extra.test.ts` (passed; this package run executed the CLI suite and the timed-out tests passed)
