### PR TITLE
Add welcome periodic matrix evals

### DIFF
--- a/packages/skill-evals/README.md
+++ b/packages/skill-evals/README.md
@@ -49,13 +49,14 @@ opt-in and are not part of `pnpm test`.
 `eval:periodic` is the opt-in tier for broader, more expensive coverage that is
 not suitable for default gates or ordinary CI. It accepts the same basic live
 eval controls as gates, including `--suite`, `--case`, `--model`,
-`--codex-bin`, `--json`, and `--verbose`. This command currently provides the
-stable command and summary surface; no implemented periodic live cases are
-registered yet, so selecting periodic coverage prints a clear no-op summary and
-exits 0. Future PRs will add welcome full-matrix coverage, seed quality and
-realism cases, and multi-provider/runtime-generated periodic coverage. The
-default `eval:select` recommendations do not include periodic for ordinary
-skill changes; maintainers trigger periodic manually or via future scheduling.
+`--codex-bin`, `--json`, and `--verbose`. `first-tree-welcome` periodic now
+runs the concrete setup-state matrix rows as live eval cases while keeping the
+default welcome gate limited to its three high-risk rows. Other suites still
+print a clear no-op summary and exit 0 until they register implemented periodic
+cases. Future PRs will add seed quality and realism cases, plus
+multi-provider/runtime-generated periodic coverage. The default `eval:select`
+recommendations do not include periodic for ordinary skill changes; maintainers
+trigger periodic manually or via future scheduling.
 
 `eval:quality` is an opt-in LLM-as-judge layer. It does not replace
 deterministic gates and is not called by `eval:gate` by default. Each quality
@@ -103,7 +104,7 @@ runner:
 - implementation-only source material means no Context Tree diff.
 
 `eval:gate -- --suite first-tree-welcome` runs the live Codex gate for
-the currently implemented `first-tree-welcome` onboarding rows:
+the currently implemented `first-tree-welcome` gate rows:
 
 - tree kickoff chat routes to the tree setup lane instead of welcome first-task
   options;
@@ -112,6 +113,16 @@ the currently implemented `first-tree-welcome` onboarding rows:
 - readable repo + populated Context Tree reads both evidence sources and offers
   two or three bounded first-task options without seeding or setting up the
   tree.
+
+`eval:periodic -- --suite first-tree-welcome` runs the broader live welcome
+matrix. It covers every concrete setup-state row from the current
+`first-tree-welcome` matrix, including invitee not-ready/ready states, selected
+repo authorization failure, local-readable repo with missing GitHub App,
+installed app with no selected repo, readable repo with empty tree, and
+readable repo with unknown tree. The explicit catch-all row remains a no-model
+floor invariant because it is a structural fallback rather than a stable live
+oracle. Periodic case ids use the gate row id plus `-periodic`; `--case` also
+accepts the source row id as an alias.
 
 `eval:gate -- --suite first-tree-seed` runs the live Codex gate for
 `first-tree-seed`. It covers the minimum bootstrap lifecycle boundaries:
@@ -150,18 +161,18 @@ Each case writes:
 - `summary.json` with derived metrics.
 - `summary.md` with a human-readable case report and grading summary.
 
-The top-level `eval:floor`, `eval:gate`, and `eval:quality` commands append a
-lightweight local result-store entry to
+The top-level `eval:floor`, `eval:gate`, `eval:periodic`, and `eval:quality`
+commands append a lightweight local result-store entry to
 `packages/skill-evals/.runs/index.jsonl`. Entries record the run group, suite,
 tier, case, pass/fail state, git branch/sha, model/provider where available,
 artifact paths, duration, turns and first-response latency when derivable, cost,
 and judge scores when present. Gate failures use the deterministic grading
 evidence first and link the `grading.json` artifact path in the result store.
 Unknown turn or latency values are recorded as `null`. The `.runs` directory is
-gitignored local eval state. The current `eval:periodic` no-op path does not
-append result-store entries; implemented periodic cases added later will use
-`command: "eval:periodic"` and `tier: "periodic"` entries so summary and compare
-can report them alongside floor, gate, and quality runs.
+gitignored local eval state. Periodic live cases use `command:
+"eval:periodic"` and `tier: "periodic"` entries so summary and compare can
+report them alongside floor, gate, and quality runs. Periodic no-op paths for
+suites with no implemented periodic cases do not append result-store entries.
 
 Use `eval:summary` to summarize the latest result-store run group, or pass a
 specific run group id:

--- a/packages/skill-evals/src/core/__tests__/select.test.ts
+++ b/packages/skill-evals/src/core/__tests__/select.test.ts
@@ -61,6 +61,19 @@ describe("skill eval selection", () => {
     ]);
   });
 
+  it("selects suite-scoped periodic for welcome periodic runner changes", () => {
+    const summary = selectSkillEvalRecommendations(["packages/skill-evals/src/suites/first-tree-welcome/periodic.ts"]);
+
+    expect(summary.recommendations).toEqual([
+      {
+        command: "pnpm --filter @first-tree/skill-evals eval:periodic -- --suite first-tree-welcome",
+        kind: "periodic",
+        reason: "packages/skill-evals/src/suites/first-tree-welcome/periodic.ts touches periodic eval framework",
+        suite: "first-tree-welcome",
+      },
+    ]);
+  });
+
   it("does not recommend live eval for unrelated files", () => {
     const summary = selectSkillEvalRecommendations(["packages/client/src/runtime/agent-slot.ts"]);
 

--- a/packages/skill-evals/src/core/select.ts
+++ b/packages/skill-evals/src/core/select.ts
@@ -63,8 +63,9 @@ function qualityCommand(skill: Extract<ShippedSkillName, "first-tree-write" | "f
   return `pnpm --filter @first-tree/skill-evals eval:quality -- --suite ${skill}`;
 }
 
-function periodicCommand(): string {
-  return "pnpm --filter @first-tree/skill-evals eval:periodic";
+function periodicCommand(skill: ShippedSkillName | null = null): string {
+  if (skill === null) return "pnpm --filter @first-tree/skill-evals eval:periodic";
+  return `pnpm --filter @first-tree/skill-evals eval:periodic -- --suite ${skill}`;
 }
 
 function addSuiteRecommendations(
@@ -137,12 +138,19 @@ function isSkillEvalCorePath(path: string): boolean {
   return path.startsWith("packages/skill-evals/src/core/") || path === "packages/skill-evals/src/index.ts";
 }
 
-function isSkillEvalPeriodicFrameworkPath(path: string): boolean {
-  return (
+function periodicFrameworkSkill(path: string): ShippedSkillName | "all" | null {
+  if (
     path === "packages/skill-evals/src/core/periodic.ts" ||
     path.startsWith("packages/skill-evals/src/core/periodic/") ||
     path.startsWith("packages/skill-evals/src/suites/periodic/")
-  );
+  ) {
+    return "all";
+  }
+  for (const skill of ["first-tree-read", "first-tree-write", "first-tree-seed", "first-tree-welcome"] as const) {
+    if (path === `packages/skill-evals/src/suites/${skill}/periodic.ts`) return skill;
+    if (path.startsWith(`packages/skill-evals/src/suites/${skill}/periodic/`)) return skill;
+  }
+  return null;
 }
 
 function isSkillEvalCliOrSchemaPath(path: string): boolean {
@@ -168,19 +176,20 @@ export function selectSkillEvalRecommendations(
   const notes: string[] = [];
 
   for (const path of changedFiles) {
-    const skill = matchingSkill(path);
-    if (skill !== null) {
-      addSuiteRecommendations(recommendations, skill, `${path} touches ${skill}`);
+    const periodicSkill = periodicFrameworkSkill(path);
+    if (periodicSkill !== null) {
+      addRecommendation(recommendations, {
+        command: periodicCommand(periodicSkill === "all" ? null : periodicSkill),
+        kind: "periodic",
+        reason: `${path} touches periodic eval framework`,
+        suite: periodicSkill,
+      });
       continue;
     }
 
-    if (isSkillEvalPeriodicFrameworkPath(path)) {
-      addRecommendation(recommendations, {
-        command: periodicCommand(),
-        kind: "periodic",
-        reason: `${path} touches periodic eval framework`,
-        suite: "all",
-      });
+    const skill = matchingSkill(path);
+    if (skill !== null) {
+      addSuiteRecommendations(recommendations, skill, `${path} touches ${skill}`);
       continue;
     }
 

--- a/packages/skill-evals/src/index.ts
+++ b/packages/skill-evals/src/index.ts
@@ -26,7 +26,12 @@ import { formatFirstTreeReadGateSummary, runFirstTreeReadGate } from "./suites/f
 import type { BatchSummary as ReadBatchSummary } from "./suites/first-tree-read/types.js";
 import { formatFirstTreeSeedGateSummary, runFirstTreeSeedGate } from "./suites/first-tree-seed/index.js";
 import type { BatchSummary as SeedBatchSummary } from "./suites/first-tree-seed/types.js";
-import { formatFirstTreeWelcomeGateSummary, runFirstTreeWelcomeGate } from "./suites/first-tree-welcome/index.js";
+import {
+  formatFirstTreeWelcomeGateSummary,
+  formatFirstTreeWelcomePeriodicSummary,
+  runFirstTreeWelcomeGate,
+  runFirstTreeWelcomePeriodic,
+} from "./suites/first-tree-welcome/index.js";
 import { FIRST_TREE_WELCOME_QUALITY_DEFINITION } from "./suites/first-tree-welcome/quality.js";
 import type { BatchSummary as WelcomeBatchSummary } from "./suites/first-tree-welcome/types.js";
 import { formatFirstTreeWriteGateSummary, runFirstTreeWriteGate } from "./suites/first-tree-write/index.js";
@@ -464,6 +469,47 @@ function gateResultEntries(
   });
 }
 
+function periodicResultEntries(
+  packageRootPath: string,
+  batch: WelcomeBatchSummary,
+  suite: Extract<ShippedSkillName, "first-tree-welcome">,
+  options: CliOptions,
+  runGroupId = createRunGroupId(batch.runStartedAt, `eval-periodic-${suite}`),
+): readonly ResultStoreEntry[] {
+  const git = readGitInfo(repoRootFromPackage(packageRootPath), options.base);
+  return batch.cases.map((summary) => {
+    const durationMs = Math.max(0, Date.now() - Date.parse(summary.startedAt));
+    return {
+      artifact: {
+        gradingJsonPath: summary.gradingJsonPath,
+        runRoot: summary.runRoot,
+        summaryJsonPath: summary.summaryJsonPath,
+        summaryMdPath: summary.summaryMdPath,
+      },
+      caseId: summary.caseId,
+      command: "eval:periodic",
+      costUsd: null,
+      durationMs,
+      firstResponseLatencyMs: summary.firstResponseLatencyMs,
+      failures: summary.passed
+        ? []
+        : [...gradingFailureMessages(summary.grading), ...(summary.driftNote ? [`drift: ${summary.driftNote}`] : [])],
+      git,
+      judgeScores: null,
+      model: options.model,
+      passed: summary.passed,
+      provider: "codex",
+      runGroupId,
+      schemaVersion: 1,
+      skill: suite,
+      startedAt: summary.startedAt,
+      status: summary.passed ? "passed" : "failed",
+      tier: "periodic",
+      turns: summary.turns,
+    } satisfies ResultStoreEntry;
+  });
+}
+
 function qualityResultEntries(
   packageRootPath: string,
   batch: QualityBatchSummary,
@@ -759,7 +805,31 @@ function runSelect(options: CliOptions): void {
   }
 }
 
-function runPeriodic(options: CliOptions): void {
+async function runPeriodic(options: CliOptions): Promise<void> {
+  const packageRootPath = packageRoot();
+  if (options.suite === null || options.suite === "first-tree-welcome") {
+    const batch = await runFirstTreeWelcomePeriodic(packageRootPath, {
+      caseId: options.caseId,
+      codexBin: options.codexBin,
+      json: options.json,
+      model: options.model,
+      verbose: options.verbose,
+    });
+    appendResultStoreEntries(
+      packageRootPath,
+      periodicResultEntries(packageRootPath, batch, "first-tree-welcome", options),
+    );
+    if (options.json) {
+      process.stdout.write(`${JSON.stringify(batch, null, 2)}\n`);
+    } else {
+      process.stdout.write(`${formatFirstTreeWelcomePeriodicSummary(batch)}\n`);
+    }
+    if (batch.failed > 0) {
+      process.exitCode = 1;
+    }
+    return;
+  }
+
   const summary = buildPeriodicSummary(SKILL_EVAL_SUITES, {
     caseId: options.caseId,
     suite: options.suite,
@@ -812,7 +882,7 @@ async function main(): Promise<void> {
     return;
   }
   if (options.command === "periodic") {
-    runPeriodic(options);
+    await runPeriodic(options);
     return;
   }
   if (options.command === "gate") {

--- a/packages/skill-evals/src/suites/first-tree-welcome/__tests__/floor.test.ts
+++ b/packages/skill-evals/src/suites/first-tree-welcome/__tests__/floor.test.ts
@@ -24,6 +24,14 @@ describe("first-tree-welcome floor invariants", () => {
     expect(validateFloor(cases)).toEqual([]);
   });
 
+  it("implements periodic coverage for every concrete non-catch-all matrix row", () => {
+    const periodicCases = cases.filter((evalCase) => evalCase.tier === "periodic");
+
+    expect(periodicCases).toHaveLength(10);
+    expect(periodicCases.every((evalCase) => evalCase.status === "implemented")).toBe(true);
+    expect(periodicCases.some((evalCase) => hasTag(evalCase, "catch-all"))).toBe(false);
+  });
+
   it("flags an implemented row whose action has no casePassed branch (orphan)", () => {
     // Deliberately break one implemented row's action; `expected` is the schema's
     // generic `unknown`, so a plain override is type-safe here.
@@ -34,6 +42,29 @@ describe("first-tree-welcome floor invariants", () => {
           : evalCase,
     );
     expect(validateFloor(broken).some((error) => error.includes("orphan"))).toBe(true);
+  });
+
+  it("flags an implemented periodic row whose action has no casePassed branch (orphan)", () => {
+    const broken = cases.map(
+      (evalCase): SkillEvalCase =>
+        evalCase.tier === "periodic" && evalCase.status === "implemented"
+          ? { ...evalCase, expected: { ...(evalCase.expected as Record<string, unknown>), action: "made_up_action" } }
+          : evalCase,
+    );
+    expect(validateFloor(broken).some((error) => error.includes("orphan"))).toBe(true);
+  });
+
+  it("flags an implemented row whose forbidden action has no detector branch (orphan)", () => {
+    const broken = cases.map(
+      (evalCase): SkillEvalCase =>
+        evalCase.tier === "periodic" && evalCase.status === "implemented"
+          ? {
+              ...evalCase,
+              forbidden: { ...(evalCase.forbidden as Record<string, unknown>), actions: ["made-up-risk"] },
+            }
+          : evalCase,
+    );
+    expect(validateFloor(broken).some((error) => error.includes("forbidden action"))).toBe(true);
   });
 
   it("flags two non-catch-all rows that claim the same state tuple", () => {

--- a/packages/skill-evals/src/suites/first-tree-welcome/__tests__/grader.test.ts
+++ b/packages/skill-evals/src/suites/first-tree-welcome/__tests__/grader.test.ts
@@ -4,13 +4,15 @@ import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 import type { RunPaths } from "../../../core/types.js";
-import { FIRST_TREE_WELCOME_GATE_CASES } from "../cases.js";
+import { FIRST_TREE_WELCOME_GATE_CASES, FIRST_TREE_WELCOME_PERIODIC_CASES } from "../cases.js";
 import { casePassed, deriveMetrics } from "../grader.js";
 import { buildGrading } from "../summary.js";
 import type { EvalMetrics, FirstTreeWelcomeEvalCase, FixtureValidation } from "../types.js";
 
 function findCase(id: string): FirstTreeWelcomeEvalCase {
-  const evalCase = FIRST_TREE_WELCOME_GATE_CASES.find((candidate) => candidate.id === id);
+  const evalCase = [...FIRST_TREE_WELCOME_GATE_CASES, ...FIRST_TREE_WELCOME_PERIODIC_CASES].find(
+    (candidate) => candidate.id === id,
+  );
   if (!evalCase) throw new Error(`Missing test case ${id}`);
   return evalCase;
 }
@@ -70,6 +72,29 @@ function skillReadEvent(): unknown {
     event: {
       item: {
         command: "sed -n '1,220p' .agents/skills/first-tree-welcome/SKILL.md",
+        type: "command_execution",
+      },
+      type: "item.completed",
+    },
+    type: "codex_event",
+  };
+}
+
+function assistantMessageEvent(text: string): unknown {
+  return {
+    event: {
+      text,
+      type: "agent_message",
+    },
+    type: "codex_event",
+  };
+}
+
+function repoEvidenceReadEvent(): unknown {
+  return {
+    event: {
+      item: {
+        command: "cat source-repo/README.md",
         type: "command_execution",
       },
       type: "item.completed",
@@ -249,6 +274,191 @@ describe("first-tree-welcome grader", () => {
     }
   });
 
+  it("fails invitee-not-ready when admin setup and repo selection are offered", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "welcome-eval-invitee-admin-setup-"));
+    try {
+      const evalCase = findCase("first-tree-welcome-invitee-not-ready-periodic");
+      const metrics = deriveMetrics(
+        [
+          skillReadEvent(),
+          assistantMessageEvent(
+            "Ask the admin to install the GitHub App and select a repo before continuing; you can send a local path later.",
+          ),
+        ],
+        evalCase,
+        fixtureValidation(),
+        0,
+        baseRunPaths(tempRoot),
+        null,
+      );
+
+      expect(metrics.forbiddenActionHits).toContain("admin-setup");
+      expect(metrics.forbiddenActionHits).toContain("repo-selection");
+      expect(casePassed(evalCase, metrics)).toBe(false);
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("passes invitee-not-ready when admin setup is only a readiness guardrail", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "welcome-eval-invitee-guardrail-"));
+    try {
+      const evalCase = findCase("first-tree-welcome-invitee-not-ready-periodic");
+      const metrics = deriveMetrics(
+        [
+          skillReadEvent(),
+          assistantMessageEvent(
+            "An admin finishes team setup; for now send a local clone path and I can help from that without selecting a repo.",
+          ),
+        ],
+        evalCase,
+        fixtureValidation(),
+        0,
+        baseRunPaths(tempRoot),
+        null,
+      );
+
+      expect(metrics.forbiddenActionHits).toEqual([]);
+      expect(casePassed(evalCase, metrics)).toBe(true);
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("fails readable-repo-empty-tree when Context Tree setup is offered as a first task option", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "welcome-eval-empty-tree-task-setup-"));
+    try {
+      const evalCase = findCase("first-tree-welcome-readable-repo-empty-tree-periodic");
+      const metrics = deriveMetrics(
+        [
+          skillReadEvent(),
+          repoEvidenceReadEvent(),
+          {
+            argv: [
+              "chat",
+              "ask",
+              "baixiaohang",
+              "Choose the first task from repo evidence.",
+              "--options",
+              JSON.stringify([
+                { description: "Debug the expired session flow.", label: "Fix session" },
+                { description: "Trace checkout reliability failures.", label: "Trace checkout" },
+                { description: "Create and seed a Context Tree first.", label: "Build Context Tree" },
+              ]),
+            ],
+            phase: "model",
+            type: "first_tree_call",
+          },
+          assistantMessageEvent("I read the repo; choose a session, checkout, or Context Tree setup task."),
+        ],
+        evalCase,
+        fixtureValidation(),
+        0,
+        baseRunPaths(tempRoot),
+        null,
+      );
+
+      expect(metrics.repoEvidenceReadObserved).toBe(true);
+      expect(metrics.taskOptionsObserved).toBe(true);
+      expect(metrics.forbiddenActionHits).toContain("tree-setup-as-first-task");
+      expect(casePassed(evalCase, metrics)).toBe(false);
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("passes readable-repo-empty-tree when tree setup is only a separate handoff note", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "welcome-eval-empty-tree-setup-handoff-"));
+    try {
+      const evalCase = findCase("first-tree-welcome-readable-repo-empty-tree-periodic");
+      const metrics = deriveMetrics(
+        [
+          skillReadEvent(),
+          repoEvidenceReadEvent(),
+          {
+            argv: [
+              "chat",
+              "ask",
+              "baixiaohang",
+              "I read the repo; choose a code-first task. The separate tree setup chat can build shared memory later.",
+              "--options",
+              JSON.stringify([
+                { description: "Debug the expired session flow.", label: "Fix session" },
+                { description: "Trace checkout reliability failures.", label: "Trace checkout" },
+              ]),
+            ],
+            phase: "model",
+            type: "first_tree_call",
+          },
+        ],
+        evalCase,
+        fixtureValidation(),
+        0,
+        baseRunPaths(tempRoot),
+        null,
+      );
+
+      expect(metrics.taskOptionsObserved).toBe(true);
+      expect(metrics.forbiddenActionHits).toEqual([]);
+      expect(casePassed(evalCase, metrics)).toBe(true);
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("fails auth-failure row when the model claims private repo evidence", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "welcome-eval-auth-failure-claim-"));
+    try {
+      const evalCase = findCase("first-tree-welcome-repo-auth-fails-periodic");
+      const metrics = deriveMetrics(
+        [
+          skillReadEvent(),
+          assistantMessageEvent(
+            "I read the selected private repo README and found checkout TODOs; still send a local clone path.",
+          ),
+        ],
+        evalCase,
+        fixtureValidation(),
+        0,
+        baseRunPaths(tempRoot),
+        null,
+      );
+
+      expect(metrics.forbiddenActionHits).toEqual(
+        expect.arrayContaining(["claim-private-repo-read", "invent-repo-evidence"]),
+      );
+      expect(casePassed(evalCase, metrics)).toBe(false);
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("fails tree-unknown row when the model claims the Context Tree is ready", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "welcome-eval-tree-ready-claim-"));
+    try {
+      const evalCase = findCase("first-tree-welcome-readable-repo-tree-unknown-periodic");
+      const metrics = deriveMetrics(
+        [
+          skillReadEvent(),
+          repoEvidenceReadEvent(),
+          assistantMessageEvent(
+            "I read repo evidence; the Context Tree is ready, so choose a checkout or session task.",
+          ),
+        ],
+        evalCase,
+        fixtureValidation(),
+        0,
+        baseRunPaths(tempRoot),
+        null,
+      );
+
+      expect(metrics.forbiddenActionHits).toContain("claim-tree-ready");
+      expect(casePassed(evalCase, metrics)).toBe(false);
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
   it("passes row 8 when the model reads repo and tree evidence and offers bounded options", () => {
     expect(
       casePassed(
@@ -264,6 +474,88 @@ describe("first-tree-welcome grader", () => {
         }),
       ),
     ).toBe(true);
+  });
+
+  it.each([
+    [
+      "first-tree-welcome-invitee-not-ready-periodic",
+      {
+        finalResponse: "The admin needs to finish team readiness. You can send a local path to get value now.",
+      },
+    ],
+    [
+      "first-tree-welcome-invitee-ready-periodic",
+      {
+        chatAskCount: 1,
+        chatOptionCount: 3,
+        finalResponse: "I read the repo and tree; choose a checkout, session, or map task.",
+        repoEvidenceReadObserved: true,
+        taskOptionsObserved: true,
+        treeEvidenceReadObserved: true,
+      },
+    ],
+    [
+      "first-tree-welcome-repo-auth-fails-periodic",
+      {
+        finalResponse: "The selected repository has a read failure. Send a local clone path or accessible URL.",
+      },
+    ],
+    [
+      "first-tree-welcome-admin-missing-github-app-periodic",
+      {
+        finalResponse:
+          "I read local repo evidence and found durable checkout/session work; GitHub App setup can be a later handoff.",
+        repoEvidenceReadObserved: true,
+      },
+    ],
+    [
+      "first-tree-welcome-app-installed-no-repo-selected-periodic",
+      {
+        finalResponse:
+          "The GitHub App is installed; select a repo for long-term team setup before I claim repo evidence.",
+      },
+    ],
+    [
+      "first-tree-welcome-readable-repo-empty-tree-periodic",
+      {
+        chatAskCount: 1,
+        chatOptionCount: 3,
+        finalResponse: "I read the repo; choose a checkout, session, or map task before tree setup.",
+        repoEvidenceReadObserved: true,
+        taskOptionsObserved: true,
+      },
+    ],
+    [
+      "first-tree-welcome-readable-repo-tree-unknown-periodic",
+      {
+        chatAskCount: 1,
+        chatOptionCount: 3,
+        finalResponse: "I read repo evidence; choose a checkout, session, or map task without assuming tree readiness.",
+        repoEvidenceReadObserved: true,
+        taskOptionsObserved: true,
+      },
+    ],
+  ] as const)("passes periodic action %s", (caseId, metrics) => {
+    expect(casePassed(findCase(caseId), baseMetrics(metrics))).toBe(true);
+  });
+
+  it("grades row 7 periodic as repo-first value without requiring populated tree evidence", () => {
+    const evalCase = findCase("first-tree-welcome-readable-repo-empty-tree-periodic");
+    const metrics = baseMetrics({
+      chatAskCount: 1,
+      chatOptionCount: 2,
+      repoEvidenceReadObserved: true,
+      taskOptionsObserved: true,
+      treeEvidenceReadObserved: false,
+    });
+
+    expect(casePassed(evalCase, metrics)).toBe(true);
+    expect(buildGrading(evalCase, metrics, true).scores).toEqual({
+      outcome_pass: true,
+      process_pass: true,
+      risk_pass: true,
+      routing_pass: true,
+    });
   });
 
   it("fails row 8 without Context Tree evidence", () => {

--- a/packages/skill-evals/src/suites/first-tree-welcome/cases.ts
+++ b/packages/skill-evals/src/suites/first-tree-welcome/cases.ts
@@ -1,6 +1,6 @@
 import type { SkillEvalCase } from "../../core/case-schema.js";
 import type { SkillEvalSuiteDefinition } from "../types.js";
-import { GRADED_ACTIONS } from "./grader.js";
+import { GRADED_ACTIONS, HANDLED_FORBIDDEN_ACTIONS } from "./grader.js";
 import { FIRST_TREE_WELCOME_QUALITY_CASE } from "./quality.js";
 import type { FirstTreeWelcomeEvalCase, WelcomeExpectedAction } from "./types.js";
 
@@ -188,13 +188,21 @@ function githubAppState(row: WelcomeRow): FirstTreeWelcomeEvalCase["fixture"]["g
   return "unknown";
 }
 
-const GATE_CASES: readonly FirstTreeWelcomeEvalCase[] = WELCOME_ROWS.map(
-  (row): FirstTreeWelcomeEvalCase => ({
+function caseFromRow(
+  row: WelcomeRow,
+  options: {
+    id: string;
+    status: FirstTreeWelcomeEvalCase["status"];
+    tags: readonly string[];
+    tier: FirstTreeWelcomeEvalCase["tier"];
+  },
+): FirstTreeWelcomeEvalCase {
+  return {
     briefingMode: "generated-fixture",
     expected: {
       action: row.action,
       evidenceSnippets:
-        row.id === "first-tree-welcome-readable-repo-populated-tree"
+        row.repoState === "selected-readable" && row.treeState === "populated"
           ? ["Acme Support Dashboard", "expired session TODO", "Checkout Reliability"]
           : undefined,
       requiredResponseHints: row.requiredResponseHints,
@@ -213,18 +221,42 @@ const GATE_CASES: readonly FirstTreeWelcomeEvalCase[] = WELCOME_ROWS.map(
       claims: row.forbiddenClaims,
       sideEffects: ["github_auth", "repo_create", "tree_create", "tree_seed", "pr_create", "push"],
     },
-    id: row.id,
+    id: options.id,
     prompt: row.prompt,
     provider: "codex",
     skill: "first-tree-welcome",
+    status: options.status,
+    tags: ["onboarding-matrix", ...row.tags, ...options.tags],
+    tier: options.tier,
+  };
+}
+
+const GATE_CASES: readonly FirstTreeWelcomeEvalCase[] = WELCOME_ROWS.map((row) =>
+  caseFromRow(row, {
+    id: row.id,
     status: IMPLEMENTED_GATE_CASE_IDS.has(row.id) ? "implemented" : "planned",
-    tags: ["onboarding-matrix", ...row.tags],
+    tags: [],
     tier: "gate",
+  }),
+);
+
+const PERIODIC_CASES: readonly FirstTreeWelcomeEvalCase[] = WELCOME_ROWS.filter(
+  (row) => !row.tags.includes("catch-all"),
+).map((row) =>
+  caseFromRow(row, {
+    id: `${row.id}-periodic`,
+    status: "implemented",
+    tags: ["periodic-full-matrix", `source-row:${row.id}`],
+    tier: "periodic",
   }),
 );
 
 export const FIRST_TREE_WELCOME_GATE_CASES: readonly FirstTreeWelcomeEvalCase[] = GATE_CASES;
 export const FIRST_TREE_WELCOME_LIVE_GATE_CASES: readonly FirstTreeWelcomeEvalCase[] = GATE_CASES.filter(
+  (evalCase) => evalCase.status === "implemented",
+);
+export const FIRST_TREE_WELCOME_PERIODIC_CASES: readonly FirstTreeWelcomeEvalCase[] = PERIODIC_CASES;
+export const FIRST_TREE_WELCOME_LIVE_PERIODIC_CASES: readonly FirstTreeWelcomeEvalCase[] = PERIODIC_CASES.filter(
   (evalCase) => evalCase.status === "implemented",
 );
 
@@ -248,6 +280,7 @@ export const FIRST_TREE_WELCOME_EVAL_CASES: readonly SkillEvalCase[] = [
     tier: "floor",
   },
   ...GATE_CASES,
+  ...PERIODIC_CASES,
   FIRST_TREE_WELCOME_QUALITY_CASE,
 ];
 
@@ -267,10 +300,42 @@ function validateFirstTreeWelcomeFloor(cases: readonly SkillEvalCase[]): readonl
 
   // Orphan-action: an implemented row whose action has no `casePassed` branch
   // would silently fail the gate regardless of model behavior. Lock it out.
-  for (const evalCase of implementedGateRows) {
+  const implementedLiveRows = cases.filter(
+    (evalCase) =>
+      evalCase.skill === "first-tree-welcome" &&
+      (evalCase.tier === "gate" || evalCase.tier === "periodic") &&
+      evalCase.status === "implemented",
+  );
+  for (const evalCase of implementedLiveRows) {
     const action = (evalCase.expected as { action?: unknown }).action;
     if (typeof action !== "string" || !GRADED_ACTIONS.has(action as WelcomeExpectedAction)) {
       errors.push(`${evalCase.id}: implemented action "${String(action)}" has no casePassed branch (orphan).`);
+    }
+    const forbidden = evalCase.forbidden as { actions?: unknown } | undefined;
+    if (Array.isArray(forbidden?.actions)) {
+      for (const forbiddenAction of forbidden.actions) {
+        if (typeof forbiddenAction !== "string" || !HANDLED_FORBIDDEN_ACTIONS.has(forbiddenAction)) {
+          errors.push(`${evalCase.id}: forbidden action "${String(forbiddenAction)}" has no detector branch (orphan).`);
+        }
+      }
+    }
+  }
+
+  const periodicRows = cases.filter(
+    (evalCase) => evalCase.skill === "first-tree-welcome" && evalCase.tier === "periodic",
+  );
+  const concreteMatrixRows = WELCOME_ROWS.filter((row) => !row.tags.includes("catch-all"));
+  if (periodicRows.length !== concreteMatrixRows.length) {
+    errors.push(
+      `welcome periodic matrix must cover ${concreteMatrixRows.length} concrete rows, found ${periodicRows.length}.`,
+    );
+  }
+  for (const periodicCase of periodicRows) {
+    if (periodicCase.status !== "implemented") {
+      errors.push(`${periodicCase.id}: periodic matrix rows must be implemented.`);
+    }
+    if (rowTags(periodicCase).includes("catch-all")) {
+      errors.push(`${periodicCase.id}: catch-all row must remain floor-only, not live periodic.`);
     }
   }
 
@@ -356,6 +421,13 @@ export const FIRST_TREE_WELCOME_SUITE: SkillEvalSuiteDefinition = {
           "Welcome onboarding matrix gate rows; tree-kickoff-chat, no-repo-intro, and readable-repo-populated-tree run as live gate cases.",
         status: "implemented",
         tier: "gate",
+      },
+      {
+        caseIds: PERIODIC_CASES.map((evalCase) => evalCase.id),
+        description:
+          "Opt-in live periodic coverage for every concrete first-tree-welcome setup-state matrix row; catch-all remains floor-only.",
+        status: "implemented",
+        tier: "periodic",
       },
       {
         caseIds: [FIRST_TREE_WELCOME_QUALITY_CASE.id],

--- a/packages/skill-evals/src/suites/first-tree-welcome/fixture.ts
+++ b/packages/skill-evals/src/suites/first-tree-welcome/fixture.ts
@@ -12,14 +12,27 @@ import type { FirstTreeWelcomeEvalCase, FixtureValidation } from "./types.js";
 const SKILL_NAME = "first-tree-welcome";
 
 function workspaceAgentsMarkdown(skillDescription: string, evalCase: FirstTreeWelcomeEvalCase): string {
-  const sourceLine =
-    evalCase.fixture.repoState === "selected-readable"
-      ? "A readable source repo fixture is available at `./source-repo`."
-      : "No source repository is connected in this eval workspace.";
-  const treeLine =
-    evalCase.fixture.treeState === "populated"
-      ? "A populated Context Tree fixture is available at `./context-tree`."
-      : "No readable populated Context Tree is available in this eval workspace.";
+  const sourceLine = (() => {
+    if (evalCase.fixture.repoState === "selected-readable") {
+      return "A selected readable source repo fixture is available at `./source-repo`.";
+    }
+    if (evalCase.fixture.repoState === "local-readable") {
+      return "A local readable source repo fixture is available at `./source-repo`; use it before asking for long-term setup.";
+    }
+    if (evalCase.fixture.repoState === "selected-auth-fails") {
+      return "A selected repository exists, but reading it fails with an authorization error. No repo evidence is readable; ask for a local clone path or accessible URL.";
+    }
+    return "No readable source repository is connected in this eval workspace.";
+  })();
+  const treeLine = (() => {
+    if (evalCase.fixture.treeState === "populated") {
+      return "A populated Context Tree fixture is available at `./context-tree`.";
+    }
+    if (evalCase.fixture.treeState === "empty") {
+      return "An empty bootstrap-only Context Tree fixture is available at `./context-tree`; it has no populated product evidence.";
+    }
+    return "No readable populated Context Tree is available in this eval workspace.";
+  })();
 
   return `# First Tree Welcome Eval Workspace
 
@@ -68,10 +81,13 @@ function installFirstTreeWelcomeSkill(
 }
 
 function writeWorkspaceManifest(paths: RunPaths, evalCase: FirstTreeWelcomeEvalCase): void {
-  const manifest =
-    evalCase.fixture.treeState === "populated"
-      ? { sources: ["source-repo"], tree: "context-tree" }
-      : { sources: [], tree: null };
+  const hasReadableRepo =
+    evalCase.fixture.repoState === "selected-readable" || evalCase.fixture.repoState === "local-readable";
+  const hasContextTree = evalCase.fixture.treeState === "populated" || evalCase.fixture.treeState === "empty";
+  const manifest = {
+    sources: hasReadableRepo ? ["source-repo"] : [],
+    tree: hasContextTree ? "context-tree" : null,
+  };
   writeText(join(paths.workspacePath, ".first-tree", "workspace.json"), `${JSON.stringify(manifest, null, 2)}\n`);
 }
 
@@ -234,6 +250,36 @@ function writeContextTreeFixture(paths: RunPaths): string {
   return contextTreePath;
 }
 
+function writeEmptyContextTreeFixture(paths: RunPaths): string {
+  const contextTreePath = join(paths.workspacePath, "context-tree");
+  mkdirSync(contextTreePath, { recursive: true });
+  writeText(join(contextTreePath, ".first-tree", "VERSION"), "0.7.0\n");
+  writeText(
+    join(contextTreePath, ".first-tree", "tree.json"),
+    `${JSON.stringify(
+      {
+        schemaVersion: 1,
+        treeId: "first-tree-welcome-empty-eval",
+        treeMode: "dedicated",
+        treeRepoName: "context-tree",
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  writeText(join(contextTreePath, "AGENTS.md"), treeAgentsMarkdown());
+  writeText(join(contextTreePath, "NODE.md"), rootNodeMarkdown());
+  writeText(join(contextTreePath, "members", "eval-owner", "NODE.md"), memberNodeMarkdown());
+
+  assertCommandOk(runCommand("git", ["init", "--initial-branch=main"], contextTreePath));
+  assertCommandOk(runCommand("git", ["config", "user.email", "eval@example.invalid"], contextTreePath));
+  assertCommandOk(runCommand("git", ["config", "user.name", "First Tree Eval"], contextTreePath));
+  assertCommandOk(runCommand("git", ["config", "commit.gpgsign", "false"], contextTreePath));
+  assertCommandOk(runCommand("git", ["add", "."], contextTreePath));
+  assertCommandOk(runCommand("git", ["commit", "-m", "chore: seed empty welcome context tree"], contextTreePath));
+  return contextTreePath;
+}
+
 export function setupFixture(
   evalCase: FirstTreeWelcomeEvalCase,
   paths: RunPaths,
@@ -250,11 +296,16 @@ export function setupFixture(
   installFirstTreeWelcomeSkill(paths.repoRoot, paths.workspacePath, evalCase);
   writeWorkspaceManifest(paths, evalCase);
   let sourceRepoHead: string | null = null;
-  if (evalCase.fixture.repoState === "selected-readable") {
+  if (evalCase.fixture.repoState === "selected-readable" || evalCase.fixture.repoState === "local-readable") {
     const sourceRepoPath = writeSourceRepoFixture(paths);
     sourceRepoHead = gitHead(sourceRepoPath);
   }
-  const contextTreePath = evalCase.fixture.treeState === "populated" ? writeContextTreeFixture(paths) : null;
+  const contextTreePath =
+    evalCase.fixture.treeState === "populated"
+      ? writeContextTreeFixture(paths)
+      : evalCase.fixture.treeState === "empty"
+        ? writeEmptyContextTreeFixture(paths)
+        : null;
   const contextTreeHead = contextTreePath === null ? null : gitHead(contextTreePath);
 
   appendEvent(paths.eventsPath, {
@@ -273,6 +324,7 @@ export function setupFixture(
 export function validateFixture(
   paths: RunPaths,
   contextTreePath: string | null,
+  evalCase: FirstTreeWelcomeEvalCase,
   caseId: string,
   verbose: boolean,
   reporter: EvalReporter,
@@ -292,9 +344,10 @@ export function validateFixture(
     join(contextTreePath, ".first-tree", "VERSION"),
     join(contextTreePath, ".first-tree", "tree.json"),
     join(contextTreePath, "NODE.md"),
-    join(contextTreePath, "product", "NODE.md"),
-    join(contextTreePath, "product", "checkout-reliability.md"),
     join(contextTreePath, "members", "eval-owner", "NODE.md"),
+    ...(evalCase.fixture.treeState === "populated"
+      ? [join(contextTreePath, "product", "NODE.md"), join(contextTreePath, "product", "checkout-reliability.md")]
+      : []),
   ];
   const missingFiles = requiredFiles.filter((file) => !existsSync(file));
   for (const missing of missingFiles) {

--- a/packages/skill-evals/src/suites/first-tree-welcome/grader.ts
+++ b/packages/skill-evals/src/suites/first-tree-welcome/grader.ts
@@ -234,12 +234,54 @@ function countTaskOptionLines(text: string): number | null {
 function withoutNegatedSetupLanguage(text: string): string {
   return text
     .replace(/(?:不先要求|不需要|无需|不用|不要先)\s*安装\s*github app/giu, "")
-    .replace(/\b(?:without|no need to|do not|don't)\s+(?:install|authorize)[^.;\n]*github app\b/giu, "");
+    .replace(/\b(?:without|no need to|do not|don't)\s+(?:install|authorize)[^.;\n]*github app\b/giu, "")
+    .replace(/\bwithout\s+(?:selecting|choosing|connecting)\s+(?:a\s+)?(?:repo|repository)\b/giu, "")
+    .replace(/\b(?:do not|don't|not)\s+(?:select|choose|connect)\s+(?:a\s+)?(?:repo|repository)\b/giu, "");
 }
 
 function containsSetupTaskLanguage(text: string): boolean {
   return /install|create.{0,30}(context\s+)?tree|seed.{0,20}tree|tree.{0,20}setup|setup.{0,20}tree|select.{0,20}repo|connect.{0,20}repo|authori[sz]e|authorization|安装.{0,20}github app|授权/iu.test(
     withoutNegatedSetupLanguage(text),
+  );
+}
+
+function containsTreeSetupLanguage(text: string): boolean {
+  return /create.{0,30}(context\s+)?tree|bind.{0,30}(context\s+)?tree|seed.{0,20}tree|tree.{0,20}setup|setup.{0,20}tree|context tree.{0,40}(setup|set up|create|bind|seed)/iu.test(
+    withoutNegatedSetupLanguage(text),
+  );
+}
+
+function containsRepoSelectionLanguage(text: string): boolean {
+  return /\b(select|choose|connect)\b.{0,30}\b(repo|repository)\b|repo selection|repository selection/iu.test(
+    withoutNegatedSetupLanguage(text),
+  );
+}
+
+function containsAdminSetupAction(text: string): boolean {
+  const checkedText = withoutNegatedSetupLanguage(text)
+    .replace(/\b(?:an?\s+)?admin\s+(?:finishes|handles|owns|will finish|can finish)\s+(?:team\s+)?setup\b/giu, "")
+    .replace(/\b(?:team\s+)?setup\s+(?:is|stays|remains)\s+(?:with|for)\s+(?:an?\s+)?admin\b/giu, "");
+  return /(?:ask|tell|have|route|send).{0,80}(admin|owner).{0,80}(setup|set up|install|authori[sz]e|github app|create|bind|seed)|\b(admin|owner)\b.{0,40}(needs?|must|should|has to).{0,60}(setup|set up|install|authori[sz]e|github app|create|bind|seed)|\b(install|authori[sz]e).{0,40}github app\b/iu.test(
+    checkedText,
+  );
+}
+
+function claimsRepoEvidence(text: string): boolean {
+  const withoutFailure = text.replace(
+    /read failure|failed to read|can't read|cannot read|unable to read|auth(?:entication|orization)? failure|permission denied/giu,
+    "",
+  );
+  return /\b(i (read|found|noticed|inspected|saw)|repo shows|repository shows|readme|src\/|checkout|session|todo)\b/iu.test(
+    withoutFailure,
+  );
+}
+
+function claimsTreeReady(text: string): boolean {
+  const withoutNegation = text
+    .replace(/without assuming (the )?(context )?tree readiness/giu, "")
+    .replace(/do not assume (the )?(context )?tree (is )?ready/giu, "");
+  return /tree is ready|context tree is ready|populated context tree|shared memory is ready|tree already exists|tree has already been set up/iu.test(
+    withoutNegation,
   );
 }
 
@@ -265,6 +307,20 @@ function optionLooksLikeTask(text: string, taskOptionHints: readonly string[]): 
     return true;
   }
   return containsSetupTaskLanguage(text);
+}
+
+function optionLineTexts(text: string): string[] {
+  return text
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => /^(-|\*|\d+[.)])\s+/u.test(line));
+}
+
+function setupTaskOptionObserved(chatOptionTexts: readonly string[], combinedText: string): boolean {
+  return (
+    chatOptionTexts.some((text) => containsSetupTaskLanguage(text)) ||
+    optionLineTexts(combinedText).some((line) => containsSetupTaskLanguage(line))
+  );
 }
 
 function bestTaskOptionCount(
@@ -336,10 +392,19 @@ function forbiddenActionHits(
   const hits: string[] = [];
   const normalized = normalizeForMatch(combinedText);
   const firstTreeText = firstTreeArgv.map((argv) => argv.join(" ")).join("\n");
+  const textForSetup = firstTreeText.concat("\n", combinedText);
 
   for (const action of evalCase.forbidden.actions) {
+    if (
+      action === "admin-setup" &&
+      (containsAdminSetupAction(combinedText) || optionLineTexts(combinedText).some(containsTreeSetupLanguage))
+    ) {
+      hits.push(action);
+    }
     if (action === "first-task-options" && (chatAskCount > 0 || taskOptionsObserved)) hits.push(action);
     if (action === "skip-for-now-option" && normalized.includes("skip for now")) hits.push(action);
+    if (action === "repo-selection" && containsRepoSelectionLanguage(combinedText)) hits.push(action);
+    if (action === "duplicate-tree" && containsTreeSetupLanguage(combinedText)) hits.push(action);
     if (action === "github-auth-first" && /\b(authori[sz]e|authorization|auth)\b/u.test(normalized)) hits.push(action);
     if (
       action === "github-app-install-first" &&
@@ -347,6 +412,10 @@ function forbiddenActionHits(
     ) {
       hits.push(action);
     }
+    if (action === "claim-private-repo-read" && claimsRepoEvidence(combinedText)) hits.push(action);
+    if (action === "invent-repo-evidence" && claimsRepoEvidence(combinedText)) hits.push(action);
+    if (action === "claim-unread-repo-evidence" && claimsRepoEvidence(combinedText)) hits.push(action);
+    if (action === "claim-tree-ready" && claimsTreeReady(combinedText)) hits.push(action);
     if (
       action === "tree-setup-as-value-task" &&
       taskOptionsObserved &&
@@ -354,10 +423,26 @@ function forbiddenActionHits(
     ) {
       hits.push(action);
     }
+    if (action === "tree-setup-as-first-task" && setupOptionObserved) {
+      hits.push(action);
+    }
     if (
       action === "setup-only-action" &&
       !taskOptionsObserved &&
       /install|select repo|connect repo|setup|set up/iu.test(combinedText)
+    ) {
+      hits.push(action);
+    }
+    if (
+      action === "setup-before-value" &&
+      containsSetupTaskLanguage(combinedText) &&
+      !/evidence|durable|readme|checkout|session|repo/iu.test(combinedText)
+    ) {
+      hits.push(action);
+    }
+    if (
+      action === "vague-setup-navigation" &&
+      /finish setup|go to settings|settings page|set up first/iu.test(combinedText)
     ) {
       hits.push(action);
     }
@@ -375,7 +460,7 @@ function forbiddenActionHits(
     }
     if (
       (action === "seed-tree" || action === "seed-tree-in-welcome-chat") &&
-      /tree seed|seeded the tree|seeding the tree/iu.test(firstTreeText.concat("\n", combinedText))
+      /tree seed|seed context tree|seeded the tree|seeding the tree/iu.test(textForSetup)
     ) {
       hits.push(action);
     }
@@ -461,7 +546,6 @@ export function deriveMetrics(
   const modelOutputTexts: string[] = [];
   const chatTexts: string[] = [];
   const chatOptionTexts: string[] = [];
-  const setupOptionTexts: string[] = [];
   let chatAskCount = 0;
   let chatOptionCount: number | null = null;
 
@@ -497,7 +581,6 @@ export function deriveMetrics(
         if (parsedOptions !== null) {
           chatOptionCount = chatOptionCount ?? parsedOptions.count;
           chatOptionTexts.push(...parsedOptions.texts);
-          setupOptionTexts.push(...parsedOptions.texts.filter(containsSetupTaskLanguage));
         }
       }
     }
@@ -521,7 +604,7 @@ export function deriveMetrics(
     combinedText,
     chatAskCount,
     taskOptionsObserved,
-    setupOptionTexts.length > 0,
+    setupTaskOptionObserved(chatOptionTexts, combinedText),
     firstTreeArgv,
   );
   const forbiddenClaims = forbiddenClaimHits(
@@ -563,8 +646,43 @@ export function deriveMetrics(
  */
 export const GRADED_ACTIONS: ReadonlySet<WelcomeExpectedAction> = new Set([
   "route_to_tree_skill",
+  "invitee_waits_for_team_readiness",
+  "offer_invitee_value_without_admin_setup",
   "ask_for_repo_path_or_url",
+  "report_auth_failure_without_claiming_repo_read",
+  "value_first_then_setup_handoff",
+  "guide_repo_selection_without_claiming_repo_read",
+  "offer_code_value_without_tree_setup_task",
   "offer_bounded_first_tasks_from_repo_and_tree",
+  "offer_repo_value_without_claiming_tree_ready",
+]);
+
+/**
+ * Forbidden action tokens that `forbiddenActionHits` can detect. Implemented
+ * live rows must not introduce a token outside this set; the floor invariant
+ * catches that before the token silently weakens the row oracle.
+ */
+export const HANDLED_FORBIDDEN_ACTIONS: ReadonlySet<string> = new Set([
+  "admin-setup",
+  "claim-private-repo-read",
+  "claim-tree-ready",
+  "claim-unread-repo-evidence",
+  "create-tree",
+  "duplicate-tree",
+  "first-task-options",
+  "github-app-install-first",
+  "github-auth-first",
+  "invent-repo-evidence",
+  "repo-selection",
+  "seed-tree",
+  "seed-tree-in-welcome-chat",
+  "setup-as-first-task",
+  "setup-before-value",
+  "setup-only-action",
+  "skip-for-now-option",
+  "tree-setup-as-first-task",
+  "tree-setup-as-value-task",
+  "vague-setup-navigation",
 ]);
 
 export function casePassed(evalCase: FirstTreeWelcomeEvalCase, metrics: EvalMetrics): boolean {
@@ -582,8 +700,37 @@ export function casePassed(evalCase: FirstTreeWelcomeEvalCase, metrics: EvalMetr
     return metrics.chatAskCount === 0 && !metrics.taskOptionsObserved;
   }
 
+  if (evalCase.expected.action === "invitee_waits_for_team_readiness") {
+    return !metrics.repoEvidenceReadObserved && !metrics.treeEvidenceReadObserved && !metrics.taskOptionsObserved;
+  }
+
+  if (evalCase.expected.action === "offer_invitee_value_without_admin_setup") {
+    return (
+      metrics.repoEvidenceReadObserved &&
+      metrics.treeEvidenceReadObserved &&
+      metrics.expectedEvidenceObserved &&
+      metrics.taskOptionsObserved
+    );
+  }
+
   if (evalCase.expected.action === "ask_for_repo_path_or_url") {
     return !metrics.repoEvidenceReadObserved && !metrics.treeEvidenceReadObserved && !metrics.taskOptionsObserved;
+  }
+
+  if (evalCase.expected.action === "report_auth_failure_without_claiming_repo_read") {
+    return !metrics.repoEvidenceReadObserved && !metrics.treeEvidenceReadObserved && !metrics.taskOptionsObserved;
+  }
+
+  if (evalCase.expected.action === "value_first_then_setup_handoff") {
+    return metrics.repoEvidenceReadObserved && !metrics.treeEvidenceReadObserved;
+  }
+
+  if (evalCase.expected.action === "guide_repo_selection_without_claiming_repo_read") {
+    return !metrics.repoEvidenceReadObserved && !metrics.treeEvidenceReadObserved && !metrics.taskOptionsObserved;
+  }
+
+  if (evalCase.expected.action === "offer_code_value_without_tree_setup_task") {
+    return metrics.repoEvidenceReadObserved && !metrics.treeEvidenceReadObserved && metrics.taskOptionsObserved;
   }
 
   if (evalCase.expected.action === "offer_bounded_first_tasks_from_repo_and_tree") {
@@ -593,6 +740,10 @@ export function casePassed(evalCase: FirstTreeWelcomeEvalCase, metrics: EvalMetr
       metrics.expectedEvidenceObserved &&
       metrics.taskOptionsObserved
     );
+  }
+
+  if (evalCase.expected.action === "offer_repo_value_without_claiming_tree_ready") {
+    return metrics.repoEvidenceReadObserved && !metrics.treeEvidenceReadObserved && metrics.taskOptionsObserved;
   }
 
   return false;
@@ -613,6 +764,25 @@ export function driftNote(evalCase: FirstTreeWelcomeEvalCase, metrics: EvalMetri
     if (!metrics.repoEvidenceReadObserved) notes.push("Repo fixture evidence was not read.");
     if (!metrics.treeEvidenceReadObserved) notes.push("Context Tree fixture evidence was not read.");
     if (!metrics.taskOptionsObserved) notes.push("Two or three bounded first-task options were not observed.");
+  }
+  if (
+    evalCase.expected.action === "offer_invitee_value_without_admin_setup" ||
+    evalCase.expected.action === "offer_code_value_without_tree_setup_task" ||
+    evalCase.expected.action === "offer_repo_value_without_claiming_tree_ready" ||
+    evalCase.expected.action === "value_first_then_setup_handoff"
+  ) {
+    if (!metrics.repoEvidenceReadObserved) notes.push("Repo fixture evidence was not read.");
+  }
+  if (evalCase.expected.action === "offer_invitee_value_without_admin_setup" && !metrics.treeEvidenceReadObserved) {
+    notes.push("Context Tree fixture evidence was not read.");
+  }
+  if (
+    (evalCase.expected.action === "offer_invitee_value_without_admin_setup" ||
+      evalCase.expected.action === "offer_code_value_without_tree_setup_task" ||
+      evalCase.expected.action === "offer_repo_value_without_claiming_tree_ready") &&
+    !metrics.taskOptionsObserved
+  ) {
+    notes.push("Two or three bounded first-task options were not observed.");
   }
   if (evalCase.expected.action === "route_to_tree_skill" && metrics.taskOptionsObserved) {
     notes.push("Tree kickoff row offered value-chat task options.");

--- a/packages/skill-evals/src/suites/first-tree-welcome/index.ts
+++ b/packages/skill-evals/src/suites/first-tree-welcome/index.ts
@@ -1,4 +1,5 @@
 import { FIRST_TREE_WELCOME_GATE_CASES, FIRST_TREE_WELCOME_LIVE_GATE_CASES } from "./cases.js";
+import { formatFirstTreeWelcomePeriodicSummary, runFirstTreeWelcomePeriodic } from "./periodic.js";
 import { runFirstTreeWelcomeCase } from "./runner.js";
 import { buildBatchSummary, formatSummaryTable } from "./summary.js";
 import type { BatchSummary, CliOptions, FirstTreeWelcomeEvalCase } from "./types.js";
@@ -42,3 +43,5 @@ export async function runFirstTreeWelcomeGate(packageRoot: string, options: CliO
 export function formatFirstTreeWelcomeGateSummary(batch: BatchSummary): string {
   return formatSummaryTable(batch);
 }
+
+export { formatFirstTreeWelcomePeriodicSummary, runFirstTreeWelcomePeriodic };

--- a/packages/skill-evals/src/suites/first-tree-welcome/periodic.ts
+++ b/packages/skill-evals/src/suites/first-tree-welcome/periodic.ts
@@ -1,0 +1,44 @@
+import { FIRST_TREE_WELCOME_LIVE_PERIODIC_CASES, FIRST_TREE_WELCOME_PERIODIC_CASES } from "./cases.js";
+import { runFirstTreeWelcomeCase } from "./runner.js";
+import { buildBatchSummary, formatSummaryTable } from "./summary.js";
+import type { BatchSummary, CliOptions, FirstTreeWelcomeEvalCase } from "./types.js";
+
+export function findFirstTreeWelcomePeriodicCase(id: string): FirstTreeWelcomeEvalCase | null {
+  for (const evalCase of FIRST_TREE_WELCOME_PERIODIC_CASES) {
+    if (evalCase.id === id || evalCase.id === `${id}-periodic`) return evalCase;
+  }
+  return null;
+}
+
+function selectPeriodicCases(caseId: string | null): readonly FirstTreeWelcomeEvalCase[] {
+  if (caseId === null) return FIRST_TREE_WELCOME_LIVE_PERIODIC_CASES;
+
+  const evalCase = findFirstTreeWelcomePeriodicCase(caseId);
+  if (evalCase === null) {
+    const available = FIRST_TREE_WELCOME_PERIODIC_CASES.map((candidate) => candidate.id).join(", ");
+    throw new Error(`Unknown first-tree-welcome periodic case '${caseId}'. Available periodic cases: ${available}`);
+  }
+  if (evalCase.status !== "implemented") {
+    throw new Error(`first-tree-welcome periodic case '${caseId}' is declared but is not implemented yet.`);
+  }
+  return [evalCase];
+}
+
+export async function runFirstTreeWelcomePeriodic(packageRoot: string, options: CliOptions): Promise<BatchSummary> {
+  const selectedCases = selectPeriodicCases(options.caseId);
+  const runStartedAt = new Date().toISOString();
+  const summaries = [];
+
+  for (const evalCase of selectedCases) {
+    if (!options.verbose) {
+      process.stderr.write(`Running first-tree-welcome periodic eval case: ${evalCase.id}\n`);
+    }
+    summaries.push(await runFirstTreeWelcomeCase(packageRoot, evalCase, options, runStartedAt));
+  }
+
+  return buildBatchSummary(summaries, runStartedAt);
+}
+
+export function formatFirstTreeWelcomePeriodicSummary(batch: BatchSummary): string {
+  return formatSummaryTable(batch);
+}

--- a/packages/skill-evals/src/suites/first-tree-welcome/runner.ts
+++ b/packages/skill-evals/src/suites/first-tree-welcome/runner.ts
@@ -31,7 +31,7 @@ export async function runFirstTreeWelcomeCase(
   createFirstTreeStagingShim(paths);
   createGhShim(paths);
   const contextTreePath = setupFixture(evalCase, paths, reporter);
-  const fixtureValidation = validateFixture(paths, contextTreePath, evalCase.id, options.verbose, reporter);
+  const fixtureValidation = validateFixture(paths, contextTreePath, evalCase, evalCase.id, options.verbose, reporter);
   const runnerExitCode = await runCodexProvider(
     {
       bin: options.codexBin,

--- a/packages/skill-evals/src/suites/first-tree-welcome/summary.ts
+++ b/packages/skill-evals/src/suites/first-tree-welcome/summary.ts
@@ -23,11 +23,32 @@ function processPass(evalCase: FirstTreeWelcomeEvalCase, metrics: EvalMetrics): 
   if (evalCase.expected.action === "route_to_tree_skill") {
     return metrics.chatAskCount === 0;
   }
+  if (evalCase.expected.action === "invitee_waits_for_team_readiness") {
+    return !metrics.repoEvidenceReadObserved && !metrics.treeEvidenceReadObserved;
+  }
+  if (evalCase.expected.action === "offer_invitee_value_without_admin_setup") {
+    return metrics.repoEvidenceReadObserved && metrics.treeEvidenceReadObserved;
+  }
   if (evalCase.expected.action === "ask_for_repo_path_or_url") {
     return !metrics.repoEvidenceReadObserved && !metrics.treeEvidenceReadObserved;
   }
+  if (evalCase.expected.action === "report_auth_failure_without_claiming_repo_read") {
+    return !metrics.repoEvidenceReadObserved && !metrics.treeEvidenceReadObserved;
+  }
+  if (evalCase.expected.action === "value_first_then_setup_handoff") {
+    return metrics.repoEvidenceReadObserved && !metrics.treeEvidenceReadObserved;
+  }
+  if (evalCase.expected.action === "guide_repo_selection_without_claiming_repo_read") {
+    return !metrics.repoEvidenceReadObserved && !metrics.treeEvidenceReadObserved;
+  }
+  if (evalCase.expected.action === "offer_code_value_without_tree_setup_task") {
+    return metrics.repoEvidenceReadObserved && !metrics.treeEvidenceReadObserved;
+  }
   if (evalCase.expected.action === "offer_bounded_first_tasks_from_repo_and_tree") {
     return metrics.repoEvidenceReadObserved && metrics.treeEvidenceReadObserved;
+  }
+  if (evalCase.expected.action === "offer_repo_value_without_claiming_tree_ready") {
+    return metrics.repoEvidenceReadObserved && !metrics.treeEvidenceReadObserved;
   }
   return false;
 }
@@ -37,11 +58,32 @@ function outcomePass(evalCase: FirstTreeWelcomeEvalCase, metrics: EvalMetrics): 
   if (evalCase.expected.action === "route_to_tree_skill") {
     return !metrics.taskOptionsObserved;
   }
+  if (evalCase.expected.action === "invitee_waits_for_team_readiness") {
+    return !metrics.taskOptionsObserved;
+  }
+  if (evalCase.expected.action === "offer_invitee_value_without_admin_setup") {
+    return metrics.expectedEvidenceObserved && metrics.taskOptionsObserved;
+  }
   if (evalCase.expected.action === "ask_for_repo_path_or_url") {
     return !metrics.taskOptionsObserved;
   }
+  if (evalCase.expected.action === "report_auth_failure_without_claiming_repo_read") {
+    return !metrics.taskOptionsObserved;
+  }
+  if (evalCase.expected.action === "value_first_then_setup_handoff") {
+    return true;
+  }
+  if (evalCase.expected.action === "guide_repo_selection_without_claiming_repo_read") {
+    return !metrics.taskOptionsObserved;
+  }
+  if (evalCase.expected.action === "offer_code_value_without_tree_setup_task") {
+    return metrics.taskOptionsObserved;
+  }
   if (evalCase.expected.action === "offer_bounded_first_tasks_from_repo_and_tree") {
     return metrics.expectedEvidenceObserved && metrics.taskOptionsObserved;
+  }
+  if (evalCase.expected.action === "offer_repo_value_without_claiming_tree_ready") {
+    return metrics.taskOptionsObserved;
   }
   return false;
 }

--- a/packages/skill-evals/src/suites/first-tree-welcome/types.ts
+++ b/packages/skill-evals/src/suites/first-tree-welcome/types.ts
@@ -54,7 +54,7 @@ export type FirstTreeWelcomeEvalCase = {
   skill: "first-tree-welcome";
   status: "implemented" | "planned";
   tags: readonly string[];
-  tier: "gate";
+  tier: "gate" | "periodic";
 };
 
 export type CliOptions = {


### PR DESCRIPTION
## Summary

- Add `first-tree-welcome` full setup-state matrix coverage to the opt-in `eval:periodic -- --suite first-tree-welcome` command.
- Keep the default `eval:gate -- --suite first-tree-welcome` limited to the existing 3 high-risk gate rows.
- Add a welcome periodic runner with `--case` support, including source-row aliases such as `first-tree-welcome-invitee-not-ready`.
- Write periodic artifacts and result-store entries with `command: "eval:periodic"` and `tier: "periodic"`.
- Fill in periodic welcome fixture semantics, grader branches, summary grading, selector behavior, and floor invariants for orphan expected/forbidden actions.

## Covered periodic rows

- `first-tree-welcome-tree-kickoff-chat-periodic`
- `first-tree-welcome-invitee-not-ready-periodic`
- `first-tree-welcome-invitee-ready-periodic`
- `first-tree-welcome-no-repo-intro-periodic`
- `first-tree-welcome-repo-auth-fails-periodic`
- `first-tree-welcome-admin-missing-github-app-periodic`
- `first-tree-welcome-app-installed-no-repo-selected-periodic`
- `first-tree-welcome-readable-repo-empty-tree-periodic`
- `first-tree-welcome-readable-repo-populated-tree-periodic`
- `first-tree-welcome-readable-repo-tree-unknown-periodic`

The catch-all row remains floor-only.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter @first-tree/skill-evals typecheck`
- `pnpm --filter @first-tree/skill-evals exec vitest run src/core/__tests__/periodic.test.ts src/core/__tests__/result-store.test.ts src/core/__tests__/select.test.ts src/suites/first-tree-welcome/__tests__/floor.test.ts src/suites/first-tree-welcome/__tests__/grader.test.ts --maxWorkers=2 --minWorkers=1`
- `pnpm --filter first-tree-dev... build`
- `pnpm --filter @first-tree/skill-evals eval:floor -- --suite first-tree-welcome`
- `pnpm --filter @first-tree/skill-evals eval:periodic -- --suite first-tree-read`
- `pnpm --filter @first-tree/skill-evals eval:periodic -- --suite first-tree-welcome --case missing-periodic-case` (expected specific failure)
- `pnpm --filter @first-tree/skill-evals eval:select -- --changed-file packages/skill-evals/src/suites/first-tree-welcome/periodic.ts`
- `pnpm --filter @first-tree/skill-evals eval:select -- --changed-file skills/first-tree-welcome/SKILL.md`
- `pnpm --filter @first-tree/skill-evals eval:summary`
- `pnpm --filter @first-tree/skill-evals eval:compare`
- `pnpm --filter @first-tree/skill-evals eval:periodic -- --suite first-tree-welcome --case first-tree-welcome-readable-repo-empty-tree-periodic --codex-bin /bin/false --json` (expected provider failure; verified fixture/setup/result-store path)
- `pnpm --filter @first-tree/skill-evals eval:periodic -- --suite first-tree-welcome --codex-bin /bin/false` (expected provider failures; verified all 10 periodic rows select and run fixture/setup paths)
- `pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-welcome --codex-bin /bin/false` (expected provider failures; verified gate still selects only 3 rows)
- `pnpm --filter @first-tree/skill-evals eval:periodic -- --suite first-tree-welcome --case first-tree-welcome-invitee-not-ready --codex-bin /bin/false` (alias smoke)
- `pnpm --filter @first-tree/skill-evals exec vitest run --passWithNoTests --maxWorkers=2 --minWorkers=1`
- `pnpm exec biome check <changed files>`
- `pnpm typecheck`
- `pnpm check` (exits 0; existing client/web warnings/info remain)
- `git diff --check`

## Notes

- I did not run a real Codex live periodic matrix to avoid consuming model quota during PR preparation.
- This PR does not add seed skeleton quality, real repo realism, Claude/multi-provider support, runtime-generated E2E, or default CI/check periodic runs.
