### PR TITLE
Remove legacy first-tree-read eval commands

### DIFF
--- a/packages/skill-evals/README.md
+++ b/packages/skill-evals/README.md
@@ -180,20 +180,5 @@ case run directory, and include `judge_scores`, `judge_reasoning`,
 `judge_model`, duration, thresholds, and failure reasons in `summary.json`.
 
 Use `--verbose` to print live, human-readable progress to stderr. It can be
-combined with `--case`, `--validate-fixtures`, and `--json`; stdout remains the
-final summary table or aggregate JSON.
-
-Fixture-only validation is available without model calls:
-
-```bash
-pnpm --filter @first-tree/skill-evals validate:first-tree-read-fixtures
-```
-
-Legacy read eval aliases are retained for compatibility, but the shared gate
-command is the primary live path:
-
-```bash
-pnpm --filter @first-tree/skill-evals eval:first-tree-read
-pnpm --filter @first-tree/skill-evals eval:first-tree-read -- --case tree-software-trigger
-pnpm --filter @first-tree/skill-evals eval:first-tree-read -- --case tree-software-trigger --validate-fixtures --verbose
-```
+combined with `--case` and `--json`; stdout remains the final summary table or
+aggregate JSON.

--- a/packages/skill-evals/package.json
+++ b/packages/skill-evals/package.json
@@ -11,9 +11,7 @@
     "eval:select": "tsx src/index.ts select",
     "eval:summary": "tsx src/index.ts summary",
     "eval:compare": "tsx src/index.ts compare",
-    "eval:first-tree-read": "tsx src/first-tree-read/index.ts",
     "test": "vitest run --passWithNoTests",
-    "validate:first-tree-read-fixtures": "tsx src/first-tree-read/index.ts --validate-fixtures",
     "typecheck": "tsc --noEmit"
   },
   "engines": {

--- a/packages/skill-evals/src/core/__tests__/select.test.ts
+++ b/packages/skill-evals/src/core/__tests__/select.test.ts
@@ -34,15 +34,6 @@ describe("skill eval selection", () => {
     ]);
   });
 
-  it("selects read floor and unified gate for legacy read wrapper changes", () => {
-    const summary = selectSkillEvalRecommendations(["packages/skill-evals/src/first-tree-read/index.ts"]);
-
-    expect(summary.recommendations.map((recommendation) => recommendation.command)).toEqual([
-      "pnpm --filter @first-tree/skill-evals eval:floor -- --suite first-tree-read",
-      "pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-read",
-    ]);
-  });
-
   it("selects all implemented gates and quality when shared judge core changes", () => {
     const summary = selectSkillEvalRecommendations(["packages/skill-evals/src/core/judge/schema.ts"]);
 

--- a/packages/skill-evals/src/core/select.ts
+++ b/packages/skill-evals/src/core/select.ts
@@ -23,11 +23,7 @@ const SKILL_BY_PATH: readonly {
   paths: readonly string[];
 }[] = [
   {
-    paths: [
-      "skills/first-tree-read/",
-      "packages/skill-evals/src/first-tree-read/",
-      "packages/skill-evals/src/suites/first-tree-read/",
-    ],
+    paths: ["skills/first-tree-read/", "packages/skill-evals/src/suites/first-tree-read/"],
     skill: "first-tree-read",
   },
   {

--- a/packages/skill-evals/src/first-tree-read/index.ts
+++ b/packages/skill-evals/src/first-tree-read/index.ts
@@ -1,7 +1,0 @@
-import { runFirstTreeReadLegacyCli } from "../suites/first-tree-read/index.js";
-
-runFirstTreeReadLegacyCli(process.argv.slice(2)).catch((error: unknown) => {
-  const message = error instanceof Error ? error.message : String(error);
-  process.stderr.write(`${message}\n`);
-  process.exitCode = 1;
-});

--- a/packages/skill-evals/src/suites/first-tree-read/eval-cases.ts
+++ b/packages/skill-evals/src/suites/first-tree-read/eval-cases.ts
@@ -2,20 +2,14 @@ import type { SkillEvalCase } from "../../core/case-schema.js";
 import type { SkillEvalSuiteDefinition } from "../types.js";
 import { FIRST_TREE_READ_CASES } from "./cases.js";
 
-const FLOOR_CASE_ID = "first-tree-read-fixture-validation";
+const FLOOR_CASE_ID = "first-tree-read-floor-coverage";
 
 export const FIRST_TREE_READ_EVAL_CASES: readonly SkillEvalCase[] = [
   {
     briefingMode: "minimal",
     expected: {
-      command: "validate:first-tree-read-fixtures",
-      hardOracle: [
-        "skill file read",
-        "first-tree tree tree --help",
-        "selector success",
-        "expected facts",
-        "non-trigger no first-tree usage",
-      ],
+      command: "eval:floor -- --suite first-tree-read",
+      hardOracle: ["coverage matrix", "skill file frontmatter", "read case declarations"],
     },
     fixture: {
       caseIds: FIRST_TREE_READ_CASES.map((evalCase) => evalCase.id),
@@ -72,7 +66,7 @@ export const FIRST_TREE_READ_SUITE: SkillEvalSuiteDefinition = {
     tiers: [
       {
         caseIds: [FLOOR_CASE_ID],
-        description: "Validate skill file and existing read fixture coverage without model calls.",
+        description: "Validate read skill file metadata and case coverage without model calls.",
         status: "implemented",
         tier: "floor",
       },

--- a/packages/skill-evals/src/suites/first-tree-read/index.ts
+++ b/packages/skill-evals/src/suites/first-tree-read/index.ts
@@ -1,8 +1,3 @@
-import { existsSync, readFileSync } from "node:fs";
-import { dirname } from "node:path";
-import { fileURLToPath } from "node:url";
-
-import { isRecord } from "../../core/events.js";
 import { FIRST_TREE_READ_CASES, findFirstTreeReadCase } from "./cases.js";
 import { runFirstTreeReadCase } from "./runner.js";
 import { buildBatchSummary, formatSummaryTable } from "./summary.js";
@@ -10,90 +5,7 @@ import type { BatchSummary, CliOptions, FirstTreeReadEvalCase } from "./types.js
 
 export { findFirstTreeReadCase };
 
-export type FirstTreeReadGateOptions = Omit<CliOptions, "validateFixtures">;
-
-function usage(): string {
-  return `Usage:
-  pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-read
-  pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-read --case <id>
-
-Compatibility aliases:
-  pnpm --filter @first-tree/skill-evals eval:first-tree-read
-  pnpm --filter @first-tree/skill-evals eval:first-tree-read -- --case <id>
-  pnpm --filter @first-tree/skill-evals eval:first-tree-read -- --json
-  pnpm --filter @first-tree/skill-evals eval:first-tree-read -- --verbose
-  pnpm --filter @first-tree/skill-evals validate:first-tree-read-fixtures
-
-Options:
-  --case <id>              Run one case.
-  --json                   Print aggregate summary as JSON.
-  --model <model>          Pass a model override to codex exec.
-  --codex-bin <path>       Codex binary to execute. Defaults to CODEX_BIN or codex.
-  --validate-fixtures      Validate fixtures only; no model calls.
-  --verbose                Print live readable progress to stderr.
-  --help                   Show this help.
-`;
-}
-
-function readOptionValue(args: readonly string[], index: number, optionName: string): string {
-  const value = args[index + 1];
-  if (!value || value.startsWith("--")) {
-    throw new Error(`${optionName} requires a value.`);
-  }
-  return value;
-}
-
-function parseArgs(args: readonly string[]): CliOptions {
-  const options: CliOptions = {
-    caseId: null,
-    codexBin: process.env.CODEX_BIN ?? "codex",
-    json: false,
-    model: process.env.CODEX_MODEL ?? null,
-    validateFixtures: false,
-    verbose: false,
-  };
-
-  for (let index = 0; index < args.length; index += 1) {
-    const arg = args[index];
-    if (arg === "--") {
-      continue;
-    }
-    if (arg === "--case") {
-      options.caseId = readOptionValue(args, index, "--case");
-      index += 1;
-      continue;
-    }
-    if (arg === "--json") {
-      options.json = true;
-      continue;
-    }
-    if (arg === "--model") {
-      options.model = readOptionValue(args, index, "--model");
-      index += 1;
-      continue;
-    }
-    if (arg === "--codex-bin") {
-      options.codexBin = readOptionValue(args, index, "--codex-bin");
-      index += 1;
-      continue;
-    }
-    if (arg === "--validate-fixtures") {
-      options.validateFixtures = true;
-      continue;
-    }
-    if (arg === "--verbose") {
-      options.verbose = true;
-      continue;
-    }
-    if (arg === "--help" || arg === "-h") {
-      process.stdout.write(usage());
-      process.exit(0);
-    }
-    throw new Error(`Unknown option: ${arg}`);
-  }
-
-  return options;
-}
+export type FirstTreeReadGateOptions = CliOptions;
 
 function selectCases(caseId: string | null): readonly FirstTreeReadEvalCase[] {
   if (caseId === null) return FIRST_TREE_READ_CASES;
@@ -118,17 +30,7 @@ export async function runFirstTreeReadGate(
     if (!options.verbose) {
       process.stderr.write(`Running first-tree-read eval case: ${evalCase.id}\n`);
     }
-    summaries.push(
-      await runFirstTreeReadCase(
-        packageRootPath,
-        evalCase,
-        {
-          ...options,
-          validateFixtures: false,
-        },
-        runStartedAt,
-      ),
-    );
+    summaries.push(await runFirstTreeReadCase(packageRootPath, evalCase, options, runStartedAt));
   }
 
   return buildBatchSummary(summaries, runStartedAt);
@@ -136,48 +38,4 @@ export async function runFirstTreeReadGate(
 
 export function formatFirstTreeReadGateSummary(batch: BatchSummary): string {
   return formatSummaryTable(batch);
-}
-
-function packageRoot(): string {
-  let current = dirname(fileURLToPath(import.meta.url));
-  while (current !== dirname(current)) {
-    const packageJsonPath = `${current}/package.json`;
-    if (existsSync(packageJsonPath)) {
-      const packageJson: unknown = JSON.parse(readFileSync(packageJsonPath, "utf8"));
-      if (isRecord(packageJson) && packageJson.name === "@first-tree/skill-evals") {
-        return current;
-      }
-    }
-    current = dirname(current);
-  }
-  throw new Error("Could not locate @first-tree/skill-evals package root.");
-}
-
-export async function runFirstTreeReadLegacyCli(args: readonly string[]): Promise<void> {
-  const options = parseArgs(args);
-  const selectedCases = selectCases(options.caseId);
-  const runStartedAt = new Date().toISOString();
-  const summaries = [];
-
-  for (const evalCase of selectedCases) {
-    if (!options.verbose) {
-      process.stderr.write(
-        options.validateFixtures
-          ? `Validating fixture: ${evalCase.id}\n`
-          : `Running first-tree-read eval case: ${evalCase.id}\n`,
-      );
-    }
-    summaries.push(await runFirstTreeReadCase(packageRoot(), evalCase, options, runStartedAt));
-  }
-
-  const batch = buildBatchSummary(summaries, runStartedAt);
-  if (options.json) {
-    process.stdout.write(`${JSON.stringify(batch, null, 2)}\n`);
-  } else {
-    process.stdout.write(`${formatSummaryTable(batch)}\n`);
-  }
-
-  if (batch.failed > 0) {
-    process.exitCode = 1;
-  }
 }

--- a/packages/skill-evals/src/suites/first-tree-read/metrics.ts
+++ b/packages/skill-evals/src/suites/first-tree-read/metrics.ts
@@ -279,7 +279,3 @@ export function casePassed(expectedTrigger: boolean, metrics: EvalMetrics): bool
     metrics.modelFirstTreeCommandsOk
   );
 }
-
-export function fixtureOnlyPassed(fixtureValidation: FixtureValidation): boolean {
-  return fixtureValidation.ok;
-}

--- a/packages/skill-evals/src/suites/first-tree-read/runner.ts
+++ b/packages/skill-evals/src/suites/first-tree-read/runner.ts
@@ -5,7 +5,7 @@ import { runCodexProvider } from "../../core/provider/codex.js";
 import { createEvalReporter } from "../../core/reporter.js";
 import { createFirstTreeShim } from "../../core/shims/first-tree.js";
 import { setupFixture, validateFixture } from "./fixture.js";
-import { casePassed, deriveMetrics, fixtureOnlyPassed } from "./metrics.js";
+import { casePassed, deriveMetrics } from "./metrics.js";
 import { buildGrading, driftNote, writeCaseSummaries } from "./summary.js";
 import type { CaseRunSummary, CliOptions, FirstTreeReadEvalCase } from "./types.js";
 
@@ -28,23 +28,19 @@ export async function runFirstTreeReadCase(
   createFirstTreeShim(paths);
   const contextTreePath = setupFixture(evalCase, paths, reporter);
   const fixtureValidation = validateFixture(paths, contextTreePath, evalCase.id, options.verbose, reporter);
-  const runnerExitCode = options.validateFixtures
-    ? 0
-    : await runCodexProvider(
-        {
-          bin: options.codexBin,
-          caseId: evalCase.id,
-          model: options.model,
-          prompt: evalCase.prompt,
-          verbose: options.verbose,
-        },
-        { paths, reporter },
-      );
+  const runnerExitCode = await runCodexProvider(
+    {
+      bin: options.codexBin,
+      caseId: evalCase.id,
+      model: options.model,
+      prompt: evalCase.prompt,
+      verbose: options.verbose,
+    },
+    { paths, reporter },
+  );
   const events = readEvents(paths.eventsPath);
   const metrics = deriveMetrics(events, fixtureValidation, runnerExitCode, evalCase.expectedFacts);
-  const passed = options.validateFixtures
-    ? fixtureOnlyPassed(fixtureValidation)
-    : casePassed(evalCase.expectedTrigger, metrics);
+  const passed = casePassed(evalCase.expectedTrigger, metrics);
   const grading = buildGrading(evalCase.id, metrics, evalCase.expectedTrigger, passed);
   const observability = deriveRunObservability(events);
 

--- a/packages/skill-evals/src/suites/first-tree-read/types.ts
+++ b/packages/skill-evals/src/suites/first-tree-read/types.ts
@@ -27,7 +27,6 @@ export type CliOptions = {
   codexBin: string;
   json: boolean;
   model: string | null;
-  validateFixtures: boolean;
   verbose: boolean;
 };
 


### PR DESCRIPTION
## Summary

- Remove the legacy `first-tree-read` CLI wrapper and its `eval:first-tree-read` / `validate:first-tree-read-fixtures` package scripts.
- Remove the now-unreachable fixture-only mode from the read suite runner.
- Keep the unified read floor/gate path as the only documented and selectable entry point.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter @first-tree/skill-evals typecheck`
- `pnpm --filter @first-tree/skill-evals exec vitest run src/core/__tests__/select.test.ts src/core/__tests__/coverage.test.ts src/core/__tests__/case-schema.test.ts src/suites/first-tree-read/__tests__/metrics.test.ts --maxWorkers=2 --minWorkers=1`
- `pnpm --filter first-tree-dev... build`
- `pnpm --filter @first-tree/skill-evals exec vitest run --passWithNoTests --maxWorkers=2 --minWorkers=1`
- `pnpm --filter @first-tree/skill-evals eval:floor -- --suite first-tree-read`
- `pnpm --filter @first-tree/skill-evals eval:select -- --changed-file packages/skill-evals/src/suites/first-tree-read/runner.ts`
- `pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-read --case blank-casual-no-trigger --codex-bin /bin/false --json` (expected failure from fake provider; verified unified read gate path still runs fixture validation and writes artifacts)
- `pnpm exec biome check packages/skill-evals/README.md packages/skill-evals/package.json packages/skill-evals/src/core/select.ts packages/skill-evals/src/core/__tests__/select.test.ts packages/skill-evals/src/suites/first-tree-read/index.ts packages/skill-evals/src/suites/first-tree-read/eval-cases.ts packages/skill-evals/src/suites/first-tree-read/types.ts packages/skill-evals/src/suites/first-tree-read/runner.ts packages/skill-evals/src/suites/first-tree-read/metrics.ts`
- `pnpm typecheck`
- `pnpm check` (exits 0; reports existing unrelated client/web warnings/info)
- `git diff --check`
- `rg -n "eval:first-tree-read|validate:first-tree-read-fixtures|src/first-tree-read|runFirstTreeReadLegacyCli|validate-fixtures|first-tree-read-fixture-validation|validateFixtures|fixtureOnlyPassed" . || true` (no matches)

## Notes

- This intentionally removes the standalone fixture-only validation command. Live read gates still perform fixture setup and `validateFixture()` before invoking the provider.
