### PR TITLE
refactor(client): render agent briefing with ejs

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -39,7 +39,7 @@
   },
   "scripts": {
     "dev": "tsx src/cli/index.ts",
-    "build": "tsdown src/cli/index.ts src/index.ts --format esm --no-dts --external @anthropic-ai/claude-agent-sdk --external @openai/codex-sdk",
+    "build": "tsdown src/cli/index.ts src/index.ts --format esm --no-dts --external @anthropic-ai/claude-agent-sdk --external @openai/codex-sdk && node ../../scripts/copy-client-runtime-templates.mjs apps/cli",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --passWithNoTests",
     "coverage": "pnpm run build && vitest run --coverage --passWithNoTests",
@@ -61,6 +61,7 @@
     "@inquirer/prompts": "^8.3.0",
     "@openai/codex-sdk": "^0.140.0",
     "commander": "^13.1.0",
+    "ejs": "^6.0.1",
     "gray-matter": "^4.0.3",
     "jose": "^6.0.0",
     "semver": "^7.6.3",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "prebuild": "node scripts/copy-bundled-skills.mjs",
-    "build": "tsdown src/index.ts src/observability/index.ts --format esm --no-dts",
+    "build": "tsdown src/index.ts src/observability/index.ts --format esm --no-dts && node ../../scripts/copy-client-runtime-templates.mjs packages/client",
     "pretest": "node scripts/copy-bundled-skills.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --passWithNoTests",
@@ -31,6 +31,7 @@
     "@anthropic-ai/claude-agent-sdk": "^0.3.187",
     "@openai/codex-sdk": "^0.140.0",
     "@sentry/node": "^10.62.0",
+    "ejs": "^6.0.1",
     "pino": "^9.5.0",
     "semver": "^7.6.3",
     "ws": "^8.20.0",
@@ -39,6 +40,7 @@
   },
   "devDependencies": {
     "@first-tree/shared": "workspace:*",
+    "@types/ejs": "^3.1.5",
     "@types/node": "^22.16.0",
     "@types/semver": "^7.5.8",
     "@types/ws": "^8.18.1",

--- a/packages/client/src/__tests__/agent-briefing-template-assets.test.ts
+++ b/packages/client/src/__tests__/agent-briefing-template-assets.test.ts
@@ -1,0 +1,28 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "..");
+
+describe("agent briefing template assets", () => {
+  it("copy script materializes the EJS template in the package dist/templates layout", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "first-tree-template-assets-"));
+    try {
+      const relativePackageDir = relative(repoRoot, tempRoot);
+
+      execFileSync("node", ["scripts/copy-client-runtime-templates.mjs", relativePackageDir], {
+        cwd: repoRoot,
+        stdio: "pipe",
+      });
+
+      const copiedTemplate = join(tempRoot, "dist", "templates", "agent-briefing.ejs");
+      expect(existsSync(copiedTemplate)).toBe(true);
+      expect(readFileSync(copiedTemplate, "utf8")).toContain("generatedBannerBlock");
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/client/src/__tests__/agent-briefing.test.ts
+++ b/packages/client/src/__tests__/agent-briefing.test.ts
@@ -8,6 +8,7 @@ import {
   type BuildAgentBriefingOptions,
   buildAgentBriefing,
   FIRST_TREE_FAMILY_SKILL_NAMES,
+  resolveAgentBriefingTemplatePath,
 } from "../runtime/agent-briefing.js";
 import type { PredeclaredSourceRepo } from "../runtime/bootstrap.js";
 import { setCliBinding } from "../runtime/cli-binding.js";
@@ -46,6 +47,18 @@ function makeOpts(overrides?: Partial<BuildAgentBriefingOptions>): BuildAgentBri
 }
 
 describe("buildAgentBriefing — top-level structure & section order", () => {
+  it("resolves the checked-in source EJS template and renders through it", () => {
+    const templatePath = resolveAgentBriefingTemplatePath();
+
+    expect(templatePath).toBe(
+      resolve(dirname(fileURLToPath(import.meta.url)), "..", "runtime", "templates", "agent-briefing.ejs"),
+    );
+
+    const briefing = buildAgentBriefing(makeOpts());
+    expect(briefing).toContain("# Identity\n\nYou are Test Agent, an autonomous agent.");
+    expect(briefing.endsWith("\n")).toBe(true);
+  });
+
   it("emits stable shared sections without per-chat Current Chat Context", () => {
     // Tree-bound case so every shared header in the expected order list is
     // present; tree-less cases are exercised in their dedicated describe

--- a/packages/client/src/runtime/agent-briefing.ts
+++ b/packages/client/src/runtime/agent-briefing.ts
@@ -1,12 +1,35 @@
+import { existsSync, readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
 import {
   AGENT_BRIEFING_GENERATED_MARKER,
   type AgentRuntimeConfigPayload,
   type PromptSection,
 } from "@first-tree/shared";
+import type * as ejs from "ejs";
 import type { PredeclaredSourceRepo } from "./bootstrap.js";
 import { getCliBinding } from "./cli-binding.js";
 import type { AgentIdentity } from "./handler.js";
 import { buildResourceSkillsBriefing } from "./resource-skills.js";
+
+const require = createRequire(import.meta.url);
+// EJS is published as CommonJS at runtime even though its types expose named
+// exports, so native ESM cannot import `render` directly.
+const ejsRuntime: typeof ejs = require("ejs");
+const AGENT_BRIEFING_TEMPLATE_FILENAME = "agent-briefing.ejs";
+const TEMPLATE_CANDIDATE_URLS = [
+  // Source execution: packages/client/src/runtime/agent-briefing.ts
+  new URL(`./templates/${AGENT_BRIEFING_TEMPLATE_FILENAME}`, import.meta.url),
+  // Bundled execution: packages/client/dist/index.mjs or apps/cli/dist/<chunk>.mjs
+  new URL(`../templates/${AGENT_BRIEFING_TEMPLATE_FILENAME}`, import.meta.url),
+] as const;
+
+type CachedTemplate = {
+  filename: string;
+  source: string;
+};
+
+let templateCache: CachedTemplate | null = null;
 
 /**
  * Wrap an arbitrary string in POSIX-safe single quotes so it can be pasted
@@ -35,6 +58,19 @@ export type BuildAgentBriefingOptions = {
    */
   contextTreeRepoUrl?: string | null;
   contextTreeBranch?: string | null;
+};
+
+type AgentBriefingRenderModel = {
+  generatedBannerBlock: string;
+  identityBlock: string;
+  teamPromptBlock: string | null;
+  agentPromptBlock: string | null;
+  agentPromptOverridesBlock: string | null;
+  legacyPromptBlock: string | null;
+  workingInFirstTreeBlock: string;
+  requiredReadingBlock: string | null;
+  contextTreeBlock: string;
+  skillsBlock: string | null;
 };
 
 /**
@@ -75,32 +111,32 @@ export type BuildAgentBriefingOptions = {
  *   7. `# Skills (First Tree Managed)`         — Team Skills (if any) + First Tree Family
  */
 export function buildAgentBriefing(opts: BuildAgentBriefingOptions): string {
-  const sections: string[] = [];
+  return renderAgentBriefingTemplate(buildAgentBriefingRenderModel(opts));
+}
 
-  sections.push(generatedBannerSection(getCliBinding().binName));
-  sections.push(identitySection(opts.identity));
+function buildAgentBriefingRenderModel(opts: BuildAgentBriefingOptions): AgentBriefingRenderModel {
+  const bin = getCliBinding().binName;
 
   const promptSections = opts.payload?.prompt.sections ?? [];
   const teamPromptBlock = teamPromptSection(promptSections);
-  if (teamPromptBlock) sections.push(teamPromptBlock);
-  const agentPromptBlock = agentPromptSection(promptSections, opts.identity, getCliBinding().binName);
-  if (agentPromptBlock) sections.push(agentPromptBlock);
+  const agentPromptBlock = agentPromptSection(promptSections, opts.identity, bin);
   const overridesBlock = agentPromptOverridesSection(promptSections);
-  if (overridesBlock) sections.push(overridesBlock);
+  let legacyPromptBlock: string | null = null;
   if (!teamPromptBlock && !agentPromptBlock && !overridesBlock) {
     // Legacy server without structured sections — keep the old single-blob
     // rendering. The blob may mix team and agent content, so it must NOT be
     // presented under the editable `# Agent Prompt` heading.
     const legacyPrompt = opts.payload?.prompt.append?.trim() ?? "";
-    if (legacyPrompt) sections.push(`## Agent-Specific Prompt\n\n${legacyPrompt}`);
+    if (legacyPrompt) legacyPromptBlock = `## Agent-Specific Prompt\n\n${legacyPrompt}`;
   }
 
-  sections.push(
-    workingInFirstTreeSection({
+  const workingInFirstTreeBlock = workingInFirstTreeSection(
+    {
       agentHome: opts.workspacePath,
       sourceRepos: opts.sourceRepos,
       contextTreePath: opts.contextTreePath,
-    }),
+    },
+    bin,
   );
 
   // `# Required Reading` — sits AFTER `# Working in First Tree` so the
@@ -116,16 +152,51 @@ export function buildAgentBriefing(opts: BuildAgentBriefingOptions): string {
   // is short-circuited in `agent-bootstrap.ts`), so mandating a load
   // would point at files that don't exist.
   const requiredReading = requiredReadingSection(opts.contextTreePath, opts.workspacePath);
-  if (requiredReading) sections.push(requiredReading);
-
-  sections.push(
-    contextTreeSection(opts.contextTreePath, opts.contextTreeRepoUrl ?? null, opts.contextTreeBranch ?? null),
+  const contextTreeBlock = contextTreeSection(
+    opts.contextTreePath,
+    opts.contextTreeRepoUrl ?? null,
+    opts.contextTreeBranch ?? null,
   );
 
   const skillsBlock = skillsSection(opts.workspacePath, opts.payload, opts.contextTreePath);
-  if (skillsBlock) sections.push(skillsBlock);
 
-  return `${sections.join("\n\n")}\n`;
+  return {
+    generatedBannerBlock: generatedBannerSection(bin),
+    identityBlock: identitySection(opts.identity),
+    teamPromptBlock,
+    agentPromptBlock,
+    agentPromptOverridesBlock: overridesBlock,
+    legacyPromptBlock,
+    workingInFirstTreeBlock,
+    requiredReadingBlock: requiredReading,
+    contextTreeBlock,
+    skillsBlock,
+  };
+}
+
+function renderAgentBriefingTemplate(model: AgentBriefingRenderModel): string {
+  const template = readAgentBriefingTemplate();
+  return ejsRuntime.render(template.source, model, { filename: template.filename });
+}
+
+function readAgentBriefingTemplate(): CachedTemplate {
+  if (templateCache) return templateCache;
+  const filename = resolveAgentBriefingTemplatePath();
+  templateCache = {
+    filename,
+    source: readFileSync(filename, "utf8"),
+  };
+  return templateCache;
+}
+
+export function resolveAgentBriefingTemplatePath(): string {
+  for (const url of TEMPLATE_CANDIDATE_URLS) {
+    const filename = fileURLToPath(url);
+    if (existsSync(filename)) return filename;
+  }
+  throw new Error(
+    `Agent briefing EJS template is missing. Expected ${AGENT_BRIEFING_TEMPLATE_FILENAME} in the client runtime templates assets.`,
+  );
 }
 
 function identitySection(identity: AgentIdentity): string {
@@ -305,8 +376,7 @@ type WorkingInFirstTreeOpts = {
   contextTreePath: string | null;
 };
 
-function workingInFirstTreeSection(opts: WorkingInFirstTreeOpts): string {
-  const bin = getCliBinding().binName;
+function workingInFirstTreeSection(opts: WorkingInFirstTreeOpts, bin: string): string {
   const blocks: string[] = [];
 
   blocks.push(`# Working in First Tree (First Tree Managed)
@@ -360,7 +430,7 @@ You are running inside **First Tree**, a messaging platform for agent teams.
   blocks.push(workspaceCollaborationBlock(bin));
   blocks.push(githubWorkingPostureBlock());
   blocks.push(githubAttentionBlock(bin, opts.contextTreePath !== null));
-  blocks.push(askingHumansBlock());
+  blocks.push(askingHumansBlock(bin));
   blocks.push(chatTopicBlock(bin));
   blocks.push(cliOverviewBlock(bin));
 
@@ -752,8 +822,7 @@ For the full flag surface, upstream-dependency follows, \`409\` /
 \`${bin} github follow --help\` / \`${bin} github unfollow --help\`.`;
 }
 
-function askingHumansBlock(): string {
-  const bin = getCliBinding().binName;
+function askingHumansBlock(bin: string): string {
   return `## Asking Humans
 
 When you need something only a human can give — a decision, sign-off, or an

--- a/packages/client/src/runtime/templates/agent-briefing.ejs
+++ b/packages/client/src/runtime/templates/agent-briefing.ejs
@@ -1,0 +1,15 @@
+<%
+const sections = [
+  generatedBannerBlock,
+  identityBlock,
+  teamPromptBlock,
+  agentPromptBlock,
+  agentPromptOverridesBlock,
+  legacyPromptBlock,
+  workingInFirstTreeBlock,
+  requiredReadingBlock,
+  contextTreeBlock,
+  skillsBlock,
+].filter((section) => section !== null && section.length > 0);
+-%>
+<%- sections.join("\n\n") %>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       commander:
         specifier: ^13.1.0
         version: 13.1.0
+      ejs:
+        specifier: ^6.0.1
+        version: 6.0.1
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
@@ -99,6 +102,9 @@ importers:
       '@sentry/node':
         specifier: ^10.62.0
         version: 10.62.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.215.0(@opentelemetry/api@1.9.1))
+      ejs:
+        specifier: ^6.0.1
+        version: 6.0.1
       pino:
         specifier: ^9.5.0
         version: 9.14.0
@@ -118,6 +124,9 @@ importers:
       '@first-tree/shared':
         specifier: workspace:*
         version: link:../shared
+      '@types/ejs':
+        specifier: ^3.1.5
+        version: 3.1.5
       '@types/node':
         specifier: ^22.16.0
         version: 22.19.15

--- a/scripts/copy-client-runtime-templates.mjs
+++ b/scripts/copy-client-runtime-templates.mjs
@@ -1,0 +1,29 @@
+import { existsSync, rmSync, statSync } from "node:fs";
+import { cp, mkdir } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packageDirArg = process.argv[2];
+
+if (!packageDirArg) {
+  throw new Error("Usage: node scripts/copy-client-runtime-templates.mjs <package-dir>");
+}
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const sourceDir = resolve(repoRoot, "packages/client/src/runtime/templates");
+const requiredTemplate = resolve(sourceDir, "agent-briefing.ejs");
+const targetDir = resolve(repoRoot, packageDirArg, "dist/templates");
+
+if (!existsSync(requiredTemplate) || !statSync(requiredTemplate).isFile()) {
+  throw new Error(`Required client runtime template is missing: ${requiredTemplate}`);
+}
+
+if (existsSync(targetDir)) {
+  rmSync(targetDir, { recursive: true, force: true });
+}
+
+await mkdir(targetDir, { recursive: true });
+await cp(sourceDir, targetDir, {
+  recursive: true,
+  filter: (source) => statSync(source).isDirectory() || source.endsWith(".ejs"),
+});


### PR DESCRIPTION
## Summary

- Refactor the agent runtime briefing builder to render a typed model through a checked-in EJS template.
- Add runtime template asset copying for both `@first-tree/client` and the bundled CLI dist layout.
- Add tests for source template resolution/rendering and template asset copying.

## Verification

- `pnpm install`
- `pnpm --filter @first-tree/client typecheck`
- `pnpm --filter @first-tree/client test -- agent-briefing.test.ts agent-briefing-template-assets.test.ts retired-tree-commands-drift.test.ts bundled-skill-list-sync.test.ts`
- `pnpm --filter @first-tree/client build`
- `pnpm --filter first-tree-dev build`
- `pnpm --filter first-tree-dev typecheck`
- `pnpm check && pnpm typecheck`

## Notes

- `pnpm test` hit two unrelated 5s timeout failures under full monorepo parallelism: `packages/skill-evals` seed periodic fixture and client `barrel-exports`. Both failed tests passed when rerun directly.
