### PR TITLE
Add provider-neutral skill eval runner

### DIFF
--- a/packages/skill-evals/README.md
+++ b/packages/skill-evals/README.md
@@ -16,6 +16,7 @@ pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-welcome
 pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-seed
 pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-seed --include-quality
 pnpm --filter @first-tree/skill-evals eval:periodic
+pnpm --filter @first-tree/skill-evals eval:periodic -- --suite first-tree-read
 pnpm --filter @first-tree/skill-evals eval:periodic -- --suite first-tree-seed
 pnpm --filter @first-tree/skill-evals eval:periodic -- --suite first-tree-welcome
 pnpm --filter @first-tree/skill-evals eval:quality
@@ -45,6 +46,9 @@ pnpm --filter @first-tree/skill-evals eval:select -- --base main --json
 The selector is intentionally conservative for shared skill-eval
 infrastructure: core runner or schema changes recommend floor plus all
 implemented deterministic gates, and judge-core changes also recommend quality.
+Provider runner changes additionally recommend the provider-sensitive
+`first-tree-read` periodic fixture. This is limited to provider infrastructure
+changes; ordinary skill changes still do not recommend periodic.
 Suite or skill changes recommend that suite's floor/gate/quality coverage where
 implemented. The command only recommends; live gate and quality evals remain
 opt-in and are not part of `pnpm test`.
@@ -52,17 +56,20 @@ opt-in and are not part of `pnpm test`.
 `eval:periodic` is the opt-in tier for broader, more expensive coverage that is
 not suitable for default gates or ordinary CI. It accepts the same basic live
 eval controls as gates, including `--suite`, `--case`, `--model`,
-`--codex-bin`, `--json`, and `--verbose`. `first-tree-welcome` periodic now
-runs the concrete setup-state matrix rows as live eval cases while keeping the
-default welcome gate limited to its three high-risk rows. `first-tree-seed`
-periodic runs a real-repo realism case that builds a per-run bare source
-fixture from the current `first-tree` repo `HEAD` and still requires the seed
-bare-source worktree protocol. `eval:periodic` with no `--suite` runs all
-implemented periodic suites in one result-store run group. Suites without
-implemented periodic cases still print a clear no-op summary and exit 0. Future
-PRs will add multi-provider/runtime-generated periodic coverage. The default
-`eval:select` recommendations do not include periodic for ordinary skill
-changes; maintainers trigger periodic manually or via future scheduling.
+`--provider`, `--codex-bin`, `--claude-bin`, `--json`, and `--verbose`.
+`first-tree-read` periodic runs a runtime-generated briefing fixture with the
+installed First Tree skill topology; it is fixture coverage for the generated
+briefing boundary, not a live First Tree Cloud/session E2E. `first-tree-welcome`
+periodic runs the concrete setup-state matrix rows as live eval cases while
+keeping the default welcome gate limited to its three high-risk rows.
+`first-tree-seed` periodic runs a real-repo realism case that builds a per-run
+bare source fixture from the current `first-tree` repo `HEAD` and still
+requires the seed bare-source worktree protocol. `eval:periodic` with no
+`--suite` runs all implemented periodic suites in one result-store run group.
+Suites without implemented periodic cases still print a clear no-op summary and
+exit 0. The default `eval:select` recommendations do not include periodic for
+ordinary skill changes; maintainers trigger periodic manually or via future
+scheduling.
 
 `eval:quality` is an opt-in LLM-as-judge layer. It does not replace
 deterministic gates and is not called by `eval:gate` by default. Each quality
@@ -94,7 +101,7 @@ guards for common external side-effect commands such as `git`, `gh`,
 `first-tree`, `curl`, and `wget`. This is a guardrail for the text judge; it is
 not a substitute for a future direct no-tools judge API.
 
-`eval:gate -- --suite first-tree-read` runs the live Codex gate for
+`eval:gate -- --suite first-tree-read` runs the live tested-agent gate for
 `first-tree-read`. It covers the existing read cases through the shared gate
 runner:
 
@@ -104,7 +111,15 @@ runner:
   expected durable facts;
 - Context Tree workspace + non-software prompt should not use `first-tree`.
 
-`eval:gate -- --suite first-tree-write` runs the live Codex gate for
+`eval:periodic -- --suite first-tree-read` runs
+`first-tree-read-runtime-generated-briefing-periodic`. The fixture writes a
+runtime-generated `AGENTS.md`/`CLAUDE.md` pair, installs the core onboarding
+skill plus tree-bound read/seed/write skills, binds a deterministic Context
+Tree fixture, and then runs the same read trigger oracle. This covers the
+generated-briefing and skill-topology boundary only; real Cloud chat delivery,
+GitHub webhooks, and live First Tree runtime E2E remain outside skill evals.
+
+`eval:gate -- --suite first-tree-write` runs the live tested-agent gate for
 `first-tree-write`. It covers the minimum source-boundary cases:
 
 - no source artifact means no Context Tree diff;
@@ -112,7 +127,7 @@ runner:
   `first-tree tree verify`;
 - implementation-only source material means no Context Tree diff.
 
-`eval:gate -- --suite first-tree-welcome` runs the live Codex gate for
+`eval:gate -- --suite first-tree-welcome` runs the live tested-agent gate for
 the currently implemented `first-tree-welcome` gate rows:
 
 - tree kickoff chat routes to the tree setup lane instead of welcome first-task
@@ -133,7 +148,7 @@ floor invariant because it is a structural fallback rather than a stable live
 oracle. Periodic case ids use the gate row id plus `-periodic`; `--case` also
 accepts the source row id as an alias.
 
-`eval:gate -- --suite first-tree-seed` runs the live Codex gate for
+`eval:gate -- --suite first-tree-seed` runs the live tested-agent gate for
 `first-tree-seed`. It covers the minimum bootstrap lifecycle boundaries:
 
 - empty tree + present bare source proposes only Phase 1 skeleton for user
@@ -163,22 +178,28 @@ periodic tier and is not part of the default seed gate.
 The runner creates isolated temporary workspaces under
 `packages/skill-evals/.runs/<timestamp>-<case-id>/`, installs
 the relevant skill, prepends command shims such as `first-tree` to `PATH`, and
-runs `codex exec --json` from the case workspace for live eval commands.
+runs the selected tested-agent provider from the case workspace for live eval
+commands. Codex is the default provider. Use `--provider claude --claude-bin
+<path>` to opt into the Claude provider, or `--provider codex --codex-bin
+<path>` to be explicit. Claude support is opt-in and is validated by no-quota
+fake-binary tests by default; real Claude live evals consume provider quota and
+must be triggered intentionally.
 Fixture validation runs `tree verify` through the per-run `first-tree` shim by
 default. To validate fixtures with an installed channel binary instead, set
 `FIRST_TREE_EVAL_VERIFY_BIN` to the desired executable, for example
 `FIRST_TREE_EVAL_VERIFY_BIN=first-tree-staging`.
-Live gate runs do not inherit the operator's full environment. The Codex
-process receives an allowlisted environment plus an isolated `HOME`, temp
-directory, and XDG cache/config directories under the case run root. The model
-shell runs with `shell_environment_policy.inherit=none`, only the eval shims and
-isolated paths are set explicitly, and Codex is invoked with
+Live gate and periodic runs do not inherit the operator's full environment. The
+selected provider receives an allowlisted environment plus an isolated `HOME`,
+temp directory, and XDG cache/config directories under the case run root. The
+Codex model shell runs with `shell_environment_policy.inherit=none`, only the
+eval shims and isolated paths are set explicitly, and Codex is invoked with
 `--ignore-user-config`, `--ignore-rules`, and `--sandbox workspace-write`.
 
 Each case writes:
 
-- `events.jsonl` with harness events, Codex JSONL events, and shimmed
-  `first-tree` invocations.
+- `events.jsonl` with harness events, provider JSONL events, and shimmed
+  `first-tree` invocations. Claude events are normalized into the existing
+  event shape used by deterministic graders.
 - `grading.json` with deterministic four-axis gate grading:
   `routing_pass`, `process_pass`, `outcome_pass`, and `risk_pass`, plus
   evidence and risk flags.

--- a/packages/skill-evals/src/core/__tests__/judge.test.ts
+++ b/packages/skill-evals/src/core/__tests__/judge.test.ts
@@ -1,6 +1,7 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { describe, expect, it } from "vitest";
 import {
@@ -38,6 +39,10 @@ const DIMENSIONS: readonly JudgeRubricDimension[] = [
 
 function tempPackageRoot(): string {
   return mkdtempSync(join(tmpdir(), "skill-evals-quality-test-"));
+}
+
+function repoPackageRoot(): string {
+  return resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
 }
 
 function fakeArtifactInput(): ReadonlyMap<string, QualityArtifactInput> {
@@ -222,11 +227,13 @@ describe("quality runner with fake judge", () => {
         packageRoot,
         {
           caseId: "first-tree-write-node-quality",
+          claudeBin: "unused",
           codexBin: "unused",
           judgeBin: "unused",
           judgeModel: null,
           json: false,
           model: null,
+          provider: "codex",
           suite: "first-tree-write",
           verbose: false,
         },
@@ -255,11 +262,13 @@ describe("quality runner with fake judge", () => {
         packageRoot,
         {
           caseId: "first-tree-write-node-quality",
+          claudeBin: "unused",
           codexBin: "unused",
           judgeBin: "unused",
           judgeModel: null,
           json: false,
           model: null,
+          provider: "codex",
           suite: "first-tree-write",
           verbose: false,
         },
@@ -285,11 +294,13 @@ describe("quality runner with fake judge", () => {
         packageRoot,
         {
           caseId: "first-tree-write-node-quality",
+          claudeBin: "unused",
           codexBin: "unused",
           judgeBin: "unused",
           judgeModel: null,
           json: false,
           model: null,
+          provider: "codex",
           suite: "first-tree-write",
           verbose: false,
         },
@@ -330,11 +341,13 @@ describe("quality runner with fake judge", () => {
         packageRoot,
         {
           caseId: "first-tree-seed-skeleton-quality",
+          claudeBin: "unused",
           codexBin: "unused",
           judgeBin: "unused",
           judgeModel: null,
           json: false,
           model: null,
+          provider: "codex",
           suite: "first-tree-seed",
           verbose: false,
         },
@@ -350,6 +363,46 @@ describe("quality runner with fake judge", () => {
       });
     } finally {
       rmSync(packageRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("uses the selected tested-agent provider for standalone quality prerequisite gates", async () => {
+    const packageRoot = repoPackageRoot();
+    const batch = await runQualityEval(
+      packageRoot,
+      {
+        caseId: "first-tree-seed-skeleton-quality",
+        claudeBin: "/bin/false",
+        codexBin: "/bin/false",
+        judgeBin: "unused",
+        judgeModel: null,
+        json: false,
+        model: "claude-test",
+        provider: "claude",
+        suite: "first-tree-seed",
+        verbose: false,
+      },
+      createFakeJudgeProvider(new Map()),
+    );
+
+    const qualityRunRoot = batch.cases[0]?.runRoot;
+    const gateRunRoot = batch.cases[0]?.gateRunRoot;
+    try {
+      expect(batch.failed).toBe(1);
+      expect(batch.cases[0]?.judge_model).toBe("not-run");
+      if (gateRunRoot === null || gateRunRoot === undefined) {
+        throw new Error("quality run did not record gate run root");
+      }
+      const gateEvents = readFileSync(join(gateRunRoot, "events.jsonl"), "utf8");
+      expect(gateEvents).toContain('"type":"claude_run_started"');
+      expect(gateEvents).not.toContain('"type":"codex_run_started"');
+    } finally {
+      if (qualityRunRoot !== null && qualityRunRoot !== undefined) {
+        rmSync(qualityRunRoot, { force: true, recursive: true });
+      }
+      if (gateRunRoot !== null && gateRunRoot !== undefined) {
+        rmSync(gateRunRoot, { force: true, recursive: true });
+      }
     }
   });
 });

--- a/packages/skill-evals/src/core/__tests__/observability.test.ts
+++ b/packages/skill-evals/src/core/__tests__/observability.test.ts
@@ -56,4 +56,26 @@ describe("run observability", () => {
       turns: null,
     });
   });
+
+  it("derives first response latency from Claude provider start events", () => {
+    const observability = deriveRunObservability([
+      {
+        timestamp: "2026-06-29T01:00:00.000Z",
+        type: "claude_run_started",
+      },
+      {
+        event: {
+          content: "Claude response.",
+          type: "assistant_message",
+        },
+        timestamp: "2026-06-29T01:00:02.000Z",
+        type: "codex_event",
+      },
+    ]);
+
+    expect(observability).toEqual({
+      firstResponseLatencyMs: 2000,
+      turns: 1,
+    });
+  });
 });

--- a/packages/skill-evals/src/core/__tests__/provider.test.ts
+++ b/packages/skill-evals/src/core/__tests__/provider.test.ts
@@ -5,6 +5,7 @@ import { delimiter, dirname, join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { readEvents } from "../events.js";
 import { createRunPaths } from "../paths.js";
+import { claudeProviderArgs, claudeProviderCommand, claudeProviderEnv, runClaudeProvider } from "../provider/claude.js";
 import { codexProviderArgs, codexProviderCommand, codexProviderEnv, runCodexProvider } from "../provider/codex.js";
 import type { ProviderRunContext, ProviderRunOptions } from "../provider/types.js";
 import { createEvalReporter } from "../reporter.js";
@@ -47,6 +48,7 @@ describe("codex provider runner hardening", () => {
         caseId: "provider-hardening-test",
         model: "gpt-test",
         prompt: "Run the eval case.",
+        provider: "codex",
         verbose: true,
       };
       const env = codexProviderEnv(options, context, {
@@ -129,6 +131,7 @@ describe("codex provider runner hardening", () => {
           caseId: "provider-hardening-test",
           model: null,
           prompt: "Run the eval case.",
+          provider: "codex",
           verbose: false,
         },
         context,
@@ -149,6 +152,130 @@ describe("codex provider runner hardening", () => {
             exitCode: 1,
             phase: "model",
             type: "first_tree_result",
+          }),
+        ]),
+      );
+    } finally {
+      rmSync(packageRoot, { force: true, recursive: true });
+    }
+  });
+});
+
+describe("claude provider runner hardening", () => {
+  it("runs Claude Code in print mode with an allowlisted environment", () => {
+    const packageRoot = tempPackageRoot();
+    try {
+      const claudeBinDir = join(packageRoot, "operator-claude-bin");
+      const operatorSecretBinDir = join(packageRoot, "operator-secret-bin");
+      mkdirSync(claudeBinDir, { recursive: true });
+      mkdirSync(operatorSecretBinDir, { recursive: true });
+      const claudeBin = join(claudeBinDir, "claude");
+      writeFileSync(claudeBin, "#!/bin/sh\nexit 0\n", "utf8");
+      chmodSync(claudeBin, 0o755);
+
+      const context = fakeContext(packageRoot);
+      const options: ProviderRunOptions = {
+        bin: "claude",
+        caseId: "provider-hardening-test",
+        model: "claude-test",
+        prompt: "Run the eval case.",
+        provider: "claude",
+        verbose: true,
+      };
+      const env = claudeProviderEnv(options, context, {
+        ANTHROPIC_API_KEY: "allowed",
+        FIRST_TREE_SERVER_URL: "https://example.invalid",
+        GH_TOKEN: "leaky-gh-token",
+        GIT_CONFIG_GLOBAL: "/tmp/leaky-gitconfig",
+        HOME: "/operator-home",
+        PATH: [operatorSecretBinDir, claudeBinDir].join(delimiter),
+      });
+      const args = claudeProviderArgs(options);
+
+      expect(claudeProviderCommand(options, { PATH: [operatorSecretBinDir, claudeBinDir].join(delimiter) })).toBe(
+        claudeBin,
+      );
+      expect(args).toEqual([
+        "-p",
+        "Run the eval case.",
+        "--output-format",
+        "stream-json",
+        "--verbose",
+        "--no-session-persistence",
+        "--permission-mode",
+        "bypassPermissions",
+        "--setting-sources",
+        "project",
+        "--model",
+        "claude-test",
+      ]);
+      expect(env.HOME).toBe(`${context.paths.runRoot}/provider-home`);
+      expect(env.TMPDIR).toBe(`${context.paths.runRoot}/provider-tmp`);
+      expect(env.XDG_CACHE_HOME).toBe(`${context.paths.runRoot}/provider-xdg-cache`);
+      expect(env.FIRST_TREE_EVAL_EVENTS).toBe(context.paths.modelEventsPath);
+      expect(env.ANTHROPIC_API_KEY).toBe("allowed");
+      expect(env.FIRST_TREE_SERVER_URL).toBeUndefined();
+      expect(env.GH_TOKEN).toBeUndefined();
+      expect(env.GIT_CONFIG_GLOBAL).toBeUndefined();
+      expect(env.PATH?.split(delimiter)).toEqual(
+        unique([context.paths.binDir, dirname(process.execPath), claudeBinDir, "/usr/local/bin", "/usr/bin", "/bin"]),
+      );
+      expect(env.PATH).not.toContain(operatorSecretBinDir);
+    } finally {
+      rmSync(packageRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("merges model-writable shim events and normalizes stream JSON for existing graders", async () => {
+    const packageRoot = tempPackageRoot();
+    try {
+      const claudeBinDir = join(packageRoot, "operator-claude-bin");
+      mkdirSync(claudeBinDir, { recursive: true });
+      const claudeBin = join(claudeBinDir, "claude");
+      writeFileSync(
+        claudeBin,
+        [
+          "#!/bin/sh",
+          "first-tree github issue list >/dev/null 2>/dev/null",
+          'printf \'%s\\n\' \'{"type":"assistant_message","content":"done"}\'',
+          "exit 0",
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+      chmodSync(claudeBin, 0o755);
+
+      const context = fakeContext(packageRoot);
+      createFirstTreeShim(context.paths);
+
+      const exitCode = await runClaudeProvider(
+        {
+          bin: claudeBin,
+          caseId: "provider-hardening-test",
+          model: null,
+          prompt: "Run the eval case.",
+          provider: "claude",
+          verbose: false,
+        },
+        context,
+      );
+
+      expect(exitCode).toBe(0);
+      const events = readEvents(context.paths.eventsPath);
+      expect(events).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            event: expect.objectContaining({ content: "done", type: "assistant_message" }),
+            type: "claude_event",
+          }),
+          expect.objectContaining({
+            event: expect.objectContaining({ content: "done", type: "assistant_message" }),
+            type: "codex_event",
+          }),
+          expect.objectContaining({
+            argv: ["github", "issue", "list"],
+            phase: "model",
+            type: "first_tree_call",
           }),
         ]),
       );

--- a/packages/skill-evals/src/core/__tests__/result-store.test.ts
+++ b/packages/skill-evals/src/core/__tests__/result-store.test.ts
@@ -223,6 +223,7 @@ describe("result store", () => {
       bounded: 4,
       useful: 3,
     });
+    expect(summary?.entries.find((candidate) => candidate.tier === "periodic")?.provider).toBe("codex");
     expect(summary?.flaky).toMatchObject({
       newFailures: 1,
       previousRunGroupId: "20260629T010000000Z-eval-gate",
@@ -235,6 +236,7 @@ describe("result store", () => {
     expect(formatted).toContain("Counts by skill: first-tree-welcome=2, first-tree-write=1");
     expect(formatted).toContain("First response latency: 350 ms");
     expect(formatted).toContain("first-tree-welcome:periodic:welcome-full-matrix command=eval:periodic");
+    expect(formatted).toContain("provider=codex");
     expect(formatted).toContain("judge_scores: bounded=4, useful=3");
   });
 

--- a/packages/skill-evals/src/core/__tests__/select.test.ts
+++ b/packages/skill-evals/src/core/__tests__/select.test.ts
@@ -59,6 +59,19 @@ describe("skill eval selection", () => {
     ]);
   });
 
+  it("selects provider-sensitive gate and read periodic coverage for provider runner changes", () => {
+    const summary = selectSkillEvalRecommendations(["packages/skill-evals/src/core/provider/claude.ts"]);
+
+    expect(summary.recommendations.map((recommendation) => recommendation.command)).toEqual([
+      "pnpm --filter @first-tree/skill-evals eval:floor",
+      "pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-read",
+      "pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-write",
+      "pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-seed",
+      "pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-welcome",
+      "pnpm --filter @first-tree/skill-evals eval:periodic -- --suite first-tree-read",
+    ]);
+  });
+
   it("selects only periodic for shared periodic framework changes", () => {
     const summary = selectSkillEvalRecommendations(["packages/skill-evals/src/core/periodic.ts"]);
 
@@ -81,6 +94,19 @@ describe("skill eval selection", () => {
         kind: "periodic",
         reason: "packages/skill-evals/src/suites/first-tree-welcome/periodic.ts touches periodic eval framework",
         suite: "first-tree-welcome",
+      },
+    ]);
+  });
+
+  it("selects suite-scoped periodic for read periodic runner changes", () => {
+    const summary = selectSkillEvalRecommendations(["packages/skill-evals/src/suites/first-tree-read/periodic.ts"]);
+
+    expect(summary.recommendations).toEqual([
+      {
+        command: "pnpm --filter @first-tree/skill-evals eval:periodic -- --suite first-tree-read",
+        kind: "periodic",
+        reason: "packages/skill-evals/src/suites/first-tree-read/periodic.ts touches periodic eval framework",
+        suite: "first-tree-read",
       },
     ]);
   });

--- a/packages/skill-evals/src/core/observability.ts
+++ b/packages/skill-evals/src/core/observability.ts
@@ -67,7 +67,10 @@ function isAssistantResponseEvent(value: unknown): boolean {
 }
 
 export function deriveRunObservability(events: readonly unknown[]): RunObservability {
-  const runStartedAt = events.find((event) => isRecord(event) && event.type === "codex_run_started") ?? null;
+  const runStartedAt =
+    events.find(
+      (event) => isRecord(event) && (event.type === "codex_run_started" || event.type === "claude_run_started"),
+    ) ?? null;
   const startedAtMs = timestampMs(runStartedAt);
   const responseTimes = events.filter(isAssistantResponseEvent).map(timestampMs).filter(isNumber);
   const firstResponseAtMs = responseTimes[0] ?? null;

--- a/packages/skill-evals/src/core/periodic.ts
+++ b/packages/skill-evals/src/core/periodic.ts
@@ -91,7 +91,7 @@ export function formatPeriodicSummary(summary: PeriodicSummary): string {
 
   lines.push(
     "",
-    "Periodic is an opt-in tier for broader, more expensive coverage. Future PRs will add implemented periodic cases.",
+    "Periodic is an opt-in tier for broader, more expensive coverage. Additional suites may add implemented periodic cases later.",
   );
   return lines.join("\n");
 }

--- a/packages/skill-evals/src/core/provider/claude.ts
+++ b/packages/skill-evals/src/core/provider/claude.ts
@@ -1,0 +1,230 @@
+import { spawn } from "node:child_process";
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import { delimiter, dirname, isAbsolute, join } from "node:path";
+import { createInterface } from "node:readline";
+
+import { appendEvent, previewText } from "../events.js";
+import { isShimTraceLine } from "../reporter.js";
+import type { ProviderRunContext, ProviderRunOptions } from "./types.js";
+
+const ALLOWED_ENV_KEYS = new Set([
+  "ALL_PROXY",
+  "ANTHROPIC_API_KEY",
+  "HTTPS_PROXY",
+  "HTTP_PROXY",
+  "LANG",
+  "LC_ALL",
+  "NODE_EXTRA_CA_CERTS",
+  "NO_PROXY",
+  "REQUESTS_CA_BUNDLE",
+  "SSL_CERT_FILE",
+  "USER",
+  "all_proxy",
+  "https_proxy",
+  "http_proxy",
+  "no_proxy",
+]);
+
+const SYSTEM_PATH_DIRS = ["/usr/local/bin", "/usr/bin", "/bin"] as const;
+
+function pathParts(pathValue: string | undefined): readonly string[] {
+  return (pathValue ?? "").split(delimiter).filter(Boolean);
+}
+
+function uniquePath(dirs: readonly (string | null | undefined)[]): string {
+  const seen = new Set<string>();
+  const kept: string[] = [];
+  for (const dir of dirs) {
+    if (!dir || seen.has(dir)) continue;
+    seen.add(dir);
+    kept.push(dir);
+  }
+  return kept.join(delimiter);
+}
+
+export function claudeProviderCommand(options: ProviderRunOptions, sourceEnv: NodeJS.ProcessEnv = process.env): string {
+  if (isAbsolute(options.bin)) return options.bin;
+  for (const dir of pathParts(sourceEnv.PATH)) {
+    const candidate = join(dir, options.bin);
+    if (existsSync(candidate)) return candidate;
+  }
+  return options.bin;
+}
+
+export function claudeProviderArgs(options: ProviderRunOptions): string[] {
+  const args = [
+    "-p",
+    options.prompt,
+    "--output-format",
+    "stream-json",
+    "--verbose",
+    "--no-session-persistence",
+    "--permission-mode",
+    "bypassPermissions",
+    "--setting-sources",
+    "project",
+  ];
+  if (options.model !== null) {
+    args.push("--model", options.model);
+  }
+  return args;
+}
+
+export function claudeProviderEnv(
+  options: ProviderRunOptions,
+  context: ProviderRunContext,
+  sourceEnv: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  const command = claudeProviderCommand(options, sourceEnv);
+  const providerHome = join(context.paths.runRoot, "provider-home");
+  const providerTmp = join(context.paths.runRoot, "provider-tmp");
+  const providerXdgCache = join(context.paths.runRoot, "provider-xdg-cache");
+  const providerXdgConfig = join(context.paths.runRoot, "provider-xdg-config");
+  for (const dir of [providerHome, providerTmp, providerXdgCache, providerXdgConfig]) {
+    mkdirSync(dir, { recursive: true });
+  }
+
+  const env: NodeJS.ProcessEnv = {};
+  for (const key of ALLOWED_ENV_KEYS) {
+    const value = sourceEnv[key];
+    if (value !== undefined) env[key] = value;
+  }
+
+  env.BASH_ENV = join(context.paths.shellEnvDir, "bash-env");
+  env.ENV = join(context.paths.shellEnvDir, "sh-env");
+  env.FIRST_TREE_EVAL_CASE_ID = options.caseId;
+  env.FIRST_TREE_EVAL_EVENTS = context.paths.modelEventsPath;
+  env.FIRST_TREE_EVAL_PHASE = "model";
+  env.FIRST_TREE_EVAL_VERBOSE = options.verbose ? "1" : "0";
+  env.HOME = providerHome;
+  env.PATH = uniquePath([
+    context.paths.binDir,
+    dirname(process.execPath),
+    isAbsolute(command) ? dirname(command) : null,
+    ...SYSTEM_PATH_DIRS,
+  ]);
+  env.TEMP = providerTmp;
+  env.TMP = providerTmp;
+  env.TMPDIR = providerTmp;
+  env.XDG_CACHE_HOME = providerXdgCache;
+  env.XDG_CONFIG_HOME = providerXdgConfig;
+  env.ZDOTDIR = context.paths.shellEnvDir;
+  return env;
+}
+
+async function consumeClaudeStdout(
+  eventsPath: string,
+  stream: NodeJS.ReadableStream,
+  context: ProviderRunContext,
+): Promise<void> {
+  const lines = createInterface({ input: stream, crlfDelay: Number.POSITIVE_INFINITY });
+  for await (const line of lines) {
+    if (!line.trim()) continue;
+    try {
+      const event = JSON.parse(line);
+      appendEvent(eventsPath, {
+        event,
+        type: "claude_event",
+      });
+      appendEvent(eventsPath, {
+        event,
+        type: "codex_event",
+      });
+      context.reporter.codexEvent(event);
+    } catch {
+      appendEvent(eventsPath, {
+        linePreview: previewText(line),
+        type: "claude_stdout",
+      });
+      context.reporter.codexStdoutLine(line);
+    }
+  }
+}
+
+async function consumeClaudeStderr(
+  eventsPath: string,
+  stream: NodeJS.ReadableStream,
+  context: ProviderRunContext,
+): Promise<void> {
+  const lines = createInterface({ input: stream, crlfDelay: Number.POSITIVE_INFINITY });
+  for await (const line of lines) {
+    if (!line.trim()) continue;
+    if (!isShimTraceLine(line)) {
+      appendEvent(eventsPath, {
+        linePreview: previewText(line),
+        type: "claude_stderr",
+      });
+    }
+    context.reporter.codexStderrLine(line);
+  }
+}
+
+async function waitForChildExit(child: ReturnType<typeof spawn>, context: ProviderRunContext): Promise<number> {
+  return await new Promise((resolve) => {
+    let settled = false;
+    child.once("error", (error) => {
+      if (settled) return;
+      settled = true;
+      appendEvent(context.paths.eventsPath, {
+        error: error.message,
+        type: "claude_spawn_error",
+      });
+      context.reporter.codexSpawnError(error);
+      resolve(127);
+    });
+    child.once("close", (code, signal) => {
+      if (settled) return;
+      settled = true;
+      appendEvent(context.paths.eventsPath, {
+        exitCode: code ?? 1,
+        signal,
+        type: "claude_process_closed",
+      });
+      context.reporter.codexProcessFinished(code ?? 1);
+      resolve(code ?? 1);
+    });
+  });
+}
+
+function appendModelEvents(context: ProviderRunContext): void {
+  if (!existsSync(context.paths.modelEventsPath)) return;
+  const modelEvents = readFileSync(context.paths.modelEventsPath, "utf8");
+  if (!modelEvents.trim()) return;
+  appendFileSync(context.paths.eventsPath, modelEvents.endsWith("\n") ? modelEvents : `${modelEvents}\n`, "utf8");
+}
+
+export async function runClaudeProvider(options: ProviderRunOptions, context: ProviderRunContext): Promise<number> {
+  const command = claudeProviderCommand(options);
+  const env = claudeProviderEnv(options, context);
+  const args = claudeProviderArgs(options);
+  appendEvent(context.paths.eventsPath, {
+    args,
+    caseId: options.caseId,
+    command,
+    envKeys: Object.keys(env).sort(),
+    type: "claude_run_started",
+  });
+  context.reporter.codexProcessStarted(args);
+
+  const child = spawn(command, args, {
+    cwd: context.paths.workspacePath,
+    env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  const streamTasks: Promise<void>[] = [];
+  if (child.stdout) streamTasks.push(consumeClaudeStdout(context.paths.eventsPath, child.stdout, context));
+  if (child.stderr) streamTasks.push(consumeClaudeStderr(context.paths.eventsPath, child.stderr, context));
+
+  const exitCode = await waitForChildExit(child, context);
+  await Promise.all(streamTasks);
+  appendModelEvents(context);
+
+  appendEvent(context.paths.eventsPath, {
+    caseId: options.caseId,
+    exitCode,
+    type: "claude_run_finished",
+  });
+
+  return exitCode;
+}

--- a/packages/skill-evals/src/core/provider/index.ts
+++ b/packages/skill-evals/src/core/provider/index.ts
@@ -1,0 +1,39 @@
+import { runClaudeProvider } from "./claude.js";
+import { runCodexProvider } from "./codex.js";
+import type { AgentProviderName, ProviderRunContext, ProviderRunOptions, ProviderRunResult } from "./types.js";
+
+export type AgentProviderCliOptions = {
+  claudeBin: string;
+  codexBin: string;
+  provider: AgentProviderName;
+};
+
+export function providerBin(options: AgentProviderCliOptions): string {
+  return options.provider === "claude" ? options.claudeBin : options.codexBin;
+}
+
+export async function runAgentProvider(
+  options: Omit<ProviderRunOptions, "bin"> & AgentProviderCliOptions,
+  context: ProviderRunContext,
+): Promise<ProviderRunResult> {
+  const bin = providerBin(options);
+  const runOptions: ProviderRunOptions = {
+    bin,
+    caseId: options.caseId,
+    model: options.model,
+    prompt: options.prompt,
+    provider: options.provider,
+    verbose: options.verbose,
+  };
+  const exitCode =
+    options.provider === "claude"
+      ? await runClaudeProvider(runOptions, context)
+      : await runCodexProvider(runOptions, context);
+  return {
+    exitCode,
+    model: options.model,
+    provider: options.provider,
+  };
+}
+
+export type { AgentProviderName, ProviderRunContext, ProviderRunOptions, ProviderRunResult };

--- a/packages/skill-evals/src/core/provider/types.ts
+++ b/packages/skill-evals/src/core/provider/types.ts
@@ -1,15 +1,24 @@
 import type { EvalReporter } from "../reporter.js";
 import type { RunPaths } from "../types.js";
 
+export type AgentProviderName = "codex" | "claude";
+
 export type ProviderRunOptions = {
   bin: string;
   caseId: string;
   model: string | null;
   prompt: string;
+  provider: AgentProviderName;
   verbose: boolean;
 };
 
 export type ProviderRunContext = {
   paths: RunPaths;
   reporter: EvalReporter;
+};
+
+export type ProviderRunResult = {
+  exitCode: number;
+  model: string | null;
+  provider: AgentProviderName;
 };

--- a/packages/skill-evals/src/core/result-store.ts
+++ b/packages/skill-evals/src/core/result-store.ts
@@ -93,6 +93,7 @@ export type ResultRunEntrySummary = {
   git: ResultStoreGitInfo;
   judgeScores: Record<string, number> | null;
   passed: boolean;
+  provider: string | null;
   skill: ShippedSkillName | "framework";
   status: ResultStoreStatus;
   tier: SkillEvalTier;
@@ -392,6 +393,7 @@ export function summarizeResultRunGroup(
       git: entry.git,
       judgeScores: entry.judgeScores,
       passed: entry.passed,
+      provider: entry.provider ?? null,
       skill: entry.skill,
       status: entry.status,
       tier: entry.tier,
@@ -483,7 +485,9 @@ export function formatResultRunSummary(summary: ResultRunSummary | null): string
     return [
       `- ${entry.status.toUpperCase()} ${entry.caseKey} command=${entry.command} tier=${entry.tier} skill=${
         entry.skill
-      } duration_ms=${formatNullableNumber(entry.durationMs)} turns=${formatNullableNumber(
+      } provider=${formatNullableText(entry.provider)} duration_ms=${formatNullableNumber(
+        entry.durationMs,
+      )} turns=${formatNullableNumber(
         entry.turns,
       )} first_response_latency_ms=${formatNullableNumber(entry.firstResponseLatencyMs)}${artifact}`,
       ...(scores === null ? [] : [`  judge_scores: ${scores}`]),

--- a/packages/skill-evals/src/core/select.ts
+++ b/packages/skill-evals/src/core/select.ts
@@ -127,6 +127,16 @@ function addQualityRecommendations(recommendations: Map<string, EvalRecommendati
   }
 }
 
+function addProviderRecommendations(recommendations: Map<string, EvalRecommendation>, reason: string): void {
+  addAllImplementedGateRecommendations(recommendations, reason);
+  addRecommendation(recommendations, {
+    command: periodicCommand("first-tree-read"),
+    kind: "periodic",
+    reason,
+    suite: "first-tree-read",
+  });
+}
+
 function matchingSkill(path: string): ShippedSkillName | null {
   for (const entry of SKILL_BY_PATH) {
     if (entry.paths.some((prefix) => path.startsWith(prefix))) {
@@ -192,6 +202,11 @@ export function selectSkillEvalRecommendations(
     const skill = matchingSkill(path);
     if (skill !== null) {
       addSuiteRecommendations(recommendations, skill, `${path} touches ${skill}`);
+      continue;
+    }
+
+    if (path.startsWith("packages/skill-evals/src/core/provider/")) {
+      addProviderRecommendations(recommendations, `${path} touches tested-agent provider infrastructure`);
       continue;
     }
 

--- a/packages/skill-evals/src/index.ts
+++ b/packages/skill-evals/src/index.ts
@@ -8,6 +8,7 @@ import { isRecord } from "./core/events.js";
 import { gateCommandFailed } from "./core/gate-exit.js";
 import { gradingFailureMessages } from "./core/grading.js";
 import { buildPeriodicSummary, formatPeriodicSummary } from "./core/periodic.js";
+import type { AgentProviderName } from "./core/provider/types.js";
 import {
   appendResultStoreEntries,
   compareResultGroups,
@@ -22,7 +23,13 @@ import {
 } from "./core/result-store.js";
 import { changedFilesFromGit, formatSelectionSummary, selectSkillEvalRecommendations } from "./core/select.js";
 import { readSkillFrontmatter } from "./core/skills/frontmatter.js";
-import { formatFirstTreeReadGateSummary, runFirstTreeReadGate } from "./suites/first-tree-read/index.js";
+import {
+  findFirstTreeReadPeriodicCase,
+  formatFirstTreeReadGateSummary,
+  formatFirstTreeReadPeriodicSummary,
+  runFirstTreeReadGate,
+  runFirstTreeReadPeriodic,
+} from "./suites/first-tree-read/index.js";
 import type { BatchSummary as ReadBatchSummary } from "./suites/first-tree-read/types.js";
 import {
   findFirstTreeSeedPeriodicCase,
@@ -59,6 +66,7 @@ type CliOptions = {
   base: string | null;
   caseId: string | null;
   changedFiles: readonly string[];
+  claudeBin: string;
   codexBin: string;
   command: "compare" | "floor" | "gate" | "periodic" | "quality" | "select" | "summary";
   currentRunGroupId: string | null;
@@ -68,6 +76,7 @@ type CliOptions = {
   json: boolean;
   model: string | null;
   previousRunGroupId: string | null;
+  provider: AgentProviderName;
   suite: ShippedSkillName | null;
   verbose: boolean;
 };
@@ -97,6 +106,7 @@ function usage(): string {
   pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-seed
   pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-seed --include-quality
   pnpm --filter @first-tree/skill-evals eval:periodic
+  pnpm --filter @first-tree/skill-evals eval:periodic -- --suite first-tree-read
   pnpm --filter @first-tree/skill-evals eval:periodic -- --suite first-tree-seed
   pnpm --filter @first-tree/skill-evals eval:periodic -- --suite first-tree-welcome
   pnpm --filter @first-tree/skill-evals eval:quality
@@ -124,8 +134,10 @@ Options:
   --current <run-id>     Current run group for eval:summary/compare. Defaults to latest.
   --previous <run-id>    Previous run group for eval:compare. Defaults to previous.
   --json                 Print summary as JSON.
-  --model <model>        Pass a model override to codex exec.
+  --provider <name>      Tested-agent provider: codex or claude. Defaults to codex.
+  --model <model>        Pass a model override to the selected tested-agent provider.
   --codex-bin <path>     Codex binary to execute. Defaults to CODEX_BIN or codex.
+  --claude-bin <path>    Claude binary to execute. Defaults to CLAUDE_BIN, CLAUDE_CODE_EXECUTABLE, or claude.
   --judge-model <model>  Judge model override. Defaults to JUDGE_MODEL, CODEX_MODEL, or provider default.
   --judge-bin <path>     Judge Codex binary. Defaults to JUDGE_CODEX_BIN, CODEX_BIN, or codex.
   --verbose              Print live readable progress to stderr.
@@ -164,6 +176,7 @@ function parseArgs(args: readonly string[]): CliOptions {
     base: null,
     caseId: null,
     changedFiles: [],
+    claudeBin: process.env.CLAUDE_BIN ?? process.env.CLAUDE_CODE_EXECUTABLE ?? "claude",
     codexBin: process.env.CODEX_BIN ?? "codex",
     command,
     currentRunGroupId: null,
@@ -173,10 +186,12 @@ function parseArgs(args: readonly string[]): CliOptions {
     json: false,
     model: process.env.CODEX_MODEL ?? null,
     previousRunGroupId: null,
+    provider: "codex",
     suite: null,
     verbose: false,
   };
 
+  let modelProvided = false;
   for (let index = 1; index < normalized.length; index += 1) {
     const arg = normalized[index];
     if (arg === "--json") {
@@ -223,11 +238,26 @@ function parseArgs(args: readonly string[]): CliOptions {
     }
     if (arg === "--model") {
       options.model = readOptionValue(normalized, index, "--model");
+      modelProvided = true;
+      index += 1;
+      continue;
+    }
+    if (arg === "--provider") {
+      const provider = readOptionValue(normalized, index, "--provider");
+      if (provider !== "codex" && provider !== "claude") {
+        throw new Error("--provider must be codex or claude.");
+      }
+      options.provider = provider;
       index += 1;
       continue;
     }
     if (arg === "--codex-bin") {
       options.codexBin = readOptionValue(normalized, index, "--codex-bin");
+      index += 1;
+      continue;
+    }
+    if (arg === "--claude-bin") {
+      options.claudeBin = readOptionValue(normalized, index, "--claude-bin");
       index += 1;
       continue;
     }
@@ -254,6 +284,9 @@ function parseArgs(args: readonly string[]): CliOptions {
 
   if (options.includeQuality && options.command !== "gate") {
     throw new Error("--include-quality is only valid with eval:gate.");
+  }
+  if (!modelProvided && options.provider === "claude") {
+    options.model = process.env.CLAUDE_MODEL ?? null;
   }
 
   return options;
@@ -479,7 +512,7 @@ function gateResultEntries(
       judgeScores: null,
       model: options.model,
       passed: summary.passed,
-      provider: "codex",
+      provider: options.provider,
       runGroupId,
       schemaVersion: 1,
       skill: suite,
@@ -493,8 +526,8 @@ function gateResultEntries(
 
 function periodicResultEntries(
   packageRootPath: string,
-  batch: SeedBatchSummary | WelcomeBatchSummary,
-  suite: Extract<ShippedSkillName, "first-tree-seed" | "first-tree-welcome">,
+  batch: ReadBatchSummary | SeedBatchSummary | WelcomeBatchSummary,
+  suite: Extract<ShippedSkillName, "first-tree-read" | "first-tree-seed" | "first-tree-welcome">,
   options: CliOptions,
   runGroupId = createRunGroupId(batch.runStartedAt, `eval-periodic-${suite}`),
 ): readonly ResultStoreEntry[] {
@@ -520,7 +553,7 @@ function periodicResultEntries(
       judgeScores: null,
       model: options.model,
       passed: summary.passed,
-      provider: "codex",
+      provider: options.provider,
       runGroupId,
       schemaVersion: 1,
       skill: suite,
@@ -600,11 +633,13 @@ async function runIncludedWriteQuality(
     packageRootPath,
     {
       caseId: FIRST_TREE_WRITE_QUALITY_DEFINITION.evalCase.id,
+      claudeBin: options.claudeBin,
       codexBin: options.codexBin,
       judgeBin: options.judgeBin,
       judgeModel: options.judgeModel,
       json: options.json,
       model: options.model,
+      provider: options.provider,
       suite: "first-tree-write",
       verbose: options.verbose,
     },
@@ -634,11 +669,13 @@ async function runIncludedWelcomeQuality(
     packageRootPath,
     {
       caseId: FIRST_TREE_WELCOME_QUALITY_DEFINITION.evalCase.id,
+      claudeBin: options.claudeBin,
       codexBin: options.codexBin,
       judgeBin: options.judgeBin,
       judgeModel: options.judgeModel,
       json: options.json,
       model: options.model,
+      provider: options.provider,
       suite: "first-tree-welcome",
       verbose: options.verbose,
     },
@@ -666,11 +703,13 @@ async function runIncludedSeedQuality(
     packageRootPath,
     {
       caseId: FIRST_TREE_SEED_QUALITY_DEFINITION.evalCase.id,
+      claudeBin: options.claudeBin,
       codexBin: options.codexBin,
       judgeBin: options.judgeBin,
       judgeModel: options.judgeModel,
       json: options.json,
       model: options.model,
+      provider: options.provider,
       suite: "first-tree-seed",
       verbose: options.verbose,
     },
@@ -723,9 +762,11 @@ async function runGate(options: CliOptions): Promise<void> {
   if (options.suite === "first-tree-read") {
     const batch = await runFirstTreeReadGate(packageRootPath, {
       caseId: options.caseId,
+      claudeBin: options.claudeBin,
       codexBin: options.codexBin,
       json: options.json,
       model: options.model,
+      provider: options.provider,
       verbose: options.verbose,
     });
     appendResultStoreEntries(packageRootPath, gateResultEntries(packageRootPath, batch, options.suite, options));
@@ -742,9 +783,11 @@ async function runGate(options: CliOptions): Promise<void> {
     }
     const batch = await runFirstTreeWriteGate(packageRootPath, {
       caseId: options.caseId,
+      claudeBin: options.claudeBin,
       codexBin: options.codexBin,
       json: options.json,
       model: options.model,
+      provider: options.provider,
       verbose: options.verbose,
     });
     const runGroupId = createRunGroupId(
@@ -775,9 +818,11 @@ async function runGate(options: CliOptions): Promise<void> {
     }
     const batch = await runFirstTreeSeedGate(packageRootPath, {
       caseId: options.caseId,
+      claudeBin: options.claudeBin,
       codexBin: options.codexBin,
       json: options.json,
       model: options.model,
+      provider: options.provider,
       verbose: options.verbose,
     });
     const runGroupId = createRunGroupId(
@@ -808,9 +853,11 @@ async function runGate(options: CliOptions): Promise<void> {
     }
     const batch = await runFirstTreeWelcomeGate(packageRootPath, {
       caseId: options.caseId,
+      claudeBin: options.claudeBin,
       codexBin: options.codexBin,
       json: options.json,
       model: options.model,
+      provider: options.provider,
       verbose: options.verbose,
     });
     const runGroupId = createRunGroupId(
@@ -844,11 +891,13 @@ async function runQuality(options: CliOptions): Promise<void> {
   const packageRootPath = packageRoot();
   const batch = await runQualityEval(packageRootPath, {
     caseId: options.caseId,
+    claudeBin: options.claudeBin,
     codexBin: options.codexBin,
     judgeBin: options.judgeBin,
     judgeModel: options.judgeModel,
     json: options.json,
     model: options.model,
+    provider: options.provider,
     suite: qualitySuite(options),
     verbose: options.verbose,
   });
@@ -878,12 +927,39 @@ function runSelect(options: CliOptions): void {
 
 async function runPeriodic(options: CliOptions): Promise<void> {
   const packageRootPath = packageRoot();
-  if (options.suite === "first-tree-seed") {
-    const batch = await runFirstTreeSeedPeriodic(packageRootPath, {
+  if (options.suite === "first-tree-read") {
+    const batch = await runFirstTreeReadPeriodic(packageRootPath, {
       caseId: options.caseId,
+      claudeBin: options.claudeBin,
       codexBin: options.codexBin,
       json: options.json,
       model: options.model,
+      provider: options.provider,
+      verbose: options.verbose,
+    });
+    appendResultStoreEntries(
+      packageRootPath,
+      periodicResultEntries(packageRootPath, batch, "first-tree-read", options),
+    );
+    if (options.json) {
+      process.stdout.write(`${JSON.stringify(batch, null, 2)}\n`);
+    } else {
+      process.stdout.write(`${formatFirstTreeReadPeriodicSummary(batch)}\n`);
+    }
+    if (batch.failed > 0) {
+      process.exitCode = 1;
+    }
+    return;
+  }
+
+  if (options.suite === "first-tree-seed") {
+    const batch = await runFirstTreeSeedPeriodic(packageRootPath, {
+      caseId: options.caseId,
+      claudeBin: options.claudeBin,
+      codexBin: options.codexBin,
+      json: options.json,
+      model: options.model,
+      provider: options.provider,
       verbose: options.verbose,
     });
     appendResultStoreEntries(
@@ -904,9 +980,11 @@ async function runPeriodic(options: CliOptions): Promise<void> {
   if (options.suite === "first-tree-welcome") {
     const batch = await runFirstTreeWelcomePeriodic(packageRootPath, {
       caseId: options.caseId,
+      claudeBin: options.claudeBin,
       codexBin: options.codexBin,
       json: options.json,
       model: options.model,
+      provider: options.provider,
       verbose: options.verbose,
     });
     appendResultStoreEntries(
@@ -927,19 +1005,39 @@ async function runPeriodic(options: CliOptions): Promise<void> {
   if (options.suite === null) {
     const runGroupStartedAt = new Date().toISOString();
     const runGroupId = createRunGroupId(runGroupStartedAt, "eval-periodic-all");
+    const runRead = options.caseId === null || findFirstTreeReadPeriodicCase(options.caseId) !== null;
     const runSeed = options.caseId === null || findFirstTreeSeedPeriodicCase(options.caseId) !== null;
     const runWelcome = options.caseId === null || findFirstTreeWelcomePeriodicCase(options.caseId) !== null;
-    if (!runSeed && !runWelcome) {
+    if (!runRead && !runSeed && !runWelcome) {
       throw new Error(
-        `No periodic case '${options.caseId}' found for implemented periodic suites first-tree-seed or first-tree-welcome.`,
+        `No periodic case '${options.caseId}' found for implemented periodic suites first-tree-read, first-tree-seed, or first-tree-welcome.`,
+      );
+    }
+    const readBatch = runRead
+      ? await runFirstTreeReadPeriodic(packageRootPath, {
+          caseId: options.caseId,
+          claudeBin: options.claudeBin,
+          codexBin: options.codexBin,
+          json: options.json,
+          model: options.model,
+          provider: options.provider,
+          verbose: options.verbose,
+        })
+      : null;
+    if (readBatch !== null) {
+      appendResultStoreEntries(
+        packageRootPath,
+        periodicResultEntries(packageRootPath, readBatch, "first-tree-read", options, runGroupId),
       );
     }
     const seedBatch = runSeed
       ? await runFirstTreeSeedPeriodic(packageRootPath, {
           caseId: options.caseId,
+          claudeBin: options.claudeBin,
           codexBin: options.codexBin,
           json: options.json,
           model: options.model,
+          provider: options.provider,
           verbose: options.verbose,
         })
       : null;
@@ -952,9 +1050,11 @@ async function runPeriodic(options: CliOptions): Promise<void> {
     const welcomeBatch = runWelcome
       ? await runFirstTreeWelcomePeriodic(packageRootPath, {
           caseId: options.caseId,
+          claudeBin: options.claudeBin,
           codexBin: options.codexBin,
           json: options.json,
           model: options.model,
+          provider: options.provider,
           verbose: options.verbose,
         })
       : null;
@@ -968,6 +1068,7 @@ async function runPeriodic(options: CliOptions): Promise<void> {
       process.stdout.write(
         `${JSON.stringify(
           {
+            "first-tree-read": readBatch,
             "first-tree-seed": seedBatch,
             "first-tree-welcome": welcomeBatch,
             runStartedAt: runGroupStartedAt,
@@ -979,6 +1080,9 @@ async function runPeriodic(options: CliOptions): Promise<void> {
     } else {
       process.stdout.write(
         [
+          ...(readBatch === null
+            ? []
+            : ["first-tree-read periodic", "", formatFirstTreeReadPeriodicSummary(readBatch), ""]),
           ...(seedBatch === null
             ? []
             : ["first-tree-seed periodic", "", formatFirstTreeSeedPeriodicSummary(seedBatch), ""]),
@@ -989,7 +1093,7 @@ async function runPeriodic(options: CliOptions): Promise<void> {
       );
       process.stdout.write("\n");
     }
-    if ((seedBatch?.failed ?? 0) > 0 || (welcomeBatch?.failed ?? 0) > 0) {
+    if ((readBatch?.failed ?? 0) > 0 || (seedBatch?.failed ?? 0) > 0 || (welcomeBatch?.failed ?? 0) > 0) {
       process.exitCode = 1;
     }
     return;

--- a/packages/skill-evals/src/suites/first-tree-read/__tests__/periodic.test.ts
+++ b/packages/skill-evals/src/suites/first-tree-read/__tests__/periodic.test.ts
@@ -1,0 +1,67 @@
+import { existsSync, lstatSync, readFileSync, readlinkSync, rmSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { createRunPaths } from "../../../core/paths.js";
+import { createEvalReporter } from "../../../core/reporter.js";
+import { FIRST_TREE_READ_PERIODIC_CASES } from "../cases.js";
+import { setupFixture } from "../fixture.js";
+import { findFirstTreeReadPeriodicCase } from "../periodic.js";
+
+describe("first-tree-read periodic cases", () => {
+  it("declares the runtime-generated briefing case as the only implemented periodic row", () => {
+    expect(FIRST_TREE_READ_PERIODIC_CASES.map((evalCase) => evalCase.id)).toEqual([
+      "first-tree-read-runtime-generated-briefing-periodic",
+    ]);
+    expect(FIRST_TREE_READ_PERIODIC_CASES[0]?.briefingMode).toBe("runtime-generated");
+    expect(FIRST_TREE_READ_PERIODIC_CASES[0]?.workspaceKind).toBe("context-tree");
+  });
+
+  it("finds the runtime-generated periodic case by id", () => {
+    expect(findFirstTreeReadPeriodicCase("first-tree-read-runtime-generated-briefing-periodic")?.briefingMode).toBe(
+      "runtime-generated",
+    );
+    expect(findFirstTreeReadPeriodicCase("missing-periodic-case")).toBeNull();
+  });
+
+  it("builds a runtime-generated briefing fixture with First Tree family skills", () => {
+    const evalCase = findFirstTreeReadPeriodicCase("first-tree-read-runtime-generated-briefing-periodic");
+    if (evalCase === null) throw new Error("missing read runtime-generated periodic case");
+
+    const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../../..");
+    const paths = createRunPaths({
+      caseId: "read-runtime-generated-briefing-fixture-test",
+      packageRoot,
+      startedAt: new Date().toISOString(),
+    });
+
+    try {
+      setupFixture(evalCase, paths, createEvalReporter(evalCase.id, false));
+
+      const agentsPath = join(paths.workspacePath, "AGENTS.md");
+      const claudePath = join(paths.workspacePath, "CLAUDE.md");
+      const briefing = readFileSync(agentsPath, "utf8");
+
+      expect(briefing).toContain("first-tree:generated");
+      expect(briefing).toContain("# Working in First Tree");
+      expect(briefing).toContain("# Context Tree");
+      expect(briefing).toContain("# Skills");
+      expect(briefing).toContain("first-tree-read");
+      expect(briefing).toContain("first-tree-seed");
+      expect(briefing).toContain("first-tree-welcome");
+      expect(briefing).toContain("first-tree-write");
+      expect(existsSync(join(paths.workspacePath, ".first-tree-workspace", "identity.json"))).toBe(true);
+      expect(lstatSync(claudePath).isSymbolicLink()).toBe(true);
+      expect(readlinkSync(claudePath)).toBe("AGENTS.md");
+
+      for (const skill of ["first-tree-welcome", "first-tree-read", "first-tree-seed", "first-tree-write"]) {
+        expect(existsSync(join(paths.workspacePath, ".agents", "skills", skill, "SKILL.md"))).toBe(true);
+        expect(lstatSync(join(paths.workspacePath, ".claude", "skills", skill)).isSymbolicLink()).toBe(true);
+      }
+    } finally {
+      rmSync(paths.runRoot, { force: true, recursive: true });
+    }
+  });
+});

--- a/packages/skill-evals/src/suites/first-tree-read/cases.ts
+++ b/packages/skill-evals/src/suites/first-tree-read/cases.ts
@@ -36,8 +36,29 @@ export const FIRST_TREE_READ_CASES: readonly FirstTreeReadEvalCase[] = [
   },
 ];
 
+export const FIRST_TREE_READ_PERIODIC_CASES: readonly FirstTreeReadEvalCase[] = [
+  {
+    briefingMode: "runtime-generated",
+    description: "Context Tree workspace with runtime-generated briefing and installed First Tree family skills.",
+    expectedFacts: JWT_AUTH_EXPECTED_FACTS,
+    expectedTrigger: true,
+    id: "first-tree-read-runtime-generated-briefing-periodic",
+    prompt:
+      "Use this workspace's current Context Tree to answer: what constraints should JWT auth routes follow for this project?",
+    promptAlternates: ["Use the current Context Tree before answering: how should multi-org JWT route scopes work?"],
+    workspaceKind: "context-tree",
+  },
+];
+
 export function findFirstTreeReadCase(id: string): FirstTreeReadEvalCase | null {
   for (const evalCase of FIRST_TREE_READ_CASES) {
+    if (evalCase.id === id) return evalCase;
+  }
+  return null;
+}
+
+export function findFirstTreeReadPeriodicCase(id: string): FirstTreeReadEvalCase | null {
+  for (const evalCase of FIRST_TREE_READ_PERIODIC_CASES) {
     if (evalCase.id === id) return evalCase;
   }
   return null;

--- a/packages/skill-evals/src/suites/first-tree-read/eval-cases.ts
+++ b/packages/skill-evals/src/suites/first-tree-read/eval-cases.ts
@@ -1,6 +1,6 @@
 import type { SkillEvalCase } from "../../core/case-schema.js";
 import type { SkillEvalSuiteDefinition } from "../types.js";
-import { FIRST_TREE_READ_CASES } from "./cases.js";
+import { FIRST_TREE_READ_CASES, FIRST_TREE_READ_PERIODIC_CASES } from "./cases.js";
 
 const FLOOR_CASE_ID = "first-tree-read-floor-coverage";
 
@@ -39,6 +39,27 @@ export const FIRST_TREE_READ_EVAL_CASES: readonly SkillEvalCase[] = [
       tier: "gate",
     }),
   ),
+  ...FIRST_TREE_READ_PERIODIC_CASES.map(
+    (evalCase): SkillEvalCase => ({
+      briefingMode: "runtime-generated",
+      expected: {
+        expectedFacts: evalCase.expectedFacts,
+        expectedTrigger: evalCase.expectedTrigger,
+        runtimeBoundary: "generated briefing fixture only; not live First Tree Cloud E2E",
+      },
+      fixture: {
+        installedSkills: ["first-tree-welcome", "first-tree-read", "first-tree-seed", "first-tree-write"],
+        workspaceKind: evalCase.workspaceKind,
+      },
+      id: evalCase.id,
+      prompt: evalCase.prompt,
+      provider: "codex",
+      skill: "first-tree-read",
+      status: "implemented",
+      tags: ["runtime-generated", "periodic"],
+      tier: "periodic",
+    }),
+  ),
 ];
 
 function validateFirstTreeReadFloor(cases: readonly SkillEvalCase[]): readonly string[] {
@@ -75,6 +96,13 @@ export const FIRST_TREE_READ_SUITE: SkillEvalSuiteDefinition = {
         description: "Run the existing three live read cases through the migrated suite.",
         status: "implemented",
         tier: "gate",
+      },
+      {
+        caseIds: FIRST_TREE_READ_PERIODIC_CASES.map((evalCase) => evalCase.id),
+        description:
+          "Run the read trigger against a runtime-generated briefing fixture without live First Tree Cloud E2E.",
+        status: "implemented",
+        tier: "periodic",
       },
     ],
   },

--- a/packages/skill-evals/src/suites/first-tree-read/fixture.ts
+++ b/packages/skill-evals/src/suites/first-tree-read/fixture.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, symlinkSync } from "node:fs";
 import { join, relative } from "node:path";
 
 import { assertCommandOk, runCommand, writeText } from "../../core/commands.js";
@@ -12,6 +12,7 @@ import type { FirstTreeReadEvalCase, FixtureValidation } from "./types.js";
 const DOMAIN_NODE_TARGET_COUNT = 100;
 const NAVIGATION_NODE_MARKER = "evalNodeKind: navigation";
 const SKILL_NAME = "first-tree-read";
+const RUNTIME_SKILL_NAMES = ["first-tree-welcome", "first-tree-read", "first-tree-seed", "first-tree-write"] as const;
 
 type DomainNode = {
   facts: readonly string[];
@@ -127,6 +128,101 @@ skill workflow exactly. In particular, if the skill instructs you to inspect a
 function installFirstTreeReadSkill(repoRoot: string, workspacePath: string): void {
   const skillMarkdown = installRepoSkill(repoRoot, workspacePath, SKILL_NAME);
   writeText(join(workspacePath, "AGENTS.md"), workspaceAgentsMarkdown(parseSkillDescription(skillMarkdown)));
+}
+
+function runtimeGeneratedWorkspaceAgentsMarkdown(
+  workspacePath: string,
+  contextTreePath: string,
+  descriptions: ReadonlyMap<string, string>,
+): string {
+  const sourceRepoPath = join(workspacePath, "source-repo");
+  const skillRows = RUNTIME_SKILL_NAMES.map(
+    (skill) => `| \`${skill}\` | ${descriptions.get(skill) ?? "Use when this skill applies."} |`,
+  ).join("\n");
+
+  return `<!-- ======================================================================
+  first-tree:generated — this file is rebuilt by the First Tree runtime at
+  every session start. This eval fixture covers generated briefing shape and
+  First Tree skill topology only; it is not a live First Tree Cloud E2E.
+====================================================================== -->
+
+# Identity
+
+You are First Tree Read Eval Agent, a personal assistant agent.
+
+# Working in First Tree (First Tree Managed)
+
+Your fixed working directory is \`${workspacePath}\`. The runtime marker
+\`.first-tree-workspace\` is the project-root boundary for provider sessions.
+
+## Source Repositories
+
+- \`${sourceRepoPath}\` (fixture source repo)
+
+# Required Reading (First Tree Managed)
+
+Before changing a Context Tree, load \`.agents/skills/first-tree-write/SKILL.md\`.
+
+# Context Tree (First Tree Managed)
+
+The current Context Tree checkout is \`${contextTreePath}\`.
+
+Read task-scoped tree context before acting on software project questions:
+
+1. Read \`.agents/skills/first-tree-read/SKILL.md\`.
+2. Inspect \`first-tree tree tree --help\`.
+3. Use \`first-tree tree tree\` selectors before answering.
+
+# Skills (First Tree Managed)
+
+## First Tree Family
+
+| Skill | Load when |
+|---|---|
+${skillRows}
+
+\`first-tree-welcome\` is the core onboarding skill. Tree-bound workspaces
+additionally install \`first-tree-read\`, \`first-tree-seed\`, and
+\`first-tree-write\`. Runtime metadata can activate skills, but visible
+instructions still define when the agent should load them.
+`;
+}
+
+function writeClaudeBriefingSymlink(workspacePath: string): void {
+  const claudeMdPath = join(workspacePath, "CLAUDE.md");
+  rmSync(claudeMdPath, { force: true });
+  symlinkSync("AGENTS.md", claudeMdPath);
+}
+
+function installRuntimeGeneratedBriefing(repoRoot: string, workspacePath: string, contextTreePath: string): void {
+  const descriptions = new Map<string, string>();
+  for (const skill of RUNTIME_SKILL_NAMES) {
+    const skillMarkdown = installRepoSkill(repoRoot, workspacePath, skill);
+    descriptions.set(skill, parseSkillDescription(skillMarkdown));
+  }
+
+  writeText(
+    join(workspacePath, ".first-tree-workspace", "identity.json"),
+    `${JSON.stringify(
+      {
+        agentId: "first-tree-read-eval-agent",
+        contextTreePath,
+        delegateMention: null,
+        displayName: "First Tree Read Eval Agent",
+        metadata: {},
+        serverUrl: "https://example.invalid",
+        type: "agent",
+        visibility: "private",
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  writeText(
+    join(workspacePath, "AGENTS.md"),
+    runtimeGeneratedWorkspaceAgentsMarkdown(workspacePath, contextTreePath, descriptions),
+  );
+  writeClaudeBriefingSymlink(workspacePath);
 }
 
 function systemNodes(): DomainNode[] {
@@ -356,8 +452,15 @@ export function setupFixture(evalCase: FirstTreeReadEvalCase, paths: RunPaths, r
   });
   reporter.fixtureSetupStarted(evalCase.workspaceKind);
 
-  installFirstTreeReadSkill(paths.repoRoot, paths.workspacePath);
   const contextTreePath = evalCase.workspaceKind === "context-tree" ? writeContextTreeFixture(paths) : null;
+  if (evalCase.briefingMode === "runtime-generated") {
+    if (contextTreePath === null) {
+      throw new Error("runtime-generated first-tree-read fixture requires a context-tree workspace.");
+    }
+    installRuntimeGeneratedBriefing(paths.repoRoot, paths.workspacePath, contextTreePath);
+  } else {
+    installFirstTreeReadSkill(paths.repoRoot, paths.workspacePath);
+  }
 
   appendEvent(paths.eventsPath, {
     caseId: evalCase.id,

--- a/packages/skill-evals/src/suites/first-tree-read/index.ts
+++ b/packages/skill-evals/src/suites/first-tree-read/index.ts
@@ -1,9 +1,19 @@
 import { FIRST_TREE_READ_CASES, findFirstTreeReadCase } from "./cases.js";
+import {
+  findFirstTreeReadPeriodicCase,
+  formatFirstTreeReadPeriodicSummary,
+  runFirstTreeReadPeriodic,
+} from "./periodic.js";
 import { runFirstTreeReadCase } from "./runner.js";
 import { buildBatchSummary, formatSummaryTable } from "./summary.js";
 import type { BatchSummary, CliOptions, FirstTreeReadEvalCase } from "./types.js";
 
-export { findFirstTreeReadCase };
+export {
+  findFirstTreeReadCase,
+  findFirstTreeReadPeriodicCase,
+  formatFirstTreeReadPeriodicSummary,
+  runFirstTreeReadPeriodic,
+};
 
 export type FirstTreeReadGateOptions = CliOptions;
 

--- a/packages/skill-evals/src/suites/first-tree-read/periodic.ts
+++ b/packages/skill-evals/src/suites/first-tree-read/periodic.ts
@@ -1,0 +1,36 @@
+import { FIRST_TREE_READ_PERIODIC_CASES, findFirstTreeReadPeriodicCase } from "./cases.js";
+import { runFirstTreeReadCase } from "./runner.js";
+import { buildBatchSummary, formatSummaryTable } from "./summary.js";
+import type { BatchSummary, CliOptions, FirstTreeReadEvalCase } from "./types.js";
+
+export { findFirstTreeReadPeriodicCase };
+
+function selectPeriodicCases(caseId: string | null): readonly FirstTreeReadEvalCase[] {
+  if (caseId === null) return FIRST_TREE_READ_PERIODIC_CASES;
+
+  const evalCase = findFirstTreeReadPeriodicCase(caseId);
+  if (evalCase === null) {
+    const available = FIRST_TREE_READ_PERIODIC_CASES.map((candidate) => candidate.id).join(", ");
+    throw new Error(`Unknown first-tree-read periodic case '${caseId}'. Available periodic cases: ${available}`);
+  }
+  return [evalCase];
+}
+
+export async function runFirstTreeReadPeriodic(packageRootPath: string, options: CliOptions): Promise<BatchSummary> {
+  const selectedCases = selectPeriodicCases(options.caseId);
+  const runStartedAt = new Date().toISOString();
+  const summaries = [];
+
+  for (const evalCase of selectedCases) {
+    if (!options.verbose) {
+      process.stderr.write(`Running first-tree-read periodic eval case: ${evalCase.id}\n`);
+    }
+    summaries.push(await runFirstTreeReadCase(packageRootPath, evalCase, options, runStartedAt));
+  }
+
+  return buildBatchSummary(summaries, runStartedAt);
+}
+
+export function formatFirstTreeReadPeriodicSummary(batch: BatchSummary): string {
+  return formatSummaryTable(batch);
+}

--- a/packages/skill-evals/src/suites/first-tree-read/runner.ts
+++ b/packages/skill-evals/src/suites/first-tree-read/runner.ts
@@ -1,7 +1,7 @@
 import { appendEvent, readEvents } from "../../core/events.js";
 import { deriveRunObservability } from "../../core/observability.js";
 import { createRunPaths } from "../../core/paths.js";
-import { runCodexProvider } from "../../core/provider/codex.js";
+import { runAgentProvider } from "../../core/provider/index.js";
 import { createEvalReporter } from "../../core/reporter.js";
 import { createFirstTreeShim } from "../../core/shims/first-tree.js";
 import { setupFixture, validateFixture } from "./fixture.js";
@@ -28,16 +28,19 @@ export async function runFirstTreeReadCase(
   createFirstTreeShim(paths);
   const contextTreePath = setupFixture(evalCase, paths, reporter);
   const fixtureValidation = validateFixture(paths, contextTreePath, evalCase.id, options.verbose, reporter);
-  const runnerExitCode = await runCodexProvider(
+  const runnerResult = await runAgentProvider(
     {
-      bin: options.codexBin,
       caseId: evalCase.id,
+      claudeBin: options.claudeBin,
+      codexBin: options.codexBin,
       model: options.model,
       prompt: evalCase.prompt,
+      provider: options.provider,
       verbose: options.verbose,
     },
     { paths, reporter },
   );
+  const runnerExitCode = runnerResult.exitCode;
   const events = readEvents(paths.eventsPath);
   const metrics = deriveMetrics(events, fixtureValidation, runnerExitCode, evalCase.expectedFacts);
   const passed = casePassed(evalCase.expectedTrigger, metrics);

--- a/packages/skill-evals/src/suites/first-tree-read/types.ts
+++ b/packages/skill-evals/src/suites/first-tree-read/types.ts
@@ -1,9 +1,12 @@
+import type { AgentProviderName } from "../../core/provider/types.js";
 import type { SkillCaseGrading } from "../../core/result-schema.js";
 import type { CommandResult } from "../../core/types.js";
 
 export type WorkspaceKind = "blank" | "context-tree";
+export type BriefingMode = "minimal" | "runtime-generated";
 
 export type FirstTreeReadEvalCase = {
+  briefingMode?: BriefingMode;
   description: string;
   expectedFacts: readonly string[];
   expectedTrigger: boolean;
@@ -24,9 +27,11 @@ export type FixtureValidation = {
 
 export type CliOptions = {
   caseId: string | null;
+  claudeBin: string;
   codexBin: string;
   json: boolean;
   model: string | null;
+  provider: AgentProviderName;
   verbose: boolean;
 };
 

--- a/packages/skill-evals/src/suites/first-tree-seed/runner.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/runner.ts
@@ -1,7 +1,7 @@
 import { appendEvent, readEvents } from "../../core/events.js";
 import { deriveRunObservability } from "../../core/observability.js";
 import { createRunPaths } from "../../core/paths.js";
-import { runCodexProvider } from "../../core/provider/codex.js";
+import { runAgentProvider } from "../../core/provider/index.js";
 import { createEvalReporter } from "../../core/reporter.js";
 import { createFirstTreeShim } from "../../core/shims/first-tree.js";
 import { createFirstTreeStagingShim } from "../../core/shims/first-tree-staging.js";
@@ -32,16 +32,19 @@ export async function runFirstTreeSeedCase(
   createGhShim(paths);
   const contextTreePath = setupFixture(evalCase, paths, reporter);
   const fixtureValidation = validateFixture(paths, contextTreePath, evalCase, options.verbose, reporter);
-  const runnerExitCode = await runCodexProvider(
+  const runnerResult = await runAgentProvider(
     {
-      bin: options.codexBin,
       caseId: evalCase.id,
+      claudeBin: options.claudeBin,
+      codexBin: options.codexBin,
       model: options.model,
       prompt: evalCase.prompt,
+      provider: options.provider,
       verbose: options.verbose,
     },
     { paths, reporter },
   );
+  const runnerExitCode = runnerResult.exitCode;
 
   const events = readEvents(paths.eventsPath);
   const metrics = deriveMetrics(events, evalCase, fixtureValidation, runnerExitCode, paths, contextTreePath);

--- a/packages/skill-evals/src/suites/first-tree-seed/types.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/types.ts
@@ -1,3 +1,4 @@
+import type { AgentProviderName } from "../../core/provider/types.js";
 import type { SkillCaseGrading } from "../../core/result-schema.js";
 import type { CommandResult } from "../../core/types.js";
 
@@ -44,9 +45,11 @@ export type FirstTreeSeedEvalCase = {
 
 export type CliOptions = {
   caseId: string | null;
+  claudeBin: string;
   codexBin: string;
   json: boolean;
   model: string | null;
+  provider: AgentProviderName;
   verbose: boolean;
 };
 

--- a/packages/skill-evals/src/suites/first-tree-welcome/runner.ts
+++ b/packages/skill-evals/src/suites/first-tree-welcome/runner.ts
@@ -1,7 +1,7 @@
 import { appendEvent, readEvents } from "../../core/events.js";
 import { deriveRunObservability } from "../../core/observability.js";
 import { createRunPaths } from "../../core/paths.js";
-import { runCodexProvider } from "../../core/provider/codex.js";
+import { runAgentProvider } from "../../core/provider/index.js";
 import { createEvalReporter } from "../../core/reporter.js";
 import { createFirstTreeShim } from "../../core/shims/first-tree.js";
 import { createFirstTreeStagingShim } from "../../core/shims/first-tree-staging.js";
@@ -32,16 +32,19 @@ export async function runFirstTreeWelcomeCase(
   createGhShim(paths);
   const contextTreePath = setupFixture(evalCase, paths, reporter);
   const fixtureValidation = validateFixture(paths, contextTreePath, evalCase, evalCase.id, options.verbose, reporter);
-  const runnerExitCode = await runCodexProvider(
+  const runnerResult = await runAgentProvider(
     {
-      bin: options.codexBin,
       caseId: evalCase.id,
+      claudeBin: options.claudeBin,
+      codexBin: options.codexBin,
       model: options.model,
       prompt: evalCase.prompt,
+      provider: options.provider,
       verbose: options.verbose,
     },
     { paths, reporter },
   );
+  const runnerExitCode = runnerResult.exitCode;
 
   const events = readEvents(paths.eventsPath);
   const metrics = deriveMetrics(events, evalCase, fixtureValidation, runnerExitCode, paths, contextTreePath);

--- a/packages/skill-evals/src/suites/first-tree-welcome/types.ts
+++ b/packages/skill-evals/src/suites/first-tree-welcome/types.ts
@@ -1,3 +1,4 @@
+import type { AgentProviderName } from "../../core/provider/types.js";
 import type { SkillCaseGrading } from "../../core/result-schema.js";
 import type { CommandResult } from "../../core/types.js";
 
@@ -59,9 +60,11 @@ export type FirstTreeWelcomeEvalCase = {
 
 export type CliOptions = {
   caseId: string | null;
+  claudeBin: string;
   codexBin: string;
   json: boolean;
   model: string | null;
+  provider: AgentProviderName;
   verbose: boolean;
 };
 

--- a/packages/skill-evals/src/suites/first-tree-write/runner.ts
+++ b/packages/skill-evals/src/suites/first-tree-write/runner.ts
@@ -2,7 +2,7 @@ import { appendEvent, readEvents } from "../../core/events.js";
 import { runFixtureVerify } from "../../core/fixture-verify.js";
 import { deriveRunObservability } from "../../core/observability.js";
 import { createRunPaths } from "../../core/paths.js";
-import { runCodexProvider } from "../../core/provider/codex.js";
+import { runAgentProvider } from "../../core/provider/index.js";
 import { createEvalReporter } from "../../core/reporter.js";
 import { createFirstTreeShim } from "../../core/shims/first-tree.js";
 import { setupFixture, validateFixture } from "./fixture.js";
@@ -29,16 +29,19 @@ export async function runFirstTreeWriteCase(
   createFirstTreeShim(paths);
   const contextTreePath = setupFixture(evalCase, paths, reporter);
   const fixtureValidation = validateFixture(paths, contextTreePath, evalCase.id, options.verbose, reporter);
-  const runnerExitCode = await runCodexProvider(
+  const runnerResult = await runAgentProvider(
     {
-      bin: options.codexBin,
       caseId: evalCase.id,
+      claudeBin: options.claudeBin,
+      codexBin: options.codexBin,
       model: options.model,
       prompt: evalCase.prompt,
+      provider: options.provider,
       verbose: options.verbose,
     },
     { paths, reporter },
   );
+  const runnerExitCode = runnerResult.exitCode;
   const postModelVerifyResult = evalCase.expected.requireVerify
     ? runFixtureVerify({
         caseId: evalCase.id,

--- a/packages/skill-evals/src/suites/first-tree-write/types.ts
+++ b/packages/skill-evals/src/suites/first-tree-write/types.ts
@@ -1,3 +1,4 @@
+import type { AgentProviderName } from "../../core/provider/types.js";
 import type { SkillCaseGrading } from "../../core/result-schema.js";
 import type { CommandResult } from "../../core/types.js";
 
@@ -40,9 +41,11 @@ export type FirstTreeWriteEvalCase = {
 
 export type CliOptions = {
   caseId: string | null;
+  claudeBin: string;
   codexBin: string;
   json: boolean;
   model: string | null;
+  provider: AgentProviderName;
   verbose: boolean;
 };
 

--- a/packages/skill-evals/src/suites/quality/runner.ts
+++ b/packages/skill-evals/src/suites/quality/runner.ts
@@ -232,9 +232,11 @@ async function collectLiveQualityInput(
   if (definition.evalCase.skill === "first-tree-write") {
     const batch = await runFirstTreeWriteGate(packageRoot, {
       caseId: definition.gateCaseId,
+      claudeBin: options.claudeBin,
       codexBin: options.codexBin,
       json: false,
       model: options.model,
+      provider: options.provider,
       verbose: options.verbose,
     });
     const summary = batch.cases[0];
@@ -247,9 +249,11 @@ async function collectLiveQualityInput(
   if (definition.evalCase.skill === "first-tree-seed") {
     const batch = await runFirstTreeSeedGate(packageRoot, {
       caseId: definition.gateCaseId,
+      claudeBin: options.claudeBin,
       codexBin: options.codexBin,
       json: false,
       model: options.model,
+      provider: options.provider,
       verbose: options.verbose,
     });
     const summary = batch.cases[0];
@@ -262,9 +266,11 @@ async function collectLiveQualityInput(
   if (definition.evalCase.skill === "first-tree-welcome") {
     const batch = await runFirstTreeWelcomeGate(packageRoot, {
       caseId: definition.gateCaseId,
+      claudeBin: options.claudeBin,
       codexBin: options.codexBin,
       json: false,
       model: options.model,
+      provider: options.provider,
       verbose: options.verbose,
     });
     const summary = batch.cases[0];

--- a/packages/skill-evals/src/suites/quality/types.ts
+++ b/packages/skill-evals/src/suites/quality/types.ts
@@ -1,5 +1,6 @@
 import type { ShippedSkillName, SkillEvalCase } from "../../core/case-schema.js";
 import type { JudgeRubricDimension } from "../../core/judge/types.js";
+import type { AgentProviderName } from "../../core/provider/types.js";
 import type { QualityJudgeRunResult } from "../../core/result-schema.js";
 
 export type QualitySkillName = Extract<ShippedSkillName, "first-tree-write" | "first-tree-seed" | "first-tree-welcome">;
@@ -49,11 +50,13 @@ export type QualityCaseDefinition = {
 
 export type QualityRunOptions = {
   caseId: string | null;
+  claudeBin: string;
   codexBin: string;
   judgeBin: string;
   judgeModel: string | null;
   json: boolean;
   model: string | null;
+  provider: AgentProviderName;
   suite: QualitySkillName | null;
   verbose: boolean;
 };


### PR DESCRIPTION
## Summary

- Add a provider-neutral skill-eval agent runner with Codex as the default tested provider and opt-in Claude support via `--provider claude` / `--claude-bin`.
- Route gate and periodic suites through the provider-neutral runner, record the selected provider in result-store summaries, and keep quality judges on Codex while prerequisite deterministic gates use the selected tested-agent provider.
- Add `first-tree-read-runtime-generated-briefing-periodic` as a periodic-only fixture covering runtime-shaped briefing / skill topology boundaries; this is not a live First Tree Cloud or session E2E.
- Update README, CLI usage, selector behavior, and focused provider/read periodic/result-store tests.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter @first-tree/skill-evals typecheck`
- focused vitest coverage for provider, quality provider threading, observability, result-store, selector, and read periodic cases
- `pnpm --filter first-tree-dev... build`
- `pnpm --filter @first-tree/skill-evals eval:floor -- --suite first-tree-read`
- `pnpm --filter @first-tree/skill-evals eval:periodic -- --suite first-tree-read --case first-tree-read-runtime-generated-briefing-periodic --provider claude --claude-bin /bin/false --json` (expected provider failure; fixture and result-store path verified)
- `pnpm --filter @first-tree/skill-evals eval:quality -- --suite first-tree-seed --provider claude --claude-bin /bin/false --judge-bin /bin/false --json` (expected fail-closed; prerequisite gate uses Claude provider and judge is not run)
- `pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-read --case blank-casual-no-trigger --codex-bin /bin/false --json` (expected provider failure)
- selector / summary / compare / no-op / missing-case smokes
- full `@first-tree/skill-evals` vitest suite: 136 tests passed
- `pnpm exec biome check <changed files>`
- `pnpm typecheck`
- `pnpm check` (exits 0; reports existing client/web warnings/info)
- `git diff --check`

## Notes

- This PR does not make Claude the default provider.
- I did not run real Claude or Codex live evals to avoid model quota usage.
- This PR intentionally does not add real Cloud/live First Tree runtime E2E; the new read periodic case is fixture coverage for the runtime-generated briefing boundary.
