### PR TITLE
fix(web): daemon-first Reconnect dialog for offline computers

### DIFF
--- a/packages/web/src/components/connect-command-panel.tsx
+++ b/packages/web/src/components/connect-command-panel.tsx
@@ -127,12 +127,45 @@ export function ConnectCommandPanel({
         </>
       )}
 
-      {caption && (
+      {/* Gate the caption on a present command so the "Single-use · regenerates"
+          line never renders over the "Generating token…" placeholder. */}
+      {caption && command && (
         <p className="text-label" style={{ color: "var(--fg-4)", margin: 0 }}>
           {caption}
         </p>
       )}
 
+      <ConnectStatusRow
+        phase={phase}
+        waitingText={waitingText}
+        successContent={successContent}
+        errorContent={errorContent}
+      />
+    </div>
+  );
+}
+
+/**
+ * The yellow→green→red status row rendered beneath a connect command.
+ * Extracted from `ConnectCommandPanel` so a host with MORE than one command
+ * block (e.g. `ReconnectDialog`: a `daemon start` primary + a reinstall
+ * fallback) can render ONE machine-arrival status row at dialog level that
+ * plainly covers "whichever command you ran", instead of pinning the spinner
+ * to a single command block.
+ */
+export function ConnectStatusRow({
+  phase,
+  waitingText = "Waiting for your computer to connect…",
+  successContent,
+  errorContent,
+}: {
+  phase: ConnectPhase;
+  waitingText?: ReactNode;
+  successContent?: ReactNode;
+  errorContent?: ReactNode;
+}) {
+  return (
+    <>
       {phase === "waiting" && (
         <div
           className="flex items-center text-body"
@@ -181,7 +214,7 @@ export function ConnectCommandPanel({
           {errorContent}
         </div>
       )}
-    </div>
+    </>
   );
 }
 

--- a/packages/web/src/pages/clients.tsx
+++ b/packages/web/src/pages/clients.tsx
@@ -37,6 +37,7 @@ import { DemoNavigator, useDemoScenarioParam } from "./clients/demo-navigator.js
 import { compareByPillPriority, deriveComputerStatus } from "./clients/derive-status.js";
 import { DEMO_AGENT_NAMES, DEMO_SELF_USER_ID, findDemoScenario } from "./clients/dev-fixtures.js";
 import { NewConnectionDialog } from "./clients/new-connection-dialog.js";
+import { ReconnectDialog } from "./clients/reconnect-dialog.js";
 
 /**
  * `embedded` drops the full-bleed `-m-6` wrapper so this page can be rendered
@@ -106,6 +107,12 @@ export function ClientsPage({ embedded = false }: { embedded?: boolean } = {}) {
   const [reAuthClientId, setReAuthClientId] = useState<string | null>(null);
   /** Hostname captured when the re-auth was kicked off — drives dialog copy. */
   const [reAuthHostname, setReAuthHostname] = useState<string | null>(null);
+  /**
+   * Reconnect target — a known offline machine the viewer owns. Opens the
+   * daemon-first ReconnectDialog scoped to this row (distinct from the
+   * install+login `+ Connect` flow, which targets an unknown machine).
+   */
+  const [reconnectClient, setReconnectClient] = useState<HubClient | null>(null);
 
   const openNewConnection = (): void => {
     setReAuthClientId(null);
@@ -361,6 +368,13 @@ export function ClientsPage({ embedded = false }: { embedded?: boolean } = {}) {
           }
         />
 
+        <ReconnectDialog
+          client={reconnectClient}
+          onOpenChange={(next) => {
+            if (!next) setReconnectClient(null);
+          }}
+        />
+
         {confirmRetire && (
           <div className="fixed inset-0 z-50 flex items-center justify-center bg-overlay-scrim">
             <div
@@ -541,7 +555,7 @@ export function ClientsPage({ embedded = false }: { embedded?: boolean } = {}) {
                           boundAgents={getClientAgents(client.id)}
                           agentName={agentName}
                           onGenerateNewToken={() => openReAuth(client)}
-                          onReconnect={openNewConnection}
+                          onReconnect={() => setReconnectClient(client)}
                           onDisconnect={() => setConfirmDisconnect(client)}
                           onRetire={() => {
                             setRetireError(null);
@@ -614,7 +628,7 @@ export function ClientsPage({ embedded = false }: { embedded?: boolean } = {}) {
                     boundAgents={getClientAgents(client.id)}
                     agentName={agentName}
                     onGenerateNewToken={() => openReAuth(client)}
-                    onReconnect={openNewConnection}
+                    onReconnect={() => setReconnectClient(client)}
                     onDisconnect={() => setConfirmDisconnect(client)}
                     onRetire={() => {
                       setRetireError(null);

--- a/packages/web/src/pages/clients/__tests__/clients-page-cards-dom.test.tsx
+++ b/packages/web/src/pages/clients/__tests__/clients-page-cards-dom.test.tsx
@@ -375,10 +375,17 @@ describe("ClientsPage computer cards", () => {
     await waitForText(container, "npm install -g @anthropic-ai/claude-code");
     await waitForText(container, "probe failed");
 
-    await click(buttonByText(container, "Daemon not running?"));
-    await waitForText(container, "first-tree-dev daemon start");
-    await click(copyButtonForCommand(container, "first-tree-dev daemon start"));
+    // Reconnect on an offline machine opens the daemon-first dialog: the
+    // primary command wakes the background service (no reinstall, no token),
+    // and the install+login path is a lazily-revealed "Still offline?" fallback.
+    await click(exactButton(container, "Reconnect"));
+    await waitForText(document.body, "Reconnect offline-box");
+    await waitForText(document.body, "first-tree-dev daemon start");
+    await click(copyButtonForCommand(document.body, "first-tree-dev daemon start"));
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith("first-tree-dev daemon start");
+    await click(buttonByText(document.body, "Still offline?"));
+    await waitForText(document.body, "first-tree-dev login connect-token");
+    await click(exactButton(document.body, "Cancel"));
 
     await click(exactButton(container, "Show"));
     await waitForText(container, "Team computers");

--- a/packages/web/src/pages/clients/cards/computer-card.tsx
+++ b/packages/web/src/pages/clients/cards/computer-card.tsx
@@ -20,13 +20,13 @@ export type ComputerCardProps = {
    */
   onGenerateNewToken: () => void;
   /**
-   * Opens the NewConnectionDialog UNSCOPED (fresh connect command).
-   * The Offline card promotes this to an inline "Reconnect" button as
-   * its primary affordance — an offline machine's credentials are
-   * usually still alive, so the operator just needs a working connect
-   * token to re-pair. Routing this through `onGenerateNewToken` would
-   * scope the arrival detector to this row and mislead with re-auth
-   * copy.
+   * Opens the `ReconnectDialog` scoped to this offline machine. The
+   * Offline card promotes this to an inline "Reconnect" button as its
+   * primary affordance. The machine is already paired and its
+   * credentials are usually still alive, so the dialog leads with the
+   * lightweight `<binName> daemon start` (no reinstall, no token) and
+   * demotes install+login to a "Still offline?" fallback — distinct
+   * from `+ Connect`, which targets an unknown machine.
    */
   onReconnect: () => void;
   /** Opens the disconnect-confirmation modal. */

--- a/packages/web/src/pages/clients/cards/offline-card-body.tsx
+++ b/packages/web/src/pages/clients/cards/offline-card-body.tsx
@@ -1,9 +1,7 @@
-import { useState } from "react";
 import type { HubClient, RuntimeAgent } from "../../../api/activity.js";
 import { BoundAgentsList } from "./shared/bound-agents-list.js";
 import { CardSection, CardSectionLabel } from "./shared/card-section.js";
 import { CompactMetaLine } from "./shared/compact-meta-line.js";
-import { InlineCommand } from "./shared/inline-command.js";
 import { PROVIDER_ORDER } from "./shared/providers.js";
 import { RuntimeStateLine } from "./shared/runtime-state-line.js";
 import { summarizeBoundAgents } from "./view-models.js";
@@ -23,18 +21,17 @@ type OfflineCardBodyProps = {
  *   Meta:           Last seen 2d ago · First Tree X · OS  (top)
  *   Runtimes:       ✓ Claude Code v0.2.130 (dimmed)
  *   Agents:         per-agent list (dimmed)
- *   Disclosure:     ⌄ Daemon not running? → wake command
  *
  * Reconnect button is rendered by `ComputerCard`'s `HeaderAction` slot
- * — paired with the pill so state ↔ action sit on one horizontal
- * line. Disclosure label is a self-explanatory question so the
- * operator doesn't need to know what a "wake command" is.
+ * — paired with the pill so state ↔ action sit on one horizontal line.
+ * The recovery command (`<binName> daemon start`, plus the reinstall +
+ * login fallback) lives in the `ReconnectDialog` that button opens, so
+ * this body stays a read-only "last reported" snapshot with no inline
+ * command to drift from the dialog's copy.
  */
 export function OfflineCardBody({ client, boundAgents, agentName }: OfflineCardBodyProps) {
   const summary = summarizeBoundAgents(boundAgents);
   const reportedProviders = PROVIDER_ORDER.filter((p) => client.capabilities[p] != null);
-  const [showCommand, setShowCommand] = useState(false);
-  const daemonStartCommand = `${client.binName} daemon start`;
   return (
     <div className="flex flex-col">
       <CardSection>
@@ -58,32 +55,6 @@ export function OfflineCardBody({ client, boundAgents, agentName }: OfflineCardB
           <BoundAgentsList summary={summary} agentName={agentName} headerless />
         </CardSection>
       )}
-      <CardSection>
-        <button
-          type="button"
-          onClick={() => setShowCommand((v) => !v)}
-          className="text-caption"
-          style={{
-            alignSelf: "flex-start",
-            background: "transparent",
-            color: "var(--fg-3)",
-            border: "none",
-            padding: 0,
-            cursor: "pointer",
-          }}
-          aria-expanded={showCommand}
-        >
-          {showCommand ? "⌃ Daemon not running?" : "⌄ Daemon not running?"}
-        </button>
-        {showCommand && (
-          <div className="flex flex-col" style={{ gap: "var(--sp-1_5)" }}>
-            <p className="text-caption" style={{ margin: 0, color: "var(--fg-3)" }}>
-              Run on this computer:
-            </p>
-            <InlineCommand command={daemonStartCommand} ariaLabel="Daemon wake command" />
-          </div>
-        )}
-      </CardSection>
     </div>
   );
 }

--- a/packages/web/src/pages/clients/reconnect-dialog.tsx
+++ b/packages/web/src/pages/clients/reconnect-dialog.tsx
@@ -1,0 +1,282 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { ChevronDown, ChevronRight } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { type ConnectTokenResponse, generateConnectToken, type HubClient, listClients } from "../../api/activity.js";
+import { useAuth } from "../../auth/auth-context.js";
+import { ConnectCommandPanel, type ConnectPhase, ConnectStatusRow } from "../../components/connect-command-panel.js";
+import { STUCK_AFTER_MS } from "../../components/connect-stuck-panel.js";
+import { Button } from "../../components/ui/button.js";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "../../components/ui/dialog.js";
+import { runVisibilityAwareInterval } from "../../lib/visibility-interval.js";
+import { selectArrivedClient } from "./new-connection-dialog.js";
+
+const POLL_MS = 5_000;
+const SUCCESS_HOLD_MS = 1_200;
+// Tolerance subtracted from the modal-open timestamp so a tiny clock skew
+// between the browser and the server (or a handshake that races a hair ahead
+// of the open) still falls inside the "after open" arrival window. Same
+// rationale as the `+ Connect` dialog's fudge.
+const RECONNECT_DETECT_FUDGE_MS = 1_000;
+// Buffer subtracted from the fallback token's server-reported expiry so the
+// panel surfaces "expired, regenerate" slightly before the server rejects it.
+const TOKEN_EXPIRY_BUFFER_MS = 2_000;
+
+// Lazy-mint lifecycle for the "Still offline?" reinstall fallback.
+type FallbackPhase = "idle" | "loading" | "ready" | "error";
+
+/**
+ * "Reconnect {hostname}" modal — the offline-card primary action.
+ *
+ * An offline computer that already reported the CLI + a runtime is a KNOWN,
+ * still-credentialed machine that merely lost its heartbeat (the common cause
+ * is the background daemon not running). So the reconnect flow is deliberately
+ * *lighter* than the `+ Connect` / re-auth flow:
+ *
+ *   - Primary command is `<binName> daemon start` — no reinstall, no fresh
+ *     login, no connect token. This is the fix for the by-far most common
+ *     offline cause and needs zero server round-trip.
+ *   - The full `npm install -g … && … login <token>` path (identical to
+ *     `+ Connect`) is demoted to a "Still offline?" disclosure and its token
+ *     is minted lazily, only when the operator expands it (or after a stuck
+ *     timeout auto-expands it) — a machine that is merely asleep should never
+ *     cost a connect token.
+ *
+ * Both paths converge on the same success signal: we poll `/clients` scoped to
+ * THIS machine's id and flip to success the moment its handshake lands after
+ * the modal opened (`selectArrivedClient` with `targetClientId`). Scoping to
+ * the row prevents an unrelated machine's reconnect from closing this modal.
+ * The arrival status row lives at DIALOG level (below both commands) so it
+ * plainly covers "whichever command you ran", not just `daemon start`.
+ *
+ * Contrast with `NewConnectionDialog`, which mints a token on open and leads
+ * with install+login because it targets an unknown / unpaired machine.
+ */
+export type ReconnectDialogProps = {
+  /** The offline machine being reconnected. `null` keeps the dialog closed. */
+  client: HubClient | null;
+  onOpenChange: (next: boolean) => void;
+};
+
+export function ReconnectDialog({ client, onOpenChange }: ReconnectDialogProps) {
+  const queryClient = useQueryClient();
+  const { user } = useAuth();
+  const open = client !== null;
+  const clientId = client?.id ?? null;
+  const hostname = client?.hostname ?? "this computer";
+  const binName = client?.binName ?? "first-tree";
+  const daemonStartCommand = `${binName} daemon start`;
+
+  const [phase, setPhase] = useState<ConnectPhase>("waiting");
+  const [arrivedHostname, setArrivedHostname] = useState<string | null>(null);
+  const [stuck, setStuck] = useState(false);
+  // Fallback (reinstall + login) disclosure state. The token is minted lazily
+  // the first time the disclosure opens (manually or via the stuck timeout).
+  const [showFallback, setShowFallback] = useState(false);
+  const [fallbackPhase, setFallbackPhase] = useState<FallbackPhase>("idle");
+  const [fallbackToken, setFallbackToken] = useState<ConnectTokenResponse | null>(null);
+  const [fallbackError, setFallbackError] = useState<string | null>(null);
+  const openedAtRef = useRef<number>(0);
+  // Bumped on every open / target-change / close so a stale async token mint
+  // from a previous lifecycle can't settle into the current one.
+  const cycleRef = useRef(0);
+  // Guards against a concurrent double-mint (rapid toggle / stuck racing a
+  // manual expand) before `fallbackPhase` has flushed to "loading".
+  const mintingRef = useRef(false);
+
+  // Mint a fresh connect token for the reinstall fallback. Cycle-guarded so a
+  // settle after close/target-change is discarded; ref-guarded against a
+  // concurrent second call.
+  const mintFallback = useCallback(async () => {
+    if (mintingRef.current) return;
+    mintingRef.current = true;
+    const cycle = cycleRef.current;
+    setFallbackPhase("loading");
+    setFallbackToken(null);
+    setFallbackError(null);
+    try {
+      const t = await generateConnectToken();
+      if (cycleRef.current !== cycle) return;
+      setFallbackToken(t);
+      setFallbackPhase("ready");
+    } catch (err) {
+      if (cycleRef.current !== cycle) return;
+      setFallbackError(err instanceof Error ? err.message : "Failed to generate connect token");
+      setFallbackPhase("error");
+    } finally {
+      mintingRef.current = false;
+    }
+  }, []);
+
+  const revealFallback = useCallback(() => {
+    setShowFallback(true);
+    if (fallbackPhase === "idle") void mintFallback();
+  }, [fallbackPhase, mintFallback]);
+
+  // On open (and whenever the target machine changes): stamp the arrival
+  // baseline, arm the waiting loop, and reset the fallback disclosure. On
+  // close: bump the cycle so in-flight mints are ignored and reset state.
+  //
+  // `clientId` is in deps even though the body doesn't read it: switching the
+  // Reconnect target to a different offline machine while the dialog is open
+  // must re-stamp the arrival baseline and reset the fallback, otherwise the
+  // detector keeps waiting on the previous row.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: clientId is intentionally in deps; see comment above.
+  useEffect(() => {
+    cycleRef.current += 1;
+    mintingRef.current = false;
+    setShowFallback(false);
+    setFallbackPhase("idle");
+    setFallbackToken(null);
+    setFallbackError(null);
+    setArrivedHostname(null);
+    setStuck(false);
+    if (!open) {
+      setPhase("waiting");
+      openedAtRef.current = 0;
+      return;
+    }
+    openedAtRef.current = Date.now() - RECONNECT_DETECT_FUDGE_MS;
+    setPhase("waiting");
+  }, [open, clientId]);
+
+  // While waiting: poll for THIS machine's handshake landing after the modal
+  // opened. Scoped to `clientId` so only this row's reconnect counts. Paused
+  // while the tab is hidden (the CLI run happens on another machine anyway).
+  useEffect(() => {
+    if (!open || phase !== "waiting" || !user || !clientId) return;
+    const tick = async () => {
+      try {
+        const fresh = await queryClient.fetchQuery({ queryKey: ["clients"], queryFn: listClients });
+        const arrived = selectArrivedClient(fresh, openedAtRef.current, user.id, clientId);
+        if (arrived) {
+          setArrivedHostname(arrived.hostname ?? null);
+          setPhase("success");
+        }
+      } catch {
+        // transient; next tick retries
+      }
+    };
+    return runVisibilityAwareInterval(tick, POLL_MS);
+  }, [open, phase, queryClient, user, clientId]);
+
+  // On success: brief green hold, then close + refresh the list.
+  useEffect(() => {
+    if (phase !== "success") return;
+    const handle = setTimeout(() => {
+      queryClient.invalidateQueries({ queryKey: ["clients"] });
+      onOpenChange(false);
+    }, SUCCESS_HOLD_MS);
+    return () => clearTimeout(handle);
+  }, [phase, onOpenChange, queryClient]);
+
+  // Stuck escalation: if `daemon start` hasn't brought the machine back after
+  // STUCK_AFTER_MS, auto-expand the reinstall fallback so a stuck operator is
+  // nudged toward the heavier path instead of waiting on the spinner forever.
+  useEffect(() => {
+    if (!open || phase !== "waiting") {
+      setStuck(false);
+      return;
+    }
+    const handle = window.setTimeout(() => setStuck(true), STUCK_AFTER_MS);
+    return () => window.clearTimeout(handle);
+  }, [open, phase]);
+  useEffect(() => {
+    if (stuck) revealFallback();
+  }, [stuck, revealFallback]);
+
+  // Fallback token expiry: flip to an actionable error (with a regenerate
+  // button) instead of leaving a silently-dead token in the panel.
+  useEffect(() => {
+    if (!open || fallbackPhase !== "ready" || !fallbackToken) return;
+    const ms = fallbackToken.expiresIn * 1_000 - TOKEN_EXPIRY_BUFFER_MS;
+    if (ms <= 0) {
+      setFallbackError("This token has no remaining validity. Generate a new one to continue.");
+      setFallbackPhase("error");
+      return;
+    }
+    const handle = window.setTimeout(() => {
+      setFallbackError("This token expired before the computer connected. Generate a new one to continue.");
+      setFallbackPhase("error");
+    }, ms);
+    return () => window.clearTimeout(handle);
+  }, [open, fallbackPhase, fallbackToken]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Reconnect {hostname}</DialogTitle>
+          <DialogDescription>
+            This computer is already set up — it just went offline. Run this on {hostname} to bring it back online:
+          </DialogDescription>
+        </DialogHeader>
+
+        <ConnectCommandPanel command={daemonStartCommand} phase="loading" caption={null} copyButtonPlacement="bottom" />
+
+        <div className="flex flex-col" style={{ gap: "var(--sp-2)" }}>
+          <button
+            type="button"
+            onClick={() => (showFallback ? setShowFallback(false) : revealFallback())}
+            className="flex items-center text-caption"
+            style={{
+              alignSelf: "flex-start",
+              background: "transparent",
+              color: "var(--fg-3)",
+              border: "none",
+              padding: 0,
+              gap: "var(--sp-1)",
+              cursor: "pointer",
+            }}
+            aria-expanded={showFallback}
+            aria-controls="reconnect-fallback"
+          >
+            {showFallback ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
+            Still offline? Reinstall and sign in again
+          </button>
+          {showFallback && (
+            <div id="reconnect-fallback" className="flex flex-col" style={{ gap: "var(--sp-2)" }}>
+              {fallbackPhase === "error" ? (
+                <>
+                  <ConnectStatusRow phase="error" errorContent={fallbackError} />
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    style={{ alignSelf: "flex-start" }}
+                    onClick={() => void mintFallback()}
+                  >
+                    Generate new token
+                  </Button>
+                </>
+              ) : (
+                <ConnectCommandPanel
+                  command={fallbackToken?.bootstrapCommand ?? null}
+                  expiresInSeconds={fallbackToken?.expiresIn}
+                  phase="loading"
+                  copyButtonPlacement="bottom"
+                />
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Single machine-arrival status row at dialog level — covers whichever
+            command the operator actually ran. */}
+        <ConnectStatusRow
+          phase={phase}
+          waitingText={`Waiting for ${hostname} to come back online…`}
+          successContent={
+            <>
+              <span className="font-semibold">{arrivedHostname ?? hostname}</span> is back online. Closing…
+            </>
+          }
+        />
+
+        <div className="flex justify-end" style={{ gap: "var(--sp-2)" }}>
+          <Button variant="ghost" size="sm" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Problem

Clicking **Reconnect** on an offline computer opened the fresh-connect "Connect computer" dialog — a full `npm install -g first-tree-staging` + `... login <token>` command with copy like *"Run this on the machine you want to **pair** with First Tree. If the CLI isn't installed yet…"*.

For a machine that is **already paired**, has the CLI installed, and is merely offline (the common cause is the background daemon not running), that command is too heavy (reinstall + a fresh single-use token) and the copy is self-contradictory. The correct lightweight fix — `<binName> daemon start` — existed only as a collapsed "Daemon not running?" disclosure buried in the offline card, while the prominent button led to the heavy flow.

## Change

Add `ReconnectDialog`, scoped to the offline machine (daemon-first, layered):

- **Primary:** `<binName> daemon start` — no reinstall, no connect token, no server round-trip. Covers the by-far most common offline cause.
- **Fallback:** the full `npm install -g … && … login <token>` (identical to `+ Connect`) is demoted to a lazily-minted **"Still offline?"** disclosure. The token is minted only when expanded (or when the stuck timeout auto-expands it), with a **Generate new token** retry on mint error / token expiry.
- **One dialog-level arrival status row** (scoped to the machine's `client.id` via `selectArrivedClient`) so the *Waiting… / back online* signal covers whichever command the operator actually ran, instead of pinning the spinner to the `daemon start` block.
- Chevron disclosure + stable label + `aria-controls`, matching the app's disclosure convention.

Supporting cleanups:
- Remove the now-redundant inline "Daemon not running?" disclosure from `offline-card-body.tsx` — the dialog owns the command, so there's one source of truth (no drift).
- Extract `ConnectStatusRow` from `ConnectCommandPanel` (reused at dialog level) and gate its caption on a present command, so *"Single-use · regenerates…"* never renders over the *"Generating token…"* placeholder (also fixes a latent case in `NewConnectionDialog`).

The re-auth ("Generate new token" on auth-expired) and `+ Connect` (fresh unknown machine) flows are untouched.

## Verification

- Two independent reviews (correctness + UX/design). Correctness: no blocking issues. UX found 2 HIGH (two-commands/one-spinner layout; caption over the "Generating token…" placeholder) + 1 MEDIUM (text-glyph disclosure vs the app's chevron convention) + a fallback mint-error dead-end and missing stuck escalation — all fixed here.
- `pnpm --filter @first-tree/web typecheck` (includes the `lint:tokens` design-token gate) — green.
- Full web suite — 1094/1094 passing (`clients-page-cards-dom` updated to exercise the new Reconnect flow).
- Headless-browser QA of both dialog states (primary daemon-start + expanded reinstall fallback).

Implementation-only; no Context Tree change (no decision/constraint/ownership shift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
