### PR TITLE
feat(web): add dev/staging-only scan landing pages

### DIFF
--- a/packages/web/src/app.tsx
+++ b/packages/web/src/app.tsx
@@ -21,6 +21,7 @@ import { OAuthCompletePage } from "./pages/oauth-complete.js";
 import { GithubConnectedPage } from "./pages/onboarding/github-connected.js";
 import { OnboardingPage } from "./pages/onboarding/onboarding-page.js";
 import { QuickstartPage } from "./pages/quickstart/quickstart-page.js";
+import { ScanLandingPage } from "./pages/scan/scan-landing-page.js";
 import { SettingsComputersPage } from "./pages/settings/computers.js";
 import { SettingsContextTreePage } from "./pages/settings/context-tree.js";
 import { SettingsGithubPage } from "./pages/settings/github.js";
@@ -150,6 +151,9 @@ export function App() {
               {/* Public: the connect-code install popup lands here to auto-close. */}
               <Route path="/onboarding/connected" element={<GithubConnectedPage />} />
               <Route path="/invite/:token" element={<InviteAcceptPage />} />
+              {/* Public top-of-funnel scan landing. Dev/staging-only via its own
+                  channel gate; feeds /quickstart with campaign + repo. */}
+              <Route path="/scan/:campaign" element={<ScanLandingPage />} />
               {ContextPreviewPage ? (
                 <Route
                   path="/preview/context"

--- a/packages/web/src/pages/scan/__tests__/scan-copy.test.ts
+++ b/packages/web/src/pages/scan/__tests__/scan-copy.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { CAMPAIGN_SLUGS } from "../../quickstart/campaigns.js";
+import { SCAN_LANDING_COPY } from "../scan-copy.js";
+
+describe("scan landing copy", () => {
+  it("covers every campaign slug — a new campaign without landing copy is a build error", () => {
+    for (const slug of CAMPAIGN_SLUGS) {
+      expect(SCAN_LANDING_COPY[slug], `missing landing copy for ${slug}`).toBeTruthy();
+    }
+    // No stray entries for retired/unknown slugs.
+    expect(Object.keys(SCAN_LANDING_COPY).sort()).toEqual([...CAMPAIGN_SLUGS].sort());
+  });
+
+  it("every entry has the non-empty fields the page renders", () => {
+    for (const slug of CAMPAIGN_SLUGS) {
+      const copy = SCAN_LANDING_COPY[slug];
+      expect(copy.eyebrow.length).toBeGreaterThan(0);
+      expect(copy.headline.length).toBeGreaterThan(0);
+      expect(copy.subhead.length).toBeGreaterThan(0);
+      expect(copy.ctaLabel.length).toBeGreaterThan(0);
+      expect(copy.repoPlaceholder.length).toBeGreaterThan(0);
+      expect(copy.checksLabel.length).toBeGreaterThan(0);
+      expect(copy.checks.length).toBeGreaterThan(0);
+      expect(copy.checks.every((c) => c.trim().length > 0)).toBe(true);
+    }
+  });
+
+  it("stays honest and restrained — no unsubstantiated superlatives the scan can't back up", () => {
+    const banned = ["#1", "best ", "guaranteed", "world's", "no.1", "number one"];
+    for (const slug of CAMPAIGN_SLUGS) {
+      const copy = SCAN_LANDING_COPY[slug];
+      const blob = `${copy.eyebrow} ${copy.headline} ${copy.subhead}`.toLowerCase();
+      for (const term of banned) {
+        expect(blob, `${slug} copy should avoid "${term.trim()}"`).not.toContain(term);
+      }
+    }
+  });
+});

--- a/packages/web/src/pages/scan/__tests__/scan-landing-page.test.tsx
+++ b/packages/web/src/pages/scan/__tests__/scan-landing-page.test.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment happy-dom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+import { readCampaignHandoff } from "../../quickstart/intent.js";
+import { buildScanHandoffHref, ScanLandingPage } from "../scan-landing-page.js";
+
+// Mock the channel hook so each test pins dev / staging / prod / loading.
+const channelMock = vi.hoisted(() => ({ value: { channel: "dev" as string | null, settled: true } }));
+vi.mock("../../../hooks/use-server-channel.js", () => ({
+  useServerChannelState: () => channelMock.value,
+}));
+
+const INPUT_LABEL = "GitHub repository URL";
+
+function renderScan(path: string): string {
+  const queryClient = new QueryClient();
+  return renderToStaticMarkup(
+    <MemoryRouter initialEntries={[path]}>
+      <QueryClientProvider client={queryClient}>
+        <Routes>
+          <Route path="/scan/:campaign" element={<ScanLandingPage />} />
+          <Route path="/" element={<div>HOME</div>} />
+          <Route path="/quickstart" element={<div>QUICKSTART</div>} />
+        </Routes>
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("buildScanHandoffHref — landing → quickstart contract", () => {
+  it("percent-encodes the repo url so it survives the post-login next round-trip", () => {
+    expect(buildScanHandoffHref("production-scan", "https://github.com/acme/backend")).toBe(
+      "/quickstart?campaign=production-scan&repo=https%3A%2F%2Fgithub.com%2Facme%2Fbackend",
+    );
+  });
+
+  it("round-trips: what the landing emits is exactly what quickstart's parser accepts", () => {
+    for (const [campaign, url] of [
+      ["production-scan", "https://github.com/acme/backend"],
+      ["agent-readiness", "https://github.com/octo-org/the.repo"],
+    ] as const) {
+      const href = buildScanHandoffHref(campaign, url);
+      const parsed = readCampaignHandoff({ search: new URL(href, "http://x").search, hash: "" });
+      expect(parsed?.campaign).toBe(campaign);
+      expect(parsed?.url).toBe(url);
+    }
+  });
+});
+
+describe("ScanLandingPage — dev/staging-only channel gate", () => {
+  it("renders the scan form on dev for a known campaign", () => {
+    channelMock.value = { channel: "dev", settled: true };
+    const markup = renderScan("/scan/production-scan");
+    expect(markup).toContain(INPUT_LABEL);
+    expect(markup).toContain("Is your repo ready to ship?");
+  });
+
+  it("renders on staging too", () => {
+    channelMock.value = { channel: "staging", settled: true };
+    expect(renderScan("/scan/agent-readiness")).toContain(INPUT_LABEL);
+  });
+
+  it("does NOT render the form in prod — the whole funnel is hidden", () => {
+    channelMock.value = { channel: "prod", settled: true };
+    expect(renderScan("/scan/production-scan")).not.toContain(INPUT_LABEL);
+  });
+
+  it("does NOT render the form for an unknown/old server (null channel)", () => {
+    channelMock.value = { channel: null, settled: true };
+    expect(renderScan("/scan/production-scan")).not.toContain(INPUT_LABEL);
+  });
+
+  it("holds a neutral surface (no form) while the channel is still loading", () => {
+    channelMock.value = { channel: null, settled: false };
+    const markup = renderScan("/scan/production-scan");
+    expect(markup).not.toContain(INPUT_LABEL);
+    expect(markup).toContain("landing-marketing");
+  });
+
+  it("redirects an unknown campaign slug even on dev", () => {
+    channelMock.value = { channel: "dev", settled: true };
+    expect(renderScan("/scan/bogus-campaign")).not.toContain(INPUT_LABEL);
+  });
+});

--- a/packages/web/src/pages/scan/scan-copy.ts
+++ b/packages/web/src/pages/scan/scan-copy.ts
@@ -1,0 +1,53 @@
+import type { CampaignSlug } from "../quickstart/campaigns.js";
+
+/**
+ * Marketing copy for the scan landing page, keyed by campaign slug. Each
+ * campaign in {@link CampaignSlug} that has a landing surface gets one entry;
+ * the landing route (`/scan/:campaign`) renders this and points its CTA at
+ * `/quickstart?campaign=<slug>&repo=<encoded>`.
+ *
+ * Kept separate from the quickstart `campaigns.ts` registry on purpose: that
+ * registry drives runtime BEHAVIOUR (the first-chat bootstrap, idempotency),
+ * whereas this is user-facing MARKETING copy. Claims stay accurate and
+ * restrained — no superlatives the scan can't back up (mirrors the landing
+ * `features.tsx` "keep value claims accurate" rule).
+ */
+export type ScanLandingCopy = {
+  /** Decorative eyebrow above the headline; kept out of the heading outline. */
+  eyebrow: string;
+  /** The <h1>. One concrete question the visitor is already asking. */
+  headline: string;
+  /** One-line value promise. Specific, honest — names the payoff, not hype. */
+  subhead: string;
+  /** Primary CTA label on the green hero button. */
+  ctaLabel: string;
+  /** Placeholder for the repo URL input. */
+  repoPlaceholder: string;
+  /** Short label above the "what we look at" chips. */
+  checksLabel: string;
+  /** A few dimensions we score — credibility, not an exhaustive rubric. */
+  checks: readonly string[];
+};
+
+export const SCAN_LANDING_COPY: Record<CampaignSlug, ScanLandingCopy> = {
+  "production-scan": {
+    eyebrow: "Production Readiness",
+    headline: "Is your repo ready to ship?",
+    subhead:
+      "A free, security-weighted audit of the blockers most likely to stop your repo shipping — with evidence, not generic advice.",
+    ctaLabel: "Scan my repo",
+    repoPlaceholder: "https://github.com/your-org/your-repo",
+    checksLabel: "What we look at",
+    checks: ["Secrets & security", "Tests & CI", "Deploy & runtime", "Dependencies"],
+  },
+  "agent-readiness": {
+    eyebrow: "Agent Readiness",
+    headline: "Is your repo ready for coding agents?",
+    subhead:
+      "A free scan of why Claude Code, Codex & Cursor get lost in your repo — and the must-fix blockers to make it agent-ready.",
+    ctaLabel: "Scan my repo",
+    repoPlaceholder: "https://github.com/your-org/your-repo",
+    checksLabel: "What we look at",
+    checks: ["Agent instructions", "Verifiability", "Navigability", "Edit boundaries"],
+  },
+};

--- a/packages/web/src/pages/scan/scan-landing-page.tsx
+++ b/packages/web/src/pages/scan/scan-landing-page.tsx
@@ -1,0 +1,145 @@
+import { ArrowRight } from "lucide-react";
+import { type FormEvent, useEffect, useState } from "react";
+import { Navigate, useNavigate, useParams } from "react-router";
+import { Button } from "../../components/ui/button.js";
+import { Input } from "../../components/ui/input.js";
+import { useServerChannelState } from "../../hooks/use-server-channel.js";
+import { Footer } from "../landing/footer.js";
+import { LandingNav } from "../landing/nav.js";
+import { type CampaignSlug, isKnownCampaign } from "../quickstart/campaigns.js";
+import { normalizeGitHubRepoUrl } from "../quickstart/intent.js";
+import { SCAN_LANDING_COPY } from "./scan-copy.js";
+
+/**
+ * Build the landing → quickstart handoff URL. The repo value is
+ * percent-encoded per the contract in quickstart `campaigns.ts`: a raw
+ * `https://…` repo (with `:` and `//`) is dropped to `/` by `safeRedirectPath`
+ * on the post-login `next` round-trip, so it MUST be encoded to survive.
+ * Extracted + exported so the contract is unit-tested against quickstart's own
+ * `readCampaignHandoff` parser (see scan-landing-page.test.tsx round-trip).
+ */
+export function buildScanHandoffHref(campaign: CampaignSlug, repoUrl: string): string {
+  return `/quickstart?campaign=${campaign}&repo=${encodeURIComponent(repoUrl)}`;
+}
+
+/**
+ * Scan landing page (`/scan/:campaign`) — the top of the growth funnel.
+ *
+ * The visitor pastes a GitHub repo and hits Scan; we hand off to the quickstart
+ * flow at `/quickstart?campaign=<slug>&repo=<encoded>`, which owns login,
+ * connecting a computer, and starting the campaign's first chat. This page does
+ * one job: validate the repo and build that handoff URL.
+ *
+ * Dev/staging-only, exactly like the quickstart it feeds: the same prod-safe
+ * channel gate (unknown / old server → null → not allowed) keeps the whole
+ * funnel hidden in prod until we open it. Public route (no auth) — login
+ * happens later, inside quickstart, carried by the `next` round-trip.
+ */
+export function ScanLandingPage() {
+  const navigate = useNavigate();
+  const { campaign: slugParam } = useParams<{ campaign: string }>();
+  const campaign: CampaignSlug | null = isKnownCampaign(slugParam) ? slugParam : null;
+
+  const { channel, settled } = useServerChannelState();
+  const channelAllowed = channel === "dev" || channel === "staging";
+
+  const copy = campaign ? SCAN_LANDING_COPY[campaign] : null;
+
+  useEffect(() => {
+    if (!copy) return;
+    const previous = document.title;
+    document.title = `${copy.headline} — First Tree`;
+    return () => {
+      document.title = previous;
+    };
+  }, [copy]);
+
+  const [repoInput, setRepoInput] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  // Hold a neutral surface while the channel resolves — never flash the form
+  // for a prod visitor mid-fetch (mirrors the quickstart gate).
+  if (!settled) {
+    return <div className="landing-marketing min-h-screen bg-background" />;
+  }
+  // Prod / unknown server, or a campaign slug we don't recognise → send home.
+  // The funnel simply does not exist outside dev/staging.
+  if (!channelAllowed || !campaign || !copy) {
+    return <Navigate to="/" replace />;
+  }
+
+  const onSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    const repo = normalizeGitHubRepoUrl(repoInput);
+    if (!repo) {
+      setError("Enter a public GitHub repo URL, like https://github.com/your-org/your-repo.");
+      return;
+    }
+    setError(null);
+    navigate(buildScanHandoffHref(campaign, repo.url));
+  };
+
+  return (
+    <div className="landing-marketing flex min-h-screen flex-col bg-background text-foreground">
+      <LandingNav />
+      <main className="flex-1">
+        <section className="mx-auto flex w-full max-w-3xl flex-col items-center px-6 pb-24 pt-20 text-center sm:pt-28">
+          <p className="mb-6 text-eyebrow uppercase text-fg-3">{copy.eyebrow}</p>
+          <h1 className="text-display text-foreground">{copy.headline}</h1>
+          <p className="mt-6 max-w-2xl text-lead text-fg-2">{copy.subhead}</p>
+
+          <form onSubmit={onSubmit} className="mt-10 flex w-full max-w-xl flex-col items-stretch gap-3" noValidate>
+            <div className="flex flex-col gap-3 sm:flex-row">
+              <Input
+                type="text"
+                inputMode="url"
+                autoComplete="off"
+                autoCapitalize="none"
+                spellCheck={false}
+                aria-label="GitHub repository URL"
+                aria-invalid={error ? true : undefined}
+                aria-describedby="scan-repo-help"
+                placeholder={copy.repoPlaceholder}
+                value={repoInput}
+                onChange={(event) => {
+                  setRepoInput(event.target.value);
+                  if (error) setError(null);
+                }}
+                className="h-11 flex-1 text-center sm:text-left"
+              />
+              <Button type="submit" variant="cta" size="lg" className="group h-11 shrink-0">
+                {copy.ctaLabel}
+                <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
+              </Button>
+            </div>
+            {/* Stable live region: present before any error so screen readers
+                reliably announce it, and the input's aria-describedby can point
+                at it. Doubles as the privacy reassurance when there's no error. */}
+            <p
+              id="scan-repo-help"
+              aria-live="polite"
+              className={error ? "text-label text-destructive" : "text-label text-fg-3"}
+            >
+              {error ?? "First Tree runs on your own computer, so your code stays local."}
+            </p>
+          </form>
+
+          <div className="mt-12 flex flex-col items-center gap-3">
+            <p className="text-eyebrow uppercase text-fg-4">{copy.checksLabel}</p>
+            <ul className="flex flex-wrap items-center justify-center gap-2">
+              {copy.checks.map((check) => (
+                <li
+                  key={check}
+                  className="rounded-[var(--radius-full)] border border-border px-3 py-1 text-label text-fg-2"
+                >
+                  {check}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </section>
+      </main>
+      <Footer />
+    </div>
+  );
+}


### PR DESCRIPTION
## What

Adds the **top-of-funnel landing** for the repo-scan growth entry: a public
`/scan/:campaign` page (`production-scan`, `agent-readiness`) where a visitor
pastes a GitHub repo and is handed off to the existing quickstart flow at
`/quickstart?campaign=<slug>&repo=<encoded>`.

This is the page the user sees *before* quickstart — it feeds the campaign +
repo into the flow that #1352 already shipped.

## Scope / safety

- **Dev/staging-only.** Same prod-safe channel gate as quickstart
  (`useServerChannelState`: unknown / old server → `null` → not allowed). A
  prod (or still-loading) visitor never sees or acts on the form and is
  redirected home — the whole funnel stays hidden in prod until we deliberately
  open it.
- **Public route** (no auth). Login happens later inside quickstart, carried by
  the `next` round-trip.

## Design

- Reuses the existing landing chrome (`LandingNav`/`Footer`, `landing-marketing`
  dark palette, the `text-*` typography + `fg-*` token scale) so it matches `/`.
- One primary `cta` (brand-green) action per the button's own usage guidance.
- Marketing copy lives in a small `scan-copy.ts` registry, kept separate from
  the quickstart `campaigns.ts` behaviour registry; claims stay scoped to the
  checks we actually run (honest, no superlatives — enforced by a test).

## Contract

The handoff-URL builder is extracted (`buildScanHandoffHref`) and unit-tested
**against quickstart's own `readCampaignHandoff` parser** (round-trip), so the
landing's output is provably what quickstart accepts — the `repo` value is
percent-encoded per the contract in `campaigns.ts` (a raw `https://…` repo is
otherwise dropped to `/` by `safeRedirectPath` on the post-login round-trip).

## Testing

- `pnpm --filter @first-tree/web typecheck` (incl. `lint:tokens`) ✓
- `biome check` on changed files ✓
- `pnpm --filter @first-tree/web test` — 135 files / 1094 tests ✓ (8 new)
- Two independent reviews (correctness/funnel + design/UX/a11y); blocking
  findings fixed (input/button height match, stable `aria-live` error region +
  `aria-describedby`, copy honesty).
- Visual QA on a local dev stack (channel=dev) for both campaigns.

## Related

- Builds on the reusable quickstart entry (#1352).
- The per-campaign **scan skill activation** (the agent actually running the
  scan + producing the report) is a separate in-flight workstream; this PR is
  only the landing surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
