### PR TITLE
Add seed quality and realism evals

### DIFF
--- a/packages/skill-evals/README.md
+++ b/packages/skill-evals/README.md
@@ -14,9 +14,12 @@ pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-write
 pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-write --include-quality
 pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-welcome
 pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-seed
+pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-seed --include-quality
 pnpm --filter @first-tree/skill-evals eval:periodic
+pnpm --filter @first-tree/skill-evals eval:periodic -- --suite first-tree-seed
 pnpm --filter @first-tree/skill-evals eval:periodic -- --suite first-tree-welcome
 pnpm --filter @first-tree/skill-evals eval:quality
+pnpm --filter @first-tree/skill-evals eval:quality -- --suite first-tree-seed
 pnpm --filter @first-tree/skill-evals eval:quality -- --suite first-tree-write
 pnpm --filter @first-tree/skill-evals eval:quality -- --suite first-tree-welcome --judge-model <model>
 pnpm --filter @first-tree/skill-evals eval:select -- --base main
@@ -51,26 +54,32 @@ not suitable for default gates or ordinary CI. It accepts the same basic live
 eval controls as gates, including `--suite`, `--case`, `--model`,
 `--codex-bin`, `--json`, and `--verbose`. `first-tree-welcome` periodic now
 runs the concrete setup-state matrix rows as live eval cases while keeping the
-default welcome gate limited to its three high-risk rows. Other suites still
-print a clear no-op summary and exit 0 until they register implemented periodic
-cases. Future PRs will add seed quality and realism cases, plus
-multi-provider/runtime-generated periodic coverage. The default `eval:select`
-recommendations do not include periodic for ordinary skill changes; maintainers
-trigger periodic manually or via future scheduling.
+default welcome gate limited to its three high-risk rows. `first-tree-seed`
+periodic runs a real-repo realism case that builds a per-run bare source
+fixture from the current `first-tree` repo `HEAD` and still requires the seed
+bare-source worktree protocol. `eval:periodic` with no `--suite` runs all
+implemented periodic suites in one result-store run group. Suites without
+implemented periodic cases still print a clear no-op summary and exit 0. Future
+PRs will add multi-provider/runtime-generated periodic coverage. The default
+`eval:select` recommendations do not include periodic for ordinary skill
+changes; maintainers trigger periodic manually or via future scheduling.
 
 `eval:quality` is an opt-in LLM-as-judge layer. It does not replace
 deterministic gates and is not called by `eval:gate` by default. Each quality
 case first runs the corresponding live gate case and requires that deterministic
 gate to pass; only then does it send the actual produced artifact to the judge.
-For write and welcome gates, `eval:gate -- --include-quality` runs the
+For write, seed, and welcome gates, `eval:gate -- --include-quality` runs the
 deterministic gate first and then reuses that same gate artifact for the
 supported quality case. If the deterministic gate fails, the judge is not run.
-`--include-quality` is intentionally rejected for read and seed suites. The
-first quality cases judge:
+`--include-quality` is intentionally rejected for read. The quality cases
+judge:
 
 - `first-tree-write` node quality from the actual `durable-source-writes` tree
   diff, with scores for durability, source-boundary discipline, rationale
   quality, and conciseness;
+- `first-tree-seed` skeleton quality from the actual `empty-tree-source-present`
+  Phase 1 proposal, with scores for source grounding, structure fit,
+  phase-boundary discipline, coverage calibration, and conciseness;
 - `first-tree-welcome` first-task quality from the actual readable-repo +
   populated-tree row output, with scores for evidence grounding, boundedness,
   usefulness, verifiability, and avoiding setup-as-task.
@@ -136,6 +145,21 @@ accepts the source row id as an alias.
 - bare source repos are read through a materialized read worktree, not as
   checkouts.
 
+`eval:quality -- --suite first-tree-seed` runs the `empty-tree-source-present`
+deterministic gate first. If that hard-rule gate passes, the quality judge
+scores the actual Phase 1 skeleton proposal and source evidence. This judge is
+opt-in and does not replace the deterministic seed gate: empty-tree self-check,
+source boundary, bare worktree protocol, no tree/source/GitHub side effects, and
+no Phase 2 leaf content before approval remain hard-rule oracle conditions.
+
+`eval:periodic -- --suite first-tree-seed` runs
+`first-tree-seed-real-first-tree-source-periodic`. The fixture creates an empty
+Context Tree plus a per-run bare source repo cloned from the current
+`first-tree` repo `HEAD`. The model must still materialize
+`worktrees/seed-source-repo`, read source evidence from that checkout, propose
+only a Phase 1 skeleton, and ask for approval. This realism case stays in the
+periodic tier and is not part of the default seed gate.
+
 The runner creates isolated temporary workspaces under
 `packages/skill-evals/.runs/<timestamp>-<case-id>/`, installs
 the relevant skill, prepends command shims such as `first-tree` to `PATH`, and
@@ -169,10 +193,11 @@ artifact paths, duration, turns and first-response latency when derivable, cost,
 and judge scores when present. Gate failures use the deterministic grading
 evidence first and link the `grading.json` artifact path in the result store.
 Unknown turn or latency values are recorded as `null`. The `.runs` directory is
-gitignored local eval state. Periodic live cases use `command:
-"eval:periodic"` and `tier: "periodic"` entries so summary and compare can
-report them alongside floor, gate, and quality runs. Periodic no-op paths for
-suites with no implemented periodic cases do not append result-store entries.
+gitignored local eval state. Periodic live cases use
+`command: "eval:periodic"` and `tier: "periodic"` entries so summary and compare
+can report them alongside floor, gate, and quality runs. Periodic no-op paths
+for suites with no implemented periodic cases do not append result-store
+entries.
 
 Use `eval:summary` to summarize the latest result-store run group, or pass a
 specific run group id:

--- a/packages/skill-evals/src/core/__tests__/judge.test.ts
+++ b/packages/skill-evals/src/core/__tests__/judge.test.ts
@@ -3,7 +3,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
-
+import {
+  FIRST_TREE_SEED_QUALITY_DEFINITION,
+  FIRST_TREE_SEED_QUALITY_SANITY_FIXTURES,
+} from "../../suites/first-tree-seed/quality.js";
 import {
   FIRST_TREE_WELCOME_QUALITY_DEFINITION,
   FIRST_TREE_WELCOME_QUALITY_SANITY_FIXTURES,
@@ -66,6 +69,23 @@ function failedGateArtifactInput(): ReadonlyMap<string, QualityArtifactInput> {
         gateSummaryJsonPath: "/tmp/fake-gate/summary.json",
         gateSummaryMdPath: "/tmp/fake-gate/summary.md",
         source: "Durable source artifact from a fake deterministic gate.",
+      },
+    ],
+  ]);
+}
+
+function seedArtifactInput(): ReadonlyMap<string, QualityArtifactInput> {
+  return new Map([
+    [
+      "first-tree-seed-skeleton-quality",
+      {
+        artifact: "Phase 1 skeleton proposal with source-backed domains and approval request.",
+        deterministicGatePassed: true,
+        gateCaseId: "empty-tree-source-present",
+        gateRunRoot: "/tmp/fake-seed-gate",
+        gateSummaryJsonPath: "/tmp/fake-seed-gate/summary.json",
+        gateSummaryMdPath: "/tmp/fake-seed-gate/summary.md",
+        source: "Source evidence from a fake seed deterministic gate.",
       },
     ],
   ]);
@@ -284,6 +304,54 @@ describe("quality runner with fake judge", () => {
       rmSync(packageRoot, { force: true, recursive: true });
     }
   });
+
+  it("runs the first-tree-seed skeleton quality case with fake judge output", async () => {
+    const packageRoot = tempPackageRoot();
+    try {
+      const provider = createFakeJudgeProvider(
+        new Map([
+          [
+            "first-tree-seed-skeleton-quality",
+            JSON.stringify({
+              reasoning: "The skeleton is source-grounded and stays in Phase 1.",
+              scores: {
+                conciseness: 4,
+                coverage_calibration: 4,
+                phase_boundary: 5,
+                source_grounding: 5,
+                structure_fit: 4,
+              },
+            }),
+          ],
+        ]),
+      );
+
+      const batch = await runQualityEval(
+        packageRoot,
+        {
+          caseId: "first-tree-seed-skeleton-quality",
+          codexBin: "unused",
+          judgeBin: "unused",
+          judgeModel: null,
+          json: false,
+          model: null,
+          suite: "first-tree-seed",
+          verbose: false,
+        },
+        provider,
+        seedArtifactInput(),
+      );
+
+      expect(batch.failed).toBe(0);
+      expect(batch.passed).toBe(1);
+      expect(batch.cases[0]?.judge_scores).toMatchObject({
+        phase_boundary: 5,
+        source_grounding: 5,
+      });
+    } finally {
+      rmSync(packageRoot, { force: true, recursive: true });
+    }
+  });
 });
 
 describe("quality rubric sanity fixtures", () => {
@@ -307,6 +375,20 @@ describe("quality rubric sanity fixtures", () => {
       const evaluation = evaluateJudgeOutput(
         parseJudgeJson(fixture.judgeOutput, FIRST_TREE_WELCOME_QUALITY_DEFINITION.dimensions),
         FIRST_TREE_WELCOME_QUALITY_DEFINITION.dimensions,
+      );
+
+      expect(prompt).toContain(fixture.input.artifact);
+      expect(prompt).toContain(fixture.input.source);
+      expect(evaluation.passed, fixture.name).toBe(fixture.expectedPassed);
+    }
+  });
+
+  it("keeps first-tree-seed good, borderline, and bad fixtures aligned with thresholds", () => {
+    for (const fixture of FIRST_TREE_SEED_QUALITY_SANITY_FIXTURES) {
+      const prompt = FIRST_TREE_SEED_QUALITY_DEFINITION.buildJudgePrompt(fixture.input);
+      const evaluation = evaluateJudgeOutput(
+        parseJudgeJson(fixture.judgeOutput, FIRST_TREE_SEED_QUALITY_DEFINITION.dimensions),
+        FIRST_TREE_SEED_QUALITY_DEFINITION.dimensions,
       );
 
       expect(prompt).toContain(fixture.input.artifact);

--- a/packages/skill-evals/src/core/__tests__/select.test.ts
+++ b/packages/skill-evals/src/core/__tests__/select.test.ts
@@ -34,6 +34,16 @@ describe("skill eval selection", () => {
     ]);
   });
 
+  it("selects seed floor, gate, and quality for seed skill changes", () => {
+    const summary = selectSkillEvalRecommendations(["skills/first-tree-seed/SKILL.md"]);
+
+    expect(summary.recommendations.map((recommendation) => recommendation.command)).toEqual([
+      "pnpm --filter @first-tree/skill-evals eval:floor -- --suite first-tree-seed",
+      "pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-seed",
+      "pnpm --filter @first-tree/skill-evals eval:quality -- --suite first-tree-seed",
+    ]);
+  });
+
   it("selects all implemented gates and quality when shared judge core changes", () => {
     const summary = selectSkillEvalRecommendations(["packages/skill-evals/src/core/judge/schema.ts"]);
 
@@ -44,6 +54,7 @@ describe("skill eval selection", () => {
       "pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-seed",
       "pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-welcome",
       "pnpm --filter @first-tree/skill-evals eval:quality -- --suite first-tree-write",
+      "pnpm --filter @first-tree/skill-evals eval:quality -- --suite first-tree-seed",
       "pnpm --filter @first-tree/skill-evals eval:quality -- --suite first-tree-welcome",
     ]);
   });
@@ -70,6 +81,19 @@ describe("skill eval selection", () => {
         kind: "periodic",
         reason: "packages/skill-evals/src/suites/first-tree-welcome/periodic.ts touches periodic eval framework",
         suite: "first-tree-welcome",
+      },
+    ]);
+  });
+
+  it("selects suite-scoped periodic for seed periodic runner changes", () => {
+    const summary = selectSkillEvalRecommendations(["packages/skill-evals/src/suites/first-tree-seed/periodic.ts"]);
+
+    expect(summary.recommendations).toEqual([
+      {
+        command: "pnpm --filter @first-tree/skill-evals eval:periodic -- --suite first-tree-seed",
+        kind: "periodic",
+        reason: "packages/skill-evals/src/suites/first-tree-seed/periodic.ts touches periodic eval framework",
+        suite: "first-tree-seed",
       },
     ]);
   });

--- a/packages/skill-evals/src/core/select.ts
+++ b/packages/skill-evals/src/core/select.ts
@@ -59,7 +59,9 @@ function gateCommand(skill: ShippedSkillName): string {
   return `pnpm --filter @first-tree/skill-evals eval:gate -- --suite ${skill}`;
 }
 
-function qualityCommand(skill: Extract<ShippedSkillName, "first-tree-write" | "first-tree-welcome">): string {
+function qualityCommand(
+  skill: Extract<ShippedSkillName, "first-tree-write" | "first-tree-seed" | "first-tree-welcome">,
+): string {
   return `pnpm --filter @first-tree/skill-evals eval:quality -- --suite ${skill}`;
 }
 
@@ -87,7 +89,7 @@ function addSuiteRecommendations(
     suite: skill,
   });
 
-  if (skill === "first-tree-write" || skill === "first-tree-welcome") {
+  if (skill === "first-tree-write" || skill === "first-tree-seed" || skill === "first-tree-welcome") {
     addRecommendation(recommendations, {
       command: qualityCommand(skill),
       kind: "quality",
@@ -115,7 +117,7 @@ function addAllImplementedGateRecommendations(recommendations: Map<string, EvalR
 }
 
 function addQualityRecommendations(recommendations: Map<string, EvalRecommendation>, reason: string): void {
-  for (const skill of ["first-tree-write", "first-tree-welcome"] as const) {
+  for (const skill of ["first-tree-write", "first-tree-seed", "first-tree-welcome"] as const) {
     addRecommendation(recommendations, {
       command: qualityCommand(skill),
       kind: "quality",

--- a/packages/skill-evals/src/index.ts
+++ b/packages/skill-evals/src/index.ts
@@ -24,9 +24,17 @@ import { changedFilesFromGit, formatSelectionSummary, selectSkillEvalRecommendat
 import { readSkillFrontmatter } from "./core/skills/frontmatter.js";
 import { formatFirstTreeReadGateSummary, runFirstTreeReadGate } from "./suites/first-tree-read/index.js";
 import type { BatchSummary as ReadBatchSummary } from "./suites/first-tree-read/types.js";
-import { formatFirstTreeSeedGateSummary, runFirstTreeSeedGate } from "./suites/first-tree-seed/index.js";
+import {
+  findFirstTreeSeedPeriodicCase,
+  formatFirstTreeSeedGateSummary,
+  formatFirstTreeSeedPeriodicSummary,
+  runFirstTreeSeedGate,
+  runFirstTreeSeedPeriodic,
+} from "./suites/first-tree-seed/index.js";
+import { FIRST_TREE_SEED_QUALITY_DEFINITION } from "./suites/first-tree-seed/quality.js";
 import type { BatchSummary as SeedBatchSummary } from "./suites/first-tree-seed/types.js";
 import {
+  findFirstTreeWelcomePeriodicCase,
   formatFirstTreeWelcomeGateSummary,
   formatFirstTreeWelcomePeriodicSummary,
   runFirstTreeWelcomeGate,
@@ -38,6 +46,7 @@ import { formatFirstTreeWriteGateSummary, runFirstTreeWriteGate } from "./suites
 import { FIRST_TREE_WRITE_QUALITY_DEFINITION } from "./suites/first-tree-write/quality.js";
 import type { BatchSummary as WriteBatchSummary } from "./suites/first-tree-write/types.js";
 import {
+  buildSeedQualityInput,
   buildWelcomeQualityInput,
   buildWriteQualityInput,
   formatQualitySummaryTable,
@@ -86,9 +95,12 @@ function usage(): string {
   pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-write --include-quality
   pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-welcome
   pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-seed
+  pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-seed --include-quality
   pnpm --filter @first-tree/skill-evals eval:periodic
+  pnpm --filter @first-tree/skill-evals eval:periodic -- --suite first-tree-seed
   pnpm --filter @first-tree/skill-evals eval:periodic -- --suite first-tree-welcome
   pnpm --filter @first-tree/skill-evals eval:quality
+  pnpm --filter @first-tree/skill-evals eval:quality -- --suite first-tree-seed
   pnpm --filter @first-tree/skill-evals eval:quality -- --suite first-tree-write
   pnpm --filter @first-tree/skill-evals eval:select -- --base main
   pnpm --filter @first-tree/skill-evals eval:summary
@@ -249,19 +261,29 @@ function parseArgs(args: readonly string[]): CliOptions {
 
 function qualitySuite(options: CliOptions): QualitySkillName | null {
   if (options.suite === null) return null;
-  if (options.suite === "first-tree-write" || options.suite === "first-tree-welcome") {
+  if (
+    options.suite === "first-tree-write" ||
+    options.suite === "first-tree-seed" ||
+    options.suite === "first-tree-welcome"
+  ) {
     return options.suite;
   }
-  throw new Error("eval:quality currently supports --suite first-tree-write or --suite first-tree-welcome.");
+  throw new Error(
+    "eval:quality currently supports --suite first-tree-write, --suite first-tree-seed, or --suite first-tree-welcome.",
+  );
 }
 
 function includeQualitySuite(options: CliOptions): QualitySkillName {
-  if (options.suite === "first-tree-write" || options.suite === "first-tree-welcome") {
+  if (
+    options.suite === "first-tree-write" ||
+    options.suite === "first-tree-seed" ||
+    options.suite === "first-tree-welcome"
+  ) {
     return options.suite;
   }
   const suiteText = options.suite === null ? "no suite" : options.suite;
   throw new Error(
-    `eval:gate --include-quality is only supported for --suite first-tree-write or --suite first-tree-welcome; got ${suiteText}.`,
+    `eval:gate --include-quality is only supported for --suite first-tree-write, --suite first-tree-seed, or --suite first-tree-welcome; got ${suiteText}.`,
   );
 }
 
@@ -471,8 +493,8 @@ function gateResultEntries(
 
 function periodicResultEntries(
   packageRootPath: string,
-  batch: WelcomeBatchSummary,
-  suite: Extract<ShippedSkillName, "first-tree-welcome">,
+  batch: SeedBatchSummary | WelcomeBatchSummary,
+  suite: Extract<ShippedSkillName, "first-tree-seed" | "first-tree-welcome">,
   options: CliOptions,
   runGroupId = createRunGroupId(batch.runStartedAt, `eval-periodic-${suite}`),
 ): readonly ResultStoreEntry[] {
@@ -626,6 +648,38 @@ async function runIncludedWelcomeQuality(
   return { batch: qualityBatch, skippedReason: null };
 }
 
+async function runIncludedSeedQuality(
+  packageRootPath: string,
+  batch: SeedBatchSummary,
+  options: CliOptions,
+): Promise<IncludedQualityResult> {
+  const skippedReason = includedQualityGateFailureReason(batch);
+  if (skippedReason !== null) return { batch: null, skippedReason };
+  const gateSummary = batch.cases.find((summary) => summary.caseId === FIRST_TREE_SEED_QUALITY_DEFINITION.gateCaseId);
+  if (gateSummary === undefined) {
+    return {
+      batch: null,
+      skippedReason: `quality was not run because gate case ${FIRST_TREE_SEED_QUALITY_DEFINITION.gateCaseId} was not included`,
+    };
+  }
+  const qualityBatch = await runQualityEval(
+    packageRootPath,
+    {
+      caseId: FIRST_TREE_SEED_QUALITY_DEFINITION.evalCase.id,
+      codexBin: options.codexBin,
+      judgeBin: options.judgeBin,
+      judgeModel: options.judgeModel,
+      json: options.json,
+      model: options.model,
+      suite: "first-tree-seed",
+      verbose: options.verbose,
+    },
+    undefined,
+    new Map([[FIRST_TREE_SEED_QUALITY_DEFINITION.evalCase.id, buildSeedQualityInput(gateSummary)]]),
+  );
+  return { batch: qualityBatch, skippedReason: null };
+}
+
 function printGateWithOptionalQuality(
   gateText: string,
   gateBatch: GateBatchSummary,
@@ -716,6 +770,9 @@ async function runGate(options: CliOptions): Promise<void> {
   }
 
   if (options.suite === "first-tree-seed") {
+    if (options.includeQuality) {
+      assertIncludedQualityCase(options, FIRST_TREE_SEED_QUALITY_DEFINITION.gateCaseId);
+    }
     const batch = await runFirstTreeSeedGate(packageRootPath, {
       caseId: options.caseId,
       codexBin: options.codexBin,
@@ -723,9 +780,23 @@ async function runGate(options: CliOptions): Promise<void> {
       model: options.model,
       verbose: options.verbose,
     });
-    appendResultStoreEntries(packageRootPath, gateResultEntries(packageRootPath, batch, options.suite, options));
-    printGateWithOptionalQuality(formatFirstTreeSeedGateSummary(batch), batch, null, options.json);
-    if (batch.failed > 0) {
+    const runGroupId = createRunGroupId(
+      batch.runStartedAt,
+      `eval-gate-${options.suite}${options.includeQuality ? "-include-quality" : ""}`,
+    );
+    appendResultStoreEntries(
+      packageRootPath,
+      gateResultEntries(packageRootPath, batch, options.suite, options, runGroupId),
+    );
+    const quality = options.includeQuality ? await runIncludedSeedQuality(packageRootPath, batch, options) : null;
+    if (quality?.batch !== null && quality?.batch !== undefined) {
+      appendResultStoreEntries(
+        packageRootPath,
+        qualityResultEntries(packageRootPath, quality.batch, options, runGroupId),
+      );
+    }
+    printGateWithOptionalQuality(formatFirstTreeSeedGateSummary(batch), batch, quality, options.json);
+    if (gateCommandFailed(batch, quality)) {
       process.exitCode = 1;
     }
     return;
@@ -807,7 +878,30 @@ function runSelect(options: CliOptions): void {
 
 async function runPeriodic(options: CliOptions): Promise<void> {
   const packageRootPath = packageRoot();
-  if (options.suite === null || options.suite === "first-tree-welcome") {
+  if (options.suite === "first-tree-seed") {
+    const batch = await runFirstTreeSeedPeriodic(packageRootPath, {
+      caseId: options.caseId,
+      codexBin: options.codexBin,
+      json: options.json,
+      model: options.model,
+      verbose: options.verbose,
+    });
+    appendResultStoreEntries(
+      packageRootPath,
+      periodicResultEntries(packageRootPath, batch, "first-tree-seed", options),
+    );
+    if (options.json) {
+      process.stdout.write(`${JSON.stringify(batch, null, 2)}\n`);
+    } else {
+      process.stdout.write(`${formatFirstTreeSeedPeriodicSummary(batch)}\n`);
+    }
+    if (batch.failed > 0) {
+      process.exitCode = 1;
+    }
+    return;
+  }
+
+  if (options.suite === "first-tree-welcome") {
     const batch = await runFirstTreeWelcomePeriodic(packageRootPath, {
       caseId: options.caseId,
       codexBin: options.codexBin,
@@ -825,6 +919,77 @@ async function runPeriodic(options: CliOptions): Promise<void> {
       process.stdout.write(`${formatFirstTreeWelcomePeriodicSummary(batch)}\n`);
     }
     if (batch.failed > 0) {
+      process.exitCode = 1;
+    }
+    return;
+  }
+
+  if (options.suite === null) {
+    const runGroupStartedAt = new Date().toISOString();
+    const runGroupId = createRunGroupId(runGroupStartedAt, "eval-periodic-all");
+    const runSeed = options.caseId === null || findFirstTreeSeedPeriodicCase(options.caseId) !== null;
+    const runWelcome = options.caseId === null || findFirstTreeWelcomePeriodicCase(options.caseId) !== null;
+    if (!runSeed && !runWelcome) {
+      throw new Error(
+        `No periodic case '${options.caseId}' found for implemented periodic suites first-tree-seed or first-tree-welcome.`,
+      );
+    }
+    const seedBatch = runSeed
+      ? await runFirstTreeSeedPeriodic(packageRootPath, {
+          caseId: options.caseId,
+          codexBin: options.codexBin,
+          json: options.json,
+          model: options.model,
+          verbose: options.verbose,
+        })
+      : null;
+    if (seedBatch !== null) {
+      appendResultStoreEntries(
+        packageRootPath,
+        periodicResultEntries(packageRootPath, seedBatch, "first-tree-seed", options, runGroupId),
+      );
+    }
+    const welcomeBatch = runWelcome
+      ? await runFirstTreeWelcomePeriodic(packageRootPath, {
+          caseId: options.caseId,
+          codexBin: options.codexBin,
+          json: options.json,
+          model: options.model,
+          verbose: options.verbose,
+        })
+      : null;
+    if (welcomeBatch !== null) {
+      appendResultStoreEntries(
+        packageRootPath,
+        periodicResultEntries(packageRootPath, welcomeBatch, "first-tree-welcome", options, runGroupId),
+      );
+    }
+    if (options.json) {
+      process.stdout.write(
+        `${JSON.stringify(
+          {
+            "first-tree-seed": seedBatch,
+            "first-tree-welcome": welcomeBatch,
+            runStartedAt: runGroupStartedAt,
+          },
+          null,
+          2,
+        )}\n`,
+      );
+    } else {
+      process.stdout.write(
+        [
+          ...(seedBatch === null
+            ? []
+            : ["first-tree-seed periodic", "", formatFirstTreeSeedPeriodicSummary(seedBatch), ""]),
+          ...(welcomeBatch === null
+            ? []
+            : ["first-tree-welcome periodic", "", formatFirstTreeWelcomePeriodicSummary(welcomeBatch)]),
+        ].join("\n"),
+      );
+      process.stdout.write("\n");
+    }
+    if ((seedBatch?.failed ?? 0) > 0 || (welcomeBatch?.failed ?? 0) > 0) {
       process.exitCode = 1;
     }
     return;

--- a/packages/skill-evals/src/suites/first-tree-seed/__tests__/grader.test.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/__tests__/grader.test.ts
@@ -4,13 +4,15 @@ import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 import type { RunPaths } from "../../../core/types.js";
-import { FIRST_TREE_SEED_GATE_CASES } from "../cases.js";
+import { FIRST_TREE_SEED_GATE_CASES, FIRST_TREE_SEED_PERIODIC_CASES } from "../cases.js";
 import { casePassed, deriveMetrics } from "../grader.js";
 import { buildGrading } from "../summary.js";
 import type { EvalMetrics, FirstTreeSeedEvalCase, FixtureValidation } from "../types.js";
 
 function findCase(id: string): FirstTreeSeedEvalCase {
-  const evalCase = FIRST_TREE_SEED_GATE_CASES.find((candidate) => candidate.id === id);
+  const evalCase = [...FIRST_TREE_SEED_GATE_CASES, ...FIRST_TREE_SEED_PERIODIC_CASES].find(
+    (candidate) => candidate.id === id,
+  );
   if (!evalCase) throw new Error(`Missing test case ${id}`);
   return evalCase;
 }
@@ -273,6 +275,45 @@ describe("first-tree-seed grader", () => {
     ).toBe(true);
   });
 
+  it("passes real first-tree periodic case when source evidence is read through a worktree", () => {
+    expect(
+      casePassed(
+        findCase("first-tree-seed-real-first-tree-source-periodic"),
+        baseMetrics({
+          finalResponse:
+            "Proposed Phase 1 skeleton: system, context-management, cloud, team-practice, members. Reply to approve.",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("detects real first-tree source evidence read from the materialized worktree", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "seed-eval-real-source-read-"));
+    try {
+      const metrics = deriveMetrics(
+        [
+          {
+            event: {
+              command: "cat worktrees/seed-source-repo/package.json && ls worktrees/seed-source-repo/packages",
+              type: "command_execution",
+            },
+            type: "codex_event",
+          },
+        ],
+        findCase("first-tree-seed-real-first-tree-source-periodic"),
+        fixtureValidation(),
+        0,
+        baseRunPaths(tempRoot),
+        join(tempRoot, "context-tree"),
+      );
+
+      expect(metrics.sourceEvidenceReadObserved).toBe(true);
+      expect(metrics.directBareSourceContentReadObserved).toBe(false);
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
   it("fails bare-source protocol when first-tree-write required reading was not loaded", () => {
     expect(
       casePassed(
@@ -333,6 +374,34 @@ describe("first-tree-seed grader", () => {
       );
 
       expect(metrics.sourceEvidenceReadObserved).toBe(true);
+      expect(metrics.directBareSourceContentReadObserved).toBe(true);
+      expect(metrics.forbiddenActionHits).toContain("direct_bare_source_read");
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("detects direct source reads through git commands against the run-scoped bare origin", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "seed-eval-real-origin-git-show-"));
+    try {
+      const metrics = deriveMetrics(
+        [
+          {
+            event: {
+              aggregated_output: "# First Tree",
+              command: "git --git-dir .first-tree-eval/source-origin show main:README.md",
+              type: "command_execution",
+            },
+            type: "codex_event",
+          },
+        ],
+        findCase("first-tree-seed-real-first-tree-source-periodic"),
+        fixtureValidation(),
+        0,
+        baseRunPaths(tempRoot),
+        join(tempRoot, "context-tree"),
+      );
+
       expect(metrics.directBareSourceContentReadObserved).toBe(true);
       expect(metrics.forbiddenActionHits).toContain("direct_bare_source_read");
     } finally {

--- a/packages/skill-evals/src/suites/first-tree-seed/__tests__/periodic.test.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/__tests__/periodic.test.ts
@@ -1,0 +1,68 @@
+import { execFileSync } from "node:child_process";
+import { rmSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { createRunPaths } from "../../../core/paths.js";
+import { createEvalReporter } from "../../../core/reporter.js";
+import { FIRST_TREE_SEED_PERIODIC_CASES } from "../cases.js";
+import { setupFixture } from "../fixture.js";
+import { findFirstTreeSeedPeriodicCase } from "../periodic.js";
+
+describe("first-tree-seed periodic cases", () => {
+  it("declares the real first-tree source realism case as the only implemented periodic row", () => {
+    expect(FIRST_TREE_SEED_PERIODIC_CASES.map((evalCase) => evalCase.id)).toEqual([
+      "first-tree-seed-real-first-tree-source-periodic",
+    ]);
+    expect(FIRST_TREE_SEED_PERIODIC_CASES[0]?.status).toBe("implemented");
+    expect(FIRST_TREE_SEED_PERIODIC_CASES[0]?.fixture.sourceRepoState).toBe("real-first-tree-bare-readable");
+  });
+
+  it("finds the periodic realism case by id", () => {
+    expect(findFirstTreeSeedPeriodicCase("first-tree-seed-real-first-tree-source-periodic")?.tier).toBe("periodic");
+    expect(findFirstTreeSeedPeriodicCase("missing-periodic-case")).toBeNull();
+  });
+
+  it("builds the real-source fixture from a run-scoped origin instead of the developer checkout", () => {
+    const evalCase = findFirstTreeSeedPeriodicCase("first-tree-seed-real-first-tree-source-periodic");
+    if (evalCase === null) throw new Error("missing seed real-source periodic case");
+
+    const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../../..");
+    const paths = createRunPaths({
+      caseId: "seed-real-source-fixture-test",
+      packageRoot,
+      startedAt: new Date().toISOString(),
+    });
+
+    try {
+      setupFixture(evalCase, paths, createEvalReporter(evalCase.id, false));
+      const sourceRepoPath = join(paths.workspacePath, "source-repos", "source-repo");
+      const origin = execFileSync("git", ["remote", "get-url", "origin"], {
+        cwd: sourceRepoPath,
+        encoding: "utf8",
+      }).trim();
+      const visibleHead = execFileSync("git", ["rev-parse", "refs/remotes/origin/main"], {
+        cwd: sourceRepoPath,
+        encoding: "utf8",
+      }).trim();
+      const repoHead = execFileSync("git", ["rev-parse", "HEAD"], {
+        cwd: paths.repoRoot,
+        encoding: "utf8",
+      }).trim();
+      const sourceOriginRemotes = execFileSync("git", ["remote", "-v"], {
+        cwd: join(paths.workspacePath, ".first-tree-eval", "source-origin"),
+        encoding: "utf8",
+      });
+
+      expect(origin).not.toBe(paths.repoRoot);
+      expect(origin).toBe(join(paths.workspacePath, ".first-tree-eval", "source-origin"));
+      expect(sourceOriginRemotes).not.toContain(paths.repoRoot);
+      expect(visibleHead).toBe(repoHead);
+      execFileSync("git", ["fetch", "origin"], { cwd: sourceRepoPath });
+    } finally {
+      rmSync(paths.runRoot, { force: true, recursive: true });
+    }
+  });
+});

--- a/packages/skill-evals/src/suites/first-tree-seed/cases.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/cases.ts
@@ -1,5 +1,6 @@
 import type { SkillEvalCase } from "../../core/case-schema.js";
 import type { SkillEvalSuiteDefinition } from "../types.js";
+import { FIRST_TREE_SEED_QUALITY_CASE } from "./quality.js";
 import type { FirstTreeSeedEvalCase } from "./types.js";
 
 const FLOOR_CASE_ID = "first-tree-seed-static-coverage";
@@ -111,6 +112,36 @@ export const FIRST_TREE_SEED_GATE_CASES: readonly FirstTreeSeedEvalCase[] = [
   },
 ];
 
+export const FIRST_TREE_SEED_PERIODIC_CASES: readonly FirstTreeSeedEvalCase[] = [
+  {
+    briefingMode: "generated-fixture",
+    expected: {
+      action: "propose_phase1_skeleton",
+      approvalHints: ["approve", "reply", "confirm", "ON"],
+      requireSourceRead: true,
+      requireWorktree: true,
+      responseHints: ["Phase 1", "skeleton", "approval"],
+      skeletonHints: ["system", "context-management", "cloud", "team-practice", "members"],
+    },
+    fixture: {
+      sourceRepoState: "real-first-tree-bare-readable",
+      treeState: "empty",
+    },
+    forbidden: {
+      actions: ["direct_bare_source_read", "phase2_leaf_content_before_approval", "skip_user_confirmation"],
+      sideEffects: ["tree_write", "tree_pr", "source_write", "github"],
+    },
+    id: "first-tree-seed-real-first-tree-source-periodic",
+    prompt:
+      "Use first-tree-seed to bootstrap the newly provisioned empty Context Tree from the bound first-tree source repo. Follow the bare-source worktree protocol, inspect source evidence, and stop after proposing only the Phase 1 top + second-level skeleton for user approval.",
+    provider: "codex",
+    skill: "first-tree-seed",
+    status: "implemented",
+    tags: ["periodic", "real-repo", "bare-source", "phase-boundary"],
+    tier: "periodic",
+  },
+];
+
 export const FIRST_TREE_SEED_EVAL_CASES: readonly SkillEvalCase[] = [
   {
     briefingMode: "generated-fixture",
@@ -119,7 +150,7 @@ export const FIRST_TREE_SEED_EVAL_CASES: readonly SkillEvalCase[] = [
       validator: "case schema and lifecycle fixture shape",
     },
     fixture: {
-      sourceRepoStates: ["bare-readable", "missing"],
+      sourceRepoStates: ["bare-readable", "missing", "real-first-tree-bare-readable"],
       treeStates: ["empty", "nonempty"],
     },
     id: FLOOR_CASE_ID,
@@ -128,6 +159,8 @@ export const FIRST_TREE_SEED_EVAL_CASES: readonly SkillEvalCase[] = [
     tier: "floor",
   },
   ...FIRST_TREE_SEED_GATE_CASES,
+  ...FIRST_TREE_SEED_PERIODIC_CASES,
+  FIRST_TREE_SEED_QUALITY_CASE,
 ];
 
 function validateFirstTreeSeedFloor(cases: readonly SkillEvalCase[]): readonly string[] {
@@ -136,6 +169,12 @@ function validateFirstTreeSeedFloor(cases: readonly SkillEvalCase[]): readonly s
   if (gateCases.length !== 4) {
     errors.push(`seed suite must declare 4 gate cases, found ${gateCases.length}.`);
   }
+  const periodicCases = cases.filter(
+    (evalCase) => evalCase.skill === "first-tree-seed" && evalCase.tier === "periodic",
+  );
+  if (periodicCases.length !== 1) {
+    errors.push(`seed suite must declare 1 periodic realism case, found ${periodicCases.length}.`);
+  }
 
   for (const evalCase of cases.filter((candidate) => candidate.skill === "first-tree-seed")) {
     if (typeof evalCase.fixture !== "object" || evalCase.fixture === null || Array.isArray(evalCase.fixture)) {
@@ -143,11 +182,11 @@ function validateFirstTreeSeedFloor(cases: readonly SkillEvalCase[]): readonly s
       continue;
     }
     const fixture = evalCase.fixture as { sourceRepoState?: unknown; treeState?: unknown };
-    if (evalCase.tier === "gate" && typeof fixture.sourceRepoState !== "string") {
-      errors.push(`${evalCase.id}: gate fixture must declare sourceRepoState.`);
+    if ((evalCase.tier === "gate" || evalCase.tier === "periodic") && typeof fixture.sourceRepoState !== "string") {
+      errors.push(`${evalCase.id}: live fixture must declare sourceRepoState.`);
     }
-    if (evalCase.tier === "gate" && typeof fixture.treeState !== "string") {
-      errors.push(`${evalCase.id}: gate fixture must declare treeState.`);
+    if ((evalCase.tier === "gate" || evalCase.tier === "periodic") && typeof fixture.treeState !== "string") {
+      errors.push(`${evalCase.id}: live fixture must declare treeState.`);
     }
   }
   return errors;
@@ -169,6 +208,20 @@ export const FIRST_TREE_SEED_SUITE: SkillEvalSuiteDefinition = {
         description: "Implemented seed lifecycle, source, and bare-worktree protocol live gate cases.",
         status: "implemented",
         tier: "gate",
+      },
+      {
+        caseIds: FIRST_TREE_SEED_PERIODIC_CASES.map((evalCase) => evalCase.id),
+        description:
+          "Opt-in seed realism periodic case using a per-run bare source fixture cloned from the current first-tree repo HEAD.",
+        status: "implemented",
+        tier: "periodic",
+      },
+      {
+        caseIds: [FIRST_TREE_SEED_QUALITY_CASE.id],
+        description:
+          "LLM-as-judge seed skeleton quality case from the empty-tree-source-present deterministic gate artifact.",
+        status: "implemented",
+        tier: "quality",
       },
     ],
   },

--- a/packages/skill-evals/src/suites/first-tree-seed/fixture.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/fixture.ts
@@ -20,9 +20,11 @@ function workspaceAgentsMarkdown(
   const sourceRepoPath = join(workspacePath, "source-repos", "source-repo");
   const sourceWorktreePath = join(workspacePath, "worktrees", "seed-source-repo");
   const sourceLine =
-    evalCase.fixture.sourceRepoState === "bare-readable"
-      ? `The manifest source \`source-repo\` exists as a bare clone at \`${sourceRepoPath}\`.`
-      : `The manifest source \`source-repo\` is intentionally missing from \`${sourceRepoPath}\`.`;
+    evalCase.fixture.sourceRepoState === "missing"
+      ? `The manifest source \`source-repo\` is intentionally missing from \`${sourceRepoPath}\`.`
+      : evalCase.fixture.sourceRepoState === "real-first-tree-bare-readable"
+        ? `The manifest source \`source-repo\` exists as a bare clone of the current first-tree repo at \`${sourceRepoPath}\`.`
+        : `The manifest source \`source-repo\` exists as a bare clone at \`${sourceRepoPath}\`.`;
   const treeLine =
     evalCase.fixture.treeState === "empty"
       ? "The Context Tree at `./context-tree` is newly provisioned and empty."
@@ -270,6 +272,10 @@ function writeBareSourceFixture(paths: RunPaths, evalCase: FirstTreeSeedEvalCase
     return null;
   }
 
+  if (evalCase.fixture.sourceRepoState === "real-first-tree-bare-readable") {
+    return writeRealFirstTreeBareSourceFixture(paths);
+  }
+
   const sourceOriginPath = writeSourceOriginFixture(paths);
   const sourceRepoPath = join(paths.workspacePath, "source-repos", "source-repo");
   mkdirSync(join(paths.workspacePath, "source-repos"), { recursive: true });
@@ -279,6 +285,28 @@ function writeBareSourceFixture(paths: RunPaths, evalCase: FirstTreeSeedEvalCase
   );
   assertCommandOk(runCommand("git", ["fetch", "origin"], sourceRepoPath));
   return sourceRepoPath;
+}
+
+function writeRealFirstTreeBareSourceFixture(paths: RunPaths): string {
+  const sourceOriginPath = writeRealFirstTreeSourceOriginFixture(paths);
+  const sourceRepoPath = join(paths.workspacePath, "source-repos", "source-repo");
+  mkdirSync(join(paths.workspacePath, "source-repos"), { recursive: true });
+  assertCommandOk(runCommand("git", ["clone", "--bare", sourceOriginPath, sourceRepoPath], paths.workspacePath));
+  assertCommandOk(
+    runCommand("git", ["config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*"], sourceRepoPath),
+  );
+  assertCommandOk(runCommand("git", ["fetch", "origin"], sourceRepoPath));
+  return sourceRepoPath;
+}
+
+function writeRealFirstTreeSourceOriginFixture(paths: RunPaths): string {
+  const sourceOriginPath = join(paths.workspacePath, ".first-tree-eval", "source-origin");
+  assertCommandOk(runCommand("git", ["init", "--bare", sourceOriginPath], paths.workspacePath));
+  assertCommandOk(runCommand("git", ["remote", "add", "source", paths.repoRoot], sourceOriginPath));
+  assertCommandOk(runCommand("git", ["fetch", "source", "HEAD:refs/heads/main"], sourceOriginPath));
+  assertCommandOk(runCommand("git", ["symbolic-ref", "HEAD", "refs/heads/main"], sourceOriginPath));
+  assertCommandOk(runCommand("git", ["remote", "remove", "source"], sourceOriginPath));
+  return sourceOriginPath;
 }
 
 function gitHead(repoPath: string, ref = "HEAD"): string | null {

--- a/packages/skill-evals/src/suites/first-tree-seed/fixture.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/fixture.ts
@@ -291,11 +291,12 @@ function writeRealFirstTreeBareSourceFixture(paths: RunPaths): string {
   const sourceOriginPath = writeRealFirstTreeSourceOriginFixture(paths);
   const sourceRepoPath = join(paths.workspacePath, "source-repos", "source-repo");
   mkdirSync(join(paths.workspacePath, "source-repos"), { recursive: true });
-  assertCommandOk(runCommand("git", ["clone", "--bare", sourceOriginPath, sourceRepoPath], paths.workspacePath));
+  assertCommandOk(runCommand("git", ["init", "--bare", sourceRepoPath], paths.workspacePath));
+  assertCommandOk(runCommand("git", ["remote", "add", "origin", sourceOriginPath], sourceRepoPath));
   assertCommandOk(
     runCommand("git", ["config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*"], sourceRepoPath),
   );
-  assertCommandOk(runCommand("git", ["fetch", "origin"], sourceRepoPath));
+  assertCommandOk(runCommand("git", ["fetch", "origin", "+refs/heads/*:refs/remotes/origin/*"], sourceRepoPath));
   return sourceRepoPath;
 }
 

--- a/packages/skill-evals/src/suites/first-tree-seed/fixture.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/fixture.ts
@@ -297,6 +297,12 @@ function writeRealFirstTreeBareSourceFixture(paths: RunPaths): string {
     runCommand("git", ["config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*"], sourceRepoPath),
   );
   assertCommandOk(runCommand("git", ["fetch", "origin", "+refs/heads/*:refs/remotes/origin/*"], sourceRepoPath));
+  const sourceMain = gitHead(sourceOriginPath, "refs/heads/main");
+  if (sourceMain === null) {
+    throw new Error(`real first-tree source origin is missing refs/heads/main: ${sourceOriginPath}`);
+  }
+  assertCommandOk(runCommand("git", ["update-ref", "refs/remotes/origin/main", sourceMain], sourceRepoPath));
+  assertCommandOk(runCommand("git", ["rev-parse", "refs/remotes/origin/main"], sourceRepoPath));
   return sourceRepoPath;
 }
 
@@ -307,6 +313,7 @@ function writeRealFirstTreeSourceOriginFixture(paths: RunPaths): string {
   assertCommandOk(runCommand("git", ["fetch", "source", "HEAD:refs/heads/main"], sourceOriginPath));
   assertCommandOk(runCommand("git", ["symbolic-ref", "HEAD", "refs/heads/main"], sourceOriginPath));
   assertCommandOk(runCommand("git", ["remote", "remove", "source"], sourceOriginPath));
+  assertCommandOk(runCommand("git", ["rev-parse", "refs/heads/main"], sourceOriginPath));
   return sourceOriginPath;
 }
 

--- a/packages/skill-evals/src/suites/first-tree-seed/fixture.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/fixture.ts
@@ -308,12 +308,23 @@ function writeRealFirstTreeBareSourceFixture(paths: RunPaths): string {
 
 function writeRealFirstTreeSourceOriginFixture(paths: RunPaths): string {
   const sourceOriginPath = join(paths.workspacePath, ".first-tree-eval", "source-origin");
-  assertCommandOk(runCommand("git", ["init", "--bare", sourceOriginPath], paths.workspacePath));
-  assertCommandOk(runCommand("git", ["remote", "add", "source", paths.repoRoot], sourceOriginPath));
-  assertCommandOk(runCommand("git", ["fetch", "source", "HEAD:refs/heads/main"], sourceOriginPath));
+  const repoHead = gitHead(paths.repoRoot);
+  if (repoHead === null) {
+    throw new Error(`real first-tree repo is missing HEAD: ${paths.repoRoot}`);
+  }
+  assertCommandOk(
+    runCommand("git", ["clone", "--bare", "--no-local", paths.repoRoot, sourceOriginPath], paths.workspacePath),
+  );
+  assertCommandOk(runCommand("git", ["update-ref", "refs/heads/main", repoHead], sourceOriginPath));
   assertCommandOk(runCommand("git", ["symbolic-ref", "HEAD", "refs/heads/main"], sourceOriginPath));
-  assertCommandOk(runCommand("git", ["remote", "remove", "source"], sourceOriginPath));
-  assertCommandOk(runCommand("git", ["rev-parse", "refs/heads/main"], sourceOriginPath));
+  const removeOrigin = runCommand("git", ["remote", "remove", "origin"], sourceOriginPath);
+  if (removeOrigin.exitCode !== 0 && !removeOrigin.stderr.includes("No such remote")) {
+    assertCommandOk(removeOrigin);
+  }
+  const sourceMain = gitHead(sourceOriginPath, "refs/heads/main");
+  if (sourceMain !== repoHead) {
+    throw new Error(`real first-tree source origin main ${sourceMain ?? "missing"} does not match ${repoHead}`);
+  }
   return sourceOriginPath;
 }
 

--- a/packages/skill-evals/src/suites/first-tree-seed/grader.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/grader.ts
@@ -33,6 +33,20 @@ const SKILL_READ_OUTPUT_KEYS = new Set([
   "stdout",
   "text",
 ]);
+const PROTECTED_BARE_SOURCE_REPO_PATTERN =
+  /(?:^|[\s"'=])(?:\.\/|\/[^\s"']*\/)?(?:source-repos\/source-repo|\.first-tree-eval\/source-origin)(?:[\s"'/:]|$)/u;
+const PROTECTED_BARE_SOURCE_CONTENT_PATHS = [
+  "source-repos/source-repo/README.md",
+  "source-repos/source-repo/package.json",
+  "source-repos/source-repo/apps/",
+  "source-repos/source-repo/docs/",
+  "source-repos/source-repo/packages/",
+  "source-repos/source-repo/raw-context/",
+  "source-repos/source-repo/skills/",
+  ".first-tree-eval/source-origin/objects/",
+  ".first-tree-eval/source-origin/packed-refs",
+  ".first-tree-eval/source-origin/refs/",
+];
 
 function eventType(event: Record<string, unknown>): string | null {
   return typeof event.type === "string" ? event.type : null;
@@ -338,9 +352,7 @@ function forbiddenSideEffectHits(events: readonly unknown[], firstTreeArgv: read
 
 function commandReadsBareSourceContent(command: string): boolean {
   if (!/\bgit\b/u.test(command)) return false;
-  if (!/(?:^|[\s"'=])(?:\.\/|\/[^\s"']*\/)?source-repos\/source-repo(?:[\s"'/:]|$)/u.test(command)) {
-    return false;
-  }
+  if (!PROTECTED_BARE_SOURCE_REPO_PATTERN.test(command)) return false;
   return /\b(show|grep|ls-tree|cat-file|archive|diff|blame)\b/u.test(command);
 }
 
@@ -351,15 +363,7 @@ function directBareSourceContentRead(events: readonly unknown[]): boolean {
         if (commandReadsBareSourceContent(command)) return true;
       }
     }
-    if (
-      containsPathAccess(event, [
-        "source-repos/source-repo/README.md",
-        "source-repos/source-repo/package.json",
-        "source-repos/source-repo/apps/",
-        "source-repos/source-repo/docs/",
-        "source-repos/source-repo/packages/",
-      ])
-    ) {
+    if (containsPathAccess(event, PROTECTED_BARE_SOURCE_CONTENT_PATHS)) {
       return true;
     }
   }
@@ -444,8 +448,12 @@ export function deriveMetrics(
     if (
       containsPathAccess(event, [
         "worktrees/seed-source-repo/README.md",
+        "worktrees/seed-source-repo/package.json",
         "worktrees/seed-source-repo/apps/cli/README.md",
         "worktrees/seed-source-repo/apps/web/README.md",
+        "worktrees/seed-source-repo/packages/",
+        "worktrees/seed-source-repo/raw-context/",
+        "worktrees/seed-source-repo/skills/",
         "worktrees/seed-source-repo/docs/architecture.md",
         "worktrees/seed-source-repo/docs/team-practice.md",
       ])

--- a/packages/skill-evals/src/suites/first-tree-seed/index.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/index.ts
@@ -1,4 +1,11 @@
 import { FIRST_TREE_SEED_GATE_CASES } from "./cases.js";
+
+export {
+  findFirstTreeSeedPeriodicCase,
+  formatFirstTreeSeedPeriodicSummary,
+  runFirstTreeSeedPeriodic,
+} from "./periodic.js";
+
 import { runFirstTreeSeedCase } from "./runner.js";
 import { buildBatchSummary, formatSummaryTable } from "./summary.js";
 import type { BatchSummary, CliOptions, FirstTreeSeedEvalCase } from "./types.js";

--- a/packages/skill-evals/src/suites/first-tree-seed/periodic.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/periodic.ts
@@ -1,0 +1,41 @@
+import { FIRST_TREE_SEED_PERIODIC_CASES } from "./cases.js";
+import { runFirstTreeSeedCase } from "./runner.js";
+import { buildBatchSummary, formatSummaryTable } from "./summary.js";
+import type { BatchSummary, CliOptions, FirstTreeSeedEvalCase } from "./types.js";
+
+export function findFirstTreeSeedPeriodicCase(id: string): FirstTreeSeedEvalCase | null {
+  for (const evalCase of FIRST_TREE_SEED_PERIODIC_CASES) {
+    if (evalCase.id === id) return evalCase;
+  }
+  return null;
+}
+
+function selectPeriodicCases(caseId: string | null): readonly FirstTreeSeedEvalCase[] {
+  if (caseId === null) return FIRST_TREE_SEED_PERIODIC_CASES;
+
+  const evalCase = findFirstTreeSeedPeriodicCase(caseId);
+  if (evalCase === null) {
+    const available = FIRST_TREE_SEED_PERIODIC_CASES.map((candidate) => candidate.id).join(", ");
+    throw new Error(`Unknown first-tree-seed periodic case '${caseId}'. Available periodic cases: ${available}`);
+  }
+  return [evalCase];
+}
+
+export async function runFirstTreeSeedPeriodic(packageRoot: string, options: CliOptions): Promise<BatchSummary> {
+  const selectedCases = selectPeriodicCases(options.caseId);
+  const runStartedAt = new Date().toISOString();
+  const summaries = [];
+
+  for (const evalCase of selectedCases) {
+    if (!options.verbose) {
+      process.stderr.write(`Running first-tree-seed periodic eval case: ${evalCase.id}\n`);
+    }
+    summaries.push(await runFirstTreeSeedCase(packageRoot, evalCase, options, runStartedAt));
+  }
+
+  return buildBatchSummary(summaries, runStartedAt);
+}
+
+export function formatFirstTreeSeedPeriodicSummary(batch: BatchSummary): string {
+  return formatSummaryTable(batch);
+}

--- a/packages/skill-evals/src/suites/first-tree-seed/quality.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/quality.ts
@@ -1,0 +1,192 @@
+import type { JudgeRubricDimension } from "../../core/judge/types.js";
+import type {
+  QualityArtifactInput,
+  QualityCaseDefinition,
+  QualityEvalCase,
+  QualitySanityFixture,
+} from "../quality/types.js";
+
+const SEED_SKELETON_QUALITY_DIMENSIONS: readonly JudgeRubricDimension[] = [
+  {
+    description:
+      "Skeleton choices are grounded in the supplied source evidence and avoid generic archetypes unsupported by the repo.",
+    key: "source_grounding",
+    threshold: 4,
+  },
+  {
+    description:
+      "Top-level and second-level domains reflect durable concern axes rather than blindly mirroring source directories.",
+    key: "structure_fit",
+    threshold: 4,
+  },
+  {
+    description:
+      "The output stays Phase 1 only: skeleton/checklist plus approval request, with no leaf content or tree writes.",
+    key: "phase_boundary",
+    threshold: 5,
+  },
+  {
+    description:
+      "The proposal communicates confidence and gaps, such as ON / weak signal / OFF or equivalent uncertainty calibration.",
+    key: "coverage_calibration",
+    threshold: 3,
+  },
+  {
+    description: "The proposal is reviewable and avoids bloated implementation walkthroughs.",
+    key: "conciseness",
+    threshold: 3,
+  },
+];
+
+export const FIRST_TREE_SEED_QUALITY_CASE: QualityEvalCase = {
+  briefingMode: "generated-fixture",
+  expected: {
+    dimensions: SEED_SKELETON_QUALITY_DIMENSIONS.map((dimension) => dimension.key),
+    rubric: "first-tree-seed skeleton quality",
+  },
+  fixture: {
+    artifact: "actual Phase 1 skeleton proposal produced by empty-tree-source-present",
+    gateCaseId: "empty-tree-source-present",
+    source: "source evidence from the empty-tree-source-present fixture",
+  },
+  id: "first-tree-seed-skeleton-quality",
+  prompt: "Judge the quality of a first-tree-seed Phase 1 skeleton proposal from the empty-tree-source-present gate.",
+  provider: "codex",
+  skill: "first-tree-seed",
+  status: "implemented",
+  tags: ["llm-judge", "quality", "skeleton-quality"],
+  tier: "quality",
+};
+
+function dimensionLines(dimensions: readonly JudgeRubricDimension[]): string {
+  return dimensions
+    .map((dimension) => `- ${dimension.key}: ${dimension.description} Minimum passing score: ${dimension.threshold}.`)
+    .join("\n");
+}
+
+function buildSeedJudgePrompt(input: QualityArtifactInput): string {
+  return `You are judging a First Tree Phase 1 Context Tree skeleton proposed by first-tree-seed.
+
+Return ONLY strict JSON with this shape:
+{"scores":{"source_grounding":1,"structure_fit":1,"phase_boundary":1,"coverage_calibration":1,"conciseness":1},"reasoning":"one concise paragraph"}
+
+Scores are integers from 1 to 5. Do not include markdown or any extra text.
+
+Rubric:
+${dimensionLines(SEED_SKELETON_QUALITY_DIMENSIONS)}
+
+Source material:
+\`\`\`text
+${input.source}
+\`\`\`
+
+Actual Phase 1 skeleton proposal from the live gate:
+\`\`\`text
+${input.artifact}
+\`\`\`
+`;
+}
+
+export const FIRST_TREE_SEED_QUALITY_DEFINITION: QualityCaseDefinition = {
+  buildJudgePrompt: buildSeedJudgePrompt,
+  dimensions: SEED_SKELETON_QUALITY_DIMENSIONS,
+  evalCase: FIRST_TREE_SEED_QUALITY_CASE,
+  gateCaseId: "empty-tree-source-present",
+  title: "first-tree-seed skeleton quality",
+};
+
+function sanityInput(name: QualitySanityFixture["name"], artifact: string): QualityArtifactInput {
+  return {
+    artifact,
+    deterministicGatePassed: true,
+    gateCaseId: FIRST_TREE_SEED_QUALITY_DEFINITION.gateCaseId,
+    gateRunRoot: `/tmp/${name}-seed-gate`,
+    gateSummaryJsonPath: `/tmp/${name}-seed-gate/summary.json`,
+    gateSummaryMdPath: `/tmp/${name}-seed-gate/summary.md`,
+    source: [
+      "README: Apollo Console ships a CLI, web dashboard, and runtime packages for an agent team.",
+      "docs/architecture.md: durable concerns are local CLI operations, Cloud onboarding, web operator surfaces, runtime packages, and team practice.",
+      "docs/team-practice.md: team handoffs and review gates are durable collaboration conventions.",
+    ].join("\n"),
+  };
+}
+
+function judgeOutput(scores: Record<string, number>, reasoning: string): string {
+  return JSON.stringify({ reasoning, scores });
+}
+
+export const FIRST_TREE_SEED_QUALITY_SANITY_FIXTURES: readonly QualitySanityFixture[] = [
+  {
+    expectedPassed: true,
+    input: sanityInput(
+      "good",
+      [
+        "Phase 1 skeleton proposal:",
+        "- system/",
+        "  - cli.md (ON: source names local CLI operations)",
+        "  - cloud.md (ON: onboarding and operator dashboard evidence)",
+        "  - runtime.md (ON: runtime package signal)",
+        "- team-practice/",
+        "  - handoffs.md (ON: team practice source)",
+        "- members/ (weak signal: owners need confirmation)",
+        "Please approve or adjust this skeleton before I write any leaf content.",
+      ].join("\n"),
+    ),
+    judgeOutput: judgeOutput(
+      {
+        conciseness: 4,
+        coverage_calibration: 4,
+        phase_boundary: 5,
+        source_grounding: 5,
+        structure_fit: 5,
+      },
+      "Source-backed concern axes with clear confidence and approval boundary.",
+    ),
+    name: "good",
+  },
+  {
+    expectedPassed: true,
+    input: sanityInput(
+      "borderline",
+      [
+        "Phase 1 only: propose system/, product/, and team-practice/ with CLI/web/runtime second-level nodes.",
+        "Signals are strongest for CLI and web; runtime and members are weak and need confirmation.",
+        "Reply approve or edit before I create leaf nodes.",
+      ].join("\n"),
+    ),
+    judgeOutput: judgeOutput(
+      {
+        conciseness: 3,
+        coverage_calibration: 3,
+        phase_boundary: 5,
+        source_grounding: 4,
+        structure_fit: 4,
+      },
+      "Minimal but source grounded and exactly meets the thresholds.",
+    ),
+    name: "borderline",
+  },
+  {
+    expectedPassed: false,
+    input: sanityInput(
+      "bad",
+      [
+        "Create a generic SaaS tree with frontend/, backend/, database/, billing/, and analytics/.",
+        "## Decision",
+        "The backend uses PostgreSQL and Redis.",
+        "I will now write the leaves and open a PR without waiting for approval.",
+      ].join("\n"),
+    ),
+    judgeOutput: judgeOutput(
+      {
+        conciseness: 2,
+        coverage_calibration: 1,
+        phase_boundary: 1,
+        source_grounding: 2,
+        structure_fit: 2,
+      },
+      "Generic template, Phase 2 leaf content, and no approval boundary.",
+    ),
+    name: "bad",
+  },
+];

--- a/packages/skill-evals/src/suites/first-tree-seed/types.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/types.ts
@@ -2,7 +2,7 @@ import type { SkillCaseGrading } from "../../core/result-schema.js";
 import type { CommandResult } from "../../core/types.js";
 
 export type SeedTreeState = "empty" | "nonempty";
-export type SeedSourceRepoState = "bare-readable" | "missing";
+export type SeedSourceRepoState = "bare-readable" | "missing" | "real-first-tree-bare-readable";
 export type SeedExpectedAction =
   | "propose_phase1_skeleton"
   | "refuse_nonempty_tree"
@@ -39,7 +39,7 @@ export type FirstTreeSeedEvalCase = {
   skill: "first-tree-seed";
   status: "implemented";
   tags: readonly string[];
-  tier: "gate";
+  tier: "gate" | "periodic";
 };
 
 export type CliOptions = {

--- a/packages/skill-evals/src/suites/first-tree-welcome/index.ts
+++ b/packages/skill-evals/src/suites/first-tree-welcome/index.ts
@@ -1,5 +1,9 @@
 import { FIRST_TREE_WELCOME_GATE_CASES, FIRST_TREE_WELCOME_LIVE_GATE_CASES } from "./cases.js";
-import { formatFirstTreeWelcomePeriodicSummary, runFirstTreeWelcomePeriodic } from "./periodic.js";
+import {
+  findFirstTreeWelcomePeriodicCase,
+  formatFirstTreeWelcomePeriodicSummary,
+  runFirstTreeWelcomePeriodic,
+} from "./periodic.js";
 import { runFirstTreeWelcomeCase } from "./runner.js";
 import { buildBatchSummary, formatSummaryTable } from "./summary.js";
 import type { BatchSummary, CliOptions, FirstTreeWelcomeEvalCase } from "./types.js";
@@ -44,4 +48,4 @@ export function formatFirstTreeWelcomeGateSummary(batch: BatchSummary): string {
   return formatSummaryTable(batch);
 }
 
-export { formatFirstTreeWelcomePeriodicSummary, runFirstTreeWelcomePeriodic };
+export { findFirstTreeWelcomePeriodicCase, formatFirstTreeWelcomePeriodicSummary, runFirstTreeWelcomePeriodic };

--- a/packages/skill-evals/src/suites/quality/index.ts
+++ b/packages/skill-evals/src/suites/quality/index.ts
@@ -1,4 +1,5 @@
 export {
+  buildSeedQualityInput,
   buildWelcomeQualityInput,
   buildWriteQualityInput,
   formatQualitySummaryTable,

--- a/packages/skill-evals/src/suites/quality/runner.ts
+++ b/packages/skill-evals/src/suites/quality/runner.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { appendEvent } from "../../core/events.js";
@@ -7,6 +7,9 @@ import { evaluateJudgeOutput, parseJudgeJson } from "../../core/judge/schema.js"
 import type { JudgeEvaluation, JudgeProvider, JudgeProviderResponse } from "../../core/judge/types.js";
 import { createRunPaths } from "../../core/paths.js";
 import type { QualityJudgeRunResult } from "../../core/result-schema.js";
+import { runFirstTreeSeedGate } from "../first-tree-seed/index.js";
+import { FIRST_TREE_SEED_QUALITY_DEFINITION } from "../first-tree-seed/quality.js";
+import type { CaseRunSummary as SeedCaseRunSummary } from "../first-tree-seed/types.js";
 import { runFirstTreeWelcomeGate } from "../first-tree-welcome/index.js";
 import { FIRST_TREE_WELCOME_QUALITY_DEFINITION } from "../first-tree-welcome/quality.js";
 import type { CaseRunSummary as WelcomeCaseRunSummary } from "../first-tree-welcome/types.js";
@@ -24,6 +27,7 @@ import type {
 
 const QUALITY_DEFINITIONS: readonly QualityCaseDefinition[] = [
   FIRST_TREE_WRITE_QUALITY_DEFINITION,
+  FIRST_TREE_SEED_QUALITY_DEFINITION,
   FIRST_TREE_WELCOME_QUALITY_DEFINITION,
 ];
 
@@ -119,6 +123,10 @@ function readFixtureFile(path: string): string {
   return readFileSync(path, "utf8");
 }
 
+function readFixtureFileIfExists(path: string): string | null {
+  return existsSync(path) ? readFileSync(path, "utf8") : null;
+}
+
 export function buildWriteQualityInput(gateSummary: WriteCaseRunSummary): QualityArtifactInput {
   return {
     artifact:
@@ -131,6 +139,53 @@ export function buildWriteQualityInput(gateSummary: WriteCaseRunSummary): Qualit
     gateSummaryJsonPath: gateSummary.summaryJsonPath,
     gateSummaryMdPath: gateSummary.summaryMdPath,
     source: readFixtureFile(join(gateSummary.workspacePath, "source-artifacts", "durable-decision-note.md")),
+  };
+}
+
+function seedEvidenceSource(gateSummary: SeedCaseRunSummary): string {
+  const worktreePath = join(gateSummary.workspacePath, "worktrees", "seed-source-repo");
+  const sourceOriginPath = join(gateSummary.runRoot, "source-origin");
+  const chunks = [
+    "Setup state: empty Context Tree and bare source repo.",
+    "",
+    "Source README:",
+    readFixtureFileIfExists(join(worktreePath, "README.md")) ??
+      readFixtureFileIfExists(join(sourceOriginPath, "README.md")) ??
+      "_not read or unavailable_",
+    "",
+    "CLI evidence:",
+    readFixtureFileIfExists(join(worktreePath, "apps", "cli", "README.md")) ??
+      readFixtureFileIfExists(join(sourceOriginPath, "apps", "cli", "README.md")) ??
+      "_not read or unavailable_",
+    "",
+    "Architecture evidence:",
+    readFixtureFileIfExists(join(worktreePath, "docs", "architecture.md")) ??
+      readFixtureFileIfExists(join(sourceOriginPath, "docs", "architecture.md")) ??
+      "_not read or unavailable_",
+    "",
+    "Team-practice evidence:",
+    readFixtureFileIfExists(join(worktreePath, "docs", "team-practice.md")) ??
+      readFixtureFileIfExists(join(sourceOriginPath, "docs", "team-practice.md")) ??
+      "_not read or unavailable_",
+  ];
+  return chunks.join("\n");
+}
+
+export function buildSeedQualityInput(gateSummary: SeedCaseRunSummary): QualityArtifactInput {
+  return {
+    artifact: [
+      "Final seed response:",
+      gateSummary.metrics.finalResponse.trim() || "_none_",
+      "",
+      "Observed first-tree commands:",
+      gateSummary.metrics.firstTreeArgv.map((argv) => `first-tree ${argv.join(" ")}`).join("\n") || "_none_",
+    ].join("\n"),
+    deterministicGatePassed: gateSummary.passed,
+    gateCaseId: gateSummary.caseId,
+    gateRunRoot: gateSummary.runRoot,
+    gateSummaryJsonPath: gateSummary.summaryJsonPath,
+    gateSummaryMdPath: gateSummary.summaryMdPath,
+    source: seedEvidenceSource(gateSummary),
   };
 }
 
@@ -187,6 +242,21 @@ async function collectLiveQualityInput(
       throw new Error(`No gate summary produced for ${definition.gateCaseId}.`);
     }
     return buildWriteQualityInput(summary);
+  }
+
+  if (definition.evalCase.skill === "first-tree-seed") {
+    const batch = await runFirstTreeSeedGate(packageRoot, {
+      caseId: definition.gateCaseId,
+      codexBin: options.codexBin,
+      json: false,
+      model: options.model,
+      verbose: options.verbose,
+    });
+    const summary = batch.cases[0];
+    if (summary === undefined) {
+      throw new Error(`No gate summary produced for ${definition.gateCaseId}.`);
+    }
+    return buildSeedQualityInput(summary);
   }
 
   if (definition.evalCase.skill === "first-tree-welcome") {

--- a/packages/skill-evals/src/suites/quality/types.ts
+++ b/packages/skill-evals/src/suites/quality/types.ts
@@ -2,7 +2,7 @@ import type { ShippedSkillName, SkillEvalCase } from "../../core/case-schema.js"
 import type { JudgeRubricDimension } from "../../core/judge/types.js";
 import type { QualityJudgeRunResult } from "../../core/result-schema.js";
 
-export type QualitySkillName = Extract<ShippedSkillName, "first-tree-write" | "first-tree-welcome">;
+export type QualitySkillName = Extract<ShippedSkillName, "first-tree-write" | "first-tree-seed" | "first-tree-welcome">;
 
 export type QualityFixture = {
   artifact: string;


### PR DESCRIPTION
## Summary

- Add `first-tree-seed` skeleton quality judging via `first-tree-seed-skeleton-quality`.
- Support `eval:quality -- --suite first-tree-seed` and `eval:gate -- --suite first-tree-seed --include-quality`, reusing the `empty-tree-source-present` deterministic gate artifact.
- Add the opt-in seed realism periodic case `first-tree-seed-real-first-tree-source-periodic`.
- Build the real-source periodic fixture as a per-run bare source origin pinned to current repo `HEAD`, without exposing the developer checkout as the model-visible remote.
- Extend seed grader/tests, result-store periodic wiring, selector recommendations, CLI usage, and README docs.

## Boundaries

- Deterministic seed gate remains the hard-rule source of truth; the quality judge does not replace or weaken it.
- Seed realism stays under `eval:periodic` and is not added to gate, default tests, check, or CI.
- Ordinary `first-tree-seed` skill changes still recommend floor/gate/quality, not periodic.
- This does not add Claude/multi-provider, runtime-generated briefing, or live First Tree runtime E2E.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter @first-tree/skill-evals typecheck`
- focused vitest for judge/result-store/select/periodic/coverage/case-schema/seed grader/seed periodic
- `pnpm --filter first-tree-dev... build`
- `pnpm --filter @first-tree/skill-evals eval:floor -- --suite first-tree-seed`
- `pnpm --filter @first-tree/skill-evals eval:quality -- --suite first-tree-seed --case first-tree-seed-skeleton-quality --codex-bin /bin/false --judge-bin /bin/false --json` (expected failure; gate failed, judge not run)
- `pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-seed --case empty-tree-source-present --include-quality --codex-bin /bin/false --judge-bin /bin/false --json` (expected failure; quality skipped after gate failure)
- `pnpm --filter @first-tree/skill-evals eval:periodic -- --suite first-tree-seed --case first-tree-seed-real-first-tree-source-periodic --codex-bin /bin/false --json` (expected provider failure; fixture validation passed)
- `pnpm --filter @first-tree/skill-evals eval:periodic -- --case first-tree-seed-real-first-tree-source-periodic --codex-bin /bin/false --json` (expected provider failure; case-only selection runs seed and leaves welcome null)
- `pnpm --filter @first-tree/skill-evals eval:periodic -- --suite first-tree-read`
- `pnpm --filter @first-tree/skill-evals eval:select -- --changed-file skills/first-tree-seed/SKILL.md`
- `pnpm --filter @first-tree/skill-evals eval:select -- --changed-file packages/skill-evals/src/suites/first-tree-seed/periodic.ts`
- `pnpm --filter @first-tree/skill-evals eval:summary`
- `pnpm --filter @first-tree/skill-evals eval:compare`
- `pnpm --filter @first-tree/skill-evals exec vitest run --passWithNoTests --maxWorkers=2 --minWorkers=1` (127 tests passed)
- `pnpm exec biome check <changed files>`
- `pnpm typecheck`
- `pnpm check` (exits 0; existing client/web warnings/info only)
- `git diff --check`

## Notes

- I did not run real Codex live seed gate, live judge, or live periodic realism to avoid model quota during PR preparation.
- `codex-reviewer` reviewed the worktree in chat; two fixture/oracle blockers were fixed before opening this PR.
