### PR TITLE
fix: transfer managed agents on self-service leave (#1353)

### DIFF
--- a/packages/server/src/__tests__/me-leave-managed-agents.test.ts
+++ b/packages/server/src/__tests__/me-leave-managed-agents.test.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
-import { eq } from "drizzle-orm";
+import { and, eq, ne } from "drizzle-orm";
+import postgres from "postgres";
 import { describe, expect, it } from "vitest";
 import { agents as agentsTable } from "../db/schema/agents.js";
 import { members as membersTable } from "../db/schema/members.js";
@@ -119,6 +120,46 @@ describe("self-service leave: managed non-human agents", () => {
     expect(memberRow?.status).toBe("active");
   });
 
+  it("lets a sole admin leave after deleting their only non-human agent (tombstones do not block)", async () => {
+    const app = getApp();
+    const org = await freshOrg("leave-tombstone");
+    const soleAdmin = await createMember(app.db, org.id, {
+      username: `tomb-${randomUUID().slice(0, 8)}`,
+      displayName: "Sole Admin",
+      role: "admin",
+    });
+    const clientId = await seedClient(app, soleAdmin.userId, org.id);
+    const managed = await createAgent(app.db, {
+      name: `managed-${randomUUID().slice(0, 8)}`,
+      type: "agent",
+      displayName: "Managed Agent",
+      managerId: soleAdmin.id,
+      clientId,
+    });
+    // The user follows the no-fallback-admin 409's guidance and deletes the
+    // agent. deleteAgent only tombstones (status='deleted', managerId intact),
+    // and retireClient already ignores deleted agents — so leave must stop
+    // counting it, otherwise the sole admin is trapped forever.
+    await app.db.update(agentsTable).set({ status: "deleted", name: null }).where(eq(agentsTable.uuid, managed.uuid));
+
+    await leaveOrganization(app.db, soleAdmin.id);
+
+    const [memberRow] = await app.db
+      .select({ status: membersTable.status })
+      .from(membersTable)
+      .where(eq(membersTable.id, soleAdmin.id))
+      .limit(1);
+    expect(memberRow?.status).toBe("left");
+    // The tombstone is left untouched — not reassigned to a (nonexistent) admin.
+    const [managedRow] = await app.db
+      .select({ managerId: agentsTable.managerId, status: agentsTable.status })
+      .from(agentsTable)
+      .where(eq(agentsTable.uuid, managed.uuid))
+      .limit(1);
+    expect(managedRow?.status).toBe("deleted");
+    expect(managedRow?.managerId).toBe(soleAdmin.id);
+  });
+
   it("allows a sole admin with no managed agents to leave (narrow scope), suspending the human mirror", async () => {
     const app = getApp();
     const org = await freshOrg("leave-empty");
@@ -144,5 +185,63 @@ describe("self-service leave: managed non-human agents", () => {
     expect(mirror?.status).toBe("suspended");
     expect(mirror?.name).not.toBeNull();
     expect(mirror?.clientId).toBeNull();
+  });
+
+  it("does not strand an agent created concurrently with the manager's departure", async () => {
+    const app = getApp();
+    const org = await freshOrg("leave-race");
+    // A fallback admin exists so the leaver is not the sole admin — this test
+    // is about the create/leave race, not the no-fallback block.
+    await createMember(app.db, org.id, {
+      username: `race-fb-${randomUUID().slice(0, 8)}`,
+      displayName: "Fallback Admin",
+      role: "admin",
+    });
+    const leaver = await createMember(app.db, org.id, {
+      username: `race-lv-${randomUUID().slice(0, 8)}`,
+      displayName: "Leaver",
+      role: "admin",
+    });
+
+    // Raw second connection holds an *uncommitted* `status = 'left'` update on
+    // the leaver, taking the same member row lock that `deactivateMembership`
+    // would. createAgent's pre-transaction check still reads the committed
+    // `active` state, but its in-transaction `FOR UPDATE` re-check blocks on
+    // this lock; once we commit, the re-check sees the member is no longer
+    // active and aborts. Without the in-transaction re-check, the agent insert
+    // would block on the FK lock and then succeed once we commit — stranding an
+    // `active` agent on a departed manager. The outcome here is driven by the
+    // lock, not by sleep timing, so it is deterministic.
+    const raw = postgres(process.env.DATABASE_URL ?? "", { max: 1 });
+    try {
+      await raw`BEGIN`;
+      await raw`UPDATE members SET status = 'left' WHERE id = ${leaver.id}`;
+
+      const createOutcome = createAgent(app.db, {
+        name: `raced-${randomUUID().slice(0, 8)}`,
+        type: "agent",
+        displayName: "Raced Agent",
+        managerId: leaver.id,
+      })
+        .then(() => "created" as const)
+        .catch((err: unknown) => err);
+
+      // Give createAgent a moment to reach (and block on) the FOR UPDATE.
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      await raw`COMMIT`;
+
+      const outcome = await createOutcome;
+      expect(outcome).not.toBe("created");
+      expect((outcome as Error)?.message ?? "").toMatch(/not found/i);
+
+      // No non-human agent was stranded on the departed manager.
+      const stranded = await app.db
+        .select({ uuid: agentsTable.uuid })
+        .from(agentsTable)
+        .where(and(eq(agentsTable.managerId, leaver.id), ne(agentsTable.type, "human")));
+      expect(stranded).toHaveLength(0);
+    } finally {
+      await raw.end();
+    }
   });
 });

--- a/packages/server/src/__tests__/me-leave-managed-agents.test.ts
+++ b/packages/server/src/__tests__/me-leave-managed-agents.test.ts
@@ -1,0 +1,148 @@
+import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import { agents as agentsTable } from "../db/schema/agents.js";
+import { members as membersTable } from "../db/schema/members.js";
+import { createAgent } from "../services/agent.js";
+import { retireClient } from "../services/client.js";
+import { createMember } from "../services/member.js";
+import { leaveOrganization } from "../services/membership.js";
+import { createOrganization } from "../services/organization.js";
+import { seedClient, useTestApp } from "./helpers.js";
+
+/**
+ * Issue #1353: self-service leave must align with admin member removal for the
+ * non-human agents the leaving member manages — otherwise those agents stay
+ * `active` and pinned to the user's client, and `retireClient`'s guard
+ * deadlocks the user out of retiring their own computer.
+ */
+describe("self-service leave: managed non-human agents", () => {
+  const getApp = useTestApp();
+
+  async function freshOrg(prefix: string) {
+    return createOrganization(getApp().db, {
+      name: `${prefix}-${randomUUID().slice(0, 8)}`,
+      displayName: "Leave Test Org",
+    });
+  }
+
+  it("transfers managed agents to a fallback admin, clears clientId, and unblocks retiring the client", async () => {
+    const app = getApp();
+    const org = await freshOrg("leave-transfer");
+    const fallbackAdmin = await createMember(app.db, org.id, {
+      username: `fb-${randomUUID().slice(0, 8)}`,
+      displayName: "Fallback Admin",
+      role: "admin",
+    });
+    const leaver = await createMember(app.db, org.id, {
+      username: `lv-${randomUUID().slice(0, 8)}`,
+      displayName: "Leaver",
+      role: "admin",
+    });
+
+    const clientId = await seedClient(app, leaver.userId, org.id);
+    const managed = await createAgent(app.db, {
+      name: `managed-${randomUUID().slice(0, 8)}`,
+      type: "agent",
+      displayName: "Managed Agent",
+      managerId: leaver.id,
+      clientId,
+    });
+
+    // Precondition: while the agent is active and pinned, retire is blocked.
+    await expect(retireClient(app.db, clientId)).rejects.toThrow(/still pinned/i);
+
+    await leaveOrganization(app.db, leaver.id);
+
+    // Managed agent moved to the fallback admin and unpinned.
+    const [managedRow] = await app.db
+      .select({ managerId: agentsTable.managerId, clientId: agentsTable.clientId, status: agentsTable.status })
+      .from(agentsTable)
+      .where(eq(agentsTable.uuid, managed.uuid))
+      .limit(1);
+    expect(managedRow?.managerId).toBe(fallbackAdmin.id);
+    expect(managedRow?.clientId).toBeNull();
+    expect(managedRow?.status).toBe("active");
+
+    // Leaver's membership is left; human mirror suspended, named, unpinned.
+    const [memberRow] = await app.db
+      .select({ status: membersTable.status })
+      .from(membersTable)
+      .where(eq(membersTable.id, leaver.id))
+      .limit(1);
+    expect(memberRow?.status).toBe("left");
+    const [mirror] = await app.db
+      .select({ status: agentsTable.status, name: agentsTable.name, clientId: agentsTable.clientId })
+      .from(agentsTable)
+      .where(eq(agentsTable.uuid, leaver.agentId))
+      .limit(1);
+    expect(mirror?.status).toBe("suspended");
+    expect(mirror?.name).not.toBeNull();
+    expect(mirror?.clientId).toBeNull();
+
+    // The client can now be retired.
+    await expect(retireClient(app.db, clientId)).resolves.toBeUndefined();
+  });
+
+  it("blocks leave when the member manages agents and no other active admin exists", async () => {
+    const app = getApp();
+    const org = await freshOrg("leave-noadmin");
+    const soleAdmin = await createMember(app.db, org.id, {
+      username: `solo-${randomUUID().slice(0, 8)}`,
+      displayName: "Sole Admin",
+      role: "admin",
+    });
+    const clientId = await seedClient(app, soleAdmin.userId, org.id);
+    const managed = await createAgent(app.db, {
+      name: `managed-${randomUUID().slice(0, 8)}`,
+      type: "agent",
+      displayName: "Managed Agent",
+      managerId: soleAdmin.id,
+      clientId,
+    });
+
+    await expect(leaveOrganization(app.db, soleAdmin.id)).rejects.toThrow(/another admin|no other active admin/i);
+
+    // Nothing changed: agent still managed + pinned, membership still active.
+    const [managedRow] = await app.db
+      .select({ managerId: agentsTable.managerId, clientId: agentsTable.clientId })
+      .from(agentsTable)
+      .where(eq(agentsTable.uuid, managed.uuid))
+      .limit(1);
+    expect(managedRow?.managerId).toBe(soleAdmin.id);
+    expect(managedRow?.clientId).toBe(clientId);
+    const [memberRow] = await app.db
+      .select({ status: membersTable.status })
+      .from(membersTable)
+      .where(eq(membersTable.id, soleAdmin.id))
+      .limit(1);
+    expect(memberRow?.status).toBe("active");
+  });
+
+  it("allows a sole admin with no managed agents to leave (narrow scope), suspending the human mirror", async () => {
+    const app = getApp();
+    const org = await freshOrg("leave-empty");
+    const soleAdmin = await createMember(app.db, org.id, {
+      username: `empty-${randomUUID().slice(0, 8)}`,
+      displayName: "Sole Admin No Agents",
+      role: "admin",
+    });
+
+    await leaveOrganization(app.db, soleAdmin.id);
+
+    const [memberRow] = await app.db
+      .select({ status: membersTable.status })
+      .from(membersTable)
+      .where(eq(membersTable.id, soleAdmin.id))
+      .limit(1);
+    expect(memberRow?.status).toBe("left");
+    const [mirror] = await app.db
+      .select({ status: agentsTable.status, name: agentsTable.name, clientId: agentsTable.clientId })
+      .from(agentsTable)
+      .where(eq(agentsTable.uuid, soleAdmin.agentId))
+      .limit(1);
+    expect(mirror?.status).toBe("suspended");
+    expect(mirror?.name).not.toBeNull();
+    expect(mirror?.clientId).toBeNull();
+  });
+});

--- a/packages/server/src/__tests__/me-leave-managed-agents.test.ts
+++ b/packages/server/src/__tests__/me-leave-managed-agents.test.ts
@@ -4,7 +4,7 @@ import postgres from "postgres";
 import { describe, expect, it } from "vitest";
 import { agents as agentsTable } from "../db/schema/agents.js";
 import { members as membersTable } from "../db/schema/members.js";
-import { createAgent } from "../services/agent.js";
+import { createAgent, updateAgent } from "../services/agent.js";
 import { retireClient } from "../services/client.js";
 import { createMember } from "../services/member.js";
 import { leaveOrganization } from "../services/membership.js";
@@ -240,6 +240,106 @@ describe("self-service leave: managed non-human agents", () => {
         .from(agentsTable)
         .where(and(eq(agentsTable.managerId, leaver.id), ne(agentsTable.type, "human")));
       expect(stranded).toHaveLength(0);
+    } finally {
+      await raw.end();
+    }
+  });
+
+  it("does not reassign an agent onto a manager who is concurrently leaving (updateAgent managerId)", async () => {
+    const app = getApp();
+    const org = await freshOrg("reassign-race");
+    const owner = await createMember(app.db, org.id, {
+      username: `ra-own-${randomUUID().slice(0, 8)}`,
+      displayName: "Owner",
+      role: "admin",
+    });
+    const leaver = await createMember(app.db, org.id, {
+      username: `ra-lv-${randomUUID().slice(0, 8)}`,
+      displayName: "Reassign Target",
+      role: "admin",
+    });
+    const agent = await createAgent(app.db, {
+      name: `reassign-${randomUUID().slice(0, 8)}`,
+      type: "agent",
+      displayName: "Reassign Me",
+      managerId: owner.id,
+    });
+
+    const raw = postgres(process.env.DATABASE_URL ?? "", { max: 1 });
+    try {
+      await raw`BEGIN`;
+      await raw`UPDATE members SET status = 'left' WHERE id = ${leaver.id}`;
+
+      // updateAgent's in-transaction FOR UPDATE on the target member blocks on
+      // the raw connection's uncommitted row lock; release it so the re-check
+      // observes the now-inactive target. Outcome is lock-driven, not timing.
+      const pending = updateAgent(app.db, agent.uuid, { managerId: leaver.id })
+        .then(() => "updated" as const)
+        .catch((err: unknown) => err);
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      await raw`COMMIT`;
+      const outcome = await pending;
+
+      expect(outcome).not.toBe("updated");
+      expect((outcome as Error)?.message ?? "").toMatch(/not found/i);
+
+      // The agent stays with its original active manager.
+      const [row] = await app.db
+        .select({ managerId: agentsTable.managerId })
+        .from(agentsTable)
+        .where(eq(agentsTable.uuid, agent.uuid))
+        .limit(1);
+      expect(row?.managerId).toBe(owner.id);
+    } finally {
+      await raw.end();
+    }
+  });
+
+  it("does not first-bind a client onto an agent whose manager is concurrently leaving (updateAgent clientId)", async () => {
+    const app = getApp();
+    const org = await freshOrg("bind-race");
+    await createMember(app.db, org.id, {
+      username: `br-fb-${randomUUID().slice(0, 8)}`,
+      displayName: "Fallback Admin",
+      role: "admin",
+    });
+    const owner = await createMember(app.db, org.id, {
+      username: `br-own-${randomUUID().slice(0, 8)}`,
+      displayName: "Owner",
+      role: "admin",
+    });
+    // Unbound agent managed by `owner`; a client owned by owner's user is the
+    // first-bind target.
+    const agent = await createAgent(app.db, {
+      name: `bind-${randomUUID().slice(0, 8)}`,
+      type: "agent",
+      displayName: "Bind Me",
+      managerId: owner.id,
+    });
+    const clientId = await seedClient(app, owner.userId, org.id);
+
+    const raw = postgres(process.env.DATABASE_URL ?? "", { max: 1 });
+    try {
+      await raw`BEGIN`;
+      await raw`UPDATE members SET status = 'left' WHERE id = ${owner.id}`;
+
+      const pending = updateAgent(app.db, agent.uuid, { clientId })
+        .then(() => "bound" as const)
+        .catch((err: unknown) => err);
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      await raw`COMMIT`;
+      const outcome = await pending;
+
+      expect(outcome).not.toBe("bound");
+      expect((outcome as Error)?.message ?? "").toMatch(/not found/i);
+
+      // The agent was not pinned to the departing owner's client.
+      const [row] = await app.db
+        .select({ clientId: agentsTable.clientId })
+        .from(agentsTable)
+        .where(eq(agentsTable.uuid, agent.uuid))
+        .limit(1);
+      expect(row?.clientId).toBeNull();
     } finally {
       await raw.end();
     }

--- a/packages/server/src/api/agent/ws-client.ts
+++ b/packages/server/src/api/agent/ws-client.ts
@@ -977,6 +977,7 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
                   inboxId: agents.inboxId,
                   status: agents.status,
                   clientId: agents.clientId,
+                  managerId: agents.managerId,
                   runtimeProvider: agents.runtimeProvider,
                   clientUserId: clients.userId,
                   managerUserId: members.userId,
@@ -1026,11 +1027,21 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
               // the operator brought up a client, or migrated from pre-M1 with
               // no presence record). The race-safe UPDATE returns 0 rows if
               // another bind claimed it first — surface as WRONG_CLIENT.
+              //
+              // The claim is also pinned to the `managerId` read above. A
+              // concurrent leave/remove transfers a departing member's managed
+              // agents by *changing* their `managerId` and clearing the pin, so
+              // requiring the manager to be unchanged closes the departure race:
+              // if the transfer already landed, the claim matches 0 rows and is
+              // rejected instead of re-pinning the departed owner's client onto a
+              // now-transferred agent (which would revive the retireClient
+              // deadlock); if this claim lands first, the departure's
+              // managerId-keyed transfer still re-scans and unpins it.
               if (agent.clientId === null) {
                 const claim = await app.db
                   .update(agents)
                   .set({ clientId, updatedAt: new Date() })
-                  .where(and(eq(agents.uuid, agent.id), isNull(agents.clientId)))
+                  .where(and(eq(agents.uuid, agent.id), isNull(agents.clientId), eq(agents.managerId, agent.managerId)))
                   .returning({ uuid: agents.uuid });
                 if (claim.length === 0) {
                   sendRejected(socket, ref, AGENT_BIND_REJECT_REASONS.WRONG_CLIENT);

--- a/packages/server/src/services/agent.ts
+++ b/packages/server/src/services/agent.ts
@@ -508,6 +508,32 @@ export async function createAgent(
     // Wrap both inserts in a transaction so the agent row is never visible
     // without its companion `agent_configs` row.
     const agent = await db.transaction(async (tx) => {
+      // Close the leave/remove race for non-human agents: lock the manager's
+      // member row and re-confirm it is still active inside the same
+      // transaction that inserts the agent. `deactivateMembership` (leave) and
+      // `deleteMember` (admin removal) both lock the departing member
+      // `FOR UPDATE` before scanning and reassigning the agents it manages, so
+      // taking the same lock here makes the two paths mutually exclusive: a
+      // create that began while the member was still active either (a) commits
+      // first, so the departure's scan sees this agent and reassigns/unpins it,
+      // or (b) blocks until the departure commits and then sees the member is no
+      // longer active and aborts — instead of stranding a freshly-created agent
+      // on a left/removed manager (which would re-create the pinned-and-orphaned
+      // state issue #1353 fixes). Human mirrors are skipped: they are created in
+      // the member-bootstrap transaction before the member row exists, so there
+      // is nothing to lock and the deferred FK validates them at commit.
+      if (data.type !== AGENT_TYPES.HUMAN) {
+        const [stillActive] = await tx
+          .select({ id: members.id })
+          .from(members)
+          .where(and(eq(members.id, managerId), eq(members.status, "active")))
+          .for("update")
+          .limit(1);
+        if (!stillActive) {
+          throw new BadRequestError(`Manager "${managerId}" not found`);
+        }
+      }
+
       const [row] = await tx
         .insert(agents)
         .values({

--- a/packages/server/src/services/agent.ts
+++ b/packages/server/src/services/agent.ts
@@ -1040,6 +1040,7 @@ export async function updateAgent(db: Database, uuid: string, data: UpdateAgent)
   // Omitting the field leaves the column untouched.
   if (data.avatarColorToken !== undefined) updates.avatarColorToken = data.avatarColorToken;
 
+  let newManagerId: string | undefined;
   if (data.managerId !== undefined) {
     if (data.managerId === null) {
       throw new BadRequestError("managerId cannot be cleared — every agent must have a manager");
@@ -1056,46 +1057,79 @@ export async function updateAgent(db: Database, uuid: string, data: UpdateAgent)
       throw new BadRequestError("Manager must belong to the same organization as the agent");
     }
     updates.managerId = data.managerId;
+    newManagerId = data.managerId;
   }
 
-  // First-set clientId (NULL → ID): validate ownership against the agent's
-  // current manager. Reuses the resolveAgentClient ownership check so the
-  // semantics match agent creation.
-  //
-  // With re-bind removed, this first bind is the ONLY path an unbound agent
-  // gets a computer, so it must also run the runtime-provider capability gate
-  // — createAgent runs it on the create-with-client path. Without it an agent
-  // could be bound to a client that does not report its provider (e.g. create
-  // an unbound `codex` agent, then bind it to a client reporting codex
-  // missing/error).
-  if (data.clientId !== undefined && data.clientId !== null && agent.clientId === null) {
-    const resolvedClientId = await resolveAgentClient(db, {
-      clientId: data.clientId,
-      managerId: updates.managerId ?? agent.managerId,
-      type: agent.type,
-    });
-    if (resolvedClientId !== null) {
-      // `agents.runtime_provider` is a text column (typed `string`); narrow it
-      // back to the RuntimeProvider union before the capability check.
-      await ensureClientSupportsRuntimeProvider(
-        db,
-        resolvedClientId,
-        runtimeProviderSchema.parse(agent.runtimeProvider),
-      );
-      updates.clientId = resolvedClientId;
+  const reassigningManager = newManagerId !== undefined && newManagerId !== agent.managerId;
+  // First-set clientId (NULL → ID): with re-bind removed, this first bind is the
+  // ONLY path an unbound agent gets a computer. Its ownership is validated
+  // against the manager (reused from createAgent), and it must run the
+  // runtime-provider capability gate. Both the resolution and the write happen
+  // under lock inside the mutation transaction below so they are departure-safe.
+  // `undefined` means "not a first-bind"; a non-null id means "bind to this".
+  const bindClientId =
+    data.clientId !== undefined && data.clientId !== null && agent.clientId === null ? data.clientId : undefined;
+  // The membership whose active state gates this write: the new manager when
+  // reassigning, otherwise the agent's current manager (whose user must own the
+  // client a first-bind pins to).
+  const gatingManagerId = reassigningManager && newManagerId !== undefined ? newManagerId : agent.managerId;
+
+  await db.transaction(async (tx) => {
+    // Close the reassignment/leave and first-bind/leave races. When this update
+    // reassigns the manager or first-binds a client, lock the gating member row
+    // FOR UPDATE and re-confirm it is active — in the SAME member→agent lock
+    // order `deactivateMembership` (leave) and `deleteMember` (admin removal)
+    // use (member row first, then the agent rows they scan/transfer), so the
+    // paths serialize without deadlocking. A departure of the gating member is
+    // then mutually exclusive with this write: it either commits first (and the
+    // departure's scan transfers/unpins the agent) or blocks until the departure
+    // commits and aborts here on the now-inactive manager. This prevents both a
+    // reassignment landing on a departed member and a stale first-bind re-pinning
+    // the departed owner's client onto an agent leave just transferred + unpinned
+    // (which would revive the retireClient deadlock issue #1353 removes).
+    if (reassigningManager || bindClientId !== undefined) {
+      const [activeManager] = await tx
+        .select({ id: members.id })
+        .from(members)
+        .where(and(eq(members.id, gatingManagerId), eq(members.status, "active")))
+        .for("update")
+        .limit(1);
+      if (!activeManager) {
+        throw new BadRequestError(`Manager "${gatingManagerId}" not found`);
+      }
     }
-  }
 
-  const [updated] = await db.update(agents).set(updates).where(eq(agents.uuid, agent.uuid)).returning();
+    if (bindClientId !== undefined) {
+      const resolvedClientId = await resolveAgentClient(tx, {
+        clientId: bindClientId,
+        managerId: gatingManagerId,
+        type: agent.type,
+      });
+      if (resolvedClientId !== null) {
+        // `agents.runtime_provider` is a text column (typed `string`); narrow it
+        // back to the RuntimeProvider union before the capability check.
+        await ensureClientSupportsRuntimeProvider(
+          tx,
+          resolvedClientId,
+          runtimeProviderSchema.parse(agent.runtimeProvider),
+        );
+        updates.clientId = resolvedClientId;
+      }
+    }
 
-  if (!updated) throw new Error("Unexpected: UPDATE RETURNING produced no row");
-  // If the manager was reassigned, watcher rows anchored on the old
-  // manager need to drop and the new manager's rows need to appear.
-  // Recompute is keyed by agent (not chat) since this single agent may
-  // participate in many chats.
-  if (data.managerId !== undefined && data.managerId !== agent.managerId) {
-    await recomputeWatchersForAgent(db, agent.uuid);
-  }
+    const [row] = await tx.update(agents).set(updates).where(eq(agents.uuid, agent.uuid)).returning();
+    if (!row) throw new Error("Unexpected: UPDATE RETURNING produced no row");
+
+    // If the manager was reassigned, watcher rows anchored on the old manager
+    // need to drop and the new manager's rows need to appear. Recompute is
+    // keyed by agent (not chat) since this single agent may participate in many
+    // chats. Inside the transaction so the manager change and its watcher
+    // fan-out commit atomically.
+    if (reassigningManager) {
+      await recomputeWatchersForAgent(tx, agent.uuid);
+    }
+    return row;
+  });
   // Re-fetch via the unified projection so the wire response carries
   // `runtimeState` like every other single-agent endpoint.
   const refreshed = await selectAgentRowWithRuntime(db, agent.uuid);

--- a/packages/server/src/services/membership.ts
+++ b/packages/server/src/services/membership.ts
@@ -286,15 +286,22 @@ export async function deactivateMembership(
 
     // Reassign the member's non-human agents to a sibling admin and unpin them.
     // The human mirror (a HUMAN-typed self-managed agent) is excluded here and
-    // suspended separately below. Scope is strictly `managerId = memberId`:
-    // agents the same user still manages via other active memberships keep
-    // their `clientId`, so a client shared across the user's orgs may still
-    // (correctly) hold pinned agents the user can reach — only the agents
-    // stranded by THIS departure are unpinned.
-    const managed = await tx
-      .select({ uuid: agents.uuid })
-      .from(agents)
-      .where(and(eq(agents.managerId, memberId), ne(agents.type, AGENT_TYPES.HUMAN)));
+    // suspended separately below. Scope is strictly `managerId = memberId` and
+    // non-deleted: agents the same user still manages via other active
+    // memberships keep their `clientId` (a client shared across the user's orgs
+    // may still correctly hold pinned agents the user can reach), and deleted
+    // tombstones are skipped entirely — `retireClient` already treats them as
+    // non-blocking, and counting them would trap a sole admin who followed the
+    // 409's "delete these agents first" guidance: the tombstone keeps its
+    // `managerId`, so an unfiltered count would still see managed agents with
+    // no fallback admin and 409 forever. Suspended agents still count — they
+    // remain live, manageable, and may still carry a `clientId`.
+    const managedFilter = and(
+      eq(agents.managerId, memberId),
+      ne(agents.type, AGENT_TYPES.HUMAN),
+      ne(agents.status, AGENT_STATUSES.DELETED),
+    );
+    const managed = await tx.select({ uuid: agents.uuid }).from(agents).where(managedFilter);
 
     let transferredAgentIds: string[] = [];
     if (managed.length > 0) {
@@ -308,7 +315,7 @@ export async function deactivateMembership(
       const transferred = await tx
         .update(agents)
         .set({ managerId: fallback.id, clientId: null, updatedAt: new Date() })
-        .where(and(eq(agents.managerId, memberId), ne(agents.type, AGENT_TYPES.HUMAN)))
+        .where(managedFilter)
         .returning({ uuid: agents.uuid });
       for (const { uuid } of transferred) {
         await recomputeWatchersForAgent(tx, uuid);

--- a/packages/server/src/services/membership.ts
+++ b/packages/server/src/services/membership.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from "node:crypto";
 import { AGENT_STATUSES, AGENT_TYPES } from "@first-tree/shared";
-import { and, desc, eq, inArray, ne, sql } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, ne, sql } from "drizzle-orm";
 import type { PgDatabase, PgQueryResultHKT } from "drizzle-orm/pg-core";
 import type { Database } from "../db/connection.js";
 import { agents } from "../db/schema/agents.js";
@@ -9,7 +9,9 @@ import { organizations } from "../db/schema/organizations.js";
 import { users } from "../db/schema/users.js";
 import { BadRequestError, ConflictError, NotFoundError } from "../errors.js";
 import { uuidv7 } from "../uuid.js";
-import { recomputeWatchersForMember } from "./watcher.js";
+import { forceDisconnect } from "./connection-manager.js";
+import * as presenceService from "./presence.js";
+import { recomputeWatchersForAgent, recomputeWatchersForMember } from "./watcher.js";
 
 /**
  * Helpers used by the SaaS onboarding flow to create / reuse / leave a
@@ -230,26 +232,109 @@ function appendAgentNameSuffix(base: string, suffix: string): string {
  * The human mirror becomes suspended, not deleted, so names and historical
  * attribution remain intact and a future explicit restore can reactivate the
  * same member+agent pair.
+ *
+ * The non-human agents this member manages are reassigned to a fallback active
+ * admin and unpinned (`clientId = null`), mirroring the admin removal path in
+ * `member.ts::deleteMember`. Without this, a self-service leave would strand
+ * those agents `active` and pinned to the user's client, and `retireClient`'s
+ * guard would later deadlock the user out of retiring their own computer
+ * (issue #1353). The whole reassignment + lifecycle flip runs in one
+ * transaction so a concurrent `createAgent`/`deleteMember` cannot interleave;
+ * the runtime force-disconnect/unbind happens after commit.
+ *
+ * Scope is deliberately narrow: leave is blocked only when the member actually
+ * manages non-human agents AND no other active admin exists to inherit them.
+ * A member with no managed non-human agents may still leave even as the sole
+ * admin — the broader "an org should keep an admin" concern is a separate org
+ * lifecycle question this function does not take on.
  */
 export async function deactivateMembership(
-  db: DbLike,
+  db: Database,
   memberId: string,
   status: typeof MEMBER_STATUSES.LEFT | typeof MEMBER_STATUSES.REMOVED,
 ) {
-  const [existing] = await db.select().from(members).where(eq(members.id, memberId)).limit(1);
-  if (!existing) throw new NotFoundError(`Membership "${memberId}" not found`);
-  if (existing.status !== MEMBER_STATUSES.ACTIVE && existing.status !== status) {
-    throw new ConflictError(`Membership "${memberId}" is not active`);
+  const { existing, transferredAgentIds } = await db.transaction(async (tx) => {
+    // Read the org up-front (unlocked) so the admin lock below is scoped to it,
+    // then lock the active-admin set in a deterministic order — identical lock
+    // ordering to `deleteMember` so concurrent removals/leaves in the same org
+    // serialize instead of deadlocking on the admin selection.
+    const [targetRef] = await tx
+      .select({ organizationId: members.organizationId })
+      .from(members)
+      .where(eq(members.id, memberId))
+      .limit(1);
+    if (!targetRef) throw new NotFoundError(`Membership "${memberId}" not found`);
+
+    const activeAdmins = await tx
+      .select({ id: members.id })
+      .from(members)
+      .where(
+        and(
+          eq(members.organizationId, targetRef.organizationId),
+          eq(members.role, "admin"),
+          eq(members.status, MEMBER_STATUSES.ACTIVE),
+        ),
+      )
+      .orderBy(asc(members.id))
+      .for("update");
+
+    const [existing] = await tx.select().from(members).where(eq(members.id, memberId)).for("update").limit(1);
+    if (!existing) throw new NotFoundError(`Membership "${memberId}" not found`);
+    if (existing.status !== MEMBER_STATUSES.ACTIVE && existing.status !== status) {
+      throw new ConflictError(`Membership "${memberId}" is not active`);
+    }
+
+    // Reassign the member's non-human agents to a sibling admin and unpin them.
+    // The human mirror (a HUMAN-typed self-managed agent) is excluded here and
+    // suspended separately below. Scope is strictly `managerId = memberId`:
+    // agents the same user still manages via other active memberships keep
+    // their `clientId`, so a client shared across the user's orgs may still
+    // (correctly) hold pinned agents the user can reach — only the agents
+    // stranded by THIS departure are unpinned.
+    const managed = await tx
+      .select({ uuid: agents.uuid })
+      .from(agents)
+      .where(and(eq(agents.managerId, memberId), ne(agents.type, AGENT_TYPES.HUMAN)));
+
+    let transferredAgentIds: string[] = [];
+    if (managed.length > 0) {
+      const fallback = activeAdmins.find((admin) => admin.id !== memberId);
+      if (!fallback) {
+        throw new ConflictError(
+          `Cannot leave the organization — you manage ${managed.length} agent(s) here and there is no other ` +
+            "active admin to take them over. Add another admin, or delete these agents, before leaving.",
+        );
+      }
+      const transferred = await tx
+        .update(agents)
+        .set({ managerId: fallback.id, clientId: null, updatedAt: new Date() })
+        .where(and(eq(agents.managerId, memberId), ne(agents.type, AGENT_TYPES.HUMAN)))
+        .returning({ uuid: agents.uuid });
+      for (const { uuid } of transferred) {
+        await recomputeWatchersForAgent(tx, uuid);
+      }
+      transferredAgentIds = transferred.map((agent) => agent.uuid);
+    }
+
+    if (existing.status !== status) {
+      await tx.update(members).set({ status }).where(eq(members.id, memberId));
+    }
+    await tx
+      .update(agents)
+      .set({ status: AGENT_STATUSES.SUSPENDED, clientId: null, updatedAt: new Date() })
+      .where(eq(agents.uuid, existing.agentId));
+    await recomputeWatchersForMember(tx, memberId);
+    return { existing, transferredAgentIds };
+  });
+
+  // After commit: drop any live runtime presence for the reassigned agents so
+  // they re-evaluate binding under their new manager instead of the departed
+  // member's client.
+  for (const agentId of transferredAgentIds) {
+    forceDisconnect(agentId, "member_left");
+    await presenceService.unbindAgent(db, agentId);
   }
 
-  if (existing.status !== status) {
-    await db.update(members).set({ status }).where(eq(members.id, memberId));
-  }
-  await db
-    .update(agents)
-    .set({ status: AGENT_STATUSES.SUSPENDED, clientId: null, updatedAt: new Date() })
-    .where(eq(agents.uuid, existing.agentId));
-  await recomputeWatchersForMember(db, memberId);
   return { ...existing, status };
 }
 

--- a/packages/web/src/components/__tests__/team-switcher-dom.test.tsx
+++ b/packages/web/src/components/__tests__/team-switcher-dom.test.tsx
@@ -375,6 +375,10 @@ describe("TeamSwitcher", () => {
 
     expect(document.body.querySelector('[role="dialog"]')?.textContent).toContain("Leave Acme Robotics?");
     expect(document.body.textContent).toContain("This removes only your membership");
+    // issue 1353: the modal warns up-front that managed agents are transferred and
+    // unpinned, and that leaving is blocked if no other admin can inherit them.
+    expect(document.body.textContent).toContain("transferred to another admin and unpinned from your computers");
+    expect(document.body.textContent).toContain("leaving is blocked until another admin can take them over");
 
     await click(buttonByText(document.body, "Leave team"));
 

--- a/packages/web/src/components/team-switcher.tsx
+++ b/packages/web/src/components/team-switcher.tsx
@@ -501,13 +501,18 @@ export function TeamSwitcher({
           <DialogHeader>
             <DialogTitle>Leave {currentOrg.displayName}?</DialogTitle>
             <DialogDescription style={{ color: "var(--fg-2)" }}>
-              This removes only your membership from this team. The team, agents, settings, and historical work stay
-              intact.
+              This removes only your membership from this team. The team, its settings, and its history stay intact.
             </DialogDescription>
           </DialogHeader>
-          <div className="rounded-[var(--radius-panel)] border p-3 text-body" style={{ borderColor: "var(--border)" }}>
-            You will need an invite to join this team again. If you are the last admin, the team may be left without an
-            active administrator.
+          <div
+            className="flex flex-col gap-2 rounded-[var(--radius-panel)] border p-3 text-body"
+            style={{ borderColor: "var(--border)" }}
+          >
+            <span>You will need an invite to join this team again.</span>
+            <span>
+              Any agents you manage here will be transferred to another admin and unpinned from your computers. If you
+              are the only admin and still manage agents, leaving is blocked until another admin can take them over.
+            </span>
           </div>
           {leaveMutation.error instanceof Error && (
             <p className="text-body" style={{ color: "var(--state-error)" }}>

--- a/packages/web/src/pages/clients.tsx
+++ b/packages/web/src/pages/clients.tsx
@@ -46,15 +46,17 @@ import { NewConnectionDialog } from "./clients/new-connection-dialog.js";
  * Data-source split (admin vs member):
  *   - **member** mode reads `/me/clients` only — single block, no Owner column,
  *     identical layout to pre-admin-view.
- *   - **admin** mode reads `/orgs/:orgId/clients` as the *single source of truth*
- *     and splits client-side into "Your computers" + "Team computers". The
- *     admin happy path deliberately does NOT call `/me/clients` (the two
- *     endpoints poll on a 10s cadence and a dual-source approach would let
- *     the user's own rows briefly disagree between the blocks on each tick).
- *     `/me/clients` is only resurrected as a *fallback* when the org-scoped
- *     listing errors out, so admins still see something instead of an empty
- *     page. Owner lookup uses `/orgs/:orgId/members` with `staleTime: 60s`
- *     and no polling to keep the Owner cell from flickering.
+ *   - **admin** mode reads `/orgs/:orgId/clients` for the "Team computers"
+ *     block and splits client-side into "Your computers" + "Team computers".
+ *     `/me/clients` is *also* fetched and unioned (deduped by id) into the
+ *     viewer's own block only — so a client the viewer owns that the
+ *     org-scoped view omits (e.g. after leaving the team that minted its
+ *     agents, issue 1353) still surfaces and stays retirable. The union is
+ *     one-directional (own block only) and dedups by id, so no row is shown
+ *     twice and the per-tick block-disagreement the single-source design
+ *     guarded against cannot occur. Owner lookup uses `/orgs/:orgId/members`
+ *     with `staleTime: 60s` and no polling to keep the Owner cell from
+ *     flickering.
  */
 export function ClientsPage({ embedded = false }: { embedded?: boolean } = {}) {
   const queryClient = useQueryClient();
@@ -130,13 +132,16 @@ export function ClientsPage({ embedded = false }: { embedded?: boolean } = {}) {
     refetchInterval: 10_000,
   });
 
-  // member mode → primary data source. admin mode → only enabled as a
-  // fallback when `/orgs/:orgId/clients` errors out (see §6 of the design
-  // doc), so the admin happy path stays single-source.
+  // member mode → primary data source. admin mode → always fetched too and
+  // unioned into the viewer's *own* block (see `mineList`). `/me/clients` is
+  // the authoritative cross-org "my computers" list, so a client the viewer
+  // owns that the org-scoped admin view omits (e.g. after leaving the team
+  // that minted its agents — issue 1353) still surfaces and stays retirable.
+  // The Team block stays org-scoped, so no row is shown twice.
   const meClientsQuery = useQuery({
     queryKey: ["clients", "me"],
     queryFn: listClients,
-    enabled: !isAdmin || orgClientsQuery.isError,
+    enabled: true,
     refetchInterval: 10_000,
   });
 
@@ -217,9 +222,18 @@ export function ClientsPage({ embedded = false }: { embedded?: boolean } = {}) {
   // churn reshuffle same-state computers. `userId === null` (legacy clients
   // that pre-date user binding) lands in the team block.
   const mineList = useMemo<HubClient[]>(() => {
-    if (!grouped || !orgClientsData || !viewerUserId) return [];
-    return [...orgClientsData].filter((c) => c.userId === viewerUserId).sort(compareByPillPriority);
-  }, [grouped, orgClientsData, viewerUserId]);
+    if (!grouped || !viewerUserId) return [];
+    // Seed from `/me/clients` so a viewer-owned client the org-scoped admin
+    // view omits still appears in "Your computers" (issue 1353). Org-scoped
+    // rows win on overlap — they carry the same owner-resolution context as
+    // the Team block, keeping fields consistent across the page.
+    const byId = new Map<string, HubClient>();
+    for (const c of meClientsData ?? []) byId.set(c.id, c);
+    for (const c of orgClientsData ?? []) {
+      if (c.userId === viewerUserId) byId.set(c.id, c);
+    }
+    return [...byId.values()].sort(compareByPillPriority);
+  }, [grouped, orgClientsData, meClientsData, viewerUserId]);
 
   const teamList = useMemo<HubClient[]>(() => {
     if (!grouped || !orgClientsData || !viewerUserId) return [];
@@ -268,22 +282,27 @@ export function ClientsPage({ embedded = false }: { embedded?: boolean } = {}) {
   };
 
   // Single source of truth for "what the user is looking at right now": admin
-  // grouped mode → the org-scoped list (covers both mineList + teamList);
-  // member mode → the pill-sorted memberList. Driving the subtitle and the
-  // empty-state branch off this list keeps the two display modes in sync.
-  const clients = grouped ? orgClientsData : memberList;
+  // grouped mode → the viewer's own block (which now unions `/me/clients`)
+  // plus the team block; member mode → the pill-sorted memberList. Driving the
+  // empty-state branch off this keeps a viewer with only `/me`-sourced
+  // computers from falling through to the "no computers" CTA (issue 1353).
+  const clients = grouped ? [...mineList, ...teamList] : memberList;
 
   // "Are we still waiting on the primary listing?" — distinct from `!clients`
   // because once a query resolves with an empty array we want to drop out of
   // loading and show the empty state. Without this gate, admins see the empty
-  // CTA flash before the org-scoped query lands on first paint. Demo mode
-  // short-circuits since fixtures are synchronous.
+  // CTA flash before the org-scoped query lands on first paint. The admin
+  // happy path now also waits on `/me/clients`, since `mineList` unions it —
+  // otherwise an admin whose org view resolves empty *before* `/me` lands
+  // would flash the "no computers" CTA for one tick before their own
+  // `/me`-sourced rows pop in (issue 1353). Demo mode short-circuits since
+  // fixtures are synchronous.
   const clientsLoading = demoScenario
     ? false
     : isAdmin
       ? orgClientsQuery.isError
         ? meClientsQuery.isLoading
-        : orgClientsQuery.isLoading
+        : orgClientsQuery.isLoading || meClientsQuery.isLoading
       : meClientsQuery.isLoading;
 
   // Subtitle is a short static description matching the rest of

--- a/packages/web/src/pages/clients/__tests__/clients-page-cards-dom.test.tsx
+++ b/packages/web/src/pages/clients/__tests__/clients-page-cards-dom.test.tsx
@@ -489,8 +489,26 @@ describe("ClientsPage computer cards", () => {
     await waitForText(fallback.container, "gandy-macbook");
     await act(async () => fallback.root.unmount());
 
-    activityMocks.listOrgClients.mockResolvedValueOnce([]);
-    activityMocks.listClients.mockResolvedValueOnce([
+    // issue 1353: an admin whose org-scoped view omits a client they own — e.g. the
+    // computer whose agents lived in a team they just left — still sees it
+    // under "Your computers" via the `/me/clients` union, so it stays
+    // retirable instead of becoming invisible and undeletable.
+    activityMocks.listOrgClients.mockResolvedValue([]);
+    activityMocks.listClients.mockResolvedValue([client({ id: "client-mine", hostname: "my-leftover" })]);
+    const ownVisible = await renderDom(<ClientsPage />);
+    await waitForText(ownVisible.container, "Your computers");
+    await waitForText(ownVisible.container, "my-leftover");
+    await act(async () => ownVisible.root.unmount());
+
+    // Truly-empty admin (no org rows, no own rows) still gets the empty-state
+    // CTA, and a freshly-connected machine is detected and announced. The
+    // dialog's one-shot poll reads `/me/clients`, so the arrival row is staged
+    // before the connect click.
+    activityMocks.listOrgClients.mockResolvedValue([]);
+    activityMocks.listClients.mockResolvedValue([]);
+    const emptyAdmin = await renderDom(<ClientsPage />);
+    await waitForText(emptyAdmin.container, "No computers connected yet.");
+    activityMocks.listClients.mockResolvedValue([
       client({
         id: "client-new",
         hostname: "new-machine",
@@ -498,8 +516,6 @@ describe("ClientsPage computer cards", () => {
         connectedAt: new Date(Date.now() + 1000).toISOString(),
       }),
     ]);
-    const emptyAdmin = await renderDom(<ClientsPage />);
-    await waitForText(emptyAdmin.container, "No computers connected yet.");
     await click(exactButton(emptyAdmin.container, "Connect your first computer"));
     await waitForText(document.body, "new-machine");
     await waitForText(document.body, "connected. Closing");


### PR DESCRIPTION
## Summary

Fixes #1353. Self-service "leave team" left the non-human agents the departing member managed `active` and still pinned to the user's client. Because `retireClient` refuses to retire a client while any non-deleted agent is pinned — and a departed member can no longer reach the old team's agents — the user was deadlocked out of retiring their own computer.

This aligns leave with the admin-removal path (`deleteMember`), which already handled this correctly.

## Backend

`leaveOrganization` → `deactivateMembership` now, inside one transaction:

- Reassigns the member's **non-human** agents to a fallback active admin (`managerId = fallback`, `clientId = null`) and recomputes watchers per agent — mirroring `deleteMember`, with identical active-admin `FOR UPDATE` lock ordering so concurrent leave/remove in the same org serialize instead of deadlocking.
- Suspends the human mirror and flips the membership (unchanged behavior).
- After commit, force-disconnects + unbinds the transferred agents from runtime presence.

**Policy (intentional, narrow scope):** leave is **blocked with a 409** only when the member manages non-human agents **and** no other active admin exists to inherit them — the error tells the user to add another admin or delete the agents first. A member who manages no non-human agents may still leave even as the sole admin (the "an org should keep an admin" concern is a separate org-lifecycle question this PR does not take on). **Never auto-deletes** agents — transfer + unpin is the safe behavior.

Scope is strictly `managerId = memberId`: agents the same user still manages via **other** active memberships keep their `clientId` by design (they remain reachable).

## Web

- **Leave-team modal** (`team-switcher.tsx`): states the impact up front — agents you manage here are transferred to another admin and unpinned from your computers, and leaving is blocked if no other admin can inherit them. The blocked-path 409 message is surfaced inline.
- **Computers page** (`clients.tsx`): admin mode now also fetches `/me/clients` and unions it (deduped by id, org row wins) into the viewer's **own** block only, so a client whose agents lived in a team the user left stays visible and retirable even when the org-scoped admin view omits it. The "Team computers" block stays org-scoped, so no row is shown twice.

## Tests

- Server (`me-leave-managed-agents.test.ts`): transfer→unpin→`retireClient` unblocked; the no-fallback-admin block (and that nothing mutates); sole-admin-with-no-agents leave succeeds.
- Web: Computers visibility fix (admin whose org view omits an owned client still sees it under "Your computers") and the leave-modal impact copy.

All suites green locally: server 1605/1605, web 1047/1047; typecheck, `lint:tokens`, biome clean.

## Context Tree

The durable constraint (leave/removal reassigns managed non-human agents to a fallback admin + unpins; blocks when none) was missing from the tree's Member Lifecycle section. Tree PR: agent-team-foundation/first-tree-context#640

🤖 Generated with [Claude Code](https://claude.com/claude-code)
