### PR TITLE
feat(scan): conversion step — produce + offer to apply the top fix

### DIFF
--- a/packages/server/src/__tests__/campaign-scan-skill.test.ts
+++ b/packages/server/src/__tests__/campaign-scan-skill.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { getCampaignScanSkill } from "../services/campaign-scan-skill.js";
+
+describe("campaign scan skills", () => {
+  it("resolves the two campaigns by slug and is null otherwise", () => {
+    expect(getCampaignScanSkill("production-scan")?.name).toBe("production-scan");
+    expect(getCampaignScanSkill("agent-readiness")?.name).toBe("agent-readiness");
+    expect(getCampaignScanSkill("nope")).toBeNull();
+  });
+
+  it("each body keeps its scan schema and the repo-locating step", () => {
+    expect(getCampaignScanSkill("production-scan")?.body).toContain("ps-1");
+    expect(getCampaignScanSkill("agent-readiness")?.body).toContain("ar-1");
+    for (const slug of ["production-scan", "agent-readiness"] as const) {
+      expect(getCampaignScanSkill(slug)?.body).toContain("Step 0 — get the repo");
+    }
+  });
+
+  it("each body drives the conversion payoff: produce a real fix + offer to apply, but read-only until consent", () => {
+    for (const slug of ["production-scan", "agent-readiness"] as const) {
+      // Normalize whitespace so phrase checks don't depend on body line-wrapping.
+      const body = (getCampaignScanSkill(slug)?.body ?? "").replace(/\s+/g, " ");
+      // Produces a concrete deliverable, not just advice.
+      expect(body).toContain("Step 5");
+      expect(body).toContain("ready-to-apply");
+      // Offers to apply via the user's own GitHub (gh), on a branch.
+      expect(body).toContain("open a PR");
+      expect(body).toContain("`gh`");
+      // Consent gate: never mutates the repo without an explicit yes.
+      expect(body.toLowerCase()).toContain("read-only until");
+      expect(body).toContain("explicit go-ahead");
+      // Even after consent the gh write is fenced to PR/issue creation only.
+      expect(body).toContain("gh pr create");
+      expect(body).toContain("no other mutating");
+    }
+    // The agent-readiness hero deliverable is a tailored AGENTS.md.
+    expect(getCampaignScanSkill("agent-readiness")?.body).toContain("AGENTS.md");
+  });
+});

--- a/packages/server/src/services/campaign-scan-skill.ts
+++ b/packages/server/src/services/campaign-scan-skill.ts
@@ -87,9 +87,27 @@ Emit strict JSON:
   "summary":"" }
 \`\`\`
 Then give the user a short, plain-language summary: the headline score, the
-per-dimension scores in one line each, and the must-fix blockers. Offer to turn
-any blocker into a fix task / PR. The score is a heuristic, not a precise grade —
-present it as such.
+per-dimension scores in one line each, and the must-fix blockers. The score is a
+heuristic, not a precise grade — present it as such.
+
+## Step 5 — turn the top fix into a real deliverable (the payoff)
+Don't stop at advice. Pick the single highest-leverage blocker (prefer a
+security or launch-blocking one) and **produce it as a finished, ready-to-apply
+artifact**, shown in full in the chat (free, no commitment): a concrete diff for
+THIS repo (e.g. the CI workflow that adds secret + dependency scanning, a
+missing \`SECURITY.md\`, the Dockerfile change to drop root), or a ready-to-file
+issue with evidence and repro steps. Tailor it to the repo, not a template.
+
+Then offer to **apply it on the user's behalf using their own GitHub**: e.g.
+"Want me to open a PR with this change to \`<owner>/<repo>\`?" (or file the
+issue). **Stay READ-ONLY until the user explicitly says yes.** On yes, use the
+\`gh\` CLI on this machine to open the PR (or file the issue) on a new branch,
+then share the link. If \`gh\` is not authenticated, hand them the exact command
+to run instead. Never push to their default branch or change anything without
+that explicit go-ahead. Even after a yes, use **only** \`gh pr create\` /
+\`gh issue create\` against a new branch on **the same repo you scanned** — no
+force-push, no deleting or modifying existing branches, no closing or editing
+existing issues or PRs, no other mutating \`gh\` command.
 `;
 
 const AGENT_READINESS_BODY = `# Agent Readiness Scan
@@ -149,9 +167,29 @@ Emit strict JSON:
   "summary":"" }
 \`\`\`
 Then a short, plain-language summary: headline score, per-dimension one-liners,
-must-fix blockers. Offer to turn any blocker into a fix task / PR (e.g. tighten
-AGENTS.md, add a "how to verify your change" section). The score is a heuristic,
-not a precise grade — present it as such.
+must-fix blockers. The score is a heuristic, not a precise grade — present it as
+such.
+
+## Step 5 — turn the top fix into a real deliverable (the payoff)
+Don't stop at advice. Pick the single highest-leverage fix and **produce it as a
+finished, ready-to-apply artifact**, shown in full in the chat (free, no
+commitment). The hero for an agent-readiness scan is a tailored **AGENTS.md**:
+if the repo lacks one or has a weak one, write a complete AGENTS.md **for THIS
+repo** — the real build/test/lint commands, the actual module map, the edit
+boundaries and "don't touch" areas — not a template. For a different top
+finding, produce that concrete artifact instead (a CONTRIBUTING / architecture
+doc, a specific diff, or a ready-to-file issue with repro steps).
+
+Then offer to **apply it on the user's behalf using their own GitHub**: e.g.
+"Want me to open a PR adding this AGENTS.md to \`<owner>/<repo>\`?" **Stay
+READ-ONLY until the user explicitly says yes.** On yes, use the \`gh\` CLI on
+this machine to open the PR (or file the issue) on a new branch, then share the
+link. If \`gh\` is not authenticated, hand them the exact command to run instead.
+Never push to their default branch or change anything without that explicit
+go-ahead. Even after a yes, use **only** \`gh pr create\` / \`gh issue create\`
+against a new branch on **the same repo you scanned** — no force-push, no
+deleting or modifying existing branches, no closing or editing existing issues
+or PRs, no other mutating \`gh\` command.
 `;
 
 const CAMPAIGN_SCAN_SKILLS: Record<string, CampaignScanSkill> = {


### PR DESCRIPTION
## What

The **conversion layer** for the repo-scan growth funnel. After the scored report, the scan skills now produce the single highest-leverage fix as a **finished, ready-to-apply artifact** in the chat, and offer to apply it on the user's behalf:

- **agent-readiness** → a tailored **AGENTS.md** for the repo (the hero deliverable — real build/test/lint commands, actual module map, edit boundaries), not a template.
- **production-scan** → a security/launch fix as a concrete diff (CI secret+dep scanning, `SECURITY.md`, drop-root Dockerfile) or a ready-to-file issue.

This is the report → "turn the top finding into a real AGENTS.md / issue / PR" step of the funnel.

## How it applies (no new infra)

The current connect-computer agent runs on the **user's own machine with their `gh`** + the cloned repo, so it applies via the **user's own GitHub** — no new First Tree auth/feature needed (the hosted path's GitHub auth is a separate effort). Runtime-independent: the hosted path inherits the same skill.

## Safety (gated write on a real repo)

READ-ONLY until the user **explicitly agrees**, then **only** `gh pr create` / `gh issue create` on a **new branch of the same repo that was scanned** — no default-branch push, no force-push, no modifying existing branches / issues / PRs, no other mutating `gh`. If `gh` isn't authenticated, the agent hands the user the command to run.

## Scope

Server-owned skill bodies in `campaign-scan-skill.ts` (the merged scan-skill catalog). Replaces the terse "offer to turn a blocker into a fix" line in Step 4 with a concrete Step 5.

## Testing

- `biome` clean; `pnpm --filter @first-tree/server typecheck` clean.
- New `campaign-scan-skill.test.ts` locks in the deliverable + apply-offer + consent gate + the `gh pr create`-only allow-list, for both campaigns (whitespace-normalized so line-wrap edits don't break it).
- Full server suite green (1621) before this PR; relevant suites (`resources-phase1`, `me-onboarding-kickoff`, `campaign-scan-skill`) green.
- Two independent reviews (safety gate + quality/fit): no blockers; adopted the safety reviewer's MEDIUM (explicit post-consent `gh` allow-list, pin to the scanned repo).

## Related

Builds on the scan activation (#1367). Part of the repo-scan funnel (#1352 / #1361). Shareable report page deferred (#1369). Context: `customer/marketing/growth-hacks/repo-scan-funnel.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
