### PR TITLE
Add skill eval periodic command

### DIFF
--- a/packages/skill-evals/README.md
+++ b/packages/skill-evals/README.md
@@ -14,6 +14,8 @@ pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-write
 pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-write --include-quality
 pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-welcome
 pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-seed
+pnpm --filter @first-tree/skill-evals eval:periodic
+pnpm --filter @first-tree/skill-evals eval:periodic -- --suite first-tree-welcome
 pnpm --filter @first-tree/skill-evals eval:quality
 pnpm --filter @first-tree/skill-evals eval:quality -- --suite first-tree-write
 pnpm --filter @first-tree/skill-evals eval:quality -- --suite first-tree-welcome --judge-model <model>
@@ -43,6 +45,17 @@ implemented deterministic gates, and judge-core changes also recommend quality.
 Suite or skill changes recommend that suite's floor/gate/quality coverage where
 implemented. The command only recommends; live gate and quality evals remain
 opt-in and are not part of `pnpm test`.
+
+`eval:periodic` is the opt-in tier for broader, more expensive coverage that is
+not suitable for default gates or ordinary CI. It accepts the same basic live
+eval controls as gates, including `--suite`, `--case`, `--model`,
+`--codex-bin`, `--json`, and `--verbose`. This command currently provides the
+stable command and summary surface; no implemented periodic live cases are
+registered yet, so selecting periodic coverage prints a clear no-op summary and
+exits 0. Future PRs will add welcome full-matrix coverage, seed quality and
+realism cases, and multi-provider/runtime-generated periodic coverage. The
+default `eval:select` recommendations do not include periodic for ordinary
+skill changes; maintainers trigger periodic manually or via future scheduling.
 
 `eval:quality` is an opt-in LLM-as-judge layer. It does not replace
 deterministic gates and is not called by `eval:gate` by default. Each quality
@@ -137,15 +150,18 @@ Each case writes:
 - `summary.json` with derived metrics.
 - `summary.md` with a human-readable case report and grading summary.
 
-The top-level `eval:floor`, `eval:gate`, and `eval:quality` commands also append
-a lightweight local result-store entry to
+The top-level `eval:floor`, `eval:gate`, and `eval:quality` commands append a
+lightweight local result-store entry to
 `packages/skill-evals/.runs/index.jsonl`. Entries record the run group, suite,
 tier, case, pass/fail state, git branch/sha, model/provider where available,
 artifact paths, duration, turns and first-response latency when derivable, cost,
 and judge scores when present. Gate failures use the deterministic grading
 evidence first and link the `grading.json` artifact path in the result store.
 Unknown turn or latency values are recorded as `null`. The `.runs` directory is
-gitignored local eval state.
+gitignored local eval state. The current `eval:periodic` no-op path does not
+append result-store entries; implemented periodic cases added later will use
+`command: "eval:periodic"` and `tier: "periodic"` entries so summary and compare
+can report them alongside floor, gate, and quality runs.
 
 Use `eval:summary` to summarize the latest result-store run group, or pass a
 specific run group id:

--- a/packages/skill-evals/package.json
+++ b/packages/skill-evals/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "eval:floor": "tsx src/index.ts floor",
     "eval:gate": "tsx src/index.ts gate",
+    "eval:periodic": "tsx src/index.ts periodic",
     "eval:quality": "tsx src/index.ts quality",
     "eval:select": "tsx src/index.ts select",
     "eval:summary": "tsx src/index.ts summary",

--- a/packages/skill-evals/src/core/__tests__/periodic.test.ts
+++ b/packages/skill-evals/src/core/__tests__/periodic.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+
+import type { SkillEvalCase } from "../case-schema.js";
+import type { SkillEvalSuiteDefinition } from "../coverage.js";
+import { buildPeriodicSummary, formatPeriodicSummary } from "../periodic.js";
+
+function evalCase(overrides: Partial<SkillEvalCase> = {}): SkillEvalCase {
+  return {
+    briefingMode: "minimal",
+    expected: {},
+    fixture: {},
+    id: "periodic-smoke",
+    prompt: "Run the periodic smoke case.",
+    skill: "first-tree-welcome",
+    status: "planned",
+    tier: "periodic",
+    ...overrides,
+  };
+}
+
+function suite(cases: readonly SkillEvalCase[]): SkillEvalSuiteDefinition {
+  return {
+    cases,
+    coverage: {
+      skill: "first-tree-welcome",
+      tiers: [
+        {
+          caseIds: ["floor-coverage"],
+          description: "Synthetic floor coverage.",
+          status: "implemented",
+          tier: "floor",
+        },
+        {
+          caseIds: ["gate-smoke"],
+          description: "Synthetic gate coverage.",
+          status: "implemented",
+          tier: "gate",
+        },
+      ],
+    },
+    skill: "first-tree-welcome",
+  };
+}
+
+describe("periodic summary", () => {
+  it("returns a clear no-op summary when no periodic cases are selected", () => {
+    const summary = buildPeriodicSummary([suite([])], {
+      caseId: null,
+      suite: null,
+    });
+
+    expect(summary).toMatchObject({
+      command: "eval:periodic",
+      failed: 0,
+      passed: 0,
+      planned: 0,
+      selected: [],
+      skipped: 0,
+    });
+    expect(formatPeriodicSummary(summary)).toContain("No implemented periodic cases selected.");
+  });
+
+  it("reports selected planned periodic cases as skipped", () => {
+    const summary = buildPeriodicSummary(
+      [
+        suite([
+          evalCase({
+            id: "welcome-full-matrix",
+          }),
+        ]),
+      ],
+      {
+        caseId: "welcome-full-matrix",
+        suite: "first-tree-welcome",
+      },
+      "2026-06-30T00:00:00.000Z",
+    );
+
+    expect(summary).toEqual({
+      command: "eval:periodic",
+      failed: 0,
+      passed: 0,
+      planned: 1,
+      runStartedAt: "2026-06-30T00:00:00.000Z",
+      selected: [
+        {
+          caseId: "welcome-full-matrix",
+          skill: "first-tree-welcome",
+          status: "planned",
+        },
+      ],
+      skipped: 1,
+    });
+    expect(formatPeriodicSummary(summary)).toContain("- first-tree-welcome:welcome-full-matrix (planned)");
+  });
+
+  it("fails specifically when a requested periodic case does not exist", () => {
+    expect(() =>
+      buildPeriodicSummary([suite([])], {
+        caseId: "missing-case",
+        suite: "first-tree-welcome",
+      }),
+    ).toThrow("No periodic case 'missing-case' found for suite first-tree-welcome.");
+  });
+
+  it("fails specifically if an implemented periodic case is selected before a runner exists", () => {
+    expect(() =>
+      buildPeriodicSummary(
+        [
+          suite([
+            evalCase({
+              id: "implemented-periodic",
+              status: "implemented",
+            }),
+          ]),
+        ],
+        {
+          caseId: null,
+          suite: null,
+        },
+      ),
+    ).toThrow(
+      "Implemented periodic cases selected but no periodic runner is registered yet: first-tree-welcome:implemented-periodic.",
+    );
+  });
+});

--- a/packages/skill-evals/src/core/__tests__/result-store.test.ts
+++ b/packages/skill-evals/src/core/__tests__/result-store.test.ts
@@ -176,12 +176,28 @@ describe("result store", () => {
       startedAt: "2026-06-29T02:00:01.000Z",
       tier: "quality",
     });
+    const currentPeriodic = entry({
+      artifact: {
+        gradingJsonPath: null,
+        runRoot: "/tmp/periodic-run",
+        summaryJsonPath: "/tmp/periodic-run/summary.json",
+        summaryMdPath: "/tmp/periodic-run/summary.md",
+      },
+      caseId: "welcome-full-matrix",
+      command: "eval:periodic",
+      durationMs: 300,
+      passed: true,
+      runGroupId: "20260629T020000000Z-eval-gate",
+      skill: "first-tree-welcome",
+      startedAt: "2026-06-29T02:00:02.000Z",
+      tier: "periodic",
+    });
 
-    const summary = summarizeResultRunGroup([previous, currentFailure, currentQuality], null);
+    const summary = summarizeResultRunGroup([previous, currentFailure, currentQuality, currentPeriodic], null);
 
     expect(summary?.runGroupId).toBe("20260629T020000000Z-eval-gate");
     expect(summary?.failed).toBe(1);
-    expect(summary?.totalDurationMs).toBe(1400);
+    expect(summary?.totalDurationMs).toBe(1700);
     expect(summary?.turns).toBe(1);
     expect(summary?.firstResponseLatencyMs).toBe(350);
     expect(summary?.git).toEqual({
@@ -191,14 +207,16 @@ describe("result store", () => {
     });
     expect(summary?.countsByCommand).toEqual({
       "eval:gate": 1,
+      "eval:periodic": 1,
       "eval:quality": 1,
     });
     expect(summary?.countsBySkill).toEqual({
-      "first-tree-welcome": 1,
+      "first-tree-welcome": 2,
       "first-tree-write": 1,
     });
     expect(summary?.countsByTier).toEqual({
       gate: 1,
+      periodic: 1,
       quality: 1,
     });
     expect(summary?.entries.find((candidate) => candidate.tier === "quality")?.judgeScores).toEqual({
@@ -212,11 +230,42 @@ describe("result store", () => {
     });
     const formatted = formatResultRunSummary(summary);
     expect(formatted).toContain("Git: branch=feat/test sha=abc123 base=n/a");
-    expect(formatted).toContain("Counts by command: eval:gate=1, eval:quality=1");
-    expect(formatted).toContain("Counts by tier: gate=1, quality=1");
-    expect(formatted).toContain("Counts by skill: first-tree-welcome=1, first-tree-write=1");
+    expect(formatted).toContain("Counts by command: eval:gate=1, eval:periodic=1, eval:quality=1");
+    expect(formatted).toContain("Counts by tier: gate=1, periodic=1, quality=1");
+    expect(formatted).toContain("Counts by skill: first-tree-welcome=2, first-tree-write=1");
     expect(formatted).toContain("First response latency: 350 ms");
+    expect(formatted).toContain("first-tree-welcome:periodic:welcome-full-matrix command=eval:periodic");
     expect(formatted).toContain("judge_scores: bounded=4, useful=3");
+  });
+
+  it("compares periodic result-store entries by case key", () => {
+    const previousPeriodic = entry({
+      caseId: "welcome-full-matrix",
+      command: "eval:periodic",
+      failures: ["periodic oracle failed"],
+      passed: false,
+      runGroupId: "20260629T010000000Z-eval-periodic",
+      skill: "first-tree-welcome",
+      startedAt: "2026-06-29T01:00:00.000Z",
+      status: "failed",
+      tier: "periodic",
+    });
+    const currentPeriodic = entry({
+      caseId: "welcome-full-matrix",
+      command: "eval:periodic",
+      passed: true,
+      runGroupId: "20260629T020000000Z-eval-periodic",
+      skill: "first-tree-welcome",
+      startedAt: "2026-06-29T02:00:00.000Z",
+      tier: "periodic",
+    });
+
+    const { current, previous } = latestRunGroups([previousPeriodic, currentPeriodic], null, null);
+    const comparison = compareResultGroups(current, previous);
+
+    expect(comparison.recovered.map((delta) => delta.caseKey)).toEqual([
+      "first-tree-welcome:periodic:welcome-full-matrix",
+    ]);
   });
 
   it("returns null when there are no result-store run groups to summarize", () => {

--- a/packages/skill-evals/src/core/__tests__/select.test.ts
+++ b/packages/skill-evals/src/core/__tests__/select.test.ts
@@ -48,6 +48,19 @@ describe("skill eval selection", () => {
     ]);
   });
 
+  it("selects only periodic for shared periodic framework changes", () => {
+    const summary = selectSkillEvalRecommendations(["packages/skill-evals/src/core/periodic.ts"]);
+
+    expect(summary.recommendations).toEqual([
+      {
+        command: "pnpm --filter @first-tree/skill-evals eval:periodic",
+        kind: "periodic",
+        reason: "packages/skill-evals/src/core/periodic.ts touches periodic eval framework",
+        suite: "all",
+      },
+    ]);
+  });
+
   it("does not recommend live eval for unrelated files", () => {
     const summary = selectSkillEvalRecommendations(["packages/client/src/runtime/agent-slot.ts"]);
 

--- a/packages/skill-evals/src/core/periodic.ts
+++ b/packages/skill-evals/src/core/periodic.ts
@@ -1,0 +1,97 @@
+import type { ShippedSkillName, SkillEvalCase } from "./case-schema.js";
+import type { SkillEvalSuiteDefinition } from "./coverage.js";
+
+export type PeriodicCaseSelection = {
+  caseId: string;
+  skill: ShippedSkillName;
+  status: "implemented" | "planned";
+};
+
+export type PeriodicSummary = {
+  command: "eval:periodic";
+  failed: number;
+  passed: number;
+  planned: number;
+  runStartedAt: string;
+  selected: readonly PeriodicCaseSelection[];
+  skipped: number;
+};
+
+export type PeriodicOptions = {
+  caseId: string | null;
+  suite: ShippedSkillName | null;
+};
+
+function periodicCases(suites: readonly SkillEvalSuiteDefinition[]): readonly SkillEvalCase[] {
+  return suites.flatMap((suite) => suite.cases.filter((evalCase) => evalCase.tier === "periodic"));
+}
+
+function selectedPeriodicCases(
+  suites: readonly SkillEvalSuiteDefinition[],
+  options: PeriodicOptions,
+): readonly SkillEvalCase[] {
+  return periodicCases(suites).filter((evalCase) => {
+    if (options.suite !== null && evalCase.skill !== options.suite) return false;
+    if (options.caseId !== null && evalCase.id !== options.caseId) return false;
+    return true;
+  });
+}
+
+export function buildPeriodicSummary(
+  suites: readonly SkillEvalSuiteDefinition[],
+  options: PeriodicOptions,
+  runStartedAt = new Date().toISOString(),
+): PeriodicSummary {
+  const selectedCases = selectedPeriodicCases(suites, options);
+  if (options.caseId !== null && selectedCases.length === 0) {
+    const suiteText = options.suite === null ? "" : ` for suite ${options.suite}`;
+    throw new Error(`No periodic case '${options.caseId}' found${suiteText}.`);
+  }
+
+  const implemented = selectedCases.filter((evalCase) => evalCase.status === "implemented");
+  if (implemented.length > 0) {
+    const cases = implemented.map((evalCase) => `${evalCase.skill}:${evalCase.id}`).join(", ");
+    throw new Error(`Implemented periodic cases selected but no periodic runner is registered yet: ${cases}.`);
+  }
+
+  const selected = selectedCases.map((evalCase) => ({
+    caseId: evalCase.id,
+    skill: evalCase.skill,
+    status: evalCase.status,
+  }));
+  const planned = selected.filter((evalCase) => evalCase.status === "planned").length;
+
+  return {
+    command: "eval:periodic",
+    failed: 0,
+    passed: 0,
+    planned,
+    runStartedAt,
+    selected,
+    skipped: planned,
+  };
+}
+
+export function formatPeriodicSummary(summary: PeriodicSummary): string {
+  const lines = [
+    "Skill Eval Periodic",
+    "",
+    "No implemented periodic cases selected.",
+    `Selected periodic cases: ${summary.selected.length}`,
+    `Planned cases: ${summary.planned}`,
+    `Skipped: ${summary.skipped}`,
+  ];
+
+  if (summary.selected.length > 0) {
+    lines.push("", "Selected cases:");
+    for (const evalCase of summary.selected) {
+      lines.push(`- ${evalCase.skill}:${evalCase.caseId} (${evalCase.status})`);
+    }
+  }
+
+  lines.push(
+    "",
+    "Periodic is an opt-in tier for broader, more expensive coverage. Future PRs will add implemented periodic cases.",
+  );
+  return lines.join("\n");
+}

--- a/packages/skill-evals/src/core/result-store.ts
+++ b/packages/skill-evals/src/core/result-store.ts
@@ -5,7 +5,7 @@ import { dirname, join } from "node:path";
 import type { ShippedSkillName, SkillEvalTier } from "./case-schema.js";
 import { isRecord } from "./events.js";
 
-export type ResultStoreCommand = "eval:floor" | "eval:gate" | "eval:quality";
+export type ResultStoreCommand = "eval:floor" | "eval:gate" | "eval:periodic" | "eval:quality";
 
 export type ResultStoreStatus = "passed" | "failed" | "skipped";
 

--- a/packages/skill-evals/src/core/select.ts
+++ b/packages/skill-evals/src/core/select.ts
@@ -2,7 +2,7 @@ import { execFileSync } from "node:child_process";
 
 import type { ShippedSkillName } from "./case-schema.js";
 
-export type EvalRecommendationKind = "floor" | "gate" | "quality";
+export type EvalRecommendationKind = "floor" | "gate" | "periodic" | "quality";
 
 export type EvalRecommendation = {
   command: string;
@@ -61,6 +61,10 @@ function gateCommand(skill: ShippedSkillName): string {
 
 function qualityCommand(skill: Extract<ShippedSkillName, "first-tree-write" | "first-tree-welcome">): string {
   return `pnpm --filter @first-tree/skill-evals eval:quality -- --suite ${skill}`;
+}
+
+function periodicCommand(): string {
+  return "pnpm --filter @first-tree/skill-evals eval:periodic";
 }
 
 function addSuiteRecommendations(
@@ -133,6 +137,14 @@ function isSkillEvalCorePath(path: string): boolean {
   return path.startsWith("packages/skill-evals/src/core/") || path === "packages/skill-evals/src/index.ts";
 }
 
+function isSkillEvalPeriodicFrameworkPath(path: string): boolean {
+  return (
+    path === "packages/skill-evals/src/core/periodic.ts" ||
+    path.startsWith("packages/skill-evals/src/core/periodic/") ||
+    path.startsWith("packages/skill-evals/src/suites/periodic/")
+  );
+}
+
 function isSkillEvalCliOrSchemaPath(path: string): boolean {
   return (
     path === "packages/skill-evals/package.json" ||
@@ -159,6 +171,16 @@ export function selectSkillEvalRecommendations(
     const skill = matchingSkill(path);
     if (skill !== null) {
       addSuiteRecommendations(recommendations, skill, `${path} touches ${skill}`);
+      continue;
+    }
+
+    if (isSkillEvalPeriodicFrameworkPath(path)) {
+      addRecommendation(recommendations, {
+        command: periodicCommand(),
+        kind: "periodic",
+        reason: `${path} touches periodic eval framework`,
+        suite: "all",
+      });
       continue;
     }
 

--- a/packages/skill-evals/src/index.ts
+++ b/packages/skill-evals/src/index.ts
@@ -7,6 +7,7 @@ import { type SkillEvalSuiteDefinition, validateCoverageMatrix } from "./core/co
 import { isRecord } from "./core/events.js";
 import { gateCommandFailed } from "./core/gate-exit.js";
 import { gradingFailureMessages } from "./core/grading.js";
+import { buildPeriodicSummary, formatPeriodicSummary } from "./core/periodic.js";
 import {
   appendResultStoreEntries,
   compareResultGroups,
@@ -45,7 +46,7 @@ type CliOptions = {
   caseId: string | null;
   changedFiles: readonly string[];
   codexBin: string;
-  command: "compare" | "floor" | "gate" | "quality" | "select" | "summary";
+  command: "compare" | "floor" | "gate" | "periodic" | "quality" | "select" | "summary";
   currentRunGroupId: string | null;
   includeQuality: boolean;
   judgeBin: string;
@@ -80,6 +81,8 @@ function usage(): string {
   pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-write --include-quality
   pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-welcome
   pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-seed
+  pnpm --filter @first-tree/skill-evals eval:periodic
+  pnpm --filter @first-tree/skill-evals eval:periodic -- --suite first-tree-welcome
   pnpm --filter @first-tree/skill-evals eval:quality
   pnpm --filter @first-tree/skill-evals eval:quality -- --suite first-tree-write
   pnpm --filter @first-tree/skill-evals eval:select -- --base main
@@ -89,6 +92,7 @@ function usage(): string {
 Commands:
   floor                  Run no-model schema, coverage, and skill-file checks.
   gate                   Run a live model gate suite and write grading.json.
+  periodic               Run opt-in broader periodic evals when implemented.
   quality                Run opt-in LLM-as-judge quality cases.
   select                 Recommend eval commands from changed files.
   summary                Summarize one result-store run group.
@@ -96,7 +100,7 @@ Commands:
 
 Options:
   --suite <skill>        Limit per-suite floor checks to one shipped skill.
-  --case <id>            Run one live gate case.
+  --case <id>            Run one live eval case.
   --include-quality      With eval:gate, run supported quality judge cases after deterministic gate passes.
   --base <ref>           Base ref for eval:select git diff. Defaults to main.
   --changed-file <path>  Add an explicit changed file for eval:select.
@@ -130,6 +134,7 @@ function parseArgs(args: readonly string[]): CliOptions {
   if (
     command !== "floor" &&
     command !== "gate" &&
+    command !== "periodic" &&
     command !== "quality" &&
     command !== "select" &&
     command !== "summary" &&
@@ -754,6 +759,18 @@ function runSelect(options: CliOptions): void {
   }
 }
 
+function runPeriodic(options: CliOptions): void {
+  const summary = buildPeriodicSummary(SKILL_EVAL_SUITES, {
+    caseId: options.caseId,
+    suite: options.suite,
+  });
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+  } else {
+    process.stdout.write(`${formatPeriodicSummary(summary)}\n`);
+  }
+}
+
 function runCompare(options: CliOptions): void {
   const packageRootPath = packageRoot();
   const entries = readResultStore(packageRootPath);
@@ -792,6 +809,10 @@ async function main(): Promise<void> {
   }
   if (options.command === "summary") {
     runSummary(options);
+    return;
+  }
+  if (options.command === "periodic") {
+    runPeriodic(options);
     return;
   }
   if (options.command === "gate") {


### PR DESCRIPTION
## Summary

- Add `eval:periodic` as an opt-in skill-eval command and package script.
- Add a periodic summary model that returns a clear no-op when no implemented periodic cases are selected.
- Extend result-store command typing and tests so summary/compare can carry `command: "eval:periodic"` with `tier: "periodic"`.
- Update `eval:select` so periodic is only recommended for periodic framework paths, not ordinary skill changes.
- Document the periodic tier and its current no-op boundary in the skill-evals README and CLI usage.

## Behavior

- Current `eval:periodic` no-op runs exit 0 and do not write result-store entries.
- Unknown requested periodic cases fail specifically.
- No periodic live runner, welcome full-matrix coverage, seed quality judge, real repo realism, multi-provider support, or runtime E2E is added in this PR.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter @first-tree/skill-evals typecheck`
- `pnpm --filter @first-tree/skill-evals exec vitest run src/core/__tests__/periodic.test.ts src/core/__tests__/result-store.test.ts src/core/__tests__/select.test.ts src/core/__tests__/coverage.test.ts src/core/__tests__/case-schema.test.ts --maxWorkers=2 --minWorkers=1`
- `pnpm --filter first-tree-dev... build`
- `pnpm --filter @first-tree/skill-evals exec vitest run --passWithNoTests --maxWorkers=2 --minWorkers=1`
- `pnpm --filter @first-tree/skill-evals eval:periodic`
- `pnpm --filter @first-tree/skill-evals eval:periodic -- --json`
- `pnpm --filter @first-tree/skill-evals eval:periodic -- --suite first-tree-welcome`
- `pnpm --filter @first-tree/skill-evals eval:periodic -- --case missing-periodic-case` (expected failure, specific error)
- `pnpm --filter @first-tree/skill-evals eval:summary`
- `pnpm --filter @first-tree/skill-evals eval:compare`
- `pnpm --filter @first-tree/skill-evals eval:select -- --changed-file packages/skill-evals/src/core/periodic.ts`
- `pnpm --filter @first-tree/skill-evals eval:select -- --changed-file skills/first-tree-write/SKILL.md`
- `pnpm --filter @first-tree/skill-evals eval:floor`
- `pnpm exec biome check packages/skill-evals/README.md packages/skill-evals/package.json packages/skill-evals/src/core/__tests__/periodic.test.ts packages/skill-evals/src/core/__tests__/result-store.test.ts packages/skill-evals/src/core/__tests__/select.test.ts packages/skill-evals/src/core/periodic.ts packages/skill-evals/src/core/result-store.ts packages/skill-evals/src/core/select.ts packages/skill-evals/src/index.ts`
- `pnpm typecheck`
- `pnpm check` (exits 0; reports existing client/web warnings/info)
- `git diff --check`

## Notes

- The first full skill-evals vitest run was attempted before `first-tree-dev... build`; three post-model verify tests failed because validator stdout was empty. After the required build step, the full skill-evals suite passed.
