### PR TITLE
fix(server): restore liveness on client heartbeat

### DIFF
--- a/packages/server/src/__tests__/client-service.test.ts
+++ b/packages/server/src/__tests__/client-service.test.ts
@@ -1,9 +1,12 @@
 import { eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 import { agentPresence } from "../db/schema/agent-presence.js";
+import { agents } from "../db/schema/agents.js";
+import { clients } from "../db/schema/clients.js";
 import { createAgent, suspendAgent } from "../services/agent.js";
 import * as clientService from "../services/client.js";
 import * as presenceService from "../services/presence.js";
+import { recordClientHeartbeat } from "../services/runtime-liveness.js";
 import { createTestAgent, useTestApp } from "./helpers.js";
 
 /**
@@ -142,5 +145,162 @@ describe("client service: pinned agent startup surfaces", () => {
       expect.objectContaining({ agentId: active.uuid, clientId, status: "active" }),
       expect.objectContaining({ agentId: suspended.uuid, clientId, status: "suspended" }),
     ]);
+  });
+});
+
+describe("runtime liveness: recordClientHeartbeat", () => {
+  const getApp = useTestApp();
+
+  it("restores client and routed agent reachability after stale cleanup without overwriting runtime activity", async () => {
+    const app = getApp();
+    const { agent, userId, organizationId, clientId } = await createTestAgent(app, {
+      name: `cs-hb-restore-${crypto.randomUUID().slice(0, 6)}`,
+    });
+
+    await clientService.registerClient(app.db, {
+      clientId,
+      userId,
+      organizationId,
+      instanceId: "current-instance",
+    });
+    await presenceService.bindAgent(app.db, agent.uuid, {
+      clientId,
+      instanceId: "current-instance",
+      runtimeType: "test",
+    });
+
+    const staleAt = new Date(Date.now() - 120_000);
+    await app.db.update(clients).set({ lastSeenAt: staleAt }).where(eq(clients.id, clientId));
+    await expect(clientService.cleanupStaleClients(app.db, 60)).resolves.toBe(1);
+
+    // Simulate a runtime frame arriving after the false-positive stale sweep:
+    // activity may recover independently, and heartbeat must not fabricate or
+    // overwrite it.
+    await presenceService.setRuntimeState(app.db, agent.uuid, "working");
+
+    const result = await recordClientHeartbeat(app.db, {
+      clientId,
+      instanceId: "current-instance",
+      routedAgentIds: [agent.uuid],
+    });
+
+    expect(result).toEqual({ clientUpdated: true, restoredAgentIds: [agent.uuid] });
+
+    const [client] = await app.db.select().from(clients).where(eq(clients.id, clientId));
+    expect(client?.status).toBe("connected");
+    expect(client?.instanceId).toBe("current-instance");
+    expect(client?.lastSeenAt.getTime()).toBeGreaterThan(staleAt.getTime());
+    expect(client?.connectedAt?.getTime()).toBeLessThan(client?.lastSeenAt.getTime() ?? 0);
+
+    const [presence] = await app.db.select().from(agentPresence).where(eq(agentPresence.agentId, agent.uuid));
+    expect(presence?.status).toBe("online");
+    expect(presence?.clientId).toBe(clientId);
+    expect(presence?.instanceId).toBe("current-instance");
+    expect(presence?.lastSeenAt.getTime()).toBeGreaterThan(staleAt.getTime());
+    expect(presence?.runtimeState).toBe("working");
+  });
+
+  it("does not restore a routed agent whose durable pin moved away from the heartbeat client", async () => {
+    const app = getApp();
+    const { agent, userId, organizationId, clientId } = await createTestAgent(app, {
+      name: `cs-hb-pin-${crypto.randomUUID().slice(0, 6)}`,
+    });
+    const otherClientId = `client-hb-pin-other-${crypto.randomUUID().slice(0, 8)}`;
+
+    await clientService.registerClient(app.db, { clientId, userId, organizationId, instanceId: "test" });
+    await clientService.registerClient(app.db, {
+      clientId: otherClientId,
+      userId,
+      organizationId,
+      instanceId: "other-instance",
+    });
+    await presenceService.bindAgent(app.db, agent.uuid, { clientId, instanceId: "test", runtimeType: "test" });
+    await app.db.update(agents).set({ clientId: otherClientId }).where(eq(agents.uuid, agent.uuid));
+    await app.db
+      .update(agentPresence)
+      .set({ status: "offline", clientId: null, instanceId: null })
+      .where(eq(agentPresence.agentId, agent.uuid));
+
+    const result = await recordClientHeartbeat(app.db, {
+      clientId,
+      instanceId: "test",
+      routedAgentIds: [agent.uuid],
+    });
+
+    expect(result).toEqual({ clientUpdated: true, restoredAgentIds: [] });
+
+    const [presence] = await app.db.select().from(agentPresence).where(eq(agentPresence.agentId, agent.uuid));
+    expect(presence?.status).toBe("offline");
+    expect(presence?.clientId).toBeNull();
+    expect(presence?.instanceId).toBeNull();
+  });
+
+  it("does not revive a client or agent route when the client lease moved to another instance", async () => {
+    const app = getApp();
+    const { agent, userId, organizationId, clientId } = await createTestAgent(app, {
+      name: `cs-hb-instance-${crypto.randomUUID().slice(0, 6)}`,
+    });
+    const newLastSeenAt = new Date();
+
+    await clientService.registerClient(app.db, { clientId, userId, organizationId, instanceId: "old-instance" });
+    await presenceService.bindAgent(app.db, agent.uuid, {
+      clientId,
+      instanceId: "old-instance",
+      runtimeType: "test",
+    });
+    await app.db
+      .update(clients)
+      .set({ status: "connected", instanceId: "new-instance", lastSeenAt: newLastSeenAt })
+      .where(eq(clients.id, clientId));
+    await app.db
+      .update(agentPresence)
+      .set({ status: "offline", clientId: null, instanceId: null })
+      .where(eq(agentPresence.agentId, agent.uuid));
+
+    const result = await recordClientHeartbeat(app.db, {
+      clientId,
+      instanceId: "old-instance",
+      routedAgentIds: [agent.uuid],
+    });
+
+    expect(result).toEqual({ clientUpdated: false, restoredAgentIds: [] });
+
+    const [client] = await app.db.select().from(clients).where(eq(clients.id, clientId));
+    expect(client?.status).toBe("connected");
+    expect(client?.instanceId).toBe("new-instance");
+    expect(client?.lastSeenAt.getTime()).toBe(newLastSeenAt.getTime());
+
+    const [presence] = await app.db.select().from(agentPresence).where(eq(agentPresence.agentId, agent.uuid));
+    expect(presence?.status).toBe("offline");
+    expect(presence?.clientId).toBeNull();
+    expect(presence?.instanceId).toBeNull();
+  });
+
+  it("does not restore a routed agent that is no longer active", async () => {
+    const app = getApp();
+    const { agent, userId, organizationId, clientId } = await createTestAgent(app, {
+      name: `cs-hb-status-${crypto.randomUUID().slice(0, 6)}`,
+    });
+
+    await clientService.registerClient(app.db, { clientId, userId, organizationId, instanceId: "test" });
+    await presenceService.bindAgent(app.db, agent.uuid, { clientId, instanceId: "test", runtimeType: "test" });
+    await suspendAgent(app.db, agent.uuid);
+    await app.db
+      .update(agentPresence)
+      .set({ status: "offline", clientId: null, instanceId: null })
+      .where(eq(agentPresence.agentId, agent.uuid));
+
+    const result = await recordClientHeartbeat(app.db, {
+      clientId,
+      instanceId: "test",
+      routedAgentIds: [agent.uuid],
+    });
+
+    expect(result).toEqual({ clientUpdated: true, restoredAgentIds: [] });
+
+    const [presence] = await app.db.select().from(agentPresence).where(eq(agentPresence.agentId, agent.uuid));
+    expect(presence?.status).toBe("offline");
+    expect(presence?.clientId).toBeNull();
+    expect(presence?.instanceId).toBeNull();
   });
 });

--- a/packages/server/src/__tests__/ws-client-reconnect-race.test.ts
+++ b/packages/server/src/__tests__/ws-client-reconnect-race.test.ts
@@ -1,12 +1,17 @@
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { SignJWT } from "jose";
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import WebSocket from "ws";
 import { agentPresence } from "../db/schema/agent-presence.js";
 import { clients } from "../db/schema/clients.js";
+import { inboxEntries } from "../db/schema/inbox-entries.js";
 import { createAgent } from "../services/agent.js";
+import { createChat } from "../services/chat.js";
 import * as clientService from "../services/client.js";
+import * as connectionManager from "../services/connection-manager.js";
+import { sendMessage } from "../services/message.js";
+import * as presenceService from "../services/presence.js";
 import { createTestAdmin, createTestApp } from "./helpers.js";
 
 /**
@@ -34,6 +39,7 @@ describe("WS client reconnect race — late onClose must not clobber a fresh sta
   let wsUrl: string;
   let userId: string;
   let memberId: string;
+  let humanAgentUuid: string;
   let orgId: string;
   let role: string;
   const jwtSecret = process.env.JWT_SECRET ?? "test-jwt-secret-key-for-vitest";
@@ -127,6 +133,19 @@ describe("WS client reconnect race — late onClose must not clobber a fresh sta
     return agent.uuid;
   }
 
+  async function loadNotifyRow(messageId: string) {
+    const [row] = await app.db
+      .select({
+        id: inboxEntries.id,
+        status: inboxEntries.status,
+        deliveredAt: inboxEntries.deliveredAt,
+      })
+      .from(inboxEntries)
+      .where(and(eq(inboxEntries.messageId, messageId), eq(inboxEntries.notify, true)))
+      .limit(1);
+    return row;
+  }
+
   beforeAll(async () => {
     app = await createTestApp();
     await app.listen({ port: 0, host: "127.0.0.1" });
@@ -139,6 +158,7 @@ describe("WS client reconnect race — late onClose must not clobber a fresh sta
     const admin = await createTestAdmin(app, { username: `race-${crypto.randomUUID().slice(0, 8)}` });
     userId = admin.userId;
     memberId = admin.memberId;
+    humanAgentUuid = admin.humanAgentUuid;
     const { members } = await import("../db/schema/members.js");
     const [m] = await app.db.select().from(members).where(eq(members.id, memberId)).limit(1);
     if (!m) throw new Error("member row missing after setup");
@@ -222,5 +242,98 @@ describe("WS client reconnect race — late onClose must not clobber a fresh sta
     expect(stalePresence?.status).toBe("offline");
     expect(stalePresence?.clientId).toBeNull();
     expect(stalePresence?.runtimeState).toBeNull();
+  }, 10_000);
+
+  it("self-heals a false-positive stale sweep on heartbeat from the still-active socket", async () => {
+    const token = await signAccess();
+    const clientId = `client_${crypto.randomUUID().slice(0, 8)}`;
+
+    const ws = await authAndRegister(token, clientId);
+    const agentId = await createBoundAgent(ws, clientId);
+
+    const staleAt = new Date(Date.now() - 120_000);
+    await app.db.update(clients).set({ lastSeenAt: staleAt }).where(eq(clients.id, clientId));
+    await expect(clientService.cleanupStaleClients(app.db, 60)).resolves.toBe(1);
+    await presenceService.setRuntimeState(app.db, agentId, "working");
+
+    const ackPromise = waitForFrame(ws, (m) => m.type === "heartbeat:ack");
+    ws.send(JSON.stringify({ type: "heartbeat" }));
+    await ackPromise;
+
+    const [client] = await app.db.select().from(clients).where(eq(clients.id, clientId));
+    expect(client?.status).toBe("connected");
+    expect(client?.instanceId).toBe("test-instance");
+    expect(client?.lastSeenAt.getTime()).toBeGreaterThan(staleAt.getTime());
+
+    const [presence] = await app.db.select().from(agentPresence).where(eq(agentPresence.agentId, agentId));
+    expect(presence?.status).toBe("online");
+    expect(presence?.clientId).toBe(clientId);
+    expect(presence?.instanceId).toBe("test-instance");
+    expect(presence?.runtimeState).toBe("working");
+
+    ws.close();
+  }, 10_000);
+
+  it("acks but does not restore when the heartbeat socket is no longer the active client connection", async () => {
+    const token = await signAccess();
+    const clientId = `client_${crypto.randomUUID().slice(0, 8)}`;
+
+    const ws = await authAndRegister(token, clientId);
+    const agentId = await createBoundAgent(ws, clientId);
+
+    const staleAt = new Date(Date.now() - 120_000);
+    await app.db.update(clients).set({ lastSeenAt: staleAt }).where(eq(clients.id, clientId));
+    await expect(clientService.cleanupStaleClients(app.db, 60)).resolves.toBe(1);
+
+    const activeSpy = vi.spyOn(connectionManager, "isActiveClientConnection").mockReturnValue(false);
+    try {
+      const ackPromise = waitForFrame(ws, (m) => m.type === "heartbeat:ack");
+      ws.send(JSON.stringify({ type: "heartbeat" }));
+      await ackPromise;
+    } finally {
+      activeSpy.mockRestore();
+      ws.close();
+    }
+
+    const [client] = await app.db.select().from(clients).where(eq(clients.id, clientId));
+    expect(client?.status).toBe("disconnected");
+    expect(client?.lastSeenAt.getTime()).toBe(staleAt.getTime());
+
+    const [presence] = await app.db.select().from(agentPresence).where(eq(agentPresence.agentId, agentId));
+    expect(presence?.status).toBe("offline");
+    expect(presence?.clientId).toBeNull();
+  }, 10_000);
+
+  it("does not repair inbox backlog when liveness guards reject the heartbeat", async () => {
+    const token = await signAccess();
+    const clientId = `client_${crypto.randomUUID().slice(0, 8)}`;
+
+    const ws = await authAndRegister(token, clientId);
+    const agentId = await createBoundAgent(ws, clientId);
+    const chat = await createChat(app.db, humanAgentUuid, {
+      type: "group",
+      participantIds: [agentId],
+    });
+
+    const sent = await sendMessage(app.db, chat.id, humanAgentUuid, {
+      source: "api",
+      format: "text",
+      content: "stale heartbeat must not repair inbox",
+      metadata: { mentions: [agentId] },
+    });
+    expect((await loadNotifyRow(sent.message.id))?.status).toBe("pending");
+
+    await app.db.update(clients).set({ instanceId: "other-instance" }).where(eq(clients.id, clientId));
+
+    const ackPromise = waitForFrame(ws, (m) => m.type === "heartbeat:ack");
+    ws.send(JSON.stringify({ type: "heartbeat" }));
+    await ackPromise;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const row = await loadNotifyRow(sent.message.id);
+    expect(row?.status).toBe("pending");
+    expect(row?.deliveredAt).toBeNull();
+
+    ws.close();
   }, 10_000);
 });

--- a/packages/server/src/api/agent/ws-client.ts
+++ b/packages/server/src/api/agent/ws-client.ts
@@ -50,6 +50,7 @@ import * as inboxService from "../../services/inbox.js";
 import * as notificationService from "../../services/notification.js";
 import type { InboxPushHandler, Notifier } from "../../services/notifier.js";
 import * as presenceService from "../../services/presence.js";
+import * as runtimeLivenessService from "../../services/runtime-liveness.js";
 import * as sessionEventService from "../../services/session-event.js";
 
 /**
@@ -1513,15 +1514,16 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
                 }
               });
             } else if (type === "heartbeat") {
-              if (clientId) {
-                await clientService.heartbeatClient(app.db, clientId);
-                await Promise.all(
-                  [...boundAgents.keys()]
-                    .filter((id) => isAgentStillRoutedHere(id))
-                    .map((id) => presenceService.touchAgent(app.db, id)),
-                );
+              if (clientId && connectionManager.isActiveClientConnection(clientId, socket)) {
+                const routedAgentIds = [...boundAgents.keys()].filter((id) => isAgentStillRoutedHere(id));
+                const liveness = await runtimeLivenessService.recordClientHeartbeat(app.db, {
+                  clientId,
+                  instanceId,
+                  routedAgentIds,
+                });
+                const repairableAgentIds = new Set(liveness.restoredAgentIds);
                 for (const info of boundAgents.values()) {
-                  if (isAgentStillRoutedHere(info.agentId)) {
+                  if (repairableAgentIds.has(info.agentId) && isAgentStillRoutedHere(info.agentId)) {
                     maybeRepairInboxBacklog(info.agentId, info.inboxId);
                   }
                 }

--- a/packages/server/src/services/client.ts
+++ b/packages/server/src/services/client.ts
@@ -14,6 +14,7 @@ import { clients } from "../db/schema/clients.js";
 import { members } from "../db/schema/members.js";
 import { BadRequestError, ClientUserMismatchError, ConflictError, NotFoundError } from "../errors.js";
 import { runtimeFieldsReset } from "./presence.js";
+import { recordClientHeartbeat } from "./runtime-liveness.js";
 
 /**
  * Assert the caller can act on this client. Throws 404 for both "not found"
@@ -139,8 +140,8 @@ export async function disconnectClient(db: Database, clientId: string) {
   await db.update(clients).set({ status: "disconnected", lastSeenAt: now }).where(eq(clients.id, clientId));
 }
 
-export async function heartbeatClient(db: Database, clientId: string) {
-  await db.update(clients).set({ lastSeenAt: new Date() }).where(eq(clients.id, clientId));
+export async function heartbeatClient(db: Database, clientId: string, instanceId: string) {
+  await recordClientHeartbeat(db, { clientId, instanceId, routedAgentIds: [] });
 }
 
 export async function getClient(db: Database, clientId: string) {

--- a/packages/server/src/services/runtime-liveness.ts
+++ b/packages/server/src/services/runtime-liveness.ts
@@ -1,0 +1,68 @@
+import { and, eq, inArray, isNull, or, sql } from "drizzle-orm";
+import type { Database } from "../db/connection.js";
+import { agentPresence } from "../db/schema/agent-presence.js";
+import { agents } from "../db/schema/agents.js";
+import { clients } from "../db/schema/clients.js";
+
+export type ClientHeartbeatRecord = {
+  clientId: string;
+  instanceId: string;
+  routedAgentIds: readonly string[];
+};
+
+export type ClientHeartbeatResult = {
+  clientUpdated: boolean;
+  restoredAgentIds: string[];
+};
+
+/**
+ * Record positive liveness evidence from the active client WebSocket.
+ *
+ * Heartbeat proves client/socket reachability and, for agents still routed on
+ * that socket, route reachability. It does not prove runtime activity or
+ * provider health, so this operation intentionally leaves runtime fields alone.
+ */
+export async function recordClientHeartbeat(db: Database, data: ClientHeartbeatRecord): Promise<ClientHeartbeatResult> {
+  const now = new Date();
+
+  const updatedClients = await db
+    .update(clients)
+    .set({
+      status: "connected",
+      instanceId: data.instanceId,
+      lastSeenAt: now,
+    })
+    .where(and(eq(clients.id, data.clientId), or(isNull(clients.instanceId), eq(clients.instanceId, data.instanceId))))
+    .returning({ id: clients.id });
+
+  const routedAgentIds = [...new Set(data.routedAgentIds)];
+  if (updatedClients.length === 0 || routedAgentIds.length === 0) {
+    return { clientUpdated: updatedClients.length > 0, restoredAgentIds: [] };
+  }
+
+  const restoredAgents = await db
+    .update(agentPresence)
+    .set({
+      status: "online",
+      clientId: data.clientId,
+      instanceId: data.instanceId,
+      lastSeenAt: now,
+    })
+    .where(
+      and(
+        inArray(agentPresence.agentId, routedAgentIds),
+        sql`EXISTS (
+          SELECT 1 FROM ${agents}
+          WHERE ${agents.uuid} = ${agentPresence.agentId}
+            AND ${agents.clientId} = ${data.clientId}
+            AND ${agents.status} = 'active'
+        )`,
+      ),
+    )
+    .returning({ agentId: agentPresence.agentId });
+
+  return {
+    clientUpdated: updatedClients.length > 0,
+    restoredAgentIds: restoredAgents.map((row) => row.agentId),
+  };
+}


### PR DESCRIPTION
## Summary

- add a runtime liveness coordinator for client heartbeat reachability writes
- restore `clients.status` / `instance_id` and still-routed `agent_presence` route leases from valid heartbeats
- guard heartbeat restore and heartbeat-triggered inbox repair by active socket, current client instance, durable agent pin, and active agent status
- keep runtime activity/provider health separate: heartbeat does not write `runtime_state`, sessions, or provider state

Fixes #1374.

## Tests

- `pnpm check`
  - passes; existing unrelated warning/info remain in `packages/client/src/__tests__/assistant-text.test.ts`, `packages/client/src/runtime/workspace-migrations.ts`, and `packages/web/src/index.css`
- `pnpm typecheck`
- `pnpm --filter @first-tree/server exec vitest run --maxWorkers=2 --maxConcurrency=2 --no-file-parallelism src/__tests__/client-service.test.ts src/__tests__/ws-client-reconnect-race.test.ts`
- `pnpm --filter @first-tree/server exec vitest run --maxWorkers=2 --maxConcurrency=2 --no-file-parallelism`
