### PR TITLE
Add skill eval result ops

### DIFF
--- a/packages/skill-evals/README.md
+++ b/packages/skill-evals/README.md
@@ -11,12 +11,14 @@ pnpm --filter @first-tree/skill-evals eval:floor
 pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-read
 pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-read --case tree-software-trigger
 pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-write
+pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-write --include-quality
 pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-welcome
 pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-seed
 pnpm --filter @first-tree/skill-evals eval:quality
 pnpm --filter @first-tree/skill-evals eval:quality -- --suite first-tree-write
 pnpm --filter @first-tree/skill-evals eval:quality -- --suite first-tree-welcome --judge-model <model>
 pnpm --filter @first-tree/skill-evals eval:select -- --base main
+pnpm --filter @first-tree/skill-evals eval:summary
 pnpm --filter @first-tree/skill-evals eval:compare
 ```
 
@@ -43,9 +45,13 @@ implemented. The command only recommends; live gate and quality evals remain
 opt-in and are not part of `pnpm test`.
 
 `eval:quality` is an opt-in LLM-as-judge layer. It does not replace
-deterministic gates and is not called by `eval:gate`. Each quality case first
-runs the corresponding live gate case and requires that deterministic gate to
-pass; only then does it send the actual produced artifact to the judge. The
+deterministic gates and is not called by `eval:gate` by default. Each quality
+case first runs the corresponding live gate case and requires that deterministic
+gate to pass; only then does it send the actual produced artifact to the judge.
+For write and welcome gates, `eval:gate -- --include-quality` runs the
+deterministic gate first and then reuses that same gate artifact for the
+supported quality case. If the deterministic gate fails, the judge is not run.
+`--include-quality` is intentionally rejected for read and seed suites. The
 first quality cases judge:
 
 - `first-tree-write` node quality from the actual `durable-source-writes` tree
@@ -131,9 +137,25 @@ The top-level `eval:floor`, `eval:gate`, and `eval:quality` commands also append
 a lightweight local result-store entry to
 `packages/skill-evals/.runs/index.jsonl`. Entries record the run group, suite,
 tier, case, pass/fail state, git branch/sha, model/provider where available,
-artifact paths, duration, cost, and judge scores when present. Gate failures use
-the deterministic grading evidence first and link the `grading.json` artifact
-path in the result store. The `.runs` directory is gitignored local eval state.
+artifact paths, duration, turns and first-response latency when derivable, cost,
+and judge scores when present. Gate failures use the deterministic grading
+evidence first and link the `grading.json` artifact path in the result store.
+Unknown turn or latency values are recorded as `null`. The `.runs` directory is
+gitignored local eval state.
+
+Use `eval:summary` to summarize the latest result-store run group, or pass a
+specific run group id:
+
+```bash
+pnpm --filter @first-tree/skill-evals eval:summary
+pnpm --filter @first-tree/skill-evals eval:summary -- --json
+pnpm --filter @first-tree/skill-evals eval:summary -- --current <run-group-id>
+```
+
+The summary is read-only. It reports pass/fail counts, failures, artifact
+paths, derived turns and first-response latency, and a lightweight flaky status:
+either "not enough comparable history", "stable", or status flips based on the
+previous comparable run group.
 
 Use `eval:compare` to compare the latest result-store run group with the
 previous one:

--- a/packages/skill-evals/package.json
+++ b/packages/skill-evals/package.json
@@ -9,6 +9,7 @@
     "eval:gate": "tsx src/index.ts gate",
     "eval:quality": "tsx src/index.ts quality",
     "eval:select": "tsx src/index.ts select",
+    "eval:summary": "tsx src/index.ts summary",
     "eval:compare": "tsx src/index.ts compare",
     "eval:first-tree-read": "tsx src/first-tree-read/index.ts",
     "test": "vitest run --passWithNoTests",

--- a/packages/skill-evals/src/core/__tests__/gate-exit.test.ts
+++ b/packages/skill-evals/src/core/__tests__/gate-exit.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { gateCommandFailed } from "../gate-exit.js";
+
+describe("gate command exit behavior", () => {
+  it.each(["first-tree-write", "first-tree-welcome"])("keeps default %s gate success when quality is omitted", () => {
+    expect(gateCommandFailed({ failed: 0 }, null)).toBe(false);
+  });
+
+  it("fails when deterministic gate fails", () => {
+    expect(gateCommandFailed({ failed: 1 }, null)).toBe(true);
+  });
+
+  it("fails when included quality is skipped or fails", () => {
+    expect(
+      gateCommandFailed(
+        { failed: 0 },
+        {
+          batch: null,
+          skippedReason: "quality was not run because deterministic gate failed",
+        },
+      ),
+    ).toBe(true);
+    expect(
+      gateCommandFailed(
+        { failed: 0 },
+        {
+          batch: { failed: 1 },
+          skippedReason: null,
+        },
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/skill-evals/src/core/__tests__/judge.test.ts
+++ b/packages/skill-evals/src/core/__tests__/judge.test.ts
@@ -4,6 +4,14 @@ import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
+import {
+  FIRST_TREE_WELCOME_QUALITY_DEFINITION,
+  FIRST_TREE_WELCOME_QUALITY_SANITY_FIXTURES,
+} from "../../suites/first-tree-welcome/quality.js";
+import {
+  FIRST_TREE_WRITE_QUALITY_DEFINITION,
+  FIRST_TREE_WRITE_QUALITY_SANITY_FIXTURES,
+} from "../../suites/first-tree-write/quality.js";
 import { runQualityEval } from "../../suites/quality/runner.js";
 import type { QualityArtifactInput } from "../../suites/quality/types.js";
 import { codexJudgeArgs, codexJudgeEnv } from "../judge/codex.js";
@@ -274,6 +282,36 @@ describe("quality runner with fake judge", () => {
       expect(batch.cases[0]?.failures[0]).toMatch(/deterministic gate durable-source-writes failed/u);
     } finally {
       rmSync(packageRoot, { force: true, recursive: true });
+    }
+  });
+});
+
+describe("quality rubric sanity fixtures", () => {
+  it("keeps first-tree-write good, borderline, and bad fixtures aligned with thresholds", () => {
+    for (const fixture of FIRST_TREE_WRITE_QUALITY_SANITY_FIXTURES) {
+      const prompt = FIRST_TREE_WRITE_QUALITY_DEFINITION.buildJudgePrompt(fixture.input);
+      const evaluation = evaluateJudgeOutput(
+        parseJudgeJson(fixture.judgeOutput, FIRST_TREE_WRITE_QUALITY_DEFINITION.dimensions),
+        FIRST_TREE_WRITE_QUALITY_DEFINITION.dimensions,
+      );
+
+      expect(prompt).toContain(fixture.input.artifact);
+      expect(prompt).toContain(fixture.input.source);
+      expect(evaluation.passed, fixture.name).toBe(fixture.expectedPassed);
+    }
+  });
+
+  it("keeps first-tree-welcome good, borderline, and bad fixtures aligned with thresholds", () => {
+    for (const fixture of FIRST_TREE_WELCOME_QUALITY_SANITY_FIXTURES) {
+      const prompt = FIRST_TREE_WELCOME_QUALITY_DEFINITION.buildJudgePrompt(fixture.input);
+      const evaluation = evaluateJudgeOutput(
+        parseJudgeJson(fixture.judgeOutput, FIRST_TREE_WELCOME_QUALITY_DEFINITION.dimensions),
+        FIRST_TREE_WELCOME_QUALITY_DEFINITION.dimensions,
+      );
+
+      expect(prompt).toContain(fixture.input.artifact);
+      expect(prompt).toContain(fixture.input.source);
+      expect(evaluation.passed, fixture.name).toBe(fixture.expectedPassed);
     }
   });
 });

--- a/packages/skill-evals/src/core/__tests__/observability.test.ts
+++ b/packages/skill-evals/src/core/__tests__/observability.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { deriveRunObservability } from "../observability.js";
+
+describe("run observability", () => {
+  it("derives turns and first response latency from assistant codex events", () => {
+    const observability = deriveRunObservability([
+      {
+        timestamp: "2026-06-29T01:00:00.000Z",
+        type: "codex_run_started",
+      },
+      {
+        event: {
+          content: "I will inspect the repo.",
+          type: "agent_message",
+        },
+        timestamp: "2026-06-29T01:00:01.250Z",
+        type: "codex_event",
+      },
+      {
+        event: {
+          item: {
+            role: "assistant",
+          },
+          text: "Final response.",
+          type: "message",
+        },
+        timestamp: "2026-06-29T01:00:05.000Z",
+        type: "codex_event",
+      },
+    ]);
+
+    expect(observability).toEqual({
+      firstResponseLatencyMs: 1250,
+      turns: 2,
+    });
+  });
+
+  it("returns nulls when no assistant response event is derivable", () => {
+    expect(
+      deriveRunObservability([
+        {
+          timestamp: "2026-06-29T01:00:00.000Z",
+          type: "codex_run_started",
+        },
+        {
+          event: {
+            type: "exec_command",
+          },
+          timestamp: "2026-06-29T01:00:01.000Z",
+          type: "codex_event",
+        },
+      ]),
+    ).toEqual({
+      firstResponseLatencyMs: null,
+      turns: null,
+    });
+  });
+});

--- a/packages/skill-evals/src/core/__tests__/result-store.test.ts
+++ b/packages/skill-evals/src/core/__tests__/result-store.test.ts
@@ -8,10 +8,12 @@ import {
   appendResultStoreEntries,
   compareResultGroups,
   createRunGroupId,
+  formatResultRunSummary,
   groupResultEntries,
   latestRunGroups,
   type ResultStoreEntry,
   readResultStore,
+  summarizeResultRunGroup,
 } from "../result-store.js";
 
 function tempPackageRoot(): string {
@@ -30,6 +32,7 @@ function entry(overrides: Partial<ResultStoreEntry> = {}): ResultStoreEntry {
     command: "eval:gate",
     costUsd: null,
     durationMs: null,
+    firstResponseLatencyMs: null,
     failures: [],
     git: {
       base: null,
@@ -136,5 +139,88 @@ describe("result store", () => {
     expect(createRunGroupId("2026-06-29T02:00:00.000Z", "eval:gate first-tree-write")).toBe(
       "20260629T020000000Z-eval-gate-first-tree-write",
     );
+  });
+
+  it("summarizes the latest run group with observability and lightweight flaky status", () => {
+    const previous = entry({
+      runGroupId: "20260629T010000000Z-eval-gate",
+      startedAt: "2026-06-29T01:00:00.000Z",
+    });
+    const currentFailure = entry({
+      durationMs: 1200,
+      failures: ["outcome_pass: expected response missing"],
+      firstResponseLatencyMs: 350,
+      passed: false,
+      runGroupId: "20260629T020000000Z-eval-gate",
+      startedAt: "2026-06-29T02:00:00.000Z",
+      status: "failed",
+      turns: 1,
+    });
+    const currentQuality = entry({
+      artifact: {
+        gradingJsonPath: null,
+        runRoot: "/tmp/quality-run",
+        summaryJsonPath: "/tmp/quality-run/summary.json",
+        summaryMdPath: "/tmp/quality-run/summary.md",
+      },
+      caseId: "first-tree-welcome-first-task-quality",
+      command: "eval:quality",
+      durationMs: 200,
+      judgeScores: {
+        bounded: 4,
+        useful: 3,
+      },
+      passed: true,
+      runGroupId: "20260629T020000000Z-eval-gate",
+      skill: "first-tree-welcome",
+      startedAt: "2026-06-29T02:00:01.000Z",
+      tier: "quality",
+    });
+
+    const summary = summarizeResultRunGroup([previous, currentFailure, currentQuality], null);
+
+    expect(summary?.runGroupId).toBe("20260629T020000000Z-eval-gate");
+    expect(summary?.failed).toBe(1);
+    expect(summary?.totalDurationMs).toBe(1400);
+    expect(summary?.turns).toBe(1);
+    expect(summary?.firstResponseLatencyMs).toBe(350);
+    expect(summary?.git).toEqual({
+      base: null,
+      branch: "feat/test",
+      sha: "abc123",
+    });
+    expect(summary?.countsByCommand).toEqual({
+      "eval:gate": 1,
+      "eval:quality": 1,
+    });
+    expect(summary?.countsBySkill).toEqual({
+      "first-tree-welcome": 1,
+      "first-tree-write": 1,
+    });
+    expect(summary?.countsByTier).toEqual({
+      gate: 1,
+      quality: 1,
+    });
+    expect(summary?.entries.find((candidate) => candidate.tier === "quality")?.judgeScores).toEqual({
+      bounded: 4,
+      useful: 3,
+    });
+    expect(summary?.flaky).toMatchObject({
+      newFailures: 1,
+      previousRunGroupId: "20260629T010000000Z-eval-gate",
+      status: "status-flips",
+    });
+    const formatted = formatResultRunSummary(summary);
+    expect(formatted).toContain("Git: branch=feat/test sha=abc123 base=n/a");
+    expect(formatted).toContain("Counts by command: eval:gate=1, eval:quality=1");
+    expect(formatted).toContain("Counts by tier: gate=1, quality=1");
+    expect(formatted).toContain("Counts by skill: first-tree-welcome=1, first-tree-write=1");
+    expect(formatted).toContain("First response latency: 350 ms");
+    expect(formatted).toContain("judge_scores: bounded=4, useful=3");
+  });
+
+  it("returns null when there are no result-store run groups to summarize", () => {
+    expect(summarizeResultRunGroup([], null)).toBeNull();
+    expect(formatResultRunSummary(null)).toContain("No result-store run groups found.");
   });
 });

--- a/packages/skill-evals/src/core/gate-exit.ts
+++ b/packages/skill-evals/src/core/gate-exit.ts
@@ -1,0 +1,14 @@
+export type GateExitBatch = {
+  failed: number;
+};
+
+export type IncludedQualityExitResult = {
+  batch: GateExitBatch | null;
+  skippedReason: string | null;
+};
+
+export function gateCommandFailed(gate: GateExitBatch, quality: IncludedQualityExitResult | null): boolean {
+  if (gate.failed > 0) return true;
+  if (quality === null) return false;
+  return (quality.batch?.failed ?? 0) > 0 || quality.skippedReason !== null;
+}

--- a/packages/skill-evals/src/core/observability.ts
+++ b/packages/skill-evals/src/core/observability.ts
@@ -1,0 +1,80 @@
+import { isRecord } from "./events.js";
+
+export type RunObservability = {
+  firstResponseLatencyMs: number | null;
+  turns: number | null;
+};
+
+function isNumber(value: number | null): value is number {
+  return value !== null;
+}
+
+function timestampMs(value: unknown): number | null {
+  if (!isRecord(value) || typeof value.timestamp !== "string") return null;
+  const ms = Date.parse(value.timestamp);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+function nestedCodexEvent(value: unknown): unknown {
+  if (!isRecord(value) || value.type !== "codex_event") return value;
+  return value.event;
+}
+
+function eventType(value: unknown): string | null {
+  if (!isRecord(value) || typeof value.type !== "string") return null;
+  return value.type;
+}
+
+function roleValue(value: unknown): string | null {
+  if (!isRecord(value)) return null;
+  const direct = value.role;
+  if (typeof direct === "string") return direct;
+  const item = value.item;
+  if (isRecord(item) && typeof item.role === "string") return item.role;
+  const message = value.message;
+  if (isRecord(message) && typeof message.role === "string") return message.role;
+  return null;
+}
+
+function hasTextPayload(value: unknown): boolean {
+  if (typeof value === "string") return value.trim().length > 0;
+  if (Array.isArray(value)) return value.some((item) => hasTextPayload(item));
+  if (!isRecord(value)) return false;
+
+  for (const [key, item] of Object.entries(value)) {
+    if ((key === "content" || key === "message" || key === "text" || key === "output") && hasTextPayload(item)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isAssistantResponseEvent(value: unknown): boolean {
+  const event = nestedCodexEvent(value);
+  const type = eventType(event);
+  const role = roleValue(event);
+  if (role === "assistant" && hasTextPayload(event)) return true;
+  if (type === null) return false;
+  if (/tool|function|command|exec|stderr|stdout|error|reasoning/iu.test(type)) return false;
+  return (
+    (type === "agent_message" ||
+      type === "assistant_message" ||
+      type === "final" ||
+      type === "response.completed" ||
+      type === "turn.completed") &&
+    hasTextPayload(event)
+  );
+}
+
+export function deriveRunObservability(events: readonly unknown[]): RunObservability {
+  const runStartedAt = events.find((event) => isRecord(event) && event.type === "codex_run_started") ?? null;
+  const startedAtMs = timestampMs(runStartedAt);
+  const responseTimes = events.filter(isAssistantResponseEvent).map(timestampMs).filter(isNumber);
+  const firstResponseAtMs = responseTimes[0] ?? null;
+
+  return {
+    firstResponseLatencyMs:
+      startedAtMs === null || firstResponseAtMs === null ? null : Math.max(0, firstResponseAtMs - startedAtMs),
+    turns: responseTimes.length === 0 ? null : responseTimes.length,
+  };
+}

--- a/packages/skill-evals/src/core/result-store.ts
+++ b/packages/skill-evals/src/core/result-store.ts
@@ -28,6 +28,7 @@ export type ResultStoreEntry = {
   command: ResultStoreCommand;
   costUsd: number | null;
   durationMs: number | null;
+  firstResponseLatencyMs: number | null;
   failures: readonly string[];
   git: ResultStoreGitInfo;
   judgeScores: Record<string, number> | null;
@@ -67,6 +68,54 @@ export type ResultCompareSummary = {
   stillFailing: readonly CompareEntryDelta[];
   stillPassing: readonly CompareEntryDelta[];
   unchangedOrNewPassing: readonly CompareEntryDelta[];
+};
+
+export type ResultRunFailure = {
+  artifactPath: string | null;
+  caseKey: string;
+  failures: readonly string[];
+};
+
+export type ResultRunFlakySummary = {
+  newFailures: number;
+  previousRunGroupId: string | null;
+  recovered: number;
+  status: "not-enough-history" | "stable" | "status-flips";
+};
+
+export type ResultRunEntrySummary = {
+  artifactPath: string | null;
+  caseKey: string;
+  command: ResultStoreCommand;
+  durationMs: number | null;
+  failures: readonly string[];
+  firstResponseLatencyMs: number | null;
+  git: ResultStoreGitInfo;
+  judgeScores: Record<string, number> | null;
+  passed: boolean;
+  skill: ShippedSkillName | "framework";
+  status: ResultStoreStatus;
+  tier: SkillEvalTier;
+  turns: number | null;
+};
+
+export type ResultRunSummary = {
+  countsByCommand: Record<string, number>;
+  countsBySkill: Record<string, number>;
+  countsByTier: Record<string, number>;
+  entries: readonly ResultRunEntrySummary[];
+  failed: number;
+  failures: readonly ResultRunFailure[];
+  firstResponseLatencyMs: number | null;
+  flaky: ResultRunFlakySummary;
+  git: ResultStoreGitInfo | null;
+  passed: number;
+  runGroupId: string;
+  skipped: number;
+  startedAt: string;
+  total: number;
+  totalDurationMs: number | null;
+  turns: number | null;
 };
 
 export function resultStorePath(packageRoot: string): string {
@@ -267,6 +316,202 @@ export function latestRunGroups(
 function groupsHaveSharedCaseKeys(left: ResultStoreRunGroup, right: ResultStoreRunGroup): boolean {
   const rightKeys = new Set(right.entries.map(caseKey));
   return left.entries.some((entry) => rightKeys.has(caseKey(entry)));
+}
+
+function artifactPath(entry: ResultStoreEntry): string | null {
+  return entry.artifact.gradingJsonPath ?? entry.artifact.summaryJsonPath ?? entry.artifact.runRoot;
+}
+
+function sumKnown(values: readonly (number | null | undefined)[]): number | null {
+  const known = values.filter((value) => typeof value === "number");
+  if (known.length === 0) return null;
+  return known.reduce((total, value) => total + value, 0);
+}
+
+function minKnown(values: readonly (number | null | undefined)[]): number | null {
+  const known = values.filter((value) => typeof value === "number");
+  if (known.length === 0) return null;
+  return Math.min(...known);
+}
+
+function countBy(
+  entries: readonly ResultStoreEntry[],
+  keyFor: (entry: ResultStoreEntry) => string,
+): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const entry of entries) {
+    const key = keyFor(entry);
+    counts[key] = (counts[key] ?? 0) + 1;
+  }
+  return Object.fromEntries(Object.entries(counts).sort(([left], [right]) => left.localeCompare(right)));
+}
+
+function previousComparableGroup(
+  current: ResultStoreRunGroup,
+  groups: readonly ResultStoreRunGroup[],
+): ResultStoreRunGroup | null {
+  return (
+    groups
+      .filter((group) => group.runGroupId !== current.runGroupId)
+      .filter((group) => group.startedAt < current.startedAt)
+      .filter((group) => groupsHaveSharedCaseKeys(current, group))
+      .at(-1) ?? null
+  );
+}
+
+export function summarizeResultRunGroup(
+  entries: readonly ResultStoreEntry[],
+  currentRunGroupId: string | null,
+): ResultRunSummary | null {
+  const groups = groupResultEntries(entries);
+  const current =
+    currentRunGroupId === null
+      ? (groups.at(-1) ?? null)
+      : (groups.find((group) => group.runGroupId === currentRunGroupId) ?? null);
+  if (current === null) return null;
+
+  const previous = previousComparableGroup(current, groups);
+  const comparison = compareResultGroups(current, previous);
+  const passed = current.entries.filter((entry) => entry.status === "passed").length;
+  const failed = current.entries.filter((entry) => entry.status === "failed").length;
+  const skipped = current.entries.filter((entry) => entry.status === "skipped").length;
+  const firstResponseLatencyMs = minKnown(current.entries.map((entry) => entry.firstResponseLatencyMs));
+  const turns = sumKnown(current.entries.map((entry) => entry.turns));
+
+  return {
+    countsByCommand: countBy(current.entries, (entry) => entry.command),
+    countsBySkill: countBy(current.entries, (entry) => entry.skill),
+    countsByTier: countBy(current.entries, (entry) => entry.tier),
+    entries: current.entries.map((entry) => ({
+      artifactPath: artifactPath(entry),
+      caseKey: caseKey(entry),
+      command: entry.command,
+      durationMs: entry.durationMs,
+      failures: entry.failures,
+      firstResponseLatencyMs: entry.firstResponseLatencyMs ?? null,
+      git: entry.git,
+      judgeScores: entry.judgeScores,
+      passed: entry.passed,
+      skill: entry.skill,
+      status: entry.status,
+      tier: entry.tier,
+      turns: entry.turns ?? null,
+    })),
+    failed,
+    failures: current.entries
+      .filter((entry) => entry.failures.length > 0)
+      .map((entry) => ({
+        artifactPath: artifactPath(entry),
+        caseKey: caseKey(entry),
+        failures: entry.failures,
+      })),
+    firstResponseLatencyMs,
+    flaky: {
+      newFailures: comparison.newFailures.length,
+      previousRunGroupId: previous?.runGroupId ?? null,
+      recovered: comparison.recovered.length,
+      status:
+        previous === null
+          ? "not-enough-history"
+          : comparison.newFailures.length + comparison.recovered.length > 0
+            ? "status-flips"
+            : "stable",
+    },
+    git: current.entries[0]?.git ?? null,
+    passed,
+    runGroupId: current.runGroupId,
+    skipped,
+    startedAt: current.startedAt,
+    total: current.entries.length,
+    totalDurationMs: sumKnown(current.entries.map((entry) => entry.durationMs)),
+    turns,
+  };
+}
+
+function formatNullableMs(value: number | null): string {
+  return value === null ? "n/a" : `${value} ms`;
+}
+
+function formatNullableNumber(value: number | null): string {
+  return value === null ? "n/a" : String(value);
+}
+
+function formatNullableText(value: string | null): string {
+  return value === null ? "n/a" : value;
+}
+
+function formatCountMap(counts: Record<string, number>): string {
+  const entries = Object.entries(counts);
+  if (entries.length === 0) return "none";
+  return entries.map(([key, value]) => `${key}=${value}`).join(", ");
+}
+
+function formatJudgeScores(scores: Record<string, number> | null): string | null {
+  if (scores === null) return null;
+  return Object.entries(scores)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, value]) => `${key}=${value}`)
+    .join(", ");
+}
+
+function formatFlaky(summary: ResultRunFlakySummary): string {
+  if (summary.status === "not-enough-history") {
+    return "not enough comparable history";
+  }
+  const prefix = summary.status === "stable" ? "stable" : "status flips";
+  return `${prefix} vs ${summary.previousRunGroupId}: new_failures=${summary.newFailures}, recovered=${summary.recovered}`;
+}
+
+export function formatResultRunSummary(summary: ResultRunSummary | null): string {
+  if (summary === null) {
+    return ["Skill Eval Summary", "", "No result-store run groups found."].join("\n");
+  }
+
+  const failureLines =
+    summary.failures.length === 0
+      ? ["Failures: 0"]
+      : [
+          `Failures: ${summary.failures.length}`,
+          ...summary.failures.flatMap((failure) => [
+            `- ${failure.caseKey}: ${failure.failures.join("; ")}`,
+            ...(failure.artifactPath === null ? [] : [`  artifact: ${failure.artifactPath}`]),
+          ]),
+        ];
+  const entryLines = summary.entries.flatMap((entry) => {
+    const artifact = entry.artifactPath === null ? "" : ` artifact=${entry.artifactPath}`;
+    const scores = formatJudgeScores(entry.judgeScores);
+    return [
+      `- ${entry.status.toUpperCase()} ${entry.caseKey} command=${entry.command} tier=${entry.tier} skill=${
+        entry.skill
+      } duration_ms=${formatNullableNumber(entry.durationMs)} turns=${formatNullableNumber(
+        entry.turns,
+      )} first_response_latency_ms=${formatNullableNumber(entry.firstResponseLatencyMs)}${artifact}`,
+      ...(scores === null ? [] : [`  judge_scores: ${scores}`]),
+    ];
+  });
+
+  return [
+    "Skill Eval Summary",
+    "",
+    `Run group: ${summary.runGroupId}`,
+    `Started: ${summary.startedAt}`,
+    `Git: branch=${formatNullableText(summary.git?.branch ?? null)} sha=${formatNullableText(
+      summary.git?.sha ?? null,
+    )} base=${formatNullableText(summary.git?.base ?? null)}`,
+    `Entries: ${summary.total} total, ${summary.passed} passed, ${summary.failed} failed, ${summary.skipped} skipped`,
+    `Counts by command: ${formatCountMap(summary.countsByCommand)}`,
+    `Counts by tier: ${formatCountMap(summary.countsByTier)}`,
+    `Counts by skill: ${formatCountMap(summary.countsBySkill)}`,
+    `Total duration: ${formatNullableMs(summary.totalDurationMs)}`,
+    `Turns: ${formatNullableNumber(summary.turns)}`,
+    `First response latency: ${formatNullableMs(summary.firstResponseLatencyMs)}`,
+    `Flaky: ${formatFlaky(summary.flaky)}`,
+    "",
+    ...failureLines,
+    "",
+    "Entries:",
+    ...entryLines,
+  ].join("\n");
 }
 
 function formatDeltaList(title: string, deltas: readonly CompareEntryDelta[]): readonly string[] {

--- a/packages/skill-evals/src/index.ts
+++ b/packages/skill-evals/src/index.ts
@@ -5,16 +5,19 @@ import { fileURLToPath } from "node:url";
 import { SHIPPED_SKILLS, type ShippedSkillName } from "./core/case-schema.js";
 import { type SkillEvalSuiteDefinition, validateCoverageMatrix } from "./core/coverage.js";
 import { isRecord } from "./core/events.js";
+import { gateCommandFailed } from "./core/gate-exit.js";
 import { gradingFailureMessages } from "./core/grading.js";
 import {
   appendResultStoreEntries,
   compareResultGroups,
   createRunGroupId,
   formatCompareSummary,
+  formatResultRunSummary,
   latestRunGroups,
   type ResultStoreEntry,
   readGitInfo,
   readResultStore,
+  summarizeResultRunGroup,
 } from "./core/result-store.js";
 import { changedFilesFromGit, formatSelectionSummary, selectSkillEvalRecommendations } from "./core/select.js";
 import { readSkillFrontmatter } from "./core/skills/frontmatter.js";
@@ -23,10 +26,17 @@ import type { BatchSummary as ReadBatchSummary } from "./suites/first-tree-read/
 import { formatFirstTreeSeedGateSummary, runFirstTreeSeedGate } from "./suites/first-tree-seed/index.js";
 import type { BatchSummary as SeedBatchSummary } from "./suites/first-tree-seed/types.js";
 import { formatFirstTreeWelcomeGateSummary, runFirstTreeWelcomeGate } from "./suites/first-tree-welcome/index.js";
+import { FIRST_TREE_WELCOME_QUALITY_DEFINITION } from "./suites/first-tree-welcome/quality.js";
 import type { BatchSummary as WelcomeBatchSummary } from "./suites/first-tree-welcome/types.js";
 import { formatFirstTreeWriteGateSummary, runFirstTreeWriteGate } from "./suites/first-tree-write/index.js";
+import { FIRST_TREE_WRITE_QUALITY_DEFINITION } from "./suites/first-tree-write/quality.js";
 import type { BatchSummary as WriteBatchSummary } from "./suites/first-tree-write/types.js";
-import { formatQualitySummaryTable, runQualityEval } from "./suites/quality/index.js";
+import {
+  buildWelcomeQualityInput,
+  buildWriteQualityInput,
+  formatQualitySummaryTable,
+  runQualityEval,
+} from "./suites/quality/index.js";
 import type { QualityBatchSummary, QualitySkillName } from "./suites/quality/types.js";
 import { SKILL_EVAL_SUITES } from "./suites/registry.js";
 
@@ -35,8 +45,9 @@ type CliOptions = {
   caseId: string | null;
   changedFiles: readonly string[];
   codexBin: string;
-  command: "compare" | "floor" | "gate" | "quality" | "select";
+  command: "compare" | "floor" | "gate" | "quality" | "select" | "summary";
   currentRunGroupId: string | null;
+  includeQuality: boolean;
   judgeBin: string;
   judgeModel: string | null;
   json: boolean;
@@ -66,11 +77,13 @@ function usage(): string {
   pnpm --filter @first-tree/skill-evals eval:floor -- --suite <skill>
   pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-read
   pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-write
+  pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-write --include-quality
   pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-welcome
   pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-seed
   pnpm --filter @first-tree/skill-evals eval:quality
   pnpm --filter @first-tree/skill-evals eval:quality -- --suite first-tree-write
   pnpm --filter @first-tree/skill-evals eval:select -- --base main
+  pnpm --filter @first-tree/skill-evals eval:summary
   pnpm --filter @first-tree/skill-evals eval:compare
 
 Commands:
@@ -78,14 +91,16 @@ Commands:
   gate                   Run a live model gate suite and write grading.json.
   quality                Run opt-in LLM-as-judge quality cases.
   select                 Recommend eval commands from changed files.
+  summary                Summarize one result-store run group.
   compare                Compare latest result-store run groups.
 
 Options:
   --suite <skill>        Limit per-suite floor checks to one shipped skill.
   --case <id>            Run one live gate case.
+  --include-quality      With eval:gate, run supported quality judge cases after deterministic gate passes.
   --base <ref>           Base ref for eval:select git diff. Defaults to main.
   --changed-file <path>  Add an explicit changed file for eval:select.
-  --current <run-id>     Current run group for eval:compare. Defaults to latest.
+  --current <run-id>     Current run group for eval:summary/compare. Defaults to latest.
   --previous <run-id>    Previous run group for eval:compare. Defaults to previous.
   --json                 Print summary as JSON.
   --model <model>        Pass a model override to codex exec.
@@ -117,6 +132,7 @@ function parseArgs(args: readonly string[]): CliOptions {
     command !== "gate" &&
     command !== "quality" &&
     command !== "select" &&
+    command !== "summary" &&
     command !== "compare"
   ) {
     throw new Error(`Unknown command: ${command}`);
@@ -129,6 +145,7 @@ function parseArgs(args: readonly string[]): CliOptions {
     codexBin: process.env.CODEX_BIN ?? "codex",
     command,
     currentRunGroupId: null,
+    includeQuality: false,
     judgeBin: process.env.JUDGE_CODEX_BIN ?? process.env.CODEX_BIN ?? "codex",
     judgeModel: process.env.JUDGE_MODEL ?? process.env.CODEX_MODEL ?? null,
     json: false,
@@ -142,6 +159,10 @@ function parseArgs(args: readonly string[]): CliOptions {
     const arg = normalized[index];
     if (arg === "--json") {
       options.json = true;
+      continue;
+    }
+    if (arg === "--include-quality") {
+      options.includeQuality = true;
       continue;
     }
     if (arg === "--case") {
@@ -209,6 +230,10 @@ function parseArgs(args: readonly string[]): CliOptions {
     throw new Error(`Unknown option: ${arg}`);
   }
 
+  if (options.includeQuality && options.command !== "gate") {
+    throw new Error("--include-quality is only valid with eval:gate.");
+  }
+
   return options;
 }
 
@@ -218,6 +243,23 @@ function qualitySuite(options: CliOptions): QualitySkillName | null {
     return options.suite;
   }
   throw new Error("eval:quality currently supports --suite first-tree-write or --suite first-tree-welcome.");
+}
+
+function includeQualitySuite(options: CliOptions): QualitySkillName {
+  if (options.suite === "first-tree-write" || options.suite === "first-tree-welcome") {
+    return options.suite;
+  }
+  const suiteText = options.suite === null ? "no suite" : options.suite;
+  throw new Error(
+    `eval:gate --include-quality is only supported for --suite first-tree-write or --suite first-tree-welcome; got ${suiteText}.`,
+  );
+}
+
+function assertIncludedQualityCase(options: CliOptions, gateCaseId: string): void {
+  if (options.caseId === null || options.caseId === gateCaseId) return;
+  throw new Error(
+    `eval:gate --include-quality requires gate case ${gateCaseId}; --case ${options.caseId} cannot produce the required quality artifact.`,
+  );
 }
 
 function packageRoot(): string {
@@ -357,6 +399,7 @@ function floorResultEntries(
     command: "eval:floor",
     costUsd: null,
     durationMs: options.durationMs,
+    firstResponseLatencyMs: null,
     failures: check.ok ? [] : [check.detail],
     git,
     judgeScores: null,
@@ -380,8 +423,8 @@ function gateResultEntries(
   batch: GateBatchSummary,
   suite: ShippedSkillName,
   options: CliOptions,
+  runGroupId = createRunGroupId(batch.runStartedAt, `eval-gate-${suite}`),
 ): readonly ResultStoreEntry[] {
-  const runGroupId = createRunGroupId(batch.runStartedAt, `eval-gate-${suite}`);
   const git = readGitInfo(repoRootFromPackage(packageRootPath), options.base);
   return batch.cases.map((summary) => {
     const durationMs = Math.max(0, Date.now() - Date.parse(summary.startedAt));
@@ -396,6 +439,7 @@ function gateResultEntries(
       command: "eval:gate",
       costUsd: null,
       durationMs,
+      firstResponseLatencyMs: summary.firstResponseLatencyMs,
       failures: summary.passed
         ? []
         : [...gradingFailureMessages(summary.grading), ...(summary.driftNote ? [`drift: ${summary.driftNote}`] : [])],
@@ -410,7 +454,7 @@ function gateResultEntries(
       startedAt: summary.startedAt,
       status: summary.passed ? "passed" : "failed",
       tier: "gate",
-      turns: null,
+      turns: summary.turns,
     } satisfies ResultStoreEntry;
   });
 }
@@ -419,8 +463,8 @@ function qualityResultEntries(
   packageRootPath: string,
   batch: QualityBatchSummary,
   options: CliOptions,
+  runGroupId = createRunGroupId(batch.runStartedAt, `eval-quality-${options.suite ?? "all"}`),
 ): readonly ResultStoreEntry[] {
-  const runGroupId = createRunGroupId(batch.runStartedAt, `eval-quality-${options.suite ?? "all"}`);
   const git = readGitInfo(repoRootFromPackage(packageRootPath), options.base);
   return batch.cases.map(
     (summary) =>
@@ -435,6 +479,7 @@ function qualityResultEntries(
         command: "eval:quality",
         costUsd: summary.cost_usd,
         durationMs: summary.duration_ms,
+        firstResponseLatencyMs: null,
         failures: summary.failures,
         git,
         judgeScores: summary.judge_scores,
@@ -452,8 +497,124 @@ function qualityResultEntries(
   );
 }
 
+type IncludedQualityResult = {
+  batch: QualityBatchSummary | null;
+  skippedReason: string | null;
+};
+
+function includedQualityGateFailureReason(batch: GateBatchSummary): string | null {
+  if (batch.failed === 0) return null;
+  return `quality was not run because deterministic gate failed (${batch.failed} failed case${
+    batch.failed === 1 ? "" : "s"
+  })`;
+}
+
+async function runIncludedWriteQuality(
+  packageRootPath: string,
+  batch: WriteBatchSummary,
+  options: CliOptions,
+): Promise<IncludedQualityResult> {
+  const skippedReason = includedQualityGateFailureReason(batch);
+  if (skippedReason !== null) return { batch: null, skippedReason };
+  const gateSummary = batch.cases.find((summary) => summary.caseId === FIRST_TREE_WRITE_QUALITY_DEFINITION.gateCaseId);
+  if (gateSummary === undefined) {
+    return {
+      batch: null,
+      skippedReason: `quality was not run because gate case ${FIRST_TREE_WRITE_QUALITY_DEFINITION.gateCaseId} was not included`,
+    };
+  }
+  const qualityBatch = await runQualityEval(
+    packageRootPath,
+    {
+      caseId: FIRST_TREE_WRITE_QUALITY_DEFINITION.evalCase.id,
+      codexBin: options.codexBin,
+      judgeBin: options.judgeBin,
+      judgeModel: options.judgeModel,
+      json: options.json,
+      model: options.model,
+      suite: "first-tree-write",
+      verbose: options.verbose,
+    },
+    undefined,
+    new Map([[FIRST_TREE_WRITE_QUALITY_DEFINITION.evalCase.id, buildWriteQualityInput(gateSummary)]]),
+  );
+  return { batch: qualityBatch, skippedReason: null };
+}
+
+async function runIncludedWelcomeQuality(
+  packageRootPath: string,
+  batch: WelcomeBatchSummary,
+  options: CliOptions,
+): Promise<IncludedQualityResult> {
+  const skippedReason = includedQualityGateFailureReason(batch);
+  if (skippedReason !== null) return { batch: null, skippedReason };
+  const gateSummary = batch.cases.find(
+    (summary) => summary.caseId === FIRST_TREE_WELCOME_QUALITY_DEFINITION.gateCaseId,
+  );
+  if (gateSummary === undefined) {
+    return {
+      batch: null,
+      skippedReason: `quality was not run because gate case ${FIRST_TREE_WELCOME_QUALITY_DEFINITION.gateCaseId} was not included`,
+    };
+  }
+  const qualityBatch = await runQualityEval(
+    packageRootPath,
+    {
+      caseId: FIRST_TREE_WELCOME_QUALITY_DEFINITION.evalCase.id,
+      codexBin: options.codexBin,
+      judgeBin: options.judgeBin,
+      judgeModel: options.judgeModel,
+      json: options.json,
+      model: options.model,
+      suite: "first-tree-welcome",
+      verbose: options.verbose,
+    },
+    undefined,
+    new Map([[FIRST_TREE_WELCOME_QUALITY_DEFINITION.evalCase.id, buildWelcomeQualityInput(gateSummary)]]),
+  );
+  return { batch: qualityBatch, skippedReason: null };
+}
+
+function printGateWithOptionalQuality(
+  gateText: string,
+  gateBatch: GateBatchSummary,
+  quality: IncludedQualityResult | null,
+  json: boolean,
+): void {
+  if (json) {
+    if (quality === null) {
+      process.stdout.write(`${JSON.stringify(gateBatch, null, 2)}\n`);
+      return;
+    }
+    process.stdout.write(
+      `${JSON.stringify(
+        {
+          gate: gateBatch,
+          quality: quality.batch,
+          qualitySkippedReason: quality.skippedReason,
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    return;
+  }
+
+  process.stdout.write(`${gateText}\n`);
+  if (quality === null) return;
+  process.stdout.write("\nIncluded Quality\n\n");
+  if (quality.batch === null) {
+    process.stdout.write(`SKIPPED  ${quality.skippedReason ?? "quality was not run"}\n`);
+    return;
+  }
+  process.stdout.write(`${formatQualitySummaryTable(quality.batch)}\n`);
+}
+
 async function runGate(options: CliOptions): Promise<void> {
   const packageRootPath = packageRoot();
+  if (options.includeQuality) {
+    includeQualitySuite(options);
+  }
   if (options.suite === "first-tree-read") {
     const batch = await runFirstTreeReadGate(packageRootPath, {
       caseId: options.caseId,
@@ -463,11 +624,7 @@ async function runGate(options: CliOptions): Promise<void> {
       verbose: options.verbose,
     });
     appendResultStoreEntries(packageRootPath, gateResultEntries(packageRootPath, batch, options.suite, options));
-    if (options.json) {
-      process.stdout.write(`${JSON.stringify(batch, null, 2)}\n`);
-    } else {
-      process.stdout.write(`${formatFirstTreeReadGateSummary(batch)}\n`);
-    }
+    printGateWithOptionalQuality(formatFirstTreeReadGateSummary(batch), batch, null, options.json);
     if (batch.failed > 0) {
       process.exitCode = 1;
     }
@@ -475,6 +632,9 @@ async function runGate(options: CliOptions): Promise<void> {
   }
 
   if (options.suite === "first-tree-write") {
+    if (options.includeQuality) {
+      assertIncludedQualityCase(options, FIRST_TREE_WRITE_QUALITY_DEFINITION.gateCaseId);
+    }
     const batch = await runFirstTreeWriteGate(packageRootPath, {
       caseId: options.caseId,
       codexBin: options.codexBin,
@@ -482,13 +642,23 @@ async function runGate(options: CliOptions): Promise<void> {
       model: options.model,
       verbose: options.verbose,
     });
-    appendResultStoreEntries(packageRootPath, gateResultEntries(packageRootPath, batch, options.suite, options));
-    if (options.json) {
-      process.stdout.write(`${JSON.stringify(batch, null, 2)}\n`);
-    } else {
-      process.stdout.write(`${formatFirstTreeWriteGateSummary(batch)}\n`);
+    const runGroupId = createRunGroupId(
+      batch.runStartedAt,
+      `eval-gate-${options.suite}${options.includeQuality ? "-include-quality" : ""}`,
+    );
+    appendResultStoreEntries(
+      packageRootPath,
+      gateResultEntries(packageRootPath, batch, options.suite, options, runGroupId),
+    );
+    const quality = options.includeQuality ? await runIncludedWriteQuality(packageRootPath, batch, options) : null;
+    if (quality?.batch !== null && quality?.batch !== undefined) {
+      appendResultStoreEntries(
+        packageRootPath,
+        qualityResultEntries(packageRootPath, quality.batch, options, runGroupId),
+      );
     }
-    if (batch.failed > 0) {
+    printGateWithOptionalQuality(formatFirstTreeWriteGateSummary(batch), batch, quality, options.json);
+    if (gateCommandFailed(batch, quality)) {
       process.exitCode = 1;
     }
     return;
@@ -503,11 +673,7 @@ async function runGate(options: CliOptions): Promise<void> {
       verbose: options.verbose,
     });
     appendResultStoreEntries(packageRootPath, gateResultEntries(packageRootPath, batch, options.suite, options));
-    if (options.json) {
-      process.stdout.write(`${JSON.stringify(batch, null, 2)}\n`);
-    } else {
-      process.stdout.write(`${formatFirstTreeSeedGateSummary(batch)}\n`);
-    }
+    printGateWithOptionalQuality(formatFirstTreeSeedGateSummary(batch), batch, null, options.json);
     if (batch.failed > 0) {
       process.exitCode = 1;
     }
@@ -515,6 +681,9 @@ async function runGate(options: CliOptions): Promise<void> {
   }
 
   if (options.suite === "first-tree-welcome") {
+    if (options.includeQuality) {
+      assertIncludedQualityCase(options, FIRST_TREE_WELCOME_QUALITY_DEFINITION.gateCaseId);
+    }
     const batch = await runFirstTreeWelcomeGate(packageRootPath, {
       caseId: options.caseId,
       codexBin: options.codexBin,
@@ -522,13 +691,23 @@ async function runGate(options: CliOptions): Promise<void> {
       model: options.model,
       verbose: options.verbose,
     });
-    appendResultStoreEntries(packageRootPath, gateResultEntries(packageRootPath, batch, options.suite, options));
-    if (options.json) {
-      process.stdout.write(`${JSON.stringify(batch, null, 2)}\n`);
-    } else {
-      process.stdout.write(`${formatFirstTreeWelcomeGateSummary(batch)}\n`);
+    const runGroupId = createRunGroupId(
+      batch.runStartedAt,
+      `eval-gate-${options.suite}${options.includeQuality ? "-include-quality" : ""}`,
+    );
+    appendResultStoreEntries(
+      packageRootPath,
+      gateResultEntries(packageRootPath, batch, options.suite, options, runGroupId),
+    );
+    const quality = options.includeQuality ? await runIncludedWelcomeQuality(packageRootPath, batch, options) : null;
+    if (quality?.batch !== null && quality?.batch !== undefined) {
+      appendResultStoreEntries(
+        packageRootPath,
+        qualityResultEntries(packageRootPath, quality.batch, options, runGroupId),
+      );
     }
-    if (batch.failed > 0) {
+    printGateWithOptionalQuality(formatFirstTreeWelcomeGateSummary(batch), batch, quality, options.json);
+    if (gateCommandFailed(batch, quality)) {
       process.exitCode = 1;
     }
     return;
@@ -587,6 +766,20 @@ function runCompare(options: CliOptions): void {
   }
 }
 
+function runSummary(options: CliOptions): void {
+  const packageRootPath = packageRoot();
+  const entries = readResultStore(packageRootPath);
+  const summary = summarizeResultRunGroup(entries, options.currentRunGroupId);
+  if (summary === null && options.currentRunGroupId !== null) {
+    throw new Error(`No result-store run group found for --current ${options.currentRunGroupId}.`);
+  }
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+  } else {
+    process.stdout.write(`${formatResultRunSummary(summary)}\n`);
+  }
+}
+
 async function main(): Promise<void> {
   const options = parseArgs(process.argv.slice(2));
   if (options.command === "select") {
@@ -595,6 +788,10 @@ async function main(): Promise<void> {
   }
   if (options.command === "compare") {
     runCompare(options);
+    return;
+  }
+  if (options.command === "summary") {
+    runSummary(options);
     return;
   }
   if (options.command === "gate") {

--- a/packages/skill-evals/src/suites/first-tree-read/runner.ts
+++ b/packages/skill-evals/src/suites/first-tree-read/runner.ts
@@ -1,4 +1,5 @@
 import { appendEvent, readEvents } from "../../core/events.js";
+import { deriveRunObservability } from "../../core/observability.js";
 import { createRunPaths } from "../../core/paths.js";
 import { runCodexProvider } from "../../core/provider/codex.js";
 import { createEvalReporter } from "../../core/reporter.js";
@@ -39,21 +40,19 @@ export async function runFirstTreeReadCase(
         },
         { paths, reporter },
       );
-  const metrics = deriveMetrics(
-    readEvents(paths.eventsPath),
-    fixtureValidation,
-    runnerExitCode,
-    evalCase.expectedFacts,
-  );
+  const events = readEvents(paths.eventsPath);
+  const metrics = deriveMetrics(events, fixtureValidation, runnerExitCode, evalCase.expectedFacts);
   const passed = options.validateFixtures
     ? fixtureOnlyPassed(fixtureValidation)
     : casePassed(evalCase.expectedTrigger, metrics);
   const grading = buildGrading(evalCase.id, metrics, evalCase.expectedTrigger, passed);
+  const observability = deriveRunObservability(events);
 
   const summary: CaseRunSummary = {
     caseId: evalCase.id,
     driftNote: driftNote(metrics, evalCase.expectedTrigger),
     expectedTrigger: evalCase.expectedTrigger,
+    firstResponseLatencyMs: observability.firstResponseLatencyMs,
     fixtureValidation,
     grading,
     gradingJsonPath: paths.gradingJsonPath,
@@ -64,6 +63,7 @@ export async function runFirstTreeReadCase(
     startedAt,
     summaryJsonPath: paths.summaryJsonPath,
     summaryMdPath: paths.summaryMdPath,
+    turns: observability.turns,
     workspacePath: paths.workspacePath,
   };
 

--- a/packages/skill-evals/src/suites/first-tree-read/summary.ts
+++ b/packages/skill-evals/src/suites/first-tree-read/summary.ts
@@ -196,6 +196,8 @@ export function writeCaseSummaries(summary: CaseRunSummary): void {
 - modelFirstTreeCommandsOk: ${markdownBool(summary.metrics.modelFirstTreeCommandsOk)}
 - firstTreeCalls: ${summary.metrics.firstTreeCalls}
 - runnerExitCode: ${summary.metrics.runnerExitCode === null ? "n/a" : summary.metrics.runnerExitCode}
+- turns: ${summary.turns ?? "n/a"}
+- firstResponseLatencyMs: ${summary.firstResponseLatencyMs ?? "n/a"}
 - gradingJsonPath: \`${summary.gradingJsonPath}\`
 
 ## Grading

--- a/packages/skill-evals/src/suites/first-tree-read/types.ts
+++ b/packages/skill-evals/src/suites/first-tree-read/types.ts
@@ -56,6 +56,7 @@ export type CaseRunSummary = {
   caseId: string;
   driftNote: string | null;
   expectedTrigger: boolean;
+  firstResponseLatencyMs: number | null;
   fixtureValidation: FixtureValidation;
   grading: SkillCaseGrading;
   gradingJsonPath: string;
@@ -66,6 +67,7 @@ export type CaseRunSummary = {
   startedAt: string;
   summaryJsonPath: string;
   summaryMdPath: string;
+  turns: number | null;
   workspacePath: string;
 };
 

--- a/packages/skill-evals/src/suites/first-tree-seed/runner.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/runner.ts
@@ -1,4 +1,5 @@
 import { appendEvent, readEvents } from "../../core/events.js";
+import { deriveRunObservability } from "../../core/observability.js";
 import { createRunPaths } from "../../core/paths.js";
 import { runCodexProvider } from "../../core/provider/codex.js";
 import { createEvalReporter } from "../../core/reporter.js";
@@ -42,21 +43,17 @@ export async function runFirstTreeSeedCase(
     { paths, reporter },
   );
 
-  const metrics = deriveMetrics(
-    readEvents(paths.eventsPath),
-    evalCase,
-    fixtureValidation,
-    runnerExitCode,
-    paths,
-    contextTreePath,
-  );
+  const events = readEvents(paths.eventsPath);
+  const metrics = deriveMetrics(events, evalCase, fixtureValidation, runnerExitCode, paths, contextTreePath);
   const passed = casePassed(evalCase, metrics);
   const grading = buildGrading(evalCase, metrics, passed);
+  const observability = deriveRunObservability(events);
 
   const summary: CaseRunSummary = {
     caseId: evalCase.id,
     driftNote: driftNote(evalCase, metrics),
     expectedAction: evalCase.expected.action,
+    firstResponseLatencyMs: observability.firstResponseLatencyMs,
     fixtureValidation,
     grading,
     gradingJsonPath: paths.gradingJsonPath,
@@ -67,6 +64,7 @@ export async function runFirstTreeSeedCase(
     startedAt,
     summaryJsonPath: paths.summaryJsonPath,
     summaryMdPath: paths.summaryMdPath,
+    turns: observability.turns,
     workspacePath: paths.workspacePath,
   };
 

--- a/packages/skill-evals/src/suites/first-tree-seed/summary.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/summary.ts
@@ -147,6 +147,8 @@ export function writeCaseSummaries(summary: CaseRunSummary): void {
     summary.metrics.forbiddenSideEffectHits.length === 0 ? "none" : summary.metrics.forbiddenSideEffectHits.join(", ")
   }
 - runnerExitCode: ${summary.metrics.runnerExitCode === null ? "n/a" : summary.metrics.runnerExitCode}
+- turns: ${summary.turns ?? "n/a"}
+- firstResponseLatencyMs: ${summary.firstResponseLatencyMs ?? "n/a"}
 - gradingJsonPath: \`${summary.gradingJsonPath}\`
 
 ## Grading

--- a/packages/skill-evals/src/suites/first-tree-seed/types.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/types.ts
@@ -85,6 +85,7 @@ export type CaseRunSummary = {
   caseId: string;
   driftNote: string | null;
   expectedAction: SeedExpectedAction;
+  firstResponseLatencyMs: number | null;
   fixtureValidation: FixtureValidation;
   grading: SkillCaseGrading;
   gradingJsonPath: string;
@@ -95,6 +96,7 @@ export type CaseRunSummary = {
   startedAt: string;
   summaryJsonPath: string;
   summaryMdPath: string;
+  turns: number | null;
   workspacePath: string;
 };
 

--- a/packages/skill-evals/src/suites/first-tree-welcome/quality.ts
+++ b/packages/skill-evals/src/suites/first-tree-welcome/quality.ts
@@ -1,5 +1,10 @@
 import type { JudgeRubricDimension } from "../../core/judge/types.js";
-import type { QualityArtifactInput, QualityCaseDefinition, QualityEvalCase } from "../quality/types.js";
+import type {
+  QualityArtifactInput,
+  QualityCaseDefinition,
+  QualityEvalCase,
+  QualitySanityFixture,
+} from "../quality/types.js";
 
 const WELCOME_TASK_QUALITY_DIMENSIONS: readonly JudgeRubricDimension[] = [
   {
@@ -87,3 +92,82 @@ export const FIRST_TREE_WELCOME_QUALITY_DEFINITION: QualityCaseDefinition = {
   gateCaseId: "first-tree-welcome-readable-repo-populated-tree",
   title: "first-tree-welcome first-task quality",
 };
+
+function sanityInput(name: QualitySanityFixture["name"], artifact: string): QualityArtifactInput {
+  return {
+    artifact,
+    deterministicGatePassed: true,
+    gateCaseId: FIRST_TREE_WELCOME_QUALITY_DEFINITION.gateCaseId,
+    gateRunRoot: `/tmp/${name}-welcome-gate`,
+    gateSummaryJsonPath: `/tmp/${name}-welcome-gate/summary.json`,
+    gateSummaryMdPath: `/tmp/${name}-welcome-gate/summary.md`,
+    source: [
+      "Repo evidence: checkout sessions expire when JWT refresh is skipped.",
+      "Context Tree evidence: checkout reliability is a current product priority.",
+    ].join("\n"),
+  };
+}
+
+function judgeOutput(scores: Record<string, number>, reasoning: string): string {
+  return JSON.stringify({ reasoning, scores });
+}
+
+export const FIRST_TREE_WELCOME_QUALITY_SANITY_FIXTURES: readonly QualitySanityFixture[] = [
+  {
+    expectedPassed: true,
+    input: sanityInput(
+      "good",
+      [
+        "1. Trace the checkout JWT refresh path and identify the smallest failing test to add.",
+        "2. Compare the Context Tree checkout reliability note with the session refresh implementation and report one concrete fix candidate.",
+      ].join("\n"),
+    ),
+    judgeOutput: judgeOutput(
+      {
+        bounded: 5,
+        evidence_backed: 5,
+        not_setup_as_task: 5,
+        useful: 4,
+        verifiable: 4,
+      },
+      "The options are evidence-backed, bounded, and directly verifiable.",
+    ),
+    name: "good",
+  },
+  {
+    expectedPassed: true,
+    input: sanityInput(
+      "borderline",
+      "Check the checkout session refresh code against the tree note and propose one small verification step.",
+    ),
+    judgeOutput: judgeOutput(
+      {
+        bounded: 4,
+        evidence_backed: 4,
+        not_setup_as_task: 5,
+        useful: 3,
+        verifiable: 3,
+      },
+      "Exactly meets every threshold without drifting into setup work.",
+    ),
+    name: "borderline",
+  },
+  {
+    expectedPassed: false,
+    input: sanityInput(
+      "bad",
+      "First connect GitHub, create a Context Tree, run seed, and then we can think about checkout work.",
+    ),
+    judgeOutput: judgeOutput(
+      {
+        bounded: 2,
+        evidence_backed: 2,
+        not_setup_as_task: 1,
+        useful: 2,
+        verifiable: 2,
+      },
+      "This packages setup as the task and is not grounded in the provided evidence.",
+    ),
+    name: "bad",
+  },
+];

--- a/packages/skill-evals/src/suites/first-tree-welcome/runner.ts
+++ b/packages/skill-evals/src/suites/first-tree-welcome/runner.ts
@@ -1,4 +1,5 @@
 import { appendEvent, readEvents } from "../../core/events.js";
+import { deriveRunObservability } from "../../core/observability.js";
 import { createRunPaths } from "../../core/paths.js";
 import { runCodexProvider } from "../../core/provider/codex.js";
 import { createEvalReporter } from "../../core/reporter.js";
@@ -42,21 +43,17 @@ export async function runFirstTreeWelcomeCase(
     { paths, reporter },
   );
 
-  const metrics = deriveMetrics(
-    readEvents(paths.eventsPath),
-    evalCase,
-    fixtureValidation,
-    runnerExitCode,
-    paths,
-    contextTreePath,
-  );
+  const events = readEvents(paths.eventsPath);
+  const metrics = deriveMetrics(events, evalCase, fixtureValidation, runnerExitCode, paths, contextTreePath);
   const passed = casePassed(evalCase, metrics);
   const grading = buildGrading(evalCase, metrics, passed);
+  const observability = deriveRunObservability(events);
 
   const summary: CaseRunSummary = {
     caseId: evalCase.id,
     driftNote: driftNote(evalCase, metrics),
     expectedAction: evalCase.expected.action,
+    firstResponseLatencyMs: observability.firstResponseLatencyMs,
     fixtureValidation,
     grading,
     gradingJsonPath: paths.gradingJsonPath,
@@ -67,6 +64,7 @@ export async function runFirstTreeWelcomeCase(
     startedAt,
     summaryJsonPath: paths.summaryJsonPath,
     summaryMdPath: paths.summaryMdPath,
+    turns: observability.turns,
     workspacePath: paths.workspacePath,
   };
 

--- a/packages/skill-evals/src/suites/first-tree-welcome/summary.ts
+++ b/packages/skill-evals/src/suites/first-tree-welcome/summary.ts
@@ -139,6 +139,8 @@ export function writeCaseSummaries(summary: CaseRunSummary): void {
     summary.metrics.forbiddenSideEffectHits.length === 0 ? "none" : summary.metrics.forbiddenSideEffectHits.join(", ")
   }
 - runnerExitCode: ${summary.metrics.runnerExitCode === null ? "n/a" : summary.metrics.runnerExitCode}
+- turns: ${summary.turns ?? "n/a"}
+- firstResponseLatencyMs: ${summary.firstResponseLatencyMs ?? "n/a"}
 - gradingJsonPath: \`${summary.gradingJsonPath}\`
 
 ## Grading

--- a/packages/skill-evals/src/suites/first-tree-welcome/types.ts
+++ b/packages/skill-evals/src/suites/first-tree-welcome/types.ts
@@ -96,6 +96,7 @@ export type CaseRunSummary = {
   caseId: string;
   driftNote: string | null;
   expectedAction: WelcomeExpectedAction;
+  firstResponseLatencyMs: number | null;
   fixtureValidation: FixtureValidation;
   grading: SkillCaseGrading;
   gradingJsonPath: string;
@@ -106,6 +107,7 @@ export type CaseRunSummary = {
   startedAt: string;
   summaryJsonPath: string;
   summaryMdPath: string;
+  turns: number | null;
   workspacePath: string;
 };
 

--- a/packages/skill-evals/src/suites/first-tree-write/quality.ts
+++ b/packages/skill-evals/src/suites/first-tree-write/quality.ts
@@ -1,5 +1,10 @@
 import type { JudgeRubricDimension } from "../../core/judge/types.js";
-import type { QualityArtifactInput, QualityCaseDefinition, QualityEvalCase } from "../quality/types.js";
+import type {
+  QualityArtifactInput,
+  QualityCaseDefinition,
+  QualityEvalCase,
+  QualitySanityFixture,
+} from "../quality/types.js";
 
 const WRITE_NODE_QUALITY_DIMENSIONS: readonly JudgeRubricDimension[] = [
   {
@@ -82,3 +87,86 @@ export const FIRST_TREE_WRITE_QUALITY_DEFINITION: QualityCaseDefinition = {
   gateCaseId: "durable-source-writes",
   title: "first-tree-write node quality",
 };
+
+function sanityInput(name: QualitySanityFixture["name"], artifact: string): QualityArtifactInput {
+  return {
+    artifact,
+    deterministicGatePassed: true,
+    gateCaseId: FIRST_TREE_WRITE_QUALITY_DEFINITION.gateCaseId,
+    gateRunRoot: `/tmp/${name}-write-gate`,
+    gateSummaryJsonPath: `/tmp/${name}-write-gate/summary.json`,
+    gateSummaryMdPath: `/tmp/${name}-write-gate/summary.md`,
+    source: [
+      "Decision: keep Context Tree nodes focused on durable product and architecture context.",
+      "Rationale: future agents need the stable rule, not every transient PR step.",
+    ].join("\n"),
+  };
+}
+
+function judgeOutput(scores: Record<string, number>, reasoning: string): string {
+  return JSON.stringify({ reasoning, scores });
+}
+
+export const FIRST_TREE_WRITE_QUALITY_SANITY_FIXTURES: readonly QualitySanityFixture[] = [
+  {
+    expectedPassed: true,
+    input: sanityInput(
+      "good",
+      [
+        "+--- a/system/context-management/task-skill-design.md",
+        "++ Agents write durable Context Tree updates only from explicit source artifacts.",
+        "++ This keeps the tree grounded in decisions and rationale that future agents can reuse.",
+      ].join("\n"),
+    ),
+    judgeOutput: judgeOutput(
+      {
+        conciseness: 4,
+        durability: 5,
+        rationale_quality: 4,
+        source_boundary: 5,
+      },
+      "Durable, source-bounded, and concise.",
+    ),
+    name: "good",
+  },
+  {
+    expectedPassed: true,
+    input: sanityInput(
+      "borderline",
+      [
+        "+--- a/system/context-management/task-skill-design.md",
+        "++ Context Tree updates require an explicit source artifact and should preserve the durable reason.",
+      ].join("\n"),
+    ),
+    judgeOutput: judgeOutput(
+      {
+        conciseness: 3,
+        durability: 4,
+        rationale_quality: 3,
+        source_boundary: 4,
+      },
+      "Exactly meets every threshold.",
+    ),
+    name: "borderline",
+  },
+  {
+    expectedPassed: false,
+    input: sanityInput(
+      "bad",
+      [
+        "+--- a/system/context-management/task-skill-design.md",
+        "++ PR #123 changed a helper signature in packages/foo/src/bar.ts and the reviewer approved it.",
+      ].join("\n"),
+    ),
+    judgeOutput: judgeOutput(
+      {
+        conciseness: 3,
+        durability: 2,
+        rationale_quality: 2,
+        source_boundary: 3,
+      },
+      "Implementation minutiae and unsupported PR details fall below the rubric.",
+    ),
+    name: "bad",
+  },
+];

--- a/packages/skill-evals/src/suites/first-tree-write/runner.ts
+++ b/packages/skill-evals/src/suites/first-tree-write/runner.ts
@@ -1,4 +1,5 @@
 import { appendEvent, readEvents } from "../../core/events.js";
+import { deriveRunObservability } from "../../core/observability.js";
 import { createRunPaths } from "../../core/paths.js";
 import { runCodexProvider } from "../../core/provider/codex.js";
 import { createEvalReporter } from "../../core/reporter.js";
@@ -38,21 +39,17 @@ export async function runFirstTreeWriteCase(
     { paths, reporter },
   );
 
-  const metrics = deriveMetrics(
-    readEvents(paths.eventsPath),
-    evalCase,
-    fixtureValidation,
-    runnerExitCode,
-    paths,
-    contextTreePath,
-  );
+  const events = readEvents(paths.eventsPath);
+  const metrics = deriveMetrics(events, evalCase, fixtureValidation, runnerExitCode, paths, contextTreePath);
   const passed = casePassed(evalCase, metrics);
   const grading = buildGrading(evalCase, metrics, passed);
+  const observability = deriveRunObservability(events);
 
   const summary: CaseRunSummary = {
     caseId: evalCase.id,
     driftNote: driftNote(evalCase, metrics),
     expectedAction: evalCase.expected.action,
+    firstResponseLatencyMs: observability.firstResponseLatencyMs,
     fixtureValidation,
     grading,
     gradingJsonPath: paths.gradingJsonPath,
@@ -63,6 +60,7 @@ export async function runFirstTreeWriteCase(
     startedAt,
     summaryJsonPath: paths.summaryJsonPath,
     summaryMdPath: paths.summaryMdPath,
+    turns: observability.turns,
     workspacePath: paths.workspacePath,
   };
 

--- a/packages/skill-evals/src/suites/first-tree-write/summary.ts
+++ b/packages/skill-evals/src/suites/first-tree-write/summary.ts
@@ -113,6 +113,8 @@ export function writeCaseSummaries(summary: CaseRunSummary): void {
 - expectedResponseObserved: ${markdownBool(summary.metrics.expectedResponseObserved)}
 - forbiddenContentHits: ${summary.metrics.forbiddenContentHits.length === 0 ? "none" : summary.metrics.forbiddenContentHits.join(", ")}
 - runnerExitCode: ${summary.metrics.runnerExitCode === null ? "n/a" : summary.metrics.runnerExitCode}
+- turns: ${summary.turns ?? "n/a"}
+- firstResponseLatencyMs: ${summary.firstResponseLatencyMs ?? "n/a"}
 - gradingJsonPath: \`${summary.gradingJsonPath}\`
 
 ## Grading

--- a/packages/skill-evals/src/suites/first-tree-write/types.ts
+++ b/packages/skill-evals/src/suites/first-tree-write/types.ts
@@ -82,6 +82,7 @@ export type CaseRunSummary = {
   caseId: string;
   driftNote: string | null;
   expectedAction: ExpectedAction;
+  firstResponseLatencyMs: number | null;
   fixtureValidation: FixtureValidation;
   grading: SkillCaseGrading;
   gradingJsonPath: string;
@@ -92,6 +93,7 @@ export type CaseRunSummary = {
   startedAt: string;
   summaryJsonPath: string;
   summaryMdPath: string;
+  turns: number | null;
   workspacePath: string;
 };
 

--- a/packages/skill-evals/src/suites/quality/index.ts
+++ b/packages/skill-evals/src/suites/quality/index.ts
@@ -1,2 +1,7 @@
-export { formatQualitySummaryTable, runQualityEval } from "./runner.js";
+export {
+  buildWelcomeQualityInput,
+  buildWriteQualityInput,
+  formatQualitySummaryTable,
+  runQualityEval,
+} from "./runner.js";
 export type { QualityBatchSummary, QualityRunOptions } from "./types.js";

--- a/packages/skill-evals/src/suites/quality/runner.ts
+++ b/packages/skill-evals/src/suites/quality/runner.ts
@@ -119,7 +119,7 @@ function readFixtureFile(path: string): string {
   return readFileSync(path, "utf8");
 }
 
-function writeQualityInput(gateSummary: WriteCaseRunSummary): QualityArtifactInput {
+export function buildWriteQualityInput(gateSummary: WriteCaseRunSummary): QualityArtifactInput {
   return {
     artifact:
       gateSummary.metrics.treeDiff.trim().length > 0
@@ -151,7 +151,7 @@ function welcomeEvidenceSource(gateSummary: WelcomeCaseRunSummary): string {
   ].join("\n");
 }
 
-function welcomeQualityInput(gateSummary: WelcomeCaseRunSummary): QualityArtifactInput {
+export function buildWelcomeQualityInput(gateSummary: WelcomeCaseRunSummary): QualityArtifactInput {
   return {
     artifact: [
       "Chat ask/send text:",
@@ -186,7 +186,7 @@ async function collectLiveQualityInput(
     if (summary === undefined) {
       throw new Error(`No gate summary produced for ${definition.gateCaseId}.`);
     }
-    return writeQualityInput(summary);
+    return buildWriteQualityInput(summary);
   }
 
   if (definition.evalCase.skill === "first-tree-welcome") {
@@ -201,7 +201,7 @@ async function collectLiveQualityInput(
     if (summary === undefined) {
       throw new Error(`No gate summary produced for ${definition.gateCaseId}.`);
     }
-    return welcomeQualityInput(summary);
+    return buildWelcomeQualityInput(summary);
   }
 
   throw new Error(`Unsupported quality suite: ${definition.evalCase.skill}.`);

--- a/packages/skill-evals/src/suites/quality/types.ts
+++ b/packages/skill-evals/src/suites/quality/types.ts
@@ -25,6 +25,13 @@ export type QualityExpected = {
   rubric: string;
 };
 
+export type QualitySanityFixture = {
+  expectedPassed: boolean;
+  input: QualityArtifactInput;
+  judgeOutput: string;
+  name: "bad" | "borderline" | "good";
+};
+
 export type QualityEvalCase = SkillEvalCase<QualityFixture, QualityExpected> & {
   provider: "codex";
   skill: QualitySkillName;


### PR DESCRIPTION
## Summary

- Add `eval:summary` for local result-store run groups, including JSON output, `--current`, git info, command/tier/skill counts, failures, judge scores, observability, and lightweight flaky status.
- Add explicit `eval:gate -- --include-quality` for `first-tree-write` and `first-tree-welcome`, reusing the same deterministic gate artifact after gate pass while keeping read/seed and wrong gate cases fail-fast.
- Add result-store observability fields for gate turns and first-response latency when derivable, with `null` when unavailable.
- Add no-model good/borderline/bad sanity fixtures for write/welcome quality rubrics.
- Update skill-evals usage docs, CLI help, and package scripts.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter @first-tree/skill-evals typecheck`
- `pnpm --filter @first-tree/skill-evals exec vitest run src/core/__tests__/observability.test.ts src/core/__tests__/result-store.test.ts src/core/__tests__/judge.test.ts --maxWorkers=2 --minWorkers=1`
- `pnpm --filter @first-tree/skill-evals exec vitest run --passWithNoTests --maxWorkers=2 --minWorkers=1`
- `pnpm --filter first-tree-dev... build`
- `pnpm --filter @first-tree/skill-evals eval:summary` (empty store)
- `pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-read --include-quality --json` (expected fail-fast)
- `pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-write --case no-source-refuses --include-quality` (expected fail-fast)
- `pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-write --case durable-source-writes --codex-bin /bin/false --include-quality --json` (expected deterministic failure + quality skipped)
- `pnpm --filter @first-tree/skill-evals eval:quality -- --suite first-tree-write --case first-tree-write-node-quality --codex-bin /bin/false --judge-bin /bin/false --json` (expected deterministic gate failure; judge not run)
- `pnpm --filter @first-tree/skill-evals eval:summary`
- `pnpm --filter @first-tree/skill-evals eval:summary -- --json`
- `pnpm --filter @first-tree/skill-evals eval:summary -- --current <run-group-id>`
- `pnpm --filter @first-tree/skill-evals eval:summary -- --current missing-run-group` (expected failure)
- `pnpm --filter @first-tree/skill-evals eval:compare -- --json`
- `pnpm --filter @first-tree/skill-evals eval:floor -- --suite first-tree-write`
- `pnpm --filter @first-tree/skill-evals validate:first-tree-read-fixtures`
- `pnpm typecheck`
- `pnpm check` (exits 0; reports existing unrelated warnings/info in client/web files)
- `pnpm exec biome check <changed skill-evals files>`
- `git diff --check`

## Notes

- This PR intentionally does not add periodic evals, welcome 9-row full live coverage, seed skeleton quality judge, real first-tree repo realism cases, Claude/multi-provider support, or live First Tree runtime E2E.
- I did not run a real Codex live gate or live judge to avoid consuming model quota during PR preparation.
