### PR TITLE
Fix runtime session reconcile active set

### DIFF
--- a/packages/client/src/__tests__/agent-slot.test.ts
+++ b/packages/client/src/__tests__/agent-slot.test.ts
@@ -81,6 +81,8 @@ function makeSdk(options?: {
   configError?: unknown;
   /** Throw `error` on the first `times` config fetches, then succeed — models a transient blip. */
   configErrorsThenSucceed?: { error: unknown; times: number };
+  activeRuntimeChatIds?: string[];
+  activeRuntimeChatIdsError?: unknown;
 }): FirstTreeHubSDK {
   const agent = options?.agent ?? makeAgent();
   let configCalls = 0;
@@ -107,6 +109,10 @@ function makeSdk(options?: {
         updatedAt: "2026-01-01T00:00:00.000Z",
         updatedBy: "user-1",
       };
+    }),
+    listActiveRuntimeChatIds: vi.fn(async () => {
+      if (options?.activeRuntimeChatIdsError) throw options.activeRuntimeChatIdsError;
+      return { chatIds: options?.activeRuntimeChatIds ?? ["chat-1", "chat-2", "chat-evicted"] };
     }),
   };
   // AgentSlot only uses this SDK subset; the concrete SDK type has many HTTP methods irrelevant here.
@@ -188,16 +194,19 @@ function installMocks(options: { syncResult?: MockState["syncResult"]; syncDelay
         return { activeCount: this.state.activeCount, lastActivityMs: this.state.lastActivityMs };
       }
 
-      getSessionStates(): FakeSessionState["sessionStates"] {
-        return this.state.sessionStates;
+      getSessionStates(activeChatIds?: ReadonlySet<string> | null): FakeSessionState["sessionStates"] {
+        if (!activeChatIds) return this.state.sessionStates;
+        return this.state.sessionStates.filter(({ chatId }) => activeChatIds.has(chatId));
       }
 
-      getEvictedChatIds(): string[] {
-        return this.state.evictedChatIds;
+      getEvictedChatIds(activeChatIds?: ReadonlySet<string> | null): string[] {
+        if (!activeChatIds) return this.state.evictedChatIds;
+        return this.state.evictedChatIds.filter((chatId) => activeChatIds.has(chatId));
       }
 
-      getSessionRuntimeStates(): FakeSessionState["runtimeStates"] {
-        return this.state.runtimeStates;
+      getSessionRuntimeStates(activeChatIds?: ReadonlySet<string> | null): FakeSessionState["runtimeStates"] {
+        if (!activeChatIds) return this.state.runtimeStates;
+        return this.state.runtimeStates.filter(({ chatId }) => activeChatIds.has(chatId));
       }
 
       getAggregateRuntimeState(): FakeSessionState["aggregateRuntimeState"] {
@@ -216,8 +225,9 @@ function installMocks(options: { syncResult?: MockState["syncResult"]; syncDelay
         this.state.applyStaleChatIds(chatIds);
       }
 
-      getHeldChatIds(): string[] {
-        return this.state.heldChatIds;
+      getHeldChatIds(activeChatIds?: ReadonlySet<string> | null): string[] {
+        if (!activeChatIds) return this.state.heldChatIds;
+        return this.state.heldChatIds.filter((chatId) => activeChatIds.has(chatId));
       }
 
       shutdown(): Promise<void> {
@@ -233,6 +243,8 @@ async function makeSlot(options?: {
   agent?: RegisterResult;
   configError?: unknown;
   configErrorsThenSucceed?: { error: unknown; times: number };
+  activeRuntimeChatIds?: string[];
+  activeRuntimeChatIdsError?: unknown;
   runtimeType?: string;
   syncResult?: MockState["syncResult"];
   syncDelayMs?: number;
@@ -248,6 +260,8 @@ async function makeSlot(options?: {
     agent: options?.agent,
     configError: options?.configError,
     configErrorsThenSucceed: options?.configErrorsThenSucceed,
+    activeRuntimeChatIds: options?.activeRuntimeChatIds,
+    activeRuntimeChatIdsError: options?.activeRuntimeChatIdsError,
   });
   const connection = new FakeClientConnection(sdk);
   const { AgentSlot } = await import("../runtime/agent-slot.js");
@@ -521,6 +535,57 @@ describe("AgentSlot", () => {
 
     connection.emit("inbox:deliver", "inbox-1", makeFrame({ entryId: 99 }));
     expect(session.dispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the active runtime chat set for full-state sync and optimistic-adds delivered chats", async () => {
+    const { slot, connection, sdk, state } = await makeSlot({ activeRuntimeChatIds: ["chat-1"] });
+
+    await slot.start();
+    const session = state.sessions[0];
+    if (!session) throw new Error("session missing");
+
+    expect(vi.mocked(sdk.listActiveRuntimeChatIds)).toHaveBeenCalledTimes(1);
+    expect(connection.reportSessionState).toHaveBeenCalledWith("agent-1", "chat-1", "active");
+    expect(connection.reportSessionState).not.toHaveBeenCalledWith("agent-1", "chat-evicted", "suspended");
+
+    const reconcile = Reflect.get(slot, "reconcileNow");
+    if (typeof reconcile !== "function") throw new Error("private method missing");
+
+    connection.sendSessionReconcile.mockClear();
+    session.heldChatIds = ["chat-1", "chat-2"];
+    reconcile.call(slot);
+    expect(connection.sendSessionReconcile).toHaveBeenCalledWith("agent-1", ["chat-1"]);
+
+    connection.emit("inbox:deliver", "inbox-1", makeFrame({ chatId: "chat-2" }));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    connection.sendSessionReconcile.mockClear();
+    reconcile.call(slot);
+    expect(connection.sendSessionReconcile).toHaveBeenCalledWith("agent-1", ["chat-1", "chat-2"]);
+
+    await slot.stop();
+  });
+
+  it("chunks reconcile frames so a large held set never exceeds the wire schema limit", async () => {
+    const chatIds = Array.from({ length: 501 }, (_, i) => `chat-${i}`);
+    const { slot, connection, state } = await makeSlot({ activeRuntimeChatIds: chatIds });
+
+    await slot.start();
+    const session = state.sessions[0];
+    if (!session) throw new Error("session missing");
+    session.heldChatIds = chatIds;
+
+    const reconcile = Reflect.get(slot, "reconcileNow");
+    if (typeof reconcile !== "function") throw new Error("private method missing");
+    connection.sendSessionReconcile.mockClear();
+    reconcile.call(slot);
+
+    expect(connection.sendSessionReconcile).toHaveBeenCalledTimes(2);
+    expect(connection.sendSessionReconcile).toHaveBeenNthCalledWith(1, "agent-1", chatIds.slice(0, 500));
+    expect(connection.sendSessionReconcile).toHaveBeenNthCalledWith(2, "agent-1", chatIds.slice(500));
+
+    await slot.stop();
   });
 
   it("starts the bind-time reconcile grace window after startup full state sync", async () => {

--- a/packages/client/src/__tests__/agent-slot.test.ts
+++ b/packages/client/src/__tests__/agent-slot.test.ts
@@ -36,6 +36,12 @@ type MockState = {
   sessionConfigs: unknown[];
 };
 
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
+};
+
 class FakeClientConnection extends EventEmitter {
   bindAgent = vi.fn(async () => ({ sdk: this.sdk }));
   unbindAgent = vi.fn(async () => {});
@@ -60,6 +66,16 @@ function makeLogger(): FakeLogger {
   };
   logger.child.mockReturnValue(logger);
   return logger;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
 }
 
 function makeAgent(overrides: Partial<RegisterResult> = {}): RegisterResult {
@@ -586,6 +602,35 @@ describe("AgentSlot", () => {
     expect(connection.sendSessionReconcile).toHaveBeenNthCalledWith(2, "agent-1", chatIds.slice(500));
 
     await slot.stop();
+  });
+
+  it("does not resurrect the active runtime chat refresh timer after stop", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    const { slot, connection, sdk } = await makeSlot({ omitReconcileInterval: true });
+
+    await slot.start();
+    expect(vi.mocked(sdk.listActiveRuntimeChatIds)).toHaveBeenCalledTimes(1);
+
+    const refresh = deferred<{ chatIds: string[] }>();
+    vi.mocked(sdk.listActiveRuntimeChatIds).mockImplementationOnce(() => refresh.promise);
+    await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
+    expect(vi.mocked(sdk.listActiveRuntimeChatIds)).toHaveBeenCalledTimes(2);
+
+    const unbind = deferred<void>();
+    connection.unbindAgent.mockImplementationOnce(() => unbind.promise);
+    const stopPromise = slot.stop();
+    await Promise.resolve();
+
+    refresh.resolve({ chatIds: ["chat-1"] });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    await vi.advanceTimersByTimeAsync(2 * 60 * 60 * 1000);
+    expect(vi.mocked(sdk.listActiveRuntimeChatIds)).toHaveBeenCalledTimes(2);
+
+    unbind.resolve();
+    await stopPromise;
   });
 
   it("starts the bind-time reconcile grace window after startup full state sync", async () => {

--- a/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
+++ b/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
@@ -238,6 +238,28 @@ afterEach(() => {
 });
 
 describe("SessionManager edge coverage", () => {
+  it("filters runtime sync by active set while force-keeping queued work", async () => {
+    const sm = makeManager();
+    const i = internals(sm);
+    i.sessions.set("chat-active", makeSessionRecord("chat-active"));
+    i.sessions.set("chat-archived", makeSessionRecord("chat-archived"));
+    i.sessions.set("chat-pending", makeSessionRecord("chat-pending"));
+    i.evictedMappings.set("chat-evicted-active", { claudeSessionId: "evicted-active", lastActivity: 1 });
+    i.evictedMappings.set("chat-evicted-archived", { claudeSessionId: "evicted-archived", lastActivity: 2 });
+    i.pendingQueue.push({ chatId: "chat-pending", message: makeMessage("chat-pending"), deliveryKind: "fresh" });
+
+    const activeSet = new Set(["chat-active", "chat-evicted-active"]);
+
+    expect(sm.getHeldChatIds(activeSet)).toEqual(["chat-active", "chat-pending", "chat-evicted-active"]);
+    expect(sm.getSessionStates(activeSet)).toEqual([
+      { chatId: "chat-active", state: "suspended" },
+      { chatId: "chat-pending", state: "suspended" },
+    ]);
+    expect(sm.getEvictedChatIds(activeSet)).toEqual(["chat-evicted-active"]);
+
+    await sm.shutdown();
+  });
+
   it("refreshes newer config before dispatch and logs refresh failures without blocking delivery", async () => {
     const okCache = makeCache();
     const okHandler = handler();

--- a/packages/client/src/runtime/agent-slot.ts
+++ b/packages/client/src/runtime/agent-slot.ts
@@ -98,6 +98,7 @@ export class AgentSlot {
   private activeRuntimeChatIds: Set<string> | null = null;
   private activeRuntimeChatIdsRefreshTimer: ReturnType<typeof setTimeout> | null = null;
   private activeRuntimeChatIdsRefreshInFlight: Promise<void> | null = null;
+  private activeRuntimeChatIdsRefreshGeneration = 0;
   private reconcileTimer: ReturnType<typeof setInterval> | null = null;
   private postBindReconcileTimer: ReturnType<typeof setTimeout> | null = null;
   private listeners: ConnectionListener[] = [];
@@ -227,6 +228,7 @@ export class AgentSlot {
       bindSucceeded = true;
       const sdk = bound.sdk;
       this.sdk = sdk;
+      this.activeRuntimeChatIdsRefreshGeneration++;
       const agent = await sdk.register();
 
       this.logger.info({ displayName: agent.displayName }, "agent bound");
@@ -437,6 +439,7 @@ export class AgentSlot {
 
   private async stopOnce(): Promise<void> {
     this.bringupAbort?.abort();
+    this.activeRuntimeChatIdsRefreshGeneration++;
     if (this.reconcileTimer) {
       clearInterval(this.reconcileTimer);
       this.reconcileTimer = null;
@@ -466,6 +469,7 @@ export class AgentSlot {
 
   private async cleanupFailedStart(opts: { unbind: boolean }): Promise<void> {
     this.bringupAbort?.abort();
+    this.activeRuntimeChatIdsRefreshGeneration++;
     if (this.reconcileTimer) {
       clearInterval(this.reconcileTimer);
       this.reconcileTimer = null;
@@ -598,27 +602,35 @@ export class AgentSlot {
   }
 
   private scheduleActiveRuntimeChatIdsRefresh(): void {
+    if (!this.sdk) return;
+    const generation = this.activeRuntimeChatIdsRefreshGeneration;
     if (this.activeRuntimeChatIdsRefreshTimer) clearTimeout(this.activeRuntimeChatIdsRefreshTimer);
     this.activeRuntimeChatIdsRefreshTimer = setTimeout(() => {
+      if (!this.isActiveRuntimeChatIdsRefreshLive(generation)) return;
       this.activeRuntimeChatIdsRefreshTimer = null;
-      void this.refreshActiveRuntimeChatIds("periodic").finally(() => this.scheduleActiveRuntimeChatIdsRefresh());
+      void this.refreshActiveRuntimeChatIds("periodic").finally(() => {
+        if (this.isActiveRuntimeChatIdsRefreshLive(generation)) {
+          this.scheduleActiveRuntimeChatIdsRefresh();
+        }
+      });
     }, jitteredActiveRuntimeChatIdsRefreshDelay());
   }
 
   private async refreshActiveRuntimeChatIds(reason: "startup" | "bind" | "periodic"): Promise<void> {
     const sdk = this.sdk;
     if (!sdk) return;
+    const generation = this.activeRuntimeChatIdsRefreshGeneration;
     if (this.activeRuntimeChatIdsRefreshInFlight) return this.activeRuntimeChatIdsRefreshInFlight;
 
     const refresh = sdk
       .listActiveRuntimeChatIds()
       .then(({ chatIds }) => {
-        if (this.sdk !== sdk) return;
+        if (this.sdk !== sdk || !this.isActiveRuntimeChatIdsRefreshLive(generation)) return;
         this.activeRuntimeChatIds = new Set(chatIds);
         this.logger.info({ count: chatIds.length, reason }, "active runtime chat ids refreshed");
       })
       .catch((err) => {
-        if (this.sdk !== sdk) return;
+        if (this.sdk !== sdk || !this.isActiveRuntimeChatIdsRefreshLive(generation)) return;
         this.logger.warn({ err, reason }, "active runtime chat ids refresh failed; keeping previous snapshot");
       })
       .finally(() => {
@@ -628,6 +640,10 @@ export class AgentSlot {
       });
     this.activeRuntimeChatIdsRefreshInFlight = refresh;
     await refresh;
+  }
+
+  private isActiveRuntimeChatIdsRefreshLive(generation: number): boolean {
+    return this.sdk !== null && this.activeRuntimeChatIdsRefreshGeneration === generation;
   }
 
   private schedulePostBindReconcile(): void {

--- a/packages/client/src/runtime/agent-slot.ts
+++ b/packages/client/src/runtime/agent-slot.ts
@@ -11,7 +11,7 @@ import { runtimeProviderSchema } from "@first-tree/shared";
 import { defaultDataDir } from "@first-tree/shared/config";
 import type { ClientConnection, SessionReconcileResult } from "../client-connection.js";
 import { createLogger, type pino } from "../observability/logger.js";
-import type { RegisterResult } from "../sdk.js";
+import type { FirstTreeHubSDK, RegisterResult } from "../sdk.js";
 import { type AgentConfigCache, createAgentConfigCache } from "./agent-config-cache.js";
 import { resolveAgentContextTreeBinding } from "./bootstrap.js";
 import type { SessionConfig } from "./config.js";
@@ -29,6 +29,9 @@ import { SessionManager } from "./session-manager.js";
  * gives up in bounded time instead of blocking bring-up forever.
  */
 const MAX_CONFIG_FETCH_ATTEMPTS = 8;
+const ACTIVE_RUNTIME_CHAT_IDS_REFRESH_MS = 60 * 60 * 1000;
+const ACTIVE_RUNTIME_CHAT_IDS_REFRESH_JITTER_RATIO = 0.1;
+const SESSION_RECONCILE_BATCH_SIZE = 500;
 
 /**
  * Sleep `ms`, resolving early if `signal` aborts. Lets a stop()/unbind during
@@ -49,6 +52,12 @@ function sleepWithAbort(ms: number, signal?: AbortSignal): Promise<void> {
     }, ms);
     signal?.addEventListener("abort", onAbort, { once: true });
   });
+}
+
+function jitteredActiveRuntimeChatIdsRefreshDelay(): number {
+  const offset =
+    (Math.random() * 2 - 1) * ACTIVE_RUNTIME_CHAT_IDS_REFRESH_MS * ACTIVE_RUNTIME_CHAT_IDS_REFRESH_JITTER_RATIO;
+  return ACTIVE_RUNTIME_CHAT_IDS_REFRESH_MS + offset;
 }
 
 export type AgentSlotConfig = {
@@ -85,6 +94,10 @@ export class AgentSlot {
   private readonly config: AgentSlotConfig;
   private logger: pino.Logger;
   private agentConfigCache: AgentConfigCache | null = null;
+  private sdk: FirstTreeHubSDK | null = null;
+  private activeRuntimeChatIds: Set<string> | null = null;
+  private activeRuntimeChatIdsRefreshTimer: ReturnType<typeof setTimeout> | null = null;
+  private activeRuntimeChatIdsRefreshInFlight: Promise<void> | null = null;
   private reconcileTimer: ReturnType<typeof setInterval> | null = null;
   private postBindReconcileTimer: ReturnType<typeof setTimeout> | null = null;
   private listeners: ConnectionListener[] = [];
@@ -175,12 +188,14 @@ export class AgentSlot {
         // reconcile. Reconnects with an existing SessionManager are handled
         // here.
         if (!this.sessionManager) return;
-        this.fullStateSync();
-        // One-shot post-bind reconcile catches operator-terminates that
-        // landed while this client was offline. It is deliberately scheduled
-        // after fullStateSync, so just-hydrated registry mappings are first
-        // advertised as suspended before the server is asked for stale rows.
-        this.schedulePostBindReconcile();
+        void this.refreshActiveRuntimeChatIds("bind").finally(() => {
+          this.fullStateSync();
+          // One-shot post-bind reconcile catches operator-terminates that
+          // landed while this client was offline. It is deliberately scheduled
+          // after fullStateSync, so just-hydrated registry mappings are first
+          // advertised as suspended before the server is asked for stale rows.
+          this.schedulePostBindReconcile();
+        });
       }
     };
     const onReconcileResult = (result: SessionReconcileResult) => {
@@ -211,6 +226,7 @@ export class AgentSlot {
       const bound = await this.clientConnection.bindAgent(this.config.agentId, runtimeType, this.config.runtimeVersion);
       bindSucceeded = true;
       const sdk = bound.sdk;
+      this.sdk = sdk;
       const agent = await sdk.register();
 
       this.logger.info({ displayName: agent.displayName }, "agent bound");
@@ -328,6 +344,7 @@ export class AgentSlot {
         }
       }
 
+      await this.refreshActiveRuntimeChatIds("startup");
       // Initial-startup fullStateSync. The `on("agent:bound", onBound)`
       // listener above also fires here now that it's attached pre-bind,
       // but `sessionManager` was null inside its callback — so its
@@ -336,6 +353,7 @@ export class AgentSlot {
       this.fullStateSync();
       this.schedulePostBindReconcile();
 
+      this.scheduleActiveRuntimeChatIdsRefresh();
       this.startReconcileLoop();
 
       return agent;
@@ -423,6 +441,10 @@ export class AgentSlot {
       clearInterval(this.reconcileTimer);
       this.reconcileTimer = null;
     }
+    if (this.activeRuntimeChatIdsRefreshTimer) {
+      clearTimeout(this.activeRuntimeChatIdsRefreshTimer);
+      this.activeRuntimeChatIdsRefreshTimer = null;
+    }
     if (this.postBindReconcileTimer) {
       clearTimeout(this.postBindReconcileTimer);
       this.postBindReconcileTimer = null;
@@ -435,6 +457,9 @@ export class AgentSlot {
     await this.sessionManager?.shutdown();
     this.sessionManager = null;
     this.agentConfigCache = null;
+    this.sdk = null;
+    this.activeRuntimeChatIds = null;
+    this.activeRuntimeChatIdsRefreshInFlight = null;
     this.inboxId = null;
     this.logger.info("stopped");
   }
@@ -444,6 +469,10 @@ export class AgentSlot {
     if (this.reconcileTimer) {
       clearInterval(this.reconcileTimer);
       this.reconcileTimer = null;
+    }
+    if (this.activeRuntimeChatIdsRefreshTimer) {
+      clearTimeout(this.activeRuntimeChatIdsRefreshTimer);
+      this.activeRuntimeChatIdsRefreshTimer = null;
     }
     if (this.postBindReconcileTimer) {
       clearTimeout(this.postBindReconcileTimer);
@@ -463,6 +492,9 @@ export class AgentSlot {
     await this.sessionManager?.shutdown();
     this.sessionManager = null;
     this.agentConfigCache = null;
+    this.sdk = null;
+    this.activeRuntimeChatIds = null;
+    this.activeRuntimeChatIdsRefreshInFlight = null;
     this.inboxId = null;
   }
 
@@ -484,13 +516,14 @@ export class AgentSlot {
 
   private fullStateSync(): void {
     if (!this.sessionManager) return;
+    const activeChatIds = this.activeRuntimeChatIds;
     // ORDERING IS LOAD-BEARING: `session:state` frames flush before any
     // `session:runtime` frame so the server's `setSessionRuntime` (gated
     // on `state='active'`) can't fail-close because the state write
     // hadn't landed yet. TCP/WS preserves the order across this single
     // send loop, and the server-side `chainSessionOp` per-(agent,chat)
     // queue preserves it through the processing pipeline as well.
-    for (const { chatId, state } of this.sessionManager.getSessionStates()) {
+    for (const { chatId, state } of this.sessionManager.getSessionStates(activeChatIds)) {
       this.clientConnection.reportSessionState(this.config.agentId, chatId, state);
     }
     // After a process restart `sessions` is empty but SessionRegistry just
@@ -500,7 +533,7 @@ export class AgentSlot {
     // (commonly `active`) forever — the next inbound message would only
     // refresh that one row, leaving the rest stale. "suspended" is the
     // closest in-schema state for "handler is gone but resumable".
-    for (const chatId of this.sessionManager.getEvictedChatIds()) {
+    for (const chatId of this.sessionManager.getEvictedChatIds(activeChatIds)) {
       this.clientConnection.reportSessionState(this.config.agentId, chatId, "suspended");
     }
     // Re-assert the *real* per-chat runtime of every still-live session.
@@ -509,7 +542,7 @@ export class AgentSlot {
     // from a process restart (where `sessions` is empty, so nothing here
     // reports `working` and the agent-global reset below settles
     // everything to idle).
-    for (const { chatId, runtimeState } of this.sessionManager.getSessionRuntimeStates()) {
+    for (const { chatId, runtimeState } of this.sessionManager.getSessionRuntimeStates(activeChatIds)) {
       this.clientConnection.reportSessionRuntime(this.config.agentId, chatId, runtimeState);
     }
     // Explicit "idle" clears any stale `working`/`blocked` on the server:
@@ -538,6 +571,8 @@ export class AgentSlot {
    */
   private async dispatchPushedFrame(frame: InboxDeliverFrame): Promise<void> {
     if (!this.sessionManager) return;
+    const chatId = frame.chatId ?? frame.message.chatId;
+    this.noteActiveRuntimeChat(chatId);
     const entry: InboxEntryWithMessage = {
       id: frame.entryId,
       inboxId: frame.inboxId,
@@ -562,6 +597,39 @@ export class AgentSlot {
     this.reconcileTimer = setInterval(() => this.reconcileNow(), intervalSec * 1000);
   }
 
+  private scheduleActiveRuntimeChatIdsRefresh(): void {
+    if (this.activeRuntimeChatIdsRefreshTimer) clearTimeout(this.activeRuntimeChatIdsRefreshTimer);
+    this.activeRuntimeChatIdsRefreshTimer = setTimeout(() => {
+      this.activeRuntimeChatIdsRefreshTimer = null;
+      void this.refreshActiveRuntimeChatIds("periodic").finally(() => this.scheduleActiveRuntimeChatIdsRefresh());
+    }, jitteredActiveRuntimeChatIdsRefreshDelay());
+  }
+
+  private async refreshActiveRuntimeChatIds(reason: "startup" | "bind" | "periodic"): Promise<void> {
+    const sdk = this.sdk;
+    if (!sdk) return;
+    if (this.activeRuntimeChatIdsRefreshInFlight) return this.activeRuntimeChatIdsRefreshInFlight;
+
+    const refresh = sdk
+      .listActiveRuntimeChatIds()
+      .then(({ chatIds }) => {
+        if (this.sdk !== sdk) return;
+        this.activeRuntimeChatIds = new Set(chatIds);
+        this.logger.info({ count: chatIds.length, reason }, "active runtime chat ids refreshed");
+      })
+      .catch((err) => {
+        if (this.sdk !== sdk) return;
+        this.logger.warn({ err, reason }, "active runtime chat ids refresh failed; keeping previous snapshot");
+      })
+      .finally(() => {
+        if (this.activeRuntimeChatIdsRefreshInFlight === refresh) {
+          this.activeRuntimeChatIdsRefreshInFlight = null;
+        }
+      });
+    this.activeRuntimeChatIdsRefreshInFlight = refresh;
+    await refresh;
+  }
+
   private schedulePostBindReconcile(): void {
     if (this.postBindReconcileTimer) clearTimeout(this.postBindReconcileTimer);
     this.postBindReconcileTimer = setTimeout(() => {
@@ -572,9 +640,18 @@ export class AgentSlot {
 
   private reconcileNow(): void {
     if (!this.sessionManager) return;
-    const chatIds = this.sessionManager.getHeldChatIds();
+    const chatIds = this.sessionManager.getHeldChatIds(this.activeRuntimeChatIds);
     if (chatIds.length === 0) return;
-    this.clientConnection.sendSessionReconcile(this.config.agentId, chatIds);
+    for (let index = 0; index < chatIds.length; index += SESSION_RECONCILE_BATCH_SIZE) {
+      this.clientConnection.sendSessionReconcile(
+        this.config.agentId,
+        chatIds.slice(index, index + SESSION_RECONCILE_BATCH_SIZE),
+      );
+    }
+  }
+
+  private noteActiveRuntimeChat(chatId: string): void {
+    this.activeRuntimeChatIds?.add(chatId);
   }
 }
 

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -118,6 +118,7 @@ type PendingMessage = {
 type SlotDeliveryKind = "fresh" | "recovery" | "control";
 
 type SessionCommandType = "session:suspend" | "session:resume" | "session:terminate";
+type RuntimeSyncActiveSet = ReadonlySet<string> | null;
 
 /**
  * Resolve the directory the runtime reads markdown doc snapshots against —
@@ -686,11 +687,15 @@ export class SessionManager {
     }
   }
 
-  /** Chat IDs this client still holds locally (sessions + evictedMappings). */
-  getHeldChatIds(): string[] {
+  /** Chat IDs this client still holds locally and should report to runtime sync. */
+  getHeldChatIds(activeChatIds: RuntimeSyncActiveSet = null): string[] {
     const ids = new Set<string>();
-    for (const id of this.sessions.keys()) ids.add(id);
-    for (const id of this.evictedMappings.keys()) ids.add(id);
+    for (const id of this.sessions.keys()) {
+      if (this.shouldIncludeInRuntimeSync(id, activeChatIds)) ids.add(id);
+    }
+    for (const id of this.evictedMappings.keys()) {
+      if (this.shouldIncludeInRuntimeSync(id, activeChatIds)) ids.add(id);
+    }
     return [...ids];
   }
 
@@ -778,11 +783,13 @@ export class SessionManager {
   }
 
   /** Return all current session states for full state sync after reconnect. */
-  getSessionStates(): Array<{ chatId: string; state: SessionState }> {
-    return [...this.sessions.entries()].map(([chatId, entry]) => ({
-      chatId,
-      state: entry.status,
-    }));
+  getSessionStates(activeChatIds: RuntimeSyncActiveSet = null): Array<{ chatId: string; state: SessionState }> {
+    return [...this.sessions.entries()]
+      .filter(([chatId]) => this.shouldIncludeInRuntimeSync(chatId, activeChatIds))
+      .map(([chatId, entry]) => ({
+        chatId,
+        state: entry.status,
+      }));
   }
 
   /**
@@ -793,8 +800,8 @@ export class SessionManager {
    * stuck on a pre-restart "active" snapshot when the in-memory handler is
    * actually gone.
    */
-  getEvictedChatIds(): string[] {
-    return [...this.evictedMappings.keys()];
+  getEvictedChatIds(activeChatIds: RuntimeSyncActiveSet = null): string[] {
+    return [...this.evictedMappings.keys()].filter((chatId) => this.shouldIncludeInRuntimeSync(chatId, activeChatIds));
   }
 
   /**
@@ -820,6 +827,18 @@ export class SessionManager {
 
   private hasLocalRecoveryRisk(chatId: string): boolean {
     return this.evictedMappings.has(chatId) || this.sessions.get(chatId)?.status === "evicted";
+  }
+
+  private shouldIncludeInRuntimeSync(chatId: string, activeChatIds: RuntimeSyncActiveSet): boolean {
+    if (activeChatIds === null) return true;
+    if (activeChatIds.has(chatId)) return true;
+    return this.hasRuntimeSyncForceKeep(chatId);
+  }
+
+  private hasRuntimeSyncForceKeep(chatId: string): boolean {
+    if (this.pendingQueue.some((queued) => queued.chatId === chatId)) return true;
+    if (this.hasPendingTransientRetry(chatId)) return true;
+    return this.inboxDelivery.hasUnsettledWork(chatId);
   }
 
   private clearRetryState(entry: SessionEntry): void {
@@ -2154,9 +2173,12 @@ export class SessionManager {
    * idling. Only `status === 'active'` sessions are returned; a session
    * with no recorded runtime defaults to `idle`.
    */
-  getSessionRuntimeStates(): Array<{ chatId: string; runtimeState: RuntimeState }> {
+  getSessionRuntimeStates(
+    activeChatIds: RuntimeSyncActiveSet = null,
+  ): Array<{ chatId: string; runtimeState: RuntimeState }> {
     const out: Array<{ chatId: string; runtimeState: RuntimeState }> = [];
     for (const [chatId, session] of this.sessions) {
+      if (!this.shouldIncludeInRuntimeSync(chatId, activeChatIds)) continue;
       const runtimeState = this.projectedRuntimeState(chatId, session);
       if (!runtimeState) continue;
       out.push({ chatId, runtimeState });

--- a/packages/client/src/sdk.ts
+++ b/packages/client/src/sdk.ts
@@ -1,4 +1,5 @@
 import {
+  type ActiveRuntimeChatIdsResponse,
   AGENT_SELECTOR_HEADER,
   type Agent,
   type AgentRuntimeConfig,
@@ -316,6 +317,10 @@ export class FirstTreeHubSDK {
 
   async listChats(options?: { limit?: number; cursor?: string }): Promise<PaginatedResult<Chat>> {
     return this.requestJson(`/api/v1/agent/chats${this.queryString(options)}`);
+  }
+
+  async listActiveRuntimeChatIds(): Promise<ActiveRuntimeChatIdsResponse> {
+    return this.requestJson<ActiveRuntimeChatIdsResponse>("/api/v1/agent/chats/active-runtime-ids");
   }
 
   /**

--- a/packages/server/src/__tests__/agent-chats.test.ts
+++ b/packages/server/src/__tests__/agent-chats.test.ts
@@ -7,7 +7,7 @@ import { members } from "../db/schema/members.js";
 import { messages } from "../db/schema/messages.js";
 import { suspendAgent } from "../services/agent.js";
 import { resolveTargetChat } from "../services/github-entity-chat.js";
-import { createMeChat, leaveMeChat } from "../services/me-chat.js";
+import { createMeChat, leaveMeChat, setChatEngagement } from "../services/me-chat.js";
 import { createTestAdmin, createTestAgent, useTestApp } from "./helpers.js";
 
 describe("Agent Chats API", () => {
@@ -32,6 +32,30 @@ describe("Agent Chats API", () => {
     const getRes = await a.request("GET", `/api/v1/agent/chats/${chat.id}`);
     expect(getRes.statusCode).toBe(200);
     expect(getRes.json().id).toBe(chat.id);
+  });
+
+  it("lists active runtime chat ids for the current human scope", async () => {
+    const app = getApp();
+    const runtime = await createTestAgent(app, { name: "active-runtime-route" });
+    const active = await createMeChat(app.db, runtime.humanAgentUuid, runtime.organizationId, {
+      participantIds: [runtime.agent.uuid],
+    });
+    const archived = await createMeChat(app.db, runtime.humanAgentUuid, runtime.organizationId, {
+      participantIds: [runtime.agent.uuid],
+    });
+    const deleted = await createMeChat(app.db, runtime.humanAgentUuid, runtime.organizationId, {
+      participantIds: [runtime.agent.uuid],
+    });
+    await setChatEngagement(app.db, archived.chatId, runtime.humanAgentUuid, "archived");
+    await setChatEngagement(app.db, deleted.chatId, runtime.humanAgentUuid, "deleted");
+
+    const res = await runtime.request("GET", "/api/v1/agent/chats/active-runtime-ids");
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ chatIds: string[] }>();
+    expect(body.chatIds).toContain(active.chatId);
+    expect(body.chatIds).not.toContain(archived.chatId);
+    expect(body.chatIds).not.toContain(deleted.chatId);
   });
 
   it("creates a task chat with an initial message, woken recipients, and silent context participants", async () => {

--- a/packages/server/src/__tests__/me-chat-service.test.ts
+++ b/packages/server/src/__tests__/me-chat-service.test.ts
@@ -29,6 +29,7 @@
 import { eq, sql } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 import { users } from "../db/schema/users.js";
+import { listActiveRuntimeChatIds } from "../services/chat.js";
 import { applyAfterFanOut } from "../services/chat-projection.js";
 import {
   addMeChatParticipants,
@@ -853,6 +854,34 @@ describe("chat-first workspace service layer", () => {
     expect(ids).toContain(stays.chatId);
     expect(ids).not.toContain(hides.chatId);
     expect(ids).not.toContain(gone.chatId);
+  });
+
+  it("listActiveRuntimeChatIds returns the runtime agent's non-archived chats for the current human scope", async () => {
+    const app = getApp();
+    const runtime = await createTestAgent(app, { name: "active-runtime-set" });
+
+    const active = await createMeChat(app.db, runtime.humanAgentUuid, runtime.organizationId, {
+      participantIds: [runtime.agent.uuid],
+    });
+    const archived = await createMeChat(app.db, runtime.humanAgentUuid, runtime.organizationId, {
+      participantIds: [runtime.agent.uuid],
+    });
+    const deleted = await createMeChat(app.db, runtime.humanAgentUuid, runtime.organizationId, {
+      participantIds: [runtime.agent.uuid],
+    });
+    await setChatEngagement(app.db, archived.chatId, runtime.humanAgentUuid, "archived");
+    await setChatEngagement(app.db, deleted.chatId, runtime.humanAgentUuid, "deleted");
+
+    const ids = await listActiveRuntimeChatIds(
+      app.db,
+      runtime.agent.uuid,
+      runtime.humanAgentUuid,
+      runtime.organizationId,
+    );
+
+    expect(ids).toContain(active.chatId);
+    expect(ids).not.toContain(archived.chatId);
+    expect(ids).not.toContain(deleted.chatId);
   });
 
   it("listMeChats ?engagement=archived shows only archived rows", async () => {

--- a/packages/server/src/api/agent/chats.ts
+++ b/packages/server/src/api/agent/chats.ts
@@ -1,4 +1,5 @@
 import {
+  activeRuntimeChatIdsResponseSchema,
   addParticipantSchema,
   createTaskChatSchema,
   followGithubEntityRequestSchema,
@@ -6,8 +7,10 @@ import {
   paginationQuerySchema,
   updateChatSchema,
 } from "@first-tree/shared";
+import { and, eq } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
-import { BadRequestError } from "../../errors.js";
+import { members } from "../../db/schema/members.js";
+import { BadRequestError, ForbiddenError } from "../../errors.js";
 import { requireAgent } from "../../middleware/require-identity.js";
 import { createLogger } from "../../observability/index.js";
 import * as chatService from "../../services/chat.js";
@@ -90,6 +93,33 @@ export async function agentChatRoutes(app: FastifyInstance): Promise<void> {
       items: result.items.map(serializeChat),
       nextCursor: result.nextCursor,
     };
+  });
+
+  app.get("/active-runtime-ids", async (request) => {
+    const identity = requireAgent(request);
+    const user = request.user;
+    if (!user) throw new ForbiddenError("User authentication required");
+
+    const [member] = await app.db
+      .select({ humanAgentId: members.agentId })
+      .from(members)
+      .where(
+        and(
+          eq(members.userId, user.userId),
+          eq(members.organizationId, identity.organizationId),
+          eq(members.status, "active"),
+        ),
+      )
+      .limit(1);
+    if (!member) throw new ForbiddenError("Agent belongs to an organization the caller is not a member of");
+
+    const chatIds = await chatService.listActiveRuntimeChatIds(
+      app.db,
+      identity.uuid,
+      member.humanAgentId,
+      identity.organizationId,
+    );
+    return activeRuntimeChatIdsResponseSchema.parse({ chatIds });
   });
 
   app.get<{ Params: { chatId: string } }>("/:chatId", async (request) => {

--- a/packages/server/src/services/chat.ts
+++ b/packages/server/src/services/chat.ts
@@ -3,6 +3,7 @@ import {
   type AddParticipant,
   AGENT_STATUSES,
   AGENT_TYPES,
+  CHAT_ENGAGEMENT_STATUSES,
   type LegacyCreateChat,
   type SendMessage,
 } from "@first-tree/shared";
@@ -10,6 +11,7 @@ import { and, desc, eq, inArray, lt, sql } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 import { agents } from "../db/schema/agents.js";
 import { chatMembership } from "../db/schema/chat-membership.js";
+import { chatUserState } from "../db/schema/chat-user-state.js";
 import { chats } from "../db/schema/chats.js";
 import { members } from "../db/schema/members.js";
 import { messages } from "../db/schema/messages.js";
@@ -657,6 +659,39 @@ export async function getChatDetail(db: Database, chatId: string, selfAgentId: s
   const viewerMembershipKind = await resolveViewerMembershipKind(db, chatId, selfAgentId);
 
   return { ...chat, participants, title, firstMessagePreview, viewerMembershipKind };
+}
+
+/**
+ * Runtime active-set projection for one agent and the human user operating the
+ * current client. This is intentionally smaller than "all chats where the
+ * agent is a speaker": archived/deleted rows are not part of the user's active
+ * working set, so clean idle local sessions for those chats do not need
+ * periodic runtime projection.
+ */
+export async function listActiveRuntimeChatIds(
+  db: Database,
+  agentId: string,
+  humanAgentId: string,
+  organizationId: string,
+): Promise<string[]> {
+  const rows = await db.execute<{ chat_id: string }>(sql`
+    SELECT DISTINCT agent_membership.chat_id
+      FROM ${chatMembership} AS agent_membership
+      JOIN ${chats}
+        ON ${chats.id} = agent_membership.chat_id
+      JOIN ${chatMembership} AS viewer_membership
+        ON viewer_membership.chat_id = agent_membership.chat_id
+       AND viewer_membership.agent_id = ${humanAgentId}
+      LEFT JOIN ${chatUserState}
+        ON ${chatUserState.chatId} = agent_membership.chat_id
+       AND ${chatUserState.agentId} = ${humanAgentId}
+     WHERE agent_membership.agent_id = ${agentId}
+       AND agent_membership.access_mode = 'speaker'
+       AND ${chats.organizationId} = ${organizationId}
+       AND COALESCE(${chatUserState.engagementStatus}, ${CHAT_ENGAGEMENT_STATUSES.ACTIVE}) = ${CHAT_ENGAGEMENT_STATUSES.ACTIVE}
+     ORDER BY agent_membership.chat_id ASC
+  `);
+  return rows.map((row) => row.chat_id);
 }
 
 async function resolveViewerMembershipKind(

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -30,6 +30,10 @@ export {
 // -- OAuth-callback open-redirect guard --
 export { DEFAULT_SAFE_REDIRECT, safeRedirectPath } from "./safe-redirect.js";
 export {
+  type ActiveRuntimeChatIdsResponse,
+  activeRuntimeChatIdsResponseSchema,
+} from "./schemas/active-runtime-chats.js";
+export {
   AGENT_NAME_MAX_LENGTH,
   AGENT_NAME_REGEX,
   AGENT_SOURCES,

--- a/packages/shared/src/schemas/active-runtime-chats.ts
+++ b/packages/shared/src/schemas/active-runtime-chats.ts
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const activeRuntimeChatIdsResponseSchema = z.object({
+  chatIds: z.array(z.string().min(1)),
+});
+export type ActiveRuntimeChatIdsResponse = z.infer<typeof activeRuntimeChatIdsResponseSchema>;


### PR DESCRIPTION
## Summary

- add an agent-scoped active runtime chat id endpoint for the current user's non-archived working set
- filter client full-state sync and reconcile to `(localHeldSet ∩ activeSet) ∪ forceKeepSet`, preserving queued/retry/unsettled delivery work
- refresh the active set on startup/bind/hourly jitter, optimistic-add newly delivered chats, and chunk reconcile frames at 500 ids

## Background

`session:reconcile` frames were rejected as malformed when a client held more than 500 local chat ids. The local held set can be larger than the wire schema limit because it combines live sessions and evicted mappings; one observed shape was `1 suspended + 500 evicted = 501`.

This keeps local runtime cache retention separate from the smaller periodic reconcile/full-state-sync projection. Archived chats are not deleted locally; clean idle archived sessions simply stop participating in periodic runtime projection until the chat is active again.

## Validation

- `pnpm --filter @first-tree/client exec vitest run src/__tests__/agent-slot.test.ts src/__tests__/session-manager-edge-coverage.test.ts --maxWorkers=2`
- `pnpm --filter @first-tree/server exec vitest run src/__tests__/me-chat-service.test.ts --maxWorkers=2`
- `pnpm --filter @first-tree/server exec vitest run src/__tests__/agent-chats.test.ts --maxWorkers=2`
- `pnpm --filter @first-tree/shared typecheck && pnpm --filter @first-tree/client typecheck && pnpm --filter @first-tree/server typecheck`
- `pnpm check`
- `TMPDIR=/var/tmp/first-tree-tests pnpm exec turbo run test --concurrency=2 --env-mode=loose -- --maxWorkers=2`
