### PR TITLE
test(cli): relax flaky integration test timeouts (CPU-starved under parallel CI)

### DIFF
--- a/apps/cli/vitest.config.ts
+++ b/apps/cli/vitest.config.ts
@@ -4,6 +4,15 @@ import { unitCoverageConfig } from "../../scripts/vitest-coverage.js";
 
 export default defineConfig({
   test: {
+    // Many CLI tests spawn the command as a subprocess and do real file/process
+    // I/O. They run ~1-2s in isolation but are CPU-bound, so under the
+    // full-monorepo `turbo run test` (every package in parallel) CI runners get
+    // starved and an occasional, varying handful cross vitest's default 5s
+    // timeout — flaky red driven by an unrelated PR's added load, not by logic
+    // (they pass when this package runs alone). Raise the package-wide timeout
+    // so transient CPU starvation can't trip them; a genuine hang still fails,
+    // just at 15s.
+    testTimeout: 15_000,
     coverage: unitCoverageConfig({
       exclude: ["src/commands/types.ts"],
     }),


### PR DESCRIPTION
## Problem

A cluster of `apps/cli` tests spawn the command as a subprocess and do real file/process I/O. In isolation they run ~1.5s and the **whole package passes 522/522 when run alone** — but under the full-monorepo `turbo run test` (every package in parallel) CI runners get CPU-starved and an occasional, **varying** handful cross vitest's default **5000ms** timeout:

- `chat-send-message-file.test.ts`
- `chat-send-escaped-newline-guard.test.ts`
- `chat-send-escaped-newline-stderr.test.ts`
- `migrate-agent-dirs-extra.test.ts` (`createApiNameResolver`)

The failing set **differs run to run** → non-deterministic, parallel-load-driven flaky, not logic. The test files are byte-identical to their passing history.

## Fix

Raise the apps/cli package-wide `testTimeout` to **15s** (vitest config) so transient CPU starvation can't trip these I/O/subprocess tests. A genuine hang still fails, just at 15s. Package-level rather than per-test so the whole cluster + future CLI tests are covered. (Confirmed *not* a shared-port/resource race — these tests do no networking.)

## Why standalone

The fragility isn't owned by any feature PR. It was surfaced by #1352 (whose added web tests tipped the parallel run over the edge), but landing it on `main` keeps it from flaking other PRs — and keeps `main` itself green once #1352 merges.

Verified locally: the 4 tests pass with the new timeout; biome clean.
