### PR TITLE
feat(scan): conversion skill — quality bar, PR-body attribution, restrained next-step

### DIFF
--- a/packages/server/src/__tests__/campaign-scan-skill.test.ts
+++ b/packages/server/src/__tests__/campaign-scan-skill.test.ts
@@ -51,12 +51,15 @@ describe("campaign scan skills", () => {
       expect(body).toContain("never inside the committed file");
       // Step 6 continues the funnel one thing at a time: next fix + one conversion next-step.
       expect(body).toContain("Step 6");
+      expect(body).toContain("after the apply offer is resolved");
+      expect(body).toContain("After the user answers the apply offer");
       expect(body).toContain("next single one");
       expect(body).toContain("standing member of their team");
       // ...but never a menu / choice overload.
       expect(body).toContain("never a menu");
       // And an explicit stop condition so a declined/quiet user is not re-pitched.
       expect(body).toContain("Know when to stop");
+      expect(body).toContain("If the apply offer is unanswered");
     }
   });
 });

--- a/packages/server/src/__tests__/campaign-scan-skill.test.ts
+++ b/packages/server/src/__tests__/campaign-scan-skill.test.ts
@@ -45,7 +45,9 @@ describe("campaign scan skills", () => {
       expect(body).toContain("never a placeholder");
       // Single-line attribution in the PR/issue description only (the share/acquisition loop) —
       // never a permanent footer in the user's committed file.
-      expect(body).toContain("Generated with First Tree");
+      // Concrete canonical URL — no placeholder can leak into a real PR/issue body.
+      expect(body).toContain("Generated with First Tree — https://first-tree.ai");
+      expect(body).not.toContain("<the First Tree URL>");
       expect(body).toContain("never inside the committed file");
       // Step 6 continues the funnel one thing at a time: next fix + one conversion next-step.
       expect(body).toContain("Step 6");

--- a/packages/server/src/__tests__/campaign-scan-skill.test.ts
+++ b/packages/server/src/__tests__/campaign-scan-skill.test.ts
@@ -36,4 +36,25 @@ describe("campaign scan skills", () => {
     // The agent-readiness hero deliverable is a tailored AGENTS.md.
     expect(getCampaignScanSkill("agent-readiness")?.body).toContain("AGENTS.md");
   });
+
+  it("each body keeps momentum after the fix: quality bar, tasteful attribution, one next step", () => {
+    for (const slug of ["production-scan", "agent-readiness"] as const) {
+      const body = (getCampaignScanSkill(slug)?.body ?? "").replace(/\s+/g, " ");
+      // Quality bar guards against low-signal, template-y deliverables.
+      expect(body).toContain("Quality bar");
+      expect(body).toContain("never a placeholder");
+      // Single-line attribution in the PR/issue description only (the share/acquisition loop) —
+      // never a permanent footer in the user's committed file.
+      expect(body).toContain("Generated with First Tree");
+      expect(body).toContain("never inside the committed file");
+      // Step 6 continues the funnel one thing at a time: next fix + one conversion next-step.
+      expect(body).toContain("Step 6");
+      expect(body).toContain("next single one");
+      expect(body).toContain("standing member of their team");
+      // ...but never a menu / choice overload.
+      expect(body).toContain("never a menu");
+      // And an explicit stop condition so a declined/quiet user is not re-pitched.
+      expect(body).toContain("Know when to stop");
+    }
+  });
 });

--- a/packages/server/src/services/campaign-scan-skill.ts
+++ b/packages/server/src/services/campaign-scan-skill.ts
@@ -98,6 +98,18 @@ THIS repo (e.g. the CI workflow that adds secret + dependency scanning, a
 missing \`SECURITY.md\`, the Dockerfile change to drop root), or a ready-to-file
 issue with evidence and repro steps. Tailor it to the repo, not a template.
 
+**Quality bar — check before you show it (a weak deliverable does more harm than
+none):** every command, path, and filename in it is real and verified against THIS
+repo — never a placeholder, a TODO, or a guessed name; a diff must apply cleanly
+against the code you scanned; an issue must carry concrete evidence and repro
+steps. If you can't make it genuinely real, drop to the next-best fix and say so,
+rather than shipping a template.
+
+When you open the PR (or file the issue), add a single brief attribution line in
+its **description** — e.g. "Generated with First Tree — <the First Tree URL>" —
+never inside the committed file itself, and never more than once. If the user
+would rather it not be there, drop it without a fuss.
+
 Then offer to **apply it on the user's behalf using their own GitHub**: e.g.
 "Want me to open a PR with this change to \`<owner>/<repo>\`?" (or file the
 issue). **Stay READ-ONLY until the user explicitly says yes.** On yes, use the
@@ -108,6 +120,19 @@ that explicit go-ahead. Even after a yes, use **only** \`gh pr create\` /
 \`gh issue create\` against a new branch on **the same repo you scanned** — no
 force-push, no deleting or modifying existing branches, no closing or editing
 existing issues or PRs, no other mutating \`gh\` command.
+
+## Step 6 — after the fix, offer the obvious next thing (one at a time)
+Once the deliverable is shown (or applied), you can offer a next step — but **one**
+thing at a time, never a menu:
+- If more must-fix blockers remain, offer the **next single one** the same way
+  ("Want me to turn the next one — <title> — into a fix too?"). Don't dump the list.
+- Once the user is clearly getting value, offer **one** natural next step matched to
+  their intent, framed as unlocking more (not a signup wall): keep watching this repo
+  and scan its future PRs automatically, scan another (or a private) repo, or make
+  this agent a standing member of their team. Walk them into setup only when they
+  take you up on it.
+- **Know when to stop.** If the user seems done, goes quiet, or declines, stop
+  offering — don't re-pitch. A single unanswered offer is the ceiling.
 `;
 
 const AGENT_READINESS_BODY = `# Agent Readiness Scan
@@ -180,6 +205,18 @@ boundaries and "don't touch" areas — not a template. For a different top
 finding, produce that concrete artifact instead (a CONTRIBUTING / architecture
 doc, a specific diff, or a ready-to-file issue with repro steps).
 
+**Quality bar — check before you show it (a weak deliverable does more harm than
+none):** every command, path, and filename in it is real and verified against THIS
+repo — never a placeholder, a TODO, or a guessed name; a diff must apply cleanly
+against the code you scanned; an issue must carry concrete evidence and repro steps.
+If you can't make it genuinely real, drop to the next-best fix and say so, rather
+than shipping a template.
+
+When you open the PR (or file the issue), add a single brief attribution line in
+its **description** — e.g. "Generated with First Tree — <the First Tree URL>" —
+never inside the committed file itself, and never more than once. If the user
+would rather it not be there, drop it without a fuss.
+
 Then offer to **apply it on the user's behalf using their own GitHub**: e.g.
 "Want me to open a PR adding this AGENTS.md to \`<owner>/<repo>\`?" **Stay
 READ-ONLY until the user explicitly says yes.** On yes, use the \`gh\` CLI on
@@ -190,6 +227,19 @@ go-ahead. Even after a yes, use **only** \`gh pr create\` / \`gh issue create\`
 against a new branch on **the same repo you scanned** — no force-push, no
 deleting or modifying existing branches, no closing or editing existing issues
 or PRs, no other mutating \`gh\` command.
+
+## Step 6 — after the fix, offer the obvious next thing (one at a time)
+Once the deliverable is shown (or applied), you can offer a next step — but **one**
+thing at a time, never a menu:
+- If more must-fix blockers remain, offer the **next single one** the same way
+  ("Want me to turn the next one — <title> — into a fix too?"). Don't dump the list.
+- Once the user is clearly getting value, offer **one** natural next step matched to
+  their intent, framed as unlocking more (not a signup wall): keep watching this repo
+  and scan its future PRs automatically, scan another (or a private) repo, or make
+  this agent a standing member of their team. Walk them into setup only when they
+  take you up on it.
+- **Know when to stop.** If the user seems done, goes quiet, or declines, stop
+  offering — don't re-pitch. A single unanswered offer is the ceiling.
 `;
 
 const CAMPAIGN_SCAN_SKILLS: Record<string, CampaignScanSkill> = {

--- a/packages/server/src/services/campaign-scan-skill.ts
+++ b/packages/server/src/services/campaign-scan-skill.ts
@@ -122,9 +122,9 @@ that explicit go-ahead. Even after a yes, use **only** \`gh pr create\` /
 force-push, no deleting or modifying existing branches, no closing or editing
 existing issues or PRs, no other mutating \`gh\` command.
 
-## Step 6 — after the fix, offer the obvious next thing (one at a time)
-Once the deliverable is shown (or applied), you can offer a next step — but **one**
-thing at a time, never a menu:
+## Step 6 — after the apply offer is resolved, offer the obvious next thing (one at a time)
+After the user answers the apply offer, or after you create the PR/issue they
+asked for, you can offer a next step — but **one** thing at a time, never a menu:
 - If more must-fix blockers remain, offer the **next single one** the same way
   ("Want me to turn the next one — <title> — into a fix too?"). Don't dump the list.
 - Once the user is clearly getting value, offer **one** natural next step matched to
@@ -132,8 +132,9 @@ thing at a time, never a menu:
   and scan its future PRs automatically, scan another (or a private) repo, or make
   this agent a standing member of their team. Walk them into setup only when they
   take you up on it.
-- **Know when to stop.** If the user seems done, goes quiet, or declines, stop
-  offering — don't re-pitch. A single unanswered offer is the ceiling.
+- **Know when to stop.** If the apply offer is unanswered, or if the user seems
+  done, goes quiet, or declines, stop offering — don't re-pitch. A single
+  unanswered offer is the ceiling.
 `;
 
 const AGENT_READINESS_BODY = `# Agent Readiness Scan
@@ -230,9 +231,9 @@ against a new branch on **the same repo you scanned** — no force-push, no
 deleting or modifying existing branches, no closing or editing existing issues
 or PRs, no other mutating \`gh\` command.
 
-## Step 6 — after the fix, offer the obvious next thing (one at a time)
-Once the deliverable is shown (or applied), you can offer a next step — but **one**
-thing at a time, never a menu:
+## Step 6 — after the apply offer is resolved, offer the obvious next thing (one at a time)
+After the user answers the apply offer, or after you create the PR/issue they
+asked for, you can offer a next step — but **one** thing at a time, never a menu:
 - If more must-fix blockers remain, offer the **next single one** the same way
   ("Want me to turn the next one — <title> — into a fix too?"). Don't dump the list.
 - Once the user is clearly getting value, offer **one** natural next step matched to
@@ -240,8 +241,9 @@ thing at a time, never a menu:
   and scan its future PRs automatically, scan another (or a private) repo, or make
   this agent a standing member of their team. Walk them into setup only when they
   take you up on it.
-- **Know when to stop.** If the user seems done, goes quiet, or declines, stop
-  offering — don't re-pitch. A single unanswered offer is the ceiling.
+- **Know when to stop.** If the apply offer is unanswered, or if the user seems
+  done, goes quiet, or declines, stop offering — don't re-pitch. A single
+  unanswered offer is the ceiling.
 `;
 
 const CAMPAIGN_SCAN_SKILLS: Record<string, CampaignScanSkill> = {

--- a/packages/server/src/services/campaign-scan-skill.ts
+++ b/packages/server/src/services/campaign-scan-skill.ts
@@ -106,9 +106,10 @@ steps. If you can't make it genuinely real, drop to the next-best fix and say so
 rather than shipping a template.
 
 When you open the PR (or file the issue), add a single brief attribution line in
-its **description** — e.g. "Generated with First Tree — <the First Tree URL>" —
-never inside the committed file itself, and never more than once. If the user
-would rather it not be there, drop it without a fuss.
+its **description** — exactly "Generated with First Tree — https://first-tree.ai" —
+never inside the committed file itself, and never more than once. Use that exact
+line (don't invent or guess a different URL); if the user would rather it not be
+there, drop it without a fuss.
 
 Then offer to **apply it on the user's behalf using their own GitHub**: e.g.
 "Want me to open a PR with this change to \`<owner>/<repo>\`?" (or file the
@@ -213,9 +214,10 @@ If you can't make it genuinely real, drop to the next-best fix and say so, rathe
 than shipping a template.
 
 When you open the PR (or file the issue), add a single brief attribution line in
-its **description** — e.g. "Generated with First Tree — <the First Tree URL>" —
-never inside the committed file itself, and never more than once. If the user
-would rather it not be there, drop it without a fuss.
+its **description** — exactly "Generated with First Tree — https://first-tree.ai" —
+never inside the committed file itself, and never more than once. Use that exact
+line (don't invent or guess a different URL); if the user would rather it not be
+there, drop it without a fuss.
 
 Then offer to **apply it on the user's behalf using their own GitHub**: e.g.
 "Want me to open a PR adding this AGENTS.md to \`<owner>/<repo>\`?" **Stay


### PR DESCRIPTION
Follow-ups to the scan **conversion step** (#1370), sharpening it toward the growth goal (activate → attribution/share → convert) while holding the genuinely-useful / high-taste bar. Skill body only (`campaign-scan-skill.ts`), both `production-scan` and `agent-readiness`.

## What
- **Quality bar** before showing a deliverable — every command/path/filename is real and verified against the scanned repo (no placeholders/TODOs), a diff must apply cleanly; else drop to the next-best fix. *A weak deliverable does more harm than none.*
- **Tasteful attribution in the PR/issue description only** (once, opt-out-friendly) — never a permanent footer in the user's committed file. Feeds the share/acquisition loop without reading as spam.
- **New Step 6** — after the fix, keep going one thing at a time (never a menu): the next single fix, then one intent-matched next step (watch the repo / scan another/private repo / make the agent a team member), plus an explicit **stop condition** so a declined or quiet user isn't re-pitched.

The READ-ONLY-until-consent gate and the `gh pr/issue create` write-fence are untouched.

## Review
Two independent reviews before opening: a correctness/consistency/test pass (template-literal safety, both-body consistency, no regression to the consent gate — no blocking issues) and a product-taste pass. The taste review's two load-bearing catches are already applied here: attribution moved to the PR/issue description only (not the committed file), and Step 6's explicit stop condition + a less salesbot-y title.

Test locks in the quality bar, PR-body-only attribution, and Step 6 for both bodies. (CI runs typecheck/biome/vitest.)