### PR TITLE
fix: materialize campaign scan skill on reused/active agents

### DIFF
--- a/packages/client/src/__tests__/claude-code-inject-materialize.test.ts
+++ b/packages/client/src/__tests__/claude-code-inject-materialize.test.ts
@@ -1,0 +1,259 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AgentRuntimeConfig, AgentRuntimeConfigPayload, RuntimeResourceSkill } from "@first-tree/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChatContext } from "../runtime/chat-context.js";
+import type { SessionContext, SessionMessage } from "../runtime/handler.js";
+import { mockCtxPlumbing } from "./test-helpers.js";
+
+// A resource skill bound to an agent that already has a live session only lands
+// on disk if the handler re-materializes it when the config version bumps —
+// see maybeSwitchConfig's restart path in claude-code.ts. This exercises that
+// path end-to-end against a real temp workspace (materializeResourceSkills is
+// NOT mocked): the SKILL.md must appear before the injected turn runs.
+const state = vi.hoisted(() => ({
+  chatContextPromise: null as Promise<ChatContext> | null,
+  resolveChatContext: null as ((value: ChatContext) => void) | null,
+  observedInputs: [] as string[],
+  pendingResults: [] as unknown[],
+  waiters: [] as Array<() => void>,
+}));
+
+function wakeQuery(): void {
+  const waiters = state.waiters.splice(0);
+  for (const waiter of waiters) waiter();
+}
+
+function flattenContent(content: unknown): string {
+  return typeof content === "string" ? content : JSON.stringify(content);
+}
+
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (args: { prompt: AsyncIterable<{ message: { content: unknown } }> }) => {
+    let closed = false;
+    void (async () => {
+      for await (const sdkMsg of args.prompt) {
+        state.observedInputs.push(flattenContent(sdkMsg.message.content));
+        state.pendingResults.push({
+          type: "result",
+          subtype: "success",
+          result: `reply ${state.observedInputs.length}`,
+        });
+        wakeQuery();
+      }
+      closed = true;
+      wakeQuery();
+    })();
+    return {
+      [Symbol.asyncIterator]() {
+        return {
+          next: async (): Promise<IteratorResult<unknown>> => {
+            while (state.pendingResults.length === 0 && !closed) {
+              await new Promise<void>((resolve) => state.waiters.push(resolve));
+            }
+            const value = state.pendingResults.shift();
+            if (value) return { value, done: false };
+            return { value: undefined, done: true };
+          },
+        };
+      },
+      close: () => {
+        closed = true;
+        wakeQuery();
+      },
+      setModel: async () => {},
+    };
+  },
+}));
+
+vi.mock("../runtime/agent-bootstrap.js", () => ({ ensureAgentBootstrap: vi.fn() }));
+vi.mock("../runtime/bootstrap.js", () => ({
+  FIRST_TREE_RUNTIME_DIR: ".first-tree-workspace",
+  FIRST_TREE_WORKSPACE_MARKER: ".first-tree-workspace",
+  ensureWorkspaceRuntimeDir: vi.fn((workspacePath: string) => {
+    const dir = join(workspacePath, ".first-tree-workspace");
+    mkdirSync(dir, { recursive: true });
+    return dir;
+  }),
+  writeAgentBriefing: vi.fn(),
+}));
+vi.mock("../runtime/agent-briefing.js", () => ({ buildAgentBriefing: vi.fn(() => "") }));
+vi.mock("../runtime/chat-context.js", () => ({
+  fetchChatContext: vi.fn(async () => {
+    if (!state.chatContextPromise) throw new Error("chat context gate was not initialised");
+    return state.chatContextPromise;
+  }),
+}));
+vi.mock("../runtime/source-repos.js", () => ({
+  declaredSourceRepos: vi.fn(() => []),
+  currentSourceRepoNamesFromPayload: vi.fn(() => null),
+}));
+
+import { createClaudeCodeHandler } from "../handlers/claude-code.js";
+import { writeAgentBriefing } from "../runtime/bootstrap.js";
+
+const AGENT_ID = "019e71d2-c9ec-7f11-86bf-5dfc9e873338";
+
+let workspaceRoot: string;
+let cachedConfig: AgentRuntimeConfig;
+
+function makePayload(skills: RuntimeResourceSkill[]): AgentRuntimeConfigPayload {
+  return {
+    kind: "claude-code",
+    prompt: { append: "" },
+    model: "",
+    mcpServers: [],
+    env: [],
+    gitRepos: [],
+    resourceSkills: skills,
+    reasoningEffort: "",
+  };
+}
+
+function makeConfig(version: number, skills: RuntimeResourceSkill[]): AgentRuntimeConfig {
+  return { agentId: AGENT_ID, version, payload: makePayload(skills), updatedAt: "", updatedBy: "" };
+}
+
+// Minimal cache stub: the handler only reads `.get()`. It always returns the
+// current `cachedConfig`, which the test mutates to simulate a mid-session bump.
+const agentConfigCache = {
+  get: () => cachedConfig,
+  refreshIfNewer: async () => cachedConfig,
+  refresh: async () => cachedConfig,
+  updateUrls: () => {},
+  allReferencedUrls: () => new Set<string>(),
+  forget: () => {},
+};
+
+const SCAN_SKILL: RuntimeResourceSkill = {
+  resourceId: "res-scan-1",
+  name: "production-scan",
+  description: "Scan this repo",
+  body: "SCAN RUBRIC BODY",
+  metadata: {},
+};
+
+function makeMessage(id: string, content: string): SessionMessage {
+  return { id, chatId: "chat-materialize", senderId: "sender-1", format: "text", content, metadata: {} };
+}
+
+function makeContext(): SessionContext {
+  const sendMessage = vi.fn().mockResolvedValue(undefined);
+  return {
+    agent: {
+      agentId: AGENT_ID,
+      inboxId: `inbox_${AGENT_ID}`,
+      displayName: "reused-agent",
+      type: "agent",
+      visibility: "organization",
+      delegateMention: null,
+      metadata: {},
+    },
+    sdk: { serverUrl: "http://test", sendMessage } as unknown as SessionContext["sdk"],
+    chatId: "chat-materialize",
+    log: () => {},
+    recordProviderActivity: () => {},
+    emitEvent: () => {},
+    ...mockCtxPlumbing({ sendMessage }, "chat-materialize"),
+    finishTurn: async () => {},
+  };
+}
+
+function resolveChatContext(): void {
+  state.resolveChatContext?.({
+    chatId: "chat-materialize",
+    title: "materialize",
+    topic: null,
+    description: null,
+    participants: [],
+  });
+}
+
+async function waitFor(assertion: () => boolean): Promise<void> {
+  const deadline = Date.now() + 1500;
+  while (!assertion()) {
+    if (Date.now() > deadline) throw new Error("timed out waiting for assertion");
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+}
+
+function skillPath(resourceId: string): string {
+  return join(workspaceRoot, ".first-tree", "resources", "skills", resourceId, "SKILL.md");
+}
+
+beforeEach(() => {
+  workspaceRoot = mkdtempSync(join(tmpdir(), "ft-claude-materialize-"));
+  state.observedInputs.length = 0;
+  state.pendingResults.length = 0;
+  state.waiters.length = 0;
+  state.chatContextPromise = new Promise((resolve) => {
+    state.resolveChatContext = resolve;
+  });
+});
+
+afterEach(() => {
+  rmSync(workspaceRoot, { recursive: true, force: true });
+  state.chatContextPromise = null;
+  state.resolveChatContext = null;
+  state.pendingResults.length = 0;
+  wakeQuery();
+});
+
+describe("claude-code inject-time resource-skill materialization", () => {
+  it("materializes a skill bound mid-session so the injected turn finds it on disk", async () => {
+    cachedConfig = makeConfig(1, []);
+    const config = { workspaceRoot, agentConfigCache };
+    const handler = createClaudeCodeHandler(config);
+    const ctx = makeContext();
+
+    const startPromise = handler.start(makeMessage("m1", "first"), ctx);
+    resolveChatContext();
+    await startPromise;
+    await waitFor(() => state.observedInputs.length === 1);
+
+    // Start ran with no skills, so nothing is on disk yet.
+    expect(existsSync(skillPath(SCAN_SKILL.resourceId))).toBe(false);
+
+    // Server binds the scan skill + bumps the config version; the cache now
+    // reflects the newer version. An injected message drives the drain →
+    // maybeSwitchConfig → materialize.
+    cachedConfig = makeConfig(2, [SCAN_SKILL]);
+    handler.inject(makeMessage("m2", "run the scan"));
+
+    // Wait for the body to actually land — existsSync alone can race the
+    // create-then-write window and observe a still-empty file.
+    const target = skillPath(SCAN_SKILL.resourceId);
+    await waitFor(() => existsSync(target) && readFileSync(target, "utf-8").includes("SCAN RUBRIC BODY"));
+    expect(readFileSync(target, "utf-8")).toContain("SCAN RUBRIC BODY");
+
+    await handler.shutdown();
+  });
+
+  it("does not prune a live skill when a refresh falls back to a lower-version empty config", async () => {
+    cachedConfig = makeConfig(2, [SCAN_SKILL]);
+    const config = { workspaceRoot, agentConfigCache };
+    const handler = createClaudeCodeHandler(config);
+    const ctx = makeContext();
+
+    const startPromise = handler.start(makeMessage("m1", "first"), ctx);
+    resolveChatContext();
+    await startPromise;
+    await waitFor(() => state.observedInputs.length === 1);
+    // Start materialized the skill at version 2.
+    expect(existsSync(skillPath(SCAN_SKILL.resourceId))).toBe(true);
+
+    // A swallowed refresh failure leaves a version-0 empty fallback config.
+    // maybeSwitchConfig still runs its restart path (writeAgentBriefing fires),
+    // but the version guard must skip re-materialization so the empty payload
+    // cannot prune the live skill.
+    vi.mocked(writeAgentBriefing).mockClear();
+    cachedConfig = makeConfig(0, []);
+    handler.inject(makeMessage("m2", "another message"));
+
+    await waitFor(() => vi.mocked(writeAgentBriefing).mock.calls.length >= 1);
+    expect(existsSync(skillPath(SCAN_SKILL.resourceId))).toBe(true);
+
+    await handler.shutdown();
+  });
+});

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -1444,6 +1444,17 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
     // would update model/mcp/effort but silently leave the per-agent prompt
     // at the old version until the next session restart.
     if (cwd) {
+      // A resource skill bound mid-session (config version bumped, model
+      // unchanged) reaches the active session on this restart path. Materialize
+      // it BEFORE rewriting the briefing so the "## Team Skills" entries the
+      // briefing lists point at real SKILL.md files on disk — without this the
+      // restarted turn sees the skill named but no file to load (the reused /
+      // already-running agent bug). Guard on a genuine version increase so a
+      // transient empty fallback config (swallowed refresh failure) can't prune
+      // skills the running turn is about to load.
+      if (cached.version > appliedConfigVersion) {
+        await materializeResourceSkills(cwd, newPayload, sessionCtx);
+      }
       const switchedBriefing = currentBriefing(sessionCtx, cwd, newPayload);
       writeAgentBriefing(cwd, switchedBriefing);
       // Refresh the on-disk briefing fingerprint so the NEXT delivered message
@@ -2094,6 +2105,14 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
         // resumes. The agent still finds the v1.x checkouts at their
         // original `<localPath>/` — just without a top-level enumeration in
         // the prompt.
+        //
+        // Materialize resource skills to the legacy cwd as well. Unlike start()
+        // and the normal-design resume path, this pre-redesign branch never
+        // wrote them, so a skill bound to a reused legacy-layout agent (the
+        // gandy-coder reuse case) never reached disk. `cwd` is `legacyCwd` here
+        // (set above), NOT the agent home, so the files land where this
+        // session's briefing paths and the SDK cwd resolve them.
+        await materializeResourceSkills(cwd, payload, sessionCtx);
         writeAgentBriefing(legacyCwd, currentBriefing(sessionCtx, legacyCwd, payload));
         // Same convert-stash-then-spawn ordering as `start()` so a stream
         // error fired on the first turn of the resumed session can replay

--- a/packages/server/src/__tests__/resources-phase1.test.ts
+++ b/packages/server/src/__tests__/resources-phase1.test.ts
@@ -130,6 +130,46 @@ describe("Resources Phase 1", () => {
     expect(configAfter?.version).toBe(2);
   });
 
+  it("ensureAndBindCampaignScanSkill refreshes a stale skill body and bumps the version so a returning user re-scan gets the latest rubric", async () => {
+    const app = getApp();
+    const owner = await createOrgUser(app, "member");
+    const agent = await createRuntimeAgent(app, owner);
+
+    await app.resourcesService.ensureAndBindCampaignScanSkill(agent.uuid, "production-scan", owner.memberId);
+
+    // Simulate a skill provisioned by an older server: overwrite the stored
+    // payload with a stale body, leaving the lookup key (the `name` column)
+    // intact, so the next ensure must refresh it to the current rubric.
+    const [before] = await app.db
+      .select()
+      .from(resources)
+      .where(and(eq(resources.ownerAgentId, agent.uuid), eq(resources.type, "skill")));
+    await app.db
+      .update(resources)
+      .set({ payload: { name: "production-scan", description: "stale", body: "STALE BODY", metadata: {} } })
+      .where(eq(resources.id, before?.id ?? ""));
+
+    await app.resourcesService.ensureAndBindCampaignScanSkill(agent.uuid, "production-scan", owner.memberId);
+
+    // Payload refreshed back to the current server-owned rubric.
+    const [after] = await app.db
+      .select()
+      .from(resources)
+      .where(and(eq(resources.ownerAgentId, agent.uuid), eq(resources.type, "skill")));
+    const body = (after?.payload as { body?: string })?.body ?? "";
+    expect(body).toContain("ps-1");
+    expect(body).not.toContain("STALE BODY");
+
+    // Linchpin: the already-bound path MUST bump the version when content
+    // changed — otherwise the client's refreshIfNewer never re-fetches the new
+    // rubric and the update silently never reaches the agent.
+    const [config] = await app.db
+      .select({ version: agentConfigs.version })
+      .from(agentConfigs)
+      .where(eq(agentConfigs.agentId, agent.uuid));
+    expect(config?.version).toBe(3);
+  });
+
   it("ensureAndBindCampaignScanSkill binds an already-provisioned skill the agent is not yet bound to", async () => {
     const app = getApp();
     const owner = await createOrgUser(app, "member");

--- a/packages/server/src/services/resources.ts
+++ b/packages/server/src/services/resources.ts
@@ -1193,6 +1193,11 @@ export function createResourcesService(opts: ResourcesServiceOptions): Resources
         body: skill.body,
         metadata: {},
       };
+      // `body` and `description` are the only server-mutable fields of a
+      // campaign scan skill: `name` is the stable lookup key and `metadata` is
+      // always empty for these skills, so this two-field diff is a complete
+      // change check. If a campaign skill ever gains meaningful metadata or a
+      // renamable identity, extend both `desiredPayload` above and this compare.
       const payloadMatchesDesired = (stored: unknown): boolean =>
         typeof stored === "object" &&
         stored !== null &&

--- a/packages/server/src/services/resources.ts
+++ b/packages/server/src/services/resources.ts
@@ -1181,12 +1181,33 @@ export function createResourcesService(opts: ResourcesServiceOptions): Resources
       // index is needed (no prod schema change). Bump the config version +
       // notify (mirroring replaceAgentResources) so the client re-fetches and
       // materializes the skill before the kickoff chat dispatches.
-      let didBind = false;
+      // The skill body is server-owned (campaign-scan-skill.ts) and evolves; a
+      // returning user's re-scan must pick up the latest rubric. So on an
+      // already-provisioned skill we refresh its payload to the current version
+      // and — the linchpin — bump the config version so the client actually
+      // re-fetches and re-materializes it. Comparing body + description first
+      // keeps a no-op re-scan from churning the version on every kickoff.
+      const desiredPayload = {
+        name: skill.name,
+        description: skill.description,
+        body: skill.body,
+        metadata: {},
+      };
+      const payloadMatchesDesired = (stored: unknown): boolean =>
+        typeof stored === "object" &&
+        stored !== null &&
+        "body" in stored &&
+        stored.body === skill.body &&
+        "description" in stored &&
+        stored.description === skill.description;
+
+      let needsNotify = false;
       await db.transaction(async (tx) => {
         const targetDb = tx as unknown as Database;
         await targetDb.select({ uuid: agents.uuid }).from(agents).where(eq(agents.uuid, agentId)).for("update");
 
         let resourceId = await findSkillResourceId(targetDb);
+        let contentChanged = false;
         if (!resourceId) {
           resourceId = uuidv7();
           await targetDb.insert(resources).values({
@@ -1199,10 +1220,23 @@ export function createResourcesService(opts: ResourcesServiceOptions): Resources
             repoCanonicalKey: null,
             defaultEnabled: null,
             status: "active",
-            payload: { name: skill.name, description: skill.description, body: skill.body, metadata: {} },
+            payload: desiredPayload,
             createdBy: actorId,
             updatedBy: actorId,
           });
+        } else {
+          const [current] = await targetDb
+            .select({ payload: resources.payload })
+            .from(resources)
+            .where(eq(resources.id, resourceId))
+            .limit(1);
+          if (!payloadMatchesDesired(current?.payload)) {
+            await targetDb
+              .update(resources)
+              .set({ payload: desiredPayload, updatedAt: new Date(), updatedBy: actorId })
+              .where(eq(resources.id, resourceId));
+            contentChanged = true;
+          }
         }
 
         const [already] = await targetDb
@@ -1210,7 +1244,19 @@ export function createResourcesService(opts: ResourcesServiceOptions): Resources
           .from(agentResourceBindings)
           .where(and(eq(agentResourceBindings.agentId, agentId), eq(agentResourceBindings.resourceId, resourceId)))
           .limit(1);
-        if (already) return;
+        if (already) {
+          // Binding set is unchanged, but a refreshed body still has to reach the
+          // client: without a version bump `refreshIfNewer` is a no-op and the
+          // new rubric never re-materializes. Skip the bump when nothing changed.
+          if (contentChanged) {
+            await targetDb
+              .update(agentConfigs)
+              .set({ version: sql`${agentConfigs.version} + 1`, updatedAt: new Date(), updatedBy: actorId })
+              .where(eq(agentConfigs.agentId, agentId));
+            needsNotify = true;
+          }
+          return;
+        }
         const existing = await targetDb
           .select({ id: agentResourceBindings.id })
           .from(agentResourceBindings)
@@ -1234,9 +1280,9 @@ export function createResourcesService(opts: ResourcesServiceOptions): Resources
           createdBy: actorId,
           updatedBy: actorId,
         });
-        didBind = true;
+        needsNotify = true;
       });
-      if (didBind) await notifyAgents([agentId]);
+      if (needsNotify) await notifyAgents([agentId]);
     },
 
     resolveRuntimeConfig,


### PR DESCRIPTION
## Problem

On staging, a scan skill bound to a **reused / already-running** agent (e.g. `gandy-coder`) was never written to disk. The kickoff directive told the agent to run the `production-scan` skill, but the `SKILL.md` was not there, so the agent improvised its own checklist instead of running the rubric.

## Root cause

Two gaps, one per side:

1. **Client** — `materializeResourceSkills` was only called in the handler's `start` / normal `resume`. It was **not** called when a skill binding arrives mid-session:
   - The mid-session config-change path (`maybeSwitchConfig`, Path B restart) rewrote the briefing so `## Team Skills` listed the new skill, but never wrote the file it pointed at.
   - The **legacy-cwd resume branch** never materialized skills at all (this is exactly the reused legacy-layout agent case).
2. **Server** — `ensureAndBindCampaignScanSkill` reused an existing skill resource without refreshing its body, and the already-bound path early-returned **without bumping `agentConfigs.version`**. So even after the body was updated, the client's `refreshIfNewer` was a no-op and never re-fetched — a returning user's re-scan silently kept the stale rubric.

## Changes

**Change 1 — client (`packages/client/src/handlers/claude-code.ts`)**
- Materialize resource skills on the `maybeSwitchConfig` restart path, **co-located with the briefing rewrite** so the `## Team Skills` paths and the on-disk files stay consistent. Reuses the existing `appliedConfigVersion` and guards on `cached.version > appliedConfigVersion`, so a swallowed-refresh empty fallback config (version 0) cannot prune skills the running turn is about to load.
- Materialize on the legacy-cwd resume branch, using that branch's `cwd` (= `legacyCwd`), matching where its briefing paths and the SDK cwd resolve.

**Change 2 — server (`packages/server/src/services/resources.ts`)**
- On an already-provisioned skill, refresh the resource payload to the current server-owned body inside the existing agent row-lock transaction.
- On the already-bound path, bump `agentConfigs.version` + notify **only when the body/description actually changed** (skip otherwise to avoid churn). This is the trigger the client's inject-time materialize consumes.

## Hook placement note

`maybeSwitchConfig` is the existing mid-session config-change handler on the inject/drain path (`pushInjectedMessage` → `maybeSwitchConfig`). A skill binding changes the payload (not just the model), so it already takes the Path B restart — which is precisely where the briefing is rewritten. Placing materialize there keeps briefing ⇔ disk consistent and reuses the version tracking, rather than adding a parallel version tracker in the drain loop.

## Handler scope

**claude-code only** in this PR — the only handler the growth funnel runs today. `codex-sdk`, `codex-app-server`, and `claude-code-tui` share the same general inject-materialize gap (they also only materialize on start/resume) and will land in a **fast-follow** general-robustness PR.

## Testing

- **Server** (`resources-phase1.test.ts`): new case — a stale skill body on the already-bound path is refreshed to the current rubric **and** bumps the config version; existing idempotency test still asserts no bump when content is unchanged. Full server suite green (1622 tests).
- **Client** (`claude-code-inject-materialize.test.ts`, new): (a) a skill bound mid-session is materialized to disk on the next injected turn; (b) a lower-version empty fallback config does **not** prune the live skill. Full client suite green (1186 tests).
- `pnpm check` (biome) + `pnpm typecheck` clean.

## Manual verification (post-release)

Reproduce the staging case: reuse `gandy-coder` (active session), run a scan directive → skill lands on disk → the scan runs by rubric (structured report + `AGENTS.md`), no improvisation.

## Context / tree

Design + review handoff for this fix lives in the growth-funnel scan-skill thread (resource model kept, two fixes, hidden-marker dropped). The broader "scan skill = agent-scoped resource" loading model (from #1367) is a candidate for a Context Tree note under the growth-funnel nodes, but this PR itself is implementation-only.

---

⚠️ **Not for self-merge.** Flow: independent review (gandy-s-assistant, 2 rounds) → code-owner approve → manual merge by gandy → client release + `gandy-coder` update → staging re-verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
