### PR TITLE
Fix skill eval sandbox shim verification

### DIFF
--- a/packages/skill-evals/src/core/__tests__/first-tree-shim.test.ts
+++ b/packages/skill-evals/src/core/__tests__/first-tree-shim.test.ts
@@ -1,0 +1,148 @@
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+import { readEvents } from "../events.js";
+import { createRunPaths } from "../paths.js";
+import { createFirstTreeShim } from "../shims/first-tree.js";
+
+describe("first-tree eval shim", () => {
+  it("handles tree tree help without spawning the real CLI", () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), "skill-evals-first-tree-shim-test-"));
+    try {
+      const packageRoot = join(repoRoot, "packages", "skill-evals");
+      mkdirSync(packageRoot, { recursive: true });
+      const paths = createRunPaths({
+        caseId: "first-tree-shim-tree-test",
+        packageRoot,
+        startedAt: "2026-06-30T00:00:00.000Z",
+      });
+      createFirstTreeShim(paths);
+
+      const result = spawnSync(join(paths.binDir, "first-tree"), ["tree", "tree", "--help"], {
+        cwd: paths.workspacePath,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          FIRST_TREE_EVAL_EVENTS: paths.eventsPath,
+          FIRST_TREE_EVAL_PHASE: "model",
+        },
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain("Usage: first-tree tree tree");
+      expect(readEvents(paths.eventsPath)).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            argv: ["tree", "tree", "--help"],
+            exitCode: 0,
+            shimmedByEval: true,
+            type: "first_tree_result",
+          }),
+        ]),
+      );
+    } finally {
+      rmSync(repoRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("uses the built CLI entry when a command is not handled by the shim", () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), "skill-evals-first-tree-shim-test-"));
+    try {
+      const packageRoot = join(repoRoot, "packages", "skill-evals");
+      const distCliDir = join(repoRoot, "apps", "cli", "dist", "cli");
+      const tsxBinDir = join(packageRoot, "node_modules", ".bin");
+      mkdirSync(distCliDir, { recursive: true });
+      mkdirSync(tsxBinDir, { recursive: true });
+      writeFileSync(
+        join(distCliDir, "index.mjs"),
+        "process.stdout.write(JSON.stringify(process.argv.slice(2)) + '\\n');\n",
+        "utf8",
+      );
+      const tsxBin = join(tsxBinDir, "tsx");
+      writeFileSync(tsxBin, "#!/bin/sh\nexit 88\n", "utf8");
+      chmodSync(tsxBin, 0o755);
+
+      const paths = createRunPaths({
+        caseId: "first-tree-shim-dist-test",
+        packageRoot,
+        startedAt: "2026-06-30T00:00:00.000Z",
+      });
+      createFirstTreeShim(paths);
+
+      const result = spawnSync(join(paths.binDir, "first-tree"), ["version"], {
+        cwd: paths.workspacePath,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          FIRST_TREE_EVAL_EVENTS: paths.eventsPath,
+          FIRST_TREE_EVAL_PHASE: "model",
+        },
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout.trim()).toBe(JSON.stringify(["version"]));
+      expect(readEvents(paths.eventsPath)).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            argv: ["version"],
+            exitCode: 0,
+            type: "first_tree_result",
+          }),
+        ]),
+      );
+    } finally {
+      rmSync(repoRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("uses the built CLI entry for tree verify outside the model phase", () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), "skill-evals-first-tree-shim-test-"));
+    try {
+      const packageRoot = join(repoRoot, "packages", "skill-evals");
+      const distCliDir = join(repoRoot, "apps", "cli", "dist", "cli");
+      mkdirSync(distCliDir, { recursive: true });
+      writeFileSync(
+        join(distCliDir, "index.mjs"),
+        "process.stdout.write('real verify ' + JSON.stringify(process.argv.slice(2)) + '\\n');\n",
+        "utf8",
+      );
+
+      const paths = createRunPaths({
+        caseId: "first-tree-shim-post-model-verify-test",
+        packageRoot,
+        startedAt: "2026-06-30T00:00:00.000Z",
+      });
+      createFirstTreeShim(paths);
+
+      const result = spawnSync(join(paths.binDir, "first-tree"), ["tree", "verify", "--tree-path", "context-tree"], {
+        cwd: paths.workspacePath,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          FIRST_TREE_EVAL_EVENTS: paths.eventsPath,
+          FIRST_TREE_EVAL_PHASE: "post_model_validation",
+        },
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout.trim()).toBe('real verify ["tree","verify","--tree-path","context-tree"]');
+      const events = readEvents(paths.eventsPath);
+      expect(events).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            argv: ["tree", "verify", "--tree-path", "context-tree"],
+            exitCode: 0,
+            type: "first_tree_result",
+          }),
+        ]),
+      );
+      const resultEvent = events.find((event) => (event as { type?: string }).type === "first_tree_result");
+      expect(resultEvent).not.toHaveProperty("shimmedByEval");
+    } finally {
+      rmSync(repoRoot, { force: true, recursive: true });
+    }
+  });
+});

--- a/packages/skill-evals/src/core/__tests__/provider.test.ts
+++ b/packages/skill-evals/src/core/__tests__/provider.test.ts
@@ -3,10 +3,12 @@ import { tmpdir } from "node:os";
 import { delimiter, dirname, join } from "node:path";
 
 import { describe, expect, it } from "vitest";
+import { readEvents } from "../events.js";
 import { createRunPaths } from "../paths.js";
-import { codexProviderArgs, codexProviderCommand, codexProviderEnv } from "../provider/codex.js";
+import { codexProviderArgs, codexProviderCommand, codexProviderEnv, runCodexProvider } from "../provider/codex.js";
 import type { ProviderRunContext, ProviderRunOptions } from "../provider/types.js";
 import { createEvalReporter } from "../reporter.js";
+import { createFirstTreeShim } from "../shims/first-tree.js";
 
 function tempPackageRoot(): string {
   return mkdtempSync(join(tmpdir(), "skill-evals-provider-test-"));
@@ -75,6 +77,7 @@ describe("codex provider runner hardening", () => {
       expect(env.HOME).toBe(`${context.paths.runRoot}/provider-home`);
       expect(env.TMPDIR).toBe(`${context.paths.runRoot}/provider-tmp`);
       expect(env.XDG_CACHE_HOME).toBe(`${context.paths.runRoot}/provider-xdg-cache`);
+      expect(env.FIRST_TREE_EVAL_EVENTS).toBe(context.paths.modelEventsPath);
       expect(env.CODEX_HOME).toBe("/codex-auth-home");
       expect(env.OPENAI_API_KEY).toBe("allowed");
       expect(env.FIRST_TREE_SERVER_URL).toBeUndefined();
@@ -88,7 +91,66 @@ describe("codex provider runner hardening", () => {
       expect(args).toContain(`shell_environment_policy.set.HOME=${JSON.stringify(env.HOME)}`);
       expect(args).toContain(`shell_environment_policy.set.TMPDIR=${JSON.stringify(env.TMPDIR)}`);
       expect(args).toContain(
+        `shell_environment_policy.set.FIRST_TREE_EVAL_EVENTS=${JSON.stringify(context.paths.modelEventsPath)}`,
+      );
+      expect(args).toContain(
         `shell_environment_policy.set.FIRST_TREE_EVAL_VERBOSE=${JSON.stringify(env.FIRST_TREE_EVAL_VERBOSE)}`,
+      );
+    } finally {
+      rmSync(packageRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("merges model-writable shim events back into the run event log", async () => {
+    const packageRoot = tempPackageRoot();
+    try {
+      const codexBinDir = join(packageRoot, "operator-codex-bin");
+      mkdirSync(codexBinDir, { recursive: true });
+      const codexBin = join(codexBinDir, "codex");
+      writeFileSync(
+        codexBin,
+        [
+          "#!/bin/sh",
+          "first-tree github issue list >/dev/null 2>/dev/null",
+          "printf '%s\\n' '{\"type\":\"turn.completed\"}'",
+          "exit 0",
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+      chmodSync(codexBin, 0o755);
+
+      const context = fakeContext(packageRoot);
+      createFirstTreeShim(context.paths);
+
+      const exitCode = await runCodexProvider(
+        {
+          bin: codexBin,
+          caseId: "provider-hardening-test",
+          model: null,
+          prompt: "Run the eval case.",
+          verbose: false,
+        },
+        context,
+      );
+
+      expect(exitCode).toBe(0);
+      const events = readEvents(context.paths.eventsPath);
+      expect(events).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            argv: ["github", "issue", "list"],
+            phase: "model",
+            type: "first_tree_call",
+          }),
+          expect.objectContaining({
+            argv: ["github", "issue", "list"],
+            blockedByEval: true,
+            exitCode: 1,
+            phase: "model",
+            type: "first_tree_result",
+          }),
+        ]),
       );
     } finally {
       rmSync(packageRoot, { force: true, recursive: true });

--- a/packages/skill-evals/src/core/fixture-verify.ts
+++ b/packages/skill-evals/src/core/fixture-verify.ts
@@ -17,7 +17,9 @@ type FixtureVerifyCommand = {
 export type RunFixtureVerifyOptions = {
   caseId: string;
   contextTreePath: string;
+  eventTypePrefix?: string;
   paths: RunPaths;
+  phase?: string;
   reporter: EvalReporter;
   sourceEnv?: NodeJS.ProcessEnv;
   verbose: boolean;
@@ -25,6 +27,8 @@ export type RunFixtureVerifyOptions = {
 
 export function runFixtureVerify(options: RunFixtureVerifyOptions): CommandResult {
   const { caseId, contextTreePath, paths, reporter, verbose } = options;
+  const eventTypePrefix = options.eventTypePrefix ?? "fixture_validation";
+  const phase = options.phase ?? "fixture_validation";
   const sourceEnv = options.sourceEnv ?? process.env;
   const args = ["tree", "verify", "--tree-path", contextTreePath];
   const verifyCommand = resolveFixtureVerifyCommand(paths, sourceEnv);
@@ -33,14 +37,15 @@ export function runFixtureVerify(options: RunFixtureVerifyOptions): CommandResul
     command: verifyCommand.command,
     commandSource: verifyCommand.source,
     contextTreePath,
-    type: "fixture_validation_started",
+    phase,
+    type: `${eventTypePrefix}_started`,
   });
   reporter.fixtureValidationStarted(args, contextTreePath);
 
   const result = spawnSync(verifyCommand.command, args, {
     cwd: paths.workspacePath,
     encoding: "utf8",
-    env: fixtureVerifyEnv(paths, caseId, verbose, verifyCommand.source, sourceEnv),
+    env: fixtureVerifyEnv(paths, caseId, verbose, verifyCommand.source, phase, sourceEnv),
     maxBuffer: 20 * 1024 * 1024,
   });
   const stdout = result.stdout ?? "";
@@ -63,9 +68,10 @@ export function runFixtureVerify(options: RunFixtureVerifyOptions): CommandResul
     command: commandResult.command,
     commandSource: verifyCommand.source,
     exitCode: commandResult.exitCode,
+    phase,
     stderrPreview: previewText(commandResult.stderr),
     stdoutPreview: previewText(commandResult.stdout),
-    type: "fixture_validation_finished",
+    type: `${eventTypePrefix}_finished`,
   });
   reporter.fixtureValidationFinished(commandResult);
 
@@ -100,6 +106,7 @@ function fixtureVerifyEnv(
   caseId: string,
   verbose: boolean,
   commandSource: FixtureVerifyCommand["source"],
+  phase: string,
   sourceEnv: NodeJS.ProcessEnv,
 ): NodeJS.ProcessEnv {
   const path = sourceEnv.PATH ?? "";
@@ -107,7 +114,7 @@ function fixtureVerifyEnv(
     ...sourceEnv,
     FIRST_TREE_EVAL_CASE_ID: caseId,
     FIRST_TREE_EVAL_EVENTS: paths.eventsPath,
-    FIRST_TREE_EVAL_PHASE: "fixture_validation",
+    FIRST_TREE_EVAL_PHASE: phase,
     FIRST_TREE_EVAL_VERBOSE: verbose ? "1" : "0",
     PATH: commandSource === "harness-shim" ? prependPath(paths.binDir, path) : path,
   };

--- a/packages/skill-evals/src/core/paths.ts
+++ b/packages/skill-evals/src/core/paths.ts
@@ -14,11 +14,13 @@ export function createRunPaths(options: CreateRunPathsOptions): RunPaths {
   const stamp = options.startedAt.replace(/[-:.]/gu, "");
   const runRoot = join(options.packageRoot, ".runs", `${stamp}-${options.caseId}`);
   const workspacePath = join(runRoot, "workspace");
+  const modelEventDir = join(workspacePath, ".first-tree-eval");
   const binDir = join(runRoot, "bin");
   const shellEnvDir = join(runRoot, "shell-env");
 
   rmSync(runRoot, { force: true, recursive: true });
   mkdirSync(workspacePath, { recursive: true });
+  mkdirSync(modelEventDir, { recursive: true });
   mkdirSync(binDir, { recursive: true });
   mkdirSync(shellEnvDir, { recursive: true });
 
@@ -26,6 +28,7 @@ export function createRunPaths(options: CreateRunPathsOptions): RunPaths {
     binDir,
     eventsPath: join(runRoot, "events.jsonl"),
     gradingJsonPath: join(runRoot, "grading.json"),
+    modelEventsPath: join(modelEventDir, "events.jsonl"),
     packageRoot: options.packageRoot,
     repoRoot,
     runRoot,

--- a/packages/skill-evals/src/core/provider/codex.ts
+++ b/packages/skill-evals/src/core/provider/codex.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { existsSync, mkdirSync } from "node:fs";
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
 import { delimiter, dirname, isAbsolute, join } from "node:path";
 import { createInterface } from "node:readline";
 
@@ -149,7 +149,7 @@ export function codexProviderEnv(
   env.BASH_ENV = join(context.paths.shellEnvDir, "bash-env");
   env.ENV = join(context.paths.shellEnvDir, "sh-env");
   env.FIRST_TREE_EVAL_CASE_ID = options.caseId;
-  env.FIRST_TREE_EVAL_EVENTS = context.paths.eventsPath;
+  env.FIRST_TREE_EVAL_EVENTS = context.paths.modelEventsPath;
   env.FIRST_TREE_EVAL_PHASE = "model";
   env.FIRST_TREE_EVAL_VERBOSE = options.verbose ? "1" : "0";
   env.HOME = providerHome;
@@ -238,6 +238,13 @@ async function waitForChildExit(child: ReturnType<typeof spawn>, context: Provid
   });
 }
 
+function appendModelEvents(context: ProviderRunContext): void {
+  if (!existsSync(context.paths.modelEventsPath)) return;
+  const modelEvents = readFileSync(context.paths.modelEventsPath, "utf8");
+  if (!modelEvents.trim()) return;
+  appendFileSync(context.paths.eventsPath, modelEvents.endsWith("\n") ? modelEvents : `${modelEvents}\n`, "utf8");
+}
+
 export async function runCodexProvider(options: ProviderRunOptions, context: ProviderRunContext): Promise<number> {
   const command = codexProviderCommand(options);
   const env = codexProviderEnv(options, context);
@@ -264,6 +271,7 @@ export async function runCodexProvider(options: ProviderRunOptions, context: Pro
 
   const exitCode = await waitForChildExit(child, context);
   await Promise.all(streamTasks);
+  appendModelEvents(context);
 
   appendEvent(context.paths.eventsPath, {
     caseId: options.caseId,

--- a/packages/skill-evals/src/core/shims/first-tree-staging.ts
+++ b/packages/skill-evals/src/core/shims/first-tree-staging.ts
@@ -11,7 +11,7 @@ export function createFirstTreeStagingShim(paths: RunPaths): void {
 import { spawnSync } from "node:child_process";
 import { appendFileSync } from "node:fs";
 
-const EVENTS_PATH = ${JSON.stringify(paths.eventsPath)};
+const EVENTS_PATH = process.env.FIRST_TREE_EVAL_EVENTS || ${JSON.stringify(paths.eventsPath)};
 
 function preview(value) {
   if (!value) return "";

--- a/packages/skill-evals/src/core/shims/first-tree.ts
+++ b/packages/skill-evals/src/core/shims/first-tree.ts
@@ -7,15 +7,18 @@ import type { RunPaths } from "../types.js";
 
 export function createFirstTreeShim(paths: RunPaths): void {
   const tsxBin = join(paths.packageRoot, "node_modules", ".bin", "tsx");
-  const cliEntry = join(paths.repoRoot, "apps", "cli", "src", "cli", "index.ts");
+  const sourceCliEntry = join(paths.repoRoot, "apps", "cli", "src", "cli", "index.ts");
+  const distCliEntry = join(paths.repoRoot, "apps", "cli", "dist", "cli", "index.mjs");
   const shimPath = join(paths.binDir, "first-tree");
   const script = `#!/usr/bin/env node
 import { spawnSync } from "node:child_process";
-import { appendFileSync } from "node:fs";
+import { appendFileSync, existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { basename, join, relative, resolve } from "node:path";
 
-const EVENTS_PATH = ${JSON.stringify(paths.eventsPath)};
+const EVENTS_PATH = process.env.FIRST_TREE_EVAL_EVENTS || ${JSON.stringify(paths.eventsPath)};
 const TSX_BIN = ${JSON.stringify(tsxBin)};
-const CLI_ENTRY = ${JSON.stringify(cliEntry)};
+const SOURCE_CLI_ENTRY = ${JSON.stringify(sourceCliEntry)};
+const DIST_CLI_ENTRY = ${JSON.stringify(distCliEntry)};
 
 function preview(value) {
   if (!value) return "";
@@ -39,6 +42,157 @@ function trace(message) {
     const caseId = process.env.FIRST_TREE_EVAL_CASE_ID || "unknown";
     process.stderr.write("[" + caseId + "] " + message + "\\n");
   }
+}
+
+function finish(argv, phase, exitCode, stdout, stderr, extra) {
+  if (stdout) process.stdout.write(stdout);
+  if (stderr) process.stderr.write(stderr);
+  append({
+    type: "first_tree_result",
+    phase,
+    argv,
+    cwd: process.cwd(),
+    exitCode,
+    signal: null,
+    stdoutPreview: preview(stdout),
+    stderrPreview: preview(stderr),
+    ...extra,
+  });
+  trace("first-tree result: exit=" + exitCode);
+  process.exit(exitCode);
+}
+
+function optionValue(argv, name) {
+  const index = argv.indexOf(name);
+  return index >= 0 ? argv[index + 1] || null : null;
+}
+
+function treeTreePathArg(argv) {
+  for (let i = 2; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "-L" || arg === "--level" || arg === "-P" || arg === "--pattern") {
+      i += 1;
+      continue;
+    }
+    if (arg === "--no-pull") continue;
+    if (!arg.startsWith("-")) return arg;
+  }
+  return ".";
+}
+
+function walkMarkdown(root) {
+  const files = [];
+  function walk(dir) {
+    let entries = [];
+    try {
+      entries = readdirSync(dir).sort();
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (entry === ".git" || entry === "node_modules") continue;
+      const child = join(dir, entry);
+      let stat;
+      try {
+        stat = statSync(child);
+      } catch {
+        continue;
+      }
+      if (stat.isDirectory()) {
+        walk(child);
+        continue;
+      }
+      if (entry.endsWith(".md")) files.push(child);
+    }
+  }
+  walk(root);
+  return files;
+}
+
+function patternMatches(value, pattern) {
+  if (!pattern) return true;
+  const normalized = value.toLowerCase();
+  const parts = pattern
+    .toLowerCase()
+    .split("*")
+    .map((part) => part.trim())
+    .filter(Boolean);
+  return parts.length === 0 || parts.every((part) => normalized.includes(part));
+}
+
+function titleFromMarkdown(path) {
+  try {
+    const text = readFileSync(path, "utf8");
+    const title = text.match(/^title:\\s*"?([^"\\n]+)"?/m)?.[1];
+    if (title) return title.trim();
+    return text.match(/^#\\s+(.+)$/m)?.[1]?.trim() || basename(path);
+  } catch {
+    return basename(path);
+  }
+}
+
+function runTreeTree(argv, phase) {
+  if (argv.includes("--help") || argv.includes("-h")) {
+    finish(
+      argv,
+      phase,
+      0,
+      "Usage: first-tree tree tree [options] [path]\\n\\nBrowse Context Tree nodes as a hierarchy.\\n\\nOptions:\\n  -L, --level <depth>      max descendant depth below the target directory\\n  -P, --pattern <pattern>  shell-style glob filter matched against path, filename, title, and description\\n  --no-pull                skip the automatic git pull refresh\\n  -h, --help               display help for command\\n",
+      "",
+      { shimmedByEval: true },
+    );
+  }
+
+  const root = resolve(process.cwd(), treeTreePathArg(argv));
+  if (!existsSync(root)) {
+    finish(argv, phase, 1, "", "Context Tree path does not exist: " + root + "\\n", { shimmedByEval: true });
+  }
+
+  const pattern = optionValue(argv, "-P") || optionValue(argv, "--pattern");
+  const rows = [basename(root) + "/ [Context Tree]"];
+  for (const file of walkMarkdown(root)) {
+    const rel = relative(root, file);
+    const title = titleFromMarkdown(file);
+    if (!patternMatches(rel + " " + title, pattern)) continue;
+    rows.push("- " + rel + " [" + title + "]");
+  }
+  finish(argv, phase, 0, rows.join("\\n") + "\\n", "", { shimmedByEval: true });
+}
+
+function runTreeVerify(argv, phase) {
+  const root = resolve(process.cwd(), optionValue(argv, "--tree-path") || ".");
+  const errors = [];
+  if (!existsSync(root)) errors.push("missing tree root");
+  if (!existsSync(join(root, "NODE.md"))) errors.push("missing NODE.md");
+  if (!existsSync(join(root, ".first-tree", "VERSION"))) errors.push("missing .first-tree/VERSION");
+  if (!existsSync(join(root, ".first-tree", "tree.json"))) errors.push("missing .first-tree/tree.json");
+  for (const file of walkMarkdown(root)) {
+    if (basename(file) === "AGENTS.md") continue;
+    const text = readFileSync(file, "utf8");
+    if (!text.startsWith("---")) errors.push(relative(root, file) + " missing frontmatter");
+    if (!/^title:/m.test(text)) errors.push(relative(root, file) + " missing title");
+    if (!/^owners:\\s*\\[/m.test(text)) errors.push(relative(root, file) + " missing owners");
+  }
+
+  if (errors.length > 0) {
+    finish(
+      argv,
+      phase,
+      1,
+      "Context Tree Verification\\n\\n  Tree root: " + root + "\\n\\n" + errors.map((error) => "  [FAIL] " + error).join("\\n") + "\\n",
+      "",
+      { shimmedByEval: true },
+    );
+  }
+
+  finish(
+    argv,
+    phase,
+    0,
+    "Context Tree Verification\\n\\n  Tree root: " + root + "\\n\\n  [PASS] framework version\\n  [PASS] tree state\\n  [PASS] root node frontmatter\\n  [PASS] node validation\\n  [PASS] member validation\\n  [PASS] progress checklist\\n\\nAll checks passed.\\n",
+    "",
+    { shimmedByEval: true },
+  );
 }
 
 const argv = process.argv.slice(2);
@@ -103,8 +257,21 @@ if (argv[0] === "chat" && ["ask", "send", "update"].includes(argv[1] || "")) {
   process.exit(exitCode);
 }
 
-const realCommand = process.env.FIRST_TREE_EVAL_REAL_FIRST_TREE || TSX_BIN;
-const realArgs = process.env.FIRST_TREE_EVAL_REAL_FIRST_TREE ? argv : [CLI_ENTRY, ...argv];
+if (argv[0] === "tree" && argv[1] === "tree") {
+  runTreeTree(argv, phase);
+}
+
+if (phase === "model" && argv[0] === "tree" && argv[1] === "verify") {
+  runTreeVerify(argv, phase);
+}
+
+const hasDistCli = existsSync(DIST_CLI_ENTRY);
+const realCommand = process.env.FIRST_TREE_EVAL_REAL_FIRST_TREE || (hasDistCli ? process.execPath : TSX_BIN);
+const realArgs = process.env.FIRST_TREE_EVAL_REAL_FIRST_TREE
+  ? argv
+  : hasDistCli
+    ? [DIST_CLI_ENTRY, ...argv]
+    : [SOURCE_CLI_ENTRY, ...argv];
 const result = spawnSync(realCommand, realArgs, {
   cwd: process.cwd(),
   encoding: "utf8",

--- a/packages/skill-evals/src/core/shims/gh.ts
+++ b/packages/skill-evals/src/core/shims/gh.ts
@@ -10,7 +10,7 @@ export function createGhShim(paths: RunPaths): void {
   const script = `#!/usr/bin/env node
 import { appendFileSync } from "node:fs";
 
-const EVENTS_PATH = ${JSON.stringify(paths.eventsPath)};
+const EVENTS_PATH = process.env.FIRST_TREE_EVAL_EVENTS || ${JSON.stringify(paths.eventsPath)};
 
 function preview(value) {
   if (!value) return "";

--- a/packages/skill-evals/src/core/types.ts
+++ b/packages/skill-evals/src/core/types.ts
@@ -11,6 +11,7 @@ export type RunPaths = {
   binDir: string;
   eventsPath: string;
   gradingJsonPath: string;
+  modelEventsPath: string;
   packageRoot: string;
   repoRoot: string;
   runRoot: string;

--- a/packages/skill-evals/src/suites/first-tree-read/__tests__/metrics.test.ts
+++ b/packages/skill-evals/src/suites/first-tree-read/__tests__/metrics.test.ts
@@ -154,6 +154,28 @@ describe("first-tree-read metrics pass criteria", () => {
     expect(casePassed(true, result)).toBe(true);
   });
 
+  it("recognizes the user JWT authorization surface when phrased as single authorization surface", () => {
+    const result = deriveMetrics(
+      [
+        skillReadEvent(),
+        firstTreeCall(HELP_ARGV),
+        firstTreeResult(HELP_ARGV, 0),
+        firstTreeCall(["tree", "tree", "systems/server/auth"]),
+        firstTreeResult(["tree", "tree", "systems/server/auth"], 0),
+        assistantTextEvent(`JWT auth routes should:
+- Use user JWT auth as the single authorization surface.
+- Check route scopes against live organization membership before cross-org actions.
+- Follow docs/development/http-path-conventions.md before auth or multi-org route changes.`),
+      ],
+      VALID_FIXTURE,
+      0,
+      JWT_EXPECTED_FACTS,
+    );
+
+    expect(result.expectedFactHits).toEqual([...JWT_EXPECTED_FACTS]);
+    expect(result.expectedFactsObserved).toBe(true);
+  });
+
   it("does not count isolated terms as expected fact concepts", () => {
     const result = deriveMetrics(
       [

--- a/packages/skill-evals/src/suites/first-tree-read/metrics.ts
+++ b/packages/skill-evals/src/suites/first-tree-read/metrics.ts
@@ -11,7 +11,10 @@ type FactMatcher = {
 
 const FACT_MATCHERS: readonly FactMatcher[] = [
   {
-    all: [/user\s+jwt/iu, /(unified authorization surface|统一[^。\n]*授权|统一[^。\n]*身份模型)/iu],
+    all: [
+      /user\s+jwt/iu,
+      /(unified authorization surface|single authorization surface|single authorization model|统一[^。\n]*授权|统一[^。\n]*身份模型)/iu,
+    ],
     fact: "User JWT auth is the unified authorization surface.",
   },
   {

--- a/packages/skill-evals/src/suites/first-tree-seed/__tests__/grader.test.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/__tests__/grader.test.ts
@@ -45,6 +45,7 @@ function baseRunPaths(workspacePath: string): RunPaths {
     binDir: join(workspacePath, "bin"),
     eventsPath: join(workspacePath, "events.jsonl"),
     gradingJsonPath: join(workspacePath, "grading.json"),
+    modelEventsPath: join(workspacePath, ".first-tree-eval", "events.jsonl"),
     packageRoot: workspacePath,
     repoRoot: workspacePath,
     runRoot: workspacePath,

--- a/packages/skill-evals/src/suites/first-tree-welcome/__tests__/grader.test.ts
+++ b/packages/skill-evals/src/suites/first-tree-welcome/__tests__/grader.test.ts
@@ -45,6 +45,7 @@ function baseRunPaths(workspacePath: string): RunPaths {
     binDir: join(workspacePath, "bin"),
     eventsPath: join(workspacePath, "events.jsonl"),
     gradingJsonPath: join(workspacePath, "grading.json"),
+    modelEventsPath: join(workspacePath, ".first-tree-eval", "events.jsonl"),
     packageRoot: workspacePath,
     repoRoot: workspacePath,
     runRoot: workspacePath,

--- a/packages/skill-evals/src/suites/first-tree-write/__tests__/grader.test.ts
+++ b/packages/skill-evals/src/suites/first-tree-write/__tests__/grader.test.ts
@@ -20,6 +20,9 @@ function baseMetrics(overrides: Partial<EvalMetrics>): EvalMetrics {
     firstTreeCommandResults: [],
     fixtureValidationOk: true,
     forbiddenContentHits: [],
+    modelVerifySucceeded: false,
+    postModelVerifyResult: null,
+    postModelVerifySucceeded: null,
     runnerExitCode: 0,
     skillFileReadObserved: true,
     sourceRepoChanged: false,
@@ -67,9 +70,44 @@ describe("first-tree-write grader", () => {
           treeChanged: true,
           treeDiff: "+Deterministic gates are separate from quality judges.\n",
           treeStatus: " M system/context-management/skill-eval-framework.md\n",
+          modelVerifySucceeded: true,
+          postModelVerifyResult: {
+            args: ["tree", "verify", "--tree-path", "/tmp/context-tree"],
+            command: "first-tree",
+            cwd: "/tmp/workspace",
+            exitCode: 0,
+            stderr: "",
+            stdout: "All checks passed.\n",
+          },
+          postModelVerifySucceeded: true,
           verifySucceeded: true,
         }),
       ),
     ).toBe(true);
+  });
+
+  it("fails durable source when the model verify command succeeds but post-model verify fails", () => {
+    expect(
+      casePassed(
+        findCase("durable-source-writes"),
+        baseMetrics({
+          finalResponse: "Updated the tree and verify passed.",
+          treeChanged: true,
+          treeDiff: "+Deterministic gates are separate from quality judges.\n",
+          treeStatus: " M system/context-management/skill-eval-framework.md\n",
+          modelVerifySucceeded: true,
+          postModelVerifyResult: {
+            args: ["tree", "verify", "--tree-path", "/tmp/context-tree"],
+            command: "first-tree",
+            cwd: "/tmp/workspace",
+            exitCode: 1,
+            stderr: "",
+            stdout: "Some checks failed.\n",
+          },
+          postModelVerifySucceeded: false,
+          verifySucceeded: false,
+        }),
+      ),
+    ).toBe(false);
   });
 });

--- a/packages/skill-evals/src/suites/first-tree-write/__tests__/post-model-verify.test.ts
+++ b/packages/skill-evals/src/suites/first-tree-write/__tests__/post-model-verify.test.ts
@@ -1,0 +1,125 @@
+import { rmSync } from "node:fs";
+import { basename, join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { writeText } from "../../../core/commands.js";
+import { runFixtureVerify } from "../../../core/fixture-verify.js";
+import { createRunPaths } from "../../../core/paths.js";
+import { createEvalReporter } from "../../../core/reporter.js";
+import { createFirstTreeShim } from "../../../core/shims/first-tree.js";
+import { FIRST_TREE_WRITE_GATE_CASES } from "../cases.js";
+import { setupFixture } from "../fixture.js";
+import type { FirstTreeWriteEvalCase } from "../types.js";
+
+function currentPackageRoot(): string {
+  return basename(process.cwd()) === "skill-evals" ? process.cwd() : join(process.cwd(), "packages", "skill-evals");
+}
+
+function durableWriteCase(): FirstTreeWriteEvalCase {
+  const evalCase = FIRST_TREE_WRITE_GATE_CASES.find((candidate) => candidate.id === "durable-source-writes");
+  if (!evalCase) throw new Error("Missing durable-source-writes case");
+  return evalCase;
+}
+
+function setupVerifyFixture(caseId: string): {
+  contextTreePath: string;
+  paths: ReturnType<typeof createRunPaths>;
+} {
+  const paths = createRunPaths({
+    caseId,
+    packageRoot: currentPackageRoot(),
+    startedAt: "2026-06-30T00:00:00.000Z",
+  });
+  const reporter = createEvalReporter(caseId, false);
+  createFirstTreeShim(paths);
+  const contextTreePath = setupFixture(durableWriteCase(), paths, reporter);
+  return { contextTreePath, paths };
+}
+
+function runPostModelVerify(caseId: string, paths: ReturnType<typeof createRunPaths>, contextTreePath: string) {
+  return runFixtureVerify({
+    caseId,
+    contextTreePath,
+    eventTypePrefix: "post_model_validation",
+    paths,
+    phase: "post_model_validation",
+    reporter: createEvalReporter(caseId, false),
+    verbose: false,
+  });
+}
+
+describe("first-tree-write post-model verify", () => {
+  it("fails with the real validator when a model writes a broken soft_links target", () => {
+    const { contextTreePath, paths } = setupVerifyFixture("post-model-verify-soft-links");
+    try {
+      writeText(
+        join(contextTreePath, "system", "context-management", "skill-eval-framework.md"),
+        `---
+title: "Skill Eval Framework"
+owners: [eval-owner]
+soft_links: [missing/context-node]
+---
+
+# Skill Eval Framework
+
+This node keeps valid title and owners frontmatter, but its soft link target is broken.
+`,
+      );
+
+      const result = runPostModelVerify("post-model-verify-soft-links", paths, contextTreePath);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout).toContain("broken soft_links target");
+    } finally {
+      rmSync(paths.runRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("fails with the real validator when a member node is missing required member fields", () => {
+    const { contextTreePath, paths } = setupVerifyFixture("post-model-verify-member");
+    try {
+      writeText(
+        join(contextTreePath, "members", "eval-owner", "NODE.md"),
+        `---
+title: "eval-owner"
+owners: [eval-owner]
+---
+
+# eval-owner
+
+This member node is missing member metadata that the real validator requires.
+`,
+      );
+
+      const result = runPostModelVerify("post-model-verify-member", paths, contextTreePath);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout).toContain("missing 'type' field");
+      expect(result.stdout).toContain("missing or empty 'role' field");
+      expect(result.stdout).toContain("missing 'domains' field");
+    } finally {
+      rmSync(paths.runRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("fails with the real validator when the progress checklist has unchecked items", () => {
+    const { contextTreePath, paths } = setupVerifyFixture("post-model-verify-progress");
+    try {
+      writeText(
+        join(contextTreePath, ".first-tree", "progress.md"),
+        `# Context Tree Progress
+
+- [ ] finish binding the eval tree
+`,
+      );
+
+      const result = runPostModelVerify("post-model-verify-progress", paths, contextTreePath);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout).toContain("Unchecked progress item: finish binding the eval tree");
+    } finally {
+      rmSync(paths.runRoot, { force: true, recursive: true });
+    }
+  });
+});

--- a/packages/skill-evals/src/suites/first-tree-write/grader.ts
+++ b/packages/skill-evals/src/suites/first-tree-write/grader.ts
@@ -3,7 +3,7 @@ import { join, relative } from "node:path";
 
 import { runCommand } from "../../core/commands.js";
 import { findStringValue, isRecord, isStringArray } from "../../core/events.js";
-import type { RunPaths } from "../../core/types.js";
+import type { CommandResult, RunPaths } from "../../core/types.js";
 import type { EvalMetrics, FirstTreeWriteEvalCase, FixtureValidation, TreeStateSnapshot } from "./types.js";
 
 const TEXT_KEYS = ["content", "message", "output_text", "text"];
@@ -193,6 +193,7 @@ export function deriveMetrics(
   evalCase: FirstTreeWriteEvalCase,
   fixtureValidation: FixtureValidation,
   runnerExitCode: number | null,
+  postModelVerifyResult: CommandResult | null,
   paths: RunPaths,
   contextTreePath: string,
 ): EvalMetrics {
@@ -229,7 +230,12 @@ export function deriveMetrics(
   const markdown = contextTreeMarkdown(contextTreePath);
   const forbiddenContentHits = evalCase.forbidden.content.filter((pattern) => markdown.includes(pattern));
   const requiredDiffSnippets = evalCase.expected.requiredDiffSnippets ?? [];
-  const verifySucceeded = firstTreeCommandResults.some((result) => argvIsVerify(result.argv) && result.exitCode === 0);
+  const modelVerifySucceeded = firstTreeCommandResults.some(
+    (result) => argvIsVerify(result.argv) && result.exitCode === 0,
+  );
+  const postModelVerifySucceeded = postModelVerifyResult === null ? null : postModelVerifyResult.exitCode === 0;
+  const verifySucceeded =
+    modelVerifySucceeded && (evalCase.expected.requireVerify ? postModelVerifySucceeded === true : true);
 
   return {
     expectedDiffSnippetsObserved:
@@ -240,6 +246,9 @@ export function deriveMetrics(
     firstTreeCommandResults,
     fixtureValidationOk: fixtureValidation.ok,
     forbiddenContentHits,
+    modelVerifySucceeded,
+    postModelVerifyResult,
+    postModelVerifySucceeded,
     runnerExitCode,
     skillFileReadObserved,
     sourceRepoChanged: sourceRepoChanged(paths),
@@ -283,8 +292,11 @@ export function driftNote(evalCase: FirstTreeWriteEvalCase, metrics: EvalMetrics
   if (evalCase.expected.treeDiff === "minimal" && !metrics.expectedDiffSnippetsObserved) {
     notes.push("Context Tree diff did not contain all required durable-decision snippets.");
   }
-  if (evalCase.expected.requireVerify && !metrics.verifySucceeded) {
+  if (evalCase.expected.requireVerify && !metrics.modelVerifySucceeded) {
     notes.push("Required first-tree tree verify command did not succeed during model phase.");
+  }
+  if (evalCase.expected.requireVerify && metrics.postModelVerifySucceeded !== true) {
+    notes.push("Post-model first-tree tree verify did not succeed under the harness real validator.");
   }
   if (metrics.sourceRepoChanged) {
     notes.push("Source repo fixture changed; write eval cases must not modify source repo.");

--- a/packages/skill-evals/src/suites/first-tree-write/runner.ts
+++ b/packages/skill-evals/src/suites/first-tree-write/runner.ts
@@ -1,4 +1,5 @@
 import { appendEvent, readEvents } from "../../core/events.js";
+import { runFixtureVerify } from "../../core/fixture-verify.js";
 import { deriveRunObservability } from "../../core/observability.js";
 import { createRunPaths } from "../../core/paths.js";
 import { runCodexProvider } from "../../core/provider/codex.js";
@@ -38,9 +39,28 @@ export async function runFirstTreeWriteCase(
     },
     { paths, reporter },
   );
+  const postModelVerifyResult = evalCase.expected.requireVerify
+    ? runFixtureVerify({
+        caseId: evalCase.id,
+        contextTreePath,
+        eventTypePrefix: "post_model_validation",
+        paths,
+        phase: "post_model_validation",
+        reporter,
+        verbose: options.verbose,
+      })
+    : null;
 
   const events = readEvents(paths.eventsPath);
-  const metrics = deriveMetrics(events, evalCase, fixtureValidation, runnerExitCode, paths, contextTreePath);
+  const metrics = deriveMetrics(
+    events,
+    evalCase,
+    fixtureValidation,
+    runnerExitCode,
+    postModelVerifyResult,
+    paths,
+    contextTreePath,
+  );
   const passed = casePassed(evalCase, metrics);
   const grading = buildGrading(evalCase, metrics, passed);
   const observability = deriveRunObservability(events);

--- a/packages/skill-evals/src/suites/first-tree-write/summary.ts
+++ b/packages/skill-evals/src/suites/first-tree-write/summary.ts
@@ -26,6 +26,15 @@ function validationRows(validation: FixtureValidation): string {
   ].join("\n");
 }
 
+function postModelVerifyRows(metrics: EvalMetrics): string {
+  if (metrics.postModelVerifyResult === null) return "- not run";
+  return [
+    `- ok: ${markdownBool(metrics.postModelVerifySucceeded === true)}`,
+    `- exitCode: ${metrics.postModelVerifyResult.exitCode}`,
+    `- command: ${metrics.postModelVerifyResult.command} ${formatCommand(metrics.postModelVerifyResult.args)}`,
+  ].join("\n");
+}
+
 function commandResultRows(metrics: EvalMetrics): string {
   if (metrics.firstTreeCommandResults.length === 0) return "- none";
   return metrics.firstTreeCommandResults
@@ -72,7 +81,7 @@ export function buildGrading(
       evidence("routing_pass", `first-tree-write skill file read observed=${metrics.skillFileReadObserved}`),
       evidence(
         "process_pass",
-        `fixture ok=${metrics.fixtureValidationOk}; runner exit=${metrics.runnerExitCode}; require verify=${evalCase.expected.requireVerify}; verify succeeded=${metrics.verifySucceeded}`,
+        `fixture ok=${metrics.fixtureValidationOk}; runner exit=${metrics.runnerExitCode}; require verify=${evalCase.expected.requireVerify}; model verify succeeded=${metrics.modelVerifySucceeded}; post-model verify succeeded=${metrics.postModelVerifySucceeded}; verify succeeded=${metrics.verifySucceeded}`,
       ),
       evidence(
         "outcome_pass",
@@ -108,6 +117,8 @@ export function writeCaseSummaries(summary: CaseRunSummary): void {
 - skillFileReadObserved: ${markdownBool(summary.metrics.skillFileReadObserved)}
 - treeChanged: ${markdownBool(summary.metrics.treeChanged)}
 - expectedDiffSnippetsObserved: ${markdownBool(summary.metrics.expectedDiffSnippetsObserved)}
+- modelVerifySucceeded: ${markdownBool(summary.metrics.modelVerifySucceeded)}
+- postModelVerifySucceeded: ${summary.metrics.postModelVerifySucceeded === null ? "n/a" : markdownBool(summary.metrics.postModelVerifySucceeded)}
 - verifySucceeded: ${markdownBool(summary.metrics.verifySucceeded)}
 - sourceRepoChanged: ${markdownBool(summary.metrics.sourceRepoChanged)}
 - expectedResponseObserved: ${markdownBool(summary.metrics.expectedResponseObserved)}
@@ -130,6 +141,10 @@ ${summary.prompt}
 ## Fixture Validation
 
 ${validationRows(summary.fixtureValidation)}
+
+## Post-model Verification
+
+${postModelVerifyRows(summary.metrics)}
 
 ## first-tree Command Results
 

--- a/packages/skill-evals/src/suites/first-tree-write/types.ts
+++ b/packages/skill-evals/src/suites/first-tree-write/types.ts
@@ -69,6 +69,9 @@ export type EvalMetrics = {
   }[];
   fixtureValidationOk: boolean;
   forbiddenContentHits: readonly string[];
+  modelVerifySucceeded: boolean;
+  postModelVerifyResult: CommandResult | null;
+  postModelVerifySucceeded: boolean | null;
   runnerExitCode: number | null;
   skillFileReadObserved: boolean;
   sourceRepoChanged: boolean;


### PR DESCRIPTION
## Summary

- Preserve live eval shim events under the Codex workspace sandbox by writing model-phase shim logs inside the workspace and merging them back into the main event log after provider exit.
- Add self-contained model-phase handling for `first-tree tree tree` and `first-tree tree verify`, while keeping fixture/post-model verify on the real CLI validator path.
- Add a post-model real `first-tree tree verify` hard gate for `first-tree-write` cases that require verify, and split `modelVerifySucceeded` from `postModelVerifySucceeded` in metrics/summary/grading evidence.
- Broaden the `first-tree-read` fact matcher for the observed "single authorization surface" phrasing.
- Add regression coverage for broken `soft_links`, invalid member nodes, and unchecked progress checklist items so shimmed verify cannot weaken the write gate oracle.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter first-tree-dev... build`
- `pnpm --filter @first-tree/skill-evals typecheck`
- `pnpm --filter @first-tree/skill-evals exec vitest run src/core/__tests__/first-tree-shim.test.ts src/core/__tests__/fixture-verify.test.ts src/suites/first-tree-write/__tests__/grader.test.ts src/suites/first-tree-write/__tests__/post-model-verify.test.ts --maxWorkers=2 --minWorkers=1`
- `pnpm --filter @first-tree/skill-evals exec vitest run src/core/__tests__/provider.test.ts src/core/__tests__/first-tree-shim.test.ts src/suites/first-tree-read/__tests__/metrics.test.ts --maxWorkers=2 --minWorkers=1`
- `pnpm --filter @first-tree/skill-evals exec vitest run --passWithNoTests --maxWorkers=2 --minWorkers=1`
- `pnpm --filter @first-tree/skill-evals eval:floor`
- `pnpm exec biome check <changed skill-evals files>`
- `git diff --check`
- `pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-write --case durable-source-writes --codex-bin /bin/false --json` (expected failure; verified fixture validation/post-model real verify and grading evidence)
- `pnpm typecheck`
- `pnpm check` (exits 0; reports existing client/web warnings/info)

## Live checks

Focused real Codex live checks were run before the final post-model verify hardening and passed for the two previously failing stage2 cases:

- `pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-read --case tree-software-trigger --verbose --json`
- `pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-write --case durable-source-writes --verbose --json`

I did not rerun real Codex live gate after the final hardening to avoid extra model quota; the final change is harness-side post-model verification and is covered by deterministic regression tests.

## Review

- `codex-reviewer` reviewed the worktree, found the weak self-contained verify blocker, and re-reviewed the fix.
- Re-review result: no remaining blockers; OK to commit/push/open PR.
