### PR TITLE
Fix welcome eval setup option classification

### DIFF
--- a/packages/skill-evals/src/suites/first-tree-welcome/__tests__/grader.test.ts
+++ b/packages/skill-evals/src/suites/first-tree-welcome/__tests__/grader.test.ts
@@ -65,6 +65,19 @@ function fixtureValidation(): FixtureValidation {
   };
 }
 
+function skillReadEvent(): unknown {
+  return {
+    event: {
+      item: {
+        command: "sed -n '1,220p' .agents/skills/first-tree-welcome/SKILL.md",
+        type: "command_execution",
+      },
+      type: "item.completed",
+    },
+    type: "codex_event",
+  };
+}
+
 describe("first-tree-welcome grader", () => {
   it("passes row 1 when the model routes tree kickoff to the tree setup lane", () => {
     expect(
@@ -117,23 +130,104 @@ describe("first-tree-welcome grader", () => {
     ).toBe(false);
   });
 
-  it("detects setup-as-first-task from chat ask options", () => {
-    const tempRoot = mkdtempSync(join(tmpdir(), "welcome-eval-row3-options-"));
+  it("does not treat repo-entry input options as first-task options", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "welcome-eval-row3-entry-options-"));
     try {
+      const evalCase = findCase("first-tree-welcome-no-repo-intro");
       const metrics = deriveMetrics(
         [
+          skillReadEvent(),
           {
             argv: [
               "chat",
               "ask",
               "baixiaohang",
-              "Choose a setup task: local clone path, GitHub URL, or install GitHub App.",
+              "请发我一个项目入口：本地 clone 路径或 GitHub 仓库 URL。",
+              "--options",
+              JSON.stringify([
+                { description: "我可以直接读取本机代码，最快开始给出基于证据的帮助。", label: "本地路径" },
+                { description: "我会优先使用本机 gh/已有凭据读取，不先要求安装 GitHub App。", label: "GitHub URL" },
+              ]),
+            ],
+            phase: "model",
+            type: "first_tree_call",
+          },
+        ],
+        evalCase,
+        fixtureValidation(),
+        0,
+        baseRunPaths(tempRoot),
+        null,
+      );
+
+      expect(metrics.chatOptionCount).toBe(2);
+      expect(metrics.taskOptionsObserved).toBe(false);
+      expect(metrics.forbiddenActionHits).not.toContain("setup-as-first-task");
+      expect(metrics.forbiddenSideEffectHits).toEqual([]);
+      expect(casePassed(evalCase, metrics)).toBe(true);
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("detects setup-as-first-task when setup is mixed into repo-entry input options", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "welcome-eval-row3-mixed-setup-option-"));
+    try {
+      const evalCase = findCase("first-tree-welcome-no-repo-intro");
+      const metrics = deriveMetrics(
+        [
+          skillReadEvent(),
+          {
+            argv: [
+              "chat",
+              "ask",
+              "baixiaohang",
+              "请发我一个项目入口，或者先建 Context Tree。",
+              "--options",
+              JSON.stringify([
+                { description: "我可以直接读取本机代码。", label: "本地路径" },
+                { description: "我可以读取 GitHub 仓库 URL。", label: "GitHub URL" },
+                { description: "Create and bind a new Context Tree.", label: "Create Context Tree" },
+              ]),
+            ],
+            phase: "model",
+            type: "first_tree_call",
+          },
+        ],
+        evalCase,
+        fixtureValidation(),
+        0,
+        baseRunPaths(tempRoot),
+        null,
+      );
+
+      expect(metrics.chatOptionCount).toBe(3);
+      expect(metrics.taskOptionsObserved).toBe(false);
+      expect(metrics.forbiddenActionHits).toContain("setup-as-first-task");
+      expect(casePassed(evalCase, metrics)).toBe(false);
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("detects setup-as-first-task from actual setup task options", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "welcome-eval-row3-setup-tasks-"));
+    try {
+      const metrics = deriveMetrics(
+        [
+          skillReadEvent(),
+          {
+            argv: [
+              "chat",
+              "ask",
+              "baixiaohang",
+              "Choose the first setup task.",
               "--options",
               JSON.stringify({
                 options: [
-                  { description: "Provide a local clone path.", label: "Local path" },
-                  { description: "Provide a GitHub URL.", label: "GitHub URL" },
-                  { description: "Install the GitHub App.", label: "Install app" },
+                  { description: "Create and bind a new Context Tree.", label: "Create Context Tree" },
+                  { description: "Install the GitHub App authorization flow first.", label: "Install GitHub App" },
+                  { description: "Seed the tree before doing product work.", label: "Seed Context Tree" },
                 ],
               }),
             ],

--- a/packages/skill-evals/src/suites/first-tree-welcome/grader.ts
+++ b/packages/skill-evals/src/suites/first-tree-welcome/grader.ts
@@ -176,15 +176,45 @@ function collectChatText(argv: readonly string[]): string {
   return argv.slice(2).join(" ");
 }
 
-function parseOptionsFromArgv(argv: readonly string[]): number | null {
+type ParsedChatOptions = {
+  count: number;
+  texts: readonly string[];
+};
+
+function collectOptionText(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) {
+    return value.map(collectOptionText).filter(Boolean).join(" ");
+  }
+  if (!isRecord(value)) return "";
+
+  const chunks: string[] = [];
+  for (const key of ["label", "description", "preview"] as const) {
+    const item = value[key];
+    if (typeof item === "string") chunks.push(item);
+  }
+  return chunks.join(" ");
+}
+
+function parseOptionsFromArgv(argv: readonly string[]): ParsedChatOptions | null {
   const optionIndex = argv.indexOf("--options");
   if (optionIndex < 0) return null;
   const raw = argv[optionIndex + 1];
   if (typeof raw !== "string") return null;
   try {
     const parsed: unknown = JSON.parse(raw);
-    if (Array.isArray(parsed)) return parsed.length;
-    if (isRecord(parsed) && Array.isArray(parsed.options)) return parsed.options.length;
+    if (Array.isArray(parsed)) {
+      return {
+        count: parsed.length,
+        texts: parsed.map(collectOptionText).filter(Boolean),
+      };
+    }
+    if (isRecord(parsed) && Array.isArray(parsed.options)) {
+      return {
+        count: parsed.options.length,
+        texts: parsed.options.map(collectOptionText).filter(Boolean),
+      };
+    }
     return null;
   } catch {
     return null;
@@ -201,8 +231,51 @@ function countTaskOptionLines(text: string): number | null {
   return optionLines.length > 0 ? optionLines.length : null;
 }
 
-function bestOptionCount(chatOptionCount: number | null, combinedText: string): number | null {
-  if (chatOptionCount !== null) return chatOptionCount;
+function withoutNegatedSetupLanguage(text: string): string {
+  return text
+    .replace(/(?:不先要求|不需要|无需|不用|不要先)\s*安装\s*github app/giu, "")
+    .replace(/\b(?:without|no need to|do not|don't)\s+(?:install|authorize)[^.;\n]*github app\b/giu, "");
+}
+
+function containsSetupTaskLanguage(text: string): boolean {
+  return /install|create.{0,30}(context\s+)?tree|seed.{0,20}tree|tree.{0,20}setup|setup.{0,20}tree|select.{0,20}repo|connect.{0,20}repo|authori[sz]e|authorization|安装.{0,20}github app|授权/iu.test(
+    withoutNegatedSetupLanguage(text),
+  );
+}
+
+function isInputCollectionOption(text: string): boolean {
+  if (
+    !/local clone path|local path|clone path|github url|repo url|repository url|project entry|项目入口|本地路径|仓库\s*url|github\s*仓库/iu.test(
+      text,
+    )
+  ) {
+    return false;
+  }
+  return !containsSetupTaskLanguage(text);
+}
+
+function optionLooksLikeTask(text: string, taskOptionHints: readonly string[]): boolean {
+  if (isInputCollectionOption(text)) return false;
+  if (countMatches(text, taskOptionHints) > 0) return true;
+  if (
+    /checkout|session|map|architecture|test|flow|task|route|trace|fix|debug|implement|review|audit|write|update|compare|investigate|verify|reliability|todo/iu.test(
+      text,
+    )
+  ) {
+    return true;
+  }
+  return containsSetupTaskLanguage(text);
+}
+
+function bestTaskOptionCount(
+  chatOptionTexts: readonly string[],
+  combinedText: string,
+  taskOptionHints: readonly string[],
+): number | null {
+  if (chatOptionTexts.length > 0) {
+    const taskOptions = chatOptionTexts.filter((text) => optionLooksLikeTask(text, taskOptionHints));
+    return taskOptions.length > 0 ? taskOptions.length : null;
+  }
   return countTaskOptionLines(combinedText);
 }
 
@@ -257,6 +330,7 @@ function forbiddenActionHits(
   combinedText: string,
   chatAskCount: number,
   taskOptionsObserved: boolean,
+  setupOptionObserved: boolean,
   firstTreeArgv: readonly (readonly string[])[],
 ): string[] {
   const hits: string[] = [];
@@ -285,6 +359,9 @@ function forbiddenActionHits(
       !taskOptionsObserved &&
       /install|select repo|connect repo|setup|set up/iu.test(combinedText)
     ) {
+      hits.push(action);
+    }
+    if (action === "setup-as-first-task" && setupOptionObserved) {
       hits.push(action);
     }
     if (
@@ -356,11 +433,13 @@ function forbiddenSideEffectHits(events: readonly unknown[], firstTreeArgv: read
     }
     if (!isRecord(event) || eventType(event) !== "codex_event") continue;
     for (const command of collectCommandStrings(event.event)) {
-      if (/\bgh\b/u.test(command)) hits.push(command);
-      if (/\bgit\s+push\b/u.test(command)) hits.push(command);
-      if (/\bgit\s+commit\b/u.test(command)) hits.push(command);
-      if (/\bfirst-tree(?:-staging)?\s+github\b/u.test(command)) hits.push(command);
-      if (/\bfirst-tree(?:-staging)?\s+tree\s+(bind|create|init|seed|setup)\b/u.test(command)) hits.push(command);
+      if (/(^|[;&|\n"']\s*)gh\s+/u.test(command)) hits.push(command);
+      if (/(^|[;&|\n"']\s*)git\s+push\b/u.test(command)) hits.push(command);
+      if (/(^|[;&|\n"']\s*)git\s+commit\b/u.test(command)) hits.push(command);
+      if (/(^|[;&|\n"']\s*)first-tree(?:-staging)?\s+github\b/u.test(command)) hits.push(command);
+      if (/(^|[;&|\n"']\s*)first-tree(?:-staging)?\s+tree\s+(bind|create|init|seed|setup)\b/u.test(command)) {
+        hits.push(command);
+      }
     }
   }
 
@@ -381,6 +460,8 @@ export function deriveMetrics(
   const firstTreeArgv: string[][] = [];
   const modelOutputTexts: string[] = [];
   const chatTexts: string[] = [];
+  const chatOptionTexts: string[] = [];
+  const setupOptionTexts: string[] = [];
   let chatAskCount = 0;
   let chatOptionCount: number | null = null;
 
@@ -412,7 +493,12 @@ export function deriveMetrics(
       if (argv[0] === "chat" && ["ask", "send", "update"].includes(argv[1] ?? "") && !argv.includes("--help")) {
         chatTexts.push(collectChatText(argv));
         if (argv[1] === "ask") chatAskCount += 1;
-        chatOptionCount = chatOptionCount ?? parseOptionsFromArgv(argv);
+        const parsedOptions = parseOptionsFromArgv(argv);
+        if (parsedOptions !== null) {
+          chatOptionCount = chatOptionCount ?? parsedOptions.count;
+          chatOptionTexts.push(...parsedOptions.texts);
+          setupOptionTexts.push(...parsedOptions.texts.filter(containsSetupTaskLanguage));
+        }
       }
     }
   }
@@ -420,10 +506,12 @@ export function deriveMetrics(
   const finalResponse = modelOutputTexts.at(-1) ?? "";
   const chatText = chatTexts.join("\n");
   const combinedText = `${chatText}\n${finalResponse}`;
-  const optionCount = bestOptionCount(chatOptionCount, combinedText);
   const taskOptionHints = evalCase.expected.taskOptionHints ?? [];
+  const taskOptionCount = bestTaskOptionCount(chatOptionTexts, combinedText, taskOptionHints);
   const taskOptionsObserved =
-    optionCount !== null ? optionCount >= 2 && optionCount <= 3 : countMatches(combinedText, taskOptionHints) >= 2;
+    taskOptionCount !== null
+      ? taskOptionCount >= 2 && taskOptionCount <= 3
+      : countMatches(combinedText, taskOptionHints) >= 2;
   const evidenceSnippets = evalCase.expected.evidenceSnippets ?? [];
   const contextStatus = treeStatus(paths);
   const baselines = baselineHeads(events);
@@ -433,6 +521,7 @@ export function deriveMetrics(
     combinedText,
     chatAskCount,
     taskOptionsObserved,
+    setupOptionTexts.length > 0,
     firstTreeArgv,
   );
   const forbiddenClaims = forbiddenClaimHits(
@@ -445,7 +534,7 @@ export function deriveMetrics(
 
   return {
     chatAskCount,
-    chatOptionCount: optionCount,
+    chatOptionCount: chatOptionCount ?? taskOptionCount,
     chatText,
     contextTreeChanged: treeChanged(paths, baselines.contextTreeHead),
     contextTreeStatus: contextStatus,


### PR DESCRIPTION
## Summary

- Distinguish first-tree-welcome repo-entry input options from bounded first-task options.
- Keep `setup-as-first-task` strict by detecting setup/install/create/bind/seed/authorize language independently from the bounded task option count.
- Avoid treating natural-language `gh` mentions inside chat text as shell side effects while preserving real `gh_call` / shell command detection.
- Add regression coverage for pure repo-entry options, mixed repo-entry + setup options, and pure setup options.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter @first-tree/skill-evals exec vitest run src/suites/first-tree-welcome/__tests__/grader.test.ts --maxWorkers=2 --minWorkers=1`
- `pnpm --filter @first-tree/skill-evals typecheck`
- `pnpm --filter first-tree-dev... build`
- `pnpm --filter @first-tree/skill-evals exec vitest run --passWithNoTests --maxWorkers=2 --minWorkers=1`
- `pnpm exec biome check packages/skill-evals/src/suites/first-tree-welcome/grader.ts packages/skill-evals/src/suites/first-tree-welcome/__tests__/grader.test.ts`
- `pnpm --filter @first-tree/skill-evals eval:floor -- --suite first-tree-welcome`
- `pnpm typecheck`
- `pnpm check` (exits 0; reports existing unrelated warnings/info in client/web files)
- `git diff --check`

## Notes

- This fixes the stage 3 false failure for `first-tree-welcome-no-repo-intro`: asking for a local clone path or GitHub URL is input collection, not a first task.
- I did not rerun live Codex gates after this grader-only fix.
