### PR TITLE
chore(web): drop redundant "no GitHub connection" line from no-repo bootstrap

### DIFF
--- a/packages/web/src/pages/workspace/center/onboarding/__tests__/bootstrap-prose.test.ts
+++ b/packages/web/src/pages/workspace/center/onboarding/__tests__/bootstrap-prose.test.ts
@@ -49,8 +49,6 @@ describe("start-chat bootstrap prose", () => {
 
     expect(message).toContain("Welcome to First Tree — this is your first chat with Nova.");
     expect(message).toContain("point it at a folder on your computer or paste a GitHub URL");
-    expect(message).toContain("No GitHub connection needed to begin");
-    expect(message).toContain("connect First Tree to GitHub later, only if a task needs it");
     expect(message).not.toContain("Operational note");
     expect(message).not.toContain("first-tree-welcome");
     expect(message).not.toContain("Ask the user for the project");

--- a/packages/web/src/pages/workspace/center/onboarding/bootstrap-prose.ts
+++ b/packages/web/src/pages/workspace/center/onboarding/bootstrap-prose.ts
@@ -47,8 +47,6 @@ export function buildNoRepoBootstrap(agentDisplayName: string): string {
     `Welcome to First Tree — this is your first chat with ${agentDisplayName}.`,
     "",
     `Tell ${agentDisplayName} what you'd like to work on: point it at a folder on your computer or paste a GitHub URL, and it'll take a look and suggest a few things you could start with.`,
-    "",
-    `No GitHub connection needed to begin — ${agentDisplayName} works right from your machine. You can connect First Tree to GitHub later, only if a task needs it.`,
   ].join("\n");
 }
 


### PR DESCRIPTION
## What

Remove the redundant third paragraph from the **no-repo** onboarding first-chat bootstrap (`buildNoRepoBootstrap`):

> ~~No GitHub connection needed to begin — {agent} works right from your machine. You can connect First Tree to GitHub later, only if a task needs it.~~

The paragraph above it already tells the user they can **point the agent at a local folder or paste a GitHub URL**, which implies local works without a GitHub connection. The extra reassurance was redundant; dropping it keeps the first-impression bubble tighter (copy-doctrine "do less").

The no-repo message becomes:

> Welcome to First Tree — this is your first chat with {agent}.
>
> Tell {agent} what you'd like to work on: point it at a folder on your computer or paste a GitHub URL, and it'll take a look and suggest a few things you could start with.

## Scope
- `buildNoRepoBootstrap` only. The other three bootstrap variants are untouched.
- Updated the two now-obsolete `.toContain` assertions in `bootstrap-prose.test.ts`.
- `step-start-chat.tsx` only calls the builder (no inline copy) — no change.

## Validation
- `vitest run bootstrap-prose.test.ts` → 6 passed. biome clean. `git diff --check` clean.

Merge left to the code-owner / maintainer path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
